### PR TITLE
Feature/improve upload recorder

### DIFF
--- a/conans/client/cmd/uploader.py
+++ b/conans/client/cmd/uploader.py
@@ -106,7 +106,7 @@ class CmdUpload(object):
         if not cur_recipe_remote and policy != UPLOAD_POLICY_SKIP:
             self._registry.refs.set(conan_ref, recipe_remote.name)
 
-        recorder.add_recipe(str(conan_ref), recipe_remote.name, recipe_remote.url)
+        recorder.add_recipe(conan_ref, recipe_remote.name, recipe_remote.url)
 
         if packages_ids:
             # Can't use build_policy_always here because it's not loaded (only load_class)
@@ -126,7 +126,7 @@ class CmdUpload(object):
                     self._registry.prefs.set(pref, p_remote.name)
 
                 if ret_upload_package:
-                    recorder.add_package(str(conan_ref), package_id)
+                    recorder.add_package(pref, p_remote.name, p_remote.url)
 
         # FIXME: I think it makes no sense to specify a remote to "post_upload"
         # FIXME: because the recipe can have one and the package a different one

--- a/conans/test/functional/upload_recorder_test.py
+++ b/conans/test/functional/upload_recorder_test.py
@@ -2,6 +2,7 @@ import unittest
 
 from datetime import datetime
 from conans.client.recorder.upload_recoder import UploadRecorder
+from conans.model.ref import ConanFileReference, PackageReference
 
 
 class UploadRecorderTest(unittest.TestCase):
@@ -15,11 +16,15 @@ class UploadRecorderTest(unittest.TestCase):
         self.assertEqual(expected_result, info)
 
     def sequential_test(self):
-        self.recorder.add_recipe("fake/0.1@user/channel", "my_remote", "https://fake_url.com")
-        self.recorder.add_package("fake/0.1@user/channel", "fake_package_id")
-        self.recorder.add_recipe("fakefake/0.1@user/channel", "my_remote2", "https://fake_url2.com")
-        self.recorder.add_package("fakefake/0.1@user/channel", "fakefake_package_id1")
-        self.recorder.add_package("fakefake/0.1@user/channel", "fakefake_package_id2")
+        ref = ConanFileReference.loads("fake/0.1@user/channel#rev")
+        ref2 = ConanFileReference.loads("fakefake/0.1@user/channel")
+        self.recorder.add_recipe(ref, "my_remote", "https://fake_url.com")
+        pref1 = PackageReference(ref, "fake_package_id")
+        pref1.revision = "prev"
+        self.recorder.add_package(pref1, "my_remote", "https://fake_url.com")
+        self.recorder.add_recipe(ref2, "my_remote2", "https://fake_url2.com")
+        self.recorder.add_package(PackageReference(ref2, "fakefake_package_id1"), "my_remote", "https://fake_url.com")
+        self.recorder.add_package(PackageReference(ref2, "fakefake_package_id2"), "my_remote", "https://fake_url.com")
         info = self.recorder.get_info()
         expected_result_without_time = {
                                            "error": False,
@@ -28,11 +33,15 @@ class UploadRecorderTest(unittest.TestCase):
                                                    "recipe": {
                                                        "id": "fake/0.1@user/channel",
                                                        "remote_name": "my_remote",
-                                                       "remote_url": "https://fake_url.com"
+                                                       "remote_url": "https://fake_url.com",
+                                                       "revision": "rev"
                                                        },
                                                    "packages": [
                                                        {
-                                                           "id": "fake_package_id"
+                                                           "id": "fake_package_id",
+                                                           "remote_name": "my_remote",
+                                                           "remote_url": "https://fake_url.com",
+                                                           "revision": "prev"
                                                        }
                                                    ]
                                                },
@@ -40,14 +49,18 @@ class UploadRecorderTest(unittest.TestCase):
                                                    "recipe": {
                                                        "id": "fakefake/0.1@user/channel",
                                                        "remote_name": "my_remote2",
-                                                       "remote_url": "https://fake_url2.com"
+                                                       "remote_url": "https://fake_url2.com",
                                                    },
                                                    "packages": [
                                                        {
-                                                           "id": "fakefake_package_id1"
+                                                           "id": "fakefake_package_id1",
+                                                           "remote_name": "my_remote",
+                                                           "remote_url": "https://fake_url.com"
                                                        },
                                                        {
-                                                           "id": "fakefake_package_id2"
+                                                           "id": "fakefake_package_id2",
+                                                           "remote_name": "my_remote",
+                                                           "remote_url": "https://fake_url.com"
                                                        }
                                                    ]
                                                }
@@ -57,12 +70,15 @@ class UploadRecorderTest(unittest.TestCase):
         self._check_result(expected_result_without_time, info)
 
     def unordered_test(self):
-        self.recorder.add_recipe("fake1/0.1@user/channel", "my_remote1", "https://fake_url1.com")
-        self.recorder.add_recipe("fake2/0.1@user/channel", "my_remote2", "https://fake_url2.com")
-        self.recorder.add_recipe("fake3/0.1@user/channel", "my_remote3", "https://fake_url3.com")
-        self.recorder.add_package("fake1/0.1@user/channel", "fake1_package_id1")
-        self.recorder.add_package("fake2/0.1@user/channel", "fake2_package_id1")
-        self.recorder.add_package("fake2/0.1@user/channel", "fake2_package_id2")
+        ref1 = ConanFileReference.loads("fake1/0.1@user/channel")
+        ref2 = ConanFileReference.loads("fake2/0.1@user/channel")
+        ref3 = ConanFileReference.loads("fake3/0.1@user/channel")
+        self.recorder.add_recipe(ref1, "my_remote1", "https://fake_url1.com")
+        self.recorder.add_recipe(ref2, "my_remote2", "https://fake_url2.com")
+        self.recorder.add_recipe(ref3, "my_remote3", "https://fake_url3.com")
+        self.recorder.add_package(PackageReference(ref1, "fake1_package_id1"), "my_remote1", "https://fake_url1.com")
+        self.recorder.add_package(PackageReference(ref2, "fake2_package_id1"), "my_remote2", "https://fake_url2.com")
+        self.recorder.add_package(PackageReference(ref2, "fake2_package_id2"), "my_remote2", "https://fake_url2.com")
         info = self.recorder.get_info()
         expected_result_without_time = {
             "error": False,
@@ -75,7 +91,9 @@ class UploadRecorderTest(unittest.TestCase):
                     },
                     "packages": [
                         {
-                            "id": "fake1_package_id1"
+                            "id": "fake1_package_id1",
+                            "remote_name": "my_remote1",
+                            "remote_url": "https://fake_url1.com"
                         }
                     ]
                 },
@@ -87,10 +105,14 @@ class UploadRecorderTest(unittest.TestCase):
                     },
                     "packages": [
                         {
-                            "id": "fake2_package_id1"
+                            "id": "fake2_package_id1",
+                            "remote_name": "my_remote2",
+                            "remote_url": "https://fake_url2.com"
                         },
                         {
-                            "id": "fake2_package_id2"
+                            "id": "fake2_package_id2",
+                            "remote_name": "my_remote2",
+                            "remote_url": "https://fake_url2.com"
                         }
                     ]
                 },
@@ -108,7 +130,7 @@ class UploadRecorderTest(unittest.TestCase):
 
         self._check_result(expected_result_without_time, info)
 
-    def _check_result(self, expeceted, result):
+    def _check_result(self, expected, result):
         for i, item in enumerate(result["uploaded"]):
             assert item["recipe"]["time"]
             del result["uploaded"][i]["recipe"]["time"]
@@ -116,4 +138,4 @@ class UploadRecorderTest(unittest.TestCase):
             for j, package in enumerate(item["packages"]):
                 assert package["time"], datetime
                 del result["uploaded"][i]["packages"][j]["time"]
-        self.assertEqual(expeceted, result)
+        self.assertEqual(expected, result)


### PR DESCRIPTION
Changelog: Feature: Added `remote_name` and `remote_url` to upload json output.

- Internally uses pure references to be able to extract more info
- Prepared to show the revision if present
- Different remotes for packages than the recipe, it could happen.


