### PR TITLE
Improve export-pkg message, add a notice about provided package-folder

### DIFF
--- a/conans/client/command.py
+++ b/conans/client/command.py
@@ -747,13 +747,11 @@ class Command(object):
 
     def export_pkg(self, *args):
         """
-        Exports a recipe, then creates a package from local-source-folder and
-        build-folder (or use already packaged files if a package-folder is provided).
+        Exports a recipe and create a binary package from local files.
 
-        The package is created by calling the package() method applied to the
-        local folders '--source-folder' and '--build-folder' It's created in
-        the local cache for the specified 'reference' and for the specified
-        '--settings', '--options' and or '--profile'.
+        If '--package-folder' is provided it will copy the files from there, otherwise it
+        will execute package() method over '--source-folder' and '--build-folder' to create
+        the binary package.
         """
         parser = argparse.ArgumentParser(description=self.export_pkg.__doc__,
                                          prog="conan export-pkg")

--- a/conans/client/command.py
+++ b/conans/client/command.py
@@ -746,7 +746,9 @@ class Command(object):
         return self._conan.imports(args.path, args.import_folder, args.install_folder)
 
     def export_pkg(self, *args):
-        """Exports a recipe, then creates a package from local source and build folders.
+        """
+        Exports a recipe, then creates a package from local-source-folder and
+        build-folder (or use already packaged files if a package-folder is provided).
 
         The package is created by calling the package() method applied to the
         local folders '--source-folder' and '--build-folder' It's created in


### PR DESCRIPTION
Changelog: omit
Docs: omit

Closes https://github.com/conan-io/conan/issues/4829 (although it is more about docs)

I've reorganized/rewritten docs related to `export-pkg`: https://github.com/conan-io/docs/pull/1232