### PR TITLE
Using Visual Studio macro for userprofile path

### DIFF
--- a/conans/client/generators/visualstudio.py
+++ b/conans/client/generators/visualstudio.py
@@ -1,6 +1,6 @@
 from conans.model import Generator
 from conans.paths import BUILD_INFO_VISUAL_STUDIO
-from os.path import expanduser
+import os
 
 
 class VisualStudioGenerator(Generator):
@@ -76,4 +76,8 @@ class VisualStudioGenerator(Generator):
             'linker_flags': " ".join(self._deps_build_info.sharedlinkflags),
             'exe_flags': " ".join(self._deps_build_info.exelinkflags)
         }
-        return self.template.format(**fields).replace(expanduser("~").replace("\\", "/"), "$(USERPROFILE)")
+        formatted_template = self.template.format(**fields)
+        if 'USERPROFILE' in os.environ:
+            formatted_template = formatted_template.replace(os.environ['USERPROFILE'].replace("\\", "/"), "$(USERPROFILE)")
+        
+        return formatted_template

--- a/conans/client/generators/visualstudio.py
+++ b/conans/client/generators/visualstudio.py
@@ -1,5 +1,6 @@
 from conans.model import Generator
 from conans.paths import BUILD_INFO_VISUAL_STUDIO
+from os.path import expanduser
 
 
 class VisualStudioGenerator(Generator):
@@ -48,7 +49,7 @@ class VisualStudioGenerator(Generator):
         sections = []
         for dep_name, cpp_info in self.deps_build_info.dependencies:
             fields = {
-                'root_dir': cpp_info.rootpath,
+                'root_dir': cpp_info.rootpath.replace("\\", "/"),
                 'name': dep_name.replace(".", "-")
             }
             section = self.item_template.format(**fields)
@@ -75,4 +76,4 @@ class VisualStudioGenerator(Generator):
             'linker_flags': " ".join(self._deps_build_info.sharedlinkflags),
             'exe_flags': " ".join(self._deps_build_info.exelinkflags)
         }
-        return self.template.format(**fields)
+        return self.template.format(**fields).replace(expanduser("~").replace("\\", "/"), "$(USERPROFILE)")


### PR DESCRIPTION
conanbuildinfo.props file which is generated for Visual Studio by conan often has got paths that looks like 'C:/Users/username/.conan/.......'. We'd like to add conanbuildinfo.props file to our VCS but it always changes on every computer, because everyone has got another username and it's annoying. Not having a file in directory causes that Visual Studio project cannot be opened without running 'conan install' before. 
Visual Studio has macro for this path and this commit changes these paths from 'C:/Users/username/.conan/'... to '$(USERPROFILE)/.conan/...' which is more universal.

- [x] Refer to the issue that supports this Pull Request.
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://raw.githubusercontent.com/conan-io/conan/develop/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [x] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. Also adding a description of the changes in the ``changelog.rst`` file. https://github.com/conan-io/docs
