### PR TITLE
Added "provided" signature to exception message

### DIFF
--- a/conans/client/tools/files.py
+++ b/conans/client/tools/files.py
@@ -118,11 +118,12 @@ def untargz(filename, destination="."):
 def check_with_algorithm_sum(algorithm_name, file_path, signature):
     real_signature = _generic_algorithm_sum(file_path, algorithm_name)
     if real_signature != signature:
-        raise ConanException("%s signature failed for '%s' file."
+        raise ConanException("%s signature failed for '%s' file. \n"
+                             " Provided signature: %s  \n"
                              " Computed signature: %s" % (algorithm_name,
                                                           os.path.basename(file_path),
+                                                          signature,
                                                           real_signature))
-
 
 def check_sha1(file_path, signature):
     check_with_algorithm_sum("sha1", file_path, signature)

--- a/conans/test/util/file_hashes_test.py
+++ b/conans/test/util/file_hashes_test.py
@@ -19,11 +19,11 @@ class HashesTest(unittest.TestCase):
         check_sha1(filepath, "eb599ec83d383f0f25691c184f656d40384f9435")
         check_sha256(filepath, "7365d029861e32c521f8089b00a6fb32daf0615025b69b599d1ce53501b845c2")
 
-        with self.assertRaisesRegexp(ConanException, "md5 signature failed for 'file.txt' file. Computed signature:"):
+        with self.assertRaisesRegexp(ConanException, "md5 signature failed for 'file.txt' file."):
             check_md5(filepath, "invalid")
 
-        with self.assertRaisesRegexp(ConanException, "sha1 signature failed for 'file.txt' file. Computed signature:"):
+        with self.assertRaisesRegexp(ConanException, "sha1 signature failed for 'file.txt' file."):
             check_sha1(filepath, "invalid")
 
-        with self.assertRaisesRegexp(ConanException, "sha256 signature failed for 'file.txt' file. Computed signature:"):
+        with self.assertRaisesRegexp(ConanException, "sha256 signature failed for 'file.txt' file."):
             check_sha256(filepath, "invalid")


### PR DESCRIPTION
This shows the exception like so: 
```
ERROR: msys2_installer/20161025@bincrafters/testing: Error in source() method, line 28
        tools.check_sha256(archive_name, checksum)
        ConanException: sha256 signature failed for 'msys2-base-x86_64-20161025.tar.xz' file.
 Provided signature: 2c198787ea1c4be39ff80466c4d831f8c7f06bd56d6d190bf63ede35292e344c
 Computed signature: bb1f1a0b35b3d96bf9c15092da8ce969a84a134f7b08811292fbc9d84d48c65d
```