### PR TITLE
fix incorrect argument handling with conan_find_libraries_abs_path function

### DIFF
--- a/conans/client/generators/cmake.py
+++ b/conans/client/generators/cmake.py
@@ -53,7 +53,7 @@ class CMakeGenerator(Generator):
 
         # TARGETS
         template = """
-    conan_find_libraries_abs_path(${{CONAN_LIBS_{uname}}} ${{CONAN_LIB_DIRS_{uname}}}
+    conan_find_libraries_abs_path("${{CONAN_LIBS_{uname}}}" "${{CONAN_LIB_DIRS_{uname}}}"
                                   CONAN_FULLPATH_LIBS_{uname})
 
     add_library({name} INTERFACE IMPORTED)

--- a/conans/client/generators/cmake_multi.py
+++ b/conans/client/generators/cmake_multi.py
@@ -47,9 +47,9 @@ class CMakeMultiGenerator(Generator):
         sections = []
         # TARGETS
         template = """
-    conan_find_libraries_abs_path(${{CONAN_LIBS_{uname}_DEBUG}} ${{CONAN_LIB_DIRS_{uname}_DEBUG}}
+    conan_find_libraries_abs_path("${{CONAN_LIBS_{uname}_DEBUG}}" "${{CONAN_LIB_DIRS_{uname}_DEBUG}}"
                                   CONAN_FULLPATH_LIBS_{uname}_DEBUG)
-    conan_find_libraries_abs_path(${{CONAN_LIBS_{uname}_RELEASE}} ${{CONAN_LIB_DIRS_{uname}_RELEASE}}
+    conan_find_libraries_abs_path("${{CONAN_LIBS_{uname}_RELEASE}}" "${{CONAN_LIB_DIRS_{uname}_RELEASE}}"
                                   CONAN_FULLPATH_LIBS_{uname}_RELEASE)
 
     add_library({name} INTERFACE IMPORTED)


### PR DESCRIPTION
At the momemt conan's cmake generators `cmake` and `cmake_multi` create the following code if i use `conan_basic_setup(TARGETS)` in my cmake file

```cmake
conan_find_libraries_abs_path(${CONAN_LIBS_MYPROJECT} ${CONAN_LIB_DIRS_MYPROJECT}
                                  CONAN_FULLPATH_LIBS_MYPROJECT)
```
If you have multiple arguments for `CONAN_LIBS_MYPROJECT` or `CONAN_LIB_DIRS_MYPROJECT` like with poco, the arguments are not correctly handled.

We could easily fix that by adding quotation marks.
```cmake
conan_find_libraries_abs_path("${CONAN_LIBS_MYPROJECT}" "${CONAN_LIB_DIRS_MYPROJECT}"
                                  CONAN_FULLPATH_LIBS_MYPROJECT)
```