### PR TITLE
fix for editable declaring build_folder

### DIFF
--- a/conans/client/installer.py
+++ b/conans/client/installer.py
@@ -421,7 +421,7 @@ class BinaryInstaller(object):
         assert pref.id, "Package-ID without value"
 
         # It is necessary to complete the sources of python requires, which might be used
-        for name, python_require in conanfile.python_requires.items():
+        for python_require in conanfile.python_requires.values():
             assert python_require.ref.revision is not None, \
                 "Installer should receive python_require.ref always"
             complete_recipe_sources(self._remote_manager, self._cache,

--- a/conans/client/manager.py
+++ b/conans/client/manager.py
@@ -77,7 +77,7 @@ class ConanManager(object):
         installer = BinaryInstaller(self._cache, self._user_io.out, self._remote_manager,
                                     recorder=self._recorder,
                                     hook_manager=self._hook_manager)
-        installer.install(deps_graph, remotes, keep_build=keep_build)
+        installer.install(deps_graph, remotes, keep_build=keep_build, graph_info=graph_info)
 
         if manifest_folder:
             manifest_manager = ManifestManager(manifest_folder, user_io=self._user_io,

--- a/conans/test/utils/tools.py
+++ b/conans/test/utils/tools.py
@@ -848,7 +848,7 @@ servers["r2"] = TestServer()
 
     def run_command(self, command):
         self.all_output += str(self.out)
-        self.init_dynamic_vars() # Resets the output
+        self.init_dynamic_vars()  # Resets the output
         return self.runner(command, cwd=self.current_folder)
 
     def save(self, files, path=None, clean_first=False):
@@ -858,6 +858,7 @@ servers["r2"] = TestServer()
         path = path or self.current_folder
         if clean_first:
             shutil.rmtree(self.current_folder, ignore_errors=True)
+        files = {f: str(content) for f, content in files.items()}
         save_files(path, files)
         if not files:
             mkdir(self.current_folder)


### PR DESCRIPTION
Changelog: Bugfix: Don't crash when an editable declare a ``build_folder`` in the layout, but not used in a workspace
Docs: omit

Close #4819
