### PR TITLE
solving regression in conan info

### DIFF
--- a/conans/client/conan_api.py
+++ b/conans/client/conan_api.py
@@ -621,12 +621,13 @@ class ConanAPIV1(object):
         cwd = get_cwd()
         try:
             ref = ConanFileReference.loads(reference_or_path)
+            install_folder = _make_abs_path(install_folder, cwd) if install_folder else None
         except ConanException:
             ref = _get_conanfile_path(reference_or_path, cwd=None, py=None)
 
-        install_folder = _make_abs_path(install_folder, cwd)
-        if not os.path.exists(os.path.join(install_folder, GRAPH_INFO_FILE)):
-            install_folder = None
+            install_folder = _make_abs_path(install_folder, cwd)
+            if not os.path.exists(os.path.join(install_folder, GRAPH_INFO_FILE)):
+                install_folder = None
 
         lockfile = _make_abs_path(lockfile, cwd) if lockfile else None
         graph_info = get_graph_info(profile_names, settings, options, env, cwd, install_folder,

--- a/conans/test/functional/command/info_test.py
+++ b/conans/test/functional/command/info_test.py
@@ -630,3 +630,16 @@ class MyTest(ConanFile):
         save(path, "broken thing")
         client.run("info .", assert_error=True)
         self.assertIn("ERROR: Error parsing GraphInfo from file", client.out)
+
+    def previous_lockfile_error_test(self):
+        # https://github.com/conan-io/conan/issues/5479
+        client = TestClient()
+        client.save({"conanfile.py": TestConanFile("pkg", "0.1")})
+        client.run("create . user/testing")
+        client.save({"conanfile.py": TestConanFile("other", "0.1",
+                                                   options="{'shared': [True, False]}",
+                                                   default_options='shared=False')})
+        client.run("install . -o shared=True")
+        client.run("info pkg/0.1@user/testing")
+        self.assertIn("pkg/0.1@user/testing", client.out)
+        self.assertNotIn("shared", client.out)


### PR DESCRIPTION
Changelog: Bugfix: Solve regression in ``conan info <ref>`` command, incorrectly reading the graph_info.json and lockfiles
Docs: omit

Close #5479

@tags: slow
