### PR TITLE
cautious treatment of compiler in b2 generator

### DIFF
--- a/conans/client/generators/b2.py
+++ b/conans/client/generators/b2.py
@@ -81,7 +81,7 @@ class B2Generator(Generator):
         name = name.lower()
         # Create a b2 project for the package dependency.
         return [self.conanbuildinfo_project_template.format(name=name)]
-    
+
     def b2_constants_for_dep(self, name, info, user=None):
         '''
         Generates a list of constant variable definitions for the information in the
@@ -214,13 +214,7 @@ class B2Generator(Generator):
         '''
         if not getattr(self, "_b2_variation_key", None):
             self._b2_variation = {}
-            self._b2_variation['toolset'] = {
-                'sun-cc': 'sun',
-                'gcc': 'gcc',
-                'Visual Studio': 'msvc',
-                'clang': 'clang',
-                'apple-clang': 'clang'
-            }.get(self.conanfile.settings.get_safe('compiler'))+'-'+self.b2_toolset_version
+            self._b2_variation['toolset'] = self.b2_toolset_name + '-' + self.b2_toolset_version
             self._b2_variation['architecture'] = {
                 'x86': 'x86', 'x86_64': 'x86',
                 'ppc64le': 'power', 'ppc64': 'power',
@@ -280,15 +274,26 @@ class B2Generator(Generator):
                 '2c': None, 'gnu2c': 'gnu',
             }.get(self.conanfile.settings.get_safe('cppstd'))
         return self._b2_variation
-    
+
+    @property
+    def b2_toolset_name(self):
+        compiler = {
+            'sun-cc': 'sun',
+            'gcc': 'gcc',
+            'Visual Studio': 'msvc',
+            'clang': 'clang',
+            'apple-clang': 'clang'
+        }.get(self.conanfile.settings.get_safe('compiler'))
+        return str(compiler)
+
     @property
     def b2_toolset_version(self):
-        if self.conanfile.settings.compiler == 'Visual Studio':
+        if self.conanfile.settings.get_safe('compiler') == 'Visual Studio':
             if self.conanfile.settings.compiler.version == '15':
                 return '14.1'
             else:
                 return str(self.conanfile.settings.compiler.version)+'.0'
-        return str(self.conanfile.settings.compiler.version)
+        return str(self.conanfile.settings.get_safe('compiler.version'))
 
     conanbuildinfo_header_text = '''\
 #|

--- a/conans/test/unittests/client/generators/b2_test.py
+++ b/conans/test/unittests/client/generators/b2_test.py
@@ -329,3 +329,11 @@ if $(__define_targets__) {
 
         for ck, cv in generator.content.items():
             self.assertEquals(cv, content[ck])
+
+    def b2_empty_settings_test(self):
+        conanfile = ConanFile(TestBufferConanOutput(), None)
+        conanfile.initialize(Settings({}), EnvValues())
+
+        generator = B2Generator(conanfile)
+        # fails if generator doesn't support empty settings
+        generator.content


### PR DESCRIPTION
Using settings.get_safe more actively. Conversion of Nones to strings.
Fixes #4201

Changelog: Bugfix: b2 generator was failing when package recipe didn't use compiler setting
Docs: omit

- [x] Refer to the issue that supports this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.