### PR TITLE
- CMAKE_SYSTEM_NAME must be Darwin for iOS, watchOS and tvOS

### DIFF
--- a/conans/client/cmake.py
+++ b/conans/client/cmake.py
@@ -171,7 +171,7 @@ class CMake(object):
             platform_os = {"Darwin": "Macos"}.get(platform.system(), platform.system())
             if (platform_os != the_os) or os_ver:  # We are cross building
                 if the_os:
-                    ret["CMAKE_SYSTEM_NAME"] = the_os
+                    ret["CMAKE_SYSTEM_NAME"] = "Darwin" if the_os in ["iOS", "tvOS", "watchOS"] else the_os
                     if os_ver:
                         ret["CMAKE_SYSTEM_VERSION"] = os_ver
                 else:


### PR DESCRIPTION
**CMAKE_SYSTEM_NAME** must be Darwin when compiling for iOS (and other systems like watchOS, tvOS)
otherwise, you'll get annoying warning:
```
System is unknown to cmake, create:
Platform/iOS to use this system, please send your config file to cmake@www.cmake.org so it can be added to cmake
```
but there is worse consequence - CMake will not have variables like **UNIX** and **APPLE** defined, so it can produce unexpected results or even fail