### PR TITLE
[WIP] implementation of `conan exec`

### DIFF
--- a/conans/client/command.py
+++ b/conans/client/command.py
@@ -1137,13 +1137,21 @@ class Command(object):
 
     def execute(self, *args):
         """ Executes a command in the environment defined by the profile, the
-        specified references, settings, and options.
+        specified references, settings, and options. Alternatively, instead of
+        references also a folder containing a recipe (conanfile.py or conanfile.txt)
+        or to the recipe file itself is accepted via the --path argument.
         """
         parser = argparse.ArgumentParser(description=self.execute.__doc__, prog="conan exec")
-        parser.add_argument("-ref", "--reference", nargs=1, action=Extender,
-                            help='Full package reference (Pkg/version@user/channel)')
         parser.add_argument('-q', '--quiet', default=False,
                             action='store_true', help='Suppress all output from conan.')
+
+        # either arbitrary many references or one path is accepted
+        parser.add_argument("-ref", "--reference", nargs=1, action=Extender,
+                            help='Full package reference (Pkg/version@user/channel)')
+        parser.add_argument("--path", default=None, action=OnceArgument,
+                            help="path to a folder containing a recipe"
+                            " (conanfile.py or conanfile.txt) or to a recipe file. e.g., "
+                            "./my_project/conanfile.txt. It could also be a reference")
 
         _add_common_install_arguments(parser, build_help=_help_build_policies)
 
@@ -1153,6 +1161,7 @@ class Command(object):
         args = parser.parse_args(*args)
         self._conan.execute(command=args.command+args.arguments,
                             references=args.reference,
+                            recipe_path=args.path,
                             profile_name=args.profile,
                             initial_env=os.environ.copy(),
                             # install arguments

--- a/conans/client/command.py
+++ b/conans/client/command.py
@@ -1142,6 +1142,8 @@ class Command(object):
         parser = argparse.ArgumentParser(description=self.execute.__doc__, prog="conan exec")
         parser.add_argument("-ref", "--reference", nargs=1, action=Extender,
                             help='Full package reference (Pkg/version@user/channel)')
+        parser.add_argument('-q', '--quiet', default=False,
+                            action='store_true', help='Suppress all output from conan.')
 
         _add_common_install_arguments(parser, build_help=_help_build_policies)
 
@@ -1156,7 +1158,7 @@ class Command(object):
                             # install arguments
                             settings=args.settings, options=args.options,
                             remote=args.remote, build_modes=args.build,
-                            update=args.update, env=args.env)
+                            update=args.update, env=args.env, quiet=args.quiet)
 
     def _show_help(self):
         """Prints a summary of all commands

--- a/conans/client/conan_api.py
+++ b/conans/client/conan_api.py
@@ -849,7 +849,7 @@ class ConanAPIV1(object):
     @api_method
     def execute(self, command, references=None, profile_name=None,
                 initial_env=None, settings=None, options=None, remote=None,
-                build_modes=None, update=None, env=None, cwd=None):
+                build_modes=None, update=None, env=None, cwd=None, quiet=None):
         """ Executes a command in the environment defined by the profile, the
         specified references, settings, and options.
 
@@ -860,6 +860,14 @@ class ConanAPIV1(object):
         cwd = cwd if cwd is not None else os.getcwd()
         references = references if references is not None else []
         initial_env = initial_env if initial_env is not None else os.environ.copy()
+
+        # TODO add workspace integration
+        recorder = ActionRecorder()
+        manager = self._init_manager(recorder)
+
+        # Disable all output from Conan
+        if quiet:
+            manager._user_io.out._stream = None
 
         # Load the profile given the specified settings, options, and env variables.
         profile = profile_from_args(profile_name, settings, options, env, cwd,
@@ -879,9 +887,6 @@ class ConanAPIV1(object):
             temp.close()
 
             # Install the dependencies if needed and get an valid conanfile.
-            # TODO add workspace integration
-            recorder = ActionRecorder()
-            manager = self._init_manager(recorder)
             conanfile = manager.install(reference=temp.name,
                                               install_folder=None,
                                               profile=profile,

--- a/conans/client/manager.py
+++ b/conans/client/manager.py
@@ -314,6 +314,7 @@ class ConanManager(object):
                 deploy_conanfile = deps_graph.inverse_levels()[1][0].conanfile
                 if hasattr(deploy_conanfile, "deploy") and callable(deploy_conanfile.deploy):
                     run_deploy(deploy_conanfile, install_folder, output)
+        return conanfile
 
     def source(self, conanfile_path, source_folder, info_folder):
         """

--- a/conans/client/output.py
+++ b/conans/client/output.py
@@ -46,12 +46,16 @@ class ConanOutput(object):
 
     @property
     def is_terminal(self):
+        if self._stream is None:
+            return False
         return hasattr(self._stream, "isatty") and self._stream.isatty()
 
     def writeln(self, data, front=None, back=None):
         self.write(data, front, back, True)
 
     def write(self, data, front=None, back=None, newline=False):
+        if self._stream is None:
+            return
         if six.PY2:
             if isinstance(data, str):
                 data = decode_text(data)  # Keep python 2 compatibility
@@ -90,6 +94,8 @@ class ConanOutput(object):
         self.write(data, Color.GREEN)
 
     def rewrite_line(self, line):
+        if self._stream is None:
+            return
         tmp_color = self._color
         self._color = False
         TOTAL_SIZE = 70

--- a/conans/test/command/exec_test.py
+++ b/conans/test/command/exec_test.py
@@ -73,6 +73,14 @@ class ToolBConan(ConanFile):
         self.assertIn("toola/0.1@lasote/testing", client.out)
         self.assertNotIn("toolb/0.1@lasote/testing", client.out)
 
+    def quiet_test(self):
+        client = TestClient()
+        self._setup_recipes(client)
+        client.run_in_external_process("exec -q -ref toola/0.1@lasote/testing %s" % self._true_cmd())
+        self.assertNotIn("Requirements", client.out)
+        self.assertNotIn("toola/0.1@lasote/testing", client.out)
+        self.assertNotIn("toolb/0.1@lasote/testing", client.out)
+
     def toolA_test(self):
         client = TestClient()
         self._setup_recipes(client)

--- a/conans/test/command/exec_test.py
+++ b/conans/test/command/exec_test.py
@@ -1,0 +1,92 @@
+import unittest
+import os
+from conans.test.utils.tools import TestClient
+from conans.tools import os_info
+
+class ExecTest(unittest.TestCase):
+
+    def _true_cmd(self):
+        if os_info.is_windows and not os_info.is_posix:
+            return "cmd /C EXIT"
+        return "true"
+
+    def _false_cmd(self):
+        if os_info.is_windows and not os_info.is_posix:
+            return "cmd /C EXIT 1"
+        return "false"
+
+    def _env_cmd(self):
+        if os_info.is_windows and not os_info.is_posix:
+            return "cmd /C SET"
+        return "env"
+
+    def _setup_recipes(self, client):
+        toolA = """
+import os
+from conans import ConanFile
+
+class ToolAConan(ConanFile):
+    name = "toola"
+    version = "0.1"
+
+    def package_info(self):
+        self.env_info.PATH = [os.path.join("toola","bin")]
+"""
+
+        toolB = """
+import os
+from conans import ConanFile
+
+class ToolBConan(ConanFile):
+    name = "toolb"
+    version = "0.1"
+    requires = "toola/0.1@lasote/testing"
+
+    def package_info(self):
+        self.env_info.PATH = [os.path.join("toolb","bin")]
+"""
+
+        client.save({"conanfile.py": toolA})
+        client.run("create . lasote/testing")
+        client.save({"conanfile.py": toolB}, clean_first=True)
+        client.run("export . lasote/testing")
+
+    def true_test(self):
+        client = TestClient()
+        client.run_in_external_process("exec %s" % self._true_cmd())
+
+    def false_test(self):
+        client = TestClient()
+        self.assertEqual(1,client.run_in_external_process("exec %s" % self._false_cmd(),
+                                                            ignore_error=True))
+
+    def env_test(self):
+        client = TestClient()
+        client.run_in_external_process("exec -e FOOKEY=FOOVALUE %s" % self._env_cmd())
+        self.assertIn("FOOKEY=FOOVALUE", client.out)
+
+    def conan_output_test(self):
+        client = TestClient()
+        self._setup_recipes(client)
+        client.run_in_external_process("exec -ref toola/0.1@lasote/testing %s" % self._true_cmd())
+        self.assertIn("Requirements", client.out)
+        self.assertIn("toola/0.1@lasote/testing", client.out)
+        self.assertNotIn("toolb/0.1@lasote/testing", client.out)
+
+    def toolA_test(self):
+        client = TestClient()
+        self._setup_recipes(client)
+        client.run_in_external_process("exec -ref toola/0.1@lasote/testing %s" % self._env_cmd())
+        self.assertIn("PATH=%s%s%s" % (os.path.join("toola","bin"), os.pathsep, os.environ["PATH"]), client.out)
+
+    def toolB_unbuild_test(self):
+        client = TestClient()
+        self._setup_recipes(client)
+        self.assertEqual(1,client.run_in_external_process("exec -ref toolb/0.1@lasote/testing %s" % self._env_cmd(),
+                                                            ignore_error=True))
+
+    def toolB_build_test(self):
+        client = TestClient()
+        self._setup_recipes(client)
+        client.run_in_external_process("exec --build=missing -ref toolb/0.1@lasote/testing %s" % self._env_cmd())
+        self.assertIn("PATH=%s%s%s%s%s" % (os.path.join("toolb","bin"), os.pathsep, os.path.join("toola","bin"), os.pathsep, os.environ["PATH"]), client.out)

--- a/conans/test/utils/tools.py
+++ b/conans/test/utils/tools.py
@@ -459,22 +459,22 @@ class TestClient(object):
 
         # Save a copy of the original stdout fd in saved_stdout_fd
         saved_stdout_fd = os.dup(original_stdout_fd)
+        # Create a temporary file and redirect stdout to it
+        tfile = tempfile.TemporaryFile(mode='w+b')
+        # Flush and close sys.stdout - also closes the file descriptor (fd)
+        if original_stdout is None:
+            sys.stdout.close()
+        _redirect_stdout(tfile.fileno())
         try:
-            # Create a temporary file and redirect stdout to it
-            tfile = tempfile.TemporaryFile(mode='w+b')
-            # Flush and close sys.stdout - also closes the file descriptor (fd)
-            if original_stdout is None:
-                sys.stdout.close()
-            _redirect_stdout(tfile.fileno())
             # Yield to caller, then redirect stdout back to the saved fd
             yield
+        finally:
             sys.stdout.close()
             _redirect_stdout(saved_stdout_fd, original_stdout)
             # Copy contents of temporary file to the given stream
             tfile.flush()
             tfile.seek(0, io.SEEK_SET)
             stream.write(tfile.read())
-        finally:
             tfile.close()
             os.close(saved_stdout_fd)
 


### PR DESCRIPTION
This is a WIP implementation of the `conan exec` feature which I proposed in #2461. It currently still lacks unit tests and has only been manually tested on Linux so far. However, at least for me, this prototype already works quite nicely.

Usage looks something like `conan exec [-pr PROFILE] [-ref REFERENCE] [...] COMMAND [ARGUMENTS ...]`. Note that also multiple references can be specified if desired. For example, executing `cmake --version` for cmake 3.5.2 looks then like `conan exec -ref cmake_installer/3.5.2@conan/stable cmake --version`.

Additionally, also all common `conan install` flags are supported which means that missing packages get installed automatically or can be built. Furthermore, customization of settings and options is possible.

Please give it a try and tell me what you think.
