### PR TITLE
import conanfile just once

### DIFF
--- a/conans/client/loader.py
+++ b/conans/client/loader.py
@@ -40,10 +40,15 @@ class ConanFileLoader(object):
         self._output = output
         self._python_requires = python_requires
         sys.modules["conans"].python_requires = python_requires
+        self._loaded_conanfiles = {}
 
     def load_class(self, conanfile_path):
-        _, conanfile = parse_conanfile(conanfile_path, self._python_requires)
-        return conanfile
+        try:
+            return self._loaded_conanfiles[conanfile_path]
+        except KeyError:
+            _, conanfile = parse_conanfile(conanfile_path, self._python_requires)
+            self._loaded_conanfiles[conanfile_path] = conanfile
+            return conanfile
 
     def load_name_version(self, conanfile_path, name, version):
         conanfile = self.load_class(conanfile_path)

--- a/conans/test/optimize_conanfile_load_test.py
+++ b/conans/test/optimize_conanfile_load_test.py
@@ -1,0 +1,27 @@
+import unittest
+
+from conans.test.utils.tools import TestClient
+
+
+class OptimizeConanFileLoadTest(unittest.TestCase):
+
+    def test_multiple_load(self):
+        client = TestClient()
+        conanfile = """from conans import ConanFile
+mycounter = 0
+class Pkg(ConanFile):
+    def configure(self):
+        global mycounter
+        mycounter += 1
+        self.output.info("My Counter %s" % mycounter)
+"""
+        client.save({"conanfile.py": conanfile})
+
+        client.run("create . Build/0.1@user/testing")
+
+        client.save({"conanfile.py": conanfile,
+                     "test_package/conanfile.py": conanfile + "    def test(self): pass",
+                     "myprofile": "[build_requires]\nBuild/0.1@user/testing"})
+
+        client.run("create . Pkg/0.1@user/testing -pr=myprofile")
+        self.assertIn("Build/0.1@user/testing: My Counter 2", client.out)


### PR DESCRIPTION
Changelog: Feature: Optimize the graph loading, specially of build-requires, by avoiding importing more than once the same conanfile.py


This is an exploratory PR, to be discussed the behavior exposed in the test.

This optimization could be relevant to flatten the dependency graph when build requires are applied to the whole graph.


