### PR TITLE
using profile or settings in export-pkg allowed

### DIFF
--- a/conans/client/conan_api.py
+++ b/conans/client/conan_api.py
@@ -398,14 +398,8 @@ class ConanAPIV1(object):
         source_folder = _make_abs_path(source_folder, cwd, default=os.path.dirname(conanfile_path))
 
         # Checks that no both settings and info files are specified
-        if install_folder and existing_info_files(install_folder) and \
-                (profile_name or settings or options or env):
-            raise ConanException("%s and %s are found, at '%s' folder, so specifying profile, "
-                                 "settings, options or env is not allowed" % (CONANINFO, BUILD_INFO,
-                                                                              install_folder))
-
         infos_present = existing_info_files(install_folder)
-        if not infos_present:
+        if profile_name or settings or options or env or not infos_present:
             profile = profile_from_args(profile_name, settings, options, env=env,
                                         cwd=cwd, client_cache=self._client_cache)
         else:

--- a/conans/client/packager.py
+++ b/conans/client/packager.py
@@ -5,7 +5,8 @@ from conans.client import tools
 from conans.util.files import mkdir, save, rmdir
 from conans.util.log import logger
 from conans.paths import CONANINFO
-from conans.errors import ConanException, ConanExceptionInUserConanfileMethod, conanfile_exception_formatter
+from conans.errors import (ConanException, ConanExceptionInUserConanfileMethod,
+                           conanfile_exception_formatter)
 from conans.model.manifest import FileTreeManifest
 from conans.client.output import ScopedOutput
 from conans.client.file_copier import FileCopier
@@ -17,7 +18,6 @@ def export_pkg(conanfile, pkg_id, src_package_folder, package_folder, output, pl
     conanfile.package_folder = src_package_folder
     output.info("Exporting to cache existing package from user folder")
     output.info("Package folder %s" % package_folder)
-    print("export_pkg", type(reference))
     plugin_manager.execute("pre_package", conanfile=conanfile, conanfile_path=conanfile_path,
                            reference=reference, package_id=pkg_id)
 


### PR DESCRIPTION
Changelog: Fix: Allow providing ``--profile`` argument (and settings, options, env, too) to ``conan export-pkg``, so it is able to correctly compute the binary package_id in case the information captured in the installed conaninfo.txt in previous ``conan install`` does not contain all information to reconstruct the graph.

- [x] Refer to the issue that supports this Pull Request.
Close #3367

Docs in https://github.com/conan-io/docs/pull/898

There is no information enough in conaninfo.txt to recover all cases, and compute the whole dependency graph, which is necessary for correctly computing the package_id of the binary being exported. So this PR allows to specify the profile (or settings, options, env) that define the binary, instead of trying to recover it from the installed conaninfo.txt


