### PR TITLE
fixing appending while download overwrite

### DIFF
--- a/conans/client/rest/uploader_downloader.py
+++ b/conans/client/rest/uploader_downloader.py
@@ -174,7 +174,7 @@ class Downloader(object):
 
                 if file_path:
                     mkdir(os.path.dirname(file_path))
-                    with open(file_path, 'ab') as handle:
+                    with open(file_path, 'wb') as handle:
                         dl_size = download_chunks(file_handler=handle)
                 else:
                     dl_size = download_chunks(ret_buffer=ret)

--- a/conans/test/util/tools_test.py
+++ b/conans/test/util/tools_test.py
@@ -16,12 +16,12 @@ from conans.model.settings import Settings
 from conans.paths import CONANFILE
 from conans.test.utils.runner import TestRunner
 from conans.test.utils.test_files import temp_folder
-from conans.test.utils.tools import TestClient, TestBufferConanOutput, TestRequester
+from conans.test.utils.tools import TestClient, TestBufferConanOutput
 from conans.test.utils.visual_project_files import get_vs_project_files
 from conans.test.utils.context_manager import which
 from conans.tools import OSInfo, SystemPackageTool, replace_in_file, AptTool, ChocolateyTool,\
     set_global_instances
-from conans.util.files import save
+from conans.util.files import save, load
 import requests
 
 
@@ -481,6 +481,7 @@ class HelloConan(ConanFile):
                        retry=3, retry_wait=0)
 
         self.assertTrue(os.path.exists(dest))
+        content = load(dest)
 
         # overwrite = False
         with self.assertRaises(ConanException):
@@ -494,6 +495,8 @@ class HelloConan(ConanFile):
                        retry=3, retry_wait=0, overwrite=True)
 
         self.assertTrue(os.path.exists(dest))
+        content_new = load(dest)
+        self.assertEqual(content, content_new)
 
         # Not authorized
         with self.assertRaises(ConanException):


### PR DESCRIPTION
https://github.com/conan-io/conan/issues/2000

Where did the "a=append" come from? Is it enough to just open the file in write mode, or is there some case we actually want to append? 