### PR TITLE
Validate CONAN_CPU_COUNT and output user friendly error message

### DIFF
--- a/conans/client/tools/oss.py
+++ b/conans/client/tools/oss.py
@@ -24,6 +24,9 @@ def cpu_count(output=None):
     output = default_output(output, 'conans.client.tools.oss.cpu_count')
     try:
         env_cpu_count = os.getenv("CONAN_CPU_COUNT", None)
+        if env_cpu_count is not None and not env_cpu_count.isdigit():
+            raise ConanException("Invalid CONAN_CPU_COUNT value '%s', "
+                                 "please specify a positive integer" % env_cpu_count)
         return int(env_cpu_count) if env_cpu_count else multiprocessing.cpu_count()
     except NotImplementedError:
         output.warn("multiprocessing.cpu_count() not implemented. Defaulting to 1 cpu")

--- a/conans/test/unittests/util/tools_test.py
+++ b/conans/test/unittests/util/tools_test.py
@@ -547,6 +547,9 @@ class ToolsTest(unittest.TestCase):
         self.assertGreaterEqual(cpus, 1)
         with tools.environment_append({"CONAN_CPU_COUNT": "34"}):
             self.assertEquals(tools.cpu_count(output=output), 34)
+        with tools.environment_append({"CONAN_CPU_COUNT": "null"}):
+            with self.assertRaisesRegexp(ConanException, "Invalid CONAN_CPU_COUNT value"):
+                tools.cpu_count(output=output)
 
     def get_env_unit_test(self):
         """


### PR DESCRIPTION
Changelog: Minor Improvement/Fix: Validate CONAN_CPU_COUNT and output user friendly message for invalid values
Docs: https://github.com/conan-io/docs/pull/XXXX

- [x] Refer to the issue that supports this Pull Request. Fixes #4371.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.