### PR TITLE
Add neon as linux distro for SystemPackageTools

### DIFF
--- a/conans/client/tools/oss.py
+++ b/conans/client/tools/oss.py
@@ -119,7 +119,7 @@ class OSInfo(object):
     @property
     def with_apt(self):
         return self.is_linux and self.linux_distro in \
-                                 ("debian", "ubuntu", "knoppix", "linuxmint", "raspbian")
+                                 ("debian", "ubuntu", "knoppix", "linuxmint", "raspbian", "neon")
 
     @property
     def with_yum(self):

--- a/conans/test/util/tools_test.py
+++ b/conans/test/util/tools_test.py
@@ -160,6 +160,11 @@ class SystemPackageToolTest(unittest.TestCase):
             spt.update()
             self.assertEquals(runner.command_called, "sudo --askpass apt-get update")
 
+            os_info.linux_distro = "neon"
+            spt = SystemPackageTool(runner=runner, os_info=os_info)
+            spt.update()
+            self.assertEquals(runner.command_called, "sudo --askpass apt-get update")
+
             os_info.linux_distro = "fedora"
             spt = SystemPackageTool(runner=runner, os_info=os_info)
             spt.update()


### PR DESCRIPTION
Changelog: Fix: Add ``neon`` as linux distro for SystemPackageTools

- [x] Refer to the issue that supports this Pull Request: closes #3719 
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://raw.githubusercontent.com/conan-io/conan/develop/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [x] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 


