### PR TITLE
Fix for issue #1640

### DIFF
--- a/conans/client/generators/cmake_common.py
+++ b/conans/client/generators/cmake_common.py
@@ -22,6 +22,15 @@ set(CONAN_EXE_LINKER_FLAGS_{dep}{build_type}_LIST "{deps.exelinkflags_list}")
 
 """
 
+def _cmake_string_representation(value):
+    """Escapes the specified string for use in a CMake command surrounded with double quotes
+       :param value the string to escape"""
+    return '"{0}"'.format(value.replace('\\', '\\\\')
+                               .replace('$', '\\$')
+                               .replace('"', '\\"'))
+                            
+    
+    
 
 def _build_type_str(build_type):
     if build_type:
@@ -33,7 +42,7 @@ def cmake_user_info_vars(deps_user_info):
     lines = []
     for dep, the_vars in deps_user_info.items():
         for name, value in the_vars.vars.items():
-            lines.append('set(CONAN_USER_%s_%s "%s")' % (dep.upper(), name, value))
+            lines.append('set(CONAN_USER_%s_%s %s)' % (dep.upper(), name, _cmake_string_representation(value)))
     return "\n".join(lines)
 
 
@@ -56,7 +65,7 @@ def cmake_settings_info(settings):
     for item in settings.items():
         key, value = item
         name = "CONAN_SETTINGS_%s" % key.upper().replace(".", "_")
-        settings_info += "set({key} \"{value}\")\n".format(key=name, value=value)
+        settings_info += "set({key} {value})\n".format(key=name, value=_cmake_string_representation(value))
     return settings_info
 
 

--- a/conans/test/generators/cmake_test.py
+++ b/conans/test/generators/cmake_test.py
@@ -55,6 +55,22 @@ class CMakeGeneratorTest(unittest.TestCase):
         self.assertIn('set(CONAN_USER_LIB1_myvar "myvalue")', cmake_lines)
         self.assertIn('set(CONAN_USER_LIB1_myvar2 "myvalue2")', cmake_lines)
         self.assertIn('set(CONAN_USER_LIB2_MYVAR2 "myvalue4")', cmake_lines)
+    
+    def variables_cmake_multi_user_vars_escape_test(self):
+        #set_trace()
+        settings_mock = namedtuple("Settings", "build_type, constraint")
+        conanfile = ConanFile(None, None, settings_mock("Release", lambda x: x), None)
+        conanfile.deps_user_info["FOO"].myvar = 'my"value"'
+        conanfile.deps_user_info["FOO"].myvar2 = 'my${value}'
+        conanfile.deps_user_info["FOO"].myvar3 = 'my\\value'
+        generator = CMakeMultiGenerator(conanfile)
+        content = generator.content["conanbuildinfo_multi.cmake"]
+        cmake_lines = content.splitlines()
+        self.assertIn(r'set(CONAN_USER_FOO_myvar "my\"value\"")', cmake_lines)
+        self.assertIn(r'set(CONAN_USER_FOO_myvar2 "my\${value}")', cmake_lines)
+        self.assertIn(r'set(CONAN_USER_FOO_myvar3 "my\\value")', cmake_lines)
+        
+
 
     def multi_flag_test(self):
         conanfile = ConanFile(None, None, Settings({}), None)


### PR DESCRIPTION
(#1640) Fixes an issue where the CMake generator would fail to escape settings and user_info values, resulting in an invalid CMake file.

The problem was a little wider than expected. Evaluated against the CMake documentation and determined that ", $, and \ all need to be properly escaped when applied. Also, I extended the implementation to the settings values as well, since it is conceivable (though unlikely) that a setting could contain a value requiring escape as well.