### PR TITLE
Removed env when proxy specified

### DIFF
--- a/conans/client/rest/conan_requester.py
+++ b/conans/client/rest/conan_requester.py
@@ -1,8 +1,6 @@
-import copy
 import fnmatch
 import os
 
-from conans import tools
 from conans.util.files import save
 
 

--- a/conans/client/rest/conan_requester.py
+++ b/conans/client/rest/conan_requester.py
@@ -81,10 +81,8 @@ class ConanRequester(object):
 
             os.environ.pop("no_proxy", None)
             os.environ.pop("NO_PROXY", None)
-
-        tmp = getattr(self._requester, method)(url, **self._add_kwargs(url, kwargs))
-        os.environ = old_env
-        return tmp
-
-
-
+        try:
+            return getattr(self._requester, method)(url, **self._add_kwargs(url, kwargs))
+        finally:
+            os.environ.clear()
+            os.environ.update(old_env)

--- a/conans/client/rest/conan_requester.py
+++ b/conans/client/rest/conan_requester.py
@@ -72,24 +72,21 @@ class ConanRequester(object):
         return self._call_method("post", url, **kwargs)
 
     def _call_method(self, method, url, **kwargs):
-        env = self._get_env()
-        with tools.environment_append(env):
-            return getattr(self._requester, method)(url, **self._add_kwargs(url, kwargs))
-
-    def _get_env(self):
+        old_env = dict(os.environ)
         if self.proxies or self._no_proxy_match:
             # Clean the proxies from the environ and use the conan specified proxies
-            env = copy.copy(os.environ)
+            os.environ.pop("http_proxy", None)
+            os.environ.pop("HTTP_PROXY", None)
 
-            env.pop("http_proxy", None)
-            env.pop("HTTP_PROXY", None)
+            os.environ.pop("https_proxy", None)
+            os.environ.pop("HTTPS_PROXY", None)
 
-            env.pop("https_proxy", None)
-            env.pop("HTTPS_PROXY", None)
+            os.environ.pop("no_proxy", None)
+            os.environ.pop("NO_PROXY", None)
 
-            env.pop("no_proxy", None)
-            env.pop("NO_PROXY", None)
-        else:
-            env = os.environ
+        tmp = getattr(self._requester, method)(url, **self._add_kwargs(url, kwargs))
+        os.environ = old_env
+        return tmp
 
-        return env
+
+

--- a/conans/test/functional/proxies_conf_test.py
+++ b/conans/test/functional/proxies_conf_test.py
@@ -95,7 +95,9 @@ no_proxy_match=MyExcludedUrl*
         with tools.environment_append({"http_proxy": "my_system_proxy"}):
             requester._requester.get = verify_env
             requester.get("MyUrl")
+            self.assertEqual(os.environ["http_proxy"], "my_system_proxy")
 
         with tools.environment_append({"HTTP_PROXY": "my_system_proxy"}):
             requester._requester.get = verify_env
             requester.get("MyUrl")
+            self.assertEqual(os.environ["HTTP_PROXY"], "my_system_proxy")


### PR DESCRIPTION
- [x] Refer to the issue that supports this Pull Request. Closes #2315

If any proxy configuration is specified in the conan conf, conan cleans from the environment the vars related to the proxy management.

**Warn**: It could be breaking if anyone is mixing both global env vars and conan conf vars. But in the otherhand if you have (probably imposed by your environment) proxy env vars you need a way to get rid of them using the conan.conf
