### PR TITLE
Do not run 'export_sources' automatically for python_requires

### DIFF
--- a/conans/client/source.py
+++ b/conans/client/source.py
@@ -144,8 +144,7 @@ def _run_source(conanfile, conanfile_path, src_folder, hook_manager, reference,
                 _run_scm(conanfile, src_folder, local_sources_path, output, cache=cache)
 
                 if cache:
-                    _get_sources_from_exports(conanfile, src_folder, export_folder,
-                                              export_source_folder, cache)
+                    _get_sources_from_exports(src_folder, export_folder, export_source_folder)
                     _clean_source_folder(src_folder)
                 with conanfile_exception_formatter(conanfile.display_name, "source"):
                     conanfile.source()
@@ -159,13 +158,7 @@ def _run_source(conanfile, conanfile_path, src_folder, hook_manager, reference,
             raise ConanException(e)
 
 
-def _get_sources_from_exports(conanfile, src_folder, export_folder, export_source_folder, cache):
-    # Files from python requires are obtained before the self files
-    from conans.client.cmd.export import export_source
-    for python_require in conanfile.python_requires:
-        src = cache.export_sources(python_require.ref)
-        export_source(conanfile, src, src_folder)
-
+def _get_sources_from_exports(src_folder, export_folder, export_source_folder):
     # so self exported files have precedence over python_requires ones
     merge_directories(export_folder, src_folder)
     # Now move the export-sources to the right location

--- a/conans/test/functional/python_requires/python_requires_test.py
+++ b/conans/test/functional/python_requires/python_requires_test.py
@@ -1,12 +1,13 @@
 import os
 import unittest
 
-from conans.model.ref import ConanFileReference
-from conans.test.utils.tools import TestClient, TestServer,\
-    NO_SETTINGS_PACKAGE_ID, create_local_git_repo
-from conans.paths import CONANFILE
-from parameterized import parameterized
 import time
+from parameterized import parameterized
+
+from conans.model.ref import ConanFileReference
+from conans.paths import CONANFILE
+from conans.test.utils.tools import TestClient, TestServer, \
+    NO_SETTINGS_PACKAGE_ID, create_local_git_repo
 
 
 class PythonExtendTest(unittest.TestCase):
@@ -340,8 +341,8 @@ class Pkg2(base.Pkg):
         self.output.info("HEADER CONTENT!: %s" % load("header.h"))
 """
         client.save({"conanfile.py": conanfile}, clean_first=True)
-        client.run("create . Pkg/0.1@user/testing")
-        self.assertIn("Pkg/0.1@user/testing: HEADER CONTENT!: my header", client.out)
+        client.run("create . Pkg/0.1@user/testing", assert_error=True)
+        self.assertIn("No such file or directory: 'header.h'", client.out)
 
     def reuse_class_members_test(self):
         client = TestClient()


### PR DESCRIPTION
Changelog: Fix: Do not run `export_sources` automatically for python_requires
Docs: omit

Removes the automatic export of the files listed in python_requires::exports_sources. This was an undocumented behavior that was not being executed in the local workflow, and we have thought that it can lead the user to unexpected results.

Implement part of https://github.com/conan-io/conan/pull/4340