### PR TITLE
Show cpp_info in output from install and create commands

### DIFF
--- a/conans/client/installer.py
+++ b/conans/client/installer.py
@@ -324,6 +324,7 @@ class ConanInstaller(object):
                 clean_dirty(package_folder)
             # Call the info method
             self._call_package_info(conan_file, package_folder)
+            self._recorder.package_cpp_info(package_ref, conan_file.cpp_info)
 
     def _handle_node_workspace(self, node, workspace_package, inverse_levels, deps_graph):
         conan_ref, conan_file = node.conan_ref, node.conanfile

--- a/conans/client/recorder/action_recorder.py
+++ b/conans/client/recorder/action_recorder.py
@@ -130,6 +130,12 @@ class ActionRecorder(object):
                    "time": the_action.time}
             if isinstance(the_ref, ConanFileReference):
                 doc["dependency"] = not self.in_development_recipe(the_ref)
+                doc["name"] = the_ref.name
+                doc["version"] = the_ref.version
+                doc["user"] = the_ref.user
+                doc["channel"] = the_ref.channel
+                if the_ref.revision:
+                    doc["revision"] = the_ref.revision
             else:
                 doc["built"] = the_action.type == INSTALL_BUILT
 

--- a/conans/test/command/json_output_test.py
+++ b/conans/test/command/json_output_test.py
@@ -17,7 +17,7 @@ class JsonOutputTest(unittest.TestCase):
         # Result of a create
         files = cpp_hello_conan_files("CC", "1.0", build=False)
         self.client.save(files, clean_first=True)
-        self.client.run("create . private_user/channel --json=myfile.json ")
+        self.client.run("create . private_user/channel --json=myfile.json")
         my_json = json.loads(load(os.path.join(self.client.current_folder, "myfile.json")))
         self.assertFalse(my_json["error"])
         self.assertEquals(my_json["installed"][0]["recipe"]["id"], "CC/1.0@private_user/channel")
@@ -25,6 +25,7 @@ class JsonOutputTest(unittest.TestCase):
         self.assertTrue(my_json["installed"][0]["recipe"]["cache"])
         self.assertIsNone(my_json["installed"][0]["recipe"]["remote"])
         self.assertTrue(my_json["installed"][0]["packages"][0]["built"])
+        self.assertTrue(my_json["installed"][0]["packages"][0]["cpp_info"])
 
         # Result of an install retrieving only the recipe
         self.client.run("upload CC/1.0@private_user/channel -c")
@@ -41,6 +42,7 @@ class JsonOutputTest(unittest.TestCase):
         self.assertTrue(my_json["installed"][0]["recipe"]["downloaded"])
         self.assertIsNotNone(my_json["installed"][0]["recipe"]["remote"])
         self.assertTrue(my_json["installed"][0]["packages"][0]["built"])
+        self.assertTrue(my_json["installed"][0]["packages"][0]["cpp_info"])
 
         # Upload the binary too
         self.client.run("upload CC/1.0@private_user/channel --all -c")
@@ -55,6 +57,7 @@ class JsonOutputTest(unittest.TestCase):
         self.assertIsNotNone(my_json["installed"][0]["recipe"]["remote"])
         self.assertFalse(my_json["installed"][0]["packages"][0]["built"])
         self.assertTrue(my_json["installed"][0]["packages"][0]["downloaded"])
+        self.assertTrue(my_json["installed"][0]["packages"][0]["cpp_info"])
 
         # Force build
         self.client.run("remove '*' -f")
@@ -68,6 +71,7 @@ class JsonOutputTest(unittest.TestCase):
         self.assertIsNotNone(my_json["installed"][0]["recipe"]["remote"])
         self.assertTrue(my_json["installed"][0]["packages"][0]["built"])
         self.assertFalse(my_json["installed"][0]["packages"][0]["downloaded"])
+        self.assertTrue(my_json["installed"][0]["packages"][0]["cpp_info"])
 
     def test_errors(self):
 


### PR DESCRIPTION
Changelog: Feature: Add cpp_info data to json output of ``install`` and``create`` commands at package level.

- [x] closes #3641
- [x] docs: https://github.com/conan-io/docs/pull/893

Output looks like this:

```json
{
    "error": false,
    "installed": [
        {
            "recipe": {
                "id": "zlib/1.2.11@conan/stable",
                "name": "zlib",
                "version": "1.2.11",
                "user": "conan",
                "channel": "stable",
                "downloaded": false,
                "cache": true,
                "error": null,
                "remote": null,
                "time": "2018-10-10T10:28:28.351753",
                "dependency": true
            },
            "packages": [
                {
                    "id": "0eaf3bfbc94fb6d2c8f230d052d75c6c1a57a4ce",
                    "downloaded": false,
                    "cache": true,
                    "error": null,
                    "remote": null,
                    "time": "2018-10-10T10:28:28.356103",
                    "built": false,
                    "cpp_info": {
                        "includedirs": [
                            "include"
                        ],
                        "libdirs": [
                            "lib"
                        ],
                        "resdirs": [
                            "res"
                        ],
                        "bindirs": [
                            "bin"
                        ],
                        "builddirs": [
                            ""
                        ],
                        "libs": [
                            "z"
                        ],
                        "rootpath": "/Users/jgsogo/.conan/data/zlib/1.2.11/conan/stable/package/0eaf3bfbc94fb6d2c8f230d052d75c6c1a57a4ce",
                        "version": "1.2.11",
                        "description": "A Massively Spiffy Yet Delicately Unobtrusive Compression Library (Also Free, Not to Mention Unencumbered by Patents)"
                    }
                }
            ]
        }
    ]
}
```

Work to be done, don't know if it is for this PR:
 - remove ``version`` and ``description`` from cpp_info, so it won't appear at the ``packages`` level.
