### PR TITLE
Use INTERFACE_LINK_LIBRARIES for dependencies

### DIFF
--- a/conans/client/generators/cmake_find_package.py
+++ b/conans/client/generators/cmake_find_package.py
@@ -72,14 +72,6 @@ endif()
 def find_dependency_lines(name, cpp_info, find_modules):
     lines = ["", "# Library dependencies", "include(CMakeFindDependencyMacro)"]
     for dep in cpp_info.public_deps:
-        def property_lines(prop):
-            lib_t = "%s::%s" % (name, name)
-            dep_t = "%s::%s" % (dep, dep)
-            return ["get_target_property(tmp %s %s)" % (dep_t, prop),
-                    "if(tmp)",
-                    "  set_property(TARGET %s APPEND PROPERTY %s ${tmp})" % (lib_t, prop),
-                    'endif()']
-
         if find_modules:
             lines.append("find_dependency(%s REQUIRED)" % dep)
         else:
@@ -91,7 +83,7 @@ def find_dependency_lines(name, cpp_info, find_modules):
             lines.append('  find_dependency(%s REQUIRED NO_MODULE)' % dep)
             lines.append("endif()")
 
-        lines.extend(property_lines("INTERFACE_LINK_LIBRARIES"))
-        lines.extend(property_lines("INTERFACE_COMPILE_DEFINITIONS"))
-        lines.extend(property_lines("INTERFACE_INCLUDE_DIRECTORIES"))
+        lines.append(
+            'set_property(TARGET %s::%s APPEND PROPERTY INTERFACE_LINK_LIBRARIES %s::%s)'
+            % (name, name, dep, dep))
     return ["    {}".format(l) for l in lines]

--- a/conans/client/generators/cmake_find_package.py
+++ b/conans/client/generators/cmake_find_package.py
@@ -84,6 +84,6 @@ def find_dependency_lines(name, cpp_info, find_modules):
             lines.append("endif()")
 
         lines.append(
-            'set_property(TARGET %s::%s APPEND PROPERTY INTERFACE_LINK_LIBRARIES %s::%s)'
+            'target_link_libraries(%s::%s INTERFACE %s::%s)'
             % (name, name, dep, dep))
     return ["    {}".format(l) for l in lines]


### PR DESCRIPTION
Changelog: Fix: Consider when package B depends on package A. The `cmake_find_package`
generator will generate targets for B and A, and then copy properties
from target A into target B. The recommended, conventional best practice
is to just express that B depends on A by adding A to the
`INTERFACE_LINK_LIBRARIES` property of B.

I haven't opened an issue for this change. It was easy, so I just went ahead and did it. Let me know if you still want me to open a separate issue.

Because this is just an implementation change, I don't think any docs are needed.

I ran the tests on a fresh checkout of `develop`, and there were errors and failures. This change introduced no new errors or failures.

- [ ] Refer to the issue that supports this Pull Request.
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [ ] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one.