### PR TITLE
allow loading custom name conanfile for install, build & info

### DIFF
--- a/conans/client/command.py
+++ b/conans/client/command.py
@@ -168,10 +168,11 @@ class Command(object):
         parser.add_argument("--package", "-p", nargs=1, action=Extender, help='Force install specified package ID (ignore settings/options)')
         parser.add_argument("--all", action='store_true',
                             default=False, help='Install all packages from the specified reference')
-
+        parser.add_argument("--file", "-f", help="specify conanfile filename")
         self._parse_args(parser)
 
         args = parser.parse_args(*args)
+
         current_path = os.getcwd()
         try:
             reference = ConanFileReference.loads(args.reference)
@@ -194,7 +195,8 @@ class Command(object):
                                   remote=args.remote,
                                   options=option_dict,
                                   settings=settings_dict,
-                                  build_mode=args.build)
+                                  build_mode=args.build,
+                                  filename=args.file)
 
     def info(self, *args):
         """ Prints information about the requirements.
@@ -206,6 +208,7 @@ class Command(object):
         parser.add_argument("reference", nargs='?', default="",
                             help='reference name or path to conanfile file, '
                             'e.g., OpenSSL/1.0.2e@lasote/stable or ./my_project/')
+        parser.add_argument("--file", "-f", help="specify conanfile filename")
         self._parse_args(parser)
 
         args = parser.parse_args(*args)
@@ -226,7 +229,8 @@ class Command(object):
                               options=option_dict,
                               settings=settings_dict,
                               build_mode=args.build,
-                              info=True)
+                              info=True,
+                              filename=args.file)
 
     def build(self, *args):
         """ calls your project conanfile.py "build" method.
@@ -237,13 +241,14 @@ class Command(object):
         parser.add_argument("path", nargs="?",
                             help='path to user conanfile.py, e.g., conans build .',
                             default="")
+        parser.add_argument("--file", "-f", help="specify conanfile filename")
         args = parser.parse_args(*args)
         current_path = os.getcwd()
         if args.path:
             root_path = os.path.abspath(args.path)
         else:
             root_path = current_path
-        self._manager.build(root_path, current_path)
+        self._manager.build(root_path, current_path, filename=args.file)
 
     def package(self, *args):
         """ calls your conanfile.py "package" method for a specific package or regenerates the existing

--- a/conans/client/loader.py
+++ b/conans/client/loader.py
@@ -26,14 +26,15 @@ class ConanFileLoader(object):
         self._settings = settings
         self._options = options
 
-    def _create_check_conan(self, conan_file, consumer, conan_file_path, output):
+    def _create_check_conan(self, conan_file, consumer, conan_file_path, output, filename):
         """ Check the integrity of a given conanfile
         """
         result = None
         for name, attr in conan_file.__dict__.iteritems():
             if "_" in name:
                 continue
-            if inspect.isclass(attr) and issubclass(attr, ConanFile) and attr != ConanFile:
+            if (inspect.isclass(attr) and issubclass(attr, ConanFile) and attr != ConanFile
+                and attr.__dict__["__module__"] == filename):
                 if result is None:
                     # Actual instantiation of ConanFile object
                     result = attr(output, self._runner,
@@ -63,11 +64,13 @@ class ConanFileLoader(object):
         if not os.path.exists(conan_file_path):
             raise NotFoundException("%s not found!" % conan_file_path)
 
+        filename = os.path.splitext(os.path.basename(conan_file_path))[0]
+
         try:
             current_dir = os.path.dirname(conan_file_path)
             sys.path.append(current_dir)
             old_modules = sys.modules.keys()
-            loaded = imp.load_source("conanfile", conan_file_path)
+            loaded = imp.load_source(filename, conan_file_path)
             # Put all imported files under a new package name
             module_id = uuid.uuid1()
             added_modules = set(sys.modules).difference(old_modules)
@@ -87,7 +90,7 @@ class ConanFileLoader(object):
             sys.path.pop()
 
         try:
-            result = self._create_check_conan(loaded, consumer, conan_file_path, output)
+            result = self._create_check_conan(loaded, consumer, conan_file_path, output, filename)
             if consumer:
                 result.options.initialize_upstream(self._options)
             return result
@@ -97,12 +100,15 @@ class ConanFileLoader(object):
     def load_conan_txt(self, conan_requirements_path, output):
 
         if not os.path.exists(conan_requirements_path):
-            raise NotFoundException("%s not found!" % CONANFILE_TXT)
+            raise NotFoundException("Conanfile not found!")
 
         conanfile = ConanFile(output, self._runner, self._settings.copy(),
                               os.path.dirname(conan_requirements_path))
 
-        parser = ConanFileTextLoader(load(conan_requirements_path))
+        try:
+            parser = ConanFileTextLoader(load(conan_requirements_path))
+        except Exception as e:
+            raise ConanException("%s:\n%s" % (conan_requirements_path, str(e)))
         for requirement_text in parser.requirements:
             ConanFileReference.loads(requirement_text)  # Raise if invalid
             conanfile.requires.add(requirement_text)

--- a/conans/client/manager.py
+++ b/conans/client/manager.py
@@ -121,7 +121,7 @@ class ConanManager(object):
             installer.download_packages(reference, info[reference].keys())
 
     def install(self, reference, current_path, remote=None, options=None, settings=None,
-                build_mode=False, info=None):
+                build_mode=False, info=None, filename=None):
         """ Fetch and build all dependencies for the given reference
         @param reference: ConanFileReference or path to user space conanfile
         @param current_path: where the output files will be saved
@@ -140,11 +140,13 @@ class ConanManager(object):
         else:
             output = ScopedOutput("Project", self._user_io.out)
             try:
-                conan_file_path = os.path.join(conanfile_path, CONANFILE)
+                if filename and filename.endswith(".txt"):
+                    raise NotFoundException()
+                conan_file_path = os.path.join(conanfile_path, filename or CONANFILE)
                 conanfile = loader.load_conan(conan_file_path, output, consumer=True)
                 is_txt = False
             except NotFoundException:  # Load requirements.txt
-                conan_path = os.path.join(conanfile_path, CONANFILE_TXT)
+                conan_path = os.path.join(conanfile_path, filename or CONANFILE_TXT)
                 conanfile = loader.load_conan_txt(conan_path, output)
                 is_txt = True
 
@@ -201,14 +203,18 @@ class ConanManager(object):
                     raise NotFoundException('Package %s does not exist' % str(package_reference))
                 packager.generate_manifest(package_folder)
 
-    def build(self, conanfile_path, current_path, test=False):
+    def build(self, conanfile_path, current_path, test=False, filename=None):
         """ Call to build() method saved on the conanfile.py
         param conanfile_path: the original source directory of the user containing a
                             conanfile.py
         """
         logger.debug("Building in %s" % current_path)
         logger.debug("Conanfile in %s" % conanfile_path)
-        conanfile_file = os.path.join(conanfile_path, CONANFILE)
+
+        if filename and filename.endswith(".txt"):
+            raise ConanException("A conanfile.py is needed to call 'conan build'")
+
+        conanfile_file = os.path.join(conanfile_path, filename or CONANFILE)
 
         try:
             output = ScopedOutput("Project", self._user_io.out)

--- a/conans/test/conanfile_extend_test.py
+++ b/conans/test/conanfile_extend_test.py
@@ -1,0 +1,124 @@
+import unittest
+from conans.test.tools import TestClient
+from conans.util.files import load
+import os
+
+
+class ConanfileExtendTest(unittest.TestCase):
+
+    def setUp(self):
+        client = TestClient()
+        base = '''
+from conans import ConanFile
+
+class ConanLib(ConanFile):
+    name = "lib"
+    version = "0.1"
+'''
+
+        files = {"conanfile.py": base}
+        client.save(files)
+        client.run("export user/channel")
+        base = '''
+from conans import ConanFile
+
+class ConanOtherLib(ConanFile):
+    name = "otherlib"
+    version = "0.2"
+    options = {"otherlib_option": [1, 2, 3]}
+    default_options="otherlib_option=3"
+'''
+
+        files = {"conanfile.py": base}
+        client.save(files)
+        client.run("export user/channel")
+
+        self.base_folder = client.base_folder
+
+    def test_base(self):
+
+        base = '''
+from conans import ConanFile
+
+class HelloConan2(ConanFile):
+    name = "test"
+    version = "1.9"
+    requires = "lib/0.1@user/channel"
+    options = {"test_option": [1, 2, 3]}
+    default_options="test_option=2"
+    my_flag = False
+
+    def build(self):
+        self.output.info("MyFlag %s" % self.my_flag)
+    '''
+        extension = '''
+from conans import ConanFile, CMake
+from conanfile import HelloConan2
+
+class DevConanFile(HelloConan2):
+    my_flag = True
+
+    def config(self):
+        self.options["otherlib"].otherlib_option = 1
+
+    def requirements(self):
+        self.requires("otherlib/0.2@user/channel")
+
+    '''
+        files = {"conanfile.py": base,
+                 "conanfile_dev.py": extension}
+
+        client = TestClient(self.base_folder)
+        client.save(files)
+        client.run("install --build")
+        conaninfo = load(os.path.join(client.current_folder, "conaninfo.txt"))
+        self.assertIn("lib/0.1@user/channel", conaninfo)
+        self.assertIn("test_option=2", conaninfo)
+        self.assertNotIn("otherlib/0.2@user/channel", conaninfo)
+        self.assertNotIn("otherlib:otherlib_option=1", conaninfo)
+        client.run("build")
+        self.assertIn("MyFlag False", client.user_io.out)
+        client.run("info")
+        self.assertIn("lib/0.1@user/channel", client.user_io.out)
+        self.assertNotIn("otherlib/0.2@user/channel", client.user_io.out)
+
+        client.run("install --build --file=conanfile_dev.py")
+        conaninfo = load(os.path.join(client.current_folder, "conaninfo.txt"))
+        self.assertIn("lib/0.1@user/channel", conaninfo)
+        self.assertIn("test_option=2", conaninfo)
+        self.assertIn("otherlib/0.2@user/channel", conaninfo)
+        self.assertIn("otherlib:otherlib_option=1", conaninfo)
+        client.run("build -f=conanfile_dev.py")
+        self.assertIn("MyFlag True", client.user_io.out)
+        client.run("info  -f=conanfile_dev.py")
+        self.assertIn("lib/0.1@user/channel", client.user_io.out)
+        self.assertIn("otherlib/0.2@user/channel", client.user_io.out)
+
+    def test_txt(self):
+
+        base = '''[requires]
+lib/0.1@user/channel
+'''
+        extension = '''[requires]
+lib/0.1@user/channel
+otherlib/0.2@user/channel
+
+[options]
+otherlib:otherlib_option = 1
+'''
+        files = {"conanfile.txt": base,
+                 "conanfile_dev.txt": extension}
+
+        client = TestClient(self.base_folder)
+        client.save(files)
+        client.run("install --build")
+        conaninfo = load(os.path.join(client.current_folder, "conaninfo.txt"))
+        self.assertIn("lib/0.1@user/channel", conaninfo)
+        self.assertNotIn("otherlib/0.2@user/channel", conaninfo)
+        self.assertNotIn("otherlib:otherlib_option=1", conaninfo)
+
+        client.run("install --build --file=conanfile_dev.txt")
+        conaninfo = load(os.path.join(client.current_folder, "conaninfo.txt"))
+        self.assertIn("lib/0.1@user/channel", conaninfo)
+        self.assertIn("otherlib/0.2@user/channel", conaninfo)
+        self.assertIn("otherlib:otherlib_option=1", conaninfo)


### PR DESCRIPTION
This PR partially addresses #77, #83, and #80:

It allows to define any custom conanfile to load for commands install, build & info.

- It allows having a .conanfile.txt and load it with (--file, -f) as (cc/ @mcraveiro):

```
$ conan install --file=.conanfile.txt
```

- You can have as many conanfile.txt files as you want for your projects:
```
$ conan install --file=conanfile_test.txt
$ conan install --file=conanfile_production.txt
```
- It allows defining different conanfiles for dev and production. The tests included show that, for example, the dev conanfile can **extend** the production conanfile to add test libraries, for example, so DRY (cc @bjoernpollex, @azriel91)

```
$ conan install -f=conanfile_dev.py
```

It works for **build and info commands too**. Please note, that not for ``export`` (only the package, canonical ``conanfile.py`` should be exported). So the packages actually use ``conanfile.py``, and the other files to be loaded with this option are for development only. 
