### PR TITLE
add gcc versions 8.3, 9.1

### DIFF
--- a/conans/client/conf/__init__.py
+++ b/conans/client/conf/__init__.py
@@ -58,8 +58,8 @@ compiler:
                   "5", "5.1", "5.2", "5.3", "5.4", "5.5",
                   "6", "6.1", "6.2", "6.3", "6.4",
                   "7", "7.1", "7.2", "7.3",
-                  "8", "8.1", "8.2",
-                  "9"]
+                  "8", "8.1", "8.2", "8.3",
+                  "9", "9.1"]
         libcxx: [libstdc++, libstdc++11]
         threads: [None, posix, win32] #  Windows MinGW
         exception: [None, dwarf2, sjlj, seh] # Windows MinGW


### PR DESCRIPTION
Changelog: Feature: Add gcc 8.3 and 9.1 new versions to default *settings.yml*
Docs: omit


Close #5111
