### PR TITLE
Bump version requirements for requests and PyYAML

### DIFF
--- a/conans/requirements.txt
+++ b/conans/requirements.txt
@@ -1,9 +1,9 @@
 PyJWT>=1.4.0, <1.5.0
-requests>=2.7.0, <2.11.0
+requests>=2.7.0, <2.12.0
 colorama>=0.3.3, <0.4.0
 passlib>=1.6.5, <1.7.0
 boto>=2.38.0, <2.43.0
-PyYAML>=3.11, <3.12.0
+PyYAML>=3.11, <3.13.0
 patch==1.16
 fasteners>=0.14.1
 six>=1.10.0


### PR DESCRIPTION
In Arch Linux, requests got updated to 2.11.1 and PyYAML to 3.12.