### PR TITLE
raise error instead of skipping files if short_paths

### DIFF
--- a/conans/client/installer.py
+++ b/conans/client/installer.py
@@ -93,7 +93,7 @@ class _ConanPackageBuilder(object):
                 shutil.copytree(self.source_folder, self.build_folder, symlinks=True)
             except Exception as e:
                 msg = str(e)
-                if "[Error 206]" in msg:  # System error shutil.Error
+                if "206" in msg:  # System error shutil.Error 206: Filename or extension too long
                     msg += "\nUse short_paths=True if paths too long"
                 raise ConanException("%s\nError copying sources to build folder" % msg)
             logger.debug("BUILD: Copied to %s", self.build_folder)

--- a/conans/client/installer.py
+++ b/conans/client/installer.py
@@ -1,5 +1,4 @@
 import os
-import platform
 import shutil
 import time
 
@@ -90,13 +89,12 @@ class _ConanPackageBuilder(object):
             mkdir(self.build_folder)
             self._conan_file.source_folder = self.source_folder
         else:
-            if platform.system() == "Windows" and os.getenv("CONAN_USER_HOME_SHORT") != "None":
-                from conans.util.windows import ignore_long_path_files
-                ignore = ignore_long_path_files(self.source_folder, self.build_folder, self._out)
-            else:
-                ignore = None
-
-            shutil.copytree(self.source_folder, self.build_folder, symlinks=True, ignore=ignore)
+            try:
+                shutil.copytree(self.source_folder, self.build_folder, symlinks=True)
+            except Exception as e:
+                msg = str(e)
+                msg += "\nConsider using short_paths=True if paths too long" if "206" in msg else ""
+                raise ConanException("%s\nError copying sources to build folder" % msg)
             logger.debug("BUILD: Copied to %s", self.build_folder)
             logger.debug("BUILD: Files copied %s", ",".join(os.listdir(self.build_folder)))
             self._conan_file.source_folder = self.build_folder

--- a/conans/client/installer.py
+++ b/conans/client/installer.py
@@ -93,7 +93,8 @@ class _ConanPackageBuilder(object):
                 shutil.copytree(self.source_folder, self.build_folder, symlinks=True)
             except Exception as e:
                 msg = str(e)
-                msg += "\nConsider using short_paths=True if paths too long" if "206" in msg else ""
+                if "[Error 206]" in msg:  # System error shutil.Error
+                    msg += "\nUse short_paths=True if paths too long"
                 raise ConanException("%s\nError copying sources to build folder" % msg)
             logger.debug("BUILD: Copied to %s", self.build_folder)
             logger.debug("BUILD: Files copied %s", ",".join(os.listdir(self.build_folder)))

--- a/conans/client/tools/files.py
+++ b/conans/client/tools/files.py
@@ -262,7 +262,8 @@ def replace_path_in_file(file_path, search, replace, strict=True, windows_paths=
     normalized_search = normalized_text(search)
     index = normalized_content.find(normalized_search)
     if index == -1:
-        return _manage_text_not_found(search, file_path, strict, "replace_path_in_file", output=output)
+        return _manage_text_not_found(search, file_path, strict, "replace_path_in_file",
+                                      output=output)
 
     while index != -1:
         content = content[:index] + replace + content[index + len(search):]
@@ -334,7 +335,8 @@ def which(filename):
         return None
 
     def _get_possible_filenames(filename):
-        extensions_win = os.getenv("PATHEXT", ".COM;.EXE;.BAT;.CMD").split(";") if "." not in filename else []
+        extensions_win = (os.getenv("PATHEXT", ".COM;.EXE;.BAT;.CMD").split(";")
+                          if "." not in filename else [])
         extensions = [".sh"] if platform.system() != "Windows" else extensions_win
         extensions.insert(1, "")  # No extension
         return ["%s%s" % (filename, entry.lower()) for entry in extensions]

--- a/conans/test/functional/old/path_limit_test.py
+++ b/conans/test/functional/old/path_limit_test.py
@@ -60,7 +60,7 @@ class PathLengthLimitTest(unittest.TestCase):
             """)
         client.save({"conanfile.py": conanfile})
         client.run("create . pkg/1.0@user/testing", assert_error=True)
-        self.assertIn("Consider using short_paths=True if paths too long", client.out)
+        self.assertIn("Use short_paths=True if paths too long", client.out)
         self.assertIn("Error copying sources to build folder", client.out)
 
     def remove_test(self):

--- a/conans/test/functional/old/path_limit_test.py
+++ b/conans/test/functional/old/path_limit_test.py
@@ -52,7 +52,7 @@ class PathLengthLimitTest(unittest.TestCase):
                 def source(self):
                     cwd = os.getcwd()
                     size = len(os.getcwd())
-                    sub = "a/"*((240-size)/2)
+                    sub = "a/"*(int((240-size)/2))
                     path = os.path.join(cwd, sub, "file.txt")
                     path = os.path.normpath(path)
                     save(path, "contents")

--- a/conans/test/functional/old/path_limit_test.py
+++ b/conans/test/functional/old/path_limit_test.py
@@ -8,6 +8,7 @@ from conans.model.ref import ConanFileReference, PackageReference
 from conans.test import CONAN_TEST_FOLDER
 from conans.test.utils.tools import NO_SETTINGS_PACKAGE_ID, TestClient, TestServer
 from conans.util.files import load
+from textwrap import dedent
 
 base = '''
 from conans import ConanFile
@@ -39,6 +40,28 @@ class ConanLib(ConanFile):
 
 
 class PathLengthLimitTest(unittest.TestCase):
+    @unittest.skipUnless(platform.system() == "Windows", "requires Win")
+    def failure_copy_test(self):
+        client = TestClient()
+        conanfile = dedent("""
+            from conans import ConanFile
+            from conans.tools import save
+            import os
+
+            class ConanLib(ConanFile):
+                def source(self):
+                    cwd = os.getcwd()
+                    size = len(os.getcwd())
+                    sub = "a/"*((240-size)/2)
+                    path = os.path.join(cwd, sub, "file.txt")
+                    path = os.path.normpath(path)
+                    save(path, "contents")
+
+            """)
+        client.save({"conanfile.py": conanfile})
+        client.run("create . pkg/1.0@user/testing", assert_error=True)
+        self.assertIn("Consider using short_paths=True if paths too long", client.out)
+        self.assertIn("Error copying sources to build folder", client.out)
 
     def remove_test(self):
         short_home = tempfile.mkdtemp(dir=CONAN_TEST_FOLDER)

--- a/conans/util/windows.py
+++ b/conans/util/windows.py
@@ -89,23 +89,6 @@ def path_shortener(path, short_paths):
     return redirect
 
 
-def ignore_long_path_files(src_folder, build_folder, output):
-    def _filter(src, files):
-        filtered_files = []
-        for the_file in files:
-            source_path = os.path.join(src, the_file)
-            # Without storage path, just relative
-            rel_path = os.path.relpath(source_path, src_folder)
-            dest_path = os.path.normpath(os.path.join(build_folder, rel_path))
-            # it is NOT that "/" is counted as "\\" so it counts double
-            # seems a bug in python, overflows paths near the limit of 260,
-            if len(dest_path) >= 249:
-                filtered_files.append(the_file)
-                output.warn("Filename too long, file excluded: %s" % dest_path)
-        return filtered_files
-    return _filter
-
-
 def rm_conandir(path):
     """removal of a directory that might contain a link to a short path"""
     link = os.path.join(path, CONAN_LINK)


### PR DESCRIPTION
Changelog:  Bugfix: Raise an error if source files cannot be correctly copied to build folder because of long paths in Windows.
Docs: omit

Close #4484
