### PR TITLE
Remove ProcessedProfile class

### DIFF
--- a/conans/client/loader.py
+++ b/conans/client/loader.py
@@ -17,17 +17,6 @@ from conans.model.values import Values
 from conans.util.files import load
 
 
-class ProcessedProfile(object):
-    def __init__(self, profile, create_reference=None):
-        self._settings = profile.processed_settings
-        self._user_options = profile.options.copy()
-
-        self._package_settings = profile.package_settings_values
-        self._env_values = profile.env_values
-        # Make sure the paths are normalized first, so env_values can be just a copy
-        self._dev_reference = create_reference
-
-
 class ConanFileLoader(object):
     def __init__(self, runner, output, python_requires):
         self._runner = runner
@@ -78,19 +67,19 @@ class ConanFileLoader(object):
         return conanfile(self._output, self._runner, str(ref), user, channel)
 
     @staticmethod
-    def _initialize_conanfile(conanfile, processed_profile):
+    def _initialize_conanfile(conanfile, profile):
         # Prepare the settings for the loaded conanfile
         # Mixing the global settings with the specified for that name if exist
-        tmp_settings = processed_profile._settings.copy()
-        if (processed_profile._package_settings and
-                conanfile.name in processed_profile._package_settings):
+        tmp_settings = profile.processed_settings.copy()
+        if (profile.package_settings_values and
+                conanfile.name in profile.package_settings_values):
             # Update the values, keeping old ones (confusing assign)
-            values_tuple = processed_profile._package_settings[conanfile.name]
+            values_tuple = profile.package_settings_values[conanfile.name]
             tmp_settings.values = Values.from_list(values_tuple)
 
-        conanfile.initialize(tmp_settings, processed_profile._env_values)
+        conanfile.initialize(tmp_settings, profile.env_values)
 
-    def load_consumer(self, conanfile_path, processed_profile, name=None, version=None, user=None,
+    def load_consumer(self, conanfile_path, profile, name=None, version=None, user=None,
                       channel=None, test=None):
 
         conanfile_class = self.load_class(conanfile_path)
@@ -113,49 +102,50 @@ class ConanFileLoader(object):
         conanfile = conanfile_class(self._output, self._runner, display_name, user, channel)
         conanfile.in_local_cache = False
         try:
-            self._initialize_conanfile(conanfile, processed_profile)
+            self._initialize_conanfile(conanfile, profile)
 
             # The consumer specific
             conanfile.develop = True
-            processed_profile._user_options.descope_options(conanfile.name)
-            conanfile.options.initialize_upstream(processed_profile._user_options,
-                                                  name=conanfile.name)
-            processed_profile._user_options.clear_unscoped_options()
+            options = profile.options.copy()
+            options.descope_options(conanfile.name)
+            conanfile.options.initialize_upstream(options, name=conanfile.name)
+            # profile._user_options.clear_unscoped_options()
 
             return conanfile
         except Exception as e:  # re-raise with file name
             raise ConanException("%s: %s" % (conanfile_path, str(e)))
 
-    def load_conanfile(self, conanfile_path, processed_profile, ref):
+    def load_conanfile(self, conanfile_path, profile, ref, is_develop):
         conanfile_class = self.load_class(conanfile_path)
         conanfile_class.name = ref.name
         conanfile_class.version = ref.version
         conanfile = conanfile_class(self._output, self._runner, str(ref), ref.user, ref.channel)
-        if processed_profile._dev_reference and processed_profile._dev_reference == ref:
-            conanfile.develop = True
+        conanfile.develop = is_develop
         try:
-            self._initialize_conanfile(conanfile, processed_profile)
+            self._initialize_conanfile(conanfile, profile)
             return conanfile
         except Exception as e:  # re-raise with file name
             raise ConanException("%s: %s" % (conanfile_path, str(e)))
 
-    def load_conanfile_txt(self, conan_txt_path, processed_profile, ref=None):
+    def load_conanfile_txt(self, conan_txt_path, profile, ref=None):
+        # TODO: Can 'ref' be None?
+        # TODO: I want to pass the 'is_develop' flag here too
         if not os.path.exists(conan_txt_path):
             raise NotFoundException("Conanfile not found!")
 
         contents = load(conan_txt_path)
         path, basename = os.path.split(conan_txt_path)
         display_name = "%s (%s)" % (basename, ref) if ref and ref.name else basename
-        conanfile = self._parse_conan_txt(contents, path, display_name, processed_profile)
+        conanfile = self._parse_conan_txt(contents, path, display_name, profile)
         return conanfile
 
-    def _parse_conan_txt(self, contents, path, display_name, processed_profile):
+    def _parse_conan_txt(self, contents, path, display_name, profile):
         conanfile = ConanFile(self._output, self._runner, display_name)
-        conanfile.initialize(Settings(), processed_profile._env_values)
+        conanfile.initialize(Settings(), profile.env_values)
         # It is necessary to copy the settings, because the above is only a constraint of
         # conanfile settings, and a txt doesn't define settings. Necessary for generators,
         # as cmake_multi, that check build_type.
-        conanfile.settings = processed_profile._settings.copy_values()
+        conanfile.settings = profile.processed_settings.copy_values()
 
         try:
             parser = ConanFileTextLoader(contents)
@@ -174,31 +164,31 @@ class ConanFileLoader(object):
 
         options = OptionsValues.loads(parser.options)
         conanfile.options.values = options
-        conanfile.options.initialize_upstream(processed_profile._user_options)
+        conanfile.options.initialize_upstream(profile.options.copy())
 
         # imports method
         conanfile.imports = parser.imports_method(conanfile)
         return conanfile
 
-    def load_virtual(self, references, processed_profile, scope_options=True,
-                     build_requires_options=None):
+    def load_virtual(self, references, profile, scope_options=True, build_requires_options=None):
         # If user don't specify namespace in options, assume that it is
         # for the reference (keep compatibility)
         conanfile = ConanFile(self._output, self._runner, display_name="virtual")
-        conanfile.initialize(processed_profile._settings.copy(), processed_profile._env_values)
-        conanfile.settings = processed_profile._settings.copy_values()
+        conanfile.initialize(profile.processed_settings.copy(), profile.env_values)
+        conanfile.settings = profile.processed_settings.copy_values()
 
         for reference in references:
             conanfile.requires.add(reference.full_repr())  # Convert to string necessary
         # Allows options without package namespace in conan install commands:
         #   conan install zlib/1.2.8@lasote/stable -o shared=True
+        options = profile.options.copy()
         if scope_options:
             assert len(references) == 1
-            processed_profile._user_options.scope_options(references[0].name)
+            options.scope_options(references[0].name)
         if build_requires_options:
             conanfile.options.initialize_upstream(build_requires_options)
         else:
-            conanfile.options.initialize_upstream(processed_profile._user_options)
+            conanfile.options.initialize_upstream(options)
 
         conanfile.generators = []  # remove the default txt generator
         return conanfile

--- a/conans/test/functional/old/create_package_test.py
+++ b/conans/test/functional/old/create_package_test.py
@@ -8,7 +8,7 @@ from conans.client.packager import create_package
 from conans.model.ref import ConanFileReference, PackageReference
 from conans.paths import CONANFILE, CONANINFO
 from conans.test.utils.test_files import hello_source_files
-from conans.test.utils.tools import TestBufferConanOutput, TestClient, test_processed_profile
+from conans.test.utils.tools import TestBufferConanOutput, TestClient, test_profile
 
 
 myconan1 = """
@@ -78,7 +78,7 @@ class ExporterTest(unittest.TestCase):
         shutil.copytree(reg_folder, build_folder)
 
         loader = ConanFileLoader(None, TestBufferConanOutput(), ConanPythonRequire(None, None))
-        conanfile = loader.load_consumer(conanfile_path, test_processed_profile())
+        conanfile = loader.load_consumer(conanfile_path, test_profile())
 
         create_package(conanfile, None, build_folder, build_folder, package_folder, install_folder,
                        client.hook_manager, conanfile_path, ref, copy_info=True)

--- a/conans/test/unittests/client/conanfile_loader_test.py
+++ b/conans/test/unittests/client/conanfile_loader_test.py
@@ -19,7 +19,7 @@ from conans.model.profile import Profile
 from conans.model.requires import Requirements
 from conans.model.settings import Settings
 from conans.test.utils.test_files import temp_folder
-from conans.test.utils.tools import test_processed_profile,\
+from conans.test.utils.tools import test_profile,\
     TestBufferConanOutput
 from conans.util.files import save
 
@@ -44,7 +44,7 @@ class BasePackage(ConanFile):
         self.assertEqual(conan_file.short_paths, True)
 
         result = loader.load_consumer(conanfile_path,
-                                      processed_profile=test_processed_profile())
+                                      profile=test_profile())
         self.assertEqual(result.short_paths, True)
 
     def requires_init_test(self):
@@ -60,7 +60,7 @@ class MyTest(ConanFile):
         for requires in ("''", "[]", "()", "None"):
             save(conanfile_path, conanfile.format(requires))
             result = loader.load_consumer(conanfile_path,
-                                          processed_profile=test_processed_profile())
+                                          profile=test_profile())
             result.requirements()
             self.assertEqual("MyPkg/0.1@user/channel", str(result.requires))
 
@@ -127,7 +127,7 @@ OpenCV2:other_option=Cosa
         file_path = os.path.join(tmp_dir, "file.txt")
         save(file_path, file_content)
         loader = ConanFileLoader(None, TestBufferConanOutput(), None)
-        ret = loader.load_conanfile_txt(file_path, test_processed_profile())
+        ret = loader.load_conanfile_txt(file_path, test_profile())
         options1 = OptionsValues.loads("""OpenCV:use_python=True
 OpenCV:other_option=False
 OpenCV2:use_python2=1
@@ -158,7 +158,7 @@ OpenCV/2.4.104phil/stable
         save(file_path, file_content)
         loader = ConanFileLoader(None, TestBufferConanOutput(), None)
         with six.assertRaisesRegex(self, ConanException, "Wrong package recipe reference(.*)"):
-            loader.load_conanfile_txt(file_path, test_processed_profile())
+            loader.load_conanfile_txt(file_path, test_profile())
 
         file_content = '''[requires]
 OpenCV/2.4.10@phil/stable111111111111111111111111111111111111111111111111111111111111111
@@ -170,7 +170,7 @@ OpenCV/bin/* - ./bin
         save(file_path, file_content)
         loader = ConanFileLoader(None, TestBufferConanOutput(), None)
         with six.assertRaisesRegex(self, ConanException, "is too long. Valid names must contain"):
-            loader.load_conanfile_txt(file_path, test_processed_profile())
+            loader.load_conanfile_txt(file_path, test_profile())
 
     def load_imports_arguments_test(self):
         file_content = '''
@@ -185,7 +185,7 @@ licenses, * -> ./licenses @ root_package=Pkg, folder=True, ignore_case=True, exc
         file_path = os.path.join(tmp_dir, "file.txt")
         save(file_path, file_content)
         loader = ConanFileLoader(None, TestBufferConanOutput(), None)
-        ret = loader.load_conanfile_txt(file_path, test_processed_profile())
+        ret = loader.load_conanfile_txt(file_path, test_profile())
 
         ret.copy = Mock()
         ret.imports()
@@ -217,19 +217,19 @@ class MyTest(ConanFile):
         loader = ConanFileLoader(None, TestBufferConanOutput(), ConanPythonRequire(None, None))
 
         recipe = loader.load_consumer(conanfile_path,
-                                      test_processed_profile(profile))
+                                      test_profile(profile))
         self.assertEqual(recipe.settings.os, "Windows")
 
         # Apply Linux for MyPackage
         profile.package_settings = {"MyPackage": OrderedDict([("os", "Linux")])}
         recipe = loader.load_consumer(conanfile_path,
-                                      test_processed_profile(profile))
+                                      test_profile(profile))
         self.assertEqual(recipe.settings.os, "Linux")
 
         # If the package name is different from the conanfile one, it wont apply
         profile.package_settings = {"OtherPACKAGE": OrderedDict([("os", "Linux")])}
         recipe = loader.load_consumer(conanfile_path,
-                                      test_processed_profile(profile))
+                                      test_profile(profile))
         self.assertIsNone(recipe.settings.os.value)
 
 

--- a/conans/test/unittests/client/graph/version_ranges_graph_test.py
+++ b/conans/test/unittests/client/graph/version_ranges_graph_test.py
@@ -9,7 +9,7 @@ from conans.model.ref import ConanFileReference
 from conans.model.requires import Requirements
 from conans.test.unittests.model.transitive_reqs_test import GraphTest
 from conans.test.utils.conanfile import TestConanFile
-from conans.test.utils.tools import test_processed_profile
+from conans.test.utils.tools import test_profile
 
 
 def _get_nodes(graph, name):
@@ -47,9 +47,9 @@ class VersionRangesTest(GraphTest):
 
     def build_graph(self, content, update=False):
         self.loader.cached_conanfiles = {}
-        processed_profile = test_processed_profile()
-        root_conan = self.retriever.root(str(content), processed_profile)
-        deps_graph = self.builder.load_graph(root_conan, update, update, None, processed_profile)
+        profile = test_profile()
+        root_conan = self.retriever.root(str(content), profile)
+        deps_graph = self.builder.load_graph(root_conan, update, update, None, profile)
         self.output.write("\n".join(self.resolver.output))
         return deps_graph
 

--- a/conans/test/unittests/client/loader_test.py
+++ b/conans/test/unittests/client/loader_test.py
@@ -27,7 +27,7 @@ class LoadConanfileTxtTest(unittest.TestCase):
         output = TestBufferConanOutput()
         self.loader = ConanFileLoader(TestRunner(output), output, None)
 
-    def env_test(self):
+    def test_env_test(self):
         env_values = EnvValues()
         env_values.add("PREPEND_PATH", ["hello", "bye"])
         env_values.add("VAR", ["var_value"])
@@ -65,5 +65,6 @@ class LoadConanfileTest(unittest.TestCase):
                     version = "1.0"
              """))
         ref = ConanFileReference("hello", "1.0", "user", "channel")
-        conanfile = self.loader.load_conanfile(self.conanfile_path, self.profile, ref)
+        conanfile = self.loader.load_conanfile(self.conanfile_path, self.profile, ref,
+                                               is_develop=False)
         self.assertEqual(conanfile.env, {"PREPEND_PATH": ["hello", "bye"], "VAR": ["var_value"]})

--- a/conans/test/unittests/client/loader_test.py
+++ b/conans/test/unittests/client/loader_test.py
@@ -8,7 +8,6 @@ from conans.client.loader import ConanFileLoader
 from conans.model.env_info import EnvValues
 from conans.model.profile import Profile
 from conans.model.ref import ConanFileReference
-from conans.test.utils.conanfile import MockSettings
 from conans.test.utils.runner import TestRunner
 from conans.test.utils.test_files import temp_folder
 from conans.test.utils.tools import TestBufferConanOutput
@@ -20,9 +19,7 @@ class LoadConanfileTxtTest(unittest.TestCase):
     def setUp(self):
         settings = Settings()
         self.profile = Profile()
-        self.profile._settings = settings
-        self.profile._user_options = None
-        self.profile._env_values = None
+        self.profile.processed_settings = settings
         self.conanfile_txt_path = os.path.join(temp_folder(), "conanfile.txt")
         output = TestBufferConanOutput()
         self.loader = ConanFileLoader(TestRunner(output), output, None)
@@ -31,7 +28,7 @@ class LoadConanfileTxtTest(unittest.TestCase):
         env_values = EnvValues()
         env_values.add("PREPEND_PATH", ["hello", "bye"])
         env_values.add("VAR", ["var_value"])
-        self.profile._env_values = env_values
+        self.profile.env_values = env_values
         save(self.conanfile_txt_path, "")
         conanfile = self.loader.load_conanfile_txt(self.conanfile_txt_path, self.profile)
         self.assertEqual(conanfile.env, {"PREPEND_PATH": ["hello", "bye"], "VAR": ["var_value"]})
@@ -42,11 +39,7 @@ class LoadConanfileTest(unittest.TestCase):
     def setUp(self):
         settings = Settings()
         self.profile = Profile()
-        self.profile._settings = settings
-        self.profile._user_options = None
-        self.profile._env_values = None
-        self.profile._dev_reference = None
-        self.profile._package_settings = None
+        self.profile.processed_settings = settings
         self.conanfile_path = os.path.join(temp_folder(), "conanfile.py")
         output = TestBufferConanOutput()
         self.loader = ConanFileLoader(TestRunner(output), output, ConanPythonRequire(None, None))
@@ -55,7 +48,7 @@ class LoadConanfileTest(unittest.TestCase):
         env_values = EnvValues()
         env_values.add("PREPEND_PATH", ["hello", "bye"])
         env_values.add("VAR", ["var_value"])
-        self.profile._env_values = env_values
+        self.profile.env_values = env_values
         save(self.conanfile_path,
              textwrap.dedent("""
                 from conans import ConanFile

--- a/conans/test/unittests/client/loader_test.py
+++ b/conans/test/unittests/client/loader_test.py
@@ -27,7 +27,7 @@ class LoadConanfileTxtTest(unittest.TestCase):
         output = TestBufferConanOutput()
         self.loader = ConanFileLoader(TestRunner(output), output, None)
 
-    def test_env_test(self):
+    def env_test(self):
         env_values = EnvValues()
         env_values.add("PREPEND_PATH", ["hello", "bye"])
         env_values.add("VAR", ["var_value"])

--- a/conans/test/unittests/model/fake_retriever.py
+++ b/conans/test/unittests/model/fake_retriever.py
@@ -13,10 +13,10 @@ class Retriever(object):
         self.loader = loader
         self.folder = temp_folder()
 
-    def root(self, content, processed_profile):
+    def root(self, content, profile):
         conan_path = os.path.join(self.folder, ".conan", "data", "root.py")
         save(conan_path, content)
-        conanfile = self.loader.load_consumer(conan_path, processed_profile)
+        conanfile = self.loader.load_consumer(conan_path, profile)
         return Node(None, conanfile, "rootpath")
 
     def save_recipe(self, ref, content):

--- a/conans/test/unittests/model/transitive_reqs_test.py
+++ b/conans/test/unittests/model/transitive_reqs_test.py
@@ -23,7 +23,7 @@ from conans.model.values import Values
 from conans.test.unittests.model.fake_retriever import Retriever
 from conans.test.utils.conanfile import TestConanFile
 from conans.test.utils.tools import (NO_SETTINGS_PACKAGE_ID, TestBufferConanOutput,
-                                     test_processed_profile)
+                                     test_profile)
 
 say_content = TestConanFile("Say", "0.1")
 say_content2 = TestConanFile("Say", "0.2")
@@ -83,7 +83,7 @@ class GraphTest(unittest.TestCase):
         self.remote_search = MockSearchRemote()
         self.resolver = RangeResolver(paths, self.remote_search)
         self.builder = DepsGraphBuilder(self.retriever, self.output, self.loader,
-                                        self.resolver, None)
+                                        self.resolver, None, dev_reference=None)
         cache = Mock()
         cache.config.default_package_id_mode = "semver_direct_mode"
         remote_manager = None
@@ -96,9 +96,9 @@ class GraphTest(unittest.TestCase):
         profile = Profile()
         profile.processed_settings = full_settings
         profile.options = OptionsValues.loads(options)
-        processed_profile = test_processed_profile(profile=profile)
-        root_conan = self.retriever.root(str(content), processed_profile)
-        deps_graph = self.builder.load_graph(root_conan, False, False, None, processed_profile)
+        profile = test_profile(profile=profile)
+        root_conan = self.retriever.root(str(content), profile)
+        deps_graph = self.builder.load_graph(root_conan, False, False, None, profile)
 
         build_mode = BuildMode([], self.output)
         self.binaries_analyzer.evaluate_graph(deps_graph, build_mode=build_mode,
@@ -1459,7 +1459,7 @@ class ConsumerConan(ConanFile):
         self.loader = ConanFileLoader(None, self.output, ConanPythonRequire(None, None))
         self.retriever = Retriever(self.loader)
         self.builder = DepsGraphBuilder(self.retriever, self.output, self.loader,
-                                        Mock(), None)
+                                        Mock(), None, dev_reference=None)
         liba_ref = ConanFileReference.loads("LibA/0.1@user/testing")
         libb_ref = ConanFileReference.loads("LibB/0.1@user/testing")
         libc_ref = ConanFileReference.loads("LibC/0.1@user/testing")
@@ -1470,9 +1470,9 @@ class ConsumerConan(ConanFile):
         self.retriever.save_recipe(libd_ref, self.libd_content)
 
     def build_graph(self, content):
-        processed_profile = test_processed_profile()
-        root_conan = self.retriever.root(content, processed_profile)
-        deps_graph = self.builder.load_graph(root_conan, False, False, None, processed_profile)
+        profile = test_profile()
+        root_conan = self.retriever.root(content, profile)
+        deps_graph = self.builder.load_graph(root_conan, False, False, None, profile)
         return deps_graph
 
     def test_avoid_duplicate_expansion(self):
@@ -1845,10 +1845,10 @@ class ChatConan(ConanFile):
         self.retriever.save_recipe(say_ref, say_content)
         self.retriever.save_recipe(hello_ref, hello_content)
 
-        processed_profile = test_processed_profile(profile=profile)
-        root_conan = self.retriever.root(chat_content, processed_profile)
+        profile = test_profile(profile=profile)
+        root_conan = self.retriever.root(chat_content, profile)
         deps_graph = self.builder.load_graph(root_conan, False, False, None,
-                                             processed_profile=processed_profile)
+                                             profile=profile)
 
         build_mode = BuildMode([], self.output)
         self.binaries_analyzer.evaluate_graph(deps_graph, build_mode=build_mode,

--- a/conans/test/unittests/tools/files_patch_test.py
+++ b/conans/test/unittests/tools/files_patch_test.py
@@ -8,7 +8,7 @@ from conans.client.graph.python_requires import ConanPythonRequire
 from conans.client.loader import ConanFileLoader
 from conans.test.utils.test_files import temp_folder
 from conans.test.utils.tools import TestClient, TestBufferConanOutput,\
-    test_processed_profile
+    test_profile
 from conans.util.files import save, load
 
 base_conanfile = '''
@@ -159,7 +159,7 @@ class ToolsFilesPatchTest(unittest.TestCase):
 
     def _build_and_check(self, tmp_dir, file_path, text_file, msg):
         loader = ConanFileLoader(None, TestBufferConanOutput(), ConanPythonRequire(None, None))
-        ret = loader.load_consumer(file_path, test_processed_profile())
+        ret = loader.load_consumer(file_path, test_profile())
         curdir = os.path.abspath(os.curdir)
         os.chdir(tmp_dir)
         try:

--- a/conans/test/utils/tools.py
+++ b/conans/test/utils/tools.py
@@ -31,7 +31,6 @@ from conans.client.command import Command
 from conans.client.conan_api import Conan, get_request_timeout, migrate_and_get_cache
 from conans.client.conan_command_output import CommandOutputer
 from conans.client.hook_manager import HookManager
-from conans.client.loader import ProcessedProfile
 from conans.client.output import ConanOutput
 from conans.client.rest.conan_requester import ConanRequester
 from conans.client.rest.uploader_downloader import IterableToFileAdapter
@@ -79,12 +78,12 @@ def inc_package_manifest_timestamp(cache, package_reference, inc_time):
     manifest.save(path)
 
 
-def test_processed_profile(profile=None, settings=None):
+def test_profile(profile=None, settings=None):
     if profile is None:
         profile = Profile()
     if profile.processed_settings is None:
         profile.processed_settings = settings or Settings()
-    return ProcessedProfile(profile=profile)
+    return profile
 
 
 class TestingResponse(object):


### PR DESCRIPTION
Changelog: (Feature | Fix | Bugfix): Describe here your pull request
Docs: https://github.com/conan-io/docs/pull/XXXX

`ProcessedProfile` is almost just a view over a `Profile`, there is no need for this extra class. The `dev_reference` from my POV should go in the graph, not in the profile.

@tags: slow
