### PR TITLE
Feature/fix remote search

### DIFF
--- a/conans/client/rest/rest_client.py
+++ b/conans/client/rest/rest_client.py
@@ -11,8 +11,7 @@ import os
 from conans.model.manifest import FileTreeManifest
 from conans.client.rest.uploader_downloader import Uploader, Downloader
 from conans.model.ref import ConanFileReference
-from six.moves.urllib.parse import urlsplit, parse_qs
-import urllib
+from six.moves.urllib.parse import urlsplit, parse_qs, urlencode
 
 
 def handle_return_deserializer(deserializer=None):
@@ -222,7 +221,7 @@ class RestApiClient(object):
             params = {"q": pattern}
             if not ignorecase:
                 params["ignorecase"] = "False"
-            query = "?%s" % urllib.urlencode(params)
+            query = "?%s" % urlencode(params)
 
         url = "%s/conans/search%s" % (self._remote_api_url, query)
         response = self._get_json(url)["results"]
@@ -232,7 +231,7 @@ class RestApiClient(object):
         url = "%s/conans/%s/search?" % (self._remote_api_url, "/".join(reference))
         if query:
             params = {"q": query}
-            url += urllib.urlencode(params)
+            url += urlencode(params)
         references = self._get_json(url)
         return references
 

--- a/conans/client/rest/rest_client.py
+++ b/conans/client/rest/rest_client.py
@@ -12,6 +12,7 @@ from conans.model.manifest import FileTreeManifest
 from conans.client.rest.uploader_downloader import Uploader, Downloader
 from conans.model.ref import ConanFileReference
 from six.moves.urllib.parse import urlsplit, parse_qs
+import urllib
 
 
 def handle_return_deserializer(deserializer=None):
@@ -218,19 +219,20 @@ class RestApiClient(object):
         """
         query = ''
         if pattern:
-            case_sensitive = "&ignorecase=False" if not ignorecase else ''
-            pattern = "q=%s" % pattern
-            query = "?%s%s" % (pattern, case_sensitive)
+            params = {"q": pattern}
+            if not ignorecase:
+                params["ignorecase"] = "False"
+            query = "?%s" % urllib.urlencode(params)
 
         url = "%s/conans/search%s" % (self._remote_api_url, query)
         response = self._get_json(url)["results"]
         return [ConanFileReference.loads(ref) for ref in response]
 
     def search_packages(self, reference, query):
-        url = "%s/conans/%s/search" % (self._remote_api_url, "/".join(reference))
+        url = "%s/conans/%s/search?" % (self._remote_api_url, "/".join(reference))
         if query:
-            url += "?q=%s" % query
-
+            params = {"q": query}
+            url += urllib.urlencode(params)
         references = self._get_json(url)
         return references
 

--- a/conans/test/command/search_test.py
+++ b/conans/test/command/search_test.py
@@ -1,10 +1,9 @@
 import unittest
 from conans.test.tools import TestClient, TestServer
 from conans.paths import PACKAGES_FOLDER, CONANINFO, EXPORT_FOLDER,\
-    CONAN_MANIFEST, CONANFILE
+    CONAN_MANIFEST
 import os
 from conans.model.manifest import FileTreeManifest
-from time import time
 import shutil
 
 


### PR DESCRIPTION
Fixes #691 
Rest client was not escaping well the query parameters so the "++" was not parsed well in remote searches.