### PR TITLE
[#3250] Better user feedback when using --outdated for searching and deleting

### DIFF
--- a/conans/client/command.py
+++ b/conans/client/command.py
@@ -721,7 +721,8 @@ class Command(object):
         parser.add_argument('-f', '--force', default=False, action='store_true',
                             help='Remove without requesting a confirmation')
         parser.add_argument("-o", "--outdated", default=False, action="store_true",
-                            help="Remove only outdated from recipe packages")
+                            help="Remove only outdated from recipe packages. " \
+                                 "This flag can only be used with a reference")
         parser.add_argument('-p', '--packages', nargs="*", action=Extender,
                             help="Select package to remove specifying the package ID")
         parser.add_argument('-q', '--query', default=None, action=OnceArgument, help=_QUERY_HELP)
@@ -740,6 +741,9 @@ class Command(object):
 
         if args.builds is not None and args.query:
             raise ConanException("'-q' and '-b' parameters can't be used at the same time")
+
+        if args.outdated and not args.pattern_or_reference:
+            raise ConanException("'--outdated' argument can only be used with a reference")
 
         if args.locks:
             if args.pattern_or_reference:
@@ -853,7 +857,8 @@ class Command(object):
         parser = argparse.ArgumentParser(description=self.search.__doc__, prog="conan search")
         parser.add_argument('pattern_or_reference', nargs='?', help=_PATTERN_OR_REFERENCE_HELP)
         parser.add_argument('-o', '--outdated', default=False, action='store_true',
-                            help='Show only outdated from recipe packages')
+                            help="Show only outdated from recipe packages. " \
+                                 "This flag can only be used with a reference")
         parser.add_argument('-q', '--query', default=None, action=OnceArgument, help=_QUERY_HELP)
         parser.add_argument('-r', '--remote', action=OnceArgument,
                             help="Remote to search in. '-r all' searches all remotes")
@@ -891,10 +896,12 @@ class Command(object):
                                                    outdated=args.outdated)
                 # search is done for one reference
                 self._outputer.print_search_packages(info["results"], reference, args.query,
-                                                     args.table)
+                                                     args.table, outdated=args.outdated)
             else:
                 if args.table:
                     raise ConanException("'--table' argument can only be used with a reference")
+                elif args.outdated:
+                    raise ConanException("'--outdated' argument can only be used with a reference")
 
                 self._check_query_parameter_and_get_reference(args.pattern_or_reference, args.query)
 

--- a/conans/client/conan_command_output.py
+++ b/conans/client/conan_command_output.py
@@ -99,13 +99,15 @@ class CommandOutputer(object):
         printer = Printer(self.user_io.out)
         printer.print_search_recipes(search_info, pattern, raw, all_remotes_search)
 
-    def print_search_packages(self, search_info, reference, packages_query, table):
+    def print_search_packages(self, search_info, reference, packages_query, table,
+                                outdated=False):
         if table:
             from conans.client.graph.grapher import html_binary_graph
             html_binary_graph(search_info, reference, table)
         else:
             printer = Printer(self.user_io.out)
-            printer.print_search_packages(search_info, reference, packages_query)
+            printer.print_search_packages(search_info, reference, packages_query,
+                                          outdated=outdated)
 
     def print_dir_list(self, list_files, path, raw):
         if not raw:

--- a/conans/client/printer.py
+++ b/conans/client/printer.py
@@ -173,7 +173,8 @@ class Printer(object):
                 for conan_item in remote_info["items"]:
                     self._out.writeln(conan_item["recipe"]["id"])
 
-    def print_search_packages(self, search_info, reference, packages_query):
+    def print_search_packages(self, search_info, reference, packages_query,
+                              outdated=False):
         assert(isinstance(reference, ConanFileReference))
         self._out.info("Existing packages for recipe %s:\n" % str(reference))
         for remote_info in search_info:
@@ -182,11 +183,11 @@ class Printer(object):
 
             if not remote_info["items"][0]["packages"]:
                 if packages_query:
-                    warn_msg = ("There are no packages for reference '%s' matching the query '%s'" %
-                                (str(reference), packages_query))
+                    warn_msg = "There are no %spackages for reference '%s' matching the query '%s'" % \
+                                ("outdated " if outdated else "", str(reference), packages_query)
                 elif remote_info["items"][0]["recipe"]:
-                    warn_msg = "There are no packages for reference '%s', but package recipe found." % \
-                            str(reference)
+                    warn_msg = "There are no %spackages for reference '%s', but package recipe found." % \
+                            ("outdated " if outdated else "", str(reference))
                 self._out.info(warn_msg)
                 continue
 


### PR DESCRIPTION
Few minor changes:

* The help message for --outdated has been updated to reflect the fact
  that it requires a reference.
* Using --outdated without a reference will raise a ConanException.
* The message that appears when a user searches with the --outdated
  option has been updated.

- [x] Refer to the issue that supports this Pull Request.
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://raw.githubusercontent.com/conan-io/conan/develop/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. Also adding a description of the changes in the ``changelog.rst`` file. https://github.com/conan-io/docs