### PR TITLE
Feature/search multi remote

### DIFF
--- a/conans/client/command.py
+++ b/conans/client/command.py
@@ -748,7 +748,7 @@ class Command(object):
                             action='store_true', help='Make a case-sensitive search. '
                                                       'Use it to guarantee case-sensitive '
                             'search in Windows or other case-insensitive filesystems')
-        parser.add_argument('-r', '--remote', help='Remote origin', action=OnceArgument)
+        parser.add_argument('-r', '--remote', help='Remote origin. `all` searches all remotes', action=OnceArgument)
         parser.add_argument('--raw', default=False, action='store_true',
                             help='Print just the list of recipes')
         parser.add_argument('--table', action=OnceArgument,

--- a/conans/client/manager.py
+++ b/conans/client/manager.py
@@ -492,7 +492,19 @@ class ConanManager(object):
 
         return adapter
 
+    def search_recipes_all(self, pattern, ignorecase):
+        reg = RemoteRegistry(self._client_cache.registry, self._user_io.out)
+        references = {}
+        for remote in reg.remotes:
+            remote_proxy = ConanProxy(self._client_cache, self._user_io, self._remote_manager, remote.name)
+            result = remote_proxy.search(pattern, ignorecase)
+            if result:
+                references[remote.name] = result
+        return references
+
     def search_recipes(self, pattern, remote, ignorecase):
+        if remote == 'all':
+            return self.search_recipes_all(pattern, ignorecase)
         references = self._get_search_adapter(remote).search(pattern, ignorecase)
         return references
 

--- a/conans/client/printer.py
+++ b/conans/client/printer.py
@@ -181,12 +181,12 @@ class Printer(object):
             self._out.info("Existing package recipes:\n")
             if isinstance(references, dict):
                 for remote, refs in references.items():
-                    self._print_colored_line("Remote '%s':" % str(remote), indent=0)
+                    self._out.highlight("Remote '%s':" % str(remote))
                     for conan_ref in sorted(refs):
-                        self._print_colored_line(str(conan_ref), indent=1)
-                return
-            for conan_ref in sorted(references):
-                self._print_colored_line(str(conan_ref), indent=0)
+                        self._print_colored_line(str(conan_ref), indent=0)
+            else:
+                for conan_ref in sorted(references):
+                    self._print_colored_line(str(conan_ref), indent=0)
         else:
             self._out.writeln("\n".join([str(ref) for ref in references]))
 

--- a/conans/client/printer.py
+++ b/conans/client/printer.py
@@ -179,6 +179,12 @@ class Printer(object):
 
         if not raw:
             self._out.info("Existing package recipes:\n")
+            if isinstance(references, dict):
+                for remote, refs in references.items():
+                    self._print_colored_line("Remote '%s':" % str(remote), indent=0)
+                    for conan_ref in sorted(refs):
+                        self._print_colored_line(str(conan_ref), indent=1)
+                return
             for conan_ref in sorted(references):
                 self._print_colored_line(str(conan_ref), indent=0)
         else:

--- a/conans/test/command/search_test.py
+++ b/conans/test/command/search_test.py
@@ -139,6 +139,20 @@ class SearchTest(unittest.TestCase):
                           },
                          self.client.paths.store)
 
+    def recipe_search_all_test(self):
+        os.rmdir(self.servers["local"].paths.store)
+        shutil.copytree(self.client.paths.store, self.servers["local"].paths.store)
+        os.rmdir(self.servers["search_able"].paths.store)
+        shutil.copytree(self.client.paths.store, self.servers["search_able"].paths.store)
+        self.client.run("search Hello* -r=all")
+        for remote in ("local", "search_able"):
+            expected = """Remote '{}':
+Hello/1.4.10@fenix/testing
+Hello/1.4.11@fenix/testing
+Hello/1.4.12@fenix/testing
+helloTest/1.4.10@fenix/stable""".format(remote)
+            self.assertIn(expected, self.client.out)
+
     def recipe_search_test(self):
         self.client.run("search Hello*")
         self.assertEquals("Existing package recipes:\n\n"


### PR DESCRIPTION
To complement: https://github.com/conan-io/conan/pull/2138 with a test and a minor style change

The issue is: https://github.com/conan-io/conan/issues/2161

This PR shouldn't be squashed to maintain credit of @kaidokert commits.


- I have not implemented searching in different remotes like ``-r=remote1 -r=remote2``. The command can be just repeated changing the remote name
- I have kept ``-r=all`` as the pattern to fire this behavior, though if in the very rare event that someone called their remote "all" it would break. I don't think this can happen.
