### PR TITLE
Bugfix: apply http.sslVerify to the current Git command only

### DIFF
--- a/conans/test/unittests/client/tools/scm/test_git.py
+++ b/conans/test/unittests/client/tools/scm/test_git.py
@@ -114,13 +114,13 @@ class GitToolTest(unittest.TestCase):
         git = Git(tmp, username="peter", password="otool", verify_ssl=True, runner=runner,
                   force_english=True)
         git.clone(url="https://myrepo.git")
-        self.assertIn("git config http.sslVerify true", runner.calls[1])
+        self.assertIn("git -c http.sslVerify=true", runner.calls[0])
 
         runner = MyRunner()
         git = Git(tmp, username="peter", password="otool", verify_ssl=False, runner=runner,
                   force_english=False)
         git.clone(url="https://myrepo.git")
-        self.assertIn("git config http.sslVerify false", runner.calls[1])
+        self.assertIn("git -c http.sslVerify=false", runner.calls[0])
 
     def test_clone_submodule_git(self):
         subsubmodule, _ = create_local_git_repo({"subsubmodule": "contents"})


### PR DESCRIPTION
Changelog: Bugfix: apply http.sslVerify to the current Git command only
Docs: omit
closes: https://github.com/conan-io/conan/issues/5462
@tags: slow, svn

- [x] Refer to the issue that supports this Pull Request.
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 

<sup>**Note:** By default this PR will skip the slower tests and will use a limited set of python versions. Check [here](https://github.com/conan-io/conan/blob/develop/.github/PR_INCREASE_TESTING.md) how to increase the testing level by writing some tags in the current PR body text.</sup>
