### PR TITLE
Set cmake_minimum_required at the top

### DIFF
--- a/conans/client/cmd/new.py
+++ b/conans/client/cmd/new.py
@@ -162,8 +162,8 @@ class {package_name}TestConan(ConanFile):
             self.run(".%sexample" % os.sep)
 """
 
-test_cmake = """project(PackageTest CXX)
-cmake_minimum_required(VERSION 2.8.12)
+test_cmake = """cmake_minimum_required(VERSION 2.8.12)
+project(PackageTest CXX)
 
 include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
 conan_basic_setup()
@@ -209,8 +209,8 @@ void hello(){
 }
 """
 
-cmake = """project(MyHello CXX)
-cmake_minimum_required(VERSION 2.8)
+cmake = """cmake_minimum_required(VERSION 2.8)
+project(MyHello CXX)
 
 include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
 conan_basic_setup()


### PR DESCRIPTION
- [x] Refer to the issue that supports this Pull Request: closes #2989 
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.

Set `cmake_minimum_required(VERSION 2.8.12)` at the top of every *CMakeLists.txt* ad best practice

- [x] I've read the [Contributing guide](https://raw.githubusercontent.com/conan-io/conan/develop/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. Also adding a description of the changes in the ``changelog.rst`` file. https://github.com/conan-io/docs

Missing changelog
