### PR TITLE
#4696 Part 4 - Now really the right way to check for casing...

### DIFF
--- a/conans/client/graph/build_mode.py
+++ b/conans/client/graph/build_mode.py
@@ -53,8 +53,8 @@ class BuildMode(object):
 
         # Patterns to match, if package matches pattern, build is forced
         for pattern in self.patterns:
-            is_matching_name = fnmatch.fnmatch(ref.name, pattern)
-            is_matching_ref = fnmatch.fnmatch(repr(ref), pattern)
+            is_matching_name = fnmatch.fnmatchcase(ref.name, pattern)
+            is_matching_ref = fnmatch.fnmatchcase(repr(ref), pattern)
             if is_matching_name or is_matching_ref:
                 try:
                     self._unused_patterns.remove(pattern)

--- a/conans/test/unittests/client/graph/build_mode_test.py
+++ b/conans/test/unittests/client/graph/build_mode_test.py
@@ -78,15 +78,17 @@ class BuildModeTest(unittest.TestCase):
 
         build_mode = BuildMode(["Boost"], self.output)
         self.assertTrue(build_mode.forced(self.conanfile, reference))
-        build_mode = BuildMode(["boost"], self.output)
-        self.assertTrue(build_mode.forced(self.conanfile, reference))
         build_mode = BuildMode(["Bo*"], self.output)
         self.assertTrue(build_mode.forced(self.conanfile, reference))
-        build_mode = BuildMode(["bo*"], self.output)
-        self.assertTrue(build_mode.forced(self.conanfile, reference))
-        
         build_mode.report_matches()
         self.assertEqual("", self.output)
+
+        build_mode = BuildMode(["boost"], self.output)
+        self.assertFalse(build_mode.forced(self.conanfile, reference))
+        build_mode = BuildMode(["bo*"], self.output)
+        self.assertFalse(build_mode.forced(self.conanfile, reference))
+        build_mode.report_matches()
+        self.assertIn("ERROR: No package matching", self.output)        
 
     def test_pattern_matching(self):
         build_mode = BuildMode(["Boost*"], self.output)

--- a/conans/test/unittests/client/graph/build_mode_test.py
+++ b/conans/test/unittests/client/graph/build_mode_test.py
@@ -73,6 +73,21 @@ class BuildModeTest(unittest.TestCase):
         build_mode = BuildMode([], self.output)
         self.assertFalse(build_mode.allowed(self.conanfile))
 
+    def test_casing(self):
+        reference = ConanFileReference.loads("Boost/1.69.0@user/stable")
+
+        build_mode = BuildMode(["Boost"], self.output)
+        self.assertTrue(build_mode.forced(self.conanfile, reference))
+        build_mode = BuildMode(["boost"], self.output)
+        self.assertTrue(build_mode.forced(self.conanfile, reference))
+        build_mode = BuildMode(["Bo*"], self.output)
+        self.assertTrue(build_mode.forced(self.conanfile, reference))
+        build_mode = BuildMode(["bo*"], self.output)
+        self.assertTrue(build_mode.forced(self.conanfile, reference))
+        
+        build_mode.report_matches()
+        self.assertEqual("", self.output)
+
     def test_pattern_matching(self):
         build_mode = BuildMode(["Boost*"], self.output)
         reference = ConanFileReference.loads("Boost/1.69.0@user/stable")


### PR DESCRIPTION
Changelog: bugfix: The `--build` pattern was case sensitive depending on the os file system, now it is always case sensitive, following the `conan search` behavior.
Docs: omit

As discussed in Part 3...