### PR TITLE
Expose sha256sum in tools.

### DIFF
--- a/conans/tools.py
+++ b/conans/tools.py
@@ -22,7 +22,7 @@ from conans.client.runner import ConanRunner
 from conans.errors import ConanException
 from conans.model.version import Version
 # noinspection PyUnresolvedReferences
-from conans.util.files import _generic_algorithm_sum, load, save
+from conans.util.files import _generic_algorithm_sum, load, save, sha256sum, sha1sum, md5sum, md5
 from conans.util.log import logger
 
 

--- a/conans/util/files.py
+++ b/conans/util/files.py
@@ -51,6 +51,10 @@ def sha1sum(file_path):
     return _generic_algorithm_sum(file_path, "sha1")
 
 
+def sha256sum(file_path):
+    return _generic_algorithm_sum(file_path, "sha256")
+
+
 def _generic_algorithm_sum(file_path, algorithm_name):
 
     with open(file_path, 'rb') as fh:


### PR DESCRIPTION
This mirrors tools.check* functions. And since we should
encourage people to use sha256 instead of sha1 it's good
to have this util function available.