### PR TITLE
Add git.get_tag() and svn.get_tag()

### DIFF
--- a/conans/client/tools/scm.py
+++ b/conans/client/tools/scm.py
@@ -342,17 +342,23 @@ class SVN(SCMBase):
             return self._show_item(item='last-changed-revision')
 
     def get_branch(self):
+        return self.get_item("branches/[^/]+|trunk", "branch")
+
+    def get_tag(self):
+        return self.get_item("tags/[^/]+|trunk", "tag")
+
+    def get_item(self, pattern, item_name):
         url = self._show_item('relative-url')
         try:
-            pattern = "(tags|branches)/[^/]+|trunk"
-            branch = re.search(pattern, url)
-            
-            if branch is None:
+            item = re.search(pattern, url)
+
+            if item is None:
                 return None
             else:
-                return branch.group(0)
+                return item.group(0)
         except Exception as e:
-            raise ConanException("Unable to get svn branch from %s: %s" % (self.folder, str(e)))
+            raise ConanException("Unable to get svn %s from %s: %s"
+                                 % (item_name, self.folder, str(e)))
 
     def _check_svn_repo(self):
         try:

--- a/conans/client/tools/scm.py
+++ b/conans/client/tools/scm.py
@@ -179,11 +179,11 @@ class Git(SCMBase):
     def get_tag(self):
         self._check_git_repo()
         try:
-            status = self.run("describe --tags")
+            status = self.run("describe --exact-match --tags")
             tag = status.splitlines()[0].strip()  # 1.11.2-42-g326d3942
             return tag
-        except Exception as e:
-            raise ConanException("Unable to get git tag from %s: %s" % (self.folder, str(e)))
+        except Exception:
+            return None
 
     def _check_git_repo(self):
         try:
@@ -342,10 +342,12 @@ class SVN(SCMBase):
             return self._show_item(item='last-changed-revision')
 
     def get_branch(self):
-        return self._get_item("branches/[^/]+|trunk", "branch")
+        item = self._get_item("branches/[^/]+|trunk", "branch")
+        return item.replace("branches/", "") if item else None
 
     def get_tag(self):
-        return self._get_item("tags/[^/]+", "tag")
+        item = self._get_item("tags/[^/]+", "tag")
+        return item.replace("tags/", "") if item else None
 
     def _get_item(self, pattern, item_name):
         url = self._show_item('relative-url')

--- a/conans/client/tools/scm.py
+++ b/conans/client/tools/scm.py
@@ -345,7 +345,7 @@ class SVN(SCMBase):
         return self.get_item("branches/[^/]+|trunk", "branch")
 
     def get_tag(self):
-        return self.get_item("tags/[^/]+|trunk", "tag")
+        return self.get_item("tags/[^/]+", "tag")
 
     def get_item(self, pattern, item_name):
         url = self._show_item('relative-url')

--- a/conans/client/tools/scm.py
+++ b/conans/client/tools/scm.py
@@ -176,6 +176,15 @@ class Git(SCMBase):
         except Exception as e:
             raise ConanException("Unable to get git branch from %s: %s" % (self.folder, str(e)))
 
+    def get_tag(self):
+        self._check_git_repo()
+        try:
+            status = self.run("describe --tags")
+            tag = status.splitlines()[0].strip()  # 1.11.2-42-g326d3942
+            return tag
+        except Exception as e:
+            raise ConanException("Unable to get git tag from %s: %s" % (self.folder, str(e)))
+
     def _check_git_repo(self):
         try:
             self.run("status")

--- a/conans/client/tools/scm.py
+++ b/conans/client/tools/scm.py
@@ -342,12 +342,12 @@ class SVN(SCMBase):
             return self._show_item(item='last-changed-revision')
 
     def get_branch(self):
-        return self.get_item("branches/[^/]+|trunk", "branch")
+        return self._get_item("branches/[^/]+|trunk", "branch")
 
     def get_tag(self):
-        return self.get_item("tags/[^/]+", "tag")
+        return self._get_item("tags/[^/]+", "tag")
 
-    def get_item(self, pattern, item_name):
+    def _get_item(self, pattern, item_name):
         url = self._show_item('relative-url')
         try:
             item = re.search(pattern, url)

--- a/conans/client/tools/scm.py
+++ b/conans/client/tools/scm.py
@@ -180,7 +180,7 @@ class Git(SCMBase):
         self._check_git_repo()
         try:
             status = self.run("describe --exact-match --tags")
-            tag = status.splitlines()[0].strip()  # 1.11.2-42-g326d3942
+            tag = status.strip()
             return tag
         except Exception:
             return None
@@ -350,17 +350,13 @@ class SVN(SCMBase):
         return item.replace("tags/", "") if item else None
 
     def _get_item(self, pattern, item_name):
-        url = self._show_item('relative-url')
         try:
-            item = re.search(pattern, url)
-
-            if item is None:
-                return None
-            else:
-                return item.group(0)
+            url = self._show_item('relative-url')
         except Exception as e:
             raise ConanException("Unable to get svn %s from %s: %s"
                                  % (item_name, self.folder, str(e)))
+        item = re.search(pattern, url)
+        return item.group(0) if item else None
 
     def _check_svn_repo(self):
         try:

--- a/conans/test/unittests/util/tools_test.py
+++ b/conans/test/unittests/util/tools_test.py
@@ -1876,7 +1876,30 @@ class SVNToolTestsBasic(SVNLocalRepoTestCase):
 
         svn = SVN(folder=self.gimme_tmp())
         svn.checkout(url='/'.join([project_url, 'prj1', 'tags', 'v12.3.4']))
-        self.assertEqual("tags/v12.3.4", svn.get_branch())
+        self.assertIsNone(svn.get_branch())
+
+    def test_tag(self):
+        project_url, _ = self.create_project(files={'prj1/trunk/myfile': "contents",
+                                                    'prj1/branches/my_feature/myfile': "",
+                                                    'prj1/branches/issue3434/myfile': "",
+                                                    'prj1/tags/v12.3.4/myfile': "",
+                                                    })
+        svn = SVN(folder=self.gimme_tmp())
+        svn.checkout(url='/'.join([project_url, 'prj1', 'trunk']))
+        self.assertIsNone(svn.get_tag())
+
+        svn = SVN(folder=self.gimme_tmp())
+        svn.checkout(url='/'.join([project_url, 'prj1', 'branches', 'my_feature']))
+        self.assertIsNone(svn.get_tag())
+
+        svn = SVN(folder=self.gimme_tmp())
+        svn.checkout(url='/'.join([project_url, 'prj1', 'branches', 'issue3434']))
+        self.assertIsNone(svn.get_tag())
+
+        svn = SVN(folder=self.gimme_tmp())
+        svn.checkout(url='/'.join([project_url, 'prj1', 'tags', 'v12.3.4']))
+        self.assertEqual("tags/v12.3.4", svn.get_tag())
+
 
 @attr("slow")
 @attr('svn')

--- a/conans/test/unittests/util/tools_test.py
+++ b/conans/test/unittests/util/tools_test.py
@@ -1649,7 +1649,7 @@ class HelloConan(ConanFile):
 class GitToolsTests(unittest.TestCase):
 
     def setUp(self):
-        self.folder, self.rev = create_local_git_repo({'/myfile': "contents"})
+        self.folder, self.rev = create_local_git_repo({'myfile.txt': "contents"})
 
     def test_no_tag(self):
         """

--- a/conans/test/unittests/util/tools_test.py
+++ b/conans/test/unittests/util/tools_test.py
@@ -1680,6 +1680,14 @@ class GitToolsTests(unittest.TestCase):
         tag = git.get_tag()
         self.assertIsNone(tag)
 
+    def test_get_tag_no_git_repo(self):
+        """
+        Try to get tag out of a git repo
+        """
+        git = Git(folder=temp_folder())
+        with self.assertRaisesRegexp(ConanException, "Not a valid git repository"):
+            git.get_tag()
+
 
 @attr("slow")
 @attr('svn')
@@ -1877,6 +1885,10 @@ class SVNToolTestsBasic(SVNLocalRepoTestCase):
         svn.checkout(url='/'.join([project_url, 'prj1', 'tags', 'v12.3.4']))
         self.assertIsNone(svn.get_branch())
 
+        svn = SVN(folder=self.gimme_tmp())
+        with self.assertRaisesRegexp(ConanException, "Unable to get svn branch"):
+            svn.get_branch()
+
     def test_tag(self):
         project_url, _ = self.create_project(files={'prj1/trunk/myfile': "contents",
                                                     'prj1/branches/my_feature/myfile': "",
@@ -1898,6 +1910,10 @@ class SVNToolTestsBasic(SVNLocalRepoTestCase):
         svn = SVN(folder=self.gimme_tmp())
         svn.checkout(url='/'.join([project_url, 'prj1', 'tags', 'v12.3.4']))
         self.assertEqual("v12.3.4", svn.get_tag())
+
+        svn = SVN(folder=self.gimme_tmp())
+        with self.assertRaisesRegexp(ConanException, "Unable to get svn tag"):
+            svn.get_tag()
 
 
 @attr("slow")

--- a/conans/test/unittests/util/tools_test.py
+++ b/conans/test/unittests/util/tools_test.py
@@ -1656,7 +1656,7 @@ class GitToolsTests(unittest.TestCase):
         No tags has been created in repo
         """
         git = Git(folder=self.folder)
-        with self.assertRaisesRegex(ConanException, "Unable to get git tag from"):
+        with self.assertRaisesRegexp(ConanException, "Unable to get git tag from"):
             git.get_tag()
 
     def test_in_tag(self):

--- a/conans/test/unittests/util/tools_test.py
+++ b/conans/test/unittests/util/tools_test.py
@@ -1656,8 +1656,8 @@ class GitToolsTests(unittest.TestCase):
         No tags has been created in repo
         """
         git = Git(folder=self.folder)
-        with self.assertRaisesRegexp(ConanException, "Unable to get git tag from"):
-            git.get_tag()
+        tag = git.get_tag()
+        self.assertIsNone(tag)
 
     def test_in_tag(self):
         """
@@ -1678,7 +1678,7 @@ class GitToolsTests(unittest.TestCase):
         git.run("add .")
         git.run("commit -m \"new file\"")
         tag = git.get_tag()
-        self.assertRegexpMatches(tag, "0.0.0-1-\w{8}")
+        self.assertIsNone(tag, "0.0.0-1-\w{8}")
 
 
 @attr("slow")
@@ -1867,11 +1867,11 @@ class SVNToolTestsBasic(SVNLocalRepoTestCase):
 
         svn = SVN(folder=self.gimme_tmp())
         svn.checkout(url='/'.join([project_url, 'prj1', 'branches', 'my_feature']))
-        self.assertEqual("branches/my_feature", svn.get_branch())
+        self.assertEqual("my_feature", svn.get_branch())
 
         svn = SVN(folder=self.gimme_tmp())
         svn.checkout(url='/'.join([project_url, 'prj1', 'branches', 'issue3434']))
-        self.assertEqual("branches/issue3434", svn.get_branch())
+        self.assertEqual("issue3434", svn.get_branch())
 
         svn = SVN(folder=self.gimme_tmp())
         svn.checkout(url='/'.join([project_url, 'prj1', 'tags', 'v12.3.4']))
@@ -1897,7 +1897,7 @@ class SVNToolTestsBasic(SVNLocalRepoTestCase):
 
         svn = SVN(folder=self.gimme_tmp())
         svn.checkout(url='/'.join([project_url, 'prj1', 'tags', 'v12.3.4']))
-        self.assertEqual("tags/v12.3.4", svn.get_tag())
+        self.assertEqual("v12.3.4", svn.get_tag())
 
 
 @attr("slow")

--- a/conans/test/unittests/util/tools_test.py
+++ b/conans/test/unittests/util/tools_test.py
@@ -1666,7 +1666,7 @@ class GitToolsTests(unittest.TestCase):
         git = Git(folder=self.folder)
         git.run("tag 0.0.0")
         tag = git.get_tag()
-        self.assertIn("0.0.0", tag)
+        self.assertEqual("0.0.0", tag)
 
     def test_in_branch_with_tag(self):
         """
@@ -1678,7 +1678,7 @@ class GitToolsTests(unittest.TestCase):
         git.run("add .")
         git.run("commit -m \"new file\"")
         tag = git.get_tag()
-        self.assertIsNone(tag, "0.0.0-1-\w{8}")
+        self.assertIsNone(tag)
 
 
 @attr("slow")

--- a/conans/test/unittests/util/tools_test.py
+++ b/conans/test/unittests/util/tools_test.py
@@ -1678,8 +1678,7 @@ class GitToolsTests(unittest.TestCase):
         git.run("add .")
         git.run("commit -m \"new file\"")
         tag = git.get_tag()
-        print(tag)
-        self.assertRegex(tag, "0.0.0-1-\w{8}")
+        self.assertRegexpMatches(tag, "0.0.0-1-\w{8}")
 
 
 @attr("slow")


### PR DESCRIPTION
Changelog: Feature: Added ``get_tag()`` methods to ``tools.Git()`` and ``tools.SVN()`` helpers.
Changelog: Fix: ``get_branch()`` method of ``tools.SVN()`` helper now returns only the branch name, not the tag when present.
Docs: https://github.com/conan-io/docs/pull/1020

@TAGS: svn, slow

- [x] Refer to the issue that supports this Pull Request: closes #3987 
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [x] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 

<sup>**Note:** By default this PR will skip the slower tests and will use a limited set of python versions. Check [here](https://github.com/conan-io/conan/blob/develop/.github/PR_INCREASE_TESTING.md) how to increase the testing level by writing some tags in the current PR body text.</sup>
