### PR TITLE
#4770 Do not force sudo when it is not found

### DIFF
--- a/conans/client/tools/system_pm.py
+++ b/conans/client/tools/system_pm.py
@@ -3,6 +3,7 @@ import sys
 
 from conans.client.runner import ConanRunner
 from conans.client.tools.oss import OSInfo
+from conans.client.tools.files import which
 from conans.errors import ConanException
 from conans.util.env_reader import get_env
 from conans.util.fallbacks import default_output
@@ -33,6 +34,8 @@ class SystemPackageTool(object):
     @staticmethod
     def _is_sudo_enabled():
         if "CONAN_SYSREQUIRES_SUDO" not in os.environ:
+            if not which("sudo"):
+                return False
             if os.name == 'posix' and os.geteuid() == 0:
                 return False
             if os.name == 'nt':

--- a/conans/test/unittests/util/tools_test.py
+++ b/conans/test/unittests/util/tools_test.py
@@ -56,6 +56,14 @@ class SystemPackageToolTest(unittest.TestCase):
             with mock.patch("sys.stdout.isatty", return_value=True):
                 self.assertEqual(SystemPackageTool._get_sudo_str(), "sudo ")
 
+    def test_system_without_sudo(self):
+        with mock.patch("os.path.isfile", return_value=False):
+            self.assertFalse(SystemPackageTool._is_sudo_enabled())
+            self.assertEqual(SystemPackageTool._get_sudo_str(), "")
+
+            with mock.patch("sys.stdout.isatty", return_value=True):
+                self.assertEqual(SystemPackageTool._get_sudo_str(), "")
+
     def verify_update_test(self):
         # https://github.com/conan-io/conan/issues/3142
         with tools.environment_append({"CONAN_SYSREQUIRES_SUDO": "False",


### PR DESCRIPTION
When CONAN_SYSREQUIRES_SUDO is not specified and sudo is not listed by `tool.which`, SystemPackageTools should not set sudo as prefix.

Changelog: Fix: SystemPackageTools doesn't run sudo when it's not found (#4470)
Docs: https://github.com/conan-io/docs/pull/1127
fixes: #4770

- [x] Refer to the issue that supports this Pull Request.
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [x] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 

<sup>**Note:** By default this PR will skip the slower tests and will use a limited set of python versions. Check [here](https://github.com/conan-io/conan/blob/develop/.github/PR_INCREASE_TESTING.md) how to increase the testing level by writing some tags in the current PR body text.</sup>
