### PR TITLE
Fix output overlap of decompress progress and plugins

### DIFF
--- a/conans/client/tools/files.py
+++ b/conans/client/tools/files.py
@@ -80,10 +80,13 @@ def unzip(filename, destination=".", keep_permissions=False, pattern=None):
     if hasattr(sys.stdout, "isatty") and sys.stdout.isatty():
         def print_progress(the_size, uncomp_size):
             the_size = (the_size * 100.0 / uncomp_size) if uncomp_size != 0 else 0
+            txt_msg = "Unzipping %d %%"
             if the_size > print_progress.last_size + 1:
-                txt_msg = "Unzipping %d %%" % the_size
-                _global_output.rewrite_line(txt_msg)
+                _global_output.rewrite_line(txt_msg % the_size)
                 print_progress.last_size = the_size
+                if int(the_size) == 99:
+                    _global_output.rewrite_line(txt_msg % 100)
+                    _global_output.writeln("")
     else:
         def print_progress(_, __):
             pass


### PR DESCRIPTION
- [x] Refer to the issue that supports this Pull Request: closes #3607
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://raw.githubusercontent.com/conan-io/conan/develop/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.

The decompress output made the plugin trace look like this:

```
C:\Users\danimtb\.conan\data\box2d\2.3.1\danimtb\testing\source
[==================================================] 1.8MB/1.8MB
Unzipping 6.0MB, this can take a while
Unzipping 99 %                                                        [PLUGIN - conan-center] post_source(): [LIBCXX] OK
box2d/2.3.1@danimtb/testing: Copying sources to build folder
```

Now it shoes like:

```
box2d/2.3.1@danimtb/testing: Configuring sources in C:\Users\danimtb\.conan\data\box2d\2.3.1\danimtb\testing\source
[==================================================] 1.8MB/1.8MB
Unzipping 6.0MB, this can take a while
Unzipping 100 %
[PLUGIN - conan-center] post_source(): [LIBCXX] OK
box2d/2.3.1@danimtb/testing: Copying sources to build folder
```

Unfortunately this is only produced in terminals with TTY so I was not able to reproduce it in a test.

Changelog: Fix: Fix output overlap of decompress progress and plugins