### PR TITLE
Auth with environment

### DIFF
--- a/conans/client/rest/auth_manager.py
+++ b/conans/client/rest/auth_manager.py
@@ -1,4 +1,4 @@
-'''
+"""
 Collaborate with RestApiClient to make remote anonymous and authenticated calls.
 Uses user_io to request user's login and password and obtain a token for calling authenticated
 methods if receives AuthenticationException from RestApiClient.
@@ -10,8 +10,7 @@ Flow:
     if receives AuthenticationException (not open method) will ask user for login and password
     and will invoke RestApiClient.get_token() (with LOGIN_RETRIES retries) and retry to call
     get_conan with the new token.
-'''
-
+"""
 
 from conans.errors import AuthenticationException, ForbiddenException,\
     ConanException

--- a/conans/client/userio.py
+++ b/conans/client/userio.py
@@ -1,3 +1,4 @@
+import os
 import sys
 from conans.client.output import ConanOutput
 from conans.model.username import Username
@@ -40,11 +41,11 @@ class UserIO(object):
 
     def get_username(self, remote_name):
         """Overridable for testing purpose"""
-        return raw_input()
+        return self._get_env_username(remote_name) or raw_input()
 
     def get_password(self, remote_name):
         """Overridable for testing purpose"""
-        return getpass.getpass("")
+        return self._get_env_password(remote_name) or getpass.getpass("")
 
     def request_string(self, msg, default_value=None):
         """Request user to input a msg
@@ -77,4 +78,27 @@ class UserIO(object):
                 ret = False
             else:
                 self.out.error("%s is not a valid answer" % s)
+        return ret
+
+    def _get_env_password(self, remote_name):
+        """
+        Try CONAN_PASSWORD_REMOTE_NAME or CONAN_PASSWORD or return None
+        """
+        remote_name = remote_name.replace("-", "_").upper()
+        var_name = "CONAN_PASSWORD_%s" % remote_name
+        ret = os.getenv(var_name, None) or os.getenv("CONAN_PASSWORD", None)
+        if ret:
+            self.out.info("Got password '******' from environment")
+        return ret
+
+    def _get_env_username(self, remote_name):
+        """
+        Try CONAN_LOGIN_USERNAME_REMOTE_NAME or CONAN_LOGIN_USERNAME or return None
+        """
+        remote_name = remote_name.replace("-", "_").upper()
+        var_name = "CONAN_LOGIN_USERNAME_%s" % remote_name
+        ret = os.getenv(var_name, None) or os.getenv("CONAN_LOGIN_USERNAME", None)
+
+        if ret:
+            self.out.info("Got username '%s' from environment" % ret)
         return ret

--- a/conans/test/remote/auth_test.py
+++ b/conans/test/remote/auth_test.py
@@ -1,4 +1,6 @@
 import unittest
+
+from conans import tools
 from conans.test.utils.tools import TestServer, TestClient
 from conans.paths import CONANFILE
 from conans.util.files import save
@@ -43,6 +45,40 @@ class AuthorizeTest(unittest.TestCase):
 
         # Check that login failed two times before ok
         self.assertEquals(self.conan.user_io.login_index["default"], 3)
+
+    def auth_with_env_test(self):
+
+        def _upload_with_credentials(credentials):
+            cli = TestClient(servers=self.servers, users={})
+            save(os.path.join(cli.current_folder, CONANFILE), conan_content)
+            cli.run("export lasote/testing")
+            with tools.environment_append(credentials):
+                cli.run("upload %s" % str(self.conan_reference))
+            return cli
+
+        # Try with remote name in credentials
+        client = _upload_with_credentials({"CONAN_PASSWORD_DEFAULT": "pepepass",
+                                           "CONAN_LOGIN_USERNAME_DEFAULT": "pepe"})
+        self.assertIn("Got username 'pepe' from environment", client.user_io.out)
+        self.assertIn("Got password '******' from environment", client.user_io.out)
+
+        # Try with generic password and login
+        client = _upload_with_credentials({"CONAN_PASSWORD": "pepepass",
+                                           "CONAN_LOGIN_USERNAME_DEFAULT": "pepe"})
+        self.assertIn("Got username 'pepe' from environment", client.user_io.out)
+        self.assertIn("Got password '******' from environment", client.user_io.out)
+
+        # Try with generic password and generic login
+        client = _upload_with_credentials({"CONAN_PASSWORD": "pepepass",
+                                           "CONAN_LOGIN_USERNAME": "pepe"})
+        self.assertIn("Got username 'pepe' from environment", client.user_io.out)
+        self.assertIn("Got password '******' from environment", client.user_io.out)
+
+        # Bad pass raise
+        with self.assertRaises(Exception):
+            client = _upload_with_credentials({"CONAN_PASSWORD": "bad",
+                                               "CONAN_LOGIN_USERNAME": "pepe"})
+            self.assertIn("Too many failed login attempts, bye!", client.user_io.out)
 
     def max_retries_test(self):
         """Bad login 3 times"""

--- a/conans/test/utils/tools.py
+++ b/conans/test/utils/tools.py
@@ -263,6 +263,9 @@ class MockedUserIO(UserIO):
 
     def get_username(self, remote_name):
         """Overridable for testing purpose"""
+        username_env = self._get_env_username(remote_name)
+        if username_env:
+            return username_env
         sub_dict = self.logins[remote_name]
         index = self.login_index[remote_name]
         if len(sub_dict) - 1 < index:
@@ -272,6 +275,10 @@ class MockedUserIO(UserIO):
 
     def get_password(self, remote_name):
         """Overridable for testing purpose"""
+        password_env = self._get_env_password(remote_name)
+        if password_env:
+            return password_env
+
         sub_dict = self.logins[remote_name]
         index = self.login_index[remote_name]
         tmp = sub_dict[index][1]


### PR DESCRIPTION
- Should solve the problem with expiring tokens reported by @tru 
- Support for multiremote=> multiuser/multipassword
- Same naming used in package tools, interesting feature to improve conan package tools, specifing multiple users/password without complexing the calls to conan user or conan upload -u -p 