### PR TITLE
Check manifest and consider the file corrupted

### DIFF
--- a/conans/client/cmd/uploader.py
+++ b/conans/client/cmd/uploader.py
@@ -334,11 +334,29 @@ class CmdUpload(object):
         return the_files
 
     def _recipe_files_to_upload(self, ref, policy, the_files, remote, remote_manifest):
-        # Get the remote snapshot
-        self._remote_manager.check_credentials(remote)
-        remote_snapshot = self._remote_manager.get_recipe_snapshot(ref, remote)
 
-        if remote_snapshot and policy != UPLOAD_POLICY_FORCE:
+        self._remote_manager.check_credentials(remote)
+
+        files_to_upload = {filename.replace("\\", "/"): path
+                           for filename, path in the_files.items()}
+
+        # Get the remote snapshot
+        remote_snapshot = self._remote_manager.get_recipe_snapshot(ref, remote)
+        if not remote_snapshot:
+            return files_to_upload, set()
+
+        deleted = set(remote_snapshot).difference(the_files)
+
+        if policy == UPLOAD_POLICY_FORCE:
+            return files_to_upload, deleted
+
+        if remote_manifest is None:
+            # https://github.com/conan-io/conan/issues/4953
+            # probably that is a concurrency issue or corruption issue?
+            self._user_io.out.warn("The remote recipe doesn't have the 'conanmanifest.txt'"
+                                   " file, the recipe needs to be overwritten: '{}'"
+                                   "".format(ref))
+        else:
             local_manifest = FileTreeManifest.loads(load(the_files["conanmanifest.txt"]))
 
             if remote_manifest == local_manifest:
@@ -348,9 +366,6 @@ class CmdUpload(object):
                 raise ConanException("Local recipe is different from the remote recipe. "
                                      "Forbidden overwrite.")
 
-        files_to_upload = {filename.replace("\\", "/"): path
-                           for filename, path in the_files.items()}
-        deleted = set(remote_snapshot).difference(the_files)
         return files_to_upload, deleted
 
     def _package_files_to_upload(self, pref, policy, the_files, remote):

--- a/conans/client/cmd/uploader.py
+++ b/conans/client/cmd/uploader.py
@@ -353,8 +353,8 @@ class CmdUpload(object):
         if remote_manifest is None:
             # https://github.com/conan-io/conan/issues/4953
             # probably that is a concurrency issue or corruption issue?
-            self._user_io.out.warn("The remote recipe doesn't have the 'conanmanifest.txt'"
-                                   " file, the recipe needs to be overwritten: '{}'"
+            self._user_io.out.warn("The remote recipe doesn't have the 'conanmanifest.txt' file"
+                                   " and needs to be overwritten: '{}'"
                                    "".format(ref))
         else:
             local_manifest = FileTreeManifest.loads(load(the_files["conanmanifest.txt"]))


### PR DESCRIPTION
Changelog: Bugfix: Fixed a bug that intermittently raised  `ERROR: 'NoneType' object has no attribute 'file_sums'` when uploading a recipe.
Docs: omit

Close #4953
Close #5009

Check if the remote recipe manifest is None before comparing with the local one.
It could be caused because:

a) Concurrency issue, maybe when we read the manifest it is None but later the snapshot is != None because the recipe might be being uploaded in a concurrent process. (Matches the symptoms)
b) Remote recipe corruption, where there is no manifest upload.

I would say the "a" is the most plausible reason. So now the client will consider that it has to upload all the contents again.