### PR TITLE
fixed recipe file exports of type:      exports = "../SomeOtherDir/*.py"

### DIFF
--- a/conans/client/file_copier.py
+++ b/conans/client/file_copier.py
@@ -62,10 +62,10 @@ class FileCopier(object):
         if symlinks is not None:
             links = symlinks
         # Check for ../ patterns and allow them
-        reldir = os.path.abspath(os.path.join(self._base_src, pattern))
-        if self._base_src.startswith(os.path.dirname(reldir)):  # ../ relative dir
-            self._base_src = os.path.dirname(reldir)
-            pattern = os.path.basename(reldir)
+        abs_wildcard_path = os.path.abspath(os.path.join(self._base_src, pattern))
+        #if self._base_src.startswith(os.path.dirname(reldir)):  # ../ relative dir
+        self._base_src = os.path.dirname(abs_wildcard_path)
+        pattern = os.path.basename(abs_wildcard_path)
 
         src = os.path.join(self._base_src, src)
         dst = os.path.join(self._base_dst, dst)

--- a/conans/client/file_copier.py
+++ b/conans/client/file_copier.py
@@ -62,10 +62,10 @@ class FileCopier(object):
         if symlinks is not None:
             links = symlinks
         # Check for ../ patterns and allow them
-        abs_wildcard_path = os.path.abspath(os.path.join(self._base_src, pattern))
-        #if self._base_src.startswith(os.path.dirname(reldir)):  # ../ relative dir
-        self._base_src = os.path.dirname(abs_wildcard_path)
-        pattern = os.path.basename(abs_wildcard_path)
+        if pattern.startswith(".."):
+            abs_wildcard_path = os.path.abspath(os.path.join(self._base_src, pattern))
+            self._base_src = os.path.dirname(abs_wildcard_path)
+            pattern = os.path.basename(abs_wildcard_path)
 
         src = os.path.join(self._base_src, src)
         dst = os.path.join(self._base_dst, dst)


### PR DESCRIPTION
Hi,

conan allows exports of type  `exports = "../*.py"` basically meaning that files in parent directories can be exported, too. 

However, exports of type `exports = "../SomeOtherDir/*.py"` are not executed. So exports from parallel directories do not work. This is fixed in the pull request.

Our use-case is to have a python base class for all our recipes to share some common code. The base class is located in a parallel directory in our recipe-repos but needs to be exported to each binary package to make the derived actual recipe classes work.