### PR TITLE
Fix warning message for package folder (#4438)

### DIFF
--- a/conans/client/file_copier.py
+++ b/conans/client/file_copier.py
@@ -6,7 +6,7 @@ from collections import defaultdict
 from conans.util.files import mkdir, walk
 
 
-def report_copied_files(copied, output):
+def report_copied_files(copied, output, message_suffix="Copied"):
     ext_files = defaultdict(list)
     for f in copied:
         _, ext = os.path.splitext(f)
@@ -19,9 +19,9 @@ def report_copied_files(copied, output):
         files_str = (", ".join(files)) if len(files) < 5 else ""
         file_or_files = "file" if len(files) == 1 else "files"
         if not ext:
-            output.info("Copied %d %s: %s" % (len(files), file_or_files, files_str))
+            output.info("%s %d %s: %s" % (message_suffix, len(files), file_or_files, files_str))
         else:
-            output.info("Copied %d '%s' %s: %s" % (len(files), ext, file_or_files, files_str))
+            output.info("%s %d '%s' %s: %s" % (message_suffix, len(files), ext, file_or_files, files_str))
     return True
 
 

--- a/conans/client/packager.py
+++ b/conans/client/packager.py
@@ -25,8 +25,6 @@ def export_pkg(conanfile, package_id, src_package_folder, package_folder, hook_m
     copier = FileCopier(src_package_folder, package_folder)
     copier("*", symlinks=True)
 
-    copier.report(output)
-
     save(os.path.join(package_folder, CONANINFO), conanfile.info.dumps())
     digest = FileTreeManifest.create(package_folder)
     digest.save(package_folder)
@@ -117,10 +115,7 @@ def _create_aux_files(install_folder, package_folder, conanfile, copy_info):
 def _report_files_from_manifest(output, package_folder):
     digest = FileTreeManifest.load(package_folder)
     copied_files = list(digest.files())
-    try:
-        copied_files.remove(CONANINFO)
-    finally:
-        pass
+    copied_files.remove(CONANINFO)
 
     if not copied_files:
         output.warn("No files in this package!")

--- a/conans/test/functional/command/create_test.py
+++ b/conans/test/functional/command/create_test.py
@@ -95,7 +95,7 @@ class MyPkg(ConanFile):
         self.assertIn("Pkg/0.1@lasote/testing: mysource!!", client.out)
         self.assertIn("Pkg/0.1@lasote/testing: mybuild!!", client.out)
         self.assertIn("Pkg/0.1@lasote/testing: mypackage!!", client.out)
-        self.assertIn("Pkg/0.1@lasote/testing package(): Copied 1 '.h' file: header.h", client.out)
+        self.assertIn("Pkg/0.1@lasote/testing package(): Packaged 1 '.h' file: header.h", client.out)
         # keep the source
         client.save({"conanfile.py": conanfile + " "})
         client.run("create . Pkg/0.1@lasote/testing --keep-source")
@@ -103,7 +103,7 @@ class MyPkg(ConanFile):
         self.assertNotIn("Pkg/0.1@lasote/testing: mysource!!", client.out)
         self.assertIn("Pkg/0.1@lasote/testing: mybuild!!", client.out)
         self.assertIn("Pkg/0.1@lasote/testing: mypackage!!", client.out)
-        self.assertIn("Pkg/0.1@lasote/testing package(): Copied 1 '.h' file: header.h", client.out)
+        self.assertIn("Pkg/0.1@lasote/testing package(): Packaged 1 '.h' file: header.h", client.out)
         # keep build
         client.run("create . Pkg/0.1@lasote/testing --keep-build")
         self.assertIn("Pkg/0.1@lasote/testing: Won't be built as specified by --keep-build",
@@ -111,7 +111,7 @@ class MyPkg(ConanFile):
         self.assertNotIn("Pkg/0.1@lasote/testing: mysource!!", client.out)
         self.assertNotIn("Pkg/0.1@lasote/testing: mybuild!!", client.out)
         self.assertIn("Pkg/0.1@lasote/testing: mypackage!!", client.out)
-        self.assertIn("Pkg/0.1@lasote/testing package(): Copied 1 '.h' file: header.h", client.out)
+        self.assertIn("Pkg/0.1@lasote/testing package(): Packaged 1 '.h' file: header.h", client.out)
 
         # Changes in the recipe again
         client.save({"conanfile.py": conanfile})
@@ -123,7 +123,7 @@ class MyPkg(ConanFile):
         self.assertNotIn("Pkg/0.1@lasote/testing: mysource!!", client.out)
         self.assertNotIn("Pkg/0.1@lasote/testing: mybuild!!", client.out)
         self.assertIn("Pkg/0.1@lasote/testing: mypackage!!", client.out)
-        self.assertIn("Pkg/0.1@lasote/testing package(): Copied 1 '.h' file: header.h", client.out)
+        self.assertIn("Pkg/0.1@lasote/testing package(): Packaged 1 '.h' file: header.h", client.out)
 
     def keep_build_error_test(self):
         client = TestClient()

--- a/conans/test/functional/command/export_pkg_test.py
+++ b/conans/test/functional/command/export_pkg_test.py
@@ -101,6 +101,7 @@ class HelloPythonConan(ConanFile):
         client.run("export-pkg . Hello/0.1@lasote/stable -pf=pkg -pr=profile")
         self.assertNotIn("PACKAGE NOT CALLED", client.out)
         self.assertIn("Hello/0.1@lasote/stable: Copied 1 '.h' file: myfile.h", client.out)
+        self.assertNotIn("No files copied from package folder!", client.out)
         ref = ConanFileReference.loads("Hello/0.1@lasote/stable")
         pkg_folder = client.cache.packages(ref)
         folders = os.listdir(pkg_folder)

--- a/conans/test/functional/command/export_pkg_test.py
+++ b/conans/test/functional/command/export_pkg_test.py
@@ -81,7 +81,7 @@ class HelloPythonConan(ConanFile):
                       client.out)
 
         client.run("export-pkg . Hello/0.1@lasote/stable -pf=pkg")
-        self.assertIn("Hello/0.1@lasote/stable: WARN: No files copied from package folder!",
+        self.assertIn("Hello/0.1@lasote/stable: WARN: No files in this package!",
                       client.out)
 
     def test_package_folder(self):
@@ -100,8 +100,8 @@ class HelloPythonConan(ConanFile):
 
         client.run("export-pkg . Hello/0.1@lasote/stable -pf=pkg -pr=profile")
         self.assertNotIn("PACKAGE NOT CALLED", client.out)
-        self.assertIn("Hello/0.1@lasote/stable: Copied 1 '.h' file: myfile.h", client.out)
-        self.assertNotIn("No files copied from package folder!", client.out)
+        self.assertIn("Hello/0.1@lasote/stable: Packaged 1 '.h' file: myfile.h", client.out)
+        self.assertNotIn("No files in this package!", client.out)
         ref = ConanFileReference.loads("Hello/0.1@lasote/stable")
         pkg_folder = client.cache.packages(ref)
         folders = os.listdir(pkg_folder)
@@ -272,10 +272,10 @@ class TestConan(ConanFile):
         client.run("export-pkg . Hello/0.1@lasote/stable %s" % settings)
         self.assertIn("Hello/0.1@lasote/stable: A new conanfile.py version was exported",
                       client.out)
-        self.assertNotIn("Hello/0.1@lasote/stable package(): WARN: No files copied",
+        self.assertNotIn("Hello/0.1@lasote/stable package(): WARN: No files in this package!",
                          client.out)  # --bare include a now mandatory package() method!
 
-        self.assertIn("Copied 1 '.a' file: libmycoollib.a", client.out)
+        self.assertIn("Packaged 1 '.a' file: libmycoollib.a", client.out)
         self._consume(client, settings + " . -g cmake")
 
         cmakeinfo = load(os.path.join(client.current_folder, "conanbuildinfo.cmake"))
@@ -381,7 +381,7 @@ class TestConan(ConanFile):
         # Partial reference is ok
         client.save({CONANFILE: conanfile, "file.txt": "txt contents"})
         client.run("export-pkg . conan/stable")
-        self.assertIn("Hello/0.1@conan/stable package(): Copied 1 '.txt' file: file.txt", client.out)
+        self.assertIn("Hello/0.1@conan/stable package(): Packaged 1 '.txt' file: file.txt", client.out)
 
         # Specify different name or version is not working
         client.run("export-pkg . lib/1.0@conan/stable -f", assert_error=True)
@@ -401,7 +401,7 @@ class TestConan(ConanFile):
         # Partial reference is ok
         client.save({CONANFILE: conanfile, "file.txt": "txt contents"})
         client.run("export-pkg . anyname/1.222@conan/stable")
-        self.assertIn("anyname/1.222@conan/stable package(): Copied 1 '.txt' file: file.txt",
+        self.assertIn("anyname/1.222@conan/stable package(): Packaged 1 '.txt' file: file.txt",
                       client.out)
 
     def test_with_deps(self):

--- a/conans/test/functional/command/package_test.py
+++ b/conans/test/functional/command/package_test.py
@@ -266,43 +266,32 @@ class MyConan(ConanFile):
         self.assertIn("package(): Packaged 1 '.h' file: file.h", client.out)
         self.assertIn("package(): Packaged 1 '.lib' file: library.lib", client.out)
 
-    def install_package_by_cmake_test(self):
+    def installer_package_test(self):
+        """ Simulates installers when packaging the file e.g. cmake install
+            The package() does not use self.copy, but files are copied to package folder
+        """
         client = TestClient()
         conanfile = """
-from conans import ConanFile, CMake
+import os
+from conans import ConanFile, tools
 
 class MyConan(ConanFile):
-    exports = "LICENSE"
-    exports_sources = "CMakeLists.txt"
-    generators = "cmake"
     def build(self):
         pass
     def package(self):
-        cmake = CMake(self)
-        cmake.configure()
-        cmake.install()
-    """
-        cmake = """
-cmake_minimum_required(VERSION 2.8)
-project(MyHello)
-include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
-conan_basic_setup()
-add_custom_target(hello DEPENDS LICENSE)
-install(FILES LICENSE DESTINATION licenses)
-    """
-        client.save({"LICENSE": "foo",
-                     "CMakeLists.txt": cmake,
-                     CONANFILE: conanfile})
+        tools.save(os.path.join(self.package_folder, "LICENSE.md"), "my license")
+"""
+        client.save({CONANFILE: conanfile})
         client.run("install .")
         client.run("package .")
         self.assertNotIn("No files in this package!", client.out)
-        self.assertIn("Install the project...", client.out)
-        self.assertIn("-- Installing:", client.out)
-        self.assertIn("package(): Packaged 1 file: LICENSE", client.out)
+        self.assertIn("package(): Packaged 1 '.md' file: LICENSE.md", client.out)
         self.assertIn("conanfile.py: Package 'package' created", client.out)
 
-
     def empty_package_folder_test(self):
+        """ When the package folder is empty, then an warning should appear
+            and no files must be listed
+        """
         conanfile = """from conans import ConanFile
 import os
 

--- a/conans/test/functional/conanfile/imports_tests.py
+++ b/conans/test/functional/conanfile/imports_tests.py
@@ -51,7 +51,7 @@ class TestConan(ConanFile):
 """
         client.save({"conanfile.py": conanfile}, clean_first=True)
         client.run("create . Pkg/0.1@user/testing --build=missing")
-        self.assertIn("Pkg/0.1@user/testing package(): Copied 1 '.md' file: LICENSE.md",
+        self.assertIn("Pkg/0.1@user/testing package(): Packaged 1 '.md' file: LICENSE.md",
                       client.out)
         pref = PackageReference(ConanFileReference.loads("Pkg/0.1@user/testing"),
                                 "e6f2dac07251ad9958120a7f7c324366fb3b6f2a")

--- a/conans/test/functional/old/conan_trace_file_test.py
+++ b/conans/test/functional/old/conan_trace_file_test.py
@@ -57,21 +57,21 @@ class HelloConan(ConanFile):
             return log_file_packaged_, client.user_io.out
 
         log_file_packaged, output = _install_a_package(False, True)
-        self.assertIn("Copied 1 '.log' file: conan_run.log", output)
+        self.assertIn("Packaged 1 '.log' file: conan_run.log", output)
         self.assertTrue(os.path.exists(log_file_packaged))
         contents = load(log_file_packaged)
         self.assertIn("Simulating cmake...", contents)
         self.assertNotIn("----Running------%s> echo" % os.linesep, contents)
 
         log_file_packaged, output = _install_a_package(True, True)
-        self.assertIn("Copied 1 '.log' file: conan_run.log", output)
+        self.assertIn("Packaged 1 '.log' file: conan_run.log", output)
         self.assertTrue(os.path.exists(log_file_packaged))
         contents = load(log_file_packaged)
         self.assertIn("Simulating cmake...", contents)
         self.assertIn("----Running------%s> echo" % os.linesep, contents)
 
         log_file_packaged, output = _install_a_package(False, False)
-        self.assertNotIn("Copied 1 '.log' file: conan_run.log", output)
+        self.assertNotIn("Packaged 1 '.log' file: conan_run.log", output)
         self.assertFalse(os.path.exists(log_file_packaged))
 
     def test_trace_actions(self):

--- a/conans/test/integration/complete_test.py
+++ b/conans/test/integration/complete_test.py
@@ -23,7 +23,7 @@ class CompleteFlowTest(unittest.TestCase):
         files = cpp_hello_conan_files("Hello0", "0.1", build=False)
         self.client.save(files)
         self.client.run("create . lasote/stable")
-        self.assertIn("Hello0/0.1@lasote/stable package(): Copied 1 '.h' file: helloHello0.h",
+        self.assertIn("Hello0/0.1@lasote/stable package(): Packaged 1 '.h' file: helloHello0.h",
                       self.client.out)
 
         # Upload package
@@ -53,7 +53,7 @@ class CompleteFlowTest(unittest.TestCase):
         files = cpp_hello_conan_files("Hello0", "0.1", need_patch=True)
         self.client.save(files)
         self.client.run("create . lasote/stable")
-        self.assertIn("Hello0/0.1@lasote/stable package(): Copied 1 '.h' file: helloHello0.h",
+        self.assertIn("Hello0/0.1@lasote/stable package(): Packaged 1 '.h' file: helloHello0.h",
                       self.client.out)
         # Check compilation ok
         package_ids = self.client.cache.conan_packages(ref)


### PR DESCRIPTION
Hi!

Do not display the warning "No files copied from build folder!" when actually there are files in the package folder. I've changed past tests to accept the new behavior, now some tests contain a file in the package folder, so it should not show any warning.

Add new test using cmake install instead of self.copy, the same scenario represented on issue #4438

Changelog: Fix: Do not display the warning when there are files in the package folder (#4438).
Docs: Omit

fixes #4438 

- [x] Refer to the issue that supports this Pull Request.
- [ ] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 

<sup>**Note:** By default this PR will skip the slower tests and will use a limited set of python versions. Check [here](https://github.com/conan-io/conan/blob/develop/.github/PR_INCREASE_TESTING.md) how to increase the testing level by writing some tags in the current PR body text.</sup>
