### PR TITLE
fix loader parse

### DIFF
--- a/conans/client/loader_parse.py
+++ b/conans/client/loader_parse.py
@@ -40,7 +40,7 @@ def _parse_module(conanfile_module, filename):
                 raise ConanException("More than 1 conanfile in the file")
         if (inspect.isclass(attr) and issubclass(attr, Generator) and attr != Generator and
                 attr.__dict__["__module__"] == filename):
-                registered_generators.add(attr.__name__, attr)
+            registered_generators.add(attr.__name__, attr)
 
     if result is None:
         raise ConanException("No subclass of ConanFile")
@@ -77,10 +77,14 @@ def _parse_file(conan_file_path):
         for added in added_modules:
             module = sys.modules[added]
             if module:
-                folder = os.path.dirname(module.__file__)
-                if folder.startswith(current_dir):
-                    module = sys.modules.pop(added)
-                    sys.modules["%s.%s" % (module_id, added)] = module
+                try:
+                    folder = os.path.dirname(module.__file__)
+                except AttributeError:  # some module doesn't have __file__
+                    pass
+                else:
+                    if folder.startswith(current_dir):
+                        module = sys.modules.pop(added)
+                        sys.modules["%s.%s" % (module_id, added)] = module
     except Exception:
         import traceback
         trace = traceback.format_exc().split('\n')


### PR DESCRIPTION
https://github.com/conan-io/conan/issues/1782

I debugged the origin issue, and it gets to the ``pyexpat`` builtin import.
It seems that this is closely related to https://bugs.python.org/issue29830, which is the only builtin with submodules. 

Maybe this fix is then too specific for just this very import. The issue might have an easy workaround, just importing locally (inside methods) the offending import.