### PR TITLE
- fix PowerPC architecture detection

### DIFF
--- a/conans/client/tools/oss.py
+++ b/conans/client/tools/oss.py
@@ -35,7 +35,21 @@ def cpu_count():
 def detected_architecture():
     # FIXME: Very weak check but not very common to run conan in other architectures
     machine = platform.machine()
-    if "64" in machine:
+    if "ppc64le" in machine:
+        return "ppc64le"
+    elif "ppc64" in machine:
+        return "ppc64"
+    elif "mips64" in machine:
+        return "mips64"
+    elif "mips" in machine:
+        return "mips"
+    elif "sparc64" in machine:
+        return "sparcv9"
+    elif "sparc" in machine:
+        return "sparc"
+    elif "aarch64" in machine:
+        return "armv8"
+    elif "64" in machine:
         return "x86_64"
     elif "86" in machine:
         return "x86"
@@ -43,6 +57,8 @@ def detected_architecture():
         return "armv8"
     elif "armv7" in machine:
         return "armv7"
+    elif "arm" in machine:
+        return "armv6"
 
     return None
 

--- a/conans/test/util/detected_architecture_test.py
+++ b/conans/test/util/detected_architecture_test.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+# vim: tabstop=8 expandtab shiftwidth=4 softtabstop=4
+
+
+import unittest
+from mock import mock
+from conans.tools import detected_architecture
+
+
+class DetectedArchitectureTest(unittest.TestCase):
+
+    def test_various(self):
+
+        # x86
+        with mock.patch("platform.machine", mock.MagicMock(return_value='i386')):
+            self.assertEqual('x86', detected_architecture())
+
+        with mock.patch("platform.machine", mock.MagicMock(return_value='i686')):
+            self.assertEqual('x86', detected_architecture())
+
+        with mock.patch("platform.machine", mock.MagicMock(return_value='x86_64')):
+            self.assertEqual('x86_64', detected_architecture())
+
+        with mock.patch("platform.machine", mock.MagicMock(return_value='amd64')):
+            self.assertEqual('x86_64', detected_architecture())
+
+        # ARM
+        with mock.patch("platform.machine", mock.MagicMock(return_value='aarch64_be')):
+            self.assertEqual('armv8', detected_architecture())
+
+        with mock.patch("platform.machine", mock.MagicMock(return_value='armv8b')):
+            self.assertEqual('armv8', detected_architecture())
+
+        with mock.patch("platform.machine", mock.MagicMock(return_value='armv7l')):
+            self.assertEqual('armv7', detected_architecture())
+
+        with mock.patch("platform.machine", mock.MagicMock(return_value='armv6l')):
+            self.assertEqual('armv6', detected_architecture())
+
+        with mock.patch("platform.machine", mock.MagicMock(return_value='arm')):
+            self.assertEqual('armv6', detected_architecture())
+
+        # PowerPC
+        with mock.patch("platform.machine", mock.MagicMock(return_value='ppc64le')):
+            self.assertEqual('ppc64le', detected_architecture())
+
+        with mock.patch("platform.machine", mock.MagicMock(return_value='ppc64')):
+            self.assertEqual('ppc64', detected_architecture())
+
+        # MIPS
+        with mock.patch("platform.machine", mock.MagicMock(return_value='mips')):
+            self.assertEqual('mips', detected_architecture())
+
+        with mock.patch("platform.machine", mock.MagicMock(return_value='mips64')):
+            self.assertEqual('mips64', detected_architecture())
+
+        # SPARC
+        with mock.patch("platform.machine", mock.MagicMock(return_value='sparc')):
+            self.assertEqual('sparc', detected_architecture())
+
+        with mock.patch("platform.machine", mock.MagicMock(return_value='sparc64')):
+            self.assertEqual('sparcv9', detected_architecture())


### PR DESCRIPTION
Signed-off-by: SSE4 <tomskside@gmail.com>

related to the https://github.com/bincrafters/community/issues/443
properly detects ppc64le architecture and few others
based on python's `platform.machine()`, which actually uses `uname` under the hood
tested on PowerPC VM
see also

1. https://stackoverflow.com/questions/45125516/possible-values-for-uname-m
2. https://en.wikipedia.org/wiki/Uname
3. https://github.com/gcc-mirror/gcc/blob/master/config.guess

- [x] Refer to the issue that supports this Pull Request.
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://raw.githubusercontent.com/conan-io/conan/develop/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. Also adding a description of the changes in the ``changelog.rst`` file. https://github.com/conan-io/docs
