### PR TITLE
fix develop

### DIFF
--- a/conans/errors.py
+++ b/conans/errors.py
@@ -47,7 +47,8 @@ def _format_conanfile_exception(scope, method, exception):
         content_lines = []
 
         while True:  # If out of index will raise and will be captured later
-            filepath, line, name, contents = traceback.extract_tb(tb, 40)[index]  # 40 levels of nested functions max, get the latest
+            # 40 levels of nested functions max, get the latest
+            filepath, line, name, contents = traceback.extract_tb(tb, 40)[index]
             if "conanfile.py" not in filepath:  # Avoid show trace from internal conan source code
                 if conanfile_reached:  # The error goes to internal code, exit print
                     break
@@ -56,11 +57,12 @@ def _format_conanfile_exception(scope, method, exception):
                     msg = "%s: Error in %s() method" % (scope, method)
                     msg += ", line %d\n\t%s" % (line, contents)
                 else:
-                    msg = "while calling '%s', line %d\n\t%s" % (name, line, contents) if line else "\n\t%s" % contents
+                    msg = ("while calling '%s', line %d\n\t%s" % (name, line, contents)
+                           if line else "\n\t%s" % contents)
                 content_lines.append(msg)
                 conanfile_reached = True
             index += 1
-    except:
+    except Exception:
         pass
     ret = "\n".join(content_lines)
     ret += "\n\t%s: %s" % (exception.__class__.__name__, str(exception))

--- a/conans/server/service/v1/service.py
+++ b/conans/server/service/v1/service.py
@@ -1,7 +1,5 @@
-from conans import DEFAULT_REVISION_V1
 from conans.errors import NotFoundException, RequestErrorException, RecipeNotFoundException, \
     PackageNotFoundException
-from conans.model.ref import PackageReference
 from conans.server.service.common.common import CommonService
 
 


### PR DESCRIPTION
Changelog: omit
Docs: omit

@revisions: 1


This is fixing the tests broken in https://github.com/conan-io/conan/pull/4494: https://github.com/conan-io/conan/pull/4494/commits/9cd4dde30f55bae18a355c4bf30f84e2251d6c89, that do not take into account revisions.

This could be a symptom that conan_server might return in v1 ``RecipeNotFoundException`` when a ``pref`` has a ``pref.ref`` that doesn't exist at all (that is the behavior implemented in v2), instead of the ``PackageNotFoundException`` that is returning. But that has to be discussed and fixed in a different PR, this is to fix develop


