### PR TITLE
print outdated from recipe in remotes

### DIFF
--- a/conans/client/manager.py
+++ b/conans/client/manager.py
@@ -494,10 +494,15 @@ class ConanManager(object):
         if isinstance(pattern_or_reference, ConanFileReference):
             packages_props = adapter.search_packages(pattern_or_reference, packages_query)
             ordered_packages = OrderedDict(sorted(packages_props.items()))
-            try:
-                recipe_hash = self._client_cache.load_manifest(pattern_or_reference).summary_hash
-            except IOError:  # It could not exist in local
-                recipe_hash = None
+            if remote:
+                remote = remote_proxy.registry.remote(remote)
+                manifest = self._remote_manager.get_conan_digest(pattern_or_reference, remote)
+                recipe_hash = manifest.summary_hash
+            else:
+                try:
+                    recipe_hash = self._client_cache.load_manifest(pattern_or_reference).summary_hash
+                except IOError:  # It could not exist in local
+                    recipe_hash = None
             printer.print_search_packages(ordered_packages, pattern_or_reference,
                                           recipe_hash, packages_query)
         else:

--- a/conans/test/command/search_test.py
+++ b/conans/test/command/search_test.py
@@ -213,6 +213,7 @@ class SearchTest(unittest.TestCase):
         shutil.copytree(self.client.paths.store, self.servers["local"].paths.store)
         self.client.run("remove Hello* -f")
         self.client.run('search Hello/1.4.10@fenix/testing -q "compiler=gcc AND compiler.libcxx=libstdc++11" -r local')
+        self.assertIn("outdated from recipe: False", self.client.user_io.out)
         self.assertIn("LinuxPackageSHA", self.client.user_io.out)
         self.assertNotIn("PlatformIndependantSHA", self.client.user_io.out)
         self.assertNotIn("WindowsPackageSHA", self.client.user_io.out)


### PR DESCRIPTION
Now, if searching a remote, no "outdated from recipe" info is output, but it is interesting.
In fact, it is using the local recipe if existing to provide that info. I think this might be confusing, so I propose to use always the remote recipe.