### PR TITLE
Check for UnicodeEncodeError when reading .count-file

### DIFF
--- a/conans/util/locks.py
+++ b/conans/util/locks.py
@@ -60,7 +60,8 @@ class Lock(object):
     def _readers(self):
         try:
             return int(load(self._count_file))
-        except IOError:
+        except (IOError, UnicodeEncodeError, ValueError):
+            self._output.warn("%s does not contain a number!" % self._count_file)
             return 0
 
 


### PR DESCRIPTION
Changelog: Fix: Handling corrupted lock files in cache

- [x] Refer to the issue that supports this Pull Request.
Fix #3815


