### PR TITLE
fix for using @ in conanfile.txt imports

### DIFF
--- a/conans/client/loader_txt.py
+++ b/conans/client/loader_txt.py
@@ -8,7 +8,8 @@ class ConanFileTextLoader(object):
     def __init__(self, input_text):
         # Prefer composition over inheritance, the __getattr__ was breaking things
         self._config_parser = ConfigParser(input_text,  ["requires", "generators", "options",
-                                                         "imports", "build_requires"], parse_lines=True)
+                                                         "imports", "build_requires"],
+                                           parse_lines=True)
 
     @property
     def requirements(self):
@@ -33,8 +34,13 @@ class ConanFileTextLoader(object):
         def _parse_args(param_string):
             root_package, ignore_case, folder, excludes, keep_path = None, False, False, None, True
             params = param_string.split(",")
-            params = [p.split("=") for p in params if p]
-            for (var, value) in params:
+            params = [p.strip() for p in params if p.strip()]
+            for param in params:
+                try:
+                    var, value = param.split("=")
+                except ValueError:
+                    raise ConanException("Wrong imports argument '%s'. "
+                                         "Need a 'arg=value' pair." % param)
                 var = var.strip()
                 value = value.strip()
                 if var == "root_package":
@@ -52,7 +58,7 @@ class ConanFileTextLoader(object):
             return root_package, ignore_case, folder, excludes, keep_path
 
         def _parse_import(line):
-            pair = line.split("->")
+            pair = line.split("->", 1)
             source = pair[0].strip().split(',', 1)
             dest = pair[1].strip()
             src, pattern = source[0].strip(), source[1].strip()
@@ -72,7 +78,7 @@ class ConanFileTextLoader(object):
                 raise ConanException("%s\n%s" % (invalid_line_msg,
                                                  "Import's paths can't begin with '/' or '..'"))
             try:
-                tokens = line.split("@", 1)
+                tokens = line.rsplit("@", 1)
                 if len(tokens) > 1:
                     line = tokens[0]
                     params = tokens[1]
@@ -80,7 +86,8 @@ class ConanFileTextLoader(object):
                     params = ""
                 root_package, ignore_case, folder, excludes, keep_path = _parse_args(params)
                 pattern, dest, src = _parse_import(line)
-                ret.append((pattern, dest, src, root_package, folder, ignore_case, excludes, keep_path))
+                ret.append((pattern, dest, src, root_package, folder, ignore_case, excludes,
+                            keep_path))
             except Exception as e:
                 raise ConanException("%s\n%s" % (invalid_line_msg, str(e)))
         return ret

--- a/conans/client/loader_txt.py
+++ b/conans/client/loader_txt.py
@@ -58,11 +58,15 @@ class ConanFileTextLoader(object):
             return root_package, ignore_case, folder, excludes, keep_path
 
         def _parse_import(line):
-            pair = line.split("->", 1)
-            source = pair[0].strip().split(',', 1)
-            dest = pair[1].strip()
-            src, pattern = source[0].strip(), source[1].strip()
-            return pattern, dest, src
+            try:
+                pair = line.split("->", 1)
+                source = pair[0].strip().split(',', 1)
+                dest = pair[1].strip()
+                src, pattern = source[0].strip(), source[1].strip()
+                return pattern, dest, src
+            except Exception:
+                raise ConanException("Wrong imports line: %s\n"
+                                     "Use syntax: path, pattern -> local-folder" % line)
 
         ret = []
         local_install_text = self._config_parser.imports

--- a/conans/test/functional/conanfile/imports_tests.py
+++ b/conans/test/functional/conanfile/imports_tests.py
@@ -107,6 +107,17 @@ LibC/0.1@lasote/testing
         client.run("install .", assert_error=True)
         self.assertIn("Wrong imports argument 'something'. Need a 'arg=value' pair.", client.out)
 
+    def imports_wrong_line_txt_test(self):
+        client = TestClient()
+        conanfile = """
+[imports]
+., license*
+"""
+        client.save({"conanfile.txt": conanfile})
+        client.run("install .", assert_error=True)
+        self.assertIn("Wrong imports line: ., license*", client.out)
+        self.assertIn("Use syntax: path, pattern -> local-folder", client.out)
+
     def imports_folders_extrachars_txt_test(self):
         # https://github.com/conan-io/conan/issues/4524
         client = self._set_up()

--- a/conans/test/functional/conanfile/imports_tests.py
+++ b/conans/test/functional/conanfile/imports_tests.py
@@ -121,7 +121,7 @@ LibC/0.1@lasote/testing
         client.run("install . --build=missing")
         self.assertEqual(load(os.path.join(client.current_folder, "lic@myfolder/LibA/LICENSE.txt")),
                          "LicenseA")
-        self.assertEqual(load(os.path.join(client.current_folder, "lic@myfolder/license.md")),
+        self.assertEqual(load(os.path.join(client.current_folder, "lic@myfolder/LICENSE.md")),
                          "LicenseB")
         self.assertEqual(load(os.path.join(client.current_folder, "lic@myfolder/LibC/license.txt")),
                          "LicenseC")


### PR DESCRIPTION
Changelog: Bugfix: Fixed problem with conanfile.txt [imports] sections using the '@' character.
Docs: https://github.com/conan-io/docs/pull/1078

Close #4524

There was a problem with folders using "@" and not extra arguments being specified, it failed because the ``rsplit(, 1)`` was splitting it. Possibilities:

- Use  spaces ``<blank>@<blank>`` to split path<->args. Could break some users if they put ``@folders=True``. But simple, will work without needing a trailing ``@``.
- Force users with ``@`` in their pathnames to define a trailing ``@``, even if empty (implemented solution).
- Do a full fledged parser that regexs over the ``folders=True``, etc. patterns (too complex for the value).
