### PR TITLE
fix new template

### DIFF
--- a/conans/client/cmd/new.py
+++ b/conans/client/cmd/new.py
@@ -285,8 +285,9 @@ def cmd_new(ref, header=False, pure_c=False, test=False, exports_sources=False, 
         if not os.path.isfile(template):
             raise ConanException("Template doesn't exist: %s" % template)
         conanfile_template = load(template)
-        files = {"conanfile.py": conanfile_template.format(name=name, version=version,
-                                                           package_name=package_name)}
+        conanfile_template = conanfile_template.replace("{name}", name).replace("{version}", version)
+        conanfile_template = conanfile_template.replace("{package_name}", package_name)
+        files = {"conanfile.py": conanfile_template}
     else:
         files = {"conanfile.py": conanfile.format(name=name, version=version,
                                                   package_name=package_name)}


### PR DESCRIPTION
Changelog: omit
Docs: omit


There is a problem if the template contains dicts or any braces in general { } as it was using the python format string to replace them. Changed for full substituion of the ``{name}`` string, but please tell if you prefer ``%name%`` placeholders instead.