### PR TITLE
Accept a list for the requires attribute

### DIFF
--- a/conans/model/conan_file.py
+++ b/conans/model/conan_file.py
@@ -42,7 +42,7 @@ def create_requirements(conanfile):
         else:
             if not conanfile.requires:
                 return Requirements()
-            if isinstance(conanfile.requires, tuple):
+            if isinstance(conanfile.requires, (tuple, list)):
                 return Requirements(*conanfile.requires)
             else:
                 return Requirements(conanfile.requires, )

--- a/conans/test/integration/conan_test_test.py
+++ b/conans/test/integration/conan_test_test.py
@@ -39,7 +39,7 @@ class HelloConan(ConanFile):
 from conans import ConanFile
 
 class HelloTestConan(ConanFile):
-    requires = "Hello/0.1@conan/stable"
+    requires = ["Hello/0.1@conan/stable", ]
     def test(self):
         self.output.warn("Tested ok!")
 ''', "Hello/0.1@conan/stable")

--- a/conans/test/integration/order_libs_test.py
+++ b/conans/test/integration/order_libs_test.py
@@ -33,7 +33,7 @@ class LibCConan(ConanFile):
 
         conanfile = """from conans import ConanFile
 class LibCConan(ConanFile):
-    requires = ("LibB/0.1@user/channel", "private"), "LibC/0.1@user/channel"
+    requires = [("LibB/0.1@user/channel", "private"), "LibC/0.1@user/channel"]
 """
         client.save({"conanfile.py": conanfile})
         client.run("install . -g cmake")

--- a/conans/test/unittests/model/conan_file/create_requirements_test.py
+++ b/conans/test/unittests/model/conan_file/create_requirements_test.py
@@ -1,0 +1,49 @@
+# coding=utf-8
+
+import unittest
+from collections import namedtuple
+
+from conans.model.conan_file import create_requirements
+
+MockConanFile = namedtuple("MockConanFile", ["requires", ])
+
+
+class TupleTest(unittest.TestCase):
+
+    def test_implicit_tuple(self):
+        requires = "req/1.0@user/version", "req2/1.0@user/version"
+        self.assertEqual(type(requires), tuple)
+        conanfile = MockConanFile(requires=requires)
+        r = create_requirements(conanfile)
+        self.assertListEqual(list(r.keys()), ["req", "req2"])
+
+    def test_tuple(self):
+        requires = ("req/1.0@user/version", "req2/1.0@user/version")
+        self.assertEqual(type(requires), tuple)
+        conanfile = MockConanFile(requires=requires)
+        r = create_requirements(conanfile)
+        self.assertListEqual(list(r.keys()), ["req", "req2"])
+
+    def test_config_tuple(self):
+        requires = (("req/1.0@user/version", "private"), )
+        self.assertEqual(type(requires), tuple)
+        conanfile = MockConanFile(requires=requires)
+        r = create_requirements(conanfile)
+        self.assertListEqual(list(r.keys()), ["req", ])
+
+
+class ListTest(unittest.TestCase):
+
+    def test_list(self):
+        requires = ["req/1.0@user/version", "req2/1.0@user/version"]
+        self.assertEqual(type(requires), list)
+        conanfile = MockConanFile(requires=requires)
+        r = create_requirements(conanfile)
+        self.assertListEqual(list(r.keys()), ["req", "req2"])
+
+    def test_config_list(self):
+        requires = [("req/1.0@user/version", "private"), ]
+        self.assertEqual(type(requires), list)
+        conanfile = MockConanFile(requires=requires)
+        r = create_requirements(conanfile)
+        self.assertListEqual(list(r.keys()), ["req", ])


### PR DESCRIPTION
Changelog: Fix: Accept a list for the requires attribute
Docs: https://github.com/conan-io/docs/pull/1332

closes https://github.com/conan-io/conan/issues/5313

Accept a list for the requires attribute, now any of these formats will get the same result:
 * `requires = "req/1.0@user/version", "req2/1.0@user/version"`
 * `requires = ("req/1.0@user/version", "req2/1.0@user/version")`
 * `requires = ["req/1.0@user/version", "req2/1.0@user/version"]`

And also, if you specify the visibility of the requires:
 * `requires = (("req/1.0@user/version", "private"), )`
 * `requires = [("req/1.0@user/version", "private"), ]`
