### PR TITLE
fixes #200, implements reporting of copies

### DIFF
--- a/conans/client/export.py
+++ b/conans/client/export.py
@@ -9,6 +9,7 @@ from conans.paths import CONAN_MANIFEST, CONANFILE
 from conans.errors import ConanException
 from conans.client.file_copier import FileCopier
 from conans.model.manifest import FileTreeManifest
+from conans.client.output import ScopedOutput
 
 
 def export_conanfile(output, paths, file_patterns, origin_folder, conan_ref, keep_source=False):
@@ -16,7 +17,7 @@ def export_conanfile(output, paths, file_patterns, origin_folder, conan_ref, kee
 
     previous_digest = _init_export_folder(destination_folder)
 
-    _export(file_patterns, origin_folder, destination_folder)
+    _export(file_patterns, origin_folder, destination_folder, output)
 
     digest = FileTreeManifest.create(destination_folder)
     save(os.path.join(destination_folder, CONAN_MANIFEST), str(digest))
@@ -47,7 +48,7 @@ def _init_export_folder(destination_folder):
     return previous_digest
 
 
-def _export(file_patterns, origin_folder, destination_folder):
+def _export(file_patterns, origin_folder, destination_folder, output):
     file_patterns = file_patterns or []
     try:
         os.unlink(os.path.join(origin_folder, CONANFILE + 'c'))
@@ -57,5 +58,7 @@ def _export(file_patterns, origin_folder, destination_folder):
     copier = FileCopier(origin_folder, destination_folder)
     for pattern in file_patterns:
         copier(pattern)
+    package_output = ScopedOutput("%s export" % output.scope, output)
+    copier.report(package_output)
 
     shutil.copy2(os.path.join(origin_folder, CONANFILE), destination_folder)

--- a/conans/client/file_copier.py
+++ b/conans/client/file_copier.py
@@ -1,7 +1,21 @@
 import os
 import fnmatch
 import shutil
+from collections import defaultdict
 
+
+def report_copied_files(copied, output, warn=False):
+    ext_files = defaultdict(list)
+    for f in copied:
+        _, ext = os.path.splitext(f)
+        ext_files[ext].append(os.path.basename(f))
+
+    for ext, files in ext_files.items():
+        files_str = (": " + ", ".join(files)) if len(files)<5 else ""
+        output.info("Copied %d '%s' files%s" % (len(files), ext, files_str))
+
+    if warn and not ext_files:
+        output.warn("No files copied!")
 
 class FileCopier(object):
     """ main responsible of copying files from place to place:
@@ -20,6 +34,10 @@ class FileCopier(object):
         """
         self._base_src = root_source_folder
         self._base_dst = root_destination_folder
+        self._copied = []
+ 
+    def report(self, output, warn=False):
+        report_copied_files(self._copied, output, warn)
 
     def __call__(self, pattern, dst="", src="", keep_path=True):
         """ FileCopier is lazy, it just store requested copies, and execute them later
@@ -56,4 +74,5 @@ class FileCopier(object):
                         pass
                     shutil.copy2(abs_src_name, abs_dst_name)
                     copied_files.append(abs_dst_name)
+                    self._copied.append(relative_name)
         return copied_files

--- a/conans/client/manager.py
+++ b/conans/client/manager.py
@@ -28,6 +28,7 @@ from conans.client.package_copier import PackageCopier
 from conans.client.output import ScopedOutput
 from conans.client.proxy import ConanProxy
 from conans.client.remote_registry import RemoteRegistry
+from conans.client.file_copier import report_copied_files
 
 
 def get_user_channel(text):
@@ -201,7 +202,9 @@ class ConanManager(object):
             local_installer = FileImporter(deps_graph, self._paths, current_path)
             conanfile.copy = local_installer
             conanfile.imports()
-            local_installer.execute()
+            copied_files = local_installer.execute()
+            import_output = ScopedOutput("%s imports()" % output.scope, output)
+            report_copied_files(copied_files, import_output)
 
     def package(self, reference, package_id, only_manifest, package_all):
         assert(isinstance(reference, ConanFileReference))

--- a/conans/client/packager.py
+++ b/conans/client/packager.py
@@ -7,6 +7,7 @@ from conans.model.build_info import DEFAULT_RES, DEFAULT_BIN, DEFAULT_LIB, DEFAU
 import shutil
 from conans.client.file_copier import FileCopier
 from conans.model.manifest import FileTreeManifest
+from conans.client.output import ScopedOutput
 
 
 def create_package(conanfile, build_folder, package_folder, output):
@@ -32,6 +33,8 @@ def create_package(conanfile, build_folder, package_folder, output):
     try:
         conanfile.package_folder = package_folder
         conanfile.package()
+        package_output = ScopedOutput("%s package()" % output.scope, output)
+        conanfile.copy.report(package_output, warn=True)
     except Exception as e:
         os.chdir(build_folder)
         try:

--- a/conans/test/integration/complete_test.py
+++ b/conans/test/integration/complete_test.py
@@ -25,6 +25,9 @@ class CompleteFlowTest(unittest.TestCase):
         self.client.save(files)
         self.client.run("export lasote/stable")
         self.client.run("install %s --build missing" % str(conan_reference))
+
+        self.assertIn("Hello0/0.1@lasote/stable package(): Copied 1 '.h' files: helloHello0.h",
+                      self.client.user_io.out)
         # Check compilation ok
         package_ids = self.client.paths.conan_packages(conan_reference)
         self.assertEquals(len(package_ids), 1)

--- a/conans/test/tools.py
+++ b/conans/test/tools.py
@@ -190,6 +190,7 @@ class TestBufferConanOutput(ConanOutput):
 
     def __init__(self):
         self._buffer = StringIO()
+        self.scope = ""
         ConanOutput.__init__(self, self._buffer, color=False)
 
     def __repr__(self):


### PR DESCRIPTION
Does a full copy report in export(), package() and imports(), as pointed out in #200

- Only warns in package()
- Maybe export() and imports() could be avoided, it makes output more verbose, but I think it is also useful to check things are ok.
