### PR TITLE
mingw4.9 no longer use Unix Makefiles

### DIFF
--- a/conans/client/cmake.py
+++ b/conans/client/cmake.py
@@ -41,8 +41,6 @@ class CMake(object):
 
         if operating_system == "Windows":
             if compiler == "gcc":
-                if self._settings.compiler.version == "4.9":
-                    return "Unix Makefiles"
                 return "MinGW Makefiles"
             if compiler in ["clang", "apple-clang"]:
                 return "MinGW Makefiles"


### PR DESCRIPTION
I have had to upgrade my computer, realized that the standard mingw version now is gcc 4.9, not 4.8, and it no longer requires Unix Makefiles for cmake (my special old 4.9 required them, nuwen I think).

Tests passing in win10 with mingw 4.9. Might fail in CI appveyor... lets see.