### PR TITLE
Don't display credentials from url while conan config install

### DIFF
--- a/conans/client/conf/config_installer.py
+++ b/conans/client/conf/config_installer.py
@@ -16,14 +16,13 @@ def _remove_credentials(resource):
     :param resource: string with url or file path
     :return: resource with credentials removed if present
     """
-    if not resource:
-        return resource
-
     parsed_url = urlparse(resource)
     if parsed_url.password is not None:
         # Remove from netloc credentials, format <username>:<password>@<host>:<port>
         # see https://tools.ietf.org/html/rfc1738#section-3.1
         new_netloc = ''.join(parsed_url.netloc.rsplit("@", 1)[1:])
+        # parsed_url is an instance of namedtuple and _replace is part of the public api,
+        # to prevent conflicts with field names, the method and attribute names start with an underscore.
         # noinspection PyProtectedMember
         return parsed_url._replace(netloc=new_netloc).geturl()
     return resource

--- a/conans/client/conf/config_installer.py
+++ b/conans/client/conf/config_installer.py
@@ -9,23 +9,15 @@ from conans import tools
 from conans.errors import ConanException
 
 
-def _remove_credentials(resource):
+def _hide_password(resource):
     """
-    Remove credentials from resource url/file path
+    Hide password from url/file path
 
     :param resource: string with url or file path
-    :return: resource with credentials removed if present
+    :return: resource with hidden password if present
     """
-    parsed_url = urlparse(resource)
-    if parsed_url.password is not None:
-        # Remove from netloc credentials, format <username>:<password>@<host>:<port>
-        # see https://tools.ietf.org/html/rfc1738#section-3.1
-        new_netloc = ''.join(parsed_url.netloc.rsplit("@", 1)[1:])
-        # parsed_url is an instance of namedtuple and _replace is part of the public api,
-        # to prevent conflicts with field names, the method and attribute names start with an underscore.
-        # noinspection PyProtectedMember
-        return parsed_url._replace(netloc=new_netloc).geturl()
-    return resource
+    password = urlparse(resource).password
+    return resource.replace(password, "<hidden>") if password else resource
 
 
 def _handle_remotes(registry_path, remote_file, output):
@@ -99,7 +91,7 @@ def _process_folder(folder, client_cache, output):
 
 
 def _process_download(item, client_cache, output, tmp_folder):
-    output.info("Trying to download  %s" % _remove_credentials(item))
+    output.info("Trying to download  %s" % _hide_password(item))
     zippath = os.path.join(tmp_folder, "config.zip")
     tools.download(item, zippath, out=output)
     _process_zip_file(zippath, client_cache, output, tmp_folder, remove=True)

--- a/conans/client/conf/config_installer.py
+++ b/conans/client/conf/config_installer.py
@@ -1,13 +1,6 @@
 import os
 import shutil
-from six import string_types
-
-try:
-    # urlparse was moved to urllib in python 3
-    from urllib.parse import urlparse
-except ImportError:
-    # location for python 2
-    from urlparse import urlparse
+from six.moves.urllib.parse import urlparse
 
 from conans.tools import unzip
 from conans.util.files import rmdir, mkdir
@@ -23,7 +16,7 @@ def _remove_credentials(resource):
     :param resource: string with url or file path
     :return: resource with credentials removed if present
     """
-    if not isinstance(resource, string_types):
+    if not resource:
         return resource
 
     parsed_url = urlparse(resource)
@@ -31,6 +24,7 @@ def _remove_credentials(resource):
         # Remove from netloc credentials, format <username>:<password>@<host>:<port>
         # see https://tools.ietf.org/html/rfc1738#section-3.1
         new_netloc = ''.join(parsed_url.netloc.rsplit("@", 1)[1:])
+        # noinspection PyProtectedMember
         return parsed_url._replace(netloc=new_netloc).geturl()
     return resource
 

--- a/conans/client/conf/config_installer.py
+++ b/conans/client/conf/config_installer.py
@@ -1,5 +1,6 @@
 import os
 import shutil
+from six import string_types
 
 try:
     # urlparse was moved to urllib in python 3
@@ -19,9 +20,12 @@ def _remove_credentials(resource):
     """
     Remove credentials from resource url/file path
 
-    :param resource: url or file path
+    :param resource: string with url or file path
     :return: resource with credentials removed if present
     """
+    if not isinstance(resource, string_types):
+        return resource
+
     parsed_url = urlparse(resource)
     if parsed_url.password is not None:
         # Remove from netloc credentials, format <username>:<password>@<host>:<port>

--- a/conans/test/command/config_install_test.py
+++ b/conans/test/command/config_install_test.py
@@ -241,10 +241,8 @@ class Pkg(ConanFile):
         windows_file_path = r"c:\windows\test"
         self.assertEqual(_remove_credentials(windows_file_path), windows_file_path)
 
-        # Check works with unknown inputs
-        self.assertIsNone(_remove_credentials(None))
+        # Check works with empty string
         self.assertEqual(_remove_credentials(''), '')
-        self.assertEqual(_remove_credentials([]), [])
 
     def remove_credentials_config_installer_test(self):
         """ Functional test to check credentials are not displayed in output but are still present


### PR DESCRIPTION
- [X] Refer to the issue that supports this Pull Request.
- [X] I've read the [Contributing guide](https://raw.githubusercontent.com/conan-io/conan/develop/.github/CONTRIBUTING.md).
- [X] I've followed the PEP8 style guides for Python code.

fixes #2324 

Only implemented the functionality to remove credentials in a generic way using urlparse which works with any kind of path. Not implemented verbose or not verbose as @markgalpin suggested in #2324 because now output displays url without credentials, see functional tests and trace below.

Added unit tests and functional tests.

Maybe function to remove credential should be moved to another module, now it's living in config_installer.

Also manual tests downloading from server with conan and checked that url is still stored with credentials in ``conan.conf``. See trace:

```
conan@1543e9c55635:~$ conan config install https://xxxx:xxxx@bitbucket.org/pvicente/test1/raw/c5f38af3544ed35e574a4d16b7720fc158decd29/conan.zip
Trying to download  https://bitbucket.org/pvicente/test1/raw/c5f38af3544ed35e574a4d16b7720fc158decd29/conan.zip
[==================================================] 9.3KB/9.3KB
Unzipping 12.7KB
Unzipping 100 %                                                       Installing settings.yml
Defining remotes
Installing profiles
    Installing profile disabled_tests
    Installing profile gcc-5.5
    Installing profile default
    Installing profile default.copy
    Installing profile gcc-6.4
    Installing profile gcc-7.3
Installing settings.yml
Defining remotes
Installing profiles
    Installing profile disabled_tests
    Installing profile gcc-5.5
    Installing profile default
    Installing profile default.copy
    Installing profile gcc-6.4
    Installing profile gcc-7.3
Processing conan.conf
Processing conan.conf
```

