### PR TITLE
Feature/replace check output

### DIFF
--- a/conans/client/runner.py
+++ b/conans/client/runner.py
@@ -1,36 +1,14 @@
 import io
 import os
-import subprocess
 import sys
-import tempfile
 from contextlib import contextmanager
-from subprocess import PIPE, Popen, STDOUT, CalledProcessError
+from subprocess import PIPE, Popen, STDOUT
 
 import six
 
-from conans import load
-from conans.client.tools import no_op
 from conans.errors import ConanException
-from conans.tools import chdir
 from conans.unicode import get_cwd
 from conans.util.files import decode_text
-
-
-def check_output(cmd, folder=None, return_code=False):
-    _, tmp_file = tempfile.mkstemp()
-    with chdir(folder) if folder else no_op():
-        process = subprocess.Popen("{} > {}".format(cmd, tmp_file), shell=True)
-        process.communicate()
-
-        if return_code:
-            return process.returncode
-
-        if process.returncode:
-            raise CalledProcessError(process.returncode, cmd)
-
-        output = load(tmp_file)
-        os.unlink(tmp_file)
-        return output
 
 
 class ConanRunner(object):

--- a/conans/client/tools/oss.py
+++ b/conans/client/tools/oss.py
@@ -442,15 +442,17 @@ def get_gnu_triplet(os_, arch, compiler=None):
 def check_output(cmd, folder=None, return_code=False):
     _, tmp_file = tempfile.mkstemp()
     with chdir(folder) if folder else no_op():
-        process = subprocess.Popen("{} > {}".format(cmd, tmp_file), shell=True)
-        process.communicate()
+        try:
+            process = subprocess.Popen("{} > {}".format(cmd, tmp_file), shell=True)
+            process.communicate()
 
-        if return_code:
-            return process.returncode
+            if return_code:
+                return process.returncode
 
-        if process.returncode:
-            raise CalledProcessError(process.returncode, cmd)
+            if process.returncode:
+                raise CalledProcessError(process.returncode, cmd)
 
-        output = load(tmp_file)
-        os.unlink(tmp_file)
-        return output
+            output = load(tmp_file)
+            return output
+        finally:
+            os.unlink(tmp_file)

--- a/conans/client/tools/oss.py
+++ b/conans/client/tools/oss.py
@@ -8,9 +8,11 @@ from subprocess import CalledProcessError
 
 from conans.client.tools import which, no_op
 from conans.client.tools.env import environment_append
+from conans.client.tools.files import chdir
 from conans.errors import ConanException
 from conans.model.version import Version
 from conans.util.fallbacks import default_output
+from conans.util.files import load
 
 
 def args_to_string(args):
@@ -79,6 +81,7 @@ def detected_architecture():
 
     return None
 
+
 # DETECT OS, VERSION AND DISTRIBUTIONS
 
 
@@ -142,13 +145,13 @@ class OSInfo(object):
     @property
     def with_apt(self):
         return self.is_linux and self.linux_distro in \
-                                 ("debian", "ubuntu", "knoppix", "linuxmint", "raspbian", "neon")
+               ("debian", "ubuntu", "knoppix", "linuxmint", "raspbian", "neon")
 
     @property
     def with_yum(self):
         return self.is_linux and self.linux_distro in \
-                                 ("centos", "redhat", "fedora", "pidora", "scientific",
-                                  "xenserver", "amazon", "oracle", "rhel")
+               ("centos", "redhat", "fedora", "pidora", "scientific",
+                "xenserver", "amazon", "oracle", "rhel")
 
     @property
     def with_pacman(self):
@@ -437,8 +440,6 @@ def get_gnu_triplet(os_, arch, compiler=None):
 
 
 def check_output(cmd, folder=None, return_code=False):
-    from conans.util.files import load
-    from conans.client.tools.files import chdir
     _, tmp_file = tempfile.mkstemp()
     with chdir(folder) if folder else no_op():
         process = subprocess.Popen("{} > {}".format(cmd, tmp_file), shell=True)

--- a/conans/client/tools/oss.py
+++ b/conans/client/tools/oss.py
@@ -451,4 +451,7 @@ def check_output(cmd, folder=None, return_code=False):
         output = load(tmp_file)
         return output
     finally:
-        os.unlink(tmp_file)
+        try:
+            os.unlink(tmp_file)
+        except:
+            pass

--- a/conans/client/tools/oss.py
+++ b/conans/client/tools/oss.py
@@ -437,7 +437,7 @@ def get_gnu_triplet(os_, arch, compiler=None):
 
 
 def check_output(cmd, folder=None, return_code=False):
-    f, tmp_file = tempfile.mkstemp()
+    fd, tmp_file = tempfile.mkstemp()
     with chdir(folder) if folder else no_op():
         try:
             process = subprocess.Popen("{} > {}".format(cmd, tmp_file), shell=True)
@@ -452,5 +452,5 @@ def check_output(cmd, folder=None, return_code=False):
             output = load(tmp_file)
             return output
         finally:
-            f.close()
+            os.close(fd)
             os.unlink(tmp_file)

--- a/conans/client/tools/oss.py
+++ b/conans/client/tools/oss.py
@@ -6,13 +6,11 @@ import sys
 import tempfile
 from subprocess import CalledProcessError
 
-from conans.client.tools import which, no_op
-from conans.client.tools.env import environment_append
-from conans.client.tools.files import chdir
+from conans.client.tools.env import environment_append, no_op
+from conans.client.tools.files import chdir, load
 from conans.errors import ConanException
 from conans.model.version import Version
 from conans.util.fallbacks import default_output
-from conans.util.files import load
 
 
 def args_to_string(args):
@@ -81,7 +79,6 @@ def detected_architecture():
 
     return None
 
-
 # DETECT OS, VERSION AND DISTRIBUTIONS
 
 
@@ -145,13 +142,13 @@ class OSInfo(object):
     @property
     def with_apt(self):
         return self.is_linux and self.linux_distro in \
-               ("debian", "ubuntu", "knoppix", "linuxmint", "raspbian", "neon")
+                                 ("debian", "ubuntu", "knoppix", "linuxmint", "raspbian", "neon")
 
     @property
     def with_yum(self):
         return self.is_linux and self.linux_distro in \
-               ("centos", "redhat", "fedora", "pidora", "scientific",
-                "xenserver", "amazon", "oracle", "rhel")
+                                 ("centos", "redhat", "fedora", "pidora", "scientific",
+                                  "xenserver", "amazon", "oracle", "rhel")
 
     @property
     def with_pacman(self):

--- a/conans/client/tools/oss.py
+++ b/conans/client/tools/oss.py
@@ -437,7 +437,7 @@ def get_gnu_triplet(os_, arch, compiler=None):
 
 
 def check_output(cmd, folder=None, return_code=False):
-    _, tmp_file = tempfile.mkstemp()
+    f, tmp_file = tempfile.mkstemp()
     with chdir(folder) if folder else no_op():
         try:
             process = subprocess.Popen("{} > {}".format(cmd, tmp_file), shell=True)
@@ -452,4 +452,5 @@ def check_output(cmd, folder=None, return_code=False):
             output = load(tmp_file)
             return output
         finally:
+            f.close()
             os.unlink(tmp_file)

--- a/conans/client/tools/oss.py
+++ b/conans/client/tools/oss.py
@@ -7,7 +7,7 @@ import tempfile
 from subprocess import CalledProcessError
 
 from conans.client.tools.env import environment_append, no_op
-from conans.client.tools.files import chdir, load
+from conans.client.tools.files import chdir, load, which
 from conans.errors import ConanException
 from conans.model.version import Version
 from conans.util.fallbacks import default_output

--- a/conans/client/tools/oss.py
+++ b/conans/client/tools/oss.py
@@ -4,7 +4,7 @@ import platform
 import subprocess
 import sys
 import tempfile
-from subprocess import CalledProcessError
+from subprocess import CalledProcessError, PIPE
 
 from conans.client.tools.env import environment_append, no_op
 from conans.client.tools.files import chdir, load, which
@@ -440,7 +440,7 @@ def check_output(cmd, folder=None, return_code=False):
     fd, tmp_file = tempfile.mkstemp()
     with chdir(folder) if folder else no_op():
         try:
-            process = subprocess.Popen("{} > {}".format(cmd, tmp_file), shell=True)
+            process = subprocess.Popen("{} > {}".format(cmd, tmp_file), shell=True, stderr=PIPE)
             process.communicate()
 
             if return_code:

--- a/conans/client/tools/scm.py
+++ b/conans/client/tools/scm.py
@@ -1,16 +1,15 @@
-
 import os
 import platform
 import re
 import subprocess
-import tempfile
 import xml.etree.ElementTree as ET
 from subprocess import CalledProcessError, PIPE, STDOUT
 
 from six.moves.urllib.parse import quote_plus, unquote, urlparse
 
+from conans.client.runner import check_output
 from conans.client.tools.env import environment_append, no_op
-from conans.client.tools.files import chdir, load
+from conans.client.tools.files import chdir
 from conans.errors import ConanException
 from conans.model.version import Version
 from conans.util.files import decode_text, to_file_bytes, walk
@@ -21,19 +20,6 @@ def _run_muted(cmd, folder=None):
         process = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
         process.communicate()
         return process.returncode
-
-
-def _run_capture_stdout(cmd, folder=None):
-    _, tmp_file = tempfile.mkstemp()
-    with chdir(folder) if folder else no_op():
-        process = subprocess.Popen("{} > {}".format(cmd, tmp_file), shell=True)
-        process.communicate()
-        if process.returncode:
-            raise ConanException("Error '{}' calling command: '{}' ".format(process.returncode,
-                                                                            cmd))
-        output = load(tmp_file)
-        os.unlink(tmp_file)
-        return output
 
 
 def _check_repo(cmd, folder, msg=None):
@@ -67,7 +53,7 @@ class SCMBase(object):
         with chdir(self.folder) if self.folder else no_op():
             with environment_append({"LC_ALL": "en_US.UTF-8"}) if self._force_eng else no_op():
                 if not self._runner:
-                    return _run_capture_stdout(command).strip()
+                    return check_output(command).strip()
                 else:
                     return self._runner(command)
 

--- a/conans/client/tools/scm.py
+++ b/conans/client/tools/scm.py
@@ -53,7 +53,7 @@ class SCMBase(object):
         with chdir(self.folder) if self.folder else no_op():
             with environment_append({"LC_ALL": "en_US.UTF-8"}) if self._force_eng else no_op():
                 if not self._runner:
-                    return decode_text(subprocess.check_output(command, shell=True, stderr=STDOUT).strip())
+                    return decode_text(subprocess.check_output(command, shell=True, stderr=PIPE).strip())
                 else:
                     return self._runner(command)
 

--- a/conans/client/tools/scm.py
+++ b/conans/client/tools/scm.py
@@ -7,7 +7,7 @@ from subprocess import CalledProcessError, PIPE, STDOUT
 
 from six.moves.urllib.parse import quote_plus, unquote, urlparse
 
-from conans.client.runner import check_output
+from conans.client.tools import check_output
 from conans.client.tools.env import environment_append, no_op
 from conans.client.tools.files import chdir
 from conans.errors import ConanException
@@ -129,8 +129,8 @@ class Git(SCMBase):
         ret = []
         try:
             file_paths = [os.path.normpath(
-                                os.path.join(
-                                    os.path.relpath(folder, self.folder), el)).replace("\\", "/")
+                os.path.join(
+                    os.path.relpath(folder, self.folder), el)).replace("\\", "/")
                           for folder, dirpaths, fs in walk(self.folder)
                           for el in fs + dirpaths]
             if file_paths:
@@ -219,6 +219,7 @@ class SVN(SCMBase):
     def __init__(self, folder=None, runner=None, *args, **kwargs):
         def runner_no_strip(command):
             return decode_text(subprocess.check_output(command, shell=True))
+
         runner = runner or runner_no_strip
         super(SVN, self).__init__(folder=folder, runner=runner, *args, **kwargs)
 
@@ -252,7 +253,8 @@ class SVN(SCMBase):
     def _show_item(self, item, target='.'):
         self.check_repo()
         if self.version >= SVN.API_CHANGE_VERSION:
-            value = self.run("info --show-item {item} \"{target}\"".format(item=item, target=target))
+            value = self.run(
+                "info --show-item {item} \"{target}\"".format(item=item, target=target))
             return value.strip()
         else:
             output = self.run("info --xml \"{target}\"".format(target=target))

--- a/conans/client/tools/scm.py
+++ b/conans/client/tools/scm.py
@@ -129,8 +129,8 @@ class Git(SCMBase):
         ret = []
         try:
             file_paths = [os.path.normpath(
-                os.path.join(
-                    os.path.relpath(folder, self.folder), el)).replace("\\", "/")
+                                os.path.join(
+                                    os.path.relpath(folder, self.folder), el)).replace("\\", "/")
                           for folder, dirpaths, fs in walk(self.folder)
                           for el in fs + dirpaths]
             if file_paths:
@@ -219,7 +219,6 @@ class SVN(SCMBase):
     def __init__(self, folder=None, runner=None, *args, **kwargs):
         def runner_no_strip(command):
             return decode_text(subprocess.check_output(command, shell=True))
-
         runner = runner or runner_no_strip
         super(SVN, self).__init__(folder=folder, runner=runner, *args, **kwargs)
 
@@ -253,8 +252,7 @@ class SVN(SCMBase):
     def _show_item(self, item, target='.'):
         self.check_repo()
         if self.version >= SVN.API_CHANGE_VERSION:
-            value = self.run(
-                "info --show-item {item} \"{target}\"".format(item=item, target=target))
+            value = self.run("info --show-item {item} \"{target}\"".format(item=item, target=target))
             return value.strip()
         else:
             output = self.run("info --xml \"{target}\"".format(target=target))


### PR DESCRIPTION
Changelog: Bugfix: Fixed recipe revision detection when some error output or unexpected output was printed to the stdout running the `git` command. 
Docs: omit

Will open an engineering issue to replace ALL the previous subprocess.check_output (and other original ways to do the same) to use this.
