### PR TITLE
Adding support for system package tool pkgutil on Solaris

### DIFF
--- a/conans/test/util/tools_test.py
+++ b/conans/test/util/tools_test.py
@@ -26,18 +26,10 @@ from conans.util.files import save
 class RunnerMock(object):
     def __init__(self, return_ok=True):
         self.command_called = None
-        self.output = """
-        ----Running------
-        > {command}
-        -----------------
-        """
-        self.output = one
         self.return_ok = return_ok
 
     def __call__(self, command, output):  # @UnusedVariable
         self.command_called = command
-        self.output = self.output.format(command=command)
-        self.output = self.output + "a_package" if not self.return_ok
         return 0 if self.return_ok else 1
 
 
@@ -252,22 +244,6 @@ class HelloConan(ConanFile):
         self.assertEquals(runner.command_called, "pkgutil --catalog")
         spt.install("a_package", force=True)
         self.assertEquals(runner.command_called, "pkgutil --install --yes a_package")
-        spt.install("a_package", force=False)
-        self.assertEquals(runner.command_called, "pkutil --list a_package")
-        spt.install("a_package", force=False)
-        self.assertEquals(runner.output, """
-        ----Running------
-        > pkutil --list a_package
-        -----------------
-        """)
-        runner = RunnerMock(return_ok=False)
-        spt.install("a_package", force=False)
-        self.assertEquals(runner.output, """
-        ----Running------
-        > pkutil --list a_package
-        -----------------
-        a_package
-        """)
 
         del os.environ["CONAN_SYSREQUIRES_SUDO"]
 

--- a/conans/tools.py
+++ b/conans/tools.py
@@ -729,7 +729,7 @@ class PkgUtilTool(object):
         _run(self._runner, "%spkgutil --install --yes %s" % (self._sudo_str, package_name))
 
     def installed(self, package_name):
-        exit_code = self._runner('test -n "$(pkgutil --list %s)"' % package_name, None)
+        exit_code = self._runner('test -n "`pkgutil --list %s`"' % package_name, None)
         return exit_code == 0
 
 

--- a/conans/tools.py
+++ b/conans/tools.py
@@ -10,7 +10,6 @@ import re
 import subprocess
 import sys
 
-import io
 
 from contextlib import contextmanager
 
@@ -611,7 +610,7 @@ class SystemPackageTool(object):
         self._is_up_to_date = False
         self._tool = tool or self._create_tool(os_info)
         self._tool._sudo_str = "sudo " if self._sudo else ""
-        self._tool._runner = runner or ConanRunner(print_commands_to_output=True)
+        self._tool._runner = runner or ConanRunner()
 
     def _create_tool(self, os_info):
         if os_info.with_apt:
@@ -623,7 +622,7 @@ class SystemPackageTool(object):
         elif os_info.is_freebsd:
             return PkgTool()
         elif os_info.is_solaris:
-            return PkgutilTool()
+            return PkgUtilTool()
         else:
             return NullTool()
 
@@ -722,7 +721,7 @@ class PkgTool(object):
         return exit_code == 0
 
 
-class PkgutilTool(object):
+class PkgUtilTool(object):
     def update(self):
         _run(self._runner, "%spkgutil --catalog" % self._sudo_str)
 
@@ -730,10 +729,9 @@ class PkgutilTool(object):
         _run(self._runner, "%spkgutil --install --yes %s" % (self._sudo_str, package_name))
 
     def installed(self, package_name):
-        with io.StringIO() as buf:
-            self._runner(u'pkgutil --list %s' % package_name, buf)
-            exit_code = 1 if len(buf.getvalue().splitlines()) <= 4 else 0
+        exit_code = self._runner('test -n "$(pkgutil --list %s)"' % package_name, None)
         return exit_code == 0
+
 
 def _run(runner, command):
     _global_output.info("Running: %s" % command)


### PR DESCRIPTION
Hello,

This PR is to add support for the pkgutil system package tool on Solaris.
This package tool is not an official one, it's linked to the [OpenCSW ](https://www.opencsw.org/about/) project that makes pre-compiled binaries for the SunOS platform easily available.
This project is however used a lot by Solaris systems administrators for the convenient and large binaries catalog they provide (and because of the poor quality of the default available tools...).

An issue I faced was with "installed" method that I copied from the BrewTool:
`exit_code = self._runner('test -n "$(brew ls --versions %s)"' % package_name, None)`
I don't have a mac to test this command but from what I understand it tries to check if the output of `brew ls --versions` is empty or if it contains the package we are trying to install.
This is the same way to check if a package is installed with `pkgutil` but I could not make it work because it seems that the underlying `os.system()` call does not expand the subshell command we want to run:

Python 2.7
```
>>> import os
>>> os.system('echo "$(echo "aa")"')
$(echo aa)
```

Bash shell
```
$ echo "$(echo "aa")"
aa
```

That's why I suspect that the BrewTool `installed()` method is always returning 0 since it's always testing a non-empty string.