### PR TITLE
Fix: Meson in case of package_folder == None

### DIFF
--- a/conans/client/build/meson.py
+++ b/conans/client/build/meson.py
@@ -28,7 +28,8 @@ class Meson(object):
         self.backend = backend or "ninja"  # Other backends are poorly supported, not default other.
 
         self.options = dict()
-        self.options['prefix'] = self._conanfile.package_folder
+        if self._conanfile.package_folder:
+            self.options['prefix'] = self._conanfile.package_folder
 
         # C++ standard
         cppstd = self._ss("cppstd")

--- a/conans/test/unittests/client/build/meson_test.py
+++ b/conans/test/unittests/client/build/meson_test.py
@@ -137,3 +137,29 @@ class MesonTest(unittest.TestCase):
 
         meson.install()
         self.assertEquals("ninja -C \"%s\" %s" % (build_expected, args_to_string(["install"])), conan_file.command)
+
+    def prefix_test(self):
+        conan_file = ConanFileMock()
+        conan_file.settings = Settings()
+        conan_file.package_folder = os.getcwd()
+        expected_prefix = '-Dprefix="%s"' % os.getcwd()
+        meson = Meson(conan_file)
+        meson.configure()
+        self.assertIn(expected_prefix, conan_file.command)
+        meson.build()
+        self.assertIn("ninja -C", conan_file.command)
+        meson.install()
+        self.assertIn("ninja -C", conan_file.command)
+
+    def no_prefix_test(self):
+        conan_file = ConanFileMock()
+        conan_file.settings = Settings()
+        conan_file.package_folder = None
+        meson = Meson(conan_file)
+        meson.configure()
+        self.assertNotIn('-Dprefix', conan_file.command)
+        meson.build()
+        self.assertIn("ninja -C", conan_file.command)
+        with self.assertRaises(TypeError):
+            meson.install()
+


### PR DESCRIPTION
closes: #4351 
@tags: slow, svn

Changelog: BugFix: Meson generator was failing in case of package_folder == None (test_package using Meson)
Docs: Omit

- [x] Refer to the issue that supports this Pull Request.
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 

<sup>**Note:** By default this PR will skip the slower tests and will use a limited set of python versions. Check [here](https://github.com/conan-io/conan/blob/develop/.github/PR_INCREASE_TESTING.md) how to increase the testing level by writing some tags in the current PR body text.</sup>
