### PR TITLE
Added test of how to package an Apple Framework

### DIFF
--- a/conans/test/integration/cmake_targets_test.py
+++ b/conans/test/integration/cmake_targets_test.py
@@ -220,8 +220,7 @@ project(MyHello C)
 cmake_minimum_required(VERSION 2.8.12)
 include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
 conan_basic_setup(KEEP_RPATHS)
-add_executable(say_hello main.c)
-target_link_libraries(say_hello ${CONAN_LIBS})       
+add_executable(say_hello main.c)    
 """
 
         main = """


### PR DESCRIPTION
- [x] Refer to the issue that supports this Pull Request. 

Closes #3394, to demonstrate how a `package_info()` should look when packaging an Apple framework.

- Docs modified here:

https://github.com/conan-io/docs/pull/839/files

Changelog: omit
