### PR TITLE
improved encoding failures

### DIFF
--- a/conans/client/command.py
+++ b/conans/client/command.py
@@ -762,10 +762,7 @@ path to the CMake binary directory, like this:
             logger.error(exc)
             errors = True
         except ConanException as exc:
-            try:
-                msg = unicode(exc)
-            except:
-                msg = str(exc)
+            msg = str(exc)
 #             import traceback
 #             logger.debug(traceback.format_exc())
             errors = True

--- a/conans/client/output.py
+++ b/conans/client/output.py
@@ -60,10 +60,15 @@ class ConanOutput(object):
         if self._color and (front or back):
             color = "%s%s" % (front or '', back or '')
             end = (Style.RESET_ALL + "\n") if newline else Style.RESET_ALL  # @UndefinedVariable
-            self._stream.write("%s%s%s" % (color, data, end))
+            data = "%s%s%s" % (color, data, end)
         else:
             if newline:
                 data = "%s\n" % data
+
+        try:
+            self._stream.write(data)
+        except UnicodeError:
+            data = data.encode("utf8").decode("ascii", "ignore")
             self._stream.write(data)
         self._stream.flush()
 

--- a/conans/client/remover.py
+++ b/conans/client/remover.py
@@ -15,16 +15,20 @@ class DiskRemover(object):
         try:
             logger.debug("Removing folder %s" % path)
             rm_conandir(path)
-        except OSError as e:
-            raise ConanException("%s: Unable to remove %s\n\t%s" % (repr(conan_ref), msg, str(e)))
+        except OSError:
+            error_msg = "Folder busy (open or some file open): %s" % path
+            raise ConanException("%s: Unable to remove %s\n\t%s"
+                                 % (repr(conan_ref), msg, error_msg))
 
     def _remove_file(self, path, conan_ref, msg=""):
         try:
             logger.debug("Removing folder %s" % path)
             if os.path.exists(path):
                 os.remove(path)
-        except OSError as e:
-            raise ConanException("Unable to remove %s %s\n\t%s" % (repr(conan_ref), msg, str(e)))
+        except OSError:
+            error_msg = "File busy (open): %s" % path
+            raise ConanException("Unable to remove %s %s\n\t%s"
+                                 % (repr(conan_ref), msg, error_msg))
 
     def remove(self, conan_ref):
         self.remove_src(conan_ref)

--- a/conans/test/output_test.py
+++ b/conans/test/output_test.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 import unittest
 from conans.client.output import ConanOutput
 from six import StringIO
@@ -8,6 +9,8 @@ import zipfile
 import os
 from conans.util.files import save, load
 import sys
+from conans.test.tools import TestClient
+from conans.client.userio import UserIO
 
 
 class OutputTest(unittest.TestCase):
@@ -19,6 +22,23 @@ class OutputTest(unittest.TestCase):
                             "because it is so long it doesn't fit in the output terminal")
         self.assertIn("This is a very long line that ha ... esn't fit in the output terminal",
                       stream.getvalue())
+
+    def error_test(self):
+        client = TestClient()
+        conanfile = """
+# -*- coding: utf-8 -*-
+
+from conans import ConanFile
+from conans.errors import ConanException
+
+class PkgConan(ConanFile):
+    def source(self):
+       self.output.info("TEXT ÑÜíóúéáàèòù абвгдежзийкл 做戏之说  ENDTEXT")
+"""
+        client.save({"conanfile.py": conanfile})
+        client.run("source")
+        self.assertIn("TEXT", client.user_io.out)
+        self.assertIn("ENDTEXT", client.user_io.out)
 
     def print_progress_test(self):
         stream = StringIO()


### PR DESCRIPTION
This should help with: https://github.com/conan-io/conan/issues/653

After many hours of trying different things, I have added a fallback ascii output when errors raise. Also, changed the messages from ``conan remove``, which OSError messages were the cause of some issues (when ran in Cyrillic or other alphabets, which typical Win terminal cp850 encodings cannot handle).

Lets see how it goes with CI...