### PR TITLE
changed settings with migration

### DIFF
--- a/conans/__init__.py
+++ b/conans/__init__.py
@@ -9,4 +9,4 @@ from conans.client.configure_environment import ConfigureEnvironment
 from conans.util.files import load
 import os
 
-__version__ = '0.6.0'
+__version__ = '0.7.0'

--- a/conans/client/conf/__init__.py
+++ b/conans/client/conf/__init__.py
@@ -11,10 +11,10 @@ MIN_SERVER_COMPATIBLE_VERSION = '0.6.0'
 
 default_settings_yml = """
 os: [Windows, Linux, Macos, Android]
-arch: [x86, x86_64, arm]
+arch: [x86, x86_64, armv6, armv7, armv7hf, armv8]
 compiler:
     gcc:
-        version: ["4.6", "4.7", "4.8", "4.9", "5.1", "5.2", "5.3"]
+        version: ["4.4", "4.5", "4.6", "4.7", "4.8", "4.9", "5.1", "5.2", "5.3"]
     Visual Studio:
         runtime: [None, MD, MT, MTd, MDd]
         version: ["8", "9", "10", "11", "12", "14"]

--- a/conans/client/migrations.py
+++ b/conans/client/migrations.py
@@ -2,6 +2,7 @@ from conans.migrations import Migrator
 from conans.util.files import rmdir, load, save
 from conans.model.version import Version
 import os
+from conans.client.conf import default_settings_yml
 
 
 class ClientMigrator(Migrator):
@@ -29,3 +30,30 @@ class ClientMigrator(Migrator):
                                     'version: ["4.6", "4.7", "4.8", "4.9", "5.0"]',
                                     'version: ["4.6", "4.7", "4.8", "4.9", "5.1", "5.2", "5.3"]')
             save(self.paths.settings_path, default_settings)
+        elif old_version < Version("0.7"):
+            self.out.warn("Migration: Updating settings.yml")
+            old_settings = """
+os: [Windows, Linux, Macos, Android]
+arch: [x86, x86_64, armv]
+compiler:
+    gcc:
+        version: ["4.6", "4.7", "4.8", "4.9", "5.1", "5.2", "5.3"]
+    Visual Studio:
+        runtime: [None, MD, MT, MTd, MDd]
+        version: ["8", "9", "10", "11", "12", "14"]
+    clang:
+        version: ["3.3", "3.4", "3.5", "3.6", "3.7"]
+    apple-clang:
+        version: ["5.0", "5.1", "6.0", "6.1", "7.0"]
+
+build_type: [None, Debug, Release]
+"""
+            current_settings = load(self.paths.settings_path)
+            if current_settings != old_settings:
+                backup_path = self.paths.settings_path + ".backup"
+                save(backup_path, current_settings)
+                self.out.warn("*" * 40)
+                self.out.warn("A new settings.yml has been defined")
+                self.out.warn("Your old settings.yml has been backup'd to: %s" % backup_path)
+                self.out.warn("*" * 40)
+            save(self.paths.settings_path, default_settings_yml)


### PR DESCRIPTION
Related to: https://github.com/conan-io/conan/issues/86

It adds several ARM architectures to default settings.yml (deprecate old "arm")
Also adding some gcc older versions, as requested by some users.

The migration just creates a backup file with old settings if modified by user.