### PR TITLE
Add context manager for set_dirty (#3835)

### DIFF
--- a/conans/client/cmd/uploader.py
+++ b/conans/client/cmd/uploader.py
@@ -503,7 +503,6 @@ def compress_files(files, symlinks, name, dest_dir, output=None):
     tgz_path = os.path.join(dest_dir, name)
     with set_dirty_context_manager(tgz_path):
         with open(tgz_path, "wb") as tgz_handle:
-            # tgz_contents = BytesIO()
             tgz = gzopen_without_timestamps(name, mode="w", fileobj=tgz_handle)
 
             for filename, dest in sorted(symlinks.items()):

--- a/conans/client/cmd/uploader.py
+++ b/conans/client/cmd/uploader.py
@@ -501,56 +501,55 @@ def compress_files(files, symlinks, name, dest_dir, output=None):
     t1 = time.time()
     # FIXME, better write to disk sequentially and not keep tgz contents in memory
     tgz_path = os.path.join(dest_dir, name)
-    with set_dirty_context_manager(tgz_path):
-        with open(tgz_path, "wb") as tgz_handle:
-            tgz = gzopen_without_timestamps(name, mode="w", fileobj=tgz_handle)
+    with set_dirty_context_manager(tgz_path), open(tgz_path, "wb") as tgz_handle:
+        tgz = gzopen_without_timestamps(name, mode="w", fileobj=tgz_handle)
 
-            for filename, dest in sorted(symlinks.items()):
-                info = tarfile.TarInfo(name=filename)
+        for filename, dest in sorted(symlinks.items()):
+            info = tarfile.TarInfo(name=filename)
+            info.type = tarfile.SYMTYPE
+            info.linkname = dest
+            info.size = 0  # A symlink shouldn't have size
+            tgz.addfile(tarinfo=info)
+
+        mask = ~(stat.S_IWOTH | stat.S_IWGRP)
+        i_file = 0
+        n_files = len(files)
+        last_progress = None
+        if output and n_files > 1 and not output.is_terminal:
+            output.write("[")
+        elif output and n_files > 1 and output.is_terminal:
+            progress_bar = tqdm(total=len(files), desc="Compressing %s" % name,
+                                unit="files", leave=True, dynamic_ncols=False,
+                                ascii=True, file=output)
+
+        for filename, abs_path in sorted(files.items()):
+            info = tarfile.TarInfo(name=filename)
+            info.size = os.stat(abs_path).st_size
+            info.mode = os.stat(abs_path).st_mode & mask
+            if os.path.islink(abs_path):
                 info.type = tarfile.SYMTYPE
-                info.linkname = dest
                 info.size = 0  # A symlink shouldn't have size
+                info.linkname = os.readlink(abs_path)  # @UndefinedVariable
                 tgz.addfile(tarinfo=info)
-
-            mask = ~(stat.S_IWOTH | stat.S_IWGRP)
-            i_file = 0
-            n_files = len(files)
-            last_progress = None
-            if output and n_files > 1 and not output.is_terminal:
-                output.write("[")
-            elif output and n_files > 1 and output.is_terminal:
-                progress_bar = tqdm(total=len(files), desc="Compressing %s" % name,
-                                    unit="files", leave=True, dynamic_ncols=False,
-                                    ascii=True, file=output)
-
-            for filename, abs_path in sorted(files.items()):
-                info = tarfile.TarInfo(name=filename)
-                info.size = os.stat(abs_path).st_size
-                info.mode = os.stat(abs_path).st_mode & mask
-                if os.path.islink(abs_path):
-                    info.type = tarfile.SYMTYPE
-                    info.size = 0  # A symlink shouldn't have size
-                    info.linkname = os.readlink(abs_path)  # @UndefinedVariable
-                    tgz.addfile(tarinfo=info)
-                else:
-                    with open(abs_path, 'rb') as file_handler:
-                        tgz.addfile(tarinfo=info, fileobj=file_handler)
-                if output and n_files > 1:
-                    i_file = i_file + 1
-                    units = min(50, int(50 * i_file / n_files))
-                    if last_progress != units:  # Avoid screen refresh if nothing has change
-                        if not output.is_terminal:
-                            output.write('=' * (units - (last_progress or 0)))
-                        last_progress = units
-                    if output.is_terminal:
-                        progress_bar.update()
-
+            else:
+                with open(abs_path, 'rb') as file_handler:
+                    tgz.addfile(tarinfo=info, fileobj=file_handler)
             if output and n_files > 1:
+                i_file = i_file + 1
+                units = min(50, int(50 * i_file / n_files))
+                if last_progress != units:  # Avoid screen refresh if nothing has change
+                    if not output.is_terminal:
+                        output.write('=' * (units - (last_progress or 0)))
+                    last_progress = units
                 if output.is_terminal:
-                    progress_bar.close()
-                else:
-                    output.writeln("]")
-            tgz.close()
+                    progress_bar.update()
+
+        if output and n_files > 1:
+            if output.is_terminal:
+                progress_bar.close()
+            else:
+                output.writeln("]")
+        tgz.close()
 
     duration = time.time() - t1
     log_compressed_files(files, duration, tgz_path)

--- a/conans/client/cmd/uploader.py
+++ b/conans/client/cmd/uploader.py
@@ -15,7 +15,7 @@ from conans.paths import (CONAN_MANIFEST, CONANFILE, EXPORT_SOURCES_TGZ_NAME,
                           EXPORT_TGZ_NAME, PACKAGE_TGZ_NAME, CONANINFO)
 from conans.search.search import search_packages, search_recipes
 from conans.util.files import (load, clean_dirty, is_dirty,
-                               gzopen_without_timestamps, set_dirty)
+                               gzopen_without_timestamps, set_dirty_context_manager)
 from conans.util.log import logger
 from conans.util.tracer import (log_recipe_upload, log_compressed_files,
                                 log_package_upload)
@@ -501,59 +501,58 @@ def compress_files(files, symlinks, name, dest_dir, output=None):
     t1 = time.time()
     # FIXME, better write to disk sequentially and not keep tgz contents in memory
     tgz_path = os.path.join(dest_dir, name)
-    set_dirty(tgz_path)
-    with open(tgz_path, "wb") as tgz_handle:
-        # tgz_contents = BytesIO()
-        tgz = gzopen_without_timestamps(name, mode="w", fileobj=tgz_handle)
+    with set_dirty_context_manager(tgz_path):
+        with open(tgz_path, "wb") as tgz_handle:
+            # tgz_contents = BytesIO()
+            tgz = gzopen_without_timestamps(name, mode="w", fileobj=tgz_handle)
 
-        for filename, dest in sorted(symlinks.items()):
-            info = tarfile.TarInfo(name=filename)
-            info.type = tarfile.SYMTYPE
-            info.linkname = dest
-            info.size = 0  # A symlink shouldn't have size
-            tgz.addfile(tarinfo=info)
-
-        mask = ~(stat.S_IWOTH | stat.S_IWGRP)
-        i_file = 0
-        n_files = len(files)
-        last_progress = None
-        if output and n_files > 1 and not output.is_terminal:
-            output.write("[")
-        elif output and n_files > 1 and output.is_terminal:
-            progress_bar = tqdm(total=len(files), desc="Compressing %s" % name,
-                                unit="files", leave=True, dynamic_ncols=False,
-                                ascii=True, file=output)
-
-        for filename, abs_path in sorted(files.items()):
-            info = tarfile.TarInfo(name=filename)
-            info.size = os.stat(abs_path).st_size
-            info.mode = os.stat(abs_path).st_mode & mask
-            if os.path.islink(abs_path):
+            for filename, dest in sorted(symlinks.items()):
+                info = tarfile.TarInfo(name=filename)
                 info.type = tarfile.SYMTYPE
+                info.linkname = dest
                 info.size = 0  # A symlink shouldn't have size
-                info.linkname = os.readlink(abs_path)  # @UndefinedVariable
                 tgz.addfile(tarinfo=info)
-            else:
-                with open(abs_path, 'rb') as file_handler:
-                    tgz.addfile(tarinfo=info, fileobj=file_handler)
+
+            mask = ~(stat.S_IWOTH | stat.S_IWGRP)
+            i_file = 0
+            n_files = len(files)
+            last_progress = None
+            if output and n_files > 1 and not output.is_terminal:
+                output.write("[")
+            elif output and n_files > 1 and output.is_terminal:
+                progress_bar = tqdm(total=len(files), desc="Compressing %s" % name,
+                                    unit="files", leave=True, dynamic_ncols=False,
+                                    ascii=True, file=output)
+
+            for filename, abs_path in sorted(files.items()):
+                info = tarfile.TarInfo(name=filename)
+                info.size = os.stat(abs_path).st_size
+                info.mode = os.stat(abs_path).st_mode & mask
+                if os.path.islink(abs_path):
+                    info.type = tarfile.SYMTYPE
+                    info.size = 0  # A symlink shouldn't have size
+                    info.linkname = os.readlink(abs_path)  # @UndefinedVariable
+                    tgz.addfile(tarinfo=info)
+                else:
+                    with open(abs_path, 'rb') as file_handler:
+                        tgz.addfile(tarinfo=info, fileobj=file_handler)
+                if output and n_files > 1:
+                    i_file = i_file + 1
+                    units = min(50, int(50 * i_file / n_files))
+                    if last_progress != units:  # Avoid screen refresh if nothing has change
+                        if not output.is_terminal:
+                            output.write('=' * (units - (last_progress or 0)))
+                        last_progress = units
+                    if output.is_terminal:
+                        progress_bar.update()
+
             if output and n_files > 1:
-                i_file = i_file + 1
-                units = min(50, int(50 * i_file / n_files))
-                if last_progress != units:  # Avoid screen refresh if nothing has change
-                    if not output.is_terminal:
-                        output.write('=' * (units - (last_progress or 0)))
-                    last_progress = units
                 if output.is_terminal:
-                    progress_bar.update()
+                    progress_bar.close()
+                else:
+                    output.writeln("]")
+            tgz.close()
 
-        if output and n_files > 1:
-            if output.is_terminal:
-                progress_bar.close()
-            else:
-                output.writeln("]")
-        tgz.close()
-
-    clean_dirty(tgz_path)
     duration = time.time() - t1
     log_compressed_files(files, duration, tgz_path)
 

--- a/conans/client/source.py
+++ b/conans/client/source.py
@@ -10,7 +10,8 @@ from conans.errors import ConanException, ConanExceptionInUserConanfileMethod, \
 from conans.model.conan_file import get_env_context_manager
 from conans.model.scm import SCM, get_scm_data
 from conans.paths import CONANFILE, CONAN_MANIFEST, EXPORT_SOURCES_TGZ_NAME, EXPORT_TGZ_NAME
-from conans.util.files import (clean_dirty, is_dirty, load, mkdir, rmdir, set_dirty, walk)
+from conans.util.files import (set_dirty, is_dirty, load, mkdir, rmdir, set_dirty_context_manager,
+                               walk)
 
 
 def complete_recipe_sources(remote_manager, cache, conanfile, ref, remotes):
@@ -143,18 +144,18 @@ def config_source(export_folder, export_source_folder, src_folder, conanfile, ou
         remove_source()
 
     if not os.path.exists(src_folder):  # No source folder, need to get it
-        set_dirty(src_folder)
-        mkdir(src_folder)
+        with set_dirty_context_manager(src_folder):
+            mkdir(src_folder)
 
-        def get_sources_from_exports():
-            # so self exported files have precedence over python_requires ones
-            merge_directories(export_folder, src_folder)
-            # Now move the export-sources to the right location
-            merge_directories(export_source_folder, src_folder)
+            def get_sources_from_exports():
+                # so self exported files have precedence over python_requires ones
+                merge_directories(export_folder, src_folder)
+                # Now move the export-sources to the right location
+                merge_directories(export_source_folder, src_folder)
 
-        _run_source(conanfile, conanfile_path, src_folder, hook_manager, reference,
-                    cache, local_sources_path, get_sources_from_exports=get_sources_from_exports)
-        clean_dirty(src_folder)  # Everything went well, remove DIRTY flag
+            _run_source(conanfile, conanfile_path, src_folder, hook_manager, reference,
+                        cache, local_sources_path,
+                        get_sources_from_exports=get_sources_from_exports)
 
 
 def _run_source(conanfile, conanfile_path, src_folder, hook_manager, reference, cache,

--- a/conans/test/unittests/util/files/test_dirty.py
+++ b/conans/test/unittests/util/files/test_dirty.py
@@ -11,28 +11,46 @@ from conans.util.files import set_dirty, clean_dirty, set_dirty_context_manager,
 class DirtyTest(unittest.TestCase):
 
     def setUp(self):
+        """ Create temporary folder to save dirty state
+
+        """
         self.temp_folder = temp_folder()
         self.dirty_folder = self.temp_folder + _DIRTY_FOLDER
 
     def test_set_dirty(self):
+        """ Dirty flag must be created by set_dirty
+
+        """
         set_dirty(self.temp_folder)
         self.assertTrue(os.path.exists(self.dirty_folder))
 
     def test_clean_dirty(self):
+        """ Dirty flag must be cleaned by clean_dirty
+
+        """
         set_dirty(self.temp_folder)
         self.assertTrue(os.path.exists(self.dirty_folder))
         clean_dirty(self.temp_folder)
         self.assertFalse(os.path.exists(self.dirty_folder))
 
     def test_set_dirty_context(self):
+        """ Dirty context must remove lock before exiting
+
+        """
         with set_dirty_context_manager(self.temp_folder):
             self.assertTrue(os.path.exists(self.dirty_folder))
         self.assertFalse(os.path.exists(self.dirty_folder))
 
+    def test_interrupted_dirty_context(self):
+        """ Broken context must preserve dirty state
+
+            Raise an exception in middle of context. By default,
+            dirty file is not removed.
+        """
         try:
             with set_dirty_context_manager(self.temp_folder):
                 self.assertTrue(os.path.exists(self.dirty_folder))
-                self.fail()
-        except AssertionError:
+                raise RuntimeError()
+        except RuntimeError:
             pass
         self.assertTrue(os.path.exists(self.dirty_folder))

--- a/conans/test/unittests/util/files/test_dirty.py
+++ b/conans/test/unittests/util/files/test_dirty.py
@@ -1,0 +1,38 @@
+# coding=utf-8
+
+import os
+import unittest
+
+
+from conans.test.utils.test_files import temp_folder
+from conans.util.files import set_dirty, clean_dirty, set_dirty_context_manager, _DIRTY_FOLDER
+
+
+class DirtyTest(unittest.TestCase):
+
+    def setUp(self):
+        self.temp_folder = temp_folder()
+        self.dirty_folder = self.temp_folder + _DIRTY_FOLDER
+
+    def test_set_dirty(self):
+        set_dirty(self.temp_folder)
+        self.assertTrue(os.path.exists(self.dirty_folder))
+
+    def test_clean_dirty(self):
+        set_dirty(self.temp_folder)
+        self.assertTrue(os.path.exists(self.dirty_folder))
+        clean_dirty(self.temp_folder)
+        self.assertFalse(os.path.exists(self.dirty_folder))
+
+    def test_set_dirty_context(self):
+        with set_dirty_context_manager(self.temp_folder):
+            self.assertTrue(os.path.exists(self.dirty_folder))
+        self.assertFalse(os.path.exists(self.dirty_folder))
+
+        try:
+            with set_dirty_context_manager(self.temp_folder):
+                self.assertTrue(os.path.exists(self.dirty_folder))
+                self.fail()
+        except AssertionError:
+            pass
+        self.assertTrue(os.path.exists(self.dirty_folder))

--- a/conans/util/files.py
+++ b/conans/util/files.py
@@ -58,14 +58,10 @@ def is_dirty(folder):
 
 
 @contextmanager
-def set_dirty_context_manager(folder, force_clean=False):
+def set_dirty_context_manager(folder):
     set_dirty(folder)
-    try:
-        yield
-        clean_dirty(folder)
-    except:
-        if force_clean:
-            clean_dirty(folder)
+    yield
+    clean_dirty(folder)
 
 
 def decode_text(text):

--- a/conans/util/files.py
+++ b/conans/util/files.py
@@ -68,7 +68,6 @@ def set_dirty_context_manager(folder, force_clean=False):
             clean_dirty(folder)
 
 
-
 def decode_text(text):
     decoders = ["utf-8", "Windows-1252"]
     for decoder in decoders:

--- a/conans/util/files.py
+++ b/conans/util/files.py
@@ -9,7 +9,9 @@ import sys
 import tarfile
 import tempfile
 
+
 from os.path import abspath, join as joinpath, realpath
+from contextlib import contextmanager
 
 import six
 
@@ -53,6 +55,18 @@ def clean_dirty(folder):
 def is_dirty(folder):
     dirty_file = os.path.normpath(folder) + _DIRTY_FOLDER
     return os.path.exists(dirty_file)
+
+
+@contextmanager
+def set_dirty_context_manager(folder, force_clean=False):
+    set_dirty(folder)
+    try:
+        yield
+        clean_dirty(folder)
+    except:
+        if force_clean:
+            clean_dirty(folder)
+
 
 
 def decode_text(text):


### PR DESCRIPTION
I've preferred add a new method with context manager supported, otherwise `set_dirty` would execute different behaviors, which is not good in terms simplicity.

Changelog: Feature: Add context manager for set_dirty (#3835)
Docs: https://github.com/conan-io/docs/issues/1231
closes #3835

- [x] Refer to the issue that supports this Pull Request.
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [ ] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [ ] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 

<sup>**Note:** By default this PR will skip the slower tests and will use a limited set of python versions. Check [here](https://github.com/conan-io/conan/blob/develop/.github/PR_INCREASE_TESTING.md) how to increase the testing level by writing some tags in the current PR body text.</sup>
