### PR TITLE
xcode generator: Fix handling of compiler flags.

### DIFF
--- a/conans/client/generators/xcode.py
+++ b/conans/client/generators/xcode.py
@@ -9,9 +9,9 @@ HEADER_SEARCH_PATHS = $(inherited) {include_dirs}
 LIBRARY_SEARCH_PATHS = $(inherited) {lib_dirs}
 OTHER_LDFLAGS = $(inherited) {linker_flags} {libs}
 
-GCC_PREPROCESSOR_DEFINITIONS = $(inherited) {compiler_flags}
-OTHER_CFLAGS = $(inherited)
-OTHER_CPLUSPLUSFLAGS = $(inherited)
+GCC_PREPROCESSOR_DEFINITIONS = $(inherited) {definitions}
+OTHER_CFLAGS = $(inherited) {c_compiler_flags}
+OTHER_CPLUSPLUSFLAGS = $(inherited) {cpp_compiler_flags}
 '''
 
     def __init__(self, conanfile):
@@ -23,7 +23,8 @@ OTHER_CPLUSPLUSFLAGS = $(inherited)
                                  for p in deps_cpp_info.lib_paths)
         self.libs = " ".join(['-l%s' % lib for lib in deps_cpp_info.libs])
         self.definitions = " ".join('"%s"' % d for d in deps_cpp_info.defines)
-        self.compiler_flags = " ".join(deps_cpp_info.cppflags + deps_cpp_info.cflags)
+        self.c_compiler_flags = " ".join(deps_cpp_info.cflags)
+        self.cpp_compiler_flags = " ".join(deps_cpp_info.cppflags)
         self.linker_flags = " ".join(deps_cpp_info.sharedlinkflags)
 
     @property

--- a/conans/test/generators/xcode_gcc_vs_test.py
+++ b/conans/test/generators/xcode_gcc_vs_test.py
@@ -21,6 +21,8 @@ class Pkg(ConanFile):
         os.makedirs(os.path.join(self.package_folder, "include"))
     def package_info(self):
         self.cpp_info.libs = ["hello"]
+        self.cpp_info.cppflags = ["-some_cpp_compiler_flag"]
+        self.cpp_info.cflags = ["-some_c_compiler_flag"]
 """})
         client.run("export Hello/0.1@lasote/stable")
         conanfile_txt = '''[requires]
@@ -86,8 +88,11 @@ xcode
         # CHECK XCODE GENERATOR
         xcode = load(os.path.join(client.current_folder, BUILD_INFO_XCODE))
 
+        expected_c_flags = '-some_c_compiler_flag'
+        expected_cpp_flags = '-some_cpp_compiler_flag'
+
         self.assertIn('LIBRARY_SEARCH_PATHS = $(inherited) "%s"' % expected_lib_dirs, xcode)
         self.assertIn('HEADER_SEARCH_PATHS = $(inherited) "%s"' % expected_include_dirs, xcode)
         self.assertIn("GCC_PREPROCESSOR_DEFINITIONS = $(inherited)", xcode)
-        self.assertIn("OTHER_CFLAGS = $(inherited)", xcode)
-        self.assertIn("OTHER_CPLUSPLUSFLAGS = $(inherited)", xcode)
+        self.assertIn('OTHER_CFLAGS = $(inherited) %s' % expected_c_flags, xcode)
+        self.assertIn('OTHER_CPLUSPLUSFLAGS = $(inherited) %s' % expected_cpp_flags, xcode)


### PR DESCRIPTION
* Populate GCC_PREPROCESSOR_DEFINITIONS from deps_cpp_info.defines.
* Populate OTHER_CFLAGS from deps_cpp_info.cflags.
* Populate OTHER_CPLUSPLUSFLAGS from deps_cpp_info.cppflags.