### PR TITLE
adding failing requirer

### DIFF
--- a/conans/client/graph/graph_builder.py
+++ b/conans/client/graph/graph_builder.py
@@ -204,8 +204,14 @@ class DepsGraphBuilder(object):
             recipe_status = RECIPE_WORKSPACE
             remote = WORKSPACE_FILE
         else:
-            result = self._proxy.get_recipe(requirement.conan_reference,
-                                            check_updates, update, remote_name)
+            try:
+                result = self._proxy.get_recipe(requirement.conan_reference,
+                                                check_updates, update, remote_name)
+            except ConanException as e:
+                base_ref = str(current_node.conan_ref or "PROJECT")
+                self._output.error("Failed requirement '%s' from '%s'" % (requirement.conan_reference,
+                                                                          base_ref))
+                raise e
             conanfile_path, recipe_status, remote = result
 
         output = ScopedOutput(str(requirement.conan_reference), self._output)

--- a/conans/client/graph/range_resolver.py
+++ b/conans/client/graph/range_resolver.py
@@ -62,8 +62,9 @@ class RangeResolver(object):
                                  % (version_range, base_conanref, str(resolved)))
             require.conan_reference = resolved
         else:
-            raise ConanException("The version in '%s' from requirement '%s' could not be resolved"
-                                 % (version_range, require))
+            base_conanref = base_conanref or "PROJECT"
+            raise ConanException("Version range '%s' from requirement '%s' required by '%s' "
+                                 "could not be resolved" % (version_range, require, base_conanref))
 
     def _resolve_local(self, search_ref, version_range):
         local_found = search_recipes(self._client_cache, search_ref)

--- a/conans/test/command/install_test.py
+++ b/conans/test/command/install_test.py
@@ -451,6 +451,8 @@ class Pkg(ConanFile):
         client.run("remote remove_ref Hello/0.1@lasote/stable")
         error = client.run("install Hello/0.1@lasote/stable", ignore_error=True)
         self.assertTrue(error)
+        self.assertIn("ERROR: Failed requirement 'Hello/0.1@lasote/stable' from 'PROJECT'",
+                      client.out)
         self.assertIn("ERROR: Unable to find 'Hello/0.1@lasote/stable' in remotes",
                       client.out)
 


### PR DESCRIPTION
- [x] Refer to the issue that supports this Pull Request.
Fix #3207

The error output now is:
```bash
> ERROR: Failed requirement 'Hello/0.1@lasote/stable' from 'PROJECT'
> ERROR: Unable to find 'Hello/0.1@lasote/stable' in remotes"
```