### PR TITLE
Return empty list if env variable is empty

### DIFF
--- a/conans/test/unittests/util/env_reader.py
+++ b/conans/test/unittests/util/env_reader.py
@@ -1,0 +1,28 @@
+# coding=utf-8
+
+import unittest
+from unittest import mock
+
+from conans.util.env_reader import get_env
+
+
+class GetEnvTest(unittest.TestCase):
+    environment = {"EMPTY_LIST": "",
+                   "LIST": "a,b,c,d"}
+
+    def test_environment(self):
+        """ Ensure that we are using os.environment if no argument is passed """
+        with mock.patch("os.environ.get", return_value="zzz"):
+            a = get_env("whatever", default=None)
+        self.assertEqual(a, "zzz")
+
+    def test_list_empty(self):
+        r = get_env("EMPTY_LIST", default=list(), environment=self.environment)
+        self.assertEqual(r, [])
+
+        r = get_env("NON-EXISTING-LIST", default=list(), environment=self.environment)
+        self.assertEqual(r, [])
+
+    def test_list(self):
+        r = get_env("LIST", default=list(), environment=self.environment)
+        self.assertEqual(r, ["a", "b", "c", "d"])

--- a/conans/util/env_reader.py
+++ b/conans/util/env_reader.py
@@ -25,5 +25,7 @@ def get_env(env_key, default=None, environment=None):
         elif isinstance(default, float):
             return float(env_var)
         elif isinstance(default, list):
-            return [var.strip() for var in env_var.split(",")]
+            if env_var.strip():
+                return [var.strip() for var in env_var.split(",")]
+            return []
     return env_var


### PR DESCRIPTION
Changelog: Fix: Return empty list if env variable is an empty string
Docs: omit

closes #4451 