### PR TITLE
Ask for password when run user command (#1929)

### DIFF
--- a/conans/client/command.py
+++ b/conans/client/command.py
@@ -584,7 +584,7 @@ class Command(object):
 
         try:
             if "@" in args.path and ConanFileReference.loads(args.path):
-                raise ArgumentError(None, "Parameter 'path' cannot be a reference," 
+                raise ArgumentError(None, "Parameter 'path' cannot be a reference,"
                                           " but a folder containing a conanfile.py or conanfile.txt"
                                           " file.")
         except ConanException:
@@ -751,14 +751,12 @@ class Command(object):
         parser.add_argument("--remote", "-r", help='look in the specified remote server')
         parser.add_argument('-c', '--clean', default=False,
                             action='store_true', help='Remove user and tokens for all remotes')
-        group = parser.add_mutually_exclusive_group()
-        group.add_argument("-p", "--password", help='User password. Use double quotes '
-                                                     'if password with spacing, and escape quotes if existing')
-        group.add_argument("-i", "--interactive", action='store_true', default=False,
-                           help='Request for user password without expose it security data')
+        parser.add_argument("-p", "--password", nargs='?', const="", type=str,
+                            help='User password. Use double quotes if password with spacing, and escape quotes if '
+                                 'existing. Request for user password without expose it security data when empty')
         args = parser.parse_args(*parameters)  # To enable -h
         return self._conan.user(name=args.name, clean=args.clean, remote=args.remote,
-                                password=args.password, interactive=args.interactive)
+                                password=args.password)
 
     def search(self, *args):
         """ Searches package recipes and binaries in the local cache or in a remote.

--- a/conans/client/command.py
+++ b/conans/client/command.py
@@ -748,14 +748,17 @@ class Command(object):
         parser.add_argument("name", nargs='?', default=None,
                             help='Username you want to use. '
                                  'If no name is provided it will show the current user.')
-        parser.add_argument("-p", "--password", help='User password. Use double quotes '
-                            'if password with spacing, and escape quotes if existing')
         parser.add_argument("--remote", "-r", help='look in the specified remote server')
         parser.add_argument('-c', '--clean', default=False,
                             action='store_true', help='Remove user and tokens for all remotes')
+        group = parser.add_mutually_exclusive_group()
+        group.add_argument("-p", "--password", help='User password. Use double quotes '
+                                                     'if password with spacing, and escape quotes if existing')
+        group.add_argument("-i", "--interactive", action='store_true', default=False,
+                           help='Request for user password without expose it security data')
         args = parser.parse_args(*parameters)  # To enable -h
         return self._conan.user(name=args.name, clean=args.clean, remote=args.remote,
-                                password=args.password)
+                                password=args.password, interactive=args.interactive)
 
     def search(self, *args):
         """ Searches package recipes and binaries in the local cache or in a remote.

--- a/conans/client/conan_api.py
+++ b/conans/client/conan_api.py
@@ -658,13 +658,13 @@ class ConanAPIV1(object):
         self._manager.copy(reference, package, new_ref.user, new_ref.channel, force)
 
     @api_method
-    def user(self, name=None, clean=False, remote=None, password=None):
+    def user(self, name=None, clean=False, remote=None, password=None, interactive=False):
         if clean:
             localdb = LocalDB(self._client_cache.localdb)
             localdb.init(clean=True)
             self._user_io.out.success("Deleted user data")
             return
-        self._manager.user(remote, name, password)
+        self._manager.user(remote, name, password, interactive)
 
     @api_method
     def search_recipes(self, pattern, remote=None, case_sensitive=False):

--- a/conans/client/conan_api.py
+++ b/conans/client/conan_api.py
@@ -658,13 +658,13 @@ class ConanAPIV1(object):
         self._manager.copy(reference, package, new_ref.user, new_ref.channel, force)
 
     @api_method
-    def user(self, name=None, clean=False, remote=None, password=None, interactive=False):
+    def user(self, name=None, clean=False, remote=None, password=None):
         if clean:
             localdb = LocalDB(self._client_cache.localdb)
             localdb.init(clean=True)
             self._user_io.out.success("Deleted user data")
             return
-        self._manager.user(remote, name, password, interactive)
+        self._manager.user(remote, name, password)
 
     @api_method
     def search_recipes(self, pattern, remote=None, case_sensitive=False):

--- a/conans/client/manager.py
+++ b/conans/client/manager.py
@@ -617,9 +617,9 @@ class ConanManager(object):
         remover.remove(pattern, src, build_ids, package_ids_filter, force=force,
                        packages_query=packages_query, outdated=outdated)
 
-    def user(self, remote=None, name=None, password=None, interactive=False):
+    def user(self, remote=None, name=None, password=None):
         remote_proxy = ConanProxy(self._client_cache, self._user_io, self._remote_manager, remote)
-        if interactive:
+        if password == "":
             if not remote:
                 remote = remote_proxy.registry.default_remote.name
             name, password = self._user_io.request_login(remote_name=remote, username=name)

--- a/conans/client/manager.py
+++ b/conans/client/manager.py
@@ -617,8 +617,12 @@ class ConanManager(object):
         remover.remove(pattern, src, build_ids, package_ids_filter, force=force,
                        packages_query=packages_query, outdated=outdated)
 
-    def user(self, remote=None, name=None, password=None):
+    def user(self, remote=None, name=None, password=None, interactive=False):
         remote_proxy = ConanProxy(self._client_cache, self._user_io, self._remote_manager, remote)
+        if interactive:
+            if not remote:
+                remote = remote_proxy.registry.default_remote.name
+            name, password = self._user_io.request_login(remote_name=remote, username=name)
         return remote_proxy.authenticate(name, password)
 
     def get_path(self, reference, package_id=None, path=None, remote=None):

--- a/conans/test/command/user_test.py
+++ b/conans/test/command/user_test.py
@@ -98,7 +98,7 @@ class ConanLib(ConanFile):
         test_server = TestServer()
         servers = {"default": test_server}
         conan = TestClient(servers=servers, users={"default": [("lasote", "mypass")]})
-        conan.run('user -i -r default lasote')
+        conan.run('user -p -r default lasote')
         self.assertIn('Please enter a password for "lasote" account:', conan.user_io.out)
         conan.run("user")
         self.assertIn("Current 'default' user: lasote", conan.user_io.out)
@@ -107,14 +107,7 @@ class ConanLib(ConanFile):
         test_server = TestServer()
         servers = {"default": test_server}
         conan = TestClient(servers=servers, users={"default": [("lasote", "mypass")]})
-        conan.run('user -i')
+        conan.run('user -p')
         self.assertIn('Please enter a password for "lasote" account:', conan.user_io.out)
         conan.run("user")
         self.assertIn("Current 'default' user: lasote", conan.user_io.out)
-
-    def test_password_and_interactive_together(self):
-        test_server = TestServer()
-        servers = {"default": test_server}
-        conan = TestClient(servers=servers, users={"default": [("lasote", "mypass")]})
-        conan.run('user lasote -p mypass -i', ignore_error=True)
-        self.assertIn("ERROR: Exiting with code: 2", conan.user_io.out)

--- a/conans/test/command/user_test.py
+++ b/conans/test/command/user_test.py
@@ -93,3 +93,28 @@ class ConanLib(ConanFile):
         client.run("upload lib/0.1@lasote/stable")
         client.run("user")
         self.assertIn("Current 'default' user: lasote", client.user_io.out)
+
+    def test_command_user_with_interactive_password(self):
+        test_server = TestServer()
+        servers = {"default": test_server}
+        conan = TestClient(servers=servers, users={"default": [("lasote", "mypass")]})
+        conan.run('user -i -r default lasote')
+        self.assertIn('Please enter a password for "lasote" account:', conan.user_io.out)
+        conan.run("user")
+        self.assertIn("Current 'default' user: lasote", conan.user_io.out)
+
+    def test_command_interactive_only(self):
+        test_server = TestServer()
+        servers = {"default": test_server}
+        conan = TestClient(servers=servers, users={"default": [("lasote", "mypass")]})
+        conan.run('user -i')
+        self.assertIn('Please enter a password for "lasote" account:', conan.user_io.out)
+        conan.run("user")
+        self.assertIn("Current 'default' user: lasote", conan.user_io.out)
+
+    def test_password_and_interactive_together(self):
+        test_server = TestServer()
+        servers = {"default": test_server}
+        conan = TestClient(servers=servers, users={"default": [("lasote", "mypass")]})
+        conan.run('user lasote -p mypass -i', ignore_error=True)
+        self.assertIn("ERROR: Exiting with code: 2", conan.user_io.out)


### PR DESCRIPTION
Hi!

This PR is about the issue #1929.

I accepted the suggestion of @memsharded, using `-i/--interactive` to request the password when run the command `conan user`.

Some more details about the feature:

If I only pass `-i` to the command, it will ask for username and password. The remote will be the default.
```
$ conan user -i
Remote 'bintray' username: uilianries
Please enter a password for "uilianries" account:
Change 'bintray' user from None (anonymous) to uilianries
```

When I pass `username` or `remote`, the argument passed by me will be used as preferred.
```
$ conan user -i -r local baz
Please enter a password for "baz" account:
Change 'local' user from None (anonymous) to baz
```

When both `password` and `interactive` are present, an error will be raised. It doesn't make sense, ask for the interactive mode, if you are passing the password by argument.
```
$ conan user -i -r local -p qux baz
usage: conan user [-h] [--remote REMOTE] [-c] [-p PASSWORD | -i] [name]
conan user: error: argument -p/--password: not allowed with argument -i/--interactive
ERROR: Exiting with code: 2
```

Regards!