### PR TITLE
fixing config parser escape % in py3

### DIFF
--- a/conans/client/conf/__init__.py
+++ b/conans/client/conf/__init__.py
@@ -261,7 +261,12 @@ class ConanClientConfigParser(ConfigParser, object):
             raise ConanException("You can't set a full section, please specify a key=value")
 
         key = tokens[1]
-        super(ConanClientConfigParser, self).set(section_name, key, value)
+        try:
+            super(ConanClientConfigParser, self).set(section_name, key, value)
+        except ValueError:
+            # https://github.com/conan-io/conan/issues/4110
+            value = value.replace("%", "%%")
+            super(ConanClientConfigParser, self).set(section_name, key, value)
 
         with open(self.filename, "w") as f:
             self.write(f)
@@ -300,8 +305,8 @@ class ConanClientConfigParser(ConfigParser, object):
                 ret = os.path.abspath(os.path.join(profiles_folder, ret))
 
             if not os.path.exists(ret):
-                raise ConanException("Environment variable 'CONAN_DEFAULT_PROFILE_PATH' must point to "
-                                     "an existing profile file.")
+                raise ConanException("Environment variable 'CONAN_DEFAULT_PROFILE_PATH' "
+                                     "must point to an existing profile file.")
             return ret
         else:
             try:

--- a/conans/test/command/config_test.py
+++ b/conans/test/command/config_test.py
@@ -60,6 +60,12 @@ class ConfigTest(unittest.TestCase):
         conf_file = load(self.client.paths.conan_conf_path)
         self.assertIn("https = myurl", conf_file.splitlines())
 
+    def set_with_weird_path_test(self):
+        # https://github.com/conan-io/conan/issues/4110
+        self.client.run("config set log.trace_file=/recipe-release%2F0.6.1")
+        self.client.run("config get log.trace_file")
+        self.assertIn("/recipe-release%2F0.6.1", self.client.out)
+
     def remove_test(self):
         self.client.run('config set proxies.https=myurl')
         self.client.run('config rm proxies.https')


### PR DESCRIPTION
Changelog: Fix: Recent updates in python break ConfigParser with % in values, like in path names containing % (jenkins)

Close #4110


