### PR TITLE
Fix regression related to merge_directories with symlinked folders

### DIFF
--- a/conans/client/source.py
+++ b/conans/client/source.py
@@ -66,7 +66,8 @@ def merge_directories(src, dst, excluded=None, symlinks=True):
                                       os.path.realpath(src))
             if not relpath.startswith("."):
                 # Absolute links could be a problem, convert to relative
-                linkto = os.path.normpath(os.path.relpath(linkto, src_dir))
+                if os.path.isabs(linkto):
+                    linkto = os.path.normpath(os.path.relpath(linkto, src_dir))
                 dst_dir = os.path.normpath(os.path.join(dst, os.path.relpath(src_dir, src)))
                 os.symlink(linkto, dst_dir)
             dirs[:] = []  # Do not enter subdirectories

--- a/conans/client/source.py
+++ b/conans/client/source.py
@@ -39,7 +39,7 @@ def complete_recipe_sources(remote_manager, cache, conanfile, ref, remotes):
     remote_manager.get_recipe_sources(ref, export_path, sources_folder, current_remote)
 
 
-def merge_directories(src, dst, excluded=None, symlinks=True):
+def merge_directories(src, dst, excluded=None):
     src = os.path.normpath(src)
     dst = os.path.normpath(dst)
     excluded = excluded or []
@@ -69,7 +69,7 @@ def merge_directories(src, dst, excluded=None, symlinks=True):
             dirs[:] = []
             continue
 
-        if os.path.islink(src_dir) and symlinks:
+        if os.path.islink(src_dir):
             link_to_rel(src_dir)
             dirs[:] = []  # Do not enter subdirectories
             continue
@@ -83,7 +83,7 @@ def merge_directories(src, dst, excluded=None, symlinks=True):
         for file_ in files:
             src_file = os.path.join(src_dir, file_)
             dst_file = os.path.join(dst_dir, file_)
-            if os.path.islink(src_file) and symlinks:
+            if os.path.islink(src_file):
                 link_to_rel(src_file)
             else:
                 shutil.copy2(src_file, dst_file)

--- a/conans/client/source.py
+++ b/conans/client/source.py
@@ -61,8 +61,14 @@ def merge_directories(src, dst, excluded=None, symlinks=True):
 
         if os.path.islink(src_dir):
             linkto = os.readlink(src_dir)
-            dst_dir = os.path.normpath(os.path.join(dst, os.path.relpath(src_dir, src)))
-            os.symlink(linkto, dst_dir)
+            # See if outside of the folder
+            relpath = os.path.relpath(os.path.realpath(src_dir),
+                                      os.path.realpath(src))
+            if not relpath.startswith("."):
+                # Absolute links could be a problem, convert to relative
+                linkto = os.path.normpath(os.path.relpath(linkto, src_dir))
+                dst_dir = os.path.normpath(os.path.join(dst, os.path.relpath(src_dir, src)))
+                os.symlink(linkto, dst_dir)
             dirs[:] = []  # Do not enter subdirectories
             continue
 

--- a/conans/client/source.py
+++ b/conans/client/source.py
@@ -54,7 +54,6 @@ def merge_directories(src, dst, excluded=None, symlinks=True):
             return True
         return False
 
-    linked_folders = []
     for src_dir, dirs, files in walk(src, followlinks=True):
 
         if is_excluded(src_dir):
@@ -62,8 +61,10 @@ def merge_directories(src, dst, excluded=None, symlinks=True):
             continue
 
         if os.path.islink(src_dir):
-            rel_link = os.path.relpath(src_dir, src)
-            linked_folders.append(rel_link)
+            linkto = os.readlink(src_dir)
+            dst_dir = os.path.normpath(os.path.join(dst, os.path.relpath(src_dir, src)))
+            os.symlink(linkto, dst_dir, target_is_directory=True)
+            dirs[:] = []  # Do not enter subdirectories
             continue
 
         # Overwriting the dirs will prevents walk to get into them
@@ -80,8 +81,6 @@ def merge_directories(src, dst, excluded=None, symlinks=True):
                 os.symlink(linkto, dst_file)
             else:
                 shutil.copy2(src_file, dst_file)
-
-    FileCopier.link_folders(src, dst, linked_folders)
 
 
 def config_source_local(src_folder, conanfile, conanfile_path, hook_manager):

--- a/conans/client/source.py
+++ b/conans/client/source.py
@@ -63,7 +63,7 @@ def merge_directories(src, dst, excluded=None, symlinks=True):
         if os.path.islink(src_dir):
             linkto = os.readlink(src_dir)
             dst_dir = os.path.normpath(os.path.join(dst, os.path.relpath(src_dir, src)))
-            os.symlink(linkto, dst_dir, target_is_directory=True)
+            os.symlink(linkto, dst_dir)
             dirs[:] = []  # Do not enter subdirectories
             continue
 

--- a/conans/client/source.py
+++ b/conans/client/source.py
@@ -5,7 +5,6 @@ import six
 
 from conans.client import tools
 from conans.client.cmd.export import export_recipe, export_source
-from conans.client.file_copier import FileCopier
 from conans.errors import ConanException, ConanExceptionInUserConanfileMethod, \
     conanfile_exception_formatter
 from conans.model.conan_file import get_env_context_manager

--- a/conans/test/integration/symlinks_test.py
+++ b/conans/test/integration/symlinks_test.py
@@ -295,9 +295,10 @@ class SymlinkExportSources(unittest.TestCase):
     def test_create_source(self):
         # Reproduces issue: https://github.com/conan-io/conan/issues/5329
         t = TestClient()
-        rel_path_content = os.path.join('src', 'framework', 'Versions', 'v1', 'headers', 'content')
+        relpath_v1 = os.path.join('src', 'framework', 'Versions', 'v1')
         t.save({'conanfile.py': self.conanfile,
-                rel_path_content: "whatever"})
+                os.path.join(relpath_v1, 'headers', 'content'): "whatever",
+                os.path.join(relpath_v1, 'file'): "content"})
 
         # Add two levels of symlinks
         os.symlink('v1',
@@ -306,10 +307,15 @@ class SymlinkExportSources(unittest.TestCase):
         os.symlink('Versions/Current/headers',
                    os.path.join(t.current_folder, 'src', 'framework', 'headers'),
                    target_is_directory=True)
+        os.symlink('Versions/Current/file',
+                   os.path.join(t.current_folder, 'src', 'framework', 'file'))
 
         # Check that things are in place
         content = os.path.join(t.current_folder, 'src', 'framework', 'headers', 'content')
         self.assertTrue(os.path.exists(content))
-        self.assertEqual(os.path.realpath(content), os.path.join(t.current_folder, rel_path_content))
+        self.assertEqual(os.path.realpath(content),
+                         os.path.join(t.current_folder, relpath_v1, 'headers', 'content'))
 
         t.run("create . user/channel")
+
+        # TODO: Check copied files

--- a/conans/test/integration/symlinks_test.py
+++ b/conans/test/integration/symlinks_test.py
@@ -282,6 +282,7 @@ class ConanSymlink(ConanFile):
         self.assertEqual(os.path.realpath(bf_symlink), os.path.join(bf, "release"))
 
 
+@unittest.skipUnless(platform.system() != "Windows", "Requires Symlinks")
 class SymlinkExportSources(unittest.TestCase):
     conanfile = textwrap.dedent("""
         from conans import ConanFile, CMake

--- a/conans/test/integration/symlinks_test.py
+++ b/conans/test/integration/symlinks_test.py
@@ -310,12 +310,18 @@ class SymlinkExportSources(unittest.TestCase):
         os.symlink('Versions/Current/file',
                    os.path.join(t.current_folder, 'src', 'framework', 'file'))
 
-        # Check that things are in place
-        content = os.path.join(t.current_folder, 'src', 'framework', 'headers', 'content')
-        self.assertTrue(os.path.exists(content))
-        self.assertEqual(os.path.realpath(content),
+        # Check that things are in place (locally): file exists and points to local directory
+        relpath_content = os.path.join('src', 'framework', 'headers', 'content')
+        local_content = os.path.join(t.current_folder, relpath_content)
+        self.assertTrue(os.path.exists(local_content))
+        self.assertEqual(os.path.realpath(local_content),
                          os.path.join(t.current_folder, relpath_v1, 'headers', 'content'))
 
         t.run("create . user/channel")
 
-        # TODO: Check copied files
+        # Check that things are in place (in the cache): exists and points to 'source' directory
+        layout = t.cache.package_layout(ConanFileReference.loads("symlinks/1.0.0@user/channel"))
+        cache_content = os.path.join(layout.source(), relpath_content)
+        self.assertTrue(os.path.exists(cache_content))
+        self.assertEqual(os.path.realpath(cache_content),
+                         os.path.join(layout.source(), relpath_v1, 'headers', 'content'))

--- a/conans/test/integration/symlinks_test.py
+++ b/conans/test/integration/symlinks_test.py
@@ -301,12 +301,9 @@ class SymlinkExportSources(unittest.TestCase):
                 os.path.join(relpath_v1, 'file'): "content"})
 
         # Add two levels of symlinks
-        os.symlink('v1',
-                   os.path.join(t.current_folder, 'src', 'framework', 'Versions', 'Current'),
-                   target_is_directory=True)
+        os.symlink('v1', os.path.join(t.current_folder, 'src', 'framework', 'Versions', 'Current'))
         os.symlink('Versions/Current/headers',
-                   os.path.join(t.current_folder, 'src', 'framework', 'headers'),
-                   target_is_directory=True)
+                   os.path.join(t.current_folder, 'src', 'framework', 'headers'))
         os.symlink('Versions/Current/file',
                    os.path.join(t.current_folder, 'src', 'framework', 'file'))
 

--- a/conans/test/unittests/client/source/test_run_scm.py
+++ b/conans/test/unittests/client/source/test_run_scm.py
@@ -27,7 +27,7 @@ class RunSCMTest(unittest.TestCase):
         conanfile.scm = {'type': 'git', 'url': 'auto', 'revision': 'auto'}
 
         # Mock functions called from inside _run_scm (tests will be here)
-        def merge_directories(src, dst, excluded=None, symlinks=True):
+        def merge_directories(src, dst, excluded=None):
             self.assertEqual(src, local_sources_path)
             self.assertEqual(dst, self.src_folder)
 
@@ -87,7 +87,7 @@ class RunSCMTest(unittest.TestCase):
         conanfile.scm = {'type': 'git', 'url': 'auto', 'revision': 'auto'}
 
         # Mock functions called from inside _run_scm (tests will be here)
-        def merge_directories(src, dst, excluded=None, symlinks=True):
+        def merge_directories(src, dst, excluded=None):
             src = os.path.normpath(src)
             dst = os.path.normpath(dst)
             self.assertEqual(src.replace('\\', '/'), local_sources_path)


### PR DESCRIPTION
Changelog: Bugfix: Do not copy directories inside a symlinked one
Docs: omit

closes #5329 

In #5237 we fixed an issue, but also introduced a wrong behavior that was failing for some use cases (see new test: folders inside symlinked folders with more than one level of indirection). The folders inside the symlinked one were being copied (so the symlink folder was generated) and the final function creating the symlinked folder failed because the folder to create was already there (it has already been created due to the previous recursion).

Just for quick reference, this is the layout of the source folder for the new test (`SymlinkExportSources::test_create_source`):

![image](https://user-images.githubusercontent.com/1406456/59337511-0a5f1d00-8d01-11e9-8e73-e35a6178d9a3.png)

![image](https://user-images.githubusercontent.com/1406456/59337645-4f834f00-8d01-11e9-8f93-a6b9d6106a70.png)

The intention of test (`test_broken_in_local_sources`) is just to prove that broken symlinks are detected before reaching the modified functions.

