### PR TITLE
Feature/dirty files fixes

### DIFF
--- a/conans/client/export.py
+++ b/conans/client/export.py
@@ -5,7 +5,7 @@ to the local store, as an initial step before building or uploading to remotes
 import shutil
 import os
 from conans.util.files import save, load, rmdir
-from conans.paths import CONAN_MANIFEST, CONANFILE, DIRTY_FILE
+from conans.paths import CONAN_MANIFEST, CONANFILE
 from conans.errors import ConanException
 from conans.model.manifest import FileTreeManifest
 from conans.client.output import ScopedOutput
@@ -73,9 +73,9 @@ def export_conanfile(output, paths, conanfile, origin_folder, conan_ref, keep_so
     save(os.path.join(destination_folder, CONAN_MANIFEST), str(digest))
 
     source = paths.source(conan_ref, conanfile.short_paths)
-    dirty = os.path.join(source, DIRTY_FILE)
+    dirty_file_path = paths.dirty_sources_file(conan_ref)
     remove = False
-    if os.path.exists(dirty):
+    if os.path.exists(dirty_file_path):
         output.info("Source folder is dirty, forcing removal")
         remove = True
     elif modified_recipe and not keep_source and os.path.exists(source):
@@ -91,7 +91,7 @@ def export_conanfile(output, paths, conanfile, origin_folder, conan_ref, keep_so
             output.error("Unable to delete source folder. "
                          "Will be marked as dirty for deletion")
             output.warn(str(e))
-            save(os.path.join(source, DIRTY_FILE), "")
+            save(dirty_file_path, "")
 
 
 def _init_export_folder(destination_folder, destination_src_folder):

--- a/conans/client/installer.py
+++ b/conans/client/installer.py
@@ -347,11 +347,12 @@ class ConanInstaller(object):
         src_folder = self._client_cache.source(conan_ref, conan_file.short_paths)
         export_folder = self._client_cache.export(conan_ref)
         export_source_folder = self._client_cache.export_sources(conan_ref, conan_file.short_paths)
+        dirty_file_path = self._client_cache.dirty_sources_file(conan_ref)
 
         self._handle_system_requirements(conan_ref, package_reference, conan_file, output)
         with environment_append(conan_file.env):
             self._build_package(export_folder, export_source_folder, src_folder, build_folder,
-                                package_folder, conan_file, output)
+                                package_folder, dirty_file_path, conan_file, output)
         return build_folder
 
     def _package_conanfile(self, conan_ref, conan_file, package_reference, build_folder,
@@ -424,7 +425,7 @@ Or read "http://docs.conan.io/en/latest/faq/troubleshooting.html#error-missing-p
             raise ConanException("Error in system requirements")
 
     def _build_package(self, export_folder, export_source_folder, src_folder, build_folder,
-                       package_folder, conan_file, output):
+                       package_folder, dirty_file_path, conan_file, output):
         """ builds the package, creating the corresponding build folder if necessary
         and copying there the contents from the src folder. The code is duplicated
         in every build, as some configure processes actually change the source
@@ -439,7 +440,8 @@ Or read "http://docs.conan.io/en/latest/faq/troubleshooting.html#error-missing-p
                                  "Close any app using it, and retry" % str(e))
 
         output.info('Building your package in %s' % build_folder)
-        config_source(export_folder, export_source_folder, src_folder, conan_file, output)
+        config_source(export_folder, export_source_folder, src_folder, dirty_file_path,
+                      conan_file, output)
         output.info('Copying sources to build folder')
 
         def check_max_path_len(src, files):

--- a/conans/client/manager.py
+++ b/conans/client/manager.py
@@ -377,10 +377,11 @@ class ConanManager(object):
             conanfile = self.load_consumer_conanfile(conanfile_path, current_path,
                                                      output, reference=reference,
                                                      deps_cpp_info_required=None)
+            dirty_file_path = self._client_cache.dirty_sources_file(reference)
             src_folder = self._client_cache.source(reference, conanfile.short_paths)
             export_folder = self._client_cache.export(reference)
             export_src_folder = self._client_cache.export_sources(reference, conanfile.short_paths)
-            config_source(export_folder, export_src_folder, src_folder, conanfile, output, force)
+            config_source(export_folder, export_src_folder, src_folder, dirty_file_path, conanfile, output, force)
 
     def imports_undo(self, current_path):
         undo_imports(current_path, self._user_io.out)

--- a/conans/client/source.py
+++ b/conans/client/source.py
@@ -6,7 +6,7 @@ import six
 from conans import tools
 from conans.errors import ConanException, conanfile_exception_formatter, \
     ConanExceptionInUserConanfileMethod
-from conans.paths import DIRTY_FILE, EXPORT_TGZ_NAME, EXPORT_SOURCES_TGZ_NAME, CONANFILE
+from conans.paths import EXPORT_TGZ_NAME, EXPORT_SOURCES_TGZ_NAME, CONANFILE
 from conans.util.files import rmdir, save
 
 
@@ -21,18 +21,18 @@ def merge_directories(src, dst):
             shutil.copy2(src_file, dst_file)
 
 
-def config_source(export_folder, export_source_folder, src_folder, conan_file, output, force=False):
+def config_source(export_folder, export_source_folder, src_folder, dirty_file_path,
+                  conan_file, output, force=False):
     """ creates src folder and retrieve, calling source() from conanfile
     the necessary source code
     """
-    dirty = os.path.join(src_folder, DIRTY_FILE)
 
     def remove_source(raise_error=True):
         output.warn("This can take a while for big packages")
         try:
             rmdir(src_folder)
         except BaseException as e_rm:
-            save(dirty, "")  # Creation of DIRTY flag
+            save(dirty_file_path, "")  # Creation of DIRTY flag
             msg = str(e_rm)
             if six.PY2:
                 msg = str(e_rm).decode("latin1")  # Windows prints some chars in latin1
@@ -44,7 +44,7 @@ def config_source(export_folder, export_source_folder, src_folder, conan_file, o
     if force:
         output.warn("Forced removal of source folder")
         remove_source()
-    elif os.path.exists(dirty):
+    elif os.path.exists(dirty_file_path):
         output.warn("Trying to remove dirty source folder")
         remove_source()
     elif conan_file.build_policy_always:
@@ -66,13 +66,13 @@ def config_source(export_folder, export_source_folder, src_folder, conan_file, o
         except OSError:
             pass
 
-        save(dirty, "")  # Creation of DIRTY flag
+        save(dirty_file_path, "")  # Creation of DIRTY flag
         os.chdir(src_folder)
         try:
             with tools.environment_append(conan_file.env):
                 with conanfile_exception_formatter(str(conan_file), "source"):
                     conan_file.source()
-            os.remove(dirty)  # Everything went well, remove DIRTY flag
+            os.remove(dirty_file_path)  # Everything went well, remove DIRTY flag
         except Exception as e:
             os.chdir(export_folder)
             # in case source() fails (user error, typically), remove the src_folder
@@ -86,16 +86,10 @@ def config_source(export_folder, export_source_folder, src_folder, conan_file, o
 
 def config_source_local(current_path, conan_file, output):
     output.info('Configuring sources in %s' % current_path)
-    dirty = os.path.join(current_path, DIRTY_FILE)
-    if os.path.exists(dirty):
-        output.warn("Your previous source command failed")
-
-    save(dirty, "")  # Creation of DIRTY flag
     try:
         with conanfile_exception_formatter(str(conan_file), "source"):
             with tools.environment_append(conan_file.env):
                 conan_file.source()
-            os.remove(dirty)  # Everything went well, remove DIRTY flag
     except ConanExceptionInUserConanfileMethod:
         raise
     except Exception as e:

--- a/conans/client/source.py
+++ b/conans/client/source.py
@@ -6,7 +6,7 @@ import six
 from conans import tools
 from conans.errors import ConanException, conanfile_exception_formatter, \
     ConanExceptionInUserConanfileMethod
-from conans.paths import EXPORT_TGZ_NAME, EXPORT_SOURCES_TGZ_NAME, CONANFILE
+from conans.paths import EXPORT_TGZ_NAME, EXPORT_SOURCES_TGZ_NAME, CONANFILE, CONAN_MANIFEST
 from conans.util.files import rmdir, save
 
 
@@ -56,7 +56,8 @@ def config_source(export_folder, export_source_folder, src_folder, dirty_file_pa
         shutil.copytree(export_folder, src_folder, symlinks=True)
         # Now move the export-sources to the right location
         merge_directories(export_source_folder, src_folder)
-        for f in (EXPORT_TGZ_NAME, EXPORT_SOURCES_TGZ_NAME, CONANFILE+"c", CONANFILE+"o"):
+        for f in (EXPORT_TGZ_NAME, EXPORT_SOURCES_TGZ_NAME, CONANFILE+"c",
+                  CONANFILE+"o", CONANFILE, CONAN_MANIFEST):
             try:
                 os.remove(os.path.join(src_folder, f))
             except OSError:

--- a/conans/paths.py
+++ b/conans/paths.py
@@ -29,7 +29,7 @@ BUILD_INFO_YCM = '.ycm_extra_conf.py'
 CONANINFO = "conaninfo.txt"
 CONANENV = "conanenv.txt"
 SYSTEM_REQS = "system_reqs.txt"
-DIRTY_FILE = ".conan_dirty"
+SOURCE_DIRTY_FILE = ".conan_source_dirty"
 PUT_HEADERS = "artifacts.properties"
 
 PACKAGE_TGZ_NAME = "conan_package.tgz"
@@ -175,6 +175,10 @@ class SimplePaths(object):
         """
         assert isinstance(conan_reference, ConanFileReference)
         return normpath(join(self._store_folder, "/".join(conan_reference)))
+
+    def dirty_sources_file(self, conan_reference):
+        assert isinstance(conan_reference, ConanFileReference)
+        return normpath(join(self.conan(conan_reference), SOURCE_DIRTY_FILE))
 
     def export(self, conan_reference):
         assert isinstance(conan_reference, ConanFileReference)

--- a/conans/test/command/source_test.py
+++ b/conans/test/command/source_test.py
@@ -16,6 +16,7 @@ class ConanLib(ConanFile):
     version = "0.1"
 
     def source(self):
+        self.assertEquals(os.listdir("."), []) # Not conanfile copied, clean source
         self.output.info("Running source!")
 '''
         client = TestClient()

--- a/conans/test/command/source_test.py
+++ b/conans/test/command/source_test.py
@@ -10,13 +10,14 @@ class SourceTest(unittest.TestCase):
     def basic_source_test(self):
         conanfile = '''
 from conans import ConanFile
+import os
 
 class ConanLib(ConanFile):
     name = "Hello"
     version = "0.1"
 
     def source(self):
-        self.assertEquals(os.listdir("."), []) # Not conanfile copied, clean source
+        assert(os.listdir(".") == []) # Not conanfile copied, clean source
         self.output.info("Running source!")
 '''
         client = TestClient()

--- a/conans/test/command/source_test.py
+++ b/conans/test/command/source_test.py
@@ -60,6 +60,5 @@ class ConanLib(ConanFile):
         client.save({CONANFILE: conanfile.replace("err", "")})
         client.run("source .")
         self.assertIn("PROJECT: Configuring sources in", client.user_io.out)
-        self.assertIn("PROJECT: WARN: Your previous source command failed", client.user_io.out)
         self.assertIn("PROJECT: Running source!", client.user_io.out)
         self.assertEqual("Hello World", load(os.path.join(client.current_folder, "file1.txt")))

--- a/conans/test/integration/build_id_test.py
+++ b/conans/test/integration/build_id_test.py
@@ -1,13 +1,14 @@
-import unittest
-from conans.test.utils.tools import TestClient
 import os
-from conans.util.files import load
-from conans.model.ref import PackageReference, ConanFileReference
+import unittest
+
 from nose_parameterized.parameterized import parameterized
+
+from conans.model.ref import PackageReference, ConanFileReference
+from conans.test.utils.tools import TestClient
+from conans.util.files import load
 
 conanfile = """from conans import ConanFile
 from conans.util.files import save
-import os
 
 class MyTest(ConanFile):
     name = "Pkg"
@@ -20,7 +21,6 @@ class MyTest(ConanFile):
 
     def build(self):
         self.output.info("Building my code!")
-        self.output.info(os.getcwd())
         save("debug/file1.txt", "Debug file1")
         save("release/file1.txt", "Release file1")
 
@@ -85,7 +85,7 @@ class BuildIdTest(unittest.TestCase):
         self.assertIn("Packaging Debug!", client.user_io.out)
         self._check_conaninfo(client)
 
-    @parameterized.expand([(True,), (False,)])
+    @parameterized.expand([(True, ), (False,)])
     def basic_test(self, python_consumer):
         client = TestClient()
 
@@ -175,7 +175,7 @@ class BuildIdTest(unittest.TestCase):
         packages = client.client_cache.conan_packages(ref)
         self.assertEqual(2, len(packages))
 
-    @parameterized.expand([(True,), (False,)])
+    @parameterized.expand([(True, ), (False,)])
     def info_test(self, python_consumer):
         client = TestClient()
         client.save({"conanfile.py": conanfile})

--- a/conans/test/integration/build_id_test.py
+++ b/conans/test/integration/build_id_test.py
@@ -5,9 +5,9 @@ from conans.util.files import load
 from conans.model.ref import PackageReference, ConanFileReference
 from nose_parameterized.parameterized import parameterized
 
-
 conanfile = """from conans import ConanFile
 from conans.util.files import save
+import os
 
 class MyTest(ConanFile):
     name = "Pkg"
@@ -20,6 +20,7 @@ class MyTest(ConanFile):
 
     def build(self):
         self.output.info("Building my code!")
+        self.output.info(os.getcwd())
         save("debug/file1.txt", "Debug file1")
         save("release/file1.txt", "Release file1")
 
@@ -56,7 +57,6 @@ class MyTest(ConanFile):
 
 
 class BuildIdTest(unittest.TestCase):
-
     def _check_conaninfo(self, client):
         # Check that conaninfo is correct
         ref_debug = PackageReference.loads("Pkg/0.1@user/channel:"
@@ -85,7 +85,7 @@ class BuildIdTest(unittest.TestCase):
         self.assertIn("Packaging Debug!", client.user_io.out)
         self._check_conaninfo(client)
 
-    @parameterized.expand([(True, ), (False,)])
+    @parameterized.expand([(True,), (False,)])
     def basic_test(self, python_consumer):
         client = TestClient()
 
@@ -175,7 +175,7 @@ class BuildIdTest(unittest.TestCase):
         packages = client.client_cache.conan_packages(ref)
         self.assertEqual(2, len(packages))
 
-    @parameterized.expand([(True, ), (False,)])
+    @parameterized.expand([(True,), (False,)])
     def info_test(self, python_consumer):
         client = TestClient()
         client.save({"conanfile.py": conanfile})

--- a/conans/test/integration/export_sources_test.py
+++ b/conans/test/integration/export_sources_test.py
@@ -85,11 +85,11 @@ class ExportsSourcesTest(unittest.TestCase):
     def _check_source_folder(self, mode):
         """ Source folder MUST be always the same
         """
-        expected_sources = ['conanfile.py', 'conanmanifest.txt', "hello.h"]
+        expected_sources = ["hello.h"]
         if mode == "both":
             expected_sources.append("data.txt")
         if mode == "nested" or mode == "overlap":
-            expected_sources = ['conanfile.py', 'conanmanifest.txt', "src/hello.h", "src/data.txt"]
+            expected_sources = ["src/hello.h", "src/data.txt"]
         expected_sources = sorted(expected_sources)
         self.assertEqual(scan_folder(self.source_folder), expected_sources)
 

--- a/conans/test/integration/go_complete_test.py
+++ b/conans/test/integration/go_complete_test.py
@@ -92,6 +92,7 @@ class GoCompleteTest(unittest.TestCase):
                  'reverse_test.go': reverse_test,
                  'reverse.txt': reverse,
                  'hello/helloreverse.txt': reverse}
+        files_without_conanfile = set(files.keys()) - set(["conanfile.py"])
         self.client.save(files)
         self.client.run("export lasote/stable")
         self.client.run("install %s --build missing" % str(conan_reference))
@@ -99,7 +100,7 @@ class GoCompleteTest(unittest.TestCase):
         package_ids = self.client.paths.conan_packages(conan_reference)
         self.assertEquals(len(package_ids), 1)
         package_ref = PackageReference(conan_reference, package_ids[0])
-        self._assert_package_exists(package_ref, self.client.paths, list(files.keys()))
+        self._assert_package_exists(package_ref, self.client.paths, files_without_conanfile)
 
         # Upload conans
         self.client.run("upload %s" % str(conan_reference))
@@ -113,7 +114,7 @@ class GoCompleteTest(unittest.TestCase):
         self.client.run("upload %s -p %s" % (str(conan_reference), str(package_ids[0])))
 
         # Check library on server
-        self._assert_package_exists_in_server(package_ref, server_paths, list(files.keys()))
+        self._assert_package_exists_in_server(package_ref, server_paths, files_without_conanfile)
 
         # Now from other "computer" install the uploaded conans with same options (nothing)
         other_conan = TestClient(servers=self.servers, users={"default": [("lasote", "mypass")]})
@@ -122,7 +123,7 @@ class GoCompleteTest(unittest.TestCase):
         build_path = other_conan.paths.build(package_ref)
         self.assertFalse(os.path.exists(build_path))
         # Lib should exist
-        self._assert_package_exists(package_ref, other_conan.paths, list(files.keys()))
+        self._assert_package_exists(package_ref, other_conan.paths, files_without_conanfile)
 
         reuse_conan = TestClient(servers=self.servers, users={"default": [("lasote", "mypass")]})
         files = {'conanfile.py': reuse_conanfile,


### PR DESCRIPTION
Move the dirty files to the root dir, rename it and remove the dirty file in local command.
#1718 
Not really solves #1717 that could be an "invalid" issue.

**UPDATE**: Excluded conanfile.py and conanmanifest.txt from being copied to the source folder. So #1717 now works, both in local and in cache.