### PR TITLE
Implement tools.Version (based on SemVer)

### DIFF
--- a/conans/client/tools/version.py
+++ b/conans/client/tools/version.py
@@ -21,15 +21,15 @@ class Version(object):
 
     @property
     def major(self):
-        return self._semver.major
+        return str(self._semver.major)
 
     @property
     def minor(self):
-        return self._semver.minor
+        return str(self._semver.minor)
 
     @property
     def patch(self):
-        return self._semver.patch
+        return str(self._semver.patch)
 
     def __eq__(self, other):
         if not isinstance(other, Version):

--- a/conans/client/tools/version.py
+++ b/conans/client/tools/version.py
@@ -1,0 +1,42 @@
+# coding=utf-8
+
+from functools import total_ordering
+
+from semver import SemVer
+
+from conans.errors import ConanException
+
+
+@total_ordering
+class Version(object):
+    _semver = None
+    loose = True  # Allow incomplete version strings like '1.2' or '1-dev0'
+
+    def __init__(self, value):
+        v = str(value).strip()
+        try:
+            self._semver = SemVer(v, loose=self.loose)
+        except ValueError:
+            raise ConanException("Invalid version '{}'".format(value))
+
+    @property
+    def major(self):
+        return self._semver.major
+
+    @property
+    def minor(self):
+        return self._semver.minor
+
+    @property
+    def patch(self):
+        return self._semver.patch
+
+    def __eq__(self, other):
+        if not isinstance(other, Version):
+            other = Version(other)
+        return self._semver.compare_main(other._semver) == 0
+
+    def __lt__(self, other):
+        if not isinstance(other, Version):
+            other = Version(other)
+        return self._semver.compare_main(other._semver) < 0

--- a/conans/client/tools/version.py
+++ b/conans/client/tools/version.py
@@ -31,12 +31,20 @@ class Version(object):
     def patch(self):
         return str(self._semver.patch)
 
+    @property
+    def prerelease(self):
+        return str(".".join(map(str, self._semver.prerelease)))
+
+    @property
+    def build(self):
+        return str(".".join(map(str, self._semver.build)))
+
     def __eq__(self, other):
         if not isinstance(other, Version):
             other = Version(other)
-        return self._semver.compare_main(other._semver) == 0
+        return self._semver.compare(other._semver) == 0
 
     def __lt__(self, other):
         if not isinstance(other, Version):
             other = Version(other)
-        return self._semver.compare_main(other._semver) < 0
+        return self._semver.compare(other._semver) < 0

--- a/conans/test/unittests/client/tools/test_version.py
+++ b/conans/test/unittests/client/tools/test_version.py
@@ -1,0 +1,85 @@
+# coding=utf-8
+
+
+import unittest
+
+import six
+
+from conans.client.tools.version import Version
+from mock import patch
+from conans.errors import ConanException
+
+
+class ToolVersionTests(unittest.TestCase):
+
+    def test_invalid_values(self):
+        self.assertRaises(ConanException, Version, "")
+        self.assertRaises(ConanException, Version, "nonsense")
+        self.assertRaises(ConanException, Version, "a1.2.3")
+
+    def test_invalid_message(self):
+        with six.assertRaisesRegex(self, ConanException, "Invalid version 'not-valid'"):
+            Version("not-valid")
+
+    def test_valid_values(self):
+        for v_str in ["1.2.3", "1.2.3-dev90", "1.2.3+dev90", "1.2.3-dev90+more", "1.2.3-dev90+a-b"]:
+            v = Version(v_str)
+            self.assertEqual(v.major, 1)
+            self.assertEqual(v.minor, 2)
+            self.assertEqual(v.patch, 3)
+
+    def test_valid_loose(self):
+        with patch.object(Version, "loose", True):
+            # These versions are considered valid with loose validation
+            self.assertTrue(Version.loose)
+            v = Version("1.2")
+            self.assertEqual(v.major, 1)
+            self.assertEqual(v.minor, 2)
+
+            v = Version("1")
+            self.assertEqual(v.major, 1)
+
+            v = Version(" 1a")
+            self.assertEqual(v.major, 1)
+
+    def test_convert_str(self):
+        # Check that we are calling the string method
+        class A(object):
+            def __str__(self):
+                return "1.2.3"
+
+        v = Version(A())
+        self.assertEqual(v.major, 1)
+        self.assertEqual(v.minor, 2)
+        self.assertEqual(v.patch, 3)
+
+    def test_compare(self):
+        self.assertTrue(Version("1.2.3") == "1.2.3")
+        self.assertTrue(Version("1.2.3") == Version("1.2.3"))
+
+        with patch.object(Version, "loose", True):
+            self.assertTrue(Version("234") == "234")
+            self.assertTrue(Version("234") == Version("234"))
+
+    def test_gt(self):
+        self.assertTrue(Version("1.2.3") > "1.2.2")
+
+        with patch.object(Version, "loose", True):
+            self.assertTrue(Version("1.2") > "1")
+            self.assertTrue(Version("1.2") > Version("1"))
+
+            self.assertFalse(Version("1.0") > "1")
+            self.assertFalse(Version("1.0.0") > "1")
+            self.assertFalse(Version("1") > "1.0")
+            self.assertFalse(Version("1") > "1.0.0")
+
+    def test_with_more_components(self):
+        # Prerelease, micro,... any other components but main ones are NOT considered
+        self.assertTrue(Version("1.2.3-dev90") == "1.2.3")
+        self.assertTrue(Version("1.2.3-dev90") == Version("1.2.3"))
+
+        with patch.object(Version, "loose", True):
+            self.assertTrue(Version("1.2.3.4") == Version("1.2.3"))
+
+            self.assertFalse(Version("1.2") > Version("1.2-dev0"))
+            self.assertFalse(Version("1.2") < Version("1.2-dev0"))

--- a/conans/test/unittests/client/tools/test_version.py
+++ b/conans/test/unittests/client/tools/test_version.py
@@ -6,7 +6,6 @@ import unittest
 import six
 
 from conans.client.tools.version import Version
-from mock import patch
 from conans.errors import ConanException
 
 
@@ -24,23 +23,29 @@ class ToolVersionTests(unittest.TestCase):
     def test_valid_values(self):
         for v_str in ["1.2.3", "1.2.3-dev90", "1.2.3+dev90", "1.2.3-dev90+more", "1.2.3-dev90+a-b"]:
             v = Version(v_str)
-            self.assertEqual(v.major, 1)
-            self.assertEqual(v.minor, 2)
-            self.assertEqual(v.patch, 3)
+            self.assertEqual(v.major, "1")
+            self.assertEqual(v.minor, "2")
+            self.assertEqual(v.patch, "3")
 
     def test_valid_loose(self):
-        with patch.object(Version, "loose", True):
-            # These versions are considered valid with loose validation
-            self.assertTrue(Version.loose)
-            v = Version("1.2")
-            self.assertEqual(v.major, 1)
-            self.assertEqual(v.minor, 2)
+        self.assertTrue(Version.loose)
 
-            v = Version("1")
-            self.assertEqual(v.major, 1)
+        # These versions are considered valid with loose validation
+        self.assertTrue(Version.loose)
+        v = Version("1.2")
+        self.assertEqual(v.major, "1")
+        self.assertEqual(v.minor, "2")
+        self.assertEqual(v.patch, "0")
 
-            v = Version(" 1a")
-            self.assertEqual(v.major, 1)
+        v = Version("1")
+        self.assertEqual(v.major, "1")
+        self.assertEqual(v.minor, "0")
+        self.assertEqual(v.patch, "0")
+
+        v = Version(" 1a")
+        self.assertEqual(v.major, "1")
+        self.assertEqual(v.minor, "0")
+        self.assertEqual(v.patch, "0")
 
     def test_convert_str(self):
         # Check that we are calling the string method
@@ -49,37 +54,37 @@ class ToolVersionTests(unittest.TestCase):
                 return "1.2.3"
 
         v = Version(A())
-        self.assertEqual(v.major, 1)
-        self.assertEqual(v.minor, 2)
-        self.assertEqual(v.patch, 3)
+        self.assertEqual(v.major, "1")
+        self.assertEqual(v.minor, "2")
+        self.assertEqual(v.patch, "3")
 
     def test_compare(self):
         self.assertTrue(Version("1.2.3") == "1.2.3")
         self.assertTrue(Version("1.2.3") == Version("1.2.3"))
 
-        with patch.object(Version, "loose", True):
-            self.assertTrue(Version("234") == "234")
-            self.assertTrue(Version("234") == Version("234"))
+        self.assertTrue(Version.loose)
+        self.assertTrue(Version("234") == "234")
+        self.assertTrue(Version("234") == Version("234"))
 
     def test_gt(self):
         self.assertTrue(Version("1.2.3") > "1.2.2")
 
-        with patch.object(Version, "loose", True):
-            self.assertTrue(Version("1.2") > "1")
-            self.assertTrue(Version("1.2") > Version("1"))
+        self.assertTrue(Version.loose)
+        self.assertTrue(Version("1.2") > "1")
+        self.assertTrue(Version("1.2") > Version("1"))
 
-            self.assertFalse(Version("1.0") > "1")
-            self.assertFalse(Version("1.0.0") > "1")
-            self.assertFalse(Version("1") > "1.0")
-            self.assertFalse(Version("1") > "1.0.0")
+        self.assertFalse(Version("1.0") > "1")
+        self.assertFalse(Version("1.0.0") > "1")
+        self.assertFalse(Version("1") > "1.0")
+        self.assertFalse(Version("1") > "1.0.0")
 
     def test_with_more_components(self):
         # Prerelease, micro,... any other components but main ones are NOT considered
         self.assertTrue(Version("1.2.3-dev90") == "1.2.3")
         self.assertTrue(Version("1.2.3-dev90") == Version("1.2.3"))
 
-        with patch.object(Version, "loose", True):
-            self.assertTrue(Version("1.2.3.4") == Version("1.2.3"))
+        self.assertTrue(Version.loose)
+        self.assertTrue(Version("1.2.3.4") == Version("1.2.3"))
 
-            self.assertFalse(Version("1.2") > Version("1.2-dev0"))
-            self.assertFalse(Version("1.2") < Version("1.2-dev0"))
+        self.assertFalse(Version("1.2") > Version("1.2-dev0"))
+        self.assertFalse(Version("1.2") < Version("1.2-dev0"))

--- a/conans/tools.py
+++ b/conans/tools.py
@@ -26,6 +26,7 @@ from conans.util.files import _generic_algorithm_sum, load, md5, md5sum, mkdir, 
     rmdir, save as files_save, save_append, sha1sum, sha256sum, touch, sha1sum, sha256sum, \
     to_file_bytes, touch
 from conans.util.log import logger
+from conans.client.tools.version import Version
 
 
 # This global variables are intended to store the configuration of the running Conan application


### PR DESCRIPTION
Changelog: Feature: Create `tools.Version` with _limited_ capabilities
Docs: https://github.com/conan-io/docs/pull/1253

 * I'm using `loose=True` to allow incomplete versions like `1.2` (no _patch_ component) or "2" (no _minor_ nor _patch_)

closes https://github.com/conan-io/conan/issues/4875

_Note.- Supersedes https://github.com/conan-io/conan/pull/4949_