### PR TITLE
correct git clone https URI in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ You can run **conan** client and server in Windows, MacOS, and Linux.
 ### Clone conan repository
 
 
-    $ git clone https://github.com/conan-co/conan
+    $ git clone https://github.com/conan-io/conan.git
 
 
 ### Install python requirements


### PR DESCRIPTION
The original one does not work for me. This one does.