### PR TITLE
winsdk_version and vcvars_ver in MSBuild()

### DIFF
--- a/conans/client/build/msbuild.py
+++ b/conans/client/build/msbuild.py
@@ -25,12 +25,14 @@ class MSBuild(object):
             self.build_env = None
 
     def build(self, project_file, targets=None, upgrade_project=True, build_type=None, arch=None,
-              parallel=True, force_vcvars=False, toolset=None, platforms=None, use_env=True):
+              parallel=True, force_vcvars=False, toolset=None, platforms=None, use_env=True,
+              vcvars_ver=None, winsdk_version=None):
         with tools.environment_append(self.build_env.vars):
             # Path for custom properties file
             props_file_contents = self._get_props_file_contents()
             with tmp_file(props_file_contents) as props_file_path:
-                vcvars = vcvars_command(self._conanfile.settings, force=force_vcvars)
+                vcvars = vcvars_command(self._conanfile.settings, force=force_vcvars,
+                                        vcvars_ver=vcvars_ver, winsdk_version=winsdk_version)
                 command = self.get_command(project_file, props_file_path,
                                            targets=targets, upgrade_project=upgrade_project,
                                            build_type=build_type, arch=arch, parallel=parallel,

--- a/conans/client/tools/win.py
+++ b/conans/client/tools/win.py
@@ -231,7 +231,8 @@ def find_windows_10_sdk():
     return None
 
 
-def vcvars_command(settings, arch=None, compiler_version=None, force=False, vcvars_ver=None, winsdk_version=None):
+def vcvars_command(settings, arch=None, compiler_version=None, force=False, vcvars_ver=None,
+                   winsdk_version=None):
     arch_setting = arch or settings.get_safe("arch")
     compiler_version = compiler_version or settings.get_safe("compiler.version")
     os_setting = settings.get_safe("os")


### PR DESCRIPTION
- [x] Refer to the issue that supports this Pull Request: closes #3102 
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://raw.githubusercontent.com/conan-io/conan/develop/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. Also adding a description of the changes in the ``changelog.rst`` file. https://github.com/conan-io/docs

Are tests needed for this? vcvars_command with this params is already tested here:
https://github.com/conan-io/conan/blob/develop/conans/test/util/vcvars_arch_test.py#L73#L103