### PR TITLE
Add build_requires support for conanfile.txt loader

### DIFF
--- a/conans/client/loader.py
+++ b/conans/client/loader.py
@@ -95,6 +95,11 @@ class ConanFileLoader(object):
         for requirement_text in parser.requirements:
             ConanFileReference.loads(requirement_text)  # Raise if invalid
             conanfile.requires.add(requirement_text)
+        for build_requirement_text in parser.build_requirements:
+            ConanFileReference.loads(build_requirement_text)
+            if not hasattr(conanfile, "build_requires"):
+                conanfile.build_requires = []
+            conanfile.build_requires.append(build_requirement_text)
 
         conanfile.generators = parser.generators
 

--- a/conans/client/loader.py
+++ b/conans/client/loader.py
@@ -97,9 +97,7 @@ class ConanFileLoader(object):
             conanfile.requires.add(requirement_text)
         for build_requirement_text in parser.build_requirements:
             ConanFileReference.loads(build_requirement_text)
-            if not hasattr(conanfile, "build_requires"):
-                conanfile.build_requires = []
-            conanfile.build_requires.append(build_requirement_text)
+            conanfile.build_requires.add(build_requirement_text)
 
         conanfile.generators = parser.generators
 

--- a/conans/client/loader.py
+++ b/conans/client/loader.py
@@ -8,6 +8,7 @@ from conans.model.options import OptionsValues
 from conans.model.ref import ConanFileReference
 from conans.model.settings import Settings
 from conans.model.values import Values
+from conans.model.requires import Requirements
 from conans.util.files import load
 
 
@@ -97,6 +98,8 @@ class ConanFileLoader(object):
             conanfile.requires.add(requirement_text)
         for build_requirement_text in parser.build_requirements:
             ConanFileReference.loads(build_requirement_text)
+            if not hasattr(conanfile, "build_requires"):
+                conanfile.build_requires = Requirements()
             conanfile.build_requires.add(build_requirement_text)
 
         conanfile.generators = parser.generators

--- a/conans/client/loader_parse.py
+++ b/conans/client/loader_parse.py
@@ -95,7 +95,7 @@ class ConanFileTextLoader(object):
     def __init__(self, input_text):
         # Prefer composition over inheritance, the __getattr__ was breaking things
         self._config_parser = ConfigParser(input_text,  ["requires", "generators", "options",
-                                                         "imports"], parse_lines=True)
+                                                         "imports", "build_requires"], parse_lines=True)
 
     @property
     def requirements(self):
@@ -103,6 +103,13 @@ class ConanFileTextLoader(object):
         EX:  "OpenCV/2.4.10@phil/stable"
         """
         return [r.strip() for r in self._config_parser.requires.splitlines()]
+
+    @property
+    def build_requirements(self):
+        """returns a list of build_requires
+        EX:  "OpenCV/2.4.10@phil/stable"
+        """
+        return [r.strip() for r in self._config_parser.build_requires.splitlines()]
 
     @property
     def options(self):

--- a/conans/model/conan_file.py
+++ b/conans/model/conan_file.py
@@ -50,22 +50,6 @@ def create_requirements(conanfile):
         raise ConanException("Error while initializing requirements. %s" % str(e))
 
 
-def create_build_requirements(conanfile):
-    try:
-        # Actual build requirements of this package
-        if not hasattr(conanfile, "build_requires"):
-            return Requirements()
-        else:
-            if not conanfile.build_requires:
-                return Requirements()
-            if isinstance(conanfile.build_requires, tuple):
-                return Requirements(*conanfile.build_requires)
-            else:
-                return Requirements(conanfile.build_requires, )
-    except Exception as e:
-        raise ConanException("Error while initializing build_requirements. %s" % str(e))
-
-
 def create_settings(conanfile, settings, local):
     try:
         defined_settings = getattr(conanfile, "settings", None)
@@ -135,7 +119,6 @@ class ConanFile(object):
         # User defined options
         self.options = create_options(self)
         self.requires = create_requirements(self)
-        self.build_requires = create_build_requirements(self)
         self.settings = create_settings(self, settings, local)
         try:
             if self.settings.os_build and self.settings.os:

--- a/conans/model/conan_file.py
+++ b/conans/model/conan_file.py
@@ -48,6 +48,22 @@ def create_requirements(conanfile):
         raise ConanException("Error while initializing requirements. %s" % str(e))
 
 
+def create_build_requirements(conanfile):
+    try:
+        # Actual build requirements of this package
+        if not hasattr(conanfile, "build_requires"):
+            return Requirements()
+        else:
+            if not conanfile.build_requires:
+                return Requirements()
+            if isinstance(conanfile.build_requires, tuple):
+                return Requirements(*conanfile.build_requires)
+            else:
+                return Requirements(conanfile.build_requires, )
+    except Exception as e:
+        raise ConanException("Error while initializing build_requirements. %s" % str(e))
+
+
 def create_settings(conanfile, settings):
     try:
         defined_settings = getattr(conanfile, "settings", None)
@@ -106,6 +122,7 @@ class ConanFile(object):
         # User defined options
         self.options = create_options(self)
         self.requires = create_requirements(self)
+        self.build_requires = create_build_requirements(self)
         self.settings = create_settings(self, settings) if not local else settings
         try:
             if self.settings.os_build and self.settings.os:

--- a/conans/test/command/source_test.py
+++ b/conans/test/command/source_test.py
@@ -1,5 +1,4 @@
 import unittest
-from conans.errors import ConanException
 from conans.paths import CONANFILE, BUILD_INFO
 from conans.test.utils.tools import TestClient
 from conans.util.files import load, mkdir
@@ -7,6 +6,28 @@ import os
 
 
 class SourceTest(unittest.TestCase):
+
+    def apply_patch_test(self):
+        # https://github.com/conan-io/conan/issues/2327
+        # Test if a patch can be applied in source() both in create
+        # and local flow
+        client = TestClient()
+        conanfile = """from conans import ConanFile
+from conans.tools import load
+import os
+class Pkg(ConanFile):
+    exports_sources = "*"
+    def source(self):
+        if self.develop:
+            patch = os.path.join(self.source_folder, "mypatch")
+            self.output.info("PATCH: %s" % load(patch))
+"""
+        client.save({"conanfile.py": conanfile,
+                     "mypatch": "this is my patch"})
+        client.run("source .")
+        self.assertIn("PATCH: this is my patch", client.out)
+        client.run("create . Pkg/0.1@user/testing")
+        self.assertIn("PATCH: this is my patch", client.out)
 
     def source_reference_test(self):
         client = TestClient()
@@ -19,13 +40,13 @@ class SourceTest(unittest.TestCase):
         client.save({"conanfile.txt": "contents"}, clean_first=True)
 
         # Path with conanfile.txt
-        error = client.run("source conanfile.txt --install-folder subdir", ignore_error = True)
+        error = client.run("source conanfile.txt --install-folder subdir", ignore_error=True)
         self.assertTrue(error)
         self.assertIn("A conanfile.py is needed (not valid conanfile.txt)", client.out)
 
         # Path with wrong conanfile path
         error = client.run("package not_real_dir/conanfile.py --build-folder build2 --install-folder build",
-                           ignore_error = True)
+                           ignore_error=True)
         self.assertTrue(error)
         self.assertIn("Conanfile not found: %s" % os.path.join(client.current_folder, "not_real_dir",
                                                                "conanfile.py"), client.out)
@@ -122,7 +143,6 @@ class ConanLib(ConanFile):
         self.output.info("MYVAR=%s" % self.deps_env_info["Hello"].MYVAR)
         self.output.info("OTHERVAR=%s" % self.deps_user_info["Hello"].OTHERVAR)
         self.output.info("CURDIR=%s" % os.getcwd())
-        
 '''
         # First, failing source()
         client.save({CONANFILE: conanfile}, clean_first=True)

--- a/conans/test/functional/conanfile_loader_test.py
+++ b/conans/test/functional/conanfile_loader_test.py
@@ -97,6 +97,8 @@ OpenCV2:other_option=Cosa #
         file_content = '''[requires]
 OpenCV/2.4.10@phil/stable
 OpenCV2/2.4.10@phil/stable
+[build_requires]
+MyPkg/1.0.0@phil/stable
 [generators]
 one
 two
@@ -121,8 +123,11 @@ OpenCV2:other_option=Cosa""")
         requirements = Requirements()
         requirements.add("OpenCV/2.4.10@phil/stable")
         requirements.add("OpenCV2/2.4.10@phil/stable")
+        build_requirements = Requirements()
+        build_requirements.add("MyPkg/1.0.0@phil/stable")
 
         self.assertEquals(ret.requires, requirements)
+        self.assertEquals(ret.build_requires, build_requirements)
         self.assertEquals(ret.generators, ["one", "two"])
         self.assertEquals(ret.options.values.dumps(), options1.dumps())
 


### PR DESCRIPTION
This PR will add build_requires support for the conanfile.txt loader. This can be usefull in f.e. conan-cmake project [#67](https://github.com/conan-io/cmake-conan/issues/67).

Greetings  
Tonka