### PR TITLE
[workspaces] Add support for sub-projects that use find_package

### DIFF
--- a/conans/model/workspace.py
+++ b/conans/model/workspace.py
@@ -108,8 +108,16 @@ class Workspace(object):
 cmake_minimum_required(VERSION 3.3)
 project({name} CXX)
 
+macro(find_package)
+    set(CONAN_SUBPROJECTS {subprojects})
+    if(NOT "${{ARGV0}}" IN_LIST CONAN_SUBPROJECTS)
+        _find_package(${{ARGV}})
+    endif()
+endmacro()
+
 """
-            cmake = template.format(name=self._name)
+            subprojects = ' '.join(self._workspace_packages.keys())
+            cmake = template.format(name=self._name, subprojects=subprojects)
             for _, workspace_package in self._workspace_packages.items():
                 build_folder = workspace_package.build_folder
                 build_folder = build_folder.replace("\\", "/")

--- a/conans/model/workspace.py
+++ b/conans/model/workspace.py
@@ -115,6 +115,8 @@ macro(find_package)
     endif()
 endmacro()
 
+enable_testing()
+
 """
             subprojects = ' '.join(self._workspace_packages.keys())
             cmake = template.format(name=self._name, subprojects=subprojects)


### PR DESCRIPTION
When using conan workspaces, if a sub-project contains a `find_package` command that points to another sub-project, CMake will fail saying that it cannot find the package.

This is expected, because the package will be added as a sub-directory by the top-level CMakeLists.txt file generated by conan.

The presence of `find_package` commands is common in packages that use the conan `cmake_paths` generator, for example.

The recommended solution to this is to re-define `find_package` as a no-op for all sub-projects, which is what this PR implements. See #3302 for more details. Closes #3302

**Note**: System-level packages and other conan dependencies found through `find_package` are unaffected, because they are not in the list of conan workspace packages, hence `find_package` is not redefined for them.

Implements #3302.

- [x] Refer to the issue that supports this Pull Request.
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://raw.githubusercontent.com/conan-io/conan/develop/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. Also adding a description of the changes in the ``changelog.rst`` file. https://github.com/conan-io/docs
