### PR TITLE
refactor export for locks

### DIFF
--- a/conans/client/conan_api.py
+++ b/conans/client/conan_api.py
@@ -372,7 +372,7 @@ class ConanAPIV1(object):
             # The new_ref contains the revision
             # To not break existing things, that they used this ref without revision
             ref = new_ref.copy_clear_rev()
-            recorder.recipe_exported(ref)
+            recorder.recipe_exported(new_ref)
 
             if build_modes is None:  # Not specified, force build the tested library
                 build_modes = [ref.name]
@@ -434,7 +434,7 @@ class ConanAPIV1(object):
                                  self._hook_manager, self._loader, self._cache)
             ref = new_ref.copy_clear_rev()
             # new_ref has revision
-            recorder.recipe_exported(ref)
+            recorder.recipe_exported(new_ref)
             recorder.add_recipe_being_developed(ref)
             remotes = self._cache.registry.load_remotes()
             export_pkg(self._cache, self._graph_manager, self._hook_manager, recorder,

--- a/conans/client/conan_api.py
+++ b/conans/client/conan_api.py
@@ -432,13 +432,14 @@ class ConanAPIV1(object):
             new_ref = cmd_export(conanfile_path, name, version, user, channel, True,
                                  self._cache.config.revisions_enabled, self._user_io.out,
                                  self._hook_manager, self._loader, self._cache)
+            ref = new_ref.copy_clear_rev()
             # new_ref has revision
-            recorder.recipe_exported(new_ref)
-            recorder.add_recipe_being_developed(new_ref)
+            recorder.recipe_exported(ref)
+            recorder.add_recipe_being_developed(ref)
             remotes = self._cache.registry.load_remotes()
             export_pkg(self._cache, self._graph_manager, self._hook_manager, recorder,
                        self._user_io.out,
-                       new_ref, source_folder=source_folder, build_folder=build_folder,
+                       ref, source_folder=source_folder, build_folder=build_folder,
                        package_folder=package_folder, install_folder=install_folder,
                        graph_info=graph_info, force=force, remotes=remotes)
             return recorder.get_info(self._cache.config.revisions_enabled)

--- a/conans/client/conan_api.py
+++ b/conans/client/conan_api.py
@@ -11,8 +11,7 @@ from conans.client.cache.cache import ClientCache
 from conans.client.cmd.build import build
 from conans.client.cmd.create import create
 from conans.client.cmd.download import download
-from conans.client.cmd.export import cmd_export, export_alias, export_recipe, export_source, \
-    check_casing_conflict
+from conans.client.cmd.export import cmd_export, export_alias, export_recipe, export_source
 from conans.client.cmd.export_pkg import export_pkg
 from conans.client.cmd.profile import (cmd_profile_create, cmd_profile_delete_key, cmd_profile_get,
                                        cmd_profile_list, cmd_profile_update)
@@ -365,23 +364,18 @@ class ConanAPIV1(object):
             remotes.select(remote_name)
             self.python_requires.enable_remotes(update=update, remotes=remotes)
 
-            conanfile = self._loader.load_export(conanfile_path, name, version, user, channel)
-            ref = ConanFileReference(conanfile.name, conanfile.version, conanfile.user,
-                                     conanfile.channel)
             # Make sure keep_source is set for keep_build
             keep_source = keep_source or keep_build
-            # Forcing an export!
-            if not not_export:
-                check_casing_conflict(cache=self._cache, ref=ref)
-                package_layout = self._cache.package_layout(ref, short_paths=conanfile.short_paths)
-                new_ref = cmd_export(package_layout, conanfile_path, conanfile, keep_source,
-                                     self._cache.config.revisions_enabled, self._user_io.out,
-                                     self._hook_manager)
-                # The new_ref contains the revision
-                recorder.recipe_exported(new_ref)
+            new_ref = cmd_export(conanfile_path, name, version, user, channel, keep_source,
+                                 self._cache.config.revisions_enabled, self._user_io.out,
+                                 self._hook_manager, self._loader, self._cache, not not_export)
+            # The new_ref contains the revision
+            # To not break existing things, that they used this ref without revision
+            ref = new_ref.copy_clear_rev()
+            recorder.recipe_exported(ref)
 
             if build_modes is None:  # Not specified, force build the tested library
-                build_modes = [conanfile.name]
+                build_modes = [ref.name]
 
             manifests = _parse_manifests_arguments(verify, manifests, manifests_interactive, cwd)
             manifest_folder, manifest_interactive, manifest_verify = manifests
@@ -435,21 +429,16 @@ class ConanAPIV1(object):
             graph_info = get_graph_info(profile_names, settings, options, env, cwd, install_folder,
                                         self._cache, self._user_io.out)
 
-            conanfile = self._loader.load_export(conanfile_path, name, version, user, channel)
-            ref = ConanFileReference(conanfile.name, conanfile.version, user, channel)
-
-            check_casing_conflict(cache=self._cache, ref=ref)
-            package_layout = self._cache.package_layout(ref, short_paths=conanfile.short_paths)
-            new_ref = cmd_export(package_layout, conanfile_path, conanfile, False,
+            new_ref = cmd_export(conanfile_path, name, version, user, channel, True,
                                  self._cache.config.revisions_enabled, self._user_io.out,
-                                 self._hook_manager)
+                                 self._hook_manager, self._loader, self._cache)
             # new_ref has revision
             recorder.recipe_exported(new_ref)
-            recorder.add_recipe_being_developed(ref)
+            recorder.add_recipe_being_developed(new_ref)
             remotes = self._cache.registry.load_remotes()
             export_pkg(self._cache, self._graph_manager, self._hook_manager, recorder,
                        self._user_io.out,
-                       ref, source_folder=source_folder, build_folder=build_folder,
+                       new_ref, source_folder=source_folder, build_folder=build_folder,
                        package_folder=package_folder, install_folder=install_folder,
                        graph_info=graph_info, force=force, remotes=remotes)
             return recorder.get_info(self._cache.config.revisions_enabled)
@@ -781,14 +770,9 @@ class ConanAPIV1(object):
         conanfile_path = _get_conanfile_path(path, cwd, py=True)
         remotes = self._cache.registry.load_remotes()
         self.python_requires.enable_remotes(remotes=remotes)
-        conanfile = self._loader.load_export(conanfile_path, name, version, user, channel)
-        ref = ConanFileReference(conanfile.name, conanfile.version, conanfile.user,
-                                 conanfile.channel)
-        check_casing_conflict(cache=self._cache, ref=ref)
-        package_layout = self._cache.package_layout(ref, short_paths=conanfile.short_paths)
-        cmd_export(package_layout, conanfile_path, conanfile, keep_source,
+        cmd_export(conanfile_path, name, version, user, channel, keep_source,
                    self._cache.config.revisions_enabled, self._user_io.out,
-                   self._hook_manager)
+                   self._hook_manager, self._loader, self._cache)
 
     @api_method
     def remove(self, pattern, query=None, packages=None, builds=None, src=False, force=False,

--- a/conans/test/integration/devflow_test.py
+++ b/conans/test/integration/devflow_test.py
@@ -237,6 +237,7 @@ class DevOutSourceFlowTest(unittest.TestCase):
         # cmake finds it, using an install_folder different from build_folder
         client = TestClient()
         client.run("new lib/1.0")
+        # FIXME: this test, so it doesn't need to clone from github
         client.run("source . --source-folder src")
 
         # Patch the CMakeLists to include the generator file from a different folder


### PR DESCRIPTION
Changelog: omit
Docs: omit

This should be a pure refactor, no functionality change.
Moving common code into ``cmd_export`` instead of being in *conan_api.py*

@tags: slow, svn