### PR TITLE
Fix: conditionally disable tests which require programs (golang, pkg-cofig)

### DIFF
--- a/conans/test/integration/go_complete_test.py
+++ b/conans/test/integration/go_complete_test.py
@@ -8,6 +8,7 @@ from conans.model.ref import ConanFileReference, PackageReference
 from conans.test.utils.test_files import scan_folder, uncompress_packaged_files
 from conans.test.utils.tools import TestClient, TestServer
 from conans.client.tools.env import environment_append
+from conans.client.tools.oss import which
 
 stringutil_conanfile = '''
 from conans import ConanFile
@@ -79,6 +80,7 @@ func main() {
 
 
 @attr('golang')
+@unittest.skipUnless(which("golang"), "requires golang")
 class GoCompleteTest(unittest.TestCase):
 
     def setUp(self):

--- a/conans/test/integration/go_diamond_test.py
+++ b/conans/test/integration/go_diamond_test.py
@@ -8,9 +8,11 @@ from conans.model.ref import ConanFileReference
 from conans.test.utils.test_files import hello_conan_files
 from conans.test.utils.tools import TestClient, TestServer
 from conans.client.tools.env import environment_append
+from conans.client.tools.oss import which
 
 
 @attr('golang')
+@unittest.skipUnless(which("golang"), "requires golang")
 class GoDiamondTest(unittest.TestCase):
 
     def setUp(self):

--- a/conans/test/integration/pkg_config_test.py
+++ b/conans/test/integration/pkg_config_test.py
@@ -1,7 +1,7 @@
-import platform
 import subprocess
 import unittest
 
+from conans.client.tools.oss import which
 from conans.test.utils.tools import TestClient
 
 hello_cpp = """
@@ -27,7 +27,7 @@ int main() {
 """
 
 
-
+@unittest.skipUnless(which("pkg-config") and which("g++"), "requires pkg-config and g++")
 class PkgConfigTest(unittest.TestCase):
 
     def test_reuse_pc_approach1(self):
@@ -92,9 +92,6 @@ class LibAConan(ConanFile):
            self.run('g++ main.cpp $(pkg-config libB --libs --cflags) -o main')
 
 """
-
-        if platform.system() == "Windows":
-            return
 
         self._run_reuse(libb_conanfile, liba_conanfile)
 
@@ -161,9 +158,6 @@ class LibAConan(ConanFile):
            self.run('g++ main.cpp $(pkg-config %s libB --libs --cflags) -o main' % args)
 
 """
-
-        if platform.system() == "Windows":
-            return
 
         self._run_reuse(libb_conanfile, liba_conanfile)
 

--- a/conans/test/unittests/util/pkg_config_test.py
+++ b/conans/test/unittests/util/pkg_config_test.py
@@ -2,12 +2,12 @@
 # -*- coding: utf-8 -*-
 
 import os
-import platform
 import unittest
 
 from nose.plugins.attrib import attr
 
 from conans.client.tools.env import environment_append
+from conans.client.tools.oss import which
 from conans.client.tools.pkg_config import PkgConfig
 from conans.errors import ConanException
 from conans.test.utils.test_files import temp_folder
@@ -29,17 +29,14 @@ Cflags: -I${includedir}/libastral -D_USE_LIBASTRAL
 
 
 @attr("unix")
+@unittest.skipUnless(which("pkg-config"), "requires pkg-config")
 class PkgConfigTest(unittest.TestCase):
     def test_negative(self):
-        if platform.system() == "Windows":
-            return
         pc = PkgConfig('libsomething_that_does_not_exist_in_the_world')
         with self.assertRaises(ConanException):
             pc.libs()
 
     def test_pc(self):
-        if platform.system() == "Windows":
-            return
         tmp_dir = temp_folder()
         filename = os.path.join(tmp_dir, 'libastral.pc')
         with open(filename, 'w') as f:
@@ -60,8 +57,6 @@ class PkgConfigTest(unittest.TestCase):
         os.unlink(filename)
 
     def test_define_prefix(self):
-        if platform.system() == "Windows":
-            return
         tmp_dir = temp_folder()
         filename = os.path.join(tmp_dir, 'libastral.pc')
         with open(filename, 'w') as f:
@@ -84,8 +79,6 @@ class PkgConfigTest(unittest.TestCase):
         os.unlink(filename)
 
     def rpaths_libs_test(self):
-        if platform.system() == "Windows":
-            return
         pc_content = """prefix=/my_prefix/path
 libdir=/my_absoulte_path/fake/mylib/lib
 libdir3=${prefix}/lib2


### PR DESCRIPTION
Changelog: omit
Docs: omit

- [ ] Refer to the issue that supports this Pull Request.
- [ ] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [ ] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [ ] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 

<sup>**Note:** By default this PR will skip the slower tests and will use a limited set of python versions. Check [here](https://github.com/conan-io/conan/blob/develop/.github/PR_INCREASE_TESTING.md) how to increase the testing level by writing some tags in the current PR body text.</sup>
