### PR TITLE
Feature/installer refactor

### DIFF
--- a/conans/client/importer.py
+++ b/conans/client/importer.py
@@ -76,6 +76,15 @@ def run_imports(conanfile, dest_folder, output):
     return copied_files
 
 
+def remove_imports(conanfile, copied_files, output):
+    if not getattr(conanfile, "keep_imports", False):
+        for f in copied_files:
+            try:
+                os.remove(f)
+            except OSError:
+                output.warn("Unable to remove imported file from build: %s" % f)
+
+
 def run_deploy(conanfile, install_folder, output):
     deploy_output = ScopedOutput("%s deploy()" % output.scope, output)
     file_importer = _FileImporter(conanfile, install_folder)

--- a/conans/client/manager.py
+++ b/conans/client/manager.py
@@ -33,6 +33,12 @@ from conans.util.log import logger
 
 
 class BuildMode(object):
+    """ build_mode => ["*"] if user wrote "--build"
+                   => ["hello*", "bye*"] if user wrote "--build hello --build bye"
+                   => False if user wrote "never"
+                   => True if user wrote "missing"
+                   => "outdated" if user wrote "--build outdated"
+    """
     def __init__(self, params, output):
         self._out = output
         self.outdated = False

--- a/conans/test/command/imports_test.py
+++ b/conans/test/command/imports_test.py
@@ -62,9 +62,9 @@ class ImportsTest(unittest.TestCase):
         self.client.save({"conanfile.py": conanfile})
         self.client.run("export . lasote/stable")
 
-    def imports_global_path_test(self):
+    def imports_global_path_removed_test(self):
         """ Ensure that when importing files in a global path, outside the package build,
-        they are not deleted
+        they are removed too
         """
         dst_global_folder = temp_folder().replace("\\", "/")
         conanfile2 = '''
@@ -84,9 +84,8 @@ class ConanLib(ConanFile):
 
         self.client.current_folder = temp_folder()
         self.client.run("install Say/0.1@lasote/stable --build=missing")
-        for filename, content in [("file1.txt", "Hello"), ("file2.txt", "World")]:
-            filecontent = load(os.path.join(dst_global_folder, filename))
-            self.assertTrue(content, filecontent)
+        for filename in ["file1.txt", "file2.txt"]:
+            self.assertFalse(os.path.exists(os.path.join(dst_global_folder, filename)))
 
     def imports_env_var_test(self):
         conanfile2 = '''


### PR DESCRIPTION
- Refactor
- Removed bug of ``imports()`` not removing imported files to absolute paths when something is built in the cache.
