### PR TITLE
Set package_folder attribute of ConanFile instance before build

### DIFF
--- a/conans/client/installer.py
+++ b/conans/client/installer.py
@@ -154,7 +154,7 @@ class ConanInstaller(object):
             if force_build:
                 output.warn('Forced build from source')
 
-            self._build_package(export_folder, src_folder, build_folder, conan_file, output)
+            self._build_package(export_folder, src_folder, build_folder, package_folder, conan_file, output)
 
             # Creating ***info.txt files
             save(os.path.join(build_folder, CONANINFO), conan_file.info.dumps())
@@ -231,7 +231,7 @@ Package configuration:
                     output.warn("**** Please delete it manually ****")
                 raise ConanException("%s: %s" % (conan_file.name, str(e)))
 
-    def _build_package(self, export_folder, src_folder, build_folder, conan_file, output):
+    def _build_package(self, export_folder, src_folder, build_folder, package_folder, conan_file, output):
         """ builds the package, creating the corresponding build folder if necessary
         and copying there the contents from the src folder. The code is duplicated
         in every build, as some configure processes actually change the source
@@ -259,6 +259,7 @@ Package configuration:
             # This is necessary because it is different for user projects
             # than for packages
             conan_file._conanfile_directory = build_folder
+            conan_file.package_folder = package_folder
             conan_file.build()
             self._out.writeln("")
             output.success("Package '%s' built" % os.path.basename(build_folder))

--- a/conans/client/packager.py
+++ b/conans/client/packager.py
@@ -31,6 +31,7 @@ def create_package(conanfile, build_folder, package_folder, output):
     conanfile.copy_bins = wrap(DEFAULT_BIN)
     conanfile.copy_res = wrap(DEFAULT_RES)
     try:
+        conanfile.package_folder = package_folder
         conanfile.package()
         package_output = ScopedOutput("%s package()" % output.scope, output)
         conanfile.copy.report(package_output, warn=True)

--- a/conans/client/packager.py
+++ b/conans/client/packager.py
@@ -31,7 +31,6 @@ def create_package(conanfile, build_folder, package_folder, output):
     conanfile.copy_bins = wrap(DEFAULT_BIN)
     conanfile.copy_res = wrap(DEFAULT_RES)
     try:
-        conanfile.package_folder = package_folder
         conanfile.package()
         package_output = ScopedOutput("%s package()" % output.scope, output)
         conanfile.copy.report(package_output, warn=True)


### PR DESCRIPTION
Some of the C++ projects which use CMake as a build system have an install target. Their listsfiles already contain the definition of what and how should be installed. Defining the installation steps of the project in the `package` method of the `ConanFile` duplicates this information. Ideally I would like to maintain the code for installation at only one place. 
So for projects with an install target, in the `package` method of the ConanFile we can build the install target instead of defining again which files need to be copied.
For this packaging method to work, the [CMAKE_INSTALL_PREFIX](https://cmake.org/cmake/help/v3.6/variable/CMAKE_INSTALL_PREFIX.html) of the project should be set at the CMake configuration step, when the `build` method is called, but at the moment the `package_folder` attribute of the `ConanFile` instance is set only before the `package` method is called. 
This PR fixes this issue by setting the `package_folder` attribute before the `build` method is called. So in the `build` method, the project can be configured with the right [CMAKE_INSTALL_PREFIX](https://cmake.org/cmake/help/v3.6/variable/CMAKE_INSTALL_PREFIX.html) and by building the install target in the `package` method all the required files of the project would get installed in the package directory.
```python
def build(self):
    cmake = CMake(self.settings)
    self.run("cmake %s %s -DCMAKE_INSTALL_PREFIX=%s" % \
        (self.conanfile_directory, cmake.command_line, self.package_folder))
    self.run("cmake --build . %s" % cmake.build_config)

def package(self):
    self.run("cmake --build . --target install")
```