### PR TITLE
Do not modify generators files if nothing has changed (close #2895)

### DIFF
--- a/conans/client/generators/__init__.py
+++ b/conans/client/generators/__init__.py
@@ -98,11 +98,11 @@ def write_generators(conanfile, path, output):
                 for k, v in content.items():
                     v = normalize(v)
                     output.info("Generator %s created %s" % (generator_name, k))
-                    save(join(path, k), v)
+                    save(join(path, k), v, only_if_modified=True)
             else:
                 content = normalize(content)
                 output.info("Generator %s created %s" % (generator_name, generator.filename))
-                save(join(path, generator.filename), content)
+                save(join(path, generator.filename), content, only_if_modified=True)
         except Exception as e:
             if get_env("CONAN_VERBOSE_TRACEBACK", False):
                 output.error(traceback.format_exc())

--- a/conans/test/util/files_test.py
+++ b/conans/test/util/files_test.py
@@ -1,0 +1,33 @@
+import unittest
+import os
+
+from conans.test.utils.test_files import temp_folder
+from conans.util.files import save
+
+
+class SaveTestCase(unittest.TestCase):
+
+    def setUp(self):
+        folder = temp_folder()
+        self.filepath = os.path.join(folder, "file.txt")
+
+        # Save some content and keep timestamp
+        self.content = "my content"
+        save(self.filepath, self.content)
+        self.timestamp = os.path.getmtime(self.filepath)
+
+    def only_if_modified_true_test(self):
+        save(self.filepath, self.content, only_if_modified=True)
+        self.assertEqual(self.timestamp, os.path.getmtime(self.filepath))
+
+    def only_if_modified_false_test(self):
+        save(self.filepath, self.content, only_if_modified=False)
+        self.assertNotEqual(self.timestamp, os.path.getmtime(self.filepath))
+
+    def modified_only_true_test(self):
+        save(self.filepath, "other content", only_if_modified=True)
+        self.assertNotEqual(self.timestamp, os.path.getmtime(self.filepath))
+
+    def modified_only_false_test(self):
+        save(self.filepath, "other content", only_if_modified=False)
+        self.assertNotEqual(self.timestamp, os.path.getmtime(self.filepath))

--- a/conans/test/util/files_test.py
+++ b/conans/test/util/files_test.py
@@ -3,6 +3,7 @@ import os
 
 from conans.test.utils.test_files import temp_folder
 from conans.util.files import save
+from time import sleep
 
 
 class SaveTestCase(unittest.TestCase):
@@ -15,6 +16,7 @@ class SaveTestCase(unittest.TestCase):
         self.content = "my content"
         save(self.filepath, self.content)
         self.timestamp = os.path.getmtime(self.filepath)
+        sleep(1)  # precission is seconds, so we need to sleep
 
     def only_if_modified_true_test(self):
         save(self.filepath, self.content, only_if_modified=True)

--- a/conans/util/files.py
+++ b/conans/util/files.py
@@ -112,20 +112,28 @@ def save_append(path, content):
         handle.write(to_file_bytes(content))
 
 
-def save(path, content):
+def save(path, content, only_if_modified=False):
     """
     Saves a file with given content
     Params:
         path: path to write file to
-        load: contents to save in the file
+        content: contents to save in the file
+        only_if_modified: file won't be modified if the content hasn't changed
     """
     try:
         os.makedirs(os.path.dirname(path))
     except:
         pass
 
+    new_content = to_file_bytes(content)
+
+    if only_if_modified:
+        old_content = load(path, binary=True)
+        if old_content == new_content:
+            return
+
     with open(path, "wb") as handle:
-        handle.write(to_file_bytes(content))
+        handle.write(new_content)
 
 
 def mkdir_tmp():

--- a/conans/util/files.py
+++ b/conans/util/files.py
@@ -166,9 +166,9 @@ def to_file_bytes(content):
     return content
 
 
-def save_files(path, files):
+def save_files(path, files, only_if_modified):
     for name, content in list(files.items()):
-        save(os.path.join(path, name), content)
+        save(os.path.join(path, name), content, only_if_modified=only_if_modified)
 
 
 def load(path, binary=False):

--- a/conans/util/files.py
+++ b/conans/util/files.py
@@ -166,7 +166,7 @@ def to_file_bytes(content):
     return content
 
 
-def save_files(path, files, only_if_modified):
+def save_files(path, files, only_if_modified=False):
     for name, content in list(files.items()):
         save(os.path.join(path, name), content, only_if_modified=only_if_modified)
 

--- a/conans/util/files.py
+++ b/conans/util/files.py
@@ -127,7 +127,7 @@ def save(path, content, only_if_modified=False):
 
     new_content = to_file_bytes(content)
 
-    if only_if_modified:
+    if only_if_modified and os.path.exists(path):
         old_content = load(path, binary=True)
         if old_content == new_content:
             return


### PR DESCRIPTION
- [x] Refer to the issue that supports this Pull Request: #2895
- [x] I've read the [Contributing guide](https://raw.githubusercontent.com/conan-io/conan/develop/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [ ] Add test


Add parameter `only_if_modified` to the utility function `save` to skip actual writing to disk if nothing has changed. 

Implement this functionality in generators generated files.