### PR TITLE
Collapse all RunnerMocks into only one: RunnerOrderedMock

### DIFF
--- a/conans/client/tools/system_pm.py
+++ b/conans/client/tools/system_pm.py
@@ -100,19 +100,24 @@ class SystemPackageTool(object):
         self._install_any(packages)
 
     def _installed(self, packages):
-        return all([self._tool.installed(pkg) for pkg in packages])
+        if not packages:
+            return True
+
+        for pkg in packages:
+            if self._tool.installed(pkg):
+                _global_output.info("Package already installed: %s" % pkg)
+                return True
+        return False
 
     def _install_any(self, packages):
-        def try_install(pck):
+        if len(packages) == 1:
+            return self._tool.install(packages[0])
+        for pkg in packages:
             try:
-                self._tool.install(pck)
-                return True
+                return self._tool.install(pkg)
             except ConanException:
-                return False
-
-        any_success = any([try_install(pck) for pck in packages])
-        if not any_success:
-            raise ConanException("Could not install any of '{}'".format("', '".join(packages)))
+                pass
+        raise ConanException("Could not install any of %s" % packages)
 
 
 class NullTool(object):

--- a/conans/test/build_helpers/autotools_configure_test.py
+++ b/conans/test/build_helpers/autotools_configure_test.py
@@ -454,7 +454,7 @@ class HelloConan(ConanFile):
         self.assertFalse(ab.host)
         self.assertFalse(ab.target)
 
-        runner.commands.append(("./configure  ", 0))  # TODO: Blanks at he end?
+        runner.commands.append(("./configure  ", 0))
         ab.configure()
 
         runner.commands.append(("./configure  --host=x86_64-apple-darwin", 0))
@@ -474,8 +474,7 @@ class HelloConan(ConanFile):
                                   None, runner)
         ab = AutoToolsBuildEnvironment(conanfile)
         if platform.system() == "Windows":
-            runner.commands.append(("./configure  --build=x86_64-apple-darwin "
-                                    "--host=x86_64-w64-mingw32", 0))
+            runner.commands.append(("./configure  ", 0))
         elif platform.system() == "Linux":
             runner.commands.append(("./configure  --build=x86_64-linux-gnu "
                                     "--host=x86_64-w64-mingw32", 0))
@@ -523,7 +522,7 @@ class HelloConan(ConanFile):
         conanfile.package_folder = "/package_folder"
         if platform.system() == "Windows":
             runner.commands.append(
-                ("./configure --prefix=/package_folder --libdir=${prefix}/lib", 0))
+                ("./configure --prefix=/package_folder --libdir=${prefix}/lib ", 0))
         else:
             runner.commands.append(
                 ("./configure '--prefix=/package_folder' '--libdir=${prefix}/lib' ", 0))
@@ -532,7 +531,7 @@ class HelloConan(ConanFile):
         # --prefix already used in args
         if platform.system() == "Windows":
             runner.commands.append(
-                ("./configure --prefix=/my_package_folder --libdir=${prefix}/lib", 0))
+                ("./configure --prefix=/my_package_folder --libdir=${prefix}/lib ", 0))
         else:
             runner.commands.append(
                 ("./configure '--prefix=/my_package_folder' '--libdir=${prefix}/lib' ", 0))
@@ -541,7 +540,7 @@ class HelloConan(ConanFile):
         # --libdir already used in args
         if platform.system() == "Windows":
             runner.commands.append(
-                ("./configure --libdir=/my_package_folder/superlibdir --prefix=/package_folder", 0))
+                ("./configure --libdir=/my_package_folder/superlibdir --prefix=/package_folder ", 0))
         else:
             runner.commands.append(
                 ("./configure '--libdir=/my_package_folder/superlibdir' "

--- a/conans/test/build_helpers/autotools_configure_test.py
+++ b/conans/test/build_helpers/autotools_configure_test.py
@@ -10,7 +10,7 @@ from conans.model.ref import ConanFileReference
 from conans.model.settings import Settings
 from conans.paths import CONANFILE
 from conans.test.build_helpers.cmake_test import ConanFileMock
-from conans.test.util.tools_test import RunnerMock
+from conans.test.utils.runner_mock import RunnerMock
 from conans.test.utils.conanfile import MockConanfile, MockSettings, MockOptions
 from conans.test.utils.tools import TestClient
 

--- a/conans/test/build_helpers/autotools_configure_test.py
+++ b/conans/test/build_helpers/autotools_configure_test.py
@@ -513,12 +513,11 @@ class HelloConan(ConanFile):
     def autotools_prefix_libdir_test(self):
         runner = RunnerOrderedMock(self)
         conanfile = MockConanfile(MockSettings({}), None, runner)
+
         # Package folder is not defined
         runner.commands.append(("./configure  ", 0))
         ab = AutoToolsBuildEnvironment(conanfile)
         ab.configure()
-        # self.assertNotIn("--prefix", runner.command_called)
-        # self.assertNotIn("--libdir", runner.command_called)
 
         # package folder defined
         conanfile.package_folder = "/package_folder"

--- a/conans/test/util/tools_test.py
+++ b/conans/test/util/tools_test.py
@@ -299,15 +299,6 @@ class SystemPackageToolTest(unittest.TestCase):
         Allowed values: (enabled, verify, disabled). Parser accepts it in lower/upper case or any combination.
         """
 
-        class RunnerMultipleMock(object):
-            def __init__(self, expected=None):
-                self.calls = 0
-                self.expected = expected
-
-            def __call__(self, command, *args, **kwargs):  # @UnusedVariable
-                self.calls += 1
-                return 0 if command in self.expected else 1
-
         packages = ["a_package", "another_package", "yet_another_package"]
 
         # Check invalid mode raises ConanException
@@ -315,12 +306,12 @@ class SystemPackageToolTest(unittest.TestCase):
             "CONAN_SYSREQUIRES_MODE": "test_not_valid_mode",
             "CONAN_SYSREQUIRES_SUDO": "True"
         }):
-            runner = RunnerMultipleMock([])
+            runner = RunnerOrderedMock(self)
             spt = SystemPackageTool(runner=runner, tool=AptTool())
             with self.assertRaises(ConanException) as exc:
                 spt.install(packages)
             self.assertIn("CONAN_SYSREQUIRES_MODE=test_not_valid_mode is not allowed", str(exc.exception))
-            self.assertEquals(0, runner.calls)
+            self.assertTrue(runner.is_empty())
 
         # Check verify mode, a package report should be displayed in output and ConanException raised.
         # No system packages are installed
@@ -329,13 +320,15 @@ class SystemPackageToolTest(unittest.TestCase):
             "CONAN_SYSREQUIRES_SUDO": "True"
         }):
             packages = ["verify_package", "verify_another_package", "verify_yet_another_package"]
-            runner = RunnerMultipleMock(["sudo apt-get update"])
+            runner = RunnerOrderedMock(self)
+            for pck in packages:
+                runner.commands.append(("dpkg -s {}".format(pck), 1))
             spt = SystemPackageTool(runner=runner, tool=AptTool())
             with self.assertRaises(ConanException) as exc:
                 spt.install(packages)
             self.assertIn("Aborted due to CONAN_SYSREQUIRES_MODE=", str(exc.exception))
             self.assertIn('\n'.join(packages), tools.system_pm._global_output)
-            self.assertEquals(3, runner.calls)
+            self.assertTrue(runner.is_empty())
 
         # Check disabled mode, a package report should be displayed in output.
         # No system packages are installed
@@ -344,23 +337,29 @@ class SystemPackageToolTest(unittest.TestCase):
             "CONAN_SYSREQUIRES_SUDO": "True"
         }):
             packages = ["disabled_package", "disabled_another_package", "disabled_yet_another_package"]
-            runner = RunnerMultipleMock(["sudo apt-get update"])
+            runner = RunnerOrderedMock(self)
             spt = SystemPackageTool(runner=runner, tool=AptTool())
             spt.install(packages)
             self.assertIn('\n'.join(packages), tools.system_pm._global_output)
-            self.assertEquals(0, runner.calls)
+            self.assertTrue(runner.is_empty())
 
         # Check enabled, default mode, system packages must be installed.
         with tools.environment_append({
             "CONAN_SYSREQUIRES_MODE": "EnAbLeD",
             "CONAN_SYSREQUIRES_SUDO": "True"
         }):
-            runner = RunnerMultipleMock(["sudo apt-get update"])
+            runner = RunnerOrderedMock(self)
+            for pck in packages:
+                runner.commands.append(("dpkg -s {}".format(pck), 1))
+            runner.commands.append(("sudo apt-get update", 0))
+            for pck in packages:
+                runner.commands.append(("sudo apt-get install -y --no-install-recommends {"
+                                        "}".format(pck), 1))
             spt = SystemPackageTool(runner=runner, tool=AptTool())
             with self.assertRaises(ConanException) as exc:
                 spt.install(packages)
             self.assertNotIn("CONAN_SYSREQUIRES_MODE", str(exc.exception))
-            self.assertEquals(7, runner.calls)
+            self.assertTrue(runner.is_empty())
 
     def system_package_tool_installed_test(self):
         if platform.system() != "Linux" and platform.system() != "Macos" and platform.system() != "Windows":

--- a/conans/test/util/tools_test.py
+++ b/conans/test/util/tools_test.py
@@ -24,7 +24,7 @@ from conans.errors import ConanException, NotFoundException
 from conans.model.settings import Settings
 
 from conans.test.utils.runner import TestRunner
-from conans.test.utils.runner_mock import RunnerMock, RunnerOrderedMock
+from conans.test.utils.runner_mock import RunnerOrderedMock
 from conans.test.utils.test_files import temp_folder
 from conans.test.utils.tools import TestClient, TestBufferConanOutput, create_local_git_repo, \
     StoppableThreadBottle

--- a/conans/test/util/tools_test.py
+++ b/conans/test/util/tools_test.py
@@ -24,7 +24,7 @@ from conans.errors import ConanException, NotFoundException
 from conans.model.settings import Settings
 
 from conans.test.utils.runner import TestRunner
-from conans.test.utils.runner_mock import RunnerMock, RunnerOrderedMock
+from conans.test.utils.runner_mock import RunnerMock, RunnerOrderedMock, RunnerMultipleMock
 from conans.test.utils.test_files import temp_folder
 from conans.test.utils.tools import TestClient, TestBufferConanOutput, create_local_git_repo, \
     StoppableThreadBottle
@@ -258,15 +258,6 @@ class SystemPackageToolTest(unittest.TestCase):
                                   'choco search --local-only --exact a_package | findstr /c:"1 packages installed."')
 
     def system_package_tool_try_multiple_test(self):
-        class RunnerMultipleMock(object):
-            def __init__(self, expected=None):
-                self.calls = 0
-                self.expected = expected
-
-            def __call__(self, command, output):  # @UnusedVariable
-                self.calls += 1
-                return 0 if command in self.expected else 1
-
         packages = ["a_package", "another_package", "yet_another_package"]
         with tools.environment_append({"CONAN_SYSREQUIRES_SUDO": "True"}):
             runner = RunnerMultipleMock(["dpkg -s another_package"])

--- a/conans/test/util/tools_test.py
+++ b/conans/test/util/tools_test.py
@@ -219,8 +219,7 @@ class SystemPackageToolTest(unittest.TestCase):
         with tools.environment_append({"CONAN_SYSREQUIRES_SUDO": "True"}):
             # All packages are install (cmd call returns 0)
             runner = RunnerOrderedMock(self)
-            for pck in packages:
-                runner.commands.append(("dpkg -s {}".format(pck), 0))
+            runner.commands.append(("dpkg -s a_package", 0))
             spt = SystemPackageTool(runner=runner, tool=AptTool())
             spt.install(packages)
             self.assertTrue(runner.is_empty())
@@ -230,9 +229,7 @@ class SystemPackageToolTest(unittest.TestCase):
             for pck in packages:
                 runner.commands.append(("dpkg -s {}".format(pck), 1))
             runner.commands.append(("sudo apt-get update", 0))
-            for pck in packages:
-                runner.commands.append(("sudo apt-get install -y --no-install-recommends %s" %
-                                        pck, 0))
+            runner.commands.append(("sudo apt-get install -y --no-install-recommends a_package", 0))
             spt = SystemPackageTool(runner=runner, tool=AptTool())
             spt.install(packages)
             self.assertTrue(runner.is_empty())

--- a/conans/test/util/tools_test.py
+++ b/conans/test/util/tools_test.py
@@ -217,14 +217,14 @@ class SystemPackageToolTest(unittest.TestCase):
     def system_package_tool_try_multiple_test(self):
         packages = ["a_package", "another_package", "yet_another_package"]
         with tools.environment_append({"CONAN_SYSREQUIRES_SUDO": "True"}):
-            # All packages are install (cmd call returns 0)
+            # One package is installed (cmd call returns 0)
             runner = RunnerOrderedMock(self)
             runner.commands.append(("dpkg -s a_package", 0))
             spt = SystemPackageTool(runner=runner, tool=AptTool())
             spt.install(packages)
             self.assertTrue(runner.is_empty())
 
-            # None is installed (cmd call returns 0)
+            # None is installed (cmd call returns 1)
             runner = RunnerOrderedMock(self)
             for pck in packages:
                 runner.commands.append(("dpkg -s {}".format(pck), 1))
@@ -234,7 +234,7 @@ class SystemPackageToolTest(unittest.TestCase):
             spt.install(packages)
             self.assertTrue(runner.is_empty())
 
-            # Fails to install any
+            # Fails to install any of them
             runner = RunnerOrderedMock(self)
             for pck in packages:
                 runner.commands.append(("dpkg -s {}".format(pck), 1))

--- a/conans/test/util/tools_test.py
+++ b/conans/test/util/tools_test.py
@@ -203,7 +203,7 @@ class SystemPackageToolTest(unittest.TestCase):
                     spt = SystemPackageTool(runner=runner, os_info=os_info, tool=ChocolateyTool())
                     spt.update()
 
-                    runner.commands.append(("choco insall --yes a_package", 0))
+                    runner.commands.append(("choco install --yes a_package", 0))
                     spt.install("a_package", force=True)
 
                     runner.commands.append(('choco search --local-only --exact a_package | '

--- a/conans/test/utils/runner_mock.py
+++ b/conans/test/utils/runner_mock.py
@@ -1,0 +1,26 @@
+
+
+class RunnerMock(object):
+    def __init__(self, return_ok=True):
+        self.command_called = None
+        self.return_ok = return_ok
+
+    def __call__(self, command, output, win_bash=False, subsystem=None):  # @UnusedVariable
+        self.command_called = command
+        self.win_bash = win_bash
+        self.subsystem = subsystem
+        return 0 if self.return_ok else 1
+
+
+class RunnerOrderedMock(object):
+    commands = []  # Command + return value
+
+    def __init__(self, test_class):
+        self._test_class = test_class
+
+    def __call__(self, command, output, win_bash=False, subsystem=None):
+        if not len(self.commands):
+            self._test_class.fail("Commands list exhausted, but runner called with '%s'" % command)
+        expected, ret = self.commands.pop(0)
+        self._test_class.assertEqual(expected, command)
+        return ret

--- a/conans/test/utils/runner_mock.py
+++ b/conans/test/utils/runner_mock.py
@@ -24,3 +24,13 @@ class RunnerOrderedMock(object):
         expected, ret = self.commands.pop(0)
         self._test_class.assertEqual(expected, command)
         return ret
+
+
+class RunnerMultipleMock(object):
+    def __init__(self, expected=None):
+        self.calls = 0
+        self.expected = expected
+
+    def __call__(self, command, output):  # @UnusedVariable
+        self.calls += 1
+        return 0 if command in self.expected else 1

--- a/conans/test/utils/runner_mock.py
+++ b/conans/test/utils/runner_mock.py
@@ -1,6 +1,13 @@
 
 
 class RunnerOrderedMock(object):
+    """ Class to mock the ConanRunner in tests. It allows to check a sequence of commands
+        that has to be provided beforehand (with return values) and would raise if it doesn't
+        match actual calls.
+
+        Commands should be provided to the `commands` member variable as a list of tuples where
+        the first item of the tuple is the command itself, and the second one is the return value.
+    """
 
     def __init__(self, test_class):
         self.commands = []

--- a/conans/test/utils/runner_mock.py
+++ b/conans/test/utils/runner_mock.py
@@ -5,8 +5,10 @@ class RunnerOrderedMock(object):
     def __init__(self, test_class):
         self.commands = []
         self._test_class = test_class
+        self.last_command = None
 
     def __call__(self, command, output, win_bash=False, subsystem=None):
+        self.last_command = command
         if self.is_empty():
             self._test_class.fail("Commands list exhausted, but runner called with '%s'" % command)
         expected, ret = self.commands.pop(0)

--- a/conans/test/utils/runner_mock.py
+++ b/conans/test/utils/runner_mock.py
@@ -27,13 +27,3 @@ class RunnerOrderedMock(object):
 
     def is_empty(self):
         return not self.commands
-
-
-class RunnerMultipleMock(object):
-    def __init__(self, expected=None):
-        self.calls = 0
-        self.expected = expected
-
-    def __call__(self, command, output):  # @UnusedVariable
-        self.calls += 1
-        return 0 if command in self.expected else 1

--- a/conans/test/utils/runner_mock.py
+++ b/conans/test/utils/runner_mock.py
@@ -1,17 +1,5 @@
 
 
-class RunnerMock(object):
-    def __init__(self, return_ok=True):
-        self.command_called = None
-        self.return_ok = return_ok
-
-    def __call__(self, command, output, win_bash=False, subsystem=None):  # @UnusedVariable
-        self.command_called = command
-        self.win_bash = win_bash
-        self.subsystem = subsystem
-        return 0 if self.return_ok else 1
-
-
 class RunnerOrderedMock(object):
 
     def __init__(self, test_class):

--- a/conans/test/utils/runner_mock.py
+++ b/conans/test/utils/runner_mock.py
@@ -13,9 +13,9 @@ class RunnerMock(object):
 
 
 class RunnerOrderedMock(object):
-    commands = []  # Command + return value
 
     def __init__(self, test_class):
+        self.commands = []
         self._test_class = test_class
 
     def __call__(self, command, output, win_bash=False, subsystem=None):

--- a/conans/test/utils/runner_mock.py
+++ b/conans/test/utils/runner_mock.py
@@ -19,11 +19,14 @@ class RunnerOrderedMock(object):
         self._test_class = test_class
 
     def __call__(self, command, output, win_bash=False, subsystem=None):
-        if not len(self.commands):
+        if self.is_empty():
             self._test_class.fail("Commands list exhausted, but runner called with '%s'" % command)
         expected, ret = self.commands.pop(0)
         self._test_class.assertEqual(expected, command)
         return ret
+
+    def is_empty(self):
+        return not self.commands
 
 
 class RunnerMultipleMock(object):


### PR DESCRIPTION
Remove several RunnerMock classes that were being declared in the code and use only one: `RunnerOrderedMock`. This class allows declaring a command sequence and the return code of each one of them, and then it checks that commands are being called in the given order.

Only test code is affected
