### PR TITLE
Fix runtime error on exception reraise

### DIFF
--- a/conans/util/files.py
+++ b/conans/util/files.py
@@ -194,7 +194,7 @@ def _change_permissions(func, path, exc_info):
         os.chmod(path, stat.S_IWUSR)
         func(path)
     else:
-        raise
+        raise Exception("Cannot change permissions for {}!".format(path))
 
 
 def rmdir(path):

--- a/conans/util/files.py
+++ b/conans/util/files.py
@@ -194,7 +194,8 @@ def _change_permissions(func, path, exc_info):
         os.chmod(path, stat.S_IWUSR)
         func(path)
     else:
-        raise Exception("Cannot change permissions for {}!".format(path))
+        raise Exception("Cannot change permissions for {}! Exception info: {}".format(
+            path, exc_info))
 
 
 def rmdir(path):


### PR DESCRIPTION
Fix issue when we doesn't have access to write and try to reraise no active exception, causes runtime error without any info.



