### PR TITLE
Fix: use self._run instead of self._conanfile.run to ensure vcvars apply for Ninja/NMake generators

### DIFF
--- a/conans/client/build/cmake.py
+++ b/conans/client/build/cmake.py
@@ -180,9 +180,9 @@ class CMake(object):
             command = "cd %s && cmake %s" % (args_to_string([self.build_dir]), arg_list)
             if platform.system() == "Windows" and self.generator == "MinGW Makefiles":
                 with tools.remove_from_path("sh"):
-                    self._conanfile.run(command)
+                    self._run(command)
             else:
-                self._conanfile.run(command)
+                self._run(command)
 
     def build(self, args=None, build_dir=None, target=None):
         if not self._conanfile.should_build:


### PR DESCRIPTION
follow up on https://github.com/conan-io/conan/pull/2803

when using `ninja_installer/1.8.2@bincrafters/stable`, right now the following code is required:

```
        if self.settings.compiler == 'Visual Studio':
            with tools.vcvars(self.settings, force=True, filter_known_paths=False):
                self.build_cmake()
        else:
            self.build_cmake()
```

I tried to simplify it in our `zmq/4.2.2@bincrafters/stable` recipe, but it currently fails, because there are places in `CMake` helper which use `self._conanfile.run` directly instead of `self._run`:

https://github.com/conan-io/conan/blob/1.8.3/conans/client/build/cmake.py#L183
https://github.com/conan-io/conan/blob/1.8.3/conans/client/build/cmake.py#L185

Changelog: (Feature | Fix | Bugfix): Describe here your pull request

- [x] Refer to the issue that supports this Pull Request.
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://raw.githubusercontent.com/conan-io/conan/develop/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 


