### PR TITLE
reduce propagate complexity from O(n2) to O(n)

### DIFF
--- a/conans/client/installer.py
+++ b/conans/client/installer.py
@@ -394,7 +394,7 @@ class ConanInstaller(object):
         closure = deps_graph.full_closure(node)
         node_order = [n for n in closure.values() if n.binary != BINARY_SKIP]
         # List sort is stable, will keep the original order of the closure, but prioritize levels
-        node_order.sort(lambda n1, n2: cmp(inverse_levels[n1], inverse_levels[n2]))
+        node_order.sort(key=lambda n: inverse_levels[n])
 
         conan_file = node.conanfile
         for n in node_order:

--- a/conans/client/installer.py
+++ b/conans/client/installer.py
@@ -261,7 +261,7 @@ class ConanInstaller(object):
         self._build(nodes_by_level, deps_graph, keep_build, root_node)
 
     def _build(self, nodes_by_level, deps_graph, keep_build, root_node):
-        inverse_levels = deps_graph.inverse_levels()
+        inverse_levels = {n: i for i, level in enumerate(deps_graph.inverse_levels()) for n in level}
 
         processed_package_references = set()
         for level in nodes_by_level:
@@ -389,14 +389,12 @@ class ConanInstaller(object):
         self._recorder.package_built(package_ref)
 
     @staticmethod
-    def _propagate_info(node, levels, deps_graph, out):
+    def _propagate_info(node, inverse_levels, deps_graph, out):
         # Get deps_cpp_info from upstream nodes
         closure = deps_graph.full_closure(node)
-        node_order = []
-        for level in levels:
-            for n in closure.values():
-                if n in level and n.binary != BINARY_SKIP:
-                    node_order.append(n)
+        node_order = [n for n in closure.values() if n.binary != BINARY_SKIP]
+        # List sort is stable, will keep the original order of the closure, but prioritize levels
+        node_order.sort(lambda n1, n2: cmp(inverse_levels[n1], inverse_levels[n2]))
 
         conan_file = node.conanfile
         for n in node_order:


### PR DESCRIPTION
While working on the CI reproducibility, graph locks, etc, I found very slow graph propagation. This PR will highly alleviate it.

Measured, for a linear graph (A->B->C-> .... ->) of 250 nodes, the propagation (computed by ConanInstaller), reduces from 30 to 3 seconds.
