### PR TITLE
changes to tqdm

### DIFF
--- a/conans/client/cmd/download.py
+++ b/conans/client/cmd/download.py
@@ -3,6 +3,7 @@ from conans.client.source import complete_recipe_sources
 from conans.model.ref import ConanFileReference, PackageReference
 from conans.errors import NotFoundException, RecipeNotFoundException
 
+
 def download(ref, package_ids, remote, recipe, remote_manager,
              cache, out, recorder, loader, hook_manager, remotes):
 

--- a/conans/client/cmd/uploader.py
+++ b/conans/client/cmd/uploader.py
@@ -520,9 +520,9 @@ def compress_files(files, symlinks, name, dest_dir, output=None):
         if output and n_files > 1 and not output.is_terminal:
             output.write("[")
         elif output and n_files > 1 and output.is_terminal:
-            progress_bar = tqdm(total=len(files), desc="Compressing package...",
+            progress_bar = tqdm(total=len(files), desc="Compressing %s" % name,
                                 unit="files", leave=True, dynamic_ncols=False,
-                                ascii=True)
+                                ascii=True, file=output)
 
         for filename, abs_path in sorted(files.items()):
             info = tarfile.TarInfo(name=filename)
@@ -544,13 +544,11 @@ def compress_files(files, symlinks, name, dest_dir, output=None):
                         output.write('=' * (units - (last_progress or 0)))
                     last_progress = units
                 if output.is_terminal:
-                    progress_bar.set_description("Compressing package: %s/%s files" % (i_file, n_files))
-                    progress_bar.update()                    
+                    progress_bar.update()
 
         if output and n_files > 1:
             if output.is_terminal:
                 progress_bar.close()
-                output.rewrite_line("{} [done]".format(progress_bar.desc))
             else:
                 output.writeln("]")
         tgz.close()

--- a/conans/client/cmd/uploader.py
+++ b/conans/client/cmd/uploader.py
@@ -520,9 +520,9 @@ def compress_files(files, symlinks, name, dest_dir, output=None):
         if output and n_files > 1 and not output.is_terminal:
             output.write("[")
         elif output and n_files > 1 and output.is_terminal:
-            progress_bar = tqdm(total=len(files), desc="Compressing package...", 
-                                unit="files", leave=False, dynamic_ncols=True,
-                                ascii=False)
+            progress_bar = tqdm(total=len(files), desc="Compressing package...",
+                                unit="files", leave=True, dynamic_ncols=False,
+                                ascii=True)
 
         for filename, abs_path in sorted(files.items()):
             info = tarfile.TarInfo(name=filename)

--- a/conans/client/rest/uploader_downloader.py
+++ b/conans/client/rest/uploader_downloader.py
@@ -52,7 +52,8 @@ class FileUploader(object):
             if response.status_code == 201:  # Artifactory returns 201 if the file is there
                 return response
 
-        self.output.info("")
+        if not self.output.is_terminal:
+            self.output.info("")
         # Actual transfer of the real content
         it = load_in_chunks(abs_path, self.chunk_size)
         # Now it is a chunked read file
@@ -123,7 +124,7 @@ class upload_with_progress(object):
         if self.output and self.output.is_terminal:
             progress_bar = tqdm(total=self.totalsize, unit='B', unit_scale=True,
                                 unit_divisor=1024, desc="Uploading {}".format(self.file_name),
-                                leave=True, dynamic_ncols=False, ascii=True)
+                                leave=True, dynamic_ncols=False, ascii=True, file=self.output)
         for index, chunk in enumerate(self.groups):
             if progress_bar is not None:
                 update_size = self.chunk_size if (index + 1) * self.chunk_size < self.totalsize \
@@ -136,7 +137,6 @@ class upload_with_progress(object):
 
         if progress_bar is not None:
             progress_bar.close()
-            self.output.rewrite_line("{} [done]".format(progress_bar.desc))
         elif self.output:
             self.output.writeln(TIMEOUT_BEAT_CHARACTER)
 
@@ -226,7 +226,7 @@ class FileDownloader(object):
         if self.output and self.output.is_terminal:
             progress_bar = tqdm(unit='B', unit_scale=True,
                                 unit_divisor=1024, dynamic_ncols=False,
-                                leave=True, ascii=True)
+                                leave=True, ascii=True, file=self.output)
 
         if total_length is None:  # no content length header
             if not file_path:

--- a/conans/client/rest/uploader_downloader.py
+++ b/conans/client/rest/uploader_downloader.py
@@ -14,6 +14,7 @@ from conans.util.tracer import log_download
 TIMEOUT_BEAT_SECONDS = 30
 TIMEOUT_BEAT_CHARACTER = '.'
 
+
 class FileUploader(object):
 
     def __init__(self, requester, output, verify, chunk_size=1000):
@@ -122,7 +123,7 @@ class upload_with_progress(object):
         if self.output and self.output.is_terminal:
             progress_bar = tqdm(total=self.totalsize, unit='B', unit_scale=True,
                                 unit_divisor=1024, desc="Uploading {}".format(self.file_name),
-                                leave=False, dynamic_ncols=True, ascii=False)
+                                leave=True, dynamic_ncols=False, ascii=True)
         for index, chunk in enumerate(self.groups):
             if progress_bar is not None:
                 update_size = self.chunk_size if (index + 1) * self.chunk_size < self.totalsize \
@@ -224,8 +225,8 @@ class FileDownloader(object):
         progress_bar = None
         if self.output and self.output.is_terminal:
             progress_bar = tqdm(unit='B', unit_scale=True,
-                                unit_divisor=1024, dynamic_ncols=True,
-                                leave=False, ascii=False)
+                                unit_divisor=1024, dynamic_ncols=False,
+                                leave=True, ascii=True)
 
         if total_length is None:  # no content length header
             if not file_path:
@@ -286,7 +287,6 @@ class FileDownloader(object):
 
         if progress_bar is not None:
             progress_bar.close()
-            self.output.writeln("{} [done]".format(progress_bar.desc))
         elif self.output:
             self.output.writeln(TIMEOUT_BEAT_CHARACTER)
 

--- a/conans/util/progress_bar.py
+++ b/conans/util/progress_bar.py
@@ -12,9 +12,9 @@ class _FileReaderWithProgressBar(object):
     tqdm_defaults = {'unit': 'B',
                      'unit_scale': True,
                      'unit_divisor': 1024,
-                     'dynamic_ncols': True,
-                     'leave': False,
-                     'ascii': False}
+                     'dynamic_ncols': False,
+                     'leave': True,
+                     'ascii': True}
 
     def __init__(self, fileobj, output, desc=None):
         pb_kwargs = self.tqdm_defaults.copy()
@@ -71,5 +71,3 @@ def open_binary(path, output, **kwargs):
         file_wrapped.pb_close()
         if not output.is_terminal:
             output.writeln("\n")
-        else:
-            output.writeln("{} [done]".format(file_wrapped.description()))


### PR DESCRIPTION
Changelog: omit
Docs: omit

Fix #5422

With these changes a few things happen:
- Using ascii output, always. It eliminates possible encoding errors in different systems. I'd trade prettiness for robustness. It also produces less "glitches" in the output, those that we needed to capture the exception and retry several times or to ignore the output
- The dynamic_ncols is = False. Filling the whole terminal was a bit weird when full screen. It also had a few glitches, when the output failed, old characters were remained to the right, unrefreshed
- The ``leave=True`` removes the need to update the line with a [done] message. I think it is nicer to leave the transfer details there, otherwise for most quick transfers it seems that nothing was done. It might help to troubleshoot some issues.

This is the output I get with the changes:

```bash
(conan27) λ conan install boost/1.69.0@conan/stable

Configuration:
[settings]
arch=x86_64
arch_build=x86_64
build_type=Release
compiler=Visual Studio
compiler.runtime=MD
compiler.version=15
os=Windows
os_build=Windows
[options]
[build_requires]
[env]

boost/1.69.0@conan/stable: Not found in local cache, looking in remotes...
boost/1.69.0@conan/stable: Trying with 'conan-center'...
Downloading conanmanifest.txt: 100%|##########| 303/303 [00:00<00:00, 75.8kB/s]
Downloading conanfile.py: 100%|##########| 37.3k/37.3k [00:00<00:00, 329kB/s]
boost/1.69.0@conan/stable: Downloaded recipe revision 0
boost/1.69.0@conan/stable: WARN: Setting 'cppstd' is deprecated in favor of 'compiler.cppstd', please update your recipe.
zlib/1.2.11@conan/stable: Not found in local cache, looking in remotes...
zlib/1.2.11@conan/stable: Trying with 'conan-center'...
Downloading conanmanifest.txt: 100%|##########| 345/345 [00:00<00:00, 21.6kB/s]
Downloading conanfile.py: 100%|##########| 8.54k/8.54k [00:00<00:00, 282kB/s]
Downloading conan_export.tgz: 100%|##########| 1.07k/1.07k [00:00<00:00, 35.2kB/s]
Decompressing conan_export.tgz: 1.07kB [00:00, 68.7kB/s]
zlib/1.2.11@conan/stable: Downloaded recipe revision 0
bzip2/1.0.6@conan/stable: Not found in local cache, looking in remotes...
bzip2/1.0.6@conan/stable: Trying with 'conan-center'...
Downloading conanmanifest.txt: 100%|##########| 163/163 [00:00<00:00, 10.2kB/s]
Downloading conanfile.py: 100%|##########| 2.21k/2.21k [00:00<00:00, 565kB/s]
Downloading conan_export.tgz: 100%|##########| 766/766 [00:00<00:00, 191kB/s]
Decompressing conan_export.tgz: 774B [00:00, 258kB/s]
bzip2/1.0.6@conan/stable: Downloaded recipe revision 0
Installing package: boost/1.69.0@conan/stable
Requirements
    boost/1.69.0@conan/stable from 'conan-center' - Downloaded
    bzip2/1.0.6@conan/stable from 'conan-center' - Downloaded
    zlib/1.2.11@conan/stable from 'conan-center' - Downloaded
Packages
    boost/1.69.0@conan/stable:e28ed7211e6b00378d5868c01918e94eb6b5b0e4 - Download
    bzip2/1.0.6@conan/stable:5be2b7a2110ec8acdbf9a1cea9de5d60747edb34 - Download
    zlib/1.2.11@conan/stable:6cc50b139b9c3d27b3e9042d5f5372d327b3a9f7 - Download

bzip2/1.0.6@conan/stable: Retrieving package 5be2b7a2110ec8acdbf9a1cea9de5d60747edb34 from remote 'conan-center'
Downloading conanmanifest.txt: 100%|##########| 398/398 [00:00<00:00, 24.9kB/s]
Downloading conaninfo.txt: 100%|##########| 490/490 [00:00<00:00, 15.8kB/s]
Downloading conan_package.tgz: 100%|##########| 89.7k/89.7k [00:00<00:00, 723kB/s]
Decompressing conan_package.tgz: 89.7kB [00:00, 1.96MB/s]
bzip2/1.0.6@conan/stable: Package installed 5be2b7a2110ec8acdbf9a1cea9de5d60747edb34
bzip2/1.0.6@conan/stable: Downloaded package revision 0
zlib/1.2.11@conan/stable: Retrieving package 6cc50b139b9c3d27b3e9042d5f5372d327b3a9f7 from remote 'conan-center'
Downloading conanmanifest.txt: 100%|##########| 403/403 [00:00<00:00, 44.8kB/s]
Downloading conaninfo.txt: 100%|##########| 474/474 [00:00<00:00, 94.8kB/s]
Downloading conan_package.tgz: 100%|##########| 98.8k/98.8k [00:00<00:00, 858kB/s]
Decompressing conan_package.tgz: 98.8kB [00:00, 2.98MB/s]
zlib/1.2.11@conan/stable: Package installed 6cc50b139b9c3d27b3e9042d5f5372d327b3a9f7
zlib/1.2.11@conan/stable: Downloaded package revision 0
boost/1.69.0@conan/stable: Retrieving package e28ed7211e6b00378d5868c01918e94eb6b5b0e4 from remote 'conan-center'
Downloading conanmanifest.txt: 100%|##########| 1.08M/1.08M [00:00<00:00, 4.25MB/s]
Downloading conaninfo.txt: 100%|##########| 2.81k/2.81k [00:00<00:00, 180kB/s]
Downloading conan_package.tgz: 100%|##########| 35.6M/35.6M [00:01<00:00, 31.8MB/s]
Decompressing conan_package.tgz: 35.6MB [00:49, 749kB/s]
boost/1.69.0@conan/stable: Package installed e28ed7211e6b00378d5868c01918e94eb6b5b0e4
boost/1.69.0@conan/stable: Downloaded package revision 0
boost/1.69.0@conan/stable: LIBRARIES: [u'libboost_wave', u'libboost_container', u'libboost_contract', u'libboost_exception', u'libboost_graph', u'libboost_iostreams', u'libboost_locale', u'libboost_log', u'libboost_program_options', u'libboost_random', u'libboost_regex', u'libboost_serialization', u'libboost_wserialization', u'libboost_coroutine', u'libboost_fiber', u'libboost_context', u'libboost_timer', u'libboost_thread', u'libboost_chrono', u'libboost_date_time', u'libboost_atomic', u'libboost_filesystem', u'libboost_system', u'libboost_type_erasure', u'libboost_log_setup', u'libboost_math_c99', u'libboost_math_c99f', u'libboost_math_c99l', u'libboost_math_tr1', u'libboost_math_tr1f', u'libboost_math_tr1l', u'libboost_stacktrace_noop', u'libboost_stacktrace_windbg', u'libboost_stacktrace_windbg_cached', u'libboost_unit_test_framework']
boost/1.69.0@conan/stable: Package folder: C:\.conan\4049a9\1
boost/1.69.0@conan/stable: Disabled magic autolinking (smart and magic decisions)
```