### PR TITLE
Add support for Chocolatey (#1612)

### DIFF
--- a/conans/test/util/tools_test.py
+++ b/conans/test/util/tools_test.py
@@ -125,7 +125,7 @@ class HelloConan(ConanFile):
         runner = RunnerMock(return_ok=False)
         spt = SystemPackageTool(runner=runner)
         platforms = {"Linux": "sudo apt-get update", "Darwin": "brew update", "Windows": "choco outdated"}
-        if platform.system() in platforms.keys():
+        if platform.system() in platforms:
             msg = "Command '%s' failed" % platforms[platform.system()]
             with self.assertRaisesRegexp(ConanException, msg):
                 spt.update()

--- a/conans/test/util/tools_test.py
+++ b/conans/test/util/tools_test.py
@@ -124,9 +124,9 @@ class HelloConan(ConanFile):
     def system_package_tool_fail_when_not_0_returned_test(self):
         runner = RunnerMock(return_ok=False)
         spt = SystemPackageTool(runner=runner)
-        if platform.system() == "Linux" or platform.system() == "Darwin":
-            msg = "Command 'sudo apt-get update' failed" if platform.system() == "Linux" \
-                else "Command 'brew update' failed"
+        platforms = {"Linux": "sudo apt-get update", "Darwin": "brew update", "Windows": "choco outdated"}
+        if platform.system() in platforms.keys():
+            msg = "Command '%s' failed" % platforms[platform.system()]
             with self.assertRaisesRegexp(ConanException, msg):
                 spt.update()
         else:
@@ -197,6 +197,17 @@ class HelloConan(ConanFile):
         spt.install("a_package", force=False)
         self.assertEquals(runner.command_called, "pkg info a_package")
 
+        os_info.is_freebsd = False
+        os_info.is_windows = True
+
+        spt = SystemPackageTool(runner=runner, os_info=os_info)
+        spt.update()
+        self.assertEquals(runner.command_called, "choco outdated")
+        spt.install("a_package", force=True)
+        self.assertEquals(runner.command_called, "choco install --yes a_package")
+        spt.install("a_package", force=False)
+        self.assertEquals(runner.command_called, 'choco search --local-only --exact a_package | findstr /c:"1 packages installed."')
+
         os.environ["CONAN_SYSREQUIRES_SUDO"] = "False"
 
         os_info = OSInfo()
@@ -245,6 +256,17 @@ class HelloConan(ConanFile):
         spt.install("a_package", force=True)
         self.assertEquals(runner.command_called, "pkgutil --install --yes a_package")
 
+        os_info.is_solaris = False
+        os_info.is_windows = True
+
+        spt = SystemPackageTool(runner=runner, os_info=os_info)
+        spt.update()
+        self.assertEquals(runner.command_called, "choco outdated")
+        spt.install("a_package", force=True)
+        self.assertEquals(runner.command_called, "choco install --yes a_package")
+        spt.install("a_package", force=False)
+        self.assertEquals(runner.command_called, 'choco search --local-only --exact a_package | findstr /c:"1 packages installed."')
+
         del os.environ["CONAN_SYSREQUIRES_SUDO"]
 
     def system_package_tool_try_multiple_test(self):
@@ -276,11 +298,15 @@ class HelloConan(ConanFile):
         self.assertEquals(7, runner.calls)
 
     def system_package_tool_installed_test(self):
-        if platform.system() != "Linux" and platform.system() != "Macos":
+        if platform.system() != "Linux" and platform.system() != "Macos" and platform.system() != "Windows":
             return
         spt = SystemPackageTool()
-        # Git should be installed on development/testing machines
-        self.assertTrue(spt._tool.installed("git"))
+        if platform.system() == "Windows":
+            # Git is not installed by default on Chocolatey
+            self.assertTrue(spt._tool.installed("chocolatey"))
+        else:
+            # Git should be installed on development/testing machines
+            self.assertTrue(spt._tool.installed("git"))
         # This package hopefully doesn't exist
         self.assertFalse(spt._tool.installed("oidfjgesiouhrgioeurhgielurhgaeiorhgioearhgoaeirhg"))
 

--- a/conans/tools.py
+++ b/conans/tools.py
@@ -623,6 +623,8 @@ class SystemPackageTool(object):
             return PkgTool()
         elif os_info.is_solaris:
             return PkgUtilTool()
+        elif os_info.is_windows:
+            return ChocolateyTool()
         else:
             return NullTool()
 
@@ -730,6 +732,17 @@ class PkgUtilTool(object):
 
     def installed(self, package_name):
         exit_code = self._runner('test -n "`pkgutil --list %s`"' % package_name, None)
+        return exit_code == 0
+
+class ChocolateyTool(object):
+    def update(self):
+        _run(self._runner, "choco outdated")
+
+    def install(self, package_name):
+        _run(self._runner, "choco install --yes %s" % package_name)
+
+    def installed(self, package_name):
+        exit_code = self._runner('choco search --local-only --exact %s | findstr /c:"1 packages installed."' % package_name, None)
         return exit_code == 0
 
 


### PR DESCRIPTION
Hi!

This PR brings  ![Chocolatey](http://i.imgur.com/6eqVxxE.png) into `SystemPackageTool`. 

Some points may be observed:
* Chocolatey doesn't have a real `update` like *apt* and *brew*, but there is an opened [issue](https://github.com/chocolatey/chocolatey/issues/320). For such feature, I'm used `choco outdated`, a shortcut for `choco upgrade all --noop`, to update information about installed packages.
* When Chocolatey search for local packages, it returns *%ERROLEVEL% == 0* when a package is installed or not. I used *findstr* to validate if such package is installed.
* The original package test expects *git* installed on development machine. By default, is not installed on AppVeyor, so I used *chocolatey* package.

Related issue: #1612 

Saludos.