### PR TITLE
Fix requirement: typed-ast less that 1.4.x

### DIFF
--- a/conans/requirements.txt
+++ b/conans/requirements.txt
@@ -15,4 +15,4 @@ deprecation>=2.0, <2.1
 tqdm>=4.28.1, <5
 Jinja2>=2.3, <3
 python-dateutil>=2.6.0, <3
-typed-ast<1.4; sys_platform == 'windows'
+typed-ast<1.4; python_version == '3.4' and sys_platform == 'win32'

--- a/conans/requirements.txt
+++ b/conans/requirements.txt
@@ -15,4 +15,4 @@ deprecation>=2.0, <2.1
 tqdm>=4.28.1, <5
 Jinja2>=2.3, <3
 python-dateutil>=2.6.0, <3
-typed-ast<1.4; python_version == '3.4' and sys_platform == 'win32'
+typed-ast<1.4; python_version == '3.4' and platform_system=='Windows'

--- a/conans/requirements.txt
+++ b/conans/requirements.txt
@@ -15,3 +15,4 @@ deprecation>=2.0, <2.1
 tqdm>=4.28.1, <5
 Jinja2>=2.3, <3
 python-dateutil>=2.6.0, <3
+typed-ast<1.4

--- a/conans/requirements.txt
+++ b/conans/requirements.txt
@@ -15,4 +15,4 @@ deprecation>=2.0, <2.1
 tqdm>=4.28.1, <5
 Jinja2>=2.3, <3
 python-dateutil>=2.6.0, <3
-typed-ast<1.4
+typed-ast<1.4; sys_platform == 'windows'


### PR DESCRIPTION
Changelog: omit
Docs: omit

Version 1.4.0 released June 5th brokes our CI trying to install the dependency: `error: Microsoft Visual C++ 10.0 is required`.

@PYVERS: py34

Waiting for https://github.com/PyCQA/astroid/issues/676 and/or https://github.com/python/typed_ast/issues/122, the alternative is to maintain a fork of `astroid` and freeze `typed-ast` dependency (LOC: https://github.com/PyCQA/astroid/blob/01a25f31962dd5017a141a6450859a7c1c82722d/astroid/__pkginfo__.py#L33)