### PR TITLE
- folders cannot be profiles

### DIFF
--- a/conans/client/profile_loader.py
+++ b/conans/client/profile_loader.py
@@ -86,7 +86,7 @@ def read_conaninfo_profile(current_path):
 def get_profile_path(profile_name, default_folder, cwd):
     if os.path.isabs(profile_name):
         profile_path = profile_name
-    elif cwd and (os.path.exists(os.path.join(cwd, profile_name)) or profile_name.startswith(".")):
+    elif cwd and (os.path.isfile(os.path.join(cwd, profile_name)) or profile_name.startswith(".")):
         # relative path name
         profile_path = os.path.abspath(os.path.join(cwd, profile_name))
     else:


### PR DESCRIPTION
for the issue initially reported by @ovidiub13 in Slack channel ```#conan```
```
Z:\Tools\Devel\Sources\myProject\build> conan profile list
Linux-Debug
Linux-Release
Windows-Debug
Windows-Release

Z:\Tools\Devel\Sources\myProject\build> conan install Z:\Tools\Devel\Sources\myProject --profile Windows-Release
ERROR: Specified profile 'Windows-Release' doesn't exist.
Existing profiles: INSTALL.vcxproj.filters, CMakeCache.txt, myProject.sln, cmake_install.cmake, conaninfo.txt, conanbuildinfo.cmake, INSTALL.vcxproj, install_manifest.txt, ZERO_CHECK.vcxproj.filters, conanbuildinfo.txt, ZERO_CHECK.vcxproj, ALL_BUILD.vcxproj.filters, ALL_BUILD.vcxproj
```

as investigation shows, problem is with folder with same name as profile:
```
Z:\Tools\Devel\Sources\myProject\build>dir
 Volume in drive Z is VBOX_work
 Volume Serial Number is 0000-FD03

 Directory of Z:\Tools\Devel\Sources\myProject\build

17.11.2017  18:41               527 INSTALL.vcxproj.filters
17.11.2017  18:41    <DIR>          Release
17.11.2017  18:36            14.468 CMakeCache.txt
17.11.2017  18:41             7.556 myProject.sln
17.11.2017  18:47    <DIR>          Win32
17.11.2017  18:41             1.667 cmake_install.cmake
17.11.2017  18:43    <DIR>          lib
17.11.2017  18:52               485 conaninfo.txt
17.11.2017  18:47    <DIR>          Debug
17.11.2017  18:52            56.953 conanbuildinfo.cmake
17.11.2017  18:53    <DIR>          Windows-Release
17.11.2017  18:41            14.330 INSTALL.vcxproj
17.11.2017  18:53                68 install_manifest.txt
17.11.2017  18:41               528 ZERO_CHECK.vcxproj.filters
17.11.2017  18:53    <DIR>          bin
17.11.2017  18:52    <DIR>          myProject
17.11.2017  18:52             8.482 conanbuildinfo.txt
17.11.2017  18:52    <DIR>          Tests
17.11.2017  18:41            23.197 ZERO_CHECK.vcxproj
17.11.2017  18:53    <DIR>          CMakeFiles
17.11.2017  18:52    <DIR>          myProjectLib
17.11.2017  18:41               285 ALL_BUILD.vcxproj.filters
17.11.2017  18:41            21.653 ALL_BUILD.vcxproj
              13 File(s)        191.159 bytes
              10 Dir(s)  368.043.872.256 bytes free
```
notice **17.11.2017  18:53    <DIR>          Windows-Release**

as profiles cannot be folder, I suggest to make logic more strict (use **isfile** instead of **exists**)