### PR TITLE
Artifactory build-info processing changes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,19 +15,19 @@ matrix:
     include:
         - language: generic
           os: osx
-          env: PYVER=py27 CONAN_COMPILER=apple-clang CONAN_COMPILER_VERSION=6.0
+          env: PYVER=py27 CONAN_COMPILER=apple-clang CONAN_COMPILER_VERSION=6.0 CONAN_LOGGING_LEVEL=20
         
         - language: generic
           os: osx
-          env: PYVER=py34 CONAN_COMPILER=apple-clang CONAN_COMPILER_VERSION=6.0
+          env: PYVER=py34 CONAN_COMPILER=apple-clang CONAN_COMPILER_VERSION=6.0 CONAN_LOGGING_LEVEL=20
           
         - language: generic
           os: osx
-          env: PYVER=py35 CONAN_COMPILER=apple-clang CONAN_COMPILER_VERSION=6.0
+          env: PYVER=py35 CONAN_COMPILER=apple-clang CONAN_COMPILER_VERSION=6.0 CONAN_LOGGING_LEVEL=20
           
         - language: generic
           os: osx
-          env: PYVER=py36 CONAN_COMPILER=apple-clang CONAN_COMPILER_VERSION=6.0
+          env: PYVER=py36 CONAN_COMPILER=apple-clang CONAN_COMPILER_VERSION=6.0 CONAN_LOGGING_LEVEL=20
 
 # command to install dependencies
 install:

--- a/conans/client/client_cache.py
+++ b/conans/client/client_cache.py
@@ -45,12 +45,13 @@ class ClientCache(SimplePaths):
         try:
             contents = load(self.put_headers_path)
             for line in contents.splitlines():
-                tmp = line.split("=", 1)
-                if len(tmp) != 2:
-                    raise Exception()
-                name = tmp[0].strip()
-                value = tmp[1].strip()
-                ret[name] = value
+                if line:
+                    tmp = line.split("=", 1)
+                    if len(tmp) != 2:
+                        raise Exception()
+                    name = tmp[0].strip()
+                    value = tmp[1].strip()
+                    ret[name] = value
             return ret
         except Exception:
             raise ConanException("Invalid %s file!" % self.put_headers_path)

--- a/conans/client/client_cache.py
+++ b/conans/client/client_cache.py
@@ -1,4 +1,6 @@
 import os
+
+from conans.errors import ConanException
 from conans.util.files import save, load, mkdir, normalize
 from conans.model.settings import Settings
 from conans.client.conf import ConanClientConfigParser, default_client_conf, default_settings_yml
@@ -6,7 +8,7 @@ from conans.model.values import Values
 from conans.client.detect import detect_defaults_settings
 from conans.model.ref import ConanFileReference
 from conans.model.manifest import FileTreeManifest
-from conans.paths import SimplePaths, CONANINFO
+from conans.paths import SimplePaths, CONANINFO, PUT_HEADERS
 from genericpath import isdir
 from conans.model.info import ConanInfo
 
@@ -30,6 +32,30 @@ class ClientCache(SimplePaths):
         self._output = output
         self._store_folder = store_folder or self.conan_config.storage_path or self.conan_folder
         super(ClientCache, self).__init__(self._store_folder)
+
+    @property
+    def put_headers_path(self):
+        return os.path.join(self.conan_folder, PUT_HEADERS)
+
+    def read_put_headers(self):
+        ret = {}
+        print(self.put_headers_path)
+        if not os.path.exists(self.put_headers_path):
+            save(self.put_headers_path, "")
+            return ret
+        try:
+            contents = load(self.put_headers_path)
+            for line in contents.splitlines():
+                tmp = line.split("=", 1)
+                if len(tmp) != 2:
+                    raise Exception()
+                name = tmp[0].strip()
+                value = tmp[1].strip()
+                ret[name] = value
+            return ret
+        except Exception:
+            raise ConanException("Invalid %s file!" % self.put_headers_path)
+
 
     @property
     def registry(self):

--- a/conans/client/client_cache.py
+++ b/conans/client/client_cache.py
@@ -51,7 +51,7 @@ class ClientCache(SimplePaths):
                         raise Exception()
                     name = tmp[0].strip()
                     value = tmp[1].strip()
-                    ret[name] = value
+                    ret[str(name)] = str(value)
             return ret
         except Exception:
             raise ConanException("Invalid %s file!" % self.put_headers_path)

--- a/conans/client/client_cache.py
+++ b/conans/client/client_cache.py
@@ -39,7 +39,6 @@ class ClientCache(SimplePaths):
 
     def read_put_headers(self):
         ret = {}
-        print(self.put_headers_path)
         if not os.path.exists(self.put_headers_path):
             save(self.put_headers_path, "")
             return ret

--- a/conans/client/command.py
+++ b/conans/client/command.py
@@ -1039,7 +1039,8 @@ def get_command():
                                                             Version(MIN_SERVER_COMPATIBLE_VERSION),
                                                             out)
         # To handle remote connections
-        rest_api_client = RestApiClient(out, requester=version_checker_requester)
+        put_headers = client_cache.read_put_headers()
+        rest_api_client = RestApiClient(out, requester=version_checker_requester, put_headers=put_headers)
         # To store user and token
         localdb = LocalDB(client_cache.localdb)
         # Wraps RestApiClient to add authentication support (same interface)

--- a/conans/client/rest/rest_client.py
+++ b/conans/client/rest/rest_client.py
@@ -67,7 +67,7 @@ class RestApiClient(object):
         Rest Api Client for handle remote.
     """
 
-    def __init__(self, output, requester):
+    def __init__(self, output, requester, put_headers=None):
 
         # Set to instance
         self.token = None
@@ -76,6 +76,7 @@ class RestApiClient(object):
         self._output = output
         self.requester = requester
         self._verify_ssl = True
+        self._put_headers = put_headers
 
     @property
     def verify_ssl(self):
@@ -469,7 +470,7 @@ class RestApiClient(object):
             auth, dedup = self._file_server_capabilities(resource_url)
             try:
                 response = uploader.upload(resource_url, files[filename], auth=auth, dedup=dedup,
-                                           retry=retry, retry_wait=retry_wait)
+                                           retry=retry, retry_wait=retry_wait, headers=self._put_headers)
                 output.writeln("")
                 if not response.ok:
                     output.error("\nError uploading file: %s, '%s'" % (filename, response.content))

--- a/conans/client/rest/uploader_downloader.py
+++ b/conans/client/rest/uploader_downloader.py
@@ -35,7 +35,7 @@ class Uploader(object):
         iterable_to_file = IterableToFileAdapter(it, file_size)
         # Now it is prepared to work with request
         ret = call_with_retry(self.output, retry, retry_wait, self._upload_file, url,
-                              data=iterable_to_file, headers=None, auth=auth)
+                              data=iterable_to_file, headers=headers, auth=auth)
 
         return ret
 

--- a/conans/client/rest/uploader_downloader.py
+++ b/conans/client/rest/uploader_downloader.py
@@ -15,10 +15,11 @@ class Uploader(object):
         self.requester = requester
         self.verify = verify
 
-    def upload(self, url, abs_path, auth=None, dedup=False, retry=1, retry_wait=0):
+    def upload(self, url, abs_path, auth=None, dedup=False, retry=1, retry_wait=0, headers=None):
         if dedup:
-            headers = {"X-Checksum-Deploy": "true",
-                       "X-Checksum-Sha1": sha1sum(abs_path)}
+            headers = headers or {}
+            headers["X-Checksum-Deploy"] = "true"
+            headers["X-Checksum-Sha1"] = sha1sum(abs_path)
             response = self.requester.put(url, data="", verify=self.verify, headers=headers,
                                           auth=auth)
             if response.status_code != 404:

--- a/conans/client/rest/uploader_downloader.py
+++ b/conans/client/rest/uploader_downloader.py
@@ -17,14 +17,15 @@ class Uploader(object):
 
     def upload(self, url, abs_path, auth=None, dedup=False, retry=1, retry_wait=0, headers=None):
         if dedup:
-            headers = headers or {}
-            headers["X-Checksum-Deploy"] = "true"
-            headers["X-Checksum-Sha1"] = sha1sum(abs_path)
-            response = self.requester.put(url, data="", verify=self.verify, headers=headers,
+            dedup_headers = {"X-Checksum-Deploy": "true", "X-Checksum-Sha1": sha1sum(abs_path)}
+            if headers:
+                dedup_headers.update(headers)
+            response = self.requester.put(url, data="", verify=self.verify, headers=dedup_headers,
                                           auth=auth)
             if response.status_code != 404:
                 return response
 
+        headers = headers or {}
         self.output.info("")
         # Actual transfer of the real content
         it = load_in_chunks(abs_path, self.chunk_size)

--- a/conans/paths.py
+++ b/conans/paths.py
@@ -29,6 +29,7 @@ CONANINFO = "conaninfo.txt"
 CONANENV = "conanenv.txt"
 SYSTEM_REQS = "system_reqs.txt"
 DIRTY_FILE = ".conan_dirty"
+PUT_HEADERS = "artifacts.properties"
 
 PACKAGE_TGZ_NAME = "conan_package.tgz"
 EXPORT_TGZ_NAME = "conan_export.tgz"

--- a/conans/test/put_properties_test.py
+++ b/conans/test/put_properties_test.py
@@ -1,0 +1,47 @@
+import os
+import unittest
+from conans.test.tools import TestClient, TestRequester, TestServer
+from conans.test.utils.cpp_test_files import cpp_hello_conan_files
+from conans.util.files import save
+
+
+class PutPropertiesTest(unittest.TestCase):
+
+    def setUp(self):
+        test_server = TestServer()
+        self.servers = {"default": test_server}
+
+    def create_empty_property_file_test(self):
+
+        files = cpp_hello_conan_files("Hello0", "0.1", build=False)
+        self.client.save(files)
+        self.client.run("export lasote/stable")
+        props_file = self.client.client_cache.put_headers_path
+        self.assertTrue(os.path.exists(props_file))
+
+    def put_properties_test(self):
+        wanted_vars = {"MyHeader1": "MyHeaderValue1;MyHeaderValue2", "Other": "Value"}
+
+        class RequesterCheckHeaders(TestRequester):
+            def put(self, url, data, headers=None, verify=None, auth=None):
+                for name, value in wanted_vars.items():
+                    value1 = headers[name]
+                    if value1 != value:
+                        raise Exception()
+                return super(RequesterCheckHeaders, self).put(url, data, headers, verify, auth)
+
+        self.client = TestClient(requester_class=RequesterCheckHeaders, servers=self.servers,
+                                 users={"default": [("lasote", "mypass")]})
+        _create_property_files(self.client, wanted_vars)
+
+        files = cpp_hello_conan_files("Hello0", "0.1", build=False)
+        self.client.save(files)
+        self.client.run("export lasote/stable")
+        self.client.run("upload Hello0/0.1@lasote/stable -c")
+
+
+def _create_property_files(client, values):
+    lines = []
+    for name, value in values.items():
+        lines.append("%s=%s" % (name, value))
+    save(client.client_cache.put_headers_path, "\n".join(lines))

--- a/conans/test/put_properties_test.py
+++ b/conans/test/put_properties_test.py
@@ -14,9 +14,10 @@ class PutPropertiesTest(unittest.TestCase):
     def create_empty_property_file_test(self):
 
         files = cpp_hello_conan_files("Hello0", "0.1", build=False)
-        self.client.save(files)
-        self.client.run("export lasote/stable")
-        props_file = self.client.client_cache.put_headers_path
+        client = TestClient(servers=self.servers, users={"default": [("lasote", "mypass")]})
+        client.save(files)
+        client.run("export lasote/stable")
+        props_file = client.client_cache.put_headers_path
         self.assertTrue(os.path.exists(props_file))
 
     def put_properties_test(self):

--- a/conans/test/tools.py
+++ b/conans/test/tools.py
@@ -381,7 +381,8 @@ class TestClient(object):
         self.requester = VersionCheckerRequester(requester, self.client_version,
                                                  self.min_server_compatible_version, output)
 
-        self.rest_api_client = RestApiClient(output, requester=self.requester)
+        put_headers = self.client_cache.read_put_headers()
+        self.rest_api_client = RestApiClient(output, requester=self.requester, put_headers=put_headers)
         # To store user and token
         self.localdb = LocalDB(self.client_cache.localdb)
         # Wraps RestApiClient to add authentication support (same interface)


### PR DESCRIPTION
- Partial build-info objects only with downloads.
- Custom PUT headers with an `artifacts.properties` file.
- OSX logging level increased, the builds fail because of the MAX log size