### PR TITLE
Fix disable login prompt environment variable.

### DIFF
--- a/conans/client/rest/auth_manager.py
+++ b/conans/client/rest/auth_manager.py
@@ -17,7 +17,7 @@ from conans.errors import AuthenticationException, ForbiddenException,\
 from uuid import getnode as get_mac
 import hashlib
 from conans.util.log import logger
-from os import getenv
+from conans.util.env_reader import get_env
 
 
 def input_credentials_if_unauthorized(func):
@@ -44,8 +44,7 @@ def input_credentials_if_unauthorized(func):
                 if "bintray" in remote.url:
                     self._user_io.out.info('If you don\'t have an account sign up here: '
                                            'https://bintray.com/signup/oss')
-                disable_login_prompt = getenv("CONAN_DISABLE_LOGIN_PROMPT", "False")
-                if disable_login_prompt == "True":
+                if get_env("CONAN_DISABLE_LOGIN_PROMPT", False):
                     raise AuthenticationException('User "%s" not authenticated' % self.user)
                 return retry_with_new_token(self, *args, **kwargs)
             else:


### PR DESCRIPTION
As stated in #2668:

> I think we jumped the gun here. I did some tests and now CONAN_DISABLE_LOGIN_PROMPT has to be set to True for this to work. This is not what is stated in the documentation.
> 
> I propose we switch to `get_env()` from `conans.util.env_reader` so setting it to 1 will also work and updating the documentation. I'll go do some pull requests.
> 

- [x] Refer to the issue that supports this Pull Request.
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://raw.githubusercontent.com/conan-io/conan/develop/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [x] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. Also adding a description of the changes in the ``changelog.rst`` file. https://github.com/conan-io/docs
