### PR TITLE
Use our own check_output everywhere 

### DIFF
--- a/conans/client/build/cmake.py
+++ b/conans/client/build/cmake.py
@@ -1,6 +1,5 @@
 import os
 import platform
-import subprocess
 from itertools import chain
 
 from six import StringIO  # Python 2 and 3 compatible
@@ -11,7 +10,7 @@ from conans.client.build.cmake_flags import CMakeDefinitionsBuilder, \
     cmake_install_prefix_var_name, get_toolset, build_type_definition, \
     cmake_in_local_cache_var_name, runtime_definition_var_name, get_generator_platform
 from conans.client.output import ConanOutput
-from conans.client.tools.oss import cpu_count, args_to_string
+from conans.client.tools.oss import cpu_count, args_to_string, check_output
 from conans.errors import ConanException
 from conans.model.conan_file import ConanFile
 from conans.model.version import Version
@@ -366,7 +365,7 @@ class CMake(object):
     @staticmethod
     def get_version():
         try:
-            out, _ = subprocess.Popen(["cmake", "--version"], stdout=subprocess.PIPE).communicate()
+            out = check_output(["cmake", "--version"])
             version_line = decode_text(out).split('\n', 1)[0]
             version_str = version_line.rsplit(' ', 1)[-1]
             return Version(version_str)

--- a/conans/client/build/meson.py
+++ b/conans/client/build/meson.py
@@ -1,10 +1,9 @@
 import os
-import subprocess
 
 from conans.client import defs_to_string, join_arguments, tools
-from conans.client.tools.oss import args_to_string
+from conans.client.tools.oss import args_to_string, check_output
 from conans.errors import ConanException
-from conans.model.build_info import DEFAULT_BIN, DEFAULT_INCLUDE, DEFAULT_LIB, DEFAULT_SHARE
+from conans.model.build_info import DEFAULT_BIN, DEFAULT_INCLUDE, DEFAULT_LIB
 from conans.model.version import Version
 from conans.util.files import decode_text, get_abs_path, mkdir
 
@@ -197,7 +196,7 @@ class Meson(object):
     @staticmethod
     def get_version():
         try:
-            out, _ = subprocess.Popen(["meson", "--version"], stdout=subprocess.PIPE).communicate()
+            out, _ = check_output(["meson", "--version"])
             version_line = decode_text(out).split('\n', 1)[0]
             version_str = version_line.rsplit(' ', 1)[-1]
             return Version(version_str)

--- a/conans/client/build/msbuild.py
+++ b/conans/client/build/msbuild.py
@@ -1,12 +1,11 @@
 import copy
 import os
 import re
-import subprocess
 
 from conans.client import tools
 from conans.client.build.visual_environment import (VisualStudioBuildEnvironment,
                                                     vs_build_type_flags, vs_std_cpp)
-from conans.client.tools.oss import cpu_count
+from conans.client.tools.oss import cpu_count, check_output
 from conans.client.tools.win import vcvars_command
 from conans.errors import ConanException
 from conans.model.conan_file import ConanFile
@@ -225,7 +224,7 @@ class MSBuild(object):
         vcvars = tools_vcvars_command(settings)
         command = "%s && %s" % (vcvars, msbuild_cmd)
         try:
-            out, _ = subprocess.Popen(command, stdout=subprocess.PIPE, shell=True).communicate()
+            out, _ = check_output(command)
             version_line = decode_text(out).split("\n")[-1]
             prog = re.compile("(\d+\.){2,3}\d+")
             result = prog.match(version_line).group()

--- a/conans/client/cmd/export_linter.py
+++ b/conans/client/cmd/export_linter.py
@@ -44,6 +44,7 @@ def _runner(args):
     command = " ".join(command)
     shell = True if platform.system() != "Windows" else False
     output = check_output(command, shell=shell)
+    print(output)
     return json.loads(output.decode("utf-8")) if output else {}
 
 

--- a/conans/client/cmd/export_linter.py
+++ b/conans/client/cmd/export_linter.py
@@ -1,11 +1,11 @@
 import json
 import os
 import platform
-import subprocess
 import sys
 
 from conans import __path__ as root_path
 from conans.client.output import Color
+from conans.client.tools.oss import check_output
 from conans.errors import ConanException
 
 
@@ -43,10 +43,8 @@ def _runner(args):
     command = ["pylint",  "--output-format=json"] + args
     command = " ".join(command)
     shell = True if platform.system() != "Windows" else False
-    proc = subprocess.Popen(command, shell=shell, bufsize=10, stdout=subprocess.PIPE,
-                            stderr=subprocess.PIPE)
-    stdout, _ = proc.communicate()
-    return json.loads(stdout.decode("utf-8")) if stdout else {}
+    output = check_output(command, shell=shell)
+    return json.loads(output.decode("utf-8")) if output else {}
 
 
 def _normal_linter(conanfile_path, hook):

--- a/conans/client/cmd/export_linter.py
+++ b/conans/client/cmd/export_linter.py
@@ -1,8 +1,8 @@
 import json
 import os
 import platform
+import subprocess
 import sys
-from subprocess import PIPE, Popen
 
 from conans import __path__ as root_path
 from conans.client.output import Color
@@ -43,7 +43,8 @@ def _runner(args):
     command = ["pylint",  "--output-format=json"] + args
     command = " ".join(command)
     shell = True if platform.system() != "Windows" else False
-    proc = Popen(command, shell=shell, bufsize=10, stdout=PIPE, stderr=PIPE)
+    proc = subprocess.Popen(command, shell=shell, bufsize=10, stdout=subprocess.PIPE,
+                            stderr=subprocess.PIPE)
     stdout, _ = proc.communicate()
     return json.loads(stdout.decode("utf-8")) if stdout else {}
 

--- a/conans/client/conf/detect.py
+++ b/conans/client/conf/detect.py
@@ -1,16 +1,17 @@
 import os
 import platform
 import re
-from subprocess import PIPE, Popen, STDOUT
+import subprocess
 
 from conans.client.output import Color
-from conans.client.tools.win import latest_visual_studio_version_installed
 from conans.client.tools import detected_os
+from conans.client.tools.win import latest_visual_studio_version_installed
 from conans.model.version import Version
 
 
 def _execute(command):
-    proc = Popen(command, shell=True, bufsize=1, stdout=PIPE, stderr=STDOUT)
+    proc = subprocess.Popen(command, shell=True, bufsize=1, stdout=subprocess.PIPE,
+                            stderr=subprocess.STDOUT)
 
     output_buffer = []
     while True:

--- a/conans/client/runner.py
+++ b/conans/client/runner.py
@@ -1,8 +1,8 @@
 import io
 import os
+import subprocess
 import sys
 from contextlib import contextmanager
-from subprocess import PIPE, Popen, STDOUT
 
 import six
 
@@ -61,7 +61,8 @@ class ConanRunner(object):
             # piping both stdout, stderr and then later only reading one will hang the process
             # if the other fills the pip. So piping stdout, and redirecting stderr to stdout,
             # so both are merged and use just a single get_stream_lines() call
-            proc = Popen(command, shell=True, stdout=PIPE, stderr=STDOUT, cwd=cwd)
+            proc = subprocess.Popen(command, shell=True, stdout=subprocess.PIPE,
+                                    stderr=subprocess.STDOUT, cwd=cwd)
         except Exception as e:
             raise ConanException("Error while executing '%s'\n\t%s" % (command, str(e)))
 

--- a/conans/client/tools/apple.py
+++ b/conans/client/tools/apple.py
@@ -1,7 +1,8 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 import os
-import subprocess
+
+from conans.client.tools.oss import check_output
 
 
 def is_apple_os(os_):
@@ -72,7 +73,7 @@ class XCRun(object):
 
     def _invoke(self, args):
         def cmd_output(cmd):
-            return subprocess.check_output(cmd).decode().strip()
+            return check_output(cmd).decode().strip()
 
         command = ['xcrun', '-find']
         if self.sdk:

--- a/conans/client/tools/oss.py
+++ b/conans/client/tools/oss.py
@@ -4,6 +4,7 @@ import platform
 import subprocess
 import sys
 import tempfile
+import six
 
 from conans.client.tools.env import environment_append
 from conans.client.tools.files import load, which
@@ -438,6 +439,7 @@ def get_gnu_triplet(os_, arch, compiler=None):
 def check_output(cmd, folder=None, return_code=False, error_to_stdout=False, shell=True):
     tmp_file = tempfile.mktemp()
     try:
+        cmd = cmd if isinstance(cmd, six.string_types) else subprocess.list2cmdline(cmd)
         stderr = subprocess.STDOUT if error_to_stdout else subprocess.PIPE
         process = subprocess.Popen("{} > {}".format(cmd, tmp_file), shell=shell,
                                    stderr=stderr, cwd=folder)

--- a/conans/client/tools/oss.py
+++ b/conans/client/tools/oss.py
@@ -4,7 +4,6 @@ import platform
 import subprocess
 import sys
 import tempfile
-from subprocess import CalledProcessError, PIPE
 
 from conans.client.tools.env import environment_append
 from conans.client.tools.files import load, which
@@ -439,15 +438,15 @@ def get_gnu_triplet(os_, arch, compiler=None):
 def check_output(cmd, folder=None, return_code=False):
     tmp_file = tempfile.mktemp()
     try:
-        process = subprocess.Popen("{} > {}".format(cmd, tmp_file),
-                                   shell=True, stderr=PIPE, cwd=folder)
+        process = subprocess.Popen("{} > {}".format(cmd, tmp_file), shell=True,
+                                   stderr=subprocess.PIPE, cwd=folder)
         process.communicate()
 
         if return_code:
             return process.returncode
 
         if process.returncode:
-            raise CalledProcessError(process.returncode, cmd)
+            raise subprocess.CalledProcessError(process.returncode, cmd)
 
         output = load(tmp_file)
         return output

--- a/conans/client/tools/oss.py
+++ b/conans/client/tools/oss.py
@@ -440,7 +440,7 @@ def check_output(cmd, folder=None, return_code=False, error_to_stdout=False, she
     try:
         stderr = subprocess.STDOUT if error_to_stdout else subprocess.PIPE
         process = subprocess.Popen("{} > {}".format(cmd, tmp_file), shell=shell,
-                                   stdout=stdout, stderr=stderr, cwd=folder)
+                                   stderr=stderr, cwd=folder)
         process.communicate()
 
         if return_code:

--- a/conans/client/tools/oss.py
+++ b/conans/client/tools/oss.py
@@ -435,12 +435,12 @@ def get_gnu_triplet(os_, arch, compiler=None):
     return "%s-%s" % (machine, op_system)
 
 
-def check_output(cmd, folder=None, return_code=False, error_to_stdout=False):
+def check_output(cmd, folder=None, return_code=False, error_to_stdout=False, shell=True):
     tmp_file = tempfile.mktemp()
     try:
         stderr = subprocess.STDOUT if error_to_stdout else subprocess.PIPE
-        process = subprocess.Popen("{} > {}".format(cmd, tmp_file), shell=True,
-                                   stderr=stderr, cwd=folder)
+        process = subprocess.Popen("{} > {}".format(cmd, tmp_file), shell=shell,
+                                   stdout=stdout, stderr=stderr, cwd=folder)
         process.communicate()
 
         if return_code:

--- a/conans/client/tools/oss.py
+++ b/conans/client/tools/oss.py
@@ -439,7 +439,8 @@ def get_gnu_triplet(os_, arch, compiler=None):
 def check_output(cmd, folder=None, return_code=False):
     tmp_file = tempfile.mktemp()
     try:
-        process = subprocess.Popen("{} > {}".format(cmd, tmp_file), shell=True, stderr=PIPE, cwd=folder)
+        process = subprocess.Popen("{} > {}".format(cmd, tmp_file),
+                                   shell=True, stderr=PIPE, cwd=folder)
         process.communicate()
 
         if return_code:

--- a/conans/client/tools/pkg_config.py
+++ b/conans/client/tools/pkg_config.py
@@ -3,13 +3,14 @@
 
 import subprocess
 
+from conans.client.tools.oss import check_output
 from conans.errors import ConanException
 
 
 class PkgConfig(object):
     @staticmethod
     def _cmd_output(command):
-        return subprocess.check_output(command).decode().strip()
+        return check_output(command).decode().strip()
 
     def __init__(self, library, pkg_config_executable='pkg-config', static=False, msvc_syntax=False, variables=None,
                  print_errors=True):

--- a/conans/client/tools/pkg_config.py
+++ b/conans/client/tools/pkg_config.py
@@ -40,7 +40,7 @@ class PkgConfig(object):
         if self.define_variables:
             for name, value in self.define_variables.items():
                 command.append('--define-variable=%s=%s' % (name, value))
-        return check_output(command).decode().strip()
+        return check_output(command).strip()
 
     def _get_option(self, option):
         if option not in self.info:

--- a/conans/client/tools/pkg_config.py
+++ b/conans/client/tools/pkg_config.py
@@ -1,10 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-import subprocess
-
 from conans.client.tools.oss import check_output
-from conans.errors import ConanException
 
 
 class PkgConfig(object):
@@ -43,10 +40,7 @@ class PkgConfig(object):
         if self.define_variables:
             for name, value in self.define_variables.items():
                 command.append('--define-variable=%s=%s' % (name, value))
-        try:
-            return self._cmd_output(command)
-        except subprocess.CalledProcessError as e:
-            raise ConanException('pkg-config command %s failed with error: %s' % (command, e))
+        return check_output(command).decode().strip()
 
     def _get_option(self, option):
         if option not in self.info:

--- a/conans/client/tools/scm.py
+++ b/conans/client/tools/scm.py
@@ -3,13 +3,12 @@ import platform
 import re
 import subprocess
 import xml.etree.ElementTree as ET
-from subprocess import CalledProcessError, PIPE, STDOUT
 
 from six.moves.urllib.parse import quote_plus, unquote, urlparse
 
-from conans.client.tools import check_output
 from conans.client.tools.env import environment_append, no_op
 from conans.client.tools.files import chdir
+from conans.client.tools.oss import check_output
 from conans.errors import ConanException
 from conans.model.version import Version
 from conans.util.files import decode_text, to_file_bytes, walk
@@ -134,13 +133,14 @@ class Git(SCMBase):
                           for folder, dirpaths, fs in walk(self.folder)
                           for el in fs + dirpaths]
             if file_paths:
-                p = subprocess.Popen(['git', 'check-ignore', '--stdin'],
-                                     stdout=PIPE, stdin=PIPE, stderr=STDOUT, cwd=self.folder)
+                p = subprocess.Popen(['git', 'check-ignore', '--stdin'], stdout=subprocess.PIPE,
+                                     stdin=subprocess.PIPE, stderr=subprocess.STDOUT,
+                                     cwd=self.folder)
                 paths = to_file_bytes("\n".join(file_paths))
 
                 grep_stdout = decode_text(p.communicate(input=paths)[0])
                 ret = grep_stdout.splitlines()
-        except (CalledProcessError, IOError, OSError) as e:
+        except (subprocess.CalledProcessError, IOError, OSError) as e:
             if self._output:
                 self._output.warn("Error checking excluded git files: %s. "
                                   "Ignoring excluded files" % e)

--- a/conans/client/tools/win.py
+++ b/conans/client/tools/win.py
@@ -9,7 +9,7 @@ import deprecation
 
 from conans.client.tools import which
 from conans.client.tools.env import environment_append
-from conans.client.tools.oss import OSInfo, detected_architecture
+from conans.client.tools.oss import OSInfo, detected_architecture, check_output, CalledProcessError
 from conans.errors import ConanException
 from conans.model.version import Version
 from conans.unicode import get_cwd
@@ -303,14 +303,14 @@ def vswhere(all_=False, prerelease=False, products=None, requires=None, version=
         arguments.append("-nologo")
 
     try:
-        output = subprocess.check_output(arguments)
+        output = check_output(arguments)
         output = decode_text(output).strip()
         # Ignore the "description" field, that even decoded contains non valid charsets for json
         # (ignored ones)
         output = "\n".join([line for line in output.splitlines()
                             if not line.strip().startswith('"description"')])
 
-    except (ValueError, subprocess.CalledProcessError, UnicodeDecodeError) as e:
+    except (ValueError, CalledProcessError, UnicodeDecodeError) as e:
         raise ConanException("vswhere error: %s" % str(e))
 
     return json.loads(output)
@@ -448,7 +448,7 @@ def vcvars_dict(settings, arch=None, compiler_version=None, force=False, filter_
                          compiler_version=compiler_version, force=force,
                          vcvars_ver=vcvars_ver, winsdk_version=winsdk_version, output=output)
     cmd += " && echo __BEGINS__ && set"
-    ret = decode_text(subprocess.check_output(cmd, shell=True))
+    ret = decode_text(check_output(cmd))
     new_env = {}
     start_reached = False
     for line in ret.splitlines():

--- a/conans/client/tools/win.py
+++ b/conans/client/tools/win.py
@@ -9,7 +9,7 @@ import deprecation
 
 from conans.client.tools import which
 from conans.client.tools.env import environment_append
-from conans.client.tools.oss import OSInfo, detected_architecture, check_output, CalledProcessError
+from conans.client.tools.oss import OSInfo, detected_architecture, check_output, ConanSubprocessError
 from conans.errors import ConanException
 from conans.model.version import Version
 from conans.unicode import get_cwd
@@ -310,7 +310,7 @@ def vswhere(all_=False, prerelease=False, products=None, requires=None, version=
         output = "\n".join([line for line in output.splitlines()
                             if not line.strip().startswith('"description"')])
 
-    except (ValueError, CalledProcessError, UnicodeDecodeError) as e:
+    except (ValueError, ConanSubprocessError, UnicodeDecodeError) as e:
         raise ConanException("vswhere error: %s" % str(e))
 
     return json.loads(output)

--- a/conans/errors.py
+++ b/conans/errors.py
@@ -131,6 +131,18 @@ class ConanInvalidConfiguration(ConanExceptionInUserConanfileMethod):
     pass
 
 
+class ConanSubprocessError(ConanException):
+    def __init__(self, return_code, command):
+        self.return_code = return_code
+        self.command = command
+
+    def __str__(self):
+        if self.return_code and self.return_code < 0:
+            return "Command '{}' died with {!r}".format(self.cmd, self.return_code)
+        else:
+            return "Command '{}' returned non-zero exit status {}".format(self.cmd, self.return_code)
+
+
 # Remote exceptions #
 class InternalErrorException(ConanException):
     """

--- a/conans/errors.py
+++ b/conans/errors.py
@@ -133,14 +133,14 @@ class ConanInvalidConfiguration(ConanExceptionInUserConanfileMethod):
 
 class ConanSubprocessError(ConanException):
     def __init__(self, return_code, command):
-        self.return_code = return_code
-        self.command = command
+        self.returncode = return_code
+        self.cmd = command
 
     def __str__(self):
-        if self.return_code and self.return_code < 0:
-            return "Command '{}' died with {!r}".format(self.cmd, self.return_code)
+        if self.returncode and self.returncode < 0:
+            return "Command '{}' died with {!r}".format(self.cmd, self.returncode)
         else:
-            return "Command '{}' returned non-zero exit status {}".format(self.cmd, self.return_code)
+            return "Command '{}' returned non-zero exit status {}".format(self.cmd, self.returncode)
 
 
 class ConanMigrationError(ConanException):

--- a/conans/test/functional/generators/virtualbuildenv_test.py
+++ b/conans/test/functional/generators/virtualbuildenv_test.py
@@ -1,9 +1,9 @@
 import os
 import platform
-import subprocess
 import unittest
 
 from conans import load
+from conans.client.tools.oss import check_output
 from conans.test.utils.tools import TestClient
 
 
@@ -56,7 +56,7 @@ class TestConan(ConanFile):
         client = TestClient(path_with_spaces=False)
         client.save({"conanfile.py": conanfile})
         client.run("install .")
-        output = subprocess.check_output(env_cmd, shell=True)
+        output = check_output(env_cmd)
         normal_environment = env_output_to_dict(output)
         client.run("install .")
         act_build_file = os.path.join(client.current_folder, "activate_build.%s" % extension)
@@ -67,9 +67,9 @@ class TestConan(ConanFile):
             act_build_content_len = len(load(act_build_file).splitlines())
             deact_build_content_len = len(load(deact_build_file).splitlines())
             self.assertEqual(act_build_content_len, deact_build_content_len)
-        output = subprocess.check_output(get_cmd(act_build_file), shell=True)
+        output = check_output(get_cmd(act_build_file))
         activate_environment = env_output_to_dict(output)
         self.assertNotEqual(normal_environment, activate_environment)
-        output = subprocess.check_output(get_cmd(deact_build_file), shell=True)
+        output = check_output(get_cmd(deact_build_file))
         deactivate_environment = env_output_to_dict(output)
         self.assertEqual(normal_environment, deactivate_environment)

--- a/conans/test/functional/tgz_macos_dot_files.py
+++ b/conans/test/functional/tgz_macos_dot_files.py
@@ -1,12 +1,12 @@
 import os
 import platform
 import shutil
-import subprocess
 import tempfile
 import textwrap
 import unittest
 
 from conans.client.remote_manager import uncompress_file
+from conans.client.tools.oss import check_output
 from conans.model.ref import ConanFileReference, PackageReference
 from conans.paths import EXPORT_SOURCES_TGZ_NAME
 from conans.test.utils.tools import TestBufferConanOutput
@@ -17,7 +17,7 @@ from conans.test.utils.tools import TestClient, TestServer
 class TgzMacosDotFilesTest(unittest.TestCase):
 
     def _add_macos_metadata_to_file(self, filepath):
-        subprocess.call(["xattr", "-w", "name", "value", filepath])
+        check_output(["xattr", "-w", "name", "value", filepath])
 
     def _test_for_metadata_in_zip_file(self, tgz, annotated_file, dot_file_expected):
         tmp_folder = tempfile.mkdtemp()
@@ -40,7 +40,7 @@ class TgzMacosDotFilesTest(unittest.TestCase):
         tmp_folder = tempfile.mkdtemp()
         try:
             tgz = os.path.join(tmp_folder, 'compressed.tgz')
-            subprocess.call(["tar", "-zcvf", tgz, "-C", folder, "."])
+            check_output(["tar", "-zcvf", tgz, "-C", folder, "."])
             self._test_for_metadata_in_zip_file(tgz, annotated_file, dot_file_expected)
         finally:
             shutil.rmtree(tmp_folder)

--- a/conans/test/integration/pkg_config_test.py
+++ b/conans/test/integration/pkg_config_test.py
@@ -1,7 +1,7 @@
 import platform
-import subprocess
 import unittest
 
+from conans.client.tools.oss import check_output
 from conans.test.utils.tools import TestClient
 
 hello_cpp = """
@@ -181,4 +181,4 @@ class LibAConan(ConanFile):
         client.run("install .")
         client.run("build .")
 
-        subprocess.Popen("./main", cwd=client.current_folder)
+        check_output("./main", folder=client.current_folder)

--- a/conans/test/integration/run_envronment_test.py
+++ b/conans/test/integration/run_envronment_test.py
@@ -1,8 +1,8 @@
 import platform
-import subprocess
 import unittest
 
 from conans.client import tools
+from conans.client.tools.oss import check_output
 from conans.paths import CONANFILE
 from conans.test.utils.cpp_test_files import cpp_hello_conan_files
 from conans.test.utils.tools import TestClient, TestServer
@@ -153,5 +153,5 @@ execute_process(COMMAND say_hello)
                 # running, or in the same line "$ DYLD_LIBRARY_PATH=[path] say_hello"
                 command = "bash -c 'source activate_run.sh && say_hello'"
 
-            output = subprocess.check_output(command, shell=True)
+            output = check_output(command)
             self.assertIn("Hello Tool!", str(output))

--- a/conans/test/unittests/client/tools/os_info/osinfo_test.py
+++ b/conans/test/unittests/client/tools/os_info/osinfo_test.py
@@ -55,7 +55,7 @@ class OSInfoTest(unittest.TestCase):
             self.assertFalse(OSInfo().is_solaris)
 
             with environment_append({"CONAN_BASH_PATH": "/fake/bash.exe"}):
-                with mock.patch('subprocess.check_output', new=self.subprocess_check_output_mock):
+                with mock.patch('conan.client.tools.oss.check_output', new=self.subprocess_check_output_mock):
                     self.assertEqual(OSInfo.uname(), self._uname.lower())
                     self.assertEqual(OSInfo.detect_windows_subsystem(), CYGWIN)
 
@@ -72,7 +72,7 @@ class OSInfoTest(unittest.TestCase):
             self.assertFalse(OSInfo().is_solaris)
 
             with environment_append({"CONAN_BASH_PATH": "/fake/bash.exe"}):
-                with mock.patch('subprocess.check_output', new=self.subprocess_check_output_mock):
+                with mock.patch('conan.client.tools.oss.check_output', new=self.subprocess_check_output_mock):
                     self.assertEqual(OSInfo.uname(), self._uname.lower())
                     self.assertEqual(OSInfo.detect_windows_subsystem(), MSYS)
 
@@ -89,7 +89,7 @@ class OSInfoTest(unittest.TestCase):
             self.assertFalse(OSInfo().is_solaris)
 
             with environment_append({"CONAN_BASH_PATH": "/fake/bash.exe"}):
-                with mock.patch('subprocess.check_output', new=self.subprocess_check_output_mock):
+                with mock.patch('conan.client.tools.oss.check_output', new=self.subprocess_check_output_mock):
                     self.assertEqual(OSInfo.uname(), self._uname.lower())
                     self.assertEqual(OSInfo.detect_windows_subsystem(), MSYS2)
 
@@ -106,7 +106,7 @@ class OSInfoTest(unittest.TestCase):
             self.assertFalse(OSInfo().is_solaris)
 
             with environment_append({"CONAN_BASH_PATH": "/fake/bash.exe"}):
-                with mock.patch('subprocess.check_output', new=self.subprocess_check_output_mock):
+                with mock.patch('conan.client.tools.oss.check_output', new=self.subprocess_check_output_mock):
                     self.assertEqual(OSInfo.uname(), self._uname.lower())
                     self.assertEqual(OSInfo.detect_windows_subsystem(), MSYS2)
 

--- a/conans/test/unittests/client/tools/os_info/osinfo_test.py
+++ b/conans/test/unittests/client/tools/os_info/osinfo_test.py
@@ -16,7 +16,7 @@ class OSInfoTest(unittest.TestCase):
         self._uname = None
         self._version = None
 
-    def subprocess_check_output_mock(self, cmd, shell):
+    def subprocess_check_output_mock(self, cmd):
         if cmd.endswith('"uname"'):
             return self._uname.encode()
         elif cmd.endswith('"uname -r"'):
@@ -55,7 +55,7 @@ class OSInfoTest(unittest.TestCase):
             self.assertFalse(OSInfo().is_solaris)
 
             with environment_append({"CONAN_BASH_PATH": "/fake/bash.exe"}):
-                with mock.patch('conan.client.tools.oss.check_output', new=self.subprocess_check_output_mock):
+                with mock.patch('conans.client.tools.oss.check_output', new=self.subprocess_check_output_mock):
                     self.assertEqual(OSInfo.uname(), self._uname.lower())
                     self.assertEqual(OSInfo.detect_windows_subsystem(), CYGWIN)
 
@@ -72,7 +72,7 @@ class OSInfoTest(unittest.TestCase):
             self.assertFalse(OSInfo().is_solaris)
 
             with environment_append({"CONAN_BASH_PATH": "/fake/bash.exe"}):
-                with mock.patch('conan.client.tools.oss.check_output', new=self.subprocess_check_output_mock):
+                with mock.patch('conans.client.tools.oss.check_output', new=self.subprocess_check_output_mock):
                     self.assertEqual(OSInfo.uname(), self._uname.lower())
                     self.assertEqual(OSInfo.detect_windows_subsystem(), MSYS)
 
@@ -89,7 +89,7 @@ class OSInfoTest(unittest.TestCase):
             self.assertFalse(OSInfo().is_solaris)
 
             with environment_append({"CONAN_BASH_PATH": "/fake/bash.exe"}):
-                with mock.patch('conan.client.tools.oss.check_output', new=self.subprocess_check_output_mock):
+                with mock.patch('conans.client.tools.oss.check_output', new=self.subprocess_check_output_mock):
                     self.assertEqual(OSInfo.uname(), self._uname.lower())
                     self.assertEqual(OSInfo.detect_windows_subsystem(), MSYS2)
 
@@ -106,7 +106,7 @@ class OSInfoTest(unittest.TestCase):
             self.assertFalse(OSInfo().is_solaris)
 
             with environment_append({"CONAN_BASH_PATH": "/fake/bash.exe"}):
-                with mock.patch('conan.client.tools.oss.check_output', new=self.subprocess_check_output_mock):
+                with mock.patch('conans.client.tools.oss.check_output', new=self.subprocess_check_output_mock):
                     self.assertEqual(OSInfo.uname(), self._uname.lower())
                     self.assertEqual(OSInfo.detect_windows_subsystem(), MSYS2)
 

--- a/conans/test/unittests/client/tools/oss/check_output_test.py
+++ b/conans/test/unittests/client/tools/oss/check_output_test.py
@@ -5,7 +5,7 @@ import unittest
 
 import six
 
-from conans.client.tools.oss import check_output, CalledProcessError
+from conans.client.tools.oss import check_output, ConanSubprocessError
 
 
 class CheckOutputTestCase(unittest.TestCase):
@@ -29,7 +29,7 @@ class CheckOutputTestCase(unittest.TestCase):
         self.assertEqual(self.success_code, ret)
 
     def test_error_call(self):
-        with self.assertRaises(CalledProcessError) as e:
+        with self.assertRaises(ConanSubprocessError) as e:
             ret = check_output("asdf")
             self.assertEqual(None, ret)
         self.assertIn("Command 'asdf' returned non-zero exit status", str(e.exception))

--- a/conans/test/unittests/client/tools/oss/check_output_test.py
+++ b/conans/test/unittests/client/tools/oss/check_output_test.py
@@ -13,7 +13,7 @@ class CheckOutputTestCase(unittest.TestCase):
     success_code = 0
 
     def test_command_success(self):
-        ret = check_output("ls")
+        ret = check_output('ls {}'.format(os.path.dirname(__file__)))
         self.assertTrue(isinstance(ret, six.string_types))
         self.assertIn("check_output_test.py\n", ret)
 

--- a/conans/test/unittests/client/tools/oss/check_output_test.py
+++ b/conans/test/unittests/client/tools/oss/check_output_test.py
@@ -1,0 +1,40 @@
+# coding=utf-8
+
+import os
+import unittest
+
+import six
+
+from conans.client.tools.oss import check_output, CalledProcessError
+
+
+class CheckOutputTestCase(unittest.TestCase):
+
+    success_code = 0
+
+    def test_command_success(self):
+        ret = check_output("ls")
+        self.assertTrue(isinstance(ret, six.string_types))
+        self.assertIn("check_output_test.py\n", ret)
+
+    def test_working_dir(self):
+        cwd = os.path.join(os.path.dirname(__file__), '..')
+        ret = check_output("ls", folder=cwd)
+        self.assertTrue(isinstance(ret, six.string_types))
+        self.assertIn("oss\n", ret)
+
+    def test_return_code(self):
+        ret = check_output("ls", return_code=True)
+        self.assertTrue(isinstance(ret, int))
+        self.assertEqual(self.success_code, ret)
+
+    def test_error_call(self):
+        with self.assertRaises(CalledProcessError) as e:
+            ret = check_output("asdf")
+            self.assertEqual(None, ret)
+        self.assertIn("Command 'asdf' returned non-zero exit status", str(e.exception))
+        self.assertNotEqual(self.success_code, e.exception.returncode)
+
+    def test_error_return_code(self):
+        ret = check_output("asdf", return_code=True)
+        self.assertNotEqual(self.success_code, ret)

--- a/conans/test/unittests/util/detect_test.py
+++ b/conans/test/unittests/util/detect_test.py
@@ -1,12 +1,11 @@
-import os
 import platform
-import subprocess
 import unittest
 
 from mock import mock
 
 from conans.client import tools
 from conans.client.conf.detect import detect_defaults_settings
+from conans.client.tools.oss import check_output, ConanSubprocessError
 from conans.paths import DEFAULT_PROFILE_NAME
 from conans.test.utils.tools import TestBufferConanOutput
 
@@ -36,8 +35,8 @@ class DetectTest(unittest.TestCase):
             return
 
         try:
-            output = subprocess.check_output(["gcc", "--version"], stderr=subprocess.STDOUT)
-        except subprocess.CalledProcessError:
+            output = check_output(["gcc", "--version"], error_to_stdout=True)
+        except ConanSubprocessError:
             # gcc is not installed or there is any error (no test scenario)
             return
 

--- a/conans/test/unittests/util/tools_test.py
+++ b/conans/test/unittests/util/tools_test.py
@@ -1042,7 +1042,7 @@ ProgramFiles(x86)=C:\Program Files (x86)
             return output_with_newline_and_spaces
 
         with mock.patch('conans.client.tools.win.vcvars_command', new=vcvars_command_mock):
-            with mock.patch('conan.client.tools.oss.check_output', new=subprocess_check_output_mock):
+            with mock.patch('conans.client.tools.oss.check_output', new=subprocess_check_output_mock):
                 vcvars = tools.vcvars_dict(None, only_diff=False, output=self.output)
                 self.assertEqual(vcvars["PROCESSOR_ARCHITECTURE"], "AMD64")
                 self.assertEqual(vcvars["PROCESSOR_IDENTIFIER"], "Intel64 Family 6 Model 158 Stepping 9, GenuineIntel")

--- a/conans/util/windows.py
+++ b/conans/util/windows.py
@@ -1,7 +1,7 @@
 import os
-import subprocess
 import tempfile
 
+from conans.client.tools.oss import check_output, CalledProcessError
 from conans.util.env_reader import get_env
 from conans.util.files import load, mkdir, rmdir, save
 from conans.util.log import logger
@@ -67,8 +67,8 @@ def path_shortener(path, short_paths):
         userdomain, username = os.getenv("USERDOMAIN"), os.environ["USERNAME"]
         domainname = "%s\%s" % (userdomain, username) if userdomain else username
         cmd = r'cacls %s /E /G "%s":F' % (short_home, domainname)
-        subprocess.check_output(cmd, stderr=subprocess.STDOUT)  # Ignoring any returned output, quiet
-    except subprocess.CalledProcessError:
+        check_output(cmd)  # Ignoring any returned output, quiet
+    except CalledProcessError:
         # cmd can fail if trying to set ACL in non NTFS drives, ignoring it.
         pass
 

--- a/conans/util/windows.py
+++ b/conans/util/windows.py
@@ -1,7 +1,7 @@
 import os
 import tempfile
 
-from conans.client.tools.oss import check_output, CalledProcessError
+from conans.client.tools.oss import check_output, ConanSubprocessError
 from conans.util.env_reader import get_env
 from conans.util.files import load, mkdir, rmdir, save
 from conans.util.log import logger
@@ -68,7 +68,7 @@ def path_shortener(path, short_paths):
         domainname = "%s\%s" % (userdomain, username) if userdomain else username
         cmd = r'cacls %s /E /G "%s":F' % (short_home, domainname)
         check_output(cmd)  # Ignoring any returned output, quiet
-    except CalledProcessError:
+    except ConanSubprocessError:
         # cmd can fail if trying to set ACL in non NTFS drives, ignoring it.
         pass
 


### PR DESCRIPTION
Changelog: (Feature | Fix | Bugfix): Describe here your pull request
Docs: https://github.com/conan-io/docs/pull/XXXX

explores https://github.com/conan-io/conan/issues/4859

I wonder if we really want our own `check_output` everywhere, or just for the use cases where we are capturing the output (then, we wouldn't want the `return_code` stuff) 😕 

