### PR TITLE
Exclude known pattern files from the upload

### DIFF
--- a/conans/model/manifest.py
+++ b/conans/model/manifest.py
@@ -9,8 +9,13 @@ from conans.util.files import load, md5, md5sum, save, walk
 
 
 def discarded_file(filename):
+    """
+    # The __conan pattern is to be prepared for the future, in case we want to manage our
+    own files that shouldn't be uploaded
+    """
     return filename == ".DS_Store" or filename.endswith(".pyc") or \
-           filename.endswith(".pyo") or filename == "__pycache__"
+           filename.endswith(".pyo") or filename == "__pycache__" or \
+           filename.startswith("__conan")
 
 
 def gather_files(folder):


### PR DESCRIPTION
Changelog: omit
Docs: omit

To be prepared for the future, in case we want to skip the upload of known files and/or the computation in the manifest.