### PR TITLE
Always remove package folder in conan create

### DIFF
--- a/conans/client/installer.py
+++ b/conans/client/installer.py
@@ -82,7 +82,7 @@ class _PackageBuilder(object):
         export_source_folder = package_layout.export_sources()
 
         complete_recipe_sources(self._remote_manager, self._cache, conanfile, pref.ref, remotes)
-        remove_folder_raising(build_folder)
+        _remove_folder_raising(build_folder)
 
         config_source(export_folder, export_source_folder, source_folder,
                       conanfile, self._output, conanfile_path, pref.ref,
@@ -190,8 +190,7 @@ class _PackageBuilder(object):
 
         # BUILD & PACKAGE
         with package_layout.conanfile_read_lock(self._output):
-            remove_folder_raising(package_folder)
-            mkdir(package_folder)
+            _remove_folder_raising(package_folder)
             mkdir(build_folder)
             os.chdir(build_folder)
             self._output.info('Building your package in %s' % build_folder)
@@ -225,7 +224,7 @@ class _PackageBuilder(object):
             return node.pref
 
 
-def remove_folder_raising(folder):
+def _remove_folder_raising(folder):
     try:
         rmdir(folder)
     except OSError as e:

--- a/conans/client/installer.py
+++ b/conans/client/installer.py
@@ -135,7 +135,6 @@ class _PackageBuilder(object):
 
     def _package(self, conanfile, pref, package_layout, conanfile_path, build_folder,
                  package_folder):
-        remove_folder_raising(package_folder)
 
         # FIXME: Is weak to assign here the recipe_hash
         manifest = package_layout.recipe_manifest()
@@ -191,6 +190,8 @@ class _PackageBuilder(object):
 
         # BUILD & PACKAGE
         with package_layout.conanfile_read_lock(self._output):
+            remove_folder_raising(package_folder)
+            mkdir(package_folder)
             mkdir(build_folder)
             os.chdir(build_folder)
             self._output.info('Building your package in %s' % build_folder)
@@ -230,6 +231,7 @@ def remove_folder_raising(folder):
     except OSError as e:
         raise ConanException("%s\n\nCouldn't remove folder, might be busy or open\n"
                              "Close any app using it, and retry" % str(e))
+
 
 def _handle_system_requirements(conan_file, pref, cache, out):
     """ check first the system_reqs/system_requirements.txt existence, if not existing

--- a/conans/test/functional/command/create_test.py
+++ b/conans/test/functional/command/create_test.py
@@ -106,7 +106,6 @@ class HelloTestConan(ConanFile):
         # keep the source
         client.save({"conanfile.py": conanfile + " "})
         client.run("create . Pkg/0.1@lasote/testing --keep-source")
-        print("PRIIIINTtttt", client.out)
         self.assertIn("A new conanfile.py version was exported", client.out)
         self.assertNotIn("Pkg/0.1@lasote/testing: mysource!!", client.out)
         self.assertIn("Pkg/0.1@lasote/testing: mybuild!!", client.out)
@@ -114,7 +113,6 @@ class HelloTestConan(ConanFile):
         self.assertIn("Pkg/0.1@lasote/testing package(): Packaged 1 '.h' file: header.h", client.out)
         # keep build
         client.run("create . Pkg/0.1@lasote/testing --keep-build")
-        print("PRIIIINT", client.out)
         self.assertIn("Pkg/0.1@lasote/testing: Won't be built as specified by --keep-build",
                       client.out)
         self.assertNotIn("Pkg/0.1@lasote/testing: mysource!!", client.out)

--- a/conans/test/functional/command/create_test.py
+++ b/conans/test/functional/command/create_test.py
@@ -84,9 +84,6 @@ class HelloTestConan(ConanFile):
                     self.copy("*.h")
             """)
         if with_test:
-            client.save({"conanfile.py": conanfile,
-                         "header.h": ""})
-        else:
             test_conanfile = textwrap.dedent("""
             from conans import ConanFile
 
@@ -97,6 +94,9 @@ class HelloTestConan(ConanFile):
             client.save({"conanfile.py": conanfile,
                          "header.h": "",
                          "test_package/conanfile.py": test_conanfile})
+        else:
+            client.save({"conanfile.py": conanfile,
+                         "header.h": ""})
 
         client.run("create . Pkg/0.1@lasote/testing")
         self.assertIn("Pkg/0.1@lasote/testing: mysource!!", client.out)


### PR DESCRIPTION
Changelog: Bugfix: Remove package folder in ``conan create`` even when using ``--keep-build``
Docs: omit

- [x] Refer to the issue that supports this Pull Request: closes #4804 
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.

<sup>**Note:** By default this PR will skip the slower tests and will use a limited set of python versions. Check [here](https://github.com/conan-io/conan/blob/develop/.github/PR_INCREASE_TESTING.md) how to increase the testing level by writing some tags in the current PR body text.</sup>
