### PR TITLE
Order profiles in 'profile list' by name instead of file system timestamp

### DIFF
--- a/conans/client/command.py
+++ b/conans/client/command.py
@@ -833,7 +833,7 @@ path to the CMake binary directory, like this:
             folder = self._client_cache.profiles_path
             if os.path.exists(folder):
                 profiles = [name for name in os.listdir(folder) if not os.path.isdir(name)]
-                for p in profiles:
+                for p in sorted(profiles):
                     self._user_io.out.info(p)
             else:
                 self._user_io.out.info("No profiles defined")

--- a/conans/test/command/profile_test.py
+++ b/conans/test/command/profile_test.py
@@ -13,12 +13,12 @@ class ProfileTest(unittest.TestCase):
 
     def list_test(self):
         client = TestClient()
+        create_profile(client.client_cache.profiles_path, "profile3")
         create_profile(client.client_cache.profiles_path, "profile1")
         create_profile(client.client_cache.profiles_path, "profile2")
-        create_profile(client.client_cache.profiles_path, "profile3")
         client.run("profile list")
-        self.assertEqual(set(["profile1", "profile2", "profile3"]),
-                         set(str(client.user_io.out).splitlines()))
+        self.assertEqual(list(["profile1", "profile2", "profile3"]),
+                         list(str(client.user_io.out).splitlines()))
 
     def show_test(self):
         client = TestClient()


### PR DESCRIPTION
```conan profile list``` should list profile alphabetically instead of relying on filesystem order.