### PR TITLE
use vswhere to locate Visual Studio 2017, if available

### DIFF
--- a/conans/client/command.py
+++ b/conans/client/command.py
@@ -136,16 +136,7 @@ class Command(object):
 
         args = parser.parse_args(*args)
 
-        try:
-            name_version, user_channel = args.reference.split("@")
-            name, version = name_version.split("/")
-            user, channel = user_channel.split("/")
-        except:
-            name, version = None, None
-            try:
-                user, channel = args.reference.split("/")
-            except:
-                user, channel = None, None
+        name, version, user, channel = get_reference_fields(args.reference)
 
         if args.test_only:
             args.build = ["never"]
@@ -902,6 +893,10 @@ def get_reference_fields(arg_reference):
     :param arg_reference: String with a complete reference, or only user/channel
     :return: name, version, user and channel, in a tuple
     """
+
+    if not arg_reference:
+        return None, None, None, None
+
     try:
         name_version, user_channel = arg_reference.split("@")
         name, version = name_version.split("/")

--- a/conans/tools.py
+++ b/conans/tools.py
@@ -203,7 +203,7 @@ def vcvars_command(settings):
         if env_var != "vs150comntools":
             command = ('call "%s../../VC/vcvarsall.bat" %s' % (vs_path, param))
         else:
-            command = ('call "%s../../VC/Auxiliary/Build/vcvarsall.bat" %s' % (vs_path, param))
+            command = ('set "VSCMD_START_DIR=%%CD%%" && call "%s../../VC/Auxiliary/Build/vcvarsall.bat" %s' % (vs_path, param))
     return command
 
 

--- a/conans/tools.py
+++ b/conans/tools.py
@@ -168,7 +168,7 @@ def build_sln_command(settings, sln_path, targets=None, upgrade_project=True, bu
 def vs_installation_path(version):
     if not hasattr(vs_installation_path, "_cached"):
         vs_installation_path._cached = dict()
-    if not version in vs_installation_path._cached.keys():
+    if not version in vs_installation_path._cached:
         version_range = "[%d.0, %d.0)" % (int(version), int(version) + 1)
         program_files = os.environ.get("ProgramFiles(x86)", os.environ["ProgramFiles"])
         vswhere_path = os.path.join(program_files, "Microsoft Visual Studio", "Installer", "vswhere.exe")

--- a/conans/tools.py
+++ b/conans/tools.py
@@ -183,8 +183,20 @@ def vcvars_command(settings):
                                  % (existing_version, compiler_version))
     else:
         env_var = "vs%s0comntools" % compiler_version
+
+        vs_path = None
+        if env_var == 'vs150comntools' and not env_var in os.environ:
+            try:
+                program_files = os.environ.get("ProgramFiles(x86)", os.environ["ProgramFiles"])
+                vswhere_path = os.path.join(program_files, "Microsoft Visual Studio", "Installer", "vswhere.exe")
+                vs_root = subprocess.check_output([vswhere_path, "-version", "[15.0, 16.0)", "-latest", "-property", "installationPath"]).decode(sys.stdout.encoding).strip()
+            except:
+                pass
+            else:
+                vs_path = os.path.join(vs_root, "Common7", "Tools", "")
+
         try:
-            vs_path = os.environ[env_var]
+            vs_path = vs_path or os.environ[env_var]
         except KeyError:
             raise ConanException("VS '%s' variable not defined. Please install VS or define "
                                  "the variable (VS2017)" % env_var)

--- a/conans/tools.py
+++ b/conans/tools.py
@@ -174,7 +174,7 @@ def vs_installation_path(version):
         vswhere_path = os.path.join(program_files, "Microsoft Visual Studio", "Installer", "vswhere.exe")
         vs_installation_path._cached[version] = subprocess.check_output([vswhere_path, "-version", version_range,
             "-latest", "-property", "installationPath"]).decode(sys.stdout.encoding).strip()
-    return vs_installation_path._cached[version];
+    return vs_installation_path._cached[version]
 
 
 def vcvars_command(settings):


### PR DESCRIPTION
as you know, Visual Studio has removed VS150COMNTOOLS environment variable, and currently it has to be manually set up in order to use conan.
however, recently MS has added tool called vswhere (https://github.com/Microsoft/vswhere) which can be used to find Visual Studio installation directory.
proposed patch uses vswhere if VS150COMNTOOLS  is not set.
also, it fixes an issue that vcvarsall.bat can change current directory (https://developercommunity.visualstudio.com/content/problem/26780/vsdevcmdbat-changes-the-current-working-directory.html)