### PR TITLE
Fix path joining in vcvars_command

### DIFF
--- a/conans/tools.py
+++ b/conans/tools.py
@@ -189,9 +189,10 @@ def vcvars_command(settings):
             raise ConanException("VS '%s' variable not defined. Please install VS or define "
                                  "the variable (VS2017)" % env_var)
         if env_var != "vs150comntools":
-            command = ('call "%s../../VC/vcvarsall.bat" %s' % (vs_path, param))
+            vs_path = os.path.join(vs_path, "../../VC/vcvarsall.bat")
         else:
-            command = ('call "%s../../VC/Auxiliary/Build/vcvarsall.bat" %s' % (vs_path, param))
+            vs_path = os.path.join(vs_path, "../../VC/Auxiliary/Build/vcvarsall.bat")
+        command = ('call "%s" %s' % (vs_path, param))
     return command
 
 


### PR DESCRIPTION
Use os.path.join for path joining in vcvars_command function.

There was a problem when the path in environment variable doesn't finish with '/' at the end.