### PR TITLE
#3558 Add Code climate badge

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,0 +1,4 @@
+plugins:
+  pep8:
+    enabled: true
+

--- a/.pycodestyle
+++ b/.pycodestyle
@@ -1,0 +1,5 @@
+[pycodestyle]
+count = False
+max-line-length = 100
+statistics = True
+

--- a/.pycodestyle
+++ b/.pycodestyle
@@ -1,4 +1,4 @@
-[pycodestyle]
+[pep8]
 count = False
 max-line-length = 100
 statistics = True

--- a/README.rst
+++ b/README.rst
@@ -29,11 +29,11 @@ Conan is a package manager for C and C++ developers:
 
 
 
-+------------------------+-------------------------+-------------------------+
-| **master**             | **develop**             |  **Coverage**           |
-+========================+=========================+=========================+
-| |Build Status Master|  | |Build Status Develop|  |  |Develop coverage|     |
-+------------------------+-------------------------+-------------------------+
++------------------------+-------------------------+-------------------------+-------------------------+
+| **master**             | **develop**             |  **Coverage**           |    **Code Climate**     |
++========================+=========================+=========================+=========================+
+| |Build Status Master|  | |Build Status Develop|  |  |Develop coverage|     |   |Develop climate|     |
++------------------------+-------------------------+-------------------------+-------------------------+
 
 
 Setup
@@ -271,6 +271,9 @@ License
    :height: 50px
    :width: 50 px
    :alt: Conan develop coverage
+
+.. |Develop climate| image:: https://api.codeclimate.com/v1/badges/081b53e570d5220b34e4/maintainability.svg
+   :target: https://codeclimate.com/github/conan-io/conan/maintainability
    
 .. |Logo| image:: https://conan.io/img/jfrog_conan_logo.png
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [pep8]
 count = False
 max-line-length = 100
-statistics = True
+statistics = False
 


### PR DESCRIPTION
This PR introduces Code climate badge on README, but Code Climate generates dynamic badges, which means one of Conan admins will need to access https://codeclimate.com/github/conan-io/conan/badges and get the badge url

Also, it would nice enabling some extra features to scan bad smells:

Repo Settings -> Analysis -> Maintainability:
[*] Identical blocks of code

The default branch to be analyzed can be changed at:
Repo Settings -> General -> Danger zone -> Default Branch

By default it's running pep8

Changelog: Omit
Docs: Omit

closes #3558

- [x] Refer to the issue that supports this Pull Request.
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 

<sup>**Note:** By default this PR will skip the slower tests and will use a limited set of python versions. Check [here](https://github.com/conan-io/conan/blob/develop/.github/PR_INCREASE_TESTING.md) how to increase the testing level by writing some tags in the current PR body text.</sup>
