### PR TITLE
FreeBSD support, part 2

### DIFF
--- a/conans/client/cmake.py
+++ b/conans/client/cmake.py
@@ -61,6 +61,9 @@ class CMake(object):
         if operating_system == "Macos":
             if compiler in ["gcc", "clang", "apple-clang"]:
                 return "Unix Makefiles"
+        if operating_system == "FreeBSD":
+            if compiler in ["gcc", "clang", "apple-clang"]:
+                return "Unix Makefiles"
 
         raise ConanException("Unknown cmake generator for these settings")
 

--- a/conans/client/conf/__init__.py
+++ b/conans/client/conf/__init__.py
@@ -10,7 +10,7 @@ from conans.paths import conan_expand_user
 
 MIN_SERVER_COMPATIBLE_VERSION = '0.12.0'
 
-default_settings_yml = """os: [Windows, Linux, Macos, Android, iOS]
+default_settings_yml = """os: [Windows, Linux, Macos, Android, iOS, FreeBSD]
 arch: [x86, x86_64, ppc64le, ppc64, armv6, armv7, armv7hf, armv8]
 compiler:
     gcc:

--- a/conans/client/configure_environment.py
+++ b/conans/client/configure_environment.py
@@ -98,7 +98,7 @@ class ConfigureEnvironment(object):
 
     @property
     def command_line_env(self):
-        if self.os == "Linux" or self.os == "Macos":
+        if self.os == "Linux" or self.os == "Macos" or self.os == "FreeBSD":
             if self.compiler == "gcc" or "clang" in str(self.compiler):
                 return self._gcc_env()
         elif self.os == "Windows":

--- a/conans/client/detect.py
+++ b/conans/client/detect.py
@@ -127,8 +127,13 @@ def _detect_compiler_version(result, output):
             result.append(("compiler.runtime", "MD"))
         elif compiler == "apple-clang":
             result.append(("compiler.libcxx", "libc++"))
-        elif compiler == "gcc" or "clang" in compiler:
+        elif compiler == "gcc" in compiler:
             result.append(("compiler.libcxx", "libstdc++"))
+        elif compiler == "clang" in compiler:
+            if platform.system() == "FreeBSD":
+                result.append(("compiler.libcxx", "libc++"))
+            else:
+                result.append(("compiler.libcxx", "libstdc++"))
 
 
 def detected_os():

--- a/conans/test/model/other_settings_test.py
+++ b/conans/test/model/other_settings_test.py
@@ -93,7 +93,7 @@ from conans import ConanFile
 class SayConan(ConanFile):
     name = "Say"
     version = "0.1"
-    settings = {"os": ["Windows", "Linux", "Macos"], "compiler": ["Visual Studio"]}
+    settings = {"os": ["Windows", "Linux", "Macos", "FreeBSD"], "compiler": ["Visual Studio"]}
 """
 
         self.client.save({CONANFILE: content})

--- a/conans/test/model/settings_test.py
+++ b/conans/test/model/settings_test.py
@@ -58,7 +58,7 @@ class SettingsTest(unittest.TestCase):
         self.assertEqual(self.sut.os, "Linux")
 
     def loads_default_test(self):
-        settings = Settings.loads("""os: [Windows, Linux, Macos, Android]
+        settings = Settings.loads("""os: [Windows, Linux, Macos, Android, FreeBSD]
 arch: [x86, x86_64, arm]
 compiler:
     gcc:

--- a/conans/test/update_settings_yml_test.py
+++ b/conans/test/update_settings_yml_test.py
@@ -24,7 +24,7 @@ class ConanFileToolsTest(ConanFile):
         self.output.warn("Building...")
     '''
         prev_settings = """
-os: [Windows, Linux, Macos, Android]
+os: [Windows, Linux, Macos, Android, FreeBSD]
 arch: [x86, x86_64, armv6, armv7, armv7hf, armv8]
 compiler:
     gcc:

--- a/conans/tools.py
+++ b/conans/tools.py
@@ -225,6 +225,7 @@ class OSInfo(object):
         print(os_info.is_linux) # True/False
         print(os_info.is_windows) # True/False
         print(os_info.is_macos) # True/False
+        print(os_info.is_freebsd) # True/False
 
         print(os_info.linux_distro)  # debian, ubuntu, fedora, centos...
 
@@ -244,6 +245,7 @@ class OSInfo(object):
         self.linux_distro = None
         self.is_windows = platform.system() == "Windows"
         self.is_macos = platform.system() == "Darwin"
+        self.is_freebsd = platform.system() == "FreeBSD"
 
         if self.is_linux:
             tmp = platform.linux_distribution(full_distribution_name=0)
@@ -259,6 +261,9 @@ class OSInfo(object):
         elif self.is_macos:
             self.os_version = Version(platform.mac_ver()[0])
             self.os_version_name = self.get_osx_version_name(self.os_version)
+        elif self.is_freebsd:
+            self.os_version = self.get_freebsd_version()
+            self.os_version_name = "FreeBSD %s" % self.os_version
 
     @property
     def with_apt(self):
@@ -359,6 +364,9 @@ class OSInfo(object):
             return "Puma"
         elif version.minor() == "10.0.Z":
             return "Cheetha"
+
+    def get_freebsd_version(self):
+        return platform.release().split("-")[0]
 
 try:
     os_info = OSInfo()


### PR DESCRIPTION
For issue #742:
1. Change default compiler to clang with libc++ on FreeBSD
2. Fix a few unit tests with FreeBSD in acceptable OS in default config file

Four kinds of error and failure remain in tests:
1. g++ not available (it's not installed by default on FreeBSD). Maybe replace with a clang test for FreeBSD?
2. Assertions on env variables fail because only the labels are written in the outputs, not the values. Happen in "ProfileTest._assert_env_variable_printed()". No idea, couldn't find where those output lines are generated by the client.
3. Go isn't available (again not installed by default, could we make those optional?)
4. conan.conans.test.integration.python_diamond_test.PythonDiamondTest fails because it expects string like "Hello Hello4" and gets "Project: Build stuff Hello3". Not sure why, seems related to Python implementation on FreeBSD.
