### PR TITLE
P argument deprecation

### DIFF
--- a/conans/client/command.py
+++ b/conans/client/command.py
@@ -79,7 +79,6 @@ class SmartFormatter(argparse.HelpFormatter):
         text = textwrap.dedent(text)
         return ''.join(indent + line for line in text.splitlines(True))
 
-
 _QUERY_EXAMPLE = ("os=Windows AND (arch=x86 OR compiler=gcc)")
 _PATTERN_EXAMPLE = ("boost/*")
 _REFERENCE_EXAMPLE = ("MyPackage/1.2@user/channel")
@@ -366,7 +365,7 @@ class Command(object):
         parser.add_argument("reference",
                             help='pkg/version@user/channel')
         parser.add_argument("-p", "--package", nargs=1, action=Extender,
-                            help='Force install specified package ID (ignore settings/options)')
+                            help='Force install specified package ID (ignore settings/options) [DEPRECATED: use full reference instead]')
         parser.add_argument("-r", "--remote", help='look in the specified remote server',
                             action=OnceArgument)
         parser.add_argument("-re", "--recipe", help='Downloads only the recipe', default=False,
@@ -1008,7 +1007,7 @@ class Command(object):
         parser.add_argument("user_channel", default="",
                             help='Destination user/channel. e.g., lasote/testing')
         parser.add_argument("-p", "--package", nargs=1, action=Extender,
-                            help='copy specified package ID')
+                            help='copy specified package ID [DEPRECATED: use full reference instead]')
         parser.add_argument("--all", action='store_true', default=False,
                             help='Copy all packages from the specified package recipe')
         parser.add_argument("--force", action='store_true', default=False,

--- a/conans/client/command.py
+++ b/conans/client/command.py
@@ -365,8 +365,8 @@ class Command(object):
         parser.add_argument("reference",
                             help='pkg/version@user/channel')
         parser.add_argument("-p", "--package", nargs=1, action=Extender,
-                            help='Force install specified package ID (ignore settings/options)"'
-                                 '"[DEPRECATED: use full reference instead]')
+                            help='Force install specified package ID (ignore settings/options)'
+                                 ' [DEPRECATED: use full reference instead]')
         parser.add_argument("-r", "--remote", help='look in the specified remote server',
                             action=OnceArgument)
         parser.add_argument("-re", "--recipe", help='Downloads only the recipe', default=False,
@@ -1024,7 +1024,7 @@ class Command(object):
             if packages_list:
                 self._user_io.out.warn("Usage of `--package` argument is deprecated."
                                        " Use a full reference instead: "
-                                       "`conan download [...] {}:{}`".format(reference, packages_list[0]))
+                                       "`conan copy [...] {}:{}`".format(reference, packages_list[0]))
 
             if args.all and packages_list:
                 raise ConanException("Cannot specify both --all and --package")

--- a/conans/client/command.py
+++ b/conans/client/command.py
@@ -365,7 +365,8 @@ class Command(object):
         parser.add_argument("reference",
                             help='pkg/version@user/channel')
         parser.add_argument("-p", "--package", nargs=1, action=Extender,
-                            help='Force install specified package ID (ignore settings/options) [DEPRECATED: use full reference instead]')
+                            help='Force install specified package ID (ignore settings/options)"'
+                                 '"[DEPRECATED: use full reference instead]')
         parser.add_argument("-r", "--remote", help='look in the specified remote server',
                             action=OnceArgument)
         parser.add_argument("-re", "--recipe", help='Downloads only the recipe', default=False,

--- a/conans/client/command.py
+++ b/conans/client/command.py
@@ -377,21 +377,21 @@ class Command(object):
             pref = PackageReference.loads(args.reference, validate=True)
         except ConanException:
             reference = args.reference
-            package_id_list = args.package
+            packages_list = args.package
 
-            if package_id_list:
+            if packages_list:
                 self._user_io.out.warn("Usage of `--package` argument is deprecated."
                                        " Use a full reference instead: "
-                                       "`conan download [...] {}:{}`".format(reference, package_id_list[0]))
+                                       "`conan download [...] {}:{}`".format(reference, packages_list[0]))
         else:
             reference = pref.ref.full_repr()
-            package_id_list = [pref.id]
+            packages_list = [pref.id]
             if args.package:
                 raise ConanException("Use a full package reference (preferred) or the `--package`"
                                      " command argument, but not both.")
 
         self._warn_python2()
-        return self._conan.download(reference=reference, package_list=package_id_list,
+        return self._conan.download(reference=reference, packages=packages_list,
                                     remote_name=args.remote, recipe=args.recipe)
 
     def install(self, *args):
@@ -1018,18 +1018,18 @@ class Command(object):
             pref = PackageReference.loads(args.reference, validate=True)
         except ConanException:
             reference = args.reference
-            package_id_list = args.package
+            packages_list = args.package
 
-            if package_id_list:
+            if packages_list:
                 self._user_io.out.warn("Usage of `--package` argument is deprecated."
                                        " Use a full reference instead: "
-                                       "`conan download [...] {}:{}`".format(reference, package_id_list[0]))
+                                       "`conan download [...] {}:{}`".format(reference, packages_list[0]))
 
-            if args.all and package_id_list:
+            if args.all and packages_list:
                 raise ConanException("Cannot specify both --all and --package")
         else:
             reference = pref.ref.full_repr()
-            package_id_list = [pref.id]
+            packages_list = [pref.id]
             if args.package:
                 raise ConanException("Use a full package reference (preferred) or the `--package`"
                                      " command argument, but not both.")
@@ -1040,7 +1040,7 @@ class Command(object):
         self._warn_python2()
 
         return self._conan.copy(reference=reference, user_channel=args.user_channel,
-                                force=args.force, packages=package_id_list or args.all)
+                                force=args.force, packages=packages_list or args.all)
 
     def user(self, *args):
         """

--- a/conans/client/conan_api.py
+++ b/conans/client/conan_api.py
@@ -431,7 +431,7 @@ class ConanAPIV1(object):
                 for package_id in packages:
                     if "#" in package_id:
                         raise ConanException("It is needed to specify the recipe revision if you "
-                                             "specify a packages revision")
+                                             "specify a package revision")
             remotes = self._cache.registry.load_remotes()
             remotes.select(remote_name)
             self._python_requires.enable_remotes(remotes=remotes)

--- a/conans/client/conan_api.py
+++ b/conans/client/conan_api.py
@@ -421,24 +421,23 @@ class ConanAPIV1(object):
             raise
 
     @api_method
-    def download(self, reference, remote_name=None, package=None, recipe=False):
-        # FIXME: The "package" parameter name is very bad, it is a list of package_ids
-        if package and recipe:
-            raise ConanException("recipe parameter cannot be used together with package")
+    def download(self, reference, remote_name=None, package_list=None, recipe=False):
+        if package_list and recipe:
+            raise ConanException("recipe parameter cannot be used together with package_list")
         # Install packages without settings (fixed ids or all)
         ref = ConanFileReference.loads(reference)
         if check_valid_ref(ref, allow_pattern=False):
-            if package and ref.revision is None:
-                for package_id in package:
+            if package_list and ref.revision is None:
+                for package_id in package_list:
                     if "#" in package_id:
                         raise ConanException("It is needed to specify the recipe revision if you "
-                                             "specify a package revision")
+                                             "specify a package_list revision")
             remotes = self._cache.registry.load_remotes()
             remotes.select(remote_name)
             self._python_requires.enable_remotes(remotes=remotes)
             remote = remotes.get_remote(remote_name)
             recorder = ActionRecorder()
-            download(ref, package, remote, recipe, self._remote_manager,
+            download(ref, package_list, remote, recipe, self._remote_manager,
                      self._cache, self._user_io.out, recorder, self._loader,
                      self._hook_manager, remotes=remotes)
         else:

--- a/conans/client/conan_api.py
+++ b/conans/client/conan_api.py
@@ -421,23 +421,23 @@ class ConanAPIV1(object):
             raise
 
     @api_method
-    def download(self, reference, remote_name=None, package_list=None, recipe=False):
-        if package_list and recipe:
-            raise ConanException("recipe parameter cannot be used together with package_list")
+    def download(self, reference, remote_name=None, packages=None, recipe=False):
+        if packages and recipe:
+            raise ConanException("recipe parameter cannot be used together with packages")
         # Install packages without settings (fixed ids or all)
         ref = ConanFileReference.loads(reference)
         if check_valid_ref(ref, allow_pattern=False):
-            if package_list and ref.revision is None:
-                for package_id in package_list:
+            if packages and ref.revision is None:
+                for package_id in packages:
                     if "#" in package_id:
                         raise ConanException("It is needed to specify the recipe revision if you "
-                                             "specify a package_list revision")
+                                             "specify a packages revision")
             remotes = self._cache.registry.load_remotes()
             remotes.select(remote_name)
             self._python_requires.enable_remotes(remotes=remotes)
             remote = remotes.get_remote(remote_name)
             recorder = ActionRecorder()
-            download(ref, package_list, remote, recipe, self._remote_manager,
+            download(ref, packages, remote, recipe, self._remote_manager,
                      self._cache, self._user_io.out, recorder, self._loader,
                      self._hook_manager, remotes=remotes)
         else:

--- a/conans/test/functional/command/copy_packages_test.py
+++ b/conans/test/functional/command/copy_packages_test.py
@@ -27,8 +27,8 @@ class Pkg(ConanFile):
         packages = os.listdir(pkgdir)
         self.assertEqual(len(packages), 3)
 
-        # Copy just one
-        client.run("copy Hello0/0.1@lasote/stable pepe/stable -p %s" % packages[0])
+        # Copy just one with --package argument
+        client.run("copy Hello0/0.1@lasote/stable:%s pepe/stable" % packages[0])
         pkgdir = client.cache.package_layout(ConanFileReference.loads("Hello0/0.1@pepe/stable")).packages()
         packages = os.listdir(pkgdir)
         self.assertEqual(len(packages), 1)

--- a/conans/test/functional/command/copy_packages_test.py
+++ b/conans/test/functional/command/copy_packages_test.py
@@ -84,3 +84,15 @@ class Pkg(ConanFile):
             self.assertIn("my data!", data)
         else:
             self.assertIn("my data rev2!", data)
+
+    def test_full_reference_with_all_argument(self):
+        client = TestClient()
+        client.run("copy pkg/0.1@user/channel:{} other/channel --all".format("mimic"),
+                   assert_error=True)
+        self.assertIn("'--all' argument cannot be used together with full reference", client.out)
+
+    def test_copy_with_p_and_all(self):
+        client = TestClient()
+        client.run("copy pkg/0.1@user/channel other/channel -p {} --all".format("mimic"),
+                   assert_error=True)
+        self.assertIn("Cannot specify both --all and --package", client.out)

--- a/conans/test/functional/command/copy_packages_test.py
+++ b/conans/test/functional/command/copy_packages_test.py
@@ -28,6 +28,12 @@ class Pkg(ConanFile):
         self.assertEqual(len(packages), 3)
 
         # Copy just one with --package argument
+        client.run("copy Hello0/0.1@lasote/stable pepe/beta -p %s" % packages[0])
+        pkgdir = client.cache.package_layout(ConanFileReference.loads("Hello0/0.1@pepe/beta")).packages()
+        packages = os.listdir(pkgdir)
+        self.assertEqual(len(packages), 1)
+
+        # Copy just one with full reference
         client.run("copy Hello0/0.1@lasote/stable:%s pepe/stable" % packages[0])
         pkgdir = client.cache.package_layout(ConanFileReference.loads("Hello0/0.1@pepe/stable")).packages()
         packages = os.listdir(pkgdir)

--- a/conans/test/functional/command/download_test.py
+++ b/conans/test/functional/command/download_test.py
@@ -197,3 +197,12 @@ class Pkg(ConanFile):
         self.assertTrue(os.path.exists(package_layout.conanfile()))
         # Check package folder created
         self.assertTrue(os.path.exists(package_folder))
+
+    def test_download_with_full_reference_and_p(self):
+        client = TestClient()
+        client.run("download pkg/0.1@user/channel:{package_id} -p {package_id}".
+                   format(package_id="dupqipa4tog2ju3pncpnrzbim1fgd09g"),
+                   assert_error=True)
+        self.assertIn("Use a full package reference (preferred) or the `--package`"
+                      " command argument, but not both.", client.out)
+

--- a/conans/test/functional/command/download_test.py
+++ b/conans/test/functional/command/download_test.py
@@ -3,7 +3,7 @@ import unittest
 from collections import OrderedDict
 
 from conans.model.ref import ConanFileReference
-from conans.test.utils.tools import TestClient, TestServer, NO_SETTINGS_PACKAGE_ID
+from conans.test.utils.tools import TestClient, TestServer, NO_SETTINGS_PACKAGE_ID, TurboTestClient
 from conans.util.files import load
 
 
@@ -12,41 +12,26 @@ class DownloadTest(unittest.TestCase):
     def download_recipe_test(self):
         server = TestServer()
         servers = {"default": server}
-        client = TestClient(servers=servers, users={"default": [("lasote", "mypass")]})
-
-        # Test argument --package and --recipe cannot be together
-        client.run("download eigen/3.3.4@conan/stable --recipe --package fake_id",
-                   assert_error=True)
-
-        self.assertIn("ERROR: recipe parameter cannot be used together with package", client.out)
+        client = TurboTestClient(servers=servers, users={"default": [("lasote", "mypass")]})
 
         # Test download of the recipe only
         conanfile = """from conans import ConanFile
 class Pkg(ConanFile):
     name = "pkg"
     version = "0.1"
-    exports_sources = "*"
 """
-        client.save({"conanfile.py": conanfile,
-                     "file.h": "myfile.h"})
-        client.run("create . lasote/stable")
         ref = ConanFileReference.loads("pkg/0.1@lasote/stable")
-        self.assertTrue(os.path.exists(client.cache.package_layout(ref).conanfile()))
-        conan = client.cache.package_layout(ref).base_folder()
-        self.assertTrue(os.path.exists(os.path.join(conan, "package")))
-        client.run("upload pkg/0.1@lasote/stable --all")
-        client.run("remove pkg/0.1@lasote/stable -f")
-        self.assertFalse(os.path.exists(client.cache.package_layout(ref).export()))
+        client.create(ref, conanfile)
+        client.upload_all(ref)
+        client.remove_all()
+
         client.run("download pkg/0.1@lasote/stable --recipe")
 
         self.assertIn("Downloading conanfile.py", client.out)
-        self.assertIn("Downloading conan_sources.tgz", client.out)
         self.assertNotIn("Downloading conan_package.tgz", client.out)
         export = client.cache.package_layout(ref).export()
         self.assertTrue(os.path.exists(os.path.join(export, "conanfile.py")))
         self.assertEqual(conanfile, load(os.path.join(export, "conanfile.py")))
-        source = client.cache.package_layout(ref).export_sources()
-        self.assertTrue(os.path.exists(os.path.join(source, "file.h")))
         conan = client.cache.package_layout(ref).base_folder()
         self.assertFalse(os.path.exists(os.path.join(conan, "package")))
 
@@ -70,11 +55,8 @@ class Pkg(ConanFile):
         client.run("export . lasote/stable")
 
         ref = ConanFileReference.loads("pkg/0.1@lasote/stable")
-        self.assertTrue(os.path.exists(client.cache.package_layout(ref).conanfile()))
-
         client.run("upload pkg/0.1@lasote/stable")
         client.run("remove pkg/0.1@lasote/stable -f")
-        self.assertFalse(os.path.exists(client.cache.package_layout(ref).export()))
 
         client.run("download pkg/0.1@lasote/stable")
         self.assertIn("Downloading conan_sources.tgz", client.out)
@@ -96,11 +78,9 @@ class Pkg(ConanFile):
         client.run("export . lasote/stable")
 
         ref = ConanFileReference.loads("pkg/0.1@lasote/stable")
-        self.assertTrue(os.path.exists(client.cache.package_layout(ref).conanfile()))
 
         client.run("upload pkg/0.1@lasote/stable")
         client.run("remove pkg/0.1@lasote/stable -f")
-        self.assertFalse(os.path.exists(client.cache.package_layout(ref).export()))
 
         client.run("download pkg/0.1@lasote/stable")
         # Check 'No remote binary packages found' warning
@@ -112,30 +92,25 @@ class Pkg(ConanFile):
         server = TestServer()
         servers = {"default": server}
 
-        client = TestClient(servers=servers, users={"default": [("lasote", "mypass")]})
+        client = TurboTestClient(servers=servers, users={"default": [("lasote", "mypass")]})
         conanfile = """from conans import ConanFile
 class Pkg(ConanFile):
     name = "pkg"
     version = "0.1"
     settings = "os"
 """
-
-        client.save({"conanfile.py": conanfile})
-        client.run("create . lasote/stable")
-
         ref = ConanFileReference.loads("pkg/0.1@lasote/stable")
-        package_layout = client.cache.package_layout(ref)
-        self.assertTrue(os.path.exists(package_layout.conanfile()))
 
-        package_folder = os.path.join(package_layout.packages(),
-                                      os.listdir(package_layout.packages())[0])
-
-        client.run("upload pkg/0.1@lasote/stable --all")
-        client.run("remove pkg/0.1@lasote/stable -f")
-        self.assertFalse(os.path.exists(package_layout.export()))
+        client.create(ref, conanfile)
+        client.upload_all(ref)
+        client.remove_all()
 
         client.run("download pkg/0.1@lasote/stable")
 
+        package_layout = client.cache.package_layout(ref)
+
+        package_folder = os.path.join(package_layout.packages(),
+                                      os.listdir(package_layout.packages())[0])
         # Check not 'No remote binary packages found' warning
         self.assertNotIn("WARN: No remote binary packages found in remote", client.out)
         # Check at conanfile.py is downloaded
@@ -144,16 +119,13 @@ class Pkg(ConanFile):
         self.assertTrue(os.path.exists(package_folder))
 
     def test_download_wrong_id(self):
-        client = TestClient(servers={"default": TestServer()},
-                            users={"default": [("lasote", "mypass")]})
-        conanfile = """from conans import ConanFile
-class Pkg(ConanFile):
-    pass
-"""
-        client.save({"conanfile.py": conanfile})
-        client.run("export . pkg/0.1@lasote/stable")
-        client.run("upload pkg/0.1@lasote/stable")
-        client.run("remove pkg/0.1@lasote/stable -f")
+        client = TurboTestClient(servers={"default": TestServer()},
+                                 users={"default": [("lasote", "mypass")]})
+
+        ref = ConanFileReference.loads("pkg/0.1@lasote/stable")
+        client.export(ref)
+        client.upload_all(ref)
+        client.remove_all()
 
         client.run("download pkg/0.1@lasote/stable:wrong", assert_error=True)
         self.assertIn("ERROR: Binary package not found: 'pkg/0.1@lasote/stable:wrong'",
@@ -168,29 +140,18 @@ class Pkg(ConanFile):
         server = TestServer()
         servers = {"default": server}
 
-        client = TestClient(servers=servers, users={"default": [("lasote", "mypass")]})
-        conanfile = """from conans import ConanFile
-class Pkg(ConanFile):
-    name = "pkg"
-    version = "0.1"
-"""
-
-        client.save({"conanfile.py": conanfile})
-        client.run("create . lasote/stable")
+        client = TurboTestClient(servers=servers, users={"default": [("lasote", "mypass")]})
 
         ref = ConanFileReference.loads("pkg/0.1@lasote/stable")
-        package_layout = client.cache.package_layout(ref)
-        self.assertTrue(os.path.exists(package_layout.conanfile()))
-
-        package_folder = os.path.join(package_layout.packages(),
-                                      os.listdir(package_layout.packages())[0])
-
-        client.run("upload pkg/0.1@lasote/stable --all")
-        client.run("remove pkg/0.1@lasote/stable -f")
-        self.assertFalse(os.path.exists(package_layout.export()))
+        client.create(ref)
+        client.upload_all(ref)
+        client.remove_all()
 
         client.run("download pkg/0.1@lasote/stable:{}".format(NO_SETTINGS_PACKAGE_ID))
 
+        package_layout = client.cache.package_layout(ref)
+        package_folder = os.path.join(package_layout.packages(),
+                                      os.listdir(package_layout.packages())[0])
         # Check not 'No remote binary packages found' warning
         self.assertNotIn("WARN: No remote binary packages found in remote", client.out)
         # Check at conanfile.py is downloaded
@@ -206,3 +167,32 @@ class Pkg(ConanFile):
         self.assertIn("Use a full package reference (preferred) or the `--package`"
                       " command argument, but not both.", client.out)
 
+    def test_download_with_package_and_recipe_args(self):
+        client = TestClient();
+        client.run("download eigen/3.3.4@conan/stable --recipe --package fake_id",
+                   assert_error=True)
+
+        self.assertIn("ERROR: recipe parameter cannot be used together with package", client.out)
+
+    def download_package_argument_test(self):
+        server = TestServer()
+        servers = {"default": server}
+
+        client = TurboTestClient(servers=servers, users={"default": [("lasote", "mypass")]})
+
+        ref = ConanFileReference.loads("pkg/0.1@lasote/stable")
+        client.create(ref)
+        client.upload_all(ref)
+        client.remove_all()
+
+        client.run("download pkg/0.1@lasote/stable -p {}".format(NO_SETTINGS_PACKAGE_ID))
+
+        package_layout = client.cache.package_layout(ref)
+        package_folder = os.path.join(package_layout.packages(),
+                                      os.listdir(package_layout.packages())[0])
+        # Check not 'No remote binary packages found' warning
+        self.assertNotIn("WARN: No remote binary packages found in remote", client.out)
+        # Check at conanfile.py is downloaded
+        self.assertTrue(os.path.exists(package_layout.conanfile()))
+        # Check package folder created
+        self.assertTrue(os.path.exists(package_folder))

--- a/conans/test/functional/command/upload_test.py
+++ b/conans/test/functional/command/upload_test.py
@@ -700,3 +700,21 @@ class Pkg(ConanFile):
             client2.run("upload lib/1.0@conan/testing")
             self.assertIn("Recipe is up to date, upload skipped", client2.out)
             self.assertNotIn("WARN", client2.out)
+
+    def upload_with_pref_and_query_test(self):
+        client = self._client()
+        client.save({"conanfile.py": conanfile})
+        client.run("create . user/testing")
+        client.run("upload Hello0/1.2.1@user/testing:{} -q 'os=Windows or os=Macos'".format(NO_SETTINGS_PACKAGE_ID),
+                   assert_error=True)
+
+        self.assertIn("'--query' argument cannot be used together with full reference", client.out)
+
+    def upload_with_package_id_and_query_test(self):
+        client = self._client()
+        client.save({"conanfile.py": conanfile})
+        client.run("create . user/testing")
+        client.run("upload Hello0/1.2.1@user/testing -p {} -q 'os=Windows or os=Macos'".format(NO_SETTINGS_PACKAGE_ID),
+                   assert_error=True)
+
+        self.assertIn("'--query' argument cannot be used together with '--package'", client.out)


### PR DESCRIPTION
Changelog: Deprecated ``conan copy|download|upload <ref> -p=ID``, use ``conan .... <pref>`` instead
Docs: conan-io/docs#1317

Fixes #5250
Closes #5225 


- [X] Refer to the issue that supports this Pull Request.
- [X] I've followed the PEP8 style guides for Python code.
- [X] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 
