### PR TITLE
disabled ConfigParser default conversion to lowercase

### DIFF
--- a/conans/server/conf/__init__.py
+++ b/conans/server/conf/__init__.py
@@ -22,10 +22,11 @@ MIN_CLIENT_COMPATIBLE_VERSION = '0.8.0'
 class ConanServerConfigParser(ConfigParser):
     """ defines the configuration of the server. It can load
     values from environment variables or from file.
-    Environment variables have PREDECENDENCE over file values
+    Environment variables have PRECEDENCE over file values
     """
     def __init__(self, base_folder, storage_folder=None, environment=os.environ):
         ConfigParser.__init__(self)
+        self.optionxform = str  # This line keeps the case of the key, important for users case
         self.conan_folder = os.path.join(base_folder, '.conan_server')
         self.config_filename = os.path.join(self.conan_folder, 'server.conf')
         self._loaded = False


### PR DESCRIPTION
The ``ConfigParser`` converts by default every key to lowercase, including the user names. See issue #423.

I think usernames with uppercase should be allowed, to match possible user names in conan.io, and other services as github. All the default files are already lowercase, so it shouldn't be a problem, but please check.