### PR TITLE
Add GCC 9 to default settings.yml

### DIFF
--- a/conans/client/conf/__init__.py
+++ b/conans/client/conf/__init__.py
@@ -58,7 +58,8 @@ compiler:
                   "5", "5.1", "5.2", "5.3", "5.4", "5.5",
                   "6", "6.1", "6.2", "6.3", "6.4",
                   "7", "7.1", "7.2", "7.3",
-                  "8", "8.1", "8.2"]
+                  "8", "8.1", "8.2",
+                  "9"]
         libcxx: [libstdc++, libstdc++11]
         threads: [None, posix, win32] #  Windows MinGW
         exception: [None, dwarf2, sjlj, seh] # Windows MinGW


### PR DESCRIPTION
Changelog: Feature: Add GCC 9 to default settings.yml
Docs: conan-io/docs#1257

- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.

I'm assuming that no separated issue is required for such a small change. Please correct me if I'm wrong with that assumption 
