### PR TITLE
do not find modules for cmake_find_package_multi

### DIFF
--- a/conans/client/generators/cmake_find_package_multi.py
+++ b/conans/client/generators/cmake_find_package_multi.py
@@ -86,7 +86,8 @@ set_property(TARGET {name}::{name}
     def _find_for_dep(self, name, cpp_info):
         lines = []
         if cpp_info.public_deps:
-            lines = find_dependency_lines(name, cpp_info)
+            # Here we are generating only Config files, so do not search for FindXXX modules
+            lines = find_dependency_lines(name, cpp_info, find_modules=False)
 
         targets_props = self.target_properties.format(name=name)
 

--- a/conans/test/functional/generators/cmake_find_package_multi_test.py
+++ b/conans/test/functional/generators/cmake_find_package_multi_test.py
@@ -6,6 +6,7 @@ import unittest
 from nose.plugins.attrib import attr
 
 from conans.test.utils.tools import TestClient
+from conans.util.files import load
 from conans.util.files import mkdir
 
 
@@ -52,6 +53,11 @@ class CMakeFindPathMultiGeneratorTest(unittest.TestCase):
             with c.chdir("build"):
                 for bt in ("Debug", "Release"):
                     c.run("install .. user/channel -s build_type={}".format(bt))
+
+                # Test that we are using find_dependency with the NO_MODULE option
+                # to skip finding first possible FindBye somewhere
+                self.assertIn("find_dependency(hello REQUIRED NO_MODULE)",
+                              load(os.path.join(c.current_folder, "byeConfig.cmake")))
 
                 if platform.system() == "Windows":
                     c.run_command('cmake .. -G "Visual Studio 15 Win64"')


### PR DESCRIPTION
Changelog: Bugfix: Bug in `cmake_find_package_multi` caused `CMake` to find incorrect modules in `CMake` modules paths when only `Config` files should be taken into account.
Docs: omit
