### PR TITLE
FreeBSD green build

### DIFF
--- a/conans/client/remote_registry.py
+++ b/conans/client/remote_registry.py
@@ -4,6 +4,7 @@ from conans.util.files import load, save
 from collections import OrderedDict, namedtuple
 import fasteners
 from conans.util.config_parser import get_bool_from_text_value
+from conans.util.log import logger
 
 
 default_remotes = """conan.io https://server.conan.io True
@@ -80,18 +81,18 @@ class RemoteRegistry(object):
 
     @property
     def remotes(self):
-        with fasteners.InterProcessLock(self._filename + ".lock"):
+        with fasteners.InterProcessLock(self._filename + ".lock", logger=logger):
             remotes, _ = self._load()
             return [Remote(ref, remote, verify_ssl) for ref, (remote, verify_ssl) in remotes.items()]
 
     @property
     def refs(self):
-        with fasteners.InterProcessLock(self._filename + ".lock"):
+        with fasteners.InterProcessLock(self._filename + ".lock", logger=logger):
             _, refs = self._load()
             return refs
 
     def remote(self, name):
-        with fasteners.InterProcessLock(self._filename + ".lock"):
+        with fasteners.InterProcessLock(self._filename + ".lock", logger=logger):
             remotes, _ = self._load()
             try:
                 return Remote(name, remotes[name][0], remotes[name][1])
@@ -100,7 +101,7 @@ class RemoteRegistry(object):
                                      % (name, self._filename))
 
     def get_ref(self, conan_reference):
-        with fasteners.InterProcessLock(self._filename + ".lock"):
+        with fasteners.InterProcessLock(self._filename + ".lock", logger=logger):
             remotes, refs = self._load()
             remote_name = refs.get(str(conan_reference))
             try:
@@ -109,7 +110,7 @@ class RemoteRegistry(object):
                 return None
 
     def remove_ref(self, conan_reference, quiet=False):
-        with fasteners.InterProcessLock(self._filename + ".lock"):
+        with fasteners.InterProcessLock(self._filename + ".lock", logger=logger):
             conan_reference = str(conan_reference)
             remotes, refs = self._load()
             try:
@@ -121,14 +122,14 @@ class RemoteRegistry(object):
                                       % conan_reference)
 
     def set_ref(self, conan_reference, remote):
-        with fasteners.InterProcessLock(self._filename + ".lock"):
+        with fasteners.InterProcessLock(self._filename + ".lock", logger=logger):
             conan_reference = str(conan_reference)
             remotes, refs = self._load()
             refs[conan_reference] = remote.name
             self._save(remotes, refs)
 
     def add_ref(self, conan_reference, remote):
-        with fasteners.InterProcessLock(self._filename + ".lock"):
+        with fasteners.InterProcessLock(self._filename + ".lock", logger=logger):
             conan_reference = str(conan_reference)
             remotes, refs = self._load()
             if conan_reference in refs:
@@ -139,7 +140,7 @@ class RemoteRegistry(object):
             self._save(remotes, refs)
 
     def update_ref(self, conan_reference, remote):
-        with fasteners.InterProcessLock(self._filename + ".lock"):
+        with fasteners.InterProcessLock(self._filename + ".lock", logger=logger):
             conan_reference = str(conan_reference)
             remotes, refs = self._load()
             if conan_reference not in refs:
@@ -150,7 +151,7 @@ class RemoteRegistry(object):
             self._save(remotes, refs)
 
     def add(self, remote_name, remote, verify_ssl=True):
-        with fasteners.InterProcessLock(self._filename + ".lock"):
+        with fasteners.InterProcessLock(self._filename + ".lock", logger=logger):
             remotes, refs = self._load()
             if remote_name in remotes:
                 raise ConanException("Remote %s already exist in remotes (use update to modify)"
@@ -159,7 +160,7 @@ class RemoteRegistry(object):
             self._save(remotes, refs)
 
     def remove(self, remote_name):
-        with fasteners.InterProcessLock(self._filename + ".lock"):
+        with fasteners.InterProcessLock(self._filename + ".lock", logger=logger):
             remotes, refs = self._load()
             if remote_name not in remotes:
                 raise ConanException("%s not found in remotes" % remote_name)
@@ -168,7 +169,7 @@ class RemoteRegistry(object):
             self._save(remotes, refs)
 
     def update(self, remote_name, remote, verify_ssl=True):
-        with fasteners.InterProcessLock(self._filename + ".lock"):
+        with fasteners.InterProcessLock(self._filename + ".lock", logger=logger):
             remotes, refs = self._load()
             if remote_name not in remotes:
                 raise ConanException("%s not found in remotes" % remote_name)

--- a/conans/server/test/utils/server_launcher.py
+++ b/conans/server/test/utils/server_launcher.py
@@ -106,7 +106,7 @@ class TestServerLauncher(object):
             def stopped(self):
                 return self._stop.isSet()
 
-        self.t1 = StoppableThread(target=self.ra.run, kwargs={"host": "0.0.0.0"})
+        self.t1 = StoppableThread(target=self.ra.run, kwargs={"host": "0.0.0.0", "quiet": True})
         self.t1.daemon = daemon
         self.t1.start()
         time.sleep(1)

--- a/conans/test/command/export_path_test.py
+++ b/conans/test/command/export_path_test.py
@@ -32,9 +32,10 @@ class ExportPathTest(unittest.TestCase):
         expected_sums = {'hello.cpp': '4f005274b2fdb25e6113b69774dac184',
                          'main.cpp': '0479f3c223c9a656a718f3148e044124',
                          'CMakeLists.txt': 'bc3405da4bb0b51a3b9f05aca71e58c8',
-                         'conanfile.py': '5632cf850a7161388ab24f42b9bdb3fd',
+                         'conanfile.py': '2d444f34e8c11e31d7e45bee1fcd2d05',
                          'executable': '68b329da9893e34099c7d8ad5cb9c940',
                          'helloHello0.h': '9448df034392fc8781a47dd03ae71bdd'}
+
         self.assertEqual(expected_sums, manif.file_sums)
 
     def test_rel_path(self):
@@ -61,7 +62,7 @@ class ExportPathTest(unittest.TestCase):
         expected_sums = {'hello.cpp': '4f005274b2fdb25e6113b69774dac184',
                          'main.cpp': '0479f3c223c9a656a718f3148e044124',
                          'CMakeLists.txt': 'bc3405da4bb0b51a3b9f05aca71e58c8',
-                         'conanfile.py': '5632cf850a7161388ab24f42b9bdb3fd',
+                         'conanfile.py': '2d444f34e8c11e31d7e45bee1fcd2d05',
                          'executable': '68b329da9893e34099c7d8ad5cb9c940',
                          'helloHello0.h': '9448df034392fc8781a47dd03ae71bdd'}
         self.assertEqual(expected_sums, manif.file_sums)
@@ -95,7 +96,7 @@ class ExportPathTest(unittest.TestCase):
         expected_sums = {'source/hello.cpp': '4f005274b2fdb25e6113b69774dac184',
                          'source/main.cpp': '0479f3c223c9a656a718f3148e044124',
                          'source/CMakeLists.txt': 'bc3405da4bb0b51a3b9f05aca71e58c8',
-                         'conanfile.py': 'c0bb94a3da6eb978cb94f5faff037ed3',
+                         'conanfile.py': '4c234a50c15f7caa82664701e3c051e5',
                          'source/executable': '68b329da9893e34099c7d8ad5cb9c940',
                          'source/helloHello0.h': '9448df034392fc8781a47dd03ae71bdd'}
         self.assertEqual(expected_sums, manif.file_sums)
@@ -132,7 +133,7 @@ class ExportPathTest(unittest.TestCase):
         expected_sums = {'source/hello.cpp': '4f005274b2fdb25e6113b69774dac184',
                          'source/main.cpp': '0479f3c223c9a656a718f3148e044124',
                          'source/CMakeLists.txt': 'bc3405da4bb0b51a3b9f05aca71e58c8',
-                         'conanfile.py': 'c0bb94a3da6eb978cb94f5faff037ed3',
+                         'conanfile.py': '4c234a50c15f7caa82664701e3c051e5',
                          'source/executable': '68b329da9893e34099c7d8ad5cb9c940',
                          'source/helloHello0.h': '9448df034392fc8781a47dd03ae71bdd'}
         self.assertEqual(expected_sums, manif.file_sums)

--- a/conans/test/command/export_path_test.py
+++ b/conans/test/command/export_path_test.py
@@ -32,7 +32,7 @@ class ExportPathTest(unittest.TestCase):
         expected_sums = {'hello.cpp': '4f005274b2fdb25e6113b69774dac184',
                          'main.cpp': '0479f3c223c9a656a718f3148e044124',
                          'CMakeLists.txt': 'bc3405da4bb0b51a3b9f05aca71e58c8',
-                         'conanfile.py': '2d444f34e8c11e31d7e45bee1fcd2d05',
+                         'conanfile.py': '0f623a95e7262a618ad140eb2f959c5f',
                          'executable': '68b329da9893e34099c7d8ad5cb9c940',
                          'helloHello0.h': '9448df034392fc8781a47dd03ae71bdd'}
 
@@ -62,7 +62,7 @@ class ExportPathTest(unittest.TestCase):
         expected_sums = {'hello.cpp': '4f005274b2fdb25e6113b69774dac184',
                          'main.cpp': '0479f3c223c9a656a718f3148e044124',
                          'CMakeLists.txt': 'bc3405da4bb0b51a3b9f05aca71e58c8',
-                         'conanfile.py': '2d444f34e8c11e31d7e45bee1fcd2d05',
+                         'conanfile.py': '0f623a95e7262a618ad140eb2f959c5f',
                          'executable': '68b329da9893e34099c7d8ad5cb9c940',
                          'helloHello0.h': '9448df034392fc8781a47dd03ae71bdd'}
         self.assertEqual(expected_sums, manif.file_sums)
@@ -96,7 +96,7 @@ class ExportPathTest(unittest.TestCase):
         expected_sums = {'source/hello.cpp': '4f005274b2fdb25e6113b69774dac184',
                          'source/main.cpp': '0479f3c223c9a656a718f3148e044124',
                          'source/CMakeLists.txt': 'bc3405da4bb0b51a3b9f05aca71e58c8',
-                         'conanfile.py': '4c234a50c15f7caa82664701e3c051e5',
+                         'conanfile.py': 'c90fe9d800e1f48c8ea0999e8e5929d8',
                          'source/executable': '68b329da9893e34099c7d8ad5cb9c940',
                          'source/helloHello0.h': '9448df034392fc8781a47dd03ae71bdd'}
         self.assertEqual(expected_sums, manif.file_sums)
@@ -133,7 +133,7 @@ class ExportPathTest(unittest.TestCase):
         expected_sums = {'source/hello.cpp': '4f005274b2fdb25e6113b69774dac184',
                          'source/main.cpp': '0479f3c223c9a656a718f3148e044124',
                          'source/CMakeLists.txt': 'bc3405da4bb0b51a3b9f05aca71e58c8',
-                         'conanfile.py': '4c234a50c15f7caa82664701e3c051e5',
+                         'conanfile.py': 'c90fe9d800e1f48c8ea0999e8e5929d8',
                          'source/executable': '68b329da9893e34099c7d8ad5cb9c940',
                          'source/helloHello0.h': '9448df034392fc8781a47dd03ae71bdd'}
         self.assertEqual(expected_sums, manif.file_sums)

--- a/conans/test/command/export_test.py
+++ b/conans/test/command/export_test.py
@@ -54,7 +54,7 @@ class ExportTest(unittest.TestCase):
         expected_sums = {'hello.cpp': '4f005274b2fdb25e6113b69774dac184',
                          'main.cpp': '0479f3c223c9a656a718f3148e044124',
                          'CMakeLists.txt': 'bc3405da4bb0b51a3b9f05aca71e58c8',
-                         'conanfile.py': '5632cf850a7161388ab24f42b9bdb3fd',
+                         'conanfile.py': '2d444f34e8c11e31d7e45bee1fcd2d05',
                          'executable': '68b329da9893e34099c7d8ad5cb9c940',
                          'helloHello0.h': '9448df034392fc8781a47dd03ae71bdd'}
         self.assertEqual(expected_sums, manif.file_sums)
@@ -137,7 +137,7 @@ class OpenSSLConan(ConanFile):
         expected_sums = {'hello.cpp': '4f005274b2fdb25e6113b69774dac184',
                          'main.cpp': '0479f3c223c9a656a718f3148e044124',
                          'CMakeLists.txt': 'bc3405da4bb0b51a3b9f05aca71e58c8',
-                         'conanfile.py': '5632cf850a7161388ab24f42b9bdb3fd',
+                         'conanfile.py': '2d444f34e8c11e31d7e45bee1fcd2d05',
                          'executable': '68b329da9893e34099c7d8ad5cb9c940',
                          'helloHello0.h': '9448df034392fc8781a47dd03ae71bdd'}
         self.assertEqual(expected_sums, digest2.file_sums)
@@ -170,7 +170,7 @@ class OpenSSLConan(ConanFile):
         expected_sums = {'hello.cpp': '4f005274b2fdb25e6113b69774dac184',
                          'main.cpp': '0479f3c223c9a656a718f3148e044124',
                          'CMakeLists.txt': 'bc3405da4bb0b51a3b9f05aca71e58c8',
-                         'conanfile.py': '7f7a5352e781be814b86e8f333593b4f',
+                         'conanfile.py': 'db93843bc009d96e8dcfd5913ecee5b1',
                          'executable': '68b329da9893e34099c7d8ad5cb9c940',
                          'helloHello0.h': '9448df034392fc8781a47dd03ae71bdd'}
         self.assertEqual(expected_sums, digest3.file_sums)

--- a/conans/test/command/export_test.py
+++ b/conans/test/command/export_test.py
@@ -54,7 +54,7 @@ class ExportTest(unittest.TestCase):
         expected_sums = {'hello.cpp': '4f005274b2fdb25e6113b69774dac184',
                          'main.cpp': '0479f3c223c9a656a718f3148e044124',
                          'CMakeLists.txt': 'bc3405da4bb0b51a3b9f05aca71e58c8',
-                         'conanfile.py': '2d444f34e8c11e31d7e45bee1fcd2d05',
+                         'conanfile.py': '0f623a95e7262a618ad140eb2f959c5f',
                          'executable': '68b329da9893e34099c7d8ad5cb9c940',
                          'helloHello0.h': '9448df034392fc8781a47dd03ae71bdd'}
         self.assertEqual(expected_sums, manif.file_sums)
@@ -137,7 +137,7 @@ class OpenSSLConan(ConanFile):
         expected_sums = {'hello.cpp': '4f005274b2fdb25e6113b69774dac184',
                          'main.cpp': '0479f3c223c9a656a718f3148e044124',
                          'CMakeLists.txt': 'bc3405da4bb0b51a3b9f05aca71e58c8',
-                         'conanfile.py': '2d444f34e8c11e31d7e45bee1fcd2d05',
+                         'conanfile.py': '0f623a95e7262a618ad140eb2f959c5f',
                          'executable': '68b329da9893e34099c7d8ad5cb9c940',
                          'helloHello0.h': '9448df034392fc8781a47dd03ae71bdd'}
         self.assertEqual(expected_sums, digest2.file_sums)
@@ -170,7 +170,7 @@ class OpenSSLConan(ConanFile):
         expected_sums = {'hello.cpp': '4f005274b2fdb25e6113b69774dac184',
                          'main.cpp': '0479f3c223c9a656a718f3148e044124',
                          'CMakeLists.txt': 'bc3405da4bb0b51a3b9f05aca71e58c8',
-                         'conanfile.py': 'db93843bc009d96e8dcfd5913ecee5b1',
+                         'conanfile.py': '6b19dfd1241712a6c694c7c397f909ce',
                          'executable': '68b329da9893e34099c7d8ad5cb9c940',
                          'helloHello0.h': '9448df034392fc8781a47dd03ae71bdd'}
         self.assertEqual(expected_sums, digest3.file_sums)

--- a/conans/test/compile_helpers_test.py
+++ b/conans/test/compile_helpers_test.py
@@ -240,8 +240,6 @@ class ConfigureEnvironmentTest(unittest.TestCase):
     def _assert_env_variable_printed(self, name, value):
         if platform.system() == "Windows":
             self.assertIn("%s=%s" % (name, value), self.client.user_io.out)
-        elif platform.system() == "Darwin":
-            self.assertIn('%s="%s"' % (name, value), self.client.user_io.out)
         else:
             self.assertIn("%s=%s" % (name, value), self.client.user_io.out)
 

--- a/conans/test/compile_helpers_test.py
+++ b/conans/test/compile_helpers_test.py
@@ -238,10 +238,7 @@ class ConfigureEnvironmentTest(unittest.TestCase):
         self._assert_env_variable_printed("CXX", "/path/tomy/g++_build")
 
     def _assert_env_variable_printed(self, name, value):
-        if platform.system() == "Windows":
-            self.assertIn("%s=%s" % (name, value), self.client.user_io.out)
-        else:
-            self.assertIn("%s=%s" % (name, value), self.client.user_io.out)
+        self.assertIn("%s=%s" % (name, value), self.client.user_io.out)
 
     def _create_profile(self, name, settings, scopes=None, env=None):
         profile = Profile()

--- a/conans/test/compile_helpers_test.py
+++ b/conans/test/compile_helpers_test.py
@@ -202,7 +202,7 @@ class AConan(ConanFile):
 
     def build(self):
         env = ConfigureEnvironment(self)
-        self.run(env.command_line + (" && SET" if self.settings.os=="Windows" else " && export"))
+        self.run(env.command_line + (" && SET" if self.settings.os=="Windows" else " && env"))
 """
 
 conanfile_dep = """
@@ -233,7 +233,7 @@ class ConfigureEnvironmentTest(unittest.TestCase):
         self.client.save({CONANFILE: conanfile_scope_env}, clean_first=True)
         self.client.run("install --build=missing")
         self.client.run("build -pr scopes_env")
-        self.assertRegexpMatches(str(self.client.user_io.out), "PATH=['\"]?/path/to/my/folder")
+        self.assertRegexpMatches(str(self.client.user_io.out), "PATH=['\"]*/path/to/my/folder")
         self._assert_env_variable_printed("CC", "/path/tomy/gcc_build")
         self._assert_env_variable_printed("CXX", "/path/tomy/g++_build")
 
@@ -243,7 +243,7 @@ class ConfigureEnvironmentTest(unittest.TestCase):
         elif platform.system() == "Darwin":
             self.assertIn('%s="%s"' % (name, value), self.client.user_io.out)
         else:
-            self.assertIn("%s='%s'" % (name, value), self.client.user_io.out)
+            self.assertIn("%s=%s" % (name, value), self.client.user_io.out)
 
     def _create_profile(self, name, settings, scopes=None, env=None):
         profile = Profile()

--- a/conans/test/integration/profile_test.py
+++ b/conans/test/integration/profile_test.py
@@ -28,7 +28,7 @@ class AConan(ConanFile):
         if self.settings.os == "Windows":
             self.run("SET")
         else:
-            self.run("export")
+            self.run("env")
 
 """
 
@@ -307,9 +307,4 @@ class DefaultNameConan(ConanFile):
         self._assert_env_variable_printed("ONE_VAR", "PACKAGE VALUE")
 
     def _assert_env_variable_printed(self, name, value):
-        if platform.system() == "Windows":
-            self.assertIn("%s=%s" % (name, value), self.client.user_io.out)
-        elif platform.system() == "Darwin":
-            self.assertIn('%s="%s"' % (name, value), self.client.user_io.out)
-        else:
-            self.assertIn("%s='%s'" % (name, value), self.client.user_io.out)
+        self.assertIn("%s=%s" % (name, value), self.client.user_io.out)

--- a/conans/test/utils/cpp_test_files.py
+++ b/conans/test/utils/cpp_test_files.py
@@ -1,4 +1,5 @@
 from conans.paths import CONANFILE, BUILD_INFO_CMAKE
+import platform
 
 
 conanfile_build_cmake = """    def build(self):
@@ -309,8 +310,13 @@ def cpp_hello_conan_files(name="Hello", version="0.1", deps=None, language=0, st
                                           static=static,
                                           libcxx_remove=libcxx_remove,
                                           build=build_env)
+
+    if platform.system() == "FreeBSD":  # Patch for using native clang
+        conanfile = conanfile.replace("g++", "clang++")
+
     if pure_c:
         conanfile = conanfile.replace("hello.cpp", "hello.c").replace("main.cpp", "main.c")
+        conanfile = conanfile.replace("clang++", "clang")
         conanfile = conanfile.replace("g++", "gcc")
     if not build:
         conanfile = conanfile.replace("build(", "build2(")

--- a/conans/test/utils/cpp_test_files.py
+++ b/conans/test/utils/cpp_test_files.py
@@ -8,7 +8,7 @@ conanfile_build_cmake = """    def build(self):
         cmake = CMake(self.settings)
         cmake_flags = cmake.command_line
         cmd = 'cmake "%s" %s %s %s' % (self.conanfile_directory, cmake_flags, lang, static_flags)
-        #print "Executing command ", cmd
+        print "Executing command ", cmd
         self.run(cmd)
         self.run("cmake --build . %s" % cmake.build_config)"""
 
@@ -36,17 +36,17 @@ conanfile_build_env = """
             # libs = " ".join("-l%s" % lib for lib in self.deps_cpp_info.libs)
             lang = '-DCONAN_LANGUAGE=%s' % self.options.language
             if self.options.static:
-                self.run("g++ -c hello.cpp {} {}".format(lang, flags))
+                self.run("c++ -c hello.cpp {} {}".format(lang, flags))
                 self.run("{} && ar rcs libhello{}.a hello.o".format(env, self.name))
             else:
                 if self.settings.os == "Windows":
-                    self.run("{} && g++ -o libhello{}.dll -shared -fPIC hello.cpp {} {} "
+                    self.run("{} && c++ -o libhello{}.dll -shared -fPIC hello.cpp {} {} "
                              "-Wl,--out-implib,libhello{}.a".
                              format(env, self.name, lang, flags, self.name))
                 else:
-                    self.run("{} && g++ -o libhello{}.so -shared -fPIC hello.cpp {} {}".
+                    self.run("{} && c++ -o libhello{}.so -shared -fPIC hello.cpp {} {}".
                     format(env, self.name, flags, lang))
-            self.run('{} && g++ -o main main.cpp -L. -lhello{} {}'.format(env, self.name, flags))
+            self.run('{} && c++ -o main main.cpp -L. -lhello{} {}'.format(env, self.name, flags))
 
         try:
             os.makedirs("bin")
@@ -311,13 +311,9 @@ def cpp_hello_conan_files(name="Hello", version="0.1", deps=None, language=0, st
                                           libcxx_remove=libcxx_remove,
                                           build=build_env)
 
-    if platform.system() == "FreeBSD":  # Patch for using native clang
-        conanfile = conanfile.replace("g++", "clang++")
-
     if pure_c:
         conanfile = conanfile.replace("hello.cpp", "hello.c").replace("main.cpp", "main.c")
-        conanfile = conanfile.replace("clang++", "clang")
-        conanfile = conanfile.replace("g++", "gcc")
+        conanfile = conanfile.replace("c++", "cc")
     if not build:
         conanfile = conanfile.replace("build(", "build2(")
     if not config:

--- a/conans/test/utils/cpp_test_files.py
+++ b/conans/test/utils/cpp_test_files.py
@@ -8,7 +8,7 @@ conanfile_build_cmake = """    def build(self):
         cmake = CMake(self.settings)
         cmake_flags = cmake.command_line
         cmd = 'cmake "%s" %s %s %s' % (self.conanfile_directory, cmake_flags, lang, static_flags)
-        print "Executing command ", cmd
+        # print "Executing command: %s" % cmd
         self.run(cmd)
         self.run("cmake --build . %s" % cmake.build_config)"""
 

--- a/conans/test/utils/test_files.py
+++ b/conans/test/utils/test_files.py
@@ -8,6 +8,7 @@ from conans.tools import untargz
 from conans.errors import ConanException
 import time
 import shutil
+import platform
 
 
 def wait_until_removed(folder):
@@ -27,7 +28,10 @@ def temp_folder():
     t = tempfile.mkdtemp(suffix='conans', dir=CONAN_TEST_FOLDER)
     # necessary for Mac OSX, where the temp folders in /var/ are symlinks to /private/var/
     t = os.path.realpath(t)
-    nt = os.path.join(t, "path with spaces")
+    # In FreeBDS path with spaces crashes in make, couldn't know why, CMake seems to scape and quote them 
+    # right but "make" command fails
+    path = "path with spaces" if not platform.system() == "FreeBSD" else "pathwithoutspaces"
+    nt = os.path.join(t, path)
     os.makedirs(nt)
     return nt
 


### PR DESCRIPTION
- Addresses #784 
- Logger changes in the fasteners is to avoid too much undesired trace in the shell during the test builds.
- Deactivated spaces in paths for FreeBSD (Make problems)
- quiet parameter for test server launcher
- Used "cc" instead of "gcc" and "c++" instead of "g++". In FreeBSD it works with clang