### PR TITLE
Use dateutil for managing ISO8601

### DIFF
--- a/conans/requirements.txt
+++ b/conans/requirements.txt
@@ -14,3 +14,4 @@ astroid>=1.6.5
 deprecation>=2.0, <2.1
 tqdm>=4.28.1, <5
 Jinja2>=2.3, <3
+python-dateutil>=2.6.0, <3

--- a/conans/server/revision_list.py
+++ b/conans/server/revision_list.py
@@ -2,7 +2,7 @@ import json
 import time
 from collections import namedtuple
 
-from conans.util.dates import from_timestamp_to_iso8601, valid_iso8601
+from conans.util.dates import from_timestamp_to_iso8601
 
 _RevisionEntry = namedtuple("RevisionEntry", "revision time")
 

--- a/conans/test/unittests/client/util/time_test.py
+++ b/conans/test/unittests/client/util/time_test.py
@@ -1,7 +1,9 @@
 import datetime
 import unittest
 
-from conans.util.dates import from_timestamp_to_iso8601, from_iso8601_to_datetime, valid_iso8601
+from dateutil.tz import tzutc
+
+from conans.util.dates import from_timestamp_to_iso8601, from_iso8601_to_datetime
 
 
 class TimeTest(unittest.TestCase):
@@ -12,15 +14,18 @@ class TimeTest(unittest.TestCase):
         self.assertEqual(iso, "2019-01-10T16:34:59Z")
 
         dt = from_iso8601_to_datetime(iso)
-        expected = datetime.datetime(year=2019, month=1, day=10, hour=16, minute=34, second=59)
+        expected = datetime.datetime(year=2019, month=1, day=10, hour=16, minute=34, second=59,
+                                     tzinfo=tzutc())
         self.assertEqual(dt, expected)
 
         artifactory_ret = '2019-02-20T13:54:47.543+0000'
         dt = from_iso8601_to_datetime(artifactory_ret)
         expected = datetime.datetime(year=2019, month=2, day=20, hour=13, minute=54, second=47,
-                                     microsecond=543000)
+                                     microsecond=543000, tzinfo=tzutc())
         self.assertEqual(dt, expected)
 
-    def validation_test(self):
-        self.assertFalse(valid_iso8601("1547138099"))
-        self.assertTrue(valid_iso8601("2019-01-10T16:34:59Z"))
+        artifactory_ret = '2019-05-14T16:52:28.383+0100'
+        dt = from_iso8601_to_datetime(artifactory_ret)  # UTC one hour less
+        expected = datetime.datetime(year=2019, month=5, day=14, hour=15, minute=52, second=28,
+                                     microsecond=383000, tzinfo=tzutc())
+        self.assertEqual(dt, expected)

--- a/conans/util/dates.py
+++ b/conans/util/dates.py
@@ -1,5 +1,5 @@
 import datetime
-import re
+from dateutil import parser
 
 
 def from_timestamp_to_iso8601(timestamp):
@@ -7,34 +7,9 @@ def from_timestamp_to_iso8601(timestamp):
 
 
 def from_iso8601_to_datetime(iso_str):
-
-    def transform_to_z_notation(the_str):
-        for p in ("+00:00", "+0000", "+00"):
-            if the_str.endswith(p):
-                the_str = the_str[0:-len(p)]
-                return "{}Z".format(the_str)
-        return the_str
-
-    base_pattern = "%Y-%m-%dT%H:%M:%S"
-    if "." in iso_str:
-        pattern = "{}.%fZ".format(base_pattern)
-    else:
-        pattern = '{}Z'.format(base_pattern)
-
-    iso_str = transform_to_z_notation(iso_str)
-    if not iso_str.endswith("Z"):
-        iso_str += "Z"
-    return datetime.datetime.strptime(iso_str, pattern)
+    return parser.isoparse(iso_str)
 
 
 def iso8601_to_str(iso_str):
     dt = from_iso8601_to_datetime(iso_str)
     return dt.strftime('%Y-%m-%d %H:%M:%S UTC')
-
-
-def valid_iso8601(the_date):
-    regex = r'^(-?(?:[1-9][0-9]*)?[0-9]{4})-(1[0-2]|0[1-9])-(3[01]|0[1-9]|[12][0-9])T' \
-            r'(2[0-3]|[01][0-9]):([0-5][0-9]):([0-5][0-9])(\.[0-9]+)?(Z|[+-]' \
-            r'(?:2[0-3]|[01][0-9]):' \
-            r'[0-5][0-9])?$'
-    return re.match(regex, the_date)


### PR DESCRIPTION
Changelog: Bugfix: Fix `conan search` command showing revisions timestamps in a different time offset than UTC.
Docs:omit

Previously I tried to avoid introducing a new dep (python-dateutil) for that but if we need to manage offsets, it is worth it.

Closes #5230 

@PYVERS: Macos@py27, Windows@py36, Linux@py27, py34
@TAGS: svn, slow
@REVISIONS: 1