### PR TITLE
Make conan_data visible to pylint

### DIFF
--- a/conans/client/cmd/export_linter.py
+++ b/conans/client/cmd/export_linter.py
@@ -69,8 +69,6 @@ def _normal_linter(conanfile_path, hook):
             return False
         if symbol == "no-name-in-module" and "python_requires" in msg.get("message"):
             return False
-        if symbol == "no-member" and "conan_data" in msg.get("message"):
-            return False
 
         return True
 

--- a/conans/client/cmd/export_linter.py
+++ b/conans/client/cmd/export_linter.py
@@ -69,6 +69,8 @@ def _normal_linter(conanfile_path, hook):
             return False
         if symbol == "no-name-in-module" and "python_requires" in msg.get("message"):
             return False
+        if symbol == "no-member" and "conan_data" in msg.get("message"):
+            return False
 
         return True
 

--- a/conans/pylint_plugin.py
+++ b/conans/pylint_plugin.py
@@ -30,6 +30,7 @@ def transform_conanfile(node):
         "build_folder": str_class,
         "package_folder": str_class,
         "install_folder": str_class,
+        "conan_data": str_class,
         "build_requires": build_requires_class,
         "info_build": info_class,
         "info": info_class,

--- a/conans/test/functional/command/export_linter_test.py
+++ b/conans/test/functional/command/export_linter_test.py
@@ -5,7 +5,7 @@ import six
 from mock import patch
 
 from conans.client import tools
-from conans.paths import CONANFILE
+from conans.paths import CONANFILE, DATA_YML
 from conans.test.utils.tools import TestClient
 
 conanfile = """
@@ -153,3 +153,24 @@ class BaseConan(ConanFile):
                          client.out)
         self.assertNotIn("WARN: Linter. Line 8: self.copy_deps is not callable",
                          client.out)
+
+    def test_conan_data(self):
+        client = TestClient()
+        conanfile = """
+from conans import ConanFile
+class ExampleConan(ConanFile):
+    name = "example"
+
+    def build(self):
+        print(self.conan_data["sources"][float(self.version)])
+"""
+        conandata = """sources:
+  2.3:
+    url: "https://github.com/google/cctz/archive/v2.3.tar.gz"
+    sha256: "8615b20d4e33e02a271c3b93a3b208e3d7d5d66880f5f6208b03426e448f32db"
+"""
+        client.save({DATA_YML: conandata})
+        client.save({CONANFILE: conanfile})
+        client.run("export . 2.3@conan/stable")
+        self.assertNotIn("Linter.", client.user_io.out)
+        self.assertNotIn("Instance of 'ExampleConan' has no 'conan_data' member", client.user_io.out)


### PR DESCRIPTION
Since Conan 1.16.0 we are able to add a data file called conandata.yml, which can be retrieved by `self.conan_data` in our recipe. However, that member is lazy and Conan's linter detects it as non-member before exporting.

Changelog: Fix: Make conan_data visible to pylint (#5327)
Docs: Omit

fixes #5327 

- [x] Refer to the issue that supports this Pull Request.
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 

<sup>**Note:** By default this PR will skip the slower tests and will use a limited set of python versions. Check [here](https://github.com/conan-io/conan/blob/develop/.github/PR_INCREASE_TESTING.md) how to increase the testing level by writing some tags in the current PR body text.</sup>
