### PR TITLE
Allow spaces in permission spec in server.conf

### DIFF
--- a/conans/server/service/authorize.py
+++ b/conans/server/service/authorize.py
@@ -178,7 +178,7 @@ class BasicAuthorizer(Authorizer):
             # TODO: Log error
             raise InternalErrorException("Invalid server configuration. "
                                          "Contact the administrator.")
-        authorized_users = rule[1].split(",")
+        authorized_users = [_.strip() for _ in rule[1].split(",")]
         if len(authorized_users) < 1:
             raise InternalErrorException("Invalid server configuration. "
                                          "Contact the administrator.")

--- a/conans/test/server/service/authorizer_test.py
+++ b/conans/test/server/service/authorizer_test.py
@@ -136,4 +136,18 @@ class AuthorizerTest(unittest.TestCase):
         self.assertRaises(ForbiddenException,
                           authorizer.check_write_package, "pepe", self.package_reference2)
 
+    def users_test(self):
+        """Check that lists of user names are parsed correctly"""
+
+        # Simple user list
+        read_perms = [("openssl/*@lasote/testing", "user1,user2,user3")]
+        authorizer = BasicAuthorizer(read_perms, [])
+        for u in ['user1','user2','user3']:
+            authorizer.check_read_conan(u, self.openssl_ref)
+
+        # Spaces bewteen user names should be ignored
+        read_perms = [("openssl/*@lasote/testing", "user1 , user2,\tuser3")]
+        authorizer = BasicAuthorizer(read_perms, [])
+        for u in ['user1','user2','user3']:
+            authorizer.check_read_conan(u, self.openssl_ref)
 


### PR DESCRIPTION
Just spent some time trying to figure out why user authentication wasn't working in my Conan installation, until I realized that Conan server doesn't allow for spaces between usernames in the `[read_permissions]` and `[write_permissions]` sections of `server.conf`. No big deal, but I figured I might as well propose this tiny change to allow for such spaces. It's an easy, nitpicky thing to overlook when setting up Conan, and it might just save someone else a few minutes.