### PR TITLE
Removed output parameter from latest visual public function

### DIFF
--- a/conans/client/conf/detect.py
+++ b/conans/client/conf/detect.py
@@ -5,7 +5,7 @@ from subprocess import Popen, PIPE, STDOUT
 
 from conans.client.output import Color
 from conans.model.version import Version
-from conans.client.tools.win import _latest_visual_studio_version_installed
+from conans.client.tools.win import latest_visual_studio_version_installed
 
 
 def _execute(command):
@@ -102,7 +102,7 @@ def _get_default_compiler(output):
         return None
 
     if detected_os() == "Windows":
-        version = _latest_visual_studio_version_installed(output)
+        version = latest_visual_studio_version_installed(output)
         vs = ('Visual Studio', version) if version else None
     gcc = _gcc_compiler(output)
     clang = _clang_compiler(output)

--- a/conans/client/conf/detect.py
+++ b/conans/client/conf/detect.py
@@ -5,7 +5,7 @@ from subprocess import Popen, PIPE, STDOUT
 
 from conans.client.output import Color
 from conans.model.version import Version
-from conans.client.tools import latest_visual_studio_version_installed
+from conans.client.tools.win import _latest_visual_studio_version_installed
 
 
 def _execute(command):
@@ -102,7 +102,7 @@ def _get_default_compiler(output):
         return None
 
     if detected_os() == "Windows":
-        version = latest_visual_studio_version_installed()
+        version = _latest_visual_studio_version_installed(output)
         vs = ('Visual Studio', version) if version else None
     gcc = _gcc_compiler(output)
     clang = _clang_compiler(output)

--- a/conans/client/conf/detect.py
+++ b/conans/client/conf/detect.py
@@ -102,7 +102,7 @@ def _get_default_compiler(output):
         return None
 
     if detected_os() == "Windows":
-        version = latest_visual_studio_version_installed(output)
+        version = latest_visual_studio_version_installed()
         vs = ('Visual Studio', version) if version else None
     gcc = _gcc_compiler(output)
     clang = _clang_compiler(output)

--- a/conans/client/tools/win.py
+++ b/conans/client/tools/win.py
@@ -91,8 +91,12 @@ def _visual_compiler(output, version):
 
 
 def latest_visual_studio_version_installed():
+    return _latest_visual_studio_version_installed(_global_output)
+
+
+def _latest_visual_studio_version_installed(output):
     for version in reversed(["8", "9", "10", "11", "12", "14", "15"]):
-        vs = _visual_compiler(_global_output, version)
+        vs = _visual_compiler(output, version)
         if vs:
             return vs[1]
     return None

--- a/conans/client/tools/win.py
+++ b/conans/client/tools/win.py
@@ -90,11 +90,11 @@ def _visual_compiler(output, version):
     return None
 
 
-def latest_visual_studio_version_installed():
-    return _latest_visual_studio_version_installed(_global_output)
+def latest_vs_version_installed():
+    return latest_visual_studio_version_installed(_global_output)
 
 
-def _latest_visual_studio_version_installed(output):
+def latest_visual_studio_version_installed(output):
     for version in reversed(["8", "9", "10", "11", "12", "14", "15"]):
         vs = _visual_compiler(output, version)
         if vs:
@@ -322,7 +322,7 @@ def vcvars_command(settings, arch=None, compiler_version=None, force=False, vcva
         # vcvars might be still needed for other compilers, e.g. clang-cl or Intel C++,
         # as they might be using Microsoft STL and other tools (e.g. resource compiler, manifest tool, etc)
         # in this case, use the latest Visual Studio available on the machine
-        last_version = latest_visual_studio_version_installed()
+        last_version = latest_vs_version_installed()
 
         compiler_version = compiler_version or last_version
     os_setting = settings.get_safe("os")

--- a/conans/client/tools/win.py
+++ b/conans/client/tools/win.py
@@ -90,9 +90,9 @@ def _visual_compiler(output, version):
     return None
 
 
-def latest_visual_studio_version_installed(output):
+def latest_visual_studio_version_installed():
     for version in reversed(["8", "9", "10", "11", "12", "14", "15"]):
-        vs = _visual_compiler(output, version)
+        vs = _visual_compiler(_global_output, version)
         if vs:
             return vs[1]
     return None
@@ -318,7 +318,7 @@ def vcvars_command(settings, arch=None, compiler_version=None, force=False, vcva
         # vcvars might be still needed for other compilers, e.g. clang-cl or Intel C++,
         # as they might be using Microsoft STL and other tools (e.g. resource compiler, manifest tool, etc)
         # in this case, use the latest Visual Studio available on the machine
-        last_version = latest_visual_studio_version_installed(output=_global_output)
+        last_version = latest_visual_studio_version_installed()
 
         compiler_version = compiler_version or last_version
     os_setting = settings.get_safe("os")

--- a/conans/test/util/vcvars_clangcl_test.py
+++ b/conans/test/util/vcvars_clangcl_test.py
@@ -43,7 +43,7 @@ class VCVarsClangClTest(unittest.TestCase):
         settings.arch = 'x86_64'
         settings.os = 'Windows'
 
-        with mock.patch('conans.client.tools.win.latest_visual_studio_version_installed',
+        with mock.patch('conans.client.tools.win.latest_vs_version_installed',
                         mock.MagicMock(return_value=None)):
             with self.assertRaises(ConanException):
                 tools.vcvars_command(settings)


### PR DESCRIPTION
Removes output param in `latest_visual_studio_version_installed()`

@SSE4 we realized after merge that there is no need to force users to set the ``output`` parameter in this function
