### PR TITLE
add dev package extension to system package manager

### DIFF
--- a/conans/client/tools/system_pm.py
+++ b/conans/client/tools/system_pm.py
@@ -113,6 +113,13 @@ class SystemPackageTool(object):
                 pass
         raise ConanException("Could not install any of %s" % packages)
 
+    @property
+    def dev_package_extension(self):
+        if hasattr(self._tool, "dev_package_extension"):
+            return self._tool.dev_package_extension()
+        else:
+            return ""
+
 
 class NullTool(object):
     def update(self):
@@ -138,6 +145,9 @@ class AptTool(object):
         exit_code = self._runner("dpkg -s %s" % package_name, None)
         return exit_code == 0
 
+    def dev_package_extension(self):
+        return "-dev"
+
 
 class YumTool(object):
     def update(self):
@@ -149,6 +159,9 @@ class YumTool(object):
     def installed(self, package_name):
         exit_code = self._runner("rpm -q %s" % package_name, None)
         return exit_code == 0
+
+    def dev_package_extension(self):
+        return "-devel"
 
 
 class BrewTool(object):
@@ -174,6 +187,9 @@ class PkgTool(object):
         exit_code = self._runner("pkg info %s" % package_name, None)
         return exit_code == 0
 
+    def dev_package_extension(self):
+        return "-devel"
+
 
 class PkgUtilTool(object):
     def update(self):
@@ -185,6 +201,9 @@ class PkgUtilTool(object):
     def installed(self, package_name):
         exit_code = self._runner('test -n "`pkgutil --list %s`"' % package_name, None)
         return exit_code == 0
+
+    def dev_package_extension(self):
+        return "-dev"
 
 
 class ChocolateyTool(object):
@@ -199,6 +218,9 @@ class ChocolateyTool(object):
                                  'findstr /c:"1 packages installed."' % package_name, None)
         return exit_code == 0
 
+    def dev_package_extension(self):
+        return ""
+
 
 class PacManTool(object):
     def update(self):
@@ -211,6 +233,9 @@ class PacManTool(object):
         exit_code = self._runner("pacman -Qi %s" % package_name, None)
         return exit_code == 0
 
+    def dev_package_extension(self):
+        return ""
+
 
 class ZypperTool(object):
     def update(self):
@@ -222,6 +247,9 @@ class ZypperTool(object):
     def installed(self, package_name):
         exit_code = self._runner("rpm -q %s" % package_name, None)
         return exit_code == 0
+
+    def dev_package_extension(self):
+        return "-devel"
 
 
 def _run(runner, command, accepted_returns=None):


### PR DESCRIPTION
- [ ] Refer to the issue that supports this Pull Request.
- [ ] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://raw.githubusercontent.com/conan-io/conan/develop/.github/CONTRIBUTING.md).
- [ ] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. Also adding a description of the changes in the ``changelog.rst`` file. https://github.com/conan-io/docs

This adds a function to the system package manager tools which returns the suffix needed for development headers in a platform specific way. This means that, for example, if a recipe needs the "python-dev" package on ubuntu, one could write:

``
spt = tools.SystemPackageTool();  spt.install("python%s" % spt.dev_package_extension)
``
which will indeed install "python-dev" on debian/ubuntu, but on RHEL/fedora/suse will install "python-devel". This makes multi linux distro recipes with system package management requirements easier to write.

If this general approach is acceptable I will write the accompanying documentation. This approach might also be suitable for e.g. 32 bit library package name extension when building a 32 bit lib on 64 bit systems. The implementation returns an empty string on those platforms where it doesn't make sense, rather than throwing an error.

