### PR TITLE
[Bug] Order of requires affects generated build info

### DIFF
--- a/conans/client/graph/graph_builder.py
+++ b/conans/client/graph/graph_builder.py
@@ -177,9 +177,20 @@ class DepsGraphBuilder(object):
                                      "    To change it, override it in your base requirements"
                                      % (node.ref, require.ref, previous.ref))
 
+            # Add ancestors
+            for it in node.ancestors:
+                previous.ancestors.add(it)
             previous.ancestors.add(node.name)
             node.public_closure[name] = previous
             dep_graph.add_edge(node, previous, require.private, require.build_require)
+
+            # Update the closure of each dependent
+            for dep_node_name, dep_node in node.public_deps.items():
+                if dep_node is node:
+                    continue
+                if dep_node_name in previous.ancestors:
+                    dep_node.public_closure[previous.name] = previous
+
             # RECURSION!
             if self._recurse(previous.public_closure, new_reqs, new_options):
                 self._load_deps(dep_graph, previous, new_reqs, node.ref,

--- a/conans/test/functional/graph/transitive_deps_test.py
+++ b/conans/test/functional/graph/transitive_deps_test.py
@@ -1,0 +1,68 @@
+# coding=utf-8
+
+import os
+import textwrap
+import unittest
+
+from parameterized import parameterized
+
+from conans.model.ref import PackageReference
+from conans.test.utils.tools import TestClient
+from conans.util.files import load
+
+
+class TransitiveDepsTest(unittest.TestCase):
+
+    conanfile = textwrap.dedent("""
+        from conans import ConanFile
+        
+        class Lib(ConanFile):
+            name = "{name}"
+            version = "1.0"
+            generators = "cmake"
+            
+            {requires}
+            
+    """)
+
+    def setUp(self):
+        # Create dependency graph: C -> B -> A
+        self.t = TestClient()
+
+        conanfile_a = self.conanfile.format(name="AAAA", requires="")
+        self.t.save({"A/conanfile.py": conanfile_a})
+        self.t.run("export ./A user/channel")
+        self.assertIn("AAAA/1.0@user/channel: A new conanfile.py version was exported", self.t.out)
+
+        conanfile_b = self.conanfile.format(name="BBBB",
+                                            requires='requires = "AAAA/1.0@user/channel"')
+        self.t.save({"B/conanfile.py": conanfile_b})
+        self.t.run("export ./B user/channel")
+        self.assertIn("BBBB/1.0@user/channel: A new conanfile.py version was exported", self.t.out)
+
+        conanfile_c = self.conanfile.format(name="CCCC",
+                                            requires='requires = "BBBB/1.0@user/channel"')
+        self.t.save({"C/conanfile.py": conanfile_c})
+        self.t.run("export ./C user/channel")
+        self.assertIn("CCCC/1.0@user/channel: A new conanfile.py version was exported", self.t.out)
+
+    @parameterized.expand([(True, ), (False, )])
+    def test_consume(self, inverse_order):
+        deps = sorted(["AAAA/1.0@user/channel", "CCCC/1.0@user/channel"], reverse=inverse_order)
+
+        # Create D -> A,C
+        conanfile_d = self.conanfile.format(name="DDDD",
+                                            requires='requires = "{}"'.format('", "'.join(deps)))
+        self.t.save({"D/conanfile.py": conanfile_d})
+        self.t.run("create ./D user/channel --build=missing")
+        self.assertIn("DDDD/1.0@user/channel: A new conanfile.py version was exported", self.t.out)
+
+        # C is being built
+        pref_c = PackageReference.loads(
+            "CCCC/1.0@user/channel:aef99e6ca67e3d2da47927c4ec1ec7129129943f")
+        self.assertIn("{} - Build".format(pref_c), self.t.out)
+        build_folder = self.t.cache.build(pref=pref_c)
+
+        # It contains information about AAAA
+        conanbuildinfo = load(os.path.join(build_folder, "conanbuildinfo.cmake"))
+        self.assertIn("set(CONAN_AAAA_ROOT ", conanbuildinfo)


### PR DESCRIPTION
Changelog: Bugfix: XXXXXX
Docs: https://github.com/conan-io/docs/pull/XXXX

Test demonstrating bug in #4727: order of requirements affects the generated output in `cmake` generator (at least).

closes #4727 