### PR TITLE
opt-in for check updates in conan info

### DIFF
--- a/conans/client/manager.py
+++ b/conans/client/manager.py
@@ -180,7 +180,10 @@ class ConanManager(object):
         deps_graph = builder.load(reference, conanfile)
         registry = RemoteRegistry(self._paths.registry, self._user_io.out)
         if info:
-            graph_updates_info = builder.get_graph_updates_info(deps_graph)
+            if check_updates:
+                graph_updates_info = builder.get_graph_updates_info(deps_graph)
+            else:
+                graph_updates_info = {}
             Printer(self._user_io.out).print_info(deps_graph, project_reference,
                                                   info, registry, graph_updates_info,
                                                   remote)

--- a/conans/client/printer.py
+++ b/conans/client/printer.py
@@ -81,8 +81,9 @@ class Printer(object):
                 self._out.writeln("    Author: %s" % author, Color.BRIGHT_GREEN)
 
             if isinstance(ref, ConanFileReference):  # Excludes PROJECT fake reference
-                update = graph_updates_info.get(ref, 0)
+                update = graph_updates_info.get(ref)
                 update_messages = {
+                 None: ("Version not checked", Color.WHITE),
                  0: ("You have the latest version (%s)" % remote_name, Color.BRIGHT_GREEN),
                  1: ("There is a newer version (%s)" % remote_name, Color.BRIGHT_YELLOW),
                  -1: ("The local file is newer than remote's one (%s)" % remote_name, Color.BRIGHT_RED)

--- a/conans/paths.py
+++ b/conans/paths.py
@@ -143,11 +143,11 @@ class StorePaths(SimplePaths):
     def conan_manifests(self, conan_reference):
         digest_path = self.digestfile_conanfile(conan_reference)
         return self._digests(digest_path)
-    
+
     def package_manifests(self, package_reference):
         digest_path = self.digestfile_package(package_reference)
         return self._digests(digest_path)
-        
+
     def _digests(self, digest_path):
         if not path_exists(digest_path, self.store):
             return None, None

--- a/conans/test/command/info_test.py
+++ b/conans/test/command/info_test.py
@@ -38,7 +38,7 @@ class InfoTest(unittest.TestCase):
         self._create("Hello1", "0.1", ["Hello0/0.1@lasote/stable"])
         self._create("Hello2", "0.1", ["Hello1/0.1@lasote/stable"], export=False)
 
-        self.client.run("info")
+        self.client.run("info -u")
         expected_output = textwrap.dedent(
             """\
             Hello2/0.1@PROJECT

--- a/conans/test/integration/multi_remotes_test.py
+++ b/conans/test/integration/multi_remotes_test.py
@@ -72,12 +72,12 @@ class MultiRemotesTest(unittest.TestCase):
         client_a.run("upload Hello0/0.0@lasote/stable -r default")
 
         # Now client_b checks for updates without -r parameter
-        client_b.run("info Hello0/0.0@lasote/stable")
+        client_b.run("info Hello0/0.0@lasote/stable -u")
         self.assertIn("Remote: local", str(client_b.user_io.out))
         self.assertIn("You have the latest version (local)", str(client_b.user_io.out))
 
         # But if we connect to default, should tell us that there is an update IN DEFAULT!
-        client_b.run("info Hello0/0.0@lasote/stable -r default")
+        client_b.run("info Hello0/0.0@lasote/stable -r default -u")
         self.assertIn("Remote: local", str(client_b.user_io.out))
         self.assertIn("There is a newer version (default)", str(client_b.user_io.out))
         client_b.run("remote list_ref")
@@ -86,5 +86,5 @@ class MultiRemotesTest(unittest.TestCase):
         # Well, now try to update the package with -r default -u
         client_b.run("install Hello0/0.0@lasote/stable -r default -u --build")
         self.assertIn("Hello0/0.0@lasote/stable: Retrieving from remote 'default'", str(client_b.user_io.out))
-        client_b.run("info Hello0/0.0@lasote/stable")
+        client_b.run("info Hello0/0.0@lasote/stable -u")
         self.assertIn("Updates: The local file is newer than remote's one (local)", str(client_b.user_io.out))


### PR DESCRIPTION
Also related to #245, but not directly. ``conan info`` was still checking for updates as default, so really slow. Made it opt-in.