### PR TITLE
Change default arguments for manifests related arguments in conan_api.

### DIFF
--- a/conans/client/conan_api.py
+++ b/conans/client/conan_api.py
@@ -168,8 +168,8 @@ class ConanAPIV1(object):
     @api_method
     def test_package(self, profile_name=None, settings=None, options=None, env=None,
                      scope=None, test_folder=None, not_export=False, build=None, keep_source=False,
-                     verify=default_manifest_folder, manifests=default_manifest_folder,
-                     manifests_interactive=default_manifest_folder,
+                     verify=None, manifests=None,
+                     manifests_interactive=None,
                      remote=None, update=False, cwd=None, user=None, channel=None, name=None,
                      version=None):
         settings = settings or []
@@ -260,8 +260,8 @@ class ConanAPIV1(object):
     @api_method
     def create(self, profile_name=None, settings=None,
                options=None, env=None, scope=None, test_folder=None, not_export=False, build=None,
-               keep_source=False, verify=default_manifest_folder,
-               manifests=default_manifest_folder, manifests_interactive=default_manifest_folder,
+               keep_source=False, verify=None,
+               manifests=None, manifests_interactive=None,
                remote=None, update=False, cwd=None,
                user=None, channel=None, name=None, version=None):
 
@@ -359,8 +359,8 @@ class ConanAPIV1(object):
 
     @api_method
     def install(self, reference="", package=None, settings=None, options=None, env=None, scope=None, all=False,
-                remote=None, werror=False, verify=default_manifest_folder, manifests=default_manifest_folder,
-                manifests_interactive=default_manifest_folder, build=None, profile_name=None,
+                remote=None, werror=False, verify=None, manifests=None,
+                manifests_interactive=None, build=None, profile_name=None,
                 update=False, generator=None, no_imports=False, filename=None, cwd=None):
 
         self._user_io.out.werror_active = werror
@@ -759,6 +759,8 @@ def _parse_manifests_arguments(verify, manifests, manifests_interactive, cwd):
     manifest_folder = verify or manifests or manifests_interactive
     if manifest_folder:
         if not os.path.isabs(manifest_folder):
+            if not cwd:
+                raise ConanException("'cwd' should be defined if the manifest folder is relative.")
             manifest_folder = os.path.join(cwd, manifest_folder)
         manifest_verify = verify is not None
         manifest_interactive = manifests_interactive is not None

--- a/conans/test/conan_api/manifests_arguments_test.py
+++ b/conans/test/conan_api/manifests_arguments_test.py
@@ -1,0 +1,71 @@
+from conans.client.conan_api import _parse_manifests_arguments, ConanException, default_manifest_folder, prepare_cwd
+import unittest
+from nose_parameterized.parameterized import parameterized
+
+
+class ArgumentsTest(unittest.TestCase):
+    @parameterized.expand([
+        (dict(verify=default_manifest_folder,
+              manifests=default_manifest_folder,
+              manifests_interactive=default_manifest_folder),),
+        (dict(verify=None,
+              manifests=default_manifest_folder,
+              manifests_interactive=default_manifest_folder),),
+        (dict(verify=default_manifest_folder,
+              manifests=None,
+              manifests_interactive=default_manifest_folder),),
+        (dict(verify=default_manifest_folder,
+              manifests=default_manifest_folder,
+              manifests_interactive=None),),
+        (dict(verify=default_manifest_folder,
+              manifests=None,
+              manifests_interactive=None),),
+    ])
+    def test_manifest_arguments_conflicting(self, arguments):
+        with self.assertRaises(ConanException):
+            _parse_manifests_arguments(cwd=None, **arguments)
+
+    def test_manifests_arguments_verify(self):
+        cwd = prepare_cwd(None)
+        manifests = _parse_manifests_arguments(verify=default_manifest_folder,
+                                               manifests=None,
+                                               manifests_interactive=None,
+                                               cwd=cwd)
+        manifest_folder, manifest_interactive, manifest_verify = manifests
+
+        self.assertIn(cwd, manifest_folder)
+        self.assertFalse(manifest_interactive)
+        self.assertTrue(manifest_verify)
+
+    def test_manifests_arguments_manifests_interactive(self):
+        cwd = prepare_cwd(None)
+        manifests = _parse_manifests_arguments(verify=None,
+                                               manifests=None,
+                                               manifests_interactive=default_manifest_folder,
+                                               cwd=cwd)
+        manifest_folder, manifest_interactive, manifest_verify = manifests
+
+        self.assertIn(cwd, manifest_folder)
+        self.assertTrue(manifest_interactive)
+        self.assertFalse(manifest_verify)
+
+    def test_manifests_arguments_manifests(self):
+        cwd = prepare_cwd(None)
+        manifests = _parse_manifests_arguments(verify=None,
+                                               manifests=default_manifest_folder,
+                                               manifests_interactive=None,
+                                               cwd=cwd)
+        manifest_folder, manifest_interactive, manifest_verify = manifests
+
+        self.assertIn(cwd, manifest_folder)
+        self.assertFalse(manifest_interactive)
+        self.assertFalse(manifest_verify)
+
+    def test_manifests_arguments_no_manifests(self):
+        cwd = prepare_cwd(None)
+        manifests = _parse_manifests_arguments(verify=None, manifests=None, manifests_interactive=None, cwd=cwd)
+        manifest_folder, manifest_interactive, manifest_verify = manifests
+
+        self.assertIsNone(manifest_folder)
+        self.assertFalse(manifest_interactive)
+        self.assertFalse(manifest_verify)


### PR DESCRIPTION
This PR fixes the issue #1689 
After this changes the variable `default_manifest_folder` does not get used inside conan_api.py. But I guess it still makes sense that it stays there. 