### PR TITLE
fixed conan.io msg in login other remotes. Removed default local

### DIFF
--- a/conans/client/remote_registry.py
+++ b/conans/client/remote_registry.py
@@ -6,7 +6,6 @@ import fasteners
 
 
 default_remotes = """conan.io https://server.conan.io
-local http://localhost:9300
 """
 
 Remote = namedtuple("Remote", "name url")

--- a/conans/client/rest/auth_manager.py
+++ b/conans/client/rest/auth_manager.py
@@ -36,10 +36,12 @@ def input_credentials_if_unauthorized(func):
             if self.user is None or self._rest_client.token is None:
                 # token is None when you change user with user command
                 # Anonymous is not enough, ask for a user
-                self._user_io.out.info('Please log in to perform this action. '
-                                       'Execute "conan user" command. '
-                                       'If you don\'t have an account sign up here: '
-                                       'http://www.conan.io')
+                remote = self.remote
+                self._user_io.out.info('Please log in to "%s" to perform this action. '
+                                       'Execute "conan user" command.' % remote.name)
+                if remote.name == "conan.io":
+                    self._user_io.out.info('If you don\'t have an account sign up here: '
+                                           'http://www.conan.io')
                 return retry_with_new_token(self, *args, **kwargs)
             else:
                 # If our user receives a ForbiddenException propagate it, not

--- a/conans/test/registry_test.py
+++ b/conans/test/registry_test.py
@@ -12,8 +12,11 @@ class RegistryTest(unittest.TestCase):
     def add_remove_update_test(self):
         f = os.path.join(temp_folder(), "aux_file")
         registry = RemoteRegistry(f, TestBufferConanOutput())
+
+        # Add
+        registry.add("local", "http://localhost:9300")
         self.assertEqual(registry.remotes, [("conan.io", "https://server.conan.io"),
-                                           ("local", "http://localhost:9300")])
+                                            ("local", "http://localhost:9300")])
         # Add
         registry.add("new", "new_url")
         self.assertEqual(registry.remotes, [("conan.io", "https://server.conan.io"),
@@ -21,7 +24,7 @@ class RegistryTest(unittest.TestCase):
                                             ("new", "new_url")])
         with self.assertRaises(ConanException):
             registry.add("new", "new_url")
-        #Update
+        # Update
         registry.update("new", "other_url")
         self.assertEqual(registry.remotes, [("conan.io", "https://server.conan.io"),
                                             ("local", "http://localhost:9300"),


### PR DESCRIPTION
This addresses issue #436 

I have also removed localhost from the default remotes.