### PR TITLE
Update conan_requester.py

### DIFF
--- a/conans/client/conf/__init__.py
+++ b/conans/client/conf/__init__.py
@@ -416,21 +416,10 @@ class ConanClientConfigParser(ConfigParser, object):
         try:
             proxies = self.get_conf("proxies")
             # If there is proxies section, but empty, it will try to use system proxy
-            if not proxies:
-                # We don't have evidences that this following line is necessary.
-                # If the proxies has been
-                # configured at system level, conan will use it, and shouldn't be necessary
-                # to return here the proxies read from the system.
-                # Furthermore, the urls excluded for use proxies at system level do not work in
-                # this case, then the only way is to remove the [proxies] section with
-                # conan config remote proxies, then this method will return None and the proxies
-                # dict passed to requests will be empty.
-                # We don't remove this line because we are afraid to break something, but maybe
-                # until now is working because no one is using system-wide proxies or those proxies
-                # rules don't contain excluded urls.c #1777
-                return urllib.request.getproxies()
-            result = {k: (None if v == "None" else v) for k, v in proxies}
-            return result
+            if proxies:
+                result = {k: (None if v == "None" else v) for k, v in proxies}
+                return result
+            return None
         except:
             return None
 

--- a/conans/client/conf/__init__.py
+++ b/conans/client/conf/__init__.py
@@ -417,9 +417,8 @@ class ConanClientConfigParser(ConfigParser, object):
             proxies = self.get_conf("proxies")
             # If there is proxies section, but empty, it will try to use system proxy
             if proxies:
-                result = {k: (None if v == "None" else v) for k, v in proxies}
-                return result
-            return None
+                return {k: (None if v == "None" else v) for k, v in proxies}
+            return {}
         except:
             return None
 

--- a/conans/client/rest/conan_requester.py
+++ b/conans/client/rest/conan_requester.py
@@ -87,8 +87,8 @@ class ConanRequester(object):
             old_env = dict(os.environ)
             # Clean the proxies from the environ and use the conan specified proxies
             for var_name in ("http_proxy", "https_proxy", "no_proxy"):
-                popped = popped or os.environ.pop(var_name, None)
-                popped = popped or os.environ.pop(var_name.upper(), None)
+                popped = True if os.environ.pop(var_name, None) else popped
+                popped = True if os.environ.pop(var_name.upper(), None) else popped
         try:
             t1 = time.time()
             all_kwargs = self._add_kwargs(url, kwargs)


### PR DESCRIPTION
Hi, I have a problem where proxy settings are _not_ being taken from the environment (so I have to manually specify them in conan.config). In searching for the solution to that problem I noticed that this code might not work as intended. When the popped variable is True the right part of the "or" will not be executed ... and thus not all proxy settings would be cleared (only the first encountered is removed).

Just as an example to check my thinking:
```
>>> False or print("hi")
hi
>>> True or print("hi")
True  <=== the right part of the or did not execute.
```

Do I understand it right? Thanks.

Changelog: Bugfix: Make sure that proxy "http_proxy", "https_proxy", "no_proxy" vars are correctly removed if custom ones are defined in the conan.conf. Also, avoid using ``urllib.request.getproxies()``, they are broken.
Docs: omit

