### PR TITLE
Cmake::msbuild_verbosity can be avoided in the command line

### DIFF
--- a/conans/client/build/cmake.py
+++ b/conans/client/build/cmake.py
@@ -23,7 +23,7 @@ class CMake(object):
 
     def __init__(self, conanfile, generator=None, cmake_system_name=True,
                  parallel=True, build_type=None, toolset=None, make_program=None,
-                 set_cmake_flags=False, msbuild_verbosity=None, cmake_program=None,
+                 set_cmake_flags=False, msbuild_verbosity="minimal", cmake_program=None,
                  generator_platform=None):
         """
         :param conanfile: Conanfile instance
@@ -69,8 +69,7 @@ class CMake(object):
         self.definitions = builder.get_definitions()
         self.toolset = toolset or get_toolset(self._settings)
         self.build_dir = None
-        self.msbuild_verbosity = (os.getenv("CONAN_MSBUILD_VERBOSITY") or msbuild_verbosity or
-                                  "minimal")
+        self.msbuild_verbosity = os.getenv("CONAN_MSBUILD_VERBOSITY") or msbuild_verbosity
 
     @property
     def build_folder(self):

--- a/conans/test/unittests/client/build/cmake_test.py
+++ b/conans/test/unittests/client/build/cmake_test.py
@@ -1333,6 +1333,10 @@ build_type: [ Release]
         cmake.build()
         self.assertIn("/verbosity:quiet", conan_file.command)
 
+        cmake = CMake(conan_file, msbuild_verbosity=None)
+        cmake.build()
+        self.assertNotIn("/verbosity", conan_file.command)
+
         with tools.environment_append({"CONAN_MSBUILD_VERBOSITY": "detailed"}):
             cmake = CMake(conan_file)
             cmake.build()


### PR DESCRIPTION
Changelog: Fix: Add the ability to avoid the `/verbosity` argument in CMake command line for MSBuild
Docs: https://github.com/conan-io/docs/pull/1292

closes #5216 

The user can avoid the `/verbosity` argument by using `msbuild_verbosity=None` in the `CMake` constructor. Previously this value was setting `/verbosity:minimal`.

----
⚠️  This PR only _breaks_ the use case where the recipe is creating `CMake` helper with an explicit `None` value for the MSBuild verbosity: `CMake(... msbuild_verbosity=None)`
 * before, it will translate to the argument `/verbosity:minimal`.
 * now it will remove the argument `/verbosity`

