### PR TITLE
Feature/fix transitive build requires

### DIFF
--- a/conans/client/build_requires.py
+++ b/conans/client/build_requires.py
@@ -13,9 +13,13 @@ def _apply_build_requires(deps_graph, conanfile, package_build_requires):
     for node in requires_nodes:
         requires_nodes_dict[node.conan_ref.name] = node.conanfile
 
+    # To guarantee that we respect the order given by the user, not the one imposed by the graph
     build_requires = []
     for package_name in package_build_requires:
-        build_requires.append((package_name, requires_nodes_dict[package_name]))
+        try:
+            build_requires.append((package_name, requires_nodes_dict[package_name]))
+        except KeyError:
+            pass
 
     for package_name, build_require_conanfile in build_requires:
         conanfile.deps_cpp_info.update(build_require_conanfile.cpp_info, package_name)
@@ -25,6 +29,7 @@ def _apply_build_requires(deps_graph, conanfile, package_build_requires):
         conanfile.deps_env_info.update_deps_env_info(build_require_conanfile.deps_env_info)
 
         conanfile.deps_user_info[package_name] = build_require_conanfile.user_info
+
 
 class _RecipeBuildRequires(OrderedDict):
     def __init__(self, conanfile):

--- a/conans/test/integration/build_requires_test.py
+++ b/conans/test/integration/build_requires_test.py
@@ -50,6 +50,38 @@ nonexistingpattern*: SomeTool/1.2@user/channel
 
 class BuildRequiresTest(unittest.TestCase):
 
+    def test_transitive2(self):
+        client = TestClient()
+        boost = """from conans import ConanFile
+class Boost(ConanFile):
+    def package_info(self):
+        self.env_info.PATH.append("myboostpath")
+"""
+        client.save({CONANFILE: boost})
+        client.run("create . Boost/1.0@user/channel")
+        other = """from conans import ConanFile
+import os
+class Other(ConanFile):
+    requires = "Boost/1.0@user/channel"
+    def build(self):
+        self.output.info("OTHER PATH FOR BUILD %s" % os.getenv("PATH"))
+    def package_info(self):
+        self.env_info.PATH.append("myotherpath")
+"""
+        client.save({CONANFILE: other})
+        client.run("create . Other/1.0@user/channel")
+        lib = """from conans import ConanFile
+import os
+class Lib(ConanFile):
+    build_requires = "Boost/1.0@user/channel", "Other/1.0@user/channel"
+    def build(self):
+        self.output.info("LIB PATH FOR BUILD %s" % os.getenv("PATH"))
+"""
+        client.save({CONANFILE: lib})
+        client.run("create . Lib/1.0@user/channel")
+        self.assertIn("LIB PATH FOR BUILD myotherpath%smyboostpath" % os.pathsep,
+                      client.out)
+
     def test_transitive(self):
         client = TestClient()
         mingw = """from conans import ConanFile

--- a/conans/test/integration/build_requires_test.py
+++ b/conans/test/integration/build_requires_test.py
@@ -50,7 +50,7 @@ nonexistingpattern*: SomeTool/1.2@user/channel
 
 class BuildRequiresTest(unittest.TestCase):
 
-    def test_transitive2(self):
+    def test_dependents(self):
         client = TestClient()
         boost = """from conans import ConanFile
 class Boost(ConanFile):


### PR DESCRIPTION
- [x] Reported in slack @theodelrieu 
- [x] Bug introduced in 1.0.0-beta, due to the ordering of build_requires, was causing exception for transitive dependencies among build requires

