### PR TITLE
Add line feeds at the end of generated manifests

### DIFF
--- a/conans/model/manifest.py
+++ b/conans/model/manifest.py
@@ -13,16 +13,16 @@ class FileTreeManifest(object):
         self.file_sums = file_sums
 
     def __repr__(self):
-        ret = "%s" % (self.time)
+        ret = "%s\n" % (self.time)
         for filepath, file_md5 in sorted(self.file_sums.items()):
-            ret += "\n%s: %s" % (filepath, file_md5)
+            ret += "%s: %s\n" % (filepath, file_md5)
         return ret
 
     @property
     def summary_hash(self):
         ret = ""  # Do not include the timestamp in the summary hash
         for filepath, file_md5 in sorted(self.file_sums.items()):
-            ret += "\n%s: %s" % (filepath, file_md5)
+            ret += "%s: %s\n" % (filepath, file_md5)
         return md5(ret)
 
     @staticmethod
@@ -34,8 +34,9 @@ class FileTreeManifest(object):
         time = int(tokens[0])
         file_sums = {}
         for md5line in tokens[1:]:
-            filename, file_md5 = md5line.split(": ")
-            file_sums[filename] = file_md5
+            if md5line:
+                filename, file_md5 = md5line.split(": ")
+                file_sums[filename] = file_md5
         return FileTreeManifest(time, file_sums)
 
     @classmethod


### PR DESCRIPTION
Conan generated manifests which didn't end with "\n" character. Such files
are shown by git with warning 'No newline at end of file', and they also
trigger warnings in style bot used by Qt review system. Editors like vim
add trailing line feed automatically, and it's generally considered to be
a good style for text files.

Also fixed parsing of anifest files ending with line feed.