### PR TITLE
Add test with an invalid use of python_requires

### DIFF
--- a/conans/client/graph/python_requires.py
+++ b/conans/client/graph/python_requires.py
@@ -5,6 +5,7 @@ from conans.client.loader import parse_conanfile
 from conans.client.recorder.action_recorder import ActionRecorder
 from conans.model.ref import ConanFileReference
 from conans.model.requires import Requirement
+from conans.errors import ConanException
 
 
 PythonRequire = namedtuple("PythonRequire", "conan_ref module conanfile")
@@ -16,6 +17,7 @@ class ConanPythonRequire(object):
         self._proxy = proxy
         self._range_resolver = range_resolver
         self._requires = None
+        self.valid = True
 
     @contextmanager
     def capture_requires(self):
@@ -49,6 +51,8 @@ class ConanPythonRequire(object):
         return python_require
 
     def __call__(self, require):
+        if not self.valid:
+            raise ConanException("Invalid use of python_requires(%s)" % require)
         python_req = self._look_for_require(require)
         self._requires.append(python_req)
         return python_req.module

--- a/conans/client/loader.py
+++ b/conans/client/loader.py
@@ -240,6 +240,10 @@ def _parse_conanfile(conan_file_path):
             sys.dont_write_bytecode = True
             loaded = imp.load_source(module_id, conan_file_path)
             loaded.python_requires = _invalid_python_requires
+            try:
+                loaded.conans.python_requires = _invalid_python_requires
+            except AttributeError:
+                pass
             sys.dont_write_bytecode = False
 
         # These lines are necessary, otherwise local conanfile imports with same name

--- a/conans/client/loader.py
+++ b/conans/client/loader.py
@@ -40,10 +40,12 @@ class ConanFileLoader(object):
         self._runner = runner
         self._output = output
         self._python_requires = python_requires
-        sys.modules["conans"].python_requires = python_requires
+        sys.modules["conans"].python_requires = self._python_requires
 
     def load_class(self, conanfile_path):
+        self._python_requires.valid = True
         _, conanfile = parse_conanfile(conanfile_path, self._python_requires)
+        self._python_requires.valid = False
         return conanfile
 
     def load_export(self, conanfile_path, name, version, user, channel):
@@ -209,10 +211,6 @@ def _parse_module(conanfile_module, module_id):
     return result
 
 
-def _invalid_python_requires(require):
-    raise ConanException("Invalid use of python_requires(%s)" % require)
-
-
 def parse_conanfile(conanfile_path, python_requires):
     with python_requires.capture_requires() as py_requires:
         module, filename = _parse_conanfile(conanfile_path)
@@ -239,11 +237,6 @@ def _parse_conanfile(conan_file_path):
         with chdir(current_dir):
             sys.dont_write_bytecode = True
             loaded = imp.load_source(module_id, conan_file_path)
-            loaded.python_requires = _invalid_python_requires
-            try:
-                loaded.conans.python_requires = _invalid_python_requires
-            except AttributeError:
-                pass
             sys.dont_write_bytecode = False
 
         # These lines are necessary, otherwise local conanfile imports with same name

--- a/conans/test/integration/python_build_test.py
+++ b/conans/test/integration/python_build_test.py
@@ -179,14 +179,14 @@ class PkgTest(conans.ConanFile):
         client = TestClient()
         reuse = """from conans import ConanFile
 from helpers import my_print
-        
+
 class PkgTest(ConanFile):
     exports = "helpers.py"
     def source(self):
         my_print()
 """
         base = """from conans import python_requires
-        
+
 def my_print():
     base = python_requires("MyConanfileBase/1.0@lasote/testing")
         """
@@ -194,10 +194,9 @@ def my_print():
         client.save({"conanfile.py": reuse, "helpers.py": base})
         error = client.run("create . Pkg/0.1@lasote/testing", ignore_error=True)
         self.assertTrue(error)
-        self.assertIn("ERROR: Pkg/0.1@lasote/testing: Error in source() method, line 4",
+        self.assertIn("ERROR: Pkg/0.1@lasote/testing: Error in source() method, line 7",
                       client.out)
-        self.assertIn('base = python_requires("MyConanfileBase/1.0@lasote/testing',
-                      client.out)
+        self.assertIn('my_print()', client.out)
         self.assertIn("ConanException: Invalid use of python_requires"
                       "(MyConanfileBase/1.0@lasote/testing)", client.out)
 
@@ -219,10 +218,9 @@ def my_print():
         client.save({"conanfile.py": reuse, "helpers.py": base})
         error = client.run("create . Pkg/0.1@lasote/testing", ignore_error=True)
         self.assertTrue(error)
-        self.assertIn("ERROR: Pkg/0.1@lasote/testing: Error in source() method, line 4",
+        self.assertIn("ERROR: Pkg/0.1@lasote/testing: Error in source() method, line 7",
                       client.out)
-        self.assertIn('base = conans.python_requires("MyConanfileBase/1.0@lasote/testing',
-                      client.out)
+        self.assertIn('my_print()', client.out)
         self.assertIn("ConanException: Invalid use of python_requires"
                       "(MyConanfileBase/1.0@lasote/testing)", client.out)
 

--- a/conans/test/integration/python_build_test.py
+++ b/conans/test/integration/python_build_test.py
@@ -154,8 +154,8 @@ class PkgTest(ConanFile):
         self.assertTrue(error)
         self.assertIn("ERROR: Pkg/0.1@lasote/testing: Error in source() method, line 4", client.out)
         self.assertIn('base = python_requires("MyConanfileBase/1.0@lasote/testing', client.out)
-        self.assertIn("ConanException: Invalid use of python_requires(MyConanfileBase/1.0@lasote/testing)",
-                      client.out)
+        self.assertIn("ConanException: Invalid use of python_requires"
+                      "(MyConanfileBase/1.0@lasote/testing)", client.out)
 
     def invalid2_test(self):
         client = TestClient()
@@ -170,9 +170,10 @@ class PkgTest(conans.ConanFile):
         self.assertTrue(error)
         self.assertIn("ERROR: Pkg/0.1@lasote/testing: Error in source() method, line 4",
                       client.out)
-        self.assertIn('base = conans.python_requires("MyConanfileBase/1.0@lasote/testing', client.out)
-        self.assertIn("ConanException: Invalid use of python_requires(MyConanfileBase/1.0@lasote/testing)",
+        self.assertIn('base = conans.python_requires("MyConanfileBase/1.0@lasote/testing',
                       client.out)
+        self.assertIn("ConanException: Invalid use of python_requires"
+                      "(MyConanfileBase/1.0@lasote/testing)", client.out)
 
     def transitive_multiple_reuse_test(self):
         client = TestClient()

--- a/conans/test/integration/python_build_test.py
+++ b/conans/test/integration/python_build_test.py
@@ -154,7 +154,24 @@ class PkgTest(ConanFile):
         self.assertTrue(error)
         self.assertIn("ERROR: Pkg/0.1@lasote/testing: Error in source() method, line 4", client.out)
         self.assertIn('base = python_requires("MyConanfileBase/1.0@lasote/testing', client.out)
-        self.assertIn("Invalid use of python_requires(MyConanfileBase/1.0@lasote/testing)",
+        self.assertIn("ConanException: Invalid use of python_requires(MyConanfileBase/1.0@lasote/testing)",
+                      client.out)
+
+    def invalid2_test(self):
+        client = TestClient()
+        reuse = """import conans
+class PkgTest(conans.ConanFile):
+    def source(self):
+        base = conans.python_requires("MyConanfileBase/1.0@lasote/testing")
+"""
+
+        client.save({"conanfile.py": reuse})
+        error = client.run("create . Pkg/0.1@lasote/testing", ignore_error=True)
+        self.assertTrue(error)
+        self.assertIn("ERROR: Pkg/0.1@lasote/testing: Error in source() method, line 4",
+                      client.out)
+        self.assertIn('base = conans.python_requires("MyConanfileBase/1.0@lasote/testing', client.out)
+        self.assertIn("ConanException: Invalid use of python_requires(MyConanfileBase/1.0@lasote/testing)",
                       client.out)
 
     def transitive_multiple_reuse_test(self):

--- a/conans/test/integration/python_build_test.py
+++ b/conans/test/integration/python_build_test.py
@@ -175,6 +175,57 @@ class PkgTest(conans.ConanFile):
         self.assertIn("ConanException: Invalid use of python_requires"
                       "(MyConanfileBase/1.0@lasote/testing)", client.out)
 
+    def invalid3_test(self):
+        client = TestClient()
+        reuse = """from conans import ConanFile
+from helpers import my_print
+        
+class PkgTest(ConanFile):
+    exports = "helpers.py"
+    def source(self):
+        my_print()
+"""
+        base = """from conans import python_requires
+        
+def my_print():
+    base = python_requires("MyConanfileBase/1.0@lasote/testing")
+        """
+
+        client.save({"conanfile.py": reuse, "helpers.py": base})
+        error = client.run("create . Pkg/0.1@lasote/testing", ignore_error=True)
+        self.assertTrue(error)
+        self.assertIn("ERROR: Pkg/0.1@lasote/testing: Error in source() method, line 4",
+                      client.out)
+        self.assertIn('base = python_requires("MyConanfileBase/1.0@lasote/testing',
+                      client.out)
+        self.assertIn("ConanException: Invalid use of python_requires"
+                      "(MyConanfileBase/1.0@lasote/testing)", client.out)
+
+    def invalid4_test(self):
+        client = TestClient()
+        reuse = """from conans import ConanFile
+from helpers import my_print
+
+class PkgTest(ConanFile):
+    exports = "helpers.py"
+    def source(self):
+        my_print()
+    """
+        base = """import conans
+def my_print():
+    base = conans.python_requires("MyConanfileBase/1.0@lasote/testing")
+            """
+
+        client.save({"conanfile.py": reuse, "helpers.py": base})
+        error = client.run("create . Pkg/0.1@lasote/testing", ignore_error=True)
+        self.assertTrue(error)
+        self.assertIn("ERROR: Pkg/0.1@lasote/testing: Error in source() method, line 4",
+                      client.out)
+        self.assertIn('base = conans.python_requires("MyConanfileBase/1.0@lasote/testing',
+                      client.out)
+        self.assertIn("ConanException: Invalid use of python_requires"
+                      "(MyConanfileBase/1.0@lasote/testing)", client.out)
+
     def transitive_multiple_reuse_test(self):
         client = TestClient()
         conanfile = """from conans import ConanFile


### PR DESCRIPTION
Changelog: Bugfix: Handle invalid use of `python_requires` when imported like `conans.python_requires`

- [ ] related to #4087


