### PR TITLE
Exclude pylint==2.3.0 (html-escaped chars in json output)

### DIFF
--- a/conans/requirements.txt
+++ b/conans/requirements.txt
@@ -7,7 +7,7 @@ fasteners>=0.14.1
 six>=1.10.0
 node-semver==0.6.1
 distro>=1.0.2, <1.2.0
-pylint>=1.9.3
+pylint>=1.9.3,!=2.3.0
 future==0.16.0
 pygments>=2.0, <3.0
 astroid>=1.6.5


### PR DESCRIPTION
Changelog: omit
Docs: omit

With the new version of Pylint (2.3.0), the JSON output contains escaped characters:

```json
[
    {
        "type": "convention",
        "module": "conanfile",
        "obj": "TestConan.build",
        "line": 9,
        "column": 15,
        "path": "conanfile.py",
        "symbol": "invalid-name",
        "message": "Variable name &quot;v&quot; doesn&#x27;t conform to snake_case naming style",
        "message-id": "C0103"
    }
]
```

I've opened an issue in their repo (https://github.com/PyCQA/pylint/issues/2769), probably it is a regression so I'm blocking just that version