### PR TITLE
Installer refactor + #772

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,4 +37,5 @@ before_script:
   - export CONAN_LOGGING_LEVEL=10
 # command to run tests
 script: 
+  - ulimit -n 2048 # Error with py3 and OSX, max file descriptors
   - ./.ci/travis/run.sh

--- a/conans/client/command.py
+++ b/conans/client/command.py
@@ -34,6 +34,7 @@ from conans.util.files import rmdir, load, save_files
 from conans.util.config_parser import get_bool_from_text_value
 from conans.client.printer import Printer
 
+
 class Extender(argparse.Action):
     '''Allows to use the same flag several times in a command and creates a list with the values.
        For example:
@@ -466,14 +467,20 @@ path to the CMake binary directory, like this:
         parser.add_argument("--update", "-u", action='store_true', default=False,
                             help="check updates exist from upstream remotes")
         parser.add_argument("--build_order", "-bo",
-                            help='given a modified reference, return ordered list to build (CI)',
+                            help='given a modified reference, return an ordered list to build (CI)',
                             nargs=1, action=Extender)
+        parser.add_argument("--build", "-b", action=Extender, nargs="*",
+                            help='given a build policy (same install command "build" parameter), '
+                                 'return an ordered list of packages that would be built from '
+                                 'sources in install command')
         parser.add_argument("--scope", "-sc", nargs=1, action=Extender,
                             help='Define scopes for packages')
         args = parser.parse_args(*args)
 
         options = self._get_tuples_list_from_extender_arg(args.options)
         settings, package_settings = self._get_simple_and_package_tuples(args.settings)
+        # Get False or a list of patterns to check
+        args.build = self._get_build_sources_parameter(args.build)
         current_path = os.getcwd()
         try:
             reference = ConanFileReference.loads(args.reference)
@@ -490,6 +497,7 @@ path to the CMake binary directory, like this:
                            check_updates=args.update,
                            filename=args.file,
                            build_order=args.build_order,
+                           build_mode=args.build,
                            scopes=scopes)
 
     def build(self, *args):

--- a/conans/client/deps_builder.py
+++ b/conans/client/deps_builder.py
@@ -381,8 +381,7 @@ class DepsGraphBuilder(object):
         try:
             if hasattr(conanfile, "config"):
                 if not conanref:
-                    ref_print = conanref or "PROJECT"
-                    output = ScopedOutput(str(ref_print), self._output)
+                    output = ScopedOutput(str("PROJECT"), self._output)
                     output.warn("config() has been deprecated."
                                 " Use config_options and configure")
                 conanfile.config()

--- a/conans/client/deps_builder.py
+++ b/conans/client/deps_builder.py
@@ -351,6 +351,10 @@ class DepsGraphBuilder(object):
             new_loop_ancestors.append(require.conan_reference)
             previous_node = public_deps.get(name)
             if require.private or not previous_node:  # new node, must be added and expanded
+                # TODO: if we could detect that current node has an available package
+                # we could not download the private dep. See installer _compute_private_nodes
+                # maybe we could move these functionality to here and build only the graph
+                # with the nodes to be took in account
                 new_node = self._create_new_node(node, dep_graph, require, public_deps, name)
                 if new_node:
                     # RECURSION!
@@ -377,8 +381,10 @@ class DepsGraphBuilder(object):
         try:
             if hasattr(conanfile, "config"):
                 if not conanref:
-                    self._output.warn("config() has been deprecated."
-                                      " Use config_options and configure")
+                    ref_print = conanref or "PROJECT"
+                    output = ScopedOutput(str(ref_print), self._output)
+                    output.warn("config() has been deprecated."
+                                " Use config_options and configure")
                 conanfile.config()
             conanfile.config_options()
             conanfile.options.propagate_upstream(down_options, down_ref, conanref, self._output)

--- a/conans/client/deps_builder.py
+++ b/conans/client/deps_builder.py
@@ -279,7 +279,7 @@ class DepsGraph(object):
         return result
 
 
-class DepsBuilder(object):
+class DepsGraphBuilder(object):
     """ Responsible for computing the dependencies graph DepsGraph
     """
     def __init__(self, retriever, output, loader, resolver):

--- a/conans/client/installer.py
+++ b/conans/client/installer.py
@@ -85,26 +85,6 @@ class ConanInstaller(object):
         skippable_nodes = deps_graph.private_nodes(skip_nodes)
         return skippable_nodes
 
-    def _build_forced(self, conan_ref, build_mode, conan_file):
-        if build_mode == "outdated":
-            return False
-
-        if conan_file.build_policy_always:
-            out = ScopedOutput(str(conan_ref), self._out)
-            out.info("Building package from source as defined by build_policy='always'")
-            return True
-
-        if build_mode is False:  # "never" option, default
-            return False
-
-        if build_mode is True:  # Build missing (just if needed), not force
-            return False
-
-        # Patterns to match, if package matches pattern, build is forced
-        force_build = any([fnmatch.fnmatch(str(conan_ref), pattern)
-                           for pattern in build_mode])
-        return force_build
-
     def _build(self, nodes_by_level, skip_private_nodes, build_mode):
         """ The build assumes an input of conans ordered by degree, first level
         should be indpendent from each other, the next-second level should have
@@ -363,3 +343,23 @@ Package configuration:
         except Exception as e:
             msg = format_conanfile_exception(str(conan_ref), "package_info", e)
             raise ConanException(msg)
+
+    def _build_forced(self, conan_ref, build_mode, conan_file):
+        if build_mode == "outdated":
+            return False
+
+        if conan_file.build_policy_always:
+            out = ScopedOutput(str(conan_ref), self._out)
+            out.info("Building package from source as defined by build_policy='always'")
+            return True
+
+        if build_mode is False:  # "never" option, default
+            return False
+
+        if build_mode is True:  # Build missing (just if needed), not force
+            return False
+
+        # Patterns to match, if package matches pattern, build is forced
+        force_build = any([fnmatch.fnmatch(str(conan_ref), pattern)
+                           for pattern in build_mode])
+        return force_build

--- a/conans/client/installer.py
+++ b/conans/client/installer.py
@@ -91,6 +91,14 @@ class ConanInstaller(object):
         skippable_private_nodes = deps_graph.private_nodes(skip_nodes)
         return skippable_private_nodes
 
+    def nodes_to_build(self, deps_graph, build_mode):
+        """Called from info command when a build policy is used in build_order parameter"""
+        # Get the nodes in order and if we have to build them
+        nodes_by_level = deps_graph.by_levels()
+        skip_private_nodes = self._compute_private_nodes(deps_graph, build_mode)
+        nodes = self._get_nodes(nodes_by_level, skip_private_nodes, build_mode)
+        return [(conan_ref, conan_file) for conan_ref, conan_file, build in nodes if build]
+
     def _build(self, nodes_by_level, skip_private_nodes, build_mode):
         """ The build assumes an input of conans ordered by degree, first level
         should be independent from each other, the next-second level should have

--- a/conans/client/installer.py
+++ b/conans/client/installer.py
@@ -139,7 +139,7 @@ class ConanInstaller(object):
             self._build_and_package(conan_ref, package_reference, package_folder, conan_file, output)
             self._call_package_info(conan_file, conan_ref)
 
-    def _get_nodes_to_build(self, nodes_by_level, skip_private_nodes, build_mode):
+    def _get_nodes_to_build(self, nodes_by_level, skip_nodes, build_mode):
         """Install the available packages if needed/allowed and return a list
         of nodes to build (tuples (conan_file, conan_ref))
         and installed nodes"""
@@ -154,7 +154,7 @@ class ConanInstaller(object):
         # Now build each level, starting from the most independent one
         for level in nodes_by_level:
             for node in level:
-                if node in skip_private_nodes:
+                if node in skip_nodes:
                     continue
                 conan_ref, conan_file = node
 

--- a/conans/client/manager.py
+++ b/conans/client/manager.py
@@ -217,7 +217,7 @@ class ConanManager(object):
         if build_mode is not False:  # sim_install is a policy or list of names (same as install build param)
             installer = ConanInstaller(self._client_cache, self._user_io, remote_proxy)
             nodes = installer.nodes_to_build(deps_graph, build_mode)
-            self._user_io.out.info("[%s]" % ", ".join(str(ref) for ref, _ in nodes))
+            self._user_io.out.info(", ".join(str(ref) for ref, _ in nodes))
             return
 
         if check_updates:

--- a/conans/client/manager.py
+++ b/conans/client/manager.py
@@ -5,7 +5,7 @@ from collections import OrderedDict
 from conans.paths import (CONANFILE, CONANINFO, CONANFILE_TXT, BUILD_INFO, CONANENV)
 from conans.client.loader import ConanFileLoader
 from conans.client.export import export_conanfile
-from conans.client.deps_builder import DepsBuilder
+from conans.client.deps_builder import DepsGraphBuilder
 from conans.client.userio import UserIO
 from conans.client.installer import ConanInstaller
 from conans.util.files import save, load, rmdir, normalize
@@ -181,7 +181,7 @@ class ConanManager(object):
         # build deps graph and install it
         local_search = None if update else self._search_manager
         resolver = RequireResolver(self._user_io.out, local_search, remote_proxy)
-        builder = DepsBuilder(remote_proxy, self._user_io.out, loader, resolver)
+        builder = DepsGraphBuilder(remote_proxy, self._user_io.out, loader, resolver)
         deps_graph = builder.load(None, conanfile)
         # These lines are so the conaninfo stores the correct complete info
         if is_txt:

--- a/conans/client/proxy.py
+++ b/conans/client/proxy.py
@@ -47,8 +47,6 @@ class ConanProxy(object):
                 remote_info = self.get_package_info(package_ref)
             except ConanException:
                 return False  # Not local nor remote
-        else:
-            output.info('Already installed!')
 
         # Maybe we have the package (locally or in remote) but it's outdated
         if check_outdated:

--- a/conans/client/remote_manager.py
+++ b/conans/client/remote_manager.py
@@ -102,6 +102,14 @@ class RemoteManager(object):
         returns (ConanDigest, remote_name)"""
         return self._call_remote(remote, "get_package_digest", package_reference)
 
+    def get_package_info(self, package_reference, remote):
+        """
+        Read a package ConanInfo from remotes
+        Will iterate the remotes to find the conans unless remote was specified
+
+        returns (ConanInfo, remote_name)"""
+        return self._call_remote(remote, "get_package_info", package_reference)
+
     def get_recipe(self, conan_reference, dest_folder, remote):
         """
         Read the conans from remotes

--- a/conans/client/rest/auth_manager.py
+++ b/conans/client/rest/auth_manager.py
@@ -151,6 +151,10 @@ class ConanApiAuthManager(object):
         return self._rest_client.get_package(package_reference, dest_folder)
 
     @input_credentials_if_unauthorized
+    def get_package_info(self, package_reference):
+        return self._rest_client.get_package_info(package_reference)
+
+    @input_credentials_if_unauthorized
     def search(self, pattern, ignorecase):
         return self._rest_client.search(pattern, ignorecase)
 

--- a/conans/test/download_test.py
+++ b/conans/test/download_test.py
@@ -67,7 +67,7 @@ class DownloadTest(unittest.TestCase):
         installer = ConanProxy(client2.paths, client2.user_io, client2.remote_manager, "default")
 
         installer.get_recipe(conan_ref)
-        installer.get_package(package_ref, force_build=False, short_paths=False, check_outdated=False)
+        installer.get_package(package_ref, short_paths=False)
         # Check that the output is done in order
         lines = [line.strip() for line in str(client2.user_io.out).splitlines()
                  if line.startswith("Downloading")]

--- a/conans/test/integration/info_test.py
+++ b/conans/test/integration/info_test.py
@@ -1,0 +1,113 @@
+import unittest
+from conans.test.tools import TestClient, TestServer
+from conans.test.utils.cpp_test_files import cpp_hello_conan_files
+from conans.paths import CONANFILE
+import os
+from conans.util.files import load, save
+
+
+class InfoTest(unittest.TestCase):
+
+    def setUp(self):
+        test_server = TestServer(users={"lu": "mypass"})
+        self.servers = {"default": test_server}
+        self.clients = {}
+
+    def _export(self, name=0, version=None, deps=None):
+        client = TestClient(servers=self.servers, users={"default": [("lu", "mypass")]})
+        self.clients[name] = client
+        files = cpp_hello_conan_files(name, version, deps)
+        client.save(files, clean_first=True)
+        client.run("export lu/st")
+        client.run("upload %s/%s@lu/st" % (name, version))
+
+    def assert_last_line(self, client, line):
+        lastline = str(client.user_io.out).splitlines()[-1]
+        self.assertEquals(lastline, line)
+
+    def info_build_test(self):
+        """Test that the output of 'conan info --build' is correct
+
+                    +-----------+
+           +------> |  H0       | <--------+
+           |        +------+----+          |
+   private |               ^               |private
+           |               |               |
+      +----+-----+    +----+------+   +----+------+
+      |  H1a     |    | H1b       |   | H1c       |
+      +----+-----+    +-----------+   +----+------+
+           ^                               ^
+           |                               |
+           |                               |
++----------+-+                     +-------+------+
+|  H2a       | <------+    +-----> |   H2c        |
++------------+        |    |       +--------------+
+                      |    |
+                  +---+----+---+
+                  |  H3        |
+                  +------------+
+
+        """
+
+        self._export("H0", "0.1")
+
+        self._export("H1a", "0.1", deps=[("H0/0.1@lu/st", "private")])
+        self._export("H1b", "0.1", deps=["H0/0.1@lu/st"])
+        self._export("H1c", "0.1", deps=[("H0/0.1@lu/st", "private")])
+
+        self._export("H2a", "0.1", deps=["H1a/0.1@lu/st"])
+        self._export("H2c", "0.1", deps=["H1c/0.1@lu/st"])
+
+        self._export("H3", "0.1", deps=["H2a/0.1@lu/st",
+                                        "H2c/0.1@lu/st"])
+
+        # If we install H3 we need to build all except H1b
+        self.clients["H3"].run("info --build missing")
+        self.assert_last_line(self.clients["H3"],
+                              "[H0/0.1@lu/st, H0/0.1@lu/st, H1a/0.1@lu/st, H1c/0.1@lu/st, H2a/0.1@lu/st, H2c/0.1@lu/st]")
+
+        # If we install H0 we need to build nothing (current project)
+        self.clients["H0"].run("info --build missing")
+        self.assert_last_line(self.clients["H0"], "[]")
+
+        # If we install H0 we need to build H0
+        self.clients["H1a"].run("info --build missing")
+        self.assert_last_line(self.clients["H1a"], "[H0/0.1@lu/st]")
+
+        # If we build and upload H1a and H1c, no more H0 (private) is required
+        self.clients["H3"].run("install H1a/0.1@lu/st --build ")
+        self.clients["H3"].run("install H1c/0.1@lu/st --build ")
+        self.clients["H3"].run("upload H1a/0.1@lu/st --all")
+        self.clients["H3"].run("upload H1c/0.1@lu/st --all")
+
+        self.clients["H3"].run("remove '*' -f")
+        self.clients["H3"].run("info --build missing")
+        self.assert_last_line(self.clients["H3"],
+                              "[H2a/0.1@lu/st, H2c/0.1@lu/st]")
+
+        # But if we force to build all, all nodes have to be built
+        self.clients["H3"].run("remove '*' -f")
+        self.clients["H3"].run("info --build")
+        self.assert_last_line(self.clients["H3"],
+                              "[H0/0.1@lu/st, H0/0.1@lu/st, H1a/0.1@lu/st, H1c/0.1@lu/st, H2a/0.1@lu/st, H2c/0.1@lu/st]")
+
+        # Now upgrade the recipe H1a and upload it (but not the package)
+        # so the package become outdated
+        conanfile_path = os.path.join(self.clients["H1a"].current_folder, CONANFILE)
+        conanfile = load(conanfile_path)
+        conanfile += "\n# MODIFIED"
+        save(conanfile_path, conanfile)
+        self.clients["H1a"].run("export lu/st")
+        self.clients["H1a"].run("upload H1a/0.1@lu/st")  # NOW IS OUTDATED!
+
+        # Without build outdated the built packages are the same
+        self.clients["H3"].run("remove '*' -f")
+        self.clients["H3"].run("info --build missing")
+        self.assert_last_line(self.clients["H3"],
+                              "[H2a/0.1@lu/st, H2c/0.1@lu/st]")
+
+        # But with build outdated we have to build the private H0 (but only once) and H1a
+        self.clients["H3"].run("remove '*' -f")
+        self.clients["H3"].run("info --build outdated")
+        self.assert_last_line(self.clients["H3"],
+                              "[H0/0.1@lu/st, H1a/0.1@lu/st, H2a/0.1@lu/st, H2c/0.1@lu/st]")

--- a/conans/test/integration/info_test.py
+++ b/conans/test/integration/info_test.py
@@ -64,15 +64,15 @@ class InfoTest(unittest.TestCase):
         # If we install H3 we need to build all except H1b
         self.clients["H3"].run("info --build missing")
         self.assert_last_line(self.clients["H3"],
-                              "[H0/0.1@lu/st, H0/0.1@lu/st, H1a/0.1@lu/st, H1c/0.1@lu/st, H2a/0.1@lu/st, H2c/0.1@lu/st]")
+                              "H0/0.1@lu/st, H0/0.1@lu/st, H1a/0.1@lu/st, H1c/0.1@lu/st, H2a/0.1@lu/st, H2c/0.1@lu/st")
 
         # If we install H0 we need to build nothing (current project)
         self.clients["H0"].run("info --build missing")
-        self.assert_last_line(self.clients["H0"], "[]")
+        self.assert_last_line(self.clients["H0"], "")
 
         # If we install H0 we need to build H0
         self.clients["H1a"].run("info --build missing")
-        self.assert_last_line(self.clients["H1a"], "[H0/0.1@lu/st]")
+        self.assert_last_line(self.clients["H1a"], "H0/0.1@lu/st")
 
         # If we build and upload H1a and H1c, no more H0 (private) is required
         self.clients["H3"].run("install H1a/0.1@lu/st --build ")
@@ -83,13 +83,13 @@ class InfoTest(unittest.TestCase):
         self.clients["H3"].run("remove '*' -f")
         self.clients["H3"].run("info --build missing")
         self.assert_last_line(self.clients["H3"],
-                              "[H2a/0.1@lu/st, H2c/0.1@lu/st]")
+                              "H2a/0.1@lu/st, H2c/0.1@lu/st")
 
         # But if we force to build all, all nodes have to be built
         self.clients["H3"].run("remove '*' -f")
         self.clients["H3"].run("info --build")
         self.assert_last_line(self.clients["H3"],
-                              "[H0/0.1@lu/st, H0/0.1@lu/st, H1a/0.1@lu/st, H1c/0.1@lu/st, H2a/0.1@lu/st, H2c/0.1@lu/st]")
+                              "H0/0.1@lu/st, H0/0.1@lu/st, H1a/0.1@lu/st, H1c/0.1@lu/st, H2a/0.1@lu/st, H2c/0.1@lu/st")
 
         # Now upgrade the recipe H1a and upload it (but not the package)
         # so the package become outdated
@@ -104,10 +104,10 @@ class InfoTest(unittest.TestCase):
         self.clients["H3"].run("remove '*' -f")
         self.clients["H3"].run("info --build missing")
         self.assert_last_line(self.clients["H3"],
-                              "[H2a/0.1@lu/st, H2c/0.1@lu/st]")
+                              "H2a/0.1@lu/st, H2c/0.1@lu/st")
 
         # But with build outdated we have to build the private H0 (but only once) and H1a
         self.clients["H3"].run("remove '*' -f")
         self.clients["H3"].run("info --build outdated")
         self.assert_last_line(self.clients["H3"],
-                              "[H0/0.1@lu/st, H1a/0.1@lu/st, H2a/0.1@lu/st, H2c/0.1@lu/st]")
+                              "H0/0.1@lu/st, H1a/0.1@lu/st, H2a/0.1@lu/st, H2c/0.1@lu/st")

--- a/conans/test/integration/install_outdated_test.py
+++ b/conans/test/integration/install_outdated_test.py
@@ -25,7 +25,6 @@ class InstallOutdatedPackagesTest(unittest.TestCase):
     def install_outdated_test(self):
         # If we try to install the same package with --build oudated it's already ok
         self.client.run("install Hello0/0.1@lasote/stable --build outdated")
-        self.assertIn("Hello0/0.1@lasote/stable: Already installed!", self.client.user_io.out)
         self.assertIn("Hello0/0.1@lasote/stable: Package is up to date", self.client.user_io.out)
 
         # Then we can export a modified recipe and try to install without --build outdated
@@ -40,7 +39,6 @@ class InstallOutdatedPackagesTest(unittest.TestCase):
 
         # Try now with the --build outdated
         self.client.run("install Hello0/0.1@lasote/stable --build outdated")
-        self.assertIn("Hello0/0.1@lasote/stable: Already installed!", self.client.user_io.out)
         self.assertNotIn("Package is up to date", self.client.user_io.out)
         self.assertIn("Outdated package!", self.client.user_io.out)
         self.assertIn("Building your package", self.client.user_io.out)

--- a/conans/test/integration/install_outdated_test.py
+++ b/conans/test/integration/install_outdated_test.py
@@ -52,7 +52,6 @@ class InstallOutdatedPackagesTest(unittest.TestCase):
         self.client.run("export lasote/stable")
         self.client.run("remote add_ref Hello0/0.1@lasote/stable default")
         self.client.run("install Hello0/0.1@lasote/stable --build outdated")
-        self.assertIn("Downloading conan_package.tgz", self.client.user_io.out)
         self.assertNotIn("Hello0/0.1@lasote/stable: Already installed!", self.client.user_io.out)
         self.assertNotIn("Package is up to date", self.client.user_io.out)
         self.assertIn("Outdated package!", self.client.user_io.out)
@@ -88,9 +87,8 @@ class InstallOutdatedPackagesTest(unittest.TestCase):
         self.assertIn("Hello0/0.1@lasote/stable: Package is up to date", new_client.user_io.out)
 
         # But if we remove the full Hello0 local package, will retrieve the updated
-        # recipe and an the outdated package
+        # recipe and the outdated package
         new_client.run("remove Hello0* -f")
         new_client.run("install Hello1/0.1@lasote/stable --build outdated")
-        self.assertIn("Downloading conan_package.tgz", new_client.user_io.out)
         self.assertIn("Hello0/0.1@lasote/stable: Outdated package!", new_client.user_io.out)
         self.assertIn("Hello0/0.1@lasote/stable: Building your package", new_client.user_io.out)

--- a/conans/test/model/transitive_reqs_test.py
+++ b/conans/test/model/transitive_reqs_test.py
@@ -2,7 +2,7 @@ import unittest
 from conans.test.tools import TestBufferConanOutput
 from conans.paths import CONANFILE
 import os
-from conans.client.deps_builder import DepsBuilder
+from conans.client.deps_builder import DepsGraphBuilder
 from conans.model.ref import ConanFileReference
 from conans.model.options import OptionsValues
 from conans.client.loader import ConanFileLoader
@@ -130,7 +130,7 @@ class ConanRequirementsTest(unittest.TestCase):
                                       OptionsValues.loads(""), Scopes(),
                                       env=[], package_env={})
         self.retriever = Retriever(self.loader, self.output)
-        self.builder = DepsBuilder(self.retriever, self.output, self.loader, MockRequireResolver())
+        self.builder = DepsGraphBuilder(self.retriever, self.output, self.loader, MockRequireResolver())
 
     def root(self, content):
         root_conan = self.retriever.root(content)
@@ -1427,7 +1427,7 @@ class CoreSettingsTest(unittest.TestCase):
         loader = ConanFileLoader(None, full_settings, None, options, Scopes(),
                                  env=None, package_env=None)
         retriever = Retriever(loader, self.output)
-        builder = DepsBuilder(retriever, self.output, loader, MockRequireResolver())
+        builder = DepsGraphBuilder(retriever, self.output, loader, MockRequireResolver())
         root_conan = retriever.root(content)
         deps_graph = builder.load(None, root_conan)
         return deps_graph
@@ -1710,7 +1710,7 @@ class ChatConan(ConanFile):
                                                      "myoption_chat=on"),
                                  Scopes(), env=None, package_env=None)
         retriever = Retriever(loader, output)
-        builder = DepsBuilder(retriever, output, loader, MockRequireResolver())
+        builder = DepsGraphBuilder(retriever, output, loader, MockRequireResolver())
         retriever.conan(say_ref, say_content)
         retriever.conan(hello_ref, hello_content)
 

--- a/conans/test/model/version_ranges_test.py
+++ b/conans/test/model/version_ranges_test.py
@@ -2,7 +2,7 @@ import unittest
 from conans.test.tools import TestBufferConanOutput
 from conans.paths import CONANFILE
 import os
-from conans.client.deps_builder import DepsBuilder
+from conans.client.deps_builder import DepsGraphBuilder
 from conans.model.ref import ConanFileReference
 from conans.model.options import OptionsValues
 from conans.client.loader import ConanFileLoader
@@ -157,7 +157,7 @@ class VersionRangesTest(unittest.TestCase):
         self.retriever = Retriever(self.loader, self.output)
         self.remote_search = MockSearchRemote()
         self.resolver = RequireResolver(self.output, self.retriever, self.remote_search)
-        self.builder = DepsBuilder(self.retriever, self.output, self.loader, self.resolver)
+        self.builder = DepsGraphBuilder(self.retriever, self.output, self.loader, self.resolver)
 
         for v in ["0.1", "0.2", "0.3", "1.1", "1.1.2", "1.2.1", "2.1", "2.2.1"]:
             say_content = """

--- a/conans/test/path_limit_test.py
+++ b/conans/test/path_limit_test.py
@@ -4,6 +4,7 @@ from conans.util.files import load
 import os
 from conans.model.ref import PackageReference, ConanFileReference
 import platform
+import time
 
 
 base = '''
@@ -46,6 +47,7 @@ class PathLengthLimitTest(unittest.TestCase):
         client.run("export lasote/channel")
         client.run("install lib/0.1@lasote/channel --build")
         client.run("upload lib/0.1@lasote/channel --all")
+        time.sleep(1)  # OSX busy folder in remove
         client.run("remove lib/0.1@lasote/channel -f")
         client.run("search")
         self.assertIn("There are no packages", client.user_io.out)
@@ -91,6 +93,7 @@ class PathLengthLimitTest(unittest.TestCase):
         self.assertNotIn("Configuring sources", client.user_io.out)
 
         # But if we remove the source, it will retrieve sources again
+        time.sleep(1)  # OSX busy folder in remove
         client.run("remove lib/0.1@user/channel -s -f")
         client.run("source lib/0.1@user/channel")
         self.assertIn("Configuring sources", client.user_io.out)

--- a/conans/test/path_limit_test.py
+++ b/conans/test/path_limit_test.py
@@ -47,7 +47,6 @@ class PathLengthLimitTest(unittest.TestCase):
         client.run("export lasote/channel")
         client.run("install lib/0.1@lasote/channel --build")
         client.run("upload lib/0.1@lasote/channel --all")
-        time.sleep(1)  # OSX busy folder in remove
         client.run("remove lib/0.1@lasote/channel -f")
         client.run("search")
         self.assertIn("There are no packages", client.user_io.out)
@@ -93,7 +92,6 @@ class PathLengthLimitTest(unittest.TestCase):
         self.assertNotIn("Configuring sources", client.user_io.out)
 
         # But if we remove the source, it will retrieve sources again
-        time.sleep(1)  # OSX busy folder in remove
         client.run("remove lib/0.1@user/channel -s -f")
         client.run("source lib/0.1@user/channel")
         self.assertIn("Configuring sources", client.user_io.out)

--- a/conans/test/remote/rest_api_test.py
+++ b/conans/test/remote/rest_api_test.py
@@ -6,15 +6,15 @@ from conans.paths import CONANFILE, CONAN_MANIFEST, CONANINFO
 import sys
 from conans.client.output import ConanOutput, Color
 from conans.model.info import ConanInfo
-import os
 from conans.server.test.utils.server_launcher import TestServerLauncher
 import requests
-from conans.model.manifest import FileTreeManifest
-from conans.util.files import md5, save
 from conans.test.utils.test_files import temp_folder
 from conans.model.version import Version
 from conans.server.rest.bottle_plugins.version_checker import VersionCheckerPlugin
 import platform
+import os
+from conans.util.files import md5, save
+from conans.model.manifest import FileTreeManifest
 
 
 class RestApiTest(unittest.TestCase):
@@ -88,6 +88,32 @@ class RestApiTest(unittest.TestCase):
         package = self.api.get_package(package_reference, tmp_dir)
         self.assertIsNotNone(package)
         self.assertIn("hello.cpp", package)
+
+    def get_package_info_test(self):
+        # Upload a conans
+        conan_reference = ConanFileReference.loads("conan3/1.0.0@private_user/testing")
+        self._upload_conan(conan_reference)
+
+        # Upload an package
+        package_reference = PackageReference(conan_reference, "1F23223EFDA")
+        conan_info = """[settings]
+    arch=x86_64
+    compiler=gcc
+    os=Linux
+[options]
+    386=False
+[requires]
+    Hello
+    Bye/2.9
+    Say/2.1@user/testing
+    Chat/2.1@user/testing:SHA_ABC
+"""
+        self._upload_package(package_reference, {CONANINFO: conan_info})
+
+        # Get the package info
+        info = self.api.get_package_info(package_reference)
+        self.assertIsInstance(info, ConanInfo)
+        self.assertEquals(info, ConanInfo.loads(conan_info))
 
     def upload_huge_conan_test(self):
         if platform.system() != "Windows":


### PR DESCRIPTION
#772 
With install refactor, `conan info --build` command that will "simulate" an install and return a list of nodes to be built.
Not used `--build_order` parameter because it has a different meaning, maybe less useful. 