### PR TITLE
fix options reuse after install in export-pkg

### DIFF
--- a/conans/client/manager.py
+++ b/conans/client/manager.py
@@ -165,7 +165,7 @@ class ConanManager(object):
                                   manifest_manager=None)
 
         loader = self.get_loader(profile)
-        conanfile = loader.load_virtual([reference], None)
+        conanfile = loader.load_virtual([reference], scope_options=True)
         if install_folder and existing_info_files(install_folder):
             _load_deps_info(install_folder, conanfile, required=True)
 


### PR DESCRIPTION
- [x] Refer to the issue that supports this Pull Request.

https://github.com/conan-io/conan/issues/2242

- [x] I've followed the PEP8 style guides for Python code.



