### PR TITLE
Fix: MSYS 3.x detection

### DIFF
--- a/conans/client/tools/oss.py
+++ b/conans/client/tools/oss.py
@@ -323,13 +323,14 @@ class OSInfo(object):
         if "cygwin" in output:
             return CYGWIN
         elif "msys" in output or "mingw" in output:
-            output = OSInfo.uname("-r")
-            if output.startswith("2"):
-                return MSYS2
-            elif output.startswith("1"):
-                return MSYS
-            else:
-                return None
+            version = OSInfo.uname("-r").split('.')
+            if version and version[0].isdigit():
+                major = int(version[0])
+                if major == 1:
+                    return MSYS
+                elif major >= 2:
+                    return MSYS2
+            return None
         elif "linux" in output:
             return WSL
         else:

--- a/conans/test/unittests/client/tools/os_info/osinfo_test.py
+++ b/conans/test/unittests/client/tools/os_info/osinfo_test.py
@@ -76,6 +76,23 @@ class OSInfoTest(unittest.TestCase):
                     self.assertEqual(OSInfo.uname(), self._uname.lower())
                     self.assertEqual(OSInfo.detect_windows_subsystem(), MSYS)
 
+    def test_msys3(self):
+        self._uname = 'MSYS_NT-10.0'
+        self._version = '3.0.6(0.338/5/3)'
+        with mock.patch("platform.system", mock.MagicMock(return_value=self._uname)):
+            self.assertTrue(OSInfo().is_windows)
+            self.assertFalse(OSInfo().is_cygwin)
+            self.assertTrue(OSInfo().is_msys)
+            self.assertFalse(OSInfo().is_linux)
+            self.assertFalse(OSInfo().is_freebsd)
+            self.assertFalse(OSInfo().is_macos)
+            self.assertFalse(OSInfo().is_solaris)
+
+            with environment_append({"CONAN_BASH_PATH": "/fake/bash.exe"}):
+                with mock.patch('conans.client.tools.oss.check_output', new=self.subprocess_check_output_mock):
+                    self.assertEqual(OSInfo.uname(), self._uname.lower())
+                    self.assertEqual(OSInfo.detect_windows_subsystem(), MSYS2)
+
     def test_mingw32(self):
         self._uname = 'MINGW32_NT-10.0'
         self._version = '2.10.0(0.325/5/3)'


### PR DESCRIPTION
Changelog: Fix: MSYS 3.x detection
Docs: omit
@tags: slow, svn

https://github.com/conan-io/conan/issues/5071

- [x] Refer to the issue that supports this Pull Request.
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [x] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 

<sup>**Note:** By default this PR will skip the slower tests and will use a limited set of python versions. Check [here](https://github.com/conan-io/conan/blob/develop/.github/PR_INCREASE_TESTING.md) how to increase the testing level by writing some tags in the current PR body text.</sup>
