### PR TITLE
The Qbs generator must export cxxFlags to cpp.cxxFlags (#4730)

### DIFF
--- a/conans/client/generators/qbs.py
+++ b/conans/client/generators/qbs.py
@@ -40,7 +40,7 @@ class QbsGenerator(Generator):
                     '            cpp.systemIncludePaths: [{deps.bin_paths}]\n'
                     '            cpp.dynamicLibraries: [{deps.libs}]\n'
                     '            cpp.defines: [{deps.defines}]\n'
-                    '            cpp.cppFlags: [{deps.cxxflags}]\n'  # TODO: cppFlags -> cxxFlags?
+                    '            cpp.cxxFlags: [{deps.cxxflags}]\n'
                     '            cpp.cFlags: [{deps.cflags}]\n'
                     '            cpp.linkerFlags: [{deps.linkerFlags}]\n'
                     '        }}\n'


### PR DESCRIPTION
The cpp_info.cxxFlags must be exported to the cpp.cxxFlags in Qbs.
The cpp.cppFlags property has a different meaning  (C preprocessor
flags).

Changelog: Bugfix: Use cxxFlags instead of cppFlags in ``qbs`` generator.
Docs: https://github.com/conan-io/docs/pull/1354


Close #4730

- [*] Refer to the issue that supports this Pull Request.
- [*] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [*] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [*] I've followed the PEP8 style guides for Python code.
- [x] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 
