### PR TITLE
Delete build folder after successful conan test (#2160)

### DIFF
--- a/conans/client/cmd/test.py
+++ b/conans/client/cmd/test.py
@@ -1,8 +1,9 @@
 import hashlib
 import os
+import tempfile
 
 from conans.util.files import rmdir
-
+from conans.util.env_reader import get_env
 
 class PackageTester(object):
 
@@ -12,32 +13,46 @@ class PackageTester(object):
 
     def install_build_and_test(self, conanfile_abs_path, reference, profile,
                                remote, update, build_modes=None, manifest_folder=None,
-                               manifest_verify=False, manifest_interactive=False, keep_build=False):
+                               manifest_verify=False, manifest_interactive=False, keep_build=False,
+                               test_build_folder=None):
         """
         Installs the reference (specified by the parameters or extracted from the test conanfile)
         and builds the test_package/conanfile.py running the test() method.
         """
         base_folder = os.path.dirname(conanfile_abs_path)
-        build_folder = self._build_folder(profile, base_folder)
-        rmdir(build_folder)
+        test_build_folder, delete_after_build = self._build_folder(test_build_folder, profile, base_folder)
+        rmdir(test_build_folder)
         if build_modes is None:
             build_modes = ["never"]
-        self._manager.install(inject_require=reference,
-                              reference=conanfile_abs_path,
-                              install_folder=build_folder,
-                              remote=remote,
-                              profile=profile,
-                              update=update,
-                              build_modes=build_modes,
-                              manifest_folder=manifest_folder,
-                              manifest_verify=manifest_verify,
-                              manifest_interactive=manifest_interactive,
-                              keep_build=keep_build)
-        self._manager.build(conanfile_abs_path, base_folder, build_folder, package_folder=None,
-                            install_folder=build_folder, test=str(reference))
+        try:
+            self._manager.install(inject_require=reference,
+                                reference=conanfile_abs_path,
+                                install_folder=test_build_folder,
+                                remote=remote,
+                                profile=profile,
+                                update=update,
+                                build_modes=build_modes,
+                                manifest_folder=manifest_folder,
+                                manifest_verify=manifest_verify,
+                                manifest_interactive=manifest_interactive,
+                                keep_build=keep_build)
+            self._manager.build(conanfile_abs_path, base_folder, test_build_folder, package_folder=None,
+                                install_folder=test_build_folder, test=str(reference))
+        finally:
+            if delete_after_build:
+                os.chdir(base_folder)    # Required for windows where deleting the cwd is not possible.
+                rmdir(test_build_folder)
 
     @staticmethod
-    def _build_folder(profile, test_folder):
+    def _build_folder(test_build_folder, profile, base_folder):
+        # Use the specified build folder when available.
+        if test_build_folder:
+            return (os.path.abspath(test_build_folder), False)
+
+        # Otherwise, generate a new test folder depending on the configuration.
+        if get_env('CONAN_TEMP_TEST_FOLDER', False):
+            return (tempfile.mkdtemp(prefix='conans'), True)
+
         sha = hashlib.sha1("".join(profile.dumps()).encode()).hexdigest()
-        build_folder = os.path.join(test_folder, "build", sha)
-        return build_folder
+        build_folder = os.path.join(base_folder, "build", sha)
+        return (build_folder, False)

--- a/conans/client/command.py
+++ b/conans/client/command.py
@@ -155,6 +155,8 @@ class Command(object):
         To create and test a binary package use the 'conan create' command.
         """
         parser = argparse.ArgumentParser(description=self.test.__doc__, prog="conan test")
+        parser.add_argument("-tbf", "--test-build-folder", action=OnceArgument,
+                            help="Optional. Working directory of the build process.")
         parser.add_argument("path", help='path to the "testing" folder containing a recipe '
                             '(conanfile.py) with a test() method or to a recipe file, '
                             'e.g. conan test_package/conanfile.py pkg/version@user/channel')
@@ -166,7 +168,7 @@ class Command(object):
         args = parser.parse_args(*args)
         return self._conan.test(args.path, args.reference, args.profile, args.settings,
                                 args.options, args.env, args.remote, args.update,
-                                build_modes=args.build)
+                                build_modes=args.build, test_build_folder=args.test_build_folder)
 
     def create(self, *args):
         """ Builds a binary package for recipe (conanfile.py) located in current dir.
@@ -186,6 +188,8 @@ class Command(object):
         parser.add_argument("-tf", "--test-folder", action=OnceArgument,
                             help='alternative test folder name, by default is "test_package". '
                                  '"None" if test stage needs to be disabled')
+        parser.add_argument("-tbf", "--test-build-folder", action=OnceArgument,
+                            help='Optional. Working directory for the build of the test project.')
         parser.add_argument('-k', '--keep-source', default=False, action='store_true',
                             help='Optional. Do not remove the source folder in local cache. '
                                  'Use for testing purposes only')
@@ -209,7 +213,8 @@ class Command(object):
                                   args.env, args.test_folder, args.not_export,
                                   args.build, args.keep_source, args.keep_build, args.verify,
                                   args.manifests, args.manifests_interactive,
-                                  args.remote, args.update)
+                                  args.remote, args.update,
+                                  test_build_folder=args.test_build_folder)
 
     def download(self, *args):
         """Downloads recipe and binaries to the local cache, without using settings.

--- a/conans/client/conan_api.py
+++ b/conans/client/conan_api.py
@@ -206,7 +206,7 @@ class ConanAPIV1(object):
 
     @api_method
     def test(self, path, reference, profile_name=None, settings=None, options=None, env=None,
-             remote=None, update=False, build_modes=None, cwd=None):
+             remote=None, update=False, build_modes=None, cwd=None, test_build_folder=None):
 
         settings = settings or []
         options = options or []
@@ -219,7 +219,8 @@ class ConanAPIV1(object):
         reference = ConanFileReference.loads(reference)
         pt = PackageTester(self._manager, self._user_io)
         pt.install_build_and_test(conanfile_path, reference, profile, remote,
-                                  update, build_modes=build_modes)
+                                  update, build_modes=build_modes,
+                                  test_build_folder=test_build_folder)
 
     @api_method
     def create(self, conanfile_path, name=None, version=None, user=None, channel=None,
@@ -228,7 +229,7 @@ class ConanAPIV1(object):
                build_modes=None,
                keep_source=False, keep_build=False, verify=None,
                manifests=None, manifests_interactive=None,
-               remote=None, update=False, cwd=None):
+               remote=None, update=False, cwd=None, test_build_folder=None):
         """
         API method to create a conan package
 
@@ -295,7 +296,8 @@ class ConanAPIV1(object):
                                       manifest_folder=manifest_folder,
                                       manifest_verify=manifest_verify,
                                       manifest_interactive=manifest_interactive,
-                                      keep_build=keep_build)
+                                      keep_build=keep_build,
+                                      test_build_folder=test_build_folder)
         else:
             self._manager.install(reference=reference,
                                   install_folder=None,  # Not output anything

--- a/conans/client/conf/__init__.py
+++ b/conans/client/conf/__init__.py
@@ -108,6 +108,9 @@ sysrequires_sudo = True               # environment CONAN_SYSREQUIRES_SUDO
 
 # cpu_count = 1             # environment CONAN_CPU_COUNT
 
+# Change the default location for building test packages to a temporary folder
+# which is deleted after the test.
+# temp_test_folder = True             # environment CONAN_TEMP_TEST_FOLDER
 
 [storage]
 # This is the default path, but you can write your own. It must be an absolute path or a
@@ -180,6 +183,7 @@ class ConanClientConfigParser(ConfigParser, object):
 
                "CONAN_BASH_PATH": self._env_c("general.bash_path", "CONAN_BASH_PATH", None),
                "CONAN_MAKE_PROGRAM": self._env_c("general.conan_make_program", "CONAN_MAKE_PROGRAM", None),
+               "CONAN_TEMP_TEST_FOLDER": self._env_c("general.temp_test_folder", "CONAN_TEMP_TEST_FOLDER", "False"),
                }
 
         # Filter None values


### PR DESCRIPTION
Additionally, by default a temp folder is used as build directory and
a new command line option can be used to specify a folder if needed.