### PR TITLE
add option for build target to make

### DIFF
--- a/conans/client/build/autotools_environment.py
+++ b/conans/client/build/autotools_environment.py
@@ -164,12 +164,12 @@ class AutoToolsBuildEnvironment(object):
                                     % (configure_dir, args_to_string(args), " ".join(triplet_args)),
                                     win_bash=self._win_bash)
 
-    def make(self, args="", make_program=None):
+    def make(self, args="", make_program=None, target=None):
         make_program = os.getenv("CONAN_MAKE_PROGRAM") or make_program or "make"
         with environment_append(self.vars):
             str_args = args_to_string(args)
             cpu_count_option = ("-j%s" % cpu_count()) if "-j" not in str_args else None
-            self._conanfile.run("%s" % join_arguments([make_program, str_args, cpu_count_option]),
+            self._conanfile.run("%s" % join_arguments([make_program, target, str_args, cpu_count_option]),
                                 win_bash=self._win_bash)
 
     @property

--- a/conans/test/build_helpers/autotools_configure_test.py
+++ b/conans/test/build_helpers/autotools_configure_test.py
@@ -419,3 +419,15 @@ class HelloConan(ConanFile):
 
         ab.configure(target="i686-apple-darwin")
         self.assertEquals(runner.command_called, "./configure  --target=i686-apple-darwin")
+
+
+    def test_make_targets(self):
+        runner = RunnerMock()
+        conanfile = MockConanfile(MockSettings({}),None,runner)
+        
+        ab = AutoToolsBuildEnvironment(conanfile)
+        ab.configure()
+        
+        ab.make(target="install")
+        self.assertEquals(runner.command_called,"make install -j%s" % cpu_count())        
+


### PR DESCRIPTION
- [ ] Refer to the issue that supports this Pull Request.
- [ ] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [X ] I've read the [Contributing guide](https://raw.githubusercontent.com/conan-io/conan/develop/.github/CONTRIBUTING.md).
- [ ] I've followed the PEP8 style guides for Python code.
- [X ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. Also adding a description of the changes in the ``changelog.rst`` file. https://github.com/conan-io/docs

This adds an option to select the target to the autotools make command. This is very useful e.g. to either do an install "make install" or build shared libraries, in the case where the project creates a separate targets (e.g. "make shared")


  