### PR TITLE
removing quotes from cmake flags

### DIFF
--- a/conans/client/generators/cmake_common.py
+++ b/conans/client/generators/cmake_common.py
@@ -8,10 +8,10 @@ set(CONAN_LIBS_{dep}{build_type} {deps.libs})
 set(CONAN_DEFINES_{dep}{build_type} {deps.defines})
 # COMPILE_DEFINITIONS are equal to CONAN_DEFINES without -D, for targets
 set(CONAN_COMPILE_DEFINITIONS_{dep}{build_type} {deps.compile_definitions})
-set(CONAN_CXX_FLAGS_{dep}{build_type} "{deps.cppflags}")
-set(CONAN_SHARED_LINKER_FLAGS_{dep}{build_type} "{deps.sharedlinkflags}")
-set(CONAN_EXE_LINKER_FLAGS_{dep}{build_type} "{deps.exelinkflags}")
-set(CONAN_C_FLAGS_{dep}{build_type} "{deps.cflags}")
+set(CONAN_CXX_FLAGS_{dep}{build_type} {deps.cppflags})
+set(CONAN_SHARED_LINKER_FLAGS_{dep}{build_type} {deps.sharedlinkflags})
+set(CONAN_EXE_LINKER_FLAGS_{dep}{build_type} {deps.exelinkflags})
+set(CONAN_C_FLAGS_{dep}{build_type} {deps.cflags})
 """
 
 
@@ -49,10 +49,10 @@ set(CONAN_BIN_DIRS{build_type} {deps.bin_paths} ${{CONAN_BIN_DIRS{build_type}}})
 set(CONAN_RES_DIRS{build_type} {deps.res_paths} ${{CONAN_RES_DIRS{build_type}}})
 set(CONAN_LIBS{build_type} {deps.libs} ${{CONAN_LIBS{build_type}}})
 set(CONAN_DEFINES{build_type} {deps.defines} ${{CONAN_DEFINES{build_type}}})
-set(CONAN_CXX_FLAGS{build_type} "{deps.cppflags} ${{CONAN_CXX_FLAGS{build_type}}}")
-set(CONAN_SHARED_LINKER_FLAGS{build_type} "{deps.sharedlinkflags} ${{CONAN_SHARED_LINKER_FLAGS{build_type}}}")
-set(CONAN_EXE_LINKER_FLAGS{build_type} "{deps.exelinkflags} ${{CONAN_EXE_LINKER_FLAGS{build_type}}}")
-set(CONAN_C_FLAGS{build_type} "{deps.cflags} ${{CONAN_C_FLAGS{build_type}}}")
+set(CONAN_CXX_FLAGS{build_type} {deps.cppflags} ${{CONAN_CXX_FLAGS{build_type}}})
+set(CONAN_SHARED_LINKER_FLAGS{build_type} {deps.sharedlinkflags} ${{CONAN_SHARED_LINKER_FLAGS{build_type}}})
+set(CONAN_EXE_LINKER_FLAGS{build_type} {deps.exelinkflags} ${{CONAN_EXE_LINKER_FLAGS{build_type}}})
+set(CONAN_C_FLAGS{build_type} {deps.cflags} ${{CONAN_C_FLAGS{build_type}}})
 set(CONAN_CMAKE_MODULE_PATH{build_type} {deps.build_paths} ${{CONAN_CMAKE_MODULE_PATH{build_type}}})
 """
 

--- a/conans/test/generators/cmake_test.py
+++ b/conans/test/generators/cmake_test.py
@@ -31,6 +31,27 @@ class CMakeGeneratorTest(unittest.TestCase):
         self.assertIn("set(CONAN_COMPILE_DEFINITIONS_MYPKG MYDEFINE1)", cmake_lines)
         self.assertIn("set(CONAN_COMPILE_DEFINITIONS_MYPKG2 MYDEFINE2)", cmake_lines)
 
+    def multi_flag_test(self):
+        conanfile = ConanFile(None, None, Settings({}), None)
+        ref = ConanFileReference.loads("MyPkg/0.1@lasote/stables")
+        cpp_info = CppInfo("dummy_root_folder1")
+        cpp_info.includedirs.append("other_include_dir")
+        cpp_info.cppflags = ["-DGTEST_USE_OWN_TR1_TUPLE=1", "-DGTEST_LINKED_AS_SHARED_LIBRARY=1"]
+        conanfile.deps_cpp_info.update(cpp_info, ref)
+        ref = ConanFileReference.loads("MyPkg2/0.1@lasote/stables")
+        cpp_info = CppInfo("dummy_root_folder2")
+        cpp_info.cflags = ["-DSOMEFLAG=1"]
+        conanfile.deps_cpp_info.update(cpp_info, ref)
+        generator = CMakeGenerator(conanfile)
+        content = generator.content
+        cmake_lines = content.splitlines()
+        self.assertIn("set(CONAN_C_FLAGS_MYPKG2 -DSOMEFLAG=1)", cmake_lines)
+        self.assertIn("set(CONAN_CXX_FLAGS_MYPKG -DGTEST_USE_OWN_TR1_TUPLE=1"
+                      " -DGTEST_LINKED_AS_SHARED_LIBRARY=1)", cmake_lines)
+        self.assertIn("set(CONAN_C_FLAGS -DSOMEFLAG=1 ${CONAN_C_FLAGS})", cmake_lines)
+        self.assertIn("set(CONAN_CXX_FLAGS -DGTEST_USE_OWN_TR1_TUPLE=1"
+                      " -DGTEST_LINKED_AS_SHARED_LIBRARY=1 ${CONAN_CXX_FLAGS})", cmake_lines)
+
     def aux_cmake_test_setup_test(self):
         conanfile = ConanFile(None, None, Settings({}), None)
         generator = CMakeGenerator(conanfile)


### PR DESCRIPTION
Should address: https://github.com/conan-io/conan/issues/950.
It would be good to test against some existing packages using cppflags, cxxflags, etc.

If @kent-at-multiscale could try running from sources from this branch, it would also be great feedback.