### PR TITLE
feat(workspaces): generate conan-workspace.cmake

### DIFF
--- a/conans/model/workspace.py
+++ b/conans/model/workspace.py
@@ -106,7 +106,6 @@ class Workspace(object):
         if self._generator == "cmake":
             template = """# conanws
 cmake_minimum_required(VERSION 3.3)
-project({name} CXX)
 
 """
             cmake = template.format(name=self._name)
@@ -114,9 +113,7 @@ project({name} CXX)
                 build_folder = workspace_package.build_folder
                 build_folder = build_folder.replace("\\", "/")
                 cmake += 'add_subdirectory(%s "%s")\n' % (workspace_package.local_cmakedir, build_folder)
-            cmake_path = os.path.join(self._base_folder, "CMakeLists.txt")
-            if os.path.exists(cmake_path) and not load(cmake_path).startswith("# conanws"):
-                raise ConanException("Can't generate CMakeLists.txt, will overwrite existing one")
+            cmake_path = os.path.join(self._install_folder, "conanws.cmake")
             save(cmake_path, cmake)
 
     def __init__(self, path, install_folder):

--- a/conans/test/integration/workspace_test.py
+++ b/conans/test/integration/workspace_test.py
@@ -94,6 +94,12 @@ add_library(hello{name} hello.cpp)
 target_link_libraries(hello{name} {dep})
 """
 
+root_cmake = """set(CMAKE_CXX_COMPILER_WORKS 1)
+project(Hello CXX)
+cmake_minimum_required(VERSION 2.8.12)
+include(${CMAKE_CURRENT_BINARY_DIR}/conanws.cmake)
+"""
+
 
 class WorkspaceTest(unittest.TestCase):
 
@@ -134,6 +140,7 @@ HelloA:
 root: HelloA
 """
         client.save({WORKSPACE_FILE: project})
+        client.save({"CMakeLists.txt": root_cmake})
         client.run("install . -if=build")
         self.assertIn("Workspace HelloC: Applying build-requirement: Tool/0.1@user/testing",
                       client.out)
@@ -185,6 +192,7 @@ generator: cmake
 name: MyProject
 """
         client.save({WORKSPACE_FILE: project})
+        client.save({"CMakeLists.txt": root_cmake})
         client.run("install . -if=build")
         generator = "Visual Studio 15 Win64" if platform.system() == "Windows" else "Unix Makefiles"
         base_folder = os.path.join(client.current_folder, "build")
@@ -278,6 +286,7 @@ HelloA:
 root: HelloA
 """
         client.save({WORKSPACE_FILE: project})
+        client.save({"CMakeLists.txt": root_cmake})
 
         release = "build" if platform.system() == "Windows" else "build_release"
         debug = "build" if platform.system() == "Windows" else "build_debug"


### PR DESCRIPTION
Generating the top-level CMakeLists.txt causes lots of issues,
one cannot:

* run tests (enable_testing() is missing)
* set variables (e.g. CMAKE_MODULE_PATH)

The top-level CMakeLists.txt was overwritten on every conan install
invocation.

So we try to mimick what is done in the ycm generator, i.e. generate a
.cmake file in the install_folder, that the top-level CMakeLists.txt
must include.

- [ ] Refer to the issue that supports this Pull Request.
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://raw.githubusercontent.com/conan-io/conan/develop/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [x] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. Also adding a description of the changes in the ``changelog.rst`` file. https://github.com/conan-io/docs
