### PR TITLE
Feature/remove warning lock

### DIFF
--- a/conans/test/functional/package_integrity_test.py
+++ b/conans/test/functional/package_integrity_test.py
@@ -13,6 +13,7 @@ class PackageIngrityTest(unittest.TestCase):
         client = TestClient()
         client.save({"conanfile.py": str(TestConanFile())})
         client.run("create . lasote/testing")
+        self.assertNotIn('does not contain a number!', client.out)
         ref = ConanFileReference.loads("Hello/0.1@lasote/testing")
         conan_folder = client.client_cache.conan(ref)
         self.assertIn("locks", os.listdir(conan_folder))

--- a/conans/util/locks.py
+++ b/conans/util/locks.py
@@ -60,7 +60,9 @@ class Lock(object):
     def _readers(self):
         try:
             return int(load(self._count_file))
-        except (IOError, UnicodeEncodeError, ValueError):
+        except IOError:
+            return 0
+        except (UnicodeEncodeError, ValueError):
             self._output.warn("%s does not contain a number!" % self._count_file)
             return 0
 


### PR DESCRIPTION
Changelog: Omit

Complementing https://github.com/conan-io/conan/pull/3816, because the warning shouldn't be displayed for file creation


cc/ @pianoslum 
