### PR TITLE
Clean env var user for testing

### DIFF
--- a/.ci/jenkins/runner.py
+++ b/.ci/jenkins/runner.py
@@ -66,6 +66,7 @@ def run_tests(module_path, pyver, source_folder, tmp_folder,
     env = get_environ(tmp_folder)
     env["PYTHONPATH"] = source_folder
     env["CONAN_LOGGING_LEVEL"] = "50" if platform.system() == "Darwin" else "50"
+    env["CHANGE_AUTHOR_DISPLAY_NAME"] = ""
     with chdir(source_folder):
         with environment_append(env):
             run(command)


### PR DESCRIPTION
Author name in the commit is breaking the build, clearing the env var before the tests should work.
The contributor should update from develop and push again to try it.

https://conan-ci.jfrog.info/blue/organizations/jenkins/ConanTestSuite/detail/PR-2549/1/pipeline/