### PR TITLE
Bugfix: do not append "-T <toolset>" if generator doesn't support it

### DIFF
--- a/conans/client/build/cmake.py
+++ b/conans/client/build/cmake.py
@@ -9,7 +9,8 @@ from conans.client import defs_to_string, join_arguments, tools
 from conans.client.build.cmake_flags import CMakeDefinitionsBuilder, \
     get_generator, is_multi_configuration, verbose_definition, verbose_definition_name, \
     cmake_install_prefix_var_name, get_toolset, build_type_definition, \
-    cmake_in_local_cache_var_name, runtime_definition_var_name, get_generator_platform
+    cmake_in_local_cache_var_name, runtime_definition_var_name, get_generator_platform, \
+    is_generator_platform_supported, is_toolset_supported
 from conans.client.output import ConanOutput
 from conans.client.tools.oss import cpu_count, args_to_string
 from conans.errors import ConanException
@@ -118,12 +119,22 @@ class CMake(object):
     def command_line(self):
         args = ['-G "%s"' % self.generator] if self.generator else []
         if self.generator_platform:
-            args.append('-A "%s"' % self.generator_platform)
+            if is_generator_platform_supported(self.generator):
+                args.append('-A "%s"' % self.generator_platform)
+            else:
+                raise ConanException('CMake does not support generator platform with generator "%s:.'
+                                     'Please check your conan profile to either remove the generator platform,'
+                                     ' or change the CMake generator.' % self.generator)
         args.append(self.flags)
         args.append('-Wno-dev')
 
         if self.toolset:
-            args.append('-T "%s"' % self.toolset)
+            if is_toolset_supported(self.generator):
+                args.append('-T "%s"' % self.toolset)
+            else:
+                raise ConanException('CMake does not support toolsets with generator "%s:.'
+                                     'Please check your conan profile to either remove the toolset,'
+                                     ' or change the CMake generator.' % self.generator)
         return join_arguments(args)
 
     @property

--- a/conans/client/build/cmake_flags.py
+++ b/conans/client/build/cmake_flags.py
@@ -93,6 +93,20 @@ def is_multi_configuration(generator):
     return "Visual" in generator or "Xcode" in generator
 
 
+def is_toolset_supported(generator):
+    # https://cmake.org/cmake/help/v3.14/variable/CMAKE_GENERATOR_TOOLSET.html
+    if not generator:
+        return False
+    return "Visual" in generator or "Xcode" in generator or "Green Hills MULTI" in generator
+
+
+def is_generator_platform_supported(generator):
+    # https://cmake.org/cmake/help/v3.14/variable/CMAKE_GENERATOR_PLATFORM.html
+    if not generator:
+        return False
+    return "Visual" in generator or "Green Hills MULTI" in generator
+
+
 def verbose_definition(value):
     return {verbose_definition_name: "ON" if value else "OFF"}
 

--- a/conans/test/unittests/client/build/cmake_test.py
+++ b/conans/test/unittests/client/build/cmake_test.py
@@ -193,10 +193,10 @@ class CMakeTest(unittest.TestCase):
         conan_file = ConanFileMock()
         conan_file.settings = Settings()
 
-        with tools.environment_append({"CONAN_CMAKE_GENERATOR": "My CMake Generator",
+        with tools.environment_append({"CONAN_CMAKE_GENERATOR": "Green Hills MULTI",
                                        "CONAN_CMAKE_GENERATOR_PLATFORM": "My CMake Platform"}):
             cmake = CMake(conan_file)
-            self.assertIn('-G "My CMake Generator" -A "My CMake Platform"', cmake.command_line)
+            self.assertIn('-G "Green Hills MULTI" -A "My CMake Platform"', cmake.command_line)
 
     def cmake_generator_platform_override_test(self):
         settings = Settings.loads(default_settings_yml)
@@ -287,6 +287,25 @@ class CMakeTest(unittest.TestCase):
                                        "CONAN_CMAKE_GENERATOR_PLATFORM": platform}):
             cmake = CMake(conan_file)
             self.assertIn('-G "Green Hills MULTI" -A "%s"' % platform, cmake.command_line)
+
+    @parameterized.expand([('Ninja',),
+                           ('NMake Makefiles',),
+                           ('NMake Makefiles JOM',)
+                           ])
+    def test_generator_platform_with_unsupported_generator(self, generator):
+        settings = Settings.loads(default_settings_yml)
+        settings.os = "Windows"
+        settings.compiler = "Visual Studio"
+        settings.compiler.version = "15"
+        settings.arch = "x86"
+        settings.compiler.toolset = "v140"
+
+        conan_file = ConanFileMock()
+        conan_file.settings = settings
+
+        with self.assertRaises(ConanException):
+            cmake = CMake(conan_file, generator=generator, generator_platform="x64")
+            cmake.command_line
 
     def cmake_fpic_test(self):
         settings = Settings.loads(default_settings_yml)
@@ -1147,6 +1166,25 @@ build_type: [ Release]
 
         cmake = CMake(conan_file)
         self.assertIn('-T "v140"', cmake.command_line)
+
+    @parameterized.expand([('Ninja',),
+                           ('NMake Makefiles',),
+                           ('NMake Makefiles JOM',)
+                           ])
+    def test_toolset_with_unsupported_generator(self, generator):
+        settings = Settings.loads(default_settings_yml)
+        settings.os = "Windows"
+        settings.compiler = "Visual Studio"
+        settings.compiler.version = "15"
+        settings.arch = "x86"
+        settings.compiler.toolset = "v140"
+
+        conan_file = ConanFileMock()
+        conan_file.settings = settings
+
+        with self.assertRaises(ConanException):
+            cmake = CMake(conan_file, generator=generator)
+            cmake.command_line
 
     def test_missing_settings(self):
         def instance_with_os_build(os_build):


### PR DESCRIPTION
closes: #5133 

Bugfix: do not append "-T <toolset>" if generator doesn't support it
Docs: omit

- [ ] Refer to the issue that supports this Pull Request.
- [ ] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [ ] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [ ] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 

<sup>**Note:** By default this PR will skip the slower tests and will use a limited set of python versions. Check [here](https://github.com/conan-io/conan/blob/develop/.github/PR_INCREASE_TESTING.md) how to increase the testing level by writing some tags in the current PR body text.</sup>
