### PR TITLE
Fixes detection of apple-clang 10.0 and adds new version to settings

### DIFF
--- a/conans/client/conf/__init__.py
+++ b/conans/client/conf/__init__.py
@@ -66,7 +66,7 @@ compiler:
         version: ["3.3", "3.4", "3.5", "3.6", "3.7", "3.8", "3.9", "4.0", "5.0", "6.0", "7.0"]
         libcxx: [libstdc++, libstdc++11, libc++]
     apple-clang:
-        version: ["5.0", "5.1", "6.0", "6.1", "7.0", "7.3", "8.0", "8.1", "9.0", "9.1"]
+        version: ["5.0", "5.1", "6.0", "6.1", "7.0", "7.3", "8.0", "8.1", "9.0", "9.1", "10.0"]
         libcxx: [libstdc++, libc++]
 
 build_type: [None, Debug, Release, RelWithDebInfo, MinSizeRel]

--- a/conans/client/conf/detect.py
+++ b/conans/client/conf/detect.py
@@ -61,7 +61,7 @@ def _clang_compiler(output, compiler_exe="clang"):
             compiler = "apple-clang"
         elif "clang version" in out:
             compiler = "clang"
-        installed_version = re.search("([0-9]\.[0-9])", out).group()
+        installed_version = re.search("([0-9]{1,}\.[0-9])", out).group()
         if installed_version:
             output.success("Found %s %s" % (compiler, installed_version))
             return compiler, installed_version

--- a/conans/client/conf/detect.py
+++ b/conans/client/conf/detect.py
@@ -61,7 +61,7 @@ def _clang_compiler(output, compiler_exe="clang"):
             compiler = "apple-clang"
         elif "clang version" in out:
             compiler = "clang"
-        installed_version = re.search("([0-9]{1,}\.[0-9])", out).group()
+        installed_version = re.search("([0-9]+\.[0-9])", out).group()
         if installed_version:
             output.success("Found %s %s" % (compiler, installed_version))
             return compiler, installed_version

--- a/conans/test/build_helpers/cpp_std_flags_test.py
+++ b/conans/test/build_helpers/cpp_std_flags_test.py
@@ -148,6 +148,8 @@ class CompilerFlagsTest(unittest.TestCase):
         self.assertEquals(cppstd_flag("apple-clang", "9.1", "14"), '-std=c++14')
         self.assertEquals(cppstd_flag("apple-clang", "9.1", "17"), "-std=c++17")
 
+        self.assertEquals(cppstd_flag("apple-clang", "10.0", "17"), "-std=c++17")
+
     def test_apple_clang_cppstd_defaults(self):
         self.assertEquals(cppstd_default("apple-clang", "2"), "gnu98")
         self.assertEquals(cppstd_default("apple-clang", "3"), "gnu98")
@@ -157,6 +159,7 @@ class CompilerFlagsTest(unittest.TestCase):
         self.assertEquals(cppstd_default("apple-clang", "7"), "gnu98")
         self.assertEquals(cppstd_default("apple-clang", "8"), "gnu98")
         self.assertEquals(cppstd_default("apple-clang", "9"), "gnu98")
+        self.assertEquals(cppstd_default("apple-clang", "10"), "gnu98")
 
     def test_visual_cppstd_flags(self):
         self.assertEquals(cppstd_flag("Visual Studio", "12", "11"), None)


### PR DESCRIPTION
- [x] Refer to the issue that supports this Pull Request: closes #3043
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://raw.githubusercontent.com/conan-io/conan/develop/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. Also adding a description of the changes in the ``changelog.rst`` file. https://github.com/conan-io/docs

Have not added tests for the detection issue but it is a simple regex