### PR TITLE
vsvars filtering path, run in bash accepting env vars

### DIFF
--- a/conans/client/tools/env.py
+++ b/conans/client/tools/env.py
@@ -76,8 +76,7 @@ def remove_from_path(command):
                     new_path.append(entry)
 
         curpath = os.pathsep.join(new_path)
-
-    if n >= 199:
+    else:
         raise ConanException("Error in tools.remove_from_path!! couldn't remove the tool %s "
                              "from the path after 200 attempts, this is a Conan client bug, please open an issue at: "
                              "https://github.com/conan-io/conan" % command)

--- a/conans/client/tools/env.py
+++ b/conans/client/tools/env.py
@@ -63,16 +63,17 @@ def remove_from_path(command):
         if not the_command:
             break
         new_path = []
-        the_command2 = ""
-        if "sysnative" in the_command and platform.system() == "Windows":
-            the_command2 = the_command.replace("sysnative", "system32")
-        for entry in curpath.split(os.pathsep):
-            if platform.system() == "Windows":
-                entry = entry.lower()
-                the_command = the_command.lower()
-                the_command2 = the_command2.lower()
-            if entry != os.path.dirname(the_command2) and entry != os.path.dirname(the_command):
-                new_path.append(entry)
+        if platform.system() == "Windows":
+            the_command2 = the_command.replace("sysnative", "system32") if "sysnative" in the_command else ""
+            for entry in curpath.split(os.pathsep):
+                if entry.lower() != os.path.dirname(the_command2.lower()) and \
+                   entry.lower() != os.path.dirname(the_command.lower()):
+                    new_path.append(entry)
+        else:
+            for entry in curpath.split(os.pathsep):
+                if entry != os.path.dirname(the_command):
+                    new_path.append(entry)
+
         curpath = os.pathsep.join(new_path)
 
     with environment_append({"PATH": curpath}):

--- a/conans/client/tools/env.py
+++ b/conans/client/tools/env.py
@@ -5,6 +5,7 @@ from contextlib import contextmanager
 import os
 
 from conans.client.tools.files import which
+from conans.errors import ConanException
 
 
 @contextmanager
@@ -52,7 +53,7 @@ def no_op():
 def remove_from_path(command):
     curpath = os.getenv("PATH")
     first_it = True
-    while 1:
+    for n in range(200):
         if not first_it:
             with environment_append({"PATH": curpath}):
                 the_command = which(command)
@@ -75,6 +76,11 @@ def remove_from_path(command):
                     new_path.append(entry)
 
         curpath = os.pathsep.join(new_path)
+
+    if n >= 199:
+        raise ConanException("Error in tools.remove_from_path!! couldn't remove the tool %s "
+                             "from the path after 200 attempts, this is a Conan client bug, please open an issue at: "
+                             "https://github.com/conan-io/conan" % command)
 
     with environment_append({"PATH": curpath}):
         yield

--- a/conans/client/tools/env.py
+++ b/conans/client/tools/env.py
@@ -51,16 +51,27 @@ def no_op():
 @contextmanager
 def remove_from_path(command):
     curpath = os.getenv("PATH")
+    first_it = True
     while 1:
-        with environment_append({"PATH": curpath}):
+        if not first_it:
+            with environment_append({"PATH": curpath}):
+                the_command = which(command)
+        else:
             the_command = which(command)
+            first_it = False
+
         if not the_command:
             break
         new_path = []
+        the_command2 = ""
         if "sysnative" in the_command and platform.system() == "Windows":
-            the_command = the_command.replace("sysnative", "system32")
+            the_command2 = the_command.replace("sysnative", "system32")
         for entry in curpath.split(os.pathsep):
-            if entry != os.path.dirname(the_command):
+            if platform.system() == "Windows":
+                entry = entry.lower()
+                the_command = the_command.lower()
+                the_command2 = the_command2.lower()
+            if entry != os.path.dirname(the_command2) and entry != os.path.dirname(the_command):
                 new_path.append(entry)
         curpath = os.pathsep.join(new_path)
 

--- a/conans/test/util/tools_test.py
+++ b/conans/test/util/tools_test.py
@@ -409,7 +409,7 @@ compiler:
             def __init__(self):
                 self.command = ""
                 self.output = namedtuple("output", "info")(lambda x: None)
-                self.env = {}
+                self.env = {"PATH": "/path/to/somewhere"}
 
             def run(self, command, win_bash=False):
                 self.command = command
@@ -423,6 +423,13 @@ compiler:
         with tools.environment_append({"CONAN_BASH_PATH": "path\\to\\mybash.exe"}):
             tools.run_in_windows_bash(conanfile, "a_command.bat", subsystem="cygwin")
             self.assertIn("path\\to\\mybash.exe --login -c", conanfile.command)
+
+        # try to append more env vars
+        conanfile = MockConanfile()
+        tools.run_in_windows_bash(conanfile, "a_command.bat", subsystem="cygwin", env={"PATH": "/other/path",
+                                                                                       "MYVAR": "34"})
+        self.assertIn('^&^& PATH=\\^"/cygdrive/other/path:/cygdrive/path/to/somewhere:$PATH\\^" '
+                      '^&^& MYVAR=34 ^&^& a_command.bat ^', conanfile.command)
 
     def download_retries_test(self):
         out = TestBufferConanOutput()


### PR DESCRIPTION
- [x] Refer to the issue that supports this Pull Request. 

PR in docs, reviewed by Diego: https://github.com/conan-io/docs/pull/452 

- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request. 

The purpose is to be able to inject more environment variables to the Windows subsystem to control in a more direct way the order of the commands in the path, in concrete with Visual Studio, and avoid the need of a visual studio wrapper. Now the way to prioritize Visual is:

```
vs_path = tools.vcvars_dict(self.settings)["PATH"]
tools.run_in_windows_bash(command, env={"PATH": vs_path})

``` 

- [x] I've read the [Contributing guide](https://raw.githubusercontent.com/conan-io/conan/develop/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [x] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. Also adding a description of the changes in the ``changelog.rst`` file. https://github.com/conan-io/docs

https://github.com/conan-io/docs/pull/452


  