### PR TITLE
allowing inline comments in conanfile.txt. Fix #224

### DIFF
--- a/conans/client/loader.py
+++ b/conans/client/loader.py
@@ -131,7 +131,7 @@ class ConanFileTextLoader(object):
     def __init__(self, input_text):
         # Prefer composition over inheritance, the __getattr__ was breaking things
         self._config_parser = ConfigParser(input_text,  ["requires", "generators", "options",
-                                                         "imports"])
+                                                         "imports"], parse_lines=True)
 
     @property
     def requirements(self):

--- a/conans/test/conanfile_loader_test.py
+++ b/conans/test/conanfile_loader_test.py
@@ -17,17 +17,17 @@ class ConanLoaderTest(unittest.TestCase):
     def plain_text_parser_test(self):
         # Valid content
         file_content = '''[requires]
-OpenCV/2.4.10@phil/stable
-OpenCV2/2.4.10@phil/stable
+OpenCV/2.4.10@phil/stable # My requirement for CV
+OpenCV2/2.4.10@phil/stable #
 OpenCV3/2.4.10@phil/stable
 [generators]
-one
+one # My generator for this
 two
 [options]
-OpenCV:use_python=True
+OpenCV:use_python=True # Some option
 OpenCV:other_option=False
 OpenCV2:use_python2=1
-OpenCV2:other_option=Cosa
+OpenCV2:other_option=Cosa #
 '''
         parser = ConanFileTextLoader(file_content)
         exp = ['OpenCV/2.4.10@phil/stable',
@@ -43,7 +43,7 @@ OpenCV2/2.4.10@phil/stable
 one
 two
 [imports]
-OpenCV/bin, * -> ./bin
+OpenCV/bin, * -> ./bin # I need this binaries
 OpenCV/lib, * -> ./lib
 [options]
 OpenCV:use_python=True

--- a/conans/test/integration/flat_requirements_test.py
+++ b/conans/test/integration/flat_requirements_test.py
@@ -5,7 +5,7 @@ from conans.paths import (CONANFILE_TXT, BUILD_INFO_CMAKE, BUILD_INFO_GCC, CONAN
                           BUILD_INFO_VISUAL_STUDIO, BUILD_INFO_XCODE)
 from conans.util.files import save, load
 import os
-from conans.test.tools import TestClient, TestServer
+from conans.test.tools import TestClient
 from conans.test.utils.test_files import temp_folder
 
 
@@ -22,9 +22,9 @@ class FlatRequirementsTest(unittest.TestCase):
         # We want to reuse exported Hello0/0.1@lasote/stable
         tmp_dir = temp_folder()
         req_file = '''[requires]
-Hello0/0.1@lasote/stable
+Hello0/0.1@lasote/stable # My req comment
 [generators]
-gcc
+gcc # I need this generator for..
 cmake
 visual_studio
 xcode

--- a/conans/util/config_parser.py
+++ b/conans/util/config_parser.py
@@ -8,7 +8,7 @@ class ConfigParser(object):
     as parser.section
     Currently used in ConanInfo and ConanFileTextLoader
     """
-    def __init__(self, text, allowed_fields=None):
+    def __init__(self, text, allowed_fields=None, parse_lines=False):
         self._sections = {}
         self._allowed_fields = allowed_fields or []
         pattern = re.compile("^\[([a-z_]{2,50})\]")
@@ -25,6 +25,9 @@ class ConfigParser(object):
                 current_lines = []
                 self._sections[group] = current_lines
             else:
+                if parse_lines:
+                    line = line.split('#')[0]
+                    line = line.strip()
                 current_lines.append(line)
 
     def __getattr__(self, name):


### PR DESCRIPTION
The interface to the ConfigParser could be improved, as it is returning text instead of list of lines, which it had already computed. But, by now, I prefer to keep it simple, as that would break the ConanInfo parser, so lets keep changes to a minimum now.