### PR TITLE
Propagate all download args to get

### DIFF
--- a/conans/client/tools/net.py
+++ b/conans/client/tools/net.py
@@ -7,14 +7,16 @@ from conans.util.fallbacks import default_output, default_requester
 
 
 def get(url, md5='', sha1='', sha256='', destination=".", filename="", keep_permissions=False,
-        pattern=None, requester=None, output=None):
+        pattern=None, requester=None, output=None, verify=True, retry=None, retry_wait=None,
+        overwrite=False, auth=None, headers=None):
     """ high level downloader + unzipper + (optional hash checker) + delete temporary zip
     """
     if not filename and ("?" in url or "=" in url):
         raise ConanException("Cannot deduce file name form url. Use 'filename' parameter.")
 
     filename = filename or os.path.basename(url)
-    download(url, filename, out=output, requester=requester)
+    download(url, filename, out=output, requester=requester, verify=verify, retry=retry,
+             retry_wait=retry_wait, overwrite=overwrite, auth=auth, headers=headers)
 
     if md5:
         check_md5(filename, md5)
@@ -47,8 +49,14 @@ def ftp_download(ip, filename, login='', password=''):
             pass
 
 
-def download(url, filename, verify=True, out=None, retry=2, retry_wait=5, overwrite=False,
+def download(url, filename, verify=True, out=None, retry=None, retry_wait=None, overwrite=False,
              auth=None, headers=None, requester=None):
+
+    if retry is None:
+        retry = 2
+    if retry_wait is None:
+        retry_wait = 5
+
     out = default_output(out, 'conans.client.tools.net.download')
     requester = default_requester(requester, 'conans.client.tools.net.download')
 


### PR DESCRIPTION
Changelog: Fix: The `tools.get` tool (download + unzip) now supports all the arguments of the `download` tool. e.g: `verify`, `retry`,  `retry_wait` etc.

Closes #4028
Docs at:  https://github.com/conan-io/docs/pull/961

