### PR TITLE
Generate conan json dependencies for Ycm generator

### DIFF
--- a/conans/client/generators/ycm.py
+++ b/conans/client/generators/ycm.py
@@ -1,4 +1,5 @@
 from conans.model import Generator
+import json
 
 
 class YouCompleteMeGenerator(Generator):
@@ -34,6 +35,7 @@ class YouCompleteMeGenerator(Generator):
 # For more information, please refer to <http://unlicense.org/>
 
 import os
+import json
 import ycm_core
 import logging
 
@@ -49,8 +51,14 @@ def DirectoryOfThisScript():
 # compilation database set (by default, one is not set).
 # CHANGE THIS LIST OF FLAGS. YES, THIS IS THE DROID YOU HAVE BEEN LOOKING FOR.
 flags = [
-{default_flags}
+ '-x', 'c++'
 ]
+
+conan_flags = json.loads(open("conan_ycm_flags.json", "r").read())
+
+flags.extend(conan_flags["flags"])
+flags.extend(conan_flags["defines"])
+flags.extend(conan_flags["includes"])
 
 
 # Set this to the absolute path to the folder (NOT the file!) containing the
@@ -164,17 +172,18 @@ def FlagsForFile( filename, **kwargs ):
 
     @property
     def filename(self):
-        return '.ycm_extra_conf.py'
+        pass
 
     @property
     def content(self):
         def prefixed(prefix, values):
             return [prefix + x for x in values]
 
-        flags = ['-x', 'c++']
-        flags.extend(self.deps_build_info.cppflags)
-        flags.extend(prefixed("-D", self.deps_build_info.defines))
-        flags.extend(prefixed("-I", self.deps_build_info.include_paths))
+        conan_flags = {
+            "includes" : prefixed("-isystem", self.deps_build_info.include_paths),
+            "defines" : prefixed("-D", self.deps_build_info.defines),
+            "flags" : self.deps_build_info.cppflags
+        }
 
         cxx_version = ''
         try:
@@ -182,5 +191,6 @@ def FlagsForFile( filename, **kwargs ):
         except:
             pass
 
-        return self.template.format(default_flags="'" + "', '".join(flags) + "'",
-                                    cxx_version=cxx_version)
+        ycm_data = self.template.format(cxx_version=cxx_version)
+        return {"conan_ycm_extra_conf.py" : ycm_data,
+                "conan_ycm_flags.json" : json.dumps(conan_flags, indent=2)}

--- a/conans/test/generators/generators_test.py
+++ b/conans/test/generators/generators_test.py
@@ -39,7 +39,7 @@ ycm
                                  'conanbuildinfo.gcc', 'conanbuildinfo.qbs', 'conanbuildinfo.pri',
                                  'SConscript_conan', 'conanbuildinfo.txt', 'conanbuildinfo.props',
                                  'conanbuildinfo.vsprops', 'conanbuildinfo.xcconfig',
-                                 '.ycm_extra_conf.py']),
+                                 'conan_ycm_flags.json', 'conan_ycm_extra_conf.py']),
                          sorted(os.listdir(client.current_folder)))
 
     def test_qmake(self):


### PR DESCRIPTION
Expose the conan dependencies in a separate json files. The consumer now
have to copy the .ycm_extra_config.py once and link the
conan_ycm_flags.json file to its build directory.

https://github.com/conan-io/conan/issues/2466

