### PR TITLE
AAP generator was added

### DIFF
--- a/conans/client/generators/__init__.py
+++ b/conans/client/generators/__init__.py
@@ -13,6 +13,7 @@ from .ycm import YouCompleteMeGenerator
 from .virtualenv import VirtualEnvGenerator
 from .env import ConanEnvGenerator
 from .cmake_multi import CMakeMultiGenerator
+from .aap import AapGenerator
 
 
 def _save_generator(name, klass):
@@ -31,6 +32,7 @@ _save_generator("xcode", XCodeGenerator)
 _save_generator("ycm", YouCompleteMeGenerator)
 _save_generator("virtualenv", VirtualEnvGenerator)
 _save_generator("env", ConanEnvGenerator)
+_save_generator("aap", AapGenerator)
 
 
 def write_generators(conanfile, path, output):

--- a/conans/client/generators/aap.py
+++ b/conans/client/generators/aap.py
@@ -1,0 +1,30 @@
+import os
+from conans.model import Generator
+
+class AapGenerator(Generator):
+    @property
+    def filename(self):
+        return 'conanbuildinfo.aap'
+
+    @property
+    def content(self):
+        all_libraries = [os.path.join(foler,lib) for foler in self.deps_build_info.lib_paths for lib in self.deps_build_info.libs]
+        existing_libs = filter(lambda x: any(os.path.exists(file) for file in [x + ext for ext in ['.lib', '.a', '.so']]), all_libraries)
+
+        content = \
+            'INCLUDE += %s\n' \
+            'LIBS += %s\n' \
+            'DEFINE += %s\n' \
+            'CPPFLAGS += %s\n' \
+            'CFLAGS += %s\n' \
+            'SHLINKFLAGS += %s\n' \
+            'LDFLAGS += %s\n' % (
+            ' '.join('-I' + x for x in self.deps_build_info.include_paths),
+            ' '.join('-l' + x for x in existing_libs),
+            ' '.join('-D' + x for x in self.deps_build_info.defines),
+            ' '.join(self.deps_build_info.cppflags),
+            ' '.join(self.deps_build_info.cflags),
+            ' '.join(self.deps_build_info.sharedlinkflags),
+            ' '.join(self.deps_build_info.exelinkflags))
+
+        return content

--- a/conans/test/generators/aap_test.py
+++ b/conans/test/generators/aap_test.py
@@ -1,0 +1,24 @@
+import re
+import unittest
+from conans.model.settings import Settings
+from conans.model.conan_file import ConanFile
+from conans.client.generators.aap import AapGenerator
+from conans.model.build_info import DepsCppInfo
+from conans.model.ref import ConanFileReference
+
+
+class SConsGeneratorTest(unittest.TestCase):
+    def variables_setup_test(self):
+        conanfile = ConanFile(None, None, Settings({}), None)
+        ref = ConanFileReference.loads("MyPkg/0.1@lasote/stables")
+        cpp_info = DepsCppInfo()
+        cpp_info.defines = ["MYDEFINE1"]
+        conanfile.deps_cpp_info.update(cpp_info, ref)
+        ref = ConanFileReference.loads("MyPkg2/0.1@lasote/stables")
+        cpp_info = DepsCppInfo()
+        cpp_info.defines = ["MYDEFINE2"]
+        conanfile.deps_cpp_info.update(cpp_info, ref)
+        generator = AapGenerator(conanfile)
+        content = generator.content
+        content_lines = content.splitlines()
+        self.assertIn('DEFINE += -DMYDEFINE1 - DMYDEFINE2', content_lines)

--- a/conans/test/generators/aap_test.py
+++ b/conans/test/generators/aap_test.py
@@ -7,7 +7,7 @@ from conans.model.build_info import DepsCppInfo
 from conans.model.ref import ConanFileReference
 
 
-class SConsGeneratorTest(unittest.TestCase):
+class AapGeneratorTest(unittest.TestCase):
     def variables_setup_test(self):
         conanfile = ConanFile(None, None, Settings({}), None)
         ref = ConanFileReference.loads("MyPkg/0.1@lasote/stables")
@@ -21,4 +21,4 @@ class SConsGeneratorTest(unittest.TestCase):
         generator = AapGenerator(conanfile)
         content = generator.content
         content_lines = content.splitlines()
-        self.assertIn('DEFINE += -DMYDEFINE1 - DMYDEFINE2', content_lines)
+        self.assertIn('DEFINE += -DMYDEFINE2 -DMYDEFINE1', content_lines)

--- a/conans/test/generators_test.py
+++ b/conans/test/generators_test.py
@@ -17,6 +17,7 @@ txt
 visual_studio
 xcode
 ycm
+aap
     '''
         files = {"conanfile.txt": base}
         client = TestClient()
@@ -25,5 +26,5 @@ ycm
         self.assertEqual(sorted(['conanfile.txt', 'conaninfo.txt', 'conanbuildinfo.cmake',
                                  'conanbuildinfo.gcc', 'conanbuildinfo.qbs', 'conanbuildinfo.pri',
                                  'SConscript_conan', 'conanbuildinfo.txt', 'conanbuildinfo.props',
-                                 'conanbuildinfo.xcconfig', '.ycm_extra_conf.py']),
+                                 'conanbuildinfo.xcconfig', '.ycm_extra_conf.py', 'conanbuildinfo.aap']),
                          sorted(os.listdir(client.current_folder)))


### PR DESCRIPTION
Generator for [AAP build system](http://www.agide.org/) was added. The output is a file **conanbuildinfo.aap** with the following content:
```
INCLUDE += -Iinclude_path_1 -Iinclude_path_2
LIBS += -labs_path_to_lib_1 -labs_path_to_lib_2
DEFINE += -DSOME_DEFINE
CPPFLAGS += <...>
CFLAGS += <...>
SHLINKFLAGS += <...> 
LDFLAGS += <...>
```

Known problems:
1. There is no way to specify a path to a library in a platform-independent way. The only option is to specify a full path to the library without its extension (see LIBS above).
It would be much easier, if the base class `Generator` has settings passed from conan (os, arch, compiler, etc.). In this case a library path could be appended to LDFLAGS with "/LIBPATH:" prefix for "Visual Studio" compiler and with "-L" prefix for other ones.
2. Only the common build info is used to easier the integration into AAP scripts. In order to generate different flags for specific libraries the ability to generate several files by a generator is needed (in my opinion). E.g. conanbuildinfo.aap, conanbuildinfo_zlib.aap.

The usage in AAP script:
```
:include conanbuildinfo.aap
```