### PR TITLE
added messages to concurrent locks

### DIFF
--- a/conans/client/client_cache.py
+++ b/conans/client/client_cache.py
@@ -46,12 +46,14 @@ class ClientCache(SimplePaths):
     def conanfile_read_lock(self, conan_ref):
         if self._no_locks():
             return NoLock()
-        return ReadLock(os.path.join(self.conan(conan_ref), "rw"))
+        return ReadLock(os.path.join(self.conan(conan_ref), "rw"), conan_ref,
+                        self._output)
 
     def conanfile_write_lock(self, conan_ref):
         if self._no_locks():
             return NoLock()
-        return WriteLock(os.path.join(self.conan(conan_ref), "rw"))
+        return WriteLock(os.path.join(self.conan(conan_ref), "rw"), conan_ref,
+                         self._output)
 
     def package_lock(self, package_ref):
         if self._no_locks():

--- a/conans/util/locks.py
+++ b/conans/util/locks.py
@@ -31,9 +31,20 @@ WRITE_BUSY_DELAY = 0.25
 
 class Lock(object):
 
-    def __init__(self, folder):
+    def __init__(self, folder, locked_item, output):
         self._count_file = folder + ".count"
         self._count_lock_file = folder + ".count.lock"
+        self._locked_item = locked_item
+        self._output = output
+        self._first_lock = True
+
+    def _info_locked(self):
+        if self._first_lock:
+            self._first_lock = False
+            self._output.info("%s is locked by another concurrent conan process, wait..."
+                              % str(self._locked_item))
+            self._output.info("If not the case, quit, and do 'conan remove %s -f'"
+                              % str(self._locked_item))
 
     def _readers(self):
         try:
@@ -51,6 +62,7 @@ class ReadLock(Lock):
                 if readers >= 0:
                     save(self._count_file, str(readers + 1))
                     break
+            self._info_locked()
             time.sleep(READ_BUSY_DELAY)
 
     def __exit__(self, exc_type, exc_val, exc_tb):   # @UnusedVariable
@@ -68,6 +80,7 @@ class WriteLock(Lock):
                 if readers == 0:
                     save(self._count_file, "-1")
                     break
+            self._info_locked()
             time.sleep(WRITE_BUSY_DELAY)
 
     def __exit__(self, exc_type, exc_val, exc_tb):  # @UnusedVariable


### PR DESCRIPTION
Should help with: https://github.com/conan-io/conan/issues/2010

It is almost impossible to add such messages to the SimpleLock over specific binaries, as it doesn't have an active wait. Collisions and hangs on SimpleLock should be less frequent anyway, these messages might be enough.