### PR TITLE
Use 'revision' as the SVN's 'peg_revision' (broken for an edge case)

### DIFF
--- a/conans/client/tools/scm.py
+++ b/conans/client/tools/scm.py
@@ -310,7 +310,7 @@ class SVN(SCMBase):
     def get_qualified_remote_url(self, remove_credentials=False):
         # Return url with peg revision
         url = self.get_remote_url(remove_credentials=remove_credentials)
-        revision = self.get_last_changed_revision()
+        revision = self.get_revision()
         return "{url}@{revision}".format(url=url, revision=revision)
 
     def is_local_repository(self):

--- a/conans/test/functional/scm/issues/test_svn_tag.py
+++ b/conans/test/functional/scm/issues/test_svn_tag.py
@@ -48,7 +48,7 @@ class SVNTaggedComponentTest(SVNLocalRepoTestCase):
         t.runner('svn co "{url}" "{path}"'.format(url=url, path=t.current_folder))
 
         # Export the recipe (be sure sources are retrieved from the repository)
-        t.run("export conanfile.py {ref}".format(ref=ref))
+        t.run("export . {ref}".format(ref=ref))
         package_layout = t.cache.package_layout(ref)
         exported_conanfile = load(package_layout.conanfile())
         self.assertNotIn("auto", exported_conanfile)

--- a/conans/test/functional/scm/issues/test_svn_tag.py
+++ b/conans/test/functional/scm/issues/test_svn_tag.py
@@ -44,9 +44,9 @@ class SVNTaggedComponentTest(SVNLocalRepoTestCase):
         ref = ConanFileReference.loads("lib/version@issue/testing")
 
         # Clone the tag to local folder
-        url = os.path.join(self.project_url, "tags/release-1.0/level1")
+        url = os.path.join(self.project_url, "tags/release-1.0/level1").replace('\\', '/')
         t.runner('svn co "{url}" "{path}"'.format(url=url, path=t.current_folder))
-
+        
         # Export the recipe (be sure sources are retrieved from the repository)
         t.run("export . {ref}".format(ref=ref))
         package_layout = t.cache.package_layout(ref)

--- a/conans/test/functional/scm/issues/test_svn_tag.py
+++ b/conans/test/functional/scm/issues/test_svn_tag.py
@@ -44,11 +44,11 @@ class SVNTaggedComponentTest(SVNLocalRepoTestCase):
         ref = ConanFileReference.loads("lib/version@issue/testing")
 
         # Clone the tag to local folder
-        url = os.path.join(self.project_url, "tags/release-1.0")
+        url = os.path.join(self.project_url, "tags/release-1.0/level1")
         t.runner('svn co "{url}" "{path}"'.format(url=url, path=t.current_folder))
 
         # Export the recipe (be sure sources are retrieved from the repository)
-        t.run("export level1/conanfile.py {ref}".format(ref=ref))
+        t.run("export conanfile.py {ref}".format(ref=ref))
         package_layout = t.cache.package_layout(ref)
         exported_conanfile = load(package_layout.conanfile())
         self.assertNotIn("auto", exported_conanfile)
@@ -58,5 +58,4 @@ class SVNTaggedComponentTest(SVNLocalRepoTestCase):
 
         # Compile (it will clone the repo)
         t.run("install {ref} --build=lib".format(ref=ref))
-        print(t.out)
-        self.fail("AAA")
+        self.assertIn("lib/version@issue/testing: Getting sources from url:", t.out)

--- a/conans/test/functional/scm/issues/test_svn_tag.py
+++ b/conans/test/functional/scm/issues/test_svn_tag.py
@@ -1,0 +1,54 @@
+# coding=utf-8
+
+import os
+import textwrap
+
+from nose.plugins.attrib import attr
+
+from conans.model.ref import ConanFileReference
+from conans.test.utils.tools import SVNLocalRepoTestCase, TestClient, \
+    load
+
+
+@attr('svn')
+class SVNTaggedComponentTest(SVNLocalRepoTestCase):
+    # Reproducing https://github.com/conan-io/conan/issues/5017
+
+    def setUp(self):
+        # Create a sample SVN repository
+        conanfile = textwrap.dedent("""
+            from conans import ConanFile, tools
+            
+            class Lib(ConanFile):
+                scm = {"type": "svn", "url": "auto", "revision": "auto"}
+        """)
+        files = {'level0.txt': "level0",
+                 'level1/level1.txt': "level1",
+                 'level1/conanfile.py': conanfile,
+                 'tags/sentinel': ""}
+        self.project_url, rev = self.create_project(files=files)
+        self.project_url = self.project_url.replace(" ", "%20")
+
+        # Create a tag for 'level1' component
+        t = TestClient()
+        t.runner('svn copy {url}/level1 {url}/tags/level1-1.0'
+                 ' -m "Release level1-1.0"'.format(url=self.project_url), cwd=t.current_folder)
+
+    def test_auto_tag(self):
+        t = TestClient()
+        ref = ConanFileReference.loads("lib/version@issue/testing")
+
+        # Clone the tag to local folder
+        url = os.path.join(self.project_url, "tags/level1-1.0")
+        t.runner('svn co "{url}" "{path}"'.format(url=url, path=t.current_folder))
+
+        # Export the recipe (be sure sources are retrieved from the repository)
+        t.run("export . {ref}".format(ref=ref))
+        package_layout = t.cache.package_layout(ref)
+        exported_conanfile = load(package_layout.conanfile())
+        self.assertNotIn("auto", exported_conanfile)
+        os.remove(package_layout.scm_folder())
+
+        t.run("install {ref} --build=lib".format(ref=ref))
+        print(t.out)
+        self.fail("AAA")


### PR DESCRIPTION
Changelog: Fix: Use `revision` as the SVN's `peg_revision` (broken for an edge case)
Docs: omit

closes #5017 

@TAGS: svn, slow
