### PR TITLE
Show profile name when detect a new one (#4818)

### DIFF
--- a/conans/client/cache/cache.py
+++ b/conans/client/cache/cache.py
@@ -191,7 +191,7 @@ class ClientCache(SimplePaths):
                                  "default profile (%s)" % self.default_profile_path,
                                  Color.BRIGHT_YELLOW)
 
-            default_settings = detect_defaults_settings(self._output, "default", self.default_profile_path)
+            default_settings = detect_defaults_settings(self._output, os.path.join(self.default_profile_path, "default"))
             self._output.writeln("Default settings", Color.BRIGHT_YELLOW)
             self._output.writeln("\n".join(["\t%s=%s" % (k, v) for (k, v) in default_settings]),
                                  Color.BRIGHT_YELLOW)

--- a/conans/client/cache/cache.py
+++ b/conans/client/cache/cache.py
@@ -191,7 +191,7 @@ class ClientCache(SimplePaths):
                                  "default profile (%s)" % self.default_profile_path,
                                  Color.BRIGHT_YELLOW)
 
-            default_settings = detect_defaults_settings(self._output)
+            default_settings = detect_defaults_settings(self._output, "default", self.default_profile_path)
             self._output.writeln("Default settings", Color.BRIGHT_YELLOW)
             self._output.writeln("\n".join(["\t%s=%s" % (k, v) for (k, v) in default_settings]),
                                  Color.BRIGHT_YELLOW)

--- a/conans/client/cache/cache.py
+++ b/conans/client/cache/cache.py
@@ -191,7 +191,7 @@ class ClientCache(SimplePaths):
                                  "default profile (%s)" % self.default_profile_path,
                                  Color.BRIGHT_YELLOW)
 
-            default_settings = detect_defaults_settings(self._output, os.path.join(self.default_profile_path, "default"))
+            default_settings = detect_defaults_settings(self._output, profile_path=self.default_profile_path)
             self._output.writeln("Default settings", Color.BRIGHT_YELLOW)
             self._output.writeln("\n".join(["\t%s=%s" % (k, v) for (k, v) in default_settings]),
                                  Color.BRIGHT_YELLOW)

--- a/conans/client/cmd/profile.py
+++ b/conans/client/cmd/profile.py
@@ -43,7 +43,7 @@ def cmd_profile_create(profile_name, cache_profiles_path, output, detect=False):
 
     profile = Profile()
     if detect:
-        settings = detect_defaults_settings(output, profile_name, cache_profiles_path)
+        settings = detect_defaults_settings(output, profile_path)
         for name, value in settings:
             profile.settings[name] = value
 

--- a/conans/client/cmd/profile.py
+++ b/conans/client/cmd/profile.py
@@ -43,7 +43,7 @@ def cmd_profile_create(profile_name, cache_profiles_path, output, detect=False):
 
     profile = Profile()
     if detect:
-        settings = detect_defaults_settings(output, profile_name)
+        settings = detect_defaults_settings(output, profile_name, cache_profiles_path)
         for name, value in settings:
             profile.settings[name] = value
 

--- a/conans/client/cmd/profile.py
+++ b/conans/client/cmd/profile.py
@@ -43,7 +43,7 @@ def cmd_profile_create(profile_name, cache_profiles_path, output, detect=False):
 
     profile = Profile()
     if detect:
-        settings = detect_defaults_settings(output)
+        settings = detect_defaults_settings(output, profile_name)
         for name, value in settings:
             profile.settings[name] = value
 

--- a/conans/client/conf/detect.py
+++ b/conans/client/conf/detect.py
@@ -125,7 +125,7 @@ def _get_default_compiler(output):
         return gcc or clang
 
 
-def _detect_compiler_version(result, output, profile_name, profiles_path):
+def _detect_compiler_version(result, output, profile_path):
     try:
         compiler, version = _get_default_compiler(output)
     except:
@@ -140,17 +140,7 @@ def _detect_compiler_version(result, output, profile_name, profiles_path):
         elif compiler == "gcc":
             result.append(("compiler.libcxx", "libstdc++"))
             if Version(version) >= Version("5.1"):
-                # profile name is only the profile name
-                if profile_name == os.path.basename(profile_name):
-                    profile_path = os.path.join(profiles_path, profile_name)
-                # profile name is an absolute path
-                elif os.path.isabs(profile_name):
-                    profile_path = profile_name
-                    profile_name = os.path.basename(profile_name)
-                # profile name is a relative path
-                else:
-                    profile_path = os.path.abspath(profile_name)
-                    profile_name = os.path.basename(profile_name)
+                profile_name = os.path.basename(profile_path)
                 msg = """
 Conan detected a GCC version > 5 but has adjusted the 'compiler.libcxx' setting to
 'libstdc++' for backwards compatibility.
@@ -203,16 +193,15 @@ def _detect_os_arch(result, output):
         result.append(("arch_build", arch))
 
 
-def detect_defaults_settings(output, profile_name="default", profiles_path="~/.conan/profiles"):
+def detect_defaults_settings(output, profile_path):
     """ try to deduce current machine values without any constraints at all
     :param output: Conan Output instance
-    :param profile_name: Conan profile name to be showed
-    :param profiles_path: Conan profiles folder
+    :param profile_path: Conan profile file path
     :return: A list with default settings
     """
     result = []
     _detect_os_arch(result, output)
-    _detect_compiler_version(result, output, profile_name, profiles_path)
+    _detect_compiler_version(result, output, profile_path)
     result.append(("build_type", "Release"))
 
     return result

--- a/conans/client/conf/detect.py
+++ b/conans/client/conf/detect.py
@@ -125,7 +125,7 @@ def _get_default_compiler(output):
         return gcc or clang
 
 
-def _detect_compiler_version(result, output):
+def _detect_compiler_version(result, output, profile_name):
     try:
         compiler, version = _get_default_compiler(output)
     except:
@@ -146,12 +146,12 @@ Conan detected a GCC version > 5 but has adjusted the 'compiler.libcxx' setting 
 'libstdc++' for backwards compatibility.
 Your compiler is likely using the new CXX11 ABI by default (libstdc++11).
 
-If you want Conan to use the new ABI, edit the default profile at:
+If you want Conan to use the new ABI, edit the {profile} profile at:
 
-    ~/.conan/profiles/default
+    ~/.conan/profiles/{profile}
 
 adjusting 'compiler.libcxx=libstdc++11'
-"""
+""".format(profile=profile_name)
                 output.writeln("\n************************* WARNING: GCC OLD ABI COMPATIBILITY "
                                "***********************\n %s\n************************************"
                                "************************************************\n\n\n" % msg,
@@ -193,12 +193,15 @@ def _detect_os_arch(result, output):
         result.append(("arch_build", arch))
 
 
-def detect_defaults_settings(output):
+def detect_defaults_settings(output, profile_name="default"):
     """ try to deduce current machine values without any constraints at all
+    :param output: Conan Output instance
+    :param profile_name: Conan profile name to be showed
+    :return: A list with default settings
     """
     result = []
     _detect_os_arch(result, output)
-    _detect_compiler_version(result, output)
+    _detect_compiler_version(result, output, profile_name)
     result.append(("build_type", "Release"))
 
     return result

--- a/conans/client/conf/detect.py
+++ b/conans/client/conf/detect.py
@@ -1,6 +1,7 @@
 import os
 import platform
 import re
+import ntpath
 from subprocess import PIPE, Popen, STDOUT
 
 from conans.client.output import Color
@@ -140,7 +141,7 @@ def _detect_compiler_version(result, output, profile_name):
         elif compiler == "gcc":
             result.append(("compiler.libcxx", "libstdc++"))
             if Version(version) >= Version("5.1"):
-
+                profile_name = ntpath.basename(profile_name)
                 msg = """
 Conan detected a GCC version > 5 but has adjusted the 'compiler.libcxx' setting to
 'libstdc++' for backwards compatibility.

--- a/conans/test/functional/command/profile_test.py
+++ b/conans/test/functional/command/profile_test.py
@@ -12,6 +12,8 @@ class ProfileTest(unittest.TestCase):
     def reuse_output_test(self):
         client = TestClient()
         client.run("profile new myprofile --detect")
+        self.assertIn("edit the myprofile profile at", client.out)
+        self.assertIn("profiles/myprofile", client.out)
         client.run("profile update options.Pkg:myoption=123 myprofile")
         client.run("profile update env.Pkg2:myenv=123 myprofile")
         client.run("profile show myprofile")
@@ -69,6 +71,8 @@ class ProfileTest(unittest.TestCase):
     def profile_update_and_get_test(self):
         client = TestClient()
         client.run("profile new ./MyProfile --detect")
+        self.assertIn("edit the ./MyProfile profile at", client.out)
+        self.assertIn("profiles/./MyProfile", client.out)
         pr_path = os.path.join(client.current_folder, "MyProfile")
 
         client.run("profile update settings.os=FakeOS ./MyProfile")

--- a/conans/test/functional/command/profile_test.py
+++ b/conans/test/functional/command/profile_test.py
@@ -76,7 +76,7 @@ class ProfileTest(unittest.TestCase):
         client.run("profile new ./MyProfile --detect")
         if "WARNING: GCC OLD ABI COMPATIBILITY" in client.out:
             self.assertIn("edit the MyProfile profile at", client.out)
-            self.assertIn("profiles/MyProfile", client.out)
+            self.assertIn(os.path.join(client.current_folder, "MyProfile"), client.out)
 
         pr_path = os.path.join(client.current_folder, "MyProfile")
 

--- a/conans/test/functional/command/profile_test.py
+++ b/conans/test/functional/command/profile_test.py
@@ -12,8 +12,11 @@ class ProfileTest(unittest.TestCase):
     def reuse_output_test(self):
         client = TestClient()
         client.run("profile new myprofile --detect")
-        self.assertIn("edit the myprofile profile at", client.out)
-        self.assertIn("profiles/myprofile", client.out)
+
+        if "WARNING: GCC OLD ABI COMPATIBILITY" in client.out:
+            self.assertIn("edit the myprofile profile at", client.out)
+            self.assertIn("profiles/myprofile", client.out)
+
         client.run("profile update options.Pkg:myoption=123 myprofile")
         client.run("profile update env.Pkg2:myenv=123 myprofile")
         client.run("profile show myprofile")
@@ -71,8 +74,10 @@ class ProfileTest(unittest.TestCase):
     def profile_update_and_get_test(self):
         client = TestClient()
         client.run("profile new ./MyProfile --detect")
-        self.assertIn("edit the ./MyProfile profile at", client.out)
-        self.assertIn("profiles/./MyProfile", client.out)
+        if "WARNING: GCC OLD ABI COMPATIBILITY" in client.out:
+            self.assertIn("edit the ./MyProfile profile at", client.out)
+            self.assertIn("profiles/./MyProfile", client.out)
+
         pr_path = os.path.join(client.current_folder, "MyProfile")
 
         client.run("profile update settings.os=FakeOS ./MyProfile")

--- a/conans/test/functional/command/profile_test.py
+++ b/conans/test/functional/command/profile_test.py
@@ -75,8 +75,8 @@ class ProfileTest(unittest.TestCase):
         client = TestClient()
         client.run("profile new ./MyProfile --detect")
         if "WARNING: GCC OLD ABI COMPATIBILITY" in client.out:
-            self.assertIn("edit the ./MyProfile profile at", client.out)
-            self.assertIn("profiles/./MyProfile", client.out)
+            self.assertIn("edit the MyProfile profile at", client.out)
+            self.assertIn("profiles/MyProfile", client.out)
 
         pr_path = os.path.join(client.current_folder, "MyProfile")
 

--- a/conans/test/integration/conf_default_settings_test.py
+++ b/conans/test/integration/conf_default_settings_test.py
@@ -53,7 +53,7 @@ os=Windows
         out = MockOut()
         cache = ClientCache(tmp_dir, None, out)
 
-        base_settings = OrderedDict(detect_defaults_settings(out))
+        base_settings = OrderedDict(detect_defaults_settings(out, profile_path="~/.conan/profiles/default"))
 
         with tools.environment_append({"CONAN_ENV_COMPILER_VERSION": "4.6"}):
             expected = copy.copy(base_settings)

--- a/conans/test/unittests/util/detect_test.py
+++ b/conans/test/unittests/util/detect_test.py
@@ -24,6 +24,8 @@ class DetectTest(unittest.TestCase):
         platform_compiler = platform_default_compilers.get(platform.system(), None)
         if platform_compiler is not None:
             self.assertEqual(result.get("compiler", None), platform_compiler)
+            self.assertIn("edit the default profile at", output)
+            self.assertIn("profiles/default", output)
 
     def detect_default_in_mac_os_using_gcc_as_default_test(self):
         """
@@ -60,3 +62,19 @@ class DetectTest(unittest.TestCase):
         result = dict(result)
         self.assertTrue("arch" not in result)
         self.assertTrue("arch_build" not in result)
+
+    def detect_custom_profile_test(self):
+        platform_default_compilers = {
+            "Linux": "gcc",
+            "Darwin": "apple-clang",
+            "Windows": "Visual Studio"
+        }
+        output = TestBufferConanOutput()
+        result = detect_defaults_settings(output, profile_name="mycustomprofile")
+        # result is a list of tuples (name, value) so converting it to dict
+        result = dict(result)
+        platform_compiler = platform_default_compilers.get(platform.system(), None)
+        if platform_compiler is not None:
+            self.assertEqual(result.get("compiler", None), platform_compiler)
+            self.assertIn("edit the mycustomprofile profile at", output)
+            self.assertIn("profiles/mycustomprofile", output)

--- a/conans/test/unittests/util/detect_test.py
+++ b/conans/test/unittests/util/detect_test.py
@@ -76,3 +76,11 @@ class DetectTest(unittest.TestCase):
             detect_defaults_settings(output)
             self.assertIn("edit the default profile at", output)
             self.assertIn("profiles/default", output)
+
+    @mock.patch("conans.client.conf.detect._gcc_compiler", return_value=("gcc", "8"))
+    def detect_file_profile_test(self, _):
+        output = TestBufferConanOutput()
+        with tools.environment_append({"CC": "gcc"}):
+            detect_defaults_settings(output, profile_name="./MyProfile")
+            self.assertIn("edit the MyProfile profile at", output)
+            self.assertIn("profiles/MyProfile", output)

--- a/conans/test/unittests/util/detect_test.py
+++ b/conans/test/unittests/util/detect_test.py
@@ -1,3 +1,4 @@
+import os
 import platform
 import subprocess
 import unittest
@@ -67,7 +68,7 @@ class DetectTest(unittest.TestCase):
         with tools.environment_append({"CC": "gcc"}):
             detect_defaults_settings(output, profile_name="mycustomprofile")
             self.assertIn("edit the mycustomprofile profile at", output)
-            self.assertIn("profiles/mycustomprofile", output)
+            self.assertIn(os.path.join("profiles", "mycustomprofile"), output)
 
     @mock.patch("conans.client.conf.detect._gcc_compiler", return_value=("gcc", "8"))
     def detect_default_profile_test(self, _):
@@ -75,7 +76,7 @@ class DetectTest(unittest.TestCase):
         with tools.environment_append({"CC": "gcc"}):
             detect_defaults_settings(output)
             self.assertIn("edit the default profile at", output)
-            self.assertIn("profiles/default", output)
+            self.assertIn(os.path.join("profiles", "default"), output)
 
     @mock.patch("conans.client.conf.detect._gcc_compiler", return_value=("gcc", "8"))
     def detect_file_profile_test(self, _):
@@ -83,4 +84,12 @@ class DetectTest(unittest.TestCase):
         with tools.environment_append({"CC": "gcc"}):
             detect_defaults_settings(output, profile_name="./MyProfile")
             self.assertIn("edit the MyProfile profile at", output)
-            self.assertIn("profiles/MyProfile", output)
+            self.assertIn(os.path.join(os.getcwd(), "MyProfile"), output)
+
+    @mock.patch("conans.client.conf.detect._gcc_compiler", return_value=("gcc", "8"))
+    def detect_abs_file_profile_test(self, _):
+        output = TestBufferConanOutput()
+        with tools.environment_append({"CC": "gcc"}):
+            detect_defaults_settings(output, profile_name="/foo/bar/quz/custom-profile")
+            self.assertIn("edit the custom-profile profile at", output)
+            self.assertIn("/foo/bar/quz/custom-profile", output)

--- a/conans/test/unittests/util/detect_test.py
+++ b/conans/test/unittests/util/detect_test.py
@@ -69,7 +69,7 @@ class DetectTest(unittest.TestCase):
         with tools.environment_append({"CC": "gcc"}):
             detect_defaults_settings(output, profile_path="~/.conan/profiles/mycustomprofile")
             self.assertIn("edit the mycustomprofile profile at", output)
-            self.assertIn(os.path.join("profiles", "mycustomprofile"), output)
+            self.assertIn("~/.conan/profiles/mycustomprofile", output)
 
     @mock.patch("conans.client.conf.detect._gcc_compiler", return_value=("gcc", "8"))
     def detect_default_profile_test(self, _):
@@ -77,7 +77,7 @@ class DetectTest(unittest.TestCase):
         with tools.environment_append({"CC": "gcc"}):
             detect_defaults_settings(output, profile_path="~/.conan/profiles/default")
             self.assertIn("edit the default profile at", output)
-            self.assertIn(os.path.join("profiles", "default"), output)
+            self.assertIn("~/.conan/profiles/default", output)
 
     @mock.patch("conans.client.conf.detect._gcc_compiler", return_value=("gcc", "8"))
     def detect_file_profile_test(self, _):

--- a/conans/test/unittests/util/detect_test.py
+++ b/conans/test/unittests/util/detect_test.py
@@ -7,6 +7,7 @@ from mock import mock
 
 from conans.client import tools
 from conans.client.conf.detect import detect_defaults_settings
+from conans.paths import DEFAULT_PROFILE_NAME
 from conans.test.utils.tools import TestBufferConanOutput
 
 
@@ -19,7 +20,7 @@ class DetectTest(unittest.TestCase):
             "Windows": "Visual Studio"
         }
         output = TestBufferConanOutput()
-        result = detect_defaults_settings(output)
+        result = detect_defaults_settings(output, profile_path=DEFAULT_PROFILE_NAME)
         # result is a list of tuples (name, value) so converting it to dict
         result = dict(result)
         platform_compiler = platform_default_compilers.get(platform.system(), None)
@@ -47,7 +48,7 @@ class DetectTest(unittest.TestCase):
 
         output = TestBufferConanOutput()
         with tools.environment_append({"CC": "gcc"}):
-            result = detect_defaults_settings(output)
+            result = detect_defaults_settings(output, profile_path=DEFAULT_PROFILE_NAME)
         # result is a list of tuples (name, value) so converting it to dict
         result = dict(result)
         # No compiler should be detected
@@ -57,7 +58,7 @@ class DetectTest(unittest.TestCase):
 
     @mock.patch("platform.machine", return_value="")
     def test_detect_empty_arch(self, _):
-        result = detect_defaults_settings(output=TestBufferConanOutput())
+        result = detect_defaults_settings(output=TestBufferConanOutput(), profile_path=DEFAULT_PROFILE_NAME)
         result = dict(result)
         self.assertTrue("arch" not in result)
         self.assertTrue("arch_build" not in result)
@@ -66,7 +67,7 @@ class DetectTest(unittest.TestCase):
     def detect_custom_profile_test(self, _):
         output = TestBufferConanOutput()
         with tools.environment_append({"CC": "gcc"}):
-            detect_defaults_settings(output, profile_name="mycustomprofile")
+            detect_defaults_settings(output, profile_path="~/.conan/profiles/mycustomprofile")
             self.assertIn("edit the mycustomprofile profile at", output)
             self.assertIn(os.path.join("profiles", "mycustomprofile"), output)
 
@@ -74,7 +75,7 @@ class DetectTest(unittest.TestCase):
     def detect_default_profile_test(self, _):
         output = TestBufferConanOutput()
         with tools.environment_append({"CC": "gcc"}):
-            detect_defaults_settings(output)
+            detect_defaults_settings(output, profile_path="~/.conan/profiles/default")
             self.assertIn("edit the default profile at", output)
             self.assertIn(os.path.join("profiles", "default"), output)
 
@@ -82,14 +83,14 @@ class DetectTest(unittest.TestCase):
     def detect_file_profile_test(self, _):
         output = TestBufferConanOutput()
         with tools.environment_append({"CC": "gcc"}):
-            detect_defaults_settings(output, profile_name="./MyProfile")
+            detect_defaults_settings(output, profile_path="./MyProfile")
             self.assertIn("edit the MyProfile profile at", output)
-            self.assertIn(os.path.join(os.getcwd(), "MyProfile"), output)
+            self.assertIn("./MyProfile", output)
 
     @mock.patch("conans.client.conf.detect._gcc_compiler", return_value=("gcc", "8"))
     def detect_abs_file_profile_test(self, _):
         output = TestBufferConanOutput()
         with tools.environment_append({"CC": "gcc"}):
-            detect_defaults_settings(output, profile_name="/foo/bar/quz/custom-profile")
+            detect_defaults_settings(output, profile_path="/foo/bar/quz/custom-profile")
             self.assertIn("edit the custom-profile profile at", output)
             self.assertIn("/foo/bar/quz/custom-profile", output)


### PR DESCRIPTION
The warning message will show the correct profile name instead of printing only "default".

Changelog: Fix: Show the correct profile name when detect a new one (#4818)
Docs: Omit

fixes #4818

- [x] Refer to the issue that supports this Pull Request.
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 

<sup>**Note:** By default this PR will skip the slower tests and will use a limited set of python versions. Check [here](https://github.com/conan-io/conan/blob/develop/.github/PR_INCREASE_TESTING.md) how to increase the testing level by writing some tags in the current PR body text.</sup>
