### PR TITLE
Add cwd parameter to conan_file#run, and pass it through to the runner

### DIFF
--- a/conans/model/conan_file.py
+++ b/conans/model/conan_file.py
@@ -137,11 +137,11 @@ class ConanFile(object):
         """ define cpp_build_info, flags, etc
         """
 
-    def run(self, command, output=True):
+    def run(self, command, output=True, cwd=None):
         """ runs such a command in the folder the Conan
         is defined
         """
-        retcode = self._runner(command, output)
+        retcode = self._runner(command, output, cwd)
         if retcode != 0:
             raise ConanException("Error %d while executing %s" % (retcode, command))
 


### PR DESCRIPTION
I updated `conan_file.py#run` to pass through the working directory in the `ConanFile#run` method. It's not _necessary_, as the commands I use accept a directory argument, but it is far more convenient - I would no longer have to keep using:

```python
self.run("some_command args {build_dir}".format(build_dir=my_build_dir))
```

but instead use:

```python
self.run("some_command args", cwd=my_build_dir)
```