### PR TITLE
TestClient: wrap command and output from command in fancy lines

### DIFF
--- a/conans/test/utils/tools.py
+++ b/conans/test/utils/tools.py
@@ -503,9 +503,14 @@ class TestClient(object):
                 sys.modules.pop(added, None)
 
         if not ignore_error and error:
-            logger.error(self.user_io.out)
-            print(self.user_io.out)
-            raise Exception("Command failed:\n%s" % command_line)
+            exc_message = "\n{command_header}\n{command}\n{output_header}\n{output}\n{output_footer}\n".format(
+                command_header='{:-^80}'.format(" Command failed: "),
+                output_header='{:-^80}'.format(" Output: "),
+                output_footer='-'*80,
+                command=command_line,
+                output=self.user_io.out
+            )
+            raise Exception(exc_message)
 
         self.all_output += str(self.user_io.out)
         return error


### PR DESCRIPTION
Improve output when TestClient raises an exception in order to know what is happening in CI:

```bash
> nosetests conans.test.integration.install_missing_dep_test
E
======================================================================
ERROR: missing_dep_test (conans.test.integration.install_missing_dep_test.InstallMissingDependency)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "C:\Javi\dev\conan\conans\test\integration\install_missing_dep_test.py", line 24, in missing_dep_test
    client.run("createe . dep1/1.0@lasote/testing")
  File "C:\Javi\dev\conan\conans\test\utils\tools.py", line 513, in run
    raise Exception(exc_message)
Exception:
------------------------------- Command failed: --------------------------------
createe . dep1/1.0@lasote/testing
----------------------------------- Output: ------------------------------------
Consumer commands
  install    Installs the requirements specified in a recipe (conanfile.py or conanfile.txt).
  config     Manages Conan configuration.
  get        Gets a file or list a directory of a given reference or package.
  info       Gets information about the dependency graph of a recipe.
  search     Searches package recipes and binaries in the local cache or in a remote.
Creator commands
  new        Creates a new package recipe template with a 'conanfile.py' and optionally,
  create     Builds a binary package for a recipe (conanfile.py).
  upload     Uploads a recipe and binary packages to a remote.
  export     Copies the recipe (conanfile.py & associated files) to your local cache.
  export-pkg Exports a recipe, then creates a package from local source and build folders.
  test       Test a package consuming it from a conanfile.py with a test() method.
Package development commands
  source     Calls your local conanfile.py 'source()' method.
  build      Calls your local conanfile.py 'build()' method.
  package    Calls your local conanfile.py 'package()' method.
Misc commands
  profile    Lists profiles in the '.conan/profiles' folder, or shows profile details.
  remote     Manages the remote list and the package recipes associated to a remote.
  user       Authenticates against a remote with user/pass, caching the auth token.
  imports    Calls your local conanfile.py or conanfile.txt 'imports' method.
  copy       Copies conan recipes and packages to another user/channel.
  remove     Removes packages or binaries matching pattern from local cache or remote.
  alias      Creates and exports an 'alias package recipe'.
  download   Downloads recipe and binaries to the local cache, without using settings.
  help       Show help of a specific commmand.

Conan commands. Type "conan <command> -h" for help
ERROR: Unknown command 'createe'

--------------------------------------------------------------------------------


----------------------------------------------------------------------
Ran 1 test in 0.250s

FAILED (errors=1)
```
