### PR TITLE
Feature/refactor proxy registry

### DIFF
--- a/conans/client/build_requires.py
+++ b/conans/client/build_requires.py
@@ -73,7 +73,7 @@ class BuildRequires(object):
 
         return conanfile.build_requires
 
-    def install(self, reference, conanfile, installer, profile_build_requires, output):
+    def install(self, reference, conanfile, installer, profile_build_requires, output, update):
         str_ref = str(reference)
         package_build_requires = self._get_recipe_build_requires(conanfile)
 
@@ -88,12 +88,12 @@ class BuildRequires(object):
                             else:  # Profile one
                                 new_profile_build_requires[build_require.name] = build_require
 
-        self._install(conanfile, reference, package_build_requires, installer, profile_build_requires, output)
+        self._install(conanfile, reference, package_build_requires, installer, profile_build_requires, output, update)
         self._install(conanfile, reference, new_profile_build_requires, installer, profile_build_requires,
-                      output, discard=True)
+                      output, update, discard=True)
 
     def _install(self, conanfile, reference, build_requires, installer, profile_build_requires, output,
-                 discard=False):
+                 update, discard=False):
         if isinstance(reference, ConanFileReference):
             build_requires.pop(reference.name, None)
         if not build_requires:
@@ -112,7 +112,7 @@ class BuildRequires(object):
                                             build_requires_options=conanfile.build_requires_options)
 
         # compute and print the graph of transitive build-requires
-        deps_graph = self._graph_builder.load(virtual)
+        deps_graph = self._graph_builder.load_graph(virtual, check_updates=False, update=update)
         Printer(output).print_graph(deps_graph, self._registry)
         # install them, recursively
         installer.install(deps_graph, profile_build_requires)

--- a/conans/client/build_requires.py
+++ b/conans/client/build_requires.py
@@ -115,6 +115,6 @@ class BuildRequires(object):
         deps_graph = self._graph_builder.load_graph(virtual, check_updates=False, update=update)
         Printer(output).print_graph(deps_graph, self._registry)
         # install them, recursively
-        installer.install(deps_graph, profile_build_requires)
+        installer.install(deps_graph, profile_build_requires, update=update)
         _apply_build_requires(deps_graph, conanfile, build_requires)
         output.info("Installed build requirements of: %s" % (reference or "PROJECT"))

--- a/conans/client/client_cache.py
+++ b/conans/client/client_cache.py
@@ -77,7 +77,7 @@ class ClientCache(SimplePaths):
         if self._no_locks():
             return NoLock()
         return SimpleLock(join(self.conan(package_ref.conan), "locks",
-                                       package_ref.package_id))
+                               package_ref.package_id))
 
     @property
     def put_headers_path(self):
@@ -136,8 +136,8 @@ class ClientCache(SimplePaths):
         if os.path.isabs(self.conan_config.default_profile):
             return self.conan_config.default_profile
         else:
-            return os.path.expanduser(join(self.conan_folder, PROFILES_FOLDER,
-                                                   self.conan_config.default_profile))
+            return join(self.conan_folder, PROFILES_FOLDER,
+                        self.conan_config.default_profile)
 
     @property
     def default_profile(self):

--- a/conans/client/cmd/copy.py
+++ b/conans/client/cmd/copy.py
@@ -4,11 +4,9 @@ from conans.util.files import rmdir
 import shutil
 from conans.errors import ConanException
 from conans.client.loader_parse import load_conanfile_class
-from conans.client.proxy import ConanProxy
 
 
-def _prepare_sources(client_cache, user_io, remote_manager, reference, recorder):
-    remote_proxy = ConanProxy(client_cache, user_io, remote_manager, None, recorder)
+def _prepare_sources(client_cache, reference, remote_proxy):
     conan_file_path = client_cache.conanfile(reference)
     conanfile = load_conanfile_class(conan_file_path)
     remote_proxy.complete_recipe_sources(conanfile, reference,
@@ -28,14 +26,14 @@ def _get_package_ids(client_cache, reference, package_ids):
     return package_ids
 
 
-def cmd_copy(reference, user_channel, package_ids, client_cache, user_io, remote_manager, recorder,
+def cmd_copy(reference, user_channel, package_ids, client_cache, user_io, remote_proxy,
              force=False):
     """
     param package_ids: Falsey=do not copy binaries. True=All existing. []=list of ids
     """
     src_ref = ConanFileReference.loads(reference)
 
-    short_paths = _prepare_sources(client_cache, user_io, remote_manager, src_ref, recorder)
+    short_paths = _prepare_sources(client_cache, src_ref, remote_proxy)
     package_ids = _get_package_ids(client_cache, src_ref, package_ids)
     package_copy(src_ref, user_channel, package_ids, client_cache, user_io,
                  short_paths, force)

--- a/conans/client/cmd/test.py
+++ b/conans/client/cmd/test.py
@@ -29,7 +29,7 @@ class PackageTester(object):
             self._manager.install(inject_require=reference,
                                   reference=conanfile_abs_path,
                                   install_folder=test_build_folder,
-                                  remote=remote,
+                                  remote_name=remote,
                                   profile=profile,
                                   update=update,
                                   build_modes=build_modes,

--- a/conans/client/cmd/uploader.py
+++ b/conans/client/cmd/uploader.py
@@ -5,7 +5,6 @@ from conans.errors import ConanException, NotFoundException
 from conans.model.ref import PackageReference, ConanFileReference
 from conans.util.log import logger
 from conans.client.loader_parse import load_conanfile_class
-from conans.client.proxy import ConanProxy
 from conans.search.search import DiskSearchManager
 
 
@@ -20,11 +19,10 @@ def _is_a_reference(ref):
 
 class CmdUpload(object):
 
-    def __init__(self, client_cache, user_io, remote_manager, remote, recorder):
+    def __init__(self, client_cache, user_io, remote_proxy):
         self._client_cache = client_cache
         self._user_io = user_io
-        self._remote_proxy = ConanProxy(self._client_cache, self._user_io, remote_manager, remote,
-                                        recorder)
+        self._remote_proxy = remote_proxy
         self._cache_search = DiskSearchManager(self._client_cache)
 
     def upload(self, conan_reference_or_pattern, package_id=None, all_packages=None,

--- a/conans/client/cmd/user.py
+++ b/conans/client/cmd/user.py
@@ -1,11 +1,9 @@
-from conans.client.remote_registry import RemoteRegistry
 from conans.errors import ConanException
 from conans.client.store.localdb import LocalDB
 
 
-def users_list(client_cache, output, remote_name=None):
+def users_list(client_cache, registry, remote_name=None):
     # List all users from required remotes
-    registry = RemoteRegistry(client_cache.registry, output)
     if remote_name:
         remotes = [registry.remote(remote_name)]
     else:
@@ -28,9 +26,8 @@ def users_clean(client_cache):
     localdb.init(clean=True)
 
 
-def user_set(client_cache, output, user, remote_name=None):
+def user_set(client_cache, output, registry, user, remote_name=None):
     localdb = LocalDB(client_cache.localdb)
-    registry = RemoteRegistry(client_cache.registry, output)
     if not remote_name:
         remote = registry.default_remote
     else:

--- a/conans/client/conan_api.py
+++ b/conans/client/conan_api.py
@@ -515,7 +515,7 @@ class ConanAPIV1(object):
                        profile_name=None, update=False, install_folder=None):
         reference, profile = self._info_get_profile(reference, install_folder, profile_name, settings,
                                                     options, env)
-        ret = self._manager.info_get_graph(reference, remote=remote, profile=profile,
+        ret = self._manager.info_get_graph(reference, remote_name=remote, profile=profile,
                                            check_updates=update)
         deps_graph, graph_updates_info, project_reference = ret
         return deps_graph, graph_updates_info, project_reference
@@ -621,7 +621,7 @@ class ConanAPIV1(object):
 
     @api_method
     def user_set(self, user, remote_name=None):
-        return user_set(self._client_cache, self._user_io.out, user, remote_name)
+        return user_set(self._client_cache, self._user_io.out, self._registry, user, remote_name)
 
     @api_method
     def users_clean(self):
@@ -629,18 +629,18 @@ class ConanAPIV1(object):
 
     @api_method
     def users_list(self, remote=None):
-        users = users_list(self._client_cache, self._user_io.out, remote)
+        users = users_list(self._client_cache, self._registry, remote)
         for remote_name, username in users:
             self._user_io.out.info("Current '%s' user: %s" % (remote_name, username))
 
     @api_method
     def search_recipes(self, pattern, remote=None, case_sensitive=False):
-        search = Search(self._client_cache, self._remote_manager, self._user_io)
+        search = Search(self._client_cache, self._remote_manager, self._registry)
         return search.search_recipes(pattern, remote, case_sensitive)
 
     @api_method
     def search_packages(self, reference, query=None, remote=None, outdated=False):
-        search = Search(self._client_cache, self._remote_manager, self._user_io)
+        search = Search(self._client_cache, self._remote_manager, self._registry)
         return search.search_packages(reference, remote, query=query,
                                       outdated=outdated)
 

--- a/conans/client/conan_api.py
+++ b/conans/client/conan_api.py
@@ -198,11 +198,11 @@ class ConanAPIV1(object):
         self._runner = runner
         self._remote_manager = remote_manager
         self.recorder = ActionRecorder()
+        self._registry = RemoteRegistry(self._client_cache.registry, self._user_io.out)
         self._manager = ConanManager(client_cache, user_io, runner, remote_manager, search_manager,
-                                     _settings_preprocessor, self.recorder)
+                                     _settings_preprocessor, self.recorder, self._registry)
         if not interactive:
             self._user_io.disable_input()
-
 
     @api_method
     def new(self, name, header=False, pure_c=False, test=False, exports_sources=False, bare=False,
@@ -325,7 +325,7 @@ class ConanAPIV1(object):
                                   manifest_folder=manifest_folder,
                                   manifest_verify=manifest_verify,
                                   manifest_interactive=manifest_interactive,
-                                  remote=remote,
+                                  remote_name=remote,
                                   profile=profile,
                                   build_modes=build_modes,
                                   update=update,
@@ -395,7 +395,7 @@ class ConanAPIV1(object):
             raise ConanException("recipe parameter cannot be used together with package")
         # Install packages without settings (fixed ids or all)
         conan_ref = ConanFileReference.loads(reference)
-        self._manager.download(conan_ref, package, remote=remote, recipe=recipe)
+        self._manager.download(conan_ref, package, remote_name=remote, recipe=recipe)
 
     @api_method
     def install_reference(self, reference, settings=None, options=None, env=None,
@@ -416,7 +416,7 @@ class ConanAPIV1(object):
             generators = False
 
         mkdir(install_folder)
-        self._manager.install(reference=reference, install_folder=install_folder, remote=remote,
+        self._manager.install(reference=reference, install_folder=install_folder, remote_name=remote,
                               profile=profile, build_modes=build, update=update,
                               manifest_folder=manifest_folder,
                               manifest_verify=manifest_verify,
@@ -442,7 +442,7 @@ class ConanAPIV1(object):
 
         self._manager.install(reference=conanfile_path,
                               install_folder=install_folder,
-                              remote=remote,
+                              remote_name=remote,
                               profile=profile,
                               build_modes=build,
                               update=update,
@@ -594,7 +594,7 @@ class ConanAPIV1(object):
     def remove(self, pattern, query=None, packages=None, builds=None, src=False, force=False,
                remote=None, outdated=False):
         self._manager.remove(pattern, package_ids_filter=packages, build_ids=builds,
-                             src=src, force=force, remote=remote, packages_query=query,
+                             src=src, force=force, remote_name=remote, packages_query=query,
                              outdated=outdated)
 
     @api_method
@@ -604,16 +604,16 @@ class ConanAPIV1(object):
         """
         from conans.client.cmd.copy import cmd_copy
         # FIXME: conan copy does not support short-paths in Windows
+        remote_proxy = self._manager.get_proxy()
         cmd_copy(reference, user_channel, packages, self._client_cache,
-                 self._user_io, self._remote_manager, self.recorder, force=force)
+                 self._user_io, remote_proxy, force=force)
 
     @api_method
     def authenticate(self, name, password, remote=None):
-        registry = RemoteRegistry(self._client_cache.registry, self._user_io.out)
         if not remote:
-            remote = registry.default_remote
+            remote = self._registry.default_remote
         else:
-            remote = registry.remote(remote)
+            remote = self._registry.remote(remote)
         if password == "":
             name, password = self._user_io.request_login(remote_name=remote.name,
                                                          username=name)
@@ -654,49 +654,42 @@ class ConanAPIV1(object):
         if force and no_overwrite:
             raise ConanException("'no_overwrite' argument cannot be used together with 'force'")
 
-        uploader = CmdUpload(self._client_cache, self._user_io, self._remote_manager, remote, self.recorder)
+        remote_proxy = self._manager.get_proxy(remote_name=remote)
+        uploader = CmdUpload(self._client_cache, self._user_io, remote_proxy)
         return uploader.upload(pattern, package, all_packages, force, confirm, retry, retry_wait,
                                skip_upload, integrity_check, no_overwrite)
 
     @api_method
     def remote_list(self):
-        registry = RemoteRegistry(self._client_cache.registry, self._user_io.out)
-        return registry.remotes
+        return self._registry.remotes
 
     @api_method
     def remote_add(self, remote, url, verify_ssl=True, insert=None):
-        registry = RemoteRegistry(self._client_cache.registry, self._user_io.out)
-        return registry.add(remote, url, verify_ssl, insert)
+        return self._registry.add(remote, url, verify_ssl, insert)
 
     @api_method
     def remote_remove(self, remote):
-        registry = RemoteRegistry(self._client_cache.registry, self._user_io.out)
-        return registry.remove(remote)
+        return self._registry.remove(remote)
 
     @api_method
     def remote_update(self, remote, url, verify_ssl=True, insert=None):
-        registry = RemoteRegistry(self._client_cache.registry, self._user_io.out)
-        return registry.update(remote, url, verify_ssl, insert)
+        return self._registry.update(remote, url, verify_ssl, insert)
 
     @api_method
     def remote_list_ref(self):
-        registry = RemoteRegistry(self._client_cache.registry, self._user_io.out)
-        return registry.refs
+        return self._registry.refs
 
     @api_method
     def remote_add_ref(self, reference, remote):
-        registry = RemoteRegistry(self._client_cache.registry, self._user_io.out)
-        return registry.add_ref(reference, remote)
+        return self._registry.add_ref(reference, remote)
 
     @api_method
     def remote_remove_ref(self, reference):
-        registry = RemoteRegistry(self._client_cache.registry, self._user_io.out)
-        return registry.remove_ref(reference)
+        return self._registry.remove_ref(reference)
 
     @api_method
     def remote_update_ref(self, reference, remote):
-        registry = RemoteRegistry(self._client_cache.registry, self._user_io.out)
-        return registry.update_ref(reference, remote)
+        return self._registry.update_ref(reference, remote)
 
     @api_method
     def profile_list(self):

--- a/conans/client/deps_builder.py
+++ b/conans/client/deps_builder.py
@@ -339,7 +339,7 @@ class DepsGraphBuilder(object):
                 # maybe we could move these functionality to here and build only the graph
                 # with the nodes to be took in account
                 new_node = self._create_new_node(node, dep_graph, require, public_deps, name,
-                                                 check_updates, update, aliased)
+                                                 aliased, check_updates, update)
                 # RECURSION!
                 self._load_deps(new_node, new_reqs, dep_graph, public_deps, conanref,
                                 new_options, new_loop_ancestors, aliased, check_updates, update)
@@ -451,7 +451,8 @@ class DepsGraphBuilder(object):
             requirement.conan_reference = ConanFileReference.loads(dep_conanfile.alias)
             aliased[alias_reference] = requirement.conan_reference
             return self._create_new_node(current_node, dep_graph, requirement, public_deps,
-                                         name_req, aliased, alias_ref=alias_reference)
+                                         name_req, aliased, check_updates, update,
+                                         alias_ref=alias_reference)
 
         new_node = Node(requirement.conan_reference, dep_conanfile)
         dep_graph.add_node(new_node)

--- a/conans/client/deps_builder.py
+++ b/conans/client/deps_builder.py
@@ -263,7 +263,8 @@ class DepsGraphBuilder(object):
         return {conan_reference: self._retriever.update_available(conan_reference)
                 for conan_reference, _ in deps_graph.nodes}
 
-    def load(self, conanfile):
+    def load_graph(self, conanfile, check_updates, update):
+        check_updates = check_updates or update
         dep_graph = DepsGraph()
         # compute the conanfile entry point for this dependency graph
         root_node = Node(None, conanfile)
@@ -274,7 +275,7 @@ class DepsGraphBuilder(object):
         t1 = time.time()
         loop_ancestors = []
         self._load_deps(root_node, Requirements(), dep_graph, public_deps, None, None,
-                        loop_ancestors, aliased)
+                        loop_ancestors, aliased, check_updates, update)
         logger.debug("Deps-builder: Time to load deps %s" % (time.time() - t1))
         t1 = time.time()
         dep_graph.propagate_info()
@@ -305,7 +306,7 @@ class DepsGraphBuilder(object):
                                     list(conanfile.requires.values())))
 
     def _load_deps(self, node, down_reqs, dep_graph, public_deps, down_ref, down_options,
-                   loop_ancestors, aliased):
+                   loop_ancestors, aliased, check_updates, update):
         """ loads a Conan object from the given file
         param node: Node object to be expanded in this step
         down_reqs: the Requirements as coming from downstream, which can overwrite current
@@ -337,10 +338,11 @@ class DepsGraphBuilder(object):
                 # we could not download the private dep. See installer _compute_private_nodes
                 # maybe we could move these functionality to here and build only the graph
                 # with the nodes to be took in account
-                new_node = self._create_new_node(node, dep_graph, require, public_deps, name, aliased)
+                new_node = self._create_new_node(node, dep_graph, require, public_deps, name,
+                                                 check_updates, update, aliased)
                 # RECURSION!
                 self._load_deps(new_node, new_reqs, dep_graph, public_deps, conanref,
-                                new_options, new_loop_ancestors, aliased)
+                                new_options, new_loop_ancestors, aliased, check_updates, update)
             else:  # a public node already exist with this name
                 previous_node, closure = previous
                 alias_ref = aliased.get(require.conan_reference, require.conan_reference)
@@ -360,7 +362,7 @@ class DepsGraphBuilder(object):
                     public_deps[name] = previous_node, closure
                 if self._recurse(closure, new_reqs, new_options):
                     self._load_deps(previous_node, new_reqs, dep_graph, public_deps, conanref,
-                                    new_options, new_loop_ancestors, aliased)
+                                    new_options, new_loop_ancestors, aliased, check_updates, update)
 
     def _recurse(self, closure, new_reqs, new_options):
         """ For a given closure, if some requirements or options coming from downstream
@@ -436,10 +438,10 @@ class DepsGraphBuilder(object):
         return new_down_reqs, new_options
 
     def _create_new_node(self, current_node, dep_graph, requirement, public_deps, name_req, aliased,
-                         alias_ref=None):
+                         check_updates, update, alias_ref=None):
         """ creates and adds a new node to the dependency graph
         """
-        conanfile_path = self._retriever.get_recipe(requirement.conan_reference)
+        conanfile_path = self._retriever.get_recipe(requirement.conan_reference, check_updates, update)
         output = ScopedOutput(str(requirement.conan_reference), self._output)
         dep_conanfile = self._loader.load_conan(conanfile_path, output,
                                                 reference=requirement.conan_reference)

--- a/conans/client/installer.py
+++ b/conans/client/installer.py
@@ -309,7 +309,7 @@ class ConanInstaller(object):
 
             if build_needed and (conan_ref, package_id) not in self._built_packages:
                 self._build_package(conan_file, conan_ref, package_id, package_ref, output,
-                                    keep_build, profile_build_requires, flat, deps_graph)
+                                    keep_build, profile_build_requires, flat, deps_graph, update)
             else:
                 self._get_existing_package(conan_file, package_ref, output, package_folder, update)
                 self._propagate_info(conan_file, conan_ref, flat, deps_graph)
@@ -321,7 +321,7 @@ class ConanInstaller(object):
         self._propagate_info(root_conanfile, None, flat, deps_graph)
 
     def _build_package(self, conan_file, conan_ref, package_id, package_ref, output, keep_build,
-                       profile_build_requires, flat, deps_graph):
+                       profile_build_requires, flat, deps_graph, update):
         build_allowed = self._build_mode.allowed(conan_file, conan_ref)
         if not build_allowed:
             raise_package_not_found_error(conan_file, conan_ref, package_id, output, self._recorder, None)
@@ -337,7 +337,7 @@ class ConanInstaller(object):
 
         if not skip_build:
             self._build_requires.install(conan_ref, conan_file, self,
-                                         profile_build_requires, output)
+                                         profile_build_requires, output, update)
 
         # It is important that it is done AFTER build_requires install
         self._propagate_info(conan_file, conan_ref, flat, deps_graph)

--- a/conans/client/installer.py
+++ b/conans/client/installer.py
@@ -337,7 +337,7 @@ class ConanInstaller(object):
 
         if not skip_build:
             self._build_requires.install(conan_ref, conan_file, self,
-                                         profile_build_requires, output, update)
+                                         profile_build_requires, output, update=update)
 
         # It is important that it is done AFTER build_requires install
         self._propagate_info(conan_file, conan_ref, flat, deps_graph)

--- a/conans/client/installer.py
+++ b/conans/client/installer.py
@@ -226,7 +226,7 @@ class ConanInstaller(object):
         self._built_packages = set()  # To avoid re-building twice the same package reference
         self._recorder = recorder
 
-    def install(self, deps_graph, profile_build_requires, keep_build=False):
+    def install(self, deps_graph, profile_build_requires, keep_build=False, update=False):
         """ given a DepsGraph object, build necessary nodes or retrieve them
         """
         t1 = time.time()
@@ -243,7 +243,7 @@ class ConanInstaller(object):
         # Get the nodes in order and if we have to build them
         nodes_to_process = self._get_nodes(nodes_by_level, skip_private_nodes)
         self._build(nodes_to_process, deps_graph, skip_private_nodes, profile_build_requires, keep_build,
-                    root_conanfile)
+                    root_conanfile, update)
         logger.debug("Install-build %s", (time.time() - t1))
 
     def _compute_private_nodes(self, deps_graph):
@@ -288,7 +288,7 @@ class ConanInstaller(object):
                 for conan_ref, package_id, conan_file, build in nodes if build]
 
     def _build(self, nodes_to_process, deps_graph, skip_nodes, profile_build_requires, keep_build,
-               root_conanfile):
+               root_conanfile, update):
         """ The build assumes an input of conans ordered by degree, first level
         should be independent from each other, the next-second level should have
         dependencies only to first level conans.
@@ -311,7 +311,7 @@ class ConanInstaller(object):
                 self._build_package(conan_file, conan_ref, package_id, package_ref, output,
                                     keep_build, profile_build_requires, flat, deps_graph)
             else:
-                self._get_existing_package(conan_file, package_ref, output, package_folder)
+                self._get_existing_package(conan_file, package_ref, output, package_folder, update)
                 self._propagate_info(conan_file, conan_ref, flat, deps_graph)
 
             # Call the info method
@@ -374,10 +374,10 @@ class ConanInstaller(object):
                     self._log_built_package(builder.build_folder, package_ref, time.time() - t1)
                     self._built_packages.add((conan_ref, package_id))
 
-    def _get_existing_package(self, conan_file, package_reference, output, package_folder):
+    def _get_existing_package(self, conan_file, package_reference, output, package_folder, update):
         with self._client_cache.package_lock(package_reference):
             installed = get_package(conan_file, package_reference, package_folder, output,
-                                    self._recorder, self._remote_proxy)
+                                    self._recorder, self._remote_proxy, update=update)
             self._remote_proxy.handle_package_manifest(package_reference)
             if installed:
                 _handle_system_requirements(conan_file, package_reference,

--- a/conans/client/manager.py
+++ b/conans/client/manager.py
@@ -387,7 +387,7 @@ class ConanManager(object):
         if not isinstance(reference, ConanFileReference):
             build_requires.install("", conanfile, installer, profile.build_requires, output, update)
 
-        installer.install(deps_graph, profile.build_requires, keep_build)
+        installer.install(deps_graph, profile.build_requires, keep_build, update=update)
         build_mode.report_matches()
 
         if install_folder:

--- a/conans/client/package_installer.py
+++ b/conans/client/package_installer.py
@@ -28,9 +28,8 @@ Or read "http://docs.conan.io/en/latest/faq/troubleshooting.html#error-missing-p
 ''' % (conan_ref, conan_ref.name))
 
 
-def get_package(conanfile, package_ref, package_folder, output, recorder, proxy):
+def get_package(conanfile, package_ref, package_folder, output, recorder, proxy, update):
     # TODO: This access to proxy attributes has to be improved
-    update = proxy._update
     remote_manager = proxy._remote_manager
     registry = proxy.registry
     try:

--- a/conans/client/proxy.py
+++ b/conans/client/proxy.py
@@ -10,16 +10,15 @@ from conans.client.action_recorder import INSTALL_ERROR_MISSING, INSTALL_ERROR_N
 from conans.errors import (ConanException, NotFoundException, NoRemoteAvailable)
 from conans.model.ref import PackageReference
 from conans.paths import EXPORT_SOURCES_TGZ_NAME
-from conans.util.files import mkdir, rmdir
+from conans.util.files import mkdir
 from conans.util.log import logger
-from conans.util.tracer import log_recipe_got_from_local_cache,\
-    log_package_got_from_local_cache
+from conans.util.tracer import log_recipe_got_from_local_cache
 
 
 class ConanProxy(object):
     """ Class to access the conan storage, to perform typical tasks as to get packages,
     getting conanfiles, uploading, removing from remote, etc.
-    It uses the RemoteRegistry to control where the packages come from.
+    It uses the registry to control where the packages come from.
     """
     def __init__(self, client_cache, user_io, remote_manager, remote_name, recorder, registry,
                  manifest_manager=False):

--- a/conans/client/proxy.py
+++ b/conans/client/proxy.py
@@ -5,7 +5,6 @@ from requests.exceptions import RequestException
 from conans.client.loader_parse import load_conanfile_class
 from conans.client.local_file_getter import get_path
 from conans.client.output import ScopedOutput
-from conans.client.remote_registry import RemoteRegistry
 from conans.client.remover import DiskRemover
 from conans.client.action_recorder import INSTALL_ERROR_MISSING, INSTALL_ERROR_NETWORK
 from conans.errors import (ConanException, NotFoundException, NoRemoteAvailable)
@@ -22,17 +21,17 @@ class ConanProxy(object):
     getting conanfiles, uploading, removing from remote, etc.
     It uses the RemoteRegistry to control where the packages come from.
     """
-    def __init__(self, client_cache, user_io, remote_manager, remote_name, recorder,
-                 update=False, check_updates=False, manifest_manager=False):
+    def __init__(self, client_cache, user_io, remote_manager, remote_name, recorder, registry,
+                 manifest_manager=False):
+        # collaborators
         self._client_cache = client_cache
         self._out = user_io.out
         self._remote_manager = remote_manager
-        self._registry = RemoteRegistry(self._client_cache.registry, self._out)
-        self._remote_name = remote_name
-        self._update = update
-        self._check_updates = check_updates or update  # Update forces check (and of course the update)
+        self._registry = registry
         self._manifest_manager = manifest_manager
         self._recorder = recorder
+        # inputs
+        self._remote_name = remote_name
 
     @property
     def registry(self):
@@ -71,23 +70,24 @@ class ConanProxy(object):
 
         return True
 
-    def get_package(self, package_ref, short_paths):
+    def get_package(self, package_ref, short_paths, check_updates, update):
         """ obtain a package, either from disk or retrieve from remotes if necessary
         and not necessary to build
         """
         output = ScopedOutput(str(package_ref.conan), self._out)
+        check_updates = check_updates or update
         package_folder = self._client_cache.package(package_ref, short_paths=short_paths)
 
         # Check current package status
         if os.path.exists(package_folder):
-            if self._check_updates:
+            if check_updates:
                 read_manifest = self._client_cache.load_package_manifest(package_ref)
                 try:  # get_conan_manifest can fail, not in server
                     upstream_manifest = self.get_package_manifest(package_ref)
                     if upstream_manifest != read_manifest:
                         if upstream_manifest.time > read_manifest.time:
                             output.warn("Current package is older than remote upstream one")
-                            if self._update:
+                            if update:
                                 output.warn("Removing it to retrieve or build an updated one")
                                 rmdir(package_folder)
                         else:
@@ -125,24 +125,24 @@ class ConanProxy(object):
             self._remote_manager.get_recipe_sources(conan_reference, export_path, sources_folder,
                                                     current_remote)
 
-    def get_recipe(self, conan_reference):
+    def get_recipe(self, conan_reference, check_updates, update):
         with self._client_cache.conanfile_write_lock(conan_reference):
-            result = self._get_recipe(conan_reference)
+            result = self._get_recipe(conan_reference, check_updates, update)
         return result
 
-    def _get_recipe(self, conan_reference):
+    def _get_recipe(self, conan_reference, check_updates, update):
         output = ScopedOutput(str(conan_reference), self._out)
-
+        check_updates = check_updates or update
         # check if it is in disk
         conanfile_path = self._client_cache.conanfile(conan_reference)
 
         if os.path.exists(conanfile_path):
-            if self._check_updates:
+            if check_updates:
                 ret = self.update_available(conan_reference)
                 if ret != 0:  # Found and not equal
                     remote, ref_remote = self._get_remote(conan_reference)
                     if ret == 1:
-                        if not self._update:
+                        if not update:
                             if remote != ref_remote:  # Forced new remote
                                 output.warn("There is a new conanfile in '%s' remote. "
                                             "Execute 'install -u -r %s' to update it."
@@ -159,7 +159,7 @@ class ConanProxy(object):
 
                             output.info("Updated!")
                     elif ret == -1:
-                        if not self._update:
+                        if not update:
                             output.info("Current conanfile is newer than %s's one" % remote.name)
                         else:
                             output.error("Current conanfile is newer than %s's one. "

--- a/conans/client/remote_registry.py
+++ b/conans/client/remote_registry.py
@@ -184,7 +184,6 @@ class RemoteRegistry(object):
             _, refs = self._load()
             new_remotes = OrderedDict()
             for remote in remotes:
-                print remote, type(remote)
                 new_remotes[remote.name] = (remote.url, remote.verify_ssl)
             refs = {k: v for k, v in refs.items() if v in new_remotes}
             self._save(new_remotes, refs)

--- a/conans/client/remote_registry.py
+++ b/conans/client/remote_registry.py
@@ -81,7 +81,7 @@ class RemoteRegistry(object):
 
     @property
     def remotes(self):
-        return self._remote_dict.values()
+        return list(self._remote_dict.values())
 
     def remote(self, name):
         try:

--- a/conans/client/remote_registry.py
+++ b/conans/client/remote_registry.py
@@ -19,6 +19,7 @@ class RemoteRegistry(object):
     def __init__(self, filename, output):
         self._filename = filename
         self._output = output
+        self._remotes = None
 
     def _parse(self, contents):
         remotes = OrderedDict()
@@ -75,29 +76,34 @@ class RemoteRegistry(object):
     def default_remote(self):
         try:
             return self.remotes[0]
-        except:
+        except IndexError:
             raise NoRemoteAvailable("No default remote defined in %s" % self._filename)
 
     @property
     def remotes(self):
-        with fasteners.InterProcessLock(self._filename + ".lock", logger=logger):
-            remotes, _ = self._load()
-            return [Remote(ref, remote, verify_ssl) for ref, (remote, verify_ssl) in remotes.items()]
+        return self._remote_dict.values()
+
+    def remote(self, name):
+        try:
+            return self._remote_dict[name]
+        except KeyError:
+            raise NoRemoteAvailable("No remote '%s' defined in remotes in file %s"
+                                    % (name, self._filename))
+
+    @property
+    def _remote_dict(self):
+        if self._remotes is None:
+            with fasteners.InterProcessLock(self._filename + ".lock", logger=logger):
+                remotes, _ = self._load()
+                self._remotes = OrderedDict([(ref, Remote(ref, remote, verify_ssl))
+                                             for ref, (remote, verify_ssl) in remotes.items()])
+        return self._remotes
 
     @property
     def refs(self):
         with fasteners.InterProcessLock(self._filename + ".lock", logger=logger):
             _, refs = self._load()
             return refs
-
-    def remote(self, name):
-        with fasteners.InterProcessLock(self._filename + ".lock", logger=logger):
-            remotes, _ = self._load()
-            try:
-                return Remote(name, remotes[name][0], remotes[name][1])
-            except KeyError:
-                raise NoRemoteAvailable("No remote '%s' defined in remotes in file %s"
-                                        % (name, self._filename))
 
     def get_ref(self, conan_reference):
         with fasteners.InterProcessLock(self._filename + ".lock", logger=logger):
@@ -157,6 +163,7 @@ class RemoteRegistry(object):
         self._add_update(remote_name, remote, verify_ssl, exists_function, insert)
 
     def remove(self, remote_name):
+        self._remotes = None  # invalidate cached remotes
         with fasteners.InterProcessLock(self._filename + ".lock", logger=logger):
             remotes, refs = self._load()
             if remote_name not in remotes:
@@ -172,16 +179,18 @@ class RemoteRegistry(object):
         self._add_update(remote_name, remote, verify_ssl, exists_function, insert)
 
     def define_remotes(self, remotes):
+        self._remotes = None  # invalidate cached remotes
         with fasteners.InterProcessLock(self._filename + ".lock", logger=logger):
             _, refs = self._load()
             new_remotes = OrderedDict()
             for remote in remotes:
+                print remote, type(remote)
                 new_remotes[remote.name] = (remote.url, remote.verify_ssl)
             refs = {k: v for k, v in refs.items() if v in new_remotes}
             self._save(new_remotes, refs)
 
     def _add_update(self, remote_name, remote, verify_ssl, exists_function, insert=None):
-
+        self._remotes = None  # invalidate cached remotes
         with fasteners.InterProcessLock(self._filename + ".lock", logger=logger):
             remotes, refs = self._load()
             exists_function(remotes)

--- a/conans/test/model/transitive_reqs_test.py
+++ b/conans/test/model/transitive_reqs_test.py
@@ -37,7 +37,7 @@ class Retriever(object):
         conan_path = os.path.join(self.folder, "/".join(conan_ref), CONANFILE)
         save(conan_path, content)
 
-    def get_recipe(self, conan_ref):
+    def get_recipe(self, conan_ref, check_updates, update):  # @UnusedVariable
         conan_path = os.path.join(self.folder, "/".join(conan_ref), CONANFILE)
         return conan_path
 
@@ -135,7 +135,7 @@ class ConanRequirementsTest(unittest.TestCase):
 
     def root(self, content):
         root_conan = self.retriever.root(content)
-        deps_graph = self.builder.load(root_conan)
+        deps_graph = self.builder.load_graph(root_conan, False, False)
         return deps_graph
 
     def test_basic(self):
@@ -1632,7 +1632,7 @@ class CoreSettingsTest(unittest.TestCase):
         retriever = Retriever(loader, self.output)
         builder = DepsGraphBuilder(retriever, self.output, loader, MockRequireResolver())
         root_conan = retriever.root(content)
-        deps_graph = builder.load(root_conan)
+        deps_graph = builder.load_graph(root_conan, False, False)
         return deps_graph
 
     def test_basic(self):
@@ -1920,7 +1920,7 @@ class ChatConan(ConanFile):
         retriever.conan(hello_ref, hello_content)
 
         root_conan = retriever.root(chat_content)
-        deps_graph = builder.load(root_conan)
+        deps_graph = builder.load_graph(root_conan, False, False)
 
         self.assertEqual(3, len(deps_graph.nodes))
         hello = _get_nodes(deps_graph, "Hello")[0]

--- a/conans/test/model/transitive_reqs_test.py
+++ b/conans/test/model/transitive_reqs_test.py
@@ -1517,7 +1517,7 @@ class ConsumerConan(ConanFile):
 
     def root(self, content):
         root_conan = self.retriever.root(content)
-        deps_graph = self.builder.load(root_conan)
+        deps_graph = self.builder.load_graph(root_conan, False, False)
         return deps_graph
 
     def test_avoid_duplicate_expansion(self):

--- a/conans/test/model/version_ranges_test.py
+++ b/conans/test/model/version_ranges_test.py
@@ -106,7 +106,7 @@ class Retriever(object):
         conan_path = os.path.join(self.folder, "/".join(conan_ref), CONANFILE)
         save(conan_path, content)
 
-    def get_recipe(self, conan_ref):
+    def get_recipe(self, conan_ref, check_updates, update):  # @UnusedVariables
         conan_path = os.path.join(self.folder, "/".join(conan_ref), CONANFILE)
         return conan_path
 
@@ -187,7 +187,7 @@ class SayConan(ConanFile):
 
     def root(self, content):
         root_conan = self.retriever.root(content)
-        deps_graph = self.builder.load(root_conan)
+        deps_graph = self.builder.load_graph(root_conan, False, False)
         return deps_graph
 
     def test_local_basic(self):


### PR DESCRIPTION
- Avoid creation of RemoteRegistry everywhere, use dependency injection
- Avoid creation of ConanProxy in multiple places
- Use ``remote_name`` instead of ``remote`` when it is not a ``Remote`` object
- Don't use ``update`` and ``check_updates`` as class attributes of proxy, pass them as arguments
- Cache remote list in ``RemoteRegistry``
