### PR TITLE
Replace slashes in win

### DIFF
--- a/conans/client/configure_build_environment.py
+++ b/conans/client/configure_build_environment.py
@@ -2,7 +2,6 @@ import copy
 import platform
 import os
 
-from conans.client.tools.files import unix_path
 from conans.tools import environment_append, args_to_string, cpu_count, cross_building, detected_architecture
 
 sun_cc_libcxx_flags_dict = {"libCstd": "-library=Cstd",

--- a/conans/client/configure_build_environment.py
+++ b/conans/client/configure_build_environment.py
@@ -2,6 +2,7 @@ import copy
 import platform
 import os
 
+from conans.client.tools.files import unix_path
 from conans.tools import environment_append, args_to_string, cpu_count, cross_building, detected_architecture
 
 sun_cc_libcxx_flags_dict = {"libCstd": "-library=Cstd",
@@ -207,7 +208,7 @@ class AutoToolsBuildEnvironment(object):
         if self._build_type == "Debug":
             ret.append("-g")  # default debug information
         elif self._build_type == "Release" and self._compiler == "gcc":
-            ret.append("-s")  # Remove all symbol table and relocation information from the executable.
+            ret.append("-s") # Remove all symbol table and relocation information from the executable.
         if self._sysroot_flag:
             ret.append(self._sysroot_flag)
         return ret
@@ -244,8 +245,8 @@ class AutoToolsBuildEnvironment(object):
                         ret.append(arg)
             return ret
 
-        lib_paths = ['-L%s' % x for x in self.library_paths]
-        include_paths = ['-I%s' % x for x in self.include_paths]
+        lib_paths = ['-L%s' % unix_path(x) for x in self.library_paths]
+        include_paths = ['-I%s' % unix_path(x) for x in self.include_paths]
 
         ld_flags = append(self.link_flags, lib_paths)
         cpp_flags = append(include_paths, ["-D%s" % x for x in self.defines])

--- a/conans/client/configure_build_environment.py
+++ b/conans/client/configure_build_environment.py
@@ -245,8 +245,8 @@ class AutoToolsBuildEnvironment(object):
                         ret.append(arg)
             return ret
 
-        lib_paths = ['-L%s' % unix_path(x) for x in self.library_paths]
-        include_paths = ['-I%s' % unix_path(x) for x in self.include_paths]
+        lib_paths = ['-L%s' % x.replace("\\", "/") for x in self.library_paths]
+        include_paths = ['-I%s' % x.replace("\\", "/") for x in self.include_paths]
 
         ld_flags = append(self.link_flags, lib_paths)
         cpp_flags = append(include_paths, ["-D%s" % x for x in self.defines])

--- a/conans/client/tools/files.py
+++ b/conans/client/tools/files.py
@@ -223,7 +223,7 @@ def replace_prefix_in_pc_file(pc_file, new_prefix):
 
 def unix_path(path):
     """"Used to translate windows paths to MSYS unix paths like
-    c/users/path/to/file"""
+    c/users/path/to/file. Not working in a regular console or MinGW!"""
     pattern = re.compile(r'([a-z]):\\', re.IGNORECASE)
     return pattern.sub('/\\1/', path).replace('\\', '/').lower()
 

--- a/conans/test/functional/autotools_configure_test.py
+++ b/conans/test/functional/autotools_configure_test.py
@@ -9,7 +9,7 @@ class AutoToolsConfigureTest(unittest.TestCase):
 
     def _set_deps_info(self, conanfile):
         conanfile.deps_cpp_info.include_paths.append("path/includes")
-        conanfile.deps_cpp_info.include_paths.append("other/include/path")
+        conanfile.deps_cpp_info.include_paths.append("other\include\path")
         # To test some path in win, to be used with MinGW make or MSYS etc
         conanfile.deps_cpp_info.lib_paths.append("one\lib\path")
         conanfile.deps_cpp_info.libs.append("onelib")

--- a/conans/test/functional/autotools_configure_test.py
+++ b/conans/test/functional/autotools_configure_test.py
@@ -10,7 +10,8 @@ class AutoToolsConfigureTest(unittest.TestCase):
     def _set_deps_info(self, conanfile):
         conanfile.deps_cpp_info.include_paths.append("path/includes")
         conanfile.deps_cpp_info.include_paths.append("other/include/path")
-        conanfile.deps_cpp_info.lib_paths.append("one/lib/path")
+        # To test some path in win, to be used with MinGW make or MSYS etc
+        conanfile.deps_cpp_info.lib_paths.append("one\lib\path")
         conanfile.deps_cpp_info.libs.append("onelib")
         conanfile.deps_cpp_info.libs.append("twolib")
         conanfile.deps_cpp_info.defines.append("onedefinition")


### PR DESCRIPTION
Env vars from `AutoToolsBuildEnvironment` will contain only slashes.
Should solve #1281 