### PR TITLE
Fixes ftp download when authentication is required

### DIFF
--- a/conans/client/tools/net.py
+++ b/conans/client/tools/net.py
@@ -41,6 +41,10 @@ def ftp_download(ip, filename, login='', password=''):
         with open(filename, 'wb') as f:
             ftp.retrbinary('RETR ' + filename, f.write)
     except Exception as e:
+        try:
+            os.unlink(filename)
+        except OSError:
+            pass
         raise ConanException("Error in FTP download from %s\n%s" % (ip, str(e)))
     finally:
         try:

--- a/conans/client/tools/net.py
+++ b/conans/client/tools/net.py
@@ -33,7 +33,8 @@ def get(url, md5='', sha1='', sha256='', destination=".", filename="", keep_perm
 def ftp_download(ip, filename, login='', password=''):
     import ftplib
     try:
-        ftp = ftplib.FTP(ip, login, password)
+        ftp = ftplib.FTP(ip)
+        ftp.login(login, password)
         filepath, filename = os.path.split(filename)
         if filepath:
             ftp.cwd(filepath)

--- a/conans/client/tools/net.py
+++ b/conans/client/tools/net.py
@@ -34,7 +34,6 @@ def ftp_download(ip, filename, login='', password=''):
     import ftplib
     try:
         ftp = ftplib.FTP(ip, login, password)
-        ftp.login()
         filepath, filename = os.path.split(filename)
         if filepath:
             ftp.cwd(filepath)

--- a/conans/test/client/tools/net_test.py
+++ b/conans/test/client/tools/net_test.py
@@ -8,11 +8,19 @@ from conans.client.tools import net
 
 class ToolsNetTest(unittest.TestCase):
 
-    test_file_name = "readme.txt"
+    test_file_name_auth = "readme.txt"
+    test_file_name_anonymous = "1KB.zip"
 
     def tearDown(self):
-        os.remove(self.test_file_name)
+
+        if os.path.exists(self.test_file_name_auth):
+            os.remove(self.test_file_name_auth)
+
+        if os.path.exists(self.test_file_name_anonymous):
+            os.remove(self.test_file_name_anonymous)
 
     def test_ftp_auth(self):
-        net.ftp_download("test.rebex.net", self.test_file_name, "demo", "password")
+        net.ftp_download("test.rebex.net", self.test_file_name_auth, "demo", "password")
 
+    def test_ftp_anonymous(self):
+        net.ftp_download("speedtest.tele2.net", self.test_file_name_anonymous)

--- a/conans/test/client/tools/net_test.py
+++ b/conans/test/client/tools/net_test.py
@@ -1,0 +1,18 @@
+# coding=utf-8
+
+import unittest
+import os
+
+from conans.client.tools import net
+
+
+class ToolsNetTest(unittest.TestCase):
+
+    test_file_name = "readme.txt"
+
+    def tearDown(self):
+        os.remove(self.test_file_name)
+
+    def test_ftp_auth(self):
+        net.ftp_download("test.rebex.net", self.test_file_name, "demo", "password")
+


### PR DESCRIPTION
Changelog: Bugfix: In ftp_download function there is extra call to ftp.login() with empty args. This causes ftp lib to login again with empty credentials and throwing exception because authentication is required by server.

It's a small fix so I did not create any issue about it.
