### PR TITLE
Refactor remote=>remote_name

### DIFF
--- a/conans/client/cmd/create.py
+++ b/conans/client/cmd/create.py
@@ -23,7 +23,7 @@ def get_test_conanfile_path(tf, conanfile_path):
                                  % tf)
 
 
-def create(reference, manager, user_io, profile, remote, update, build_modes, manifest_folder,
+def create(reference, manager, user_io, profile, remote_name, update, build_modes, manifest_folder,
            manifest_verify, manifest_interactive, keep_build, test_build_folder, test_folder,
            conanfile_path):
 
@@ -31,7 +31,7 @@ def create(reference, manager, user_io, profile, remote, update, build_modes, ma
 
     if test_conanfile_path:
         pt = PackageTester(manager, user_io)
-        pt.install_build_and_test(test_conanfile_path, reference, profile, remote, update,
+        pt.install_build_and_test(test_conanfile_path, reference, profile, remote_name, update,
                                   build_modes=build_modes,
                                   manifest_folder=manifest_folder,
                                   manifest_verify=manifest_verify,
@@ -44,7 +44,7 @@ def create(reference, manager, user_io, profile, remote, update, build_modes, ma
                         manifest_folder=manifest_folder,
                         manifest_verify=manifest_verify,
                         manifest_interactive=manifest_interactive,
-                        remote_name=remote,
+                        remote_name=remote_name,
                         profile=profile,
                         build_modes=build_modes,
                         update=update,

--- a/conans/client/cmd/download.py
+++ b/conans/client/cmd/download.py
@@ -18,7 +18,7 @@ def download(reference, package_ids, remote_name, recipe, registry, remote_manag
 
     # First of all download package recipe
     remote_manager.get_recipe(reference, remote)
-    registry.set_ref(reference, remote)
+    registry.set_ref(reference, remote.name)
 
     if recipe:
         return

--- a/conans/client/cmd/search.py
+++ b/conans/client/cmd/search.py
@@ -10,15 +10,15 @@ class Search(object):
         self._remote_manager = remote_manager
         self._registry = remote_registry
 
-    def search_recipes(self, pattern, remote=None, case_sensitive=False):
+    def search_recipes(self, pattern, remote_name=None, case_sensitive=False):
         ignorecase = not case_sensitive
 
         references = OrderedDict()
-        if not remote:
+        if not remote_name:
             references[None] = search_recipes(self._client_cache, pattern, ignorecase)
             return references
 
-        if remote == 'all':
+        if remote_name == 'all':
             remotes = self._registry.remotes
             # We have to check if there is a remote called "all"
             # Deprecate: 2.0 can remove this check
@@ -29,7 +29,7 @@ class Search(object):
                         references[remote.name] = refs
                 return references
         # single remote
-        remote = self._registry.remote(remote)
+        remote = self._registry.remote(remote_name)
         refs = self._remote_manager.search_recipes(remote, pattern, ignorecase)
         references[remote.name] = refs
         return references

--- a/conans/client/cmd/test.py
+++ b/conans/client/cmd/test.py
@@ -13,7 +13,7 @@ class PackageTester(object):
         self._user_io = user_io
 
     def install_build_and_test(self, conanfile_abs_path, reference, profile,
-                               remote, update, build_modes=None, manifest_folder=None,
+                               remote_name, update, build_modes=None, manifest_folder=None,
                                manifest_verify=False, manifest_interactive=False, keep_build=False,
                                test_build_folder=None):
         """
@@ -29,7 +29,7 @@ class PackageTester(object):
             self._manager.install(inject_require=reference,
                                   reference=conanfile_abs_path,
                                   install_folder=test_build_folder,
-                                  remote_name=remote,
+                                  remote_name=remote_name,
                                   profile=profile,
                                   update=update,
                                   build_modes=build_modes,

--- a/conans/client/cmd/uploader.py
+++ b/conans/client/cmd/uploader.py
@@ -104,7 +104,7 @@ class CmdUpload(object):
                     recorder.add_package(str(conan_ref), package_id)
 
         if not defined_remote and not skip_upload:
-            self._registry.set_ref(conan_ref, upload_remote)
+            self._registry.set_ref(conan_ref, upload_remote.name)
 
     def _upload_recipe(self, conan_reference, retry, retry_wait, skip_upload, no_overwrite, remote):
         conan_file_path = self._client_cache.conanfile(conan_reference)

--- a/conans/client/cmd/user.py
+++ b/conans/client/cmd/user.py
@@ -23,12 +23,12 @@ def users_clean(localdb_file):
     localdb.init(clean=True)
 
 
-def user_set(localdb_file, user, remote=None):
+def user_set(localdb_file, user, remote_name=None):
     localdb = LocalDB(localdb_file)
 
     if user.lower() == "none":
         user = None
-    return update_localdb(localdb, user, None, remote)
+    return update_localdb(localdb, user, None, remote_name)
 
 
 def update_localdb(localdb, user, token, remote):

--- a/conans/client/command.py
+++ b/conans/client/command.py
@@ -273,7 +273,7 @@ class Command(object):
         args = parser.parse_args(*args)
 
         return self._conan.download(reference=args.reference, package=args.package,
-                                    remote=args.remote, recipe=args.recipe)
+                                    remote_name=args.remote, recipe=args.recipe)
 
     def install(self, *args):
         """Installs the requirements specified in a recipe (conanfile.py or conanfile.txt). It can
@@ -316,7 +316,7 @@ class Command(object):
                 info = self._conan.install(path=args.path_or_reference,
                                            settings=args.settings, options=args.options,
                                            env=args.env,
-                                           remote=args.remote,
+                                           remote_name=args.remote,
                                            verify=args.verify, manifests=args.manifests,
                                            manifests_interactive=args.manifests_interactive,
                                            build=args.build, profile_name=args.profile,
@@ -327,7 +327,7 @@ class Command(object):
                 info = self._conan.install_reference(reference, settings=args.settings,
                                                      options=args.options,
                                                      env=args.env,
-                                                     remote=args.remote,
+                                                     remote_name=args.remote,
                                                      verify=args.verify, manifests=args.manifests,
                                                      manifests_interactive=args.manifests_interactive,
                                                      build=args.build, profile_name=args.profile,
@@ -438,7 +438,7 @@ class Command(object):
                                                options=args.options,
                                                env=args.env,
                                                profile_name=args.profile,
-                                               remote=args.remote,
+                                               remote_name=args.remote,
                                                build_order=args.build_order,
                                                check_updates=args.update,
                                                install_folder=args.install_folder)
@@ -456,7 +456,7 @@ class Command(object):
                                                        options=args.options,
                                                        env=args.env,
                                                        profile_name=args.profile,
-                                                       remote=args.remote,
+                                                       remote_name=args.remote,
                                                        check_updates=args.update,
                                                        install_folder=args.install_folder)
             self._outputer.nodes_to_build(nodes)
@@ -464,7 +464,7 @@ class Command(object):
         # INFO ABOUT DEPS OF CURRENT PROJECT OR REFERENCE
         else:
             data = self._conan.info(args.path_or_reference,
-                                    remote=args.remote,
+                                    remote_name=args.remote,
                                     settings=args.settings,
                                     options=args.options,
                                     env=args.env,
@@ -487,8 +487,8 @@ class Command(object):
             if args.graph:
                 self._outputer.info_graph(args.graph, deps_graph, project_reference, get_cwd())
             else:
-                self._outputer.info(deps_graph, only, args.remote,
-                                    args.package_filter, args.paths, project_reference)
+                self._outputer.info(deps_graph, only, args.package_filter, args.paths,
+                                    project_reference)
 
     def source(self, *args):
         """ Calls your local conanfile.py 'source()' method. e.g., Downloads and unzip the package
@@ -755,7 +755,7 @@ class Command(object):
 
         return self._conan.remove(pattern=reference or args.pattern_or_reference, query=args.query,
                                   packages=args.packages, builds=args.builds, src=args.src,
-                                  force=args.force, remote=args.remote, outdated=args.outdated)
+                                  force=args.force, remote_name=args.remote, outdated=args.outdated)
 
     def copy(self, *args):
         """Copies conan recipes and packages to another user/channel. Useful to promote packages
@@ -823,17 +823,18 @@ class Command(object):
                 info = self._conan.users_list(args.remote)
                 self._outputer.print_user_list(info)
             elif args.password is None:  # set user for remote (no password indicated)
-                remote, prev_user, user = self._conan.user_set(args.name, args.remote)
-                self._outputer.print_user_set(remote, prev_user, user)
+                remote_name, prev_user, user = self._conan.user_set(args.name, args.remote)
+                self._outputer.print_user_set(remote_name, prev_user, user)
             else:  # login a remote
-                remote = args.remote or self._conan.get_default_remote().name
+                remote_name = args.remote or self._conan.get_default_remote().name
                 name = args.name
                 password = args.password
                 if not password:
-                    name, password = self._user_io.request_login(remote_name=remote, username=name)
-                remote, prev_user, user = self._conan.authenticate(name, remote=remote,
-                                                                   password=password)
-                self._outputer.print_user_set(remote, prev_user, user)
+                    name, password = self._user_io.request_login(remote_name=remote_name, username=name)
+                remote_name, prev_user, user = self._conan.authenticate(name,
+                                                                        remote_name=remote_name,
+                                                                        password=password)
+                self._outputer.print_user_set(remote_name, prev_user, user)
         except ConanException as exc:
             info = exc.info
             raise
@@ -887,7 +888,8 @@ class Command(object):
 
         try:
             if reference:
-                info = self._conan.search_packages(reference, query=args.query, remote=args.remote,
+                info = self._conan.search_packages(reference, query=args.query,
+                                                   remote_name=args.remote,
                                                    outdated=args.outdated)
                 # search is done for one reference
                 self._outputer.print_search_packages(info["results"], reference, args.query,
@@ -898,7 +900,8 @@ class Command(object):
 
                 self._check_query_parameter_and_get_reference(args.pattern_or_reference, args.query)
 
-                info = self._conan.search_recipes(args.pattern_or_reference, remote=args.remote,
+                info = self._conan.search_recipes(args.pattern_or_reference,
+                                                  remote_name=args.remote,
                                                   case_sensitive=args.case_sensitive)
                 # Deprecate 2.0: Dirty check if search is done for all remotes or for remote "all"
                 try:
@@ -956,7 +959,8 @@ class Command(object):
 
         try:
             info = self._conan.upload(pattern=args.pattern_or_reference, package=args.package,
-                                      remote=args.remote, all_packages=args.all, force=args.force,
+                                      remote_name=args.remote, all_packages=args.all,
+                                      force=args.force,
                                       confirm=args.confirm, retry=args.retry,
                                       retry_wait=args.retry_wait, skip_upload=args.skip_upload,
                                       integrity_check=args.check, no_overwrite=args.no_overwrite)
@@ -1019,7 +1023,7 @@ class Command(object):
 
         verify_ssl = get_bool_from_text(args.verify_ssl) if hasattr(args, 'verify_ssl') else False
 
-        remote = args.remote if hasattr(args, 'remote') else None
+        remote_name = args.remote if hasattr(args, 'remote') else None
         new_remote = args.new_remote if hasattr(args, 'new_remote') else None
         url = args.url if hasattr(args, 'url') else None
 
@@ -1027,22 +1031,22 @@ class Command(object):
             remotes = self._conan.remote_list()
             self._outputer.remote_list(remotes, args.raw)
         elif args.subcommand == "add":
-            return self._conan.remote_add(remote, url, verify_ssl, args.insert, args.force)
+            return self._conan.remote_add(remote_name, url, verify_ssl, args.insert, args.force)
         elif args.subcommand == "remove":
-            return self._conan.remote_remove(remote)
+            return self._conan.remote_remove(remote_name)
         elif args.subcommand == "rename":
-            return self._conan.remote_rename(remote, new_remote)
+            return self._conan.remote_rename(remote_name, new_remote)
         elif args.subcommand == "update":
-            return self._conan.remote_update(remote, url, verify_ssl, args.insert)
+            return self._conan.remote_update(remote_name, url, verify_ssl, args.insert)
         elif args.subcommand == "list_ref":
             refs = self._conan.remote_list_ref()
             self._outputer.remote_ref_list(refs)
         elif args.subcommand == "add_ref":
-            return self._conan.remote_add_ref(reference, remote)
+            return self._conan.remote_add_ref(reference, remote_name)
         elif args.subcommand == "remove_ref":
             return self._conan.remote_remove_ref(reference)
         elif args.subcommand == "update_ref":
-            return self._conan.remote_update_ref(reference, remote)
+            return self._conan.remote_update_ref(reference, remote_name)
 
     def profile(self, *args):
         """ Lists profiles in the '.conan/profiles' folder, or shows profile details.

--- a/conans/client/conan_api.py
+++ b/conans/client/conan_api.py
@@ -252,7 +252,7 @@ class ConanAPIV1(object):
 
     @api_method
     def test(self, path, reference, profile_name=None, settings=None, options=None, env=None,
-             remote=None, update=False, build_modes=None, cwd=None, test_build_folder=None):
+             remote_name=None, update=False, build_modes=None, cwd=None, test_build_folder=None):
 
         settings = settings or []
         options = options or []
@@ -266,7 +266,7 @@ class ConanAPIV1(object):
         recorder = ActionRecorder()
         manager = self._init_manager(recorder)
         pt = PackageTester(manager, self._user_io)
-        pt.install_build_and_test(conanfile_path, reference, profile, remote,
+        pt.install_build_and_test(conanfile_path, reference, profile, remote_name,
                                   update, build_modes=build_modes,
                                   test_build_folder=test_build_folder)
 
@@ -277,7 +277,7 @@ class ConanAPIV1(object):
                build_modes=None,
                keep_source=False, keep_build=False, verify=None,
                manifests=None, manifests_interactive=None,
-               remote=None, update=False, cwd=None, test_build_folder=None):
+               remote_name=None, update=False, cwd=None, test_build_folder=None):
         """
         API method to create a conan package
 
@@ -322,7 +322,7 @@ class ConanAPIV1(object):
             manager = self._init_manager(recorder)
             recorder.add_recipe_being_developed(reference)
 
-            create(reference, manager, self._user_io, profile, remote, update, build_modes,
+            create(reference, manager, self._user_io, profile, remote_name, update, build_modes,
                    manifest_folder, manifest_verify, manifest_interactive, keep_build,
                    test_build_folder, test_folder, conanfile_path)
 
@@ -393,18 +393,18 @@ class ConanAPIV1(object):
                            profile=profile, force=force)
 
     @api_method
-    def download(self, reference, remote=None, package=None, recipe=False):
+    def download(self, reference, remote_name=None, package=None, recipe=False):
         if package and recipe:
             raise ConanException("recipe parameter cannot be used together with package")
         # Install packages without settings (fixed ids or all)
         conan_ref = ConanFileReference.loads(reference)
         recorder = ActionRecorder()
-        download(conan_ref, package, remote, recipe, self._registry, self._remote_manager,
+        download(conan_ref, package, remote_name, recipe, self._registry, self._remote_manager,
                  self._client_cache, self._user_io.out, recorder)
 
     @api_method
     def install_reference(self, reference, settings=None, options=None, env=None,
-                          remote=None, verify=None, manifests=None,
+                          remote_name=None, verify=None, manifests=None,
                           manifests_interactive=None, build=None, profile_name=None,
                           update=False, generators=None, install_folder=None, cwd=None):
 
@@ -425,7 +425,7 @@ class ConanAPIV1(object):
             mkdir(install_folder)
             manager = self._init_manager(recorder)
             manager.install(reference=reference, install_folder=install_folder,
-                            remote_name=remote, profile=profile, build_modes=build,
+                            remote_name=remote_name, profile=profile, build_modes=build,
                             update=update, manifest_folder=manifest_folder,
                             manifest_verify=manifest_verify,
                             manifest_interactive=manifest_interactive,
@@ -438,7 +438,7 @@ class ConanAPIV1(object):
 
     @api_method
     def install(self, path="", settings=None, options=None, env=None,
-                remote=None, verify=None, manifests=None,
+                remote_name=None, verify=None, manifests=None,
                 manifests_interactive=None, build=None, profile_name=None,
                 update=False, generators=None, no_imports=False, install_folder=None, cwd=None):
 
@@ -463,7 +463,7 @@ class ConanAPIV1(object):
             if workspace:
                 self._user_io.out.success("Using conanws.yml file from %s" % workspace._base_folder)
                 manager = self._init_manager(recorder)
-                manager.install_workspace(profile, workspace, remote, build, update)
+                manager.install_workspace(profile, workspace, remote_name, build, update)
                 return
 
             install_folder = _make_abs_path(install_folder, cwd)
@@ -471,7 +471,7 @@ class ConanAPIV1(object):
             manager = self._init_manager(recorder)
             manager.install(reference=conanfile_path,
                             install_folder=install_folder,
-                            remote_name=remote,
+                            remote_name=remote_name,
                             profile=profile,
                             build_modes=build,
                             update=update,
@@ -527,38 +527,38 @@ class ConanAPIV1(object):
 
     @api_method
     def info_build_order(self, reference, settings=None, options=None, env=None,
-                         profile_name=None, remote=None, build_order=None, check_updates=None,
+                         profile_name=None, remote_name=None, build_order=None, check_updates=None,
                          install_folder=None):
         reference, profile = self._info_get_profile(reference, install_folder, profile_name, settings,
                                                     options, env)
 
         recorder = ActionRecorder()
         manager = self._init_manager(recorder)
-        graph = manager.info_build_order(reference, profile, build_order, remote, check_updates)
+        graph = manager.info_build_order(reference, profile, build_order, remote_name, check_updates)
         return graph
 
     @api_method
     def info_nodes_to_build(self, reference, build_modes, settings=None, options=None, env=None,
-                            profile_name=None, remote=None, check_updates=None, install_folder=None):
+                            profile_name=None, remote_name=None, check_updates=None, install_folder=None):
         reference, profile = self._info_get_profile(reference, install_folder, profile_name, settings,
                                                     options, env)
 
         recorder = ActionRecorder()
         manager = self._init_manager(recorder)
-        ret = manager.info_nodes_to_build(reference, profile, build_modes, remote,
+        ret = manager.info_nodes_to_build(reference, profile, build_modes, remote_name,
                                           check_updates)
         ref_list, project_reference = ret
         return ref_list, project_reference
 
     @api_method
-    def info(self, reference, remote=None, settings=None, options=None, env=None,
+    def info(self, reference, remote_name=None, settings=None, options=None, env=None,
              profile_name=None, update=False, install_folder=None, build=None):
         reference, profile = self._info_get_profile(reference, install_folder, profile_name, settings,
                                                     options, env)
 
         recorder = ActionRecorder()
         manager = self._init_manager(recorder)
-        ret = manager.info_get_graph(reference, remote_name=remote, profile=profile,
+        ret = manager.info_get_graph(reference, remote_name=remote_name, profile=profile,
                                      check_updates=update, build_mode=build)
         deps_graph, project_reference = ret
         return deps_graph, project_reference
@@ -645,9 +645,9 @@ class ConanAPIV1(object):
 
     @api_method
     def remove(self, pattern, query=None, packages=None, builds=None, src=False, force=False,
-               remote=None, outdated=False):
+               remote_name=None, outdated=False):
         remover = ConanRemover(self._client_cache, self._remote_manager, self._user_io, self._registry)
-        remover.remove(pattern, remote, src, builds, packages, force=force,
+        remover.remove(pattern, remote_name, src, builds, packages, force=force,
                        packages_query=query, outdated=outdated)
 
     @api_method
@@ -662,14 +662,14 @@ class ConanAPIV1(object):
                  self._user_io, self._remote_manager, self._registry, force=force)
 
     @api_method
-    def authenticate(self, name, password, remote):
-        remote = self.get_remote_by_name(remote)
-        _, remote, prev_user, user = self._remote_manager.authenticate(remote, name, password)
-        return remote, prev_user, user
+    def authenticate(self, name, password, remote_name):
+        remote = self.get_remote_by_name(remote_name)
+        _, remote_name, prev_user, user = self._remote_manager.authenticate(remote, name, password)
+        return remote_name, prev_user, user
 
     @api_method
-    def user_set(self, user, remote=None):
-        remote = self.get_default_remote() if not remote else self.get_remote_by_name(remote)
+    def user_set(self, user, remote_name=None):
+        remote = self.get_default_remote() if not remote_name else self.get_remote_by_name(remote_name)
         return user_set(self._client_cache.localdb, user, remote)
 
     @api_method
@@ -677,9 +677,9 @@ class ConanAPIV1(object):
         users_clean(self._client_cache.localdb)
 
     @api_method
-    def users_list(self, remote=None):
+    def users_list(self, remote_name=None):
         info = {"error": False, "remotes": []}
-        remotes = [self.get_remote_by_name(remote)] if remote else self.remote_list()
+        remotes = [self.get_remote_by_name(remote_name)] if remote_name else self.remote_list()
         try:
             info["remotes"] = users_list(self._client_cache.localdb, remotes)
             return info
@@ -689,30 +689,30 @@ class ConanAPIV1(object):
             raise
 
     @api_method
-    def search_recipes(self, pattern, remote=None, case_sensitive=False):
+    def search_recipes(self, pattern, remote_name=None, case_sensitive=False):
         recorder = SearchRecorder()
         search = Search(self._client_cache, self._remote_manager, self._registry)
 
         try:
-            references = search.search_recipes(pattern, remote, case_sensitive)
+            references = search.search_recipes(pattern, remote_name, case_sensitive)
         except ConanException as exc:
             recorder.error = True
             exc.info = recorder.get_info()
             raise
 
-        for remote, refs in references.items():
+        for remote_name, refs in references.items():
             for ref in refs:
-                recorder.add_recipe(str(remote), str(ref), with_packages=False)
+                recorder.add_recipe(remote_name, ref, with_packages=False)
         return recorder.get_info()
 
     @api_method
-    def search_packages(self, reference, query=None, remote=None, outdated=False):
+    def search_packages(self, reference, query=None, remote_name=None, outdated=False):
         recorder = SearchRecorder()
         search = Search(self._client_cache, self._remote_manager, self._registry)
 
         try:
             reference = ConanFileReference.loads(str(reference))
-            references = search.search_packages(reference, remote,
+            references = search.search_packages(reference, remote_name,
                                                 query=query,
                                                 outdated=outdated)
         except ConanException as exc:
@@ -720,12 +720,12 @@ class ConanAPIV1(object):
             exc.info = recorder.get_info()
             raise
 
-        for remote, remote_ref in references.items():
-            recorder.add_recipe(str(remote), reference)
+        for remote_name, remote_ref in references.items():
+            recorder.add_recipe(remote_name, reference)
             if remote_ref.ordered_packages:
                 for package_id, properties in remote_ref.ordered_packages.items():
                     package_recipe_hash = properties.get("recipe_hash", None)
-                    recorder.add_package(str(remote), reference, package_id,
+                    recorder.add_package(remote_name, reference, package_id,
                                          properties.get("options", []),
                                          properties.get("settings", []),
                                          properties.get("full_requires", []),
@@ -733,7 +733,7 @@ class ConanAPIV1(object):
         return recorder.get_info()
 
     @api_method
-    def upload(self, pattern, package=None, remote=None, all_packages=False, force=False,
+    def upload(self, pattern, package=None, remote_name=None, all_packages=False, force=False,
                confirm=False, retry=2, retry_wait=5, skip_upload=False, integrity_check=False,
                no_overwrite=None):
         """ Uploads a package recipe and the generated binary packages to a specified remote
@@ -751,7 +751,7 @@ class ConanAPIV1(object):
                              self._registry)
         try:
             uploader.upload(recorder, pattern, package, all_packages, force, confirm, retry,
-                            retry_wait, skip_upload, integrity_check, no_overwrite, remote)
+                            retry_wait, skip_upload, integrity_check, no_overwrite, remote_name)
             return recorder.get_info()
         except ConanException as exc:
             recorder.error = True
@@ -763,29 +763,29 @@ class ConanAPIV1(object):
         return self._registry.remotes
 
     @api_method
-    def remote_add(self, remote, url, verify_ssl=True, insert=None, force=None):
-        return self._registry.add(remote, url, verify_ssl, insert, force)
+    def remote_add(self, remote_name, url, verify_ssl=True, insert=None, force=None):
+        return self._registry.add(remote_name, url, verify_ssl, insert, force)
 
     @api_method
-    def remote_remove(self, remote):
-        return self._registry.remove(remote)
+    def remote_remove(self, remote_name):
+        return self._registry.remove(remote_name)
 
     @api_method
-    def remote_update(self, remote, url, verify_ssl=True, insert=None):
-        return self._registry.update(remote, url, verify_ssl, insert)
+    def remote_update(self, remote_name, url, verify_ssl=True, insert=None):
+        return self._registry.update(remote_name, url, verify_ssl, insert)
 
     @api_method
-    def remote_rename(self, remote, new_remote):
-        return self._registry.rename(remote, new_remote)
+    def remote_rename(self, remote_name, new_new_remote):
+        return self._registry.rename(remote_name, new_new_remote)
 
     @api_method
     def remote_list_ref(self):
         return self._registry.refs
 
     @api_method
-    def remote_add_ref(self, reference, remote):
+    def remote_add_ref(self, reference, remote_name):
         reference = ConanFileReference.loads(str(reference))
-        return self._registry.add_ref(reference, remote)
+        return self._registry.set_ref(reference, remote_name, check_exists=True)
 
     @api_method
     def remote_remove_ref(self, reference):
@@ -793,9 +793,9 @@ class ConanAPIV1(object):
         return self._registry.remove_ref(reference)
 
     @api_method
-    def remote_update_ref(self, reference, remote):
+    def remote_update_ref(self, reference, remote_name):
         reference = ConanFileReference.loads(str(reference))
-        return self._registry.update_ref(reference, remote)
+        return self._registry.update_ref(reference, remote_name)
 
     @api_method
     def profile_list(self):
@@ -824,16 +824,16 @@ class ConanAPIV1(object):
         return p
 
     @api_method
-    def get_path(self, reference, package_id=None, path=None, remote=None):
+    def get_path(self, reference, package_id=None, path=None, remote_name=None):
         from conans.client.local_file_getter import get_path
         reference = ConanFileReference.loads(str(reference))
         if not path:
             path = "conanfile.py" if not package_id else "conaninfo.txt"
 
-        if not remote:
+        if not remote_name:
             return get_path(self._client_cache, reference, package_id, path), path
         else:
-            remote = self.get_remote_by_name(remote)
+            remote = self.get_remote_by_name(remote_name)
             return self._remote_manager.get_path(reference, package_id, path, remote), path
 
     @api_method
@@ -847,8 +847,8 @@ class ConanAPIV1(object):
         return self._registry.default_remote
 
     @api_method
-    def get_remote_by_name(self, remote):
-        return self._registry.remote(remote)
+    def get_remote_by_name(self, remote_name):
+        return self._registry.remote(remote_name)
 
 
 Conan = ConanAPIV1

--- a/conans/client/conan_command_output.py
+++ b/conans/client/conan_command_output.py
@@ -32,8 +32,8 @@ class CommandOutputer(object):
                 self.user_io.out.info("%s: %s [Verify SSL: %s]" % (r.name, r.url, r.verify_ssl))
 
     def remote_ref_list(self, refs):
-        for ref, remote in refs.items():
-            self.user_io.out.info("%s: %s" % (ref, remote))
+        for ref, remote_name in refs.items():
+            self.user_io.out.info("%s: %s" % (ref, remote_name))
 
     def build_order(self, info):
         msg = ", ".join(str(s) for s in info)
@@ -74,11 +74,11 @@ class CommandOutputer(object):
     def nodes_to_build(self, nodes_to_build):
         self.user_io.out.info(", ".join(str(n) for n in nodes_to_build))
 
-    def info(self, deps_graph, only, remote, package_filter, show_paths, project_reference):
+    def info(self, deps_graph, only, package_filter, show_paths, project_reference):
         registry = RemoteRegistry(self.client_cache.registry, self.user_io.out)
         Printer(self.user_io.out).print_info(deps_graph, project_reference,
                                              only, registry,
-                                             remote=remote, node_times=self._read_dates(deps_graph),
+                                             node_times=self._read_dates(deps_graph),
                                              path_resolver=self.client_cache, package_filter=package_filter,
                                              show_paths=show_paths)
 
@@ -140,7 +140,7 @@ class CommandOutputer(object):
                                   (remote["name"], str(remote["user_name"]), anonymous,
                                    authenticated))
 
-    def print_user_set(self, remote, prev_user, user):
+    def print_user_set(self, remote_name, prev_user, user):
         previous_username = prev_user or "None"
         previous_anonymous = " (anonymous)" if not prev_user else ""
         username = user or "None"
@@ -148,8 +148,8 @@ class CommandOutputer(object):
 
         if prev_user == user:
             self.user_io.out.info("User of remote '%s' is already '%s'%s" %
-                                  (remote, previous_username, previous_anonymous))
+                                  (remote_name, previous_username, previous_anonymous))
         else:
             self.user_io.out.info("Changed user of remote '%s' from '%s'%s to '%s'%s" %
-                                  (remote, previous_username, previous_anonymous, username,
+                                  (remote_name, previous_username, previous_anonymous, username,
                                    anonymous))

--- a/conans/client/graph/proxy.py
+++ b/conans/client/graph/proxy.py
@@ -72,7 +72,7 @@ class ConanProxy(object):
                     DiskRemover(self._client_cache).remove_recipe(reference)
                     output.info("Retrieving from remote '%s'..." % update_remote.name)
                     reference = self._remote_manager.get_recipe(reference, update_remote)
-                    self._registry.set_ref(reference, update_remote)
+                    self._registry.set_ref(reference, update_remote.name)
                     status = RECIPE_UPDATED
                 else:
                     status = RECIPE_UPDATEABLE
@@ -89,7 +89,7 @@ class ConanProxy(object):
         def _retrieve_from_remote(the_remote):
             output.info("Trying with '%s'..." % the_remote.name)
             new_reference = self._remote_manager.get_recipe(conan_reference, the_remote)
-            self._registry.set_ref(new_reference, the_remote)
+            self._registry.set_ref(new_reference, the_remote.name)
             self._recorder.recipe_downloaded(conan_reference, the_remote.url)
             return new_reference
 

--- a/conans/client/installer.py
+++ b/conans/client/installer.py
@@ -231,7 +231,7 @@ def raise_package_not_found_error(conan_file, conan_ref, package_id, out, record
 ''' % (conan_ref, settings_text, options_text, package_id)
     out.warn(msg)
     recorder.package_install_error(PackageReference(conan_ref, package_id),
-                                   INSTALL_ERROR_MISSING, msg, remote=remote_url)
+                                   INSTALL_ERROR_MISSING, msg, remote_name=remote_url)
     raise ConanException('''Missing prebuilt package for '%s'
 Try to build it from sources with "--build %s"
 Or read "http://docs.conan.io/en/latest/faq/troubleshooting.html#error-missing-prebuilt-package"
@@ -299,7 +299,7 @@ class ConanInstaller(object):
                 elif node.binary in (BINARY_UPDATE, BINARY_DOWNLOAD):
                     self._download_package(conan_file, package_ref, output, package_folder, node.binary_remote)
                     if node.binary_remote != node.remote:
-                        self._registry.set_ref(conan_ref, node.binary_remote)
+                        self._registry.set_ref(conan_ref, node.binary_remote.name)
                 elif node.binary == BINARY_CACHE:
                     output.success('Already installed!')
                     log_package_got_from_local_cache(package_ref)
@@ -358,7 +358,7 @@ class ConanInstaller(object):
                 msg = "--keep-build specified, but build folder not found"
                 self._recorder.package_install_error(package_ref,
                                                      INSTALL_ERROR_MISSING_BUILD_FOLDER,
-                                                     msg, remote=None)
+                                                     msg, remote_name=None)
                 raise ConanException(msg)
         else:
             with self._client_cache.conanfile_write_lock(conan_ref):
@@ -373,7 +373,7 @@ class ConanInstaller(object):
                 builder.package()
             except ConanException as exc:
                 self._recorder.package_install_error(package_ref, INSTALL_ERROR_BUILDING,
-                                                     str(exc), remote=None)
+                                                     str(exc), remote_name=None)
                 raise exc
             else:
                 # Log build

--- a/conans/client/installer.py
+++ b/conans/client/installer.py
@@ -220,7 +220,7 @@ def call_system_requirements(conanfile, output):
         raise ConanException("Error in system requirements")
 
 
-def raise_package_not_found_error(conan_file, conan_ref, package_id, out, recorder, remote_url):
+def raise_package_not_found_error(conan_file, conan_ref, package_id, out, recorder):
     settings_text = ", ".join(conan_file.info.full_settings.dumps().splitlines())
     options_text = ", ".join(conan_file.info.full_options.dumps().splitlines())
 
@@ -231,7 +231,7 @@ def raise_package_not_found_error(conan_file, conan_ref, package_id, out, record
 ''' % (conan_ref, settings_text, options_text, package_id)
     out.warn(msg)
     recorder.package_install_error(PackageReference(conan_ref, package_id),
-                                   INSTALL_ERROR_MISSING, msg, remote_name=remote_url)
+                                   INSTALL_ERROR_MISSING, msg)
     raise ConanException('''Missing prebuilt package for '%s'
 Try to build it from sources with "--build %s"
 Or read "http://docs.conan.io/en/latest/faq/troubleshooting.html#error-missing-prebuilt-package"
@@ -268,7 +268,7 @@ class ConanInstaller(object):
                 output = ScopedOutput(str(conan_ref), self._out)
                 package_id = conan_file.info.package_id()
                 if node.binary == BINARY_MISSING:
-                    raise_package_not_found_error(conan_file, conan_ref, package_id, output, self._recorder, None)
+                    raise_package_not_found_error(conan_file, conan_ref, package_id, output, self._recorder)
 
                 self._propagate_info(node, inverse_levels, deps_graph, output)
                 if node.binary == BINARY_SKIP:  # Privates not necessary

--- a/conans/client/manifest_manager.py
+++ b/conans/client/manifest_manager.py
@@ -1,4 +1,6 @@
 import os
+
+from conans.client.remote_registry import Remote
 from conans.paths import SimplePaths
 from conans.model.manifest import FileTreeManifest
 from conans.errors import ConanException
@@ -47,10 +49,10 @@ class ManifestManager(object):
         self._handle_folder(folder, ref, read_manifest, interactive, node.remote, verify)
 
     def _handle_folder(self, folder, ref, read_manifest, interactive, remote, verify):
-        remote = "local cache" if not remote else "%s:%s" % (remote.name, remote.url)
+        assert(isinstance(remote, Remote))
+        remote_name = "local cache" if not remote else "%s:%s" % (remote.name, remote.url)
         if os.path.exists(folder):
-            self._handle_manifest(ref, folder, read_manifest, interactive,
-                                  remote, verify)
+            self._handle_manifest(ref, folder, read_manifest, interactive, remote_name, verify)
         else:
             if verify:
                 raise ConanException("New manifest '%s' detected.\n"
@@ -76,7 +78,7 @@ class ManifestManager(object):
                                  "some file hash doesn't match manifest"
                                  % (str(ref)))
 
-    def _handle_manifest(self, ref, folder, read_manifest, interactive, remote, verify):
+    def _handle_manifest(self, ref, folder, read_manifest, interactive, remote_name, verify):
         captured_manifest = FileTreeManifest.load(folder)
         if captured_manifest == read_manifest:
             self._log.append("Manifest for '%s': OK" % str(ref))
@@ -86,14 +88,14 @@ class ManifestManager(object):
                                         % (fname, h1, h2) for fname, (h1, h2) in diff.items())
             raise ConanException("Modified or new manifest '%s' detected.\n"
                                  "Remote: %s\nProject manifest doesn't match installed one\n%s"
-                                 % (str(ref), remote, error_msg))
+                                 % (str(ref), remote_name, error_msg))
         else:
-            self._check_accept_install(interactive, ref, remote)
+            self._check_accept_install(interactive, ref, remote_name)
             self._log.append("Installed manifest for '%s' from %s"
-                             % (str(ref), remote))
+                             % (str(ref), remote_name))
             read_manifest.save(folder)
 
     def print_log(self):
-        self._user_io.out.success("\nManifests : %s" % (self._paths.store))
+        self._user_io.out.success("\nManifests : %s" % self._paths.store)
         for log_entry in self._log:
             self._user_io.out.info(log_entry)

--- a/conans/client/manifest_manager.py
+++ b/conans/client/manifest_manager.py
@@ -49,7 +49,7 @@ class ManifestManager(object):
         self._handle_folder(folder, ref, read_manifest, interactive, node.remote, verify)
 
     def _handle_folder(self, folder, ref, read_manifest, interactive, remote, verify):
-        assert(isinstance(remote, Remote))
+        assert(isinstance(remote, Remote) or remote is None)
         remote_name = "local cache" if not remote else "%s:%s" % (remote.name, remote.url)
         if os.path.exists(folder):
             self._handle_manifest(ref, folder, read_manifest, interactive, remote_name, verify)
@@ -57,17 +57,17 @@ class ManifestManager(object):
             if verify:
                 raise ConanException("New manifest '%s' detected.\n"
                                      "Remote: %s\nProject manifest doesn't match installed one"
-                                     % (str(ref), remote))
+                                     % (str(ref), remote_name))
             else:
-                self._check_accept_install(interactive, ref, remote)
+                self._check_accept_install(interactive, ref, remote_name)
                 self._log.append("Installed manifest for '%s' from %s"
-                                 % (str(ref), remote))
+                                 % (str(ref), remote_name))
                 read_manifest.save(folder)
 
-    def _check_accept_install(self, interactive, ref, remote):
+    def _check_accept_install(self, interactive, ref, remote_name):
         if (interactive and
             not self._user_io.request_boolean("Installing %s from %s\n"
-                                              "Do you trust it?" % (str(ref), remote),
+                                              "Do you trust it?" % (str(ref), remote_name),
                                               True)):
             raise ConanException("Installation of '%s' rejected!" % str(ref))
 

--- a/conans/client/printer.py
+++ b/conans/client/printer.py
@@ -43,8 +43,7 @@ class Printer(object):
                 path = path_resolver.package(PackageReference(ref, id_), conan.short_paths)
                 self._out.writeln("    package_folder: %s" % path, Color.BRIGHT_GREEN)
 
-    def print_info(self, deps_graph, project_reference, _info, registry,
-                   remote=None, node_times=None, path_resolver=None, package_filter=None,
+    def print_info(self, deps_graph, project_reference, _info, registry, node_times=None, path_resolver=None, package_filter=None,
                    show_paths=False):
         """ Print the dependency information for a conan file
 
@@ -54,8 +53,6 @@ class Printer(object):
                                        file for a project on the path. This may be None,
                                        in which case the project itself will not be part
                                        of the printed dependencies.
-                remote: Remote specified in install command.
-                        Could be different from the registry one.
         """
         if _info is None:  # No filter
             def show(_):

--- a/conans/client/printer.py
+++ b/conans/client/printer.py
@@ -178,8 +178,8 @@ class Printer(object):
         assert(isinstance(reference, ConanFileReference))
         self._out.info("Existing packages for recipe %s:\n" % str(reference))
         for remote_info in search_info:
-            if remote_info["remote"] != 'None':
-                self._out.info("Existing recipe in remote '%s':\n" % str(remote_info["remote"]))
+            if remote_info["remote"]:
+                self._out.info("Existing recipe in remote '%s':\n" % remote_info["remote"])
 
             if not remote_info["items"][0]["packages"]:
                 if packages_query:

--- a/conans/client/recorder/action_recorder.py
+++ b/conans/client/recorder/action_recorder.py
@@ -56,11 +56,11 @@ class ActionRecorder(object):
     def recipe_fetched_from_cache(self, reference):
         self._add_recipe_action(reference, Action(INSTALL_CACHE))
 
-    def recipe_downloaded(self, reference, remote):
-        self._add_recipe_action(reference, Action(INSTALL_DOWNLOADED, {"remote": remote}))
+    def recipe_downloaded(self, reference, remote_name):
+        self._add_recipe_action(reference, Action(INSTALL_DOWNLOADED, {"remote": remote_name}))
 
-    def recipe_install_error(self, reference, error_type, description, remote):
-        doc = {"type": error_type, "description": description, "remote": remote}
+    def recipe_install_error(self, reference, error_type, description, remote_name):
+        doc = {"type": error_type, "description": description, "remote": remote_name}
         self._add_recipe_action(reference, Action(INSTALL_ERROR, doc))
 
     # PACKAGE METHODS
@@ -70,14 +70,14 @@ class ActionRecorder(object):
     def package_fetched_from_cache(self, reference):
         self._add_package_action(reference, Action(INSTALL_CACHE))
 
-    def package_downloaded(self, reference, remote):
-        self._add_package_action(reference, Action(INSTALL_DOWNLOADED, {"remote": remote}))
+    def package_downloaded(self, reference, remote_name):
+        self._add_package_action(reference, Action(INSTALL_DOWNLOADED, {"remote": remote_name}))
 
-    def package_install_error(self, reference, error_type, description, remote=None):
+    def package_install_error(self, reference, error_type, description, remote_name=None):
         assert(isinstance(reference, PackageReference))
         if reference not in self._inst_packages_actions:
             self._inst_packages_actions[reference] = []
-        doc = {"type": error_type, "description": description, "remote": remote}
+        doc = {"type": error_type, "description": description, "remote": remote_name}
         self._inst_packages_actions[reference].append(Action(INSTALL_ERROR, doc))
 
     @property

--- a/conans/client/recorder/search_recorder.py
+++ b/conans/client/recorder/search_recorder.py
@@ -24,23 +24,23 @@ class SearchRecorder(object):
         self.keyword = "results"
         self._info = OrderedDict()
 
-    def add_recipe(self, remote, reference, with_packages=True):
+    def add_recipe(self, remote_name, reference, with_packages=True):
         recipe = _SearchRecipe(reference)
         recipe.with_packages = with_packages
-        if remote not in self._info:
-            self._info[remote] = OrderedDict()
-        self._info[remote][reference] = {"recipe": recipe, "packages": []}
+        if remote_name not in self._info:
+            self._info[remote_name] = OrderedDict()
+        self._info[remote_name][reference] = {"recipe": recipe, "packages": []}
 
-    def add_package(self, remote, reference, package_id, options, settings, requires, outdated):
-        self._info[remote][reference]["packages"].append(_SearchPackage(package_id, options,
-                                                                        settings, requires,
-                                                                        outdated))
+    def add_package(self, remote_name, reference, package_id, options, settings, requires, outdated):
+        self._info[remote_name][reference]["packages"].append(_SearchPackage(package_id, options,
+                                                                             settings, requires,
+                                                                             outdated))
 
     def get_info(self):
         info = {"error": self.error, self.keyword: []}
 
-        for remote, recipe_packages in sorted(self._info.items()):
-            remote_info = {"remote": remote, "items": []}
+        for remote_name, recipe_packages in sorted(self._info.items()):
+            remote_info = {"remote": remote_name, "items": []}
             for reference, item in recipe_packages.items():
                 recipe_info = item["recipe"].to_dict()
                 if item["recipe"].with_packages:

--- a/conans/client/remote_registry.py
+++ b/conans/client/remote_registry.py
@@ -40,23 +40,23 @@ class RemoteRegistry(object):
             chunks = line.split()
             if not end_remotes:
                 if len(chunks) == 2:  # Retro compatibility
-                    ref, remote = chunks
+                    ref, remote_name = chunks
                     verify_ssl = "True"
                 elif len(chunks) == 3:
-                    ref, remote, verify_ssl = chunks
+                    ref, remote_name, verify_ssl = chunks
                 else:
                     raise ConanException("Bad file format, wrong item numbers in line '%s'" % line)
 
                 verify_ssl = get_bool_from_text_value(verify_ssl)
-                remotes[ref] = (remote, verify_ssl)
+                remotes[ref] = (remote_name, verify_ssl)
             else:
-                ref, remote = chunks
-                refs[ref] = remote
+                ref, remote_name = chunks
+                refs[ref] = remote_name
 
         return remotes, refs
 
     def _to_string(self, remotes, refs):
-        lines = ["%s %s %s" % (ref, remote, verify_ssl) for ref, (remote, verify_ssl) in remotes.items()]
+        lines = ["%s %s %s" % (ref, remote_name, verify_ssl) for ref, (remote_name, verify_ssl) in remotes.items()]
         lines.append("")
         lines.extend(["%s %s" % (ref, remote) for ref, remote in sorted(refs.items())])
         text = os.linesep.join(lines)
@@ -86,20 +86,20 @@ class RemoteRegistry(object):
     def remotes(self):
         return list(self._remote_dict.values())
 
-    def remote(self, name):
+    def remote(self, remote_name):
         try:
-            return self._remote_dict[name]
+            return self._remote_dict[remote_name]
         except KeyError:
             raise NoRemoteAvailable("No remote '%s' defined in remotes in file %s"
-                                    % (name, self._filename))
+                                    % (remote_name, self._filename))
 
     @property
     def _remote_dict(self):
         if self._remotes is None:
             with fasteners.InterProcessLock(self._filename + ".lock", logger=logger):
                 remotes, _ = self._load()
-                self._remotes = OrderedDict([(ref, Remote(ref, remote, verify_ssl))
-                                             for ref, (remote, verify_ssl) in remotes.items()])
+                self._remotes = OrderedDict([(ref, Remote(ref, remote_name, verify_ssl))
+                                             for ref, (remote_name, verify_ssl) in remotes.items()])
         return self._remotes
 
     @property
@@ -130,33 +130,27 @@ class RemoteRegistry(object):
                     self._output.warn("Couldn't delete '%s' from remote registry"
                                       % str(conan_reference))
 
-    def set_ref(self, conan_reference, remote):
+    def set_ref(self, conan_reference, remote_name, check_exists=False):
         assert(isinstance(conan_reference, ConanFileReference))
         with fasteners.InterProcessLock(self._filename + ".lock", logger=logger):
             remotes, refs = self._load()
-            refs[str(conan_reference)] = remote.name
+            if check_exists:
+                if conan_reference in refs:
+                    raise ConanException("%s already exists. Use update" % conan_reference)
+                if remote_name not in remotes:
+                    raise ConanException("%s not in remotes" % remote_name)
+            refs[str(conan_reference)] = remote_name
             self._save(remotes, refs)
 
-    def add_ref(self, conan_reference, remote):
-        assert(isinstance(conan_reference, ConanFileReference))
-        with fasteners.InterProcessLock(self._filename + ".lock", logger=logger):
-            remotes, refs = self._load()
-            if conan_reference in refs:
-                raise ConanException("%s already exists. Use update" % conan_reference)
-            if remote not in remotes:
-                raise ConanException("%s not in remotes" % remote)
-            refs[str(conan_reference)] = remote
-            self._save(remotes, refs)
-
-    def update_ref(self, conan_reference, remote):
+    def update_ref(self, conan_reference, remote_name):
         assert(isinstance(conan_reference, ConanFileReference))
         with fasteners.InterProcessLock(self._filename + ".lock", logger=logger):
             remotes, refs = self._load()
             if str(conan_reference) not in refs:
                 raise ConanException("%s does not exist. Use add" % str(conan_reference))
-            if remote not in remotes:
-                raise ConanException("%s not in remotes" % remote)
-            refs[str(conan_reference)] = remote
+            if remote_name not in remotes:
+                raise ConanException("%s not in remotes" % remote_name)
+            refs[str(conan_reference)] = remote_name
             self._save(remotes, refs)
 
     def _upsert(self, remote_name, url, verify_ssl, insert):

--- a/conans/client/remover.py
+++ b/conans/client/remover.py
@@ -1,5 +1,6 @@
 import os
 
+from conans.client.remote_registry import Remote
 from conans.errors import ConanException
 from conans.util.log import logger
 from conans.model.ref import PackageReference
@@ -91,6 +92,7 @@ class ConanRemover(object):
         self._registry = remote_registry
 
     def _remote_remove(self, reference, package_ids, remote):
+        assert(isinstance(remote, Remote))
         if package_ids is None:
             result = self._remote_manager.remove(reference, remote)
             current_remote = self._registry.get_recipe_remote(reference)
@@ -114,7 +116,7 @@ class ConanRemover(object):
             remover.remove(reference)
             self._registry.remove_ref(reference, quiet=True)
 
-    def remove(self, pattern, remote, src=None, build_ids=None, package_ids_filter=None, force=False,
+    def remove(self, pattern, remote_name, src=None, build_ids=None, package_ids_filter=None, force=False,
                packages_query=None, outdated=False):
         """ Remove local/remote conans, package folders, etc.
         @param src: Remove src folder
@@ -125,11 +127,11 @@ class ConanRemover(object):
         @param packages_query: Only if src is a reference. Query settings and options
         """
 
-        if remote and (build_ids is not None or src):
+        if remote_name and (build_ids is not None or src):
             raise ConanException("Remotes don't have 'build' or 'src' folder, just packages")
 
-        if remote:
-            remote = self._registry.remote(remote)
+        if remote_name:
+            remote = self._registry.remote(remote_name)
             references = self._remote_manager.search_recipes(remote, pattern)
         else:
             references = search_recipes(self._client_cache, pattern)
@@ -143,12 +145,12 @@ class ConanRemover(object):
             package_ids = package_ids_filter
             if packages_query or outdated:
                 # search packages
-                if remote:
+                if remote_name:
                     packages = self._remote_manager.search_packages(remote, reference, packages_query)
                 else:
                     packages = search_packages(self._client_cache, reference, packages_query)
                 if outdated:
-                    if remote:
+                    if remote_name:
                         recipe_hash = self._remote_manager.get_conan_manifest(reference, remote).summary_hash
                     else:
                         recipe_hash = self._client_cache.load_manifest(reference).summary_hash
@@ -164,13 +166,13 @@ class ConanRemover(object):
 
             if self._ask_permission(reference, src, build_ids, package_ids, force):
                 deleted_refs.append(reference)
-                if remote:
+                if remote_name:
                     self._remote_remove(reference, package_ids, remote)
                 else:
                     deleted_refs.append(reference)
                     self._local_remove(reference, src, build_ids, package_ids)
 
-        if not remote:
+        if not remote_name:
             self._client_cache.delete_empty_dirs(deleted_refs)
 
     def _ask_permission(self, conan_ref, src, build_ids, package_ids_filter, force):

--- a/conans/client/rest/auth_manager.py
+++ b/conans/client/rest/auth_manager.py
@@ -197,5 +197,5 @@ class ConanApiAuthManager(object):
             raise ConanException("Password contains not allowed symbols")
 
         # Store result in DB
-        remote, prev_user, user = update_localdb(self._localdb, user, token, self._remote)
-        return token, remote, prev_user, user
+        remote_name, prev_user, user = update_localdb(self._localdb, user, token, self._remote)
+        return token, remote_name, prev_user, user

--- a/conans/test/command/search_test.py
+++ b/conans/test/command/search_test.py
@@ -600,7 +600,7 @@ helloTest/1.4.10@fenix/stable""".format(remote)
             'error': False,
             'results': [
                 {
-                    'remote': 'None',
+                    'remote': None,
                     'items': [
                         {
                             'recipe': {
@@ -725,7 +725,7 @@ helloTest/1.4.10@fenix/stable""".format(remote)
             'error': False,
             'results': [
                 {
-                    'remote': 'None',
+                    'remote': None,
                     'items': [
                         {
                             'recipe': {

--- a/conans/test/functional/action_recorder_test.py
+++ b/conans/test/functional/action_recorder_test.py
@@ -53,7 +53,7 @@ class ActionRecorderTest(unittest.TestCase):
         tracer.package_downloaded(self.ref_p1, "http://drl.com")
         tracer.recipe_downloaded(self.ref2, "http://drl.com")
         tracer.package_install_error(self.ref_p2, INSTALL_ERROR_MISSING, "no package found",
-                                     remote="https://drl.com")
+                                     remote_name="https://drl.com")
 
         tracer.recipe_fetched_from_cache(self.ref3)
         tracer.package_built(self.ref_p3)

--- a/conans/test/functional/registry_test.py
+++ b/conans/test/functional/registry_test.py
@@ -58,11 +58,11 @@ class RegistryTest(unittest.TestCase):
         ref = ConanFileReference.loads("MyLib/0.1@lasote/stable")
 
         remotes = registry.remotes
-        registry.set_ref(ref, remotes[0])
+        registry.set_ref(ref, remotes[0].name)
         remote = registry.get_recipe_remote(ref)
         self.assertEqual(remote, remotes[0])
 
-        registry.set_ref(ref, remotes[0])
+        registry.set_ref(ref, remotes[0].name)
         remote = registry.get_recipe_remote(ref)
         self.assertEqual(remote, remotes[0])
 

--- a/conans/util/tracer.py
+++ b/conans/util/tracer.py
@@ -68,14 +68,14 @@ def _file_document(name, path):
     return {"name": name, "path": path, "md5": md5sum(path), "sha1": sha1sum(path)}
 
 
-def log_recipe_upload(conan_reference, duration, files_uploaded, remote):
+def log_recipe_upload(conan_reference, duration, files_uploaded, remote_name):
     assert(isinstance(conan_reference, ConanFileReference))
     files_uploaded = files_uploaded or {}
     files_uploaded = [_file_document(name, path) for name, path in files_uploaded.items()]
     _append_action("UPLOADED_RECIPE", {"_id": str(conan_reference),
                                        "duration": duration,
                                        "files": files_uploaded,
-                                       "remote": remote.name})
+                                       "remote": remote_name})
 
 
 def log_package_upload(package_ref, duration, files_uploaded, remote):
@@ -89,23 +89,23 @@ def log_package_upload(package_ref, duration, files_uploaded, remote):
                                         "remote": remote.name})
 
 
-def log_recipe_download(conan_reference, duration, remote, files_downloaded):
+def log_recipe_download(conan_reference, duration, remote_name, files_downloaded):
     assert(isinstance(conan_reference, ConanFileReference))
     files_downloaded = files_downloaded or {}
     files_downloaded = [_file_document(name, path) for name, path in files_downloaded.items()]
     _append_action("DOWNLOADED_RECIPE", {"_id": str(conan_reference),
                                          "duration": duration,
-                                         "remote": remote.name,
+                                         "remote": remote_name,
                                          "files": files_downloaded})
 
 
-def log_recipe_sources_download(conan_reference, duration, remote, files_downloaded):
+def log_recipe_sources_download(conan_reference, duration, remote_name, files_downloaded):
     assert(isinstance(conan_reference, ConanFileReference))
     files_downloaded = files_downloaded or {}
     files_downloaded = [_file_document(name, path) for name, path in files_downloaded.items()]
     _append_action("DOWNLOADED_RECIPE_SOURCES", {"_id": str(conan_reference),
                                                  "duration": duration,
-                                                 "remote": remote.name,
+                                                 "remote": remote_name,
                                                  "files": files_downloaded})
 
 


### PR DESCRIPTION
Pure refactor of variable names. `remote` is a `Remote` object (almost only managed by the remote manager and the graph), and `remote_name` is a`str`.