### PR TITLE
removing build_info from generators

### DIFF
--- a/conans/__init__.py
+++ b/conans/__init__.py
@@ -15,5 +15,5 @@ from conans.util.files import load
 COMPLEX_SEARCH_CAPABILITY = "complex_search"
 SERVER_CAPABILITIES = [COMPLEX_SEARCH_CAPABILITY, ]
 
-__version__ = '0.30.0'
+__version__ = '1.0.0-beta.1'
 

--- a/conans/client/generators/ycm.py
+++ b/conans/client/generators/ycm.py
@@ -1,5 +1,4 @@
 from conans.model import Generator
-from conans.paths import BUILD_INFO_YCM
 
 
 class YouCompleteMeGenerator(Generator):
@@ -165,7 +164,7 @@ def FlagsForFile( filename, **kwargs ):
 
     @property
     def filename(self):
-        return BUILD_INFO_YCM
+        return '.ycm_extra_conf.py'
 
     @property
     def content(self):
@@ -174,12 +173,7 @@ def FlagsForFile( filename, **kwargs ):
 
         flags = ['-x', 'c++']
         flags.extend(self.deps_build_info.cppflags)
-        flags.extend(self.build_info.cppflags)
-
         flags.extend(prefixed("-D", self.deps_build_info.defines))
-        flags.extend(prefixed("-D", self.build_info.defines))
-
-        flags.extend(prefixed("-I", self.build_info.include_paths))
         flags.extend(prefixed("-I", self.deps_build_info.include_paths))
 
         cxx_version = ''

--- a/conans/model/conan_generator.py
+++ b/conans/model/conan_generator.py
@@ -7,7 +7,6 @@ class Generator(object):
     def __init__(self, conanfile):
         self.conanfile = conanfile
         self._deps_build_info = conanfile.deps_cpp_info
-        self._build_info = conanfile.cpp_info
         self._deps_env_info = conanfile.deps_env_info
         self._env_info = conanfile.env_info
         self._deps_user_info = conanfile.deps_user_info
@@ -15,10 +14,6 @@ class Generator(object):
     @property
     def deps_build_info(self):
         return self._deps_build_info
-
-    @property
-    def build_info(self):
-        return self._build_info
 
     @property
     def deps_env_info(self):

--- a/conans/paths.py
+++ b/conans/paths.py
@@ -33,7 +33,6 @@ BUILD_INFO_QMAKE = 'conanbuildinfo.pri'
 BUILD_INFO_QBS = 'conanbuildinfo.qbs'
 BUILD_INFO_VISUAL_STUDIO = 'conanbuildinfo.props'
 BUILD_INFO_XCODE = 'conanbuildinfo.xcconfig'
-BUILD_INFO_YCM = '.ycm_extra_conf.py'
 CONANINFO = "conaninfo.txt"
 CONANENV = "conanenv.txt"
 SYSTEM_REQS = "system_reqs.txt"


### PR DESCRIPTION
Address: https://github.com/conan-io/conan/pull/2074

The access to ``build_info`` from generators is pointless, even potentially dangerous:

- When the package is in the local cache, ``package_info()`` has not been called yet while building (but build() uses generators), so the info is empty
- Not only is empty, but as the directories are non-existing and the results are cached, it breaks dependencies info if ``include_paths`` is checked
- If the package is in user folder, ``package_info()`` is not called at all. That was removed a few versions ago. So right now, the information of ycm for local installs is always empty for the current package. Then, this PR is not breaking anything, it was already not working.

I think it is much safer with this fix. The only missing functionality (that was already missing, it is not introduced in this PR), is having a ``.ycm_extra_conf`` file that allows for configuration of the current project for local development. @skizzay I am willing to improve over it, I think the best way could be to add something to the generated like:

```python
try:
     from .ycm_project_extra_conf import flags
     current_flags += flags
except:  # user didn't provide it
    pass
```
In this way projects can have their own configuration (which by the way, could be totally different to the information conveyed in ``package_info()->cpp_info``, for example, we want access to the internal include directories, not only to the public package interface headers.