### PR TITLE
MSBuild runtime when no runtime setting

### DIFF
--- a/conans/client/build/msbuild.py
+++ b/conans/client/build/msbuild.py
@@ -116,14 +116,21 @@ class MSBuild(object):
             flags = vs_build_type_flags(self._settings)
             flags.append(vs_std_cpp(self._settings))
 
+        flags_str = " ".join(list(filter(None, flags))) # Removes empty and None elements
+        additional_node = "<AdditionalOptions>" \
+                          "{} %(AdditionalOptions)" \
+                          "</AdditionalOptions>".format(flags_str) if flags_str else ""
+        runtime_node = "<RuntimeLibrary>" \
+                       "{}" \
+                       "</RuntimeLibrary>".format(runtime_library) if runtime_library else ""
         template = """<?xml version="1.0" encoding="utf-8"?>
-    <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-      <ItemDefinitionGroup>
-        <ClCompile>
-          <RuntimeLibrary>{runtime}</RuntimeLibrary>
-          <AdditionalOptions>{compiler_flags} %(AdditionalOptions)</AdditionalOptions>
-        </ClCompile>
-      </ItemDefinitionGroup>
-    </Project>""".format(**{"runtime": runtime_library,
-                            "compiler_flags": " ".join([flag for flag in flags if flag])})
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemDefinitionGroup>
+    <ClCompile>
+      {runtime_node}
+      {additional_node}
+    </ClCompile>
+  </ItemDefinitionGroup>
+</Project>""".format(**{"runtime_node": runtime_node,
+                        "additional_node": additional_node})
         return template

--- a/conans/test/build_helpers/msbuild_test.py
+++ b/conans/test/build_helpers/msbuild_test.py
@@ -16,7 +16,8 @@ class MSBuildTest(unittest.TestCase):
     def dont_mess_with_build_type_test(self):
         settings = MockSettings({"build_type": "Debug",
                                  "compiler": "Visual Studio",
-                                 "arch": "x86_64"})
+                                 "arch": "x86_64",
+                                 "compiler.runtime": "MDd"})
         conanfile = MockConanfile(settings)
         msbuild = MSBuild(conanfile)
         self.assertEquals(msbuild.build_env.flags, ["-Zi", "-Ob0", "-Od"])
@@ -30,6 +31,16 @@ class MSBuildTest(unittest.TestCase):
 
         self.assertNotIn("-Ob0", template)
         self.assertNotIn("-Od", template)
+        self.assertIn("<RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>", template)
+
+    def without_runtime_test(self):
+        settings = MockSettings({"build_type": "Debug",
+                                 "compiler": "Visual Studio",
+                                 "arch": "x86_64"})
+        conanfile = MockConanfile(settings)
+        msbuild = MSBuild(conanfile)
+        template = msbuild._get_props_file_contents()
+        self.assertNotIn("<RuntimeLibrary>", template)
 
     @attr('slow')
     def build_vs_project_test(self):


### PR DESCRIPTION
- [x] Refer to the issue that supports this Pull Request. Closes #2848 

Would be nice to confirm if it helps, but anyway should be better this way, without generating the XML nodes if no value has to be specified.