### PR TITLE
Bugfix: Bad performance when downloading large files.:w

### DIFF
--- a/conans/client/rest/uploader_downloader.py
+++ b/conans/client/rest/uploader_downloader.py
@@ -24,7 +24,7 @@ class Downloader(object):
         self.verify = verify
 
     def download(self, url):
-        ret = b""
+        ret = bytearray()
         response = self.requester.get(url, stream=True, verify=self.verify)
         if not response.ok:
             raise ConanException("Error %d downloading file %s" % (response.status_code, url))
@@ -40,14 +40,14 @@ class Downloader(object):
                 last_progress = None
                 for data in response.iter_content(chunk_size=1024):
                     dl += len(data)
-                    ret += data
+                    ret.extend(data)
                     units = progress_units(dl, total_length)
                     if last_progress != units:  # Avoid screen refresh if nothing has change
                         if self.output:
                             print_progress(self.output, units)
                         last_progress = units
 
-            return ret
+            return bytes(ret)
         except Exception as e:
             # If this part failed, it means problems with the connection to server
             raise ConanConnectionError("Download failed, check server, possibly try again\n%s"


### PR DESCRIPTION
Found a performance issue when downloading large conan packages. Boost took 30+ secs on my machine and only 1-2 secs in the browser. After the simple changes in this changeset the performance is now acceptable (comparable to the browser). 

Please consider downloading all conan packages by streaming downloads to temporary files, and not to memory, then to disk - as we are seeing some packages with a size of 500+ MB.