### PR TITLE
Remove package refs when packages are removed

### DIFF
--- a/conans/client/remover.py
+++ b/conans/client/remover.py
@@ -1,13 +1,12 @@
 import os
-
 from conans.client.remote_registry import Remote
 from conans.errors import ConanException
-from conans.util.log import logger
+from conans.model.ref import ConanFileReference
 from conans.model.ref import PackageReference
 from conans.paths import SYSTEM_REQS, rm_conandir
-from conans.model.ref import ConanFileReference
-from conans.search.search import filter_outdated, search_recipes,\
+from conans.search.search import filter_outdated, search_recipes, \
     search_packages
+from conans.util.log import logger
 
 
 class DiskRemover(object):
@@ -95,12 +94,15 @@ class ConanRemover(object):
         assert(isinstance(remote, Remote))
         if package_ids is None:
             result = self._remote_manager.remove(reference, remote)
-            current_remote = self._registry.refs.get(reference)
-            if current_remote == remote:
-                self._registry.refs.remove(reference)
+            self._registry.refs.remove(reference, remote_name=remote.name)
+            self._registry.prefs.remove_all(reference, remote_name=remote.name)
             return result
         else:
-            return self._remote_manager.remove_packages(reference, package_ids, remote)
+            tmp = self._remote_manager.remove_packages(reference, package_ids, remote)
+            for pid in package_ids:
+                pref = PackageReference(reference, pid)
+                self._registry.prefs.remove(pref, remote_name=remote.name)
+            return tmp
 
     def _local_remove(self, reference, src, build_ids, package_ids):
         # Make sure to clean the locks too
@@ -112,6 +114,9 @@ class ConanRemover(object):
             remover.remove_builds(reference, build_ids)
         if package_ids is not None:
             remover.remove_packages(reference, package_ids)
+            for pid in package_ids:
+                pref = PackageReference(reference, pid)
+                self._registry.prefs.remove(pref)
         if not src and build_ids is None and package_ids is None:
             remover.remove(reference)
             self._registry.refs.remove(reference, quiet=True)

--- a/conans/model/ref.py
+++ b/conans/model/ref.py
@@ -130,6 +130,14 @@ class ConanFileReference(namedtuple("ConanFileReference", "name version user cha
         ret.revision = None
         return ret
 
+    def matches_with_ref(self, other):
+        # if other hasn't revision and the current obj has it, it matches
+        # otherwise the revision and the reference should be equal
+        if not other.revision:
+            return super(ConanFileReference, self).__eq__(other)
+        else:
+            return self == other
+
 
 class PackageReference(namedtuple("PackageReference", "conan package_id")):
     """ Full package reference, e.g.:

--- a/conans/test/functional/registry_test.py
+++ b/conans/test/functional/registry_test.py
@@ -3,7 +3,7 @@ import os
 from conans.test.utils.test_files import temp_folder
 from conans.client.remote_registry import RemoteRegistry, migrate_registry_file, dump_registry, \
     default_remotes
-from conans.model.ref import ConanFileReference
+from conans.model.ref import ConanFileReference, PackageReference
 from conans.errors import ConanException
 from conans.test.utils.tools import TestBufferConanOutput, TestClient
 from conans.util.files import save
@@ -114,3 +114,42 @@ other/1.0@lasote/testing conan.io
                                             ("repo2", "url2", True),
                                             ("conan.io", "https://server.conan.io", True),
                                             ("repo3", "url3", True)])
+
+    def remove_all_package_test(self):
+        f = os.path.join(temp_folder(), "aux_file")
+        save(f, dump_registry(default_remotes, {}, {}))
+        registry = RemoteRegistry(f, TestBufferConanOutput())
+
+        registry.remotes.add("r1", "url1", True, insert=0)
+        registry.remotes.add("r2", "url2", True, insert=0)
+
+        ref = ConanFileReference.loads("MyLib/0.1@lasote/stable")
+        ref2 = ConanFileReference.loads("MyLib2/0.1@lasote/stable")
+
+        registry.prefs.set(PackageReference(ref, "1"), "r1")
+        registry.prefs.set(PackageReference(ref, "2"), "r1")
+        registry.prefs.set(PackageReference(ref, "3"), "r1")
+        registry.prefs.set(PackageReference(ref, "4"), "r2")
+        registry.prefs.set(PackageReference(ref2, "1"), "r1")
+
+        registry.prefs.remove_all(ref)
+
+        self.assertIsNone(registry.prefs.get(PackageReference(ref, "1")))
+        self.assertIsNone(registry.prefs.get(PackageReference(ref, "2")))
+        self.assertIsNone(registry.prefs.get(PackageReference(ref, "3")))
+        self.assertIsNone(registry.prefs.get(PackageReference(ref, "4")))
+        self.assertEquals(registry.prefs.get(PackageReference(ref2, "1")).name, "r1")
+
+        registry.prefs.set(PackageReference(ref, "1"), "r1")
+        registry.prefs.set(PackageReference(ref, "2"), "r1")
+        registry.prefs.set(PackageReference(ref, "3"), "r1")
+        registry.prefs.set(PackageReference(ref, "4"), "r2")
+        registry.prefs.set(PackageReference(ref2, "1"), "r1")
+
+        registry.prefs.remove_all(ref, "r1")
+
+        self.assertIsNone(registry.prefs.get(PackageReference(ref, "1")))
+        self.assertIsNone(registry.prefs.get(PackageReference(ref, "2")))
+        self.assertIsNone(registry.prefs.get(PackageReference(ref, "3")))
+        self.assertEquals(registry.prefs.get(PackageReference(ref, "4")).name, "r2")
+        self.assertEquals(registry.prefs.get(PackageReference(ref2, "1")).name, "r1")

--- a/conans/test/model/ref_test.py
+++ b/conans/test/model/ref_test.py
@@ -43,6 +43,22 @@ class RefTest(unittest.TestCase):
         self.assertRaises(ConanException, ConanFileReference.loads,
                           "opencv/2.4.10@laso/testing%s" % "A" * 40)
 
+    def check_with_revision_test(self):
+        _br = ConanFileReference.loads
+        ref = _br("opencv/2.4.10@3rd-party/testing")
+        self.assertTrue(ref.matches_with_ref(ref))
+
+        self.assertFalse(ref.matches_with_ref(_br("opencv/2.4.10@3rd-party/testing#Revision")))
+        self.assertTrue(_br("opencv/2.4.10@3rd-party/testing#Revision").matches_with_ref(ref))
+
+        self.assertTrue(_br("opencv/2.4.10@3rd-party/"
+                            "testing#Revision").matches_with_ref(_br("opencv/2.4.10@3rd-party/"
+                                                                     "testing#Revision")))
+
+        self.assertFalse(_br("opencv/2.4.10@3rd-party/"
+                             "testing#Revision2").matches_with_ref(_br("opencv/2.4.10@3rd-party/"
+                                                                       "testing#Revision1")))
+
 
 class ConanNameTestCase(unittest.TestCase):
 


### PR DESCRIPTION
Changelog: omit

I realized that the package references in the registry were not removed when removed packages/recipes. I need all this for the revisions branch iteration.