### PR TITLE
Skip cmake compiler checks when toolset declared

### DIFF
--- a/conans/client/generators/cmake_common.py
+++ b/conans/client/generators/cmake_common.py
@@ -350,6 +350,10 @@ endfunction()
 
 function(check_compiler_version)
     conan_split_version(${CMAKE_CXX_COMPILER_VERSION} VERSION_MAJOR VERSION_MINOR)
+    if(DEFINED CONAN_SETTINGS_COMPILER_TOOLSET)
+       conan_message(STATUS "Conan: Skipping compiler check: Declared 'compiler.toolset'")
+       return()
+    endif()
     if(CMAKE_CXX_COMPILER_ID MATCHES MSVC)
         # MSVC_VERSION is defined since 2.8.2 at least
         # https://cmake.org/cmake/help/v2.8.2/cmake.html#variable:MSVC_VERSION
@@ -357,8 +361,8 @@ function(check_compiler_version)
         if(
             # 1920-1929 = VS 16.0 (v142 toolset)
             (CONAN_COMPILER_VERSION STREQUAL "16" AND NOT((MSVC_VERSION GREATER 1919) AND (MSVC_VERSION LESS 1930))) OR
-            # 1910-1919 = VS 15.0 (v140 and v141 toolsets)
-            (CONAN_COMPILER_VERSION STREQUAL "15" AND NOT((MSVC_VERSION GREATER_EQUAL  1900) AND (MSVC_VERSION LESS 1920))) OR
+            # 1910-1919 = VS 15.0 (v141 toolset)
+            (CONAN_COMPILER_VERSION STREQUAL "15" AND NOT((MSVC_VERSION GREATER 1909) AND (MSVC_VERSION LESS 1920))) OR
             # 1900      = VS 14.0 (v140 toolset)
             (CONAN_COMPILER_VERSION STREQUAL "14" AND NOT(MSVC_VERSION EQUAL 1900)) OR
             # 1800      = VS 12.0 (v120 toolset)

--- a/conans/test/functional/generators/cmake_test.py
+++ b/conans/test/functional/generators/cmake_test.py
@@ -1,4 +1,5 @@
 import os
+import platform
 import unittest
 
 from nose.plugins.attrib import attr
@@ -34,6 +35,36 @@ CONAN_BASIC_SETUP()
 
         client.run('install .')
         client.run('build .')
+
+    @attr("slow")
+    @unittest.skipUnless(platform.system() == "Windows", "Requires MSBuild")
+    def skip_check_if_toolset_test(self):
+        file_content = '''from conans import ConanFile, CMake
+
+class ConanFileToolsTest(ConanFile):
+    generators = "cmake"
+    exports_sources = "CMakeLists.txt"
+    settings = "os", "arch", "compiler"
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+    '''
+        client = TestClient()
+        cmakelists = '''
+set(CMAKE_CXX_COMPILER_WORKS 1)
+set(CMAKE_CXX_ABI_COMPILED 1)
+PROJECT(Hello)
+cmake_minimum_required(VERSION 2.8)
+include("${CMAKE_BINARY_DIR}/conanbuildinfo.cmake")
+CONAN_BASIC_SETUP()
+'''
+        client.save({"conanfile.py": file_content,
+                     "CMakeLists.txt": cmakelists})
+        client.run("create . lib/1.0@user/channel -s compiler='Visual Studio' -s compiler.toolset=v140")
+        self.assertIn("Conan: Skipping compiler check: Declared 'compiler.toolset'", client.out)
+
 
     @attr('slow')
     def no_output_test(self):


### PR DESCRIPTION
Changelog: Fix: Skipped the compiler version check in the cmake generator when a `-s compiler.toolset` is specified (Visual Studio).
Docs:  omit

Close #5343 
Reverted https://github.com/conan-io/conan/pull/5321