### PR TITLE
hotfix: graph fails if a package has several licenses

### DIFF
--- a/conans/client/graph/grapher.py
+++ b/conans/client/graph/grapher.py
@@ -63,6 +63,8 @@ class ConanHTMLGrapher(object):
                                ("author", conanfile.author),
                                ("topics", str(conanfile.topics))]:
                 if data:
+                    if isinstance(data, (tuple, list)):
+                        data = ', '.join(data)
                     data = data.replace("'", '"')
                     fulllabel.append("<li><b>%s</b>: %s</li>" % (name, data))
 

--- a/conans/test/functional/configuration/client_certs_test.py
+++ b/conans/test/functional/configuration/client_certs_test.py
@@ -29,7 +29,7 @@ class ClientCertsTest(unittest.TestCase):
         tools.save(client.cache.client_cert_key_path, "Fake key")
         client.init_dynamic_vars()
         self.assertEqual(client.requester.get("url"), (client.cache.client_cert_path,
-                                                        client.cache.client_cert_key_path))
+                                                       client.cache.client_cert_key_path))
 
         # assert that the cacert file is created
         self.assertTrue(os.path.exists(client.cache.cacert_path))


### PR DESCRIPTION
Changelog: omit
Docs: omit

If a package has several licenses like [rapidxml](https://github.com/bincrafters/conan-rapidxml/blob/stable/1.13/conanfile.py#L15), graph code fails in the `data.replace`.

```python

class RapiXMLConan(ConanFile):
    name = "rapidxml"
    version = "1.13"
    description = "RapidXml is an attempt to create the fastest XML parser possible"
    url = "https://github.com/bincrafters/conan-rapidxml"
    homepage = "http://rapidxml.sourceforge.net"
    author = "Bincrafters <bincrafters@gmail.com>"

    license = ("BSL-1.0", "MIT")

    exports = ["LICENSE.md"]
    exports_sources = ["CMakeLists.txt"]
    source_subfolder = "source_subfolder"
    no_copy_source = True


```