### PR TITLE
Add ConanInvalidConfiguration exception and handle error codes.

### DIFF
--- a/conans/errors.py
+++ b/conans/errors.py
@@ -22,6 +22,9 @@ def conanfile_exception_formatter(conanfile_name, func_name):
     """
     try:
         yield
+    except ConanInvalidConfiguration as exc:
+        msg = "{}: Invalid configuration: {}".format(conanfile_name, exc)  # TODO: Move from here?
+        raise ConanInvalidConfiguration(msg)
     except Exception as exc:
         msg = _format_conanfile_exception(conanfile_name, func_name, exc)
         raise ConanExceptionInUserConanfileMethod(msg)
@@ -95,7 +98,7 @@ class ConanExceptionInUserConanfileMethod(ConanException):
     pass
 
 
-class ConanInvalidConfiguration(ConanException):
+class ConanInvalidConfiguration(ConanExceptionInUserConanfileMethod):
     pass
 
 

--- a/conans/errors.py
+++ b/conans/errors.py
@@ -95,6 +95,10 @@ class ConanExceptionInUserConanfileMethod(ConanException):
     pass
 
 
+class ConanInvalidConfiguration(ConanException):
+    pass
+
+
 # Remote exceptions #
 class InternalErrorException(ConanException):
     """

--- a/conans/test/command/invalid_configuration_test.py
+++ b/conans/test/command/invalid_configuration_test.py
@@ -1,0 +1,68 @@
+import unittest
+import platform
+import os
+
+from conans.test.utils.tools import TestClient, TestServer
+from conans.model.ref import ConanFileReference, PackageReference
+from conans.paths import CONANFILE, CONANINFO
+from conans.model.info import ConanInfo
+from conans.test.utils.cpp_test_files import cpp_hello_conan_files
+from conans.paths import CONANFILE_TXT
+from conans.client.conf.detect import detected_os
+from conans.util.files import load, mkdir, rmdir
+
+
+class InvalidConfigurationTest(unittest.TestCase):
+
+    def setUp(self):
+        self.client = TestClient()
+        self.client.save({"conanfile.py": """
+from conans import ConanFile
+from conans.errors import ConanInvalidConfiguration
+
+class MyPkg(ConanFile):
+    settings = "os", "compiler", "build_type", "arch"
+    
+    def configure(self):
+        if self.settings.compiler.version == "12":
+            raise ConanInvalidConfiguration("user says that compiler.version=12 is invalid")
+
+    """})
+        settings = "-s os=Windows -s compiler='Visual Studio' -s compiler.version={ver}"
+        self.settings_msvc15 = settings.format(ver="15")
+        self.settings_msvc12 = settings.format(ver="12")
+
+    def test_install_method(self):
+        self.client.run("install . %s" % self.settings_msvc15)
+
+        error = self.client.run("install . %s" % self.settings_msvc12, ignore_error=True)
+        self.assertEqual(error, 5)  # TODO: hardcoded!!
+        self.assertIn("Invalid configuration: user says that compiler.version=12 is invalid",
+                      self.client.out)
+
+    def test_create_method(self):
+        self.client.run("create . name/ver@jgsogo/test %s" % self.settings_msvc15)
+
+        error = self.client.run("create . name/ver@jgsogo/test %s" % self.settings_msvc12,
+                                ignore_error=True)
+        self.assertEqual(error, 5)  # TODO: hardcoded!!
+        self.assertIn("name/ver@jgsogo/test: Invalid configuration: user says that "
+                      "compiler.version=12 is invalid", self.client.out)
+
+    def test_as_requirement(self):
+        self.client.run("create . name/ver@jgsogo/test %s" % self.settings_msvc15)
+        self.client.save({"other/conanfile.py": """
+from conans import ConanFile
+from conans.errors import ConanInvalidConfiguration
+
+class MyPkg(ConanFile):
+    requires = "name/ver@jgsogo/test"
+    settings = "os", "compiler", "build_type", "arch"
+    """})
+        self.client.run("create other/ other/ver@jgsogo/test %s" % self.settings_msvc15)
+
+        error = self.client.run("create other/ other/ver@jgsogo/test %s" % self.settings_msvc12,
+                                ignore_error=True)
+        self.assertEqual(error, 5)  # TODO: hardcoded!!
+        self.assertIn("name/ver@jgsogo/test: Invalid configuration: user says that "
+                      "compiler.version=12 is invalid", self.client.out)

--- a/conans/test/command/invalid_configuration_test.py
+++ b/conans/test/command/invalid_configuration_test.py
@@ -1,15 +1,8 @@
-import unittest
-import platform
-import os
 
-from conans.test.utils.tools import TestClient, TestServer
-from conans.model.ref import ConanFileReference, PackageReference
-from conans.paths import CONANFILE, CONANINFO
-from conans.model.info import ConanInfo
-from conans.test.utils.cpp_test_files import cpp_hello_conan_files
-from conans.paths import CONANFILE_TXT
-from conans.client.conf.detect import detected_os
-from conans.util.files import load, mkdir, rmdir
+import unittest
+
+from conans.test.utils.tools import TestClient
+from conans.client.command import ERROR_INVALID_CONFIGURATION
 
 
 class InvalidConfigurationTest(unittest.TestCase):
@@ -36,7 +29,7 @@ class MyPkg(ConanFile):
         self.client.run("install . %s" % self.settings_msvc15)
 
         error = self.client.run("install . %s" % self.settings_msvc12, ignore_error=True)
-        self.assertEqual(error, 5)  # TODO: hardcoded!!
+        self.assertEqual(error, ERROR_INVALID_CONFIGURATION)
         self.assertIn("Invalid configuration: user says that compiler.version=12 is invalid",
                       self.client.out)
 
@@ -45,7 +38,7 @@ class MyPkg(ConanFile):
 
         error = self.client.run("create . name/ver@jgsogo/test %s" % self.settings_msvc12,
                                 ignore_error=True)
-        self.assertEqual(error, 5)  # TODO: hardcoded!!
+        self.assertEqual(error, ERROR_INVALID_CONFIGURATION)
         self.assertIn("name/ver@jgsogo/test: Invalid configuration: user says that "
                       "compiler.version=12 is invalid", self.client.out)
 
@@ -63,6 +56,6 @@ class MyPkg(ConanFile):
 
         error = self.client.run("create other/ other/ver@jgsogo/test %s" % self.settings_msvc12,
                                 ignore_error=True)
-        self.assertEqual(error, 5)  # TODO: hardcoded!!
+        self.assertEqual(error, ERROR_INVALID_CONFIGURATION)
         self.assertIn("name/ver@jgsogo/test: Invalid configuration: user says that "
                       "compiler.version=12 is invalid", self.client.out)


### PR DESCRIPTION
- [x] (close #3484)
- [x] I've read the [Contributing guide](https://raw.githubusercontent.com/conan-io/conan/develop/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [x] Documented [here](https://docs.conan.io/en/latest/uploading_packages/bintray/conan_center_guide.html#recipe-quality): https://github.com/conan-io/docs/pull/820


The aim of this PR is to implement a ConanInvalidConfiguration exception that the user can raise from the `configure()` function in ConanFile to tell consumers of the recipe that a given set of settings (and options?) is known to fail (and it is ok).

This exception should be propagated across Conan code up to the command caller, letting the caller know about this specific _error_ and handle it. It will be very useful for tools like `conan-package-tools`.

Feedback is needed from experienced frogarians 🐸 as other use cases may be affected:
 - anything related to workspaces?
 - anything related to APIs?
 - somewhere in the graph model?

Let's talk about this