### PR TITLE
Fix: ensure tools.environment_append doesn't raise trying to unset variables

### DIFF
--- a/conans/client/tools/env.py
+++ b/conans/client/tools/env.py
@@ -54,7 +54,8 @@ def environment_append(env_vars):
         old_env = dict(os.environ)
         os.environ.update(env_vars)
         for var in unset_vars:
-            os.environ.pop(var)
+            if var in os.environ:
+                os.environ.pop(var)
         try:
             yield
         finally:

--- a/conans/client/tools/env.py
+++ b/conans/client/tools/env.py
@@ -54,8 +54,7 @@ def environment_append(env_vars):
         old_env = dict(os.environ)
         os.environ.update(env_vars)
         for var in unset_vars:
-            if var in os.environ:
-                os.environ.pop(var)
+            os.environ.pop(var, None)
         try:
             yield
         finally:

--- a/conans/test/unittests/client/tools/test_env.py
+++ b/conans/test/unittests/client/tools/test_env.py
@@ -46,3 +46,9 @@ class ToolsEnvTest(unittest.TestCase):
                               'env_var2': 'value2'}),\
              env.environment_append({'env_var1': None}):
                 self.assertNotIn('env_var1', os.environ)
+
+    def test_environment_append_unsetting_non_existing_variables(self):
+        with mock.patch.dict('os.environ',
+                             {'env_var2': 'value2'}),\
+             env.environment_append({'env_var1': None}):
+                self.assertNotIn('env_var1', os.environ)


### PR DESCRIPTION
closes #4323 

Changelog: Fix: ensure tools.environment_append doesn't raise trying to unset variables
Docs: https://github.com/conan-io/docs/pull/1023

- [x] Refer to the issue that supports this Pull Request.
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [x] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 

<sup>**Note:** By default this PR will skip the slower tests and will use a limited set of python versions. Check [here](https://github.com/conan-io/conan/blob/develop/.github/PR_INCREASE_TESTING.md) how to increase the testing level by writing some tags in the current PR body text.</sup>
