### PR TITLE
Add env-var and config-var to explicitly set the cacert_path

### DIFF
--- a/conans/client/cache/cache.py
+++ b/conans/client/cache/cache.py
@@ -5,8 +5,7 @@ from os.path import join, normpath
 
 from conans.client.cache.editable import EditablePackages
 from conans.client.cache.remote_registry import default_remotes, dump_registry, \
-    migrate_registry_file, \
-    RemoteRegistry
+    migrate_registry_file, RemoteRegistry
 from conans.client.conf import ConanClientConfigParser, default_client_conf, default_settings_yml
 from conans.client.conf.detect import detect_defaults_settings
 from conans.client.output import Color
@@ -36,9 +35,6 @@ HOOKS_FOLDER = "hooks"
 # Client certificates
 CLIENT_CERT = "client.crt"
 CLIENT_KEY = "client.key"
-
-# Server authorities file
-CACERT_FILE = "cacert.pem"
 
 
 class ClientCache(SimplePaths):
@@ -84,7 +80,7 @@ class ClientCache(SimplePaths):
 
     @property
     def cacert_path(self):
-        return normpath(join(self.conan_folder, CACERT_FILE))
+        return self.config.cacert_path
 
     def _no_locks(self):
         if self._no_lock is None:

--- a/conans/client/conf/__init__.py
+++ b/conans/client/conf/__init__.py
@@ -5,7 +5,7 @@ from six.moves.configparser import ConfigParser, NoSectionError
 
 from conans.errors import ConanException
 from conans.model.env_info import unquote
-from conans.paths import DEFAULT_PROFILE_NAME, conan_expand_user
+from conans.paths import DEFAULT_PROFILE_NAME, conan_expand_user, CACERT_FILE
 from conans.util.env_reader import get_env
 from conans.util.files import load
 
@@ -128,6 +128,8 @@ request_timeout = 60                  # environment CONAN_REQUEST_TIMEOUT (secon
 # which is deleted after the test.
 # temp_test_folder = True             # environment CONAN_TEMP_TEST_FOLDER
 
+# cacert_path                         # environment CONAN_CACERT_PATH
+
 [storage]
 # This is the default path, but you can write your own. It must be an absolute path or a
 # path beginning with "~" (if the environment var CONAN_USER_HOME is specified, this directory, even
@@ -216,7 +218,8 @@ class ConanClientConfigParser(ConfigParser, object):
                "CONAN_HOOKS": self._env_c("hooks", "CONAN_HOOKS", None),
                "CONAN_MSBUILD_VERBOSITY": self._env_c("general.msbuild_verbosity",
                                                       "CONAN_MSBUILD_VERBOSITY",
-                                                      None)
+                                                      None),
+               "CONAN_CACERT_PATH": self._env_c("general.cacert_path", "CONAN_CACERT_PATH", None)
                }
 
         # Filter None values
@@ -414,3 +417,18 @@ class ConanClientConfigParser(ConfigParser, object):
             return result
         except:
             return None
+
+    @property
+    def cacert_path(self):
+        try:
+            cacert_path = get_env("CONAN_CACERT_PATH")
+            if not cacert_path:
+                cacert_path = self.get_item("general.cacert_path")
+        except ConanException:
+            cacert_path = os.path.join(os.path.dirname(self.filename), CACERT_FILE)
+        else:
+            # For explicit cacert files, the file should already exist
+            if not os.path.exists(cacert_path):
+                raise ConanException("Configured file for 'cacert_path'"
+                                     " doesn't exists: '{}'".format(cacert_path))
+        return cacert_path

--- a/conans/client/rest/conan_requester.py
+++ b/conans/client/rest/conan_requester.py
@@ -1,9 +1,9 @@
 import fnmatch
 import os
 import platform
-import time
 
 import requests
+import time
 
 from conans import __version__ as client_version
 from conans.util.files import save
@@ -63,9 +63,10 @@ class ConanRequester(object):
             kwargs["timeout"] = self._timeout_seconds
         if not kwargs.get("headers"):
             kwargs["headers"] = {}
-        kwargs["headers"]["User-Agent"] = "Conan/%s (Python %s) %s" % (client_version,
-                                                                       platform.python_version(),
-                                                                       requests.utils.default_user_agent())
+
+        user_agent = "Conan/%s (Python %s) %s" % (client_version, platform.python_version(),
+                                                  requests.utils.default_user_agent())
+        kwargs["headers"]["User-Agent"] = user_agent
         return kwargs
 
     def get(self, url, **kwargs):

--- a/conans/paths/__init__.py
+++ b/conans/paths/__init__.py
@@ -53,6 +53,7 @@ RUN_LOG_NAME = "conan_run.log"
 DEFAULT_PROFILE_NAME = "default"
 SCM_FOLDER = "scm_folder.txt"
 PACKAGE_METADATA = "metadata.json"
+CACERT_FILE = "cacert.pem"  # Server authorities file
 
 # Directories
 EXPORT_FOLDER = "export"

--- a/conans/test/functional/configuration/requester_test.py
+++ b/conans/test/functional/configuration/requester_test.py
@@ -1,0 +1,82 @@
+# coding=utf-8
+
+import os
+import unittest
+
+import six
+from mock import Mock
+
+from conans.client.conan_api import Conan
+from conans.client.tools import environment_append
+from conans.client.tools.files import replace_in_file, save
+from conans.errors import ConanException
+from conans.paths import CACERT_FILE
+from conans.test.utils.tools import TestBufferConanOutput, temp_folder
+
+
+class MockRequesterGet(Mock):
+    verify = None
+
+    def get(self, url, **kwargs):
+        self.verify = kwargs.get('verify', None)
+
+
+class ConanRequesterCacertPathTests(unittest.TestCase):
+
+    @staticmethod
+    def _create_requesters(conan_user_home=temp_folder()):
+        with environment_append({'CONAN_USER_HOME': conan_user_home}):
+            conan_api, cache, _ = Conan.factory()
+        requester = conan_api._requester
+        mock_requester = MockRequesterGet()
+        requester._requester = mock_requester
+        return requester, mock_requester, cache
+
+    def test_default_no_verify(self):
+        requester, mocked_requester, _ = self._create_requesters()
+        requester.get(url="aaa", verify=False)
+        self.assertEqual(mocked_requester.verify, False)
+
+    def test_default_verify(self):
+        requester, mocked_requester, cache = self._create_requesters()
+        requester.get(url="aaa", verify=True)
+        self.assertEqual(mocked_requester.verify, cache.cacert_path)
+
+    def test_env_variable(self):
+        file_path = os.path.join(temp_folder(), "whatever_cacert")
+        save(file_path, "dummy content")
+        with environment_append({"CONAN_CACERT_PATH": file_path}):
+            requester, mocked_requester, cache = self._create_requesters()
+            requester.get(url="aaa", verify=True)
+            self.assertEqual(mocked_requester.verify, file_path)
+
+    def test_cache_config(self):
+        file_path = os.path.join(temp_folder(), "whatever_cacert")
+        save(file_path, "dummy")
+
+        requester, mocked_requester, cache = self._create_requesters()
+        replace_in_file(cache.conan_conf_path, "# cacert_path",
+                        "cacert_path={}".format(file_path),
+                        output=TestBufferConanOutput())
+        cache.invalidate()
+
+        requester.get(url="bbbb", verify=True)
+        self.assertEqual(mocked_requester.verify, file_path)
+
+    def test_non_existing_file(self):
+        file_path = os.path.join(temp_folder(), "whatever_cacert")
+        self.assertFalse(os.path.exists(file_path))
+        with environment_append({"CONAN_CACERT_PATH": file_path}):
+            with six.assertRaisesRegex(self, ConanException, "Configured file for 'cacert_path'"
+                                                             " doesn't exist"):
+                self._create_requesters()
+
+    def test_non_existing_default_file(self):
+        conan_user_home = temp_folder()
+        default_cacert_path = os.path.join(conan_user_home, ".conan", CACERT_FILE)
+        self.assertFalse(os.path.exists(default_cacert_path))
+
+        requester, mocked_requester, cache = self._create_requesters(conan_user_home)
+        requester.get(url="aaa", verify=True)
+        self.assertEqual(mocked_requester.verify, cache.cacert_path)
+        self.assertEqual(cache.cacert_path, default_cacert_path)


### PR DESCRIPTION
Changelog: Feature: Allow the user to configure the path to the CACERT file used in requests
Docs: https://github.com/conan-io/docs/pull/1136

closes #3668 

This PR implements a configuration variable `general.cacert_path` together with the corresponding environment variable `CONAN_CACERT_PATH` to allow the user to set a different path for the CACERT file that will be used in requests:
 * If nothing is set, Conan will use the default one: `${CONAN_USER_HOME}/.conan/cacert.pem`. This file will be created if it doesn't exists.
 * If some of the configuration variables are set, then **the file must exist** and it will be used for the requests.