### PR TITLE
_compute_private_nodes checks if the private_requirer isn't the orignal node.

### DIFF
--- a/conans/client/installer.py
+++ b/conans/client/installer.py
@@ -21,13 +21,13 @@ class ConanInstaller(object):
         self._out = user_io.out
         self._remote_proxy = remote_proxy
 
-    def install(self, deps_graph, build_mode=False):
+    def install(self, deps_graph, build_mode=False, source=None):
         """ given a DepsGraph object, build necessary nodes or retrieve them
         """
         self._deps_graph = deps_graph  # necessary for _build_package
         self._out.writeln("\nInstalling requirements", Color.BRIGHT_YELLOW)
         nodes_by_level = self._process_buildinfo(deps_graph)
-        skip_private_nodes = self._compute_private_nodes(deps_graph, build_mode)
+        skip_private_nodes = self._compute_private_nodes(deps_graph, build_mode, source)
         self._build(nodes_by_level, skip_private_nodes, build_mode)
 
     def _process_buildinfo(self, deps_graph):
@@ -56,7 +56,7 @@ class ConanInstaller(object):
         nodes_by_level = deps_graph.propagate_buildinfo()
         return nodes_by_level
 
-    def _compute_private_nodes(self, deps_graph, build_mode):
+    def _compute_private_nodes(self, deps_graph, build_mode, source=None):
         """ computes a list of nodes that are not required to be built, as they are
         private requirements of already available shared libraries as binaries
         """
@@ -65,6 +65,8 @@ class ConanInstaller(object):
         for private_node, private_requirers in private_closure:
             for private_requirer in private_requirers:
                 conan_ref, conan_file = private_requirer
+                if conan_file is source:
+                    break
                 if conan_ref is None:
                     continue
                 package_id = conan_file.info.package_id()

--- a/conans/client/manager.py
+++ b/conans/client/manager.py
@@ -183,7 +183,7 @@ class ConanManager(object):
 
         remote_proxy = ConanRemoteProxy(self._paths, self._user_io, self._remote_manager, remote)
         installer = ConanInstaller(self._paths, self._user_io, remote_proxy)
-        installer.install(deps_graph, build_mode)
+        installer.install(deps_graph, build_mode, conanfile)
 
         if not reference_given:
             if is_txt:


### PR DESCRIPTION
If you mark a requirement in a project as private it doesn't get installed. Added a check for private packages if the requirer isn't the package to be build. Tests seem to pass, should which would be fixed by the pull request?