### PR TITLE
Do not print stderr in stdout

### DIFF
--- a/conans/client/tools/scm.py
+++ b/conans/client/tools/scm.py
@@ -53,7 +53,7 @@ class SCMBase(object):
         with chdir(self.folder) if self.folder else no_op():
             with environment_append({"LC_ALL": "en_US.UTF-8"}) if self._force_eng else no_op():
                 if not self._runner:
-                    return decode_text(subprocess.check_output(command, shell=True, stderr=STDOUT).strip())
+                    return decode_text(subprocess.check_output(command, shell=True, stderr=PIPE).strip())
                 else:
                     return self._runner(command)
 


### PR DESCRIPTION
Changelog: Bugfix: The error output was piped to stdout causing issues while running git commands, especially during the detection of the scm revision
Docs: omit