### PR TITLE
Updated Colorama to allow 0.4.0 in pip requirements

### DIFF
--- a/conans/requirements.txt
+++ b/conans/requirements.txt
@@ -1,6 +1,6 @@
 PyJWT>=1.4.0, <2.0.0
 requests>=2.7.0, <3.0.0
-colorama>=0.3.3, <0.4.0
+colorama>=0.3.3, <0.5.0
 PyYAML>=3.11, <3.14.0
 patch==1.16
 fasteners>=0.14.1


### PR DESCRIPTION
Changelog: Fix: Updated Colorama to allow 0.4.0 in pip requirements

- [x] Refer to the issue that supports this Pull Request: closes #3924 
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://raw.githubusercontent.com/conan-io/conan/develop/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.


