### PR TITLE
Fixed Git class, wrongly replacing characters from the branch name

### DIFF
--- a/conans/client/tools/scm.py
+++ b/conans/client/tools/scm.py
@@ -144,8 +144,6 @@ class Git(object):
             status = self.run("status -bs --porcelain")
             # ## feature/scm_branch...myorigin/feature/scm_branch
             branch = status.splitlines()[0].split("...")[0].strip("#").strip()
-            # Replace non alphanumeric
-            branch = re.sub('[^0-9a-zA-Z]+', '_', branch)
             return branch
         except Exception as e:
             raise ConanException("Unable to get git branch from %s\n%s" % (self.folder, str(e)))

--- a/conans/test/util/tools_test.py
+++ b/conans/test/util/tools_test.py
@@ -1217,12 +1217,15 @@ class GitToolTest(unittest.TestCase):
 
     def git_to_capture_branch_test(self):
         conanfile = """
+import re
 from conans import ConanFile, tools
 
 def get_version():
     git = tools.Git()
     try:
-        return "%s_%s" % (git.get_branch(), git.get_revision())
+        branch = git.get_branch()
+        branch = re.sub('[^0-9a-zA-Z]+', '_', branch)
+        return "%s_%s" % (branch, git.get_revision())
     except:
         return None
 


### PR DESCRIPTION
The `Git` `get_branch` method has to return the branch name, the responsibility of adapting it to be used as a version is not from the `Git` class. @niosHD The test has been updated to reflect how it can be used now.