### PR TITLE
refactor manifest

### DIFF
--- a/conans/client/client_cache.py
+++ b/conans/client/client_cache.py
@@ -8,12 +8,11 @@ from conans.client.conf.detect import detect_defaults_settings
 from conans.client.output import Color
 from conans.client.profile_loader import read_profile
 from conans.errors import ConanException
-from conans.model.info import ConanInfo
 from conans.model.manifest import FileTreeManifest
 from conans.model.profile import Profile
 from conans.model.ref import ConanFileReference
 from conans.model.settings import Settings
-from conans.paths import SimplePaths, CONANINFO, PUT_HEADERS, check_ref_case,\
+from conans.paths import SimplePaths, PUT_HEADERS, check_ref_case,\
     CONAN_MANIFEST
 from conans.util.files import save, load, normalize, list_folder_subdirs
 from conans.util.locks import SimpleLock, ReadLock, WriteLock, NoLock, Lock
@@ -223,21 +222,6 @@ class ClientCache(SimplePaths):
         """conan_id = sha(zip file)"""
         package_folder = self.package(package_reference, short_paths=None)
         return FileTreeManifest.load(package_folder)
-
-    @staticmethod
-    def read_package_recipe_hash(package_folder):
-        filename = join(package_folder, CONANINFO)
-        info = ConanInfo.loads(load(filename))
-        return info.recipe_hash
-
-    def conan_manifests(self, conan_reference):
-        assert isinstance(conan_reference, ConanFileReference)
-        export_folder = self.export(conan_reference)
-        check_ref_case(conan_reference, export_folder, self.store)
-        if not os.path.exists(os.path.join(export_folder, CONAN_MANIFEST)):
-            return None, None
-        export_sources_path = self.export_sources(conan_reference, short_paths=None)
-        return self._digests(export_folder, export_sources_path)
 
     def package_manifests(self, package_reference):
         package_folder = self.package(package_reference, short_paths=None)

--- a/conans/client/graph/build_requires.py
+++ b/conans/client/graph/build_requires.py
@@ -2,10 +2,10 @@ import copy
 import fnmatch
 from collections import OrderedDict
 
-from conans.client.printer import Printer
 from conans.errors import conanfile_exception_formatter
 from conans.model.ref import ConanFileReference
 from conans.model.conan_file import get_env_context_manager
+from conans.client.graph.printer import print_graph
 
 
 def _apply_build_requires(deps_graph, conanfile, package_build_requires):
@@ -113,7 +113,7 @@ class BuildRequires(object):
 
         # compute and print the graph of transitive build-requires
         deps_graph = self._graph_builder.load_graph(virtual, check_updates=False, update=update)
-        Printer(output).print_graph(deps_graph, self._registry)
+        print_graph(deps_graph, output)
         # install them, recursively
         installer.install(deps_graph, profile_build_requires, update=update)
         _apply_build_requires(deps_graph, conanfile, build_requires)

--- a/conans/client/graph/graph.py
+++ b/conans/client/graph/graph.py
@@ -10,6 +10,7 @@ class Node(object):
         self.conanfile = conanfile
         self.dependencies = []  # Ordered Edges
         self.dependants = set()  # Edges
+        self.remote = None
 
     def add_edge(self, edge):
         if edge.src == self:

--- a/conans/client/graph/printer.py
+++ b/conans/client/graph/printer.py
@@ -1,0 +1,30 @@
+from conans.client.output import Color
+from conans.model.ref import PackageReference
+
+
+def print_graph(deps_graph, out):
+    all_nodes = []
+    ids = set()
+    for node in sorted(n for n in deps_graph.nodes if n.conan_ref):
+        package_id = PackageReference(node.conan_ref, node.conanfile.package_id())
+        if package_id not in ids:
+            all_nodes.append(node)
+            ids.add(package_id)
+    requires = [n for n in all_nodes]
+    out.writeln("Requirements", Color.BRIGHT_YELLOW)
+
+    def _recipes(nodes):
+        for node in nodes:
+            from_text = "from local cache" if not node.remote else "from '%s'" % node.remote.name
+            out.writeln("    %s %s" % (repr(node.conan_ref), from_text), Color.BRIGHT_CYAN)
+    _recipes(requires)
+    out.writeln("Packages", Color.BRIGHT_YELLOW)
+
+    def _packages(nodes):
+        for node in nodes:
+            ref, conanfile = node.conan_ref, node.conanfile
+            ref = PackageReference(ref, conanfile.info.package_id())
+            out.writeln("    %s" % (repr(ref)), Color.BRIGHT_CYAN)
+    _packages(requires)
+
+    out.writeln("")

--- a/conans/client/installer.py
+++ b/conans/client/installer.py
@@ -392,8 +392,6 @@ class ConanInstaller(object):
                                                      str(exc), remote=None)
                 raise exc
             else:
-                self._remote_proxy.handle_package_manifest(package_ref)
-
                 # Log build
                 self._log_built_package(builder.build_folder, package_ref, time.time() - t1)
                 self._built_packages.add((conan_ref, package_id))
@@ -401,7 +399,6 @@ class ConanInstaller(object):
     def _get_existing_package(self, conan_file, package_reference, output, package_folder, update):
         installed = get_package(conan_file, package_reference, package_folder, output,
                                 self._recorder, self._remote_proxy, update=update)
-        self._remote_proxy.handle_package_manifest(package_reference)
         if installed:
             _handle_system_requirements(conan_file, package_reference,
                                         self._client_cache, output)

--- a/conans/client/manager.py
+++ b/conans/client/manager.py
@@ -13,7 +13,6 @@ from conans.client.installer import ConanInstaller, call_system_requirements
 from conans.client.loader import ConanFileLoader
 from conans.client.manifest_manager import ManifestManager
 from conans.client.output import ScopedOutput, Color
-from conans.client.printer import Printer
 from conans.client.profile_loader import read_conaninfo_profile
 from conans.client.proxy import ConanProxy
 from conans.client.graph.range_resolver import RangeResolver
@@ -29,6 +28,7 @@ from conans.util.log import logger
 from conans.client.loader_parse import load_conanfile_class
 from conans.client.graph.build_mode import BuildMode
 from conans.client.cmd.download import download_binaries
+from conans.client.graph.printer import print_graph
 
 
 class ConanManager(object):
@@ -89,10 +89,9 @@ class ConanManager(object):
             self._settings_preprocessor.preprocess(cache_settings)
         return ConanFileLoader(self._runner, cache_settings, profile)
 
-    def get_proxy(self, remote_name=None, manifest_manager=None):
+    def get_proxy(self, remote_name=None):
         remote_proxy = ConanProxy(self._client_cache, self._user_io, self._remote_manager,
-                                  remote_name=remote_name, recorder=self._recorder, registry=self._registry,
-                                  manifest_manager=manifest_manager)
+                                  remote_name=remote_name, recorder=self._recorder, registry=self._registry)
         return remote_proxy
 
     def export_pkg(self, reference, source_folder, build_folder, package_folder, install_folder, profile, force):
@@ -272,11 +271,7 @@ class ConanManager(object):
             generators = set(generators) if generators else set()
             generators.add("txt")  # Add txt generator by default
 
-        manifest_manager = ManifestManager(manifest_folder, user_io=self._user_io,
-                                           client_cache=self._client_cache,
-                                           verify=manifest_verify,
-                                           interactive=manifest_interactive) if manifest_folder else None
-        remote_proxy = self.get_proxy(remote_name=remote_name, manifest_manager=manifest_manager)
+        remote_proxy = self.get_proxy(remote_name=remote_name)
 
         loader = self.get_loader(profile)
         if not install_reference:
@@ -297,7 +292,7 @@ class ConanManager(object):
         else:
             output = ScopedOutput(str(reference), self._user_io.out)
             output.highlight("Installing package")
-        Printer(self._user_io.out).print_graph(deps_graph, self._registry)
+        print_graph(deps_graph, self._user_io.out)
 
         try:
             if cross_building(loader._settings):
@@ -318,6 +313,20 @@ class ConanManager(object):
 
         installer.install(deps_graph, profile.build_requires, keep_build, update=update)
         build_mode.report_matches()
+
+        if manifest_folder:
+            manifest_manager = ManifestManager(manifest_folder, user_io=self._user_io,
+                                               client_cache=self._client_cache)
+            for node in deps_graph.nodes:
+                if not node.conan_ref:
+                    continue
+                conanfile = node.conanfile
+                complete_recipe_sources(self._remote_manager, self._client_cache, self._registry,
+                                        conanfile, node.conan_ref)
+            manifest_manager.check_graph(deps_graph,
+                                         verify=manifest_verify,
+                                         interactive=manifest_interactive)
+            manifest_manager.print_log()
 
         if install_folder:
             # Write generators
@@ -340,9 +349,6 @@ class ConanManager(object):
                 deploy_conanfile = deps_graph.inverse_levels()[1][0].conanfile
                 if hasattr(deploy_conanfile, "deploy") and callable(deploy_conanfile.deploy):
                     run_deploy(deploy_conanfile, install_folder, output)
-
-        if manifest_manager:
-            manifest_manager.print_log()
 
     def source(self, conanfile_path, source_folder, info_folder):
         """

--- a/conans/client/manifest_manager.py
+++ b/conans/client/manifest_manager.py
@@ -2,77 +2,98 @@ import os
 from conans.paths import SimplePaths
 from conans.model.manifest import FileTreeManifest
 from conans.errors import ConanException
+from conans.model.ref import PackageReference
 
 
 class ManifestManager(object):
 
-    def __init__(self, folder, user_io, client_cache, verify=False, interactive=False):
-        if verify and not os.path.exists(folder):
-            raise ConanException("Manifest folder does not exist: %s" % folder)
+    def __init__(self, folder, user_io, client_cache):
         self._paths = SimplePaths(folder)
         self._user_io = user_io
         self._client_cache = client_cache
-        self._verify = verify
-        self._interactive = interactive
         self._log = []
+
+    def check_graph(self, graph, verify, interactive):
+        if verify and not os.path.exists(self._paths.store):
+            raise ConanException("Manifest folder does not exist: %s"
+                                 % self._paths.store)
+        levels = graph.by_levels()
+        for level in levels:
+            for node in level:
+                ref = node.conan_ref
+                if not ref:
+                    continue
+                self._handle_recipe(node, verify, interactive)
+                self._handle_package(node, verify, interactive)
+
+    def _handle_recipe(self, node, verify, interactive):
+        ref = node.conan_ref
+        export = self._client_cache.export(ref)
+        exports_sources_folder = self._client_cache.export_sources(ref)
+        read_manifest = FileTreeManifest.load(export)
+        expected_manifest = FileTreeManifest.create(export, exports_sources_folder)
+        self._check_not_corrupted(ref, read_manifest, expected_manifest)
+        folder = self._paths.export(ref)
+        self._handle_folder(folder, ref, read_manifest, interactive, node.remote, verify)
+
+    def _handle_package(self, node, verify, interactive):
+        ref = node.conan_ref
+        ref = PackageReference(ref, node.conanfile.info.package_id())
+        package_folder = self._client_cache.package(ref)
+        read_manifest = FileTreeManifest.load(package_folder)
+        expected_manifest = FileTreeManifest.create(package_folder)
+        self._check_not_corrupted(ref, read_manifest, expected_manifest)
+        folder = self._paths.package(ref)
+        self._handle_folder(folder, ref, read_manifest, interactive, node.remote, verify)
+
+    def _handle_folder(self, folder, ref, read_manifest, interactive, remote, verify):
+        remote = "local cache" if not remote else "%s:%s" % (remote.name, remote.url)
+        if os.path.exists(folder):
+            self._handle_manifest(ref, folder, read_manifest, interactive,
+                                  remote, verify)
+        else:
+            if verify:
+                raise ConanException("New manifest '%s' detected.\n"
+                                     "Remote: %s\nProject manifest doesn't match installed one"
+                                     % (str(ref), remote))
+            else:
+                self._check_accept_install(interactive, ref, remote)
+                self._log.append("Installed manifest for '%s' from %s"
+                                 % (str(ref), remote))
+                read_manifest.save(folder)
+
+    def _check_accept_install(self, interactive, ref, remote):
+        if (interactive and
+            not self._user_io.request_boolean("Installing %s from %s\n"
+                                              "Do you trust it?" % (str(ref), remote),
+                                              True)):
+            raise ConanException("Installation of '%s' rejected!" % str(ref))
+
+    @staticmethod
+    def _check_not_corrupted(ref, read_manifest, expected_manifest):
+        if read_manifest != expected_manifest:
+            raise ConanException("%s local cache package is corrupted: "
+                                 "some file hash doesn't match manifest"
+                                 % (str(ref)))
+
+    def _handle_manifest(self, ref, folder, read_manifest, interactive, remote, verify):
+        captured_manifest = FileTreeManifest.load(folder)
+        if captured_manifest == read_manifest:
+            self._log.append("Manifest for '%s': OK" % str(ref))
+        elif verify:
+            diff = captured_manifest.difference(read_manifest)
+            error_msg = os.linesep.join("Mismatched checksum '%s' (manifest: %s, file: %s)"
+                                        % (fname, h1, h2) for fname, (h1, h2) in diff.items())
+            raise ConanException("Modified or new manifest '%s' detected.\n"
+                                 "Remote: %s\nProject manifest doesn't match installed one\n%s"
+                                 % (str(ref), remote, error_msg))
+        else:
+            self._check_accept_install(interactive, ref, remote)
+            self._log.append("Installed manifest for '%s' from %s"
+                             % (str(ref), remote))
+            read_manifest.save(folder)
 
     def print_log(self):
         self._user_io.out.success("\nManifests : %s" % (self._paths.store))
         for log_entry in self._log:
             self._user_io.out.info(log_entry)
-
-    def _handle_add(self, reference, remote, manifest, pkg_folder):
-        # query the user for approval
-        if self._interactive:
-            ok = self._user_io.request_boolean("Installing %s from %s\n"
-                                               "Do you trust it?" % (str(reference), remote),
-                                               True)
-        else:
-            ok = True
-
-        if ok:
-            manifest.save(pkg_folder)
-            self._log.append("Installed manifest for '%s' from %s" % (str(reference), remote))
-        else:
-            raise ConanException("Installation of '%s' rejected!" % str(reference))
-
-    def _check(self, reference, manifest, remote, pkg_folder):
-        if os.path.exists(pkg_folder):
-            existing_manifest = FileTreeManifest.load(pkg_folder)
-            if existing_manifest == manifest:
-                self._log.append("Manifest for '%s': OK" % str(reference))
-                return
-
-        if self._verify:
-            diff = existing_manifest.difference(manifest)
-            error_msg = os.linesep.join("Mismatched checksum '%s' (manifest: %s, file: %s)"
-                                        % (fname, h1, h2) for fname, (h1, h2) in diff.items())
-            raise ConanException("Modified or new manifest '%s' detected.\n"
-                                 "Remote: %s\nProject manifest doesn't match installed one\n%s"
-                                 % (str(reference), remote, error_msg))
-
-        self._handle_add(reference, remote, manifest, pkg_folder)
-
-    def _match_manifests(self, read_manifest, expected_manifest, reference):
-        if read_manifest is None or read_manifest != expected_manifest:
-            raise ConanException("%s local cache package is corrupted: "
-                                 "some file hash doesn't match manifest"
-                                 % (str(reference)))
-
-    def check_recipe(self, conan_reference, remote):
-        manifests = self._client_cache.conan_manifests(conan_reference)
-        read_manifest, expected_manifest = manifests
-        remote = "local cache" if not remote else "%s:%s" % (remote.name, remote.url)
-        self._match_manifests(read_manifest, expected_manifest, conan_reference)
-
-        path = self._paths.export(conan_reference)
-        self._check(conan_reference, read_manifest, remote, path)
-
-    def check_package(self, package_reference, remote):
-        manifests = self._client_cache.package_manifests(package_reference)
-        read_manifest, expected_manifest = manifests
-        remote = "local cache" if not remote else "%s:%s" % (remote.name, remote.url)
-        self._match_manifests(read_manifest, expected_manifest, package_reference)
-
-        pkg_folder = self._paths.package(package_reference, short_paths=None)
-        self._check(package_reference, read_manifest, remote, pkg_folder)

--- a/conans/client/printer.py
+++ b/conans/client/printer.py
@@ -23,27 +23,6 @@ class Printer(object):
     def __init__(self, out):
         self._out = out
 
-    def print_graph(self, deps_graph, registry):
-        """ Simple pretty printing of a deps graph, can be improved
-        with options, info like licenses, etc
-        """
-        self._out.writeln("Requirements", Color.BRIGHT_YELLOW)
-        for node in sorted(deps_graph.nodes):
-            ref = node.conan_ref
-            if not ref:
-                continue
-            remote = registry.get_ref(ref)
-            from_text = "from local cache" if not remote else "from '%s'" % remote.name
-            self._out.writeln("    %s %s" % (repr(ref), from_text), Color.BRIGHT_CYAN)
-        self._out.writeln("Packages", Color.BRIGHT_YELLOW)
-        for node in sorted(deps_graph.nodes):
-            ref, conanfile = node.conan_ref, node.conanfile
-            if not ref:
-                continue
-            ref = PackageReference(ref, conanfile.info.package_id())
-            self._out.writeln("    %s" % repr(ref), Color.BRIGHT_CYAN)
-        self._out.writeln("")
-
     def _print_paths(self, ref, conan, path_resolver, show):
         if isinstance(ref, ConanFileReference):
             if show("export_folder"):

--- a/conans/client/proxy.py
+++ b/conans/client/proxy.py
@@ -179,7 +179,7 @@ class ConanProxy(object):
                 pass
         else:
             msg = "Unable to find '%s' in remotes" % str(conan_reference)
-            logger.debug("Not found in any remote, raising...%s" % exc)
+            logger.debug("Not found in any remote, raising NotFoundException")
             self._recorder.recipe_install_error(conan_reference, INSTALL_ERROR_MISSING,
                                                 msg, None)
             raise NotFoundException(msg)

--- a/conans/client/proxy.py
+++ b/conans/client/proxy.py
@@ -2,16 +2,15 @@ import os
 
 from requests.exceptions import RequestException
 
-from conans.client.loader_parse import load_conanfile_class
 from conans.client.output import ScopedOutput
 from conans.client.remover import DiskRemover
 from conans.client.recorder.action_recorder import INSTALL_ERROR_MISSING, INSTALL_ERROR_NETWORK
 from conans.errors import (ConanException, NotFoundException, NoRemoteAvailable)
-from conans.model.ref import PackageReference
 from conans.util.log import logger
 from conans.util.tracer import log_recipe_got_from_local_cache
-from conans.client.source import complete_recipe_sources
 from conans.model.info import ConanInfo
+from conans.paths import CONANINFO
+from conans.model.manifest import FileTreeManifest
 
 
 class ConanProxy(object):
@@ -19,14 +18,12 @@ class ConanProxy(object):
     getting conanfiles, uploading, removing from remote, etc.
     It uses the registry to control where the packages come from.
     """
-    def __init__(self, client_cache, user_io, remote_manager, remote_name, recorder, registry,
-                 manifest_manager=False):
+    def __init__(self, client_cache, user_io, remote_manager, remote_name, recorder, registry):
         # collaborators
         self._client_cache = client_cache
         self._out = user_io.out
         self._remote_manager = remote_manager
         self._registry = registry
-        self._manifest_manager = manifest_manager
         self._recorder = recorder
         # inputs
         self._remote_name = remote_name
@@ -57,7 +54,7 @@ class ConanProxy(object):
             if remote_info:
                 package_hash = remote_info.recipe_hash
             else:
-                package_hash = self._client_cache.read_package_recipe_hash(package_folder)
+                package_hash = ConanInfo.load_file(os.path.join(package_folder, CONANINFO)).recipe_hash
             local_recipe_hash = self._client_cache.load_manifest(package_ref.conan).summary_hash
             up_to_date = local_recipe_hash == package_hash
             if not up_to_date:
@@ -67,11 +64,6 @@ class ConanProxy(object):
             return up_to_date
 
         return True
-
-    def handle_package_manifest(self, package_ref):
-        if self._manifest_manager:
-            remote = self._registry.get_ref(package_ref.conan)
-            self._manifest_manager.check_package(package_ref, remote)
 
     def get_recipe(self, conan_reference, check_updates, update):
         with self._client_cache.conanfile_write_lock(conan_reference):
@@ -84,6 +76,7 @@ class ConanProxy(object):
         # check if it is in disk
         conanfile_path = self._client_cache.conanfile(conan_reference)
 
+        remote = None
         if os.path.exists(conanfile_path):
             if check_updates:
                 ret = self.update_available(conan_reference)
@@ -116,27 +109,19 @@ class ConanProxy(object):
 
             log_recipe_got_from_local_cache(conan_reference)
             self._recorder.recipe_fetched_from_cache(conan_reference)
-
         else:
-            self._retrieve_recipe(conan_reference, output)
+            remote = self._retrieve_recipe(conan_reference, output)
 
-        if self._manifest_manager:
-            # Just make sure that the recipe sources are there to check
-            conanfile = load_conanfile_class(conanfile_path)
-            complete_recipe_sources(self._remote_manager, self._client_cache, self._registry,
-                                    conanfile, conan_reference)
-
+        if not remote:
             remote = self._registry.get_ref(conan_reference)
-            self._manifest_manager.check_recipe(conan_reference, remote)
-
-        return conanfile_path
+        return conanfile_path, remote
 
     def update_available(self, conan_reference):
         """Returns 0 if the conanfiles are equal, 1 if there is an update and -1 if
         the local is newer than the remote"""
         if not conan_reference:
             return 0
-        read_manifest, _ = self._client_cache.conan_manifests(conan_reference)
+        read_manifest = FileTreeManifest.load(self._client_cache.export(conan_reference))
         if read_manifest:
             try:  # get_conan_manifest can fail, not in server
                 remote, _ = self._get_remote(conan_reference)
@@ -169,7 +154,7 @@ class ConanProxy(object):
         if ref_remote:
             try:
                 _retrieve_from_remote(ref_remote)
-                return
+                return ref_remote
             except NotFoundException:
                 msg = "%s was not found in remote '%s'" % (str(conan_reference), ref_remote.name)
                 self._recorder.recipe_install_error(conan_reference, INSTALL_ERROR_MISSING,
@@ -182,21 +167,22 @@ class ConanProxy(object):
 
         output.info("Not found in local cache, looking in remotes...")
         remotes = self._registry.remotes
+        if not remotes:
+            raise ConanException("No remote defined")
         for remote in remotes:
             logger.debug("Trying with remote %s" % remote.name)
             try:
                 _retrieve_from_remote(remote)
-                return
+                return remote
             # If not found continue with the next, else raise
             except NotFoundException as exc:
-                if remote == remotes[-1]:  # Last element not found
-                    msg = "Unable to find '%s' in remotes" % str(conan_reference)
-                    logger.debug("Not found in any remote, raising...%s" % exc)
-                    self._recorder.recipe_install_error(conan_reference, INSTALL_ERROR_MISSING,
-                                                        msg, None)
-                    raise NotFoundException(msg)
-
-        raise ConanException("No remote defined")
+                pass
+        else:
+            msg = "Unable to find '%s' in remotes" % str(conan_reference)
+            logger.debug("Not found in any remote, raising...%s" % exc)
+            self._recorder.recipe_install_error(conan_reference, INSTALL_ERROR_MISSING,
+                                                msg, None)
+            raise NotFoundException(msg)
 
     def _get_remote(self, conan_ref=None):
         # Prioritize -r , then reference registry and then the default remote

--- a/conans/client/remote_manager.py
+++ b/conans/client/remote_manager.py
@@ -3,6 +3,7 @@ import shutil
 import tarfile
 import time
 import traceback
+import stat
 
 from requests.exceptions import ConnectionError
 
@@ -21,7 +22,6 @@ from conans.util.tracer import (log_package_upload, log_recipe_upload,
                                 log_uncompressed_file, log_compressed_files, log_recipe_download,
                                 log_package_download)
 from conans.client.source import merge_directories
-import stat
 from conans.util.env_reader import get_env
 
 
@@ -231,8 +231,8 @@ class RemoteManager(object):
             touch_folder(dest_folder)
             if get_env("CONAN_READ_ONLY_CACHE", False):
                 make_read_only(dest_folder)
-            output.success('Package installed %s' % package_id)
             recorder.package_downloaded(package_reference, remote.url)
+            output.success('Package installed %s' % package_id)
         except NotFoundException:
             raise NotFoundException("Package binary '%s' not found in '%s'" % (package_reference, remote.name))
         except BaseException as e:

--- a/conans/test/model/transitive_reqs_test.py
+++ b/conans/test/model/transitive_reqs_test.py
@@ -39,7 +39,7 @@ class Retriever(object):
 
     def get_recipe(self, conan_ref, check_updates, update):  # @UnusedVariable
         conan_path = os.path.join(self.folder, "/".join(conan_ref), CONANFILE)
-        return conan_path
+        return conan_path, None
 
 
 say_content = """

--- a/conans/test/model/version_ranges_test.py
+++ b/conans/test/model/version_ranges_test.py
@@ -108,7 +108,7 @@ class Retriever(object):
 
     def get_recipe(self, conan_ref, check_updates, update):  # @UnusedVariables
         conan_path = os.path.join(self.folder, "/".join(conan_ref), CONANFILE)
-        return conan_path
+        return conan_path, None
 
 
 hello_content = """


### PR DESCRIPTION
Yet another refactor to prepare 1.5:
- Manifests management is done at the end of the install process
- print_graph extracted
- Remote defined in the Node
- Minor renames and style