### PR TITLE
Add loghandler for patch module

### DIFF
--- a/conans/test/conanfile_tools_test.py
+++ b/conans/test/conanfile_tools_test.py
@@ -8,6 +8,7 @@ from conans.test.utils.test_files import temp_folder
 from conans.model.scope import Scopes
 from conans import tools
 from nose_parameterized.parameterized import parameterized
+from conans.test.tools import TestBufferConanOutput, TestClient
 
 
 base_conanfile = '''
@@ -91,6 +92,20 @@ class ConanfileToolsTest(unittest.TestCase):
 '''
         tmp_dir, file_path, text_file = self._save_files(file_content)
         self._build_and_check(tmp_dir, file_path, text_file, "ONE TWO DOH!")
+
+    def test_error_patch(self):
+        file_content = base_conanfile + '''
+    def build(self):
+        patch_content = "some corrupted patch"
+        patch(patch_string=patch_content, output=self.output)
+
+'''
+        client = TestClient()
+        client.save({"conanfile.py": file_content})
+        error = client.run("build", ignore_error=True)
+        self.assertTrue(error)
+        self.assertIn("patch: error: no patch data found!", client.user_io.out)
+        self.assertIn("ERROR: Failed to parse patch: string", client.user_io.out)
 
     def _save_files(self, file_content):
         tmp_dir = temp_folder()

--- a/conans/tools.py
+++ b/conans/tools.py
@@ -208,14 +208,14 @@ def check_sha256(file_path, signature):
     check_with_algorithm_sum("sha256", file_path, signature)
 
 
-def patch(base_path=None, patch_file=None, patch_string=None, strip=0):
+def patch(base_path=None, patch_file=None, patch_string=None, strip=0, output=None):
     """Applies a diff from file (patch_file)  or string (patch_string)
     in base_path directory or current dir if None"""
 
     class PatchLogHandler(logging.Handler):
         def __init__(self):
             logging.Handler.__init__(self, logging.DEBUG)
-            self.output = ConanOutput(sys.stdout, True)
+            self.output = output or ConanOutput(sys.stdout, True)
             self.patchname = patch_file if patch_file else "patch"
 
         def emit(self, record):


### PR DESCRIPTION
If something goes wrong with tools.patch() today you
get a very generic problem and it can be hard to track
down. Fortunately patch provides a logging logger that
can be used to output ConanOutput information. This
gives way better info than just the generic exception.