### PR TITLE
Add support for letting the generators save multiple files.

### DIFF
--- a/conans/client/generators/__init__.py
+++ b/conans/client/generators/__init__.py
@@ -9,7 +9,6 @@ from .qbs import QbsGenerator
 from .visualstudio import VisualStudioGenerator
 from .xcode import XCodeGenerator
 from .ycm import YouCompleteMeGenerator
-from six import string_types
 
 
 def _save_generator(name, klass):
@@ -48,14 +47,21 @@ def write_generators(conanfile, path, output):
                 # To allow old-style generator packages to work (e.g. premake)
                 output.warn("Generator %s failed with new __init__(), trying old one")
                 generator = generator_class(conanfile.deps_cpp_info, conanfile.cpp_info)
-            content = normalize(generator.content)
-            if isinstance(content, string_types) and not generator.filename is None:
-                output.info("Generated %s created %s" % (generator_name, generator.filename))
-                save(join(path, generator.filename), content)
-            elif isinstance(content, dict):
-                for k, v in content.iteritems():
-                    output.info("Generated %s created %s" % (generator_name, k))
-                    save(join(path, k), v)
-            else:
-                output.warn("Generator %s didn't generate anything" % generator_name)
 
+            try:
+                content = generator.content
+                if isinstance(content, dict):
+                    if generator.filename:
+                        output.warn("Generator %s is multifile. Property 'filename' not used"
+                                    % (generator_name,))
+                    for k, v in content.items():
+                        v = normalize(v)
+                        output.info("Generated %s created %s" % (generator_name, k))
+                        save(join(path, k), v)
+                else:
+                    content = normalize(content)
+                    output.info("Generated %s created %s" % (generator_name, generator.filename))
+                    save(join(path, generator.filename), content)
+            except Exception as e:
+                output.error("Generator %s(file:%s) failed\n%s"
+                             % (generator_name, generator.filename, str(e)))

--- a/conans/client/generators/__init__.py
+++ b/conans/client/generators/__init__.py
@@ -47,6 +47,14 @@ def write_generators(conanfile, path, output):
                 # To allow old-style generator packages to work (e.g. premake)
                 output.warn("Generator %s failed with new __init__(), trying old one")
                 generator = generator_class(conanfile.deps_cpp_info, conanfile.cpp_info)
-            output.info("Generated %s created %s" % (generator_name, generator.filename))
             content = normalize(generator.content)
-            save(join(path, generator.filename), content)
+            if isinstance(content, basestring) and not generator.filename is None:
+                output.info("Generated %s created %s" % (generator_name, generator.filename))
+                save(join(path, generator.filename), content)
+            elif isinstance(content, dict):
+                for k, v in content.iteritems():
+                    output.info("Generated %s created %s" % (generator_name, k))
+                    save(join(path, k), v)
+            else:
+                output.warn("Generator %s didn't generate anything" % generator_name)
+

--- a/conans/client/generators/__init__.py
+++ b/conans/client/generators/__init__.py
@@ -9,6 +9,7 @@ from .qbs import QbsGenerator
 from .visualstudio import VisualStudioGenerator
 from .xcode import XCodeGenerator
 from .ycm import YouCompleteMeGenerator
+from six import string_types
 
 
 def _save_generator(name, klass):
@@ -48,7 +49,7 @@ def write_generators(conanfile, path, output):
                 output.warn("Generator %s failed with new __init__(), trying old one")
                 generator = generator_class(conanfile.deps_cpp_info, conanfile.cpp_info)
             content = normalize(generator.content)
-            if isinstance(content, basestring) and not generator.filename is None:
+            if isinstance(content, string_types) and not generator.filename is None:
                 output.info("Generated %s created %s" % (generator_name, generator.filename))
                 save(join(path, generator.filename), content)
             elif isinstance(content, dict):

--- a/conans/test/integration/custom_generator_test.py
+++ b/conans/test/integration/custom_generator_test.py
@@ -36,6 +36,35 @@ MyCustomGen/0.2@lasote/stable
 MyCustomGenerator
 """
 
+generator_multi = """
+from conans.model import Generator
+from conans.paths import BUILD_INFO
+from conans import ConanFile, CMake
+
+class MyCustomGenerator(Generator):
+    @property
+    def filename(self):
+        return "customfile.gen"
+
+    @property
+    def content(self):
+        return {"file1.gen": "CustomContent1",
+                "file2.gen": "CustomContent2"}
+
+
+class MyCustomGeneratorPackage(ConanFile):
+    name = "MyCustomGen"
+    version = "0.2"
+"""
+
+consumer_multi = """
+[requires]
+MyCustomGen/0.2@lasote/stable
+
+[generators]
+MyCustomGenerator
+"""
+
 
 class CustomGeneratorTest(unittest.TestCase):
 
@@ -76,3 +105,21 @@ class CustomGeneratorTest(unittest.TestCase):
 
         generated = load(os.path.join(client.current_folder, "customfile.gen"))
         self.assertEqual(generated, "My custom generator content")
+
+    def multifile_test(self):
+        gen_reference = ConanFileReference.loads("MyCustomGen/0.2@lasote/stable")
+        client = TestClient(servers=self.servers, users={"default": [("lasote", "mypass")]})
+        files = {CONANFILE: generator_multi}
+        client.save(files)
+        client.run("export lasote/stable")
+        client.run("upload %s" % str(gen_reference))
+
+        # Test local, no retrieval
+        files = {CONANFILE_TXT: consumer_multi}
+        client.save(files, clean_first=True)
+        client.run("install --build")
+        self.assertIn("Generator MyCustomGenerator is multifile. Property 'filename' not used",
+                      client.user_io.out)
+        for i in (1, 2):
+            generated = load(os.path.join(client.current_folder, "file%d.gen" % i))
+            self.assertEqual(generated, "CustomContent%d" % i)


### PR DESCRIPTION
For what I was doing with the PkgConfig generator I had to
be able to generate one file per dependency. The current
generator system was not able to handle this. Fortunately
it was a easy change without having to break any current
generators.