### PR TITLE
FreeBSD minimal support

### DIFF
--- a/conans/client/cmake.py
+++ b/conans/client/cmake.py
@@ -61,6 +61,9 @@ class CMake(object):
         if operating_system == "Macos":
             if compiler in ["gcc", "clang", "apple-clang"]:
                 return "Unix Makefiles"
+        if operating_system == "FreeBSD":
+            if compiler in ["gcc", "clang", "apple-clang"]:
+                return "Unix Makefiles"
 
         raise ConanException("Unknown cmake generator for these settings")
 

--- a/conans/client/conf/__init__.py
+++ b/conans/client/conf/__init__.py
@@ -11,7 +11,7 @@ from conans.paths import conan_expand_user
 MIN_SERVER_COMPATIBLE_VERSION = '0.12.0'
 
 default_settings_yml = """
-os: [Windows, Linux, Macos, Android, iOS]
+os: [Windows, Linux, Macos, Android, iOS, FreeBSD]
 arch: [x86, x86_64, ppc64le, ppc64, armv6, armv7, armv7hf, armv8]
 compiler:
     gcc:

--- a/conans/client/configure_environment.py
+++ b/conans/client/configure_environment.py
@@ -98,7 +98,7 @@ class ConfigureEnvironment(object):
 
     @property
     def command_line_env(self):
-        if self.os == "Linux" or self.os == "Macos":
+        if self.os == "Linux" or self.os == "Macos" or self.os == "FreeBSD":
             if self.compiler == "gcc" or "clang" in str(self.compiler):
                 return self._gcc_env()
         elif self.os == "Windows":

--- a/conans/tools.py
+++ b/conans/tools.py
@@ -225,6 +225,7 @@ class OSInfo(object):
         print(os_info.is_linux) # True/False
         print(os_info.is_windows) # True/False
         print(os_info.is_macos) # True/False
+        print(os_info.is_freebsd) # True/False
 
         print(os_info.linux_distro)  # debian, ubuntu, fedora, centos...
 
@@ -244,6 +245,7 @@ class OSInfo(object):
         self.linux_distro = None
         self.is_windows = platform.system() == "Windows"
         self.is_macos = platform.system() == "Darwin"
+        self.is_freebsd = platform.system() == "FreeBSD"
 
         if self.is_linux:
             tmp = platform.linux_distribution(full_distribution_name=0)
@@ -259,6 +261,9 @@ class OSInfo(object):
         elif self.is_macos:
             self.os_version = Version(platform.mac_ver()[0])
             self.os_version_name = self.get_osx_version_name(self.os_version)
+        elif self.is_freebsd:
+            self.os_version = self.get_freebsd_version()
+            self.os_version_name = "FreeBSD %s" % self.os_version
 
     @property
     def with_apt(self):
@@ -359,6 +364,9 @@ class OSInfo(object):
             return "Puma"
         elif version.minor() == "10.0.Z":
             return "Cheetha"
+
+    def get_freebsd_version(self):
+        return platform.release().split("-")[0]
 
 try:
     os_info = OSInfo()


### PR DESCRIPTION
Basic support for FreeBSD (#742):
- FreeBSD listed under os in the default settings
- CMake generators
- OSInfo tools (is_freebsd and os_version)