### PR TITLE
[workspace] Do not import targets but create an alias to the project one

### DIFF
--- a/conans/client/cmd/new.py
+++ b/conans/client/cmd/new.py
@@ -220,7 +220,7 @@ void hello(){
 cmake = """cmake_minimum_required(VERSION 2.8)
 project(MyHello CXX)
 
-include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
+include(${CMAKE_CURRENT_BINARY_DIR}/conanbuildinfo.cmake)
 conan_basic_setup()
 
 add_library(hello hello.cpp)

--- a/conans/client/generators/cmake_common.py
+++ b/conans/client/generators/cmake_common.py
@@ -109,37 +109,40 @@ set(CONAN_CMD_C_FLAGS ${CONAN_C_FLAGS})
 
 
 _target_template = """
-    conan_package_library_targets("${{CONAN_LIBS_{uname}}}" "${{CONAN_LIB_DIRS_{uname}}}"
-                                  CONAN_PACKAGE_TARGETS_{uname} "{deps}" "" {pkg_name})
-    conan_package_library_targets("${{CONAN_LIBS_{uname}_DEBUG}}" "${{CONAN_LIB_DIRS_{uname}_DEBUG}}"
-                                  CONAN_PACKAGE_TARGETS_{uname}_DEBUG "{deps}" "debug" {pkg_name})
-    conan_package_library_targets("${{CONAN_LIBS_{uname}_RELEASE}}" "${{CONAN_LIB_DIRS_{uname}_RELEASE}}"
-                                  CONAN_PACKAGE_TARGETS_{uname}_RELEASE "{deps}" "release" {pkg_name})
-
-    add_library({name} INTERFACE IMPORTED)
-
-    # Property INTERFACE_LINK_FLAGS do not work, necessary to add to INTERFACE_LINK_LIBRARIES
-    set_property(TARGET {name} PROPERTY INTERFACE_LINK_LIBRARIES ${{CONAN_PACKAGE_TARGETS_{uname}}} ${{CONAN_SHARED_LINKER_FLAGS_{uname}_LIST}} ${{CONAN_EXE_LINKER_FLAGS_{uname}_LIST}}
-                                                                 $<$<CONFIG:Release>:${{CONAN_PACKAGE_TARGETS_{uname}_RELEASE}} ${{CONAN_SHARED_LINKER_FLAGS_{uname}_RELEASE_LIST}} ${{CONAN_EXE_LINKER_FLAGS_{uname}_RELEASE_LIST}}>
-                                                                 $<$<CONFIG:RelWithDebInfo>:${{CONAN_PACKAGE_TARGETS_{uname}_RELEASE}} ${{CONAN_SHARED_LINKER_FLAGS_{uname}_RELEASE_LIST}} ${{CONAN_EXE_LINKER_FLAGS_{uname}_RELEASE_LIST}}>
-                                                                 $<$<CONFIG:MinSizeRel>:${{CONAN_PACKAGE_TARGETS_{uname}_RELEASE}} ${{CONAN_SHARED_LINKER_FLAGS_{uname}_RELEASE_LIST}} ${{CONAN_EXE_LINKER_FLAGS_{uname}_RELEASE_LIST}}>
-                                                                 $<$<CONFIG:Debug>:${{CONAN_PACKAGE_TARGETS_{uname}_DEBUG}} ${{CONAN_SHARED_LINKER_FLAGS_{uname}_DEBUG_LIST}} ${{CONAN_EXE_LINKER_FLAGS_{uname}_DEBUG_LIST}}>
-                                                                 {deps})
-    set_property(TARGET {name} PROPERTY INTERFACE_INCLUDE_DIRECTORIES ${{CONAN_INCLUDE_DIRS_{uname}}}
-                                                                      $<$<CONFIG:Release>:${{CONAN_INCLUDE_DIRS_{uname}_RELEASE}}>
-                                                                      $<$<CONFIG:RelWithDebInfo>:${{CONAN_INCLUDE_DIRS_{uname}_RELEASE}}>
-                                                                      $<$<CONFIG:MinSizeRel>:${{CONAN_INCLUDE_DIRS_{uname}_RELEASE}}>
-                                                                      $<$<CONFIG:Debug>:${{CONAN_INCLUDE_DIRS_{uname}_DEBUG}}>)
-    set_property(TARGET {name} PROPERTY INTERFACE_COMPILE_DEFINITIONS ${{CONAN_COMPILE_DEFINITIONS_{uname}}}
-                                                                      $<$<CONFIG:Release>:${{CONAN_COMPILE_DEFINITIONS_{uname}_RELEASE}}>
-                                                                      $<$<CONFIG:RelWithDebInfo>:${{CONAN_COMPILE_DEFINITIONS_{uname}_RELEASE}}>
-                                                                      $<$<CONFIG:MinSizeRel>:${{CONAN_COMPILE_DEFINITIONS_{uname}_RELEASE}}>
-                                                                      $<$<CONFIG:Debug>:${{CONAN_COMPILE_DEFINITIONS_{uname}_DEBUG}}>)
-    set_property(TARGET {name} PROPERTY INTERFACE_COMPILE_OPTIONS ${{CONAN_C_FLAGS_{uname}_LIST}} ${{CONAN_CXX_FLAGS_{uname}_LIST}}
-                                                                  $<$<CONFIG:Release>:${{CONAN_C_FLAGS_{uname}_RELEASE_LIST}} ${{CONAN_CXX_FLAGS_{uname}_RELEASE_LIST}}>
-                                                                  $<$<CONFIG:RelWithDebInfo>:${{CONAN_C_FLAGS_{uname}_RELEASE_LIST}} ${{CONAN_CXX_FLAGS_{uname}_RELEASE_LIST}}>
-                                                                  $<$<CONFIG:MinSizeRel>:${{CONAN_C_FLAGS_{uname}_RELEASE_LIST}} ${{CONAN_CXX_FLAGS_{uname}_RELEASE_LIST}}>
-                                                                  $<$<CONFIG:Debug>:${{CONAN_C_FLAGS_{uname}_DEBUG_LIST}}  ${{CONAN_CXX_FLAGS_{uname}_DEBUG_LIST}}>)
+    if (NOT DEFINED CONAN_IS_WS OR NOT ${{CONAN_IS_WS}})
+        message(">>>>> NOT CONAN_IS_WS")
+        conan_package_library_targets("${{CONAN_LIBS_{uname}}}" "${{CONAN_LIB_DIRS_{uname}}}"
+                                      CONAN_PACKAGE_TARGETS_{uname} "{deps}" "" {pkg_name})
+        conan_package_library_targets("${{CONAN_LIBS_{uname}_DEBUG}}" "${{CONAN_LIB_DIRS_{uname}_DEBUG}}"
+                                      CONAN_PACKAGE_TARGETS_{uname}_DEBUG "{deps}" "debug" {pkg_name})
+        conan_package_library_targets("${{CONAN_LIBS_{uname}_RELEASE}}" "${{CONAN_LIB_DIRS_{uname}_RELEASE}}"
+                                      CONAN_PACKAGE_TARGETS_{uname}_RELEASE "{deps}" "release" {pkg_name})
+    
+        add_library({name} INTERFACE IMPORTED)
+    
+        # Property INTERFACE_LINK_FLAGS do not work, necessary to add to INTERFACE_LINK_LIBRARIES
+        set_property(TARGET {name} PROPERTY INTERFACE_LINK_LIBRARIES ${{CONAN_PACKAGE_TARGETS_{uname}}} ${{CONAN_SHARED_LINKER_FLAGS_{uname}_LIST}} ${{CONAN_EXE_LINKER_FLAGS_{uname}_LIST}}
+                                                                     $<$<CONFIG:Release>:${{CONAN_PACKAGE_TARGETS_{uname}_RELEASE}} ${{CONAN_SHARED_LINKER_FLAGS_{uname}_RELEASE_LIST}} ${{CONAN_EXE_LINKER_FLAGS_{uname}_RELEASE_LIST}}>
+                                                                     $<$<CONFIG:RelWithDebInfo>:${{CONAN_PACKAGE_TARGETS_{uname}_RELEASE}} ${{CONAN_SHARED_LINKER_FLAGS_{uname}_RELEASE_LIST}} ${{CONAN_EXE_LINKER_FLAGS_{uname}_RELEASE_LIST}}>
+                                                                     $<$<CONFIG:MinSizeRel>:${{CONAN_PACKAGE_TARGETS_{uname}_RELEASE}} ${{CONAN_SHARED_LINKER_FLAGS_{uname}_RELEASE_LIST}} ${{CONAN_EXE_LINKER_FLAGS_{uname}_RELEASE_LIST}}>
+                                                                     $<$<CONFIG:Debug>:${{CONAN_PACKAGE_TARGETS_{uname}_DEBUG}} ${{CONAN_SHARED_LINKER_FLAGS_{uname}_DEBUG_LIST}} ${{CONAN_EXE_LINKER_FLAGS_{uname}_DEBUG_LIST}}>
+                                                                     {deps})
+        set_property(TARGET {name} PROPERTY INTERFACE_INCLUDE_DIRECTORIES ${{CONAN_INCLUDE_DIRS_{uname}}}
+                                                                          $<$<CONFIG:Release>:${{CONAN_INCLUDE_DIRS_{uname}_RELEASE}}>
+                                                                          $<$<CONFIG:RelWithDebInfo>:${{CONAN_INCLUDE_DIRS_{uname}_RELEASE}}>
+                                                                          $<$<CONFIG:MinSizeRel>:${{CONAN_INCLUDE_DIRS_{uname}_RELEASE}}>
+                                                                          $<$<CONFIG:Debug>:${{CONAN_INCLUDE_DIRS_{uname}_DEBUG}}>)
+        set_property(TARGET {name} PROPERTY INTERFACE_COMPILE_DEFINITIONS ${{CONAN_COMPILE_DEFINITIONS_{uname}}}
+                                                                          $<$<CONFIG:Release>:${{CONAN_COMPILE_DEFINITIONS_{uname}_RELEASE}}>
+                                                                          $<$<CONFIG:RelWithDebInfo>:${{CONAN_COMPILE_DEFINITIONS_{uname}_RELEASE}}>
+                                                                          $<$<CONFIG:MinSizeRel>:${{CONAN_COMPILE_DEFINITIONS_{uname}_RELEASE}}>
+                                                                          $<$<CONFIG:Debug>:${{CONAN_COMPILE_DEFINITIONS_{uname}_DEBUG}}>)
+        set_property(TARGET {name} PROPERTY INTERFACE_COMPILE_OPTIONS ${{CONAN_C_FLAGS_{uname}_LIST}} ${{CONAN_CXX_FLAGS_{uname}_LIST}}
+                                                                      $<$<CONFIG:Release>:${{CONAN_C_FLAGS_{uname}_RELEASE_LIST}} ${{CONAN_CXX_FLAGS_{uname}_RELEASE_LIST}}>
+                                                                      $<$<CONFIG:RelWithDebInfo>:${{CONAN_C_FLAGS_{uname}_RELEASE_LIST}} ${{CONAN_CXX_FLAGS_{uname}_RELEASE_LIST}}>
+                                                                      $<$<CONFIG:MinSizeRel>:${{CONAN_C_FLAGS_{uname}_RELEASE_LIST}} ${{CONAN_CXX_FLAGS_{uname}_RELEASE_LIST}}>
+                                                                      $<$<CONFIG:Debug>:${{CONAN_C_FLAGS_{uname}_DEBUG_LIST}}  ${{CONAN_CXX_FLAGS_{uname}_DEBUG_LIST}}>)
+    endif()
 """
 
 

--- a/conans/model/editable_layout.py
+++ b/conans/model/editable_layout.py
@@ -39,6 +39,10 @@ class EditableLayout(object):
     def __init__(self, filepath):
         self._filepath = filepath
 
+    @property
+    def filepath(self):
+        return self._filepath
+
     def folder(self, ref, name, settings, options):
         _, folders = self._load_data(ref, settings=settings, options=options)
         try:

--- a/conans/model/workspace.py
+++ b/conans/model/workspace.py
@@ -56,7 +56,7 @@ class Workspace(object):
         macro(conan_workspace_subdirectories)
             set(CONAN_IS_WS TRUE)
             {% for item in editables %}
-                add_subdirectory(${PACKAGE_{{ item.name }}_SRC} {{ item.build_folder }})
+                add_subdirectory(${PACKAGE_{{ item.name }}_SRC} "{{ item.build_folder }}")
                 {% if item.alias_target %}
                 add_library(CONAN_PKG::{{ item.name }} ALIAS {{ item.alias_target }}) # Use our library
                 {% endif %}

--- a/conans/model/workspace.py
+++ b/conans/model/workspace.py
@@ -85,7 +85,7 @@ class Workspace(object):
 
                 source_folder = editable.folder(node.ref, EditableLayout.SOURCE_FOLDER,
                                                 node.conanfile.settings, node.conanfile.options)
-                source_folder = os.path.join(ws_pkg.root_folder, source_folder)
+                source_folder = os.path.join(ws_pkg.root_folder, source_folder or '.')
                 if not os.path.exists(os.path.join(source_folder, "CMakeLists.txt")):
                     raise ConanException("Invalid source_folder for reference '{}' in layout"
                                          " file '{}': cannot find a 'CMakeLists.txt' file".

--- a/conans/model/workspace.py
+++ b/conans/model/workspace.py
@@ -88,8 +88,9 @@ class Workspace(object):
                 source_folder = os.path.join(ws_pkg.root_folder, source_folder or '.')
                 if not os.path.exists(os.path.join(source_folder, "CMakeLists.txt")):
                     raise ConanException("Invalid source_folder for reference '{}' in layout"
-                                         " file '{}': cannot find a 'CMakeLists.txt' file".
-                                         format(node.ref, editable.filepath))
+                                         " file '{}': cannot find a 'CMakeLists.txt' file"
+                                         " in path '{}'".
+                                         format(node.ref, editable.filepath, source_folder))
 
                 build_folder = os.path.join(cwd, node.ref.name)
                 write_generators(node.conanfile, build_folder, output)

--- a/conans/model/workspace.py
+++ b/conans/model/workspace.py
@@ -5,8 +5,10 @@ from collections import OrderedDict
 import yaml
 from jinja2 import Template
 
+from conans.client.file_copier import report_copied_files
 from conans.client.generators import write_generators
 from conans.client.graph.graph import RECIPE_EDITABLE
+from conans.client.importer import run_imports
 from conans.client.output import ScopedOutput
 from conans.errors import ConanException
 from conans.model.editable_layout import get_editable_abs_path, EditableLayout
@@ -91,6 +93,9 @@ class Workspace(object):
 
                 build_folder = os.path.join(cwd, node.ref.name)
                 write_generators(node.conanfile, build_folder, output)
+                copied_files = run_imports(node.conanfile, build_folder)
+                report_copied_files(copied_files, output)
+                # TODO: This logic is repeated in `BinaryInstaller::_handle_node_editable`
 
                 unique_refs[node.ref.name] = {
                     'name': node.ref.name,

--- a/conans/model/workspace.py
+++ b/conans/model/workspace.py
@@ -87,7 +87,7 @@ class Workspace(object):
 
                 source_folder = editable.folder(node.ref, EditableLayout.SOURCE_FOLDER,
                                                 node.conanfile.settings, node.conanfile.options)
-                if source_folder:
+                if source_folder is not None:
                     source_folder = os.path.join(ws_pkg.root_folder, source_folder)
                 else:
                     output.warn("source_folder is not defined for reference '{}'"
@@ -95,7 +95,7 @@ class Workspace(object):
 
                 build_folder = editable.folder(node.ref, EditableLayout.BUILD_FOLDER,
                                                node.conanfile.settings, node.conanfile.options)
-                if build_folder:
+                if build_folder is not None:
                     build_folder = os.path.join(ws_pkg.root_folder, build_folder)
                 else:
                     output.warn("build_folder is not defined for reference '{}'"

--- a/conans/test/functional/workspace/workspace_test.py
+++ b/conans/test/functional/workspace/workspace_test.py
@@ -883,7 +883,7 @@ class Pkg(ConanFile):
         self.assertTrue(os.path.exists(os.path.join(client.current_folder,
                                                     "conanworkspace.cmake")))
 
-    def gen_subdirectories_test(self):
+    def test_gen_subdirectories_test(self):
         client = TestClient()
 
         def files(name, depend=None):
@@ -924,3 +924,5 @@ class Pkg(ConanFile):
         for p in ("HelloC", "HelloB", "HelloA"):
             self.assertIn("add_subdirectory(${PACKAGE_%s_SRC} ${PACKAGE_%s_BUILD})" % (p, p),
                           conanws_cmake)
+
+        # TODO: Require at least "." instead of an empty section?


### PR DESCRIPTION
Changelog: (Feature | Fix | Bugfix): Describe here your pull request
Docs: https://github.com/conan-io/docs/pull/XXXX

Demo example here: https://github.com/jgsogo/ws-not-editable

For WS only makes sense the `source_folder` and `build_folder` entries in the layout files, everything else has to be in the target itself... do I need settings and options there? Anyway, I DO have `node.conanfile.settings` and `node.conanfile.options`... I wonder, are _editables_ needed for _workspaces_ or has it been a misconception? I can get `source_folder` and `build_folder` from the _workspaces file_ instead of getting them from the _editables layout file_, this separation also makes sense because those folders aren't needed/used in _editables_ (unless we enable the `conan install <ref-in-editable-mode> --build` for a local build).

