### PR TITLE
vcvars better diff and var list management

### DIFF
--- a/conans/client/tools/win.py
+++ b/conans/client/tools/win.py
@@ -321,16 +321,21 @@ def vcvars_dict(settings, arch=None, compiler_version=None, force=False, filter_
             continue
         try:
             name_var, value = line.split("=", 1)
-            # Return only new vars & changed ones, but only with the changed elements if the var is a list
+            new_value = value.split(os.pathsep) if name_var in known_path_lists else value
+            # Return only new vars & changed ones, but only with the changed elements if the var is
+            # a list
             if only_diff:
                 old_value = os.environ.get(name_var)
-                if old_value and value.endswith(os.pathsep + old_value):  # List of paths, do the diff
+                # The new value ends with separator and the old value, is a list, get only the
+                # new elements
+                if old_value and value.endswith(os.pathsep + old_value):
                     new_env[name_var] = value[:-(len(old_value) + 1)].split(os.pathsep)
                 elif value != old_value:
-                    # Only if the vcvars changed something, we return the variable, otherwise is not vcvars related
-                    new_env[name_var] = value.split(os.pathsep) if name_var in known_path_lists else value
+                    # Only if the vcvars changed something, we return the variable,
+                    # otherwise is not vcvars related
+                    new_env[name_var] = new_value
             else:
-                new_env[name_var] = value.split(os.pathsep) if name_var in known_path_lists else value
+                new_env[name_var] = new_value
 
         except ValueError:
             pass

--- a/conans/test/util/tools_test.py
+++ b/conans/test/util/tools_test.py
@@ -759,6 +759,20 @@ compiler:
             self.assertNotIn("MYVAR", ret)
             self.assertIn("VCINSTALLDIR", ret)
 
+        my_lib_paths = "C:\\PATH\TO\MYLIBS;C:\\OTHER_LIBPATH"
+        with tools.environment_append({"LIBPATH": "C:\\PATH\TO\MYLIBS;C:\\OTHER_LIBPATH"}):
+            ret = vcvars_dict(settings, only_diff=False)
+            str_var_value = os.pathsep.join(ret["LIBPATH"])
+            self.assertTrue(str_var_value.endswith(my_lib_paths))
+
+            # Now only a diff, it should return the values as a list, but without the old values
+            ret = vcvars_dict(settings, only_diff=True)
+            self.assertEquals(ret["LIBPATH"], str_var_value.split(os.pathsep)[0:-2])
+
+            # But if we apply both environments, they are composed correctly
+            with tools.environment_append(ret):
+                self.assertEquals(os.environ["LIBPATH"], str_var_value)
+
     def vcvars_dict_test(self):
         # https://github.com/conan-io/conan/issues/2904
         output_with_newline_and_spaces = """__BEGINS__

--- a/conans/test/util/tools_test.py
+++ b/conans/test/util/tools_test.py
@@ -760,7 +760,7 @@ compiler:
             self.assertIn("VCINSTALLDIR", ret)
 
         my_lib_paths = "C:\\PATH\TO\MYLIBS;C:\\OTHER_LIBPATH"
-        with tools.environment_append({"LIBPATH": "C:\\PATH\TO\MYLIBS;C:\\OTHER_LIBPATH"}):
+        with tools.environment_append({"LIBPATH": my_lib_paths}):
             ret = vcvars_dict(settings, only_diff=False)
             str_var_value = os.pathsep.join(ret["LIBPATH"])
             self.assertTrue(str_var_value.endswith(my_lib_paths))


### PR DESCRIPTION
- [x] Refer to the issue that supports this Pull Request. Closes #3159 

In addition to #3159, `vcvars_dict` also returns as a list for the vars `("INCLUDE", "LIB", "LIBPATH", "PATH")`. 

This way, it plays nicely with the `environment_append`. As now, by default, only the new elements in these lists are returned, the old values are naturally appended to the environment in the `environment_append` so no breaking behavior has introduced. 

NOTE: Only if someone was supposing that `ret["LIB"]` is a string would be affected, but I think it is not common to call directly to `vcvars_dict` and accesing directly to the return.

- [x] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. Also adding a description of the changes in the ``changelog.rst`` file. https://github.com/conan-io/docs

