### PR TITLE
Detect System package name by recipe settings (#5026)

### DIFF
--- a/conans/client/tools/system_pm.py
+++ b/conans/client/tools/system_pm.py
@@ -13,6 +13,7 @@ class SystemPackageTool(object):
 
     def __init__(self, runner=None, os_info=None, tool=None, recommends=False, output=None, conanfile=None):
 
+output = output if output else conanfile.output if conanfile else None
         self._output = default_output(output, 'conans.client.tools.system_pm.SystemPackageTool')
         os_info = os_info or OSInfo()
         self._is_up_to_date = False

--- a/conans/client/tools/system_pm.py
+++ b/conans/client/tools/system_pm.py
@@ -12,8 +12,7 @@ from conans.util.fallbacks import default_output
 class SystemPackageTool(object):
 
     def __init__(self, runner=None, os_info=None, tool=None, recommends=False, output=None, conanfile=None):
-
-output = output if output else conanfile.output if conanfile else None
+        output = output if output else conanfile.output if conanfile else None
         self._output = default_output(output, 'conans.client.tools.system_pm.SystemPackageTool')
         os_info = os_info or OSInfo()
         self._is_up_to_date = False

--- a/conans/client/tools/system_pm.py
+++ b/conans/client/tools/system_pm.py
@@ -122,9 +122,8 @@ class SystemPackageTool(object):
             arch = host_arch or build_arch
             parsed_packages = []
             for package in packages:
-                if isinstance(package, str):
-                    for package_name in package.split(" "):
-                        parsed_packages.append(self._tool._parse_package(package_name, arch, platforms))
+                for package_name in package.split(" "):
+                    parsed_packages.append(self._tool._parse_package(package_name, arch, platforms))
             return parsed_packages
         return packages
 
@@ -191,9 +190,6 @@ class AptTool(BaseTool):
     def installed(self, package_name):
         exit_code = self._runner("dpkg-query -W -f='${Status}' %s | grep -q \"ok installed\"" % package_name, None)
         return exit_code == 0
-
-    def _platforms(self):
-        return
 
     def _parse_package(self, package, arch, platforms):
         if platforms is None:

--- a/conans/client/tools/system_pm.py
+++ b/conans/client/tools/system_pm.py
@@ -11,7 +11,7 @@ from conans.util.fallbacks import default_output
 
 class SystemPackageTool(object):
 
-    def __init__(self, runner=None, os_info=None, tool=None, recommends=False, output=None, settings=None):
+    def __init__(self, runner=None, os_info=None, tool=None, recommends=False, output=None, conanfile=None):
 
         self._output = default_output(output, 'conans.client.tools.system_pm.SystemPackageTool')
         os_info = os_info or OSInfo()
@@ -20,7 +20,7 @@ class SystemPackageTool(object):
         self._tool._sudo_str = self._get_sudo_str()
         self._tool._runner = runner or ConanRunner(output=self._output)
         self._tool._recommends = recommends
-        self._settings = settings
+        self._conanfile = conanfile
 
     @staticmethod
     def _get_sudo_str():
@@ -128,8 +128,8 @@ class SystemPackageTool(object):
         :param arch_names: Package suffix/prefix name used by installer tool
         :return: list with all parsed names e.g. ["libusb-dev:armhf libfoobar-dev:armhf"]
         """
-        if self._settings and cross_building(self._settings):
-            _, build_arch, _, host_arch = get_cross_building_settings(self._settings)
+        if self._conanfile and self._conanfile.settings and cross_building(self._conanfile.settings):
+            _, build_arch, _, host_arch = get_cross_building_settings(self._conanfile.settings)
             arch = host_arch or build_arch
             parsed_packages = []
             for package in packages:

--- a/conans/test/unittests/client/tools/system_pm_test.py
+++ b/conans/test/unittests/client/tools/system_pm_test.py
@@ -14,6 +14,7 @@ from conans.client.tools.system_pm import ChocolateyTool, SystemPackageTool,\
 from conans.errors import ConanException
 from conans.test.unittests.util.tools_test import RunnerMock
 from conans.test.utils.tools import TestBufferConanOutput
+from conans.test.utils.conanfile import MockSettings
 
 
 class SystemPackageToolTest(unittest.TestCase):
@@ -166,6 +167,15 @@ class SystemPackageToolTest(unittest.TestCase):
             spt.install("a_package", force=True)
             self.assertEqual(runner.command_called, "sudo -A yum install -y a_package")
 
+            settings = MockSettings({"arch": "x86", "arch_build": "x86_64", "os": "Linux",
+                                     "os_build": "Linux"})
+            spt = SystemPackageTool(runner=runner, os_info=os_info, output=self.out,
+                                    settings=settings)
+            spt.install("a_package", force=False)
+            self.assertEqual(runner.command_called, "rpm -q a_package.i?86")
+            spt.install("a_package", force=True)
+            self.assertEqual(runner.command_called, "sudo -A yum install -y a_package.i?86")
+
             os_info.linux_distro = "debian"
             spt = SystemPackageTool(runner=runner, os_info=os_info, output=self.out)
             with self.assertRaises(ConanException):
@@ -234,6 +244,19 @@ class SystemPackageToolTest(unittest.TestCase):
 
             spt.update()
             self.assertEqual(runner.command_called, "apt-get update")
+
+            for arch, distro_arch in {"x86_64": "", "x86": ":i386", "ppc32": ":powerpc",
+                                      "ppc64le": ":ppc64el", "armv7": ":arm", "armv7hf": ":armhf",
+                                      "armv8": ":arm64", "s390x": ":s390x"}.items():
+                settings = MockSettings({"arch": arch,
+                                         "arch_build": "x86_64",
+                                         "os": "Linux",
+                                         "os_build": "Linux"})
+                spt = SystemPackageTool(runner=runner, os_info=os_info, output=self.out,
+                                        settings=settings)
+                spt.install("a_package", force=True)
+                self.assertEqual(runner.command_called,
+                            "apt-get install -y --no-install-recommends a_package%s" % distro_arch)
 
             os_info.is_macos = True
             os_info.is_linux = False

--- a/conans/test/unittests/client/tools/system_pm_test.py
+++ b/conans/test/unittests/client/tools/system_pm_test.py
@@ -265,7 +265,7 @@ class SystemPackageToolTest(unittest.TestCase):
                                          "os_build": "Linux"})
                 spt = SystemPackageTool(runner=runner, os_info=os_info, output=self.out,
                                         settings=settings)
-                spt.install("a_package", force=True, platforms={"x86": "all"})
+                spt.install("a_package", force=True, arch_names={"x86": "all"})
                 self.assertEqual(runner.command_called,
                             "apt-get install -y --no-install-recommends a_package%s" % distro_arch)
 

--- a/conans/test/unittests/client/tools/system_pm_test.py
+++ b/conans/test/unittests/client/tools/system_pm_test.py
@@ -14,7 +14,7 @@ from conans.client.tools.system_pm import ChocolateyTool, SystemPackageTool,\
 from conans.errors import ConanException
 from conans.test.unittests.util.tools_test import RunnerMock
 from conans.test.utils.tools import TestBufferConanOutput
-from conans.test.utils.conanfile import MockSettings
+from conans.test.utils.conanfile import MockSettings, MockConanfile
 
 
 class SystemPackageToolTest(unittest.TestCase):
@@ -169,8 +169,9 @@ class SystemPackageToolTest(unittest.TestCase):
 
             settings = MockSettings({"arch": "x86", "arch_build": "x86_64", "os": "Linux",
                                      "os_build": "Linux"})
+            conanfile = MockConanfile(settings)
             spt = SystemPackageTool(runner=runner, os_info=os_info, output=self.out,
-                                    settings=settings)
+                                    conanfile=conanfile)
             spt.install("a_package", force=False)
             self.assertEqual(runner.command_called, "rpm -q a_package.i?86")
             spt.install("a_package", force=True)
@@ -252,8 +253,9 @@ class SystemPackageToolTest(unittest.TestCase):
                                          "arch_build": "x86_64",
                                          "os": "Linux",
                                          "os_build": "Linux"})
+                conanfile = MockConanfile(settings)
                 spt = SystemPackageTool(runner=runner, os_info=os_info, output=self.out,
-                                        settings=settings)
+                                        conanfile=conanfile)
                 spt.install("a_package", force=True)
                 self.assertEqual(runner.command_called,
                             "apt-get install -y --no-install-recommends a_package%s" % distro_arch)
@@ -263,8 +265,9 @@ class SystemPackageToolTest(unittest.TestCase):
                                          "arch_build": "x86_64",
                                          "os": "Linux",
                                          "os_build": "Linux"})
+                conanfile = MockConanfile(settings)
                 spt = SystemPackageTool(runner=runner, os_info=os_info, output=self.out,
-                                        settings=settings)
+                                        conanfile=conanfile)
                 spt.install("a_package", force=True, arch_names={"x86": "all"})
                 self.assertEqual(runner.command_called,
                             "apt-get install -y --no-install-recommends a_package%s" % distro_arch)

--- a/conans/test/unittests/client/tools/system_pm_test.py
+++ b/conans/test/unittests/client/tools/system_pm_test.py
@@ -258,6 +258,17 @@ class SystemPackageToolTest(unittest.TestCase):
                 self.assertEqual(runner.command_called,
                             "apt-get install -y --no-install-recommends a_package%s" % distro_arch)
 
+            for arch, distro_arch in {"x86_64": "", "x86": ":all"}.items():
+                settings = MockSettings({"arch": arch,
+                                         "arch_build": "x86_64",
+                                         "os": "Linux",
+                                         "os_build": "Linux"})
+                spt = SystemPackageTool(runner=runner, os_info=os_info, output=self.out,
+                                        settings=settings)
+                spt.install("a_package", force=True, platforms={"x86": "all"})
+                self.assertEqual(runner.command_called,
+                            "apt-get install -y --no-install-recommends a_package%s" % distro_arch)
+
             os_info.is_macos = True
             os_info.is_linux = False
             os_info.is_windows = False


### PR DESCRIPTION
Changelog: Feature: SystemPackageTool platform detection (#5026)
Docs: https://github.com/conan-io/docs/pull/1291

closes #5026

- [x] Refer to the issue that supports this Pull Request.
- [ ] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [x] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 

<sup>**Note:** By default this PR will skip the slower tests and will use a limited set of python versions. Check [here](https://github.com/conan-io/conan/blob/develop/.github/PR_INCREASE_TESTING.md) how to increase the testing level by writing some tags in the current PR body text.</sup>
