### PR TITLE
fixed duplicated download of manifest and manifest download output

### DIFF
--- a/conans/client/cmd/uploader.py
+++ b/conans/client/cmd/uploader.py
@@ -89,10 +89,12 @@ class CmdUpload(object):
             upload_remote = self._registry.default_remote
 
         if policy != UPLOAD_POLICY_FORCE:
-            self._check_recipe_date(conan_ref, upload_remote)
+            remote_manifest = self._check_recipe_date(conan_ref, upload_remote)
+        else:
+            remote_manifest = None
 
         self._user_io.out.info("Uploading %s to remote '%s'" % (str(conan_ref), upload_remote.name))
-        self._upload_recipe(conan_ref, retry, retry_wait, policy, upload_remote)
+        self._upload_recipe(conan_ref, retry, retry_wait, policy, upload_remote, remote_manifest)
 
         recorder.add_recipe(str(conan_ref), upload_remote.name, upload_remote.url)
 
@@ -113,7 +115,7 @@ class CmdUpload(object):
         if not defined_remote and policy != UPLOAD_POLICY_SKIP:
             self._registry.set_ref(conan_ref, upload_remote.name)
 
-    def _upload_recipe(self, conan_reference, retry, retry_wait, policy, remote):
+    def _upload_recipe(self, conan_reference, retry, retry_wait, policy, remote, remote_manifest):
         conan_file_path = self._client_cache.conanfile(conan_reference)
         current_remote = self._registry.get_recipe_remote(conan_reference)
         if remote != current_remote:
@@ -121,7 +123,7 @@ class CmdUpload(object):
             complete_recipe_sources(self._remote_manager, self._client_cache, self._registry,
                                     conanfile, conan_reference)
         result = self._remote_manager.upload_recipe(conan_reference, remote, retry, retry_wait,
-                                                    policy=policy)
+                                                    policy=policy, remote_manifest=remote_manifest)
         return result
 
     def _upload_package(self, package_ref, index=1, total=1, retry=None, retry_wait=None,
@@ -150,3 +152,5 @@ class CmdUpload(object):
             raise ConanException("Remote recipe is newer than local recipe: "
                                  "\n Remote date: %s\n Local date: %s" %
                                  (remote_recipe_manifest.time, local_manifest.time))
+
+        return remote_recipe_manifest

--- a/conans/client/remote_manager.py
+++ b/conans/client/remote_manager.py
@@ -39,7 +39,7 @@ class RemoteManager(object):
         self._output = output
         self._auth_manager = auth_manager
 
-    def upload_recipe(self, conan_reference, remote, retry, retry_wait, policy=None):
+    def upload_recipe(self, conan_reference, remote, retry, retry_wait, policy, remote_manifest):
         t1 = time.time()
         export_folder = self._client_cache.export(conan_reference)
 
@@ -61,7 +61,7 @@ class RemoteManager(object):
             return None
 
         ret, new_ref = self._call_remote(remote, "upload_recipe", conan_reference, the_files, retry,
-                                         retry_wait, policy)
+                                         retry_wait, policy, remote_manifest)
         duration = time.time() - t1
         log_recipe_upload(new_ref, duration, the_files, remote.name)
         if ret:

--- a/conans/client/rest/auth_manager.py
+++ b/conans/client/rest/auth_manager.py
@@ -125,9 +125,9 @@ class ConanApiAuthManager(object):
     # ######### CONAN API METHODS ##########
 
     @input_credentials_if_unauthorized
-    def upload_recipe(self, conan_reference, the_files, retry, retry_wait, policy):
+    def upload_recipe(self, conan_reference, the_files, retry, retry_wait, policy, remote_manifest):
         return self._rest_client.upload_recipe(conan_reference, the_files, retry, retry_wait,
-                                               policy)
+                                               policy, remote_manifest)
 
     @input_credentials_if_unauthorized
     def upload_package(self, package_reference, the_files, retry, retry_wait, policy):

--- a/conans/client/rest/rest_client.py
+++ b/conans/client/rest/rest_client.py
@@ -52,9 +52,9 @@ class RestApiClient(object):
     def get_path(self, conan_reference, package_id, path):
         return self._get_api().get_path(conan_reference, package_id, path)
 
-    def upload_recipe(self, conan_reference, the_files, retry, retry_wait, no_overwrite):
+    def upload_recipe(self, conan_reference, the_files, retry, retry_wait, policy, remote_manifest):
         return self._get_api().upload_recipe(conan_reference, the_files, retry, retry_wait,
-                                             no_overwrite)
+                                             policy, remote_manifest)
 
     def upload_package(self, package_reference, the_files, retry, retry_wait, no_overwrite):
         return self._get_api().upload_package(package_reference, the_files, retry, retry_wait,

--- a/conans/client/rest/rest_client_v1.py
+++ b/conans/client/rest/rest_client_v1.py
@@ -31,13 +31,13 @@ class RestV1Methods(RestCommonMethods):
     def remote_api_url(self):
         return "%s/v1" % self.remote_url.rstrip("/")
 
-    def _download_files(self, file_urls, output=None):
+    def _download_files(self, file_urls, quiet=False):
         """
         :param: file_urls is a dict with {filename: url}
 
         Its a generator, so it yields elements for memory performance
         """
-        output = self._output if output is None else output
+        output = self._output if not quiet else None
         downloader = Downloader(self.requester, output, self.verify_ssl)
         # Take advantage of filenames ordering, so that conan_package.tgz and conan_export.tgz
         # can be < conanfile, conaninfo, and sent always the last, so smaller files go first
@@ -70,7 +70,7 @@ class RestV1Methods(RestCommonMethods):
         urls = self._get_file_to_url_dict(url)
 
         # Get the digest
-        contents = self._download_files(urls, output=False)
+        contents = self._download_files(urls, quiet=True)
         # Unroll generator and decode shas (plain text)
         contents = {key: decode_text(value) for key, value in dict(contents).items()}
         return FileTreeManifest.loads(contents[CONAN_MANIFEST])
@@ -83,7 +83,7 @@ class RestV1Methods(RestCommonMethods):
         urls = self._get_file_to_url_dict(url)
 
         # Get the digest
-        contents = self._download_files(urls, output=False)
+        contents = self._download_files(urls, quiet=True)
         # Unroll generator and decode shas (plain text)
         contents = {key: decode_text(value) for key, value in dict(contents).items()}
         return FileTreeManifest.loads(contents[CONAN_MANIFEST])

--- a/conans/client/rest/uploader_downloader.py
+++ b/conans/client/rest/uploader_downloader.py
@@ -169,9 +169,10 @@ class Downloader(object):
             if not file_path:
                 ret += response.content
             else:
-                total_length = len(response.content)
-                progress = human_readable_progress(total_length, total_length)
-                print_progress(self.output, 50, progress)
+                if self.output:
+                    total_length = len(response.content)
+                    progress = human_readable_progress(total_length, total_length)
+                    print_progress(self.output, 50, progress)
                 save_append(file_path, response.content)
         else:
             total_length = int(total_length)
@@ -191,13 +192,12 @@ class Downloader(object):
                         ret_buffer.extend(data)
                     if file_handler is not None:
                         file_handler.write(to_file_bytes(data))
-
-                    units = progress_units(download_size, total_length)
-                    progress = human_readable_progress(download_size, total_length)
-                    if last_progress != units:  # Avoid screen refresh if nothing has change
-                        if self.output:
+                    if self.output:
+                        units = progress_units(download_size, total_length)
+                        progress = human_readable_progress(download_size, total_length)
+                        if last_progress != units:  # Avoid screen refresh if nothing has change
                             print_progress(self.output, units, progress)
-                        last_progress = units
+                            last_progress = units
                 return download_size
 
             if file_path:
@@ -243,7 +243,8 @@ def call_with_retry(out, retry, retry_wait, method, *args, **kwargs):
             if counter == (retry - 1):
                 raise
             else:
-                msg = exception_message_safe(exc)
-                out.error(msg)
-                out.info("Waiting %d seconds to retry..." % retry_wait)
+                if out:
+                    msg = exception_message_safe(exc)
+                    out.error(msg)
+                    out.info("Waiting %d seconds to retry..." % retry_wait)
                 time.sleep(retry_wait)

--- a/conans/test/remote/rest_api_test.py
+++ b/conans/test/remote/rest_api_test.py
@@ -281,4 +281,4 @@ class MyConan(ConanFile):
         abs_paths[CONAN_MANIFEST] = os.path.join(tmp_dir, CONAN_MANIFEST)
         conan_digest.save(tmp_dir)
 
-        self.api.upload_recipe(conan_reference, abs_paths, retry, retry_wait, None)
+        self.api.upload_recipe(conan_reference, abs_paths, retry, retry_wait, None, None)


### PR DESCRIPTION
Close #3550

To be checked and discussed.

Changelog: Fix: Avoid downloading the manifest of the recipe twice for uploads. Making this download quiet, without output.
