### PR TITLE
[fix] get_cased_path doesn't raise when path does not exists

### DIFF
--- a/conans/client/tools/win.py
+++ b/conans/client/tools/win.py
@@ -389,11 +389,15 @@ def get_cased_path(name):
         parent, child = os.path.split(current)
         if parent == current:
             break
-        children = os.listdir(parent)
-        for c in children:
-            if c.upper() == child.upper():
-                result.append(c)
-                break
+
+        child_cased = child
+        if os.path.exists(parent):
+            children = os.listdir(parent)
+            for c in children:
+                if c.upper() == child.upper():
+                    child_cased = c
+                    break
+        result.append(child_cased)
         current = parent
     drive, _ = os.path.splitdrive(current)
     result.append(drive)

--- a/conans/test/util/unix_path_test.py
+++ b/conans/test/util/unix_path_test.py
@@ -21,27 +21,21 @@ class GetCasedPath(unittest.TestCase):
         self.assertEqual(p1, get_cased_path(os.path.join(folder, "myfolder", "subfolder")))
 
     def test_case_not_existing(self):
-        try:
-            non_existing_path = os.path.abspath(
-                os.path.join("this", "Path", "does", "NOT", "Exists"))
-            p = get_cased_path(non_existing_path)  # If not exists from the root, returns as is
-            self.assertEqual(p, non_existing_path)
-        except Exception as e:
-            self.fail("Unexpected exception: %s" % e)
+        non_existing_path = os.path.abspath(
+            os.path.join("this", "Path", "does", "NOT", "Exists"))
+        p = get_cased_path(non_existing_path)  # If not exists from the root, returns as is
+        self.assertEqual(p, non_existing_path)
 
     @unittest.skipUnless(platform.system() == "Windows", "Requires Windows")
     def test_case_partial_exists(self):
-        try:
-            folder = get_cased_path(temp_folder())
-            p1 = os.path.join(folder, "MyFolder", "Subfolder")
-            mkdir(p1)
+        folder = get_cased_path(temp_folder())
+        p1 = os.path.join(folder, "MyFolder", "Subfolder")
+        mkdir(p1)
 
-            non_existing_path = os.path.join(folder, "myfolder", "subfolder", "not-existing")
-            # The first part of the path will be properly cased.
-            self.assertEqual(os.path.join(p1, "not-existing"),
-                             get_cased_path(non_existing_path))
-        except Exception as e:
-            self.fail("Unexpected exception: %s" % e)
+        non_existing_path = os.path.join(folder, "myfolder", "subfolder", "not-existing")
+        # The first part of the path will be properly cased.
+        self.assertEqual(os.path.join(p1, "not-existing"),
+                         get_cased_path(non_existing_path))
 
 
 class UnixPathTest(unittest.TestCase):

--- a/conans/test/util/unix_path_test.py
+++ b/conans/test/util/unix_path_test.py
@@ -37,7 +37,7 @@ class GetCasedPath(unittest.TestCase):
             mkdir(p1)
 
             non_existing_path = os.path.join(folder, "myfolder", "subfolder", "not-existing")
-            # The first path of the path will be properly cased.
+            # The first part of the path will be properly cased.
             self.assertEqual(os.path.join(p1, "not-existing"),
                              get_cased_path(non_existing_path))
         except Exception as e:

--- a/conans/test/util/unix_path_test.py
+++ b/conans/test/util/unix_path_test.py
@@ -12,16 +12,22 @@ from conans.util.files import mkdir
 
 class GetCasedPath(unittest.TestCase):
     @unittest.skipUnless(platform.system() == "Windows", "Requires Windows")
-    def test_case(self):
+    def test_case_existing(self):
         folder = temp_folder()
         p1 = os.path.join(folder, "MyFolder", "Subfolder")
         mkdir(p1)
-        p2 = get_cased_path(p1)
-        self.assertEqual(p1, p2)
 
-        p3 = os.path.join(folder, "myfolder", "subfolder")
-        p4 = get_cased_path(p3)
-        self.assertEqual(p1, p4)
+        self.assertEqual(p1, get_cased_path(p1))  # Idempotent
+        self.assertEqual(p1, get_cased_path(os.path.join(folder, "myfolder", "subfolder")))
+
+    def test_case_not_existing(self):
+        try:
+            non_existing_path = os.path.abspath(
+                os.path.join("this", "Path", "does", "NOT", "Exists"))
+            p = get_cased_path(non_existing_path)
+            self.assertEqual(p, non_existing_path)
+        except Exception as e:
+            self.fail("Unexpected exception: %s" % e)
 
 
 class UnixPathTest(unittest.TestCase):

--- a/conans/test/util/unix_path_test.py
+++ b/conans/test/util/unix_path_test.py
@@ -24,8 +24,21 @@ class GetCasedPath(unittest.TestCase):
         try:
             non_existing_path = os.path.abspath(
                 os.path.join("this", "Path", "does", "NOT", "Exists"))
-            p = get_cased_path(non_existing_path)
+            p = get_cased_path(non_existing_path)  # If not exists from the root, returns as is
             self.assertEqual(p, non_existing_path)
+        except Exception as e:
+            self.fail("Unexpected exception: %s" % e)
+
+    def test_case_partial_exists(self):
+        try:
+            folder = temp_folder()
+            p1 = os.path.join(folder, "MyFolder", "Subfolder")
+            mkdir(p1)
+
+            non_existing_path = os.path.join(folder, "myfolder", "subfolder", "not-existing")
+            # The first path of the path will be properly cased.
+            self.assertEqual(os.path.join(p1, "not-existing"),
+                             get_cased_path(non_existing_path))
         except Exception as e:
             self.fail("Unexpected exception: %s" % e)
 


### PR DESCRIPTION
Fix/improve implementation of `get_cased_path`: if you call it with a non-existing path, it will work only on the existing part of the path and leave the rest as is.
