### PR TITLE
Fix add_cmake_flag in cmake helper

### DIFF
--- a/conans/client/build/cmake_flags.py
+++ b/conans/client/build/cmake_flags.py
@@ -72,7 +72,7 @@ def add_cmake_flag(cmake_flags, name, flag):
         if name not in cmake_flags:
             cmake_flags[name] = flag
         else:
-            cmake_flags[name] = ' ' + flag
+            cmake_flags[name] += ' ' + flag
     return cmake_flags
 
 


### PR DESCRIPTION
Changelog: Fix how cmake flags are appended
Docs: omit

The description of the add_cmake_flags function does not correspond to the actual behavior.