### PR TITLE
Fix/cpu count 1 default

### DIFF
--- a/conans/test/functional/command/export_test.py
+++ b/conans/test/functional/command/export_test.py
@@ -338,8 +338,8 @@ class OpenSSLConan(ConanFile):
     def test_export_the_same_code(self):
         file_list = self._create_packages_and_builds()
         # Export the same conans
-
-        conan2 = TestClient(self.conan.base_folder)
+        # Do not adjust cpu_count, it is reusing a cache
+        conan2 = TestClient(self.conan.base_folder, cpu_count=False)
         files2 = cpp_hello_conan_files("Hello0", "0.1")
         conan2.save(files2)
         conan2.run("export . lasote/stable")
@@ -373,7 +373,8 @@ class OpenSSLConan(ConanFile):
         self._create_packages_and_builds()
         # Export an update of the same conans
 
-        conan2 = TestClient(self.conan.base_folder)
+        # Do not adjust cpu_count, it is reusing a cache
+        conan2 = TestClient(self.conan.base_folder, cpu_count=False)
         files2 = cpp_hello_conan_files("Hello0", "0.1")
         files2[CONANFILE] = "# insert comment\n %s" % files2[CONANFILE]
         conan2.save(files2)

--- a/conans/test/functional/command/install_test.py
+++ b/conans/test/functional/command/install_test.py
@@ -312,7 +312,8 @@ class Pkg(ConanFile):
     def change_option_txt_test(self):
         self._create("Hello0", "0.1")
 
-        client = TestClient(base_folder=self.client.base_folder)
+        # Do not adjust cpu_count, it is reusing a cache
+        client = TestClient(base_folder=self.client.base_folder, cpu_count=False)
         files = {CONANFILE_TXT: """[requires]
         Hello0/0.1@lasote/stable
 

--- a/conans/test/functional/old/conanfile_extend_test.py
+++ b/conans/test/functional/old/conanfile_extend_test.py
@@ -69,7 +69,8 @@ class DevConanFile(HelloConan2):
         files = {"conanfile.py": base,
                  "conanfile_dev.py": extension}
 
-        client = TestClient(self.base_folder)
+        # Do not adjust cpu_count, it is reusing a cache
+        client = TestClient(self.base_folder, cpu_count=False)
         client.save(files)
         client.run("install . --build")
         conaninfo = load(os.path.join(client.current_folder, "conaninfo.txt"))
@@ -127,7 +128,8 @@ class ConanFileToolsTest(ConanBase):
     '''
         files = {"base_conan.py": base,
                  "conanfile.py": extension}
-        client = TestClient(self.base_folder)
+        # Do not adjust cpu_count, it is reusing a cache
+        client = TestClient(self.base_folder, cpu_count=False)
 
         client.save(files)
         client.run("create . conan/testing -o test:test_option=3 --build")
@@ -155,7 +157,8 @@ otherlib:otherlib_option = 1
         files = {"conanfile.txt": base,
                  "conanfile_dev.txt": extension}
 
-        client = TestClient(self.base_folder)
+        # Do not adjust cpu_count, it is reusing a cache
+        client = TestClient(self.base_folder, cpu_count=False)
         client.save(files)
         client.run("install . --build")
         conaninfo = load(os.path.join(client.current_folder, "conaninfo.txt"))

--- a/conans/test/functional/old/test_migrations.py
+++ b/conans/test/functional/old/test_migrations.py
@@ -81,7 +81,8 @@ the old general
                                                         "attribute_checker.py")
             save(old_conf_path, "\n[plugins]    # CONAN_PLUGINS\nattribute_checker")
             save(old_attribute_checker_plugin, "")
-            client_cache = TestClient(base_folder=old_user_home).client_cache
+            # Do not adjust cpu_count, it is reusing a cache
+            client_cache = TestClient(base_folder=old_user_home, cpu_count=False).client_cache
             assert old_conan_folder == client_cache.conan_folder
             return old_user_home, old_conan_folder, old_conf_path, old_attribute_checker_plugin,\
                    client_cache

--- a/conans/test/integration/basic_build_test.py
+++ b/conans/test/integration/basic_build_test.py
@@ -32,7 +32,7 @@ class BasicBuildTest(unittest.TestCase):
 
 
 def build(tester, cmd, static, pure_c, use_cmake, lang):
-    client = TestClient(cpu_count=1)
+    client = TestClient()
     dll_export = client.default_compiler_visual_studio and not static
     files = cpp_hello_conan_files("Hello0", "0.1", dll_export=dll_export,
                                   pure_c=pure_c, use_cmake=use_cmake)

--- a/conans/test/integration/diamond_test.py
+++ b/conans/test/integration/diamond_test.py
@@ -20,18 +20,16 @@ class DiamondTest(unittest.TestCase):
         self.servers = {"default": test_server}
 
     def diamond_cmake_test(self):
-        self.client = TestClient(servers=self.servers, users={"default": [("lasote", "mypass")]},
-                                 cpu_count=1)
+        self.client = TestClient(servers=self.servers, users={"default": [("lasote", "mypass")]})
         self._run(use_cmake=True, language=1)
 
     def diamond_cmake_targets_test(self):
-        self.client = TestClient(servers=self.servers, users={"default": [("lasote", "mypass")]},
-                                 cpu_count=1)
+        self.client = TestClient(servers=self.servers, users={"default": [("lasote", "mypass")]})
         self._run(use_cmake=True, cmake_targets=True)
 
     def diamond_default_test(self):
         self.client = TestClient(servers=self.servers, users={"default": [("lasote", "mypass")]},
-                                 path_with_spaces=False, cpu_count=1)
+                                 path_with_spaces=False)
         self._run(use_cmake=False)
 
     def _export(self, name, version=None, deps=None, use_cmake=True, cmake_targets=False):

--- a/conans/test/integration/manifest_validation_test.py
+++ b/conans/test/integration/manifest_validation_test.py
@@ -126,7 +126,8 @@ class ConanFileTest(ConanFile):
     name = "Hello2"
     version = "0.1"
 """
-        client = TestClient(base_folder=self.client.base_folder)
+        # Do not adjust cpu_count, it is reusing a cache
+        client = TestClient(base_folder=self.client.base_folder, cpu_count=False)
         client.save({CONANFILE: conanfile})
         client.run("export . lasote/stable")
 

--- a/conans/test/utils/tools.py
+++ b/conans/test/utils/tools.py
@@ -483,7 +483,7 @@ class TestClient(object):
         if cpu_count:
             self.client_cache.conan_config
             replace_in_file(os.path.join(self.client_cache.conan_conf_path),
-                            "# cpu_count = 1", "cpu_count = %s" % cpu_count)
+                            "# cpu_count = 1", "cpu_count = %s" % cpu_count, strict=False)
             # Invalidate the cached config
             self.client_cache.invalidate()
         if self.revisions:

--- a/conans/test/utils/tools.py
+++ b/conans/test/utils/tools.py
@@ -483,7 +483,7 @@ class TestClient(object):
         if cpu_count:
             self.client_cache.conan_config
             replace_in_file(os.path.join(self.client_cache.conan_conf_path),
-                            "# cpu_count = 1", "cpu_count = %s" % cpu_count, strict=False)
+                            "# cpu_count = 1", "cpu_count = %s" % cpu_count)
             # Invalidate the cached config
             self.client_cache.invalidate()
         if self.revisions:

--- a/conans/test/utils/tools.py
+++ b/conans/test/utils/tools.py
@@ -447,7 +447,7 @@ class TestClient(object):
                  servers=None, users=None, client_version=CLIENT_VERSION,
                  min_server_compatible_version=MIN_SERVER_COMPATIBLE_VERSION,
                  requester_class=None, runner=None, path_with_spaces=True,
-                 block_v2=None, revisions=None, cpu_count=None):
+                 block_v2=None, revisions=None, cpu_count=1):
         """
         storage_folder: Local storage path
         current_folder: Current execution folder


### PR DESCRIPTION
Changelog: omit

Default cpu_count=1 on testing. Several tests on windows failing with weird msbuild issues.
To check:

- Green status, of course
- Time measurement (really slower?)