### PR TITLE
bump security requirements

### DIFF
--- a/conans/requirements_osx.txt
+++ b/conans/requirements_osx.txt
@@ -1,3 +1,3 @@
 idna==2.6 # Solving conflict, somehow is installing 2.7 when requests require 2.6
-cryptography>=1.3.4, <2.4.0
-pyOpenSSL>=16.0.0, <19.0.0
+cryptography>=1.3.4, <2.7.0
+pyOpenSSL>=16.0.0, <20.0.0


### PR DESCRIPTION
Changelog: Bumped versions of security deps for OSX.
Docs: omit

@PYVERS: Macos@py27