### PR TITLE
check in conan export for case insensitive OSs. Fix #171

### DIFF
--- a/conans/client/cmake.py
+++ b/conans/client/cmake.py
@@ -41,8 +41,6 @@ class CMake(object):
 
         if operating_system == "Windows":
             if compiler == "gcc":
-                if self._settings.compiler.version == "4.9":
-                    return "Unix Makefiles"
                 return "MinGW Makefiles"
             if compiler in ["clang", "apple-clang"]:
                 return "MinGW Makefiles"

--- a/conans/client/manager.py
+++ b/conans/client/manager.py
@@ -98,6 +98,15 @@ class ConanManager(object):
                                    "It is recommended to add the package license as attribute")
 
         conan_ref = ConanFileReference(conan_file.name, conan_file.version, user_name, channel)
+
+        conan_ref_str = str(conan_ref)
+        # Maybe a platform check could be added, but depends on disk partition
+        info = self.file_manager.search(conan_ref_str, ignorecase=True)
+        refs = {s for s in info.iterkeys() if str(s).lower() == conan_ref_str.lower()}
+        if refs and conan_ref not in refs:
+            raise ConanException("Cannot export package with same name but different case\n"
+                                 "You exported '%s' but already existing '%s'"
+                                 % (conan_ref_str, " ".join(str(s) for s in refs)))
         output = ScopedOutput(str(conan_ref), self._user_io.out)
         export_conanfile(output, self._paths,
                          conan_file.exports, conan_file_path, conan_ref, keep_source)

--- a/conans/test/command/export_test.py
+++ b/conans/test/command/export_test.py
@@ -6,6 +6,7 @@ from conans.model.ref import ConanFileReference
 from conans.test.utils.cpp_test_files import cpp_hello_conan_files
 from conans.model.manifest import FileTreeManifest
 from conans.test.tools import TestClient
+from conans.errors import ConanException
 
 
 class ExportTest(unittest.TestCase):
@@ -37,6 +38,15 @@ class ExportTest(unittest.TestCase):
                          'conanfile.py': '644b60e95962dabec1a814dedea32874',
                          'helloHello0.h': '9448df034392fc8781a47dd03ae71bdd'}
         self.assertEqual(expected_sums, manif.file_sums)
+
+    def test_case_sensitive(self):
+        self.files = cpp_hello_conan_files("hello0", "0.1")
+        self.conan_ref = ConanFileReference("hello0", "0.1", "lasote", "stable")
+        self.conan.save(self.files)
+        error = self.conan.run("export lasote/stable", ignore_error=True)
+        self.assertTrue(error)
+        self.assertIn("ERROR: Cannot export package with same name but different case",
+                      self.conan.user_io.out)
 
     def test_export_filter(self):
         content = """


### PR DESCRIPTION
Win was overwriting package HelloX, with package hELlox, due to filesystem insensitiveness.