### PR TITLE
Change current working directory for the loaded conanfile.py

### DIFF
--- a/conans/client/loader_parse.py
+++ b/conans/client/loader_parse.py
@@ -10,6 +10,7 @@ from conans.model.conan_file import ConanFile
 from conans.model.conan_generator import Generator
 from conans.util.config_parser import ConfigParser
 from conans.util.files import rmdir
+from conans.tools import chdir
 
 
 def load_conanfile_class(conanfile_path):
@@ -65,10 +66,11 @@ def _parse_file(conan_file_path):
     filename = os.path.splitext(os.path.basename(conan_file_path))[0]
 
     try:
-        current_dir = os.path.dirname(conan_file_path)
+        current_dir = os.path.dirname(conan_file_path) or "."
         sys.path.append(current_dir)
         old_modules = list(sys.modules.keys())
-        loaded = imp.load_source(filename, conan_file_path)
+        with chdir(current_dir):
+            loaded = imp.load_source(filename, conan_file_path)
         # Put all imported files under a new package name
         module_id = uuid.uuid1()
         added_modules = set(sys.modules).difference(old_modules)

--- a/conans/client/loader_parse.py
+++ b/conans/client/loader_parse.py
@@ -66,7 +66,7 @@ def _parse_file(conan_file_path):
     filename = os.path.splitext(os.path.basename(conan_file_path))[0]
 
     try:
-        current_dir = os.path.dirname(conan_file_path) or "."
+        current_dir = os.path.dirname(conan_file_path)
         sys.path.append(current_dir)
         old_modules = list(sys.modules.keys())
         with chdir(current_dir):

--- a/conans/client/manager.py
+++ b/conans/client/manager.py
@@ -282,12 +282,14 @@ class ConanManager(object):
         if inject_require:
             output = ScopedOutput("%s test package" % str(inject_require), self._user_io.out)
             output.info("Installing dependencies")
-        elif not isinstance(reference, ConanFileReference):
-            output = ScopedOutput("PROJECT", self._user_io.out)
-            Printer(self._user_io.out).print_graph(deps_graph, registry)
         else:
-            output = ScopedOutput(str(reference), self._user_io.out)
-            output.highlight("Installing package")
+            if not isinstance(reference, ConanFileReference):
+                output = ScopedOutput("PROJECT", self._user_io.out)
+                output.highlight("Installing %s" % reference)
+            else:
+                output = ScopedOutput(str(reference), self._user_io.out)
+                output.highlight("Installing package")
+            Printer(self._user_io.out).print_graph(deps_graph, registry)
 
         try:
             if loader._settings.os and detected_os() != loader._settings.os:
@@ -357,6 +359,8 @@ class ConanManager(object):
                 conan_file_path = os.path.join(reference, CONANFILE)
                 if not os.path.exists(conan_file_path):
                     conan_file_path = os.path.join(reference, CONANFILE_TXT)
+            elif not os.path.isabs(conan_file_path):
+                conan_file_path = os.path.abspath(os.path.join(reference, conan_file_path))
             reference = None
         else:
             output = ScopedOutput(str(reference), self._user_io.out)

--- a/conans/test/integration/load_requires_file_test.py
+++ b/conans/test/integration/load_requires_file_test.py
@@ -1,0 +1,36 @@
+import unittest
+
+from conans.test.utils.tools import TestClient
+
+
+class LoadRequirementsTextFileTest(unittest.TestCase):
+
+    def load_reqs_from_text_file_test(self):
+        client = TestClient()
+        conanfile = """from conans import ConanFile, load
+def reqs():
+    try:
+        content = load("reqs.txt")
+        lines = [line for line in content.splitlines() if line]
+        return tuple(lines)
+    except:
+        return None
+
+class Test(ConanFile):
+    exports = "reqs.txt"
+    requires = reqs()
+"""
+        client.save({"conanfile.py": conanfile})
+        client.run("create Hello0/0.1@user/channel")
+
+        for i in (0, 1, 2):
+            reqs = "Hello%s/0.1@user/channel" % i
+            client.save({"conanfile.py": conanfile,
+                         "reqs.txt": reqs})
+            client.run("create Hello%s/0.1@user/channel" % (i + 1))
+
+        client.run("install Hello3/0.1@user/channel")
+        self.assertIn("Hello0/0.1@user/channel from local", client.out)
+        self.assertIn("Hello1/0.1@user/channel from local", client.out)
+        self.assertIn("Hello2/0.1@user/channel from local", client.out)
+        self.assertIn("Hello3/0.1@user/channel from local", client.out)


### PR DESCRIPTION
For our projects, we're loading the list of 'requires' from an external yml file into the conanfile.py recipe. The yml file is called the same thing in each project. Once we attempted to build a consumer project, the dependent project claimed to have a dependency loop.

After adding some print statements to both recipes, it was discovered that the list of 'requires' for the consumer project was being injected into the dependent project. Once we debugged the Conan code, it was realised that the current working folder always stays the same and points to the consumer project.

When the dependent projects conanfile.py was loaded, the recipe was parsed and the code to dynamically load the list of requires runs and looks for the yml file and because the current working folder is set to the consumer and because the filename exists in that project, it loads the file from that location and not the location of the dependent project.

For now we have changed our recipe to force loading the yml file based on the location of the conanfile.py (i.e., basepath = os.path.dirname(__file__)) but we feel that other developers might fall into this trap. So we changed the Conan code to push into the folder containing the conanfile.py before loading and then popping back out afterwards and this appears to solve the problem.

In addition, the current_dir variable can be an empty string, so I have changed it to "." so that the call to chdir() doesn't fail in those cases.

It's not a problem if you have a different solution :)