### PR TITLE
- new helper : fill_cppinfo_from_pc_file

### DIFF
--- a/conans/client/tools/pkg_config.py
+++ b/conans/client/tools/pkg_config.py
@@ -98,3 +98,14 @@ class PkgConfig(object):
             for name in variable_names:
                 self._variables[name] = self._parse_output('variable=%s' % name)
         return self._variables
+
+
+def fill_cppinfo_from_pc_file(conanfile, library, pkg_config_executable='pkg-config', static=False, msvc_syntax=False,
+                              variables=None, print_errors=True):
+    pkg_config = PkgConfig(library, pkg_config_executable, static, msvc_syntax, variables, print_errors)
+    libs = [lib[2:] for lib in pkg_config.libs_only_l]  # cut -l prefix
+    lib_paths = [lib[2:] for lib in pkg_config.libs_only_L]  # cut -L prefix
+    conanfile.cpp_info.libs.extend(libs)
+    conanfile.cpp_info.libdirs.extend(lib_paths)
+    conanfile.cpp_info.sharedlinkflags.extend(pkg_config.libs_only_other)
+    conanfile.cpp_info.exelinkflags.extend(pkg_config.libs_only_other)

--- a/conans/test/utils/conanfile.py
+++ b/conans/test/utils/conanfile.py
@@ -14,23 +14,39 @@ class MockSettings(object):
 MockOptions = MockSettings
 
 
-class MockDepsCppInfo(object):
+class MockCppInfo(object):
 
     def __init__(self):
-        self.include_paths = []
-        self.lib_paths = []
+        self.includedirs = []
+        self.libdirs = []
+        self.resdirs = []
+        self.bindirs = []
+        self.builddirs = []
         self.libs = []
         self.defines = []
         self.cflags = []
         self.cppflags = []
         self.sharedlinkflags = []
         self.exelinkflags = []
+        self.rootpath = ""
         self.sysroot = ""
+
+
+class MockDepsCppInfo(MockCppInfo):
+
+    def __init__(self):
+        super(MockDepsCppInfo, self).__init__()
+        self.include_paths = []
+        self.lib_paths = []
+        self.bin_paths = []
+        self.build_paths = []
+        self.res_paths = []
 
 
 class MockConanfile(ConanFile):
 
     def __init__(self, settings, options=None, runner=None):
+        self.cpp_info = MockCppInfo()
         self.deps_cpp_info = MockDepsCppInfo()
         self.settings = settings
         self.runner = runner


### PR DESCRIPTION
Signed-off-by: SSE4 <tomskside@gmail.com>

I find it useful to extract `add_libraries_from_pc` helper, as it's currently used in various recipes already (e.g. OpenCV, SDL2, ffmpeg, libcurl, etc). it basically adds flags from pkg-config into `self.cpp_info`.

- [x] Refer to the issue that supports this Pull Request.
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://raw.githubusercontent.com/conan-io/conan/develop/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. Also adding a description of the changes in the ``changelog.rst`` file. https://github.com/conan-io/docs
