### PR TITLE
require fresh pylint and astroid

### DIFF
--- a/conans/requirements.txt
+++ b/conans/requirements.txt
@@ -7,7 +7,7 @@ fasteners>=0.14.1
 six>=1.10.0
 node-semver==0.2.0
 distro>=1.0.2, <1.2.0
-pylint>=1.6.5, <=1.8.0
+pylint>=1.8.1, <1.9.0
 future==0.16.0
 pygments>=2.0, <3.0
-astroid<1.6
+astroid>=1.6, <1.7


### PR DESCRIPTION
Solves #2164, avoids pylint false warnings on Python 3.