### PR TITLE
package() working for package_files

### DIFF
--- a/conans/client/command.py
+++ b/conans/client/command.py
@@ -207,6 +207,10 @@ class Command(object):
                             help='package recipe reference e.g., MyPackage/1.2@user/channel')
         parser.add_argument("--package_folder", "-pf",
                             help='Get binaries from this path, relative to current or absolute')
+        parser.add_argument("--source_folder", "-sf",
+                            help='Get artifacts from this path, relative to current or absolute')
+        parser.add_argument("--build_folder", "-bf",
+                            help='Get artifacts from this path, relative to current or absolute')
         parser.add_argument("--profile", "-pr",
                             help='Profile for this package')
         parser.add_argument("--options", "-o",
@@ -220,6 +224,8 @@ class Command(object):
 
         args = parser.parse_args(*args)
         return self._conan.package_files(reference=args.reference,
+                                         source_folder=args.source_folder,
+                                         build_folder=args.build_folder,
                                          package_folder=args.package_folder,
                                          profile_name=args.profile, force=args.force,
                                          settings=args.settings, options=args.options)

--- a/conans/client/conan_api.py
+++ b/conans/client/conan_api.py
@@ -333,18 +333,25 @@ class ConanAPIV1(object):
                             test=str(reference))
 
     @api_method
-    def package_files(self, reference, package_folder=None, profile_name=None,
-                      force=False, settings=None, options=None, cwd=None):
+    def package_files(self, reference, source_folder=None, build_folder=None, package_folder=None,
+                      profile_name=None, force=False, settings=None, options=None, cwd=None):
 
         cwd = prepare_cwd(cwd)
 
         reference = ConanFileReference.loads(reference)
+        profile = profile_from_args(profile_name, settings, options, env=None, scope=None, cwd=cwd,
+                                    default_folder=self._client_cache.profiles_path)
         package_folder = package_folder or cwd
+        if not source_folder and build_folder:
+            source_folder = build_folder
         if not os.path.isabs(package_folder):
             package_folder = os.path.join(cwd, package_folder)
-        profile = profile_from_args(profile_name, settings, options, env=None,
-                                    scope=None, cwd=cwd, default_folder=self._client_cache.profiles_path)
-        self._manager.package_files(reference=reference, package_folder=package_folder,
+        if source_folder and not os.path.isabs(source_folder):
+            source_folder = os.path.normpath(os.path.join(cwd, source_folder))
+        if build_folder and not os.path.isabs(build_folder):
+            build_folder = os.path.normpath(os.path.join(cwd, build_folder))
+        self._manager.package_files(reference=reference, source_folder=source_folder,
+                                    build_folder=build_folder, package_folder=package_folder,
                                     profile=profile, force=force)
 
     @api_method

--- a/conans/client/installer.py
+++ b/conans/client/installer.py
@@ -375,7 +375,7 @@ class ConanInstaller(object):
         else:
             source_folder = build_folder
         with environment_append(conan_file.env):
-            create_package(conan_file, source_folder, build_folder, package_folder, output, False)
+            create_package(conan_file, source_folder, build_folder, package_folder, output)
             self._remote_proxy.handle_package_manifest(package_reference, installed=True)
 
     def _raise_package_not_found_error(self, conan_ref, conan_file):

--- a/conans/client/packager.py
+++ b/conans/client/packager.py
@@ -11,7 +11,8 @@ from conans.client.output import ScopedOutput
 from conans.client.file_copier import FileCopier
 
 
-def create_package(conanfile, source_folder, build_folder, package_folder, output, local=False):
+def create_package(conanfile, source_folder, build_folder, package_folder, output, local=False,
+                   copy_info=False):
     """ copies built artifacts, libs, headers, data, etc from build_folder to
     package folder
     """
@@ -57,27 +58,25 @@ def create_package(conanfile, source_folder, build_folder, package_folder, outpu
             raise
         raise ConanException(e)
 
-    _create_aux_files(build_folder, package_folder, conanfile)
+    _create_aux_files(build_folder, package_folder, conanfile, copy_info)
     output.success("Package '%s' created" % os.path.basename(package_folder))
 
 
-def _create_aux_files(build_folder, package_folder, conanfile):
+def _create_aux_files(build_folder, package_folder, conanfile, copy_info):
     """ auxiliary method that creates CONANINFO and manifest in
     the package_folder
     """
-
     logger.debug("Creating config files to %s" % package_folder)
-    if hasattr(conanfile, "build_id"):
-        # It is important to create a new fresh CONANINFO, because for shared
-        # build_id folders, the existing one in the build folders is wrong
-        save(os.path.join(package_folder, CONANINFO), conanfile.info.dumps())
-    else:
+    if copy_info:
         try:
             shutil.copy(os.path.join(build_folder, CONANINFO), package_folder)
         except IOError:
             raise ConanException("%s does not exist inside of your %s folder. "
                                  "Try to re-build it again to solve it."
                                  % (CONANINFO, build_folder))
+    else:
+        save(os.path.join(package_folder, CONANINFO), conanfile.info.dumps())
+
     # Create the digest for the package
     digest = FileTreeManifest.create(package_folder)
     save(os.path.join(package_folder, CONAN_MANIFEST), str(digest))

--- a/conans/test/functional/create_package_test.py
+++ b/conans/test/functional/create_package_test.py
@@ -82,7 +82,8 @@ class ExporterTest(unittest.TestCase):
         loader = ConanFileLoader(None, Settings(), Profile())
         conanfile = loader.load_conan(conanfile_path, None)
         output = ScopedOutput("", TestBufferConanOutput())
-        create_package(conanfile, build_folder, build_folder, package_folder, output)
+        create_package(conanfile, build_folder, build_folder, package_folder, output,
+                       copy_info=True)
 
         # test build folder
         self.assertTrue(os.path.exists(build_folder))


### PR DESCRIPTION
It changes behavior a little:
- In conan cache, now ``conaninfo.txt`` in package folder is always generated, not copied from build folder. The generation of ``conaninfo.txt`` and ``conanbuildinfo.txt`` in build folder might be removed, I don't think anyone is using them


Related to https://github.com/conan-io/conan/issues/1548
