### PR TITLE
[POC] AST-based conanfile rewriting for scm and `conan_expand`

### DIFF
--- a/conans/__init__.py
+++ b/conans/__init__.py
@@ -6,7 +6,7 @@ from conans.client.build.meson import Meson
 from conans.client.build.msbuild import MSBuild
 from conans.client.build.visual_environment import VisualStudioBuildEnvironment
 from conans.client.run_environment import RunEnvironment
-from conans.model.conan_file import ConanFile
+from conans.model.conan_file import ConanFile, conan_expand
 from conans.model.options import Options
 from conans.model.settings import Settings
 from conans.util.files import load

--- a/conans/model/conan_file.py
+++ b/conans/model/conan_file.py
@@ -2,7 +2,6 @@ import ast
 import asttokens
 import operator
 import os
-from functools import reduce
 from contextlib import contextmanager
 
 from conans import tools  # @UnusedImport KEEP THIS! Needed for pyinstaller to copy to exe.
@@ -74,11 +73,11 @@ def compute_conan_expand_replacements(atok, value, mapping):
 def expand_recipe(recipe_path, conanfile, output, additional_expansions=[]):
     atok = asttokens.ASTTokens(load(recipe_path), parse=True)
 
-    # Iterate through the ast at root level and search the one class that derives from ConanFile.
+    # Iterate through the ast at root level and search the ConanFile class by name.
     conanclass_node = None
     for item in atok.tree.body:
         if not isinstance(item, ast.ClassDef): continue
-        if reduce(operator.and_, [not isinstance(x, ast.Name) or x.id != "ConanFile" for x in item.bases], True): continue
+        if item.name !=  conanfile.__name__: continue
         conanclass_node = item
         break
     assert(conanclass_node)

--- a/conans/model/conan_file.py
+++ b/conans/model/conan_file.py
@@ -1,4 +1,8 @@
+import ast
+import asttokens
+import operator
 import os
+from functools import reduce
 from contextlib import contextmanager
 
 from conans import tools  # @UnusedImport KEEP THIS! Needed for pyinstaller to copy to exe.
@@ -13,7 +17,109 @@ from conans.paths import RUN_LOG_NAME
 from conans.tools import environment_append, no_op
 from conans.client.output import Color
 from conans.client.tools.oss import os_info
+from conans.util.files import load, save
 
+# Simple tag function to mark values that should be expanded during recipe export.
+def conan_expand(value):
+    return value
+
+# Formats the expanded values.
+def format_expanded_value(value, indentation):
+    import pprint
+    lines = pprint.pformat(value).splitlines()
+    if isinstance(value, dict) or isinstance(value, list) or isinstance(value, tuple):
+        indentation += 1
+    formated = ('\n' + ' '*indentation).join(lines)
+    return formated
+
+# Recursively map all nodes that are within Tuples, Lists, and Dicts.
+def map_value_nodes(node):
+    sub_nodes = None
+    if isinstance(node, ast.Tuple) or isinstance(node, ast.List):
+        sub_nodes = dict([(idx, map_value_nodes(n)) for idx,n in enumerate(node.elts) ])
+    elif isinstance(node, ast.Dict):
+        sub_nodes = {}
+        assert(len(node.keys) == len(node.values))
+        for key, value in zip(node.keys,node.values):
+            if isinstance(key, ast.Str):
+                sub_nodes[key.s] = map_value_nodes(value)
+            elif isinstance(key, ast.Num):
+                sub_nodes[key.n] = map_value_nodes(value)
+    if sub_nodes: return sub_nodes
+    return node
+
+def is_conan_expand_call(node):
+    if not isinstance(node, ast.Call): return False
+    if not isinstance(node.func, ast.Name): return False
+    if node.func.id != "conan_expand": return False
+    return True
+
+# Traverse the mappings and schedule the replacements when the conan_expand function is found.
+def compute_conan_expand_replacements(atok, value, mapping):
+    if not isinstance(mapping, dict):
+        # Base case, there is no hierarchical mapping information anymore.
+        # Check if a replacement should be performed.
+        if is_conan_expand_call(mapping):
+            value_range = atok.get_text_range(mapping)
+            return {value_range: format_expanded_value(value, mapping.col_offset-1)}
+        return {}
+    # Hierarchical mapping information is available, recurse if possible and collect results.
+    replacements = {}
+    for key, mapping_value in mapping.items():
+        if isinstance(value, dict) or isinstance(value, list) or isinstance(value, tuple):
+            replacements.update(compute_conan_expand_replacements(atok, value[key], mapping_value))
+        # TODO support special types if needed
+    return replacements
+
+def expand_recipe(recipe_path, conanfile, output, additional_expansions=[]):
+    atok = asttokens.ASTTokens(load(recipe_path), parse=True)
+
+    # Iterate through the ast at root level and search the one class that derives from ConanFile.
+    conanclass_node = None
+    for item in atok.tree.body:
+        if not isinstance(item, ast.ClassDef): continue
+        if reduce(operator.and_, [not isinstance(x, ast.Name) or x.id != "ConanFile" for x in item.bases], True): continue
+        conanclass_node = item
+        break
+    assert(conanclass_node)
+
+    # Iterate through the class and determine a mapping between class members and ast nodes.
+    member_value_mapping = {}
+    for node in conanclass_node.body:
+        if not isinstance(node, ast.Assign): continue
+        assert(len(node.targets) == 1)
+        if isinstance(node.targets[0], ast.Name):
+            member_value_mapping[node.targets[0].id] = map_value_nodes(node.value)
+        # TODO only simple assignments are supported for now, i.e., tuple unpacking is not working atm
+
+    # Calculate replacements by looking for conan_expand calls within the mapped nodes.
+    replacements = {}
+    for member, mapping in member_value_mapping.items():
+        value = getattr(conanfile, member)
+        replacements.update(compute_conan_expand_replacements(atok, value, mapping))
+
+    # Check for missed conan_expand calls and emit warning.
+    for node in ast.walk(atok.tree):
+        if not is_conan_expand_call(node): continue
+        if atok.get_text_range(node) in replacements: continue
+        output.writeln("(Line %d:%d) WARNING: \'%s\' could not be expanded." % (node.lineno, node.col_offset, atok.get_text(node)),
+                               front=Color.BRIGHT_RED)
+
+    # Add program defined replacements.
+    for trace in additional_expansions:
+        assert(isinstance(trace, tuple) and len(trace) > 0)
+        node = member_value_mapping[trace[0]]
+        value = getattr(conanfile, trace[0])
+        for element in trace[1:]:
+            assert(element in node and element in value)
+            node = node[element]
+            value = value[element]
+        node_range = atok.get_text_range(node)
+        replacements[node_range] = format_expanded_value(value, node.col_offset-1)
+
+    # Convert replacement dictionary into list and perform replacement.
+    replacements = [ (range[0], range[1], value) for range, value in replacements.items() ]
+    save(recipe_path, asttokens.util.replace(atok.text, replacements))
 
 def create_options(conanfile):
     try:

--- a/conans/model/scm.py
+++ b/conans/model/scm.py
@@ -37,14 +37,6 @@ class SCMData(object):
         d = {k: v for k, v in d.items() if v}
         return json.dumps(d, sort_keys=True)
 
-    def replace_in_file(self, path):
-        content = load(path)
-        dumps = self.__repr__()
-        dumps = ",\n          ".join(dumps.split(","))
-        content = re.sub(r"scm\s*=\s*{[^}]*}", "scm = %s" % dumps, content)
-        save(path, content)
-
-
 class SCM(object):
     def __init__(self, data, repo_folder):
         self._data = data

--- a/conans/requirements.txt
+++ b/conans/requirements.txt
@@ -12,3 +12,4 @@ future==0.16.0
 pygments>=2.0, <3.0
 astroid>=1.6, <1.7
 deprecation>=2.0, <2.1
+asttokens>=1.1.11

--- a/conans/test/functional/expand_test.py
+++ b/conans/test/functional/expand_test.py
@@ -1,0 +1,71 @@
+import unittest
+
+from conans import tools
+from conans.test.utils.tools import TestClient, create_local_git_repo
+
+class ExpandTest(unittest.TestCase):
+
+    def setUp(self):
+        self.client = TestClient()
+
+    def _commit_contents(self):
+        self.client.runner("git init .", cwd=self.client.current_folder)
+        self.client.runner('git config user.email "you@example.com"', cwd=self.client.current_folder)
+        self.client.runner('git config user.name "Your Name"', cwd=self.client.current_folder)
+        self.client.runner("git add .", cwd=self.client.current_folder)
+        self.client.runner('git commit -m  "commiting"', cwd=self.client.current_folder)
+
+    def test_expand_in_version(self):
+        conanfile = '''
+import os
+from conans import ConanFile, tools, conan_expand
+
+def get_version(variable):
+    return tools.get_env(variable, "error")
+
+class ConanLib(ConanFile):
+    name = "lib"
+    version = conan_expand(get_version("MY_VERSION"))
+
+    def source(self):
+        self.output.warn("version = '{}'".format(self.version))
+'''
+        self.client.save({"conanfile.py": conanfile})
+        with tools.environment_append({"MY_VERSION": "123"}):
+            self.client.run("export . user/channel")
+        self.client.run("install lib/123@user/channel --build")
+        self.assertIn("version = '123'", self.client.out)
+
+    def test_expand_in_scm_structure(self):
+        conanfile = '''
+import os
+from conans import ConanFile, tools, conan_expand
+
+class ConanLib(ConanFile):
+    name = "lib"
+    version = "0.1"
+    scm = {
+        "type": "git",
+        "username": conan_expand(tools.get_env("MY_USERNAME", "error")),
+        "password": tools.get_env("MY_PASSWORD", "error"),
+        "url": "auto",
+        "revision": "auto"
+    }
+
+    def source(self):
+        self.output.warn("scm['username'] = '{}'".format(self.scm['username']))
+        self.output.warn("scm['password'] = '{}'".format(self.scm['password']))
+'''
+        path, commit = create_local_git_repo({"myfile": "contents", "conanfile.py": conanfile},
+                                             branch="my_release")
+        self.client.current_folder = path
+        self.client.runner('git remote add origin https://myrepo.com.git', cwd=path)
+        self._commit_contents()
+
+        self.client.save({"conanfile.py": conanfile})
+        with tools.environment_append({"MY_USERNAME": "export user", "MY_PASSWORD": "export password"}):
+            self.client.run("export . user/channel")
+        with tools.environment_append({"MY_USERNAME": "install user", "MY_PASSWORD": "install password"}):
+            self.client.run("install lib/0.1@user/channel --build")
+        self.assertIn("scm['username'] = 'export user'", self.client.out)
+        self.assertIn("scm['password'] = 'install password'", self.client.out)


### PR DESCRIPTION
I took a stab at fixing #3183. In more detail, I replaced the simple regex-based rewriting of the conanfile through an AST-based approach. This permits to do the rewriting in a more controlled manner, i.e., without the surprising expansion of neighbouring subfields as discussed in the issue.

Furthermore, using the same rewriting approach, I implemented support for replacing `conan_expand` function calls, used in member assignments of the ConanFile derived class. This permits the user to capture and store arbitrary information, during export-time, within the conanfile and also fixes #3150.
