### PR TITLE
added chardet dependency to fix crash on LinuxMint

### DIFF
--- a/conans/requirements.txt
+++ b/conans/requirements.txt
@@ -13,3 +13,4 @@ pygments>=2.0, <3.0
 astroid>=1.6.5
 deprecation>=2.0, <2.1
 tqdm>=4.28.1, <5
+chardet==3.0.4


### PR DESCRIPTION
I was looking for a fix for `conan` crashing with a fresh install on LinuxMint for awhile and I stumbled on #3434. None of the fixes worked for me so I decided to try and fix it myself. I found a fix from this issue in another repository https://github.com/iheanyi/bandcamp-dl/issues/101. I was unable to test this on Mac and Windows as I don't any machines with those installed, but I doubt there will be much issue as I just added `chardet` as a dependency.