### PR TITLE
Apply general scope options to consumer Conanfile first

### DIFF
--- a/conans/client/loader.py
+++ b/conans/client/loader.py
@@ -55,19 +55,10 @@ class ConanFileLoader(object):
 
             print("User options 1:", self._user_options)
             if consumer:
-                # Apply "*" scoped options to result.name scope
-                try:
-                    self._user_options[result.name] = self._user_options["*"]
-                except:
-                    pass
+                self._user_options.descope_options("*")
                 self._user_options.descope_options(result.name)
-                print("User options 2:", self._user_options)
-                print("Result options 1:", result.options.values)
                 result.options.initialize_upstream(self._user_options, local=local)
-                print("Result options 2:", result.options.values)
-                print("User options 3:", self._user_options)
                 self._user_options.clear_unscoped_options()
-                print("User options 4:", self._user_options)
             else:
                 result.in_local_cache = True
 

--- a/conans/client/loader.py
+++ b/conans/client/loader.py
@@ -53,10 +53,21 @@ class ConanFileLoader(object):
             # Assign environment
             result._env_values.update(self._env_values)
 
+            print("User options 1:", self._user_options)
             if consumer:
+                # Apply "*" scoped options to result.name scope
+                try:
+                    self._user_options[result.name] = self._user_options["*"]
+                except:
+                    pass
                 self._user_options.descope_options(result.name)
+                print("User options 2:", self._user_options)
+                print("Result options 1:", result.options.values)
                 result.options.initialize_upstream(self._user_options, local=local)
+                print("Result options 2:", result.options.values)
+                print("User options 3:", self._user_options)
                 self._user_options.clear_unscoped_options()
+                print("User options 4:", self._user_options)
             else:
                 result.in_local_cache = True
 

--- a/conans/client/loader.py
+++ b/conans/client/loader.py
@@ -53,9 +53,8 @@ class ConanFileLoader(object):
             # Assign environment
             result._env_values.update(self._env_values)
 
-            print("User options 1:", self._user_options)
             if consumer:
-                self._user_options.descope_options("*")
+                self._user_options[result.name].update(self._user_options["*"])
                 self._user_options.descope_options(result.name)
                 result.options.initialize_upstream(self._user_options, local=local)
                 self._user_options.clear_unscoped_options()

--- a/conans/model/options.py
+++ b/conans/model/options.py
@@ -486,9 +486,8 @@ class PackageOptions(object):
 
 
 class Options(object):
-    """ all options of a package, both its own options and the upstream
-    ones.
-    Owned by conanfile
+    """ All options of a package, both its own options and the upstream ones.
+    Owned by ConanFile.
     """
     def __init__(self, options):
         assert isinstance(options, PackageOptions)
@@ -584,14 +583,9 @@ class Options(object):
                 self._package_options.set_local(user_values._package_values)
             else:
                 self._package_options.values = user_values._package_values
-            print("initialize_upstream():", user_values._reqs_options.items())
             for package_name, package_values in user_values._reqs_options.items():
-                print("package name:", package_name)
-                print("package_values:", package_values.fields)
                 pkg_values = self._deps_package_values.setdefault(package_name, PackageOptionValues())
                 pkg_values.update(package_values)
-                print("pkg_values:", pkg_values.fields)
-            print("Package options", self._package_options.items())
 
     def validate(self):
         return self._package_options.validate()

--- a/conans/model/options.py
+++ b/conans/model/options.py
@@ -191,11 +191,14 @@ class OptionsValues(object):
             self._package_values = PackageOptionValues()
 
     def descope_options(self, name):
+        print("descope_options(): INIT", self._package_values.fields)
         package_values = self._reqs_options.pop(name, None)
         if package_values:
             self._package_values.update(package_values)
+        print("descope_options(): FINISH", self._package_values.fields)
 
     def clear_unscoped_options(self):
+        print("clear_unscoped_options()", self._package_values.fields)
         self._package_values.clear()
 
     def __getitem__(self, item):
@@ -581,9 +584,14 @@ class Options(object):
                 self._package_options.set_local(user_values._package_values)
             else:
                 self._package_options.values = user_values._package_values
+            print("initialize_upstream():", user_values._reqs_options.items())
             for package_name, package_values in user_values._reqs_options.items():
+                print("package name:", package_name)
+                print("package_values:", package_values.fields)
                 pkg_values = self._deps_package_values.setdefault(package_name, PackageOptionValues())
                 pkg_values.update(package_values)
+                print("pkg_values:", pkg_values.fields)
+            print("Package options", self._package_options.items())
 
     def validate(self):
         return self._package_options.validate()

--- a/conans/model/options.py
+++ b/conans/model/options.py
@@ -191,14 +191,11 @@ class OptionsValues(object):
             self._package_values = PackageOptionValues()
 
     def descope_options(self, name):
-        print("descope_options(): INIT", self._package_values.fields)
         package_values = self._reqs_options.pop(name, None)
         if package_values:
             self._package_values.update(package_values)
-        print("descope_options(): FINISH", self._package_values.fields)
 
     def clear_unscoped_options(self):
-        print("clear_unscoped_options()", self._package_values.fields)
         self._package_values.clear()
 
     def __getitem__(self, item):

--- a/conans/test/integration/options_test.py
+++ b/conans/test/integration/options_test.py
@@ -66,6 +66,7 @@ zlib/0.1@lasote/testing
         self.assertNotIn("zlib:shared=True", conaninfo)
 
     def general_scope_options_test(self):
+        # https://github.com/conan-io/conan/issues/2538
         client = TestClient()
         conanfile_libA = """
 from conans import ConanFile
@@ -95,15 +96,27 @@ class LibB(ConanFile):
     """
         client.save({"conanfile_liba.py": conanfile_libA,
                      "conanfile_libb.py": conanfile_libB})
-        client.run("export conanfile_liba.py danimtb/testing")
-        client.run("info conanfile_libb.py -o *:shared=True --graph graph.html")
-        self.assertNotIn("PROJECT: shared=False", client.out)
-        self.assertIn("PROJECT: shared=True", client.out)
-        self.assertIn("libA/0.1@danimtb/testing: shared=True", client.out)
-        client.save({
-            "conanfile_libb.py":
-                conanfile_libB.replace("        self.options[\"*\"].shared = self.options.shared", "")})
-        client.run("info conanfile_libb.py -o *:shared=True --graph graph.html")
-        self.assertNotIn("PROJECT: shared=False", client.out)
-        self.assertIn("PROJECT: shared=True", client.out)
-        self.assertIn("libA/0.1@danimtb/testing: shared=True", client.out)
+
+        for without_configure_line in [True, False]:
+            client.save({"conanfile_liba.py": conanfile_libA})
+
+            if without_configure_line:
+                client.save({"conanfile_libb.py": conanfile_libB.replace(
+                    "        self.options[\"*\"].shared = self.options.shared", "")})
+            else:
+                client.save({"conanfile_libb.py": conanfile_libB})
+
+            # Test info
+            client.run("export conanfile_liba.py danimtb/testing")
+            client.run("info conanfile_libb.py -o *:shared=True")
+            self.assertIn("PROJECT: shared=True", client.out)
+            self.assertIn("libA/0.1@danimtb/testing: shared=True", client.out)
+            # Test create
+            client.run("create conanfile_liba.py danimtb/testing -o *:shared=True")
+            client.run("create conanfile_libb.py danimtb/testing -o *:shared=True")
+            self.assertIn("libB/0.1@danimtb/testing: shared=True", client.out)
+            self.assertIn("libA/0.1@danimtb/testing: shared=True", client.out)
+            # Test install
+            client.run("install conanfile_libb.py -o *:shared=True")
+            self.assertIn("PROJECT: shared=True", client.out)
+            self.assertIn("libA/0.1@danimtb/testing: shared=True", client.out)

--- a/conans/test/integration/options_test.py
+++ b/conans/test/integration/options_test.py
@@ -65,7 +65,7 @@ zlib/0.1@lasote/testing
         conaninfo = load(os.path.join(client.current_folder, CONANINFO))
         self.assertNotIn("zlib:shared=True", conaninfo)
 
-    def asterisc_operator_configure_test(self):
+    def general_scope_options_test(self):
         client = TestClient()
         conanfile_libA = """
 from conans import ConanFile
@@ -99,3 +99,11 @@ class LibB(ConanFile):
         client.run("info conanfile_libb.py -o *:shared=True --graph graph.html")
         self.assertNotIn("PROJECT: shared=False", client.out)
         self.assertIn("PROJECT: shared=True", client.out)
+        self.assertIn("libA/0.1@danimtb/testing: shared=True", client.out)
+        client.save({
+            "conanfile_libb.py":
+                conanfile_libB.replace("        self.options[\"*\"].shared = self.options.shared", "")})
+        client.run("info conanfile_libb.py -o *:shared=True --graph graph.html")
+        self.assertNotIn("PROJECT: shared=False", client.out)
+        self.assertIn("PROJECT: shared=True", client.out)
+        self.assertIn("libA/0.1@danimtb/testing: shared=True", client.out)


### PR DESCRIPTION
- [x] Refer to the issue that supports this Pull Request: closes #2538 
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.

The real issue was this line in `configure()`:
```
self.options["*"].shared = self.options.shared
```
And user input with something like ``conan install -o *:shared=True``.

Basically, options with ``*`` operator are reserved for the graph builder to be applied to requirements when graph is complete. The option with ``*`` is not applied initially to the consumer conanfile and when it hits the line above in configure, changes the general scope option to its default value (``shared=False``).

- [x] I've read the [Contributing guide](https://raw.githubusercontent.com/conan-io/conan/develop/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [x] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. Also adding a description of the changes in the ``changelog.rst`` file. https://github.com/conan-io/docs
