### PR TITLE
Add apple-clang 11 to settings.yml (#5328)

### DIFF
--- a/conans/client/conf/__init__.py
+++ b/conans/client/conf/__init__.py
@@ -83,7 +83,7 @@ compiler:
         libcxx: [libstdc++, libstdc++11, libc++, c++_shared, c++_static]
         cppstd: [None, 98, gnu98, 11, gnu11, 14, gnu14, 17, gnu17, 20, gnu20]
     apple-clang:
-        version: ["5.0", "5.1", "6.0", "6.1", "7.0", "7.3", "8.0", "8.1", "9.0", "9.1", "10.0"]
+        version: ["5.0", "5.1", "6.0", "6.1", "7.0", "7.3", "8.0", "8.1", "9.0", "9.1", "10.0", "11.0"]
         libcxx: [libstdc++, libc++]
         cppstd: [None, 98, gnu98, 11, gnu11, 14, gnu14, 17, gnu17, 20, gnu20]
     qcc:

--- a/conans/test/unittests/client/build/cpp_std_flags_test.py
+++ b/conans/test/unittests/client/build/cpp_std_flags_test.py
@@ -159,6 +159,7 @@ class CompilerFlagsTest(unittest.TestCase):
         self.assertEqual(cppstd_flag("apple-clang", "9.1", "17"), "-std=c++17")
 
         self.assertEqual(cppstd_flag("apple-clang", "10.0", "17"), "-std=c++17")
+        self.assertEqual(cppstd_flag("apple-clang", "11.0", "17"), "-std=c++17")
 
     def test_apple_clang_cppstd_defaults(self):
         self.assertEqual(cppstd_default("apple-clang", "2"), "gnu98")
@@ -170,6 +171,7 @@ class CompilerFlagsTest(unittest.TestCase):
         self.assertEqual(cppstd_default("apple-clang", "8"), "gnu98")
         self.assertEqual(cppstd_default("apple-clang", "9"), "gnu98")
         self.assertEqual(cppstd_default("apple-clang", "10"), "gnu98")
+        self.assertEqual(cppstd_default("apple-clang", "11"), "gnu98")
 
     def test_visual_cppstd_flags(self):
         self.assertEqual(cppstd_flag("Visual Studio", "12", "11"), None)


### PR DESCRIPTION
Changelog: Feature: Add apple-clang 11.0 to settings.yml (#5328)
Docs: https://github.com/conan-io/docs/pull/1327
closes #5328 

- [x] Refer to the issue that supports this Pull Request.
- [ ] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [x] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 

<sup>**Note:** By default this PR will skip the slower tests and will use a limited set of python versions. Check [here](https://github.com/conan-io/conan/blob/develop/.github/PR_INCREASE_TESTING.md) how to increase the testing level by writing some tags in the current PR body text.</sup>
