### PR TITLE
Allow to export upper directory files

### DIFF
--- a/conans/client/file_copier.py
+++ b/conans/client/file_copier.py
@@ -34,6 +34,12 @@ class FileCopier(object):
                          lib dir
         return: list of copied files
         """
+        # Check for ../ patterns and allow them
+        reldir = os.path.abspath(os.path.join(self._base_src, pattern))
+        if self._base_src.startswith(os.path.dirname(reldir)):  # ../ relative dir
+            self._base_src = os.path.dirname(reldir)
+            pattern = os.path.basename(reldir)
+
         copied_files = []
         src = os.path.join(self._base_src, src)
         dst = os.path.join(self._base_dst, dst)


### PR DESCRIPTION
- It allows to export "../files" relative to current conanfile.py.
- The motivation is maybe having the conan stuff in the same project/repo than original project, but maybe we want to put the conanfile.py and test folder (very common that it collide with the project test folder) in a directory ".conan".

   .conan/conanfile.py
   .conan/test/main.cpp
    CMakeLists.txt
    proyect.cpp
    proyect.h

- This way, the exports could be something like "exports = ["../*"]", and not git clone in source would be required.