### PR TITLE
fix migration

### DIFF
--- a/conans/client/cache/remote_registry.py
+++ b/conans/client/cache/remote_registry.py
@@ -63,15 +63,17 @@ def migrate_registry_file(cache, out):
 
     def add_ref_remote(reference, remotes, remote_name):
         ref = ConanFileReference.loads(reference, validate=True)
-        remote = remotes[remote_name]
-        with cache.package_layout(ref).update_metadata() as metadata:
-            metadata.recipe.remote = remote.name
+        remote = remotes.get(remote_name)
+        if remote:
+            with cache.package_layout(ref).update_metadata() as metadata:
+                metadata.recipe.remote = remote.name
 
     def add_pref_remote(pkg_ref, remotes, remote_name):
         pref = PackageReference.loads(pkg_ref, validate=True)
-        remote = remotes[remote_name]
-        with cache.package_layout(pref.ref).update_metadata() as metadata:
-            metadata.packages[pref.id].remote = remote.name
+        remote = remotes.get(remote_name)
+        if remote:
+            with cache.package_layout(pref.ref).update_metadata() as metadata:
+                metadata.packages[pref.id].remote = remote.name
 
     try:
         if os.path.exists(reg_json_path):

--- a/conans/client/migrations_settings.py
+++ b/conans/client/migrations_settings.py
@@ -288,3 +288,80 @@ settings_1_14_1 = settings_1_14_0
 settings_1_14_2 = settings_1_14_1
 settings_1_14_3 = settings_1_14_2
 settings_1_14_4 = settings_1_14_3
+
+settings_1_15_0 = """
+# Only for cross building, 'os_build/arch_build' is the system that runs Conan
+os_build: [Windows, WindowsStore, Linux, Macos, FreeBSD, SunOS]
+arch_build: [x86, x86_64, ppc32, ppc64le, ppc64, armv5el, armv5hf, armv6, armv7, armv7hf, armv7s, armv7k, armv8, armv8_32, armv8.3, sparc, sparcv9, mips, mips64, avr, s390, s390x]
+
+# Only for building cross compilation tools, 'os_target/arch_target' is the system for
+# which the tools generate code
+os_target: [Windows, Linux, Macos, Android, iOS, watchOS, tvOS, FreeBSD, SunOS, Arduino]
+arch_target: [x86, x86_64, ppc32, ppc64le, ppc64, armv5el, armv5hf, armv6, armv7, armv7hf, armv7s, armv7k, armv8, armv8_32, armv8.3, sparc, sparcv9, mips, mips64, avr, s390, s390x, asm.js, wasm]
+
+# Rest of the settings are "host" settings:
+# - For native building/cross building: Where the library/program will run.
+# - For building cross compilation tools: Where the cross compiler will run.
+os:
+    Windows:
+        subsystem: [None, cygwin, msys, msys2, wsl]
+    WindowsStore:
+        version: ["8.1", "10.0"]
+    WindowsCE:
+        platform: ANY
+        version: ["5.0", "6.0", "7.0", "8.0"]
+    Linux:
+    Macos:
+        version: [None, "10.6", "10.7", "10.8", "10.9", "10.10", "10.11", "10.12", "10.13", "10.14"]
+    Android:
+        api_level: ANY
+    iOS:
+        version: ["7.0", "7.1", "8.0", "8.1", "8.2", "8.3", "9.0", "9.1", "9.2", "9.3", "10.0", "10.1", "10.2", "10.3", "11.0", "11.1", "11.2", "11.3", "11.4", "12.0", "12.1"]
+    watchOS:
+        version: ["4.0", "4.1", "4.2", "4.3", "5.0", "5.1"]
+    tvOS:
+        version: ["11.0", "11.1", "11.2", "11.3", "11.4", "12.0", "12.1"]
+    FreeBSD:
+    SunOS:
+    Arduino:
+        board: ANY
+    Emscripten:
+arch: [x86, x86_64, ppc32, ppc64le, ppc64, armv4, armv4i, armv5el, armv5hf, armv6, armv7, armv7hf, armv7s, armv7k, armv8, armv8_32, armv8.3, sparc, sparcv9, mips, mips64, avr, s390, s390x, asm.js, wasm]
+compiler:
+    sun-cc:
+        version: ["5.10", "5.11", "5.12", "5.13", "5.14"]
+        threads: [None, posix]
+        libcxx: [libCstd, libstdcxx, libstlport, libstdc++]
+    gcc:
+        version: ["4.1", "4.4", "4.5", "4.6", "4.7", "4.8", "4.9",
+                  "5", "5.1", "5.2", "5.3", "5.4", "5.5",
+                  "6", "6.1", "6.2", "6.3", "6.4",
+                  "7", "7.1", "7.2", "7.3",
+                  "8", "8.1", "8.2",
+                  "9"]
+        libcxx: [libstdc++, libstdc++11]
+        threads: [None, posix, win32] #  Windows MinGW
+        exception: [None, dwarf2, sjlj, seh] # Windows MinGW
+        cppstd: [None, 98, gnu98, 11, gnu11, 14, gnu14, 17, gnu17, 20, gnu20]
+    Visual Studio:
+        runtime: [MD, MT, MTd, MDd]
+        version: ["8", "9", "10", "11", "12", "14", "15", "16"]
+        toolset: [None, v90, v100, v110, v110_xp, v120, v120_xp,
+                  v140, v140_xp, v140_clang_c2, LLVM-vs2012, LLVM-vs2012_xp,
+                  LLVM-vs2013, LLVM-vs2013_xp, LLVM-vs2014, LLVM-vs2014_xp,
+                  LLVM-vs2017, LLVM-vs2017_xp, v141, v141_xp, v141_clang_c2, v142]
+        cppstd: [None, 14, 17, 20]
+    clang:
+        version: ["3.3", "3.4", "3.5", "3.6", "3.7", "3.8", "3.9", "4.0",
+                  "5.0", "6.0", "7.0",
+                  "8"]
+        libcxx: [libstdc++, libstdc++11, libc++]
+        cppstd: [None, 98, gnu98, 11, gnu11, 14, gnu14, 17, gnu17, 20, gnu20]
+    apple-clang:
+        version: ["5.0", "5.1", "6.0", "6.1", "7.0", "7.3", "8.0", "8.1", "9.0", "9.1", "10.0"]
+        libcxx: [libstdc++, libc++]
+        cppstd: [None, 98, gnu98, 11, gnu11, 14, gnu14, 17, gnu17, 20, gnu20]
+
+build_type: [None, Debug, Release, RelWithDebInfo, MinSizeRel]
+cppstd: [None, 98, gnu98, 11, gnu11, 14, gnu14, 17, gnu17, 20, gnu20]  # Deprecated, use compiler.cppstd
+"""

--- a/conans/test/functional/configuration/registry_test.py
+++ b/conans/test/functional/configuration/registry_test.py
@@ -1,15 +1,16 @@
 import os
+import textwrap
 import unittest
 
+from conans.client.cache.cache import ClientCache
 from conans.client.cache.remote_registry import RemoteRegistry, Remote, Remotes,\
     migrate_registry_file
 from conans.errors import ConanException
+from conans.migrations import CONAN_VERSION
+from conans.model.ref import ConanFileReference
 from conans.test.utils.test_files import temp_folder
 from conans.test.utils.tools import TestBufferConanOutput, TestClient
 from conans.util.files import save
-from conans.client.cache.cache import ClientCache
-from conans.migrations import CONAN_VERSION
-from conans.model.ref import ConanFileReference
 
 
 class RegistryTest(unittest.TestCase):
@@ -17,7 +18,10 @@ class RegistryTest(unittest.TestCase):
     def retro_compatibility_test(self):
         folder = temp_folder()
         f = os.path.join(folder, ".conan", "registry.txt")
-        save(f, "conan.io https://server.conan.io")  # Without SSL parameter
+        save(f, textwrap.dedent("""conan.io https://server.conan.io
+
+            pkg/0.1@user/testing some_remote
+            """))
         cache = ClientCache(folder, TestBufferConanOutput())
         migrate_registry_file(cache, TestBufferConanOutput())
         registry = RemoteRegistry(cache)


### PR DESCRIPTION
Changelog: Fix: Fix migration of *registry.json|txt* file including reference to non existing remotes.
Docs: omit


@lasote it is necessary to find a way to fix the migrations settings.yml before closing the release, otherwise both develop and all patch releases are broken initially,