### PR TITLE
[workspace] [POC] Handle all the packages involved in a WS (editables and dependents)

### DIFF
--- a/conans/client/conan_api.py
+++ b/conans/client/conan_api.py
@@ -468,7 +468,7 @@ class ConanAPIV1(object):
         workspace = Workspace.create(abs_path, self._cache)
         workspace.generate(install_folder, manager=manager, output=self._user_io.out,
                            graph_info=graph_info, remotes=remotes,
-                           update=update, create_reference=False)
+                           update=update, create_reference=False, build_modes=build)
 
     @api_method
     def install_reference(self, reference, settings=None, options=None, env=None,

--- a/conans/client/manager.py
+++ b/conans/client/manager.py
@@ -117,3 +117,5 @@ class ConanManager(object):
                 deploy_conanfile = neighbours[0].conanfile
                 if hasattr(deploy_conanfile, "deploy") and callable(deploy_conanfile.deploy):
                     run_deploy(deploy_conanfile, install_folder)
+
+        return deps_graph

--- a/conans/model/workspace.py
+++ b/conans/model/workspace.py
@@ -41,6 +41,24 @@ class LocalPackage(object):
 class Workspace(object):
     default_filename = "conanws.yml"
 
+    def __init__(self, path, cache):
+        self._cache = cache
+        self._ws_generator = None
+        self._workspace_packages = OrderedDict()  # {reference: LocalPackage}
+
+        if not os.path.isfile(path):
+            path = os.path.join(path, self.default_filename)
+
+        self._base_folder = os.path.dirname(path)
+        try:
+            content = load(path)
+        except IOError:
+            raise ConanException("Couldn't load workspace file in %s" % path)
+        try:
+            self._loads(content)
+        except Exception as e:
+            raise ConanException("There was an error parsing %s: %s" % (path, str(e)))
+
     def generate(self, install_folder, graph, output):
         if self._ws_generator == "cmake":
             cmake = ""
@@ -86,24 +104,6 @@ class Workspace(object):
                 cmake += "endmacro()"
             cmake_path = os.path.join(install_folder, "conanworkspace.cmake")
             save(cmake_path, cmake)
-
-    def __init__(self, path, cache):
-        self._cache = cache
-        self._ws_generator = None
-        self._workspace_packages = OrderedDict()  # {reference: LocalPackage}
-
-        if not os.path.isfile(path):
-            path = os.path.join(path, self.default_filename)
-
-        self._base_folder = os.path.dirname(path)
-        try:
-            content = load(path)
-        except IOError:
-            raise ConanException("Couldn't load workspace file in %s" % path)
-        try:
-            self._loads(content)
-        except Exception as e:
-            raise ConanException("There was an error parsing %s: %s" % (path, str(e)))
 
     def get_editable_dict(self):
         return {ref: {"path": ws_package.root_folder, "layout": ws_package.layout}

--- a/conans/model/workspace.py
+++ b/conans/model/workspace.py
@@ -147,7 +147,6 @@ class WorkspaceCMake(Workspace):
         add_library({{ ref.name }}::{{ ref.name }} ALIAS {{ ref.name }})
         add_library(CONAN_PKG::{{ ref.name }} ALIAS {{ ref.name }}) 
         {% endfor %}
-
     """)
 
     cmakelists_template = textwrap.dedent(r"""
@@ -158,7 +157,6 @@ class WorkspaceCMake(Workspace):
         conan_basic_setup()  # Execute Conan magic
         
         include(${CMAKE_CURRENT_SOURCE_DIR}/conanworkspace.cmake)
-        
     """)
 
     def generate(self, install_folder, manager, output, **kwargs):

--- a/conans/model/workspace.py
+++ b/conans/model/workspace.py
@@ -6,6 +6,7 @@ import yaml
 from jinja2 import Template
 
 from conans.client.graph.graph import RECIPE_EDITABLE
+from conans.client.importer import run_imports
 from conans.errors import ConanException
 from conans.model.editable_layout import get_editable_abs_path, EditableLayout
 from conans.model.ref import ConanFileReference
@@ -235,6 +236,10 @@ class WorkspaceCMake(Workspace):
                        'target_name': self.packages[node.ref].target_name}
                 in_ws[node.ref] = pkg
                 ordered_packages.append((node.ref, pkg))
+
+                # Run imports for _editable_ packages
+                # TODO: I need to run the imports, is this the place?
+                run_imports(conanfile, self.packages[node.ref].layout_path(source_folder))
             else:
                 if not node.ref:
                     continue

--- a/conans/model/workspace.py
+++ b/conans/model/workspace.py
@@ -39,54 +39,6 @@ class Workspace(object):
                 raise ConanException("Root {} is not defined as editable".format(ref))
         return True
 
-    """
-    def generate(self, install_folder, graph, output):
-        if self._ws_generator == "cmake":
-            cmake = ""
-            add_subdirs = ""
-            # To avoid multiple additions (can happen for build_requires repeated nodes)
-            unique_refs = OrderedDict()
-            for node in graph.ordered_iterate():
-                if node.recipe != RECIPE_EDITABLE:
-                    continue
-                unique_refs[node.ref] = node
-            for ref, node in unique_refs.items():
-                ws_pkg = self._workspace_packages[ref]
-                layout = self._cache.package_layout(ref)
-                editable = layout.editable_cpp_info()
-
-                conanfile = node.conanfile
-                src = build = None
-                if editable:
-                    build = editable.folder(ref, EditableLayout.BUILD_FOLDER, conanfile.settings,
-                                            conanfile.options)
-                    src = editable.folder(ref, EditableLayout.SOURCE_FOLDER, conanfile.settings,
-                                          conanfile.options)
-                if src is not None:
-                    src = os.path.join(ws_pkg.root_folder, src).replace("\\", "/")
-                    cmake += 'set(PACKAGE_%s_SRC "%s")\n' % (ref.name, src)
-                else:
-                    output.warn("CMake workspace: source_folder is not defined for %s" % str(ref))
-                if build is not None:
-                    build = os.path.join(ws_pkg.root_folder, build).replace("\\", "/")
-                    cmake += 'set(PACKAGE_%s_BUILD "%s")\n' % (ref.name, build)
-                else:
-                    output.warn("CMake workspace: build_folder is not defined for %s" % str(ref))
-
-                if src and build:
-                    add_subdirs += ('    add_subdirectory(${PACKAGE_%s_SRC} ${PACKAGE_%s_BUILD})\n'
-                                    % (ref.name, ref.name))
-                else:
-                    output.warn("CMake workspace: cannot 'add_subdirectory()'")
-
-            if add_subdirs:
-                cmake += "macro(conan_workspace_subdirectories)\n"
-                cmake += add_subdirs
-                cmake += "endmacro()"
-            cmake_path = os.path.join(install_folder, "conanworkspace.cmake")
-            save(cmake_path, cmake)
-    """
-
     @classmethod
     def create(cls, path, cache):
         # Look for the workspace file
@@ -133,6 +85,9 @@ class Workspace(object):
                 layout = data.pop("layout", ws_layout)
                 if layout:
                     layout = get_editable_abs_path(layout, base_folder, cache.cache_folder)
+                if not layout:
+                    raise ConanException("No layout defined for editable '{}' and cannot find the"
+                                         " default one neither".format(ref))
 
                 data.pop("generators", None)  # Not used
 

--- a/conans/model/workspace.py
+++ b/conans/model/workspace.py
@@ -1,5 +1,6 @@
 import os
 import textwrap
+from collections import OrderedDict
 
 import yaml
 from jinja2 import Template
@@ -30,7 +31,7 @@ class Workspace(object):
 
     def __init__(self, cache):
         self._cache = cache
-        self.packages = {}
+        self.packages = OrderedDict()
 
     @classmethod
     def create(cls, path, cache):

--- a/conans/model/workspace.py
+++ b/conans/model/workspace.py
@@ -207,21 +207,21 @@ class WorkspaceCMake(Workspace):
                                                conanfile.settings, conanfile.options)
 
                 pkg = {'name': node.ref.name,
-                                   'source_folder': self.packages[node.ref].layout_path(source_folder),
-                                   'build_folder': self.packages[node.ref].layout_path(build_folder),
-                                   'requires': [it.ref.name for it in node.neighbors()
-                                                if it.ref in in_ws or
-                                                it.ref in out_dependents],
-                                   'in': True}
+                       'source_folder': self.packages[node.ref].layout_path(source_folder),
+                       'build_folder': self.packages[node.ref].layout_path(build_folder),
+                       'requires': [it.ref.name for it in node.neighbors()
+                                    if it.ref in in_ws or
+                                    it.ref in out_dependents],
+                       'in': True}
                 in_ws[node.ref] = pkg
                 ordered_packages.append((node.ref, pkg))
             else:
                 if node.ref and any([it.ref in in_ws for it in node.public_closure]):
                     pkg = {'name': node.ref.name,
-                                                'requires': [it.ref.name for it in node.neighbors()
-                                                             if it.ref in in_ws or
-                                                             it.ref in out_dependents],
-                                                'in': False}
+                           'requires': [it.ref.name for it in node.neighbors()
+                                        if it.ref in in_ws or
+                                        it.ref in out_dependents],
+                           'in': False}
                     out_dependents[node.ref] = pkg
                     ordered_packages.append((node.ref, pkg))
 

--- a/conans/model/workspace.py
+++ b/conans/model/workspace.py
@@ -102,9 +102,7 @@ class Workspace(object):
                      for ref, ws_package in self.packages.items()}
         self._cache.editable_packages.override(editables)
 
-        return manager.install(refs, manifest_folder=False, install_folder=None,
-                               build_modes=["never"],
-                               **kwargs)
+        return manager.install(refs, manifest_folder=False, install_folder=None, **kwargs)
 
 
 class WorkspaceCMake(Workspace):
@@ -182,13 +180,16 @@ class WorkspaceCMake(Workspace):
         include(${CMAKE_CURRENT_SOURCE_DIR}/conanbuildinfo.cmake)
         conan_basic_setup()  # Execute Conan magic
         
+        set(CMAKE_SKIP_RPATH 0)  # We are not creating packages here, it is ok to have rpaths
+        
         include(${CMAKE_CURRENT_SOURCE_DIR}/conanworkspace.cmake)
     """)
 
     def generate(self, install_folder, manager, output, **kwargs):
         # Add roots and editables, all together
         roots = list(self.packages.keys())
-        graph = self._build_graph(manager, refs=roots, **kwargs)
+        kwargs.pop("build_modes")  # TODO: Can we build non-ws packages?
+        graph = self._build_graph(manager, refs=roots, build_modes=["never"], **kwargs)
 
         # Prepare the context for the templates
         ordered_packages = []  # [(ref, pkg), ]

--- a/conans/model/workspace.py
+++ b/conans/model/workspace.py
@@ -130,7 +130,7 @@ class WorkspaceCMake(Workspace):
         endfunction()
         
         function(include)
-            if ("${ARGV0}" MATCHES ".*/conanbuildinfo(_multi)?.cmake")
+            if ("${ARGV0}" MATCHES ".*conanbuildinfo(_multi)?\.cmake")
                 message("Ignore inclusion of ${ARGV0}")
             else()
                 _include(${ARGV})

--- a/conans/model/workspace.py
+++ b/conans/model/workspace.py
@@ -111,16 +111,16 @@ class WorkspaceCMake(Workspace):
     conanworkspace_cmake_template = textwrap.dedent(r"""
         # List of targets involved in the workspace
         {%- for _, pkg in ordered_packages %}
-        list(APPEND ws_targets "{{ pkg.name }}")
+            list(APPEND ws_targets "{{ pkg.name }}")
         {%- endfor %}
 
         {% if out_dependents %}
-        # Packages that are consumed by editable ones
-        {%- for ref, pkg in out_dependents.items() %}
-        find_package({{ pkg.name }} REQUIRED)
-        set_target_properties({{pkg.name}}::{{pkg.name}} PROPERTIES IMPORTED_GLOBAL TRUE)
-        add_library(CONAN_PKG::{{ pkg.name }} ALIAS {{ pkg.name }}::{{ pkg.name }}) 
-        {% endfor %}
+            # Packages that are consumed by editable ones
+            {%- for ref, pkg in out_dependents.items() %}
+                find_package({{ pkg.name }} REQUIRED)
+                set_target_properties({{pkg.name}}::{{pkg.name}} PROPERTIES IMPORTED_GLOBAL TRUE)
+                add_library(CONAN_PKG::{{ pkg.name }} ALIAS {{ pkg.name }}::{{ pkg.name }})
+            {% endfor %}
         {%- endif %}
 
         # Override functions to avoid importing their own TARGETs (or calling again Conan Magic)

--- a/conans/model/workspace.py
+++ b/conans/model/workspace.py
@@ -240,7 +240,6 @@ class WorkspaceCMake(Workspace):
                 out_dependents[node.ref] = pkg
                 ordered_packages.append((node.ref, pkg))
 
-
         # Warn for package not in workspace but depending on packages in the workspace
         if out_dependents:
             output.warn("Packages '{}' are not included in the workspace and depend on"

--- a/conans/model/workspace.py
+++ b/conans/model/workspace.py
@@ -234,12 +234,13 @@ class WorkspaceCMake(Workspace):
         save(os.path.join(install_folder, 'CMakeLists.txt'), content)
 
         # Create the conanbuildinfo.cmake (no dependencies)
-        # TODO: Silent output here (it will confuse the users)
+        # TODO: Silent output here (it could confuse the users)
         manager.install([], manifest_folder=False, install_folder=install_folder,
                         build_modes=["never"], generators=["cmake", ], **kwargs)
 
         # Create findXXX files for consumed packages
         if out_consumed:
+            # TODO: Silent output here?
             manager.install([it for it in out_consumed],
                             manifest_folder=False, install_folder=install_folder,
                             build_modes=["never"], generators=["cmake_find_package", ], **kwargs)

--- a/conans/model/workspace.py
+++ b/conans/model/workspace.py
@@ -26,10 +26,11 @@ class LocalPackage(object):
 class Workspace(object):
     default_filename = "conanws.yml"
     name = None
-    packages = {}
+    packages = None
 
     def __init__(self, cache):
         self._cache = cache
+        self.packages = {}
 
     @classmethod
     def create(cls, path, cache):

--- a/conans/model/workspace.py
+++ b/conans/model/workspace.py
@@ -3,62 +3,48 @@ import os
 from collections import OrderedDict
 
 import yaml
+import textwrap
+from jinja2 import Template
 
 from conans.client.graph.graph import RECIPE_EDITABLE
 from conans.errors import ConanException
+from conans.client.graph.printer import print_graph
 from conans.model.editable_layout import get_editable_abs_path, EditableLayout
 from conans.model.ref import ConanFileReference
 from conans.util.files import load, save
+from conans.client.recorder.action_recorder import ActionRecorder
+from conans.client.installer import BinaryInstaller
 
 
 class LocalPackage(object):
-    def __init__(self, base_folder, data, cache, ws_layout, ws_generators, ref):
-        if not data or not data.get("path"):
-            raise ConanException("Workspace editable %s does not define path" % str(ref))
-        self._base_folder = base_folder
-        self._conanfile_folder = data.pop("path", None)  # The folder with the conanfile
-        layout = data.pop("layout", None)
-        if layout:
-            self.layout = get_editable_abs_path(layout, self._base_folder, cache.cache_folder)
-        else:
-            self.layout = ws_layout
 
-        generators = data.pop("generators", None)
-        if isinstance(generators, str):
-            generators = [generators]
-        if generators is None:
-            generators = ws_generators
-        self.generators = generators
+    def __init__(self, ref, path, layout):
+        self._ref = ref
+        self.path = path
+        self.layout = layout
 
-        if data:
-            raise ConanException("Workspace unrecognized fields: %s" % data)
-
-    @property
-    def root_folder(self):
-        return os.path.abspath(os.path.join(self._base_folder, self._conanfile_folder))
+        def layout_path(self, path):
+            return os.path.normpath(os.path.join(os.path.dirname(self.layout), path))
 
 
 class Workspace(object):
     default_filename = "conanws.yml"
+    name = None
+    root_list = None
+    packages = {}
 
-    def __init__(self, path, cache):
+    def __init__(self, cache):
         self._cache = cache
-        self._ws_generator = None
-        self._workspace_packages = OrderedDict()  # {reference: LocalPackage}
 
-        if not os.path.isfile(path):
-            path = os.path.join(path, self.default_filename)
+    def validate(self):
+        # Every package in the root list must be contained in the packages dictionary
+        for ref in self.root_list:
+            if ref not in self.packages:
+                raise ConanException("Package '{}' from root has to be in"
+                                     " editables dict".format(ref))
+        return True
 
-        self._base_folder = os.path.dirname(path)
-        try:
-            content = load(path)
-        except IOError:
-            raise ConanException("Couldn't load workspace file in %s" % path)
-        try:
-            self._loads(content)
-        except Exception as e:
-            raise ConanException("There was an error parsing %s: %s" % (path, str(e)))
-
+    """
     def generate(self, install_folder, graph, output):
         if self._ws_generator == "cmake":
             cmake = ""
@@ -104,48 +90,193 @@ class Workspace(object):
                 cmake += "endmacro()"
             cmake_path = os.path.join(install_folder, "conanworkspace.cmake")
             save(cmake_path, cmake)
+    """
 
-    def get_editable_dict(self):
-        return {ref: {"path": ws_package.root_folder, "layout": ws_package.layout}
-                for ref, ws_package in self._workspace_packages.items()}
+    @classmethod
+    def create(cls, path, cache):
+        # Look for the workspace file
+        if not os.path.isfile(path):
+            path = os.path.join(path, cls.default_filename)
+        base_folder = os.path.dirname(path)
 
-    def __getitem__(self, ref):
-        return self._workspace_packages.get(ref)
+        try:
+            content = load(path)
+            yml = yaml.safe_load(content)
+        except IOError:
+            raise ConanException("Couldn't load workspace file in %s" % path)
+        except Exception as e:
+            raise ConanException("There was an error parsing %s: %s" % (path, str(e)))
 
-    @property
-    def root(self):
-        return self._root
+        ws_generator = yml.pop("workspace_generator", None)
+        if ws_generator == 'cmake':
+            ws = WorkspaceCMake(cache)
+        else:
+            raise ConanException("Generator '{}' not supported for a workspace".format(ws_generator))
 
-    def _loads(self, text):
-        yml = yaml.safe_load(text)
-        self._ws_generator = yml.pop("workspace_generator", None)
-        yml.pop("name", None)
+        ws.name = yml.pop("name", "Conan Workspace")
+
+        # Global parameters, if not defined for each package
         ws_layout = yml.pop("layout", None)
         if ws_layout:
-            ws_layout = get_editable_abs_path(ws_layout, self._base_folder,
-                                              self._cache.cache_folder)
-        generators = yml.pop("generators", None)
-        if isinstance(generators, str):
-            generators = [generators]
+            ws_layout = get_editable_abs_path(ws_layout, base_folder, cache.cache_folder)
 
+        yml.pop("generators", None)  # Not used
+
+        # Root packages
         root_list = yml.pop("root", [])
         if isinstance(root_list, str):
             root_list = root_list.split(",")
+        ws.root_list = [ConanFileReference.loads(s.strip(), validate=True)
+                        for s in root_list if s.strip()]
 
-        self._root = [ConanFileReference.loads(s.strip())
-                      for s in root_list if s.strip()]
-        if not self._root:
-            raise ConanException("Conan workspace needs at least 1 root conanfile")
-
+        # Editable packages
         editables = yml.pop("editables", {})
         for ref, data in editables.items():
-            workspace_package = LocalPackage(self._base_folder, data,
-                                             self._cache, ws_layout, generators, ref)
-            package_name = ConanFileReference.loads(ref)
-            self._workspace_packages[package_name] = workspace_package
-        for package_name in self._root:
-            if package_name not in self._workspace_packages:
-                raise ConanException("Root %s is not defined as editable" % str(package_name))
+            try:
+                layout = data.pop("layout", ws_layout)
+                if layout:
+                    layout = get_editable_abs_path(layout, base_folder, cache.cache_folder)
 
-        if yml:
-            raise ConanException("Workspace unrecognized fields: %s" % yml)
+                data.pop("generators", None)  # Not used
+
+                ref = ConanFileReference.loads(ref, validate=True)
+                path = os.path.normpath(os.path.join(base_folder, data.pop("path")))
+                package = LocalPackage(ref, path, layout)
+                ws.packages[ref] = package
+
+                if data:
+                    raise ConanException("Unrecognized field '{}' for"
+                                         " editable '{}'".format(data.keys(), ref))
+            except KeyError as e:
+                raise ConanException("Field '{}' not found for editable '{}'".format(e, ref))
+
+        ws.validate()
+        return ws
+
+    def _build_graph(self, manager, refs, **kwargs):
+        # Load editable packages:
+        editables = {ref: {"path": ws_package.path, "layout": ws_package.layout}
+                     for ref, ws_package in self.packages.items()}
+        self._cache.editable_packages.override(editables)
+
+        return manager.install(refs, manifest_folder=False, install_folder=None,
+                               build_modes=["never"],
+                               **kwargs)
+
+
+class WorkspaceCMake(Workspace):
+    """ Implements workspaces for a CMake generator """
+
+    conanworkspace_cmake_template = textwrap.dedent(r"""
+        # List of targets involved in the workspace
+        {%- for ref in in_ws %}
+        list(APPEND ws_targets "{{ ref.name }}")
+        {%- endfor %}
+
+        # Override functions to avoid importing existing TARGETs (or calling again Conan Magic)
+        function(conan_basic_setup)
+            message("Ignored call to 'conan_basic_setup'")
+        endfunction()
+        
+        # Do not use find_package for those packages handled within the workspace
+        function(find_package)
+            if(NOT "${ARG0}" IN_LIST ws_targets)
+                # Note.- If it's been already overridden, it will recurse forever
+                message("find_package(${ARG0})")
+                _find_package(${ARGV})
+            else()
+                message("find_package(${ARG0}) ignored, it is a target handled by Conan workspace")
+            endif()
+        endfunction()
+        
+        {# Packages that depend on editable ones: out_dependents #}
+
+        {%- if out_consumed %}
+        # Packages that are consumed by editable ones
+        {%- for pkg in out_consumed %}
+        find_package({{ pkg.name }} REQUIRED)
+        add_library(CONAN_PKG::{{ pkg.name }} ALIAS {{ pkg.name }}) 
+        {%- endfor %}
+        {%- endif %}
+        
+        # Add subdirectories for packages (like it is now) and create aliases
+        {%- for ref, pkg in in_ws.items() %}
+        add_subdirectory("{{ pkg.source_folder }}" "{{ pkg.build_folder }}")
+        add_library({{ ref.name }}::{{ ref.name }} ALIAS {{ ref.name }})
+        add_library(CONAN_PKG::{{ ref.name }} ALIAS {{ ref.name }}) 
+        {% endfor %}
+
+    """)
+
+    cmakelists_template = textwrap.dedent(r"""
+        cmake_minimum_required(VERSION 2.8.12)
+        project({{ ws.name }})
+        
+        include(${CMAKE_CURRENT_BINARY_DIR}/conanbuildinfo.cmake)
+        conan_basic_setup()  # Execute Conan magic
+        
+        include(${CMAKE_CURRENT_BINARY_DIR}/conanworkspace.cmake)
+        
+    """)
+
+    def validate(self):
+        super(WorkspaceCMake, self).validate()
+        for _, pkg in self.packages.items():
+            pass
+
+    def generate(self, install_folder, manager, output, **kwargs):
+        # Add roots and editables, all together
+        roots = list(set(self.root_list + list(self.packages.keys())))
+        graph = self._build_graph(manager, refs=roots, **kwargs)
+
+        # Prepare the context for the templates
+        in_ws = {}  # {ref: {source_folder: X, build_folder: Y}}
+        out_ws = []
+        out_dependents = []
+        for node in graph.ordered_iterate():
+            if node.ref in self.packages:
+                assert node.recipe == RECIPE_EDITABLE, "Not editable in the graph, but in workspace"
+                layout = self._cache.package_layout(node.ref)
+                editable = layout.editable_cpp_info()
+                conanfile = node.conanfile
+
+                source_folder = editable.folder(node.ref, EditableLayout.SOURCE_FOLDER,
+                                                conanfile.settings, conanfile.options)
+                build_folder = editable.folder(node.ref, EditableLayout.BUILD_FOLDER,
+                                               conanfile.settings, conanfile.options)
+
+                in_ws[node.ref] = {'source_folder': self.packages[node.ref].layout_path(source_folder),
+                                   'build_folder': self.packages[node.ref].layout_path(build_folder)}
+            else:
+                out_ws.append(node)
+                if node.ref and any([it.ref in in_ws for it in node.public_closure]):
+                    out_dependents.append(node.ref)
+        out_ws = [it for it in out_ws if it.ref is not None]  # Get rid of the None ref
+
+        # Warn for package not in workspace but depending on packages in the workspace
+        if out_dependents:
+            output.warn("Packages '{}' are not included in the workspace and depend on"
+                        " packages that are included. Binaries for these packages are not"
+                        " going to take into account local changes, you'll need to build"
+                        " them manually".format("', '".join(map(str, out_dependents))))
+
+        # Gather packages not in workspace but consumed by packages in the workspace
+        out_consumed = []
+        for it in out_ws:
+            if any([n.ref in in_ws for n in it.inverse_closure]):
+                out_consumed.append(it.ref)
+
+        # Create the conanworkspace.cmake file
+        t = Template(self.conanworkspace_cmake_template)
+        content = t.render(ws=self, in_ws=in_ws, out_dependents=out_dependents,
+                           out_consumed=out_consumed)
+        save(os.path.join(install_folder, 'conanworkspace.cmake'), content)
+
+        # Create the CMakeLists.txt file
+        t = Template(self.cmakelists_template)
+        content = t.render(ws=self, in_ws=in_ws, out_dependents=out_dependents,
+                           out_consumed=out_consumed)
+        save(os.path.join(install_folder, 'CMakeLists.txt'), content)
+
+
+

--- a/conans/model/workspace.py
+++ b/conans/model/workspace.py
@@ -155,9 +155,9 @@ class WorkspaceCMake(Workspace):
         function(outer_package PKG_NAME FULL_REF)
             set(PKG_SENTINEL "{{install_folder}}/${PKG_NAME}.setinel")
             add_custom_command(OUTPUT ${PKG_SENTINEL}
-                               COMMAND echo "Package ${FULL_REF} not build"
+                               COMMAND echo "Package ${FULL_REF} not built" > ${PKG_SENTINEL}
                                WORKING_DIRECTORY "{{install_folder}}"
-                               COMMENT "Conan install for outter ${PKG_NAME}")
+                               COMMENT "Build ${PKG_NAME} outside workspace")
             add_custom_target(${PKG_NAME} DEPENDS ${PKG_SENTINEL})
         endfunction()
         

--- a/conans/test/functional/workspace/cmake_workspace_test.py
+++ b/conans/test/functional/workspace/cmake_workspace_test.py
@@ -175,7 +175,8 @@ class WSTests(unittest.TestCase):
         t.run_command('cd build && cmake ..'
                       ' -DCMAKE_MODULE_PATH="{}"'
                       ' -DBUILD_SHARED_LIBS:BOOL=TRUE'
-                      ' -DWINDOWS_EXPORT_ALL_SYMBOLS:BOOL=TRUE'.format(t.current_folder))
+                      ' -DWINDOWS_EXPORT_ALL_SYMBOLS:BOOL=TRUE'
+                      ' -DCONAN_CMAKE_POSITION_INDEPENDENT_CODE:BOOL=ON'.format(t.current_folder))
         t.run_command('cd build && cmake --build .')
 
         # Check that it is building shared libs:

--- a/conans/test/functional/workspace/cmake_workspace_test.py
+++ b/conans/test/functional/workspace/cmake_workspace_test.py
@@ -1,0 +1,135 @@
+# coding=utf-8
+
+import os
+import platform
+import unittest
+
+from jinja2 import Template
+import textwrap
+
+from conans.test.functional.workspace.scaffolding.package import Package
+from conans.test.functional.workspace.scaffolding.templates import workspace_yml_template
+from conans.test.utils.test_files import temp_folder
+from conans.test.utils.tools import TestClient
+
+
+class WSTests(unittest.TestCase):
+    """
+        Dependency graph: packages on lower level depends on those in the upper one.
+
+                +------+      +------+
+                | pkgA |      | pkgD |
+                +--+---+      +---+--+
+                   ^              ^
+        +------+   |   +------+   |
+        | pkgB +---+---+ pkgC +---+
+        +--+---+       +---+--+
+           ^               ^
+           |               |
+           |    +------+   |  +------+
+           +----+ pkgE +---+--+ pkgF |
+                +------+      +------+
+                   ^               ^
+                   |               |
+                   |    +------+   |
+                   +----+ pkgG +---+
+                        +------+
+
+    """
+
+    original_output = textwrap.dedent("""\
+        > pkgG_exe: default
+        > pkgG: default
+        \t> pkgE: default
+        \t\t> pkgB: default
+        \t\t\t> pkgA: default
+        \t\t> pkgC: default
+        \t\t\t> pkgA: default
+        \t\t\t> pkgD: default
+        \t> pkgF: default
+        \t\t> pkgC: default
+        \t\t\t> pkgA: default
+        \t\t\t> pkgD: default""")
+
+    @staticmethod
+    def _plain_package(client, pkg, lib_requires=None, add_executable=False):
+        """ Create a package with only one library that links and uses libraries declared
+            in 'lib_requires'. Optionally it adds an executable to the package (the
+            executable will link to the library in the same package)
+        """
+        pkg = Package(name=pkg)
+        pkg_lib = pkg.add_library(name=pkg.name)  # TODO: Include components (@danimtb)
+        if lib_requires:
+            for item in lib_requires:
+                library = item.libraries[0]  # There is only one lib per package (wait for Dani)
+                pkg_lib.add_link_library(library, generator='cmake')
+        if add_executable:
+            exec = pkg.add_executable(name="{}_{}".format(pkg.name, "exe"))
+            exec.add_link_library(pkg_lib)
+        pkg_folder = pkg.render()
+        client.run('create "{}" ws/testing'.format(os.path.join(pkg_folder, 'conanfile.py')))
+        return pkg
+
+    @classmethod
+    def setUpClass(cls):
+        super(WSTests, cls).setUpClass()
+        folder = temp_folder(path_with_spaces=False)
+        cls.base_folder = temp_folder(path_with_spaces=False)
+
+        t = TestClient(current_folder=folder, base_folder=cls.base_folder)
+        cls.libA = cls._plain_package(t, pkg="pkgA")
+        cls.libD = cls._plain_package(t, pkg="pkgD")
+        cls.libB = cls._plain_package(t, pkg="pkgB", lib_requires=[cls.libA, ])
+        cls.libC = cls._plain_package(t, pkg="pkgC", lib_requires=[cls.libA, cls.libD])
+        cls.libE = cls._plain_package(t, pkg="pkgE", lib_requires=[cls.libB, cls.libC])
+        cls.libF = cls._plain_package(t, pkg="pkgF", lib_requires=[cls.libC])
+        cls.libG = cls._plain_package(t, pkg="pkgG", lib_requires=[cls.libE, cls.libF], add_executable=True)
+
+        cls.editables = [cls.libA, cls.libB, cls.libE, cls.libG]
+        cls.affected_by_editables = [cls.libC, cls.libF]
+        cls.inmutable = [cls.libD, ]
+
+    def _reset_cache(self):
+        """ In order to return the cache to the original state, it is only needed to revert
+            the packages affected by the workspace whose binaries are in the cache
+            # TODO: These should be fixed in the future, the cache cannot be poisoned by workspaces
+        """
+        for it in self.affected_by_editables:
+            it.modify_cpp_message("default")
+
+    def run_outside_ws(self):
+        """ This function runs the full project without taking into account the ws,
+            it should only take into account packages in the cache and those in
+            editable mode
+        """
+        t = TestClient(base_folder=self.base_folder)
+        t.save({'conanfile.txt': "[requires]\n{}".format(self.libG.ref)})
+        t.run('install conanfile.txt -g virtualrunenv')
+        exec = self.libG.executables[0]
+        if platform.system() != "Windows":
+            t.run_command("bash -c 'source activate_run.sh && {}'".format(exec.name))
+        else:
+            t.run_command("activate_run.bat && {}.exe".format(exec.name))
+        self.assertMultiLineEqual(str(t.out).strip(), self.original_output.strip())
+
+    def test_created_projects(self):
+        self.run_outside_ws()
+
+    def test_workspace(self):
+        t = TestClient(base_folder=self.base_folder)
+        ws_yml = Template(workspace_yml_template).render(editables=self.editables)
+        t.save({'ws.yml': ws_yml}, clean_first=True)
+        t.run("workspace install ws.yml")
+
+        t.run_command('mkdir build')
+        t.run_command('cd build && cmake .. -DCMAKE_MODULE_PATH="{}"'.format(t.current_folder))
+        t.run_command('cd build && cmake --build .')
+        t.run_command('cd build && ./bin/pkgG_exe')
+        self.assertMultiLineEqual(str(t.out).strip(), self.original_output.strip())
+
+        self.libA.modify_cpp_message("Edited!!!")
+        t.run_command('cd build && cmake --build .')
+        t.run_command('cd build && ./bin/pkgG_exe')
+        print(t.out)
+
+        self.fail("test_workspace")

--- a/conans/test/functional/workspace/cmake_workspace_test.py
+++ b/conans/test/functional/workspace/cmake_workspace_test.py
@@ -138,11 +138,15 @@ class WSTests(unittest.TestCase):
         t.run_command('mkdir build')
         t.run_command('cd build && cmake .. -DCMAKE_MODULE_PATH="{}"'.format(t.current_folder))
         t.run_command('cd build && cmake --build .')
+        self.assertIn("Built target {}".format(self.libC.name), t.out)
+        self.assertIn("Built target {}".format(self.libF.name), t.out)
         t.run_command('cd build && ./bin/pkgG_exe')
         self.assertMultiLineEqual(str(t.out).strip(), self.original_output.strip())
 
         self.libA.modify_cpp_message("Edited!!!")  # It will change value in cpp and in header file
         t.run_command('cd build && cmake --build .')
+        self.assertIn("Built target {}".format(self.libC.name), t.out)
+        self.assertIn("Built target {}".format(self.libF.name), t.out)
         t.run_command('cd build && ./bin/pkgG_exe')
 
         self.assertMultiLineEqual(str(t.out).strip(), textwrap.dedent("""\

--- a/conans/test/functional/workspace/cmake_workspace_test.py
+++ b/conans/test/functional/workspace/cmake_workspace_test.py
@@ -36,6 +36,7 @@ class WSTests(unittest.TestCase):
                         +------+
 
     """
+    maxDiff = None
 
     original_output = textwrap.dedent("""\
         > pkgG_exe: default
@@ -63,7 +64,7 @@ class WSTests(unittest.TestCase):
         \t\t\t> pkgD: default""")
 
     @staticmethod
-    def _plain_package(client, pkg, lib_requires=None, add_executable=False):
+    def _plain_package(client, pkg, lib_requires=None, add_executable=False, shared=False):
         """ Create a package with only one library that links and uses libraries declared
             in 'lib_requires'. Optionally it adds an executable to the package (the
             executable will link to the library in the same package)
@@ -77,6 +78,7 @@ class WSTests(unittest.TestCase):
         if add_executable:
             executable = pkg.add_executable(name="{}_{}".format(pkg.name, "exe"))
             executable.add_link_library(pkg_lib)
+        pkg.shared = shared
         pkg_folder = pkg.render()
         client.run('create "{}" ws/testing'.format(os.path.join(pkg_folder, 'conanfile.py')))
         return pkg
@@ -100,12 +102,12 @@ class WSTests(unittest.TestCase):
         cls.affected_by_editables = [cls.libC, cls.libF]
         cls.inmutable = [cls.libD, ]
 
-    def _reset_cache(self):
-        """ In order to return the cache to the original state, it is only needed to revert
-            the packages affected by the workspace whose binaries are in the cache
-            # TODO: These should be fixed in the future, the cache cannot be poisoned by workspaces
-        """
-        for it in self.affected_by_editables:
+    #def setUp(self):
+    #    self._reset()
+
+    def _reset(self):
+        # Return editable packages to its original state
+        for it in self.editables:
             it.modify_cpp_message("default")
 
     def run_outside_ws(self):
@@ -149,33 +151,90 @@ class WSTests(unittest.TestCase):
         self.assertIn("Built target {}".format(self.libF.name), t.out)
         t.run_command('cd build && ./bin/pkgG_exe')
 
-        self.assertMultiLineEqual(str(t.out).strip(), textwrap.dedent("""\
-            > pkgG_exe: default
-            > pkgG_header: default
-            > pkgG: default
-            \t> pkgE_header: default
-            \t> pkgE: default
-            \t\t> pkgB_header: default
-            \t\t> pkgB: default
-            \t\t\t> pkgA_header: Edited!!!
-            \t\t\t> pkgA: Edited!!!
-            \t\t> pkgC_header: default
-            \t\t> pkgC: default
-            \t\t\t> pkgA_header: default
-            \t\t\t> pkgA: Edited!!!
-            \t\t\t> pkgD_header: default
-            \t\t\t> pkgD: default
-            \t> pkgF_header: default
-            \t> pkgF: default
-            \t\t> pkgC_header: default
-            \t\t> pkgC: default
-            \t\t\t> pkgA_header: default
-            \t\t\t> pkgA: Edited!!!
-            \t\t\t> pkgD_header: default
-            \t\t\t> pkgD: default"""))
-
-        # TODO: The desired output should take into account changes for libraries not in WS
-        # self.assertNotIn("> pkgA_header: default", t.out)
+        # Check the resulting message with the 'Editted!!!'
+        original_output = self.original_output.replace("> pkgA: default",
+                                                       "> pkgA: Edited!!!")
+        # TODO: FIXME, if pkgC is compiled, then all pkgA_header would have the Edited!!! message.
+        original_output = original_output.replace(
+            "\t\t> pkgB: default\n\t\t\t> pkgA_header: default",
+            "\t\t> pkgB: default\n\t\t\t> pkgA_header: Edited!!!")
+        self.assertMultiLineEqual(str(t.out).strip(), original_output)
 
         # And outside the workspace, everything should behave exactly the same
         self.run_outside_ws()
+
+    def test_editables_shared(self):
+        """ All the editable packages are built as shared libs """
+        t = TestClient(base_folder=self.base_folder)
+        ws_yml = Template(workspace_yml_template).render(editables=self.editables)
+        t.save({'ws.yml': ws_yml}, clean_first=True)
+
+        t.run("workspace install ws.yml")
+        t.run_command('mkdir build')
+        t.run_command('cd build && cmake ..'
+                      ' -DCMAKE_MODULE_PATH="{}"'
+                      ' -DBUILD_SHARED_LIBS:BOOL=TRUE'
+                      ' -DWINDOWS_EXPORT_ALL_SYMBOLS:BOOL=TRUE'.format(t.current_folder))
+        t.run_command('cd build && cmake --build .')
+
+        # Check that it is building shared libs:
+        system = platform.system()
+        extension = "dylib" if system == "Darwin" else "so" if system == "Linux" else "dll"
+        self.assertIn("pkgA.{}".format(extension), t.out)
+        self.assertIn("pkgB.{}".format(extension), t.out)
+        self.assertIn("pkgE.{}".format(extension), t.out)
+        self.assertIn("pkgG.{}".format(extension), t.out)
+
+        # And it runs!
+        t.run_command('cd build && ./bin/pkgG_exe')
+
+        # And libraries are shared!
+        original_output = self.original_output
+        for it in self.editables:
+            original_output = original_output.replace("> {n}: default".format(n=it.name),
+                                                      "> {n}: default (shared!)".format(n=it.name))
+        self.assertMultiLineEqual(str(t.out).strip(), original_output.strip())
+
+        # Now, if I edit the libA, as it is a shared library, all will get the edition
+        self.libA.modify_cpp_message("Edited!!!")  # It will change value in cpp and in header file
+        t.run_command('cd build && cmake --build .')
+        self.assertIn("Built target {}".format(self.libC.name), t.out)
+        self.assertIn("Built target {}".format(self.libF.name), t.out)
+        t.run_command('cd build && ./bin/pkgG_exe')
+
+        original_output = original_output.replace("> pkgA: default (shared!)",
+                                                  "> pkgA: Edited!!! (shared!)")
+        # TODO: FIXME, if pkgC is compiled, then all pkgA_header would have the Edited!!! message.
+        original_output = original_output.replace(
+            "\t\t> pkgB: default (shared!)\n\t\t\t> pkgA_header: default",
+            "\t\t> pkgB: default (shared!)\n\t\t\t> pkgA_header: Edited!!!")
+        self.assertMultiLineEqual(str(t.out).strip(), original_output.strip())
+
+        # And outside the workspace, everything should behave exactly the same
+        self.run_outside_ws()
+
+    def test_dependents_shared(self):
+        """ Packages outside the workspace are shared """
+        t = TestClient(base_folder=self.base_folder)
+        ws_yml = Template(workspace_yml_template).render(editables=self.editables)
+        t.save({'ws.yml': ws_yml}, clean_first=True)
+
+        # Build the shared packages (right now we cannot do it using the workspace command)
+        t.run("install {ref} -o {n}:shared=True --build {n}".format(ref=self.libC.ref,
+                                                                    n=self.libC.name))
+        self.assertIn("{}: Forced build from source".format(self.libC.ref), t.out)
+
+        t.run("install {ref} -o {nC}:shared=True -o {n}:shared=True --build {n}"
+              .format(ref=self.libF.ref, n=self.libF.name, nC=self.libC.name))
+        self.assertIn("{}: Forced build from source".format(self.libF.ref), t.out)
+
+        t.run("workspace install ws.yml -o pkgF:shared=True -o pkgC:shared=True")
+        t.run_command('mkdir build')
+        t.run_command('cd build && cmake .. -DCMAKE_MODULE_PATH="{}"'.format(t.current_folder))
+        t.run_command('cd build && cmake --build .')
+
+        # And it runs!
+        t.run_command('cd build && ./bin/pkgG_exe')
+        output_shared = self.original_output.replace("> pkgF: default", "> pkgF: default (shared!)")
+        output_shared = output_shared.replace("> pkgC: default", "> pkgC: default (shared!)")
+        self.assertMultiLineEqual(str(t.out).strip(), output_shared)

--- a/conans/test/functional/workspace/cmake_workspace_test.py
+++ b/conans/test/functional/workspace/cmake_workspace_test.py
@@ -6,6 +6,7 @@ import textwrap
 import unittest
 
 from jinja2 import Template
+from nose.plugins.attrib import attr
 
 from conans.test.functional.workspace.scaffolding.package import Package
 from conans.test.functional.workspace.scaffolding.templates import workspace_yml_template
@@ -13,6 +14,7 @@ from conans.test.utils.test_files import temp_folder
 from conans.test.utils.tools import TestClient
 
 
+@attr("slow")
 class WSTests(unittest.TestCase):
     """
         Dependency graph: packages on lower level depends on those in the upper one.
@@ -86,8 +88,7 @@ class WSTests(unittest.TestCase):
         client.run('create "{}" ws/testing'.format(os.path.join(pkg_folder, 'conanfile.py')))
         return pkg
 
-    @classmethod
-    def setUpClass(cls):
+    def setUp(cls):
         super(WSTests, cls).setUpClass()
         folder = temp_folder(path_with_spaces=False)
         cls.base_folder = temp_folder(path_with_spaces=False)
@@ -109,15 +110,6 @@ class WSTests(unittest.TestCase):
         cls.editables = [cls.libA, cls.libB, cls.libE, cls.libG]
         cls.affected_by_editables = [cls.libC, cls.libF]
         cls.inmutable = [cls.libD, cls.libH]
-
-    def setUp(self):
-        self._reset()
-
-    def _reset(self):
-        # Return editable packages to its original state
-        for it in self.editables:
-            it.modify_cpp_message()
-            it.modify_options()
 
     def run_outside_ws(self):
         """ This function runs the full project without taking into account the ws,
@@ -344,5 +336,3 @@ class WSTests(unittest.TestCase):
         self.assertIn("WARN: {} requirement {} overridden by your conanfile"
                       " to {}".format(newB.ref, newA.ref, self.libA.ref), t.out)
         self.assertIn("{} from user folder - Editable".format(self.libA.ref), t.out)
-
-

--- a/conans/test/functional/workspace/cmake_workspace_test.py
+++ b/conans/test/functional/workspace/cmake_workspace_test.py
@@ -262,7 +262,7 @@ class WSCMakeTests(unittest.TestCase):
         newB = _plain_package(t, pkg="pkgB", lib_requires=[newA, ])
 
         t = TestClient(base_folder=self.base_folder)
-        editables = sorted([self.libA, newB, self.libE, self.libG], key=lambda u: u.name)  # py2 fail
+        editables = [self.libA, newB, self.libE, self.libG]
         ws_yml = Template(workspace_yml_template).render(editables=editables)
         t.save({'ws.yml': ws_yml}, clean_first=True)
         t.run("workspace install ws.yml")

--- a/conans/test/functional/workspace/cmake_workspace_test.py
+++ b/conans/test/functional/workspace/cmake_workspace_test.py
@@ -75,8 +75,8 @@ class WSTests(unittest.TestCase):
                 library = item.libraries[0]  # There is only one lib per package (wait for Dani)
                 pkg_lib.add_link_library(library, generator='cmake')
         if add_executable:
-            exec = pkg.add_executable(name="{}_{}".format(pkg.name, "exe"))
-            exec.add_link_library(pkg_lib)
+            executable = pkg.add_executable(name="{}_{}".format(pkg.name, "exe"))
+            executable.add_link_library(pkg_lib)
         pkg_folder = pkg.render()
         client.run('create "{}" ws/testing'.format(os.path.join(pkg_folder, 'conanfile.py')))
         return pkg

--- a/conans/test/functional/workspace/cmake_workspace_test.py
+++ b/conans/test/functional/workspace/cmake_workspace_test.py
@@ -267,8 +267,10 @@ class WSCMakeTests(unittest.TestCase):
         t.save({'ws.yml': ws_yml}, clean_first=True)
         t.run("workspace install ws.yml")
 
-        self.assertIn("WARN: {} requirement {} overridden by your conanfile"
-                      " to {}".format(newB.ref, newA.ref, self.libA.ref), t.out)
+        import six
+        who = self.libE.ref if six.PY2 else "your conanfile"  # TODO: Make a unittest
+        self.assertIn("WARN: {} requirement {} overridden by {}"
+                      " to {}".format(newB.ref, newA.ref, who, self.libA.ref), t.out)
         self.assertIn("{} from user folder - Editable".format(self.libA.ref), t.out)
 
     @unittest.expectedFailure

--- a/conans/test/functional/workspace/cmake_workspace_test.py
+++ b/conans/test/functional/workspace/cmake_workspace_test.py
@@ -129,8 +129,9 @@ class WSTests(unittest.TestCase):
         self.run_outside_ws()
 
     def test_modify_editable(self):
-        """ If an editable package is modified, then only the changes into cpp work (if ABI compatible)
-            because the linking is done in the root project.
+        """ If an editable package is modified, then only the changes into CPP files
+            will be reflected because the linking is done in the root project (given
+            ABI compatibility).
         """
         t = TestClient(base_folder=self.base_folder)
         ws_yml = Template(workspace_yml_template).render(editables=self.editables)

--- a/conans/test/functional/workspace/cmake_workspace_test.py
+++ b/conans/test/functional/workspace/cmake_workspace_test.py
@@ -176,7 +176,7 @@ class WSTests(unittest.TestCase):
                       ' -DCMAKE_MODULE_PATH="{}"'
                       ' -DBUILD_SHARED_LIBS:BOOL=TRUE'
                       ' -DWINDOWS_EXPORT_ALL_SYMBOLS:BOOL=TRUE'
-                      ' -DCONAN_CMAKE_POSITION_INDEPENDENT_CODE:BOOL=ON'.format(t.current_folder))
+                      ' -DCMAKE_POSITION_INDEPENDENT_CODE:BOOL=ON'.format(t.current_folder))
         t.run_command('cd build && cmake --build .')
 
         # Check that it is building shared libs:

--- a/conans/test/functional/workspace/cmake_workspace_test.py
+++ b/conans/test/functional/workspace/cmake_workspace_test.py
@@ -102,8 +102,8 @@ class WSTests(unittest.TestCase):
         cls.affected_by_editables = [cls.libC, cls.libF]
         cls.inmutable = [cls.libD, ]
 
-    #def setUp(self):
-    #    self._reset()
+    def setUp(self):
+        self._reset()
 
     def _reset(self):
         # Return editable packages to its original state

--- a/conans/test/functional/workspace/cmake_workspace_test.py
+++ b/conans/test/functional/workspace/cmake_workspace_test.py
@@ -116,11 +116,11 @@ class WSTests(unittest.TestCase):
         t = TestClient(base_folder=self.base_folder)
         t.save({'conanfile.txt': "[requires]\n{}".format(self.libG.ref)})
         t.run('install conanfile.txt -g virtualrunenv')
-        exec = self.libG.executables[0]
+        executable = self.libG.executables[0]
         if platform.system() != "Windows":
-            t.run_command("bash -c 'source activate_run.sh && {}'".format(exec.name))
+            t.run_command("bash -c 'source activate_run.sh && {}'".format(executable.name))
         else:
-            t.run_command("activate_run.bat && {}.exe".format(exec.name))
+            t.run_command("activate_run.bat && {}.exe".format(executable.name))
         self.assertMultiLineEqual(str(t.out).strip(), self.original_output.strip())
 
     def test_created_projects(self):

--- a/conans/test/functional/workspace/cmake_workspace_test.py
+++ b/conans/test/functional/workspace/cmake_workspace_test.py
@@ -176,8 +176,8 @@ class WSTests(unittest.TestCase):
                       ' -DCMAKE_MODULE_PATH="{}"'
                       ' -DBUILD_SHARED_LIBS:BOOL=TRUE'
                       ' -DWINDOWS_EXPORT_ALL_SYMBOLS:BOOL=TRUE'
-                      ' -DCMAKE_POSITION_INDEPENDENT_CODE:BOOL=ON'.format(t.current_folder))
-        t.run_command('cd build && cmake --build .')
+                      ' -DCONAN_CMAKE_POSITION_INDEPENDENT_CODE:BOOL=ON'.format(t.current_folder))
+        t.run_command('cd build && cmake --build .')  # TODO: Might need  --clean-first, but better if we control where the ws/build directories are placed.
 
         # Check that it is building shared libs:
         system = platform.system()

--- a/conans/test/functional/workspace/cmake_workspace_test.py
+++ b/conans/test/functional/workspace/cmake_workspace_test.py
@@ -262,7 +262,7 @@ class WSCMakeTests(unittest.TestCase):
         newB = _plain_package(t, pkg="pkgB", lib_requires=[newA, ])
 
         t = TestClient(base_folder=self.base_folder)
-        editables = [self.libA, newB, self.libE, self.libG]
+        editables = sorted([self.libA, newB, self.libE, self.libG], key=lambda u: u.name)  # py2 fail
         ws_yml = Template(workspace_yml_template).render(editables=editables)
         t.save({'ws.yml': ws_yml}, clean_first=True)
         t.run("workspace install ws.yml")

--- a/conans/test/functional/workspace/parse_test.py
+++ b/conans/test/functional/workspace/parse_test.py
@@ -1,0 +1,77 @@
+# coding=utf-8
+
+import os
+import unittest
+from textwrap import dedent
+
+import six
+
+from conans.errors import ConanException
+from conans.model.workspace import Workspace
+from conans.test.utils.test_files import temp_folder
+from conans.util.files import save
+
+
+class ParseTestSuite(unittest.TestCase):
+
+    def _parse_ws_file(self, content):
+        path = os.path.join(temp_folder(), "filename.yml")
+        save(path, content)
+        Workspace.create(path, cache=None)
+
+    def test_root_not_editable(self):
+        project = dedent("""
+                    workspace_generator: cmake
+                    root: Hellob/0.1@lasote/stable
+                    """)
+        with six.assertRaisesRegex(self, ConanException,
+                                   "Root Hellob/0.1@lasote/stable is not defined as editable"):
+            self._parse_ws_file(project)
+
+    def test_unkonwn_fields_editable(self):
+        project = dedent("""
+                    editables:
+                        HelloB/0.1@lasote/stable:
+                            path: B
+                            random: something
+                    workspace_generator: cmake
+                    root: HelloB/0.1@lasote/stable
+                    """)
+        with six.assertRaisesRegex(self, ConanException, "Unrecognized fields 'random' for"
+                                                         " editable 'HelloB/0.1@lasote/stable'"):
+            self._parse_ws_file(project)
+
+    def test_unknown_fields(self):
+        project = dedent("""
+            editables:
+                HelloB/0.1@lasote/stable:
+                    path: B
+            workspace_generator: cmake
+            root: HelloB/0.1@lasote/stable
+            random: something
+            """)
+        with six.assertRaisesRegex(self, ConanException, "Unrecognized fields 'random'"):
+            self._parse_ws_file(project)
+
+    def test_no_fields(self):
+        project = dedent("""
+            editables:
+                HelloB/0.1@lasote/stable:
+            workspace_generator: cmake
+            root: HelloB/0.1@lasote/stable
+            """)
+        with six.assertRaisesRegex(self, ConanException, "Editable 'HelloB/0.1@lasote/stable'"
+                                                         " doesn't define field 'path'"):
+            self._parse_ws_file(project)
+
+    def test_no_path_field(self):
+        project = dedent("""
+            editables:
+                HelloB/0.1@lasote/stable:
+                    layout: layout
+            workspace_generator: cmake
+            root: HelloB/0.1@lasote/stable
+            """)
+        with six.assertRaisesRegex(self, ConanException, "Editable 'HelloB/0.1@lasote/stable'"
+                                                         " doesn't define field 'path'"):
+            self._parse_ws_file(project)

--- a/conans/test/functional/workspace/parse_test.py
+++ b/conans/test/functional/workspace/parse_test.py
@@ -2,6 +2,7 @@
 
 import os
 import unittest
+from collections import namedtuple
 from textwrap import dedent
 
 import six
@@ -11,22 +12,20 @@ from conans.model.workspace import Workspace
 from conans.test.utils.test_files import temp_folder
 from conans.util.files import save
 
+MockCache = namedtuple("MockCache", ["cache_folder", ])
+
 
 class ParseTestSuite(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        cls.default_layout = os.path.join(temp_folder(), "default")
+        save(cls.default_layout, "")
 
     def _parse_ws_file(self, content):
         path = os.path.join(temp_folder(), "filename.yml")
         save(path, content)
-        Workspace.create(path, cache=None)
-
-    def test_root_not_editable(self):
-        project = dedent("""
-                    workspace_generator: cmake
-                    root: Hellob/0.1@lasote/stable
-                    """)
-        with six.assertRaisesRegex(self, ConanException,
-                                   "Root Hellob/0.1@lasote/stable is not defined as editable"):
-            self._parse_ws_file(project)
+        Workspace.create(path, cache=MockCache(cache_folder="."))
 
     def test_unkonwn_fields_editable(self):
         project = dedent("""
@@ -34,9 +33,10 @@ class ParseTestSuite(unittest.TestCase):
                         HelloB/0.1@lasote/stable:
                             path: B
                             random: something
+                    layout: {}
                     workspace_generator: cmake
                     root: HelloB/0.1@lasote/stable
-                    """)
+                    """.format(self.default_layout))
         with six.assertRaisesRegex(self, ConanException, "Unrecognized fields 'random' for"
                                                          " editable 'HelloB/0.1@lasote/stable'"):
             self._parse_ws_file(project)
@@ -46,10 +46,11 @@ class ParseTestSuite(unittest.TestCase):
             editables:
                 HelloB/0.1@lasote/stable:
                     path: B
+            layout: {}
             workspace_generator: cmake
             root: HelloB/0.1@lasote/stable
             random: something
-            """)
+            """.format(self.default_layout))
         with six.assertRaisesRegex(self, ConanException, "Unrecognized fields 'random'"):
             self._parse_ws_file(project)
 
@@ -57,9 +58,10 @@ class ParseTestSuite(unittest.TestCase):
         project = dedent("""
             editables:
                 HelloB/0.1@lasote/stable:
+            layout: {}
             workspace_generator: cmake
             root: HelloB/0.1@lasote/stable
-            """)
+            """.format(self.default_layout))
         with six.assertRaisesRegex(self, ConanException, "Editable 'HelloB/0.1@lasote/stable'"
                                                          " doesn't define field 'path'"):
             self._parse_ws_file(project)

--- a/conans/test/functional/workspace/scaffolding/package.py
+++ b/conans/test/functional/workspace/scaffolding/package.py
@@ -8,6 +8,7 @@ from jinja2 import Template
 from conans.test.functional.workspace.scaffolding.templates import conanfile_template, \
     cmakelists_template, lib_cpp_template, lib_h_template, main_cpp_template, layout_template
 from conans.test.utils.test_files import temp_folder
+from conans.util.files import mkdir
 
 
 class _Library:
@@ -116,7 +117,7 @@ class Package:
 
     def render(self, output_folder=None):
         self._directory = output_folder or os.path.join(temp_folder(False), self.name)
-        os.makedirs(self._directory)
+        mkdir(self._directory)
         self._render_template(conanfile_template,
                               os.path.join(self._directory, 'conanfile.py'),
                               package=self)
@@ -126,7 +127,7 @@ class Package:
         self._render_template(layout_template, self.layout_file, package=self)
         for library in self._libraries:
             library_dir = os.path.join(self._directory, library.name)
-            os.makedirs(library_dir)
+            mkdir(library_dir)
             self._render_template(lib_h_template,
                                   os.path.join(library_dir, 'lib.h'),
                                   package=self, library=library)
@@ -135,7 +136,7 @@ class Package:
                                   package=self, library=library)
         for executable in self._executables:
             executable_dir = os.path.join(self._directory, executable.name)
-            os.makedirs(executable_dir, exist_ok=True)
+            mkdir(executable_dir)
             self._render_template(main_cpp_template,
                                   os.path.join(executable_dir, 'main.cpp'),
                                   package=self, executable=executable)

--- a/conans/test/functional/workspace/scaffolding/package.py
+++ b/conans/test/functional/workspace/scaffolding/package.py
@@ -115,6 +115,12 @@ class Package:
                                   os.path.join(library_dir, 'lib.cpp'),
                                   package=self, library=library, message=message)
 
+    def modify_options(self, shared=False):
+        self.shared = shared
+        self._render_template(conanfile_template,
+                              os.path.join(self._directory, 'conanfile.py'),
+                              package=self)
+
     def render(self, output_folder=None):
         self._directory = output_folder or os.path.join(temp_folder(False), self.name)
         mkdir(self._directory)

--- a/conans/test/functional/workspace/scaffolding/package.py
+++ b/conans/test/functional/workspace/scaffolding/package.py
@@ -1,0 +1,167 @@
+# coding=utf-8
+
+import os
+from collections import namedtuple, defaultdict
+
+from jinja2 import Template
+
+from conans.test.functional.workspace.scaffolding.templates import conanfile_template, \
+    cmakelists_template, lib_cpp_template, lib_h_template, main_cpp_template, layout_template
+from conans.test.utils.test_files import temp_folder
+
+
+class _Library:
+    Requirement = namedtuple("Requirement", ["name", "target"])
+
+    def __init__(self, name, package):
+        self.package = package
+        self.name = name
+        self.target = name
+        self._requires = set()
+
+    def add_link_library(self, other, generator=None):
+        assert isinstance(other, _Library), "type(other)={}".format(type(other))
+        if other.package == self.package:
+            # Generator makes no sense for the same package, it always be the naked target
+            self._requires.add(self.Requirement(other.name, other.target))
+        else:
+            if generator == 'cmake':
+                self._requires.add(self.Requirement(other.name, "CONAN_PKG::{}".format(other.package.name)))
+            elif generator == 'cmake_find_packages':
+                self._requires.add(
+                    self.Requirement(other.name, "{pkg}::{pkg}".format(pkg=other.package.name)))
+            else:
+                raise RuntimeError("Generator '{}' not expected".format(generator))
+            self.package._add_requires(other.package, generator=generator)
+
+    def __str__(self):
+        return self.name
+
+    @property
+    def requires(self):
+        return sorted(self._requires, key=lambda u: u.name)
+
+
+class Package:
+    def __init__(self, name, version="0.1", user="ws", channel="testing"):
+        self.name = name
+        self.version = version
+        self.user = user
+        self.channel = channel
+        self._requires = set()
+        self._libraries = []
+        self._executables = []
+        self.shared = False
+
+        self.generators = defaultdict(set)
+
+        self._directory = None
+
+    @property
+    def local_path(self):
+        return self._directory
+
+    @property
+    def ref(self):
+        return "{}/{}@{}/{}".format(self.name, self.version, self.user, self.channel)
+
+    @property
+    def requires(self):
+        return sorted(self._requires, key=lambda u: u.name)
+
+    @property
+    def libraries(self):
+        return sorted(self._libraries, key=lambda u: u.name)
+
+    @property
+    def executables(self):
+        return sorted(self._executables, key=lambda u: u.name)
+
+    @property
+    def layout_file(self):
+        return os.path.join(self.local_path, 'layout')
+
+    def add_library(self, **data):
+        lib = _Library(package=self, **data)
+        self._libraries.append(lib)
+        return lib
+
+    def add_executable(self, **data):
+        exe = _Library(package=self, **data)
+        self._executables.append(exe)
+        return exe
+
+    def _add_requires(self, requirement, generator):
+        assert isinstance(requirement, Package), "type(requirement)={}".format(type(requirement))
+        self._requires.add(requirement)
+        self.generators[generator].add(requirement)
+
+    @staticmethod
+    def _render_template(template_content, output_filename, **context):
+        t = Template(template_content)
+        output = t.render(**context)
+        with open(output_filename, 'w') as f:
+            f.write(output)
+        return output_filename
+
+    def modify_cpp_message(self, message=None):
+        for library in self._libraries:
+            library_dir = os.path.join(self._directory, library.name)
+            self._render_template(lib_cpp_template,
+                                  os.path.join(library_dir, 'lib.cpp'),
+                                  package=self, library=library, message=message)
+
+    def render(self, output_folder=None):
+        self._directory = output_folder or os.path.join(temp_folder(False), self.name)
+        os.makedirs(self._directory)
+        self._render_template(conanfile_template,
+                              os.path.join(self._directory, 'conanfile.py'),
+                              package=self)
+        self._render_template(cmakelists_template,
+                              os.path.join(self._directory, 'CMakeLists.txt'),
+                              package=self)
+        self._render_template(layout_template, self.layout_file, package=self)
+        for library in self._libraries:
+            library_dir = os.path.join(self._directory, library.name)
+            os.makedirs(library_dir)
+            self._render_template(lib_h_template,
+                                  os.path.join(library_dir, 'lib.h'),
+                                  package=self, library=library)
+            self._render_template(lib_cpp_template,
+                                  os.path.join(library_dir, 'lib.cpp'),
+                                  package=self, library=library)
+        for executable in self._executables:
+            executable_dir = os.path.join(self._directory, executable.name)
+            os.makedirs(executable_dir, exist_ok=True)
+            self._render_template(main_cpp_template,
+                                  os.path.join(executable_dir, 'main.cpp'),
+                                  package=self, executable=executable)
+        return self._directory
+
+
+if __name__ == "__main__":
+    # Clean output folder
+    import shutil
+    me = os.path.dirname(__file__)
+    output_folder = os.path.join(me, "_tmp")
+    if os.path.exists(output_folder):
+        shutil.rmtree(output_folder)
+    os.makedirs(output_folder)
+
+    # Package 1
+    pkg1 = Package(name="pkg1")
+    lib1 = pkg1.add_library(name="lib1")
+    lib2 = pkg1.add_library(name="lib2")
+    lib2.add_link_library(lib1)
+    exe1 = pkg1.add_executable(name="exe1")
+    exe1.add_link_library(lib1)
+    pkg1.render(os.path.join(output_folder, pkg1.name))
+
+    # Package 2
+    pkg2 = Package(name="pkg2")
+    pkg2_lib1 = pkg2.add_library(name="pkg2_lib1")
+    pkg2_lib1.add_link_library(lib1, generator='cmake')
+    pkg2_exe1 = pkg2.add_executable(name="pkg2_exe1")
+    pkg2_exe1.add_link_library(pkg2_lib1)
+    pkg2.render(os.path.join(output_folder, pkg2.name))
+

--- a/conans/test/functional/workspace/scaffolding/package.py
+++ b/conans/test/functional/workspace/scaffolding/package.py
@@ -107,6 +107,9 @@ class Package:
     def modify_cpp_message(self, message=None):
         for library in self._libraries:
             library_dir = os.path.join(self._directory, library.name)
+            self._render_template(lib_h_template,
+                                  os.path.join(library_dir, 'lib.h'),
+                                  package=self, library=library, message=message)
             self._render_template(lib_cpp_template,
                                   os.path.join(library_dir, 'lib.cpp'),
                                   package=self, library=library, message=message)

--- a/conans/test/functional/workspace/scaffolding/package.py
+++ b/conans/test/functional/workspace/scaffolding/package.py
@@ -42,6 +42,10 @@ class _Library:
     def requires(self):
         return sorted(self._requires, key=lambda u: u.name)
 
+    def path_to_exec(self):
+        # Get build folder from the layout
+        return os.path.join(self.package.local_path, 'build', self.name)
+
 
 class Package:
     def __init__(self, name, version="0.1", user="ws", channel="testing"):

--- a/conans/test/functional/workspace/scaffolding/package.py
+++ b/conans/test/functional/workspace/scaffolding/package.py
@@ -59,6 +59,7 @@ class Package:
         self.shared = False
 
         self.generators = defaultdict(set)
+        self.generators['cmake'] = set()  # Need to apply Conan magic to every package (handle fPIC)
 
         self._directory = None
 

--- a/conans/test/functional/workspace/scaffolding/package.py
+++ b/conans/test/functional/workspace/scaffolding/package.py
@@ -110,14 +110,18 @@ class Package:
         return output_filename
 
     def modify_cpp_message(self, message=None):
+        context = {'package': self}
+        if message:
+            context["message"] = message
+
         for library in self._libraries:
             library_dir = os.path.join(self._directory, library.name)
             self._render_template(lib_h_template,
                                   os.path.join(library_dir, 'lib.h'),
-                                  package=self, library=library, message=message)
+                                  library=library, **context)
             self._render_template(lib_cpp_template,
                                   os.path.join(library_dir, 'lib.cpp'),
-                                  package=self, library=library, message=message)
+                                  library=library, **context)
 
     def modify_options(self, shared=False):
         self.shared = shared

--- a/conans/test/functional/workspace/scaffolding/templates.py
+++ b/conans/test/functional/workspace/scaffolding/templates.py
@@ -4,6 +4,9 @@ import textwrap
 
 # At package level
 cmakelists_template = textwrap.dedent(r"""
+    set(CMAKE_CXX_COMPILER_WORKS 1)
+    set(CMAKE_CXX_ABI_COMPILED 1)
+
     cmake_minimum_required(VERSION {{cmake_minimum_version|default("3.10")}})
     project({{package.name}} LANGUAGES CXX)
 

--- a/conans/test/functional/workspace/scaffolding/templates.py
+++ b/conans/test/functional/workspace/scaffolding/templates.py
@@ -42,13 +42,17 @@ conanfile_template = textwrap.dedent(r"""
         name = "{{ package.name }}"
         version = "{{ package.version }}"
         settings = "os", "arch", "compiler", "build_type"
-        options = {"shared": [True, False]}
-        default_options = {"shared": {{"True" if package.shared else "False"}}}
+        options = {"shared": [True, False], "fPIC": [True, False]}
+        default_options = {"shared": {{"True" if package.shared else "False"}}, "fPIC": True}
         exports = "*"
 
         {% if package.generators %}
         generators = "{{package.generators.keys()|join('", "')}}"
         {% endif %}
+
+        def configure(self):
+            if self.settings.compiler == 'Visual Studio':
+                del self.options.fPIC
 
         def requirements(self):
             {%- for require in package.requires %}

--- a/conans/test/functional/workspace/scaffolding/templates.py
+++ b/conans/test/functional/workspace/scaffolding/templates.py
@@ -12,7 +12,7 @@ cmakelists_template = textwrap.dedent(r"""
     find_package(item.name REQUIRED)
     {% endfor %}
     {% endif %}
-
+    
     {% if 'cmake' in package.generators %}
     include(${CMAKE_CURRENT_BINARY_DIR}/conanbuildinfo.cmake)
     conan_basic_setup({% if use_targets|default(True) %}TARGETS{% endif %})
@@ -88,7 +88,11 @@ lib_cpp_template = textwrap.dedent(r"""
     {% endfor %}
 
     void {{library.name}}(int tabs) {
-        std::cout << std::string(tabs, '\t') << "> {{library.name}}: {{ message|default("default") }}" << std::endl;
+        #ifdef {{library.name}}_EXPORTS
+            std::cout << std::string(tabs, '\t') << "> {{library.name}}: {{ message|default("default") }} (shared!)" << std::endl;
+        #else
+            std::cout << std::string(tabs, '\t') << "> {{library.name}}: {{ message|default("default") }}" << std::endl;
+        #endif
         {% for require in library.requires %}
         {{require.name}}_header(tabs+1);
         {{require.name}}(tabs+1);

--- a/conans/test/functional/workspace/scaffolding/templates.py
+++ b/conans/test/functional/workspace/scaffolding/templates.py
@@ -138,7 +138,7 @@ layout_template = textwrap.dedent(r"""
     .
 
     [build_folder]
-    .
+    build/
 
     [includedirs]
     .

--- a/conans/test/functional/workspace/scaffolding/templates.py
+++ b/conans/test/functional/workspace/scaffolding/templates.py
@@ -19,7 +19,7 @@ cmakelists_template = textwrap.dedent(r"""
     {% endif %}
 
     {% for library in package.libraries %}
-    add_library({{library.target}} {{library.name}}/lib.cpp)
+    add_library({{library.target}} {{library.name}}/lib.cpp {{library.name}}/lib.h)
     target_include_directories({{library.target}}
         PUBLIC
             $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>)
@@ -82,7 +82,6 @@ conanfile_template = textwrap.dedent(r"""
 # For each library/component inside a package
 lib_cpp_template = textwrap.dedent(r"""
     #include "{{library.name}}/lib.h"
-    #include <iostream>
 
     {% for require in library.requires %}
     #include "{{require.name}}/lib.h"
@@ -91,6 +90,7 @@ lib_cpp_template = textwrap.dedent(r"""
     void {{library.name}}(int tabs) {
         std::cout << std::string(tabs, '\t') << "> {{library.name}}: {{ message|default("default") }}" << std::endl;
         {% for require in library.requires %}
+        {{require.name}}_header(tabs+1);
         {{require.name}}(tabs+1);
         {% endfor %}
     }
@@ -98,8 +98,14 @@ lib_cpp_template = textwrap.dedent(r"""
 
 lib_h_template = textwrap.dedent(r"""
     #pragma once
+    
+    #include <iostream>
 
     void {{library.name}}(int tabs);
+    
+    static void {{library.name}}_header(int tabs) {
+        std::cout << std::string(tabs, '\t') << "> {{library.name}}_header: {{ message|default("default") }}" << std::endl;
+    }
 """)
 
 main_cpp_template = textwrap.dedent(r"""
@@ -112,6 +118,7 @@ main_cpp_template = textwrap.dedent(r"""
     int main() {
         std::cout << "> {{executable.name}}: {{ message|default("default") }}" << std::endl;
         {% for require in executable.requires %}
+        {{require.name}}_header(0);
         {{require.name}}(0);
         {% endfor %}
     }

--- a/conans/test/functional/workspace/scaffolding/templates.py
+++ b/conans/test/functional/workspace/scaffolding/templates.py
@@ -1,0 +1,140 @@
+# coding=utf-8
+
+import textwrap
+
+# At package level
+cmakelists_template = textwrap.dedent(r"""
+    cmake_minimum_required(VERSION {{cmake_minimum_version|default("3.10")}})
+    project({{package.name}} LANGUAGES CXX)
+
+    {% if 'cmake_find_package' in package.generators %}
+    {% for item in package.generators["cmake_find_package"] %}
+    find_package(item.name REQUIRED)
+    {% endfor %}
+    {% endif %}
+
+    {% if 'cmake' in package.generators %}
+    include(${CMAKE_CURRENT_BINARY_DIR}/conanbuildinfo.cmake)
+    conan_basic_setup({% if use_targets|default(True) %}TARGETS{% endif %})
+    {% endif %}
+
+    {% for library in package.libraries %}
+    add_library({{library.target}} {{library.name}}/lib.cpp)
+    target_include_directories({{library.target}}
+        PUBLIC
+            $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>)
+    {% if library.requires %}target_link_libraries({{library.target}} PUBLIC {% for r in library.requires %}{{r.target}} {% endfor %}){% endif%}
+    set_target_properties({{library.target}} PROPERTIES OUTPUT_NAME {{library.name}})
+    {% endfor %}
+
+    {% for executable in package.executables %}
+    add_executable({{executable.name}} {{executable.name}}/main.cpp)
+    {% if executable.requires %}target_link_libraries({{executable.target}} PUBLIC {% for r in executable.requires %}{{r.target}} {% endfor %}){% endif%}
+    set_target_properties({{executable.target}} PROPERTIES OUTPUT_NAME {{executable.name}})
+    {% endfor %}
+""")
+
+conanfile_template = textwrap.dedent(r"""
+    import os
+    from conans import ConanFile, CMake
+
+    class {{package.name}}(ConanFile):
+        name = "{{ package.name }}"
+        version = "{{ package.version }}"
+        settings = "os", "arch", "compiler", "build_type"
+        options = {"shared": [True, False]}
+        default_options = {"shared": {{"True" if package.shared else "False"}}}
+        exports = "*"
+
+        {% if package.generators %}
+        generators = "{{package.generators.keys()|join('", "')}}"
+        {% endif %}
+
+        def requirements(self):
+            {%- for require in package.requires %}
+            self.requires("{{require.ref}}")
+            {%- endfor %}
+            pass
+
+        def build(self):
+            cmake = CMake(self)
+            cmake.configure()
+            cmake.build()
+
+        def package(self):
+            self.copy("*.h", dst="include", keep_path=True)
+            self.copy("*.lib", dst="lib", keep_path=False)
+            self.copy("*.dll", dst="bin", keep_path=False)
+            self.copy("*.so", dst="lib", keep_path=False)
+            self.copy("*.dylib", dst="lib", keep_path=False)
+            self.copy("*.a", dst="lib", keep_path=False)
+            {%- for exec in package.executables %}
+            self.copy("{{ exec.name }}", src="bin", dst="bin", keep_path=False)
+            {%- endfor %}
+
+        def package_info(self):
+            self.cpp_info.libs = ["{{package.libraries|join('", "')}}"]
+            {%- if package.executables %}
+            self.env_info.PATH.append(os.path.join(self.package_folder, "bin"))
+            {%- endif %}
+""")
+
+# For each library/component inside a package
+lib_cpp_template = textwrap.dedent(r"""
+    #include "{{library.name}}/lib.h"
+    #include <iostream>
+
+    {% for require in library.requires %}
+    #include "{{require.name}}/lib.h"
+    {% endfor %}
+
+    void {{library.name}}(int tabs) {
+        std::cout << std::string(tabs, '\t') << "> {{library.name}}: {{ message|default("default") }}" << std::endl;
+        {% for require in library.requires %}
+        {{require.name}}(tabs+1);
+        {% endfor %}
+    }
+""")
+
+lib_h_template = textwrap.dedent(r"""
+    #pragma once
+
+    void {{library.name}}(int tabs);
+""")
+
+main_cpp_template = textwrap.dedent(r"""
+    #include <iostream>
+
+    {% for require in executable.requires %}
+    #include "{{require.name}}/lib.h"
+    {% endfor %}
+
+    int main() {
+        std::cout << "> {{executable.name}}: {{ message|default("default") }}" << std::endl;
+        {% for require in executable.requires %}
+        {{require.name}}(0);
+        {% endfor %}
+    }
+""")
+
+# Related to WORKSPACES
+layout_template = textwrap.dedent(r"""
+    [source_folder]
+    .
+
+    [build_folder]
+    .
+
+    [includedirs]
+    .
+""")
+
+workspace_yml_template = textwrap.dedent(r"""
+    editables:
+        {%- for editable in editables %}
+        {{editable.ref}}:
+            path: {{ editable.local_path }}
+            layout: {{ editable.layout_file }}            
+        {%- endfor %}
+    workspace_generator: cmake
+""")

--- a/conans/test/functional/workspace/workspace_test.py
+++ b/conans/test/functional/workspace/workspace_test.py
@@ -231,11 +231,13 @@ class WorkspaceTest(unittest.TestCase):
                     path: D
                 HelloC/0.1@lasote/stable:
                     path: C
+                    layout: layout
             workspace_generator: cmake
             root: HelloC/0.1@lasote/stable
             """)
 
-        client.save({"conanws.yml": project})
+        client.save({"conanws.yml": project,
+                     "layout": ""})
         client.run("workspace install conanws.yml", assert_error=True)
         self.assertIn("No layout defined for editable 'HelloD/0.1@lasote/stable' and cannot"
                       " find the default one neither", client.out)

--- a/conans/test/functional/workspace/workspace_test.py
+++ b/conans/test/functional/workspace/workspace_test.py
@@ -69,15 +69,6 @@ add_library(hello{name} hello.cpp)
 conan_target_link_libraries(hello{name})
 """
 
-cmake_targets = """set(CMAKE_CXX_COMPILER_WORKS 1)
-project(Hello CXX)
-cmake_minimum_required(VERSION 2.8.12)
-include(${{CMAKE_CURRENT_BINARY_DIR}}/conanbuildinfo.cmake)
-conan_basic_setup(TARGETS)
-add_library(hello{name} hello.cpp)
-target_link_libraries(hello{name} {dep})
-"""
-
 
 class WorkspaceTest(unittest.TestCase):
 

--- a/conans/test/functional/workspace/workspace_test.py
+++ b/conans/test/functional/workspace/workspace_test.py
@@ -1,18 +1,15 @@
 import os
 import platform
-import time
 import unittest
 from textwrap import dedent
 
-import six
 from parameterized.parameterized import parameterized
 
 from conans.client import tools
-from conans.errors import ConanException
 from conans.model.workspace import Workspace
 from conans.test.utils.test_files import temp_folder
 from conans.test.utils.tools import TestClient
-from conans.util.files import load, save
+from conans.util.files import load
 
 conanfile_build = """from conans import ConanFile, CMake
 class Pkg(ConanFile):


### PR DESCRIPTION
Changelog: (Feature | Fix | Bugfix): Describe here your pull request
Docs: https://github.com/conan-io/docs/pull/XXXX

Related to #5291 (close?) and #4879 (superseedes)

This PR implements a new approach of workspaces: packages declared inside the `conanws.yml` file are consumed using CMake targets (see (1) in the TODO list), and packages that depend on any of these are declared as `custom_targets` (only a sentinel at this moment, see (2) in the TODO list). CMake models all the dependencies between these projects and triggers the build of the projects that are affected by any change.

### Graph used in the tests:

![image](https://user-images.githubusercontent.com/1406456/59367972-7a8b9400-8d3d-11e9-9b1e-cdf10e849e3d.png)

In this implementation, we can distinguish three categories for packages:
 1. packages included in the workspace, those declared as editable in the `conanws.yml`: `pkgA`, `pkgB`, `pkgE` and `pkgG`
 2. packages not included in the workspace, and without any dependency to packages included in the workspace: `pkgH`, `pkgD`
 3. packages not included in the workspace that depend on packages included in the workspace: `pkgC` and `pkgF`

### Workspace creation

We need the `conanws.yml` file:

```yaml
editables:
    pkgA/0.1@ws/testing:
        path: /private/var/folders/yq/14hmvxm96xd7gfgl37_tnrbh0000gn/T/tmp2n7z7h55conans/pathwithoutspaces/pkgA
        layout: /private/var/folders/yq/14hmvxm96xd7gfgl37_tnrbh0000gn/T/tmp2n7z7h55conans/pathwithoutspaces/pkgA/layout
    pkgB/0.1@ws/testing:
        path: /private/var/folders/yq/14hmvxm96xd7gfgl37_tnrbh0000gn/T/tmpi2uxtn3cconans/pathwithoutspaces/pkgB
        layout: /private/var/folders/yq/14hmvxm96xd7gfgl37_tnrbh0000gn/T/tmpi2uxtn3cconans/pathwithoutspaces/pkgB/layout
    pkgE/0.1@ws/testing:
        path: /private/var/folders/yq/14hmvxm96xd7gfgl37_tnrbh0000gn/T/tmphy2up924conans/pathwithoutspaces/pkgE
        layout: /private/var/folders/yq/14hmvxm96xd7gfgl37_tnrbh0000gn/T/tmphy2up924conans/pathwithoutspaces/pkgE/layout
    pkgG/0.1@ws/testing:
        path: /private/var/folders/yq/14hmvxm96xd7gfgl37_tnrbh0000gn/T/tmp833gi6xhconans/pathwithoutspaces/pkgG
        layout: /private/var/folders/yq/14hmvxm96xd7gfgl37_tnrbh0000gn/T/tmp833gi6xhconans/pathwithoutspaces/pkgG/layout
workspace_generator: cmake
```

Comments about the fields:
 * we don't need the `root`s, all the editables will be included as roots so we get sure they override any existing dependency upstreams. **This solves the issue of the version ranges**.
 * `workspace_generator`: currently only `cmake`, but in the future it should accept `visual_studio` too.
 * There is no need for generators associated to the _editables_, the generators needed for each package should be already in its recipe.
 * All of the _editables_ can use the same layout file, as it was done before.

### Generated files (CMake)

#### CMakeLists.txt
I'm generating the `CMakeLists.txt` file:

```cmake
cmake_minimum_required(VERSION 3.3)
project("Conan Workspace")

include(${CMAKE_CURRENT_SOURCE_DIR}/conanbuildinfo.cmake)
conan_basic_setup(NO_OUTPUT_DIRS)  # Execute Conan magic

set(CMAKE_SKIP_RPATH 0)  # We are not creating packages here, it is ok to have rpaths

include(${CMAKE_CURRENT_SOURCE_DIR}/conanworkspace.cmake)
```
 * I can have a name for the `project(...)` if I add a `name` field to `conanws.yml` file
 * I'm including a `conanbuildinfo.cmake` to keep doing Conan magic, this file has been generated **without** dependencies.
 * As the workspace is not going to create a package, I can use `RPATHS`, so linux binaries will find shared libraries. ⚠️ Need to check if I can pass `SKIP_RPATHS` for the same behavior.
 * I need `NO_OUTPUT_DIRS` so each library will generate the binaries in the place defined by the `layout` file (see (3) in TODO list).

#### conanworkspace.cmake

And also, it generates a `conanworkspace.cmake` file, I'm dividing it into sections to talk about each one:

```cmake
# List of targets involved in the workspace
    list(APPEND ws_targets "pkgD")
    list(APPEND ws_targets "pkgH")
    list(APPEND ws_targets "pkgA")
    list(APPEND ws_targets "pkgC")
    list(APPEND ws_targets "pkgB")
    list(APPEND ws_targets "pkgF")
    list(APPEND ws_targets "pkgE")
    list(APPEND ws_targets "pkgG")
```

```cmake
    # Packages that are consumed by editable ones
        find_package(pkgD REQUIRED)
        set_target_properties(pkgD::pkgD PROPERTIES IMPORTED_GLOBAL TRUE)
        add_library(CONAN_PKG::pkgD ALIAS pkgD::pkgD)
    
        find_package(pkgH REQUIRED)
        set_target_properties(pkgH::pkgH PROPERTIES IMPORTED_GLOBAL TRUE)
        add_library(CONAN_PKG::pkgH ALIAS pkgH::pkgH)
    
        find_package(pkgC REQUIRED)
        set_target_properties(pkgC::pkgC PROPERTIES IMPORTED_GLOBAL TRUE)
        add_library(CONAN_PKG::pkgC ALIAS pkgC::pkgC)
    
        find_package(pkgF REQUIRED)
        set_target_properties(pkgF::pkgF PROPERTIES IMPORTED_GLOBAL TRUE)
        add_library(CONAN_PKG::pkgF ALIAS pkgF::pkgF)
```

These packages are consumed by editable ones, I cannot know if they are being consumed using the `cmake + TARGET` approach or the `cmake_find_package` approach, so I'm generating the alias for both.
 * ⚠️  `pkgC` and `pkgF` must be creating transitive targets too, check how CMake handles this duplication.
 * ⚠️ I can traverse the recipes declared in `conanws.yml` to check which generators are being used.

```cmake
# Override functions to avoid importing their own TARGETs (or calling again Conan Magic)
function(conan_basic_setup)
    message("Ignored call to 'conan_basic_setup'")
endfunction()

function(include)
    if ("${ARGV0}" MATCHES ".*/conanbuildinfo(_multi)?.cmake")
        message("Ignore inclusion of ${ARGV0}")
    else()
        _include(${ARGV})
    endif()
endfunction(include)
```

Override functions, I have already executed `conan_basic_setup`, no need to do it again (also, I don't want `${CONAN_LIBS}` to be populated). ⚠️ I think it is ok if we do not support consuming dependencies using `${CONAN_LIBS}`

```cmake
# Do not use find_package for those packages handled within the workspace
function(find_package)
    if(NOT "${ARGV0}" IN_LIST ws_targets)
        # Note.- If it's been already overridden, it will recurse forever
        message("find_package(${ARGV0})")
        _find_package(${ARGV})
    else()
        message("find_package(${ARGV0}) ignored, it is a target handled by Conan workspace")
    endif()
endfunction()
```

I don't want to `find_package` again any library that is being handled by the workspace.

```cmake
# Custom target
function(outer_package PKG_NAME FULL_REF)
    set(PKG_SENTINEL "/private/var/folders/yq/14hmvxm96xd7gfgl37_tnrbh0000gn/T/tmpi6nniq7oconans/path with spaces/${PKG_NAME}.setinel")
    add_custom_command(OUTPUT ${PKG_SENTINEL}
                       COMMAND echo "Package ${FULL_REF} not built" > ${PKG_SENTINEL}
                       WORKING_DIRECTORY "/private/var/folders/yq/14hmvxm96xd7gfgl37_tnrbh0000gn/T/tmpi6nniq7oconans/path with spaces"
                       COMMENT "Build ${PKG_NAME} outside workspace")
    add_custom_target(${PKG_NAME} DEPENDS ${PKG_SENTINEL})
endfunction()
```

Custom targets for package corresponding to the category (3), right now this is just a `custom_target` running a dummy `custom_command` (see (2) in the TODO list).

```cmake
        # Inner: pkgA/0.1@ws/testing
        add_subdirectory("/private/var/folders/yq/14hmvxm96xd7gfgl37_tnrbh0000gn/T/tmp2n7z7h55conans/pathwithoutspaces/pkgA" "/private/var/folders/yq/14hmvxm96xd7gfgl37_tnrbh0000gn/T/tmp2n7z7h55conans/pathwithoutspaces/pkgA/build")
        add_library(pkgA::pkgA ALIAS pkgA)
        add_library(CONAN_PKG::pkgA ALIAS pkgA)
```

Packages inside the workspace (category (1)) are included using `add_subdirectory`. Afterwards, I need to create the aliases corresponding to generators `cmake` and `cmake_find_package` because these packages can be consumed using any of those approaches.

```cmake
        # Outter: pkgC/0.1@ws/testing
        outer_package(pkgC pkgC/0.1@ws/testing)
        add_dependencies(pkgC pkgA)
        add_dependencies(pkgC pkgD)
```

Packages outside the workspace are added as `custom_target` with the dependencies declared. This is needed to have the full graph representation of the workspace into the CMake model.


**TODO**:
 1. Currently target name must match the name of the package, there are a couple of this to improve here:
    * The `conanws.yml` can contain a `target` field to use. But still, this is limited to only one target per package.
    * Ongoing work on #5242 can be used to know all the targets included in the package an to generate the corresponding aliases.
 2. Packages outside the workspace don't take into account changes of _editable_ packages. This can be implemented, taken advantage of the _graphlock_ feature, but I can only imagine a scenario where Conan is being run from inside CMake.
 3. Where to generate the binaries?
    * package inside the workspace should generate the binaries in the workspace folder (and it is easy), BUT these packages will be found by packages not in the workspace using the _editable feature_... ⚠️  Building packages outside the workspace is not considered yet, so we can move the generation of this binaries to the workspace folder.
    * packages outside the workspace are not being generated.
 
Other tasks ⚠️ 
 * Check problems related to paths (https://github.com/conan-io/conan/issues/5132)
 * Check with unconnected graphs
 * Check Debug/Relase generators
 * Verify that the implementation could be valid for others than `cmake` generator

@tags: slow