### PR TITLE
workspaces templates change to allow out-of-source builds

### DIFF
--- a/conans/test/functional/workspace/workspace_test.py
+++ b/conans/test/functional/workspace/workspace_test.py
@@ -98,7 +98,7 @@ class WorkspaceTest(unittest.TestCase):
         project = "root: Hellob/0.1@lasote/stable"
         save(path, project)
         with six.assertRaisesRegex(self, ConanException,
-                                     "Root Hellob/0.1@lasote/stable is not defined as editable"):
+                                   "Root Hellob/0.1@lasote/stable is not defined as editable"):
             Workspace(path, None)
 
         project = dedent("""
@@ -111,7 +111,7 @@ class WorkspaceTest(unittest.TestCase):
         save(path, project)
 
         with six.assertRaisesRegex(self, ConanException,
-                                     "Workspace unrecognized fields: {'random': 'something'}"):
+                                   "Workspace unrecognized fields: {'random': 'something'}"):
             Workspace(path, None)
 
         project = dedent("""
@@ -124,7 +124,7 @@ class WorkspaceTest(unittest.TestCase):
         save(path, project)
 
         with six.assertRaisesRegex(self, ConanException,
-                                     "Workspace unrecognized fields: {'random': 'something'}"):
+                                   "Workspace unrecognized fields: {'random': 'something'}"):
             Workspace(path, None)
 
         project = dedent("""
@@ -135,8 +135,8 @@ class WorkspaceTest(unittest.TestCase):
         save(path, project)
 
         with six.assertRaisesRegex(self, ConanException,
-                                     "Workspace editable HelloB/0.1@lasote/stable "
-                                     "does not define path"):
+                                   "Workspace editable HelloB/0.1@lasote/stable "
+                                   "does not define path"):
             Workspace(path, None)
 
         project = dedent("""
@@ -148,8 +148,8 @@ class WorkspaceTest(unittest.TestCase):
         save(path, project)
 
         with six.assertRaisesRegex(self, ConanException,
-                                     "Workspace editable HelloB/0.1@lasote/stable "
-                                     "does not define path"):
+                                   "Workspace editable HelloB/0.1@lasote/stable "
+                                   "does not define path"):
             Workspace(path, None)
 
     def simple_test(self):
@@ -374,6 +374,79 @@ class WorkspaceTest(unittest.TestCase):
         client.run("build C -bf=C/build/%s" % build_type)
         client.run("build B -bf=B/build/%s" % build_type)
         client.run("build A -bf=A/build/%s" % build_type)
+
+        client.runner(cmd_debug, cwd=client.current_folder)
+        self.assertIn("Hello World C Debug!", client.out)
+        self.assertIn("Hello World B Debug!", client.out)
+        self.assertIn("Hello World A Debug!", client.out)
+
+    def simple_out_of_source_build_test(self):
+        client = TestClient()
+
+        def files(name, depend=None):
+            includes = ('#include "hello%s.h"' % depend) if depend else ""
+            calls = ('hello%s();' % depend) if depend else ""
+            deps = ('"Hello%s/0.1@lasote/stable"' % depend) if depend else "None"
+            return {"conanfile.py": conanfile_build.format(deps=deps, name=name),
+                    "src/hello%s.h" % name: hello_h.format(name=name),
+                    "src/hello.cpp": hello_cpp.format(name=name, includes=includes, calls=calls),
+                    "src/CMakeLists.txt": cmake.format(name=name)}
+
+        client.save(files("C"), path=os.path.join(client.current_folder, "HelloC"))
+        client.save(files("B", "C"), path=os.path.join(client.current_folder, "HelloB"))
+        a = files("A", "B")
+        a["src/CMakeLists.txt"] += ("add_executable(app main.cpp)\n"
+                                    "target_link_libraries(app helloA)\n")
+        a["src/main.cpp"] = main_cpp
+        client.save(a, path=os.path.join(client.current_folder, "HelloA"))
+
+        project = dedent("""
+            editables:
+                HelloB/0.1@lasote/stable:
+                    path: HelloB
+                HelloC/0.1@lasote/stable:
+                    path: HelloC
+                HelloA/0.1@lasote/stable:
+                    path: HelloA
+            layout: layout
+            root: HelloA/0.1@lasote/stable
+            """)
+        layout = dedent("""
+            [build_folder]
+            ../build/{{reference.name}}/{{settings.build_type}}
+
+            [includedirs]
+            src
+
+            [libdirs]
+            ../build/{{reference.name}}/{{settings.build_type}}/lib
+            """)
+
+        client.save({"conanws.yml": project,
+                     "layout": layout})
+        client.run("workspace install conanws.yml")
+        client.run("workspace install conanws.yml -s build_type=Debug")
+        self.assertIn("HelloA/0.1@lasote/stable from user folder - Editable", client.out)
+        self.assertIn("HelloB/0.1@lasote/stable from user folder - Editable", client.out)
+        self.assertIn("HelloC/0.1@lasote/stable from user folder - Editable", client.out)
+
+        build_type = "Release"
+        client.run("build HelloC -bf=build/HelloC/%s" % build_type)
+        client.run("build HelloB -bf=build/HelloB/%s" % build_type)
+        client.run("build HelloA -bf=build/HelloA/%s" % build_type)
+
+        cmd_release = os.path.normpath("./build/HelloA/Release/bin/app")
+        cmd_debug = os.path.normpath("./build/HelloA/Debug/bin/app")
+
+        client.runner(cmd_release, cwd=client.current_folder)
+        self.assertIn("Hello World C Release!", client.out)
+        self.assertIn("Hello World B Release!", client.out)
+        self.assertIn("Hello World A Release!", client.out)
+
+        build_type = "Debug"
+        client.run("build HelloC -bf=build/HelloC/%s" % build_type)
+        client.run("build HelloB -bf=build/HelloB/%s" % build_type)
+        client.run("build HelloA -bf=build/HelloA/%s" % build_type)
 
         client.runner(cmd_debug, cwd=client.current_folder)
         self.assertIn("Hello World C Debug!", client.out)

--- a/conans/util/templates.py
+++ b/conans/util/templates.py
@@ -5,4 +5,4 @@ from jinja2 import Template
 
 def render_layout_file(content, ref=None, settings=None, options=None):
     t = Template(content)
-    return t.render(reference=str(ref), settings=settings, options=options)
+    return t.render(reference=ref, settings=settings, options=options)


### PR DESCRIPTION
Changelog: Fix: Allow using ``reference`` object in workspaces in templates for out of source builds
Docs: https://github.com/conan-io/docs/pull/XXXX

Close #4800

The key is allowing:

```
[build_folder]
../build/{{reference.name}}/{{settings.build_type}}
```

@tags: slow
