### PR TITLE
Feature/alternative fix 2368

### DIFF
--- a/conans/client/manager.py
+++ b/conans/client/manager.py
@@ -119,8 +119,8 @@ class ConanManager(object):
             conanfile = loader.load_conan(conanfile_path, output, consumer=True, local=True)
         else:
             conanfile = loader.load_conan_txt(conanfile_path, output)
-        if deps_info_required is not None:
-            _load_deps_info(info_folder, conanfile, required=deps_info_required)
+
+        _load_deps_info(info_folder, conanfile, required=deps_info_required)
 
         return conanfile
 

--- a/conans/model/conan_file.py
+++ b/conans/model/conan_file.py
@@ -54,7 +54,7 @@ def create_settings(conanfile, settings, local):
         if isinstance(defined_settings, str):
             defined_settings = [defined_settings]
         current = defined_settings or {}
-        settings.constraint(current, raise_missing_value=not local)
+        settings.constraint(current, raise_undefined_field=not local)
         return settings
     except Exception as e:
         raise ConanException("Error while initializing settings. %s" % str(e))

--- a/conans/model/conan_file.py
+++ b/conans/model/conan_file.py
@@ -48,13 +48,13 @@ def create_requirements(conanfile):
         raise ConanException("Error while initializing requirements. %s" % str(e))
 
 
-def create_settings(conanfile, settings):
+def create_settings(conanfile, settings, local):
     try:
         defined_settings = getattr(conanfile, "settings", None)
         if isinstance(defined_settings, str):
             defined_settings = [defined_settings]
         current = defined_settings or {}
-        settings.constraint(current)
+        settings.constraint(current, raise_missing_value=not local)
         return settings
     except Exception as e:
         raise ConanException("Error while initializing settings. %s" % str(e))
@@ -106,7 +106,7 @@ class ConanFile(object):
         # User defined options
         self.options = create_options(self)
         self.requires = create_requirements(self)
-        self.settings = create_settings(self, settings) if not local else settings
+        self.settings = create_settings(self, settings, local)
         try:
             if self.settings.os_build and self.settings.os:
                 output.writeln("*"*60, front=Color.BRIGHT_RED)

--- a/conans/model/settings.py
+++ b/conans/model/settings.py
@@ -315,11 +315,18 @@ class Settings(object):
         assert isinstance(vals, Values)
         self.values_list = vals.as_list()
 
-    def constraint(self, constraint_def):
+    def constraint(self, constraint_def, raise_missing_value=True):
         """ allows to restrict a given Settings object with the input of another Settings object
         1. The other Settings object MUST be exclusively a subset of the former.
            No additions allowed
         2. If the other defines {"compiler": None} means to keep the full specification
+
+        :param raise_missing_value:
+
+                When True: will raise when a value for a declared setting is not defined
+                When False: will remove the setting if it has not a value for it
+                            (local methods reading from a conaninfo.txt with already removed settings)
+
         """
         if isinstance(constraint_def, (list, tuple, set)):
             constraint_def = {str(k): None for k in constraint_def or []}
@@ -355,7 +362,10 @@ class Settings(object):
         # Sanity check for input constraint wrong fields
         for field in constraint_def:
             if field not in self._data:
-                raise undefined_field(self._name, field, self.fields)
+                if raise_missing_value:
+                    raise undefined_field(self._name, field, self.fields)
+                else:
+                    fields_to_remove.append(field)
 
         # remove settings not defined in the constraint
         self.remove(fields_to_remove)

--- a/conans/model/settings.py
+++ b/conans/model/settings.py
@@ -315,7 +315,7 @@ class Settings(object):
         assert isinstance(vals, Values)
         self.values_list = vals.as_list()
 
-    def constraint(self, constraint_def, raise_missing_value=True):
+    def constraint(self, constraint_def, raise_undefined_field=True):
         """ allows to restrict a given Settings object with the input of another Settings object
         1. The other Settings object MUST be exclusively a subset of the former.
            No additions allowed
@@ -360,12 +360,10 @@ class Settings(object):
             config_item.remove(values_to_remove)
 
         # Sanity check for input constraint wrong fields
-        for field in constraint_def:
-            if field not in self._data:
-                if raise_missing_value:
+        if raise_undefined_field:
+            for field in constraint_def:
+                if field not in self._data:
                     raise undefined_field(self._name, field, self.fields)
-                else:
-                    fields_to_remove.append(field)
 
         # remove settings not defined in the constraint
         self.remove(fields_to_remove)

--- a/conans/test/command/source_test.py
+++ b/conans/test/command/source_test.py
@@ -1,5 +1,4 @@
 import unittest
-from conans.errors import ConanException
 from conans.paths import CONANFILE, BUILD_INFO
 from conans.test.utils.tools import TestClient
 from conans.util.files import load, mkdir
@@ -7,6 +6,17 @@ import os
 
 
 class SourceTest(unittest.TestCase):
+
+    def source_warning_os_build_test(self):
+        # https://github.com/conan-io/conan/issues/2368
+        conanfile = '''from conans import ConanFile
+class ConanLib(ConanFile):
+    pass
+'''
+        client = TestClient()
+        client.save({CONANFILE: conanfile})
+        client.run("source .")
+        self.assertNotIn("This package defines both 'os' and 'os_build'", client.out)
 
     def source_reference_test(self):
         client = TestClient()
@@ -122,7 +132,7 @@ class ConanLib(ConanFile):
         self.output.info("MYVAR=%s" % self.deps_env_info["Hello"].MYVAR)
         self.output.info("OTHERVAR=%s" % self.deps_user_info["Hello"].OTHERVAR)
         self.output.info("CURDIR=%s" % os.getcwd())
-        
+
 '''
         # First, failing source()
         client.save({CONANFILE: conanfile}, clean_first=True)

--- a/conans/test/generators/cmake_test.py
+++ b/conans/test/generators/cmake_test.py
@@ -44,7 +44,7 @@ class CMakeGeneratorTest(unittest.TestCase):
 
     def variables_cmake_multi_user_vars_test(self):
         settings_mock = namedtuple("Settings", "build_type, os, os_build, constraint")
-        conanfile = ConanFile(None, None, settings_mock("Release", None, None, lambda x: x), None)
+        conanfile = ConanFile(None, None, settings_mock("Release", None, None, lambda x, raise_missing_value: x), None)
         conanfile.deps_user_info["LIB1"].myvar = "myvalue"
         conanfile.deps_user_info["LIB1"].myvar2 = "myvalue2"
         conanfile.deps_user_info["lib2"].MYVAR2 = "myvalue4"
@@ -57,7 +57,7 @@ class CMakeGeneratorTest(unittest.TestCase):
 
     def variables_cmake_multi_user_vars_escape_test(self):
         settings_mock = namedtuple("Settings", "build_type, os, os_build, constraint")
-        conanfile = ConanFile(None, None, settings_mock("Release", None, None, lambda x: x), None)
+        conanfile = ConanFile(None, None, settings_mock("Release", None, None, lambda x, raise_missing_value: x), None)
         conanfile.deps_user_info["FOO"].myvar = 'my"value"'
         conanfile.deps_user_info["FOO"].myvar2 = 'my${value}'
         conanfile.deps_user_info["FOO"].myvar3 = 'my\\value'

--- a/conans/test/generators/cmake_test.py
+++ b/conans/test/generators/cmake_test.py
@@ -44,7 +44,7 @@ class CMakeGeneratorTest(unittest.TestCase):
 
     def variables_cmake_multi_user_vars_test(self):
         settings_mock = namedtuple("Settings", "build_type, os, os_build, constraint")
-        conanfile = ConanFile(None, None, settings_mock("Release", None, None, lambda x, raise_missing_value: x), None)
+        conanfile = ConanFile(None, None, settings_mock("Release", None, None, lambda x, raise_undefined_field: x), None)
         conanfile.deps_user_info["LIB1"].myvar = "myvalue"
         conanfile.deps_user_info["LIB1"].myvar2 = "myvalue2"
         conanfile.deps_user_info["lib2"].MYVAR2 = "myvalue4"
@@ -57,7 +57,7 @@ class CMakeGeneratorTest(unittest.TestCase):
 
     def variables_cmake_multi_user_vars_escape_test(self):
         settings_mock = namedtuple("Settings", "build_type, os, os_build, constraint")
-        conanfile = ConanFile(None, None, settings_mock("Release", None, None, lambda x, raise_missing_value: x), None)
+        conanfile = ConanFile(None, None, settings_mock("Release", None, None, lambda x, raise_undefined_field: x), None)
         conanfile.deps_user_info["FOO"].myvar = 'my"value"'
         conanfile.deps_user_info["FOO"].myvar2 = 'my${value}'
         conanfile.deps_user_info["FOO"].myvar3 = 'my\\value'

--- a/conans/test/remove_subsetting_test.py
+++ b/conans/test/remove_subsetting_test.py
@@ -31,14 +31,22 @@ class Pkg(ConanFile):
     settings = "os", "build_type"
     def configure(self):
         del self.settings.build_type
+
+    def source(self):
+        self.settings.build_type
 """
         client.save({"conanfile.py": conanfile})
         build_folder = os.path.join(client.current_folder, "build")
         mkdir(build_folder)
         client.current_folder = build_folder
+        client.run("source ..")  # Without install you can access build_type, no one has removed it
         client.run("install ..")
         # This raised an error because build_type wasn't defined
         client.run("build ..")
+
+        error = client.run("source ..", ignore_error=True)
+        self.assertTrue(error)
+        self.assertIn("'settings.build_type' doesn't exist", client.user_io.out)
 
     def remove_runtime_test(self):
         # https://github.com/conan-io/conan/issues/2327


### PR DESCRIPTION
- [x] Refer to the issue that supports this Pull Request. #2368
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.

This implementation is more solid because it doesn't inject more settings than the declared in the recipe, so the problem of `os_build` is gone. If the read settings from the conaninfo have missing values has to be because the configure removed it, so the setting is removed automatically because of the missing value.

Cheery picked test from your branch and removed `if deps_info_required is not None:`