### PR TITLE
Fixed tabular indentation in help text

### DIFF
--- a/conans/client/command.py
+++ b/conans/client/command.py
@@ -799,9 +799,12 @@ class Command(object):
         self._user_io.out.writeln('Conan commands. Type $conan "command" -h for help',
                                   Color.BRIGHT_YELLOW)
         commands = self._commands()
+        # future-proof way to ensure tabular formatting
+        max_len = max((len(c) for c in commands)) + 2
+        fmt = '  %-{}s'.format(max_len)
         for name in sorted(self._commands()):
-            self._user_io.out.write('  %-10s' % name, Color.GREEN)
-            self._user_io.out.writeln(commands[name].__doc__.split('\n', 1)[0])
+            self._user_io.out.write(fmt % name, Color.GREEN)
+            self._user_io.out.writeln(commands[name].__doc__.split('\n', 1)[0].strip())
 
     def _commands(self):
         """ returns a list of available commands


### PR DESCRIPTION
Just a fix for a tiny annoyance I had :).
This computes the required tabulation amount based on the length of the longest command and synthesizes a format string. It is also required to strip the help string because sometimes there is an extra whitespace. 

![](http://i.imgur.com/R7s798Z.png)
(left - before, right - after)