### PR TITLE
do not add default paths to sub-configs

### DIFF
--- a/conans/model/build_info.py
+++ b/conans/model/build_info.py
@@ -95,11 +95,6 @@ class CppInfo(_CppInfo):
             result = _CppInfo()
             result.rootpath = self.rootpath
             result.sysroot = self.sysroot
-            result.includedirs.append(DEFAULT_INCLUDE)
-            result.libdirs.append(DEFAULT_LIB)
-            result.bindirs.append(DEFAULT_BIN)
-            result.resdirs.append(DEFAULT_RES)
-            result.builddirs.append("")
             return result
 
         return self.configs.setdefault(config, _get_cpp_info())


### PR DESCRIPTION
Improvement for behavior described in: https://github.com/conan-io/conan/issues/2739

TO BE CHECKED for possible breaking behavior.
