### PR TITLE
Servers with order guaranteed in testing

### DIFF
--- a/conans/test/command/download_test.py
+++ b/conans/test/command/download_test.py
@@ -1,5 +1,7 @@
 import unittest
 import os
+from collections import OrderedDict
+
 from conans.test.utils.tools import TestClient, TestServer
 from conans.model.ref import ConanFileReference
 from conans.util.files import load
@@ -50,8 +52,9 @@ class Pkg(ConanFile):
 
     def download_with_sources_test(self):
         server = TestServer()
-        servers = {"default": server,
-                   "other": TestServer()}
+        servers = OrderedDict()
+        servers["default"] = server
+        servers["other"] = TestServer()
 
         client = TestClient(servers=servers, users={"default": [("lasote", "mypass")],
                                                     "other": [("lasote", "mypass")]})

--- a/conans/test/command/search_test.py
+++ b/conans/test/command/search_test.py
@@ -1,5 +1,7 @@
 import json
 import os
+from collections import OrderedDict
+
 import shutil
 import unittest
 
@@ -84,8 +86,9 @@ conan_vars4 = """[settings]
 class SearchTest(unittest.TestCase):
 
     def setUp(self):
-        self.servers = {"local": TestServer(server_capabilities=[]),
-                        "search_able": TestServer(server_capabilities=[COMPLEX_SEARCH_CAPABILITY])}
+        self.servers = OrderedDict()
+        self.servers["local"] = TestServer(server_capabilities=[])
+        self.servers["search_able"] = TestServer(server_capabilities=[COMPLEX_SEARCH_CAPABILITY])
         self.client = TestClient(servers=self.servers)
 
         # No conans created

--- a/conans/test/command/user_test.py
+++ b/conans/test/command/user_test.py
@@ -2,6 +2,7 @@ import json
 import unittest
 
 import os
+from collections import OrderedDict
 
 from conans.test.utils.tools import TestClient, TestServer
 from conans.util.files import load
@@ -24,10 +25,9 @@ class UserTest(unittest.TestCase):
     def test_command_user_list(self):
         """ Test list of user is reported for all remotes or queried remote
         """
-        servers = {
-            "default": TestServer(),
-            "test_remote_1": TestServer(),
-        }
+        servers = OrderedDict()
+        servers["default"] = TestServer()
+        servers["test_remote_1"] = TestServer()
         client = TestClient(servers=servers)
 
         # Test with wrong remote right error is reported
@@ -179,7 +179,9 @@ class ConanLib(ConanFile):
 
     def authenticated_test(self):
         test_server = TestServer(users={"lasote": "mypass", "danimtb": "passpass"})
-        servers = {"default": test_server, "other_server": TestServer()}
+        servers = OrderedDict()
+        servers["default"] = test_server
+        servers["other_server"] = TestServer()
         client = TestClient(servers=servers, users={"default": [("lasote", "mypass"),
                                                                 ("danimtb", "passpass")],
                                                     "other_server": []})
@@ -218,7 +220,9 @@ class ConanLib(ConanFile):
 
         default_server = TestServer(users={"lasote": "mypass", "danimtb": "passpass"})
         other_server = TestServer()
-        servers = {"default": default_server, "other_server": other_server}
+        servers = OrderedDict()
+        servers["default"] = default_server
+        servers["other_server"] = other_server
         client = TestClient(servers=servers, users={"default": [("lasote", "mypass"),
                                                                 ("danimtb", "passpass")],
                                                     "other_server": []})

--- a/conans/test/integration/install_update_test.py
+++ b/conans/test/integration/install_update_test.py
@@ -95,7 +95,9 @@ class Pkg(ConanFile):
     def package(self):
         tools.save(os.path.join(self.package_folder, "file.txt"), str(random.random()))
 """
-        servers = {"r1": TestServer(), "r2": TestServer()}
+        servers = OrderedDict()
+        servers["r1"] = TestServer()
+        servers["r2"] = TestServer()
         client = TestClient(servers=servers, users={"r1": [("lasote", "mypass")],
                                                     "r2": [("lasote", "mypass")]})
 

--- a/conans/test/integration/test_build_info_extraction.py
+++ b/conans/test/integration/test_build_info_extraction.py
@@ -2,6 +2,7 @@ import json
 import os
 import unittest
 import sys
+from collections import OrderedDict
 
 from conans import tools
 from conans.build_info.conan_build_info import get_build_info
@@ -16,7 +17,9 @@ class MyBuildInfo(unittest.TestCase):
     def setUp(self):
         test_server = TestServer(users={"lasote": "lasote"})
         test_server2 = TestServer(users={"lasote": "lasote"})
-        self.servers = {"default": test_server, "alternative": test_server2}
+        self.servers = OrderedDict()
+        self.servers["default"] = test_server
+        self.servers["alternative"] = test_server2
         self.client = TestClient(servers=self.servers, users={"default": [("lasote", "lasote")],
                                                               "alternative": [("lasote", "lasote")]})
 

--- a/conans/test/integration/version_ranges_diamond_test.py
+++ b/conans/test/integration/version_ranges_diamond_test.py
@@ -1,5 +1,6 @@
 import os
 import unittest
+from collections import OrderedDict
 
 from parameterized import parameterized
 
@@ -99,8 +100,9 @@ class HelloReuseConan(ConanFile):
 class VersionRangesMultiRemoteTest(unittest.TestCase):
 
     def setUp(self):
-        self.servers = {"default": TestServer(),
-                        "other": TestServer()}
+        self.servers = OrderedDict()
+        self.servers["default"] = TestServer()
+        self.servers["other"] = TestServer()
         self.client = TestClient(servers=self.servers, users={"default": [("lasote", "mypass")],
                                                               "other": [("lasote", "mypass")]})
 

--- a/conans/test/remote_checks_test.py
+++ b/conans/test/remote_checks_test.py
@@ -10,7 +10,11 @@ from conans.test.utils.tools import TestClient, TestServer, \
 class RemoteChecksTest(unittest.TestCase):
 
     def test_recipe_updates(self):
-        servers = {"server1": TestServer(), "server2": TestServer(), "server3": TestServer()}
+        servers = OrderedDict()
+        servers["server1"] = TestServer()
+        servers["server2"] = TestServer()
+        servers["server3"] = TestServer()
+
         client = TestClient(servers=servers, users={"server1": [("lasote", "mypass")],
                                                     "server2": [("lasote", "mypass")],
                                                     "server3": [("lasote", "mypass")]})
@@ -243,7 +247,9 @@ class Pkg(ConanFile):
         self.assertIn("Pkg/0.1@lasote/testing: server2", client.out)
 
     def test_binaries_from_different_remotes(self):
-        servers = {"server1": TestServer(), "server2": TestServer()}
+        servers = OrderedDict()
+        servers["server1"] = TestServer()
+        servers["server2"] = TestServer()
         client = TestClient(servers=servers, users={"server1": [("lasote", "mypass")],
                                                     "server2": [("lasote", "mypass")]})
         conanfile = """from conans import ConanFile

--- a/conans/test/utils/tools.py
+++ b/conans/test/utils/tools.py
@@ -6,7 +6,7 @@ import stat
 import sys
 import tempfile
 import unittest
-from collections import Counter
+from collections import Counter, OrderedDict
 from contextlib import contextmanager
 from io import StringIO
 
@@ -448,6 +448,13 @@ class TestClient(object):
 
         self.requester_class = requester_class
         self.conan_runner = runner
+
+        if servers and len(servers) > 1 and not isinstance(servers, OrderedDict):
+            raise Exception("""Testing framework error: Servers should be an OrderedDict. e.g: 
+servers = OrderedDict()
+servers["r1"] = server
+servers["r2"] = TestServer()
+""")
 
         self.servers = servers or {}
         if servers is not False:  # Do not mess with registry remotes


### PR DESCRIPTION
Changelog: omit

Only tests changes to guarantee that the servers are ordered and we do not introduce bugs because of that.
