### PR TITLE
Parsing from Artifactory ISO8601

### DIFF
--- a/conans/test/integration/revisions_test.py
+++ b/conans/test/integration/revisions_test.py
@@ -1170,6 +1170,20 @@ class SearchingPackagesWithRevisions(unittest.TestCase):
                  assert_error=True)
         self.assertIn("The remote doesn't support revisions", c_v1.out)
 
+    def search_revisions_regular_results_test(self):
+        """If I upload several revisions to a server, we can list the times"""
+        server = TestServer()
+        servers = OrderedDict([("default", server)])
+        c_v2 = TurboTestClient(revisions_enabled=True, servers=servers)
+        pref = c_v2.create(self.ref)
+        c_v2.upload_all(self.ref)
+        pref_rev = pref.copy_with_revs(pref.ref.revision, None)
+
+        c_v2.run("search {} --revisions -r default".format(pref_rev.full_repr()))
+        # I don't want to mock here because I want to run this test against Artifactory
+        self.assertIn("83c38d3b4e5f1b8450434436eec31b00 (", c_v2.out)
+        self.assertIn(" UTC)", c_v2.out)
+
 
 @unittest.skipUnless(get_env("TESTING_REVISIONS_ENABLED", False), "Only revisions")
 class UploadPackagesWithRevisions(unittest.TestCase):

--- a/conans/test/unittests/client/util/time_test.py
+++ b/conans/test/unittests/client/util/time_test.py
@@ -15,6 +15,12 @@ class TimeTest(unittest.TestCase):
         expected = datetime.datetime(year=2019, month=1, day=10, hour=16, minute=34, second=59)
         self.assertEquals(dt, expected)
 
+        artifactory_ret = '2019-02-20T13:54:47.543+0000'
+        dt = from_iso8601_to_datetime(artifactory_ret)
+        expected = datetime.datetime(year=2019, month=2, day=20, hour=13, minute=54, second=47,
+                                     microsecond=543000)
+        self.assertEquals(dt, expected)
+
     def validation_test(self):
         self.assertFalse(valid_iso8601("1547138099"))
         self.assertTrue(valid_iso8601("2019-01-10T16:34:59Z"))

--- a/conans/util/dates.py
+++ b/conans/util/dates.py
@@ -7,7 +7,24 @@ def from_timestamp_to_iso8601(timestamp):
 
 
 def from_iso8601_to_datetime(iso_str):
-    return datetime.datetime.strptime(iso_str, '%Y-%m-%dT%H:%M:%SZ')
+
+    def transform_to_z_notation(the_str):
+        for p in ("+00:00", "+0000", "+00"):
+            if the_str.endswith(p):
+                the_str = the_str[0:-len(p)]
+                return "{}Z".format(the_str)
+        return the_str
+
+    base_pattern = "%Y-%m-%dT%H:%M:%S"
+    if "." in iso_str:
+        pattern = "{}.%fZ".format(base_pattern)
+    else:
+        pattern = '{}Z'.format(base_pattern)
+
+    iso_str = transform_to_z_notation(iso_str)
+    if not iso_str.endswith("Z"):
+        iso_str += "Z"
+    return datetime.datetime.strptime(iso_str, pattern)
 
 
 def iso8601_to_str(iso_str):


### PR DESCRIPTION
Changelog: omit
Docs: omit

The `ISO8601` format is too open, I needed to improve the parsing to support the format used in Artifactory.

@REVISIONS: 1