### PR TITLE
Fixed failure to detect compiler with Python 3

### DIFF
--- a/conans/client/detect.py
+++ b/conans/client/detect.py
@@ -15,7 +15,7 @@ def _execute(command):
         if not line:
             break
         # output.write(line)
-        output_buffer.append(line)
+        output_buffer.append(str(line))
 
     proc.communicate()
     return proc.returncode, "".join(output_buffer)


### PR DESCRIPTION
The compiler detection (at least linux, gcc) fails when using python 3, because the following line in conans.client.detect._execute throws an exception:
`return proc.returncode, "".join(output_buffer)`

The reason is that in Python 3 the output_buffer is a list of bytes, not strings.

This commit should fix that.
If you want, I can write a test for that as well, because I haven't tested it with Python 2, if you tell me in which file to put the test case - maybe conans/test/command/install_test.py?