### PR TITLE
adding tools.cpu_count

### DIFF
--- a/conans/test/tools_test.py
+++ b/conans/test/tools_test.py
@@ -1,9 +1,8 @@
-
 import unittest
 from conans.tools import SystemPackageTool, replace_in_file
 import os
 from conans.test.utils.test_files import temp_folder
-import codecs
+from conans import tools
 
 
 class RunnerMock(object):
@@ -46,6 +45,11 @@ class ReplaceInFileTest(unittest.TestCase):
 
 
 class ToolsTest(unittest.TestCase):
+
+    def cpu_count_test(self):
+        cpus = tools.cpu_count()
+        self.assertIsInstance(cpus, int)
+        self.assertGreaterEqual(cpus, 1)
 
     def system_package_tool_test(self):
 

--- a/conans/tools.py
+++ b/conans/tools.py
@@ -14,6 +14,7 @@ from conans.model.version import Version
 from conans.util.log import logger
 from conans.client.runner import ConanRunner
 from contextlib import contextmanager
+import multiprocessing
 
 
 @contextmanager
@@ -29,6 +30,14 @@ def vcvars_command(settings):
     command = ('call "%%vs%s0comntools%%../../VC/vcvarsall.bat" %s'
                % (settings.compiler.version, param))
     return command
+
+
+def cpu_count():
+    try:
+        return multiprocessing.cpu_count()
+    except NotImplementedError:
+        print("WARN: multiprocessing.cpu_count() not implemented. Defaulting to 1 cpu")
+    return 1  # Safe guess
 
 
 def human_size(size_bytes):


### PR DESCRIPTION
This should implement: https://github.com/conan-io/conan/issues/537

Note: I have NOT protected against an ImportError. Those errors where happening in the installer (deb, win), as pyinstaller didnt bundle multiprocessing. Now that the import is explicit to multiprocessing, it seems that the installer also work (tested in the installer in Win, should be tested in other OSs)

