### PR TITLE
Add --askpass argument to 'sudo' if it is not an interactive terminal

### DIFF
--- a/conans/client/runner.py
+++ b/conans/client/runner.py
@@ -56,7 +56,7 @@ class ConanRunner(object):
 
         try:
             # piping both stdout, stderr and then later only reading one will hang the process
-            # if the other fills the pip. So piping stdout, and redirecting stderr to stdour,
+            # if the other fills the pip. So piping stdout, and redirecting stderr to stdout,
             # so both are merged and use just a single get_stream_lines() call
             proc = Popen(command, shell=True, stdout=PIPE, stderr=STDOUT, cwd=cwd)
         except Exception as e:

--- a/conans/client/tools/system_pm.py
+++ b/conans/client/tools/system_pm.py
@@ -1,5 +1,6 @@
 import os
-from six import string_types
+import sys
+
 from conans.client.runner import ConanRunner
 from conans.client.tools.oss import OSInfo
 from conans.errors import ConanException
@@ -14,9 +15,19 @@ class SystemPackageTool(object):
         os_info = os_info or OSInfo()
         self._is_up_to_date = False
         self._tool = tool or self._create_tool(os_info)
-        self._tool._sudo_str = "sudo " if self._is_sudo_enabled() else ""
+        self._tool._sudo_str = self._get_sudo_str()
         self._tool._runner = runner or ConanRunner()
         self._tool._recommends = recommends
+
+    @staticmethod
+    def _get_sudo_str():
+        if not SystemPackageTool._is_sudo_enabled():
+            return ""
+
+        if hasattr(sys.stdout, "isatty") and sys.stdout.isatty():
+            return "sudo --askpass "
+        else:
+            return "sudo "
 
     @staticmethod
     def _is_sudo_enabled():

--- a/conans/client/tools/system_pm.py
+++ b/conans/client/tools/system_pm.py
@@ -24,7 +24,7 @@ class SystemPackageTool(object):
         if not SystemPackageTool._is_sudo_enabled():
             return ""
 
-        if hasattr(sys.stdout, "isatty") and sys.stdout.isatty():
+        if hasattr(sys.stdout, "isatty") and not sys.stdout.isatty():
             return "sudo --askpass "
         else:
             return "sudo "

--- a/conans/test/util/tools_test.py
+++ b/conans/test/util/tools_test.py
@@ -46,6 +46,18 @@ class SystemPackageToolTest(unittest.TestCase):
         out = TestBufferConanOutput()
         set_global_instances(out, requests)
 
+    def test_sudo_tty(self):
+        with tools.environment_append({"CONAN_SYSREQUIRES_SUDO": "False",}):
+            self.assertFalse(SystemPackageTool._is_sudo_enabled())
+            self.assertEqual(SystemPackageTool._get_sudo_str(), "")
+
+        with tools.environment_append({"CONAN_SYSREQUIRES_SUDO": "True"}):
+            self.assertTrue(SystemPackageTool._is_sudo_enabled())
+            self.assertEqual(SystemPackageTool._get_sudo_str(), "sudo --askpass ")
+
+            with mock.patch("sys.stdout.isatty", return_value=True):
+                self.assertEqual(SystemPackageTool._get_sudo_str(), "sudo ")
+
     def verify_update_test(self):
         # https://github.com/conan-io/conan/issues/3142
         with tools.environment_append({"CONAN_SYSREQUIRES_SUDO": "False",
@@ -86,8 +98,11 @@ class SystemPackageToolTest(unittest.TestCase):
                 self.assertEqual(expected, command)
                 return ret
 
-        def _run_add_repository_test(repository, gpg_key, sudo, update):
-            sudo_cmd = "sudo " if sudo else ""
+        def _run_add_repository_test(repository, gpg_key, sudo, isatty, update):
+            sudo_cmd = ""
+            if sudo:
+                sudo_cmd = "sudo " if isatty else "sudo --askpass "
+
             runner = RunnerOrderedMock()
             runner.commands.append(("{}apt-add-repository {}".format(sudo_cmd, repository), 0))
             if gpg_key:
@@ -110,12 +125,15 @@ class SystemPackageToolTest(unittest.TestCase):
         # Run several test cases
         repository = "deb http://repo/url/ saucy universe multiverse"
         gpg_key = 'http://one/key.gpg'
-        _run_add_repository_test(repository, gpg_key, sudo=True, update=True)
-        _run_add_repository_test(repository, gpg_key, sudo=True, update=False)
-        _run_add_repository_test(repository, gpg_key, sudo=False, update=True)
-        _run_add_repository_test(repository, gpg_key, sudo=False, update=False)
-        _run_add_repository_test(repository, gpg_key=None, sudo=True, update=True)
-        _run_add_repository_test(repository, gpg_key=None, sudo=False, update=False)
+        _run_add_repository_test(repository, gpg_key, sudo=True, isatty=False, update=True)
+        _run_add_repository_test(repository, gpg_key, sudo=True, isatty=False, update=False)
+        _run_add_repository_test(repository, gpg_key, sudo=False, isatty=False, update=True)
+        _run_add_repository_test(repository, gpg_key, sudo=False, isatty=False, update=False)
+        _run_add_repository_test(repository, gpg_key=None, sudo=True, isatty=False, update=True)
+        _run_add_repository_test(repository, gpg_key=None, sudo=False, isatty=True, update=False)
+
+        with mock.patch("sys.stdout.isatty", return_value=True):
+            _run_add_repository_test(repository, gpg_key, sudo=True, isatty=True, update=True)
 
     def system_package_tool_test(self):
 
@@ -129,41 +147,41 @@ class SystemPackageToolTest(unittest.TestCase):
             os_info.linux_distro = "debian"
             spt = SystemPackageTool(runner=runner, os_info=os_info)
             spt.update()
-            self.assertEquals(runner.command_called, "sudo apt-get update")
+            self.assertEquals(runner.command_called, "sudo --askpass apt-get update")
 
             os_info.linux_distro = "ubuntu"
             spt = SystemPackageTool(runner=runner, os_info=os_info)
             spt.update()
-            self.assertEquals(runner.command_called, "sudo apt-get update")
+            self.assertEquals(runner.command_called, "sudo --askpass apt-get update")
 
             os_info.linux_distro = "knoppix"
             spt = SystemPackageTool(runner=runner, os_info=os_info)
             spt.update()
-            self.assertEquals(runner.command_called, "sudo apt-get update")
+            self.assertEquals(runner.command_called, "sudo --askpass apt-get update")
 
             os_info.linux_distro = "fedora"
             spt = SystemPackageTool(runner=runner, os_info=os_info)
             spt.update()
-            self.assertEquals(runner.command_called, "sudo yum update")
+            self.assertEquals(runner.command_called, "sudo --askpass yum update")
 
             os_info.linux_distro = "opensuse"
             spt = SystemPackageTool(runner=runner, os_info=os_info)
             spt.update()
-            self.assertEquals(runner.command_called, "sudo zypper --non-interactive ref")
+            self.assertEquals(runner.command_called, "sudo --askpass zypper --non-interactive ref")
 
             os_info.linux_distro = "redhat"
             spt = SystemPackageTool(runner=runner, os_info=os_info)
             spt.install("a_package", force=False)
             self.assertEquals(runner.command_called, "rpm -q a_package")
             spt.install("a_package", force=True)
-            self.assertEquals(runner.command_called, "sudo yum install -y a_package")
+            self.assertEquals(runner.command_called, "sudo --askpass yum install -y a_package")
 
             os_info.linux_distro = "debian"
             spt = SystemPackageTool(runner=runner, os_info=os_info)
             with self.assertRaises(ConanException):
                 runner.return_ok = False
                 spt.install("a_package")
-                self.assertEquals(runner.command_called, "sudo apt-get install -y --no-install-recommends a_package")
+                self.assertEquals(runner.command_called, "sudo --askpass apt-get install -y --no-install-recommends a_package")
 
             runner.return_ok = True
             spt.install("a_package", force=False)
@@ -184,9 +202,9 @@ class SystemPackageToolTest(unittest.TestCase):
 
             spt = SystemPackageTool(runner=runner, os_info=os_info)
             spt.update()
-            self.assertEquals(runner.command_called, "sudo pkg update")
+            self.assertEquals(runner.command_called, "sudo --askpass pkg update")
             spt.install("a_package", force=True)
-            self.assertEquals(runner.command_called, "sudo pkg install -y a_package")
+            self.assertEquals(runner.command_called, "sudo --askpass pkg install -y a_package")
             spt.install("a_package", force=False)
             self.assertEquals(runner.command_called, "pkg info a_package")
 
@@ -286,13 +304,13 @@ class SystemPackageToolTest(unittest.TestCase):
             spt = SystemPackageTool(runner=runner, tool=AptTool())
             spt.install(packages)
             self.assertEquals(2, runner.calls)
-            runner = RunnerMultipleMock(["sudo apt-get update",
-                                         "sudo apt-get install -y --no-install-recommends yet_another_package"])
+            runner = RunnerMultipleMock(["sudo --askpass apt-get update",
+                                         "sudo --askpass apt-get install -y --no-install-recommends yet_another_package"])
             spt = SystemPackageTool(runner=runner, tool=AptTool())
             spt.install(packages)
             self.assertEquals(7, runner.calls)
 
-            runner = RunnerMultipleMock(["sudo apt-get update"])
+            runner = RunnerMultipleMock(["sudo --askpass apt-get update"])
             spt = SystemPackageTool(runner=runner, tool=AptTool())
             with self.assertRaises(ConanException):
                 spt.install(packages)
@@ -334,7 +352,7 @@ class SystemPackageToolTest(unittest.TestCase):
             "CONAN_SYSREQUIRES_SUDO": "True"
         }):
             packages = ["verify_package", "verify_another_package", "verify_yet_another_package"]
-            runner = RunnerMultipleMock(["sudo apt-get update"])
+            runner = RunnerMultipleMock(["sudo --askpass apt-get update"])
             spt = SystemPackageTool(runner=runner, tool=AptTool())
             with self.assertRaises(ConanException) as exc:
                 spt.install(packages)
@@ -349,7 +367,7 @@ class SystemPackageToolTest(unittest.TestCase):
             "CONAN_SYSREQUIRES_SUDO": "True"
         }):
             packages = ["disabled_package", "disabled_another_package", "disabled_yet_another_package"]
-            runner = RunnerMultipleMock(["sudo apt-get update"])
+            runner = RunnerMultipleMock(["sudo --askpass apt-get update"])
             spt = SystemPackageTool(runner=runner, tool=AptTool())
             spt.install(packages)
             self.assertIn('\n'.join(packages), tools.system_pm._global_output)
@@ -360,7 +378,7 @@ class SystemPackageToolTest(unittest.TestCase):
             "CONAN_SYSREQUIRES_MODE": "EnAbLeD",
             "CONAN_SYSREQUIRES_SUDO": "True"
         }):
-            runner = RunnerMultipleMock(["sudo apt-get update"])
+            runner = RunnerMultipleMock(["sudo --askpass apt-get update"])
             spt = SystemPackageTool(runner=runner, tool=AptTool())
             with self.assertRaises(ConanException) as exc:
                 spt.install(packages)
@@ -391,13 +409,13 @@ class SystemPackageToolTest(unittest.TestCase):
             os_info = OSInfo()
             update_command = None
             if os_info.with_apt:
-                update_command = "sudo apt-get update"
+                update_command = "sudo --askpass apt-get update"
             elif os_info.with_yum:
-                update_command = "sudo yum update"
+                update_command = "sudo --askpass yum update"
             elif os_info.with_zypper:
-                update_command = "sudo zypper --non-interactive ref"
+                update_command = "sudo --askpass zypper --non-interactive ref"
             elif os_info.with_pacman:
-                update_command = "sudo pacman -Syyu --noconfirm"
+                update_command = "sudo --askpass pacman -Syyu --noconfirm"
 
             return "Command '{0}' failed".format(update_command) if update_command is not None else None
 


### PR DESCRIPTION
Changelog: Fix: Add ``--askpass`` argument to ``sudo`` if it is not an interactive terminal

- [x] closes #3285 

I'm supposing that everywhere ``sudo`` is used, the argument ``--askpassp`` is available. I hope this statement to be true 🤞 