### PR TITLE
Add ?:"Any authenticated user" to BasicAuthorizer

### DIFF
--- a/conans/server/conf/default_server_conf.py
+++ b/conans/server/conf/default_server_conf.py
@@ -45,10 +45,15 @@ updown_secret: {updown_secret}
 # name/version@user/channel: user1, user2, user3
 # The rules are applied in order. If a rule applies to a conan, system wont look further.
 #
-# Example: All versions of opencv package from lasote user in testing channel is only
-# readable by default_user and default_user2. Rest of packages are world readable
+# Example: 
+#  All versions of opencv package from lasote user in testing channel are only
+#    readable by default_user and default_user2. 
+#  All versions of internal package from any user/channel are only readable by
+#    authenticated users. 
+#  Rest of packages are world readable.
 #
-#   opencv/1.2.3@lasote/testing: default_user default_user2
+#   opencv/*@lasote/testing: default_user default_user2
+#   internal/*@*/*: ?
 #   *:*@*/*: *
 #
 # By default all users can read all blocks

--- a/conans/server/service/authorize.py
+++ b/conans/server/service/authorize.py
@@ -189,7 +189,10 @@ class BasicAuthorizer(Authorizer):
                 return True  # Ok, applies and match username
             else:
                 if username:
-                    raise ForbiddenException("Permission denied")
+                    if authorized_users[0] == "?":
+                        return True #Ok, applies and match any authenticated username
+                    else:
+                        raise ForbiddenException("Permission denied")
                 else:
                     raise AuthenticationException()
 

--- a/conans/test/server/service/authorizer_test.py
+++ b/conans/test/server/service/authorizer_test.py
@@ -136,6 +136,19 @@ class AuthorizerTest(unittest.TestCase):
         self.assertRaises(ForbiddenException,
                           authorizer.check_write_package, "pepe", self.package_reference2)
 
+
+        # Only authenticated users can read openssl
+        read_perms = [(str(self.openssl_ref), "?"), ("*/*@*/*", "*")]
+
+        authorizer = BasicAuthorizer(read_perms, write_perms)
+
+        # Authenticated user can read conans
+        authorizer.check_read_conan("pepe", self.openssl_ref)
+
+        # Anonymous user can not
+        self.assertRaises(ForbiddenException,
+                          authorizer.check_read_package, None, self.openssl_ref)
+
     def users_test(self):
         """Check that lists of user names are parsed correctly"""
 


### PR DESCRIPTION
Currently, the BasicAuthroizer pattern `*` includes even unauthenticated users. In the spirit of PCRE where `*` can match 0 or more occurrences, but `?` matches 1+ occurrence, this pull request adds the ability to specify wildcard rules that require authentication.

e.g. This config snippet
```default_server_conf:
[read_permissions]
*/*@*/*: ?
```
will require authentication for all recipe and package operations, but any authenticated user is authorized.