### PR TITLE
Fix conan_find_libraries for cross-compile.

### DIFF
--- a/conans/client/generators/cmake_common.py
+++ b/conans/client/generators/cmake_common.py
@@ -46,7 +46,7 @@ _cmake_common_macros = """
 function(conan_find_libraries_abs_path libraries package_libdir libraries_abs_path)
     foreach(_LIBRARY_NAME ${libraries})
         unset(FOUND_LIBRARY CACHE)
-        find_library(FOUND_LIBRARY NAME ${_LIBRARY_NAME} PATHS ${package_libdir} NO_DEFAULT_PATH)
+        find_library(FOUND_LIBRARY NAME ${_LIBRARY_NAME} PATHS ${package_libdir} NO_DEFAULT_PATH NO_CMAKE_FIND_ROOT_PATH)
         if(FOUND_LIBRARY)
             message(STATUS "Library ${_LIBRARY_NAME} found ${FOUND_LIBRARY}")
             set(CONAN_FULLPATH_LIBS ${CONAN_FULLPATH_LIBS} ${FOUND_LIBRARY})


### PR DESCRIPTION
In case cross compilation some toolchain defines
```
set(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY)
set(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY)
set(CMAKE_FIND_ROOT_PATH_MODE_PACKAGE ONLY)
```
This effectively prevents conan to find proper libraries.
But in case of conan the path is already known and there is no need to search for library in other places.