### PR TITLE
Less likely already in use ports for StoppableThreadBottle

### DIFF
--- a/conans/test/utils/tools.py
+++ b/conans/test/utils/tools.py
@@ -666,14 +666,13 @@ class StoppableThreadBottle(threading.Thread):
     """
     Real server to test download endpoints
     """
-    server = None
-    port = None
 
-    def __init__(self, host="127.0.0.1", port=None):
-        self.port = port or random.randrange(8200, 8600)
+    def __init__(self, host=None, port=None):
+        self.host = host or "127.0.0.1"
+        self.port = port or random.randrange(49000, 49151)
         self.server = bottle.Bottle()
         super(StoppableThreadBottle, self).__init__(target=self.server.run,
-                                                    kwargs={"host": host, "port": self.port})
+                                                    kwargs={"host": self.host, "port": self.port})
         self.daemon = True
         self._stop = threading.Event()
 

--- a/conans/test/utils/tools.py
+++ b/conans/test/utils/tools.py
@@ -669,7 +669,7 @@ class StoppableThreadBottle(threading.Thread):
 
     def __init__(self, host=None, port=None):
         self.host = host or "127.0.0.1"
-        self.port = port or random.randrange(49000, 49151)
+        self.port = port or random.randrange(48000, 49151)
         self.server = bottle.Bottle()
         super(StoppableThreadBottle, self).__init__(target=self.server.run,
                                                     kwargs={"host": self.host, "port": self.port})


### PR DESCRIPTION
Changelog: omit
Docs: omit

The nightly CI testsuite was failing because of this util using a port already in use: https://conan-ci.jfrog.info/blue/organizations/jenkins/ConanNightly/detail/ConanNightly/349/pipeline/

I have changed the class to use a random less likely in use port number
