### PR TITLE
Symlinks checks: tar creation, extraction and gather_files

### DIFF
--- a/conans/client/cmd/export.py
+++ b/conans/client/cmd/export.py
@@ -29,7 +29,7 @@ class AliasConanfile(ConanFile):
 """ % (target_ref.full_repr(), revision_mode)
 
     save(package_layout.conanfile(), conanfile)
-    digest = FileTreeManifest.create(package_layout.export())
+    digest = FileTreeManifest.create(package_layout.export(), output=output)
     digest.save(folder=package_layout.export())
 
     # Create the metadata for the alias
@@ -98,7 +98,8 @@ def cmd_export(conanfile_path, name, version, user, channel, keep_source, revisi
                              conanfile_path=package_layout.conanfile())
 
         # Compute the new digest
-        digest = FileTreeManifest.create(package_layout.export(), package_layout.export_sources())
+        digest = FileTreeManifest.create(package_layout.export(), package_layout.export_sources(),
+                                         output=output)
         modified_recipe = not previous_digest or previous_digest != digest
         if modified_recipe:
             output.success('A new %s version was exported' % CONANFILE)

--- a/conans/client/cmd/export.py
+++ b/conans/client/cmd/export.py
@@ -339,7 +339,7 @@ def export_source(conanfile, origin_folder, destination_source_folder):
         conanfile.exports_sources = (conanfile.exports_sources, )
 
     included_sources, excluded_sources = _classify_patterns(conanfile.exports_sources)
-    copier = FileCopier([origin_folder], destination_source_folder)
+    copier = FileCopier([origin_folder], destination_source_folder, output=conanfile.output)
     for pattern in included_sources:
         copier(pattern, links=True, excludes=excluded_sources)
     output = conanfile.output
@@ -368,7 +368,7 @@ def export_recipe(conanfile, origin_folder, destination_folder):
     except OSError:
         pass
 
-    copier = FileCopier([origin_folder], destination_folder)
+    copier = FileCopier([origin_folder], destination_folder, output=output)
     for pattern in included_exports:
         copier(pattern, links=True, excludes=excluded_exports)
 

--- a/conans/client/cmd/uploader.py
+++ b/conans/client/cmd/uploader.py
@@ -297,11 +297,11 @@ class CmdUpload(object):
                 os.remove(tgz_path)
                 clean_dirty(tgz_path)
 
-        files, symlinks = gather_files(export_folder)
+        files, symlinks = gather_files(export_folder, output=self._user_io.out)
         if CONANFILE not in files or CONAN_MANIFEST not in files:
             raise ConanException("Cannot upload corrupted recipe '%s'" % str(ref))
         export_src_folder = self._cache.package_layout(ref).export_sources()
-        src_files, src_symlinks = gather_files(export_src_folder)
+        src_files, src_symlinks = gather_files(export_src_folder, output=self._user_io.out)
         the_files = _compress_recipe_files(files, symlinks, src_files, src_symlinks, export_folder,
                                            self._user_io.out)
         return the_files
@@ -323,7 +323,7 @@ class CmdUpload(object):
             os.remove(tgz_path)
             clean_dirty(tgz_path)
         # Get all the files in that directory
-        files, symlinks = gather_files(package_folder)
+        files, symlinks = gather_files(package_folder, output=self._user_io.out)
 
         if CONANINFO not in files or CONAN_MANIFEST not in files:
             logger.error("Missing info or manifest in uploading files: %s" % (str(files)))

--- a/conans/client/cmd/uploader.py
+++ b/conans/client/cmd/uploader.py
@@ -510,7 +510,7 @@ def _compress_files(gathered_files, name, dest_dir, output):
         tgz = gzopen_without_timestamps(name, mode="w", fileobj=tgz_handle)
 
         for relpath, dest in sorted(gathered_files.symlinks.items()):
-            if dest.startswith("."):
+            if dest.startswith("../"):
                 warn_outside_sources(os.path.join(gathered_files.base_folder, relpath), dest)
 
             info = tarfile.TarInfo(name=relpath)
@@ -534,7 +534,7 @@ def _compress_files(gathered_files, name, dest_dir, output):
                 linkto = os.path.join(os.path.dirname(abs_path), os.readlink(abs_path))
                 linkto = os.path.normpath(linkto)
                 linkto_rel = os.path.relpath(linkto, gathered_files.base_folder)
-                if linkto_rel.startswith("."):
+                if linkto_rel.startswith("../"):
                     warn_outside_sources(abs_path, linkto)
 
                 info.type = tarfile.SYMTYPE

--- a/conans/client/cmd/uploader.py
+++ b/conans/client/cmd/uploader.py
@@ -470,7 +470,7 @@ def _compress_recipe_files(files, symlinks, src_files, src_symlinks, dest_folder
             result[tgz_name] = tgz_path
         elif tgz_files:
             output.rewrite_line(msg)
-            tgz_path = compress_files(tgz_files, tgz_symlinks, tgz_name, dest_folder, output)
+            tgz_path = _compress_files(tgz_files, tgz_symlinks, tgz_name, dest_folder, output)
             result[tgz_name] = tgz_path
 
     add_tgz(EXPORT_TGZ_NAME, export_tgz_path, files, symlinks, "Compressing recipe...")
@@ -485,14 +485,14 @@ def _compress_package_files(files, symlinks, dest_folder, output):
     if not tgz_path:
         output.writeln("Compressing package...")
         tgz_files = {f: path for f, path in files.items() if f not in [CONANINFO, CONAN_MANIFEST]}
-        tgz_path = compress_files(tgz_files, symlinks, PACKAGE_TGZ_NAME, dest_folder, output)
+        tgz_path = _compress_files(tgz_files, symlinks, PACKAGE_TGZ_NAME, dest_folder, output)
 
     return {PACKAGE_TGZ_NAME: tgz_path,
             CONANINFO: files[CONANINFO],
             CONAN_MANIFEST: files[CONAN_MANIFEST]}
 
 
-def compress_files(files, symlinks, name, dest_dir, output=None):
+def _compress_files(files, symlinks, name, dest_dir, output=None):
     t1 = time.time()
     # FIXME, better write to disk sequentially and not keep tgz contents in memory
     tgz_path = os.path.join(dest_dir, name)

--- a/conans/client/cmd/uploader.py
+++ b/conans/client/cmd/uploader.py
@@ -536,11 +536,11 @@ def _compress_files(gathered_files, name, dest_dir, output):
                 linkto_rel = os.path.relpath(linkto, gathered_files.base_folder)
                 if linkto_rel.startswith("."):
                     warn_outside_sources(abs_path, linkto)
-                else:
-                    info.type = tarfile.SYMTYPE
-                    info.size = 0  # A symlink shouldn't have size
-                    info.linkname = linkto_rel  # @UndefinedVariable
-                    tgz.addfile(tarinfo=info)
+
+                info.type = tarfile.SYMTYPE
+                info.size = 0  # A symlink shouldn't have size
+                info.linkname = linkto_rel  # @UndefinedVariable
+                tgz.addfile(tarinfo=info)
             else:
                 with open(abs_path, 'rb') as file_handler:
                     tgz.addfile(tarinfo=info, fileobj=file_handler)

--- a/conans/client/file_copier.py
+++ b/conans/client/file_copier.py
@@ -206,6 +206,11 @@ class FileCopier(object):
             if not os.path.exists(abs_path):
                 base_path = os.path.dirname(dst_link)
                 os.remove(dst_link)
+
+                if self._output:
+                    self._output.warn("File '{}' is pointing to '{}' that doesn't exists. It"
+                                      " will be skipped".format(dst_link, abs_path))
+
                 while base_path.startswith(dst):
                     try:  # Take advantage that os.rmdir does not delete non-empty dirs
                         os.rmdir(base_path)

--- a/conans/client/file_copier.py
+++ b/conans/client/file_copier.py
@@ -149,7 +149,7 @@ class FileCopier(object):
                         self._output.warn("File '{}' is pointing to '{}' that doesn't exists. It"
                                           " will be skipped".format(abs_path, linkto))
                         continue
-                    if os.path.relpath(linkto, src).startswith("."):
+                    if os.path.relpath(linkto, src).startswith("../"):
                         self._output.warn("File '{}' points to '{}' which is outside the source"
                                           " directory. It will be skipped".format(abs_path, linkto))
                         continue
@@ -177,7 +177,7 @@ class FileCopier(object):
             # Discard symlinks that go out of the src folder
             abs_path = os.path.realpath(src_link)
             relpath = os.path.relpath(abs_path, os.path.realpath(src))
-            if relpath.startswith("."):
+            if relpath.startswith("../"):
                 if self._output:
                     self._output.warn("Folder '{}' points to '{}', which is outside the"
                                       " source directory, it is skipped".format(src_link, abs_path))

--- a/conans/client/importer.py
+++ b/conans/client/importer.py
@@ -104,7 +104,7 @@ def run_deploy(conanfile, install_folder):
     # This is necessary to capture FileCopier full destination paths
     # Maybe could be improved in FileCopier
     def file_copier(*args, **kwargs):
-        file_copy = FileCopier([conanfile.package_folder], install_folder)
+        file_copy = FileCopier([conanfile.package_folder], install_folder, output=conanfile.output)
         copied = file_copy(*args, **kwargs)
         _make_files_writable(copied)
         package_copied.update(copied)
@@ -155,7 +155,7 @@ class _FileImporter(object):
         matching_paths = self._get_folders(root_package)
         for name, matching_path in matching_paths.items():
             final_dst_path = os.path.join(real_dst_folder, name) if folder else real_dst_folder
-            file_copier = FileCopier([matching_path], final_dst_path)
+            file_copier = FileCopier([matching_path], final_dst_path, output=self._conanfile.output)
             files = file_copier(pattern, src=src, links=True, ignore_case=ignore_case,
                                 excludes=excludes, keep_path=keep_path)
             self.copied_files.update(files)

--- a/conans/client/manifest_manager.py
+++ b/conans/client/manifest_manager.py
@@ -31,7 +31,8 @@ class ManifestManager(object):
         export = layout.export()
         exports_sources_folder = layout.export_sources()
         read_manifest = FileTreeManifest.load(export)
-        expected_manifest = FileTreeManifest.create(export, exports_sources_folder)
+        expected_manifest = FileTreeManifest.create(export, exports_sources_folder,
+                                                    output=self._user_io.out)
         self._check_not_corrupted(ref, read_manifest, expected_manifest)
         folder = os.path.join(self._target_folder, ref.dir_repr(), EXPORT_FOLDER)
         self._handle_folder(folder, ref, read_manifest, interactive, node.remote, verify)
@@ -41,7 +42,7 @@ class ManifestManager(object):
         pref = PackageReference(ref, node.package_id)
         package_folder = self._cache.package_layout(pref.ref).package(pref)
         read_manifest = FileTreeManifest.load(package_folder)
-        expected_manifest = FileTreeManifest.create(package_folder)
+        expected_manifest = FileTreeManifest.create(package_folder, output=self._user_io.out)
         self._check_not_corrupted(pref, read_manifest, expected_manifest)
         folder = os.path.join(self._target_folder, ref.dir_repr(), PACKAGES_FOLDER, pref.id)
         self._handle_folder(folder, pref, read_manifest, interactive, node.remote, verify)

--- a/conans/client/packager.py
+++ b/conans/client/packager.py
@@ -22,7 +22,7 @@ def export_pkg(conanfile, package_id, src_package_folder, package_folder, hook_m
     hook_manager.execute("pre_package", conanfile=conanfile, conanfile_path=conanfile_path,
                          reference=ref, package_id=package_id)
 
-    copier = FileCopier([src_package_folder], package_folder)
+    copier = FileCopier([src_package_folder], package_folder, output=conanfile.output)
     copier("*", symlinks=True)
 
     save(os.path.join(package_folder, CONANINFO), conanfile.info.dumps())
@@ -62,7 +62,7 @@ def create_package(conanfile, package_id, source_folder, build_folder, package_f
         output.highlight("Calling package()")
 
         folders = [source_folder, build_folder] if source_folder != build_folder else [build_folder]
-        conanfile.copy = FileCopier(folders, package_folder)
+        conanfile.copy = FileCopier(folders, package_folder, output=conanfile.output)
         with conanfile_exception_formatter(str(conanfile), "package"):
             with chdir(build_folder):
                 conanfile.package()

--- a/conans/client/packager.py
+++ b/conans/client/packager.py
@@ -26,7 +26,7 @@ def export_pkg(conanfile, package_id, src_package_folder, package_folder, hook_m
     copier("*", symlinks=True)
 
     save(os.path.join(package_folder, CONANINFO), conanfile.info.dumps())
-    digest = FileTreeManifest.create(package_folder)
+    digest = FileTreeManifest.create(package_folder, output=conanfile.output)
     digest.save(package_folder)
 
     _report_files_from_manifest(output, package_folder)
@@ -103,7 +103,7 @@ def _create_aux_files(install_folder, package_folder, conanfile, copy_info):
         save(os.path.join(package_folder, CONANINFO), conanfile.info.dumps())
 
     # Create the digest for the package
-    digest = FileTreeManifest.create(package_folder)
+    digest = FileTreeManifest.create(package_folder, output=conanfile.output)
     digest.save(package_folder)
 
 

--- a/conans/client/remote_manager.py
+++ b/conans/client/remote_manager.py
@@ -283,7 +283,7 @@ def uncompress_file(src_path, dest_folder, output):
     try:
         with progress_bar.open_binary(src_path, desc="Decompressing %s" % os.path.basename(src_path),
                                       output=output) as file_handler:
-            tar_extract(file_handler, dest_folder)
+            tar_extract(file_handler, dest_folder, output=output)
     except Exception as e:
         error_msg = "Error while downloading/extracting files to %s\n%s\n" % (dest_folder, str(e))
         # try to remove the files

--- a/conans/client/source.py
+++ b/conans/client/source.py
@@ -10,7 +10,8 @@ from conans.errors import ConanException, ConanExceptionInUserConanfileMethod, \
 from conans.model.conan_file import get_env_context_manager
 from conans.model.scm import SCM, get_scm_data
 from conans.paths import CONANFILE, CONAN_MANIFEST, EXPORT_SOURCES_TGZ_NAME, EXPORT_TGZ_NAME
-from conans.util.files import (clean_dirty, is_dirty, load, mkdir, rmdir, set_dirty, walk)
+from conans.util.files import clean_dirty, is_dirty, load, mkdir, rmdir, set_dirty, walk, \
+    copy_symlink
 
 
 def complete_recipe_sources(remote_manager, cache, conanfile, ref, remotes):
@@ -53,29 +54,13 @@ def merge_directories(src, dst, excluded=None):
             return True
         return False
 
-    def link_to_rel(pointer_src):
-        linkto = os.readlink(pointer_src)
-        if not os.path.isabs(linkto):
-            linkto = os.path.join(os.path.dirname(pointer_src), linkto)
-
-        # Check if it is outside the sources
-        out_of_source = os.path.relpath(linkto, os.path.realpath(src)).startswith(".")
-        if out_of_source:
-            # May warn about out of sources symlink
-            return
-
-        # Create the symlink
-        linkto_rel = os.path.relpath(linkto, os.path.dirname(pointer_src))
-        pointer_dst = os.path.normpath(os.path.join(dst, os.path.relpath(pointer_src, src)))
-        os.symlink(linkto_rel, pointer_dst)
-
     for src_dir, dirs, files in walk(src, followlinks=True):
         if is_excluded(src_dir):
             dirs[:] = []
             continue
 
         if os.path.islink(src_dir):
-            link_to_rel(src_dir)
+            copy_symlink(src_dir, src, dst)
             dirs[:] = []  # Do not enter subdirectories
             continue
 
@@ -89,7 +74,7 @@ def merge_directories(src, dst, excluded=None):
             src_file = os.path.join(src_dir, file_)
             dst_file = os.path.join(dst_dir, file_)
             if os.path.islink(src_file):
-                link_to_rel(src_file)
+                copy_symlink(src_file, src, dst)
             else:
                 shutil.copy2(src_file, dst_file)
 

--- a/conans/model/manifest.py
+++ b/conans/model/manifest.py
@@ -20,9 +20,11 @@ def discarded_file(filename):
 
 
 def gather_files(folder):
+    assert not os.path.islink(folder), "The folder ('{}') passed to 'gather_files'" \
+                                       " cannot be a symlink".format(folder)
     file_dict = {}
     symlinks = {}
-    for root, dirs, files in walk(folder):
+    for root, dirs, files in walk(folder, followlinks=False):
         dirs[:] = [d for d in dirs if d != "__pycache__"]  # Avoid recursing pycache
         for d in dirs:
             abs_path = os.path.join(root, d)

--- a/conans/model/manifest.py
+++ b/conans/model/manifest.py
@@ -46,7 +46,7 @@ def gather_files(folder, output):
                 linkto = os.path.join(os.path.dirname(abs_path), os.readlink(abs_path))
                 linkto = os.path.normpath(linkto)
                 if os.path.exists(linkto):
-                    relpath = os.path.relpath(abs_path, folder)
+                    relpath = os.path.relpath(abs_path, folder).replace("\\", "/")
                     symlinks[relpath] = os.path.relpath(linkto, folder)
                 else:
                     warn_broken_symlink(abs_path, linkto, do_raise=False)
@@ -56,7 +56,7 @@ def gather_files(folder, output):
             if discarded_file(f):
                 continue
             abs_path = os.path.join(root, f)
-            relpath = os.path.relpath(abs_path, folder)
+            relpath = os.path.relpath(abs_path, folder).replace("\\", "/")
 
             if os.path.islink(abs_path):
                 linkto = os.path.join(os.path.dirname(abs_path), os.readlink(abs_path))

--- a/conans/test/functional/graph/graph_manager_base.py
+++ b/conans/test/functional/graph/graph_manager_base.py
@@ -49,7 +49,8 @@ class GraphManagerTest(unittest.TestCase):
         save(self.cache.package_layout(ref).conanfile(), str(test_conanfile))
         with self.cache.package_layout(ref).update_metadata() as metadata:
             metadata.recipe.revision = revision or "123"
-        manifest = FileTreeManifest.create(self.cache.package_layout(ref).export())
+        manifest = FileTreeManifest.create(self.cache.package_layout(ref).export(),
+                                           output=self.output)
         manifest.save(self.cache.package_layout(ref).export())
 
     def build_graph(self, content, profile_build_requires=None, ref=None, create_ref=None):

--- a/conans/test/functional/old/file_copier_test.py
+++ b/conans/test/functional/old/file_copier_test.py
@@ -21,7 +21,7 @@ class FileCopierTest(unittest.TestCase):
         save(os.path.join(sub2, "file2.c"), "2 Hello2")
 
         folder2 = temp_folder()
-        copier = FileCopier([folder1], folder2)
+        copier = FileCopier([folder1], folder2, output=None)
         copier("*.txt", "texts")
         self.assertEqual("Hello1", load(os.path.join(folder2, "texts/subdir1/file1.txt")))
         self.assertEqual("Hello1 sub", load(os.path.join(folder2, "texts/subdir1/sub1/file1.txt")))
@@ -29,7 +29,7 @@ class FileCopierTest(unittest.TestCase):
         self.assertEqual(['file1.txt'], os.listdir(os.path.join(folder2, "texts/subdir2")))
 
         folder2 = temp_folder()
-        copier = FileCopier([folder1], folder2)
+        copier = FileCopier([folder1], folder2, output=None)
         copier("*.txt", "texts", "subdir1")
         self.assertEqual("Hello1", load(os.path.join(folder2, "texts/file1.txt")))
         self.assertEqual("Hello1 sub", load(os.path.join(folder2, "texts/sub1/file1.txt")))
@@ -48,7 +48,7 @@ class FileCopierTest(unittest.TestCase):
 
         for links in (False, True):
             folder2 = temp_folder()
-            copier = FileCopier([folder1], folder2)
+            copier = FileCopier([folder1], folder2, output=None)
             copier("*.txt", "texts", links=links)
             if links:
                 self.assertEqual(os.readlink(os.path.join(folder2, "texts/subdir2")), "subdir1") # @UndefinedVariable
@@ -59,7 +59,7 @@ class FileCopierTest(unittest.TestCase):
 
         for links in (False, True):
             folder2 = temp_folder()
-            copier = FileCopier([folder1], folder2)
+            copier = FileCopier([folder1], folder2, output=None)
             copier("*.txt", "texts", "subdir1", links=links)
             self.assertEqual("Hello1", load(os.path.join(folder2, "texts/file1.txt")))
             self.assertEqual("Hello1 sub", load(os.path.join(folder2, "texts/sub1/file1.txt")))
@@ -77,7 +77,7 @@ class FileCopierTest(unittest.TestCase):
         save(os.path.join(sub1, "sub1/file1.txt"), "Hello1 sub")
 
         folder2 = temp_folder()
-        copier = FileCopier([folder1], folder2)
+        copier = FileCopier([folder1], folder2, output=None)
         copier("*.cpp", links=True)
         self.assertEqual(os.listdir(folder2), [])
         copier("*.txt", links=True)
@@ -95,7 +95,7 @@ class FileCopierTest(unittest.TestCase):
         os.symlink("other/file", sub2)  # @UndefinedVariable
 
         folder2 = temp_folder()
-        copier = FileCopier([folder1], folder2)
+        copier = FileCopier([folder1], folder2, output=None)
         copier("*", links=True)
         symlink = os.path.join(folder2, "foo", "symlink")
         self.assertTrue(os.path.islink(symlink))
@@ -111,7 +111,7 @@ class FileCopierTest(unittest.TestCase):
         os.symlink("60.2", sub2)  # @UndefinedVariable
 
         folder2 = temp_folder()
-        copier = FileCopier([folder1], folder2)
+        copier = FileCopier([folder1], folder2, output=None)
         copied = copier("*.cpp", links=True)
         self.assertEqual(copied, [])
 
@@ -140,7 +140,7 @@ class FileCopierTest(unittest.TestCase):
         save(src_dir_file, "file")
         os.symlink(src_dir, src_dir_link)
 
-        copier = FileCopier([src], dst)
+        copier = FileCopier([src], dst, output=None)
         copied = copier("*", symlinks=True)
 
         self.assertEqual(copied, [dst_dir_file])
@@ -154,7 +154,7 @@ class FileCopierTest(unittest.TestCase):
         save(os.path.join(sub1, "file2.c"), "Hello2")
 
         folder2 = temp_folder()
-        copier = FileCopier([folder1], folder2)
+        copier = FileCopier([folder1], folder2, output=None)
         copier("*.*", "texts", excludes="*.c")
         self.assertEqual(['file1.txt'], os.listdir(os.path.join(folder2, "texts/subdir1")))
 
@@ -163,11 +163,11 @@ class FileCopierTest(unittest.TestCase):
         save(os.path.join(folder1, "MyLibImpl.txt"), "")
         save(os.path.join(folder1, "MyLibTests.txt"), "")
         folder2 = temp_folder()
-        copier = FileCopier([folder1], folder2)
+        copier = FileCopier([folder1], folder2, output=None)
         copier("*.txt", excludes="*Test*.txt")
         self.assertEqual(set(['MyLib.txt', 'MyLibImpl.txt']), set(os.listdir(folder2)))
 
         folder2 = temp_folder()
-        copier = FileCopier([folder1], folder2)
+        copier = FileCopier([folder1], folder2, output=None)
         copier("*.txt", excludes=("*Test*.txt", "*Impl*"))
         self.assertEqual(['MyLib.txt'], os.listdir(folder2))

--- a/conans/test/functional/old/file_copier_test.py
+++ b/conans/test/functional/old/file_copier_test.py
@@ -139,6 +139,33 @@ class FileCopierTest(unittest.TestCase):
         self.assertFalse(os.path.islink(symlink))
 
     @unittest.skipUnless(platform.system() != "Windows", "Requires Symlinks")
+    def test_linked_inside_sources_with_dot_test(self):
+        folder1 = temp_folder()
+        foo1 = os.path.join(folder1, ".symlink_file")
+        other1 = os.path.join(folder1, ".file")
+        save(other1, "whatever")
+        os.symlink(other1, foo1)  # @UndefinedVariable
+
+        foo2 = os.path.join(folder1, ".symlink_folder")
+        other2 = os.path.join(folder1, ".folder")
+        save(os.path.join(other2, "file"), "whatever")
+        os.symlink(other2, foo2)  # @UndefinedVariable
+
+        folder2 = temp_folder()
+        output = TestBufferConanOutput()
+        copier = FileCopier([folder1], folder2, output=output)
+        copier("*", links=True)
+        self.assertEqual(str(output), "")
+
+        symlink = os.path.join(folder2, ".symlink_file")
+        self.assertTrue(os.path.islink(symlink))
+        self.assertTrue(os.path.exists(symlink))
+
+        symlink = os.path.join(folder2, ".symlink_folder")
+        self.assertTrue(os.path.islink(symlink))
+        self.assertTrue(os.path.exists(symlink))
+
+    @unittest.skipUnless(platform.system() != "Windows", "Requires Symlinks")
     def linked_folder_nested_test(self):
         # https://github.com/conan-io/conan/issues/2959
         folder1 = temp_folder()

--- a/conans/test/functional/old/remove_old_export_sources_layout_test.py
+++ b/conans/test/functional/old/remove_old_export_sources_layout_test.py
@@ -37,7 +37,7 @@ class MyPkg(ConanFile):
         self.assertTrue(os.path.exists(sources_tgz))
         folder = temp_folder()
         with open(sources_tgz, 'rb') as file_handler:
-            tar_extract(file_handler, folder)
+            tar_extract(file_handler, folder, output=None)
         self.assertEqual(os.listdir(folder), ["myfile.txt"])
         # Now install again
         client.run("install Pkg/0.1@lasote/testing --build=missing")

--- a/conans/test/functional/symlinks/compress_files_test.py
+++ b/conans/test/functional/symlinks/compress_files_test.py
@@ -1,0 +1,60 @@
+# coding=utf-8
+
+import os
+import platform
+import unittest
+
+import six
+
+from conans.client.cmd.uploader import _compress_files
+from conans.client.tools import environment_append
+from conans.client.tools.files import chdir
+from conans.model.manifest import gather_files
+from conans.test.utils.test_files import temp_folder
+from conans.test.utils.tools import TestBufferConanOutput
+from conans.util.files import save, save_files
+
+
+@unittest.skipUnless(platform.system() != "Windows", "Symlinks not handled for Windows")
+class CompressFilesTestCase(unittest.TestCase):
+
+    def setUp(self):
+        self.tmp_folder = temp_folder()
+        with chdir(self.tmp_folder):
+            # Create some files
+            save("linked_file", "")
+            os.makedirs("linked_folder")
+            ori_files_dir = os.path.join(self.tmp_folder, "ori")
+            save_files(ori_files_dir, {"file1": "",
+                                       "folder/file2": ""})
+            # And symlinks pointing outside
+            self.out_folder = os.path.join(ori_files_dir, "out_folder")
+            os.symlink(os.path.join(self.tmp_folder, "linked_folder"), self.out_folder)
+            self.out_file = os.path.join(ori_files_dir, "out_file")
+            os.symlink(os.path.join(self.tmp_folder, "linked_file"), self.out_file)
+
+        with environment_append({"CONAN_SKIP_BROKEN_SYMLINKS_CHECK": "True"}):
+            self.gathered_files = gather_files(os.path.join(self.tmp_folder, "ori"), output=None)
+
+    def test_warn_outside(self):
+        output = TestBufferConanOutput()
+        _compress_files(self.gathered_files, "compress.tar.gz", self.tmp_folder, output=output)
+        # Warn about the folder
+        self.assertIn("WARN: Symbolic link '{}' points to".format(self.out_folder), output)
+        # Want about the file
+        self.assertIn("WARN: Symbolic link '{}' points to".format(self.out_file), output)
+
+    def test_broken_file(self):
+        os.unlink(os.path.join(self.tmp_folder, 'linked_file'))
+
+        output = TestBufferConanOutput()
+        with six.assertRaisesRegex(self, Exception, "No such file or directory:"
+                                                    " '{}'".format(self.out_file)):
+            _compress_files(self.gathered_files, "compress.tar.gz", self.tmp_folder, output=output)
+
+    def test_broken_directory(self):
+        os.rmdir(os.path.join(self.tmp_folder, 'linked_folder'))
+
+        output = TestBufferConanOutput()
+        _compress_files(self.gathered_files, "compress.tar.gz", self.tmp_folder, output=output)
+        # TODO: Should raise exception?

--- a/conans/test/functional/symlinks/compress_files_test.py
+++ b/conans/test/functional/symlinks/compress_files_test.py
@@ -26,19 +26,29 @@ class CompressFilesTestCase(unittest.TestCase):
             os.makedirs("linked_folder")
             ori_files_dir = os.path.join(self.tmp_folder, "ori")
             save_files(ori_files_dir, {"file1": "",
-                                       "folder/file2": ""})
+                                       "folder/file2": "",
+                                       ".file1": "",
+                                       ".folder/file2": ""})
             # And symlinks pointing outside
             self.out_folder = os.path.join(ori_files_dir, "out_folder")
             os.symlink(os.path.join(self.tmp_folder, "linked_folder"), self.out_folder)
             self.out_file = os.path.join(ori_files_dir, "out_file")
             os.symlink(os.path.join(self.tmp_folder, "linked_file"), self.out_file)
 
+            # And some pointing inside
+            self.in_folder = os.path.join(ori_files_dir, ".in_folder")
+            os.symlink(os.path.join(ori_files_dir, ".folder"), self.in_folder)
+            self.in_file = os.path.join(ori_files_dir, ".in_file")
+            os.symlink(os.path.join(ori_files_dir, ".file1"), self.in_file)
+
+        output = TestBufferConanOutput()
         with environment_append({"CONAN_SKIP_BROKEN_SYMLINKS_CHECK": "True"}):
-            self.gathered_files = gather_files(os.path.join(self.tmp_folder, "ori"), output=None)
+            self.gathered_files = gather_files(os.path.join(self.tmp_folder, "ori"), output=output)
 
     def test_warn_outside(self):
         output = TestBufferConanOutput()
         _compress_files(self.gathered_files, "compress.tar.gz", self.tmp_folder, output=output)
+        self.assertEqual(str(output).count("WARN: Symbolic link"), 2)
         # Warn about the folder
         self.assertIn("WARN: Symbolic link '{}' points to".format(self.out_folder), output)
         # Want about the file
@@ -51,10 +61,12 @@ class CompressFilesTestCase(unittest.TestCase):
         with six.assertRaisesRegex(self, Exception, "No such file or directory:"
                                                     " '{}'".format(self.out_file)):
             _compress_files(self.gathered_files, "compress.tar.gz", self.tmp_folder, output=output)
+        self.assertEqual(str(output).count("WARN: Symbolic link"), 1)
 
     def test_broken_directory(self):
         os.rmdir(os.path.join(self.tmp_folder, 'linked_folder'))
 
         output = TestBufferConanOutput()
         _compress_files(self.gathered_files, "compress.tar.gz", self.tmp_folder, output=output)
+        self.assertEqual(str(output).count("WARN: Symbolic link"), 2)
         # TODO: Should raise exception?

--- a/conans/test/functional/symlinks/copy_symlink_test.py
+++ b/conans/test/functional/symlinks/copy_symlink_test.py
@@ -32,6 +32,24 @@ class CopySymlinkTestSuite(unittest.TestCase):
         self.assertTrue(os.path.islink(os.path.join(dst_folder, "link_file")))
         self.assertFalse(os.path.exists(os.path.join(dst_folder, "link_file")))
 
+    @parameterized.expand([(False, ), (True, )])
+    def test_symlink_inside_with_dot(self, file_exists):
+        ori_folder = temp_folder()
+        linked_file = os.path.join(ori_folder, ".file")
+        if file_exists:
+            save(linked_file, "")
+        ptr_source = os.path.join(ori_folder, ".link_file")
+        os.symlink(linked_file, ptr_source)
+
+        output = TestBufferConanOutput()
+        dst_folder = temp_folder()
+        copy_symlink(ptr_source, ori_folder, dst_folder, output=output)
+
+        self.assertEqual("", str(output))
+        # The link exists, but the file has not been copied yet
+        self.assertTrue(os.path.islink(os.path.join(dst_folder, ".link_file")))
+        self.assertFalse(os.path.exists(os.path.join(dst_folder, ".link_file")))
+
     @parameterized.expand([(False,), (True,)])
     def test_symlink_outside(self, file_exists):
         base_folder = temp_folder()

--- a/conans/test/functional/symlinks/copy_symlink_test.py
+++ b/conans/test/functional/symlinks/copy_symlink_test.py
@@ -1,0 +1,54 @@
+# coding=utf-8
+
+import os
+import platform
+import unittest
+
+from parameterized import parameterized
+
+from conans.test.utils.test_files import temp_folder
+from conans.test.utils.tools import TestBufferConanOutput
+from conans.util.files import save, copy_symlink
+
+
+@unittest.skipUnless(platform.system() != "Windows", "Symlinks not handled for Windows")
+class CopySymlinkTestSuite(unittest.TestCase):
+
+    @parameterized.expand([(False, ), (True, )])
+    def test_symlink_inside(self, file_exists):
+        ori_folder = temp_folder()
+        linked_file = os.path.join(ori_folder, "file")
+        if file_exists:
+            save(linked_file, "")
+        ptr_source = os.path.join(ori_folder, "link_file")
+        os.symlink(linked_file, ptr_source)
+
+        output = TestBufferConanOutput()
+        dst_folder = temp_folder()
+        copy_symlink(ptr_source, ori_folder, dst_folder, output=output)
+
+        self.assertEqual("", str(output))
+        # The link exists, but the file has not been copied yet
+        self.assertTrue(os.path.islink(os.path.join(dst_folder, "link_file")))
+        self.assertFalse(os.path.exists(os.path.join(dst_folder, "link_file")))
+
+    @parameterized.expand([(False,), (True,)])
+    def test_symlink_outside(self, file_exists):
+        base_folder = temp_folder()
+        linked_file = os.path.join(base_folder, "file")
+        if file_exists:
+            save(linked_file, "")
+
+        ori_folder = os.path.join(base_folder, "ori")
+        os.makedirs(ori_folder)
+        ptr_source = os.path.join(ori_folder, "link_file")
+        os.symlink(linked_file, ptr_source)
+
+        output = TestBufferConanOutput()
+        dst_folder = temp_folder()
+        copy_symlink(ptr_source, ori_folder, dst_folder, output=output)
+
+        self.assertIn("WARN: Symbolic link '{}' is pointing to '{}' outside the source folder"
+                      " and won't be copied".format(ptr_source, ori_folder), str(output))
+        # The link doesn't exists
+        self.assertFalse(os.path.islink(os.path.join(dst_folder, "link_file")))

--- a/conans/test/functional/symlinks/gather_files_test.py
+++ b/conans/test/functional/symlinks/gather_files_test.py
@@ -1,6 +1,7 @@
 # coding=utf-8
 
 import os
+import platform
 import unittest
 
 import six
@@ -14,6 +15,7 @@ from conans.test.utils.tools import TestBufferConanOutput
 from conans.util.files import save, save_files
 
 
+@unittest.skipUnless(platform.system() != "Windows", "Symlinks not handled for Windows")
 class GatherFilesTestCase(unittest.TestCase):
 
     def setUp(self):

--- a/conans/test/functional/symlinks/gather_files_test.py
+++ b/conans/test/functional/symlinks/gather_files_test.py
@@ -1,0 +1,75 @@
+# coding=utf-8
+
+import os
+import unittest
+
+import six
+
+from conans.client.tools import environment_append
+from conans.client.tools.files import chdir
+from conans.errors import ConanException
+from conans.model.manifest import gather_files
+from conans.test.utils.test_files import temp_folder
+from conans.test.utils.tools import TestBufferConanOutput
+from conans.util.files import save, save_files
+
+
+class GatherFilesTestCase(unittest.TestCase):
+
+    def setUp(self):
+        self.tmp_folder = temp_folder()
+        with chdir(self.tmp_folder):
+            # Create some files
+            save("linked_file", "")
+            os.makedirs("linked_folder")
+            ori_files_dir = os.path.join(self.tmp_folder, "ori")
+            save_files(ori_files_dir, {"file1": "",
+                                       "folder/file2": ""})
+            # And symlinks pointing outside
+            os.symlink(os.path.join(self.tmp_folder, "linked_folder"),
+                       os.path.join(ori_files_dir, "out_folder"))
+            os.symlink(os.path.join(self.tmp_folder, "linked_file"),
+                       os.path.join(ori_files_dir, "out_file"))
+
+    def test_basic_behavior(self):
+        output = TestBufferConanOutput()
+        gathered_files = gather_files(os.path.join(self.tmp_folder, "ori"), output)
+        self.assertListEqual(sorted(gathered_files.files.keys()),
+                             ['file1', 'folder/file2', 'out_file'])
+        self.assertListEqual(sorted(gathered_files.symlinks.keys()), ['out_folder'])
+
+    def test_error_broken_file(self):
+        os.unlink(os.path.join(self.tmp_folder, 'linked_file'))
+
+        output = TestBufferConanOutput()
+        with six.assertRaisesRegex(self, ConanException, "The file is a broken symlink"):
+            gather_files(os.path.join(self.tmp_folder, "ori"), output)
+
+    def test_error_broken_directory(self):
+        os.rmdir(os.path.join(self.tmp_folder, 'linked_folder'))
+
+        output = TestBufferConanOutput()
+        with six.assertRaisesRegex(self, ConanException, "The file is a broken symlink"):
+            gather_files(os.path.join(self.tmp_folder, "ori"), output)
+
+    def test_warn_broken_file(self):
+        os.unlink(os.path.join(self.tmp_folder, 'linked_file'))
+
+        output = TestBufferConanOutput()
+        with environment_append({"CONAN_SKIP_BROKEN_SYMLINKS_CHECK": "True"}):
+            gathered_files = gather_files(os.path.join(self.tmp_folder, "ori"), output)
+        self.assertIn("WARN: Broken symlink", output)
+        self.assertListEqual(sorted(gathered_files.files.keys()),
+                             ['file1', 'folder/file2',])
+        self.assertListEqual(sorted(gathered_files.symlinks.keys()), ['out_folder'])
+
+    def test_warn_broken_directory(self):
+        os.rmdir(os.path.join(self.tmp_folder, 'linked_folder'))
+
+        output = TestBufferConanOutput()
+        with environment_append({"CONAN_SKIP_BROKEN_SYMLINKS_CHECK": "True"}):
+            gathered_files = gather_files(os.path.join(self.tmp_folder, "ori"), output)
+        self.assertIn("WARN: Broken symlink", output)
+        self.assertListEqual(sorted(gathered_files.files.keys()),
+                             ['file1', 'folder/file2', 'out_file'])
+        self.assertListEqual(sorted(gathered_files.symlinks.keys()), [])

--- a/conans/test/functional/symlinks/tar_extract_test.py
+++ b/conans/test/functional/symlinks/tar_extract_test.py
@@ -1,6 +1,7 @@
 # coding=utf-8
 
 import os
+import platform
 import unittest
 
 from conans.client.cmd.uploader import _compress_files
@@ -12,6 +13,7 @@ from conans.test.utils.tools import TestBufferConanOutput
 from conans.util.files import tar_extract, save, save_files
 
 
+@unittest.skipUnless(platform.system() != "Windows", "Symlinks not handled for Windows")
 class TarExtractTestSuite(unittest.TestCase):
 
     def setUp(self):

--- a/conans/test/functional/symlinks/tar_extract_test.py
+++ b/conans/test/functional/symlinks/tar_extract_test.py
@@ -1,0 +1,49 @@
+# coding=utf-8
+
+import os
+import unittest
+
+from conans.client.cmd.uploader import _compress_files
+from conans.client.tools import environment_append
+from conans.client.tools.files import chdir
+from conans.model.manifest import gather_files
+from conans.test.utils.test_files import temp_folder
+from conans.test.utils.tools import TestBufferConanOutput
+from conans.util.files import tar_extract, save, save_files
+
+
+class TarExtractTestSuite(unittest.TestCase):
+
+    def setUp(self):
+        self.tmp_folder = temp_folder()
+        with chdir(self.tmp_folder):
+            # Create some files
+            save("linked_file", "")
+            os.makedirs("linked_folder")
+            ori_files_dir = os.path.join(self.tmp_folder, "ori")
+            save_files(ori_files_dir, {"file1": "",
+                                       "folder/file2": ""})
+            # And symlinks pointing outside
+            os.symlink(os.path.join(self.tmp_folder, "linked_folder"),
+                       os.path.join(ori_files_dir, "out_folder"))
+            os.symlink(os.path.join(self.tmp_folder, "linked_file"),
+                       os.path.join(ori_files_dir, "out_file"))
+
+        with environment_append({"CONAN_SKIP_BROKEN_SYMLINKS_CHECK": "True"}):
+            gathered_files = gather_files(ori_files_dir, output=None)
+
+        # Create a tar.gz file with the above files
+        self.tgz_file = _compress_files(gathered_files, "file.tar.gz", self.tmp_folder, output=None)
+
+    def test_warn_outside_symlink(self):
+        output = TestBufferConanOutput()
+        dst_folder = temp_folder()
+        with open(self.tgz_file, 'rb') as file_handler:
+            tar_extract(file_handler, dst_folder, output=output)
+
+        self.assertIn("WARN: File 'out_folder' inside the tar is a symlink pointing outside"
+                      " the tar, it will be skipped", output)
+        self.assertIn("WARN: File 'out_file' inside the tar is a symlink pointing outside"
+                      " the tar, it will be skipped", output)
+
+        self.assertListEqual(sorted(os.listdir(dst_folder)), ['file1', 'folder'])

--- a/conans/test/unittests/client/remote_manager_test.py
+++ b/conans/test/unittests/client/remote_manager_test.py
@@ -20,7 +20,7 @@ class RemoteManagerTest(unittest.TestCase):
         }
 
         gathered_files = _GatheredFiles("", files, {})
-        path = _compress_files(gathered_files, PACKAGE_TGZ_NAME, dest_dir=folder)
+        path = _compress_files(gathered_files, PACKAGE_TGZ_NAME, dest_dir=folder, output=None)
         self.assertTrue(os.path.exists(path))
         expected_path = os.path.join(folder, PACKAGE_TGZ_NAME)
         self.assertEqual(path, expected_path)

--- a/conans/test/unittests/client/remote_manager_test.py
+++ b/conans/test/unittests/client/remote_manager_test.py
@@ -1,7 +1,8 @@
 import os
 import unittest
 
-from conans.client.cmd.uploader import _compress_files, _GatheredFiles
+from conans.client.cmd.uploader import _compress_files
+from conans.model.manifest import _GatheredFiles
 from conans.paths import PACKAGE_TGZ_NAME
 from conans.test.utils.test_files import temp_folder
 from conans.util.files import save

--- a/conans/test/unittests/client/remote_manager_test.py
+++ b/conans/test/unittests/client/remote_manager_test.py
@@ -1,7 +1,7 @@
 import os
 import unittest
 
-from conans.client.cmd.uploader import _compress_files
+from conans.client.cmd.uploader import _compress_files, _GatheredFiles
 from conans.paths import PACKAGE_TGZ_NAME
 from conans.test.utils.test_files import temp_folder
 from conans.util.files import save
@@ -19,7 +19,8 @@ class RemoteManagerTest(unittest.TestCase):
             "Two_file.txt": os.path.join(folder, "Two_file.txt"),
         }
 
-        path = _compress_files(files, {}, PACKAGE_TGZ_NAME, dest_dir=folder)
+        gathered_files = _GatheredFiles("", files, {})
+        path = _compress_files(gathered_files, PACKAGE_TGZ_NAME, dest_dir=folder)
         self.assertTrue(os.path.exists(path))
         expected_path = os.path.join(folder, PACKAGE_TGZ_NAME)
         self.assertEqual(path, expected_path)

--- a/conans/test/unittests/client/remote_manager_test.py
+++ b/conans/test/unittests/client/remote_manager_test.py
@@ -1,7 +1,7 @@
 import os
 import unittest
 
-from conans.client.cmd.uploader import compress_files
+from conans.client.cmd.uploader import _compress_files
 from conans.paths import PACKAGE_TGZ_NAME
 from conans.test.utils.test_files import temp_folder
 from conans.util.files import save
@@ -19,7 +19,7 @@ class RemoteManagerTest(unittest.TestCase):
             "Two_file.txt": os.path.join(folder, "Two_file.txt"),
         }
 
-        path = compress_files(files, {}, PACKAGE_TGZ_NAME, dest_dir=folder)
+        path = _compress_files(files, {}, PACKAGE_TGZ_NAME, dest_dir=folder)
         self.assertTrue(os.path.exists(path))
         expected_path = os.path.join(folder, PACKAGE_TGZ_NAME)
         self.assertEqual(path, expected_path)

--- a/conans/test/unittests/client/util/files_test.py
+++ b/conans/test/unittests/client/util/files_test.py
@@ -2,7 +2,7 @@ import os
 import time
 import unittest
 
-from conans.client.cmd.uploader import _compress_files
+from conans.client.cmd.uploader import _compress_files, _GatheredFiles
 from conans.paths import PACKAGE_TGZ_NAME
 from conans.test.utils.test_files import temp_folder
 from conans.util.files import md5sum, mkdir, path_exists, save
@@ -23,7 +23,8 @@ class FilesTest(unittest.TestCase):
             "Two_file.txt": os.path.join(folder, "Two_file.txt"),
         }
 
-        _compress_files(files, {}, PACKAGE_TGZ_NAME, dest_dir=folder)
+        gathered_files = _GatheredFiles("", files, {})
+        _compress_files(gathered_files, PACKAGE_TGZ_NAME, dest_dir=folder)
         file_path = os.path.join(folder, PACKAGE_TGZ_NAME)
 
         md5_a = md5sum(file_path)
@@ -32,7 +33,8 @@ class FilesTest(unittest.TestCase):
         time.sleep(1)  # Timestamps change
 
         folder = temp_folder()
-        _compress_files(files, {}, PACKAGE_TGZ_NAME, dest_dir=folder)
+        gathered_files = _GatheredFiles("", files, {})
+        _compress_files(gathered_files, PACKAGE_TGZ_NAME, dest_dir=folder)
         file_path = os.path.join(folder, PACKAGE_TGZ_NAME)
 
         md5_b = md5sum(file_path)

--- a/conans/test/unittests/client/util/files_test.py
+++ b/conans/test/unittests/client/util/files_test.py
@@ -2,7 +2,8 @@ import os
 import time
 import unittest
 
-from conans.client.cmd.uploader import _compress_files, _GatheredFiles
+from conans.client.cmd.uploader import _compress_files
+from conans.model.manifest import _GatheredFiles
 from conans.paths import PACKAGE_TGZ_NAME
 from conans.test.utils.test_files import temp_folder
 from conans.util.files import md5sum, mkdir, path_exists, save

--- a/conans/test/unittests/client/util/files_test.py
+++ b/conans/test/unittests/client/util/files_test.py
@@ -34,7 +34,7 @@ class FilesTest(unittest.TestCase):
 
         folder = temp_folder()
         gathered_files = _GatheredFiles("", files, {})
-        _compress_files(gathered_files, PACKAGE_TGZ_NAME, dest_dir=folder)
+        _compress_files(gathered_files, PACKAGE_TGZ_NAME, dest_dir=folder, output=None)
         file_path = os.path.join(folder, PACKAGE_TGZ_NAME)
 
         md5_b = md5sum(file_path)

--- a/conans/test/unittests/client/util/files_test.py
+++ b/conans/test/unittests/client/util/files_test.py
@@ -2,7 +2,7 @@ import os
 import time
 import unittest
 
-from conans.client.cmd.uploader import compress_files
+from conans.client.cmd.uploader import _compress_files
 from conans.paths import PACKAGE_TGZ_NAME
 from conans.test.utils.test_files import temp_folder
 from conans.util.files import md5sum, mkdir, path_exists, save
@@ -23,7 +23,7 @@ class FilesTest(unittest.TestCase):
             "Two_file.txt": os.path.join(folder, "Two_file.txt"),
         }
 
-        compress_files(files, {}, PACKAGE_TGZ_NAME, dest_dir=folder)
+        _compress_files(files, {}, PACKAGE_TGZ_NAME, dest_dir=folder)
         file_path = os.path.join(folder, PACKAGE_TGZ_NAME)
 
         md5_a = md5sum(file_path)
@@ -32,7 +32,7 @@ class FilesTest(unittest.TestCase):
         time.sleep(1)  # Timestamps change
 
         folder = temp_folder()
-        compress_files(files, {}, PACKAGE_TGZ_NAME, dest_dir=folder)
+        _compress_files(files, {}, PACKAGE_TGZ_NAME, dest_dir=folder)
         file_path = os.path.join(folder, PACKAGE_TGZ_NAME)
 
         md5_b = md5sum(file_path)

--- a/conans/test/unittests/client/util/files_test.py
+++ b/conans/test/unittests/client/util/files_test.py
@@ -24,7 +24,7 @@ class FilesTest(unittest.TestCase):
         }
 
         gathered_files = _GatheredFiles("", files, {})
-        _compress_files(gathered_files, PACKAGE_TGZ_NAME, dest_dir=folder)
+        _compress_files(gathered_files, PACKAGE_TGZ_NAME, dest_dir=folder, output=None)
         file_path = os.path.join(folder, PACKAGE_TGZ_NAME)
 
         md5_a = md5sum(file_path)

--- a/conans/test/unittests/util/files/tar_extract_test.py
+++ b/conans/test/unittests/util/files/tar_extract_test.py
@@ -28,8 +28,8 @@ class TarExtractTest(unittest.TestCase):
             with open(self.tgz_file, "wb") as tgz_handle:
                 tgz = gzopen_without_timestamps("name", mode="w", fileobj=tgz_handle)
 
-                files, _ = gather_files(ori_files_dir, output=None)
-                for filename, abs_path in files.items():
+                gathered_files = gather_files(ori_files_dir, output=None)
+                for filename, abs_path in gathered_files.files.items():
                     info = tarfile.TarInfo(name=filename)
                     with open(file1, 'rb') as file_handler:
                         tgz.addfile(tarinfo=info, fileobj=file_handler)

--- a/conans/test/unittests/util/files/tar_extract_test.py
+++ b/conans/test/unittests/util/files/tar_extract_test.py
@@ -28,7 +28,7 @@ class TarExtractTest(unittest.TestCase):
             with open(self.tgz_file, "wb") as tgz_handle:
                 tgz = gzopen_without_timestamps("name", mode="w", fileobj=tgz_handle)
 
-                files, _ = gather_files(ori_files_dir)
+                files, _ = gather_files(ori_files_dir, output=None)
                 for filename, abs_path in files.items():
                     info = tarfile.TarInfo(name=filename)
                     with open(file1, 'rb') as file_handler:

--- a/conans/test/unittests/util/files/tar_extract_test.py
+++ b/conans/test/unittests/util/files/tar_extract_test.py
@@ -52,12 +52,12 @@ class TarExtractTest(unittest.TestCase):
             # Unpack and check
             destination_dir = os.path.join(self.tmp_folder, "dest")
             with open(self.tgz_file, 'rb') as file_handler:
-                tar_extract(file_handler, destination_dir)
+                tar_extract(file_handler, destination_dir, output=None)
             check_files(destination_dir)
 
             # Unpack and check (now we have a symlinked local folder)
             os.symlink(temp_folder(), "folder")
             destination_dir = os.path.join(self.tmp_folder, "dest2")
             with open(self.tgz_file, 'rb') as file_handler:
-                tar_extract(file_handler, destination_dir)
+                tar_extract(file_handler, destination_dir, output=None)
             check_files(destination_dir)

--- a/conans/util/files.py
+++ b/conans/util/files.py
@@ -337,3 +337,30 @@ def exception_message_safe(exc):
         return str(exc)
     except Exception:
         return decode_text(repr(exc))
+
+
+def copy_symlink(pointer_src, src, dst):
+    """
+    Copy the symlink 'pointer_src' from the 'src' directory to the 'dst' one. It
+    will warn if the linked file is outside the 'src' directory
+
+    :param pointer_src: symlink inside 'src' directory
+    :param src: source directory
+    :param dst: destination directory
+    :return:
+    """
+
+    linkto = os.readlink(pointer_src)
+    if not os.path.isabs(linkto):
+        linkto = os.path.join(os.path.dirname(pointer_src), linkto)
+
+    # Check if it is outside the sources
+    out_of_source = os.path.relpath(linkto, os.path.realpath(src)).startswith(".")
+    if out_of_source:
+        # May warn about out of sources symlink
+        return
+
+    # Create the symlink
+    linkto_rel = os.path.relpath(linkto, os.path.dirname(pointer_src))
+    pointer_dst = os.path.normpath(os.path.join(dst, os.path.relpath(pointer_src, src)))
+    os.symlink(linkto_rel, pointer_dst)

--- a/conans/util/files.py
+++ b/conans/util/files.py
@@ -357,7 +357,7 @@ def copy_symlink(pointer_src, src, dst, output=None):
         linkto = os.path.join(os.path.dirname(pointer_src), linkto)
 
     # Check if it is outside the sources
-    out_of_source = os.path.relpath(linkto, os.path.realpath(src)).startswith(".")
+    out_of_source = os.path.relpath(linkto, os.path.realpath(src)).startswith("../")
     if out_of_source and output:
         output.warn("Symbolic link '{}' is pointing to '{}' outside the source folder"
                     " and won't be copied".format(os.path.normpath(pointer_src),

--- a/conans/util/files.py
+++ b/conans/util/files.py
@@ -294,13 +294,13 @@ def gzopen_without_timestamps(name, mode="r", fileobj=None, compresslevel=None, 
 def tar_extract(fileobj, destination_dir, output):
     """Extract tar file controlling not absolute paths and fixing the routes
     if the tar was zipped in windows"""
+    base = os.path.realpath(os.path.abspath(destination_dir))
+
     def badpath(path, base):
         # joinpath will ignore base if path is absolute
         return not os.path.realpath(os.path.abspath(os.path.join(base, path))).startswith(base)
 
     def safemembers(members):
-        base = os.path.realpath(os.path.abspath(destination_dir))
-
         for finfo in members:
             if badpath(finfo.name, base) or \
                (finfo.islnk() or finfo.issym() and badpath(finfo.linkname, base)):

--- a/conans/util/files.py
+++ b/conans/util/files.py
@@ -302,7 +302,8 @@ def tar_extract(fileobj, destination_dir, output):
         base = os.path.realpath(os.path.abspath(destination_dir))
 
         for finfo in members:
-            if badpath(finfo.name, base) or finfo.islnk():
+            if badpath(finfo.name, base) or \
+               (finfo.islnk() or finfo.issym() and badpath(finfo.linkname, base)):
                 if output:
                     output.warn("File '{}' inside the tar is a symlink pointing outside the"
                                 " tar, it will be skipped".format(finfo.name))

--- a/conans/util/files.py
+++ b/conans/util/files.py
@@ -339,7 +339,7 @@ def exception_message_safe(exc):
         return decode_text(repr(exc))
 
 
-def copy_symlink(pointer_src, src, dst):
+def copy_symlink(pointer_src, src, dst, output=None):
     """
     Copy the symlink 'pointer_src' from the 'src' directory to the 'dst' one. It
     will warn if the linked file is outside the 'src' directory
@@ -347,6 +347,7 @@ def copy_symlink(pointer_src, src, dst):
     :param pointer_src: symlink inside 'src' directory
     :param src: source directory
     :param dst: destination directory
+    :param output:
     :return:
     """
 
@@ -356,8 +357,10 @@ def copy_symlink(pointer_src, src, dst):
 
     # Check if it is outside the sources
     out_of_source = os.path.relpath(linkto, os.path.realpath(src)).startswith(".")
-    if out_of_source:
-        # May warn about out of sources symlink
+    if out_of_source and output:
+        output.warn("Symbolic link '{}' is pointing to '{}' outside the source folder"
+                    " and won't be copied".format(os.path.normpath(pointer_src),
+                                                  os.path.normpath(src)))
         return
 
     # Create the symlink


### PR DESCRIPTION
Changelog: Fix: Better handling of symlinks, warn the user about skipped ones
Docs: omit

This PR output warnings related to any symlink broken or pointing outside the origin directory of any copy, compress or extract action. It is touching the following functionalities:
 * compress files: 
    + warns about symlinks pointing outside the source folder (broken symlinks have already been handled before entering this function)
     + for compatibility, it still adds these files to the zip/tar
 * gather files: 
    + warn about broken symlinks
    + do not add broken symlinks to the files gathered.
 * FileCopier: the helper class used inside recipes `self.copy(...)`:
    + warns about broken symlinks and symlinks outside the source folder
    + do not copy broken symlinks and those outside the source folder
 * `tar_extract`:
    + warn about symlinks pointing outside the extracted directory
    + those symlinks are removed

There are some subtle changes that could lead to breaking changes, I'm adding comments on those conditions. IMO those are safe enough (even suggested in the issue), but I prefer to remark them once again.

Thanks!

Note.- Probably a refactor in the near future related to some of these functions can be useful. I think there are things almost duplicated, and also some of them can be simplified.

closes #4966 
closes #5063 