### PR TITLE
Fix: ensure tools.OSInfo doesn't raise in MSYS/Cygwin environment

### DIFF
--- a/conans/client/tools/oss.py
+++ b/conans/client/tools/oss.py
@@ -184,6 +184,8 @@ class OSInfo(object):
 
         os_version = _OSVERSIONINFOEXW()
         os_version.dwOSVersionInfoSize = ctypes.sizeof(os_version)
+        if not hasattr(ctypes, "windll"):
+            return None
         retcode = ctypes.windll.Ntdll.RtlGetVersion(ctypes.byref(os_version))
         if retcode != 0:
             return None

--- a/conans/test/unittests/client/conf/detect/detected_os_test.py
+++ b/conans/test/unittests/client/conf/detect/detected_os_test.py
@@ -10,33 +10,23 @@ from conans.client.tools.oss import detected_os, OSInfo
 class DetectedOSTest(unittest.TestCase):
     def test_windows(self):
         with mock.patch("platform.system", mock.MagicMock(return_value='Windows')):
-            with mock.patch.object(OSInfo, "get_win_version_name", return_value="Windows 98"):
-                with mock.patch.object(OSInfo, "get_win_os_version", return_value="4.0"):
-                    self.assertEqual(detected_os(), "Windows")
+            self.assertEqual(detected_os(), "Windows")
 
     def test_cygwin(self):
         with mock.patch("platform.system", mock.MagicMock(return_value='CYGWIN_NT-10.0')):
-            with mock.patch.object(OSInfo, "get_win_version_name", return_value="Windows 98"):
-                with mock.patch.object(OSInfo, "get_win_os_version", return_value="4.0"):
-                    self.assertEqual(detected_os(), "Windows")
+            self.assertEqual(detected_os(), "Windows")
 
     def test_msys(self):
         with mock.patch("platform.system", mock.MagicMock(return_value='MSYS_NT-10.0')):
-            with mock.patch.object(OSInfo, "get_win_version_name", return_value="Windows 98"):
-                with mock.patch.object(OSInfo, "get_win_os_version", return_value="4.0"):
-                    self.assertEqual(detected_os(), "Windows")
+            self.assertEqual(detected_os(), "Windows")
 
     def test_mingw32(self):
         with mock.patch("platform.system", mock.MagicMock(return_value='MINGW32_NT-10.0')):
-            with mock.patch.object(OSInfo, "get_win_version_name", return_value="Windows 98"):
-                with mock.patch.object(OSInfo, "get_win_os_version", return_value="4.0"):
-                    self.assertEqual(detected_os(), "Windows")
+            self.assertEqual(detected_os(), "Windows")
 
     def test_mingw64(self):
         with mock.patch("platform.system", mock.MagicMock(return_value='MINGW64_NT-10.0')):
-            with mock.patch.object(OSInfo, "get_win_version_name", return_value="Windows 98"):
-                with mock.patch.object(OSInfo, "get_win_os_version", return_value="4.0"):
-                    self.assertEqual(detected_os(), "Windows")
+            self.assertEqual(detected_os(), "Windows")
 
     def test_darwin(self):
         with mock.patch("platform.system", mock.MagicMock(return_value='Darwin')):

--- a/conans/test/unittests/client/tools/os_info/osinfo_test.py
+++ b/conans/test/unittests/client/tools/os_info/osinfo_test.py
@@ -26,102 +26,88 @@ class OSInfoTest(unittest.TestCase):
         self._uname = None
         self._version = None
         with mock.patch("platform.system", mock.MagicMock(return_value='Windows')):
-            with mock.patch.object(OSInfo, "get_win_version_name", return_value="Windows 98"):
-                with mock.patch.object(OSInfo, "get_win_os_version", return_value="4.0"):
-                    with remove_from_path("uname"):
-                        with remove_from_path("bash"):
-                            # FIXME: bug in environment_append removing variables which aren't exist (another PR)
-                            new_env = dict()
-                            if 'CONAN_BASH_PATH' in os.environ:
-                                new_env['CONAN_BASH_PATH'] = None
-                            with environment_append(new_env):
-                                self.assertTrue(OSInfo().is_windows)
-                                self.assertFalse(OSInfo().is_cygwin)
-                                self.assertFalse(OSInfo().is_msys)
-                                self.assertFalse(OSInfo().is_linux)
-                                self.assertFalse(OSInfo().is_freebsd)
-                                self.assertFalse(OSInfo().is_macos)
-                                self.assertFalse(OSInfo().is_solaris)
+            with remove_from_path("uname"):
+                with remove_from_path("bash"):
+                    with environment_append({'CONAN_BASH_PATH': None}):
+                        self.assertTrue(OSInfo().is_windows)
+                        self.assertFalse(OSInfo().is_cygwin)
+                        self.assertFalse(OSInfo().is_msys)
+                        self.assertFalse(OSInfo().is_linux)
+                        self.assertFalse(OSInfo().is_freebsd)
+                        self.assertFalse(OSInfo().is_macos)
+                        self.assertFalse(OSInfo().is_solaris)
 
-                                with self.assertRaises(ConanException):
-                                    OSInfo.uname()
-                                self.assertIsNone(OSInfo.detect_windows_subsystem())
+                        with self.assertRaises(ConanException):
+                            OSInfo.uname()
+                        self.assertIsNone(OSInfo.detect_windows_subsystem())
 
     def test_cygwin(self):
         self._uname = 'CYGWIN_NT-10.0'
         self._version = '2.11.2(0.329/5/3)'
         with mock.patch("platform.system", mock.MagicMock(return_value=self._uname)):
-            with mock.patch.object(OSInfo, "get_win_version_name", return_value="Windows 98"):
-                with mock.patch.object(OSInfo, "get_win_os_version", return_value="4.0"):
-                    self.assertTrue(OSInfo().is_windows)
-                    self.assertTrue(OSInfo().is_cygwin)
-                    self.assertFalse(OSInfo().is_msys)
-                    self.assertFalse(OSInfo().is_linux)
-                    self.assertFalse(OSInfo().is_freebsd)
-                    self.assertFalse(OSInfo().is_macos)
-                    self.assertFalse(OSInfo().is_solaris)
+            self.assertTrue(OSInfo().is_windows)
+            self.assertTrue(OSInfo().is_cygwin)
+            self.assertFalse(OSInfo().is_msys)
+            self.assertFalse(OSInfo().is_linux)
+            self.assertFalse(OSInfo().is_freebsd)
+            self.assertFalse(OSInfo().is_macos)
+            self.assertFalse(OSInfo().is_solaris)
 
-                    with environment_append({"CONAN_BASH_PATH": "/fake/bash.exe"}):
-                        with mock.patch('subprocess.check_output', new=self.subprocess_check_output_mock):
-                            self.assertEqual(OSInfo.uname(), self._uname.lower())
-                            self.assertEqual(OSInfo.detect_windows_subsystem(), CYGWIN)
+            with environment_append({"CONAN_BASH_PATH": "/fake/bash.exe"}):
+                with mock.patch('subprocess.check_output', new=self.subprocess_check_output_mock):
+                    self.assertEqual(OSInfo.uname(), self._uname.lower())
+                    self.assertEqual(OSInfo.detect_windows_subsystem(), CYGWIN)
 
     def test_msys2(self):
         self._uname = 'MSYS_NT-10.0'
         self._version = '1.0.18(0.48/3/2)'
         with mock.patch("platform.system", mock.MagicMock(return_value=self._uname)):
-            with mock.patch.object(OSInfo, "get_win_version_name", return_value="Windows 98"):
-                with mock.patch.object(OSInfo, "get_win_os_version", return_value="4.0"):
-                    self.assertTrue(OSInfo().is_windows)
-                    self.assertFalse(OSInfo().is_cygwin)
-                    self.assertTrue(OSInfo().is_msys)
-                    self.assertFalse(OSInfo().is_linux)
-                    self.assertFalse(OSInfo().is_freebsd)
-                    self.assertFalse(OSInfo().is_macos)
-                    self.assertFalse(OSInfo().is_solaris)
+            self.assertTrue(OSInfo().is_windows)
+            self.assertFalse(OSInfo().is_cygwin)
+            self.assertTrue(OSInfo().is_msys)
+            self.assertFalse(OSInfo().is_linux)
+            self.assertFalse(OSInfo().is_freebsd)
+            self.assertFalse(OSInfo().is_macos)
+            self.assertFalse(OSInfo().is_solaris)
 
-                    with environment_append({"CONAN_BASH_PATH": "/fake/bash.exe"}):
-                        with mock.patch('subprocess.check_output', new=self.subprocess_check_output_mock):
-                            self.assertEqual(OSInfo.uname(), self._uname.lower())
-                            self.assertEqual(OSInfo.detect_windows_subsystem(), MSYS)
+            with environment_append({"CONAN_BASH_PATH": "/fake/bash.exe"}):
+                with mock.patch('subprocess.check_output', new=self.subprocess_check_output_mock):
+                    self.assertEqual(OSInfo.uname(), self._uname.lower())
+                    self.assertEqual(OSInfo.detect_windows_subsystem(), MSYS)
 
     def test_mingw32(self):
         self._uname = 'MINGW32_NT-10.0'
         self._version = '2.10.0(0.325/5/3)'
         with mock.patch("platform.system", mock.MagicMock(return_value=self._uname)):
-            with mock.patch.object(OSInfo, "get_win_version_name", return_value="Windows 98"):
-                with mock.patch.object(OSInfo, "get_win_os_version", return_value="4.0"):
-                    self.assertTrue(OSInfo().is_windows)
-                    self.assertFalse(OSInfo().is_cygwin)
-                    self.assertTrue(OSInfo().is_msys)
-                    self.assertFalse(OSInfo().is_linux)
-                    self.assertFalse(OSInfo().is_freebsd)
-                    self.assertFalse(OSInfo().is_macos)
-                    self.assertFalse(OSInfo().is_solaris)
+            self.assertTrue(OSInfo().is_windows)
+            self.assertFalse(OSInfo().is_cygwin)
+            self.assertTrue(OSInfo().is_msys)
+            self.assertFalse(OSInfo().is_linux)
+            self.assertFalse(OSInfo().is_freebsd)
+            self.assertFalse(OSInfo().is_macos)
+            self.assertFalse(OSInfo().is_solaris)
 
-                    with environment_append({"CONAN_BASH_PATH": "/fake/bash.exe"}):
-                        with mock.patch('subprocess.check_output', new=self.subprocess_check_output_mock):
-                            self.assertEqual(OSInfo.uname(), self._uname.lower())
-                            self.assertEqual(OSInfo.detect_windows_subsystem(), MSYS2)
+            with environment_append({"CONAN_BASH_PATH": "/fake/bash.exe"}):
+                with mock.patch('subprocess.check_output', new=self.subprocess_check_output_mock):
+                    self.assertEqual(OSInfo.uname(), self._uname.lower())
+                    self.assertEqual(OSInfo.detect_windows_subsystem(), MSYS2)
 
     def test_mingw64(self):
         self._uname = 'MINGW64_NT-10.0'
         self._version = '2.4.0(0.292/5/3)'
         with mock.patch("platform.system", mock.MagicMock(return_value=self._uname)):
-            with mock.patch.object(OSInfo, "get_win_version_name", return_value="Windows 98"):
-                with mock.patch.object(OSInfo, "get_win_os_version", return_value="4.0"):
-                    self.assertTrue(OSInfo().is_windows)
-                    self.assertFalse(OSInfo().is_cygwin)
-                    self.assertTrue(OSInfo().is_msys)
-                    self.assertFalse(OSInfo().is_linux)
-                    self.assertFalse(OSInfo().is_freebsd)
-                    self.assertFalse(OSInfo().is_macos)
-                    self.assertFalse(OSInfo().is_solaris)
+            self.assertTrue(OSInfo().is_windows)
+            self.assertFalse(OSInfo().is_cygwin)
+            self.assertTrue(OSInfo().is_msys)
+            self.assertFalse(OSInfo().is_linux)
+            self.assertFalse(OSInfo().is_freebsd)
+            self.assertFalse(OSInfo().is_macos)
+            self.assertFalse(OSInfo().is_solaris)
 
-                    with environment_append({"CONAN_BASH_PATH": "/fake/bash.exe"}):
-                        with mock.patch('subprocess.check_output', new=self.subprocess_check_output_mock):
-                            self.assertEqual(OSInfo.uname(), self._uname.lower())
-                            self.assertEqual(OSInfo.detect_windows_subsystem(), MSYS2)
+            with environment_append({"CONAN_BASH_PATH": "/fake/bash.exe"}):
+                with mock.patch('subprocess.check_output', new=self.subprocess_check_output_mock):
+                    self.assertEqual(OSInfo.uname(), self._uname.lower())
+                    self.assertEqual(OSInfo.detect_windows_subsystem(), MSYS2)
 
     def test_linux(self):
         with mock.patch("platform.system", mock.MagicMock(return_value='Linux')):


### PR DESCRIPTION
closes: #4540
Changelog: Omit
Docs: Omit
tags: @slow, @svn

- [x] Refer to the issue that supports this Pull Request.
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 

<sup>**Note:** By default this PR will skip the slower tests and will use a limited set of python versions. Check [here](https://github.com/conan-io/conan/blob/develop/.github/PR_INCREASE_TESTING.md) how to increase the testing level by writing some tags in the current PR body text.</sup>
