### PR TITLE
Feature/fix merge graph

### DIFF
--- a/conans/model/graph_lock.py
+++ b/conans/model/graph_lock.py
@@ -153,7 +153,8 @@ class GraphLock(object):
             if node.modified:
                 old_node = self._nodes[id_]
                 if old_node.modified:
-                    raise ConanException("Lockfile had already modified %s" % str(node.pref))
+                    if not old_node.pref.is_compatible_with(node.pref):
+                        raise ConanException("Lockfile had already modified %s" % str(node.pref))
                 self._nodes[id_] = node
 
     def clean_modified(self):

--- a/conans/model/graph_lock.py
+++ b/conans/model/graph_lock.py
@@ -206,11 +206,14 @@ class GraphLock(object):
                 if node.recipe == RECIPE_CONSUMER:
                     continue  # If the consumer node is not found, could be a test_package
                 raise
-            if lock_node.pref and lock_node.pref.full_repr() != node.pref.full_repr():
-                if node.binary == BINARY_BUILD or node.id in affected:
+            if lock_node.pref:
+                # If the update is compatible (resolved complete PREV) or if the node has
+                # been build, then update the graph
+                if lock_node.pref.is_compatible_with(node.pref) or \
+                        node.binary == BINARY_BUILD or node.id in affected:
                     lock_node.pref = node.pref
                 else:
-                    raise ConanException("Mistmatch between lock and graph:\nLock:  %s\nGraph: %s"
+                    raise ConanException("Mismatch between lock and graph:\nLock:  %s\nGraph: %s"
                                          % (lock_node.pref.full_repr(), node.pref.full_repr()))
 
     def lock_node(self, node, requires):

--- a/conans/model/ref.py
+++ b/conans/model/ref.py
@@ -134,7 +134,7 @@ class ConanFileReference(namedtuple("ConanFileReference", "name version user cha
     def is_compatible_with(self, new_ref):
         """Returns true if the new_ref is completing the RREV field of this object but
          having the rest equal """
-        if self == new_ref:
+        if self.full_repr() == new_ref.full_repr():
             return True
         if self.copy_clear_rev() != new_ref.copy_clear_rev():
             return False
@@ -191,7 +191,7 @@ class PackageReference(namedtuple("PackageReference", "ref id revision")):
     def is_compatible_with(self, new_ref):
         """Returns true if the new_ref is completing the PREV field of this object but
          having the rest equal """
-        if self == new_ref:
+        if self.full_repr() == new_ref.full_repr():
             return True
         if not self.ref.is_compatible_with(new_ref.ref) or self.id != new_ref.id:
             return False

--- a/conans/model/ref.py
+++ b/conans/model/ref.py
@@ -131,6 +131,16 @@ class ConanFileReference(namedtuple("ConanFileReference", "name version user cha
     def copy_clear_rev(self):
         return ConanFileReference(self.name, self.version, self.user, self.channel, None)
 
+    def is_compatible_with(self, new_ref):
+        """Returns true if the new_ref is completing the RREV field of this object but
+         having the rest equal """
+        if self == new_ref:
+            return True
+        if self.copy_clear_rev() != new_ref.copy_clear_rev():
+            return False
+
+        return self.revision is None
+
 
 class PackageReference(namedtuple("PackageReference", "ref id revision")):
     """ Full package reference, e.g.:
@@ -183,9 +193,7 @@ class PackageReference(namedtuple("PackageReference", "ref id revision")):
          having the rest equal """
         if self == new_ref:
             return True
-        if self.ref != new_ref.ref or self.id != new_ref.id:
+        if not self.ref.is_compatible_with(new_ref.ref) or self.id != new_ref.id:
             return False
-        if self.revision is None:
-            return True
 
-        return False
+        return self.revision is None  # Only the revision is different and we don't have one

--- a/conans/model/ref.py
+++ b/conans/model/ref.py
@@ -183,7 +183,7 @@ class PackageReference(namedtuple("PackageReference", "ref id revision")):
          having the rest equal """
         if self == new_ref:
             return True
-        if self.ref != new_ref.ref or self.package_id != new_ref.package_id:
+        if self.ref != new_ref.ref or self.id != new_ref.id:
             return False
         if self.revision is None:
             return True

--- a/conans/model/ref.py
+++ b/conans/model/ref.py
@@ -177,3 +177,15 @@ class PackageReference(namedtuple("PackageReference", "ref id revision")):
 
     def copy_clear_revs(self):
         return self.copy_with_revs(None, None)
+
+    def is_compatible_with(self, new_ref):
+        """Returns true if the new_ref is completing the PREV field of this object but
+         having the rest equal """
+        if self == new_ref:
+            return True
+        if self.ref != new_ref.ref or self.package_id != new_ref.package_id:
+            return False
+        if self.revision is None:
+            return True
+
+        return False

--- a/conans/test/unittests/model/ref_test.py
+++ b/conans/test/unittests/model/ref_test.py
@@ -152,3 +152,11 @@ class CheckValidRefTest(unittest.TestCase):
         ref_pattern = ConanFileReference.loads("package/*@user/channel")
         self.assertFalse(check_valid_ref(ref_pattern, allow_pattern=False))
         self.assertTrue(check_valid_ref(ref_pattern, allow_pattern=True))
+
+
+class CompatiblePrefTest(unittest.TestCase):
+
+    def test_compatible(self):
+        pref1 = PackageReference.loads("package/1.0@user/channel#RREV1:packageid1#PREV1")
+        pref2 = PackageReference.loads("package/1.0@user/channel#RREV1:packageid1#PREV1")
+

--- a/conans/test/unittests/model/ref_test.py
+++ b/conans/test/unittests/model/ref_test.py
@@ -157,6 +157,37 @@ class CheckValidRefTest(unittest.TestCase):
 class CompatiblePrefTest(unittest.TestCase):
 
     def test_compatible(self):
-        pref1 = PackageReference.loads("package/1.0@user/channel#RREV1:packageid1#PREV1")
-        pref2 = PackageReference.loads("package/1.0@user/channel#RREV1:packageid1#PREV1")
+
+        def ok(pref1, pref2):
+            pref1 = PackageReference.loads(pref1)
+            pref2 = PackageReference.loads(pref2)
+            return pref1.is_compatible_with(pref2)
+
+        # Same ref is ok
+        self.assertTrue(ok("package/1.0@user/channel#RREV1:packageid1#PREV1",
+                           "package/1.0@user/channel#RREV1:packageid1#PREV1"))
+
+        # Change PREV is not ok
+        self.assertFalse(ok("package/1.0@user/channel#RREV1:packageid1#PREV1",
+                            "package/1.0@user/channel#RREV1:packageid1#PREV2"))
+
+        # Different ref is not ok
+        self.assertFalse(ok("packageA/1.0@user/channel#RREV1:packageid1#PREV1",
+                            "packageB/1.0@user/channel#RREV1:packageid1#PREV1"))
+
+        # Different ref is not ok
+        self.assertFalse(ok("packageA/1.0@user/channel#RREV1:packageid1",
+                            "packageB/1.0@user/channel#RREV1:packageid1#PREV1"))
+
+        # Different package_id is not ok
+        self.assertFalse(ok("packageA/1.0@user/channel#RREV1:packageid1",
+                            "packageA/1.0@user/channel#RREV1:packageid2#PREV1"))
+
+        # Completed PREV is ok
+        self.assertTrue(ok("packageA/1.0@user/channel#RREV1:packageid1",
+                           "packageA/1.0@user/channel#RREV1:packageid1#PREV1"))
+
+        # But only in order, the second ref cannot remove PREV
+        self.assertFalse(ok("packageA/1.0@user/channel#RREV1:packageid1#PREV1",
+                            "packageA/1.0@user/channel#RREV1:packageid1"))
 

--- a/conans/test/unittests/model/ref_test.py
+++ b/conans/test/unittests/model/ref_test.py
@@ -191,3 +191,10 @@ class CompatiblePrefTest(unittest.TestCase):
         self.assertFalse(ok("packageA/1.0@user/channel#RREV1:packageid1#PREV1",
                             "packageA/1.0@user/channel#RREV1:packageid1"))
 
+        # Completing RREV is also OK
+        self.assertTrue(ok("packageA/1.0@user/channel:packageid1",
+                           "packageA/1.0@user/channel#RREV1:packageid1"))
+
+        # Completing RREV and PREV is also OK
+        self.assertTrue(ok("packageA/1.0@user/channel:packageid1",
+                           "packageA/1.0@user/channel#RREV:packageid1#PREV"))


### PR DESCRIPTION
Changelog: Bugfix: The lock files mechanism now allows to update a node providing new information, like a retrieved package revision, if the "base" reference was the same.
Docs: omit

