### PR TITLE
Up tqdm to 4.27: fix weakref warning

### DIFF
--- a/conans/requirements.txt
+++ b/conans/requirements.txt
@@ -12,4 +12,4 @@ future==0.16.0
 pygments>=2.0, <3.0
 astroid>=1.6.5
 deprecation>=2.0, <2.1
-tqdm==4.20.0
+tqdm>=4.27.0, <5.0


### PR DESCRIPTION
Changelog: Fix: Upgrade dependency of tqdm to >=4.27: solves issue with weakref assertion.

 * Unlocks tqdm==4.20.0 that was fixed here: https://github.com/conan-io/conan/pull/3545#issuecomment-421068377
 * Could avoid issues like #3728 because now we have an open dependency and it won't fail if the installed one satisfies our requirement.
