### PR TITLE
Feature/fix stdout pipe

### DIFF
--- a/conans/client/runner.py
+++ b/conans/client/runner.py
@@ -46,6 +46,9 @@ class ConanRunner(object):
     def _pipe_os_call(self, command, stream_output, log_handler, cwd):
 
         try:
+            # piping both stdout, stderr and then later only reading one will hang the process
+            # if the other fills the pip. So piping stdout, and redirecting stderr to stdour,
+            # so both are merged and use just a single get_stream_lines() call
             proc = Popen(command, shell=True, stdout=PIPE, stderr=STDOUT, cwd=cwd)
         except Exception as e:
             raise ConanException("Error while executing '%s'\n\t%s" % (command, str(e)))

--- a/conans/client/runner.py
+++ b/conans/client/runner.py
@@ -1,6 +1,6 @@
 import os
 import sys
-from subprocess import Popen, PIPE
+from subprocess import Popen, PIPE, STDOUT
 from conans.util.files import decode_text
 from conans.errors import ConanException
 import six
@@ -46,7 +46,7 @@ class ConanRunner(object):
     def _pipe_os_call(self, command, stream_output, log_handler, cwd):
 
         try:
-            proc = Popen(command, shell=True, stdout=PIPE, stderr=PIPE, cwd=cwd)
+            proc = Popen(command, shell=True, stdout=PIPE, stderr=STDOUT, cwd=cwd)
         except Exception as e:
             raise ConanException("Error while executing '%s'\n\t%s" % (command, str(e)))
 
@@ -70,7 +70,7 @@ class ConanRunner(object):
                     log_handler.write(line if six.PY2 else decoded_line)
 
         get_stream_lines(proc.stdout)
-        get_stream_lines(proc.stderr)
+        # get_stream_lines(proc.stderr)
 
         proc.communicate()
         ret = proc.returncode


### PR DESCRIPTION
- [x] Refer to the issue that supports this Pull Request.
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.

https://github.com/conan-io/conan/issues/2267


The underlying problem is that stderr is PIPEing text, but it is only retrieved once the stdout has been processed, so if the PIPE is full, it will block the process. The solution is to redirect stderr to STDOUT instead, so both outputs are handled in the same place.
