### PR TITLE
remove warnings related to python_requires

### DIFF
--- a/conans/client/cmd/export_linter.py
+++ b/conans/client/cmd/export_linter.py
@@ -50,8 +50,8 @@ def _runner(args):
 
 
 def _normal_linter(conanfile_path, hook):
-    args = ["--py3k", "--enable=all", "--reports=no", "--disable=no-absolute-import", "--persistent=no", 
-            "--load-plugins=conans.pylint_plugin",
+    args = ["--py3k", "--enable=all", "--reports=no", "--disable=no-absolute-import",
+            "--persistent=no", "--load-plugins=conans.pylint_plugin",
             hook, '"%s"' % conanfile_path]
     pylintrc = os.environ.get("CONAN_PYLINTRC", None)
     if pylintrc:
@@ -67,6 +67,8 @@ def _normal_linter(conanfile_path, hook):
         if symbol in ("bare-except", "broad-except"):  # No exception type(s) specified
             return False
         if symbol == "import-error" and msg.get("column") > 3:  # Import of a conan python package
+            return False
+        if symbol == "no-name-in-module" and "python_requires" in msg.get("message"):
             return False
 
         return True

--- a/conans/client/graph/python_requires.py
+++ b/conans/client/graph/python_requires.py
@@ -37,7 +37,8 @@ class ConanPythonRequire(object):
             self._references.append(reference)
             try:
                 sys.path.append(os.path.dirname(path))
-                module = imp.load_source(str(r), path)
+                # replace avoid warnings in Py2 with dots
+                module = imp.load_source(str(r).replace(".", "*"), path)
             finally:
                 sys.path.pop()
             self._modules[require] = module, reference

--- a/conans/pylint_plugin.py
+++ b/conans/pylint_plugin.py
@@ -5,7 +5,7 @@ from astroid import MANAGER
 
 def register(linter):
     """Declare package as plugin
-    
+
     This function needs to be declared so astroid treats
     current file as a plugin.
     """

--- a/conans/test/command/export_linter_test.py
+++ b/conans/test/command/export_linter_test.py
@@ -75,7 +75,9 @@ class BaseConan(ConanFile):
         client.run("export . conan/stable")
 
         conanfile2 = """
-from conans import ConanFile
+from conans import ConanFile, python_requires
+
+python_requires("baselib/1.0@conan/stable")
 class TestConan(ConanFile):
     name = "Hello"
     version = "1.2"


### PR DESCRIPTION
Changelog: Fix: Remove warnings related to python_requires(), both in linter and due to Python2.

Close #3704




