### PR TITLE
Travis (linux only), Appveyor support and fixed test with DLL and Visual Studio en…

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,20 @@
+os:
+  - linux
+#  - osx
+language: python
+sudo: required
+dist: trusty
+env:
+  - CONAN_COMPILER=gcc CONAN_COMPILER_VERSION=4.8
+python:
+  - "2.7"
+# command to install dependencies
+install:
+  - pip install -r requirements_dev.txt
+  - pip install -r requirements_server.txt
+  - pip install -r requirements.txt
+before_script:
+  - export PYTHONPATH=$PYTHONPATH:$(pwd)
+  - export CONAN_LOGGING_LEVEL=10
+# command to run tests
+script: nosetests

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,22 @@
+build: false
+
+environment:
+  matrix:
+    - PYTHON: "C:\\Python27"
+      PYTHON_VERSION: "2.7.8"
+      PYTHON_ARCH: "32"
+
+init:
+  - "ECHO %PYTHON% %PYTHON_VERSION% %PYTHON_ARCH%"
+
+install:
+  - "set PYTHONPATH=%PYTHONPATH%;%CD%"
+  - "set CONAN_LOGGING_LEVEL=10"
+  - "set CONAN_COMPILER=Visual Studio"
+  - "set CONAN_COMPILER_VERSION=12"
+  - "%PYTHON%/Scripts/pip.exe install -r requirements.txt"
+  - "%PYTHON%/Scripts/pip.exe install -r requirements_dev.txt"
+  - "%PYTHON%/Scripts/pip.exe install -r requirements_server.txt"
+
+test_script:
+  - "%PYTHON%/Scripts/nosetests"

--- a/conans/test/command/export_test.py
+++ b/conans/test/command/export_test.py
@@ -32,8 +32,8 @@ class ExportTest(unittest.TestCase):
 
         expected_sums = {'hello.cpp': '4f005274b2fdb25e6113b69774dac184',
                          'main.cpp': '0479f3c223c9a656a718f3148e044124',
-                         'CMakeLists.txt': '06dc55633f00448bb528e191736a591b',
-                         'conanfile.py': 'be0ef62b526bae06aceae66bc8eaf306',
+                         'CMakeLists.txt': '4ddc61c8efb118c7a0b1621dc04b31af',
+                         'conanfile.py': '4df4b5266ad6d5d55cbdd0a8b12c9d1a',
                          'helloHello0.h': '9448df034392fc8781a47dd03ae71bdd'}
         self.assertEqual(expected_sums, manif.file_sums)
 
@@ -103,8 +103,8 @@ class OpenSSLConan(ConanFile):
 
         expected_sums = {'hello.cpp': '4f005274b2fdb25e6113b69774dac184',
                          'main.cpp': '0479f3c223c9a656a718f3148e044124',
-                         'CMakeLists.txt': '06dc55633f00448bb528e191736a591b',
-                         'conanfile.py': 'be0ef62b526bae06aceae66bc8eaf306',
+                         'CMakeLists.txt': '4ddc61c8efb118c7a0b1621dc04b31af',
+                         'conanfile.py': '4df4b5266ad6d5d55cbdd0a8b12c9d1a',
                          'helloHello0.h': '9448df034392fc8781a47dd03ae71bdd'}
         self.assertEqual(expected_sums, digest2.file_sums)
 
@@ -136,8 +136,8 @@ class OpenSSLConan(ConanFile):
 
         expected_sums = {'hello.cpp': '4f005274b2fdb25e6113b69774dac184',
                          'main.cpp': '0479f3c223c9a656a718f3148e044124',
-                         'CMakeLists.txt': '06dc55633f00448bb528e191736a591b',
-                         'conanfile.py': '7388c7cdbaa168576bcd760db25967fa',
+                         'CMakeLists.txt': '4ddc61c8efb118c7a0b1621dc04b31af',
+                         'conanfile.py': '5a2c6e2d6b39638b7d8560786d7935a3',
                          'helloHello0.h': '9448df034392fc8781a47dd03ae71bdd'}
         self.assertEqual(expected_sums, digest3.file_sums)
 

--- a/conans/test/integration/basic_build_test.py
+++ b/conans/test/integration/basic_build_test.py
@@ -15,15 +15,16 @@ class BasicBuildTest(unittest.TestCase):
 
     def complete_build_flow_test(self):
         """In local user folder"""
-        files = cpp_hello_conan_files("Hello0", "0.1")
         client = TestClient()
-        client.save(files)
-        command = "say_hello" if platform.system() == "Windows" else "./say_hello"
+        command = os.sep.join([".", "bin", "say_hello"])
 
         for install, lang, static in [("install", 0, True),
                                       ("install -o language=1", 1, True),
                                       ("install -o language=1 -o static=False", 1, False),
                                       ("install -o static=False", 0, False)]:
+            dll_export = client.default_compiler_visual_studio and not static
+            files = cpp_hello_conan_files("Hello0", "0.1", dll_export=dll_export)
+            client.save(files)
             client.run(install)
             time.sleep(1)  # necessary so the conaninfo.txt is flushed to disc
             client.run('build')

--- a/conans/test/integration/complete_test.py
+++ b/conans/test/integration/complete_test.py
@@ -70,10 +70,7 @@ class CompleteFlowTest(unittest.TestCase):
         client3.save(files3)
         client3.run('install')
         client3.run('build')
-        if platform.system() == "Windows":
-            command = "say_hello"
-        else:
-            command = './say_hello'
+        command = os.sep.join([".", "bin", "say_hello"])
         client3.runner(command, client3.current_folder)
         self.assertIn("Hello Hello1", client3.user_io.out)
         self.assertIn("Hello Hello0", client3.user_io.out)
@@ -82,10 +79,7 @@ class CompleteFlowTest(unittest.TestCase):
         time.sleep(1)
         client3.run('build')
 
-        if platform.system() == "Windows":
-            command = "say_hello"
-        else:
-            command = './say_hello'
+        command = os.sep.join([".", "bin", "say_hello"])
         client3.runner(command, client3.current_folder)
         self.assertIn("Hola Hello1", client3.user_io.out)
         self.assertIn("Hola Hello0", client3.user_io.out)
@@ -98,7 +92,6 @@ class CompleteFlowTest(unittest.TestCase):
     def _assert_library_files(self, path):
         libraries = os.listdir(os.path.join(path, "lib"))
         self.assertEquals(len(libraries), 1)
-        self.assertTrue(os.path.basename(libraries[0]).startswith("libhello"))
 
     def _assert_library_exists_in_server(self, package_ref, paths):
         folder = uncompress_packaged_files(paths, package_ref)

--- a/conans/test/integration/diamond_test.py
+++ b/conans/test/integration/diamond_test.py
@@ -70,8 +70,7 @@ class DiamondTest(unittest.TestCase):
         client.run("build .")
         self._check_individual_deps(client)
 
-        command = "say_hello" if platform.system() == "Windows" else "./say_hello"
-
+        command = os.sep.join([".", "bin", "say_hello"])
         client.runner(command, client.current_folder)
         self.assertEqual(['Hello Hello4', 'Hello Hello3', 'Hello Hello1', 'Hello Hello0',
                           'Hello Hello2', 'Hello Hello0'],

--- a/conans/test/integration/go_diamond_test.py
+++ b/conans/test/integration/go_diamond_test.py
@@ -36,7 +36,7 @@ class GoDiamondTest(unittest.TestCase):
         os.chdir(client.current_folder)
         client.run("install --build missing")
         client.run("build")
-        command = "say_hello" if platform.system() == "Windows" else "./say_hello"
+        command = os.sep.join([".", "bin", "say_hello"])
         with CustomEnvPath(paths_to_add=['$GOPATH/bin'],
                            var_to_add=[('GOPATH', client.current_folder), ]):
 
@@ -67,7 +67,7 @@ class GoDiamondTest(unittest.TestCase):
         client2.save(files3)
 
         client2.run("install --build missing")
-        command = "say_hello" if platform.system() == "Windows" else "./say_hello"
+        command = os.sep.join([".", "bin", "say_hello"])
         with CustomEnvPath(paths_to_add=['$GOPATH/bin'],
                            var_to_add=[('GOPATH', client2.current_folder), ]):
 

--- a/conans/test/integration/multi_build_test.py
+++ b/conans/test/integration/multi_build_test.py
@@ -47,7 +47,7 @@ class MultiBuildTest(unittest.TestCase):
             client.run('install')
             client.run('build')
 
-            command = '.%ssay_hello' % os.sep
+            command = os.sep.join([".", "bin", "say_hello"])
             client.runner(command, client.current_folder)
             self.assertIn("Hello Hello1", client.user_io.out)
             self.assertIn("Hello Hello0", client.user_io.out)

--- a/conans/test/tools.py
+++ b/conans/test/tools.py
@@ -273,12 +273,18 @@ class TestClient(object):
         # Set default settings in global defined
         self.paths.conan_config  # For create the default file if not existing
         text = load(self.paths.conan_conf_path)
-        text = text.replace("compiler.runtime=MD", "")
+        if compiler != "Visual Studio":
+            text = text.replace("compiler.runtime=MD", "")
         text = text.replace("build_type=Release", "")
 
         text += "\n" + "compiler=%s" % compiler
         text += "\n" + "compiler.version=%s" % compiler_version
         save(self.paths.conan_conf_path, text)
+
+    @property
+    def default_compiler_visual_studio(self):
+        text = load(self.paths.conan_conf_path)
+        return "compiler=Visual Studio" in text
 
     def init_dynamic_vars(self, user_io=None):
 


### PR DESCRIPTION
Now hello test files optionally exports the declaration of the hello method in order to build the *.lib library necessary to link with in case of DLL.

Enabled support for CI systems and PR analysis:

Travis (linux by now)
Appveyor (windows)