### PR TITLE
fix storage path

### DIFF
--- a/conans/client/conan_api.py
+++ b/conans/client/conan_api.py
@@ -567,8 +567,12 @@ class ConanAPIV1(object):
     @api_method
     def config_get(self, item):
         config_parser = ConanClientConfigParser(self._cache.conan_conf_path)
-        self._user_io.out.info(config_parser.get_item(item))
-        return config_parser.get_item(item)
+        if item == "storage.path":
+            result = config_parser.storage_path
+        else:
+            result = config_parser.get_item(item)
+        self._user_io.out.info(result)
+        return result
 
     @api_method
     def config_set(self, item, value):

--- a/conans/client/conf/__init__.py
+++ b/conans/client/conf/__init__.py
@@ -364,10 +364,6 @@ class ConanClientConfigParser(ConfigParser, object):
             return False
 
     @property
-    def storage(self):
-        return dict(self.get_conf("storage"))
-
-    @property
     def request_timeout(self):
         timeout = os.getenv("CONAN_REQUEST_TIMEOUT")
         if not timeout:
@@ -416,7 +412,7 @@ class ConanClientConfigParser(ConfigParser, object):
                 current_dir = os.path.dirname(self.filename)
                 # if env var is declared, any specified path will be relative to CONAN_USER_HOME
                 # even with the ~/
-                result = self.storage["path"]
+                result = dict(self.get_conf("storage"))["path"]
                 if result.startswith("."):
                     result = os.path.abspath(os.path.join(current_dir, result))
                 elif result[:2] == "~/":

--- a/conans/test/functional/command/config_test.py
+++ b/conans/test/functional/command/config_test.py
@@ -1,3 +1,4 @@
+import os
 import unittest
 
 from conans.test.utils.tools import TestClient
@@ -21,8 +22,9 @@ class ConfigTest(unittest.TestCase):
         self.assertIn("path = ./data", self.client.user_io.out)
 
         self.client.run("config get storage.path")
-        self.assertIn("./data", self.client.user_io.out)
-        self.assertNotIn("path:", self.client.user_io.out)
+        full_path = os.path.join(self.client.base_folder, "data")
+        self.assertIn(full_path, self.client.out)
+        self.assertNotIn("path:", self.client.out)
 
     def errors_test(self):
         self.client.run("config get whatever", assert_error=True)


### PR DESCRIPTION
Changelog: Fix: Make ``conan config get storage.path`` return an absolute, resolved path
Docs: omit

Close #5338
