### PR TITLE
Fix develop testsuite: MSBuild verbosity level

### DIFF
--- a/conans/test/functional/build_helpers/msbuild_test.py
+++ b/conans/test/functional/build_helpers/msbuild_test.py
@@ -28,7 +28,7 @@ class HelloConan(ConanFile):
 
     def build(self):
         msbuild = MSBuild(self)
-        msbuild.build("MyProject.sln")
+        msbuild.build("MyProject.sln", verbosity="normal")
 
     def package(self):
         self.copy(pattern="*.exe")
@@ -45,7 +45,7 @@ class HelloConan(ConanFile):
                    'compiler="Visual Studio" -s compiler.version=14', assert_error=True)
         client.run('create . Hello/1.2.1@lasote/stable -s cppstd=17 '
                    '-s compiler="Visual Studio" -s compiler.version=14')
-        self.assertIn("Copied 1 '.exe' file: MyProject.exe", client.user_io.out)
+        self.assertIn("Copied 1 '.exe' file: MyProject.exe", client.out)
 
         files = get_vs_project_files()
         files[CONANFILE] = conan_build_vs
@@ -57,28 +57,28 @@ class HelloConan(ConanFile):
         client.save(files, clean_first=True)
         client.run("create . Hello/1.2.1@lasote/stable --build")
         self.assertNotIn("devenv", client.user_io.out)
-        self.assertIn("Skipped sln project upgrade", client.user_io.out)
+        self.assertIn("Skipped sln project upgrade", client.out)
 
         # Try with x86_64
         client.save(files)
         client.run("export . lasote/stable")
         client.run("install Hello/1.2.1@lasote/stable --build -s arch=x86_64")
         self.assertIn("Release|x64", client.user_io.out)
-        self.assertIn("Copied 1 '.exe' file: MyProject.exe", client.user_io.out)
+        self.assertIn("Copied 1 '.exe' file: MyProject.exe", client.out)
 
         # Try with x86
         client.save(files, clean_first=True)
         client.run("export . lasote/stable")
         client.run("install Hello/1.2.1@lasote/stable --build -s arch=x86")
         self.assertIn("Release|x86", client.user_io.out)
-        self.assertIn("Copied 1 '.exe' file: MyProject.exe", client.user_io.out)
+        self.assertIn("Copied 1 '.exe' file: MyProject.exe", client.out)
 
         # Try with x86 debug
         client.save(files, clean_first=True)
         client.run("export . lasote/stable")
         client.run("install Hello/1.2.1@lasote/stable --build -s arch=x86 -s build_type=Debug")
         self.assertIn("Debug|x86", client.user_io.out)
-        self.assertIn("Copied 1 '.exe' file: MyProject.exe", client.user_io.out)
+        self.assertIn("Copied 1 '.exe' file: MyProject.exe", client.out)
 
         # Try with a custom property file name
         files[CONANFILE] = conan_build_vs.replace('msbuild.build("MyProject.sln")',
@@ -87,7 +87,7 @@ class HelloConan(ConanFile):
         client.save(files, clean_first=True)
         client.run("create . Hello/1.2.1@lasote/stable --build -s arch=x86 -s build_type=Debug")
         self.assertIn("Debug|x86", client.user_io.out)
-        self.assertIn("Copied 1 '.exe' file: MyProject.exe", client.user_io.out)
+        self.assertIn("Copied 1 '.exe' file: MyProject.exe", client.out)
         full_ref = "Hello/1.2.1@lasote/stable:b786e9ece960c3a76378ca4d5b0d0e922f4cedc1"
         pref = PackageReference.loads(full_ref)
         build_folder = client.cache.build(pref)

--- a/conans/test/functional/build_helpers/msbuild_test.py
+++ b/conans/test/functional/build_helpers/msbuild_test.py
@@ -91,7 +91,7 @@ class HelloConan(ConanFile):
         full_ref = "Hello/1.2.1@lasote/stable:b786e9ece960c3a76378ca4d5b0d0e922f4cedc1"
         pref = PackageReference.loads(full_ref)
         build_folder = client.cache.build(pref)
-        self.assertTrue(os.path.exists(os.path.join(build_folder, "myprops.props")))
+        self.assertTrue(os.path.exists(os.path.join(build_folder, "conan_build.props")))
 
     @unittest.skipUnless(platform.system() == "Windows", "Requires MSBuild")
     def reuse_msbuild_object_test(self):

--- a/conans/test/functional/build_helpers/msbuild_test.py
+++ b/conans/test/functional/build_helpers/msbuild_test.py
@@ -81,9 +81,9 @@ class HelloConan(ConanFile):
         self.assertIn("Copied 1 '.exe' file: MyProject.exe", client.out)
 
         # Try with a custom property file name
-        files[CONANFILE] = conan_build_vs.replace('msbuild.build("MyProject.sln")',
-                                                  'msbuild.build("MyProject.sln", '
-                                                  'property_file_name="myprops.props")')
+        files[CONANFILE] = conan_build_vs.replace(
+                'msbuild.build("MyProject.sln", verbosity="normal")',
+                'msbuild.build("MyProject.sln", verbosity="normal", property_file_name="mp.props")')
         client.save(files, clean_first=True)
         client.run("create . Hello/1.2.1@lasote/stable --build -s arch=x86 -s build_type=Debug")
         self.assertIn("Debug|x86", client.user_io.out)
@@ -91,7 +91,7 @@ class HelloConan(ConanFile):
         full_ref = "Hello/1.2.1@lasote/stable:b786e9ece960c3a76378ca4d5b0d0e922f4cedc1"
         pref = PackageReference.loads(full_ref)
         build_folder = client.cache.build(pref)
-        self.assertTrue(os.path.exists(os.path.join(build_folder, "conan_build.props")))
+        self.assertTrue(os.path.exists(os.path.join(build_folder, "mp.props")))
 
     @unittest.skipUnless(platform.system() == "Windows", "Requires MSBuild")
     def reuse_msbuild_object_test(self):


### PR DESCRIPTION
Changelog: omit
Docs: omit

Seems all the test affected by MSBuild verbosity level were not run in #4251 due to skipping "slow" tagged ones.

@TAGS: slow

- [x] Refer to the issue that supports this Pull Request: https://conan-ci.jfrog.info/blue/organizations/jenkins/ConanTestSuite/detail/develop/35/pipeline
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.

<sup>**Note:** By default this PR will skip the slower tests and will use a limited set of python versions. Check [here](https://github.com/conan-io/conan/blob/develop/.github/PR_INCREASE_TESTING.md) how to increase the testing level by writing some tags in the current PR body text.</sup>
