### PR TITLE
Excluded build type flags for MSBuild()

### DIFF
--- a/conans/client/build/msbuild.py
+++ b/conans/client/build/msbuild.py
@@ -19,7 +19,8 @@ class MSBuild(object):
             self._conanfile = conanfile
             self._settings = self._conanfile.settings
             self._output = self._conanfile.output
-            self.build_env = VisualStudioBuildEnvironment(self._conanfile)
+            self.build_env = VisualStudioBuildEnvironment(self._conanfile,
+                                                          with_build_type_flags=False)
         else:  # backwards compatible with build_sln_command
             self._settings = conanfile
             self.build_env = None
@@ -123,7 +124,7 @@ class MSBuild(object):
             flags = copy.copy(self.build_env.flags)
             flags.append(self.build_env.std)
         else:  # To be removed when build_sln_command is deprecated
-            flags = vs_build_type_flags(self._settings)
+            flags = vs_build_type_flags(self._settings, with_flags=False)
             flags.append(vs_std_cpp(self._settings))
 
         flags_str = " ".join(list(filter(None, flags))) # Removes empty and None elements

--- a/conans/test/build_helpers/msbuild_test.py
+++ b/conans/test/build_helpers/msbuild_test.py
@@ -20,17 +20,18 @@ class MSBuildTest(unittest.TestCase):
                                  "compiler.runtime": "MDd"})
         conanfile = MockConanfile(settings)
         msbuild = MSBuild(conanfile)
-        self.assertEquals(msbuild.build_env.flags, ["-Zi", "-Ob0", "-Od"])
+        self.assertEquals(msbuild.build_env.flags, [])
         template = msbuild._get_props_file_contents()
 
-        self.assertIn("-Ob0", template)
-        self.assertIn("-Od", template)
+        self.assertNotIn("-Ob0", template)
+        self.assertNotIn("-Od", template)
 
         msbuild.build_env.flags = ["-Zi"]
         template = msbuild._get_props_file_contents()
 
         self.assertNotIn("-Ob0", template)
         self.assertNotIn("-Od", template)
+        self.assertIn("-Zi", template)
         self.assertIn("<RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>", template)
 
     def without_runtime_test(self):

--- a/conans/test/util/build_sln_command_test.py
+++ b/conans/test/util/build_sln_command_test.py
@@ -142,5 +142,5 @@ class BuildSLNCommandTest(unittest.TestCase):
         self.assertTrue(os.path.exists(path_tmp))
         contents = load(path_tmp)
         self.assertIn("<RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>", contents)
-        self.assertIn("<AdditionalOptions>-Zi -Ob0 -Od /std:c++17 %(AdditionalOptions)</AdditionalOptions>",
+        self.assertIn("<AdditionalOptions>/std:c++17 %(AdditionalOptions)</AdditionalOptions>",
                       contents)


### PR DESCRIPTION
Changelog:  Fix: The `MSBuild()` build helper doesn't adjust the compiler flags for the build_type anymore because they are adjusted by the project itself.

Closes #3548

Docs here: https://github.com/conan-io/docs/pull/914/files