### PR TITLE
Added install_folder to dynamic fields list.

### DIFF
--- a/conans/pylint_plugin.py
+++ b/conans/pylint_plugin.py
@@ -29,6 +29,7 @@ def transform_conanfile(node):
         "source_folder": str_class,
         "build_folder": str_class,
         "package_folder": str_class,
+        "install_folder": str_class,
         "build_requires": build_requires_class,
         "info_build": info_class,
         "info": info_class,

--- a/conans/test/functional/command/export_linter_test.py
+++ b/conans/test/functional/command/export_linter_test.py
@@ -87,6 +87,7 @@ class TestConan(ConanFile):
         self.output.info(self.source_folder)
         self.output.info(self.package_folder)
         self.output.info(self.build_folder)
+        self.output.info(self.install_folder)
 
     def package(self):
         self.copy("*")


### PR DESCRIPTION
Changelog: Fix: `Instance of 'TestConan' has no 'install_folder' member` when exporting recipe

- [ ] Refer to the issue that supports this Pull Request.
- [ ] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 

<sup>**Note:** By default this PR will skip the slower tests and will use a limited set of python versions. Check [here](https://github.com/conan-io/conan/blob/develop/.github/PR_INCREASE_TESTING.md) how to increase the testing level by writing some tags in the current PR body text.</sup>
