### PR TITLE
#685 remove trailing slash from the remote URL

### DIFF
--- a/conans/client/rest/rest_client.py
+++ b/conans/client/rest/rest_client.py
@@ -403,7 +403,7 @@ class RestApiClient(object):
 
     @property
     def _remote_api_url(self):
-        return "%s/v1" % self.remote_url
+        return "%s/v1" % self.remote_url.rstrip("/")
 
     def _file_server_capabilities(self, resource_url):
         auth = None


### PR DESCRIPTION
Signed-off-by: SSE4 <tomskside@gmail.com>