### PR TITLE
Quote string(REPLACE) cmake command fourth argument

### DIFF
--- a/conans/client/generators/cmake.py
+++ b/conans/client/generators/cmake.py
@@ -238,7 +238,7 @@ endmacro()
 
 macro(conan_split_version VERSION_STRING MAJOR MINOR)
     #make a list from the version string
-    string(REPLACE "." ";" VERSION_LIST ${${VERSION_STRING}})
+    string(REPLACE "." ";" VERSION_LIST "${${VERSION_STRING}}")
 
     #write output values
     list(GET VERSION_LIST 0 ${MAJOR})


### PR DESCRIPTION
This commit fixes potential errors when CONAN_VERSION variable
in conan_split_version() function is not set so the command
is interpreted as with 3 arguments only. This could also help if
the variable has spaces so the command is interpreted with 5 arguments.
As a rule, always quote cmake command arguments

See https://travis-ci.org/foonathan/type_safe/jobs/186587154#L756 and https://travis-ci.org/ChaiScript/ChaiScript/jobs/186450865#L558 for examples of this error.