### PR TITLE
range resolver don't output directly

### DIFF
--- a/conans/client/conan_api.py
+++ b/conans/client/conan_api.py
@@ -240,7 +240,7 @@ class ConanAPIV1(object):
 
         self._proxy = ConanProxy(client_cache, self._user_io.out, remote_manager,
                                  registry=self._registry)
-        resolver = RangeResolver(self._user_io.out, client_cache, self._proxy)
+        resolver = RangeResolver(client_cache, self._proxy)
         python_requires = ConanPythonRequire(self._proxy, resolver)
         self._loader = ConanFileLoader(self._runner, self._user_io.out, python_requires)
 

--- a/conans/client/graph/graph_builder.py
+++ b/conans/client/graph/graph_builder.py
@@ -247,7 +247,7 @@ class DepsGraphBuilder(object):
                                    % (requirement.conan_reference, base_ref))
                 raise e
             conanfile_path, recipe_status, remote, new_ref = result
-            
+
         dep_conanfile = self._loader.load_conanfile(conanfile_path, output, processed_profile,
                                                     reference=requirement.conan_reference)
 

--- a/conans/client/graph/graph_manager.py
+++ b/conans/client/graph/graph_manager.py
@@ -131,6 +131,12 @@ class GraphManager(object):
                                       profile_build_requires=profile.build_requires,
                                       recorder=recorder, workspace=workspace,
                                       processed_profile=processed_profile)
+        version_ranges_output = self._resolver.output
+        if version_ranges_output:
+            self._output.success("Version ranges solved")
+            for msg in version_ranges_output:
+                self._output.info("    %s" % msg)
+            self._output.writeln("")
         build_mode.report_matches()
         return deps_graph, conanfile, cache_settings
 

--- a/conans/client/graph/range_resolver.py
+++ b/conans/client/graph/range_resolver.py
@@ -9,7 +9,7 @@ re_param = re.compile(r"^(?P<function>include_prerelease|loose)\s*=\s*(?P<value>
 re_version = re.compile(r"^((?!(include_prerelease|loose))[a-zA-Z0-9_+.\-~<>=|*^\s])*$")
 
 
-def _parse_versionexpr(versionexpr, output):
+def _parse_versionexpr(versionexpr, result):
     expression = [it.strip() for it in versionexpr.split(",")]
     if len(expression) > 4:
         raise ConanException("Invalid expression for version_range '{}'".format(versionexpr))
@@ -45,21 +45,21 @@ def _parse_versionexpr(versionexpr, output):
                                      "parameter '{}'".format(match_param.group(1)))
 
     if len(version_range) > 1:
-        output.warn("Commas as separator in version '%s' range will are deprecated and will be removed in Conan 2.0" %
-                    str(versionexpr))
+        result.append("WARN: Commas as separator in version '%s' range are deprecated "
+                      "and will be removed in Conan 2.0" % str(versionexpr))
 
     version_range = " ".join(map(str, version_range))
     return version_range, loose, include_prerelease
 
 
-def satisfying(list_versions, versionexpr, output):
+def satisfying(list_versions, versionexpr, result):
     """ returns the maximum version that satisfies the expression
     if some version cannot be converted to loose SemVer, it is discarded with a msg
     This provides some workaround for failing comparisons like "2.1" not matching "<=2.1"
     """
     from semver import SemVer, Range, max_satisfying
 
-    version_range, loose, include_prerelease = _parse_versionexpr(versionexpr, output)
+    version_range, loose, include_prerelease = _parse_versionexpr(versionexpr, result)
 
     # Check version range expression
     try:
@@ -74,7 +74,8 @@ def satisfying(list_versions, versionexpr, output):
             ver = SemVer(v, loose=loose)
             candidates[ver] = v
         except (ValueError, AttributeError):
-            output.warn("Version '%s' is not semver, cannot be compared with a range" % str(v))
+            result.append("WARN: Version '%s' is not semver, cannot be compared with a range"
+                          % str(v))
 
     # Search best matching version in range
     result = max_satisfying(candidates, act_range, loose=loose,
@@ -84,11 +85,17 @@ def satisfying(list_versions, versionexpr, output):
 
 class RangeResolver(object):
 
-    def __init__(self, output, client_cache, remote_search):
-        self._output = output
+    def __init__(self, client_cache, remote_search):
         self._client_cache = client_cache
         self._remote_search = remote_search
         self._cached_remote_found = {}
+        self._result = []
+
+    @property
+    def output(self):
+        result = self._result
+        self._result = []
+        return result
 
     def resolve(self, require, base_conanref, update, remote_name):
         version_range = require.version_range
@@ -103,9 +110,9 @@ class RangeResolver(object):
                                      "downstream requirement '%s'"
                                      % (version_range, base_conanref, str(ref)))
             else:
-                self._output.success("Version range '%s' required by '%s' valid for "
-                                     "downstream requirement '%s'"
-                                     % (version_range, base_conanref, str(ref)))
+                self._result.append("Version range '%s' required by '%s' valid for "
+                                    "downstream requirement '%s'"
+                                    % (version_range, base_conanref, str(ref)))
             return
 
         ref = require.conan_reference
@@ -120,8 +127,8 @@ class RangeResolver(object):
                         self._resolve_remote(search_ref, version_range, remote_name))
 
         if resolved:
-            self._output.success("Version range '%s' required by '%s' resolved to '%s'"
-                                 % (version_range, base_conanref, str(resolved)))
+            self._result.append("Version range '%s' required by '%s' resolved to '%s'"
+                                % (version_range, base_conanref, str(resolved)))
             require.conan_reference = resolved
         else:
             base_conanref = base_conanref or "PROJECT"
@@ -149,5 +156,5 @@ class RangeResolver(object):
 
     def _resolve_version(self, version_range, refs_found):
         versions = {ref.version: ref for ref in refs_found}
-        result = satisfying(versions, version_range, self._output)
+        result = satisfying(versions, version_range, self._result)
         return versions.get(result)

--- a/conans/test/integration/version_ranges_diamond_test.py
+++ b/conans/test/integration/version_ranges_diamond_test.py
@@ -178,6 +178,7 @@ class HelloReuseConan(ConanFile):
 
         self.client.run('remove "Hello0/0.*" -f')
         self.client.run("install . --build missing")
+        print self.client.out
         self.assertIn("Version range '>0.1,<0.3' required by 'None' "
                       "resolved to 'Hello0/0.2@lasote/stable'", self.client.user_io.out)
         self.assertIn("PROJECT: Generated conaninfo.txt", self.client.user_io.out)

--- a/conans/test/integration/version_ranges_diamond_test.py
+++ b/conans/test/integration/version_ranges_diamond_test.py
@@ -178,7 +178,6 @@ class HelloReuseConan(ConanFile):
 
         self.client.run('remove "Hello0/0.*" -f')
         self.client.run("install . --build missing")
-        print self.client.out
         self.assertIn("Version range '>0.1,<0.3' required by 'None' "
                       "resolved to 'Hello0/0.2@lasote/stable'", self.client.user_io.out)
         self.assertIn("PROJECT: Generated conaninfo.txt", self.client.user_io.out)

--- a/conans/test/model/version_ranges_test.py
+++ b/conans/test/model/version_ranges_test.py
@@ -40,12 +40,14 @@ class BasicMaxVersionTest(unittest.TestCase):
         self.assertEqual(result, "4.2.3")
 
     def loose_versions_test(self):
-        output = TestBufferConanOutput()
+        output = []
         result = satisfying(["4.2.2", "4.2.3-pre"], "~4.2.1,loose=False", output)
         self.assertEqual(result, "4.2.2")
-        result = satisfying(["1.1.1", "1.1.2", "1.2", "1.2.1", "1.3", "2.1"], "1.8||1.3,loose=False", output)
+        result = satisfying(["1.1.1", "1.1.2", "1.2", "1.2.1", "1.3", "2.1"], "1.8||1.3,loose=False",
+                            output)
         self.assertEqual(result, None)
-        result = satisfying(["1.1.1", "1.1.2", "1.2", "1.2.1", "1.3", "2.1"], "1.8||1.3, loose = False ", output)
+        result = satisfying(["1.1.1", "1.1.2", "1.2", "1.2.1", "1.3", "2.1"],
+                            "1.8||1.3, loose = False ", output)
         self.assertEqual(result, None)
         result = satisfying(["1.1.1", "1.1.2", "1.2", "1.2.1", "1.3", "2.1"], "1.8||1.3", output)
         self.assertEqual(result, "1.3")
@@ -58,7 +60,7 @@ class BasicMaxVersionTest(unittest.TestCase):
         self.assertEqual(result, "4.2.2")
 
     def basic_test(self):
-        output = TestBufferConanOutput()
+        output = []
         result = satisfying(["1.1", "1.2", "1.3", "2.1"], "", output)
         self.assertEqual(result, "2.1")
         result = satisfying(["1.1", "1.2", "1.3", "2.1"], "1", output)
@@ -86,7 +88,7 @@ class BasicMaxVersionTest(unittest.TestCase):
         result = satisfying(["1.1.1", "1.1.2", "1.2", "1.2.1", "1.3", "2.1"], "<1.3", output)
         self.assertEqual(result, "1.2.1")
         result = satisfying(["1.a.1", "master", "X.2", "1.2.1", "1.3", "2.1"], "1.3", output)
-        self.assertIn("Version 'master' is not semver", output)
+        self.assertIn("Version 'master' is not semver", "".join(output))
         self.assertEqual(result, "1.3")
         result = satisfying(["1.1.1", "1.1.2", "1.2", "1.2.1", "1.3", "2.1"], "1.8||1.3", output)
         self.assertEqual(result, "1.3")
@@ -125,7 +127,7 @@ from conans import ConanFile
 class HelloConan(ConanFile):
     name = "Hello"
     version = "1.2"
-    requires = "Say/[%s]@memsharded/testing"
+    requires = "Say/[%s]@myuser/testing"
 """
 
 
@@ -164,7 +166,7 @@ class VersionRangesTest(unittest.TestCase):
         self.retriever = Retriever(self.loader, self.output)
         self.remote_search = MockSearchRemote()
         paths = SimplePaths(self.retriever.folder)
-        self.resolver = RangeResolver(self.output, paths, self.remote_search)
+        self.resolver = RangeResolver(paths, self.remote_search)
         self.builder = DepsGraphBuilder(self.retriever, self.output, self.loader, self.resolver,
                                         None, None)
 
@@ -176,13 +178,14 @@ class SayConan(ConanFile):
     name = "Say"
     version = "%s"
 """ % v
-            say_ref = ConanFileReference.loads("Say/%s@memsharded/testing" % v)
+            say_ref = ConanFileReference.loads("Say/%s@myuser/testing" % v)
             self.retriever.conan(say_ref, say_content)
 
     def root(self, content, update=False):
         processed_profile = ProcessedProfile()
         root_conan = self.retriever.root(content, processed_profile)
         deps_graph = self.builder.load_graph(root_conan, update, update, None, processed_profile)
+        self.output.write("\n".join(self.resolver.output))
         return deps_graph
 
     def test_local_basic(self):
@@ -207,14 +210,14 @@ class SayConan(ConanFile):
             conanfile = hello.conanfile
             self.assertEqual(conanfile.version, "1.2")
             self.assertEqual(conanfile.name, "Hello")
-            say_ref = ConanFileReference.loads("Say/%s@memsharded/testing" % solution)
+            say_ref = ConanFileReference.loads("Say/%s@myuser/testing" % solution)
             self.assertEqual(_clear_revs(conanfile.requires), Requirements(str(say_ref)))
 
     def test_remote_basic(self):
         self.resolver._local_search = None
         remote_packages = []
         for v in ["0.1", "0.2", "0.3", "1.1", "1.1.2", "1.2.1", "2.1", "2.2.1"]:
-            say_ref = ConanFileReference.loads("Say/%s@memsharded/testing" % v)
+            say_ref = ConanFileReference.loads("Say/%s@myuser/testing" % v)
             remote_packages.append(say_ref)
         self.remote_search.packages = remote_packages
         for expr, solution in [(">0.0", "2.2.1"),
@@ -228,7 +231,7 @@ class SayConan(ConanFile):
                                ("~=2.1", "2.1"),
                                ]:
             deps_graph = self.root(hello_content % expr, update=True)
-            self.assertEqual(self.remote_search.count, {'Say/*@memsharded/testing': 1})
+            self.assertEqual(self.remote_search.count, {'Say/*@myuser/testing': 1})
             self.assertEqual(2, len(deps_graph.nodes))
             hello = _get_nodes(deps_graph, "Hello")[0]
             say = _get_nodes(deps_graph, "Say")[0]
@@ -238,30 +241,30 @@ class SayConan(ConanFile):
             conanfile = hello.conanfile
             self.assertEqual(conanfile.version, "1.2")
             self.assertEqual(conanfile.name, "Hello")
-            say_ref = ConanFileReference.loads("Say/%s@memsharded/testing" % solution)
+            say_ref = ConanFileReference.loads("Say/%s@myuser/testing" % solution)
             self.assertEqual(_clear_revs(conanfile.requires), Requirements(str(say_ref)))
 
     def test_remote_optimized(self):
         self.resolver._local_search = None
         remote_packages = []
         for v in ["0.1", "0.2", "0.3", "1.1", "1.1.2", "1.2.1", "2.1", "2.2.1"]:
-            say_ref = ConanFileReference.loads("Say/%s@memsharded/testing" % v)
+            say_ref = ConanFileReference.loads("Say/%s@myuser/testing" % v)
             remote_packages.append(say_ref)
         self.remote_search.packages = remote_packages
 
         dep_content = """from conans import ConanFile
 class Dep1Conan(ConanFile):
-    requires = "Say/[%s]@memsharded/testing"
+    requires = "Say/[%s]@myuser/testing"
 """
-        dep_ref = ConanFileReference.loads("Dep1/0.1@memsharded/testing")
+        dep_ref = ConanFileReference.loads("Dep1/0.1@myuser/testing")
         self.retriever.conan(dep_ref, dep_content % ">=0.1")
-        dep_ref = ConanFileReference.loads("Dep2/0.1@memsharded/testing")
+        dep_ref = ConanFileReference.loads("Dep2/0.1@myuser/testing")
         self.retriever.conan(dep_ref, dep_content % ">=0.1")
 
         hello_content = """from conans import ConanFile
 class HelloConan(ConanFile):
     name = "Hello"
-    requires = "Dep1/0.1@memsharded/testing", "Dep2/0.1@memsharded/testing"
+    requires = "Dep1/0.1@myuser/testing", "Dep2/0.1@myuser/testing"
 """
         deps_graph = self.root(hello_content, update=True)
         self.assertEqual(4, len(deps_graph.nodes))
@@ -273,22 +276,22 @@ class HelloConan(ConanFile):
                                                   Edge(dep1, say), Edge(dep2, say)})
 
         # Most important check: counter of calls to remote
-        self.assertEqual(self.remote_search.count, {'Say/*@memsharded/testing': 1})
+        self.assertEqual(self.remote_search.count, {'Say/*@myuser/testing': 1})
 
     @parameterized.expand([("", "0.3", None, None),
-                           ('"Say/1.1@memsharded/testing"', "1.1", False, False),
-                           ('"Say/0.2@memsharded/testing"', "0.2", False, True),
-                           ('("Say/1.1@memsharded/testing", "override")', "1.1", True, False),
-                           ('("Say/0.2@memsharded/testing", "override")', "0.2", True, True),
+                           ('"Say/1.1@myuser/testing"', "1.1", False, False),
+                           ('"Say/0.2@myuser/testing"', "0.2", False, True),
+                           ('("Say/1.1@myuser/testing", "override")', "1.1", True, False),
+                           ('("Say/0.2@myuser/testing", "override")', "0.2", True, True),
                            # ranges
-                           ('"Say/[<=1.2]@memsharded/testing"', "1.2.1", False, False),
-                           ('"Say/[>=0.2,<=1.0]@memsharded/testing"', "0.3", False, True),
-                           ('("Say/[<=1.2]@memsharded/testing", "override")', "1.2.1", True, False),
-                           ('("Say/[>=0.2,<=1.0]@memsharded/testing", "override")', "0.3", True, True),
+                           ('"Say/[<=1.2]@myuser/testing"', "1.2.1", False, False),
+                           ('"Say/[>=0.2,<=1.0]@myuser/testing"', "0.3", False, True),
+                           ('("Say/[<=1.2]@myuser/testing", "override")', "1.2.1", True, False),
+                           ('("Say/[>=0.2,<=1.0]@myuser/testing", "override")', "0.3", True, True),
                            ])
     def transitive_test(self, version_range, solution, override, valid):
         hello_text = hello_content % ">0.1, <1"
-        hello_ref = ConanFileReference.loads("Hello/1.2@memsharded/testing")
+        hello_ref = ConanFileReference.loads("Hello/1.2@myuser/testing")
         self.retriever.conan(hello_ref, hello_text)
 
         chat_content = """
@@ -297,7 +300,7 @@ from conans import ConanFile
 class ChatConan(ConanFile):
     name = "Chat"
     version = "2.3"
-    requires = "Hello/1.2@memsharded/testing", %s
+    requires = "Hello/1.2@myuser/testing", %s
 """
         if valid is False:
             with self.assertRaisesRegexp(ConanException, "not valid"):
@@ -318,6 +321,7 @@ class ChatConan(ConanFile):
 
         if valid is True:
             self.assertIn(" valid", self.output)
+            self.assertNotIn("not valid", self.output)
         elif valid is False:
             self.assertIn("not valid", self.output)
         self.assertEqual(3, len(deps_graph.nodes))
@@ -328,7 +332,7 @@ class ChatConan(ConanFile):
         conanfile = hello.conanfile
         self.assertEqual(conanfile.version, "1.2")
         self.assertEqual(conanfile.name, "Hello")
-        say_ref = ConanFileReference.loads("Say/%s@memsharded/testing" % solution)
+        say_ref = ConanFileReference.loads("Say/%s@myuser/testing" % solution)
         self.assertEqual(_clear_revs(conanfile.requires), Requirements(str(say_ref)))
 
     def duplicated_error_test(self):
@@ -339,7 +343,7 @@ class Log3cppConan(ConanFile):
     name = "log4cpp"
     version = "1.1.1"
 """
-        log4cpp_ref = ConanFileReference.loads("log4cpp/1.1.1@memsharded/testing")
+        log4cpp_ref = ConanFileReference.loads("log4cpp/1.1.1@myuser/testing")
         self.retriever.conan(log4cpp_ref, content)
 
         content = """
@@ -350,9 +354,9 @@ class LoggerInterfaceConan(ConanFile):
     version = "0.1.1"
 
     def requirements(self):
-        self.requires("log4cpp/[~1.1]@memsharded/testing")
+        self.requires("log4cpp/[~1.1]@myuser/testing")
 """
-        logiface_ref = ConanFileReference.loads("LoggerInterface/0.1.1@memsharded/testing")
+        logiface_ref = ConanFileReference.loads("LoggerInterface/0.1.1@myuser/testing")
         self.retriever.conan(logiface_ref, content)
 
         content = """
@@ -361,16 +365,16 @@ from conans import ConanFile
 class OtherConan(ConanFile):
     name = "other"
     version = "2.0.11549"
-    requires = "LoggerInterface/[~0.1]@memsharded/testing"
+    requires = "LoggerInterface/[~0.1]@myuser/testing"
 """
-        other_ref = ConanFileReference.loads("other/2.0.11549@memsharded/testing")
+        other_ref = ConanFileReference.loads("other/2.0.11549@myuser/testing")
         self.retriever.conan(other_ref, content)
 
         content = """
 from conans import ConanFile
 
 class Project(ConanFile):
-    requires = "LoggerInterface/[~0.1]@memsharded/testing", "other/[~2.0]@memsharded/testing"
+    requires = "LoggerInterface/[~0.1]@myuser/testing", "other/[~2.0]@myuser/testing"
 """
         deps_graph = self.root(content)
 

--- a/conans/test/unittests/client/graph/test_range_resolver.py
+++ b/conans/test/unittests/client/graph/test_range_resolver.py
@@ -2,25 +2,24 @@ import unittest
 
 from conans.client.graph.range_resolver import _parse_versionexpr
 from conans.errors import ConanException
-from conans.test.utils.tools import TestBufferConanOutput
 
 
 class ParseVersionExprTest(unittest.TestCase):
     def test_backwards_compatibility(self):
-        output = TestBufferConanOutput()
+        output = []
         self.assertEqual(_parse_versionexpr("2.3, 3.2", output), ("2.3 3.2", True, False))
-        self.assertTrue(str(output).startswith("WARN: Commas as separator"))
-        output = TestBufferConanOutput()
+        self.assertTrue(output[0].startswith("WARN: Commas as separator"))
+        output = []
         self.assertEqual(_parse_versionexpr("2.3, <=3.2", output), ("2.3 <=3.2", True, False))
-        self.assertTrue(str(output).startswith("WARN: Commas as separator"))
+        self.assertTrue(output[0].startswith("WARN: Commas as separator"))
 
     def test_only_spaces_without_warning(self):
-        output = TestBufferConanOutput()
+        output = []
         self.assertEqual(_parse_versionexpr("2.3 3.2", output), ("2.3 3.2", True, False))
-        self.assertEqual(str(output), "")
+        self.assertEqual(output, [])
 
     def test_standard_semver(self):
-        output = TestBufferConanOutput()
+        output = []
         self.assertEqual(_parse_versionexpr("*", output), ("*", True, False))
         self.assertEqual(_parse_versionexpr("", output), ("", True, False))  # Defaults to '*'
         self.assertEqual(_parse_versionexpr("~1", output), ("~1", True, False))
@@ -29,29 +28,36 @@ class ParseVersionExprTest(unittest.TestCase):
         self.assertEqual(_parse_versionexpr("1.2.3 - 2.3.4", output), ("1.2.3 - 2.3.4", True, False))
 
     def test_only_loose(self):
-        output = TestBufferConanOutput()
-        self.assertEqual(_parse_versionexpr("2.3 ,3.2, loose=True", output), ("2.3 3.2", True, False))
-        self.assertEqual(_parse_versionexpr("2.3 3.2, loose=False", output), ("2.3 3.2", False, False))
-        self.assertEqual(_parse_versionexpr("2.3 3.2, loose  = False", output), ("2.3 3.2", False, False))
-        self.assertEqual(_parse_versionexpr("2.3 3.2,  loose  = True", output), ("2.3 3.2", True, False))
+        output = []
+        self.assertEqual(_parse_versionexpr("2.3 ,3.2, loose=True", output),
+                         ("2.3 3.2", True, False))
+        self.assertEqual(_parse_versionexpr("2.3 3.2, loose=False", output),
+                         ("2.3 3.2", False, False))
+        self.assertEqual(_parse_versionexpr("2.3 3.2, loose  = False", output),
+                         ("2.3 3.2", False, False))
+        self.assertEqual(_parse_versionexpr("2.3 3.2,  loose  = True", output),
+                         ("2.3 3.2", True, False))
 
     def test_only_prerelease(self):
-        output = TestBufferConanOutput()
+        output = []
         self.assertEqual(_parse_versionexpr("2.3, 3.2, include_prerelease=False", output),
                          ("2.3 3.2", True, False))
         self.assertEqual(_parse_versionexpr("2.3, 3.2, include_prerelease=True", output),
                          ("2.3 3.2", True, True))
 
     def test_both(self):
-        output = TestBufferConanOutput()
-        self.assertEqual(_parse_versionexpr("2.3, 3.2, loose=False, include_prerelease=True", output),
+        output = []
+        self.assertEqual(_parse_versionexpr("2.3, 3.2, loose=False, include_prerelease=True",
+                                            output),
                          ("2.3 3.2", False, True))
-        self.assertEqual(_parse_versionexpr("2.3, 3.2, include_prerelease=True, loose=False", output),
+        self.assertEqual(_parse_versionexpr("2.3, 3.2, include_prerelease=True, loose=False",
+                                            output),
                          ("2.3 3.2", False, True))
 
     def test_invalid(self):
-        output = TestBufferConanOutput()
-        self.assertRaises(ConanException, _parse_versionexpr, "loose=False, include_prerelease=True", output)
+        output = []
+        self.assertRaises(ConanException, _parse_versionexpr,
+                          "loose=False, include_prerelease=True", output)
         self.assertRaises(ConanException, _parse_versionexpr, "2.3, 3.2, unexpected=True", output)
         self.assertRaises(ConanException, _parse_versionexpr, "2.3, 3.2, loose=Other", output)
         self.assertRaises(ConanException, _parse_versionexpr, "2.3, 3.2, ", output)


### PR DESCRIPTION
Changelog: Feature: Display the version-ranges resolutions in a cleaner way.


Need it for graph-lock




