### PR TITLE
Workspace: Use CMAKE_BINARY_DIR to refer to installation folder

### DIFF
--- a/conans/model/workspace.py
+++ b/conans/model/workspace.py
@@ -113,6 +113,8 @@ project({name} CXX)
             for _, workspace_package in self._workspace_packages.items():
                 build_folder = workspace_package.build_folder
                 build_folder = build_folder.replace("\\", "/")
+                if build_folder.startswith(self._install_folder):
+                    build_folder = build_folder.replace(self._install_folder, '${CMAKE_BINARY_DIR}', 1)
                 cmake += 'add_subdirectory(%s "%s")\n' % (workspace_package.local_cmakedir, build_folder)
             cmake_path = os.path.join(self._base_folder, "CMakeLists.txt")
             if os.path.exists(cmake_path) and not load(cmake_path).startswith("# conanws"):


### PR DESCRIPTION
This fixes up a problem when using 'conan install' to create multiple build
directories, for instance, to create both a cmake-build-debug and a
cmake-build-release directory for use with CLion.

The CMakeLists.txt is repeatedly generated in that case, and the binary_dir of
each subdirectory points to the last build directory created. It is amazing what
number of strange CMake errors arise when the directories are intertwined.

Instead, use CMAKE_BINARY_DIR, which points to the build directory in use.

Changelog: (Feature | Fix | Bugfix): Describe here your pull request

- [ ] Refer to the issue that supports this Pull Request.
- [ ] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://raw.githubusercontent.com/conan-io/conan/develop/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 


