### PR TITLE
Only create zero size symlinks in tarfiles (Implements #4050)

### DIFF
--- a/conans/client/remote_manager.py
+++ b/conans/client/remote_manager.py
@@ -392,6 +392,7 @@ def compress_files(files, symlinks, name, dest_dir, output=None):
         for filename, dest in sorted(symlinks.items()):
             info = tarfile.TarInfo(name=filename)
             info.type = tarfile.SYMTYPE
+            info.size = 0
             info.linkname = dest
             tgz.addfile(tarinfo=info)
 
@@ -407,6 +408,7 @@ def compress_files(files, symlinks, name, dest_dir, output=None):
             info.mode = os.stat(abs_path).st_mode & mask
             if os.path.islink(abs_path):
                 info.type = tarfile.SYMTYPE
+                info.size = 0
                 info.linkname = os.readlink(abs_path)  # @UndefinedVariable
                 tgz.addfile(tarinfo=info)
             else:


### PR DESCRIPTION
Changelog: Bugfix: symlinks in the `tgz` files were created with size != 0

Closes #4050