### PR TITLE
disabling pylint for pyinstaller

### DIFF
--- a/conans/client/cmd/export_linter.py
+++ b/conans/client/cmd/export_linter.py
@@ -12,6 +12,9 @@ from conans.errors import ConanException
 
 
 def conan_linter(conanfile_path, out):
+    if getattr(sys, 'frozen', False):
+        out.info("No linter available. Use a pip installed conan for recipe linting")
+        return
     apply_lint = os.environ.get("CONAN_RECIPE_LINTER", True)
     if not apply_lint or apply_lint == "False":
         return


### PR DESCRIPTION
- [x] Refer to the issue that supports this Pull Request.
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.

Close #2523

I have been checking extensively pyinstaller and pylint, and couldn't figure out a way to make the python modules dynamically available for pylint running from the pyinstaller app (the python modules are simply not there). So at least disable the linter with an information message.