### PR TITLE
fix some Windows tests

### DIFF
--- a/conans/test/functional/scm/test_command_export.py
+++ b/conans/test/functional/scm/test_command_export.py
@@ -5,8 +5,35 @@ import textwrap
 import unittest
 
 from parameterized import parameterized
+from nose.plugins.attrib import attr
 
 from conans.test.utils.tools import TestClient, create_local_git_repo
+
+
+@attr("svn")
+class ExportErrorCommandTestCase(unittest.TestCase):
+    conanfile = textwrap.dedent("""\
+        from conans import ConanFile
+
+        class Lib(ConanFile):
+            scm = {{"type": "{repo_type}",
+                    "url": "{url_value}",
+                    "revision": "{rev_value}"}}
+    """)
+
+    @parameterized.expand(itertools.product(["SVN", "git"], [(True, False), (False, True)]))
+    def test_no_repo(self, repo_type, autos):
+        auto_url, auto_rev = autos
+        url_value = "auto" if auto_url else "http://this.url"
+        rev_value = "auto" if auto_rev else "123"
+
+        self.client = TestClient()
+        self.client.save({"conanfile.py": self.conanfile.format(repo_type=repo_type.lower(),
+                                                                url_value=url_value,
+                                                                rev_value=rev_value)
+                          })
+        self.client.run("export . lib/version@user/channel", assert_error=True)
+        self.assertIn("ERROR: Not a valid {} repository".format(repo_type), self.client.out)
 
 
 class ExportCommandTestCase(unittest.TestCase):
@@ -14,24 +41,10 @@ class ExportCommandTestCase(unittest.TestCase):
         from conans import ConanFile
 
         class Lib(ConanFile):
-            scm = {{"type": "{type}",
+            scm = {{"type": "{repo_type}",
                     "url": "{url_value}",
                     "revision": "{rev_value}"}}
     """)
-
-    @parameterized.expand(itertools.product(["SVN", "git"], [(True, False), (False, True)]))
-    def test_no_repo(self, type, autos):
-        auto_url, auto_rev = autos
-        url_value = "auto" if auto_url else "http://this.url"
-        rev_value = "auto" if auto_rev else "123"
-
-        self.client = TestClient()
-        self.client.save({"conanfile.py": self.conanfile.format(type=type.lower(),
-                                                                url_value=url_value,
-                                                                rev_value=rev_value)
-                          })
-        self.client.run("export . lib/version@user/channel", assert_error=True)
-        self.assertIn("ERROR: Not a valid {} repository".format(type), self.client.out)
 
     @parameterized.expand([(True, False), (False, True)])
     def test_non_existing_remote(self, auto_url, auto_rev):
@@ -39,7 +52,7 @@ class ExportCommandTestCase(unittest.TestCase):
         rev_value = "auto" if auto_rev else "123"
 
         self.path, _ = create_local_git_repo({"conanfile.py":
-                                              self.conanfile.format(type="git",
+                                              self.conanfile.format(repo_type="git",
                                                                     url_value=url_value,
                                                                     rev_value=rev_value)})
         self.client = TestClient()

--- a/conans/test/functional/scm/workflows/test_conanfile_in_repo_root.py
+++ b/conans/test/functional/scm/workflows/test_conanfile_in_repo_root.py
@@ -1,7 +1,6 @@
 # coding=utf-8
 
 import os
-import textwrap
 import unittest
 
 from nose.plugins.attrib import attr

--- a/conans/test/unittests/client/cmd/export/test_capture_export_scm_data.py
+++ b/conans/test/unittests/client/cmd/export/test_capture_export_scm_data.py
@@ -62,7 +62,8 @@ class CaptureExportSCMDataTest(unittest.TestCase):
             self.assertIn("WARN: Repo origin looks like a local path: {}".format(url), output)
 
         scm_folder_file = os.path.join(self.cache_ref_folder, SCM_FOLDER)
-        self.assertEqual(load(scm_folder_file), self.conanfile_dir)
+        self.assertEqual(os.path.normcase(load(scm_folder_file)),
+                         os.path.normcase(self.conanfile_dir))
 
     @parameterized.expand([(True, ), (False, ), ])
     def test_revision_auto(self, _, is_pristine):
@@ -94,7 +95,8 @@ class CaptureExportSCMDataTest(unittest.TestCase):
 
         scm_folder_file = os.path.join(self.cache_ref_folder, SCM_FOLDER)
         self.assertTrue(os.path.exists(scm_folder_file))
-        self.assertEqual(load(scm_folder_file), self.conanfile_dir)
+        self.assertEqual(os.path.normcase(load(scm_folder_file)),
+                         os.path.normcase(self.conanfile_dir))
 
     def test_url_auto(self, _):
         output = TestBufferConanOutput()
@@ -123,4 +125,5 @@ class CaptureExportSCMDataTest(unittest.TestCase):
 
         scm_folder_file = os.path.join(self.cache_ref_folder, SCM_FOLDER)
         self.assertTrue(os.path.exists(scm_folder_file))
-        self.assertEqual(load(scm_folder_file), self.conanfile_dir)
+        self.assertEqual(os.path.normcase(load(scm_folder_file)),
+                         os.path.normcase(self.conanfile_dir))

--- a/conans/test/unittests/client/source/test_run_scm.py
+++ b/conans/test/unittests/client/source/test_run_scm.py
@@ -35,7 +35,8 @@ class RunSCMTest(unittest.TestCase):
             self.assertEqual(folder, self.src_folder)
 
         with mock.patch("conans.client.source.merge_directories", side_effect=merge_directories):
-            with mock.patch("conans.client.source._clean_source_folder", side_effect=clean_source_folder):
+            with mock.patch("conans.client.source._clean_source_folder",
+                            side_effect=clean_source_folder):
                 _run_scm(conanfile=conanfile,
                          src_folder=self.src_folder,
                          local_sources_path=local_sources_path,
@@ -60,7 +61,8 @@ class RunSCMTest(unittest.TestCase):
         def scm_checkout(scm_itself):
             self.assertEqual(scm_itself.repo_folder, os.path.join(self.src_folder, subfolder))
 
-        with mock.patch("conans.client.source._clean_source_folder", side_effect=clean_source_folder):
+        with mock.patch("conans.client.source._clean_source_folder",
+                        side_effect=clean_source_folder):
             with mock.patch.object(SCM, "checkout", new=scm_checkout):
                 _run_scm(conanfile=conanfile,
                          src_folder=self.src_folder,
@@ -72,7 +74,6 @@ class RunSCMTest(unittest.TestCase):
 
     def test_user_space_with_local_sources(self):
         output = TestBufferConanOutput()
-        local_sources_path = self.tmp_dir
 
         # Need a real repo to get a working SCM object
         local_sources_path = os.path.join(self.tmp_dir, 'git_repo').replace('\\', '/')
@@ -89,8 +90,8 @@ class RunSCMTest(unittest.TestCase):
         def merge_directories(src, dst, excluded=None, symlinks=True):
             src = os.path.normpath(src)
             dst = os.path.normpath(dst)
-            self.assertEqual(src.replace('\\', '/'), local_sources_path)
-            self.assertEqual(dst, self.src_folder)
+            self.assertEqual(os.path.normcase(src), os.path.normcase(local_sources_path))
+            self.assertEqual(os.path.normcase(dst), os.path.normcase(self.src_folder))
 
         with mock.patch("conans.client.source.merge_directories", side_effect=merge_directories):
             _run_scm(conanfile=conanfile,
@@ -99,7 +100,8 @@ class RunSCMTest(unittest.TestCase):
                      output=output,
                      cache=False)
 
-        self.assertIn("Getting sources from folder: {}".format(local_sources_path), output)
+        self.assertIn("Getting sources from folder: {}".format(os.path.normcase(local_sources_path)),
+                      output)
 
     def test_user_space_no_local_sources(self):
         output = TestBufferConanOutput()


### PR DESCRIPTION
Changelog: omit
Docs: omit

Fixing some tests in Windows:

- Comparing full paths in Windows is very problematic and error prone. Please avoid it as much as possible.
- There was a test not labeled as SVN
- Usage of restricted keyword "type"

There are some more failing tests in Windows.

@TAGS: slow, svn

