### PR TITLE
Two minor fixes

### DIFF
--- a/conans/client/remote_manager.py
+++ b/conans/client/remote_manager.py
@@ -117,7 +117,10 @@ class RemoteManager(object):
 
     @property
     def default_remote(self):
-        return self.remote_names[0]
+        try:
+            return self.remote_names[0]
+        except IndexError:
+            raise ConanException("There is no configured default remote")
 
     def authenticate(self, remote, name, password):
         return self._call_without_remote_selection(remote, 'authenticate', name, password)

--- a/conans/test/integration/complete_test.py
+++ b/conans/test/integration/complete_test.py
@@ -2,7 +2,6 @@ import unittest
 from conans.test.tools import TestServer, TestClient
 from conans.model.ref import ConanFileReference, PackageReference
 import os
-import platform
 import time
 from conans.test.utils.cpp_test_files import cpp_hello_conan_files
 from nose.plugins.attrib import attr

--- a/conans/test/remote_manager_test.py
+++ b/conans/test/remote_manager_test.py
@@ -4,8 +4,9 @@ from mock import Mock
 from conans.errors import NotFoundException
 from conans.model.ref import ConanFileReference, PackageReference
 from conans.client.paths import ConanPaths
-from conans.test.tools import TestBufferConanOutput
+from conans.test.tools import TestBufferConanOutput, TestClient
 from conans.test.utils.test_files import temp_folder
+from conans.test.utils.cpp_test_files import cpp_hello_conan_files
 
 
 class MockRemoteClient(object):
@@ -35,9 +36,17 @@ class RemoteManagerTest(unittest.TestCase):
         self.package_reference = PackageReference(self.conan_reference, "123123123")
         self.remote_client = MockRemoteClient()
         self.output = TestBufferConanOutput()
-        self.paths = ConanPaths(temp_folder(), None, self.output)
+        self.paths = ConanPaths(temp_folder(), temp_folder(), self.output)
         self.remotes = [("default", "url1"), ("other", "url2"), ("last", "url3")]
         self.manager = RemoteManager(self.paths, self.remotes, self.remote_client, self.output)
+
+    def test_no_remotes(self):
+        client = TestClient()
+        files = cpp_hello_conan_files("Hello0", "0.1")
+        client.save(files)
+        client.run("export lasote/stable")
+        client.run("upload Hello0/0.1@lasote/stable", ignore_error=True)
+        self.assertIn("ERROR: There is no configured default remote", client.user_io.out)
 
     def test_properties(self):
         # Remote names


### PR DESCRIPTION
fixed test that writed to user .conan/data, fixed bug error msg for no remotes

conans/test/remote_manager_test.py -> line 38, was causing writes to user .conan/data instead of temporary folders