### PR TITLE
Add support for Suse's zypper in SystemPackageTool

### DIFF
--- a/conans/client/tools/oss.py
+++ b/conans/client/tools/oss.py
@@ -110,6 +110,11 @@ class OSInfo(object):
             return uname.startswith('MSYS_NT') and which('pacman.exe')
         return False
 
+    @property
+    def with_zypper(self):
+        return self.is_linux and self.linux_distro in \
+            ("opensuse", "sles")
+    
     @staticmethod
     def get_win_os_version():
         """

--- a/conans/client/tools/system_pm.py
+++ b/conans/client/tools/system_pm.py
@@ -36,6 +36,8 @@ class SystemPackageTool(object):
             return PkgTool()
         elif os_info.is_solaris:
             return PkgUtilTool()
+        elif os_info.with_zypper:
+            return ZypperTool()
         else:
             return NullTool()
 
@@ -171,6 +173,17 @@ class PacManTool(object):
         exit_code = self._runner("pacman -Qi %s" % package_name, None)
         return exit_code == 0
 
+
+class ZypperTool(object):
+    def update(self):
+        _run(self._runner, "%szypper --non-interactive ref" % self._sudo_str)
+
+    def install(self, package_name):
+        _run(self._runner, "%szypper --non-interactive in %s" % (self._sudo_str, package_name))
+
+    def installed(self, package_name):
+        exit_code = self._runner("rpm -q %s" % package_name, None)
+        return exit_code == 0
 
 def _run(runner, command, accepted_returns=None):
     accepted_returns = accepted_returns or [0, ]

--- a/conans/test/util/tools_test.py
+++ b/conans/test/util/tools_test.py
@@ -157,24 +157,31 @@ class HelloConan(ConanFile):
             spt.update()
             self.assertEquals(runner.command_called, "sudo yum check-update")
 
+            os_info.linux_distro = "opensuse"
+            spt = SystemPackageTool(runner=runner, os_info=os_info)
+            spt.update()
+            self.assertEquals(runner.command_called, "sudo zypper ref")
+
+            
             os_info.linux_distro = "redhat"
             spt = SystemPackageTool(runner=runner, os_info=os_info)
             spt.install("a_package", force=False)
             self.assertEquals(runner.command_called, "rpm -q a_package")
             spt.install("a_package", force=True)
             self.assertEquals(runner.command_called, "sudo yum install -y a_package")
-
+            
             os_info.linux_distro = "debian"
             spt = SystemPackageTool(runner=runner, os_info=os_info)
             with self.assertRaises(ConanException):
                 runner.return_ok = False
                 spt.install("a_package")
                 self.assertEquals(runner.command_called, "sudo apt-get install -y --no-install-recommends a_package")
-
+                
             runner.return_ok = True
             spt.install("a_package", force=False)
             self.assertEquals(runner.command_called, "dpkg -s a_package")
 
+            
             os_info.is_macos = True
             os_info.is_linux = False
             os_info.is_windows = False

--- a/conans/test/util/tools_test.py
+++ b/conans/test/util/tools_test.py
@@ -160,7 +160,7 @@ class HelloConan(ConanFile):
             os_info.linux_distro = "opensuse"
             spt = SystemPackageTool(runner=runner, os_info=os_info)
             spt.update()
-            self.assertEquals(runner.command_called, "sudo zypper ref")
+            self.assertEquals(runner.command_called, "sudo zypper --non-interactive ref")
 
             
             os_info.linux_distro = "redhat"

--- a/conans/test/util/tools_test.py
+++ b/conans/test/util/tools_test.py
@@ -136,7 +136,9 @@ class HelloConan(ConanFile):
             runner = RunnerMock()
             # fake os info to linux debian, default sudo
             os_info = OSInfo()
+            os_info.is_macos = False
             os_info.is_linux = True
+            os_info.is_windows = False
             os_info.linux_distro = "debian"
             spt = SystemPackageTool(runner=runner, os_info=os_info)
             spt.update()


### PR DESCRIPTION
This adds the commands to support the zypper package management
tool as used in the opensuse and Suse Linux Enterprise Server
distributions within SystemPackageTool

p.s. apologies for multiple pull requests, my usual workflow is patches & emails, I am not very good with github!