### PR TITLE
Fixed unzip with files without contents

### DIFF
--- a/conans/client/tools/files.py
+++ b/conans/client/tools/files.py
@@ -69,7 +69,8 @@ def unzip(filename, destination=".", keep_permissions=False):
 
     if hasattr(sys.stdout, "isatty") and sys.stdout.isatty():
         def print_progress(the_size, uncomp_size):
-            txt_msg = "Unzipping %.0f %%" % (the_size * 100.0 / uncomp_size)
+            the_size = (the_size * 100.0 / uncomp_size) if uncomp_size != 0 else 0
+            txt_msg = "Unzipping %.0f %%" % the_size
             _global_output.rewrite_line(txt_msg)
     else:
         def print_progress(_, __):


### PR DESCRIPTION
This happened when a zip contained a file with 0 bytes:

```
ERROR: Traceback (most recent call last):
  File "/Users/luism/workspace/conan/conans/errors.py", line 24, in conanfile_exception_formatter
    yield
  File "/Users/luism/workspace/conan/conans/client/source.py", line 94, in config_source_local
    conan_file.source()
...
  File "/Users/luism/workspace/conan/conans/client/tools/files.py", line 72, in print_progress
    txt_msg = "Unzipping %.0f %%" % (the_size * 100.0 / uncomp_size)
ZeroDivisionError: float division by zero
```
