### PR TITLE
Replace py2/3 deprecated test functions: 'assertRaisesRegexp' and 'assertRegexpMatches' by 'six' implementation

### DIFF
--- a/conans/test/functional/command/remove_test.py
+++ b/conans/test/functional/command/remove_test.py
@@ -395,11 +395,11 @@ class RemoveTest(unittest.TestCase):
                             src_folders={"H1": True, "H2": True, "B": True, "O": True})
 
     def try_remove_using_query_and_packages_or_builds_test(self):
-        with self.assertRaisesRegexp(Exception, "Command failed"):
+        with six.assertRaisesRegex(self, Exception, "Command failed"):
             self.client.run("remove hello/1.4.10@lasote/stable -p=1_H1 -q 'compiler.version=4.8' ")
             self.assertIn("'-q' and '-p' parameters can't be used at the same time", self.client.out)
 
-        with self.assertRaisesRegexp(Exception, "Command failed"):
+        with six.assertRaisesRegex(self, Exception, "Command failed"):
             self.client.run("remove hello/1.4.10@lasote/stable -b=1_H1 -q 'compiler.version=4.8' ")
             self.assertIn("'-q' and '-b' parameters can't be used at the same time", self.client.out)
 

--- a/conans/test/functional/command/source_test.py
+++ b/conans/test/functional/command/source_test.py
@@ -1,6 +1,8 @@
 import os
 import unittest
 
+import six
+
 from conans.paths import BUILD_INFO, CONANFILE
 from conans.test.utils.tools import TestClient
 from conans.util.files import load, mkdir
@@ -244,9 +246,9 @@ class ConanLib(ConanFile):
         client = TestClient()
         client.save({CONANFILE: conanfile})
         client.run("source ./conanfile.py --source-folder sf")
-        with self.assertRaisesRegexp(Exception, "Command failed"):
+        with six.assertRaisesRegex(self, Exception, "Command failed"):
             client.run("source . --source-folder sf --source-folder sf")
-        with self.assertRaisesRegexp(Exception, "Command failed"):
+        with six.assertRaisesRegex(self, Exception, "Command failed"):
             client.run("source conanfile.py --source-folder sf --install-folder if "
                        "--install-folder rr")
 

--- a/conans/test/functional/command/upload_complete_test.py
+++ b/conans/test/functional/command/upload_complete_test.py
@@ -4,6 +4,7 @@ import platform
 import stat
 import unittest
 
+import six
 from requests.packages.urllib3.exceptions import ConnectionError
 
 from conans import DEFAULT_REVISION_V1
@@ -131,7 +132,7 @@ class UploadTest(unittest.TestCase):
         self.client.run("export . frodo/stable")
         ref = ConanFileReference.loads("Hello0/1.2.1@frodo/stable")
         os.unlink(os.path.join(self.client.cache.export(ref), CONAN_MANIFEST))
-        with self.assertRaisesRegexp(Exception, "Command failed"):
+        with six.assertRaisesRegex(self, Exception, "Command failed"):
             self.client.run("upload %s" % str(ref))
 
         self.assertIn("Cannot upload corrupted recipe", self.client.user_io.out)

--- a/conans/test/functional/configuration/registry_test.py
+++ b/conans/test/functional/configuration/registry_test.py
@@ -1,6 +1,8 @@
 import os
 import unittest
 
+import six
+
 from conans.client.cache.remote_registry import RemoteRegistry, default_remotes, dump_registry, \
     load_registry_txt, migrate_registry_file
 from conans.errors import ConanException
@@ -136,5 +138,5 @@ other/1.0@lasote/testing conan.io
         ref = ConanFileReference.loads("lib/1.0@user/channel")
         # Test already exists
         registry.refs.set(ref, "conan.io", check_exists=True)
-        with self.assertRaisesRegexp(ConanException, "already exists"):
+        with six.assertRaisesRegex(self, ConanException, "already exists"):
             registry.refs.set(ref.copy_with_rev("revision"), "conan.io", check_exists=True)

--- a/conans/test/functional/graph/graph_manager_test.py
+++ b/conans/test/functional/graph/graph_manager_test.py
@@ -1,7 +1,9 @@
 import os
 import unittest
 
+import six
 from mock import Mock
+from parameterized import parameterized
 
 from conans.client.cache.cache import ClientCache
 from conans.client.graph.graph import RECIPE_CONSUMER, RECIPE_INCACHE
@@ -12,6 +14,7 @@ from conans.client.graph.range_resolver import RangeResolver
 from conans.client.installer import BinaryInstaller
 from conans.client.loader import ConanFileLoader
 from conans.client.recorder.action_recorder import ActionRecorder
+from conans.errors import ConanException
 from conans.model.graph_info import GraphInfo
 from conans.model.manifest import FileTreeManifest
 from conans.model.options import OptionsValues
@@ -22,8 +25,6 @@ from conans.test.utils.conanfile import TestConanFile
 from conans.test.utils.test_files import temp_folder
 from conans.test.utils.tools import TestBufferConanOutput
 from conans.util.files import save
-from conans.errors import ConanException
-from parameterized import parameterized
 
 
 class GraphManagerTest(unittest.TestCase):
@@ -201,7 +202,7 @@ class TransitiveGraphTest(GraphManagerTest):
         self._cache_recipe(liba_ref2, TestConanFile("liba", "0.2"))
         self._cache_recipe(libb_ref, TestConanFile("libb", "0.1", requires=[liba_ref]))
         self._cache_recipe(libc_ref, TestConanFile("libc", "0.1", requires=[liba_ref2]))
-        with self.assertRaisesRegexp(ConanException, "Requirement liba/0.2@user/testing conflicts"):
+        with six.assertRaisesRegex(self, ConanException, "Requirement liba/0.2@user/testing conflicts"):
             self.build_graph(TestConanFile("app", "0.1", requires=[libb_ref, libc_ref]))
 
     def test_loop(self):
@@ -213,7 +214,7 @@ class TransitiveGraphTest(GraphManagerTest):
         self._cache_recipe(liba_ref, TestConanFile("liba", "0.1", requires=[libc_ref]))
         self._cache_recipe(libb_ref, TestConanFile("libb", "0.1", requires=[liba_ref]))
         self._cache_recipe(libc_ref, TestConanFile("libc", "0.1", requires=[libb_ref]))
-        with self.assertRaisesRegexp(ConanException, "Loop detected: 'liba/0.1@user/testing' "
+        with six.assertRaisesRegex(self, ConanException, "Loop detected: 'liba/0.1@user/testing' "
                                      "requires 'libc/0.1@user/testing'"):
             self.build_graph(TestConanFile("app", "0.1", requires=[libc_ref]))
 
@@ -270,7 +271,7 @@ class TransitiveGraphTest(GraphManagerTest):
         self._cache_recipe(lib_ref,
                            TestConanFile("lib", "0.1",
                                          build_requires=["tool/0.1@user/testing"]))
-        with self.assertRaisesRegexp(ConanException, "Loop detected: 'tool/0.1@user/testing' "
+        with six.assertRaisesRegex(self, ConanException, "Loop detected: 'tool/0.1@user/testing' "
                                      "requires 'lib/0.1@user/testing'"):
             self.build_graph(TestConanFile("app", "0.1", requires=["lib/0.1@user/testing"]))
 
@@ -323,7 +324,7 @@ class TransitiveGraphTest(GraphManagerTest):
                            TestConanFile("lib", "0.1", requires=[zlib_ref],
                                          build_requires=["gtest/0.1@user/testing"]))
 
-        with self.assertRaisesRegexp(ConanException, "Requirement zlib/0.2@user/testing conflicts"):
+        with six.assertRaisesRegex(self, ConanException, "Requirement zlib/0.2@user/testing conflicts"):
             self.build_graph(TestConanFile("app", "0.1", requires=["lib/0.1@user/testing"]))
 
     def test_not_conflict_transitive_build_requires(self):
@@ -405,7 +406,7 @@ class TransitiveGraphTest(GraphManagerTest):
                            TestConanFile("lib", "0.1", requires=[zlib_ref],
                                          build_requires=["gtest/0.1@user/testing"]))
 
-        with self.assertRaisesRegexp(ConanException,
+        with six.assertRaisesRegex(self, ConanException,
                                      "tried to change zlib/0.1@user/testing option shared to True"):
             self.build_graph(TestConanFile("app", "0.1", requires=["lib/0.1@user/testing"]))
 
@@ -418,7 +419,7 @@ class TransitiveGraphTest(GraphManagerTest):
         self._cache_recipe(liba_ref2, TestConanFile("liba", "0.2"))
         self._cache_recipe(libb_ref, TestConanFile("libb", "0.1", requires=[liba_ref]))
         self._cache_recipe(libc_ref, TestConanFile("libc", "0.1", requires=[liba_ref2]))
-        with self.assertRaisesRegexp(ConanException, "Requirement liba/0.2@user/testing conflicts"):
+        with six.assertRaisesRegex(self, ConanException, "Requirement liba/0.2@user/testing conflicts"):
             self.build_graph(TestConanFile("app", "0.1", private_requires=[libb_ref, libc_ref]))
 
     def test_loop_private(self):
@@ -430,7 +431,7 @@ class TransitiveGraphTest(GraphManagerTest):
         self._cache_recipe(lib_ref,
                            TestConanFile("lib", "0.1",
                                          private_requires=["tool/0.1@user/testing"]))
-        with self.assertRaisesRegexp(ConanException, "Loop detected: 'tool/0.1@user/testing' "
+        with six.assertRaisesRegex(self, ConanException, "Loop detected: 'tool/0.1@user/testing' "
                                      "requires 'lib/0.1@user/testing'"):
             self.build_graph(TestConanFile("app", "0.1", requires=[lib_ref]))
 

--- a/conans/test/functional/hooks/test_post_export.py
+++ b/conans/test/functional/hooks/test_post_export.py
@@ -4,6 +4,7 @@ import os
 import textwrap
 import unittest
 
+import six
 from mock import patch
 
 from conans.client.hook_manager import HookManager
@@ -34,7 +35,7 @@ class PostExportTestCase(unittest.TestCase):
 
         def mocked_post_export(*args, **kwargs):
             # There shouldn't be a digest yet
-            with self.assertRaisesRegexp(IOError, "No such file or directory"):
+            with six.assertRaisesRegex(self, IOError, "No such file or directory"):
                 FileTreeManifest.load(package_layout.export())
             self.assertFalse(os.path.exists(os.path.join(package_layout.export(), CONAN_MANIFEST)))
 

--- a/conans/test/functional/old/compile_helpers_test.py
+++ b/conans/test/functional/old/compile_helpers_test.py
@@ -1,6 +1,8 @@
 import os
 import unittest
 
+import six
+
 from conans.model.env_info import DepsEnvInfo
 from conans.model.profile import Profile
 from conans.model.settings import Settings
@@ -156,7 +158,7 @@ class ProfilesEnvironmentTest(unittest.TestCase):
         self.client.save({CONANFILE: conanfile_scope_env}, clean_first=True)
         self.client.run("install . --build=missing --pr scopes_env")
         self.client.run("build .")
-        self.assertRegexpMatches(str(self.client.user_io.out), "PATH=['\"]*/path/to/my/folder")
+        six.assertRegex(self, str(self.client.user_io.out), "PATH=['\"]*/path/to/my/folder")
         self._assert_env_variable_printed("CC", "/path/tomy/gcc_build")
         self._assert_env_variable_printed("CXX", "/path/tomy/g++_build")
 

--- a/conans/test/functional/old/requester_test.py
+++ b/conans/test/functional/old/requester_test.py
@@ -1,5 +1,7 @@
 import unittest
 
+import six
+
 from conans.client import tools
 from conans.test.utils.tools import TestClient
 from conans.util.files import save
@@ -40,7 +42,7 @@ request_timeout=2
 request_timeout=any_string
 """
         save(client.cache.conan_conf_path, conf)
-        with self.assertRaisesRegexp(Exception, "Specify a numeric parameter for 'request_timeout'"):
+        with six.assertRaisesRegex(self, Exception, "Specify a numeric parameter for 'request_timeout'"):
             client.run("install Lib/1.0@conan/stable")
 
     def no_request_timeout_test(self):

--- a/conans/test/functional/workspace/workspace_test.py
+++ b/conans/test/functional/workspace/workspace_test.py
@@ -1,18 +1,17 @@
 import os
 import platform
-import time
 import unittest
-
 from textwrap import dedent
 
+import six
+import time
 
 from conans.client import tools
+from conans.errors import ConanException
+from conans.model.workspace import Workspace
+from conans.test.utils.test_files import temp_folder
 from conans.test.utils.tools import TestClient
 from conans.util.files import load, save
-from conans.test.utils.test_files import temp_folder
-from conans.model.workspace import Workspace
-from conans.errors import ConanException
-
 
 conanfile_build = """from conans import ConanFile, CMake
 class Pkg(ConanFile):
@@ -98,7 +97,7 @@ class WorkspaceTest(unittest.TestCase):
         path = os.path.join(folder, "conanws.yml")
         project = "root: Hellob/0.1@lasote/stable"
         save(path, project)
-        with self.assertRaisesRegexp(ConanException,
+        with six.assertRaisesRegex(self, ConanException,
                                      "Root Hellob/0.1@lasote/stable is not defined as editable"):
             Workspace(path, None)
 
@@ -111,7 +110,7 @@ class WorkspaceTest(unittest.TestCase):
             """)
         save(path, project)
 
-        with self.assertRaisesRegexp(ConanException,
+        with six.assertRaisesRegex(self, ConanException,
                                      "Workspace unrecognized fields: {'random': 'something'}"):
             Workspace(path, None)
 
@@ -124,7 +123,7 @@ class WorkspaceTest(unittest.TestCase):
             """)
         save(path, project)
 
-        with self.assertRaisesRegexp(ConanException,
+        with six.assertRaisesRegex(self, ConanException,
                                      "Workspace unrecognized fields: {'random': 'something'}"):
             Workspace(path, None)
 
@@ -135,7 +134,7 @@ class WorkspaceTest(unittest.TestCase):
             """)
         save(path, project)
 
-        with self.assertRaisesRegexp(ConanException,
+        with six.assertRaisesRegex(self, ConanException,
                                      "Workspace editable HelloB/0.1@lasote/stable "
                                      "does not define path"):
             Workspace(path, None)
@@ -148,7 +147,7 @@ class WorkspaceTest(unittest.TestCase):
             """)
         save(path, project)
 
-        with self.assertRaisesRegexp(ConanException,
+        with six.assertRaisesRegex(self, ConanException,
                                      "Workspace editable HelloB/0.1@lasote/stable "
                                      "does not define path"):
             Workspace(path, None)

--- a/conans/test/integration/system_reqs_test.py
+++ b/conans/test/integration/system_reqs_test.py
@@ -2,9 +2,10 @@ import os
 import stat
 import unittest
 
-from conans.paths import SYSTEM_REQS_FOLDER
+import six
 
 from conans.model.ref import ConanFileReference, PackageReference
+from conans.paths import SYSTEM_REQS_FOLDER
 from conans.test.utils.tools import NO_SETTINGS_PACKAGE_ID, TestClient
 from conans.util.files import load
 
@@ -51,7 +52,7 @@ class SystemReqsTest(unittest.TestCase):
 
         files = {'conanfile.py': base_conanfile.replace("%GLOBAL%", "self.run('fake command!')")}
         client.save(files)
-        with self.assertRaisesRegexp(Exception, "Command failed"):
+        with six.assertRaisesRegex(self, Exception, "Command failed"):
             client.run("install .")
 
     def per_package_test(self):
@@ -179,17 +180,17 @@ class SystemReqsTest(unittest.TestCase):
     def invalid_remove_reqs_test(self):
         client = TestClient()
 
-        with self.assertRaisesRegexp(
+        with six.assertRaisesRegex(self,
                 Exception, "ERROR: Please specify a valid package reference to be cleaned"):
             client.run("remove --system-reqs")
 
         # wrong file reference should be treated as error
-        with self.assertRaisesRegexp(
+        with six.assertRaisesRegex(self,
                 Exception, "ERROR: Unable to remove system_reqs: foo/version@bar/testing does not exist"):
             client.run("remove --system-reqs foo/version@bar/testing")
 
         # package is not supported with system_reqs
-        with self.assertRaisesRegexp(
+        with six.assertRaisesRegex(self,
                 Exception, "ERROR: '-t' and '-p' parameters can't be used at the same time"):
             client.run("remove --system-reqs foo/bar@foo/bar -p f0ba3ca2c218df4a877080ba99b65834b9413798")
 
@@ -212,7 +213,7 @@ class SystemReqsTest(unittest.TestCase):
         os.chmod(system_reqs_path, current & ~stat.S_IWRITE)
 
         # friendly message for permission error
-        with self.assertRaisesRegexp(
+        with six.assertRaisesRegex(self,
                 Exception, "ERROR: Unable to remove system_reqs:"):
             client.run("remove --system-reqs Test/0.1@user/channel")
         self.assertTrue(os.path.exists(system_reqs_path))

--- a/conans/test/integration/test_build_info_extraction.py
+++ b/conans/test/integration/test_build_info_extraction.py
@@ -4,6 +4,7 @@ import sys
 import unittest
 from collections import OrderedDict
 
+import six
 from nose.plugins.attrib import attr
 
 from conans.build_info.conan_build_info import get_build_info
@@ -91,7 +92,7 @@ class MyBuildInfo(unittest.TestCase):
     def test_invalid_tracer(self):
         trace_file = os.path.join(temp_folder(), "conan_trace.log")
         save(trace_file, "invalid contents")
-        with self.assertRaisesRegexp(Exception, "INVALID TRACE FILE!"):
+        with six.assertRaisesRegex(self, Exception, "INVALID TRACE FILE!"):
             get_build_info(trace_file).serialize()
 
     def test_cross_remotes(self):

--- a/conans/test/unittests/client/build/cmake_test.py
+++ b/conans/test/unittests/client/build/cmake_test.py
@@ -6,6 +6,7 @@ import sys
 import unittest
 
 import mock
+import six
 from parameterized.parameterized import parameterized
 
 from conans.client import tools
@@ -381,7 +382,7 @@ class CMakeTest(unittest.TestCase):
                                               base_cmd=base_cmd.format(flags=flags_in_local_cache)))
 
             # Raise mixing
-            with self.assertRaisesRegexp(ConanException, "Use 'build_folder'/'source_folder'"):
+            with six.assertRaisesRegex(self, ConanException, "Use 'build_folder'/'source_folder'"):
                 cmake = CMake(conan_file)
                 cmake.configure(source_folder="source", build_dir="build")
 

--- a/conans/test/unittests/client/build/meson_test.py
+++ b/conans/test/unittests/client/build/meson_test.py
@@ -2,6 +2,8 @@ import os
 import shutil
 import unittest
 
+import six
+
 from conans.client import defs_to_string
 from conans.client.build.meson import Meson
 from conans.client.conf import default_settings_yml
@@ -134,7 +136,7 @@ class MesonTest(unittest.TestCase):
         self._check_commands(cmd_expected, conan_file.command)
 
         # Raise mixing
-        with self.assertRaisesRegexp(ConanException, "Use 'build_folder'/'source_folder'"):
+        with six.assertRaisesRegex(self, ConanException, "Use 'build_folder'/'source_folder'"):
             meson.configure(source_folder="source", build_dir="build")
 
         meson.test()

--- a/conans/test/unittests/client/build/msbuild_test.py
+++ b/conans/test/unittests/client/build/msbuild_test.py
@@ -1,12 +1,14 @@
-import mock
 import os
 import platform
 import re
 import unittest
+
+import mock
+import six
 from parameterized import parameterized
 
-from conans.client.build.msbuild import MSBuild
 from conans.client import tools
+from conans.client.build.msbuild import MSBuild
 from conans.errors import ConanException
 from conans.model.version import Version
 from conans.test.utils.conanfile import MockConanfile, MockSettings
@@ -129,7 +131,7 @@ class MSBuildTest(unittest.TestCase):
                                  "arch": "x86_64",
                                  "compiler.runtime": "MDd"})
         version = MSBuild.get_version(settings)
-        self.assertRegexpMatches(version, "(\d+\.){2,3}\d+")
+        six.assertRegex(self, version, "(\d+\.){2,3}\d+")
         self.assertGreater(version, "15.1")
 
     @parameterized.expand([("16", "v142"),

--- a/conans/test/unittests/client/conanfile_loader_test.py
+++ b/conans/test/unittests/client/conanfile_loader_test.py
@@ -69,19 +69,19 @@ class MyTest(ConanFile):
         file_content = '''[requires}
 OpenCV/2.4.10@phil/stable # My requirement for CV
 '''
-        with self.assertRaisesRegexp(ConanException, "Bad syntax"):
+        with six.assertRaisesRegex(self, ConanException, "Bad syntax"):
             ConanFileTextLoader(file_content)
 
         file_content = '{hello}'
-        with self.assertRaisesRegexp(ConanException, "Unexpected line"):
+        with six.assertRaisesRegex(self, ConanException, "Unexpected line"):
             ConanFileTextLoader(file_content)
 
         file_content = '[imports]\nhello'
-        with self.assertRaisesRegexp(ConanException, "Invalid imports line: hello"):
+        with six.assertRaisesRegex(self, ConanException, "Invalid imports line: hello"):
             ConanFileTextLoader(file_content).imports_method(None)
 
         file_content = '[imports]\nbin, * -> bin @ kk=3 '
-        with self.assertRaisesRegexp(ConanException, "Unknown argument kk"):
+        with six.assertRaisesRegex(self, ConanException, "Unknown argument kk"):
             ConanFileTextLoader(file_content).imports_method(None)
 
     def plain_text_parser_test(self):
@@ -157,7 +157,7 @@ OpenCV/2.4.104phil/stable
         file_path = os.path.join(tmp_dir, "file.txt")
         save(file_path, file_content)
         loader = ConanFileLoader(None, TestBufferConanOutput(), None)
-        with self.assertRaisesRegexp(ConanException, "Wrong package recipe reference(.*)"):
+        with six.assertRaisesRegex(self, ConanException, "Wrong package recipe reference(.*)"):
             loader.load_conanfile_txt(file_path, test_processed_profile())
 
         file_content = '''[requires]
@@ -169,7 +169,7 @@ OpenCV/bin/* - ./bin
         file_path = os.path.join(tmp_dir, "file.txt")
         save(file_path, file_content)
         loader = ConanFileLoader(None, TestBufferConanOutput(), None)
-        with self.assertRaisesRegexp(ConanException, "is too long. Valid names must contain"):
+        with six.assertRaisesRegex(self, ConanException, "is too long. Valid names must contain"):
             loader.load_conanfile_txt(file_path, test_processed_profile())
 
     def load_imports_arguments_test(self):
@@ -299,11 +299,11 @@ class ImportModuleLoaderTest(unittest.TestCase):
         myfunc1, value1 = "recipe1", 42
 
         # Item imported does not exist, but file exists
-        with self.assertRaisesRegexp(ConanException, "Unable to load conanfile in"):
+        with six.assertRaisesRegex(self, ConanException, "Unable to load conanfile in"):
             self._create_and_load(myfunc1, value1, "requests", add_subdir_init)
 
         # File does not exists in already existing module
-        with self.assertRaisesRegexp(ConanException, "Unable to load conanfile in"):
+        with six.assertRaisesRegex(self, ConanException, "Unable to load conanfile in"):
             self._create_and_load(myfunc1, value1, "conans", add_subdir_init)
 
     def test_helpers_python_library(self):

--- a/conans/test/unittests/client/conf/config_installer_test.py
+++ b/conans/test/unittests/client/conf/config_installer_test.py
@@ -1,6 +1,7 @@
 import os
 import unittest
-import tempfile
+
+import six
 
 from conans.client.conf.config_installer import _process_config_install_item, _handle_hooks
 from conans.errors import ConanException
@@ -62,7 +63,7 @@ class ConfigInstallerTests(unittest.TestCase):
 
         # Test wrong input
         for item in ["git@github.com:conan-io/conan.git, None", "file/not/exists.zip"]:
-            with self.assertRaisesRegexp(ConanException, "Unable to process config install"):
+            with six.assertRaisesRegex(self, ConanException, "Unable to process config install"):
                 _, _, _, _ = _process_config_install_item(item)
 
     def handle_hooks_test(self):

--- a/conans/test/unittests/client/graph/build_mode_test.py
+++ b/conans/test/unittests/client/graph/build_mode_test.py
@@ -1,11 +1,12 @@
 import unittest
 
-from conans.client.graph.build_mode import BuildMode
-from conans.model.ref import ConanFileReference
-from conans.errors import ConanException
+import six
 
-from conans.test.utils.tools import TestBufferConanOutput
+from conans.client.graph.build_mode import BuildMode
+from conans.errors import ConanException
+from conans.model.ref import ConanFileReference
 from conans.test.utils.conanfile import MockConanfile
+from conans.test.utils.tools import TestBufferConanOutput
 
 
 class BuildModeTest(unittest.TestCase):
@@ -26,7 +27,7 @@ class BuildModeTest(unittest.TestCase):
         self.assertTrue(build_mode.never)
 
     def test_invalid_configuration(self):
-        with self.assertRaisesRegexp(ConanException,
+        with six.assertRaisesRegex(self, ConanException,
                                      "--build=never not compatible with other options"):
             BuildMode(["outdated", "missing", "never"], self.output)
 

--- a/conans/test/unittests/client/graph/version_ranges_graph_test.py
+++ b/conans/test/unittests/client/graph/version_ranges_graph_test.py
@@ -1,7 +1,8 @@
 
-from parameterized import parameterized
-
 from collections import namedtuple
+
+import six
+from parameterized import parameterized
 
 from conans.errors import ConanException
 from conans.model.ref import ConanFileReference
@@ -173,7 +174,7 @@ class ChatConan(ConanFile):
     requires = "Hello/1.2@myuser/testing", %s
 """
         if valid is False:
-            with self.assertRaisesRegexp(ConanException, "not valid"):
+            with six.assertRaisesRegex(self, ConanException, "not valid"):
                 self.build_graph(chat_content % version_range)
             return
 

--- a/conans/test/unittests/client/hook_manager_test.py
+++ b/conans/test/unittests/client/hook_manager_test.py
@@ -1,6 +1,8 @@
 import os
 import unittest
 
+import six
+
 from conans import load
 from conans.client.hook_manager import HookManager
 from conans.errors import ConanException
@@ -104,7 +106,7 @@ def pre_build(output, **kwargs):
     raise Exception("My custom exception")
 """
         save(hook_path, my_hook)
-        with self.assertRaisesRegexp(ConanException, "My custom exception"):
+        with six.assertRaisesRegex(self, ConanException, "My custom exception"):
             hook_manager.execute("pre_build")
         # Check traceback output
         try:

--- a/conans/test/unittests/client/profile_loader_test.py
+++ b/conans/test/unittests/client/profile_loader_test.py
@@ -1,6 +1,8 @@
 import os
 import unittest
 
+import six
+
 from conans.client.profile_loader import ProfileParser, read_profile
 from conans.errors import ConanException
 from conans.model.env_info import EnvValues
@@ -232,7 +234,7 @@ VARIABLE WITH SPACES=12
 [env]
 MYVAR=$VARIABLE WITH SPACES
                         '''
-        with self.assertRaisesRegexp(ConanException, "The names of the variables cannot contain spaces"):
+        with six.assertRaisesRegex(self, ConanException, "The names of the variables cannot contain spaces"):
             self._get_profile(tmp, txt)
 
     def test_profiles_includes(self):

--- a/conans/test/unittests/client/tools/net_test.py
+++ b/conans/test/unittests/client/tools/net_test.py
@@ -5,6 +5,8 @@ import shutil
 import tempfile
 import unittest
 
+import six
+
 from conans.client.tools import chdir
 from conans.client.tools import net
 from conans.errors import ConanException
@@ -31,12 +33,12 @@ class ToolsNetTest(unittest.TestCase):
         self.assertTrue(os.path.exists(os.path.basename(filename)))
 
     def test_ftp_invalid_path(self):
-        with self.assertRaisesRegexp(ConanException,
+        with six.assertRaisesRegex(self, ConanException,
                                      "550 The system cannot find the file specified."):
             net.ftp_download("test.rebex.net", "invalid-file", "demo", "password")
         self.assertFalse(os.path.exists("invalid-file"))
 
     def test_ftp_invalid_auth(self):
-        with self.assertRaisesRegexp(ConanException, "530 User cannot log in."):
+        with six.assertRaisesRegex(self, ConanException, "530 User cannot log in."):
             net.ftp_download("test.rebex.net", "readme.txt", "demo", "invalid")
         self.assertFalse(os.path.exists("readme.txt"))

--- a/conans/test/unittests/model/editable_layout/load_data_test.py
+++ b/conans/test/unittests/model/editable_layout/load_data_test.py
@@ -5,6 +5,8 @@ import shutil
 import textwrap
 import unittest
 
+import six
+
 from conans.errors import ConanException
 from conans.model.editable_layout import EditableLayout
 from conans.test.utils.test_files import temp_folder
@@ -26,14 +28,14 @@ class ParseTest(unittest.TestCase):
                             something
                             """)
         save(self.layout_filepath, content)
-        with self.assertRaisesRegexp(ConanException, "Wrong cpp_info field 'includedrs' in layout"):
+        with six.assertRaisesRegex(self, ConanException, "Wrong cpp_info field 'includedrs' in layout"):
             _ = self.editable_cpp_info._load_data(ref=None, settings=None, options=None)
         content = textwrap.dedent("""
                             [*:includedrs]
                             something
                             """)
         save(self.layout_filepath, content)
-        with self.assertRaisesRegexp(ConanException, "Wrong cpp_info field 'includedrs' in layout"):
+        with six.assertRaisesRegex(self, ConanException, "Wrong cpp_info field 'includedrs' in layout"):
             _ = self.editable_cpp_info._load_data(ref=None, settings=None, options=None)
 
         content = textwrap.dedent("""
@@ -41,7 +43,7 @@ class ParseTest(unittest.TestCase):
                             something
                             """)
         save(self.layout_filepath, content)
-        with self.assertRaisesRegexp(ConanException, "Wrong package reference '\*' in layout file"):
+        with six.assertRaisesRegex(self, ConanException, "Wrong package reference '\*' in layout file"):
             _ = self.editable_cpp_info._load_data(ref=None, settings=None, options=None)
 
         content = textwrap.dedent("""
@@ -49,6 +51,6 @@ class ParseTest(unittest.TestCase):
                             something
                             """)
         save(self.layout_filepath, content)
-        with self.assertRaisesRegexp(ConanException, "Wrong package reference "
+        with six.assertRaisesRegex(self, ConanException, "Wrong package reference "
                                      "'pkg/version@user/channel:revision' in layout file"):
             _ = self.editable_cpp_info._load_data(ref=None, settings=None, options=None)

--- a/conans/test/unittests/model/options_test.py
+++ b/conans/test/unittests/model/options_test.py
@@ -38,7 +38,7 @@ class OptionsTest(unittest.TestCase):
         """
         package_options = PackageOptions.loads("""{
         path: ANY}""")
-        with self.assertRaisesRegexp(ConanException, option_undefined_msg("path")):
+        with six.assertRaisesRegex(self, ConanException, option_undefined_msg("path")):
             package_options.validate()
         package_options.path = "Something"
         package_options.validate()
@@ -63,7 +63,7 @@ class OptionsTest(unittest.TestCase):
                                             ("static", "True")])
         self.assertEqual(self.sut.items(), [("optimized", "3"), ("path", "C:/MyPath"),
                                             ("static", "True")])
-        with self.assertRaisesRegexp(ConanException,
+        with six.assertRaisesRegex(self, ConanException,
                                      "'5' is not a valid 'options.optimized' value"):
             self.sut.optimized = 5
 
@@ -117,7 +117,7 @@ class OptionsTest(unittest.TestCase):
                     "Hello1": hello1_values}
         down_ref = ConanFileReference.loads("Hello2/0.1@diego/testing")
 
-        with self.assertRaisesRegexp(ConanException, "Hello2/0.1@diego/testing tried to change "
+        with six.assertRaisesRegex(self, ConanException, "Hello2/0.1@diego/testing tried to change "
                                      "Hello1/0.1@diego/testing option optimized to 2"):
             self.sut.propagate_upstream(options2, down_ref, own_ref)
 
@@ -334,22 +334,22 @@ class OptionsValuesTest(unittest.TestCase):
     def test_loads_exceptions(self):
         emsg = "not enough values to unpack" if six.PY3 and sys.version_info.minor > 4 \
             else "need more than 1 value to unpack"
-        with self.assertRaisesRegexp(ValueError, emsg):
+        with six.assertRaisesRegex(self, ValueError, emsg):
             OptionsValues.loads("a=2\nconfig\nb=3")
 
-        with self.assertRaisesRegexp(ValueError, emsg):
+        with six.assertRaisesRegex(self, ValueError, emsg):
             OptionsValues.loads("config\na=2\ncommit\nb=3")
 
     def test_exceptions_empty_value(self):
         emsg = "not enough values to unpack" if six.PY3 and sys.version_info.minor > 4 \
             else "need more than 1 value to unpack"
-        with self.assertRaisesRegexp(ValueError, emsg):
+        with six.assertRaisesRegex(self, ValueError, emsg):
             OptionsValues("a=2\nconfig\nb=3")
 
-        with self.assertRaisesRegexp(ValueError, emsg):
+        with six.assertRaisesRegex(self, ValueError, emsg):
             OptionsValues(("a=2", "config"))
 
-        with self.assertRaisesRegexp(ValueError, emsg):
+        with six.assertRaisesRegex(self, ValueError, emsg):
             OptionsValues([('a', 2), ('config', ), ])
 
     def test_exceptions_repeated_value(self):

--- a/conans/test/unittests/model/ref_test.py
+++ b/conans/test/unittests/model/ref_test.py
@@ -1,5 +1,7 @@
 import unittest
 
+import six
+
 from conans.errors import ConanException
 from conans.model.ref import ConanFileReference, ConanName, InvalidNameException, PackageReference, \
     check_valid_ref
@@ -101,11 +103,11 @@ class RefTest(unittest.TestCase):
 class ConanNameTestCase(unittest.TestCase):
 
     def _check_invalid_format(self, value, *args):
-        with self.assertRaisesRegexp(InvalidNameException, "Valid names"):
+        with six.assertRaisesRegex(self, InvalidNameException, "Valid names"):
             ConanName.validate_name(value, *args)
 
     def _check_invalid_type(self, value):
-        with self.assertRaisesRegexp(InvalidNameException, "is not a string"):
+        with six.assertRaisesRegex(self, InvalidNameException, "is not a string"):
             ConanName.validate_name(value)
 
     def validate_name_test(self):

--- a/conans/test/unittests/model/settings_test.py
+++ b/conans/test/unittests/model/settings_test.py
@@ -1,5 +1,7 @@
 import unittest
 
+import six
+
 from conans.errors import ConanException
 from conans.model.settings import Settings, bad_value_msg, undefined_field, undefined_value
 
@@ -68,7 +70,7 @@ class SettingsLoadsTest(unittest.TestCase):
         subsystem: [None, cygwin]
     Windows:
 """
-        with self.assertRaisesRegexp(ConanException,
+        with six.assertRaisesRegex(self, ConanException,
                                      "settings.yml: None setting can't have subsettings"):
             Settings.loads(yml)
 
@@ -314,24 +316,24 @@ os: [Windows, Linux]
         self.sut.compiler = "gcc"
 
     def validate_test(self):
-        with self.assertRaisesRegexp(ConanException, str(undefined_value("settings.compiler"))):
+        with six.assertRaisesRegex(self, ConanException, str(undefined_value("settings.compiler"))):
             self.sut.validate()
 
         self.sut.compiler = "gcc"
-        with self.assertRaisesRegexp(ConanException, str(undefined_value("settings.compiler.arch"))):
+        with six.assertRaisesRegex(self, ConanException, str(undefined_value("settings.compiler.arch"))):
             self.sut.validate()
 
         self.sut.compiler.arch = "x86"
-        with self.assertRaisesRegexp(ConanException,
+        with six.assertRaisesRegex(self, ConanException,
                                      str(undefined_value("settings.compiler.arch.speed"))):
             self.sut.validate()
 
         self.sut.compiler.arch.speed = "A"
-        with self.assertRaisesRegexp(ConanException, str(undefined_value("settings.compiler.version"))):
+        with six.assertRaisesRegex(self, ConanException, str(undefined_value("settings.compiler.version"))):
             self.sut.validate()
 
         self.sut.compiler.version = "4.8"
-        with self.assertRaisesRegexp(ConanException, str(undefined_value("settings.os"))):
+        with six.assertRaisesRegex(self, ConanException, str(undefined_value("settings.os"))):
             self.sut.validate()
 
         self.sut.os = "Windows"
@@ -345,11 +347,11 @@ os: [Windows, Linux]
     def validate2_test(self):
         self.sut.os = "Windows"
         self.sut.compiler = "Visual Studio"
-        with self.assertRaisesRegexp(ConanException, str(undefined_value("settings.compiler.runtime"))):
+        with six.assertRaisesRegex(self, ConanException, str(undefined_value("settings.compiler.runtime"))):
             self.sut.validate()
 
         self.sut.compiler.runtime = "MD"
-        with self.assertRaisesRegexp(ConanException, str(undefined_value("settings.compiler.version"))):
+        with six.assertRaisesRegex(self, ConanException, str(undefined_value("settings.compiler.version"))):
             self.sut.validate()
 
         self.sut.compiler.version = "10"

--- a/conans/test/unittests/model/transitive_reqs_test.py
+++ b/conans/test/unittests/model/transitive_reqs_test.py
@@ -1,6 +1,7 @@
 import unittest
 from collections import namedtuple, Counter
 
+import six
 from mock import Mock
 
 from conans import DEFAULT_REVISION_V1
@@ -23,7 +24,6 @@ from conans.test.unittests.model.fake_retriever import Retriever
 from conans.test.utils.conanfile import TestConanFile
 from conans.test.utils.tools import (NO_SETTINGS_PACKAGE_ID, TestBufferConanOutput,
                                      test_processed_profile)
-
 
 say_content = TestConanFile("Say", "0.1")
 say_content2 = TestConanFile("Say", "0.2")
@@ -400,7 +400,7 @@ class ChatConan(ConanFile):
         self.retriever.conan(say_ref2, say_content2)
         self.retriever.conan(hello_ref, hello_content)
         self.retriever.conan(bye_ref, bye_content2)
-        with self.assertRaisesRegexp(ConanException, "Conflict in Bye/0.2@user/testing"):
+        with six.assertRaisesRegex(self, ConanException, "Conflict in Bye/0.2@user/testing"):
             self.build_graph(chat_content)
 
     def test_diamond_conflict(self):
@@ -417,7 +417,7 @@ class ChatConan(ConanFile):
         self.retriever.conan(hello_ref, hello_content)
         self.retriever.conan(bye_ref, bye_content2)
 
-        with self.assertRaisesRegexp(ConanException, "Conflict in Bye/0.2@user/testing"):
+        with six.assertRaisesRegex(self, ConanException, "Conflict in Bye/0.2@user/testing"):
             self.build_graph(chat_content)
 
     def test_diamond_conflict_solved(self):
@@ -852,7 +852,7 @@ class ChatConan(ConanFile):
         self.retriever.conan(hello_ref, hello_content)
         self.retriever.conan(bye_ref, bye_content)
 
-        with self.assertRaisesRegexp(ConanException, "tried to change"):
+        with six.assertRaisesRegex(self, ConanException, "tried to change"):
             self.build_graph(chat_content)
 
     def test_diamond_conflict_options_solved(self):
@@ -1493,7 +1493,7 @@ class LibDConan(ConanFile):
         libd_ref = ConanFileReference.loads("LibD/0.1@user/testing")
         self.retriever.conan(libd_ref, libd_content)
 
-        with self.assertRaisesRegexp(ConanException, "Conflict in LibB/0.1@user/testing"):
+        with six.assertRaisesRegex(self, ConanException, "Conflict in LibB/0.1@user/testing"):
             self.build_graph(self.consumer_content)
         self.assertIn("LibB/0.1@user/testing requirement LibA/0.1@user/testing overridden by "
                       "LibD/0.1@user/testing to LibA/0.2@user/testing", str(self.output))
@@ -1512,7 +1512,7 @@ class LibDConan(ConanFile):
         libd_ref = ConanFileReference.loads("LibD/0.1@user/testing")
         self.retriever.conan(libd_ref, libd_content)
 
-        with self.assertRaisesRegexp(ConanException, "Conflict in LibB/0.1@user/testing"):
+        with six.assertRaisesRegex(self, ConanException, "Conflict in LibB/0.1@user/testing"):
             self.build_graph(self.consumer_content)
         self.assertEqual(1, str(self.output).count("LibA requirements()"))
         self.assertEqual(1, str(self.output).count("LibA configure()"))
@@ -1551,7 +1551,7 @@ class LibDConan(ConanFile):
                                                      requires=["LibB/0.1@user/testing"],
                                                      default_options="LibA:shared=False"))
 
-        with self.assertRaisesRegexp(ConanException,
+        with six.assertRaisesRegex(self, ConanException,
                                      "LibD/0.1@user/testing tried to change LibB/0.1@user/testing "
                                      "option LibA:shared to True"):
             self.build_graph(self.consumer_content)
@@ -1612,10 +1612,10 @@ class SayConan(ConanFile):
         check(conanfile, "myoption=1", "os=Linux")
 
     def test_errors(self):
-        with self.assertRaisesRegexp(ConanException, "root.py: No subclass of ConanFile"):
+        with six.assertRaisesRegex(self, ConanException, "root.py: No subclass of ConanFile"):
             self.build_graph("")
 
-        with self.assertRaisesRegexp(ConanException, "root.py: More than 1 conanfile in the file"):
+        with six.assertRaisesRegex(self, ConanException, "root.py: More than 1 conanfile in the file"):
             self.build_graph("""from conans import ConanFile
 class HelloConan(ConanFile):pass
 class ByeConan(ConanFile):pass""")

--- a/conans/test/unittests/search/search_query_parse_test.py
+++ b/conans/test/unittests/search/search_query_parse_test.py
@@ -1,5 +1,7 @@
 import unittest
 
+import six
+
 from conans.search.query_parse import evaluate_postfix, infix_to_postfix
 
 
@@ -21,7 +23,7 @@ class QueryParseTest(unittest.TestCase):
         r = infix_to_postfix("(a=2 OR b=3) AND (j=34 AND j=45) OR (a=1)")
         self.assertEqual(r, ["a=2", "b=3", "|", "j=34", "j=45", "&", "a=1", "&", "|"])
 
-        with self.assertRaisesRegexp(Exception, "Invalid expression: 2"):
+        with six.assertRaisesRegex(self, Exception, "Invalid expression: 2"):
             r = infix_to_postfix("a= 2 OR b=3")
 
     def test_evaluate_postfix(self):

--- a/conans/test/unittests/server/conan_server_config_parser_test.py
+++ b/conans/test/unittests/server/conan_server_config_parser_test.py
@@ -2,6 +2,8 @@
 import os
 import unittest
 
+import six
+
 from conans.errors import ConanException
 from conans.server.conf import ConanServerConfigParser
 from conans.test.utils.test_files import temp_folder
@@ -39,7 +41,7 @@ demo: %s
         save(conf_path, server_conf % "cönan")
 
         server_config = ConanServerConfigParser(tmp_dir)
-        with self.assertRaisesRegexp(ConanException, "Password contains invalid characters. Only ASCII encoding is supported"):
+        with six.assertRaisesRegex(self, ConanException, "Password contains invalid characters. Only ASCII encoding is supported"):
             server_config.users
 
         save(conf_path, server_conf % "manol ito!@")
@@ -48,7 +50,7 @@ demo: %s
 
         # Now test from ENV
         server_config = ConanServerConfigParser(tmp_dir, environment={"CONAN_SERVER_USERS": "demo: cönan"})
-        with self.assertRaisesRegexp(ConanException, "Password contains invalid characters. Only ASCII encoding is supported"):
+        with six.assertRaisesRegex(self, ConanException, "Password contains invalid characters. Only ASCII encoding is supported"):
             server_config.users
 
         server_config = ConanServerConfigParser(tmp_dir, environment={"CONAN_SERVER_USERS": "demo:manolito!@"})

--- a/conans/test/unittests/server/conf_test.py
+++ b/conans/test/unittests/server/conf_test.py
@@ -2,6 +2,8 @@ import os
 import unittest
 from datetime import timedelta
 
+import six
+
 from conans.errors import ConanException
 from conans.paths import conan_expand_user
 from conans.server.conf import ConanServerConfigParser
@@ -60,7 +62,7 @@ var=walker
         self.assertEqual(conf.two, "other=var")
         self.assertEqual(conf.three, "var")
         self.assertEqual(conf.moon, "var=walker")
-        with self.assertRaisesRegexp(ConanException, "Unrecognized field 'NOEXIST'"):
+        with six.assertRaisesRegex(self, ConanException, "Unrecognized field 'NOEXIST'"):
             conf.NOEXIST
 
         # IF an old config file is readed but the section is in the list, just return it empty

--- a/conans/test/unittests/util/file_hashes_test.py
+++ b/conans/test/unittests/util/file_hashes_test.py
@@ -1,6 +1,8 @@
 import os
 import unittest
 
+import six
+
 from conans.client.tools.files import check_md5, check_sha1, check_sha256
 from conans.errors import ConanException
 from conans.test.utils.test_files import temp_folder
@@ -19,11 +21,11 @@ class HashesTest(unittest.TestCase):
         check_sha1(filepath, "eb599ec83d383f0f25691c184f656d40384f9435")
         check_sha256(filepath, "7365d029861e32c521f8089b00a6fb32daf0615025b69b599d1ce53501b845c2")
 
-        with self.assertRaisesRegexp(ConanException, "md5 signature failed for 'file.txt' file."):
+        with six.assertRaisesRegex(self, ConanException, "md5 signature failed for 'file.txt' file."):
             check_md5(filepath, "invalid")
 
-        with self.assertRaisesRegexp(ConanException, "sha1 signature failed for 'file.txt' file."):
+        with six.assertRaisesRegex(self, ConanException, "sha1 signature failed for 'file.txt' file."):
             check_sha1(filepath, "invalid")
 
-        with self.assertRaisesRegexp(ConanException, "sha256 signature failed for 'file.txt' file."):
+        with six.assertRaisesRegex(self, ConanException, "sha256 signature failed for 'file.txt' file."):
             check_sha256(filepath, "invalid")

--- a/conans/test/unittests/util/files/test_remove.py
+++ b/conans/test/unittests/util/files/test_remove.py
@@ -4,6 +4,8 @@ import os
 import stat
 import unittest
 
+import six
+
 from conans.test.utils.test_files import temp_folder
 from conans.util.files import remove, save
 
@@ -21,7 +23,7 @@ class RemoveTest(unittest.TestCase):
 
     def test_remove_readonly(self):
         os.chmod(self.file, stat.S_IREAD|stat.S_IRGRP|stat.S_IROTH)
-        with self.assertRaisesRegexp((IOError, OSError), "Permission denied"):
+        with six.assertRaisesRegex(self, (IOError, OSError), "Permission denied"):
             save(self.file, "change the content")
         remove(self.file)
         self.assertFalse(os.path.exists(self.file))

--- a/conans/test/unittests/util/output_test.py
+++ b/conans/test/unittests/util/output_test.py
@@ -4,6 +4,7 @@ import platform
 import unittest
 import zipfile
 
+import six
 from six import StringIO
 
 from conans.client import tools
@@ -69,7 +70,7 @@ class PkgConan(ConanFile):
         tools.unzip(zip_path, output_dir, output=ConanOutput(new_out))
 
         output = new_out.getvalue()
-        self.assertRegexpMatches(output, "Unzipping [\d]+B")
+        six.assertRegex(self, output, "Unzipping [\d]+B")
         content = load(os.path.join(output_dir, "example.txt"))
         self.assertEqual(content, "Hello world!")
 

--- a/conans/test/unittests/util/tools_test.py
+++ b/conans/test/unittests/util/tools_test.py
@@ -79,7 +79,7 @@ class SystemPackageToolTest(unittest.TestCase):
         os_info.is_windows = False
         os_info.linux_distro = "fedora"  # Will instantiate YumTool
 
-        with self.assertRaisesRegexp(ConanException, "add_repository not implemented"):
+        with six.assertRaisesRegex(self, ConanException, "add_repository not implemented"):
             new_out = StringIO()
             spt = SystemPackageTool(os_info=os_info, output=ConanOutput(new_out))
             spt.add_repository(repository="deb http://repo/url/ saucy universe multiverse",
@@ -439,7 +439,7 @@ class SystemPackageToolTest(unittest.TestCase):
 
         msg = platform_update_error_msg.get(platform.system(), None)
         if msg is not None:
-            with self.assertRaisesRegexp(ConanException, msg):
+            with six.assertRaisesRegex(self, ConanException, msg):
                 spt.update()
         else:
             spt.update()  # Won't raise anything because won't do anything
@@ -548,7 +548,7 @@ class ToolsTest(unittest.TestCase):
         with tools.environment_append({"CONAN_CPU_COUNT": "34"}):
             self.assertEqual(tools.cpu_count(output=output), 34)
         with tools.environment_append({"CONAN_CPU_COUNT": "null"}):
-            with self.assertRaisesRegexp(ConanException, "Invalid CONAN_CPU_COUNT value"):
+            with six.assertRaisesRegex(self, ConanException, "Invalid CONAN_CPU_COUNT value"):
                 tools.cpu_count(output=output)
 
     def get_env_unit_test(self):
@@ -689,10 +689,10 @@ class HelloConan(ConanFile):
         self.assertIn('vcvarsall.bat', cmd)
 
         # tests errors if args not defined
-        with self.assertRaisesRegexp(ConanException, "Cannot build_sln_command"):
+        with six.assertRaisesRegex(self, ConanException, "Cannot build_sln_command"):
             tools.msvc_build_command(settings, "project.sln")
         settings.arch = "x86"
-        with self.assertRaisesRegexp(ConanException, "Cannot build_sln_command"):
+        with six.assertRaisesRegex(self, ConanException, "Cannot build_sln_command"):
             tools.msvc_build_command(settings, "project.sln")
 
         # successful definition via settings
@@ -859,7 +859,7 @@ compiler:
         settings.os = "Windows"
         settings.compiler = "Visual Studio"
         settings.compiler.version = "5"
-        with self.assertRaisesRegexp(ConanException, "VS non-existing installation: Visual Studio 5"):
+        with six.assertRaisesRegex(self, ConanException, "VS non-existing installation: Visual Studio 5"):
             output = ConanOutput(StringIO())
             tools.vcvars_command(settings, output=output)
 
@@ -876,7 +876,7 @@ compiler:
         settings = Settings.loads(text)
         settings.os = "Windows"
         settings.compiler = "Visual Studio"
-        with self.assertRaisesRegexp(ConanException,
+        with six.assertRaisesRegex(self, ConanException,
                                      "compiler.version setting required for vcvars not defined"):
             tools.vcvars_command(settings, output=output)
 
@@ -886,7 +886,7 @@ compiler:
         with tools.environment_append({"vs140comntools": "path/to/fake"}):
             tools.vcvars_command(settings, output=output)
             with tools.environment_append({"VisualStudioVersion": "12"}):
-                with self.assertRaisesRegexp(ConanException,
+                with six.assertRaisesRegex(self, ConanException,
                                              "Error, Visual environment already set to 12"):
                     tools.vcvars_command(settings, output=output)
 
@@ -1059,7 +1059,7 @@ ProgramFiles(x86)=C:\Program Files (x86)
         out = TestBufferConanOutput()
 
         # Connection error
-        with self.assertRaisesRegexp(ConanException, "HTTPConnectionPool"):
+        with six.assertRaisesRegex(self, ConanException, "HTTPConnectionPool"):
             tools.download("http://fakeurl3.es/nonexists",
                            os.path.join(temp_folder(), "file.txt"), out=out,
                            requester=requests,
@@ -1067,7 +1067,7 @@ ProgramFiles(x86)=C:\Program Files (x86)
 
         # Not found error
         self.assertEqual(str(out).count("Waiting 0 seconds to retry..."), 2)
-        with self.assertRaisesRegexp(NotFoundException, "Not found: "):
+        with six.assertRaisesRegex(self, NotFoundException, "Not found: "):
             tools.download("https://github.com/conan-io/conan/blob/develop/FILE_NOT_FOUND.txt",
                            os.path.join(temp_folder(), "README.txt"), out=out,
                            requester=requests,
@@ -1317,7 +1317,7 @@ ProgramFiles(x86)=C:\Program Files (x86)
 
         out = TestBufferConanOutput()
         # Test: File name cannot be deduced from '?file=1'
-        with self.assertRaisesRegexp(ConanException,
+        with six.assertRaisesRegex(self, ConanException,
                                      "Cannot deduce file name form url. Use 'filename' parameter."):
             tools.get("http://localhost:%s/?file=1" % thread.port, output=out)
 
@@ -1338,7 +1338,7 @@ ProgramFiles(x86)=C:\Program Files (x86)
             self.assertTrue(os.path.exists("test_folder"))
         thread.stop()
 
-        with self.assertRaisesRegexp(ConanException, "Error"):
+        with six.assertRaisesRegex(self, ConanException, "Error"):
             tools.get("http://localhost:%s/error_url" % thread.port,
                       filename="fake_sample.tar.gz", requester=requests, output=out, verify=False,
                       retry=3, retry_wait=0)
@@ -1479,7 +1479,7 @@ class GitToolTest(unittest.TestCase):
         tmp = temp_folder()
         save(os.path.join(tmp, "file"), "dummy contents")
         git = Git(tmp)
-        with self.assertRaisesRegexp(ConanException, "specify a branch to checkout"):
+        with six.assertRaisesRegex(self, ConanException, "specify a branch to checkout"):
             git.clone("https://github.com/conan-community/conan-zlib.git")
 
     def test_credentials(self):
@@ -1536,7 +1536,7 @@ class GitToolTest(unittest.TestCase):
         tmp, submodule_path, subsubmodule_path = _create_paths()
         git = Git(tmp)
         git.clone(path)
-        with self.assertRaisesRegexp(ConanException, "Invalid 'submodule' attribute value in the 'scm'."):
+        with six.assertRaisesRegex(self, ConanException, "Invalid 'submodule' attribute value in the 'scm'."):
             git.checkout(commit, submodule="invalid")
 
         # Check shallow
@@ -1697,7 +1697,7 @@ class GitToolsTests(unittest.TestCase):
         Try to get tag out of a git repo
         """
         git = Git(folder=temp_folder())
-        with self.assertRaisesRegexp(ConanException, "Not a valid 'git' repository"):
+        with six.assertRaisesRegex(self, ConanException, "Not a valid 'git' repository"):
             git.get_tag()
 
     def test_excluded_files(self):
@@ -1716,7 +1716,7 @@ class SVNToolTestsBasic(SVNLocalRepoTestCase):
         project_url, _ = self.create_project(files={'myfile': "contents"})
         tmp_folder = self.gimme_tmp()
         svn = SVN(folder=tmp_folder)
-        with self.assertRaisesRegexp(ConanException, "Not a valid 'svn' repository"):
+        with six.assertRaisesRegex(self, ConanException, "Not a valid 'svn' repository"):
             svn.check_repo()
         svn.checkout(url=project_url)
         try:
@@ -1918,7 +1918,7 @@ class SVNToolTestsBasic(SVNLocalRepoTestCase):
         self.assertIsNone(svn.get_branch())
 
         svn = SVN(folder=self.gimme_tmp())
-        with self.assertRaisesRegexp(ConanException, "Unable to get svn branch"):
+        with six.assertRaisesRegex(self, ConanException, "Unable to get svn branch"):
             svn.get_branch()
 
     def test_tag(self):
@@ -1944,7 +1944,7 @@ class SVNToolTestsBasic(SVNLocalRepoTestCase):
         self.assertEqual("v12.3.4", svn.get_tag())
 
         svn = SVN(folder=self.gimme_tmp())
-        with self.assertRaisesRegexp(ConanException, "Unable to get svn tag"):
+        with six.assertRaisesRegex(self, ConanException, "Unable to get svn tag"):
             svn.get_tag()
 
 

--- a/conans/test/unittests/util/xz_test.py
+++ b/conans/test/unittests/util/xz_test.py
@@ -94,6 +94,6 @@ class Pkg(ConanFile):
 
     @unittest.skipUnless(six.PY2, "only Py2")
     def test_error_python2(self):
-        with self.assertRaisesRegexp(ConanException, "XZ format not supported in Python 2"):
+        with six.assertRaisesRegex(self, ConanException, "XZ format not supported in Python 2"):
             dest_folder = temp_folder()
             unzip("somefile.tar.xz", dest_folder)


### PR DESCRIPTION
Changelog: omit
Docs: omit

Replace `self.assertRaisesRegexp` by `six.assertRaisesRegex`
Replace `self.assertRegexMatches`  by `six.assertRegex`
Add `import six` where necessary

Related to https://github.com/conan-io/conan/pull/4548

