### PR TITLE
Add support for GCC 7.1+ detection

### DIFF
--- a/conans/client/detect.py
+++ b/conans/client/detect.py
@@ -25,7 +25,13 @@ def _gcc_compiler(output, compiler_exe="gcc"):
     try:
         _, out = _execute('%s -dumpversion' % compiler_exe)
         compiler = "gcc"
-        installed_version = re.search("([0-9]\.[0-9])", out).group()
+        installed_version = re.search("([0-9](\.[0-9])?)", out).group()
+        # Since GCC 7.1, -dumpversion return the major version number
+        # only ("7"). We must use -dumpfullversion to get the full version
+        # number ("7.1.1").
+        if len(installed_version) == 1:
+            _, out = _execute('%s -dumpfullversion' % compiler_exe)
+            installed_version = re.search("([0-9]\.[0-9])", out).group()
         if installed_version:
             output.success("Found %s %s" % (compiler, installed_version))
             return compiler, installed_version


### PR DESCRIPTION
It looks like my last PR (#1309) does not really add support for GCC 7.1, since GCC new configure option `--with-gcc-major-version-only` break Conan's GCC version detection.

With `--with-gcc-major-version-only` enabled (which is the default for packaged versions of GCC), the `-dumpversion` argument no longer return the full version but only the major version number.
We need to use the new `-dumpfullversion` argument in order to retrieve the full version.

Relevant GCC patch : https://gcc.gnu.org/ml/gcc-patches/2017-01/msg00567.html

This PR make `_gcc_compiler()` function to use `-dumpfullversion` if `-dumpversion` return only one number. 