### PR TITLE
Command 'conan profile list' will now list profiles recursively

### DIFF
--- a/conans/client/cmd/profile.py
+++ b/conans/client/cmd/profile.py
@@ -21,13 +21,18 @@ def _get_profile_keys(key):
 
 
 def cmd_profile_list(cache_profiles_path, output):
-    folder = cache_profiles_path
-    if os.path.exists(folder):
-        return [name for name in os.listdir(folder)
-                if not os.path.isdir(os.path.join(folder, name))]
-    else:
+    profiles = []
+    if os.path.exists(cache_profiles_path):
+        for current_directory, dirs, files in os.walk(cache_profiles_path, followlinks=True):
+            for filename in files:
+                relative_to_profile_dir = os.path.relpath(current_directory, cache_profiles_path)
+                rel_path = os.path.relpath(os.path.join(current_directory, filename), cache_profiles_path)
+                profiles.append(rel_path)
+
+    if len(profiles) == 0:
         output.info("No profiles defined")
-        return []
+    profiles.sort()
+    return profiles
 
 
 def cmd_profile_create(profile_name, cache_profiles_path, output, detect=False):

--- a/conans/client/cmd/profile.py
+++ b/conans/client/cmd/profile.py
@@ -23,13 +23,13 @@ def _get_profile_keys(key):
 def cmd_profile_list(cache_profiles_path, output):
     profiles = []
     if os.path.exists(cache_profiles_path):
-        for current_directory, dirs, files in os.walk(cache_profiles_path, followlinks=True):
+        for current_directory, _, files in os.walk(cache_profiles_path, followlinks=True):
             for filename in files:
-                relative_to_profile_dir = os.path.relpath(current_directory, cache_profiles_path)
-                rel_path = os.path.relpath(os.path.join(current_directory, filename), cache_profiles_path)
+                rel_path = os.path.relpath(os.path.join(current_directory, filename),
+                                           cache_profiles_path)
                 profiles.append(rel_path)
 
-    if len(profiles) == 0:
+    if not profiles:
         output.info("No profiles defined")
     profiles.sort()
     return profiles

--- a/conans/test/functional/command/profile_test.py
+++ b/conans/test/functional/command/profile_test.py
@@ -4,6 +4,7 @@ import unittest
 from conans.test.utils.profiles import create_profile
 from conans.test.utils.tools import TestClient
 from conans.util.files import load
+import platform
 
 
 class ProfileTest(unittest.TestCase):
@@ -32,21 +33,23 @@ class ProfileTest(unittest.TestCase):
         profiles = ["profile1", "profile2", "profile3",
                     "nested" + os.path.sep + "profile4",
                     "nested" + os.path.sep + "two" + os.path.sep + "profile5",
-                    "nested" + os.path.sep + "profile6",
-                    "symlink_me" + os.path.sep + "profile7"]
-        profiles.sort()
+                    "nested" + os.path.sep + "profile6"]
+        if platform.system() != "Windows":
+            profiles.append("symlink_me" + os.path.sep + "profile7")
         for profile in profiles:
             create_profile(client.cache.profiles_path, profile)
 
-        os.symlink(os.path.join(client.cache.profiles_path, 'symlink_me'), os.path.join(client.cache.profiles_path, 'link'))
-        # profile7 will be shown twice because it is symlinked.
-        profiles.append("link" + os.path.sep + "profile7")
+        if platform.system() != "Windows":
+            os.symlink(os.path.join(client.cache.profiles_path, 'symlink_me'),
+                       os.path.join(client.cache.profiles_path, 'link'))
+            # profile7 will be shown twice because it is symlinked.
+            profiles.append("link" + os.path.sep + "profile7")
 
         # Make sure local folder doesn't interact with profiles
         os.mkdir(os.path.join(client.current_folder, "profile3"))
         client.run("profile list")
         profiles.sort()
-        self.assertEqual(profiles, list(str(client.user_io.out).splitlines()))
+        self.assertEqual(profiles, list(str(client.out).splitlines()))
 
     def show_test(self):
         client = TestClient()

--- a/conans/test/functional/command/profile_test.py
+++ b/conans/test/functional/command/profile_test.py
@@ -29,14 +29,24 @@ class ProfileTest(unittest.TestCase):
 
     def list_test(self):
         client = TestClient()
-        create_profile(client.cache.profiles_path, "profile3")
-        create_profile(client.cache.profiles_path, "profile1")
-        create_profile(client.cache.profiles_path, "profile2")
+        profiles = ["profile1", "profile2", "profile3",
+                    "nested" + os.path.sep + "profile4",
+                    "nested" + os.path.sep + "two" + os.path.sep + "profile5",
+                    "nested" + os.path.sep + "profile6",
+                    "symlink_me" + os.path.sep + "profile7"]
+        profiles.sort()
+        for profile in profiles:
+            create_profile(client.cache.profiles_path, profile)
+
+        os.symlink(os.path.join(client.cache.profiles_path, 'symlink_me'), os.path.join(client.cache.profiles_path, 'link'))
+        # profile7 will be shown twice because it is symlinked.
+        profiles.append("link" + os.path.sep + "profile7")
+
         # Make sure local folder doesn't interact with profiles
         os.mkdir(os.path.join(client.current_folder, "profile3"))
         client.run("profile list")
-        self.assertEqual(list(["profile1", "profile2", "profile3"]),
-                         list(str(client.user_io.out).splitlines()))
+        profiles.sort()
+        self.assertEqual(profiles, list(str(client.user_io.out).splitlines()))
 
     def show_test(self):
         client = TestClient()


### PR DESCRIPTION
This fixes #4589

Changelog: Fix: `conan profile list` will now recursively list profiles.
Docs: omit

I am not sure this warrants a documentation change.