### PR TITLE
- display warning if VS150COMNTOOLS is set to invalid path

### DIFF
--- a/conans/client/tools/win.py
+++ b/conans/client/tools/win.py
@@ -102,6 +102,9 @@ def vcvars_command(settings):
                 else:
                     raise ConanException("VS2017 '%s' variable not defined, "
                                          "and vswhere didn't find it" % env_var)
+            if not os.path.isdir(vcvars_path):
+                _global_output.warn('VS variable %s points to the non-existing path "%s",'
+                    'please check that you have set it correctly' % (env_var, vcvars_path))
             vcvars_path = os.path.join(vs_path, "../../VC/Auxiliary/Build/vcvarsall.bat")
             command = ('set "VSCMD_START_DIR=%%CD%%" && '
                        'call "%s" %s' % (vcvars_path, param))
@@ -110,6 +113,9 @@ def vcvars_command(settings):
                 vs_path = os.environ[env_var]
             except KeyError:
                 raise ConanException("VS '%s' variable not defined. Please install VS" % env_var)
+            if not os.path.isdir(vcvars_path):
+                _global_output.warn('VS variable %s points to the non-existing path "%s",'
+                    'please check that you have set it correctly' % (env_var, vcvars_path))
             vcvars_path = os.path.join(vs_path, "../../VC/vcvarsall.bat")
             command = ('call "%s" %s' % (vcvars_path, param))
 

--- a/conans/client/tools/win.py
+++ b/conans/client/tools/win.py
@@ -102,9 +102,9 @@ def vcvars_command(settings):
                 else:
                     raise ConanException("VS2017 '%s' variable not defined, "
                                          "and vswhere didn't find it" % env_var)
-            if not os.path.isdir(vcvars_path):
+            if not os.path.isdir(vs_path):
                 _global_output.warn('VS variable %s points to the non-existing path "%s",'
-                    'please check that you have set it correctly' % (env_var, vcvars_path))
+                    'please check that you have set it correctly' % (env_var, vs_path))
             vcvars_path = os.path.join(vs_path, "../../VC/Auxiliary/Build/vcvarsall.bat")
             command = ('set "VSCMD_START_DIR=%%CD%%" && '
                        'call "%s" %s' % (vcvars_path, param))
@@ -113,9 +113,9 @@ def vcvars_command(settings):
                 vs_path = os.environ[env_var]
             except KeyError:
                 raise ConanException("VS '%s' variable not defined. Please install VS" % env_var)
-            if not os.path.isdir(vcvars_path):
+            if not os.path.isdir(vs_path):
                 _global_output.warn('VS variable %s points to the non-existing path "%s",'
-                    'please check that you have set it correctly' % (env_var, vcvars_path))
+                    'please check that you have set it correctly' % (env_var, vs_path))
             vcvars_path = os.path.join(vs_path, "../../VC/vcvarsall.bat")
             command = ('call "%s" %s' % (vcvars_path, param))
 


### PR DESCRIPTION
follow up on #1794 
I suppose it is worth to display a warning message if users have VS150COMNTOOLS environment variable set incorrectly, at least it will help to troubleshooting such kind of problems