### PR TITLE
client: Don't add dependencies we've already seen

### DIFF
--- a/conans/client/deps_builder.py
+++ b/conans/client/deps_builder.py
@@ -285,14 +285,14 @@ class DepsBuilder(object):
         public_deps = {}  # {name: Node} dict with public nodes, so they are not added again
         # enter recursive computation
         t1 = time.time()
-        self._load_deps(root_node, Requirements(), dep_graph, public_deps, conan_ref, None)
+        self._load_deps(root_node, Requirements(), dep_graph, public_deps, conan_ref, None, set([conanfile.name]))
         logger.debug("Deps-builder: Time to load deps %s" % (time.time() - t1))
         t1 = time.time()
         dep_graph.propagate_info()
         logger.debug("Deps-builder: Propagate info %s" % (time.time() - t1))
         return dep_graph
 
-    def _load_deps(self, node, down_reqs, dep_graph, public_deps, down_ref, down_options):
+    def _load_deps(self, node, down_reqs, dep_graph, public_deps, down_ref, down_options, seen):
         """ loads a Conan object from the given file
         param node: Node object to be expanded in this step
         down_reqs: the Requirements as coming from downstream, which can overwrite current
@@ -315,10 +315,10 @@ class DepsBuilder(object):
             previous_node = public_deps.get(name)
             if require.private or not previous_node:  # new node, must be added and expanded
                 new_node = self._create_new_node(node, dep_graph, require, public_deps, name)
-                if new_node:
+                if new_node and not name in seen:
                     # RECURSION!
                     self._load_deps(new_node, new_reqs, dep_graph, public_deps, conanref,
-                                    new_options.copy())
+                                    new_options.copy(), seen | set([name]))
             else:  # a public node already exist with this name
                 if previous_node.conan_ref != require.conan_reference:
                     self._output.error("Conflict in %s\n"
@@ -327,10 +327,11 @@ class DepsBuilder(object):
                                        "    To change it, override it in your base requirements"
                                        % (conanref, require.conan_reference,
                                           previous_node.conan_ref, previous_node.conan_ref))
-                dep_graph.add_edge(node, previous_node)
-                # RECURSION!
-                self._load_deps(previous_node, new_reqs, dep_graph, public_deps, conanref,
-                                new_options.copy())
+                if not name in seen:
+                    dep_graph.add_edge(node, previous_node)
+                    # RECURSION!
+                    self._load_deps(previous_node, new_reqs, dep_graph, public_deps, conanref,
+                                    new_options.copy(), seen | set([name]))
 
     def _config_node(self, conanfile, conanref, down_reqs, down_ref, down_options):
         """ update settings and option in the current ConanFile, computing actual

--- a/conans/test/tools.py
+++ b/conans/test/tools.py
@@ -291,7 +291,8 @@ class TestClient(object):
         self.storage_folder = os.path.join(self.base_folder, ".conan", "data")
         self.paths = ConanPaths(self.base_folder, self.storage_folder, TestBufferConanOutput())
         self.default_settings(get_env("CONAN_COMPILER", "gcc"),
-                              get_env("CONAN_COMPILER_VERSION", "4.8"))
+                              get_env("CONAN_COMPILER_VERSION", "4.8"),
+                              get_env("CONAN_LIBCXX", "libstdc++"))
 
         self.init_dynamic_vars()
 
@@ -303,7 +304,7 @@ class TestClient(object):
         logger.debug("Client storage = %s" % self.storage_folder)
         self.current_folder = current_folder or temp_folder()
 
-    def default_settings(self, compiler, compiler_version):
+    def default_settings(self, compiler, compiler_version, libcxx):
         """ allows to change the default settings in the file, to change compiler, version
         """
         # Set default settings in global defined
@@ -318,7 +319,7 @@ class TestClient(object):
             text += "\ncompiler=%s" % compiler
             text += "\ncompiler.version=%s" % compiler_version
             if compiler != "Visual Studio":
-                text += "\ncompiler.libcxx=libstdc++"
+                text += "\ncompiler.libcxx=%s" % libcxx
     
             save(self.paths.conan_conf_path, text)
 


### PR DESCRIPTION
This fixes an issue where infinite recursion could happen when
a module transitively dependended on itself. The `public_deps`
dict is apparently supposed to avoid that, but it seems like it
only works for modules that have an existing `conan_ref`, which might
not be true of a module at the root of the tree.

This adds a new set argument to `_load_deps` which ensures that
dependencies with the same name are not loaded again.