### PR TITLE
build_requires and private when already in graph

### DIFF
--- a/conans/client/graph/graph_builder.py
+++ b/conans/client/graph/graph_builder.py
@@ -134,7 +134,8 @@ class DepsGraphBuilder(object):
                                  % (node.ref, require.ref))
 
         previous = node.public_deps.get(name)
-        if require.private or require.build_require or not previous:
+        previous_closure = node.public_closure.get(name)
+        if not previous or ((require.build_require or require.private) and not previous_closure):
             # new node, must be added and expanded
             # node -> new_node
             new_node = self._create_new_node(node, dep_graph, require, name,


### PR DESCRIPTION
Changelog: Bugfix: ``build-requires`` and ``private`` requirements that resolve to a dependency that is already in the graph won't span a new node, nor will be ``build-requires`` or ``private``. They can conflict too.
Docs: Omit

Close #4931

@tags: slow
