### PR TITLE
Add include paths to CFLAGS and CPPFLAGS.

### DIFF
--- a/conans/client/configure_environment.py
+++ b/conans/client/configure_environment.py
@@ -29,10 +29,13 @@ class ConfigureEnvironment(object):
         if self.os == "Linux" or self.os == "Macos":
             libs = 'LIBS="%s"' % " ".join(["-l%s" % lib for lib in self._deps_cpp_info.libs])
             archflag = "-m32" if self.arch == "x86" else ""
-            ldflags = 'LDFLAGS="%s %s"' % (" ".join(["-L%s" % lib for lib in self._deps_cpp_info.lib_paths]), archflag)
+            ldflags = 'LDFLAGS="%s %s"' % (" ".join(["-L%s" % lib
+                                                     for lib in self._deps_cpp_info.lib_paths]),
+                                           archflag)
             debug = "-g" if self.build_type == "Debug" else "-s -DNDEBUG"
-            cflags = 'CFLAGS="%s %s %s %s"' % (archflag, " ".join(self._deps_cpp_info.cflags), debug, " ".join(['-I%s' % i for i in self._deps_cpp_info.include_paths]))
-            cpp_flags = 'CPPFLAGS="%s %s %s %s"' % (archflag, " ".join(self._deps_cpp_info.cppflags), debug, " ".join(['-I%s' % i for i in self._deps_cpp_info.include_paths]))
+            include_flags = " ".join(['-I%s' % i for i in self._deps_cpp_info.include_paths])
+            cflags = 'CFLAGS="%s %s %s %s"' % (archflag, " ".join(self._deps_cpp_info.cflags),
+                                               debug, include_flags)
 
             # Append the definition for libcxx
             all_cpp_flags = copy.copy(self._deps_cpp_info.cppflags)
@@ -48,10 +51,10 @@ class ConfigureEnvironment(object):
                     else:
                         all_cpp_flags.append("-stdlib=libstdc++")
 
-            cpp_flags = 'CPPFLAGS="%s %s"' % (archflag, " ".join(all_cpp_flags))
+            cpp_flags = 'CPPFLAGS="%s %s %s %s"' % (archflag, " ".join(all_cpp_flags),
+                                                    debug, include_flags)
             include_paths = ":".join(['"%s"' % lib for lib in self._deps_cpp_info.include_paths])
             headers_flags = 'C_INCLUDE_PATH=%s CPP_INCLUDE_PATH=%s' % (include_paths, include_paths)
-
             command = "env %s %s %s %s %s" % (libs, ldflags, cflags, cpp_flags, headers_flags)
         elif self.os == "Windows" and self.compiler == "Visual Studio":
             cl_args = " ".join(['/I"%s"' % lib for lib in self._deps_cpp_info.include_paths])

--- a/conans/client/configure_environment.py
+++ b/conans/client/configure_environment.py
@@ -31,8 +31,8 @@ class ConfigureEnvironment(object):
             archflag = "-m32" if self.arch == "x86" else ""
             ldflags = 'LDFLAGS="%s %s"' % (" ".join(["-L%s" % lib for lib in self._deps_cpp_info.lib_paths]), archflag)
             debug = "-g" if self.build_type == "Debug" else "-s -DNDEBUG"
-            cflags = 'CFLAGS="%s %s %s"' % (archflag, " ".join(self._deps_cpp_info.cflags), debug)
-            cpp_flags = 'CPPFLAGS="%s %s %s"' % (archflag, " ".join(self._deps_cpp_info.cppflags), debug)
+            cflags = 'CFLAGS="%s %s %s %s"' % (archflag, " ".join(self._deps_cpp_info.cflags), debug, " ".join(['-I%s' % i for i in self._deps_cpp_info.include_paths]))
+            cpp_flags = 'CPPFLAGS="%s %s %s %s"' % (archflag, " ".join(self._deps_cpp_info.cppflags), debug, " ".join(['-I%s' % i for i in self._deps_cpp_info.include_paths]))
 
             # Append the definition for libcxx
             all_cpp_flags = copy.copy(self._deps_cpp_info.cppflags)

--- a/conans/test/compile_helpers_test.py
+++ b/conans/test/compile_helpers_test.py
@@ -86,8 +86,10 @@ class CompileHelpersTest(unittest.TestCase):
 
         env = ConfigureEnvironment(BuildInfoMock(), MockLinuxSettings())
         self.assertEquals(env.command_line, 'env LIBS="-llib1 -llib2" LDFLAGS="-Lpath/to/lib1 '
-                                            '-Lpath/to/lib2 -m32" CFLAGS="-m32 cflag1 -s -DNDEBUG" '
-                                            'CPPFLAGS="-m32 cppflag1" '
+                                            '-Lpath/to/lib2 -m32" CFLAGS="-m32 cflag1 -s -DNDEBUG '
+                                            '-Ipath/to/includes/lib1 -Ipath/to/includes/lib2" '
+                                            'CPPFLAGS="-m32 cppflag1 -s -DNDEBUG '
+                                            '-Ipath/to/includes/lib1 -Ipath/to/includes/lib2" '
                                             'C_INCLUDE_PATH="path/to/includes/lib1":'
                                             '"path/to/includes/lib2" '
                                             'CPP_INCLUDE_PATH="path/to/includes/lib1":'


### PR DESCRIPTION
Some configure scripts doesn't seem to honor C_INLUDE_PATH and
CPP_INCLUDE_PATH but instead expect -I <path> to be set in CFLAGS
and CPPFLAGS. I ran into this in the Python configure script

Adding them here should not have any negative effects except listing
some of the include paths twice if the configure script honors
both environments.

An alternative approach would be to allow a option to be set to
tell it where to add the include paths, but it might be to complicated.