### PR TITLE
Update scm.py

### DIFF
--- a/conans/model/scm.py
+++ b/conans/model/scm.py
@@ -58,7 +58,7 @@ class SCM(object):
              "password": self.password, "type": self.type, "verify_ssl": self.verify_ssl,
              "subfolder": self.subfolder}
         d = {k: v for k, v in d.items() if v}
-        return json.dumps(d)
+        return json.dumps(d, sort_keys=True)
 
     def replace_in_file(self, path):
         content = load(path)


### PR DESCRIPTION
Dictionaries are unordered by default, so the exported conanfile.py can change between two builds (without any modification in the source) when using the scm-attribute. Sorting the keys of the scm data solves this issue.

Implements #3095

- [X] Refer to the issue that supports this Pull Request.
- [X] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [X] I've read the [Contributing guide](https://raw.githubusercontent.com/conan-io/conan/develop/.github/CONTRIBUTING.md).
- [X] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. Also adding a description of the changes in the ``changelog.rst`` file. https://github.com/conan-io/docs
