### PR TITLE
Fixed 0 size and test

### DIFF
--- a/conans/client/cmd/uploader.py
+++ b/conans/client/cmd/uploader.py
@@ -502,6 +502,7 @@ def compress_files(files, symlinks, name, dest_dir, output=None):
             info = tarfile.TarInfo(name=filename)
             info.type = tarfile.SYMTYPE
             info.linkname = dest
+            info.size = 0  # A symlink shouldn't have size
             tgz.addfile(tarinfo=info)
 
         mask = ~(stat.S_IWOTH | stat.S_IWGRP)
@@ -516,6 +517,7 @@ def compress_files(files, symlinks, name, dest_dir, output=None):
             info.mode = os.stat(abs_path).st_mode & mask
             if os.path.islink(abs_path):
                 info.type = tarfile.SYMTYPE
+                info.size = 0  # A symlink shouldn't have size
                 info.linkname = os.readlink(abs_path)  # @UndefinedVariable
                 tgz.addfile(tarinfo=info)
             else:

--- a/conans/test/functional/configuration/compressed_symlinks_test.py
+++ b/conans/test/functional/configuration/compressed_symlinks_test.py
@@ -41,12 +41,12 @@ class HelloConan(ConanFile):
 lrw-r--r-- 0/0               0 1970-01-01 01:00 link.txt -> file.txt
         """
 
-        for l in lines:
-            if ".txt" not in l:
+        for line in lines:
+            if ".txt" not in line:
                 continue
 
-            size = int(filter(None, l.split(" "))[2])
-            if "link.txt" in l:
+            size = int([i for i in line.split(" ") if i][2])
+            if "link.txt" in line:
                 self.assertEqual(int(size), 0)
             elif "file.txt":
                 self.assertGreater(int(size), 0)

--- a/conans/test/functional/configuration/compressed_symlinks_test.py
+++ b/conans/test/functional/configuration/compressed_symlinks_test.py
@@ -8,7 +8,7 @@ from conans.test.utils.tools import TestServer, TurboTestClient
 
 class CompressSymlinksZeroSize(unittest.TestCase):
 
-    @unittest.skipIf(platform.system() == "Windows", "Better to test only in NIX the symlinks")
+    @unittest.skipIf(platform.system() != "Linux", "Only linux")
     def test_package_symlinks_zero_size(self):
         server = TestServer()
         client = TurboTestClient(servers={"default": server})
@@ -41,6 +41,7 @@ class HelloConan(ConanFile):
 lrw-r--r-- 0/0               0 1970-01-01 01:00 link.txt -> file.txt
         """
 
+        self.assertIn("link.txt", " ".join(lines))
         for line in lines:
             if ".txt" not in line:
                 continue

--- a/conans/test/functional/configuration/compressed_symlinks_test.py
+++ b/conans/test/functional/configuration/compressed_symlinks_test.py
@@ -1,0 +1,52 @@
+import os
+import platform
+import unittest
+
+from conans.model.ref import ConanFileReference
+from conans.test.utils.tools import TestServer, TurboTestClient
+
+
+class CompressSymlinksZeroSize(unittest.TestCase):
+
+    @unittest.skipIf(platform.system() == "Windows", "Better to test only in NIX the symlinks")
+    def test_package_symlinks_zero_size(self):
+        server = TestServer()
+        client = TurboTestClient(servers={"default": server})
+
+        conanfile = """
+import os
+from conans import ConanFile, tools
+
+class HelloConan(ConanFile):
+
+    def package(self):
+        # Link to file.txt and then remove it
+        tools.save(os.path.join(self.package_folder, "file.txt"), "contents")
+        os.symlink("file.txt", os.path.join(self.package_folder, "link.txt"))    
+"""
+        ref = ConanFileReference.loads("lib/1.0@conan/stable")
+        # By default it is not allowed
+        pref = client.create(ref, conanfile=conanfile)
+        # Upload, it will create the tgz
+        client.upload_all(ref)
+
+        # We can uncompress it without warns
+        p_folder = client.cache.package_layout(pref.ref).package(pref)
+        tgz = os.path.join(p_folder, "conan_package.tgz")
+        client.run_command('gzip -d "{}"'.format(tgz))
+        client.run_command('tar tvf "{}"'.format(os.path.join(p_folder, "conan_package.tar")))
+        lines = str(client.out).splitlines()
+        """
+-rw-r--r-- 0/0               8 1970-01-01 01:00 file.txt
+lrw-r--r-- 0/0               0 1970-01-01 01:00 link.txt -> file.txt
+        """
+
+        for l in lines:
+            if ".txt" not in l:
+                continue
+
+            size = int(filter(None, l.split(" "))[2])
+            if "link.txt" in l:
+                self.assertEqual(int(size), 0)
+            elif "file.txt":
+                self.assertGreater(int(size), 0)


### PR DESCRIPTION
Changelog: Bugfix: The symlinks compressed in a `tgz` had invalid nonzero size.
Docs: omit

Close #4050 