### PR TITLE
TEST CI: Use execfile and __import__() to load conanfile module

### DIFF
--- a/conans/client/loader.py
+++ b/conans/client/loader.py
@@ -233,7 +233,9 @@ def _parse_file(conan_file_path):
         old_modules = list(sys.modules.keys())
         with chdir(current_dir):
             sys.dont_write_bytecode = True
+            print("Before import:", filename)
             loaded = __import__(filename)
+            print("After import:", filename)
             loaded.python_requires = _invalid_python_requires
             sys.dont_write_bytecode = False
         # Put all imported files under a new package name
@@ -254,7 +256,7 @@ def _parse_file(conan_file_path):
         import traceback
         trace = traceback.format_exc().split('\n')
         raise ConanException("Unable to load conanfile in %s\n%s" % (conan_file_path,
-                                                                     '\n'.join(trace[3:])))
+                                                                     '\n'.join(trace[:])))
     finally:
         sys.path.pop()
 

--- a/conans/client/loader.py
+++ b/conans/client/loader.py
@@ -233,7 +233,6 @@ def _parse_file(conan_file_path):
         old_modules = list(sys.modules.keys())
         with chdir(current_dir):
             sys.dont_write_bytecode = True
-            execfile(conan_file_path, globals(), locals())
             loaded = __import__(filename)
             loaded.python_requires = _invalid_python_requires
             sys.dont_write_bytecode = False

--- a/conans/client/loader.py
+++ b/conans/client/loader.py
@@ -1,8 +1,9 @@
 import os
 import sys
-import imp
 import inspect
 import uuid
+
+from past.builtins import execfile
 
 from conans.client.loader_txt import ConanFileTextLoader
 from conans.errors import ConanException, NotFoundException
@@ -232,7 +233,8 @@ def _parse_file(conan_file_path):
         old_modules = list(sys.modules.keys())
         with chdir(current_dir):
             sys.dont_write_bytecode = True
-            loaded = imp.load_source(filename, conan_file_path)
+            execfile(conan_file_path)
+            loaded = __import__(filename)
             loaded.python_requires = _invalid_python_requires
             sys.dont_write_bytecode = False
         # Put all imported files under a new package name

--- a/conans/client/loader.py
+++ b/conans/client/loader.py
@@ -234,7 +234,7 @@ def _parse_file(conan_file_path):
         with chdir(current_dir):
             sys.dont_write_bytecode = True
             print("Before import:", filename)
-            loaded = __import__(filename)
+            loaded = __import__(filename, locals=None, globals=globals(), fromlist=[])
             print("After import:", filename)
             loaded.python_requires = _invalid_python_requires
             sys.dont_write_bytecode = False

--- a/conans/client/loader.py
+++ b/conans/client/loader.py
@@ -233,7 +233,7 @@ def _parse_file(conan_file_path):
         old_modules = list(sys.modules.keys())
         with chdir(current_dir):
             sys.dont_write_bytecode = True
-            execfile(conan_file_path)
+            execfile(conan_file_path, globals(), locals())
             loaded = __import__(filename)
             loaded.python_requires = _invalid_python_requires
             sys.dont_write_bytecode = False


### PR DESCRIPTION
- [x] Refer to the issue that supports this Pull Request: closes #3441 
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://raw.githubusercontent.com/conan-io/conan/develop/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. Also adding a description of the changes in the ``changelog.rst`` file. https://github.com/conan-io/docs

I am using the same idea to load plugins and this is the solution I come up with after looking into some sugestions from https://stackoverflow.com/questions/2349991/how-to-import-other-python-files