### PR TITLE
Workaround with user path that contains Unicode characters on Windows

### DIFF
--- a/conans/client/command.py
+++ b/conans/client/command.py
@@ -27,6 +27,7 @@ from argparse import RawTextHelpFormatter
 import re
 from conans.client.runner import ConanRunner
 from conans.client.remote_registry import RemoteRegistry
+from conans.tools import expand_user_path
 
 
 class Extender(argparse.Action):
@@ -581,7 +582,8 @@ def get_command():
     out = ConanOutput(sys.stdout, color)
     user_io = UserIO(out=out)
 
-    user_folder = os.getenv("CONAN_USER_HOME", os.path.expanduser("~"))
+    p = expand_user_path("~")
+    user_folder = os.getenv("CONAN_USER_HOME", p)
     try:
         # To capture exceptions in conan.conf parsing
         paths = ConanPaths(user_folder, None, out)

--- a/conans/client/conf/__init__.py
+++ b/conans/client/conf/__init__.py
@@ -5,6 +5,7 @@ from conans.util.env_reader import get_env
 from conans.util.files import save, load
 from six.moves.configparser import ConfigParser, NoSectionError
 from conans.model.values import Values
+from conans.tools import expand_user_path
 import urllib
 
 MIN_SERVER_COMPATIBLE_VERSION = '0.6.0'
@@ -79,7 +80,7 @@ class ConanClientConfigParser(ConfigParser):
                     storage = storage[2:]
                 result = os.path.join(conan_user_home, storage)
             else:
-                result = os.path.expanduser(self.storage["path"])
+                result = expand_user_path(self.storage["path"])
         except KeyError:
             result = None
         result = get_env('CONAN_STORAGE_PATH', result)

--- a/conans/client/rest/cacert.py
+++ b/conans/client/rest/cacert.py
@@ -3,6 +3,7 @@
 import os
 from conans.util.files import save
 import logging
+from conans.tools import expand_user_path
 
 # Capture SSL warnings as pointed out here:
 # https://urllib3.readthedocs.org/en/latest/security.html#insecureplatformwarning
@@ -5719,7 +5720,7 @@ lBlGGSW4gNfL1IYoakRwJiNiqZ+Gb7+6kHDSVneFeO/qJakXzlByjAA6quPbYzSf
 # Workaround to avoid pyinstaller statics hell.
 # request (at the end because openssl) needs a file with
 # certs, it can't be injected. Damned coupled code.
-dir_path = os.path.expanduser("~/.conan")
+dir_path = expand_user_path("~/.conan")
 file_path = os.path.join(dir_path, "cacert.pem")
 if not os.path.exists(file_path):
     save(file_path, cacert)

--- a/conans/server/conf/__init__.py
+++ b/conans/server/conf/__init__.py
@@ -15,6 +15,7 @@ from conans.server.store.disk_adapter import DiskAdapter
 from conans.server.store.file_manager import FileManager
 from conans.util.log import logger
 from conans.server.conf.default_server_conf import default_server_conf
+from conans.tools import expand_user_path
 
 MIN_CLIENT_COMPATIBLE_VERSION = '0.8.0'
 
@@ -112,7 +113,7 @@ class ConanServerConfigParser(ConfigParser):
             ret = self.env_config["disk_storage_path"]
         else:
             try:
-                ret = os.path.expanduser(self._get_file_conf("server", "disk_storage_path"))
+                ret = expand_user_path(self._get_file_conf("server", "disk_storage_path"))
             except ConanException:
                 # If storage_path is not defined in file, use the current dir
                 # So tests use test folder instead of user/.conan_server
@@ -205,7 +206,7 @@ def get_file_manager(config, public_url=None, updown_auth_manager=None):
         adapter = DiskAdapter(disk_controller_url, config.disk_storage_path, updown_auth_manager)
         paths = SimplePaths(config.disk_storage_path)
     else:
-        # Want to develop new adapter? create a subclass of 
+        # Want to develop new adapter? create a subclass of
         # conans.server.store.file_manager.StorageAdapter and implement the abstract methods
         raise Exception("Store adapter not implemented! Change 'store_adapter' "
                         "variable in server.conf file to one of the available options: 'disk' ")

--- a/conans/server/server_launcher.py
+++ b/conans/server/server_launcher.py
@@ -12,6 +12,7 @@ from conans.server.conf import MIN_CLIENT_COMPATIBLE_VERSION
 from conans.model.version import Version
 from conans.server.migrations import ServerMigrator
 from conans.util.log import logger
+from conans.tools import expand_user_path
 
 
 def migrate_and_get_server_config(base_folder, storage_folder=None):
@@ -33,7 +34,7 @@ def migrate_and_get_server_config(base_folder, storage_folder=None):
 
 class ServerLauncher(object):
     def __init__(self):
-        user_folder = os.path.expanduser("~")
+        user_folder = expand_user_path("~")
 
         server_config = migrate_and_get_server_config(user_folder)
 

--- a/conans/server/test/conf_test.py
+++ b/conans/server/test/conf_test.py
@@ -2,6 +2,7 @@ import unittest
 from conans.util.files import save
 import os
 from conans.server.conf import ConanServerConfigParser
+from conans.tools import expand_user_path
 from datetime import timedelta
 from conans.test.utils.test_files import temp_folder
 
@@ -40,7 +41,7 @@ class ServerConfTest(unittest.TestCase):
         config = ConanServerConfigParser(self.file_path, environment=self.environ)
         self.assertEquals(config.jwt_secret, "mysecret")
         self.assertEquals(config.jwt_expire_time, timedelta(minutes=121))
-        self.assertEquals(config.disk_storage_path, os.path.normpath(os.path.expanduser("~/.conans")))
+        self.assertEquals(config.disk_storage_path, os.path.normpath(expand_user_path("~/.conans")))
         self.assertTrue(config.ssl_enabled)
         self.assertEquals(config.port, 9220)
         self.assertEquals(config.write_permissions, [("openssl/2.0.1@lasote/testing", "pepe")])
@@ -60,7 +61,7 @@ class ServerConfTest(unittest.TestCase):
         config = ConanServerConfigParser(self.file_path, environment=self.environ)
         self.assertEquals(config.jwt_secret,  "newkey")
         self.assertEquals(config.jwt_expire_time, timedelta(minutes=123))
-        self.assertEquals(config.disk_storage_path, os.path.expanduser(tmp_storage))
+        self.assertEquals(config.disk_storage_path, expand_user_path(tmp_storage))
         self.assertFalse(config.ssl_enabled)
         self.assertEquals(config.port, 1233)
         self.assertEquals(config.write_permissions, [("openssl/2.0.1@lasote/testing", "pepe")])

--- a/conans/tools.py
+++ b/conans/tools.py
@@ -126,3 +126,11 @@ def patch(base_path=None, patch_file=None, patch_string=None):
         patchset = fromstring(patch_string.encode())
 
     patchset.apply(root=base_path)
+
+def expand_user_path(path):
+    if sys.platform == 'win32':
+        # Workaround for Python 2.7 issue (http://bugs.python.org/issue13207) with user path
+        # that contains Unicode characters
+        return os.path.expanduser(path).decode("cp1251")
+    else:
+        return os.path.expanduser(path)


### PR DESCRIPTION
Workaround for Python 2.7 issue (http://bugs.python.org/issue13207) with user path that contains Unicode characters on Windows