### PR TITLE
Handle old versions (<1.8) of SVN

### DIFF
--- a/conans/client/tools/scm.py
+++ b/conans/client/tools/scm.py
@@ -286,8 +286,8 @@ class SVN(SCMBase):
         else:
             import warnings
             warnings.warn("SVN::is_pristine for SVN v{} (less than {}) is not implemented, it is"
-                          "returning not-pristine always because it cannot compare with"
-                          "checkout version.".format(self.version, SVN.API_CHANGE_VERSION))
+                          " returning not-pristine always because it cannot compare with"
+                          " checked out version.".format(self.version, SVN.API_CHANGE_VERSION))
             return False
 
     def get_revision(self):

--- a/conans/test/util/tools_test.py
+++ b/conans/test/util/tools_test.py
@@ -1624,8 +1624,9 @@ class SVNToolTestsBasic(SVNLocalRepoTestCase):
 
         self.assertFalse(svn.is_pristine())
         svn.checkout(url=project_url)  # SVN::clone over a dirty repo reverts all changes (but it doesn't delete non versioned files)
-        self.assertTrue(svn.is_pristine())
-        # self.assertFalse(os.path.exists(new_file))
+        if svn.version >= SVN.API_CHANGE_VERSION:  # SVN::is_pristine returns always False.
+            self.assertTrue(svn.is_pristine())
+            # self.assertFalse(os.path.exists(new_file))
 
     def test_excluded_files(self):
         project_url, _ = self.create_project(files={'myfile': "contents"})
@@ -1774,6 +1775,7 @@ class SVNToolTestsBasicOldVersion(SVNToolTestsBasic):
     # Do not add tests to this class, all should be compatible with new version of SVN
 
 
+@unittest.skipUnless(SVN.get_version() >= SVN.API_CHANGE_VERSION, "SVN::is_pristine not implemented")
 class SVNToolTestsPristine(SVNLocalRepoTestCase):
 
     def test_checkout(self):

--- a/conans/test/util/tools_test.py
+++ b/conans/test/util/tools_test.py
@@ -14,6 +14,7 @@ from six import StringIO
 from six.moves.urllib.parse import unquote
 
 from conans.client.client_cache import CONAN_CONF
+from conans.model.version import Version
 
 from conans import tools
 from conans.client.conan_api import ConanAPIV1
@@ -1565,7 +1566,6 @@ class HelloConan(ConanFile):
 
 
 class SVNToolTestsBasic(SVNLocalRepoTestCase):
-
     def test_clone(self):
         project_url, _ = self.create_project(files={'myfile': "contents"})
         tmp_folder = self.gimme_tmp()
@@ -1677,7 +1677,7 @@ class SVNToolTestsBasic(SVNLocalRepoTestCase):
         svn = SVN(folder=self.gimme_tmp(), username="peter", password="otool", verify_ssl=False)
         runner = MyRunner(svn)
         svn.checkout(url=project_url)
-        if SVN.get_version() >= SVN.API_CHANGE_VERSION:
+        if svn.version >= SVN.API_CHANGE_VERSION:
             self.assertIn("--trust-server-cert-failures=unknown-ca", runner.calls[1])
         else:
             self.assertIn("--trust-server-cert", runner.calls[1])
@@ -1758,6 +1758,20 @@ class SVNToolTestsBasic(SVNLocalRepoTestCase):
         svn = SVN(folder=self.gimme_tmp())
         svn.checkout(url='/'.join([project_url, 'prj1', 'tags', 'v12.3.4']))
         self.assertEqual("tags/v12.3.4", svn.get_branch())
+
+
+class SVNToolTestsBasicOldVersion(SVNToolTestsBasic):
+    def run(self, *args, **kwargs):
+        try:
+            setattr(SVN, '_version', Version("1.5"))
+            self.assertTrue(SVN().version < SVN.API_CHANGE_VERSION)
+            super(SVNToolTestsBasicOldVersion, self).run(*args, **kwargs)
+        finally:
+            delattr(SVN, '_version')
+            assert SVN().version == SVN.get_version(), \
+                "{} != {}".format(SVN().version, SVN.get_version())
+
+    # Do not add tests to this class, all should be compatible with new version of SVN
 
 
 class SVNToolTestsPristine(SVNLocalRepoTestCase):

--- a/conans/test/utils/tools.py
+++ b/conans/test/utils/tools.py
@@ -350,7 +350,13 @@ class SVNLocalRepoTestCase(unittest.TestCase):
             with chdir(tmp_project_dir):
                 subprocess.check_output("svn add .", shell=True)
                 subprocess.check_output('svn commit -m "{}"'.format(commit_msg), shell=True)
-                rev = subprocess.check_output("svn info --show-item revision", shell=True).decode().strip()
+                if SVN.get_version() >= SVN.API_CHANGE_VERSION:
+                    rev = subprocess.check_output("svn info --show-item revision", shell=True).decode().strip()
+                else:
+                    import xml.etree.ElementTree as ET
+                    output = subprocess.check_output("svn info --xml", shell=True).decode().strip()
+                    root = ET.fromstring(output)
+                    rev = root.findall("./entry")[0].get("revision")
             project_url = self.repo_url + "/" + quote(rel_project_path.replace("\\", "/"))
             return project_url, rev
         finally:


### PR DESCRIPTION
Changelog: Fix: Use XML output to retrieve information from SVN command line if its client version is less than 1.8 (command ``--show-item`` is not available).

Changelog: Fix: SVN v1.7 does not have ``-r`` argument in ``svn status``, so functionality ``SVN::is_pristine`` won't be available. 

- [x] close #3737
- [x] No docs needed.

Here it is a PR to handle interface changes (detected up to now) between SVN 1.7.x and newer versions:

![image](https://user-images.githubusercontent.com/1406456/47026034-dbd67580-d164-11e8-9f7c-df7c7e5c2780.png)

It should work for the use-cases reported up to now, but new issues will raise and we are not running CI tests with old SVN versions so we may break something in the future 😰 