### PR TITLE
Add cmake flag 'CMAKE_OSX_DEPLOYMENT_TARGET' according to settings.os.version

### DIFF
--- a/conans/client/build/cmake_flags.py
+++ b/conans/client/build/cmake_flags.py
@@ -229,7 +229,6 @@ class CMakeDefinitionsBuilder(object):
         compiler_version = self._ss("compiler.version")
         arch = self._ss("arch")
         os_ = self._ss("os")
-        os_version = self._ss("os.version")
         libcxx = self._ss("compiler.libcxx")
         runtime = self._ss("compiler.runtime")
         build_type = self._ss("build_type")

--- a/conans/client/build/cmake_flags.py
+++ b/conans/client/build/cmake_flags.py
@@ -168,7 +168,7 @@ class CMakeDefinitionsBuilder(object):
                         ret["CMAKE_SYSTEM_NAME"] = "Generic"
         if os_ver:
             ret["CMAKE_SYSTEM_VERSION"] = os_ver
-            if str(os_).lower() == "macos":
+            if str(os_) == "Macos":
                 ret["CMAKE_OSX_DEPLOYMENT_TARGET"] = os_ver
 
         # system processor
@@ -237,7 +237,7 @@ class CMakeDefinitionsBuilder(object):
         ret.update(build_type_definition(build_type, self.generator))
         ret.update(runtime_definition(runtime))
 
-        if str(os_).lower() == "macos":
+        if str(os_) == "Macos":
             if arch == "x86":
                 ret["CMAKE_OSX_ARCHITECTURES"] = "i386"
 

--- a/conans/client/build/cmake_flags.py
+++ b/conans/client/build/cmake_flags.py
@@ -168,6 +168,8 @@ class CMakeDefinitionsBuilder(object):
                         ret["CMAKE_SYSTEM_NAME"] = "Generic"
         if os_ver:
             ret["CMAKE_SYSTEM_VERSION"] = os_ver
+            if str(os_).lower() == "macos":
+                ret["CMAKE_OSX_DEPLOYMENT_TARGET"] = os_ver
 
         # system processor
         cmake_system_processor = os.getenv("CONAN_CMAKE_SYSTEM_PROCESSOR")
@@ -227,6 +229,7 @@ class CMakeDefinitionsBuilder(object):
         compiler_version = self._ss("compiler.version")
         arch = self._ss("arch")
         os_ = self._ss("os")
+        os_version = self._ss("os.version")
         libcxx = self._ss("compiler.libcxx")
         runtime = self._ss("compiler.runtime")
         build_type = self._ss("build_type")

--- a/conans/test/build_helpers/cmake_test.py
+++ b/conans/test/build_helpers/cmake_test.py
@@ -962,6 +962,42 @@ build_type: [ Release]
             cmake = CMake(conan_file)
             self.assertEquals(cmake.definitions["CMAKE_SYSTEM_VERSION"], "32")
 
+    def test_cmake_system_version_osx(self):
+        settings = Settings.loads(default_settings_yml)
+        settings.os = "Macos"
+
+        # No version defined
+        conanfile = ConanFileMock()
+        conanfile.settings = settings
+        cmake = CMake(conanfile)
+        self.assertFalse("CMAKE_OSX_DEPLOYMENT_TARGET" in cmake.definitions)
+        self.assertFalse("CMAKE_SYSTEM_NAME" in cmake.definitions)
+        self.assertFalse("CMAKE_SYSTEM_VERSION" in cmake.definitions)
+
+        # Version defined using Conan env variable
+        with tools.environment_append({"CONAN_CMAKE_SYSTEM_VERSION": "23"}):
+            conanfile = ConanFileMock()
+            conanfile.settings = settings
+            cmake = CMake(conanfile)
+            self.assertEqual(cmake.definitions["CMAKE_SYSTEM_VERSION"], "23")
+            self.assertEqual(cmake.definitions["CMAKE_OSX_DEPLOYMENT_TARGET"], "23")
+
+        # Version defined in settings
+        settings.os.version = "10.9"
+        conanfile = ConanFileMock()
+        conanfile.settings = settings
+        cmake = CMake(conanfile)
+        self.assertEqual(cmake.definitions["CMAKE_SYSTEM_VERSION"], "10.9")
+        self.assertEqual(cmake.definitions["CMAKE_OSX_DEPLOYMENT_TARGET"], "10.9")
+
+        # Version defined in settings AND using Conan env variable
+        with tools.environment_append({"CONAN_CMAKE_SYSTEM_VERSION": "23"}):
+            conanfile = ConanFileMock()
+            conanfile.settings = settings
+            cmake = CMake(conanfile)
+            self.assertEqual(cmake.definitions["CMAKE_SYSTEM_VERSION"], "23")
+            self.assertEqual(cmake.definitions["CMAKE_OSX_DEPLOYMENT_TARGET"], "23")
+
     @staticmethod
     def scape(args):
         pattern = "%s" if sys.platform == "win32" else r"'%s'"

--- a/conans/test/build_helpers/cmake_test.py
+++ b/conans/test/build_helpers/cmake_test.py
@@ -4,6 +4,7 @@ import stat
 import sys
 import unittest
 import platform
+import mock
 
 from collections import namedtuple
 
@@ -962,7 +963,8 @@ build_type: [ Release]
             cmake = CMake(conan_file)
             self.assertEquals(cmake.definitions["CMAKE_SYSTEM_VERSION"], "32")
 
-    def test_cmake_system_version_osx(self):
+    @mock.patch('platform.system', return_value="Macos")
+    def test_cmake_system_version_osx(self, _):
         settings = Settings.loads(default_settings_yml)
         settings.os = "Macos"
 


### PR DESCRIPTION
- [x] close #3346
- [x] I've read the [Contributing guide](https://raw.githubusercontent.com/conan-io/conan/develop/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [x] No need for docs
- [x] Discussion ongoing in #3346 

Changelog: Feature:  Added definition ``CMAKE_OSX_DEPLOYMENT_TARGET`` to the ``CMake`` build helper following the ``os.version`` setting for ``Macos``.