### PR TITLE
#5101 Export detected_os from OSS Tools

### DIFF
--- a/conans/test/unittests/client/conf/detect/detected_os_test.py
+++ b/conans/test/unittests/client/conf/detect/detected_os_test.py
@@ -5,6 +5,7 @@
 import unittest
 from mock import mock
 from conans.client.tools.oss import detected_os, OSInfo
+from conans import tools
 
 
 class DetectedOSTest(unittest.TestCase):
@@ -44,3 +45,7 @@ class DetectedOSTest(unittest.TestCase):
     def test_solaris(self):
         with mock.patch("platform.system", mock.MagicMock(return_value='SunOS')):
             self.assertEqual(detected_os(), "SunOS")
+
+    def test_export_tools(self):
+        with mock.patch("platform.system", mock.MagicMock(return_value='FreeBSD')):
+            self.assertEqual(tools.detected_os(), "FreeBSD")

--- a/conans/tools.py
+++ b/conans/tools.py
@@ -111,6 +111,7 @@ def replace_path_in_file(*args, **kwargs):
 # from conans.client.tools.oss
 args_to_string = tools_oss.args_to_string
 detected_architecture = tools_oss.detected_architecture
+detected_os = tools_oss.detected_os
 OSInfo = tools_oss.OSInfo
 cross_building = tools_oss.cross_building
 get_cross_building_settings = tools_oss.get_cross_building_settings


### PR DESCRIPTION
Add alias for tools.oss.detected_os

Changelog: Fix: Export detected_os from tools.oss (#5101)
Docs: https://github.com/conan-io/docs/pull/1276
fixes #5101

- [x] Refer to the issue that supports this Pull Request.
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 

<sup>**Note:** By default this PR will skip the slower tests and will use a limited set of python versions. Check [here](https://github.com/conan-io/conan/blob/develop/.github/PR_INCREASE_TESTING.md) how to increase the testing level by writing some tags in the current PR body text.</sup>
