### PR TITLE
Hide conaninfo download for manifest checks

### DIFF
--- a/conans/__init__.py
+++ b/conans/__init__.py
@@ -19,3 +19,4 @@ REVISIONS = "revisions"  # Only when enabled in config, not by default look at s
 SERVER_CAPABILITIES = [COMPLEX_SEARCH_CAPABILITY, ]  # Still without v2 because it is changing
 
 __version__ = '1.9.0-dev'
+

--- a/conans/client/rest/rest_client_v1.py
+++ b/conans/client/rest/rest_client_v1.py
@@ -100,7 +100,7 @@ class RestV1Methods(RestCommonMethods):
             raise NotFoundException("Package %s doesn't have the %s file!" % (package_reference,
                                                                               CONANINFO))
         # Get the info (in memory)
-        contents = self._download_files({CONANINFO: urls[CONANINFO]})
+        contents = self._download_files({CONANINFO: urls[CONANINFO]}, quiet=True)
         # Unroll generator and decode shas (plain text)
         contents = {key: decode_text(value) for key, value in dict(contents).items()}
         return ConanInfo.loads(contents[CONANINFO])

--- a/conans/test/integration/install_update_test.py
+++ b/conans/test/integration/install_update_test.py
@@ -226,6 +226,8 @@ class Pkg(ConanFile):
         client2 = TestClient(servers=self.servers, users={"default": [("lasote", "mypass")]})
         client2.run("install Hello0/1.0@lasote/stable")
 
+        self.assertEquals(str(client2.out).count("Downloading conaninfo.txt"), 1)
+
         files["helloHello0.h"] = "//EMPTY!"
         self.client.save(files, clean_first=True)
         sleep(1)

--- a/conans/test/remote/broken_download_test.py
+++ b/conans/test/remote/broken_download_test.py
@@ -47,7 +47,7 @@ class ConanFileToolsTest(ConanFile):
                 super(DownloadFilesBrokenRequester, self).__init__(*args, **kwargs)
 
             def get(self, url, **kwargs):
-                if "conaninfo.txt" in url and not self.first_fail:
+                if "conanmanifest.txt" in url and not self.first_fail:
                     self.first_fail = True
                     raise ConnectionError("Fake connection error exception")
                 else:

--- a/conans/test/remote/broken_download_test.py
+++ b/conans/test/remote/broken_download_test.py
@@ -47,6 +47,7 @@ class ConanFileToolsTest(ConanFile):
                 super(DownloadFilesBrokenRequester, self).__init__(*args, **kwargs)
 
             def get(self, url, **kwargs):
+                # conaninfo is skipped sometimes from the output, use manifest
                 if "conanmanifest.txt" in url and not self.first_fail:
                     self.first_fail = True
                     raise ConnectionError("Fake connection error exception")


### PR DESCRIPTION
Changelog: Fix: Hidden confusing messages `download conaninfo.txt` when requesting the server to check package manifests.

Closes #3707 

