### PR TITLE
fix qmake with hyphen

### DIFF
--- a/conans/client/generators/qmake.py
+++ b/conans/client/generators/qmake.py
@@ -59,7 +59,7 @@ class QmakeGenerator(Generator):
         template_deps = template + 'CONAN{dep_name}_ROOT{build_type} = "{deps.rootpath}"\n'
 
         for dep_name, dep_cpp_info in self.deps_build_info.dependencies:
-            dep_name = "_" + dep_name.upper().replace("-", "_")
+            dep_name = "_" + dep_name.upper().replace("-", "_").replace(".", "_")
             deps = DepsCppQmake(dep_cpp_info)
             dep_flags = template_deps.format(dep_name=dep_name, deps=deps,
                                              build_type="")

--- a/conans/client/generators/qmake.py
+++ b/conans/client/generators/qmake.py
@@ -59,14 +59,15 @@ class QmakeGenerator(Generator):
         template_deps = template + 'CONAN{dep_name}_ROOT{build_type} = "{deps.rootpath}"\n'
 
         for dep_name, dep_cpp_info in self.deps_build_info.dependencies:
+            dep_name = "_" + dep_name.upper().replace("-", "_")
             deps = DepsCppQmake(dep_cpp_info)
-            dep_flags = template_deps.format(dep_name="_" + dep_name.upper(), deps=deps,
+            dep_flags = template_deps.format(dep_name=dep_name, deps=deps,
                                              build_type="")
             sections.append(dep_flags)
 
             for config, cpp_info in dep_cpp_info.configs.items():
                 deps = DepsCppQmake(cpp_info)
-                dep_flags = template_deps.format(dep_name="_" + dep_name.upper(), deps=deps,
+                dep_flags = template_deps.format(dep_name=dep_name, deps=deps,
                                                  build_type="_" + str(config).upper())
                 sections.append(dep_flags)
 

--- a/conans/test/generators/generators_test.py
+++ b/conans/test/generators/generators_test.py
@@ -85,3 +85,40 @@ qmake
         self.assertIn("CONAN_LIBS_RELEASE += -lhellor", qmake)
         self.assertIn("CONAN_LIBS_DEBUG += -lhellod", qmake)
         self.assertIn("CONAN_LIBS += -lhello", qmake)
+
+    def test_qmake_hyphen(self):
+        client = TestClient()
+        dep = """
+from conans import ConanFile
+
+class TestConan(ConanFile):
+    name = "Pkg-Name"
+    version = "0.1"
+
+    def package_info(self):
+        self.cpp_info.libs = ["hello"]
+        self.cpp_info.debug.includedirs = []
+        self.cpp_info.debug.libs = ["hellod"]
+        self.cpp_info.release.libs = ["hellor"]
+
+"""
+        base = '''
+[requires]
+Pkg-Name/0.1@lasote/testing
+[generators]
+qmake
+    '''
+        client.save({"conanfile.py": dep})
+        client.run("export . lasote/testing")
+        client.save({"conanfile.txt": base}, clean_first=True)
+        client.run("install . --build")
+
+        qmake = load(os.path.join(client.current_folder, "conanbuildinfo.pri"))
+        self.assertIn("CONAN_RESDIRS += ", qmake)
+        self.assertEqual(qmake.count("CONAN_LIBS += "), 1)
+        self.assertIn("CONAN_LIBS_PKG_NAME_RELEASE += -lhellor", qmake)
+        self.assertIn("CONAN_LIBS_PKG_NAME_DEBUG += -lhellod", qmake)
+        self.assertIn("CONAN_LIBS_PKG_NAME += -lhello", qmake)
+        self.assertIn("CONAN_LIBS_RELEASE += -lhellor", qmake)
+        self.assertIn("CONAN_LIBS_DEBUG += -lhellod", qmake)
+        self.assertIn("CONAN_LIBS += -lhello", qmake)

--- a/conans/test/generators/generators_test.py
+++ b/conans/test/generators/generators_test.py
@@ -86,13 +86,13 @@ qmake
         self.assertIn("CONAN_LIBS_DEBUG += -lhellod", qmake)
         self.assertIn("CONAN_LIBS += -lhello", qmake)
 
-    def test_qmake_hyphen(self):
+    def test_qmake_hyphen_dot(self):
         client = TestClient()
         dep = """
 from conans import ConanFile
 
 class TestConan(ConanFile):
-    name = "Pkg-Name"
+    name = "Pkg-Name.World"
     version = "0.1"
 
     def package_info(self):
@@ -104,7 +104,7 @@ class TestConan(ConanFile):
 """
         base = '''
 [requires]
-Pkg-Name/0.1@lasote/testing
+Pkg-Name.World/0.1@lasote/testing
 [generators]
 qmake
     '''
@@ -116,9 +116,9 @@ qmake
         qmake = load(os.path.join(client.current_folder, "conanbuildinfo.pri"))
         self.assertIn("CONAN_RESDIRS += ", qmake)
         self.assertEqual(qmake.count("CONAN_LIBS += "), 1)
-        self.assertIn("CONAN_LIBS_PKG_NAME_RELEASE += -lhellor", qmake)
-        self.assertIn("CONAN_LIBS_PKG_NAME_DEBUG += -lhellod", qmake)
-        self.assertIn("CONAN_LIBS_PKG_NAME += -lhello", qmake)
+        self.assertIn("CONAN_LIBS_PKG_NAME_WORLD_RELEASE += -lhellor", qmake)
+        self.assertIn("CONAN_LIBS_PKG_NAME_WORLD_DEBUG += -lhellod", qmake)
+        self.assertIn("CONAN_LIBS_PKG_NAME_WORLD += -lhello", qmake)
         self.assertIn("CONAN_LIBS_RELEASE += -lhellor", qmake)
         self.assertIn("CONAN_LIBS_DEBUG += -lhellod", qmake)
         self.assertIn("CONAN_LIBS += -lhello", qmake)


### PR DESCRIPTION
- [x] Refer to the issue that supports this Pull Request.
Fix #3351

Actually, the same issue could happen with ``cmake`` and other generators. Should I fix them all? Wait until it is reported?

Update: CMake generator is not affected by dots/hyphens in package names.