### PR TITLE
local source command execute export

### DIFF
--- a/conans/client/export.py
+++ b/conans/client/export.py
@@ -16,7 +16,7 @@ def export_conanfile(output, paths, conanfile, origin_folder, conan_ref, short_p
                      keep_source):
     destination_folder = paths.export(conan_ref)
     previous_digest = _init_export_folder(destination_folder)
-    _export(conanfile, origin_folder, destination_folder, output)
+    execute_export(conanfile, origin_folder, destination_folder, output)
 
     digest = FileTreeManifest.create(destination_folder)
     save(os.path.join(destination_folder, CONAN_MANIFEST), str(digest))
@@ -67,7 +67,7 @@ def _init_export_folder(destination_folder):
     return previous_digest
 
 
-def _export(conanfile, origin_folder, destination_folder, output):
+def execute_export(conanfile, origin_folder, destination_folder, output):
     def classify(patterns):
         patterns = patterns or []
         included, excluded = [], []

--- a/conans/client/source.py
+++ b/conans/client/source.py
@@ -8,6 +8,7 @@ from conans.errors import ConanException, format_conanfile_exception
 from conans.paths import DIRTY_FILE, EXPORT_SOURCES_DIR, EXPORT_TGZ_NAME, EXPORT_SOURCES_TGZ_NAME,\
     CONANFILE
 from conans.util.files import rmdir, save
+from conans.client.export import execute_export
 
 
 def _merge_directories(src, dst):
@@ -93,12 +94,7 @@ def config_source_local(export_folder, current_path, conan_file, output):
         output.warn("Your previous source command failed")
 
     if current_path != export_folder:
-        for item in os.listdir(export_folder):
-            origin = os.path.join(export_folder, item)
-            if os.path.isdir(origin):
-                shutil.copytree(origin, os.path.join(current_path, item))
-            else:
-                shutil.copy2(origin, os.path.join(current_path, item))
+        execute_export(conan_file, export_folder, current_path, output)
 
     save(dirty, "")  # Creation of DIRTY flag
     try:

--- a/conans/test/command/package_command_test.py
+++ b/conans/test/command/package_command_test.py
@@ -70,10 +70,12 @@ class MyConan(ConanFile):
 from conans import ConanFile
 
 class MyConan(ConanFile):
+    exports = "*file.h"
     def package(self):
         self.copy(pattern="*.h", dst="include", src="include")
 """
         files = {"include/file.h": "foo",
+                 "include/file2.h": "bar",
                  CONANFILE: conanfile_template}
 
         client.save(files)
@@ -83,6 +85,7 @@ class MyConan(ConanFile):
         client.current_folder = build_folder
         client.run("install .. -g env -g txt")
         client.run("source ..")
+        self.assertEqual(os.listdir(os.path.join(client.current_folder, "include")), ["file.h"])
         client.run("build ..")
         client.current_folder = temp_folder()
         client.run('package "%s/build"' % origin_folder)


### PR DESCRIPTION
The local ``conan source`` command was copying all the origin folder, which is weird, because in normal operation, it will do the ``exports`` only. 

Address: https://github.com/conan-io/conan/issues/1095