### PR TITLE
Fail nicely without revisions and only_v2

### DIFF
--- a/conans/__init__.py
+++ b/conans/__init__.py
@@ -15,6 +15,7 @@ from conans.util.files import load
 COMPLEX_SEARCH_CAPABILITY = "complex_search"
 CHECKSUM_DEPLOY = "checksum_deploy"  # Only when v2
 REVISIONS = "revisions"  # Only when enabled in config, not by default look at server_launcher.py
+ONLY_V2 = "only_v2"  # Remotes and virtuals from Artifactory returns this capability
 SERVER_CAPABILITIES = [COMPLEX_SEARCH_CAPABILITY, REVISIONS]  # Server is always with revisions
 DEFAULT_REVISION_V1 = "0"
 

--- a/conans/client/conan_api.py
+++ b/conans/client/conan_api.py
@@ -5,7 +5,6 @@ from collections import OrderedDict
 import requests
 
 import conans
-
 from conans import __version__ as client_version
 from conans.client import packager, tools
 from conans.client.cache.cache import ClientCache
@@ -22,6 +21,7 @@ from conans.client.cmd.test import PackageTester
 from conans.client.cmd.uploader import CmdUpload
 from conans.client.cmd.user import user_set, users_clean, users_list
 from conans.client.conf import ConanClientConfigParser
+from conans.client.graph.graph import RECIPE_EDITABLE
 from conans.client.graph.graph_manager import GraphManager
 from conans.client.graph.printer import print_graph
 from conans.client.graph.proxy import ConanProxy
@@ -62,8 +62,6 @@ from conans.util.env_reader import get_env
 from conans.util.files import exception_message_safe, mkdir, save_files
 from conans.util.log import configure_logger
 from conans.util.tracer import log_command, log_exception
-from conans.client.graph.graph import RECIPE_EDITABLE
-
 
 default_manifest_folder = '.conan_manifests'
 

--- a/conans/client/rest/rest_client.py
+++ b/conans/client/rest/rest_client.py
@@ -1,8 +1,9 @@
 from collections import defaultdict
 
-from conans import CHECKSUM_DEPLOY, REVISIONS
+from conans import CHECKSUM_DEPLOY, REVISIONS, ONLY_V2
 from conans.client.rest.rest_client_v1 import RestV1Methods
 from conans.client.rest.rest_client_v2 import RestV2Methods
+from conans.errors import OnlyV2Available
 
 
 class RestApiClient(object):
@@ -32,6 +33,8 @@ class RestApiClient(object):
                                 self.requester, self.verify_ssl, self._put_headers)
             _, _, cap = tmp.server_info()
             self._cached_capabilities[self.remote_url] = cap
+            if not self._revisions_enabled and ONLY_V2 in cap:
+                raise OnlyV2Available(self.remote_url)
 
         if self._revisions_enabled and REVISIONS in self._cached_capabilities[self.remote_url]:
             checksum_deploy = CHECKSUM_DEPLOY in self._cached_capabilities[self.remote_url]

--- a/conans/errors.py
+++ b/conans/errors.py
@@ -92,6 +92,15 @@ class ConanException(Exception):
         return exception_message_safe(msg)
 
 
+class OnlyV2Available(ConanException):
+
+    def __init__(self, remote_url):
+        msg = "The remote at '%s' only works with revisions enabled. " \
+              "Set CONAN_REVISIONS_ENABLED=1 " \
+              "or set 'general.revisions_enabled = 1' at the 'conan.conf'" % remote_url
+        super(OnlyV2Available, self).__init__(msg)
+
+
 class NoRestV2Available(ConanException):
     pass
 

--- a/conans/test/integration/revisions_test.py
+++ b/conans/test/integration/revisions_test.py
@@ -6,7 +6,7 @@ import time
 from nose.plugins.attrib import attr
 from parameterized.parameterized import parameterized
 
-from conans import DEFAULT_REVISION_V1, load
+from conans import DEFAULT_REVISION_V1, load, ONLY_V2
 from conans.client.tools import environment_append
 from conans.errors import RecipeNotFoundException, PackageNotFoundException
 from conans.model.ref import ConanFileReference
@@ -1356,6 +1356,16 @@ class CapabilitiesRevisionsTest(unittest.TestCase):
         c_v2.remove_all()
         c_v2.run("install {}".format(ref))
         self.assertEquals(c_v2.recipe_revision(ref), DEFAULT_REVISION_V1)
+
+    def test_server_with_only_v2_capability(self):
+        server = TestServer(server_capabilities=[ONLY_V2])
+        c_v2 = TurboTestClient(revisions_enabled=False, servers={"default": server})
+        ref = ConanFileReference.loads("lib/1.0@conan/testing")
+        c_v2.create(ref)
+        c_v2.upload_all(ref, remote="default", assert_error=True)
+        self.assertIn("The remote at '{}' only works with revisions enabled. "
+                      "Set CONAN_REVISIONS_ENABLED=1 or set 'general.revisions_enabled = 1' "
+                      "at the 'conan.conf'. [Remote: default]".format(server.fake_url), c_v2.out)
 
 
 @unittest.skipUnless(get_env("TESTING_REVISIONS_ENABLED", False), "Only revisions")

--- a/conans/test/utils/tools.py
+++ b/conans/test/utils/tools.py
@@ -905,8 +905,10 @@ class TurboTestClient(TestClient):
         remote = remote or list(self.servers.keys())[0]
         self.run("upload {} -c --all -r {} {}".format(ref.full_repr(), remote, args or ""),
                  assert_error=assert_error)
-        remote_rrev, _ = self.servers[remote].server_store.get_last_revision(ref)
-        return ref.copy_with_rev(remote_rrev)
+        if not assert_error:
+            remote_rrev, _ = self.servers[remote].server_store.get_last_revision(ref)
+            return ref.copy_with_rev(remote_rrev)
+        return
 
     def remove_all(self):
         self.run("remove '*' -f")


### PR DESCRIPTION
Changelog: omit
Docs: omit

Closes #4607

Tested also manually with Artifactory.

@revisions: 1


Team, allow me to introduce here the changelog for the installers and there is no PR to open for that:

Changelog: Feature: The `deb` and `windows` Conan installers now use Python 3.
