### PR TITLE
Feature: initial Visual Studio 2019 (16) support

### DIFF
--- a/conans/client/build/cmake_flags.py
+++ b/conans/client/build/cmake_flags.py
@@ -47,7 +47,8 @@ def get_generator(settings):
                     '11': '11 2012',
                     '12': '12 2013',
                     '14': '14 2015',
-                    '15': '15 2017'}
+                    '15': '15 2017',
+                    '16': '16 2019'}
         base = "Visual Studio %s" % _visuals.get(compiler_version,
                                                  "UnknownVersion %s" % compiler_version)
         if arch == "x86_64":

--- a/conans/client/conf/__init__.py
+++ b/conans/client/conf/__init__.py
@@ -64,7 +64,7 @@ compiler:
         toolset: [None, v90, v100, v110, v110_xp, v120, v120_xp,
                   v140, v140_xp, v140_clang_c2, LLVM-vs2012, LLVM-vs2012_xp,
                   LLVM-vs2013, LLVM-vs2013_xp, LLVM-vs2014, LLVM-vs2014_xp,
-                  LLVM-vs2017, LLVM-vs2017_xp, v141, v141_xp, v141_clang_c2]
+                  LLVM-vs2017, LLVM-vs2017_xp, v141, v141_xp, v141_clang_c2, v142]
     clang:
         version: ["3.3", "3.4", "3.5", "3.6", "3.7", "3.8", "3.9", "4.0",
                   "5.0", "6.0", "7.0",

--- a/conans/client/conf/__init__.py
+++ b/conans/client/conf/__init__.py
@@ -60,7 +60,7 @@ compiler:
         exception: [None, dwarf2, sjlj, seh] # Windows MinGW
     Visual Studio:
         runtime: [MD, MT, MTd, MDd]
-        version: ["8", "9", "10", "11", "12", "14", "15"]
+        version: ["8", "9", "10", "11", "12", "14", "15", "16"]
         toolset: [None, v90, v100, v110, v110_xp, v120, v120_xp,
                   v140, v140_xp, v140_clang_c2, LLVM-vs2012, LLVM-vs2012_xp,
                   LLVM-vs2013, LLVM-vs2013_xp, LLVM-vs2014, LLVM-vs2014_xp,

--- a/conans/client/migrations.py
+++ b/conans/client/migrations.py
@@ -106,7 +106,7 @@ compiler:
         toolset: [None, v90, v100, v110, v110_xp, v120, v120_xp,
                   v140, v140_xp, v140_clang_c2, LLVM-vs2012, LLVM-vs2012_xp,
                   LLVM-vs2013, LLVM-vs2013_xp, LLVM-vs2014, LLVM-vs2014_xp,
-                  LLVM-vs2017, LLVM-vs2017_xp, v141, v141_xp, v141_clang_c2]
+                  LLVM-vs2017, LLVM-vs2017_xp, v141, v141_xp, v141_clang_c2, v142]
     clang:
         version: ["3.3", "3.4", "3.5", "3.6", "3.7", "3.8", "3.9", "4.0",
                   "5.0", "6.0", "7.0",

--- a/conans/client/migrations.py
+++ b/conans/client/migrations.py
@@ -102,11 +102,11 @@ compiler:
         exception: [None, dwarf2, sjlj, seh] # Windows MinGW
     Visual Studio:
         runtime: [MD, MT, MTd, MDd]
-        version: ["8", "9", "10", "11", "12", "14", "15", "16"]
+        version: ["8", "9", "10", "11", "12", "14", "15"]
         toolset: [None, v90, v100, v110, v110_xp, v120, v120_xp,
                   v140, v140_xp, v140_clang_c2, LLVM-vs2012, LLVM-vs2012_xp,
                   LLVM-vs2013, LLVM-vs2013_xp, LLVM-vs2014, LLVM-vs2014_xp,
-                  LLVM-vs2017, LLVM-vs2017_xp, v141, v141_xp, v141_clang_c2, v142]
+                  LLVM-vs2017, LLVM-vs2017_xp, v141, v141_xp, v141_clang_c2]
     clang:
         version: ["3.3", "3.4", "3.5", "3.6", "3.7", "3.8", "3.9", "4.0",
                   "5.0", "6.0", "7.0",

--- a/conans/client/migrations.py
+++ b/conans/client/migrations.py
@@ -102,7 +102,7 @@ compiler:
         exception: [None, dwarf2, sjlj, seh] # Windows MinGW
     Visual Studio:
         runtime: [MD, MT, MTd, MDd]
-        version: ["8", "9", "10", "11", "12", "14", "15"]
+        version: ["8", "9", "10", "11", "12", "14", "15", "16"]
         toolset: [None, v90, v100, v110, v110_xp, v120, v120_xp,
                   v140, v140_xp, v140_clang_c2, LLVM-vs2012, LLVM-vs2012_xp,
                   LLVM-vs2013, LLVM-vs2013_xp, LLVM-vs2014, LLVM-vs2014_xp,

--- a/conans/client/tools/win.py
+++ b/conans/client/tools/win.py
@@ -59,13 +59,13 @@ def _visual_compiler(output, version):
     if platform.system().startswith("CYGWIN"):
         return _visual_compiler_cygwin(output, version)
 
-    if version == "15":
-        vs_path = os.getenv('vs150comntools')
-        path = vs_path or vs_installation_path("15")
+    if Version(version) >= "15":
+        vs_path = os.getenv('vs%s0comntools' % version)
+        path = vs_path or vs_installation_path(version)
         if path:
             compiler = "Visual Studio"
-            output.success("Found %s %s" % (compiler, "15"))
-            return compiler, "15"
+            output.success("Found %s %s" % (compiler, version))
+            return compiler, version
         return None
 
     version = "%s.0" % version
@@ -93,7 +93,8 @@ def latest_vs_version_installed(output):
     return latest_visual_studio_version_installed(output=output)
 
 
-MSVS_DEFAULT_TOOLSETS = {"15": "v141",
+MSVS_DEFAULT_TOOLSETS = {"16": "v142",
+                         "15": "v141",
                          "14": "v140",
                          "12": "v120",
                          "11": "v110",
@@ -102,7 +103,8 @@ MSVS_DEFAULT_TOOLSETS = {"15": "v141",
                          "8": "v80"}
 
 # inverse version of the above MSVS_DEFAULT_TOOLSETS (keys and values are swapped)
-MSVS_DEFAULT_TOOLSETS_INVERSE = {"v141": "15",
+MSVS_DEFAULT_TOOLSETS_INVERSE = {"v142": "16",
+                                 "v141": "15",
                                  "v140": "14",
                                  "v120": "12",
                                  "v110": "11",

--- a/conans/client/tools/win.py
+++ b/conans/client/tools/win.py
@@ -189,7 +189,7 @@ def vs_installation_path(version, preference=None):
 
     # Try with vswhere()
     try:
-        legacy_products = vswhere(legacy=True)
+        legacy_products = vswhere(legacy=True, prerelease=True)
         all_products = vswhere(products=["*"])
         products = legacy_products + all_products
     except ConanException:

--- a/conans/client/tools/win.py
+++ b/conans/client/tools/win.py
@@ -191,7 +191,7 @@ def vs_installation_path(version, preference=None):
 
     # Try with vswhere()
     try:
-        legacy_products = vswhere(legacy=True, prerelease=True)
+        legacy_products = vswhere(legacy=True)
         all_products = vswhere(products=["*"])
         products = legacy_products + all_products
     except ConanException:

--- a/conans/test/unittests/client/build/msbuild_test.py
+++ b/conans/test/unittests/client/build/msbuild_test.py
@@ -132,17 +132,6 @@ class MSBuildTest(unittest.TestCase):
         self.assertRegexpMatches(version, "(\d+\.){2,3}\d+")
         self.assertGreater(version, "15.1")
 
-    def custom_properties_test(self):
-        settings = MockSettings({"build_type": "Debug",
-                                 "compiler": "Visual Studio",
-                                 "arch": "x86_64"})
-        conanfile = MockConanfile(settings)
-        msbuild = MSBuild(conanfile)
-        command = msbuild.get_command("project_should_flags_test_file.sln",
-                                      properties={"MyProp1": "MyValue1", "MyProp2": "MyValue2"})
-        self.assertIn('/p:MyProp1="MyValue1"', command)
-        self.assertIn('/p:MyProp2="MyValue2"', command)
-
     @parameterized.expand([("16", "v142"),
                            ("15", "v141"),
                            ("14", "v140"),

--- a/conans/test/unittests/client/build/msbuild_test.py
+++ b/conans/test/unittests/client/build/msbuild_test.py
@@ -132,7 +132,19 @@ class MSBuildTest(unittest.TestCase):
         self.assertRegexpMatches(version, "(\d+\.){2,3}\d+")
         self.assertGreater(version, "15.1")
 
-    @parameterized.expand([("15", "v141"),
+    def custom_properties_test(self):
+        settings = MockSettings({"build_type": "Debug",
+                                 "compiler": "Visual Studio",
+                                 "arch": "x86_64"})
+        conanfile = MockConanfile(settings)
+        msbuild = MSBuild(conanfile)
+        command = msbuild.get_command("project_should_flags_test_file.sln",
+                                      properties={"MyProp1": "MyValue1", "MyProp2": "MyValue2"})
+        self.assertIn('/p:MyProp1="MyValue1"', command)
+        self.assertIn('/p:MyProp2="MyValue2"', command)
+
+    @parameterized.expand([("16", "v142"),
+                           ("15", "v141"),
                            ("14", "v140"),
                            ("12", "v120"),
                            ("11", "v110"),
@@ -149,7 +161,8 @@ class MSBuildTest(unittest.TestCase):
         command = msbuild.get_command("project_should_flags_test_file.sln")
         self.assertIn('/p:PlatformToolset="%s"' % expected_toolset, command)
 
-    @parameterized.expand([("v141",),
+    @parameterized.expand([("v142",),
+                           ("v141",),
                            ("v140",),
                            ("v120",),
                            ("v110",),

--- a/conans/test/unittests/model/info/vs_toolset_compatible_test.py
+++ b/conans/test/unittests/model/info/vs_toolset_compatible_test.py
@@ -11,7 +11,8 @@ from conans.model.settings import Settings
 
 
 class VSToolsetCompatibleTest(unittest.TestCase):
-    @parameterized.expand([("14", "v141", "15"),
+    @parameterized.expand([("15", "v142", "16"),
+                           ("14", "v141", "15"),
                            ("15", "v140", "14"),
                            ("11", "v120", "12"),
                            ("12", "v110", "11"),
@@ -29,7 +30,8 @@ class VSToolsetCompatibleTest(unittest.TestCase):
         self.assertEqual(info.settings.compiler.version, expected_version)
         self.assertIsNone(info.settings.get_safe("compiler.toolset"))
 
-    @parameterized.expand([("14", "v141_xp"),
+    @parameterized.expand([("16", "v141_xp"),
+                           ("14", "v141_xp"),
                            ("15", "v140_xp"),
                            ("11", "v120_xp"),
                            ("12", "v110_xp"),

--- a/conans/test/unittests/util/msvs_toolset_test.py
+++ b/conans/test/unittests/util/msvs_toolset_test.py
@@ -15,7 +15,8 @@ from conans.test.utils.conanfile import MockSettings
 @unittest.skipUnless(platform.system() == "Windows", "Requires Windows")
 class MSVCToolsetTest(unittest.TestCase):
 
-    @parameterized.expand([("15", "v141"),
+    @parameterized.expand([("16", "v142"),
+                           ("15", "v141"),
                            ("14", "v140"),
                            ("12", "v120"),
                            ("11", "v110"),
@@ -27,7 +28,8 @@ class MSVCToolsetTest(unittest.TestCase):
                                  "compiler.version": compiler_version})
         self.assertEqual(expected_toolset, tools.msvs_toolset(settings))
 
-    @parameterized.expand([("15", "v141_xp"),
+    @parameterized.expand([("16", "v141_xp"),
+                           ("15", "v141_xp"),
                            ("14", "v140_xp"),
                            ("12", "v120_xp"),
                            ("11", "v110_xp")])


### PR DESCRIPTION
Changelog: Feature: Conan is ready for the release of Visual Studio 2019 (16). Still not working for the pre-release.
Docs: omit

closes #4146 
closes #2822

- add Visual Studio 2019 (16) to the default `settings.yml`
- allow to detect pre-release Visual Studio versions
- detect Visual Studio 2019 (16) as well
- by default, Visual Studio 2019 uses the same toolset as previous - v141
- no changes to C++ standard (no support for C++20 added as for Preview 1)
- add support for upcoming `Visual Studio 16 2019` CMake generator (https://gitlab.kitware.com/cmake/cmake/merge_requests/2711)

Q: should we modify code at `cmake_common.py` line 353 to handle Visual Studio 2017 and 2019?