### PR TITLE
Feature/conan environ

### DIFF
--- a/conans/client/command.py
+++ b/conans/client/command.py
@@ -300,6 +300,8 @@ path to the CMake binary directory, like this:
                             help="update with new upstream packages")
         parser.add_argument("--scope", "-sc", nargs=1, action=Extender,
                             help='Define scopes for packages')
+        parser.add_argument("--generator", "-g", nargs=1, action=Extender,
+                            help='Generators to use')
         self._parse_args(parser)
 
         args = parser.parse_args(*args)
@@ -332,7 +334,8 @@ path to the CMake binary directory, like this:
                                   filename=args.file,
                                   update=args.update,
                                   integrity=args.integrity,
-                                  scopes=scopes)
+                                  scopes=scopes,
+                                  generators=args.generator)
 
     def info(self, *args):
         """ Prints information about the requirements.

--- a/conans/client/configure_environment.py
+++ b/conans/client/configure_environment.py
@@ -1,22 +1,51 @@
 from conans.model.settings import Settings
 import copy
+from conans.client.generators.virtualenv import get_setenv_variables_commands
+from conans.model.env_info import DepsEnvInfo
 
 
 class ConfigureEnvironment(object):
 
-    def __init__(self, deps_cpp_info, settings):
+    def __init__(self, *args):
+        if len(args) == 2:
+            deps_cpp_info = args[0]
+            deps_env_info = DepsEnvInfo()
+            settings = args[1]
+        elif len(args) == 1:  # conanfile (new interface)
+            self.conanfile = args[0]
+            deps_cpp_info = self.conanfile.deps_cpp_info
+            deps_env_info = self.conanfile.deps_env_info
+            settings = self.conanfile.settings
+
         assert isinstance(settings, Settings)
+
         self._settings = settings
         self._deps_cpp_info = deps_cpp_info
-        self.compiler = getattr(self._settings, "compiler", None)
-        self.arch = getattr(self._settings, "arch", None)
-        self.os = getattr(self._settings, "os", None)
-        self.build_type = getattr(self._settings, "build_type", None)
-        self.libcxx = None
+        self._deps_env_info = deps_env_info
         try:
-            self.libcxx = self.compiler.libcxx
+            self.compiler = str(self._settings.compiler)
         except:
-            pass
+            self.compiler = None
+
+        try:
+            self.arch = str(self._settings.arch)
+        except:
+            self.arch = None
+
+        try:
+            self.os = str(self._settings.os)
+        except:
+            self.os = None
+
+        try:
+            self.build_type = str(self._settings.build_type)
+        except:
+            self.build_type = None
+
+        try:
+            self.libcxx = str(self.compiler.libcxx)
+        except:
+            self.libcxx = None
 
     @property
     def command_line(self):
@@ -26,7 +55,7 @@ class ConfigureEnvironment(object):
             self.run(command)
         """
         command = ""
-        if self.os == "Linux" or self.os == "Macos":
+        if self.os == "Linux" or self.os == "Macos" or (self.os == "Windows" and self.compiler == "gcc"):
             libflags = " ".join(["-l%s" % lib for lib in self._deps_cpp_info.libs])
             libs = 'LIBS="%s"' % libflags
             archflag = "-m32" if self.arch == "x86" else ""
@@ -61,4 +90,7 @@ class ConfigureEnvironment(object):
             cl_args = " ".join(['/I"%s"' % lib for lib in self._deps_cpp_info.include_paths])
             lib_paths = ";".join(['"%s"' % lib for lib in self._deps_cpp_info.lib_paths])
             command = "SET LIB=%s;%%LIB%% && SET CL=%s" % (lib_paths, cl_args)
+
+        # Add the rest of env variables from deps_env_info
+        command += " ".join(get_setenv_variables_commands(self._deps_env_info, "" if self.os != "Windows" else "SET"))
         return command

--- a/conans/client/deps_builder.py
+++ b/conans/client/deps_builder.py
@@ -104,7 +104,7 @@ class DepsGraph(object):
         return "\n".join(["Nodes:\n    ",
                           "\n    ".join(repr(n) for n in self.nodes)])
 
-    def propagate_buildinfo(self):
+    def propagate_info_objects(self):
         """ takes the exports from upper level and updates the imports
         right now also the imports are propagated, but should be checked
         E.g. Conan A, depends on B.  A=>B
@@ -127,7 +127,7 @@ class DepsGraph(object):
                 _, conanfile = node
                 for n in node_order:
                     conanfile.deps_cpp_info.update(n.conanfile.cpp_info, n.conan_ref)
-
+                    conanfile.deps_env_info.update(n.conanfile.env_info, n.conan_ref)
         return ordered
 
     def propagate_info(self):

--- a/conans/client/generators/__init__.py
+++ b/conans/client/generators/__init__.py
@@ -1,4 +1,5 @@
 from conans.model import registered_generators
+from conans.model.env_info import EnvInfo
 from conans.util.files import save, normalize
 from os.path import join
 from .text import TXTGenerator
@@ -9,6 +10,7 @@ from .qbs import QbsGenerator
 from .visualstudio import VisualStudioGenerator
 from .xcode import XCodeGenerator
 from .ycm import YouCompleteMeGenerator
+from .virtualenv import VirtualEnvGenerator
 
 
 def _save_generator(name, klass):
@@ -23,6 +25,7 @@ _save_generator("qbs", QbsGenerator)
 _save_generator("visual_studio", VisualStudioGenerator)
 _save_generator("xcode", XCodeGenerator)
 _save_generator("ycm", YouCompleteMeGenerator)
+_save_generator("virtualenv", VirtualEnvGenerator)
 
 
 def write_generators(conanfile, path, output):
@@ -33,6 +36,8 @@ def write_generators(conanfile, path, output):
 
     conanfile.cpp_info = CppInfo(path)
     conanfile.cpp_info.dependencies = []
+
+    conanfile.env_info = EnvInfo(path)
     conanfile.package_info()
 
     for generator_name in conanfile.generators:

--- a/conans/client/generators/virtualenv.py
+++ b/conans/client/generators/virtualenv.py
@@ -1,0 +1,85 @@
+from conans.model import Generator
+import platform
+import os
+import copy
+from conans.errors import ConanException
+
+
+def get_setenv_variables_commands(deps_env_info, command_set=None):
+    if command_set is None:
+        command_set = "SET" if platform.system() == "Windows" else "export"
+
+    multiple_to_set, simple_to_set = get_dict_values(deps_env_info)
+    ret = []
+    for name, value in multiple_to_set.items():
+        if platform.system() == "Windows":
+            ret.append(command_set + ' "' + name + '=' + value + ';%' + name + '%"')
+        else:
+            ret.append(command_set + ' ' + name + '=' + value + ':$' + name)
+    for name, value in simple_to_set.items():
+        if platform.system() == "Windows":
+            ret.append(command_set + ' "' + name + '=' + value + '"')
+        else:
+            ret.append(command_set + ' ' + name + '=' + value)
+    return ret
+
+
+def get_dict_values(deps_env_info):
+    def adjust_var_name(name):
+        return "PATH" if name.lower() == "path" else name
+    separator = ";" if platform.system() == "Windows" else ":"
+    multiple_to_set = {adjust_var_name(name): separator.join(value_list)
+                       for name, value_list in deps_env_info.vars.items()
+                       if isinstance(value_list, list)}
+    simple_to_set = {adjust_var_name(name): value
+                     for name, value in deps_env_info.vars.items()
+                     if not isinstance(value, list)}
+    return multiple_to_set, simple_to_set
+
+
+class VirtualEnvGenerator(Generator):
+
+    @property
+    def filename(self):
+        return
+
+    @property
+    def content(self):
+        old_venv = os.environ.get("_CONAN_VENV", None)
+        if old_venv:
+            raise ConanException("Deactivate the current virtual environment (or close the console) and then execute conan install again: %s" % old_venv)
+        multiple_to_set, simple_to_set = get_dict_values(self.deps_env_info)
+        all_vars = copy.copy(multiple_to_set)
+        all_vars.update(simple_to_set)
+        venv_name = os.path.basename(self.conanfile.conanfile_directory)
+        venv_dir = self.conanfile.conanfile_directory
+        deactivate_lines = ["@echo off"] if platform.system() == "Windows" else []
+        for name in all_vars.keys():
+            old_value = os.environ.get(name, "")
+            if platform.system() == "Windows":
+                deactivate_lines.append('SET "%s=%s"' % (name, old_value))
+            else:
+                deactivate_lines.append('export %s=%s' % (name, old_value))
+        if platform.system() == "Windows":
+            deactivate_lines.append("SET PROMPT=%s" % os.environ.get("PROMPT", ""))
+            deactivate_lines.append("SET _CONAN_VENV=")
+        else:
+            deactivate_lines.append(r"export PS1=\"\[\e]0;\u@\h: \w\a\]${debian_chroot:+($debian_chroot)}\u@\h:\w\$ \"")
+            deactivate_lines.append("export _CONAN_VENV=")
+
+        activate_lines = ["@echo off"] if platform.system() == "Windows" else []
+        if platform.system() == "Windows":
+            activate_lines.append('if defined _CONAN_VENV (echo Deactivate current venv first with %_CONAN_VENV%\deactivate.bat)')
+            activate_lines.append('if defined _CONAN_VENV (EXIT /B)')
+            activate_lines.append("SET PROMPT=(%s) " % venv_name + "%PROMPT%")
+            activate_lines.append("SET _CONAN_VENV=%s" % venv_dir)
+        else:
+            activate_lines.append('if [ -n "$_CONAN_VENV" ]; then echo "Deactivate current venv first with \'source $_CONAN_VENV\deactivate"; fi')
+            activate_lines.append('if [ -n "$_CONAN_VENV" ]; then exit; fi')
+            activate_lines.append("export PS1=\"(%s) " % venv_name + "$PS1\"")
+            activate_lines.append("export _CONAN_VENV=%s" % venv_dir)
+
+        activate_lines.extend(get_setenv_variables_commands(self.deps_env_info))
+        ext = "bat" if platform.system() == "Windows" else "sh"
+        return {"activate.%s" % ext: os.linesep.join(activate_lines),
+                "deactivate.%s" % ext: os.linesep.join(deactivate_lines)}

--- a/conans/client/loader.py
+++ b/conans/client/loader.py
@@ -14,7 +14,6 @@ import sys
 from conans.model.conan_generator import Generator
 from conans.client.generators import _save_generator
 from conans.model.scope import Scopes
-from conans.client.output import ScopedOutput
 
 
 class ConanFileLoader(object):
@@ -222,12 +221,3 @@ class ConanFileTextLoader(object):
             for import_params in parameters:
                 conan_file.copy(*import_params)
         return imports
-
-    @staticmethod
-    def get_txt_contents(requirements, generators, options):
-        return "[requires]%(nl)s%(requires)s%(nl)s[generators]%(nl)s%(generators)s%(nl)s\
-[options]%(nl)s%(options)s%(nl)s" % {"requires": os.linesep.join([str(req) for req in requirements]),
-                                     "generators": os.linesep.join(generators),
-                                     "options": os.linesep.join(["=".join(option) for option in options]),
-                                     "nl": os.linesep}
-

--- a/conans/client/loader.py
+++ b/conans/client/loader.py
@@ -115,18 +115,24 @@ class ConanFileLoader(object):
         except Exception as e:  # re-raise with file name
             raise ConanException("%s: %s" % (conan_file_path, str(e)))
 
-    def load_conan_txt(self, conan_requirements_path, output):
+    def load_conan_txt(self, conan_txt_path, output):
 
-        if not os.path.exists(conan_requirements_path):
+        if not os.path.exists(conan_txt_path):
             raise NotFoundException("Conanfile not found!")
 
-        conanfile = ConanFile(output, self._runner, self._settings.copy(),
-                              os.path.dirname(conan_requirements_path))
+        contents = load(conan_txt_path)
+        path = os.path.dirname(conan_txt_path)
+
+        conanfile = self.parse_conan_txt(contents, path, output)
+        return conanfile
+
+    def parse_conan_txt(self, contents, path, output):
+        conanfile = ConanFile(output, self._runner, self._settings.copy(), path)
 
         try:
-            parser = ConanFileTextLoader(load(conan_requirements_path))
+            parser = ConanFileTextLoader(contents)
         except Exception as e:
-            raise ConanException("%s:\n%s" % (conan_requirements_path, str(e)))
+            raise ConanException("%s:\n%s" % (path, str(e)))
         for requirement_text in parser.requirements:
             ConanFileReference.loads(requirement_text)  # Raise if invalid
             conanfile.requires.add(requirement_text)
@@ -143,7 +149,7 @@ class ConanFileLoader(object):
         conanfile.scope = self._scopes.package_scope()
         return conanfile
 
-    def load_virtual(self, reference):
+    def load_virtual(self, reference, path):
         fixed_options = []
         # If user don't specify namespace in options, assume that it's for the reference (keep compatibility)
         for option_name, option_value in self._options.as_list():
@@ -154,7 +160,7 @@ class ConanFileLoader(object):
             fixed_options.append(tmp)
         options = OptionsValues.from_list(fixed_options)
 
-        conanfile = ConanFile(None, self._runner, self._settings.copy(), None)
+        conanfile = ConanFile(None, self._runner, self._settings.copy(), path)
 
         conanfile.requires.add(str(reference))  # Convert to string necessary
         # conanfile.options.values = options
@@ -216,3 +222,12 @@ class ConanFileTextLoader(object):
             for import_params in parameters:
                 conan_file.copy(*import_params)
         return imports
+
+    @staticmethod
+    def get_txt_contents(requirements, generators, options):
+        return "[requires]%(nl)s%(requires)s%(nl)s[generators]%(nl)s%(generators)s%(nl)s\
+[options]%(nl)s%(options)s%(nl)s" % {"requires": os.linesep.join([str(req) for req in requirements]),
+                                     "generators": os.linesep.join(generators),
+                                     "options": os.linesep.join(["=".join(option) for option in options]),
+                                     "nl": os.linesep}
+

--- a/conans/model/conan_file.py
+++ b/conans/model/conan_file.py
@@ -3,6 +3,7 @@ from conans.model.requires import Requirements
 from conans.model.build_info import DepsCppInfo
 from conans import tools  # @UnusedImport KEEP THIS! Needed for pyinstaller to copy to exe.
 from conans.errors import ConanException
+from conans.model.env_info import DepsEnvInfo
 
 
 def create_options(conanfile):
@@ -93,6 +94,11 @@ class ConanFile(object):
         # needed variables to pack the project
         self.cpp_info = None  # Will be initialized at processing time
         self.deps_cpp_info = DepsCppInfo()
+
+        # environment variables declared in the package_info
+        self.env_info = None  # Will be initialized at processing time
+        self.deps_env_info = DepsEnvInfo()
+
         self.copy = None  # initialized at runtime
 
         # an output stream (writeln, info, warn error)

--- a/conans/model/conan_generator.py
+++ b/conans/model/conan_generator.py
@@ -9,6 +9,8 @@ class Generator(object):
         self.conanfile = conanfile
         self._deps_build_info = conanfile.deps_cpp_info
         self._build_info = conanfile.cpp_info
+        self._deps_env_info = conanfile.deps_env_info
+        self._env_info = conanfile.env_info
 
     @property
     def deps_build_info(self):
@@ -17,6 +19,14 @@ class Generator(object):
     @property
     def build_info(self):
         return self._build_info
+
+    @property
+    def deps_env_info(self):
+        return self._deps_env_info
+
+    @property
+    def env_info(self):
+        return self._env_info
 
     @abstractproperty
     def content(self):

--- a/conans/model/env_info.py
+++ b/conans/model/env_info.py
@@ -1,0 +1,77 @@
+from collections import OrderedDict
+from conans.util.log import logger
+
+
+class EnvInfo(object):
+    """ Object that stores all the environment variables required:
+
+    env = EnvInfo()
+    env.hola = True
+    env.Cosa.append("OTRO")
+    env.Cosa.append("MAS")
+    env.Cosa = "hello"
+    env.Cosa.append("HOLA")
+
+    """
+    def __init__(self, root_folder=None):
+        self._root_folder_ = root_folder
+        self._values_ = {}
+        
+    def __getattr__(self, name):
+        if name.startswith("_") and name.endswith("_"):
+            return super(EnvInfo, self).__getattr__(name)
+        else:
+            if not self._values_.get(name):
+                self._values_[name] = []
+            elif not isinstance(self._values_[name], list):
+                tmp = self._values_[name]
+                self._values_[name] = [tmp]
+            return self._values_[name]
+
+    def __setattr__(self, name, value):
+        if (name.startswith("_") and name.endswith("_")):
+            super(EnvInfo, self).__setattr__(name, value)
+        else:
+            self._values_[name] = value
+        return
+
+    @property
+    def vars(self):
+        return self._values_
+
+
+class DepsEnvInfo(EnvInfo):
+    """ All the env info for a conanfile dependencies
+    """
+    def __init__(self):
+        super(DepsEnvInfo, self).__init__()
+        self._dependencies_ = OrderedDict()
+
+    @property
+    def dependencies(self):
+        return self._dependencies_.items()
+
+    @property
+    def deps(self):
+        return self._dependencies_.keys()
+
+    def __getitem__(self, item):
+        return self._dependencies_[item]
+
+    def update(self, dep_env_info, conan_ref=None):
+        if conan_ref is not None:
+            self._dependencies_[conan_ref.name] = dep_env_info
+        else:
+            self._dependencies_.update(dep_env_info.dependencies)
+
+        # With vars if its setted the keep the setted value
+        for varname, value in dep_env_info.vars.items():
+            if varname not in self.vars:
+                self.vars[varname] = value
+            elif isinstance(self.vars[varname], list):
+                if isinstance(value, list):
+                    self.vars[varname].extend(value)
+                else:
+                    self.vars[varname].append(value)
+            else:
+                logger.warn("DISCARDED variable %s=%s from %s" % (varname, value, str(conan_ref))) 

--- a/conans/test/compile_helpers_test.py
+++ b/conans/test/compile_helpers_test.py
@@ -97,7 +97,16 @@ class CompileHelpersTest(unittest.TestCase):
                                             '"path/to/includes/lib2"')
         # Not supported yet
         env = ConfigureEnvironment(BuildInfoMock(), MockWinGccSettings())
-        self.assertEquals(env.command_line, "")
+        self.assertEquals(env.command_line, 'env LIBS="-llib1 -llib2" LDFLAGS="-Lpath/to/lib1 '
+                                            '-Lpath/to/lib2 -llib1 -llib2 -m32" '
+                                            'CFLAGS="-m32 cflag1 -s -DNDEBUG '
+                                            '-Ipath/to/includes/lib1 -Ipath/to/includes/lib2" '
+                                            'CPPFLAGS="-m32 cppflag1 -s -DNDEBUG '
+                                            '-Ipath/to/includes/lib1 -Ipath/to/includes/lib2" '
+                                            'C_INCLUDE_PATH="path/to/includes/lib1":'
+                                            '"path/to/includes/lib2" '
+                                            'CPP_INCLUDE_PATH="path/to/includes/lib1":'
+                                            '"path/to/includes/lib2"')
 
     def gcc_test(self):
         gcc = GCC(MockLinuxSettings())

--- a/conans/test/integration/conan_env_test.py
+++ b/conans/test/integration/conan_env_test.py
@@ -1,0 +1,60 @@
+import unittest
+from conans.test.tools import TestClient
+from conans.util.files import load
+import os
+import platform
+
+
+class ConanEnvTest(unittest.TestCase):
+
+    def conan_env_deps_test(self):
+        client = TestClient()
+        conanfile = '''
+from conans import ConanFile
+
+class HelloConan(ConanFile):
+    name = "Hello"
+    version = "0.1"
+    def package_info(self):
+        self.env_info.var1="bad value"
+        self.env_info.var2.append("value2")
+        self.env_info.var3="Another value"
+        self.env_info.path = "/dir"
+'''
+        files = {}
+        files["conanfile.py"] = conanfile
+        client.save(files)
+        client.run("export lasote/stable")
+        conanfile = '''
+from conans import ConanFile
+
+class HelloConan(ConanFile):
+    name = "Hello2"
+    version = "0.1"
+    def config(self):
+        self.requires("Hello/0.1@lasote/stable")
+
+    def package_info(self):
+        self.env_info.var1="good value"
+        self.env_info.var2.append("value3")
+    '''
+        files["conanfile.py"] = conanfile
+        client.save(files, clean_first=True)
+        client.run("export lasote/stable")
+        client.run("install Hello2/0.1@lasote/stable --build -g virtualenv")
+        ext = "bat" if platform.system() == "Windows" else "sh"
+        self.assertTrue(os.path.exists(os.path.join(client.current_folder, "activate.%s" % ext)))
+        self.assertTrue(os.path.exists(os.path.join(client.current_folder, "deactivate.%s" % ext)))
+        activate_contents = load(os.path.join(client.current_folder, "activate.%s" % ext))
+        deactivate_contents = load(os.path.join(client.current_folder, "deactivate.%s" % ext))
+        self.assertNotIn("bad value", activate_contents)
+        self.assertIn("var1=good value", activate_contents)
+        if platform.system() == "Windows":
+            self.assertIn("var2=value3;value2;%var2%", activate_contents)
+        else:
+            self.assertIn("var2=value3:value2:$var2", activate_contents)
+        self.assertIn("Another value", activate_contents)
+        self.assertIn("PATH=/dir", activate_contents)
+
+        self.assertIn('var1=', deactivate_contents)
+        self.assertIn('var2=', deactivate_contents)

--- a/conans/test/integration/conan_scopes_test.py
+++ b/conans/test/integration/conan_scopes_test.py
@@ -1,3 +1,4 @@
+
 import unittest
 from conans.test.tools import TestClient
 from conans.util.files import load

--- a/conans/test/model/build_info_test.py
+++ b/conans/test/model/build_info_test.py
@@ -2,6 +2,7 @@ import unittest
 from conans.model.build_info import DepsCppInfo
 from conans.client.generators import TXTGenerator
 from collections import namedtuple
+from conans.model.env_info import DepsEnvInfo
 
 
 class BuildInfoTest(unittest.TestCase):
@@ -12,6 +13,7 @@ class BuildInfoTest(unittest.TestCase):
                              getattr(item2, field))
 
     def help_test(self):
+        deps_env_info = DepsEnvInfo()
         deps_cpp_info = DepsCppInfo()
         deps_cpp_info.includedirs.append("C:/whatever")
         deps_cpp_info.includedirs.append("C:/whenever")
@@ -21,7 +23,7 @@ class BuildInfoTest(unittest.TestCase):
         child.includedirs.append("F:/ChildrenPath")
         child.cppflags.append("cxxmyflag")
         deps_cpp_info._dependencies["Boost"] = child
-        fakeconan = namedtuple("Conanfile", "deps_cpp_info cpp_info")
-        output = TXTGenerator(fakeconan(deps_cpp_info, None)).content
+        fakeconan = namedtuple("Conanfile", "deps_cpp_info cpp_info deps_env_info env_info")
+        output = TXTGenerator(fakeconan(deps_cpp_info, None, deps_env_info, None)).content
         deps_cpp_info2 = DepsCppInfo.loads(output)
         self._equal(deps_cpp_info, deps_cpp_info2)

--- a/conans/test/model/env_info_test.py
+++ b/conans/test/model/env_info_test.py
@@ -1,0 +1,35 @@
+import unittest
+from conans.model.env_info import DepsEnvInfo
+from conans.model.ref import ConanFileReference
+
+
+class EnvInfoTest(unittest.TestCase):
+
+    def assign_test(self):
+        env = DepsEnvInfo()
+        env.foo = "var"
+        env.foo.append("var2")
+        env.foo2 = "var3"
+        env.foo2 = "var4"
+        env.foo63 = "other"
+
+        self.assertEquals(env.vars, {"foo": ["var", "var2"], "foo2": "var4", "foo63": "other"})
+
+    def update_test(self):
+        env = DepsEnvInfo()
+        env.foo = "var"
+        env.foo.append("var2")
+        env.foo2 = "var3"
+        env.foo2 = "var4"
+        env.foo63 = "other"
+
+        env2 = DepsEnvInfo()
+        env2.foo = "new_value"
+        env2.foo2.append("not")
+        env2.foo3.append("var3")
+
+        env.update(env2, ConanFileReference.loads("pack/1.0@lasote/testing"))
+
+        self.assertEquals(env.vars, {"foo": ["var", "var2", "new_value"],
+                                     "foo2": "var4", "foo3": ["var3"],
+                                     "foo63": "other"})

--- a/conans/test/model/order_libs_test.py
+++ b/conans/test/model/order_libs_test.py
@@ -9,7 +9,7 @@ from conans.client.loader import ConanFileLoader
 from conans.util.files import save
 from conans.model.settings import Settings
 from conans.test.utils.test_files import temp_folder
-from conans.client.installer import init_cpp_info
+from conans.client.installer import init_info_objects
 from conans.model.scope import Scopes
 
 
@@ -86,8 +86,8 @@ class ConanRequirementsTest(unittest.TestCase):
         self.retriever.conan("SDL2_ttf", ["freeType", "SDL2"])
         root = self.retriever.root("MyProject", ["SDL2_ttf"])
         deps_graph = self.builder.load(None, root)
-        init_cpp_info(deps_graph, self.retriever)
-        bylevel = deps_graph.propagate_buildinfo()
+        init_info_objects(deps_graph, self.retriever)
+        bylevel = deps_graph.propagate_info_objects()
         E = bylevel[-1][0]
         self.assertEqual(E.conanfile.deps_cpp_info.libs,
                          ['SDL2_ttf', 'SDL2', 'rt', 'pthread', 'dl', 'freeType',


### PR DESCRIPTION
I'm not happy with the install method in manager. Now it creates in a tmp file a conanfile.txt file to emulate it when it receives a reference. It's necessary to process the reference as a depenency node in the graph because the generator needs the vars that the package reference declares.

About the rest, it's necessary to test virutalenv in OSx and Linux a lot, but basic usage is very good.
You can export this cmake recipe, should work in win but i've tested in linux:

https://github.com/lasote/conan-cmake-installer


