### PR TITLE
not throw if intel in cmake

### DIFF
--- a/conans/client/generators/cmake_common.py
+++ b/conans/client/generators/cmake_common.py
@@ -381,6 +381,8 @@ function(conan_check_compiler)
         if (CONAN_SETTINGS_COMPILER_TOOLSET MATCHES "LLVM" OR
             CONAN_SETTINGS_COMPILER_TOOLSET MATCHES "clang")
             set(EXPECTED_CMAKE_CXX_COMPILER_ID "Clang")
+        elseif (CONAN_SETTINGS_COMPILER_TOOLSET MATCHES "Intel")
+            set(EXPECTED_CMAKE_CXX_COMPILER_ID "Intel")
         else()
             set(EXPECTED_CMAKE_CXX_COMPILER_ID "MSVC")
         endif()


### PR DESCRIPTION
- [x] Refer to the issue that supports this Pull Request.
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.

https://github.com/conan-io/conan/issues/2310

The check for compiler in ``conanbuildinfo.cmake`` only covers CLang/LLVM as accepted toolsets, so it is raising for Intel.

I have searched for some sensible defaults for Intel toolsets to add to ``settings.yml`` but no clear reference so far, and if any, there are a lot of versions, not sure which of them to add. As they can be added by users, not a big stopper.

Testing might be difficult, without installing the toolsets. CMake will likely complain if it is not in the system before getting to that poing, and it is very difficult to mock.
