### PR TITLE
Bugfix/find conaninfo txt in conanfile directory

### DIFF
--- a/conans/client/generators/__init__.py
+++ b/conans/client/generators/__init__.py
@@ -40,7 +40,7 @@ def write_generators(conanfile, path, output):
                         (generator_name, ", ".join(registered_generators.available)))
         else:
             generator_class = registered_generators[generator_name]
-            generator = generator_class(conanfile.deps_cpp_info, conanfile.cpp_info)
+            generator = generator_class(conanfile.conanfile_directory, conanfile.deps_cpp_info, conanfile.cpp_info)
             output.info("Generated %s created %s" % (generator_name, generator.filename))
             content = normalize(generator.content)
             save(join(path, generator.filename), content)

--- a/conans/client/generators/cmake.py
+++ b/conans/client/generators/cmake.py
@@ -140,12 +140,13 @@ macro(conan_error_compiler_version)
 endmacro()
 
 function(conan_get_compiler CONAN_INFO_COMPILER CONAN_INFO_COMPILER_VERSION)
-    if(NOT EXISTS ${CMAKE_BINARY_DIR}/conaninfo.txt)
+    set(CONANINFO_TXT \"""" + self.conanfile_directory.replace('\\', '/') + """/conaninfo.txt")
+    if(NOT EXISTS "${CONANINFO_TXT}")
         message(STATUS "WARN: conaninfo.txt not found")
         return()
     endif()
 
-    file (READ "${CMAKE_BINARY_DIR}/conaninfo.txt" CONANINFO)
+    file (READ "${CONANINFO_TXT}" CONANINFO)
 
     string(REGEX MATCH "compiler=([A-Za-z0-9_ ]+)" _MATCHED ${CONANINFO})
     if(DEFINED CMAKE_MATCH_1)

--- a/conans/client/generators/visualstudio.py
+++ b/conans/client/generators/visualstudio.py
@@ -24,8 +24,8 @@ class VisualStudioGenerator(Generator):
   <ItemGroup />
 </Project>'''
 
-    def __init__(self, deps_cpp_info, cpp_info):
-        super(VisualStudioGenerator, self).__init__(deps_cpp_info, cpp_info)
+    def __init__(self, conanfile_directory, deps_cpp_info, cpp_info):
+        super(VisualStudioGenerator, self).__init__(conanfile_directory, deps_cpp_info, cpp_info)
         self.include_dirs = "".join('%s;' % p.replace("\\", "/")
                                     for p in deps_cpp_info.include_paths)
         self.lib_dirs = "".join('%s;' % p.replace("\\", "/")

--- a/conans/client/generators/xcode.py
+++ b/conans/client/generators/xcode.py
@@ -14,8 +14,8 @@ OTHER_CFLAGS = $(inherited)
 OTHER_CPLUSPLUSFLAGS = $(inherited)
 '''
 
-    def __init__(self, deps_cpp_info, cpp_info):
-        super(XCodeGenerator, self).__init__(deps_cpp_info, cpp_info)
+    def __init__(self, conanfile_directory, deps_cpp_info, cpp_info):
+        super(XCodeGenerator, self).__init__(conanfile_directory, deps_cpp_info, cpp_info)
         self.include_dirs = " ".join('"%s"' % p.replace("\\", "/")
                                      for p in deps_cpp_info.include_paths)
         self.lib_dirs = " ".join('"%s"' % p.replace("\\", "/")

--- a/conans/client/installer.py
+++ b/conans/client/installer.py
@@ -205,7 +205,8 @@ class ConanInstaller(object):
             # Creating ***info.txt files
             save(os.path.join(build_folder, CONANINFO), conan_file.info.dumps())
             output.info("Generated %s" % CONANINFO)
-            save(os.path.join(build_folder, BUILD_INFO), TXTGenerator(conan_file.deps_cpp_info,
+            save(os.path.join(build_folder, BUILD_INFO), TXTGenerator(conan_file.conanfile_directory,
+                                                                      conan_file.deps_cpp_info,
                                                                       conan_file.cpp_info).content)
             output.info("Generated %s" % BUILD_INFO)
 

--- a/conans/model/build_info.py
+++ b/conans/model/build_info.py
@@ -79,7 +79,7 @@ class DepsCppInfo(_CppInfo):
         return self._dependencies[item]
 
     def __repr__(self):
-        return TXTGenerator(self, None).content
+        return TXTGenerator(None, self, None).content
 
     @staticmethod
     def loads(text):

--- a/conans/model/conan_generator.py
+++ b/conans/model/conan_generator.py
@@ -5,9 +5,14 @@ from abc import ABCMeta, abstractproperty
 class Generator(object):
     __metaclass__ = ABCMeta
 
-    def __init__(self, deps_build_info, build_info):
+    def __init__(self, conanfile_directory, deps_build_info, build_info):
+        self._conanfile_directory = conanfile_directory
         self._deps_build_info = deps_build_info
         self._build_info = build_info
+
+    @property
+    def conanfile_directory(self):
+        return self._conanfile_directory
 
     @property
     def deps_build_info(self):


### PR DESCRIPTION
When projects use a separate subdirectory for an out-of-source build, `conaninfo.txt` does not exist inside `CMAKE_BINARY_DIR`, and so building the project fails when conan tries to detect the compiler. This PR updates the CMake generator to search for `conaninfo.txt` from the conanfile_directory.