### PR TITLE
Use TestClient.client_cache and TestServer.server_store

### DIFF
--- a/conans/test/functional/command/build_test.py
+++ b/conans/test/functional/command/build_test.py
@@ -124,7 +124,7 @@ class AConan(ConanFile):
         client.save({"my_conanfile.py": conanfile_scope_env})
         client.run("build ./my_conanfile.py")
         ref = PackageReference.loads("Hello/0.1@lasote/testing:%s" % NO_SETTINGS_PACKAGE_ID)
-        package_folder = client.paths.package(ref).replace("\\", "/")
+        package_folder = client.client_cache.package(ref).replace("\\", "/")
         self.assertIn("Project: INCLUDE PATH: %s/include" % package_folder, client.user_io.out)
         self.assertIn("Project: HELLO ROOT PATH: %s" % package_folder, client.user_io.out)
         self.assertIn("Project: HELLO INCLUDE PATHS: %s/include"

--- a/conans/test/functional/command/config_test.py
+++ b/conans/test/functional/command/config_test.py
@@ -40,24 +40,24 @@ class ConfigTest(unittest.TestCase):
 
     def define_test(self):
         self.client.run("config set general.fakeos=Linux")
-        conf_file = load(self.client.paths.conan_conf_path)
+        conf_file = load(self.client.client_cache.conan_conf_path)
         self.assertIn("fakeos = Linux", conf_file)
 
         self.client.run('config set general.compiler="Other compiler"')
-        conf_file = load(self.client.paths.conan_conf_path)
+        conf_file = load(self.client.client_cache.conan_conf_path)
         self.assertIn('compiler = Other compiler', conf_file)
 
         self.client.run('config set general.compiler.version=123.4.5')
-        conf_file = load(self.client.paths.conan_conf_path)
+        conf_file = load(self.client.client_cache.conan_conf_path)
         self.assertIn('compiler.version = 123.4.5', conf_file)
         self.assertNotIn("14", conf_file)
 
         self.client.run('config set general.new_setting=mysetting ')
-        conf_file = load(self.client.paths.conan_conf_path)
+        conf_file = load(self.client.client_cache.conan_conf_path)
         self.assertIn('new_setting = mysetting', conf_file)
 
         self.client.run('config set proxies.https=myurl')
-        conf_file = load(self.client.paths.conan_conf_path)
+        conf_file = load(self.client.client_cache.conan_conf_path)
         self.assertIn("https = myurl", conf_file.splitlines())
 
     def set_with_weird_path_test(self):
@@ -69,18 +69,18 @@ class ConfigTest(unittest.TestCase):
     def remove_test(self):
         self.client.run('config set proxies.https=myurl')
         self.client.run('config rm proxies.https')
-        conf_file = load(self.client.paths.conan_conf_path)
+        conf_file = load(self.client.client_cache.conan_conf_path)
         self.assertNotIn('myurl', conf_file)
 
     def remove_section_test(self):
         self.client.run('config rm proxies')
-        conf_file = load(self.client.paths.conan_conf_path)
+        conf_file = load(self.client.client_cache.conan_conf_path)
         self.assertNotIn('[proxies]', conf_file)
 
     def remove_envvar_test(self):
         self.client.run('config set env.MY_VAR=MY_VALUE')
-        conf_file = load(self.client.paths.conan_conf_path)
+        conf_file = load(self.client.client_cache.conan_conf_path)
         self.assertIn('MY_VAR = MY_VALUE', conf_file)
         self.client.run('config rm env.MY_VAR')
-        conf_file = load(self.client.paths.conan_conf_path)
+        conf_file = load(self.client.client_cache.conan_conf_path)
         self.assertNotIn('MY_VAR', conf_file)

--- a/conans/test/functional/command/copy_packages_test.py
+++ b/conans/test/functional/command/copy_packages_test.py
@@ -21,13 +21,13 @@ class Pkg(ConanFile):
 
         # Copy all packages
         client.run("copy Hello0/0.1@lasote/stable pepe/testing --all")
-        pkgdir = client.paths.packages(ConanFileReference.loads("Hello0/0.1@pepe/testing"))
+        pkgdir = client.client_cache.packages(ConanFileReference.loads("Hello0/0.1@pepe/testing"))
         packages = os.listdir(pkgdir)
         self.assertEquals(len(packages), 3)
 
         # Copy just one
         client.run("copy Hello0/0.1@lasote/stable pepe/stable -p %s" % packages[0])
-        pkgdir = client.paths.packages(ConanFileReference.loads("Hello0/0.1@pepe/stable"))
+        pkgdir = client.client_cache.packages(ConanFileReference.loads("Hello0/0.1@pepe/stable"))
         packages = os.listdir(pkgdir)
         self.assertEquals(len(packages), 1)
 
@@ -38,5 +38,5 @@ class Pkg(ConanFile):
 
         # Copy only recipe
         client.run("copy Hello0/0.1@lasote/stable pepe/alpha")
-        pkgdir = client.paths.packages(ConanFileReference.loads("Hello0/0.1@pepe/alpha"))
+        pkgdir = client.client_cache.packages(ConanFileReference.loads("Hello0/0.1@pepe/alpha"))
         self.assertFalse(os.path.exists(pkgdir))

--- a/conans/test/functional/command/download_test.py
+++ b/conans/test/functional/command/download_test.py
@@ -31,12 +31,12 @@ class Pkg(ConanFile):
                      "file.h": "myfile.h"})
         client.run("create . lasote/stable")
         ref = ConanFileReference.loads("pkg/0.1@lasote/stable")
-        self.assertTrue(os.path.exists(client.paths.conanfile(ref)))
+        self.assertTrue(os.path.exists(client.client_cache.conanfile(ref)))
         conan = client.client_cache.conan(ref)
         self.assertTrue(os.path.exists(os.path.join(conan, "package")))
         client.run("upload pkg/0.1@lasote/stable --all")
         client.run("remove pkg/0.1@lasote/stable -f")
-        self.assertFalse(os.path.exists(client.paths.export(ref)))
+        self.assertFalse(os.path.exists(client.client_cache.export(ref)))
         client.run("download pkg/0.1@lasote/stable --recipe")
 
         self.assertIn("Downloading conanfile.py", client.out)
@@ -70,11 +70,11 @@ class Pkg(ConanFile):
         client.run("export . lasote/stable")
 
         ref = ConanFileReference.loads("pkg/0.1@lasote/stable")
-        self.assertTrue(os.path.exists(client.paths.conanfile(ref)))
+        self.assertTrue(os.path.exists(client.client_cache.conanfile(ref)))
 
         client.run("upload pkg/0.1@lasote/stable")
         client.run("remove pkg/0.1@lasote/stable -f")
-        self.assertFalse(os.path.exists(client.paths.export(ref)))
+        self.assertFalse(os.path.exists(client.client_cache.export(ref)))
 
         client.run("download pkg/0.1@lasote/stable")
         self.assertIn("Downloading conan_sources.tgz", client.out)
@@ -96,17 +96,17 @@ class Pkg(ConanFile):
         client.run("export . lasote/stable")
 
         ref = ConanFileReference.loads("pkg/0.1@lasote/stable")
-        self.assertTrue(os.path.exists(client.paths.conanfile(ref)))
+        self.assertTrue(os.path.exists(client.client_cache.conanfile(ref)))
 
         client.run("upload pkg/0.1@lasote/stable")
         client.run("remove pkg/0.1@lasote/stable -f")
-        self.assertFalse(os.path.exists(client.paths.export(ref)))
+        self.assertFalse(os.path.exists(client.client_cache.export(ref)))
 
         client.run("download pkg/0.1@lasote/stable")
         # Check 'No remote binary packages found' warning
         self.assertTrue("WARN: No remote binary packages found in remote", client.out)
         # Check at least conanfile.py is downloaded
-        self.assertTrue(os.path.exists(client.paths.conanfile(ref)))
+        self.assertTrue(os.path.exists(client.client_cache.conanfile(ref)))
 
     def download_reference_with_packages_test(self):
         server = TestServer()
@@ -124,21 +124,21 @@ class Pkg(ConanFile):
         client.run("create . lasote/stable")
 
         ref = ConanFileReference.loads("pkg/0.1@lasote/stable")
-        self.assertTrue(os.path.exists(client.paths.conanfile(ref)))
+        self.assertTrue(os.path.exists(client.client_cache.conanfile(ref)))
 
-        package_folder = os.path.join(client.paths.conan(ref), "package",
-                                      os.listdir(client.paths.packages(ref))[0])
+        package_folder = os.path.join(client.client_cache.conan(ref), "package",
+                                      os.listdir(client.client_cache.packages(ref))[0])
 
         client.run("upload pkg/0.1@lasote/stable --all")
         client.run("remove pkg/0.1@lasote/stable -f")
-        self.assertFalse(os.path.exists(client.paths.export(ref)))
+        self.assertFalse(os.path.exists(client.client_cache.export(ref)))
 
         client.run("download pkg/0.1@lasote/stable")
 
         # Check not 'No remote binary packages found' warning
         self.assertNotIn("WARN: No remote binary packages found in remote", client.out)
         # Check at conanfile.py is downloaded
-        self.assertTrue(os.path.exists(client.paths.conanfile(ref)))
+        self.assertTrue(os.path.exists(client.client_cache.conanfile(ref)))
         # Check package folder created
         self.assertTrue(os.path.exists(package_folder))
 

--- a/conans/test/functional/command/export_dirty_test.py
+++ b/conans/test/functional/command/export_dirty_test.py
@@ -54,7 +54,7 @@ class ExportDirtyTest(unittest.TestCase):
         self.client.run("export . lasote/stable")
         self.client.run("install Hello0/0.1@lasote/stable --build")
         ref = ConanFileReference.loads("Hello0/0.1@lasote/stable")
-        source_path = self.client.paths.source(ref)
+        source_path = self.client.client_cache.source(ref)
         file_open = os.path.join(source_path, "main.cpp")
 
         self.f = open(file_open, 'wb')

--- a/conans/test/functional/command/export_path_test.py
+++ b/conans/test/functional/command/export_path_test.py
@@ -18,8 +18,8 @@ class ExportPathTest(unittest.TestCase):
         conan_ref = ConanFileReference("Hello0", "0.1", "lasote", "stable")
         client.save(files, path=source_folder)
         client.run("export source lasote/stable")
-        reg_path = client.paths.export(conan_ref)
-        manif = FileTreeManifest.load(client.paths.export(conan_ref))
+        reg_path = client.client_cache.export(conan_ref)
+        manif = FileTreeManifest.load(client.client_cache.export(conan_ref))
 
         self.assertIn('%s: A new conanfile.py version was exported' % str(conan_ref),
                       client.user_io.out)
@@ -47,8 +47,8 @@ class ExportPathTest(unittest.TestCase):
         conan_ref = ConanFileReference("Hello0", "0.1", "lasote", "stable")
         client.save(files, path=source_folder)
         client.run("export ../source lasote/stable")
-        reg_path = client.paths.export(conan_ref)
-        manif = FileTreeManifest.load(client.paths.export(conan_ref))
+        reg_path = client.client_cache.export(conan_ref)
+        manif = FileTreeManifest.load(client.client_cache.export(conan_ref))
 
         self.assertIn('%s: A new conanfile.py version was exported' % str(conan_ref),
                       client.user_io.out)
@@ -79,8 +79,8 @@ class ExportPathTest(unittest.TestCase):
 
         client.save({"conanfile.py": conanfile})
         client.run("export . lasote/stable")
-        reg_path = client.paths.export(conan_ref)
-        manif = FileTreeManifest.load(client.paths.export(conan_ref))
+        reg_path = client.client_cache.export(conan_ref)
+        manif = FileTreeManifest.load(client.client_cache.export(conan_ref))
 
         self.assertIn('%s: A new conanfile.py version was exported' % str(conan_ref),
                       client.user_io.out)
@@ -116,8 +116,8 @@ class ExportPathTest(unittest.TestCase):
 
         client.save({"conanfile.py": conanfile}, path=conanfile_folder)
         client.run("export ../conan lasote/stable")
-        reg_path = client.paths.export(conan_ref)
-        manif = FileTreeManifest.load(client.paths.export(conan_ref))
+        reg_path = client.client_cache.export(conan_ref)
+        manif = FileTreeManifest.load(client.client_cache.export(conan_ref))
 
         self.assertIn('%s: A new conanfile.py version was exported' % str(conan_ref),
                       client.user_io.out)

--- a/conans/test/functional/command/export_test.py
+++ b/conans/test/functional/command/export_test.py
@@ -138,7 +138,7 @@ class TestConan(ConanFile):
             client.current_folder = os.path.join(client.current_folder, "recipe")
             client.run("export . lasote/stable")
             conan_ref = ConanFileReference("Hello", "1.2", "lasote", "stable")
-            export_path = client.paths.export(conan_ref)
+            export_path = client.client_cache.export(conan_ref)
             content = load(os.path.join(export_path, "sibling/file.txt"))
             self.assertEqual("Hello World!", content)
 
@@ -158,7 +158,7 @@ class TestConan(ConanFile):
         client.current_folder = os.path.join(client.current_folder, "recipe")
         client.run("export . lasote/stable")
         conan_ref = ConanFileReference("Hello", "1.2", "lasote", "stable")
-        export_path = client.paths.export(conan_ref)
+        export_path = client.client_cache.export(conan_ref)
         content = load(os.path.join(export_path, "file.txt"))
         self.assertEqual("Hello World!", content)
 
@@ -180,7 +180,7 @@ class TestConan(ConanFile):
         client.current_folder = os.path.join(client.current_folder, "recipe")
         client.run("export . lasote/stable")
         conan_ref = ConanFileReference("Hello", "1.2", "lasote", "stable")
-        export_path = client.paths.export_sources(conan_ref)
+        export_path = client.client_cache.export_sources(conan_ref)
         self.assertEqual(sorted(['file.txt', 'file.cpp', 'file.h']),
                          sorted(os.listdir(export_path)))
 
@@ -199,7 +199,7 @@ class TestConan(ConanFile):
         self.assertIn("Hello/1.2@lasote/stable: A new conanfile.py version was exported",
                       client.user_io.out)
         conan_ref = ConanFileReference("Hello", "1.2", "lasote", "stable")
-        export_path = client.paths.export(conan_ref)
+        export_path = client.client_cache.export(conan_ref)
         conanfile = load(os.path.join(export_path, "conanfile.py"))
         self.assertIn('name = "Hello"', conanfile)
         manifest = load(os.path.join(export_path, "conanmanifest.txt"))
@@ -223,8 +223,8 @@ class TestConan(ConanFile):
                      "file_temp.cpp": ""})
         client.run("export . lasote/stable")
         conan_ref = ConanFileReference("Hello", "1.2", "lasote", "stable")
-        export_path = client.paths.export(conan_ref)
-        exports_sources_path = client.paths.export_sources(conan_ref)
+        export_path = client.client_cache.export(conan_ref)
+        exports_sources_path = client.client_cache.export_sources(conan_ref)
         self.assertTrue(os.path.exists(os.path.join(export_path, "file.txt")))
         self.assertFalse(os.path.exists(os.path.join(export_path, "file1.txt")))
         self.assertTrue(os.path.exists(os.path.join(exports_sources_path, "file.cpp")))
@@ -246,7 +246,7 @@ class TestConan(ConanFile):
                      "other/sub/file2.txt": ""})
         client.run("export . lasote/stable")
         conan_ref = ConanFileReference("Hello", "1.2", "lasote", "stable")
-        export_path = client.paths.export(conan_ref)
+        export_path = client.client_cache.export(conan_ref)
         self.assertTrue(os.path.exists(os.path.join(export_path, "file.txt")))
         self.assertFalse(os.path.exists(os.path.join(export_path, "any/temp/file1.txt")))
         self.assertTrue(os.path.exists(os.path.join(export_path, "other/sub/file2.txt")))
@@ -264,8 +264,8 @@ class ExportTest(unittest.TestCase):
     def test_basic(self):
         """ simple registration of a new conans
         """
-        reg_path = self.conan.paths.export(self.conan_ref)
-        manif = FileTreeManifest.load(self.conan.paths.export(self.conan_ref))
+        reg_path = self.conan.client_cache.export(self.conan_ref)
+        manif = FileTreeManifest.load(self.conan.client_cache.export(self.conan_ref))
 
         self.assertIn('%s: A new conanfile.py version was exported' % str(self.conan_ref),
                       self.conan.user_io.out)
@@ -301,7 +301,7 @@ class OpenSSLConan(ConanFile):
 """
         save(os.path.join(self.conan.current_folder, CONANFILE), content)
         self.conan.run("export . lasote/stable")
-        reg_path = self.conan.paths.export(ConanFileReference.loads('openssl/2.0.1@lasote/stable'))
+        reg_path = self.conan.client_cache.export(ConanFileReference.loads('openssl/2.0.1@lasote/stable'))
         self.assertEqual(sorted(os.listdir(reg_path)),
                          [CONANFILE, CONAN_MANIFEST])
 
@@ -315,7 +315,7 @@ class OpenSSLConan(ConanFile):
 """
         save(os.path.join(self.conan.current_folder, CONANFILE), content)
         self.conan.run("export . lasote/stable")
-        reg_path = self.conan.paths.export(ConanFileReference.loads('openssl/2.0.1@lasote/stable'))
+        reg_path = self.conan.client_cache.export(ConanFileReference.loads('openssl/2.0.1@lasote/stable'))
         self.assertEqual(sorted(os.listdir(reg_path)),
                          ['CMakeLists.txt', CONANFILE, CONAN_MANIFEST,
                           'helloHello0.h'])
@@ -331,7 +331,7 @@ class OpenSSLConan(ConanFile):
 """
         save(os.path.join(self.conan.current_folder, CONANFILE), content)
         self.conan.run("export . lasote/stable")
-        reg_path = self.conan.paths.export(ConanFileReference.loads('openssl/2.0.1@lasote/stable'))
+        reg_path = self.conan.client_cache.export(ConanFileReference.loads('openssl/2.0.1@lasote/stable'))
         self.assertEqual(sorted(os.listdir(reg_path)),
                          ['CMakeLists.txt', CONANFILE, CONAN_MANIFEST, 'helloHello0.h'])
 
@@ -343,8 +343,8 @@ class OpenSSLConan(ConanFile):
         files2 = cpp_hello_conan_files("Hello0", "0.1")
         conan2.save(files2)
         conan2.run("export . lasote/stable")
-        reg_path2 = conan2.paths.export(self.conan_ref)
-        digest2 = FileTreeManifest.load(conan2.paths.export(self.conan_ref))
+        reg_path2 = conan2.client_cache.export(self.conan_ref)
+        digest2 = FileTreeManifest.load(conan2.client_cache.export(self.conan_ref))
 
         self.assertNotIn('A new Conan version was exported', conan2.user_io.out)
         self.assertNotIn('Cleaning the old builds ...', conan2.user_io.out)
@@ -379,8 +379,8 @@ class OpenSSLConan(ConanFile):
         conan2.save(files2)
         conan2.run("export . lasote/stable")
 
-        reg_path3 = conan2.paths.export(self.conan_ref)
-        digest3 = FileTreeManifest.load(conan2.paths.export(self.conan_ref))
+        reg_path3 = conan2.client_cache.export(self.conan_ref)
+        digest3 = FileTreeManifest.load(conan2.client_cache.export(self.conan_ref))
 
         self.assertIn('%s: A new conanfile.py version was exported' % str(self.conan_ref),
                       self.conan.user_io.out)
@@ -403,8 +403,8 @@ class OpenSSLConan(ConanFile):
         #    self.assertFalse(os.path.exists(f))
 
     def _create_packages_and_builds(self):
-        reg_builds = self.conan.paths.builds(self.conan_ref)
-        reg_packs = self.conan.paths.packages(self.conan_ref)
+        reg_builds = self.conan.client_cache.builds(self.conan_ref)
+        reg_packs = self.conan.client_cache.packages(self.conan_ref)
 
         folders = [os.path.join(reg_builds, '342525g4f52f35f'),
                    os.path.join(reg_builds, 'ew9o8asdf908asdf80'),

--- a/conans/test/functional/command/install_test.py
+++ b/conans/test/functional/command/install_test.py
@@ -211,14 +211,14 @@ class Pkg(ConanFile):
             self.assertEqual("language=%s\nstatic=True" % lang, conan_info.options.dumps())
             conan_ref = ConanFileReference.loads("Hello0/0.1@lasote/stable")
 
-            hello0 = self.client.paths.package(PackageReference(conan_ref, id0))
+            hello0 = self.client.client_cache.package(PackageReference(conan_ref, id0))
             hello0_info = os.path.join(hello0, CONANINFO)
             hello0_conan_info = ConanInfo.load_file(hello0_info)
             self.assertEqual(lang, hello0_conan_info.options.language)
 
             package_ref1 = PackageReference(ConanFileReference.loads("Hello1/0.1@lasote/stable"),
                                             id1)
-            hello1 = self.client.paths.package(package_ref1)
+            hello1 = self.client.client_cache.package(package_ref1)
             hello1_info = os.path.join(hello1, CONANINFO)
             hello1_conan_info = ConanInfo.load_file(hello1_info)
             self.assertEqual(lang, hello1_conan_info.options.language)
@@ -235,7 +235,7 @@ class Pkg(ConanFile):
         self.assertEqual("language=1\nstatic=True", conan_info.options.dumps())
         conan_ref = ConanFileReference.loads("Hello0/0.1@lasote/stable")
 
-        hello0 = self.client.paths.package(PackageReference(conan_ref,
+        hello0 = self.client.client_cache.package(PackageReference(conan_ref,
                                            "8b964e421a5b7e48b7bc19b94782672be126be8b"))
         hello0_info = os.path.join(hello0, CONANINFO)
         hello0_conan_info = ConanInfo.load_file(hello0_info)
@@ -243,7 +243,7 @@ class Pkg(ConanFile):
 
         package_ref1 = PackageReference(ConanFileReference.loads("Hello1/0.1@lasote/stable"),
                                         "44671ecdd9c606eb7166f2197ab50be8d36a3c3b")
-        hello1 = self.client.paths.package(package_ref1)
+        hello1 = self.client.client_cache.package(package_ref1)
         hello1_info = os.path.join(hello1, CONANINFO)
         hello1_conan_info = ConanInfo.load_file(hello1_info)
         self.assertEqual(0, hello1_conan_info.options.language)
@@ -262,7 +262,7 @@ class Pkg(ConanFile):
         self.assertEqual("language=0\nstatic=True", conan_info.options.dumps())
         conan_ref = ConanFileReference.loads("Hello0/0.1@lasote/stable")
 
-        hello0 = self.client.paths.package(PackageReference(conan_ref,
+        hello0 = self.client.client_cache.package(PackageReference(conan_ref,
                                            "2e38bbc2c3ef1425197c8e2ffa8532894c347d26"))
         hello0_info = os.path.join(hello0, CONANINFO)
         hello0_conan_info = ConanInfo.load_file(hello0_info)
@@ -270,7 +270,7 @@ class Pkg(ConanFile):
 
         package_ref1 = PackageReference(ConanFileReference.loads("Hello1/0.1@lasote/stable"),
                                         "3eeab577a3134fa3afdcd82881751789ec48e08f")
-        hello1 = self.client.paths.package(package_ref1)
+        hello1 = self.client.client_cache.package(package_ref1)
         hello1_info = os.path.join(hello1, CONANINFO)
         hello1_conan_info = ConanInfo.load_file(hello1_info)
         self.assertEqual("language=1\nstatic=True", hello1_conan_info.options.dumps())
@@ -296,7 +296,7 @@ class Pkg(ConanFile):
         self.assertEqual("", conan_info.options.dumps())
         conan_ref = ConanFileReference.loads("Hello0/0.1@lasote/stable")
 
-        hello0 = self.client.paths.package(PackageReference(conan_ref,
+        hello0 = self.client.client_cache.package(PackageReference(conan_ref,
                                            "8b964e421a5b7e48b7bc19b94782672be126be8b"))
         hello0_info = os.path.join(hello0, CONANINFO)
         hello0_conan_info = ConanInfo.load_file(hello0_info)
@@ -304,7 +304,7 @@ class Pkg(ConanFile):
 
         package_ref1 = PackageReference(ConanFileReference.loads("Hello1/0.1@lasote/stable"),
                                         "44671ecdd9c606eb7166f2197ab50be8d36a3c3b")
-        hello1 = self.client.paths.package(package_ref1)
+        hello1 = self.client.client_cache.package(package_ref1)
         hello1_info = os.path.join(hello1, CONANINFO)
         hello1_conan_info = ConanInfo.load_file(hello1_info)
         self.assertEqual(0, hello1_conan_info.options.language)

--- a/conans/test/functional/command/remove_test.py
+++ b/conans/test/functional/command/remove_test.py
@@ -179,8 +179,8 @@ class RemoveTest(unittest.TestCase):
                             {"H1": True, "H2": True, "B": True, "O": True})
 
     def assert_folders(self, local_folders, remote_folders, build_folders, src_folders):
-        for base_path, folders in [(self.client.paths, local_folders),
-                                   (self.server.paths, remote_folders)]:
+        for base_path, folders in [(self.client.client_cache, local_folders),
+                                   (self.server.server_store, remote_folders)]:
             root_folder = base_path.store
             for k, shas in folders.items():
                 folder = os.path.join(root_folder, self.root_folder[k].replace("@", "/"))
@@ -220,7 +220,7 @@ class RemoveTest(unittest.TestCase):
                         else:
                             self.assertFalse(os.path.exists(package_folder))
 
-        root_folder = self.client.paths.store
+        root_folder = self.client.client_cache.store
         for k, shas in build_folders.items():
             folder = os.path.join(root_folder, self.root_folder[k].replace("@", "/"))
             if shas is None:

--- a/conans/test/functional/command/search_test.py
+++ b/conans/test/functional/command/search_test.py
@@ -166,24 +166,24 @@ class SearchTest(unittest.TestCase):
                           "%s/%s/linx64/%s" % (root_folder_tool,
                                                PACKAGES_FOLDER,
                                                CONANINFO): conan_vars_tool_linx64},
-                         self.client.paths.store)
+                         self.client.client_cache.store)
 
         # Fake some manifests to be able to calculate recipe hash
         fake_manifest = FileTreeManifest(1212, {})
-        fake_manifest.save(os.path.join(self.client.paths.store, root_folder1, EXPORT_FOLDER))
-        fake_manifest.save(os.path.join(self.client.paths.store, root_folder2, EXPORT_FOLDER))
-        fake_manifest.save(os.path.join(self.client.paths.store, root_folder3, EXPORT_FOLDER))
-        fake_manifest.save(os.path.join(self.client.paths.store, root_folder4, EXPORT_FOLDER))
-        fake_manifest.save(os.path.join(self.client.paths.store, root_folder5, EXPORT_FOLDER))
-        fake_manifest.save(os.path.join(self.client.paths.store, root_folder11, EXPORT_FOLDER))
-        fake_manifest.save(os.path.join(self.client.paths.store, root_folder12, EXPORT_FOLDER))
-        fake_manifest.save(os.path.join(self.client.paths.store, root_folder_tool, EXPORT_FOLDER))
+        fake_manifest.save(os.path.join(self.client.client_cache.store, root_folder1, EXPORT_FOLDER))
+        fake_manifest.save(os.path.join(self.client.client_cache.store, root_folder2, EXPORT_FOLDER))
+        fake_manifest.save(os.path.join(self.client.client_cache.store, root_folder3, EXPORT_FOLDER))
+        fake_manifest.save(os.path.join(self.client.client_cache.store, root_folder4, EXPORT_FOLDER))
+        fake_manifest.save(os.path.join(self.client.client_cache.store, root_folder5, EXPORT_FOLDER))
+        fake_manifest.save(os.path.join(self.client.client_cache.store, root_folder11, EXPORT_FOLDER))
+        fake_manifest.save(os.path.join(self.client.client_cache.store, root_folder12, EXPORT_FOLDER))
+        fake_manifest.save(os.path.join(self.client.client_cache.store, root_folder_tool, EXPORT_FOLDER))
 
     def recipe_search_all_test(self):
-        os.rmdir(self.servers["local"].paths.store)
-        self._copy_to_server(self.client.paths, self.servers["local"].paths)
-        os.rmdir(self.servers["search_able"].paths.store)
-        self._copy_to_server(self.client.paths, self.servers["search_able"].paths)
+        os.rmdir(self.servers["local"].server_store.store)
+        self._copy_to_server(self.client.client_cache, self.servers["local"].server_store)
+        os.rmdir(self.servers["search_able"].server_store.store)
+        self._copy_to_server(self.client.client_cache, self.servers["search_able"].server_store)
 
         def check():
             for remote in ("local", "search_able"):
@@ -300,10 +300,10 @@ helloTest/1.4.10@myuser/stable""".format(remote)
         self.assertIn("<td>Windows Visual Studio 8.1</td>", html)
 
     def search_html_table_all_test(self):
-        os.rmdir(self.servers["local"].paths.store)
-        self._copy_to_server(self.client.paths, self.servers["local"].paths)
-        os.rmdir(self.servers["search_able"].paths.store)
-        self._copy_to_server(self.client.paths, self.servers["search_able"].paths)
+        os.rmdir(self.servers["local"].server_store.store)
+        self._copy_to_server(self.client.client_cache, self.servers["local"].server_store)
+        os.rmdir(self.servers["search_able"].server_store.store)
+        self._copy_to_server(self.client.client_cache, self.servers["search_able"].server_store)
 
         self.client.run("search Hello/1.4.10@myuser/testing -r=all --table=table.html")
         html = load(os.path.join(self.client.current_folder, "table.html"))
@@ -344,8 +344,8 @@ helloTest/1.4.10@myuser/stable""".format(remote)
         self.assertNotIn("WindowsPackageSHA", self.client.out)
 
         # Now search with a remote
-        os.rmdir(self.servers["local"].paths.store)
-        self._copy_to_server(self.client.paths, self.servers["local"].paths)
+        os.rmdir(self.servers["local"].server_store.store)
+        self._copy_to_server(self.client.client_cache, self.servers["local"].server_store)
 
         self.client.run('search Hello/1.4.10@myuser/testing '
                         '-q "compiler=gcc AND compiler.libcxx=libstdc++11" -r local')
@@ -361,8 +361,8 @@ helloTest/1.4.10@myuser/stable""".format(remote)
         self.assertNotIn("WindowsPackageSHA", self.client.out)
 
         # Now search in all remotes
-        os.rmdir(self.servers["search_able"].paths.store)
-        self._copy_to_server(self.client.paths, self.servers["search_able"].paths)
+        os.rmdir(self.servers["search_able"].server_store.store)
+        self._copy_to_server(self.client.client_cache, self.servers["search_able"].server_store)
 
         self.client.run('search Hello/1.4.10@myuser/testing '
                         '-q "compiler=gcc AND compiler.libcxx=libstdc++11" -r all')
@@ -403,8 +403,8 @@ helloTest/1.4.10@myuser/stable""".format(remote)
         def test_cases(remote=None):
 
             if remote:  # Simulate upload to remote
-                os.rmdir(self.servers[remote].paths.store)
-                self._copy_to_server(self.client.paths, self.servers[remote].paths)
+                os.rmdir(self.servers[remote].server_store.store)
+                self._copy_to_server(self.client.client_cache, self.servers[remote].server_store)
 
             q = ''
             self._assert_pkg_q(q, ["LinuxPackageSHA", "PlatformIndependantSHA",
@@ -503,10 +503,10 @@ helloTest/1.4.10@myuser/stable""".format(remote)
                 server_store.update_last_package_revision(pid)
 
     def package_search_all_remotes_test(self):
-        os.rmdir(self.servers["local"].paths.store)
-        self._copy_to_server(self.client.paths, self.servers["local"].paths)
-        os.rmdir(self.servers["search_able"].paths.store)
-        self._copy_to_server(self.client.paths, self.servers["search_able"].paths)
+        os.rmdir(self.servers["local"].server_store.store)
+        self._copy_to_server(self.client.client_cache, self.servers["local"].server_store)
+        os.rmdir(self.servers["search_able"].server_store.store)
+        self._copy_to_server(self.client.client_cache, self.servers["search_able"].server_store)
 
         self.client.run("search Hello/1.4.10@myuser/testing -r=all")
         self.assertIn("Existing recipe in remote 'local':", self.client.out)
@@ -694,10 +694,10 @@ helloTest/1.4.10@myuser/stable""".format(remote)
         self.assertEqual(expected_output, output)
 
         # Test search recipes all remotes
-        os.rmdir(self.servers["local"].paths.store)
-        self._copy_to_server(self.client.paths, self.servers["local"].paths)
-        os.rmdir(self.servers["search_able"].paths.store)
-        self._copy_to_server(self.client.paths, self.servers["search_able"].paths)
+        os.rmdir(self.servers["local"].server_store.store)
+        self._copy_to_server(self.client.client_cache, self.servers["local"].server_store)
+        os.rmdir(self.servers["search_able"].server_store.store)
+        self._copy_to_server(self.client.client_cache, self.servers["search_able"].server_store)
 
         self.client.run("search Hello* -r=all --json search.json")
         self.assertTrue(os.path.exists(json_path))

--- a/conans/test/functional/generators/xcode_gcc_vs_test.py
+++ b/conans/test/functional/generators/xcode_gcc_vs_test.py
@@ -75,9 +75,9 @@ xcode
         lib_dirs = linker.getElementsByTagName("AdditionalLibraryDirectories")[0].firstChild.data
         libs = linker.getElementsByTagName("AdditionalDependencies")[0].firstChild.data
 
-        package_id = os.listdir(client.paths.packages(conan_ref))[0]
+        package_id = os.listdir(client.client_cache.packages(conan_ref))[0]
         package_ref = PackageReference(conan_ref, package_id)
-        package_path = client.paths.package(package_ref).replace("\\", "/")
+        package_path = client.client_cache.package(package_ref).replace("\\", "/")
 
         replaced_path = re.sub(os.getenv("USERPROFILE", "not user profile").replace("\\", "/"),
                                "$(USERPROFILE)", package_path, flags=re.I)

--- a/conans/test/functional/old/create_package_test.py
+++ b/conans/test/functional/old/create_package_test.py
@@ -46,7 +46,7 @@ class ExporterTest(unittest.TestCase):
         files = hello_source_files()
 
         conan_ref = ConanFileReference.loads("Hello/1.2.1@frodo/stable")
-        reg_folder = client.paths.export(conan_ref)
+        reg_folder = client.client_cache.export(conan_ref)
 
         client.save(files, path=reg_folder)
         client.save({CONANFILE: myconan1,
@@ -73,8 +73,8 @@ class ExporterTest(unittest.TestCase):
 
         conanfile_path = os.path.join(reg_folder, CONANFILE)
         package_ref = PackageReference(conan_ref, "myfakeid")
-        build_folder = client.paths.build(package_ref)
-        package_folder = client.paths.package(package_ref)
+        build_folder = client.client_cache.build(package_ref)
+        package_folder = client.client_cache.package(package_ref)
         install_folder = os.path.join(build_folder, "infos")
 
         shutil.copytree(reg_folder, build_folder)

--- a/conans/test/functional/old/disk_search_test.py
+++ b/conans/test/functional/old/disk_search_test.py
@@ -16,10 +16,10 @@ class SearchTest(unittest.TestCase):
 
     def setUp(self):
         folder = temp_folder()
-        self.paths = ClientCache(folder, store_folder=folder, output=TestBufferConanOutput())
+        self.client_cache = ClientCache(folder, store_folder=folder, output=TestBufferConanOutput())
 
     def basic_test2(self):
-        with chdir(self.paths.store):
+        with chdir(self.client_cache.store):
             conan_ref1 = ConanFileReference.loads("opencv/2.4.10@lasote/testing")
             root_folder = str(conan_ref1).replace("@", "/")
             artifacts = ["a", "b", "c"]
@@ -32,12 +32,12 @@ class SearchTest(unittest.TestCase):
                 info = ConanInfo().loads("[settings]\n[options]")
                 save(os.path.join(artif1, CONANINFO), info.dumps())
 
-            packages = search_packages(self.paths, conan_ref1, "")
+            packages = search_packages(self.client_cache, conan_ref1, "")
             all_artif = [_artif for _artif in sorted(packages)]
             self.assertEqual(all_artif, artifacts)
 
     def pattern_test(self):
-        with chdir(self.paths.store):
+        with chdir(self.client_cache.store):
             refs = ["opencv/2.4.%s@lasote/testing" % ref for ref in ("1", "2", "3")]
             refs = [ConanFileReference.loads(ref) for ref in refs]
             for ref in refs:
@@ -45,11 +45,11 @@ class SearchTest(unittest.TestCase):
                 reg1 = "%s/%s" % (root_folder, EXPORT_FOLDER)
                 os.makedirs(reg1)
 
-            recipes = search_recipes(self.paths, "opencv/*@lasote/testing")
+            recipes = search_recipes(self.client_cache, "opencv/*@lasote/testing")
             self.assertEqual(recipes, refs)
 
     def case_insensitive_test(self):
-        with chdir(self.paths.store):
+        with chdir(self.client_cache.store):
             root_folder2 = "sdl/1.5/lasote/stable"
             conan_ref2 = ConanFileReference.loads("sdl/1.5@lasote/stable")
             os.makedirs("%s/%s" % (root_folder2, EXPORT_FOLDER))
@@ -67,15 +67,16 @@ class SearchTest(unittest.TestCase):
             os.makedirs("%s/%s" % (root_folder5, EXPORT_FOLDER))
             # Case insensitive searches
 
-            reg_conans = sorted([str(_reg) for _reg in search_recipes(self.paths, "*")])
+            reg_conans = sorted([str(_reg) for _reg in search_recipes(self.client_cache, "*")])
             self.assertEqual(reg_conans, [str(conan_ref5),
                                           str(conan_ref3),
                                           str(conan_ref2),
                                           str(conan_ref4)])
 
-            reg_conans = sorted([str(_reg) for _reg in search_recipes(self.paths, pattern="sdl*")])
+            reg_conans = sorted([str(_reg) for _reg in search_recipes(self.client_cache, pattern="sdl*")])
             self.assertEqual(reg_conans, [str(conan_ref5), str(conan_ref2), str(conan_ref4)])
 
             # Case sensitive search
-            self.assertEqual(str(search_recipes(self.paths, pattern="SDL*", ignorecase=False)[0]),
+            self.assertEqual(str(search_recipes(self.client_cache, pattern="SDL*",
+                                                ignorecase=False)[0]),
                              str(conan_ref5))

--- a/conans/test/functional/old/download_test.py
+++ b/conans/test/functional/old/download_test.py
@@ -45,7 +45,7 @@ class DownloadTest(unittest.TestCase):
         client2 = TestClient(servers=servers, requester_class=BuggyRequester)
         conan_ref = ConanFileReference.loads("Hello/1.2.1@frodo/stable")
         registry = RemoteRegistry(client2.client_cache.registry, client2.out)
-        installer = ConanProxy(client2.paths, client2.user_io.out, client2.remote_manager,
+        installer = ConanProxy(client2.client_cache, client2.user_io.out, client2.remote_manager,
                                registry=registry)
 
         with self.assertRaises(NotFoundException):
@@ -57,7 +57,7 @@ class DownloadTest(unittest.TestCase):
 
         client2 = TestClient(servers=servers, requester_class=BuggyRequester2)
         registry = RemoteRegistry(client2.client_cache.registry, client2.out)
-        installer = ConanProxy(client2.paths, client2.user_io.out, client2.remote_manager,
+        installer = ConanProxy(client2.client_cache, client2.user_io.out, client2.remote_manager,
                                registry=registry)
 
         try:

--- a/conans/test/functional/old/remove_old_export_sources_layout_test.py
+++ b/conans/test/functional/old/remove_old_export_sources_layout_test.py
@@ -30,7 +30,7 @@ class MyPkg(ConanFile):
         client.run("search")
         self.assertIn("There are no packages", client.user_io.out)
         conan_reference = ConanFileReference.loads("Pkg/0.1@lasote/testing")
-        path = test_server.paths.export(conan_reference)
+        path = test_server.server_store.export(conan_reference)
         sources_tgz = os.path.join(path, "conan_sources.tgz")
         self.assertTrue(os.path.exists(sources_tgz))
         folder = temp_folder()

--- a/conans/test/functional/remote/auth_test.py
+++ b/conans/test/functional/remote/auth_test.py
@@ -43,7 +43,7 @@ class AuthorizeTest(unittest.TestCase):
         # Check that return was  ok
         self.assertFalse(errors)
         # Check that upload was granted
-        self.assertTrue(os.path.exists(self.test_server.paths.export(self.conan_reference)))
+        self.assertTrue(os.path.exists(self.test_server.server_store.export(self.conan_reference)))
 
         # Check that login failed two times before ok
         self.assertEquals(self.conan.user_io.login_index["default"], 3)
@@ -94,7 +94,7 @@ class AuthorizeTest(unittest.TestCase):
         self.assertTrue(errors)
         # Check that upload was not granted
         with self.assertRaises(NotFoundException):
-            self.test_server.paths.export(self.conan_reference)
+            self.test_server.server_store.export(self.conan_reference)
 
         # Check that login failed all times
         self.assertEquals(self.conan.user_io.login_index["default"], 3)
@@ -112,7 +112,7 @@ class AuthorizeTest(unittest.TestCase):
         self.conan.run("upload %s" % str(self.conan_reference))
 
         # Check that upload was granted
-        self.assertTrue(os.path.exists(self.test_server.paths.export(self.conan_reference)))
+        self.assertTrue(os.path.exists(self.test_server.server_store.export(self.conan_reference)))
 
         # Check that login failed once before ok
         self.assertEquals(self.conan.user_io.login_index["default"], 2)

--- a/conans/test/functional/remote/broken_download_test.py
+++ b/conans/test/functional/remote/broken_download_test.py
@@ -17,16 +17,16 @@ class BrokenDownloadTest(unittest.TestCase):
         client.save(files)
         client.run("export . lasote/stable")
         ref = ConanFileReference.loads("Hello/0.1@lasote/stable")
-        self.assertTrue(os.path.exists(client.paths.export(ref)))
+        self.assertTrue(os.path.exists(client.client_cache.export(ref)))
         client.run("upload Hello/0.1@lasote/stable")
         client.run("remove Hello/0.1@lasote/stable -f")
-        self.assertFalse(os.path.exists(client.paths.export(ref)))
+        self.assertFalse(os.path.exists(client.client_cache.export(ref)))
         path = server.test_server.server_store.export(ref)
         tgz = os.path.join(path, "conan_export.tgz")
         save(tgz, "contents")  # dummy content to break it, so the download decompress will fail
         client.run("install Hello/0.1@lasote/stable --build", assert_error=True)
         self.assertIn("ERROR: Error while downloading/extracting files to", client.user_io.out)
-        self.assertFalse(os.path.exists(client.paths.export(ref)))
+        self.assertFalse(os.path.exists(client.client_cache.export(ref)))
 
     def client_retries_test(self):
         server = TestServer()

--- a/conans/test/integration/conan_test_test.py
+++ b/conans/test/integration/conan_test_test.py
@@ -115,14 +115,14 @@ class HelloReuseConan(ConanFile):
         client.run("test test Hello/0.1@lasote/stable")
         ref = PackageReference.loads("Hello/0.1@lasote/stable:%s" % NO_SETTINGS_PACKAGE_ID)
         self.assertEqual("Hello FindCmake",
-                         load(os.path.join(client.paths.package(ref), "FindXXX.cmake")))
+                         load(os.path.join(client.client_cache.package(ref), "FindXXX.cmake")))
         client.save({"FindXXX.cmake": "Bye FindCmake"})
         client.run("test test Hello/0.1@lasote/stable")  # Test do not rebuild the package
         self.assertEqual("Hello FindCmake",
-                         load(os.path.join(client.paths.package(ref), "FindXXX.cmake")))
+                         load(os.path.join(client.client_cache.package(ref), "FindXXX.cmake")))
         client.run("create . lasote/stable")  # create rebuild the package
         self.assertEqual("Bye FindCmake",
-                         load(os.path.join(client.paths.package(ref), "FindXXX.cmake")))
+                         load(os.path.join(client.client_cache.package(ref), "FindXXX.cmake")))
 
     def conan_test_test(self):
 

--- a/conans/test/integration/export_sources_test.py
+++ b/conans/test/integration/export_sources_test.py
@@ -118,7 +118,7 @@ class ExportsSourcesTest(unittest.TestCase):
                                'conanmanifest.txt']
 
         server = server or self.server
-        self.assertEqual(scan_folder(server.paths.export(self.reference)), expected_server)
+        self.assertEqual(scan_folder(server.server_store.export(self.reference)), expected_server)
 
     def _check_export_folder(self, mode, export_folder=None, export_src_folder=None):
         if mode == "exports_sources":
@@ -387,7 +387,7 @@ class ExportsSourcesTest(unittest.TestCase):
         self.assertIn("Hello/0.1@lasote/testing: Already installed!", self.client.user_io.out)
         self._check_export_installed_folder(mode)
 
-        server_path = self.server.paths.export(self.reference)
+        server_path = self.server.server_store.export(self.reference)
         save(os.path.join(server_path, "license.txt"), "mylicense")
         manifest = FileTreeManifest.load(server_path)
         manifest.time += 1

--- a/conans/test/integration/go_complete_test.py
+++ b/conans/test/integration/go_complete_test.py
@@ -98,16 +98,16 @@ class GoCompleteTest(unittest.TestCase):
         self.client.run("export . lasote/stable")
         self.client.run("install %s --build missing" % str(conan_reference))
         # Check compilation ok
-        package_ids = self.client.paths.conan_packages(conan_reference)
+        package_ids = self.client.client_cache.conan_packages(conan_reference)
         self.assertEquals(len(package_ids), 1)
         package_ref = PackageReference(conan_reference, package_ids[0])
-        self._assert_package_exists(package_ref, self.client.paths, files_without_conanfile)
+        self._assert_package_exists(package_ref, self.client.client_cache, files_without_conanfile)
 
         # Upload conans
         self.client.run("upload %s" % str(conan_reference))
 
         # Check that conans exists on server
-        server_paths = self.servers["default"].paths
+        server_paths = self.servers["default"].server_store
         conan_path = server_paths.export(conan_reference)
         self.assertTrue(os.path.exists(conan_path))
 
@@ -121,10 +121,10 @@ class GoCompleteTest(unittest.TestCase):
         other_conan = TestClient(servers=self.servers, users={"default": [("lasote", "mypass")]})
         other_conan.run("install %s --build missing" % str(conan_reference))
         # Build should be empty
-        build_path = other_conan.paths.build(package_ref)
+        build_path = other_conan.client_cache.build(package_ref)
         self.assertFalse(os.path.exists(build_path))
         # Lib should exist
-        self._assert_package_exists(package_ref, other_conan.paths, files_without_conanfile)
+        self._assert_package_exists(package_ref, other_conan.client_cache, files_without_conanfile)
 
         reuse_conan = TestClient(servers=self.servers, users={"default": [("lasote", "mypass")]})
         files = {'conanfile.py': reuse_conanfile,

--- a/conans/test/integration/install_outdated_test.py
+++ b/conans/test/integration/install_outdated_test.py
@@ -82,7 +82,7 @@ class InstallOutdatedPackagesTest(unittest.TestCase):
         self.client.run("upload Hello0/0.1@lasote/stable")
 
         # Now, with the new_client, remove only the binary package from Hello0
-        rmdir(new_client.paths.packages(self.ref))
+        rmdir(new_client.client_cache.packages(self.ref))
         # And try to install Hello1 again, should not complain because the remote
         # binary is in the "same version" than local cached Hello0
         new_client.run("install Hello1/0.1@lasote/stable --build outdated")
@@ -122,7 +122,7 @@ class InstallOutdatedPackagesTest(unittest.TestCase):
         self.client.run("upload Hello0/0.1@lasote/stable")
 
         # Now, with the new_client, remove only the binary package from Hello0
-        rmdir(new_client.paths.packages(self.ref))
+        rmdir(new_client.client_cache.packages(self.ref))
         # And try to install Hello1 again, should not complain because the remote
         # binary is in the "same version" than local cached Hello0
         new_client.run("install Hello1/0.1@lasote/stable --build outdated --build Hello1")

--- a/conans/test/integration/install_selected_packages_test.py
+++ b/conans/test/integration/install_selected_packages_test.py
@@ -21,39 +21,39 @@ class InstallSelectedPackagesTest(unittest.TestCase):
     def install_all_test(self):
         # Should retrieve the three packages
         self.new_client.run("download Hello0/0.1@lasote/stable")
-        p1 = os.path.join(self.new_client.paths.packages(self.ref))
+        p1 = os.path.join(self.new_client.client_cache.packages(self.ref))
         packages = os.listdir(p1)
         self.assertEquals(len(packages), 3)
 
     def install_some_reference_test(self):
         # Should retrieve the specified packages
         self.new_client.run("download Hello0/0.1@lasote/stable -p %s" % self.package_ids[0])
-        packages = os.listdir(self.new_client.paths.packages(self.ref))
+        packages = os.listdir(self.new_client.client_cache.packages(self.ref))
         self.assertEquals(len(packages), 1)
         self.assertEquals(packages[0], self.package_ids[0])
 
         self.new_client.run("download Hello0/0.1@lasote/stable -p %s -p %s" % (self.package_ids[0],
                                                                                self.package_ids[1]))
-        packages = os.listdir(self.new_client.paths.packages(self.ref))
+        packages = os.listdir(self.new_client.client_cache.packages(self.ref))
         self.assertEquals(len(packages), 2)
 
     def download_recipe_twice_test(self):
         expected_conanfile_contents = self.files[CONANFILE]
         self.new_client.run("download Hello0/0.1@lasote/stable")
-        got_conanfile = load(os.path.join(self.new_client.paths.export(self.ref), CONANFILE))
+        got_conanfile = load(os.path.join(self.new_client.client_cache.export(self.ref), CONANFILE))
         self.assertEquals(expected_conanfile_contents, got_conanfile)
 
         self.new_client.run("download Hello0/0.1@lasote/stable")
-        got_conanfile = load(os.path.join(self.new_client.paths.export(self.ref), CONANFILE))
+        got_conanfile = load(os.path.join(self.new_client.client_cache.export(self.ref), CONANFILE))
         self.assertEquals(expected_conanfile_contents, got_conanfile)
 
         self.new_client.run("download Hello0/0.1@lasote/stable")
-        got_conanfile = load(os.path.join(self.new_client.paths.export(self.ref), CONANFILE))
+        got_conanfile = load(os.path.join(self.new_client.client_cache.export(self.ref), CONANFILE))
         self.assertEquals(expected_conanfile_contents, got_conanfile)
 
     def download_packages_twice_test(self):
         expected_header_contents = self.files["helloHello0.h"]
-        package_folder = self.new_client.paths.package(PackageReference(self.ref,
+        package_folder = self.new_client.client_cache.package(PackageReference(self.ref,
                                                                         self.package_ids[0]))
 
         self.new_client.run("download Hello0/0.1@lasote/stable")
@@ -99,4 +99,4 @@ class InstallSelectedPackagesTest(unittest.TestCase):
         client.run("install Hello0/0.1@lasote/stable -s os=Linux -s compiler=gcc -s "
                    "compiler.version=4.6 -s compiler.libcxx=libstdc++ --build missing")
         client.run("upload  Hello0/0.1@lasote/stable --all")
-        return os.listdir(self.client.paths.packages(self.ref))
+        return os.listdir(self.client.client_cache.packages(self.ref))

--- a/conans/test/integration/install_update_test.py
+++ b/conans/test/integration/install_update_test.py
@@ -248,8 +248,8 @@ class Pkg(ConanFile):
 
         client2.run("install Hello0/1.0@lasote/stable --update")
         ref = ConanFileReference.loads("Hello0/1.0@lasote/stable")
-        package_ids = client2.paths.conan_packages(ref)
-        package_path = client2.paths.package(PackageReference(ref, package_ids[0]))
+        package_ids = client2.client_cache.conan_packages(ref)
+        package_path = client2.client_cache.package(PackageReference(ref, package_ids[0]))
         header = load(os.path.join(package_path, "include/helloHello0.h"))
         self.assertEqual(header, "//EMPTY!")
 

--- a/conans/test/integration/manifest_validation_test.py
+++ b/conans/test/integration/manifest_validation_test.py
@@ -224,11 +224,11 @@ class ConanFileTest(ConanFile):
         client.save(self.files)
         client.run("export . lasote/stable")
         client.run("install Hello/0.1@lasote/stable --build=missing")
-        info = os.path.join(client.paths.package(package_reference), "conaninfo.txt")
+        info = os.path.join(client.client_cache.package(package_reference), "conaninfo.txt")
         info_content = load(info)
         info_content += "# Dummy string"
         save(info, info_content)
-        package_folder = client.paths.package(package_reference)
+        package_folder = client.client_cache.package(package_reference)
         manifest = FileTreeManifest.load(package_folder)
         manifest.file_sums["conaninfo.txt"] = md5(info_content)
         manifest.save(package_folder)
@@ -269,7 +269,7 @@ class ConanFileTest(ConanFile):
         self.assertIn("ERROR: Do not specify both", self.client.user_io.out)
 
     def test_corrupted_recipe(self):
-        export_path = self.client.paths.export(self.reference)
+        export_path = self.client.client_cache.export(self.reference)
         file_path = os.path.join(export_path, "data.txt")
         save(file_path, "BAD CONTENT")
 
@@ -282,7 +282,7 @@ class ConanFileTest(ConanFile):
         self.client.run("install %s --build missing" % str(self.reference))
         package_reference = PackageReference.loads("Hello/0.1@lasote/stable:"
                                                    "%s" % NO_SETTINGS_PACKAGE_ID)
-        package_path = self.client.paths.package(package_reference)
+        package_path = self.client.client_cache.package(package_reference)
         file_path = os.path.join(package_path, "conaninfo.txt")
         save(file_path, load(file_path) + "  ")
 

--- a/conans/test/integration/multi_build_test.py
+++ b/conans/test/integration/multi_build_test.py
@@ -21,7 +21,7 @@ class CollectLibsTest(unittest.TestCase):
         client.run("install %s --build missing" % str(conan_reference))
 
         # Check compilation ok
-        package_ids = client.paths.conan_packages(conan_reference)
+        package_ids = client.client_cache.conan_packages(conan_reference)
         self.assertEquals(len(package_ids), 1)
 
         # Reuse them

--- a/conans/test/integration/only_source_test.py
+++ b/conans/test/integration/only_source_test.py
@@ -158,8 +158,8 @@ class MyPackage(ConanFile):
         client.run("export . lasote/stable")
         client.run("install %s --build missing" % str(conan_reference))
 
-        self.assertTrue(os.path.exists(client.paths.builds(conan_reference)))
-        self.assertTrue(os.path.exists(client.paths.packages(conan_reference)))
+        self.assertTrue(os.path.exists(client.client_cache.builds(conan_reference)))
+        self.assertTrue(os.path.exists(client.client_cache.packages(conan_reference)))
 
         # Upload
         client.run("upload %s --all" % str(conan_reference))
@@ -167,28 +167,28 @@ class MyPackage(ConanFile):
         # Now from other "computer" install the uploaded conans with same options (nothing)
         other_conan = TestClient(servers=self.servers, users={"default": [("lasote", "mypass")]})
         other_conan.run("install %s --build missing" % str(conan_reference))
-        self.assertFalse(os.path.exists(other_conan.paths.builds(conan_reference)))
-        self.assertTrue(os.path.exists(other_conan.paths.packages(conan_reference)))
+        self.assertFalse(os.path.exists(other_conan.client_cache.builds(conan_reference)))
+        self.assertTrue(os.path.exists(other_conan.client_cache.packages(conan_reference)))
 
         # Now from other "computer" install the uploaded conans with same options (nothing)
         other_conan = TestClient(servers=self.servers, users={"default": [("lasote", "mypass")]})
         other_conan.run("install %s --build" % str(conan_reference))
-        self.assertTrue(os.path.exists(other_conan.paths.builds(conan_reference)))
-        self.assertTrue(os.path.exists(other_conan.paths.packages(conan_reference)))
+        self.assertTrue(os.path.exists(other_conan.client_cache.builds(conan_reference)))
+        self.assertTrue(os.path.exists(other_conan.client_cache.packages(conan_reference)))
 
         # Use an invalid pattern and check that its not builded from source
         other_conan = TestClient(servers=self.servers, users={"default": [("lasote", "mypass")]})
         other_conan.run("install %s --build HelloInvalid" % str(conan_reference))
         self.assertIn("No package matching 'HelloInvalid' pattern", other_conan.user_io.out)
-        self.assertFalse(os.path.exists(other_conan.paths.builds(conan_reference)))
-        # self.assertFalse(os.path.exists(other_conan.paths.packages(conan_reference)))
+        self.assertFalse(os.path.exists(other_conan.client_cache.builds(conan_reference)))
+        # self.assertFalse(os.path.exists(other_conan.client_cache.packages(conan_reference)))
 
         # Use another valid pattern and check that its not builded from source
         other_conan = TestClient(servers=self.servers, users={"default": [("lasote", "mypass")]})
         other_conan.run("install %s --build HelloInvalid -b Hello" % str(conan_reference))
         self.assertIn("No package matching 'HelloInvalid' pattern", other_conan.user_io.out)
-        # self.assertFalse(os.path.exists(other_conan.paths.builds(conan_reference)))
-        # self.assertFalse(os.path.exists(other_conan.paths.packages(conan_reference)))
+        # self.assertFalse(os.path.exists(other_conan.client_cache.builds(conan_reference)))
+        # self.assertFalse(os.path.exists(other_conan.client_cache.packages(conan_reference)))
 
         # Now even if the package is in local store, check that's rebuilded
         other_conan.run("install %s -b Hello*" % str(conan_reference))

--- a/conans/test/integration/revisions_test.py
+++ b/conans/test/integration/revisions_test.py
@@ -43,7 +43,7 @@ class HelloConan(ConanFile):
     def test_revisions_recipes_without_scm(self):
 
         self._create_and_upload(self.conanfile, self.ref)
-        rev = self.servers["remote0"].paths.get_last_revision(self.ref).revision
+        rev = self.servers["remote0"].server_store.get_last_revision(self.ref).revision
         self.assertEquals(rev, "149570a812b46d87c7dfa6408809b370")
 
         # Create a new revision and upload
@@ -94,18 +94,18 @@ class HelloConan(ConanFile):
 '''
         with environment_append({"PACKAGE_CONTENTS": "1"}):
             self._create_and_upload(conanfile, self.ref)
-        rev = self.servers["remote0"].paths.get_last_revision(self.ref).revision
+        rev = self.servers["remote0"].server_store.get_last_revision(self.ref).revision
         self.assertEquals(rev, "202f9ce41808083a0f0c0d071fb5f398")
 
         self.ref = self.ref.copy_with_rev(rev)
         p_ref = PackageReference(self.ref, "5ab84d6acfe1f23c4fae0ab88f26e3a396351ac9")
-        pkg_rev = self.servers["remote0"].paths.get_last_package_revision(p_ref).revision
+        pkg_rev = self.servers["remote0"].server_store.get_last_package_revision(p_ref).revision
         self.assertEquals(pkg_rev, "15ab113a16e2ac8c9ecffb4ba48306b2")
 
         # Create new package revision for the same recipe
         with environment_append({"PACKAGE_CONTENTS": "2"}):
             self._create_and_upload(conanfile, self.ref.copy_clear_rev())
-        pkg_rev = self.servers["remote0"].paths.get_last_package_revision(p_ref).revision
+        pkg_rev = self.servers["remote0"].server_store.get_last_package_revision(p_ref).revision
         self.assertEquals(pkg_rev, "8e54c6ea967722f2f9bdcbacb21792f5")
 
         # Delete all from local
@@ -115,13 +115,13 @@ class HelloConan(ConanFile):
         self.client.run("download %s -p 5ab84d6acfe1f23c4fae0ab88f26e3a396351ac9#"
                         "8e54c6ea967722f2f9bdcbacb21792f5" % self.ref.full_repr())
 
-        contents = load(os.path.join(self.client.paths.package(p_ref), "myfile.txt"))
+        contents = load(os.path.join(self.client.client_cache.package(p_ref), "myfile.txt"))
         self.assertEquals(contents, "2")
 
         # Download previous package revision
         self.client.run("download %s -p 5ab84d6acfe1f23c4fae0ab88f26e3a396351ac9#"
                         "15ab113a16e2ac8c9ecffb4ba48306b2" % self.ref.full_repr())
-        contents = load(os.path.join(self.client.paths.package(p_ref), "myfile.txt"))
+        contents = load(os.path.join(self.client.client_cache.package(p_ref), "myfile.txt"))
         self.assertEquals(contents, "1")
 
         # Specify a package revision without a recipe revision
@@ -141,9 +141,9 @@ class HelloConan(ConanFile):
         self.output.warn("Revision 1")
 '''
         self._create_and_upload(conanfile, self.ref, args="-s os=Linux")
-        rev1 = self.servers["remote0"].paths.get_last_revision(self.ref).revision
+        rev1 = self.servers["remote0"].server_store.get_last_revision(self.ref).revision
         self._create_and_upload(conanfile.replace('"os"', '"arch"'), self.ref, args="-s arch=x86")
-        rev2 = self.servers["remote0"].paths.get_last_revision(self.ref).revision
+        rev2 = self.servers["remote0"].server_store.get_last_revision(self.ref).revision
         self.assertNotEqual(rev1, rev2)
 
         # Search every package in local cache (we get both binary packages)
@@ -196,7 +196,7 @@ class HelloConan(ConanFile):
         self.client.current_folder = path
         self.client.run("create . %s" % str(self.ref))
         self.client.run("upload %s -c --all -r remote0" % str(self.ref))
-        rev_server = self.servers["remote0"].paths.get_last_revision(self.ref)
+        rev_server = self.servers["remote0"].server_store.get_last_revision(self.ref)
         self.assertEqual(commit, rev_server.revision)
 
         self.client.run("remove %s -f" % str(self.ref))
@@ -277,14 +277,14 @@ class HelloConan(ConanFile):
         self.client.run("create . %s" % str(self.ref))
         self.client.run("upload %s -c --all -r remote0" % str(self.ref))
         rev = self.client.get_revision(self.ref)
-        remote_rev = self.servers["remote0"].paths.get_last_revision(self.ref)
+        remote_rev = self.servers["remote0"].server_store.get_last_revision(self.ref)
         self.assertEquals(remote_rev.revision, rev)
 
         self.client.save({"conanfile.py": self.conanfile + " "})
         self.client.run("create . %s" % str(self.ref))
         self.client.run("upload %s -c --all -r remote0" % str(self.ref))
         rev2 = self.client.get_revision(self.ref)
-        remote_rev2 = self.servers["remote0"].paths.get_last_revision(self.ref)
+        remote_rev2 = self.servers["remote0"].server_store.get_last_revision(self.ref)
         self.assertEquals(remote_rev2.revision, rev2)
         self.assertNotEquals(rev, rev2)
 
@@ -354,9 +354,9 @@ class HelloConan(ConanFile):
 '''
         ref_a = ConanFileReference.loads("libA/1.0@lasote/testing")
         self._create_and_upload(conanfile, ref_a)
-        rev = self.servers["remote0"].paths.get_last_revision(ref_a).revision
+        rev = self.servers["remote0"].server_store.get_last_revision(ref_a).revision
         self._create_and_upload(conanfile + " ", ref_a)  # New revision
-        rev2 = self.servers["remote0"].paths.get_last_revision(ref_a).revision
+        rev2 = self.servers["remote0"].server_store.get_last_revision(ref_a).revision
 
         ref_b = ConanFileReference.loads("libB/1.0@lasote/testing")
         req = "%s#%s" % (ref_a, rev)
@@ -441,7 +441,7 @@ class AliasConanfile(ConanFile):
         self.client.run("upload %s -c --all -r remote0" % str(self.ref))
         self.client.run("remove %s -r remote0 -f" % str(self.ref))
 
-        last_rev = self.servers["remote0"].paths.get_last_revision(self.ref)
+        last_rev = self.servers["remote0"].server_store.get_last_revision(self.ref)
         self.assertIsNone(last_rev)
 
     def test_recipe_revision_delete_one(self):
@@ -450,7 +450,7 @@ class AliasConanfile(ConanFile):
         self.client.run("create . %s" % str(self.ref))
         self.client.run("upload %s -c --all -r remote0" % str(self.ref))
         rev = self.client.get_revision(self.ref)
-        remote_rev = self.servers["remote0"].paths.get_last_revision(self.ref)
+        remote_rev = self.servers["remote0"].server_store.get_last_revision(self.ref)
         self.assertEquals(remote_rev.revision, rev)
 
         # Upload revision2
@@ -458,12 +458,12 @@ class AliasConanfile(ConanFile):
         self.client.run("create . %s" % str(self.ref))
         self.client.run("upload %s -c --all -r remote0" % str(self.ref))
         rev2 = self.client.get_revision(self.ref)
-        remote_rev = self.servers["remote0"].paths.get_last_revision(self.ref)
+        remote_rev = self.servers["remote0"].server_store.get_last_revision(self.ref)
         self.assertEquals(remote_rev.revision, rev2)
 
         # Remove revision2
         self.client.run("remove %s#%s -r remote0 -f" % (str(self.ref), rev2))
-        remote_rev = self.servers["remote0"].paths.get_last_revision(self.ref)
+        remote_rev = self.servers["remote0"].server_store.get_last_revision(self.ref)
         self.assertEquals(remote_rev.revision, rev)
 
         # Upload revision3
@@ -472,12 +472,12 @@ class AliasConanfile(ConanFile):
         self.client.run("upload %s -c --all -r remote0" % str(self.ref))
         rev3 = self.client.get_revision(self.ref)
         self.assertNotEquals(rev3, rev2)
-        remote_rev = self.servers["remote0"].paths.get_last_revision(self.ref)
+        remote_rev = self.servers["remote0"].server_store.get_last_revision(self.ref)
         self.assertEquals(remote_rev.revision, rev3)
 
         # Remove revision 3, remote is rev1
         self.client.run("remove %s#%s -r remote0 -f" % (str(self.ref), rev3))
-        remote_rev = self.servers["remote0"].paths.get_last_revision(self.ref)
+        remote_rev = self.servers["remote0"].server_store.get_last_revision(self.ref)
         self.assertEquals(remote_rev.revision, rev)
 
     def test_remote_search(self):
@@ -494,12 +494,12 @@ class HelloConan(ConanFile):
         self.client.save({"conanfile.py": conanfile})
         self.client.run("create . %s -s os=Windows" % str(self.ref))
         self.client.run("upload %s -c --all -r remote0" % str(self.ref))
-        rev1 = self.servers["remote0"].paths.get_last_revision(self.ref).revision
+        rev1 = self.servers["remote0"].server_store.get_last_revision(self.ref).revision
         # Create other recipe revision with a different binary package
         self.client.save({"conanfile.py": conanfile + " "})
         self.client.run("create . %s -s os=Linux" % str(self.ref))
         self.client.run("upload %s -c --all -r remote0" % str(self.ref))
-        rev2 = self.servers["remote0"].paths.get_last_revision(self.ref).revision
+        rev2 = self.servers["remote0"].server_store.get_last_revision(self.ref).revision
         # Search with revision1 (only win package available)
         self.client.run("search %s#%s -r remote0" % (str(self.ref), rev1))
         self.assertIn("Existing recipe in remote 'remote0'", self.client.out)
@@ -538,13 +538,13 @@ class HelloConan(ConanFile):
 
         # If I specify rev2 only rev2 is removed
         self.client.run("remove %s#%s -f -r remote0" % (str(ref), rev2))
-        latestrev = self.servers["remote0"].paths.get_last_revision(ref).revision
+        latestrev = self.servers["remote0"].server_store.get_last_revision(ref).revision
         self.assertEquals(latestrev, rev1)
 
         self._upload_two_revisions(ref)
         # If I don't specify revision all the revisions are removed
         self.client.run("remove %s -f -r remote0" % str(ref))
-        latestrev = self.servers["remote0"].paths.get_last_revision(ref)
+        latestrev = self.servers["remote0"].server_store.get_last_revision(ref)
         self.assertIsNone(latestrev)
 
     def test_remove_packages_v2_test(self):
@@ -555,8 +555,8 @@ class HelloConan(ConanFile):
         rev1, rev2 = self._upload_two_revisions(ref)
         full_pr1 = PackageReference(ref.copy_with_rev(rev1), pid)
         full_pr2 = PackageReference(ref.copy_with_rev(rev2), pid)
-        path1 = self.servers["remote0"].paths.package(full_pr1)
-        path2 = self.servers["remote0"].paths.package(full_pr2)
+        path1 = self.servers["remote0"].server_store.package(full_pr1)
+        path2 = self.servers["remote0"].server_store.package(full_pr2)
         self.assertTrue(os.path.exists(path1))
         self.assertTrue(os.path.exists(path2))
 
@@ -573,16 +573,16 @@ class HelloConan(ConanFile):
         # Now generate different package revisions also
         rev1, rev2 = self._upload_two_revisions(ref, different_binary=True)
         full_pr1 = PackageReference(ref.copy_with_rev(rev1), pid)
-        prevs = [el.revision for el in self.servers["remote0"].paths.get_package_revisions(full_pr1)]
+        prevs = [el.revision for el in self.servers["remote0"].server_store.get_package_revisions(full_pr1)]
         self.assertEquals(len(prevs), 1)
         self._upload_two_revisions(ref, different_binary=True)
-        prevs = [el.revision for el in self.servers["remote0"].paths.get_package_revisions(full_pr1)]
+        prevs = [el.revision for el in self.servers["remote0"].server_store.get_package_revisions(full_pr1)]
         self.assertEquals(len(prevs), 2)
 
         # Remove a concrete package reference
         self.client.run("remove %s#%s -f -r remote0 -p %s#%s" % (str(ref), rev1, pid, prevs[0]))
         prevs_now = [el.revision
-                     for el in self.servers["remote0"].paths.get_package_revisions(full_pr1)]
+                     for el in self.servers["remote0"].server_store.get_package_revisions(full_pr1)]
         self.assertEquals(len(prevs_now), 1)
         self.assertEquals(prevs_now[0], prevs[1])
 
@@ -618,7 +618,7 @@ class HelloConan(ConanFile):
 
         # First a pre-check, if I remove only the package for the rev4 the rest is there
         self.client.run("remove %s#%s -f -r remote0" % (ref, rev4))
-        latestrev = self.servers["remote0"].paths.get_last_revision(ref).revision
+        latestrev = self.servers["remote0"].server_store.get_last_revision(ref).revision
         self.assertEquals(latestrev, rev3)
         self.client.run("install %s#%s" % (self.ref, rev3))
 
@@ -653,7 +653,7 @@ class HelloConan(ConanFile):
         client_no_rev.run("create . %s" % str(self.ref))
         client_no_rev.run("upload %s -c --all -r remote0" % str(self.ref))
 
-        rev1 = self.servers["remote0"].paths.get_last_revision(self.ref).revision
+        rev1 = self.servers["remote0"].server_store.get_last_revision(self.ref).revision
         self.assertEquals(rev1, DEFAULT_REVISION_V1)
 
         # An upload from the other client with revisions puts a new revision as latest
@@ -661,7 +661,7 @@ class HelloConan(ConanFile):
         self.client.run("create . %s" % str(self.ref))
         self.client.run("upload %s -c --all -r remote0" % str(self.ref))
 
-        rev1 = self.servers["remote0"].paths.get_last_revision(self.ref).revision
+        rev1 = self.servers["remote0"].server_store.get_last_revision(self.ref).revision
         self.assertNotEquals(rev1, DEFAULT_REVISION_V1)
 
         client_no_rev.run('remove "*" -f')
@@ -675,7 +675,7 @@ class HelloConan(ConanFile):
         client_no_rev.run("create . %s" % str(self.ref))
         client_no_rev.run("upload %s -c --all -r remote0" % str(self.ref))
 
-        rev1 = self.servers["remote0"].paths.get_last_revision(self.ref).revision
+        rev1 = self.servers["remote0"].server_store.get_last_revision(self.ref).revision
         self.assertEquals(rev1, DEFAULT_REVISION_V1)
 
         # Even for the client with revision, now the latest is 0
@@ -897,7 +897,7 @@ class ConanFileToolsTest(ConanFile):
         self.client.run("upload %s -r=remote0 --all" % str(ref))
         rev1 = self.client.get_revision(ref)
         package_ref = PackageReference(ref.copy_with_rev(rev1), NO_SETTINGS_PACKAGE_ID)
-        prev1 = self.client.servers["remote0"].paths.get_last_package_revision(package_ref).revision
+        prev1 = self.client.servers["remote0"].server_store.get_last_package_revision(package_ref).revision
 
         # Use another client to install the only binary revision for ref
         client2 = TestClient(servers=self.servers, users=self.users)
@@ -911,7 +911,7 @@ class ConanFileToolsTest(ConanFile):
         rev1_ = self.client.get_revision(ref)
         self.assertEquals(rev1, rev1_)
         package_ref = PackageReference(ref.copy_with_rev(rev1), NO_SETTINGS_PACKAGE_ID)
-        prev2 = self.client.servers["remote0"].paths.get_last_package_revision(package_ref).revision
+        prev2 = self.client.servers["remote0"].server_store.get_last_package_revision(package_ref).revision
         self.assertNotEqual(prev1, prev2)  # Verify a new package revision is uploaded
 
         # Generate another recipe revision (and also bin revision)
@@ -949,5 +949,5 @@ class HelloConan(ConanFile):
         client.run("install %s" % str(ref))
         package_ref = PackageReference(ref.copy_with_rev(DEFAULT_REVISION_V1),
                                        NO_SETTINGS_PACKAGE_ID)
-        prev2 = client.servers["old_server"].paths.get_last_package_revision(package_ref)
+        prev2 = client.servers["old_server"].server_store.get_last_package_revision(package_ref)
         self.assertEquals(prev2.revision, DEFAULT_REVISION_V1)

--- a/conans/test/integration/settings_override_test.py
+++ b/conans/test/integration/settings_override_test.py
@@ -35,13 +35,13 @@ class SettingsOverrideTest(unittest.TestCase):
         self.assertIn("COMPILER=> VisualBuild Visual Studio", self.client.user_io.out)
 
         # CHECK CONANINFO FILE
-        packs_dir = self.client.paths.packages(ConanFileReference.loads("MinGWBuild/0.1@lasote/testing"))
+        packs_dir = self.client.client_cache.packages(ConanFileReference.loads("MinGWBuild/0.1@lasote/testing"))
         pack_dir = os.path.join(packs_dir, os.listdir(packs_dir)[0])
         conaninfo = load(os.path.join(pack_dir, CONANINFO))
         self.assertIn("compiler=gcc", conaninfo)
 
         # CHECK CONANINFO FILE
-        packs_dir = self.client.paths.packages(ConanFileReference.loads("VisualBuild/0.1@lasote/testing"))
+        packs_dir = self.client.client_cache.packages(ConanFileReference.loads("VisualBuild/0.1@lasote/testing"))
         pack_dir = os.path.join(packs_dir, os.listdir(packs_dir)[0])
         conaninfo = load(os.path.join(pack_dir, CONANINFO))
         self.assertIn("compiler=Visual Studio", conaninfo)

--- a/conans/test/integration/shared_chain_test.py
+++ b/conans/test/integration/shared_chain_test.py
@@ -29,7 +29,7 @@ class SharedChainTest(unittest.TestCase):
         conan.run("install '%s' --build missing" % str(conan_ref))
         conan.run("upload %s --all" % str(conan_ref))
         rmdir(conan.current_folder)
-        shutil.rmtree(conan.paths.store, ignore_errors=True)
+        shutil.rmtree(conan.client_cache.store, ignore_errors=True)
 
     def uploaded_chain_test(self):
         self._export_upload("Hello0", "0.1")

--- a/conans/test/integration/symlinks_test.py
+++ b/conans/test/integration/symlinks_test.py
@@ -43,9 +43,9 @@ Hello/0.1@lasote/stable
 class SymLinksTest(unittest.TestCase):
 
     def _check(self, client, ref, build=True):
-        folders = [client.paths.package(ref), client.current_folder]
+        folders = [client.client_cache.package(ref), client.current_folder]
         if build:
-            folders.append(client.paths.build(ref))
+            folders.append(client.client_cache.build(ref))
         for base in folders:
             filepath = os.path.join(base, "file1.txt")
             link = os.path.join(base, "file1.txt.1")
@@ -57,7 +57,6 @@ class SymLinksTest(unittest.TestCase):
             # Save any different string, random, or the base path
             save(filepath, base)
             self.assertEqual(load(link), base)
-            filepath = os.path.join(base, "version1")
             link = os.path.join(base, "latest")
             self.assertEqual(os.readlink(link), "version1")
             filepath = os.path.join(base, "latest/file2.txt")
@@ -129,9 +128,12 @@ class TestConan(ConanFile):
         package_ref = PackageReference(conan_ref, NO_SETTINGS_PACKAGE_ID)
         team_package_ref = PackageReference(team_ref, NO_SETTINGS_PACKAGE_ID)
 
-        for folder in [client.paths.export(conan_ref), client.paths.source(conan_ref),
-                       client.paths.build(package_ref), client.paths.package(package_ref),
-                       client.paths.export(team_ref), client.paths.package(team_package_ref)]:
+        for folder in [client.client_cache.export(conan_ref),
+                       client.client_cache.source(conan_ref),
+                       client.client_cache.build(package_ref),
+                       client.client_cache.package(package_ref),
+                       client.client_cache.export(team_ref),
+                       client.client_cache.package(team_package_ref)]:
             exported_lib = os.path.join(folder, lib_name)
             exported_link = os.path.join(folder, link_name)
             self.assertEqual(os.readlink(exported_link), lib_name)
@@ -181,7 +183,7 @@ class ConanSymlink(ConanFile):
             os.symlink(symlinked_path, symlink_path)
             client.run("export . danimtb/testing")
             ref = ConanFileReference("ConanSymlink", "3.0.0", "danimtb", "testing")
-            export_sources = client.paths.export_sources(ref)
+            export_sources = client.client_cache.export_sources(ref)
             cache_other_dir = os.path.join(export_sources, "another_other_directory")
             cache_src = os.path.join(export_sources, "src")
             cache_main = os.path.join(cache_src, "main.cpp")
@@ -214,17 +216,17 @@ class ConanSymlink(ConanFile):
         os.symlink(symlinked_path, symlink_path)
         client.run("create . danimtb/testing")
         ref = ConanFileReference("ConanSymlink", "3.0.0", "danimtb", "testing")
-        cache_file = os.path.join(client.paths.export_sources(ref), "another_directory",
+        cache_file = os.path.join(client.client_cache.export_sources(ref), "another_directory",
                                   "not_to_copy.txt")
         self.assertTrue(os.path.exists(cache_file))
-        cache_other_dir = os.path.join(client.paths.export_sources(ref),
+        cache_other_dir = os.path.join(client.client_cache.export_sources(ref),
                                        "another_other_directory")
         self.assertTrue(os.path.exists(cache_other_dir))
         pkg_ref = PackageReference(ref, NO_SETTINGS_PACKAGE_ID)
-        package_file = os.path.join(client.paths.package(pkg_ref), "another_directory",
+        package_file = os.path.join(client.client_cache.package(pkg_ref), "another_directory",
                                     "not_to_copy.txt")
         self.assertFalse(os.path.exists(package_file))
-        package_other_dir = os.path.join(client.paths.package(pkg_ref),
+        package_other_dir = os.path.join(client.client_cache.package(pkg_ref),
                                          "another_other_directory")
         self.assertFalse(os.path.exists(package_other_dir))
         client.save({"conanfile.py": conanfile % "True"})

--- a/conans/test/integration/syncronize_test.py
+++ b/conans/test/integration/syncronize_test.py
@@ -29,7 +29,7 @@ class SynchronizeTest(unittest.TestCase):
         files["to_be_deleted.txt"] = "delete me"
         files["to_be_deleted2.txt"] = "delete me2"
 
-        remote_paths = self.client.servers["default"].paths
+        remote_paths = self.client.servers["default"].server_store
 
         self.client.save(files)
         self.client.run("export . lasote/stable")
@@ -89,7 +89,7 @@ class SynchronizeTest(unittest.TestCase):
 
         self.client.run("install %s --build missing" % str(conan_reference))
         # Upload package
-        package_ids = self.client.paths.conan_packages(conan_reference)
+        package_ids = self.client.client_cache.conan_packages(conan_reference)
         self.client.run("upload %s -p %s" % (str(conan_reference), str(package_ids[0])))
 
         # Check that conans exists on server
@@ -98,7 +98,7 @@ class SynchronizeTest(unittest.TestCase):
         self.assertTrue(os.path.exists(package_server_path))
 
         # Add a new file to package (artificially), upload again and check
-        pack_path = self.client.paths.package(package_reference)
+        pack_path = self.client.client_cache.package(package_reference)
         new_file_source_path = os.path.join(pack_path, "newlib.lib")
         save(new_file_source_path, "newlib")
         os.unlink(os.path.join(pack_path, PACKAGE_TGZ_NAME))  # Force new tgz
@@ -134,6 +134,6 @@ class SynchronizeTest(unittest.TestCase):
 
     def _create_manifest(self, package_reference):
         # Create the manifest to be able to upload the package
-        pack_path = self.client.paths.package(package_reference)
+        pack_path = self.client.client_cache.package(package_reference)
         expected_manifest = FileTreeManifest.create(pack_path)
         expected_manifest.save(pack_path)

--- a/conans/test/integration/system_reqs_test.py
+++ b/conans/test/integration/system_reqs_test.py
@@ -60,35 +60,35 @@ class SystemReqsTest(unittest.TestCase):
         client.run("install Test/0.1@user/testing --build missing")
         self.assertIn("*+Running system requirements+*", client.user_io.out)
         conan_ref = ConanFileReference.loads("Test/0.1@user/testing")
-        self.assertFalse(os.path.exists(client.paths.system_reqs(conan_ref)))
+        self.assertFalse(os.path.exists(client.client_cache.system_reqs(conan_ref)))
         package_ref = PackageReference(conan_ref, "f0ba3ca2c218df4a877080ba99b65834b9413798")
-        load_file = load(client.paths.system_reqs_package(package_ref))
+        load_file = load(client.client_cache.system_reqs_package(package_ref))
         self.assertIn("Installed my stuff", load_file)
 
         # Run again
         client.run("install Test/0.1@user/testing --build missing")
         self.assertNotIn("*+Running system requirements+*", client.user_io.out)
-        self.assertFalse(os.path.exists(client.paths.system_reqs(conan_ref)))
-        load_file = load(client.paths.system_reqs_package(package_ref))
+        self.assertFalse(os.path.exists(client.client_cache.system_reqs(conan_ref)))
+        load_file = load(client.client_cache.system_reqs_package(package_ref))
         self.assertIn("Installed my stuff", load_file)
 
         # Run with different option
         client.run("install Test/0.1@user/testing -o myopt=False --build missing")
         self.assertIn("*+Running system requirements+*", client.user_io.out)
-        self.assertFalse(os.path.exists(client.paths.system_reqs(conan_ref)))
+        self.assertFalse(os.path.exists(client.client_cache.system_reqs(conan_ref)))
         package_ref2 = PackageReference(conan_ref, NO_SETTINGS_PACKAGE_ID)
-        load_file = load(client.paths.system_reqs_package(package_ref2))
+        load_file = load(client.client_cache.system_reqs_package(package_ref2))
         self.assertIn("Installed my stuff", load_file)
 
         # remove packages
         client.run("remove Test* -f -p 544")
-        self.assertTrue(os.path.exists(client.paths.system_reqs_package(package_ref)))
+        self.assertTrue(os.path.exists(client.client_cache.system_reqs_package(package_ref)))
         client.run("remove Test* -f -p f0ba3ca2c218df4a877080ba99b65834b9413798")
-        self.assertFalse(os.path.exists(client.paths.system_reqs_package(package_ref)))
-        self.assertTrue(os.path.exists(client.paths.system_reqs_package(package_ref2)))
+        self.assertFalse(os.path.exists(client.client_cache.system_reqs_package(package_ref)))
+        self.assertTrue(os.path.exists(client.client_cache.system_reqs_package(package_ref2)))
         client.run("remove Test* -f -p %s" % NO_SETTINGS_PACKAGE_ID)
-        self.assertFalse(os.path.exists(client.paths.system_reqs_package(package_ref)))
-        self.assertFalse(os.path.exists(client.paths.system_reqs_package(package_ref2)))
+        self.assertFalse(os.path.exists(client.client_cache.system_reqs_package(package_ref)))
+        self.assertFalse(os.path.exists(client.client_cache.system_reqs_package(package_ref2)))
 
     def global_test(self):
         client = TestClient()
@@ -100,31 +100,31 @@ class SystemReqsTest(unittest.TestCase):
         self.assertIn("*+Running system requirements+*", client.user_io.out)
         conan_ref = ConanFileReference.loads("Test/0.1@user/testing")
         package_ref = PackageReference(conan_ref, "a527106fd9f2e3738a55b02087c20c0a63afce9d")
-        self.assertFalse(os.path.exists(client.paths.system_reqs_package(package_ref)))
-        load_file = load(client.paths.system_reqs(conan_ref))
+        self.assertFalse(os.path.exists(client.client_cache.system_reqs_package(package_ref)))
+        load_file = load(client.client_cache.system_reqs(conan_ref))
         self.assertIn("Installed my stuff", load_file)
 
         # Run again
         client.run("install Test/0.1@user/testing --build missing")
         self.assertNotIn("*+Running system requirements+*", client.user_io.out)
-        self.assertFalse(os.path.exists(client.paths.system_reqs_package(package_ref)))
-        load_file = load(client.paths.system_reqs(conan_ref))
+        self.assertFalse(os.path.exists(client.client_cache.system_reqs_package(package_ref)))
+        load_file = load(client.client_cache.system_reqs(conan_ref))
         self.assertIn("Installed my stuff", load_file)
 
         # Run with different option
         client.run("install Test/0.1@user/testing -o myopt=False --build missing")
         self.assertNotIn("*+Running system requirements+*", client.user_io.out)
         package_ref2 = PackageReference(conan_ref, "54c9626b48cefa3b819e64316b49d3b1e1a78c26")
-        self.assertFalse(os.path.exists(client.paths.system_reqs_package(package_ref)))
-        self.assertFalse(os.path.exists(client.paths.system_reqs_package(package_ref2)))
-        load_file = load(client.paths.system_reqs(conan_ref))
+        self.assertFalse(os.path.exists(client.client_cache.system_reqs_package(package_ref)))
+        self.assertFalse(os.path.exists(client.client_cache.system_reqs_package(package_ref2)))
+        load_file = load(client.client_cache.system_reqs(conan_ref))
         self.assertIn("Installed my stuff", load_file)
 
         # remove packages
         client.run("remove Test* -f -p")
-        self.assertFalse(os.path.exists(client.paths.system_reqs_package(package_ref)))
-        self.assertFalse(os.path.exists(client.paths.system_reqs_package(package_ref2)))
-        self.assertFalse(os.path.exists(client.paths.system_reqs(conan_ref)))
+        self.assertFalse(os.path.exists(client.client_cache.system_reqs_package(package_ref)))
+        self.assertFalse(os.path.exists(client.client_cache.system_reqs_package(package_ref2)))
+        self.assertFalse(os.path.exists(client.client_cache.system_reqs(conan_ref)))
 
     def wrong_output_test(self):
         client = TestClient()
@@ -135,7 +135,7 @@ class SystemReqsTest(unittest.TestCase):
         client.run("install Test/0.1@user/testing --build missing")
         self.assertIn("*+Running system requirements+*", client.user_io.out)
         conan_ref = ConanFileReference.loads("Test/0.1@user/testing")
-        self.assertFalse(os.path.exists(client.paths.system_reqs(conan_ref)))
+        self.assertFalse(os.path.exists(client.client_cache.system_reqs(conan_ref)))
         package_ref = PackageReference(conan_ref, "f0ba3ca2c218df4a877080ba99b65834b9413798")
-        load_file = load(client.paths.system_reqs_package(package_ref))
+        load_file = load(client.client_cache.system_reqs_package(package_ref))
         self.assertEqual('', load_file)

--- a/conans/test/integration/upload_test.py
+++ b/conans/test/integration/upload_test.py
@@ -77,10 +77,10 @@ class CompleteFlowTest(unittest.TestCase):
         self.assertNotIn("Compressing recipe", str(self.client.user_io.out))
 
         # Check that conans exists on server
-        server_paths = self.servers["default"].paths
+        server_paths = self.servers["default"].server_store
         conan_path = server_paths.export(conan_reference)
         self.assertTrue(os.path.exists(conan_path))
-        package_ids = self.client.paths.conan_packages(conan_reference)
+        package_ids = self.client.client_cache.conan_packages(conan_reference)
         package_ref = PackageReference(conan_reference, package_ids[0])
 
         # Upload package

--- a/conans/test/unittests/client/cmd/export_test.py
+++ b/conans/test/unittests/client/cmd/export_test.py
@@ -104,7 +104,7 @@ class TestConan(ConanFile):
         client.run("upload test/1.0@danimtb/testing -r upload_repo")
         self.assertIn("Uploading conan_sources.tgz", client.out)
         conan_ref = ConanFileReference("test", "1.0", "danimtb", "testing")
-        export_sources_path = os.path.join(servers["upload_repo"].paths.export(conan_ref),
+        export_sources_path = os.path.join(servers["upload_repo"].server_store.export(conan_ref),
                                            "conan_sources.tgz")
         self.assertTrue(os.path.exists(export_sources_path))
 
@@ -125,6 +125,6 @@ class TestConan(ConanFile):
         self.assertIn("Repo origin deduced by 'auto': https://github.com/fake/fake.git", client.out)
         client.run("upload test/1.0@danimtb/testing -r upload_repo")
         self.assertNotIn("Uploading conan_sources.tgz", client.out)
-        export_sources_path = os.path.join(servers["upload_repo"].paths.export(conan_ref),
+        export_sources_path = os.path.join(servers["upload_repo"].server_store.export(conan_ref),
                                            "conan_sources.tgz")
         self.assertFalse(os.path.exists(export_sources_path))

--- a/conans/test/unittests/model/other_settings_test.py
+++ b/conans/test/unittests/model/other_settings_test.py
@@ -17,8 +17,8 @@ class SettingsTest(unittest.TestCase):
         subsystem: [None, msys]
 """
         client = TestClient()
-        save(client.paths.settings_path, settings)
-        save(client.paths.default_profile_path, "")
+        save(client.client_cache.settings_path, settings)
+        save(client.client_cache.default_profile_path, "")
         conanfile = """from conans import ConanFile
 class Pkg(ConanFile):
     settings = "os", "compiler"
@@ -35,8 +35,8 @@ class Pkg(ConanFile):
 cppstd: [None, 98, gnu98, 11, gnu11, 14, gnu14, 17, gnu17, 20, gnu20]
 """
         client = TestClient()
-        save(client.paths.settings_path, settings)
-        save(client.paths.default_profile_path, """[settings]
+        save(client.client_cache.settings_path, settings)
+        save(client.client_cache.default_profile_path, """[settings]
 compiler=mycomp
 compiler.version=2.3
 cppstd=11
@@ -65,8 +65,8 @@ cppstd=11""", client.out)
 compiler: [gcc, visual]
 """
         client = TestClient()
-        save(client.paths.settings_path, settings)
-        save(client.paths.default_profile_path, "")
+        save(client.client_cache.settings_path, settings)
+        save(client.client_cache.default_profile_path, "")
         conanfile = """from conans import ConanFile
 class Pkg(ConanFile):
     settings = "os", "compiler"
@@ -78,7 +78,7 @@ class Pkg(ConanFile):
         self.assertNotIn("os: None", client.out)
         package_reference = PackageReference.loads("Pkg/0.1@lasote/testing:"
                                                    "544c1d8c53e9d269737e68e00ec66716171d2704")
-        info_path = os.path.join(client.paths.package(package_reference), CONANINFO)
+        info_path = os.path.join(client.client_cache.package(package_reference), CONANINFO)
         info = load(info_path)
         self.assertNotIn("os", info)
         # Explicitly specifying None, put it in the conaninfo.txt, but does not affect the hash
@@ -134,7 +134,7 @@ compiler:
         client = TestClient()
         client.save(files)
         client.run("export . lasote/testing")
-        save(client.paths.settings_path, prev_settings)
+        save(client.client_cache.settings_path, prev_settings)
         client.client_cache.default_profile  # Generate the default
         conf = load(client.client_cache.default_profile_path)
         conf = conf.replace("build_type=Release", "")
@@ -154,7 +154,7 @@ compiler:
         client.run("install test/1.9@lasote/testing --build -s arch=x86_64 -s compiler=gcc "
                    "-s compiler.version=4.9 -s os=Windows -s build_type=None -s "
                    "compiler.libcxx=libstdc++")
-        self.assertIn("build_type", load(client.paths.settings_path))
+        self.assertIn("build_type", load(client.client_cache.settings_path))
         self.assertIn("390146894f59dda18c902ee25e649ef590140732", client.user_io.out)
 
     def settings_constraint_error_type_test(self):
@@ -257,9 +257,9 @@ class SayConan(ConanFile):
         '''Test wrong values and wrong constraints'''
         client = TestClient()
         client.client_cache.default_profile
-        default_conf = load(client.paths.default_profile_path)
+        default_conf = load(client.client_cache.default_profile_path)
         new_conf = default_conf.replace("\nos=", "\n# os=")
-        save(client.paths.default_profile_path, new_conf)
+        save(client.client_cache.default_profile_path, new_conf)
         # MISSING VALUE FOR A SETTING
         content = """
 from conans import ConanFile
@@ -343,11 +343,11 @@ class SayConan(ConanFile):
                       str(client.user_io.out))
 
         # Now add new settings to config and try again
-        config = load(client.paths.settings_path)
+        config = load(client.client_cache.settings_path)
         config = config.replace("Windows:%s" % os.linesep,
                                 "Windows:%s    ChromeOS:%s" % (os.linesep, os.linesep))
 
-        save(client.paths.settings_path, config)
+        save(client.client_cache.settings_path, config)
         client.run("install . -s os=ChromeOS --build missing")
         self.assertIn('Generated conaninfo.txt', str(client.user_io.out))
 

--- a/conans/test/unittests/util/xz_test.py
+++ b/conans/test/unittests/util/xz_test.py
@@ -22,8 +22,8 @@ class XZTest(TestCase):
         server = TestServer()
         ref = ConanFileReference.loads("Pkg/0.1@user/channel")
         ref = ref.copy_with_rev(DEFAULT_REVISION_V1)
-        export = server.paths.export(ref)
-        server.paths.update_last_revision(ref)
+        export = server.server_store.export(ref)
+        server.server_store.update_last_revision(ref)
         save_files(export, {"conanfile.py": "#",
                             "conanmanifest.txt": "#",
                             "conan_export.txz": "#"})
@@ -39,8 +39,8 @@ class XZTest(TestCase):
         ref = ref.copy_with_rev(DEFAULT_REVISION_V1)
         client = TestClient(servers={"default": server},
                             users={"default": [("lasote", "mypass")]})
-        server.paths.update_last_revision(ref)
-        export = server.paths.export(ref)
+        server.server_store.update_last_revision(ref)
+        export = server.server_store.export(ref)
         conanfile = """from conans import ConanFile
 class Pkg(ConanFile):
     exports_sources = "*"
@@ -58,8 +58,8 @@ class Pkg(ConanFile):
         ref = ref.copy_with_rev(DEFAULT_REVISION_V1)
         client = TestClient(servers={"default": server},
                             users={"default": [("lasote", "mypass")]})
-        server.paths.update_last_revision(ref)
-        export = server.paths.export(ref)  # *1 the path can't be known before upload a revision
+        server.server_store.update_last_revision(ref)
+        export = server.server_store.export(ref)  # *1 the path can't be known before upload a revision
         conanfile = """from conans import ConanFile
 class Pkg(ConanFile):
     exports_sources = "*"
@@ -67,10 +67,10 @@ class Pkg(ConanFile):
         save_files(export, {"conanfile.py": conanfile,
                             "conanmanifest.txt": "1"})
         pkg_ref = PackageReference(ref, NO_SETTINGS_PACKAGE_ID)
-        server.paths.update_last_package_revision(pkg_ref.copy_with_revs(DEFAULT_REVISION_V1,
+        server.server_store.update_last_package_revision(pkg_ref.copy_with_revs(DEFAULT_REVISION_V1,
                                                                          DEFAULT_REVISION_V1))
 
-        package = server.paths.package(pkg_ref)
+        package = server.server_store.package(pkg_ref)
         save_files(package, {"conaninfo.txt": "#",
                              "conanmanifest.txt": "1",
                              "conan_package.txz": "#"})

--- a/conans/test/utils/tools.py
+++ b/conans/test/utils/tools.py
@@ -264,7 +264,7 @@ class TestServer(object):
         self.app = TestApp(self.test_server.ra.root_app)
 
     @property
-    def paths(self):
+    def server_store(self):
         return self.test_server.server_store
 
     def __repr__(self):
@@ -533,10 +533,6 @@ servers["r2"] = TestServer()
     @property
     def remote_registry(self):
         return RemoteRegistry(self.client_cache.registry, TestBufferConanOutput())
-
-    @property
-    def paths(self):
-        return self.client_cache
 
     @property
     def default_compiler_visual_studio(self):


### PR DESCRIPTION
Changelog: omit

If `TestClient.paths` returns the member `client_cache` call it properly; same for `TestServer.paths` that returns `server_store` member.

@TAGS: svn, slow
