### PR TITLE
make conan download directly retrieve the sources

### DIFF
--- a/conans/client/manager.py
+++ b/conans/client/manager.py
@@ -30,6 +30,7 @@ from conans.model.ref import ConanFileReference, PackageReference
 from conans.paths import CONANFILE, CONANINFO, CONANFILE_TXT, CONAN_MANIFEST, BUILD_INFO
 from conans.util.files import save, rmdir, normalize, mkdir, load
 from conans.util.log import logger
+from conans.client.loader_parse import load_conanfile_class
 
 
 class BuildMode(object):
@@ -220,6 +221,11 @@ class ConanManager(object):
 
         # First of all download package recipe
         remote_proxy.get_recipe(reference)
+        # Download the sources too, don't be lazy
+        conan_file_path = self._client_cache.conanfile(reference)
+        conanfile = load_conanfile_class(conan_file_path)
+        remote_proxy.complete_recipe_sources(conanfile, reference,
+                                             short_paths=conanfile.short_paths)
 
         if package_ids:
             remote_proxy.download_packages(reference, package_ids)

--- a/conans/test/command/download_test.py
+++ b/conans/test/command/download_test.py
@@ -2,9 +2,41 @@ import unittest
 import os
 from conans.test.utils.tools import TestClient, TestServer
 from conans.model.ref import ConanFileReference
+from conans.util.files import load
 
 
 class DownloadTest(unittest.TestCase):
+
+    def download_with_sources_test(self):
+        server = TestServer()
+        servers = {"default": server,
+                   "other": TestServer()}
+
+        client = TestClient(servers=servers, users={"default": [("lasote", "mypass")],
+                                                    "other": [("lasote", "mypass")]})
+        conanfile = """from conans import ConanFile
+class Pkg(ConanFile):
+    name = "pkg"
+    version = "0.1"
+    exports_sources = "*"
+"""
+        client.save({"conanfile.py": conanfile,
+                     "file.h": "myfile.h",
+                     "otherfile.cpp": "C++code"})
+        client.run("export . lasote/stable")
+
+        ref = ConanFileReference.loads("pkg/0.1@lasote/stable")
+        self.assertTrue(os.path.exists(client.paths.conanfile(ref)))
+
+        client.run("upload pkg/0.1@lasote/stable")
+        client.run("remove pkg/0.1@lasote/stable -f")
+        self.assertFalse(os.path.exists(client.paths.export(ref)))
+
+        client.run("download pkg/0.1@lasote/stable")
+        self.assertIn("Downloading conan_sources.tgz", client.out)
+        source = client.client_cache.export_sources(ref)
+        self.assertEqual("myfile.h", load(os.path.join(source, "file.h")))
+        self.assertEqual("C++code", load(os.path.join(source, "otherfile.cpp")))
 
     def download_reference_without_packages_test(self):
         server = TestServer()


### PR DESCRIPTION
- [x] Refer to the issue that supports this Pull Request.
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.

From investigating https://github.com/conan-io/conan/issues/2616 and @fsturm feedback

It happens that ``conan download`` is lazy regarding the sources. While the default lazy behavior is fine for install, I think that the correct behavior for download is to fetch them directly. This PR implements this.
