### PR TITLE
[engineering] SCM discard empty string values

### DIFF
--- a/conans/client/source.py
+++ b/conans/client/source.py
@@ -214,7 +214,7 @@ def _run_scm(conanfile, src_folder, local_sources_path, output, cache):
     if not scm_data:
         return
 
-    dest_dir = os.path.normpath(os.path.join(src_folder, scm_data.subfolder))
+    dest_dir = os.path.normpath(os.path.join(src_folder, scm_data.subfolder or ""))
     if cache:
         # When in cache, capturing the sources from user space is done only if exists
         if not local_sources_path or not os.path.exists(local_sources_path):

--- a/conans/model/scm.py
+++ b/conans/model/scm.py
@@ -23,7 +23,7 @@ class SCMData(object):
             self.verify_ssl = data.get("verify_ssl")
             self.username = data.get("username")
             self.password = data.get("password")
-            self.subfolder = data.get("subfolder", "")
+            self.subfolder = data.get("subfolder")
             self.submodule = data.get("submodule")
         else:
             raise ConanException("Not SCM enabled in conanfile")
@@ -46,7 +46,7 @@ class SCMData(object):
         d = {"url": self.url, "revision": self.revision, "username": self.username,
              "password": self.password, "type": self.type, "verify_ssl": self.verify_ssl,
              "subfolder": self.subfolder, "submodule": self.submodule}
-        d = {k: v for k, v in d.items() if v is not None and v is not ""}
+        d = {k: v for k, v in d.items() if v is not None}
         return json.dumps(d, sort_keys=True)
 
 


### PR DESCRIPTION
Changelog: Fix: Discard empty string values in SCM including `subfolder`
Docs: omit

@tags: SVN

Related to https://github.com/conan-io/conan/pull/5441
Discard the empty string values in the representation of the `SCMData` class.

- [x] Refer to the issue that supports this Pull Request: https://github.com/conan-io/conan/pull/5441#discussion_r300707572
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [x] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 

<sup>**Note:** By default this PR will skip the slower tests and will use a limited set of python versions. Check [here](https://github.com/conan-io/conan/blob/develop/.github/PR_INCREASE_TESTING.md) how to increase the testing level by writing some tags in the current PR body text.</sup>
