### PR TITLE
Exclude tests from distribution

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -88,7 +88,7 @@ setup(
 
     # You can just specify the packages manually here if your project is
     # simple. Or you can use find_packages().
-    packages=find_packages(),
+    packages=find_packages(exclude=("conans.test*",)),
 
     # Alternatively, if you want to distribute just a my_module.py, uncomment
     # this:


### PR DESCRIPTION
Changelog: Fix: Do not distribute the tests in the python package nor in the installers.
Docs: omit.

Closes https://github.com/conan-io/conan/issues/4563
