### PR TITLE
Add an official conan_server Docker image on Docker Hub

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -2,20 +2,19 @@ FROM python:3.6.1-alpine3.6
 
 ENV CONAN_VERSION=0.25.1
 
-RUN apk add —no-cache git
+ADD https://github.com/conan-io/conan/archive/${CONAN_VERSION}.zip /
 
-RUN cd / \
-    && git clone https://github.com/conan-io/conan.git \
-    && cd conan \
-    && git checkout $CONAN_VERSION \
+RUN unzip ${CONAN_VERSION} \
+    && rm ${CONAN_VERSION}.zip \
+    && cd conan-${CONAN_VERSION} \
     && pip3 install -r conans/requirements.txt \
     && pip3 install -r conans/requirements_server.txt \
     && pip3 install gunicorn
 
 EXPOSE 9300
 
-VOLUME /root/.conan_server
+WORKDIR /conan-${CONAN_VERSION}
 
-WORKDIR /conan
+COPY entrypoint.sh .
 
-ENTRYPOINT gunicorn -b 0.0.0.0:9300 -w 4 -t 300 conans.server.server_launcher:app
+CMD /conan-${CONAN_VERSION}/entrypoint.sh

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,21 @@
+FROM python:3.6.1-alpine3.6
+
+ENV CONAN_VERSION=0.25.1
+
+RUN apk add —no-cache git
+
+RUN cd / \
+    && git clone https://github.com/conan-io/conan.git \
+    && cd conan \
+    && git checkout $CONAN_VERSION \
+    && pip3 install -r conans/requirements.txt \
+    && pip3 install -r conans/requirements_server.txt \
+    && pip3 install gunicorn
+
+EXPOSE 9300
+
+VOLUME /root/.conan_server
+
+WORKDIR /conan
+
+ENTRYPOINT gunicorn -b 0.0.0.0:9300 -w 4 -t 300 conans.server.server_launcher:app

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,0 +1,12 @@
+version: '3'
+services:
+    server:
+        build: .
+        image: conan_server:latest
+        container_name: conan_server
+        volumes:
+            - ./config:/root/.conan_server:rw
+        ports:
+            - '9300:9300'
+        restart: unless-stopped
+

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,7 +1,6 @@
 version: '3'
 services:
     server:
-        build: .
         image: conan_server:latest
         container_name: conan_server
         volumes:

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+# Run server on port 9300 with 4 workers and a timeout of 5 minutes (300 seconds)
+gunicorn -b 0.0.0.0:9300 -w 4 -t 300 conans.server.server_launcher:app


### PR DESCRIPTION
I want to help add an official Docker image in the public Docker Hub with Conan_server, so that it will be easier for users to deploy their own instance of conan_server.

This is my initial version, which can be used as is, but it still needs some tweaking in order to meet the Docker official image regulations.