### PR TITLE
remove search from download call

### DIFF
--- a/conans/client/cmd/download.py
+++ b/conans/client/cmd/download.py
@@ -2,8 +2,8 @@ import os
 
 from conans.model.ref import PackageReference, ConanFileReference
 from conans.client.output import ScopedOutput
-from conans.errors import ConanException
 from conans.client.source import complete_recipe_sources
+from conans.errors import NotFoundException
 
 
 def download(reference, package_ids, remote_name, recipe, registry, remote_manager,
@@ -12,13 +12,13 @@ def download(reference, package_ids, remote_name, recipe, registry, remote_manag
     assert(isinstance(reference, ConanFileReference))
     output = ScopedOutput(str(reference), out)
     remote = registry.remotes.get(remote_name) if remote_name else registry.remotes.default
-    package = remote_manager.search_recipes(remote, reference, None)
-    if not package:  # Search the reference first, and raise if it doesn't exist
-        raise ConanException("'%s' not found in remote" % str(reference))
 
     hook_manager.execute("pre_download", reference=reference, remote=remote)
     # First of all download package recipe
-    remote_manager.get_recipe(reference, remote)
+    try:
+        remote_manager.get_recipe(reference, remote)
+    except NotFoundException:
+        raise NotFoundException("'%s' not found in remote '%s'" % (str(reference), remote.name))
     registry.refs.set(reference, remote.name)
     conan_file_path = client_cache.conanfile(reference)
     conanfile = loader.load_class(conan_file_path)

--- a/conans/client/conan_api.py
+++ b/conans/client/conan_api.py
@@ -411,7 +411,8 @@ class ConanAPIV1(object):
 
             build_folder = _make_abs_path(build_folder, cwd)
             install_folder = _make_abs_path(install_folder, cwd, default=build_folder)
-            source_folder = _make_abs_path(source_folder, cwd, default=os.path.dirname(conanfile_path))
+            source_folder = _make_abs_path(source_folder, cwd,
+                                           default=os.path.dirname(conanfile_path))
 
             # Checks that no both settings and info files are specified
             infos_present = existing_info_files(install_folder)

--- a/conans/client/store/localdb.py
+++ b/conans/client/store/localdb.py
@@ -34,9 +34,9 @@ class LocalDB(object):
                 cursor.execute("drop table if exists %s" % REMOTES_USER_TABLE)
                 try:
                     # https://github.com/ghaering/pysqlite/issues/109
-                    cursor.isolation_level = None
+                    self.connection.isolation_level = None
                     cursor.execute('VACUUM')  # Make sure the DB is cleaned, drop doesn't do that
-                    cursor.isolation_level = ''  # note this is  default value of isolation_level
+                    self.connection.isolation_level = ''  # default value of isolation_level
                 except OperationalError:
                     pass
 

--- a/conans/client/store/localdb.py
+++ b/conans/client/store/localdb.py
@@ -31,6 +31,7 @@ class LocalDB(object):
             cursor = self.connection.cursor()
             if clean:
                 cursor.execute("drop table if exists %s" % REMOTES_USER_TABLE)
+                cursor.execute("vacuum")  # Make sure the DB is cleaned, drop doesn't do that
             cursor.execute("create table if not exists %s "
                            "(remote_url TEXT UNIQUE, user TEXT, token TEXT)" % REMOTES_USER_TABLE)
         except Exception as e:

--- a/conans/client/userio.py
+++ b/conans/client/userio.py
@@ -1,9 +1,11 @@
+import getpass
 import os
 import sys
-from conans.client.output import ConanOutput
-from conans.errors import InvalidNameException, ConanException
-import getpass
+
 from six.moves import input as raw_input
+
+from conans.client.output import ConanOutput
+from conans.errors import ConanException
 
 
 class UserIO(object):

--- a/conans/test/integration/install_selected_packages_test.py
+++ b/conans/test/integration/install_selected_packages_test.py
@@ -1,9 +1,10 @@
-import unittest
-from conans.test.utils.tools import TestClient, TestServer
 import os
-from conans.test.utils.cpp_test_files import cpp_hello_conan_files
-from conans.paths import CONANFILE
+import unittest
+
 from conans.model.ref import ConanFileReference, PackageReference
+from conans.paths import CONANFILE
+from conans.test.utils.cpp_test_files import cpp_hello_conan_files
+from conans.test.utils.tools import TestClient, TestServer
 from conans.util.files import load
 
 
@@ -52,7 +53,8 @@ class InstallSelectedPackagesTest(unittest.TestCase):
 
     def download_packages_twice_test(self):
         expected_header_contents = self.files["helloHello0.h"]
-        package_folder = self.new_client.paths.package(PackageReference(self.ref, self.package_ids[0]))
+        package_folder = self.new_client.paths.package(PackageReference(self.ref,
+                                                                        self.package_ids[0]))
 
         self.new_client.run("download Hello0/0.1@lasote/stable")
         got_header = load(os.path.join(package_folder, "include", "helloHello0.h"))
@@ -88,7 +90,8 @@ class InstallSelectedPackagesTest(unittest.TestCase):
         self.ref = ConanFileReference.loads("Hello0/0.1@lasote/stable")
         self.files = cpp_hello_conan_files("Hello0", "0.1")
         # No build.
-        self.files[CONANFILE] = self.files[CONANFILE].replace("def build(self):", "def build(self):\n        return\n")
+        self.files[CONANFILE] = self.files[CONANFILE].replace("def build(self):",
+                                                              "def build(self):\n        return\n")
         client.save(self.files)
         client.run("export . lasote/stable")
         client.run("install Hello0/0.1@lasote/stable -s os=Windows --build missing")


### PR DESCRIPTION
Changelog: Fix: ``conan download`` of packages that require auth to read them has been fixed.

Removing search in download command, it doesn't work properly when remote packages read is not anonymous, as Artifactory search is returning nothing found, so the credentials are not requested at all.

Also, as suggested by @puetzk, doing a ``vacuum`` of the DB when cleaning, to ensure info is totally removed.
