### PR TITLE
Introduce helper class to store Node objects

### DIFF
--- a/conans/client/graph/graph_binaries.py
+++ b/conans/client/graph/graph_binaries.py
@@ -205,7 +205,7 @@ class GraphBinariesAnalyzer(object):
                 if not neigh.private:
                     continue
                 # Current closure contains own node to be skipped
-                for n in neigh.public_closure.values():
+                for n in neigh.public_closure:
                     if n.private:
                         n.binary = BINARY_SKIP
                         self._handle_private(n)

--- a/conans/client/graph/graph_manager.py
+++ b/conans/client/graph/graph_manager.py
@@ -244,12 +244,8 @@ class GraphManager(object):
         # Sort of closures, for linking order
         inverse_levels = {n: i for i, level in enumerate(graph.inverse_levels()) for n in level}
         for node in graph.nodes:
-            closure = node.public_closure
-            closure.pop(node.name)
-            node_order = list(closure.values())
-            # List sort is stable, will keep the original order of the closure, but prioritize levels
-            node_order.sort(key=lambda n: inverse_levels[n])
-            node.public_closure = node_order
+            node.public_closure.pop(node.name)
+            node.public_closure.sort(key_fn=lambda n: inverse_levels[n])
 
         return graph
 

--- a/conans/test/functional/graph/graph_manager_base.py
+++ b/conans/test/functional/graph/graph_manager_base.py
@@ -93,7 +93,7 @@ class GraphManagerTest(unittest.TestCase):
             self.assertEqual(conanfile.requires[dep.name].ref,
                              dep.ref)
 
-        self.assertEqual(closure, node.public_closure)
+        self.assertListEqual(closure, list(node.public_closure))
         libs = []
         envs = []
         for n in closure:

--- a/conans/test/functional/graph/graph_manager_test.py
+++ b/conans/test/functional/graph/graph_manager_test.py
@@ -36,14 +36,14 @@ class TransitiveGraphTest(GraphManagerTest):
         self.assertEqual(libb.conanfile.name, "libb")
         self.assertEqual(len(libb.dependencies), 0)
         self.assertEqual(len(libb.dependants), 1)
-        self.assertEqual(libb.inverse_neighbors(), [app])
+        self.assertListEqual(libb.inverse_neighbors(), [app])
         self.assertEqual(libb.ancestors, set([app.ref.name]))
         self.assertEqual(libb.recipe, RECIPE_INCACHE)
 
-        self.assertEqual(app.public_closure, [libb])
-        self.assertEqual(libb.public_closure, [])
-        self.assertEqual(app.public_deps, {"app": app, "libb": libb})
-        self.assertEqual(libb.public_deps, app.public_deps)
+        self.assertListEqual(list(app.public_closure), [libb])
+        self.assertListEqual(list(libb.public_closure), [])
+        self.assertListEqual(list(app.public_deps), [app, libb])
+        self.assertListEqual(list(libb.public_deps), list(app.public_deps))
 
     def test_transitive_two_levels(self):
         # app -> libb0.1 -> liba0.1


### PR DESCRIPTION
Changelog: omit
Docs: omit

This PR introduces a helper class `_NodeOrderedDict` to store the nodes of the graph using a custom key for uniqueness. Right now, the key is just the name (`key=lambda n: n.name`), for the crossbuilding it should be `name + build_context` so the same node can appear several times in the graph for different contexts (host -vs- build). This way, there shouldn't be changes in the graph building logic to introduce the crossbuilding.
