### PR TITLE
Revert CMake default generator on Windows

### DIFF
--- a/conans/client/build/cmake.py
+++ b/conans/client/build/cmake.py
@@ -45,6 +45,8 @@ class CMake(object):
         self._cmake_program = os.getenv("CONAN_CMAKE_PROGRAM") or cmake_program or "cmake"
 
         self.generator = generator or get_generator(conanfile.settings)
+        if not self.generator:
+            self._conanfile.output.warn("CMake generator could not be deduced from settings")
         self.parallel = parallel
         # Initialize definitions (won't be updated if conanfile or any of these variables change)
         builder = CMakeDefinitionsBuilder(self._conanfile,

--- a/conans/client/build/cmake_flags.py
+++ b/conans/client/build/cmake_flags.py
@@ -36,7 +36,8 @@ def get_generator(settings):
 
     if not compiler or not compiler_version or not arch:
         if os_build == "Windows":
-            return "MinGW Makefiles"
+            logger.warning("No compiler has been detected for Windows platform")
+            return None
         return "Unix Makefiles"
 
     if compiler == "Visual Studio":

--- a/conans/client/build/cmake_flags.py
+++ b/conans/client/build/cmake_flags.py
@@ -36,7 +36,7 @@ def get_generator(settings):
 
     if not compiler or not compiler_version or not arch:
         if os_build == "Windows":
-            logger.warning("No compiler has been detected for Windows platform")
+            logger.warning("No generator has been detected for CMake")
             return None
         return "Unix Makefiles"
 

--- a/conans/client/build/cmake_flags.py
+++ b/conans/client/build/cmake_flags.py
@@ -36,7 +36,7 @@ def get_generator(settings):
 
     if not compiler or not compiler_version or not arch:
         if os_build == "Windows":
-            logger.warning("No generator has been detected for CMake")
+            logger.warning("CMake generator could not be deduced from settings")
             return None
         return "Unix Makefiles"
 
@@ -65,6 +65,8 @@ def get_generator(settings):
 
 
 def is_multi_configuration(generator):
+    if not generator:
+        return False
     return "Visual" in generator or "Xcode" in generator
 
 

--- a/conans/test/functional/build_helpers/cmake_flags_test.py
+++ b/conans/test/functional/build_helpers/cmake_flags_test.py
@@ -6,6 +6,7 @@ from textwrap import dedent
 from nose.plugins.attrib import attr
 from parameterized.parameterized import parameterized
 
+from conans import load
 from conans.client.build.cmake import CMake
 from conans.model.version import Version
 from conans.test.utils.tools import TestClient
@@ -447,6 +448,7 @@ conan_basic_setup()
 
             def package(self):
                 cmake = CMake(self)
+                self.output.info("Configure command: %s" % cmake.command_line)
                 cmake.configure()
                 cmake.install()
         """)
@@ -460,3 +462,6 @@ conan_basic_setup()
         client = TestClient()
         client.save({"conanfile.py": conanfile, "CMakeLists.txt": cmakelists, "include/file.h": ""})
         client.run("create . danimtb/testing")
+        self.assertIn('Configure command: -DCONAN_EXPORTED="1" -DCONAN_IN_LOCAL_CACHE="ON" '
+                      '-DCMAKE_INSTALL_PREFIX=', client.out)
+        self.assertIn("WARN: CMake generator could not be deduced from settings", client.out)

--- a/conans/test/functional/build_helpers/cmake_flags_test.py
+++ b/conans/test/functional/build_helpers/cmake_flags_test.py
@@ -467,5 +467,5 @@ conan_basic_setup()
             self.assertIn('Configure command: -DCONAN_EXPORTED="1" -DCONAN_IN_LOCAL_CACHE="ON" '
                           '-DCMAKE_INSTALL_PREFIX=', client.out)
         else:
-            self.assertIn('-G "Unix Makefiles" - DCONAN_EXPORTED = "1" - DCONAN_IN_LOCAL_CACHE = '
-                          '"ON" -DCMAKE_INSTALL_PREFIX =', client.out)
+            self.assertIn('Configure command: -G "Unix Makefiles" -DCONAN_EXPORTED="1" '
+                          '-DCONAN_IN_LOCAL_CACHE="ON" -DCMAKE_INSTALL_PREFIX =', client.out)

--- a/conans/test/functional/build_helpers/cmake_flags_test.py
+++ b/conans/test/functional/build_helpers/cmake_flags_test.py
@@ -8,8 +8,6 @@ from parameterized.parameterized import parameterized
 
 from conans.client.build.cmake import CMake
 from conans.model.version import Version
-from conans.test.utils.conanfile import MockSettings, MockConanfile, MockOptions
-from conans.test.utils.test_files import temp_folder
 from conans.test.utils.tools import TestClient
 
 conanfile_py = """

--- a/conans/test/functional/build_helpers/cmake_flags_test.py
+++ b/conans/test/functional/build_helpers/cmake_flags_test.py
@@ -462,6 +462,10 @@ conan_basic_setup()
         client = TestClient()
         client.save({"conanfile.py": conanfile, "CMakeLists.txt": cmakelists, "include/file.h": ""})
         client.run("create . danimtb/testing")
-        self.assertIn('Configure command: -DCONAN_EXPORTED="1" -DCONAN_IN_LOCAL_CACHE="ON" '
-                      '-DCMAKE_INSTALL_PREFIX=', client.out)
-        self.assertIn("WARN: CMake generator could not be deduced from settings", client.out)
+        if platform.system() == "Windows":
+            self.assertIn("WARN: CMake generator could not be deduced from settings", client.out)
+            self.assertIn('Configure command: -DCONAN_EXPORTED="1" -DCONAN_IN_LOCAL_CACHE="ON" '
+                          '-DCMAKE_INSTALL_PREFIX=', client.out)
+        else:
+            self.assertIn('-G "Unix Makefiles" - DCONAN_EXPORTED = "1" - DCONAN_IN_LOCAL_CACHE = '
+                          '"ON" -DCMAKE_INSTALL_PREFIX =', client.out)

--- a/conans/test/functional/build_helpers/cmake_flags_test.py
+++ b/conans/test/functional/build_helpers/cmake_flags_test.py
@@ -468,4 +468,4 @@ conan_basic_setup()
                           '-DCMAKE_INSTALL_PREFIX=', client.out)
         else:
             self.assertIn('Configure command: -G "Unix Makefiles" -DCONAN_EXPORTED="1" '
-                          '-DCONAN_IN_LOCAL_CACHE="ON" -DCMAKE_INSTALL_PREFIX =', client.out)
+                          '-DCONAN_IN_LOCAL_CACHE="ON" -DCMAKE_INSTALL_PREFIX=', client.out)

--- a/conans/test/functional/generators/cmake_generator_test.py
+++ b/conans/test/functional/generators/cmake_generator_test.py
@@ -58,6 +58,7 @@ class CMakeGeneratorTest(unittest.TestCase):
         else:
             self.assertNotIn("cmake -G", client.out)
             self.assertFalse(os.path.isfile(os.path.join(client.current_folder, "Makefile")))
+            self.assertIn("No generator has been detected for CMake", client.out)
 
     @unittest.skipUnless(tools.os_info.is_linux, "Compilation with real gcc needed")
     def test_cmake_default_generator_linux(self):

--- a/conans/test/functional/generators/cmake_generator_test.py
+++ b/conans/test/functional/generators/cmake_generator_test.py
@@ -58,7 +58,6 @@ class CMakeGeneratorTest(unittest.TestCase):
         else:
             self.assertNotIn("cmake -G", client.out)
             self.assertFalse(os.path.isfile(os.path.join(client.current_folder, "Makefile")))
-            self.assertIn("No generator has been detected for CMake", client.out)
 
     @unittest.skipUnless(tools.os_info.is_linux, "Compilation with real gcc needed")
     def test_cmake_default_generator_linux(self):

--- a/conans/test/functional/generators/cmake_generator_test.py
+++ b/conans/test/functional/generators/cmake_generator_test.py
@@ -52,16 +52,17 @@ class CMakeGeneratorTest(unittest.TestCase):
         client.run("install . -p my_profile")
         client.run("build .")
 
-        self.assertIn('cmake -G "{}"'.format(generator), client.out)
-        self.assertTrue(os.path.isfile(os.path.join(client.current_folder, "Makefile")))
+        if generator:
+            self.assertIn('cmake -G "{}"'.format(generator), client.out)
+            self.assertTrue(os.path.isfile(os.path.join(client.current_folder, "Makefile")))
 
     @unittest.skipUnless(tools.os_info.is_linux, "Compilation with real gcc needed")
     def test_cmake_default_generator_linux(self):
         self._check_build_generator("Linux", "Unix Makefiles")
 
-    @unittest.skipUnless(tools.os_info.is_windows, "MinGW is only supported on Windows")
+    @unittest.skipUnless(tools.os_info.is_windows, "Windows does not support default compiler")
     def test_cmake_default_generator_windows(self):
-        self._check_build_generator("Windows", "MinGW Makefiles")
+        self._check_build_generator("Windows", None)
 
     @unittest.skipUnless(tools.os_info.is_macos, "Compilation with real clang is needed")
     def test_cmake_default_generator_osx(self):

--- a/conans/test/functional/generators/cmake_generator_test.py
+++ b/conans/test/functional/generators/cmake_generator_test.py
@@ -55,6 +55,9 @@ class CMakeGeneratorTest(unittest.TestCase):
         if generator:
             self.assertIn('cmake -G "{}"'.format(generator), client.out)
             self.assertTrue(os.path.isfile(os.path.join(client.current_folder, "Makefile")))
+        else:
+            self.assertNotIn("cmake -G", client.out)
+            self.assertFalse(os.path.isfile(os.path.join(client.current_folder, "Makefile")))
 
     @unittest.skipUnless(tools.os_info.is_linux, "Compilation with real gcc needed")
     def test_cmake_default_generator_linux(self):

--- a/conans/test/unittests/client/build/cmake_test.py
+++ b/conans/test/unittests/client/build/cmake_test.py
@@ -1037,7 +1037,7 @@ build_type: [ Release]
         self.assertEquals(cmake.generator, "Unix Makefiles")
 
         cmake = instance_with_os_build("Windows")
-        self.assertEquals(cmake.generator, "MinGW Makefiles")
+        self.assertEquals(cmake.generator, None)
 
         with tools.environment_append({"CONAN_CMAKE_GENERATOR": "MyCoolGenerator"}):
             cmake = instance_with_os_build("Windows")

--- a/conans/test/unittests/client/build/cmake_test.py
+++ b/conans/test/unittests/client/build/cmake_test.py
@@ -17,7 +17,7 @@ from conans.errors import ConanException
 from conans.model.build_info import CppInfo, DepsCppInfo
 from conans.model.ref import ConanFileReference
 from conans.model.settings import Settings
-from conans.test.utils.conanfile import ConanFileMock
+from conans.test.utils.conanfile import ConanFileMock, MockSettings
 from conans.test.utils.test_files import temp_folder
 from conans.util.files import load, save
 
@@ -1231,3 +1231,14 @@ build_type: [ Release]
             self.assertEquals(conanfile.captured_env["CTEST_OUTPUT_ON_FAILURE"], "1")
             self.assertEquals(conanfile.captured_env["CTEST_PARALLEL_LEVEL"], "666")
 
+    def test_unkown_generator_does_not_raise(self):
+        # https://github.com/conan-io/conan/issues/4265
+        settings = MockSettings({"os_build": "Windows", "compiler": "random",
+                                 "compiler.version": "15", "build_type": "Release"})
+        conanfile = ConanFileMock()
+        conanfile.settings = settings
+        cmake = CMake(conanfile)
+        self.assertIsNone(cmake.generator)
+        self.assertIn("WARN: CMake generator could not be deduced from settings", conanfile.output)
+        cmake.configure()
+        cmake.build()


### PR DESCRIPTION
Changelog: Fix: Revert default cmake generator on Windows (#4265)
Docs: https://github.com/conan-io/docs/pull/1072
Related comment: https://github.com/conan-io/docs/pull/1026#issuecomment-462334623

Since this change is related to CMake, all platforms should be tested, including slow tests

@PYVERS: Macos@py27, Windows@py36, Linux@py27, py34
@TAGS: slow

Hi!

As @danimtb commented before, the feature #4265 solved a problem on Windows, but now it causes a new problem when mingw is not installed. This PR reverts the previous change and show an warning message when a generator is not detected.

- [x] Refer to the issue that supports this Pull Request.
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [x] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 

<sup>**Note:** By default this PR will skip the slower tests and will use a limited set of python versions. Check [here](https://github.com/conan-io/conan/blob/develop/.github/PR_INCREASE_TESTING.md) how to increase the testing level by writing some tags in the current PR body text.</sup>
