### PR TITLE
Use 'share' folder for DATAROOTDIR in CMake and AutoTools build helpers

### DIFF
--- a/conans/client/build/autotools_environment.py
+++ b/conans/client/build/autotools_environment.py
@@ -9,7 +9,7 @@ from conans.client.build.compiler_flags import (architecture_flag, format_librar
                                                 build_type_flags, libcxx_flag, build_type_define,
                                                 libcxx_define, pic_flag, rpath_flags)
 from conans.client.build.cppstd_flags import cppstd_flag
-from conans.model.build_info import DEFAULT_BIN, DEFAULT_LIB, DEFAULT_INCLUDE, DEFAULT_RES
+from conans.model.build_info import DEFAULT_BIN, DEFAULT_LIB, DEFAULT_INCLUDE, DEFAULT_SHARE
 from conans.client.tools.oss import OSInfo
 from conans.client.tools.win import unix_path
 from conans.tools import (environment_append, args_to_string, cpu_count, cross_building,
@@ -167,7 +167,7 @@ class AutoToolsBuildEnvironment(object):
                     if self._valid_configure_flag(varname, args, available_flags):
                         args.append("--%s=${prefix}/%s" % (varname, DEFAULT_INCLUDE))
                 if self._valid_configure_flag("datarootdir", args, available_flags):
-                    args.append("--datarootdir=${prefix}/%s" % DEFAULT_RES)
+                    args.append("--datarootdir=${prefix}/%s" % DEFAULT_SHARE)
 
         with environment_append(pkg_env):
             with environment_append(vars or self.vars):

--- a/conans/client/build/cmake_flags.py
+++ b/conans/client/build/cmake_flags.py
@@ -6,7 +6,7 @@ from conans.client.build.compiler_flags import architecture_flag, parallel_compi
 from conans.client.build.cppstd_flags import cppstd_flag
 from conans.client.tools import cross_building
 from conans.client.tools.oss import get_cross_building_settings
-from conans.model.build_info import DEFAULT_BIN, DEFAULT_LIB, DEFAULT_INCLUDE, DEFAULT_RES
+from conans.model.build_info import DEFAULT_BIN, DEFAULT_LIB, DEFAULT_INCLUDE, DEFAULT_SHARE
 from conans.errors import ConanException
 from conans.util.env_reader import get_env
 from conans.util.log import logger
@@ -284,7 +284,7 @@ class CMakeDefinitionsBuilder(object):
                 ret["CMAKE_INSTALL_LIBDIR"] = DEFAULT_LIB
                 ret["CMAKE_INSTALL_INCLUDEDIR"] = DEFAULT_INCLUDE
                 ret["CMAKE_INSTALL_OLDINCLUDEDIR"] = DEFAULT_INCLUDE
-                ret["CMAKE_INSTALL_DATAROOTDIR"] = DEFAULT_RES
+                ret["CMAKE_INSTALL_DATAROOTDIR"] = DEFAULT_SHARE
         except AttributeError:
             pass
 

--- a/conans/model/build_info.py
+++ b/conans/model/build_info.py
@@ -6,6 +6,7 @@ DEFAULT_INCLUDE = "include"
 DEFAULT_LIB = "lib"
 DEFAULT_BIN = "bin"
 DEFAULT_RES = "res"
+DEFAULT_SHARE = "share"
 
 
 class _CppInfo(object):

--- a/conans/test/build_helpers/autotools_configure_test.py
+++ b/conans/test/build_helpers/autotools_configure_test.py
@@ -588,12 +588,12 @@ class HelloConan(ConanFile):
             self.assertIn("./configure --prefix=/package_folder --bindir=${prefix}/bin "
                           "--sbin=${prefix}/bin --libexec=${prefix}/bin --libdir=${prefix}/lib "
                           "--includedir=${prefix}/include --oldincludedir=${prefix}/include "
-                          "--datarootdir=${prefix}/res", runner.command_called)
+                          "--datarootdir=${prefix}/share", runner.command_called)
         else:
             self.assertIn("./configure '--prefix=/package_folder' '--bindir=${prefix}/bin' "
                           "'--sbin=${prefix}/bin' '--libexec=${prefix}/bin' '--libdir=${prefix}/lib' "
                           "'--includedir=${prefix}/include' '--oldincludedir=${prefix}/include' "
-                          "'--datarootdir=${prefix}/res'", runner.command_called)
+                          "'--datarootdir=${prefix}/share'", runner.command_called)
         # --prefix already used in args
         ab.configure(args=["--prefix=/my_package_folder"])
         self.assertIn("--prefix=/my_package_folder", runner.command_called)
@@ -608,13 +608,13 @@ class HelloConan(ConanFile):
             self.assertIn("./configure --bindir=/pf/superbindir --libdir=/pf/superlibdir "
                           "--includedir=/pf/superincludedir --prefix=/package_folder "
                           "--sbin=${prefix}/bin --libexec=${prefix}/bin "
-                          "--oldincludedir=${prefix}/include --datarootdir=${prefix}/res",
+                          "--oldincludedir=${prefix}/include --datarootdir=${prefix}/share",
                           runner.command_called)
         else:
             self.assertIn("./configure '--bindir=/pf/superbindir' '--libdir=/pf/superlibdir' "
                           "'--includedir=/pf/superincludedir' '--prefix=/package_folder' "
                           "'--sbin=${prefix}/bin' '--libexec=${prefix}/bin' "
-                          "'--oldincludedir=${prefix}/include' '--datarootdir=${prefix}/res'",
+                          "'--oldincludedir=${prefix}/include' '--datarootdir=${prefix}/share'",
                           runner.command_called)
         # opt-out from default installation dirs
         ab.configure(use_default_install_dirs=False)

--- a/conans/test/build_helpers/cmake_test.py
+++ b/conans/test/build_helpers/cmake_test.py
@@ -1032,7 +1032,7 @@ build_type: [ Release]
                               "CMAKE_INSTALL_LIBDIR": "lib",
                               "CMAKE_INSTALL_INCLUDEDIR": "include",
                               "CMAKE_INSTALL_OLDINCLUDEDIR": "include",
-                              "CMAKE_INSTALL_DATAROOTDIR": "res"}
+                              "CMAKE_INSTALL_DATAROOTDIR": "share"}
 
         # Without package_folder
         cmake = CMake(conanfile)


### PR DESCRIPTION
Changelog: Fix: Use *share* folder for ``DATAROOTDIR`` in CMake and AutoTools build helpers.


