### PR TITLE
python-distro 1.1.0 is out

### DIFF
--- a/conans/requirements.txt
+++ b/conans/requirements.txt
@@ -6,7 +6,7 @@ patch==1.16
 fasteners>=0.14.1
 six>=1.10.0
 node-semver==0.2.0
-distro>=1.0.2, <1.1.0
+distro>=1.0.2, <1.2.0
 pylint>=1.6.5, <=1.8.0
 future==0.16.0
 pygments>=2.0, <3.0


### PR DESCRIPTION
distro 1.1.0 is out and already packaged for eg. Arch Linux.