### PR TITLE
fix credentials necessary for install

### DIFF
--- a/conans/client/cmd/uploader.py
+++ b/conans/client/cmd/uploader.py
@@ -353,6 +353,7 @@ class CmdUpload(object):
         return files_to_upload, deleted
 
     def _package_files_to_upload(self, pref, policy, the_files, remote):
+        self._remote_manager.check_credentials()
         remote_snapshot = self._remote_manager.get_package_snapshot(pref, remote)
 
         if remote_snapshot:

--- a/conans/client/cmd/uploader.py
+++ b/conans/client/cmd/uploader.py
@@ -353,7 +353,6 @@ class CmdUpload(object):
         return files_to_upload, deleted
 
     def _package_files_to_upload(self, pref, policy, the_files, remote):
-        self._remote_manager.check_credentials()
         remote_snapshot = self._remote_manager.get_package_snapshot(pref, remote)
 
         if remote_snapshot:

--- a/conans/client/cmd/uploader.py
+++ b/conans/client/cmd/uploader.py
@@ -335,6 +335,7 @@ class CmdUpload(object):
 
     def _recipe_files_to_upload(self, ref, policy, the_files, remote, remote_manifest):
         # Get the remote snapshot
+        self._remote_manager.check_credentials(remote)
         remote_snapshot = self._remote_manager.get_recipe_snapshot(ref, remote)
 
         if remote_snapshot and policy != UPLOAD_POLICY_FORCE:
@@ -353,6 +354,7 @@ class CmdUpload(object):
         return files_to_upload, deleted
 
     def _package_files_to_upload(self, pref, policy, the_files, remote):
+        self._remote_manager.check_credentials(remote)
         remote_snapshot = self._remote_manager.get_package_snapshot(pref, remote)
 
         if remote_snapshot:

--- a/conans/client/remote_manager.py
+++ b/conans/client/remote_manager.py
@@ -32,6 +32,9 @@ class RemoteManager(object):
         self._auth_manager = auth_manager
         self._hook_manager = hook_manager
 
+    def check_credentials(self, remote):
+        self._call_remote(remote, "check_credentials")
+
     def get_recipe_snapshot(self, ref, remote):
         assert ref.revision, "get_recipe_snapshot requires revision"
         return self._call_remote(remote, "get_recipe_snapshot", ref)

--- a/conans/client/rest/auth_manager.py
+++ b/conans/client/rest/auth_manager.py
@@ -124,6 +124,9 @@ class ConanApiAuthManager(object):
         custom_headers['X-Client-Id'] = str(username or "")
 
     # ######### CONAN API METHODS ##########
+    @input_credentials_if_unauthorized
+    def check_credentials(self):
+        self._rest_client.check_credentials()
 
     @input_credentials_if_unauthorized
     def upload_recipe(self, ref, files_to_upload, deleted, retry, retry_wait):

--- a/conans/client/rest/rest_client_common.py
+++ b/conans/client/rest/rest_client_common.py
@@ -162,15 +162,15 @@ class RestCommonMethods(object):
             self._remove_conanfile_files(ref, deleted)
 
     def get_recipe_snapshot(self, ref):
+        # this method is used only for UPLOADING, then it requires the credentials
         self.check_credentials()
-
         url = self.router.recipe_snapshot(ref)
         snap = self._get_snapshot(url)
         return snap
 
     def get_package_snapshot(self, pref):
-        self.check_credentials()
-
+        # this method is also used to check the integrity of the package upstream
+        # while installing, so check_credentials is done in uploader.
         url = self.router.package_snapshot(pref)
         snap = self._get_snapshot(url)
         return snap

--- a/conans/client/rest/rest_client_common.py
+++ b/conans/client/rest/rest_client_common.py
@@ -163,7 +163,7 @@ class RestCommonMethods(object):
 
     def get_recipe_snapshot(self, ref):
         # this method is used only for UPLOADING, then it requires the credentials
-        self.check_credentials()
+        # Check of credentials is done in the uploader
         url = self.router.recipe_snapshot(ref)
         snap = self._get_snapshot(url)
         return snap

--- a/conans/test/functional/old/conan_trace_file_test.py
+++ b/conans/test/functional/old/conan_trace_file_test.py
@@ -126,7 +126,7 @@ class HelloConan(ConanFile):
             self.assertEqual(num_post, 2)  # 2 get urls
 
         num_get = len([it for it in actions if "REST_API_CALL" in it and "GET" in it])
-        self.assertEqual(num_get, 9)
+        self.assertEqual(num_get, 10)
 
         # Check masked signature
         for action in actions:

--- a/conans/test/functional/old/conan_trace_file_test.py
+++ b/conans/test/functional/old/conan_trace_file_test.py
@@ -126,7 +126,7 @@ class HelloConan(ConanFile):
             self.assertEqual(num_post, 2)  # 2 get urls
 
         num_get = len([it for it in actions if "REST_API_CALL" in it and "GET" in it])
-        self.assertEqual(num_get, 10)
+        self.assertEqual(num_get, 9)
 
         # Check masked signature
         for action in actions:


### PR DESCRIPTION
Changelog: Bugfix: Client does not require credentials for anonymous downloads from remotes.
Docs: omit

Close #4871

@tags: slow

cc/ @fschoenm