### PR TITLE
Feature: define environment variables for CTest

### DIFF
--- a/conans/client/build/cmake.py
+++ b/conans/client/build/cmake.py
@@ -233,14 +233,13 @@ class CMake(object):
                                  "defined" % cmake_install_prefix_var_name)
         self._build(args=args, build_dir=build_dir, target="install")
 
-    def test(self, args=None, build_dir=None, target=None, progress=False, output_on_failure=False):
+    def test(self, args=None, build_dir=None, target=None, output_on_failure=False):
         if not self._conanfile.should_test:
             return
         if not target:
             target = "RUN_TESTS" if self.is_multi_configuration else "test"
 
-        env = {'CTEST_PROGRESS_OUTPUT': '1' if progress else '0',
-               'CTEST_OUTPUT_ON_FAILURE': '1' if output_on_failure else '0'}
+        env = {'CTEST_OUTPUT_ON_FAILURE': '1' if output_on_failure else '0'}
         if self.parallel:
             env['CTEST_PARALLEL_LEVEL'] = str(cpu_count(self._conanfile.output))
         with tools.environment_append(env):

--- a/conans/client/build/cmake.py
+++ b/conans/client/build/cmake.py
@@ -233,12 +233,18 @@ class CMake(object):
                                  "defined" % cmake_install_prefix_var_name)
         self._build(args=args, build_dir=build_dir, target="install")
 
-    def test(self, args=None, build_dir=None, target=None):
+    def test(self, args=None, build_dir=None, target=None, progress=False, output_on_failure=False):
         if not self._conanfile.should_test:
             return
         if not target:
             target = "RUN_TESTS" if self.is_multi_configuration else "test"
-        self._build(args=args, build_dir=build_dir, target=target)
+
+        env = {'CTEST_PROGRESS_OUTPUT': '1' if progress else '0',
+               'CTEST_OUTPUT_ON_FAILURE': '1' if output_on_failure else '0'}
+        if self.parallel:
+            env['CTEST_PARALLEL_LEVEL'] = str(cpu_count(self._conanfile.output))
+        with tools.environment_append(env):
+            self._build(args=args, build_dir=build_dir, target=target)
 
     @property
     def verbose(self):

--- a/conans/test/unittests/client/build/cmake_test.py
+++ b/conans/test/unittests/client/build/cmake_test.py
@@ -1160,3 +1160,24 @@ build_type: [ Release]
             vcvars_mock.__exit__ = mock.MagicMock(return_value=None)
             cmake.build()
             self.assertTrue(vcvars_mock.called, "vcvars weren't called")
+
+    def test_ctest_variables(self):
+        conanfile = ConanFileMock()
+        settings = Settings.loads(default_settings_yml)
+        settings.os = "Windows"
+        settings.compiler = "Visual Studio"
+        settings.compiler.version = "14"
+        conanfile.settings = settings
+
+        cmake = CMake(conanfile, parallel=False, generator="NMake Makefiles")
+        cmake.test()
+        self.assertEquals(conanfile.captured_env["CTEST_PROGRESS_OUTPUT"], "0")
+        self.assertEquals(conanfile.captured_env["CTEST_OUTPUT_ON_FAILURE"], "0")
+        self.assertNotIn("CTEST_PARALLEL_LEVEL", conanfile.captured_env)
+
+        with tools.environment_append({"CONAN_CPU_COUNT": "666"}):
+            cmake = CMake(conanfile, parallel=True, generator="NMake Makefiles")
+            cmake.test(progress=True, output_on_failure=True)
+            self.assertEquals(conanfile.captured_env["CTEST_PROGRESS_OUTPUT"], "1")
+            self.assertEquals(conanfile.captured_env["CTEST_OUTPUT_ON_FAILURE"], "1")
+            self.assertEquals(conanfile.captured_env["CTEST_PARALLEL_LEVEL"], "666")

--- a/conans/test/unittests/client/build/cmake_test.py
+++ b/conans/test/unittests/client/build/cmake_test.py
@@ -1171,13 +1171,11 @@ build_type: [ Release]
 
         cmake = CMake(conanfile, parallel=False, generator="NMake Makefiles")
         cmake.test()
-        self.assertEquals(conanfile.captured_env["CTEST_PROGRESS_OUTPUT"], "0")
         self.assertEquals(conanfile.captured_env["CTEST_OUTPUT_ON_FAILURE"], "0")
         self.assertNotIn("CTEST_PARALLEL_LEVEL", conanfile.captured_env)
 
         with tools.environment_append({"CONAN_CPU_COUNT": "666"}):
             cmake = CMake(conanfile, parallel=True, generator="NMake Makefiles")
-            cmake.test(progress=True, output_on_failure=True)
-            self.assertEquals(conanfile.captured_env["CTEST_PROGRESS_OUTPUT"], "1")
+            cmake.test(output_on_failure=True)
             self.assertEquals(conanfile.captured_env["CTEST_OUTPUT_ON_FAILURE"], "1")
             self.assertEquals(conanfile.captured_env["CTEST_PARALLEL_LEVEL"], "666")


### PR DESCRIPTION
closes #3511 

Changelog: Feature: define environment variables for CTest
Docs: https://github.com/conan-io/docs/pull/1018

- [x] Refer to the issue that supports this Pull Request.
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 

<sup>**Note:** By default this PR will skip the slower tests and will use a limited set of python versions. Check [here](https://github.com/conan-io/conan/blob/develop/.github/PR_INCREASE_TESTING.md) how to increase the testing level by writing some tags in the current PR body text.</sup>

/cc @cjdb