### PR TITLE
Support multi-config variables for the scons generator

### DIFF
--- a/conans/client/generators/scons.py
+++ b/conans/client/generators/scons.py
@@ -25,10 +25,18 @@ class SConsGenerator(Generator):
         all_flags = template.format(dep="conan", info=self.deps_build_info)
         sections.append(all_flags)
 
+        for config, cpp_info in self.deps_build_info.configs.items():
+            all_flags = template.format(dep="conan:" + config, info=cpp_info)
+            sections.append(all_flags)
+
         for dep_name, info in self.deps_build_info.dependencies:
             dep_name = dep_name.replace("-", "_")
             dep_flags = template.format(dep=dep_name, info=info)
             sections.append(dep_flags)
+
+            for config, cpp_info in info.configs.items():
+                all_flags = template.format(dep=dep_name + ":" + config, info=cpp_info)
+                sections.append(all_flags)
 
         sections.append("}\n")
 


### PR DESCRIPTION
Just like the cmake and txt generators, the scons generator now
supports so called "multi-config variables".

name = mylib
def package_info(self):
    self.cpp_info.regex.libs = ["myregexlib1", "myregexlib2"]
    self.cpp_info.filesystem.libs = ["myfilesystemlib"]

From this snippet, the generator will create in SConscript_conan the keys:
- conan
- conan:regex
- conan:filesystem
- mylib
- mylib:regex
- mylib:filesystem

All the keys containing a colon are the new generated ones.