### PR TITLE
CI Fixes: rest api failures

### DIFF
--- a/.ci/jenkins/Jenkinsfile
+++ b/.ci/jenkins/Jenkinsfile
@@ -194,6 +194,7 @@ try{
         builders["Windows Rest API Test"] = {
             node("Windows"){
                 stage("REST tests Windows ${pyver}"){
+                    checkout scm
                     try{
                       bat(script: "python ${runner} conans.test.functional.remote.rest_api_test ${pyver} ${WORKSPACE} \"${win_tmp_base}${commit}\"")
                     }
@@ -206,6 +207,7 @@ try{
         builders["Linux Rest API Test"] = {
             node("Linux"){
                 stage("REST tests Linux ${pyver}"){
+                    checkout scm
                     docker.image('conanio/conantests').inside("-e CONAN_USER_HOME=${WORKSPACE}") {
                         sh(script: "python ${runner} conans.test.functional.remote.rest_api_test ${pyver} ${WORKSPACE} /tmp/${commit}")
                     }


### PR DESCRIPTION
Changelog: omit
Docs: omit

Try to solve the random errors running the rest API test:
Hypothesis: When a different Linux slave runs the rest API the checkout is not there.

```

+ python .ci/jenkins/runner.py conans.test.functional.remote.rest_api_test py36 /home/jenkins_ci/workspace/ConanTestSuite_PR-4172 /tmp/761f

python: can't open file '.ci/jenkins/runner.py': [Errno 2] No such file or directory

script returned exit code 2

```