### PR TITLE
Update error message for copy command files.py

### DIFF
--- a/conans/client/tools/files.py
+++ b/conans/client/tools/files.py
@@ -209,7 +209,7 @@ def collect_libs(conanfile, folder="lib"):
         return []
     lib_folder = os.path.join(conanfile.package_folder, folder)
     if not os.path.exists(lib_folder):
-        conanfile.output.warn("Lib folder doesn't exist, can't collect libraries")
+        conanfile.output.warn("Lib folder doesn't exist, can't collect libraries: {0}".format(lib_folder))
         return []
     files = os.listdir(lib_folder)
     result = []


### PR DESCRIPTION
A few of us felt this error was a bit misleading with the capital L, knowing that linux is case sensitive, some wondered if perhaps this meant it was looking for a `Lib` folder with a capital `L` .  Seeing that is can be passed in as a parameter, it doesn't feel like a good improvement to change the error to have a lower case `l` which would still be confusing if you passed in a non-default folder name.  So, this seemed more robust, although it might make the message too long.  Just a simple suggestion, feel free to reject. Also, did not test.