### PR TITLE
fixing test_package pattern

### DIFF
--- a/conans/client/conan_api.py
+++ b/conans/client/conan_api.py
@@ -205,7 +205,7 @@ class ConanAPIV1(object):
             user_channel = "%s/%s" % (first_dep.user, first_dep.channel)
             self._manager.export(user_channel, root_folder, keep_source=keep_source)
 
-        lib_to_test = first_dep.name + "*"
+        lib_to_test = first_dep.name
         # Get False or a list of patterns to check
         if build is None and lib_to_test:  # Not specified, force build the tested library
             build = [lib_to_test]

--- a/conans/client/installer.py
+++ b/conans/client/installer.py
@@ -72,7 +72,7 @@ class BuildMode(object):
                 elif param == "never":
                     never = True
                 else:
-                    self.patterns.append("%s*" % param)
+                    self.patterns.append("%s" % param)
 
             if never and (self.outdated or self.missing or self.patterns):
                 raise ConanException("--build=never not compatible with other options")
@@ -82,12 +82,12 @@ class BuildMode(object):
         if self.all:
             return True
 
-        ref = str(reference)
         if conanfile.build_policy_always:
-            out = ScopedOutput(ref, self._out)
+            out = ScopedOutput(str(reference), self._out)
             out.info("Building package from source as defined by build_policy='always'")
             return True
 
+        ref = reference.name
         # Patterns to match, if package matches pattern, build is forced
         force_build = any([fnmatch.fnmatch(ref, pattern) for pattern in self.patterns])
         return force_build
@@ -306,7 +306,7 @@ class ConanInstaller(object):
         # A check to be sure that if introduced a pattern, something is going to be built
 
         if build_mode.patterns:
-            to_build = [str(n[0]) for n in nodes_to_build if n[3]]
+            to_build = [str(n[0].name) for n in nodes_to_build if n[3]]
             build_mode.check_matches(to_build)
 
         return nodes_to_build

--- a/conans/test/command/install_test.py
+++ b/conans/test/command/install_test.py
@@ -72,11 +72,10 @@ class InstallTest(unittest.TestCase):
         self.client.run("install %s --build=missing" % (self.settings))
 
         self.client.run("install %s --build=Bye" % (self.settings))
-        self.assertIn("No package matching 'Bye*' pattern", self.client.user_io.out)
+        self.assertIn("No package matching 'Bye' pattern", self.client.user_io.out)
 
         for package in ["Hello0", "Hello1"]:
-            error = self.client.run("install %s --build=%s" % (self.settings, package))
-            self.assertFalse(error)
+            self.client.run("install %s --build=%s" % (self.settings, package))
             self.assertNotIn("No package matching", self.client.user_io.out)
 
     def reuse_test(self):

--- a/conans/test/integration/only_source_test.py
+++ b/conans/test/integration/only_source_test.py
@@ -181,14 +181,14 @@ class MyPackage(ConanFile):
         # Use an invalid pattern and check that its not builded from source
         other_conan = TestClient(servers=self.servers, users={"default": [("lasote", "mypass")]})
         other_conan.run("install %s --build HelloInvalid" % str(conan_reference))
-        self.assertIn("No package matching 'HelloInvalid*' pattern", other_conan.user_io.out)
+        self.assertIn("No package matching 'HelloInvalid' pattern", other_conan.user_io.out)
         self.assertFalse(os.path.exists(other_conan.paths.builds(conan_reference)))
         # self.assertFalse(os.path.exists(other_conan.paths.packages(conan_reference)))
 
         # Use another valid pattern and check that its not builded from source
         other_conan = TestClient(servers=self.servers, users={"default": [("lasote", "mypass")]})
         other_conan.run("install %s --build HelloInvalid -b Hello" % str(conan_reference))
-        self.assertIn("No package matching 'HelloInvalid*' pattern", other_conan.user_io.out)
+        self.assertIn("No package matching 'HelloInvalid' pattern", other_conan.user_io.out)
         # self.assertFalse(os.path.exists(other_conan.paths.builds(conan_reference)))
         # self.assertFalse(os.path.exists(other_conan.paths.packages(conan_reference)))
 


### PR DESCRIPTION
https://github.com/conan-io/conan/issues/1366

Could break something. Until now, the "*" was automatically being added to the created ``--build=Pkg`` by the ``test_package`` command. So if someone is relying on ``conan --build=Pkg`` to find and build ``PkgLibrary`` it will not work. They will have to change to ``conan --build=Pkg*``