### PR TITLE
my proposal for fixing the case-sensitive paths

### DIFF
--- a/conans/client/client_cache.py
+++ b/conans/client/client_cache.py
@@ -1,5 +1,5 @@
 import os
-from conans.util.files import save, load, path_exists, mkdir, normalize
+from conans.util.files import save, load, mkdir, normalize
 from conans.model.settings import Settings
 from conans.client.conf import ConanClientConfigParser, default_client_conf, default_settings_yml
 from conans.model.values import Values
@@ -122,7 +122,7 @@ class ClientCache(SimplePaths):
 
     def conan_manifests(self, conan_reference):
         digest_path = self.digestfile_conanfile(conan_reference)
-        if not path_exists(digest_path, self.store):
+        if not os.path.exists(digest_path):
             return None, None
         return self._digests(digest_path)
 

--- a/conans/client/proxy.py
+++ b/conans/client/proxy.py
@@ -1,5 +1,5 @@
 from conans.client.output import ScopedOutput
-from conans.util.files import path_exists, rmdir
+from conans.util.files import rmdir
 from conans.model.ref import PackageReference
 from conans.errors import (ConanException, ConanConnectionError, ConanOutdatedClient,
                            NotFoundException)
@@ -103,9 +103,8 @@ class ConanProxy(object):
 
         # check if it is in disk
         conanfile_path = self._client_cache.conanfile(conan_reference)
-        path_exist = path_exists(conanfile_path, self._client_cache.store)
 
-        if path_exist:
+        if os.path.exists(conanfile_path):
             if self._check_updates:
                 ret = self.update_available(conan_reference)
                 if ret != 0:  # Found and not equal

--- a/conans/client/remote_manager.py
+++ b/conans/client/remote_manager.py
@@ -7,7 +7,7 @@ import traceback
 from requests.exceptions import ConnectionError
 
 from conans.errors import ConanException, ConanConnectionError
-from conans.util.files import tar_extract, relative_dirs
+from conans.util.files import tar_extract, relative_dirs, rmdir
 from conans.util.log import logger
 from conans.paths import PACKAGE_TGZ_NAME, CONANINFO, CONAN_MANIFEST, CONANFILE, EXPORT_TGZ_NAME,\
     rm_conandir
@@ -108,8 +108,7 @@ class RemoteManager(object):
         Will iterate the remotes to find the conans unless remote was specified
 
         returns (dict relative_filepath:abs_path , remote_name)"""
-
-        rm_conandir(dest_folder)  # Remove first the destination folder
+        rmdir(dest_folder)  # Remove first the destination folder
         zipped_files = self._call_remote(remote, "get_recipe", conan_reference, dest_folder)
         files = unzip_and_get_files(zipped_files, dest_folder, EXPORT_TGZ_NAME)
         # Make sure that the source dir is deleted

--- a/conans/test/path_exists_test.py
+++ b/conans/test/path_exists_test.py
@@ -23,9 +23,9 @@ class PathExistsTest(unittest.TestCase):
 
         test_server = TestServer()
         self.servers = {"default": test_server}
-        self.client = TestClient(servers=self.servers, users={"default":[("lasote", "mypass")]})
+        self.client = TestClient(servers=self.servers, users={"default": [("lasote", "mypass")]})
 
-        files = cpp_hello_conan_files("Hello0", "0.1")
+        files = cpp_hello_conan_files("Hello0", "0.1", build=False)
 
         self.client.save(files)
         self.client.run("export lasote/stable")
@@ -35,12 +35,12 @@ class PathExistsTest(unittest.TestCase):
         self.client.run("upload Hello0/0.1@lasote/stable")
 
         # Now with requirements.txt (bug in server)
-        self.client = TestClient(servers=self.servers, users={"default":[("lasote", "mypass")]})
+        self.client = TestClient(servers=self.servers, users={"default": [("lasote", "mypass")]})
         self.client.save({"conanfile.txt": "[requires]\nHello0/0.1@lasote/stable\n[generators]\ntxt"})
         self.client.run("install --build missing ")
         build_info = load(os.path.join(self.client.current_folder, "conanbuildinfo.txt"))
         self.assertIn("helloHello0", build_info)
 
-        self.client = TestClient(servers=self.servers, users={"default":[("lasote", "mypass")]})
+        self.client = TestClient(servers=self.servers, users={"default": [("lasote", "mypass")]})
         self.client.save({"conanfile.txt": "[requires]\nhello0/0.1@lasote/stable\n[generators]\ntxt"})
         self.assertRaises(Exception, self.client.run, "install")

--- a/conans/util/files.py
+++ b/conans/util/files.py
@@ -126,18 +126,16 @@ def rmdir(path):
         raise
 
 
-def mkdir(path, raise_if_already_exists=False):
-    """Recursive mkdir. If dir already exists
-    only raise if raise_if_already_exists"""
+def mkdir(path):
+    """Recursive mkdir, doesnt fail if already existing"""
     try:
         os.makedirs(path)
     except OSError as err:
-        if err.errno == EEXIST and not raise_if_already_exists:
-            return
-        raise
+        if err.errno != EEXIST:
+            raise
 
 
-def path_exists(path, basedir=None):
+def path_exists(path, basedir):
     """Case sensitive, for windows, optional
     basedir for skip caps check for tmp folders in testing for example (returned always
     in lowercase for some strange reason)"""
@@ -146,15 +144,9 @@ def path_exists(path, basedir=None):
         return exists
 
     path = os.path.normpath(path)
-
-    if basedir:
-        path = os.path.relpath(path, basedir)
-        chunks = path.split(os.sep)
-        tmp = basedir
-    else:
-        chunks = path.split(os.sep)
-        tmp = chunks[0]  # Skip unit (c:)
-        chunks = chunks[1:]
+    path = os.path.relpath(path, basedir)
+    chunks = path.split(os.sep)
+    tmp = basedir
 
     for chunk in chunks:
         if chunk and chunk not in os.listdir(tmp):


### PR DESCRIPTION
NOT TO MERGE, a proposal to review:

- Remove ``path_exists`` from client operations
- Check in ``Paths``, always a conanfile path or conanfile manifest is requested
- Simplified files -> ``mkdir``, ``path_exists`` removing unused code
- Clean ``path_exists_test``, removing unnecessary slow build.

