### PR TITLE
conan download always fetch sources

### DIFF
--- a/conans/client/cmd/download.py
+++ b/conans/client/cmd/download.py
@@ -18,10 +18,10 @@ def download(ref, package_ids, remote, recipe, remote_manager,
     conan_file_path = cache.package_layout(ref).conanfile()
     conanfile = loader.load_class(conan_file_path)
 
-    if not recipe:  # Not only the recipe
-        # Download the sources too, don't be lazy
-        complete_recipe_sources(remote_manager, cache, conanfile, ref, remotes)
+    # Download the sources too, don't be lazy
+    complete_recipe_sources(remote_manager, cache, conanfile, ref, remotes)
 
+    if not recipe:  # Not only the recipe
         if not package_ids:  # User didn't specify a specific package binary
             output.info("Getting the complete package list from '%s'..." % ref.full_repr())
             packages_props = remote_manager.search_packages(remote, ref, None)

--- a/conans/test/functional/command/download_test.py
+++ b/conans/test/functional/command/download_test.py
@@ -40,13 +40,13 @@ class Pkg(ConanFile):
         client.run("download pkg/0.1@lasote/stable --recipe")
 
         self.assertIn("Downloading conanfile.py", client.out)
-        self.assertNotIn("Downloading conan_sources.tgz", client.out)
+        self.assertIn("Downloading conan_sources.tgz", client.out)
         self.assertNotIn("Downloading conan_package.tgz", client.out)
         export = client.cache.package_layout(ref).export()
         self.assertTrue(os.path.exists(os.path.join(export, "conanfile.py")))
         self.assertEqual(conanfile, load(os.path.join(export, "conanfile.py")))
         source = client.cache.package_layout(ref).export_sources()
-        self.assertFalse(os.path.exists(os.path.join(source, "file.h")))
+        self.assertTrue(os.path.exists(os.path.join(source, "file.h")))
         conan = client.cache.package_layout(ref).base_folder()
         self.assertFalse(os.path.exists(os.path.join(conan, "package")))
 


### PR DESCRIPTION
Changelog: Bugfix: ``conan download`` always retrieve the sources, also with ``--recipe`` argument, which should only skip download binaries, not the sources.
Docs: omit

Close #5193
