### PR TITLE
Bug with install update with build mode outdated

### DIFF
--- a/conans/client/graph/graph_binaries.py
+++ b/conans/client/graph/graph_binaries.py
@@ -103,7 +103,7 @@ class GraphBinariesAnalyzer(object):
                             node.prev = pref.revision  # With revision
                             if build_mode.outdated:
                                 info, pref = self._remote_manager.get_package_info(pref, remote)
-                                package_hash = info.recipe_hash()
+                                package_hash = info.recipe_hash
                 elif remotes:
                     pass
                 else:

--- a/conans/test/integration/install_outdated_test.py
+++ b/conans/test/integration/install_outdated_test.py
@@ -1,8 +1,10 @@
+import time
 import unittest
+from collections import OrderedDict
 
 from conans.model.ref import ConanFileReference
 from conans.test.utils.cpp_test_files import cpp_hello_conan_files
-from conans.test.utils.tools import TestClient, TestServer
+from conans.test.utils.tools import TestClient, TestServer, TurboTestClient, GenConanfile
 from conans.util.env_reader import get_env
 from conans.util.files import rmdir
 
@@ -126,3 +128,23 @@ class InstallOutdatedPackagesTest(unittest.TestCase):
         self.assertIn("Downloading conan_package.tgz", new_client.user_io.out)
         self.assertIn("Hello1/0.1@lasote/stable: WARN: Forced build from source",
                       new_client.user_io.out)
+
+    def install_outdated_checking_updates_test(self):
+        server = TestServer()
+        servers = OrderedDict([("default", server)])
+        client = TurboTestClient(servers=servers)
+        client2 = TurboTestClient(servers=servers)
+
+        ref = ConanFileReference.loads("lib/1.0@conan/testing")
+        client.create(ref)
+        client.upload_all(ref)
+
+        # Generate a new recipe, the binary becomes outdated
+        time.sleep(1)
+        client2.create(ref, conanfile=GenConanfile().with_build_msg("Some modified stuff"))
+        client2.run("upload {} -r default".format(ref))
+
+        # Update, building the outdated
+        client.run("install -u -b outdated {}".format(ref))
+        # The outdated is built
+        self.assertIn("Some modified stuff", client.out)


### PR DESCRIPTION
Changelog: Bugfix: Installing a reference with "update" and "build outdated" options raised an exception.
Docs: omit

@REVISIONS: 1

Close #4789