### PR TITLE
Add enable_test to workspace generated CMakeLists.txt 

### DIFF
--- a/conans/model/workspace.py
+++ b/conans/model/workspace.py
@@ -107,6 +107,7 @@ class Workspace(object):
             template = """# conanws
 cmake_minimum_required(VERSION 3.3)
 project({name} CXX)
+enable_testing()
 
 """
             cmake = template.format(name=self._name)


### PR DESCRIPTION
Changelog: Fix #3141: [workspaces] test targets are not generated

- [x] Refer to the issue that supports this Pull Request.
- [ ] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 

<sup>**Note:** By default this PR will skip the slower tests and will use a limited set of python versions. Check [here](https://github.com/conan-io/conan/blob/develop/.github/PR_INCREASE_TESTING.md) how to increase the testing level by writing some tags in the current PR body text.</sup>
