### PR TITLE
NOT MERGE: Release 1.4.1

### DIFF
--- a/conans/__init__.py
+++ b/conans/__init__.py
@@ -16,4 +16,5 @@ COMPLEX_SEARCH_CAPABILITY = "complex_search"
 SERVER_CAPABILITIES = [COMPLEX_SEARCH_CAPABILITY, ]
 
 
-__version__ = '1.4.0'
+__version__ = '1.4.1'
+

--- a/conans/client/build/cppstd_flags.py
+++ b/conans/client/build/cppstd_flags.py
@@ -3,7 +3,7 @@ from conans.model.version import Version
 
 def available_cppstd_versions(compiler, compiler_version):
     ret = []
-    stds = ["98", "gnu98", "11", "gnu11", "14",  "gnu14", "17", "gnu17"]
+    stds = ["98", "gnu98", "11", "gnu11", "14",  "gnu14", "17", "gnu17", "20", "gnu20"]
     for stdver in stds:
         if cppstd_flag(compiler, compiler_version, stdver):
             ret.append(stdver)

--- a/conans/client/cmd/export.py
+++ b/conans/client/cmd/export.py
@@ -112,7 +112,7 @@ def _capture_export_scm_data(conanfile, src_path, destination_folder, output, pa
     if scm.url == "auto":
         origin = scm.get_remote_url()
         if not origin:
-            raise ConanException("Repo origin cannot be deduced by 'auto', using source folder")
+            raise ConanException("Repo origin cannot be deduced by 'auto'")
         output.success("Repo origin deduced by 'auto': %s" % origin)
         scm.url = origin
     if scm.revision == "auto":

--- a/conans/client/conf/__init__.py
+++ b/conans/client/conf/__init__.py
@@ -70,7 +70,7 @@ compiler:
         libcxx: [libstdc++, libc++]
 
 build_type: [None, Debug, Release, RelWithDebInfo, MinSizeRel]
-cppstd: [None, 98, gnu98, 11, gnu11, 14, gnu14, 17, gnu17]
+cppstd: [None, 98, gnu98, 11, gnu11, 14, gnu14, 17, gnu17, 20, gnu20]
 """
 
 default_client_conf = """

--- a/conans/client/file_copier.py
+++ b/conans/client/file_copier.py
@@ -3,7 +3,7 @@ import fnmatch
 import shutil
 from collections import defaultdict
 
-from conans import tools
+from conans.util.files import mkdir
 
 
 def report_copied_files(copied, output):
@@ -146,6 +146,7 @@ class FileCopier(object):
                 pass
             # link is a string relative to linked_folder
             # e.j: os.symlink("test/bar", "./foo/test_link") will create a link to foo/test/bar in ./foo/test_link
+            mkdir(os.path.dirname(dst_link))
             os.symlink(link, dst_link)
         # Remove empty links
         for linked_folder in linked_folders:

--- a/conans/client/generators/cmake_find_package.py
+++ b/conans/client/generators/cmake_find_package.py
@@ -49,7 +49,7 @@ if(NOT ${{CMAKE_VERSION}} VERSION_LESS "3.0")
           INTERFACE_INCLUDE_DIRECTORIES "${{{name}_INCLUDE_DIRS}}")
         endif()
         set_property(TARGET {name}::{name} PROPERTY INTERFACE_LINK_LIBRARIES ${{{name}_LIBRARIES_TARGETS}})
-        set_property(TARGET {name}::{name} PROPERTY INTERFACE_COMPILE_DEFINITIONS {deps.defines})
+        set_property(TARGET {name}::{name} PROPERTY INTERFACE_COMPILE_DEFINITIONS {deps.compile_definitions})
     endif()
     {find_dependencies}
 endif()
@@ -89,7 +89,6 @@ class CMakeFindPackageGenerator(Generator):
                 return ["get_target_property(tmp %s %s)" % (dep_t, prop),
                         "if(tmp)",
                         "  set_property(TARGET %s APPEND PROPERTY %s ${tmp})" % (lib_t, prop),
-                        '  message("${tmp}")',
                         'endif()']
 
             lines.append("find_dependency(%s REQUIRED)" % dep)

--- a/conans/client/migrations.py
+++ b/conans/client/migrations.py
@@ -98,7 +98,7 @@ compiler:
         version: ["5.0", "5.1", "6.0", "6.1", "7.0", "7.3", "8.0", "8.1", "9.0", "9.1"]
         libcxx: [libstdc++, libc++]
 build_type: [None, Debug, Release, RelWithDebInfo, MinSizeRel]
-cppstd: [None, 98, gnu98, 11, gnu11, 14, gnu14, 17, gnu17, 20, gnu20]
+cppstd: [None, 98, gnu98, 11, gnu11, 14, gnu14, 17, gnu17]
 """
             self._update_settings_yml(old_settings)
 

--- a/conans/client/tools/win.py
+++ b/conans/client/tools/win.py
@@ -1,4 +1,3 @@
-import glob
 import json
 import os
 import platform
@@ -361,17 +360,22 @@ def get_cased_path(name):
         return name
     if not os.path.isabs(name):
         name = os.path.abspath(name)
-    dirs = name.split('\\')
-    # disk letter
-    test_name = [dirs[0].upper()]
-    for d in dirs[1:]:
-        test_name += ["%s[%s]" % (d[:-1], d[-1])]  # This brackets do the trick to match cased
 
-    res = glob.glob('\\'.join(test_name))
-    if not res:
-        # File not found
-        return None
-    return res[0]
+    result = []
+    current = name
+    while True:
+        parent, child = os.path.split(current)
+        if parent == current:
+            break
+        children = os.listdir(parent)
+        for c in children:
+            if c.upper() == child.upper():
+                result.append(c)
+                break
+        current = parent
+    drive, _ = os.path.splitdrive(current)
+    result.append(drive)
+    return os.sep.join(reversed(result))
 
 
 MSYS2 = 'msys2'

--- a/conans/test/functional/file_copier_test.py
+++ b/conans/test/functional/file_copier_test.py
@@ -101,6 +101,20 @@ class FileCopierTest(unittest.TestCase):
         self.assertTrue(os.path.islink(symlink))
         self.assertTrue(load(os.path.join(symlink, "file.txt")), "Hello")
 
+    @unittest.skipUnless(platform.system() != "Windows", "Requires Symlinks")
+    def linked_folder_nested_test(self):
+        # https://github.com/conan-io/conan/issues/2959
+        folder1 = temp_folder()
+        sub1 = os.path.join(folder1, "lib/icu/60.2")
+        sub2 = os.path.join(folder1, "lib/icu/current")
+        os.makedirs(sub1)
+        os.symlink("60.2", sub2)  # @UndefinedVariable
+
+        folder2 = temp_folder()
+        copier = FileCopier(folder1, folder2)
+        copied = copier("*.cpp", links=True)
+        self.assertEqual(copied, [])
+
     def excludes_test(self):
         folder1 = temp_folder()
         sub1 = os.path.join(folder1, "subdir1")

--- a/conans/test/integration/cppstd_test.py
+++ b/conans/test/integration/cppstd_test.py
@@ -28,6 +28,22 @@ class TestConan(ConanFile):
         client.run('create . user/testing -s compiler="gcc" -s compiler.libcxx="libstdc++11" '
                    '-s compiler.version="6.3" -s cppstd=17')
 
+    def gcc_8_std_20_test(self):
+        client = TestClient()
+
+        conanfile = """from conans import ConanFile
+
+class TestConan(ConanFile):
+    name = "MyLib"
+    version = "0.1"
+    settings = "compiler", "cppstd"
+
+"""
+        client.save({CONANFILE: conanfile})
+        client.run('create . user/testing -s compiler="gcc" '
+                   '-s compiler.libcxx="libstdc++11" '
+                   '-s compiler.version="8" -s cppstd=20')
+
     def set_default_package_id_test(self):
         client = TestClient()
         conanfile = """from conans import ConanFile

--- a/conans/test/util/unix_path_test.py
+++ b/conans/test/util/unix_path_test.py
@@ -3,6 +3,25 @@
 
 import unittest
 from conans import tools
+from conans.client.tools.win import get_cased_path
+from conans.test.utils.test_files import temp_folder
+import os
+import platform
+from conans.util.files import mkdir
+
+
+class GetCasedPath(unittest.TestCase):
+    @unittest.skipUnless(platform.system() == "Windows", "Requires Windows")
+    def test_case(self):
+        folder = temp_folder()
+        p1 = os.path.join(folder, "MyFolder", "Subfolder")
+        mkdir(p1)
+        p2 = get_cased_path(p1)
+        self.assertEqual(p1, p2)
+
+        p3 = os.path.join(folder, "myfolder", "subfolder")
+        p4 = get_cased_path(p3)
+        self.assertEqual(p1, p4)
 
 
 class UnixPathTest(unittest.TestCase):


### PR DESCRIPTION
- Fixed `cmake_find_package` generator, that wrongly used `deps.defines` (containing the -D) instead of `deps.compile_definitions`.
- Bad message
