### PR TITLE
#4956 cmake_find_package_multi might need also CMAKE_MODULE_PATH

### DIFF
--- a/conans/client/build/cmake_flags.py
+++ b/conans/client/build/cmake_flags.py
@@ -324,13 +324,15 @@ class CMakeDefinitionsBuilder(object):
 
         # Adjust automatically the module path in case the conanfile is using the
         # cmake_find_package or cmake_find_package_multi
+        install_folder = self._conanfile.install_folder.replace("\\", "/")
         if "cmake_find_package" in self._conanfile.generators:
-            ret["CMAKE_MODULE_PATH"] = self._conanfile.install_folder.replace("\\", "/")
+            ret["CMAKE_MODULE_PATH"] = install_folder
 
         if "cmake_find_package_multi" in self._conanfile.generators:
             # The cmake_find_package_multi only works with targets and generates XXXConfig.cmake
-            # that require the prefix path, not the module path
-            ret["CMAKE_PREFIX_PATH"] = self._conanfile.install_folder.replace("\\", "/")
+            # that require the prefix path and the module path
+            ret["CMAKE_PREFIX_PATH"] = install_folder
+            ret["CMAKE_MODULE_PATH"] = install_folder
 
         ret.update(self._get_make_program_definition())
 


### PR DESCRIPTION
cmake_flags.py add also CMAKE_MODULE_PATH when using that generator. Looks like the find_dependency needs it.

closes #4956

Changelog: Fix: Include CMAKE_MODULE_PATH for CMake find_dependency (#4956)
Docs: Omit

- [x] Refer to the issue that supports this Pull Request.
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 

<sup>**Note:** By default this PR will skip the slower tests and will use a limited set of python versions. Check [here](https://github.com/conan-io/conan/blob/develop/.github/PR_INCREASE_TESTING.md) how to increase the testing level by writing some tags in the current PR body text.</sup>
