### PR TITLE
fix compiler args

### DIFF
--- a/conans/client/build/compiler_flags.py
+++ b/conans/client/build/compiler_flags.py
@@ -190,8 +190,15 @@ def format_library_paths(library_paths, win_bash=False, subsystem=None, compiler
 
 
 def format_libraries(libraries, compiler=None):
-    pattern = "%s.lib" if str(compiler) == 'Visual Studio' else "-l%s"
-    return [pattern % library for library in libraries if library]
+    result = []
+    for library in libraries:
+        if str(compiler) == 'Visual Studio':
+            if not library.endswith(".lib"):
+                library += ".lib"
+            result.append(library)
+        else:
+            result.append("-l%s" % library)
+    return result
 
 
 def parallel_compiler_cl_flag():

--- a/conans/test/generators/compiler_args_test.py
+++ b/conans/test/generators/compiler_args_test.py
@@ -12,6 +12,28 @@ from conans.test.build_helpers.cmake_test import ConanFileMock
 
 class CompilerArgsTest(unittest.TestCase):
 
+    def visual_studio_extensions_test(self):
+        settings = Settings.loads(default_settings_yml)
+        settings.os = "Windows"
+        settings.compiler = "Visual Studio"
+        settings.compiler.version = "15"
+        settings.arch = "x86"
+        settings.build_type = "Release"
+
+        conan_file = ConanFileMock()
+        conan_file.settings = settings
+        conan_file.deps_env_info = DepsEnvInfo()
+        conan_file.deps_user_info = DepsUserInfo()
+        conan_file.deps_cpp_info = DepsCppInfo()
+        cpp_info = CppInfo("/root")
+        cpp_info.libs.append("mylib")
+        cpp_info.libs.append("other.lib")
+        conan_file.deps_cpp_info.update(cpp_info, "zlib")
+        conan_file.env_info = EnvInfo()
+
+        gen = CompilerArgsGenerator(conan_file)
+        self.assertEquals('-O2 -Ob2 -DNDEBUG -link mylib.lib other.lib', gen.content)
+
     def _get_conanfile(self, settings):
         conan_file = ConanFileMock()
         conan_file.settings = settings


### PR DESCRIPTION
Changelog: Bugfix: compiler_args generated "mytool.lib.lib" for Visual Studio libraries that were defined with the ``.lib`` extension in the ``self.cpp_info.libs`` field of ``package_info()``.




