### PR TITLE
Filter directories

### DIFF
--- a/conans/client/command.py
+++ b/conans/client/command.py
@@ -136,16 +136,7 @@ class Command(object):
 
         args = parser.parse_args(*args)
 
-        try:
-            name_version, user_channel = args.reference.split("@")
-            name, version = name_version.split("/")
-            user, channel = user_channel.split("/")
-        except:
-            name, version = None, None
-            try:
-                user, channel = args.reference.split("/")
-            except:
-                user, channel = None, None
+        name, version, user, channel = get_reference_fields(args.reference)
 
         if args.test_only:
             args.build = ["never"]
@@ -902,6 +893,10 @@ def get_reference_fields(arg_reference):
     :param arg_reference: String with a complete reference, or only user/channel
     :return: name, version, user and channel, in a tuple
     """
+
+    if not arg_reference:
+        return None, None, None, None
+
     try:
         name_version, user_channel = arg_reference.split("@")
         name, version = name_version.split("/")

--- a/conans/model/build_info.py
+++ b/conans/model/build_info.py
@@ -32,30 +32,30 @@ class _CppInfo(object):
         self.rootpath = ""
         self.sysroot = None
 
+    def filter_paths(self, paths):
+        abs_paths = [os.path.join(self.rootpath, p)
+                if not os.path.isabs(p) else p for p in paths]
+        return [p for p in abs_paths if os.path.isdir(p) and os.listdir(p)]
+
     @property
     def include_paths(self):
-        return [os.path.join(self.rootpath, p)
-                if not os.path.isabs(p) else p for p in self.includedirs]
+        return self.filter_paths(self.includedirs)
 
     @property
     def lib_paths(self):
-        return [os.path.join(self.rootpath, p)
-                if not os.path.isabs(p) else p for p in self.libdirs]
+        return self.filter_paths(self.libdirs)
 
     @property
     def bin_paths(self):
-        return [os.path.join(self.rootpath, p)
-                if not os.path.isabs(p) else p for p in self.bindirs]
+        return self.filter_paths(self.bindirs)
 
     @property
     def build_paths(self):
-        return [os.path.join(self.rootpath, p)
-                if not os.path.isabs(p) else p for p in self.builddirs]
+        return self.filter_paths(self.builddirs)
 
     @property
     def res_paths(self):
-        return [os.path.join(self.rootpath, p)
-                if not os.path.isabs(p) else p for p in self.resdirs]
+        return self.filter_paths(self.resdirs)
 
 
 class CppInfo(_CppInfo):


### PR DESCRIPTION
filter out non-existing and empty directories
such directories can cause troubles for certain generators, e.g. CMake targets complains about them

#1607 