### PR TITLE
Implement add_repository for SystemPackageTool (only AptTool) (close #3385)

### DIFF
--- a/conans/client/tools/system_pm.py
+++ b/conans/client/tools/system_pm.py
@@ -55,18 +55,8 @@ class SystemPackageTool(object):
         else:
             return NullTool()
 
-    def add_repositories(self, repositories, repo_keys=None, update=True):
-        """
-            Add repositories from list, using provided keys (if any) and update afterwards if requested
-        """
-        repositories = [repositories, ] if isinstance(repositories, string_types) else repositories
-        assert (repo_keys is None or len(repo_keys) == len(repositories)), \
-            "If keys are provided, both lists should have the same size (fill with None)"
-
-        for i, repository in enumerate(repositories):
-            repo_key = repo_keys[i] if repo_keys else None
-            self._tool.add_repository(repository, repo_key=repo_key)
-
+    def add_repository(self, repository, repo_key=None, update=True):
+        self._tool.add_repository(repository, repo_key=repo_key)
         if update:
             self.update()
 

--- a/conans/client/tools/system_pm.py
+++ b/conans/client/tools/system_pm.py
@@ -148,7 +148,7 @@ class AptTool(object):
     def add_repository(self, repository, repo_key=None):
         _run(self._runner, "%sapt-add-repository %s" % (self._sudo_str, repository))
         if repo_key:
-            _run(self._runner, "wget -qO - %s | sudo apt-key add -" % repo_key)
+            _run(self._runner, "wget -qO - %s | %sapt-key add -" % (repo_key, self._sudo_str))
 
     def update(self):
         _run(self._runner, "%sapt-get update" % self._sudo_str)
@@ -164,8 +164,7 @@ class AptTool(object):
 
 class YumTool(object):
     def add_repository(self, repository, repo_key=None):
-        _run(self._runner, "%syum-config-manager --add-repo %s" % (self._sudo_str, repository))
-        # TODO: Add GPG key (although it is not needed): https://codingbee.net/tutorials/rhcsa/rhcsa-yum-repository-gpg-keys
+        raise ConanException("YumTool::add_repository not implemented (see #3385)")
 
     def update(self):
         _run(self._runner, "%syum update" % self._sudo_str, accepted_returns=[0, 100])
@@ -180,8 +179,7 @@ class YumTool(object):
 
 class BrewTool(object):
     def add_repository(self, repository, repo_key=None):
-        _run(self._runner, "brew tap user/repo %s" % repository)  # TODO: Which name?
-        # TODO: Anything to do with key?
+        raise ConanException("BrewTool::add_repository not implemented (see #3385)")
 
     def update(self):
         _run(self._runner, "brew update")
@@ -196,7 +194,7 @@ class BrewTool(object):
 
 class PkgTool(object):
     def add_repository(self, repository, repo_key=None):
-        raise NotImplementedError  # TODO: Does it have something related to this?
+        raise ConanException("PkgTool::add_repository not implemented (see #3385)")
 
     def update(self):
         _run(self._runner, "%spkg update" % self._sudo_str)
@@ -211,8 +209,7 @@ class PkgTool(object):
 
 class PkgUtilTool(object):
     def add_repository(self, repository, repo_key=None):
-        raise NotImplementedError
-        # Instead of adding a repository, it may be better 'pkgutil -t <url> -i <package>'
+        raise ConanException("PkgUtilTool::add_repository not implemented (see #3385)")
 
     def update(self):
         _run(self._runner, "%spkgutil --catalog" % self._sudo_str)
@@ -227,11 +224,7 @@ class PkgUtilTool(object):
 
 class ChocolateyTool(object):
     def add_repository(self, repository, repo_key=None):
-        # https://github.com/chocolatey/choco/wiki/CommandsSources
-        command = 'choco source add -n=bob -s="%s"' % repository
-        if repo_key:
-            command += ' --cert=%s' % repo_key  # TODO: Always a file? can be a http?
-        _run(self._runner, command)
+        raise ConanException("ChocolateyTool::add_repository not implemented (see #3385)")
 
     def update(self):
         _run(self._runner, "choco outdated")
@@ -247,9 +240,7 @@ class ChocolateyTool(object):
 
 class PacManTool(object):
     def add_repository(self, repository, repo_key=None):
-        # TODO: https://wiki.archlinux.org/index.php/Pacman#Repositories_and_mirrors
-        # Repos, mirrors,... are handled in a configuration file
-        raise NotImplementedError
+        raise ConanException("PacManTool::add_repository not implemented (see #3385)")
 
     def update(self):
         _run(self._runner, "%spacman -Syyu --noconfirm" % self._sudo_str)
@@ -264,8 +255,7 @@ class PacManTool(object):
 
 class ZypperTool(object):
     def add_repository(self, repository, repo_key=None):
-        _run(self._runner, "%szypper ar %s repo-name" % (self._sudo_str, repository))
-        # TODO: something with repo_key
+        raise ConanException("ZypperTool::add_repository not implemented (see #3385)")
 
     def update(self):
         _run(self._runner, "%szypper --non-interactive ref" % self._sudo_str)

--- a/conans/client/tools/system_pm.py
+++ b/conans/client/tools/system_pm.py
@@ -60,7 +60,8 @@ class SystemPackageTool(object):
             Add repositories from list, using provided keys (if any) and update afterwards if requested
         """
         repositories = [repositories, ] if isinstance(repositories, string_types) else repositories
-        assert (repo_keys is None or len(repo_keys) == len(repositories)), "If keys are provided, both lists should have the same size (fill with None)"
+        assert (repo_keys is None or len(repo_keys) == len(repositories)), \
+            "If keys are provided, both lists should have the same size (fill with None)"
 
         for i, repository in enumerate(repositories):
             repo_key = repo_keys[i] if repo_keys else None

--- a/conans/client/tools/system_pm.py
+++ b/conans/client/tools/system_pm.py
@@ -155,7 +155,7 @@ class AptTool(object):
 
 class YumTool(object):
     def add_repository(self, repository, repo_key=None):
-        raise ConanException("YumTool::add_repository not implemented (see #3385)")
+        raise ConanException("YumTool::add_repository not implemented")
 
     def update(self):
         _run(self._runner, "%syum update" % self._sudo_str, accepted_returns=[0, 100])
@@ -170,7 +170,7 @@ class YumTool(object):
 
 class BrewTool(object):
     def add_repository(self, repository, repo_key=None):
-        raise ConanException("BrewTool::add_repository not implemented (see #3385)")
+        raise ConanException("BrewTool::add_repository not implemented")
 
     def update(self):
         _run(self._runner, "brew update")
@@ -185,7 +185,7 @@ class BrewTool(object):
 
 class PkgTool(object):
     def add_repository(self, repository, repo_key=None):
-        raise ConanException("PkgTool::add_repository not implemented (see #3385)")
+        raise ConanException("PkgTool::add_repository not implemented")
 
     def update(self):
         _run(self._runner, "%spkg update" % self._sudo_str)
@@ -200,7 +200,7 @@ class PkgTool(object):
 
 class PkgUtilTool(object):
     def add_repository(self, repository, repo_key=None):
-        raise ConanException("PkgUtilTool::add_repository not implemented (see #3385)")
+        raise ConanException("PkgUtilTool::add_repository not implemented")
 
     def update(self):
         _run(self._runner, "%spkgutil --catalog" % self._sudo_str)
@@ -215,7 +215,7 @@ class PkgUtilTool(object):
 
 class ChocolateyTool(object):
     def add_repository(self, repository, repo_key=None):
-        raise ConanException("ChocolateyTool::add_repository not implemented (see #3385)")
+        raise ConanException("ChocolateyTool::add_repository not implemented")
 
     def update(self):
         _run(self._runner, "choco outdated")
@@ -231,7 +231,7 @@ class ChocolateyTool(object):
 
 class PacManTool(object):
     def add_repository(self, repository, repo_key=None):
-        raise ConanException("PacManTool::add_repository not implemented (see #3385)")
+        raise ConanException("PacManTool::add_repository not implemented")
 
     def update(self):
         _run(self._runner, "%spacman -Syyu --noconfirm" % self._sudo_str)
@@ -246,7 +246,7 @@ class PacManTool(object):
 
 class ZypperTool(object):
     def add_repository(self, repository, repo_key=None):
-        raise ConanException("ZypperTool::add_repository not implemented (see #3385)")
+        raise ConanException("ZypperTool::add_repository not implemented")
 
     def update(self):
         _run(self._runner, "%szypper --non-interactive ref" % self._sudo_str)

--- a/conans/test/util/tools_test.py
+++ b/conans/test/util/tools_test.py
@@ -101,7 +101,7 @@ class SystemPackageToolTest(unittest.TestCase):
                 spt = SystemPackageTool(runner=runner, os_info=os_info)
 
                 spt.add_repository(repository=repository, repo_key=gpg_key, update=update)
-                self.assertTrue(len(runner.commands) == 0)
+                self.assertEqual(len(runner.commands), 0)
 
         # Run several test cases
         repository = "deb http://repo/url/ saucy universe multiverse"

--- a/conans/test/util/tools_test.py
+++ b/conans/test/util/tools_test.py
@@ -109,11 +109,6 @@ class SystemPackageToolTest(unittest.TestCase):
             spt.add_repositories(repositories=repositories, repo_keys=gpg_keys, update=False)
             self.assertTrue(len(runner.commands) == 0)
 
-            with self.assertRaisesRegexp(ConanException, "add_repository not implemented"):
-                os_info.linux_distro = "fedora"  # Will instantiate YumTool
-                spt = SystemPackageTool(runner=runner, os_info=os_info)
-                spt.add_repositories(repositories=repositories, repo_keys=gpg_keys)
-
         with tools.environment_append({"CONAN_SYSREQUIRES_SUDO": "False"}):
             runner = RunnerOrderedMock()
             runner.commands.append(("apt-add-repository {}".format(repositories[0]), 0))

--- a/conans/test/util/tools_test.py
+++ b/conans/test/util/tools_test.py
@@ -59,7 +59,26 @@ class SystemPackageToolTest(unittest.TestCase):
             self.assertIn('Not updating system_requirements. CONAN_SYSREQUIRES_MODE=verify',
                           tools.system_pm._global_output)
 
-    def system_package_tool_add_repositories_test(self):
+    def add_repositories_exception_cases_test(self):
+        repositories = ["deb http://repo/url/ saucy universe multiverse",
+                        "deb http://other/repo/url/ saucy-updates universe multiverse"]
+        gpg_keys = ['http://one/key.gpg', None]
+
+        os_info = OSInfo()
+        os_info.is_macos = False
+        os_info.is_linux = True
+        os_info.is_windows = False
+        os_info.linux_distro = "fedora"  # Will instantiate YumTool
+
+        with self.assertRaisesRegexp(ConanException, "add_repository not implemented"):
+            spt = SystemPackageTool(os_info=os_info)
+            spt.add_repositories(repositories=repositories, repo_keys=gpg_keys)
+
+        with self.assertRaisesRegexp(AssertionError, "both lists should have the same size"):
+            spt = SystemPackageTool(os_info=os_info)
+            spt.add_repositories(repositories=repositories, repo_keys=["only-one-key", ])
+
+    def add_repositories_test(self):
         repositories = ["deb http://repo/url/ saucy universe multiverse",
                         "deb http://other/repo/url/ saucy-updates universe multiverse"]
         gpg_keys = ['http://one/key.gpg', None]


### PR DESCRIPTION
- [x] close #3385 
- [x] I've read the [Contributing guide](https://raw.githubusercontent.com/conan-io/conan/develop/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. Also adding a description of the changes in the ``changelog.rst`` file. https://github.com/conan-io/docs
- [x] Add test
- [ ] Someone must confirm it actually works in production for AptTool (test is checking the command, but there might be a typo)

Following last comments  by @lasote [here](https://github.com/conan-io/conan/issues/3385#issuecomment-417239791) this pr implements the `add_repository` functionality for SystemPackageTool (only available for AptTool).