### PR TITLE
Print warning but ignore gitignored files optimization

### DIFF
--- a/conans/client/cmd/export.py
+++ b/conans/client/cmd/export.py
@@ -73,7 +73,7 @@ def _capture_export_scm_data(conanfile, conanfile_dir, destination_folder, outpu
     if not scm_data or not (scm_data.capture_origin or scm_data.capture_revision):
         return None, captured_revision
 
-    scm = SCM(scm_data, conanfile_dir)
+    scm = SCM(scm_data, conanfile_dir, output)
 
     if scm_data.url == "auto":
         origin = scm.get_qualified_remote_url()

--- a/conans/client/source.py
+++ b/conans/client/source.py
@@ -201,12 +201,12 @@ def _run_scm(conanfile, src_folder, local_sources_path, output, cache):
     local_sources_path = local_sources_path if captured else None
 
     if local_sources_path:
-        excluded = SCM(scm_data, local_sources_path).excluded_files
+        excluded = SCM(scm_data, local_sources_path, output).excluded_files
         output.info("Getting sources from folder: %s" % local_sources_path)
         merge_directories(local_sources_path, dest_dir, excluded=excluded)
     else:
         output.info("Getting sources from url: '%s'" % scm_data.url)
-        scm = SCM(scm_data, dest_dir)
+        scm = SCM(scm_data, dest_dir, output)
         scm.checkout()
     if cache:
         # This is a bit weird. Why after a SCM should we remove files. Maybe check conan 2.0

--- a/conans/client/tools/scm.py
+++ b/conans/client/tools/scm.py
@@ -18,8 +18,8 @@ from conans.util.files import decode_text, to_file_bytes, walk
 class SCMBase(object):
     cmd_command = None
 
-    def __init__(self, folder=None, verify_ssl=True, username=None, password=None, force_english=True,
-                 runner=None):
+    def __init__(self, folder=None, verify_ssl=True, username=None, password=None,
+                 force_english=True, runner=None, output=None):
         self.folder = folder or os.getcwd()
         if not os.path.exists(self.folder):
             os.makedirs(self.folder)
@@ -28,6 +28,7 @@ class SCMBase(object):
         self._username = username
         self._password = password
         self._runner = runner
+        self._output = output
 
     def run(self, command):
         command = "%s %s" % (self.cmd_command, command)
@@ -97,19 +98,24 @@ class Git(SCMBase):
         return output
 
     def excluded_files(self):
+        ret = []
         try:
 
             file_paths = [os.path.normpath(os.path.join(os.path.relpath(folder, self.folder), el)).replace("\\", "/")
                           for folder, dirpaths, fs in walk(self.folder)
                           for el in fs + dirpaths]
-            p = subprocess.Popen(['git', 'check-ignore', '--stdin'],
-                                 stdout=PIPE, stdin=PIPE, stderr=STDOUT, cwd=self.folder)
-            paths = to_file_bytes("\n".join(file_paths))
-            grep_stdout = decode_text(p.communicate(input=paths)[0])
-            tmp = grep_stdout.splitlines()
-        except CalledProcessError:
-            tmp = []
-        return tmp
+            if file_paths:
+                p = subprocess.Popen(['git', 'check-ignore', '--stdin'],
+                                     stdout=PIPE, stdin=PIPE, stderr=STDOUT, cwd=self.folder)
+                paths = to_file_bytes("\n".join(file_paths))
+                grep_stdout = decode_text(p.communicate(input=paths)[0])
+                ret = grep_stdout.splitlines()
+        except (CalledProcessError, FileNotFoundError) as e:
+            if self._output:
+                self._output.warn("Error checking excluded git files: %s. "
+                                  "Ignoring excluded files" % e)
+            ret = []
+        return ret
 
     def get_remote_url(self, remote_name=None):
         self._check_git_repo()

--- a/conans/model/scm.py
+++ b/conans/model/scm.py
@@ -50,8 +50,9 @@ class SCMData(object):
 
 
 class SCM(object):
-    def __init__(self, data, repo_folder):
+    def __init__(self, data, repo_folder, output):
         self._data = data
+        self._output = output
         self.repo_folder = repo_folder
         # Finally instance a repo
         self.repo = self._get_repo()
@@ -62,7 +63,8 @@ class SCM(object):
             raise ConanException("SCM not supported: %s" % self._data.type)
 
         return repo_class(folder=self.repo_folder, verify_ssl=self._data.verify_ssl,
-                          username=self._data.username, password=self._data.password)
+                          username=self._data.username, password=self._data.password,
+                          output=self._output)
 
     @property
     def excluded_files(self):


### PR DESCRIPTION
Changelog: Fix: Using the `scm` feature when Conan is not able to read the gitignored files (local optimization mechanism) print a warning to improve the debug information but not crash.  

Closes #4027
