### PR TITLE
PATH always uppercase in self.env_info

### DIFF
--- a/conans/model/env_info.py
+++ b/conans/model/env_info.py
@@ -142,7 +142,6 @@ class EnvValues(object):
             # DepsEnvInfo. the OLD values are always kept, never overwrite,
             elif isinstance(env_obj, DepsEnvInfo):
                 for (name, value) in env_obj.vars.items():
-                    name = name.upper() if name.lower() == "path" else name
                     self.add(name, value)
             else:
                 raise ConanException("unknown env type: %s" % env_obj)
@@ -197,10 +196,17 @@ class EnvInfo(object):
     def __init__(self):
         self._values_ = {}
 
+    @staticmethod
+    def _adjust_casing(name):
+        """We don't want to mix "path" with "PATH", actually we don`t want to mix anything
+        with different casing. Furthermore in Windows all is uppercase, but managing all in
+        upper case will be breaking."""
+        return name.upper() if name.lower() == "path" else name
+
     def __getattr__(self, name):
         if name.startswith("_") and name.endswith("_"):
             return super(EnvInfo, self).__getattr__(name)
-
+        name = self._adjust_casing(name)
         attr = self._values_.get(name)
         if not attr:
             self._values_[name] = []
@@ -209,6 +215,7 @@ class EnvInfo(object):
     def __setattr__(self, name, value):
         if name.startswith("_") and name.endswith("_"):
             return super(EnvInfo, self).__setattr__(name, value)
+        name = self._adjust_casing(name)
         self._values_[name] = value
 
     @property

--- a/conans/test/integration/conan_env_test.py
+++ b/conans/test/integration/conan_env_test.py
@@ -673,7 +673,7 @@ PATH=["path_from_B"]""", info)
             self.assertIn('PATH="path_from_A":"path_from_B":$PATH', activate)
         else:
             activate = load(os.path.join(client.current_folder, "activate.bat"))
-            self.assertIn('PATH=path_from_A;path_from_B;%PATH%"', activate)
+            self.assertIn('PATH=path_from_A;path_from_B;%PATH%', activate)
 
     def check_conaninfo_completion_test(self):
         """

--- a/conans/test/integration/conan_env_test.py
+++ b/conans/test/integration/conan_env_test.py
@@ -662,6 +662,7 @@ virtualenv
         client.save({"conanfile.txt": conanfile}, clean_first=True)
         client.run("install .")
         info = load(os.path.join(client.current_folder, "conanbuildinfo.txt"))
+        info = info.replace("\r\n", "\n")
         self.assertIn("""
 [ENV_libA]
 PATH=["path_from_A"]
@@ -673,7 +674,6 @@ PATH=["path_from_B"]""", info)
         else:
             activate = load(os.path.join(client.current_folder, "activate.bat"))
             self.assertIn('PATH=path_from_A;path_from_B;%PATH%"', activate)
-
 
     def check_conaninfo_completion_test(self):
         """

--- a/conans/test/integration/conan_env_test.py
+++ b/conans/test/integration/conan_env_test.py
@@ -626,6 +626,45 @@ class Hello2Conan(ConanFile):
         self.assertInSep("VAR2=>24:23*", client.user_io.out)
         self.assertInSep("VAR3=>bestvalue*", client.user_io.out)
 
+    def mix_path_case_test(self):
+        client = TestClient()
+        conanfile = """
+from conans import ConanFile
+class LibConan(ConanFile):
+    name = "libB"
+    version = "1.0"
+
+    def package_info(self):
+        self.env_info.path = ["path_from_B"]
+"""
+        client.save({"conanfile.py": conanfile})
+        client.run("create . user/channel")
+
+        conanfile = """
+from conans import ConanFile
+class LibConan(ConanFile):
+    name = "libA"
+    version = "1.0"
+    requires = "libB/1.0@user/channel"
+
+    def package_info(self):
+        self.env_info.PATH.extend(["path_from_A"])
+"""
+        client.save({"conanfile.py": conanfile})
+        client.run("create . user/channel")
+
+        conanfile = """
+[requires]
+libA/1.0@user/channel
+"""
+        client.save({"conanfile.txt": conanfile}, clean_first=True)
+        client.run("install .")
+        info = load(os.path.join(client.current_folder, "conanbuildinfo.txt"))
+        self.assertIn("""
+[ENV_libA]
+PATH=["path_from_A"]
+[ENV_libB]
+PATH=["path_from_B"]""", info)
 
     def check_conaninfo_completion_test(self):
         """

--- a/conans/test/integration/conan_env_test.py
+++ b/conans/test/integration/conan_env_test.py
@@ -656,6 +656,8 @@ class LibConan(ConanFile):
         conanfile = """
 [requires]
 libA/1.0@user/channel
+[generators]
+virtualenv
 """
         client.save({"conanfile.txt": conanfile}, clean_first=True)
         client.run("install .")
@@ -665,6 +667,13 @@ libA/1.0@user/channel
 PATH=["path_from_A"]
 [ENV_libB]
 PATH=["path_from_B"]""", info)
+        if platform.system() != "Windows":
+            activate = load(os.path.join(client.current_folder, "activate.sh"))
+            self.assertIn('PATH="path_from_A":"path_from_B":$PATH', activate)
+        else:
+            activate = load(os.path.join(client.current_folder, "activate.bat"))
+            self.assertIn('PATH=path_from_A;path_from_B;%PATH%"', activate)
+
 
     def check_conaninfo_completion_test(self):
         """


### PR DESCRIPTION
- [x] Refer to the issue that supports this Pull Request. Closes #2620

Instead of fixing the casing on the propagation, the path is always added uppercased now to the env object.
