### PR TITLE
Better to check the return code of the file indeed there than otherwise

### DIFF
--- a/conans/client/rest/uploader_downloader.py
+++ b/conans/client/rest/uploader_downloader.py
@@ -25,7 +25,7 @@ class Uploader(object):
                 dedup_headers.update(headers)
             response = self.requester.put(url, data="", verify=self.verify, headers=dedup_headers,
                                           auth=auth)
-            if response.status_code != 404:
+            if response.status_code == 201:  # Artifactory returns 201 if the file is there
                 return response
 
         headers = headers or {}


### PR DESCRIPTION
Changelog: Fix: Fixed the check of the return code from Artifactory when using the checksum deploy feature. 

`status_code != 404` could be even a 500 error. Checked with Artifactory team that the code to check is a "201" when the file exists or it has been created.