### PR TITLE
Workaround with user path that contains Unicode characters on Windows

### DIFF
--- a/conans/client/command.py
+++ b/conans/client/command.py
@@ -22,7 +22,7 @@ from conans.model.version import Version
 from conans.client.migrations import ClientMigrator
 import hashlib
 import shutil
-from conans.util.files import rmdir, load
+from conans.util.files import rmdir, load, expand_user_path
 from argparse import RawTextHelpFormatter
 import re
 from conans.client.runner import ConanRunner
@@ -581,7 +581,7 @@ def get_command():
     out = ConanOutput(sys.stdout, color)
     user_io = UserIO(out=out)
 
-    user_folder = os.getenv("CONAN_USER_HOME", os.path.expanduser("~"))
+    user_folder = os.getenv("CONAN_USER_HOME", expand_user_path("~"))
     try:
         # To capture exceptions in conan.conf parsing
         paths = ConanPaths(user_folder, None, out)

--- a/conans/client/conf/__init__.py
+++ b/conans/client/conf/__init__.py
@@ -2,7 +2,7 @@ import os
 from conans.errors import ConanException
 import logging
 from conans.util.env_reader import get_env
-from conans.util.files import save, load
+from conans.util.files import save, load, expand_user_path
 from six.moves.configparser import ConfigParser, NoSectionError
 from conans.model.values import Values
 import urllib
@@ -79,7 +79,7 @@ class ConanClientConfigParser(ConfigParser):
                     storage = storage[2:]
                 result = os.path.join(conan_user_home, storage)
             else:
-                result = os.path.expanduser(self.storage["path"])
+                result = expand_user_path(self.storage["path"])
         except KeyError:
             result = None
         result = get_env('CONAN_STORAGE_PATH', result)

--- a/conans/client/loader.py
+++ b/conans/client/loader.py
@@ -5,7 +5,7 @@ import inspect
 import uuid
 import imp
 import os
-from conans.util.files import load
+from conans.util.files import load, encode_fs_path, decode_fs_path
 from conans.util.config_parser import ConfigParser
 from conans.model.options import OptionsValues
 from conans.model.ref import ConanFileReference
@@ -80,14 +80,14 @@ class ConanFileLoader(object):
             current_dir = os.path.dirname(conan_file_path)
             sys.path.append(current_dir)
             old_modules = list(sys.modules.keys())
-            loaded = imp.load_source(filename, conan_file_path)
+            loaded = imp.load_source(filename, encode_fs_path(conan_file_path))
             # Put all imported files under a new package name
             module_id = uuid.uuid1()
             added_modules = set(sys.modules).difference(old_modules)
             for added in added_modules:
                 module = sys.modules[added]
                 if module:
-                    folder = os.path.dirname(module.__file__)
+                    folder = os.path.dirname(decode_fs_path(module.__file__))
                     if folder.startswith(current_dir):
                         module = sys.modules.pop(added)
                         sys.modules["%s.%s" % (module_id, added)] = module

--- a/conans/client/rest/cacert.py
+++ b/conans/client/rest/cacert.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 
 import os
-from conans.util.files import save
+from conans.util.files import save, expand_user_path
 import logging
 
 # Capture SSL warnings as pointed out here:
@@ -5719,7 +5719,7 @@ lBlGGSW4gNfL1IYoakRwJiNiqZ+Gb7+6kHDSVneFeO/qJakXzlByjAA6quPbYzSf
 # Workaround to avoid pyinstaller statics hell.
 # request (at the end because openssl) needs a file with
 # certs, it can't be injected. Damned coupled code.
-dir_path = os.path.expanduser("~/.conan")
+dir_path = expand_user_path("~/.conan")
 file_path = os.path.join(dir_path, "cacert.pem")
 if not os.path.exists(file_path):
     save(file_path, cacert)

--- a/conans/server/conf/__init__.py
+++ b/conans/server/conf/__init__.py
@@ -8,7 +8,7 @@ import os
 import random
 import string
 from conans.errors import ConanException
-from conans.util.files import save, mkdir
+from conans.util.files import save, mkdir, expand_user_path
 from six.moves.configparser import ConfigParser, NoSectionError
 from conans.paths import SimplePaths
 from conans.server.store.disk_adapter import DiskAdapter
@@ -112,7 +112,7 @@ class ConanServerConfigParser(ConfigParser):
             ret = self.env_config["disk_storage_path"]
         else:
             try:
-                ret = os.path.expanduser(self._get_file_conf("server", "disk_storage_path"))
+                ret = expand_user_path(self._get_file_conf("server", "disk_storage_path"))
             except ConanException:
                 # If storage_path is not defined in file, use the current dir
                 # So tests use test folder instead of user/.conan_server
@@ -205,7 +205,7 @@ def get_file_manager(config, public_url=None, updown_auth_manager=None):
         adapter = DiskAdapter(disk_controller_url, config.disk_storage_path, updown_auth_manager)
         paths = SimplePaths(config.disk_storage_path)
     else:
-        # Want to develop new adapter? create a subclass of 
+        # Want to develop new adapter? create a subclass of
         # conans.server.store.file_manager.StorageAdapter and implement the abstract methods
         raise Exception("Store adapter not implemented! Change 'store_adapter' "
                         "variable in server.conf file to one of the available options: 'disk' ")

--- a/conans/server/server_launcher.py
+++ b/conans/server/server_launcher.py
@@ -12,6 +12,7 @@ from conans.server.conf import MIN_CLIENT_COMPATIBLE_VERSION
 from conans.model.version import Version
 from conans.server.migrations import ServerMigrator
 from conans.util.log import logger
+from conans.util.files import expand_user_path
 
 
 def migrate_and_get_server_config(base_folder, storage_folder=None):
@@ -33,7 +34,7 @@ def migrate_and_get_server_config(base_folder, storage_folder=None):
 
 class ServerLauncher(object):
     def __init__(self):
-        user_folder = os.path.expanduser("~")
+        user_folder = expand_user_path("~")
 
         server_config = migrate_and_get_server_config(user_folder)
 

--- a/conans/server/test/conf_test.py
+++ b/conans/server/test/conf_test.py
@@ -1,5 +1,5 @@
 import unittest
-from conans.util.files import save
+from conans.util.files import save, expand_user_path
 import os
 from conans.server.conf import ConanServerConfigParser
 from datetime import timedelta
@@ -40,7 +40,7 @@ class ServerConfTest(unittest.TestCase):
         config = ConanServerConfigParser(self.file_path, environment=self.environ)
         self.assertEquals(config.jwt_secret, "mysecret")
         self.assertEquals(config.jwt_expire_time, timedelta(minutes=121))
-        self.assertEquals(config.disk_storage_path, os.path.normpath(os.path.expanduser("~/.conans")))
+        self.assertEquals(config.disk_storage_path, os.path.normpath(expand_user_path("~/.conans")))
         self.assertTrue(config.ssl_enabled)
         self.assertEquals(config.port, 9220)
         self.assertEquals(config.write_permissions, [("openssl/2.0.1@lasote/testing", "pepe")])
@@ -60,7 +60,7 @@ class ServerConfTest(unittest.TestCase):
         config = ConanServerConfigParser(self.file_path, environment=self.environ)
         self.assertEquals(config.jwt_secret,  "newkey")
         self.assertEquals(config.jwt_expire_time, timedelta(minutes=123))
-        self.assertEquals(config.disk_storage_path, os.path.expanduser(tmp_storage))
+        self.assertEquals(config.disk_storage_path, expand_user_path(tmp_storage))
         self.assertFalse(config.ssl_enabled)
         self.assertEquals(config.port, 1233)
         self.assertEquals(config.write_permissions, [("openssl/2.0.1@lasote/testing", "pepe")])

--- a/conans/util/files.py
+++ b/conans/util/files.py
@@ -239,3 +239,26 @@ def tar_extract(fileobj, destination_dir):
     the_tar = tarfile.open(fileobj=fileobj)
     the_tar.extractall(path=destination_dir, members=safemembers(the_tar))
     the_tar.close()
+
+def expand_user_path(path):
+    data = os.path.expanduser(path)
+    if sys.version_info < (3, 0) and sys.platform == 'win32' and not isinstance(data, str):
+        # Workaround for Python 2.7 issue (http://bugs.python.org/issue13207) with user path
+        # that contains Unicode characters
+        return data.decode(sys.getfilesystemencoding())
+    else:
+        return data
+
+def encode_fs_path(path):
+    if sys.version_info < (3, 0) and sys.platform == 'win32' and isinstance(path, str):
+        # Workaround for Python 2.7 issue
+        return path.encode(sys.getfilesystemencoding())
+    else:
+        return path
+
+def decode_fs_path(path):
+    if sys.version_info < (3, 0) and sys.platform == 'win32' and not isinstance(path, str):
+        # Workaround for Python 2.7 issue
+        return path.decode(sys.getfilesystemencoding())
+    else:
+        return path


### PR DESCRIPTION
Workaround for Python 2.7 issue (http://bugs.python.org/issue13207) with user path that contains Unicode characters on Windows

Currently conan return this error:
```
>conan
ERROR: ('Could not connect to local cache', OperationalError('unable to open database file',))
```