### PR TITLE
check SettingsItem return type

### DIFF
--- a/conans/model/settings.py
+++ b/conans/model/settings.py
@@ -85,7 +85,7 @@ class SettingsItem(object):
         return self.__bool__()
 
     def __str__(self):
-        return self._value
+        return str(self._value)
 
     def __eq__(self, other):
         if other is None:

--- a/conans/test/unittests/model/settings_test.py
+++ b/conans/test/unittests/model/settings_test.py
@@ -31,6 +31,14 @@ class SettingsLoadsTest(unittest.TestCase):
         self.assertEqual(_os, None)
         self.assertEqual(str(_os), "None")
 
+    def test_get_safe(self):
+        yml = "os: [None, Windows]"
+        settings = Settings.loads(yml)
+        settings.os = "Windows"
+        self.assertEqual(settings.os, "Windows")
+        self.assertEqual(settings.get_safe("compiler.version"), None)
+        self.assertEqual(settings.get_safe("build_type"), None)
+
     def test_none_subsetting(self):
         yml = """os:
     None:

--- a/conans/test/unittests/model/settings_test.py
+++ b/conans/test/unittests/model/settings_test.py
@@ -23,6 +23,14 @@ class SettingsLoadsTest(unittest.TestCase):
         self.assertTrue(settings.os == "Windows")
         self.assertEqual("os=Windows", settings.values.dumps())
 
+    def getattr_none_test(self):
+        yml = "os: [None, Windows]"
+        settings = Settings.loads(yml)
+        self.assertEqual(settings.os, None)
+        _os = getattr(settings, "os")
+        self.assertEqual(_os, None)
+        self.assertEqual(str(_os), "None")
+
     def test_none_subsetting(self):
         yml = """os:
     None:


### PR DESCRIPTION
Changelog: Bugfix: Avoid ``str(self.settings.xxx)`` crash when the value is None.
Docs: https://github.com/conan-io/docs/pull/1089

Testing https://github.com/conan-io/conan/issues/4562
