### PR TITLE
fix meson build_type (#4489)

### DIFF
--- a/conans/client/build/meson.py
+++ b/conans/client/build/meson.py
@@ -4,6 +4,7 @@ import subprocess
 from conans.client import defs_to_string, join_arguments, tools
 from conans.client.tools.oss import args_to_string
 from conans.errors import ConanException
+from conans.model.build_info import DEFAULT_BIN, DEFAULT_INCLUDE, DEFAULT_LIB, DEFAULT_SHARE
 from conans.model.version import Version
 from conans.util.files import decode_text, get_abs_path, mkdir
 
@@ -30,6 +31,11 @@ class Meson(object):
         self.options = dict()
         if self._conanfile.package_folder:
             self.options['prefix'] = self._conanfile.package_folder
+        self.options['libdir'] = DEFAULT_LIB
+        self.options['bindir'] = DEFAULT_BIN
+        self.options['sbindir'] = DEFAULT_BIN
+        self.options['libexecdir'] = DEFAULT_BIN
+        self.options['includedir'] = DEFAULT_INCLUDE
 
         # C++ standard
         cppstd = self._ss("cppstd")
@@ -45,7 +51,7 @@ class Meson(object):
 
         # shared
         shared = self._so("shared")
-        self.options['default-library'] = "shared" if shared is None or shared else "static"
+        self.options['default_library'] = "shared" if shared is None or shared else "static"
 
         # fpic
         if self._os and "Windows" not in self._os:

--- a/conans/test/unittests/client/build/meson_test.py
+++ b/conans/test/unittests/client/build/meson_test.py
@@ -58,8 +58,13 @@ class MesonTest(unittest.TestCase):
         meson = Meson(conan_file)
 
         defs = {
-            'default-library': 'shared',
+            'default_library': 'shared',
             'prefix': package_folder,
+            'libdir': 'lib',
+            'bindir': 'bin',
+            'sbindir': 'bin',
+            'libexecdir': 'bin',
+            'includedir': 'include',
             'cpp_std': 'none'
         }
 
@@ -119,9 +124,9 @@ class MesonTest(unittest.TestCase):
         self._check_commands(cmd_expected, conan_file.command)
 
         args = ['--werror', '--warnlevel 3']
-        defs['default-library'] = 'static'
+        defs['default_library'] = 'static'
         meson.configure(source_folder="source", build_folder="build", args=args,
-                        defs={'default-library': 'static'})
+                        defs={'default_library': 'static'})
         build_expected = os.path.join(self.tempdir, "my_cache_build_folder", "build")
         source_expected = os.path.join(self.tempdir, "my_cache_source_folder", "source")
         cmd_expected = 'meson "%s" "%s" --backend=ninja %s %s --buildtype=release' \


### PR DESCRIPTION
Replicates @ericLemanissier PR #4489, I merged it to `master` (reverted in #4503). 

> Meson's documentation currently mentions default-library option,
but it is a typo, the proper option is default_library

Changelog: Bugfix: meson build type actually reflects recipe shared option
Docs: omit
