### PR TITLE
Removed source_dir from conan new command

### DIFF
--- a/conans/client/cmd/new.py
+++ b/conans/client/cmd/new.py
@@ -29,7 +29,7 @@ conan_basic_setup()''')
 
     def build(self):
         cmake = CMake(self)
-        cmake.configure(source_dir="%s/hello" % self.source_folder)
+        cmake.configure(source_folder="hello")
         cmake.build()
 
         # Explicit way:
@@ -83,7 +83,7 @@ class {package_name}Conan(ConanFile):
 
     def build(self):
         cmake = CMake(self)
-        cmake.configure(source_dir="src")
+        cmake.configure(source_folder="src")
         cmake.build()
 
         # Explicit way:


### PR DESCRIPTION
Removed `source_dir` from files generated with `conan new --sources` and `conan new --ci-shared`

PR to docs: https://github.com/conan-io/docs/pull/434