### PR TITLE
fix meson build_type

### DIFF
--- a/conans/client/build/meson.py
+++ b/conans/client/build/meson.py
@@ -45,7 +45,7 @@ class Meson(object):
 
         # shared
         shared = self._so("shared")
-        self.options['default-library'] = "shared" if shared is None or shared else "static"
+        self.options['default_library'] = "shared" if shared is None or shared else "static"
 
         # fpic
         if self._os and "Windows" not in self._os:

--- a/conans/client/build/meson.py
+++ b/conans/client/build/meson.py
@@ -4,6 +4,7 @@ import subprocess
 from conans.client import defs_to_string, join_arguments, tools
 from conans.client.tools.oss import args_to_string
 from conans.errors import ConanException
+from conans.model.build_info import DEFAULT_BIN, DEFAULT_INCLUDE, DEFAULT_LIB, DEFAULT_SHARE
 from conans.model.version import Version
 from conans.util.files import decode_text, get_abs_path, mkdir
 
@@ -30,6 +31,11 @@ class Meson(object):
         self.options = dict()
         if self._conanfile.package_folder:
             self.options['prefix'] = self._conanfile.package_folder
+        self.options['libdir'] = DEFAULT_LIB
+        self.options['bindir'] = DEFAULT_BIN
+        self.options['sbindir'] = DEFAULT_BIN
+        self.options['libexecdir'] = DEFAULT_BIN
+        self.options['includedir'] = DEFAULT_INCLUDE
 
         # C++ standard
         cppstd = self._ss("cppstd")

--- a/conans/test/unittests/client/build/meson_test.py
+++ b/conans/test/unittests/client/build/meson_test.py
@@ -60,6 +60,11 @@ class MesonTest(unittest.TestCase):
         defs = {
             'default_library': 'shared',
             'prefix': package_folder,
+            'libdir': 'lib',
+            'bindir': 'bin',
+            'sbindir': 'bin',
+            'libexecdir': 'bin',
+            'includedir': 'include',
             'cpp_std': 'none'
         }
 

--- a/conans/test/unittests/client/build/meson_test.py
+++ b/conans/test/unittests/client/build/meson_test.py
@@ -58,7 +58,7 @@ class MesonTest(unittest.TestCase):
         meson = Meson(conan_file)
 
         defs = {
-            'default-library': 'shared',
+            'default_library': 'shared',
             'prefix': package_folder,
             'cpp_std': 'none'
         }
@@ -119,9 +119,9 @@ class MesonTest(unittest.TestCase):
         self._check_commands(cmd_expected, conan_file.command)
 
         args = ['--werror', '--warnlevel 3']
-        defs['default-library'] = 'static'
+        defs['default_library'] = 'static'
         meson.configure(source_folder="source", build_folder="build", args=args,
-                        defs={'default-library': 'static'})
+                        defs={'default_library': 'static'})
         build_expected = os.path.join(self.tempdir, "my_cache_build_folder", "build")
         source_expected = os.path.join(self.tempdir, "my_cache_source_folder", "source")
         cmd_expected = 'meson "%s" "%s" --backend=ninja %s %s --buildtype=release' \


### PR DESCRIPTION
Meson's documentation currently mentions default-library option,
but it is a typo, the proper option is default_library

Changelog: Bugfix: meson build type actually reflects recipe shared option
Docs: omit

- [ ] Refer to the issue that supports this Pull Request.
- [ ] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [X] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [X] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 

<sup>**Note:** By default this PR will skip the slower tests and will use a limited set of python versions. Check [here](https://github.com/conan-io/conan/blob/develop/.github/PR_INCREASE_TESTING.md) how to increase the testing level by writing some tags in the current PR body text.</sup>
