### PR TITLE
Revert "Test and fix for read only files from `svn:needs-lock`attribute"

### DIFF
--- a/conans/client/cmd/export.py
+++ b/conans/client/cmd/export.py
@@ -1,6 +1,5 @@
 import ast
 import os
-import stat
 import shutil
 import six
 from conans.client.cmd.export_linter import conan_linter
@@ -141,9 +140,6 @@ def _replace_scm_data_in_conanfile(conanfile_path, scm_data):
     new_text = "scm = " + ",\n          ".join(str(scm_data).split(",")) + "\n"
     content = content.replace(to_replace[0], new_text)
     content = content if not headers else ''.join(headers) + content
-    
-    if not os.access(conanfile_path, os.W_OK):
-        os.chmod(conanfile_path, stat.S_IRWXU | stat.S_IRWXG | stat.S_IRWXO)  # 0777
     save(conanfile_path, content)
 
 

--- a/conans/client/source.py
+++ b/conans/client/source.py
@@ -1,6 +1,5 @@
 import os
 import shutil
-import stat
 
 import six
 
@@ -67,8 +66,6 @@ def merge_directories(src, dst, excluded=None, symlinks=True):
                 linkto = os.readlink(src_file)
                 os.symlink(linkto, dst_file)
             else:
-                if os.path.isfile(dst_file) and not os.access(dst_file, os.W_OK):
-                    os.chmod(dst_file, stat.S_IRWXU | stat.S_IRWXG | stat.S_IRWXO)  # 0777
                 shutil.copy2(src_file, dst_file)
 
 

--- a/conans/test/functional/scm_test.py
+++ b/conans/test/functional/scm_test.py
@@ -1,6 +1,5 @@
 import json
 import os
-import stat
 import unittest
 from collections import namedtuple
 
@@ -562,39 +561,6 @@ class ConanLib(ConanFile):
                       str(self.client.out).lower())
         self.assertIn("My file is copied", self.client.out)
 
-    def test_with_locked_svn(self):
-        conanfile = base_svn.format(directory="None", url="auto", revision="auto")
-        project_url, rev = self.create_project(files={"conanfile.py": conanfile,
-                                                      "myfile.txt": "My file is copied"},
-                                               lock_repo=True)
-        project_url = project_url.replace(" ", "%20")
-        self.client.runner('svn co "{url}" "{path}"'.format(url=project_url, path=self.client.current_folder))
-
-        curdir = self.client.current_folder.replace("\\", "/")
-        # Create the package, will copy the sources from the local folder
-        self.client.run("create . user/channel")
-        sources_dir = self.client.client_cache.scm_folder(self.reference)
-        self.assertEquals(load(sources_dir), curdir)
-        self.assertIn("Repo origin deduced by 'auto': {}".format(project_url).lower(),
-                      str(self.client.out).lower())
-        self.assertIn("Revision deduced by 'auto'", self.client.out)
-        self.assertIn("Getting sources from folder: %s" % curdir, self.client.out)
-        self.assertIn("My file is copied", self.client.out)
-
-        # Export again but now with absolute reference, so no pointer file is created nor kept
-        svn = SVN(curdir)
-        if not os.access(os.path.join(curdir, "conanfile.py"), os.W_OK):
-            os.chmod(os.path.join(curdir, "conanfile.py"), stat.S_IRWXU | stat.S_IRWXG | stat.S_IRWXO)  # 0777
-        self.client.save({"conanfile.py": base_svn.format(url=svn.get_remote_url(), revision=svn.get_revision())})
-        self.client.run("create . user/channel", ignore_error=False)
-        sources_dir = self.client.client_cache.scm_folder(self.reference)
-        self.assertFalse(os.path.exists(sources_dir))
-        self.assertNotIn("Repo origin deduced by 'auto'", self.client.out)
-        self.assertNotIn("Revision deduced by 'auto'", self.client.out)
-        self.assertIn("Getting sources from url: '{}'".format(project_url).lower(),
-                      str(self.client.out).lower())
-        self.assertIn("My file is copied", self.client.out)
-        
     def test_auto_subfolder(self):
         conanfile = base_svn.replace('"revision": "{revision}"',
                                      '"revision": "{revision}",\n        '

--- a/conans/test/utils/tools.py
+++ b/conans/test/utils/tools.py
@@ -336,8 +336,7 @@ class SVNLocalRepoTestCase(unittest.TestCase):
             os.makedirs(tmp)
         return tmp
 
-    def create_project(self, files, rel_project_path=None, commit_msg='default commit message',
-                       delete_checkout=True, lock_repo=False):
+    def create_project(self, files, rel_project_path=None, commit_msg='default commit message', delete_checkout=True):
         tmp_dir = self.gimme_tmp()
         try:
             rel_project_path = rel_project_path or str(uuid.uuid4())
@@ -348,8 +347,6 @@ class SVNLocalRepoTestCase(unittest.TestCase):
             save_files(tmp_project_dir, files)
             with chdir(tmp_project_dir):
                 subprocess.check_output("svn add .", shell=True)
-                if lock_repo:
-                    subprocess.check_output('svn propset svn:needs-lock * . -R', shell=True)
                 subprocess.check_output('svn commit -m "{}"'.format(commit_msg), shell=True)
                 if SVN.get_version() >= SVN.API_CHANGE_VERSION:
                     rev = subprocess.check_output("svn info --show-item revision", shell=True).decode().strip()


### PR DESCRIPTION
This reverts commit d07097fa8bc715d8d24fee01797df4d34dd15e67.

After discussion with the team we think changing permissions is something too risky and our vision of the problematic is still not clear.

Changelog: omit

- [x] Refer to the issue that supports this Pull Request: related to #3638 



