### PR TITLE
fixed options initialization in local flow

### DIFF
--- a/conans/client/loader.py
+++ b/conans/client/loader.py
@@ -59,7 +59,7 @@ class ConanFileLoader(object):
 
             if consumer:
                 self._user_options.descope_options(result.name)
-                result.options.initialize_upstream(self._user_options)
+                result.options.initialize_upstream(self._user_options, local=local)
                 self._user_options.clear_unscoped_options()
             else:
                 result.in_local_cache = True

--- a/conans/model/options.py
+++ b/conans/model/options.py
@@ -431,8 +431,8 @@ class PackageOptions(object):
         # For local commands, to restore state from conaninfo it is necessary to remove
         for k in self._data.keys():
             try:
-                self._data[k].value = getattr(values, k)
-            except AttributeError:
+                self._data[k].value = values._dict[k]
+            except KeyError:
                 self._data.pop(k)
 
     def propagate_upstream(self, package_values, down_ref, own_ref, pattern_options):

--- a/conans/model/options.py
+++ b/conans/model/options.py
@@ -429,7 +429,7 @@ class PackageOptions(object):
 
     def set_local(self, values):
         # For local commands, to restore state from conaninfo it is necessary to remove
-        for k in self._data.keys():
+        for k in list(self._data):
             try:
                 self._data[k].value = values._dict[k]
             except KeyError:

--- a/conans/model/options.py
+++ b/conans/model/options.py
@@ -430,10 +430,9 @@ class PackageOptions(object):
     def set_local(self, values):
         # For local commands, to restore state from conaninfo it is necessary to remove
         for k in self._data.keys():
-            val = getattr(values, k, None)
-            if val:
-                self._data[k].value = val
-            else:
+            try:
+                self._data[k].value = getattr(values, k)
+            except AttributeError:
                 self._data.pop(k)
 
     def propagate_upstream(self, package_values, down_ref, own_ref, pattern_options):

--- a/conans/model/options.py
+++ b/conans/model/options.py
@@ -427,6 +427,15 @@ class PackageOptions(object):
             self._ensure_exists(name)
             self._data[name].value = value
 
+    def set_local(self, values):
+        # For local commands, to restore state from conaninfo it is necessary to remove
+        for k in self._data.keys():
+            val = getattr(values, k, None)
+            if val:
+                self._data[k].value = val
+            else:
+                self._data.pop(k)
+
     def propagate_upstream(self, package_values, down_ref, own_ref, pattern_options):
         """
         :param: package_values: PackageOptionValues({"shared": "True"}
@@ -547,13 +556,16 @@ class Options(object):
                 pkg_values = self._deps_package_values.setdefault(name, PackageOptionValues())
                 pkg_values.propagate_upstream(option_values, down_ref, own_ref, name)
 
-    def initialize_upstream(self, user_values):
+    def initialize_upstream(self, user_values, local=False):
         """ used to propagate from downstream the options to the upper requirements
         """
         if user_values is not None:
             assert isinstance(user_values, OptionsValues)
             # This values setter implements an update, not an overwrite
-            self._package_options.values = user_values._package_values
+            if local:
+                self._package_options.set_local(user_values._package_values)
+            else:
+                self._package_options.values = user_values._package_values
             for package_name, package_values in user_values._reqs_options.items():
                 pkg_values = self._deps_package_values.setdefault(package_name, PackageOptionValues())
                 pkg_values.update(package_values)


### PR DESCRIPTION
- [x] Refer to the issue that supports this Pull Request.
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.

Close #2781

The local flow was not recovering the correct state. It was done for settings, but not for options.
