### PR TITLE
Remove seemingly superfluous variable

### DIFF
--- a/conans/client/generators/premake.py
+++ b/conans/client/generators/premake.py
@@ -53,7 +53,6 @@ class PremakeGenerator(Generator):
         template_deps = template + 'conan_rootpath{dep} = "{deps.rootpath}"\n'
 
         for dep_name, dep_cpp_info in self.deps_build_info.dependencies:
-            deps = PremakeDeps(dep_cpp_info)
             dep_name = dep_name.replace("-", "_")
             dep_flags = template_deps.format(dep="_" + dep_name, deps=deps)
             sections.append(dep_flags)


### PR DESCRIPTION
These two things happen in the same scope:    
````
deps = PremakeDeps(self.deps_build_info)
````
````
deps = PremakeDeps(dep_cpp_info)
````

I think it works fine because I think the two assignments are functionally equivalent, and also because the second just shadows the first.  I remember seeing some generators change from using `deps_cpp_info` to using `self.deps_build_info` at some point, but I'm not sure which is the more current standard. 

I could be wrong about this, and both calls could be required.  In that case, they should probably use the same syntax.

Changelog: (Feature | Fix | Bugfix): Describe here your pull request
Docs: https://github.com/conan-io/docs/pull/XXXX

- [x] Refer to the issue that supports this Pull Request.
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [x] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 

<sup>**Note:** By default this PR will skip the slower tests and will use a limited set of python versions. Check [here](https://github.com/conan-io/conan/blob/develop/.github/PR_INCREASE_TESTING.md) how to increase the testing level by writing some tags in the current PR body text.</sup>
