### PR TITLE
Fix missing symlink copy if src folder is a symlink (#5114)

### DIFF
--- a/conans/client/file_copier.py
+++ b/conans/client/file_copier.py
@@ -161,7 +161,7 @@ class FileCopier(object):
             src_link = os.path.join(src, linked_folder)
             # Discard symlinks that go out of the src folder
             abs_path = os.path.realpath(src_link)
-            relpath = os.path.relpath(abs_path, src)
+            relpath = os.path.relpath(abs_path, os.path.realpath(src))
             if relpath.startswith("."):
                 continue
 


### PR DESCRIPTION
Changelog: Fix: self.copy with symlinks=True does not copy symlink if the .conan directory is a symlink #5114
Docs: omit
- [x] Refer to the issue that supports this Pull Request.
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 

<sup>**Note:** By default this PR will skip the slower tests and will use a limited set of python versions. Check [here](https://github.com/conan-io/conan/blob/develop/.github/PR_INCREASE_TESTING.md) how to increase the testing level by writing some tags in the current PR body text.</sup>
