### PR TITLE
Use forward slashes for PROFILE_DIR

### DIFF
--- a/conans/client/profile_loader.py
+++ b/conans/client/profile_loader.py
@@ -130,7 +130,7 @@ def _load_profile(text, profile_path, default_folder):
 
         # Apply the automatic PROFILE_DIR variable
         if cwd:
-            inherited_vars["PROFILE_DIR"] = os.path.abspath(cwd)
+            inherited_vars["PROFILE_DIR"] = os.path.abspath(cwd).replace('\\', '/')
             # Allows PYTHONPATH=$PROFILE_DIR/pythontools
 
         # Replace the variables from parents in the current profile
@@ -144,7 +144,7 @@ def _load_profile(text, profile_path, default_folder):
         # Merge the inherited profile with the readed from current profile
         _apply_inner_profile(doc, inherited_profile)
 
-        # Return the intherited vars to apply them in the parent profile if exists
+        # Return the inherited vars to apply them in the parent profile if exists
         inherited_vars.update(profile_parser.vars)
         return inherited_profile, inherited_vars
 

--- a/conans/test/unittests/client/profile_loader/profile_loader_test.py
+++ b/conans/test/unittests/client/profile_loader/profile_loader_test.py
@@ -325,8 +325,8 @@ PYTHONPATH=$PROFILE_DIR/my_python_tools
 '''
 
         def assert_path(profile):
-            pythonpath = profile.env_values.env_dicts("")[0]["PYTHONPATH"].replace("/", "\\")
-            self.assertEqual(pythonpath, os.path.join(tmp, "my_python_tools").replace("/", "\\"))
+            pythonpath = profile.env_values.env_dicts("")[0]["PYTHONPATH"]
+            self.assertEqual(pythonpath, os.path.join(tmp, "my_python_tools").replace('\\', '/'))
 
         abs_profile_path = os.path.join(tmp, "Myprofile.txt")
         save(abs_profile_path, txt)

--- a/conans/test/unittests/client/profile_loader/profile_loader_test.py
+++ b/conans/test/unittests/client/profile_loader/profile_loader_test.py
@@ -307,8 +307,10 @@ one/1.5@lasote/stable
 
         profile, variables = read_profile("./profile4.txt", tmp, None)
 
-        self.assertEqual(variables, {"MYVAR": "1", "OTHERVAR": "34", "PROFILE_DIR":
-                                      tmp, "ROOTVAR": "0"})
+        self.assertEqual(variables, {"MYVAR": "1",
+                                     "OTHERVAR": "34",
+                                     "PROFILE_DIR": tmp.replace('\\', '/'),
+                                     "ROOTVAR": "0"})
         self.assertEqual("FromProfile3And34", profile.env_values.data[None]["MYVAR"])
         self.assertEqual("1", profile.env_values.data["package1"]["ENVY"])
         self.assertEqual(profile.settings, {"os": "1"})


### PR DESCRIPTION
Changelog: Fix: Force forward slashes in the variable `$PROFILE_DIR`
Docs: https://github.com/conan-io/docs/pull/1333

closes #5349

