### PR TITLE
python-dateutil>=2.7.0 is required for dateutil.parser.isoparse

### DIFF
--- a/conans/requirements.txt
+++ b/conans/requirements.txt
@@ -14,5 +14,5 @@ astroid>=1.6.5
 deprecation>=2.0, <2.1
 tqdm>=4.28.1, <5
 Jinja2>=2.3, <3
-python-dateutil>=2.6.0, <3
+python-dateutil>=2.7.0, <3
 typed-ast<1.4; python_version == '3.4' and platform_system=='Windows'


### PR DESCRIPTION
Changelog: Bugfix: Update python-dateutil dependency to ensure availability of `dateutil.parser.isoparse`

Docs: Omit

- Closes: #5484.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one.

Do you want a docs PR for this one? I feel like this one will be very rarely hit.