### PR TITLE
Add --force option to conan remote remove

### DIFF
--- a/conans/client/command.py
+++ b/conans/client/command.py
@@ -1009,6 +1009,8 @@ class Command(object):
                                 help="Force addition, will update if existing")
         parser_rm = subparsers.add_parser('remove', help='Remove a remote')
         parser_rm.add_argument('remote', help='Name of the remote')
+        parser_rm.add_argument("-f", "--force", default=False, action='store_true',
+                               help="Ignore nonexistent remotes")
         parser_upd = subparsers.add_parser('update', help='Update the remote url')
         parser_upd.add_argument('remote', help='Name of the remote')
 
@@ -1050,7 +1052,7 @@ class Command(object):
         elif args.subcommand == "add":
             return self._conan.remote_add(remote_name, url, verify_ssl, args.insert, args.force)
         elif args.subcommand == "remove":
-            return self._conan.remote_remove(remote_name)
+            return self._conan.remote_remove(remote_name, args.force)
         elif args.subcommand == "rename":
             return self._conan.remote_rename(remote_name, new_remote)
         elif args.subcommand == "update":

--- a/conans/client/conan_api.py
+++ b/conans/client/conan_api.py
@@ -752,8 +752,8 @@ class ConanAPIV1(object):
         return self._registry.add(remote_name, url, verify_ssl, insert, force)
 
     @api_method
-    def remote_remove(self, remote_name):
-        return self._registry.remove(remote_name)
+    def remote_remove(self, remote_name, force=None):
+        return self._registry.remove(remote_name, force)
 
     @api_method
     def remote_update(self, remote_name, url, verify_ssl=True, insert=None):

--- a/conans/client/remote_registry.py
+++ b/conans/client/remote_registry.py
@@ -194,13 +194,14 @@ class RemoteRegistry(object):
                                      % remote_name)
         self._add_update(remote_name, url, verify_ssl, exists_function, insert)
 
-    def remove(self, remote_name):
+    def remove(self, remote_name, force=False):
         self._remotes = None  # invalidate cached remotes
         with fasteners.InterProcessLock(self._filename + ".lock", logger=logger):
             remotes, refs = self._load()
-            if remote_name not in remotes:
+
+            if not remotes.pop(remote_name, force):
                 raise ConanException("Remote '%s' not found in remotes" % remote_name)
-            del remotes[remote_name]
+
             refs = {k: v for k, v in refs.items() if v != remote_name}
             self._save(remotes, refs)
 

--- a/conans/test/command/remote_test.py
+++ b/conans/test/command/remote_test.py
@@ -81,6 +81,17 @@ class RemoteTest(unittest.TestCase):
         self.assertNotIn("Hello2/0.1@user/testing", registry)
         self.assertNotIn("Hello/0.1@user/testing", registry)
 
+    def remove_remote_force_test(self):
+        self.client.run("remote remove --force remote0")
+        self.client.run("remote list")
+        self.assertNotIn("remote0", self.client.out)
+
+    def remove_remote_with_force_the_second_time_test(self):
+        self.client.run("remote remove remote0")
+        self.client.run("remote remove --force remote0")
+        self.client.run("remote list")
+        self.assertNotIn("remote0", self.client.out)
+
     def add_force_test(self):
         client = TestClient()
         client.run("remote add r1 https://r1")


### PR DESCRIPTION
This PR adds `--force` option to `conan remote remove`.  If this option is set no error will be raised if the specified remote doesn't exist.

This is useful to write idempotent scripts.

For our use specific use case, we want to ensure that we pull from only our own private remotes. The `--force` option alleviates pain points when removing the pre-existing remotes, e.g. conan-center.

The corresponding documentation PR can be found here: https://github.com/conan-io/docs/pull/791

This PR was co-authored with @kmdouglass and @marco-m

- [X] Refer to the issue that supports this Pull Request.
- [X] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [X] I've read the [Contributing guide](https://raw.githubusercontent.com/conan-io/conan/develop/.github/CONTRIBUTING.md).
- [X] I've followed the PEP8 style guides for Python code.
- [X] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. Also adding a description of the changes in the ``changelog.rst`` file. https://github.com/conan-io/docs
