### PR TITLE
Feature/fix profiles paths

### DIFF
--- a/conans/client/conan_api.py
+++ b/conans/client/conan_api.py
@@ -775,7 +775,8 @@ class ConanAPIV1(object):
 
     @api_method
     def create_profile(self, profile_name, detect=False):
-        profile_path = get_profile_path(profile_name, self._client_cache.profiles_path, os.getcwd())
+        profile_path = get_profile_path(profile_name, self._client_cache.profiles_path, os.getcwd(),
+                                        exists=False)
         if os.path.exists(profile_path):
             raise ConanException("Profile already exists")
 

--- a/conans/client/profile_loader.py
+++ b/conans/client/profile_loader.py
@@ -86,7 +86,7 @@ def read_conaninfo_profile(current_path):
 def get_profile_path(profile_name, default_folder, cwd):
     if os.path.isabs(profile_name):
         profile_path = profile_name
-    elif cwd and (os.path.exists(os.path.join(cwd, profile_name)) or profile_name.startswith(".")):
+    elif cwd and profile_name.startswith("."):
         # relative path name
         profile_path = os.path.abspath(os.path.join(cwd, profile_name))
     else:

--- a/conans/client/profile_loader.py
+++ b/conans/client/profile_loader.py
@@ -86,7 +86,7 @@ def read_conaninfo_profile(current_path):
 def get_profile_path(profile_name, default_folder, cwd):
     if os.path.isabs(profile_name):
         profile_path = profile_name
-    elif cwd and profile_name.startswith("."):
+    elif cwd and profile_name[:2] in ("./", ".\\"):
         # relative path name
         profile_path = os.path.abspath(os.path.join(cwd, profile_name))
     else:

--- a/conans/client/profile_loader.py
+++ b/conans/client/profile_loader.py
@@ -83,16 +83,27 @@ def read_conaninfo_profile(current_path):
     return profile
 
 
-def get_profile_path(profile_name, default_folder, cwd):
+def get_profile_path(profile_name, default_folder, cwd, exists=True):
+    def valid_path(profile_path):
+        if exists and not os.path.isfile(profile_path):
+            raise ConanException("Profile not found: %s" % profile_path)
+        return profile_path
+
     if os.path.isabs(profile_name):
-        profile_path = profile_name
-    elif cwd and profile_name[:2] in ("./", ".\\"):
-        # relative path name
+        return valid_path(profile_name)
+
+    if profile_name[:2] in ("./", ".\\"):  # local
         profile_path = os.path.abspath(os.path.join(cwd, profile_name))
-    else:
-        if not os.path.exists(default_folder):
-            mkdir(default_folder)
-        profile_path = os.path.join(default_folder, profile_name)
+        return valid_path(profile_path)
+
+    if not os.path.exists(default_folder):
+        mkdir(default_folder)
+    profile_path = os.path.join(default_folder, profile_name)
+    if exists:
+        if not os.path.isfile(profile_path):
+            profile_path = os.path.abspath(os.path.join(cwd, profile_name))
+        if not os.path.isfile(profile_path):
+            raise ConanException("Profile not found: %s" % profile_name)
     return profile_path
 
 
@@ -105,17 +116,7 @@ def read_profile(profile_name, cwd, default_folder):
         return None, None
 
     profile_path = get_profile_path(profile_name, default_folder, cwd)
-    try:
-        text = load(profile_path)
-    except IOError:
-        folder = os.path.dirname(profile_path)
-        if os.path.exists(folder):
-            profiles = [name for name in os.listdir(folder) if not os.path.isdir(name)]
-        else:
-            profiles = []
-        current_profiles = ", ".join(profiles) or "[]"
-        raise ConanException("Specified profile '%s' doesn't exist.\nExisting profiles: "
-                             "%s" % (profile_name, current_profiles))
+    text = load(profile_path)
 
     try:
         return _load_profile(text, profile_path, default_folder)

--- a/conans/test/command/install_test.py
+++ b/conans/test/command/install_test.py
@@ -9,7 +9,7 @@ from conans.model.info import ConanInfo
 from conans.test.utils.cpp_test_files import cpp_hello_conan_files
 from conans.paths import CONANFILE_TXT
 from conans.client.conf.detect import detected_os
-from conans.util.files import load
+from conans.util.files import load, mkdir
 
 
 class InstallTest(unittest.TestCase):
@@ -299,3 +299,30 @@ class TestConan(ConanFile):
         client.save({}, clean_first=True)
         client.run("install Hello/0.1@conan/stable")
         self.assertFalse(os.path.exists(os.path.join(client.current_folder, "conanbuildinfo.txt")))
+
+    def install_with_profile_test(self):
+        # Test for https://github.com/conan-io/conan/pull/2043
+        conanfile = """from conans import ConanFile
+class TestConan(ConanFile):
+    settings = "os"
+    def requirements(self):
+        self.output.info("PKGOS=%s" % self.settings.os)
+"""
+        client = TestClient()
+        client.save({"conanfile.py": conanfile})
+        client.run("profile new myprofile")
+        client.run("profile update settings.os=Linux myprofile")
+        client.run("install . -pr=myprofile --build")
+        self.assertIn("PKGOS=Linux", client.out)
+        mkdir(os.path.join(client.current_folder, "myprofile"))
+        client.run("install . -pr=myprofile")
+        client.run("profile new myotherprofile")
+        client.run("profile update settings.os=FreeBSD myotherprofile")
+        client.run("install . -pr=myotherprofile")
+        self.assertIn("PKGOS=FreeBSD", client.out)
+        client.save({"myotherprofile": "Some garbage without sense [garbage]"})
+        client.run("install . -pr=myotherprofile")
+        self.assertIn("PKGOS=FreeBSD", client.out)
+        error = client.run("install . -pr=./myotherprofile", ignore_error=True)
+        self.assertTrue(error)
+        self.assertIn("Error parsing the profile", client.out)

--- a/conans/test/functional/profile_loader_test.py
+++ b/conans/test/functional/profile_loader_test.py
@@ -298,8 +298,8 @@ class ProfileTest(unittest.TestCase):
         self.client.save({CONANFILE: conanfile_scope_env})
         error = self.client.run('install -pr "%sscopes_env"' % path, ignore_error=True)
         self.assertTrue(error)
-        self.assertIn("ERROR: Profile not found: %sscopes_env" % path,
-                      self.client.user_io.out)
+        self.assertIn("ERROR: Profile not found: ", self.client.out)
+        self.assertIn("scopes_env", self.client.out)
 
     def install_profile_env_test(self):
         files = cpp_hello_conan_files("Hello0", "0.1", build=False)

--- a/conans/test/functional/profile_loader_test.py
+++ b/conans/test/functional/profile_loader_test.py
@@ -177,12 +177,11 @@ class ProfileTest(unittest.TestCase):
         self.assertIn("QTPATH2=C:/QtCommercial2/5.8/msvc2015_64/bin", new_profile.dumps())
 
     def profile_load_dump_test(self):
-
         # Empty profile
         tmp = temp_folder()
         profile = Profile()
-        dump = profile.dumps()
-        new_profile, _ = self._get_profile(tmp, "")
+        dumps = profile.dumps()
+        new_profile, _ = self._get_profile(tmp, dumps)
         self.assertEquals(new_profile.settings, profile.settings)
 
         # Settings
@@ -564,7 +563,7 @@ class DefaultNameConan(ConanFile):
         [env]
         MYVAR=$MY_MAGIC_VAR what they seem.
         '''
-        profile, vars = self._get_profile(tmp, txt)
+        profile, _ = self._get_profile(tmp, txt)
         self.assertEquals("The owls are not what they seem.", profile.env_values.data[None]["MYVAR"])
 
         # Order in replacement, variable names (simplification of preprocessor)
@@ -575,7 +574,7 @@ class DefaultNameConan(ConanFile):
                 [env]
                 MYVAR=$P2
                 '''
-        profile, vars = self._get_profile(tmp, txt)
+        profile, _ = self._get_profile(tmp, txt)
         self.assertEquals("Diane, the coffee at the Great Northern2", profile.env_values.data[None]["MYVAR"])
 
         # Variables without spaces
@@ -588,8 +587,8 @@ MYVAR=$VARIABLE WITH SPACES
             self._get_profile(tmp, txt)
 
     def test_profiles_includes(self):
-
         tmp = temp_folder()
+
         def save_profile(txt, name):
             abs_profile_path = os.path.join(tmp, name)
             save(abs_profile_path, txt)
@@ -610,11 +609,7 @@ two/1.2@lasote/stable
         profile1 = """
  # Include in subdir, curdir
 MYVAR=1
-include(profile0.txt)
-
-
-
-
+include(./profile0.txt)
 
 [settings]
 os=Windows
@@ -631,7 +626,7 @@ my_scope=TRUE
 
         profile2 = """
 #  Include in subdir
-include(subdir/profile1.txt)
+include(./subdir/profile1.txt)
 [settings]
 os=$MYVAR
 """
@@ -664,9 +659,10 @@ one/1.5@lasote/stable
 
         save_profile(profile4, "profile4.txt")
 
-        profile, vars = read_profile("./profile4.txt", tmp, None)
+        profile, variables = read_profile("./profile4.txt", tmp, None)
 
-        self.assertEquals(vars, {"MYVAR": "1", "OTHERVAR": "34", "PROFILE_DIR": tmp , "ROOTVAR": "0"})
+        self.assertEquals(variables, {"MYVAR": "1", "OTHERVAR": "34", "PROFILE_DIR":
+                                      tmp, "ROOTVAR": "0"})
         self.assertEquals("FromProfile3And34", profile.env_values.data[None]["MYVAR"])
         self.assertEquals("1", profile.env_values.data["package1"]["ENVY"])
         self.assertEquals(profile.settings, {"os": "1"})

--- a/conans/test/functional/profile_loader_test.py
+++ b/conans/test/functional/profile_loader_test.py
@@ -298,7 +298,7 @@ class ProfileTest(unittest.TestCase):
         self.client.save({CONANFILE: conanfile_scope_env})
         error = self.client.run('install -pr "%sscopes_env"' % path, ignore_error=True)
         self.assertTrue(error)
-        self.assertIn("ERROR: Specified profile '%sscopes_env' doesn't exist" % path,
+        self.assertIn("ERROR: Profile not found: %sscopes_env" % path,
                       self.client.user_io.out)
 
     def install_profile_env_test(self):

--- a/conans/test/integration/profile_test.py
+++ b/conans/test/integration/profile_test.py
@@ -135,8 +135,8 @@ class ProfileTest(unittest.TestCase):
         self.client.save({CONANFILE: conanfile_scope_env})
         error = self.client.run('install -pr "%sscopes_env"' % path, ignore_error=True)
         self.assertTrue(error)
-        self.assertIn("ERROR: Specified profile '%sscopes_env' doesn't exist" % path,
-                      self.client.user_io.out)
+        self.assertIn("ERROR: Profile not found:", self.client.out)
+        self.assertIn("scopes_env", self.client.out)
 
     def install_profile_env_test(self):
         files = cpp_hello_conan_files("Hello0", "0.1", build=False)


### PR DESCRIPTION
Going further than: https://github.com/conan-io/conan/pull/2043

While adding tests, I realized there could be also name conflicts with files too. The approach could be to force relative/local paths to profiles always start with "./"