### PR TITLE
yum update without confirmation.

### DIFF
--- a/conans/client/tools/system_pm.py
+++ b/conans/client/tools/system_pm.py
@@ -158,7 +158,7 @@ class YumTool(object):
         raise ConanException("YumTool::add_repository not implemented")
 
     def update(self):
-        _run(self._runner, "%syum update" % self._sudo_str, accepted_returns=[0, 100])
+        _run(self._runner, "%syum update -y" % self._sudo_str, accepted_returns=[0, 100])
 
     def install(self, package_name):
         _run(self._runner, "%syum install -y %s" % (self._sudo_str, package_name))

--- a/conans/test/util/tools_test.py
+++ b/conans/test/util/tools_test.py
@@ -144,7 +144,7 @@ class SystemPackageToolTest(unittest.TestCase):
             os_info.linux_distro = "fedora"
             spt = SystemPackageTool(runner=runner, os_info=os_info)
             spt.update()
-            self.assertEquals(runner.command_called, "sudo yum update")
+            self.assertEquals(runner.command_called, "sudo yum update -y")
 
             os_info.linux_distro = "opensuse"
             spt = SystemPackageTool(runner=runner, os_info=os_info)

--- a/conans/test/util/tools_test.py
+++ b/conans/test/util/tools_test.py
@@ -212,7 +212,7 @@ class SystemPackageToolTest(unittest.TestCase):
             spt.install("a_package", force=True)
             self.assertEquals(runner.command_called, "yum install -y a_package")
             spt.update()
-            self.assertEquals(runner.command_called, "yum update")
+            self.assertEquals(runner.command_called, "yum update -y")
 
             os_info.linux_distro = "ubuntu"
             spt = SystemPackageTool(runner=runner, os_info=os_info)
@@ -393,7 +393,7 @@ class SystemPackageToolTest(unittest.TestCase):
             if os_info.with_apt:
                 update_command = "sudo apt-get update"
             elif os_info.with_yum:
-                update_command = "sudo yum update"
+                update_command = "sudo yum update -y"
             elif os_info.with_zypper:
                 update_command = "sudo zypper --non-interactive ref"
             elif os_info.with_pacman:


### PR DESCRIPTION
Changelog: (Bugfix):  `yum update` needs user's confirmation, which breaks system update in Centos non-interactive terminal.

- [x] I've read the [Contributing guide](https://raw.githubusercontent.com/conan-io/conan/develop/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [x] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 


