### PR TITLE
Feature/vcvars diff

### DIFF
--- a/conans/client/tools/win.py
+++ b/conans/client/tools/win.py
@@ -293,7 +293,8 @@ def vcvars_command(settings, arch=None, compiler_version=None, force=False):
     return command
 
 
-def vcvars_dict(settings, arch=None, compiler_version=None, force=False, filter_known_paths=False):
+def vcvars_dict(settings, arch=None, compiler_version=None, force=False, filter_known_paths=False,
+                only_diff=False):
     cmd = vcvars_command(settings, arch=arch,
                          compiler_version=compiler_version, force=force) + " && echo __BEGINS__ && set"
     ret = decode_text(subprocess.check_output(cmd, shell=True))
@@ -305,11 +306,13 @@ def vcvars_dict(settings, arch=None, compiler_version=None, force=False, filter_
             if "__BEGINS__" in line:
                 start_reached = True
             continue
+
         if line == "\n" or not line:
             continue
         try:
             name_var, value = line.split("=", 1)
-            new_env[name_var] = value
+            if not only_diff or os.environ.get(name_var) != value:
+                new_env[name_var] = value
         except ValueError:
             pass
 

--- a/conans/client/tools/win.py
+++ b/conans/client/tools/win.py
@@ -293,8 +293,7 @@ def vcvars_command(settings, arch=None, compiler_version=None, force=False):
     return command
 
 
-def vcvars_dict(settings, arch=None, compiler_version=None, force=False, filter_known_paths=False,
-                only_diff=False):
+def vcvars_dict(settings, arch=None, compiler_version=None, force=False, filter_known_paths=False, only_diff=False):
     cmd = vcvars_command(settings, arch=arch,
                          compiler_version=compiler_version, force=force) + " && echo __BEGINS__ && set"
     ret = decode_text(subprocess.check_output(cmd, shell=True))

--- a/conans/client/tools/win.py
+++ b/conans/client/tools/win.py
@@ -293,7 +293,9 @@ def vcvars_command(settings, arch=None, compiler_version=None, force=False):
     return command
 
 
-def vcvars_dict(settings, arch=None, compiler_version=None, force=False, filter_known_paths=False, only_diff=False):
+def vcvars_dict(settings, arch=None, compiler_version=None, force=False, filter_known_paths=False,
+                only_diff=True):
+
     cmd = vcvars_command(settings, arch=arch,
                          compiler_version=compiler_version, force=force) + " && echo __BEGINS__ && set"
     ret = decode_text(subprocess.check_output(cmd, shell=True))

--- a/conans/test/util/tools_test.py
+++ b/conans/test/util/tools_test.py
@@ -640,11 +640,11 @@ compiler:
         settings.compiler = "Visual Studio"
         settings.compiler.version = "14"
         with tools.environment_append({"MYVAR": "1"}):
-            ret = vcvars_dict(settings)
+            ret = vcvars_dict(settings, only_diff=False)
             self.assertIn("MYVAR", ret)
             self.assertIn("VCINSTALLDIR", ret)
 
-            ret = vcvars_dict(settings, only_diff=True)
+            ret = vcvars_dict(settings)
             self.assertNotIn("MYVAR", ret)
             self.assertIn("VCINSTALLDIR", ret)
 

--- a/conans/test/util/tools_test.py
+++ b/conans/test/util/tools_test.py
@@ -613,7 +613,7 @@ class MyConan(ConanFile):
     settings = "os", "compiler"
 
     def build(self):
-        with tools.vcvars(self.settings):
+        with tools.vcvars(self.settings, only_diff=True):
             self.output.info("VCINSTALLDIR set to: " + str(tools.get_env("VCINSTALLDIR")))
 """
         client = TestClient()

--- a/conans/test/util/tools_test.py
+++ b/conans/test/util/tools_test.py
@@ -678,7 +678,7 @@ ProgramFiles(x86)=C:\Program Files (x86)
 
         with mock.patch('conans.client.tools.win.vcvars_command', new=vcvars_command_mock):
             with mock.patch('subprocess.check_output', new=subprocess_check_output_mock):
-                vars = tools.vcvars_dict(None)
+                vars = tools.vcvars_dict(None, only_diff=False)
                 self.assertEqual(vars["PROCESSOR_ARCHITECTURE"], "AMD64")
                 self.assertEqual(vars["PROCESSOR_IDENTIFIER"], "Intel64 Family 6 Model 158 Stepping 9, GenuineIntel")
                 self.assertEqual(vars["PROCESSOR_LEVEL"], "6")


### PR DESCRIPTION
Related with https://github.com/conan-io/conan/pull/2930
The `vcvars_dict` is returning the whole environment captured, while probably we only want to return the new/modified variables. #2930 is a good example, we don't want to write the whole environment in the `activate.bat` script.

Important: Should it be opt-in or opt-out or always doing the diff? Could really break? Was it a bug?
