### PR TITLE
#4331 Bump pyOpenSSL version for OSX

### DIFF
--- a/conans/requirements_osx.txt
+++ b/conans/requirements_osx.txt
@@ -1,3 +1,3 @@
 idna==2.6 # Solving conflict, somehow is installing 2.7 when requests require 2.6
 cryptography>=1.3.4, <2.4.0
-pyOpenSSL>=16.0.0, <18.0.0
+pyOpenSSL>=16.0.0, <19.0.0


### PR DESCRIPTION
closes #4331 
Changelog:  Fix minimal version for pyOpenSSL on OSX
Docs: Omit

- [X] Refer to the issue that supports this Pull Request.
- [X] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [X] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [] I've followed the PEP8 style guides for Python code.
- [] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 

<sup>**Note:** By default this PR will skip the slower tests and will use a limited set of python versions. Check [here](https://github.com/conan-io/conan/blob/develop/.github/PR_INCREASE_TESTING.md) how to increase the testing level by writing some tags in the current PR body text.</sup>
