### PR TITLE
fix remote update --insert with same url

### DIFF
--- a/conans/client/cache/remote_registry.py
+++ b/conans/client/cache/remote_registry.py
@@ -230,7 +230,7 @@ class Remotes(object):
 
     def _add_update(self, remote_name, url, verify_ssl, insert=None):
         prev_remote = self._get_by_url(url)
-        if prev_remote and verify_ssl == prev_remote.verify_ssl:
+        if prev_remote and verify_ssl == prev_remote.verify_ssl and insert is None:
             raise ConanException("Remote '%s' already exists with same URL" % prev_remote.name)
         updated_remote = Remote(remote_name, url, verify_ssl)
         if insert is not None:

--- a/conans/test/functional/command/remote_test.py
+++ b/conans/test/functional/command/remote_test.py
@@ -258,6 +258,14 @@ class HelloConan(ConanFile):
         self.assertIn("r3: https://r3", lines[1])
         self.assertIn("r2: https://r2new2", lines[2])
 
+    def test_update_insert_same_url(self):
+        # https://github.com/conan-io/conan/issues/5107
+        client = TestClient()
+        client.run("remote add r1 https://r1")
+        client.run("remote add r2 https://r2")
+        client.run("remote add r3 https://r3")
+        client.run("remote update r2 https://r2 --insert=0")
+
     def verify_ssl_test(self):
         client = TestClient()
         client.run("remote add my-remote http://someurl TRUE")

--- a/conans/test/functional/command/remote_test.py
+++ b/conans/test/functional/command/remote_test.py
@@ -265,6 +265,9 @@ class HelloConan(ConanFile):
         client.run("remote add r2 https://r2")
         client.run("remote add r3 https://r3")
         client.run("remote update r2 https://r2 --insert=0")
+        client.run("remote list")
+        self.assertLess(str(client.out).find("r2"), str(client.out).find("r1"))
+        self.assertLess(str(client.out).find("r1"), str(client.out).find("r3"))
 
     def verify_ssl_test(self):
         client = TestClient()


### PR DESCRIPTION
Changelog: Fix: Fix regression of ``conan remote update --insert`` using the same URL it had before
Docs: omit

Close #5107
