### PR TITLE
Add conan settings to cmake generated file

### DIFF
--- a/conans/client/generators/cmake.py
+++ b/conans/client/generators/cmake.py
@@ -2,7 +2,7 @@ from conans.model import Generator
 from conans.paths import BUILD_INFO_CMAKE
 from conans.client.generators.cmake_common import cmake_dependency_vars,\
     cmake_macros, generate_targets_section, cmake_dependencies, cmake_package_info,\
-    cmake_global_vars, cmake_user_info_vars
+    cmake_global_vars, cmake_user_info_vars, cmake_settings_info
 
 
 class DepsCppCmake(object):
@@ -61,6 +61,7 @@ class CMakeGenerator(Generator):
         sections.append("\n### Definition of global aggregated variables ###\n")
         sections.append(cmake_package_info(name=self.conanfile.name,
                                            version=self.conanfile.version))
+        sections.append(cmake_settings_info(self.conanfile.settings))
         all_flags = cmake_dependencies(dependencies=self.deps_build_info.deps)
         sections.append(all_flags)
         deps = DepsCppCmake(self.deps_build_info)

--- a/conans/client/generators/cmake_common.py
+++ b/conans/client/generators/cmake_common.py
@@ -51,6 +51,15 @@ def cmake_package_info(name, version):
     return _cmake_package_info.format(name=name, version=version)
 
 
+def cmake_settings_info(settings):
+    settings_info = ""
+    for item in settings.items():
+        key, value = item
+        name = "CONAN_SETTINGS_%s" % key.upper().replace(".", "_")
+        settings_info += "set({key} \"{value}\")\n".format(key=name, value=value)
+    return settings_info
+
+
 def cmake_dependencies(dependencies, build_type=""):
     build_type = _build_type_str(build_type)
     dependencies = " ".join(dependencies)

--- a/conans/test/generators/cmake_test.py
+++ b/conans/test/generators/cmake_test.py
@@ -8,6 +8,8 @@ from conans.model.conan_file import ConanFile
 from conans.client.generators.cmake import CMakeGenerator
 from conans.model.build_info import CppInfo
 from conans.model.ref import ConanFileReference
+from conans.client.conf import default_settings_yml
+
 
 
 class CMakeGeneratorTest(unittest.TestCase):
@@ -125,3 +127,33 @@ endmacro()""", macro)
         set(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ${CONAN_CMAKE_FIND_ROOT_PATH_MODE_INCLUDE})
     endif()
 endmacro()""", macro)
+
+    def name_and_version_are_generated_test(self):
+        conanfile = ConanFile(None, None, Settings({}), None)
+        conanfile.name = "MyPkg"
+        conanfile.version = "1.1.0"
+        generator = CMakeGenerator(conanfile)
+        content = generator.content
+        cmake_lines = content.splitlines()
+        self.assertIn('set(CONAN_PACKAGE_NAME MyPkg)', cmake_lines)
+        self.assertIn('set(CONAN_PACKAGE_VERSION 1.1.0)', cmake_lines)
+
+    def settings_are_generated_tests(self):
+        settings = Settings.loads(default_settings_yml)
+        settings.os = "Windows"
+        settings.compiler = "Visual Studio"
+        settings.compiler.version = "12"
+        settings.compiler.runtime = "MD"
+        settings.arch = "x86"
+        settings.build_type = "Debug"
+        conanfile = ConanFile(None, None, Settings({}), None)
+        conanfile.settings = settings
+        generator = CMakeGenerator(conanfile)
+        content = generator.content
+        cmake_lines = content.splitlines()
+        self.assertIn('set(CONAN_SETTINGS_BUILD_TYPE "Debug")', cmake_lines)
+        self.assertIn('set(CONAN_SETTINGS_ARCH "x86")', cmake_lines)
+        self.assertIn('set(CONAN_SETTINGS_COMPILER "Visual Studio")', cmake_lines)
+        self.assertIn('set(CONAN_SETTINGS_COMPILER_VERSION "12")', cmake_lines)
+        self.assertIn('set(CONAN_SETTINGS_COMPILER_RUNTIME "MD")', cmake_lines)
+        self.assertIn('set(CONAN_SETTINGS_OS "Windows")', cmake_lines)


### PR DESCRIPTION
This small change adds the settings from the install command to the generated cmake file.
Based on this, I can define some other includes I want to make in my own cmake files and mainly I can restrict the Visual Studio build to the installed build_type via CMAKE_CONFIGURATION_TYPES to avoid confusion.
