### PR TITLE
bugfix: Wrong param in function `search_packages`

### DIFF
--- a/conans/client/cmd/search.py
+++ b/conans/client/cmd/search.py
@@ -91,7 +91,7 @@ class Search(object):
                     continue
             return references
 
-        return self._search_packages_in(self, 'all', ref, query, outdated)
+        return self._search_packages_in('all', ref, query, outdated)
 
     def _search_packages_in(self, remote_name, ref=None, query=None, outdated=False):
         remote = self._registry.remotes.get(remote_name)

--- a/conans/test/functional/command/search_test.py
+++ b/conans/test/functional/command/search_test.py
@@ -2,15 +2,8 @@ import json
 import os
 import shutil
 import textwrap
-import time
 import unittest
 from collections import OrderedDict
-<<<<<<< HEAD
-=======
-from textwrap import dedent
-
-from mock import patch
->>>>>>> add test
 
 from conans import COMPLEX_SEARCH_CAPABILITY, DEFAULT_REVISION_V1
 from conans.model.manifest import FileTreeManifest


### PR DESCRIPTION
Changelog: Bugfix: Fix search packages function when remote is called `all`
Docs: omit

It looks like users do not name their remotes as `all`...