### PR TITLE
normalizing in Win crlf for user generated files

### DIFF
--- a/conans/client/generators/__init__.py
+++ b/conans/client/generators/__init__.py
@@ -1,5 +1,5 @@
 from conans.model import registered_generators
-from conans.util.files import save
+from conans.util.files import save, normalize
 from os.path import join
 from .text import TXTGenerator
 from .gcc import GCCGenerator
@@ -42,4 +42,5 @@ def write_generators(conanfile, path, output):
             generator_class = registered_generators[generator_name]
             generator = generator_class(conanfile.deps_cpp_info, conanfile.cpp_info)
             output.info("Generated %s created %s" % (generator_name, generator.filename))
-            save(join(path, generator.filename), generator.content)
+            content = normalize(generator.content)
+            save(join(path, generator.filename), content)

--- a/conans/client/manager.py
+++ b/conans/client/manager.py
@@ -5,7 +5,7 @@ from conans.client.export import export_conanfile
 from conans.client.deps_builder import DepsBuilder
 from conans.client.userio import UserIO
 from conans.client.installer import ConanInstaller
-from conans.util.files import save, load, rmdir
+from conans.util.files import save, load, rmdir, normalize
 from conans.util.log import logger
 from conans.client.uploader import ConanUploader
 from conans.client.printer import Printer
@@ -161,7 +161,8 @@ class ConanManager(object):
             if is_txt:
                 conanfile.info.settings = loader._settings.values
                 conanfile.info.full_settings = loader._settings.values
-            save(os.path.join(current_path, CONANINFO), conanfile.info.dumps())
+            content = normalize(conanfile.info.dumps())
+            save(os.path.join(current_path, CONANINFO), content)
             self._user_io.out.writeln("")
             output.info("Generated %s" % CONANINFO)
             write_generators(conanfile, current_path, output)

--- a/conans/model/conan_generator.py
+++ b/conans/model/conan_generator.py
@@ -1,4 +1,3 @@
-from conans.util.files import save
 from conans.errors import ConanException
 from abc import ABCMeta, abstractproperty
 

--- a/conans/util/files.py
+++ b/conans/util/files.py
@@ -4,8 +4,16 @@ from errno import ENOENT, EEXIST
 import hashlib
 import sys
 import tarfile
-from os.path import abspath, realpath, dirname, join as joinpath
-from tarfile import TarInfo
+from os.path import abspath, realpath, join as joinpath
+import platform
+import re
+
+
+def normalize(text):
+    if platform.system() == "Windows":
+        return re.sub("\r?\n", "\r\n", text)
+    else:
+        return text
 
 
 def md5(content):
@@ -110,7 +118,7 @@ def mkdir(path, raise_if_already_exists=False):
 
 
 def path_exists(path, basedir=None):
-    """Case sensitive, for windows, optional 
+    """Case sensitive, for windows, optional
     basedir for skip caps check for tmp folders in testing for example (returned always
     in lowercase for some strange reason)"""
     exists = os.path.exists(path)


### PR DESCRIPTION
This PR addresses https://github.com/conan-io/conan/issues/74

It has been done just for user side project generated files (conaninfo.txt and all generators: conanbuildinfo.cmake, ...) The problem with doing it for all files, i.e. also for package files is that packages are SHA signed in the manifest, so changing line endings can cause troubles. Also they would very rarely be inspected, so I think it can be enough with user side files.