### PR TITLE
Accept v140 and VS 15.0 for CMake generator (#5318)

### DIFF
--- a/conans/client/generators/cmake_common.py
+++ b/conans/client/generators/cmake_common.py
@@ -357,8 +357,8 @@ function(check_compiler_version)
         if(
             # 1920-1929 = VS 16.0 (v142 toolset)
             (CONAN_COMPILER_VERSION STREQUAL "16" AND NOT((MSVC_VERSION GREATER 1919) AND (MSVC_VERSION LESS 1930))) OR
-            # 1910-1919 = VS 15.0 (v141 toolset)
-            (CONAN_COMPILER_VERSION STREQUAL "15" AND NOT((MSVC_VERSION GREATER 1909) AND (MSVC_VERSION LESS 1920))) OR
+            # 1910-1919 = VS 15.0 (v140 and v141 toolsets)
+            (CONAN_COMPILER_VERSION STREQUAL "15" AND NOT((MSVC_VERSION GREATER_EQUAL  1900) AND (MSVC_VERSION LESS 1920))) OR
             # 1900      = VS 14.0 (v140 toolset)
             (CONAN_COMPILER_VERSION STREQUAL "14" AND NOT(MSVC_VERSION EQUAL 1900)) OR
             # 1800      = VS 12.0 (v120 toolset)


### PR DESCRIPTION
fixes #5318 

Changelog: Fix: Accept v140 and VS 15.0 for CMake generator (#5318)
Docs: Omit

- [x] Refer to the issue that supports this Pull Request.
- [ ] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 

<sup>**Note:** By default this PR will skip the slower tests and will use a limited set of python versions. Check [here](https://github.com/conan-io/conan/blob/develop/.github/PR_INCREASE_TESTING.md) how to increase the testing level by writing some tags in the current PR body text.</sup>
