### PR TITLE
CMake helper build_type and runtime as a configurable definition

### DIFF
--- a/conans/test/functional/cmake_test.py
+++ b/conans/test/functional/cmake_test.py
@@ -231,8 +231,8 @@ build_type: [ Release]
         cmake.configure()
 
         cores = '-DCONAN_CXX_FLAGS="/MP{0}" -DCONAN_C_FLAGS="/MP{0}" '.format(tools.cpu_count())
-        self.assertEqual('cd {0} && cmake -G "Visual Studio 12 2013" -DCONAN_LINK_RUNTIME=/MDd {1}-DCONAN_EXPORTED="1" '
-                         '-DCONAN_COMPILER="Visual Studio" -DCONAN_COMPILER_VERSION="12" {2}'
+        self.assertEqual('cd {0} && cmake -G "Visual Studio 12 2013" -DCONAN_LINK_RUNTIME="/MDd" {1}-DCONAN_EXPORTED="1"'
+                         ' -DCONAN_COMPILER="Visual Studio" -DCONAN_COMPILER_VERSION="12" {2}'
                          '-Wno-dev {0}'.format(dot_dir, cross, cores),
                          conan_file.command)
 
@@ -257,7 +257,7 @@ build_type: [ Release]
         else:
             escaped_args = "'--foo \"bar\"' -DSHARED=\"True\" '/source'"
 
-        self.assertEqual('cd %s && cmake -G "Visual Studio 12 2013" -DCONAN_LINK_RUNTIME=/MDd %s-DCONAN_EXPORTED="1" '
+        self.assertEqual('cd %s && cmake -G "Visual Studio 12 2013" -DCONAN_LINK_RUNTIME="/MDd" %s-DCONAN_EXPORTED="1" '
                          '-DCONAN_COMPILER="Visual Studio" -DCONAN_COMPILER_VERSION="12" %s'
                          '-Wno-dev %s' % (tempdir, cross, cores, escaped_args),
                          conan_file.command)


### PR DESCRIPTION
- To be able to alter the `.definitions` dict after the CMake() instantiation.
- All automatic definitions built with quotes using the same function.