### PR TITLE
Give better warning messages when package integrity failed.

### DIFF
--- a/conans/client/remote_manager.py
+++ b/conans/client/remote_manager.py
@@ -70,12 +70,16 @@ class RemoteManager(object):
         # recipes and packages
         diff = set(expected_manifest.file_sums.keys()).difference(read_manifest.file_sums.keys())
         for d in diff:
-            if d.endswith(".pyc"):
+            if d.endswith(".pyc") or d.endswith(".pyo"):
                 del expected_manifest.file_sums[d]
                 # It has to be in files, otherwise couldn't be in expected_manifest
                 del the_files[d]
 
         if read_manifest is None or read_manifest.file_sums != expected_manifest.file_sums:
+            for fname in read_manifest.file_sums.keys():
+                if read_manifest.file_sums[fname] != expected_manifest.file_sums[fname]:
+                    self._output.warn("Mismatched checksum for file %s (checksum: %s, expected: %s)" %
+                                      (fname, read_manifest.file_sums[fname], expected_manifest.file_sums[fname]))
             if PACKAGE_TGZ_NAME in the_files:
                 try:
                     tgz_path = os.path.join(package_folder, PACKAGE_TGZ_NAME)


### PR DESCRIPTION
When checksumming files for upload it could fail, currently
it's really hard to figure out what's going wrong since it
just says fails. This patch adds more feedback on what files
that fails.