### PR TITLE
don't retry auth

### DIFF
--- a/conans/test/functional/remote/auth_test.py
+++ b/conans/test/functional/remote/auth_test.py
@@ -2,7 +2,6 @@ import os
 import unittest
 
 from conans.client import tools
-from conans.errors import NotFoundException
 from conans.model.ref import ConanFileReference
 from conans.paths import CONANFILE
 from conans.test.utils.tools import TestClient, TestServer

--- a/conans/test/functional/remote/retry_test.py
+++ b/conans/test/functional/remote/retry_test.py
@@ -57,8 +57,8 @@ class RetryDownloadTests(unittest.TestCase):
             uploader.upload(url="fake", abs_path=self.filename, retry=2)
         output_lines = str(output).splitlines()
         counter = Counter(output_lines)
-        self.assertEqual(counter["ERROR: content"], 2)
-        self.assertEqual(counter["Waiting 0 seconds to retry..."], 2)
+        self.assertEqual(counter["ERROR: content"], 0)
+        self.assertEqual(counter["Waiting 0 seconds to retry..."], 0)
 
     def test_error_403_forbidden(self):
         output = TestBufferConanOutput()
@@ -69,8 +69,8 @@ class RetryDownloadTests(unittest.TestCase):
             uploader.upload(url="fake", abs_path=self.filename, retry=2, auth=auth("token"))
         output_lines = str(output).splitlines()
         counter = Counter(output_lines)
-        self.assertEqual(counter["ERROR: content"], 2)
-        self.assertEqual(counter["Waiting 0 seconds to retry..."], 2)
+        self.assertEqual(counter["ERROR: content"], 0)
+        self.assertEqual(counter["Waiting 0 seconds to retry..."], 0)
 
     def test_error_403_authentication(self):
         output = TestBufferConanOutput()
@@ -81,8 +81,8 @@ class RetryDownloadTests(unittest.TestCase):
             uploader.upload(url="fake", abs_path=self.filename, retry=2, auth=auth(None))
         output_lines = str(output).splitlines()
         counter = Counter(output_lines)
-        self.assertEqual(counter["ERROR: content"], 2)
-        self.assertEqual(counter["Waiting 0 seconds to retry..."], 2)
+        self.assertEqual(counter["ERROR: content"], 0)
+        self.assertEqual(counter["Waiting 0 seconds to retry..."], 0)
 
     def test_error_requests(self):
         class _RequesterMock:


### PR DESCRIPTION
Changelog: Fix: Do not retry file transfer operations for 401 and 403 auth and permissions errors.
Docs: omit

Comes from https://github.com/conan-io/conan/issues/5271 (but is not the fix to that issue)

@tags: slow
