### PR TITLE
SSL verify

### DIFF
--- a/conans/tools.py
+++ b/conans/tools.py
@@ -70,9 +70,13 @@ def get(url):
     os.unlink(filename)
 
 
-def download(url, filename):
+def download(url, filename, verify=True):
     out = ConanOutput(sys.stdout, True)
-    downloader = Downloader(requests, out, verify=False)
+    if verify:
+        # We check the certificate using a list of known verifiers
+        import conans.client.rest.cacert as cacert
+        verify = cacert.file_path
+    downloader = Downloader(requests, out, verify=verify)
     content = downloader.download(url)
     out.writeln("")
     save(filename, content)


### PR DESCRIPTION
If we tried to download a zip (in conanfile source method) from a valid https domain it can still fail because it depends if our local computer (issue detected in appveyor) have a valid openssl with a ssl authorities list. The requests client uses this autorities list to verify that the remote certificate is valid.
Even you specify verify=False for requests library it failed too (maybe its a requests bug).

The PR uses the list that we already used for our server connections.