### PR TITLE
Conanfile directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -87,6 +87,7 @@ cacert.pem
 
 #linux backup files
 *~
+.*.swp
 
 #Pyinstaller generated binaries
 /pyinstaller

--- a/conans/client/loader.py
+++ b/conans/client/loader.py
@@ -76,6 +76,7 @@ class ConanFileLoader(object):
             result = self._create_check_conan(loaded, consumer)
             if consumer:
                 result.options.initialize_upstream(self._options)
+	    type(result).conanfile_directory = property(lambda self, _path=conan_file_path: os.path.dirname(_path))
             return result
         except Exception as e:  # re-raise with file name
             raise ConanException("%s: %s" % (conan_file_path, str(e)))

--- a/conans/model/conan_file.py
+++ b/conans/model/conan_file.py
@@ -72,7 +72,7 @@ class ConanFile(object):
     license = None  # The license of the PACKAGE, just a shortcut, does not replace or
                     # change the actual license of the source code
 
-    def __init__(self, output, runner, settings):
+    def __init__(self, output, runner, settings, conanfile_directory):
         '''
         param settings: Settings
         '''
@@ -97,6 +97,12 @@ class ConanFile(object):
         self.output = output
         # something that can run commands, as os.sytem
         self._runner = runner
+
+        self._conanfile_directory = conanfile_directory
+
+    @property
+    def conanfile_directory(self):
+        return self._conanfile_directory
 
     def source(self):
         pass

--- a/conans/test/deps_graph_test.py
+++ b/conans/test/deps_graph_test.py
@@ -15,8 +15,8 @@ class DepsGraphTest(unittest.TestCase):
         conan_ref1 = ConanFileReference.loads("Hello/0.1@user/stable")
         conan_ref2 = ConanFileReference.loads("Hello/0.1@user/stable")
 
-        conanfile1 = ConanFile(None, None, Settings({}))
-        conanfile2 = ConanFile(None, None, Settings({}))
+        conanfile1 = ConanFile(None, None, Settings({}), ".")
+        conanfile2 = ConanFile(None, None, Settings({}), ".")
         n1 = Node(conan_ref1, conanfile1)
         n2 = Node(conan_ref2, conanfile2)
 


### PR DESCRIPTION
As discussed, creating pull request for `conanfile_directory`.  The big pro of attaching it as a property when the conan file is loaded is that the user doesn't have to worry about it; it's done for free.  The big con of doing it this way is that it's introducing *magic* that the user may be looking to figure out how this is done.

Another option would be to create the property in the base class that returns a private member.  When we load the conan file, I can set the member to the path provided.  It should be available immediately to the implementation except for the constructor (but that's a limitation of the current proposed implementation anyway).