### PR TITLE
Add include directories for the MIDL compiler

### DIFF
--- a/conans/client/generators/visualstudio.py
+++ b/conans/client/generators/visualstudio.py
@@ -29,6 +29,9 @@ class VisualStudioGenerator(Generator):
       <AdditionalDependencies>{libs}%(AdditionalDependencies)</AdditionalDependencies>
       <AdditionalOptions>{linker_flags} %(AdditionalOptions)</AdditionalOptions>
     </Link>
+    <Midl>
+      <AdditionalIncludeDirectories>{include_dirs}%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+    </Midl>
   </ItemDefinitionGroup>
   <ItemGroup />
 </Project>'''


### PR DESCRIPTION
visual_studio generator: Add include directories for the MIDL compiler, so that it can find and use `*.idl` files from dependencies. This change assumes that the `*.idl` files will be exported into the same `include` directories as normal headers.

IDL files in Visual Studio are "Interface Definition Language" files, the COM equivalent of `*.h` files.