### PR TITLE
[CI ONLY] Fixed bug using v2

### DIFF
--- a/conans/__init__.py
+++ b/conans/__init__.py
@@ -16,7 +16,7 @@ COMPLEX_SEARCH_CAPABILITY = "complex_search"
 API_V2 = "api_v2"
 CHECKSUM_DEPLOY = "checksum_deploy"  # Only when v2
 REVISIONS = "revisions"  # Only when enabled in config, not by default look at server_launcher.py
-SERVER_CAPABILITIES = [COMPLEX_SEARCH_CAPABILITY, API_V2]
+SERVER_CAPABILITIES = [COMPLEX_SEARCH_CAPABILITY, ]  # Still without v2 because it is changing
 
 __version__ = '1.7.4'
 

--- a/conans/__init__.py
+++ b/conans/__init__.py
@@ -18,5 +18,5 @@ CHECKSUM_DEPLOY = "checksum_deploy"  # Only when v2
 REVISIONS = "revisions"  # Only when enabled in config, not by default look at server_launcher.py
 SERVER_CAPABILITIES = [COMPLEX_SEARCH_CAPABILITY, API_V2]
 
-__version__ = '1.7.3'
+__version__ = '1.7.4'
 

--- a/conans/server/rest/controllers/v2/conan_controller.py
+++ b/conans/server/rest/controllers/v2/conan_controller.py
@@ -35,6 +35,7 @@ class ConanControllerV2(Controller):
             file_generator = conan_service.get_package_file(package_reference, the_path, auth_user)
             return file_generator
 
+        @app.route(r.package_file, method=["PUT"])
         @app.route(r.package_revision_file, method=["PUT"])
         def upload_package_file(name, version, username, channel, package_id,
                                 the_path, auth_user, revision=None, p_revision=None):
@@ -61,6 +62,7 @@ class ConanControllerV2(Controller):
             file_generator = conan_service.get_conanfile_file(reference, the_path, auth_user)
             return file_generator
 
+        @app.route(r.recipe_file, method=["PUT"])
         @app.route(r.recipe_revision_file, method=["PUT"])
         def upload_recipe_file(name, version, username, channel, the_path, auth_user,
                                revision=None):


### PR DESCRIPTION
- There was a bug in the v2 of the server released in the 1.7.3
The bug only shows up within a client speaking v2 (1.8.0).
- Removed v2 capability from server until v2 is mature to not causing backward compatibilities with modern clients speaking with old servers