### PR TITLE
Added keep_path parameter to copy in imports()

### DIFF
--- a/conans/client/importer.py
+++ b/conans/client/importer.py
@@ -116,7 +116,7 @@ class _FileImporter(object):
         self.copied_files = set()
 
     def __call__(self, pattern, dst="", src="", root_package=None, folder=False,
-                 ignore_case=False, excludes=None):
+                 ignore_case=False, excludes=None, keep_path=False):
         """
         param pattern: an fnmatch file pattern of the files that should be copied. Eg. *.dll
         param dst: the destination local folder, wrt to current conanfile dir, to which
@@ -136,7 +136,7 @@ class _FileImporter(object):
             final_dst_path = os.path.join(real_dst_folder, name) if folder else real_dst_folder
             file_copier = FileCopier(matching_path, final_dst_path)
             files = file_copier(pattern, src=src, links=True, ignore_case=ignore_case,
-                                excludes=excludes)
+                                excludes=excludes, keep_path=keep_path)
             self.copied_files.update(files)
 
     def _get_folders(self, pattern):

--- a/conans/client/importer.py
+++ b/conans/client/importer.py
@@ -116,7 +116,7 @@ class _FileImporter(object):
         self.copied_files = set()
 
     def __call__(self, pattern, dst="", src="", root_package=None, folder=False,
-                 ignore_case=False, excludes=None, keep_path=False):
+                 ignore_case=False, excludes=None, keep_path=True):
         """
         param pattern: an fnmatch file pattern of the files that should be copied. Eg. *.dll
         param dst: the destination local folder, wrt to current conanfile dir, to which

--- a/conans/client/loader_parse.py
+++ b/conans/client/loader_parse.py
@@ -111,7 +111,7 @@ class ConanFileTextLoader(object):
     @property
     def _import_parameters(self):
         def _parse_args(param_string):
-            root_package, ignore_case, folder, excludes, keep_path = None, False, False, None, False
+            root_package, ignore_case, folder, excludes, keep_path = None, False, False, None, True
             params = param_string.split(",")
             params = [p.split("=") for p in params if p]
             for (var, value) in params:

--- a/conans/client/loader_parse.py
+++ b/conans/client/loader_parse.py
@@ -111,7 +111,7 @@ class ConanFileTextLoader(object):
     @property
     def _import_parameters(self):
         def _parse_args(param_string):
-            root_package, ignore_case, folder, excludes = None, False, False, None
+            root_package, ignore_case, folder, excludes, keep_path = None, False, False, None, False
             params = param_string.split(",")
             params = [p.split("=") for p in params if p]
             for (var, value) in params:
@@ -125,9 +125,11 @@ class ConanFileTextLoader(object):
                     folder = (value.lower() == "true")
                 elif var == "excludes":
                     excludes = value.split()
+                elif var == "keep_path":
+                    keep_path = (value.lower() == "true")
                 else:
                     raise Exception("Invalid imports. Unknown argument %s" % var)
-            return root_package, ignore_case, folder, excludes
+            return root_package, ignore_case, folder, excludes, keep_path
 
         def _parse_import(line):
             pair = line.split("->")
@@ -156,9 +158,9 @@ class ConanFileTextLoader(object):
                     params = tokens[1]
                 else:
                     params = ""
-                root_package, ignore_case, folder, excludes = _parse_args(params)
+                root_package, ignore_case, folder, excludes, keep_path = _parse_args(params)
                 pattern, dest, src = _parse_import(line)
-                ret.append((pattern, dest, src, root_package, folder, ignore_case, excludes))
+                ret.append((pattern, dest, src, root_package, folder, ignore_case, excludes, keep_path))
             except Exception as e:
                 raise ConanException("%s\n%s" % (invalid_line_msg, str(e)))
         return ret

--- a/conans/test/functional/conanfile_loader_test.py
+++ b/conans/test/functional/conanfile_loader_test.py
@@ -162,6 +162,7 @@ OpenCV/bin, * -> ./bin # I need this binaries
 OpenCV/lib, * -> ./lib @ root_package=Pkg
 OpenCV/data, * -> ./data @ root_package=Pkg, folder=True # Irrelevant
 docs, * -> ./docs @ root_package=Pkg, folder=True, ignore_case=True, excludes="a b c" # Other
+licenses, * -> ./licenses @ root_package=Pkg, folder=True, ignore_case=True, excludes="a b c", keep_path=False # Other
 '''
         tmp_dir = temp_folder()
         file_path = os.path.join(tmp_dir, "file.txt")
@@ -171,10 +172,12 @@ docs, * -> ./docs @ root_package=Pkg, folder=True, ignore_case=True, excludes="a
 
         ret.copy = Mock()
         ret.imports()
-        expected = [call(u'*', u'./bin', u'OpenCV/bin', None, False, False, None),
-                    call(u'*', u'./lib', u'OpenCV/lib', u'Pkg', False, False, None),
-                    call(u'*', u'./data', u'OpenCV/data', u'Pkg', True, False, None),
-                    call(u'*', u'./docs', u'docs', u'Pkg', True, True, [u'"a', u'b', u'c"'])]
+        expected = [call(u'*', u'./bin', u'OpenCV/bin', None, False, False, None, True),
+                    call(u'*', u'./lib', u'OpenCV/lib', u'Pkg', False, False, None, True),
+                    call(u'*', u'./data', u'OpenCV/data', u'Pkg', True, False, None, True),
+                    call(u'*', u'./docs', u'docs', u'Pkg', True, True, [u'"a', u'b', u'c"'], True),
+                    call(u'*', u'./licenses', u'licenses', u'Pkg', True, True, [u'"a', u'b', u'c"'],
+                         False)]
         self.assertEqual(ret.copy.call_args_list, expected)
 
     def test_package_settings(self):

--- a/conans/test/functional/imports_tests.py
+++ b/conans/test/functional/imports_tests.py
@@ -141,11 +141,7 @@ bin, *.dll ->  @ excludes=Foo/*.dll Baz/*.dll
                                                      "licenses/path/to/license.txt")))
 
         # keep_path = False AND conanfile.py
-        testconanfile = conanfile % "LibD" + "    requires='LibC/0.1@lasote/testing'"
-        testconanfile += """
-    def imports(self):
-        self.copy("*license*", dst="licenses", keep_path=False)
-"""
+        testconanfile = testconanfile.replace("keep_path=True", "keep_path=False")
         client.save({"conanfile.py": testconanfile}, clean_first=True)
         client.run("install . --build=missing")
         self.assertTrue(os.path.exists(os.path.join(client.current_folder,
@@ -163,11 +159,7 @@ bin, *.dll ->  @ excludes=Foo/*.dll Baz/*.dll
                                                      "licenses/path/to/license.txt")))
 
         # keep_path = False AND conanfile.txt
-        testconanfile = conanfile_txt % "LibC/0.1@lasote/testing"
-        testconanfile += """
-[imports]:
-., *license* -> licenses @ keep_path=False
-"""
+        testconanfile = testconanfile.replace("keep_path=True", "keep_path=False")
         client.save({"conanfile.txt": testconanfile}, clean_first=True)
         client.run("install . --build=missing")
         self.assertTrue(os.path.exists(os.path.join(client.current_folder, "licenses")))


### PR DESCRIPTION
- [x] Refer to the issue that supports this Pull Request: closes #2418
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://raw.githubusercontent.com/conan-io/conan/develop/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. Also adding a description of the changes in the ``changelog.rst`` file. https://github.com/conan-io/docs

Added `keep_path` parameter to `self.copy()` inside `imports()` for *conanfile.py*:
```
def imports(self):
        self.copy("*license*", dst="licenses", keep_path=True)
```

and in `[imports]` for *conanfile.txt*:

```
[imports]:
., *license* -> ./licenses @ keep_path=True
```

Still missing docs!
