### PR TITLE
OSInfo fix: full_distribution_name should be specified to false ...

### DIFF
--- a/conans/tools.py
+++ b/conans/tools.py
@@ -215,7 +215,7 @@ class OSInfo(object):
         self.is_macos = platform.system() == "Darwin"
 
         if self.is_linux:
-            tmp = platform.linux_distribution()
+            tmp = platform.linux_distribution(full_distribution_name=0)
             self.linux_distro = None
             self.linux_distro = tmp[0].lower()
             self.os_version = Version(tmp[1])


### PR DESCRIPTION
…inorder for it to return the short version of the distro name. For example it will now return 'centos' instead of 'centos linux'