### PR TITLE
Feature/cpp global dirs

### DIFF
--- a/conans/model/build_info.py
+++ b/conans/model/build_info.py
@@ -44,21 +44,21 @@ class CppInfo(_CppInfo):
         self.libdirs.append(DEFAULT_LIB)
         self.bindirs.append(DEFAULT_BIN)
         self.resdirs.append(DEFAULT_RES)
-        self.abs_includedirs = []
-        self.abs_libdirs = []
-        self.abs_bindirs = []
 
     @property
     def include_paths(self):
-        return [os.path.join(self.rootpath, p) for p in self.includedirs] + self.abs_includedirs
+        return [os.path.join(self.rootpath, p)
+                if not os.path.isabs(p) else p for p in self.includedirs]
 
     @property
     def lib_paths(self):
-        return [os.path.join(self.rootpath, p) for p in self.libdirs] + self.abs_libdirs
+        return [os.path.join(self.rootpath, p)
+                if not os.path.isabs(p) else p for p in self.libdirs]
 
     @property
     def bin_paths(self):
-        return [os.path.join(self.rootpath, p) for p in self.bindirs] + self.abs_bindirs
+        return [os.path.join(self.rootpath, p)
+                if not os.path.isabs(p) else p for p in self.bindirs]
 
 
 class DepsCppInfo(_CppInfo):

--- a/conans/model/build_info.py
+++ b/conans/model/build_info.py
@@ -44,18 +44,21 @@ class CppInfo(_CppInfo):
         self.libdirs.append(DEFAULT_LIB)
         self.bindirs.append(DEFAULT_BIN)
         self.resdirs.append(DEFAULT_RES)
+        self.abs_includedirs = []
+        self.abs_libdirs = []
+        self.abs_bindirs = []
 
     @property
     def include_paths(self):
-        return [os.path.join(self.rootpath, p) for p in self.includedirs]
+        return [os.path.join(self.rootpath, p) for p in self.includedirs] + self.abs_includedirs
 
     @property
     def lib_paths(self):
-        return [os.path.join(self.rootpath, p) for p in self.libdirs]
+        return [os.path.join(self.rootpath, p) for p in self.libdirs] + self.abs_libdirs
 
     @property
     def bin_paths(self):
-        return [os.path.join(self.rootpath, p) for p in self.bindirs]
+        return [os.path.join(self.rootpath, p) for p in self.bindirs] + self.abs_bindirs
 
 
 class DepsCppInfo(_CppInfo):

--- a/conans/test/model/build_info_test.py
+++ b/conans/test/model/build_info_test.py
@@ -33,9 +33,11 @@ class BuildInfoTest(unittest.TestCase):
     def cpp_info_test(self):
         folder = temp_folder()
         info = CppInfo(folder)
-        info.abs_includedirs.append("/usr/include")
-        info.abs_libdirs.append("/usr/lib")
-        info.abs_bindirs.append("/usr/bin")
+        info.includedirs.append("/usr/include")
+        info.libdirs.append("/usr/lib")
+        info.bindirs.append("C:/usr/bin")
+        info.bindirs.append("local_bindir")
         self.assertEqual(info.include_paths, [os.path.join(folder, "include"), "/usr/include"])
         self.assertEqual(info.lib_paths, [os.path.join(folder, "lib"), "/usr/lib"])
-        self.assertEqual(info.bin_paths, [os.path.join(folder, "bin"), "/usr/bin"])
+        self.assertEqual(info.bin_paths, [os.path.join(folder, "bin"), "C:/usr/bin",
+                                          os.path.join(folder, "local_bindir")])

--- a/conans/test/model/build_info_test.py
+++ b/conans/test/model/build_info_test.py
@@ -1,8 +1,10 @@
 import unittest
-from conans.model.build_info import DepsCppInfo
+import os
+from conans.model.build_info import DepsCppInfo, CppInfo
 from conans.client.generators import TXTGenerator
 from collections import namedtuple
 from conans.model.env_info import DepsEnvInfo
+from conans.test.utils.test_files import temp_folder
 
 
 class BuildInfoTest(unittest.TestCase):
@@ -27,3 +29,13 @@ class BuildInfoTest(unittest.TestCase):
         output = TXTGenerator(fakeconan(deps_cpp_info, None, deps_env_info, None)).content
         deps_cpp_info2 = DepsCppInfo.loads(output)
         self._equal(deps_cpp_info, deps_cpp_info2)
+
+    def cpp_info_test(self):
+        folder = temp_folder()
+        info = CppInfo(folder)
+        info.abs_includedirs.append("/usr/include")
+        info.abs_libdirs.append("/usr/lib")
+        info.abs_bindirs.append("/usr/bin")
+        self.assertEqual(info.include_paths, [os.path.join(folder, "include"), "/usr/include"])
+        self.assertEqual(info.lib_paths, [os.path.join(folder, "lib"), "/usr/lib"])
+        self.assertEqual(info.bin_paths, [os.path.join(folder, "bin"), "/usr/bin"])


### PR DESCRIPTION
This is why I did, very simple.

It should work for typical libraries without find.cmake, but the first example I was trying (Qt) uses findqt.cmake. For that case, it is still not enough, as actually, to let the system find the findqt.cmake script, you have to add something to the system path (I had for the windows DLLs) or add to CMAKE_PATH_PREFIX. Surprisingly the first one is enough for Qt, I'd say that CMake also looks for cmake modules in system path. Maybe it sounds as the case for the "env" generator, but still a bit weird for MSVC packages consuming Qt.