### PR TITLE
lockfiles

### DIFF
--- a/conans/client/cmd/export_pkg.py
+++ b/conans/client/cmd/export_pkg.py
@@ -58,8 +58,13 @@ def export_pkg(cache, graph_manager, hook_manager, recorder, output,
     readed_manifest = FileTreeManifest.load(dest_package_folder)
     pref = PackageReference(pref.ref, pref.id, readed_manifest.summary_hash)
     output.info("Package revision %s" % pref.revision)
+
     with layout.update_metadata() as metadata:
         metadata.packages[package_id].revision = pref.revision
         metadata.packages[package_id].recipe_revision = metadata.recipe.revision
 
+    if graph_info.graph_lock:
+        # after the package has been created we need to update the node PREV
+        nodes[0].prev = pref.revision
+        graph_info.graph_lock.update_check_graph(deps_graph, output)
     recorder.package_exported(pref)

--- a/conans/client/command.py
+++ b/conans/client/command.py
@@ -10,7 +10,8 @@ from argparse import ArgumentError
 from conans import __version__ as client_version
 from conans.client.cmd.uploader import UPLOAD_POLICY_FORCE, \
     UPLOAD_POLICY_NO_OVERWRITE, UPLOAD_POLICY_NO_OVERWRITE_RECIPE, UPLOAD_POLICY_SKIP
-from conans.client.conan_api import (Conan, default_manifest_folder)
+from conans.client.conan_api import (Conan, default_manifest_folder,
+    _make_abs_path)
 from conans.client.conan_command_output import CommandOutputer
 from conans.client.output import Color
 from conans.client.printer import Printer
@@ -283,7 +284,8 @@ class Command(object):
         self._warn_python2()
         return self._conan.test(args.path, args.reference, args.profile, args.settings,
                                 args.options, args.env, args.remote, args.update,
-                                build_modes=args.build, test_build_folder=args.test_build_folder)
+                                build_modes=args.build, test_build_folder=args.test_build_folder,
+                                lockfile=args.lockfile)
 
     def create(self, *args):
         """
@@ -339,7 +341,8 @@ class Command(object):
                                       args.build, args.keep_source, args.keep_build, args.verify,
                                       args.manifests, args.manifests_interactive,
                                       args.remote, args.update,
-                                      test_build_folder=args.test_build_folder)
+                                      test_build_folder=args.test_build_folder,
+                                      lockfile=args.lockfile)
         except ConanException as exc:
             info = exc.info
             raise
@@ -424,7 +427,6 @@ class Command(object):
         parser.add_argument("-if", "--install-folder", action=OnceArgument,
                             help='Use this directory as the directory where to put the generator'
                                  'files. e.g., conaninfo/conanbuildinfo.txt')
-
         _add_manifests_arguments(parser)
 
         parser.add_argument("--no-imports", action='store_true', default=False,
@@ -454,7 +456,8 @@ class Command(object):
                                            build=args.build, profile_names=args.profile,
                                            update=args.update, generators=args.generator,
                                            no_imports=args.no_imports,
-                                           install_folder=args.install_folder)
+                                           install_folder=args.install_folder,
+                                           lockfile=args.lockfile)
             else:
                 if args.reference:
                     raise ConanException("A full reference was provided as first argument, second "
@@ -470,7 +473,8 @@ class Command(object):
                                                      build=args.build, profile_names=args.profile,
                                                      update=args.update,
                                                      generators=args.generator,
-                                                     install_folder=args.install_folder)
+                                                     install_folder=args.install_folder,
+                                                     lockfile=args.lockfile)
         except ConanException as exc:
             info = exc.info
             raise
@@ -579,7 +583,6 @@ class Command(object):
         parser.add_argument("--package-filter", nargs='?',
                             help='Print information only for packages that match the filter pattern'
                                  ' e.g., MyPackage/1.2@user/channel or MyPackage*')
-
         dry_build_help = ("Apply the --build argument to output the information, as it would be done"
                           " by the install command")
         parser.add_argument("-db", "--dry-build", action=Extender, nargs="?", help=dry_build_help)
@@ -637,7 +640,8 @@ class Command(object):
                                     profile_names=args.profile,
                                     update=args.update,
                                     install_folder=args.install_folder,
-                                    build=args.dry_build)
+                                    build=args.dry_build,
+                                    lockfile=args.lockfile)
             deps_graph, _ = data
             only = args.only
             if args.only == ["None"]:
@@ -872,6 +876,10 @@ class Command(object):
         parser.add_argument("-j", "--json", default=None, action=OnceArgument,
                             help='Path to a json file where the install information will be '
                             'written')
+        parser.add_argument("-l", "--lockfile", action=OnceArgument, nargs='?', const=".",
+                            help="Path to lockfile. Lockfile will be updated with "
+                            "the exported package")
+
         args = parser.parse_args(*args)
 
         self._warn_python2()
@@ -893,7 +901,8 @@ class Command(object):
                                           options=args.options,
                                           force=args.force,
                                           user=user,
-                                          channel=channel)
+                                          channel=channel,
+                                          lockfile=args.lockfile)
         except ConanException as exc:
             info = exc.info
             raise
@@ -917,13 +926,16 @@ class Command(object):
                                               "and version are not declared in the conanfile.py")
         parser.add_argument('-k', '-ks', '--keep-source', default=False, action='store_true',
                             help=_KEEP_SOURCE_HELP)
+        parser.add_argument("-l", "--lockfile", action=OnceArgument, nargs='?', const=".",
+                            help="Path to lockfile. Lockfile will be updated with "
+                            "the exported package")
 
         args = parser.parse_args(*args)
         self._warn_python2()
         name, version, user, channel = get_reference_fields(args.reference)
         return self._conan.export(path=args.path,
                                   name=name, version=version, user=user, channel=channel,
-                                  keep_source=args.keep_source)
+                                  keep_source=args.keep_source, lockfile=args.lockfile)
 
     def remove(self, *args):
         """
@@ -1650,6 +1662,64 @@ class Command(object):
                 self._user_io.out.writeln("    Path: %s" % v["path"])
                 self._user_io.out.writeln("    Layout: %s" % v["layout"])
 
+    def graph(self, *args):
+        """
+        """
+        parser = argparse.ArgumentParser(description=self.remote.__doc__,
+                                         prog="conan graph",
+                                         formatter_class=SmartFormatter)
+        subparsers = parser.add_subparsers(dest='subcommand', help='sub-command help')
+        subparsers.required = True
+
+        # create the parser for the "a" command
+        merge_cmd = subparsers.add_parser('update-lock', help='merge two lockfiles')
+        merge_cmd.add_argument('old_lockfile', help='path to previous lockfile')
+        merge_cmd.add_argument('new_lockfile', help='path to modified lockfile')
+
+        build_order_cmd = subparsers.add_parser('build-order', help='Returns build-order')
+        build_order_cmd.add_argument('lockfile', help='lockfile folder')
+        build_order_cmd.add_argument("-b", "--build", action=Extender, nargs="?",
+                                     help="nodes to build")
+        build_order_cmd.add_argument("--json", action=OnceArgument,
+                                     help="generate output file in json format")
+
+        clean_cmd = subparsers.add_parser('clean-modified', help='Clean modified')
+        clean_cmd.add_argument('lockfile', help='lockfile folder')
+
+        lock_cmd = subparsers.add_parser('lock', help='create a lockfile')
+        lock_cmd.add_argument("path_or_reference", help="Path to a folder containing a recipe"
+                              " (conanfile.py or conanfile.txt) or to a recipe file. e.g., "
+                              "./my_project/conanfile.txt. It could also be a reference")
+        lock_cmd.add_argument("-l", "--lockfile", action=OnceArgument,
+                              help="Path to lockfile to be created. If not specified 'conan.lock'"
+                              " will be created in current folder")
+        _add_common_install_arguments(lock_cmd, build_help="Packages to build from source",
+                                      lockfile=False)
+
+        args = parser.parse_args(*args)
+        self._warn_python2()
+
+        if args.subcommand == "update-lock":
+            self._conan.update_lock(args.old_lockfile, args.new_lockfile)
+        elif args.subcommand == "build-order":
+            build_order = self._conan.build_order(args.lockfile, args.build)
+            self._user_io.out.writeln(build_order)
+            if args.json:
+                json_file = _make_abs_path(args.json)
+                save(json_file, json.dumps(build_order, indent=True))
+        elif args.subcommand == "clean-modified":
+            self._conan.lock_clean_modified(args.lockfile)
+        elif args.subcommand == "lock":
+            self._conan.create_lock(args.path_or_reference,
+                                    remote_name=args.remote,
+                                    settings=args.settings,
+                                    options=args.options,
+                                    env=args.env,
+                                    profile_names=args.profile,
+                                    update=args.update,
+                                    lockfile=args.lockfile,
+                                    build=args.build)
+
     def _show_help(self):
         """
         Prints a summary of all commands.
@@ -1659,7 +1729,7 @@ class Command(object):
                 ("Package development commands", ("source", "build", "package", "editable",
                                                   "workspace")),
                 ("Misc commands", ("profile", "remote", "user", "imports", "copy", "remove",
-                                   "alias", "download", "inspect", "help"))]
+                                   "alias", "download", "inspect", "help", "graph"))]
 
         def check_all_commands_listed():
             """Keep updated the main directory, raise if don't"""
@@ -1828,7 +1898,7 @@ def _add_manifests_arguments(parser):
                         action=OnceArgument)
 
 
-def _add_common_install_arguments(parser, build_help):
+def _add_common_install_arguments(parser, build_help, lockfile=True):
     if build_help:
         parser.add_argument("-b", "--build", action=Extender, nargs="?", help=build_help)
 
@@ -1846,6 +1916,9 @@ def _add_common_install_arguments(parser, build_help):
                              '-s compiler=gcc')
     parser.add_argument("-u", "--update", action='store_true', default=False,
                         help="Check updates exist from upstream remotes")
+    if lockfile:
+        parser.add_argument("-l", "--lockfile", action=OnceArgument, nargs='?', const=".",
+                            help="Path to lockfile. Lockfile can be updated if packages change")
 
 
 _help_build_policies = '''Optional, use it to choose if you want to build from sources:

--- a/conans/client/command.py
+++ b/conans/client/command.py
@@ -880,8 +880,8 @@ class Command(object):
                             help='Path to a json file where the install information will be '
                             'written')
         parser.add_argument("-l", "--lockfile", action=OnceArgument, nargs='?', const=".",
-                            help="Path to lockfile. Lockfile will be updated with "
-                            "the exported package")
+                            help="Path to a lockfile or folder containing 'conan.lock' file. "
+                            "Lockfile will be updated with the exported package")
 
         args = parser.parse_args(*args)
 
@@ -930,8 +930,8 @@ class Command(object):
         parser.add_argument('-k', '-ks', '--keep-source', default=False, action='store_true',
                             help=_KEEP_SOURCE_HELP)
         parser.add_argument("-l", "--lockfile", action=OnceArgument, nargs='?', const=".",
-                            help="Path to lockfile. Lockfile will be updated with "
-                            "the exported package")
+                            help="Path to a lockfile or folder containing 'conan.lock' file. "
+                            "Lockfile will be updated with the exported package")
 
         args = parser.parse_args(*args)
         self._warn_python2()
@@ -1921,7 +1921,8 @@ def _add_common_install_arguments(parser, build_help, lockfile=True):
                         help="Check updates exist from upstream remotes")
     if lockfile:
         parser.add_argument("-l", "--lockfile", action=OnceArgument, nargs='?', const=".",
-                            help="Path to lockfile. Lockfile can be updated if packages change")
+                            help="Path to a lockfile or folder containing 'conan.lock' file. "
+                            "Lockfile can be updated if packages change")
 
 
 _help_build_policies = '''Optional, use it to choose if you want to build from sources:

--- a/conans/client/conan_api.py
+++ b/conans/client/conan_api.py
@@ -49,6 +49,7 @@ from conans.errors import (ConanException, RecipeNotFoundException,
 from conans.model.conan_file import get_env_context_manager
 from conans.model.editable_layout import get_editable_abs_path
 from conans.model.graph_info import GraphInfo, GRAPH_INFO_FILE
+from conans.model.graph_lock import GraphLockFile, LOCKFILE
 from conans.model.ref import ConanFileReference, PackageReference, check_valid_ref
 from conans.model.version import Version
 from conans.model.workspace import Workspace
@@ -284,7 +285,8 @@ class ConanAPIV1(object):
 
     @api_method
     def test(self, path, reference, profile_names=None, settings=None, options=None, env=None,
-             remote_name=None, update=False, build_modes=None, cwd=None, test_build_folder=None):
+             remote_name=None, update=False, build_modes=None, cwd=None, test_build_folder=None,
+             lockfile=None):
 
         settings = settings or []
         options = options or []
@@ -296,8 +298,9 @@ class ConanAPIV1(object):
 
         conanfile_path = _get_conanfile_path(path, cwd, py=True)
         cwd = cwd or get_cwd()
+        lockfile = _make_abs_path(lockfile, cwd) if lockfile else None
         graph_info = get_graph_info(profile_names, settings, options, env, cwd, None,
-                                    self._cache, self._user_io.out)
+                                    self._cache, self._user_io.out, lockfile=lockfile)
         ref = ConanFileReference.loads(reference)
         recorder = ActionRecorder()
         manager = self._init_manager(recorder)
@@ -313,7 +316,8 @@ class ConanAPIV1(object):
                build_modes=None,
                keep_source=False, keep_build=False, verify=None,
                manifests=None, manifests_interactive=None,
-               remote_name=None, update=False, cwd=None, test_build_folder=None):
+               remote_name=None, update=False, cwd=None, test_build_folder=None,
+               lockfile=None):
         """
         API method to create a conan package
 
@@ -334,11 +338,17 @@ class ConanAPIV1(object):
             remotes.select(remote_name)
             self._python_requires.enable_remotes(update=update, remotes=remotes)
 
+            lockfile = _make_abs_path(lockfile, cwd) if lockfile else None
+            graph_info = get_graph_info(profile_names, settings, options, env, cwd, None,
+                                        self._cache, self._user_io.out, lockfile=lockfile)
+
             # Make sure keep_source is set for keep_build
             keep_source = keep_source or keep_build
             new_ref = cmd_export(conanfile_path, name, version, user, channel, keep_source,
                                  self._cache.config.revisions_enabled, self._user_io.out,
-                                 self._hook_manager, self._loader, self._cache, not not_export)
+                                 self._hook_manager, self._loader, self._cache, not not_export,
+                                 graph_lock=graph_info.graph_lock)
+
             # The new_ref contains the revision
             # To not break existing things, that they used this ref without revision
             ref = new_ref.copy_clear_rev()
@@ -349,15 +359,17 @@ class ConanAPIV1(object):
 
             manifests = _parse_manifests_arguments(verify, manifests, manifests_interactive, cwd)
             manifest_folder, manifest_interactive, manifest_verify = manifests
-            graph_info = get_graph_info(profile_names, settings, options, env, cwd, None,
-                                        self._cache, self._user_io.out)
 
+            # FIXME: Dirty hack: remove the root for the test_package/conanfile.py consumer
+            graph_info.root = ConanFileReference(None, None, None, None, validate=False)
             manager = self._init_manager(recorder)
             recorder.add_recipe_being_developed(ref)
             create(ref, manager, self._user_io, graph_info, remotes, update, build_modes,
                    manifest_folder, manifest_verify, manifest_interactive, keep_build,
                    test_build_folder, test_folder, conanfile_path)
 
+            if lockfile:
+                graph_info.save_lock(lockfile)
             return recorder.get_info(self._cache.config.revisions_enabled)
 
         except ConanException as exc:
@@ -368,7 +380,8 @@ class ConanAPIV1(object):
     @api_method
     def export_pkg(self, conanfile_path, name, channel, source_folder=None, build_folder=None,
                    package_folder=None, install_folder=None, profile_names=None, settings=None,
-                   options=None, env=None, force=False, user=None, version=None, cwd=None):
+                   options=None, env=None, force=False, user=None, version=None, cwd=None,
+                   lockfile=None):
 
         remotes = self._cache.registry.load_remotes()
         self._python_requires.enable_remotes(remotes=remotes)
@@ -397,13 +410,15 @@ class ConanAPIV1(object):
             source_folder = _make_abs_path(source_folder, cwd,
                                            default=os.path.dirname(conanfile_path))
 
+            lockfile = _make_abs_path(lockfile, cwd) if lockfile else None
             # Checks that no both settings and info files are specified
             graph_info = get_graph_info(profile_names, settings, options, env, cwd, install_folder,
-                                        self._cache, self._user_io.out)
+                                        self._cache, self._user_io.out, lockfile=lockfile)
 
             new_ref = cmd_export(conanfile_path, name, version, user, channel, True,
                                  self._cache.config.revisions_enabled, self._user_io.out,
-                                 self._hook_manager, self._loader, self._cache)
+                                 self._hook_manager, self._loader, self._cache,
+                                 graph_lock=graph_info.graph_lock)
             ref = new_ref.copy_clear_rev()
             # new_ref has revision
             recorder.recipe_exported(new_ref)
@@ -414,6 +429,8 @@ class ConanAPIV1(object):
                        ref, source_folder=source_folder, build_folder=build_folder,
                        package_folder=package_folder, install_folder=install_folder,
                        graph_info=graph_info, force=force, remotes=remotes)
+            if lockfile:
+                graph_info.save_lock(lockfile)
             return recorder.get_info(self._cache.config.revisions_enabled)
         except ConanException as exc:
             recorder.error = True
@@ -489,21 +506,24 @@ class ConanAPIV1(object):
     def install_reference(self, reference, settings=None, options=None, env=None,
                           remote_name=None, verify=None, manifests=None,
                           manifests_interactive=None, build=None, profile_names=None,
-                          update=False, generators=None, install_folder=None, cwd=None):
+                          update=False, generators=None, install_folder=None, cwd=None,
+                          lockfile=None):
 
         try:
             recorder = ActionRecorder()
             cwd = cwd or os.getcwd()
-            install_folder = _make_abs_path(install_folder, cwd)
 
             manifests = _parse_manifests_arguments(verify, manifests, manifests_interactive, cwd)
             manifest_folder, manifest_interactive, manifest_verify = manifests
 
+            lockfile = _make_abs_path(lockfile, cwd) if lockfile else None
             graph_info = get_graph_info(profile_names, settings, options, env, cwd, None,
-                                        self._cache, self._user_io.out)
+                                        self._cache, self._user_io.out, lockfile=lockfile)
 
             if not generators:  # We don't want the default txt
                 generators = False
+
+            install_folder = _make_abs_path(install_folder, cwd)
 
             mkdir(install_folder)
             remotes = self._cache.registry.load_remotes()
@@ -515,7 +535,7 @@ class ConanAPIV1(object):
                             update=update, manifest_folder=manifest_folder,
                             manifest_verify=manifest_verify,
                             manifest_interactive=manifest_interactive,
-                            generators=generators)
+                            generators=generators, use_lock=lockfile)
             return recorder.get_info(self._cache.config.revisions_enabled)
         except ConanException as exc:
             recorder.error = True
@@ -527,7 +547,8 @@ class ConanAPIV1(object):
                 settings=None, options=None, env=None,
                 remote_name=None, verify=None, manifests=None,
                 manifests_interactive=None, build=None, profile_names=None,
-                update=False, generators=None, no_imports=False, install_folder=None, cwd=None):
+                update=False, generators=None, no_imports=False, install_folder=None, cwd=None,
+                lockfile=None):
 
         try:
             recorder = ActionRecorder()
@@ -535,9 +556,11 @@ class ConanAPIV1(object):
             manifests = _parse_manifests_arguments(verify, manifests, manifests_interactive, cwd)
             manifest_folder, manifest_interactive, manifest_verify = manifests
 
+            lockfile = _make_abs_path(lockfile, cwd) if lockfile else None
             graph_info = get_graph_info(profile_names, settings, options, env, cwd, None,
                                         self._cache, self._user_io.out,
-                                        name=name, version=version, user=user, channel=channel)
+                                        name=name, version=version, user=user, channel=channel,
+                                        lockfile=lockfile)
 
             install_folder = _make_abs_path(install_folder, cwd)
             conanfile_path = _get_conanfile_path(path, cwd, py=None)
@@ -593,23 +616,21 @@ class ConanAPIV1(object):
                                      requester=self._requester, config_type=config_type, args=args,
                                      source_folder=source_folder, target_folder=target_folder)
 
-    def _info_args(self, reference_or_path, install_folder, profile_names, settings, options, env):
+    def _info_args(self, reference_or_path, install_folder, profile_names, settings, options, env,
+                   lockfile=None):
         cwd = get_cwd()
         try:
             ref = ConanFileReference.loads(reference_or_path)
-            install_folder = None
         except ConanException:
             ref = _get_conanfile_path(reference_or_path, cwd=None, py=None)
 
-            if install_folder:
-                install_folder = _make_abs_path(install_folder, cwd)
-            else:
-                # FIXME: This is a hack for old UI, need to be fixed in Conan 2.0
-                if os.path.exists(os.path.join(cwd, GRAPH_INFO_FILE)):
-                    install_folder = cwd
+        install_folder = _make_abs_path(install_folder, cwd)
+        if not os.path.exists(os.path.join(install_folder, GRAPH_INFO_FILE)):
+            install_folder = None
 
+        lockfile = _make_abs_path(lockfile, cwd) if lockfile else None
         graph_info = get_graph_info(profile_names, settings, options, env, cwd, install_folder,
-                                    self._cache, self._user_io.out)
+                                    self._cache, self._user_io.out, lockfile=lockfile)
 
         return ref, graph_info
 
@@ -646,9 +667,9 @@ class ConanAPIV1(object):
 
     @api_method
     def info(self, reference, remote_name=None, settings=None, options=None, env=None,
-             profile_names=None, update=False, install_folder=None, build=None):
+             profile_names=None, update=False, install_folder=None, build=None, lockfile=None):
         reference, graph_info = self._info_args(reference, install_folder, profile_names,
-                                                settings, options, env)
+                                                settings, options, env, lockfile=lockfile)
         recorder = ActionRecorder()
         remotes = self._cache.registry.load_remotes()
         remotes.select(remote_name)
@@ -657,6 +678,11 @@ class ConanAPIV1(object):
         deps_graph, conanfile = self._graph_manager.load_graph(reference, None, graph_info, build,
                                                                update, False, remotes,
                                                                recorder)
+
+        if install_folder:
+            output_folder = _make_abs_path(install_folder)
+            graph_info.save(output_folder)
+            self._user_io.out.info("Generated graphinfo")
         return deps_graph, conanfile
 
     @api_method
@@ -749,13 +775,24 @@ class ConanAPIV1(object):
         undo_imports(manifest_path, self._user_io.out)
 
     @api_method
-    def export(self, path, name, version, user, channel, keep_source=False, cwd=None):
+    def export(self, path, name, version, user, channel, keep_source=False, cwd=None,
+               lockfile=None):
         conanfile_path = _get_conanfile_path(path, cwd, py=True)
+        graph_lock = None
+        if lockfile:
+            lockfile = _make_abs_path(lockfile, cwd)
+            graph_lock_file = GraphLockFile.load(lockfile)
+            graph_lock = graph_lock_file.graph_lock
+            self._user_io.out.info("Using lockfile: '{}'".format(lockfile))
+
         remotes = self._cache.registry.load_remotes()
         self._python_requires.enable_remotes(remotes=remotes)
         cmd_export(conanfile_path, name, version, user, channel, keep_source,
                    self._cache.config.revisions_enabled, self._user_io.out,
-                   self._hook_manager, self._loader, self._cache)
+                   self._hook_manager, self._loader, self._cache, graph_lock=graph_lock)
+
+        if lockfile:
+            graph_lock_file.save(lockfile)
 
     @api_method
     def remove(self, pattern, query=None, packages=None, builds=None, src=False, force=False,
@@ -1165,20 +1202,99 @@ class ConanAPIV1(object):
     def editable_list(self):
         return {str(k): v for k, v in self._cache.editable_packages.edited_refs.items()}
 
+    @api_method
+    def update_lock(self, old_lockfile, new_lockfile, cwd=None):
+        cwd = cwd or os.getcwd()
+        old_lockfile = _make_abs_path(old_lockfile, cwd)
+        old_lock = GraphLockFile.load(old_lockfile)
+        new_lockfile = _make_abs_path(new_lockfile, cwd)
+        new_lock = GraphLockFile.load(new_lockfile)
+        if old_lock.profile.dumps() != new_lock.profile.dumps():
+            raise ConanException("Profiles of lockfiles are different\n%s\n%s"
+                                 % (old_lock.profile, new_lock.profile))
+        old_lock.graph_lock.update_lock(new_lock.graph_lock)
+        old_lock.save(old_lockfile)
+
+    @api_method
+    def build_order(self, lockfile, build=None, cwd=None):
+        cwd = cwd or os.getcwd()
+        lockfile = _make_abs_path(lockfile, cwd)
+
+        recorder = ActionRecorder()
+        remotes = self._cache.registry.load_remotes()
+        self._python_requires.enable_remotes(remotes=remotes)
+
+        graph_info = get_graph_info(None, None, None, None,
+                                    cwd=cwd, install_folder=None,
+                                    cache=self._cache, output=self._user_io.out,
+                                    lockfile=lockfile)
+        reference = graph_info.graph_lock.root_node().pref.ref.copy_clear_rev()
+        deps_graph, _ = self._graph_manager.load_graph(reference, None, graph_info, build,
+                                                       False, False, remotes, recorder)
+
+        print_graph(deps_graph, self._user_io.out)
+        graph_info.save_lock(lockfile)
+        return deps_graph.new_build_order()
+
+    @api_method
+    def lock_clean_modified(self, lockfile, cwd=None):
+        cwd = cwd or os.getcwd()
+        lockfile = _make_abs_path(lockfile, cwd)
+        lock = GraphLockFile.load(lockfile)
+        lock.graph_lock.clean_modified()
+        lock.save(lockfile)
+
+    @api_method
+    def create_lock(self, reference, remote_name=None, settings=None, options=None, env=None,
+                    profile_names=None, update=False, lockfile=None, build=None,):
+        reference, graph_info = self._info_args(reference, None, profile_names,
+                                                settings, options, env)
+        recorder = ActionRecorder()
+        remotes = self._cache.registry.load_remotes()
+        remotes.select(remote_name)
+        # FIXME: Using update as check_update?
+        self._python_requires.enable_remotes(check_updates=update, remotes=remotes)
+        deps_graph, _ = self._graph_manager.load_graph(reference, None, graph_info, build, update,
+                                                       False, remotes, recorder)
+
+        print_graph(deps_graph, self._user_io.out)
+        lockfile = _make_abs_path(lockfile)
+        graph_info.save_lock(lockfile)
+        self._user_io.out.info("Generated lockfile")
+
 
 Conan = ConanAPIV1
 
 
 def get_graph_info(profile_names, settings, options, env, cwd, install_folder, cache, output,
-                   name=None, version=None, user=None, channel=None):
+                   name=None, version=None, user=None, channel=None, lockfile=None):
+    if lockfile:
+        try:
+            graph_info_folder = lockfile if os.path.isdir(lockfile) else os.path.dirname(lockfile)
+            graph_info = GraphInfo.load(graph_info_folder)
+        except IOError:  # Only if file is missing
+            graph_info = GraphInfo()
+            root_ref = ConanFileReference(name, version, user, channel, validate=False)
+            graph_info.root = root_ref
+        lockfile = lockfile if os.path.isfile(lockfile) else os.path.join(lockfile, LOCKFILE)
+        graph_lock_file = GraphLockFile.load(lockfile)
+        graph_info.profile = graph_lock_file.profile
+        graph_info.profile.process_settings(cache, preprocess=False)
+        graph_info.graph_lock = graph_lock_file.graph_lock
+        output.info("Using lockfile: '{}'".format(lockfile))
+        return graph_info
+
     try:
         graph_info = GraphInfo.load(install_folder)
-        graph_info.profile.process_settings(cache, preprocess=False)
     except IOError:  # Only if file is missing
         if install_folder:
             raise ConanException("Failed to load graphinfo file in install-folder: %s"
                                  % install_folder)
         graph_info = None
+    else:
+        graph_lock_file = GraphLockFile.load(install_folder)
+        graph_info.profile = graph_lock_file.profile
+        graph_info.profile.process_settings(cache, preprocess=False)
 
     if profile_names or settings or options or env or not graph_info:
         if graph_info:

--- a/conans/client/conan_api.py
+++ b/conans/client/conan_api.py
@@ -1210,8 +1210,9 @@ class ConanAPIV1(object):
         new_lockfile = _make_abs_path(new_lockfile, cwd)
         new_lock = GraphLockFile.load(new_lockfile)
         if old_lock.profile.dumps() != new_lock.profile.dumps():
-            raise ConanException("Profiles of lockfiles are different\n%s\n%s"
-                                 % (old_lock.profile, new_lock.profile))
+            raise ConanException("Profiles of lockfiles are different\n%s:\n%s\n%s:\n%s"
+                                 % (old_lockfile, old_lock.profile.dumps(),
+                                    new_lockfile, new_lock.profile.dumps()))
         old_lock.graph_lock.update_lock(new_lock.graph_lock)
         old_lock.save(old_lockfile)
 

--- a/conans/client/graph/graph.py
+++ b/conans/client/graph/graph.py
@@ -1,4 +1,7 @@
+import uuid
+
 from conans.model.ref import PackageReference
+
 
 RECIPE_DOWNLOADED = "Downloaded"
 RECIPE_INCACHE = "Cache"  # The previously installed recipe in cache is being used
@@ -43,6 +46,18 @@ class Node(object):
         self.public_closure = None  # {ref.name: Node}
         self.inverse_closure = set()  # set of nodes that have this one in their public
         self.ancestors = None  # set{ref.name}
+        self._id = None  # Unique ID (uuid at the moment) of a node in the graph
+        self.graph_lock_node = None  # the locking information can be None
+
+    @property
+    def id(self):
+        if self._id is None:
+            self._id = str(uuid.uuid1())
+        return self._id
+
+    @id.setter
+    def id(self, id_):
+        self._id = id_
 
     @property
     def package_id(self):
@@ -59,6 +74,7 @@ class Node(object):
 
     @property
     def pref(self):
+        assert self.ref is not None and self.package_id is not None, "Node %s" % self.recipe
         return PackageReference(self.ref, self.package_id, self.prev)
 
     def partial_copy(self):
@@ -246,6 +262,25 @@ class DepsGraph(object):
                 dst = result_node
                 result.add_edge(src, dst, dep.private, dep.build_require)
 
+        return result
+
+    def new_build_order(self):
+        """ returns an ordered list of lists, with tuples (node_id, pref)
+        of the nodes of the graph to be built. Duplicates of pref will be ommitted
+        It will return all the nodes with BINARY_BUILD status, i.e. those that have
+        been processed according to rules like --build=missing and really need re-building
+        """
+        levels = self.inverse_levels()
+        result = []
+        total_prefs = set()  # to remove duplicates, same pref shouldn't build twice
+        for level in reversed(levels):
+            new_level = []
+            for n in level:
+                if n.binary == BINARY_BUILD and n.pref not in total_prefs:
+                    new_level.append((n.id, n.pref.full_repr()))
+                    total_prefs.add(n.pref)
+            if new_level:
+                result.append(new_level)
         return result
 
     def build_order(self, references):

--- a/conans/client/graph/graph.py
+++ b/conans/client/graph/graph.py
@@ -173,11 +173,18 @@ class Node(object):
 
 
 class Edge(object):
-    def __init__(self, src, dst, private=False, build_require=False):
+    def __init__(self, src, dst, require):
         self.src = src
         self.dst = dst
-        self.private = private
-        self.build_require = build_require
+        self.require = require
+
+    @property
+    def private(self):
+        return self.require.private
+
+    @property
+    def build_require(self):
+        return self.require.build_require
 
     def __eq__(self, other):
         return self.src == self.src and self.dst == other.dst
@@ -202,9 +209,9 @@ class DepsGraph(object):
             self.root = node
         self.nodes.add(node)
 
-    def add_edge(self, src, dst, private=False, build_require=False):
+    def add_edge(self, src, dst, require):
         assert src in self.nodes and dst in self.nodes
-        edge = Edge(src, dst, private, build_require)
+        edge = Edge(src, dst, require)
         src.add_edge(edge)
         dst.add_edge(edge)
 
@@ -256,11 +263,11 @@ class DepsGraph(object):
             for dep in node.dependencies:
                 src = result_node
                 dst = nodes_map[dep.dst]
-                result.add_edge(src, dst, dep.private, dep.build_require)
+                result.add_edge(src, dst, dep.require)
             for dep in node.dependants:
                 src = nodes_map[dep.src]
                 dst = result_node
-                result.add_edge(src, dst, dep.private, dep.build_require)
+                result.add_edge(src, dst, dep.require)
 
         return result
 

--- a/conans/client/graph/graph_binaries.py
+++ b/conans/client/graph/graph_binaries.py
@@ -34,7 +34,14 @@ class GraphBinariesAnalyzer(object):
         assert node.package_id is not None, "Node.package_id shouldn't be None"
 
         ref, conanfile = node.ref, node.conanfile
-        pref = PackageReference(ref, node.package_id)
+        pref = node.pref
+        # If it has lock
+        locked = node.graph_lock_node
+        if locked and locked.pref.id == node.package_id:
+            pref = locked.pref  # Keep the locked with PREV
+        else:
+            assert node.prev is None, "Non locked node shouldn't have PREV in evaluate_node"
+            pref = PackageReference(ref, node.package_id)
 
         # Check that this same reference hasn't already been checked
         previous_nodes = evaluated_nodes.get(pref)
@@ -54,7 +61,16 @@ class GraphBinariesAnalyzer(object):
             # TODO: PREV?
             return
 
-        with_deps_to_build = any([dep.dst.binary == BINARY_BUILD for dep in node.dependencies])
+        with_deps_to_build = False
+        # For cascade mode, we need to check also the "modified" status of the lockfile if exists
+        # modified nodes have already been built, so they shouldn't be built again
+        if build_mode.cascade and not (node.graph_lock_node and node.graph_lock_node.modified):
+            for dep in node.dependencies:
+                dep_node = dep.dst
+                if (dep_node.binary == BINARY_BUILD or
+                        (dep_node.graph_lock_node and dep_node.graph_lock_node.modified)):
+                    with_deps_to_build = True
+                    break
         if build_mode.forced(conanfile, ref, with_deps_to_build):
             output.info('Forced build from source')
             node.binary = BINARY_BUILD

--- a/conans/client/graph/graph_builder.py
+++ b/conans/client/graph/graph_builder.py
@@ -196,7 +196,7 @@ class DepsGraphBuilder(object):
                 previous.make_public()
 
             node.connect_closure(previous)
-            dep_graph.add_edge(node, previous, require.private, require.build_require)
+            dep_graph.add_edge(node, previous, require)
             # All the upstream dependencies (public_closure) of the previously existing node
             # now will be also connected to the node and to all its dependants
             for name, n in previous.public_closure.items():
@@ -362,5 +362,5 @@ class DepsGraphBuilder(object):
         new_node.private = current_node.private or requirement.private
 
         dep_graph.add_node(new_node)
-        dep_graph.add_edge(current_node, new_node, requirement.private, requirement.build_require)
+        dep_graph.add_edge(current_node, new_node, requirement)
         return new_node

--- a/conans/client/graph/graph_builder.py
+++ b/conans/client/graph/graph_builder.py
@@ -20,7 +20,8 @@ class DepsGraphBuilder(object):
         self._resolver = resolver
         self._recorder = recorder
 
-    def load_graph(self, root_node, check_updates, update, remotes, processed_profile):
+    def load_graph(self, root_node, check_updates, update, remotes, processed_profile,
+                   graph_lock=None):
         check_updates = check_updates or update
         dep_graph = DepsGraph()
         # compute the conanfile entry point for this dependency graph
@@ -34,12 +35,12 @@ class DepsGraphBuilder(object):
         t1 = time.time()
         self._load_deps(dep_graph, root_node, Requirements(), None, None,
                         check_updates, update, remotes,
-                        processed_profile)
+                        processed_profile, graph_lock)
         logger.debug("GRAPH: Time to load deps %s" % (time.time() - t1))
         return dep_graph
 
     def extend_build_requires(self, graph, node, build_requires_refs, check_updates, update,
-                              remotes, processed_profile):
+                              remotes, processed_profile, graph_lock):
 
         # The options that will be defined in the node will be the real options values that have
         # been already propagated downstream from the dependency graph. This will override any
@@ -52,13 +53,16 @@ class DepsGraphBuilder(object):
         conanfile = node.conanfile
         scope = conanfile.display_name
         requires = [Requirement(ref) for ref in build_requires_refs]
+        if graph_lock:
+            graph_lock.lock_node(node, requires)
+
         self._resolve_ranges(graph, requires, scope, update, remotes)
 
         for require in requires:
             name = require.ref.name
             require.build_require = True
             self._handle_require(name, node, require, graph, check_updates, update,
-                                 remotes, processed_profile, new_reqs, new_options)
+                                 remotes, processed_profile, new_reqs, new_options, graph_lock)
 
         new_nodes = set(n for n in graph.nodes if n.package_id is None)
         # This is to make sure that build_requires have precedence over the normal requires
@@ -102,7 +106,7 @@ class DepsGraphBuilder(object):
                                     list(conanfile.requires.values())))
 
     def _load_deps(self, dep_graph, node, down_reqs, down_ref, down_options,
-                   check_updates, update, remotes, processed_profile):
+                   check_updates, update, remotes, processed_profile, graph_lock):
         """ expands the dependencies of the node, recursively
 
         param node: Node object to be expanded in this step
@@ -113,6 +117,9 @@ class DepsGraphBuilder(object):
         # basic node configuration: calling configure() and requirements()
         new_reqs, new_options = self._config_node(dep_graph, node, down_reqs, down_ref, down_options)
 
+        if graph_lock:
+            graph_lock.lock_node(node, node.conanfile.requires.values())
+
         # if there are version-ranges, resolve them before expanding each of the requirements
         self._resolve_deps(dep_graph, node, update, remotes)
 
@@ -121,10 +128,10 @@ class DepsGraphBuilder(object):
             if require.override:
                 continue
             self._handle_require(name, node, require, dep_graph, check_updates, update,
-                                 remotes, processed_profile, new_reqs, new_options)
+                                 remotes, processed_profile, new_reqs, new_options, graph_lock)
 
     def _handle_require(self, name, node, require, dep_graph, check_updates, update,
-                        remotes, processed_profile, new_reqs, new_options):
+                        remotes, processed_profile, new_reqs, new_options, graph_lock):
         # Handle a requirement of a node. There are 2 possibilities
         #    node -(require)-> new_node (creates a new node in the graph)
         #    node -(require)-> previous (creates a diamond with a previously existing node)
@@ -142,7 +149,7 @@ class DepsGraphBuilder(object):
         if not previous or ((require.build_require or require.private) and not previous_closure):
             # new node, must be added and expanded (node -> new_node)
             new_node = self._create_new_node(node, dep_graph, require, name, check_updates, update,
-                                             remotes, processed_profile)
+                                             remotes, processed_profile, graph_lock)
 
             # The closure of a new node starts with just itself
             new_node.public_closure = OrderedDict([(new_node.ref.name, new_node)])
@@ -167,7 +174,8 @@ class DepsGraphBuilder(object):
 
             # RECURSION, keep expanding (depth-first) the new node
             self._load_deps(dep_graph, new_node, new_reqs, node.ref, new_options, check_updates,
-                            update, remotes, processed_profile)
+                            update, remotes, processed_profile, graph_lock)
+
         else:  # a public node already exist with this name
             # This is closing a diamond, the node already exists and is reachable
             alias_ref = dep_graph.aliased.get(require.ref)
@@ -202,7 +210,7 @@ class DepsGraphBuilder(object):
             # configuration of upstream versions and options
             if self._recurse(previous.public_closure, new_reqs, new_options):
                 self._load_deps(dep_graph, previous, new_reqs, node.ref, new_options, check_updates,
-                                update, remotes, processed_profile)
+                                update, remotes, processed_profile, graph_lock)
 
     @staticmethod
     def _conflicting_references(previous_ref, new_ref, consumer_ref=None):
@@ -301,7 +309,8 @@ class DepsGraphBuilder(object):
         return new_down_reqs, new_options
 
     def _create_new_node(self, current_node, dep_graph, requirement, name_req,
-                         check_updates, update, remotes, processed_profile, alias_ref=None):
+                         check_updates, update, remotes, processed_profile, graph_lock,
+                         alias_ref=None):
         """ creates and adds a new node to the dependency graph
         """
 
@@ -316,8 +325,11 @@ class DepsGraphBuilder(object):
             raise e
         conanfile_path, recipe_status, remote, new_ref = result
 
+        locked_id = requirement.locked_id
+        lock_python_requires = graph_lock.python_requires(locked_id) if locked_id else None
         dep_conanfile = self._loader.load_conanfile(conanfile_path, processed_profile,
-                                                    ref=requirement.ref)
+                                                    ref=requirement.ref,
+                                                    lock_python_requires=lock_python_requires)
         if recipe_status == RECIPE_EDITABLE:
             dep_conanfile.in_local_cache = False
             dep_conanfile.develop = True
@@ -328,7 +340,7 @@ class DepsGraphBuilder(object):
             dep_graph.aliased[alias_ref] = requirement.ref
             return self._create_new_node(current_node, dep_graph, requirement,
                                          name_req, check_updates, update,
-                                         remotes, processed_profile,
+                                         remotes, processed_profile, graph_lock,
                                          alias_ref=alias_ref)
 
         logger.debug("GRAPH: new_node: %s" % str(new_ref))
@@ -339,6 +351,10 @@ class DepsGraphBuilder(object):
         # Ancestors are a copy of the parent, plus the parent itself
         new_node.ancestors = current_node.ancestors.copy()
         new_node.ancestors.add(current_node.name)
+
+        if locked_id:
+            new_node.id = locked_id
+
         # build-requires and private affect transitively. If "node" is already
         # a build_require or a private one, its requirements will inherit that property
         # Or if the require specify that property, then it will get it too

--- a/conans/client/graph/graph_manager.py
+++ b/conans/client/graph/graph_manager.py
@@ -12,6 +12,7 @@ from conans.client.loader import ProcessedProfile
 from conans.errors import ConanException, conanfile_exception_formatter
 from conans.model.conan_file import get_env_context_manager
 from conans.model.graph_info import GraphInfo
+from conans.model.graph_lock import GraphLock, GraphLockFile
 from conans.model.ref import ConanFileReference
 from conans.paths import BUILD_INFO
 from conans.util.files import load
@@ -57,23 +58,33 @@ class GraphManager(object):
         """
         try:
             graph_info = GraphInfo.load(info_folder)
+            graph_lock_file = GraphLockFile.load(info_folder)
+            graph_lock = graph_lock_file.graph_lock
+            self._output.info("Using lockfile: '{}/conan.lock'".format(info_folder))
+            profile = graph_lock_file.profile
+            self._output.info("Using cached profile from lockfile")
         except IOError:  # Only if file is missing
+            graph_lock = None
             # This is very dirty, should be removed for Conan 2.0 (source() method only)
             profile = self._cache.default_profile
             profile.process_settings(self._cache)
             name, version, user, channel = None, None, None, None
         else:
             name, version, user, channel, _ = graph_info.root
-            profile = graph_info.profile
             profile.process_settings(self._cache, preprocess=False)
             # This is the hack of recovering the options from the graph_info
             profile.options.update(graph_info.options)
         processed_profile = ProcessedProfile(profile, None)
         if conanfile_path.endswith(".py"):
+            lock_python_requires = None
+            if graph_lock:
+                node_id = graph_lock.get_node(graph_info.root)
+                lock_python_requires = graph_lock.python_requires(node_id)
             conanfile = self._loader.load_consumer(conanfile_path,
                                                    processed_profile=processed_profile, test=test,
                                                    name=name, version=version,
-                                                   user=user, channel=channel)
+                                                   user=user, channel=channel,
+                                                   lock_python_requires=lock_python_requires)
             with get_env_context_manager(conanfile, without_python=True):
                 with conanfile_exception_formatter(str(conanfile), "config_options"):
                     conanfile.config_options()
@@ -108,6 +119,7 @@ class GraphManager(object):
         profile = graph_info.profile
         processed_profile = ProcessedProfile(profile, create_reference)
         ref = None
+        graph_lock = graph_info.graph_lock
         if isinstance(reference, list):  # Install workspace with multiple root nodes
             conanfile = self._loader.load_virtual(reference, processed_profile,
                                                   scope_options=False)
@@ -119,15 +131,23 @@ class GraphManager(object):
             # create without test_package and install <ref>
             conanfile = self._loader.load_virtual([reference], processed_profile)
             root_node = Node(ref, conanfile, recipe=RECIPE_VIRTUAL)
+            if graph_lock:  # Find the Node ID in the lock of current root
+                graph_lock.find_consumer_node(root_node, reference)
         else:
             path = reference
             if path.endswith(".py"):
                 test = str(create_reference) if create_reference else None
+                lock_python_requires = None
+                if graph_lock:
+                    node_id = graph_lock.get_node(graph_info.root)
+                    lock_python_requires = graph_lock.python_requires(node_id)
+
                 conanfile = self._loader.load_consumer(path, processed_profile, test=test,
                                                        name=graph_info.root.name,
                                                        version=graph_info.root.version,
                                                        user=graph_info.root.user,
-                                                       channel=graph_info.root.channel)
+                                                       channel=graph_info.root.channel,
+                                                       lock_python_requires=lock_python_requires)
                 if create_reference:  # create with test_package
                     _inject_require(conanfile, create_reference)
 
@@ -140,17 +160,27 @@ class GraphManager(object):
 
             root_node = Node(ref, conanfile, recipe=RECIPE_CONSUMER)
 
+            if graph_lock:  # Find the Node ID in the lock of current root
+                graph_lock.find_consumer_node(root_node, create_reference)
+
         build_mode = BuildMode(build_mode, self._output)
         deps_graph = self._load_graph(root_node, check_updates, update,
                                       build_mode=build_mode, remotes=remotes,
                                       profile_build_requires=profile.build_requires,
                                       recorder=recorder,
                                       processed_profile=processed_profile,
-                                      apply_build_requires=apply_build_requires)
+                                      apply_build_requires=apply_build_requires,
+                                      graph_lock=graph_lock)
 
         # THIS IS NECESSARY to store dependencies options in profile, for consumer
         # FIXME: This is a hack. Might dissapear if the graph for local commands is always recomputed
         graph_info.options = root_node.conanfile.options.values
+        if ref:
+            graph_info.root = ref
+        if graph_info.graph_lock is None:
+            graph_info.graph_lock = GraphLock(deps_graph)
+        else:
+            graph_info.graph_lock.update_check_graph(deps_graph, self._output)
 
         version_ranges_output = self._resolver.output
         if version_ranges_output:
@@ -174,7 +204,7 @@ class GraphManager(object):
 
     def _recurse_build_requires(self, graph, builder, binaries_analyzer, check_updates, update,
                                 build_mode, remotes, profile_build_requires, recorder,
-                                processed_profile, apply_build_requires=True):
+                                processed_profile, graph_lock, apply_build_requires=True):
 
         binaries_analyzer.evaluate_graph(graph, build_mode, update, remotes)
         if not apply_build_requires:
@@ -209,36 +239,39 @@ class GraphManager(object):
                 subgraph = builder.extend_build_requires(graph, node,
                                                          package_build_requires.values(),
                                                          check_updates, update, remotes,
-                                                         processed_profile)
+                                                         processed_profile, graph_lock)
                 self._recurse_build_requires(subgraph, builder, binaries_analyzer, check_updates,
                                              update, build_mode,
                                              remotes, profile_build_requires, recorder,
-                                             processed_profile)
+                                             processed_profile, graph_lock)
                 graph.nodes.update(subgraph.nodes)
 
             if new_profile_build_requires:
                 subgraph = builder.extend_build_requires(graph, node, new_profile_build_requires,
                                                          check_updates, update, remotes,
-                                                         processed_profile)
+                                                         processed_profile, graph_lock)
                 self._recurse_build_requires(subgraph, builder, binaries_analyzer, check_updates,
                                              update, build_mode,
                                              remotes, {}, recorder,
-                                             processed_profile)
+                                             processed_profile, graph_lock)
                 graph.nodes.update(subgraph.nodes)
 
     def _load_graph(self, root_node, check_updates, update, build_mode, remotes,
-                    profile_build_requires, recorder, processed_profile, apply_build_requires):
+                    profile_build_requires, recorder, processed_profile, apply_build_requires,
+                    graph_lock):
 
         assert isinstance(build_mode, BuildMode)
         builder = DepsGraphBuilder(self._proxy, self._output, self._loader, self._resolver,
                                    recorder)
-        graph = builder.load_graph(root_node, check_updates, update, remotes, processed_profile)
+        graph = builder.load_graph(root_node, check_updates, update, remotes, processed_profile,
+                                   graph_lock)
         binaries_analyzer = GraphBinariesAnalyzer(self._cache, self._output,
                                                   self._remote_manager)
 
         self._recurse_build_requires(graph, builder, binaries_analyzer, check_updates, update,
                                      build_mode, remotes,
                                      profile_build_requires, recorder, processed_profile,
+                                     graph_lock,
                                      apply_build_requires=apply_build_requires)
 
         # Sort of closures, for linking order

--- a/conans/client/graph/graph_manager.py
+++ b/conans/client/graph/graph_manager.py
@@ -140,6 +140,14 @@ class GraphManager(object):
                 lock_python_requires = None
                 # do not try apply lock_python_requires for test_package/conanfile.py consumer
                 if graph_lock and not create_reference:
+                    if graph_info.root.name is None:
+                        # If the graph_info information is not there, better get what we can from
+                        # the conanfile
+                        conanfile = self._loader.load_class(path)
+                        graph_info.root = ConanFileReference(graph_info.root.name or conanfile.name,
+                                                             graph_info.root.version or conanfile.version,
+                                                             graph_info.root.user,
+                                                             graph_info.root.channel, validate=False)
                     node_id = graph_lock.get_node(graph_info.root)
                     lock_python_requires = graph_lock.python_requires(node_id)
 

--- a/conans/client/graph/graph_manager.py
+++ b/conans/client/graph/graph_manager.py
@@ -77,7 +77,7 @@ class GraphManager(object):
         processed_profile = ProcessedProfile(profile, None)
         if conanfile_path.endswith(".py"):
             lock_python_requires = None
-            if graph_lock:
+            if graph_lock and not test:  # Only lock python requires if it is not test_package
                 node_id = graph_lock.get_node(graph_info.root)
                 lock_python_requires = graph_lock.python_requires(node_id)
             conanfile = self._loader.load_consumer(conanfile_path,
@@ -138,7 +138,8 @@ class GraphManager(object):
             if path.endswith(".py"):
                 test = str(create_reference) if create_reference else None
                 lock_python_requires = None
-                if graph_lock:
+                # do not try apply lock_python_requires for test_package/conanfile.py consumer
+                if graph_lock and not create_reference:
                     node_id = graph_lock.get_node(graph_info.root)
                     lock_python_requires = graph_lock.python_requires(node_id)
 

--- a/conans/client/graph/python_requires.py
+++ b/conans/client/graph/python_requires.py
@@ -21,6 +21,7 @@ class ConanPythonRequire(object):
         self._check_updates = False
         self._update = False
         self._remote_name = None
+        self.locked_versions = None
 
     def enable_remotes(self, check_updates=False, update=False, remotes=None):
         self._check_updates = check_updates
@@ -39,11 +40,12 @@ class ConanPythonRequire(object):
         yield self._requires
         self._requires = old_requires
 
-    def _look_for_require(self, require):
+    def _look_for_require(self, reference):
+        ref = ConanFileReference.loads(reference)
+        ref = self.locked_versions[ref.name] if self.locked_versions is not None else ref
         try:
-            python_require = self._cached_requires[require]
+            python_require = self._cached_requires[ref]
         except KeyError:
-            ref = ConanFileReference.loads(require)
             requirement = Requirement(ref)
             self._range_resolver.resolve(requirement, "python_require", update=self._update,
                                          remotes=self._remotes)
@@ -64,16 +66,16 @@ class ConanPythonRequire(object):
                 exports_folder = package_layout.export()
                 python_require = PythonRequire(new_ref, module, conanfile,
                                                exports_folder, exports_sources_folder)
-            self._cached_requires[require] = python_require
+            self._cached_requires[ref] = python_require
 
         return python_require
 
-    def __call__(self, require):
+    def __call__(self, reference):
         if not self.valid:
-            raise ConanException("Invalid use of python_requires(%s)" % require)
+            raise ConanException("Invalid use of python_requires(%s)" % reference)
         try:
-            python_req = self._look_for_require(require)
+            python_req = self._look_for_require(reference)
             self._requires.append(python_req)
             return python_req.module
         except NotFoundException:
-            raise ConanException('Unable to find python_requires("{}") in remotes'.format(require))
+            raise ConanException('Unable to find python_requires("{}") in remotes'.format(reference))

--- a/conans/client/graph/range_resolver.py
+++ b/conans/client/graph/range_resolver.py
@@ -57,7 +57,6 @@ def satisfying(list_versions, versionexpr, result):
     This provides some workaround for failing comparisons like "2.1" not matching "<=2.1"
     """
     from semver import SemVer, Range, max_satisfying
-
     version_range, loose, include_prerelease = _parse_versionexpr(versionexpr, result)
 
     # Check version range expression

--- a/conans/client/loader.py
+++ b/conans/client/loader.py
@@ -43,17 +43,23 @@ class ConanFileLoader(object):
         self.cached_conanfiles = {}
         self._python_requires.invalidate_caches()
 
-    def load_class(self, conanfile_path):
-        conanfile = self.cached_conanfiles.get(conanfile_path)
-        if conanfile:
-            return conanfile
+    def load_class(self, conanfile_path, lock_python_requires=None):
+        cached = self.cached_conanfiles.get(conanfile_path)
+        if cached and cached[1] == lock_python_requires:
+            return cached[0]
 
+        if lock_python_requires is not None:
+            self._python_requires.locked_versions = {r.name: r for r in lock_python_requires}
         try:
             self._python_requires.valid = True
             _, conanfile = parse_conanfile(conanfile_path, self._python_requires)
             self._python_requires.valid = False
-            self.cached_conanfiles[conanfile_path] = conanfile
+
+            self._python_requires.locked_versions = None
+            self.cached_conanfiles[conanfile_path] = (conanfile, lock_python_requires)
+
             conanfile.conan_data = self._load_data(conanfile_path)
+
             return conanfile
         except ConanException as e:
             raise ConanException("Error loading conanfile at '{}': {}".format(conanfile_path, e))
@@ -70,8 +76,9 @@ class ConanFileLoader(object):
 
         return data or {}
 
-    def load_export(self, conanfile_path, name, version, user, channel):
-        conanfile = self.load_class(conanfile_path)
+    def load_export(self, conanfile_path, name, version, user, channel, lock_python_requires=None):
+        conanfile = self.load_class(conanfile_path, lock_python_requires)
+
         # Export does a check on existing name & version
         if "name" in conanfile.__dict__:
             if name and name != conanfile.name:
@@ -107,9 +114,9 @@ class ConanFileLoader(object):
         conanfile.initialize(tmp_settings, processed_profile._env_values)
 
     def load_consumer(self, conanfile_path, processed_profile, name=None, version=None, user=None,
-                      channel=None, test=None):
+                      channel=None, test=None, lock_python_requires=None):
 
-        conanfile_class = self.load_class(conanfile_path)
+        conanfile_class = self.load_class(conanfile_path, lock_python_requires)
         if name and conanfile_class.name and name != conanfile_class.name:
             raise ConanException("Package recipe name %s!=%s" % (name, conanfile_class.name))
         if version and conanfile_class.version and version != conanfile_class.version:
@@ -142,8 +149,8 @@ class ConanFileLoader(object):
         except Exception as e:  # re-raise with file name
             raise ConanException("%s: %s" % (conanfile_path, str(e)))
 
-    def load_conanfile(self, conanfile_path, processed_profile, ref):
-        conanfile_class = self.load_class(conanfile_path)
+    def load_conanfile(self, conanfile_path, processed_profile, ref, lock_python_requires=None):
+        conanfile_class = self.load_class(conanfile_path, lock_python_requires)
         conanfile_class.name = ref.name
         conanfile_class.version = ref.version
         conanfile = conanfile_class(self._output, self._runner, str(ref), ref.user, ref.channel)
@@ -255,6 +262,7 @@ def parse_conanfile(conanfile_path, python_requires):
             conanfile = _parse_module(module, filename)
 
             # Check for duplicates
+            # TODO: move it into PythonRequires
             py_reqs = {}
             for it in py_requires:
                 if it.ref.name in py_reqs:

--- a/conans/model/graph_info.py
+++ b/conans/model/graph_info.py
@@ -1,12 +1,12 @@
 import json
 import os
 
-from conans.client.profile_loader import _load_profile
 from conans.errors import ConanException
 from conans.model.options import OptionsValues
 from conans.model.ref import ConanFileReference
 from conans.tools import save
 from conans.util.files import load
+from conans.model.graph_lock import GraphLockFile, LOCKFILE
 
 
 GRAPH_INFO_FILE = "graph_info.json"
@@ -15,28 +15,27 @@ GRAPH_INFO_FILE = "graph_info.json"
 class GraphInfo(object):
 
     def __init__(self, profile=None, options=None, root_ref=None):
-        self.profile = profile
         # This field is a temporary hack, to store dependencies options for the local flow
         self.options = options
         self.root = root_ref
+        self.profile = profile
+        self.graph_lock = None
 
     @staticmethod
     def load(path):
         if not path:
             raise IOError("Invalid path")
-        p = path if os.path.isfile(path) else os.path.join(path, GRAPH_INFO_FILE)
+        p = os.path.join(path, GRAPH_INFO_FILE)
         content = load(p)
         try:
-            return GraphInfo.loads(content)
+            graph_info = GraphInfo.loads(content)
+            return graph_info
         except Exception as e:
             raise ConanException("Error parsing GraphInfo from file '{}': {}".format(p, e))
 
     @staticmethod
     def loads(text):
         graph_json = json.loads(text)
-        profile = graph_json["profile"]
-        # FIXME: Reading private very ugly
-        profile, _ = _load_profile(profile, None, None)
         try:
             options = graph_json["options"]
         except KeyError:
@@ -46,16 +45,25 @@ class GraphInfo(object):
         root = graph_json.get("root", {"name": None, "version": None, "user": None, "channel": None})
         root_ref = ConanFileReference(root["name"], root["version"], root["user"], root["channel"],
                                       validate=False)
-        return GraphInfo(profile=profile, options=options, root_ref=root_ref)
+
+        return GraphInfo(options=options, root_ref=root_ref)
 
     def save(self, folder, filename=None):
         filename = filename or GRAPH_INFO_FILE
         p = os.path.join(folder, filename)
-        serialized_graph_str = self.dumps()
+        serialized_graph_str = self._dumps()
         save(p, serialized_graph_str)
 
-    def dumps(self):
-        result = {"profile": self.profile.dumps()}
+        # A bit hacky, but to avoid repetition by now
+        graph_lock_file = GraphLockFile(self.profile, self.graph_lock)
+        graph_lock_file.save(os.path.join(folder, LOCKFILE))
+
+    def save_lock(self, lockfile):
+        graph_lock_file = GraphLockFile(self.profile, self.graph_lock)
+        graph_lock_file.save(lockfile)
+
+    def _dumps(self):
+        result = {}
         if self.options is not None:
             result["options"] = self.options.as_list()
         result["root"] = {"name": self.root.name,

--- a/conans/model/graph_lock.py
+++ b/conans/model/graph_lock.py
@@ -1,0 +1,300 @@
+import json
+import os
+
+from conans.client.graph.graph import RECIPE_VIRTUAL, RECIPE_CONSUMER,\
+    BINARY_BUILD
+from conans.client.profile_loader import _load_profile
+from conans.errors import ConanException
+from conans.model.options import OptionsValues
+from conans.model.ref import PackageReference, ConanFileReference
+from conans.util.files import load, save
+
+
+LOCKFILE = "conan.lock"
+
+
+class GraphLockFile(object):
+
+    def __init__(self, profile, graph_lock):
+        self.profile = profile
+        self.graph_lock = graph_lock
+
+    @staticmethod
+    def load(path):
+        if not path:
+            raise IOError("Invalid path")
+        if not os.path.isfile(path):
+            p = os.path.join(path, LOCKFILE)
+            if not os.path.isfile(p):
+                raise ConanException("Missing lockfile in: %s" % path)
+            path = p
+        content = load(path)
+        try:
+            return GraphLockFile.loads(content)
+        except Exception as e:
+            raise ConanException("Error parsing lockfile '{}': {}".format(path, e))
+
+    @staticmethod
+    def loads(text):
+        graph_json = json.loads(text)
+        profile = graph_json["profile"]
+        # FIXME: Reading private very ugly
+        profile, _ = _load_profile(profile, None, None)
+        graph_lock = GraphLock.from_dict(graph_json["graph_lock"])
+        graph_lock_file = GraphLockFile(profile, graph_lock)
+        return graph_lock_file
+
+    def save(self, path):
+        if not path.endswith(".lock"):
+            path = os.path.join(path, LOCKFILE)
+        serialized_graph_str = self.dumps()
+        save(path, serialized_graph_str)
+
+    def dumps(self):
+        result = {"profile": self.profile.dumps(),
+                  "graph_lock": self.graph_lock.as_dict()}
+        return json.dumps(result, indent=True)
+
+
+class GraphLockNode(object):
+    def __init__(self, pref, python_requires, options, modified):
+        self.pref = pref
+        self.python_requires = python_requires
+        self.options = options
+        self.modified = modified
+
+    @staticmethod
+    def from_dict(data):
+        """ constructs a GraphLockNode from a json like dict
+        """
+        json_pref = data["pref"]
+        pref = PackageReference.loads(json_pref) if json_pref else None
+        python_requires = data.get("python_requires")
+        if python_requires:
+            python_requires = [ConanFileReference.loads(ref) for ref in python_requires]
+        options = OptionsValues.loads(data["options"])
+        modified = data.get("modified")
+        return GraphLockNode(pref, python_requires, options, modified)
+
+    def as_dict(self):
+        """ returns the object serialized as a dict of plain python types
+        that can be converted to json
+        """
+        result = {}
+        result["pref"] = self.pref.full_repr() if self.pref else None
+        result["options"] = self.options.dumps()
+        if self.python_requires:
+            result["python_requires"] = [r.full_repr() for r in self.python_requires]
+        if self.modified:
+            result["modified"] = True
+        return result
+
+
+class GraphLock(object):
+
+    def __init__(self, graph=None):
+        self._nodes = {}  # {numeric id: PREF or None}
+        self._edges = {}  # {numeric_id: [numeric_ids]}
+        if graph:
+            for node in graph.nodes:
+                if node.recipe == RECIPE_VIRTUAL:
+                    continue
+                dependencies = []
+                for edge in node.dependencies:
+                    dependencies.append(edge.dst.id)
+                python_reqs = getattr(node.conanfile, "python_requires", {})
+                python_reqs = [r.ref for _, r in python_reqs.items()] if python_reqs else None
+                graph_node = GraphLockNode(node.pref if node.ref else None, python_reqs,
+                                           node.conanfile.options.values, False)
+                self._nodes[node.id] = graph_node
+                self._edges[node.id] = dependencies
+
+    def root_node(self):
+        """ obtain the node in the graph that is not depended by anyone else,
+        i.e. the root or downstream consumer
+        """
+        total = []
+        for list_ids in self._edges.values():
+            total.extend(list_ids)
+        roots = set(self._edges).difference(total)
+        assert len(roots) == 1
+        return self._nodes[roots.pop()]
+
+    @staticmethod
+    def from_dict(data):
+        """ constructs a GraphLock from a json like dict
+        """
+        graph_lock = GraphLock()
+        for id_, node in data["nodes"].items():
+            graph_lock._nodes[id_] = GraphLockNode.from_dict(node)
+        for id_, dependencies in data["edges"].items():
+            graph_lock._edges[id_] = dependencies
+
+        return graph_lock
+
+    def as_dict(self):
+        """ returns the object serialized as a dict of plain python types
+        that can be converted to json
+        """
+        result = {}
+        nodes = {}
+        for id_, node in self._nodes.items():
+            nodes[id_] = node.as_dict()
+        result["nodes"] = nodes
+        result["edges"] = self._edges
+        return result
+
+    def update_lock(self, new_lock):
+        """ update the lockfile with the contents of other one that was branched from this
+        one and had some node re-built. Only nodes marked as "modified" in the new one are
+        processed, and if the current lockfile already has it modified, it is a conflict,
+        and raise
+        """
+        for id_, node in new_lock._nodes.items():
+            if node.modified:
+                old_node = self._nodes[id_]
+                if old_node.modified:
+                    raise ConanException("Lockfile had already modified %s" % str(node.pref))
+                self._nodes[id_] = node
+
+    def clean_modified(self):
+        """ remove all the "modified" flags from the lockfile
+        """
+        for _, node in self._nodes.items():
+            node.modified = False
+
+    def _closure_affected(self):
+        """ returns all the IDs of the nodes that depend directly or indirectly of some
+        package marked as "modified"
+        """
+        closure = set()
+        current = [id_ for id_, node in self._nodes.items() if node.modified]
+        # closure.update(current)
+        while current:
+            new_current = set()
+            for n in current:
+                new_neighs = self._inverse_neighbors(n)
+                to_add = set(new_neighs).difference(current)
+                new_current.update(to_add)
+                closure.update(to_add)
+            current = new_current
+
+        return closure
+
+    def _inverse_neighbors(self, node_id):
+        """ return all the nodes that have an edge to the "node_id". Useful for computing
+        the set of nodes affected downstream by a change in one package
+        """
+        result = []
+        for id_, nodes_ids in self._edges.items():
+            if node_id in nodes_ids:
+                result.append(id_)
+        return result
+
+    def update_check_graph(self, deps_graph, output):
+        """ update the lockfile, checking for security that only nodes that are being built
+        from sources can change their PREF, or nodes that depend on some other "modified"
+        package, because their binary-id can change too
+        """
+        affected = self._closure_affected()
+        for node in deps_graph.nodes:
+            if node.recipe == RECIPE_VIRTUAL:
+                continue
+            lock_node = self._nodes[node.id]
+            if lock_node.pref and lock_node.pref.full_repr() != node.pref.full_repr():
+                if node.binary == BINARY_BUILD or node.id in affected:
+                    lock_node.pref = node.pref
+                else:
+                    raise ConanException("Mistmatch between lock and graph:\nLock:  %s\nGraph: %s"
+                                         % (lock_node.pref.full_repr(), node.pref.full_repr()))
+
+    def lock_node(self, node, requires):
+        """ apply options and constraints on requirements of a node, given the information from
+        the lockfile. Requires remove their version ranges.
+        """
+        if node.recipe == RECIPE_VIRTUAL:
+            return
+        locked_node = self._nodes[node.id]
+        prefs = self._dependencies(node.id)
+        node.graph_lock_node = locked_node
+        node.conanfile.options.values = locked_node.options
+        for require in requires:
+            # Not new unlocked dependencies at this stage
+            locked_pref, locked_id = prefs[require.ref.name]
+            require.lock(locked_pref.ref, locked_id)
+
+    def pref(self, node_id):
+        return self._nodes[node_id].pref
+
+    def python_requires(self, node_id):
+        return self._nodes[node_id].python_requires
+
+    def _dependencies(self, node_id):
+        # return {pkg_name: PREF}
+        return {self._nodes[i].pref.ref.name: (self._nodes[i].pref, i)
+                for i in self._edges[node_id]}
+
+    def get_node(self, ref):
+        """ given a REF, return the Node of the package in the lockfile that correspond to that
+        REF, or raise if it cannot find it.
+        First, search with REF without revisions is done, then approximate search by just name
+        """
+        # None reference
+        if ref is None:
+            try:
+                return self._nodes[None].pref
+            except KeyError:
+                raise ConanException("Unspecified reference in graph-lock, please specify")
+
+        # First search by ref (without RREV)
+        ids = []
+        search_ref = str(ref)
+        for id_, node in self._nodes.items():
+            if node.pref and str(node.pref.ref) == search_ref:
+                ids.append(id_)
+        if ids:
+            if len(ids) == 1:
+                return ids[0]
+            raise ConanException("There are %s binaries for ref %s" % (len(ids), ref))
+
+        # Search by approximate name
+        ids = []
+        for id_, node in self._nodes.items():
+            if node.pref and node.pref.ref.name == ref.name:
+                ids.append(id_)
+        if ids:
+            if len(ids) == 1:
+                return ids[0]
+            raise ConanException("There are %s binaries with name %s" % (len(ids), ref.name))
+
+        raise ConanException("Couldn't find '%s' in graph-lock" % ref.full_repr())
+
+    def update_exported_ref(self, node_id, ref):
+        """ when the recipe is exported, it will change its reference, typically the RREV, and
+        the lockfile needs to be updated. The lockfile reference will lose PREV information and
+        be marked as modified
+        """
+        lock_node = self._nodes[node_id]
+        if lock_node.pref.ref != ref:
+            lock_node.pref = PackageReference(ref, lock_node.pref.id)
+            lock_node.modified = True
+
+    def find_consumer_node(self, node, reference):
+        """ similar to get_node(), but taking into account that the consumer node can be a virtual
+        one for some cases of commands, like "conan install <ref>"
+        It will lock the found node, or raise if not found
+        """
+        if node.recipe == RECIPE_VIRTUAL:
+            assert reference
+            node_id = self.get_node(reference)
+            pref = self._nodes[node_id].pref
+            # Adding a new node, has the problem of
+            # python_requires
+
+            for require in node.conanfile.requires.values():
+                require.lock(pref.ref, node_id)
+            return
+
+        assert node.recipe == RECIPE_CONSUMER
+        node_id = self.get_node(node.ref)
+        node.id = node_id

--- a/conans/model/graph_lock.py
+++ b/conans/model/graph_lock.py
@@ -186,7 +186,7 @@ class GraphLock(object):
         """
         result = []
         for id_, node in self._nodes.items():
-            if node_id in node.requires:
+            if node_id in node.requires.values():
                 result.append(id_)
         return result
 

--- a/conans/model/requires.py
+++ b/conans/model/requires.py
@@ -21,6 +21,16 @@ class Requirement(object):
         self.override = override
         self.private = private
         self.build_require = False
+        self._locked_id = None
+
+    def lock(self, locked_ref, locked_id):
+        # When a requirment is locked it doesn't has ranges
+        self.ref = self.range_ref = locked_ref
+        self._locked_id = locked_id  # And knows the ID of the locked node that is pointing to
+
+    @property
+    def locked_id(self):
+        return self._locked_id
 
     @property
     def version_range(self):

--- a/conans/model/scm.py
+++ b/conans/model/scm.py
@@ -46,7 +46,7 @@ class SCMData(object):
         d = {"url": self.url, "revision": self.revision, "username": self.username,
              "password": self.password, "type": self.type, "verify_ssl": self.verify_ssl,
              "subfolder": self.subfolder, "submodule": self.submodule}
-        d = {k: v for k, v in d.items() if v}
+        d = {k: v for k, v in d.items() if v is not None and v is not ""}
         return json.dumps(d, sort_keys=True)
 
 

--- a/conans/test/functional/conanfile/in_local_cache_test.py
+++ b/conans/test/functional/conanfile/in_local_cache_test.py
@@ -65,5 +65,3 @@ class OtherConan(ConanFile):
         client.run("install Hello1/0.1@lasote/stable --build")
         self.assertIn("build() IN LOCAL CACHE=> True", client.user_io.out)
         self.assertIn("package() IN LOCAL CACHE=> True", client.user_io.out)
-
-

--- a/conans/test/functional/generators/generators_test.py
+++ b/conans/test/functional/generators/generators_test.py
@@ -6,6 +6,7 @@ import unittest
 from conans.model.graph_info import GRAPH_INFO_FILE
 from conans.test.utils.tools import NO_SETTINGS_PACKAGE_ID, TestClient
 from conans.util.files import load
+from conans.model.graph_lock import LOCKFILE
 
 
 class GeneratorsTest(unittest.TestCase):
@@ -50,7 +51,7 @@ ycm
                                  'SConscript_conan', 'conanbuildinfo.txt', 'conanbuildinfo.props',
                                  'conanbuildinfo.vsprops', 'conanbuildinfo.xcconfig',
                                  'conan_ycm_flags.json', 'conan_ycm_extra_conf.py',
-                                 GRAPH_INFO_FILE] + venv_files),
+                                 GRAPH_INFO_FILE, LOCKFILE] + venv_files),
                          sorted(os.listdir(client.current_folder)))
 
     def test_srcdirs(self):

--- a/conans/test/functional/generators/xcode_gcc_vs_test.py
+++ b/conans/test/functional/generators/xcode_gcc_vs_test.py
@@ -8,6 +8,7 @@ from conans.paths import (BUILD_INFO, BUILD_INFO_CMAKE, BUILD_INFO_GCC, BUILD_IN
                           BUILD_INFO_XCODE, CONANFILE_TXT, CONANINFO)
 from conans.test.utils.tools import TestClient
 from conans.util.files import load
+from conans.model.graph_lock import LOCKFILE
 
 
 class VSXCodeGeneratorsTest(unittest.TestCase):
@@ -41,7 +42,7 @@ xcode
         client.run('install . --build missing')
         self.assertEqual(sorted([CONANFILE_TXT, BUILD_INFO_GCC, BUILD_INFO_CMAKE,
                                  BUILD_INFO_VISUAL_STUDIO, BUILD_INFO,
-                                 BUILD_INFO_XCODE, CONANINFO, GRAPH_INFO_FILE]),
+                                 BUILD_INFO_XCODE, CONANINFO, GRAPH_INFO_FILE, LOCKFILE]),
                          sorted(os.listdir(client.current_folder)))
 
         cmake = load(os.path.join(client.current_folder, BUILD_INFO_CMAKE))

--- a/conans/test/functional/graph_lock/graph_lock_ci_test.py
+++ b/conans/test/functional/graph_lock/graph_lock_ci_test.py
@@ -1,0 +1,306 @@
+import os
+import textwrap
+import unittest
+
+from conans.model.graph_lock import LOCKFILE
+from conans.test.utils.tools import TestClient, TestServer
+from conans.util.files import load
+from conans.model.ref import PackageReference
+import json
+
+
+class GraphLockCITest(unittest.TestCase):
+
+    def test(self):
+        conanfile = textwrap.dedent("""
+            from conans import ConanFile, load
+            import os
+            class Pkg(ConanFile):
+                {requires}
+                exports_sources = "myfile.txt"
+                keep_imports = True
+                def imports(self):
+                    self.copy("myfile.txt", folder=True)
+                def package(self):
+                    self.copy("*myfile.txt")
+                def package_info(self):
+                    self.output.info("SELF FILE: %s"
+                        % load(os.path.join(self.package_folder, "myfile.txt")))
+                    for d in os.listdir(self.package_folder):
+                        p = os.path.join(self.package_folder, d, "myfile.txt")
+                        if os.path.isfile(p):
+                            self.output.info("DEP FILE %s: %s" % (d, load(p)))
+                """)
+        test_server = TestServer(users={"user": "mypass"})
+        client = TestClient(servers={"default": test_server},
+                            users={"default": [("user", "mypass")]})
+        client.save({"conanfile.py": conanfile.format(requires=""),
+                     "myfile.txt": "HelloA"})
+        client.run("create . PkgA/0.1@user/channel")
+        client.save({"conanfile.py": conanfile.format(
+            requires='requires = "PkgA/0.1@user/channel"'),
+                     "myfile.txt": "HelloB"})
+        client.run("create . PkgB/0.1@user/channel")
+        client.save({"conanfile.py": conanfile.format(
+            requires='requires = "PkgB/0.1@user/channel"'),
+                     "myfile.txt": "HelloC"})
+        client.run("create . PkgC/0.1@user/channel")
+        client.save({"conanfile.py": conanfile.format(
+            requires='requires = "PkgC/0.1@user/channel"'),
+                     "myfile.txt": "HelloD"})
+        client.run("create . PkgD/0.1@user/channel")
+        self.assertIn("PkgD/0.1@user/channel: SELF FILE: HelloD", client.out)
+        self.assertIn("PkgD/0.1@user/channel: DEP FILE PkgA: HelloA", client.out)
+        self.assertIn("PkgD/0.1@user/channel: DEP FILE PkgB: HelloB", client.out)
+        self.assertIn("PkgD/0.1@user/channel: DEP FILE PkgC: HelloC", client.out)
+
+        client.run("config set general.revisions_enabled=True")
+        client.run("upload * --all --confirm")
+
+        # FIXME: We need to do this with info, to avoid installing the binaries when we want info
+        client.run("graph lock PkgD/0.1@user/channel")
+        lock_file = load(os.path.join(client.current_folder, LOCKFILE))
+        initial_lock_file = lock_file
+        self.assertIn("PkgB/0.1@user/channel#c51f99a8622d6c837cd9dcd2595e43e4:"
+                      "5bf1ba84b5ec8663764a406f08a7f9ae5d3d5fb5#e7f906f2f693abccb3dc3419c4270413",
+                      lock_file)
+        self.assertIn("PkgA/0.1@user/channel#189390ce059842ce984e0502c52cf736:"
+                      "5ab84d6acfe1f23c4fae0ab88f26e3a396351ac9#5ba7f606729949527141beef73c72bc8",
+                      lock_file)
+        self.assertIn("PkgC/0.1@user/channel#1c63e932e9392857cdada81f34bf4690:"
+                      "8f97510bcea8206c1c046cc8d71cc395d4146547#7ae97bd9488da55592ab7d94a1885282",
+                      lock_file)
+        self.assertIn("PkgD/0.1@user/channel#d3d184611fb757faa65e4d4203198579:"
+                      "7e4312d9a6d3726436d62a6b508f361d13e65354#55f822331b182e54b5144e578ba9135b",
+                      lock_file)
+
+        # Do a change in B
+        clientb = TestClient(base_folder=client.base_folder, servers={"default": test_server})
+        clientb.run("config set general.revisions_enabled=True")
+        clientb.save({"conanfile.py": conanfile.format(requires='requires="PkgA/0.1@user/channel"'),
+                     "myfile.txt": "ByeB World!!",
+                      LOCKFILE: lock_file})
+        clientb.run("create . PkgB/0.1@user/channel --lockfile")
+        lock_fileb = load(os.path.join(clientb.current_folder, LOCKFILE))
+        self.assertIn("PkgB/0.1@user/channel#569839e7b741ee474406de1db69d19c2:"
+                      "5bf1ba84b5ec8663764a406f08a7f9ae5d3d5fb5#d1974c85c53dfaa549478a9ead361fe2",
+                      lock_fileb)
+        self.assertIn("PkgA/0.1@user/channel#189390ce059842ce984e0502c52cf736:"
+                      "5ab84d6acfe1f23c4fae0ab88f26e3a396351ac9#5ba7f606729949527141beef73c72bc8",
+                      lock_fileb)
+        self.assertIn("PkgC/0.1@user/channel#1c63e932e9392857cdada81f34bf4690:"
+                      "8f97510bcea8206c1c046cc8d71cc395d4146547#7ae97bd9488da55592ab7d94a1885282",
+                      lock_fileb)
+        self.assertIn("PkgD/0.1@user/channel#d3d184611fb757faa65e4d4203198579:"
+                      "7e4312d9a6d3726436d62a6b508f361d13e65354#55f822331b182e54b5144e578ba9135b",
+                      lock_fileb)
+        self.assertIn('"modified": true', lock_fileb)
+        # Go back to main orchestrator
+        client.save({"new_lock/%s" % LOCKFILE: lock_fileb})
+        client.run("graph update-lock . new_lock")
+        client.run("graph build-order . --json=build_order.json --build=cascade")
+        lock_file_order = load(os.path.join(clientb.current_folder, LOCKFILE))
+        json_file = os.path.join(client.current_folder, "build_order.json")
+        to_build = json.loads(load(json_file))
+        lock_fileaux = lock_file_order
+        while to_build:
+            for _, pkg_ref in to_build[0]:
+                pkg_ref = PackageReference.loads(pkg_ref)
+                client_aux = TestClient(base_folder=client.base_folder,
+                                        servers={"default": test_server})
+                client_aux.run("config set general.revisions_enabled=True")
+                client_aux.save({LOCKFILE: lock_fileaux})
+                client_aux.run("graph clean-modified .")
+                client_aux.run("install %s --build=%s --lockfile"
+                               % (pkg_ref.ref, pkg_ref.ref.name))
+                lock_fileaux = load(os.path.join(client_aux.current_folder, LOCKFILE))
+                client.save({"new_lock/%s" % LOCKFILE: lock_fileaux})
+                client.run("graph update-lock . new_lock")
+
+            client.run("graph build-order . --build=cascade")
+            lock_fileaux = load(os.path.join(client.current_folder, LOCKFILE))
+            output = str(client.out).splitlines()[-1]
+            to_build = eval(output)
+
+        new_lockfile = load(os.path.join(client.current_folder, LOCKFILE))
+        client.run("install PkgD/0.1@user/channel --lockfile")
+        self.assertIn("PkgC/0.1@user/channel: DEP FILE PkgB: ByeB World!!", client.out)
+        self.assertIn("PkgD/0.1@user/channel: DEP FILE PkgB: ByeB World!!", client.out)
+        client.run("upload * --all --confirm")
+
+        client.save({LOCKFILE: initial_lock_file})
+        client.run("remove * -f")
+        client.run("install PkgD/0.1@user/channel --lockfile")
+        self.assertIn("PkgC/0.1@user/channel: DEP FILE PkgB: HelloB", client.out)
+        self.assertIn("PkgD/0.1@user/channel: DEP FILE PkgB: HelloB", client.out)
+
+        client.save({LOCKFILE: new_lockfile})
+        client.run("remove * -f")
+        client.run("install PkgD/0.1@user/channel --lockfile")
+        self.assertIn("PkgC/0.1@user/channel: DEP FILE PkgB: ByeB World!!", client.out)
+        self.assertIn("PkgD/0.1@user/channel: DEP FILE PkgB: ByeB World!!", client.out)
+
+    def test_version_ranges(self):
+        conanfile = textwrap.dedent("""
+            from conans import ConanFile, load
+            import os
+            class Pkg(ConanFile):
+                {requires}
+                exports_sources = "myfile.txt"
+                keep_imports = True
+                def imports(self):
+                    self.copy("myfile.txt", folder=True)
+                def package(self):
+                    self.copy("*myfile.txt")
+                def package_info(self):
+                    self.output.info("SELF FILE: %s"
+                        % load(os.path.join(self.package_folder, "myfile.txt")))
+                    for d in os.listdir(self.package_folder):
+                        p = os.path.join(self.package_folder, d, "myfile.txt")
+                        if os.path.isfile(p):
+                            self.output.info("DEP FILE %s: %s" % (d, load(p)))
+                """)
+        client = TestClient()
+        client.run("config set general.default_package_id_mode=full_package_mode")
+        client.save({"conanfile.py": conanfile.format(requires=""),
+                     "myfile.txt": "HelloA"})
+        client.run("create . PkgA/0.1@user/channel")
+        client.save({"conanfile.py": conanfile.format(requires='requires="PkgA/[*]@user/channel"'),
+                     "myfile.txt": "HelloB"})
+        client.run("create . PkgB/0.1@user/channel")
+        client.save({"conanfile.py": conanfile.format(requires='requires="PkgB/[*]@user/channel"'),
+                     "myfile.txt": "HelloC"})
+        client.run("create . PkgC/0.1@user/channel")
+        client.save({"conanfile.py": conanfile.format(requires='requires="PkgC/[*]@user/channel"'),
+                     "myfile.txt": "HelloD"})
+        client.run("create . PkgD/0.1@user/channel")
+        self.assertIn("PkgD/0.1@user/channel: SELF FILE: HelloD", client.out)
+        self.assertIn("PkgD/0.1@user/channel: DEP FILE PkgA: HelloA", client.out)
+        self.assertIn("PkgD/0.1@user/channel: DEP FILE PkgB: HelloB", client.out)
+        self.assertIn("PkgD/0.1@user/channel: DEP FILE PkgC: HelloC", client.out)
+
+        # FIXME: We need to do this with info, to avoid installing the binaries when we want info
+        client.run("graph lock PkgD/0.1@user/channel")
+        lock_file = load(os.path.join(client.current_folder, LOCKFILE))
+        initial_lock_file = lock_file
+        self.assertIn("PkgB/0.1@user/channel", lock_file)
+        self.assertIn("PkgA/0.1@user/channel", lock_file)
+        self.assertIn("PkgC/0.1@user/channel", lock_file)
+        self.assertIn("PkgD/0.1@user/channel", lock_file)
+
+        # Do a change in B
+        clientb = TestClient(base_folder=client.base_folder)
+        clientb.run("config set general.default_package_id_mode=full_package_mode")
+        clientb.save({"conanfile.py": conanfile.format(requires='requires="PkgA/[*]@user/channel"'),
+                     "myfile.txt": "ByeB World!!",
+                      LOCKFILE: lock_file})
+        clientb.run("create . PkgB/0.2@user/channel --lockfile")
+        lock_fileb = load(os.path.join(clientb.current_folder, LOCKFILE))
+        self.assertIn("PkgB/0.2@user/channel", lock_fileb)
+        self.assertIn("PkgA/0.1@user/channel", lock_fileb)
+        self.assertIn("PkgC/0.1@user/channel", lock_fileb)
+        self.assertIn("PkgD/0.1@user/channel", lock_fileb)
+
+        # Go back to main orchestrator
+        client.save({"new_lock/%s" % LOCKFILE: lock_fileb})
+        client.run("graph update-lock . new_lock")
+        client.run("graph build-order . --json=build_order.json --build=missing")
+        lock_fileb = load(os.path.join(client.current_folder, LOCKFILE))
+        json_file = os.path.join(client.current_folder, "build_order.json")
+        to_build = json.loads(load(json_file))
+        lock_fileaux = lock_fileb
+        while to_build:
+            for _, pkg_ref in to_build[0]:
+                pkg_ref = PackageReference.loads(pkg_ref)
+                client_aux = TestClient(base_folder=client.base_folder)
+                client_aux.run("config set general.default_package_id_mode=full_package_mode")
+                client_aux.save({LOCKFILE: lock_fileaux})
+                client_aux.run("graph clean-modified .")
+                client_aux.run("install %s --build=%s --lockfile"
+                               % (pkg_ref.ref, pkg_ref.ref.name))
+                lock_fileaux = load(os.path.join(client_aux.current_folder, LOCKFILE))
+                client.save({"new_lock/%s" % LOCKFILE: lock_fileaux})
+                client.run("graph update-lock . new_lock")
+
+            client.run("graph build-order . --build=missing")
+            lock_fileaux = load(os.path.join(client.current_folder, LOCKFILE))
+            output = str(client.out).splitlines()[-1]
+            to_build = eval(output)
+
+        new_lockfile = load(os.path.join(client.current_folder, LOCKFILE))
+        client.run("install PkgD/0.1@user/channel --lockfile")
+        self.assertIn("PkgC/0.1@user/channel: DEP FILE PkgB: ByeB World!!", client.out)
+        self.assertIn("PkgD/0.1@user/channel: DEP FILE PkgB: ByeB World!!", client.out)
+
+        client.save({LOCKFILE: initial_lock_file})
+        client.run("install PkgD/0.1@user/channel --lockfile")
+        self.assertIn("PkgC/0.1@user/channel: DEP FILE PkgB: HelloB", client.out)
+        self.assertIn("PkgD/0.1@user/channel: DEP FILE PkgB: HelloB", client.out)
+
+        client.save({LOCKFILE: new_lockfile})
+        client.run("install PkgD/0.1@user/channel --lockfile")
+        self.assertIn("PkgC/0.1@user/channel: DEP FILE PkgB: ByeB World!!", client.out)
+        self.assertIn("PkgD/0.1@user/channel: DEP FILE PkgB: ByeB World!!", client.out)
+
+    def test_options(self):
+        conanfile = textwrap.dedent("""
+            from conans import ConanFile, load
+            import os
+            class Pkg(ConanFile):
+                {requires}
+                options = {{"myoption": [1, 2, 3, 4, 5]}}
+                default_options = {{"myoption": 1}}
+                def build(self):
+                    self.output.info("BUILDING WITH OPTION: %s!!" % self.options.myoption)
+                def package_info(self):
+                    self.output.info("PACKAGE_INFO OPTION: %s!!" % self.options.myoption)
+                """)
+        client = TestClient()
+        client.save({"conanfile.py": conanfile.format(requires="")})
+        client.run("export . PkgA/0.1@user/channel")
+        client.save({"conanfile.py": conanfile.format(requires='requires="PkgA/0.1@user/channel"')})
+        client.run("export . PkgB/0.1@user/channel")
+        client.save({"conanfile.py": conanfile.format(requires='requires="PkgB/0.1@user/channel"')})
+        client.run("export . PkgC/0.1@user/channel")
+        conanfileD = conanfile.format(requires='requires="PkgC/0.1@user/channel"')
+        conanfileD = conanfileD.replace('default_options = {"myoption": 1}',
+                                        'default_options = {"myoption": 2, "PkgC:myoption": 3,'
+                                        '"PkgB:myoption": 4, "PkgA:myoption": 5}')
+        client.save({"conanfile.py": conanfileD})
+        client.run("export . PkgD/0.1@user/channel")
+
+        # FIXME: We need to do this with info, to avoid installing the binaries when we want info
+        client.run("profile new myprofile")
+        # To make sure we can provide a profile as input
+        client.run("graph lock PkgD/0.1@user/channel -pr=myprofile")
+        lock_file = load(os.path.join(client.current_folder, LOCKFILE))
+
+        client2 = TestClient(base_folder=client.base_folder)
+        client2.save({"conanfile.py": conanfile.format(requires=""), LOCKFILE: lock_file})
+        client2.run("create . PkgA/0.1@user/channel --lockfile")
+        self.assertIn("PkgA/0.1@user/channel: BUILDING WITH OPTION: 5!!", client2.out)
+        self.assertIn("PkgA/0.1@user/channel: PACKAGE_INFO OPTION: 5!!", client2.out)
+
+        client2.save({"conanfile.py": conanfile.format(
+            requires='requires="PkgA/0.1@user/channel"')})
+        client2.run("create . PkgB/0.1@user/channel --lockfile")
+        self.assertIn("PkgB/0.1@user/channel: PACKAGE_INFO OPTION: 4!!", client2.out)
+        self.assertIn("PkgB/0.1@user/channel: BUILDING WITH OPTION: 4!!", client2.out)
+        self.assertIn("PkgA/0.1@user/channel: PACKAGE_INFO OPTION: 5!!", client2.out)
+
+        client2.save({"conanfile.py": conanfile.format(
+            requires='requires="PkgB/0.1@user/channel"')})
+        client2.run("create . PkgC/0.1@user/channel --lockfile")
+        self.assertIn("PkgC/0.1@user/channel: PACKAGE_INFO OPTION: 3!!", client2.out)
+        self.assertIn("PkgC/0.1@user/channel: BUILDING WITH OPTION: 3!!", client2.out)
+        self.assertIn("PkgB/0.1@user/channel: PACKAGE_INFO OPTION: 4!!", client2.out)
+        self.assertIn("PkgA/0.1@user/channel: PACKAGE_INFO OPTION: 5!!", client2.out)
+
+        client2.save({"conanfile.py": conanfile.format(
+            requires='requires="PkgC/0.1@user/channel"')})
+        client2.run("create . PkgD/0.1@user/channel --lockfile")
+        self.assertIn("PkgD/0.1@user/channel: PACKAGE_INFO OPTION: 2!!", client2.out)
+        self.assertIn("PkgD/0.1@user/channel: BUILDING WITH OPTION: 2!!", client2.out)
+        self.assertIn("PkgC/0.1@user/channel: PACKAGE_INFO OPTION: 3!!", client2.out)
+        self.assertIn("PkgB/0.1@user/channel: PACKAGE_INFO OPTION: 4!!", client2.out)
+        self.assertIn("PkgA/0.1@user/channel: PACKAGE_INFO OPTION: 5!!", client2.out)

--- a/conans/test/functional/graph_lock/graph_lock_test.py
+++ b/conans/test/functional/graph_lock/graph_lock_test.py
@@ -103,6 +103,23 @@ class GraphLockVersionRangeTest(unittest.TestCase):
         self._check_lock("PkgB/0.1@user/channel#%s" % self.pkg_b_revision,
                          self.pkg_b_package_revision)
 
+    def create_test_lock_test(self):
+        # Create is also possible
+        client = self.client
+        test_conanfile = textwrap.dedent("""
+            from conans import ConanFile
+            class Test(ConanFile):
+                def test(self):
+                    pass
+            """)
+        client.save({"conanfile.py": str(self.consumer),
+                     "test_package/conanfile.py": test_conanfile})
+        client.run("create . PkgB/0.1@user/channel --lockfile")
+        self.assertIn("PkgA/0.1@user/channel", client.out)
+        self.assertNotIn("PkgA/0.2/user/channel", client.out)
+        self._check_lock("PkgB/0.1@user/channel#%s" % self.pkg_b_revision,
+                         self.pkg_b_package_revision)
+
     def export_pkg_test(self):
         client = self.client
         client.run("export-pkg . PkgB/0.1@user/channel --lockfile")

--- a/conans/test/functional/graph_lock/graph_lock_test.py
+++ b/conans/test/functional/graph_lock/graph_lock_test.py
@@ -1,0 +1,306 @@
+import json
+import os
+import textwrap
+import unittest
+
+from conans.test.utils.tools import TestClient, TestServer
+from conans.util.files import load
+from conans.test.utils.conanfile import TestConanFile
+from conans.model.graph_lock import LOCKFILE
+
+
+class GraphLockErrorsTest(unittest.TestCase):
+    def missing_lock_error_test(self):
+        client = TestClient()
+        client.save({"conanfile.py": str(TestConanFile("PkgA", "0.1"))})
+        client.run("install . --lockfile", assert_error=True)
+        self.assertIn("ERROR: Missing lockfile in", client.out)
+
+
+class GraphLockVersionRangeTest(unittest.TestCase):
+    consumer = TestConanFile("PkgB", "0.1", requires=["PkgA/[>=0.1]@user/channel"])
+    pkg_b_revision = "180919b324d7823f2683af9381d11431"
+    pkg_b_id = "5bf1ba84b5ec8663764a406f08a7f9ae5d3d5fb5"
+    pkg_b_package_revision = "#2913f67cea630aee496fe70fd38b5b0f"
+    modified_pkg_b_revision = "e161d0bf1cd009d1815961619854119d"
+    modified_pkg_b_package_revision = "#a986ef401af61f8fc9f32695f475123e"
+    graph_lock_command = "install ."
+
+    def setUp(self):
+        client = TestClient()
+        self.client = client
+        client.save({"conanfile.py": str(TestConanFile("PkgA", "0.1"))})
+        client.run("create . PkgA/0.1@user/channel")
+
+        # Use a consumer with a version range
+        client.save({"conanfile.py": str(self.consumer)})
+        client.run(self.graph_lock_command)
+
+        self._check_lock("PkgB/0.1@None/None")
+
+        # If we create a new PkgA version
+        client.save({"conanfile.py": str(TestConanFile("PkgA", "0.2"))})
+        client.run("create . PkgA/0.2@user/channel")
+        client.save({"conanfile.py": str(self.consumer)})
+
+    def _check_lock(self, ref_b, rev_b=""):
+        lock_file = load(os.path.join(self.client.current_folder, LOCKFILE))
+        lock_file_json = json.loads(lock_file)
+        self.assertEqual(2, len(lock_file_json["graph_lock"]["nodes"]))
+        self.assertIn("PkgA/0.1@user/channel#b55538d56afb03f068a054f11310ce5a:"
+                      "5ab84d6acfe1f23c4fae0ab88f26e3a396351ac9#6d56ca1040e37a13b75bc286f3e1a5ad",
+                      lock_file)
+        self.assertIn('"%s:%s%s"' % (str(ref_b), self.pkg_b_id, rev_b), lock_file)
+
+    def install_info_lock_test(self):
+        # Normal install will use it (use install-folder to not change graph-info)
+        client = self.client
+        client.run("install . -if=tmp")  # Output graph_info to temporary
+        self.assertIn("PkgA/0.2@user/channel", client.out)
+        self.assertNotIn("PkgA/0.1@user/channel", client.out)
+
+        # Locked install will use PkgA/0.1
+        # To use the stored graph_info.json, it has to be explicit in "--install-folder"
+        client.run("install . -g=cmake --lockfile")
+        self._check_lock("PkgB/0.1@None/None")
+
+        self.assertIn("PkgA/0.1@user/channel", client.out)
+        self.assertNotIn("PkgA/0.2@user/channel", client.out)
+        cmake = load(os.path.join(client.current_folder, "conanbuildinfo.cmake"))
+        self.assertIn("PkgA/0.1/user/channel", cmake)
+        self.assertNotIn("PkgA/0.2/user/channel", cmake)
+
+        # Info also works
+        client.run("info . --lockfile")
+        self.assertIn("PkgA/0.1@user/channel", client.out)
+        self.assertNotIn("PkgA/0.2/user/channel", client.out)
+
+    def install_ref_lock_test(self):
+        client = self.client
+        client.run("install PkgA/[>=0.1]@user/channel -if=tmp")
+        self.assertIn("PkgA/0.2@user/channel: Already installed!", client.out)
+        self.assertNotIn("PkgA/0.1@user/channel", client.out)
+        # Explicit one
+        client.run("install PkgA/0.1@user/channel --install-folder=.")
+        self.assertIn("PkgA/0.1@user/channel: Already installed!", client.out)
+        self.assertNotIn("PkgA/0.2@user/channel", client.out)
+        # Range locked one
+        client.run("install PkgA/[>=0.1]@user/channel --lockfile")
+        self.assertIn("PkgA/0.1@user/channel: Already installed!", client.out)
+        self.assertNotIn("PkgA/0.2@user/channel", client.out)
+
+    def export_lock_test(self):
+        # locking a version range at export
+        self.client.run("export . user/channel --lockfile")
+        self._check_lock("PkgB/0.1@user/channel#%s" % self.pkg_b_revision)
+
+    def create_lock_test(self):
+        # Create is also possible
+        client = self.client
+        client.run("create . PkgB/0.1@user/channel --lockfile")
+        self.assertIn("PkgA/0.1@user/channel", client.out)
+        self.assertNotIn("PkgA/0.2/user/channel", client.out)
+        self._check_lock("PkgB/0.1@user/channel#%s" % self.pkg_b_revision,
+                         self.pkg_b_package_revision)
+
+    def export_pkg_test(self):
+        client = self.client
+        client.run("export-pkg . PkgB/0.1@user/channel --lockfile")
+        self._check_lock("PkgB/0.1@user/channel#%s" % self.pkg_b_revision,
+                         self.pkg_b_package_revision)
+
+        # Same, but modifying also PkgB Recipe
+        client.save({"conanfile.py": str(self.consumer) + "\n#comment"})
+        client.run("export-pkg . PkgB/0.1@user/channel --lockfile --force")
+        self._check_lock("PkgB/0.1@user/channel#%s" % self.modified_pkg_b_revision,
+                         self.modified_pkg_b_package_revision)
+
+
+class GraphLockBuildRequireVersionRangeTest(GraphLockVersionRangeTest):
+    consumer = TestConanFile("PkgB", "0.1", build_requires=["PkgA/[>=0.1]@user/channel"])
+    pkg_b_revision = "4e4df18e796d2a1bfc7bbce7f8865ecd"
+    pkg_b_id = "5ab84d6acfe1f23c4fae0ab88f26e3a396351ac9"
+    pkg_b_package_revision = "#4d2f336ae4c2979e2e56d28aed4c2ebb"
+    modified_pkg_b_revision = "e171fce5bb7af66e2315f78ea104c638"
+    modified_pkg_b_package_revision = "#7e88c21f05a1fd1f8529e7fad0d7a2e3"
+
+
+class GraphLockVersionRangeInfoTest(GraphLockVersionRangeTest):
+    graph_lock_command = "info . --install-folder=."
+
+
+class GraphLockRevisionTest(unittest.TestCase):
+    pkg_b_revision = "9b64caa2465f7660e6f613b7e87f0cd7"
+    pkg_b_id = "5bf1ba84b5ec8663764a406f08a7f9ae5d3d5fb5"
+    pkg_b_package_revision = "#2ec4fb334e1b4f3fd0a6f66605066ac7"
+
+    def setUp(self):
+        test_server = TestServer(users={"user": "user"})
+        servers = {"default": test_server}
+        client = TestClient(servers=servers, users={"default": [("user", "user")]})
+        # Important to activate revisions
+        client.run("config set general.revisions_enabled=True")
+        self.client = client
+        client.save({"conanfile.py": str(TestConanFile("PkgA", "0.1"))})
+        client.run("create . PkgA/0.1@user/channel")
+        client.run("upload PkgA/0.1@user/channel --all")
+
+        consumer = textwrap.dedent("""
+            from conans import ConanFile
+            class Pkg(ConanFile):
+                name = "PkgB"
+                version = "0.1"
+                requires = "PkgA/0.1@user/channel"
+                def build(self):
+                    self.output.info("BUILD DEP LIBS: %s!!" % ",".join(self.deps_cpp_info.libs))
+                def package_info(self):
+                    self.output.info("PACKAGE_INFO DEP LIBS: %s!!"
+                                     % ",".join(self.deps_cpp_info.libs))
+            """)
+        client.save({"conanfile.py": str(consumer)})
+        client.run("install .")
+
+        self._check_lock("PkgB/0.1@None/None")
+
+        # If we create a new PkgA revision, for example adding info
+        client.save({"conanfile.py": str(TestConanFile("PkgA", "0.1", info=True))})
+        client.run("create . PkgA/0.1@user/channel")
+        client.save({"conanfile.py": str(consumer)})
+
+    def _check_lock(self, ref_b, rev_b=""):
+        lock_file = load(os.path.join(self.client.current_folder, LOCKFILE))
+        lock_file_json = json.loads(lock_file)
+        self.assertEqual(2, len(lock_file_json["graph_lock"]["nodes"]))
+        self.assertIn("PkgA/0.1@user/channel#b55538d56afb03f068a054f11310ce5a:"
+                      "5ab84d6acfe1f23c4fae0ab88f26e3a396351ac9#6d56ca1040e37a13b75bc286f3e1a5ad",
+                      lock_file)
+        self.assertIn('"%s:%s%s"' % (str(ref_b), self.pkg_b_id, rev_b), lock_file)
+
+    def install_info_lock_test(self):
+        # Normal install will use it (use install-folder to not change graph-info)
+        client = self.client
+        client.run("install . -if=tmp")  # Output graph_info to temporary
+        client.run("build . -if=tmp")
+        self.assertIn("conanfile.py (PkgB/0.1@None/None): BUILD DEP LIBS: mylibPkgA0.1lib!!",
+                      client.out)
+
+        # Locked install will use PkgA/0.1
+        # This is a bit weird, that is necessary to force the --update the get the rigth revision
+        client.run("install . -g=cmake --lockfile --update")
+        self._check_lock("PkgB/0.1@None/None")
+        client.run("build .")
+        self.assertIn("conanfile.py (PkgB/0.1@None/None): BUILD DEP LIBS: !!", client.out)
+
+        # Info also works
+        client.run("info . --lockfile")
+        self.assertIn("Revision: b55538d56afb03f068a054f11310ce5a", client.out)
+
+    def export_lock_test(self):
+        # locking a version range at export
+        self.client.run("export . user/channel --lockfile")
+        self._check_lock("PkgB/0.1@user/channel#%s" % self.pkg_b_revision)
+
+    def create_lock_test(self):
+        # Create is also possible
+        client = self.client
+        client.run("create . PkgB/0.1@user/channel --update --lockfile")
+        self._check_lock("PkgB/0.1@user/channel#%s" % self.pkg_b_revision,
+                         self.pkg_b_package_revision)
+
+    def export_pkg_test(self):
+        client = self.client
+        # Necessary to clean previous revision
+        client.run("remove * -f")
+        client.run("export-pkg . PkgB/0.1@user/channel --lockfile")
+        self._check_lock("PkgB/0.1@user/channel#%s" % self.pkg_b_revision,
+                         self.pkg_b_package_revision)
+
+
+class GraphLockPythonRequiresTest(unittest.TestCase):
+
+    def setUp(self):
+        client = TestClient()
+        self.client = client
+        conanfile = textwrap.dedent("""
+            from conans import ConanFile
+            var = 42
+            class Pkg(ConanFile):
+                pass
+            """)
+        client.save({"conanfile.py": conanfile})
+        client.run("export . Tool/0.1@user/channel")
+
+        # Use a consumer with a version range
+        consumer = textwrap.dedent("""
+            from conans import ConanFile, python_requires
+            dep = python_requires("Tool/[>=0.1]@user/channel")
+
+            class Pkg(ConanFile):
+                name = "Pkg"
+                def configure(self):
+                    self.output.info("CONFIGURE VAR=%s" % dep.var)
+                def build(self):
+                    self.output.info("BUILD VAR=%s" % dep.var)
+            """)
+        client.save({"conanfile.py": consumer})
+        client.run("install .")
+        self.assertIn("Tool/0.1@user/channel", client.out)
+        self.assertIn("conanfile.py (Pkg/None@None/None): CONFIGURE VAR=42", client.out)
+        self._check_lock("Pkg/None@None/None")
+
+        client.run("build .")
+        self.assertIn("conanfile.py (Pkg/None@None/None): CONFIGURE VAR=42", client.out)
+        self.assertIn("conanfile.py (Pkg/None@None/None): BUILD VAR=42", client.out)
+
+        # If we create a new Tool version
+        client.save({"conanfile.py": conanfile.replace("42", "111")})
+        client.run("export . Tool/0.2@user/channel")
+        client.save({"conanfile.py": consumer})
+
+    def _check_lock(self, ref_b):
+        lock_file = load(os.path.join(self.client.current_folder, LOCKFILE))
+        self.assertIn("Tool/0.1@user/channel", lock_file)
+        self.assertNotIn("Tool/0.2@user/channel", lock_file)
+        lock_file_json = json.loads(lock_file)
+        self.assertEqual(1, len(lock_file_json["graph_lock"]["nodes"]))
+        self.assertIn("%s:5ab84d6acfe1f23c4fae0ab88f26e3a396351ac9" % ref_b,
+                      lock_file)
+        self.assertIn('"Tool/0.1@user/channel#ac4036130c39cab7715b1402e8c211d3"', lock_file)
+
+    def install_info_test(self):
+        client = self.client
+        # Make sure to use temporary if to not change graph_info.json
+        client.run("install . -if=tmp")
+        self.assertIn("Tool/0.2@user/channel", client.out)
+        client.run("build . -if=tmp")
+        self.assertIn("conanfile.py (Pkg/None@None/None): CONFIGURE VAR=111", client.out)
+        self.assertIn("conanfile.py (Pkg/None@None/None): BUILD VAR=111", client.out)
+
+        client.run("install . --lockfile")
+        self.assertIn("Tool/0.1@user/channel", client.out)
+        self.assertNotIn("Tool/0.2@user/channel", client.out)
+        self._check_lock("Pkg/None@None/None")
+        client.run("build .")
+        self.assertIn("conanfile.py (Pkg/None@None/None): CONFIGURE VAR=42", client.out)
+        self.assertIn("conanfile.py (Pkg/None@None/None): BUILD VAR=42", client.out)
+
+        client.run("package .")
+        self.assertIn("conanfile.py (Pkg/None@None/None): CONFIGURE VAR=42", client.out)
+
+        client.run("info . --lockfile")
+        self.assertIn("conanfile.py (Pkg/None@None/None): CONFIGURE VAR=42", client.out)
+
+    def create_test(self):
+        client = self.client
+        client.run("create . Pkg/0.1@user/channel --lockfile")
+        self.assertIn("Pkg/0.1@user/channel: CONFIGURE VAR=42", client.out)
+        self.assertIn("Pkg/0.1@user/channel: BUILD VAR=42", client.out)
+        self.assertIn("Tool/0.1@user/channel", client.out)
+        self.assertNotIn("Tool/0.2@user/channel", client.out)
+        self._check_lock("Pkg/0.1@user/channel#332c2615c2ff9f78fc40682e733e5aa5")
+
+    def export_pkg_test(self):
+        client = self.client
+        client.run("export-pkg . Pkg/0.1@user/channel --install-folder=.  --lockfile")
+        self.assertIn("Pkg/0.1@user/channel: CONFIGURE VAR=42", client.out)
+        self._check_lock("Pkg/0.1@user/channel#332c2615c2ff9f78fc40682e733e5aa5")

--- a/conans/test/functional/scm/scm_test.py
+++ b/conans/test/functional/scm/scm_test.py
@@ -869,7 +869,7 @@ class ConanLib(ConanFile):
 
     def test_scm_serialization(self):
         data = {"url": "myurl", "revision": "23", "username": "myusername",
-                "password": "mypassword", "type": "svn", "verify_ssl": True,
+                "password": "mypassword", "type": "svn", "verify_ssl": False,
                 "subfolder": "mysubfolder"}
         conanfile = namedtuple("ConanfileMock", "scm")(data)
         scm_data = SCMData(conanfile)

--- a/conans/test/unittests/client/graph/deps_graph_test.py
+++ b/conans/test/unittests/client/graph/deps_graph_test.py
@@ -35,8 +35,8 @@ class DepsGraphTest(unittest.TestCase):
         deps.add_node(n1)
         deps.add_node(n2)
         deps.add_node(n3)
-        deps.add_edge(n1, n2)
-        deps.add_edge(n2, n3)
+        deps.add_edge(n1, n2, None)
+        deps.add_edge(n2, n3, None)
         self.assertEqual([[n3], [n2], [n1]], deps.by_levels())
 
     def multi_levels_test(self):
@@ -54,9 +54,9 @@ class DepsGraphTest(unittest.TestCase):
         deps.add_node(n2)
         deps.add_node(n32)
         deps.add_node(n31)
-        deps.add_edge(n1, n2)
-        deps.add_edge(n2, n31)
-        deps.add_edge(n2, n32)
+        deps.add_edge(n1, n2, None)
+        deps.add_edge(n2, n31, None)
+        deps.add_edge(n2, n32, None)
         self.assertEqual([[n31, n32], [n2], [n1]], deps.by_levels())
 
     def multi_levels_test2(self):
@@ -78,10 +78,10 @@ class DepsGraphTest(unittest.TestCase):
         deps.add_node(n2)
         deps.add_node(n32)
         deps.add_node(n31)
-        deps.add_edge(n1, n2)
-        deps.add_edge(n1, n5)
-        deps.add_edge(n2, n31)
-        deps.add_edge(n2, n32)
+        deps.add_edge(n1, n2, None)
+        deps.add_edge(n1, n5, None)
+        deps.add_edge(n2, n31, None)
+        deps.add_edge(n2, n32, None)
         self.assertEqual([[n5, n31, n32], [n2], [n1]], deps.by_levels())
 
     def multi_levels_test3(self):
@@ -103,9 +103,9 @@ class DepsGraphTest(unittest.TestCase):
         deps.add_node(n2)
         deps.add_node(n32)
         deps.add_node(n31)
-        deps.add_edge(n1, n2)
-        deps.add_edge(n1, n5)
-        deps.add_edge(n2, n31)
-        deps.add_edge(n2, n32)
-        deps.add_edge(n32, n5)
+        deps.add_edge(n1, n2, None)
+        deps.add_edge(n1, n5, None)
+        deps.add_edge(n2, n31, None)
+        deps.add_edge(n2, n32, None)
+        deps.add_edge(n32, n5, None)
         self.assertEqual([[n5, n31], [n32], [n2], [n1]], deps.by_levels())

--- a/conans/test/unittests/model/fake_retriever.py
+++ b/conans/test/unittests/model/fake_retriever.py
@@ -1,7 +1,7 @@
 import os
 
 from conans import DEFAULT_REVISION_V1
-from conans.client.graph.graph import Node
+from conans.client.graph.graph import Node, RECIPE_CONSUMER
 from conans.client.tools.files import save
 from conans.model.ref import ConanFileReference
 from conans.paths import CONANFILE
@@ -17,7 +17,9 @@ class Retriever(object):
         conan_path = os.path.join(self.folder, "data", "root.py")
         save(conan_path, content)
         conanfile = self.loader.load_consumer(conan_path, processed_profile)
-        return Node(None, conanfile, "rootpath")
+        node = Node(None, conanfile, "rootpath")
+        node.recipe = RECIPE_CONSUMER
+        return node
 
     def save_recipe(self, ref, content):
         content = str(content)


### PR DESCRIPTION
Changelog: Feature: Implementation of lockfiles. Lockfiles store in a file all the configuration, exact versions (including revisions), necessary to achieve reproducible builds, even when using version-ranges or package revisions.
Docs: https://github.com/conan-io/docs/pull/1350

--lockfile
======
- The main addition to the UI is an argument ``--lockfile`` that applies to multiple commands (create, install, info, test) and acts both as input and output
- Commands that modify a package, like rebuilding it, will modify the lockfile, and that node will be marked as "modified"
- The default value for ``--lockfile`` is the current dir, and the default filename is ``conan.lock``
- The file must exist when specified ``--lockfile``
- Commands like ``conan install .`` will generate a ``conan.lock`` file by default, without needing to specify an output, but won't be used unless ``--lockfile`` is specified.
- The conan.lock lockfile contains a copy of the effective profile

New command ``conan graph``
====================
- ``conan graph lock`` generates a new conan.lock lockfile. This is necessary if we don't want to actually install binaries yet (CI), and the ``conan info`` will fail if we try to specify a profile or settings
- ``conan graph build-order`` gets a lockfile and outputs a list of lists in order to be build: Each item has the node ID, not used yet, and the package reference of the node to build
- ``conan graph update`` is able to update a lockfile with another lockfile, that has been modified (like building some of its packages again)
- ``conan graph clean-modified`` removes the "modified" flag from all packages in a lockfile



