### PR TITLE
apply environment to export-pkg

### DIFF
--- a/conans/client/cmd/export_pkg.py
+++ b/conans/client/cmd/export_pkg.py
@@ -6,6 +6,7 @@ from conans.errors import ConanException
 from conans.model.manifest import FileTreeManifest
 from conans.model.ref import PackageReference
 from conans.util.files import rmdir
+from conans.model.conan_file import get_env_context_manager
 
 
 def export_pkg(cache, graph_manager, hook_manager, recorder, output,
@@ -47,9 +48,10 @@ def export_pkg(cache, graph_manager, hook_manager, recorder, output,
         packager.export_pkg(conanfile, package_id, package_folder, dest_package_folder,
                             hook_manager, conan_file_path, ref)
     else:
-        packager.create_package(conanfile, package_id, source_folder, build_folder,
-                                dest_package_folder, install_folder, hook_manager, conan_file_path,
-                                ref, local=True)
+        with get_env_context_manager(conanfile):
+            packager.create_package(conanfile, package_id, source_folder, build_folder,
+                                    dest_package_folder, install_folder, hook_manager,
+                                    conan_file_path, ref, local=True)
     with cache.package_layout(ref).update_metadata() as metadata:
         readed_manifest = FileTreeManifest.load(dest_package_folder)
         metadata.packages[package_id].revision = readed_manifest.summary_hash

--- a/conans/test/functional/generators/cmake_paths_test.py
+++ b/conans/test/functional/generators/cmake_paths_test.py
@@ -28,7 +28,7 @@ class CMakePathsGeneratorTest(unittest.TestCase):
                    '${{CMAKE_PREFIX_PATH}} ${{CMAKE_CURRENT_LIST_DIR}})'
         if platform.system() != "Windows":
             expected = expected.replace("\r", "")
-        self.assertEquals(expected.format(pfolder1=pfolder1, pfolder2=pfolder2), contents)
+        self.assertEqual(expected.format(pfolder1=pfolder1, pfolder2=pfolder2), contents)
 
     def cmake_paths_integration_test(self):
         """First package with own findHello0.cmake file"""


### PR DESCRIPTION
Changelog: Fix: Apply environment variables from profile and from requirements to ``conan export-pkg``
Docs: omit

Close #4832

@tags: slow
