### PR TITLE
Feature: detect_windows_subsystem recognizes WSL

### DIFF
--- a/conans/client/tools/oss.py
+++ b/conans/client/tools/oss.py
@@ -290,6 +290,7 @@ class OSInfo(object):
         from conans.client.tools.win import CYGWIN, MSYS2, MSYS, WSL
         if OSInfo().is_linux:
             try:
+                # https://github.com/Microsoft/WSL/issues/423#issuecomment-221627364
                 with open("/proc/sys/kernel/osrelease") as f:
                     return WSL if f.read().endswith("Microsoft") else None
             except FileNotFoundError:

--- a/conans/client/tools/oss.py
+++ b/conans/client/tools/oss.py
@@ -288,6 +288,12 @@ class OSInfo(object):
     @staticmethod
     def detect_windows_subsystem():
         from conans.client.tools.win import CYGWIN, MSYS2, MSYS, WSL
+        if OSInfo().is_linux:
+            try:
+                with open("/proc/sys/kernel/osrelease") as f:
+                    return WSL if f.read().endswith("Microsoft") else None
+            except FileNotFoundError:
+                return None
         try:
             output = OSInfo.uname()
         except ConanException:

--- a/conans/test/unittests/client/tools/os_info/osinfo_test.py
+++ b/conans/test/unittests/client/tools/os_info/osinfo_test.py
@@ -5,7 +5,8 @@ import os
 import unittest
 from mock import mock
 
-from conans.client.tools import OSInfo, environment_append, CYGWIN, MSYS2, MSYS, remove_from_path
+from conans.client.tools import OSInfo, environment_append, CYGWIN, MSYS2, MSYS, WSL, \
+    remove_from_path
 from conans.errors import ConanException
 
 
@@ -179,3 +180,22 @@ class OSInfoTest(unittest.TestCase):
             with self.assertRaises(ConanException):
                 OSInfo.uname()
             self.assertIsNone(OSInfo.detect_windows_subsystem())
+
+    def test_wsl(self):
+        from six.moves import builtins
+
+        with mock.patch("platform.system", mock.MagicMock(return_value='Linux')):
+            with mock.patch.object(OSInfo, '_get_linux_distro_info'):
+                self.assertFalse(OSInfo().is_windows)
+                self.assertFalse(OSInfo().is_cygwin)
+                self.assertFalse(OSInfo().is_msys)
+                self.assertTrue(OSInfo().is_linux)
+                self.assertFalse(OSInfo().is_freebsd)
+                self.assertFalse(OSInfo().is_macos)
+                self.assertFalse(OSInfo().is_solaris)
+
+                with self.assertRaises(ConanException):
+                    OSInfo.uname()
+                with mock.patch.object(builtins, "open",
+                                       mock.mock_open(read_data="4.4.0-43-Microsoft")):
+                    self.assertEqual(OSInfo.detect_windows_subsystem(), WSL)


### PR DESCRIPTION
Changelog: Bugfix: `tool.detect_windows_subsystem` know recognizes WSL correctly.
Docs: omit

related to the #2817

detection based on suggestion from MSFT developer: https://github.com/Microsoft/WSL/issues/844
```
sse4@DESKTOP-E3NFU1V:~$ cat /proc/version
Linux version 4.4.0-43-Microsoft (Microsoft@Microsoft.com) (gcc version 5.4.0 (GCC) ) #1-Microsoft Wed Dec 31 14:42:53 PST 2014
sse4@DESKTOP-E3NFU1V:~$ cat /proc/sys/kernel/osrelease
4.4.0-43-Microsoft
```

/cc @db4
