### PR TITLE
#4399 Fix config install for hooks

### DIFF
--- a/conans/client/conf/config_installer.py
+++ b/conans/client/conf/config_installer.py
@@ -30,7 +30,15 @@ def _handle_remotes(cache, remote_file):
     registry.remotes.define(remotes)
 
 
-def _handle_profiles(source_folder, target_folder, output):
+def _handle_config_files(source_folder, target_folder, output):
+    """
+    Copies files to the target_folder overwriting the files that are in the same path
+    (shutil.copytree fails on doing this) and outputs the copied files
+
+    :param source_folder: Folder where the files come from
+    :param target_folder:  Folder where the files should finally go
+    :param output: Output to indicate the files copied
+    """
     mkdir(target_folder)
     for root, _, files in walk(source_folder):
         relative_path = os.path.relpath(root, source_folder)
@@ -97,12 +105,12 @@ def _process_folder(folder, cache, output):
             if d == "profiles":
                 output.info("Installing profiles:")
                 profiles_path = cache.profiles_path
-                _handle_profiles(os.path.join(root, d), profiles_path, output)
+                _handle_config_files(os.path.join(root, d), profiles_path, output)
             elif d == "hooks" and ".git" not in root:  # Avoid git hooks
                 output.info("Installing hooks:")
                 src_hooks_path = os.path.join(root, d)
                 dst_hooks_path = cache.hooks_path
-                _handle_hooks(src_hooks_path, dst_hooks_path, output)
+                _handle_config_files(src_hooks_path, dst_hooks_path, output)
         dirs[:] = [d for d in dirs if d not in ("profiles", ".git", "hooks")]
 
 
@@ -190,30 +198,3 @@ def _process_config_install_item(item):
         verify_ssl = "true" in verify_ssl.lower()
         args = None if "none" in args.lower() else args
     return config_type, path_or_url, verify_ssl, args
-
-
-def _handle_hooks(src_hooks_path, dst_hooks_path, output):
-    """
-    Copies files to the hooks folder overwriting the files that are in the same path
-    (shutil.copytree fails on doing this), skips git related files (.git, .gitmodule...) and outputs
-    the copied files
-
-    :param src_hooks_path: Folder where the hooks come from
-    :param dst_hooks_path:  Folder where the hooks should finally go
-    :param output: Output to indicate the files copied
-    """
-    hooks_dirs = []
-    for root, dirs, files in walk(src_hooks_path):
-        if root == src_hooks_path:
-            hooks_dirs = dirs
-        else:
-            copied_files = False
-            relpath = os.path.relpath(root, src_hooks_path)
-            for f in files:
-                if ".git" not in f:
-                    dst = os.path.join(dst_hooks_path, relpath)
-                    mkdir(dst)
-                    shutil.copy(os.path.join(root, f), dst)
-                    copied_files = True
-            if copied_files and relpath in hooks_dirs:
-                output.info(" - %s" % relpath)

--- a/conans/test/unittests/client/conf/config_installer_test.py
+++ b/conans/test/unittests/client/conf/config_installer_test.py
@@ -1,10 +1,11 @@
 import os
 import unittest
-from parameterized import parameterized
+import tempfile
 
-from conans.client.conf.config_installer import _process_config_install_item
+from conans.client.conf.config_installer import _process_config_install_item, _handle_config_files
 from conans.errors import ConanException
 from conans.test.utils.test_files import temp_folder
+from conans.test.utils.tools import TestBufferConanOutput
 from conans.util.files import save
 
 
@@ -64,3 +65,20 @@ class ConfigInstallerTests(unittest.TestCase):
                      "file/not/exists.zip"]:
             with self.assertRaisesRegexp(ConanException, "Unable to process config install"):
                 _, _, _, _ = _process_config_install_item(item)
+
+    def handle_config_files_test(self):
+        src_dir = temp_folder()
+        target_dir = temp_folder()
+        temp_files = []
+        output = TestBufferConanOutput()
+
+        for _ in range(10):
+            _, path = tempfile.mkstemp(dir=src_dir)
+            temp_files.append(path)
+
+        _handle_config_files(source_folder=src_dir, target_folder=target_dir, output=output)
+
+        for file_name in temp_files:
+            expected_path = os.path.join(target_dir, file_name)
+            self.assertTrue(os.path.exists(expected_path))
+            self.assertTrue(os.path.isfile(expected_path))


### PR DESCRIPTION
.git folder is checked twice when installing hooks and all files from source folder are skipped (bug). Since .git folder is verified by _process_folder,
we dont need to check it again, just copy all files from source to target folder
as done for profile.

I've added an unit test to check copy tree behavior. Is there a possible functional test to be added?

fixes #4399

Changelog: Bugfix: Fixes config install when copying hooks
Docs: omit

- [x] Refer to the issue that supports this Pull Request.
- [ ] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 

<sup>**Note:** By default this PR will skip the slower tests and will use a limited set of python versions. Check [here](https://github.com/conan-io/conan/blob/develop/.github/PR_INCREASE_TESTING.md) how to increase the testing level by writing some tags in the current PR body text.</sup>
