### PR TITLE
[WIP] Show remote name for upload command output

### DIFF
--- a/conans/client/output.py
+++ b/conans/client/output.py
@@ -1,3 +1,5 @@
+from contextlib import contextmanager
+
 import six
 from colorama import Fore, Style
 
@@ -44,6 +46,7 @@ class ConanOutput(object):
     def __init__(self, stream, color=False):
         self._stream = stream
         self._color = color
+        self._scoped = None
 
     @property
     def is_terminal(self):
@@ -52,7 +55,7 @@ class ConanOutput(object):
     def writeln(self, data, front=None, back=None):
         self.write(data, front, back, True)
 
-    def write(self, data, front=None, back=None, newline=False):
+    def _write(self, data, front=None, back=None, newline=False):
         if six.PY2:
             if isinstance(data, str):
                 data = decode_text(data)  # Keep python 2 compatibility
@@ -92,17 +95,35 @@ class ConanOutput(object):
 
     def rewrite_line(self, line):
         tmp_color = self._color
-        self._color = False
-        TOTAL_SIZE = 70
-        LIMIT_SIZE = 32  # Hard coded instead of TOTAL_SIZE/2-3 that fails in Py3 float division
-        if len(line) > TOTAL_SIZE:
-            line = line[0:LIMIT_SIZE] + " ... " + line[-LIMIT_SIZE:]
-        self.write("\r%s%s" % (line, " " * (TOTAL_SIZE - len(line))))
-        self._stream.flush()
-        self._color = tmp_color
+        try:
+            self._color = False
+            TOTAL_SIZE = 70 if not self._scoped else (70 - len(self._scoped) - 2)
+            LIMIT_SIZE = int(TOTAL_SIZE/2-3)
+            if len(line) > TOTAL_SIZE:
+                line = line[0:LIMIT_SIZE] + " ... " + line[-LIMIT_SIZE:]
+            else:
+                line += " " * (TOTAL_SIZE-len(line))
+            self._write("\r", newline=False)
+            self.write(line, newline=True)
+            self._stream.flush()
+        finally:
+            self._color = tmp_color
 
     def flush(self):
         self._stream.flush()
+
+    def write(self, data, front=None, back=None, newline=False):
+        if not self._scoped:
+            self._write(data, front=front, back=back, newline=newline)
+        else:
+            self._write("%s: " % self._scoped, front, back, False)
+            self._write("%s" % data, Color.BRIGHT_WHITE, back, newline)
+
+    @contextmanager
+    def scoped(self, scope):
+        self._scoped = scope
+        yield
+        self._scoped = None
 
 
 class ScopedOutput(ConanOutput):

--- a/conans/client/output.py
+++ b/conans/client/output.py
@@ -125,14 +125,12 @@ class ConanOutput(object):
         yield
         self._scoped = None
 
+    @property
+    def scope(self):
+        return self._scoped
+
 
 class ScopedOutput(ConanOutput):
     def __init__(self, scope, output):
-        self.scope = scope
-        self._stream = output._stream
-        self._color = output._color
-
-    def write(self, data, front=None, back=None, newline=False):
-        assert self.scope != "virtual", "printing with scope==virtual"
-        super(ScopedOutput, self).write("%s: " % self.scope, front, back, False)
-        super(ScopedOutput, self).write("%s" % data, Color.BRIGHT_WHITE, back, newline)
+        super(ScopedOutput, self).__init__(stream=output._stream, color=output._color)
+        self._scoped = scope

--- a/conans/client/remote_manager.py
+++ b/conans/client/remote_manager.py
@@ -159,7 +159,6 @@ class RemoteManager(object):
         logger.debug("UPLOAD: Time remote_manager upload_package: %f" % duration)
         if not uploaded:
             self._output.rewrite_line("Package is up to date, upload skipped")
-            self._output.writeln("")
 
         self._hook_manager.execute("post_upload_package", conanfile_path=conanfile_path,
                                    reference=package_reference.conan,

--- a/conans/test/functional/command/upload_complete_test.py
+++ b/conans/test/functional/command/upload_complete_test.py
@@ -322,7 +322,7 @@ class TestConan(ConanFile):
                              stat.S_IRWXU, stat.S_IRWXU)
 
     def upload_all_test(self):
-        '''Upload conans and package together'''
+        """Upload conans and package together"""
         # Try to upload all conans and packages
         self.client.run('upload %s --all' % str(self.conan_ref))
         lines = [line.strip() for line in str(self.client.user_io.out).splitlines()


### PR DESCRIPTION
Changelog: Feature: Show remote name during upload command outputs
Docs: https://github.com/conan-io/docs/pull/XXXX

- [ ] closes #3951

New output would look like this (image below to show the colors):

```bash
⇒  conan upload myLib\* --all
Uploading to remote 'my-remote':
remote:my-remote: Are you sure you want to upload 'myLib/0.0@demo/demo'? (yes/no): yes
remote:my-remote: Uploading myLib/0.0@demo/demo to remote 'my-remote'
remote:my-remote: Recipe is up to date, upload skipped
remote:my-remote: Uploading package 1/1: f8bda7f0751e4bc3beaa6c3b2eb02d455291c8a2 to 'my-remote'
remote:my-remote: Package is up to date, upload skipped               
Uploading to remote 'conan-center':
remote:conan-center: Are you sure you want to upload 'myLib/0.0@jgsogo/issue'? (yes/no): no
remote:conan-center: Are you sure you want to upload 'myLib/0.0@jsogo/issue'? (yes/no): no
remote:conan-center: Are you sure you want to upload 'myLib/0.0@testing/issue'? (yes/no): no
remote:conan-center: Are you sure you want to upload 'myLib/1.0@testing/issue'? (yes/no): no
```

![image](https://user-images.githubusercontent.com/1406456/50522454-560f6880-0acb-11e9-95b6-5e50a953b613.png)

There are two different things in this PR:
 1. references are grouped by remote before calling the upload function. This makes sense, but also it is clearer in order to show the `Uploading to remote '<remote-name>':`, each remote will appear only once.
 1. changes related to **scoped output** (it will have its own branch, that's the reason why this PR is a WIP): there are two different implementations of the scoped output concept:
    1. Existing `ScopedOutput` class, it allows to create an object wrapping an `output` that will prepend every output line written to it with a prefix. It works great for the `conanfile.output = ScopedOutput("<reference>", output)` as it will add the prefix only to the lines written from inside the conanfile.
    1. Here I'm introducing a different implementation: the ability to add a scope to an existing `output` object, so the prefix will be prepended to everyone using it. In the context/example of this PR, as some lines are written using the output of the `remote_manager`, others using the one in the `CmdUpload`,... this is the cleanest solution if we want to give scope to all the lines (because the underlying `output` is shared).

So, before going ahead and fixing some tests that are failing, and cleaning the implementation and so no, I need a word about:
 * I like this implementation, let's keep it
 * I don't like the new implementation, but I want to give scope to every line (like the image above). ==> We will need to substitute the output in the `remote_manager` and `CmdUpload` with a `ScopedOutput` object during all this calls... or remove the member attribute and pass the `output` to the functions that are being used.
 * Just give scope to the lines printed from the `CmdUpload`
 * No scope at all, just the first line with information about the context.
