### PR TITLE
Install config from folder

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -195,7 +195,7 @@ To run specific tests, you can specify the test name too, something like:
 
 .. code-block:: bash
 
-    $ nosetests conans.test.integration.flat_requirements_test --nocapture
+    $ nosetests conans.test.command.config_install_test:ConfigInstallTest.install_file_test --nocapture
 
 The ``--nocapture`` argument can be useful to see some output that otherwise is captured by nosetests.
 

--- a/conans/client/command.py
+++ b/conans/client/command.py
@@ -386,7 +386,7 @@ class Command(object):
         rm_subparser.add_argument("item", help="Item to remove")
         get_subparser.add_argument("item", nargs="?", help="Item to print")
         set_subparser.add_argument("item", help="'item=value' to set")
-        install_subparser.add_argument("item", nargs="?", help="Configuration file to use")
+        install_subparser.add_argument("item", nargs="?", help="Configuration file or directory to use")
 
         install_subparser.add_argument("--verify-ssl", nargs="?", default="True",
                                        help='Verify SSL connection when downloading file')

--- a/conans/client/conf/config_installer.py
+++ b/conans/client/conf/config_installer.py
@@ -123,8 +123,9 @@ def configuration_install(item, client_cache, output, verify_ssl, config_type=No
 
         if item.endswith(".git") or config_type == "git":
             _process_git_repo(item, client_cache, output, tmp_folder, verify_ssl, args)
-        elif os.path.exists(item):
-            # is a local file
+        elif os.path.isdir(item):
+            _process_folder(item, client_cache, output)
+        elif os.path.isfile(item):
             _process_zip_file(item, client_cache, output, tmp_folder)
         elif item.startswith("http"):
             _process_download(item, client_cache, output, tmp_folder, verify_ssl)

--- a/conans/test/command/config_install_test.py
+++ b/conans/test/command/config_install_test.py
@@ -168,6 +168,14 @@ class Pkg(ConanFile):
         self._check(zippath)
         self.assertTrue(os.path.exists(zippath))
 
+    def install_dir_test(self):
+        """ should install from a dir in current dir
+        """
+        folder = self._create_profile_folder()
+        self.assertTrue(os.path.isdir(folder))
+        self.client.run('config install "%s"' % folder)
+        self._check(folder)
+
     def test_without_profile_folder(self):
         shutil.rmtree(self.client.client_cache.profiles_path)
         zippath = self._create_zip()


### PR DESCRIPTION
Changelog: Feature: Allow `conan config install` to install configuration from a folder and not only from compressed files.

Fixes #3670 

- [X] Refer to the issue that supports this Pull Request.
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [X] I've read the [Contributing guide](https://raw.githubusercontent.com/conan-io/conan/develop/.github/CONTRIBUTING.md).
- [X] I've followed the PEP8 style guides for Python code.
- [X] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 


