### PR TITLE
concurrent uploads checks and tests

### DIFF
--- a/conans/client/cmd/uploader.py
+++ b/conans/client/cmd/uploader.py
@@ -208,8 +208,8 @@ class CmdUpload(object):
                                    remote=recipe_remote)
 
     def _upload_recipe(self, ref, conanfile, retry, retry_wait, policy, remote):
-        current_remote_name = self._registry.refs.get(ref)
-        if remote.name != current_remote_name:
+        current_remote = self._registry.refs.get(ref)
+        if remote != current_remote:
             complete_recipe_sources(self._remote_manager, self._cache, conanfile, ref)
 
         conanfile_path = self._cache.conanfile(ref)
@@ -242,7 +242,7 @@ class CmdUpload(object):
                                    reference=ref, remote=remote)
 
         # The recipe wasn't in the registry or it has changed the revision field only
-        if not current_remote_name:
+        if not current_remote:
             self._registry.refs.set(ref, remote.name)
 
         return ref

--- a/conans/test/functional/command/upload_test.py
+++ b/conans/test/functional/command/upload_test.py
@@ -626,12 +626,11 @@ class Pkg(ConanFile):
         ref = ConanFileReference.loads("lib/1.0@conan/testing")
         client.create(ref)
         client.upload_all(ref)
-        # Simulate a missing manifest, maybe because it hasn't been uploaded yet
+        # The _check_recipe_date returns None, but later it will get the manifest ok
         with patch.object(CmdUpload, "_check_recipe_date") as check_date:
             check_date.return_value = None
             # Upload same with client2
             client2.create(ref)
             client2.run("upload lib/1.0@conan/testing")
-
             self.assertIn("Recipe is up to date, upload skipped", client2.out)
             self.assertNotIn("WARN", client2.out)


### PR DESCRIPTION
Changelog: Bugfix: Solved errors in concurrent uploads of same recipe
Docs: omit

Branched from https://github.com/conan-io/conan/pull/5012, but:

- Delayed _check_recipe_date AFTER compressing the zip, so it is closer to snapshot
- Avoiding loading local manifest twice
- If remote_manifest not there, try to get it in a later attempt
- New test with a patch to simulate exactly the concurrent behavior

@tags: slow
