### PR TITLE
[bug] Modify behaviour of SystemPackageTool

### DIFF
--- a/conans/client/tools/system_pm.py
+++ b/conans/client/tools/system_pm.py
@@ -100,24 +100,19 @@ class SystemPackageTool(object):
         self._install_any(packages)
 
     def _installed(self, packages):
-        if not packages:
-            return True
-
-        for pkg in packages:
-            if self._tool.installed(pkg):
-                _global_output.info("Package already installed: %s" % pkg)
-                return True
-        return False
+        return all([self._tool.installed(pkg) for pkg in packages])
 
     def _install_any(self, packages):
-        if len(packages) == 1:
-            return self._tool.install(packages[0])
-        for pkg in packages:
+        def try_install(pck):
             try:
-                return self._tool.install(pkg)
+                self._tool.install(pck)
+                return True
             except ConanException:
-                pass
-        raise ConanException("Could not install any of %s" % packages)
+                return False
+
+        any_success = any([try_install(pck) for pck in packages])
+        if not any_success:
+            raise ConanException("Could not install any of '{}'".format("', '".join(packages)))
 
 
 class NullTool(object):

--- a/conans/test/util/tools_test.py
+++ b/conans/test/util/tools_test.py
@@ -266,7 +266,7 @@ class SystemPackageToolTest(unittest.TestCase):
                 self.assertEquals(runner.command_called,
                                   'choco search --local-only --exact a_package | findstr /c:"1 packages installed."')
 
-    def system_package_tool_try_multiple_test(self):
+    def test_system_package_tool_try_multiple_test(self):
         class RunnerMultipleMock(object):
             def __init__(self, expected=None):
                 self.calls = 0
@@ -278,10 +278,11 @@ class SystemPackageToolTest(unittest.TestCase):
 
         packages = ["a_package", "another_package", "yet_another_package"]
         with tools.environment_append({"CONAN_SYSREQUIRES_SUDO": "True"}):
-            runner = RunnerMultipleMock(["dpkg -s another_package"])
+            runner = RunnerMultipleMock(["dpkg -s another_package", "dpkg -s a_package",
+                                         "dpkg -s yet_another_package"])
             spt = SystemPackageTool(runner=runner, tool=AptTool())
             spt.install(packages)
-            self.assertEquals(2, runner.calls)
+            self.assertEquals(3, runner.calls)
             runner = RunnerMultipleMock(["sudo apt-get update",
                                          "sudo apt-get install -y --no-install-recommends yet_another_package"])
             spt = SystemPackageTool(runner=runner, tool=AptTool())


### PR DESCRIPTION
I'm almost sure that this is a bug

This PR modifies the behavior of `SystemPackageTool::_installed` function, so it only returns `True` if all the packages are already installed (before it was returning True as long as one of them was installed).

It also modifies `SystemPackageTool::_install_any` a little bit: it will succeed if no `packages` are given instead of raising an exception with an incomplete message.
