### PR TITLE
- add tools.which helper

### DIFF
--- a/conans/client/tools/files.py
+++ b/conans/client/tools/files.py
@@ -220,3 +220,12 @@ def collect_libs(conanfile, folder="lib"):
                 name = name[3:]
             result.append(name)
     return result
+
+
+def which(filename):
+    """ same affect as posix which command or shutil.which from python3 """
+    for path in os.environ["PATH"].split(os.pathsep):
+        fullname = os.path.join(path, filename)
+        if os.path.exists(fullname) and os.access(fullname, os.X_OK):
+            return os.path.join(path, filename)
+    return None

--- a/conans/test/util/which_test.py
+++ b/conans/test/util/which_test.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+import unittest
+import os
+import stat
+import platform
+from conans import tools
+from conans.test.utils.test_files import temp_folder
+
+
+class WhichTest(unittest.TestCase):
+    @staticmethod
+    def _touch(filename):
+        with open(filename, 'a'):
+            os.utime(filename, None)
+
+    @staticmethod
+    def _add_executable_bit(filename):
+        if os.name == 'posix':
+            mode = os.stat(filename).st_mode
+            mode |= stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH
+            os.chmod(filename, stat.S_IMODE(mode))
+
+    def test_which_positive(self):
+        tmp_dir = temp_folder()
+        fullname = os.path.join(tmp_dir, 'example.sh')
+        self._touch(fullname)
+        self._add_executable_bit(fullname)
+        with tools.environment_append({'PATH': tmp_dir}):
+            self.assertEqual(tools.which('example.sh'), fullname)
+
+    def test_which_negative(self):
+        tmp_dir = temp_folder()
+        with tools.environment_append({'PATH': tmp_dir}):
+            self.assertIsNone(tools.which('example.sh'))
+
+    def test_which_non_executable(self):
+        if platform.system() == "Windows":
+            """on Windows we always have executable permissions by default"""
+            return
+        tmp_dir = temp_folder()
+        fullname = os.path.join(tmp_dir, 'example.sh')
+        self._touch(fullname)
+        with tools.environment_append({'PATH': tmp_dir}):
+            self.assertIsNone(tools.which('example.sh'))


### PR DESCRIPTION
**tools.which** has the same effect as posix **which** command, or **shutil.which** from python3
as conan is for python2, it's necessary addition
certain build tools sometimes need full paths, e.g. CMake needs **CMAKE_AR** and **CMAKE_RANLIB** to be absolute paths