### PR TITLE
Keep order when loading from json (fix py3.4 failing test)

### DIFF
--- a/conans/client/remote_registry.py
+++ b/conans/client/remote_registry.py
@@ -60,7 +60,7 @@ def dump_registry(remotes, refs, prefs):
 
 def load_registry(contents):
     """From json"""
-    data = json.loads(contents)
+    data = json.loads(contents, object_pairs_hook=OrderedDict)
     remotes = OrderedDict()
     refs = data.get("references", {})
     prefs = data.get("package_references", {})


### PR DESCRIPTION
Changelog: Bugfix: Keep the order defined in the json

