### PR TITLE
build sets node.prev

### DIFF
--- a/conans/client/installer.py
+++ b/conans/client/installer.py
@@ -43,156 +43,187 @@ def build_id(conan_file):
     return None
 
 
-class _ConanPackageBuilder(object):
-    """Builds and packages a single conan_file binary package"""
-
-    def __init__(self, conan_file, pref, cache, output, hook_manager):
+class _PackageBuilder(object):
+    def __init__(self, cache, output, hook_manager, remote_manager):
         self._cache = cache
-        self._conan_file = conan_file
-        self._out = output
-        self._pref = pref
-        self._ref = self._pref.ref
-        self._skip_build = False  # If build_id()
+        self._output = output
         self._hook_manager = hook_manager
+        self._remote_manager = remote_manager
 
-        new_id = build_id(self._conan_file)
-        self.build_pref = PackageReference(self._ref, new_id) if new_id else pref
-        self.build_folder = self._cache.build(self.build_pref, self._conan_file.short_paths)
-        self.package_folder = self._cache.package(self._pref, self._conan_file.short_paths)
-        self.source_folder = self._cache.source(self._ref, self._conan_file.short_paths)
+    def _get_build_folder(self, conanfile, package_layout, pref, keep_build, recorder):
+        # Build folder can use a different package_ID if build_id() is defined.
+        # This function decides if the build folder should be re-used (not build again)
+        # and returns the build folder
+        new_id = build_id(conanfile)
+        build_pref = PackageReference(pref.ref, new_id) if new_id else pref
+        build_folder = package_layout.build(build_pref)
 
-    def prepare_build(self):
-        if self.build_pref != self._pref and \
-              os.path.exists(self.build_folder) and hasattr(self._conan_file, "build_id"):
-            self._skip_build = True
-            return
+        if is_dirty(build_folder):
+            self._output.warn("Build folder is dirty, removing it: %s" % build_folder)
+            rmdir(build_folder)
 
-        # build_id is not caching the build folder, so actually rebuild the package
-        export_folder = self._cache.export(self._ref)
-        export_source_folder = self._cache.export_sources(self._ref,
-                                                          self._conan_file.short_paths)
-        conanfile_path = self._cache.conanfile(self._ref)
+        # Decide if the build folder should be kept
+        skip_build = conanfile.develop and keep_build
+        if skip_build:
+            self._output.info("Won't be built as specified by --keep-build")
+            if not os.path.exists(build_folder):
+                msg = "--keep-build specified, but build folder not found"
+                recorder.package_install_error(pref, INSTALL_ERROR_MISSING_BUILD_FOLDER,
+                                               msg, remote_name=None)
+                raise ConanException(msg)
+        elif build_pref != pref and os.path.exists(build_folder) and hasattr(conanfile, "build_id"):
+            self._output.info("Won't be built, using previous build folder as defined in build_id()")
+            skip_build = True
 
+        return build_folder, skip_build
+
+    def _prepare_sources(self, conanfile, pref, package_layout, conanfile_path, source_folder,
+                         build_folder, package_folder):
+        export_folder = package_layout.export()
+        export_source_folder = package_layout.export_sources()
+
+        complete_recipe_sources(self._remote_manager, self._cache, conanfile, pref.ref)
         try:
-            rmdir(self.build_folder)
-            rmdir(self.package_folder)
+            rmdir(build_folder)
+            rmdir(package_folder)
         except OSError as e:
             raise ConanException("%s\n\nCouldn't remove folder, might be busy or open\n"
                                  "Close any app using it, and retry" % str(e))
 
-        self._out.info('Building your package in %s' % self.build_folder)
-        config_source(export_folder, export_source_folder, self.source_folder,
-                      self._conan_file, self._out, conanfile_path, self._ref,
+        self._output.info('Configuring sources in %s' % source_folder)
+        config_source(export_folder, export_source_folder, source_folder,
+                      conanfile, self._output, conanfile_path, pref.ref,
                       self._hook_manager, self._cache)
-        self._out.info('Copying sources to build folder')
 
-        if getattr(self._conan_file, 'no_copy_source', False):
-            mkdir(self.build_folder)
-            self._conan_file.source_folder = self.source_folder
-        else:
+        if not getattr(conanfile, 'no_copy_source', False):
+            self._output.info('Copying sources to build folder')
+            ignore = None
             if platform.system() == "Windows" and os.getenv("CONAN_USER_HOME_SHORT") != "None":
                 from conans.util.windows import ignore_long_path_files
-                ignore = ignore_long_path_files(self.source_folder, self.build_folder, self._out)
-            else:
-                ignore = None
+                ignore = ignore_long_path_files(source_folder, build_folder, self._output)
+            shutil.copytree(source_folder, build_folder, symlinks=True, ignore=ignore)
+            logger.debug("BUILD: Copied to %s", build_folder)
+            logger.debug("BUILD: Files copied %s", ",".join(os.listdir(build_folder)))
 
-            shutil.copytree(self.source_folder, self.build_folder, symlinks=True, ignore=ignore)
-            logger.debug("BUILD: Copied to %s", self.build_folder)
-            logger.debug("BUILD: Files copied %s", ",".join(os.listdir(self.build_folder)))
-            self._conan_file.source_folder = self.build_folder
-
-    def build(self):
-        """Calls the conanfile's build method"""
-        if self._skip_build:
-            return
-        with get_env_context_manager(self._conan_file):
-            self._build_package()
-
-    def package(self):
-        """Generate the info txt files and calls the conanfile package method.
-        """
-
-        # FIXME: Is weak to assign here the recipe_hash
-        manifest = self._cache.package_layout(self._ref).recipe_manifest()
-        self._conan_file.info.recipe_hash = manifest.summary_hash
-
-        # Creating ***info.txt files
-        save(os.path.join(self.build_folder, CONANINFO), self._conan_file.info.dumps())
-        self._out.info("Generated %s" % CONANINFO)
-        save(os.path.join(self.build_folder, BUILD_INFO), TXTGenerator(self._conan_file).content)
-        self._out.info("Generated %s" % BUILD_INFO)
-
-        os.chdir(self.build_folder)
-
-        if getattr(self._conan_file, 'no_copy_source', False):
-            source_folder = self.source_folder
-        else:
-            source_folder = self.build_folder
-        with get_env_context_manager(self._conan_file):
-            install_folder = self.build_folder  # While installing, the infos goes to build folder
-            pkg_id = self._pref.id
-            conanfile_path = self._cache.conanfile(self._ref)
-
-            create_package(self._conan_file, pkg_id, source_folder, self.build_folder,
-                           self.package_folder, install_folder, self._hook_manager,
-                           conanfile_path, self._ref)
-
-        layout = self._cache.package_layout(self._pref.ref, self._conan_file.short_paths)
-        package_hash = layout.package_summary_hash(self._pref)
-        package_id = self._pref.id
-
-        with self._cache.package_layout(self._ref).update_metadata() as metadata:
-            if metadata.packages[package_id].revision != package_hash:
-                metadata.packages[package_id].revision = package_hash
-            metadata.packages[package_id].recipe_revision = self._ref.revision
-
-        if get_env("CONAN_READ_ONLY_CACHE", False):
-            make_read_only(self.package_folder)
-
-    def _build_package(self):
-        """ calls the imports + conanfile.build() method
-        """
-        os.chdir(self.build_folder)
-        self._conan_file.build_folder = self.build_folder
-        self._conan_file.package_folder = self.package_folder
-        # In local cache, install folder always is build_folder
-        self._conan_file.install_folder = self.build_folder
-
+    def _build(self, conanfile, pref, build_folder):
         # Read generators from conanfile and generate the needed files
         logger.info("GENERATORS: Writing generators")
-        write_generators(self._conan_file, self.build_folder, self._out)
+        write_generators(conanfile, build_folder, self._output)
 
         # Build step might need DLLs, binaries as protoc to generate source files
         # So execute imports() before build, storing the list of copied_files
-        copied_files = run_imports(self._conan_file, self.build_folder)
+        copied_files = run_imports(conanfile, build_folder)
 
         try:
-            # This is necessary because it is different for user projects
-            # than for packages
-            self._hook_manager.execute("pre_build", conanfile=self._conan_file,
-                                       reference=self._ref,
-                                       package_id=self._pref.id)
+            self._hook_manager.execute("pre_build", conanfile=conanfile,
+                                       reference=pref.ref, package_id=pref.id)
             logger.debug("Call conanfile.build() with files in build folder: %s",
-                         os.listdir(self.build_folder))
-            self._out.highlight("Calling build()")
-            with conanfile_exception_formatter(str(self._conan_file), "build"):
-                self._conan_file.build()
+                         os.listdir(build_folder))
+            self._output.highlight("Calling build()")
+            with conanfile_exception_formatter(str(conanfile), "build"):
+                conanfile.build()
 
-            self._out.success("Package '%s' built" % self._pref.id)
-            self._out.info("Build folder %s" % self.build_folder)
-            self._hook_manager.execute("post_build", conanfile=self._conan_file,
-                                       reference=self._ref,
-                                       package_id=self._pref.id)
+            self._output.success("Package '%s' built" % pref.id)
+            self._output.info("Build folder %s" % build_folder)
+            self._hook_manager.execute("post_build", conanfile=conanfile,
+                                       reference=pref.ref, package_id=pref.id)
         except Exception as exc:
-            self._out.writeln("")
-            self._out.error("Package '%s' build failed" % self._pref.id)
-            self._out.warn("Build folder %s" % self.build_folder)
+            self._output.writeln("")
+            self._output.error("Package '%s' build failed" % pref.id)
+            self._output.warn("Build folder %s" % build_folder)
             if isinstance(exc, ConanExceptionInUserConanfileMethod):
                 raise exc
             raise ConanException(exc)
         finally:
             # Now remove all files that were imported with imports()
-            remove_imports(self._conan_file, copied_files, self._out)
+            remove_imports(conanfile, copied_files, self._output)
+
+    def _package(self, conanfile, pref, package_layout, conanfile_path, build_folder,
+                 package_folder):
+        # FIXME: Is weak to assign here the recipe_hash
+        manifest = package_layout.recipe_manifest()
+        conanfile.info.recipe_hash = manifest.summary_hash
+
+        # Creating ***info.txt files
+        save(os.path.join(build_folder, CONANINFO), conanfile.info.dumps())
+        self._output.info("Generated %s" % CONANINFO)
+        save(os.path.join(build_folder, BUILD_INFO), TXTGenerator(conanfile).content)
+        self._output.info("Generated %s" % BUILD_INFO)
+
+        package_id = pref.id
+        # Do the actual copy, call the conanfile.package() method
+        with get_env_context_manager(conanfile):
+            # Could be source or build depends no_copy_source
+            source_folder = conanfile.source_folder
+            install_folder = build_folder  # While installing, the infos goes to build folder
+            create_package(conanfile, package_id, source_folder, build_folder,
+                           package_folder, install_folder, self._hook_manager,
+                           conanfile_path, pref.ref)
+
+        # Update package metadata
+        package_hash = package_layout.package_summary_hash(pref)
+        with package_layout.update_metadata() as metadata:
+            metadata.packages[package_id].revision = package_hash
+            metadata.packages[package_id].recipe_revision = pref.ref.revision
+
+        if get_env("CONAN_READ_ONLY_CACHE", False):
+            make_read_only(package_folder)
+        # FIXME: Conan 2.0 Clear the registry entry (package ref)
+        return package_hash
+
+    def build_package(self, node, keep_build, recorder):
+        t1 = time.time()
+
+        conanfile = node.conanfile
+        pref = node.pref
+
+        package_layout = self._cache.package_layout(pref.ref, conanfile.short_paths)
+        source_folder = package_layout.source()
+        conanfile_path = package_layout.conanfile()
+        package_folder = package_layout.package(pref)
+
+        build_folder, skip_build = self._get_build_folder(conanfile, package_layout,
+                                                          pref, keep_build, recorder)
+        # PREPARE SOURCES
+        if not skip_build:
+            with package_layout.conanfile_write_lock(self._output):
+                set_dirty(build_folder)
+                self._prepare_sources(conanfile, pref, package_layout, conanfile_path, source_folder,
+                                      build_folder, package_folder)
+
+        # BUILD & PACKAGE
+        with package_layout.conanfile_read_lock(self._output):
+            mkdir(build_folder)
+            os.chdir(build_folder)
+            self._output.info('Building your package in %s' % build_folder)
+            try:
+                if getattr(conanfile, 'no_copy_source', False):
+                    conanfile.source_folder = source_folder
+                else:
+                    conanfile.source_folder = build_folder
+
+                if not skip_build:
+                    with get_env_context_manager(conanfile):
+                        conanfile.build_folder = build_folder
+                        conanfile.package_folder = package_folder
+                        # In local cache, install folder always is build_folder
+                        conanfile.install_folder = build_folder
+                        self._build(conanfile, pref, build_folder)
+                    clean_dirty(build_folder)
+
+                prev = self._package(conanfile, pref, package_layout, conanfile_path, build_folder,
+                                     package_folder)
+                node.prev = prev
+                log_file = os.path.join(build_folder, RUN_LOG_NAME)
+                log_file = log_file if os.path.exists(log_file) else None
+                log_package_built(pref, time.time() - t1, log_file)
+                recorder.package_built(pref)
+            except ConanException as exc:
+                recorder.package_install_error(pref, INSTALL_ERROR_BUILDING,
+                                               str(exc), remote_name=None)
+                raise exc
+
+            return node.pref
 
 
 def _handle_system_requirements(conan_file, pref, cache, out):
@@ -267,9 +298,9 @@ class BinaryInstaller(object):
         root_level = nodes_by_level.pop()
         root_node = root_level[0]
         # Get the nodes in order and if we have to build them
-        self._build(nodes_by_level, deps_graph, keep_build, root_node, graph_info)
+        self._build(nodes_by_level, keep_build, root_node, graph_info)
 
-    def _build(self, nodes_by_level, deps_graph, keep_build, root_node, graph_info):
+    def _build(self, nodes_by_level, keep_build, root_node, graph_info):
         processed_package_refs = set()
         for level in nodes_by_level:
             for node in level:
@@ -287,6 +318,7 @@ class BinaryInstaller(object):
                 else:
                     if node.binary == BINARY_SKIP:  # Privates not necessary
                         continue
+                    assert ref.revision is not None, "Installer should receive RREV always"
                     _handle_system_requirements(conan_file, node.pref, self._cache, output)
                     self._handle_node_cache(node, keep_build, processed_package_refs)
 
@@ -336,6 +368,8 @@ class BinaryInstaller(object):
 
     def _handle_node_cache(self, node, keep_build, processed_package_references):
         pref = node.pref
+        assert pref.id, "Package-ID without value"
+
         conan_file = node.conanfile
         output = conan_file.output
         package_folder = self._cache.package(pref, conan_file.short_paths)
@@ -344,10 +378,14 @@ class BinaryInstaller(object):
             if pref not in processed_package_references:
                 processed_package_references.add(pref)
                 if node.binary == BINARY_BUILD:
+                    assert node.prev is None, "PREV for %s to be built should be None" % str(pref)
                     set_dirty(package_folder)
-                    self._build_package(node, pref, output, keep_build)
+                    pref = self._build_package(node, pref, output, keep_build)
                     clean_dirty(package_folder)
+                    assert node.prev is not None, "PREV for %s to be built is None" % str(pref)
+                    assert pref.revision is not None, "PREV for %s to be built is None" % str(pref)
                 elif node.binary in (BINARY_UPDATE, BINARY_DOWNLOAD):
+                    assert node.prev, "PREV for %s is None" % str(pref)
                     if not self._node_concurrently_installed(node, package_folder):
                         set_dirty(package_folder)
                         assert pref.revision is not None, "Installer should receive #PREV always"
@@ -361,6 +399,7 @@ class BinaryInstaller(object):
                         log_package_got_from_local_cache(pref)
                         self._recorder.package_fetched_from_cache(pref)
                 elif node.binary == BINARY_CACHE:
+                    assert node.prev, "PREV for %s is None" % str(pref)
                     output.success('Already installed!')
                     log_package_got_from_local_cache(pref)
                     self._recorder.package_fetched_from_cache(pref)
@@ -370,61 +409,19 @@ class BinaryInstaller(object):
             self._recorder.package_cpp_info(pref, conan_file.cpp_info)
 
     def _build_package(self, node, pref, output, keep_build):
-        ref, conan_file = node.ref, node.conanfile
+        conanfile = node.conanfile
+        assert pref.id, "Package-ID without value"
 
-        t1 = time.time()
         # It is necessary to complete the sources of python requires, which might be used
-        for python_require in conan_file.python_requires:
+        for python_require in conanfile.python_requires:
             assert python_require.ref.revision is not None, \
                 "Installer should receive python_require.ref always"
             complete_recipe_sources(self._remote_manager, self._cache,
-                                    conan_file, python_require.ref)
+                                    conanfile, python_require.ref)
 
-        builder = _ConanPackageBuilder(conan_file, pref, self._cache, output, self._hook_manager)
-
-        if is_dirty(builder.build_folder):
-            output.warn("Build folder is dirty, removing it: %s" % builder.build_folder)
-            rmdir(builder.build_folder)
-
-        skip_build = conan_file.develop and keep_build
-        if skip_build:
-            output.info("Won't be built as specified by --keep-build")
-        if skip_build:
-            if not os.path.exists(builder.build_folder):
-                msg = "--keep-build specified, but build folder not found"
-                self._recorder.package_install_error(pref,
-                                                     INSTALL_ERROR_MISSING_BUILD_FOLDER,
-                                                     msg, remote_name=None)
-                raise ConanException(msg)
-        else:
-            with self._cache.conanfile_write_lock(ref):
-                set_dirty(builder.build_folder)
-                assert ref.revision is not None, \
-                    "Installer should receive RREV always"
-                complete_recipe_sources(self._remote_manager, self._cache, conan_file, ref)
-                builder.prepare_build()
-
-        with self._cache.conanfile_read_lock(ref):
-            try:
-                if not skip_build:
-                    builder.build()
-                    clean_dirty(builder.build_folder)
-                builder.package()
-            except ConanException as exc:
-                self._recorder.package_install_error(pref, INSTALL_ERROR_BUILDING,
-                                                     str(exc), remote_name=None)
-                raise exc
-            else:
-                # Log build
-                self._log_built_package(builder.build_folder, pref.copy_clear_rev(),
-                                        time.time() - t1)
-                # FIXME: Conan 2.0 Clear the registry entry (package ref)
-
-    def _log_built_package(self, build_folder, pref, duration):
-        log_file = os.path.join(build_folder, RUN_LOG_NAME)
-        log_file = log_file if os.path.exists(log_file) else None
-        log_package_built(pref, duration, log_file)
-        self._recorder.package_built(pref)
+        builder = _PackageBuilder(self._cache, output, self._hook_manager, self._remote_manager)
+        pref = builder.build_package(node, keep_build, self._recorder)
+        return pref
 
     @staticmethod
     def _propagate_info(node):


### PR DESCRIPTION
Changelog: omit
Docs: omit

- Checking pref.prev definition in BinaryInstaller (assertions) for downloads, updates
- Make sure the node.prev is set after a package build from sources
- Refactor _ConanPackageBuilder, using ``PackageCacheLayout``, more clear use of ``skip_build``.
- 

@tags: slow


