### PR TITLE
[refactor] Simplify the graph a little bit (preparing for the crossbuilding)

### DIFF
--- a/conans/client/graph/graph.py
+++ b/conans/client/graph/graph.py
@@ -76,13 +76,6 @@ class Node(object):
         # The dependencies that will be part of deps_cpp_info, can't conflict
         self._public_closure = None  # {ref.name: Node}
         self.inverse_closure = set()  # set of nodes that have this one in their public
-        self.ancestors = None  # set{ref.name}
-
-    def update_ancestors(self, ancestors):
-        # When a diamond is closed, it is necessary to update all upstream ancestors, recursively
-        self.ancestors.update(ancestors)
-        for n in self.neighbors():
-            n.update_ancestors(ancestors)
 
     @property
     def public_deps(self):

--- a/conans/client/graph/graph.py
+++ b/conans/client/graph/graph.py
@@ -130,8 +130,11 @@ class Node(object):
         if edge.src == self:
             if edge not in self.dependencies:
                 self.dependencies.append(edge)
+                self.public_closure.add(edge.dst)
+                self.public_deps.add(edge.dst)
         else:
             self.dependants.add(edge)
+            self.inverse_closure.add(edge.src)
 
     def neighbors(self):
         return [edge.dst for edge in self.dependencies]

--- a/conans/client/graph/graph.py
+++ b/conans/client/graph/graph.py
@@ -23,20 +23,21 @@ BINARY_EDITABLE = "Editable"
 
 
 class _NodeOrderedDict(object):
-    def __init__(self):
+    def __init__(self, key=lambda n: n.name):
         self._nodes = OrderedDict()
+        self._key = key
 
     def add(self, node):
-        assert isinstance(node, Node), "Not a node: ({}) {}".format(type(node), node)
-        inserted = node.name not in self._nodes
-        self._nodes[node.name] = node
+        key = self._key(node)
+        inserted = key not in self._nodes
+        self._nodes[key] = node
         return inserted
 
-    def get(self, name):
-        return self._nodes.get(name)
+    def get(self, key):
+        return self._nodes.get(key)
 
-    def pop(self, name):
-        return self._nodes.pop(name)
+    def pop(self, key):
+        return self._nodes.pop(key)
 
     def sort(self, key_fn):
         """ It will sort the nodes according to the value returned from key_fn """
@@ -49,7 +50,6 @@ class _NodeOrderedDict(object):
         return ret
 
     def prepend(self, other):
-        assert isinstance(other, _NodeOrderedDict), "Can assign only from same type"
         items = other._nodes.copy()
         items.update(self._nodes)
         self._nodes = items

--- a/conans/client/graph/graph_binaries.py
+++ b/conans/client/graph/graph_binaries.py
@@ -205,7 +205,7 @@ class GraphBinariesAnalyzer(object):
                 if not neigh.private:
                     continue
                 # Current closure contains own node to be skipped
-                for n in neigh.public_closure.values():
+                for n in neigh.public_closure:
                     if n.private:
                         n.binary = BINARY_SKIP
                         self._handle_private(n)

--- a/conans/client/graph/graph_builder.py
+++ b/conans/client/graph/graph_builder.py
@@ -133,20 +133,14 @@ class DepsGraphBuilder(object):
         if not previous or ((require.build_require or require.private) and not previous_closure):
             # new node, must be added and expanded
             # node -> new_node
-            new_node = self._create_new_node(node, dep_graph, require,
-                                             check_updates, update, remotes,
-                                             processed_profile)
-
-            # The closure of a new node starts with just itself
-            node.public_closure.add(new_node)
-            new_node.inverse_closure.add(node)
-            node.public_deps.add(new_node)
+            new_node = self._create_new_node(node, dep_graph, require, check_updates, update,
+                                             remotes, processed_profile)
 
             # If the parent node is a build-require, this new node will be a build-require
             # If the requirement is a build-require, this node will also be a build-require
-            new_node.build_require = node.build_require or require.build_require
+            new_node.build_require = node.build_require or require.build_require  # TODO: needed?
             # New nodes will inherit the private property of its ancestor
-            new_node.private = node.private or require.private
+            new_node.private = node.private or require.private  # TODO: needed?
             if require.private or require.build_require:
                 # If the requirement is private (or build_require), a new public scope is defined
                 new_node.public_deps.prepend(node.public_closure)
@@ -184,9 +178,6 @@ class DepsGraphBuilder(object):
             if previous.private and not require.private:
                 previous.make_public()
 
-            node.public_closure.add(previous)
-            previous.inverse_closure.add(node)
-            node.public_deps.add(previous)
             dep_graph.add_edge(node, previous, require.private, require.build_require)
             # Update the closure of each dependent
             for n in previous.public_closure:

--- a/conans/client/graph/graph_builder.py
+++ b/conans/client/graph/graph_builder.py
@@ -143,9 +143,9 @@ class DepsGraphBuilder(object):
             new_node.private = node.private or require.private  # TODO: needed?
             if require.private or require.build_require:
                 # If the requirement is private (or build_require), a new public scope is defined
-                new_node.public_deps.prepend(node.public_closure)
+                new_node.public_deps.prepend(node.public_closure)  # TODO: ??
             else:
-                new_node.public_deps.prepend(node.public_deps)
+                new_node.public_deps.prepend(node.public_deps)  # TODO: ??
 
                 # Update the closure of each dependent
                 for dep_node in node.inverse_closure:

--- a/conans/client/graph/graph_builder.py
+++ b/conans/client/graph/graph_builder.py
@@ -317,9 +317,6 @@ class DepsGraphBuilder(object):
 
         dep_conanfile = self._loader.load_conanfile(conanfile_path, processed_profile,
                                                     ref=requirement.ref)
-        if recipe_status == RECIPE_EDITABLE:
-            dep_conanfile.in_local_cache = False
-            dep_conanfile.develop = True
 
         if getattr(dep_conanfile, "alias", None):
             alias_ref = alias_ref or new_ref.copy_clear_rev()
@@ -329,6 +326,10 @@ class DepsGraphBuilder(object):
                                          check_updates, update,
                                          remotes, processed_profile,
                                          alias_ref=alias_ref)
+
+        if recipe_status == RECIPE_EDITABLE:
+            dep_conanfile.in_local_cache = False
+            dep_conanfile.develop = True
 
         logger.debug("GRAPH: new_node: %s" % str(new_ref))
         new_node = Node(new_ref, dep_conanfile)

--- a/conans/client/graph/graph_builder.py
+++ b/conans/client/graph/graph_builder.py
@@ -27,8 +27,6 @@ class DepsGraphBuilder(object):
         check_updates = check_updates or update
         dep_graph = DepsGraph()
         # compute the conanfile entry point for this dependency graph
-        root_node.public_closure = root_node
-        root_node.public_deps = root_node
         dep_graph.add_node(root_node)
 
         # enter recursive computation
@@ -140,7 +138,6 @@ class DepsGraphBuilder(object):
                                              processed_profile)
 
             # The closure of a new node starts with just itself
-            new_node.public_closure = new_node
             node.public_closure.add(new_node)
             new_node.inverse_closure.add(node)
             node.public_deps.add(new_node)
@@ -152,11 +149,9 @@ class DepsGraphBuilder(object):
             new_node.private = node.private or require.private
             if require.private or require.build_require:
                 # If the requirement is private (or build_require), a new public scope is defined
-                new_node.public_deps = node.public_closure.copy()
-                new_node.public_deps.add(new_node)
+                new_node.public_deps.prepend(node.public_closure)
             else:
-                new_node.public_deps = node.public_deps.copy()
-                new_node.public_deps.add(new_node)
+                new_node.public_deps.prepend(node.public_deps)
 
                 # Update the closure of each dependent
                 for dep_node in node.inverse_closure:

--- a/conans/client/graph/graph_builder.py
+++ b/conans/client/graph/graph_builder.py
@@ -27,9 +27,8 @@ class DepsGraphBuilder(object):
         check_updates = check_updates or update
         dep_graph = DepsGraph()
         # compute the conanfile entry point for this dependency graph
-        name = root_node.name
-        root_node.public_closure = OrderedDict([(name, root_node)])
-        root_node.public_deps = {name: root_node}
+        root_node.public_closure = root_node
+        root_node.public_deps = root_node
         root_node.ancestors = set()
         dep_graph.add_node(root_node)
 
@@ -52,8 +51,7 @@ class DepsGraphBuilder(object):
         new_options = node.conanfile.build_requires_options._reqs_options
         new_reqs = Requirements()
 
-        conanfile = node.conanfile
-        scope = conanfile.display_name
+        scope = node.conanfile.display_name
         requires = [Requirement(ref) for ref in build_requires_refs]
         self._resolve_ranges(graph, requires, scope, update, remotes)
 
@@ -65,9 +63,7 @@ class DepsGraphBuilder(object):
 
         new_nodes = set([n for n in graph.nodes if n.package_id is None])
         # This is to make sure that build_requires have precedence over the normal requires
-        ordered_closure = list(node.public_closure.items())
-        ordered_closure.sort(key=lambda x: x[1] not in new_nodes)
-        node.public_closure = OrderedDict(ordered_closure)
+        node.public_closure.sort(key_fn=lambda x: x not in new_nodes)
 
         subgraph = DepsGraph()
         subgraph.aliased = graph.aliased
@@ -145,10 +141,10 @@ class DepsGraphBuilder(object):
                                              processed_profile)
 
             # The closure of a new node starts with just itself
-            new_node.public_closure = OrderedDict([(new_node.ref.name, new_node)])
-            node.public_closure[name] = new_node
+            new_node.public_closure = new_node
+            node.public_closure.add(new_node)
             new_node.inverse_closure.add(node)
-            node.public_deps[new_node.name] = new_node
+            node.public_deps.add(new_node)
 
             # If the parent node is a build-require, this new node will be a build-require
             # If the requirement is a build-require, this node will also be a build-require
@@ -158,16 +154,16 @@ class DepsGraphBuilder(object):
             if require.private or require.build_require:
                 # If the requirement is private (or build_require), a new public scope is defined
                 new_node.public_deps = node.public_closure.copy()
-                new_node.public_deps[name] = new_node
+                new_node.public_deps.add(new_node)
             else:
                 new_node.public_deps = node.public_deps.copy()
-                new_node.public_deps[name] = new_node
+                new_node.public_deps.add(new_node)
 
                 # Update the closure of each dependent
                 for dep_node in node.inverse_closure:
-                    dep_node.public_closure[new_node.name] = new_node
+                    dep_node.public_closure.add(new_node)
                     new_node.inverse_closure.add(dep_node)
-                    dep_node.public_deps[new_node.name] = new_node
+                    dep_node.public_deps.add(new_node)
 
             # RECURSION!
             self._load_deps(dep_graph, new_node, new_reqs, node.ref,
@@ -195,19 +191,19 @@ class DepsGraphBuilder(object):
             if previous.private and not require.private:
                 previous.make_public()
 
-            node.public_closure[name] = previous
+            node.public_closure.add(previous)
             previous.inverse_closure.add(node)
-            node.public_deps[name] = previous
+            node.public_deps.add(previous)
             dep_graph.add_edge(node, previous, require.private, require.build_require)
             # Update the closure of each dependent
-            for name, n in previous.public_closure.items():
+            for n in previous.public_closure:
                 if n.build_require or n.private:
                     continue
-                node.public_closure[name] = n
+                node.public_closure.add(n)
                 n.inverse_closure.add(node)
                 for dep_node in node.inverse_closure:
-                    dep_node.public_closure[name] = n
-                    dep_node.public_deps[name] = n
+                    dep_node.public_closure.add(n)
+                    dep_node.public_deps.add(n)
                     n.inverse_closure.add(dep_node)
 
             # RECURSION!

--- a/conans/client/graph/graph_manager.py
+++ b/conans/client/graph/graph_manager.py
@@ -244,12 +244,8 @@ class GraphManager(object):
         # Sort of closures, for linking order
         inverse_levels = {n: i for i, level in enumerate(graph.inverse_levels()) for n in level}
         for node in graph.nodes:
-            closure = node.public_closure
-            closure.pop(node.name)
-            node_order = list(closure.values())
-            # List sort is stable, will keep the original order of the closure, but prioritize levels
-            node_order.sort(key=lambda n: inverse_levels[n])
-            node.public_closure = node_order
+            node.public_closure.pop(node.name)
+            node.public_closure.sort(key_fn=lambda n: inverse_levels[n])
 
         return graph
 

--- a/conans/test/functional/graph/graph_manager_base.py
+++ b/conans/test/functional/graph/graph_manager_base.py
@@ -93,7 +93,7 @@ class GraphManagerTest(unittest.TestCase):
             self.assertEqual(conanfile.requires[dep.name].ref,
                              dep.ref)
 
-        self.assertEqual(closure, node.public_closure)
+        self.assertListEqual(closure, list(node.public_closure))
         libs = []
         envs = []
         for n in closure:

--- a/conans/test/functional/graph/graph_manager_test.py
+++ b/conans/test/functional/graph/graph_manager_test.py
@@ -36,14 +36,14 @@ class TransitiveGraphTest(GraphManagerTest):
         self.assertEqual(libb.conanfile.name, "libb")
         self.assertEqual(len(libb.dependencies), 0)
         self.assertEqual(len(libb.dependants), 1)
-        self.assertEqual(libb.inverse_neighbors(), [app])
+        self.assertListEqual(libb.inverse_neighbors(), [app])
         self.assertEqual(libb.ancestors, set([app.ref.name]))
         self.assertEqual(libb.recipe, RECIPE_INCACHE)
 
-        self.assertEqual(app.public_closure, [libb])
-        self.assertEqual(libb.public_closure, [])
-        self.assertEqual(app.public_deps, {"app": app, "libb": libb})
-        self.assertEqual(libb.public_deps, app.public_deps)
+        self.assertListEqual(list(app.public_closure), [libb])
+        self.assertListEqual(list(libb.public_closure), [])
+        self.assertListEqual(list(app.public_deps), [app, libb])
+        self.assertListEqual(list(libb.public_deps), list(app.public_deps))
 
     def test_transitive_two_levels(self):
         # app -> libb0.1 -> liba0.1

--- a/conans/test/functional/graph/graph_manager_test.py
+++ b/conans/test/functional/graph/graph_manager_test.py
@@ -37,7 +37,6 @@ class TransitiveGraphTest(GraphManagerTest):
         self.assertEqual(len(libb.dependencies), 0)
         self.assertEqual(len(libb.dependants), 1)
         self.assertListEqual(libb.inverse_neighbors(), [app])
-        self.assertEqual(libb.ancestors, set([app.ref.name]))
         self.assertEqual(libb.recipe, RECIPE_INCACHE)
 
         self.assertListEqual(list(app.public_closure), [libb])


### PR DESCRIPTION
Changelog: omit
Docs: omit

Refactor around the graph:
 * Create a class `_NodeOrderedDict` to centralize some common operations around `public_closure` and `public_deps` and **to prepare for the cross building model: the key will be the name+context and with this change it is only needed to change the `key` function provided in the constructor**.
 * Populate variables from nodes:
   - each time a `Node` is created, add itself to its own public closure/deps
   - when an `Edge` is created, populate the member variables of the connected nodes

There are some comments I need to think about.