### PR TITLE
#5098 Copy DLL as symlink

### DIFF
--- a/conans/client/importer.py
+++ b/conans/client/importer.py
@@ -137,7 +137,7 @@ class _FileImporter(object):
         self.copied_files = set()
 
     def __call__(self, pattern, dst="", src="", root_package=None, folder=False,
-                 ignore_case=False, excludes=None, keep_path=True):
+                 ignore_case=False, excludes=None, keep_path=True, link_dll=False):
         """
         param pattern: an fnmatch file pattern of the files that should be copied. Eg. *.dll
         param dst: the destination local folder, wrt to current conanfile dir, to which
@@ -146,6 +146,9 @@ class _FileImporter(object):
                    will be stripped from the dst name. Eg.: lib/Debug/x86
         param root_package: fnmatch pattern of the package name ("OpenCV", "Boost") from
                             which files will be copied. Default: all packages in deps
+        param excludes: patterns to be excluded from the copy
+        param ignore_case: case-insensitive pattern matching
+        param link_dll: generate symbolic for DLLs rather than copying
         """
         if os.path.isabs(dst):
             real_dst_folder = dst
@@ -157,7 +160,7 @@ class _FileImporter(object):
             final_dst_path = os.path.join(real_dst_folder, name) if folder else real_dst_folder
             file_copier = FileCopier([matching_path], final_dst_path)
             files = file_copier(pattern, src=src, links=True, ignore_case=ignore_case,
-                                excludes=excludes, keep_path=keep_path)
+                                excludes=excludes, keep_path=keep_path, link_dll=link_dll)
             self.copied_files.update(files)
 
     def _get_folders(self, pattern):

--- a/conans/test/functional/old/file_copier_test.py
+++ b/conans/test/functional/old/file_copier_test.py
@@ -190,9 +190,10 @@ class FileCopierTest(unittest.TestCase):
         copier("*.so", dst="bin", src="lib", link_dll=True)
         copier("*.dylib", dst="bin", src="lib", link_dll=True)
 
-        self.assertEqual(['foobar.lib', 'foobar.a'], os.listdir(os.path.join(folder2, "lib")))
-        self.assertEqual(['foobar.dylib', 'foobar.so', 'foobar.dll'],
-                         os.listdir(os.path.join(folder2, "bin")))
+        self.assertEqual(sorted(['foobar.a', 'foobar.lib']),
+                         sorted(os.listdir(os.path.join(folder2, "lib"))))
+        self.assertEqual(sorted(['foobar.dylib', 'foobar.so', 'foobar.dll']),
+                         sorted(os.listdir(os.path.join(folder2, "bin"))))
 
         self.assertTrue(os.path.islink(os.path.join(folder2, "bin", "foobar.dll")))
         self.assertFalse(os.path.islink(os.path.join(folder2, "bin", "foobar.dylib")))


### PR DESCRIPTION
- Add new parameter to FileCopier, link_dll. When it's True, any
  DLL will won't be copied, but linked. It ONLY works for DLLs
- Add test to check any possible future regression using other
  extensions

Changelog: Feature: Copy function creating symlinks (#5098)
Docs: https://github.com/conan-io/docs/pull/1324
close #5098

- [x] Refer to the issue that supports this Pull Request.
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [x] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 

<sup>**Note:** By default this PR will skip the slower tests and will use a limited set of python versions. Check [here](https://github.com/conan-io/conan/blob/develop/.github/PR_INCREASE_TESTING.md) how to increase the testing level by writing some tags in the current PR body text.</sup>
