### PR TITLE
Not 0 exit code when handling signals.

### DIFF
--- a/conans/client/command.py
+++ b/conans/client/command.py
@@ -1226,11 +1226,11 @@ def main(args):
 
         def ctrl_c_handler(_, __):
             print('You pressed Ctrl+C!')
-            sys.exit(0)
+            sys.exit(-1)
 
         def ctrl_break_handler(_, __):
             print('You pressed Ctrl+Break!')
-            sys.exit(0)
+            sys.exit(-2)
 
         signal.signal(signal.SIGINT, ctrl_c_handler)
         if sys.platform == 'win32':

--- a/conans/client/command.py
+++ b/conans/client/command.py
@@ -1212,11 +1212,19 @@ _help_build_policies = '''Optional, use it to choose if you want to build from s
 def main(args):
     """ main entry point of the conan application, using a Command to
     parse parameters
+
+    Exit codes for conan command:
+
+        0: Success (done)
+        1: General ConanException error (done)
+        2: Migration error
+        3: Ctrl+C
+        4: Ctrl+Break
     """
     try:
         conan_api, client_cache, user_io = Conan.factory()
     except ConanException:  # Error migrating
-        sys.exit(-1)
+        sys.exit(2)
 
     outputer = CommandOutputer(user_io, client_cache)
     command = Command(conan_api, client_cache, user_io, outputer)
@@ -1226,11 +1234,11 @@ def main(args):
 
         def ctrl_c_handler(_, __):
             print('You pressed Ctrl+C!')
-            sys.exit(-1)
+            sys.exit(3)
 
         def ctrl_break_handler(_, __):
             print('You pressed Ctrl+Break!')
-            sys.exit(-2)
+            sys.exit(4)
 
         signal.signal(signal.SIGINT, ctrl_c_handler)
         if sys.platform == 'win32':


### PR DESCRIPTION
See more details about valid return codes:
   - https://stackoverflow.com/questions/6466711/what-is-the-return-value-of-os-system-in-python

- [x] Refer to the issue that supports this Pull Request.
- [x] I've read the [Contributing guide](https://raw.githubusercontent.com/conan-io/conan/develop/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [x] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. Also adding a description of the changes in the ``changelog.rst`` file. https://github.com/conan-io/docs

fixes #2360 

Manual test in Mac os X:

```bash
10:21 $ conan create . pedro/test
Hello/0.1@pedro/test: Exporting package recipe
^CYou pressed Ctrl+C!
ERROR: Exiting with code: 3
10:21 $ echo $?
3
```
And Linux:

```bash
conan@0588fa293512:~/test$ conan create . pedro/test
Hello/0.1@pedro/test: Exporting package recipe
^CYou pressed Ctrl+C!
ERROR: Exiting with code: 3
conan@0588fa293512:~/test$ echo $?
3
conan@0588fa293512:~/test$ uname -a
Linux 0588fa293512 4.9.60-linuxkit-aufs #1 SMP Mon Nov 6 16:00:12 UTC 2017 x86_64 x86_64 x86_64 GNU/Linux
```

See more about return codes:
    - https://stackoverflow.com/questions/6466711/what-is-the-return-value-of-os-system-in-python

I'm not sure if we need to automate any test here but I found this post about it:

   - https://stackoverflow.com/questions/26158373/how-to-really-test-signal-handling-in-python
