### PR TITLE
Robust shutil.rmtree with onerror permissions

### DIFF
--- a/conans/client/export.py
+++ b/conans/client/export.py
@@ -4,7 +4,7 @@ to the local store, as an initial step before building or uploading to remotes
 
 import shutil
 import os
-from conans.util.files import save, load
+from conans.util.files import save, load, rmdir
 from conans.paths import CONAN_MANIFEST, CONANFILE
 from conans.errors import ConanException
 from conans.client.file_copier import FileCopier
@@ -39,7 +39,7 @@ def _init_export_folder(destination_folder):
                 manifest_content = load(os.path.join(destination_folder, CONAN_MANIFEST))
                 previous_digest = FileTreeManifest.loads(manifest_content)
             # Maybe here we want to invalidate cache
-            shutil.rmtree(destination_folder)
+            rmdir(destination_folder)
         os.makedirs(destination_folder)
     except Exception as e:
         raise ConanException("Unable to create folder %s\n%s" % (destination_folder, str(e)))

--- a/conans/client/installer.py
+++ b/conans/client/installer.py
@@ -261,7 +261,7 @@ Package configuration:
                 # and raise to interrupt any other processes (build, package)
                 os.chdir(export_folder)
                 try:
-                    shutil.rmtree(src_folder)
+                    rmdir(src_folder)
                 except Exception as e_rm:
                     self._user_io.out.error("Unable to remove src folder %s\n%s"
                                             % (src_folder, str(e_rm)))

--- a/conans/client/packager.py
+++ b/conans/client/packager.py
@@ -34,7 +34,7 @@ def create_package(conanfile, build_folder, package_folder, output):
     except Exception as e:
         os.chdir(build_folder)
         try:
-            shutil.rmtree(package_folder)
+            rmdir(package_folder)
         except Exception as e_rm:
             output.error("Unable to remove package folder %s\n%s"
                                     % (package_folder, str(e_rm)))

--- a/conans/operations.py
+++ b/conans/operations.py
@@ -1,9 +1,9 @@
 from conans.util.log import logger
-import shutil
 from conans.errors import ConanException
 from conans.model.ref import PackageReference
 from conans.paths import SYSTEM_REQS
 import os
+from conans.util.files import rmdir
 
 
 class DiskRemover(object):
@@ -13,7 +13,7 @@ class DiskRemover(object):
     def _remove(self, path, conan_ref, msg=""):
         try:
             logger.debug("Removing folder %s" % path)
-            shutil.rmtree(path)
+            rmdir(path)
         except OSError as e:
             raise ConanException("Unable to remove %s %s\n\t%s" % (repr(conan_ref), msg, str(e)))
 

--- a/conans/util/files.py
+++ b/conans/util/files.py
@@ -75,11 +75,20 @@ def relative_dirs(path):
     return ret
 
 
+def _change_permissions(func, path, exc_info):
+    import stat
+    if not os.access(path, os.W_OK):
+        os.chmod(path, stat.S_IWUSR)
+        func(path)
+    else:
+        raise
+
+
 def rmdir(path, raise_if_not_exist=False):
     '''Recursive rm of a directory. If dir not exists
     only raise exception if raise_if_not_exist'''
     try:
-        shutil.rmtree(path)
+        shutil.rmtree(path, onerror=_change_permissions)
     except OSError as err:
         if err.errno == ENOENT and not raise_if_not_exist:
             return


### PR DESCRIPTION
this eliminate lots of problems with conan remove (specially .git folders), and other deletions, nightmare  in windows