### PR TITLE
Deprecate 'cppflags' in favor of 'cxxflags' in class CppInfo

### DIFF
--- a/conans/model/build_info.py
+++ b/conans/model/build_info.py
@@ -1,6 +1,7 @@
 import os
 from collections import OrderedDict
 
+import deprecation
 
 DEFAULT_INCLUDE = "include"
 DEFAULT_LIB = "lib"
@@ -25,7 +26,7 @@ class _CppInfo(object):
         self.libs = []  # The libs to link against
         self.defines = []  # preprocessor definitions
         self.cflags = []  # pure C flags
-        self.cppflags = []  # C++ compilation flags
+        self.cxxflags = []  # C++ compilation flags
         self.sharedlinkflags = []  # linker flags
         self.exelinkflags = []  # linker flags
         self.rootpath = ""
@@ -85,6 +86,17 @@ class _CppInfo(object):
             self._res_paths = self._filter_paths(self.resdirs)
         return self._res_paths
 
+    # Compatibility for 'cppflags' (old style property to allow decoration)
+    @deprecation.deprecated(deprecated_in="1.13", removed_in="2.0", details="Use 'cxxflags' instead")
+    def get_cppflags(self):
+        return self.cxxflags
+
+    @deprecation.deprecated(deprecated_in="1.13", removed_in="2.0", details="Use 'cxxflags' instead")
+    def set_cppflags(self, value):
+        self.cxxflags = value
+
+    cppflags = property(get_cppflags, set_cppflags)
+
 
 class CppInfo(_CppInfo):
     """ Build Information declared to be used by the CONSUMERS of a
@@ -140,7 +152,7 @@ class _BaseDepsCppInfo(_CppInfo):
 
         # Note these are in reverse order
         self.defines = merge_lists(dep_cpp_info.defines, self.defines)
-        self.cppflags = merge_lists(dep_cpp_info.cppflags, self.cppflags)
+        self.cxxflags = merge_lists(dep_cpp_info.cxxflags, self.cxxflags)
         self.cflags = merge_lists(dep_cpp_info.cflags, self.cflags)
         self.sharedlinkflags = merge_lists(dep_cpp_info.sharedlinkflags, self.sharedlinkflags)
         self.exelinkflags = merge_lists(dep_cpp_info.exelinkflags, self.exelinkflags)


### PR DESCRIPTION
Changelog: Fix: Deprecate 'cppflags' in favor of 'cxxflags' in class CppInfo
Docs: https://github.com/conan-io/docs/pull/1091

closes #4337

- [x] Update docs

----

In order to remove all the usages of the deprecated member in our codebase, I find one problem: the files written by the generators...

For example, the `conanbuildinfo.txt` file now contains

```ini
[cppflags_Hello]
FLAG
```

and the expected (for Conan v2.0) should be:

```ini
[cxxflags_Hello]
FLAG
```

During the transition, we can output something like the following one, to keep compatibility:
```ini
[cppflags_Hello]
FLAG
[cxxflags_Hello]
FLAG
```

So, our reader should be able to deal with the first option and the last one until Conan V2 (checking that both sections contain the same information). This is easy for the `txt` generator, but it might require some more testing for other generators.

Maybe we can merge this PR jsut with the deprecation notice as the issue states, and then we can open a different PR to fix all the usages of this deprecated code. WDYT?