### PR TITLE
fixing module.__file__ is None in py3

### DIFF
--- a/conans/client/hook_manager.py
+++ b/conans/client/hook_manager.py
@@ -101,8 +101,14 @@ class HookManager(object):
                 module = sys.modules[added]
                 if module:
                     try:
-                        folder = os.path.dirname(module.__file__)
-                    except AttributeError:  # some module doesn't have __file__
+                        try:
+                            # Most modules will have __file__ != None
+                            folder = os.path.dirname(module.__file__)
+                        except (AttributeError, TypeError):
+                            # But __file__ might not exist or equal None
+                            # Like some builtins and Namespace packages py3
+                            folder = module.__path__._path[0]
+                    except AttributeError:  # In case the module.__path__ doesn't exist
                         pass
                     else:
                         if folder.startswith(current_dir):

--- a/conans/client/loader.py
+++ b/conans/client/loader.py
@@ -262,10 +262,13 @@ def _parse_conanfile(conan_file_path):
             if module:
                 try:
                     try:
+                        # Most modules will have __file__ != None
                         folder = os.path.dirname(module.__file__)
-                    except (AttributeError, TypeError):  # Namespace packages py3 module.__file__
+                    except (AttributeError, TypeError):
+                        # But __file__ might not exist or equal None
+                        # Like some builtins and Namespace packages py3
                         folder = module.__path__._path[0]
-                except AttributeError:  # some module doesn't have __file__
+                except AttributeError:  # In case the module.__path__ doesn't exist
                     pass
                 else:
                     if folder.startswith(current_dir):

--- a/conans/client/loader.py
+++ b/conans/client/loader.py
@@ -263,7 +263,7 @@ def _parse_conanfile(conan_file_path):
                 try:
                     try:
                         folder = os.path.dirname(module.__file__)
-                    except TypeError:  # Namespace packages py3 module.__file__ is None
+                    except (AttributeError, TypeError):  # Namespace packages py3 module.__file__
                         folder = module.__path__._path[0]
                 except AttributeError:  # some module doesn't have __file__
                     pass

--- a/conans/client/loader.py
+++ b/conans/client/loader.py
@@ -261,7 +261,10 @@ def _parse_conanfile(conan_file_path):
             module = sys.modules[added]
             if module:
                 try:
-                    folder = os.path.dirname(module.__file__)
+                    try:
+                        folder = os.path.dirname(module.__file__)
+                    except TypeError:  # Namespace packages py3 module.__file__ is None
+                        folder = module.__path__._path[0]
                 except AttributeError:  # some module doesn't have __file__
                     pass
                 else:

--- a/conans/test/unittests/client/conanfile_loader_test.py
+++ b/conans/test/unittests/client/conanfile_loader_test.py
@@ -1,21 +1,27 @@
 import os
+import textwrap
 import unittest
 from collections import OrderedDict
 
+import six
 from mock import Mock
 from mock.mock import call
+from parameterized import parameterized
 
 from conans.client.graph.python_requires import ConanPythonRequire
-from conans.client.loader import ConanFileLoader, ConanFileTextLoader
+from conans.client.loader import ConanFileLoader, ConanFileTextLoader,\
+    _parse_conanfile
+from conans.client.tools.files import chdir
 from conans.errors import ConanException
 from conans.model.options import OptionsValues
 from conans.model.profile import Profile
 from conans.model.requires import Requirements
 from conans.model.settings import Settings
 from conans.test.utils.test_files import temp_folder
-from conans.util.files import save
 from conans.test.utils.tools import test_processed_profile,\
     TestBufferConanOutput
+from conans.util.files import save, load
+import sys
 
 
 class ConanLoaderTest(unittest.TestCase):
@@ -225,3 +231,110 @@ class MyTest(ConanFile):
         recipe = loader.load_consumer(conanfile_path,
                                       test_processed_profile(profile))
         self.assertIsNone(recipe.settings.os.value)
+
+
+class ImportModuleLoaderTest(unittest.TestCase):
+
+    @staticmethod
+    def _create_and_load(myfunc, value, subdir_name, add_subdir_init):
+        subdir_content = textwrap.dedent("""
+            def get_value():
+                return {value}
+            def {myfunc}():
+                return "{myfunc}"
+        """)
+
+        side_content = textwrap.dedent("""
+            def get_side_value():
+                return {value}
+            def side_{myfunc}():
+                return "{myfunc}"
+        """)
+
+        conanfile = textwrap.dedent("""
+            import pickle
+            from {subdir}.api import get_value, {myfunc}
+            from file import get_side_value, side_{myfunc}
+            from fractions import Fraction
+            def conanfile_func():
+                return get_value(), {myfunc}(), get_side_value(), side_{myfunc}(), str(Fraction(1,1))
+        """)
+        expected_return = (value, myfunc, value, myfunc, "1")
+
+        tmp = temp_folder()
+        with chdir(tmp):
+            save("conanfile.py", conanfile.format(value=value, myfunc=myfunc, subdir=subdir_name))
+            save("file.py", side_content.format(value=value, myfunc=myfunc))
+            save("{}/api.py".format(subdir_name), subdir_content.format(value=value, myfunc=myfunc))
+            if add_subdir_init:
+                save("{}/__init__.py".format(subdir_name), "")
+
+        loaded, module_id = _parse_conanfile(os.path.join(tmp, "conanfile.py"))
+        return loaded, module_id, expected_return
+
+    @unittest.skipIf(six.PY2, "Python 2 requires __init__.py file in modules")
+    def test_py3_recipe_colliding_filenames(self):
+        myfunc1, value1 = "recipe1", 42
+        myfunc2, value2 = "recipe2", 23
+        loaded1, module_id1, exp_ret1 = self._create_and_load(myfunc1, value1, "subdir", False)
+        loaded2, module_id2, exp_ret2 = self._create_and_load(myfunc2, value2, "subdir", False)
+
+        self.assertNotEqual(module_id1, module_id2)
+        self.assertEqual(loaded1.conanfile_func(), exp_ret1)
+        self.assertEqual(loaded2.conanfile_func(), exp_ret2)
+
+    def test_recipe_colliding_filenames(self):
+        myfunc1, value1 = "recipe1", 42
+        myfunc2, value2 = "recipe2", 23
+        loaded1, module_id1, exp_ret1 = self._create_and_load(myfunc1, value1, "subdir", True)
+        loaded2, module_id2, exp_ret2 = self._create_and_load(myfunc2, value2, "subdir", True)
+
+        self.assertNotEqual(module_id1, module_id2)
+        self.assertEqual(loaded1.conanfile_func(), exp_ret1)
+        self.assertEqual(loaded2.conanfile_func(), exp_ret2)
+
+    @parameterized.expand([(True, ), (False, )])
+    def test_wrong_imports(self, add_subdir_init):
+        myfunc1, value1 = "recipe1", 42
+
+        # Item imported does not exist, but file exists
+        with self.assertRaisesRegexp(ConanException, "Unable to load conanfile in"):
+            self._create_and_load(myfunc1, value1, "requests", add_subdir_init)
+
+        # File does not exists in already existing module
+        with self.assertRaisesRegexp(ConanException, "Unable to load conanfile in"):
+            self._create_and_load(myfunc1, value1, "conans", add_subdir_init)
+
+    def test_helpers_python_library(self):
+        mylogger = """import os
+f = open(os.path.join("%s", "mylogfile.txt"), "w")
+def save(data):
+    f.write(data)
+"""
+        temp = temp_folder()
+        save(os.path.join(temp, "mylogger.py"), mylogger % temp.replace("\\", "/"))
+        save(os.path.join(temp, "__init__.py"), "")
+
+        conanfile = '''
+import mylogger
+def log():
+    mylogger.save("mylogger %s!!!")
+'''
+        temp1 = temp_folder()
+        save(os.path.join(temp1, "conanfile.py"), conanfile % "first")
+        temp2 = temp_folder()
+        save(os.path.join(temp2, "conanfile.py"), conanfile % "second")
+
+        try:
+            sys.path.append(temp)
+            loaded1, _ = _parse_conanfile(os.path.join(temp1, "conanfile.py"))
+            loaded2, _ = _parse_conanfile(os.path.join(temp2, "conanfile.py"))
+            loaded1.log()
+            loaded2.log()
+            logfile = os.path.join(temp, "mylogfile.txt")
+            loaded1.mylogger.f.close()
+            logged = load(logfile)
+            self.assertIn("mylogger first!!!", logged)
+            self.assertIn("mylogger second!!!", logged)
+        finally:
+            sys.path.remove(temp)

--- a/conans/test/unittests/client/conanfile_loader_test.py
+++ b/conans/test/unittests/client/conanfile_loader_test.py
@@ -1,4 +1,5 @@
 import os
+import sys
 import textwrap
 import unittest
 from collections import OrderedDict
@@ -20,8 +21,7 @@ from conans.model.settings import Settings
 from conans.test.utils.test_files import temp_folder
 from conans.test.utils.tools import test_processed_profile,\
     TestBufferConanOutput
-from conans.util.files import save, load
-import sys
+from conans.util.files import save
 
 
 class ConanLoaderTest(unittest.TestCase):
@@ -234,7 +234,6 @@ class MyTest(ConanFile):
 
 
 class ImportModuleLoaderTest(unittest.TestCase):
-
     @staticmethod
     def _create_and_load(myfunc, value, subdir_name, add_subdir_init):
         subdir_content = textwrap.dedent("""
@@ -267,17 +266,19 @@ class ImportModuleLoaderTest(unittest.TestCase):
             save("file.py", side_content.format(value=value, myfunc=myfunc))
             save("{}/api.py".format(subdir_name), subdir_content.format(value=value, myfunc=myfunc))
             if add_subdir_init:
+                save("__init__.py", "")
                 save("{}/__init__.py".format(subdir_name), "")
 
         loaded, module_id = _parse_conanfile(os.path.join(tmp, "conanfile.py"))
         return loaded, module_id, expected_return
 
+    @parameterized.expand([(True, False), (False, True), (False, False)])
     @unittest.skipIf(six.PY2, "Python 2 requires __init__.py file in modules")
-    def test_py3_recipe_colliding_filenames(self):
+    def test_py3_recipe_colliding_init_filenames(self, sub1, sub2):
         myfunc1, value1 = "recipe1", 42
         myfunc2, value2 = "recipe2", 23
-        loaded1, module_id1, exp_ret1 = self._create_and_load(myfunc1, value1, "subdir", False)
-        loaded2, module_id2, exp_ret2 = self._create_and_load(myfunc2, value2, "subdir", False)
+        loaded1, module_id1, exp_ret1 = self._create_and_load(myfunc1, value1, "subdir", sub1)
+        loaded2, module_id2, exp_ret2 = self._create_and_load(myfunc2, value2, "subdir", sub2)
 
         self.assertNotEqual(module_id1, module_id2)
         self.assertEqual(loaded1.conanfile_func(), exp_ret1)
@@ -306,35 +307,26 @@ class ImportModuleLoaderTest(unittest.TestCase):
             self._create_and_load(myfunc1, value1, "conans", add_subdir_init)
 
     def test_helpers_python_library(self):
-        mylogger = """import os
-f = open(os.path.join("%s", "mylogfile.txt"), "w")
-def save(data):
-    f.write(data)
+        mylogger = """
+value = ""
+def append(data):
+    global value
+    value += data
 """
         temp = temp_folder()
-        save(os.path.join(temp, "mylogger.py"), mylogger % temp.replace("\\", "/"))
-        save(os.path.join(temp, "__init__.py"), "")
+        save(os.path.join(temp, "myconanlogger.py"), mylogger)
 
-        conanfile = '''
-import mylogger
-def log():
-    mylogger.save("mylogger %s!!!")
-'''
+        conanfile = "import myconanlogger"
         temp1 = temp_folder()
-        save(os.path.join(temp1, "conanfile.py"), conanfile % "first")
+        save(os.path.join(temp1, "conanfile.py"), conanfile)
         temp2 = temp_folder()
-        save(os.path.join(temp2, "conanfile.py"), conanfile % "second")
+        save(os.path.join(temp2, "conanfile.py"), conanfile)
 
         try:
             sys.path.append(temp)
             loaded1, _ = _parse_conanfile(os.path.join(temp1, "conanfile.py"))
             loaded2, _ = _parse_conanfile(os.path.join(temp2, "conanfile.py"))
-            loaded1.log()
-            loaded2.log()
-            logfile = os.path.join(temp, "mylogfile.txt")
-            loaded1.mylogger.f.close()
-            logged = load(logfile)
-            self.assertIn("mylogger first!!!", logged)
-            self.assertIn("mylogger second!!!", logged)
+            self.assertIs(loaded1.myconanlogger, loaded2.myconanlogger)
+            self.assertIs(loaded1.myconanlogger.value, loaded2.myconanlogger.value)
         finally:
             sys.path.remove(temp)


### PR DESCRIPTION
Changelog: Bugfix: Solve problem with loading recipe python files in Python 3.7 because of ``module.__file__ = None``
Docs: omit

closes #4636
close #4641

@PYVERS: Macos@py27, Windows@py36, Linux@py27, py34
