### PR TITLE
Allow pylint versions 1.6.5 up to 1.8.0

### DIFF
--- a/conans/requirements.txt
+++ b/conans/requirements.txt
@@ -7,7 +7,7 @@ fasteners>=0.14.1
 six>=1.10.0
 node-semver==0.1.1
 distro>=1.0.2, <1.1.0
-pylint==1.6.5
+pylint>=1.6.5, <=1.8.0
 future==0.16.0
 pygments>=2.0, <3.0
 


### PR DESCRIPTION
Related to #1710, allow pylint versions from 1.6.5 up to 1.8.0 in requirements.txt. Current pylint 1.7.2 works fine and passes all Conan tests.