### PR TITLE
build_type not defined not error

### DIFF
--- a/conans/client/loader.py
+++ b/conans/client/loader.py
@@ -8,7 +8,6 @@ from conans.model.options import OptionsValues
 from conans.model.ref import ConanFileReference
 from conans.model.settings import Settings
 from conans.model.values import Values
-from conans.model.requires import Requirements
 from conans.util.files import load
 
 

--- a/conans/test/built_type_setting_test.py
+++ b/conans/test/built_type_setting_test.py
@@ -1,0 +1,50 @@
+import unittest
+from conans.test.utils.tools import TestClient
+
+
+class BuildTypeSettingTest(unittest.TestCase):
+
+    def test_build_type(self):
+        # https://github.com/conan-io/conan/issues/2500
+        client = TestClient()
+        conanfile = """from conans import ConanFile
+class Pkg(ConanFile):
+    settings = "build_type"
+    def build(self):
+        self.output.info("BUILD TYPE: %s" % (self.settings.build_type or "Not defined"))
+"""
+        test_conanfile = """from conans import ConanFile
+class Pkg(ConanFile):
+    settings = "build_type"
+    def build(self):
+        self.output.info("BUILD TYPE: %s" % (self.settings.build_type or "Not defined"))
+    def test(self):
+        pass
+"""
+        client.save({"conanfile.py": conanfile,
+                     "test_package/conanfile.py": test_conanfile,
+                     "myprofile": ""})
+
+        # This won't fail, as it has a build_type=None, which is allowed
+        client.run("export . Pkg/0.1@lasote/testing")
+        client.run("install Pkg/0.1@lasote/testing -pr=myprofile --build")
+        self.assertEqual(1, str(client.out).count("BUILD TYPE: Not defined"))
+
+        # This is an error. test_package/conanfile won't have build_type defined, more restrictive
+        error = client.run("create . Pkg/0.1@lasote/testing -pr=myprofile", ignore_error=True)
+        self.assertTrue(error)
+        self.assertEqual(1, str(client.out).count("BUILD TYPE: Not defined"))
+        self.assertIn("ConanException: 'settings.build_type' doesn't exist", client.out)
+
+        client.save({"conanfile.py": conanfile,
+                     "test_package/conanfile.py": test_conanfile,
+                     "myprofile": "[settings]\nbuild_type=None"})
+
+        # This won't fail, as it has a build_type=None, which is allowed
+        client.run("export . Pkg/0.1@lasote/testing")
+        client.run("install Pkg/0.1@lasote/testing -pr=myprofile --build")
+        self.assertEqual(1, str(client.out).count("BUILD TYPE: Not defined"))
+
+        # This is NOT an error. build_type has a value = None
+        client.run("create . Pkg/0.1@lasote/testing -pr=myprofile")
+        self.assertEqual(2, str(client.out).count("BUILD TYPE: Not defined"))


### PR DESCRIPTION
- [x] Refer to the issue that supports this Pull Request. 
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.

This test shows the current behavior:
- ``build_type`` in a recipe won't fail if not defined, as ``None`` is a valid value
- ``build_type`` in a test_package will fail if not defined. Because it is recovered from install state, and ``build_type`` wont exist there
- It works with ``build_type=None``, that doesn't fail

Closes https://github.com/conan-io/conan/issues/2500