### PR TITLE
support WindowsStore OS

### DIFF
--- a/conans/client/build/cmake.py
+++ b/conans/client/build/cmake.py
@@ -273,7 +273,7 @@ class CMake(object):
         except AttributeError:
             pass
 
-        if self._os == "Windows" and self._compiler == "Visual Studio":
+        if str(self._os) in ["Windows", "WindowsStore"] and self._compiler == "Visual Studio":
             if self.parallel:
                 cpus = tools.cpu_count()
                 ret["CONAN_CXX_FLAGS"] = "/MP%s" % cpus

--- a/conans/client/conf/__init__.py
+++ b/conans/client/conf/__init__.py
@@ -14,6 +14,8 @@ MIN_SERVER_COMPATIBLE_VERSION = '0.12.0'
 default_settings_yml = """
 os:
     Windows:
+    WindowsStore:
+        version: ["8.1", "10.0"]
     Linux:
     Macos:
     Android:

--- a/conans/client/tools/win.py
+++ b/conans/client/tools/win.py
@@ -121,6 +121,7 @@ def vcvars_command(settings, arch=None, compiler_version=None, force=False):
         raise ConanException("compiler.version setting required for vcvars not defined")
 
     # https://msdn.microsoft.com/en-us/library/f2ccy3wt.aspx
+    arch_setting = arch_setting or 'x86_64'
     if detected_architecture() == 'x86_64':
         vcvars_arch = {'x86': 'x86',
                        'x86_64': 'amd64',

--- a/conans/client/tools/win.py
+++ b/conans/client/tools/win.py
@@ -40,11 +40,12 @@ def build_sln_command(settings, sln_path, targets=None, upgrade_project=True, bu
         raise ConanException("Cannot build_sln_command, arch not defined")
     command += "msbuild %s /p:Configuration=%s" % (sln_path, build_type)
     arch = str(arch)
-    if arch in ["x86_64", "x86"]:
-        command += ' /p:Platform='
-        command += '"x64"' if arch == "x86_64" else '"x86"'
-    elif "ARM" in arch.upper():
-        command += ' /p:Platform="ARM"'
+    msvc_arch = {'x86': 'x86',
+                 'x86_64': 'x64',
+                 'armv7': 'ARM',
+                 'armv8': 'ARM64'}.get(arch)
+    if msvc_arch:
+        command += ' /p:Platform="%s"' % msvc_arch
 
     if parallel:
         command += ' /m:%s' % cpu_count()

--- a/conans/client/tools/win.py
+++ b/conans/client/tools/win.py
@@ -179,7 +179,10 @@ def vcvars_command(settings, arch=None, compiler_version=None, force=False):
         if os_version_setting == '8.1':
             command += ' store 8.1'
         elif os_version_setting == '10.0':
-            command += ' store ' + find_windows_10_sdk()
+            windows_10_sdk = find_windows_10_sdk()
+            if not windows_10_sdk:
+                raise ConanException("cross-compiling for WindowsStore 10 (UWP), but Windows 10 SDK wasn't found")
+            command += ' store ' + windows_10_sdk
         else:
             raise ConanException('unsupported Windows Store version %s' % os_version_setting)
     return command

--- a/conans/test/functional/cmake_test.py
+++ b/conans/test/functional/cmake_test.py
@@ -79,9 +79,11 @@ class CMakeTest(unittest.TestCase):
 
         def check(text, build_config, generator=None):
             os = str(settings.os)
+            os_ver = str(settings.os.version) if settings.get_safe('os.version') else None
             for cmake_system_name in (True, False):
-                cross = ("-DCMAKE_SYSTEM_NAME=\"%s\" -DCMAKE_SYSROOT=\"/path/to/sysroot\" "
-                         % {"Macos": "Darwin"}.get(os, os)
+                cross_ver = ("-DCMAKE_SYSTEM_VERSION=\"%s\" " % os_ver) if os_ver else ""
+                cross = ("-DCMAKE_SYSTEM_NAME=\"%s\" %s-DCMAKE_SYSROOT=\"/path/to/sysroot\" "
+                         % ({"Macos": "Darwin"}.get(os, os), cross_ver)
                          if (platform.system() != os and cmake_system_name) else "")
                 cmake = CMake(conan_file, generator=generator, cmake_system_name=cmake_system_name)
                 new_text = text.replace("-DCONAN_EXPORTED", "%s-DCONAN_EXPORTED" % cross)
@@ -179,6 +181,21 @@ class CMakeTest(unittest.TestCase):
               '-DCONAN_COMPILER_VERSION="5.10" -DCONAN_CXX_FLAGS="-m64" '
               '-DCONAN_SHARED_LINKER_FLAGS="-m64" -DCONAN_C_FLAGS="-m64" -Wno-dev',
               "")
+
+        settings.compiler = "Visual Studio"
+        settings.compiler.version = "12"
+        settings.os = "WindowsStore"
+        settings.os.version = "8.1"
+        settings.build_type = "Debug"
+        check('-G "Visual Studio 12 2013" -DCONAN_EXPORTED="1" '
+              '-DCONAN_COMPILER="Visual Studio" -DCONAN_COMPILER_VERSION="12" -Wno-dev',
+              "--config Debug")
+
+        settings.os.version = "10.0"
+        check('-G "Visual Studio 12 2013" -DCONAN_EXPORTED="1" '
+              '-DCONAN_COMPILER="Visual Studio" -DCONAN_COMPILER_VERSION="12" -Wno-dev',
+              "--config Debug")
+
 
     def deleted_os_test(self):
         partial_settings = """

--- a/conans/test/functional/compile_helpers_test.py
+++ b/conans/test/functional/compile_helpers_test.py
@@ -53,7 +53,7 @@ class MockSettings(Settings):
 
     @property
     def os(self):
-        return self._os
+        return MockSetting(self._os)
 
     @property
     def arch(self):

--- a/conans/test/model/other_settings_test.py
+++ b/conans/test/model/other_settings_test.py
@@ -148,7 +148,8 @@ class SayConan(ConanFile):
         self.client.save({CONANFILE: content})
         self.client.run("install -s os=ChromeOS --build missing", ignore_error=True)
         self.assertIn(bad_value_msg("settings.os", "ChromeOS",
-                                    ['Android', 'Arduino', 'FreeBSD', 'Linux', 'Macos', 'SunOS', 'Windows', 'iOS', 'tvOS', 'watchOS']),
+                                    ['Android', 'Arduino', 'FreeBSD', 'Linux', 'Macos', 'SunOS', 'Windows',
+                                     'WindowsStore', 'iOS', 'tvOS', 'watchOS']),
                       str(self.client.user_io.out))
 
         # Now add new settings to config and try again

--- a/conans/test/model/transitive_reqs_test.py
+++ b/conans/test/model/transitive_reqs_test.py
@@ -1869,7 +1869,8 @@ class SayConan(ConanFile):
             self.root(content, options="arch_independent=True", settings="os=Linux")
         self.assertIn(bad_value_msg("settings.os", "Linux",
                                     ['Android', 'Arduino', 'FreeBSD', 'Macos',
-                                     'SunOS', "Windows", "iOS", "tvOS", "watchOS"]),
+                                     'SunOS', 'Windows', 'WindowsStore',
+                                     'iOS', 'tvOS', 'watchOS']),
                       str(cm.exception))
 
     def test_config_remove2(self):

--- a/conans/test/util/build_sln_command_test.py
+++ b/conans/test/util/build_sln_command_test.py
@@ -49,9 +49,9 @@ class BuildSLNCommandTest(unittest.TestCase):
 
     def target_test(self):
         command = build_sln_command(Settings({}), sln_path='dummy.sln', targets=['teapot'], upgrade_project=False,
-                                    build_type='Debug', arch='x86', parallel=False)
+                                    build_type='Debug', arch='armv8', parallel=False)
         self.assertIn('msbuild dummy.sln', command)
-        self.assertIn('/p:Platform="x86"', command)
+        self.assertIn('/p:Platform="ARM64"', command)
         self.assertNotIn('devenv dummy.sln /upgrade', command)
         self.assertNotIn('/m:%s' % cpu_count(), command)
         self.assertIn('/target:teapot', command)

--- a/conans/test/util/vcvars_arch_test.py
+++ b/conans/test/util/vcvars_arch_test.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+import platform
+import unittest
+from nose.plugins.attrib import attr
+from conans.model.settings import Settings
+from conans.client.conf import default_settings_yml
+from conans.errors import ConanException
+from conans import tools
+
+
+@attr('visual_studio')
+class VCVarsArchTest(unittest.TestCase):
+    def test_arch(self):
+        if platform.system() != "Windows":
+            return
+        settings = Settings.loads(default_settings_yml)
+        settings.compiler = 'Visual Studio'
+        settings.compiler.version = '14'
+
+        settings.arch = 'x86'
+        command = tools.vcvars_command(settings)
+        self.assertIn('vcvarsall.bat', command)
+        self.assertIn('x86', command)
+
+        settings.arch = 'x86_64'
+        command = tools.vcvars_command(settings)
+        self.assertIn('vcvarsall.bat', command)
+        self.assertIn('amd64', command)
+
+        settings.arch = 'armv7'
+        command = tools.vcvars_command(settings)
+        self.assertIn('vcvarsall.bat', command)
+        self.assertNotIn('arm64', command)
+        self.assertIn('arm', command)
+
+        settings.arch = 'armv8'
+        command = tools.vcvars_command(settings)
+        self.assertIn('vcvarsall.bat', command)
+        self.assertIn('arm64', command)
+
+        settings.arch = 'mips'
+        with self.assertRaises(ConanException):
+            tools.vcvars_command(settings)
+
+    def test_arch_override(self):
+        if platform.system() != "Windows":
+            return
+        settings = Settings.loads(default_settings_yml)
+        settings.compiler = 'Visual Studio'
+        settings.compiler.version = '14'
+        settings.arch = 'mips64'
+
+        command = tools.vcvars_command(settings, arch='x86')
+        self.assertIn('vcvarsall.bat', command)
+        self.assertIn('x86', command)
+
+        command = tools.vcvars_command(settings, arch='x86_64')
+        self.assertIn('vcvarsall.bat', command)
+        self.assertIn('amd64', command)
+
+        command = tools.vcvars_command(settings, arch='armv7')
+        self.assertIn('vcvarsall.bat', command)
+        self.assertNotIn('arm64', command)
+        self.assertIn('arm', command)
+
+        command = tools.vcvars_command(settings, arch='armv8')
+        self.assertIn('vcvarsall.bat', command)
+        self.assertIn('arm64', command)
+
+        with self.assertRaises(ConanException):
+            tools.vcvars_command(settings, arch='mips')

--- a/conans/test/util/vcvars_store_test.py
+++ b/conans/test/util/vcvars_store_test.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+import platform
+import unittest
+from nose.plugins.attrib import attr
+from conans.model.settings import Settings
+from conans.client.conf import default_settings_yml
+from conans.errors import ConanException
+from conans import tools
+
+
+@attr('visual_studio')
+class VCVarsStoreTest(unittest.TestCase):
+    def test_81(self):
+        if platform.system() != "Windows":
+            return
+
+        settings = Settings.loads(default_settings_yml)
+        settings.compiler = 'Visual Studio'
+        settings.compiler.version = '14'
+        settings.arch = 'x86'
+        settings.os = 'WindowsStore'
+        settings.os.version = '8.1'
+
+        command = tools.vcvars_command(settings)
+        self.assertIn('vcvarsall.bat', command)
+        self.assertIn('x86', command)
+        self.assertIn('store', command)
+        self.assertIn('8.1', command)
+
+    def test_10(self):
+        if platform.system() != "Windows":
+            return
+        sdk_version = tools.find_windows_10_sdk()
+        if not sdk_version:
+            return
+
+        settings = Settings.loads(default_settings_yml)
+        settings.compiler = 'Visual Studio'
+        settings.compiler.version = '14'
+        settings.arch = 'x86'
+        settings.os = 'WindowsStore'
+        settings.os.version = '10.0'
+
+        command = tools.vcvars_command(settings)
+        self.assertIn('vcvarsall.bat', command)
+        self.assertIn('x86', command)
+        self.assertIn('store', command)
+        self.assertIn(sdk_version, command)
+
+    def test_invalid(self):
+        if platform.system() != "Windows":
+            return
+
+        fake_settings_yml = """
+        os:
+            WindowsStore:
+                version: ["666"]
+        arch: [x86]
+        compiler:
+            Visual Studio:
+                runtime: [MD, MT, MTd, MDd]
+                version: ["8", "9", "10", "11", "12", "14", "15"]
+
+        build_type: [None, Debug, Release]
+        """
+
+        settings = Settings.loads(fake_settings_yml)
+        settings.compiler = 'Visual Studio'
+        settings.compiler.version = '14'
+        settings.arch = 'x86'
+        settings.os = 'WindowsStore'
+        settings.os.version = '666'
+
+        with self.assertRaises(ConanException):
+            tools.vcvars_command(settings)


### PR DESCRIPTION
follow up on #1155 and #1584 
also addresses #1262 
adds basic support for WindowsStore OS:

- WindowsStore 8.1 = WinRT
- WindowsStore 10.0 = UWP

this doesn't add support for Windows Phone, Windows Mobile or Windows CE - it will come as separate PRs later.