### PR TITLE
Fixing downloader

### DIFF
--- a/conans/client/rest/uploader_downloader.py
+++ b/conans/client/rest/uploader_downloader.py
@@ -115,12 +115,16 @@ class Downloader(object):
 
     def download(self, url, file_path=None, auth=None, retry=1, retry_wait=0, overwrite=False):
 
+        if file_path and not os.path.isabs(file_path):
+            file_path = os.path.abspath(file_path)
+
         if file_path and os.path.exists(file_path):
             if overwrite:
                 if self.output:
                     self.output.warn("file '%s' already exists, overwriting" % file_path)
             else:
-                # Should not happen, better to raise, probably we had to remove the dest folder before
+                # Should not happen, better to raise, probably we had to remove
+                # the dest folder before
                 raise ConanException("Error, the file to download already exists: '%s'" % file_path)
 
         t1 = time.time()


### PR DESCRIPTION
The mkdir of the destination dir was failing if the file_path is just a file name, with no dir.