### PR TITLE
 Fix metadata not being updated for export-pkg --package-folder

### DIFF
--- a/conans/client/cmd/export_pkg.py
+++ b/conans/client/cmd/export_pkg.py
@@ -50,9 +50,9 @@ def export_pkg(cache, graph_manager, hook_manager, recorder, output,
         packager.create_package(conanfile, package_id, source_folder, build_folder,
                                 dest_package_folder, install_folder, hook_manager, conan_file_path,
                                 ref, local=True)
-        with cache.package_layout(ref).update_metadata() as metadata:
-            readed_manifest = FileTreeManifest.load(dest_package_folder)
-            metadata.packages[package_id].revision = readed_manifest.summary_hash
-            metadata.packages[package_id].recipe_revision = metadata.recipe.revision
+    with cache.package_layout(ref).update_metadata() as metadata:
+        readed_manifest = FileTreeManifest.load(dest_package_folder)
+        metadata.packages[package_id].revision = readed_manifest.summary_hash
+        metadata.packages[package_id].recipe_revision = metadata.recipe.revision
 
     recorder.package_exported(pref)

--- a/conans/test/functional/command/alias_test.py
+++ b/conans/test/functional/command/alias_test.py
@@ -511,18 +511,3 @@ class Pkg(ConanFile):
 
         t.run("inspect {} -a description".format(reference2))
         self.assertIn("description: None", t.out)  # The alias conanfile doesn't have description
-
-    def alias_short_paths_test(self):
-        client = TestClient()
-
-        client.run("new alias_copy_repro/1.0.0@user/testing")
-        conanfile_path = os.path.join(client.current_folder, "conanfile.py")
-        new_content = load(conanfile_path).replace("version = \"1.0.0\"",
-                                                   "version = \"1.0.0\"\n    short_paths = True")
-        client.save({"conanfile.py": new_content})
-        client.run("profile new default --detect")
-        client.run("profile update settings.build_type=Release default")
-        client.run("create . user/testing -s build_type=Debug")
-        client.run("alias alias_copy_repro/ALIAS@user/testing alias_copy_repro/1.0.0@user/testing")
-        client.run("copy --all alias_copy_repro/1.0.0@user/testing test/testing")
-        print(client.all_output)

--- a/conans/test/functional/command/alias_test.py
+++ b/conans/test/functional/command/alias_test.py
@@ -511,3 +511,18 @@ class Pkg(ConanFile):
 
         t.run("inspect {} -a description".format(reference2))
         self.assertIn("description: None", t.out)  # The alias conanfile doesn't have description
+
+    def alias_short_paths_test(self):
+        client = TestClient()
+
+        client.run("new alias_copy_repro/1.0.0@user/testing")
+        conanfile_path = os.path.join(client.current_folder, "conanfile.py")
+        new_content = load(conanfile_path).replace("version = \"1.0.0\"",
+                                                   "version = \"1.0.0\"\n    short_paths = True")
+        client.save({"conanfile.py": new_content})
+        client.run("profile new default --detect")
+        client.run("profile update settings.build_type=Release default")
+        client.run("create . user/testing -s build_type=Debug")
+        client.run("alias alias_copy_repro/ALIAS@user/testing alias_copy_repro/1.0.0@user/testing")
+        client.run("copy --all alias_copy_repro/1.0.0@user/testing test/testing")
+        print(client.all_output)

--- a/conans/test/functional/command/upload_test.py
+++ b/conans/test/functional/command/upload_test.py
@@ -577,7 +577,7 @@ class Pkg(ConanFile):
 
     def upload_export_pkg_test(self):
         """
-        Package metadata is created when doing an export-pkg and then uploading the package
+        Package metadata created when doing an export-pkg and then uploading the package works
         """
         server1 = TestServer([("*/*@*/*", "*")], [("*/*@*/*", "*")], users={"lasote": "mypass"})
         servers = OrderedDict()
@@ -591,7 +591,5 @@ class Pkg(ConanFile):
         self.assertNotIn("Binary package hello/1.0@user/testing:5%s not found" %
                          NO_SETTINGS_PACKAGE_ID, client.out)
         ref = ConanFileReference("hello", "1.0", "user", "testing")
-        metadata_content = load(os.path.join(client.cache.conan(ref), "metadata.json"))
-        metadata = json.loads(metadata_content)
-        packages = metadata["packages"]
-        self.assertTrue(len(packages) == 1)
+        metadata = client.cache.package_layout(ref).load_metadata()
+        self.assertTrue(metadata.packages)

--- a/conans/test/functional/command/upload_test.py
+++ b/conans/test/functional/command/upload_test.py
@@ -1,12 +1,10 @@
 import itertools
-import json
 import os
 import unittest
 from collections import OrderedDict
 
 from mock import mock
 
-from conans import load
 from conans.client.tools.env import environment_append
 from conans.errors import ConanException
 from conans.model.ref import ConanFileReference, PackageReference
@@ -592,4 +590,5 @@ class Pkg(ConanFile):
                          NO_SETTINGS_PACKAGE_ID, client.out)
         ref = ConanFileReference("hello", "1.0", "user", "testing")
         metadata = client.cache.package_layout(ref).load_metadata()
-        self.assertTrue(metadata.packages)
+        self.assertIn(NO_SETTINGS_PACKAGE_ID, metadata.packages)
+        self.assertTrue(metadata.packages[NO_SETTINGS_PACKAGE_ID].revision)


### PR DESCRIPTION
Changelog: Bugfix:  Fix metadata not being updated for ``conan export-pkg`` when using  ``--package-folder``
Docs: omit

- [x] Refer to the issue that supports this Pull Request: closes #4833
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [x] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 

<sup>**Note:** By default this PR will skip the slower tests and will use a limited set of python versions. Check [here](https://github.com/conan-io/conan/blob/develop/.github/PR_INCREASE_TESTING.md) how to increase the testing level by writing some tags in the current PR body text.</sup>
