### PR TITLE
Feature/export dirty

### DIFF
--- a/conans/client/export.py
+++ b/conans/client/export.py
@@ -45,7 +45,7 @@ def export_conanfile(output, paths, file_patterns, origin_folder, conan_ref, kee
         output.info("Removing 'source' folder, this can take a while for big packages")
         try:
             rmdir(source)
-        except Exception as e:
+        except BaseException as e:
             output.error("Unable to delete source folder. "
                          "Will be marked as dirty for deletion")
             output.warn(str(e))

--- a/conans/client/export.py
+++ b/conans/client/export.py
@@ -25,20 +25,31 @@ def export_conanfile(output, paths, file_patterns, origin_folder, conan_ref, kee
     if previous_digest and previous_digest.file_sums == digest.file_sums:
         digest = previous_digest
         output.info("The stored package has not changed")
+        modified_recipe = False
     else:
         output.success('A new %s version was exported' % CONANFILE)
-        source = paths.source(conan_ref)
-        if not keep_source and os.path.exists(source):
-            output.info("Removing 'source' folder, this can take a while for big packages")
-            output.info("Use the --keep-source, -k option to skip it")
-            try:
-                rmdir(source)
-            except Exception as e:
-                output.warn("Unable to delete source folder. Will be marked as dirty for deletion")
-                output.warn(str(e))
-                save(os.path.join(source, DIRTY_FILE), "")
-        output.success('%s exported to local storage' % CONANFILE)
         output.info('Folder: %s' % destination_folder)
+        modified_recipe = True
+
+    source = paths.source(conan_ref)
+    dirty = os.path.join(source, DIRTY_FILE)
+    remove = False
+    if os.path.exists(dirty):
+        output.info("Source folder is dirty, forcing removal")
+        remove = True
+    elif modified_recipe and not keep_source and os.path.exists(source):
+        output.info("Package recipe modified in export, forcing source folder removal")
+        output.info("Use the --keep-source, -k option to skip it")
+        remove = True
+    if remove:
+        output.info("Removing 'source' folder, this can take a while for big packages")
+        try:
+            rmdir(source)
+        except Exception as e:
+            output.error("Unable to delete source folder. "
+                         "Will be marked as dirty for deletion")
+            output.warn(str(e))
+            save(os.path.join(source, DIRTY_FILE), "")
 
 
 def _init_export_folder(destination_folder):

--- a/conans/client/installer.py
+++ b/conans/client/installer.py
@@ -224,7 +224,8 @@ Package configuration:
         dirty = os.path.join(src_folder, DIRTY_FILE)
 
         def remove_source(raise_error=False):
-            output.warning("Trying to remove dirty source folder")
+            output.warn("Trying to remove dirty source folder")
+            output.warn("This can take a while for big packages")
             try:
                 rmdir(src_folder)
             except Exception as e_rm:

--- a/conans/client/installer.py
+++ b/conans/client/installer.py
@@ -4,7 +4,7 @@ import platform
 import fnmatch
 import shutil
 
-from conans.paths import CONANINFO, BUILD_INFO
+from conans.paths import CONANINFO, BUILD_INFO, DIRTY_FILE
 from conans.util.files import save, rmdir
 from conans.model.ref import PackageReference
 from conans.util.log import logger
@@ -221,22 +221,36 @@ Package configuration:
         """ creates src folder and retrieve, calling source() from conanfile
         the necessary source code
         """
+        dirty = os.path.join(src_folder, DIRTY_FILE)
+
+        def remove_source(raise_error=False):
+            output.warning("Trying to remove dirty source folder")
+            try:
+                rmdir(src_folder)
+            except Exception as e_rm:
+                save(dirty, "")  # Creation of DIRTY flag
+                output.error("Unable to remove source folder %s\n%s" % (src_folder, str(e_rm)))
+                output.warn("**** Please delete it manually ****")
+                if raise_error:
+                    raise ConanException("Unable to remove source folder")
+
+        if os.path.exists(dirty):
+            remove_source(raise_error=True)
+
         if not os.path.exists(src_folder):
             output.info('Configuring sources in %s' % src_folder)
             shutil.copytree(export_folder, src_folder)
+            save(dirty, "")  # Creation of DIRTY flag
             os.chdir(src_folder)
             try:
                 conan_file.source()
+                os.remove(dirty)  # Everything went well, remove DIRTY flag
             except Exception as e:
+                os.chdir(export_folder)
                 output.error("Error while executing source(): %s" % str(e))
                 # in case source() fails (user error, typically), remove the src_folder
                 # and raise to interrupt any other processes (build, package)
-                os.chdir(export_folder)
-                try:
-                    rmdir(src_folder)
-                except Exception as e_rm:
-                    output.error("Unable to remove src folder %s\n%s" % (src_folder, str(e_rm)))
-                    output.warn("**** Please delete it manually ****")
+                remove_source()
                 raise ConanException("%s: %s" % (conan_file.name, str(e)))
 
     def _build_package(self, export_folder, src_folder, build_folder, package_folder, conan_file,

--- a/conans/client/installer.py
+++ b/conans/client/installer.py
@@ -228,11 +228,11 @@ Package configuration:
             output.warn("This can take a while for big packages")
             try:
                 rmdir(src_folder)
-            except Exception as e_rm:
+            except BaseException as e_rm:
                 save(dirty, "")  # Creation of DIRTY flag
                 output.error("Unable to remove source folder %s\n%s" % (src_folder, str(e_rm)))
                 output.warn("**** Please delete it manually ****")
-                if raise_error:
+                if raise_error or isinstance(e_rm, KeyboardInterrupt):
                     raise ConanException("Unable to remove source folder")
 
         if os.path.exists(dirty):

--- a/conans/paths.py
+++ b/conans/paths.py
@@ -36,6 +36,7 @@ BUILD_INFO_XCODE = 'conanbuildinfo.xcconfig'
 BUILD_INFO_YCM = '.ycm_extra_conf.py'
 CONANINFO = "conaninfo.txt"
 SYSTEM_REQS = "system_reqs.txt"
+DIRTY_FILE = ".conan_dirty"
 
 PACKAGE_TGZ_NAME = "conan_package.tgz"
 EXPORT_TGZ_NAME = "conan_export.tgz"

--- a/conans/test/command/export_dirty_test.py
+++ b/conans/test/command/export_dirty_test.py
@@ -1,0 +1,54 @@
+import unittest
+import os
+from conans.paths import CONANFILE
+from conans.model.ref import ConanFileReference
+from conans.test.utils.cpp_test_files import cpp_hello_conan_files
+from conans.test.tools import TestClient
+
+
+class ExportDirtyTest(unittest.TestCase):
+    """ Make sure than when the source folder becomes dirty, due to a export of
+    a new recipe with a rmdir failure, or to an uncomplete execution of source(),
+    it is marked as dirty and removed when necessary
+    """
+
+    def setUp(self):
+        self.client = TestClient()
+        files = cpp_hello_conan_files("Hello0", "0.1")
+        files[CONANFILE] = files[CONANFILE].replace("build(", "build2(")
+        self.client.save(files)
+        self.client.run("export lasote/stable")
+        self.client.run("install Hello0/0.1@lasote/stable --build")
+        ref = ConanFileReference.loads("Hello0/0.1@lasote/stable")
+        source_path = self.client.paths.source(ref)
+        file_open = os.path.join(source_path, "main.cpp")
+
+        self.f = open(file_open, 'rb')
+        files[CONANFILE] = files[CONANFILE].replace("build2(", "build3(")
+        self.client.save(files)
+        self.client.run("export lasote/stable")
+        self.assertIn("ERROR: Unable to delete source folder. "
+                      "Will be marked as dirty for deletion",
+                      self.client.user_io.out)
+
+        err = self.client.run("install Hello0/0.1@lasote/stable --build", ignore_error=True)
+        self.assertTrue(err)
+        self.assertIn("ERROR: Unable to remove source folder", self.client.user_io.out)
+
+    def test_export_remove(self):
+        """ The export is able to remove dirty source folders
+        """
+        self.f.close()
+        self.client.run("export lasote/stable")
+        self.assertIn("Source folder is dirty, forcing removal", self.client.user_io.out)
+        err = self.client.run("install Hello0/0.1@lasote/stable --build")
+        self.assertFalse(err)
+
+    def test_install_remove(self):
+        """ The install is also able to remove dirty source folders
+        """
+        # Now, release the handle to the file
+        self.f.close()
+        err = self.client.run("install Hello0/0.1@lasote/stable --build")
+        self.assertFalse(err)
+        self.assertIn("WARN: Trying to remove dirty source folder", self.client.user_io.out)

--- a/conans/test/command/export_dirty_test.py
+++ b/conans/test/command/export_dirty_test.py
@@ -4,6 +4,7 @@ from conans.paths import CONANFILE
 from conans.model.ref import ConanFileReference
 from conans.test.utils.cpp_test_files import cpp_hello_conan_files
 from conans.test.tools import TestClient
+import platform
 
 
 class ExportDirtyTest(unittest.TestCase):
@@ -13,6 +14,8 @@ class ExportDirtyTest(unittest.TestCase):
     """
 
     def setUp(self):
+        if platform.system() != "Windows":
+            return
         self.client = TestClient()
         files = cpp_hello_conan_files("Hello0", "0.1")
         files[CONANFILE] = files[CONANFILE].replace("build(", "build2(")
@@ -38,6 +41,8 @@ class ExportDirtyTest(unittest.TestCase):
     def test_export_remove(self):
         """ The export is able to remove dirty source folders
         """
+        if platform.system() != "Windows":
+            return
         self.f.close()
         self.client.run("export lasote/stable")
         self.assertIn("Source folder is dirty, forcing removal", self.client.user_io.out)
@@ -47,6 +52,8 @@ class ExportDirtyTest(unittest.TestCase):
     def test_install_remove(self):
         """ The install is also able to remove dirty source folders
         """
+        if platform.system() != "Windows":
+            return
         # Now, release the handle to the file
         self.f.close()
         err = self.client.run("install Hello0/0.1@lasote/stable --build")

--- a/conans/test/command/export_test.py
+++ b/conans/test/command/export_test.py
@@ -23,7 +23,7 @@ class ExportTest(unittest.TestCase):
         reg_path = self.conan.paths.export(self.conan_ref)
         manif = FileTreeManifest.loads(load(self.conan.paths.digestfile_conanfile(self.conan_ref)))
 
-        self.assertIn('%s: conanfile.py exported to local storage' % str(self.conan_ref),
+        self.assertIn('%s: A new conanfile.py version was exported' % str(self.conan_ref),
                       self.conan.user_io.out)
         self.assertIn('%s: Folder: %s' % (str(self.conan_ref), reg_path), self.conan.user_io.out)
         self.assertTrue(os.path.exists(reg_path))
@@ -105,7 +105,7 @@ class OpenSSLConan(ConanFile):
         self.assertNotIn('Cleaning the old builds ...', conan2.user_io.out)
         self.assertNotIn('Cleaning the old packs ...', conan2.user_io.out)
         self.assertNotIn('All the previous packs were cleaned', conan2.user_io.out)
-        self.assertIn('%s: conanfile.py exported to local storage' % str(self.conan_ref),
+        self.assertIn('%s: A new conanfile.py version was exported' % str(self.conan_ref),
                       self.conan.user_io.out)
         self.assertIn('%s: Folder: %s' % (str(self.conan_ref), reg_path2), self.conan.user_io.out)
         self.assertTrue(os.path.exists(reg_path2))
@@ -137,8 +137,7 @@ class OpenSSLConan(ConanFile):
         reg_path3 = conan2.paths.export(self.conan_ref)
         digest3 = FileTreeManifest.loads(load(conan2.paths.digestfile_conanfile(self.conan_ref)))
 
-        self.assertIn('A new conanfile.py version was exported', conan2.user_io.out)
-        self.assertIn('%s: conanfile.py exported to local storage' % str(self.conan_ref),
+        self.assertIn('%s: A new conanfile.py version was exported' % str(self.conan_ref),
                       self.conan.user_io.out)
         self.assertIn('%s: Folder: %s' % (str(self.conan_ref), reg_path3), self.conan.user_io.out)
 


### PR DESCRIPTION
I agree with this feature. 
It can be confusing when the source folder comes into a dirty state, due to some failure. I have added a dirty file to manage it.

This will improve https://github.com/conan-io/conan/issues/352 and https://github.com/conan-io/conan/issues/353