### PR TITLE
 Added with_login parameter to tools.run_in_windows_bash()

### DIFF
--- a/conans/client/tools/win.py
+++ b/conans/client/tools/win.py
@@ -575,7 +575,8 @@ def unix_path(path, path_flavor=None):
     return None
 
 
-def run_in_windows_bash(conanfile, bashcmd, cwd=None, subsystem=None, msys_mingw=True, env=None):
+def run_in_windows_bash(conanfile, bashcmd, cwd=None, subsystem=None, msys_mingw=True, env=None,
+                        with_login=True):
     """ Will run a unix command inside a bash terminal
         It requires to have MSYS2, CYGWIN, or WSL
     """
@@ -637,7 +638,8 @@ def run_in_windows_bash(conanfile, bashcmd, cwd=None, subsystem=None, msys_mingw
         to_run = 'cd "%s"%s && %s ' % (curdir, hack_env, bashcmd)
         bash_path = OSInfo.bash_path()
         bash_path = '"%s"' % bash_path if " " in bash_path else bash_path
-        wincmd = '%s --login -c %s' % (bash_path, escape_windows_cmd(to_run))
+        login = "--login" if with_login else ""
+        wincmd = '%s %s -c %s' % (bash_path, login, escape_windows_cmd(to_run))
         conanfile.output.info('run_in_windows_bash: %s' % wincmd)
 
         # If is there any other env var that we know it contains paths, convert it to unix_path

--- a/conans/model/conan_file.py
+++ b/conans/model/conan_file.py
@@ -247,13 +247,13 @@ class ConanFile(object):
         """
 
     def run(self, command, output=True, cwd=None, win_bash=False, subsystem=None, msys_mingw=True,
-            ignore_errors=False, run_environment=False):
+            ignore_errors=False, run_environment=False, with_login=True):
         def _run():
             if not win_bash:
                 return self._conan_runner(command, output, os.path.abspath(RUN_LOG_NAME), cwd)
             # FIXME: run in windows bash is not using output
             return tools.run_in_windows_bash(self, bashcmd=command, cwd=cwd, subsystem=subsystem,
-                                             msys_mingw=msys_mingw)
+                                             msys_mingw=msys_mingw, with_login=with_login)
         if run_environment:
             with tools.run_environment(self):
                 if OSInfo().is_macos:

--- a/conans/test/unittests/util/tools_test.py
+++ b/conans/test/unittests/util/tools_test.py
@@ -1017,8 +1017,9 @@ ProgramFiles(x86)=C:\Program Files (x86)
             self.assertIn('path\\to\\mybash.exe --login -c', conanfile._conan_runner.command)
 
         with tools.environment_append({"CONAN_BASH_PATH": "path with spaces\\to\\mybash.exe"}):
-            tools.run_in_windows_bash(conanfile, "a_command.bat", subsystem="cygwin")
-            self.assertIn('"path with spaces\\to\\mybash.exe" --login -c', conanfile._conan_runner.command)
+            tools.run_in_windows_bash(conanfile, "a_command.bat", subsystem="cygwin",
+                                      with_login=False)
+            self.assertIn('"path with spaces\\to\\mybash.exe"  -c', conanfile._conan_runner.command)
 
         # try to append more env vars
         conanfile = MockConanfile()


### PR DESCRIPTION
Changelog: Feature: Added with_login parameter to tools.run_in_windows_bash()
Docs: https://github.com/conan-io/docs/pull/1103

- [x] Refer to the issue that supports this Pull Request: closes #4304
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [x] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 

<sup>**Note:** By default this PR will skip the slower tests and will use a limited set of python versions. Check [here](https://github.com/conan-io/conan/blob/develop/.github/PR_INCREASE_TESTING.md) how to increase the testing level by writing some tags in the current PR body text.</sup>
