### PR TITLE
Feature/performance

### DIFF
--- a/conans/client/cmake.py
+++ b/conans/client/cmake.py
@@ -41,7 +41,7 @@ class CMake(object):
             base = "Visual Studio %s" % _visuals.get(str_ver, "UnknownVersion %s" % str_ver)
             if arch == "x86_64":
                 return base + " Win64"
-            elif arch == "arm":
+            elif "arm" in str(arch):
                 return base + " ARM"
             else:
                 return base

--- a/conans/client/command.py
+++ b/conans/client/command.py
@@ -234,6 +234,8 @@ path to the CMake binary directory, like this:
                             help='Force install specified package ID (ignore settings/options)')
         parser.add_argument("--all", action='store_true', default=False,
                             help='Install all packages from the specified package recipe')
+        parser.add_argument("--integrity", "-i", action='store_true', default=False,
+                            help='Check that the stored recipe or package manifests are correct')
         parser.add_argument("--file", "-f", help="specify conanfile filename")
         parser.add_argument("--update", "-u", action='store_true', default=False,
                             help="update with new upstream packages")
@@ -267,7 +269,8 @@ path to the CMake binary directory, like this:
                                   settings=settings,
                                   build_mode=args.build,
                                   filename=args.file,
-                                  update=args.update)
+                                  update=args.update,
+                                  integrity=args.integrity)
 
     def info(self, *args):
         """ Prints information about the requirements.
@@ -287,6 +290,10 @@ path to the CMake binary directory, like this:
         parser.add_argument("--settings", "-s",
                             help='load settings to build the package, -s compiler:gcc',
                             nargs=1, action=Extender)
+        parser.add_argument("--integrity", "-i", action='store_true', default=False,
+                            help='Check that the stored recipe or package manifests are correct')
+        parser.add_argument("--update", "-u", action='store_true', default=False,
+                            help="check updates exist from upstream remotes")
 
         args = parser.parse_args(*args)
 
@@ -305,6 +312,8 @@ path to the CMake binary directory, like this:
                               settings=settings,
                               build_mode=False,
                               info=True,
+                              check_updates=args.update,
+                              integrity=args.integrity,
                               filename=args.file)
 
     def build(self, *args):

--- a/conans/client/deps_builder.py
+++ b/conans/client/deps_builder.py
@@ -4,7 +4,6 @@ point, which could be both a user conanfile or an installed one
 from conans.model.requires import Requirements
 from collections import namedtuple
 from conans.model.ref import PackageReference
-from conans.model.build_info import DepsCppInfo
 from conans.model.info import ConanInfo
 from conans.errors import ConanException
 from conans.client.output import ScopedOutput
@@ -27,7 +26,6 @@ class Node(namedtuple("Node", "conan_ref conanfile")):
     def __repr__(self):
         return "%s => %s" % (repr(self.conan_ref), repr(self.conanfile)[:100].replace("\n", " "))
 
-
     def __cmp__(self, other):
         if other is None:
             return -1
@@ -35,14 +33,14 @@ class Node(namedtuple("Node", "conan_ref conanfile")):
             return 0 if other.conan_ref is None else -1
         elif other.conan_ref is None:
             return 1
-        
+
         if self.conan_ref == other.conan_ref:
             return 0
         if self.conan_ref < other.conan_ref:
             return -1
-        
+
         return 1
-    
+
     def __gt__(self, other):
         return self.__cmp__(other) == 1
 
@@ -54,6 +52,7 @@ class Node(namedtuple("Node", "conan_ref conanfile")):
 
     def __ge__(self, other):
         return self.__cmp__(other) in [0, 1]
+
 
 class DepsGraph(object):
     """ DAG of dependencies
@@ -294,9 +293,7 @@ class DepsBuilder(object):
         dep_graph.add_node(root_node)
         public_deps = {}  # {name: Node} dict with public nodes, so they are not added again
         # enter recursive computation
-        print "Enter load deps"
         self._load_deps(root_node, Requirements(), dep_graph, public_deps, conan_ref, None)
-        print "Exist load deps"
         dep_graph.propagate_info()
         return dep_graph
 

--- a/conans/client/deps_builder.py
+++ b/conans/client/deps_builder.py
@@ -294,7 +294,9 @@ class DepsBuilder(object):
         dep_graph.add_node(root_node)
         public_deps = {}  # {name: Node} dict with public nodes, so they are not added again
         # enter recursive computation
+        print "Enter load deps"
         self._load_deps(root_node, Requirements(), dep_graph, public_deps, conan_ref, None)
+        print "Exist load deps"
         dep_graph.propagate_info()
         return dep_graph
 

--- a/conans/client/manager.py
+++ b/conans/client/manager.py
@@ -29,6 +29,7 @@ from conans.client.output import ScopedOutput
 from conans.client.proxy import ConanProxy
 from conans.client.remote_registry import RemoteRegistry
 from conans.client.file_copier import report_copied_files
+import time
 
 
 def get_user_channel(text):
@@ -149,7 +150,7 @@ class ConanManager(object):
         # Not check for updates for info command, it'll be checked when dep graph is built
         check_updates = not info
         remote_proxy = ConanProxy(self._paths, self._user_io, self._remote_manager,
-                                  remote, update, check_updates)
+                                  remote, update, False)
 
         if reference_given:
             project_reference = None
@@ -176,7 +177,9 @@ class ConanManager(object):
 
         # build deps graph and install it
         builder = DepsBuilder(remote_proxy, self._user_io.out, loader)
+        t1 = time.time()
         deps_graph = builder.load(reference, conanfile)
+        logger.debug("Time to build graph = %s" % (time.time() - t1))
         registry = RemoteRegistry(self._paths.registry, self._user_io.out)
         if info:
             graph_updates_info = builder.get_graph_updates_info(deps_graph)

--- a/conans/client/manager.py
+++ b/conans/client/manager.py
@@ -132,7 +132,8 @@ class ConanManager(object):
             remote_proxy.download_packages(reference, list(info[reference].keys()))
 
     def install(self, reference, current_path, remote=None, options=None, settings=None,
-                build_mode=False, info=None, filename=None, update=False):
+                build_mode=False, info=None, filename=None, update=False, check_updates=False,
+                integrity=False):
         """ Fetch and build all dependencies for the given reference
         @param reference: ConanFileReference or path to user space conanfile
         @param current_path: where the output files will be saved
@@ -148,9 +149,9 @@ class ConanManager(object):
 
         loader = self._loader(current_path, settings, options)
         # Not check for updates for info command, it'll be checked when dep graph is built
-        check_updates = not info
         remote_proxy = ConanProxy(self._paths, self._user_io, self._remote_manager,
-                                  remote, update, False)
+                                  remote, update=update, check_updates=check_updates,
+                                  check_integrity=integrity)
 
         if reference_given:
             project_reference = None

--- a/conans/client/proxy.py
+++ b/conans/client/proxy.py
@@ -41,7 +41,7 @@ class ConanProxy(object):
                 output.warn("Bad package '%s' detected! Removing "
                             "package directory... " % str(package_reference.package_id))
                 rmdir(package_folder)
-            else:
+            elif self._check_updates:
                 try:  # get_conan_digest can fail, not in server
                     upstream_manifest = self.get_package_digest(package_reference)
                     if upstream_manifest.file_sums != read_manifest.file_sums:

--- a/conans/client/proxy.py
+++ b/conans/client/proxy.py
@@ -14,14 +14,15 @@ class ConanProxy(object):
     It uses the RemoteRegistry to control where the packages come from.
     """
     def __init__(self, paths, user_io, remote_manager, remote_name,
-                 update=False, check_updates=True):
+                 update=False, check_updates=False, check_integrity=False):
         self._paths = paths
         self._out = user_io.out
         self._remote_manager = remote_manager
         self._registry = RemoteRegistry(self._paths.registry, self._out)
         self._remote_name = remote_name
         self._update = update
-        self._check_updates = check_updates
+        self._check_updates = check_updates or update  # Update forces check
+        self._check_integrity = check_integrity
 
     @property
     def registry(self):
@@ -33,15 +34,18 @@ class ConanProxy(object):
         """
         output = ScopedOutput(str(package_reference.conan), self._out)
         package_folder = self._paths.package(package_reference)
-        # Check if package is corrupted
-        read_manifest, expected_manifest = self._paths.package_manifests(package_reference)
-        if read_manifest is not None:  # Package exists
-            if read_manifest.file_sums != expected_manifest.file_sums:
-                # If not valid package, ensure empty folder
-                output.warn("Bad package '%s' detected! Removing "
-                            "package directory... " % str(package_reference.package_id))
-                rmdir(package_folder)
-            elif self._check_updates:
+
+        # Check current package status
+        if path_exists(package_folder, self._paths.store):
+            if self._check_integrity:  # Check if package is corrupted
+                read_manifest, expected_manifest = self._paths.package_manifests(package_reference)
+                if read_manifest.file_sums != expected_manifest.file_sums:
+                    # If not valid package, ensure empty folder
+                    output.warn("Bad package '%s' detected! Removing "
+                                "package directory... " % str(package_reference.package_id))
+                    rmdir(package_folder)
+
+            if self._check_updates:
                 try:  # get_conan_digest can fail, not in server
                     upstream_manifest = self.get_package_digest(package_reference)
                     if upstream_manifest.file_sums != read_manifest.file_sums:
@@ -83,11 +87,11 @@ class ConanProxy(object):
         # check if it is in disk
         conanfile_path = self._paths.conanfile(conan_reference)
         if path_exists(conanfile_path, self._paths.store):
-            # Check manifest integrity
-            read_manifest, expected_manifest = self._paths.conan_manifests(conan_reference)
-            if read_manifest.file_sums != expected_manifest.file_sums:
-                output.warn("Bad conanfile detected! Removing export directory... ")
-                _refresh()
+            if self._check_integrity:  # Check if package is corrupted
+                read_manifest, expected_manifest = self._paths.conan_manifests(conan_reference)
+                if read_manifest.file_sums != expected_manifest.file_sums:
+                    output.warn("Bad conanfile detected! Removing export directory... ")
+                    _refresh()
             else:  # Check for updates
                 if self._check_updates:
                     ret = self.update_available(conan_reference)
@@ -123,7 +127,7 @@ class ConanProxy(object):
         return conanfile_path
 
     def update_available(self, conan_reference):
-        """Returns 0 if the conanfiles are equal, 1 if there is an update and -1 if 
+        """Returns 0 if the conanfiles are equal, 1 if there is an update and -1 if
         the local is newer than the remote"""
         if not conan_reference:
             return 0

--- a/conans/test/integration/manifest_validation_test.py
+++ b/conans/test/integration/manifest_validation_test.py
@@ -14,7 +14,7 @@ class ManifestValidationTest(unittest.TestCase):
                                  [],  # write permissions
                                  users={"lasote": "mypass"})  # exported users and passwords
         self.servers = {"default": test_server}
-        self.conan = TestClient(servers=self.servers, users={"default":[("lasote", "mypass")]})
+        self.conan = TestClient(servers=self.servers, users={"default": [("lasote", "mypass")]})
 
         # Export and upload the conanfile
         self.conan_reference = ConanFileReference.loads("hello0/0.1@lasote/stable")
@@ -37,7 +37,7 @@ class ManifestValidationTest(unittest.TestCase):
         file_path = os.path.join(export_path, list(self.files.keys())[0])
         save(file_path, "BAD CONTENT")
 
-        self.conan.run("install %s --build missing" % str(self.conan_reference))
+        self.conan.run("install %s --build missing --integrity" % str(self.conan_reference))
         self.assertIn("Bad conanfile detected!", str(self.conan.user_io.out))
         self.assertIn("%s: Retrieving from remote 'default'"
                       % str(self.conan_reference),
@@ -62,6 +62,6 @@ class ManifestValidationTest(unittest.TestCase):
         file_path = os.path.join(package_path, "hello0/hello.go")
         save(file_path, "BAD CONTENT")
 
-        self.conan.run("install %s --build missing" % str(self.conan_reference))
+        self.conan.run("install %s --build missing -i" % str(self.conan_reference))
         self.assertIn("%s: WARN: Bad package" % str(self.conan_reference),
                       self.conan.user_io.out)

--- a/conans/test/integration/multi_remotes_test.py
+++ b/conans/test/integration/multi_remotes_test.py
@@ -53,18 +53,15 @@ class MultiRemotesTest(unittest.TestCase):
         client_a.run("upload Hello0/0.0@lasote/stable -r local")
 
         # Execute info method in client_b, should advise that there is an update
-        client_b.run("info Hello0/0.0@lasote/stable")
+        client_b.run("info Hello0/0.0@lasote/stable -u")
         self.assertIn("Updates: There is a newer version (local)", str(client_b.user_io.out))
-        client_b.run("install Hello0/0.0@lasote/stable")
-        self.assertIn("There is a new conanfile in 'local' remote", str(client_b.user_io.out))
-        client_b.run("install Hello0/0.0@lasote/stable")
-        self.assertIn("There is a new conanfile in 'local' remote", str(client_b.user_io.out))
 
         # Now try to update the package with install -u
         client_b.run("remote list_ref")
         self.assertIn("Hello0/0.0@lasote/stable: local", str(client_b.user_io.out))
         client_b.run("install Hello0/0.0@lasote/stable -u --build")
-        self.assertIn("Hello0/0.0@lasote/stable: Retrieving from remote 'local'", str(client_b.user_io.out))
+        self.assertIn("Hello0/0.0@lasote/stable: Retrieving from remote 'local'",
+                      str(client_b.user_io.out))
         client_b.run("remote list_ref")
         self.assertIn("Hello0/0.0@lasote/stable: local", str(client_b.user_io.out))
 

--- a/conans/test/integration/package_command_test.py
+++ b/conans/test/integration/package_command_test.py
@@ -89,7 +89,7 @@ class MyConan(ConanFile):
 
         # And try to do the same without regenerate manifest
         save(os.path.join(package_path, "newfile2.txt"), "new content")
-        self.client.run("install %s" % str(conan_reference), ignore_error=True)
+        self.client.run("install %s -i" % str(conan_reference), ignore_error=True)
         self.assertIn("Bad package", self.client.user_io.out)
 
         # Try to do it specifying the package (without --all)

--- a/conans/test/performance/multi_row.py
+++ b/conans/test/performance/multi_row.py
@@ -15,7 +15,7 @@ def run(command):
 class PerformanceTest(unittest.TestCase):
 
     def deep_deps_test(self):
-        num = 5
+        num = 50
         for i in range(num):
             if i == 0:
                 files = cpp_hello_conan_files("Hello0", "0.1")

--- a/conans/test/performance/multi_row.py
+++ b/conans/test/performance/multi_row.py
@@ -1,0 +1,51 @@
+import unittest
+from conans.test.utils.cpp_test_files import cpp_hello_conan_files
+from conans.util.files import save_files
+from conans.test.utils.test_files import temp_folder
+import os
+import time
+
+
+def run(command):
+    retcode = os.system(command)
+    if retcode != 0:
+        raise Exception("Error while executing:\n\t %s" % command)
+
+
+class PerformanceTest(unittest.TestCase):
+
+    def deep_deps_test(self):
+        num = 5
+        for i in range(num):
+            if i == 0:
+                files = cpp_hello_conan_files("Hello0", "0.1")
+            else:
+                files = cpp_hello_conan_files("Hello%d" % i, "0.1",
+                                              ["Hello%s/0.1@lasote/stable" % (i-1)])
+            files["conanfile.py"] = files["conanfile.py"].replace("build(", "build2(")
+            t_folder = temp_folder()
+            save_files(t_folder, files)
+            try:
+                old_folder = os.getcwd()
+                os.chdir(t_folder)
+                run("conan export lasote/stable > null")
+            finally:
+                os.chdir(old_folder)
+
+        # Now lets depend on it
+        files = cpp_hello_conan_files("HelloFinal", "0.1", ["Hello%s/0.1@lasote/stable" % (num-1)])
+        files["conanfile.py"] = files["conanfile.py"].replace("build(", "build2(")
+        t_folder = temp_folder()
+        save_files(t_folder, files)
+        try:
+            old_folder = os.getcwd()
+            os.chdir(t_folder)
+            t1 = time.time()
+            run("conan install --build")
+            print("Final time with build %s" % (time.time() - t1))
+            t1 = time.time()
+            run("conan install")
+            print("Final time %s" % (time.time() - t1))
+        finally:
+            print("Final time %s" % (time.time() - t1))
+            os.chdir(old_folder)


### PR DESCRIPTION
Improves the first performance problem in isssue #245 

- Check for updates is opt-in
- Check for manifest integrity is opt-in

With this, I get a 10x faster for the initial graph load time, for a 50 packages project from 10seconds to less than 1 second.

Note that the performance test is NOT a test, as it doesn't run autmoatically cause it doesnt have "test" in the filename. I can put it elsewhere if necessary