### PR TITLE
Add output argument to 'vcvars_command' call from Meson helper

### DIFF
--- a/conans/client/build/meson.py
+++ b/conans/client/build/meson.py
@@ -156,7 +156,8 @@ class Meson(object):
 
     def _append_vs_if_needed(self, command):
         if self._compiler == "Visual Studio" and self.backend == "ninja":
-            command = "%s && %s" % (tools.vcvars_command(self._conanfile.settings), command)
+            vcvars = tools.vcvars_command(self._conanfile.settings, output=self._conanfile.output)
+            command = "%s && %s" % (vcvars, command)
         return command
 
     def build(self, args=None, build_dir=None, targets=None):


### PR DESCRIPTION
Changelog: omit
Docs: omit

Add `output` argument to `vcvars_command` call to avoid warning (and error in CI, [preflight is broken](https://conan-ci.jfrog.info/blue/organizations/jenkins/Preflight_develop/detail/Preflight_develop/143/pipeline))