### PR TITLE
Fix: call vcvars for clang-cl as well

### DIFF
--- a/conans/client/build/cmake.py
+++ b/conans/client/build/cmake.py
@@ -138,8 +138,10 @@ class CMake(object):
 
     def _run(self, command):
         compiler = self._settings.get_safe("compiler")
-        if compiler == 'Visual Studio' and self.generator in ['Ninja', 'NMake Makefiles',
-                                                              'NMake Makefiles JOM']:
+        the_os = self._settings.get_safe("os")
+        is_clangcl = the_os == 'Windows' and compiler == 'clang'
+        is_msvc = compiler == 'Visual Studio'
+        if (is_msvc or is_clangcl) and self.generator in ['Ninja', 'NMake Makefiles', 'NMake Makefiles JOM']:
             with tools.vcvars(self._settings, force=True, filter_known_paths=False):
                 self._conanfile.run(command)
         else:

--- a/conans/test/build_helpers/cmake_test.py
+++ b/conans/test/build_helpers/cmake_test.py
@@ -1089,13 +1089,19 @@ build_type: [ Release]
         pattern = "%s" if sys.platform == "win32" else r"'%s'"
         return ' '.join(pattern % i for i in args.split())
 
-    @parameterized.expand([('Ninja',), ('NMake Makefiles',), ('NMake Makefiles JOM',)])
-    def test_vcvars_applied(self, generator):
+    @parameterized.expand([('Ninja', 'Visual Studio', 15),
+                           ('NMake Makefiles', 'Visual Studio', 15),
+                           ('NMake Makefiles JOM', 'Visual Studio', 15),
+                           ('Ninja', 'clang', 6.0),
+                           ('NMake Makefiles', 'clang', 6.0),
+                           ('NMake Makefiles JOM', 'clang', 6.0)
+                           ])
+    def test_vcvars_applied(self, generator, compiler, version):
         conanfile = ConanFileMock()
         settings = Settings.loads(default_settings_yml)
         settings.os = "Windows"
-        settings.compiler = 'Visual Studio'
-        settings.compiler.version = 15
+        settings.compiler = compiler
+        settings.compiler.version = version
         conanfile.settings = settings
 
         cmake = CMake(conanfile, generator=generator)
@@ -1104,13 +1110,13 @@ build_type: [ Release]
             vcvars_mock.__enter__ = mock.MagicMock(return_value=(mock.MagicMock(), None))
             vcvars_mock.__exit__ = mock.MagicMock(return_value=None)
             cmake.configure()
-            self.assertTrue(vcvars_mock.called)
+            self.assertTrue(vcvars_mock.called, "vcvars weren't called")
 
         with mock.patch("conans.tools.vcvars") as vcvars_mock:
             vcvars_mock.__enter__ = mock.MagicMock(return_value=(mock.MagicMock(), None))
             vcvars_mock.__exit__ = mock.MagicMock(return_value=None)
             cmake.build()
-            self.assertTrue(vcvars_mock.called)
+            self.assertTrue(vcvars_mock.called, "vcvars weren't called")
 
 
 class ConanFileMock(ConanFile):


### PR DESCRIPTION
follow up on #3803 
clang-cl also requires vcvars to be set, otherwise CMake generation fails (it will fail to find `rc.exe`)

Changelog: (Feature | Fix | Bugfix): Describe here your pull request

- [x] Refer to the issue that supports this Pull Request.
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://raw.githubusercontent.com/conan-io/conan/develop/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 


