### PR TITLE
Fix tests on recent versions of OSX and Xcode

### DIFF
--- a/conans/test/update_settings_yml_test.py
+++ b/conans/test/update_settings_yml_test.py
@@ -34,10 +34,10 @@ compiler:
         runtime: [None, MD, MT, MTd, MDd]
         version: ["8", "9", "10", "11", "12", "14"]
     clang:
-        version: ["3.3", "3.4", "3.5", "3.6", "3.7"]
+        version: ["3.3", "3.4", "3.5", "3.6", "3.7", "3.8"]
         libcxx: [libstdc++, libstdc++11, libc++]
     apple-clang:
-        version: ["5.0", "5.1", "6.0", "6.1", "7.0"]
+        version: ["5.0", "5.1", "6.0", "6.1", "7.0", "7.1", "7.2", "7.3"]
         libcxx: [libstdc++, libc++]
 
 """


### PR DESCRIPTION
The settings in the update_settings_yml_test failed because
my compiler was a higher version number than the ones listed
in there. I have updated the settings.yml in the source file
but we might want to make sure that these settings are shared
between the test and what we ship in the acutal application
to avoid these problems in the future.