### PR TITLE
adding support for checking existing option with in

### DIFF
--- a/conans/model/options.py
+++ b/conans/model/options.py
@@ -345,6 +345,9 @@ class PackageOptions(object):
                       for k, v in definition.items()}
         self._modified = {}
 
+    def __contains__(self, option):
+        return str(option) in self._data
+
     @staticmethod
     def loads(text):
         return PackageOptions(yaml.load(text) or {})
@@ -463,6 +466,9 @@ class Options(object):
 
     def clear(self):
         self._package_options.clear()
+
+    def __contains__(self, option):
+        return option in self._package_options
 
     def __getitem__(self, item):
         return self._deps_package_values.setdefault(item, PackageOptionValues())

--- a/conans/test/model/options_test.py
+++ b/conans/test/model/options_test.py
@@ -19,6 +19,14 @@ class OptionsTest(unittest.TestCase):
         package_options.values = values
         self.sut = Options(package_options)
 
+    def test_in(self):
+        package_options = PackageOptions.loads("{static: [True, False]}")
+        sut = Options(package_options)
+        self.assertTrue("static" in sut)
+        self.assertFalse("shared" in sut)
+        self.assertTrue("shared" not in sut)
+        self.assertFalse("static" not in sut)
+
     def undefined_value_test(self):
         """ Not assigning a value to options will raise an error at validate() step
         """


### PR DESCRIPTION
Comes from: https://github.com/conan-io/conan/issues/1975

doing ``some_option in self.options`` to check if some option is existing in the current options, hangs and finally crashes python interpreter (recursive calls)