### PR TITLE
strawman skeleton for implementing export / install linters

### DIFF
--- a/conans/client/cmd/export.py
+++ b/conans/client/cmd/export.py
@@ -16,7 +16,7 @@ from conans.model.conan_file import create_exports, create_exports_sources
 from conans.client.loader_parse import load_conanfile_class
 from conans.client.cmd.export_linter import conan_linter
 from conans.model.ref import ConanFileReference
-
+from conans.client.linters.linters_base import global_registered_linters
 
 def cmd_export(conanfile_path, name, version, user, channel, keep_source,
                output, search_manager, client_cache):
@@ -30,6 +30,17 @@ def cmd_export(conanfile_path, name, version, user, channel, keep_source,
 
     conan_linter(conanfile_path, output)
     conanfile = _load_export_conanfile(conanfile_path, output, name, version)
+    #run requested linters
+    for linter in conanfile.export_linters:
+        if linter not in global_registered_linters["export"]:
+            output.error("no export linter named %s found" % linter)
+        
+        output.highlight("running linter: %s" % linter)
+        lt_instance = global_registered_linters["export"][linter](conanfile,output)
+        lt_instance.do_check()
+            
+    
+    
     conan_ref = ConanFileReference(conanfile.name, conanfile.version, user, channel)
     conan_ref_str = str(conan_ref)
     # Maybe a platform check could be added, but depends on disk partition

--- a/conans/client/linters/__init__.py
+++ b/conans/client/linters/__init__.py
@@ -1,0 +1,3 @@
+# -*- coding: utf-8 -*-
+
+from .check_spdx_license import CheckSPDXLicense

--- a/conans/client/linters/check_spdx_license.py
+++ b/conans/client/linters/check_spdx_license.py
@@ -1,0 +1,31 @@
+# -*- coding: utf-8 -*-
+from conans.client.linters.linters_base import ExportLinterBase
+import spdx_lookup
+import glob
+import os
+
+
+
+
+class CheckSPDXLicense(ExportLinterBase):
+    linter_name = "check_spdx_license"
+    
+    def do_check(self):
+        return self._check_license_id(self._conanfile.license)
+        
+    
+    def _check_license_id(self,lic):
+        match = spdx_lookup.by_id(lic)
+        if match is None:
+            self._output.error('License string: "%s" was not matched with a valid SPDX code!'
+                               % lic)
+            return False
+        else:
+            self._output.success("matched license id: %s" % lic)
+            self._output.info("license name: %s" % match.name)
+            self._output.info("OSI approved? %s" % str(match.osi_approved))
+            
+            return True
+    
+        
+        

--- a/conans/client/linters/linters_base.py
+++ b/conans/client/linters/linters_base.py
@@ -1,0 +1,35 @@
+# -*- coding: utf-8 -*-
+from six import with_metaclass
+
+
+global_registered_linters = {}
+
+class RegisterLintersMeta(type):
+    def __init__(cls, name, bases, dct):
+        
+        if not hasattr(cls,"category") and name != "LinterBase":
+            raise TypeError("linter has no category!")
+            
+        if hasattr(cls,"category") and cls.category not in global_registered_linters:
+            global_registered_linters[cls.category] = {}
+        
+        
+        if hasattr(cls,"linter_name"):
+            ln = cls.linter_name
+            if ln not in global_registered_linters[cls.category]:
+                global_registered_linters[cls.category][ln] = cls
+        
+        super(RegisterLintersMeta,cls).__init__(name,bases,dct)
+    
+    
+class LinterBase(with_metaclass(RegisterLintersMeta,object)):
+    def __init__(self,conanfile,output):
+        self._conanfile = conanfile
+        self._output = output
+    
+    
+class ExportLinterBase(LinterBase):
+    category = "export"
+
+class InstallLinterBase(LinterBase):
+    category = "install"

--- a/conans/model/conan_file.py
+++ b/conans/model/conan_file.py
@@ -78,6 +78,28 @@ def create_exports_sources(conanfile):
         return conanfile.exports_sources
 
 
+def create_export_linters(conanfile):
+    if not hasattr(conanfile, "export_linters"):
+        []
+    
+    else:
+        if isinstance(conanfile.export_linters, str):
+            return (conanfile.export_linters, )
+        return conanfile.export_linters
+        
+def create_install_linters(conanfile):
+    if not hasattr(conanfile, "install_linters"):
+        []
+    
+    else:
+        if isinstance(conanfile.install_linters, str):
+            return (conanfile.install_linters, )
+        return conanfile.install_linters
+        
+    
+
+
+
 def get_env_context_manager(conanfile):
     return environment_append(conanfile.env) if conanfile.apply_env else no_op()
 
@@ -153,6 +175,13 @@ class ConanFile(object):
 
         # Init a description
         self.description = None
+        
+        #export linters
+        self.export_linters = create_export_linters(self)
+        
+        #import linters
+        self.install_linters = create_install_linters(self)
+        
 
     @property
     def env(self):

--- a/conans/requirements.txt
+++ b/conans/requirements.txt
@@ -11,3 +11,4 @@ pylint>=1.8.1, <1.9.0
 future==0.16.0
 pygments>=2.0, <3.0
 astroid>=1.6, <1.7
+spdx-lookup>=0.3.2


### PR DESCRIPTION
- [x] Refer to the issue that supports this Pull Request.
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://raw.githubusercontent.com/conan-io/conan/develop/.github/CONTRIBUTING.md).
- [ ] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. Also adding a description of the changes in the ``changelog.rst`` file. https://github.com/conan-io/docs

This is related to the discussion in https://github.com/conan-io/conan/issues/2342
Here is one possible fairly unintrusive way of allowing export linters to be implemented. I have included only one actual linter, which does a very simple spdx license check. 

Checks I feel that might be done this way reasonably robustly and usefully:
- check that all specified libraries mentioned in cpp_info are actually present
- check that shared libraries have no dynamic dependencies outside conan packages, apart from base system libraries (this is easy at least on linux & OSX)
- check whether libraries have been stripped in debug mode
- check whether a copy of the license is present (as required by e.g. GPL)
- check whether text/resource files contain absolute paths


