### PR TITLE
Provide a user-agent header for Conan (#3390)

### DIFF
--- a/conans/client/rest/conan_requester.py
+++ b/conans/client/rest/conan_requester.py
@@ -1,9 +1,10 @@
 import fnmatch
 import os
+import requests
+import platform
 
 from conans.util.files import save
 from conans import __version__ as client_version
-from sys import version as python_version
 
 class ConanRequester(object):
 
@@ -58,7 +59,7 @@ class ConanRequester(object):
             kwargs["timeout"] = self._timeout_seconds
         if not kwargs.get("headers"):
             kwargs["headers"]  = {}
-        kwargs["headers"]["User-Agent"] = "Conan/%s (Python %s)" % (client_version,python_version.split()[0])
+        kwargs["headers"]["User-Agent"] = "Conan/%s (Python %s) %s" % (client_version,platform.python_version(),requests.utils.default_user_agent())
         return kwargs
 
     def get(self, url, **kwargs):

--- a/conans/client/rest/conan_requester.py
+++ b/conans/client/rest/conan_requester.py
@@ -2,7 +2,8 @@ import fnmatch
 import os
 
 from conans.util.files import save
-
+from conans import __version__ as client_version
+from sys import version as python_version
 
 class ConanRequester(object):
 
@@ -55,6 +56,9 @@ class ConanRequester(object):
                 kwargs["proxies"] = self.proxies
         if self._timeout_seconds:
             kwargs["timeout"] = self._timeout_seconds
+        if not kwargs.get("headers"):
+            kwargs["headers"]  = {}
+        kwargs["headers"]["User-Agent"] = "Conan/%s (Python %s)" % (client_version,python_version.split()[0])
         return kwargs
 
     def get(self, url, **kwargs):

--- a/conans/client/rest/conan_requester.py
+++ b/conans/client/rest/conan_requester.py
@@ -59,7 +59,9 @@ class ConanRequester(object):
             kwargs["timeout"] = self._timeout_seconds
         if not kwargs.get("headers"):
             kwargs["headers"]  = {}
-        kwargs["headers"]["User-Agent"] = "Conan/%s (Python %s) %s" % (client_version,platform.python_version(),requests.utils.default_user_agent())
+        kwargs["headers"]["User-Agent"] = "Conan/%s (Python %s) %s" % (client_version,
+                                                                       platform.python_version(),
+                                                                       requests.utils.default_user_agent())
         return kwargs
 
     def get(self, url, **kwargs):


### PR DESCRIPTION
- [X] Refer to the issue that supports this Pull Request: Closes #3097 

Docs: https://github.com/conan-io/docs/pull/700

This PR generates a user agent string that outputs the Conan client version and the Python version.  This will allow us to track data for client version uptake, and data needed for assessing python version deprecation.  Example: Conan/1.5.0 (Python 2.7.1)

I have not implemented tests yet.  I did do manual tests to confirm it achieves the desired result against Bintray, and when requesting a source tarball from places like source forge.