### PR TITLE
Add default_package_id_mode in the default conan.conf (#4974)

### DIFF
--- a/conans/client/conf/__init__.py
+++ b/conans/client/conf/__init__.py
@@ -94,6 +94,7 @@ default_profile = %s
 compression_level = 9                 # environment CONAN_COMPRESSION_LEVEL
 sysrequires_sudo = True               # environment CONAN_SYSREQUIRES_SUDO
 request_timeout = 60                  # environment CONAN_REQUEST_TIMEOUT (seconds)
+default_package_id_mode = semver_direct_mode # environment CONAN_DEFAULT_PACKAGE_ID_MODE
 # sysrequires_mode = enabled          # environment CONAN_SYSREQUIRES_MODE (allowed modes enabled/verify/disabled)
 # vs_installation_preference = Enterprise, Professional, Community, BuildTools # environment CONAN_VS_INSTALLATION_PREFERENCE
 # verbose_traceback = False           # environment CONAN_VERBOSE_TRACEBACK
@@ -222,7 +223,9 @@ class ConanClientConfigParser(ConfigParser, object):
                "CONAN_MSBUILD_VERBOSITY": self._env_c("general.msbuild_verbosity",
                                                       "CONAN_MSBUILD_VERBOSITY",
                                                       None),
-               "CONAN_CACERT_PATH": self._env_c("general.cacert_path", "CONAN_CACERT_PATH", None)
+               "CONAN_CACERT_PATH": self._env_c("general.cacert_path", "CONAN_CACERT_PATH", None),
+               "CONAN_DEFAULT_PACKAGE_ID_MODE": self._env_c("general.default_package_id_mode",
+                                                            "CONAN_DEFAULT_PACKAGE_ID_MODE", None),
                }
 
         # Filter None values
@@ -364,9 +367,12 @@ class ConanClientConfigParser(ConfigParser, object):
     @property
     def default_package_id_mode(self):
         try:
-            return self.get_item("general.default_package_id_mode")
+            default_package_id_mode = get_env("CONAN_DEFAULT_PACKAGE_ID_MODE")
+            if default_package_id_mode is None:
+                default_package_id_mode = self.get_item("general.default_package_id_mode")
         except ConanException:
             return "semver_direct_mode"
+        return default_package_id_mode
 
     @property
     def storage_path(self):

--- a/conans/test/functional/command/config_install_test.py
+++ b/conans/test/functional/command/config_install_test.py
@@ -48,6 +48,7 @@ level = 10                  # environment CONAN_LOGGING_LEVEL
 [general]
 compression_level = 6                 # environment CONAN_COMPRESSION_LEVEL
 cpu_count = 1             # environment CONAN_CPU_COUNT
+default_package_id_mode = full_package_mode # environment CONAN_DEFAULT_PACKAGE_ID_MODE
 
 [proxies]
 # Empty section will try to use system proxies.
@@ -131,6 +132,7 @@ class ConfigInstallTest(unittest.TestCase):
         self.assertEqual(conan_conf.get_item("log.run_to_file"), "False")
         self.assertEqual(conan_conf.get_item("log.level"), "10")
         self.assertEqual(conan_conf.get_item("general.compression_level"), "6")
+        self.assertEqual(conan_conf.get_item("general.default_package_id_mode"), "full_package_mode")
         self.assertEqual(conan_conf.get_item("general.sysrequires_sudo"), "True")
         self.assertEqual(conan_conf.get_item("general.cpu_count"), "1")
         with six.assertRaisesRegex(self, ConanException, "'config_install' doesn't exist"):

--- a/conans/test/functional/graph/package_id_modes_test.py
+++ b/conans/test/functional/graph/package_id_modes_test.py
@@ -1,3 +1,4 @@
+from conans.client.tools import environment_append
 from conans.test.functional.graph.graph_manager_base import GraphManagerTest
 from conans.test.utils.conanfile import TestConanFile
 
@@ -19,11 +20,10 @@ class PackageIDGraphTests(GraphManagerTest):
         configs.append((mode, "liba/1.1.2@user/testing", "42a9ff9024adabbd54849331cf01be7d95139948"))
         configs.append((mode, "liba/1.1.1@user/stable", "b41d6c026473cffed4abded4b0eaa453497be1d2"))
 
-        for package_id_mode, ref, package_id in configs:
-            self.cache.config.set_item("general.default_package_id_mode", package_id_mode)
+        def _assert_recipe_mode(ref_arg, package_id_arg):
             libb_ref = "libb/0.1@user/testing"
             self._cache_recipe(ref, TestConanFile("liba", "0.1.1"))
-            self._cache_recipe(libb_ref, TestConanFile("libb", "0.1", requires=[ref]))
+            self._cache_recipe(libb_ref, TestConanFile("libb", "0.1", requires=[ref_arg]))
             deps_graph = self.build_graph(TestConanFile("app", "0.1", requires=[libb_ref]))
 
             self.assertEqual(3, len(deps_graph.nodes))
@@ -32,4 +32,12 @@ class PackageIDGraphTests(GraphManagerTest):
             liba = libb.dependencies[0].dst
 
             self.assertEqual(liba.package_id, "5ab84d6acfe1f23c4fae0ab88f26e3a396351ac9")
-            self.assertEqual(libb.package_id, package_id)
+            self.assertEqual(libb.package_id, package_id_arg)
+
+        for package_id_mode, ref, package_id in configs:
+            self.cache.config.set_item("general.default_package_id_mode", package_id_mode)
+            _assert_recipe_mode(ref, package_id)
+
+        for package_id_mode, ref, package_id in configs:
+            with environment_append({"CONAN_DEFAULT_PACKAGE_ID_MODE": package_id_mode}):
+                _assert_recipe_mode(ref, package_id)


### PR DESCRIPTION
- Add default_package_id_mode into default conan.conf
- Add env var CONAN_DEFAULT_PACKAGE_ID_MODE
- Set default value to semver_direct_mode
- Update Functional tests to validate the env var

fixes #4974

Changelog: Fix: Add default_package_id_mode in the default conan.conf (#4947)
Docs: https://github.com/conan-io/docs/pull/1248

- [x] Refer to the issue that supports this Pull Request.
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [x] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 

<sup>**Note:** By default this PR will skip the slower tests and will use a limited set of python versions. Check [here](https://github.com/conan-io/conan/blob/develop/.github/PR_INCREASE_TESTING.md) how to increase the testing level by writing some tags in the current PR body text.</sup>
