### PR TITLE
Use named arguments when calling to hook functions

### DIFF
--- a/conans/client/hook_manager.py
+++ b/conans/client/hook_manager.py
@@ -53,7 +53,7 @@ class HookManager(object):
         for name, method in self.hooks[method_name]:
             try:
                 output = ScopedOutput("[HOOK - %s] %s()" % (name, method_name), self.output)
-                method(output, **kwargs)
+                method(output=output, **kwargs)
             except Exception as e:
                 raise ConanException("[HOOK - %s] %s(): %s\n%s" % (name, method_name, str(e),
                                                                    traceback.format_exc()))


### PR DESCRIPTION
Changelog: omit
Docs: omit

If we don't use named arguments here, we are forcing the hooks to have `output` as the first one. 