### PR TITLE
added draft of default_deploy feature

### DIFF
--- a/conans/client/cmd/create.py
+++ b/conans/client/cmd/create.py
@@ -41,6 +41,7 @@ def create(reference, manager, user_io, profile, remote_name, update, build_mode
     else:
         manager.install(reference=reference,
                         install_folder=None,  # Not output anything
+                        deploy_folder=None,
                         manifest_folder=manifest_folder,
                         manifest_verify=manifest_verify,
                         manifest_interactive=manifest_interactive,

--- a/conans/client/command.py
+++ b/conans/client/command.py
@@ -294,6 +294,9 @@ class Command(object):
         parser.add_argument("-if", "--install-folder", action=OnceArgument,
                             help='Use this directory as the directory where to put the generator'
                                  'files. e.g., conaninfo/conanbuildinfo.txt')
+        parser.add_argument("-df", "--deploy-folder", action=OnceArgument,
+                            help='Use this directory as the directory where to copy all package '
+                                 'contents after package step.')
 
         _add_manifests_arguments(parser)
 
@@ -333,7 +336,8 @@ class Command(object):
                                                      build=args.build, profile_name=args.profile,
                                                      update=args.update,
                                                      generators=args.generator,
-                                                     install_folder=args.install_folder)
+                                                     install_folder=args.install_folder,
+                                                     deploy_folder=args.deploy_folder)
         except ConanException as exc:
             info = exc.info
             raise

--- a/conans/client/conan_api.py
+++ b/conans/client/conan_api.py
@@ -406,12 +406,14 @@ class ConanAPIV1(object):
     def install_reference(self, reference, settings=None, options=None, env=None,
                           remote_name=None, verify=None, manifests=None,
                           manifests_interactive=None, build=None, profile_name=None,
-                          update=False, generators=None, install_folder=None, cwd=None):
+                          update=False, generators=None, install_folder=None,
+                          deploy_folder=None, cwd=None):
 
         try:
             recorder = ActionRecorder()
             cwd = cwd or os.getcwd()
             install_folder = _make_abs_path(install_folder, cwd)
+            deploy_folder = _make_abs_path(deploy_folder, cwd)
 
             manifests = _parse_manifests_arguments(verify, manifests, manifests_interactive, cwd)
             manifest_folder, manifest_interactive, manifest_verify = manifests
@@ -423,8 +425,10 @@ class ConanAPIV1(object):
                 generators = False
 
             mkdir(install_folder)
+            mkdir(deploy_folder)
             manager = self._init_manager(recorder)
             manager.install(reference=reference, install_folder=install_folder,
+                            deploy_folder=deploy_folder,
                             remote_name=remote_name, profile=profile, build_modes=build,
                             update=update, manifest_folder=manifest_folder,
                             manifest_verify=manifest_verify,

--- a/conans/client/conan_api.py
+++ b/conans/client/conan_api.py
@@ -413,7 +413,8 @@ class ConanAPIV1(object):
             recorder = ActionRecorder()
             cwd = cwd or os.getcwd()
             install_folder = _make_abs_path(install_folder, cwd)
-            deploy_folder = _make_abs_path(deploy_folder, cwd)
+            if deploy_folder is not None:
+                deploy_folder = _make_abs_path(deploy_folder, cwd)
 
             manifests = _parse_manifests_arguments(verify, manifests, manifests_interactive, cwd)
             manifest_folder, manifest_interactive, manifest_verify = manifests

--- a/conans/client/conan_api.py
+++ b/conans/client/conan_api.py
@@ -426,7 +426,9 @@ class ConanAPIV1(object):
                 generators = False
 
             mkdir(install_folder)
-            mkdir(deploy_folder)
+            if deploy_folder is not None:
+                mkdir(deploy_folder)
+
             manager = self._init_manager(recorder)
             manager.install(reference=reference, install_folder=install_folder,
                             deploy_folder=deploy_folder,

--- a/conans/client/importer.py
+++ b/conans/client/importer.py
@@ -117,9 +117,7 @@ def run_deploy(conanfile, install_folder, deploy_folder, output):
         conanfile.copy_deps = file_importer
         conanfile.copy = file_copier
 
-        base_folder = install_folder
-        if deploy_folder:
-            base_folder = deploy_folder
+        base_folder = deploy_folder or install_folder
 
         with get_env_context_manager(conanfile):
             conanfile.install_folder = base_folder

--- a/conans/client/importer.py
+++ b/conans/client/importer.py
@@ -96,29 +96,42 @@ def remove_imports(conanfile, copied_files, output):
                 output.warn("Unable to remove imported file from build: %s" % f)
 
 
-def run_deploy(conanfile, install_folder, output):
+def default_deploy(conanfile, deploy_folder):
+    conanfile.copy(pattern="*", dst=deploy_folder)
+
+
+def run_deploy(conanfile, install_folder, deploy_folder, output):
     deploy_output = ScopedOutput("%s deploy()" % output.scope, output)
     file_importer = _FileImporter(conanfile, install_folder)
     package_copied = set()
 
-    # This is necessary to capture FileCopier full destination paths
-    # Maybe could be improved in FileCopier
-    def file_copier(*args, **kwargs):
-        file_copy = FileCopier(conanfile.package_folder, install_folder)
-        copied = file_copy(*args, **kwargs)
-        _make_files_writable(copied)
-        package_copied.update(copied)
+    if (hasattr(conanfile, "deploy") and callable(conanfile.deploy)) or deploy_folder:
+        # This is necessary to capture FileCopier full destination paths
+        # Maybe could be improved in FileCopier
+        def file_copier(*args, **kwargs):
+            file_copy = FileCopier(conanfile.package_folder, install_folder)
+            copied = file_copy(*args, **kwargs)
+            _make_files_writable(copied)
+            package_copied.update(copied)
 
-    conanfile.copy_deps = file_importer
-    conanfile.copy = file_copier
-    conanfile.install_folder = install_folder
-    with get_env_context_manager(conanfile):
-        with tools.chdir(install_folder):
-            conanfile.deploy()
+        conanfile.copy_deps = file_importer
+        conanfile.copy = file_copier
 
-    copied_files = file_importer.copied_files
-    copied_files.update(package_copied)
-    _report_save_manifest(copied_files, deploy_output, install_folder, "deploy_manifest.txt")
+        base_folder = install_folder
+        if deploy_folder:
+            base_folder = deploy_folder
+
+        with get_env_context_manager(conanfile):
+            conanfile.install_folder = base_folder
+            with tools.chdir(base_folder):
+                if not hasattr(conanfile, "deploy") or not callable(conanfile.deploy):
+                    conanfile.output.warn("Recipe has no deploy method, using default.")
+                    conanfile.deploy = default_deploy
+                conanfile.deploy(conanfile, deploy_folder)
+
+        copied_files = file_importer.copied_files
+        copied_files.update(package_copied)
+        _report_save_manifest(copied_files, deploy_output, base_folder, "deploy_manifest.txt")
 
 
 class _FileImporter(object):

--- a/conans/client/manager.py
+++ b/conans/client/manager.py
@@ -217,13 +217,14 @@ class ConanManager(object):
         build_mode.report_matches()
         workspace.generate()
 
-    def install(self, reference, install_folder, profile, remote_name=None, build_modes=None,
+    def install(self, reference, install_folder, deploy_folder, profile, remote_name=None, build_modes=None,
                 update=False, manifest_folder=None, manifest_verify=False,
                 manifest_interactive=False, generators=None, no_imports=False, inject_require=None,
                 install_reference=False, keep_build=False):
         """ Fetch and build all dependencies for the given reference
         @param reference: ConanFileReference or path to user space conanfile
         @param install_folder: where the output files will be saved
+        @param deploy_folder: user-specified place where package contents will be copied
         @param remote: install only from that remote
         @param profile: Profile object with both the -s introduced options and profile read values
         @param build_modes: List of build_modes specified
@@ -311,8 +312,8 @@ class ConanManager(object):
             if install_reference:
                 # The conanfile loaded is really a virtual one. The one with the deploy is the first level one
                 deploy_conanfile = deps_graph.inverse_levels()[1][0].conanfile
-                if hasattr(deploy_conanfile, "deploy") and callable(deploy_conanfile.deploy):
-                    run_deploy(deploy_conanfile, install_folder, output)
+                # if hasattr(deploy_conanfile, "deploy") and callable(deploy_conanfile.deploy):
+                run_deploy(deploy_conanfile, install_folder, deploy_folder, output)
 
     def source(self, conanfile_path, source_folder, info_folder):
         """

--- a/conans/client/manager.py
+++ b/conans/client/manager.py
@@ -312,7 +312,6 @@ class ConanManager(object):
             if install_reference:
                 # The conanfile loaded is really a virtual one. The one with the deploy is the first level one
                 deploy_conanfile = deps_graph.inverse_levels()[1][0].conanfile
-                # if hasattr(deploy_conanfile, "deploy") and callable(deploy_conanfile.deploy):
                 run_deploy(deploy_conanfile, install_folder, deploy_folder, output)
 
     def source(self, conanfile_path, source_folder, info_folder):


### PR DESCRIPTION
In response to:  https://github.com/conan-io/conan/issues/3280

I have not added tests, changelog, or documentation yet as this is a first/rough draft, however it works locally and is very simplistic so far.   

With this, users just pass a `--deploy-folder` parameter and the following default deploy method will be used: 
```
def default_deploy(conanfile, deploy_folder):
    conanfile.copy(pattern="*", dst=deploy_folder)
```

Also, I tried to override the "base" folder for recipes which have `deploy()` with these two statements, but I don't know if either the `install_folder` or `chdir` even applies inside the `deploy()` method: 

```
        base_folder = install_folder
        if deploy_folder:
            base_folder = deploy_folder
```
followed by this...
```
            conanfile.install_folder = base_folder
            with tools.chdir(base_folder):
```


Looking for feedback before going further. 

- [x] Refer to the issue that supports this Pull Request.
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://raw.githubusercontent.com/conan-io/conan/develop/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. Also adding a description of the changes in the ``changelog.rst`` file. https://github.com/conan-io/docs
