### PR TITLE
MSBuild crash logs

### DIFF
--- a/.ci/jenkins/conf.py
+++ b/.ci/jenkins/conf.py
@@ -16,6 +16,8 @@ linuxpylocation = {"py27": "/usr/bin/python2.7",
                    "py36": "/usr/bin/python3.6",
                    "py37": "/usr/bin/python3.7"}
 
+win_msbuilds_logs_folder = "D:\\J\\msbuild_logs"
+
 
 def get_environ(tmp_path):
     if platform.system() == "Windows":

--- a/.ci/jenkins/runner.py
+++ b/.ci/jenkins/runner.py
@@ -2,7 +2,7 @@ import os
 import platform
 
 from conf import Extender, chdir, environment_append, get_environ, linuxpylocation, macpylocation, \
-    winpylocation
+    winpylocation, win_msbuilds_logs_folder
 
 pylocations = {"Windows": winpylocation,
                "Linux": linuxpylocation,
@@ -68,6 +68,8 @@ def run_tests(module_path, pyver, source_folder, tmp_folder, flavor, excluded_ta
     env["CHANGE_AUTHOR_DISPLAY_NAME"] = ""
     env["CONAN_API_V2_BLOCKED"] = "True" if flavor == "blocked_v2" else "False"
     env["CONAN_CLIENT_REVISIONS_ENABLED"] = "True" if flavor == "enabled_revisions" else "False"
+    # Try to specify a known folder to keep there msbuild failure logs
+    env["MSBUILDDEBUGPATH"] = win_msbuilds_logs_folder
 
     with chdir(source_folder):
         with environment_append(env):


### PR DESCRIPTION
Changelog: omit

Try to specify a known folder for MSBuild to put the crash logs. Currently, I can't find them where they are supposed to be.
