### PR TITLE
Remove sudo from Travis template

### DIFF
--- a/conans/client/cmd/new_ci.py
+++ b/conans/client/cmd/new_ci.py
@@ -11,9 +11,8 @@ env:
 linux: &linux
    os: linux
    dist: xenial
-   sudo: required
    language: python
-   python: "3.6"
+   python: "3.7"
    services:
      - docker
 osx: &osx


### PR DESCRIPTION
- sudo is no longer required to run Docker
- Update Python version to 3.7

Changelog: Fix: Remove sudo from Travis CI template
Docs: https://github.com/conan-io/docs/pull/1270

- [ ] Refer to the issue that supports this Pull Request.
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [x] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 

<sup>**Note:** By default this PR will skip the slower tests and will use a limited set of python versions. Check [here](https://github.com/conan-io/conan/blob/develop/.github/PR_INCREASE_TESTING.md) how to increase the testing level by writing some tags in the current PR body text.</sup>
