### PR TITLE
Fix/cmake paths

### DIFF
--- a/conans/client/generators/cmake_paths.py
+++ b/conans/client/generators/cmake_paths.py
@@ -11,14 +11,12 @@ class CMakePathsGenerator(Generator):
     @property
     def content(self):
         lines = []
-        deps = DepsCppCmake(self.deps_build_info)
         # The CONAN_XXX_ROOT variables are needed because the FindXXX.cmake or XXXConfig.cmake
         # in a package could have been "patched" with the `cmake.patch_config_paths()`
         # replacing absolute paths with CONAN_XXX_ROOT variables.
         for dep_name, dep_cpp_info in self.deps_build_info.dependencies:
             var_name = "CONAN_{}_ROOT".format(dep_name.upper())
-            deps = DepsCppCmake(dep_cpp_info)
-            lines.append('set({} {})'.format(var_name, deps.rootpath))
+            lines.append('set({} {})'.format(var_name, DepsCppCmake(dep_cpp_info).rootpath))
 
         # We want to prioritize the FindXXX.cmake files:
         # 1. First the files found in the packages
@@ -26,6 +24,7 @@ class CMakePathsGenerator(Generator):
         # 3. The "install_folder" ones, in case there is no FindXXX.cmake, try with the install dir
         #    if the user used the "cmake_find_package" will find the auto-generated
         # 4. The CMake installation dir/Modules ones.
+        deps = DepsCppCmake(self.deps_build_info)
         lines.append("set(CMAKE_MODULE_PATH {deps.build_paths} ${{CMAKE_MODULE_PATH}} "
                      "${{CMAKE_CURRENT_LIST_DIR}})".format(deps=deps))
         lines.append("set(CMAKE_PREFIX_PATH {deps.build_paths} ${{CMAKE_PREFIX_PATH}} "

--- a/conans/test/functional/generators/cmake_paths_test.py
+++ b/conans/test/functional/generators/cmake_paths_test.py
@@ -26,8 +26,8 @@ class CMakePathsGeneratorTest(unittest.TestCase):
                    '${{CMAKE_MODULE_PATH}} ${{CMAKE_CURRENT_LIST_DIR}})\r\n' \
                    'set(CMAKE_PREFIX_PATH "{pfolder2}/"\r\n\t\t\t"{pfolder1}/" ' \
                    '${{CMAKE_PREFIX_PATH}} ${{CMAKE_CURRENT_LIST_DIR}})'
-        if(platform.system() != "Windows"):
-            expected = expected.replace("\\r", "")
+        if platform.system() != "Windows":
+            expected = expected.replace("\r", "")
         self.assertEquals(expected.format(pfolder1=pfolder1, pfolder2=pfolder2), contents)
 
     def cmake_paths_integration_test(self):


### PR DESCRIPTION
Changelog: omit
Docs: omit

Fix cmake_paths generator broken by me for 1.14 also. Added test to double check the contents are correctly generated.