### PR TITLE
fixed build_requirements() env

### DIFF
--- a/conans/client/build_requires.py
+++ b/conans/client/build_requires.py
@@ -5,6 +5,7 @@ from collections import OrderedDict
 from conans.client.printer import Printer
 from conans.errors import conanfile_exception_formatter
 from conans.model.ref import ConanFileReference
+from conans.model.conan_file import get_env_context_manager
 
 
 def _apply_build_requires(deps_graph, conanfile, package_build_requires):
@@ -67,8 +68,9 @@ class BuildRequires(object):
     def _get_recipe_build_requires(conanfile):
         conanfile.build_requires = _RecipeBuildRequires(conanfile)
         if hasattr(conanfile, "build_requirements"):
-            with conanfile_exception_formatter(str(conanfile), "build_requirements"):
-                conanfile.build_requirements()
+            with get_env_context_manager(conanfile):
+                with conanfile_exception_formatter(str(conanfile), "build_requirements"):
+                    conanfile.build_requirements()
 
         return conanfile.build_requires
 

--- a/conans/test/integration/same_userchannel_test.py
+++ b/conans/test/integration/same_userchannel_test.py
@@ -68,7 +68,7 @@ class HelloReuseConan(ConanFile):
         error = self.client.run("install .", ignore_error=True)
         self.assertTrue(error)
         self.assertIn("ERROR: Hello/0.1@PROJECT: Error in requirements() method, line 10", self.client.out)
-        self.assertIn("ConanException: CONAN_CHANNEL environment variable not defined, but self.user is used",
+        self.assertIn("ConanException: CONAN_USERNAME environment variable not defined, but self.user is used",
                       self.client.out)
 
         os.environ["CONAN_USERNAME"] = "lasote"


### PR DESCRIPTION
- [x] Refer to the issue that supports this Pull Request.
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://raw.githubusercontent.com/conan-io/conan/develop/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.

https://github.com/conan-io/conan/issues/2254

If ``build_requirements()`` use ``self.user`` and ``self.channel``, it is failing even if the env vars CONAN_USERNAME are defined in the environment, because the environment is not being correctly applied to build_requirements().
