### PR TITLE
Feature/fix msbuild props injection

### DIFF
--- a/conans/client/build/msbuild.py
+++ b/conans/client/build/msbuild.py
@@ -160,7 +160,8 @@ class MSBuild(object):
             command.append('/verbosity:%s' % verbosity)
 
         if props_file_path:
-            command.append('/p:ForceImportBeforeCppTargets="%s"' % props_file_path)
+            command.append('/p:ForceImportBeforeCppTargets="%s"' %
+                           os.path.abspath(props_file_path))
 
         for name, value in properties.items():
             command.append('/p:%s="%s"' % (name, value))

--- a/conans/test/unittests/client/build/msbuild_test.py
+++ b/conans/test/unittests/client/build/msbuild_test.py
@@ -245,7 +245,6 @@ class MSBuildTest(unittest.TestCase):
         msbuild = MSBuild(conanfile)
         command = msbuild.get_command("dummy.sln", props_file_path="conan_build.props")
 
-        print(command)
         match = re.search('/p:ForceImportBeforeCppTargets="(.+?)"', command)
         self.assertTrue(
             match, "Haven't been able to find the ForceImportBeforeCppTargets")

--- a/conans/test/unittests/client/build/msbuild_test.py
+++ b/conans/test/unittests/client/build/msbuild_test.py
@@ -133,17 +133,6 @@ class MSBuildTest(unittest.TestCase):
         self.assertRegexpMatches(version, "(\d+\.){2,3}\d+")
         self.assertGreater(version, "15.1")
 
-    def custom_properties_test(self):
-        settings = MockSettings({"build_type": "Debug",
-                                 "compiler": "Visual Studio",
-                                 "arch": "x86_64"})
-        conanfile = MockConanfile(settings)
-        msbuild = MSBuild(conanfile)
-        command = msbuild.get_command("project_should_flags_test_file.sln",
-                                      properties={"MyProp1": "MyValue1", "MyProp2": "MyValue2"})
-        self.assertIn('/p:MyProp1="MyValue1"', command)
-        self.assertIn('/p:MyProp2="MyValue2"', command)
-
     @parameterized.expand([("15", "v141"),
                            ("14", "v140"),
                            ("12", "v120"),


### PR DESCRIPTION
Fixes #4471
Also removes one redundant test.

I have a PEP8 embedded into VSCode. Should I also use it to auto-format files affected by PRs on the way?