### PR TITLE
Forced the current working directory for the loaded conanfile.py

### DIFF
--- a/conans/client/loader_parse.py
+++ b/conans/client/loader_parse.py
@@ -10,6 +10,7 @@ from conans.model.conan_file import ConanFile
 from conans.model.conan_generator import Generator
 from conans.util.config_parser import ConfigParser
 from conans.util.files import rmdir
+from conans.tools import chdir
 
 
 def load_conanfile_class(conanfile_path):
@@ -66,9 +67,9 @@ def _parse_file(conan_file_path):
 
     try:
         current_dir = os.path.dirname(conan_file_path)
-        sys.path.append(current_dir)
         old_modules = list(sys.modules.keys())
-        loaded = imp.load_source(filename, conan_file_path)
+        with chdir(current_dir):
+            loaded = imp.load_source(filename, conan_file_path)
         # Put all imported files under a new package name
         module_id = uuid.uuid1()
         added_modules = set(sys.modules).difference(old_modules)
@@ -84,8 +85,6 @@ def _parse_file(conan_file_path):
         trace = traceback.format_exc().split('\n')
         raise ConanException("Unable to load conanfile in %s\n%s" % (conan_file_path,
                                                                      '\n'.join(trace[3:])))
-    finally:
-        sys.path.pop()
 
     return loaded, filename
 

--- a/conans/client/loader_parse.py
+++ b/conans/client/loader_parse.py
@@ -66,7 +66,7 @@ def _parse_file(conan_file_path):
     filename = os.path.splitext(os.path.basename(conan_file_path))[0]
 
     try:
-        current_dir = os.path.dirname(conan_file_path)
+        current_dir = os.path.dirname(conan_file_path) or "."
         old_modules = list(sys.modules.keys())
         with chdir(current_dir):
             loaded = imp.load_source(filename, conan_file_path)


### PR DESCRIPTION
For our projects, we're loading the list of 'requires' from an external yml file into the conanfile.py recipe. The yml file is called the same thing in each project. Once we attempted to build a consumer project, the dependent project claimed to have a dependency loop.

After adding some print statements to both recipes, it was discovered that the list of 'requires' for the consumer project was being injected into the dependent project. Once we debugged the Conan code, it was realised that the current working folder always stays the same and points to the consumer project. 

When the dependent projects conanfile.py was loaded, the recipe was parsed and the code to dynamically load the list of requires runs and looks for the yml file and because the current working folder is set to the consumer and because the filename exists in that project, it loads the file from that location and not the location of the dependent project.

For now we have changed our recipe to force loading the yml file based on the location of the conanfile.py (i.e., basepath = os.path.dirname(\_\_file\_\_)) but we feel that other developers might fall into this trap. So we changed the Conan code to push into the folder containing the conanfile.py before loading and then popping back out afterwards and this appears to solve the problem. Whilst doing this, we felt that the code which adds the path to the list of sys.path was redundant and removed it.

It's not a problem if you have a different solution :)