### PR TITLE
[SVN] Ignore line if it is empty

### DIFF
--- a/conans/client/tools/scm.py
+++ b/conans/client/tools/scm.py
@@ -227,7 +227,7 @@ class SVN(SCMBase):
         excluded_list = []
         output = self.run("status --no-ignore")
         for it in output.splitlines():
-            if it[0] == 'I':  # Only ignored files
+            if it.startswith('I'):  # Only ignored files
                 filepath = it[8:].strip()
                 excluded_list.append(os.path.normpath(filepath))
         return excluded_list


### PR DESCRIPTION
Changelog: Fix: Ignore empty line when parsing output inside `SVN::excluded_files` function.

- [x] closes #3810

