### PR TITLE
Subsystems PATH as a list failing

### DIFF
--- a/conans/client/tools/win.py
+++ b/conans/client/tools/win.py
@@ -569,22 +569,30 @@ def run_in_windows_bash(conanfile, bashcmd, cwd=None, subsystem=None, msys_mingw
         env_vars = {}
 
     with environment_append(env_vars):
+
         hack_env = ""
+        # In the bash.exe from WSL this trick do not work, always the /usr/bin etc at first place
         if subsystem != WSL:
-            # In the bash.exe from WSL this trick do not work, always the /usr/bin etc at first place
-            inherited_path = conanfile.env.get("PATH", None)
-            if isinstance(inherited_path, list):
-                paths = [unix_path(path, path_flavor=subsystem) for path in inherited_path]
-                inherited_path = ":".join(paths)
-            else:
-                inherited_path = unix_path(inherited_path, path_flavor=subsystem)
 
-            if "PATH" in env:
-                tmp = unix_path(env["PATH"].replace(";", ":"), path_flavor=subsystem)
-                inherited_path = "%s:%s" % (tmp, inherited_path) if inherited_path else tmp
+            def get_path_value(container, subsystem_name):
+                """Gets the path from the container dict and returns a string with the path for the subsystem_name"""
+                _path_key = next((name for name in container.keys() if "path" == name.lower()), None)
+                if _path_key:
+                    _path_value = container.get(_path_key)
+                    if isinstance(_path_value, list):
+                        return ":".join([unix_path(path, path_flavor=subsystem_name) for path in _path_value])
+                    else:
+                        return unix_path(_path_value, path_flavor=subsystem_name)
 
+            # First get the PATH from the conanfile.env
+            inherited_path = get_path_value(conanfile.env, subsystem)
+            # Then get the PATH from the real env
+            env_path = get_path_value(env, subsystem)
+
+            # Both together
+            full_env = ":".join(v for v in [env_path, inherited_path] if v)
             # Put the build_requires and requires path at the first place inside the shell
-            hack_env = ' && PATH="%s:$PATH"' % inherited_path if inherited_path else ""
+            hack_env = ' && PATH="%s:$PATH"' % full_env if full_env else ""
 
         for var_name, value in env.items():
             if var_name == "PATH":


### PR DESCRIPTION
Changelog: Bugfix: Running Windows subsystem scripts crashed when the PATH environment variable passed as a list.

Spotted in preflight develop.
