### PR TITLE
Compare sha256 case insensitive

### DIFF
--- a/conans/client/tools/files.py
+++ b/conans/client/tools/files.py
@@ -148,7 +148,7 @@ def untargz(filename, destination=".", pattern=None):
 
 def check_with_algorithm_sum(algorithm_name, file_path, signature):
     real_signature = _generic_algorithm_sum(file_path, algorithm_name)
-    if real_signature != signature:
+    if real_signature != signature.lower():
         raise ConanException("%s signature failed for '%s' file. \n"
                              " Provided signature: %s  \n"
                              " Computed signature: %s" % (algorithm_name,


### PR DESCRIPTION
Changelog: Bugfix: Use case insensitive comparison for SHA256 checksums
Docs: Omit


Fixes mismatches for the same signature with different case sensitivity e.g.:
```
Provided signature: C75203EF4759E4D7BC38E686B156C54C43B78EDC73123C0B25DB5224758BD1FC  
Computed signature: c75203ef4759e4d7bc38e686b156c54c43b78edc73123c0b25db5224758bd1fc
```

@SSE4 