### PR TITLE
Fix --build-order option name in `conan info` help

### DIFF
--- a/conans/client/command.py
+++ b/conans/client/command.py
@@ -410,7 +410,7 @@ class Command(object):
                             "specify both install-folder and any setting/option "
                             "it will raise an error.")
         parser.add_argument("-j", "--json", nargs='?', const="1", type=str,
-                            help='Only with --build_order option, return the information in a json.'
+                            help='Only with --build-order option, return the information in a json.'
                                  ' e.g --json=/path/to/filename.json or --json to output the json')
         parser.add_argument("-n", "--only", nargs=1, action=Extender,
                             help="Show only the specified fields: %s. '--paths' information can "


### PR DESCRIPTION
Fixes conan part of #3414 .

- [X] Refer to the issue that supports this Pull Request.
- [X] I've read the [Contributing guide](https://raw.githubusercontent.com/conan-io/conan/develop/.github/CONTRIBUTING.md).
- [X] I've followed the PEP8 style guides for Python code.
- [X] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 