### PR TITLE
Raise invalid configuration when restricted

### DIFF
--- a/conans/client/loader.py
+++ b/conans/client/loader.py
@@ -7,7 +7,7 @@ import uuid
 from conans.client.generators import registered_generators
 from conans.client.loader_txt import ConanFileTextLoader
 from conans.client.tools.files import chdir
-from conans.errors import ConanException, NotFoundException
+from conans.errors import ConanException, NotFoundException, ConanInvalidConfiguration
 from conans.model.conan_file import ConanFile
 from conans.model.conan_generator import Generator
 from conans.model.options import OptionsValues
@@ -136,6 +136,8 @@ class ConanFileLoader(object):
         try:
             self._initialize_conanfile(conanfile, processed_profile)
             return conanfile
+        except ConanInvalidConfiguration:
+            raise
         except Exception as e:  # re-raise with file name
             raise ConanException("%s: %s" % (conanfile_path, str(e)))
 

--- a/conans/model/conan_file.py
+++ b/conans/model/conan_file.py
@@ -5,7 +5,7 @@ from conans.client import tools
 from conans.client.output import Color, ScopedOutput
 from conans.client.tools.env import environment_append, no_op, pythonpath
 from conans.client.tools.oss import OSInfo
-from conans.errors import ConanException
+from conans.errors import ConanException, ConanInvalidConfiguration
 from conans.model.build_info import DepsCppInfo
 from conans.model.env_info import DepsEnvInfo
 from conans.model.options import Options, OptionsValues, PackageOptions
@@ -59,7 +59,7 @@ def create_settings(conanfile, settings):
         settings.constraint(current)
         return settings
     except Exception as e:
-        raise ConanException("Error while initializing settings. %s" % str(e))
+        raise ConanInvalidConfiguration("Error while initializing settings. %s" % str(e))
 
 
 @contextmanager

--- a/conans/test/functional/command/invalid_configuration_test.py
+++ b/conans/test/functional/command/invalid_configuration_test.py
@@ -59,3 +59,16 @@ class MyPkg(ConanFile):
         self.assertEqual(error, ERROR_INVALID_CONFIGURATION)
         self.assertIn("name/ver@jgsogo/test: Invalid configuration: user says that "
                       "compiler.version=12 is invalid", self.client.out)
+
+    def restricted_settings_raise_invalid_code_too_test(self):
+        self.client.save({"conanfile.py": """
+from conans import ConanFile
+from conans.errors import ConanInvalidConfiguration
+
+class MyPkg(ConanFile):
+    requires = "name/ver@jgsogo/test"
+    settings = {"arch": ["x86_64"]}
+"""})
+
+        error = self.client.run("create . lib/1.0@user/channel -s arch=x86", assert_error=True)
+        self.assertEqual(error, ERROR_INVALID_CONFIGURATION)


### PR DESCRIPTION
Changelog: Bugfix: Conan command returns 6 (Invalid configuration) also when the settings are restricted in the recipe
Docs: PENDING

Closes #5163