### PR TITLE
fixed bash path with spaces issue

### DIFF
--- a/conans/client/runner.py
+++ b/conans/client/runner.py
@@ -15,7 +15,7 @@ class ConanRunner(object):
         self._generate_run_log_file = generate_run_log_file
         self._log_run_to_output = log_run_to_output
 
-    def __call__(self, command, output, log_filepath=None, cwd=None):
+    def __call__(self, command, output, log_filepath=None, cwd=None, subprocess=False):
         """
         @param command: Command to execute
         @param output: Instead of print to sys.stdout print to that stream. Could be None
@@ -38,7 +38,7 @@ class ConanRunner(object):
             stream_output.write(call_message)
 
         # No output has to be redirected to logs or buffer or omitted
-        if output is True and not log_filepath and self._log_run_to_output:
+        if output is True and not log_filepath and self._log_run_to_output and not subprocess:
             return self._simple_os_call(command, cwd)
         elif log_filepath:
             if stream_output:

--- a/conans/client/tools/win.py
+++ b/conans/client/tools/win.py
@@ -443,4 +443,6 @@ def run_in_windows_bash(conanfile, bashcmd, cwd=None, subsystem=None, msys_mingw
         bash_path = '"%s"' % bash_path if " " in bash_path else bash_path
         wincmd = '%s --login -c %s' % (bash_path, escape_windows_cmd(to_run))
         conanfile.output.info('run_in_windows_bash: %s' % wincmd)
-        return conanfile.run(wincmd, win_bash=False)
+        # Using the trick of output=False to force not using os.system calls
+        # so bash with pats also works
+        return conanfile.run(wincmd, output=False, win_bash=False)

--- a/conans/client/tools/win.py
+++ b/conans/client/tools/win.py
@@ -443,6 +443,4 @@ def run_in_windows_bash(conanfile, bashcmd, cwd=None, subsystem=None, msys_mingw
         bash_path = '"%s"' % bash_path if " " in bash_path else bash_path
         wincmd = '%s --login -c %s' % (bash_path, escape_windows_cmd(to_run))
         conanfile.output.info('run_in_windows_bash: %s' % wincmd)
-        # Using the trick of output=False to force not using os.system calls
-        # so bash with pats also works
-        return conanfile.run(wincmd, output=False, win_bash=False)
+        return conanfile._runner(wincmd, win_bash=False, subprocess=True)

--- a/conans/client/tools/win.py
+++ b/conans/client/tools/win.py
@@ -443,4 +443,5 @@ def run_in_windows_bash(conanfile, bashcmd, cwd=None, subsystem=None, msys_mingw
         bash_path = '"%s"' % bash_path if " " in bash_path else bash_path
         wincmd = '%s --login -c %s' % (bash_path, escape_windows_cmd(to_run))
         conanfile.output.info('run_in_windows_bash: %s' % wincmd)
+        # https://github.com/conan-io/conan/issues/2839 (subprocess=True)
         return conanfile._runner(wincmd, win_bash=False, subprocess=True)

--- a/conans/model/conan_file.py
+++ b/conans/model/conan_file.py
@@ -259,6 +259,7 @@ class ConanFile(object):
         if not win_bash:
             retcode = self._runner(command, output, os.path.abspath(RUN_LOG_NAME),  cwd)
         else:
+            # FIXME: run in windows bash is not using output
             retcode = tools.run_in_windows_bash(self, bashcmd=command, cwd=cwd, subsystem=subsystem,
                                                 msys_mingw=msys_mingw)
 

--- a/conans/model/conan_file.py
+++ b/conans/model/conan_file.py
@@ -257,7 +257,7 @@ class ConanFile(object):
 
     def run(self, command, output=True, cwd=None, win_bash=False, subsystem=None, msys_mingw=True):
         if not win_bash:
-            retcode = self._runner(command, output, os.path.abspath(RUN_LOG_NAME),  cwd)
+            retcode = self._runner(command, output, os.path.abspath(RUN_LOG_NAME), cwd)
         else:
             # FIXME: run in windows bash is not using output
             retcode = tools.run_in_windows_bash(self, bashcmd=command, cwd=cwd, subsystem=subsystem,

--- a/conans/test/util/tools_test.py
+++ b/conans/test/util/tools_test.py
@@ -31,7 +31,7 @@ class RunnerMock(object):
         self.command_called = None
         self.return_ok = return_ok
 
-    def __call__(self, command, output, win_bash=False, subsystem=None): # @UnusedVariable
+    def __call__(self, command, output, win_bash=False, subsystem=None):  # @UnusedVariable
         self.command_called = command
         self.win_bash = win_bash
         self.subsystem = subsystem
@@ -267,26 +267,24 @@ class HelloConan(ConanFile):
             spt.update()
             self.assertEquals(runner.command_called, "sudo zypper --non-interactive ref")
 
-            
             os_info.linux_distro = "redhat"
             spt = SystemPackageTool(runner=runner, os_info=os_info)
             spt.install("a_package", force=False)
             self.assertEquals(runner.command_called, "rpm -q a_package")
             spt.install("a_package", force=True)
             self.assertEquals(runner.command_called, "sudo yum install -y a_package")
-            
+
             os_info.linux_distro = "debian"
             spt = SystemPackageTool(runner=runner, os_info=os_info)
             with self.assertRaises(ConanException):
                 runner.return_ok = False
                 spt.install("a_package")
                 self.assertEquals(runner.command_called, "sudo apt-get install -y --no-install-recommends a_package")
-                
+
             runner.return_ok = True
             spt.install("a_package", force=False)
             self.assertEquals(runner.command_called, "dpkg -s a_package")
 
-            
             os_info.is_macos = True
             os_info.is_linux = False
             os_info.is_windows = False
@@ -318,7 +316,8 @@ class HelloConan(ConanFile):
                 spt.install("a_package", force=True)
                 self.assertEquals(runner.command_called, "choco install --yes a_package")
                 spt.install("a_package", force=False)
-                self.assertEquals(runner.command_called, 'choco search --local-only --exact a_package | findstr /c:"1 packages installed."')
+                self.assertEquals(runner.command_called,
+                                  'choco search --local-only --exact a_package | findstr /c:"1 packages installed."')
 
         with tools.environment_append({"CONAN_SYSREQUIRES_SUDO": "False"}):
 
@@ -384,7 +383,8 @@ class HelloConan(ConanFile):
                 spt.install("a_package", force=True)
                 self.assertEquals(runner.command_called, "choco install --yes a_package")
                 spt.install("a_package", force=False)
-                self.assertEquals(runner.command_called, 'choco search --local-only --exact a_package | findstr /c:"1 packages installed."')
+                self.assertEquals(runner.command_called,
+                                  'choco search --local-only --exact a_package | findstr /c:"1 packages installed."')
 
     def system_package_tool_try_multiple_test(self):
         class RunnerMultipleMock(object):
@@ -425,7 +425,7 @@ class HelloConan(ConanFile):
                 self.calls = 0
                 self.expected = expected
 
-            def __call__(self, command, *args, **kwargs):
+            def __call__(self, command, *args, **kwargs):  # @UnusedVariable
                 self.calls += 1
                 return 0 if command in self.expected else 1
 
@@ -618,10 +618,10 @@ class MyConan(ConanFile):
         class MockConanfile(object):
             def __init__(self):
                 self.command = ""
-                self.output = namedtuple("output", "info")(lambda x: None)
+                self.output = namedtuple("output", "info")(lambda x: None)  # @UnusedVariable
                 self.env = {"PATH": "/path/to/somewhere"}
 
-            def run(self, command, win_bash=False):
+            def run(self, command, win_bash=False, output=True):  # @UnusedVariable
                 self.command = command
 
         conanfile = MockConanfile()


### PR DESCRIPTION
- [x] Refer to the issue that supports this Pull Request.
Close #2839

As explained in the issue, it is tricky. This solutions uses the ``output=False`` trick to force calling Popen instead of ``os.system()``. This was possible because ``self.run(win_bash=True)`` is totally ignoring ``output`` argument, which probably should be fixed at some point.
