### PR TITLE
fix: username validation regex to comply with the error description

### DIFF
--- a/conans/model/username.py
+++ b/conans/model/username.py
@@ -6,7 +6,7 @@ class Username(str):
 
     max_len = 30
     min_len = 2
-    base_er = "[a-zA-Z][a-zA-Z0-9_-]{%s,%s}" % (min_len-1, max_len-1)
+    base_er = "[a-zA-Z0-9_-]{%s,%s}" % (min_len, max_len)
     pattern = re.compile("^%s$" % base_er)
 
     def __new__(cls, name):


### PR DESCRIPTION
Although the error message states 

>  Valid names should begin with alphanumerical characters, '_' and '-'.

The accompanying validation regex only allows alpha charactors as the first letter of the name.