### PR TITLE
Peg cryptography module to less than version 1.5

### DIFF
--- a/conans/requirements_osx.txt
+++ b/conans/requirements_osx.txt
@@ -1,3 +1,4 @@
+cryptography>=1.3.4, <1.5
 pyOpenSSL>=16.0.0, <16.1.0
 ndg-httpsclient>=0.4.1, <0.5.0
 pyasn>=1.5.0b7, <1.6.0


### PR DESCRIPTION
This is in reference to issue #431 