### PR TITLE
fixing python_requires remotes commands

### DIFF
--- a/conans/client/conan_api.py
+++ b/conans/client/conan_api.py
@@ -766,6 +766,8 @@ class ConanAPIV1(object):
         info_folder = _make_abs_path(info_folder, cwd)
         dest = _make_abs_path(dest, cwd)
 
+        remotes = self._cache.registry.load_remotes()
+        self.python_requires.enable_remotes(remotes=remotes)
         mkdir(dest)
         conanfile_abs_path = _get_conanfile_path(path, cwd, py=None)
         conanfile = self._graph_manager.load_consumer_conanfile(conanfile_abs_path, info_folder,
@@ -802,6 +804,7 @@ class ConanAPIV1(object):
         """
         from conans.client.cmd.copy import cmd_copy
         remotes = self._cache.registry.load_remotes()
+        self.python_requires.enable_remotes(remotes=remotes)
         # FIXME: conan copy does not support short-paths in Windows
         ref = ConanFileReference.loads(reference)
         cmd_copy(ref, user_channel, packages, self._cache,
@@ -1134,6 +1137,8 @@ class ConanAPIV1(object):
 
     @api_method
     def editable_add(self, path, reference, layout, cwd):
+        remotes = self._cache.registry.load_remotes()
+        self.python_requires.enable_remotes(remotes=remotes)
         # Retrieve conanfile.py from target_path
         target_path = _get_conanfile_path(path=path, cwd=cwd, py=True)
 


### PR DESCRIPTION
Changelog: Bugfix: Avoid crash of commands copy, imports, editable-add for packages using python_requires
Docs: omit

Close #https://github.com/conan-io/conan/issues/5140
