### PR TITLE
Fix topics breaking info graph html

### DIFF
--- a/conans/client/graph/grapher.py
+++ b/conans/client/graph/grapher.py
@@ -146,7 +146,7 @@ class ConanHTMLGrapher(object):
                                    ("homepage", '<a href="{url}">{url}</a>'.format(url=conanfile.homepage)),
                                    ("license", conanfile.license),
                                    ("author", conanfile.author),
-                                   ("topics", conanfile.topics)]:
+                                   ("topics", str(conanfile.topics))]:
                     if data:
                         data = data.replace("'", '"')
                         fulllabel.append("<li><b>%s</b>: %s</li>" % (name, data))

--- a/conans/test/command/info_test.py
+++ b/conans/test/command/info_test.py
@@ -500,10 +500,9 @@ class MyTest(ConanFile):
         self.assertNotIn("URL:", self.client.user_io.out)
 
     def test_full_attributes(self):
-        self.client = TestClient()
+        client = TestClient()
 
         conanfile = """from conans import ConanFile
-from conans.util.files import load, save
 
 class MyTest(ConanFile):
     name = "Pkg"
@@ -513,18 +512,45 @@ class MyTest(ConanFile):
     license = "MIT"
     url = "https://foo.bar.baz"
     homepage = "https://foo.bar.site"
-    topics = ["foo", "bar", "qux"]
-
+    topics = ("foo", "bar", "qux")
 """
 
-        self.client.save({"subfolder/conanfile.py": conanfile})
-        self.client.run("export ./subfolder lasote/testing")
+        client.save({"subfolder/conanfile.py": conanfile})
+        client.run("export ./subfolder lasote/testing")
+        client.run("info ./subfolder")
 
-        self.client.run("info ./subfolder")
+        self.assertIn("Pkg/0.2@PROJECT", client.out)
+        self.assertIn("License: MIT", client.out)
+        self.assertIn("Author: John Doe", client.out)
+        self.assertIn("Topics: foo, bar, qux", client.out)
+        self.assertIn("URL: https://foo.bar.baz", client.out)
+        self.assertIn("Homepage: https://foo.bar.site", client.out)
 
-        self.assertIn("Pkg/0.2@PROJECT", self.client.user_io.out)
-        self.assertIn("License: MIT", self.client.user_io.out)
-        self.assertIn("Author: John Doe", self.client.user_io.out)
-        self.assertIn("Topics: foo, bar, qux", self.client.user_io.out)
-        self.assertIn("URL: https://foo.bar.baz", self.client.user_io.out)
-        self.assertIn("Homepage: https://foo.bar.site", self.client.user_io.out)
+    def topics_graph_test(self):
+        conanfile = """from conans import ConanFile
+
+class MyTest(ConanFile):
+    name = "Pkg"
+    version = "0.2"
+    topics = ("foo", "bar", "qux")
+        """
+
+        client = TestClient()
+        client.save({"conanfile.py": conanfile})
+        client.run("export . lasote/testing")
+
+        # Topics as tuple
+        client.run("info Pkg/0.2@lasote/testing --graph file.html")
+        html_path = os.path.join(client.current_folder, "file.html")
+        html_content = load(html_path)
+        self.assertIn("<h3>Pkg/0.2@lasote/testing</h3>", html_content)
+        self.assertIn("<li><b>topics</b>: (\"foo\", \"bar\", \"qux\")</li><ul>", html_content)
+
+        # Topics as a string
+        conanfile = conanfile.replace("(\"foo\", \"bar\", \"qux\")", "\"foo\"")
+        client.save({"conanfile.py": conanfile}, clean_first=True)
+        client.run("export . lasote/testing")
+        client.run("info Pkg/0.2@lasote/testing --graph file.html")
+        html_content = load(html_path)
+        self.assertIn("<h3>Pkg/0.2@lasote/testing</h3>", html_content)
+        self.assertIn("<li><b>topics</b>: foo", html_content)

--- a/conans/test/command/inspect_test.py
+++ b/conans/test/command/inspect_test.py
@@ -159,7 +159,7 @@ class Pkg(ConanFile):
     license = "MIT"
     description = "Yet Another Test"
     generators = "cmake"
-    topics = ["foo", "bar", "qux"]
+    topics = ("foo", "bar", "qux")
     _private = "Nothing"
     def build(self):
         pass
@@ -173,7 +173,7 @@ homepage: https://john.company.site
 license: MIT
 author: John Doe
 description: Yet Another Test
-topics: ['foo', 'bar', 'qux']
+topics: ('foo', 'bar', 'qux')
 generators: cmake
 exports: None
 exports_sources: None


### PR DESCRIPTION
Changelog: Fix: ``topics`` attribute in conanfile breaking info graph html generation

- [x] I've read the [Contributing guide](https://raw.githubusercontent.com/conan-io/conan/develop/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 


