### PR TITLE
Try to fix random Linux makefile test suite errores

### DIFF
--- a/conans/test/functional/generators/make_test.py
+++ b/conans/test/functional/generators/make_test.py
@@ -109,7 +109,7 @@ $(SHARED_LIB_FILENAME)  :   $(CXX_OBJ_FILES)
 $(STATIC_LIB_FILENAME)  :   $(CXX_OBJ_FILES)
 	$(CREATE_STATIC_LIB_COMMAND)
 
-%.o                     :   $(CXX_SRCS)
+$(CXX_OBJ_FILES)        :   $(CXX_SRCS)
 	$(COMPILE_CXX_COMMAND)
 """
         conanfile = """
@@ -210,7 +210,7 @@ exe                     :   $(EXE_FILENAME)
 $(EXE_FILENAME)         :   $(CXX_OBJ_FILES)
 	$(CREATE_EXE_COMMAND)
 
-%.o                     :   $(CXX_SRCS)
+$(CXX_OBJ_FILES)        :   $(CXX_SRCS)
 	$(COMPILE_CXX_COMMAND)
 """
         conanfile_txt = """


### PR DESCRIPTION
Changelog: omit

Apparently `make` can match the rule `%.o ` when tries to generate (don't know why) a Makefile, so it tries to create a senseless `Makefile.o`. With this modification, the rule will only match the `.o` of the test.