### PR TITLE
- add PacManTool for pacman (Arch Linux)

### DIFF
--- a/conans/client/tools/oss.py
+++ b/conans/client/tools/oss.py
@@ -100,6 +100,10 @@ class OSInfo(object):
                                  ("centos", "redhat", "fedora", "pidora", "scientific",
                                   "xenserver", "amazon", "oracle", "rhel")
 
+    @property
+    def with_pacman(self):
+        return self.is_linux and self.linux_distro == "arch"
+
     @staticmethod
     def get_win_os_version():
         """

--- a/conans/client/tools/system_pm.py
+++ b/conans/client/tools/system_pm.py
@@ -23,6 +23,8 @@ class SystemPackageTool(object):
             return AptTool()
         elif os_info.with_yum:
             return YumTool()
+        elif os_info.with_pacman:
+            return PacManTool()
         elif os_info.is_macos:
             return BrewTool()
         elif os_info.is_freebsd:
@@ -149,6 +151,17 @@ class ChocolateyTool(object):
 
     def installed(self, package_name):
         exit_code = self._runner('choco search --local-only --exact %s | findstr /c:"1 packages installed."' % package_name, None)
+        return exit_code == 0
+
+class PacManTool(object):
+    def update(self):
+        _run(self._runner, "%spacman -Syyu --noconfirm" % self._sudo_str)
+
+    def install(self, package_name):
+        _run(self._runner, "%spacman -S --noconfirm %s" % (self._sudo_str, package_name))
+
+    def installed(self, package_name):
+        exit_code = self._runner("pacman -Qi %s" % package_name, None)
         return exit_code == 0
 
 


### PR DESCRIPTION
add PacManTool as SystemPackageTool implementation for Arch Linux
also could be used for MSYS2 (but I don't know how to detect MSYS2 environment ATM, and not sure if it is a sane default)