### PR TITLE
#3799 Accept full reference for --build

### DIFF
--- a/conans/client/graph/build_mode.py
+++ b/conans/client/graph/build_mode.py
@@ -62,7 +62,7 @@ class BuildMode(object):
                 return True
         return False
 
-    def allowed(self, conan_file, reference):
+    def allowed(self, conan_file):
         if self.missing or self.outdated:
             return True
         if conan_file.build_policy_missing:

--- a/conans/client/graph/build_mode.py
+++ b/conans/client/graph/build_mode.py
@@ -6,6 +6,7 @@ from conans.errors import ConanException
 class BuildMode(object):
     """ build_mode => ["*"] if user wrote "--build"
                    => ["hello*", "bye*"] if user wrote "--build hello --build bye"
+                   => ["hello/0.1@foo/bar"] if user wrote "--build hello/0.1@foo/bar"
                    => False if user wrote "never"
                    => True if user wrote "missing"
                    => "outdated" if user wrote "--build outdated"
@@ -53,7 +54,7 @@ class BuildMode(object):
         ref = reference.name
         # Patterns to match, if package matches pattern, build is forced
         for pattern in self.patterns:
-            if fnmatch.fnmatch(ref, pattern):
+            if fnmatch.fnmatch(ref, pattern) or repr(reference) == pattern:
                 try:
                     self._unused_patterns.remove(pattern)
                 except ValueError:

--- a/conans/client/graph/graph_binaries.py
+++ b/conans/client/graph/graph_binaries.py
@@ -146,7 +146,7 @@ class GraphBinariesAnalyzer(object):
                 node.binary = BINARY_DOWNLOAD
                 package_hash = remote_info.recipe_hash
             else:
-                if build_mode.allowed(conanfile, ref):
+                if build_mode.allowed(conanfile):
                     node.binary = BINARY_BUILD
                 else:
                     node.binary = BINARY_MISSING

--- a/conans/test/functional/command/build_test.py
+++ b/conans/test/functional/command/build_test.py
@@ -125,8 +125,8 @@ class AConan(ConanFile):
         client.run("build ./my_conanfile.py")
         pref = PackageReference.loads("Hello/0.1@lasote/testing:%s" % NO_SETTINGS_PACKAGE_ID)
         package_folder = client.cache.package(pref).replace("\\", "/")
-        self.assertIn("my_conanfile.py: INCLUDE PATH: %s/include" % package_folder, client.user_io.out)
-        self.assertIn("my_conanfile.py: HELLO ROOT PATH: %s" % package_folder, client.user_io.out)
+        self.assertIn("my_conanfile.py: INCLUDE PATH: %s/include" % package_folder, client.out)
+        self.assertIn("my_conanfile.py: HELLO ROOT PATH: %s" % package_folder, client.out)
         self.assertIn("my_conanfile.py: HELLO INCLUDE PATHS: %s/include"
                       % package_folder, client.user_io.out)
 

--- a/conans/test/functional/command/build_test.py
+++ b/conans/test/functional/command/build_test.py
@@ -310,7 +310,20 @@ class AConan(ConanFile):
         client.run("install . --build missing")
         client.run("build .")
 
-    def build_full_reference_test(self):
+    def build_single_full_reference_test(self):
+        client = TestClient()
+        conanfile = """
+from conans import ConanFile, CMake
+
+class FooConan(ConanFile):
+    name = "foo"
+    version = "1.0"
+"""
+        client.save({CONANFILE: conanfile})
+        client.run("create --build foo/1.0@user/stable . user/stable")
+        self.assertIn("foo/1.0@user/stable: WARN: Forced build from source", client.out)
+
+    def build_multiple_full_reference_test(self):
         client = TestClient()
         conanfile = """
 from conans import ConanFile, CMake
@@ -334,4 +347,3 @@ class BarConan(ConanFile):
         client.run("create --build foo/1.0@user/stable --build bar/1.0@user/testing . user/testing")
         self.assertIn("foo/1.0@user/stable: WARN: Forced build from source", client.out)
         self.assertIn("bar/1.0@user/testing: WARN: Forced build from source", client.out)
-        self.assertNotIn("ERROR", client.out)

--- a/conans/test/unittests/client/graph/build_mode_test.py
+++ b/conans/test/unittests/client/graph/build_mode_test.py
@@ -26,7 +26,8 @@ class BuildModeTest(unittest.TestCase):
         self.assertTrue(build_mode.never)
 
     def test_invalid_configuration(self):
-        with self.assertRaises(ConanException):
+        with self.assertRaisesRegexp(ConanException,
+                                     "--build=never not compatible with other options"):
             BuildMode(["outdated", "missing", "never"], self.output)
 
     def test_common_build_force(self):
@@ -66,8 +67,7 @@ class BuildModeTest(unittest.TestCase):
 
     def test_allowed(self):
         build_mode = BuildMode(["outdated", "missing"], self.output)
-        reference = ConanFileReference.loads("Bar/0.1@user/stable")
-        self.assertTrue(build_mode.allowed(self.conanfile, reference))
+        self.assertTrue(build_mode.allowed(self.conanfile))
 
         build_mode = BuildMode([], self.output)
-        self.assertFalse(build_mode.allowed(self.conanfile, reference))
+        self.assertFalse(build_mode.allowed(self.conanfile))

--- a/conans/test/unittests/client/graph/build_mode_test.py
+++ b/conans/test/unittests/client/graph/build_mode_test.py
@@ -1,0 +1,73 @@
+import unittest
+
+from conans.client.graph.build_mode import BuildMode
+from conans.model.ref import ConanFileReference
+from conans.errors import ConanException
+
+from conans.test.utils.tools import TestBufferConanOutput
+from conans.test.utils.conanfile import MockConanfile
+
+
+class BuildModeTest(unittest.TestCase):
+
+    def setUp(self):
+        self.output = TestBufferConanOutput()
+        self.conanfile = MockConanfile(None)
+
+    def test_valid_params(self):
+        build_mode = BuildMode(["outdated", "missing"], self.output)
+        self.assertTrue(build_mode.outdated)
+        self.assertTrue(build_mode.missing)
+        self.assertFalse(build_mode.never)
+
+        build_mode = BuildMode(["never"], self.output)
+        self.assertFalse(build_mode.outdated)
+        self.assertFalse(build_mode.missing)
+        self.assertTrue(build_mode.never)
+
+    def test_invalid_configuration(self):
+        with self.assertRaises(ConanException):
+            BuildMode(["outdated", "missing", "never"], self.output)
+
+    def test_common_build_force(self):
+        reference = ConanFileReference.loads("Hello/0.1@user/testing")
+        build_mode = BuildMode(["Hello"], self.output)
+        self.assertTrue(build_mode.forced(self.conanfile, reference))
+        build_mode.report_matches()
+        self.assertEqual("", self.output)
+
+    def test_non_matching_build_force(self):
+        reference = ConanFileReference.loads("Bar/0.1@user/testing")
+        build_mode = BuildMode(["Hello"], self.output)
+        self.assertFalse(build_mode.forced(self.conanfile, reference))
+        build_mode.report_matches()
+        self.assertIn("ERROR: No package matching 'Hello' pattern", self.output)
+
+    def test_full_reference_build_force(self):
+        reference = ConanFileReference.loads("Bar/0.1@user/testing")
+        build_mode = BuildMode(["Bar/0.1@user/testing"], self.output)
+        self.assertTrue(build_mode.forced(self.conanfile, reference))
+        build_mode.report_matches()
+        self.assertEqual("", self.output)
+
+    def test_non_matching_full_reference_build_force(self):
+        reference = ConanFileReference.loads("Bar/0.1@user/stable")
+        build_mode = BuildMode(["Bar/0.1@user/testing"], self.output)
+        self.assertFalse(build_mode.forced(self.conanfile, reference))
+        build_mode.report_matches()
+        self.assertIn("No package matching 'Bar/0.1@user/testing' pattern", self.output)
+
+    def test_multiple_builds(self):
+        reference = ConanFileReference.loads("Bar/0.1@user/stable")
+        build_mode = BuildMode(["Bar", "Foo"], self.output)
+        self.assertTrue(build_mode.forced(self.conanfile, reference))
+        build_mode.report_matches()
+        self.assertIn("ERROR: No package matching", self.output)
+
+    def test_allowed(self):
+        build_mode = BuildMode(["outdated", "missing"], self.output)
+        reference = ConanFileReference.loads("Bar/0.1@user/stable")
+        self.assertTrue(build_mode.allowed(self.conanfile, reference))
+
+        build_mode = BuildMode([], self.output)
+        self.assertFalse(build_mode.allowed(self.conanfile, reference))


### PR DESCRIPTION
Related issue #3799 

Changelog: Package reference is now accepted as --build pattern

Docs: https://github.com/conan-io/docs/pull/1017

- [X] Refer to the issue that supports this Pull Request.
- [X] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [X] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [X] I've followed the PEP8 style guides for Python code.
- [X] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 

<sup>**Note:** By default this PR will skip the slower tests and will use a limited set of python versions. Check [here](https://github.com/conan-io/conan/blob/develop/.github/PR_INCREASE_TESTING.md) how to increase the testing level by writing some tags in the current PR body text.</sup>
