### PR TITLE
Collect libs uses sorted list (#4542)

### DIFF
--- a/conans/client/tools/files.py
+++ b/conans/client/tools/files.py
@@ -322,6 +322,7 @@ def collect_libs(conanfile, folder=None):
                                           "times with a different file extension" % name)
                 else:
                     result.append(name)
+    result.sort()
     return result
 
 
@@ -369,5 +370,3 @@ def unix2dos(filepath):
 
 def dos2unix(filepath):
     _replace_with_separator(filepath, "\n")
-
-

--- a/conans/test/unittests/util/tools_test.py
+++ b/conans/test/unittests/util/tools_test.py
@@ -632,7 +632,7 @@ class HelloConan(ConanFile):
 
     def test_global_tools_overrided(self):
         client = TestClient()
- 
+
         conanfile = """
 from conans import ConanFile, tools
 
@@ -960,17 +960,17 @@ compiler:
 PROCESSOR_IDENTIFIER=Intel64 Family 6 Model 158 Stepping 9, GenuineIntel
 
 
- PROCESSOR_LEVEL=6 
+ PROCESSOR_LEVEL=6
 
-PROCESSOR_REVISION=9e09    
+PROCESSOR_REVISION=9e09
 
-                         
+
 set nl=^
 env_var=
 without_equals_sign
 
 ProgramFiles(x86)=C:\Program Files (x86)
-       
+
 """.encode("utf-8")
 
         def vcvars_command_mock(settings, arch, compiler_version, force, vcvars_ver, winsdk_version,
@@ -1168,15 +1168,15 @@ ProgramFiles(x86)=C:\Program Files (x86)
         build, host = get_values("Linux", "x86_64", "Linux", "armv8_32")
         self.assertEqual(build, "x86_64-linux-gnu")
         self.assertEqual(host, "aarch64-linux-gnu_ilp32")
-        
+
         build, host = get_values("Linux", "x86_64", "Linux", "armv5el")
         self.assertEqual(build, "x86_64-linux-gnu")
         self.assertEqual(host, "arm-linux-gnueabi")
-        
+
         build, host = get_values("Linux", "x86_64", "Linux", "armv5hf")
         self.assertEqual(build, "x86_64-linux-gnu")
         self.assertEqual(host, "arm-linux-gnueabihf")
-       
+
         build, host = get_values("Linux", "x86_64", "Android", "x86")
         self.assertEqual(build, "x86_64-linux-gnu")
         self.assertEqual(host, "i686-linux-android")
@@ -2268,7 +2268,7 @@ class CollectLibTestCase(unittest.TestCase):
         # Use cpp_info.libdirs
         conanfile.cpp_info.libdirs = ["lib", "custom_folder"]
         result = tools.collect_libs(conanfile)
-        self.assertEqual(["mylib", "customlib"], result)
+        self.assertEqual(["customlib", "mylib"], result)
 
         # Custom folder with multiple libdirs should only collect from custom folder
         self.assertEqual(["lib", "custom_folder"], conanfile.cpp_info.libdirs)
@@ -2334,7 +2334,7 @@ class CollectLibTestCase(unittest.TestCase):
         # Use cpp_info.libdirs
         conanfile.cpp_info.libdirs = ["lib", "custom_folder"]
         result = conanfile.collect_libs()
-        self.assertEqual(["mylib", "customlib"], result)
+        self.assertEqual(["customlib", "mylib"], result)
 
         # Custom folder with multiple libdirs should only collect from custom folder
         self.assertEqual(["lib", "custom_folder"], conanfile.cpp_info.libdirs)


### PR DESCRIPTION
Changelog: Feature: Sort library list name when calling tools.collect_libs (#4542)
Docs: https://github.com/conan-io/docs/pull/1124

- [x] Refer to the issue that supports this Pull Request.
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [x] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 

<sup>**Note:** By default this PR will skip the slower tests and will use a limited set of python versions. Check [here](https://github.com/conan-io/conan/blob/develop/.github/PR_INCREASE_TESTING.md) how to increase the testing level by writing some tags in the current PR body text.</sup>
