### PR TITLE
Fixed copy_deps linter warning when exporting

### DIFF
--- a/conans/client/cmd/export_linter.py
+++ b/conans/client/cmd/export_linter.py
@@ -100,6 +100,8 @@ def _normal_linter(conanfile_path):
                     return False
         if symbol == "not-callable" and "self.copy is not callable" == text:
             return False
+        if symbol == "not-callable" and "self.copy_deps is not callable" == text:
+            return False
         if symbol in ("bare-except", "broad-except"):  # No exception type(s) specified
             return False
         return True

--- a/conans/model/conan_file.py
+++ b/conans/model/conan_file.py
@@ -148,6 +148,7 @@ class ConanFile(object):
         self.deps_user_info = DepsUserInfo()
 
         self.copy = None  # initialized at runtime
+        self.copy_deps = None  # initialized at runtime
 
         # an output stream (writeln, info, warn error)
         self.output = output

--- a/conans/test/command/export_linter_test.py
+++ b/conans/test/command/export_linter_test.py
@@ -125,3 +125,19 @@ class BaseConan(ConanFile):
         self._check_linter(client.user_io.out)
         self.assertIn("ERROR: Package recipe has linter errors. Please fix them",
                       client.user_io.out)
+
+    def export_deploy_test(self):
+
+        conanfile = """
+from conans import ConanFile
+class BaseConan(ConanFile):
+    name = "baselib"
+    version = "1.0"
+
+    def deploy(self):
+        self.copy_deps("*.dll")
+"""
+        client = TestClient()
+        client.save({CONANFILE: conanfile})
+        client.run("export . conan/stable")
+        self.assertNotIn("Instance of 'BaseConan' has no 'copy_deps' member", client.out)

--- a/conans/test/command/export_linter_test.py
+++ b/conans/test/command/export_linter_test.py
@@ -140,4 +140,8 @@ class BaseConan(ConanFile):
         client = TestClient()
         client.save({CONANFILE: conanfile})
         client.run("export . conan/stable")
-        self.assertNotIn("Instance of 'BaseConan' has no 'copy_deps' member", client.out)
+        self.assertNotIn("Linter warnings", client.out)
+        self.assertNotIn("WARN: Linter. Line 8: Instance of 'BaseConan' has no 'copy_deps' member",
+                         client.out)
+        self.assertNotIn("WARN: Linter. Line 8: self.copy_deps is not callable",
+                         client.out)


### PR DESCRIPTION
- [x] Refer to the issue that supports this Pull Request: closes #2598 
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://raw.githubusercontent.com/conan-io/conan/develop/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [x] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. Also adding a description of the changes in the ``changelog.rst`` file. https://github.com/conan-io/docs
