### PR TITLE
changed order of CONAN_CMAKE_GENERATOR to not need settings

### DIFF
--- a/conans/client/build/cmake.py
+++ b/conans/client/build/cmake.py
@@ -92,13 +92,12 @@ class CMake(object):
         return defs_to_string(self.definitions)
 
     def _generator(self):
+        if "CONAN_CMAKE_GENERATOR" in os.environ:
+            return os.environ["CONAN_CMAKE_GENERATOR"]
 
         if not self._compiler or not self._compiler_version or not self._arch:
             raise ConanException("You must specify compiler, compiler.version and arch in "
                                  "your settings to use a CMake generator")
-
-        if "CONAN_CMAKE_GENERATOR" in os.environ:
-            return os.environ["CONAN_CMAKE_GENERATOR"]
 
         if self._compiler == "Visual Studio":
             _visuals = {'8': '8 2005',

--- a/conans/test/build_helpers/cmake_test.py
+++ b/conans/test/build_helpers/cmake_test.py
@@ -26,6 +26,13 @@ class CMakeTest(unittest.TestCase):
     def tearDown(self):
         shutil.rmtree(self.tempdir)
 
+    def cmake_generator_test(self):
+        conan_file = ConanFileMock()
+        conan_file.settings = Settings()
+        with tools.environment_append({"CONAN_CMAKE_GENERATOR": "My CMake Generator"}):
+            cmake = CMake(conan_file)
+            self.assertIn('-G "My CMake Generator"', cmake.command_line)
+
     def folders_test(self):
         def quote_var(var):
             return "'%s'" % var if platform.system() != "Windows" else var


### PR DESCRIPTION
Fix https://github.com/conan-io/conan/issues/2370

CONAN_CMAKE_GENERATOR can define the generator, and in that case checking for some settings that will not be used to define the generator seems unnecessary. I have swapped the order.