### PR TITLE
Add Arduino as OS and AVR as Arch 

### DIFF
--- a/conans/client/cmake.py
+++ b/conans/client/cmake.py
@@ -135,6 +135,12 @@ class CMake(object):
     def _cmake_cross_build_defines(self, the_os, os_ver):
         ret = OrderedDict()
         os_ver = get_env("CONAN_CMAKE_SYSTEM_VERSION", os_ver)
+        toolchain_file = get_env("CONAN_CMAKE_TOOLCHAIN_FILE", "")
+
+        if toolchain_file != "":
+            logger.info("Setting Cross build toolchain file: %s" % toolchain_file)
+            ret["CMAKE_TOOLCHAIN_FILE"] = toolchain_file
+            return ret
 
         if self._cmake_system_name is False:
             return ret

--- a/conans/client/conf/__init__.py
+++ b/conans/client/conf/__init__.py
@@ -22,7 +22,8 @@ os:
         version: ["7.0", "7.1", "8.0", "8.1", "8.2", "8.3", "9.0", "9.1", "9.2", "9.3", "10.0", "10.1", "10.2", "10.3"]
     FreeBSD:
     SunOS:
-arch: [x86, x86_64, ppc64le, ppc64, armv6, armv7, armv7hf, armv8, sparc, sparcv9, mips, mips64]
+    Arduino:
+arch: [x86, x86_64, ppc64le, ppc64, armv6, armv7, armv7hf, armv8, sparc, sparcv9, mips, mips64, avr]
 compiler:
     sun-cc:
        version: ["5.10", "5.11", "5.12", "5.13", "5.14"]

--- a/conans/client/conf/__init__.py
+++ b/conans/client/conf/__init__.py
@@ -65,6 +65,7 @@ sysrequires_sudo = True               # environment CONAN_SYSREQUIRES_SUDO
 
 # cmake_generator                     # environment CONAN_CMAKE_GENERATOR
 # http://www.vtk.org/Wiki/CMake_Cross_Compiling
+# cmake_toolchain_file                # environment CONAN_CMAKE_TOOLCHAIN_FILE
 # cmake_system_name                   # environment CONAN_CMAKE_SYSTEM_NAME
 # cmake_system_version                # environment CONAN_CMAKE_SYSTEM_VERSION
 # cmake_system_processor              # environment CONAN_CMAKE_SYSTEM_PROCESSOR
@@ -120,6 +121,7 @@ class ConanClientConfigParser(ConfigParser, object):
                "CONAN_CPU_COUNT": self._env_c("general.cpu_count", "CONAN_CPU_COUNT", None),
                # http://www.vtk.org/Wiki/CMake_Cross_Compiling
                "CONAN_CMAKE_GENERATOR": self._env_c("general.cmake_generator", "CONAN_CMAKE_GENERATOR", None),
+               "CONAN_CMAKE_TOOLCHAIN_FILE": self._env_c("general.cmake_toolchain_file", "CONAN_CMAKE_TOOLCHAIN_FILE", None),
                "CONAN_CMAKE_SYSTEM_NAME": self._env_c("general.cmake_system_name", "CONAN_CMAKE_SYSTEM_NAME", None),
                "CONAN_CMAKE_SYSTEM_VERSION": self._env_c("general.cmake_system_version", "CONAN_CMAKE_SYSTEM_VERSION", None),
                "CONAN_CMAKE_SYSTEM_PROCESSOR": self._env_c("general.cmake_system_processor",

--- a/conans/client/conf/__init__.py
+++ b/conans/client/conf/__init__.py
@@ -23,6 +23,7 @@ os:
     FreeBSD:
     SunOS:
     Arduino:
+        board: ANY
 arch: [x86, x86_64, ppc64le, ppc64, armv6, armv7, armv7hf, armv8, sparc, sparcv9, mips, mips64, avr]
 compiler:
     sun-cc:

--- a/conans/client/conf/__init__.py
+++ b/conans/client/conf/__init__.py
@@ -26,9 +26,9 @@ os:
 arch: [x86, x86_64, ppc64le, ppc64, armv6, armv7, armv7hf, armv8, sparc, sparcv9, mips, mips64, avr]
 compiler:
     sun-cc:
-       version: ["5.10", "5.11", "5.12", "5.13", "5.14"]
-       threads: [None, posix]
-       libcxx: [libCstd, libstdcxx, libstlport, libstdc++]
+        version: ["5.10", "5.11", "5.12", "5.13", "5.14"]
+        threads: [None, posix]
+        libcxx: [libCstd, libstdcxx, libstlport, libstdc++]
     gcc:
         version: ["4.1", "4.4", "4.5", "4.6", "4.7", "4.8", "4.9", "5.1", "5.2", "5.3", "5.4", "6.1", "6.2", "6.3", "7.1"]
         libcxx: [libstdc++, libstdc++11]

--- a/conans/test/model/other_settings_test.py
+++ b/conans/test/model/other_settings_test.py
@@ -148,7 +148,7 @@ class SayConan(ConanFile):
         self.client.save({CONANFILE: content})
         self.client.run("install -s os=ChromeOS --build missing", ignore_error=True)
         self.assertIn(bad_value_msg("settings.os", "ChromeOS",
-                                    ['Android', 'FreeBSD', 'Linux', 'Macos', 'SunOS', 'Windows', 'iOS']),
+                                    ['Android', 'Arduino', 'FreeBSD', 'Linux', 'Macos', 'SunOS', 'Windows', 'iOS']),
                       str(self.client.user_io.out))
 
         # Now add new settings to config and try again

--- a/conans/test/model/transitive_reqs_test.py
+++ b/conans/test/model/transitive_reqs_test.py
@@ -1654,7 +1654,7 @@ class SayConan(ConanFile):
         with self.assertRaises(ConanException) as cm:
             self.root(content, options="arch_independent=True", settings="os=Linux")
         self.assertIn(bad_value_msg("settings.os", "Linux",
-                                    ['Android', 'FreeBSD', 'Macos', 'SunOS', "Windows", "iOS"]),
+                                    ['Android', 'Arduino', 'FreeBSD', 'Macos', 'SunOS', "Windows", "iOS"]),
                       str(cm.exception))
 
     def test_config_remove2(self):


### PR DESCRIPTION
For cross-compilation to Arduino/avr I need to add these OS/arch to settings.
It will be nice to have them in the mainstream conan.