### PR TITLE
allow relative paths (from conan.conf) in env variable

### DIFF
--- a/conans/client/conf/__init__.py
+++ b/conans/client/conf/__init__.py
@@ -290,8 +290,8 @@ class ConanClientConfigParser(ConfigParser, object):
         ret = os.environ.get("CONAN_DEFAULT_PROFILE_PATH", None)
         if ret:
             if not os.path.isabs(ret):
-                raise ConanException("Environment variable 'CONAN_DEFAULT_PROFILE_PATH' must point "
-                                     "to an absolute path.")
+                ret = os.path.abspath(os.path.join(os.path.dirname(self.filename), ret))
+
             if not os.path.exists(ret):
                 raise ConanException("Environment variable 'CONAN_DEFAULT_PROFILE_PATH' must point to "
                                      "an existing profile file.")

--- a/conans/client/conf/__init__.py
+++ b/conans/client/conf/__init__.py
@@ -290,7 +290,9 @@ class ConanClientConfigParser(ConfigParser, object):
         ret = os.environ.get("CONAN_DEFAULT_PROFILE_PATH", None)
         if ret:
             if not os.path.isabs(ret):
-                ret = os.path.abspath(os.path.join(os.path.dirname(self.filename), ret))
+                from conans.client.client_cache import PROFILES_FOLDER
+                profiles_folder = os.path.join(os.path.dirname(self.filename), PROFILES_FOLDER)
+                ret = os.path.abspath(os.path.join(profiles_folder, ret))
 
             if not os.path.exists(ret):
                 raise ConanException("Environment variable 'CONAN_DEFAULT_PROFILE_PATH' must point to "

--- a/conans/test/functional/default_profile_test.py
+++ b/conans/test/functional/default_profile_test.py
@@ -161,10 +161,15 @@ class MyConanfile(ConanFile):
             self.assertIn(">>> " + env_variable, client.out)
 
         # Use relative path defined in environment variable
-        with tools.environment_append({'CONAN_DEFAULT_PROFILE_PATH': '../whatever'}):
-            client.run("create . name/version@user/channel", ignore_error=True)
-            self.assertIn("Environment variable 'CONAN_DEFAULT_PROFILE_PATH' must point to "
-                          "an absolute path", client.out)
+        env_variable = "env_variable=relative_profile"
+        rel_path = os.path.join('..', 'env_rel_profile')
+        self.assertFalse(os.path.isabs(rel_path))
+        default_profile_path = os.path.join(os.path.dirname(client.client_cache.conan_conf_path),
+                                            rel_path)
+        save(default_profile_path, "[env]\n" + env_variable)
+        with tools.environment_append({'CONAN_DEFAULT_PROFILE_PATH': rel_path}):
+            client.run("create . name/version@user/channel")
+            self.assertIn(">>> " + env_variable, client.out)
 
         # Use non existing path
         profile_path = os.path.join(tmp, "this", "is", "a", "path")

--- a/conans/test/functional/default_profile_test.py
+++ b/conans/test/functional/default_profile_test.py
@@ -7,6 +7,7 @@ from conans.test.utils.test_files import temp_folder
 from conans.test.utils.tools import TestClient
 from conans.util.files import save
 from conans import tools
+from conans.client.client_cache import PROFILES_FOLDER
 
 
 class DefaultProfileTest(unittest.TestCase):
@@ -164,8 +165,8 @@ class MyConanfile(ConanFile):
         env_variable = "env_variable=relative_profile"
         rel_path = os.path.join('..', 'env_rel_profile')
         self.assertFalse(os.path.isabs(rel_path))
-        default_profile_path = os.path.join(os.path.dirname(client.client_cache.conan_conf_path),
-                                            rel_path)
+        default_profile_path = os.path.join(client.client_cache.conan_folder,
+                                            PROFILES_FOLDER, rel_path)
         save(default_profile_path, "[env]\n" + env_variable)
         with tools.environment_append({'CONAN_DEFAULT_PROFILE_PATH': rel_path}):
             client.run("create . name/version@user/channel")


### PR DESCRIPTION
Changelog: Feature: The environment variable CONAN_DEFAULT_PROFILE_PATH allows the user to define the path (existing) to the default profile that will be used by Conan.

- [x] closes #3193
- [x] Modify docs https://github.com/conan-io/docs/pull/849

