### PR TITLE
Add include directories for the Resource compiler

### DIFF
--- a/conans/client/generators/visualstudio.py
+++ b/conans/client/generators/visualstudio.py
@@ -32,6 +32,9 @@ class VisualStudioGenerator(Generator):
     <Midl>
       <AdditionalIncludeDirectories>{include_dirs}%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </Midl>
+    <ResourceCompile>
+      <AdditionalIncludeDirectories>{include_dirs}%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+    </ResourceCompile>
   </ItemDefinitionGroup>
   <ItemGroup />
 </Project>'''


### PR DESCRIPTION
visual_studio generator: Add include directories for the resource compiler, so that it can find and use *.h files that define resource symbols and IDs. This will allow dependencies to use resources from the projects they depend on. (use the same directories as normal header includes)

This change should not break anyone because they will only need it if they are including header files, and if they are doing that, the header files should have unique names.

Related to conan-io #1421.