### PR TITLE
Add option to pass different build type in CMake build helper.

### DIFF
--- a/conans/client/cmake.py
+++ b/conans/client/cmake.py
@@ -231,12 +231,16 @@ class CMake(object):
             return {"CONAN_LINK_RUNTIME": "/%s" % self._runtime}
         return {}
 
+    @staticmethod
+    def _get_build_config(build_type):
+        return "--config %s" % build_type
+
     @property
     def build_config(self):
         """ cmake --build tool have a --config option for Multi-configuration IDEs
         """
         if self._build_type and self.is_multi_configuration:
-            return "--config %s" % self._build_type
+            return self._get_build_config(self._build_type)
         return ""
 
     def _get_cmake_definitions(self):
@@ -317,15 +321,15 @@ class CMake(object):
         else:
             self._conanfile.run(command)
 
-    def _build_old(self, conanfile, args=None, build_dir=None, target=None):
+    def _build_old(self, conanfile, args=None, build_dir=None, target=None, build_type=None):
         """Deprecated in 0.22"""
         if not isinstance(conanfile, ConanFile):
             raise ConanException(deprecated_conanfile_param_message)
         self._conanfile = conanfile
         self._conanfile.output.warn(deprecated_conanfile_param_message)
-        return self._build_new(args=args, build_dir=build_dir, target=target)
+        return self._build_new(args=args, build_dir=build_dir, target=target, build_type=build_type)
 
-    def _build_new(self, args=None, build_dir=None, target=None):
+    def _build_new(self, args=None, build_dir=None, target=None, build_type=None):
         if isinstance(args, ConanFile):
             raise ConanException(deprecated_conanfile_param_message)
         args = args or []
@@ -341,24 +345,24 @@ class CMake(object):
 
         arg_list = _join_arguments([
             args_to_string([build_dir]),
-            self.build_config,
+            self._get_build_config(build_type) if build_type else self.build_config,
             args_to_string(args)
         ])
         command = "cmake --build %s" % arg_list
         self._conanfile.run(command)
 
-    def install(self, args=None, build_dir=None):
+    def install(self, args=None, build_dir=None, build_type=None):
         if not self.definitions.get("CMAKE_INSTALL_PREFIX"):
             raise ConanException("CMAKE_INSTALL_PREFIX not defined for 'cmake.install()'\n"
                                  "Make sure 'package_folder' is defined")
-        self._build_new(args=args, build_dir=build_dir, target="install")
+        self._build_new(args=args, build_dir=build_dir, target="install", build_type=build_type)
 
-    def test(self, args=None, build_dir=None, target=None):
+    def test(self, args=None, build_dir=None, target=None, build_type=None):
         if isinstance(args, ConanFile):
             raise ConanException(deprecated_conanfile_param_message)
         if not target:
             target = "RUN_TESTS" if self._compiler == "Visual Studio" else "test"
-        self._build_new(args=args, build_dir=build_dir, target=target)
+        self._build_new(args=args, build_dir=build_dir, target=target, build_type=build_type)
 
     @property
     def verbose(self):

--- a/conans/client/cmake.py
+++ b/conans/client/cmake.py
@@ -39,13 +39,14 @@ def _get_env_cmake_system_name():
 class CMake(object):
 
     def __init__(self, settings_or_conanfile, generator=None, cmake_system_name=True,
-                 parallel=True):
+                 parallel=True, build_type=None):
         """
         :param settings_or_conanfile: Conanfile instance (or settings for retro compatibility)
         :param generator: Generator name to use or none to autodetect
         :param cmake_system_name: False to not use CMAKE_SYSTEM_NAME variable,
                True for auto-detect or directly a string with the system name
         :param parallel: Try to build with multiple cores if available
+        :param build_type: Override default build type comming from settings
         """
         if isinstance(settings_or_conanfile, Settings):
             self._settings = settings_or_conanfile
@@ -65,6 +66,8 @@ class CMake(object):
         self._compiler_version = self._settings.get_safe("compiler.version")
         self._arch = self._settings.get_safe("arch")
         self._build_type = self._settings.get_safe("build_type")
+        if build_type:
+            self._build_type = build_type
         self._op_system_version = self._settings.get_safe("os.version")
         self._libcxx = self._settings.get_safe("compiler.libcxx")
         self._runtime = self._settings.get_safe("compiler.runtime")

--- a/conans/client/cmake.py
+++ b/conans/client/cmake.py
@@ -234,16 +234,12 @@ class CMake(object):
             return {"CONAN_LINK_RUNTIME": "/%s" % self._runtime}
         return {}
 
-    @staticmethod
-    def _get_build_config(build_type):
-        return "--config %s" % build_type
-
     @property
     def build_config(self):
         """ cmake --build tool have a --config option for Multi-configuration IDEs
         """
         if self._build_type and self.is_multi_configuration:
-            return self._get_build_config(self._build_type)
+            return "--config %s" % self._build_type
         return ""
 
     def _get_cmake_definitions(self):
@@ -324,15 +320,15 @@ class CMake(object):
         else:
             self._conanfile.run(command)
 
-    def _build_old(self, conanfile, args=None, build_dir=None, target=None, build_type=None):
+    def _build_old(self, conanfile, args=None, build_dir=None, target=None):
         """Deprecated in 0.22"""
         if not isinstance(conanfile, ConanFile):
             raise ConanException(deprecated_conanfile_param_message)
         self._conanfile = conanfile
         self._conanfile.output.warn(deprecated_conanfile_param_message)
-        return self._build_new(args=args, build_dir=build_dir, target=target, build_type=build_type)
+        return self._build_new(args=args, build_dir=build_dir, target=target)
 
-    def _build_new(self, args=None, build_dir=None, target=None, build_type=None):
+    def _build_new(self, args=None, build_dir=None, target=None):
         if isinstance(args, ConanFile):
             raise ConanException(deprecated_conanfile_param_message)
         args = args or []
@@ -348,24 +344,24 @@ class CMake(object):
 
         arg_list = _join_arguments([
             args_to_string([build_dir]),
-            self._get_build_config(build_type) if build_type else self.build_config,
+            self.build_config,
             args_to_string(args)
         ])
         command = "cmake --build %s" % arg_list
         self._conanfile.run(command)
 
-    def install(self, args=None, build_dir=None, build_type=None):
+    def install(self, args=None, build_dir=None):
         if not self.definitions.get("CMAKE_INSTALL_PREFIX"):
             raise ConanException("CMAKE_INSTALL_PREFIX not defined for 'cmake.install()'\n"
                                  "Make sure 'package_folder' is defined")
-        self._build_new(args=args, build_dir=build_dir, target="install", build_type=build_type)
+        self._build_new(args=args, build_dir=build_dir, target="install")
 
-    def test(self, args=None, build_dir=None, target=None, build_type=None):
+    def test(self, args=None, build_dir=None, target=None):
         if isinstance(args, ConanFile):
             raise ConanException(deprecated_conanfile_param_message)
         if not target:
             target = "RUN_TESTS" if self._compiler == "Visual Studio" else "test"
-        self._build_new(args=args, build_dir=build_dir, target=target, build_type=build_type)
+        self._build_new(args=args, build_dir=build_dir, target=target)
 
     @property
     def verbose(self):

--- a/conans/test/util/tools_test.py
+++ b/conans/test/util/tools_test.py
@@ -19,7 +19,8 @@ from conans.test.utils.runner import TestRunner
 from conans.test.utils.test_files import temp_folder
 from conans.test.utils.tools import TestClient, TestBufferConanOutput
 from conans.test.utils.visual_project_files import get_vs_project_files
-from conans.tools import OSInfo, SystemPackageTool, replace_in_file, AptTool
+from conans.test.utils.context_manager import which
+from conans.tools import OSInfo, SystemPackageTool, replace_in_file, AptTool, ChocolateyTool
 from conans.util.files import save
 
 
@@ -124,10 +125,14 @@ class HelloConan(ConanFile):
     def system_package_tool_fail_when_not_0_returned_test(self):
         runner = RunnerMock(return_ok=False)
         spt = SystemPackageTool(runner=runner)
-        platforms = {"Linux": "sudo apt-get update", "Darwin": "brew update", "Windows": "choco outdated"}
+        platforms = {"Linux": "sudo apt-get update", "Darwin": "brew update"}
         if platform.system() in platforms:
             msg = "Command '%s' failed" % platforms[platform.system()]
             with self.assertRaisesRegexp(ConanException, msg):
+                spt.update()
+        elif platform.system() == "Windows" and which("choco.exe"):
+            spt = SystemPackageTool(runner=runner, tool=ChocolateyTool())
+            with self.assertRaisesRegexp(ConanException, "Command 'choco outdated' failed"):
                 spt.update()
         else:
             spt.update()  # Won't raise anything because won't do anything
@@ -197,16 +202,18 @@ class HelloConan(ConanFile):
         spt.install("a_package", force=False)
         self.assertEquals(runner.command_called, "pkg info a_package")
 
-        os_info.is_freebsd = False
-        os_info.is_windows = True
+        # Chocolatey is an optional package manager on Windows
+        if platform.system() == "Windows" and which("choco.exe"):
+            os_info.is_freebsd = False
+            os_info.is_windows = True
 
-        spt = SystemPackageTool(runner=runner, os_info=os_info)
-        spt.update()
-        self.assertEquals(runner.command_called, "choco outdated")
-        spt.install("a_package", force=True)
-        self.assertEquals(runner.command_called, "choco install --yes a_package")
-        spt.install("a_package", force=False)
-        self.assertEquals(runner.command_called, 'choco search --local-only --exact a_package | findstr /c:"1 packages installed."')
+            spt = SystemPackageTool(runner=runner, os_info=os_info, tool=ChocolateyTool())
+            spt.update()
+            self.assertEquals(runner.command_called, "choco outdated")
+            spt.install("a_package", force=True)
+            self.assertEquals(runner.command_called, "choco install --yes a_package")
+            spt.install("a_package", force=False)
+            self.assertEquals(runner.command_called, 'choco search --local-only --exact a_package | findstr /c:"1 packages installed."')
 
         os.environ["CONAN_SYSREQUIRES_SUDO"] = "False"
 
@@ -256,16 +263,18 @@ class HelloConan(ConanFile):
         spt.install("a_package", force=True)
         self.assertEquals(runner.command_called, "pkgutil --install --yes a_package")
 
-        os_info.is_solaris = False
-        os_info.is_windows = True
+        # Chocolatey is an optional package manager on Windows
+        if platform.system() == "Windows" and which("choco.exe"):
+            os_info.is_solaris = False
+            os_info.is_windows = True
 
-        spt = SystemPackageTool(runner=runner, os_info=os_info)
-        spt.update()
-        self.assertEquals(runner.command_called, "choco outdated")
-        spt.install("a_package", force=True)
-        self.assertEquals(runner.command_called, "choco install --yes a_package")
-        spt.install("a_package", force=False)
-        self.assertEquals(runner.command_called, 'choco search --local-only --exact a_package | findstr /c:"1 packages installed."')
+            spt = SystemPackageTool(runner=runner, os_info=os_info, tool=ChocolateyTool())
+            spt.update()
+            self.assertEquals(runner.command_called, "choco outdated")
+            spt.install("a_package", force=True)
+            self.assertEquals(runner.command_called, "choco install --yes a_package")
+            spt.install("a_package", force=False)
+            self.assertEquals(runner.command_called, 'choco search --local-only --exact a_package | findstr /c:"1 packages installed."')
 
         del os.environ["CONAN_SYSREQUIRES_SUDO"]
 
@@ -300,13 +309,16 @@ class HelloConan(ConanFile):
     def system_package_tool_installed_test(self):
         if platform.system() != "Linux" and platform.system() != "Macos" and platform.system() != "Windows":
             return
+        if platform.system() == "Windows" and not which("choco.exe"):
+            return
         spt = SystemPackageTool()
-        if platform.system() == "Windows":
+        expected_package = "git"
+        if platform.system() == "Windows" and which("choco.exe"):
+            spt = SystemPackageTool(tool=ChocolateyTool())
             # Git is not installed by default on Chocolatey
-            self.assertTrue(spt._tool.installed("chocolatey"))
-        else:
-            # Git should be installed on development/testing machines
-            self.assertTrue(spt._tool.installed("git"))
+            expected_package = "chocolatey"
+        # The expected should be installed on development/testing machines
+        self.assertTrue(spt._tool.installed(expected_package))
         # This package hopefully doesn't exist
         self.assertFalse(spt._tool.installed("oidfjgesiouhrgioeurhgielurhgaeiorhgioearhgoaeirhg"))
 

--- a/conans/tools.py
+++ b/conans/tools.py
@@ -623,8 +623,6 @@ class SystemPackageTool(object):
             return PkgTool()
         elif os_info.is_solaris:
             return PkgUtilTool()
-        elif os_info.is_windows:
-            return ChocolateyTool()
         else:
             return NullTool()
 


### PR DESCRIPTION
Add additional argument build_type for **CMake** build helper - build, install and test methods to be able to override **Conan** _build_type_ setting.

When using **CMake** build helper for _Release_ **Conan** setting in recipe sometimes I want to build _RelWithDebInfo_ **CMake** configuration instead of _Release_ configuration. Currently when I have _Release_ in settings and I call `cmake.build()`, **Conan** tries `cmake --build <build_dir> --config Release`. It will be good to be possible to override the default assumptions for _Debug_ when I have _Debug_ **Conan** setting and Release when I have _Release_ **Conan** setting.

Of course I always can call appropriate build command with `self.run` but having direct support for this in **CMake** build helper will be more convenient.