### PR TITLE
Import configparser from six for Python2 compatiblity

### DIFF
--- a/conans/model/editable_cpp_info.py
+++ b/conans/model/editable_cpp_info.py
@@ -1,9 +1,9 @@
 # coding=utf-8
-import configparser
 import ntpath
 import os
 import posixpath
 from collections import defaultdict
+import six.moves.configparser
 
 from conans.client.tools.files import load
 

--- a/conans/model/editable_cpp_info.py
+++ b/conans/model/editable_cpp_info.py
@@ -2,8 +2,12 @@
 import ntpath
 import os
 import posixpath
+import six
 from collections import defaultdict
-from six.moves import configparser
+if six.PY2:
+    from backports import configparser  # To use 'delimiters' in ConfigParser
+else:
+    import configparser
 
 from conans.client.tools.files import load
 

--- a/conans/model/editable_cpp_info.py
+++ b/conans/model/editable_cpp_info.py
@@ -3,7 +3,7 @@ import ntpath
 import os
 import posixpath
 from collections import defaultdict
-import six.moves.configparser
+from six.moves import configparser
 
 from conans.client.tools.files import load
 


### PR DESCRIPTION
Changelog: omit
Docs: omit

@PYVERS: py27

- [x] Refer to the issue that supports this Pull Request: Conan CI Preflight Develop broken -> https://conan-ci.jfrog.info/blue/organizations/jenkins/Preflight_develop/detail/Preflight_develop/71/pipeline/16#step-107-log-1880
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.

<sup>**Note:** By default this PR will skip the slower tests and will use a limited set of python versions. Check [here](https://github.com/conan-io/conan/blob/develop/.github/PR_INCREASE_TESTING.md) how to increase the testing level by writing some tags in the current PR body text.</sup>
