### PR TITLE
Basic profile query commands: list and show

### DIFF
--- a/conans/client/client_cache.py
+++ b/conans/client/client_cache.py
@@ -153,3 +153,17 @@ class ClientCache(SimplePaths):
         if not os.path.exists(self.profiles_path):
             mkdir(self.profiles_path)
         return os.path.join(self.profiles_path, name)
+
+    def load_profile(self, name):
+        try:
+            text = load(self.profile_path(name))
+        except Exception:
+            current_profiles = ", ".join(self.current_profiles()) or "[]"
+            raise ConanException("Specified profile '%s' doesn't exist.\nExisting profiles: "
+                                 "%s" % (name, current_profiles))
+        return Profile.loads(text)
+
+    def current_profiles(self):
+        if not os.path.isdir(self.profiles_path):
+            return []
+        return [name for name in os.listdir(self.profiles_path) if not os.path.isdir(name)]

--- a/conans/client/command.py
+++ b/conans/client/command.py
@@ -32,7 +32,7 @@ from conans.util.log import logger
 from conans.util.env_reader import get_env
 from conans.util.files import rmdir, load, save_files
 from conans.util.config_parser import get_bool_from_text_value
-
+from conans.client.printer import Printer
 
 class Extender(argparse.Action):
     '''Allows to use the same flag several times in a command and creates a list with the values.
@@ -795,6 +795,25 @@ path to the CMake binary directory, like this:
             registry.remove_ref(args.reference)
         elif args.subcommand == "update_ref":
             registry.update_ref(args.reference, args.remote)
+
+    def profile(self, *args):
+        """ manage profiles
+        """
+        parser = argparse.ArgumentParser(description=self.profile.__doc__, prog="conan profile")
+        subparsers = parser.add_subparsers(dest='subcommand', help='sub-command help')
+
+        # create the parser for the "profile" command
+        subparsers.add_parser('list', help='list current profiles')
+        parser_show = subparsers.add_parser('show', help='show the values defined for a profile')
+        parser_show.add_argument('profile',  help='name of the profile')
+        args = parser.parse_args(*args)
+
+        if args.subcommand == "list":
+            for p in self._client_cache.current_profiles():
+                self._user_io.out.info(p)
+        elif args.subcommand == "show":
+            p = self._client_cache.load_profile(args.profile)
+            Printer(self._user_io.out).print_profile(args.profile, p)
 
     def _show_help(self):
         """ prints a summary of all commands

--- a/conans/client/printer.py
+++ b/conans/client/printer.py
@@ -177,9 +177,9 @@ class Printer(object):
             del scopes[_root]["dev"] # Ignore dev
             if not scopes[_root]:
                del scopes[_root] # Remove empty section
-        self._print_colored_line("[sections]")
+        self._print_colored_line("[scopes]")
         for section, values in scopes.items():
-            self._print_profile_section(section, values, indent=1)
+            self._print_profile_section(section, values.items(), indent=1)
 
     def _print_profile_section(self, name, items, indent=0):
         self._print_colored_line("[%s]" % name, indent=indent)

--- a/conans/client/printer.py
+++ b/conans/client/printer.py
@@ -1,6 +1,7 @@
 from conans.client.output import Color
 from conans.model.ref import PackageReference
 from conans.model.ref import ConanFileReference
+from conans.model.scope import _root
 from collections import OrderedDict
 
 
@@ -166,6 +167,24 @@ class Printer(object):
             if recipe_hash:
                 self._print_colored_line("outdated from recipe: %s" % (recipe_hash != package_recipe_hash), indent=2)
             self._out.writeln("")
+
+    def print_profile(self, name, profile):
+        self._out.info("Configuration for profile %s:\n" % name)
+        self._print_profile_section("settings", profile.settings)
+        self._print_profile_section("env", profile.env)
+        scopes = profile.scopes
+        if scopes[_root].get("dev", None):
+            del scopes[_root]["dev"] # Ignore dev
+            if not scopes[_root]:
+               del scopes[_root] # Remove empty section
+        self._print_colored_line("[sections]")
+        for section, values in scopes.items():
+            self._print_profile_section(section, values, indent=1)
+
+    def _print_profile_section(self, name, items, indent=0):
+        self._print_colored_line("[%s]" % name, indent=indent)
+        for key, value in items:
+            self._print_colored_line(key, value=value, indent=indent+1)
 
     def _print_colored_line(self, text, value=None, indent=0):
         """ Print a colored line depending on its indentation level


### PR DESCRIPTION
I've added a simple conan command to query available profiles:
- list: show the list of available profiles
- show <profile>: displays the profile

I'm not too fond of the [_root] hack in Scopes but I'm not certain I master Conan's code enough to propose a better alternative.