### PR TITLE
#4265 CMake generator IS optional on Windows

### DIFF
--- a/conans/client/build/cmake_flags.py
+++ b/conans/client/build/cmake_flags.py
@@ -36,8 +36,7 @@ def get_generator(settings):
 
     if not compiler or not compiler_version or not arch:
         if os_build == "Windows":
-            # Not enough settings to set a generator in Windows
-            return None
+            return "MinGW Makefiles"
         return "Unix Makefiles"
 
     if compiler == "Visual Studio":

--- a/conans/test/functional/generators/cmake_generator_test.py
+++ b/conans/test/functional/generators/cmake_generator_test.py
@@ -1,0 +1,63 @@
+import unittest
+
+from nose.plugins.attrib import attr
+
+from conans import tools
+from conans.test.utils.tools import TestClient
+
+
+CONAN_RECIPE = """
+from conans import ConanFile, CMake
+
+class FooConan(ConanFile):
+    name = "foo"
+    version = "0.1"
+    settings = "os_build", "compiler", "build_type"
+    generators = "cmake"
+    exports = '*'
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+"""
+
+
+CPP_CONTENT = """
+int main() {}
+"""
+
+CMAKE_RECIPE = """
+cmake_minimum_required(VERSION 2.8.12)
+project(dummy CXX)
+
+include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
+conan_basic_setup()
+
+add_executable(dummy dummy.cpp)
+"""
+
+
+@attr("slow")
+class CMakeGeneratorTest(unittest.TestCase):
+
+    def _generator_test_helper(self, os_build):
+        try:
+            client = TestClient()
+            client.save({"conanfile.py": CONAN_RECIPE,
+                        "CMakeLists.txt": CMAKE_RECIPE,
+                        "dummy.cpp": CPP_CONTENT})
+            client.run("create . lasote/testing -s os_build={}".format(os_build))
+        finally:
+            self.assertNotIn("TypeError: argument of type 'NoneType' is not iterable", client.user_io.out)
+            self.assertNotIn("ERROR:", client.user_io.out)
+            self.assertIn("Check for working CXX compiler", client.user_io.out)
+
+    def test_cmake_default_generator_linux(self):
+        self._generator_test_helper("Linux")
+
+    @unittest.skipUnless(tools.os_info.is_windows, "MinGW is only supported on Windows")
+    def test_cmake_default_generator_windows(self):
+        self._generator_test_helper("Windows")
+
+    def test_cmake_default_generator_osx(self):
+        self._generator_test_helper("Macos")


### PR DESCRIPTION
Hi!

- When arch is not declared and only os_build is available,
  both Linux and Macos can run CMake to generate a default
  build tool e.g. Makefiles. However, on Windows this is not
  true and raises an error.

- This commit returns "MinGW Makefiles" for Windows when arch
  is not specified.

- I've added unit tests to check on Windows, Linux and Macos.

Changelog: (Fix): Fixes #4265 

Docs: https://github.com/conan-io/docs/pull/XXXX

- [x] Refer to the issue that supports this Pull Request.
- [ ] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 

<sup>**Note:** By default this PR will skip the slower tests and will use a limited set of python versions. Check [here](https://github.com/conan-io/conan/blob/develop/.github/PR_INCREASE_TESTING.md) how to increase the testing level by writing some tags in the current PR body text.</sup>
