### PR TITLE
#1399 Conan new generates Gitlab CI

### DIFF
--- a/conans/client/command.py
+++ b/conans/client/command.py
@@ -85,6 +85,10 @@ class Command(object):
                             help='Generate travis-ci files for OSX apple-clang')
         parser.add_argument("-ciw", "--ci_appveyor_win", action='store_true', default=False,
                             help='Generate appveyor files for Appveyor Visual Studio')
+        parser.add_argument("-ciglg", "--ci_gitlab_gcc", action='store_true', default=False,
+                            help='Generate GitLab files for linux gcc')
+        parser.add_argument("-ciglc", "--ci_gitlab_clang", action='store_true', default=False,
+                            help='Generate GitLab files for linux clang')
         parser.add_argument("-gi", "--gitignore", action='store_true', default=False,
                             help='Generate a .gitignore with the known patterns to excluded')
         parser.add_argument("-ciu", "--ci_upload_url",
@@ -98,7 +102,9 @@ class Command(object):
                         linux_clang_versions=args.ci_travis_clang,
                         gitignore=args.gitignore,
                         osx_clang_versions=args.ci_travis_osx, shared=args.ci_shared,
-                        upload_url=args.ci_upload_url)
+                        upload_url=args.ci_upload_url,
+                        gitlab_gcc_versions=args.ci_gitlab_gcc,
+                        gitlab_clang_versions=args.ci_gitlab_clang)
 
     def test_package(self, *args):
         """ Export, build package and test it with a consumer project.

--- a/conans/client/conan_api.py
+++ b/conans/client/conan_api.py
@@ -145,7 +145,7 @@ class ConanAPIV1(object):
     @api_method
     def new(self, name, header=False, pure_c=False, test=False, exports_sources=False, bare=False, cwd=None,
             visual_versions=None, linux_gcc_versions=None, linux_clang_versions=None, osx_clang_versions=None,
-            shared=None, upload_url=None, gitignore=None):
+            shared=None, upload_url=None, gitignore=None, gitlab_gcc_versions=None, gitlab_clang_versions=None):
         from conans.client.new import get_files
         cwd = prepare_cwd(cwd)
         files = get_files(name, header=header, pure_c=pure_c, test=test,
@@ -154,7 +154,9 @@ class ConanAPIV1(object):
                           linux_gcc_versions=linux_gcc_versions,
                           linux_clang_versions=linux_clang_versions,
                           osx_clang_versions=osx_clang_versions, shared=shared,
-                          upload_url=upload_url, gitignore=gitignore)
+                          upload_url=upload_url, gitignore=gitignore,
+                          gitlab_gcc_versions=gitlab_gcc_versions,
+                          gitlab_clang_versions=gitlab_clang_versions)
 
         save_files(cwd, files)
         for f in sorted(files):

--- a/conans/client/new.py
+++ b/conans/client/new.py
@@ -216,7 +216,7 @@ test_package/build
 
 def get_files(ref, header=False, pure_c=False, test=False, exports_sources=False, bare=False,
               visual_versions=None, linux_gcc_versions=None, linux_clang_versions=None, osx_clang_versions=None,
-              shared=None, upload_url=None, gitignore=None):
+              shared=None, upload_url=None, gitignore=None, gitlab_gcc_versions=None, gitlab_clang_versions=None):
     try:
         tokens = ref.split("@")
         name, version = tokens[0].split("/")
@@ -271,5 +271,7 @@ def get_files(ref, header=False, pure_c=False, test=False, exports_sources=False
         files[".gitignore"] = gitignore_template
 
     files.update(ci_get_files(name, version, user, channel, visual_versions,
-                              linux_gcc_versions, linux_clang_versions, osx_clang_versions, shared, upload_url))
+                              linux_gcc_versions, linux_clang_versions,
+                              osx_clang_versions, shared, upload_url,
+                              gitlab_gcc_versions, gitlab_clang_versions))
     return files

--- a/conans/test/command/new_test.py
+++ b/conans/test/command/new_test.py
@@ -109,7 +109,7 @@ class NewTest(unittest.TestCase):
 
     def new_ci_test(self):
         client = TestClient()
-        client.run('new MyPackage/1.3@myuser/testing -cis -ciw -cilg -cilc -cio -ciu=myurl')
+        client.run('new MyPackage/1.3@myuser/testing -cis -ciw -cilg -cilc -cio -ciglg -ciglc -ciu=myurl')
         root = client.current_folder
         build_py = load(os.path.join(root, "build.py"))
         self.assertIn('builder.add_common_builds(shared_option_name="MyPackage:shared")',
@@ -118,6 +118,9 @@ class NewTest(unittest.TestCase):
         self.assertNotIn('gcc_versions=', build_py)
         self.assertNotIn('clang_versions=', build_py)
         self.assertNotIn('apple_clang_versions=', build_py)
+        self.assertNotIn('gitlab_gcc_versions=', build_py)
+        self.assertNotIn('gitlab_clang_versions=', build_py)
+
         appveyor = load(os.path.join(root, "appveyor.yml"))
         self.assertIn("CONAN_UPLOAD: \"myurl\"", appveyor)
         self.assertIn('CONAN_REFERENCE: "MyPackage/1.3"', appveyor)
@@ -135,6 +138,13 @@ class NewTest(unittest.TestCase):
         self.assertIn('env: CONAN_GCC_VERSIONS=5.4 CONAN_DOCKER_IMAGE=lasote/conangcc54',
                       travis)
 
+        gitlab = load(os.path.join(root, ".gitlab-ci.yml"))
+        self.assertIn("CONAN_UPLOAD: \"myurl\"", gitlab)
+        self.assertIn('CONAN_REFERENCE: "MyPackage/1.3"', gitlab)
+        self.assertIn('CONAN_USERNAME: "myuser"', gitlab)
+        self.assertIn('CONAN_CHANNEL: "testing"', gitlab)
+        self.assertIn('CONAN_GCC_VERSIONS: "5.4"', gitlab)
+
     def new_ci_test_partial(self):
         client = TestClient()
         root = client.current_folder
@@ -147,6 +157,7 @@ class NewTest(unittest.TestCase):
         self.assertTrue(os.path.exists(os.path.join(root, ".travis/install.sh")))
         self.assertTrue(os.path.exists(os.path.join(root, ".travis/run.sh")))
         self.assertFalse(os.path.exists(os.path.join(root, "appveyor.yml")))
+        self.assertFalse(os.path.exists(os.path.join(root, ".gitlab-ci.yml")))
 
         client = TestClient()
         root = client.current_folder
@@ -156,6 +167,7 @@ class NewTest(unittest.TestCase):
         self.assertFalse(os.path.exists(os.path.join(root, ".travis/install.sh")))
         self.assertFalse(os.path.exists(os.path.join(root, ".travis/run.sh")))
         self.assertTrue(os.path.exists(os.path.join(root, "appveyor.yml")))
+        self.assertFalse(os.path.exists(os.path.join(root, ".gitlab-ci.yml")))
 
         client = TestClient()
         root = client.current_folder
@@ -165,9 +177,29 @@ class NewTest(unittest.TestCase):
         self.assertTrue(os.path.exists(os.path.join(root, ".travis/install.sh")))
         self.assertTrue(os.path.exists(os.path.join(root, ".travis/run.sh")))
         self.assertFalse(os.path.exists(os.path.join(root, "appveyor.yml")))
+        self.assertFalse(os.path.exists(os.path.join(root, ".gitlab-ci.yml")))
 
         client = TestClient()
         root = client.current_folder
         client.run('new MyPackage/1.3@myuser/testing -gi')
         self.assertTrue(os.path.exists(os.path.join(root, ".gitignore")))
 
+        client = TestClient()
+        root = client.current_folder
+        client.run('new MyPackage/1.3@myuser/testing -ciglg')
+        self.assertTrue(os.path.exists(os.path.join(root, "build.py")))
+        self.assertTrue(os.path.exists(os.path.join(root, ".gitlab-ci.yml")))
+        self.assertFalse(os.path.exists(os.path.join(root, ".travis.yml")))
+        self.assertFalse(os.path.exists(os.path.join(root, ".travis/install.sh")))
+        self.assertFalse(os.path.exists(os.path.join(root, ".travis/run.sh")))
+        self.assertFalse(os.path.exists(os.path.join(root, "appveyor.yml")))
+
+        client = TestClient()
+        root = client.current_folder
+        client.run('new MyPackage/1.3@myuser/testing -ciglc')
+        self.assertTrue(os.path.exists(os.path.join(root, "build.py")))
+        self.assertTrue(os.path.exists(os.path.join(root, ".gitlab-ci.yml")))
+        self.assertFalse(os.path.exists(os.path.join(root, ".travis.yml")))
+        self.assertFalse(os.path.exists(os.path.join(root, ".travis/install.sh")))
+        self.assertFalse(os.path.exists(os.path.join(root, ".travis/run.sh")))
+        self.assertFalse(os.path.exists(os.path.join(root, "appveyor.yml")))


### PR DESCRIPTION
This PR provides GitLab CI support for Gcc and Clang, by `conan new`

I tested this feature in Gitlab, with Catch project. The gitlab recipe created by conan new is [here](https://gitlab.com/uilianries/conan-catch/blob/playground/.gitlab-ci.yml) and you can see all tests results [here](https://gitlab.com/uilianries/conan-catch/pipelines/9088694).

Gitlab CI looks like Travis, however, some aspects are not present in both:
* There is not Travis matrix in Gitlab CI, it uses multiple jobs and all are named.
* Also, in Gitlab you can choice the docker image for each job, different from Travis.
* Gitlab doesn't support `sudo: required` as Travis, so, we need to call `sudo` when necessary.
* In Gitlab, `script:` must be present for each job. In Travis we could use only a global declaration.

I didn't use `CONAN_DOCKER_IMAGE` because in Gitlab, I'll need to call a Docker service + Docker image with DinD (docker-in-docker) and as result, invoke Conan container. It doesn't make sense, when I can call Conan docker image directly by job.

If you want read more about Gitlab CI, see [here](https://docs.gitlab.com/ee/ci/yaml/).

Regards!
 