### PR TITLE
Appending environment variables in BuildEnvTools and VirtualEnvTools

### DIFF
--- a/conans/client/configure_build_environment.py
+++ b/conans/client/configure_build_environment.py
@@ -218,8 +218,7 @@ class AutoToolsBuildEnvironment(object):
     def _architecture_flag(self):
         return architecture_dict.get(self._arch, "")
 
-    @property
-    def vars(self):
+    def _get_vars(self):
         def append(*args):
             ret = []
             for arg in args:
@@ -244,11 +243,40 @@ class AutoToolsBuildEnvironment(object):
         cxx_flags = append(tmp_compilation_flags, self.cxx_flags)
         c_flags = tmp_compilation_flags
 
-        def environ_values(var_name):
-            if os.environ.get(var_name, ""):
-                return " %s" % os.environ.get(var_name, "")
-            else:
-                return ""
+        return ld_flags, cpp_flags, libs, cxx_flags, c_flags
+
+    @property
+    def vars_list(self):
+
+        ld_flags, cpp_flags, libs, cxx_flags, c_flags = self._get_vars()
+
+        if os.environ.get("CPPFLAGS", None):
+            cpp_flags.append(os.environ.get("CPPFLAGS", None))
+
+        if os.environ.get("CXXFLAGS", None):
+            cxx_flags.append(os.environ.get("CXXFLAGS", None))
+
+        if os.environ.get("CFLAGS", None):
+            c_flags.append(os.environ.get("CFLAGS", None))
+
+        if os.environ.get("LDFLAGS", None):
+            ld_flags.append(os.environ.get("LDFLAGS", None))
+
+        if os.environ.get("LIBS", None):
+            libs.append(os.environ.get("LIBS", None))
+
+        ret = {"CPPFLAGS": cpp_flags,
+               "CXXFLAGS": cxx_flags,
+               "CFLAGS": c_flags,
+               "LDFLAGS": ld_flags,
+               "LIBS": libs,
+               }
+        return ret
+
+    @property
+    def vars(self):
+
+        ld_flags, cpp_flags, libs, cxx_flags, c_flags = self._get_vars()
 
         cpp_flags = " ".join(cpp_flags) + environ_values("CPPFLAGS")
         cxx_flags = " ".join(cxx_flags) + environ_values("CXXFLAGS")
@@ -256,11 +284,18 @@ class AutoToolsBuildEnvironment(object):
         ldflags = " ".join(ld_flags) + environ_values("LDFLAGS")
         libs = " ".join(libs) + environ_values("LIBS")
 
-        ret = {"CPPFLAGS": cpp_flags,
-               "CXXFLAGS": cxx_flags,
-               "CFLAGS": cflags,
-               "LDFLAGS": ldflags,
-               "LIBS": libs,
+        ret = {"CPPFLAGS": cpp_flags.strip(),
+               "CXXFLAGS": cxx_flags.strip(),
+               "CFLAGS": cflags.strip(),
+               "LDFLAGS": ldflags.strip(),
+               "LIBS": libs.strip(),
                }
 
         return ret
+
+
+def environ_values(var_name):
+    if os.environ.get(var_name, ""):
+        return " %s" % os.environ.get(var_name, "")
+    else:
+        return ""

--- a/conans/client/configure_build_environment.py
+++ b/conans/client/configure_build_environment.py
@@ -41,24 +41,39 @@ class VisualStudioBuildEnvironment(object):
     - LIB: library paths with semicolon separator
     - CL: /I (include paths)
     """
-    def __init__(self, conanfile, quote_paths=True):
+    def __init__(self, conanfile):
         """
         :param conanfile: ConanFile instance
         :param quote_paths: The path directories will be quoted. If you are using the vars together with
                             environment_append keep it to True, for virtualbuildenv quote_paths=False is required.
         """
-        self._deps_cpp_info = conanfile.deps_cpp_info
-        self.quote_paths = quote_paths
+        self.include_paths = conanfile.deps_cpp_info.include_paths
+        self.lib_paths = conanfile.deps_cpp_info.lib_paths
 
     @property
     def vars(self):
-        if self.quote_paths:
-            cl_args = " ".join(['/I"%s"' % lib for lib in self._deps_cpp_info.include_paths])
-        else:
-            cl_args = " ".join(['/I%s' % lib for lib in self._deps_cpp_info.include_paths])
-        lib_paths = ";".join(['%s' % lib for lib in self._deps_cpp_info.lib_paths])
+        """Used in conanfile with environment_append"""
+        cl_args = " ".join(['/I"%s"' % lib for lib in self.include_paths]) + environ_value_prefix("CL")
+        lib_paths = ";".join(['%s' % lib for lib in self.lib_paths]) + environ_value_prefix("LIB", ";")
         return {"CL": cl_args,
                 "LIB": lib_paths}
+
+    @property
+    def vars_dict(self):
+        """Used in virtualbuildenvironment"""
+        # Here we do not quote the include paths, it's going to be used by virtual environment
+        cl = ['/I%s' % lib for lib in self.include_paths]
+        lib = [lib for lib in self.lib_paths] # copy
+
+        if os.environ.get("CL", None):
+            cl.append(os.environ.get("CL"))
+
+        if os.environ.get("LIB", None):
+            lib.append(os.environ.get("LIB"))
+
+        ret = {"CL": cl,
+               "LIB": lib}
+        return ret
 
 
 class AutoToolsBuildEnvironment(object):
@@ -246,7 +261,7 @@ class AutoToolsBuildEnvironment(object):
         return ld_flags, cpp_flags, libs, cxx_flags, c_flags
 
     @property
-    def vars_list(self):
+    def vars_dict(self):
 
         ld_flags, cpp_flags, libs, cxx_flags, c_flags = self._get_vars()
 
@@ -278,11 +293,11 @@ class AutoToolsBuildEnvironment(object):
 
         ld_flags, cpp_flags, libs, cxx_flags, c_flags = self._get_vars()
 
-        cpp_flags = " ".join(cpp_flags) + environ_values("CPPFLAGS")
-        cxx_flags = " ".join(cxx_flags) + environ_values("CXXFLAGS")
-        cflags = " ".join(c_flags) + environ_values("CFLAGS")
-        ldflags = " ".join(ld_flags) + environ_values("LDFLAGS")
-        libs = " ".join(libs) + environ_values("LIBS")
+        cpp_flags = " ".join(cpp_flags) + environ_value_prefix("CPPFLAGS")
+        cxx_flags = " ".join(cxx_flags) + environ_value_prefix("CXXFLAGS")
+        cflags = " ".join(c_flags) + environ_value_prefix("CFLAGS")
+        ldflags = " ".join(ld_flags) + environ_value_prefix("LDFLAGS")
+        libs = " ".join(libs) + environ_value_prefix("LIBS")
 
         ret = {"CPPFLAGS": cpp_flags.strip(),
                "CXXFLAGS": cxx_flags.strip(),
@@ -294,8 +309,8 @@ class AutoToolsBuildEnvironment(object):
         return ret
 
 
-def environ_values(var_name):
+def environ_value_prefix(var_name, prefix=" "):
     if os.environ.get(var_name, ""):
-        return " %s" % os.environ.get(var_name, "")
+        return "%s%s" % (prefix, os.environ.get(var_name, ""))
     else:
         return ""

--- a/conans/client/generators/virtualbuildenv.py
+++ b/conans/client/generators/virtualbuildenv.py
@@ -7,14 +7,19 @@ from conans.client.configure_build_environment import (AutoToolsBuildEnvironment
 class VirtualBuildEnvGenerator(VirtualEnvGenerator):
 
     def __init__(self, conanfile):
+
         super(VirtualBuildEnvGenerator, self).__init__(conanfile)
 
         compiler = conanfile.settings.get_safe("compiler")
         self.env = {}
         if compiler != "Visual Studio":
             auto_tools_b = AutoToolsBuildEnvironment(conanfile)
-            tmp = {var: '%s' % value for var, value in auto_tools_b.vars.items()}
-            self.env = tmp
+            # We append the list, so the parent virtualenv generator will append the current environment
+            # values and automatically merge this variables with spaces, because we are adding the keys
+            # to "append_with_spaces"
+            vars_list = auto_tools_b.vars_list
+            self.append_with_spaces.extend(vars_list.keys())
+            self.env = vars_list
         else:
             visual_b = VisualStudioBuildEnvironment(conanfile, quote_paths=False)
             self.env = visual_b.vars

--- a/conans/client/generators/virtualbuildenv.py
+++ b/conans/client/generators/virtualbuildenv.py
@@ -1,28 +1,18 @@
-import platform
-
-from conans.client.generators.virtualenv import VirtualEnvGenerator
 from conans.client.configure_build_environment import (AutoToolsBuildEnvironment, VisualStudioBuildEnvironment)
+from conans.client.generators.virtualenv import VirtualEnvGenerator
 
 
 class VirtualBuildEnvGenerator(VirtualEnvGenerator):
 
     def __init__(self, conanfile):
-
         super(VirtualBuildEnvGenerator, self).__init__(conanfile)
-
         compiler = conanfile.settings.get_safe("compiler")
-        self.env = {}
         if compiler != "Visual Studio":
-            auto_tools_b = AutoToolsBuildEnvironment(conanfile)
-            # We append the list, so the parent virtualenv generator will append the current environment
-            # values and automatically merge this variables with spaces, because we are adding the keys
-            # to "append_with_spaces"
-            vars_list = auto_tools_b.vars_list
-            self.append_with_spaces.extend(vars_list.keys())
-            self.env = vars_list
+            tools = AutoToolsBuildEnvironment(conanfile)
         else:
-            visual_b = VisualStudioBuildEnvironment(conanfile, quote_paths=False)
-            self.env = visual_b.vars
+            tools = VisualStudioBuildEnvironment(conanfile)
+
+        self.env = tools.vars_dict
 
     @property
     def content(self):

--- a/conans/client/generators/virtualenv.py
+++ b/conans/client/generators/virtualenv.py
@@ -6,14 +6,13 @@ from conans.model import Generator
 
 class VirtualEnvGenerator(Generator):
 
-    append_with_spaces = ["CPPFLAGS", "CFLAGS", "CXXFLAGS", "LIBS", "LDFLAGS"]
+    append_with_spaces = ["CPPFLAGS", "CFLAGS", "CXXFLAGS", "LIBS", "LDFLAGS", "CL"]
 
     def __init__(self, conanfile):
         self.conanfile = conanfile
         self.env = conanfile.env
 
         super(VirtualEnvGenerator, self).__init__(conanfile)
-
 
     @property
     def filename(self):

--- a/conans/test/functional/autotools_configure_test.py
+++ b/conans/test/functional/autotools_configure_test.py
@@ -2,36 +2,7 @@ import unittest
 
 from conans.client.configure_build_environment import AutoToolsBuildEnvironment
 from conans import tools
-
-
-class MockDepsCppInfo(object):
-
-    def __init__(self):
-        self.include_paths = []
-        self.lib_paths = []
-        self.libs = []
-        self.defines = []
-        self.cflags = []
-        self.cppflags = []
-        self.sharedlinkflags = []
-        self.exelinkflags = []
-        self.sysroot = ""
-
-
-class MockConanfile(object):
-
-    def __init__(self, settings):
-        self.deps_cpp_info = MockDepsCppInfo()
-        self.settings = settings
-
-
-class MockSettings(object):
-
-    def __init__(self, values):
-        self.values = values
-
-    def get_safe(self, value):
-        return self.values.get(value, None)
+from conans.test.utils.conanfile import MockConanfile, MockSettings
 
 
 class AutoToolsConfigureTest(unittest.TestCase):

--- a/conans/test/functional/autotools_configure_test.py
+++ b/conans/test/functional/autotools_configure_test.py
@@ -247,6 +247,15 @@ class AutoToolsConfigureTest(unittest.TestCase):
                     'LIBS': '-lonelib -ltwolib'}
         self.assertEquals(be.vars, expected)
 
+    def test_previous_env(self):
+        settings = MockSettings({"arch": "x86",
+                                 "os": "Linux"})
+        conanfile = MockConanfile(settings)
+
+        with tools.environment_append({"CPPFLAGS": "MyCppFlag"}):
+            be = AutoToolsBuildEnvironment(conanfile)
+            self.assertEquals(be.vars["CPPFLAGS"], "MyCppFlag")
+
     def cross_build_flags_test(self):
         def get_values(this_os, this_arch, setting_os, setting_arch):
             settings = MockSettings({"arch": setting_arch,

--- a/conans/test/functional/build_environment_helpers.py
+++ b/conans/test/functional/build_environment_helpers.py
@@ -1,0 +1,46 @@
+import unittest
+
+from conans import tools
+from conans.client.configure_build_environment import VisualStudioBuildEnvironment
+from conans.test.utils.conanfile import MockConanfile, MockSettings
+
+
+class BuildEnvironmentHelpers(unittest.TestCase):
+
+    def test_visual(self):
+        settings = MockSettings({})
+        conanfile = MockConanfile(settings)
+        conanfile.deps_cpp_info.include_paths.append("/one/include/path")
+        conanfile.deps_cpp_info.include_paths.append("/two/include/path")
+        conanfile.deps_cpp_info.lib_paths.append("/one/lib/path")
+        conanfile.deps_cpp_info.lib_paths.append("/two/lib/path")
+        tool = VisualStudioBuildEnvironment(conanfile)
+        self.assertEquals(tool.vars_dict, {
+            "CL": ["/I/one/include/path", "/I/two/include/path"],
+            "LIB": ["/one/lib/path", "/two/lib/path"],
+        })
+
+        # Now alter the paths before the vars_dict call
+        tool.include_paths.append("/three/include/path")
+        tool.lib_paths.append("/three/lib/path")
+
+        self.assertEquals(tool.vars_dict, {
+            "CL": ["/I/one/include/path", "/I/two/include/path", "/I/three/include/path"],
+            "LIB": ["/one/lib/path", "/two/lib/path", "/three/lib/path"],
+        })
+
+        # Now try appending to environment
+        with tools.environment_append({"CL": "/I/four/include/path /I/five/include/path",
+                                       "LIB": "/four/lib/path;/five/lib/path"}):
+            self.assertEquals(tool.vars_dict, {
+                "CL": ["/I/one/include/path", "/I/two/include/path",
+                       "/I/three/include/path", "/I/four/include/path /I/five/include/path"],
+                "LIB": ["/one/lib/path", "/two/lib/path", "/three/lib/path", "/four/lib/path;/five/lib/path"],
+            })
+
+            self.assertEquals(tool.vars, {
+                "CL": '/I"/one/include/path" /I"/two/include/path" '
+                      '/I"/three/include/path" /I/four/include/path /I/five/include/path',
+                "LIB": "/one/lib/path;/two/lib/path;/three/lib/path;/four/lib/path;/five/lib/path",
+            })
+æ

--- a/conans/test/integration/conan_env_test.py
+++ b/conans/test/integration/conan_env_test.py
@@ -198,11 +198,12 @@ class HelloConan(ConanFile):
     def package_info(self):
         self.env_info.var1="good value"
         self.env_info.var2.append("value3")
+        self.env_info.CPPFLAGS.append("MYCPPFLAG=1")
     '''
         files["conanfile.py"] = conanfile
         client.save(files, clean_first=True)
         client.run("export lasote/stable")
-        client.run("install Hello2/0.1@lasote/stable --build -g virtualenv")
+        client.run("install Hello2/0.1@lasote/stable --build -g virtualenv -e CPPFLAGS=[OtherFlag=2]")
         ext = "bat" if platform.system() == "Windows" else "sh"
         self.assertTrue(os.path.exists(os.path.join(client.current_folder, "activate.%s" % ext)))
         self.assertTrue(os.path.exists(os.path.join(client.current_folder, "deactivate.%s" % ext)))
@@ -218,6 +219,7 @@ class HelloConan(ConanFile):
             self.assertIn('var2=value3;value2;%var2%', activate_contents)
         else:
             self.assertIn('var2="value3":"value2":$var2', activate_contents)
+            self.assertIn('CPPFLAGS="OtherFlag=2 MYCPPFLAG=1 $CPPFLAGS"', activate_contents)
         self.assertIn("Another value", activate_contents)
         if platform.system() == "Windows":
             self.assertIn("PATH=/dir", activate_contents)

--- a/conans/test/utils/conanfile.py
+++ b/conans/test/utils/conanfile.py
@@ -1,4 +1,34 @@
 
+class MockSettings(object):
+
+    def __init__(self, values):
+        self.values = values
+
+    def get_safe(self, value):
+        return self.values.get(value, None)
+
+
+class MockDepsCppInfo(object):
+
+    def __init__(self):
+        self.include_paths = []
+        self.lib_paths = []
+        self.libs = []
+        self.defines = []
+        self.cflags = []
+        self.cppflags = []
+        self.sharedlinkflags = []
+        self.exelinkflags = []
+        self.sysroot = ""
+
+
+class MockConanfile(object):
+
+    def __init__(self, settings):
+        self.deps_cpp_info = MockDepsCppInfo()
+        self.settings = settings
+
+
 class TestConanFile(object):
     def __init__(self, name="Hello", version="0.1", settings=None, requires=None, options=None,
                  default_options=None, package_id=None):


### PR DESCRIPTION
#1287, #1408 and #1389

**Goal:** virtualbuildenv append to flags (CPPFLAGS, LDFLAGS...etc) the previously declared env variables, for example from a profile, from -r...etc

**Problem solved**: Conan only appended variables with previously environment value if the received value was a list, and it joined all the values with `os.pathsep`. But it was a problem, CPPFLAGS etc should be joined with spaces so a list with known variables `append_with_spaces` has been added to `VirtualEnvGenerator`

UPDATED, Also VisualStudio similar problems (#1408 and #1389)
