### PR TITLE
fixing version ranges with spaces

### DIFF
--- a/conans/model/ref.py
+++ b/conans/model/ref.py
@@ -78,7 +78,6 @@ class ConanFileReference(namedtuple("ConanFileReference", "name version user cha
     """ Full reference of a package recipes, e.g.:
     opencv/2.4.10@lasote/testing
     """
-    whitespace_pattern = re.compile(r"\s+")
     sep_pattern = re.compile(r"([^/]+)/([^/]+)@([^/]+)/([^/#]+)#?(.+)?")
 
     def __new__(cls, name, version, user, channel, revision=None, validate=True):
@@ -107,7 +106,6 @@ class ConanFileReference(namedtuple("ConanFileReference", "name version user cha
     def loads(text, validate=True):
         """ Parses a text string to generate a ConanFileReference object
         """
-        text = ConanFileReference.whitespace_pattern.sub("", text)
         try:
             # Split returns empty start and end groups
             _, name, version, user, channel, revision, _ = ConanFileReference.sep_pattern.split(text)

--- a/conans/test/functional/graph/version_ranges_diamond_test.py
+++ b/conans/test/functional/graph/version_ranges_diamond_test.py
@@ -12,26 +12,6 @@ from conans.util.files import load
 
 class VersionRangesUpdatingTest(unittest.TestCase):
 
-    def space_separator_test(self):
-        # https://github.com/conan-io/conan/issues/4270
-        conanfile = """from conans import ConanFile
-class HelloReuseConan(ConanFile):
-    pass
-"""
-        client = TestClient()
-        client.save({"conanfile.py": conanfile})
-        client.run("create . Pkg/1.1@myuser/testing")
-        client.run("create . Pkg/1.2@myuser/testing")
-
-        conanfile = """from conans import ConanFile
-class HelloReuseConan(ConanFile):
-    requires = "Pkg/[>1.0 <1.3]@myuser/testing"
-"""
-        client.save({"conanfile.py": conanfile})
-        client.run("install .")
-        # Resolves to local package
-        self.assertIn("Pkg/1.2@myuser/testing: Already installed!", client.out)
-
     def update_test(self):
         client = TestClient(servers={"default": TestServer()},
                             users={"default": [("lasote", "mypass")]})

--- a/conans/test/functional/graph/version_ranges_diamond_test.py
+++ b/conans/test/functional/graph/version_ranges_diamond_test.py
@@ -12,6 +12,26 @@ from conans.util.files import load
 
 class VersionRangesUpdatingTest(unittest.TestCase):
 
+    def space_separator_test(self):
+        # https://github.com/conan-io/conan/issues/4270
+        conanfile = """from conans import ConanFile
+class HelloReuseConan(ConanFile):
+    pass
+"""
+        client = TestClient()
+        client.save({"conanfile.py": conanfile})
+        client.run("create . Pkg/1.1@myuser/testing")
+        client.run("create . Pkg/1.2@myuser/testing")
+
+        conanfile = """from conans import ConanFile
+class HelloReuseConan(ConanFile):
+    requires = "Pkg/[>1.0 <1.3]@myuser/testing"
+"""
+        client.save({"conanfile.py": conanfile})
+        client.run("install .")
+        # Resolves to local package
+        self.assertIn("Pkg/1.2@myuser/testing: Already installed!", client.out)
+
     def update_test(self):
         client = TestClient(servers={"default": TestServer()},
                             users={"default": [("lasote", "mypass")]})

--- a/conans/test/functional/old/paths_test.py
+++ b/conans/test/functional/old/paths_test.py
@@ -32,7 +32,7 @@ class PathsTest(unittest.TestCase):
         folder = temp_folder()
         paths = SimplePaths(folder)
         self.assertEqual(paths._store_folder, folder)
-        conan_ref = ConanFileReference.loads("opencv/2.4.10 @ lasote /testing")
+        conan_ref = ConanFileReference.loads("opencv/2.4.10@lasote/testing")
         package_ref = PackageReference(conan_ref, "456fa678eae68")
         expected_base = os.path.join(folder, os.path.sep.join(["opencv", "2.4.10",
                                                                "lasote", "testing"]))
@@ -84,4 +84,3 @@ class PathShortenerTest(unittest.TestCase):
 
             self.assertEqual(self.home_short in r, short_paths)
             self.assertEqual(self.home in r, not short_paths)
-

--- a/conans/test/unittests/model/ref_test.py
+++ b/conans/test/unittests/model/ref_test.py
@@ -39,6 +39,8 @@ class RefTest(unittest.TestCase):
         self.assertRaises(ConanException, ConanFileReference.loads, "opencv/2.4.10")
         self.assertRaises(ConanException, ConanFileReference.loads, "opencv/2.4.10@lasote")
         self.assertRaises(ConanException, ConanFileReference.loads, "opencv??/2.4.10@laso/testing")
+        self.assertRaises(ConanException, ConanFileReference.loads, "opencv/2.4.10 @ laso/testing")
+        self.assertRaises(ConanException, ConanFileReference.loads, "o/2.4.10@laso/testing")
         self.assertRaises(ConanException, ConanFileReference.loads, ".opencv/2.4.10@lasote/testing")
         self.assertRaises(ConanException, ConanFileReference.loads, "o/2.4.10 @ lasote/testing")
         self.assertRaises(ConanException, ConanFileReference.loads, "lib/1.0@user&surname/channel")

--- a/conans/test/unittests/model/ref_test.py
+++ b/conans/test/unittests/model/ref_test.py
@@ -7,7 +7,7 @@ from conans.model.ref import ConanFileReference, ConanName, InvalidNameException
 
 class RefTest(unittest.TestCase):
     def basic_test(self):
-        ref = ConanFileReference.loads("opencv/2.4.10 @ lasote/testing")
+        ref = ConanFileReference.loads("opencv/2.4.10@lasote/testing")
         self.assertEqual(ref.name, "opencv")
         self.assertEqual(ref.version, "2.4.10")
         self.assertEqual(ref.user, "lasote")
@@ -37,7 +37,7 @@ class RefTest(unittest.TestCase):
     def errors_test(self):
         self.assertRaises(ConanException, ConanFileReference.loads, "")
         self.assertRaises(ConanException, ConanFileReference.loads, "opencv/2.4.10")
-        self.assertRaises(ConanException, ConanFileReference.loads, "opencv/2.4.10 @ lasote")
+        self.assertRaises(ConanException, ConanFileReference.loads, "opencv/2.4.10@lasote")
         self.assertRaises(ConanException, ConanFileReference.loads, "opencv??/2.4.10@laso/testing")
         self.assertRaises(ConanException, ConanFileReference.loads, ".opencv/2.4.10@lasote/testing")
         self.assertRaises(ConanException, ConanFileReference.loads, "o/2.4.10 @ lasote/testing")

--- a/conans/test/unittests/model/version_ranges_test.py
+++ b/conans/test/unittests/model/version_ranges_test.py
@@ -287,8 +287,10 @@ class HelloConan(ConanFile):
                            # ranges
                            ('"Say/[<=1.2]@myuser/testing"', "1.2.1", False, False),
                            ('"Say/[>=0.2,<=1.0]@myuser/testing"', "0.3", False, True),
+                           ('"Say/[>=0.2 <=1.0]@myuser/testing"', "0.3", False, True),
                            ('("Say/[<=1.2]@myuser/testing", "override")', "1.2.1", True, False),
                            ('("Say/[>=0.2,<=1.0]@myuser/testing", "override")', "0.3", True, True),
+                           ('("Say/[>=0.2 <=1.0]@myuser/testing", "override")', "0.3", True, True),
                            ])
     def transitive_test(self, version_range, solution, override, valid):
         hello_text = hello_content % ">0.1, <1"


### PR DESCRIPTION
Changelog: Bugfix: Fix version ranges containing spaces and not separated by commas.
Docs: Omit

Close #4270


I think it doesn't make sense to replace whitespace in the middle of a <ref>. That should be an error, not "magically" fixed.