### PR TITLE
visualstudio.py should generate paths with backslashes

### DIFF
--- a/conans/client/generators/visualstudio.py
+++ b/conans/client/generators/visualstudio.py
@@ -55,9 +55,9 @@ class VisualStudioGenerator(Generator):
         per_item_props = self._format_items(self._deps_build_info)
         fields = {
             'item_properties': per_item_props,
-            'bin_dirs': "".join("%s;" % p for p in self._deps_build_info.bin_paths).replace("\\", "/"),
-            'include_dirs': "".join("%s;" % p for p in self._deps_build_info.include_paths).replace("\\", "/"),
-            'lib_dirs': "".join("%s;" % p for p in self._deps_build_info.lib_paths).replace("\\", "/"),
+            'bin_dirs': "".join("%s;" % p for p in self._deps_build_info.bin_paths),
+            'include_dirs': "".join("%s;" % p for p in self._deps_build_info.include_paths),
+            'lib_dirs': "".join("%s;" % p for p in self._deps_build_info.lib_paths),
             'libs': "".join(['%s.lib;' % lib if not lib.endswith(".lib")
                                   else '%s;' % lib for lib in self._deps_build_info.libs]),
             'definitions': "".join("%s;" % d for d in self._deps_build_info.defines),


### PR DESCRIPTION
the props files generated by visualstudio.py should have backslashes on windows instead of slashes.

The following parts are affected:

- ExecutablePath
- AdditionalIncludeDirectories
- AdditionalLibraryDirectories