### PR TITLE
Disable v2 for 1.8 release

### DIFF
--- a/.ci/jenkins/Jenkinsfile
+++ b/.ci/jenkins/Jenkinsfile
@@ -17,7 +17,6 @@ def api_confs = ["v1"]
 
 if (full_py_vers){
     pyvers = ['py37', 'py36', 'py34', 'py27']
-    api_confs = ["v1", "v2"]
 }
 else if(test_v2){
     api_confs = ["v1", "v2"]

--- a/.ci/jenkins/Jenkinsfile
+++ b/.ci/jenkins/Jenkinsfile
@@ -1,6 +1,6 @@
 // ########## CONFIGURATION ##################
 def full_py_vers = true
-def test_v2 = true
+def test_v2 = false
 // ############################
 
 

--- a/conans/client/rest/rest_client.py
+++ b/conans/client/rest/rest_client.py
@@ -1,8 +1,6 @@
 from collections import defaultdict
 
-from conans import API_V2, CHECKSUM_DEPLOY
 from conans.client.rest.rest_client_v1 import RestV1Methods
-from conans.client.rest.rest_client_v2 import RestV2Methods
 
 
 class RestApiClient(object):
@@ -31,14 +29,17 @@ class RestApiClient(object):
             _, _, cap = tmp.server_info()
             self._capabilities[self.remote_url] = cap
 
-        if API_V2 in self._capabilities[self.remote_url]:
-            checksum_deploy = CHECKSUM_DEPLOY in self._capabilities[self.remote_url]
-            return RestV2Methods(self.remote_url, self.token, self.custom_headers, self._output,
-                                 self.requester, self.verify_ssl, self._put_headers,
-                                 checksum_deploy)
-        else:
-            return RestV1Methods(self.remote_url, self.token, self.custom_headers, self._output,
-                                 self.requester, self.verify_ssl, self._put_headers)
+        # FIXME: ONLY CONNECT TO APIV2 THE CLIENT WHEN THE PROTOCOL IS STABLE
+        # from conans import API_V2, CHECKSUM_DEPLOY
+        # from conans.client.rest.rest_client_v2 import RestV2Methods
+        #if API_V2 in self._capabilities[self.remote_url]:
+        #    checksum_deploy = CHECKSUM_DEPLOY in self._capabilities[self.remote_url]
+        #    return RestV2Methods(self.remote_url, self.token, self.custom_headers, self._output,
+        #                         self.requester, self.verify_ssl, self._put_headers,
+        #                         checksum_deploy)
+        #else:
+        return RestV1Methods(self.remote_url, self.token, self.custom_headers, self._output,
+                             self.requester, self.verify_ssl, self._put_headers)
 
     def get_conan_manifest(self, conan_reference):
         return self._get_api().get_conan_manifest(conan_reference)


### PR DESCRIPTION
Changelog: Disabled apiv2 until the new protocol become stable.

Only allow the client to speak v2 when we are ready.

