### PR TITLE
Do not retry 400 and print better error messages

### DIFF
--- a/conans/client/rest/__init__.py
+++ b/conans/client/rest/__init__.py
@@ -1,0 +1,22 @@
+import json
+
+
+def response_to_str(response):
+    content = response.content
+    try:
+        # A bytes message, decode it as str
+        if isinstance(content, bytes):
+            content = content.decode()
+
+        if response.headers.get("content-type") == "application/json":
+            # Errors from Artifactory looks like:
+            #  {"errors" : [ {"status" : 400, "message" : "Bla bla bla"}]}
+            try:
+                data = json.loads(content)["errors"][0]
+                content = "{}: {}".format(data["status"], data["message"])
+            except Exception:
+                pass
+        return content
+
+    except Exception:
+        return response.content

--- a/conans/client/rest/rest_client_common.py
+++ b/conans/client/rest/rest_client_common.py
@@ -3,6 +3,7 @@ import json
 from requests.auth import AuthBase, HTTPBasicAuth
 
 from conans import COMPLEX_SEARCH_CAPABILITY
+from conans.client.rest import response_to_str
 from conans.errors import (EXCEPTION_CODE_MAPPING, NotFoundException, ConanException,
                            AuthenticationException, RecipeNotFoundException,
                            PackageNotFoundException)
@@ -139,7 +140,7 @@ class RestCommonMethods(object):
 
         if response.status_code != 200:  # Error message is text
             response.charset = "utf-8"  # To be able to access ret.text (ret.content are bytes)
-            raise get_exception_from_error(response.status_code)(response.text)
+            raise get_exception_from_error(response.status_code)(response_to_str(response))
 
         content = decode_text(response.content)
         content_type = response.headers.get("Content-Type")

--- a/conans/client/rest/rest_client_v1.py
+++ b/conans/client/rest/rest_client_v1.py
@@ -148,15 +148,10 @@ class RestV1Methods(RestCommonMethods):
             output.rewrite_line("Uploading %s" % filename)
             auth, dedup = self._file_server_capabilities(resource_url)
             try:
-                response = uploader.upload(resource_url, files[filename], auth=auth, dedup=dedup,
-                                           retry=retry, retry_wait=retry_wait,
-                                           headers=self._put_headers)
+                uploader.upload(resource_url, files[filename], auth=auth, dedup=dedup,
+                                retry=retry, retry_wait=retry_wait,
+                                headers=self._put_headers)
                 output.writeln("")
-                if not response.ok:
-                    output.error("\nError uploading file: %s, '%s'" % (filename, response.content))
-                    failed.append(filename)
-                else:
-                    pass
             except Exception as exc:
                 output.error("\nError uploading file: %s, '%s'" % (filename, exc))
                 failed.append(filename)

--- a/conans/client/rest/rest_client_v2.py
+++ b/conans/client/rest/rest_client_v2.py
@@ -181,17 +181,11 @@ class RestV2Methods(RestCommonMethods):
             self._output.rewrite_line("Uploading %s" % filename)
             resource_url = urls[filename]
             try:
-                response = uploader.upload(resource_url, files[filename], auth=self.auth,
-                                           dedup=self._checksum_deploy, retry=retry,
-                                           retry_wait=retry_wait,
-                                           headers=self._put_headers)
+                uploader.upload(resource_url, files[filename], auth=self.auth,
+                                dedup=self._checksum_deploy, retry=retry,
+                                retry_wait=retry_wait,
+                                headers=self._put_headers)
                 self._output.writeln("")
-                if not response.ok:
-                    self._output.error("\nError uploading file: %s, '%s'" % (filename,
-                                                                             response.content))
-                    failed.append(filename)
-                else:
-                    pass
             except (AuthenticationException, ForbiddenException):
                 raise
             except Exception as exc:


### PR DESCRIPTION
Changelog: Bugfix: Conan was retrying the upload when failed with error 400 (request error).
Changelog: Feature: Print nicer error messages when receive an error from Artifactory.
Docs: omit

Raised by Artifactory QA team, when trying to upload to a virtual repository (without configured deploy repo) we were retrying and not printing anymore the server error in the output:

**At 1.15**:

```
Error uploading file: conanfile.py, 'b'{\n  "errors" : [ {\n    "status" : 400,\n    "message" : "Unable to upload into a virtual Conan repository without default local deployment repository configured."\n  } ]\n}''
```

**At 1.16**:

```
Error uploading file: conanfile.py, '400 Client Error: Bad Request for url: http://artifactory:8081/artifactory/api/conan/conan-virtual/v2/conans/simple/1.0/user/channel/revisions/a20a0ec96d592dd6e90448b311856074/files/conanfile.py
```

**From now on**:

```
Error uploading file: conanfile.py, '400: Unable to upload into a virtual Conan repository without default local deployment repository configured.'
```

