### PR TITLE
ConanConnectionError for disconnection while downloading. Fix #211

### DIFF
--- a/conans/client/proxy.py
+++ b/conans/client/proxy.py
@@ -269,6 +269,8 @@ class ConanProxy(object):
             self._remote_manager.get_package(package_reference, remote)
             output.success('Package installed %s' % package_id)
             return True
+        except ConanConnectionError:
+            raise  # This shouldn't be skipped
         except ConanException as e:
             output.warn('Binary for %s not in remote: %s' % (package_id, str(e)))
             return False

--- a/conans/client/rest/rest_client.py
+++ b/conans/client/rest/rest_client.py
@@ -357,5 +357,3 @@ class RestApiClient(object):
             raise ConanException("Upload failed!")
         else:
             logger.debug("\nAll uploaded! Total time: %s\n" % str(time.time() - t1))
-
-  

--- a/conans/client/rest/uploader_downloader.py
+++ b/conans/client/rest/uploader_downloader.py
@@ -1,4 +1,4 @@
-from conans.errors import ConanException
+from conans.errors import ConanException, ConanConnectionError
 
 
 class Uploader(object):
@@ -29,24 +29,29 @@ class Downloader(object):
         if not response.ok:
             raise ConanException("Error %d downloading file %s" % (response.status_code, url))
 
-        total_length = response.headers.get('content-length')
+        try:
+            total_length = response.headers.get('content-length')
 
-        if total_length is None:  # no content length header
-            ret.append(response.content)
-        else:
-            dl = 0
-            total_length = int(total_length)
-            last_progress = None
-            for data in response.iter_content(chunk_size=1024):
-                dl += len(data)
-                ret.append(data)
-                units = progress_units(dl, total_length)
-                if last_progress != units:  # Avoid screen refresh if nothing has change
-                    if self.output:
-                        print_progress(self.output, units)
-                    last_progress = units
+            if total_length is None:  # no content length header
+                ret.append(response.content)
+            else:
+                dl = 0
+                total_length = int(total_length)
+                last_progress = None
+                for data in response.iter_content(chunk_size=1024):
+                    dl += len(data)
+                    ret.append(data)
+                    units = progress_units(dl, total_length)
+                    if last_progress != units:  # Avoid screen refresh if nothing has change
+                        if self.output:
+                            print_progress(self.output, units)
+                        last_progress = units
 
-        return "".join(ret)
+            return "".join(ret)
+        except Exception as e:
+            # If this part failed, it means problems with the connection to server
+            raise ConanConnectionError("Download failed, check server, possibly try again\n%s"
+                                       % str(e))
 
 
 class upload_in_chunks(object):


### PR DESCRIPTION
I have had a look to this issue. First, it is not related to a "version check" error, it is a connection error during a normal download. Maybe the last layer of the communication stack which is called VersionChecker was confusing.

I tried it disconnecting the network in the middle of a download. The only issue, is that it takes a lot, until it realizes it is disconnected, I guess this is a good thing. Actually, if the network is up again, it resumes download.