### PR TITLE
Fix migrations

### DIFF
--- a/conans/conan_server.py
+++ b/conans/conan_server.py
@@ -1,8 +1,15 @@
-from conans.server.server_launcher import main
+import argparse
+
+from conans.server.launcher import ServerLauncher
 
 
 def run():
-    main()
+    parser = argparse.ArgumentParser(description='Launch the server')
+    parser.add_argument('--migrate', default=False, action='store_true',
+                        help='Run the pending migrations')
+    args = parser.parse_args()
+    launcher = ServerLauncher(force_migration=args.migrate)
+    launcher.launch()
 
 
 if __name__ == '__main__':

--- a/conans/server/launcher.py
+++ b/conans/server/launcher.py
@@ -1,0 +1,61 @@
+#!/usr/bin/python
+import argparse
+import os
+
+from conans import SERVER_CAPABILITIES
+from conans import __version__ as SERVER_VERSION, REVISIONS
+from conans.model.version import Version
+from conans.paths import conan_expand_user
+from conans.server.conf import MIN_CLIENT_COMPATIBLE_VERSION
+from conans.server.conf import get_server_store
+
+from conans.server.crypto.jwt.jwt_credentials_manager import JWTCredentialsManager
+from conans.server.crypto.jwt.jwt_updown_manager import JWTUpDownAuthManager
+from conans.server.migrate import migrate_and_get_server_config
+from conans.server.plugin_loader import load_authentication_plugin
+from conans.server.rest.server import ConanServer
+
+from conans.server.service.authorize import BasicAuthorizer, BasicAuthenticator
+
+
+class ServerLauncher(object):
+    def __init__(self, force_migration=False):
+        user_folder = conan_expand_user("~")
+        server_folder = os.path.join(user_folder, '.conan_server')
+
+        server_config = migrate_and_get_server_config(user_folder, None, force_migration)
+        custom_auth = server_config.custom_authenticator
+        if custom_auth:
+            authenticator = load_authentication_plugin(server_folder, custom_auth)
+        else:
+            authenticator = BasicAuthenticator(dict(server_config.users))
+
+        authorizer = BasicAuthorizer(server_config.read_permissions,
+                                     server_config.write_permissions)
+        credentials_manager = JWTCredentialsManager(server_config.jwt_secret,
+                                                    server_config.jwt_expire_time)
+
+        updown_auth_manager = JWTUpDownAuthManager(server_config.updown_secret,
+                                                   server_config.authorize_timeout)
+
+        server_store = get_server_store(server_config.disk_storage_path,
+                                        server_config.public_url,
+                                        updown_auth_manager=updown_auth_manager)
+
+        server_capabilities = SERVER_CAPABILITIES
+        server_capabilities.append(REVISIONS)
+
+        self.ra = ConanServer(server_config.port, credentials_manager, updown_auth_manager,
+                              authorizer, authenticator, server_store,
+                              Version(SERVER_VERSION), Version(MIN_CLIENT_COMPATIBLE_VERSION),
+                              server_capabilities)
+
+        print("***********************")
+        print("Using config: %s" % server_config.config_filename)
+        print("Storage: %s" % server_config.disk_storage_path)
+        print("Public URL: %s" % server_config.public_url)
+        print("PORT: %s" % server_config.port)
+        print("***********************")
+
+    def launch(self):
+        self.ra.run(host="0.0.0.0")

--- a/conans/server/migrate.py
+++ b/conans/server/migrate.py
@@ -5,11 +5,11 @@ from conans.server.migrations import ServerMigrator
 from conans.util.log import logger
 
 
-def migrate_and_get_server_config(base_folder, storage_folder=None):
+def migrate_and_get_server_config(base_folder, storage_folder=None, force_migration=False):
     server_config = ConanServerConfigParser(base_folder, storage_folder=storage_folder)
     storage_path = server_config.disk_storage_path
     migrator = ServerMigrator(server_config.conan_folder, storage_path,
-                              Version(SERVER_VERSION), logger)
+                              Version(SERVER_VERSION), logger, force_migration)
     migrator.migrate()
 
     # Init again server_config, migrator could change something

--- a/conans/server/server_launcher.py
+++ b/conans/server/server_launcher.py
@@ -1,7 +1,7 @@
 from conans.server.launcher import ServerLauncher
 
 launcher = ServerLauncher()
-app = launcher.ra.root_app
+app = launcher.server.root_app
 
 def main(*args):
     launcher.launch()

--- a/conans/server/server_launcher.py
+++ b/conans/server/server_launcher.py
@@ -1,72 +1,10 @@
-#!/usr/bin/python
-import os
-
-from conans import SERVER_CAPABILITIES
-from conans import __version__ as SERVER_VERSION, REVISIONS
-from conans.model.version import Version
-from conans.paths import conan_expand_user
-from conans.server.conf import MIN_CLIENT_COMPATIBLE_VERSION
-from conans.server.conf import get_server_store
-
-from conans.server.crypto.jwt.jwt_credentials_manager import JWTCredentialsManager
-from conans.server.crypto.jwt.jwt_updown_manager import JWTUpDownAuthManager
-from conans.server.migrate import migrate_and_get_server_config
-from conans.server.plugin_loader import load_authentication_plugin
-from conans.server.rest.server import ConanServer
-
-from conans.server.service.authorize import BasicAuthorizer, BasicAuthenticator
-
-
-class ServerLauncher(object):
-    def __init__(self):
-        user_folder = conan_expand_user("~")
-        server_folder = os.path.join(user_folder, '.conan_server')
-
-        server_config = migrate_and_get_server_config(user_folder)
-        custom_auth = server_config.custom_authenticator
-        if custom_auth:
-            authenticator = load_authentication_plugin(server_folder, custom_auth)
-        else:
-            authenticator = BasicAuthenticator(dict(server_config.users))
-
-        authorizer = BasicAuthorizer(server_config.read_permissions,
-                                     server_config.write_permissions)
-        credentials_manager = JWTCredentialsManager(server_config.jwt_secret,
-                                                    server_config.jwt_expire_time)
-
-        updown_auth_manager = JWTUpDownAuthManager(server_config.updown_secret,
-                                                   server_config.authorize_timeout)
-
-        server_store = get_server_store(server_config.disk_storage_path,
-                                        server_config.public_url,
-                                        updown_auth_manager=updown_auth_manager)
-
-        server_capabilities = SERVER_CAPABILITIES
-        server_capabilities.append(REVISIONS)
-
-        self.ra = ConanServer(server_config.port, credentials_manager, updown_auth_manager,
-                              authorizer, authenticator, server_store,
-                              Version(SERVER_VERSION), Version(MIN_CLIENT_COMPATIBLE_VERSION),
-                              server_capabilities)
-
-        print("***********************")
-        print("Using config: %s" % server_config.config_filename)
-        print("Storage: %s" % server_config.disk_storage_path)
-        print("Public URL: %s" % server_config.public_url)
-        print("PORT: %s" % server_config.port)
-        print("***********************")
-
-    def launch(self):
-        self.ra.run(host="0.0.0.0")
-
+from conans.server.launcher import ServerLauncher
 
 launcher = ServerLauncher()
 app = launcher.ra.root_app
 
-
 def main(*args):
     launcher.launch()
-
 
 if __name__ == "__main__":
     main()

--- a/conans/server/store/server_store.py
+++ b/conans/server/store/server_store.py
@@ -268,7 +268,7 @@ class ServerStore(SimplePaths):
         if not rev_list:
             # FIXING BREAK MIGRATION NOT CREATING INDEXES
             # BOTH FOR RREV AND PREV THE FILE SHOULD BE CREATED WITH "0" REVISION
-            if self.path_exists(os.path.join(os.path.dirname(rev_file_path)), DEFAULT_REVISION_V1):
+            if self.path_exists(os.path.join(os.path.dirname(rev_file_path), DEFAULT_REVISION_V1)):
                 rev_list = RevisionList()
                 rev_list.add_revision(DEFAULT_REVISION_V1)
                 self._storage_adapter.write_file(rev_file_path, rev_list.dumps(),

--- a/conans/server/store/server_store.py
+++ b/conans/server/store/server_store.py
@@ -1,5 +1,7 @@
+import os
 from os.path import join, normpath, relpath
 
+from conans import DEFAULT_REVISION_V1
 from conans.errors import ConanException, NotFoundException
 from conans.model.ref import ConanFileReference, PackageReference
 from conans.paths import EXPORT_FOLDER, PACKAGES_FOLDER, SimplePaths
@@ -264,7 +266,16 @@ class ServerStore(SimplePaths):
     def _get_latest_revision(self, rev_file_path):
         rev_list = self._get_revisions(rev_file_path)
         if not rev_list:
-            return None
+            # FIXING BREAK MIGRATION NOT CREATING INDEXES
+            # BOTH FOR RREV AND PREV THE FILE SHOULD BE CREATED WITH "0" REVISION
+            if self.path_exists(os.path.join(os.path.dirname(rev_file_path)), DEFAULT_REVISION_V1):
+                rev_list = RevisionList()
+                rev_list.add_revision(DEFAULT_REVISION_V1)
+                self._storage_adapter.write_file(rev_file_path, rev_list.dumps(),
+                                                 lock_file=rev_file_path + ".lock")
+                return DEFAULT_REVISION_V1
+            else:
+                return None
         return rev_list.latest_revision()
 
     def _recipe_revisions_file(self, reference):


### PR DESCRIPTION
Changelog: Bugfix: The migrated data in the server from a version previous to Conan `1.10.0` was not migrated creating the needed indexes. This fixes the migration and creates the index on the fly for fixing broken migrations. Also the server doesn't try to migrate while running but warns the user to run `conan server --migrate` after doing a backup of the data, avoiding issues when running the production servers like gunicorn where the process doesn't accept input from the user.

Docs: omit
Closes #4219 