### PR TITLE
Post export function of hooks is called before computing the digest

### DIFF
--- a/conans/client/cmd/export.py
+++ b/conans/client/cmd/export.py
@@ -61,7 +61,7 @@ def cmd_export(conanfile_path, conanfile, ref, keep_source, output, cache, hook_
     package_layout = cache.package_layout(ref, conanfile.short_paths)
     try:
         previous_digest = FileTreeManifest.load(package_layout.export())
-    except FileNotFoundError:
+    except IOError:
         previous_digest = None
     finally:
         _recreate_folders(package_layout.export(), package_layout.export_sources())

--- a/conans/client/cmd/export.py
+++ b/conans/client/cmd/export.py
@@ -10,7 +10,7 @@ from conans.client.output import ScopedOutput
 from conans.errors import ConanException
 from conans.model.manifest import FileTreeManifest
 from conans.model.scm import SCM, get_scm_data
-from conans.paths import CONANFILE, CONAN_MANIFEST
+from conans.paths import CONANFILE
 from conans.search.search import search_recipes
 from conans.util.files import is_dirty, load, mkdir, rmdir, save, set_dirty, remove
 from conans.util.log import logger
@@ -101,15 +101,15 @@ def cmd_export(conanfile_path, conanfile, ref, keep_source, output, cache, hook_
 
     # FIXME: Conan 2.0 Clear the registry entry if the recipe has changed
     source = package_layout.source()
-    remove = False
+    remove_source_folder = False
     if is_dirty(source):
         output.info("Source folder is corrupted, forcing removal")
-        remove = True
+        remove_source_folder = True
     elif modified_recipe and not keep_source and os.path.exists(source):
         output.info("Package recipe modified in export, forcing source folder removal")
         output.info("Use the --keep-source, -k option to skip it")
-        remove = True
-    if remove:
+        remove_source_folder = True
+    if remove_source_folder:
         output.info("Removing 'source' folder, this can take a while for big packages")
         try:
             # remove only the internal

--- a/conans/client/cmd/export.py
+++ b/conans/client/cmd/export.py
@@ -84,7 +84,7 @@ def cmd_export(conanfile_path, conanfile, ref, keep_source, output, cache, hook_
 
         # Compute the new digest
         digest = FileTreeManifest.create(package_layout.export(), package_layout.export_sources())
-        modified_recipe = not previous_digest or previous_digest == digest
+        modified_recipe = not previous_digest or previous_digest != digest
         if modified_recipe:
             output.success('A new %s version was exported' % CONANFILE)
             output.info('Folder: %s' % package_layout.export())

--- a/conans/client/cmd/export.py
+++ b/conans/client/cmd/export.py
@@ -55,6 +55,8 @@ def cmd_export(conanfile_path, conanfile, ref, keep_source, output, cache, hook_
                              "You exported '%s' but already existing '%s'"
                              % (reference, " ".join(str(s) for s in refs)))
 
+    output = conanfile.output
+
     # Get previous digest
     package_layout = cache.package_layout(ref, conanfile.short_paths)
     try:

--- a/conans/test/functional/hooks/test_post_export.py
+++ b/conans/test/functional/hooks/test_post_export.py
@@ -32,9 +32,9 @@ class PostExportTestCase(unittest.TestCase):
         t.save({'conanfile.py': conanfile})
         package_layout = t.cache.package_layout(ref)
 
-        def mocked_post_export(output, conanfile_path, reference, *args, **kwargs):
+        def mocked_post_export(*args, **kwargs):
             # There shouldn't be a digest yet
-            with self.assertRaisesRegexp(FileNotFoundError, "No such file or directory"):
+            with self.assertRaisesRegexp(IOError, "No such file or directory"):
                 FileTreeManifest.load(package_layout.export())
             self.assertFalse(os.path.exists(os.path.join(package_layout.export(), CONAN_MANIFEST)))
 

--- a/conans/test/functional/hooks/test_post_export.py
+++ b/conans/test/functional/hooks/test_post_export.py
@@ -1,0 +1,46 @@
+# coding=utf-8
+
+import os
+import textwrap
+import unittest
+
+from mock import patch
+
+from conans.client.hook_manager import HookManager
+from conans.model.manifest import FileTreeManifest
+from conans.model.ref import ConanFileReference
+from conans.paths import CONAN_MANIFEST
+from conans.test.utils.tools import TestClient
+
+
+class PostExportTestCase(unittest.TestCase):
+
+    def test_called_before_digest(self):
+        """ Test that 'post_export' hook is called before computing the digest of the
+            exported folders
+        """
+        
+        ref = ConanFileReference.loads("name/version@user/channel")
+        conanfile = textwrap.dedent("""\
+            from conans import ConanFile
+            
+            class MyLib(ConanFile):
+                pass
+        """)
+
+        t = TestClient()
+        t.save({'conanfile.py': conanfile})
+        package_layout = t.cache.package_layout(ref)
+
+        def mocked_post_export(output, conanfile_path, reference, *args, **kwargs):
+            # There shouldn't be a digest yet
+            with self.assertRaisesRegexp(FileNotFoundError, "No such file or directory"):
+                FileTreeManifest.load(package_layout.export())
+            self.assertFalse(os.path.exists(os.path.join(package_layout.export(), CONAN_MANIFEST)))
+
+        def mocked_load_hooks(hook_manager):
+            hook_manager.hooks["post_export"] = [("_", mocked_post_export)]
+
+        with patch.object(HookManager, "load_hooks", new=mocked_load_hooks):
+            t.run("export . {}".format(ref))
+        self.assertTrue(os.path.exists(os.path.join(package_layout.export(), CONAN_MANIFEST)))

--- a/conans/test/functional/hooks/test_post_export.py
+++ b/conans/test/functional/hooks/test_post_export.py
@@ -19,7 +19,7 @@ class PostExportTestCase(unittest.TestCase):
         """ Test that 'post_export' hook is called before computing the digest of the
             exported folders
         """
-        
+
         ref = ConanFileReference.loads("name/version@user/channel")
         conanfile = textwrap.dedent("""\
             from conans import ConanFile

--- a/conans/util/files.py
+++ b/conans/util/files.py
@@ -170,14 +170,14 @@ def save_files(path, files, only_if_modified=False):
 
 
 def load(path, binary=False):
-    '''Loads a file content'''
+    """ Loads a file content """
     with open(path, 'rb') as handle:
         tmp = handle.read()
         return tmp if binary else decode_text(tmp)
 
 
 def relative_dirs(path):
-    ''' Walks a dir and return a list with the relative paths '''
+    """ Walks a dir and return a list with the relative paths """
     ret = []
     for dirpath, _, fnames in walk(path):
         for filename in fnames:


### PR DESCRIPTION
Changelog: Fix: `post_export` hooks are called before computing the digest
Docs: https://github.com/conan-io/docs/pull/XXXX

closes #4425 

After computing (and storing) the digest for all the exported files of a package, it doesn't make sense to call any hook that could potentially change those sources. This PR modifies this behavior so the digest is computed and stored after calling all the `post_export` hooks.

