### PR TITLE
Ported #5318 and #5324 to 1.15

### DIFF
--- a/conans/client/generators/cmake_common.py
+++ b/conans/client/generators/cmake_common.py
@@ -353,8 +353,8 @@ function(check_compiler_version)
         if(
             # 1920-1929 = VS 16.0 (v142 toolset)
             (CONAN_COMPILER_VERSION STREQUAL "16" AND NOT((MSVC_VERSION GREATER 1919) AND (MSVC_VERSION LESS 1930))) OR
-            # 1910-1919 = VS 15.0 (v141 toolset)
-            (CONAN_COMPILER_VERSION STREQUAL "15" AND NOT((MSVC_VERSION GREATER 1909) AND (MSVC_VERSION LESS 1920))) OR
+            # 1910-1919 = VS 15.0 (v140 and v141 toolsets)
+            (CONAN_COMPILER_VERSION STREQUAL "15" AND NOT((MSVC_VERSION GREATER_EQUAL  1900) AND (MSVC_VERSION LESS 1920))) OR
             # 1900      = VS 14.0 (v140 toolset)
             (CONAN_COMPILER_VERSION STREQUAL "14" AND NOT(MSVC_VERSION EQUAL 1900)) OR
             # 1800      = VS 12.0 (v120 toolset)

--- a/conans/requirements.txt
+++ b/conans/requirements.txt
@@ -14,3 +14,4 @@ astroid>=1.6.5
 deprecation>=2.0, <2.1
 tqdm>=4.28.1, <5
 Jinja2>=2.3, <3
+typed-ast<1.4; python_version=="3.4" and platform_system=='Windows'


### PR DESCRIPTION
Changelog: Fix: Accept v140 and VS 15.0 for CMake generator (#5318)
Changelog: Fix: Constraint transitive dependency typed-ast (required by astroid) in python3.4, as they stopped releasing wheels, and it fails to build in some Windows platforms with older SDKs.
Docs:omit
