### PR TITLE
Add verbose definition for cmake helper

### DIFF
--- a/conans/client/cmake.py
+++ b/conans/client/cmake.py
@@ -12,6 +12,7 @@ from conans.util.files import mkdir
 from conans.tools import cpu_count, args_to_string
 from conans import tools
 from conans.util.log import logger
+from conans.util.config_parser import get_bool_from_text
 
 # Deprecated in 0.22
 deprecated_conanfile_param_message = '''
@@ -359,6 +360,17 @@ class CMake(object):
             target = "RUN_TESTS" if self._compiler == "Visual Studio" else "test"
         self._build_new(args=args, build_dir=build_dir, target=target)
 
+    @property
+    def verbose(self):
+        try:
+            verbose = self.definitions["CMAKE_VERBOSE_MAKEFILE"]
+            return get_bool_from_text(str(verbose))
+        except:
+            return False
+
+    @verbose.setter
+    def verbose(self, value):
+        self.definitions["CMAKE_VERBOSE_MAKEFILE"] = "ON" if value else "OFF"
 
 def _defs_to_string(defs):
     return " ".join(['-D{0}="{1}"'.format(k, v) for k, v in defs.items()])

--- a/conans/test/functional/cmake_test.py
+++ b/conans/test/functional/cmake_test.py
@@ -375,6 +375,35 @@ build_type: [ Release]
 
         self.assertNotIn("BUILD_SHARED_LIBS", cmake.definitions)
 
+    def test_verbose(self):
+        settings = Settings.loads(default_settings_yml)
+        settings.os = "Windows"
+        settings.compiler = "Visual Studio"
+        settings.compiler.version = "12"
+        settings.arch = "x86"
+        settings.os = "Windows"
+
+        conan_file = ConanFileMock()
+        conan_file.settings = settings
+        cmake = CMake(conan_file)
+
+        self.assertNotIn("CMAKE_VERBOSE_MAKEFILE", cmake.definitions)
+
+        cmake.verbose = True
+        self.assertEquals(cmake.definitions["CMAKE_VERBOSE_MAKEFILE"], "ON")
+
+        cmake.verbose = False
+        self.assertEquals(cmake.definitions["CMAKE_VERBOSE_MAKEFILE"], "OFF")
+
+        cmake.definitions["CMAKE_VERBOSE_MAKEFILE"] = True
+        self.assertTrue(cmake.verbose)
+
+        cmake.definitions["CMAKE_VERBOSE_MAKEFILE"] = False
+        self.assertFalse(cmake.verbose)
+
+        del cmake.definitions["CMAKE_VERBOSE_MAKEFILE"]
+        self.assertFalse(cmake.verbose)
+
     @staticmethod
     def scape(args):
         pattern = "%s" if sys.platform == "win32" else r"'%s'"

--- a/contributors.txt
+++ b/contributors.txt
@@ -1,7 +1,7 @@
 Contributors
 -------------
 
-This is the list of contributors to this project source code, in alphabetical order. 
+This is the list of contributors to this project source code, in alphabetical order.
 Many thanks to all of them!
 
 - Bocanegra Algarra, Raul (raul.bocanegra.algarra@gmail.com)
@@ -17,5 +17,5 @@ Many thanks to all of them!
 - Lee, Jeongseok (jslee02@gmail.com, @jslee02)
 - Márki, Róbert (gsmiko@gmail.com, @robertmrk)
 - Ray, Chris (chris@xaltotun.com)
-- Sechet, Olivier (osechet@gmail.com)
 - Ries, Uilian (uilianries@gmail.com, @uilianries)
+- Sechet, Olivier (osechet@gmail.com)


### PR DESCRIPTION
Hi! 

This PR is an enhancement to provide `CMAKE_VERBOSE_MAKEFILE` in CMake helper.

Related issue: #1569

Regards.