### PR TITLE
Run OSX builds in parallel too

### DIFF
--- a/.ci/jenkins/runner.py
+++ b/.ci/jenkins/runner.py
@@ -28,7 +28,7 @@ def run_tests(module_path, pyver, source_folder, tmp_folder, flavor, excluded_ta
     debug_traces = ""  # "--debug=nose,nose.result" if platform.system() == "Darwin" and pyver != "py27" else ""
     # pyenv = "/usr/local/bin/python2"
     multiprocess = ("--processes=%s --process-timeout=1000 "
-                    "--process-restartworker --with-coverage" % num_cores) if platform.system() != "Darwin" else ""
+                    "--process-restartworker --with-coverage" % num_cores)
 
     if num_cores <= 1:
         multiprocess = ""


### PR DESCRIPTION
Looks like running parallel builds in OSX is working good now. I don't know why, but I would merge it and observe if Mac builds hang or not.

Changelog: omit
@TAGS: slow, svn
@PYVERS: Macos@py27, Macos@py36, Macos@py37