### PR TITLE
Add support to user-provided copytree function for performance improvement

### DIFF
--- a/conans/client/installer.py
+++ b/conans/client/installer.py
@@ -107,7 +107,11 @@ class _ConanPackageBuilder(object):
             else:
                 ignore = None
 
-            shutil.copytree(src_folder, self.build_folder, symlinks=True, ignore=ignore)
+            if hasattr(self._conan_file, "copytree"):
+                logger.debug("Utilizing user-provided copytree function")
+                self._conan_file.copytree(src_folder, self.build_folder, symlinks=True, ignore=ignore)
+            else:
+                shutil.copytree(src_folder, self.build_folder, symlinks=True, ignore=ignore)
             logger.debug("Copied to %s", self.build_folder)
             logger.debug("Files copied %s", os.listdir(self.build_folder))
             self._conan_file.source_folder = self.build_folder

--- a/conans/test/integration/only_source_test.py
+++ b/conans/test/integration/only_source_test.py
@@ -104,6 +104,32 @@ class MyPackage(ConanFile):
                       client.user_io.out)
         client.run("upload test/1.9@lasote/stable")
 
+    def user_copytree_test(self):
+        client = TestClient(servers=self.servers, users={"default": [("lasote", "mypass")]})
+        conanfile = """
+from conans import ConanFile
+
+class MyPackage(ConanFile):
+    name = "test"
+    version = "1.9"
+    build_policy = 'always'
+
+    def copytree(self, src_folder, build_folder, symlinks=True, ignore=None):
+        import shutil
+        self.output.info("my_copy(src_folder={src_folder}, build_folder={build_folder},"
+                "symlinks={symlinks}, ignore={ignore}".format(**locals()))
+        shutil.copytree(src_folder, build_folder, symlinks, ignore)
+
+    def source(self):
+        pass
+        """
+
+        files = {CONANFILE: conanfile}
+        client.save(files, clean_first=True)
+        client.run("export lasote/stable")
+        client.run("install test/1.9@lasote/stable")
+        self.assertIn("my_copy", client.user_io.out)
+
     def build_policies_in_conanfile_test(self):
 
         client = TestClient(servers=self.servers, users={"default": [("lasote", "mypass")]})


### PR DESCRIPTION
On Windows, shutil.copytree performs rather poorly. In the worst cases (like boost with large amount of small files) copying sources often takes more time than building the library.

There are faster options for copying large amount of files, either by implementing a better function in python or simply calling a tool that will use the hardware more effectively, such as robocopy or emcopy. 

Rather than supporting an individual tool, I think it's best to allow users to provide a shutil.copytree-like function as a ConanFile member which will be picked up and used automatically. This PR adds this capability by checking if the conanfile has a `copytree` attribute available.

### Benchmark

I performed the following test with our boost package:

First, I changed the build method to return immediately, so it only performs copying the sources. I made sure that the sources are downloaded before the benchmark and then used the -k switch. 

In the first case, I didn't change anything else, so the default shutil.copytree copying was performed.

In the second case, I added the following to the conanfile:

```py
  def copytree(self, src_folder, build_folder, symlinks=True, ignore=None):
    import subprocess
    ret = subprocess.run(["robocopy", src_folder, build_folder, "/MT:64", "/e"], 
                         stdout=subprocess.PIPE, stderr=subprocess.PIPE).returncode
    assert ret in (0, 1)
```

**Results**

```
C:\Users\tamas\work\conan\packages\boost                                                          
λ  Measure-Command { py ..\..\envwrap.py py $MYCONAN create plex/stable -pr ..\..\profiles\plex-windows-x86_64-msvc14-release --build boost -k }
                                                                                                                                                
                                                                                                                                                
Days              : 0                                                                                                                           
Hours             : 0                                                                                                                           
Minutes           : 4                                                                                                                           
Seconds           : 22                                                                                                                          
Milliseconds      : 642                                                                                                                         
Ticks             : 2626422981                                                                                                                  
TotalDays         : 0,00303984141319444                                                                                                         
TotalHours        : 0,0729561939166667                                                                                                          
TotalMinutes      : 4,377371635                                                                                                                 
TotalSeconds      : 262,6422981                                                                                                                 
TotalMilliseconds : 262642,2981                                                                                                                 
                                                                                                                                                
                                                                                                                                                
                                                                                                                                                
C:\Users\tamas\work\conan\packages\boost                                                               
λ  Measure-Command { py ..\..\envwrap.py py $MYCONAN create plex/stable -pr ..\..\profiles\plex-windows-x86_64-msvc14-release --build boost -k }
                                                                                                                                                
                                                                                                                                                
Days              : 0                                                                                                                           
Hours             : 0                                                                                                                           
Minutes           : 1                                                                                                                           
Seconds           : 58                                                                                                                          
Milliseconds      : 277                                                                                                                         
Ticks             : 1182770323                                                                                                                  
TotalDays         : 0,00136894713310185                                                                                                         
TotalHours        : 0,0328547311944444                                                                                                          
TotalMinutes      : 1,97128387166667                                                                                                            
TotalSeconds      : 118,2770323                                                                                                                 
TotalMilliseconds : 118277,0323                                                                                                                 
```

**That is a 182% improvement** (which obviously adds up to several minutes with many packages), so we would be very interested in this or something similar in conan. Naturally, the `ignore` function is discarded in this naive implementation of the user provided copytree, but I think it's OK for the user to make that decision.

/cc @tru 