### PR TITLE
Fix premake quoted path or names

### DIFF
--- a/conans/client/generators/premake.py
+++ b/conans/client/generators/premake.py
@@ -11,12 +11,12 @@ class PremakeDeps(object):
                                     for p in deps_cpp_info.lib_paths)
         self.bin_paths = ",\n".join('"%s"' % p.replace("\\", "/")
                                     for p in deps_cpp_info.bin_paths)
-        self.libs = ", ".join('"%s"' % p for p in deps_cpp_info.libs)
+        self.libs = ", ".join('"%s"' % p.replace('"', '\\"') for p in deps_cpp_info.libs)
         self.defines = ", ".join('"%s"' % p for p in deps_cpp_info.defines)
         self.cxxflags = ", ".join('"%s"' % p for p in deps_cpp_info.cxxflags)
         self.cflags = ", ".join('"%s"' % p for p in deps_cpp_info.cflags)
-        self.sharedlinkflags = ", ".join('"%s"' % p for p in deps_cpp_info.sharedlinkflags)
-        self.exelinkflags = ", ".join('"%s"' % p for p in deps_cpp_info.exelinkflags)
+        self.sharedlinkflags = ", ".join('"%s"' % p.replace('"', '\\"') for p in deps_cpp_info.sharedlinkflags)
+        self.exelinkflags = ", ".join('"%s"' % p.replace('"', '\\"') for p in deps_cpp_info.exelinkflags)
 
         self.rootpath = "%s" % deps_cpp_info.rootpath.replace("\\", "/")
 
@@ -41,7 +41,7 @@ class PremakeGenerator(Generator):
                     'conan_exelinkflags{dep} = {{{deps.exelinkflags}}}\n')
 
         sections = ["#!lua"]
-        
+
         sections.extend(
                 ['conan_build_type = "{0}"'.format(str(self.settings.get_safe("build_type"))),
                  'conan_arch = "{0}"'.format(str(self.settings.get_safe("arch"))),

--- a/conans/test/unittests/client/generators/premake_test.py
+++ b/conans/test/unittests/client/generators/premake_test.py
@@ -29,8 +29,8 @@ class PremakeGeneratorTest(unittest.TestCase):
     conan_defines = {{"MYDEFINE2", "MYDEFINE1"}}
     conan_cxxflags = {{"-march=native", "-fPIE"}}
     conan_cflags = {{"-mtune=native", "-fPIC"}}
-    conan_sharedlinkflags = {{"-framework AudioFoundation", "-framework Cocoa"}}
-    conan_exelinkflags = {{"-framework VideoToolbox", "-framework QuartzCore"}}
+    conan_sharedlinkflags = {{"-framework AudioFoundation", "-framework \\\"Some Spaced Framework\\\"", "-framework Cocoa"}}
+    conan_exelinkflags = {{"-framework VideoToolbox", "-framework \\\"Other Spaced Framework\\\"", "-framework QuartzCore"}}
 
     conan_includedirs_MyPkg1 = {{"{include1}"}}
     conan_libdirs_MyPkg1 = {{"{lib1}"}}
@@ -50,8 +50,8 @@ class PremakeGeneratorTest(unittest.TestCase):
     conan_defines_MyPkg2 = {{"MYDEFINE2"}}
     conan_cxxflags_MyPkg2 = {{"-march=native"}}
     conan_cflags_MyPkg2 = {{"-mtune=native"}}
-    conan_sharedlinkflags_MyPkg2 = {{"-framework AudioFoundation"}}
-    conan_exelinkflags_MyPkg2 = {{"-framework VideoToolbox"}}
+    conan_sharedlinkflags_MyPkg2 = {{"-framework AudioFoundation", "-framework \\\"Some Spaced Framework\\\""}}
+    conan_exelinkflags_MyPkg2 = {{"-framework VideoToolbox", "-framework \\\"Other Spaced Framework\\\""}}
     conan_rootpath_MyPkg2 = "{root2}"
 
     function conan_basic_setup()
@@ -100,8 +100,8 @@ class PremakeGeneratorTest(unittest.TestCase):
         cpp_info.version = "3.2.3"
         cpp_info.cflags = ['-mtune=native']
         cpp_info.cxxflags = ['-march=native']
-        cpp_info.sharedlinkflags = ['-framework AudioFoundation']
-        cpp_info.exelinkflags = ['-framework VideoToolbox']
+        cpp_info.sharedlinkflags = ['-framework AudioFoundation', '-framework "Some Spaced Framework"']
+        cpp_info.exelinkflags = ['-framework VideoToolbox', '-framework "Other Spaced Framework"']
         self.conanfile.deps_cpp_info.update(cpp_info, ref.name)
 
     def test_variables_content(self):


### PR DESCRIPTION
Changelog: Fix: Handle quoted path and libraries in the premake generator

Fix #5050

- [x] Refer to the issue that supports this Pull Request.
- [ ] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 

<sup>**Note:** By default this PR will skip the slower tests and will use a limited set of python versions. Check [here](https://github.com/conan-io/conan/blob/develop/.github/PR_INCREASE_TESTING.md) how to increase the testing level by writing some tags in the current PR body text.</sup>
