### PR TITLE
Fix: propagation of options with value None upstream

### DIFF
--- a/conans/model/options.py
+++ b/conans/model/options.py
@@ -122,8 +122,7 @@ class PackageOptionValues(object):
 
         assert isinstance(down_package_values, PackageOptionValues)
         for (name, value) in down_package_values.items():
-            current_value = self._dict.get(name)
-            if value != 'None' and value == current_value:
+            if name in self._dict and self._dict.get(name) == value:
                 continue
 
             modified = self._modified.get(name)

--- a/conans/model/options.py
+++ b/conans/model/options.py
@@ -123,7 +123,7 @@ class PackageOptionValues(object):
         assert isinstance(down_package_values, PackageOptionValues)
         for (name, value) in down_package_values.items():
             current_value = self._dict.get(name)
-            if value == current_value:
+            if value != 'None' and value == current_value:
                 continue
 
             modified = self._modified.get(name)

--- a/conans/model/options.py
+++ b/conans/model/options.py
@@ -462,8 +462,7 @@ class PackageOptions(object):
             return
 
         for (name, value) in package_values.items():
-            current_value = self._data.get(name)
-            if value == current_value:
+            if name in self._data and self._data.get(name) == value:
                 continue
 
             modified = self._modified.get(name)

--- a/conans/test/model/options_test.py
+++ b/conans/test/model/options_test.py
@@ -224,6 +224,23 @@ Poco:deps_bundled=True""")
                                                      ("OpenSSL.*:fake_option", "FuzzBuzz"),
                                                      ])
 
+    def test_propagate_none_upstream(self):
+        package_options = PackageOptions.loads("""{opt: [None, "a", "b"],}""")
+        values = PackageOptionValues()
+        values.add_option("opt", "a")
+        package_options.values = values
+        sut = Options(package_options)
+
+        other_options = PackageOptionValues()
+        other_options.add_option("opt", None)
+        options = {"whatever.*": other_options}
+        down_ref = ConanFileReference.loads("Boost.Assert/0.1@diego/testing")
+        own_ref = ConanFileReference.loads("Boost.Assert/0.1@diego/testing")
+        sut.propagate_upstream(options, down_ref, own_ref)
+        self.assertEqual(sut.values.as_list(), [("opt", "a"),
+                                                ("whatever.*:opt", "None"),
+                                                ])
+
 
 class OptionsValuesTest(unittest.TestCase):
 

--- a/conans/test/model/options_test.py
+++ b/conans/test/model/options_test.py
@@ -224,7 +224,10 @@ Poco:deps_bundled=True""")
                                                      ("OpenSSL.*:fake_option", "FuzzBuzz"),
                                                      ])
 
-    def test_propagate_none_upstream(self):
+
+class OptionsValuesPropagationUpstreamNone(unittest.TestCase):
+
+    def test_propagate_in_options(self):
         package_options = PackageOptions.loads("""{opt: [None, "a", "b"],}""")
         values = PackageOptionValues()
         values.add_option("opt", "a")
@@ -240,6 +243,14 @@ Poco:deps_bundled=True""")
         self.assertEqual(sut.values.as_list(), [("opt", "a"),
                                                 ("whatever.*:opt", "None"),
                                                 ])
+
+    def test_propagate_in_pacakge_options(self):
+        package_options = PackageOptions.loads("""{opt: [None, "a", "b"],}""")
+        values = PackageOptionValues()
+        package_options.values = values
+
+        package_options.propagate_upstream({'opt': None}, None, None, [])
+        self.assertEqual(package_options.values.items(), [('opt', 'None'), ])
 
 
 class OptionsValuesTest(unittest.TestCase):


### PR DESCRIPTION
Changelog: Fix: ``None`` option value was not being propagated upstream in the dependency graph

- [x] closes #3407



