### PR TITLE
fixing transitive order of privates

### DIFF
--- a/conans/client/graph/graph.py
+++ b/conans/client/graph/graph.py
@@ -39,6 +39,7 @@ class Node(object):
         self.public_deps = None  # {ref.name: Node}
         # all the public deps only in the closure of this node
         self.public_closure = None  # {ref.name: Node}
+        self.acc_closure = None
         self.ancestors = None  # set{ref.name}
 
     def update_ancestors(self, ancestors):
@@ -88,6 +89,12 @@ class Node(object):
 
     def private_neighbors(self):
         return [edge.dst for edge in self.dependencies if edge.private]
+
+    def make_public(self):
+        self.private = False
+        for edge in self.dependencies:
+            if not edge.private:
+                edge.dst.make_public()
 
     def inverse_neighbors(self):
         return [edge.src for edge in self.dependants]

--- a/conans/client/graph/graph.py
+++ b/conans/client/graph/graph.py
@@ -39,6 +39,7 @@ class Node(object):
         self.public_deps = None  # {ref.name: Node}
         # all the public deps only in the closure of this node
         self.public_closure = None  # {ref.name: Node}
+        self.inverse_closure = set()  # set of nodes that have this one in their public
         self.acc_closure = None
         self.ancestors = None  # set{ref.name}
 

--- a/conans/client/graph/graph.py
+++ b/conans/client/graph/graph.py
@@ -35,12 +35,13 @@ class Node(object):
         self.build_require = False
         self.private = False
         self.revision_pinned = False  # The revision has been specified by the user
-        # all the public deps to which this node belongs
+
+        # The dependencies that can conflict to downstream consumers
         self.public_deps = None  # {ref.name: Node}
         # all the public deps only in the closure of this node
+        # The dependencies that will be part of deps_cpp_info, can't conflict
         self.public_closure = None  # {ref.name: Node}
         self.inverse_closure = set()  # set of nodes that have this one in their public
-        self.acc_closure = None
         self.ancestors = None  # set{ref.name}
 
     def update_ancestors(self, ancestors):

--- a/conans/client/graph/graph_binaries.py
+++ b/conans/client/graph/graph_binaries.py
@@ -198,10 +198,13 @@ class GraphBinariesAnalyzer(object):
         if node.binary in (BINARY_CACHE, BINARY_DOWNLOAD, BINARY_UPDATE, BINARY_SKIP):
             private_neighbours = node.private_neighbors()
             for neigh in private_neighbours:
+                if not neigh.private:
+                    continue
                 # Current closure contains own node to be skipped
                 for n in neigh.public_closure.values():
-                    n.binary = BINARY_SKIP
-                    self._handle_private(n)
+                    if n.private:
+                        n.binary = BINARY_SKIP
+                        self._handle_private(n)
 
     def evaluate_graph(self, deps_graph, build_mode, update, remote_name):
         default_package_id_mode = self._cache.config.default_package_id_mode

--- a/conans/client/graph/graph_builder.py
+++ b/conans/client/graph/graph_builder.py
@@ -146,15 +146,19 @@ class DepsGraphBuilder(object):
             # The closure of a new node starts with just itself
             new_node.public_closure = OrderedDict([(new_node.ref.name, new_node)])
             node.public_closure[name] = new_node
+            new_node.inverse_closure.add(node)
             node.acc_closure[new_node.name] = new_node
-            new_node.acc_closure = node.acc_closure.copy()
-            new_node.acc_closure[name] = new_node
+
             # New nodes will inherit the private property of its ancestor
             new_node.private = node.private or require.private
             if require.private or require.build_require:
                 # If the requirement is private (or build_require), a new public scope is defined
                 new_node.public_deps = node.public_closure
+                new_node.acc_closure = node.public_closure.copy()
+                new_node.acc_closure[name] = new_node
             else:
+                new_node.acc_closure = node.acc_closure.copy()
+                new_node.acc_closure[name] = new_node
                 # But if it is a normal require, the public_deps scope is the same as its parent
                 new_node.public_deps = node.public_deps
 
@@ -162,13 +166,10 @@ class DepsGraphBuilder(object):
                 node.public_deps[name] = new_node
 
                 # Update the closure of each dependent
-                for dep_node_name, dep_node in node.public_deps.items():
-                    if dep_node is node:
-                        continue
-
-                    if dep_node_name in new_node.ancestors:
-                        dep_node.public_closure[new_node.name] = new_node
-                        dep_node.acc_closure[new_node.name] = new_node
+                for dep_node in node.inverse_closure:
+                    dep_node.public_closure[new_node.name] = new_node
+                    new_node.inverse_closure.add(dep_node)
+                    dep_node.acc_closure[new_node.name] = new_node
 
             # RECURSION!
             self._load_deps(dep_graph, new_node, new_reqs, node.ref,
@@ -197,6 +198,7 @@ class DepsGraphBuilder(object):
                 previous.make_public()
 
             node.public_closure[name] = previous
+            previous.inverse_closure.add(node)
             node.public_deps[name] = previous
             node.acc_closure[name] = previous
             dep_graph.add_edge(node, previous, require.private, require.build_require)
@@ -205,11 +207,11 @@ class DepsGraphBuilder(object):
                 if n.build_require or n.private:
                     continue
                 node.public_closure[name] = n
-                for dep_node_name in node.ancestors:
-                    dep_node = node.public_deps.get(dep_node_name)
-                    if dep_node:
-                        dep_node.public_closure[name] = n
-                        dep_node.acc_closure[name] = n
+                n.inverse_closure.add(node)
+                for dep_node in node.inverse_closure:
+                    dep_node.public_closure[name] = n
+                    dep_node.acc_closure[name] = n
+                    n.inverse_closure.add(dep_node)
 
             # RECURSION!
             if self._recurse(previous.public_closure, new_reqs, new_options):

--- a/conans/test/functional/graph/graph_manager_base.py
+++ b/conans/test/functional/graph/graph_manager_base.py
@@ -75,7 +75,7 @@ class GraphManagerTest(unittest.TestCase):
         self.binary_installer.install(deps_graph, False, graph_info)
         return deps_graph
 
-    def _check_node(self, node, ref, deps, build_deps, dependents, closure, public_deps):
+    def _check_node(self, node, ref, deps, build_deps, dependents, closure):
         conanfile = node.conanfile
         ref = ConanFileReference.loads(str(ref))
         self.assertEqual(node.ref.full_repr(), ref.full_repr())
@@ -86,9 +86,6 @@ class GraphManagerTest(unittest.TestCase):
         self.assertEqual(len(dependants), len(dependents))
         for d in dependents:
             self.assertIn(d, dependants)
-
-        public_deps = {n.name: n for n in public_deps}
-        self.assertEqual(node.public_deps, public_deps)
 
         # The recipe requires is resolved to the reference WITH revision!
         self.assertEqual(len(deps), len(conanfile.requires))

--- a/conans/test/functional/graph/graph_manager_test.py
+++ b/conans/test/functional/graph/graph_manager_test.py
@@ -59,11 +59,11 @@ class TransitiveGraphTest(GraphManagerTest):
 
         # No Revision??? Because of consumer?
         self._check_node(app, "app/0.1@None/None", deps=[libb], build_deps=[], dependents=[],
-                         closure=[libb, liba], public_deps=[app, libb, liba])
+                         closure=[libb, liba])
         self._check_node(libb, "libb/0.1@user/testing#123", deps=[liba], build_deps=[],
-                         dependents=[app], closure=[liba], public_deps=[app, libb, liba])
+                         dependents=[app], closure=[liba])
         self._check_node(liba, "liba/0.1@user/testing#123", deps=[], build_deps=[],
-                         dependents=[libb], closure=[], public_deps=[app, libb, liba])
+                         dependents=[libb], closure=[])
 
     def test_diamond(self):
         # app -> libb0.1 -> liba0.1
@@ -84,13 +84,13 @@ class TransitiveGraphTest(GraphManagerTest):
 
         # No Revision??? Because of consumer?
         self._check_node(app, "app/0.1@None/None", deps=[libb, libc], build_deps=[], dependents=[],
-                         closure=[libb, libc, liba], public_deps=[app, libb, libc, liba])
+                         closure=[libb, libc, liba])
         self._check_node(libb, "libb/0.1@user/testing#123", deps=[liba], build_deps=[],
-                         dependents=[app], closure=[liba], public_deps=[app, libb, libc, liba])
+                         dependents=[app], closure=[liba])
         self._check_node(libb, "libb/0.1@user/testing#123", deps=[liba], build_deps=[],
-                         dependents=[app], closure=[liba], public_deps=[app, libb, libc, liba])
+                         dependents=[app], closure=[liba])
         self._check_node(liba, "liba/0.1@user/testing#123", deps=[], build_deps=[],
-                         dependents=[libb, libc], closure=[], public_deps=[app, libb, libc, liba])
+                         dependents=[libb, libc], closure=[])
 
     def test_consecutive_diamonds(self):
         # app -> libe0.1 -> libd0.1 -> libb0.1 -> liba0.1
@@ -118,24 +118,20 @@ class TransitiveGraphTest(GraphManagerTest):
         libc = libd.dependencies[1].dst
         liba = libc.dependencies[0].dst
 
-        public_deps = [app, libb, libc, liba, libd, libe, libf]
         self._check_node(app, "app/0.1@None/None", deps=[libe, libf], build_deps=[], dependents=[],
-                         closure=[libe, libf, libd, libb, libc, liba], public_deps=public_deps)
+                         closure=[libe, libf, libd, libb, libc, liba])
         self._check_node(libe, "libe/0.1@user/testing#123", deps=[libd], build_deps=[],
-                         dependents=[app], closure=[libd, libb, libc, liba],
-                         public_deps=public_deps)
+                         dependents=[app], closure=[libd, libb, libc, liba])
         self._check_node(libf, "libf/0.1@user/testing#123", deps=[libd], build_deps=[],
-                         dependents=[app], closure=[libd, libb, libc, liba],
-                         public_deps=public_deps)
+                         dependents=[app], closure=[libd, libb, libc, liba])
         self._check_node(libd, "libd/0.1@user/testing#123", deps=[libb, libc], build_deps=[],
-                         dependents=[libe, libf], closure=[libb, libc, liba],
-                         public_deps=public_deps)
+                         dependents=[libe, libf], closure=[libb, libc, liba])
         self._check_node(libc, "libc/0.1@user/testing#123", deps=[liba], build_deps=[],
-                         dependents=[libd], closure=[liba], public_deps=public_deps)
+                         dependents=[libd], closure=[liba])
         self._check_node(libb, "libb/0.1@user/testing#123", deps=[liba], build_deps=[],
-                         dependents=[libd], closure=[liba], public_deps=public_deps)
+                         dependents=[libd], closure=[liba])
         self._check_node(liba, "liba/0.1@user/testing#123", deps=[], build_deps=[],
-                         dependents=[libb, libc], closure=[], public_deps=public_deps)
+                         dependents=[libb, libc], closure=[])
 
     def test_parallel_diamond(self):
         # app -> libb0.1 -> liba0.1
@@ -159,17 +155,16 @@ class TransitiveGraphTest(GraphManagerTest):
         libd = app.dependencies[2].dst
         liba = libb.dependencies[0].dst
 
-        public_deps = [app, libb, libc, liba, libd]
         self._check_node(app, "app/0.1@None/None", deps=[libb, libc, libd], build_deps=[],
-                         dependents=[], closure=[libb, libc, libd, liba], public_deps=public_deps)
+                         dependents=[], closure=[libb, libc, libd, liba])
         self._check_node(libb, "libb/0.1@user/testing#123", deps=[liba], build_deps=[],
-                         dependents=[app], closure=[liba], public_deps=public_deps)
+                         dependents=[app], closure=[liba])
         self._check_node(libc, "libc/0.1@user/testing#123", deps=[liba], build_deps=[],
-                         dependents=[app], closure=[liba], public_deps=public_deps)
+                         dependents=[app], closure=[liba])
         self._check_node(libd, "libd/0.1@user/testing#123", deps=[liba], build_deps=[],
-                         dependents=[app], closure=[liba], public_deps=public_deps)
+                         dependents=[app], closure=[liba])
         self._check_node(liba, "liba/0.1@user/testing#123", deps=[], build_deps=[],
-                         dependents=[libb, libc, libd], closure=[], public_deps=public_deps)
+                         dependents=[libb, libc, libd], closure=[])
 
     def test_nested_diamond(self):
         # app --------> libb0.1 -> liba0.1
@@ -193,17 +188,16 @@ class TransitiveGraphTest(GraphManagerTest):
         libd = app.dependencies[2].dst
         liba = libb.dependencies[0].dst
 
-        public_deps = [app, libb, libc, liba, libd]
         self._check_node(app, "app/0.1@None/None", deps=[libb, libc, libd], build_deps=[],
-                         dependents=[], closure=[libb, libd, libc, liba], public_deps=public_deps)
+                         dependents=[], closure=[libb, libd, libc, liba])
         self._check_node(libb, "libb/0.1@user/testing#123", deps=[liba], build_deps=[],
-                         dependents=[app], closure=[liba], public_deps=public_deps)
+                         dependents=[app], closure=[liba])
         self._check_node(libc, "libc/0.1@user/testing#123", deps=[liba], build_deps=[],
-                         dependents=[app, libd], closure=[liba], public_deps=public_deps)
+                         dependents=[app, libd], closure=[liba])
         self._check_node(libd, "libd/0.1@user/testing#123", deps=[libc], build_deps=[],
-                         dependents=[app], closure=[libc, liba], public_deps=public_deps)
+                         dependents=[app], closure=[libc, liba])
         self._check_node(liba, "liba/0.1@user/testing#123", deps=[], build_deps=[],
-                         dependents=[libb, libc], closure=[], public_deps=public_deps)
+                         dependents=[libb, libc], closure=[])
 
     def test_multiple_transitive(self):
         # https://github.com/conanio/conan/issues/4720
@@ -226,16 +220,14 @@ class TransitiveGraphTest(GraphManagerTest):
         libb = liba.dependencies[2].dst
 
         self._check_node(libd, "libd/0.1@user/testing#123", deps=[], build_deps=[],
-                         dependents=[liba, libc], closure=[], public_deps=[liba, libb, libc, libd])
+                         dependents=[liba, libc], closure=[])
         self._check_node(liba, "liba/0.1@None/None", deps=[libd, libc, libb], build_deps=[],
                          dependents=[],
-                         closure=[libb, libc, libd], public_deps=[liba, libb, libc, libd])
+                         closure=[libb, libc, libd])
         self._check_node(libb, "libb/0.1@user/testing#123", deps=[libc], build_deps=[],
-                         dependents=[liba], closure=[libc, libd],
-                         public_deps=[liba, libb, libc, libd])
+                         dependents=[liba], closure=[libc, libd])
         self._check_node(libc, "libc/0.1@user/testing#123", deps=[libd], build_deps=[],
-                         dependents=[liba, libb], closure=[libd],
-                         public_deps=[liba, libb, libc, libd])
+                         dependents=[liba, libb], closure=[libd])
 
     def test_diamond_conflict(self):
         # app -> libb0.1 -> liba0.1
@@ -291,9 +283,9 @@ class TransitiveGraphTest(GraphManagerTest):
         tool = app.dependencies[0].dst
 
         self._check_node(app, "app/0.1@None/None", deps=[], build_deps=[tool], dependents=[],
-                         closure=[tool], public_deps=[app])
+                         closure=[tool])
         self._check_node(tool, "tool/0.1@user/testing#123", deps=[], build_deps=[],
-                         dependents=[app], closure=[], public_deps=[tool, app])
+                         dependents=[app], closure=[])
 
     def test_transitive_build_require_recipe(self):
         # app -> lib -(br)-> tool
@@ -310,13 +302,11 @@ class TransitiveGraphTest(GraphManagerTest):
         tool = lib.dependencies[0].dst
 
         self._check_node(app, "app/0.1@None/None", deps=[lib], build_deps=[], dependents=[],
-                         closure=[lib], public_deps=[app, lib])
-
+                         closure=[lib])
         self._check_node(lib, "lib/0.1@user/testing#123", deps=[], build_deps=[tool],
-                         dependents=[app], closure=[tool], public_deps=[app, lib])
-
+                         dependents=[app], closure=[tool])
         self._check_node(tool, "tool/0.1@user/testing#123", deps=[], build_deps=[],
-                         dependents=[lib], closure=[], public_deps=[tool, lib])
+                         dependents=[lib], closure=[])
 
     def test_loop_build_require(self):
         # app -> lib -(br)-> tool ->|
@@ -353,19 +343,19 @@ class TransitiveGraphTest(GraphManagerTest):
         mingw_app = app.dependencies[1].dst
 
         self._check_node(app, "app/0.1@None/None", deps=[lib], build_deps=[mingw_app], dependents=[],
-                         closure=[mingw_app, lib], public_deps=[app, lib])
+                         closure=[mingw_app, lib])
 
         self._check_node(lib, "lib/0.1@user/testing#123", deps=[], build_deps=[mingw_lib, gtest],
-                         dependents=[app], closure=[mingw_lib, gtest], public_deps=[app, lib])
+                         dependents=[app], closure=[mingw_lib, gtest])
         self._check_node(gtest, "gtest/0.1@user/testing#123", deps=[], build_deps=[mingw_gtest],
-                         dependents=[lib], closure=[mingw_gtest], public_deps=[gtest, lib])
+                         dependents=[lib], closure=[mingw_gtest])
         # MinGW leaf nodes
         self._check_node(mingw_gtest, "mingw/0.1@user/testing#123", deps=[], build_deps=[],
-                         dependents=[gtest], closure=[], public_deps=[mingw_gtest, gtest])
+                         dependents=[gtest], closure=[])
         self._check_node(mingw_lib, "mingw/0.1@user/testing#123", deps=[], build_deps=[],
-                         dependents=[lib], closure=[], public_deps=[mingw_lib, gtest, lib])
+                         dependents=[lib], closure=[])
         self._check_node(mingw_app, "mingw/0.1@user/testing#123", deps=[], build_deps=[],
-                         dependents=[app], closure=[], public_deps=[mingw_app, lib, app])
+                         dependents=[app], closure=[])
 
     def test_conflict_transitive_build_requires(self):
         zlib_ref = "zlib/0.1@user/testing"
@@ -405,13 +395,13 @@ class TransitiveGraphTest(GraphManagerTest):
         gtest = lib.dependencies[1].dst
         zlib2 = gtest.dependencies[0].dst
         self._check_node(app, "app/0.1@None/None", deps=[lib], build_deps=[], dependents=[],
-                         closure=[lib, zlib], public_deps=[app, lib, zlib])
+                         closure=[lib, zlib])
 
         self._check_node(lib, "lib/0.1@user/testing#123", deps=[zlib], build_deps=[gtest],
-                         dependents=[app], closure=[gtest, zlib], public_deps=[app, lib, zlib])
+                         dependents=[app], closure=[gtest, zlib])
 
         self._check_node(gtest, "gtest/0.1@user/testing#123", deps=[], build_deps=[zlib2],
-                         dependents=[lib], closure=[zlib2], public_deps=[gtest, lib, zlib])
+                         dependents=[lib], closure=[zlib2])
 
     def test_diamond_no_option_conflict_build_requires(self):
         # Same as above, but gtest->(build_require)->zlib2
@@ -438,13 +428,13 @@ class TransitiveGraphTest(GraphManagerTest):
         zlib2 = gtest.dependencies[0].dst
         self.assertIs(zlib, zlib2)
         self._check_node(app, "app/0.1@None/None", deps=[lib], build_deps=[], dependents=[],
-                         closure=[lib, zlib], public_deps=[app, lib, zlib])
+                         closure=[lib, zlib])
 
         self._check_node(lib, "lib/0.1@user/testing#123", deps=[zlib], build_deps=[gtest],
-                         dependents=[app], closure=[gtest, zlib], public_deps=[app, lib, zlib])
+                         dependents=[app], closure=[gtest, zlib])
 
         self._check_node(gtest, "gtest/0.1@user/testing#123", deps=[zlib2], build_deps=[],
-                         dependents=[lib], closure=[zlib2], public_deps=[gtest, lib, zlib])
+                         dependents=[lib], closure=[zlib2])
 
     def test_diamond_option_conflict_build_requires(self):
         # Same as above, but gtest->(build_require)->zlib2
@@ -494,30 +484,20 @@ class TransitiveGraphTest(GraphManagerTest):
         libc = libd.dependencies[1].dst
         liba = libc.dependencies[0].dst
 
-        public_deps = [app, libb, liba, libd, libe]
         self._check_node(app, "app/0.1@None/None", deps=[libe], build_deps=[libf], dependents=[],
-                         closure=[libf, libe, libd, libb, liba], public_deps=public_deps)
+                         closure=[libf, libe, libd, libb, liba])
         self._check_node(libe, "libe/0.1@user/testing#123", deps=[libd], build_deps=[],
-                         dependents=[app], closure=[libd, libb, liba],
-                         public_deps=public_deps)
-
-        public_deps = [app, libb, liba, libd, libe, libf]
+                         dependents=[app], closure=[libd, libb, liba])
         self._check_node(libf, "libf/0.1@user/testing#123", deps=[libd], build_deps=[],
-                         dependents=[app], closure=[libd, libb, liba],
-                         public_deps=public_deps)
-
-        public_deps = [app, libb, liba, libd, libe]
+                         dependents=[app], closure=[libd, libb, liba])
         self._check_node(libd, "libd/0.1@user/testing#123", deps=[libb], build_deps=[libc],
-                         dependents=[libe, libf], closure=[libc, libb, liba],
-                         public_deps=public_deps)
-        public_deps = [libd, libb, libc, liba]
+                         dependents=[libe, libf], closure=[libc, libb, liba])
         self._check_node(libc, "libc/0.1@user/testing#123", deps=[liba], build_deps=[],
-                         dependents=[libd], closure=[liba], public_deps=public_deps)
-        public_deps = [app, libb, liba, libd, libe]
+                         dependents=[libd], closure=[liba])
         self._check_node(libb, "libb/0.1@user/testing#123", deps=[liba], build_deps=[],
-                         dependents=[libd], closure=[liba], public_deps=public_deps)
+                         dependents=[libd], closure=[liba])
         self._check_node(liba, "liba/0.1@user/testing#123", deps=[], build_deps=[],
-                         dependents=[libb, libc], closure=[], public_deps=public_deps)
+                         dependents=[libb, libc], closure=[])
 
     def test_consecutive_diamonds_private(self):
         # app -> libe0.1 -------------> libd0.1 -> libb0.1 -------------> liba0.1
@@ -547,30 +527,21 @@ class TransitiveGraphTest(GraphManagerTest):
         libc = libd.dependencies[1].dst
         liba = libc.dependencies[0].dst
 
-        main_public_deps = [app, libb, liba, libd, libe]
         self._check_node(app, "app/0.1@None/None", deps=[libe, libf], build_deps=[], dependents=[],
-                         closure=[libe, libf, libd, libb, liba], public_deps=main_public_deps)
+                         closure=[libe, libf, libd, libb, liba], )
         self._check_node(libe, "libe/0.1@user/testing#123", deps=[libd], build_deps=[],
-                         dependents=[app], closure=[libd, libb, liba],
-                         public_deps=main_public_deps)
+                         dependents=[app], closure=[libd, libb, liba])
 
-        libf_public_deps = [libb, liba, libd, libe, libf]
         self._check_node(libf, "libf/0.1@user/testing#123", deps=[libd], build_deps=[],
-                         dependents=[app], closure=[libd, libb, liba],
-                         public_deps=libf_public_deps)
-
+                         dependents=[app], closure=[libd, libb, liba])
         self._check_node(libd, "libd/0.1@user/testing#123", deps=[libb, libc], build_deps=[],
-                         dependents=[libe, libf], closure=[libb, libc, liba],
-                         public_deps=main_public_deps)
-
-        libc_public_deps = [libb, libc, liba]
+                         dependents=[libe, libf], closure=[libb, libc, liba])
         self._check_node(libc, "libc/0.1@user/testing#123", deps=[liba], build_deps=[],
-                         dependents=[libd], closure=[liba], public_deps=libc_public_deps)
-
+                         dependents=[libd], closure=[liba])
         self._check_node(libb, "libb/0.1@user/testing#123", deps=[liba], build_deps=[],
-                         dependents=[libd], closure=[liba], public_deps=main_public_deps)
+                         dependents=[libd], closure=[liba])
         self._check_node(liba, "liba/0.1@user/testing#123", deps=[], build_deps=[],
-                         dependents=[libb, libc], closure=[], public_deps=main_public_deps)
+                         dependents=[libb, libc], closure=[])
 
     def test_parallel_diamond_build_requires(self):
         # app --------> libb0.1 ---------> liba0.1
@@ -595,19 +566,16 @@ class TransitiveGraphTest(GraphManagerTest):
         libd = app.dependencies[2].dst
         liba = libb.dependencies[0].dst
 
-        public_deps = [app, libb, libc, liba]
         self._check_node(app, "app/0.1@None/None", deps=[libb, libc], build_deps=[libd],
-                         dependents=[], closure=[libd, libb, libc, liba], public_deps=public_deps)
+                         dependents=[], closure=[libd, libb, libc, liba])
         self._check_node(libb, "libb/0.1@user/testing#123", deps=[liba], build_deps=[],
-                         dependents=[app], closure=[liba], public_deps=public_deps)
+                         dependents=[app], closure=[liba])
         self._check_node(libc, "libc/0.1@user/testing#123", deps=[liba], build_deps=[],
-                         dependents=[app], closure=[liba], public_deps=public_deps)
-        public_deps = [app, libd, libb, libc, liba]
+                         dependents=[app], closure=[liba])
         self._check_node(libd, "libd/0.1@user/testing#123", deps=[liba], build_deps=[],
-                         dependents=[app], closure=[liba], public_deps=public_deps)
-        public_deps = [app, libb, libc, liba]
+                         dependents=[app], closure=[liba])
         self._check_node(liba, "liba/0.1@user/testing#123", deps=[], build_deps=[],
-                         dependents=[libb, libc, libd], closure=[], public_deps=public_deps)
+                         dependents=[libb, libc, libd], closure=[])
 
     def test_conflict_private(self):
         liba_ref = "liba/0.1@user/testing"
@@ -654,16 +622,16 @@ class TransitiveGraphTest(GraphManagerTest):
         zlib = tool.dependencies[0].dst
 
         self._check_node(app, "app/0.1@None/None", deps=[lib], build_deps=[], dependents=[],
-                         closure=[lib], public_deps=[app, lib])
+                         closure=[lib])
 
         self._check_node(lib, "lib/0.1@user/testing#123", deps=[], build_deps=[tool],
-                         dependents=[app], closure=[tool], public_deps=[app, lib])
+                         dependents=[app], closure=[tool])
 
         self._check_node(tool, "tool/0.1@user/testing#123", deps=[zlib], build_deps=[],
-                         dependents=[lib], closure=[zlib], public_deps=[tool, lib])
+                         dependents=[lib], closure=[zlib])
 
         self._check_node(zlib, "zlib/0.1@user/testing#123", deps=[], build_deps=[],
-                         dependents=[tool], closure=[], public_deps=[zlib])
+                         dependents=[tool], closure=[])
 
     def test_transitive_private_conflict(self):
         # https://github.com/conan-io/conan/issues/4931
@@ -715,8 +683,7 @@ class TransitiveGraphTest(GraphManagerTest):
         grass2 = cheetah.dependencies[1].dst
 
         self._check_node(cheetah, "cheetah/0.1@None/None", deps=[gazelle], build_deps=[grass2],
-                         dependents=[], closure=[gazelle, grass],
-                         public_deps=[cheetah, gazelle, grass])
+                         dependents=[], closure=[gazelle, grass])
         self.assertEqual(cheetah.conanfile.deps_cpp_info.libs,
                          ['mylibgazelle0.1lib', 'mylibgrass0.1lib'])
 
@@ -750,12 +717,10 @@ class TransitiveGraphTest(GraphManagerTest):
         self.assertIs(liba, liba2)
         self.assertFalse(liba.private)
 
-        main_public_deps = [app, libb, liba, libc]
         self._check_node(app, "app/0.1@None/None", deps=[libc], build_deps=[], dependents=[],
-                         closure=[libc, libb, liba], public_deps=main_public_deps)
+                         closure=[libc, libb, liba], )
         self._check_node(libc, "libc/0.1@user/testing#123", deps=[libb, liba], build_deps=[],
-                         dependents=[app], closure=[libb, liba],
-                         public_deps=main_public_deps)
+                         dependents=[app], closure=[libb, liba])
 
     @parameterized.expand([(True, ), (False, )])
     def test_dont_conflict_private(self, private_first):
@@ -787,10 +752,8 @@ class TransitiveGraphTest(GraphManagerTest):
         self.assertTrue(liba1.private)
         self.assertTrue(liba2.private)
 
-        main_public_deps = [app, libb, libc]
         self._check_node(app, "app/0.1@None/None", deps=[libc], build_deps=[], dependents=[],
-                         closure=[libc, libb], public_deps=main_public_deps)
+                         closure=[libc, libb])
         closure = [liba2, libb] if private_first else [libb, liba2]
         self._check_node(libc, "libc/0.1@user/testing#123", deps=[libb, liba2], build_deps=[],
-                         dependents=[app], closure=closure,
-                         public_deps=[app, libb, libc])
+                         dependents=[app], closure=closure)

--- a/conans/test/functional/graph/private_deps_test.py
+++ b/conans/test/functional/graph/private_deps_test.py
@@ -40,7 +40,7 @@ class Pkg(ConanFile):
         self.assertIn("set(CONAN_LIBS PkgA PkgC ${CONAN_LIBS})", conanbuildinfo)
         client.run("info . --graph=file.html")
         html = load(os.path.join(client.current_folder, "file.html"))
-        self.assertEqual(2, html.count("label: 'PkgC/0.1', shape: 'box'"))
+        self.assertEqual(1, html.count("label: 'PkgC/0.1', shape: 'box'"))
 
     def test_private_regression_skip(self):
         # https://github.com/conan-io/conan/issues/3166

--- a/conans/test/functional/graph/private_deps_test.py
+++ b/conans/test/functional/graph/private_deps_test.py
@@ -9,6 +9,8 @@ from conans.paths import BUILD_INFO_CMAKE, CONANINFO
 from conans.test.utils.cpp_test_files import cpp_hello_conan_files
 from conans.test.utils.tools import NO_SETTINGS_PACKAGE_ID, TestClient, TestServer
 from conans.util.files import load
+from textwrap import dedent
+from conans.test.utils.conanfile import TestConanFile
 
 
 class PrivateBinariesTest(unittest.TestCase):
@@ -165,6 +167,29 @@ class V3D(ConanFile):
         # The order is dictated by public mypackage -> zlib
         self.assertIn("set(CONAN_LIBS mypackage zlib ${CONAN_LIBS})", conanbuildinfo)
         self.assertNotIn("bzip2", conanbuildinfo)
+
+    def test_private_dont_skip(self):
+        client = TestClient()
+        client.save({"conanfile.py": str(TestConanFile("LibA", "0.1", info=True))})
+        client.run("create . LibA/0.1@conan/stable")
+
+        client.save({"conanfile.py": str(TestConanFile("LibB", "0.1",
+                                                       requires=["LibA/0.1@conan/stable"]))})
+        client.run("create . LibB/0.1@conan/stable")
+
+        client.save({"conanfile.py": str(TestConanFile("LibC", "0.1",
+                                                       private_requires=["LibA/0.1@conan/stable"]))})
+        client.run("create . LibC/0.1@conan/stable")
+
+        for requires in (["LibB/0.1@conan/stable", "LibC/0.1@conan/stable"],
+                         ["LibC/0.1@conan/stable", "LibB/0.1@conan/stable"]):
+            client.save({"conanfile.py": str(TestConanFile("LibD", "0.1",
+                                                           requires=requires))})
+            client.run("install . -g cmake")
+            self.assertIn("LibA/0.1@conan/stable:5ab84d6acfe1f23c4fae0ab88f26e3a396351ac9 - Cache",
+                          client.out)
+            conanbuildinfo = load(os.path.join(client.current_folder, "conanbuildinfo.cmake"))
+            self.assertIn("set(CONAN_LIBS mylibLibA0.1lib ${CONAN_LIBS})", conanbuildinfo)
 
 
 @attr("slow")

--- a/conans/test/utils/conanfile.py
+++ b/conans/test/utils/conanfile.py
@@ -59,7 +59,7 @@ class MockConanfile(ConanFile):
 class TestConanFile(object):
     def __init__(self, name="Hello", version="0.1", settings=None, requires=None, options=None,
                  default_options=None, package_id=None, build_requires=None, info=None,
-                 private_requires=None):
+                 private_requires=None, private_first=False):
         self.name = name
         self.version = version
         self.settings = settings
@@ -70,6 +70,7 @@ class TestConanFile(object):
         self.default_options = default_options
         self.package_id = package_id
         self.info = info
+        self.private_first = private_first
 
     def __repr__(self):
         base = """from conans import ConanFile
@@ -81,8 +82,12 @@ class {name}Conan(ConanFile):
         if self.settings:
             base += "    settings = %s\n" % self.settings
         if self.requires or self.private_requires:
-            reqs_list = ['"%s"' % r for r in self.requires or []]
-            reqs_list.extend(["('%s', 'private')" % r for r in self.private_requires or []])
+            if self.private_first:
+                reqs_list = ["('%s', 'private')" % r for r in self.private_requires or []]
+                reqs_list.extend(['"%s"' % r for r in self.requires or []])
+            else:
+                reqs_list = ['"%s"' % r for r in self.requires or []]
+                reqs_list.extend(["('%s', 'private')" % r for r in self.private_requires or []])
             reqs_list.append("")
             base += "    requires = %s\n" % (", ".join(reqs_list))
         if self.build_requires:


### PR DESCRIPTION
Changelog: Bugfix: Fix skipping binaries because of transitive ``private`` requirements
Docs: omit

@tags: slow

Close: #4970 