### PR TITLE
TarGZ exported files to support conanfiles exporting whole source

### DIFF
--- a/conans/client/installer.py
+++ b/conans/client/installer.py
@@ -39,24 +39,16 @@ class ConanInstaller(object):
             self._user_io.out.info("Conan %s not found, retrieving from server"
                                    % str(conan_reference))
             # If not in localhost, download it. Will raise if not found
-            self._retrieve_remote_conan_file(conan_reference)
+            self._remote_manager.get_conanfile(conan_reference, self._remote)
         conanfile = self._loader.load_conan(conanfile_path, consumer)
         return conanfile
 
     def download_packages(self, reference, package_ids):
         assert(isinstance(package_ids, list))
-        self._retrieve_remote_conan_file(reference)
+        self._remote_manager.get_conanfile(reference, self._remote)
         for package_id in package_ids:
             package_reference = PackageReference(reference, package_id)
             self._retrieve_remote_package(package_reference)
-
-    def _retrieve_remote_conan_file(self, conan_reference):
-        export_files = self._remote_manager.get_conanfile(conan_reference, self._remote)
-        export_folder = self._paths.export(conan_reference)
-#       TODO: Download only the CONANFILE file and only download the rest of files
-#       in install if needed (not found remote package)
-        for file_name, content in export_files:  # export_files is a generator
-            save(os.path.join(export_folder, file_name), content)
 
     def _retrieve_remote_package(self, package_reference):
         try:
@@ -226,10 +218,10 @@ class ConanInstaller(object):
         options_text = ", ".join(conan_file.info.full_options.dumps().splitlines())
         author_contact = " at '%s'" % conan_file.url if conan_file.url else ""
 
-        raise ConanException('''Can't find a '%s' package for the specified options and settings. 
+        raise ConanException('''Can't find a '%s' package for the specified options and settings
 
 - Try to build from sources with "--build %s" parameter
-- If it fails, you could try to contact the package author%s, report your configuration and try to collaborate to support it.
+- If it fails, you could try to contact the package author %s, report your configuration and try to collaborate to support it.
 
 Package configuration:
 - Settings: %s

--- a/conans/client/remote_manager.py
+++ b/conans/client/remote_manager.py
@@ -5,7 +5,7 @@ from conans.util.log import logger
 import traceback
 from conans.errors import ConanOutdatedClient
 import os
-from conans.paths import PACKAGE_TGZ_NAME, CONANINFO, CONAN_MANIFEST
+from conans.paths import PACKAGE_TGZ_NAME, CONANINFO, CONAN_MANIFEST, CONANFILE, EXPORT_TGZ_NAME
 from cStringIO import StringIO
 import tarfile
 from conans.util.files import gzopen_without_timestamps
@@ -49,7 +49,7 @@ class RemoteManager(object):
         rel_files = self._paths.export_paths(conan_reference)
 
         the_files = build_files_set(basedir, rel_files)
-
+        the_files = compress_export_files(the_files)
         return self._call_without_remote_selection(remote,
                                                    "upload_conan", conan_reference, the_files)
 
@@ -78,7 +78,11 @@ class RemoteManager(object):
         Will iterate the remotes to find the conans unless remote was specified
 
         returns (dict relative_filepath:content , remote_name)"""
-        return self._call_with_remote_selection(remote, "get_conanfile", conan_reference)
+        export_files = self._call_with_remote_selection(remote, "get_conanfile", conan_reference)
+        export_folder = self._paths.export(conan_reference)
+        uncompress_files(export_files, export_folder, EXPORT_TGZ_NAME)
+#       TODO: Download only the CONANFILE file and only download the rest of files
+#       in install if needed (not found remote package)
 
     def get_package(self, package_reference, remote=None):
         """
@@ -87,13 +91,7 @@ class RemoteManager(object):
 
         returns (dict relative_filepath:content , remote_name)"""
         package_files = self._call_with_remote_selection(remote, "get_package", package_reference)
-
-        for file_name, content in package_files:  # package_files is a generator
-            if os.path.basename(file_name) != PACKAGE_TGZ_NAME:
-                save(os.path.join(self._paths.package(package_reference), file_name), content)
-            else:
-                #  Unzip the file
-                tar_extract(StringIO(content), self._paths.package(package_reference))
+        uncompress_files(package_files, self._paths.package(package_reference), PACKAGE_TGZ_NAME)
 
     def search(self, pattern=None, remote=None, ignorecase=True):
         """
@@ -169,11 +167,19 @@ class RemoteManager(object):
 
 
 def compress_package_files(files):
+    return compress_files(files, PACKAGE_TGZ_NAME, excluded=(CONANINFO, CONAN_MANIFEST))
+
+
+def compress_export_files(files):
+    return compress_files(files, EXPORT_TGZ_NAME, excluded=(CONANFILE, CONAN_MANIFEST))
+
+
+def compress_files(files, name, excluded):
     """Compress the package and returns the new dict (name => content) of files,
     only with the conanXX files and the compressed file"""
 
     tgz_contents = StringIO()
-    tgz = gzopen_without_timestamps(PACKAGE_TGZ_NAME, mode="w", fileobj=tgz_contents)
+    tgz = gzopen_without_timestamps(name, mode="w", fileobj=tgz_contents)
 
     def addfile(name, contents, tar):
         info = tarfile.TarInfo(name=name)
@@ -182,15 +188,23 @@ def compress_package_files(files):
         tar.addfile(tarinfo=info, fileobj=string)
 
     for the_file, content in files.iteritems():
-        if the_file not in (CONANINFO, CONAN_MANIFEST):
+        if the_file not in excluded:
             addfile(the_file, content, tgz)
 
     tgz.close()
     ret = {}
-    if CONANINFO in files:
-        ret[CONANINFO] = files[CONANINFO]
-    if CONAN_MANIFEST in files:
-        ret[CONAN_MANIFEST] = files[CONAN_MANIFEST]
-    ret[PACKAGE_TGZ_NAME] = tgz_contents.getvalue()
+    for e in excluded:
+        if e in files:
+            ret[e] = files[e]
+    ret[name] = tgz_contents.getvalue()
 
     return ret
+
+
+def uncompress_files(files, folder, name):
+    for file_name, content in files:
+        if os.path.basename(file_name) != name:
+            save(os.path.join(folder, file_name), content)
+        else:
+            #  Unzip the file
+            tar_extract(StringIO(content), folder)

--- a/conans/paths.py
+++ b/conans/paths.py
@@ -26,6 +26,7 @@ CONANINFO = "conaninfo.txt"
 SYSTEM_REQS = "system_reqs.txt"
 
 PACKAGE_TGZ_NAME = "conan_package.tgz"
+EXPORT_TGZ_NAME = "conan_export.tgz"
 
 
 class SimplePaths(object):

--- a/conans/test/remote_manager_test.py
+++ b/conans/test/remote_manager_test.py
@@ -14,7 +14,7 @@ class MockRemoteClient(object):
     def __init__(self):
         self.upload_package = Mock()
         self.get_conan_digest = Mock()
-        self.get_conanfile = Mock()
+        self.get_conanfile = Mock(return_value=[("one.txt", "ONE")])
         self.get_package = Mock(return_value=[("one.txt", "ONE")])
         self.remote_url = None
 

--- a/conans/test/tgz_md5_test.py
+++ b/conans/test/tgz_md5_test.py
@@ -1,10 +1,10 @@
 import unittest
-from conans.client.remote_manager import compress_package_files
 from conans.test.utils.test_files import temp_folder
 from conans.util.files import save, md5sum
 from conans.paths import PACKAGE_TGZ_NAME
 import os
 import time
+from conans.client.remote_manager import compress_files
 
 
 class TgzMd5Test(unittest.TestCase):
@@ -13,7 +13,7 @@ class TgzMd5Test(unittest.TestCase):
     def testMd5Name(self):
         files = {"one_file.txt": "The contents",
                  "Two_file.txt": "Two contents"}
-        new_files = compress_package_files(files)
+        new_files = compress_files(files, PACKAGE_TGZ_NAME, excluded=[])
         folder = temp_folder()
         file_path = os.path.join(folder, PACKAGE_TGZ_NAME)
         save(file_path, new_files[PACKAGE_TGZ_NAME])
@@ -22,7 +22,7 @@ class TgzMd5Test(unittest.TestCase):
 
         time.sleep(1)  # Timestamps change
 
-        new_files = compress_package_files(files)
+        new_files = compress_files(files, PACKAGE_TGZ_NAME, excluded=[])
         folder = temp_folder()
         file_path = os.path.join(folder, PACKAGE_TGZ_NAME)
         save(file_path, new_files[PACKAGE_TGZ_NAME])

--- a/conans/test/upload_test.py
+++ b/conans/test/upload_test.py
@@ -1,13 +1,14 @@
 import unittest
 from conans.test.tools import TestClient, TestServer
-from conans.test.utils.test_files import hello_source_files
+from conans.test.utils.test_files import hello_source_files, temp_folder
 from conans.client.manager import CONANFILE
 import os
-from conans.paths import CONAN_MANIFEST
+from conans.paths import CONAN_MANIFEST, PACKAGE_TGZ_NAME, EXPORT_TGZ_NAME
 from conans.util.files import save
 from conans.model.ref import ConanFileReference, PackageReference
 from conans.model.manifest import FileTreeManifest
 from conans.test.utils.test_files import uncompress_packaged_files
+from conans.tools import untargz
 
 
 myconan1 = """
@@ -89,8 +90,15 @@ class UploadTest(unittest.TestCase):
                  'include/math/lib1.h',
                  'my_data/readme.txt']
 
-        for _file in files:
-            self.assertTrue(os.path.exists(os.path.join(self.server_reg_folder, _file)))
+        self.assertTrue(os.path.exists(os.path.join(self.server_reg_folder, CONANFILE)))
+        self.assertTrue(os.path.exists(os.path.join(self.server_reg_folder, EXPORT_TGZ_NAME)))
+        tmp = temp_folder()
+        untargz(os.path.join(self.server_reg_folder, EXPORT_TGZ_NAME), tmp)
+        for f in files:
+            if f not in (CONANFILE, CONAN_MANIFEST):
+                self.assertTrue(os.path.exists(os.path.join(tmp, f)))
+            else:
+                self.assertFalse(os.path.exists(os.path.join(tmp, f)))
 
         folder = uncompress_packaged_files(self.test_server.paths, self.package_ref)
 


### PR DESCRIPTION
The upload/download of exported files is done file by file. This can be terribly slow if exporting a lot of files, which is the case for in-repository conanfiles.

Conanfile inside library repositories is necessary for package creators that want to develop their packages with conan too, i.e. for development of intermediate conan packages both with dependencies and dependees.

This PR is closely related to issues #80 and #77, asi it is related to the fact that there are packages that  can be under active development using conan to handle its dependencies, then package and upload to be used by others.

This is a necessary improvement towards that goal, targz'ing all the exported files for performance in upload/downloads.