### PR TITLE
fixed sources not being removed with recipe update

### DIFF
--- a/conans/client/proxy.py
+++ b/conans/client/proxy.py
@@ -130,6 +130,7 @@ class ConanProxy(object):
             rmdir(export_path)
             # It might need to remove shortpath
             rm_conandir(self._client_cache.source(conan_reference))
+            rm_conandir(self._client_cache.export_sources(conan_reference))
             current_remote, _ = self._get_remote(conan_reference)
             output.info("Retrieving from remote '%s'..." % current_remote.name)
             self._remote_manager.get_recipe(conan_reference, export_path, current_remote)

--- a/conans/client/proxy.py
+++ b/conans/client/proxy.py
@@ -125,20 +125,6 @@ class ConanProxy(object):
     def get_recipe(self, conan_reference):
         output = ScopedOutput(str(conan_reference), self._out)
 
-        def _refresh():
-            export_path = self._client_cache.export(conan_reference)
-            rmdir(export_path)
-            # It might need to remove shortpath
-            rm_conandir(self._client_cache.source(conan_reference))
-            rm_conandir(self._client_cache.export_sources(conan_reference))
-            current_remote, _ = self._get_remote(conan_reference)
-            output.info("Retrieving from remote '%s'..." % current_remote.name)
-            self._remote_manager.get_recipe(conan_reference, export_path, current_remote)
-            if self._update:
-                output.info("Updated!")
-            else:
-                output.info("Installed!")
-
         # check if it is in disk
         conanfile_path = self._client_cache.conanfile(conan_reference)
 
@@ -160,10 +146,11 @@ class ConanProxy(object):
                                             % remote.name)
                             output.warn("Refused to install!")
                         else:
-                            if remote != ref_remote:
-                                # Delete packages, could be non coherent with new remote
-                                DiskRemover(self._client_cache).remove_packages(conan_reference)
-                            _refresh()
+                            export_path = self._client_cache.export(conan_reference)
+                            DiskRemover(self._client_cache).remove(conan_reference)
+                            output.info("Retrieving from remote '%s'..." % remote.name)
+                            self._remote_manager.get_recipe(conan_reference, export_path, remote)
+                            output.info("Updated!")
                     elif ret == -1:
                         if not self._update:
                             output.info("Current conanfile is newer "

--- a/conans/test/integration/install_update_test.py
+++ b/conans/test/integration/install_update_test.py
@@ -116,8 +116,8 @@ class ConanLib(ConanFile):
         time.sleep(1)
         upload("mycontent2")
 
-        # What if we dont do this remove of the package: old pkg is used
-        client.run("remove Pkg/0.1@lasote/channel -p -f")
+        # This is no longer necessary, as binary packages are removed when recipe is updated
+        # client.run("remove Pkg/0.1@lasote/channel -p -f")
         client.run("install Pkg/0.1@lasote/channel -u --build=missing")
         conan_ref = ConanFileReference.loads("Pkg/0.1@lasote/channel")
         pkg_ref = PackageReference(conan_ref, "5ab84d6acfe1f23c4fae0ab88f26e3a396351ac9")


### PR DESCRIPTION
https://github.com/conan-io/conan/issues/1841

I am concerned about the following scenario (check L120 of the test)

- Recipe is updated from remote
- Source code is updated from remote
- Package binary is not updated, the old one is currently used, if it is not updated from the remote, or forced to build.

Maybe this is to be changed, and always remove all binaries when the recipe has been updated from the remote.