### PR TITLE
remove output warning in MSBuild

### DIFF
--- a/conans/client/build/msbuild.py
+++ b/conans/client/build/msbuild.py
@@ -11,6 +11,7 @@ from conans.client.tools.win import vcvars_command
 from conans.errors import ConanException
 from conans.model.conan_file import ConanFile
 from conans.model.version import Version
+from conans.tools import vcvars_command as tools_vcvars_command
 from conans.util.env_reader import get_env
 from conans.util.files import decode_text, save
 
@@ -135,7 +136,7 @@ class MSBuild(object):
                 self._output.warn("Use 'platforms' argument to define your architectures")
 
         if output_binary_log:
-            msbuild_version = MSBuild.get_version(self._settings, self._output)
+            msbuild_version = MSBuild.get_version(self._settings)
             if msbuild_version >= "15.3":  # http://msbuildlog.com/
                 command.append('/bl' if isinstance(output_binary_log, bool)
                                else '/bl:"%s"' % output_binary_log)
@@ -219,9 +220,9 @@ class MSBuild(object):
         return template
 
     @staticmethod
-    def get_version(settings, output=None):
+    def get_version(settings):
         msbuild_cmd = "msbuild -version"
-        vcvars = vcvars_command(settings, output=output)
+        vcvars = tools_vcvars_command(settings)
         command = "%s && %s" % (vcvars, msbuild_cmd)
         try:
             out, _ = subprocess.Popen(command, stdout=subprocess.PIPE, shell=True).communicate()

--- a/conans/client/build/msbuild.py
+++ b/conans/client/build/msbuild.py
@@ -135,7 +135,7 @@ class MSBuild(object):
                 self._output.warn("Use 'platforms' argument to define your architectures")
 
         if output_binary_log:
-            msbuild_version = MSBuild.get_version(self._settings)
+            msbuild_version = MSBuild.get_version(self._settings, self._output)
             if msbuild_version >= "15.3":  # http://msbuildlog.com/
                 command.append('/bl' if isinstance(output_binary_log, bool)
                                else '/bl:"%s"' % output_binary_log)
@@ -219,9 +219,9 @@ class MSBuild(object):
         return template
 
     @staticmethod
-    def get_version(settings):
+    def get_version(settings, output=None):
         msbuild_cmd = "msbuild -version"
-        vcvars = vcvars_command(settings)
+        vcvars = vcvars_command(settings, output=output)
         command = "%s && %s" % (vcvars, msbuild_cmd)
         try:
             out, _ = subprocess.Popen(command, stdout=subprocess.PIPE, shell=True).communicate()

--- a/conans/client/generators/virtualbuildenv.py
+++ b/conans/client/generators/virtualbuildenv.py
@@ -12,7 +12,7 @@ class VirtualBuildEnvGenerator(VirtualEnvGenerator):
         compiler = conanfile.settings.get_safe("compiler")
         if compiler == "Visual Studio":
             self.env = VisualStudioBuildEnvironment(conanfile).vars_dict
-            self.env.update(vcvars_dict(conanfile.settings))
+            self.env.update(vcvars_dict(conanfile.settings, output=conanfile.output))
         else:
             self.env = AutoToolsBuildEnvironment(conanfile).vars_dict
 

--- a/conans/test/functional/build_helpers/msbuild_test.py
+++ b/conans/test/functional/build_helpers/msbuild_test.py
@@ -5,7 +5,7 @@ import unittest
 from nose.plugins.attrib import attr
 from parameterized import parameterized
 
-from conans.client import tools
+from conans.client.tools.files import replace_in_file
 from conans.model.ref import PackageReference
 from conans.paths import CONANFILE
 from conans.test.utils.tools import TestClient
@@ -51,9 +51,10 @@ class HelloConan(ConanFile):
         files[CONANFILE] = conan_build_vs
 
         # Try to not update the project
-        client.cache._conan_config = None  # Invalidate cached config
-        tools.replace_in_file(client.cache.conan_conf_path, "[general]",
-                              "[general]\nskip_vs_projects_upgrade = True")
+        client.cache._config = None  # Invalidate cached config
+        replace_in_file(client.cache.conan_conf_path, "[general]",
+                        "[general]\nskip_vs_projects_upgrade = True", output=client.out)
+
         client.save(files, clean_first=True)
         client.run("create . Hello/1.2.1@lasote/stable --build")
         self.assertNotIn("devenv", client.user_io.out)


### PR DESCRIPTION
Changelog: Fix: Remove output warnings in MSBuild helper.
Docs: Omit
