### PR TITLE
Move comments above fields

### DIFF
--- a/conans/server/conf/default_server_conf.py
+++ b/conans/server/conf/default_server_conf.py
@@ -28,9 +28,6 @@ updown_secret: {updown_secret}
 #
 # custom_authenticator: my_authenticator
 
-[write_permissions]
-
-#
 # name/version@user/channel: user1, user2, user3
 #
 # The rules are applied in order. 
@@ -43,10 +40,8 @@ updown_secret: {updown_secret}
 #
 #   opencv/2.3.4@lasote/testing: default_user, default_user2
 #
+[write_permissions]
 
-[read_permissions]
-
-#
 # name/version@user/channel: user1, user2, user3
 # The rules are applied in order. If a rule applies to a conan, system wont look further.
 #
@@ -57,10 +52,12 @@ updown_secret: {updown_secret}
 #   *:*@*/*: *
 #
 # By default all users can read all blocks
+#
+[read_permissions]
 */*@*/*: *
-
 
 [users]
 #default_user: defaultpass
 demo: demo
+
 """


### PR DESCRIPTION
Moved comments for permissions above fields to match other fields in the config, and match general config file patterns.