### PR TITLE
correct/improve/simplify makefile unit test

### DIFF
--- a/conans/test/generators/make_test.py
+++ b/conans/test/generators/make_test.py
@@ -242,7 +242,7 @@ include conanbuildinfo.mak
 #     Make variables for a sample App
 #----------------------------------------
 
-CXX_INCLUDE_PATHS = \
+INCLUDE_PATHS = \
 ./include
 
 CXX_SRCS = \
@@ -262,12 +262,12 @@ libhellowrapper.so
 #     Prepare flags from variables
 #----------------------------------------
 
-CFLAGS          += $(CONAN_CFLAGS)
-CPPFLAGS        += $(addprefix -I, $(CXX_INCLUDE_PATHS) $(CONAN_INCLUDE_PATHS))
-CPPFLAGS        += $(addprefix -D, $(CONAN_DEFINES))
-LDFLAGS         += $(addprefix -L, $(CONAN_LIB_PATHS))
-LIBS            += $(addprefix -l, $(CONAN_LIBS))
-
+CFLAGS              += $(CONAN_CFLAGS)
+CPPFLAGS            += $(addprefix -I, $(INCLUDE_PATHS) $(CONAN_INCLUDE_PATHS))
+CPPFLAGS            += $(addprefix -D, $(CONAN_DEFINES))
+LDFLAGS             += $(addprefix -L, $(CONAN_LIB_PATHS))
+LDFLAGS             += $(addprefix -l, $(CONAN_LIBS))
+SHAREDLINKFLAGS     += $(CONAN_SHAREDLINKFLAGS)
 
 #----------------------------------------
 #     Make Commands
@@ -278,7 +278,7 @@ COMPILE_CXX_COMMAND         ?= \
 
 CREATE_SHARED_LIB_COMMAND   ?= \
 	g++ -shared $(CXX_OBJ_FILES) \
-	$(LDFLAGS) $(LDFLAGS_SHARED) $(CPPFLAGS) $(LIBS) \
+	$(CFLAGS) $(LDFLAGS) $(SHAREDLINKFLAGS) \
 	-o $(SHARED_LIB_FILENAME)
 
 CREATE_STATIC_LIB_COMMAND   ?= \
@@ -337,7 +337,7 @@ class HelloWrapper(ConanFile):
 
         main = """
 #include "hellowrapper.h"
-
+CONAN_EXELINKFLAGS
 int main()
 {
      hellowrapper();
@@ -365,12 +365,12 @@ main
 #     Prepare flags from variables
 #----------------------------------------
 
-CFLAGS          += $(CONAN_CFLAGS)
-CPPFLAGS        += $(addprefix -I, $(CONAN_INCLUDE_PATHS))
-CPPFLAGS        += $(addprefix -D, $(CONAN_DEFINES))
-LDFLAGS         += $(addprefix -L, $(CONAN_LIB_PATHS))
-LIBS            += $(addprefix -l, $(CONAN_LIBS))
-
+CFLAGS              += $(CONAN_CFLAGS)
+CPPFLAGS            += $(addprefix -I, $(CONAN_INCLUDE_PATHS))
+CPPFLAGS            += $(addprefix -D, $(CONAN_DEFINES))
+LDFLAGS             += $(addprefix -L, $(CONAN_LIB_PATHS))
+LDFLAGS             += $(addprefix -l, $(CONAN_LIBS))
+CONAN_EXELINKFLAGS  += $(CONAN_EXELINKFLAGS)
 
 #----------------------------------------
 #     Make Commands
@@ -381,7 +381,7 @@ COMPILE_CXX_COMMAND         ?= \
 
 CREATE_EXE_COMMAND          ?= \
 	g++ $(CXX_OBJ_FILES) \
-	$(LDFLAGS) $(LIBS) \
+	$(CFLAGS) $(LDFLAGS) $(CONAN_EXELINKFLAGS) \
 	-o $(EXE_FILENAME)
 
 

--- a/conans/test/generators/make_test.py
+++ b/conans/test/generators/make_test.py
@@ -257,12 +257,15 @@ libhellowrapper.a
 SHARED_LIB_FILENAME = \
 libhellowrapper.so
 
+CXXFLAGS += \
+-fPIC
 
 #----------------------------------------
 #     Prepare flags from variables
 #----------------------------------------
 
 CFLAGS              += $(CONAN_CFLAGS)
+CXXFLAGS            += $(CONAN_CPPFLAGS)
 CPPFLAGS            += $(addprefix -I, $(INCLUDE_PATHS) $(CONAN_INCLUDE_PATHS))
 CPPFLAGS            += $(addprefix -D, $(CONAN_DEFINES))
 LDFLAGS             += $(addprefix -L, $(CONAN_LIB_PATHS))
@@ -274,11 +277,11 @@ SHAREDLINKFLAGS     += $(CONAN_SHAREDLINKFLAGS)
 #----------------------------------------
 
 COMPILE_CXX_COMMAND         ?= \
-	g++ -c $(CFLAGS) $(CPPFLAGS) $< -o $@
+	g++ -c $(CPPFLAGS) $(CFLAGS) $(CXXFLAGS) $< -o $@
 
 CREATE_SHARED_LIB_COMMAND   ?= \
 	g++ -shared $(CXX_OBJ_FILES) \
-	$(CFLAGS) $(LDFLAGS) $(SHAREDLINKFLAGS) \
+	$(CFLAGS) $(CXXFLAGS) $(LDFLAGS) $(SHAREDLINKFLAGS) \
 	-o $(SHARED_LIB_FILENAME)
 
 CREATE_STATIC_LIB_COMMAND   ?= \
@@ -337,7 +340,6 @@ class HelloWrapper(ConanFile):
 
         main = """
 #include "hellowrapper.h"
-CONAN_EXELINKFLAGS
 int main()
 {
      hellowrapper();
@@ -360,28 +362,34 @@ main.o
 EXE_FILENAME = \
 main
 
+CXXFLAGS += \
+-fPIC
+
+EXELINKFLAGS += \
+-fPIE
 
 #----------------------------------------
 #     Prepare flags from variables
 #----------------------------------------
 
 CFLAGS              += $(CONAN_CFLAGS)
+CXXFLAGS            += $(CONAN_CPPFLAGS)
 CPPFLAGS            += $(addprefix -I, $(CONAN_INCLUDE_PATHS))
 CPPFLAGS            += $(addprefix -D, $(CONAN_DEFINES))
 LDFLAGS             += $(addprefix -L, $(CONAN_LIB_PATHS))
 LDFLAGS             += $(addprefix -l, $(CONAN_LIBS))
-CONAN_EXELINKFLAGS  += $(CONAN_EXELINKFLAGS)
+EXELINKFLAGS        += $(CONAN_EXELINKFLAGS)
 
 #----------------------------------------
 #     Make Commands
 #----------------------------------------
 
 COMPILE_CXX_COMMAND         ?= \
-	g++ -c $(CFLAGS) $(CPPFLAGS) $< -o $@
+	g++ -c $(CPPFLAGS) $(CFLAGS) $(CXXFLAGS) $< -o $@
 
 CREATE_EXE_COMMAND          ?= \
 	g++ $(CXX_OBJ_FILES) \
-	$(CFLAGS) $(LDFLAGS) $(CONAN_EXELINKFLAGS) \
+	$(CFLAGS) $(CXXFLAGS) $(LDFLAGS) $(EXELINKFLAGS) \
 	-o $(EXE_FILENAME)
 
 

--- a/conans/test/generators/make_test.py
+++ b/conans/test/generators/make_test.py
@@ -36,8 +36,8 @@ class MakeGeneratorTest(unittest.TestCase):
         cpp_info.libs = ['libfoo']
         cpp_info.bindirs = ['bin1']
         cpp_info.version = "0.1"
-        cpp_info.cflags = ['-fPIC']
-        cpp_info.cppflags = ['-fPIE']
+        cpp_info.cflags = ['-fgimple']
+        cpp_info.cppflags = ['-fdollars-in-identifiers']
         cpp_info.sharedlinkflags = ['-framework Cocoa']
         cpp_info.exelinkflags = ['-framework QuartzCore']
         conanfile.deps_cpp_info.update(cpp_info, ref.name)
@@ -49,8 +49,8 @@ class MakeGeneratorTest(unittest.TestCase):
         cpp_info.libs = ['libbar']
         cpp_info.bindirs = ['bin2']
         cpp_info.version = "3.2.3"
-        cpp_info.cflags = ['-mtune=native']
-        cpp_info.cppflags = ['-march=native']
+        cpp_info.cflags = ['-fno-asm']
+        cpp_info.cppflags = ['-pthread']
         cpp_info.sharedlinkflags = ['-framework AudioFoundation']
         cpp_info.exelinkflags = ['-framework VideoToolbox']
         conanfile.deps_cpp_info.update(cpp_info, ref.name)
@@ -86,10 +86,10 @@ CONAN_DEFINES_MYPKG1 +=  \\
 MYDEFINE1
 
 CONAN_CFLAGS_MYPKG1 +=  \\
--fPIC
+-fgimple
 
 CONAN_CPPFLAGS_MYPKG1 +=  \\
--fPIE
+-fdollars-in-identifiers
 
 CONAN_SHAREDLINKFLAGS_MYPKG1 +=  \\
 -framework Cocoa
@@ -125,10 +125,10 @@ CONAN_DEFINES_MYPKG2 +=  \\
 MYDEFINE2
 
 CONAN_CFLAGS_MYPKG2 +=  \\
--mtune=native
+-fno-asm
 
 CONAN_CPPFLAGS_MYPKG2 +=  \\
--march=native
+-pthread
 
 CONAN_SHAREDLINKFLAGS_MYPKG2 +=  \\
 -framework AudioFoundation
@@ -242,7 +242,7 @@ include conanbuildinfo.mak
 #     Make variables for a sample App
 #----------------------------------------
 
-CXX_INCLUDES = \
+CXX_INCLUDE_PATHS = \
 ./include
 
 CXX_SRCS = \
@@ -262,11 +262,11 @@ libhellowrapper.so
 #     Prepare flags from variables
 #----------------------------------------
 
-CPPFLAGS        += $(addprefix -I, $(CXX_INCLUDES) $(CONAN_INCLUDE_PATHS))
+CFLAGS          += $(CONAN_CFLAGS)
+CPPFLAGS        += $(addprefix -I, $(CXX_INCLUDE_PATHS) $(CONAN_INCLUDE_PATHS))
 CPPFLAGS        += $(addprefix -D, $(CONAN_DEFINES))
 LDFLAGS         += $(addprefix -L, $(CONAN_LIB_PATHS))
 LIBS            += $(addprefix -l, $(CONAN_LIBS))
-CXXFLAGS        += $(addprefix -f, PIC)
 
 
 #----------------------------------------
@@ -274,7 +274,7 @@ CXXFLAGS        += $(addprefix -f, PIC)
 #----------------------------------------
 
 COMPILE_CXX_COMMAND         ?= \
-	g++ -c $(CXXFLAGS) $(CPPFLAGS) $< -o $@
+	g++ -c $(CFLAGS) $(CPPFLAGS) $< -o $@
 
 CREATE_SHARED_LIB_COMMAND   ?= \
 	g++ -shared $(CXX_OBJ_FILES) \
@@ -365,6 +365,7 @@ main
 #     Prepare flags from variables
 #----------------------------------------
 
+CFLAGS          += $(CONAN_CFLAGS)
 CPPFLAGS        += $(addprefix -I, $(CONAN_INCLUDE_PATHS))
 CPPFLAGS        += $(addprefix -D, $(CONAN_DEFINES))
 LDFLAGS         += $(addprefix -L, $(CONAN_LIB_PATHS))
@@ -376,7 +377,7 @@ LIBS            += $(addprefix -l, $(CONAN_LIBS))
 #----------------------------------------
 
 COMPILE_CXX_COMMAND         ?= \
-	g++ -c $(CXXFLAGS) $(CPPFLAGS) $< -o $@
+	g++ -c $(CFLAGS) $(CPPFLAGS) $< -o $@
 
 CREATE_EXE_COMMAND          ?= \
 	g++ $(CXX_OBJ_FILES) \

--- a/conans/test/generators/make_test.py
+++ b/conans/test/generators/make_test.py
@@ -269,7 +269,7 @@ CXXFLAGS            += $(CONAN_CPPFLAGS)
 CPPFLAGS            += $(addprefix -I, $(INCLUDE_PATHS) $(CONAN_INCLUDE_PATHS))
 CPPFLAGS            += $(addprefix -D, $(CONAN_DEFINES))
 LDFLAGS             += $(addprefix -L, $(CONAN_LIB_PATHS))
-LDFLAGS             += $(addprefix -l, $(CONAN_LIBS))
+LDLIBS              += $(addprefix -l, $(CONAN_LIBS))
 SHAREDLINKFLAGS     += $(CONAN_SHAREDLINKFLAGS)
 
 #----------------------------------------
@@ -277,11 +277,11 @@ SHAREDLINKFLAGS     += $(CONAN_SHAREDLINKFLAGS)
 #----------------------------------------
 
 COMPILE_CXX_COMMAND         ?= \
-	g++ -c $(CPPFLAGS) $(CFLAGS) $(CXXFLAGS) $< -o $@
+	g++ -c $(CPPFLAGS) $(CXXFLAGS) $< -o $@
 
 CREATE_SHARED_LIB_COMMAND   ?= \
 	g++ -shared $(CXX_OBJ_FILES) \
-	$(CFLAGS) $(CXXFLAGS) $(LDFLAGS) $(SHAREDLINKFLAGS) \
+	$(CXXFLAGS) $(LDFLAGS) $(LDLIBS) $(SHAREDLINKFLAGS) \
 	-o $(SHARED_LIB_FILENAME)
 
 CREATE_STATIC_LIB_COMMAND   ?= \
@@ -377,7 +377,7 @@ CXXFLAGS            += $(CONAN_CPPFLAGS)
 CPPFLAGS            += $(addprefix -I, $(CONAN_INCLUDE_PATHS))
 CPPFLAGS            += $(addprefix -D, $(CONAN_DEFINES))
 LDFLAGS             += $(addprefix -L, $(CONAN_LIB_PATHS))
-LDFLAGS             += $(addprefix -l, $(CONAN_LIBS))
+LDLIBS              += $(addprefix -l, $(CONAN_LIBS))
 EXELINKFLAGS        += $(CONAN_EXELINKFLAGS)
 
 #----------------------------------------
@@ -385,11 +385,11 @@ EXELINKFLAGS        += $(CONAN_EXELINKFLAGS)
 #----------------------------------------
 
 COMPILE_CXX_COMMAND         ?= \
-	g++ -c $(CPPFLAGS) $(CFLAGS) $(CXXFLAGS) $< -o $@
+	g++ -c $(CPPFLAGS) $(CXXFLAGS) $< -o $@
 
 CREATE_EXE_COMMAND          ?= \
 	g++ $(CXX_OBJ_FILES) \
-	$(CFLAGS) $(CXXFLAGS) $(LDFLAGS) $(EXELINKFLAGS) \
+	$(CXXFLAGS) $(LDFLAGS) $(LDLIBS) $(EXELINKFLAGS) \
 	-o $(EXE_FILENAME)
 
 


### PR DESCRIPTION
Changelog: (Fix): Improve makefile generator test

This is a followup adjustment to: 
https://github.com/conan-io/conan/pull/4003
which closed:
https://github.com/conan-io/conan/issues/3773


The makefile generator unit test still had some small issues, summarized as they appear below.  On one hand, the builds and tests passed, making these seem like mostly cosmetic issues.  On the other hand, people sometimes look at tests, and probably moreso for new generators than anything else.  Non-gcc experts might be confused about how they should use these flags/vars in their own makefiles, and gcc-experts might be concerned that the unit test does things incorrectly and still passes.  Best to make these test as correct as possible. 

`-fPIC`/`-fPIE` are particularly important flags, which need to go to both compiler and linker, and should always be set by the current package, never propagated from upstream dependencies.  

`-march`/`-mtune` would be defined on "platform" basis, likely passed in via a profile/environment_varaible/toolchain file rather than from upstream dependencies.  

-Thus, replaced the `cflags` above with ones that people might realistically want to pass from upstream to downstream.  Of note, `-pthread` is indeed a compiler flag separate from the linker flag `-lpthread`. 

-Modified `CXX_INCLUDE_PATHS` var name to be consistent with `CONAN_INCLUDE_PATHS`

-Added new `CFLAGS` variable and set it equal to `$(CONAN_CFLAGS)`.  It turned out that the latter was simply ignored (never referenced) in the build, and that was definitely a problem.  This is probably the most significant of the improvements. 

-Simply removed the use of the `CXX_FLAGS` variable.  There was no reason to add a new variable, as it just complicates the example overall.  Also, this removes the `-fPIC` compiler flag from the equation completely, which is good because it's not strictly necessary. To handle `fPIC` and `fPIE` properly,  one should make it a Conan option and only apply it conditionally in the makefile, none of which is necessary for this test. 


- [x] Refer to the issue that supports this Pull Request.
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://raw.githubusercontent.com/conan-io/conan/develop/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [x] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 


