### PR TITLE
- allow to override compiler_version in vcvars_command

### DIFF
--- a/conans/client/tools/win.py
+++ b/conans/client/tools/win.py
@@ -75,9 +75,9 @@ def vs_installation_path(version):
     return vs_installation_path._cached[version]
 
 
-def vcvars_command(settings):
-    arch_setting = settings.get_safe("arch")
-    compiler_version = settings.get_safe("compiler.version")
+def vcvars_command(settings, arch=None, compiler_version=None):
+    arch_setting = arch or settings.get_safe("arch")
+    compiler_version = compiler_version or settings.get_safe("compiler.version")
     if not compiler_version:
         raise ConanException("compiler.version setting required for vcvars not defined")
 


### PR DESCRIPTION
in certain cases, users compile for non-MSVC but still need Visual Studio command prompt.
one of such examples, is using **Clang on Windows** - although compiler is Clang, it still needs Visual Studio standard library headers, Windows SDK headers, libraries and certain tools, such as resource compiler, manifest tool, sign tool, etc.

_I think the same story applies to the Intel compiler._

so given that fact, vcvars_command is not something just for MSVC compiler, but the entire infrastructure for Windows development.

therefore, to use vcvars_command, we still need to pass Visual Studio version, instead of compiler version of compiler we're currently building for (that can be different entities in case of Clang or ICC).

there is valid workaround for this - declaring custom settings object like:
```
class clang_settings:
    def get_sage(token):
        if token == "arch":
            return self.arch
        elif token == "compiler.version":
            return "15"
```
but it has several disadvantages:
* it looks too ugly and monstrous
* it has to be copy-pasted from one recipe to another constantly

that way, I suppose solution to override compiler version is much more elegant
arch is overridden just for consistency (however, I still see valid cases for it - two stage cross-compilation, e.g. first compile some tool for the host platform, and than use that tool to build for target device)