### PR TITLE
Feature/fix win case path tests

### DIFF
--- a/conans/test/functional/scm_test.py
+++ b/conans/test/functional/scm_test.py
@@ -9,6 +9,7 @@ from conans.model.scm import SCMData
 from conans.test.utils.test_files import temp_folder
 from conans.test.utils.tools import TestClient, TestServer, create_local_git_repo
 from conans.util.files import load, rmdir
+from conans.client.tools.win import get_cased_path
 
 base = '''
 import os
@@ -102,7 +103,7 @@ class ConanLib(ConanFile):
         self.assertIn("lib/0.1@user/channel: Getting sources from url:", self.client.out)
 
     def test_auto_git(self):
-        curdir = self.client.current_folder.replace("\\", "/")
+        curdir = get_cased_path(self.client.current_folder).replace("\\", "/")
         conanfile = base.format(directory="None", url="auto", revision="auto")
         self.client.save({"conanfile.py": conanfile, "myfile.txt": "My file is copied"})
         self._commit_contents()
@@ -153,7 +154,7 @@ class ConanLib(ConanFile):
         """
         Conanfile is not in the root of the repo: https://github.com/conan-io/conan/issues/3465
         """
-        curdir = self.client.current_folder
+        curdir = get_cased_path(self.client.current_folder).replace("\\", "/")
         conanfile = base.format(url="auto", revision="auto")
         self.client.save({"conan/conanfile.py": conanfile, "myfile.txt": "content of my file"})
         self._commit_contents()

--- a/conans/test/util/tools_test.py
+++ b/conans/test/util/tools_test.py
@@ -1102,6 +1102,7 @@ class GitToolTest(unittest.TestCase):
 
     def test_repo_root(self):
         root_path, _ = create_local_git_repo({"myfile": "anything"})
+
         # Initialized in the root folder
         git = Git(root_path)
         self.assertEqual(root_path, git.get_repo_root())

--- a/conans/test/util/tools_test.py
+++ b/conans/test/util/tools_test.py
@@ -1102,7 +1102,6 @@ class GitToolTest(unittest.TestCase):
 
     def test_repo_root(self):
         root_path, _ = create_local_git_repo({"myfile": "anything"})
-
         # Initialized in the root folder
         git = Git(root_path)
         self.assertEqual(root_path, git.get_repo_root())

--- a/conans/test/util/unix_path_test.py
+++ b/conans/test/util/unix_path_test.py
@@ -13,7 +13,7 @@ from conans.util.files import mkdir
 class GetCasedPath(unittest.TestCase):
     @unittest.skipUnless(platform.system() == "Windows", "Requires Windows")
     def test_case(self):
-        folder = temp_folder()
+        folder = get_cased_path(temp_folder())
         p1 = os.path.join(folder, "MyFolder", "Subfolder")
         mkdir(p1)
         p2 = get_cased_path(p1)

--- a/conans/test/utils/tools.py
+++ b/conans/test/utils/tools.py
@@ -41,6 +41,7 @@ from conans.util.files import save_files, save, mkdir
 from conans.util.log import logger
 from conans.model.ref import ConanFileReference, PackageReference
 from conans.model.manifest import FileTreeManifest
+from conans.client.tools.win import get_cased_path
 
 
 def inc_recipe_manifest_timestamp(client_cache, conan_ref, inc_time):
@@ -282,6 +283,7 @@ class TestBufferConanOutput(ConanOutput):
 
 def create_local_git_repo(files=None, branch=None, submodules=None, folder=None):
     tmp = folder or temp_folder()
+    tmp = get_cased_path(tmp)
     if files:
         save_files(tmp, files)
     git = Git(tmp)


### PR DESCRIPTION
Some tests are failing in my Windows machine, due to differences in the paths C:/User vs C:/user.
