### PR TITLE
CI run linux first

### DIFF
--- a/.ci/jenkins/Jenkinsfile
+++ b/.ci/jenkins/Jenkinsfile
@@ -106,7 +106,7 @@ echo "EXCLUDED TAGS: ${excluded_tags}"
 
 
 // FIRST rest api tests, fail ASAP
-rest_builders = [:]
+/*rest_builders = [:]
 for (n in ["Windows", "Linux"]) {
     def the_node = n
     def pyver = "py36"
@@ -158,7 +158,7 @@ for (n in ["Windows", "Linux"]) {
     }
 }
 parallel rest_builders
-
+*/
 
 try{
     for (flavor in flavors){

--- a/.ci/jenkins/Jenkinsfile
+++ b/.ci/jenkins/Jenkinsfile
@@ -162,13 +162,13 @@ parallel rest_builders
 
 try{
     for (flavor in flavors){
-        def builders = [:]
+        def linux_builders = [:]
         def slave = "Linux"
         def pyvers = all_pyvers[slave]
         for (y in pyvers) {
             def pyver = y
             def name = "${slave} - ${flavor} - ${pyver} - '${e_tags}'"
-            builders[name] = {
+            linux_builders[name] = {
                 node(slave) {
                     stage(name){
                         def workdir
@@ -210,10 +210,10 @@ try{
                 }
             }
         }
-        parallel builders
+        parallel linux_builders
 
         //Now Windows and Mac, much slower
-        builders = [:]
+        def builders = [:]
         for (x in ['Windows', 'Macos']) {
             slave = x
             pyvers = all_pyvers[slave]

--- a/.ci/jenkins/Jenkinsfile
+++ b/.ci/jenkins/Jenkinsfile
@@ -213,6 +213,7 @@ try{
         parallel builders
 
         //Now Windows and Mac, much slower
+        builders = [:]
         for (x in ['Windows', 'Macos']) {
             slave = x
             pyvers = all_pyvers[slave]

--- a/.ci/jenkins/Jenkinsfile
+++ b/.ci/jenkins/Jenkinsfile
@@ -162,14 +162,14 @@ parallel rest_builders
 
 try{
     for (flavor in flavors){
-        /*def linux_builders = [:]
-        def slave = "Linux"
-        def pyvers = all_pyvers[slave]
-        for (y in pyvers) {
+        def linux_builders = [:]
+        def slave_linux = "Linux"
+        def pyvers_linux = all_pyvers[slave_linux]
+        for (y in pyvers_linux) {
             def pyver = y
-            def name = "${slave} - ${flavor} - ${pyver} - '${e_tags}'"
+            def name = "${slave_linux} - ${flavor} - ${pyver} - '${e_tags}'"
             linux_builders[name] = {
-                node(slave) {
+                node(slave_linux) {
                     stage(name){
                         def workdir
                         def sourcedir
@@ -209,7 +209,7 @@ try{
                 }
             }
         }
-        parallel linux_builders*/
+        parallel linux_builders
 
         //Now Windows and Mac, much slower
         def builders = [:]

--- a/.ci/jenkins/Jenkinsfile
+++ b/.ci/jenkins/Jenkinsfile
@@ -163,7 +163,57 @@ parallel rest_builders
 try{
     for (flavor in flavors){
         def builders = [:]
-        for (x in slaves) {
+        slave = "Linux"
+        def pyvers = all_pyvers[slave]
+        for (y in pyvers) {
+            def pyver = y
+            def name = "${slave} - ${flavor} - ${pyver} - '${e_tags}'"
+            builders[name] = {
+                node(slave) {
+                    stage(name){
+                        def workdir
+                        def sourcedir
+                        def base_source
+                        lock('source_code') { // Prepare a clean new directory with the sources
+                            try{
+                                step ([$class: 'WsCleanup'])
+                            }
+                            catch(e){
+                                echo "Cannot clean WS"
+                            }
+
+                            def vars = checkout scm
+                            commit = vars["GIT_COMMIT"].substring(0, 4)
+                            branch = vars["GIT_BRANCH"]
+                            echo "Starting ${env.JOB_NAME} with branch ${env.BRANCH_NAME}"
+                            def base_dir = (slave == "Windows") ? win_tmp_base : rest_tmp_base
+                            workdir = "${base_dir}${commit}/${pyver}/${flavor}"
+                            base_source = "${base_dir}source/${commit}"
+                            sourcedir = "${base_source}/${pyver}/${flavor}"
+                            while(fileExists(sourcedir)){
+                                sourcedir = sourcedir + "_"
+                            }
+
+                            dir(base_source){ // Trick to create the parent
+                                def escaped_ws = "${WORKSPACE}".replace("\\", "/")
+                                def cmd = "python -c \"import shutil; shutil.copytree('${escaped_ws}', '${sourcedir}')\""
+                                sh(script: cmd)
+                            }
+                        }
+
+                        sh "docker pull conanio/conantests"
+                        docker.image('conanio/conantests').inside("-e CONAN_USER_HOME=${sourcedir} -v${sourcedir}:${sourcedir}") {
+                            sh(script: "python ${runner} ${module} ${pyver} ${sourcedir} ${workdir} -e rest_api ${numcores} --flavor ${flavor} ${e_tags}")
+                        }
+                        //step([$class: 'JUnitResultArchiver', testResults: '**/nosetests.xml'])
+                    }
+                }
+            }
+        }
+        parallel builders
+
+        //Now Windows and Mac, much slower
+        for (x in ['Windows', 'Macos']) {
             def slave = x
             def pyvers = all_pyvers[slave]
             for (y in pyvers) {
@@ -209,13 +259,7 @@ try{
                                     }
                                 }
                             }
-                            if(slave == "Linux"){
-                                sh "docker pull conanio/conantests"
-                                docker.image('conanio/conantests').inside("-e CONAN_USER_HOME=${sourcedir} -v${sourcedir}:${sourcedir}") {
-                                    sh(script: "python ${runner} ${module} ${pyver} ${sourcedir} ${workdir} -e rest_api ${numcores} --flavor ${flavor} ${e_tags}")
-                                }
-                            }
-                            else if(slave == "Windows"){
+                            if(slave == "Windows"){
                                 try{
 
                                   withEnv(["CONAN_TEST_FOLDER=${workdir}"]){

--- a/.ci/jenkins/Jenkinsfile
+++ b/.ci/jenkins/Jenkinsfile
@@ -163,7 +163,7 @@ parallel rest_builders
 try{
     for (flavor in flavors){
         def builders = [:]
-        slave = "Linux"
+        def slave = "Linux"
         def pyvers = all_pyvers[slave]
         for (y in pyvers) {
             def pyver = y
@@ -214,8 +214,8 @@ try{
 
         //Now Windows and Mac, much slower
         for (x in ['Windows', 'Macos']) {
-            def slave = x
-            def pyvers = all_pyvers[slave]
+            slave = x
+            pyvers = all_pyvers[slave]
             for (y in pyvers) {
                 def pyver = y
                 if(slave != "Linux" && pyver=="py37"){

--- a/.ci/jenkins/Jenkinsfile
+++ b/.ci/jenkins/Jenkinsfile
@@ -162,7 +162,7 @@ parallel rest_builders
 
 try{
     for (flavor in flavors){
-        def linux_builders = [:]
+        /*def linux_builders = [:]
         def slave = "Linux"
         def pyvers = all_pyvers[slave]
         for (y in pyvers) {
@@ -205,18 +205,17 @@ try{
                         docker.image('conanio/conantests').inside("-e CONAN_USER_HOME=${sourcedir} -v${sourcedir}:${sourcedir}") {
                             sh(script: "python ${runner} ${module} ${pyver} ${sourcedir} ${workdir} -e rest_api ${numcores} --flavor ${flavor} ${e_tags}")
                         }
-                        //step([$class: 'JUnitResultArchiver', testResults: '**/nosetests.xml'])
                     }
                 }
             }
         }
-        parallel linux_builders
+        parallel linux_builders*/
 
         //Now Windows and Mac, much slower
         def builders = [:]
         for (x in ['Windows', 'Macos']) {
-            slave = x
-            pyvers = all_pyvers[slave]
+            def slave = x
+            def pyvers = all_pyvers[slave]
             for (y in pyvers) {
                 def pyver = y
                 if(slave != "Linux" && pyver=="py37"){

--- a/.ci/jenkins/Jenkinsfile
+++ b/.ci/jenkins/Jenkinsfile
@@ -106,7 +106,7 @@ echo "EXCLUDED TAGS: ${excluded_tags}"
 
 
 // FIRST rest api tests, fail ASAP
-/*rest_builders = [:]
+rest_builders = [:]
 for (n in ["Windows", "Linux"]) {
     def the_node = n
     def pyver = "py36"
@@ -158,7 +158,6 @@ for (n in ["Windows", "Linux"]) {
     }
 }
 parallel rest_builders
-*/
 
 try{
     for (flavor in flavors){

--- a/.ci/jenkins/Jenkinsfile
+++ b/.ci/jenkins/Jenkinsfile
@@ -186,7 +186,7 @@ try{
                             commit = vars["GIT_COMMIT"].substring(0, 4)
                             branch = vars["GIT_BRANCH"]
                             echo "Starting ${env.JOB_NAME} with branch ${env.BRANCH_NAME}"
-                            def base_dir = (slave == "Windows") ? win_tmp_base : rest_tmp_base
+                            def base_dir = (slave_linux == "Windows") ? win_tmp_base : rest_tmp_base
                             workdir = "${base_dir}${commit}/${pyver}/${flavor}"
                             base_source = "${base_dir}source/${commit}"
                             sourcedir = "${base_source}/${pyver}/${flavor}"


### PR DESCRIPTION
Changelog: omit
Docs: omit

Build time in CI goes from 14 mins => 16 mins, but the overall usage should be more efficient, specially in releases when many builds are awaiting until slow Win and MacOS builds, that are most of the times going to fail if the Linux builds failed.

![image](https://user-images.githubusercontent.com/15367152/55199782-7f6b8d80-51bb-11e9-9d0e-7be66541b4ae.png)
