### PR TITLE
 Map Conan cppflags to CXXFLAGS in make generator

### DIFF
--- a/conans/client/generators/make.py
+++ b/conans/client/generators/make.py
@@ -47,15 +47,15 @@ class MakeGenerator(Generator):
 
         vars_info = [("ROOT", self.assignment_if_absent, [cpp_info.rootpath]),
                      ("SYSROOT", self.assignment_if_absent, [cpp_info.sysroot]),
-                     ("INCLUDE_PATHS", self.assignment_append, cpp_info.include_paths),
-                     ("LIB_PATHS", self.assignment_append, cpp_info.lib_paths),
-                     ("BIN_PATHS", self.assignment_append, cpp_info.bin_paths),
-                     ("BUILD_PATHS", self.assignment_append, cpp_info.build_paths),
-                     ("RES_PATHS", self.assignment_append, cpp_info.res_paths),
+                     ("INCLUDE_DIRS", self.assignment_append, cpp_info.include_paths),
+                     ("LIB_DIRS", self.assignment_append, cpp_info.lib_paths),
+                     ("BIN_DIRS", self.assignment_append, cpp_info.bin_paths),
+                     ("BUILD_DIRS", self.assignment_append, cpp_info.build_paths),
+                     ("RES_DIRS", self.assignment_append, cpp_info.res_paths),
                      ("LIBS", self.assignment_append, cpp_info.libs),
                      ("DEFINES", self.assignment_append, cpp_info.defines),
                      ("CFLAGS", self.assignment_append, cpp_info.cflags),
-                     ("CPPFLAGS", self.assignment_append, cpp_info.cppflags),
+                     ("CXXFLAGS", self.assignment_append, cpp_info.cppflags),
                      ("SHAREDLINKFLAGS", self.assignment_append, cpp_info.sharedlinkflags),
                      ("EXELINKFLAGS", self.assignment_append, cpp_info.exelinkflags)]
 
@@ -104,6 +104,6 @@ class MakeGenerator(Generator):
 
     @staticmethod
     def all_dep_vars():
-        return ["rootpath", "sysroot", "include_paths", "lib_paths", "bin_paths", "build_paths",
-                "res_paths", "libs", "defines", "cflags", "cppflags", "sharedlinkflags",
+        return ["rootpath", "sysroot", "include_dirs", "lib_dirs", "bin_dirs", "build_dirs",
+                "res_dirs", "libs", "defines", "cflags", "cxxflags", "sharedlinkflags",
                 "exelinkflags"]

--- a/conans/test/functional/generators/make_test.py
+++ b/conans/test/functional/generators/make_test.py
@@ -17,8 +17,9 @@ class MakeGeneratorTest(unittest.TestCase):
         client.run("new myhello/1.0.0 --sources")
         conanfile_path = os.path.join(client.current_folder, "conanfile.py")
         replace_in_file(conanfile_path, "{\"shared\": [True, False]}",
-                        "{\"shared\": [True, False], \"fPIC\": [True, False]}")
-        replace_in_file(conanfile_path, "\"shared=False\"", "\"shared=False\", \"fPIC=True\"")
+                        "{\"shared\": [True, False], \"fPIC\": [True, False]}", output=client.out)
+        replace_in_file(conanfile_path, "\"shared=False\"", "\"shared=False\", \"fPIC=True\"",
+                        output = client.out)
         client.run("create . danimtb/testing")
         hellowrapper_include = """
 #pragma once
@@ -64,7 +65,7 @@ CXXFLAGS += \
 #----------------------------------------
 
 CFLAGS              += $(CONAN_CFLAGS)
-CXXFLAGS            += $(CONAN_CPPFLAGS)
+CXXFLAGS            += $(CONAN_CXXFLAGS)
 CPPFLAGS            += $(addprefix -I, $(INCLUDE_PATHS) $(CONAN_INCLUDE_PATHS))
 CPPFLAGS            += $(addprefix -D, $(CONAN_DEFINES))
 LDFLAGS             += $(addprefix -L, $(CONAN_LIB_PATHS))
@@ -172,7 +173,7 @@ EXELINKFLAGS += \
 #----------------------------------------
 
 CFLAGS              += $(CONAN_CFLAGS)
-CXXFLAGS            += $(CONAN_CPPFLAGS)
+CXXFLAGS            += $(CONAN_CXXFLAGS)
 CPPFLAGS            += $(addprefix -I, $(CONAN_INCLUDE_PATHS))
 CPPFLAGS            += $(addprefix -D, $(CONAN_DEFINES))
 LDFLAGS             += $(addprefix -L, $(CONAN_LIB_PATHS))

--- a/conans/test/unittests/client/generators/make_test.py
+++ b/conans/test/unittests/client/generators/make_test.py
@@ -62,19 +62,19 @@ CONAN_ROOT_MYPKG1 ?=  \\
 CONAN_SYSROOT_MYPKG1 ?=  \\
 
 
-CONAN_INCLUDE_PATHS_MYPKG1 +=  \\
-{conan_include_paths_mypkg1}
+CONAN_INCLUDE_DIRS_MYPKG1 +=  \\
+{conan_include_dirs_mypkg1}
 
-CONAN_LIB_PATHS_MYPKG1 +=  \\
-{conan_lib_paths_mypkg1}
+CONAN_LIB_DIRS_MYPKG1 +=  \\
+{conan_lib_dirs_mypkg1}
 
-CONAN_BIN_PATHS_MYPKG1 +=  \\
-{conan_bin_paths_mypkg1}
+CONAN_BIN_DIRS_MYPKG1 +=  \\
+{conan_bin_dirs_mypkg1}
 
-CONAN_BUILD_PATHS_MYPKG1 +=  \\
-{conan_build_paths_mypkg1}
+CONAN_BUILD_DIRS_MYPKG1 +=  \\
+{conan_build_dirs_mypkg1}
 
-CONAN_RES_PATHS_MYPKG1 +=  \\
+CONAN_RES_DIRS_MYPKG1 +=  \\
 
 
 CONAN_LIBS_MYPKG1 +=  \\
@@ -86,7 +86,7 @@ MYDEFINE1
 CONAN_CFLAGS_MYPKG1 +=  \\
 -fgimple
 
-CONAN_CPPFLAGS_MYPKG1 +=  \\
+CONAN_CXXFLAGS_MYPKG1 +=  \\
 -fdollars-in-identifiers
 
 CONAN_SHAREDLINKFLAGS_MYPKG1 +=  \\
@@ -101,19 +101,19 @@ CONAN_ROOT_MYPKG2 ?=  \\
 CONAN_SYSROOT_MYPKG2 ?=  \\
 
 
-CONAN_INCLUDE_PATHS_MYPKG2 +=  \\
-{conan_include_paths_mypkg2}
+CONAN_INCLUDE_DIRS_MYPKG2 +=  \\
+{conan_include_dirs_mypkg2}
 
-CONAN_LIB_PATHS_MYPKG2 +=  \\
-{conan_lib_paths_mypkg2}
+CONAN_LIB_DIRS_MYPKG2 +=  \\
+{conan_lib_dirs_mypkg2}
 
-CONAN_BIN_PATHS_MYPKG2 +=  \\
-{conan_bin_paths_mypkg2}
+CONAN_BIN_DIRS_MYPKG2 +=  \\
+{conan_bin_dirs_mypkg2}
 
-CONAN_BUILD_PATHS_MYPKG2 +=  \\
-{conan_build_paths_mypkg2}
+CONAN_BUILD_DIRS_MYPKG2 +=  \\
+{conan_build_dirs_mypkg2}
 
-CONAN_RES_PATHS_MYPKG2 +=  \\
+CONAN_RES_DIRS_MYPKG2 +=  \\
 
 
 CONAN_LIBS_MYPKG2 +=  \\
@@ -125,7 +125,7 @@ MYDEFINE2
 CONAN_CFLAGS_MYPKG2 +=  \\
 -fno-asm
 
-CONAN_CPPFLAGS_MYPKG2 +=  \\
+CONAN_CXXFLAGS_MYPKG2 +=  \\
 -pthread
 
 CONAN_SHAREDLINKFLAGS_MYPKG2 +=  \\
@@ -142,25 +142,25 @@ CONAN_SYSROOT +=  \\
 $(CONAN_SYSROOT_MYPKG1) \\
 $(CONAN_SYSROOT_MYPKG2)
 
-CONAN_INCLUDE_PATHS +=  \\
-$(CONAN_INCLUDE_PATHS_MYPKG1) \\
-$(CONAN_INCLUDE_PATHS_MYPKG2)
+CONAN_INCLUDE_DIRS +=  \\
+$(CONAN_INCLUDE_DIRS_MYPKG1) \\
+$(CONAN_INCLUDE_DIRS_MYPKG2)
 
-CONAN_LIB_PATHS +=  \\
-$(CONAN_LIB_PATHS_MYPKG1) \\
-$(CONAN_LIB_PATHS_MYPKG2)
+CONAN_LIB_DIRS +=  \\
+$(CONAN_LIB_DIRS_MYPKG1) \\
+$(CONAN_LIB_DIRS_MYPKG2)
 
-CONAN_BIN_PATHS +=  \\
-$(CONAN_BIN_PATHS_MYPKG1) \\
-$(CONAN_BIN_PATHS_MYPKG2)
+CONAN_BIN_DIRS +=  \\
+$(CONAN_BIN_DIRS_MYPKG1) \\
+$(CONAN_BIN_DIRS_MYPKG2)
 
-CONAN_BUILD_PATHS +=  \\
-$(CONAN_BUILD_PATHS_MYPKG1) \\
-$(CONAN_BUILD_PATHS_MYPKG2)
+CONAN_BUILD_DIRS +=  \\
+$(CONAN_BUILD_DIRS_MYPKG1) \\
+$(CONAN_BUILD_DIRS_MYPKG2)
 
-CONAN_RES_PATHS +=  \\
-$(CONAN_RES_PATHS_MYPKG1) \\
-$(CONAN_RES_PATHS_MYPKG2)
+CONAN_RES_DIRS +=  \\
+$(CONAN_RES_DIRS_MYPKG1) \\
+$(CONAN_RES_DIRS_MYPKG2)
 
 CONAN_LIBS +=  \\
 $(CONAN_LIBS_MYPKG1) \\
@@ -174,9 +174,9 @@ CONAN_CFLAGS +=  \\
 $(CONAN_CFLAGS_MYPKG1) \\
 $(CONAN_CFLAGS_MYPKG2)
 
-CONAN_CPPFLAGS +=  \\
-$(CONAN_CPPFLAGS_MYPKG1) \\
-$(CONAN_CPPFLAGS_MYPKG2)
+CONAN_CXXFLAGS +=  \\
+$(CONAN_CXXFLAGS_MYPKG1) \\
+$(CONAN_CXXFLAGS_MYPKG2)
 
 CONAN_SHAREDLINKFLAGS +=  \\
 $(CONAN_SHAREDLINKFLAGS_MYPKG1) \\
@@ -199,13 +199,14 @@ $(CONAN_EXELINKFLAGS_MYPKG2)
         bin2 = os.path.join(tmp_folder2, 'bin2').replace('\\', '/')
 
         expected_content = content_template.format(conan_root_mypkg1=root1,
-                                                   conan_include_paths_mypkg1=inc1,
-                                                   conan_lib_paths_mypkg1=lib1,
-                                                   conan_bin_paths_mypkg1=bin1,
-                                                   conan_build_paths_mypkg1=root1 + "/",
+                                                   conan_include_dirs_mypkg1=inc1,
+                                                   conan_lib_dirs_mypkg1=lib1,
+                                                   conan_bin_dirs_mypkg1=bin1,
+                                                   conan_build_dirs_mypkg1=root1 + "/",
                                                    conan_root_mypkg2=root2,
-                                                   conan_include_paths_mypkg2=inc2,
-                                                   conan_lib_paths_mypkg2=lib2,
-                                                   conan_bin_paths_mypkg2=bin2,
-                                                   conan_build_paths_mypkg2=root2 + "/")
+                                                   conan_include_dirs_mypkg2=inc2,
+                                                   conan_lib_dirs_mypkg2=lib2,
+                                                   conan_bin_dirs_mypkg2=bin2,
+                                                   conan_build_dirs_mypkg2=root2 + "/")
+        self.maxDiff = None
         self.assertIn(expected_content, content)


### PR DESCRIPTION
Changelog: Fix: Map ``cpp_info.cppflags`` to ``CONAN_CXXFLAGS`` in ``make`` generator.
Changelog: Fix: Use ``*_DIRS`` instead of ``*_PATHS`` ending for varaibles generated by the ``make`` generator: ``INCLUDE_DIRS``, ``LIB_DIRS``, ``BIN_DIRS``, ``BUILD_DIRS`` and ``RES_DIRS``
Docs: **MISSING**

@TAGS: slow

- [x] Refer to the issue that supports this Pull Request: closes #4336 
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 

<sup>**Note:** By default this PR will skip the slower tests and will use a limited set of python versions. Check [here](https://github.com/conan-io/conan/blob/develop/.github/PR_INCREASE_TESTING.md) how to increase the testing level by writing some tags in the current PR body text.</sup>
