### PR TITLE
MSBuild. parameter to skip toolset adjustement

### DIFF
--- a/conans/client/build/msbuild.py
+++ b/conans/client/build/msbuild.py
@@ -104,7 +104,8 @@ class MSBuild(object):
 
         build_type = build_type or self._settings.get_safe("build_type")
         arch = arch or self._settings.get_safe("arch")
-        toolset = toolset or tools.msvs_toolset(self._settings)
+        if toolset is None:  # False value to skip adjusting
+            toolset = tools.msvs_toolset(self._settings)
         verbosity = os.getenv("CONAN_MSBUILD_VERBOSITY") or verbosity or "minimal"
         if not build_type:
             raise ConanException("Cannot build_sln_command, build_type not defined")

--- a/conans/test/unittests/client/build/msbuild_test.py
+++ b/conans/test/unittests/client/build/msbuild_test.py
@@ -8,6 +8,7 @@ import six
 from parameterized import parameterized
 
 from conans.client import tools
+from conans.client.tools.files import chdir
 from conans.client.build.msbuild import MSBuild
 from conans.errors import ConanException
 from conans.model.version import Version
@@ -152,6 +153,7 @@ class MSBuildTest(unittest.TestCase):
         command = msbuild.get_command("project_should_flags_test_file.sln")
         self.assertIn('/p:PlatformToolset="%s"' % expected_toolset, command)
 
+    @unittest.skipUnless(platform.system() == "Windows", "Requires MSBuild")
     def skip_toolset_test(self):
         settings = MockSettings({"build_type": "Debug",
                                  "compiler": "Visual Studio",
@@ -166,19 +168,20 @@ class MSBuildTest(unittest.TestCase):
             def __call__(self, *args, **kwargs):
                 self.commands.append(args[0])
 
-        runner = Runner()
-        conanfile = MockConanfile(settings, runner=runner)
-        msbuild = MSBuild(conanfile)
-        msbuild.build("myproject", toolset=False)
-        self.assertEqual(len(runner.commands), 1)
-        self.assertNotIn("PlatformToolset", runner.commands[0])
+        with chdir(tools.mkdir_tmp()):
+            runner = Runner()
+            conanfile = MockConanfile(settings, runner=runner)
+            msbuild = MSBuild(conanfile)
+            msbuild.build("myproject", toolset=False)
+            self.assertEqual(len(runner.commands), 1)
+            self.assertNotIn("PlatformToolset", runner.commands[0])
 
-        runner = Runner()
-        conanfile = MockConanfile(settings, runner=runner)
-        msbuild = MSBuild(conanfile)
-        msbuild.build("myproject", toolset="mytoolset")
-        self.assertEqual(len(runner.commands), 1)
-        self.assertIn('/p:PlatformToolset="mytoolset"', runner.commands[0])
+            runner = Runner()
+            conanfile = MockConanfile(settings, runner=runner)
+            msbuild = MSBuild(conanfile)
+            msbuild.build("myproject", toolset="mytoolset")
+            self.assertEqual(len(runner.commands), 1)
+            self.assertIn('/p:PlatformToolset="mytoolset"', runner.commands[0])
 
     @parameterized.expand([("v142",),
                            ("v141",),


### PR DESCRIPTION
Changelog: Feature: The `MSBuild` build helper allows the parameter `toolset` with `False` value to skip the toolset adjustment.
Docs: https://github.com/conan-io/docs/pull/1260

Closes #4975 