### PR TITLE
Package command

### DIFF
--- a/conans/client/command.py
+++ b/conans/client/command.py
@@ -11,7 +11,7 @@ from conans.client.rest.auth_manager import ConanApiAuthManager
 from conans.client.rest.rest_client import RestApiClient
 from conans.client.store.localdb import LocalDB
 from conans.util.log import logger
-from conans.model.ref import ConanFileReference
+from conans.model.ref import ConanFileReference, PackageReference
 from conans.client.manager import ConanManager
 from conans.paths import CONANFILE
 import requests
@@ -194,6 +194,25 @@ class Command(object):
         args = parser.parse_args(*args)
         root_path = os.path.normpath(os.path.join(os.getcwd(), args.path))
         self._manager.build(root_path)
+
+    def package(self, *args):
+        """ calls your conanfile.py "package" method for a specific package.
+            Intended for package creators, for regenerate package without recompile the source.
+            EX: conans package openssl/1.0.2@lasote/testing 9cf83afd07b678d38a9c1645f605875400847ff3
+        """
+        parser = argparse.ArgumentParser(description=self.package.__doc__, prog="conan")
+        parser.add_argument("reference", help='reference name. e.g., openssl/1.0.2@lasote/testing')
+        parser.add_argument("package", help='Package ID to regenerate. e.g., 9cf83afd07b678d38a9c1645f605875400847ff3')
+
+        args = parser.parse_args(*args)
+
+        try:
+            reference = ConanFileReference.loads(args.reference)
+        except:
+            raise ConanException("Invalid conanfile reference. e.g., openssl/1.0.2@lasote/testing")
+
+        package_reference = PackageReference(reference, args.package)
+        self._manager.package(package_reference)
 
     def export(self, *args):
         """ copies a conanfile.py and associated (export) files to your local store,

--- a/conans/test/integration/package_command_test.py
+++ b/conans/test/integration/package_command_test.py
@@ -1,0 +1,80 @@
+import unittest
+from conans.test.tools import TestClient
+from conans.model.ref import ConanFileReference, PackageReference
+import os
+from conans.paths import CONANFILE
+
+
+class PackageCommandTest(unittest.TestCase):
+
+    def package_test(self):
+        """Use 'conan package' command to repackage a generated package (without build it)"""
+        self.client = TestClient(users=[("lasote", "mypass")])
+        conanfile_template = """
+from conans import ConanFile, CMake
+import platform
+
+class MyConan(ConanFile):
+    name = "MyLib"
+    version = "0.1"
+    generators = "cmake"
+    exports = '*'
+
+    def build(self):
+        pass
+
+    def package(self):
+        self.copy(pattern="*.h", dst="include", keep_path=False)
+#       self.copy(pattern="*.a", dst="lib", keep_path=False)
+
+
+"""
+        files = {"lib/file1.a": "foo",
+                 "include/file.h": "foo",
+                 CONANFILE: conanfile_template}
+
+        self.client.save(files)
+        self.client.run("export lasote/stable")
+
+        # Build and package conan file
+        conan_reference = ConanFileReference.loads("MyLib/0.1@lasote/stable")
+        self.client.run("install %s --build missing" % str(conan_reference))
+
+        package_id = "5ab84d6acfe1f23c4fae0ab88f26e3a396351ac9"
+
+        package_path = self.client.paths.package(PackageReference(conan_reference, package_id))
+
+        # Verify the headers are there but lib doesn't
+        self.assertTrue(os.path.exists(os.path.join(package_path, "include", "file.h")))
+        self.assertFalse(os.path.exists(os.path.join(package_path, "lib", "file1.a")))
+
+        # Now we modify the package method and try again (NOTE: if build is called with raise)
+        conanfile_template = """
+from conans import ConanFile, CMake
+import platform
+
+class MyConan(ConanFile):
+    name = "MyLib"
+    version = "0.1"
+    generators = "cmake"
+    exports = '*'
+
+    def build(self):
+        raise Exception("DON'T WANT TO BUILD!")
+
+    def package(self):
+        self.copy(pattern="*.h", dst="include", keep_path=False)
+        self.copy(pattern="*.a", dst="lib", keep_path=False)
+"""
+
+        files[CONANFILE] = conanfile_template
+
+        self.client.save(files)
+        self.client.run("export lasote/stable")
+
+        # Build and package conan file
+        self.client.run("package %s %s" % (conan_reference, package_id))
+
+        # Verify the headers are there but lib doesn't
+        self.assertTrue(os.path.exists(os.path.join(package_path, "include", "file.h")))
+        self.assertTrue(os.path.exists(os.path.join(package_path, "lib", "file1.a")))


### PR DESCRIPTION
Very useful for big libraries which with is not possible to just recompile if you have bugs in package method. Reads options/settings from build/xxx/conaninfo.txt and regenerate package folder.

    conans package openssl/1.0.2@lasote/testing 9cf83afd07b678d38a9c1645f605875400847ff3