### PR TITLE
Don't touch registry when deleted from a remote

### DIFF
--- a/conans/client/remover.py
+++ b/conans/client/remover.py
@@ -93,15 +93,9 @@ class ConanRemover(object):
     def _remote_remove(self, reference, package_ids, remote):
         assert(isinstance(remote, Remote))
         if package_ids is None:
-            result = self._remote_manager.remove(reference, remote)
-            self._registry.refs.remove(reference, remote_name=remote.name)
-            self._registry.prefs.remove_all(reference, remote_name=remote.name)
-            return result
+            return self._remote_manager.remove(reference, remote)
         else:
             tmp = self._remote_manager.remove_packages(reference, package_ids, remote)
-            for pid in package_ids:
-                pref = PackageReference(reference, pid)
-                self._registry.prefs.remove(pref, remote_name=remote.name)
             return tmp
 
     def _local_remove(self, reference, src, build_ids, package_ids):

--- a/conans/test/command/remote_test.py
+++ b/conans/test/command/remote_test.py
@@ -37,11 +37,11 @@ class HelloConan(ConanFile):
         self.client.run('remote list_ref')
         self.assertIn("lib/1.0@lasote/channel: remote1", self.client.out)
 
-        # Upload again to remote2 and remove from remote1, the ref should be removed
+        # Upload again to remote2 and remove from remote1, the ref shouldm't be removed
         self.client.run('upload "*" -c -r remote2')
         self.client.run('remove "lib/1.0@lasote/channel" -f -r remote1')
         self.client.run('remote list_ref')
-        self.assertNotIn("lib/1.0@lasote/channel: remote1", self.client.out)
+        self.assertIn("lib/1.0@lasote/channel: remote1", self.client.out)
 
         # Test the packages references now
         self.client.run('upload "*" -c -r remote1 --all')
@@ -57,13 +57,13 @@ class HelloConan(ConanFile):
         self.assertIn("lib/1.0@lasote/channel:5ab84d6acfe1f23c4fae0ab88f26e3a396351ac9: remote1",
                       self.client.out)
 
-        # Upload again to remote2 and remove from remote1, the ref should be removed
+        # Upload again to remote2 and remove from remote1, the ref shouldn't be removed
         self.client.run('upload "*" -c -r remote2 --all')
         self.client.run('remove "lib/1.0@lasote/channel" '
                         '-p 5ab84d6acfe1f23c4fae0ab88f26e3a396351ac9 -f -r remote1')
         self.client.run('remote list_ref')
         self.client.run('remote list_pref lib/1.0@lasote/channel')
-        self.assertNotIn("lib/1.0@lasote/channel:5ab84d6acfe1f23c4fae0ab88f26e3a396351ac9: remote1",
+        self.assertIn("lib/1.0@lasote/channel:5ab84d6acfe1f23c4fae0ab88f26e3a396351ac9: remote1",
                          self.client.out)
 
         # Remove package locally


### PR DESCRIPTION
Changelog: Fix: The registry won't remove a reference to a remote removed recipe or package.
