### PR TITLE
- use forward slashes for short paths

### DIFF
--- a/conans/util/windows.py
+++ b/conans/util/windows.py
@@ -51,7 +51,7 @@ def path_shortener(path, short_paths):
     short_home = os.getenv("CONAN_USER_HOME_SHORT")
     if not short_home:
         drive = os.path.splitdrive(path)[0]
-        short_home = drive + "/.conan"
+        short_home = os.path.join(drive, os.sep, ".conan")
     mkdir(short_home)
 
     # Workaround for short_home living in NTFS file systems. Give full control permission to current user to avoid


### PR DESCRIPTION
Signed-off-by: SSE4 <tomskside@gmail.com>

it's just much more convenient to use `C:\.conan\2xez1sh5\1` instead of `C:/.conan\2xez1sh5\1`, such paths can be easily copied and opened everywhere on Windows

- [x] Refer to the issue that supports this Pull Request.
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://raw.githubusercontent.com/conan-io/conan/develop/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. Also adding a description of the changes in the ``changelog.rst`` file. https://github.com/conan-io/docs
