### PR TITLE
#2260 Ignore surrogates from file contents

### DIFF
--- a/conans/test/unittests/util/files_test.py
+++ b/conans/test/unittests/util/files_test.py
@@ -47,5 +47,8 @@ class SaveTestCase(unittest.TestCase):
         self.assertTrue(a_file.endswith("badfile.txt"))
 
     def surrogates_content_test(self):
-        content = to_file_bytes("pepe\xE3\x81\x82\udcc3foobarqux")
-        self.assertEqual(b"pepe\xc3\xa3\xc2\x81\xc2\x82foobarqux", content)
+        content = to_file_bytes(u"pepe\xE3\x81\x82\udcc3foobarqux")
+        if six.PY3:
+            self.assertEqual(b"pepe\xc3\xa3\xc2\x81\xc2\x82foobarqux", content)
+        else:
+            self.assertEqual(b"pepe\xc3\xa3\xc2\x81\xc2\x82\xed\xb3\x83foobarqux", content)

--- a/conans/test/unittests/util/files_test.py
+++ b/conans/test/unittests/util/files_test.py
@@ -45,3 +45,7 @@ class SaveTestCase(unittest.TestCase):
             folder = unicode(folder)
         a_file = [f[0] for _, _, f in walk(folder)][0]
         self.assertTrue(a_file.endswith("badfile.txt"))
+
+    def surrogates_content_test(self):
+        content = to_file_bytes("pepe\xE3\x81\x82\udcc3foobarqux")
+        self.assertEqual(b"pepe\xc3\xa3\xc2\x81\xc2\x82foobarqux", content)

--- a/conans/util/files.py
+++ b/conans/util/files.py
@@ -158,7 +158,7 @@ def mkdir_tmp():
 def to_file_bytes(content):
     if six.PY3:
         if not isinstance(content, bytes):
-            content = bytes(content, "utf-8")
+            content = bytes(content, "utf-8", "ignore")
     elif isinstance(content, unicode):
         content = content.encode("utf-8")
     return content


### PR DESCRIPTION
Hi!

The original error was described [here](https://github.com/conan-io/conan/issues/2260#issuecomment-459607059).

When a file contents is encoded, some surrogates characters are not supported on Python 3. Following the same approach from `decode_text` we will ignore them.

I've added an unit test to validate the regression.

I think we cannot close the issue #2260 by this PR, because the original poster is related to constraints of Python 2.

Changelog: Fix: Ignores surrogates contents (#2260)
Docs: Omit

@PYVERS: Macos@py27, Windows@py36, Linux@py27, py34

- [x] Refer to the issue that supports this Pull Request.
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 

<sup>**Note:** By default this PR will skip the slower tests and will use a limited set of python versions. Check [here](https://github.com/conan-io/conan/blob/develop/.github/PR_INCREASE_TESTING.md) how to increase the testing level by writing some tags in the current PR body text.</sup>
