### PR TITLE
Enable "unhack" user and channel

### DIFF
--- a/conans/model/conan_file.py
+++ b/conans/model/conan_file.py
@@ -165,7 +165,7 @@ class ConanFile(object):
     @property
     def channel(self):
         if not self._conan_channel:
-            self._conan_channel = os.getenv("CONAN_CHANNEL") or self.default_channel()
+            self._conan_channel = os.getenv("CONAN_CHANNEL") or self.default_channel
             if not self._conan_channel:
                 raise ConanException("CONAN_CHANNEL environment variable not defined, "
                                      "but self.channel is used in conanfile")
@@ -174,7 +174,7 @@ class ConanFile(object):
     @property
     def user(self):
         if not self._conan_user:
-            self._conan_user = os.getenv("CONAN_USERNAME") or self.default_user()
+            self._conan_user = os.getenv("CONAN_USERNAME") or self.default_user
             if not self._conan_user:
                 raise ConanException("CONAN_USERNAME environment variable not defined, "
                                      "but self.user is used in conanfile")
@@ -196,12 +196,14 @@ class ConanFile(object):
     def source(self):
         pass
 
+    @property
     def default_user(self):
         """
         this method can be overwritten to return a user if no user has been specified (local method)
         and there is no CONAN_USERNAME declared env var
         """
 
+    @property
     def default_channel(self):
         """
         this method can be overwritten to return a channel if no channel has been specified

--- a/conans/model/conan_file.py
+++ b/conans/model/conan_file.py
@@ -165,7 +165,7 @@ class ConanFile(object):
     @property
     def channel(self):
         if not self._conan_channel:
-            self._conan_channel = os.getenv("CONAN_CHANNEL")
+            self._conan_channel = os.getenv("CONAN_CHANNEL") or self.default_channel()
             if not self._conan_channel:
                 raise ConanException("CONAN_CHANNEL environment variable not defined, "
                                      "but self.channel is used in conanfile")
@@ -174,7 +174,7 @@ class ConanFile(object):
     @property
     def user(self):
         if not self._conan_user:
-            self._conan_user = os.getenv("CONAN_USERNAME")
+            self._conan_user = os.getenv("CONAN_USERNAME") or self.default_user()
             if not self._conan_user:
                 raise ConanException("CONAN_USERNAME environment variable not defined, "
                                      "but self.user is used in conanfile")
@@ -195,6 +195,18 @@ class ConanFile(object):
 
     def source(self):
         pass
+
+    def default_user(self):
+        """
+        this method can be overwritten to return a user if no user has been specified (local method)
+        and there is no CONAN_USERNAME declared env var
+        """
+
+    def default_channel(self):
+        """
+        this method can be overwritten to return a channel if no channel has been specified
+        (local method) and there is no CONAN_CHANNEL declared env var
+        """
 
     def system_requirements(self):
         """ this method can be overwritten to implement logic for system package

--- a/conans/model/conan_file.py
+++ b/conans/model/conan_file.py
@@ -105,6 +105,10 @@ class ConanFile(object):
     in_local_cache = True
     develop = False
 
+    # Defaulting the reference fields
+    default_channel = None
+    default_user = None
+
     def __init__(self, output, runner, user=None, channel=None):
         # an output stream (writeln, info, warn error)
         self.output = output
@@ -195,20 +199,6 @@ class ConanFile(object):
 
     def source(self):
         pass
-
-    @property
-    def default_user(self):
-        """
-        this method can be overwritten to return a user if no user has been specified (local method)
-        and there is no CONAN_USERNAME declared env var
-        """
-
-    @property
-    def default_channel(self):
-        """
-        this method can be overwritten to return a channel if no channel has been specified
-        (local method) and there is no CONAN_CHANNEL declared env var
-        """
 
     def system_requirements(self):
         """ this method can be overwritten to implement logic for system package

--- a/conans/test/integration/same_userchannel_test.py
+++ b/conans/test/integration/same_userchannel_test.py
@@ -128,13 +128,12 @@ class SayConan(ConanFile):
     name = "Say"
     version = "0.1"
     build_policy = "missing"
+    default_user = "userfoo"
     
     def build(self):
         self.output.info("Building %s/%s" % (self.user, self.channel) )
 
-    def default_user(self):
-        return "userfoo"
-        
+    @property
     def default_channel(self):
         return "channelbar"
 """

--- a/conans/test/integration/same_userchannel_test.py
+++ b/conans/test/integration/same_userchannel_test.py
@@ -119,6 +119,30 @@ class HelloReuseConan(ConanFile):
         del os.environ["CONAN_USERNAME"]
         del os.environ["CONAN_CHANNEL"]
 
+        # Now use the default_ methods to declare user and channel
+        self.client = TestClient()
+        conanfile = """
+from conans import ConanFile
+
+class SayConan(ConanFile):
+    name = "Say"
+    version = "0.1"
+    build_policy = "missing"
+    
+    def build(self):
+        self.output.info("Building %s/%s" % (self.user, self.channel) )
+
+    def default_user(self):
+        return "userfoo"
+        
+    def default_channel(self):
+        return "channelbar"
+"""
+        self.client.save({"conanfile.py": conanfile})
+        self.client.run("install .")
+        self.client.run("build .")
+        self.assertIn("Building userfoo/channelbar", self.client.out)
+
 
 class BuildRequireUserChannelTest(unittest.TestCase):
     def test(self):


### PR DESCRIPTION
Changelog: Feature: New attributes `default_user` and `default_channel` that can be declared in a conanfile to specify the `user` and `channel` for conan local methods when neither `CONAN_USERNAME` and `CONAN_CHANNEL` environment variables exist. 

- [x] Refer to the issue that supports this Pull Request. #3697