### PR TITLE
#3447 Support info build-order and graph

### DIFF
--- a/conans/client/command.py
+++ b/conans/client/command.py
@@ -595,7 +595,7 @@ class Command(object):
 
         # BUILD ORDER ONLY
         if args.build_order:
-            build_orded, deps_graph = self._conan.info_build_order(args.path_or_reference,
+            ret = self._conan.info_build_order(args.path_or_reference,
                                                settings=args.settings,
                                                options=args.options,
                                                env=args.env,
@@ -604,13 +604,11 @@ class Command(object):
                                                build_order=args.build_order,
                                                check_updates=args.update,
                                                install_folder=args.install_folder)
-            if args.graph:
-                self._outputer.info_graph(args.graph, deps_graph, get_cwd())
             if args.json:
                 json_arg = True if args.json == "1" else args.json
-                self._outputer.json_build_order(build_orded, json_arg, get_cwd())
+                self._outputer.json_build_order(ret, json_arg, get_cwd())
             else:
-                self._outputer.build_order(build_orded)
+                self._outputer.build_order(ret)
 
         # INSTALL SIMULATION, NODES TO INSTALL
         elif args.build is not None:

--- a/conans/client/command.py
+++ b/conans/client/command.py
@@ -595,7 +595,7 @@ class Command(object):
 
         # BUILD ORDER ONLY
         if args.build_order:
-            ret = self._conan.info_build_order(args.path_or_reference,
+            build_orded, deps_graph = self._conan.info_build_order(args.path_or_reference,
                                                settings=args.settings,
                                                options=args.options,
                                                env=args.env,
@@ -604,11 +604,13 @@ class Command(object):
                                                build_order=args.build_order,
                                                check_updates=args.update,
                                                install_folder=args.install_folder)
+            if args.graph:
+                self._outputer.info_graph(args.graph, deps_graph, get_cwd())
             if args.json:
                 json_arg = True if args.json == "1" else args.json
-                self._outputer.json_build_order(ret, json_arg, get_cwd())
+                self._outputer.json_build_order(build_orded, json_arg, get_cwd())
             else:
-                self._outputer.build_order(ret)
+                self._outputer.build_order(build_orded)
 
         # INSTALL SIMULATION, NODES TO INSTALL
         elif args.build is not None:

--- a/conans/client/command.py
+++ b/conans/client/command.py
@@ -592,6 +592,9 @@ class Command(object):
         if args.install_folder and (args.profile or args.settings or args.options or args.env):
             raise ArgumentError(None,
                                 "--install-folder cannot be used together with -s, -o, -e or -pr")
+        if args.build_order and args.graph:
+            raise ArgumentError(None,
+                                "--build-order cannot be used together with --graph")
 
         # BUILD ORDER ONLY
         if args.build_order:

--- a/conans/client/conan_api.py
+++ b/conans/client/conan_api.py
@@ -626,7 +626,7 @@ class ConanAPIV1(object):
         deps_graph, _ = self._graph_manager.load_graph(reference, None, graph_info, ["missing"],
                                                        check_updates, False, remotes,
                                                        recorder)
-        return deps_graph.build_order(build_order)
+        return deps_graph.build_order(build_order), deps_graph
 
     @api_method
     def info_nodes_to_build(self, reference, build_modes, settings=None, options=None, env=None,

--- a/conans/client/conan_api.py
+++ b/conans/client/conan_api.py
@@ -626,7 +626,7 @@ class ConanAPIV1(object):
         deps_graph, _ = self._graph_manager.load_graph(reference, None, graph_info, ["missing"],
                                                        check_updates, False, remotes,
                                                        recorder)
-        return deps_graph.build_order(build_order), deps_graph
+        return deps_graph.build_order(build_order)
 
     @api_method
     def info_nodes_to_build(self, reference, build_modes, settings=None, options=None, env=None,

--- a/conans/test/functional/command/info_test.py
+++ b/conans/test/functional/command/info_test.py
@@ -626,15 +626,3 @@ class MyTest(ConanFile):
         save(path, "broken thing")
         client.run("info .", assert_error=True)
         self.assertIn("ERROR: Error parsing GraphInfo from file", client.out)
-
-    def test_build_order_and_graph(self):
-        self.client = TestClient()
-        self._create("Hello0", "0.1")
-        self._create("Hello1", "0.1", ["Hello0/0.1@lasote/stable"])
-        self._create("Hello2", "0.1", ["Hello1/0.1@lasote/stable"], export=False)
-
-        self.client.run("info ./conanfile.py -bo=Hello0/0.1@lasote/stable --graph hello.html")
-        self.assertIn("[Hello0/0.1@lasote/stable], [Hello1/0.1@lasote/stable]", self.client.user_io.out)
-        html_path = os.path.join(self.client.current_folder, "hello.html")
-        html_content = load(html_path)
-        self.assertIn("<h3>Hello1/0.1@lasote/stable</h3>", html_content)

--- a/conans/test/functional/command/info_test.py
+++ b/conans/test/functional/command/info_test.py
@@ -434,6 +434,10 @@ class MyTest(ConanFile):
         self.assertIn('{"groups": [["Hello0/0.1@lasote/stable"], ["Hello1/0.1@lasote/stable"]]}',
                       self.client.out)
 
+        self.client.run("info Hello1/0.1@lasote/stable --build-order=Hello0/0.1@lasote/stable "
+                        "--graph=index.html", assert_error=True)
+        self.assertIn("--build-order cannot be used together with --graph", self.client.out)
+
     def build_order_build_requires_test(self):
         # https://github.com/conan-io/conan/issues/3267
         client = TestClient()

--- a/conans/test/functional/command/info_test.py
+++ b/conans/test/functional/command/info_test.py
@@ -626,3 +626,15 @@ class MyTest(ConanFile):
         save(path, "broken thing")
         client.run("info .", assert_error=True)
         self.assertIn("ERROR: Error parsing GraphInfo from file", client.out)
+
+    def test_build_order_and_graph(self):
+        self.client = TestClient()
+        self._create("Hello0", "0.1")
+        self._create("Hello1", "0.1", ["Hello0/0.1@lasote/stable"])
+        self._create("Hello2", "0.1", ["Hello1/0.1@lasote/stable"], export=False)
+
+        self.client.run("info ./conanfile.py -bo=Hello0/0.1@lasote/stable --graph hello.html")
+        self.assertIn("[Hello0/0.1@lasote/stable], [Hello1/0.1@lasote/stable]", self.client.user_io.out)
+        html_path = os.path.join(self.client.current_folder, "hello.html")
+        html_content = load(html_path)
+        self.assertIn("<h3>Hello1/0.1@lasote/stable</h3>", html_content)


### PR DESCRIPTION
Retrieve dependencies graph from Conan API to generate html.

Changelog: Fix: Allow --build-order and --graph together for conan info (#3447)
Docs: Omit
fixes #3447

- [x] Refer to the issue that supports this Pull Request.
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 

<sup>**Note:** By default this PR will skip the slower tests and will use a limited set of python versions. Check [here](https://github.com/conan-io/conan/blob/develop/.github/PR_INCREASE_TESTING.md) how to increase the testing level by writing some tags in the current PR body text.</sup>
