### PR TITLE
Update Yum cache only (#5370)

### DIFF
--- a/conans/client/tools/system_pm.py
+++ b/conans/client/tools/system_pm.py
@@ -185,7 +185,7 @@ class YumTool(BaseTool):
         raise ConanException("YumTool::add_repository not implemented")
 
     def update(self):
-        _run(self._runner, "%syum update -y" % self._sudo_str, accepted_returns=[0, 100],
+        _run(self._runner, "%syum check-update -y" % self._sudo_str, accepted_returns=[0, 100],
              output=self._output)
 
     def install(self, package_name):

--- a/conans/test/unittests/client/tools/system_pm_test.py
+++ b/conans/test/unittests/client/tools/system_pm_test.py
@@ -152,7 +152,7 @@ class SystemPackageToolTest(unittest.TestCase):
             os_info.linux_distro = "fedora"
             spt = SystemPackageTool(runner=runner, os_info=os_info, output=self.out)
             spt.update()
-            self.assertEqual(runner.command_called, "sudo -A yum update -y")
+            self.assertEqual(runner.command_called, "sudo -A yum check-update -y")
 
             os_info.linux_distro = "opensuse"
             spt = SystemPackageTool(runner=runner, os_info=os_info, output=self.out)
@@ -224,7 +224,7 @@ class SystemPackageToolTest(unittest.TestCase):
             spt.install("a_package", force=True)
             self.assertEqual(runner.command_called, "yum install -y a_package")
             spt.update()
-            self.assertEqual(runner.command_called, "yum update -y")
+            self.assertEqual(runner.command_called, "yum check-update -y")
 
             os_info.linux_distro = "ubuntu"
             spt = SystemPackageTool(runner=runner, os_info=os_info, output=self.out)
@@ -414,7 +414,7 @@ class SystemPackageToolTest(unittest.TestCase):
             if os_info.with_apt:
                 update_command = "sudo -A apt-get update"
             elif os_info.with_yum:
-                update_command = "sudo -A yum update -y"
+                update_command = "sudo -A yum check-update -y"
             elif os_info.with_zypper:
                 update_command = "sudo -A zypper --non-interactive ref"
             elif os_info.with_pacman:


### PR DESCRIPTION
 SystemPackageTool.update() must update only the local cache, but it shouldn't upgrade package. However, Yum uses `update` as a command to update all packages.

Changelog: Fix: Update Yum cache (#5370)
Docs: Omit

fixes #5370

- [x] Refer to the issue that supports this Pull Request.
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 

<sup>**Note:** By default this PR will skip the slower tests and will use a limited set of python versions. Check [here](https://github.com/conan-io/conan/blob/develop/.github/PR_INCREASE_TESTING.md) how to increase the testing level by writing some tags in the current PR body text.</sup>
