### PR TITLE
2231 conan compiler detection

### DIFF
--- a/conans/client/conf/detect.py
+++ b/conans/client/conf/detect.py
@@ -156,14 +156,14 @@ def _get_default_compiler(output):
         command = cc or cxx
         if "gcc" in command:
             gcc = _gcc_compiler(output, command)
-            if gcc is not None:
-                return gcc
-            if platform.system() == "Darwin":
+            if platform.system() == "Darwin" and gcc is None:
                 output.warn(
                     "%s detected as a frontend using apple-clang, skipping it to use native apple-clang" % command
                 )
-                # using clang instead
+                # Fallback to use clang instead
                 command = "clang"
+            else:
+                return gcc
         if "clang" in command.lower():
             return _clang_compiler(output, command)
         if platform.system() == "SunOS" and command.lower() == "cc":

--- a/conans/client/conf/detect.py
+++ b/conans/client/conf/detect.py
@@ -157,13 +157,10 @@ def _get_default_compiler(output):
         if "gcc" in command:
             gcc = _gcc_compiler(output, command)
             if platform.system() == "Darwin" and gcc is None:
-                output.warn(
-                    "%s detected as a frontend using apple-clang, skipping it to use native apple-clang" % command
+                output.error(
+                    "%s detected as a frontend using apple-clang. Compiler not supported" % command
                 )
-                # Fallback to use clang instead
-                command = "clang"
-            else:
-                return gcc
+            return gcc
         if "clang" in command.lower():
             return _clang_compiler(output, command)
         if platform.system() == "SunOS" and command.lower() == "cc":

--- a/conans/client/conf/detect.py
+++ b/conans/client/conf/detect.py
@@ -25,14 +25,14 @@ def _execute(command):
 
 def _gcc_compiler(output, compiler_exe="gcc"):
 
-    if platform.system() == "Darwin":
-        # In Mac OS X check if gcc is a fronted using apple-clang
-        _, out = _execute("%s --version" % compiler_exe)
-        out = out.lower()
-        if "clang" in out:
-            return None
-
     try:
+        if platform.system() == "Darwin":
+            # In Mac OS X check if gcc is a fronted using apple-clang
+            _, out = _execute("%s --version" % compiler_exe)
+            out = out.lower()
+            if "clang" in out:
+                return None
+
         _, out = _execute('%s -dumpversion' % compiler_exe)
         compiler = "gcc"
         installed_version = re.search("([0-9](\.[0-9])?)", out).group()

--- a/conans/test/util/detect_test.py
+++ b/conans/test/util/detect_test.py
@@ -53,3 +53,5 @@ class DetectTest(unittest.TestCase):
         # result is a list of tuples (name, value) so converting it to dict
         result = dict(result)
         self.assertEquals(result.get("compiler", None), "apple-clang")
+        self.assertIn("gcc detected as a frontend using apple-clang", output)
+        self.assertIsNotNone(output.warn)

--- a/conans/test/util/detect_test.py
+++ b/conans/test/util/detect_test.py
@@ -8,18 +8,17 @@ from conans.test.utils.tools import TestBufferConanOutput
 
 class DetectTest(unittest.TestCase):
 
-    platform_default_compilers = {
-        "Linux": "gcc",
-        "Darwin": "apple-clang",
-        "Windows": "Visual Studio"
-    }
-
     def detect_default_compilers_test(self):
+        platform_default_compilers = {
+            "Linux": "gcc",
+            "Darwin": "apple-clang",
+            "Windows": "Visual Studio"
+        }
         output = TestBufferConanOutput()
         result = detect_defaults_settings(output)
         # result is a list of tuples (name, value) so converting it to dict
         result = dict(result)
-        platform_compiler = self.platform_default_compilers.get(platform.system(), None)
+        platform_compiler = platform_default_compilers.get(platform.system(), None)
         if platform_compiler is not None:
             self.assertEquals(result.get("compiler", None), platform_compiler)
 
@@ -31,6 +30,4 @@ class DetectTest(unittest.TestCase):
             result = detect_defaults_settings(output)
         # result is a list of tuples (name, value) so converting it to dict
         result = dict(result)
-        platform_compiler = self.platform_default_compilers.get(platform.system(), None)
-        self.assertIsNotNone(platform_compiler)
-        self.assertEquals(result.get("compiler", None), platform_compiler)
+        self.assertEquals(result.get("compiler", None), "apple-clang")

--- a/conans/test/util/detect_test.py
+++ b/conans/test/util/detect_test.py
@@ -39,7 +39,8 @@ class DetectTest(unittest.TestCase):
 
         if "clang" not in output:
             # Not test scenario gcc should display clang in output
-            return
+            # see: https://stackoverflow.com/questions/19535422/os-x-10-9-gcc-links-to-clang
+            raise Exception("Apple gcc doesn't point to clang with gcc frontend anymore! please check")
 
         output = TestBufferConanOutput()
         with tools.environment_append({"CC": "gcc"}):

--- a/conans/test/util/detect_test.py
+++ b/conans/test/util/detect_test.py
@@ -1,6 +1,6 @@
 import platform
+import subprocess
 import unittest
-from subprocess import Popen, PIPE, STDOUT
 
 from conans import tools
 from conans.client.conf.detect import detect_defaults_settings
@@ -31,23 +31,14 @@ class DetectTest(unittest.TestCase):
         if platform.system() != "Darwin":
             return
 
-        def _execute(command):
-            proc = Popen(command, shell=True, bufsize=1, stdout=PIPE, stderr=STDOUT)
+        try:
+            output = subprocess.check_output(["gcc", "--version"], stderr=subprocess.STDOUT)
+        except subprocess.CalledProcessError:
+            # gcc is not installed or there is any error (no test scenario)
+            return
 
-            output_buffer = []
-            while True:
-                line = proc.stdout.readline()
-                if not line:
-                    break
-                # output.write(line)
-                output_buffer.append(str(line))
-
-            proc.communicate()
-            return proc.returncode, "".join(output_buffer)
-
-        proc_return, output = _execute("gcc --version")
-        if proc_return != 0 or "clang" not in output:
-            # Not test scenario (gcc should display clang in output
+        if "clang" not in output:
+            # Not test scenario gcc should display clang in output
             return
 
         output = TestBufferConanOutput()

--- a/conans/test/util/detect_test.py
+++ b/conans/test/util/detect_test.py
@@ -37,7 +37,7 @@ class DetectTest(unittest.TestCase):
             # gcc is not installed or there is any error (no test scenario)
             return
 
-        if "clang" not in output:
+        if b"clang" not in output:
             # Not test scenario gcc should display clang in output
             # see: https://stackoverflow.com/questions/19535422/os-x-10-9-gcc-links-to-clang
             raise Exception("Apple gcc doesn't point to clang with gcc frontend anymore! please check")

--- a/conans/test/util/detect_test.py
+++ b/conans/test/util/detect_test.py
@@ -1,15 +1,36 @@
-import unittest
-from conans.test.utils.tools import TestBufferConanOutput
-from conans.client.conf.detect import detect_defaults_settings
 import platform
+import unittest
+
+from conans import tools
+from conans.client.conf.detect import detect_defaults_settings
+from conans.test.utils.tools import TestBufferConanOutput
 
 
 class DetectTest(unittest.TestCase):
 
-    def detect_test(self):
+    platform_default_compilers = {
+        "Linux": "gcc",
+        "Darwin": "apple-clang",
+        "Windows": "Visual Studio"
+    }
+
+    def detect_default_compilers_test(self):
         output = TestBufferConanOutput()
         result = detect_defaults_settings(output)
-        if platform.system() == "Linux":
-            for (name, value) in result:
-                if name == "compiler":
-                    self.assertEquals(value, "gcc")
+        # result is a list of tuples (name, value) so converting it to dict
+        result = dict(result)
+        platform_compiler = self.platform_default_compilers.get(platform.system(), None)
+        if platform_compiler is not None:
+            self.assertEquals(result.get("compiler", None), platform_compiler)
+
+    @unittest.skipIf(platform.system() != "Darwin", "Test only running in Mac OS X")
+    def detect_default_in_mac_os_using_gcc_as_default_test(self):
+        # See: https://github.com/conan-io/conan/issues/2231
+        output = TestBufferConanOutput()
+        with tools.environment_append({"CC": "gcc"}):
+            result = detect_defaults_settings(output)
+        # result is a list of tuples (name, value) so converting it to dict
+        result = dict(result)
+        platform_compiler = self.platform_default_compilers.get(platform.system(), None)
+        self.assertIsNotNone(platform_compiler)
+        self.assertEquals(result.get("compiler", None), platform_compiler)

--- a/conans/test/util/detect_test.py
+++ b/conans/test/util/detect_test.py
@@ -25,9 +25,12 @@ class DetectTest(unittest.TestCase):
 
     def detect_default_in_mac_os_using_gcc_as_default_test(self):
         """
-        In some Mac OS X gcc is in reality clang.
+        Test if gcc in Mac OS X is using apple-clang as frontend
         """
         # See: https://github.com/conan-io/conan/issues/2231
+        if platform.system() != "Darwin":
+            return
+
         def _execute(command):
             proc = Popen(command, shell=True, bufsize=1, stdout=PIPE, stderr=STDOUT)
 
@@ -44,7 +47,7 @@ class DetectTest(unittest.TestCase):
 
         proc_return, output = _execute("gcc --version")
         if proc_return != 0 or "clang" not in output:
-            # Not test scenario (gcc should display that it's clang)
+            # Not test scenario (gcc should display clang in output
             return
 
         output = TestBufferConanOutput()

--- a/conans/test/util/detect_test.py
+++ b/conans/test/util/detect_test.py
@@ -47,6 +47,7 @@ class DetectTest(unittest.TestCase):
             result = detect_defaults_settings(output)
         # result is a list of tuples (name, value) so converting it to dict
         result = dict(result)
-        self.assertEquals(result.get("compiler", None), "apple-clang")
+        # No compiler should be detected
+        self.assertIsNone(result.get("compiler", None))
         self.assertIn("gcc detected as a frontend using apple-clang", output)
-        self.assertIsNotNone(output.warn)
+        self.assertIsNotNone(output.error)


### PR DESCRIPTION
- [X] Refer to the issue that supports this Pull Request.
- [X] I've read the [Contributing guide](https://raw.githubusercontent.com/conan-io/conan/develop/.github/CONTRIBUTING.md).
- [X] I've followed the PEP8 style guides for Python code.

closes #2231 

Previously failing compiler detection in mac os x when gcc was forced:

```bash
09:28 $ CC=gcc CXX=g++ conan install boost/1.66.0@conan/stable
Auto detecting your dev setup to initialize the default profile (/Users/pvicente/.conan/profiles/default)
CC and CXX: gcc, g++
Found gcc 4.2
Default settings
	os=Macos
	os_build=Macos
	arch=x86_64
	arch_build=x86_64
	compiler=gcc
	compiler.version=4.2
	compiler.libcxx=libstdc++
	build_type=Release
*** You can change them in /Users/pvicente/.conan/profiles/default ***
*** Or override with -s compiler='other' -s ...s***


ERROR: Invalid setting '4.2' is not a valid 'settings.compiler.version' value.
Possible values are ['4.1', '4.4', '4.5', '4.6', '4.7', '4.8', '4.9', '5', '5.1', '5.2', '5.3', '5.4', '5.5', '6', '6.1', '6.2', '6.3', '6.4', '7', '7.1', '7.2', '7.3']
Read "http://docs.conan.io/en/latest/faq/troubleshooting.html#error-invalid-setting"
```

Now:

```bash
09:26 $ CC=gcc CXX=g++ conan install boost/1.66.0@conan/stable
Auto detecting your dev setup to initialize the default profile (/Users/pvicente/.conan/profiles/default)
CC and CXX: gcc, g++
Found apple-clang 9.0
Default settings
	os=Macos
	os_build=Macos
	arch=x86_64
	arch_build=x86_64
	compiler=apple-clang
	compiler.version=9.0
	compiler.libcxx=libc++
	build_type=Release
*** You can change them in /Users/pvicente/.conan/profiles/default ***
*** Or override with -s compiler='other' -s ...s***
...
```
