### PR TITLE
refactor for remove and manifests

### DIFF
--- a/conans/client/client_cache.py
+++ b/conans/client/client_cache.py
@@ -12,7 +12,8 @@ from conans.model.manifest import FileTreeManifest
 from conans.model.profile import Profile
 from conans.model.ref import ConanFileReference
 from conans.model.settings import Settings
-from conans.paths import SimplePaths, CONANINFO, PUT_HEADERS
+from conans.paths import SimplePaths, CONANINFO, PUT_HEADERS, _check_ref_case,\
+    CONAN_MANIFEST
 from conans.util.files import save, load, normalize, list_folder_subdirs
 from conans.util.locks import SimpleLock, ReadLock, WriteLock, NoLock, Lock
 import shutil
@@ -214,13 +215,14 @@ class ClientCache(SimplePaths):
     def load_manifest(self, conan_reference):
         """conan_id = sha(zip file)"""
         assert isinstance(conan_reference, ConanFileReference)
-        filename = self.digestfile_conanfile(conan_reference)
-        return FileTreeManifest.loads(load(filename))
+        export_folder = self.export(conan_reference)
+        _check_ref_case(conan_reference, export_folder, self.store)
+        return FileTreeManifest.load(export_folder)
 
     def load_package_manifest(self, package_reference):
         """conan_id = sha(zip file)"""
-        filename = self.digestfile_package(package_reference, short_paths=None)
-        return FileTreeManifest.loads(load(filename))
+        package_folder = self.package(package_reference, short_paths=None)
+        return FileTreeManifest.load(package_folder)
 
     @staticmethod
     def read_package_recipe_hash(package_folder):
@@ -230,23 +232,23 @@ class ClientCache(SimplePaths):
 
     def conan_manifests(self, conan_reference):
         assert isinstance(conan_reference, ConanFileReference)
-        digest_path = self.digestfile_conanfile(conan_reference)
-        if not os.path.exists(digest_path):
+        export_folder = self.export(conan_reference)
+        _check_ref_case(conan_reference, export_folder, self.store)
+        if not os.path.exists(os.path.join(export_folder, CONAN_MANIFEST)):
             return None, None
         export_sources_path = self.export_sources(conan_reference, short_paths=None)
-        return self._digests(digest_path, export_sources_path)
+        return self._digests(export_folder, export_sources_path)
 
     def package_manifests(self, package_reference):
-        digest_path = self.digestfile_package(package_reference, short_paths=None)
-        if not os.path.exists(digest_path):
+        package_folder = self.package(package_reference, short_paths=None)
+        if not os.path.exists(os.path.join(package_folder, CONAN_MANIFEST)):
             return None, None
-        return self._digests(digest_path)
+        return self._digests(package_folder)
 
     @staticmethod
-    def _digests(digest_path, exports_sources_folder=None):
-        readed_digest = FileTreeManifest.loads(load(digest_path))
-        expected_digest = FileTreeManifest.create(os.path.dirname(digest_path),
-                                                  exports_sources_folder)
+    def _digests(folder, exports_sources_folder=None):
+        readed_digest = FileTreeManifest.load(folder)
+        expected_digest = FileTreeManifest.create(folder, exports_sources_folder)
         return readed_digest, expected_digest
 
     def delete_empty_dirs(self, deleted_refs):

--- a/conans/client/client_cache.py
+++ b/conans/client/client_cache.py
@@ -12,7 +12,7 @@ from conans.model.manifest import FileTreeManifest
 from conans.model.profile import Profile
 from conans.model.ref import ConanFileReference
 from conans.model.settings import Settings
-from conans.paths import SimplePaths, CONANINFO, PUT_HEADERS, _check_ref_case,\
+from conans.paths import SimplePaths, CONANINFO, PUT_HEADERS, check_ref_case,\
     CONAN_MANIFEST
 from conans.util.files import save, load, normalize, list_folder_subdirs
 from conans.util.locks import SimpleLock, ReadLock, WriteLock, NoLock, Lock
@@ -216,7 +216,7 @@ class ClientCache(SimplePaths):
         """conan_id = sha(zip file)"""
         assert isinstance(conan_reference, ConanFileReference)
         export_folder = self.export(conan_reference)
-        _check_ref_case(conan_reference, export_folder, self.store)
+        check_ref_case(conan_reference, export_folder, self.store)
         return FileTreeManifest.load(export_folder)
 
     def load_package_manifest(self, package_reference):
@@ -233,7 +233,7 @@ class ClientCache(SimplePaths):
     def conan_manifests(self, conan_reference):
         assert isinstance(conan_reference, ConanFileReference)
         export_folder = self.export(conan_reference)
-        _check_ref_case(conan_reference, export_folder, self.store)
+        check_ref_case(conan_reference, export_folder, self.store)
         if not os.path.exists(os.path.join(export_folder, CONAN_MANIFEST)):
             return None, None
         export_sources_path = self.export_sources(conan_reference, short_paths=None)

--- a/conans/client/conan_api.py
+++ b/conans/client/conan_api.py
@@ -45,6 +45,7 @@ from conans.client.cmd.user import users_clean, users_list, user_set
 from conans.client.importer import undo_imports
 from conans.client.cmd.export import cmd_export, export_alias
 from conans.unicode import get_cwd
+from conans.client.remover import ConanRemover
 
 
 default_manifest_folder = '.conan_manifests'
@@ -631,12 +632,9 @@ class ConanAPIV1(object):
     @api_method
     def remove(self, pattern, query=None, packages=None, builds=None, src=False, force=False,
                remote=None, outdated=False):
-
-        recorder = ActionRecorder()
-        manager = self._init_manager(recorder)
-        manager.remove(pattern, package_ids_filter=packages, build_ids=builds,
-                       src=src, force=force, remote_name=remote, packages_query=query,
-                       outdated=outdated)
+        remover = ConanRemover(self._client_cache, self._remote_manager, self._user_io, self._registry)
+        remover.remove(pattern, remote, src, builds, packages, force=force,
+                       packages_query=query, outdated=outdated)
 
     @api_method
     def copy(self, reference, user_channel, force=False, packages=None):

--- a/conans/client/manager.py
+++ b/conans/client/manager.py
@@ -17,7 +17,6 @@ from conans.client.output import ScopedOutput, Color
 from conans.client.printer import Printer
 from conans.client.profile_loader import read_conaninfo_profile
 from conans.client.proxy import ConanProxy
-from conans.client.remover import ConanRemover
 from conans.client.graph.require_resolver import RequireResolver
 from conans.client.source import config_source_local, complete_recipe_sources
 from conans.client.tools import cross_building, get_cross_building_settings
@@ -505,23 +504,6 @@ class ConanManager(object):
             import traceback
             trace = traceback.format_exc().split('\n')
             raise ConanException("Unable to build it successfully\n%s" % '\n'.join(trace[3:]))
-
-    def remove(self, pattern, src=False, build_ids=None, package_ids_filter=None, force=False,
-               remote_name=None, packages_query=None, outdated=False):
-        """ Remove conans and/or packages
-        @param pattern: string to match packages
-        @param src: Remove src folder
-        @param package_ids_filter: list of ids or [] for all list
-        @param build_ids: list of ids or [] for all list
-        @param remote: search on another origin to get packages info
-        @param force: if True, it will be deleted without requesting anything
-        @param packages_query: Only if src is a reference. Query settings and options
-        """
-        remote_proxy = self.get_proxy(remote_name=remote_name)
-        remover = ConanRemover(self._client_cache, self._remote_manager, self._user_io, remote_proxy,
-                               self._registry)
-        remover.remove(pattern, remote_name, src, build_ids, package_ids_filter, force=force,
-                       packages_query=packages_query, outdated=outdated)
 
 
 def _load_deps_info(current_path, conanfile, required):

--- a/conans/client/manifest_manager.py
+++ b/conans/client/manifest_manager.py
@@ -74,5 +74,5 @@ class ManifestManager(object):
         remote = "local cache" if not remote else "%s:%s" % (remote.name, remote.url)
         self._match_manifests(read_manifest, expected_manifest, package_reference)
 
-        pkg_folder = self._paths.package_folder(package_reference, short_paths=None)
+        pkg_folder = self._paths.package(package_reference, short_paths=None)
         self._check(package_reference, read_manifest, remote, pkg_folder)

--- a/conans/client/manifest_manager.py
+++ b/conans/client/manifest_manager.py
@@ -1,7 +1,6 @@
 import os
 from conans.paths import SimplePaths
 from conans.model.manifest import FileTreeManifest
-from conans.util.files import load
 from conans.errors import ConanException
 
 
@@ -22,7 +21,7 @@ class ManifestManager(object):
         for log_entry in self._log:
             self._user_io.out.info(log_entry)
 
-    def _handle_add(self, reference, remote, manifest, path):
+    def _handle_add(self, reference, remote, manifest, pkg_folder):
         # query the user for approval
         if self._interactive:
             ok = self._user_io.request_boolean("Installing %s from %s\n"
@@ -32,14 +31,14 @@ class ManifestManager(object):
             ok = True
 
         if ok:
-            manifest.save(os.path.dirname(path), os.path.basename(path))
+            manifest.save(pkg_folder)
             self._log.append("Installed manifest for '%s' from %s" % (str(reference), remote))
         else:
             raise ConanException("Installation of '%s' rejected!" % str(reference))
 
-    def _check(self, reference, manifest, remote, path):
-        if os.path.exists(path):
-            existing_manifest = FileTreeManifest.loads(load(path))
+    def _check(self, reference, manifest, remote, pkg_folder):
+        if os.path.exists(pkg_folder):
+            existing_manifest = FileTreeManifest.load(pkg_folder)
             if existing_manifest == manifest:
                 self._log.append("Manifest for '%s': OK" % str(reference))
                 return
@@ -52,7 +51,7 @@ class ManifestManager(object):
                                  "Remote: %s\nProject manifest doesn't match installed one\n%s"
                                  % (str(reference), remote, error_msg))
 
-        self._handle_add(reference, remote, manifest, path)
+        self._handle_add(reference, remote, manifest, pkg_folder)
 
     def _match_manifests(self, read_manifest, expected_manifest, reference):
         if read_manifest is None or read_manifest != expected_manifest:
@@ -66,7 +65,7 @@ class ManifestManager(object):
         remote = "local cache" if not remote else "%s:%s" % (remote.name, remote.url)
         self._match_manifests(read_manifest, expected_manifest, conan_reference)
 
-        path = self._paths.digestfile_conanfile(conan_reference)
+        path = self._paths.export(conan_reference)
         self._check(conan_reference, read_manifest, remote, path)
 
     def check_package(self, package_reference, remote):
@@ -75,5 +74,5 @@ class ManifestManager(object):
         remote = "local cache" if not remote else "%s:%s" % (remote.name, remote.url)
         self._match_manifests(read_manifest, expected_manifest, package_reference)
 
-        path = self._paths.digestfile_package(package_reference, short_paths=None)
-        self._check(package_reference, read_manifest, remote, path)
+        pkg_folder = self._paths.package_folder(package_reference, short_paths=None)
+        self._check(package_reference, read_manifest, remote, pkg_folder)

--- a/conans/client/proxy.py
+++ b/conans/client/proxy.py
@@ -136,7 +136,8 @@ class ConanProxy(object):
         read_manifest, _ = self._client_cache.conan_manifests(conan_reference)
         if read_manifest:
             try:  # get_conan_manifest can fail, not in server
-                upstream_manifest = self.get_conan_manifest(conan_reference)
+                remote, _ = self._get_remote(conan_reference)
+                upstream_manifest = self._remote_manager.get_conan_manifest(conan_reference, remote)
                 if upstream_manifest != read_manifest:
                     return 1 if upstream_manifest.time > read_manifest.time else -1
             except (NotFoundException, NoRemoteAvailable):  # 404
@@ -202,15 +203,6 @@ class ConanProxy(object):
         else:
             remote = ref_remote or self._registry.default_remote
         return remote, ref_remote
-
-    def get_conan_manifest(self, conan_ref):
-        """ used by update to check the date of packages, require force if older
-        """
-        remote, current_remote = self._get_remote(conan_ref)
-        result = self._remote_manager.get_conan_manifest(conan_ref, remote)
-        if not current_remote:
-            self._registry.set_ref(conan_ref, remote)
-        return result
 
     def get_package_manifest(self, package_ref):
         """ used by update to check the date of packages, require force if older

--- a/conans/client/proxy.py
+++ b/conans/client/proxy.py
@@ -45,7 +45,9 @@ class ConanProxy(object):
         # No package in local cache
         if not os.path.exists(package_folder):
             try:
-                remote_info = self.get_package_info(package_ref)
+                # NOTE This call can associate a recently exported recipe, with anything
+                # to a remote containing the recipe reference
+                remote_info = self._get_package_info(package_ref)
             except (NotFoundException, NoRemoteAvailable):  # 404 or no remote
                 return False
 
@@ -213,7 +215,7 @@ class ConanProxy(object):
             self._registry.set_ref(package_ref.conan, remote)
         return result
 
-    def get_package_info(self, package_ref):
+    def _get_package_info(self, package_ref):
         """ Gets the package info to check if outdated
         """
         remote, ref_remote = self._get_remote(package_ref.conan)

--- a/conans/client/remover.py
+++ b/conans/client/remover.py
@@ -80,9 +80,8 @@ class DiskRemover(object):
 class ConanRemover(object):
     """ Class responsible for removing locally/remotely conans, package folders, etc. """
 
-    def __init__(self, client_cache, remote_manager, user_io, remote_proxy, remote_registry):
+    def __init__(self, client_cache, remote_manager, user_io, remote_registry):
         self._user_io = user_io
-        self._remote_proxy = remote_proxy
         self._client_cache = client_cache
         self._remote_manager = remote_manager
         self._registry = remote_registry
@@ -147,7 +146,7 @@ class ConanRemover(object):
                     packages = disk_search.search_packages(reference, packages_query)
                 if outdated:
                     if remote:
-                        recipe_hash = self._remote_proxy.get_conan_manifest(reference).summary_hash
+                        recipe_hash = self._remote_manager.get_conan_manifest(reference, remote).summary_hash
                     else:
                         recipe_hash = self._client_cache.load_manifest(reference).summary_hash
                     packages = filter_outdated(packages, recipe_hash)

--- a/conans/paths.py
+++ b/conans/paths.py
@@ -124,15 +124,6 @@ class SimplePaths(object):
         _check_ref_case(conan_reference, export, self.store)
         return normpath(join(export, CONANFILE))
 
-    def digestfile_conanfile(self, conan_reference):
-        export = self.export(conan_reference)
-        _check_ref_case(conan_reference, export, self.store)
-        return normpath(join(export, CONAN_MANIFEST))
-
-    def digestfile_package(self, package_reference, short_paths=False):
-        assert isinstance(package_reference, PackageReference)
-        return normpath(join(self.package(package_reference, short_paths), CONAN_MANIFEST))
-
     def builds(self, conan_reference):
         assert isinstance(conan_reference, ConanFileReference)
         return normpath(join(self.conan(conan_reference), BUILD_FOLDER))
@@ -161,4 +152,3 @@ class SimplePaths(object):
         p = normpath(join(self.conan(package_reference.conan), PACKAGES_FOLDER,
                           package_reference.package_id))
         return path_shortener(p, short_paths)
-

--- a/conans/paths.py
+++ b/conans/paths.py
@@ -65,7 +65,7 @@ def is_case_insensitive_os():
 
 
 if is_case_insensitive_os():
-    def _check_ref_case(conan_reference, conan_folder, store_folder):
+    def check_ref_case(conan_reference, conan_folder, store_folder):
         if not os.path.exists(conan_folder):  # If it doesn't exist, not a problem
             return
         # If exists, lets check path
@@ -83,7 +83,7 @@ if is_case_insensitive_os():
                                      % (str(conan_reference), offending))
             tmp = os.path.normpath(tmp + os.sep + part)
 else:
-    def _check_ref_case(conan_reference, conan_folder, store_folder):  # @UnusedVariable
+    def check_ref_case(conan_reference, conan_folder, store_folder):  # @UnusedVariable
         pass
 
 
@@ -121,7 +121,7 @@ class SimplePaths(object):
 
     def conanfile(self, conan_reference):
         export = self.export(conan_reference)
-        _check_ref_case(conan_reference, export, self.store)
+        check_ref_case(conan_reference, export, self.store)
         return normpath(join(export, CONANFILE))
 
     def builds(self, conan_reference):

--- a/conans/test/command/export_path_test.py
+++ b/conans/test/command/export_path_test.py
@@ -1,6 +1,6 @@
 import unittest
 import os
-from conans.util.files import load
+
 from conans.model.ref import ConanFileReference
 from conans.test.utils.cpp_test_files import cpp_hello_conan_files
 from conans.model.manifest import FileTreeManifest
@@ -19,7 +19,7 @@ class ExportPathTest(unittest.TestCase):
         client.save(files, path=source_folder)
         client.run("export source lasote/stable")
         reg_path = client.paths.export(conan_ref)
-        manif = FileTreeManifest.loads(load(client.paths.digestfile_conanfile(conan_ref)))
+        manif = FileTreeManifest.load(client.paths.export(conan_ref))
 
         self.assertIn('%s: A new conanfile.py version was exported' % str(conan_ref),
                       client.user_io.out)
@@ -48,7 +48,7 @@ class ExportPathTest(unittest.TestCase):
         client.save(files, path=source_folder)
         client.run("export ../source lasote/stable")
         reg_path = client.paths.export(conan_ref)
-        manif = FileTreeManifest.loads(load(client.paths.digestfile_conanfile(conan_ref)))
+        manif = FileTreeManifest.load(client.paths.export(conan_ref))
 
         self.assertIn('%s: A new conanfile.py version was exported' % str(conan_ref),
                       client.user_io.out)
@@ -80,7 +80,7 @@ class ExportPathTest(unittest.TestCase):
         client.save({"conanfile.py": conanfile})
         client.run("export . lasote/stable")
         reg_path = client.paths.export(conan_ref)
-        manif = FileTreeManifest.loads(load(client.paths.digestfile_conanfile(conan_ref)))
+        manif = FileTreeManifest.load(client.paths.export(conan_ref))
 
         self.assertIn('%s: A new conanfile.py version was exported' % str(conan_ref),
                       client.user_io.out)
@@ -117,7 +117,7 @@ class ExportPathTest(unittest.TestCase):
         client.save({"conanfile.py": conanfile}, path=conanfile_folder)
         client.run("export ../conan lasote/stable")
         reg_path = client.paths.export(conan_ref)
-        manif = FileTreeManifest.loads(load(client.paths.digestfile_conanfile(conan_ref)))
+        manif = FileTreeManifest.load(client.paths.export(conan_ref))
 
         self.assertIn('%s: A new conanfile.py version was exported' % str(conan_ref),
                       client.user_io.out)

--- a/conans/test/command/export_test.py
+++ b/conans/test/command/export_test.py
@@ -266,7 +266,7 @@ class ExportTest(unittest.TestCase):
         """ simple registration of a new conans
         """
         reg_path = self.conan.paths.export(self.conan_ref)
-        manif = FileTreeManifest.loads(load(self.conan.paths.digestfile_conanfile(self.conan_ref)))
+        manif = FileTreeManifest.load(self.conan.paths.export(self.conan_ref))
 
         self.assertIn('%s: A new conanfile.py version was exported' % str(self.conan_ref),
                       self.conan.user_io.out)
@@ -346,7 +346,7 @@ class OpenSSLConan(ConanFile):
         conan2.save(files2)
         conan2.run("export . lasote/stable")
         reg_path2 = conan2.paths.export(self.conan_ref)
-        digest2 = FileTreeManifest.loads(load(conan2.paths.digestfile_conanfile(self.conan_ref)))
+        digest2 = FileTreeManifest.load(conan2.paths.export(self.conan_ref))
 
         self.assertNotIn('A new Conan version was exported', conan2.user_io.out)
         self.assertNotIn('Cleaning the old builds ...', conan2.user_io.out)
@@ -382,7 +382,7 @@ class OpenSSLConan(ConanFile):
         conan2.run("export . lasote/stable")
 
         reg_path3 = conan2.paths.export(self.conan_ref)
-        digest3 = FileTreeManifest.loads(load(conan2.paths.digestfile_conanfile(self.conan_ref)))
+        digest3 = FileTreeManifest.load(conan2.paths.export(self.conan_ref))
 
         self.assertIn('%s: A new conanfile.py version was exported' % str(self.conan_ref),
                       self.conan.user_io.out)

--- a/conans/test/command/remove_test.py
+++ b/conans/test/command/remove_test.py
@@ -99,8 +99,8 @@ class RemoveTest(unittest.TestCase):
 
         # Create the manifests to be able to upload
         for pack_ref in pack_refs:
-            digest_path = client.client_cache.digestfile_package(pack_ref)
-            expected_manifest = FileTreeManifest.create(os.path.dirname(digest_path))
+            pkg_folder = client.client_cache.package(pack_ref)
+            expected_manifest = FileTreeManifest.create(pkg_folder)
             files["%s/%s/%s/%s" % ("/".join(pack_ref.conan),
                                    PACKAGES_FOLDER,
                                    pack_ref.package_id,

--- a/conans/test/command/upload_complete_test.py
+++ b/conans/test/command/upload_complete_test.py
@@ -102,8 +102,8 @@ class UploadTest(unittest.TestCase):
                  os.stat(os.path.join(package_folder, "bin", "my_bin", "executable")).st_mode |
                  stat.S_IRWXU)
 
-        digest_path = self.client.client_cache.digestfile_package(self.package_ref)
-        expected_manifest = FileTreeManifest.create(os.path.dirname(digest_path))
+        package_path = self.client.client_cache.package(self.package_ref)
+        expected_manifest = FileTreeManifest.create(package_path)
         expected_manifest.save(package_folder)
 
         self.server_reg_folder = self.test_server.paths.export(self.conan_ref)
@@ -210,8 +210,8 @@ class UploadTest(unittest.TestCase):
     def upload_same_package_dont_compress_test(self):
         # Create a manifest for the faked package
         pack_path = self.client.paths.package(self.package_ref)
-        digest_path = self.client.client_cache.digestfile_package(self.package_ref)
-        expected_manifest = FileTreeManifest.create(os.path.dirname(digest_path))
+        package_path = self.client.client_cache.package(self.package_ref)
+        expected_manifest = FileTreeManifest.create(package_path)
         expected_manifest.save(pack_path)
 
         self.client.run("upload %s --all" % str(self.conan_ref), ignore_error=False)

--- a/conans/test/integration/install_update_test.py
+++ b/conans/test/integration/install_update_test.py
@@ -6,6 +6,7 @@ from conans.test.utils.cpp_test_files import cpp_hello_conan_files
 from conans.util.files import load, save
 from time import sleep
 import time
+from conans.paths import CONAN_MANIFEST
 
 
 class InstallUpdateTest(unittest.TestCase):
@@ -99,8 +100,10 @@ class Pkg(ConanFile):
 
         ref = ConanFileReference.loads("Hello0/1.0@lasote/stable")
         package_ref = PackageReference(ref, "55a3af76272ead64e6f543c12ecece30f94d3eda")
-        recipe_manifest = self.client.client_cache.digestfile_conanfile(ref)
-        package_manifest = self.client.client_cache.digestfile_package(package_ref)
+        export_folder = self.client.client_cache.export(ref)
+        recipe_manifest = os.path.join(export_folder, CONAN_MANIFEST)
+        package_folder = self.client.client_cache.package(package_ref)
+        package_manifest = os.path.join(package_folder, CONAN_MANIFEST)
 
         def timestamps():
             recipe_timestamp = load(recipe_manifest).splitlines()[0]

--- a/conans/test/integration/manifest_validation_test.py
+++ b/conans/test/integration/manifest_validation_test.py
@@ -6,7 +6,7 @@ from conans.test.utils.tools import TestServer, TestClient
 from conans.model.ref import ConanFileReference
 from conans.util.files import save, load, md5
 from conans.model.ref import PackageReference
-from conans.paths import CONANFILE, SimplePaths
+from conans.paths import CONANFILE, SimplePaths, CONAN_MANIFEST
 from conans.test.utils.test_files import temp_folder
 from conans.model.manifest import FileTreeManifest
 
@@ -66,10 +66,10 @@ class ConsumerFileTest(ConanFile):
                       self.client.user_io.out)
 
         paths = SimplePaths(output_folder)
-        self.assertTrue(os.path.exists(paths.digestfile_conanfile(self.reference)))
+        self.assertTrue(os.path.exists(os.path.join(paths.export(self.reference), CONAN_MANIFEST)))
         package_reference = PackageReference.loads("Hello/0.1@lasote/stable:"
                                                    "5ab84d6acfe1f23c4fae0ab88f26e3a396351ac9")
-        self.assertTrue(os.path.exists(paths.digestfile_package(package_reference)))
+        self.assertTrue(os.path.exists(os.path.join(paths.package(package_reference), CONAN_MANIFEST)))
         # now verify
         self.client.run("create . lasote/stable --verify%s" % dest)
         self.assertIn("Manifest for 'Hello/0.1@lasote/stable': OK", self.client.user_io.out)
@@ -86,10 +86,10 @@ class ConsumerFileTest(ConanFile):
         real_folder = folder or ".conan_manifests"
         output_folder = os.path.join(self.client.current_folder, real_folder)
         paths = SimplePaths(output_folder)
-        self.assertTrue(os.path.exists(paths.digestfile_conanfile(self.reference)))
+        self.assertTrue(os.path.exists(os.path.join(paths.export(self.reference), CONAN_MANIFEST)))
         package_reference = PackageReference.loads("Hello/0.1@lasote/stable:"
                                                    "5ab84d6acfe1f23c4fae0ab88f26e3a396351ac9")
-        self.assertTrue(os.path.exists(paths.digestfile_package(package_reference)))
+        self.assertTrue(os.path.exists(os.path.join(paths.package(package_reference), CONAN_MANIFEST)))
 
         # again should do nothing
         self.client.run("install %s --build missing --manifests %s"
@@ -145,11 +145,8 @@ class ConanFileTest(ConanFile):
 
         output_folder = os.path.join(self.client.current_folder, folder)
         paths = SimplePaths(output_folder)
-        self.assertTrue(os.path.exists(paths.digestfile_conanfile(self.reference)))
-        self.assertTrue(os.path.exists(paths.digestfile_package(package_reference)))
-        package_reference = PackageReference.loads("Hello2/0.1@lasote/stable:"
-                                                   "5ab84d6acfe1f23c4fae0ab88f26e3a396351ac9")
-        self.assertTrue(os.path.exists(paths.digestfile_package(package_reference)))
+        self.assertTrue(os.path.exists(os.path.join(paths.export(self.reference), CONAN_MANIFEST)))
+        self.assertTrue(os.path.exists(os.path.join(paths.package(package_reference), CONAN_MANIFEST)))
 
     def remote_capture_verify_manifest_test(self):
         self.client.run("upload %s --all" % str(self.reference))
@@ -168,11 +165,11 @@ class ConanFileTest(ConanFile):
 
         output_folder = os.path.join(self.client.current_folder, ".conan_manifests")
         paths = SimplePaths(output_folder)
-        self.assertTrue(os.path.exists(paths.digestfile_conanfile(self.reference)))
+        self.assertTrue(os.path.exists(os.path.join(paths.export(self.reference), CONAN_MANIFEST)))
 
         package_reference = PackageReference.loads("Hello/0.1@lasote/stable:"
                                                    "5ab84d6acfe1f23c4fae0ab88f26e3a396351ac9")
-        self.assertTrue(os.path.exists(paths.digestfile_package(package_reference)))
+        self.assertTrue(os.path.exists(os.path.join(paths.package(package_reference), CONAN_MANIFEST)))
 
         client = TestClient(servers=self.servers, users={"default": [("lasote", "mypass")]})
         conanfile = """from conans import ConanFile
@@ -215,11 +212,11 @@ class ConanFileTest(ConanFile):
 
         output_folder = os.path.join(self.client.current_folder, ".conan_manifests")
         paths = SimplePaths(output_folder)
-        self.assertTrue(os.path.exists(paths.digestfile_conanfile(self.reference)))
+        self.assertTrue(os.path.exists(os.path.join(paths.export(self.reference), CONAN_MANIFEST)))
 
         package_reference = PackageReference.loads("Hello/0.1@lasote/stable:"
                                                    "5ab84d6acfe1f23c4fae0ab88f26e3a396351ac9")
-        self.assertTrue(os.path.exists(paths.digestfile_package(package_reference)))
+        self.assertTrue(os.path.exists(os.path.join(paths.package(package_reference), CONAN_MANIFEST)))
 
         client = TestClient(servers=self.servers, users={"default": [("lasote", "mypass")]})
 

--- a/conans/test/integration/syncronize_test.py
+++ b/conans/test/integration/syncronize_test.py
@@ -6,7 +6,7 @@ from conans.test.utils.cpp_test_files import cpp_hello_conan_files
 from nose.plugins.attrib import attr
 from conans.util.files import load, save
 from conans.test.utils.test_files import uncompress_packaged_files, temp_folder
-from conans.paths import EXPORT_TGZ_NAME, CONAN_MANIFEST, PACKAGE_TGZ_NAME
+from conans.paths import EXPORT_TGZ_NAME, PACKAGE_TGZ_NAME
 from conans.tools import untargz
 from conans.model.manifest import FileTreeManifest
 
@@ -117,6 +117,5 @@ class SynchronizeTest(unittest.TestCase):
     def _create_manifest(self, package_reference):
         # Create the manifest to be able to upload the package
         pack_path = self.client.paths.package(package_reference)
-        digest_path = self.client.client_cache.digestfile_package(package_reference)
-        expected_manifest = FileTreeManifest.create(os.path.dirname(digest_path))
-        save(os.path.join(pack_path, CONAN_MANIFEST), str(expected_manifest))
+        expected_manifest = FileTreeManifest.create(pack_path)
+        expected_manifest.save(pack_path)

--- a/conans/test/integration/version_ranges_diamond_test.py
+++ b/conans/test/integration/version_ranges_diamond_test.py
@@ -1,6 +1,6 @@
 import unittest
 from conans.test.utils.tools import TestClient, TestServer
-from conans.paths import CONANFILE
+from conans.paths import CONANFILE, CONAN_MANIFEST
 from conans.util.files import load, save
 import os
 from parameterized import parameterized
@@ -74,7 +74,7 @@ class HelloReuseConan(ConanFile):
         client2.save({"conanfile.py": conanfile.format("*1.2*")})
         client2.run("create . Pkg/1.2@lasote/testing")
         conan_reference = ConanFileReference.loads("Pkg/1.2@lasote/testing")
-        manifest = client2.client_cache.digestfile_conanfile(conan_reference)
+        manifest = os.path.join(client2.client_cache.export(conan_reference), CONAN_MANIFEST)
         # Make sure timestamp increases, in some machines in testing, it can fail due to same timestamp
         content = load(manifest).splitlines()
         content[0] = str(int(content[0]) + 1)


### PR DESCRIPTION
More refactors (all refactors, functionality shouldnt change):
- Simplified ``ConanRemover`` it didn't need the proxy anymore
- Continued the FiletreeManifest load/save simplifications
- Removed the ugly named ``digestfile_xxxx`` methods