### PR TITLE
try visual_studio generator with backslashes

### DIFF
--- a/conans/client/generators/visualstudio.py
+++ b/conans/client/generators/visualstudio.py
@@ -98,7 +98,7 @@ class VisualStudioGenerator(Generator):
 
         userprofile = os.getenv("USERPROFILE")
         if userprofile:
-            userprofile = userprofile.replace("\\", "/")
+            userprofile = userprofile.replace("\\", "\\\\")
             formatted_template = re.sub(userprofile, "$(USERPROFILE)", formatted_template,
                                         flags=re.I)
         return formatted_template

--- a/conans/client/generators/visualstudio.py
+++ b/conans/client/generators/visualstudio.py
@@ -53,7 +53,7 @@ class VisualStudioGenerator(Generator):
         sections = []
         for dep_name, cpp_info in self._deps_build_info.dependencies:
             fields = {
-                'root_dir': cpp_info.rootpath.replace("\\", "/"),
+                'root_dir': cpp_info.rootpath,
                 'name': dep_name.replace(".", "-")
             }
             section = self.item_template.format(**fields)

--- a/conans/client/generators/visualstudio.py
+++ b/conans/client/generators/visualstudio.py
@@ -67,10 +67,10 @@ class VisualStudioGenerator(Generator):
     def _format_properties(self, build_info, condition):
         fields = {
             'condition': condition,
-            'bin_dirs': "".join("%s;" % p for p in build_info.bin_paths).replace("\\", "/"),
-            'res_dirs': "".join("%s;" % p for p in build_info.res_paths).replace("\\", "/"),
-            'include_dirs': "".join("%s;" % p for p in build_info.include_paths).replace("\\", "/"),
-            'lib_dirs': "".join("%s;" % p for p in build_info.lib_paths).replace("\\", "/"),
+            'bin_dirs': "".join("%s;" % p for p in build_info.bin_paths),
+            'res_dirs': "".join("%s;" % p for p in build_info.res_paths),
+            'include_dirs': "".join("%s;" % p for p in build_info.include_paths),
+            'lib_dirs': "".join("%s;" % p for p in build_info.lib_paths),
             'libs': "".join(['%s.lib;' % lib if not lib.endswith(".lib")
                              else '%s;' % lib for lib in build_info.libs]),
             'definitions': "".join("%s;" % d for d in build_info.defines),

--- a/conans/test/functional/generators/xcode_gcc_vs_test.py
+++ b/conans/test/functional/generators/xcode_gcc_vs_test.py
@@ -68,7 +68,8 @@ xcode
         definition_group = xmldoc.getElementsByTagName('ItemDefinitionGroup')[0]
         compiler = definition_group.getElementsByTagName("ClCompile")[0]
 
-        include_dirs = compiler.getElementsByTagName("AdditionalIncludeDirectories")[0].firstChild.data
+        elem = compiler.getElementsByTagName("AdditionalIncludeDirectories")
+        include_dirs = elem[0].firstChild.data
         definitions = compiler.getElementsByTagName("PreprocessorDefinitions")[0].firstChild.data
 
         linker = definition_group.getElementsByTagName("Link")[0]
@@ -77,12 +78,12 @@ xcode
 
         package_id = os.listdir(client.cache.packages(ref))[0]
         pref = PackageReference(ref, package_id)
-        package_path = client.cache.package(pref).replace("\\", "/")
+        package_path = client.cache.package(pref)
 
-        replaced_path = re.sub(os.getenv("USERPROFILE", "not user profile").replace("\\", "/"),
+        replaced_path = re.sub(os.getenv("USERPROFILE", "not user profile").replace("\\", "\\\\"),
                                "$(USERPROFILE)", package_path, flags=re.I)
-        expected_lib_dirs = os.path.join(replaced_path, "lib").replace("\\", "/")
-        expected_include_dirs = os.path.join(replaced_path, "include").replace("\\", "/")
+        expected_lib_dirs = os.path.join(replaced_path, "lib")
+        expected_include_dirs = os.path.join(replaced_path, "include")
 
         self.assertIn(expected_lib_dirs, lib_dirs)
         self.assertEqual("hello.lib;%(AdditionalDependencies)", libs)
@@ -102,4 +103,5 @@ xcode
         self.assertIn("GCC_PREPROCESSOR_DEFINITIONS = $(inherited)", xcode)
         self.assertIn('OTHER_CFLAGS = $(inherited) %s' % expected_c_flags, xcode)
         self.assertIn('OTHER_CPLUSPLUSFLAGS = $(inherited) %s' % expected_cpp_flags, xcode)
-        self.assertIn('FRAMEWORK_SEARCH_PATHS = $(inherited) "%s"' % package_path.replace("\\", "/"), xcode)
+        self.assertIn('FRAMEWORK_SEARCH_PATHS = $(inherited) "%s"' % package_path.replace("\\", "/"),
+                      xcode)

--- a/conans/test/unittests/client/generators/visual_studio_test.py
+++ b/conans/test/unittests/client/generators/visual_studio_test.py
@@ -56,14 +56,14 @@ class VisualStudioGeneratorTest(unittest.TestCase):
         with tools.environment_append({"USERPROFILE": tmp_folder}):
             content = generator.content
             xml.etree.ElementTree.fromstring(content)
-            self.assertIn("<AdditionalIncludeDirectories>$(USERPROFILE)/pkg1/include;"
-                          "$(USERPROFILE)/pkg2/include;", content)
+            self.assertIn("<AdditionalIncludeDirectories>$(USERPROFILE)\pkg1\include;"
+                          "$(USERPROFILE)\pkg2\include;", content)
 
         with tools.environment_append({"USERPROFILE": tmp_folder.upper()}):
             content = generator.content
             xml.etree.ElementTree.fromstring(content)
-            self.assertIn("<AdditionalIncludeDirectories>$(USERPROFILE)/pkg1/include;"
-                          "$(USERPROFILE)/pkg2/include;", content)
+            self.assertIn("<AdditionalIncludeDirectories>$(USERPROFILE)\pkg1\include;"
+                          "$(USERPROFILE)\pkg2\include;", content)
 
     def multi_config_test(self):
         tmp_folder = temp_folder()
@@ -87,11 +87,11 @@ class VisualStudioGeneratorTest(unittest.TestCase):
                         "_DEBUG;DEBUG;%(PreprocessorDefinitions)" \
                         "</PreprocessorDefinitions>"
         defines_release = "<PreprocessorDefinitions>" \
-                        "NDEBUG;%(PreprocessorDefinitions)" \
-                        "</PreprocessorDefinitions>"
-        defines_custom = "<PreprocessorDefinitions>" \
-                          "CUSTOM_BUILD;%(PreprocessorDefinitions)" \
+                          "NDEBUG;%(PreprocessorDefinitions)" \
                           "</PreprocessorDefinitions>"
+        defines_custom = "<PreprocessorDefinitions>" \
+                         "CUSTOM_BUILD;%(PreprocessorDefinitions)" \
+                         "</PreprocessorDefinitions>"
         self.assertIn(defines_common, content)
         self.assertIn(defines_debug, content)
         self.assertIn(defines_release, content)

--- a/conans/test/unittests/client/generators/visual_studio_test.py
+++ b/conans/test/unittests/client/generators/visual_studio_test.py
@@ -43,13 +43,13 @@ class VisualStudioGeneratorTest(unittest.TestCase):
         pkg1 = os.path.join(tmp_folder, "pkg1")
         cpp_info = CppInfo(pkg1)
         cpp_info.includedirs = ["include"]
-        save(os.path.join(pkg1, "include/file.h"), "")
+        save(os.path.join(pkg1, "include", "file.h"), "")
         conanfile.deps_cpp_info.update(cpp_info, ref.name)
         ref = ConanFileReference.loads("My.Fancy-Pkg_2/0.1@user/testing")
         pkg2 = os.path.join(tmp_folder, "pkg2")
         cpp_info = CppInfo(pkg2)
         cpp_info.includedirs = ["include"]
-        save(os.path.join(pkg2, "include/file.h"), "")
+        save(os.path.join(pkg2, "include", "file.h"), "")
         conanfile.deps_cpp_info.update(cpp_info, ref.name)
         generator = VisualStudioGenerator(conanfile)
 

--- a/conans/test/unittests/client/generators/visual_studio_test.py
+++ b/conans/test/unittests/client/generators/visual_studio_test.py
@@ -53,17 +53,18 @@ class VisualStudioGeneratorTest(unittest.TestCase):
         conanfile.deps_cpp_info.update(cpp_info, ref.name)
         generator = VisualStudioGenerator(conanfile)
 
+        path1 = os.path.join("$(USERPROFILE)", "pkg1", "include")
+        path2 = os.path.join("$(USERPROFILE)", "pkg2", "include")
+        expected = "<AdditionalIncludeDirectories>%s;%s;" % (path1, path2)
         with tools.environment_append({"USERPROFILE": tmp_folder}):
             content = generator.content
             xml.etree.ElementTree.fromstring(content)
-            self.assertIn("<AdditionalIncludeDirectories>$(USERPROFILE)\pkg1\include;"
-                          "$(USERPROFILE)\pkg2\include;", content)
+            self.assertIn(expected, content)
 
         with tools.environment_append({"USERPROFILE": tmp_folder.upper()}):
             content = generator.content
             xml.etree.ElementTree.fromstring(content)
-            self.assertIn("<AdditionalIncludeDirectories>$(USERPROFILE)\pkg1\include;"
-                          "$(USERPROFILE)\pkg2\include;", content)
+            self.assertIn(expected, content)
 
     def multi_config_test(self):
         tmp_folder = temp_folder()


### PR DESCRIPTION
Changelog: Fix: Use back slashes for ``visual_studio`` generator instead of forward slashes
Docs: omit

NOTE: This might be a bit risky, as visual_studio is not that thoroughly tested. Might need extra manual check.

@tags: slow

Close #4969
