### PR TITLE
fix detection of zypper package tool on latest versions of opensuse

### DIFF
--- a/conans/client/tools/oss.py
+++ b/conans/client/tools/oss.py
@@ -122,9 +122,12 @@ class OSInfo(object):
 
     @property
     def with_zypper(self):
-        return self.is_linux and self.linux_distro in \
-            ("opensuse", "sles")
-
+        if not self.is_linux:
+            return False
+        if "opensuse" in self.linux_distro or "sles" in self.linux_distro:
+            return True
+        return False
+    
     @staticmethod
     def get_win_os_version():
         """


### PR DESCRIPTION
- [X] Refer to the issue that supports this Pull Request. Closes #3371
- [X] I've read the [Contributing guide](https://raw.githubusercontent.com/conan-io/conan/develop/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.

The newest versions of opensuse now report their distro.id() as "opensuse-leap", which breaks conan's detection of zypper. This patch fixes it for opensuse leap, opensuse tumbleweed and SLES