### PR TITLE
remove dependency on boto

### DIFF
--- a/conans/requirements.txt
+++ b/conans/requirements.txt
@@ -1,7 +1,6 @@
 PyJWT>=1.4.0, <1.5.0
 requests>=2.7.0, <2.13.0
 colorama>=0.3.3, <0.4.0
-boto>=2.38.0, <2.44.0
 PyYAML>=3.11, <3.13.0
 patch==1.16
 fasteners>=0.14.1


### PR DESCRIPTION
boto is not used by Conan. Remove the formal dependency from requirements.txt.