### PR TITLE
Adding support for the runtime for Android - #2856

### DIFF
--- a/conans/client/build/cmake.py
+++ b/conans/client/build/cmake.py
@@ -157,6 +157,7 @@ class CMake(object):
                                                     source_dir, build_dir,
                                                     cache_build_folder)
         mkdir(self.build_dir)
+
         arg_list = join_arguments([
             self.command_line,
             args_to_string(args),
@@ -182,6 +183,8 @@ class CMake(object):
                     self._conanfile.run(command)
             else:
                 self._conanfile.run(command)
+
+        pass
 
     def build(self, args=None, build_dir=None, target=None):
         if not self._conanfile.should_build:

--- a/conans/client/build/cmake_flags.py
+++ b/conans/client/build/cmake_flags.py
@@ -210,6 +210,14 @@ class CMakeDefinitionsBuilder(object):
                 if arch_abi_settings:
                     ret["CMAKE_ANDROID_ARCH_ABI"] = arch_abi_settings
 
+                # Raffi this is needed only when compiling from the NDK
+                stl_type = {'libc++_shared': 'c++_shared',
+                            'libc++_static': 'c++_static',
+                            'libstdc++': 'gnustl_shared',
+                            'libstdc++11': 'gnustl_shared',
+                            }.get(self._ss("compiler.libcxx"), "c++_shared")
+                ret["CMAKE_ANDROID_STL_TYPE"] = stl_type
+
         logger.info("Setting Cross build flags: %s"
                     % ", ".join(["%s=%s" % (k, v) for k, v in ret.items()]))
         return ret

--- a/conans/client/build/cppstd_flags.py
+++ b/conans/client/build/cppstd_flags.py
@@ -15,6 +15,7 @@ def cppstd_flag(compiler, compiler_version, cppstd):
         return ""
     func = {"gcc": _cppstd_gcc,
             "clang": _cppstd_clang,
+            "android-clang": _cppstd_android_clang,
             "apple-clang": _cppstd_apple_clang,
             "Visual Studio": _cppstd_visualstudio}.get(str(compiler), None)
     flag = None
@@ -26,6 +27,7 @@ def cppstd_flag(compiler, compiler_version, cppstd):
 def cppstd_default(compiler, compiler_version):
     default = {"gcc": _gcc_cppstd_default(compiler_version),
                "clang": _clang_cppstd_default(compiler_version),
+               "android-clang": _clang_cppstd_default(compiler_version), # same as for default clang
                "apple-clang": "gnu98",  # Confirmed in apple-clang 9.1 with a simple "auto i=1;"
                "Visual Studio": _visual_cppstd_default(compiler_version)}.get(str(compiler), None)
     return default
@@ -147,6 +149,10 @@ def _cppstd_clang(clang_version, cppstd):
             "17": v17, "gnu17": vgnu17,
             "20": v20, "gnu20": vgnu20}.get(cppstd, None)
     return "-std=%s" % flag if flag else None
+
+
+def _cppstd_android_clang(clang_version, cppstd):
+    return "-std=libc++_shared"
 
 
 def _cppstd_gcc(gcc_version, cppstd):

--- a/conans/client/conf/__init__.py
+++ b/conans/client/conf/__init__.py
@@ -69,6 +69,9 @@ compiler:
     clang:
         version: ["3.3", "3.4", "3.5", "3.6", "3.7", "3.8", "3.9", "4.0", "5.0", "6.0", "7.0"]
         libcxx: [libstdc++, libstdc++11, libc++]
+    android-clang:
+        version: ["3.3", "3.4", "3.5", "3.6", "3.7", "3.8", "3.9", "4.0", "5.0", "6.0", "7.0"]
+        libcxx: [libstdc++, libstdc++11, libc++_shared, libc++_static]
     apple-clang:
         version: ["5.0", "5.1", "6.0", "6.1", "7.0", "7.3", "8.0", "8.1", "9.0", "9.1", "10.0"]
         libcxx: [libstdc++, libc++]

--- a/conans/client/conf/detect.py
+++ b/conans/client/conf/detect.py
@@ -59,6 +59,8 @@ def _clang_compiler(output, compiler_exe="clang"):
             return None
         if "Apple" in out:
             compiler = "apple-clang"
+        if "Android" in out:
+            compiler = "android-clang"
         elif "clang version" in out:
             compiler = "clang"
         installed_version = re.search("([0-9]+\.[0-9])", out).group()
@@ -202,6 +204,8 @@ def _detect_compiler_version(result, output):
         result.append(("compiler.version", version))
         if compiler == "apple-clang":
             result.append(("compiler.libcxx", "libc++"))
+        elif compiler == "android-clang":
+            result.append(("compiler.libcxx", "libc++_shared"))
         elif compiler == "gcc":
             result.append(("compiler.libcxx", "libstdc++"))
             if Version(version) >= Version("5.1"):

--- a/conans/client/generators/cmake_common.py
+++ b/conans/client/generators/cmake_common.py
@@ -208,11 +208,20 @@ endfunction()
 macro(conan_set_libcxx)
     if(DEFINED CONAN_LIBCXX)
         message(STATUS "Conan: C++ stdlib: ${CONAN_LIBCXX}")
-        if(CONAN_COMPILER STREQUAL "clang" OR CONAN_COMPILER STREQUAL "apple-clang")
+        if(CONAN_COMPILER STREQUAL "clang" 
+           OR CONAN_COMPILER STREQUAL "apple-clang")
             if(CONAN_LIBCXX STREQUAL "libstdc++" OR CONAN_LIBCXX STREQUAL "libstdc++11" )
                 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -stdlib=libstdc++")
             elseif(CONAN_LIBCXX STREQUAL "libc++")
                 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -stdlib=libc++")
+            endif()
+        elseif(CONAN_COMPILER STREQUAL "android-clang")
+            if(CONAN_LIBCXX STREQUAL "c++_shared")
+                set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -stdlib=libc++_shared")
+            elseif(CONAN_LIBCXX STREQUAL "c++_static")
+                set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -stdlib=libc++_static")
+            elseif(CONAN_LIBCXX STREQUAL "libstdc++" OR CONAN_LIBCXX STREQUAL "libstdc++11" )
+                set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -stdlib=libstdc++")
             endif()
         endif()
         if(CONAN_COMPILER STREQUAL "sun-cc")
@@ -427,6 +436,7 @@ function(conan_check_compiler)
     # Actually CMake is detecting "clang" when you are using apple-clang, only if CMP0025 is set to NEW will detect apple-clang
     elseif((CONAN_COMPILER STREQUAL "gcc" AND NOT CMAKE_CXX_COMPILER_ID MATCHES "GNU") OR
         (CONAN_COMPILER STREQUAL "apple-clang" AND NOT CROSS_BUILDING AND (NOT APPLE OR NOT CMAKE_CXX_COMPILER_ID MATCHES "Clang")) OR
+        (CONAN_COMPILER STREQUAL "android-clang" AND NOT CMAKE_CXX_COMPILER_ID MATCHES "Clang") OR
         (CONAN_COMPILER STREQUAL "clang" AND NOT CMAKE_CXX_COMPILER_ID MATCHES "Clang") OR
         (CONAN_COMPILER STREQUAL "sun-cc" AND NOT CMAKE_CXX_COMPILER_ID MATCHES "SunPro") )
         message(FATAL_ERROR "Incorrect '${CONAN_COMPILER}', is not the one detected by CMake: '${CMAKE_CXX_COMPILER_ID}'")

--- a/conans/model/settings.py
+++ b/conans/model/settings.py
@@ -31,6 +31,7 @@ class SettingsItem(object):
     - A dict {subsetting: definition}, e.g. {version: [], runtime: []} for VS
     """
     def __init__(self, definition, name):
+
         self._name = name  # settings.compiler
         self._value = None  # gcc
         if isinstance(definition, dict):
@@ -191,6 +192,7 @@ class SettingsItem(object):
 
 class Settings(object):
     def __init__(self, definition=None, name="settings", parent_value=None):
+
         if parent_value == "None" and definition:
             raise ConanException("settings.yml: None setting can't have subsettings")
         definition = definition or {}

--- a/conans/test/build_helpers/compiler_flags_test.py
+++ b/conans/test/build_helpers/compiler_flags_test.py
@@ -61,6 +61,9 @@ class CompilerFlagsTest(unittest.TestCase):
         arch_flags = libcxx_flag(compiler='apple-clang', libcxx='libc++')
         self.assertEquals(arch_flags, '-stdlib=libc++')
 
+        arch_flags = libcxx_flag(compiler='android-clang', libcxx='libc++')
+        self.assertEquals(arch_flags, '-stdlib=libc++_shared')
+
         arch_flags = libcxx_flag(compiler='Visual Studio', libcxx=None)
         self.assertEquals(arch_flags, "")
 

--- a/conans/test/generators/compiler_args_test.py
+++ b/conans/test/generators/compiler_args_test.py
@@ -113,3 +113,17 @@ class CompilerArgsTest(unittest.TestCase):
         self.assertEquals('-Dmydefine1 -Ipath/to/include1 cxx_flag1 c_flag1 -m32 -O3 -DNDEBUG '
                           '-Wl,-rpath,"path/to/lib1" '
                           '-Lpath/to/lib1 -lmylib', args.content)
+
+        settings = Settings.loads(default_settings_yml)
+        settings.os = "Linux"
+        settings.os_build = "Android"
+        settings.compiler = "android-clang"
+        settings.compiler.version = "6.0"
+        settings.arch = "armv7"
+        settings.build_type = "Release"
+
+        conan_file = self._get_conanfile(settings)
+        args = CompilerArgsGenerator(conan_file)
+        self.assertEquals('-Dmydefine1 -Ipath/to/include1 cxx_flag1 c_flag1 -m32 -O3 -DNDEBUG '
+                          '-Wl,-rpath,"path/to/lib1" '
+                          '-Lpath/to/lib1 -lmylib', args.content)

--- a/conans/test/model/other_settings_test.py
+++ b/conans/test/model/other_settings_test.py
@@ -100,6 +100,9 @@ compiler:
     clang:
         version: ["3.3", "3.4", "3.5", "3.6", "3.7", "3.8"]
         libcxx: [libstdc++, libstdc++11, libc++]
+    android-clang:
+        version: ["3.3", "3.4", "3.5", "3.6", "3.7", "3.8"]
+        libcxx: [libc++_shared, libc++_static]
     apple-clang:
         version: ["5.0", "5.1", "6.0", "6.1", "7.0", "7.1", "7.2", "7.3", "8.0", "8.1"]
         libcxx: [libstdc++, libc++]


### PR DESCRIPTION
- [x] Refer to the issue that supports this Pull Request.
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://raw.githubusercontent.com/conan-io/conan/develop/.github/CONTRIBUTING.md).
- [ ] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. Also adding a description of the changes in the ``changelog.rst`` file. https://github.com/conan-io/docs

Hi,

This is a first step for addressing #2856. 

The PR needs to be polished a bit, but this is mainly for asking directions to solve the issue. 

I believe the right way to address the capability of the toolchain to handle several STL is to add an `android-clang` that supports several STLs and C++ runtimes. 

I tried to add a new 'runtime' for clang without luck, as currently only Windows handle this.

The current state is that the `-stdlib=libc++_static` or `-stdlib=libc++_shared` is properly passed to the compiler, and inspecting the ELF part of the generated shared libraries properly states the static/shared version of the Android `libc++`.

Again, the PR is WIP, I am happy to gather your feedback before going further.

