### PR TITLE
#1496 SystemPackgeTool on FreeBSD

### DIFF
--- a/conans/test/util/tools_test.py
+++ b/conans/test/util/tools_test.py
@@ -186,6 +186,17 @@ class HelloConan(ConanFile):
         spt.install("a_package", force=True)
         self.assertEquals(runner.command_called, "brew install a_package")
 
+        os_info.is_freebsd = True
+        os_info.is_macos = False
+
+        spt = SystemPackageTool(runner=runner, os_info=os_info)
+        spt.update()
+        self.assertEquals(runner.command_called, "sudo pkg update")
+        spt.install("a_package", force=True)
+        self.assertEquals(runner.command_called, "sudo pkg install -y a_package")
+        spt.install("a_package", force=False)
+        self.assertEquals(runner.command_called, "pkg info a_package")
+
         os.environ["CONAN_SYSREQUIRES_SUDO"] = "False"
 
         os_info = OSInfo()
@@ -213,6 +224,17 @@ class HelloConan(ConanFile):
         self.assertEquals(runner.command_called, "brew update")
         spt.install("a_package", force=True)
         self.assertEquals(runner.command_called, "brew install a_package")
+
+        os_info.is_freebsd = True
+        os_info.is_macos = False
+
+        spt = SystemPackageTool(runner=runner, os_info=os_info)
+        spt.update()
+        self.assertEquals(runner.command_called, "pkg update")
+        spt.install("a_package", force=True)
+        self.assertEquals(runner.command_called, "pkg install -y a_package")
+        spt.install("a_package", force=False)
+        self.assertEquals(runner.command_called, "pkg info a_package")
 
         del os.environ["CONAN_SYSREQUIRES_SUDO"]
 

--- a/conans/tools.py
+++ b/conans/tools.py
@@ -618,6 +618,8 @@ class SystemPackageTool(object):
             return YumTool()
         elif os_info.is_macos:
             return BrewTool()
+        elif os_info.is_freebsd:
+            return PkgTool()
         else:
             return NullTool()
 
@@ -662,7 +664,7 @@ class NullTool(object):
         pass
 
     def install(self, package_name):
-        _global_output.warn("Only available for linux with apt-get or yum or OSx with brew")
+        _global_output.warn("Only available for linux with apt-get or yum or OSx with brew or FreeBSD with pkg")
 
     def installed(self, package_name):
         return False
@@ -701,6 +703,18 @@ class BrewTool(object):
 
     def installed(self, package_name):
         exit_code = self._runner('test -n "$(brew ls --versions %s)"' % package_name, None)
+        return exit_code == 0
+
+
+class PkgTool(object):
+    def update(self):
+        _run(self._runner, "%spkg update" % self._sudo_str)
+
+    def install(self, package_name):
+        _run(self._runner, "%spkg install -y %s" % (self._sudo_str, package_name))
+
+    def installed(self, package_name):
+        exit_code = self._runner("pkg info %s" % package_name, None)
         return exit_code == 0
 
 

--- a/contributors.txt
+++ b/contributors.txt
@@ -17,3 +17,4 @@ Many thanks to all of them!
 - Ray, Chris (chris@xaltotun.com)
 - Sechet, Olivier (osechet@gmail.com)
 - Ford, Andrew (andrewford55139@gmail.com)
+- Ries, Uilian (uilianries@gmail.com, @uilianries)


### PR DESCRIPTION
Hi guys!

I bring a new tool support for FreeBSD: **pkg**

Here are some important references about pkg:
[pkg-install](https://www.freebsd.org/cgi/man.cgi?query=pkg-install&sektion=8&apropos=0&manpath=FreeBSD+11.0-RELEASE+and+Ports)
[pkg-info](https://www.freebsd.org/cgi/man.cgi?query=pkg-info&sektion=8&apropos=0&manpath=FreeBSD+11.0-RELEASE+and+Ports)
[pkg-update](https://www.freebsd.org/cgi/man.cgi?query=pkg-update&sektion=8&apropos=0&manpath=FreeBSD+11.0-RELEASE+and+Ports)

To test this feature, I used Vagrant to create a VM with FreeBSD-11.0, after that, I just created a dummy project by `conan new`:

```python
# conanfile.py
def build_requirements(self):
        if self.settings.os == "FreeBSD":
            package_tool = tools.SystemPackageTool()
            package_tool.install("tree")
```

As result:

```shelll
foobar/0.1.0@qux/testing: WARN: Forced build from source
pkg: No package(s) matching tree
Running: sudo pkg update
Updating FreeBSD repository catalogue...
FreeBSD repository is up to date.
All repositories are up to date.
Running: sudo pkg install -y tree
Updating FreeBSD repository catalogue...
FreeBSD repository is up to date.
All repositories are up to date.
The following 1 package(s) will be affected (of 0 checked):

New packages to be INSTALLED:
	tree: 1.7.0

Number of packages to be installed: 1

42 KiB to be downloaded.
[1/1] Fetching tree-1.7.0.txz: 100%   42 KiB  42.5kB/s    00:01    
Checking integrity... done (0 conflicting)
[1/1] Installing tree-1.7.0...
Extracting tree-1.7.0: 100%
```

Regards!