### PR TITLE
Remove old folder for conan install  (#5376)

### DIFF
--- a/conans/client/conf/config_installer.py
+++ b/conans/client/conf/config_installer.py
@@ -1,7 +1,6 @@
 import json
 import os
 import shutil
-import uuid
 
 from contextlib import contextmanager
 from six.moves.urllib.parse import urlparse
@@ -35,10 +34,10 @@ def _handle_remotes(cache, remote_file):
 
 @contextmanager
 def tmp_config_install_folder(cache):
-    unique_id = uuid.uuid4()
-    tmp_folder = os.path.join(cache.cache_folder, "tmp_config_install_%s" % unique_id)
+    tmp_folder = os.path.join(cache.cache_folder, "tmp_config_install")
     # necessary for Mac OSX, where the temp folders in /var/ are symlinks to /private/var/
     tmp_folder = os.path.realpath(tmp_folder)
+    rmdir(tmp_folder)
     mkdir(tmp_folder)
     try:
         yield tmp_folder

--- a/conans/client/conf/config_installer.py
+++ b/conans/client/conf/config_installer.py
@@ -1,7 +1,7 @@
 import json
 import os
 import shutil
-import datetime
+import uuid
 
 from contextlib import contextmanager
 from six.moves.urllib.parse import urlparse
@@ -35,8 +35,8 @@ def _handle_remotes(cache, remote_file):
 
 @contextmanager
 def tmp_config_install_folder(cache):
-    now = datetime.datetime.now().strftime("%Y%m%d%H%M%S%f")
-    tmp_folder = os.path.join(cache.cache_folder, "tmp_config_install_%s" % now)
+    unique_id = uuid.uuid4()
+    tmp_folder = os.path.join(cache.cache_folder, "tmp_config_install_%s" % unique_id)
     # necessary for Mac OSX, where the temp folders in /var/ are symlinks to /private/var/
     tmp_folder = os.path.realpath(tmp_folder)
     mkdir(tmp_folder)

--- a/conans/client/conf/config_installer.py
+++ b/conans/client/conf/config_installer.py
@@ -1,6 +1,7 @@
 import json
 import os
 import shutil
+import datetime
 
 from contextlib import contextmanager
 from six.moves.urllib.parse import urlparse
@@ -34,7 +35,8 @@ def _handle_remotes(cache, remote_file):
 
 @contextmanager
 def tmp_config_install_folder(cache):
-    tmp_folder = os.path.join(cache.cache_folder, "tmp_config_install")
+    now = datetime.datetime.now().strftime("%Y%m%d%H%M%S%f")
+    tmp_folder = os.path.join(cache.cache_folder, "tmp_config_install_%s" % now)
     # necessary for Mac OSX, where the temp folders in /var/ are symlinks to /private/var/
     tmp_folder = os.path.realpath(tmp_folder)
     mkdir(tmp_folder)

--- a/conans/test/unittests/client/conf/config_installer/test_install_folder.py
+++ b/conans/test/unittests/client/conf/config_installer/test_install_folder.py
@@ -1,6 +1,9 @@
 # coding=utf-8
 
 import unittest
+import os
+from os import listdir
+from os.path import isfile, join
 
 from conans.client.conf.config_installer import tmp_config_install_folder
 from conans.test.utils.tools import TestClient
@@ -12,5 +15,8 @@ class InstallFolderTests(unittest.TestCase):
         client = TestClient()
 
         with tmp_config_install_folder(client.cache) as tmp_folder_first:
+            open(os.path.join(tmp_folder_first, "foobar.txt"), "w+")
             with tmp_config_install_folder(client.cache) as tmp_folder_second:
-                self.assertNotEqual(tmp_folder_first, tmp_folder_second)
+                first = [f for f in listdir(tmp_folder_first) if isfile(join(tmp_folder_first, f))]
+                second = [f for f in listdir(tmp_folder_second) if isfile(join(tmp_folder_second, f))]
+                self.assertEqual(first, second)

--- a/conans/test/unittests/client/conf/config_installer/test_install_folder.py
+++ b/conans/test/unittests/client/conf/config_installer/test_install_folder.py
@@ -2,8 +2,6 @@
 
 import unittest
 import os
-from os import listdir
-from os.path import isfile, join
 
 from conans.client.conf.config_installer import tmp_config_install_folder
 from conans.test.utils.tools import TestClient
@@ -12,11 +10,16 @@ from conans.test.utils.tools import TestClient
 class InstallFolderTests(unittest.TestCase):
 
     def test_unique_install_folder(self):
+        """ Validate if tmp_config_install_folder is removing old folder before creating a new one
+
+        tmp_config_install_folder must create the same folder, but all items must be exclude when a
+        new folder is created.
+        """
         client = TestClient()
 
         with tmp_config_install_folder(client.cache) as tmp_folder_first:
-            open(os.path.join(tmp_folder_first, "foobar.txt"), "w+")
+            temp_file = os.path.join(tmp_folder_first, "foobar.txt")
+            open(temp_file, "w+")
             with tmp_config_install_folder(client.cache) as tmp_folder_second:
-                first = [f for f in listdir(tmp_folder_first) if isfile(join(tmp_folder_first, f))]
-                second = [f for f in listdir(tmp_folder_second) if isfile(join(tmp_folder_second, f))]
-                self.assertEqual(first, second)
+                self.assertEqual(tmp_folder_first, tmp_folder_second)
+                self.assertFalse(os.path.exists(temp_file))

--- a/conans/test/unittests/client/conf/config_installer/test_install_folder.py
+++ b/conans/test/unittests/client/conf/config_installer/test_install_folder.py
@@ -1,0 +1,16 @@
+# coding=utf-8
+
+import unittest
+
+from conans.client.conf.config_installer import tmp_config_install_folder
+from conans.test.utils.tools import TestClient
+
+
+class InstallFolderTests(unittest.TestCase):
+
+    def test_unique_install_folder(self):
+        client = TestClient()
+
+        with tmp_config_install_folder(client.cache) as tmp_folder_first:
+            with tmp_config_install_folder(client.cache) as tmp_folder_second:
+                self.assertNotEqual(tmp_folder_first, tmp_folder_second)


### PR DESCRIPTION
- Run rmdir before creating a new temp folder

Changelog: Fix: Remove old folder for conan install (#5376)
Docs: Omit
fixes #5376

- [x] Refer to the issue that supports this Pull Request.
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 

<sup>**Note:** By default this PR will skip the slower tests and will use a limited set of python versions. Check [here](https://github.com/conan-io/conan/blob/develop/.github/PR_INCREASE_TESTING.md) how to increase the testing level by writing some tags in the current PR body text.</sup>
