### PR TITLE
Touch files when getting the recipe. It fixes #556

### DIFF
--- a/conans/client/remote_manager.py
+++ b/conans/client/remote_manager.py
@@ -97,8 +97,8 @@ class RemoteManager(object):
         files = unzip_and_get_files(zipped_files, dest_folder, EXPORT_TGZ_NAME)
         # Make sure that the source dir is deleted
         rmdir(self._client_cache.source(conan_reference), True)
-        for dirname, _, files in os.walk(dest_folder):
-            for fname in files:
+        for dirname, _, filenames in os.walk(dest_folder):
+            for fname in filenames:
                 touch(os.path.join(dirname, fname))
 #       TODO: Download only the CONANFILE file and only download the rest of files
 #       in install if needed (not found remote package)
@@ -113,8 +113,8 @@ class RemoteManager(object):
         zipped_files = self._call_remote(remote, "get_package", package_reference, dest_folder)
         files = unzip_and_get_files(zipped_files, dest_folder, PACKAGE_TGZ_NAME)
         # Issue #214 https://github.com/conan-io/conan/issues/214
-        for dirname, _, files in os.walk(dest_folder):
-            for fname in files:
+        for dirname, _, filenames in os.walk(dest_folder):
+            for fname in filenames:
                 touch(os.path.join(dirname, fname))
 
         return files

--- a/conans/client/remote_manager.py
+++ b/conans/client/remote_manager.py
@@ -97,6 +97,9 @@ class RemoteManager(object):
         files = unzip_and_get_files(zipped_files, dest_folder, EXPORT_TGZ_NAME)
         # Make sure that the source dir is deleted
         rmdir(self._client_cache.source(conan_reference), True)
+        for dirname, _, files in os.walk(dest_folder):
+            for fname in files:
+                touch(os.path.join(dirname, fname))
 #       TODO: Download only the CONANFILE file and only download the rest of files
 #       in install if needed (not found remote package)
         return files


### PR DESCRIPTION
When we have files in the recipe with bad dates (epoch time) we need to touch the files to avoid problems as the one described in #556.

This change should fix that issue. 

Note that this piece of code could be extracted to a independent function and be reused in get_recipe and get_package, since it is exactly the same. I leave that improvement for the principal maintainers since I am not confident enough with python ;)