### PR TITLE
Feature/rename docker images

### DIFF
--- a/conans/client/cmd/new_ci.py
+++ b/conans/client/cmd/new_ci.py
@@ -35,11 +35,11 @@ linux_config = """
 
 
 linux_config_gcc = linux_config + """
-        env: CONAN_GCC_VERSIONS={version} CONAN_DOCKER_IMAGE=lasote/conangcc{name}
+        env: CONAN_GCC_VERSIONS={version} CONAN_DOCKER_IMAGE=conanio/gcc{name}
 """
 
 linux_config_clang = linux_config + """
-        env: CONAN_CLANG_VERSIONS={version} CONAN_DOCKER_IMAGE=lasote/conanclang{name}
+        env: CONAN_CLANG_VERSIONS={version} CONAN_DOCKER_IMAGE=conanio/clang{name}
 """
 
 osx_config = """
@@ -143,7 +143,7 @@ variables:
 
 gitlab_config_gcc = """
 gcc-{version}:
-    image: lasote/conangcc{name}
+    image: conanio/gcc{name}
     variables:
         CONAN_GCC_VERSIONS: "{version}"
     <<: *build-template
@@ -151,7 +151,7 @@ gcc-{version}:
 
 gitlab_config_clang = """
 clang-{version}:
-    image: lasote/conanclang{name}
+    image: conanio/clang{name}
     variables:
         CONAN_CLANG_VERSIONS: "{version}"
     <<: *build-template
@@ -185,7 +185,7 @@ jobs:
 circleci_config_gcc = """
   gcc-{name}:
       docker:
-        - image: lasote/conangcc{name}
+        - image: conanio/gcc{name}
       environment:
         - CONAN_GCC_VERSIONS: "{version}"
       <<: *conan-steps
@@ -194,7 +194,7 @@ circleci_config_gcc = """
 circleci_config_clang = """
   clang-{name}:
       docker:
-        - image: lasote/conanclang{name}
+        - image: conanio/clang{name}
       environment:
         - CONAN_CLANG_VERSIONS: "{version}"
       <<: *conan-steps

--- a/conans/test/command/new_test.py
+++ b/conans/test/command/new_test.py
@@ -138,7 +138,7 @@ class NewTest(unittest.TestCase):
         self.assertIn('- CONAN_REFERENCE: "MyPackage/1.3"', travis)
         self.assertIn('- CONAN_USERNAME: "myuser"', travis)
         self.assertIn('- CONAN_CHANNEL: "testing"', travis)
-        self.assertIn('env: CONAN_GCC_VERSIONS=5 CONAN_DOCKER_IMAGE=lasote/conangcc5',
+        self.assertIn('env: CONAN_GCC_VERSIONS=5 CONAN_DOCKER_IMAGE=conanio/gcc5',
                       travis)
 
         gitlab = load(os.path.join(root, ".gitlab-ci.yml"))


### PR DESCRIPTION
Changelog: Feature: Now the default templates of the `conan new` command use the docker images from the `conanio` organization: https://hub.docker.com/u/conanio
