### PR TITLE
not skipping build if build_id() does not affect

### DIFF
--- a/conans/client/installer.py
+++ b/conans/client/installer.py
@@ -52,7 +52,8 @@ class _ConanPackageBuilder(object):
                                                      self._conan_file.short_paths)
 
     def prepare_build(self):
-        if os.path.exists(self.build_folder) and hasattr(self._conan_file, "build_id"):
+        if self.build_reference != self._package_reference and \
+              os.path.exists(self.build_folder) and hasattr(self._conan_file, "build_id"):
             self._skip_build = True
             return
 

--- a/conans/test/integration/build_id_test.py
+++ b/conans/test/integration/build_id_test.py
@@ -13,11 +13,12 @@ from conans.util.files import save
 class MyTest(ConanFile):
     name = "Pkg"
     version = "0.1"
-    settings = "build_type"
+    settings = "os", "build_type"
     build_policy = "missing"
 
     def build_id(self):
-        self.info_build.settings.build_type = "Any"
+        if self.settings.os == "Windows":
+            self.info_build.settings.build_type = "Any"
 
     def build(self):
         self.output.info("Building my code!")
@@ -44,7 +45,7 @@ consumer_py = """from conans import ConanFile
 class MyTest(ConanFile):
     name = "MyTest"
     version = "0.1"
-    settings = "build_type"
+    settings = "os", "build_type"
     requires = "Pkg/0.1@user/channel"
 
     def build_id(self):
@@ -60,14 +61,30 @@ class BuildIdTest(unittest.TestCase):
     def _check_conaninfo(self, client):
         # Check that conaninfo is correct
         ref_debug = PackageReference.loads("Pkg/0.1@user/channel:"
-                                           "5a67a79dbc25fd0fa149a0eb7a20715189a0d988")
+                                           "f3989dcba0ab50dc5ed9b40ede202bdd7b421f09")
         conaninfo = load(os.path.join(client.client_cache.package(ref_debug), "conaninfo.txt"))
+        self.assertIn("os=Windows", conaninfo)
         self.assertIn("build_type=Debug", conaninfo)
         self.assertNotIn("Release", conaninfo)
 
         ref_release = PackageReference.loads("Pkg/0.1@user/channel:"
-                                             "4024617540c4f240a6a5e8911b0de9ef38a11a72")
+                                             "ab2e9f86b4109980930cdc685f4a320b359e7bb4")
         conaninfo = load(os.path.join(client.client_cache.package(ref_release), "conaninfo.txt"))
+        self.assertIn("os=Windows", conaninfo)
+        self.assertIn("build_type=Release", conaninfo)
+        self.assertNotIn("Debug", conaninfo)
+
+        ref_debug = PackageReference.loads("Pkg/0.1@user/channel:"
+                                           "322de4b4a41f905f6b18f454ab5f498690b39c2a")
+        conaninfo = load(os.path.join(client.client_cache.package(ref_debug), "conaninfo.txt"))
+        self.assertIn("os=Linux", conaninfo)
+        self.assertIn("build_type=Debug", conaninfo)
+        self.assertNotIn("Release", conaninfo)
+
+        ref_release = PackageReference.loads("Pkg/0.1@user/channel:"
+                                             "24c3aa2d6c5929d53bd86b31e020c55d96b265c7")
+        conaninfo = load(os.path.join(client.client_cache.package(ref_release), "conaninfo.txt"))
+        self.assertIn("os=Linux", conaninfo)
         self.assertIn("build_type=Release", conaninfo)
         self.assertNotIn("Debug", conaninfo)
 
@@ -76,12 +93,20 @@ class BuildIdTest(unittest.TestCase):
         """
         client = TestClient()
         client.save({"conanfile.py": conanfile})
-        client.run("create . user/channel")
+        client.run("create . user/channel -s os=Windows -s build_type=Release")
         self.assertIn("Pkg/0.1@user/channel: Calling build()", client.out)
         self.assertIn("Building my code!", client.user_io.out)
         self.assertIn("Packaging Release!", client.user_io.out)
-        client.run("create . user/channel -s build_type=Debug")
+        client.run("create . user/channel -s os=Windows -s build_type=Debug")
         self.assertNotIn("Pkg/0.1@user/channel: Calling build()", client.out)
+        self.assertIn("Packaging Debug!", client.user_io.out)
+
+        client.run("create . user/channel -s os=Linux -s build_type=Release")
+        self.assertIn("Pkg/0.1@user/channel: Calling build()", client.out)
+        self.assertIn("Building my code!", client.user_io.out)
+        self.assertIn("Packaging Release!", client.user_io.out)
+        client.run("create . user/channel -s os=Linux -s build_type=Debug")
+        self.assertIn("Pkg/0.1@user/channel: Calling build()", client.out)
         self.assertIn("Packaging Debug!", client.user_io.out)
         self._check_conaninfo(client)
 
@@ -95,15 +120,28 @@ class BuildIdTest(unittest.TestCase):
             client.save({"conanfile.py": consumer_py}, clean_first=True)
         else:
             client.save({"conanfile.txt": consumer}, clean_first=True)
-        client.run('install . -s build_type=Debug')
+        client.run('install . -s os=Windows -s build_type=Debug')
         self.assertIn("Building package from source as defined by build_policy='missing'",
                       client.user_io.out)
         self.assertIn("Building my code!", client.user_io.out)
         self.assertIn("Packaging Debug!", client.user_io.out)
         content = load(os.path.join(client.current_folder, "file1.txt"))
         self.assertEqual("Debug file1", content)
-        client.run('install . -s build_type=Release')
+        client.run('install . -s os=Windows -s build_type=Release')
         self.assertNotIn("Building my code!", client.user_io.out)
+        self.assertIn("Packaging Release!", client.user_io.out)
+        content = load(os.path.join(client.current_folder, "file1.txt"))
+        self.assertEqual("Release file1", content)
+        # Now Linux
+        client.run('install . -s os=Linux -s build_type=Debug')
+        self.assertIn("Building package from source as defined by build_policy='missing'",
+                      client.user_io.out)
+        self.assertIn("Building my code!", client.user_io.out)
+        self.assertIn("Packaging Debug!", client.user_io.out)
+        content = load(os.path.join(client.current_folder, "file1.txt"))
+        self.assertEqual("Debug file1", content)
+        client.run('install . -s os=Linux -s build_type=Release')
+        self.assertIn("Building my code!", client.user_io.out)
         self.assertIn("Packaging Release!", client.user_io.out)
         content = load(os.path.join(client.current_folder, "file1.txt"))
         self.assertEqual("Release file1", content)
@@ -111,13 +149,26 @@ class BuildIdTest(unittest.TestCase):
 
         # Check that repackaging works, not necessary to re-build
         client.run("remove Pkg/0.1@user/channel -p -f")
-        client.run('install . -s build_type=Debug')
+        client.run('install . -s os=Windows -s build_type=Debug')
         self.assertNotIn("Building my code!", client.user_io.out)
         self.assertIn("Packaging Debug!", client.user_io.out)
         content = load(os.path.join(client.current_folder, "file1.txt"))
         self.assertEqual("Debug file1", content)
-        client.run('install . -s build_type=Release')
+        client.run('install . -s os=Windows -s build_type=Release')
         self.assertNotIn("Building my code!", client.user_io.out)
+        self.assertIn("Packaging Release!", client.user_io.out)
+        content = load(os.path.join(client.current_folder, "file1.txt"))
+        self.assertEqual("Release file1", content)
+        # Now Linux
+        client.run('install . -s os=Linux -s build_type=Debug')
+        self.assertIn("Building package from source as defined by build_policy='missing'",
+                      client.user_io.out)
+        self.assertIn("Building my code!", client.user_io.out)
+        self.assertIn("Packaging Debug!", client.user_io.out)
+        content = load(os.path.join(client.current_folder, "file1.txt"))
+        self.assertEqual("Debug file1", content)
+        client.run('install . -s os=Linux -s build_type=Release')
+        self.assertIn("Building my code!", client.user_io.out)
         self.assertIn("Packaging Release!", client.user_io.out)
         content = load(os.path.join(client.current_folder, "file1.txt"))
         self.assertEqual("Release file1", content)
@@ -125,12 +176,23 @@ class BuildIdTest(unittest.TestCase):
 
         # But if the build folder is removed, the packages are there, do nothing
         client.run("remove Pkg/0.1@user/channel -b -f")
-        client.run('install . -s build_type=Debug')
+        client.run('install . -s os=Windows -s build_type=Debug')
         self.assertNotIn("Building my code!", client.user_io.out)
         self.assertNotIn("Packaging Debug!", client.user_io.out)
         content = load(os.path.join(client.current_folder, "file1.txt"))
         self.assertEqual("Debug file1", content)
-        client.run('install . -s build_type=Release')
+        client.run('install . -s os=Windows -s build_type=Release')
+        self.assertNotIn("Building my code!", client.user_io.out)
+        self.assertNotIn("Packaging Release!", client.user_io.out)
+        content = load(os.path.join(client.current_folder, "file1.txt"))
+        self.assertEqual("Release file1", content)
+        # Now Linux
+        client.run('install . -s os=Linux -s build_type=Debug')
+        self.assertNotIn("Building my code!", client.user_io.out)
+        self.assertNotIn("Packaging Debug!", client.user_io.out)
+        content = load(os.path.join(client.current_folder, "file1.txt"))
+        self.assertEqual("Debug file1", content)
+        client.run('install . -s os=Linux -s build_type=Release')
         self.assertNotIn("Building my code!", client.user_io.out)
         self.assertNotIn("Packaging Release!", client.user_io.out)
         content = load(os.path.join(client.current_folder, "file1.txt"))
@@ -140,10 +202,8 @@ class BuildIdTest(unittest.TestCase):
     def remove_specific_builds_test(self):
         client = TestClient()
         client.save({"conanfile.py": conanfile})
-        client.run("export . user/channel")
-        client.save({"conanfile.txt": consumer}, clean_first=True)
-        client.run('install . -s build_type=Debug')
-        client.run('install . -s build_type=Release')
+        client.run('create . user/channel -s os=Windows -s build_type=Debug')
+        client.run('create . user/channel -s os=Windows -s build_type=Release')
         ref = ConanFileReference.loads("Pkg/0.1@user/channel")
 
         def _check_builds():
@@ -172,14 +232,13 @@ class BuildIdTest(unittest.TestCase):
             client.save({"conanfile.py": consumer_py}, clean_first=True)
         else:
             client.save({"conanfile.txt": consumer}, clean_first=True)
-        client.run('install . -s build_type=Debug')
-        client.run('install . -s build_type=Release')
+        client.run('install . -s os=Windows -s build_type=Debug')
+        client.run('install . -s os=Windows -s build_type=Release')
         client.run("info .")  # Uses release
 
         def _check():
-            build_ids = str(client.user_io.out).count("BuildID:"
-                                                      " 18b7fe8d22ef48b0476252ca1a28aed3812fe609")
-            build_nones = str(client.user_io.out).count("BuildID: None")
+            build_ids = str(client.out).count("BuildID: 427f426a482a2b22a1744e9e949aa7f2544f5b7c")
+            build_nones = str(client.out).count("BuildID: None")
             if python_consumer:
                 self.assertEqual(2, build_ids)
                 self.assertEqual(0, build_nones)
@@ -188,21 +247,21 @@ class BuildIdTest(unittest.TestCase):
                 self.assertEqual(1, build_nones)
 
         _check()
-        self.assertIn("ID: 4024617540c4f240a6a5e8911b0de9ef38a11a72", client.user_io.out)
-        self.assertNotIn("ID: 5a67a79dbc25fd0fa149a0eb7a20715189a0d988", client.user_io.out)
+        self.assertIn("ID: ab2e9f86b4109980930cdc685f4a320b359e7bb4", client.out)
+        self.assertNotIn("ID: f3989dcba0ab50dc5ed9b40ede202bdd7b421f09", client.out)
 
-        client.run("info . -s build_type=Debug")
+        client.run("info . -s os=Windows -s build_type=Debug")
         _check()
-        self.assertNotIn("ID: 4024617540c4f240a6a5e8911b0de9ef38a11a72", client.user_io.out)
-        self.assertIn("ID: 5a67a79dbc25fd0fa149a0eb7a20715189a0d988", client.user_io.out)
+        self.assertNotIn("ID: 4024617540c4f240a6a5e8911b0de9ef38a11a72", client.out)
+        self.assertIn("ID: f3989dcba0ab50dc5ed9b40ede202bdd7b421f09", client.out)
 
         if python_consumer:
             client.run("export . user/channel")
             client.run("info MyTest/0.1@user/channel -s build_type=Debug")
             _check()
-            self.assertNotIn("ID: 4024617540c4f240a6a5e8911b0de9ef38a11a72", client.user_io.out)
-            self.assertIn("ID: 5a67a79dbc25fd0fa149a0eb7a20715189a0d988", client.user_io.out)
+            self.assertNotIn("ID: ab2e9f86b4109980930cdc685f4a320b359e7bb4", client.out)
+            self.assertIn("ID: f3989dcba0ab50dc5ed9b40ede202bdd7b421f09", client.out)
             client.run("info MyTest/0.1@user/channel -s build_type=Release")
             _check()
-            self.assertIn("ID: 4024617540c4f240a6a5e8911b0de9ef38a11a72", client.user_io.out)
-            self.assertNotIn("ID: 5a67a79dbc25fd0fa149a0eb7a20715189a0d988", client.user_io.out)
+            self.assertIn("ID: ab2e9f86b4109980930cdc685f4a320b359e7bb4", client.out)
+            self.assertNotIn("ID: f3989dcba0ab50dc5ed9b40ede202bdd7b421f09", client.out)

--- a/conans/test/integration/build_id_test.py
+++ b/conans/test/integration/build_id_test.py
@@ -257,11 +257,11 @@ class BuildIdTest(unittest.TestCase):
 
         if python_consumer:
             client.run("export . user/channel")
-            client.run("info MyTest/0.1@user/channel -s build_type=Debug")
+            client.run("info MyTest/0.1@user/channel -s os=Windows -s build_type=Debug")
             _check()
             self.assertNotIn("ID: ab2e9f86b4109980930cdc685f4a320b359e7bb4", client.out)
             self.assertIn("ID: f3989dcba0ab50dc5ed9b40ede202bdd7b421f09", client.out)
-            client.run("info MyTest/0.1@user/channel -s build_type=Release")
+            client.run("info MyTest/0.1@user/channel -s os=Windows -s build_type=Release")
             _check()
             self.assertIn("ID: ab2e9f86b4109980930cdc685f4a320b359e7bb4", client.out)
             self.assertNotIn("ID: f3989dcba0ab50dc5ed9b40ede202bdd7b421f09", client.out)


### PR DESCRIPTION
- [x] Refer to the issue that supports this Pull Request.
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. Also adding a description of the changes in the ``changelog.rst`` file. https://github.com/conan-io/docs

https://github.com/conan-io/conan/issues/2225

Docs: https://github.com/conan-io/docs/pull/500

I have been reviewing the usage, and it seems there is an easy solution: if the build_id (or ``build_reference`` in code) is the same as the ``package_reference``, then it can be assumed that the ``build_id()`` method did not have any effect, and then the normal behavior could be used