### PR TITLE
 Store verify_ssl argument in config install

### DIFF
--- a/conans/client/conf/config_installer.py
+++ b/conans/client/conf/config_installer.py
@@ -111,7 +111,6 @@ def _process_download(item, client_cache, output, tmp_folder, verify_ssl, reques
 
 def configuration_install(path_or_url, client_cache, output, verify_ssl, requester,
                           config_type=None, args=None):
-    print(type(verify_ssl), verify_ssl)
     if path_or_url is None:
         try:
             item = client_cache.conan_config.get_item("general.config_install")
@@ -151,7 +150,7 @@ def configuration_install(path_or_url, client_cache, output, verify_ssl, request
             raise ConanException("Unable to process config install: %s" % path_or_url)
     finally:
         if config_type is not None and path_or_url is not None:
-            value = "%s:[%s, %s, %s]" % (config_type, path_or_url, verify_ssl, args)
+            value = "%s, %s, %s, %s" % (config_type, path_or_url, verify_ssl, args)
             client_cache.conan_config.set_item("general.config_install", value)
         rmdir(tmp_folder)
 
@@ -167,7 +166,7 @@ def _process_config_install_item(item):
     additional arguments
     """
     config_type, path_or_url, verify_ssl, args = None, None, None, None
-    if not item.startswith(("git:", "dir:", "url:", "file:")):
+    if not item.startswith(("git,", "dir,", "url,", "file,")):
         path_or_url = item
         if path_or_url.endswith(".git"):
             config_type = "git"
@@ -180,8 +179,7 @@ def _process_config_install_item(item):
         else:
             raise ConanException("Unable to process config install: %s" % path_or_url)
     else:
-        config_type, rest = item.split(":", 1)
-        path_or_url, verify_ssl, args = [item.strip() for item in rest[1:-1].rstrip().split(",", 2)]
+        config_type, path_or_url, verify_ssl, args = [r.strip() for r in item.split(",")]
         verify_ssl = "true" in verify_ssl.lower()
         args = None if "none" in args.lower() else args
     return config_type, path_or_url, verify_ssl, args

--- a/conans/test/functional/command/config_install_test.py
+++ b/conans/test/functional/command/config_install_test.py
@@ -180,7 +180,7 @@ class Pkg(ConanFile):
         """
         zippath = self._create_zip()
         self.client.run('config install "%s"' % zippath)
-        self._check("file:[%s, None]" % zippath)
+        self._check("file:[%s, True, None]" % zippath)
         self.assertTrue(os.path.exists(zippath))
 
     def install_dir_test(self):
@@ -189,7 +189,7 @@ class Pkg(ConanFile):
         folder = self._create_profile_folder()
         self.assertTrue(os.path.isdir(folder))
         self.client.run('config install "%s"' % folder)
-        self._check("dir:[%s, None]" % folder)
+        self._check("dir:[%s, True, None]" % folder)
 
     def test_without_profile_folder(self):
         shutil.rmtree(self.client.client_cache.profiles_path)
@@ -209,11 +209,11 @@ class Pkg(ConanFile):
 
         with patch.object(Downloader, 'download', new=my_download):
             self.client.run("config install http://myfakeurl.com/myconf.zip")
-            self._check("url:[http://myfakeurl.com/myconf.zip, None]")
+            self._check("url:[http://myfakeurl.com/myconf.zip, True, None]")
 
             # repeat the process to check
             self.client.run("config install http://myfakeurl.com/myconf.zip")
-            self._check("url:[http://myfakeurl.com/myconf.zip, None]")
+            self._check("url:[http://myfakeurl.com/myconf.zip, True, None]")
 
     def failed_install_repo_test(self):
         """ should install from a git repo
@@ -242,7 +242,7 @@ class Pkg(ConanFile):
 
         self.client.run('config install "%s/.git"' % folder)
         check_path = os.path.join(folder, ".git")
-        self._check("git:[%s, None]" % check_path)
+        self._check("git:[%s, True, None]" % check_path)
 
     def install_repo_relative_test(self):
         relative_folder = "./config"
@@ -257,7 +257,7 @@ class Pkg(ConanFile):
             self.client.runner('git commit -m "mymsg"')
 
         self.client.run('config install "%s/.git"' % relative_folder)
-        self._check("git:[%s, None]" % os.path.join("%s" % folder, ".git"))
+        self._check("git:[%s, True, None]" % os.path.join("%s" % folder, ".git"))
 
     def install_custom_args_test(self):
         """ should install from a git repo
@@ -273,7 +273,7 @@ class Pkg(ConanFile):
 
         self.client.run('config install "%s/.git" --args="-c init.templateDir=value"' % folder)
         check_path = os.path.join(folder, ".git")
-        self._check("git:[%s, -c init.templateDir=value]" % check_path)
+        self._check("git:[%s, True, -c init.templateDir=value]" % check_path)
 
     def force_git_type_test(self):
         client = TestClient()
@@ -286,7 +286,7 @@ class Pkg(ConanFile):
         zippath = self._create_zip()
         self.client.run('config set general.config_install="%s"' % zippath)
         self.client.run("config install")
-        self._check("file:[%s, None]" % zippath)
+        self._check("file:[%s, True, None]" % zippath)
 
     def reinstall_error_test(self):
         """ should use configured URL in conan.conf
@@ -343,7 +343,7 @@ class Pkg(ConanFile):
             self.assertIn(fake_url_hidden_password, self.client.out)
 
             # Check credentials still stored in configuration
-            self._check("url:[%s, None]" % fake_url_with_credentials)
+            self._check("url:[%s, True, None]" % fake_url_with_credentials)
 
     def ssl_verify_test(self):
         fake_url = "https://fakeurl.com/myconf.zip"
@@ -380,18 +380,18 @@ class Pkg(ConanFile):
         # Without checkout
         self.client.run('config install "%s/.git"' % folder)
         check_path = os.path.join(folder, ".git")
-        self._check("git:[%s, None]" % check_path)
+        self._check("git:[%s, True, None]" % check_path)
         file_path = os.path.join(self.client.client_cache.conan_folder, "hooks", "cust", "cust.py")
         self.assertFalse(os.path.exists(file_path))
         # With checkout tag and reuse url
         self.client.run('config install --args="-b 0.0.1"')
         check_path = os.path.join(folder, ".git")
-        self._check("git:[%s, -b 0.0.1]" % check_path)
+        self._check("git:[%s, True, -b 0.0.1]" % check_path)
         self.assertTrue(os.path.exists(file_path))
         # With checkout branch and reuse url
         self.client.run('config install --args="-b other_branch"')
         check_path = os.path.join(folder, ".git")
-        self._check("git:[%s, -b other_branch]" % check_path)
+        self._check("git:[%s, True, -b other_branch]" % check_path)
         self.assertTrue(os.path.exists(file_path))
         # Add changes to that branch and update
         with tools.chdir(folder):
@@ -405,5 +405,5 @@ class Pkg(ConanFile):
         self.assertFalse(os.path.exists(other_path))
         self.client.run('config install')
         check_path = os.path.join(folder, ".git")
-        self._check("git:[%s, -b other_branch]" % check_path)
+        self._check("git:[%s, True, -b other_branch]" % check_path)
         self.assertTrue(os.path.exists(other_path))

--- a/conans/test/functional/command/config_install_test.py
+++ b/conans/test/functional/command/config_install_test.py
@@ -180,7 +180,7 @@ class Pkg(ConanFile):
         """
         zippath = self._create_zip()
         self.client.run('config install "%s"' % zippath)
-        self._check("file:[%s, True, None]" % zippath)
+        self._check("file, %s, True, None" % zippath)
         self.assertTrue(os.path.exists(zippath))
 
     def install_dir_test(self):
@@ -189,7 +189,7 @@ class Pkg(ConanFile):
         folder = self._create_profile_folder()
         self.assertTrue(os.path.isdir(folder))
         self.client.run('config install "%s"' % folder)
-        self._check("dir:[%s, True, None]" % folder)
+        self._check("dir, %s, True, None" % folder)
 
     def test_without_profile_folder(self):
         shutil.rmtree(self.client.client_cache.profiles_path)
@@ -209,11 +209,11 @@ class Pkg(ConanFile):
 
         with patch.object(Downloader, 'download', new=my_download):
             self.client.run("config install http://myfakeurl.com/myconf.zip")
-            self._check("url:[http://myfakeurl.com/myconf.zip, True, None]")
+            self._check("url, http://myfakeurl.com/myconf.zip, True, None")
 
             # repeat the process to check
             self.client.run("config install http://myfakeurl.com/myconf.zip")
-            self._check("url:[http://myfakeurl.com/myconf.zip, True, None]")
+            self._check("url, http://myfakeurl.com/myconf.zip, True, None")
 
     def failed_install_repo_test(self):
         """ should install from a git repo
@@ -242,7 +242,7 @@ class Pkg(ConanFile):
 
         self.client.run('config install "%s/.git"' % folder)
         check_path = os.path.join(folder, ".git")
-        self._check("git:[%s, True, None]" % check_path)
+        self._check("git, %s, True, None" % check_path)
 
     def install_repo_relative_test(self):
         relative_folder = "./config"
@@ -257,7 +257,7 @@ class Pkg(ConanFile):
             self.client.runner('git commit -m "mymsg"')
 
         self.client.run('config install "%s/.git"' % relative_folder)
-        self._check("git:[%s, True, None]" % os.path.join("%s" % folder, ".git"))
+        self._check("git, %s, True, None" % os.path.join("%s" % folder, ".git"))
 
     def install_custom_args_test(self):
         """ should install from a git repo
@@ -273,7 +273,7 @@ class Pkg(ConanFile):
 
         self.client.run('config install "%s/.git" --args="-c init.templateDir=value"' % folder)
         check_path = os.path.join(folder, ".git")
-        self._check("git:[%s, True, -c init.templateDir=value]" % check_path)
+        self._check("git, %s, True, -c init.templateDir=value" % check_path)
 
     def force_git_type_test(self):
         client = TestClient()
@@ -286,7 +286,7 @@ class Pkg(ConanFile):
         zippath = self._create_zip()
         self.client.run('config set general.config_install="%s"' % zippath)
         self.client.run("config install")
-        self._check("file:[%s, True, None]" % zippath)
+        self._check("file, %s, True, None" % zippath)
 
     def reinstall_error_test(self):
         """ should use configured URL in conan.conf
@@ -343,7 +343,7 @@ class Pkg(ConanFile):
             self.assertIn(fake_url_hidden_password, self.client.out)
 
             # Check credentials still stored in configuration
-            self._check("url:[%s, True, None]" % fake_url_with_credentials)
+            self._check("url, %s, True, None" % fake_url_with_credentials)
 
     def ssl_verify_test(self):
         fake_url = "https://fakeurl.com/myconf.zip"
@@ -380,18 +380,18 @@ class Pkg(ConanFile):
         # Without checkout
         self.client.run('config install "%s/.git"' % folder)
         check_path = os.path.join(folder, ".git")
-        self._check("git:[%s, True, None]" % check_path)
+        self._check("git, %s, True, None" % check_path)
         file_path = os.path.join(self.client.client_cache.conan_folder, "hooks", "cust", "cust.py")
         self.assertFalse(os.path.exists(file_path))
         # With checkout tag and reuse url
         self.client.run('config install --args="-b 0.0.1"')
         check_path = os.path.join(folder, ".git")
-        self._check("git:[%s, True, -b 0.0.1]" % check_path)
+        self._check("git, %s, True, -b 0.0.1" % check_path)
         self.assertTrue(os.path.exists(file_path))
         # With checkout branch and reuse url
         self.client.run('config install --args="-b other_branch"')
         check_path = os.path.join(folder, ".git")
-        self._check("git:[%s, True, -b other_branch]" % check_path)
+        self._check("git, %s, True, -b other_branch" % check_path)
         self.assertTrue(os.path.exists(file_path))
         # Add changes to that branch and update
         with tools.chdir(folder):
@@ -405,5 +405,5 @@ class Pkg(ConanFile):
         self.assertFalse(os.path.exists(other_path))
         self.client.run('config install')
         check_path = os.path.join(folder, ".git")
-        self._check("git:[%s, True, -b other_branch]" % check_path)
+        self._check("git, %s, True, -b other_branch" % check_path)
         self.assertTrue(os.path.exists(other_path))

--- a/conans/test/unittests/client/conf/config_installer_test.py
+++ b/conans/test/unittests/client/conf/config_installer_test.py
@@ -62,5 +62,5 @@ class ConfigInstallerTests(unittest.TestCase):
         # Test wrong input
         for item in ["git@github.com:conan-io/conan.git, None"
                      "file/not/exists.zip"]:
-            with self.assertRaisesRegex(ConanException, "Unable to process config install"):
+            with self.assertRaisesRegexp(ConanException, "Unable to process config install"):
                 _, _, _, _ = _process_config_install_item(item)

--- a/conans/test/unittests/client/conf/config_installer_test.py
+++ b/conans/test/unittests/client/conf/config_installer_test.py
@@ -21,7 +21,7 @@ class ConfigInstallerTests(unittest.TestCase):
         config_type, url_or_path, verify_ssl, args = _process_config_install_item("whaterver.url.com/repo.git")
         self.assertEqual("git", config_type)
         self.assertEqual("whaterver.url.com/repo.git", url_or_path)
-        self.assertTrue(verify_ssl)
+        self.assertIsNone(verify_ssl)
         self.assertIsNone(args)
 
         dir_path = temp_folder()
@@ -29,7 +29,8 @@ class ConfigInstallerTests(unittest.TestCase):
             config_type, url_or_path, verify_ssl, args = _process_config_install_item(dir_item)
             self.assertEqual("dir", config_type)
             self.assertEqual(dir_path, url_or_path)
-            self.assertTrue(verify_ssl)
+            self.assertTrue(verify_ssl) if dir_item.startswith("dir:")\
+                else self.assertIsNone(verify_ssl)
             self.assertIsNone(args)
 
         file_path = os.path.join(dir_path, "file.zip")
@@ -38,7 +39,8 @@ class ConfigInstallerTests(unittest.TestCase):
             config_type, url_or_path, verify_ssl, args = _process_config_install_item(file_item)
             self.assertEqual("file", config_type)
             self.assertEqual(file_path, url_or_path)
-            self.assertTrue(verify_ssl)
+            self.assertTrue(verify_ssl) if file_item.startswith("file:") \
+                else self.assertIsNone(verify_ssl)
             self.assertIsNone(args)
 
         for url_item in ["url:[http://is/an/absloute/path with spaces/here/file.zip, True, None]",
@@ -46,7 +48,8 @@ class ConfigInstallerTests(unittest.TestCase):
             config_type, url_or_path, verify_ssl, args = _process_config_install_item(url_item)
             self.assertEqual("url", config_type)
             self.assertEqual("http://is/an/absloute/path with spaces/here/file.zip", url_or_path)
-            self.assertTrue(verify_ssl)
+            self.assertTrue(verify_ssl) if url_item.startswith("url:") \
+                else self.assertIsNone(verify_ssl)
             self.assertIsNone(args)
 
         config_type, url, verify_ssl, args = _process_config_install_item(

--- a/conans/test/unittests/client/conf/config_installer_test.py
+++ b/conans/test/unittests/client/conf/config_installer_test.py
@@ -12,7 +12,7 @@ class ConfigInstallerTests(unittest.TestCase):
 
     def process_config_install_item_test(self):
         config_type, url_or_path, verify_ssl, args = _process_config_install_item(
-                "git:[whaterver.url.com/repo.git, False, --recusrive --other -b 0.3.4]")
+                "git, whaterver.url.com/repo.git, False, --recusrive --other -b 0.3.4")
         self.assertEqual("git", config_type)
         self.assertEqual("whaterver.url.com/repo.git", url_or_path)
         self.assertFalse(verify_ssl)
@@ -25,35 +25,35 @@ class ConfigInstallerTests(unittest.TestCase):
         self.assertIsNone(args)
 
         dir_path = temp_folder()
-        for dir_item in ["dir:[%s, True, None]" % dir_path, dir_path]:
+        for dir_item in ["dir, %s, True, None" % dir_path, dir_path]:
             config_type, url_or_path, verify_ssl, args = _process_config_install_item(dir_item)
             self.assertEqual("dir", config_type)
             self.assertEqual(dir_path, url_or_path)
-            self.assertTrue(verify_ssl) if dir_item.startswith("dir:")\
+            self.assertTrue(verify_ssl) if dir_item.startswith("dir,")\
                 else self.assertIsNone(verify_ssl)
             self.assertIsNone(args)
 
         file_path = os.path.join(dir_path, "file.zip")
         save(file_path, "")
-        for file_item in ["file:[%s, True, None]" % file_path, file_path]:
+        for file_item in ["file, %s, True, None" % file_path, file_path]:
             config_type, url_or_path, verify_ssl, args = _process_config_install_item(file_item)
             self.assertEqual("file", config_type)
             self.assertEqual(file_path, url_or_path)
-            self.assertTrue(verify_ssl) if file_item.startswith("file:") \
+            self.assertTrue(verify_ssl) if file_item.startswith("file,") \
                 else self.assertIsNone(verify_ssl)
             self.assertIsNone(args)
 
-        for url_item in ["url:[http://is/an/absloute/path with spaces/here/file.zip, True, None]",
+        for url_item in ["url, http://is/an/absloute/path with spaces/here/file.zip, True, None",
                          "http://is/an/absloute/path with spaces/here/file.zip"]:
             config_type, url_or_path, verify_ssl, args = _process_config_install_item(url_item)
             self.assertEqual("url", config_type)
             self.assertEqual("http://is/an/absloute/path with spaces/here/file.zip", url_or_path)
-            self.assertTrue(verify_ssl) if url_item.startswith("url:") \
+            self.assertTrue(verify_ssl) if url_item.startswith("url,") \
                 else self.assertIsNone(verify_ssl)
             self.assertIsNone(args)
 
         config_type, url, verify_ssl, args = _process_config_install_item(
-                "url:[http://is/an/absloute/path with spaces/here/file.zip, False, --option]")
+                "url,   http://is/an/absloute/path with spaces/here/file.zip,False, --option  ")
         self.assertEqual("url", config_type)
         self.assertEqual("http://is/an/absloute/path with spaces/here/file.zip", url)
         self.assertFalse(verify_ssl)

--- a/conans/test/unittests/client/conf/config_installer_test.py
+++ b/conans/test/unittests/client/conf/config_installer_test.py
@@ -11,47 +11,53 @@ from conans.util.files import save
 class ConfigInstallerTests(unittest.TestCase):
 
     def process_config_install_item_test(self):
-        config_type, url_or_path, args = _process_config_install_item(
-                "git:[whaterver.url.com/repo.git, --recusrive --other -b 0.3.4]")
+        config_type, url_or_path, verify_ssl, args = _process_config_install_item(
+                "git:[whaterver.url.com/repo.git, False, --recusrive --other -b 0.3.4]")
         self.assertEqual("git", config_type)
         self.assertEqual("whaterver.url.com/repo.git", url_or_path)
+        self.assertFalse(verify_ssl)
         self.assertEqual("--recusrive --other -b 0.3.4", args)
 
-        config_type, url_or_path, args = _process_config_install_item("whaterver.url.com/repo.git")
+        config_type, url_or_path, verify_ssl, args = _process_config_install_item("whaterver.url.com/repo.git")
         self.assertEqual("git", config_type)
         self.assertEqual("whaterver.url.com/repo.git", url_or_path)
+        self.assertTrue(verify_ssl)
         self.assertIsNone(args)
 
         dir_path = temp_folder()
-        for dir_item in ["dir:[%s, None]" % dir_path, dir_path]:
-            config_type, url_or_path, args = _process_config_install_item(dir_item)
+        for dir_item in ["dir:[%s, True, None]" % dir_path, dir_path]:
+            config_type, url_or_path, verify_ssl, args = _process_config_install_item(dir_item)
             self.assertEqual("dir", config_type)
             self.assertEqual(dir_path, url_or_path)
+            self.assertTrue(verify_ssl)
             self.assertIsNone(args)
 
         file_path = os.path.join(dir_path, "file.zip")
         save(file_path, "")
-        for file_item in ["file:[%s, None]" % file_path, file_path]:
-            config_type, url_or_path, args = _process_config_install_item(file_item)
+        for file_item in ["file:[%s, True, None]" % file_path, file_path]:
+            config_type, url_or_path, verify_ssl, args = _process_config_install_item(file_item)
             self.assertEqual("file", config_type)
             self.assertEqual(file_path, url_or_path)
+            self.assertTrue(verify_ssl)
             self.assertIsNone(args)
 
-        for url_item in ["url:[http://is/an/absloute/path with spaces/here/file.zip, None]",
+        for url_item in ["url:[http://is/an/absloute/path with spaces/here/file.zip, True, None]",
                          "http://is/an/absloute/path with spaces/here/file.zip"]:
-            config_type, url_or_path, args = _process_config_install_item(url_item)
+            config_type, url_or_path, verify_ssl, args = _process_config_install_item(url_item)
             self.assertEqual("url", config_type)
             self.assertEqual("http://is/an/absloute/path with spaces/here/file.zip", url_or_path)
+            self.assertTrue(verify_ssl)
             self.assertIsNone(args)
 
-        config_type, url, args = _process_config_install_item(
-                "url:[http://is/an/absloute/path with spaces/here/file.zip, --option]")
+        config_type, url, verify_ssl, args = _process_config_install_item(
+                "url:[http://is/an/absloute/path with spaces/here/file.zip, False, --option]")
         self.assertEqual("url", config_type)
         self.assertEqual("http://is/an/absloute/path with spaces/here/file.zip", url)
+        self.assertFalse(verify_ssl)
         self.assertEqual("--option", args)
 
         # Test wrong input
         for item in ["git@github.com:conan-io/conan.git, None"
                      "file/not/exists.zip"]:
             with self.assertRaisesRegex(ConanException, "Unable to process config install"):
-                _, _, _ = _process_config_install_item(item)
+                _, _, _, _ = _process_config_install_item(item)


### PR DESCRIPTION
Changelog: Feature: Store verify_ssl argument in `conan config install`

- [x] Refer to the issue that supports this Pull Request: closes #4154 
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://raw.githubusercontent.com/conan-io/conan/develop/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [x] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one: https://github.com/conan-io/docs/pull/976

<sup>**Note:** By default this PR will skip the slower tests and will use a limited set of python versions. Check [here](https://github.com/conan-io/conan/blob/develop/.github/PR_INCREASE_TESTING.md) how to increase the testing level by writing some tags in the current PR body text.</sup>
