### PR TITLE
Look for vswhere in PATH when using tools.vswhere()

### DIFF
--- a/conans/client/tools/win.py
+++ b/conans/client/tools/win.py
@@ -251,13 +251,15 @@ def vswhere(all_=False, prerelease=False, products=None, requires=None, version=
         raise ConanException("The 'legacy' parameter cannot be specified with either the "
                              "'products' or 'requires' parameter")
 
+    installer_path = None
+    vswhere_in_path = which("vswhere")
     program_files = get_env("ProgramFiles(x86)") or get_env("ProgramFiles")
-
     if program_files:
-        vswhere_path = os.path.join(program_files, "Microsoft Visual Studio", "Installer",
-                                    "vswhere.exe")
-    else:
-        vswhere_path = which("vswhere")
+        expected_path = os.path.join(program_files, "Microsoft Visual Studio", "Installer",
+                                     "vswhere.exe")
+        if os.path.isfile(expected_path):
+            installer_path = expected_path
+    vswhere_path = installer_path or vswhere_in_path
 
     if not vswhere_path:
         raise ConanException("Cannot locate vswhere in 'Program Files'/'Program Files (x86)' "

--- a/conans/client/tools/win.py
+++ b/conans/client/tools/win.py
@@ -7,6 +7,7 @@ from contextlib import contextmanager
 
 import deprecation
 
+from conans.client.tools import which
 from conans.client.tools.env import environment_append
 from conans.client.tools.oss import OSInfo, detected_architecture
 from conans.errors import ConanException
@@ -250,15 +251,17 @@ def vswhere(all_=False, prerelease=False, products=None, requires=None, version=
         raise ConanException("The 'legacy' parameter cannot be specified with either the "
                              "'products' or 'requires' parameter")
 
-    program_files = os.environ.get("ProgramFiles(x86)", os.environ.get("ProgramFiles"))
+    program_files = get_env("ProgramFiles(x86)") or get_env("ProgramFiles")
 
     if program_files:
         vswhere_path = os.path.join(program_files, "Microsoft Visual Studio", "Installer",
                                     "vswhere.exe")
-        if not os.path.isfile(vswhere_path):
-            raise ConanException("Cannot locate 'vswhere'")
     else:
-        raise ConanException("Cannot locate 'Program Files'/'Program Files (x86)' directory")
+        vswhere_path = which("vswhere")
+
+    if not vswhere_path:
+        raise ConanException("Cannot locate vswhere in 'Program Files'/'Program Files (x86)' "
+                             "directory nor in PATH")
 
     arguments = list()
     arguments.append(vswhere_path)

--- a/conans/test/unittests/util/tools_test.py
+++ b/conans/test/unittests/util/tools_test.py
@@ -801,7 +801,7 @@ class HelloConan(ConanFile):
         with tools.environment_append({"ProgramFiles": None, "ProgramFiles(x86)": None, "PATH": ""}):
             with self.assertRaisesRegex(ConanException, "Cannot locate vswhere"):
                 vswhere()
-
+        # vswhere in ProgramFiles
         program_files = get_env("ProgramFiles(x86)") or get_env("ProgramFiles")
         vswhere_path = None
         if program_files:
@@ -809,10 +809,8 @@ class HelloConan(ConanFile):
                                          "vswhere.exe")
             if os.path.isfile(expected_path):
                 vswhere_path = expected_path
-        # vswhere in ProgramFiles
-        if vswhere_path:
-            with tools.environment_append({"PATH": ""}):
-                self.assertTrue(vswhere())
+                with tools.environment_append({"PATH": ""}):
+                    self.assertTrue(vswhere())
         # vswhere in PATH
         env = {"ProgramFiles": None, "ProgramFiles(x86)": None}
         if not which("vswhere") and vswhere_path:

--- a/conans/test/unittests/util/tools_test.py
+++ b/conans/test/unittests/util/tools_test.py
@@ -37,6 +37,7 @@ from conans.test.utils.test_files import temp_folder
 from conans.test.utils.tools import SVNLocalRepoTestCase, StoppableThreadBottle, \
     TestBufferConanOutput, TestClient, create_local_git_repo, try_remove_readonly
 from conans.tools import get_global_instances
+from conans.util.env_reader import get_env
 from conans.util.files import load, md5, mkdir, save
 
 
@@ -793,6 +794,31 @@ class HelloConan(ConanFile):
         with patch('conans.client.tools.win.subprocess', myrunner):
             json = vswhere()
             self.assertNotIn("descripton", json)
+
+    @unittest.skipUnless(platform.system() == "Windows", "Requires vswhere")
+    def vswhere_path_test(self):
+        # vswhere not found
+        with tools.environment_append({"ProgramFiles": None, "ProgramFiles(x86)": None,
+                                       "PATH": ""}):
+            with self.assertRaisesRegex(ConanException, "Cannot locate vswhere"):
+                vswhere()
+
+        program_files = get_env("ProgramFiles(x86)") or get_env("ProgramFiles")
+        vswhere_path = None
+        if program_files:
+            vswhere_path = os.path.join(program_files, "Microsoft Visual Studio", "Installer",
+                                        "vswhere.exe")
+        # vswhere in ProramFiles
+        if vswhere_path:
+            with tools.environment_append({"PATH": ""}):
+                self.assertTrue(vswhere())
+        # vswhere in PATH
+        env = {"ProgramFiles": None, "ProgramFiles(x86)": None}
+        if not which("vswhere") and vswhere_path:
+                vswhere_folder = os.path.join(program_files, "Microsoft Visual Studio", "Installer")
+                env.update({"PATH": [vswhere_folder]})
+        with tools.environment_append(env):
+            self.assertTrue(vswhere())
 
     def vcvars_echo_test(self):
         if platform.system() != "Windows":

--- a/conans/test/unittests/util/tools_test.py
+++ b/conans/test/unittests/util/tools_test.py
@@ -798,17 +798,18 @@ class HelloConan(ConanFile):
     @unittest.skipUnless(platform.system() == "Windows", "Requires vswhere")
     def vswhere_path_test(self):
         # vswhere not found
-        with tools.environment_append({"ProgramFiles": None, "ProgramFiles(x86)": None,
-                                       "PATH": ""}):
+        with tools.environment_append({"ProgramFiles": None, "ProgramFiles(x86)": None, "PATH": ""}):
             with self.assertRaisesRegex(ConanException, "Cannot locate vswhere"):
                 vswhere()
 
         program_files = get_env("ProgramFiles(x86)") or get_env("ProgramFiles")
         vswhere_path = None
         if program_files:
-            vswhere_path = os.path.join(program_files, "Microsoft Visual Studio", "Installer",
-                                        "vswhere.exe")
-        # vswhere in ProramFiles
+            expected_path = os.path.join(program_files, "Microsoft Visual Studio", "Installer",
+                                         "vswhere.exe")
+            if os.path.isfile(expected_path):
+                vswhere_path = expected_path
+        # vswhere in ProgramFiles
         if vswhere_path:
             with tools.environment_append({"PATH": ""}):
                 self.assertTrue(vswhere())


### PR DESCRIPTION
Changelog: Fix: Look for ``vswhere`` in ``PATH`` when using ``tools.vswhere()``
Docs: omit

- [x] Refer to the issue that supports this Pull Request: closes #4786
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [x] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 

<sup>**Note:** By default this PR will skip the slower tests and will use a limited set of python versions. Check [here](https://github.com/conan-io/conan/blob/develop/.github/PR_INCREASE_TESTING.md) how to increase the testing level by writing some tags in the current PR body text.</sup>
