### PR TITLE
bump version to 0.10.1

### DIFF
--- a/conans/__init__.py
+++ b/conans/__init__.py
@@ -9,5 +9,5 @@ from conans.client.configure_environment import ConfigureEnvironment
 from conans.util.files import load
 import os
 
-__version__ = '0.10.0'
+__version__ = '0.10.1'
 


### PR DESCRIPTION
The version of conans doesn't reflect the correct version, thus the client complains that the server is not up to date althought it is using the correct branch. 