### PR TITLE
Bump version for PyYAML to 3.13

### DIFF
--- a/conans/requirements.txt
+++ b/conans/requirements.txt
@@ -1,7 +1,7 @@
 PyJWT>=1.4.0, <2.0.0
 requests>=2.7.0, <3.0.0
 colorama>=0.3.3, <0.4.0
-PyYAML>=3.11, <3.13.0
+PyYAML>=3.11, <3.14.0
 patch==1.16
 fasteners>=0.14.1
 six>=1.10.0


### PR DESCRIPTION
Installation fails with Python 3.7 and PyYAML 3.12 due to yaml/pyyaml#126.

Fixes #3249.
