### PR TITLE
Test plugins->hooks migration with an already hooks folder

### DIFF
--- a/conans/client/migrations.py
+++ b/conans/client/migrations.py
@@ -192,7 +192,7 @@ def migrate_c_src_export_source(client_cache, out):
 
 def migrate_plugins_to_hooks(client_cache):
     plugins_path = os.path.join(client_cache.conan_folder, "plugins")
-    if os.path.exists(plugins_path):
+    if os.path.exists(plugins_path) and not os.path.exists(client_cache.hooks_path):
         os.rename(plugins_path, client_cache.hooks_path)
     conf_path = client_cache.conan_conf_path
     replace_in_file(conf_path, "[plugins]", "[hooks]", strict=False)

--- a/conans/test/test_migrations.py
+++ b/conans/test/test_migrations.py
@@ -70,19 +70,35 @@ the old general
 """)
 
     def migration_from_plugins_to_hooks_test(self):
-        old_user_home = temp_folder()
-        old_conan_folder = os.path.join(old_user_home, ".conan")
-        old_conf_path = os.path.join(old_conan_folder, "conan.conf")
-        old_attribute_checker_plugin = os.path.join(old_conan_folder, "plugins",
-                                                    "attribute_checker.py")
-        save(old_conf_path, "\n[plugins]    # CONAN_PLUGINS\nattribute_checker")
-        save(old_attribute_checker_plugin, "")
-        self.assertTrue(os.path.exists(old_attribute_checker_plugin))
-        client_cache = TestClient(base_folder=old_user_home).client_cache
-        self.assertEqual(old_conan_folder, client_cache.conan_folder)
+
+        def _create_old_layout():
+            old_user_home = temp_folder()
+            old_conan_folder = os.path.join(old_user_home, ".conan")
+            old_conf_path = os.path.join(old_conan_folder, "conan.conf")
+            old_attribute_checker_plugin = os.path.join(old_conan_folder, "plugins",
+                                                        "attribute_checker.py")
+            save(old_conf_path, "\n[plugins]    # CONAN_PLUGINS\nattribute_checker")
+            save(old_attribute_checker_plugin, "")
+            client_cache = TestClient(base_folder=old_user_home).client_cache
+            assert old_conan_folder == client_cache.conan_folder
+            return old_user_home, old_conan_folder, old_conf_path, old_attribute_checker_plugin,\
+                   client_cache
+
+        old_uh, old_cf, old_cp, old_acp, client_cache = _create_old_layout()
         migrate_plugins_to_hooks(client_cache)
-        self.assertFalse(os.path.exists(old_attribute_checker_plugin))
-        self.assertTrue(os.path.join(old_conan_folder, "hooks"))
-        conf_content = load(old_conf_path)
+        self.assertFalse(os.path.exists(old_acp))
+        self.assertTrue(os.path.join(old_cf, "hooks"))
+        conf_content = load(old_cp)
+        self.assertNotIn("[plugins]", conf_content)
+        self.assertIn("[hooks]", conf_content)
+
+        # Test with a hook folder: Maybe there was already a hooks folder and a plugins folder
+        old_uh, old_cf, old_cp, old_acp, client_cache = _create_old_layout()
+        existent_hook = os.path.join(old_cf, "hooks", "hook.py")
+        save(existent_hook, "")
+        migrate_plugins_to_hooks(client_cache)
+        self.assertTrue(os.path.exists(old_acp))
+        self.assertTrue(os.path.join(old_cf, "hooks"))
+        conf_content = load(old_cp)
         self.assertNotIn("[plugins]", conf_content)
         self.assertIn("[hooks]", conf_content)


### PR DESCRIPTION
Changelog: omit

Fix plugins->hooks migration with an already existing hooks folder


