### PR TITLE
Enabling private_deps from current project, fix #79

### DIFF
--- a/conans/client/installer.py
+++ b/conans/client/installer.py
@@ -107,6 +107,8 @@ class ConanInstaller(object):
         for private_node, private_requirers in private_closure:
             for private_requirer in private_requirers:
                 conan_ref, conan_file = private_requirer
+                if conan_ref is None:
+                    continue
                 package_id = conan_file.info.package_id()
                 package_reference = PackageReference(conan_ref, package_id)
                 package_folder = self._paths.package(package_reference)


### PR DESCRIPTION
Private deps tests, as are defined are very slow (building shared libs in a complex graph), so I have just added some code to an existing test (thus adding about 8 seconds to test, in win which is the slowest).

The fix is simple, basically the computation of private dependencies skipping (not having to retrieve/build private dependencies for existing binaries), was not prepared for user projects, only for packages. For the current project, the ConanReference does not exist (and we cannot skip that dependency), so just avoiding it seems to be enough.