### PR TITLE
Taking in account "ANY" config definition

### DIFF
--- a/conans/model/config_dict.py
+++ b/conans/model/config_dict.py
@@ -71,7 +71,7 @@ class ConfigItem(object):
         if other is None:
             return self._value is None
         other = str(other)
-        if other not in self.values_range:
+        if self._definition != "ANY" and other not in self.values_range:
             raise ConanException(bad_value_msg(self._name, other, self.values_range))
         return other == self.__str__()
 

--- a/conans/test/model/settings_test.py
+++ b/conans/test/model/settings_test.py
@@ -19,6 +19,12 @@ class SettingsTest(unittest.TestCase):
                 "os": ["Windows", "Linux"]}
         self.sut = Settings(data)
 
+    def any_test(self):
+        data = {"target": "ANY"}
+        sut = Settings(data)
+        sut.target = "native"
+        self.assertTrue(sut.target == "native")
+
     def remove_test(self):
         self.sut.remove("compiler")
         self.sut.os = "Windows"


### PR DESCRIPTION
When compairing a ConfigItem defined by `ANY`, it automatically failed because the `values_range` was empty. I just don't use `values_range`when defined by `ANY`