### PR TITLE
- add tools for Apple development

### DIFF
--- a/conans/client/tools/__init__.py
+++ b/conans/client/tools/__init__.py
@@ -13,3 +13,5 @@ from .system_pm import *
 from .win import *
 # noinspection PyUnresolvedReferences
 from .pkg_config import *
+# noinspection PyUnresolvedReferences
+from .apple import *

--- a/conans/client/tools/apple.py
+++ b/conans/client/tools/apple.py
@@ -4,10 +4,6 @@
 import subprocess
 
 
-def cmd_output(command):
-    return subprocess.check_output(command).decode().strip()
-
-
 def is_apple_os(_os):
     """returns True if OS is Apple one (Macos, iOS, watchOS or tvOS"""
     return str(_os) in ['Macos', 'iOS', 'watchOS', 'tvOS']
@@ -57,50 +53,67 @@ def apple_deployment_target_flag_name(_os):
             'tvOS': '-mappletvos-version-min'}.get(str(_os))
 
 
-class XCRun:
+class XCRun(object):
 
     def __init__(self, sdk=None):
         self.sdk = sdk
 
     def _invoke(self, args):
+        def cmd_output(cmd):
+            return subprocess.check_output(cmd).decode().strip()
+
         command = ['xcrun', '-find']
         if self.sdk:
             command.extend(['-sdk', self.sdk])
         command.extend(args)
         return cmd_output(command)
 
+    @property
     def find(self, tool):
         """find SDK tools (e.g. clang, ar, ranlib, lipo, codesign, etc.)"""
         return self._invoke(['--find', tool])
 
+    @property
     def sdk_path(self):
         """obtain sdk path (aka apple sysroot or -isysroot"""
         return self._invoke(['--show-sdk-path'])
 
+    @property
     def sdk_version(self):
         """obtain sdk version"""
         return self._invoke(['--show-sdk-version'])
 
+    @property
     def sdk_platform_path(self):
         """obtain sdk platform path"""
         return self._invoke(['--show-sdk-platform-path'])
 
+    @property
     def sdk_platform_version(self):
         """obtain sdk platform version"""
         return self._invoke(['--show-sdk-platform-version'])
 
     @property
     def cc(self):
+        """path to C compiler (CC)"""
         return self.find('clang')
 
     @property
     def cxx(self):
+        """path to C++ compiler (CXX)"""
         return self.find('clang++')
 
     @property
     def ar(self):
+        """path to archiver (AR)"""
         return self.find('ar')
 
     @property
     def ranlib(self):
+        """path to archive indexer (RANBLI)"""
         return self.find('ranlib')
+
+    @property
+    def strip(self):
+        """path to symbol removal utility (STRIP)"""
+        return self.find('strip')

--- a/conans/client/tools/apple.py
+++ b/conans/client/tools/apple.py
@@ -68,7 +68,6 @@ class XCRun(object):
         command.extend(args)
         return cmd_output(command)
 
-    @property
     def find(self, tool):
         """find SDK tools (e.g. clang, ar, ranlib, lipo, codesign, etc.)"""
         return self._invoke(['--find', tool])

--- a/conans/client/tools/apple.py
+++ b/conans/client/tools/apple.py
@@ -1,0 +1,106 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+import subprocess
+
+
+def cmd_output(command):
+    return subprocess.check_output(command).decode().strip()
+
+
+def is_apple_os(_os):
+    """returns True if OS is Apple one (Macos, iOS, watchOS or tvOS"""
+    return str(_os) in ['Macos', 'iOS', 'watchOS', 'tvOS']
+
+
+def to_apple_arch(arch):
+    """converts conan-style architecture into Apple-style arch"""
+    return {'x86': 'i386',
+            'x86_64': 'x86_64',
+            'armv7': 'armv7',
+            'armv8': 'arm64',
+            'armv7s': 'armv7s',
+            'armv7k': 'armv7k'}.get(str(arch))
+
+
+def apple_sdk_name(settings):
+    """returns proper SDK name suitable for OS and architecture
+    we're building for (considering simulators)"""
+    arch = settings.get_safe('arch')
+    _os = settings.get_safe('os')
+    if str(arch).startswith('x86'):
+        return {'Macos': 'macosx',
+                'iOS': 'iphonesimulator',
+                'watchOS': 'watchsimulator',
+                'tvOS': 'appletvsimulator'}.get(str(_os))
+    elif str(arch).startswith('arm'):
+        return {'iOS': 'iphoneos',
+                'watchOS': 'watchos',
+                'tvOS': 'appletvos'}.get(str(_os))
+    else:
+        return None
+
+
+def apple_deployment_target_env_name(_os):
+    """environment variable name which controls deployment target"""
+    return {'Macos': 'MACOSX_DEPLOYMENT_TARGET',
+            'iOS': 'IOS_DEPLOYMENT_TARGET',
+            'watchOS': 'WATCHOS_DEPLOYMENT_TARGET',
+            'tvOS': 'TVOS_DEPLOYMENT_TARGET'}.get(str(_os))
+
+
+def apple_deployment_target_flag_name(_os):
+    """compiler flag name which controls deployment target"""
+    return {'Macos': '-mmacosx-version-min',
+            'iOS': '-mios-version-min',
+            'watchOS': '-mwatchos-version-min',
+            'tvOS': '-mappletvos-version-min'}.get(str(_os))
+
+
+class XCRun:
+
+    def __init__(self, sdk=None):
+        self.sdk = sdk
+
+    def _invoke(self, args):
+        command = ['xcrun', '-find']
+        if self.sdk:
+            command.extend(['-sdk', self.sdk])
+        command.extend(args)
+        return cmd_output(command)
+
+    def find(self, tool):
+        """find SDK tools (e.g. clang, ar, ranlib, lipo, codesign, etc.)"""
+        return self._invoke(['--find', tool])
+
+    def sdk_path(self):
+        """obtain sdk path (aka apple sysroot or -isysroot"""
+        return self._invoke(['--show-sdk-path'])
+
+    def sdk_version(self):
+        """obtain sdk version"""
+        return self._invoke(['--show-sdk-version'])
+
+    def sdk_platform_path(self):
+        """obtain sdk platform path"""
+        return self._invoke(['--show-sdk-platform-path'])
+
+    def sdk_platform_version(self):
+        """obtain sdk platform version"""
+        return self._invoke(['--show-sdk-platform-version'])
+
+    @property
+    def cc(self):
+        return self.find('clang')
+
+    @property
+    def cxx(self):
+        return self.find('clang++')
+
+    @property
+    def ar(self):
+        return self.find('ar')
+
+    @property
+    def ranlib(self):
+        return self.find('ranlib')

--- a/conans/client/tools/apple.py
+++ b/conans/client/tools/apple.py
@@ -55,7 +55,7 @@ def apple_deployment_target_flag(os_, os_version):
             'watchOS': '-mwatchos-version-min',
             'tvOS': '-mappletvos-version-min'}.get(str(os_))
     if not flag:
-        return None
+        return ''
     return "%s=%s" % (flag, os_version)
 
 

--- a/conans/client/tools/apple.py
+++ b/conans/client/tools/apple.py
@@ -119,7 +119,7 @@ class XCRun(object):
 
     @property
     def ranlib(self):
-        """path to archive indexer (RANBLI)"""
+        """path to archive indexer (RANLIB)"""
         return self.find('ranlib')
 
     @property

--- a/conans/test/util/apple_test.py
+++ b/conans/test/util/apple_test.py
@@ -74,7 +74,7 @@ class AppleTest(unittest.TestCase):
         self.assertTrue(xcrun.ranlib.endswith('ranlib'))
         self.assertTrue(xcrun.strip.endswith('strip'))
 
-        self.assertTrue(os.path.isdir(xcrun.sdk_path()))
+        self.assertTrue(os.path.isdir(xcrun.sdk_path))
 
         xcrun = tools.XCRun()
         self.assertTrue(xcrun.find('lipo').endswith('lipo'))

--- a/conans/test/util/apple_test.py
+++ b/conans/test/util/apple_test.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+import unittest
+import platform
+import os
+from nose.plugins.attrib import attr
+from conans import tools
+
+
+class AppleTest(unittest.TestCase):
+    def test_is_apple_os(self):
+        self.assertTrue(tools.is_apple_os('iOS'))
+        self.assertTrue(tools.is_apple_os('tvOS'))
+        self.assertTrue(tools.is_apple_os('watchOS'))
+        self.assertTrue(tools.is_apple_os('Macos'))
+        self.assertFalse(tools.is_apple_os('Windows'))
+        self.assertFalse(tools.is_apple_os('Linux'))
+        self.assertFalse(tools.is_apple_os('Android'))
+
+    def test_to_apple_arch(self):
+        self.assertEqual(tools.to_apple_arch('x86'), 'i386')
+        self.assertEqual(tools.to_apple_arch('x86_64'), 'x86_64')
+        self.assertEqual(tools.to_apple_arch('armv7'), 'armv7')
+        self.assertEqual(tools.to_apple_arch('armv7s'), 'armv7s')
+        self.assertEqual(tools.to_apple_arch('armv7k'), 'armv7k')
+        self.assertEqual(tools.to_apple_arch('armv8'), 'arm64')
+        self.assertIsNone(tools.to_apple_arch('mips'))
+
+    def test_apple_sdk_name(self):
+        class FakeSettings(object):
+            def __init__(self, _os, _arch):
+                self._os = _os
+                self._arch = _arch
+
+            def get_safe(self, name):
+                if name == 'os':
+                    return self._os
+                elif name == 'arch':
+                    return self._arch
+
+        self.assertEqual(tools.apple_sdk_name(FakeSettings('Macos', 'x86')), 'macosx')
+        self.assertEqual(tools.apple_sdk_name(FakeSettings('Macos', 'x86_64')), 'macosx')
+        self.assertEqual(tools.apple_sdk_name(FakeSettings('iOS', 'x86_64')), 'iphonesimulator')
+        self.assertEqual(tools.apple_sdk_name(FakeSettings('iOS', 'armv7')), 'iphoneos')
+        self.assertEqual(tools.apple_sdk_name(FakeSettings('watchOS', 'x86_64')), 'watchsimulator')
+        self.assertEqual(tools.apple_sdk_name(FakeSettings('watchOS', 'armv7k')), 'watchos')
+        self.assertEqual(tools.apple_sdk_name(FakeSettings('tvOS', 'x86')), 'appletvsimulator')
+        self.assertEqual(tools.apple_sdk_name(FakeSettings('tvOS', 'armv8')), 'appletvos')
+        self.assertIsNone(tools.apple_sdk_name(FakeSettings('Windows', 'x86')))
+
+    def test_deployment_target_env_name(self):
+        self.assertEqual(tools.apple_deployment_target_env_name('Macos'), 'MACOSX_DEPLOYMENT_TARGET')
+        self.assertEqual(tools.apple_deployment_target_env_name('iOS'), 'IOS_DEPLOYMENT_TARGET')
+        self.assertEqual(tools.apple_deployment_target_env_name('watchOS'), 'WATCHOS_DEPLOYMENT_TARGET')
+        self.assertEqual(tools.apple_deployment_target_env_name('tvOS'), 'TVOS_DEPLOYMENT_TARGET')
+        self.assertIsNone(tools.apple_deployment_target_env_name('Linux'))
+
+    def test_deployment_target_flag_name(self):
+        self.assertEqual(tools.apple_deployment_target_flag_name('Macos'), '-mmacosx-version-min')
+        self.assertEqual(tools.apple_deployment_target_flag_name('iOS'), '-mios-version-min')
+        self.assertEqual(tools.apple_deployment_target_flag_name('watchOS'), '-mwatchos-version-min')
+        self.assertEqual(tools.apple_deployment_target_flag_name('tvOS'), '-mappletvos-version-min')
+        self.assertIsNone(tools.apple_deployment_target_flag_name('Solaris'))
+
+    @attr('darwin')
+    def test_xcrun(self):
+        if platform.system() != "Darwin":
+            return
+        xcrun = tools.XCRun('macosx')
+        self.assertTrue(xcrun.cc.endswith('clang'))
+        self.assertTrue(xcrun.cxx.endswith('clang++'))
+        self.assertTrue(xcrun.ar.endswith('ar'))
+        self.assertTrue(xcrun.ranlib.endswith('ranlib'))
+        self.assertTrue(xcrun.strip.endswith('strip'))
+
+        self.assertTrue(os.path.isdir(xcrun.sdk_path()))
+
+        xcrun = tools.XCRun()
+        self.assertTrue(xcrun.find('lipo').endswith('lipo'))

--- a/conans/test/util/apple_test.py
+++ b/conans/test/util/apple_test.py
@@ -70,7 +70,7 @@ class AppleTest(unittest.TestCase):
                          '-mwatchos-version-min=10.1')
         self.assertEqual(tools.apple_deployment_target_flag('tvOS', "10.1"),
                          '-mappletvos-version-min=10.1')
-        self.assertIsNone(tools.apple_deployment_target_flag('Solaris', "10.1"))
+        self.assertEqual('', tools.apple_deployment_target_flag('Solaris', "10.1"))
 
     @unittest.skipUnless(platform.system() == "Darwin", "Requires OSX")
     def test_xcrun(self):


### PR DESCRIPTION
add various tools I am using for apple development
I was using them for my private recipes and keep copy-pasting between packages
now I am compiling bincrafters packages for iOS, and need them as well
so I've decided it is beneficial to have tools in conan codebase

Closes #2322