### PR TITLE
gcc majors and clang deprecated in travis

### DIFF
--- a/conans/client/cmd/new_ci.py
+++ b/conans/client/cmd/new_ci.py
@@ -159,12 +159,13 @@ clang-{version}:
 """
 
 
-def get_build_py(name, user, channel, shared):
+def get_build_py(name, shared):
     shared = 'shared_option_name="{}:shared"'.format(name) if shared else ""
     return build_py.format(name=name, shared=shared)
 
 
-def get_travis(name, version, user, channel, linux_gcc_versions, linux_clang_versions, osx_clang_versions, upload_url):
+def get_travis(name, version, user, channel, linux_gcc_versions, linux_clang_versions,
+               osx_clang_versions, upload_url):
     config = []
 
     if linux_gcc_versions:
@@ -176,9 +177,8 @@ def get_travis(name, version, user, channel, linux_gcc_versions, linux_clang_ver
             config.append(linux_config_clang.format(version=clang, name=clang.replace(".", "")))
 
     xcode_map = {"8.1": "8.3",
-                 "8.0": "8.2",
                  "7.3": "7.3",
-                 "9.0": "9"}
+                 "9.0": "9.2"}
     for apple_clang in osx_clang_versions:
         xcode = xcode_map[apple_clang]
         config.append(osx_config.format(xcode=xcode, version=apple_clang))
@@ -226,15 +226,16 @@ def get_gitlab(name, version, user, channel, linux_gcc_versions, linux_clang_ver
     return files
 
 
-def ci_get_files(name, version, user, channel, visual_versions, linux_gcc_versions, linux_clang_versions,
-                 osx_clang_versions, shared, upload_url, gitlab_gcc_versions, gitlab_clang_versions):
-    if shared and not (visual_versions or linux_gcc_versions or linux_clang_versions or osx_clang_versions or
-                       gitlab_gcc_versions or gitlab_clang_versions):
+def ci_get_files(name, version, user, channel, visual_versions, linux_gcc_versions,
+                 linux_clang_versions, osx_clang_versions, shared, upload_url, gitlab_gcc_versions,
+                 gitlab_clang_versions):
+    if shared and not (visual_versions or linux_gcc_versions or linux_clang_versions or
+                       osx_clang_versions or gitlab_gcc_versions or gitlab_clang_versions):
         raise ConanException("Trying to specify 'shared' in CI, but no CI system specified")
     if not (visual_versions or linux_gcc_versions or linux_clang_versions or osx_clang_versions or
             gitlab_gcc_versions or gitlab_clang_versions):
         return {}
-    gcc_versions = ["4.9", "5.4", "6.3"]
+    gcc_versions = ["4.9", "5", "6", "7"]
     clang_versions = ["3.9", "4.0"]
     if visual_versions is True:
         visual_versions = ["12", "14", "15"]
@@ -247,7 +248,7 @@ def ci_get_files(name, version, user, channel, visual_versions, linux_gcc_versio
     if gitlab_clang_versions is True:
         gitlab_clang_versions = clang_versions
     if osx_clang_versions is True:
-        osx_clang_versions = ["7.3", "8.0", "8.1", "9.0"]
+        osx_clang_versions = ["7.3", "8.1", "9.0"]
     if not visual_versions:
         visual_versions = []
     if not linux_gcc_versions:
@@ -260,15 +261,14 @@ def ci_get_files(name, version, user, channel, visual_versions, linux_gcc_versio
         gitlab_gcc_versions = []
     if not gitlab_clang_versions:
         gitlab_clang_versions = []
-    build_py = get_build_py(name, user, channel, shared)
-    files = {"build.py": build_py}
+    files = {"build.py": get_build_py(name, shared)}
     if linux_gcc_versions or osx_clang_versions or linux_clang_versions:
-        files.update(get_travis(name, version, user, channel, linux_gcc_versions, linux_clang_versions,
-                                osx_clang_versions, upload_url))
+        files.update(get_travis(name, version, user, channel, linux_gcc_versions,
+                                linux_clang_versions, osx_clang_versions, upload_url))
 
     if gitlab_gcc_versions or gitlab_clang_versions:
-        files.update(get_gitlab(name, version, user, channel, gitlab_gcc_versions, gitlab_clang_versions,
-                                upload_url))
+        files.update(get_gitlab(name, version, user, channel, gitlab_gcc_versions,
+                                gitlab_clang_versions, upload_url))
 
     if visual_versions:
         files.update(get_appveyor(name, version, user, channel, visual_versions, upload_url))

--- a/conans/test/command/new_test.py
+++ b/conans/test/command/new_test.py
@@ -135,7 +135,7 @@ class NewTest(unittest.TestCase):
         self.assertIn('- CONAN_REFERENCE: "MyPackage/1.3"', travis)
         self.assertIn('- CONAN_USERNAME: "myuser"', travis)
         self.assertIn('- CONAN_CHANNEL: "testing"', travis)
-        self.assertIn('env: CONAN_GCC_VERSIONS=5.4 CONAN_DOCKER_IMAGE=lasote/conangcc54',
+        self.assertIn('env: CONAN_GCC_VERSIONS=5 CONAN_DOCKER_IMAGE=lasote/conangcc5',
                       travis)
 
         gitlab = load(os.path.join(root, ".gitlab-ci.yml"))
@@ -143,7 +143,7 @@ class NewTest(unittest.TestCase):
         self.assertIn('CONAN_REFERENCE: "MyPackage/1.3"', gitlab)
         self.assertIn('CONAN_USERNAME: "myuser"', gitlab)
         self.assertIn('CONAN_CHANNEL: "testing"', gitlab)
-        self.assertIn('CONAN_GCC_VERSIONS: "5.4"', gitlab)
+        self.assertIn('CONAN_GCC_VERSIONS: "5"', gitlab)
 
     def new_ci_test_partial(self):
         client = TestClient()


### PR DESCRIPTION
#2167 
I've reviewed the docs, nothing concrete to update, in #433 I updated a detail about package_tools that can be already merged to master.