### PR TITLE
#3953 Inspect -a shouln't raise AttributeError

### DIFF
--- a/conans/client/conan_api.py
+++ b/conans/client/conan_api.py
@@ -278,8 +278,8 @@ class ConanAPIV1(object):
             try:
                 attr = getattr(conanfile, attribute)
                 result[attribute] = attr
-            except AttributeError as e:
-                raise ConanException(str(e))
+            except AttributeError:
+                result[attribute] = ''
         return result
 
     @api_method

--- a/conans/test/functional/command/inspect_test.py
+++ b/conans/test/functional/command/inspect_test.py
@@ -106,8 +106,8 @@ class Pkg(ConanFile):
         client.run("inspect . -a=revision_mode")
         self.assertIn("revision_mode: hash", client.out)
 
-        client.run("inspect . -a=unexisting_attr", assert_error=True)
-        self.assertIn("ERROR: 'Pkg' object has no attribute 'unexisting_attr'", client.out)
+        client.run("inspect . -a=unexisting_attr")
+        self.assertIn("unexisting_attr:", client.out)
 
     def options_test(self):
         client = TestClient()
@@ -378,8 +378,8 @@ class InspectRawTest(unittest.TestCase):
     def test_invalid_field(self):
         client = TestClient()
         client.save({"conanfile.py": self.conanfile})
-        client.run("inspect . --raw=not_exists", assert_error=True)
-        self.assertIn("ERROR: 'Pkg' object has no attribute 'not_exists'", client.out)
+        client.run("inspect . --raw=not_exists")
+        self.assertEqual("", client.out)
 
     def test_private_field(self):
         client = TestClient()


### PR DESCRIPTION
When an attribute inspected by Conan is missing, is will be returned as empty

Changelog: Fix: Inspect missing attribute is not an error (#3953)
Docs: Omit
fixes #3953

- [x] Refer to the issue that supports this Pull Request.
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 

<sup>**Note:** By default this PR will skip the slower tests and will use a limited set of python versions. Check [here](https://github.com/conan-io/conan/blob/develop/.github/PR_INCREASE_TESTING.md) how to increase the testing level by writing some tags in the current PR body text.</sup>
