### PR TITLE
Feature: add support for Emscripten (asm.js & wasm)

### DIFF
--- a/conans/client/conf/__init__.py
+++ b/conans/client/conf/__init__.py
@@ -46,7 +46,7 @@ os:
     Arduino:
         board: ANY
     Emscripten:
-arch: [x86, x86_64, ppc32, ppc64le, ppc64, armv4, armv4i, armv5el, armv5hf, armv6, armv7, armv7hf, armv7s, armv7k, armv8, armv8_32, armv8.3, sparc, sparcv9, mips, mips64, avr, s390, s390x, asmjs, wasm]
+arch: [x86, x86_64, ppc32, ppc64le, ppc64, armv4, armv4i, armv5el, armv5hf, armv6, armv7, armv7hf, armv7s, armv7k, armv8, armv8_32, armv8.3, sparc, sparcv9, mips, mips64, avr, s390, s390x, asm.js, wasm]
 compiler:
     sun-cc:
         version: ["5.10", "5.11", "5.12", "5.13", "5.14"]

--- a/conans/client/conf/__init__.py
+++ b/conans/client/conf/__init__.py
@@ -18,7 +18,7 @@ arch_build: [x86, x86_64, ppc32, ppc64le, ppc64, armv5el, armv5hf, armv6, armv7,
 # Only for building cross compilation tools, 'os_target/arch_target' is the system for
 # which the tools generate code
 os_target: [Windows, Linux, Macos, Android, iOS, watchOS, tvOS, FreeBSD, SunOS, Arduino]
-arch_target: [x86, x86_64, ppc32, ppc64le, ppc64, armv5el, armv5hf, armv6, armv7, armv7hf, armv7s, armv7k, armv8, armv8_32, armv8.3, sparc, sparcv9, mips, mips64, avr, s390, s390x]
+arch_target: [x86, x86_64, ppc32, ppc64le, ppc64, armv5el, armv5hf, armv6, armv7, armv7hf, armv7s, armv7k, armv8, armv8_32, armv8.3, sparc, sparcv9, mips, mips64, avr, s390, s390x, asm.js, wasm]
 
 # Rest of the settings are "host" settings:
 # - For native building/cross building: Where the library/program will run.
@@ -45,7 +45,8 @@ os:
     SunOS:
     Arduino:
         board: ANY
-arch: [x86, x86_64, ppc32, ppc64le, ppc64, armv4, armv4i, armv5el, armv5hf, armv6, armv7, armv7hf, armv7s, armv7k, armv8, armv8_32, armv8.3, sparc, sparcv9, mips, mips64, avr, s390, s390x]
+    Emscripten:
+arch: [x86, x86_64, ppc32, ppc64le, ppc64, armv4, armv4i, armv5el, armv5hf, armv6, armv7, armv7hf, armv7s, armv7k, armv8, armv8_32, armv8.3, sparc, sparcv9, mips, mips64, avr, s390, s390x, asmjs, wasm]
 compiler:
     sun-cc:
         version: ["5.10", "5.11", "5.12", "5.13", "5.14"]

--- a/conans/client/tools/files.py
+++ b/conans/client/tools/files.py
@@ -321,7 +321,7 @@ def collect_libs(conanfile, folder=None):
         files = os.listdir(lib_folder)
         for f in files:
             name, ext = os.path.splitext(f)
-            if ext in (".so", ".lib", ".a", ".dylib"):
+            if ext in (".so", ".lib", ".a", ".dylib", ".bc"):
                 if ext != ".lib" and name.startswith("lib"):
                     name = name[3:]
                 if name in result:

--- a/conans/client/tools/oss.py
+++ b/conans/client/tools/oss.py
@@ -375,7 +375,9 @@ def get_gnu_triplet(os_, arch, compiler=None):
                "x86_64": "x86_64",
                "armv8": "aarch64",
                "armv8_32": "aarch64",  # https://wiki.linaro.org/Platform/arm64-ilp32
-               "armv8.3": "aarch64"
+               "armv8.3": "aarch64",
+               "asm.js": "asmjs",
+               "wasm": "wasm32",
                }.get(arch, None)
 
     if not machine:
@@ -421,7 +423,10 @@ def get_gnu_triplet(os_, arch, compiler=None):
                  "Macos": "apple-darwin",
                  "iOS": "apple-darwin",
                  "watchOS": "apple-darwin",
-                 "tvOS": "apple-darwin"}.get(os_, os_.lower())
+                 "tvOS": "apple-darwin",
+                 # NOTE: it technically must be "asmjs-unknown-emscripten" or
+                 # "wasm32-unknown-emscripten", but it's not recognized by old config.sub versions
+                 "Emscripten": "local-emscripten"}.get(os_, os_.lower())
 
     if os_ in ("Linux", "Android"):
         if "arm" in arch and "armv8" not in arch:

--- a/conans/test/unittests/model/other_settings_test.py
+++ b/conans/test/unittests/model/other_settings_test.py
@@ -338,7 +338,7 @@ class SayConan(ConanFile):
         client.save({CONANFILE: content})
         client.run("install . -s os=ChromeOS --build missing", assert_error=True)
         self.assertIn(bad_value_msg("settings.os", "ChromeOS",
-                                    ['Android', 'Arduino', 'FreeBSD', 'Linux', 'Macos', 'SunOS',
+                                    ['Android', 'Arduino', 'Emscripten', 'FreeBSD', 'Linux', 'Macos', 'SunOS',
                                      'Windows', 'WindowsCE', 'WindowsStore', 'iOS', 'tvOS', 'watchOS']),
                       str(client.user_io.out))
 

--- a/conans/test/unittests/model/transitive_reqs_test.py
+++ b/conans/test/unittests/model/transitive_reqs_test.py
@@ -1713,7 +1713,7 @@ class SayConan(ConanFile):
         with self.assertRaises(ConanException) as cm:
             self.build_graph(content, options="arch_independent=True", settings="os=Linux")
         self.assertIn(bad_value_msg("settings.os", "Linux",
-                                    ['Android', 'Arduino', 'FreeBSD', 'Macos',
+                                    ['Android', 'Arduino', 'Emscripten', 'FreeBSD', 'Macos',
                                      'SunOS', 'Windows', 'WindowsCE', 'WindowsStore',
                                      'iOS', 'tvOS', 'watchOS']),
                       str(cm.exception))

--- a/conans/test/unittests/util/tools_test.py
+++ b/conans/test/unittests/util/tools_test.py
@@ -1203,7 +1203,9 @@ ProgramFiles(x86)=C:\Program Files (x86)
         ["watchOS", "armv7k", None, "arm-apple-darwin"],
         ["watchOS", "armv8_32", None, "aarch64-apple-darwin"],
         ["tvOS", "armv8", None, "aarch64-apple-darwin"],
-        ["tvOS", "armv8.3", None, "aarch64-apple-darwin"]
+        ["tvOS", "armv8.3", None, "aarch64-apple-darwin"],
+        ["Emscripten", "asm.js", None, "asmjs-local-emscripten"],
+        ["Emscripten", "wasm", None, "wasm32-local-emscripten"]
     ])
     def get_gnu_triplet_test(self, os, arch, compiler, expected_triplet):
         triplet = tools.get_gnu_triplet(os, arch, compiler)


### PR DESCRIPTION
docs: https://github.com/conan-io/docs/pull/1249

closes #4366
related:
- https://github.com/conan-io/cmake-conan/issues/72
- https://github.com/conan-io/conan/pull/1565
- https://github.com/bincrafters/community/issues/599

additions:
- add `Emscripten` OS
- add `asm.js` and `wasm` (Web Assembly) architectures
- add `asmjs-local-emscripten` and `wasm32-local-emscripten` GNU triplets (see http://git.savannah.gnu.org/gitweb/?p=config.git;a=blob;f=config.sub;h=3b4c7624b68d2d7f84618e1b5fa2badd43a48325;hb=HEAD#l1248 and http://git.savannah.gnu.org/gitweb/?p=config.git;a=blob;f=config.sub;h=3b4c7624b68d2d7f84618e1b5fa2badd43a48325;hb=HEAD#l1170)

I've did some testing with the following profile:
```
[settings]
os=Emscripten
arch=asm.js
os_build=Linux
arch_build=x86_64
compiler=clang
compiler.version=6.0
compiler.libcxx=libc++
[options]
[build_requires]
emsdk_installer/1.38.22@bincrafters/stable
[env]
```
was able to successfully build the following projects:

- zlib
- bzip2
- libiconv
- gtest
- boost (with minimal modifications)

Changelog: Feature: add support for Emscripten (asm.js & wasm)
Docs: https://github.com/conan-io/docs/pull/XXXX

- [x] Refer to the issue that supports this Pull Request.
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [x] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 

<sup>**Note:** By default this PR will skip the slower tests and will use a limited set of python versions. Check [here](https://github.com/conan-io/conan/blob/develop/.github/PR_INCREASE_TESTING.md) how to increase the testing level by writing some tags in the current PR body text.</sup>

/cc @trivigy @mikea @tonka3000 t