### PR TITLE
do not automatically generate conanbuildinfo.txt for install ref

### DIFF
--- a/conans/client/loader.py
+++ b/conans/client/loader.py
@@ -189,7 +189,7 @@ class ConanFileLoader(object):
         # conanfile.options.values = options
         conanfile.options.initialize_upstream(options)
 
-        conanfile.generators = ["txt"]
+        conanfile.generators = []
         conanfile.scope = self._scopes.package_scope()
 
         return conanfile

--- a/conans/client/manager.py
+++ b/conans/client/manager.py
@@ -12,7 +12,7 @@ from conans.util.files import save, load, rmdir, normalize
 from conans.util.log import logger
 from conans.client.uploader import ConanUploader
 from conans.client.printer import Printer
-from conans.errors import NotFoundException, ConanException, format_conanfile_exception
+from conans.errors import NotFoundException, ConanException
 from conans.client.generators import write_generators
 from conans.client.importer import FileImporter
 from conans.model.ref import ConanFileReference, PackageReference

--- a/conans/test/integration/only_source_test.py
+++ b/conans/test/integration/only_source_test.py
@@ -114,12 +114,12 @@ class MyPackage(ConanFile):
         client.run("export lasote/stable")
 
         # Install, it will build automatically if missing (without the --build missing option)
-        client.run("install Hello0/1.0@lasote/stable")
+        client.run("install Hello0/1.0@lasote/stable -g txt")
         self.assertIn("Building", client.user_io.out)
         self.assertIn("Generated txt created conanbuildinfo.txt", client.user_io.out)
 
         # Try to do it again, now we have the package, so not build is done
-        client.run("install Hello0/1.0@lasote/stable")
+        client.run("install Hello0/1.0@lasote/stable -g txt")
         self.assertNotIn("Building", client.user_io.out)
         self.assertIn("Generated txt created conanbuildinfo.txt", client.user_io.out)
 
@@ -132,14 +132,14 @@ class MyPackage(ConanFile):
         client.run("export lasote/stable")
 
         # Install, it will build automatically if missing (without the --build missing option)
-        client.run("install Hello0/1.0@lasote/stable")
+        client.run("install Hello0/1.0@lasote/stable -g txt")
         self.assertIn("Detected build_policy 'always', trying to remove source folder",
                       client.user_io.out)
         self.assertIn("Building", client.user_io.out)
         self.assertIn("Generated txt created conanbuildinfo.txt", client.user_io.out)
 
         # Try to do it again, now we have the package, but we build again
-        client.run("install Hello0/1.0@lasote/stable")
+        client.run("install Hello0/1.0@lasote/stable -g txt")
         self.assertIn("Building", client.user_io.out)
         self.assertIn("Detected build_policy 'always', trying to remove source folder",
                       client.user_io.out)


### PR DESCRIPTION
This should solve issue: https://github.com/conan-io/conan/issues/545

Generating conanbuildinfo.txt not necessary, now you can specify it with ``-g txt`` argument