### PR TITLE
Bugfix: Parallel download of files

### DIFF
--- a/conans/util/files.py
+++ b/conans/util/files.py
@@ -231,7 +231,11 @@ def mkdir(path):
     """Recursive mkdir, doesnt fail if already existing"""
     if os.path.exists(path):
         return
-    os.makedirs(path)
+    try:
+        os.makedirs(name=path)  # thread-safe
+    except OSError as e:
+        if e.errno != errno.EEXIST:
+            raise
 
 
 def path_exists(path, basedir):


### PR DESCRIPTION
Changelog: Bugfix: Parallel download of files
Docs: omit
@TAGS: slow, svn
@PYVERS: Macos@py27, Windows@py36, Linux@py27, py34
related: https://github.com/conan-io/conan/issues/5477

benchmark is here: https://github.com/SSE4/conan-speed-test
parallelised function: `_download_files_to_folder` 

basically, it's getting about 2 times faster for me. `tqdm` progress bars work for me for parallel downloads (on OSX).

sequential (overral):
```
conan create . bincrafters/testing -k  8.30s user 3.77s system 5% cpu 4:00.04 total
conan create . bincrafters/testing -k  8.26s user 3.74s system 4% cpu 4:11.55 total
```
parallel (overral):
```
conan create . bincrafters/testing -k  9.13s user 4.71s system 10% cpu 2:12.07 total
conan create . bincrafters/testing -k  9.34s user 4.96s system 11% cpu 2:00.64 total
```

sequential (detailed):
```
boost_random/1.69.0@bincrafters/stable: Not found in local cache, looking in remotes...
boost_random/1.69.0@bincrafters/stable: Trying with 'conan-center'...
boost_random/1.69.0@bincrafters/stable: Trying with 'bincrafters'...
Downloading conanmanifest.txt: 100%|##########| 103/103 [00:00<00:00, 97.5kB/s]
Downloading conanfile.py: 100%|##########| 496/496 [00:00<00:00, 382kB/s]
Downloading conan_export.tgz: 100%|##########| 758/758 [00:00<00:00, 571kB/s]
AAA download files took: 0.755559921265
Decompressing conan_export.tgz: 766B [00:00, 195kB/s]
boost_random/1.69.0@bincrafters/stable: Downloaded recipe revision 0
boost_base/1.69.0@bincrafters/stable: Not found in local cache, looking in remotes...
boost_base/1.69.0@bincrafters/stable: Trying with 'conan-center'...
boost_base/1.69.0@bincrafters/stable: Trying with 'bincrafters'...
Downloading conanmanifest.txt: 100%|##########| 103/103 [00:00<00:00, 80.8kB/s]
Downloading conanfile.py: 100%|##########| 10.1k/10.1k [00:00<00:00, 9.81MB/s]
Downloading conan_export.tgz: 100%|##########| 758/758 [00:00<00:00, 589kB/s]
AAA download files took: 0.62668299675
Decompressing conan_export.tgz: 766B [00:00, 201kB/s]
boost_base/1.69.0@bincrafters/stable: Downloaded recipe revision 0
boost_cycle_group_c/1.69.0@bincrafters/stable: Not found in local cache, looking in remotes...
boost_cycle_group_c/1.69.0@bincrafters/stable: Trying with 'conan-center'...
boost_cycle_group_c/1.69.0@bincrafters/stable: Trying with 'bincrafters'...
Downloading conanmanifest.txt: 100%|##########| 103/103 [00:00<00:00, 84.8kB/s]
Downloading conanfile.py: 100%|##########| 3.36k/3.36k [00:00<00:00, 3.29MB/s]
Downloading conan_export.tgz: 100%|##########| 758/758 [00:00<00:00, 650kB/s]
AAA download files took: 1.91298604012
Decompressing conan_export.tgz: 766B [00:00, 674kB/s]
boost_cycle_group_c/1.69.0@bincrafters/stable: Downloaded recipe revision 0
boost_algorithm/1.69.0@bincrafters/stable: Not found in local cache, looking in remotes...
boost_algorithm/1.69.0@bincrafters/stable: Trying with 'conan-center'...
boost_algorithm/1.69.0@bincrafters/stable: Trying with 'bincrafters'...
Downloading conanmanifest.txt: 100%|##########| 103/103 [00:00<00:00, 82.6kB/s]
Downloading conanfile.py: 100%|##########| 468/468 [00:00<00:00, 373kB/s]
Downloading conan_export.tgz: 100%|##########| 758/758 [00:00<00:00, 758kB/s]
AAA download files took: 0.639534950256
Decompressing conan_export.tgz: 766B [00:00, 707kB/s]
boost_algorithm/1.69.0@bincrafters/stable: Downloaded recipe revision 0
boost_cycle_group_a/1.69.0@bincrafters/stable: Not found in local cache, looking in remotes...
boost_cycle_group_a/1.69.0@bincrafters/stable: Trying with 'conan-center'...
boost_cycle_group_a/1.69.0@bincrafters/stable: Trying with 'bincrafters'...
Downloading conanmanifest.txt: 100%|##########| 103/103 [00:00<00:00, 91.6kB/s]
Downloading conanfile.py: 100%|##########| 1.13k/1.13k [00:00<00:00, 931kB/s]
Downloading conan_export.tgz: 100%|##########| 758/758 [00:00<00:00, 582kB/s]
AAA download files took: 0.628607988358
Decompressing conan_export.tgz: 766B [00:00, 765kB/s]
boost_cycle_group_a/1.69.0@bincrafters/stable: Downloaded recipe revision 0
boost_array/1.69.0@bincrafters/stable: Not found in local cache, looking in remotes...
boost_array/1.69.0@bincrafters/stable: Trying with 'conan-center'...
boost_array/1.69.0@bincrafters/stable: Trying with 'bincrafters'...
Downloading conanmanifest.txt: 100%|##########| 103/103 [00:00<00:00, 88.4kB/s]
Downloading conanfile.py: 100%|##########| 525/525 [00:00<00:00, 141kB/s]
Downloading conan_export.tgz: 100%|##########| 758/758 [00:00<00:00, 608kB/s]
AAA download files took: 0.628017187119
Decompressing conan_export.tgz: 766B [00:00, 758kB/s]
```
parallel (detailed):
```
boost_random/1.69.0@bincrafters/stable: Not found in local cache, looking in remotes...
boost_random/1.69.0@bincrafters/stable: Trying with 'conan-center'...
boost_random/1.69.0@bincrafters/stable: Trying with 'bincrafters'...
Downloading conanmanifest.txt: 100%|##########| 103/103 [00:00<00:00, 81.7kB/s]
Downloading conan_export.tgz: 100%|##########| 758/758 [00:00<00:00, 677kB/s]
Downloading conanfile.py: 100%|##########| 496/496 [00:00<00:00, 398kB/s]
AAA download files took: 0.747133016586
Decompressing conan_export.tgz: 766B [00:00, 200kB/s]
boost_random/1.69.0@bincrafters/stable: Downloaded recipe revision 0
boost_base/1.69.0@bincrafters/stable: Not found in local cache, looking in remotes...
boost_base/1.69.0@bincrafters/stable: Trying with 'conan-center'...
boost_base/1.69.0@bincrafters/stable: Trying with 'bincrafters'...
Downloading conanmanifest.txt: 100%|##########| 103/103 [00:00<00:00, 132kB/s]
Downloading conan_export.tgz: 100%|##########| 758/758 [00:00<00:00, 857kB/s]
Downloading conanfile.py: 100%|##########| 10.1k/10.1k [00:00<00:00, 8.31MB/s]
AAA download files took: 0.325643062592
Decompressing conan_export.tgz: 766B [00:00, 669kB/s]
boost_base/1.69.0@bincrafters/stable: Downloaded recipe revision 0
boost_cycle_group_c/1.69.0@bincrafters/stable: Not found in local cache, looking in remotes...
boost_cycle_group_c/1.69.0@bincrafters/stable: Trying with 'conan-center'...
boost_cycle_group_c/1.69.0@bincrafters/stable: Trying with 'bincrafters'...
Downloading conan_export.tgz: 100%|##########| 758/758 [00:00<00:00, 199kB/s]
Downloading conanfile.py: 100%|##########| 3.36k/3.36k [00:00<00:00, 643kB/s]s]
AAA download files took: 0.212547063828
Decompressing conan_export.tgz: 766B [00:00, 608kB/s]
boost_cycle_group_c/1.69.0@bincrafters/stable: Downloaded recipe revision 0
boost_algorithm/1.69.0@bincrafters/stable: Not found in local cache, looking in remotes...
boost_algorithm/1.69.0@bincrafters/stable: Trying with 'conan-center'...
boost_algorithm/1.69.0@bincrafters/stable: Trying with 'bincrafters'...
Downloading conan_export.tgz: 100%|##########| 758/758 [00:00<00:00, 1.10MB/s]
Downloading conanmanifest.txt: 100%|##########| 103/103 [00:00<00:00, 119kB/s]
Downloading conanfile.py: 100%|##########| 468/468 [00:00<00:00, 361kB/s]
AAA download files took: 0.218121051788
Decompressing conan_export.tgz: 766B [00:00, 569kB/s]
boost_algorithm/1.69.0@bincrafters/stable: Downloaded recipe revision 0
boost_cycle_group_a/1.69.0@bincrafters/stable: Not found in local cache, looking in remotes...
boost_cycle_group_a/1.69.0@bincrafters/stable: Trying with 'conan-center'...
boost_cycle_group_a/1.69.0@bincrafters/stable: Trying with 'bincrafters'...
Downloading conanfile.py: 100%|##########| 1.13k/1.13k [00:00<00:00, 1.00MB/s]
Downloading conan_export.tgz: 100%|##########| 758/758 [00:00<00:00, 209kB/s]
Downloading conanmanifest.txt: 100%|##########| 103/103 [00:00<00:00, 79.6kB/s]
AAA download files took: 0.215751171112
Decompressing conan_export.tgz: 766B [00:00, 613kB/s]
boost_cycle_group_a/1.69.0@bincrafters/stable: Downloaded recipe revision 0
boost_array/1.69.0@bincrafters/stable: Not found in local cache, looking in remotes...
boost_array/1.69.0@bincrafters/stable: Trying with 'conan-center'...
boost_array/1.69.0@bincrafters/stable: Trying with 'bincrafters'...
Downloading conanfile.py: 100%|##########| 525/525 [00:00<00:00, 415kB/s]
Downloading conan_export.tgz: 100%|##########| 758/758 [00:00<00:00, 594kB/s]
Downloading conanmanifest.txt: 100%|##########| 103/103 [00:00<00:00, 79.6kB/s]
AAA download files took: 0.217633008957
Decompressing conan_export.tgz: 766B [00:00, 654kB/s]
```

- [x] Refer to the issue that supports this Pull Request.
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 

<sup>**Note:** By default this PR will skip the slower tests and will use a limited set of python versions. Check [here](https://github.com/conan-io/conan/blob/develop/.github/PR_INCREASE_TESTING.md) how to increase the testing level by writing some tags in the current PR body text.</sup>
