### PR TITLE
- add visual_studio_multi generator

### DIFF
--- a/conans/client/generators/__init__.py
+++ b/conans/client/generators/__init__.py
@@ -11,6 +11,7 @@ from .qmake import QmakeGenerator
 from .qbs import QbsGenerator
 from .scons import SConsGenerator
 from .visualstudio import VisualStudioGenerator
+from .visualstudio_multi import VisualStudioMultiGenerator
 from .visualstudiolegacy import VisualStudioLegacyGenerator
 from .xcode import XCodeGenerator
 from .ycm import YouCompleteMeGenerator
@@ -50,6 +51,7 @@ registered_generators.add("qmake", QmakeGenerator)
 registered_generators.add("qbs", QbsGenerator)
 registered_generators.add("scons", SConsGenerator)
 registered_generators.add("visual_studio", VisualStudioGenerator)
+registered_generators.add("visual_studio_multi", VisualStudioMultiGenerator)
 registered_generators.add("visual_studio_legacy", VisualStudioLegacyGenerator)
 registered_generators.add("xcode", XCodeGenerator)
 registered_generators.add("ycm", YouCompleteMeGenerator)

--- a/conans/client/generators/visualstudio_multi.py
+++ b/conans/client/generators/visualstudio_multi.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+import os
+from conans.model import Generator
+from conans.client.generators import VisualStudioGenerator
+from xml.dom import minidom
+
+
+class VisualStudioMultiGenerator(Generator):
+    template = """<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<ImportGroup Label="PropertySheets" ></ImportGroup>
+<PropertyGroup Label="UserMacros" />
+<PropertyGroup />
+<ItemDefinitionGroup />
+<ItemGroup />
+</Project>
+"""
+
+    @property
+    def filename(self):
+        pass
+
+    @property
+    def content(self):
+        configuration = str(self.conanfile.settings.build_type)
+        platform = {'x86': 'Win32', 'x86_64': 'x64'}.get(str(self.conanfile.settings.arch))
+        vsversion = str(self.settings.compiler.version)
+
+        # there is also ClCompile.RuntimeLibrary, but it's handling is a bit complicated, so skipping for now
+        condition = " '$(Configuration)' == '%s' And '$(Platform)' == '%s' And '$(VisualStudioVersion)' == '%s' "\
+                    % (configuration, platform, vsversion + '.0')
+
+        name_multi = 'conanbuildinfo_multi.props'
+        name_current = ('conanbuildinfo_%s_%s_%s.props' % (configuration, platform, vsversion)).lower()
+
+        content_multi = self.template
+        if os.path.isfile(name_multi):
+            content_multi = open(name_multi, 'r').read()
+
+        dom = minidom.parseString(content_multi)
+        import_node = dom.createElement('Import')
+        import_node.setAttribute('Condition', condition)
+        import_node.setAttribute('Project', name_current)
+        import_group = dom.getElementsByTagName('ImportGroup')[0]
+        import_group.appendChild(import_node)
+        content_multi = dom.toprettyxml()
+
+        vs_generator = VisualStudioGenerator(self.conanfile)
+        content_current = vs_generator.content
+
+        return {name_multi: content_multi, name_current: content_current}

--- a/conans/client/loader_parse.py
+++ b/conans/client/loader_parse.py
@@ -40,7 +40,7 @@ def _parse_module(conanfile_module, filename):
                 raise ConanException("More than 1 conanfile in the file")
         if (inspect.isclass(attr) and issubclass(attr, Generator) and attr != Generator and
                 attr.__dict__["__module__"] == filename):
-                registered_generators.add(attr.__name__, attr)
+            registered_generators.add(attr.__name__, attr)
 
     if result is None:
         raise ConanException("No subclass of ConanFile")
@@ -77,10 +77,14 @@ def _parse_file(conan_file_path):
         for added in added_modules:
             module = sys.modules[added]
             if module:
-                folder = os.path.dirname(module.__file__)
-                if folder.startswith(current_dir):
-                    module = sys.modules.pop(added)
-                    sys.modules["%s.%s" % (module_id, added)] = module
+                try:
+                    folder = os.path.dirname(module.__file__)
+                except AttributeError:  # some module doesn't have __file__
+                    pass
+                else:
+                    if folder.startswith(current_dir):
+                        module = sys.modules.pop(added)
+                        sys.modules["%s.%s" % (module_id, added)] = module
     except Exception:
         import traceback
         trace = traceback.format_exc().split('\n')

--- a/conans/client/tools/files.py
+++ b/conans/client/tools/files.py
@@ -209,7 +209,7 @@ def collect_libs(conanfile, folder="lib"):
         return []
     lib_folder = os.path.join(conanfile.package_folder, folder)
     if not os.path.exists(lib_folder):
-        conanfile.output.warn("Lib folder doesn't exist, can't collect libraries")
+        conanfile.output.warn("Lib folder doesn't exist, can't collect libraries: {0}".format(lib_folder))
         return []
     files = os.listdir(lib_folder)
     result = []

--- a/conans/client/tools/net.py
+++ b/conans/client/tools/net.py
@@ -3,17 +3,25 @@ import sys
 import os
 from conans.client.output import ConanOutput
 from conans.client.rest.uploader_downloader import Downloader
-from conans.client.tools.files import unzip
+from conans.client.tools.files import unzip, check_md5, check_sha1, check_sha256
 from conans.errors import ConanException
 
 _global_requester = None
 
 
-def get(url):
-    """ high level downloader + unziper + delete temporary zip
+def get(url, md5='', sha1='', sha256=''):
+    """ high level downloader + unzipper + (optional hash checker) + delete temporary zip
     """
     filename = os.path.basename(url)
     download(url, filename)
+
+    if md5:
+        check_md5(filename, md5)
+    if sha1:
+        check_sha1(filename, sha1)
+    if sha256:
+        check_sha256(filename, sha256)
+
     unzip(filename)
     os.unlink(filename)
 

--- a/conans/test/generators/visual_studio_multi_test.py
+++ b/conans/test/generators/visual_studio_multi_test.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+import unittest
+import os
+from nose.plugins.attrib import attr
+from conans.model.settings import Settings
+from conans.model.conan_file import ConanFile
+from conans.model.build_info import CppInfo
+from conans.model.ref import ConanFileReference
+from conans.client.conf import default_settings_yml
+
+from conans.client.generators import VisualStudioMultiGenerator
+from conans.tools import chdir
+from conans.test.utils.test_files import temp_folder
+
+
+@attr('visual_studio')
+class VisualStudioMultiGeneratorTest(unittest.TestCase):
+    def valid_xml_test(self):
+
+        tempdir = temp_folder()
+        with chdir(tempdir):
+            settings = Settings.loads(default_settings_yml)
+            settings.os = "Windows"
+            settings.compiler = "Visual Studio"
+            settings.compiler.version = "12"
+            settings.compiler.runtime = "MD"
+            conanfile = ConanFile(None, None, Settings({}), None)
+
+            ref = ConanFileReference.loads("MyPkg/0.1@user/testing")
+            cpp_info = CppInfo("dummy_root_folder1")
+            conanfile.deps_cpp_info.update(cpp_info, ref.name)
+            ref = ConanFileReference.loads("My.Fancy-Pkg_2/0.1@user/testing")
+            cpp_info = CppInfo("dummy_root_folder2")
+            conanfile.deps_cpp_info.update(cpp_info, ref.name)
+
+            settings.arch = "x86"
+            settings.build_type = "Debug"
+            settings.compiler.version = "12"
+            conanfile.settings = settings
+
+            generator = VisualStudioMultiGenerator(conanfile)
+            content = generator.content
+
+            self.assertEqual(2, len(content))
+            self.assertIn('conanbuildinfo_multi.props', content.keys())
+            self.assertIn('conanbuildinfo_debug_win32_12.props', content.keys())
+
+            content_multi = content['conanbuildinfo_multi.props']
+            self.assertIn("<Import Condition=\" '$(Configuration)' == 'Debug' "
+                          "And '$(Platform)' == 'Win32' "
+                          "And '$(VisualStudioVersion)' == '12.0' \" "
+                          "Project=\"conanbuildinfo_debug_win32_12.props\"/>", content_multi)
+
+            with open('conanbuildinfo_multi.props', 'w') as f:
+                f.write(content_multi)
+
+            settings.arch = "x86_64"
+            settings.build_type = "Release"
+            settings.compiler.version = "14"
+            conanfile.settings = settings
+
+            generator = VisualStudioMultiGenerator(conanfile)
+            content = generator.content
+
+            self.assertEqual(2, len(content))
+            self.assertIn('conanbuildinfo_multi.props', content.keys())
+            self.assertIn('conanbuildinfo_release_x64_14.props', content.keys())
+
+            content_multi = content['conanbuildinfo_multi.props']
+            self.assertIn("<Import Condition=\" '$(Configuration)' == 'Debug' "
+                          "And '$(Platform)' == 'Win32' "
+                          "And '$(VisualStudioVersion)' == '12.0' \" "
+                          "Project=\"conanbuildinfo_debug_win32_12.props\"/>", content_multi)
+            self.assertIn("<Import Condition=\" '$(Configuration)' == 'Release' "
+                          "And '$(Platform)' == 'x64' "
+                          "And '$(VisualStudioVersion)' == '14.0' \" "
+                          "Project=\"conanbuildinfo_release_x64_14.props\"/>", content_multi)
+
+            os.unlink('conanbuildinfo_multi.props')


### PR DESCRIPTION
follow up on #1674 
adds **visual_studio_multi** generator - same as **visual_studio**, but supports multiple configurations (just like **cmake_multi**)
I have the following script which demonstrates generator usages:
```
call conan install . -g visual_studio_multi -s arch=x86 -s build_type=Debug   -s compiler="Visual Studio" -s compiler.version=14 -s compiler.runtime=MDd --build missing --update
call conan install . -g visual_studio_multi -s arch=x86_64 -s build_type=Debug   -s compiler="Visual Studio" -s compiler.version=14 -s compiler.runtime=MDd --build missing --update
call conan install . -g visual_studio_multi -s arch=x86 -s build_type=Release   -s compiler="Visual Studio" -s compiler.version=14 -s compiler.runtime=MD --build missing --update
call conan install . -g visual_studio_multi -s arch=x86_64 -s build_type=Release   -s compiler="Visual Studio" -s compiler.version=14 -s compiler.runtime=MD --build missing --update
```