### PR TITLE
mkdir fails when the directory exists

### DIFF
--- a/conans/util/files.py
+++ b/conans/util/files.py
@@ -229,13 +229,10 @@ def rmdir(path):
 
 def mkdir(path):
     """Recursive mkdir, doesnt fail if already existing"""
-    try:
-        os.makedirs(path)
-    except OSError as err:
-        if err.errno != EEXIST:
-            # e.g: mkdir("C:") => OSError:Access is denied, but you can even write on it, so if the dir exists, it's ok.
-            if not os.path.exists(path):
-                raise
+    if os.path.exists(path):
+        return
+    os.makedirs(path)
+
 
 def path_exists(path, basedir):
     """Case sensitive, for windows, optional

--- a/conans/util/files.py
+++ b/conans/util/files.py
@@ -233,8 +233,9 @@ def mkdir(path):
         os.makedirs(path)
     except OSError as err:
         if err.errno != EEXIST:
-            raise
-
+            # e.g: mkdir("C:") => OSError:Access is denied, but you can even write on it, so if the dir exists, it's ok.
+            if not os.path.exists(path):
+                raise
 
 def path_exists(path, basedir):
     """Case sensitive, for windows, optional


### PR DESCRIPTION
Changelog:  Bugfix: A `conan install` with a reference failed when running in the operating system root folder because python tried to create the directory even when nothing is going to be written.

Closes #4002 

The real issue happen if you try to run `os.makedirs("c:")` python will fail with a different error than `EEXIST`, note that the directory `c:\` of course, exists, and we are able to write it even! But we cannot create it.
