### PR TITLE
Sort file list when generating manifests

### DIFF
--- a/conans/model/manifest.py
+++ b/conans/model/manifest.py
@@ -14,14 +14,14 @@ class FileTreeManifest(object):
 
     def __repr__(self):
         ret = "%s" % (self.time)
-        for filepath, file_md5 in self.file_sums.items():
+        for filepath, file_md5 in sorted(self.file_sums.items()):
             ret += "\n%s: %s" % (filepath, file_md5)
         return ret
 
     @property
     def summary_hash(self):
         ret = ""  # Do not include the timestamp in the summary hash
-        for filepath, file_md5 in self.file_sums.items():
+        for filepath, file_md5 in sorted(self.file_sums.items()):
             ret += "\n%s: %s" % (filepath, file_md5)
         return md5(ret)
 


### PR DESCRIPTION
When manifests are stored in revision control system, it's necessary to
reduce differences to simplify review of changes. That requires reproducible
order of files, e.g. alphabetic sorting.