### PR TITLE
minor fixes and worarounds around node-semver

### DIFF
--- a/conans/test/model/version_ranges_test.py
+++ b/conans/test/model/version_ranges_test.py
@@ -52,6 +52,25 @@ class BasicMaxVersionTest(unittest.TestCase):
         result = satisfying(["1.1.1", "1.1.2", "1.2", "1.2.1", "1.3", "2.1"], "1.8||1.3", output)
         self.assertEqual(result, "1.3")
 
+        result = satisfying(["1.3", "1.3.1"], "<1.3", output)
+        self.assertEqual(result, None)
+        result = satisfying(["1.3.0", "1.3.1"], "<1.3", output)
+        self.assertEqual(result, None)
+        result = satisfying(["1.3", "1.3.1"], "<=1.3", output)
+        self.assertEqual(result, "1.3")
+        result = satisfying(["1.3.0", "1.3.1"], "<=1.3", output)
+        self.assertEqual(result, "1.3.0")
+        # >2 means >=3.0.0-0
+        result = satisfying(["2.1"], ">2", output)
+        self.assertEqual(result, None)
+        result = satisfying(["2.1"], ">2.0", output)
+        self.assertEqual(result, "2.1")
+        # >2.1 means >=2.2.0-0
+        result = satisfying(["2.1.1"], ">2.1", output)
+        self.assertEqual(result, None)
+        result = satisfying(["2.1.1"], ">2.1.0", output)
+        self.assertEqual(result, "2.1.1")
+
 
 class Retriever(object):
     def __init__(self, loader, output):


### PR DESCRIPTION
This improves the behavior of the node-semver library used for version ranges, removing the annoying, version "2.1" not being solution for "<=2.1", plus avoid crashing for versions not semver, as "master".

It seems that with this we could avoid forking the upstream lib. Plus it is not fully clear to me a fix to such lib, without messing too much, as the source of the problem seems the prerelease part of the version being automatically added, might break things if removed or modified?

cc/ @DEGoodmanWilson 