### PR TITLE
Sparc CPU support

### DIFF
--- a/conans/client/cmake.py
+++ b/conans/client/cmake.py
@@ -137,11 +137,11 @@ class CMake(object):
             flags.append('-DCONAN_COMPILER_VERSION="%s"' % comp_version)
 
         if op_system == "Linux" or op_system == "FreeBSD" or op_system == "SunOS":
-            if arch == "x86":
+            if arch == "x86" or arch == "sparc":
                 flags.extend(["-DCONAN_CXX_FLAGS=-m32",
                               "-DCONAN_SHARED_LINKER_FLAGS=-m32",
                               "-DCONAN_C_FLAGS=-m32"])
-            if arch == "x86_64":
+            if arch == "x86_64" or arch == "sparcv9":
                 flags.extend(["-DCONAN_CXX_FLAGS=-m64",
                               "-DCONAN_SHARED_LINKER_FLAGS=-m64",
                               "-DCONAN_C_FLAGS=-m64"])

--- a/conans/client/conf/__init__.py
+++ b/conans/client/conf/__init__.py
@@ -12,7 +12,7 @@ from collections import OrderedDict
 MIN_SERVER_COMPATIBLE_VERSION = '0.12.0'
 
 default_settings_yml = """os: [Windows, Linux, Macos, Android, iOS, FreeBSD, SunOS]
-arch: [x86, x86_64, ppc64le, ppc64, armv6, armv7, armv7hf, armv8]
+arch: [x86, x86_64, ppc64le, ppc64, armv6, armv7, armv7hf, armv8, sparc, sparcv9]
 compiler:
     sun-cc:
        version: ["5.10", "5.11", "5.12", "5.13", "5.14"]

--- a/conans/client/configure_environment.py
+++ b/conans/client/configure_environment.py
@@ -99,9 +99,9 @@ class ConfigureEnvironment(object):
             self.libcxx = None
 
     def _gcc_arch_flags(self):
-        if self.arch == "x86_64":
+        if self.arch == "x86_64" or self.arch == "sparcv9":
             return "-m64"
-        elif self.arch == "x86":
+        elif self.arch == "x86" or self.arch == "sparc":
             return "-m32"
         else:
             return "";
@@ -211,7 +211,6 @@ class ConfigureEnvironment(object):
     def compile_flags(self):
         if self.compiler == "gcc" or "clang" in str(self.compiler) or self.compiler == "sun-cc":
             flags = []
-            flags.extend("-l%s" % lib for lib in self._deps_cpp_info.libs)
             flags.append(self._gcc_arch_flags())
             flags.extend(self._deps_cpp_info.exelinkflags)
             flags.extend(self._deps_cpp_info.sharedlinkflags)
@@ -222,6 +221,7 @@ class ConfigureEnvironment(object):
             flags.extend('-D%s' % i for i in self._deps_cpp_info.defines)
             flags.extend('-I"%s"' % i for i in self._deps_cpp_info.include_paths)
             flags.extend('-L"%s"' % i for i in self._deps_cpp_info.lib_paths)
+            flags.extend("-l%s" % lib for lib in self._deps_cpp_info.libs)
             flags.extend(self._deps_cpp_info.cppflags)
             flags.extend(self._gcc_lib_flags())
 

--- a/conans/client/detect.py
+++ b/conans/client/detect.py
@@ -170,7 +170,8 @@ def _detect_os_arch(result, output):
                      'i686': 'x86',
                      'i86pc': 'x86',
                      'amd64': 'x86_64',
-                     'aarch64': 'armv8'}
+                     'aarch64': 'armv8',
+                     'sun4v': 'sparc'}
 
     result.append(("os", detected_os()))
     arch = architectures.get(platform.machine().lower(), platform.machine().lower())

--- a/conans/test/cmake_test.py
+++ b/conans/test/cmake_test.py
@@ -108,6 +108,23 @@ class CMakeTest(unittest.TestCase):
                          '-DCONAN_SHARED_LINKER_FLAGS=-m64 -DCONAN_C_FLAGS=-m64 -Wno-dev',
                          cmake.command_line)
 
+        settings.arch = "sparc"
+        cmake = CMake(settings)
+        self.assertEqual('-G "Unix Makefiles" -DCMAKE_BUILD_TYPE=Debug -DCONAN_EXPORTED=1 '
+                         '-DCONAN_COMPILER="sun-cc" '
+                         '-DCONAN_COMPILER_VERSION="5.10" -DCONAN_CXX_FLAGS=-m32 '
+                         '-DCONAN_SHARED_LINKER_FLAGS=-m32 -DCONAN_C_FLAGS=-m32 -Wno-dev',
+                         cmake.command_line)
+
+        settings.arch = "sparcv9"
+        cmake = CMake(settings)
+        self.assertEqual('-G "Unix Makefiles" -DCMAKE_BUILD_TYPE=Debug -DCONAN_EXPORTED=1 '
+                         '-DCONAN_COMPILER="sun-cc" '
+                         '-DCONAN_COMPILER_VERSION="5.10" -DCONAN_CXX_FLAGS=-m64 '
+                         '-DCONAN_SHARED_LINKER_FLAGS=-m64 -DCONAN_C_FLAGS=-m64 -Wno-dev',
+                         cmake.command_line)
+
+
     def deleted_os_test(self):
         partial_settings = """
 os: [Linux]

--- a/conans/test/compile_helpers_test.py
+++ b/conans/test/compile_helpers_test.py
@@ -140,86 +140,106 @@ class CompileHelpersTest(unittest.TestCase):
         linux_s = MockSettings("Release", os="Linux", arch="x86",
                                compiler_name="gcc", libcxx="libstdc++", version="4.9")
         env = ConfigureEnvironment(MockConanfile(linux_s))
-        self.assertEquals(env.compile_flags, '-llib1 -llib2 -m32 -framework thing -framework '
+        self.assertEquals(env.compile_flags, '-m32 -framework thing -framework '
                                              'thing2 -s -DNDEBUG -DMYDEF1 -DMYDEF2 '
                                              '-I"path/to/includes/lib1" -I"path/to/includes/lib2" '
-                                             '-L"path/to/lib1" -L"path/to/lib2" cppflag1 '
+                                             '-L"path/to/lib1" -L"path/to/lib2" -llib1 -llib2 cppflag1 '
                                              '-D_GLIBCXX_USE_CXX11_ABI=0')
 
         linux_s_11 = MockSettings("Debug", os="Linux", arch="x86_64",
                                   compiler_name="gcc", libcxx="libstdc++11", version="4.9")
         env = ConfigureEnvironment(MockConanfile(linux_s_11))
-        self.assertEquals(env.compile_flags, '-llib1 -llib2 -m64 -framework thing -framework thing2'
+        self.assertEquals(env.compile_flags, '-m64 -framework thing -framework thing2'
                                              ' -g -DMYDEF1 -DMYDEF2 -I"path/to/includes/lib1" '
                                              '-I"path/to/includes/lib2" -L"path/to/lib1" '
-                                             '-L"path/to/lib2" cppflag1 '
+                                             '-L"path/to/lib2" -llib1 -llib2 cppflag1 '
                                              '-D_GLIBCXX_USE_CXX11_ABI=1')
 
         linux_s_clang_std = MockSettings("Debug", os="Linux", arch="x86_64",
                                          compiler_name="clang", libcxx="libstdc", version="4.9")
         env = ConfigureEnvironment(MockConanfile(linux_s_clang_std))
-        self.assertEquals(env.compile_flags, '-llib1 -llib2 -m64 -framework thing -framework thing2'
+        self.assertEquals(env.compile_flags, '-m64 -framework thing -framework thing2'
                                              ' -g -DMYDEF1 -DMYDEF2 -I"path/to/includes/lib1" '
                                              '-I"path/to/includes/lib2" -L"path/to/lib1" '
-                                             '-L"path/to/lib2" cppflag1 -stdlib=libstdc++')
+                                             '-L"path/to/lib2" -llib1 -llib2 cppflag1 '
+                                             '-stdlib=libstdc++')
 
         linux_s_clang = MockSettings("Debug", os="Linux", arch="x86_64",
                                      compiler_name="clang", libcxx="libc++", version="4.9")
         env = ConfigureEnvironment(MockConanfile(linux_s_clang))
-        self.assertEquals(env.compile_flags, '-llib1 -llib2 -m64 -framework thing -framework thing2'
+        self.assertEquals(env.compile_flags, '-m64 -framework thing -framework thing2'
                                              ' -g -DMYDEF1 -DMYDEF2 -I"path/to/includes/lib1" '
                                              '-I"path/to/includes/lib2" -L"path/to/lib1" '
-                                             '-L"path/to/lib2" cppflag1 -stdlib=libc++')
+                                             '-L"path/to/lib2" -llib1 -llib2 cppflag1 '
+                                             '-stdlib=libc++')
 
         freebsd_s_clang_32 = MockSettings("Debug", os="FreeBSD", arch="x86",
                                           compiler_name="clang", libcxx="libc++", version="3.8")
         env = ConfigureEnvironment(MockConanfile(freebsd_s_clang_32))
-        self.assertEquals(env.compile_flags, '-llib1 -llib2 -m32 -framework thing -framework thing2'
+        self.assertEquals(env.compile_flags, '-m32 -framework thing -framework thing2'
                                              ' -g -DMYDEF1 -DMYDEF2 -I"path/to/includes/lib1" '
                                              '-I"path/to/includes/lib2" -L"path/to/lib1" '
-                                             '-L"path/to/lib2" cppflag1 -stdlib=libc++')
+                                             '-L"path/to/lib2" -llib1 -llib2 cppflag1 '
+                                             '-stdlib=libc++')
 
         freebsd_s_clang_64 = MockSettings("Debug", os="FreeBSD", arch="x86_64",
                                           compiler_name="clang", libcxx="libc++", version="3.8")
         env = ConfigureEnvironment(MockConanfile(freebsd_s_clang_64))
-        self.assertEquals(env.compile_flags, '-llib1 -llib2 -m64 -framework thing -framework thing2'
+        self.assertEquals(env.compile_flags, '-m64 -framework thing -framework thing2'
                                              ' -g -DMYDEF1 -DMYDEF2 -I"path/to/includes/lib1" '
                                              '-I"path/to/includes/lib2" -L"path/to/lib1" '
-                                             '-L"path/to/lib2" cppflag1 -stdlib=libc++')
+                                             '-L"path/to/lib2" -llib1 -llib2 cppflag1 -stdlib=libc++')
 
         solaris_s_sun_cc_32 = MockSettings("Debug", os="SunOS", arch="x86",
                                            compiler_name="sun-cc", libcxx="libCstd", version="5.10")
         env = ConfigureEnvironment(MockConanfile(solaris_s_sun_cc_32))
-        self.assertEquals(env.compile_flags, '-llib1 -llib2 -m32 -framework thing -framework thing2'
+        self.assertEquals(env.compile_flags, '-m32 -framework thing -framework thing2'
                                              ' -g -DMYDEF1 -DMYDEF2 -I"path/to/includes/lib1" '
                                              '-I"path/to/includes/lib2" -L"path/to/lib1" '
-                                             '-L"path/to/lib2" cppflag1 -library=Cstd')
+                                             '-L"path/to/lib2" -llib1 -llib2 cppflag1 -library=Cstd')
 
         solaris_s_sun_cc_64 = MockSettings("Debug", os="SunOS", arch="x86_64",
                                            compiler_name="sun-cc", libcxx="libCstd", version="5.10")
         env = ConfigureEnvironment(MockConanfile(solaris_s_sun_cc_64))
-        self.assertEquals(env.compile_flags, '-llib1 -llib2 -m64 -framework thing -framework thing2'
+        self.assertEquals(env.compile_flags, '-m64 -framework thing -framework thing2'
                                              ' -g -DMYDEF1 -DMYDEF2 -I"path/to/includes/lib1" '
                                              '-I"path/to/includes/lib2" -L"path/to/lib1" '
-                                             '-L"path/to/lib2" cppflag1 -library=Cstd')
+                                             '-L"path/to/lib2" -llib1 -llib2 cppflag1 -library=Cstd')
 
         solaris_s_sun_cc_stlport = MockSettings("Debug", os="SunOS", arch="x86_64",
                                                 compiler_name="sun-cc", libcxx="libstlport",
                                                 version="5.10")
         env = ConfigureEnvironment(MockConanfile(solaris_s_sun_cc_stlport))
-        self.assertEquals(env.compile_flags, '-llib1 -llib2 -m64 -framework thing -framework thing2'
+        self.assertEquals(env.compile_flags, '-m64 -framework thing -framework thing2'
                                              ' -g -DMYDEF1 -DMYDEF2 -I"path/to/includes/lib1" '
                                              '-I"path/to/includes/lib2" -L"path/to/lib1" '
-                                             '-L"path/to/lib2" cppflag1 -library=stlport4')
+                                             '-L"path/to/lib2" -llib1 -llib2 cppflag1 -library=stlport4')
 
         solaris_s_sun_cc_stdcxx = MockSettings("Debug", os="SunOS", arch="x86_64",
                                                compiler_name="sun-cc", libcxx="libstdcxx",
                                                version="5.10")
         env = ConfigureEnvironment(MockConanfile(solaris_s_sun_cc_stdcxx))
-        self.assertEquals(env.compile_flags, '-llib1 -llib2 -m64 -framework thing -framework thing2'
+        self.assertEquals(env.compile_flags, '-m64 -framework thing -framework thing2'
                                              ' -g -DMYDEF1 -DMYDEF2 -I"path/to/includes/lib1" '
                                              '-I"path/to/includes/lib2" -L"path/to/lib1" '
-                                             '-L"path/to/lib2" cppflag1 -library=stdcxx4')
+                                             '-L"path/to/lib2" -llib1 -llib2 cppflag1 -library=stdcxx4')
+
+        solaris_s_sun_cc_sparc = MockSettings("Debug", os="SunOS", arch="sparc",
+                                              compiler_name="sun-cc", libcxx="libCstd", version="5.10")
+        env = ConfigureEnvironment(MockConanfile(solaris_s_sun_cc_sparc))
+        self.assertEquals(env.compile_flags, '-m32 -framework thing -framework thing2'
+                                             ' -g -DMYDEF1 -DMYDEF2 -I"path/to/includes/lib1" '
+                                             '-I"path/to/includes/lib2" -L"path/to/lib1" '
+                                             '-L"path/to/lib2" -llib1 -llib2 cppflag1 -library=Cstd')
+
+        solaris_s_sun_cc_sparcv9 = MockSettings("Debug", os="SunOS", arch="sparcv9",
+                                                compiler_name="sun-cc", libcxx="libCstd", version="5.10")
+        env = ConfigureEnvironment(MockConanfile(solaris_s_sun_cc_sparcv9))
+        self.assertEquals(env.compile_flags, '-m64 -framework thing -framework thing2'
+                                             ' -g -DMYDEF1 -DMYDEF2 -I"path/to/includes/lib1" '
+                                             '-I"path/to/includes/lib2" -L"path/to/lib1" '
+                                             '-L"path/to/lib2" -llib1 -llib2 cppflag1 -library=Cstd')
+
 
     def configure_environment_test(self):
         win_settings = MockSettings("Release", os="Windows", arch="x86",
@@ -326,6 +346,20 @@ class CompileHelpersTest(unittest.TestCase):
                                             'CFLAGS="$CFLAGS -m64 cflag1 -DNDEBUG '
                                             '-Ipath/to/includes/lib1 -Ipath/to/includes/lib2 -DMYDEF1 -DMYDEF2" '
                                             'CXXFLAGS="$CXXFLAGS -m64 cppflag1 -library=stlport4 -DNDEBUG '
+                                            '-Ipath/to/includes/lib1 -Ipath/to/includes/lib2 -DMYDEF1 -DMYDEF2" '
+                                            'C_INCLUDE_PATH=$C_INCLUDE_PATH:"path/to/includes/lib1":'
+                                            '"path/to/includes/lib2" '
+                                            'CPLUS_INCLUDE_PATH=$CPLUS_INCLUDE_PATH:"path/to/includes/lib1":'
+                                            '"path/to/includes/lib2"')
+
+        solaris_sparc_settings = MockSettings("Release", os="SunOS", arch="sparc",
+                                              compiler_name="sun-cc", libcxx="libstlport", version="5.10")
+        env = ConfigureEnvironment(MockConanfile(solaris_sparc_settings))
+        self.assertEquals(env.command_line, 'env LIBS="-llib1 -llib2" LDFLAGS="-Lpath/to/lib1 '
+                                            '-Lpath/to/lib2 -m32 -framework thing -framework thing2 $LDFLAGS" '
+                                            'CFLAGS="$CFLAGS -m32 cflag1 -DNDEBUG '
+                                            '-Ipath/to/includes/lib1 -Ipath/to/includes/lib2 -DMYDEF1 -DMYDEF2" '
+                                            'CXXFLAGS="$CXXFLAGS -m32 cppflag1 -library=stlport4 -DNDEBUG '
                                             '-Ipath/to/includes/lib1 -Ipath/to/includes/lib2 -DMYDEF1 -DMYDEF2" '
                                             'C_INCLUDE_PATH=$C_INCLUDE_PATH:"path/to/includes/lib1":'
                                             '"path/to/includes/lib2" '

--- a/conans/test/tools_test.py
+++ b/conans/test/tools_test.py
@@ -78,7 +78,7 @@ class ToolsTest(unittest.TestCase):
     def system_package_tool_fail_when_not_0_returned_test(self):
         runner = RunnerMock(return_ok=False)
         spt = SystemPackageTool(runner=runner)
-        if platform.system() != "Windows":
+        if platform.system() == "Linux" or platform.system() == "Macos":
             msg = "Command 'sudo apt-get update' failed" if platform.system() == "Linux" \
                                                          else "Command 'brew update' failed"
             with self.assertRaisesRegexp(ConanException, msg):
@@ -199,7 +199,7 @@ class ToolsTest(unittest.TestCase):
         self.assertEquals(7, runner.calls)
 
     def system_package_tool_installed_test(self):
-        if platform.system() == "Windows":
+        if platform.system() != "Linux" and platform.system() != "Macos":
             return
         spt = SystemPackageTool()
         # Git should be installed on development/testing machines

--- a/conans/test/update_settings_yml_test.py
+++ b/conans/test/update_settings_yml_test.py
@@ -27,7 +27,7 @@ class ConanFileToolsTest(ConanFile):
     '''
         prev_settings = """
 os: [Windows, Linux, Macos, Android, FreeBSD, SunOS]
-arch: [x86, x86_64, armv6, armv7, armv7hf, armv8]
+arch: [x86, x86_64, armv6, armv7, armv7hf, armv8, sparc, sparcv9]
 compiler:
     sun-cc:
         version: ["5.10", "5.11", "5.12", "5.13", "5.14"]


### PR DESCRIPTION
This offers support for ```sparc``` (32 bits) and ```sparcv9``` (64 bits) cpus in Conan.
I've tested only on Solaris for obvious reasons.

By the way, I noticed that some new tests failed on Solaris (and most likely on FreeBSD too).
I've fixed them but I was wondering: would you guys be interested if I could setup a CI bot that would check PRs on a Solaris machine?