### PR TITLE
cacert.pem auto generated, but in homepath

### DIFF
--- a/conans/client/rest/cacert.py
+++ b/conans/client/rest/cacert.py
@@ -5719,7 +5719,7 @@ lBlGGSW4gNfL1IYoakRwJiNiqZ+Gb7+6kHDSVneFeO/qJakXzlByjAA6quPbYzSf
 # Workaround to avoid pyinstaller statics hell.
 # request (at the end because openssl) needs a file with
 # certs, it can't be injected. Damned coupled code.
-cur_path = os.path.dirname(os.path.abspath(__file__))
-file_path = os.path.join(cur_path, "cacert.pem")
+dir_path = os.path.expanduser("~/.conan")
+file_path = os.path.join(dir_path, "cacert.pem")
 if not os.path.exists(file_path):
     save(file_path, cacert)


### PR DESCRIPTION
There is a problem with pip installation of package (and don't really know why with installer either), cacert.pem is autogenerated (for workaround the pyinstaller hell with statics) but it was trying to generate in installation dir. If I install conan as root (sudo pip install conan) and then, first use with regular user, access to write the file was forbidden.