### PR TITLE
limit cpu_count=1 for diamond test

### DIFF
--- a/conans/test/integration/diamond_test.py
+++ b/conans/test/integration/diamond_test.py
@@ -20,16 +20,18 @@ class DiamondTest(unittest.TestCase):
         self.servers = {"default": test_server}
 
     def diamond_cmake_test(self):
-        self.client = TestClient(servers=self.servers, users={"default": [("lasote", "mypass")]})
+        self.client = TestClient(servers=self.servers, users={"default": [("lasote", "mypass")]},
+                                 cpu_count=1)
         self._run(use_cmake=True, language=1)
 
     def diamond_cmake_targets_test(self):
-        self.client = TestClient(servers=self.servers, users={"default": [("lasote", "mypass")]})
+        self.client = TestClient(servers=self.servers, users={"default": [("lasote", "mypass")]},
+                                 cpu_count=1)
         self._run(use_cmake=True, cmake_targets=True)
 
     def diamond_default_test(self):
         self.client = TestClient(servers=self.servers, users={"default": [("lasote", "mypass")]},
-                                 path_with_spaces=False)
+                                 path_with_spaces=False, cpu_count=1)
         self._run(use_cmake=False)
 
     def _export(self, name, version=None, deps=None, use_cmake=True, cmake_targets=False):

--- a/conans/test/utils/tools.py
+++ b/conans/test/utils/tools.py
@@ -447,7 +447,7 @@ class TestClient(object):
                  servers=None, users=None, client_version=CLIENT_VERSION,
                  min_server_compatible_version=MIN_SERVER_COMPATIBLE_VERSION,
                  requester_class=None, runner=None, path_with_spaces=True,
-                 block_v2=None, revisions=None):
+                 block_v2=None, revisions=None, cpu_count=None):
         """
         storage_folder: Local storage path
         current_folder: Current execution folder
@@ -480,6 +480,12 @@ class TestClient(object):
         self.requester_class = requester_class
         self.conan_runner = runner
 
+        if cpu_count:
+            self.client_cache.conan_config
+            replace_in_file(os.path.join(self.client_cache.conan_conf_path),
+                            "# cpu_count = 1", "cpu_count = %s" % cpu_count)
+            # Invalidate the cached config
+            self.client_cache.invalidate()
         if self.revisions:
             # Generate base file
             self.client_cache.conan_config


### PR DESCRIPTION
Changelog: Omit

Try to avoid random CI failures: 
```
msbuild : error msb4166: child node exited prematurely. shutting down.
```

They only appear in CI jenkins, couldn't reproduce locally.
Couldn't reproduce in Jenkins Windows slave, even with 5 concurrent test suites in parallel.


