### PR TITLE
Improvement/issue 109 output project ref in info command

### DIFF
--- a/conans/client/manager.py
+++ b/conans/client/manager.py
@@ -94,7 +94,7 @@ class ConanManager(object):
                                    "It is recommended to add your repo URL as attribute")
         if not license_:
             self._user_io.out.warn("Conanfile doesn't have a 'license'.\n"
-                                  "It is recommended to add the package license as attribute")
+                                   "It is recommended to add the package license as attribute")
 
         conan_ref = ConanFileReference(conan_file.name, conan_file.version, user_name, channel)
         output = ScopedOutput(str(conan_ref), self._user_io.out)
@@ -217,9 +217,9 @@ class ConanManager(object):
         except NotFoundException:
             # TODO: Auto generate conanfile from requirements file
             raise ConanException("'%s' file is needed for build.\n"
-                               "Create a '%s' and move manually the "
-                               "requirements and generators from '%s' file"
-                               % (CONANFILE, CONANFILE, CONANFILE_TXT))
+                                 "Create a '%s' and move manually the "
+                                 "requirements and generators from '%s' file"
+                                 % (CONANFILE, CONANFILE, CONANFILE_TXT))
         try:
             build_info_file = os.path.join(current_path, BUILD_INFO)
             if os.path.exists(build_info_file):

--- a/conans/client/manager.py
+++ b/conans/client/manager.py
@@ -146,13 +146,16 @@ class ConanManager(object):
                 conan_file_path = os.path.join(conanfile_path, CONANFILE)
                 conanfile = loader.load_conan(conan_file_path, output, consumer=True)
                 is_txt = False
+
+                if conanfile.name is not None and conanfile.version is not None:
+                    # Calculate a placeholder conan file reference for the project
+                    current_user = self._localdb.get_username() or 'anonymous'
+                    user, channel = get_user_channel(current_user)
+                    placeholder_reference = ConanFileReference.loads("%s/%s@%s/%s" % (conanfile.name, conanfile.version, user, channel))
             except NotFoundException:  # Load requirements.txt
                 conan_path = os.path.join(conanfile_path, CONANFILE_TXT)
                 conanfile = loader.load_conan_txt(conan_path, output)
                 is_txt = True
-            current_user = self._localdb.get_username() or 'anonymous'
-            user, channel = get_user_channel(current_user)
-            placeholder_reference = ConanFileReference.loads("%s/%s@%s/%s" % (conanfile.name, conanfile.version, user, channel))
 
         # build deps graph and install it
         builder = DepsBuilder(installer, self._user_io.out)

--- a/conans/client/printer.py
+++ b/conans/client/printer.py
@@ -96,7 +96,7 @@ class Printer(object):
                             self._print_colored_line(str(name), indent=3)
                 else:
                     if conan_info.settings:
-                        settings_line = [values[1] for values in \
+                        settings_line = [values[1] for values in
                                          [setting.split("=")
                                           for setting in conan_info.settings.dumps().splitlines()]]
                         settings_line = "(%s)" % ", ".join(settings_line)

--- a/conans/client/printer.py
+++ b/conans/client/printer.py
@@ -34,11 +34,20 @@ class Printer(object):
             ref = PackageReference(ref, conanfile.info.package_id())
             self._out.writeln("    %s" % repr(ref), Color.BRIGHT_CYAN)
 
-    def print_info(self, deps_graph, _):
+    def print_info(self, deps_graph, placeholder_reference, _info):
+        """ Print the dependency information for a conan file
+
+            Attributes:
+                deps_graph: the dependency graph of conan file references to print
+                placeholder_reference: the conan file reference that represents the conan
+                                       file for a project on the path
+        """
         for node in sorted(deps_graph.nodes):
             ref, conan = node
             if not ref:
-                continue
+                # ref is only None iff info is being printed for a project directory, and
+                # not a passed in reference
+                ref = placeholder_reference
             self._out.writeln("%s" % repr(ref), Color.BRIGHT_CYAN)
             url = getattr(conan, "url", None)
             license_ = getattr(conan, "license", None)

--- a/conans/client/printer.py
+++ b/conans/client/printer.py
@@ -40,14 +40,19 @@ class Printer(object):
             Attributes:
                 deps_graph: the dependency graph of conan file references to print
                 placeholder_reference: the conan file reference that represents the conan
-                                       file for a project on the path
+                                       file for a project on the path. This may be None,
+                                       in which case the project itself will not be part
+                                       of the printed dependencies.
         """
         for node in sorted(deps_graph.nodes):
             ref, conan = node
             if not ref:
                 # ref is only None iff info is being printed for a project directory, and
                 # not a passed in reference
-                ref = placeholder_reference
+                if placeholder_reference is None:
+                    continue
+                else:
+                    ref = placeholder_reference
             self._out.writeln("%s" % repr(ref), Color.BRIGHT_CYAN)
             url = getattr(conan, "url", None)
             license_ = getattr(conan, "license", None)

--- a/conans/model/ref.py
+++ b/conans/model/ref.py
@@ -19,10 +19,10 @@ def validate_conan_name(name):
                           " at least %s characters." % (name, ConanFileReference.min_chars)
             else:
                 message = "'%s' is an invalid name. Valid names MUST begin with a "\
-                            "letter or number, have between %s-%s chars, including "\
-                            "letters, numbers, underscore,"\
-                            " dot and dash" % (name, ConanFileReference.min_chars,
-                                               ConanFileReference.max_chars)
+                          "letter or number, have between %s-%s chars, including "\
+                          "letters, numbers, underscore,"\
+                          " dot and dash" % (name, ConanFileReference.min_chars,
+                                             ConanFileReference.max_chars)
             raise InvalidNameException(message)
         return name
     except AttributeError:
@@ -68,7 +68,7 @@ class ConanFileReference(namedtuple("ConanFileReference", "name version user cha
             channel = tokens[3]
         except IndexError:
             raise ConanException("Wrong conans reference %s\nWrite something like "
-                               "OpenCV/1.0.6@phil/stable" % text)
+                                 "OpenCV/1.0.6@phil/stable" % text)
         return ConanFileReference(name, version, user, channel, validate)
 
     def __repr__(self):

--- a/conans/test/command/info_test.py
+++ b/conans/test/command/info_test.py
@@ -2,6 +2,7 @@ import unittest
 from conans.test.tools import TestClient
 from conans.test.utils.cpp_test_files import cpp_hello_conan_files
 from conans.paths import CONANFILE
+import textwrap
 
 
 class InstallTest(unittest.TestCase):
@@ -14,10 +15,13 @@ class InstallTest(unittest.TestCase):
         self.client.save(files, clean_first=True)
         if export:
             self.client.run("export lasote/stable")
-            self.assertIn("""WARN: Conanfile doesn't have 'url'.
-It is recommended to add your repo URL as attribute
-WARN: Conanfile doesn't have a 'license'.
-It is recommended to add the package license as attribute""", self.client.user_io.out)
+            expected_output = textwrap.dedent(
+                """\
+                WARN: Conanfile doesn't have 'url'.
+                It is recommended to add your repo URL as attribute
+                WARN: Conanfile doesn't have a 'license'.
+                It is recommended to add the package license as attribute""")
+            self.assertIn(expected_output, self.client.user_io.out)
 
         files[CONANFILE] = files[CONANFILE].replace('version = "0.1"',
                                                     'version = "0.1"\n'
@@ -35,18 +39,18 @@ It is recommended to add the package license as attribute""", self.client.user_i
         self._create("Hello2", "0.1", ["Hello1/0.1@lasote/stable"], export=False)
 
         self.client.run("info")
-        self.assertIn("""Hello0/0.1@lasote/stable
-    URL: myurl
-    License: MIT
-    Required by:
-        Hello1/0.1@lasote/stable
-Hello1/0.1@lasote/stable
-    URL: myurl
-    License: MIT
-    Required by:
-        Project
-    Requires:
-        Hello0/0.1@lasote/stable""", self.client.user_io.out)
-
-
- 
+        expected_output = textwrap.dedent(
+            """\
+            Hello0/0.1@lasote/stable
+                URL: myurl
+                License: MIT
+                Required by:
+                    Hello1/0.1@lasote/stable
+            Hello1/0.1@lasote/stable
+                URL: myurl
+                License: MIT
+                Required by:
+                    Project
+                Requires:
+                    Hello0/0.1@lasote/stable""")
+        self.assertIn(expected_output, self.client.user_io.out)

--- a/conans/test/command/info_test.py
+++ b/conans/test/command/info_test.py
@@ -41,6 +41,42 @@ class InstallTest(unittest.TestCase):
         self.client.run("info")
         expected_output = textwrap.dedent(
             """\
+            Hello2/0.1@anonymous/testing
+                URL: myurl
+                License: MIT
+                Required by:
+                Requires:
+                    Hello1/0.1@lasote/stable
+            Hello0/0.1@lasote/stable
+                URL: myurl
+                License: MIT
+                Required by:
+                    Hello1/0.1@lasote/stable
+            Hello1/0.1@lasote/stable
+                URL: myurl
+                License: MIT
+                Required by:
+                    Project
+                Requires:
+                    Hello0/0.1@lasote/stable""")
+        self.assertIn(expected_output, self.client.user_io.out)
+
+    def username_included_in_info_test(self):
+        self.client = TestClient()
+        self._create("Hello0", "0.1")
+        self._create("Hello1", "0.1", ["Hello0/0.1@lasote/stable"])
+        self._create("Hello2", "0.1", ["Hello1/0.1@lasote/stable"], export=False)
+
+        self.client.run("user superman")
+        self.client.run("info")
+        expected_output = textwrap.dedent(
+            """\
+            Hello2/0.1@superman/testing
+                URL: myurl
+                License: MIT
+                Required by:
+                Requires:
+                    Hello1/0.1@lasote/stable
             Hello0/0.1@lasote/stable
                 URL: myurl
                 License: MIT


### PR DESCRIPTION
Issue #109 

Easier to review commit by commit for less noise.

Automatically tested:

* `conan info` includes project directory dependencies in output when both name and version are specified

Manually tested:

* projects with `conanfile.txt` will not have the project node included in output
* projects with `conanfile.py` will not have the project node included in output if either of the name or version are not specified
