### PR TITLE
Add vcvars_ver and winsdk_version to tools.vcvars_command

### DIFF
--- a/conans/client/tools/win.py
+++ b/conans/client/tools/win.py
@@ -298,10 +298,11 @@ def vcvars_command(settings, arch=None, compiler_version=None, force=False, vcva
 
 
 def vcvars_dict(settings, arch=None, compiler_version=None, force=False, filter_known_paths=False,
-                only_diff=True):
+                only_diff=True, vcvars_ver=None, winsdk_version=None):
 
     cmd = vcvars_command(settings, arch=arch,
-                         compiler_version=compiler_version, force=force) + " && echo __BEGINS__ && set"
+                         compiler_version=compiler_version, force=force,
+                         vcvars_ver=vcvars_ver, winsdk_version=winsdk_version) + " && echo __BEGINS__ && set"
     ret = decode_text(subprocess.check_output(cmd, shell=True))
     new_env = {}
     start_reached = False

--- a/conans/client/tools/win.py
+++ b/conans/client/tools/win.py
@@ -228,7 +228,7 @@ def find_windows_10_sdk():
     return None
 
 
-def vcvars_command(settings, arch=None, compiler_version=None, force=False):
+def vcvars_command(settings, arch=None, compiler_version=None, force=False, vcvars_ver=None, winsdk_version=None):
     arch_setting = arch or settings.get_safe("arch")
     compiler_version = compiler_version or settings.get_safe("compiler.version")
     os_setting = settings.get_safe("os")
@@ -274,6 +274,10 @@ def vcvars_command(settings, arch=None, compiler_version=None, force=False):
                 vcvars_path = os.path.join(vs_path, "VC/Auxiliary/Build/vcvarsall.bat")
                 command = ('set "VSCMD_START_DIR=%%CD%%" && '
                            'call "%s" %s' % (vcvars_path, vcvars_arch))
+                if winsdk_version:
+                    command += " %s" % winsdk_version
+                if vcvars_ver:
+                    command += " -vcvars_ver=%s" % vcvars_ver
             else:
                 vcvars_path = os.path.join(vs_path, "VC/vcvarsall.bat")
                 command = ('call "%s" %s' % (vcvars_path, vcvars_arch))

--- a/conans/test/util/tools_test.py
+++ b/conans/test/util/tools_test.py
@@ -670,7 +670,7 @@ ProgramFiles(x86)=C:\Program Files (x86)
        
 """.encode("utf-8")
 
-        def vcvars_command_mock(settings, arch, compiler_version, force):  # @UnusedVariable
+        def vcvars_command_mock(settings, arch, compiler_version, force, vcvars_ver, winsdk_version):  # @UnusedVariable
             return "unused command"
 
         def subprocess_check_output_mock(cmd, shell):

--- a/conans/test/util/vcvars_arch_test.py
+++ b/conans/test/util/vcvars_arch_test.py
@@ -71,3 +71,39 @@ class VCVarsArchTest(unittest.TestCase):
 
         with self.assertRaises(ConanException):
             tools.vcvars_command(settings, arch='mips')
+
+    def test_vcvars_ver_override(self):
+        if platform.system() != "Windows":
+            return
+        settings = Settings.loads(default_settings_yml)
+        settings.compiler = 'Visual Studio'
+        settings.compiler.version = '15'
+        settings.arch = 'x86_64'
+
+        command = tools.vcvars_command(settings, vcvars_ver='14.14')
+        self.assertIn('vcvarsall.bat', command)
+        self.assertIn('-vcvars_ver=14.14', command)
+
+        settings.compiler.version = '14'
+
+        command = tools.vcvars_command(settings, vcvars_ver='14.14')
+        self.assertIn('vcvarsall.bat', command)
+        self.assertNotIn('-vcvars_ver', command)
+
+    def test_winsdk_version_override(self):
+        if platform.system() != "Windows":
+            return
+        settings = Settings.loads(default_settings_yml)
+        settings.compiler = 'Visual Studio'
+        settings.compiler.version = '15'
+        settings.arch = 'x86_64'
+
+        command = tools.vcvars_command(settings, winsdk_version='8.1')
+        self.assertIn('vcvarsall.bat', command)
+        self.assertIn('8.1', command)
+
+        settings.compiler.version = '14'
+
+        command = tools.vcvars_command(settings, winsdk_version='8.1')
+        self.assertIn('vcvarsall.bat', command)
+        self.assertNotIn('8.1', command)


### PR DESCRIPTION
Add `vcvars_ver` and `winsdk_version` arguments to `tools.vcvars_command`. This make it possible to set all possible arguments for `vcvarsall.bat`. It will be set when the `compiler.version > 14`.

The new arguments are named like in the Syntax help, but `vcvar_ver` f.e. could also be named `vc_version` or something like that.

```bat
:usage
echo Syntax:
echo     %~nx0 [arch] [platform_type] [winsdk_version] [-vcvars_ver=vc_version]
echo where : 
echo     [arch]: x86 ^| amd64 ^| x86_amd64 ^| x86_arm ^| x86_arm64 ^| amd64_x86 ^| amd64_arm ^| amd64_arm64
echo     [platform_type]: {empty} ^| store ^| uwp 
echo     [winsdk_version] : full Windows 10 SDK number (e.g. 10.0.10240.0) or "8.1" to use the Windows 8.1 SDK.   
echo     [vc_version] : {none} for default VS 2017 VC++ compiler toolset ^|
echo                    "14.0" for VC++ 2015 Compiler Toolset ^|
echo                    "14.1x" for the latest 14.1x.yyyyy toolset installed (e.g. "14.11") ^|
echo                    "14.1x.yyyyy" for a specific full version number (e.g. 14.11.25503)
```
Closes #2934 