### PR TITLE
Changed output of invalid downstream requirements from warn to werror

### DIFF
--- a/conans/client/require_resolver.py
+++ b/conans/client/require_resolver.py
@@ -40,7 +40,7 @@ class RequireResolver(object):
             ref = require.conan_reference
             resolved = self._resolve_version(version_range, [ref])
             if not resolved:
-                self._output.warn("Version range '%s' required by '%s' not valid for "
+                self._output.werror("Version range '%s' required by '%s' not valid for "
                                   "downstream requirement '%s'"
                                   % (version_range, base_conanref, str(ref)))
             else:

--- a/conans/test/integration/version_ranges_conflict_test.py
+++ b/conans/test/integration/version_ranges_conflict_test.py
@@ -1,0 +1,64 @@
+import unittest
+from conans.test.tools import TestClient, TestServer
+from conans.paths import CONANFILE
+from conans.util.files import load
+import os
+
+
+class VersionRangesConflictTest(unittest.TestCase):
+
+
+    conanfileA = """
+from conans import ConanFile, CMake
+import os
+class MyConanA(ConanFile):
+    name = "MyPkg1"
+    version = "%s"
+    """
+
+    conanfileB = """
+from conans import ConanFile, CMake
+import os
+class MyConanB(ConanFile):
+    name = "MyPkg2"
+    version = "0.1"
+    requires = "MyPkg1/[~0.1]@user/testing"
+    """
+
+    conanfileC = """
+from conans import ConanFile, CMake
+import os
+class MyConanC(ConanFile):
+    name = "MyPkg3"
+    version = "0.1"
+    requires = "MyPkg1/[~0.2]@user/testing", "MyPkg2/[~0.1]@user/testing"
+    """
+
+    def _prepareClient(self):
+        client = TestClient()
+        client.save({CONANFILE: self.conanfileA % "0.1.0"})
+        client.run("export user/testing")
+        client.save({CONANFILE: self.conanfileA % "0.2.0"})
+        client.run("export user/testing")
+        client.save({CONANFILE: self.conanfileB})
+        client.run("export user/testing")
+        client.save({CONANFILE: self.conanfileC})
+        return client
+
+    def werror_warn_test(self):
+        client = self._prepareClient()
+        client.run("info")
+        self.assertIn("WARN: Version range '~0.1' required by 'MyPkg2/0.1@user/testing' "
+                      "not valid for downstream requirement 'MyPkg1/0.2.0@user/testing'", client.user_io.out)
+
+    def werror_fail_test(self):
+        client = self._prepareClient()
+        client.run("install --build --werror", ignore_error=True)
+
+        print(client.user_io.out)
+
+        self.assertNotIn("WARN: Version range '~0.1' required by 'MyPkg2/0.1@user/testing' "
+                      "not valid for downstream requirement 'MyPkg1/0.2.0@user/testing'", client.user_io.out)
+
+        self.assertIn("ERROR: Version range '~0.1' required by 'MyPkg2/0.1@user/testing' "
+                         "not valid for downstream requirement 'MyPkg1/0.2.0@user/testing'", client.user_io.out)

--- a/conans/test/integration/version_ranges_conflict_test.py
+++ b/conans/test/integration/version_ranges_conflict_test.py
@@ -55,8 +55,6 @@ class MyConanC(ConanFile):
         client = self._prepareClient()
         client.run("install --build --werror", ignore_error=True)
 
-        print(client.user_io.out)
-
         self.assertNotIn("WARN: Version range '~0.1' required by 'MyPkg2/0.1@user/testing' "
                       "not valid for downstream requirement 'MyPkg1/0.2.0@user/testing'", client.user_io.out)
 


### PR DESCRIPTION
This was metioned in #747, but never fixed. 