### PR TITLE
export-pkg shouldn't touch server

### DIFF
--- a/conans/client/graph/graph_manager.py
+++ b/conans/client/graph/graph_manager.py
@@ -73,6 +73,21 @@ class GraphManager(object):
 
         return conanfile
 
+    def load_simple_graph(self, reference, profile, recorder):
+        # Loads a graph without computing the binaries. It is necessary for
+        # export-pkg command, not hitting the server
+        # # https://github.com/conan-io/conan/issues/3432
+        builder = DepsGraphBuilder(self._proxy, self._output, self._loader, self._resolver,
+                                   workspace=None, recorder=recorder)
+        cache_settings = self._client_cache.settings.copy()
+        cache_settings.values = profile.settings_values
+        settings_preprocessor.preprocess(cache_settings)
+        processed_profile = ProcessedProfile(cache_settings, profile, create_reference=None)
+        conanfile = self._loader.load_virtual([reference], processed_profile)
+        graph = builder.load_graph(conanfile, check_updates=False, update=False, remote_name=None,
+                                   processed_profile=processed_profile)
+        return graph
+
     def load_graph(self, reference, create_reference, profile, build_mode, check_updates, update, remote_name,
                    recorder, workspace):
 

--- a/conans/client/manager.py
+++ b/conans/client/manager.py
@@ -43,9 +43,7 @@ class ConanManager(object):
         if not os.path.exists(conan_file_path):
             raise ConanException("Package recipe '%s' does not exist" % str(reference))
 
-        deps_graph, _, _ = self._graph_manager.load_graph(reference, None, profile,
-                                                          build_mode=None, check_updates=False, update=False,
-                                                          remote_name=None, recorder=self._recorder, workspace=None)
+        deps_graph = self._graph_manager.load_simple_graph(reference, profile, self._recorder)
 
         # this is a bit tricky, but works. The root (virtual), has only 1 neighbor,
         # which is the exported pkg

--- a/conans/test/command/export_pkg_test.py
+++ b/conans/test/command/export_pkg_test.py
@@ -3,7 +3,7 @@ import platform
 import os
 
 from conans.paths import CONANFILE
-from conans.test.utils.tools import TestClient
+from conans.test.utils.tools import TestClient, TestServer
 from conans.model.ref import ConanFileReference, PackageReference
 from conans.util.files import load, mkdir
 from conans.test.utils.conanfile import TestConanFile
@@ -11,6 +11,23 @@ from parameterized import parameterized
 
 
 class ExportPkgTest(unittest.TestCase):
+    def test_dont_touch_server(self):
+        # https://github.com/conan-io/conan/issues/3432
+        class RequesterMock(object):
+            def __init__(self, *args, **kwargs):
+                pass
+
+        # https://github.com/conan-io/conan/issues/3432
+        client = TestClient(servers={"default": TestServer()},
+                            requester_class=RequesterMock,
+                            users={"default": [("lasote", "mypass")]})
+        conanfile = """from conans import ConanFile
+class Pkg(ConanFile):
+    pass
+"""
+        client.save({"conanfile.py": conanfile})
+        client.run("install .")
+        client.run("export-pkg . Pkg/0.1@user/testing")
 
     def test_package_folder_errors(self):
         # https://github.com/conan-io/conan/issues/2350


### PR DESCRIPTION
- [x] Refer to the issue that supports this Pull Request.
Fix #3432

With the new graph computation, the ``export-pkg`` command was computing the whole graph, including the binaries availability. It was asking the server if it had binaries for the current exported package binary. While it worked (besides the issue of trying to connect the server), it was unnecessary, better remove it.
