### PR TITLE
Exclude conanfile.py from bare package copy

### DIFF
--- a/conans/client/cmd/new.py
+++ b/conans/client/cmd/new.py
@@ -68,7 +68,7 @@ class {package_name}Conan(ConanFile):
     topics = None
 
     def package(self):
-        self.copy("*")
+        self.copy("*", excludes="conanfile.py")
 
     def package_info(self):
         self.cpp_info.libs = tools.collect_libs(self)

--- a/conans/test/functional/command/export_pkg_test.py
+++ b/conans/test/functional/command/export_pkg_test.py
@@ -303,6 +303,7 @@ class TestConan(ConanFile):
         self.assertNotIn("Hello/0.1@lasote/stable package(): WARN: No files in this package!",
                          client.out)  # --bare include a now mandatory package() method!
 
+        self.assertNotIn("Packaged 1 '.py' file: conanfile.py", client.out)
         self.assertIn("Packaged 1 '.a' file: libmycoollib.a", client.out)
         self._consume(client, settings + " . -g cmake")
 


### PR DESCRIPTION
Changelog: Fix: Example bare package recipe excludes `conanfile.py` from copy
Docs: omit

closes https://github.com/conan-io/conan/issues/4829
