### PR TITLE
fix for alias diamond conflict

### DIFF
--- a/conans/test/integration/alias_test.py
+++ b/conans/test/integration/alias_test.py
@@ -6,6 +6,55 @@ import os
 
 class ConanAliasTest(unittest.TestCase):
 
+    def alias_bug_test(self):
+        # https://github.com/conan-io/conan/issues/2252
+        client = TestClient()
+        conanfile = """from conans import ConanFile
+class Pkg(ConanFile):
+    pass
+"""
+        client.save({"conanfile.py": conanfile})
+        client.run("create . Pkg/0.1@user/testing")
+        client.run("alias Pkg/latest@user/testing Pkg/0.1@user/testing")
+        dep_conanfile = """from conans import ConanFile
+class Pkg(ConanFile):
+    requires = "Pkg/latest@user/testing"
+"""
+        client.save({"conanfile.py": dep_conanfile})
+        client.run("create . Pkg1/0.1@user/testing")
+        client.run("create . Pkg2/0.1@user/testing")
+
+        root_conanfile = """from conans import ConanFile
+class Pkg(ConanFile):
+    requires = "Pkg1/0.1@user/testing", "Pkg2/0.1@user/testing"
+"""
+        client.save({"conanfile.py": root_conanfile})
+        client.run("create . PkgRoot/0.1@user/testing")
+        self.assertNotIn("Pkg/latest@user/testing", client.out)
+        self.assertIn("Pkg/0.1@user/testing: Already installed!", client.out)
+        self.assertIn("Pkg1/0.1@user/testing: Already installed!", client.out)
+        self.assertIn("Pkg2/0.1@user/testing: Already installed!", client.out)
+
+    def transitive_alias_test(self):
+        client = TestClient()
+        conanfile = """from conans import ConanFile
+class Pkg(ConanFile):
+    pass
+"""
+        client.save({"conanfile.py": conanfile})
+        client.run("create . Pkg/0.1@user/testing")
+        client.run("alias Pkg/latest@user/testing Pkg/0.1@user/testing")
+        client.run("alias Pkg/superlatest@user/testing Pkg/latest@user/testing")
+        client.run("alias Pkg/megalatest@user/testing Pkg/superlatest@user/testing")
+        dep_conanfile = """from conans import ConanFile
+class Pkg(ConanFile):
+    requires = "Pkg/megalatest@user/testing"
+"""
+        client.save({"conanfile.py": dep_conanfile})
+        client.run("create . Consumer/0.1@user/testing")
+        self.assertIn("Pkg/0.1@user/testing: Already installed!", client.out)
+        self.assertNotIn("latest", client.out)
+
     def repeated_alias_test(self):
         client = TestClient()
         client.run("alias Hello/0.X@lasote/channel Hello/0.1@lasote/channel")


### PR DESCRIPTION
- [x] Refer to the issue that supports this Pull Request.
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've followed the PEP8 style guides for Python code.

Address: https://github.com/conan-io/conan/issues/2252
The issue is due to the conflict detection in the dependency graph calculation when there are diamonds. If there is an alias:
- Pkg/latest => Pkg/0.1
And a diamond:
- LibA => Pkg/latest
- LibB => Pkg/latest
- Consumer => LibA, LibB

The first time the graph is expanded, via LibA, we get Consumer->LibA->Pkg/0.1 (alias substitution).
The second branch checks LibB->Pkg/latest and raises a conflict. As conflicts are raised before actually fetching the dependency by the algorithm, the easiest way to fix it seems to store the resolved aliased references, to check them. 

