### PR TITLE
add processing indicator during files compression

### DIFF
--- a/conans/client/remote_manager.py
+++ b/conans/client/remote_manager.py
@@ -298,7 +298,7 @@ def _compress_recipe_files(files, symlinks, src_files, src_symlinks, dest_folder
             result[tgz_name] = tgz_path
         elif tgz_files:
             output.rewrite_line(msg)
-            tgz_path = compress_files(tgz_files, tgz_symlinks, tgz_name, dest_folder)
+            tgz_path = compress_files(tgz_files, tgz_symlinks, tgz_name, dest_folder, output)
             result[tgz_name] = tgz_path
 
     add_tgz(EXPORT_TGZ_NAME, export_tgz_path, files, symlinks, "Compressing recipe...")
@@ -311,9 +311,9 @@ def _compress_recipe_files(files, symlinks, src_files, src_symlinks, dest_folder
 def compress_package_files(files, symlinks, dest_folder, output):
     tgz_path = files.get(PACKAGE_TGZ_NAME)
     if not tgz_path:
-        output.rewrite_line("Compressing package...")
+        output.writeln("Compressing package...")
         tgz_files = {f: path for f, path in files.items() if f not in [CONANINFO, CONAN_MANIFEST]}
-        tgz_path = compress_files(tgz_files, symlinks, PACKAGE_TGZ_NAME, dest_dir=dest_folder)
+        tgz_path = compress_files(tgz_files, symlinks, PACKAGE_TGZ_NAME, dest_folder, output)
 
     return {PACKAGE_TGZ_NAME: tgz_path,
             CONANINFO: files[CONANINFO],
@@ -330,7 +330,7 @@ def check_compressed_files(tgz_name, files):
                                  "Please upgrade conan client." % f)
 
 
-def compress_files(files, symlinks, name, dest_dir):
+def compress_files(files, symlinks, name, dest_dir, output=None):
     t1 = time.time()
     # FIXME, better write to disk sequentially and not keep tgz contents in memory
     tgz_path = os.path.join(dest_dir, name)
@@ -346,6 +346,11 @@ def compress_files(files, symlinks, name, dest_dir):
             tgz.addfile(tarinfo=info)
 
         mask = ~(stat.S_IWOTH | stat.S_IWGRP)
+        i_file = 0
+        n_files = len(files)
+        last_progress = None
+        if output and n_files > 1 and not output.is_terminal:
+            output.write("[")
         for filename, abs_path in sorted(files.items()):
             info = tarfile.TarInfo(name=filename)
             info.size = os.stat(abs_path).st_size
@@ -357,7 +362,22 @@ def compress_files(files, symlinks, name, dest_dir):
             else:
                 with open(abs_path, 'rb') as file_handler:
                     tgz.addfile(tarinfo=info, fileobj=file_handler)
+            if output and n_files > 1:
+                i_file = i_file + 1
+                units = min(50, int(50 * i_file / n_files))
+                if last_progress != units:  # Avoid screen refresh if nothing has change
+                    if output.is_terminal:
+                        text = "%s/%s files" % (i_file, n_files)
+                        output.rewrite_line("[%s%s] %s" % ('=' * units, ' ' * (50 - units), text))
+                    else:
+                        output.write('=' * (units - (last_progress or 0)))
+                    last_progress = units
 
+        if output and n_files > 1:
+            if output.is_terminal:
+                output.writeln("")
+            else:
+                output.writeln("]")
         tgz.close()
 
     clean_dirty(tgz_path)


### PR DESCRIPTION
during file compression, a new dot is displayed every 60 seconds
it avoids CI builds to be considered stalled

- [ ] Refer to the issue that supports this Pull Request.
- [ ] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://raw.githubusercontent.com/conan-io/conan/develop/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. Also adding a description of the changes in the ``changelog.rst`` file. https://github.com/conan-io/docs
