### PR TITLE
Feature/export pkg default source

### DIFF
--- a/conans/client/command.py
+++ b/conans/client/command.py
@@ -598,7 +598,7 @@ class Command(object):
         args = parser.parse_args(*args)
         name, version, user, channel = get_reference_fields(args.reference)
 
-        return self._conan.export_pkg(path=args.path,
+        return self._conan.export_pkg(conanfile_path=args.path,
                                       name=name,
                                       version=version,
                                       source_folder=args.source_folder,

--- a/conans/client/command.py
+++ b/conans/client/command.py
@@ -568,8 +568,9 @@ class Command(object):
                                               ' (Pkg/version@user/channel), if name and version '
                                               ' are not declared in the recipe (conanfile.py)')
         parser.add_argument("-sf", "--source-folder", action=OnceArgument,
-                            help="local folder containing the sources. Defaulted to --build-folder."
-                                 " A relative path to the current dir can also be specified")
+                            help="local folder containing the sources. Defaulted to the directory "
+                                 "of the conanfile. A relative path can also be specified "
+                                 "(relative to the current directory)")
         parser.add_argument("-bf", "--build-folder", action=OnceArgument,
                             help="build folder, working directory of the build process. Defaulted "
                                  "to the current directory. A relative path can also be specified "

--- a/conans/client/conan_api.py
+++ b/conans/client/conan_api.py
@@ -292,7 +292,7 @@ class ConanAPIV1(object):
                                   update=update)
 
     @api_method
-    def export_pkg(self, path, name, channel, source_folder=None, build_folder=None,
+    def export_pkg(self, conanfile_path, name, channel, source_folder=None, build_folder=None,
                    install_folder=None, profile_name=None, settings=None, options=None,
                    env=None, force=False, user=None, version=None, cwd=None):
 
@@ -306,9 +306,10 @@ class ConanAPIV1(object):
             raise ConanException("The specified --install-folder doesn't contain '%s' and '%s' "
                                  "files" % (CONANINFO, BUILD_INFO))
 
+        conanfile_path = _get_conanfile_path(conanfile_path, cwd, py=True)
         build_folder = _make_abs_path(build_folder, cwd)
         install_folder = _make_abs_path(install_folder, cwd, default=build_folder)
-        source_folder = _make_abs_path(source_folder, cwd, default=build_folder)
+        source_folder = _make_abs_path(source_folder, cwd, default=os.path.dirname(conanfile_path))
 
         # Checks that no both settings and info files are specified
         if install_folder and existing_info_files(install_folder) and \
@@ -324,7 +325,6 @@ class ConanAPIV1(object):
         else:
             profile = read_conaninfo_profile(install_folder)
 
-        conanfile_path = _get_conanfile_path(path, cwd, py=True)
         conanfile = load_conanfile_class(conanfile_path)
         if (name and conanfile.name and conanfile.name != name) or \
            (version and conanfile.version and conanfile.version != version):

--- a/conans/test/command/export_pkg_test.py
+++ b/conans/test/command/export_pkg_test.py
@@ -209,38 +209,32 @@ class TestConan(ConanFile):
         self.assertEqual(os.listdir(lib), ["hello.lib"])
         self.assertEqual(load(os.path.join(lib, "hello.lib")), "My Lib")
 
-    def test_no_source_folder(self):
+    def test_default_source_folder(self):
         client = TestClient()
-        conanfile = """
-from conans import ConanFile
+        conanfile = """from conans import ConanFile
 class TestConan(ConanFile):
-    name = "Hello"
-    version = "0.1"
-    settings = "os"
 
     def package(self):
+        self.copy("*.h", src="src", dst="include")
         self.copy("*.lib", dst="lib", keep_path=False)
 """
         client.save({CONANFILE: conanfile,
-                     "rootfile.lib": "contents",
+                     "src/header.h": "contents",
                      "build/lib/hello.lib": "My Lib"})
         client.run("export-pkg . Hello/0.1@lasote/stable -s os=Windows --build-folder=build")
         conan_ref = ConanFileReference.loads("Hello/0.1@lasote/stable")
-        package_ref = PackageReference(conan_ref, "3475bd55b91ae904ac96fde0f106a136ab951a5e")
+        package_ref = PackageReference(conan_ref, "5ab84d6acfe1f23c4fae0ab88f26e3a396351ac9")
         package_folder = client.client_cache.package(package_ref)
-        rootfile_path = os.path.join(package_folder, "lib", "rootfile.lib")
-        self.assertFalse(os.path.exists(rootfile_path))
+        header = os.path.join(package_folder, "include/header.h")
+        self.assertTrue(os.path.exists(header))
 
         hello_path = os.path.join(package_folder, "lib", "hello.lib")
         self.assertTrue(os.path.exists(hello_path))
 
     def test_build_source_folders(self):
         client = TestClient()
-        conanfile = """
-from conans import ConanFile
+        conanfile = """from conans import ConanFile
 class TestConan(ConanFile):
-    name = "Hello"
-    version = "0.1"
     settings = "os"
 
     def package(self):


### PR DESCRIPTION
- [x] Refer to the issue that supports this Pull Request.
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. Also adding a description of the changes in the ``changelog.rst`` file. https://github.com/conan-io/docs

https://github.com/conan-io/conan/issues/2174

The default folders have been changed for ``$ conan export-pkg``, to match exactly the same as ``$ conan build``. In fact the code now for folder is identical in both methods.

Docs updated: https://github.com/conan-io/docs/pull/463


