### PR TITLE
Command conan source working for local directories

### DIFF
--- a/conans/client/command.py
+++ b/conans/client/command.py
@@ -431,8 +431,8 @@ path to the CMake binary directory, like this:
                            scopes=scopes)
 
     def build(self, *args):
-        """ calls your project conanfile.py "build" method.
-            EX: conan build ./my_project
+        """ Calls your project conanfile.py "build" method.
+            E.g. conan build ./my_project
             Intended for package creators, requires a conanfile.py.
         """
         parser = argparse.ArgumentParser(description=self.build.__doc__, prog="conan build")
@@ -450,14 +450,14 @@ path to the CMake binary directory, like this:
         self._manager.build(root_path, current_path, filename=args.file, profile_name=args.profile)
 
     def package(self, *args):
-        """ calls your conanfile.py "package" method for a specific package or
+        """ Calls your conanfile.py "package" method for a specific package or
             regenerates the existing package's manifest.
             It will not create a new package, use 'install' or 'test_package' instead.
             Intended for package creators, for regenerating a package without
             recompiling the source, i.e. for troubleshooting,
             and fixing the package() method, not normal operation. It requires
             the package has been built locally, it will not re-package otherwise.
-            e.g. conan package MyPackage/1.2@user/channel 9cf83afd07b678da9c1645f605875400847ff3
+            E.g. conan package MyPackage/1.2@user/channel 9cf83afd07b678da9c1645f605875400847ff3
         """
         parser = argparse.ArgumentParser(description=self.package.__doc__, prog="conan package")
         parser.add_argument("reference", help='package recipe reference name. '
@@ -482,20 +482,21 @@ path to the CMake binary directory, like this:
             I.e., downloads and unzip the package source.
         """
         parser = argparse.ArgumentParser(description=self.source.__doc__, prog="conan source")
-        parser.add_argument("reference", help="package recipe reference name. e.g., zlib-ng/1.2.8@plex/stable")
+        parser.add_argument("reference", help="package recipe reference. e.g., MyPackage/1.2@user/channel or ./my_project/")
         parser.add_argument("-f", "--force", default=False, action="store_true", help="force remove the source directory and run again.")
 
         args = parser.parse_args(*args)
 
+        current_path = os.getcwd()
         try:
             reference = ConanFileReference.loads(args.reference)
         except:
-            raise ConanException("Invalid package recipe reference. e.g., zlib-ng/1.2.8@plex/stable")
+            reference = os.path.normpath(os.path.join(current_path, args.reference))
 
-        self._manager.source(reference, args.force)
+        self._manager.source(current_path, reference, args.force)
 
     def export(self, *args):
-        """ copies the package recipe (conanfile.py and associated files) to your local store,
+        """ Copies the package recipe (conanfile.py and associated files) to your local store,
         where it can be shared and reused in other projects.
         From that store, it can be uploaded to any remote with "upload" command.
         """

--- a/conans/client/manager.py
+++ b/conans/client/manager.py
@@ -339,7 +339,7 @@ If not:
         else:
             conan_file_path = self._client_cache.conanfile(reference)
             conan_file = self._loader().load_conan(conan_file_path, output)
-            src_folder = self._client_cache.source(reference, conanfile.short_paths)
+            src_folder = self._client_cache.source(reference, conan_file.short_paths)
             export_folder = self._client_cache.export(reference)
 
         config_source(export_folder, src_folder, conan_file, output, force)

--- a/conans/client/source.py
+++ b/conans/client/source.py
@@ -5,7 +5,6 @@ import six
 from conans.errors import ConanException, format_conanfile_exception
 import shutil
 
-
 def config_source(export_folder, src_folder, conan_file, output, force=False):
     """ creates src folder and retrieve, calling source() from conanfile
     the necessary source code
@@ -26,29 +25,51 @@ def config_source(export_folder, src_folder, conan_file, output, force=False):
             if raise_error or isinstance(e_rm, KeyboardInterrupt):
                 raise ConanException("Unable to remove source folder")
 
-    if force:
-        output.warn("Forced removal of source folder")
-        remove_source(raise_error=True)
-    elif os.path.exists(dirty):
-        output.warn("Trying to remove dirty source folder")
-        remove_source(raise_error=True)
-    elif conan_file.build_policy_always:
-        output.warn("Detected build_policy 'always', trying to remove source folder")
-        remove_source(raise_error=True)
+    def create_source_dirty_flag():
+        # Flag directory that we will try to download sources there
+        save(dirty, "")
 
-    if not source_exists(src_folder):
-        output.info('Configuring sources in %s' % src_folder)
-        shutil.copytree(export_folder, src_folder)
-        save(dirty, "")  # Creation of DIRTY flag
-        os.chdir(src_folder)
+    def clear_source_dirty_flag():
+        # Everything went well, remove flag
+        os.remove(dirty)
+
+    is_local = export_folder == None
+    if is_local:
+        if os.path.exists(dirty):
+            output.warn("Your previous source command failed")
+            clear_source_dirty_flag()
+
+        create_source_dirty_flag()
         try:
             conan_file.source()
-            os.remove(dirty)  # Everything went well, remove DIRTY flag
+            clear_source_dirty_flag()
         except Exception as e:
-            os.chdir(export_folder)
-            # in case source() fails (user error, typically), remove the src_folder
-            # and raise to interrupt any other processes (build, package)
-            output.warn("Trying to remove dirty source folder")
-            remove_source()
             msg = format_conanfile_exception(output.scope, "source", e)
             raise ConanException(msg)
+    else:
+        if force:
+            output.warn("Forced removal of source folder")
+            remove_source(raise_error=True)
+        elif os.path.exists(dirty):
+            output.warn("Trying to remove dirty source folder")
+            remove_source(raise_error=True)
+        elif conan_file.build_policy_always:
+            output.warn("Detected build_policy 'always', trying to remove source folder")
+            remove_source(raise_error=True)
+
+        if not source_exists(src_folder):
+            output.info('Configuring sources in %s' % src_folder)
+            shutil.copytree(export_folder, src_folder)
+            os.chdir(src_folder)
+            create_source_dirty_flag()
+            try:
+                conan_file.source()
+                clear_source_dirty_flag()
+            except Exception as e:
+                os.chdir(export_folder)
+                # in case source() fails (user error, typically), remove the src_folder
+                # and raise to interrupt any other processes (build, package)
+                output.warn("Trying to remove dirty source folder")
+                remove_source()
+                msg = format_conanfile_exception(output.scope, "source", e)
+                raise ConanException(msg)


### PR DESCRIPTION
I allowed myself to propose solution for #607 and #604. 
It will not change behavior for existing conan source < ref > command.
I tested it manually and it seems to work. Now I will try to write some tests to be sure :). Any hints and feedback appreciated. 

Briefly:
- allows user to call "conan source < directory_name >"
- will download whatever is specified in ConanFile source() command to current working directory
- behavior of dirty flag is slightly changed for local directories - it will warn user that source directory is dirty and continue anyway
- it will never delete local source directory (it assumes that user knows what he is doing)
- I also fixed help messages for build, export and package commands (minors - capital letters, etc.)

Unknowns:
- I'm not copying exports to source directory (current source command is copying them). Should I also add this?