### PR TITLE
Allowing requiring color output with ``CONAN_COLOR_DISPLAY=1``

### DIFF
--- a/conans/client/conan_api.py
+++ b/conans/client/conan_api.py
@@ -144,11 +144,21 @@ class ConanAPIV1(object):
     @staticmethod
     def factory(interactive=None):
         """Factory"""
-
-        use_color = get_env("CONAN_COLOR_DISPLAY", 1)
-        if use_color and hasattr(sys.stdout, "isatty") and sys.stdout.isatty():
+        # Respect color env setting or check tty if unset
+        color_set = "CONAN_COLOR_DISPLAY" in os.environ
+        if ((color_set and get_env("CONAN_COLOR_DISPLAY", 1))
+                or (not color_set
+                    and hasattr(sys.stdout, "isatty")
+                    and sys.stdout.isatty())):
+            # in PyCharm disable convert/strip
+            if get_env("PYCHARM_HOSTED"):
+                convert = False
+                strip = False
+            else:
+                convert = None
+                strip = None
             import colorama
-            colorama.init()
+            colorama.init(convert=convert, strip=strip)
             color = True
         else:
             color = False


### PR DESCRIPTION
- [x] Refer to the issue that supports this Pull Request.
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://raw.githubusercontent.com/conan-io/conan/develop/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [x] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. Also adding a description of the changes in the ``changelog.rst`` file. https://github.com/conan-io/docs

Issue: #2782 
Change how CONAN_COLOR_DISPLAY is handled and add special handling when PYCHARM detected.
- The terminal used for run config inside of PYCHARM requires special settings for colored output.
- Allowing requiring color output with ``CONAN_COLOR_DISPLAY=1`` environment variable
- If ``CONAN_COLOR_DISPLAY`` is not set rely on tty detection for colored output

[docs PR](https://github.com/conan-io/docs/pull/635)
