### PR TITLE
Fix verify_ssl field in SCM discarded when used with False value

### DIFF
--- a/conans/model/scm.py
+++ b/conans/model/scm.py
@@ -43,7 +43,7 @@ class SCMData(object):
         raise ConanException("Not implemented recipe revision for %s" % self.type)
 
     def __repr__(self):
-        invalid_values = [None, "", {}, []]
+        invalid_values = [None, "", {}, []]  # Discard not used/empty values but keep the False ones
         d = {"url": self.url, "revision": self.revision, "username": self.username,
              "password": self.password, "type": self.type, "verify_ssl": self.verify_ssl,
              "subfolder": self.subfolder, "submodule": self.submodule}

--- a/conans/model/scm.py
+++ b/conans/model/scm.py
@@ -43,11 +43,10 @@ class SCMData(object):
         raise ConanException("Not implemented recipe revision for %s" % self.type)
 
     def __repr__(self):
-        invalid_values = [None, "", {}, []]  # Discard not used/empty values but keep the False ones
         d = {"url": self.url, "revision": self.revision, "username": self.username,
              "password": self.password, "type": self.type, "verify_ssl": self.verify_ssl,
              "subfolder": self.subfolder, "submodule": self.submodule}
-        d = {k: v for k, v in d.items() if v not in invalid_values}
+        d = {k: v for k, v in d.items() if v is not None}
         return json.dumps(d, sort_keys=True)
 
 

--- a/conans/model/scm.py
+++ b/conans/model/scm.py
@@ -46,7 +46,7 @@ class SCMData(object):
         d = {"url": self.url, "revision": self.revision, "username": self.username,
              "password": self.password, "type": self.type, "verify_ssl": self.verify_ssl,
              "subfolder": self.subfolder, "submodule": self.submodule}
-        d = {k: v for k, v in d.items() if v is not None}
+        d = {k: v for k, v in d.items() if v is not None and v is not ""}
         return json.dumps(d, sort_keys=True)
 
 

--- a/conans/model/scm.py
+++ b/conans/model/scm.py
@@ -43,10 +43,11 @@ class SCMData(object):
         raise ConanException("Not implemented recipe revision for %s" % self.type)
 
     def __repr__(self):
+        invalid_values = [None, "", {}, []]
         d = {"url": self.url, "revision": self.revision, "username": self.username,
              "password": self.password, "type": self.type, "verify_ssl": self.verify_ssl,
              "subfolder": self.subfolder, "submodule": self.submodule}
-        d = {k: v for k, v in d.items() if v}
+        d = {k: v for k, v in d.items() if v not in invalid_values}
         return json.dumps(d, sort_keys=True)
 
 

--- a/conans/test/functional/scm/scm_test.py
+++ b/conans/test/functional/scm/scm_test.py
@@ -869,7 +869,7 @@ class ConanLib(ConanFile):
 
     def test_scm_serialization(self):
         data = {"url": "myurl", "revision": "23", "username": "myusername",
-                "password": "mypassword", "type": "svn", "verify_ssl": True,
+                "password": "mypassword", "type": "svn", "verify_ssl": False,
                 "subfolder": "mysubfolder"}
         conanfile = namedtuple("ConanfileMock", "scm")(data)
         scm_data = SCMData(conanfile)


### PR DESCRIPTION
Changelog: Bugfix: `verify_ssl` field in SCM being discarded when used with `False` value.
Docs: omit

- [x] Refer to the issue that supports this Pull Request: fixes #5402 
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [x] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 

<sup>**Note:** By default this PR will skip the slower tests and will use a limited set of python versions. Check [here](https://github.com/conan-io/conan/blob/develop/.github/PR_INCREASE_TESTING.md) how to increase the testing level by writing some tags in the current PR body text.</sup>
