### PR TITLE
Improve resolution speed of version ranges in remotes using the name as pattern

### DIFF
--- a/conans/client/graph/range_resolver.py
+++ b/conans/client/graph/range_resolver.py
@@ -116,7 +116,7 @@ class RangeResolver(object):
 
         ref = require.ref
         # The search pattern must be a string
-        search_ref = str(ConanFileReference(ref.name, "*", ref.user, ref.channel))
+        search_ref = ConanFileReference(ref.name, "*", ref.user, ref.channel)
 
         if update:
             resolved_ref, remote_name = self._resolve_remote(search_ref, version_range, remotes)
@@ -130,13 +130,14 @@ class RangeResolver(object):
                 resolved_ref, remote_name = self._resolve_remote(search_ref, version_range, remotes)
 
         origin = ("remote '%s'" % remote_name) if remote_name else "local cache"
-        if resolved_ref:    
+        if resolved_ref:
             self._result.append("Version range '%s' required by '%s' resolved to '%s' in %s"
                                 % (version_range, base_conanref, str(resolved_ref), origin))
             require.ref = resolved_ref
         else:
             raise ConanException("Version range '%s' from requirement '%s' required by '%s' "
-                                 "could not be resolved in %s" % (version_range, require, base_conanref, origin))
+                                 "could not be resolved in %s"
+                                 % (version_range, require, base_conanref, origin))
 
     def _resolve_local(self, search_ref, version_range):
         local_found = search_recipes(self._cache, search_ref)
@@ -159,7 +160,11 @@ class RangeResolver(object):
         # We should use ignorecase=False, we want the exact case!
         found_refs, remote_name = self._cached_remote_found.get(search_ref, (None, None))
         if found_refs is None:
-            found_refs, remote_name = self._search_remotes(search_ref, remotes)
+            simplified_ref = "%s/*" % search_ref.name
+            found_refs, remote_name = self._search_remotes(simplified_ref, remotes)
+            if found_refs:
+                found_refs = [r for r in found_refs
+                              if r.user == search_ref.user and r.channel == search_ref.channel]
             if found_refs:
                 self._result.append("%s versions found in '%s' remote" % (search_ref, remote_name))
             else:

--- a/conans/client/graph/range_resolver.py
+++ b/conans/client/graph/range_resolver.py
@@ -160,8 +160,8 @@ class RangeResolver(object):
         # We should use ignorecase=False, we want the exact case!
         found_refs, remote_name = self._cached_remote_found.get(search_ref, (None, None))
         if found_refs is None:
-            simplified_ref = "%s/*" % search_ref.name
-            found_refs, remote_name = self._search_remotes(simplified_ref, remotes)
+            # Searching for just the name is much faster in remotes like Artifactory
+            found_refs, remote_name = self._search_remotes(search_ref.name, remotes)
             if found_refs:
                 found_refs = [r for r in found_refs
                               if r.user == search_ref.user and r.channel == search_ref.channel]

--- a/conans/test/unittests/client/graph/version_ranges_graph_test.py
+++ b/conans/test/unittests/client/graph/version_ranges_graph_test.py
@@ -101,7 +101,7 @@ class VersionRangesTest(GraphTest):
             deps_graph = self.build_graph(TestConanFile("Hello", "1.2",
                                                         requires=["Say/[%s]@myuser/testing" % expr]),
                                           update=True)
-            self.assertEqual(self.remote_manager.count, {'Say/*@myuser/testing': 1})
+            self.assertEqual(self.remote_manager.count, {'Say': 1})
             self.assertEqual(2, len(deps_graph.nodes))
             hello = _get_nodes(deps_graph, "Hello")[0]
             say = _get_nodes(deps_graph, "Say")[0]
@@ -147,7 +147,7 @@ class HelloConan(ConanFile):
                                                   Edge(dep1, say), Edge(dep2, say)})
 
         # Most important check: counter of calls to remote
-        self.assertEqual(self.remote_manager.count, {'Say/*@myuser/testing': 1})
+        self.assertEqual(self.remote_manager.count, {'Say': 1})
 
     @parameterized.expand([("", "0.3", None, None),
                            ('"Say/1.1@myuser/testing"', "1.1", False, False),


### PR DESCRIPTION
Changelog: Fix: Improve resolution of version ranges for remotes
Docs: omit

Partially address, in the client side #5432

Separate work must be done in Artifactory
