### PR TITLE
#4331 No more extra requirements for OSX

### DIFF
--- a/.ci/jenkins/runner.py
+++ b/.ci/jenkins/runner.py
@@ -38,9 +38,6 @@ def run_tests(module_path, pyver, source_folder, tmp_folder, flavor, excluded_ta
                    "pip install -r conans/requirements_dev.txt && " \
                    "pip install -r conans/requirements_server.txt && "
 
-    if platform.system() == "Darwin":
-        pip_installs += "pip install -r conans/requirements_osx.txt && "
-
     #  --nocapture
     command = "virtualenv --python \"{pyenv}\" \"{venv_dest}\" && " \
               "{source_cmd} \"{venv_exe}\" && " \

--- a/README.rst
+++ b/README.rst
@@ -147,13 +147,6 @@ Without tox
     $ pip install -r conans/requirements_dev.txt
 
 
-Only in OSX:
-
-.. code-block:: bash
-
-    $ pip install -r conans/requirements_osx.txt # You can omit this one if not running OSX
-
-
 If you are not Windows and you are not using a python virtual environment, you will need to run these
 commands using `sudo`.
 

--- a/conans/requirements.txt
+++ b/conans/requirements.txt
@@ -1,5 +1,5 @@
 PyJWT>=1.4.0, <2.0.0
-requests[security]
+requests[security]>=2.7.0, <3.0.0
 colorama>=0.3.3, <0.5.0
 PyYAML>=3.11, <3.14.0
 patch==1.16

--- a/conans/requirements.txt
+++ b/conans/requirements.txt
@@ -1,5 +1,5 @@
 PyJWT>=1.4.0, <2.0.0
-requests>=2.7.0, <3.0.0
+requests[security]
 colorama>=0.3.3, <0.5.0
 PyYAML>=3.11, <3.14.0
 patch==1.16

--- a/conans/requirements_osx.txt
+++ b/conans/requirements_osx.txt
@@ -1,3 +1,0 @@
-idna==2.6 # Solving conflict, somehow is installing 2.7 when requests require 2.6
-cryptography>=1.3.4, <2.4.0
-pyOpenSSL>=16.0.0, <19.0.0

--- a/setup.py
+++ b/setup.py
@@ -27,8 +27,6 @@ def get_requires(filename):
 
 
 project_requirements = get_requires("conans/requirements.txt")
-if platform.system() == "Darwin":
-    project_requirements.extend(get_requires("conans/requirements_osx.txt"))
 project_requirements.extend(get_requires("conans/requirements_server.txt"))
 dev_requirements = get_requires("conans/requirements_dev.txt")
 


### PR DESCRIPTION
Hi!

The idea here is to use `requests[security]` instead of trying to solve possible conflicts on OSX related to idna, openssl or crypto by extra requirements.

Changelog: Fix: Remove requirements for OSX (#4331)
Docs: Omit

@PYVERS: Macos@py27, Macos@py36, Windows@py36, Linux@py27, py34
@TAGS: svn, slow
@REVISIONS: 1

- [x] Refer to the issue that supports this Pull Request.
- [ ] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [ ] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 

<sup>**Note:** By default this PR will skip the slower tests and will use a limited set of python versions. Check [here](https://github.com/conan-io/conan/blob/develop/.github/PR_INCREASE_TESTING.md) how to increase the testing level by writing some tags in the current PR body text.</sup>
