### PR TITLE
new full metadata revision migration

### DIFF
--- a/conans/client/migrations.py
+++ b/conans/client/migrations.py
@@ -51,8 +51,25 @@ class ClientMigrator(Migrator):
         if old_version is None:
             return
 
-        if old_version < Version("1.14.0"):
-            migrate_config_install(self.cache)
+        if old_version < Version("0.25"):
+            from conans.paths import DEFAULT_PROFILE_NAME
+            default_profile_path = os.path.join(self.cache.conan_folder, PROFILES_FOLDER,
+                                                DEFAULT_PROFILE_NAME)
+            if not os.path.exists(default_profile_path):
+                self.out.warn("Migration: Moving default settings from %s file to %s"
+                              % (CONAN_CONF, DEFAULT_PROFILE_NAME))
+                conf_path = os.path.join(self.cache.conan_folder, CONAN_CONF)
+
+                migrate_to_default_profile(conf_path, default_profile_path)
+
+                self.out.warn("Migration: export_source cache new layout")
+                migrate_c_src_export_source(self.cache, self.out)
+
+        if old_version < Version("1.0"):
+            _migrate_lock_files(self.cache, self.out)
+
+        if old_version < Version("1.12.0"):
+            migrate_plugins_to_hooks(self.cache)
 
         if old_version < Version("1.13.0"):
             old_settings = """
@@ -127,25 +144,8 @@ cppstd: [None, 98, gnu98, 11, gnu11, 14, gnu14, 17, gnu17, 20, gnu20]
             # MIGRATE LOCAL CACHE TO GENERATE MISSING METADATA.json
             _migrate_create_metadata(self.cache, self.out)
 
-        if old_version < Version("1.12.0"):
-            migrate_plugins_to_hooks(self.cache)
-
-        if old_version < Version("1.0"):
-            _migrate_lock_files(self.cache, self.out)
-
-        if old_version < Version("0.25"):
-            from conans.paths import DEFAULT_PROFILE_NAME
-            default_profile_path = os.path.join(self.cache.conan_folder, PROFILES_FOLDER,
-                                                DEFAULT_PROFILE_NAME)
-            if not os.path.exists(default_profile_path):
-                self.out.warn("Migration: Moving default settings from %s file to %s"
-                              % (CONAN_CONF, DEFAULT_PROFILE_NAME))
-                conf_path = os.path.join(self.cache.conan_folder, CONAN_CONF)
-
-                migrate_to_default_profile(conf_path, default_profile_path)
-
-                self.out.warn("Migration: export_source cache new layout")
-                migrate_c_src_export_source(self.cache, self.out)
+        if old_version < Version("1.14.0"):
+            migrate_config_install(self.cache)
 
         if old_version < Version("1.14.2"):
             _migrate_full_metadata(self.cache, self.out)

--- a/conans/test/functional/old/test_migrations.py
+++ b/conans/test/functional/old/test_migrations.py
@@ -1,3 +1,4 @@
+import json
 import os
 import unittest
 
@@ -7,12 +8,50 @@ from conans import __version__
 from conans.client.migrations import migrate_plugins_to_hooks, migrate_to_default_profile
 from conans.client.output import ConanOutput
 from conans.migrations import CONAN_VERSION
+from conans.model.ref import ConanFileReference
+from conans.test.utils.conanfile import TestConanFile
 from conans.test.utils.test_files import temp_folder
 from conans.test.utils.tools import TestClient
 from conans.util.files import load, save
 
 
 class TestMigrations(unittest.TestCase):
+
+    def test_migrate_revision_metadata(self):
+        # https://github.com/conan-io/conan/issues/4898
+        client = TestClient()
+        client.save({"conanfile.py": str(TestConanFile("Hello", "0.1"))})
+        client.run("create . user/testing")
+        ref = ConanFileReference.loads("Hello/0.1@user/testing")
+        layout1 = client.cache.package_layout(ref)
+        metadata = json.loads(load(layout1.package_metadata()))
+        metadata["recipe"]["revision"] = None
+        metadata["packages"]["WRONG"] = {"revision": ""}
+        metadata["packages"]["5ab84d6acfe1f23c4fae0ab88f26e3a396351ac9"]["revision"] = None
+        metadata["packages"]["5ab84d6acfe1f23c4fae0ab88f26e3a396351ac9"]["recipe_revision"] = None
+        save(layout1.package_metadata(), json.dumps(metadata))
+
+        client.run("create . user/stable")
+        ref2 = ConanFileReference.loads("Hello/0.1@user/stable")
+        layout2 = client.cache.package_layout(ref2)
+        metadata = json.loads(load(layout2.package_metadata()))
+        metadata["recipe"]["revision"] = "Other"
+        save(layout2.package_metadata(), json.dumps(metadata))
+
+        version_file = os.path.join(client.cache.conan_folder, CONAN_VERSION)
+        save(version_file, "1.14.1")
+        client.run("search")  # This will fire a migration
+
+        metadata_ref1 = client.cache.package_layout(ref).load_metadata()
+        self.assertEqual(metadata_ref1.recipe.revision, "2e48797069e65568befd81854aa8aaf0")
+        pkg_metadata = metadata_ref1.packages["5ab84d6acfe1f23c4fae0ab88f26e3a396351ac9"]
+        self.assertEqual(pkg_metadata.recipe_revision, "2e48797069e65568befd81854aa8aaf0")
+        self.assertEqual(pkg_metadata.revision, "38d05b42210ca2becb43a05f9265abbe")
+        self.assertEqual(list(metadata_ref1.packages.keys()),
+                         ["5ab84d6acfe1f23c4fae0ab88f26e3a396351ac9"])
+
+        metadata_ref2 = client.cache.package_layout(ref2).load_metadata()
+        self.assertEqual(metadata_ref2.recipe.revision, "Other")
 
     def test_migrate_config_install(self):
         client = TestClient()


### PR DESCRIPTION
Changelog: Bugfix: Run a full metadata migration in the cache to avoid old ``null`` revisions in package metadata
Docs: omit

Close #4898
Close #4913