### PR TITLE
trailing locks bug when packages not found

### DIFF
--- a/conans/test/functional/command/info_test.py
+++ b/conans/test/functional/command/info_test.py
@@ -14,6 +14,17 @@ from conans.test.utils.conanfile import TestConanFile
 
 class InfoTest(unittest.TestCase):
 
+    def not_found_package_dirty_cache_test(self):
+        # Conan does a lock on the cache, and even if the package doesn't exist
+        # left a trailing folder with the filelocks. This test checks
+        # it will be cleared
+        client = TestClient()
+        client.run("info nothing/0.1@user/testing", assert_error=True)
+        self.assertEqual(os.listdir(client.cache.store), [])
+        # This used to fail in Windows, because of the different case
+        client.save({"conanfile.py": TestConanFile("Nothing", "0.1")})
+        client.run("export . user/testing")
+
     def failed_info_test(self):
         client = TestClient()
         conanfile = """from conans import ConanFile

--- a/conans/util/locks.py
+++ b/conans/util/locks.py
@@ -102,3 +102,19 @@ class WriteLock(Lock):
     def __exit__(self, exc_type, exc_val, exc_tb):  # @UnusedVariable
         with fasteners.InterProcessLock(self._count_lock_file, logger=logger):
             save(self._count_file, "0")
+
+        if exc_type is not None:
+            # If there was an exception while locking this, might be empty
+            # Try to clean up the trailing filelocks
+            try:
+                os.remove(self._count_file)
+                os.remove(self._count_lock_file)
+                path = os.path.dirname(self._count_file)
+                for _ in range(3):
+                    try:  # Take advantage that os.rmdir does not delete non-empty dirs
+                        os.rmdir(path)
+                    except Exception:
+                        break  # not empty
+                    path = os.path.dirname(path)
+            except Exception:
+                pass


### PR DESCRIPTION
Changelog: Bugfix: Trailing files left when packages are not found in conan info and install, restricted further installs with different case in Windows, without ``rm -rf ~/.conan/data/pkg_name``
Docs: omit

This hasn't been reported by users, so maybe not urgent, I could rebase it to develop for next 1.18

@tags: slow
