### PR TITLE
Feature/b2 rooted dep projects

### DIFF
--- a/conans/client/generators/b2.py
+++ b/conans/client/generators/b2.py
@@ -385,6 +385,7 @@ local __conanbuildinfo__ = [ GLOB $(__file__:D) : conanbuildinfo-*.jam : downcas
     conanbuildinfo_project_template = '''\
 # {name}
 project-define {name} ;
+use-project /{name} : {name} ;
 '''
 
     conanbuildinfo_postfix_text = '''\

--- a/conans/client/generators/b2.py
+++ b/conans/client/generators/b2.py
@@ -329,6 +329,10 @@ rule project-define ( id )
         : constant-if call-in-project
         : $(id-mod)
         : constant-if call-in-project ;
+    if [ project.is-jamroot-module $(base-project-mod) ]
+    {
+        use-project /$(id) : $(id) ;
+    }
     return $(id-mod) ;
 }
 
@@ -385,7 +389,6 @@ local __conanbuildinfo__ = [ GLOB $(__file__:D) : conanbuildinfo-*.jam : downcas
     conanbuildinfo_project_template = '''\
 # {name}
 project-define {name} ;
-use-project /{name} : {name} ;
 '''
 
     conanbuildinfo_postfix_text = '''\

--- a/conans/test/unittests/client/generators/b2_test.py
+++ b/conans/test/unittests/client/generators/b2_test.py
@@ -137,11 +137,13 @@ local __conanbuildinfo__ = [ GLOB $(__file__:D) : conanbuildinfo-*.jam : downcas
 # mypkg
 # mypkg
 project-define mypkg ;
+use-project /mypkg : mypkg ;
 
 
 # mypkg2
 # mypkg2
 project-define mypkg2 ;
+use-project /mypkg2 : mypkg2 ;
 
 {
     local __define_targets__ = yes ;

--- a/conans/test/unittests/client/generators/b2_test.py
+++ b/conans/test/unittests/client/generators/b2_test.py
@@ -81,6 +81,10 @@ rule project-define ( id )
         : constant-if call-in-project
         : $(id-mod)
         : constant-if call-in-project ;
+    if [ project.is-jamroot-module $(base-project-mod) ]
+    {
+        use-project /$(id) : $(id) ;
+    }
     return $(id-mod) ;
 }
 
@@ -137,13 +141,11 @@ local __conanbuildinfo__ = [ GLOB $(__file__:D) : conanbuildinfo-*.jam : downcas
 # mypkg
 # mypkg
 project-define mypkg ;
-use-project /mypkg : mypkg ;
 
 
 # mypkg2
 # mypkg2
 project-define mypkg2 ;
-use-project /mypkg2 : mypkg2 ;
 
 {
     local __define_targets__ = yes ;


### PR DESCRIPTION
Changelog: Fix: Allow referring to projects created by b2 generator for dependencies with absolute paths.
Docs: Omit

- [x] Refer to the issue that supports this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.