### PR TITLE
base_folder => cache_folder

### DIFF
--- a/conans/client/cache/cache.py
+++ b/conans/client/cache/cache.py
@@ -62,8 +62,8 @@ class ClientCache(object):
     of conans commands. Accesses to real disk and reads/write things. (OLD client ConanPaths)
     """
 
-    def __init__(self, base_folder, output):
-        self.cache_folder = base_folder
+    def __init__(self, cache_folder, output):
+        self.cache_folder = cache_folder
         self._output = output
 
         # Caching

--- a/conans/client/command.py
+++ b/conans/client/command.py
@@ -10,8 +10,7 @@ from argparse import ArgumentError
 from conans import __version__ as client_version
 from conans.client.cmd.uploader import UPLOAD_POLICY_FORCE, \
     UPLOAD_POLICY_NO_OVERWRITE, UPLOAD_POLICY_NO_OVERWRITE_RECIPE, UPLOAD_POLICY_SKIP
-from conans.client.conan_api import (Conan, default_manifest_folder,
-    _make_abs_path)
+from conans.client.conan_api import (Conan, default_manifest_folder, _make_abs_path)
 from conans.client.conan_command_output import CommandOutputer
 from conans.client.output import Color
 from conans.client.printer import Printer
@@ -114,11 +113,11 @@ class Command(object):
     def __init__(self, conan_api):
         assert isinstance(conan_api, Conan)
         self._conan = conan_api
-        self._user_io = conan_api._user_io
+        self._out = conan_api._user_io.out
 
     @property
     def _outputer(self):
-        return CommandOutputer(self._user_io.out, self._conan._cache)
+        return CommandOutputer(self._out, self._conan._cache)
 
     def help(self, *args):
         """
@@ -250,7 +249,7 @@ class Command(object):
         attributes = [args.raw, ] if args.raw else args.attribute
 
         result = self._conan.inspect(args.path_or_reference, attributes, args.remote)
-        Printer(self._user_io.out).print_inspect(result, raw=args.raw)
+        Printer(self._out).print_inspect(result, raw=args.raw)
         if args.json:
             json_output = json.dumps(result)
             if not os.path.isabs(args.json):
@@ -385,10 +384,9 @@ class Command(object):
             packages_list = args.package
 
             if packages_list:
-                self._user_io.out.warn("Usage of `--package` argument is deprecated."
-                                       " Use a full reference instead: "
-                                       "`conan download [...] {}:{}`".format(reference,
-                                                                             packages_list[0]))
+                self._out.warn("Usage of `--package` argument is deprecated."
+                               " Use a full reference instead: "
+                               "`conan download [...] {}:{}`".format(reference, packages_list[0]))
         else:
             reference = pref.ref.full_repr()
             packages_list = [pref.id]
@@ -990,7 +988,7 @@ class Command(object):
             if args.pattern_or_reference:
                 raise ConanException("Specifying a pattern is not supported when removing locks")
             self._conan.remove_locks()
-            self._user_io.out.info("Cache locks removed")
+            self._out.info("Cache locks removed")
             return
         elif args.system_reqs:
             if args.packages:
@@ -1040,10 +1038,9 @@ class Command(object):
             packages_list = args.package
 
             if packages_list:
-                self._user_io.out.warn("Usage of `--package` argument is deprecated."
-                                       " Use a full reference instead: "
-                                       "`conan copy [...] {}:{}`".format(reference,
-                                                                         packages_list[0]))
+                self._out.warn("Usage of `--package` argument is deprecated."
+                               " Use a full reference instead: "
+                               "`conan copy [...] {}:{}`".format(reference, packages_list[0]))
 
             if args.all and packages_list:
                 raise ConanException("Cannot specify both --all and --package")
@@ -1285,9 +1282,9 @@ class Command(object):
             package_id = args.package
 
             if package_id:
-                self._user_io.out.warn("Usage of `--package` argument is deprecated."
-                                       " Use a full reference instead: "
-                                       "`conan upload [...] {}:{}`".format(reference, package_id))
+                self._out.warn("Usage of `--package` argument is deprecated."
+                               " Use a full reference instead: "
+                               "`conan upload [...] {}:{}`".format(reference, package_id))
 
             if args.query and package_id:
                 raise ConanException("'--query' argument cannot be used together with '--package'")
@@ -1518,7 +1515,7 @@ class Command(object):
             self._conan.update_profile(profile, key, value)
         elif args.subcommand == "get":
             key = args.item
-            self._user_io.out.writeln(self._conan.get_profile_key(profile, key))
+            self._out.writeln(self._conan.get_profile_key(profile, key))
         elif args.subcommand == "remove":
             self._conan.delete_profile_key(profile, args.item)
 
@@ -1551,9 +1548,9 @@ class Command(object):
             package_id = args.package
 
             if package_id:
-                self._user_io.out.warn("Usage of `--package` argument is deprecated."
-                                       " Use a full reference instead: "
-                                       "`conan get [...] {}:{}`".format(reference, package_id))
+                self._out.warn("Usage of `--package` argument is deprecated."
+                               " Use a full reference instead: "
+                               "`conan get [...] {}:{}`".format(reference, package_id))
         else:
             reference = pref.ref.full_repr()
             package_id = pref.id
@@ -1603,9 +1600,9 @@ class Command(object):
 
         install_parser = subparsers.add_parser('install',
                                                help='same as a "conan install" command'
-                                                    ' but using the workspace data from the file. If'
-                                                    ' no file is provided, it will look for a file'
-                                                    ' named "conanws.yml"')
+                                                    ' but using the workspace data from the file. '
+                                                    'If no file is provided, it will look for a '
+                                                    'file named "conanws.yml"')
         install_parser.add_argument('path', help='path to workspace definition file (it will look'
                                                  ' for a "conanws.yml" inside if a directory is'
                                                  ' given)')
@@ -1655,20 +1652,19 @@ class Command(object):
 
         if args.subcommand == "add":
             self._conan.editable_add(args.path, args.reference, args.layout, cwd=os.getcwd())
-            self._user_io.out.success("Reference '{}' in editable mode".format(args.reference))
+            self._out.success("Reference '{}' in editable mode".format(args.reference))
         elif args.subcommand == "remove":
             ret = self._conan.editable_remove(args.reference)
             if ret:
-                self._user_io.out.success("Removed editable mode for reference "
-                                          "'{}'".format(args.reference))
+                self._out.success("Removed editable mode for reference '{}'".format(args.reference))
             else:
-                self._user_io.out.warn("Reference '{}' was not installed "
-                                       "as editable".format(args.reference))
+                self._out.warn("Reference '{}' was not installed "
+                               "as editable".format(args.reference))
         elif args.subcommand == "list":
             for k, v in self._conan.editable_list().items():
-                self._user_io.out.info("%s" % k)
-                self._user_io.out.writeln("    Path: %s" % v["path"])
-                self._user_io.out.writeln("    Layout: %s" % v["layout"])
+                self._out.info("%s" % k)
+                self._out.writeln("    Path: %s" % v["path"])
+                self._out.writeln("    Layout: %s" % v["layout"])
 
     def graph(self, *args):
         """
@@ -1712,7 +1708,7 @@ class Command(object):
             self._conan.update_lock(args.old_lockfile, args.new_lockfile)
         elif args.subcommand == "build-order":
             build_order = self._conan.build_order(args.lockfile, args.build)
-            self._user_io.out.writeln(build_order)
+            self._out.writeln(build_order)
             if args.json:
                 json_file = _make_abs_path(args.json)
                 save(json_file, json.dumps(build_order, indent=True))
@@ -1754,10 +1750,10 @@ class Command(object):
         fmt = '  %-{}s'.format(max_len)
 
         for group_name, comm_names in grps:
-            self._user_io.out.writeln(group_name, Color.BRIGHT_MAGENTA)
+            self._out.writeln(group_name, Color.BRIGHT_MAGENTA)
             for name in comm_names:
                 # future-proof way to ensure tabular formatting
-                self._user_io.out.write(fmt % name, Color.GREEN)
+                self._out.write(fmt % name, Color.GREEN)
 
                 # Help will be all the lines up to the first empty one
                 docstring_lines = commands[name].__doc__.split('\n')
@@ -1774,11 +1770,10 @@ class Command(object):
 
                 import textwrap
                 txt = textwrap.fill(' '.join(data), 80, subsequent_indent=" "*(max_len+2))
-                self._user_io.out.writeln(txt)
+                self._out.writeln(txt)
 
-        self._user_io.out.writeln("")
-        self._user_io.out.writeln('Conan commands. Type "conan <command> -h" for help',
-                                  Color.BRIGHT_YELLOW)
+        self._out.writeln("")
+        self._out.writeln('Conan commands. Type "conan <command> -h" for help', Color.BRIGHT_YELLOW)
 
     def _commands(self):
         """ returns a list of available commands
@@ -1796,13 +1791,12 @@ class Command(object):
 
     def _warn_python2(self):
         if six.PY2:
-            self._user_io.out.writeln("")
-            self._user_io.out.writeln("Python 2 will soon be deprecated. It is strongly "
-                                      "recommended to use Python 3 with Conan:",
-                                      front=Color.BRIGHT_YELLOW)
-            self._user_io.out.writeln("https://docs.conan.io/en/latest/installation.html"
-                                      "#python-2-deprecation-notice", front=Color.BRIGHT_YELLOW)
-            self._user_io.out.writeln("")
+            self._out.writeln("")
+            self._out.writeln("Python 2 will soon be deprecated. It is strongly "
+                              "recommended to use Python 3 with Conan:", front=Color.BRIGHT_YELLOW)
+            self._out.writeln("https://docs.conan.io/en/latest/installation.html"
+                              "#python-2-deprecation-notice", front=Color.BRIGHT_YELLOW)
+            self._out.writeln("")
 
     @staticmethod
     def _check_query_parameter(pattern, query):
@@ -1828,7 +1822,7 @@ class Command(object):
                 method = commands[command]
             except KeyError as exc:
                 if command in ["-v", "--version"]:
-                    self._user_io.out.success("Conan version %s" % client_version)
+                    self._out.success("Conan version %s" % client_version)
                     return False
                 self._warn_python2()
                 self._show_help()
@@ -1845,20 +1839,20 @@ class Command(object):
         except SystemExit as exc:
             if exc.code != 0:
                 logger.error(exc)
-                self._user_io.out.error("Exiting with code: %d" % exc.code)
+                self._out.error("Exiting with code: %d" % exc.code)
             ret_code = exc.code
         except ConanInvalidConfiguration as exc:
             ret_code = ERROR_INVALID_CONFIGURATION
-            self._user_io.out.error(exc)
+            self._out.error(exc)
         except ConanException as exc:
             ret_code = ERROR_GENERAL
-            self._user_io.out.error(exc)
+            self._out.error(exc)
         except Exception as exc:
             import traceback
             print(traceback.format_exc())
             ret_code = ERROR_GENERAL
             msg = exception_message_safe(exc)
-            self._user_io.out.error(msg)
+            self._out.error(msg)
 
         return ret_code
 

--- a/conans/client/conan_api.py
+++ b/conans/client/conan_api.py
@@ -146,14 +146,14 @@ class ConanAPIV1(object):
         user_io = UserIO(out=out)
 
         user_home = get_conan_user_home()
-        base_folder = os.path.join(user_home, ".conan")
+        cache_folder = os.path.join(user_home, ".conan")
 
-        cache = ClientCache(base_folder, out)
+        cache = ClientCache(cache_folder, out)
         # Migration system
         migrator = ClientMigrator(cache, Version(client_version), out)
         migrator.migrate()
 
-        sys.path.append(os.path.join(base_folder, "python"))
+        sys.path.append(os.path.join(cache_folder, "python"))
 
         config = cache.config
         # Adjust CONAN_LOGGING_LEVEL with the env readed

--- a/conans/test/functional/command/config_install_test.py
+++ b/conans/test/functional/command/config_install_test.py
@@ -169,20 +169,20 @@ class ConfigInstallTest(unittest.TestCase):
         self.assertEqual(conan_conf.get_item("proxies.https"), "None")
         self.assertEqual(conan_conf.get_item("proxies.http"), "http://user:pass@10.10.1.10:3128/")
         self.assertEqual("#Custom pylint",
-                         load(os.path.join(self.client.cache.cache_folder, "pylintrc")))
+                         load(os.path.join(self.client.cache_folder, "pylintrc")))
         self.assertEqual("",
-                         load(os.path.join(self.client.cache.cache_folder, "python",
+                         load(os.path.join(self.client.cache_folder, "python",
                                            "__init__.py")))
         self.assertEqual("#hook dummy",
-                         load(os.path.join(self.client.cache.cache_folder, "hooks", "dummy")))
+                         load(os.path.join(self.client.cache_folder, "hooks", "dummy")))
         self.assertEqual("#hook foo",
-                         load(os.path.join(self.client.cache.cache_folder, "hooks", "foo.py")))
+                         load(os.path.join(self.client.cache_folder, "hooks", "foo.py")))
         self.assertEqual("#hook custom",
-                         load(os.path.join(self.client.cache.cache_folder, "hooks", "custom",
+                         load(os.path.join(self.client.cache_folder, "hooks", "custom",
                                            "custom.py")))
-        self.assertFalse(os.path.exists(os.path.join(self.client.cache.cache_folder, "hooks",
+        self.assertFalse(os.path.exists(os.path.join(self.client.cache_folder, "hooks",
                                                      ".git")))
-        self.assertFalse(os.path.exists(os.path.join(self.client.cache.cache_folder, ".git")))
+        self.assertFalse(os.path.exists(os.path.join(self.client.cache_folder, ".git")))
 
     def reuse_python_test(self):
         zippath = self._create_zip()
@@ -220,9 +220,9 @@ class Pkg(ConanFile):
         save_files(folder, {"subf/file.txt": "hello",
                             "subf/subf/file2.txt": "bye"})
         self.client.run('config install "%s" -sf=subf -tf=newsubf' % folder)
-        content = load(os.path.join(self.client.cache.cache_folder, "newsubf/file.txt"))
+        content = load(os.path.join(self.client.cache_folder, "newsubf/file.txt"))
         self.assertEqual(content, "hello")
-        content = load(os.path.join(self.client.cache.cache_folder, "newsubf/subf/file2.txt"))
+        content = load(os.path.join(self.client.cache_folder, "newsubf/subf/file2.txt"))
         self.assertEqual(content, "bye")
 
     def install_multiple_configs_test(self):
@@ -230,8 +230,8 @@ class Pkg(ConanFile):
         save_files(folder, {"subf/file.txt": "hello",
                             "subf2/file2.txt": "bye"})
         self.client.run('config install "%s" -sf=subf' % folder)
-        content = load(os.path.join(self.client.cache.cache_folder, "file.txt"))
-        file2 = os.path.join(self.client.cache.cache_folder, "file2.txt")
+        content = load(os.path.join(self.client.cache_folder, "file.txt"))
+        file2 = os.path.join(self.client.cache_folder, "file2.txt")
         self.assertEqual(content, "hello")
         self.assertFalse(os.path.exists(file2))
         self.client.run('config install "%s" -sf=subf2' % folder)
@@ -240,7 +240,7 @@ class Pkg(ConanFile):
         save_files(folder, {"subf/file.txt": "HELLO!!",
                             "subf2/file2.txt": "BYE!!"})
         self.client.run('config install')
-        content = load(os.path.join(self.client.cache.cache_folder, "file.txt"))
+        content = load(os.path.join(self.client.cache_folder, "file.txt"))
         self.assertEqual(content, "HELLO!!")
         content = load(file2)
         self.assertEqual(content, "BYE!!")
@@ -499,7 +499,7 @@ class Pkg(ConanFile):
             self.client.run_command('git add .')
             self.client.run_command('git commit -m "my other file"')
             self.client.run_command('git checkout master')
-        other_path = os.path.join(self.client.cache.cache_folder, "hooks", "other", "other.py")
+        other_path = os.path.join(self.client.cache_folder, "hooks", "other", "other.py")
         self.assertFalse(os.path.exists(other_path))
         self.client.run('config install')
         check_path = os.path.join(folder, ".git")

--- a/conans/test/functional/command/config_test.py
+++ b/conans/test/functional/command/config_test.py
@@ -22,7 +22,7 @@ class ConfigTest(unittest.TestCase):
         self.assertIn("path = ./data", self.client.out)
 
         self.client.run("config get storage.path")
-        full_path = os.path.join(self.client.base_folder, "data")
+        full_path = os.path.join(self.client.cache_folder, "data")
         self.assertIn(full_path, self.client.out)
         self.assertNotIn("path:", self.client.out)
 

--- a/conans/test/functional/command/export_test.py
+++ b/conans/test/functional/command/export_test.py
@@ -340,7 +340,7 @@ class OpenSSLConan(ConanFile):
         file_list = self._create_packages_and_builds()
         # Export the same conans
         # Do not adjust cpu_count, it is reusing a cache
-        client2 = TestClient(self.client.base_folder, cpu_count=False)
+        client2 = TestClient(self.client.cache_folder, cpu_count=False)
         files2 = cpp_hello_conan_files("Hello0", "0.1")
         client2.save(files2)
         client2.run("export . lasote/stable")
@@ -375,7 +375,7 @@ class OpenSSLConan(ConanFile):
         # Export an update of the same conans
 
         # Do not adjust cpu_count, it is reusing a cache
-        client2 = TestClient(self.client.base_folder, cpu_count=False)
+        client2 = TestClient(self.client.cache_folder, cpu_count=False)
         files2 = cpp_hello_conan_files("Hello0", "0.1")
         files2[CONANFILE] = "# insert comment\n %s" % files2[CONANFILE]
         client2.save(files2)

--- a/conans/test/functional/command/info_folders_test.py
+++ b/conans/test/functional/command/info_folders_test.py
@@ -113,11 +113,11 @@ class InfoFoldersTest(unittest.TestCase):
 
     @unittest.skipIf(platform.system() != "Windows", "Needs windows for short_paths")
     def test_short_paths(self):
-        folder = temp_folder(False)
-        short_folder = os.path.join(folder, ".cn")
+        cache_folder = temp_folder(False)
+        short_folder = os.path.join(cache_folder, ".cn")
 
         with tools.environment_append({"CONAN_USER_HOME_SHORT": short_folder}):
-            client = TestClient(base_folder=folder)
+            client = TestClient(cache_folder=cache_folder)
             client.save({CONANFILE: conanfile_py.replace("False", "True")})
             client.run("export . %s" % self.user_channel)
             client.run("info %s --paths" % (self.reference1))
@@ -150,13 +150,13 @@ class InfoFoldersTest(unittest.TestCase):
         granted with full control permission to avoid access problems when cygwin/msys2
         windows subsystems are mounting/using that folder.
         """
-        folder = temp_folder(False)  # Creates a temporary folder in %HOME%\appdata\local\temp
+        cache_folder = temp_folder(False)  # Creates a temporary folder in %HOME%\appdata\local\temp
 
         out = subprocess.check_output("wmic logicaldisk %s get FileSystem"
-                                      % os.path.splitdrive(folder)[0])
+                                      % os.path.splitdrive(cache_folder)[0])
         if "NTFS" not in str(out):
             return
-        short_folder = os.path.join(folder, ".cnacls")
+        short_folder = os.path.join(cache_folder, ".cnacls")
 
         self.assertFalse(os.path.exists(short_folder), "short_folder: %s shouldn't exists"
                          % short_folder)
@@ -175,7 +175,7 @@ class InfoFoldersTest(unittest.TestCase):
 
         # Run conan export in using short_folder
         with tools.environment_append({"CONAN_USER_HOME_SHORT": short_folder}):
-            client = TestClient(base_folder=folder)
+            client = TestClient(cache_folder=cache_folder)
             client.save({CONANFILE: conanfile_py.replace("False", "True")})
             client.run("export . %s" % self.user_channel)
 
@@ -202,8 +202,8 @@ class InfoFoldersTest(unittest.TestCase):
     @unittest.skipIf(platform.system() != "Windows", "Needs windows for short_paths")
     def test_short_paths_folders(self):
         # https://github.com/conan-io/conan/issues/4612
-        folder = temp_folder(False)
-        short_folder = os.path.join(folder, ".cn")
+        cache_folder = temp_folder(False)
+        short_folder = os.path.join(cache_folder, ".cn")
 
         conanfile = dedent("""
             from conans import ConanFile
@@ -212,7 +212,7 @@ class InfoFoldersTest(unittest.TestCase):
                 short_paths=True
             """)
         with tools.environment_append({"CONAN_USER_HOME_SHORT": short_folder}):
-            client = TestClient(base_folder=folder, servers={"default": TestServer()},
+            client = TestClient(cache_folder=cache_folder, servers={"default": TestServer()},
                                 users={"default": [("lasote", "mypass")]})
             client.save({CONANFILE: conanfile})
             client.run("export . pkga/0.1@lasote/testing")

--- a/conans/test/functional/command/info_test.py
+++ b/conans/test/functional/command/info_test.py
@@ -201,8 +201,8 @@ class MyTest(ConanFile):
 
     def graph_html_embedded_visj_test(self):
         client = TestClient()
-        visjs_path = os.path.join(client.cache.cache_folder, "vis.min.js")
-        viscss_path = os.path.join(client.cache.cache_folder, "vis.min.css")
+        visjs_path = os.path.join(client.cache_folder, "vis.min.js")
+        viscss_path = os.path.join(client.cache_folder, "vis.min.css")
         save(visjs_path, "")
         save(viscss_path, "")
         client.save({"conanfile.txt": ""})

--- a/conans/test/functional/command/install_test.py
+++ b/conans/test/functional/command/install_test.py
@@ -371,7 +371,7 @@ class Pkg(ConanFile):
         self._create("Hello0", "0.1")
 
         # Do not adjust cpu_count, it is reusing a cache
-        client = TestClient(base_folder=self.client.base_folder, cpu_count=False)
+        client = TestClient(cache_folder=self.client.cache_folder, cpu_count=False)
         files = {CONANFILE_TXT: """[requires]
         Hello0/0.1@lasote/stable
 
@@ -443,7 +443,8 @@ class TestConan(ConanFile):
                    "--install-folder=win_dir")
         self.assertIn("Hello/0.1@lasote/stable from local cache",
                       client.out)  # Test "from local cache" output message
-        client.run("install . --build=missing -s os=Macos -s os_build=Macos --install-folder=os_dir")
+        client.run("install . --build=missing -s os=Macos -s os_build=Macos "
+                   "--install-folder=os_dir")
         conaninfo = load(os.path.join(client.current_folder, "win_dir/conaninfo.txt"))
         self.assertIn("os=Windows", conaninfo)
         self.assertNotIn("os=Macos", conaninfo)

--- a/conans/test/functional/command/new_test.py
+++ b/conans/test/functional/command/new_test.py
@@ -17,7 +17,7 @@ class NewTest(unittest.TestCase):
                 name = "{{name}}"
                 version = "{{version}}"
         """)
-        save(os.path.join(client.base_folder, "templates/mytemplate.py"), template1)
+        save(os.path.join(client.cache_folder, "templates/mytemplate.py"), template1)
         client.run("new hello/0.1 --template=mytemplate.py")
         conanfile = load(os.path.join(client.current_folder, "conanfile.py"))
         self.assertIn("class HelloConan(ConanFile):", conanfile)
@@ -30,7 +30,8 @@ class NewTest(unittest.TestCase):
             class {{package_name}}Conan(ConanFile):
                 version = "fixed"
         """)
-        save(os.path.join(client.base_folder, "templates", "subfolder", "mytemplate.py"), template2)
+        save(os.path.join(client.cache_folder, "templates", "subfolder", "mytemplate.py"),
+             template2)
         client.run("new hello/0.1 -m=subfolder/mytemplate.py")
         conanfile = load(os.path.join(client.current_folder, "conanfile.py"))
         self.assertIn("class HelloConan(ConanFile):", conanfile)

--- a/conans/test/functional/configuration/default_profile_test.py
+++ b/conans/test/functional/configuration/default_profile_test.py
@@ -164,7 +164,7 @@ class MyConanfile(ConanFile):
         env_variable = "env_variable=relative_profile"
         rel_path = os.path.join('..', 'env_rel_profile')
         self.assertFalse(os.path.isabs(rel_path))
-        default_profile_path = os.path.join(client.cache.cache_folder,
+        default_profile_path = os.path.join(client.cache_folder,
                                             PROFILES_FOLDER, rel_path)
         save(default_profile_path, "[env]\n" + env_variable)
         with tools.environment_append({'CONAN_DEFAULT_PROFILE_PATH': rel_path}):

--- a/conans/test/functional/configuration/registry_test.py
+++ b/conans/test/functional/configuration/registry_test.py
@@ -38,7 +38,7 @@ lib/1.0@conan/stable conan.io
 other/1.0@lasote/testing conan.io
 """)
         client = TestClient(cache_folder=cache_folder, servers=False)
-        version_file = os.path.join(client.cache.cache_folder, CONAN_VERSION)
+        version_file = os.path.join(client.cache_folder, CONAN_VERSION)
         save(version_file, "1.12.0")
         client.run("remote list")
         self.assertIn("conan.io: https://server.conan.io", client.out)

--- a/conans/test/functional/configuration/registry_test.py
+++ b/conans/test/functional/configuration/registry_test.py
@@ -30,14 +30,14 @@ class RegistryTest(unittest.TestCase):
                          [("conan.io", "https://server.conan.io", True)])
 
     def to_json_migration_test(self):
-        tmp = temp_folder()
-        f = os.path.join(tmp, "registry.txt")
+        cache_folder = temp_folder()
+        f = os.path.join(cache_folder, "registry.txt")
         save(f, """conan.io https://server.conan.io True
 
 lib/1.0@conan/stable conan.io
 other/1.0@lasote/testing conan.io
 """)
-        client = TestClient(base_folder=tmp, servers=False)
+        client = TestClient(cache_folder=cache_folder, servers=False)
         version_file = os.path.join(client.cache.cache_folder, CONAN_VERSION)
         save(version_file, "1.12.0")
         client.run("remote list")

--- a/conans/test/functional/cppstd/compiler_cppstd_test.py
+++ b/conans/test/functional/cppstd/compiler_cppstd_test.py
@@ -33,8 +33,7 @@ class SettingsCppStdScopedPackageTests(unittest.TestCase):
             unittest.TestCase.run(self, *args, **kwargs)
 
     def setUp(self):
-        self.tmp_folder = temp_folder()
-        self.t = TestClient(base_folder=self.tmp_folder)
+        self.t = TestClient(cache_folder=temp_folder())
 
         settings = ["os", "compiler", "build_type", "arch"]
         if self.recipe_cppstd:
@@ -49,8 +48,8 @@ class SettingsCppStdScopedPackageTests(unittest.TestCase):
         self.t.save({"conanfile.py": conanfile})
 
     def test_value_invalid(self):
-        self.t.run("create . hh/0.1@user/channel -shh:compiler=apple-clang -shh:compiler.cppstd=144",
-                   assert_error=True)
+        self.t.run("create . hh/0.1@user/channel -shh:compiler=apple-clang "
+                   "-shh:compiler.cppstd=144", assert_error=True)
         self.assertIn("Invalid setting '144' is not a valid 'settings.compiler.cppstd' value",
                       self.t.out)
 
@@ -79,7 +78,7 @@ class SettingsCppStdScopedPackageTests(unittest.TestCase):
             class Lib(ConanFile):
                 settings = "os", "arch"
         """)
-        t = TestClient(base_folder=temp_folder())
+        t = TestClient(cache_folder=temp_folder())
         t.save({'conanfile.py': conanfile})
 
         with catch_deprecation_warning(self):
@@ -101,7 +100,7 @@ class SettingsCppStdScopedPackageTests(unittest.TestCase):
                 def configure(self):
                     self.output.info(">>> cppstd: {}".format(self.settings.cppstd))
         """)
-        t = TestClient(base_folder=temp_folder())
+        t = TestClient(cache_folder=temp_folder())
         t.save({'conanfile.py': conanfile}, clean_first=True)
 
         with catch_deprecation_warning(self):
@@ -144,7 +143,8 @@ class UseCompilerCppStdSettingTests(unittest.TestCase):
         self.assertIn(">>> compiler.cppstd: None", self.t.out)
 
     def test_only_compiler_cppstd(self):
-        """ settings.cppstd is available only if declared explicitly (otherwise it is deprecated) """
+        """ settings.cppstd is available only if declared explicitly (otherwise it is deprecated)
+        """
         self.t.run("info . -s compiler.cppstd=14")
         self.assertNotIn(">>> cppstd: 14", self.t.out)
         self.assertIn(">>> cppstd: None", self.t.out)

--- a/conans/test/functional/editable/consume_header_only_test.py
+++ b/conans/test/functional/editable/consume_header_only_test.py
@@ -1,16 +1,15 @@
 # coding=utf-8
 
 import os
-import tempfile
 import textwrap
 import unittest
 
 from parameterized import parameterized
 
 from conans.model.editable_layout import DEFAULT_LAYOUT_FILE, LAYOUTS_FOLDER
-from conans.test import CONAN_TEST_FOLDER
 from conans.test.utils.tools import TestClient
 from conans.util.files import save
+from conans.test.utils.test_files import temp_folder
 
 
 class HeaderOnlyLibTestClient(TestClient):
@@ -87,19 +86,19 @@ class EditableReferenceTest(unittest.TestCase):
     @parameterized.expand([(False, True), (True, False), (True, True), (False, False)])
     def test_header_only(self, use_repo_file, use_cache_file):
         # We need two clients sharing the same Conan cache
-        base_folder = tempfile.mkdtemp(suffix='conans', dir=CONAN_TEST_FOLDER)
+        cache_folder = temp_folder()
 
         # Editable project
         client_editable = HeaderOnlyLibTestClient(use_repo_file=use_repo_file,
                                                   use_cache_file=use_cache_file,
-                                                  base_folder=base_folder)
+                                                  cache_folder=cache_folder)
         if use_repo_file:
             client_editable.run("editable add . MyLib/0.1@user/editable --layout=mylayout")
         else:
             client_editable.run("editable add . MyLib/0.1@user/editable")
 
         # Consumer project
-        client = TestClient(base_folder=base_folder)
+        client = TestClient(cache_folder=cache_folder)
         conanfile_py = """
 import os
 from conans import ConanFile, CMake

--- a/conans/test/functional/editable/consume_settings_and_options_test.py
+++ b/conans/test/functional/editable/consume_settings_and_options_test.py
@@ -2,15 +2,14 @@
 
 import itertools
 import os
-import tempfile
 import unittest
 
 from parameterized import parameterized
 
 from conans.model.editable_layout import DEFAULT_LAYOUT_FILE, LAYOUTS_FOLDER
-from conans.test import CONAN_TEST_FOLDER
 from conans.test.utils.tools import TestClient
 from conans.util.files import save
+from conans.test.utils.test_files import temp_folder
 
 
 class HeaderOnlyLibTestClient(TestClient):
@@ -84,18 +83,18 @@ class SettingsAndOptionsTest(unittest.TestCase):
                                             [True, False, ]))  # use_repo_file
     def test_settings_options(self, build_type, shared, use_repo_file):
         # We need two clients sharing the same Conan cache
-        base_folder = tempfile.mkdtemp(suffix='conans', dir=CONAN_TEST_FOLDER)
+        cache_folder = temp_folder()
 
         # Editable project
         client_editable = HeaderOnlyLibTestClient(use_repo_file=use_repo_file,
-                                                  base_folder=base_folder)
+                                                  cache_folder=cache_folder)
         if use_repo_file:
             client_editable.run("editable add . MyLib/0.1@user/editable -l=mylayout")
         else:
             client_editable.run("editable add . MyLib/0.1@user/editable")
 
         # Consumer project
-        client = TestClient(base_folder=base_folder)
+        client = TestClient(cache_folder=cache_folder)
         conanfile_txt = """
 import os
 from conans import ConanFile, CMake

--- a/conans/test/functional/editable/layouts_test.py
+++ b/conans/test/functional/editable/layouts_test.py
@@ -25,7 +25,7 @@ class LayoutTest(unittest.TestCase):
         client.save({"conanfile.py": TestConanFile("lib", "1.0"),
                      "mylayout": layout})
         client.run("editable add . {} --layout mylayout".format(ref))
-        client2 = TestClient(base_folder=client.base_folder)
+        client2 = TestClient(cache_folder=client.cache_folder)
         client2.save({"conanfile.py": TestConanFile("app", "1.0",
                                                     requires=["lib/1.0@conan/stable"])})
         client2.run("create . user/testing")
@@ -44,7 +44,7 @@ class LayoutTest(unittest.TestCase):
                      "layout": ""})
         client.run("editable add . mytool/0.1@user/testing -l=layout")
         self.assertIn("Using layout file:", client.out)
-        client2 = TestClient(client.base_folder)
+        client2 = TestClient(client.cache_folder)
         consumer = textwrap.dedent("""
             [requires]
             mytool/0.1@user/testing
@@ -76,7 +76,7 @@ class LayoutTest(unittest.TestCase):
             [{}:includedirs]
             include_{}
             """)
-        layout_folder = os.path.join(client.base_folder, LAYOUTS_FOLDER)
+        layout_folder = os.path.join(client.cache_folder, LAYOUTS_FOLDER)
         ref_str = "mytool/0.1@user/testing"
         save_files(layout_folder, {"layout_win_cache": layout_cache.format(ref_str, "win_cache"),
                                    "layout_linux_cache": layout_cache.format(ref_str,
@@ -87,7 +87,7 @@ class LayoutTest(unittest.TestCase):
                      "layout_win": layout_repo.format("win"),
                      "layout_linux": layout_repo.format("linux")})
         client.run("editable add . mytool/0.1@user/testing")
-        client2 = TestClient(client.base_folder)
+        client2 = TestClient(client.cache_folder)
         consumer = textwrap.dedent("""
             [requires]
             mytool/0.1@user/testing
@@ -120,14 +120,14 @@ class LayoutTest(unittest.TestCase):
             include_{}
             """)
 
-        layout_folder = os.path.join(client.base_folder, LAYOUTS_FOLDER)
+        layout_folder = os.path.join(client.cache_folder, LAYOUTS_FOLDER)
         save_files(layout_folder, {"win/cache": layout_repo.format("win/cache"),
                                    "linux/cache": layout_repo.format("linux/cache")})
         client.save({"conanfile.py": conanfile,
                      "layout/win": layout_repo.format("layout/win"),
                      "layout/linux": layout_repo.format("layout/linux")})
         client.run("editable add . mytool/0.1@user/testing")
-        client2 = TestClient(client.base_folder)
+        client2 = TestClient(client.cache_folder)
         consumer = textwrap.dedent("""
             [requires]
             mytool/0.1@user/testing
@@ -162,7 +162,7 @@ class LayoutTest(unittest.TestCase):
 
         client.save({"conanfile.py": conanfile})
         client.run("editable add . mytool/0.1@user/testing")
-        client2 = TestClient(client.base_folder)
+        client2 = TestClient(client.cache_folder)
         consumer = textwrap.dedent("""
             [requires]
             mytool/0.1@user/testing
@@ -188,7 +188,7 @@ class LayoutTest(unittest.TestCase):
 
         client.save({"conanfile.py": conanfile})
         client.run("editable add . mytool/0.1@user/testing")
-        client2 = TestClient(client.base_folder)
+        client2 = TestClient(client.cache_folder)
         consumer = textwrap.dedent("""
             [requires]
             mytool/0.1@user/testing
@@ -212,7 +212,7 @@ class LayoutTest(unittest.TestCase):
         client.save({"conanfile.py": conanfile,
                      "layout": layout_repo})
         client.run("editable add . mytool/0.1@user/testing -l=layout")
-        client2 = TestClient(client.base_folder)
+        client2 = TestClient(client.cache_folder)
         consumer = textwrap.dedent("""
             [requires]
             mytool/0.1@user/testing
@@ -250,7 +250,7 @@ class LayoutTest(unittest.TestCase):
         save(layout_path, layoutabs)
         client.save({"conanfile.py": conanfile})
         client.run('editable add . mytool/0.1@user/testing -l="%s"' % layout_path)
-        client2 = TestClient(client.base_folder)
+        client2 = TestClient(client.cache_folder)
         consumer = textwrap.dedent("""
             [requires]
             mytool/0.1@user/testing

--- a/conans/test/functional/editable/transitive_editable_test.py
+++ b/conans/test/functional/editable/transitive_editable_test.py
@@ -17,7 +17,7 @@ class TransitiveEditableTest(unittest.TestCase):
         client.save({"conanfile.py": str(conanfileC)})
         client.run("editable add . LibC/0.1@user/testing")
 
-        client2 = TestClient(client.base_folder)
+        client2 = TestClient(client.cache_folder)
         conanfileB = TestConanFile("LibB", "0.1", requires=["LibC/0.1@user/testing"])
 
         client2.save({"conanfile.py": str(conanfileB)})

--- a/conans/test/functional/graph/full_revision_mode_test.py
+++ b/conans/test/functional/graph/full_revision_mode_test.py
@@ -22,12 +22,12 @@ class FullRevisionModeTest(unittest.TestCase):
         clienta.save({"conanfile.py": conanfilea})
         clienta.run("create . liba/0.1@user/testing")
 
-        clientb = TestClient(base_folder=clienta.base_folder)
+        clientb = TestClient(cache_folder=clienta.cache_folder)
         clientb.save({"conanfile.py": str(TestConanFile("libb", "0.1",
                                                         requires=["liba/0.1@user/testing"]))})
         clientb.run("create . user/testing")
 
-        clientc = TestClient(base_folder=clienta.base_folder)
+        clientc = TestClient(cache_folder=clienta.cache_folder)
         clientc.save({"conanfile.py": str(TestConanFile("libc", "0.1",
                                                         requires=["libb/0.1@user/testing"]))})
         clientc.run("install . user/testing")

--- a/conans/test/functional/graph_lock/graph_lock_ci_test.py
+++ b/conans/test/functional/graph_lock/graph_lock_ci_test.py
@@ -75,7 +75,7 @@ class GraphLockCITest(unittest.TestCase):
                       lock_file)
 
         # Do a change in B
-        clientb = TestClient(base_folder=client.base_folder, servers={"default": test_server})
+        clientb = TestClient(cache_folder=client.cache_folder, servers={"default": test_server})
         clientb.run("config set general.revisions_enabled=True")
         clientb.save({"conanfile.py": conanfile.format(requires='requires="PkgA/0.1@user/channel"'),
                      "myfile.txt": "ByeB World!!",
@@ -106,7 +106,7 @@ class GraphLockCITest(unittest.TestCase):
         while to_build:
             for _, pkg_ref in to_build[0]:
                 pkg_ref = PackageReference.loads(pkg_ref)
-                client_aux = TestClient(base_folder=client.base_folder,
+                client_aux = TestClient(cache_folder=client.cache_folder,
                                         servers={"default": test_server})
                 client_aux.run("config set general.revisions_enabled=True")
                 client_aux.save({LOCKFILE: lock_fileaux})
@@ -204,7 +204,7 @@ class GraphLockCITest(unittest.TestCase):
                       lock_file)
 
         # Do a change in B
-        clientb = TestClient(base_folder=client.base_folder, servers={"default": test_server})
+        clientb = TestClient(cache_folder=client.cache_folder, servers={"default": test_server})
         clientb.run("config set general.revisions_enabled=True")
         clientb.run("config set general.default_package_id_mode=package_revision_mode")
         clientb.save({"conanfile.py": conanfile.format(requires='requires="PkgA/0.1@user/channel"'),
@@ -236,7 +236,7 @@ class GraphLockCITest(unittest.TestCase):
         while to_build:
             for _, pkg_ref in to_build[0]:
                 pkg_ref = PackageReference.loads(pkg_ref)
-                client_aux = TestClient(base_folder=client.base_folder,
+                client_aux = TestClient(cache_folder=client.cache_folder,
                                         servers={"default": test_server})
                 client_aux.run("config set general.revisions_enabled=True")
                 client_aux.save({LOCKFILE: lock_fileaux})
@@ -318,7 +318,7 @@ class GraphLockCITest(unittest.TestCase):
         self.assertIn("PkgD/0.1@user/channel", lock_file)
 
         # Do a change in B
-        clientb = TestClient(base_folder=client.base_folder)
+        clientb = TestClient(cache_folder=client.cache_folder)
         clientb.run("config set general.default_package_id_mode=full_package_mode")
         clientb.save({"conanfile.py": conanfile.format(requires='requires="PkgA/[*]@user/channel"'),
                      "myfile.txt": "ByeB World!!",
@@ -341,7 +341,7 @@ class GraphLockCITest(unittest.TestCase):
         while to_build:
             for _, pkg_ref in to_build[0]:
                 pkg_ref = PackageReference.loads(pkg_ref)
-                client_aux = TestClient(base_folder=client.base_folder)
+                client_aux = TestClient(cache_folder=client.cache_folder)
                 client_aux.run("config set general.default_package_id_mode=full_package_mode")
                 client_aux.save({LOCKFILE: lock_fileaux})
                 client_aux.run("graph clean-modified .")
@@ -420,7 +420,7 @@ class GraphLockCITest(unittest.TestCase):
         self.assertIn("PkgD/0.1@user/channel", lock_file)
 
         # Do a change in A
-        clientb = TestClient(base_folder=client.base_folder)
+        clientb = TestClient(cache_folder=client.cache_folder)
         clientb.run("config set general.default_package_id_mode=full_package_mode")
         clientb.save({"conanfile.py": conanfile.format(requires=''),
                      "myfile.txt": "ByeA World!!",
@@ -443,7 +443,7 @@ class GraphLockCITest(unittest.TestCase):
         while to_build:
             _, pkg_ref = to_build[0].pop(0)
             pkg_ref = PackageReference.loads(pkg_ref)
-            client_aux = TestClient(base_folder=client.base_folder)
+            client_aux = TestClient(cache_folder=client.cache_folder)
             client_aux.run("config set general.default_package_id_mode=full_package_mode")
             client_aux.save({LOCKFILE: lock_fileaux})
             client_aux.run("graph clean-modified .")
@@ -509,7 +509,7 @@ class GraphLockCITest(unittest.TestCase):
         client.run("graph lock PkgD/0.1@user/channel -pr=myprofile")
         lock_file = load(os.path.join(client.current_folder, LOCKFILE))
 
-        client2 = TestClient(base_folder=client.base_folder)
+        client2 = TestClient(cache_folder=client.cache_folder)
         client2.save({"conanfile.py": conanfile.format(requires=""), LOCKFILE: lock_file})
         client2.run("create . PkgA/0.1@user/channel --lockfile")
         self.assertIn("PkgA/0.1@user/channel: BUILDING WITH OPTION: 5!!", client2.out)

--- a/conans/test/functional/old/conanfile_extend_test.py
+++ b/conans/test/functional/old/conanfile_extend_test.py
@@ -34,7 +34,7 @@ class ConanOtherLib(ConanFile):
         client.save(files)
         client.run("export . user/channel")
 
-        self.base_folder = client.base_folder
+        self.cache_folder = client.cache_folder
 
     def test_base(self):
 
@@ -70,7 +70,7 @@ class DevConanFile(HelloConan2):
                  "conanfile_dev.py": extension}
 
         # Do not adjust cpu_count, it is reusing a cache
-        client = TestClient(self.base_folder, cpu_count=False)
+        client = TestClient(self.cache_folder, cpu_count=False)
         client.save(files)
         client.run("install . --build")
         conaninfo = load(os.path.join(client.current_folder, "conaninfo.txt"))
@@ -129,7 +129,7 @@ class ConanFileToolsTest(ConanBase):
         files = {"base_conan.py": base,
                  "conanfile.py": extension}
         # Do not adjust cpu_count, it is reusing a cache
-        client = TestClient(self.base_folder, cpu_count=False)
+        client = TestClient(self.cache_folder, cpu_count=False)
 
         client.save(files)
         client.run("create . conan/testing -o test:test_option=3 --build")
@@ -158,7 +158,7 @@ otherlib:otherlib_option = 1
                  "conanfile_dev.txt": extension}
 
         # Do not adjust cpu_count, it is reusing a cache
-        client = TestClient(self.base_folder, cpu_count=False)
+        client = TestClient(self.cache_folder, cpu_count=False)
         client.save(files)
         client.run("install . --build")
         conaninfo = load(os.path.join(client.current_folder, "conaninfo.txt"))

--- a/conans/test/functional/old/test_migrations.py
+++ b/conans/test/functional/old/test_migrations.py
@@ -152,7 +152,7 @@ the old general
             save(old_conf_path, "\n[general]\n[plugins]    # CONAN_PLUGINS\nattribute_checker")
             save(old_attribute_checker_plugin, "")
             # Do not adjust cpu_count, it is reusing a cache
-            cache = TestClient(base_folder=old_user_home, cpu_count=False).cache
+            cache = TestClient(cache_folder=old_user_home, cpu_count=False).cache
             assert old_conan_folder == cache.cache_folder
             return old_user_home, old_conan_folder, old_conf_path, \
                 old_attribute_checker_plugin, cache

--- a/conans/test/functional/old/test_migrations.py
+++ b/conans/test/functional/old/test_migrations.py
@@ -55,7 +55,7 @@ class TestMigrations(unittest.TestCase):
         metadata["recipe"]["revision"] = "Other"
         save(layout2.package_metadata(), json.dumps(metadata))
 
-        version_file = os.path.join(client.cache.cache_folder, CONAN_VERSION)
+        version_file = os.path.join(client.cache_folder, CONAN_VERSION)
         save(version_file, "1.14.1")
         client.run("search")  # This will fire a migration
 
@@ -73,7 +73,7 @@ class TestMigrations(unittest.TestCase):
     def test_migrate_config_install(self):
         client = TestClient()
         client.run('config set general.config_install="url, http:/fake.url, None, None"')
-        version_file = os.path.join(client.cache.cache_folder, CONAN_VERSION)
+        version_file = os.path.join(client.cache_folder, CONAN_VERSION)
         save(version_file, "1.12.0")
         client.run("search")
         self.assertEqual(load(version_file), __version__)

--- a/conans/test/functional/scm/test_local_modified.py
+++ b/conans/test/functional/scm/test_local_modified.py
@@ -48,7 +48,7 @@ class SCMFolderObsoleteTest(unittest.TestCase):
 
     def test_install_workflow(self):
         """ Using the install command, it won't be taken into account """
-        t2 = TestClient(base_folder=self.t.base_folder)
+        t2 = TestClient(cache_folder=self.t.cache_folder)
         t2.save({'conanfile.txt': "[requires]\n{}".format(self.reference)})
         ref = ConanFileReference.loads(self.reference)
         t2.run("install . --build={}".format(ref.name))

--- a/conans/test/integration/manifest_validation_test.py
+++ b/conans/test/integration/manifest_validation_test.py
@@ -157,7 +157,7 @@ class ConanFileTest(ConanFile):
     version = "0.1"
 """
         # Do not adjust cpu_count, it is reusing a cache
-        client = TestClient(base_folder=self.client.base_folder, cpu_count=False)
+        client = TestClient(cache_folder=self.client.cache_folder, cpu_count=False)
         client.save({CONANFILE: conanfile})
         client.run("export . lasote/stable")
 

--- a/conans/test/integration/run_envronment_test.py
+++ b/conans/test/integration/run_envronment_test.py
@@ -96,7 +96,7 @@ class Pkg(ConanFile):
 
         # MAKE SURE WE USE ANOTHER CLIENT, with another USER HOME PATH
         client2 = TestClient(servers=servers, users={"default": [("lasote", "mypass")]})
-        self.assertNotEqual(client2.base_folder, client.base_folder)
+        self.assertNotEqual(client2.cache_folder, client.cache_folder)
         reuse = '''from conans import ConanFile
 class HelloConan(ConanFile):
     requires = "Pkg/0.1@lasote/testing"

--- a/conans/test/unittests/model/other_settings_test.py
+++ b/conans/test/unittests/model/other_settings_test.py
@@ -190,7 +190,7 @@ class Test(ConanFile):
         client = TestClient()
         client.save({"conanfile.py": conanfile,
                      "test_package/conanfile.py": test})
-        default_profile = os.path.join(client.base_folder, "profiles/default")
+        default_profile = os.path.join(client.cache_folder, "profiles/default")
         save(default_profile, "[settings]\ncompiler=gcc\ncompiler.version=6.3")
         client.run("create . user/channel", assert_error=True)
         self.assertIn("Invalid setting '6.3' is not a valid 'settings.compiler.version'",

--- a/conans/test/utils/tools.py
+++ b/conans/test/utils/tools.py
@@ -647,7 +647,7 @@ class TestClient(object):
     in command line
     """
 
-    def __init__(self, base_folder=None, current_folder=None, servers=None, users=None,
+    def __init__(self, cache_folder=None, current_folder=None, servers=None, users=None,
                  requester_class=None, runner=None, path_with_spaces=True,
                  revisions_enabled=None, cpu_count=1):
         """
@@ -662,8 +662,8 @@ class TestClient(object):
         if self.users is None:
             self.users = {"default": [(TESTING_REMOTE_PRIVATE_USER, TESTING_REMOTE_PRIVATE_PASS)]}
 
-        self.base_folder = base_folder or temp_folder(path_with_spaces)
-        self.cache = ClientCache(self.base_folder, TestBufferConanOutput())
+        self.cache_folder = cache_folder or temp_folder(path_with_spaces)
+        self.cache = ClientCache(self.cache_folder, TestBufferConanOutput())
         self.storage_folder = self.cache.store
 
         self.requester_class = requester_class
@@ -672,7 +672,7 @@ class TestClient(object):
         if revisions_enabled is None:
             revisions_enabled = get_env("TESTING_REVISIONS_ENABLED", False)
 
-        self.tune_conan_conf(base_folder, cpu_count, revisions_enabled)
+        self.tune_conan_conf(cache_folder, cpu_count, revisions_enabled)
 
         if servers and len(servers) > 1 and not isinstance(servers, OrderedDict):
             raise Exception("""Testing framework error: Servers should be an OrderedDict. e.g:
@@ -708,14 +708,14 @@ servers["r2"] = TestServer()
         self._set_revisions("0")
         assert not self.cache.config.revisions_enabled
 
-    def tune_conan_conf(self, base_folder, cpu_count, revisions_enabled):
+    def tune_conan_conf(self, cache_folder, cpu_count, revisions_enabled):
         # Create the default
         self.cache.config
 
         if cpu_count:
             replace_in_file(self.cache.conan_conf_path,
                             "# cpu_count = 1", "cpu_count = %s" % cpu_count,
-                            output=TestBufferConanOutput(), strict=not bool(base_folder))
+                            output=TestBufferConanOutput(), strict=not bool(cache_folder))
 
         current_conf = load(self.cache.conan_conf_path)
         if "revisions_enabled" in current_conf:  # Invalidate any previous value to be sure
@@ -793,7 +793,7 @@ servers["r2"] = TestServer()
         # Migration system
         output = TestBufferConanOutput()
         self.user_io = user_io or MockedUserIO(self.users, out=output)
-        self.cache = ClientCache(self.base_folder, output)
+        self.cache = ClientCache(self.cache_folder, output)
 
         # Migration system
         migrator = ClientMigrator(self.cache, Version(__version__), output)


### PR DESCRIPTION
Changelog: Omit
Docs: Omit

Pure refactor:
- Use self._out in Command instead of self._user_io.out
- Use ``cache_folder`` instead of ``base_folder`` in TestClient
- Use ``client.cache_folder`` access directly, instead of ``client.cache.cache_folder``

@tags: slow, svn
