### PR TITLE
Consider scm_folder.txt only for developing packages

### DIFF
--- a/conans/client/graph/build_mode.py
+++ b/conans/client/graph/build_mode.py
@@ -39,7 +39,7 @@ class BuildMode(object):
                 raise ConanException("--build=never not compatible with other options")
         self._unused_patterns = list(self.patterns)
 
-    def forced(self, conan_file, reference):
+    def forced(self, conan_file, ref):
         if self.never:
             return False
         if self.all:
@@ -50,7 +50,7 @@ class BuildMode(object):
                                    "build_policy='always'")
             return True
 
-        ref = reference.name
+        ref = ref.name
         # Patterns to match, if package matches pattern, build is forced
         for pattern in self.patterns:
             if fnmatch.fnmatch(ref, pattern):

--- a/conans/client/source.py
+++ b/conans/client/source.py
@@ -196,8 +196,7 @@ def _run_scm(conanfile, src_folder, local_sources_path, output, cache):
     else:
         # In user space, if revision="auto", then copy
         captured = scm_data.capture_origin or scm_data.capture_revision
-    local_sources_path = local_sources_path if captured else None
-    local_sources_path = local_sources_path if conanfile.develop else None
+    local_sources_path = local_sources_path if captured and conanfile.develop else None
 
     if local_sources_path:
         excluded = SCM(scm_data, local_sources_path, output).excluded_files

--- a/conans/client/source.py
+++ b/conans/client/source.py
@@ -197,6 +197,7 @@ def _run_scm(conanfile, src_folder, local_sources_path, output, cache):
         # In user space, if revision="auto", then copy
         captured = scm_data.capture_origin or scm_data.capture_revision
     local_sources_path = local_sources_path if captured else None
+    local_sources_path = local_sources_path if conanfile.develop else None
 
     if local_sources_path:
         excluded = SCM(scm_data, local_sources_path, output).excluded_files

--- a/conans/test/functional/scm/test_local_modified.py
+++ b/conans/test/functional/scm/test_local_modified.py
@@ -1,0 +1,57 @@
+# coding=utf-8
+
+import textwrap
+import unittest
+
+from conans.model.ref import ConanFileReference
+from conans.test.utils.tools import TestClient, create_local_git_repo
+
+
+class SCMFolderObsoleteTest(unittest.TestCase):
+    conanfile = textwrap.dedent("""\
+        from conans import ConanFile, tools
+
+        class Pkg(ConanFile):
+            scm = {"type": "git",
+                   "url": "auto",
+                   "revision": "auto"}
+
+            def build(self):
+                content = tools.load("file.txt")
+                self.output.info(">>>> I'm {}/{}@{}/{}".format(self.name, self.version,
+                                                               self.user, self.channel))
+                self.output.info(">>>> content: {} ".format(content))
+        """)
+
+    def setUp(self):
+        self.reference = "pkg/v1@user/channel"
+        self.t = TestClient(path_with_spaces=False)
+
+        # Create pkg/v1
+        url, _ = create_local_git_repo(files={'conanfile.py': self.conanfile,
+                                              'file.txt': self.reference},
+                                       folder=self.t.current_folder)
+        self.t.runner('git remote add origin {}'.format(url), cwd=self.t.current_folder)
+        self.t.run("create . {}".format(self.reference))
+        self.assertIn(">>>> I'm {}".format(self.reference), self.t.out)
+        self.assertIn(">>>> content: {}".format(self.reference), self.t.out)
+
+        # Change something in the local folder
+        self.new_content = "Updated in the local folder!"
+        self.t.save({'file.txt': self.new_content})
+
+    def test_create_workflow(self):
+        """ Use the 'create' command, local changes are reflected in the cache """
+        self.t.run("create . {}".format(self.reference))
+        self.assertIn(">>>> I'm {}".format(self.reference), self.t.out)
+        self.assertIn(">>>> content: {}".format(self.new_content), self.t.out)
+
+    def test_install_workflow(self):
+        """ Using the install command, it won't be taken into account """
+        t2 = TestClient(base_folder=self.t.base_folder)
+        t2.save({'conanfile.txt': "[requires]\n{}".format(self.reference)})
+        ref = ConanFileReference.loads(self.reference)
+        t2.run("install . --build={}".format(ref.name))
+        self.assertNotIn(self.new_content, t2.out)
+        self.assertIn(">>>> I'm {}".format(self.reference), self.t.out)
+        self.assertIn(">>>> content: {}".format(self.reference), self.t.out)


### PR DESCRIPTION
Changelog: Fix: SCM optimization related to `scm_folder.txt` is taken into account only for packages under development.
Docs: Omit

closes #4218 