### PR TITLE
Preserve links when exporting

### DIFF
--- a/conans/client/export.py
+++ b/conans/client/export.py
@@ -77,13 +77,13 @@ def _export(conanfile, origin_folder, destination_folder, output):
 
     copier = FileCopier(origin_folder, destination_folder)
     for pattern in exports:
-        copier(pattern)
+        copier(pattern, links=True)
     # create directory for sources, and import them
     export_sources_dir = os.path.join(destination_folder, EXPORT_SOURCES_DIR)
     mkdir(export_sources_dir)
     copier = FileCopier(origin_folder, export_sources_dir)
     for pattern in exports_sources:
-        copier(pattern)
+        copier(pattern, links=True)
     package_output = ScopedOutput("%s export" % output.scope, output)
     copier.report(package_output)
 

--- a/conans/client/source.py
+++ b/conans/client/source.py
@@ -39,7 +39,7 @@ def config_source(export_folder, src_folder, conan_file, output, force=False):
 
     if not os.path.exists(src_folder):
         output.info('Configuring sources in %s' % src_folder)
-        shutil.copytree(export_folder, src_folder)
+        shutil.copytree(export_folder, src_folder, symlinks=True)
         # Now move the export-sources to the right location
         source_sources_folder = os.path.join(src_folder, EXPORT_SOURCES_DIR)
         if os.path.exists(source_sources_folder):

--- a/conans/test/integration/symlinks_test.py
+++ b/conans/test/integration/symlinks_test.py
@@ -1,7 +1,7 @@
 import unittest
 from conans.test.tools import TestClient, TestServer
 from conans.util.files import load, save
-from conans.model.ref import PackageReference
+from conans.model.ref import PackageReference, ConanFileReference
 import os
 import platform
 
@@ -13,6 +13,7 @@ import os
 class HelloConan(ConanFile):
     name = "Hello"
     version = "0.1"
+    exports = "*"
 
     def build(self):
         save("file1.txt", "Hello1")
@@ -20,6 +21,7 @@ class HelloConan(ConanFile):
 
     def package(self):
         self.copy("*.txt*", links=True)
+        self.copy("*.so*", links=True)
 """
 
 test_conanfile = """[requires]
@@ -64,6 +66,37 @@ class SymLinksTest(unittest.TestCase):
 
         client.run("install --build -f=conanfile.txt")
         self._check(client, ref)
+
+    def export_test(self):
+        if platform.system() == "Windows":
+            return
+
+        lib_name = "libtest.so.2"
+        lib_contents = "TestLib"
+        link_name = "libtest.so"
+
+        client = TestClient()
+        client.save({"conanfile.py": conanfile,
+                     "conanfile.txt": test_conanfile,
+                     lib_name: lib_contents})
+
+        pre_export_link = os.path.join(client.current_folder, link_name)
+        os.symlink(lib_name, pre_export_link)
+
+        client.run("export lasote/stable")
+        client.run("install --build -f=conanfile.txt")
+        conan_ref = ConanFileReference.loads("Hello/0.1@lasote/stable")
+        package_ref = PackageReference(conan_ref,
+                                       "5ab84d6acfe1f23c4fae0ab88f26e3a396351ac9")
+
+        export_directory = client.paths.export(conan_ref)
+        exported_lib = os.path.join(export_directory, lib_name)
+        exported_link = os.path.join(export_directory, link_name)
+
+        self.assertEqual(load(exported_lib), load(exported_link))
+        self.assertTrue(os.path.islink(exported_link))
+
+        self._check(client, package_ref)
 
     def upload_test(self):
         if platform.system() == "Windows":

--- a/conans/test/integration/symlinks_test.py
+++ b/conans/test/integration/symlinks_test.py
@@ -89,12 +89,14 @@ class SymLinksTest(unittest.TestCase):
         package_ref = PackageReference(conan_ref,
                                        "5ab84d6acfe1f23c4fae0ab88f26e3a396351ac9")
 
-        export_directory = client.paths.export(conan_ref)
-        exported_lib = os.path.join(export_directory, lib_name)
-        exported_link = os.path.join(export_directory, link_name)
+        for folder in [client.paths.export(conan_ref), client.paths.source(conan_ref),
+                       client.paths.build(package_ref), client.paths.package(package_ref)]:
+            exported_lib = os.path.join(folder, lib_name)
+            exported_link = os.path.join(folder, link_name)
+            self.assertEqual(os.readlink(exported_link), lib_name)
 
-        self.assertEqual(load(exported_lib), load(exported_link))
-        self.assertTrue(os.path.islink(exported_link))
+            self.assertEqual(load(exported_lib), load(exported_link))
+            self.assertTrue(os.path.islink(exported_link))
 
         self._check(client, package_ref)
 


### PR DESCRIPTION
Previously, the `FileCopier` used for exporting did not preserve symbolic links. This caused issues for packages which contain static asset libraries. For example:

```
├── shared_library.so -> shared_library.so.2
└── shared_library.so.2
```

If the package exports these files, the symbolic link was not previously preserved. Instead, the conan store would receive duplicates of the same file, under the different names.

I believe the `links=True` addition to the export logic will change this behavior.
