### PR TITLE
#4339 Remove profile from cmake gen tests

### DIFF
--- a/conans/test/functional/generators/cmake_generator_test.py
+++ b/conans/test/functional/generators/cmake_generator_test.py
@@ -16,7 +16,7 @@ class FooConan(ConanFile):
     generators = "cmake"
 
     def build(self):
-        cmake = CMake(self, generator="{}")
+        cmake = CMake(self)
         cmake.configure()
 """
 
@@ -40,7 +40,7 @@ class CMakeGeneratorTest(unittest.TestCase):
 
     def _check_build_generator(self, generator):
         client = TestClient()
-        client.save({"conanfile.py": CONAN_RECIPE.format(generator),
+        client.save({"conanfile.py": CONAN_RECIPE,
                      "CMakeLists.txt": CMAKE_RECIPE,
                      "dummy.cpp": CPP_CONTENT})
 

--- a/conans/test/functional/generators/cmake_generator_test.py
+++ b/conans/test/functional/generators/cmake_generator_test.py
@@ -1,4 +1,5 @@
 import unittest
+import os
 
 from nose.plugins.attrib import attr
 
@@ -12,7 +13,7 @@ from conans import ConanFile, CMake
 class FooConan(ConanFile):
     name = "foo"
     version = "0.1"
-    settings = "os_build", "compiler", "build_type"
+    settings = "os_build"
     generators = "cmake"
 
     def build(self):
@@ -27,45 +28,41 @@ int main() {}
 
 CMAKE_RECIPE = """
 cmake_minimum_required(VERSION 2.8.12)
-project(dummy CXX)
+project(dummy)
 
 include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
 conan_basic_setup()
-
-add_executable(dummy dummy.cpp)
 """
 
 PROFILE = """
 [settings]
+os={os_build}
 os_build={os_build}
-compiler={compiler}
-compiler.version={compiler_version}
-compiler.libcxx=libstdc++
 """
-
 
 class CMakeGeneratorTest(unittest.TestCase):
 
-    def _check_build_generator(self, os_build, compiler, compiler_version, generator):
+    def _check_build_generator(self, os_build, generator):
         client = TestClient()
         client.save({"conanfile.py": CONAN_RECIPE,
                      "CMakeLists.txt": CMAKE_RECIPE,
                      "dummy.cpp": CPP_CONTENT,
-                     "my_profile": PROFILE.format(os_build=os_build, compiler=compiler,
-                                                  compiler_version=compiler_version)})
+                     "my_profile": PROFILE.format(os_build=os_build)
+                     })
         client.run("install . -p my_profile")
         client.run("build .")
-        self.assertIn("Check for working CXX compiler", client.out)
+
         self.assertIn('cmake -G "{}"'.format(generator), client.out)
+        self.assertTrue(os.path.isfile(os.path.join(client.current_folder, "Makefile")))
 
     @unittest.skipUnless(tools.os_info.is_linux, "Compilation with real gcc needed")
     def test_cmake_default_generator_linux(self):
-        self._check_build_generator("Linux", "gcc", "5", "Unix Makefiles")
+        self._check_build_generator("Linux", "Unix Makefiles")
 
     @unittest.skipUnless(tools.os_info.is_windows, "MinGW is only supported on Windows")
     def test_cmake_default_generator_windows(self):
-        self._check_build_generator("Windows", "gcc", "7", "MinGW Makefiles")
+        self._check_build_generator("Windows", "MinGW Makefiles")
 
     @unittest.skipUnless(tools.os_info.is_macos, "Compilation with real clang is needed")
     def test_cmake_default_generator_osx(self):
-        self._check_build_generator("Macos", "apple-clang", "9.0", "Unix Makefiles")
+        self._check_build_generator("Macos", "Unix Makefiles")

--- a/conans/test/functional/generators/cmake_generator_test.py
+++ b/conans/test/functional/generators/cmake_generator_test.py
@@ -35,37 +35,28 @@ conan_basic_setup()
 add_executable(dummy dummy.cpp)
 """
 
-PROFILE = """
-[settings]
-os_build={os_build}
-compiler={compiler}
-compiler.version={compiler_version}
-compiler.libcxx=libstdc++
-"""
-
 
 class CMakeGeneratorTest(unittest.TestCase):
 
-    def _check_build_generator(self, os_build, compiler, compiler_version, generator):
+    def _check_build_generator(self, generator):
         client = TestClient()
         client.save({"conanfile.py": CONAN_RECIPE,
                      "CMakeLists.txt": CMAKE_RECIPE,
-                     "dummy.cpp": CPP_CONTENT,
-                     "my_profile": PROFILE.format(os_build=os_build, compiler=compiler,
-                                                  compiler_version=compiler_version)})
-        client.run("install . -p my_profile")
+                     "dummy.cpp": CPP_CONTENT})
+
+        client.run("install .")
         client.run("build .")
         self.assertIn("Check for working CXX compiler", client.out)
         self.assertIn('cmake -G "{}"'.format(generator), client.out)
 
     @unittest.skipUnless(tools.os_info.is_linux, "Compilation with real gcc needed")
     def test_cmake_default_generator_linux(self):
-        self._check_build_generator("Linux", "gcc", "5", "Unix Makefiles")
+        self._check_build_generator("Unix Makefiles")
 
     @unittest.skipUnless(tools.os_info.is_windows, "MinGW is only supported on Windows")
     def test_cmake_default_generator_windows(self):
-        self._check_build_generator("Windows", "gcc", "7", "MinGW Makefiles")
+        self._check_build_generator("MinGW Makefiles")
 
     @unittest.skipUnless(tools.os_info.is_macos, "Compilation with real clang is needed")
     def test_cmake_default_generator_osx(self):
-        self._check_build_generator("Macos", "apple-clang", "9.0", "Unix Makefiles")
+        self._check_build_generator("Unix Makefiles")

--- a/conans/test/functional/generators/cmake_generator_test.py
+++ b/conans/test/functional/generators/cmake_generator_test.py
@@ -16,7 +16,7 @@ class FooConan(ConanFile):
     generators = "cmake"
 
     def build(self):
-        cmake = CMake(self)
+        cmake = CMake(self, generator="{}")
         cmake.configure()
 """
 
@@ -40,7 +40,7 @@ class CMakeGeneratorTest(unittest.TestCase):
 
     def _check_build_generator(self, generator):
         client = TestClient()
-        client.save({"conanfile.py": CONAN_RECIPE,
+        client.save({"conanfile.py": CONAN_RECIPE.format(generator),
                      "CMakeLists.txt": CMAKE_RECIPE,
                      "dummy.cpp": CPP_CONTENT})
 

--- a/conans/test/unittests/client/build/cmake_flags.py
+++ b/conans/test/unittests/client/build/cmake_flags.py
@@ -1,7 +1,8 @@
 import unittest
 
+from conans import CMake
 from conans.client.build.cmake_flags import get_generator
-from conans.test.utils.conanfile import MockSettings
+from conans.test.utils.conanfile import MockSettings, ConanFileMock
 
 
 class CMakeGeneratorTest(unittest.TestCase):
@@ -10,13 +11,24 @@ class CMakeGeneratorTest(unittest.TestCase):
         settings = MockSettings({"os_build": "Linux"})
         generator = get_generator(settings)
         self.assertEquals("Unix Makefiles", generator)
+        self._test_default_generator_cmake(settings, "Unix Makefiles")
 
     def test_cmake_default_generator_osx(self):
         settings = MockSettings({"os_build": "Macos"})
         generator = get_generator(settings)
         self.assertEquals("Unix Makefiles", generator)
+        self._test_default_generator_cmake(settings, "Unix Makefiles")
 
     def test_default_generator_windows(self):
         settings = MockSettings({"os_build": "Windows"})
         generator = get_generator(settings)
         self.assertEquals("MinGW Makefiles", generator)
+        self._test_default_generator_cmake(settings, "MinGW Makefiles")
+
+    def _test_default_generator_cmake(self, settings, generator):
+        conanfile = ConanFileMock()
+        conanfile.settings = settings
+        cmake = CMake(conanfile)
+        self.assertEquals(generator, cmake.generator)
+        self.assertIn('-G "{}"'.format(generator), cmake.command_line)
+


### PR DESCRIPTION
I think the best we can do now is exclude the temporary profile from CMake generator tests

closes #4339 
Changelog: Omit
Docs: Omit

/cc @jgsogo 

- [X] Refer to the issue that supports this Pull Request.
- [X] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [X] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [X] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 

<sup>**Note:** By default this PR will skip the slower tests and will use a limited set of python versions. Check [here](https://github.com/conan-io/conan/blob/develop/.github/PR_INCREASE_TESTING.md) how to increase the testing level by writing some tags in the current PR body text.</sup>
