### PR TITLE
Fix "Package '1' created" message with short_paths=True

### DIFF
--- a/conans/client/installer.py
+++ b/conans/client/installer.py
@@ -131,8 +131,9 @@ class _ConanPackageBuilder(object):
             source_folder = self.build_folder
         with get_env_context_manager(self._conan_file):
             install_folder = self.build_folder  # While installing, the infos goes to build folder
-            create_package(self._conan_file, source_folder, self.build_folder, self.package_folder,
-                           install_folder, self._out)
+            pkg_id = self._conan_file.info.package_id()
+            create_package(self._conan_file, pkg_id, source_folder, self.build_folder,
+                           self.package_folder, install_folder, self._out)
 
         if get_env("CONAN_READ_ONLY_CACHE", False):
             make_read_only(self.package_folder)

--- a/conans/client/manager.py
+++ b/conans/client/manager.py
@@ -200,10 +200,11 @@ class ConanManager(object):
         conanfile.develop = True
         package_output = ScopedOutput(str(reference), self._user_io.out)
         if package_folder:
-            packager.export_pkg(conanfile, package_folder, dest_package_folder, package_output)
+            packager.export_pkg(conanfile, pkg_id, package_folder, dest_package_folder,
+                                package_output)
         else:
-            packager.create_package(conanfile, source_folder, build_folder, dest_package_folder,
-                                    install_folder, package_output, local=True)
+            packager.create_package(conanfile, pkg_id, source_folder, build_folder,
+                                    dest_package_folder, install_folder, package_output, local=True)
 
     def download(self, reference, package_ids, remote_name, recipe):
         """ Download conanfile and specified packages to local repository
@@ -449,7 +450,7 @@ class ConanManager(object):
         output = ScopedOutput("PROJECT", self._user_io.out)
         conanfile = self._load_consumer_conanfile(conanfile_path, install_folder, output,
                                                   deps_info_required=True)
-        packager.create_package(conanfile, source_folder, build_folder, package_folder,
+        packager.create_package(conanfile, None, source_folder, build_folder, package_folder,
                                 install_folder, output, local=True, copy_info=True)
 
     def build(self, conanfile_path, source_folder, build_folder, package_folder, install_folder,

--- a/conans/client/packager.py
+++ b/conans/client/packager.py
@@ -27,7 +27,7 @@ def export_pkg(conanfile, src_package_folder, package_folder, output):
     save(os.path.join(package_folder, CONANINFO), conanfile.info.dumps())
     digest = FileTreeManifest.create(package_folder)
     digest.save(package_folder)
-    output.success("Package '%s' created" % conanfile.info.package_id())
+    output.success("Package '%s' created" % os.path.basename(package_folder))
 
 
 def create_package(conanfile, source_folder, build_folder, package_folder, install_folder,
@@ -82,7 +82,7 @@ def create_package(conanfile, source_folder, build_folder, package_folder, insta
         raise ConanException(e)
 
     _create_aux_files(install_folder, package_folder, conanfile, copy_info)
-    output.success("Package '%s' created" % conanfile.info.package_id())
+    output.success("Package '%s' created" % os.path.basename(package_folder))
 
 
 def _create_aux_files(install_folder, package_folder, conanfile, copy_info):

--- a/conans/client/packager.py
+++ b/conans/client/packager.py
@@ -27,7 +27,7 @@ def export_pkg(conanfile, src_package_folder, package_folder, output):
     save(os.path.join(package_folder, CONANINFO), conanfile.info.dumps())
     digest = FileTreeManifest.create(package_folder)
     digest.save(package_folder)
-    output.success("Package '%s' created" % os.path.basename(package_folder))
+    output.success("Package '%s' created" % conanfile.info.package_id())
 
 
 def create_package(conanfile, source_folder, build_folder, package_folder, install_folder,
@@ -82,7 +82,7 @@ def create_package(conanfile, source_folder, build_folder, package_folder, insta
         raise ConanException(e)
 
     _create_aux_files(install_folder, package_folder, conanfile, copy_info)
-    output.success("Package '%s' created" % os.path.basename(package_folder))
+    output.success("Package '%s' created" % conanfile.info.package_id())
 
 
 def _create_aux_files(install_folder, package_folder, conanfile, copy_info):

--- a/conans/client/packager.py
+++ b/conans/client/packager.py
@@ -11,7 +11,7 @@ from conans.client.output import ScopedOutput
 from conans.client.file_copier import FileCopier
 
 
-def export_pkg(conanfile, src_package_folder, package_folder, output):
+def export_pkg(conanfile, pkg_id, src_package_folder, package_folder, output):
     mkdir(package_folder)
 
     output.info("Exporting to cache existing package from user folder")
@@ -27,10 +27,10 @@ def export_pkg(conanfile, src_package_folder, package_folder, output):
     save(os.path.join(package_folder, CONANINFO), conanfile.info.dumps())
     digest = FileTreeManifest.create(package_folder)
     digest.save(package_folder)
-    output.success("Package '%s' created" % os.path.basename(package_folder))
+    output.success("Package '%s' created" % pkg_id)
 
 
-def create_package(conanfile, source_folder, build_folder, package_folder, install_folder,
+def create_package(conanfile, pkg_id, source_folder, build_folder, package_folder, install_folder,
                    output, local=False, copy_info=False):
     """ copies built artifacts, libs, headers, data, etc. from build_folder to
     package folder
@@ -82,7 +82,8 @@ def create_package(conanfile, source_folder, build_folder, package_folder, insta
         raise ConanException(e)
 
     _create_aux_files(install_folder, package_folder, conanfile, copy_info)
-    output.success("Package '%s' created" % os.path.basename(package_folder))
+    pkg_id = pkg_id or os.path.basename(package_folder)
+    output.success("Package '%s' created" % pkg_id)
 
 
 def _create_aux_files(install_folder, package_folder, conanfile, copy_info):

--- a/conans/test/functional/create_package_test.py
+++ b/conans/test/functional/create_package_test.py
@@ -84,7 +84,7 @@ class ExporterTest(unittest.TestCase):
         loader = ConanFileLoader(None, Settings(), Profile())
         conanfile = loader.load_conan(conanfile_path, None)
 
-        create_package(conanfile, build_folder, build_folder, package_folder, install_folder,
+        create_package(conanfile, None, build_folder, build_folder, package_folder, install_folder,
                        output, copy_info=True)
 
         # test build folder

--- a/conans/test/functional/short_paths_test.py
+++ b/conans/test/functional/short_paths_test.py
@@ -1,4 +1,5 @@
 import os
+import platform
 import unittest
 
 from conans.model.ref import ConanFileReference
@@ -7,6 +8,7 @@ from conans.test.utils.tools import TestClient
 
 class ShortPathsTest(unittest.TestCase):
 
+    @unittest.skipUnless(platform.system() == "Windows", "Requires Windows")
     def short_paths_test(self):
         conanfile = """
 import os

--- a/conans/test/functional/short_paths_test.py
+++ b/conans/test/functional/short_paths_test.py
@@ -65,25 +65,3 @@ class TestConan(ConanFile):
         self.assertIn("PACKAGE: source_file.cpp", client.out)
         self.assertIn("PACKAGE: artifact", client.out)
         self.assertEqual([".conan_link"], os.listdir(package_folder))
-
-    @unittest.skipUnless(platform.system() == "Windows", "Requires Windows")
-    def package_output_test(self):
-        conanfile = """
-import os
-from conans import ConanFile, tools
-
-
-class TestConan(ConanFile):
-    name = "test"
-    version = "1.0"
-    short_paths = True
-"""
-
-        client = TestClient()
-        client.save({"conanfile.py": conanfile.format("False"),
-                     "source_file.cpp": ""})
-        client.run("create . danimtb/testing")
-        self.assertNotIn("test/1.0@danimtb/testing: Package '1' created", client.out)
-        self.assertIn(
-            "test/1.0@danimtb/testing: Package '5ab84d6acfe1f23c4fae0ab88f26e3a396351ac9' created",
-            client.out)

--- a/conans/test/functional/short_paths_test.py
+++ b/conans/test/functional/short_paths_test.py
@@ -73,3 +73,25 @@ class TestConan(ConanFile):
         self.assertNotIn("source_file.cpp", os.listdir(package_folder))
         self.assertNotIn("artifact", os.listdir(package_folder))
         self.assertIn(".conan_link", os.listdir(package_folder))
+
+    @unittest.skipUnless(platform.system() == "Windows", "Requires Windows")
+    def short_paths_test(self):
+        conanfile = """
+import os
+from conans import ConanFile, tools
+
+
+class TestConan(ConanFile):
+    name = "test"
+    version = "1.0"
+    short_paths = True
+"""
+
+        client = TestClient()
+        client.save({"conanfile.py": conanfile.format("False"),
+                     "source_file.cpp": ""})
+        client.run("create . danimtb/testing")
+        self.assertNotIn("test/1.0@danimtb/testing: Package '1' created", client.out)
+        self.assertIn(
+            "test/1.0@danimtb/testing: Package '5ab84d6acfe1f23c4fae0ab88f26e3a396351ac9' created",
+            client.out)

--- a/conans/test/functional/short_paths_test.py
+++ b/conans/test/functional/short_paths_test.py
@@ -1,0 +1,73 @@
+import os
+import unittest
+
+from conans.model.ref import ConanFileReference
+from conans.test.utils.tools import TestClient
+
+
+class ShortPathsTest(unittest.TestCase):
+
+    def short_paths_test(self):
+        conanfile = """
+import os
+from conans import ConanFile, tools
+
+
+class TestConan(ConanFile):
+    name = "test"
+    version = "1.0"
+    short_paths = {0}
+    exports_sources = "source_file.cpp"
+    
+    def source(self):
+        for item in os.listdir(self.source_folder):
+            self.output.info("SOURCE: " + str(item))
+    def build(self):
+        tools.save(os.path.join(self.build_folder, "artifact"), "")
+        for item in os.listdir(self.build_folder):
+            self.output.info("BUILD: " + str(item))
+    def package(self):
+        self.copy("source_file.cpp")
+        self.copy("artifact")
+        for item in os.listdir(self.build_folder):
+            self.output.info("PACKAGE: " + str(item))
+"""
+
+        client = TestClient()
+        client.save({"conanfile.py": conanfile.format("False"),
+                     "source_file.cpp": ""})
+        client.run("create . danimtb/testing")
+        conan_ref = ConanFileReference("test", "1.0", "danimtb", "testing")
+        source_folder = os.path.join(client.client_cache.conan(conan_ref), "source")
+        build_folder = os.path.join(client.client_cache.conan(conan_ref), "build",
+                                    "5ab84d6acfe1f23c4fae0ab88f26e3a396351ac9")
+        package_folder = os.path.join(client.client_cache.conan(conan_ref), "package",
+                                      "5ab84d6acfe1f23c4fae0ab88f26e3a396351ac9")
+        self.assertIn("SOURCE: source_file.cpp", client.out)
+        self.assertIn("source_file.cpp", os.listdir(source_folder))
+        self.assertNotIn(".conan_link", os.listdir(source_folder))
+        self.assertIn("BUILD: source_file.cpp", client.out)
+        self.assertIn("BUILD: artifact", client.out)
+        self.assertIn("source_file.cpp", os.listdir(build_folder))
+        self.assertIn("artifact", os.listdir(build_folder))
+        self.assertNotIn(".conan_link", os.listdir(build_folder))
+        self.assertIn("PACKAGE: source_file.cpp", client.out)
+        self.assertIn("PACKAGE: artifact", client.out)
+        self.assertIn("source_file.cpp", os.listdir(package_folder))
+        self.assertIn("artifact", os.listdir(package_folder))
+        self.assertNotIn(".conan_link", os.listdir(package_folder))
+        client.save({"conanfile.py": conanfile.format("True")})
+        client.run("create . danimtb/testing")
+        self.assertIn("SOURCE: source_file.cpp", client.out)
+        self.assertNotIn("source_file.cpp", os.listdir(source_folder))
+        self.assertIn(".conan_link", os.listdir(source_folder))
+        self.assertIn("BUILD: source_file.cpp", client.out)
+        self.assertIn("BUILD: artifact", client.out)
+        self.assertNotIn("source_file.cpp", os.listdir(build_folder))
+        self.assertNotIn("artifact", os.listdir(build_folder))
+        self.assertIn(".conan_link", os.listdir(build_folder))
+        self.assertIn("PACKAGE: source_file.cpp", client.out)
+        self.assertIn("PACKAGE: artifact", client.out)
+        self.assertNotIn("source_file.cpp", os.listdir(package_folder))
+        self.assertNotIn("artifact", os.listdir(package_folder))
+        self.assertIn(".conan_link", os.listdir(package_folder))

--- a/conans/test/functional/short_paths_test.py
+++ b/conans/test/functional/short_paths_test.py
@@ -9,7 +9,7 @@ from conans.test.utils.tools import TestClient
 class ShortPathsTest(unittest.TestCase):
 
     @unittest.skipUnless(platform.system() == "Windows", "Requires Windows")
-    def short_paths_test(self):
+    def inconsistent_cache_test(self):
         conanfile = """
 import os
 from conans import ConanFile, tools
@@ -46,36 +46,28 @@ class TestConan(ConanFile):
         package_folder = os.path.join(client.client_cache.conan(conan_ref), "package",
                                       "5ab84d6acfe1f23c4fae0ab88f26e3a396351ac9")
         self.assertIn("SOURCE: source_file.cpp", client.out)
-        self.assertIn("source_file.cpp", os.listdir(source_folder))
-        self.assertNotIn(".conan_link", os.listdir(source_folder))
+        self.assertEqual(["source_file.cpp"], os.listdir(source_folder))
         self.assertIn("BUILD: source_file.cpp", client.out)
         self.assertIn("BUILD: artifact", client.out)
-        self.assertIn("source_file.cpp", os.listdir(build_folder))
-        self.assertIn("artifact", os.listdir(build_folder))
-        self.assertNotIn(".conan_link", os.listdir(build_folder))
+        self.assertEqual(["artifact", "conanbuildinfo.txt", "conaninfo.txt", "source_file.cpp"],
+                         os.listdir(build_folder))
         self.assertIn("PACKAGE: source_file.cpp", client.out)
         self.assertIn("PACKAGE: artifact", client.out)
-        self.assertIn("source_file.cpp", os.listdir(package_folder))
-        self.assertIn("artifact", os.listdir(package_folder))
-        self.assertNotIn(".conan_link", os.listdir(package_folder))
+        self.assertEqual(["artifact", "conaninfo.txt", "conanmanifest.txt", "source_file.cpp"],
+                         os.listdir(package_folder))
         client.save({"conanfile.py": conanfile.format("True")})
         client.run("create . danimtb/testing")
         self.assertIn("SOURCE: source_file.cpp", client.out)
-        self.assertNotIn("source_file.cpp", os.listdir(source_folder))
-        self.assertIn(".conan_link", os.listdir(source_folder))
+        self.assertEqual([".conan_link"], os.listdir(source_folder))
         self.assertIn("BUILD: source_file.cpp", client.out)
         self.assertIn("BUILD: artifact", client.out)
-        self.assertNotIn("source_file.cpp", os.listdir(build_folder))
-        self.assertNotIn("artifact", os.listdir(build_folder))
-        self.assertIn(".conan_link", os.listdir(build_folder))
+        self.assertEqual([".conan_link"], os.listdir(build_folder))
         self.assertIn("PACKAGE: source_file.cpp", client.out)
         self.assertIn("PACKAGE: artifact", client.out)
-        self.assertNotIn("source_file.cpp", os.listdir(package_folder))
-        self.assertNotIn("artifact", os.listdir(package_folder))
-        self.assertIn(".conan_link", os.listdir(package_folder))
+        self.assertEqual([".conan_link"], os.listdir(package_folder))
 
     @unittest.skipUnless(platform.system() == "Windows", "Requires Windows")
-    def short_paths_test(self):
+    def package_output_test(self):
         conanfile = """
 import os
 from conans import ConanFile, tools

--- a/conans/test/functional/short_paths_test.py
+++ b/conans/test/functional/short_paths_test.py
@@ -49,12 +49,14 @@ class TestConan(ConanFile):
         self.assertEqual(["source_file.cpp"], os.listdir(source_folder))
         self.assertIn("BUILD: source_file.cpp", client.out)
         self.assertIn("BUILD: artifact", client.out)
-        self.assertEqual(["artifact", "conanbuildinfo.txt", "conaninfo.txt", "source_file.cpp"],
-                         os.listdir(build_folder))
+        self.assertEqual(
+            sorted(["artifact", "conanbuildinfo.txt", "conaninfo.txt", "source_file.cpp"]),
+            sorted(os.listdir(build_folder)))
         self.assertIn("PACKAGE: source_file.cpp", client.out)
         self.assertIn("PACKAGE: artifact", client.out)
-        self.assertEqual(["artifact", "conaninfo.txt", "conanmanifest.txt", "source_file.cpp"],
-                         os.listdir(package_folder))
+        self.assertEqual(
+            sorted(["artifact", "conaninfo.txt", "conanmanifest.txt", "source_file.cpp"]),
+            sorted(os.listdir(package_folder)))
         client.save({"conanfile.py": conanfile.format("True")})
         client.run("create . danimtb/testing")
         self.assertIn("SOURCE: source_file.cpp", client.out)

--- a/conans/util/windows.py
+++ b/conans/util/windows.py
@@ -45,6 +45,9 @@ def path_shortener(path, short_paths):
     elif short_paths is None:
         return path
 
+    if os.path.exists(path):
+        rmdir(path)
+
     short_home = os.getenv("CONAN_USER_HOME_SHORT")
     if not short_home:
         drive = os.path.splitdrive(path)[0]


### PR DESCRIPTION
- [x] Refer to the issue that supports this Pull Request.
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://raw.githubusercontent.com/conan-io/conan/develop/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [x] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. Also adding a description of the changes in the ``changelog.rst`` file. https://github.com/conan-io/docs

When short_paths=True in a conanfile.py, the message displayed after package is created says "`Package '1' created`" instead of package ID due to the name of the short paths directory. This PR solves that