### PR TITLE
Feature/proxy refactor

### DIFF
--- a/conans/client/cmd/copy.py
+++ b/conans/client/cmd/copy.py
@@ -4,13 +4,14 @@ from conans.util.files import rmdir
 import shutil
 from conans.errors import ConanException
 from conans.client.loader_parse import load_conanfile_class
+from conans.client.source import complete_recipe_sources
 
 
-def _prepare_sources(client_cache, reference, remote_proxy):
+def _prepare_sources(client_cache, reference, remote_manager, registry):
     conan_file_path = client_cache.conanfile(reference)
     conanfile = load_conanfile_class(conan_file_path)
-    remote_proxy.complete_recipe_sources(conanfile, reference,
-                                         short_paths=conanfile.short_paths)
+    complete_recipe_sources(remote_manager, client_cache, registry,
+                            conanfile, reference)
     return conanfile.short_paths
 
 
@@ -26,14 +27,14 @@ def _get_package_ids(client_cache, reference, package_ids):
     return package_ids
 
 
-def cmd_copy(reference, user_channel, package_ids, client_cache, user_io, remote_proxy,
-             force=False):
+def cmd_copy(reference, user_channel, package_ids, client_cache, user_io, remote_manager,
+             registry, force=False):
     """
     param package_ids: Falsey=do not copy binaries. True=All existing. []=list of ids
     """
     src_ref = ConanFileReference.loads(reference)
 
-    short_paths = _prepare_sources(client_cache, src_ref, remote_proxy)
+    short_paths = _prepare_sources(client_cache, src_ref, remote_manager, registry)
     package_ids = _get_package_ids(client_cache, src_ref, package_ids)
     package_copy(src_ref, user_channel, package_ids, client_cache, user_io,
                  short_paths, force)

--- a/conans/client/cmd/export.py
+++ b/conans/client/cmd/export.py
@@ -24,7 +24,7 @@ def export_alias(reference, target_reference, client_cache):
 from conans import ConanFile
 
 class AliasConanfile(ConanFile):
-alias = "%s"
+    alias = "%s"
 """ % str(target_reference)
 
     export_path = client_cache.export(reference)

--- a/conans/client/cmd/export.py
+++ b/conans/client/cmd/export.py
@@ -15,8 +15,24 @@ from conans.model.manifest import FileTreeManifest
 from conans.model.ref import ConanFileReference
 from conans.paths import CONAN_MANIFEST, CONANFILE
 from conans.search.search import DiskSearchManager
-from conans.util.files import save, load, rmdir, is_dirty, set_dirty
+from conans.util.files import save, load, rmdir, is_dirty, set_dirty, mkdir
 from conans.util.log import logger
+
+
+def export_alias(reference, target_reference, client_cache):
+    conanfile = """
+from conans import ConanFile
+
+class AliasConanfile(ConanFile):
+alias = "%s"
+""" % str(target_reference)
+
+    export_path = client_cache.export(reference)
+    mkdir(export_path)
+    save(os.path.join(export_path, CONANFILE), conanfile)
+    mkdir(client_cache.export_sources(reference))
+    digest = FileTreeManifest.create(export_path)
+    save(os.path.join(export_path, CONAN_MANIFEST), str(digest))
 
 
 def cmd_export(conanfile_path, name, version, user, channel, keep_source,

--- a/conans/client/cmd/uploader.py
+++ b/conans/client/cmd/uploader.py
@@ -73,11 +73,11 @@ class CmdUpload(object):
 
         defined_remote = self._registry.get_ref(conan_ref)
         if remote_name:  # If remote_name is given, use it
-            upload_remote = self.remote(remote_name)
+            upload_remote = self._registry.remote(remote_name)
         elif defined_remote:  # Else, if the package had defined a remote, use it
             upload_remote = defined_remote
         else:  # Or use the default otherwise
-            upload_remote = self.default_remote
+            upload_remote = self._registry.default_remote
 
         if not force:
             self._check_recipe_date(conan_ref, upload_remote)

--- a/conans/client/cmd/uploader.py
+++ b/conans/client/cmd/uploader.py
@@ -1,4 +1,3 @@
-import os
 import time
 
 from conans.errors import ConanException, NotFoundException
@@ -6,6 +5,8 @@ from conans.model.ref import PackageReference, ConanFileReference
 from conans.util.log import logger
 from conans.client.loader_parse import load_conanfile_class
 from conans.search.search import DiskSearchManager
+from conans.paths import EXPORT_SOURCES_TGZ_NAME
+from conans.client.source import complete_recipe_sources
 
 
 def _is_a_reference(ref):
@@ -19,51 +20,29 @@ def _is_a_reference(ref):
 
 class CmdUpload(object):
 
-    def __init__(self, client_cache, user_io, remote_proxy):
+    def __init__(self, client_cache, user_io, remote_manager, registry):
         self._client_cache = client_cache
         self._user_io = user_io
-        self._remote_proxy = remote_proxy
+        self._remote_manager = remote_manager
+        self._registry = registry
         self._cache_search = DiskSearchManager(self._client_cache)
 
-    def upload(self, conan_reference_or_pattern, package_id=None, all_packages=None,
+    def upload(self, reference_or_pattern, package_id=None, all_packages=None,
                force=False, confirm=False, retry=0, retry_wait=0, skip_upload=False,
-               integrity_check=False, no_overwrite=None):
+               integrity_check=False, no_overwrite=None, remote_name=None):
         """If package_id is provided, conan_reference_or_pattern is a ConanFileReference"""
-        if package_id and not _is_a_reference(conan_reference_or_pattern):
+        if package_id and not _is_a_reference(reference_or_pattern):
             raise ConanException("-p parameter only allowed with a valid recipe reference, "
                                  "not with a pattern")
         t1 = time.time()
-        if package_id:  # Upload package
-            ref = ConanFileReference.loads(conan_reference_or_pattern)
-            self._check_reference(ref)
-            self.upload_package(PackageReference(ref, package_id), retry=retry,
-                                retry_wait=retry_wait, skip_upload=skip_upload,
-                                integrity_check=integrity_check, no_overwrite=no_overwrite)
-        else:  # Upload conans
-            self._run_upload(conan_reference_or_pattern, all_packages=all_packages,
-                             force=force, confirm=confirm,
-                             retry=retry, retry_wait=retry_wait, skip_upload=skip_upload,
-                             integrity_check=integrity_check, no_overwrite=no_overwrite)
-
-        logger.debug("====> Time manager upload: %f" % (time.time() - t1))
-
-    def _run_upload(self, ref_or_pattern, force=False, all_packages=False, confirm=False,
-                    retry=None, retry_wait=None, skip_upload=False, integrity_check=False,
-                    no_overwrite=None):
-        """Upload all the recipes matching 'pattern'"""
-        if _is_a_reference(ref_or_pattern):
-            ref = ConanFileReference.loads(ref_or_pattern)
-            export_path = self._client_cache.export(ref)
-            if not os.path.exists(export_path):
-                raise NotFoundException("There is no local conanfile exported as %s"
-                                        % str(ref))
+        if package_id or _is_a_reference(reference_or_pattern):  # Upload package
+            ref = ConanFileReference.loads(reference_or_pattern)
             references = [ref, ]
             confirm = True
         else:
-            references = self._cache_search.search_recipes(ref_or_pattern)
-
-        if not references:
-            raise NotFoundException("No packages found matching pattern '%s'" % ref_or_pattern)
+            references = self._cache_search.search_recipes(reference_or_pattern)
+            if not references:
+                raise NotFoundException("No packages found matching pattern '%s'" % reference_or_pattern)
 
         for conan_ref in references:
             upload = True
@@ -71,55 +50,83 @@ class CmdUpload(object):
                 msg = "Are you sure you want to upload '%s'?" % str(conan_ref)
                 upload = self._user_io.request_boolean(msg)
             if upload:
-                self._upload(conan_ref, force, all_packages, retry, retry_wait, skip_upload,
-                             integrity_check, no_overwrite)
+                try:
+                    conanfile_path = self._client_cache.conanfile(conan_ref)
+                    conan_file = load_conanfile_class(conanfile_path)
+                except NotFoundException:
+                    raise NotFoundException("There is no local conanfile exported as %s"
+                                            % str(conan_ref))
+                if all_packages:
+                    packages_ids = self._client_cache.conan_packages(conan_ref)
+                elif package_id:
+                    packages_ids = [package_id, ]
+                else:
+                    packages_ids = []
+                self._upload(conan_file, conan_ref, force, packages_ids, retry, retry_wait, skip_upload,
+                             integrity_check, no_overwrite, remote_name=remote_name)
 
-    def _upload(self, conan_ref, force, all_packages, retry, retry_wait, skip_upload,
-                integrity_check, no_overwrite):
+        logger.debug("====> Time manager upload: %f" % (time.time() - t1))
+
+    def _upload(self, conan_file, conan_ref, force, packages_ids, retry, retry_wait, skip_upload,
+                integrity_check, no_overwrite, remote_name):
         """Uploads the recipes and binaries identified by conan_ref"""
+
+        remote, ref_remote = self._registry.get_remotes(conan_ref, remote_name)
+        if not ref_remote:
+            self._user_io.out.warn("Remote for '%s' not defined, uploading to %s"
+                                   % (str(conan_ref), remote.name))
         if not force:
-            self._check_recipe_date(conan_ref)
+            self._check_recipe_date(conan_ref, remote)
 
         self._user_io.out.info("Uploading %s" % str(conan_ref))
-        self._remote_proxy.upload_recipe(conan_ref, retry, retry_wait, skip_upload, no_overwrite)
+        self._upload_recipe(conan_ref, retry, retry_wait, skip_upload, no_overwrite, remote)
 
-        if all_packages:
-            self._check_reference(conan_ref)
+        if packages_ids:
+            # Can't use build_policy_always here because it's not loaded (only load_class)
+            if conan_file.build_policy == "always":
+                raise ConanException("Conanfile has build_policy='always', "
+                                     "no packages can be uploaded")
+            total = len(packages_ids)
+            for index, package_id in enumerate(packages_ids):
+                self._upload_package(PackageReference(conan_ref, package_id), index + 1, total,
+                                     retry, retry_wait, skip_upload, integrity_check, no_overwrite,
+                                     remote)
 
-            packages = self._client_cache.conan_packages(conan_ref)
-            total = len(packages)
-            for index, package_id in enumerate(packages):
-                self.upload_package(PackageReference(conan_ref, package_id), index + 1, total,
-                                    retry, retry_wait, skip_upload, integrity_check, no_overwrite)
+        if not ref_remote and not skip_upload:
+            self._registry.set_ref(conan_ref, remote)
 
-    def _check_reference(self, conan_reference):
-        try:
-            conanfile_path = self._client_cache.conanfile(conan_reference)
-            conan_file = load_conanfile_class(conanfile_path)
-        except NotFoundException:
-            raise NotFoundException("There is no local conanfile exported as %s"
-                                    % str(conan_reference))
+    def _upload_recipe(self, conan_reference, retry, retry_wait, skip_upload, no_overwrite, remote):
+        conan_file_path = self._client_cache.conanfile(conan_reference)
+        current_remote = self._registry.get_ref(conan_reference)
+        if remote != current_remote:
+            conanfile = load_conanfile_class(conan_file_path)
+            complete_recipe_sources(self._remote_manager, self._client_cache, self._registry,
+                                    conanfile, conan_reference)
+            ignore_deleted_file = None
+        else:
+            ignore_deleted_file = EXPORT_SOURCES_TGZ_NAME
+        result = self._remote_manager.upload_recipe(conan_reference, remote, retry, retry_wait,
+                                                    ignore_deleted_file=ignore_deleted_file,
+                                                    skip_upload=skip_upload,
+                                                    no_overwrite=no_overwrite)
+        return result
 
-        # Can't use build_policy_always here because it's not loaded (only load_class)
-        if conan_file.build_policy == "always":
-            raise ConanException("Conanfile has build_policy='always', "
-                                 "no packages can be uploaded")
-
-    def upload_package(self, package_ref, index=1, total=1, retry=None, retry_wait=None,
-                       skip_upload=False, integrity_check=False, no_overwrite=None):
+    def _upload_package(self, package_ref, index=1, total=1, retry=None, retry_wait=None,
+                        skip_upload=False, integrity_check=False, no_overwrite=None, remote=None):
         """Uploads the package identified by package_id"""
 
         msg = ("Uploading package %d/%d: %s" % (index, total, str(package_ref.package_id)))
         t1 = time.time()
         self._user_io.out.info(msg)
-        self._remote_proxy.upload_package(package_ref, retry, retry_wait, skip_upload,
-                                          integrity_check, no_overwrite)
 
+        result = self._remote_manager.upload_package(package_ref, remote, retry, retry_wait,
+                                                     skip_upload, integrity_check, no_overwrite)
+        return result
         logger.debug("====> Time uploader upload_package: %f" % (time.time() - t1))
 
-    def _check_recipe_date(self, conan_ref):
+    def _check_recipe_date(self, conan_ref, remote):
         try:
-            remote_recipe_manifest = self._remote_proxy.get_conan_manifest(conan_ref)
+            remote_recipe_manifest = self._remote_manager.get_conan_manifest(conan_ref, remote)
         except NotFoundException:
             return  # First time uploading this package
 

--- a/conans/client/cmd/uploader.py
+++ b/conans/client/cmd/uploader.py
@@ -82,7 +82,7 @@ class CmdUpload(object):
         if not force:
             self._check_recipe_date(conan_ref, upload_remote)
 
-        self._user_io.out.info("Uploading '%s' to remote '%s'"
+        self._user_io.out.info("Uploading %s to remote '%s'"
                                % (str(conan_ref), upload_remote.name))
         self._upload_recipe(conan_ref, retry, retry_wait, skip_upload, no_overwrite, upload_remote)
 

--- a/conans/client/conan_api.py
+++ b/conans/client/conan_api.py
@@ -629,9 +629,8 @@ class ConanAPIV1(object):
         """
         from conans.client.cmd.copy import cmd_copy
         # FIXME: conan copy does not support short-paths in Windows
-        remote_proxy = self._manager.get_proxy()
         cmd_copy(reference, user_channel, packages, self._client_cache,
-                 self._user_io, remote_proxy, force=force)
+                 self._user_io, self._remote_manager, self._registry, force=force)
 
     @api_method
     def authenticate(self, name, password, remote=None):
@@ -679,10 +678,9 @@ class ConanAPIV1(object):
         if force and no_overwrite:
             raise ConanException("'no_overwrite' argument cannot be used together with 'force'")
 
-        remote_proxy = self._manager.get_proxy(remote_name=remote)
-        uploader = CmdUpload(self._client_cache, self._user_io, remote_proxy)
+        uploader = CmdUpload(self._client_cache, self._user_io, self._remote_manager, self._registry)
         return uploader.upload(pattern, package, all_packages, force, confirm, retry, retry_wait,
-                               skip_upload, integrity_check, no_overwrite)
+                               skip_upload, integrity_check, no_overwrite, remote)
 
     @api_method
     def remote_list(self):

--- a/conans/client/conan_api.py
+++ b/conans/client/conan_api.py
@@ -40,6 +40,8 @@ from conans.client.cmd.profile import cmd_profile_update, cmd_profile_get,\
     cmd_profile_delete_key, cmd_profile_create, cmd_profile_list
 from conans.client.cmd.search import Search
 from conans.client.cmd.user import users_clean, users_list, user_set
+from conans.client.importer import undo_imports
+from conans.client.cmd.export import cmd_export, export_alias
 
 
 default_manifest_folder = '.conan_manifests'
@@ -156,15 +158,11 @@ class ConanAPIV1(object):
                 or (not color_set
                     and hasattr(sys.stdout, "isatty")
                     and sys.stdout.isatty())):
-            # in PyCharm disable convert/strip
-            if get_env("PYCHARM_HOSTED"):
-                convert = False
-                strip = False
-            else:
-                convert = None
-                strip = None
             import colorama
-            colorama.init(convert=convert, strip=strip)
+            if get_env("PYCHARM_HOSTED"):  # in PyCharm disable convert/strip
+                colorama.init(convert=False, strip=False)
+            else:
+                colorama.init()
             color = True
         else:
             color = False
@@ -200,8 +198,8 @@ class ConanAPIV1(object):
             # Settings preprocessor
             if interactive is None:
                 interactive = not get_env("CONAN_NON_INTERACTIVE", False)
-            conan = Conan(client_cache, user_io, get_conan_runner(), remote_manager, search_manager,
-                          settings_preprocessor, interactive=interactive)
+            conan = ConanAPIV1(client_cache, user_io, get_conan_runner(), remote_manager, search_manager,
+                               settings_preprocessor, interactive=interactive)
 
         return conan, client_cache, user_io
 
@@ -304,7 +302,8 @@ class ConanAPIV1(object):
         # Forcing an export!
         if not not_export:
             scoped_output.highlight("Exporting package recipe")
-            self._manager.export(conanfile_path, name, version, user, channel, keep_source)
+            cmd_export(conanfile_path, name, version, user, channel, keep_source,
+                       self._user_io.out, self._client_cache)
 
         if build_modes is None:  # Not specified, force build the tested library
             build_modes = [name]
@@ -402,7 +401,8 @@ class ConanAPIV1(object):
            (version and conanfile.version and conanfile.version != version):
             raise ConanException("Specified name/version doesn't match with the "
                                  "name/version in the conanfile")
-        self._manager.export(conanfile_path, name, version, user, channel)
+        cmd_export(conanfile_path, name, version, user, channel, False,
+                   self._user_io.out, self._client_cache)
 
         if not (name and version):
             name = conanfile.name
@@ -607,12 +607,13 @@ class ConanAPIV1(object):
     def imports_undo(self, manifest_path):
         cwd = os.getcwd()
         manifest_path = _make_abs_path(manifest_path, cwd)
-        self._manager.imports_undo(manifest_path)
+        undo_imports(manifest_path, self._user_io.out)
 
     @api_method
     def export(self, path, name, version, user, channel, keep_source=False, cwd=None):
         conanfile_path = _get_conanfile_path(path, cwd, py=True)
-        self._manager.export(conanfile_path, name, version, user, channel, keep_source)
+        cmd_export(conanfile_path, name, version, user, channel, keep_source,
+                   self._user_io.out, self._client_cache)
 
     @api_method
     def remove(self, pattern, query=None, packages=None, builds=None, src=False, force=False,
@@ -747,14 +748,22 @@ class ConanAPIV1(object):
 
     @api_method
     def get_path(self, reference, package_id=None, path=None, remote=None):
+        from conans.client.local_file_getter import get_path
         reference = ConanFileReference.loads(str(reference))
-        return self._manager.get_path(reference, package_id, path, remote)
+        if not path:
+            path = "conanfile.py" if not package_id else "conaninfo.txt"
+
+        if not remote:
+            return get_path(self._client_cache, reference, package_id, path)
+        else:
+            remote = self._registry.remote(remote)
+            return self._remote_manager.get_path(reference, package_id, path, remote)
 
     @api_method
     def export_alias(self, reference, target_reference):
         reference = ConanFileReference.loads(str(reference))
         target_reference = ConanFileReference.loads(str(target_reference))
-        return self._manager.export_alias(reference, target_reference)
+        return export_alias(reference, target_reference, self._client_cache)
 
 
 Conan = ConanAPIV1

--- a/conans/client/conan_api.py
+++ b/conans/client/conan_api.py
@@ -754,10 +754,10 @@ class ConanAPIV1(object):
             path = "conanfile.py" if not package_id else "conaninfo.txt"
 
         if not remote:
-            return get_path(self._client_cache, reference, package_id, path)
+            return get_path(self._client_cache, reference, package_id, path), path
         else:
             remote = self._registry.remote(remote)
-            return self._remote_manager.get_path(reference, package_id, path, remote)
+            return self._remote_manager.get_path(reference, package_id, path, remote), path
 
     @api_method
     def export_alias(self, reference, target_reference):

--- a/conans/client/installer.py
+++ b/conans/client/installer.py
@@ -19,7 +19,7 @@ from conans.client.packager import create_package
 from conans.client.generators import write_generators, TXTGenerator
 from conans.model.build_info import CppInfo
 from conans.client.output import ScopedOutput
-from conans.client.source import config_source
+from conans.client.source import config_source, complete_recipe_sources
 from conans.util.env_reader import get_env
 from conans.client.importer import remove_imports
 
@@ -362,7 +362,8 @@ class ConanInstaller(object):
                 raise ConanException(msg)
         else:
             with self._client_cache.conanfile_write_lock(conan_ref):
-                self._remote_proxy.get_recipe_sources(conan_ref, conan_file.short_paths)
+                complete_recipe_sources(self._remote_proxy._remote_manager, self._client_cache,
+                                        self._remote_proxy.registry, conan_file, conan_ref)
                 builder.prepare_build()
 
         with self._client_cache.conanfile_read_lock(conan_ref):

--- a/conans/client/manager.py
+++ b/conans/client/manager.py
@@ -19,7 +19,7 @@ from conans.client.profile_loader import read_conaninfo_profile
 from conans.client.proxy import ConanProxy
 from conans.client.remover import ConanRemover
 from conans.client.graph.require_resolver import RequireResolver
-from conans.client.source import config_source_local
+from conans.client.source import config_source_local, complete_recipe_sources
 from conans.client.tools import cross_building, get_cross_building_settings
 from conans.client.userio import UserIO
 from conans.errors import NotFoundException, ConanException, conanfile_exception_formatter
@@ -229,8 +229,8 @@ class ConanManager(object):
         # Download the sources too, don't be lazy
         conan_file_path = self._client_cache.conanfile(reference)
         conanfile = load_conanfile_class(conan_file_path)
-        remote_proxy.complete_recipe_sources(conanfile, reference,
-                                             short_paths=conanfile.short_paths)
+        complete_recipe_sources(self._remote_manager, self._client_cache, self._registry,
+                                conanfile, reference)
 
         if package_ids:
             remote_proxy.download_packages(reference, package_ids)

--- a/conans/client/manager.py
+++ b/conans/client/manager.py
@@ -5,11 +5,11 @@ from collections import Counter
 from conans.client import packager
 from conans.client.graph.build_requires import BuildRequires
 from conans.client.client_cache import ClientCache
-from conans.client.cmd.export import cmd_export, _execute_export
+from conans.client.cmd.export import _execute_export
 from conans.client.graph.graph_builder import DepsGraphBuilder
 from conans.client.generators import write_generators
 from conans.client.generators.text import TXTGenerator
-from conans.client.importer import run_imports, undo_imports, run_deploy
+from conans.client.importer import run_imports, run_deploy
 from conans.client.installer import ConanInstaller, call_system_requirements
 from conans.client.loader import ConanFileLoader
 from conans.client.manifest_manager import ManifestManager
@@ -24,9 +24,8 @@ from conans.client.tools import cross_building, get_cross_building_settings
 from conans.client.userio import UserIO
 from conans.errors import NotFoundException, ConanException, conanfile_exception_formatter
 from conans.model.conan_file import get_env_context_manager
-from conans.model.manifest import FileTreeManifest
 from conans.model.ref import ConanFileReference, PackageReference
-from conans.paths import CONANFILE, CONANINFO, CONANFILE_TXT, CONAN_MANIFEST, BUILD_INFO
+from conans.paths import CONANFILE, CONANINFO, CONANFILE_TXT, BUILD_INFO
 from conans.util.files import save, rmdir, normalize, mkdir, load
 from conans.util.log import logger
 from conans.client.loader_parse import load_conanfile_class
@@ -157,10 +156,6 @@ class ConanManager(object):
         else:
             self._settings_preprocessor.preprocess(cache_settings)
         return ConanFileLoader(self._runner, cache_settings, profile)
-
-    def export(self, conanfile_path, name, version, user, channel,  keep_source=False):
-        cmd_export(conanfile_path, name, version, user, channel, keep_source,
-                   self._user_io.out, self._client_cache)
 
     def get_proxy(self, remote_name=None, manifest_manager=None):
         remote_proxy = ConanProxy(self._client_cache, self._user_io, self._remote_manager,
@@ -433,9 +428,6 @@ class ConanManager(object):
                             source_folder, output)
         config_source_local(source_folder, conanfile, output)
 
-    def imports_undo(self, current_path):
-        undo_imports(current_path, self._user_io.out)
-
     def imports(self, conan_file_path, dest_folder, info_folder):
         """
         :param conan_file_path: Abs path to a conanfile
@@ -530,30 +522,6 @@ class ConanManager(object):
                                self._registry)
         remover.remove(pattern, remote_name, src, build_ids, package_ids_filter, force=force,
                        packages_query=packages_query, outdated=outdated)
-
-    def get_path(self, reference, package_id=None, path=None, remote_name=None):
-        remote_proxy = self.get_proxy(remote_name=remote_name)
-        if not path and not package_id:
-            path = "conanfile.py"
-        elif not path and package_id:
-            path = "conaninfo.txt"
-        return remote_proxy.get_path(reference, package_id, path), path
-
-    def export_alias(self, reference, target_reference):
-
-        conanfile = """
-from conans import ConanFile
-
-class AliasConanfile(ConanFile):
-    alias = "%s"
-""" % str(target_reference)
-
-        export_path = self._client_cache.export(reference)
-        mkdir(export_path)
-        save(os.path.join(export_path, CONANFILE), conanfile)
-        mkdir(self._client_cache.export_sources(reference))
-        digest = FileTreeManifest.create(export_path)
-        save(os.path.join(export_path, CONAN_MANIFEST), str(digest))
 
 
 def _load_deps_info(current_path, conanfile, required):

--- a/conans/client/proxy.py
+++ b/conans/client/proxy.py
@@ -313,22 +313,6 @@ class ConanProxy(object):
             if search_result:
                 return search_result
 
-    def remove(self, conan_ref):
-        if not self._remote_name:
-            raise ConanException("Cannot remove, remote not defined")
-        remote = self._registry.remote(self._remote_name)
-        result = self._remote_manager.remove(conan_ref, remote)
-        current_remote = self._registry.get_ref(conan_ref)
-        if current_remote == remote:
-            self._registry.remove_ref(conan_ref)
-        return result
-
-    def remove_packages(self, conan_ref, remove_ids):
-        if not self._remote_name:
-            raise ConanException("Cannot remove, remote not defined")
-        remote = self._registry.remote(self._remote_name)
-        return self._remote_manager.remove_packages(conan_ref, remove_ids, remote)
-
     def download_packages(self, reference, package_ids):
         assert(isinstance(package_ids, list))
         remote, _ = self._get_remote(reference)

--- a/conans/client/proxy.py
+++ b/conans/client/proxy.py
@@ -3,7 +3,6 @@ import os
 from requests.exceptions import RequestException
 
 from conans.client.loader_parse import load_conanfile_class
-from conans.client.local_file_getter import get_path
 from conans.client.output import ScopedOutput
 from conans.client.remover import DiskRemover
 from conans.client.action_recorder import INSTALL_ERROR_MISSING, INSTALL_ERROR_NETWORK
@@ -329,13 +328,6 @@ class ConanProxy(object):
             raise ConanException("Cannot remove, remote not defined")
         remote = self._registry.remote(self._remote_name)
         return self._remote_manager.remove_packages(conan_ref, remove_ids, remote)
-
-    def get_path(self, conan_ref, package_id, path):
-        if not self._remote_name:
-            return get_path(self._client_cache, conan_ref, package_id, path)
-        else:
-            remote = self._registry.remote(self._remote_name)
-            return self._remote_manager.get_path(conan_ref, package_id, path, remote)
 
     def download_packages(self, reference, package_ids):
         assert(isinstance(package_ids, list))

--- a/conans/client/remote_registry.py
+++ b/conans/client/remote_registry.py
@@ -99,6 +99,14 @@ class RemoteRegistry(object):
                                              for ref, (remote, verify_ssl) in remotes.items()])
         return self._remotes
 
+    def get_remotes(self, conan_reference, remote_name):
+        ref_remote = self.get_ref(conan_reference)
+        if remote_name:
+            remote = self.remote(remote_name)
+        else:
+            remote = ref_remote or self.default_remote
+        return remote, ref_remote
+
     @property
     def refs(self):
         with fasteners.InterProcessLock(self._filename + ".lock", logger=logger):

--- a/conans/client/remote_registry.py
+++ b/conans/client/remote_registry.py
@@ -99,14 +99,6 @@ class RemoteRegistry(object):
                                              for ref, (remote, verify_ssl) in remotes.items()])
         return self._remotes
 
-    def get_remotes(self, conan_reference, remote_name):
-        ref_remote = self.get_ref(conan_reference)
-        if remote_name:
-            remote = self.remote(remote_name)
-        else:
-            remote = ref_remote or self.default_remote
-        return remote, ref_remote
-
     @property
     def refs(self):
         with fasteners.InterProcessLock(self._filename + ".lock", logger=logger):

--- a/conans/client/remover.py
+++ b/conans/client/remover.py
@@ -87,11 +87,15 @@ class ConanRemover(object):
         self._remote_manager = remote_manager
         self._registry = remote_registry
 
-    def _remote_remove(self, reference, package_ids):
+    def _remote_remove(self, reference, package_ids, remote):
         if package_ids is None:
-            self._remote_proxy.remove(reference)
+            result = self._remote_manager.remove(reference, remote)
+            current_remote = self._registry.get_ref(reference)
+            if current_remote == remote:
+                self._registry.remove_ref(reference)
+            return result
         else:
-            self._remote_proxy.remove_packages(reference, package_ids)
+            return self._remote_manager.remove_packages(reference, package_ids, remote)
 
     def _local_remove(self, reference, src, build_ids, package_ids):
         # Make sure to clean the locks too
@@ -159,7 +163,7 @@ class ConanRemover(object):
             if self._ask_permission(reference, src, build_ids, package_ids, force):
                 deleted_refs.append(reference)
                 if remote:
-                    self._remote_remove(reference, package_ids)
+                    self._remote_remove(reference, package_ids, remote)
                 else:
                     deleted_refs.append(reference)
                     self._local_remove(reference, src, build_ids, package_ids)

--- a/conans/search/search.py
+++ b/conans/search/search.py
@@ -1,6 +1,7 @@
 import re
+import os
 
-from abc import ABCMeta, abstractmethod
+
 from fnmatch import translate
 
 from conans.errors import ConanException, NotFoundException
@@ -8,59 +9,8 @@ from conans.model.info import ConanInfo
 from conans.model.ref import PackageReference, ConanFileReference
 from conans.paths import CONANINFO
 from conans.util.log import logger
-import os
 from conans.search.query_parse import infix_to_postfix, evaluate_postfix
-
-
-class SearchAdapterABC(object):
-    """Methods that allows access to disk or s3 or whatever to make a search"""
-    __metaclass__ = ABCMeta
-
-    @abstractmethod
-    def list_folder_subdirs(self, basedir, level):
-        pass
-
-    @abstractmethod
-    def path_exists(self, path):
-        pass
-
-    @abstractmethod
-    def load(self, filepath):
-        pass
-
-    @abstractmethod
-    def join_paths(self, *args):
-        pass
-
-
-class DiskSearchAdapter(SearchAdapterABC):
-
-    def list_folder_subdirs(self, basedir, level):
-        from conans.util.files import list_folder_subdirs
-        return list_folder_subdirs(basedir, level)
-
-    def path_exists(self, path):
-        return os.path.exists(path)
-
-    def load(self, filepath):
-        from conans.util.files import load
-        return load(filepath)
-
-    def join_paths(self, *args):
-        return os.path.join(*args)
-
-
-class SearchManagerABC(object):
-    """Methods that allows access to disk or s3 or whatever to make a search"""
-    __metaclass__ = ABCMeta
-
-    @abstractmethod
-    def search_recipes(self, pattern=None, ignorecase=True):
-        pass
-
-    @abstractmethod
-    def search_packages(self, reference, query):
-        pass
+from conans.util.files import list_folder_subdirs, load
 
 
 def filter_outdated(packages_infos, recipe_hash):
@@ -124,13 +74,12 @@ def evaluate(prop_name, prop_value, conan_vars_info):
     return False
 
 
-class DiskSearchManager(SearchManagerABC):
+class DiskSearchManager(object):
     """Will search recipes and packages using a file system.
     Can be used with a SearchAdapter"""
 
-    def __init__(self, paths, disk_search_adapter=None):
+    def __init__(self, paths):
         self._paths = paths
-        self._adapter = disk_search_adapter or DiskSearchAdapter()
 
     def search_recipes(self, pattern=None, ignorecase=True):
         # Conan references in main storage
@@ -140,7 +89,7 @@ class DiskSearchManager(SearchManagerABC):
             pattern = translate(pattern)
             pattern = re.compile(pattern, re.IGNORECASE) if ignorecase else re.compile(pattern)
 
-        subdirs = self._adapter.list_folder_subdirs(basedir=self._paths.store, level=4)
+        subdirs = list_folder_subdirs(basedir=self._paths.store, level=4)
         if not pattern:
             return sorted([ConanFileReference(*folder.split("/")) for folder in subdirs])
         else:
@@ -166,17 +115,16 @@ class DiskSearchManager(SearchManagerABC):
     def _get_local_infos_min(self, reference):
         result = {}
         packages_path = self._paths.packages(reference)
-        subdirs = self._adapter.list_folder_subdirs(packages_path, level=1)
+        subdirs = list_folder_subdirs(packages_path, level=4)
         for package_id in subdirs:
             # Read conaninfo
             try:
                 package_reference = PackageReference(reference, package_id)
-                info_path = self._adapter.join_paths(self._paths.package(package_reference,
-                                                                         short_paths=None),
-                                                     CONANINFO)
-                if not self._adapter.path_exists(info_path):
+                info_path = os.path.join(self._paths.package(package_reference,
+                                                             short_paths=None), CONANINFO)
+                if not os.path.exists(info_path):
                     raise NotFoundException("")
-                conan_info_content = self._adapter.load(info_path)
+                conan_info_content = load(info_path)
                 conan_vars_info = ConanInfo.loads(conan_info_content).serialize_min()
                 result[package_id] = conan_vars_info
 

--- a/conans/search/search.py
+++ b/conans/search/search.py
@@ -115,7 +115,7 @@ class DiskSearchManager(object):
     def _get_local_infos_min(self, reference):
         result = {}
         packages_path = self._paths.packages(reference)
-        subdirs = list_folder_subdirs(packages_path, level=4)
+        subdirs = list_folder_subdirs(packages_path, level=1)
         for package_id in subdirs:
             # Read conaninfo
             try:

--- a/conans/server/server_launcher.py
+++ b/conans/server/server_launcher.py
@@ -11,7 +11,7 @@ from conans.model.version import Version
 from conans.server.migrate import migrate_and_get_server_config
 from conans import __version__ as SERVER_VERSION
 from conans.paths import conan_expand_user, SimplePaths
-from conans.search.search import DiskSearchManager, DiskSearchAdapter
+from conans.search.search import DiskSearchManager
 from conans import SERVER_CAPABILITIES
 
 
@@ -37,9 +37,7 @@ class ServerLauncher(object):
 
         file_manager = get_file_manager(server_config, updown_auth_manager=updown_auth_manager)
 
-        search_adapter = DiskSearchAdapter()
-        search_manager = DiskSearchManager(SimplePaths(server_config.disk_storage_path),
-                                           search_adapter)
+        search_manager = DiskSearchManager(SimplePaths(server_config.disk_storage_path))
 
         server_capabilities = SERVER_CAPABILITIES
         self.ra = ConanServer(server_config.port, credentials_manager, updown_auth_manager,

--- a/conans/test/command/upload_complete_test.py
+++ b/conans/test/command/upload_complete_test.py
@@ -239,16 +239,16 @@ class TestConan(ConanFile):
         self.client.run("upload Hello/1.2@lasote/stable", ignore_error=False)
         self.assertIn("Uploading conanmanifest.txt", self.client.user_io.out)
 
+    def single_binary_test(self):
+        """ basic installation of a new conans
+        """
+        # Try to upload an package without upload conans first
+        self.client.run('upload %s -p %s' % (self.conan_ref, str(self.package_ref.package_id)))
+        self.assertIn("Uploaded conan recipe '%s'" % str(self.conan_ref), self.client.out)
+
     def simple_test(self):
         """ basic installation of a new conans
         """
-
-        # Try to upload an package without upload conans first
-        self.client.run('upload %s -p %s' % (self.conan_ref, str(self.package_ref.package_id)),
-                        ignore_error=True)
-        self.assertIn("There are no remote conanfiles like %s" % str(self.conan_ref),
-                      self.client.user_io.out)
-
         # Upload conans
         self.client.run('upload %s' % str(self.conan_ref))
         self.assertTrue(os.path.exists(self.server_reg_folder))

--- a/conans/test/command/upload_complete_test.py
+++ b/conans/test/command/upload_complete_test.py
@@ -305,7 +305,7 @@ class TestConan(ConanFile):
         self.client.run('upload %s --all' % str(self.conan_ref))
         lines = [line.strip() for line in str(self.client.user_io.out).splitlines()
                  if line.startswith("Uploading")]
-        self.assertEqual(lines, ["Uploading Hello/1.2.1@frodo/stable",
+        self.assertEqual(lines, ["Uploading Hello/1.2.1@frodo/stable to remote 'default'",
                                  "Uploading conanmanifest.txt",
                                  "Uploading conanfile.py",
                                  "Uploading conan_export.tgz",

--- a/conans/test/command/upload_test.py
+++ b/conans/test/command/upload_test.py
@@ -235,7 +235,7 @@ class MyPkg(ConanFile):
 
         # CASE: Without changes
         client.run("create . frodo/stable")
-        ## upload recipe and packages
+        # upload recipe and packages
         client.run("upload Hello0/1.2.1@frodo/stable --all --no-overwrite")
         self.assertIn("Recipe is up to date, upload skipped", client.all_output)
         self.assertIn("Package is up to date, upload skipped", client.out)
@@ -246,18 +246,18 @@ class MyPkg(ConanFile):
                                            "self.copy(\"*.h\")\n        self.copy(\"*.cpp\")")
         client.save({"conanfile.py": new_recipe})
         client.run("create . frodo/stable")
-        ## upload recipe and packages
+        # upload recipe and packages
         error = client.run("upload Hello0/1.2.1@frodo/stable --all --no-overwrite",
                            ignore_error=True)
         self.assertTrue(error)
         self.assertIn("Forbbiden overwrite", client.out)
         self.assertNotIn("Uploading package", client.out)
 
-         # CASE: When package changes
+        # CASE: When package changes
         client.run("upload Hello0/1.2.1@frodo/stable --all")
         with environment_append({"MY_VAR": "True"}):
             client.run("create . frodo/stable")
-        ## upload recipe and packages
+        # upload recipe and packages
         error = client.run("upload Hello0/1.2.1@frodo/stable --all --no-overwrite",
                            ignore_error=True)
         self.assertTrue(error)
@@ -307,7 +307,7 @@ class MyPkg(ConanFile):
                                            "self.copy(\"*.h\")\n        self.copy(\"*.cpp\")")
         client.save({"conanfile.py": new_recipe})
         client.run("create . frodo/stable")
-        ## upload recipe and packages
+        # upload recipe and packages
         error = client.run("upload Hello0/1.2.1@frodo/stable --all --no-overwrite recipe",
                            ignore_error=True)
         self.assertTrue(error)
@@ -318,7 +318,7 @@ class MyPkg(ConanFile):
         client.run("upload Hello0/1.2.1@frodo/stable --all")
         with environment_append({"MY_VAR": "True"}):
             client.run("create . frodo/stable")
-        ## upload recipe and packages
+        # upload recipe and packages
         client.run("upload Hello0/1.2.1@frodo/stable --all --no-overwrite recipe")
         self.assertIn("Recipe is up to date, upload skipped", client.out)
         self.assertIn("Uploading conan_package.tgz", client.out)
@@ -395,7 +395,7 @@ class Pkg(ConanFile):
         self.assertNotIn("Uploading conanmanifest.txt", client.out)
         self.assertNotIn("Uploading conanfile.py", client.out)
         self.assertNotIn("Uploading conan_export.tgz", client.out)
-        
+
     def upload_login_prompt_disabled_user_not_authenticated_test(self):
         """ When a user is not authenticated, uploads should fail when login prompt has been disabled.
         """
@@ -412,7 +412,7 @@ class Pkg(ConanFile):
         self.assertNotIn("Uploading conanmanifest.txt", client.out)
         self.assertNotIn("Uploading conanfile.py", client.out)
         self.assertNotIn("Uploading conan_export.tgz", client.out)
-        
+
     def upload_login_prompt_disabled_user_authenticated_test(self):
         """ When a user is authenticated, uploads should work even when login prompt has been disabled.
         """

--- a/conans/test/functional/disk_search_test.py
+++ b/conans/test/functional/disk_search_test.py
@@ -3,7 +3,7 @@ import unittest
 from conans.paths import (BUILD_FOLDER, PACKAGES_FOLDER, EXPORT_FOLDER, SimplePaths, CONANINFO)
 from conans.model.ref import ConanFileReference
 from conans.test.utils.test_files import temp_folder
-from conans.search.search import DiskSearchManager, DiskSearchAdapter
+from conans.search.search import DiskSearchManager
 from conans.util.files import save
 from conans.model.info import ConanInfo
 
@@ -13,8 +13,7 @@ class SearchTest(unittest.TestCase):
     def setUp(self):
         folder = temp_folder()
         paths = SimplePaths(folder)
-        search_adapter = DiskSearchAdapter()
-        self.search_manager = DiskSearchManager(paths, search_adapter)
+        self.search_manager = DiskSearchManager(paths)
         os.chdir(paths.store)
         self.paths = paths
 
@@ -63,8 +62,7 @@ class SearchTest(unittest.TestCase):
         conan_ref5 = ConanFileReference.loads("SDL_fake/1.10@lasote/testing")
         os.makedirs("%s/%s" % (root_folder5, EXPORT_FOLDER))
         # Case insensitive searches
-        search_adapter = DiskSearchAdapter()
-        search_manager = DiskSearchManager(self.paths, search_adapter)
+        search_manager = DiskSearchManager(self.paths)
 
         reg_conans = sorted([str(_reg) for _reg in search_manager.search_recipes("*")])
         self.assertEqual(reg_conans, [str(conan_ref5),

--- a/conans/test/integration/export_sources_test.py
+++ b/conans/test/integration/export_sources_test.py
@@ -166,12 +166,7 @@ class ExportsSourcesTest(unittest.TestCase):
             expected_exports.append("license.txt")
 
         self.assertEqual(scan_folder(self.export_folder), sorted(expected_exports))
-        if reuploaded and mode == "exports":
-            # In this mode, we know the sources are not required
-            # So the local folder is created, but empty
-            self.assertTrue(os.path.exists(self.export_sources_folder))
-        else:
-            self.assertFalse(os.path.exists(self.export_sources_folder))
+        self.assertFalse(os.path.exists(self.export_sources_folder))
 
     def _check_export_uploaded_folder(self, mode, export_folder=None, export_src_folder=None):
         if mode == "exports_sources":

--- a/conans/test/server/service/service_test.py
+++ b/conans/test/server/service/service_test.py
@@ -15,7 +15,7 @@ from time import sleep
 from conans.model.manifest import FileTreeManifest
 from conans.test.utils.test_files import temp_folder
 from conans.server.store.disk_adapter import ServerDiskAdapter
-from conans.search.search import DiskSearchManager, DiskSearchAdapter
+from conans.search.search import DiskSearchManager
 
 
 class MockFileSaver(object):
@@ -91,8 +91,7 @@ class ConanServiceTest(unittest.TestCase):
         self.paths = SimplePaths(self.tmp_dir)
         self.file_manager = FileManager(self.paths, adapter)
 
-        search_adapter = DiskSearchAdapter()
-        self.search_manager = DiskSearchManager(self.paths, search_adapter)
+        self.search_manager = DiskSearchManager(self.paths)
 
         self.service = ConanService(authorizer, self.file_manager, "lasote")
         self.search_service = SearchService(authorizer, self.search_manager, "lasote")

--- a/conans/test/server/utils/server_launcher.py
+++ b/conans/test/server/utils/server_launcher.py
@@ -9,7 +9,7 @@ from conans.util.log import logger
 from conans.util.files import mkdir
 from conans.test.utils.test_files import temp_folder
 from conans.server.migrate import migrate_and_get_server_config
-from conans.search.search import DiskSearchAdapter, DiskSearchManager
+from conans.search.search import DiskSearchManager
 from conans.paths import SimplePaths
 import time
 import shutil
@@ -54,8 +54,7 @@ class TestServerLauncher(object):
         self.file_manager = get_file_manager(server_config, public_url=base_url,
                                              updown_auth_manager=updown_auth_manager)
 
-        search_adapter = DiskSearchAdapter()
-        self.search_manager = DiskSearchManager(SimplePaths(server_config.disk_storage_path), search_adapter)
+        self.search_manager = DiskSearchManager(SimplePaths(server_config.disk_storage_path))
         # Prepare some test users
         if not read_permissions:
             read_permissions = server_config.read_permissions


### PR DESCRIPTION
- Refactors:
  - Removed SearchAdapterABC, SearchManagerABC
  - Moved functionality among files, simplifying duplicated code
- Changes:
  - The only minor change should be that upload now always upload the recipe for ``-p=id`` argument (it didn't in the past, only uploaded binary. Breaking?
