### PR TITLE
Feature/unicode exception output

### DIFF
--- a/conans/client/command.py
+++ b/conans/client/command.py
@@ -27,6 +27,7 @@ from conans.client.runner import ConanRunner
 from conans.client.remote_registry import RemoteRegistry
 from conans.model.scope import Scopes
 import re
+import six
 
 
 class Extender(argparse.Action):
@@ -681,11 +682,14 @@ path to the CMake binary directory, like this:
             logger.error(exc)
             errors = True
         except ConanException as exc:
-            logger.error(exc)
+            if six.PY2:
+                msg = unicode(exc)
+            else:
+                msg = str(exc)
 #             import traceback
 #             logger.debug(traceback.format_exc())
             errors = True
-            self._user_io.out.error(str(exc))
+            self._user_io.out.error(msg)
 
         return errors
 

--- a/conans/client/command.py
+++ b/conans/client/command.py
@@ -27,7 +27,6 @@ from conans.client.runner import ConanRunner
 from conans.client.remote_registry import RemoteRegistry
 from conans.model.scope import Scopes
 import re
-import six
 
 
 class Extender(argparse.Action):
@@ -682,9 +681,9 @@ path to the CMake binary directory, like this:
             logger.error(exc)
             errors = True
         except ConanException as exc:
-            if six.PY2:
+            try:
                 msg = unicode(exc)
-            else:
+            except:
                 msg = str(exc)
 #             import traceback
 #             logger.debug(traceback.format_exc())

--- a/conans/client/rest/rest_client.py
+++ b/conans/client/rest/rest_client.py
@@ -316,7 +316,10 @@ class RestApiClient(object):
             response.charset = "utf-8" # To be able to access ret.text (ret.content are bytes)
             raise get_exception_from_error(response.status_code)(response.text)
 
-        return json.loads(decode_text(response.content))
+        result = json.loads(decode_text(response.content))
+        if not isinstance(result, dict):
+            raise ConanException("Unexpected server response %s" % result)
+        return result
 
     @property
     def _remote_api_url(self):


### PR DESCRIPTION
This might solve issue https://github.com/conan-io/conan/issues/416

I have tried to build a test with some other ConanException containing unicode characters, but the test itself had many issues, not behaving like the real console. Hope in other terminals behave the same. I have manually tried in Win with Py3 and Py3.

I have setup a dummy server like this, and returning 400 and 200 to detect and propose the two fixes submitted:

```python
# -*- coding: utf-8 -*-
import time
import BaseHTTPServer

HOST_NAME = 'localhost' # !!!REMEMBER TO CHANGE THIS!!!
PORT_NUMBER = 8001 # Maybe set this to 9000.

class MyHandler(BaseHTTPServer.BaseHTTPRequestHandler):
  def do_HEAD(s):
    s.send_response(200)
    s.send_header("Content-type", "application/json")
    s.end_headers()

  def do_GET(s):
    """Respond to a GET request."""
    s.send_response(400)
    s.send_header("Content-type", "application/json")
    s.end_headers()
    s.wfile.write(r'"Üïöòìè"')

if __name__ == '__main__':
  server_class = BaseHTTPServer.HTTPServer
  httpd = server_class((HOST_NAME, PORT_NUMBER), MyHandler)
  print time.asctime(), "Server Starts - %s:%s" % (HOST_NAME, PORT_NUMBER)
  try:
    httpd.serve_forever()
  except KeyboardInterrupt:
    pass
  httpd.server_close()
  print time.asctime(), "Server Stops - %s:%s" % (HOST_NAME, PORT_NUMBER)
```