### PR TITLE
add default_deploy feature enabling the deployment of any package

### DIFF
--- a/conans/client/cmd/create.py
+++ b/conans/client/cmd/create.py
@@ -42,6 +42,7 @@ def create(reference, manager, user_io, profile, remote_name, update, build_mode
         manager.install(reference=reference,
                         create_reference=reference,
                         install_folder=None,  # Not output anything
+                        deploy_folder=None,
                         manifest_folder=manifest_folder,
                         manifest_verify=manifest_verify,
                         manifest_interactive=manifest_interactive,

--- a/conans/client/command.py
+++ b/conans/client/command.py
@@ -305,6 +305,9 @@ class Command(object):
         parser.add_argument("-if", "--install-folder", action=OnceArgument,
                             help='Use this directory as the directory where to put the generator'
                                  'files. e.g., conaninfo/conanbuildinfo.txt')
+        parser.add_argument("-df", "--deploy-folder", action=OnceArgument,
+                            help='Use this directory as the directory where to copy all package '
+                                 'contents after package step.')
 
         _add_manifests_arguments(parser)
 
@@ -333,7 +336,8 @@ class Command(object):
                                            build=args.build, profile_name=args.profile,
                                            update=args.update, generators=args.generator,
                                            no_imports=args.no_imports,
-                                           install_folder=args.install_folder)
+                                           install_folder=args.install_folder,
+                                           deploy_folder=args.deploy_folder)
             else:
                 info = self._conan.install_reference(reference, settings=args.settings,
                                                      options=args.options,
@@ -344,7 +348,8 @@ class Command(object):
                                                      build=args.build, profile_name=args.profile,
                                                      update=args.update,
                                                      generators=args.generator,
-                                                     install_folder=args.install_folder)
+                                                     install_folder=args.install_folder,
+                                                     deploy_folder=args.deploy_folder)
         except ConanException as exc:
             info = exc.info
             raise

--- a/conans/client/conan_api.py
+++ b/conans/client/conan_api.py
@@ -395,12 +395,15 @@ class ConanAPIV1(object):
     def install_reference(self, reference, settings=None, options=None, env=None,
                           remote_name=None, verify=None, manifests=None,
                           manifests_interactive=None, build=None, profile_name=None,
-                          update=False, generators=None, install_folder=None, cwd=None):
+                          update=False, generators=None, install_folder=None,
+                          deploy_folder=None, cwd=None):
 
         try:
             recorder = ActionRecorder()
             cwd = cwd or os.getcwd()
             install_folder = _make_abs_path(install_folder, cwd)
+            if deploy_folder is not None:
+                deploy_folder = _make_abs_path(deploy_folder, cwd)
 
             manifests = _parse_manifests_arguments(verify, manifests, manifests_interactive, cwd)
             manifest_folder, manifest_interactive, manifest_verify = manifests
@@ -412,8 +415,11 @@ class ConanAPIV1(object):
                 generators = False
 
             mkdir(install_folder)
+            if deploy_folder is not None:
+                mkdir(deploy_folder)
             manager = self._init_manager(recorder)
             manager.install(reference=reference, install_folder=install_folder,
+                            deploy_folder=deploy_folder,
                             remote_name=remote_name, profile=profile, build_modes=build,
                             update=update, manifest_folder=manifest_folder,
                             manifest_verify=manifest_verify,
@@ -429,7 +435,8 @@ class ConanAPIV1(object):
     def install(self, path="", settings=None, options=None, env=None,
                 remote_name=None, verify=None, manifests=None,
                 manifests_interactive=None, build=None, profile_name=None,
-                update=False, generators=None, no_imports=False, install_folder=None, cwd=None):
+                update=False, generators=None, no_imports=False, install_folder=None,
+                deploy_folder=None, cwd=None):
 
         try:
             recorder = ActionRecorder()
@@ -456,10 +463,13 @@ class ConanAPIV1(object):
                 return
 
             install_folder = _make_abs_path(install_folder, cwd)
+            deploy_folder = _make_abs_path(deploy_folder, cwd)
+            mkdir(deploy_folder)
             conanfile_path = _get_conanfile_path(path, cwd, py=None)
             manager = self._init_manager(recorder)
             manager.install(reference=conanfile_path,
                             install_folder=install_folder,
+                            deploy_folder=deploy_folder,
                             remote_name=remote_name,
                             profile=profile,
                             build_modes=build,

--- a/conans/client/importer.py
+++ b/conans/client/importer.py
@@ -131,6 +131,7 @@ class _FileImporter(object):
     It can be also used for Golang projects, in which the packages are always
     source based and need to be copied to the user folder to be built
     """
+
     def __init__(self, conanfile, dst_folder):
         self._conanfile = conanfile
         self._dst_folder = dst_folder

--- a/conans/client/importer.py
+++ b/conans/client/importer.py
@@ -131,7 +131,6 @@ class _FileImporter(object):
     It can be also used for Golang projects, in which the packages are always
     source based and need to be copied to the user folder to be built
     """
-
     def __init__(self, conanfile, dst_folder):
         self._conanfile = conanfile
         self._dst_folder = dst_folder

--- a/conans/client/manager.py
+++ b/conans/client/manager.py
@@ -89,13 +89,14 @@ class ConanManager(object):
         installer.install(deps_graph, keep_build=False)
         workspace.generate()
 
-    def install(self, reference, install_folder, profile, remote_name=None, build_modes=None,
+    def install(self, reference, install_folder, deploy_folder, profile, remote_name=None, build_modes=None,
                 update=False, manifest_folder=None, manifest_verify=False,
                 manifest_interactive=False, generators=None, no_imports=False, create_reference=None,
                 keep_build=False):
         """ Fetch and build all dependencies for the given reference
         @param reference: ConanFileReference or path to user space conanfile
         @param install_folder: where the output files will be saved
+        @param deploy_folder: user-specified place where package contents will be copied
         @param remote: install only from that remote
         @param profile: Profile object with both the -s introduced options and profile read values
         @param build_modes: List of build_modes specified
@@ -173,6 +174,12 @@ class ConanManager(object):
                 # The conanfile loaded is really a virtual one. The one with the deploy is the first level one
                 neighbours = deps_graph.root.neighbors()
                 deploy_conanfile = neighbours[0].conanfile
+
+                if not hasattr(deploy_conanfile, "deploy"):
+                    if deploy_folder:
+                        output.info("setting up default_deploy")
+                        deploy_conanfile.deploy = lambda: deploy_conanfile.copy(pattern="*", dst=deploy_folder)
+
                 if hasattr(deploy_conanfile, "deploy") and callable(deploy_conanfile.deploy):
                     run_deploy(deploy_conanfile, install_folder, output)
 


### PR DESCRIPTION
In response to: #3280

The primary capability added with this feature, is the long-requested ability to "easily get ahold of" any arbitrary file from any existing Conan package for use outside of Conan from a single CLI call without having to create some intermediate recipe.  It is fundamentally different from the existing `deploy` functionality, which requires recipes to be written with `deploy()` methods before they can be deployed. 

One noteworthy decision about scope with this implementation is that the feature provides only a simple extraction of artifacts to user space.  Users will no doubt need to apply custom logic for selecting specific files and moving them to custom destinations.  With this implementation, any such logic must all be implemented in scripts outside of Conan.  This seems reasonable as most of the non-trivial uses of this feature are likely to involve automated CI scripts which are calling Conan CLI anyway.  

An alternative to this feature which would enable users to achieve a similar capability would be for the `conan info` command to return manifests of the contents of packages with full local file paths for each file.  This seemed more complex to implement, and will require users to loop over the results outside of Conan.  Requiring the user to loop over results seems reasonable for devops automation use cases, and would save an unnecessary copy compared how my team is using this `default_deploy` feature currently. Personally, I would like both features to co-exist. 

While still a rough draft, this feature feature has solved some very real-world devops workflow challenges we had when integrating Conan into an existing environment, relating to migrations between workflows. 

Until there is some approval to move forward with this feature in principle, I will wait to write a documentation PR for it. 

- [x] Refer to the issue that supports this Pull Request.
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://raw.githubusercontent.com/conan-io/conan/develop/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. Also adding a description of the changes in the ``changelog.rst`` file. https://github.com/conan-io/docs
