### PR TITLE
Add revision to ref in the install json output

### DIFF
--- a/conans/client/cmd/export.py
+++ b/conans/client/cmd/export.py
@@ -93,11 +93,11 @@ def cmd_export(package_layout, conanfile_path, conanfile, keep_source, revisions
         digest.save(package_layout.export())
 
     # Compute the revision for the recipe
-    _update_revision_in_metadata(package_layout=package_layout,
-                                 revisions_enabled=revisions_enabled,
-                                 output=output,
-                                 path=os.path.dirname(conanfile_path),
-                                 digest=digest)
+    revision = _update_revision_in_metadata(package_layout=package_layout,
+                                            revisions_enabled=revisions_enabled,
+                                            output=output,
+                                            path=os.path.dirname(conanfile_path),
+                                            digest=digest)
 
     # FIXME: Conan 2.0 Clear the registry entry if the recipe has changed
     source_folder = package_layout.source()
@@ -127,6 +127,8 @@ def cmd_export(package_layout, conanfile_path, conanfile, keep_source, revisions
             output.info("Removing the local binary packages from different recipe revisions")
             remover = DiskRemover()
             remover.remove_packages(package_layout, ids_filter=to_remove)
+
+    return package_layout.ref.copy_with_rev(revision)
 
 
 def _capture_export_scm_data(conanfile, conanfile_dir, destination_folder, output, scm_src_file):
@@ -250,6 +252,8 @@ def _update_revision_in_metadata(package_layout, revisions_enabled, output, path
                         " revision: {} ".format(revision))
     with package_layout.update_metadata() as metadata:
         metadata.recipe.revision = revision
+
+    return revision
 
 
 def _recreate_folders(destination_folder, destination_src_folder):

--- a/conans/client/conan_api.py
+++ b/conans/client/conan_api.py
@@ -365,11 +365,11 @@ class ConanAPIV1(object):
             if not not_export:
                 check_casing_conflict(cache=self._cache, ref=ref)
                 package_layout = self._cache.package_layout(ref, short_paths=conanfile.short_paths)
-                cmd_export(package_layout, conanfile_path, conanfile, keep_source,
-                           self._cache.config.revisions_enabled, self._user_io.out,
-                           self._hook_manager)
-
-                recorder.recipe_exported(ref)
+                new_ref = cmd_export(package_layout, conanfile_path, conanfile, keep_source,
+                                     self._cache.config.revisions_enabled, self._user_io.out,
+                                     self._hook_manager)
+                # The new_ref contains the revision
+                recorder.recipe_exported(new_ref)
 
             if build_modes is None:  # Not specified, force build the tested library
                 build_modes = [conanfile.name]
@@ -430,13 +430,15 @@ class ConanAPIV1(object):
             conanfile = self._loader.load_export(conanfile_path, name, version, user, channel)
             ref = ConanFileReference(conanfile.name, conanfile.version, user, channel)
 
-            recorder.recipe_exported(ref)
-            recorder.add_recipe_being_developed(ref)
             check_casing_conflict(cache=self._cache, ref=ref)
             package_layout = self._cache.package_layout(ref, short_paths=conanfile.short_paths)
-            cmd_export(package_layout, conanfile_path, conanfile, False,
-                       self._cache.config.revisions_enabled, self._user_io.out,
-                       self._hook_manager)
+            new_ref = cmd_export(package_layout, conanfile_path, conanfile, False,
+                                 self._cache.config.revisions_enabled, self._user_io.out,
+                                 self._hook_manager)
+            # new_ref has revision
+            recorder.recipe_exported(new_ref)
+            recorder.add_recipe_being_developed(ref)
+
             export_pkg(self._cache, self._graph_manager, self._hook_manager, recorder,
                        self._user_io.out,
                        ref, source_folder=source_folder, build_folder=build_folder,

--- a/conans/client/conan_api.py
+++ b/conans/client/conan_api.py
@@ -386,11 +386,11 @@ class ConanAPIV1(object):
                    manifest_folder, manifest_verify, manifest_interactive, keep_build,
                    test_build_folder, test_folder, conanfile_path)
 
-            return recorder.get_info()
+            return recorder.get_info(self._cache.config.revisions_enabled)
 
         except ConanException as exc:
             recorder.error = True
-            exc.info = recorder.get_info()
+            exc.info = recorder.get_info(self._cache.config.revisions_enabled)
             raise
 
     @api_method
@@ -442,10 +442,10 @@ class ConanAPIV1(object):
                        ref, source_folder=source_folder, build_folder=build_folder,
                        package_folder=package_folder, install_folder=install_folder,
                        graph_info=graph_info, force=force)
-            return recorder.get_info()
+            return recorder.get_info(self._cache.config.revisions_enabled)
         except ConanException as exc:
             recorder.error = True
-            exc.info = recorder.get_info()
+            exc.info = recorder.get_info(self._cache.config.revisions_enabled)
             raise
 
     @api_method
@@ -533,10 +533,10 @@ class ConanAPIV1(object):
                             manifest_verify=manifest_verify,
                             manifest_interactive=manifest_interactive,
                             generators=generators)
-            return recorder.get_info()
+            return recorder.get_info(self._cache.config.revisions_enabled)
         except ConanException as exc:
             recorder.error = True
-            exc.info = recorder.get_info()
+            exc.info = recorder.get_info(self._cache.config.revisions_enabled)
             raise
 
     @api_method
@@ -570,10 +570,10 @@ class ConanAPIV1(object):
                             manifest_interactive=manifest_interactive,
                             generators=generators,
                             no_imports=no_imports)
-            return recorder.get_info()
+            return recorder.get_info(self._cache.config.revisions_enabled)
         except ConanException as exc:
             recorder.error = True
-            exc.info = recorder.get_info()
+            exc.info = recorder.get_info(self._cache.config.revisions_enabled)
             raise
 
     @api_method

--- a/conans/client/recorder/action_recorder.py
+++ b/conans/client/recorder/action_recorder.py
@@ -22,12 +22,12 @@ INSTALL_ERROR_MISSING_BUILD_FOLDER = "missing_build_folder"
 INSTALL_ERROR_BUILDING = "building"
 
 
-class Action(namedtuple("Action", "type, doc, time")):
+class Action(namedtuple("Action", "type, full_ref, doc, time")):
 
-    def __new__(cls, the_type, doc=None):
+    def __new__(cls, the_type, full_ref, doc=None):
         doc = doc or {}
         the_time = datetime.utcnow()
-        return super(cls, Action).__new__(cls, the_type, doc, the_time)
+        return super(cls, Action).__new__(cls, the_type, full_ref, doc, the_time)
 
 
 class ActionRecorder(object):
@@ -53,56 +53,54 @@ class ActionRecorder(object):
 
     def _add_package_action(self, pref, action):
         assert(isinstance(pref, PackageReference))
-        pref = pref.copy_clear_rev()
+        pref = pref.copy_clear_revs()
         if pref not in self._inst_packages_actions:
             self._inst_packages_actions[pref] = []
         self._inst_packages_actions[pref].append(action)
 
     # RECIPE METHODS
     def recipe_exported(self, ref):
-        self._add_recipe_action(ref, Action(INSTALL_EXPORTED))
+        self._add_recipe_action(ref, Action(INSTALL_EXPORTED, ref))
 
     def recipe_fetched_from_cache(self, ref):
-        self._add_recipe_action(ref, Action(INSTALL_CACHE))
+        self._add_recipe_action(ref, Action(INSTALL_CACHE, ref))
 
     def recipe_downloaded(self, ref, remote_name):
-        self._add_recipe_action(ref, Action(INSTALL_DOWNLOADED, {"remote": remote_name}))
+        self._add_recipe_action(ref, Action(INSTALL_DOWNLOADED, ref, {"remote": remote_name}))
 
     def recipe_install_error(self, ref, error_type, description, remote_name):
         doc = {"type": error_type, "description": description, "remote": remote_name}
-        self._add_recipe_action(ref, Action(INSTALL_ERROR, doc))
+        self._add_recipe_action(ref, Action(INSTALL_ERROR, ref, doc))
 
     # PACKAGE METHODS
     def package_exported(self, pref):
-        self._add_package_action(pref, Action(INSTALL_EXPORTED))
+        self._add_package_action(pref, Action(INSTALL_EXPORTED, pref))
 
     def package_built(self, pref):
-        self._add_package_action(pref, Action(INSTALL_BUILT))
+        self._add_package_action(pref, Action(INSTALL_BUILT, pref))
 
     def package_fetched_from_cache(self, pref):
-        self._add_package_action(pref, Action(INSTALL_CACHE))
+        self._add_package_action(pref, Action(INSTALL_CACHE, pref))
 
     def package_downloaded(self, pref, remote_name):
-        self._add_package_action(pref, Action(INSTALL_DOWNLOADED, {"remote": remote_name}))
+        self._add_package_action(pref, Action(INSTALL_DOWNLOADED, pref, {"remote": remote_name}))
 
     def package_install_error(self, pref, error_type, description, remote_name=None):
         assert(isinstance(pref, PackageReference))
-        pref = pref.copy_clear_rev()
         if pref not in self._inst_packages_actions:
-            self._inst_packages_actions[pref] = []
+            self._inst_packages_actions[pref.copy_clear_revs()] = []
         doc = {"type": error_type, "description": description, "remote": remote_name}
-        self._inst_packages_actions[pref].append(Action(INSTALL_ERROR, doc))
+        self._inst_packages_actions[pref.copy_clear_revs()].append(Action(INSTALL_ERROR, pref, doc))
 
     def package_cpp_info(self, pref, cpp_info):
         assert isinstance(pref, PackageReference)
-        pref = pref.copy_clear_rev()
         # assert isinstance(cpp_info, CppInfo)
         doc = {}
         for it, value in vars(cpp_info).items():
             if it.startswith("_") or not value:
                 continue
             doc[it] = value
-        self._inst_packages_info[pref]['cpp_info'] = doc
+        self._inst_packages_info[pref.copy_clear_revs()]['cpp_info'] = doc
 
     @property
     def install_errored(self):
@@ -126,10 +124,10 @@ class ActionRecorder(object):
     def in_development_recipe(self, ref):
         return ref in self._inst_recipes_develop
 
-    def get_info(self):
-        return self.get_install_info()
+    def get_info(self, revisions_enabled):
+        return self.get_install_info(revisions_enabled)
 
-    def get_install_info(self):
+    def get_install_info(self, revisions_enabled):
         ret = {"error": self.install_errored or self.error,
                "installed": []}
 
@@ -141,8 +139,12 @@ class ActionRecorder(object):
             remote = None if not remotes else remotes[0]
             action_types = [action.type for action in the_actions]
             time = the_actions[0].time
+            if revisions_enabled and isinstance(the_ref, ConanFileReference):
+                the_id = the_actions[0].full_ref
+            else:
+                the_id = str(the_ref)
 
-            doc = {"id": str(the_ref),
+            doc = {"id": the_id,
                    "downloaded": INSTALL_DOWNLOADED in action_types,
                    "exported": INSTALL_EXPORTED in action_types,
                    "error": error,

--- a/conans/client/recorder/action_recorder.py
+++ b/conans/client/recorder/action_recorder.py
@@ -42,7 +42,7 @@ class ActionRecorder(object):
     # ###### INSTALL METHODS ############
     def add_recipe_being_developed(self, ref):
         assert(isinstance(ref, ConanFileReference))
-        self._inst_recipes_develop.add(ref)
+        self._inst_recipes_develop.add(ref.copy_clear_rev())
 
     def _add_recipe_action(self, ref, action):
         assert(isinstance(ref, ConanFileReference))
@@ -140,7 +140,7 @@ class ActionRecorder(object):
             action_types = [action.type for action in the_actions]
             time = the_actions[0].time
             if revisions_enabled and isinstance(the_ref, ConanFileReference):
-                the_id = the_actions[0].full_ref
+                the_id = the_actions[0].full_ref.full_repr()
             else:
                 the_id = str(the_ref)
 

--- a/conans/model/ref.py
+++ b/conans/model/ref.py
@@ -174,3 +174,6 @@ class PackageReference(namedtuple("PackageReference", "ref id revision")):
     def copy_clear_rev(self):
         ref = self.ref.copy_clear_rev()
         return PackageReference(ref, self.id, revision=None)
+
+    def copy_clear_revs(self):
+        return self.copy_with_revs(None, None)

--- a/conans/test/functional/command/export_pkg_test.py
+++ b/conans/test/functional/command/export_pkg_test.py
@@ -450,8 +450,10 @@ class TestConan(ConanFile):
             json_content = load(json_path)
             output = json.loads(json_content)
             self.assertEqual(output["error"], with_error)
-            self.assertEqual(output["installed"][0]["recipe"]["id"],
-                             "mypackage/0.1.0@danimtb/testing")
+            tmp = ConanFileReference.loads(output["installed"][0]["recipe"]["id"])
+            if self.client.cache.config.revisions_enabled:
+                self.assertIsNotNone(tmp.revision)
+            self.assertEqual(str(tmp), "mypackage/0.1.0@danimtb/testing")
             self.assertFalse(output["installed"][0]["recipe"]["dependency"])
             self.assertTrue(output["installed"][0]["recipe"]["exported"])
             if with_error:

--- a/conans/test/functional/command/export_pkg_test.py
+++ b/conans/test/functional/command/export_pkg_test.py
@@ -498,8 +498,10 @@ class MyConan(ConanFile):
             json_content = load(json_path)
             output = json.loads(json_content)
             self.assertEqual(output["error"], with_error)
-            self.assertEqual(output["installed"][0]["recipe"]["id"],
-                             "pkg2/1.0@danimtb/testing")
+            tmp = ConanFileReference.loads(output["installed"][0]["recipe"]["id"])
+            if self.client.cache.config.revisions_enabled:
+                self.assertIsNotNone(tmp.revision)
+            self.assertEqual(str(tmp), "pkg2/1.0@danimtb/testing")
             self.assertFalse(output["installed"][0]["recipe"]["dependency"])
             self.assertTrue(output["installed"][0]["recipe"]["exported"])
             if with_error:
@@ -508,8 +510,10 @@ class MyConan(ConanFile):
                 self.assertEqual(output["installed"][0]["packages"][0]["id"],
                                  "5825778de2dc9312952d865df314547576f129b3")
                 self.assertTrue(output["installed"][0]["packages"][0]["exported"])
-                self.assertEqual(output["installed"][1]["recipe"]["id"],
-                                 "pkg1/1.0@danimtb/testing")
+                tmp = ConanFileReference.loads(output["installed"][1]["recipe"]["id"])
+                if self.client.cache.config.revisions_enabled:
+                    self.assertIsNotNone(tmp.revision)
+                self.assertEqual(str(tmp), "pkg1/1.0@danimtb/testing")
                 self.assertTrue(output["installed"][1]["recipe"]["dependency"])
 
         conanfile = """from conans import ConanFile

--- a/conans/test/functional/command/json_output_test.py
+++ b/conans/test/functional/command/json_output_test.py
@@ -2,6 +2,7 @@ import json
 import os
 import unittest
 
+from conans.model.ref import ConanFileReference
 from conans.test.utils.cpp_test_files import cpp_hello_conan_files
 from conans.test.utils.tools import TestClient, TestServer
 from conans.util.files import load, save
@@ -165,7 +166,10 @@ AA*: CC/1.0@private_user/channel
 
         # Installed the build require CC with two options
         self.assertEquals(len(my_json["installed"][2]["packages"]), 2)
-        self.assertEquals(my_json["installed"][2]["recipe"]["id"], "CC/1.0@private_user/channel")
+        tmp = ConanFileReference.loads(my_json["installed"][2]["recipe"]["id"])
+        if self.client.cache.config.revisions_enabled:
+            self.assertIsNotNone(tmp.revision)
+        self.assertEquals(str(tmp), "CC/1.0@private_user/channel")
         self.assertFalse(my_json["installed"][2]["recipe"]["downloaded"])
         self.assertFalse(my_json["installed"][2]["packages"][0]["downloaded"])
         self.assertFalse(my_json["installed"][2]["packages"][1]["downloaded"])

--- a/conans/test/functional/command/json_output_test.py
+++ b/conans/test/functional/command/json_output_test.py
@@ -21,7 +21,10 @@ class JsonOutputTest(unittest.TestCase):
         self.client.run("create . private_user/channel --json=myfile.json")
         my_json = json.loads(load(os.path.join(self.client.current_folder, "myfile.json")))
         self.assertFalse(my_json["error"])
-        self.assertEquals(my_json["installed"][0]["recipe"]["id"], "CC/1.0@private_user/channel")
+        tmp = ConanFileReference.loads(my_json["installed"][0]["recipe"]["id"])
+        self.assertEquals(str(tmp), "CC/1.0@private_user/channel")
+        if self.client.cache.config.revisions_enabled:
+            self.assertIsNotNone(tmp.revision)
         self.assertFalse(my_json["installed"][0]["recipe"]["dependency"])
         self.assertTrue(my_json["installed"][0]["recipe"]["exported"])
         self.assertFalse(my_json["installed"][0]["recipe"]["downloaded"])

--- a/conans/test/integration/revisions_test.py
+++ b/conans/test/integration/revisions_test.py
@@ -365,6 +365,16 @@ class InstallingPackagesWithRevisionsTest(unittest.TestCase):
             client.run(command, assert_error=True)
             self.assertIn("Can't find a '{}' package".format(self.ref), client.out)
 
+    def test_json_output(self):
+        client = TurboTestClient()
+        client.save({"conanfile.py": str(GenConanfile())})
+        client.run("create . {} --json file.json".format(self.ref.full_repr()))
+        json_path = os.path.join(client.current_folder, "file.json")
+        import json
+        data = json.loads(load(json_path))
+        ref = ConanFileReference.loads(data["installed"][0]["recipe"]["id"])
+        self.assertIsNotNone(ref.revision)
+
 
 @unittest.skipUnless(get_env("TESTING_REVISIONS_ENABLED", False), "Only revisions")
 class RevisionsInLocalCacheTest(unittest.TestCase):

--- a/conans/test/unittests/client/recorder/action_recorder_test.py
+++ b/conans/test/unittests/client/recorder/action_recorder_test.py
@@ -20,7 +20,7 @@ class ActionRecorderTest(unittest.TestCase):
         tracer = ActionRecorder()
         tracer.recipe_install_error(self.ref1, INSTALL_ERROR_NETWORK, "SSL wtf", "http://drl.com")
         tracer.add_recipe_being_developed(self.ref1)
-        install_info = tracer.get_info()
+        install_info = tracer.get_info(False)
         self.assertTrue(install_info["error"])
         self.assertEquals(install_info["installed"][0]["packages"], [])
         self.assertEquals(install_info["installed"][0]["recipe"]["dependency"], False)
@@ -32,7 +32,7 @@ class ActionRecorderTest(unittest.TestCase):
         tracer.package_downloaded(self.pref1, "http://drl.com")
         tracer.package_fetched_from_cache(self.pref1)
 
-        install_info = tracer.get_info()
+        install_info = tracer.get_info(False)
         self.assertFalse(install_info["error"])
 
         first_installed = install_info["installed"][0]
@@ -59,7 +59,7 @@ class ActionRecorderTest(unittest.TestCase):
         tracer.package_built(self.pref3)
         tracer.add_recipe_being_developed(self.ref1)
 
-        install_info = tracer.get_info()
+        install_info = tracer.get_info(False)
         self.assertTrue(install_info["error"])
 
         first_installed = install_info["installed"][0]


### PR DESCRIPTION
Changelog: Fix: When revisions enabled, add the revision to the json output of the info/install commands.
Docs: omit

Close #4623 

Probably the recorder would need a refactor but this change fixes the issue.
@revisions: 1