### PR TITLE
Add htpasswd and authorize middleware

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -92,3 +92,6 @@ cacert.pem
 
 #Pyinstaller generated binaries
 /pyinstaller
+
+#vscode folder
+.vscode

--- a/conans/errors.py
+++ b/conans/errors.py
@@ -30,7 +30,6 @@ class ConanException(Exception):
     """
     pass
 
-
 class InvalidNameException(ConanException):
     pass
 

--- a/conans/requirements_server.txt
+++ b/conans/requirements_server.txt
@@ -1,2 +1,3 @@
 # Server
 bottle>=0.12.8, < 0.13
+passlib>=1.7, < 1.8

--- a/conans/server/conf/__init__.py
+++ b/conans/server/conf/__init__.py
@@ -141,10 +141,9 @@ class ConanServerConfigParser(ConfigParser):
     @property
     def authentication(self):
         if self.env_config["authentication"]:
-            auth = self.env_config["authentication"].split(",")
-            return {a.split(":") for a in auth}
+            return self.env_config["authentication"].split(",")
         else:
-            return dict(self._get_file_conf("authentication"))
+            return list(self._get_file_conf("server", "authentication"))
 
     @property
     def users(self):

--- a/conans/server/conf/__init__.py
+++ b/conans/server/conf/__init__.py
@@ -36,8 +36,6 @@ class ConanServerConfigParser(ConfigParser):
                            "disk_storage_path": get_env("CONAN_STORAGE_PATH", storage_folder, environment),
                            "jwt_secret": get_env("CONAN_JWT_SECRET", None, environment),
                            "jwt_expire_minutes": get_env("CONAN_JWT_EXPIRE_MINUTES", None, environment),
-                           "write_permissions": [],
-                           "read_permissions": [],
                            "ssl_enabled": get_env("CONAN_SSL_ENABLED", None, environment),
                            "port": get_env("CONAN_SERVER_PORT", None, environment),
                            "public_port": get_env("CONAN_SERVER_PUBLIC_PORT", None, environment),
@@ -127,24 +125,18 @@ class ConanServerConfigParser(ConfigParser):
 
     @property
     def read_permissions(self):
-        if self.env_config["read_permissions"]:
-            return self.env_config["read_permissions"]
-        else:
-            return self._get_file_conf("read_permissions")
+        return self._get_file_conf("read_permissions")
 
     @property
     def write_permissions(self):
-        if self.env_config["write_permissions"]:
-            return self.env_config["write_permissions"]
-        else:
-            return self._get_file_conf("write_permissions")
+        return self._get_file_conf("write_permissions")
 
     @property
     def authentication(self):
         if self.env_config["authentication"]:
             return self.env_config["authentication"].split(",")
         else:
-            return list(self._get_file_conf("server", "authentication"))
+            return self._get_file_conf("server", "authentication").split(",")
 
     @property
     def htpasswd_file(self):

--- a/conans/server/conf/__init__.py
+++ b/conans/server/conf/__init__.py
@@ -42,6 +42,8 @@ class ConanServerConfigParser(ConfigParser):
                            "port": get_env("CONAN_SERVER_PORT", None, environment),
                            "public_port": get_env("CONAN_SERVER_PUBLIC_PORT", None, environment),
                            "host_name": get_env("CONAN_HOST_NAME", None, environment),
+                           # authentication process
+                           "authentication" : get_env("CONAN_SERVER_AUTHENTICATION", None, environment),
                            # "user:pass,user2:pass2"
                            "users": get_env("CONAN_SERVER_USERS", None, environment)}
 
@@ -135,6 +137,14 @@ class ConanServerConfigParser(ConfigParser):
             return self.env_config["write_permissions"]
         else:
             return self._get_file_conf("write_permissions")
+
+    @property
+    def authentication(self):
+        if self.env_config["authentication"]:
+            auth = self.env_config["authentication"].split(",")
+            return {a.split(":") for a in auth}
+        else:
+            return dict(self._get_file_conf("authentication"))
 
     @property
     def users(self):

--- a/conans/server/conf/__init__.py
+++ b/conans/server/conf/__init__.py
@@ -44,6 +44,7 @@ class ConanServerConfigParser(ConfigParser):
                            "host_name": get_env("CONAN_HOST_NAME", None, environment),
                            # authentication process
                            "authentication" : get_env("CONAN_SERVER_AUTHENTICATION", None, environment),
+                           "htpasswd_file" : get_env("CONAN_HTPASSWD_FILE", None, environment),
                            # "user:pass,user2:pass2"
                            "users": get_env("CONAN_SERVER_USERS", None, environment)}
 
@@ -144,6 +145,13 @@ class ConanServerConfigParser(ConfigParser):
             return self.env_config["authentication"].split(",")
         else:
             return list(self._get_file_conf("server", "authentication"))
+
+    @property
+    def htpasswd_file(self):
+        if self.env_config["htpasswd_file"]:
+            return self.env_config["htpasswd_file"]
+        else:
+            return self._get_file_conf("server", "htpasswd_file")
 
     @property
     def users(self):

--- a/conans/server/conf/default_server_conf.py
+++ b/conans/server/conf/default_server_conf.py
@@ -22,6 +22,12 @@ disk_storage_path: ~/.conan_server/data
 disk_authorize_timeout: 1800
 updown_secret: {updown_secret}
 
+# authentication middleware: processed in order
+# Default is: basic (uses the users list in this config)
+authentication: basic
+
+# For the htpasswd middleware: add path to htpasswd file
+htpasswd_file: 
 
 [write_permissions]
 
@@ -50,11 +56,6 @@ updown_secret: {updown_secret}
 #
 # By default all users can read all blocks
 */*@*/*: *
-
-[authentication]
-# define order: top is checked first
-# htpasswd: file
-basic: 
 
 [users]
 #default_user: defaultpass

--- a/conans/server/conf/default_server_conf.py
+++ b/conans/server/conf/default_server_conf.py
@@ -51,6 +51,10 @@ updown_secret: {updown_secret}
 # By default all users can read all blocks
 */*@*/*: *
 
+[authentication]
+# define order: top is checked first
+# htpasswd: file
+basic
 
 [users]
 #default_user: defaultpass

--- a/conans/server/conf/default_server_conf.py
+++ b/conans/server/conf/default_server_conf.py
@@ -54,7 +54,7 @@ updown_secret: {updown_secret}
 [authentication]
 # define order: top is checked first
 # htpasswd: file
-basic
+basic: 
 
 [users]
 #default_user: defaultpass

--- a/conans/server/migrate.py
+++ b/conans/server/migrate.py
@@ -1,7 +1,7 @@
 from conans.server.conf import ConanServerConfigParser
 from conans.server.migrations import ServerMigrator
-from conans.util.log import logger
 from conans.model.version import Version
+from conans.util.log import logger
 from conans import __version__ as SERVER_VERSION
 
 
@@ -11,6 +11,7 @@ def migrate_and_get_server_config(base_folder, storage_folder=None):
     if server_config.store_adapter == "disk":
         storage_path = server_config.disk_storage_path
     else:
+        
         storage_path = None
 
     migrator = ServerMigrator(server_config.conan_folder, storage_path,

--- a/conans/server/migrations.py
+++ b/conans/server/migrations.py
@@ -1,7 +1,7 @@
 from conans.migrations import Migrator
 from conans.model.version import Version
 from conans.util.files import rmdir
-
+from conans.server.conf import ConanServerConfigParser
 
 class ServerMigrator(Migrator):
 
@@ -16,5 +16,14 @@ class ServerMigrator(Migrator):
                 rmdir(self.conf_path)
             if self.store_path:
                 rmdir(self.store_path)
+        # VERSION 0.19
+        if old_version < Version("0.19.1"):
+            self.out.warn("Upgrading to new authentication middleware ...")
+            config = ConanServerConfigParser(self.base_folder)
+            config.read(config.config_filename)
+            config.set("server", "authentication", "basic")
+            config.set("server", "htpasswd_file", "")
+            with open(config.config_filename) as fp:
+                config.write(fp)
 
         # ########################################################################

--- a/conans/server/migrations.py
+++ b/conans/server/migrations.py
@@ -2,12 +2,13 @@ from conans.migrations import Migrator
 from conans.model.version import Version
 from conans.util.files import rmdir
 from conans.server.conf import ConanServerConfigParser
+import os
 
 class ServerMigrator(Migrator):
 
     def _make_migrations(self, old_version):
         # ############### FILL THIS METHOD WITH THE REQUIRED ACTIONS ##############
-
+        
         # VERSION 0.1
         if old_version == Version("0.1"):
             # Remove config, conans, all!
@@ -17,13 +18,13 @@ class ServerMigrator(Migrator):
             if self.store_path:
                 rmdir(self.store_path)
         # VERSION 0.19
-        if old_version < Version("0.19.1"):
+        elif old_version < Version("0.19.1"):
             self.out.warn("Upgrading to new authentication middleware ...")
-            config = ConanServerConfigParser(self.base_folder)
+            config = ConanServerConfigParser(os.path.join(self.conf_path, ".."))
             config.read(config.config_filename)
             config.set("server", "authentication", "basic")
             config.set("server", "htpasswd_file", "")
-            with open(config.config_filename) as fp:
+            with open(config.config_filename, 'w') as fp:
                 config.write(fp)
 
         # ########################################################################

--- a/conans/server/server_launcher.py
+++ b/conans/server/server_launcher.py
@@ -1,5 +1,5 @@
 #!/usr/bin/python
-from conans.server.service.authorize import BasicAuthorizer, BasicAuthenticator
+from conans.server.service.authorize import BasicAuthorizer, AuthenticatorManager
 from conans.server.conf import get_file_manager
 from conans.server.rest.server import ConanServer
 from conans.server.crypto.jwt.jwt_credentials_manager import JWTCredentialsManager
@@ -20,8 +20,9 @@ class ServerLauncher(object):
         server_config = migrate_and_get_server_config(user_folder)
 
         authorizer = BasicAuthorizer(server_config.read_permissions,
-                                     server_config.write_permissions)
-        authenticator = BasicAuthenticator(dict(server_config.users))
+                                        server_config.write_permissions)
+        
+        authenticator = AuthorizeManager(server_config)
 
         credentials_manager = JWTCredentialsManager(server_config.jwt_secret,
                                                     server_config.jwt_expire_time)

--- a/conans/server/service/authorize.py
+++ b/conans/server/service/authorize.py
@@ -104,8 +104,9 @@ class HTPasswdAuthenticator(Authenticator):
     Handles the user authentication for htpasswd files
     htpasswd is the location of the htpasswd to use
     """
-    def __init__(self, htfile, server_config):
+    def __init__(self, server_config):
         # server_config: the server config object
+        htfile = server_config.htpasswd_file
         if not os.path.isabs(htfile):
             htfile = os.path.join(server_config.conan_folder, htfile)
         self.htpasswd = HtpasswdFile(htfile)
@@ -140,7 +141,7 @@ class AuthorizeManager(Authenticator):
             logger.debug("Creating entry %s" % auth)
             if auth not in self.known_authenticators:
                 raise ConanException("Unknown authenticator provided: %s" % auth)
-            self.auths.append(self.known_authenticators[auth](authentication[auth], server_config))
+            self.auths.append(self.known_authenticators[auth](server_config))
     
     def valid_user(self, username, plain_password):
         for m in self.auths:

--- a/conans/server/service/authorize.py
+++ b/conans/server/service/authorize.py
@@ -12,8 +12,11 @@ Replace this module with other that keeps the interface or super class.
 
 from abc import ABCMeta, abstractmethod
 from conans.errors import ForbiddenException, InternalErrorException,\
-    AuthenticationException
+    AuthenticationException, ConanException
 from conans.model.ref import ConanFileReference
+from passlib.apache import HtpasswdFile
+from conans.util.log import logger
+import os
 
 #  ############################################
 #  ############ ABSTRACT CLASSES ##############
@@ -81,20 +84,69 @@ class Authenticator(object):
 class BasicAuthenticator(Authenticator):
     """
     Handles the user authentication from a dict of plain users and passwords.
-    users is {username: plain-text-passwd}
+    users is {username: plain-text-passwd} 
     """
 
-    def __init__(self, users):
-        self.users = users
+    def __init__(self, _, server_config):
+        # server_config: the server config object
+        self.users = dict(server_config.users)
 
     def valid_user(self, username, plain_password):
         """
-        username: User that request to read the conans
-        conan_reference: ConanFileReference
+        username: Username to be authenticated
+        plain_password: The password to authenticate with
         return: True if match False if don't
         """
         return username in self.users and self.users[username] == plain_password
 
+class HTPasswdAuthenticator(Authenticator):
+    """
+    Handles the user authentication for htpasswd files
+    htpasswd is the location of the htpasswd to use
+    """
+    def __init__(self, htfile, server_config):
+        # server_config: the server config object
+        if not os.path.isabs(htfile):
+            htfile = os.path.join(server_config.conan_folder, htfile)
+        self.htpasswd = HtpasswdFile(htfile)
+
+    
+    def valid_user(self, username, plain_password):
+        """
+        username: Username to be authenticated
+        plain_password: The password to authenticate with
+        return: True if match False if don't
+        """
+        # Update
+        self.htpasswd.load_if_changed()
+        # Verify
+        return username in self.htpasswd.users() and self.htpasswd.check_password(username, plain_password)
+
+class AuthorizeManager(Authenticator):
+    """
+    Manager for multiple authenticators
+    """
+    known_authenticators = {
+        "basic" : BasicAuthenticator,
+        "htpasswd" : HTPasswdAuthenticator
+    }
+
+    def __init__(self, server_config):
+        # Uses the server config to generate all needed authenticators
+        self.auths = []
+        authentication = server_config.authentication
+        logger.debug("Initialize default authentication: %s" % authentication)
+        for auth in authentication:
+            logger.debug("Creating entry %s" % auth)
+            if auth not in self.known_authenticators:
+                raise ConanException("Unknown authenticator provided: %s" % auth)
+            self.auths.append(self.known_authenticators[auth](authentication[auth], server_config))
+    
+    def valid_user(self, username, plain_password):
+        for m in self.auths:
+            if m.valid_user(username, plain_password):
+                return True
+        return False
 
 class BasicAuthorizer(Authorizer):
     """

--- a/conans/server/service/authorize.py
+++ b/conans/server/service/authorize.py
@@ -87,7 +87,7 @@ class BasicAuthenticator(Authenticator):
     users is {username: plain-text-passwd} 
     """
 
-    def __init__(self, _, server_config):
+    def __init__(self, server_config):
         # server_config: the server config object
         self.users = dict(server_config.users)
 

--- a/conans/test/auth_test.py
+++ b/conans/test/auth_test.py
@@ -19,8 +19,9 @@ class OpenSSLConan(ConanFile):
 
 class AuthorizeTest(unittest.TestCase):
 
-    def setUp(self):
-        unittest.TestCase.setUp(self)
+    @classmethod
+    def setUpClass(self):
+        print("I am called")
         self.servers = {}
         self.conan_reference = ConanFileReference.loads("openssl/2.0.1@lasote/testing")
         users = {"lasote": "mypass", "pepe": "pepepass"}
@@ -47,7 +48,7 @@ class AuthorizeTest(unittest.TestCase):
                                                                        ("pepe", "pepepass")]})
         save(os.path.join(self.conan.current_folder, CONANFILE), conan_content)
         self.conan.run("export lasote")
-        errors = self.conan.run("upload %s" % str(self.conan_reference))
+        errors = self.conan.run("upload %s --remote default" % str(self.conan_reference))
         # Check that return was  ok
         self.assertFalse(errors)
         # Check that upload was granted
@@ -63,7 +64,7 @@ class AuthorizeTest(unittest.TestCase):
                                                                     ("baduser3", "badpass3")]})
         save(os.path.join(self.conan.current_folder, CONANFILE), conan_content)
         self.conan.run("export lasote -p ./ ")
-        errors = self.conan.run("upload %s" % str(self.conan_reference), ignore_error=True)
+        errors = self.conan.run("upload %s --remote default" % str(self.conan_reference), ignore_error=True)
         # Check that return was not ok
         self.assertTrue(errors)
         # Check that upload was not granted
@@ -89,7 +90,7 @@ class AuthorizeTest(unittest.TestCase):
         self.assertEquals(self.conan.user_io.login_index["htpasswd"], 3)
 
     def max_retries_htpasswd_test(self):
-        """Bad login 3 times"""
+        """Bad login 3 times using htpasswd"""
         self.conan = TestClient(servers=self.servers, users={"htpasswd": [("baduser", "badpass"),
                                                                     ("baduser", "badpass2"),
                                                                     ("baduser3", "badpass3")]})

--- a/conans/test/auth_test.py
+++ b/conans/test/auth_test.py
@@ -20,26 +20,24 @@ class OpenSSLConan(ConanFile):
 class AuthorizeTest(unittest.TestCase):
 
     @classmethod
-    def setUpClass(self):
-        print("I am called")
-        self.servers = {}
-        self.conan_reference = ConanFileReference.loads("openssl/2.0.1@lasote/testing")
+    def setUpClass(cls):
+        cls.servers = {}
+        cls.conan_reference = ConanFileReference.loads("openssl/2.0.1@lasote/testing")
         users = {"lasote": "mypass", "pepe": "pepepass"}
         # Create a default remote. R/W is not authorized for conan_reference, just for pepe and owner
-        self.test_server = TestServer([(str(self.conan_reference), "pepe")],  # read permissions
-                                      [(str(self.conan_reference), "pepe")],  # write permissions
+        cls.test_server = TestServer([(str(cls.conan_reference), "pepe")],  # read permissions
+                                      [(str(cls.conan_reference), "pepe")],  # write permissions
                                       users=users)  # exported users and passwords
-        self.servers["default"] = self.test_server
+        cls.servers["default"] = cls.test_server
         #create htpasswd remote
         base_path = temp_folder()
         mkdir(os.path.join(base_path,".conan_server"))
         create_dummy_htpasswd(os.path.join(base_path,".conan_server", ".htpasswd"), users)
-        self.test_server2 = TestServer([(str(self.conan_reference), "pepe")],  # read permissions
-                                      [(str(self.conan_reference), "pepe")],  # write permissions
+        cls.test_server2 = TestServer([(str(cls.conan_reference), "pepe")],  # read permissions
+                                      [(str(cls.conan_reference), "pepe")],  # write permissions
                                       base_path=base_path,#custom base path here due to .htpasswd file
                                       authentication={"htpasswd": ".htpasswd"})
-        self.servers["htpasswd"] = self.test_server2
-        
+        cls.servers["htpasswd"] = cls.test_server2
 
     def retries_test(self):
         """Bad login 2 times"""

--- a/conans/test/auth_test.py
+++ b/conans/test/auth_test.py
@@ -1,4 +1,5 @@
 import unittest
+from conans.errors import ConanException
 from conans.test.tools import TestServer, TestClient
 from conans.test.server.utils.dummy_server_conf import create_dummy_htpasswd
 from conans.paths import CONANFILE
@@ -102,3 +103,7 @@ class AuthorizeTest(unittest.TestCase):
 
         # Check that login failed all times
         self.assertEquals(self.conan.user_io.login_index["htpasswd"], 3)
+
+    def invalid_authorizer_test(self):
+        with self.assertRaises(ConanException):
+            TestServer(authentication="unknown")

--- a/conans/test/auth_test.py
+++ b/conans/test/auth_test.py
@@ -2,8 +2,9 @@ import unittest
 from conans.test.tools import TestServer, TestClient
 from conans.test.server.utils.dummy_server_conf import create_dummy_htpasswd
 from conans.paths import CONANFILE
-from conans.util.files import save
+from conans.util.files import save, mkdir
 from conans.model.ref import ConanFileReference
+from conans.test.utils.test_files import temp_folder
 import os
 
 conan_content = """
@@ -29,12 +30,13 @@ class AuthorizeTest(unittest.TestCase):
                                       users=users)  # exported users and passwords
         self.servers["default"] = self.test_server
         #create htpasswd remote
+        base_path = temp_folder()
+        mkdir(os.path.join(base_path,".conan_server"))
+        create_dummy_htpasswd(os.path.join(base_path,".conan_server", ".htpasswd"), users)
         self.test_server2 = TestServer([(str(self.conan_reference), "pepe")],  # read permissions
                                       [(str(self.conan_reference), "pepe")],  # write permissions
+                                      base_path=base_path,#custom base path here due to .htpasswd file
                                       authentication={"htpasswd": ".htpasswd"})
-        create_dummy_htpasswd(os.path.join(self.test_server2.config_path, ".htpasswd"), users)
-        if not os.path.exists(os.path.join(self.test_server2.config_path, ".htpasswd")):
-            raise Exception()
         self.servers["htpasswd"] = self.test_server2
         
 
@@ -77,14 +79,14 @@ class AuthorizeTest(unittest.TestCase):
                                                                        ("pepe", "pepepass")]})
         save(os.path.join(self.conan.current_folder, CONANFILE), conan_content)
         self.conan.run("export lasote")
-        errors = self.conan.run("upload %s" % str(self.conan_reference))
+        errors = self.conan.run("upload %s --remote htpasswd" % str(self.conan_reference))
         # Check that return was  ok
         self.assertFalse(errors)
         # Check that upload was granted
-        self.assertTrue(os.path.exists(self.test_server.paths.export(self.conan_reference)))
+        self.assertTrue(os.path.exists(self.test_server2.paths.export(self.conan_reference)))
 
         # Check that login failed two times before ok
-        self.assertEquals(self.conan.user_io.login_index["default"], 3)
+        self.assertEquals(self.conan.user_io.login_index["htpasswd"], 3)
 
     def max_retries_htpasswd_test(self):
         """Bad login 3 times"""
@@ -93,11 +95,11 @@ class AuthorizeTest(unittest.TestCase):
                                                                     ("baduser3", "badpass3")]})
         save(os.path.join(self.conan.current_folder, CONANFILE), conan_content)
         self.conan.run("export lasote -p ./ ")
-        errors = self.conan.run("upload %s" % str(self.conan_reference), ignore_error=True)
+        errors = self.conan.run("upload %s --remote htpasswd" % str(self.conan_reference), ignore_error=True)
         # Check that return was not ok
         self.assertTrue(errors)
         # Check that upload was not granted
         self.assertFalse(os.path.exists(self.test_server.paths.export(self.conan_reference)))
 
         # Check that login failed all times
-        self.assertEquals(self.conan.user_io.login_index["default"], 3)
+        self.assertEquals(self.conan.user_io.login_index["htpasswd"], 3)

--- a/conans/test/auth_test.py
+++ b/conans/test/auth_test.py
@@ -1,5 +1,6 @@
 import unittest
 from conans.test.tools import TestServer, TestClient
+from conans.test.server.utils.dummy_server_conf import create_dummy_htpasswd
 from conans.paths import CONANFILE
 from conans.util.files import save
 from conans.model.ref import ConanFileReference
@@ -21,12 +22,21 @@ class AuthorizeTest(unittest.TestCase):
         unittest.TestCase.setUp(self)
         self.servers = {}
         self.conan_reference = ConanFileReference.loads("openssl/2.0.1@lasote/testing")
+        users = {"lasote": "mypass", "pepe": "pepepass"}
         # Create a default remote. R/W is not authorized for conan_reference, just for pepe and owner
         self.test_server = TestServer([(str(self.conan_reference), "pepe")],  # read permissions
                                       [(str(self.conan_reference), "pepe")],  # write permissions
-                                      users={"lasote": "mypass",
-                                             "pepe": "pepepass"})  # exported users and passwords
+                                      users=users)  # exported users and passwords
         self.servers["default"] = self.test_server
+        #create htpasswd remote
+        self.test_server2 = TestServer([(str(self.conan_reference), "pepe")],  # read permissions
+                                      [(str(self.conan_reference), "pepe")],  # write permissions
+                                      authentication={"htpasswd": ".htpasswd"})
+        create_dummy_htpasswd(os.path.join(self.test_server2.config_path, ".htpasswd"), users)
+        if not os.path.exists(os.path.join(self.test_server2.config_path, ".htpasswd")):
+            raise Exception()
+        self.servers["htpasswd"] = self.test_server2
+        
 
     def retries_test(self):
         """Bad login 2 times"""
@@ -47,6 +57,38 @@ class AuthorizeTest(unittest.TestCase):
     def max_retries_test(self):
         """Bad login 3 times"""
         self.conan = TestClient(servers=self.servers, users={"default": [("baduser", "badpass"),
+                                                                    ("baduser", "badpass2"),
+                                                                    ("baduser3", "badpass3")]})
+        save(os.path.join(self.conan.current_folder, CONANFILE), conan_content)
+        self.conan.run("export lasote -p ./ ")
+        errors = self.conan.run("upload %s" % str(self.conan_reference), ignore_error=True)
+        # Check that return was not ok
+        self.assertTrue(errors)
+        # Check that upload was not granted
+        self.assertFalse(os.path.exists(self.test_server.paths.export(self.conan_reference)))
+
+        # Check that login failed all times
+        self.assertEquals(self.conan.user_io.login_index["default"], 3)
+
+    def retries_htpasswd_test(self):
+        """Bad login 2 times using htpasswd"""
+        self.conan = TestClient(servers=self.servers, users={"htpasswd": [("baduser", "badpass"),
+                                                                       ("baduser", "badpass2"),
+                                                                       ("pepe", "pepepass")]})
+        save(os.path.join(self.conan.current_folder, CONANFILE), conan_content)
+        self.conan.run("export lasote")
+        errors = self.conan.run("upload %s" % str(self.conan_reference))
+        # Check that return was  ok
+        self.assertFalse(errors)
+        # Check that upload was granted
+        self.assertTrue(os.path.exists(self.test_server.paths.export(self.conan_reference)))
+
+        # Check that login failed two times before ok
+        self.assertEquals(self.conan.user_io.login_index["default"], 3)
+
+    def max_retries_htpasswd_test(self):
+        """Bad login 3 times"""
+        self.conan = TestClient(servers=self.servers, users={"htpasswd": [("baduser", "badpass"),
                                                                     ("baduser", "badpass2"),
                                                                     ("baduser3", "badpass3")]})
         save(os.path.join(self.conan.current_folder, CONANFILE), conan_content)

--- a/conans/test/server/conf_test.py
+++ b/conans/test/server/conf_test.py
@@ -1,20 +1,25 @@
 import unittest
-from conans.util.files import save
 import os
+from conans.errors import ConanException
+from conans.util.files import save, load
+from conans.util.log import logger
 from conans.server.conf import ConanServerConfigParser
 from datetime import timedelta
 from conans.test.utils.test_files import temp_folder
 from conans.paths import conan_expand_user
-
+from conans.server.migrate import migrate_and_get_server_config
+from conans import __version__ as VERSION
 
 fileconfig = '''
 [server]
 jwt_secret: mysecret
 jwt_expire_minutes: 121
 disk_storage_path: %s
+store_adapter: disk
 ssl_enabled: true
 port: 9220
-
+public_port: 
+host_name: noname
 
 [write_permissions]
 openssl/2.0.1@lasote/testing: pepe
@@ -39,6 +44,24 @@ class ServerConfTest(unittest.TestCase):
         save(server_conf, fileconfig % self.storage_path)
         self.environ = {}
 
+    def writeVersion(self, version):
+        # A version.txt file 
+        save(os.path.join(self.conf_path, "version.txt"), version)
+    
+    def readVersion(self):
+        return load(os.path.join(self.conf_path, "version.txt"))
+
+    def loadConfig(self):
+        config = ConanServerConfigParser(self.file_path, environment=self.environ)
+        #trigger _get_file_conf
+        config._get_file_conf("server", "port")
+        return config
+    
+    def writeConfig(self, config):
+        with open(config.config_filename, 'w') as fp:
+            config.write(fp)
+
+
     def test_values(self):
         config = ConanServerConfigParser(self.file_path, environment=self.environ)
         self.assertEquals(config.jwt_secret, "mysecret")
@@ -50,7 +73,18 @@ class ServerConfTest(unittest.TestCase):
         self.assertEquals(config.read_permissions, [("*/*@*/*", "*"),
                                                     ("openssl/2.0.1@lasote/testing", "pepe")])
         self.assertEquals(config.users, {"lasote": "defaultpass", "pepe": "pepepass"})
+        self.assertEquals(config.public_port, 9220)
+        self.assertEquals(config.host_name, "noname")
+        self.assertEquals(config.public_url, "https://noname:9220/v1")
 
+
+        # set public port
+        config.set("server","public_port", "5555")
+        self.assertEquals(config.public_port, 5555)
+        # should throw without updown_secret
+        config.set("server", "updown_secret", "")
+        with self.assertRaises(ConanException):
+            config.updown_secret
         # Now check with environments
         tmp_storage = temp_folder()
         self.environ["CONAN_STORAGE_PATH"] = tmp_storage
@@ -59,6 +93,7 @@ class ServerConfTest(unittest.TestCase):
         self.environ["CONAN_SSL_ENABLED"] = "False"
         self.environ["CONAN_SERVER_PORT"] = "1233"
         self.environ["CONAN_SERVER_USERS"] = "lasote:lasotepass,pepe2:pepepass2"
+        self.environ["CONAN_SERVER_PUBLIC_PORT"] = "1234"
 
         config = ConanServerConfigParser(self.file_path, environment=self.environ)
         self.assertEquals(config.jwt_secret,  "newkey")
@@ -70,23 +105,34 @@ class ServerConfTest(unittest.TestCase):
         self.assertEquals(config.read_permissions, [("*/*@*/*", "*"),
                                                     ("openssl/2.0.1@lasote/testing", "pepe")])
         self.assertEquals(config.users, {"lasote": "lasotepass", "pepe2": "pepepass2"})
+        self.assertEquals(config.public_port, 1234)
+        self.assertEquals(config.public_url, "http://noname:1234/v1")
     
-    def writeVersion(self, version):
-        # A version.txt file 
-        save(os.path.join(self.conf_path, "version.txt"), version)
+    
+    def test_migration_without_store_adapter(self):
+        """ Seems to be here for some reason """
+        config1 = self.loadConfig()
+        config1.set("server", "store_adapter", "other")
+        self.writeConfig(config1)
+        #migrate
+        self.assertEqual(config1.store_adapter, "other")
+        migrate_and_get_server_config(self.file_path)
+        self.assertEqual(self.readVersion(), VERSION)
+        config = ConanServerConfigParser(self.file_path)
+        self.assertEqual(config.store_adapter, "other")
 
     def test_migration_from_0_1(self):
-        # Should delete all files
+        """ Should delete all files """
         self.writeVersion("0.1")
         migrate_and_get_server_config(self.file_path, self.storage_path)
         self.assertFalse(os.path.exists(self.storage_path))
-        self.assertFalse(os.path.exists(self.conf_path))
+        self.assertFalse(os.path.exists(os.path.join(self.conf_path, "server.conf")))
     
     def test_migration_from_0_19(self):
-        # Should add authentication and htpasswd_file
+        """ Should add authentication and htpasswd_file """
         migrate_and_get_server_config(self.file_path, self.storage_path)
         # load it
-        config = ConanServerConfigParser(self.file_path, environment=self.environ)
+        config = self.loadConfig()
         self.assertEquals(config.authentication, ["basic"])
         # assumes that the conig file has been loaded
         self.assertEquals(config.get("server", "htpasswd_file"), "")
@@ -98,6 +144,14 @@ class ServerConfTest(unittest.TestCase):
         self.assertEquals(config.htpasswd_file, "fancyfile")
 
     def test_auto_creates_conf(self):
+        """ Should automatically create a config file """
         os.remove(os.path.join(self.conf_path, "server.conf"))
         config = ConanServerConfigParser(self.file_path, environment=self.environ)
         self.assertTrue(config.jwt_secret != None)
+        self.assertTrue(os.path.exists(os.path.join(self.conf_path, "server.conf")))
+    
+    def test_invalid_section(self):
+        """ Should throw if requesting unknown section """
+        config = self.loadConfig()
+        with self.assertRaises(ConanException):
+            config._get_file_conf("notdefinedsection")

--- a/conans/test/server/conf_test.py
+++ b/conans/test/server/conf_test.py
@@ -85,10 +85,18 @@ class ServerConfTest(unittest.TestCase):
     def test_migration_from_0_19(self):
         # Should add authentication and htpasswd_file
         migrate_and_get_server_config(self.file_path, self.storage_path)
+        # load it
+        config = ConanServerConfigParser(self.file_path, environment=self.environ)
         self.assertEquals(config.authentication, ["basic"])
         # assumes that the conig file has been loaded
         self.assertEquals(config.get("server", "htpasswd_file"), "")
-    
+        # now check with
+        self.environ["CONAN_SERVER_AUTHENTICATION"] = "htpasswd,ldap,test"
+        self.environ["CONAN_HTPASSWD_FILE"] = "fancyfile"
+        config = ConanServerConfigParser(self.file_path, environment=self.environ)
+        self.assertEquals(config.authentication, ["htpasswd", "ldap", "test"])
+        self.assertEquals(config.htpasswd_file, "fancyfile")
+
     def test_auto_creates_conf(self):
         os.remove(os.path.join(self.conf_path, "server.conf"))
         config = ConanServerConfigParser(self.file_path, environment=self.environ)

--- a/conans/test/server/utils/dummy_server_conf.py
+++ b/conans/test/server/utils/dummy_server_conf.py
@@ -1,0 +1,62 @@
+"""
+Generate a test server config 
+"""
+import random
+import string
+from passlib.apache import HtpasswdFile
+
+test_server_conf = """[server]
+jwt_secret: {jwt_secret}
+jwt_expire_minutes: 120
+
+ssl_enabled: False
+port: 9300
+public_port:
+host_name: localhost
+
+store_adapter: disk
+authorize_timeout: 1800
+
+disk_storage_path: {storage_path}
+disk_authorize_timeout: 1800
+updown_secret: {updown_secret}
+
+
+[write_permissions]
+{write_permissions}
+[read_permissions]
+{read_permissions}
+[authentication]
+{authentication}
+[users]
+{users}
+"""
+
+def _tuple_to_conf(t):
+    # Converts a tuple to a config string
+    return "%s: %s" % (t[0],t[1])
+
+def create_dummy_server_conf(storage_path, read_permissions = ("*/*@*/*", "*"), write_permissions = (), users={"demo":"demo"}, authentication={"basic": ""}):
+    """ Creates a dummy server conf
+    storage_path: the path to the data
+    read_permissions: default access to read
+    write_permissions: default access to write (empty)
+    users: dict of users 
+    authentication: dict of authentication plugins
+    """
+    jwt_random_secret = ''.join(random.choice(string.ascii_letters) for _ in range(24))
+    updown_random_secret = ''.join(random.choice(string.ascii_letters) for _ in range(24))
+    server_conf = test_server_conf.format(jwt_secret=jwt_random_secret,
+            updown_secret=updown_random_secret,
+            storage_path=storage_path,
+            users="\n".join(key + ": " + users[key] for key in users),
+            read_permissions="\n".join(_tuple_to_conf(a) for a in read_permissions),
+            write_permissions="\n".join(_tuple_to_conf(a) for a in write_permissions),
+            authentication="\n".join(key + ": " + authentication[key] for key in authentication))
+    return server_conf
+ 
+def create_dummy_htpasswd(loc, users):
+    ht = HtpasswdFile()
+    for k in users:
+        ht.set_password(k, users[k])
+    ht.save(loc)

--- a/conans/test/server/utils/dummy_server_conf.py
+++ b/conans/test/server/utils/dummy_server_conf.py
@@ -36,7 +36,7 @@ def _tuple_to_conf(t):
     # Converts a tuple to a config string
     return "%s: %s" % (t[0],t[1])
 
-def create_dummy_server_conf(storage_path, read_permissions = ("*/*@*/*", "*"), write_permissions = (), users={"demo":"demo"}, authentication={"basic": ""}):
+def create_dummy_server_conf(storage_path, read_permissions = [("*/*@*/*", "*")], write_permissions = [], users={"demo":"demo"}, authentication={"basic": ""}):
     """ Creates a dummy server conf
     storage_path: the path to the data
     read_permissions: default access to read
@@ -46,12 +46,21 @@ def create_dummy_server_conf(storage_path, read_permissions = ("*/*@*/*", "*"), 
     """
     jwt_random_secret = ''.join(random.choice(string.ascii_letters) for _ in range(24))
     updown_random_secret = ''.join(random.choice(string.ascii_letters) for _ in range(24))
+    if read_permissions:
+        read_permissions = "\n".join(_tuple_to_conf(a) for a in read_permissions)
+    else:
+        read_permissions = ""
+    if write_permissions:
+        "\n".join(_tuple_to_conf(a) for a in write_permissions)
+    else:
+        write_permissions = ""
+    # Create the config
     server_conf = test_server_conf.format(jwt_secret=jwt_random_secret,
             updown_secret=updown_random_secret,
             storage_path=storage_path,
             users="\n".join(key + ": " + users[key] for key in users),
-            read_permissions="\n".join(_tuple_to_conf(a) for a in read_permissions),
-            write_permissions="\n".join(_tuple_to_conf(a) for a in write_permissions),
+            read_permissions=read_permissions,
+            write_permissions=write_permissions,
             authentication="\n".join(key + ": " + authentication[key] for key in authentication))
     return server_conf
  

--- a/conans/test/server/utils/dummy_server_conf.py
+++ b/conans/test/server/utils/dummy_server_conf.py
@@ -51,7 +51,7 @@ def create_dummy_server_conf(storage_path, read_permissions = [("*/*@*/*", "*")]
     else:
         read_permissions = ""
     if write_permissions:
-        "\n".join(_tuple_to_conf(a) for a in write_permissions)
+        write_permissions = "\n".join(_tuple_to_conf(a) for a in write_permissions)
     else:
         write_permissions = ""
     # Create the config

--- a/conans/test/server/utils/dummy_server_conf.py
+++ b/conans/test/server/utils/dummy_server_conf.py
@@ -21,13 +21,13 @@ disk_storage_path: {storage_path}
 disk_authorize_timeout: 1800
 updown_secret: {updown_secret}
 
+authentication: {authentication}
+htpasswd_file: .htpasswd
 
 [write_permissions]
 {write_permissions}
 [read_permissions]
 {read_permissions}
-[authentication]
-{authentication}
 [users]
 {users}
 """
@@ -36,7 +36,7 @@ def _tuple_to_conf(t):
     # Converts a tuple to a config string
     return "%s: %s" % (t[0],t[1])
 
-def create_dummy_server_conf(storage_path, read_permissions = [("*/*@*/*", "*")], write_permissions = [], users={"demo":"demo"}, authentication={"basic": ""}):
+def create_dummy_server_conf(storage_path, read_permissions = [("*/*@*/*", "*")], write_permissions = [], users={"demo":"demo"}, authentication=["basic"]):
     """ Creates a dummy server conf
     storage_path: the path to the data
     read_permissions: default access to read
@@ -61,7 +61,7 @@ def create_dummy_server_conf(storage_path, read_permissions = [("*/*@*/*", "*")]
             users="\n".join(key + ": " + users[key] for key in users),
             read_permissions=read_permissions,
             write_permissions=write_permissions,
-            authentication="\n".join(key + ": " + authentication[key] for key in authentication))
+            authentication=",".join(key for key in authentication))
     return server_conf
  
 def create_dummy_htpasswd(loc, users):

--- a/conans/test/server/utils/server_launcher.py
+++ b/conans/test/server/utils/server_launcher.py
@@ -1,14 +1,13 @@
 #!/usr/bin/python
 from conans.server.service.authorize import BasicAuthorizer, AuthorizeManager
 import os
-from conans.server.conf import get_file_manager
+from conans.server.conf import ConanServerConfigParser, get_file_manager
 from conans.server.rest.server import ConanServer
 from conans.server.crypto.jwt.jwt_credentials_manager import JWTCredentialsManager
 from conans.server.crypto.jwt.jwt_updown_manager import JWTUpDownAuthManager
 from conans.util.log import logger
 from conans.util.files import mkdir, save
 from conans.test.utils.test_files import temp_folder
-from conans.server.migrate import migrate_and_get_server_config
 from conans.search.search import DiskSearchAdapter, DiskSearchManager
 from conans.paths import SimplePaths
 import time
@@ -60,7 +59,8 @@ class TestServerLauncher(object):
         config = create_dummy_server_conf(self.storage_folder, read_permissions, write_permissions, users, authentication)
         save(os.path.join(base_path, ".conan_server", "server.conf"), config)
         # now load the config
-        server_config = migrate_and_get_server_config(base_path, self.storage_folder)
+        # don't use migrate here, as no version info string is present!
+        server_config = ConanServerConfigParser(base_path, storage_folder=self.storage_folder)
 
         if TestServerLauncher.port == 0:
             TestServerLauncher.port = server_config.port

--- a/conans/test/server/utils/server_launcher.py
+++ b/conans/test/server/utils/server_launcher.py
@@ -1,12 +1,12 @@
 #!/usr/bin/python
-from conans.server.service.authorize import BasicAuthorizer, BasicAuthenticator
+from conans.server.service.authorize import BasicAuthorizer, AuthorizeManager
 import os
 from conans.server.conf import get_file_manager
 from conans.server.rest.server import ConanServer
 from conans.server.crypto.jwt.jwt_credentials_manager import JWTCredentialsManager
 from conans.server.crypto.jwt.jwt_updown_manager import JWTUpDownAuthManager
 from conans.util.log import logger
-from conans.util.files import mkdir
+from conans.util.files import mkdir, save
 from conans.test.utils.test_files import temp_folder
 from conans.server.migrate import migrate_and_get_server_config
 from conans.search.search import DiskSearchAdapter, DiskSearchManager
@@ -14,7 +14,7 @@ from conans.paths import SimplePaths
 import time
 import shutil
 from conans import SERVER_CAPABILITIES
-
+from conans.test.server.utils.dummy_server_conf import create_dummy_server_conf 
 
 TESTING_REMOTE_PRIVATE_USER = "private_user"
 TESTING_REMOTE_PRIVATE_PASS = "private_pass"
@@ -25,14 +25,14 @@ class TestServerLauncher(object):
 
     def __init__(self, base_path=None, read_permissions=None,
                  write_permissions=None, users=None, base_url=None, plugins=None,
-                 server_version=None,
+                 server_version=None, authentication=None,
                  min_client_compatible_version=None,
                  server_capabilities=None):
 
         plugins = plugins or []
         if not base_path:
             base_path = temp_folder()
-
+        
         if server_capabilities is None:
             server_capabilities = SERVER_CAPABILITIES  # Default enabled
 
@@ -41,8 +41,25 @@ class TestServerLauncher(object):
 
         # Define storage_folder, if not, it will be readed from conf file and pointed to real user home
         self.storage_folder = os.path.join(base_path, ".conan_server", "data")
+        self.config_folder = os.path.join(base_path, ".conan_server")
         mkdir(self.storage_folder)
+        # Prepare some test users
+        if not read_permissions:
+            read_permissions = server_config.read_permissions
+            read_permissions.append(("private_library/1.0.0@private_user/testing", "*"))
+            read_permissions.append(("*/*@*/*", "*"))
 
+        if not write_permissions:
+            write_permissions = server_config.write_permissions
+
+        if not users:
+            users = []
+        users[TESTING_REMOTE_PRIVATE_USER] = TESTING_REMOTE_PRIVATE_PASS
+        # create test server create_dummy_server_conf
+        logger.debug("Creating dummy configuration")
+        config = create_dummy_server_conf(self.storage_folder, read_permissions, write_permissions, users, authentication)
+        save(os.path.join(base_path, ".conan_server", "server.conf"), config)
+        # now load the config
         server_config = migrate_and_get_server_config(base_path, self.storage_folder)
 
         if TestServerLauncher.port == 0:
@@ -56,22 +73,10 @@ class TestServerLauncher(object):
 
         search_adapter = DiskSearchAdapter()
         self.search_manager = DiskSearchManager(SimplePaths(server_config.disk_storage_path), search_adapter)
-        # Prepare some test users
-        if not read_permissions:
-            read_permissions = server_config.read_permissions
-            read_permissions.append(("private_library/1.0.0@private_user/testing", "*"))
-            read_permissions.append(("*/*@*/*", "*"))
 
-        if not write_permissions:
-            write_permissions = server_config.write_permissions
 
-        if not users:
-            users = dict(server_config.users)
-
-        users[TESTING_REMOTE_PRIVATE_USER] = TESTING_REMOTE_PRIVATE_PASS
-
-        authorizer = BasicAuthorizer(read_permissions, write_permissions)
-        authenticator = BasicAuthenticator(users)
+        authorizer = BasicAuthorizer(server_config.read_permissions, server_config.write_permissions)
+        authenticator = AuthorizeManager(server_config)
         credentials_manager = JWTCredentialsManager(server_config.jwt_secret,
                                                     server_config.jwt_expire_time)
 

--- a/conans/test/server/utils/server_launcher.py
+++ b/conans/test/server/utils/server_launcher.py
@@ -45,11 +45,12 @@ class TestServerLauncher(object):
         mkdir(self.storage_folder)
         # Prepare some test users
         if not read_permissions:
+            read_permissions = []
             read_permissions.append(("private_library/1.0.0@private_user/testing", "*"))
             read_permissions.append(("*/*@*/*", "*"))
 
         if not users:
-            users = []
+            users = {}
         users[TESTING_REMOTE_PRIVATE_USER] = TESTING_REMOTE_PRIVATE_PASS
         # create test server create_dummy_server_conf
         logger.debug("Creating dummy configuration")

--- a/conans/test/server/utils/server_launcher.py
+++ b/conans/test/server/utils/server_launcher.py
@@ -51,6 +51,9 @@ class TestServerLauncher(object):
 
         if not users:
             users = {}
+        # Default: basic
+        if not authentication:
+            authentication = {"basic" : ""}
         users[TESTING_REMOTE_PRIVATE_USER] = TESTING_REMOTE_PRIVATE_PASS
         # create test server create_dummy_server_conf
         logger.debug("Creating dummy configuration")

--- a/conans/test/server/utils/server_launcher.py
+++ b/conans/test/server/utils/server_launcher.py
@@ -45,12 +45,8 @@ class TestServerLauncher(object):
         mkdir(self.storage_folder)
         # Prepare some test users
         if not read_permissions:
-            read_permissions = server_config.read_permissions
             read_permissions.append(("private_library/1.0.0@private_user/testing", "*"))
             read_permissions.append(("*/*@*/*", "*"))
-
-        if not write_permissions:
-            write_permissions = server_config.write_permissions
 
         if not users:
             users = []

--- a/conans/test/tools.py
+++ b/conans/test/tools.py
@@ -169,6 +169,7 @@ class TestServer(object):
                  write_permissions=None, users=None, plugins=None, base_path=None,
                  server_version=Version(SERVER_VERSION),
                  min_client_compatible_version=Version(MIN_CLIENT_COMPATIBLE_VERSION),
+                 authentication=None,
                  server_capabilities=None):
         """
              'read_permissions' and 'write_permissions' is a list of:
@@ -186,13 +187,16 @@ class TestServer(object):
             write_permissions = []
         if users is None:
             users = {"lasote": "mypass"}
-
+        if authentication is None:
+            authentication = {"basic": ""}
+        
         self.fake_url = "http://fake%s.com" % str(uuid.uuid4()).replace("-", "")
         min_client_ver = min_client_compatible_version
         self.test_server = TestServerLauncher(base_path, read_permissions,
                                               write_permissions, users,
                                               base_url=self.fake_url + "/v1",
                                               plugins=plugins,
+                                              authentication=authentication,
                                               server_version=server_version,
                                               min_client_compatible_version=min_client_ver,
                                               server_capabilities=server_capabilities)
@@ -202,6 +206,10 @@ class TestServer(object):
     def paths(self):
         return self.test_server.file_manager.paths
 
+    @property
+    def config_path(self):
+        return self.test_server.storage_folder
+    
     def __repr__(self):
         return "TestServer @ " + self.fake_url
 


### PR DESCRIPTION
Creating a htpasswd compatible middleware to allow authentication against secure files

To allow multiple authorizations, a middleware is added. On instantiation, the authenticators get the server_config and the parameter defined in the config.