### PR TITLE
hotfix/requirements_typed_ast

### DIFF
--- a/conans/requirements.txt
+++ b/conans/requirements.txt
@@ -15,3 +15,4 @@ deprecation>=2.0, <2.1
 tqdm>=4.28.1, <5
 Jinja2>=2.3, <3
 python-dateutil>=2.6.0, <3
+typed-ast<1.4; python_version=="3.4" and platform_system=='Windows'


### PR DESCRIPTION
Changelog: Fix: Constraint transitive dependency ``typed-ast`` (required by astroid) in python3.4, as they stopped releasing wheels, and it fails to build in some Windows platforms with older SDKs.
Docs: omit

Similar to https://github.com/conan-io/conan/pull/5301, but with conditionals

@PYVERS: py34
