### PR TITLE
Assuming os_build and arch_build as settings

### DIFF
--- a/conans/search/search.py
+++ b/conans/search/search.py
@@ -66,7 +66,7 @@ def evaluate(prop_name, prop_value, conan_vars_info):
     info_settings = conan_vars_info.get("settings", [])
     info_options = conan_vars_info.get("options", [])
 
-    if prop_name in ["os", "compiler", "arch", "build_type"] or prop_name.startswith("compiler."):
+    if prop_name in ["os", "os_build", "compiler", "arch", "arch_build", "build_type"] or prop_name.startswith("compiler."):
         return compatible_prop(info_settings.get(prop_name, None), prop_value)
     else:
         return compatible_prop(info_options.get(prop_name, None), prop_value)

--- a/conans/test/command/search_test.py
+++ b/conans/test/command/search_test.py
@@ -82,7 +82,6 @@ conan_vars4 = """[settings]
   HelloInfo1/0.45@myuser/testing:33333
 """
 
-
 class SearchTest(unittest.TestCase):
 
     def setUp(self):
@@ -179,8 +178,7 @@ helloTest/1.4.10@myuser/stable""".format(remote)
         self.assertEquals("Existing package recipes:\n\n"
                           "Hello/1.4.10@myuser/testing\n"
                           "Hello/1.4.11@myuser/testing\n"
-                          "Hello/1.4.12@myuser/testing\n",
-                          self.client.out)
+                          "Hello/1.4.12@myuser/testing\n", self.client.out)
 
         self.client.run("search *myuser* --case-sensitive")
         self.assertEquals("Existing package recipes:\n\n"
@@ -287,30 +285,6 @@ helloTest/1.4.10@myuser/stable""".format(remote)
         self.client.run("search Hello* --table=table.html", ignore_error=True)
         self.assertIn("ERROR: '--table' argument can only be used with a reference",
                       self.client.out)
-
-    def recipe_pattern_search_test(self):
-        self.client.run("search Hello*")
-        self.assertEquals("Existing package recipes:\n\n"
-                          "Hello/1.4.10@myuser/testing\n"
-                          "Hello/1.4.11@myuser/testing\n"
-                          "Hello/1.4.12@myuser/testing\n"
-                          "helloTest/1.4.10@myuser/stable\n", self.client.out)
-
-        self.client.run("search Hello* --case-sensitive")
-        self.assertEquals("Existing package recipes:\n\n"
-                          "Hello/1.4.10@myuser/testing\n"
-                          "Hello/1.4.11@myuser/testing\n"
-                          "Hello/1.4.12@myuser/testing\n", self.client.out)
-
-        self.client.run("search *myuser* --case-sensitive")
-        self.assertEquals("Existing package recipes:\n\n"
-                          "Bye/0.14@myuser/testing\n"
-                          "Hello/1.4.10@myuser/testing\n"
-                          "Hello/1.4.11@myuser/testing\n"
-                          "Hello/1.4.12@myuser/testing\n"
-                          "MissFile/1.0.2@myuser/stable\n"
-                          "NodeInfo/1.0.2@myuser/stable\n"
-                          "helloTest/1.4.10@myuser/stable\n", self.client.out)
 
     def package_search_with_invalid_reference_test(self):
         self.client.run("search Hello -q 'a=1'", ignore_error=True)


### PR DESCRIPTION
Changelog: Bugfix: Take into account ``os_build`` and ``arch_build`` for search queries.

Accoding to issue https://github.com/conan-io/conan/issues/4060 os_build and arch_build are not handled as options. This tries to fix it, but maybe further things are needed?

Close #4060