### PR TITLE
Add argument '--raw' to command inspect, more machine friendly

### DIFF
--- a/conans/client/command.py
+++ b/conans/client/command.py
@@ -208,10 +208,16 @@ class Command(object):
                             action=OnceArgument)
         parser.add_argument("-j", "--json", default=None, action=OnceArgument,
                             help='json output file')
+        parser.add_argument('--raw', default=False, action='store_true',
+                            help='Print just the value of the attributes to be displayed (ordered)')
 
         args = parser.parse_args(*args)
+
+        if args.raw and not args.attribute:
+            raise ConanException("With option '--raw' a list of attributes is required")
+
         result = self._conan.inspect(args.path_or_reference, args.attribute, args.remote)
-        Printer(self._user_io.out).print_inspect(result)
+        Printer(self._user_io.out).print_inspect(result, raw=args.raw)
         if args.json:
             json_output = json.dumps(result)
             if not os.path.isabs(args.json):

--- a/conans/client/command.py
+++ b/conans/client/command.py
@@ -216,6 +216,9 @@ class Command(object):
         if args.raw and args.attribute:
             raise ConanException("Argument '--raw' is incompatible with '-a'")
 
+        if args.raw and args.json:
+            raise ConanException("Argument '--raw' is incompatible with '--json'")
+
         attributes = [args.raw, ] if args.raw else args.attribute
 
         result = self._conan.inspect(args.path_or_reference, attributes, args.remote)

--- a/conans/client/command.py
+++ b/conans/client/command.py
@@ -208,15 +208,17 @@ class Command(object):
                             action=OnceArgument)
         parser.add_argument("-j", "--json", default=None, action=OnceArgument,
                             help='json output file')
-        parser.add_argument('--raw', default=False, action='store_true',
-                            help='Print just the value of the attributes to be displayed (ordered)')
+        parser.add_argument('--raw', default=None, action=OnceArgument,
+                            help='Print just the value of the requested attribute')
 
         args = parser.parse_args(*args)
 
-        if args.raw and not args.attribute:
-            raise ConanException("With option '--raw' a list of attributes is required")
+        if args.raw and args.attribute:
+            raise ConanException("Argument '--raw' is incompatible with '-a'")
 
-        result = self._conan.inspect(args.path_or_reference, args.attribute, args.remote)
+        attributes = [args.raw, ] if args.raw else args.attribute
+
+        result = self._conan.inspect(args.path_or_reference, attributes, args.remote)
         Printer(self._user_io.out).print_inspect(result, raw=args.raw)
         if args.json:
             json_output = json.dumps(result)

--- a/conans/client/printer.py
+++ b/conans/client/printer.py
@@ -29,15 +29,18 @@ class Printer(object):
                     v = OptionsValues(v)
                 elif isinstance(v, list):
                     v = OptionsValues(tuple(v))
-            if isinstance(v, (dict, OptionsValues)):
-                self._out.writeln("%s:" % k)
-                for ok, ov in sorted(v.items()):
-                    self._out.writeln("    %s: %s" % (ok, ov))
+                elif isinstance(v, dict):
+                    v = OptionsValues(v)
+
+            if raw:
+                self._out.write(str(v))
             else:
-                if not raw:
-                    self._out.writeln("%s: %s" % (k, str(v)))
+                if isinstance(v, (dict, OptionsValues)):
+                    self._out.writeln("%s:" % k)
+                    for ok, ov in sorted(v.items()):
+                        self._out.writeln("    %s: %s" % (ok, ov))
                 else:
-                    self._out.writeln(str(v))
+                    self._out.writeln("%s: %s" % (k, str(v)))
 
     def print_info(self, data, _info, package_filter=None, show_paths=False, show_revisions=False):
         """ Print in console the dependency information for a conan file

--- a/conans/client/printer.py
+++ b/conans/client/printer.py
@@ -20,7 +20,7 @@ class Printer(object):
     def __init__(self, out):
         self._out = out
 
-    def print_inspect(self, inspect):
+    def print_inspect(self, inspect, raw=False):
         for k, v in inspect.items():
             if k == "default_options":
                 if isinstance(v, str):
@@ -34,7 +34,10 @@ class Printer(object):
                 for ok, ov in sorted(v.items()):
                     self._out.writeln("    %s: %s" % (ok, ov))
             else:
-                self._out.writeln("%s: %s" % (k, str(v)))
+                if not raw:
+                    self._out.writeln("%s: %s" % (k, str(v)))
+                else:
+                    self._out.writeln(str(v))
 
     def print_info(self, data, _info, package_filter=None, show_paths=False, show_revisions=False):
         """ Print in console the dependency information for a conan file

--- a/conans/test/functional/command/inspect_test.py
+++ b/conans/test/functional/command/inspect_test.py
@@ -365,11 +365,15 @@ class InspectRawTest(unittest.TestCase):
         client.run("inspect . --raw", assert_error=True)
         client.run("inspect . --raw=name --raw=version", assert_error=True)
 
-    def test_invalid_with_attribute(self):
+    def test_incompatible_commands(self):
         client = TestClient()
         client.save({"conanfile.py": self.conanfile})
+
         client.run("inspect . --raw=name -a=version", assert_error=True)
         self.assertIn("ERROR: Argument '--raw' is incompatible with '-a'", client.out)
+
+        client.run("inspect . --raw=name --json=tmp.json", assert_error=True)
+        self.assertIn("ERROR: Argument '--raw' is incompatible with '--json'", client.out)
 
     def test_invalid_field(self):
         client = TestClient()

--- a/conans/test/functional/command/inspect_test.py
+++ b/conans/test/functional/command/inspect_test.py
@@ -365,6 +365,7 @@ class InspectRawTest(unittest.TestCase):
         client.run("inspect . -a name -a version --raw")
         self.assertEqual("MyPkg\n1.2.3\n", client.out)
 
+    @unittest.expectedFailure
     def test_options(self):
         client = TestClient()
         client.save({"conanfile.py": self.conanfile})
@@ -374,6 +375,7 @@ class InspectRawTest(unittest.TestCase):
         print(client.out)
         self.fail("AAA")
 
+    @unittest.expectedFailure
     def test_settings(self):
         client = TestClient()
         client.save({"conanfile.py": self.conanfile})

--- a/conans/test/functional/command/inspect_test.py
+++ b/conans/test/functional/command/inspect_test.py
@@ -362,6 +362,8 @@ class InspectRawTest(unittest.TestCase):
         client.save({"conanfile.py": self.conanfile})
         client.run("inspect . -a version -a name --raw")
         self.assertEqual("1.2.3\nMyPkg\n", client.out)
+        client.run("inspect . -a name -a version --raw")
+        self.assertEqual("MyPkg\n1.2.3\n", client.out)
 
     def test_options(self):
         client = TestClient()


### PR DESCRIPTION
Changelog: Feature: Add a `--raw` argument to `conan inspect` command to get an output only with the value of the requested attributes
Docs: https://github.com/conan-io/docs/pull/1240

closes #3913 

