### PR TITLE
Don't fail silently when patching files

### DIFF
--- a/conans/tools.py
+++ b/conans/tools.py
@@ -134,5 +134,5 @@ def patch(base_path=None, patch_file=None, patch_string=None):
         patchset = fromstring(patch_string.encode())
 
     if not patchset.apply(root=base_path):
-        raise Exception("Failed to apply patch: %s" % patch_file)
+        raise ConanException("Failed to apply patch: %s" % patch_file)
 

--- a/conans/tools.py
+++ b/conans/tools.py
@@ -10,7 +10,6 @@ from conans.client.rest.uploader_downloader import Downloader
 import requests
 from conans.client.output import ConanOutput
 
-
 def vcvars_command(settings):
     param = "x86" if settings.arch == "x86" else "amd64"
     command = ('call "%%vs%s0comntools%%../../VC/vcvarsall.bat" %s'
@@ -134,4 +133,6 @@ def patch(base_path=None, patch_file=None, patch_string=None):
     else:
         patchset = fromstring(patch_string.encode())
 
-    patchset.apply(root=base_path)
+    if not patchset.apply(root=base_path):
+        raise Exception("Failed to apply patch: %s" % patch_file)
+


### PR DESCRIPTION
After searching for why my files where not patched correctly
way to long I came to the conclusion that the patch tool actually
silently failed. This is pretty bad behavior if something changes
so I have added a exception for this.