### PR TITLE
Clean repeated entries in PATH after vcvars call

### DIFF
--- a/conans/client/tools/win.py
+++ b/conans/client/tools/win.py
@@ -306,7 +306,7 @@ def vcvars_command(settings, arch=None, compiler_version=None, force=False, vcva
 
 def vcvars_dict(settings, arch=None, compiler_version=None, force=False, filter_known_paths=False,
                 vcvars_ver=None, winsdk_version=None, only_diff=True):
-    known_path_lists = ("INCLUDE", "LIB", "LIBPATH", "PATH")
+    known_path_lists = ("include", "lib", "libpath", "path")
     cmd = vcvars_command(settings, arch=arch,
                          compiler_version=compiler_version, force=force,
                          vcvars_ver=vcvars_ver, winsdk_version=winsdk_version) + " && echo __BEGINS__ && set"
@@ -324,26 +324,18 @@ def vcvars_dict(settings, arch=None, compiler_version=None, force=False, filter_
             continue
         try:
             name_var, value = line.split("=", 1)
-            new_value = value.split(os.pathsep) if name_var in known_path_lists else value
+            new_value = value.split(os.pathsep) if name_var.lower() in known_path_lists else value
             # Return only new vars & changed ones, but only with the changed elements if the var is
             # a list
             if only_diff:
                 old_value = os.environ.get(name_var)
-                # The new value ends with separator and the old value, is a list, get only the
-                # new elements
-                if old_value and value.endswith(os.pathsep + old_value):
-                    tmp = value[:-(len(old_value) + 1)].split(os.pathsep)
-                    if name_var.lower() == "path":
-                        # vcvars doesn't look if previous paths are already set so clean the repeated to avoid
-                        # max path (or any other list env var) len issues:
-                        new_env[name_var] = []
-                        uniques = []
-                        for i in tmp:
-                            if i and i.lower() not in uniques:
-                                uniques.append(i.lower())
-                                new_env[name_var].append(i)
-                    else:
-                        new_env[name_var] = tmp
+                if name_var.lower() == "path":
+                    old_values_lower = [v.lower() for v in old_value.split(os.pathsep)]
+                    # Clean all repeated entries, not append if the element was already there
+                    new_env[name_var] = [v for v in new_value if v.lower() not in old_values_lower]
+                elif old_value and value.endswith(os.pathsep + old_value):
+                    # The new value ends with separator and the old value, is a list, get only the new elements
+                    new_env[name_var] = value[:-(len(old_value) + 1)].split(os.pathsep)
                 elif value != old_value:
                     # Only if the vcvars changed something, we return the variable,
                     # otherwise is not vcvars related

--- a/conans/client/tools/win.py
+++ b/conans/client/tools/win.py
@@ -332,7 +332,15 @@ def vcvars_dict(settings, arch=None, compiler_version=None, force=False, filter_
                 # The new value ends with separator and the old value, is a list, get only the
                 # new elements
                 if old_value and value.endswith(os.pathsep + old_value):
-                    new_env[name_var] = value[:-(len(old_value) + 1)].split(os.pathsep)
+                    tmp = value[:-(len(old_value) + 1)].split(os.pathsep)
+                    # vcvars doesn't look if previous paths are already set so clean the repeated to avoid
+                    # max path (or any other list env var) len issues:
+                    new_env[name_var] = []
+                    uniques = []
+                    for i in tmp:
+                        if i and i.lower() not in uniques:
+                            uniques.append(i.lower())
+                            new_env[name_var].append(i)
                 elif value != old_value:
                     # Only if the vcvars changed something, we return the variable,
                     # otherwise is not vcvars related
@@ -354,7 +362,6 @@ def vcvars_dict(settings, arch=None, compiler_version=None, force=False, filter_
         new_env["PATH"] = ";".join(path)
 
     return new_env
-
 
 @contextmanager
 def vcvars(*args, **kwargs):

--- a/conans/client/tools/win.py
+++ b/conans/client/tools/win.py
@@ -333,14 +333,17 @@ def vcvars_dict(settings, arch=None, compiler_version=None, force=False, filter_
                 # new elements
                 if old_value and value.endswith(os.pathsep + old_value):
                     tmp = value[:-(len(old_value) + 1)].split(os.pathsep)
-                    # vcvars doesn't look if previous paths are already set so clean the repeated to avoid
-                    # max path (or any other list env var) len issues:
-                    new_env[name_var] = []
-                    uniques = []
-                    for i in tmp:
-                        if i and i.lower() not in uniques:
-                            uniques.append(i.lower())
-                            new_env[name_var].append(i)
+                    if name_var.lower() == "path":
+                        # vcvars doesn't look if previous paths are already set so clean the repeated to avoid
+                        # max path (or any other list env var) len issues:
+                        new_env[name_var] = []
+                        uniques = []
+                        for i in tmp:
+                            if i and i.lower() not in uniques:
+                                uniques.append(i.lower())
+                                new_env[name_var].append(i)
+                    else:
+                        new_env[name_var] = tmp
                 elif value != old_value:
                     # Only if the vcvars changed something, we return the variable,
                     # otherwise is not vcvars related

--- a/conans/test/util/tools_test.py
+++ b/conans/test/util/tools_test.py
@@ -723,7 +723,8 @@ class HelloConan(ConanFile):
 
         # Set the env with a PATH containing the vcvars paths
         tmp = tools.vcvars_dict(settings, only_diff=False)
-        with tools.environment_append({"path": ";".join(tmp["Path"])}):
+        tmp = {key.lower(): value for key, value in tmp.items()}
+        with tools.environment_append({"path": ";".join(tmp["path"])}):
             previous_path = os.environ["PATH"].split(";")
             # Duplicate the path, inside the tools.vcvars shouldn't have repeated entries in PATH
             with tools.vcvars(settings):

--- a/conans/test/util/tools_test.py
+++ b/conans/test/util/tools_test.py
@@ -721,10 +721,11 @@ class HelloConan(ConanFile):
         settings.arch = "x86"
         settings.arch_build = "x86_64"
 
-        # Duplicate the path, inside the tools.vcvars shouldn't have repeated entries in PATH
+        # Set the env with a PATH containing the vcvars paths
         tmp = tools.vcvars_dict(settings, only_diff=False)
-        with tools.environment_append(tmp):
+        with tools.environment_append({"path": ";".join(tmp["Path"])}):
             previous_path = os.environ["PATH"].split(";")
+            # Duplicate the path, inside the tools.vcvars shouldn't have repeated entries in PATH
             with tools.vcvars(settings):
                 path = os.environ["PATH"].split(";")
                 new_values = []


### PR DESCRIPTION
- [x] Refer to the issue that supports this Pull Request. Closes #3522

To clarify, there was no bug in Conan. **vcvars** prepends new variables to the PATH, but without looking if the entries in the path are or not already set with the same value there. With some recipes manipulating the environment, sometimes the max chars for PATHS is reached. So with this PR, the `vcvars_dict` will remove repeated entries in the PATH.

Changelog: Feature: Clean repeated entries in the ``PATH`` when ``vcvars`` is run, mitigating the max size of the env var issues.
