### PR TITLE
fixed creation of packages when non-existing

### DIFF
--- a/conans/client/client_cache.py
+++ b/conans/client/client_cache.py
@@ -53,6 +53,11 @@ class ClientCache(SimplePaths):
             return NoLock()
         return WriteLock(self.conan(conan_ref), conan_ref, self._output)
 
+    def conanfile_lock_files(self, conan_ref):
+        if self._no_locks():
+            return ()
+        return WriteLock(self.conan(conan_ref), conan_ref, self._output).files
+
     def package_lock(self, package_ref):
         if self._no_locks():
             return NoLock()

--- a/conans/client/client_cache.py
+++ b/conans/client/client_cache.py
@@ -46,14 +46,12 @@ class ClientCache(SimplePaths):
     def conanfile_read_lock(self, conan_ref):
         if self._no_locks():
             return NoLock()
-        return ReadLock(os.path.join(self.conan(conan_ref), "rw"), conan_ref,
-                        self._output)
+        return ReadLock(self.conan(conan_ref), conan_ref, self._output)
 
     def conanfile_write_lock(self, conan_ref):
         if self._no_locks():
             return NoLock()
-        return WriteLock(self.conan(conan_ref), conan_ref,
-                         self._output)
+        return WriteLock(self.conan(conan_ref), conan_ref, self._output)
 
     def package_lock(self, package_ref):
         if self._no_locks():

--- a/conans/client/client_cache.py
+++ b/conans/client/client_cache.py
@@ -52,7 +52,7 @@ class ClientCache(SimplePaths):
     def conanfile_write_lock(self, conan_ref):
         if self._no_locks():
             return NoLock()
-        return WriteLock(os.path.join(self.conan(conan_ref), "rw"), conan_ref,
+        return WriteLock(self.conan(conan_ref), conan_ref,
                          self._output)
 
     def package_lock(self, package_ref):

--- a/conans/client/remover.py
+++ b/conans/client/remover.py
@@ -37,14 +37,12 @@ class DiskRemover(object):
         self.remove_packages(conan_ref)
         self._remove(self._paths.export(conan_ref), conan_ref, "export folder")
         self._remove(self._paths.export_sources(conan_ref), conan_ref, "export_source folder")
-        conan_ref_dir = self._paths.conan(conan_ref)
-        self._remove(conan_ref_dir, conan_ref)
-        try:
-            dir_name, channel = os.path.split(conan_ref_dir)
-            os.remove(os.path.join(dir_name, "%s.count" % channel))
-            os.remove(os.path.join(dir_name, "%s.count.lock" % channel))
-        except OSError:
-            pass
+        self._remove(self._paths.conan(conan_ref), conan_ref)
+        for f in self._paths.conanfile_lock_files(conan_ref):
+            try:
+                os.remove(f)
+            except OSError:
+                pass
 
     def remove_src(self, conan_ref):
         self._remove(self._paths.source(conan_ref), conan_ref, "src folder")

--- a/conans/client/remover.py
+++ b/conans/client/remover.py
@@ -37,7 +37,14 @@ class DiskRemover(object):
         self.remove_packages(conan_ref)
         self._remove(self._paths.export(conan_ref), conan_ref, "export folder")
         self._remove(self._paths.export_sources(conan_ref), conan_ref, "export_source folder")
-        self._remove(self._paths.conan(conan_ref), conan_ref)
+        conan_ref_dir = self._paths.conan(conan_ref)
+        self._remove(conan_ref_dir, conan_ref)
+        try:
+            dir_name, channel = os.path.split(conan_ref_dir)
+            os.remove(os.path.join(dir_name, "%s.count" % channel))
+            os.remove(os.path.join(dir_name, "%s.count.lock" % channel))
+        except OSError:
+            pass
 
     def remove_src(self, conan_ref):
         self._remove(self._paths.source(conan_ref), conan_ref, "src folder")

--- a/conans/test/command/export_test.py
+++ b/conans/test/command/export_test.py
@@ -6,7 +6,6 @@ from conans.model.ref import ConanFileReference
 from conans.test.utils.cpp_test_files import cpp_hello_conan_files
 from conans.model.manifest import FileTreeManifest
 from conans.test.utils.tools import TestClient
-import platform
 import stat
 from nose_parameterized import parameterized
 

--- a/conans/test/command/info_test.py
+++ b/conans/test/command/info_test.py
@@ -11,6 +11,20 @@ from conans.util.files import load
 
 class InfoTest(unittest.TestCase):
 
+    def failed_info_test(self):
+        client = TestClient()
+        conanfile = """from conans import ConanFile
+class Pkg(ConanFile):
+    requires = "Pkg/1.0.x@user/testing"
+"""
+        client.save({"conanfile.py": conanfile})
+        error = client.run("info .", ignore_error=True)
+        self.assertTrue(error)
+        self.assertIn("Pkg/1.0.x@user/testing: Not found in local cache", client.out)
+        client.run("search")
+        self.assertIn("There are no packages", client.out)
+        self.assertNotIn("Pkg/1.0.x@user/testing", client.out)
+
     def _create(self, number, version, deps=None, deps_dev=None, export=True):
         files = cpp_hello_conan_files(number, version, deps, build=False)
         files[CONANFILE] = files[CONANFILE].replace("config(", "configure(")

--- a/conans/util/locks.py
+++ b/conans/util/locks.py
@@ -38,6 +38,10 @@ class Lock(object):
         self._output = output
         self._first_lock = True
 
+    @property
+    def files(self):
+        return (self._count_file, self._count_lock_file)
+
     def _info_locked(self):
         if self._first_lock:
             self._first_lock = False


### PR DESCRIPTION
- [x] Refer to the issue that supports this Pull Request.

Address https://github.com/conan-io/conan/issues/2243


The problem with https://github.com/conan-io/conan/issues/2243 is that when the code does:

```python
    def get_recipe(self, conan_reference):
        with self._client_cache.conanfile_write_lock(conan_reference):
            result = self._get_recipe(conan_reference)
        return result
```
The ``conanfile_write_lock`` creates the lock file (rw.count) inside the conan local cache Pkg/version/user/channel folder. If the ``_get_recipe`` fails because the package doesn't exist, the lock files are still there (they can't be removed, as you don't know about concurrent usage). So the search, that uses the folder existence to detect packages, is giving a false positive

Another possible solution could be to change the **search** and force it to detect an ``export/conanfile.py`` file in the local cache to return a positive, but I thought that fixing the lock files would be less changing and potentially break less things

The solution proposed just moves Pkg/version/user/channel/rw.count => Pkg/version/user/channel.count

  