### PR TITLE
fixing regression of graph_info not having root

### DIFF
--- a/conans/model/graph_info.py
+++ b/conans/model/graph_info.py
@@ -25,8 +25,9 @@ class GraphInfo(object):
         if not path:
             raise IOError("Invalid path")
         p = path if os.path.isfile(path) else os.path.join(path, GRAPH_INFO_FILE)
+        content = load(p)
         try:
-            return GraphInfo.loads(load(p))
+            return GraphInfo.loads(content)
         except Exception as e:
             raise ConanException("Error parsing GraphInfo from file '{}': {}".format(p, e))
 

--- a/conans/test/functional/command/info_test.py
+++ b/conans/test/functional/command/info_test.py
@@ -626,3 +626,6 @@ class MyTest(ConanFile):
         save(path, json.dumps(graph_info))
         client.run("info .")
         self.assertIn("conanfile.py (Hello/0.1@None/None)", client.out)
+        save(path, "broken thing")
+        client.run("info .", assert_error=True)
+        self.assertIn("ERROR: Error parsing GraphInfo from file", client.out)


### PR DESCRIPTION
Changelog: Bugfix: GraphInfo parsing of existing graph_info.json files raises KeyError over "root".
Docs: omit


Close #4443
Close #4447