### PR TITLE
- implement patter matching for options

### DIFF
--- a/conans/model/options.py
+++ b/conans/model/options.py
@@ -415,6 +415,10 @@ class PackageOptions(object):
             self._data[name].value = value
 
     def propagate_upstream(self, package_values, down_ref, own_ref, output, ignore_unknown=False):
+        """ ignore_unknown: do not raise Exception if the given option doesn't exist in this package.
+                            Useful for pattern defined options like "-o *:shared=True", for packages
+                            not defining the "shared" options, they will not fail
+        """
         if not package_values:
             return
 

--- a/conans/test/model/options_test.py
+++ b/conans/test/model/options_test.py
@@ -125,6 +125,52 @@ Boost:thread=True
 Boost:thread.multi=off
 Poco:deps_bundled=True""")
 
+    def pattern_positive_test(self):
+        boost_values = PackageOptionValues()
+        boost_values.add_option("static", False)
+        boost_values.add_option("path", "FuzzBuzz")
+
+        options = {"Boost.*": boost_values}
+        down_ref = ConanFileReference.loads("Boost.Assert/0.1@diego/testing")
+        own_ref = ConanFileReference.loads("Boost.Assert/0.1@diego/testing")
+        output = TestBufferConanOutput()
+        self.sut.propagate_upstream(options, down_ref, own_ref, output)
+        self.assertEqual(self.sut.values.as_list(), [("optimized", "3"),
+                                                     ("path", "FuzzBuzz"),
+                                                     ("static", "False"),
+                                                     ("Boost.*:path", "FuzzBuzz"),
+                                                     ("Boost.*:static", "False"),
+                                                     ])
+
+    def pattern_ignore_test(self):
+        boost_values = PackageOptionValues()
+        boost_values.add_option("fake_option", "FuzzBuzz")
+
+        options = {"Boost.*": boost_values}
+        down_ref = ConanFileReference.loads("Boost.Assert/0.1@diego/testing")
+        own_ref = ConanFileReference.loads("Boost.Assert/0.1@diego/testing")
+        output = TestBufferConanOutput()
+        self.sut.propagate_upstream(options, down_ref, own_ref, output)
+        self.assertEqual(self.sut.values.as_list(), [("optimized", "3"),
+                                                     ("path", "NOTDEF"),
+                                                     ("static", "True"),
+                                                     ("Boost.*:fake_option", "FuzzBuzz"),
+                                                     ])
+
+    def pattern_unmatch_test(self):
+        boost_values = PackageOptionValues()
+        boost_values.add_option("fake_option", "FuzzBuzz")
+
+        options = {"OpenSSL.*": boost_values}
+        down_ref = ConanFileReference.loads("Boost.Assert/0.1@diego/testing")
+        own_ref = ConanFileReference.loads("Boost.Assert/0.1@diego/testing")
+        output = TestBufferConanOutput()
+        self.sut.propagate_upstream(options, down_ref, own_ref, output)
+        self.assertEqual(self.sut.values.as_list(), [("optimized", "3"),
+                                                     ("path", "NOTDEF"),
+                                                     ("static", "True"),
+                                                     ("OpenSSL.*:fake_option", "FuzzBuzz"),
+                                                     ])
 
 class OptionsValuesTest(unittest.TestCase):
 

--- a/conans/test/model/options_test.py
+++ b/conans/test/model/options_test.py
@@ -131,8 +131,8 @@ Poco:deps_bundled=True""")
         boost_values.add_option("path", "FuzzBuzz")
 
         options = {"Boost.*": boost_values}
-        down_ref = ConanFileReference.loads("Boost.Assert/0.1@diego/testing")
         own_ref = ConanFileReference.loads("Boost.Assert/0.1@diego/testing")
+        down_ref = ConanFileReference.loads("Consumer/0.1@diego/testing")
         output = TestBufferConanOutput()
         self.sut.propagate_upstream(options, down_ref, own_ref, output)
         self.assertEqual(self.sut.values.as_list(), [("optimized", "3"),
@@ -142,12 +142,65 @@ Poco:deps_bundled=True""")
                                                      ("Boost.*:static", "False"),
                                                      ])
 
+    def multi_pattern_test(self):
+        boost_values = PackageOptionValues()
+        boost_values.add_option("static", False)
+        boost_values.add_option("path", "FuzzBuzz")
+        boost_values2 = PackageOptionValues()
+        boost_values2.add_option("optimized", 2)
+
+        options = {"Boost.*": boost_values,
+                   "*": boost_values2}
+        own_ref = ConanFileReference.loads("Boost.Assert/0.1@diego/testing")
+        down_ref = ConanFileReference.loads("Consumer/0.1@diego/testing")
+        output = TestBufferConanOutput()
+        self.sut.propagate_upstream(options, down_ref, own_ref, output)
+        self.assertEqual(self.sut.values.as_list(), [("optimized", "2"),
+                                                     ("path", "FuzzBuzz"),
+                                                     ("static", "False"),
+                                                     ('*:optimized', '2'),
+                                                     ("Boost.*:path", "FuzzBuzz"),
+                                                     ("Boost.*:static", "False"),
+                                                     ])
+
+    def multi_pattern_error_test(self):
+        boost_values = PackageOptionValues()
+        boost_values.add_option("optimized", 4)
+        boost_values2 = PackageOptionValues()
+        boost_values2.add_option("optimized", 2)
+
+        options = {"Boost.*": boost_values,
+                   "*": boost_values2}
+        own_ref = ConanFileReference.loads("Boost.Assert/0.1@diego/testing")
+        down_ref = ConanFileReference.loads("Consumer/0.1@diego/testing")
+        output = TestBufferConanOutput()
+        output.werror_active = True
+        with self.assertRaises(ConanException):
+            self.sut.propagate_upstream(options, down_ref, own_ref, output)
+
+    def all_positive_test(self):
+        boost_values = PackageOptionValues()
+        boost_values.add_option("static", False)
+        boost_values.add_option("path", "FuzzBuzz")
+
+        options = {"*": boost_values}
+        own_ref = ConanFileReference.loads("Boost.Assert/0.1@diego/testing")
+        down_ref = ConanFileReference.loads("Consumer/0.1@diego/testing")
+        output = TestBufferConanOutput()
+        self.sut.propagate_upstream(options, down_ref, own_ref, output)
+        self.assertEqual(self.sut.values.as_list(), [("optimized", "3"),
+                                                     ("path", "FuzzBuzz"),
+                                                     ("static", "False"),
+                                                     ("*:path", "FuzzBuzz"),
+                                                     ("*:static", "False"),
+                                                     ])
+
     def pattern_ignore_test(self):
         boost_values = PackageOptionValues()
         boost_values.add_option("fake_option", "FuzzBuzz")
 
         options = {"Boost.*": boost_values}
-        down_ref = ConanFileReference.loads("Boost.Assert/0.1@diego/testing")
+        down_ref = ConanFileReference.loads("Consumer/0.1@diego/testing")
         own_ref = ConanFileReference.loads("Boost.Assert/0.1@diego/testing")
         output = TestBufferConanOutput()
         self.sut.propagate_upstream(options, down_ref, own_ref, output)
@@ -171,6 +224,7 @@ Poco:deps_bundled=True""")
                                                      ("static", "True"),
                                                      ("OpenSSL.*:fake_option", "FuzzBuzz"),
                                                      ])
+
 
 class OptionsValuesTest(unittest.TestCase):
 

--- a/conans/test/model/transitive_reqs_test.py
+++ b/conans/test/model/transitive_reqs_test.py
@@ -698,6 +698,56 @@ class ChatConan(ConanFile):
                          "%s:48bb3c5cbdb4822ae87914437ca3cceb733c7e1d"
                          % (str(hello_ref), str(say_ref)))
 
+    def test_transitive_pattern_options(self):
+        say_content = """
+from conans import ConanFile
+
+class SayConan(ConanFile):
+    name = "Say"
+    version = "0.1"
+    options = {"myoption": [123, 234]}
+"""
+        hello_content = """
+from conans import ConanFile
+
+class HelloConan(ConanFile):
+    name = "Hello"
+    version = "1.2"
+    requires = "Say/0.1@user/testing"
+    options = {"myoption": [123, 234]}
+"""
+        chat_content = """
+from conans import ConanFile
+
+class ChatConan(ConanFile):
+    name = "Chat"
+    version = "2.3"
+    requires = "Hello/1.2@user/testing"
+    default_options = "*:myoption=234"
+"""
+        self.retriever.conan(say_ref, say_content)
+        self.retriever.conan(hello_ref, hello_content)
+        deps_graph = self.root(chat_content)
+
+        self.assertEqual(3, len(deps_graph.nodes))
+        hello = _get_nodes(deps_graph, "Hello")[0]
+        say = _get_nodes(deps_graph, "Say")[0]
+        chat = _get_nodes(deps_graph, "Chat")[0]
+        self.assertEqual(_get_edges(deps_graph), {Edge(hello, say), Edge(chat, hello)})
+
+        self.assertEqual(hello.conan_ref, hello_ref)
+        self.assertEqual(say.conan_ref, say_ref)
+
+        self._check_say(say.conanfile, options="myoption=234")
+
+        conanfile = hello.conanfile
+        self.assertEqual(conanfile.options.values.dumps(), "myoption=234\nSay:myoption=234")
+        self.assertEqual(conanfile.info.full_options.dumps(), "myoption=234\nSay:myoption=234")
+
+        conanfile = chat.conanfile
+        self.assertEqual(conanfile.options.values.dumps(), "Hello:myoption=234\nSay:myoption=234")
+        self.assertEqual(conanfile.info.full_options.dumps(), "Hello:myoption=234\nSay:myoption=234")
+
     def test_transitive_two_levels_wrong_options(self):
         say_content = """
 from conans import ConanFile


### PR DESCRIPTION
follow up #1715 
support specifying options like `-o Boost.*:shared=True`
that shall apply `shared=True` to all boost packages
there is major difference in implementation - if option doesn't exist in one of packages, it is just ignored (regular syntax like `-o Boost.Assert:shared=False` causes command to fail)
it was requested by users, since among various Boost packages, some of them are header-only and have no shared option, while others have it