### PR TITLE
Raise more meaningful messages from GraphInfo parsing

### DIFF
--- a/conans/model/graph_info.py
+++ b/conans/model/graph_info.py
@@ -26,7 +26,7 @@ class GraphInfo(object):
         p = path if os.path.isfile(path) else os.path.join(path, GRAPH_INFO_FILE)
         try:
             return GraphInfo.loads(load(p))
-        except Exception as e:
+        except ConanException as e:
             raise ConanException("Error parsing GraphInfo from file '{}': {}".format(p, e))
 
     @staticmethod

--- a/conans/model/graph_info.py
+++ b/conans/model/graph_info.py
@@ -33,18 +33,27 @@ class GraphInfo(object):
     def loads(text):
         try:
             graph_json = json.loads(text)
-            profile = graph_json["profile"]
-            # FIXME: Reading private very ugly
-            profile, _ = _load_profile(profile, None, None)
+
+            # Work with required fields
+            try:
+                profile = graph_json["profile"]
+                # FIXME: Reading private very ugly
+                profile, _ = _load_profile(profile, None, None)
+
+                root = graph_json["root"]
+                root_ref = ConanFileReference(root["name"], root["version"], root["user"],
+                                              root["channel"], validate=False)
+            except KeyError as e:
+                raise Exception("Required node {} is not present".format(e))
+
+            # Work with option 'options'
             try:
                 options = graph_json["options"]
             except KeyError:
                 options = None
             else:
                 options = OptionsValues(options)
-            root = graph_json["root"]
-            root_ref = ConanFileReference(root["name"], root["version"], root["user"], root["channel"],
-                                          validate=False)
+
             return GraphInfo(profile=profile, options=options, root_ref=root_ref)
         except ConanException:
             raise


### PR DESCRIPTION
Changelog: omit
Docs: omit

Related to #4443, add more meaningful errors related to `graph_info.json` parsing. The output for the linked issue would have been:

```bash
⇒  conan info .
ERROR: Error parsing GraphInfo from file '/Users/jgsogo/dev/conan/issues/tmp2/graph_info.json': Error related to GraphInfo text content: Required node 'root' is not present
```

@lasote I'm not sure if I should open this PR against `develop` or against a minor `1.12.1`.

closes #4443