### PR TITLE
Retry upload or download for error in response message

### DIFF
--- a/conans/client/rest/uploader_downloader.py
+++ b/conans/client/rest/uploader_downloader.py
@@ -63,6 +63,9 @@ class Uploader(object):
                 if auth.token is None:
                     raise AuthenticationException(response.content)
                 raise ForbiddenException(response.content)
+
+            response.raise_for_status()  # Raise HTTPError for bad http response status
+
         except ConanException:
             raise
         except Exception as exc:

--- a/conans/test/functional/remote/retry_test.py
+++ b/conans/test/functional/remote/retry_test.py
@@ -1,0 +1,104 @@
+# coding=utf-8
+
+import os
+import unittest
+from collections import namedtuple, Counter
+
+import six
+
+from conans.client.rest.uploader_downloader import Uploader
+from conans.errors import AuthenticationException, ForbiddenException
+from conans.test.utils.test_files import temp_folder
+from conans.test.utils.tools import TestBufferConanOutput
+from conans.util.files import save
+from requests.exceptions import HTTPError
+
+
+class response_type:
+    def __init__(self, status_code, content):
+        self.status_code = status_code
+        self.content = content
+
+    def raise_for_status(self):
+        """Raises stored :class:`HTTPError`, if one occurred."""
+
+        http_error_msg = ''
+        if 400 <= self.status_code < 500:
+            http_error_msg = u'%s Client Error: %s' % (self.status_code, self.content)
+
+        elif 500 <= self.status_code < 600:
+            http_error_msg = u'%s Server Error: %s' % (self.status_code, self.content)
+
+        if http_error_msg:
+            raise HTTPError(http_error_msg, response=self)
+
+
+class _RequesterMock:
+    def __init__(self, status_code, content):
+        self.response = response_type(status_code, content)
+
+    def put(self, *args, **kwargs):
+        return self.response
+
+
+class RetryDownloadTests(unittest.TestCase):
+
+    def setUp(self):
+        self.filename = os.path.join(temp_folder(), "anyfile")
+        save(self.filename, "anything")
+
+    def test_error_401(self):
+        output = TestBufferConanOutput()
+        uploader = Uploader(requester=_RequesterMock(401, "content"), output=output, verify=False)
+        with six.assertRaisesRegex(self, AuthenticationException, "content"):
+            uploader.upload(url="fake", abs_path=self.filename, retry=3)
+        output_lines = str(output).splitlines()
+        counter = Counter(output_lines)
+        self.assertEqual(counter["ERROR: content"], 2)
+        self.assertEqual(counter["Waiting 0 seconds to retry..."], 2)
+
+    def test_error_403_forbidden(self):
+        output = TestBufferConanOutput()
+        uploader = Uploader(requester=_RequesterMock(403, "content"), output=output, verify=False)
+        with six.assertRaisesRegex(self, ForbiddenException, "content"):
+            auth = namedtuple("auth", "token")
+            uploader.upload(url="fake", abs_path=self.filename, retry=3, auth=auth("token"))
+        output_lines = str(output).splitlines()
+        counter = Counter(output_lines)
+        self.assertEqual(counter["ERROR: content"], 2)
+        self.assertEqual(counter["Waiting 0 seconds to retry..."], 2)
+
+    def test_error_403_authentication(self):
+        output = TestBufferConanOutput()
+        uploader = Uploader(requester=_RequesterMock(403, "content"), output=output, verify=False)
+        with six.assertRaisesRegex(self, AuthenticationException, "content"):
+            auth = namedtuple("auth", "token")
+            uploader.upload(url="fake", abs_path=self.filename, retry=3, auth=auth(None))
+        output_lines = str(output).splitlines()
+        counter = Counter(output_lines)
+        self.assertEqual(counter["ERROR: content"], 2)
+        self.assertEqual(counter["Waiting 0 seconds to retry..."], 2)
+
+    def test_error_requests(self):
+        class _RequesterMock:
+            def put(self, *args, **kwargs):
+                raise Exception("any exception")
+
+        output = TestBufferConanOutput()
+        uploader = Uploader(requester=_RequesterMock(), output=output, verify=False)
+        with six.assertRaisesRegex(self, Exception, "any exception"):
+            uploader.upload(url="fake", abs_path=self.filename, retry=3)
+        output_lines = str(output).splitlines()
+        counter = Counter(output_lines)
+        self.assertEqual(counter["ERROR: any exception"], 2)
+        self.assertEqual(counter["Waiting 0 seconds to retry..."], 2)
+
+    def test_error_500(self):
+        output = TestBufferConanOutput()
+        uploader = Uploader(requester=_RequesterMock(500, "content"), output=output, verify=False)
+        with six.assertRaisesRegex(self, Exception, "500 Server Error: content"):
+            uploader.upload(url="fake", abs_path=self.filename, retry=3)
+        output_lines = str(output).splitlines()
+        counter = Counter(output_lines)
+        self.assertEqual(counter["ERROR: 500 Server Error: content"], 2)
+        self.assertEqual(counter["Waiting 0 seconds to retry..."], 2)

--- a/conans/test/utils/tools.py
+++ b/conans/test/utils/tools.py
@@ -23,6 +23,7 @@ from mock import Mock
 from six import StringIO
 from six.moves.urllib.parse import quote, urlsplit, urlunsplit
 from webtest.app import TestApp
+from requests.exceptions import HTTPError
 
 from conans import tools, load
 from conans.client.cache.cache import ClientCache
@@ -108,6 +109,18 @@ class TestingResponse(object):
     @property
     def ok(self):
         return self.test_response.status_code == 200
+
+    def raise_for_status(self):
+        """Raises stored :class:`HTTPError`, if one occurred."""
+        http_error_msg = ''
+        if 400 <= self.status_code < 500:
+            http_error_msg = u'%s Client Error: %s' % (self.status_code, self.content)
+
+        elif 500 <= self.status_code < 600:
+            http_error_msg = u'%s Server Error: %s' % (self.status_code, self.content)
+
+        if http_error_msg:
+            raise HTTPError(http_error_msg, response=self)
 
     @property
     def content(self):


### PR DESCRIPTION
Change-Id: Ic1c1814b6e5f46dec8b7e1ffd0661ae619a01ca1

Changelog: Feature: Retry upload or download for error in response message (e.g. status is '500')

Close #4907

- [X] Refer to the issue: https://github.com/conan-io/conan/issues/4907
- [X] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [X] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [X] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 

I added a first fix for the issue in https://github.com/conan-io/conan/issues/4907.
