### PR TITLE
extracted from installer retrieve methods

### DIFF
--- a/conans/client/command.py
+++ b/conans/client/command.py
@@ -165,9 +165,10 @@ class Command(object):
         parser.add_argument("reference", nargs='?', default="",
                             help='reference'
                             'e.g., OpenSSL/1.0.2e@lasote/stable or ./my_project/')
-        parser.add_argument("--package", "-p", nargs=1, action=Extender, help='Force install specified package ID (ignore settings/options)')
-        parser.add_argument("--all", action='store_true',
-                            default=False, help='Install all packages from the specified reference')
+        parser.add_argument("--package", "-p", nargs=1, action=Extender,
+                            help='Force install specified package ID (ignore settings/options)')
+        parser.add_argument("--all", action='store_true', default=False,
+                            help='Install all packages from the specified reference')
         parser.add_argument("--file", "-f", help="specify conanfile filename")
         self._parse_args(parser)
 
@@ -183,7 +184,8 @@ class Command(object):
             if args.all:
                 args.package = []
             if not args.reference or not isinstance(reference, ConanFileReference):
-                raise ConanException("Invalid conanfile reference. e.g., OpenSSL/1.0.2e@lasote/stable")
+                raise ConanException("Invalid conanfile reference. "
+                                     "e.g., OpenSSL/1.0.2e@lasote/stable")
             self._manager.download(reference, args.package, remote=args.remote)
         else:  # Classic install, package chosen with settings and options
             # Get False or a list of patterns to check
@@ -251,10 +253,11 @@ class Command(object):
         self._manager.build(root_path, current_path, filename=args.file)
 
     def package(self, *args):
-        """ calls your conanfile.py "package" method for a specific package or regenerates the existing
-            package's manifest.
-            Intended for package creators, for regenerating a package without recompiling the source.
-            e.g. conan package OpenSSL/1.0.2e@lasote/stable 9cf83afd07b678d38a9c1645f605875400847ff3
+        """ calls your conanfile.py "package" method for a specific package or
+            regenerates the existing package's manifest.
+            Intended for package creators, for regenerating a package without
+            recompiling the source.
+            e.g. conan package OpenSSL/1.0.2e@lasote/stable 9cf83afd07b678da9c1645f605875400847ff3
         """
         parser = argparse.ArgumentParser(description=self.package.__doc__, prog="conan package")
         parser.add_argument("reference", help='reference name. e.g., openssl/1.0.2@lasote/testing')
@@ -522,7 +525,7 @@ def main(args):
     try:
         import signal
 
-        def sigint_handler(signal, frame):
+        def sigint_handler(signal, frame):  # @UnusedVariable
             print('You pressed Ctrl+C!')
             sys.exit(0)
 

--- a/conans/client/loader.py
+++ b/conans/client/loader.py
@@ -5,7 +5,6 @@ import uuid
 import imp
 import os
 from conans.util.files import load
-from conans.paths import CONANFILE_TXT
 from conans.util.config_parser import ConfigParser
 from conans.model.options import OptionsValues
 from conans.model.ref import ConanFileReference

--- a/conans/client/proxy.py
+++ b/conans/client/proxy.py
@@ -1,0 +1,87 @@
+from conans.client.output import ScopedOutput
+from conans.util.files import path_exists, rmdir
+from conans.model.ref import PackageReference
+from conans.errors import ConanException
+
+
+class ConanfileRemoteProxy(object):
+    """ A Remote proxy just for loading conanfiles. It is needed by the DepsBuilder,
+    when it has to build the transitive graph of dependencies
+    """
+    def __init__(self, paths, user_io, conan_loader, remote_manager, remote):
+        self._paths = paths
+        self._loader = conan_loader
+        self._out = user_io.out
+        self._remote_manager = remote_manager
+        self._remote = remote
+
+    def retrieve_conanfile(self, conan_reference, consumer=False):
+        """ returns the requested conanfile object, retrieving it from
+        remotes if necessary. Can raise NotFoundException
+        """
+        output = ScopedOutput(str(conan_reference), self._out)
+        conanfile_path = self._paths.conanfile(conan_reference)
+
+        if not self._paths.valid_conan_digest(conan_reference):
+            conan_dir_path = self._paths.export(conan_reference)
+            if path_exists(conan_dir_path, self._paths.store):
+                # If not valid conanfile, ensure empty folder
+                output.warn("Bad conanfile detected! Removing export directory... ")
+                rmdir(conan_dir_path)
+            output.info("Conanfile not found, retrieving from server")
+            # If not in localhost, download it. Will raise if not found
+            self._remote_manager.get_conanfile(conan_reference, self._remote)
+        conanfile = self._loader.load_conan(conanfile_path, output, consumer)
+        return conanfile
+
+
+class ConanRemoteProxy(object):
+    """ The remote proxy for binaries, downloads and uploads
+    """
+    def __init__(self, paths, user_io, remote_manager, remote):
+        self._paths = paths
+        self._out = user_io.out
+        self._remote_manager = remote_manager
+        self._remote = remote
+
+    @property
+    def remote(self):
+        return self._remote
+
+    def upload_conan(self, conan_reference):
+        return self._remote_manager.upload_conan(conan_reference, self._remote)
+
+    def upload_package(self, package_reference):
+        return self._remote_manager.upload_package(package_reference, self._remote)
+
+    def get_conan_digest(self, conan_ref):
+        return self._remote_manager.get_conan_digest(conan_ref, self._remote)
+
+    def search(self, pattern=None, ignorecase=True):
+        return self._remote_manager.search(pattern, self._remote, ignorecase)
+
+    def remove(self, conan_ref):
+        return self._remote_manager.remove(conan_ref, self._remote)
+
+    def remove_packages(self, conan_ref, remove_ids):
+        return self._remote_manager.remove_packages(conan_ref, remove_ids, self._remote)
+
+    def download_packages(self, reference, package_ids):
+        assert(isinstance(package_ids, list))
+        self._remote_manager.get_conanfile(reference, self._remote)
+        output = ScopedOutput(str(reference), self._out)
+        for package_id in package_ids:
+            package_reference = PackageReference(reference, package_id)
+            self.retrieve_remote_package(package_reference, output)
+
+    def retrieve_remote_package(self, package_reference, output):
+        package_id = str(package_reference.package_id)
+        try:
+            output.info("Looking for package %s in remotes" % package_id)
+            # Will raise if not found NotFoundException
+            self._remote_manager.get_package(package_reference, self._remote)
+            output.success('Package installed %s' % package_id)
+            return True
+        except ConanException as e:
+            output.warn('Binary for %s not in remote: %s' % (package_id, str(e)))
+            return False

--- a/conans/client/uploader.py
+++ b/conans/client/uploader.py
@@ -5,11 +5,10 @@ from conans.model.ref import PackageReference
 
 class ConanUploader(object):
 
-    def __init__(self, paths, user_io, remote_manager, remote):
+    def __init__(self, paths, user_io, remote_proxy):
         self._paths = paths
         self._user_io = user_io
-        self._remote_manager = remote_manager
-        self._remote = remote
+        self._remote_proxy = remote_proxy
 
     def upload_conan(self, conan_ref, force=False, all_packages=False):
         """Uploads the conans identified by conan_ref"""
@@ -19,7 +18,7 @@ class ConanUploader(object):
                 self._check_package_date(conan_ref)
 
             self._user_io.out.info("Uploading %s" % str(conan_ref))
-            self._remote_manager.upload_conan(conan_ref, self._remote)
+            self._remote_proxy.upload_conan(conan_ref)
 
             if all_packages:
                 for index, package_id in enumerate(self._paths.conan_packages(conan_ref)):
@@ -33,11 +32,11 @@ class ConanUploader(object):
         """Uploads the package identified by package_id"""
         msg = ("Uploading package %d/%d: %s" % (index, total, str(package_ref.package_id)))
         self._user_io.out.info(msg)
-        self._remote_manager.upload_package(package_ref, self._remote)
+        self._remote_proxy.upload_package(package_ref)
 
     def _check_package_date(self, conan_ref):
         try:
-            remote_conan_digest = self._remote_manager.get_conan_digest(conan_ref, self._remote)
+            remote_conan_digest = self._remote_proxy.get_conan_digest(conan_ref)
         except NotFoundException:
             return  # First upload
 

--- a/conans/test/download_test.py
+++ b/conans/test/download_test.py
@@ -6,11 +6,11 @@ import os
 from conans.model.ref import ConanFileReference, PackageReference
 from conans.paths import CONAN_MANIFEST
 from conans.util.files import save
-from conans.client.installer import ConanInstaller
 from conans.model.manifest import FileTreeManifest
 from conans.model.options import OptionsValues
 from conans.client.loader import ConanFileLoader
 from conans.model.settings import Settings
+from conans.client.proxy import ConanfileRemoteProxy, ConanRemoteProxy
 
 
 myconan1 = """
@@ -62,13 +62,17 @@ class DownloadTest(unittest.TestCase):
         client2.init_dynamic_vars()
         loader = ConanFileLoader(None, Settings(), OptionsValues.loads(""))
 
-        installer = ConanInstaller(client2.paths,
-                                    client2.user_io,
-                                    loader,
-                                    client2.remote_manager,
-                                    "default")
+        installer = ConanfileRemoteProxy(client2.paths,
+                                         client2.user_io,
+                                         loader,
+                                         client2.remote_manager,
+                                         "default")
         installer.retrieve_conanfile(conan_ref)
-        installer._retrieve_remote_package(package_ref, TestBufferConanOutput())
+        installer = ConanRemoteProxy(client2.paths,
+                                     client2.user_io,
+                                     client2.remote_manager,
+                                     "default")
+        installer.retrieve_remote_package(package_ref, TestBufferConanOutput())
 
         reg_path = client2.paths.export(ConanFileReference.loads("Hello/1.2.1/frodo/stable"))
         pack_folder = client2.paths.package(package_ref)


### PR DESCRIPTION
I have started to implement the "update" feature, with packages that are overwritten, knowing if downstream have to update to latest. 

I was checking where to implement it, and realized that there were several methods in ``ConanInstaller`` totally related to ``RemoteManager``, while the main responsibility of ``ConanInstaller`` is clearly building things, and managing export=>source=>build=>package when upstream binaries are not available.

 ``RemoteManager`` is clearly more related to connection to the remotes, and executing remote commands. So I decided to propose a Proxy class that can be put in the middle and is the responsible of "middleware" interceptions, as e.g. the update feature, when requested a conanfile.


 