### PR TITLE
Added sha1 header always

### DIFF
--- a/conans/client/rest/uploader_downloader.py
+++ b/conans/client/rest/uploader_downloader.py
@@ -20,6 +20,7 @@ class Uploader(object):
 
     def upload(self, url, abs_path, auth=None, dedup=False, retry=1, retry_wait=0, headers=None):
         # Send always the header with the Sha1
+        headers = headers or {}
         headers["X-Checksum-Sha1"] = sha1sum(abs_path)
         if dedup:
             dedup_headers = {"X-Checksum-Deploy": "true"}
@@ -31,8 +32,6 @@ class Uploader(object):
             if response.status_code == 201:  # Artifactory returns 201 if the file is there
                 print("File already there")
                 return response
-
-        headers = headers or {}
 
         self.output.info("")
         # Actual transfer of the real content

--- a/conans/client/rest/uploader_downloader.py
+++ b/conans/client/rest/uploader_downloader.py
@@ -29,7 +29,6 @@ class Uploader(object):
             response = self.requester.put(url, data="", verify=self.verify, headers=dedup_headers,
                                           auth=auth)
             if response.status_code == 201:  # Artifactory returns 201 if the file is there
-                print("File already there")
                 return response
 
         self.output.info("")

--- a/conans/client/rest/uploader_downloader.py
+++ b/conans/client/rest/uploader_downloader.py
@@ -26,7 +26,6 @@ class Uploader(object):
             dedup_headers = {"X-Checksum-Deploy": "true"}
             if headers:
                 dedup_headers.update(headers)
-            print(headers)
             response = self.requester.put(url, data="", verify=self.verify, headers=dedup_headers,
                                           auth=auth)
             if response.status_code == 201:  # Artifactory returns 201 if the file is there
@@ -42,7 +41,6 @@ class Uploader(object):
         # Now it will print progress in each iteration
         iterable_to_file = IterableToFileAdapter(it, file_size)
         # Now it is prepared to work with request
-        print(headers)
         ret = call_with_retry(self.output, retry, retry_wait, self._upload_file, url,
                               data=iterable_to_file, headers=headers, auth=auth)
 


### PR DESCRIPTION
Changelog: Fix: Conan client now always include the `X-Checksum-Sha1` header in the file uploads, not only when checking if the file is already there with a remote supporting checksum deploy (Artifactory)

Docs: omit

Closes #3544