### PR TITLE
- add print_errors option to PkgConfig helper

### DIFF
--- a/conans/client/tools/pkg_config.py
+++ b/conans/client/tools/pkg_config.py
@@ -10,19 +10,22 @@ class PkgConfig(object):
     def _cmd_output(command):
         return subprocess.check_output(command).decode().strip()
 
-    def __init__(self, library, pkg_config_executable='pkg-config', static=False, msvc_syntax=False, variables=None):
+    def __init__(self, library, pkg_config_executable='pkg-config', static=False, msvc_syntax=False, variables=None,
+                 print_errors=True):
         """
         :param library: library (package) name, such as libastral
         :param pkg_config_executable: specify custom pkg-config executable (e.g. for cross-compilation)
         :param static: output libraries suitable for static linking (adds --static to pkg-config command line)
         :param msvc_syntax: MSVC compatibility (adds --msvc-syntax to pkg-config command line)
         :param variables: dictionary of pkg-config variables (passed as --define-variable=VARIABLENAME=VARIABLEVALUE)
+        :param print_errors: output error messages (adds --print-errors)
         """
         self.library = library
         self.pkg_config_executable = pkg_config_executable
         self.static = static
         self.msvc_syntax = msvc_syntax
         self.define_variables = variables
+        self.print_errors = print_errors
 
         self._variables = dict()
         self.info = dict()
@@ -33,6 +36,8 @@ class PkgConfig(object):
             command.append('--static')
         if self.msvc_syntax:
             command.append('--msvc-syntax')
+        if self.print_errors:
+            command.append('--print-errors')
         if self.define_variables:
             for name, value in self.define_variables.items():
                 command.append('--define-variable=%s=%s' % (name, value))


### PR DESCRIPTION
- [ ] Refer to the issue that supports this Pull Request.
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://raw.githubusercontent.com/conan-io/conan/develop/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. Also adding a description of the changes in the ``changelog.rst`` file. https://github.com/conan-io/docs

add `--print-errors` flag to pkg-config executions. this allows to get more descriptive error messages, and helps to better understand build failures on CI or from user's logs.
