### PR TITLE
Better ref representation

### DIFF
--- a/conans/build_info/conan_build_info.py
+++ b/conans/build_info/conan_build_info.py
@@ -17,7 +17,8 @@ def _extract_uploads_from_conan_trace(path):
                 doc = json.loads(line)
                 if doc["_action"] in ("UPLOADED_RECIPE", "UPLOADED_PACKAGE"):
                     module_type = "recipe" if doc["_action"] == "UPLOADED_RECIPE" else "package"
-                    modules[doc["_id"]] = {"remote": doc["remote"], "files": [], "type": module_type}
+                    modules[doc["_id"]] = {"remote": doc["remote"],
+                                           "files": [], "type": module_type}
                     modules[doc["_id"]]["files"].extend(doc["files"])
     except ValueError as exc:
         raise Exception("INVALID TRACE FILE! %s" % exc)
@@ -68,8 +69,9 @@ def _get_upload_modules_with_deps(uploaded_files, downloaded_files):
                 conan_info = conan_infos[0]["path"]
                 info = ConanInfo.loads(load(conan_info))
                 for pref in info.full_requires:
-                    deps[str(ref_or_pref.ref)].add(str(pref.ref))
-                    deps[str(ref_or_pref)].add(str(pref))
+                    clear_pref = pref.copy_clear_revs()
+                    deps[repr(ref_or_pref.ref.copy_clear_rev())].add(repr(clear_pref.ref))
+                    deps[repr(ref_or_pref.copy_clear_revs())].add(repr(clear_pref))
 
     # Add the modules
     for module_id, mod_doc in uploaded_files.items():

--- a/conans/client/cmd/download.py
+++ b/conans/client/cmd/download.py
@@ -28,7 +28,7 @@ def download(ref, package_ids, remote, recipe, remote_manager,
 
     if not recipe:  # Not only the recipe
         if not package_ids:  # User didn't specify a specific package binary
-            output.info("Getting the complete package list from '%s'..." % ref.full_repr())
+            output.info("Getting the complete package list from '%s'..." % ref.full_str())
             packages_props = remote_manager.search_packages(remote, ref, None)
             package_ids = list(packages_props.keys())
             if not package_ids:

--- a/conans/client/cmd/export.py
+++ b/conans/client/cmd/export.py
@@ -26,7 +26,7 @@ from conans import ConanFile
 class AliasConanfile(ConanFile):
     alias = "%s"
     revision_mode = "%s"
-""" % (target_ref.full_repr(), revision_mode)
+""" % (target_ref.full_str(), revision_mode)
 
     save(package_layout.conanfile(), conanfile)
     digest = FileTreeManifest.create(package_layout.export())

--- a/conans/client/command.py
+++ b/conans/client/command.py
@@ -388,7 +388,7 @@ class Command(object):
                                " Use a full reference instead: "
                                "`conan download [...] {}:{}`".format(reference, packages_list[0]))
         else:
-            reference = pref.ref.full_repr()
+            reference = repr(pref.ref)
             packages_list = [pref.id]
             if args.package:
                 raise ConanException("Use a full package reference (preferred) or the `--package`"
@@ -1045,7 +1045,7 @@ class Command(object):
             if args.all and packages_list:
                 raise ConanException("Cannot specify both --all and --package")
         else:
-            reference = pref.ref.full_repr()
+            reference = repr(pref.ref)
             packages_list = [pref.id]
             if args.package:
                 raise ConanException("Use a full package reference (preferred) or the `--package`"
@@ -1189,8 +1189,7 @@ class Command(object):
                 except (TypeError, ConanException, AttributeError):
                     pass
                 else:
-                    info = self._conan.get_package_revisions(pref.full_repr(),
-                                                             remote_name=args.remote)
+                    info = self._conan.get_package_revisions(repr(pref), remote_name=args.remote)
 
                 if not info:
                     if not ref:
@@ -1199,13 +1198,13 @@ class Command(object):
                               "recipe revision (e.g {ref}#3453453453:d50a0d523d98c15bb147b18f" \
                               "a7d203887c38be8b)".format(ref=_REFERENCE_EXAMPLE)
                         raise ConanException(msg)
-                    info = self._conan.get_recipe_revisions(ref.full_repr(),
+                    info = self._conan.get_recipe_revisions(repr(ref),
                                                             remote_name=args.remote)
                 self._outputer.print_revisions(ref, info, remote_name=args.remote)
                 return
 
             if ref:
-                info = self._conan.search_packages(ref.full_repr(), query=args.query,
+                info = self._conan.search_packages(repr(ref), query=args.query,
                                                    remote_name=args.remote,
                                                    outdated=args.outdated)
                 # search is done for one reference
@@ -1289,7 +1288,7 @@ class Command(object):
             if args.query and package_id:
                 raise ConanException("'--query' argument cannot be used together with '--package'")
         else:
-            reference = pref.ref.full_repr()
+            reference = repr(pref.ref)
             package_id = pref.id
 
             if args.package:
@@ -1552,7 +1551,7 @@ class Command(object):
                                " Use a full reference instead: "
                                "`conan get [...] {}:{}`".format(reference, package_id))
         else:
-            reference = pref.ref.full_repr()
+            reference = repr(pref.ref)
             package_id = pref.id
             if args.package:
                 raise ConanException("Use a full package reference (preferred) or the `--package`"

--- a/conans/client/conan_api.py
+++ b/conans/client/conan_api.py
@@ -267,7 +267,7 @@ class ConanAPIV1(object):
             conanfile_class = self._loader.load_class(conanfile_path)
             conanfile_class.name = ref.name
             conanfile_class.version = ref.version
-        conanfile = conanfile_class(self._user_io.out, None, str(ref))
+        conanfile = conanfile_class(self._user_io.out, None, repr(ref))
 
         result = OrderedDict()
         if not attributes:
@@ -961,7 +961,7 @@ class ConanAPIV1(object):
         tmp = self._cache.registry.prefs_list
         for pref, remote in tmp.items():
             if pref.ref == ref and remote:
-                ret[pref.full_repr()] = remote
+                ret[repr(pref)] = remote
         return ret
 
     @api_method
@@ -1008,7 +1008,7 @@ class ConanAPIV1(object):
     @api_method
     def remove_system_reqs_by_pattern(self, pattern):
         for ref in search_recipes(self._cache, pattern=pattern):
-            self.remove_system_reqs(ref.full_repr())
+            self.remove_system_reqs(repr(ref))
 
     @api_method
     def remove_locks(self):
@@ -1073,7 +1073,7 @@ class ConanAPIV1(object):
         alias_conanfile_path = self._cache.package_layout(ref).conanfile()
         if os.path.exists(alias_conanfile_path):
             conanfile_class = self._loader.load_class(alias_conanfile_path)
-            conanfile = conanfile_class(self._user_io.out, None, str(ref))
+            conanfile = conanfile_class(self._user_io.out, None, repr(ref))
             if not getattr(conanfile, 'alias', None):
                 raise ConanException("Reference '{}' is already a package, remove it before "
                                      "creating and alias with the same name".format(ref))
@@ -1098,7 +1098,7 @@ class ConanAPIV1(object):
                                  " Enable this feature setting to '1' the environment variable"
                                  " 'CONAN_REVISIONS_ENABLED' or the config value"
                                  " 'general.revisions_enabled' in your conan.conf file")
-        ref = ConanFileReference.loads(str(reference))
+        ref = ConanFileReference.loads(repr(reference))
         if ref.revision:
             raise ConanException("Cannot list the revisions of a specific recipe revision")
 
@@ -1137,7 +1137,7 @@ class ConanAPIV1(object):
                                  " Enable this feature setting to '1' the environment variable"
                                  " 'CONAN_REVISIONS_ENABLED' or the config value"
                                  " 'general.revisions_enabled' in your conan.conf file")
-        pref = PackageReference.loads(str(reference), validate=True)
+        pref = PackageReference.loads(repr(reference), validate=True)
         if not pref.ref.revision:
             raise ConanException("Specify a recipe reference with revision")
         if pref.revision:

--- a/conans/client/conan_api.py
+++ b/conans/client/conan_api.py
@@ -1098,7 +1098,7 @@ class ConanAPIV1(object):
                                  " Enable this feature setting to '1' the environment variable"
                                  " 'CONAN_REVISIONS_ENABLED' or the config value"
                                  " 'general.revisions_enabled' in your conan.conf file")
-        ref = ConanFileReference.loads(repr(reference))
+        ref = ConanFileReference.loads(reference)
         if ref.revision:
             raise ConanException("Cannot list the revisions of a specific recipe revision")
 
@@ -1137,7 +1137,7 @@ class ConanAPIV1(object):
                                  " Enable this feature setting to '1' the environment variable"
                                  " 'CONAN_REVISIONS_ENABLED' or the config value"
                                  " 'general.revisions_enabled' in your conan.conf file")
-        pref = PackageReference.loads(repr(reference), validate=True)
+        pref = PackageReference.loads(reference, validate=True)
         if not pref.ref.revision:
             raise ConanException("Specify a recipe reference with revision")
         if pref.revision:

--- a/conans/client/conan_command_output.py
+++ b/conans/client/conan_command_output.py
@@ -37,19 +37,20 @@ class CommandOutputer(object):
     def remote_ref_list(self, refs):
         for reference, remote_name in refs.items():
             ref = ConanFileReference.loads(reference)
-            self._output.info("%s: %s" % (ref.full_repr(), remote_name))
+            self._output.info("%s: %s" % (ref.full_str(), remote_name))
 
     def remote_pref_list(self, package_references):
         for package_reference, remote_name in package_references.items():
             pref = PackageReference.loads(package_reference)
-            self._output.info("%s: %s" % (pref.full_repr(), remote_name))
+            self._output.info("%s: %s" % (pref.full_str(), remote_name))
 
     def build_order(self, info):
-        msg = ", ".join(str(s) for s in info)
+        groups = [[ref.copy_clear_rev() for ref in group] for group in info]
+        msg = ", ".join(str(s) for s in groups)
         self._output.info(msg)
 
     def json_build_order(self, info, json_output, cwd):
-        data = {"groups": [[str(ref) for ref in group] for group in info]}
+        data = {"groups": [[repr(ref.copy_clear_rev()) for ref in group] for group in info]}
         json_str = json.dumps(data)
         if json_output is True:  # To the output
             self._output.write(json_str)
@@ -120,7 +121,7 @@ class CommandOutputer(object):
             if node.recipe == RECIPE_CONSUMER:
                 ref = str(conanfile)
             else:
-                item_data["revision"] = str(ref.revision)
+                item_data["revision"] = ref.revision
 
             item_data["reference"] = str(ref)
             item_data["is_ref"] = isinstance(ref, ConanFileReference)
@@ -189,10 +190,11 @@ class CommandOutputer(object):
             build_requires = [d for d in depends if d.build_require]
 
             if requires:
-                item_data["requires"] = [repr(d.ref) for d in requires]
+                item_data["requires"] = [repr(d.ref.copy_clear_rev()) for d in requires]
 
             if build_requires:
-                item_data["build_requires"] = [repr(d.ref) for d in build_requires]
+                item_data["build_requires"] = [repr(d.ref.copy_clear_rev())
+                                               for d in build_requires]
 
             ret.append(item_data)
 

--- a/conans/client/graph/build_mode.py
+++ b/conans/client/graph/build_mode.py
@@ -60,7 +60,7 @@ class BuildMode(object):
         # Patterns to match, if package matches pattern, build is forced
         for pattern in self.patterns:
             is_matching_name = fnmatch.fnmatchcase(ref.name, pattern)
-            is_matching_ref = fnmatch.fnmatchcase(repr(ref), pattern)
+            is_matching_ref = fnmatch.fnmatchcase(repr(ref.copy_clear_rev()), pattern)
             if is_matching_name or is_matching_ref:
                 try:
                     self._unused_patterns.remove(pattern)

--- a/conans/client/graph/graph.py
+++ b/conans/client/graph/graph.py
@@ -284,7 +284,7 @@ class DepsGraph(object):
             new_level = []
             for n in level:
                 if n.binary == BINARY_BUILD and n.pref not in total_prefs:
-                    new_level.append((n.id, n.pref.full_repr()))
+                    new_level.append((n.id, repr(n.pref)))
                     total_prefs.add(n.pref)
             if new_level:
                 result.append(new_level)

--- a/conans/client/graph/printer.py
+++ b/conans/client/graph/printer.py
@@ -39,14 +39,14 @@ def print_graph(deps_graph, out):
             else:
                 from_text = ("from local cache" if not node.remote
                              else "from '%s'" % node.remote.name)
-            out.writeln("    %s %s - %s" % (repr(node.ref), from_text, node.recipe),
+            out.writeln("    %s %s - %s" % (str(node.ref), from_text, node.recipe),
                         Color.BRIGHT_CYAN)
 
     _recipes(requires)
     if python_requires:
         out.writeln("Python requires", Color.BRIGHT_YELLOW)
         for p in python_requires:
-            out.writeln("    %s" % repr(p), Color.BRIGHT_CYAN)
+            out.writeln("    %s" % repr(p.copy_clear_rev()), Color.BRIGHT_CYAN)
     out.writeln("Packages", Color.BRIGHT_YELLOW)
 
     def _packages(nodes):
@@ -58,7 +58,7 @@ def print_graph(deps_graph, out):
                 binary.remove(BINARY_SKIP)
             assert len(binary) == 1
             binary = binary.pop()
-            out.writeln("    %s - %s" % (repr(package_id), binary), Color.BRIGHT_CYAN)
+            out.writeln("    %s - %s" % (str(package_id), binary), Color.BRIGHT_CYAN)
     _packages(requires)
 
     if build_requires:

--- a/conans/client/graph/proxy.py
+++ b/conans/client/graph/proxy.py
@@ -159,7 +159,7 @@ class ConanProxy(object):
             except NotFoundException:
                 pass
         else:
-            msg = "Unable to find '%s' in remotes" % ref.full_repr()
+            msg = "Unable to find '%s' in remotes" % ref.full_str()
             recorder.recipe_install_error(ref, INSTALL_ERROR_MISSING,
                                           msg, None)
             raise NotFoundException(msg)

--- a/conans/client/loader.py
+++ b/conans/client/loader.py
@@ -216,7 +216,7 @@ class ConanFileLoader(object):
         conanfile.settings = processed_profile._settings.copy_values()
 
         for reference in references:
-            conanfile.requires.add(reference.full_repr())  # Convert to string necessary
+            conanfile.requires.add(repr(reference))  # Convert to string necessary
         # Allows options without package namespace in conan install commands:
         #   conan install zlib/1.2.8@lasote/stable -o shared=True
         if scope_options:

--- a/conans/client/recorder/action_recorder.py
+++ b/conans/client/recorder/action_recorder.py
@@ -152,7 +152,7 @@ class ActionRecorder(object):
             action_types = [action.type for action in the_actions]
             time = the_actions[0].time
             if revisions_enabled and isinstance(the_ref, ConanFileReference):
-                the_id = the_actions[0].full_ref.full_repr()
+                the_id = repr(the_actions[0].full_ref)
             else:
                 the_id = str(the_ref)
 

--- a/conans/client/recorder/search_recorder.py
+++ b/conans/client/recorder/search_recorder.py
@@ -29,11 +29,11 @@ class SearchRecorder(object):
         recipe.with_packages = with_packages
         if remote_name not in self._info:
             self._info[remote_name] = OrderedDict()
-        self._info[remote_name][ref.full_repr()] = {"recipe": recipe, "packages": []}
+        self._info[remote_name][repr(ref)] = {"recipe": recipe, "packages": []}
 
     def add_package(self, remote_name, ref, package_id, options, settings, requires, outdated):
         sp = _SearchPackage(package_id, options, settings, requires, outdated)
-        self._info[remote_name][ref.full_repr()]["packages"].append(sp)
+        self._info[remote_name][repr(ref)]["packages"].append(sp)
 
     def get_info(self):
         info = {"error": self.error, self.keyword: []}

--- a/conans/client/recorder/upload_recoder.py
+++ b/conans/client/recorder/upload_recoder.py
@@ -38,11 +38,11 @@ class UploadRecorder(object):
 
     def add_recipe(self, ref, remote_name, remote_url):
 
-        self._info[str(ref)] = {"recipe": _UploadElement(ref, remote_name, remote_url),
+        self._info[repr(ref.copy_clear_rev())] = {"recipe": _UploadElement(ref, remote_name, remote_url),
                                 "packages": []}
 
     def add_package(self, pref, remote_name, remote_url):
-        self._info[str(pref.ref)]["packages"].append(_UploadElement(pref, remote_name, remote_url))
+        self._info[repr(pref.ref.copy_clear_rev())]["packages"].append(_UploadElement(pref, remote_name, remote_url))
 
     def get_info(self):
         info = {"error": self.error, "uploaded": []}

--- a/conans/client/remover.py
+++ b/conans/client/remover.py
@@ -211,7 +211,7 @@ class ConanRemover(object):
                     package_ids = list(packages.keys())
                 if not package_ids:
                     self._user_io.out.warn("No matching packages to remove for %s"
-                                           % ref.full_repr())
+                                           % ref.full_str())
                     continue
 
             if self._ask_permission(ref, src, build_ids, package_ids, force):

--- a/conans/client/rest/client_routes.py
+++ b/conans/client/rest/client_routes.py
@@ -33,7 +33,7 @@ class ClientCommonRouter(object):
         query = ''
         if pattern:
             if isinstance(pattern, ConanFileReference):
-                pattern = pattern.full_repr()
+                pattern = repr(pattern)
             params = {"q": pattern}
             if not ignorecase:
                 params["ignorecase"] = "False"

--- a/conans/client/rest/rest_client_v1.py
+++ b/conans/client/rest/rest_client_v1.py
@@ -89,7 +89,7 @@ class RestV1Methods(RestCommonMethods):
             return FileTreeManifest.loads(decode_text(content))
         except Exception as e:
             msg = "Error retrieving manifest file for package " \
-                  "'{}' from remote ({}): '{}'".format(pref.full_repr(), self.remote_url, e)
+                  "'{}' from remote ({}): '{}'".format(repr(pref), self.remote_url, e)
             logger.error(msg)
             logger.error(traceback.format_exc())
             raise ConanException(msg)

--- a/conans/client/rest/rest_client_v2.py
+++ b/conans/client/rest/rest_client_v2.py
@@ -66,7 +66,7 @@ class RestV2Methods(RestCommonMethods):
             return FileTreeManifest.loads(decode_text(content))
         except Exception as e:
             msg = "Error retrieving manifest file for package " \
-                  "'{}' from remote ({}): '{}'".format(pref.full_repr(), self.remote_url, e)
+                  "'{}' from remote ({}): '{}'".format(repr(pref), self.remote_url, e)
             logger.error(msg)
             logger.error(traceback.format_exc())
             raise ConanException(msg)

--- a/conans/errors.py
+++ b/conans/errors.py
@@ -185,7 +185,7 @@ class RecipeNotFoundException(NotFoundException):
         super(RecipeNotFoundException, self).__init__(remote=remote)
 
     def __str__(self):
-        tmp = self.ref.full_repr() if self.print_rev else str(self.ref)
+        tmp = repr(self.ref) if self.print_rev else str(self.ref)
         return "Recipe not found: '{}'".format(tmp, self.remote_message())
 
 
@@ -201,7 +201,7 @@ class PackageNotFoundException(NotFoundException):
         super(PackageNotFoundException, self).__init__(remote=remote)
 
     def __str__(self):
-        tmp = self.pref.full_repr() if self.print_rev else str(self.pref)
+        tmp = self.pref.full_str() if self.print_rev else str(self.pref)
         return "Binary package not found: '{}'{}".format(tmp, self.remote_message())
 
 

--- a/conans/model/graph_lock.py
+++ b/conans/model/graph_lock.py
@@ -90,10 +90,10 @@ class GraphLockNode(object):
         that can be converted to json
         """
         result = {}
-        result["pref"] = self.pref.full_repr() if self.pref else None
+        result["pref"] = repr(self.pref) if self.pref else None
         result["options"] = self.options.dumps()
         if self.python_requires:
-            result["python_requires"] = [r.full_repr() for r in self.python_requires]
+            result["python_requires"] = [repr(r) for r in self.python_requires]
         if self.modified:
             result["modified"] = True
         if self.requires:
@@ -111,7 +111,7 @@ class GraphLock(object):
                     continue
                 requires = {}
                 for edge in node.dependencies:
-                    requires[edge.require.ref.full_repr()] = edge.dst.id
+                    requires[repr(edge.require.ref)] = edge.dst.id
                 python_reqs = getattr(node.conanfile, "python_requires", {})
                 python_reqs = [r.ref for _, r in python_reqs.items()] if python_reqs else None
                 graph_node = GraphLockNode(node.pref if node.ref else None, python_reqs,
@@ -212,12 +212,12 @@ class GraphLock(object):
                 if node.recipe == RECIPE_CONSUMER:
                     continue  # If the consumer node is not found, could be a test_package
                 raise
-            if lock_node.pref and lock_node.pref.full_repr() != node.pref.full_repr():
+            if lock_node.pref and repr(lock_node.pref) != repr(node.pref):
                 if node.binary == BINARY_BUILD or node.id in affected:
                     lock_node.pref = node.pref
                 else:
                     raise ConanException("Mistmatch between lock and graph:\nLock:  %s\nGraph: %s"
-                                         % (lock_node.pref.full_repr(), node.pref.full_repr()))
+                                         % (lock_node.pref.full_str(), node.pref.full_str()))
 
     def lock_node(self, node, requires):
         """ apply options and constraints on requirements of a node, given the information from
@@ -263,9 +263,9 @@ class GraphLock(object):
 
         # First search by ref (without RREV)
         ids = []
-        search_ref = str(ref)
+        search_ref = repr(ref)
         for id_, node in self._nodes.items():
-            if node.pref and str(node.pref.ref) == search_ref:
+            if node.pref and repr(node.pref.ref) == search_ref:
                 ids.append(id_)
         if ids:
             if len(ids) == 1:
@@ -282,7 +282,7 @@ class GraphLock(object):
                 return ids[0]
             raise ConanException("There are %s binaries with name %s" % (len(ids), ref.name))
 
-        raise ConanException("Couldn't find '%s' in graph-lock" % ref.full_repr())
+        raise ConanException("Couldn't find '%s' in graph-lock" % ref.full_str())
 
     def update_exported_ref(self, node_id, ref):
         """ when the recipe is exported, it will change its reference, typically the RREV, and

--- a/conans/model/ref.py
+++ b/conans/model/ref.py
@@ -115,10 +115,16 @@ class ConanFileReference(namedtuple("ConanFileReference", "name version user cha
         ref = ConanFileReference(name, version, user, channel, revision, validate=validate)
         return ref
 
-    def __repr__(self):
+    def __str__(self):
+        if not self.user and not self.channel:
+            return "%s/%s" % (self.name, self.version)
         return "%s/%s@%s/%s" % (self.name, self.version, self.user, self.channel)
 
-    def full_repr(self):
+    def __repr__(self):
+        str_rev = "#%s" % self.revision if self.revision else ""
+        return "%s/%s@%s/%s%s" % (self.name, self.version, self.user, self.channel, str_rev)
+
+    def full_str(self):
         str_rev = "#%s" % self.revision if self.revision else ""
         return "%s%s" % (str(self), str_rev)
 
@@ -161,11 +167,16 @@ class PackageReference(namedtuple("PackageReference", "ref id revision")):
         return PackageReference(ref, package_id, validate=validate)
 
     def __repr__(self):
+        str_rev = "#%s" % self.revision if self.revision else ""
+        tmp = "%s:%s%s" % (repr(self.ref), self.id, str_rev)
+        return tmp
+
+    def __str__(self):
         return "%s:%s" % (self.ref, self.id)
 
-    def full_repr(self):
+    def full_str(self):
         str_rev = "#%s" % self.revision if self.revision else ""
-        tmp = "%s:%s%s" % (self.ref.full_repr(), self.id, str_rev)
+        tmp = "%s:%s%s" % (self.ref.full_str(), self.id, str_rev)
         return tmp
 
     def copy_with_revs(self, revision, p_revision):

--- a/conans/server/rest/controller/v1/search.py
+++ b/conans/server/rest/controller/v1/search.py
@@ -21,7 +21,7 @@ class SearchController(object):
             if isinstance(ignore_case, str):
                 ignore_case = False if 'false' == ignore_case.lower() else True
             search_service = SearchService(app.authorizer, app.server_store, auth_user)
-            references = [str(ref) for ref in search_service.search(pattern, ignore_case)]
+            references = [repr(ref) for ref in search_service.search(pattern, ignore_case)]
             return {"results": references}
 
         @app.route(r.common_search_packages, method=["GET"])

--- a/conans/server/rest/controller/v2/search.py
+++ b/conans/server/rest/controller/v2/search.py
@@ -21,7 +21,7 @@ class SearchControllerV2(object):
             if isinstance(ignore_case, str):
                 ignore_case = False if 'false' == ignore_case.lower() else True
             search_service = SearchService(app.authorizer, app.server_store, auth_user)
-            references = [ref.full_repr() for ref in search_service.search(pattern, ignore_case)]
+            references = [repr(ref) for ref in search_service.search(pattern, ignore_case)]
             return {"results": references}
 
         @app.route(r.common_search_packages, method=["GET"])

--- a/conans/server/service/common/search.py
+++ b/conans/server/service/common/search.py
@@ -105,7 +105,7 @@ class SearchService(object):
             ret = set()
             for subdir in subdirs:
                 new_ref = ConanFileReference(*subdir.split("/"))
-                if _partial_match(b_pattern, new_ref.full_repr()):
+                if _partial_match(b_pattern, repr(new_ref)):
                     ret.add(new_ref.copy_clear_rev())
 
             return sorted(ret)

--- a/conans/server/store/server_store.py
+++ b/conans/server/store/server_store.py
@@ -261,7 +261,7 @@ class ServerStore(object):
         else:
             rev_list = RevisionList()
         if ref.revision is None:
-            raise ConanException("Invalid revision for: %s" % ref.full_repr())
+            raise ConanException("Invalid revision for: %s" % ref.full_str())
         rev_list.add_revision(ref.revision)
         self._storage_adapter.write_file(rev_file_path, rev_list.dumps(),
                                          lock_file=rev_file_path + ".lock")

--- a/conans/test/functional/build_requires/build_requires_test.py
+++ b/conans/test/functional/build_requires/build_requires_test.py
@@ -186,10 +186,10 @@ class App(ConanFile):
         client.save({CONANFILE: app,
                      "myprofile": myprofile})
         client.run("install . -pr=myprofile")
-        self.assertIn("conanfile.py (consumer/None@None/None): Applying build-requirement: "
+        self.assertIn("conanfile.py (consumer/None): Applying build-requirement: "
                       "mingw/0.1@myuser/stable", client.out)
         client.run("build .")
-        self.assertIn("conanfile.py (consumer/None@None/None): APP PATH FOR BUILD mymingwpath",
+        self.assertIn("conanfile.py (consumer/None): APP PATH FOR BUILD mymingwpath",
                       client.out)
 
     def test_transitive(self):

--- a/conans/test/functional/build_requires/profile_build_requires_test.py
+++ b/conans/test/functional/build_requires/profile_build_requires_test.py
@@ -175,7 +175,7 @@ build2/0.1@user/testing
         self.assertNotIn("Hello World!", client.out)
         client.run("build .")
         self.assertIn("Hello World!", client.out)
-        self.assertIn("conanfile.py (MyLib/0.1@None/None): Hello world from python tool!",
+        self.assertIn("conanfile.py (MyLib/0.1): Hello world from python tool!",
                       client.out)
 
     def test_build_mode_requires(self):
@@ -302,11 +302,11 @@ class MyLib(ConanFile):
         self.assertIn("MyTool/0.1@lasote/stable from local cache", client.out)
         self.assertIn("MyTool/0.1@lasote/stable: Calling build()", client.out)
         client.run("build .")
-        self.assertIn("conanfile.py (MyLib/0.1@None/None): Coverage True", client.out)
+        self.assertIn("conanfile.py (MyLib/0.1): Coverage True", client.out)
 
         client.save({CONANFILE: conanfile}, clean_first=True)
         client.run("install . -o coverage=True")
         self.assertIn("MyTool/0.1@lasote/stable from local cache", client.out)
         self.assertIn("MyTool/0.1@lasote/stable: Already installed!", client.out)
         client.run("build .")
-        self.assertIn("conanfile.py (MyLib/0.1@None/None): Coverage True", client.out)
+        self.assertIn("conanfile.py (MyLib/0.1): Coverage True", client.out)

--- a/conans/test/functional/command/build_test.py
+++ b/conans/test/functional/command/build_test.py
@@ -373,5 +373,5 @@ class BarConan(ConanFile):
         client.run("install . -s MyPkg:build_type=Debug -s build_type=Release")
         self.assertIn("Dep/0.1@user/testing: PACKAGE_INFO: Dep BuildType=Release!", client.out)
         client.run("build .")
-        self.assertIn("conanfile.py (MyPkg/None@None/None): BUILD: MyPkg BuildType=Debug!",
+        self.assertIn("conanfile.py (MyPkg/None): BUILD: MyPkg BuildType=Debug!",
                       client.out)

--- a/conans/test/functional/command/create_test.py
+++ b/conans/test/functional/command/create_test.py
@@ -512,7 +512,7 @@ class TestConanLib(ConanFile):
         client.save({"conanfile.py": conanfile})
         ref = ConanFileReference("pkg", "0.1", "danimtb", "testing")
         pref = PackageReference(ref, NO_SETTINGS_PACKAGE_ID, None)
-        client.run("create . %s" % ref.full_repr(), assert_error=True)
+        client.run("create . %s" % ref.full_str(), assert_error=True)
         self.assertIn("Build error", client.out)
         package_folder = client.cache.package_layout(pref.ref).package(pref)
         self.assertFalse(os.path.exists(package_folder))

--- a/conans/test/functional/command/info_options_test.py
+++ b/conans/test/functional/command/info_options_test.py
@@ -17,9 +17,9 @@ class InfoOptionsTest(unittest.TestCase):
 
         # Check that I can pass options to info
         client.run("info . -o shared=True")
-        self.assertIn("conanfile.py (My-Package/1.3@None/None)", client.out)
+        self.assertIn("conanfile.py (My-Package/1.3)", client.out)
         client.run("info . -o My-Package:shared=True")
-        self.assertIn("conanfile.py (My-Package/1.3@None/None)", client.out)
+        self.assertIn("conanfile.py (My-Package/1.3)", client.out)
 
         # errors
         client.run("info . -o shared2=True", assert_error=True)

--- a/conans/test/functional/command/info_test.py
+++ b/conans/test/functional/command/info_test.py
@@ -141,7 +141,7 @@ class MyTest(ConanFile):
             parent_reference = node_matches[0]
             deps_ref = [ConanFileReference.loads(references) for references in node_matches[1:]]
 
-            if parent_reference == "conanfile.py (Hello0/0.1@None/None)":
+            if parent_reference == "conanfile.py (Hello0/0.1)":
                 parent_ref = ConanFileReference("Hello0", None, None, None, validate=False)
             else:
                 parent_ref = ConanFileReference.loads(parent_reference)
@@ -251,14 +251,14 @@ class AConan(ConanFile):
 
         self.client.run("info . --only None")
         self.assertEqual(["Hello0/0.1@lasote/stable", "Hello1/0.1@lasote/stable",
-                          "conanfile.py (Hello2/0.1@None/None)"],
+                          "conanfile.py (Hello2/0.1)"],
                          str(self.client.out).splitlines()[-3:])
         self.client.run("info . --only=date")
         lines = [(line if "date" not in line else "Date")
                  for line in str(self.client.out).splitlines()]
         self.assertEqual(["Hello0/0.1@lasote/stable", "Date",
                           "Hello1/0.1@lasote/stable", "Date",
-                          "conanfile.py (Hello2/0.1@None/None)"], lines)
+                          "conanfile.py (Hello2/0.1)"], lines)
 
         self.client.run("info . --only=invalid", assert_error=True)
         self.assertIn("Invalid --only value", self.client.out)
@@ -283,7 +283,7 @@ class MyTest(ConanFile):
         self.client.run("export ./subfolder lasote/testing")
 
         self.client.run("info ./subfolder")
-        self.assertIn("conanfile.py (Pkg/0.1@None/None)", self.client.out)
+        self.assertIn("conanfile.py (Pkg/0.1)", self.client.out)
 
         self.client.run("info ./subfolder --build-order "
                         "Pkg/0.1@lasote/testing --json=jsonfile.txt")
@@ -329,10 +329,10 @@ class MyTest(ConanFile):
                 Binary: Missing
                 Binary remote: None
                 Required by:
-                    conanfile.py (Hello2/0.1@None/None)
+                    conanfile.py (Hello2/0.1)
                 Requires:
                     Hello0/0.1@lasote/stable
-            conanfile.py (Hello2/0.1@None/None)
+            conanfile.py (Hello2/0.1)
                 URL: myurl
                 Licenses: MIT, GPL
                 Requires:
@@ -363,7 +363,7 @@ class MyTest(ConanFile):
                 URL: myurl
             Hello1/0.1@lasote/stable
                 URL: myurl
-            conanfile.py (Hello2/0.1@None/None)
+            conanfile.py (Hello2/0.1)
                 URL: myurl""")
 
         self.assertIn(expected_output, clean_output(self.client.out))
@@ -376,7 +376,7 @@ class MyTest(ConanFile):
             Hello1/0.1@lasote/stable
                 URL: myurl
                 License: MIT
-            conanfile.py (Hello2/0.1@None/None)
+            conanfile.py (Hello2/0.1)
                 URL: myurl
                 Licenses: MIT, GPL""")
 
@@ -402,7 +402,7 @@ class MyTest(ConanFile):
         self.assertEqual(content[0]["reference"], "LibA/0.1@lasote/stable")
         self.assertEqual(content[0]["license"][0], "MIT")
         self.assertEqual(content[1]["url"], "myurl")
-        self.assertEqual(content[1]["required_by"][0], "conanfile.py (LibD/0.1@None/None)")
+        self.assertEqual(content[1]["required_by"][0], "conanfile.py (LibD/0.1)")
 
     def build_order_test(self):
         self.client = TestClient()
@@ -550,7 +550,7 @@ class MyTest(ConanFile):
 
         self.client.run("info ./subfolder")
 
-        self.assertIn("conanfile.py (Pkg/0.1@None/None)", self.client.out)
+        self.assertIn("conanfile.py (Pkg/0.1)", self.client.out)
         self.assertNotIn("License:", self.client.out)
         self.assertNotIn("Author:", self.client.out)
         self.assertNotIn("Topics:", self.client.out)
@@ -577,7 +577,7 @@ class MyTest(ConanFile):
         client.run("export ./subfolder lasote/testing")
         client.run("info ./subfolder")
 
-        self.assertIn("conanfile.py (Pkg/0.2@None/None)", client.out)
+        self.assertIn("conanfile.py (Pkg/0.2)", client.out)
         self.assertIn("License: MIT", client.out)
         self.assertIn("Author: John Doe", client.out)
         self.assertIn("Topics: foo, bar, qux", client.out)
@@ -626,7 +626,7 @@ class MyTest(ConanFile):
         graph_info.pop("root")
         save(path, json.dumps(graph_info))
         client.run("info .")
-        self.assertIn("conanfile.py (Hello/0.1@None/None)", client.out)
+        self.assertIn("conanfile.py (Hello/0.1)", client.out)
         save(path, "broken thing")
         client.run("info .", assert_error=True)
         self.assertIn("ERROR: Error parsing GraphInfo from file", client.out)

--- a/conans/test/functional/command/source_test.py
+++ b/conans/test/functional/command/source_test.py
@@ -142,8 +142,8 @@ class ConanLib(ConanFile):
         os.mkdir(subdir)
         client.run("install . --install-folder subdir")
         client.run("source . --install-folder subdir --source-folder subdir")
-        self.assertIn("conanfile.py (Hello/0.1@None/None): Configuring sources", client.out)
-        self.assertIn("conanfile.py (Hello/0.1@None/None): cwd=>%s" % subdir, client.out)
+        self.assertIn("conanfile.py (Hello/0.1): Configuring sources", client.out)
+        self.assertIn("conanfile.py (Hello/0.1): cwd=>%s" % subdir, client.out)
 
     def local_source_src_not_exist_test(self):
         conanfile = '''

--- a/conans/test/functional/generators/deploy_test.py
+++ b/conans/test/functional/generators/deploy_test.py
@@ -24,7 +24,7 @@ class DeployGeneratorTest(unittest.TestCase):
         ref = ConanFileReference("name", "version", "user", "channel")
         self.client.create(ref, conanfile)
         self.client.current_folder = temp_folder()
-        self.client.run("install %s -g deploy" % ref.full_repr())
+        self.client.run("install %s -g deploy" % ref.full_str())
 
     def deploy_folder_path_test(self):
         base_path = os.path.join(self.client.current_folder, "name")
@@ -84,7 +84,7 @@ class DeployGeneratorGraphTest(unittest.TestCase):
         self.client.create(ref1, conanfile1)
         self.client.create(ref2, conanfile2)
         self.client.current_folder = temp_folder()
-        self.client.run("install %s -g deploy" % ref2.full_repr())
+        self.client.run("install %s -g deploy" % ref2.full_str())
 
     def get_expected_paths(self):
         base1_path = os.path.join(self.client.current_folder, "name1")
@@ -133,7 +133,7 @@ class DeployGeneratorPermissionsTest(unittest.TestCase):
         self.assertFalse(stat_info.st_mode & stat.S_IXUSR)
         os.chmod(self.header_path, stat_info.st_mode | stat.S_IXUSR)
         self.client.current_folder = temp_folder()
-        self.client.run("install %s -g deploy" % self.ref1.full_repr())
+        self.client.run("install %s -g deploy" % self.ref1.full_str())
         base1_path = os.path.join(self.client.current_folder, "name1")
         header1_path = os.path.join(base1_path, "include", "header1.h")
         stat_info = os.stat(header1_path)

--- a/conans/test/functional/graph/conflict_diamond_test.py
+++ b/conans/test/functional/graph/conflict_diamond_test.py
@@ -52,7 +52,7 @@ class ConflictDiamondTest(unittest.TestCase):
                       "Hello0/0.1@lasote/stable"], export=False)
         self.client.run("install . --build missing", assert_error=False)
         self.assertIn("Hello2/0.1@lasote/stable requirement Hello0/0.2@lasote/stable overridden"
-                      " by Hello3/0.1@None/None to Hello0/0.1@lasote/stable",
+                      " by Hello3/0.1 to Hello0/0.1@lasote/stable",
                       self.client.out)
 
     def test_error_on_override(self):
@@ -66,7 +66,7 @@ class ConflictDiamondTest(unittest.TestCase):
                           "Hello0/0.1@lasote/stable"], export=False)
             self.client.run("install . --build missing", assert_error=True)
             self.assertIn("ERROR: Hello2/0.1@lasote/stable: requirement Hello0/0.2@lasote/stable"
-                          " overridden by Hello3/0.1@None/None to Hello0/0.1@lasote/stable",
+                          " overridden by Hello3/0.1 to Hello0/0.1@lasote/stable",
                           self.client.out)
 
     def test_override_explicit(self):
@@ -82,7 +82,7 @@ class ConflictDiamondTest(unittest.TestCase):
             self.client.save({CONANFILE: conanfile})
             self.client.run("install . --build missing")
             self.assertIn("Hello2/0.1@lasote/stable requirement Hello0/0.2@lasote/stable overridden"
-                          " by Hello3/0.1@None/None to Hello0/0.1@lasote/stable",
+                          " by Hello3/0.1 to Hello0/0.1@lasote/stable",
                           self.client.out)
 
             # ...but there is no way to tell Conan that 'Hello3' wants to depend also on 'Hello0'.

--- a/conans/test/functional/graph/graph_manager_base.py
+++ b/conans/test/functional/graph/graph_manager_base.py
@@ -80,7 +80,7 @@ class GraphManagerTest(unittest.TestCase):
     def _check_node(self, node, ref, deps, build_deps, dependents, closure):
         conanfile = node.conanfile
         ref = ConanFileReference.loads(str(ref))
-        self.assertEqual(node.ref.full_repr(), ref.full_repr())
+        self.assertEqual(repr(node.ref), repr(ref))
         self.assertEqual(conanfile.name, ref.name)
         self.assertEqual(len(node.dependencies), len(deps) + len(build_deps))
 

--- a/conans/test/functional/graph/half_diamond_test.py
+++ b/conans/test/functional/graph/half_diamond_test.py
@@ -32,7 +32,7 @@ class HalfDiamondTest(unittest.TestCase):
         self._export("Hello3", ["Hello2/0.1@lasote/stable"], export=False)
 
         self.client.run("install . --build missing")
-        self.assertIn("conanfile.py (Hello3/0.1@None/None): Generated conaninfo.txt",
+        self.assertIn("conanfile.py (Hello3/0.1): Generated conaninfo.txt",
                       self.client.out)
 
     def check_duplicated_full_requires_test(self):
@@ -42,7 +42,7 @@ class HalfDiamondTest(unittest.TestCase):
                      export=False)
 
         self.client.run("install . --build missing")
-        self.assertIn("conanfile.py (Hello2/0.1@None/None): Generated conaninfo.txt",
+        self.assertIn("conanfile.py (Hello2/0.1): Generated conaninfo.txt",
                       self.client.out)
         conaninfo = load(os.path.join(self.client.current_folder, "conaninfo.txt"))
         self.assertEqual(1, conaninfo.count("Hello0/0.1@lasote/stable"))

--- a/conans/test/functional/graph/python_diamond_test.py
+++ b/conans/test/functional/graph/python_diamond_test.py
@@ -37,7 +37,7 @@ class PythonDiamondTest(unittest.TestCase):
         self.assertNotIn("Project: Build stuff Hello3", self.client.out)
 
         self.client.run("build .")
-        self.assertIn("conanfile.py (Hello4/0.1@None/None): Build stuff Hello3",
+        self.assertIn("conanfile.py (Hello4/0.1): Build stuff Hello3",
                       self.client.out)
 
         if platform.system() == "Windows":

--- a/conans/test/functional/graph/version_ranges_diamond_test.py
+++ b/conans/test/functional/graph/version_ranges_diamond_test.py
@@ -174,10 +174,10 @@ class HelloReuseConan(ConanFile):
             self.client.run('remove "Hello0/0.*" -f')
             self.client.run("install . --build missing -r=%s" % remote)
             self.assertIn("Version range '>0.1,<0.4' required by "
-                          "'conanfile.py (Hello1/0.1@None/None)' "
+                          "'conanfile.py (Hello1/0.1)' "
                           "resolved to 'Hello0/%s@lasote/stable'" % solution,
                           self.client.out)
-            self.assertIn("conanfile.py (Hello1/0.1@None/None): Generated conaninfo.txt",
+            self.assertIn("conanfile.py (Hello1/0.1): Generated conaninfo.txt",
                           self.client.out)
             content = load(os.path.join(self.client.current_folder, "conaninfo.txt"))
             self.assertIn("Hello0/%s@lasote/stable" % solution, content)
@@ -218,9 +218,9 @@ class HelloReuseConan(ConanFile):
 
         self.client.run('remove "Hello0/0.*" -f')
         self.client.run("install . --build missing")
-        self.assertIn("Version range '>0.1,<0.3' required by 'conanfile.py (Hello1/0.1@None/None)' "
+        self.assertIn("Version range '>0.1,<0.3' required by 'conanfile.py (Hello1/0.1)' "
                       "resolved to 'Hello0/0.2@lasote/stable'", self.client.out)
-        self.assertIn("conanfile.py (Hello1/0.1@None/None): Generated conaninfo.txt",
+        self.assertIn("conanfile.py (Hello1/0.1): Generated conaninfo.txt",
                       self.client.out)
 
         content = load(os.path.join(self.client.current_folder, "conaninfo.txt"))
@@ -242,14 +242,14 @@ class HelloReuseConan(ConanFile):
         self.client.run("install . --build missing")
 
         def check1():
-            self.assertIn("Version range '~=0' required by 'conanfile.py (Hello3/0.1@None/None)' "
+            self.assertIn("Version range '~=0' required by 'conanfile.py (Hello3/0.1)' "
                           "resolved to 'Hello2/0.1@lasote/stable'", self.client.out)
             self.assertIn("Version range '>0.1,<0.3' required by 'Hello1/0.1@lasote/stable' "
                           "resolved to 'Hello0/0.2@lasote/stable'", self.client.out)
             self.assertIn("Version range '0.2' required by 'Hello2/0.1@lasote/stable' resolved "
                           "to 'Hello0/0.2@lasote/stable'", self.client.out)
             self.assertNotIn("Conflict", self.client.out)
-            self.assertIn("conanfile.py (Hello3/0.1@None/None): Generated conaninfo.txt",
+            self.assertIn("conanfile.py (Hello3/0.1): Generated conaninfo.txt",
                           self.client.out)
 
             content = load(os.path.join(self.client.current_folder, "conaninfo.txt"))
@@ -269,14 +269,14 @@ class HelloReuseConan(ConanFile):
             check1()
             # Now update
             self.client.run("install . --update --build missing")
-            self.assertIn("Version range '~=0' required by 'conanfile.py (Hello3/0.1@None/None)' "
+            self.assertIn("Version range '~=0' required by 'conanfile.py (Hello3/0.1)' "
                           "resolved to 'Hello2/0.1@lasote/stable'", self.client.out)
             self.assertIn("Version range '>0.1,<0.3' required by 'Hello1/0.1@lasote/stable' "
                           "resolved to 'Hello0/0.2.1@lasote/stable'", self.client.out)
             self.assertIn("Version range '0.2' required by 'Hello2/0.1@lasote/stable' resolved "
                           "to 'Hello0/0.2.1@lasote/stable'", self.client.out)
             self.assertNotIn("Conflict", self.client.out)
-            self.assertIn("conanfile.py (Hello3/0.1@None/None): Generated conaninfo.txt",
+            self.assertIn("conanfile.py (Hello3/0.1): Generated conaninfo.txt",
                           self.client.out)
 
             content = load(os.path.join(self.client.current_folder, "conaninfo.txt"))

--- a/conans/test/functional/graph_lock/graph_lock_test.py
+++ b/conans/test/functional/graph_lock/graph_lock_test.py
@@ -247,7 +247,7 @@ class GraphLockRevisionTest(unittest.TestCase):
         client = self.client
         client.run("install . -if=tmp")  # Output graph_info to temporary
         client.run("build . -if=tmp")
-        self.assertIn("conanfile.py (PkgB/0.1@None/None): BUILD DEP LIBS: mylibPkgA0.1lib!!",
+        self.assertIn("conanfile.py (PkgB/0.1): BUILD DEP LIBS: mylibPkgA0.1lib!!",
                       client.out)
 
         # Locked install will use PkgA/0.1
@@ -255,7 +255,7 @@ class GraphLockRevisionTest(unittest.TestCase):
         client.run("install . -g=cmake --lockfile --update")
         self._check_lock("PkgB/0.1@None/None")
         client.run("build .")
-        self.assertIn("conanfile.py (PkgB/0.1@None/None): BUILD DEP LIBS: !!", client.out)
+        self.assertIn("conanfile.py (PkgB/0.1): BUILD DEP LIBS: !!", client.out)
 
         # Info also works
         client.run("info . --lockfile")
@@ -311,12 +311,12 @@ class GraphLockPythonRequiresTest(unittest.TestCase):
         client.save({"conanfile.py": consumer})
         client.run("install .")
         self.assertIn("Tool/0.1@user/channel", client.out)
-        self.assertIn("conanfile.py (Pkg/None@None/None): CONFIGURE VAR=42", client.out)
+        self.assertIn("conanfile.py (Pkg/None): CONFIGURE VAR=42", client.out)
         self._check_lock("Pkg/None@None/None")
 
         client.run("build .")
-        self.assertIn("conanfile.py (Pkg/None@None/None): CONFIGURE VAR=42", client.out)
-        self.assertIn("conanfile.py (Pkg/None@None/None): BUILD VAR=42", client.out)
+        self.assertIn("conanfile.py (Pkg/None): CONFIGURE VAR=42", client.out)
+        self.assertIn("conanfile.py (Pkg/None): BUILD VAR=42", client.out)
 
         # If we create a new Tool version
         client.save({"conanfile.py": conanfile.replace("42", "111")})
@@ -339,22 +339,22 @@ class GraphLockPythonRequiresTest(unittest.TestCase):
         client.run("install . -if=tmp")
         self.assertIn("Tool/0.2@user/channel", client.out)
         client.run("build . -if=tmp")
-        self.assertIn("conanfile.py (Pkg/None@None/None): CONFIGURE VAR=111", client.out)
-        self.assertIn("conanfile.py (Pkg/None@None/None): BUILD VAR=111", client.out)
+        self.assertIn("conanfile.py (Pkg/None): CONFIGURE VAR=111", client.out)
+        self.assertIn("conanfile.py (Pkg/None): BUILD VAR=111", client.out)
 
         client.run("install . --lockfile")
         self.assertIn("Tool/0.1@user/channel", client.out)
         self.assertNotIn("Tool/0.2@user/channel", client.out)
         self._check_lock("Pkg/None@None/None")
         client.run("build .")
-        self.assertIn("conanfile.py (Pkg/None@None/None): CONFIGURE VAR=42", client.out)
-        self.assertIn("conanfile.py (Pkg/None@None/None): BUILD VAR=42", client.out)
+        self.assertIn("conanfile.py (Pkg/None): CONFIGURE VAR=42", client.out)
+        self.assertIn("conanfile.py (Pkg/None): BUILD VAR=42", client.out)
 
         client.run("package .")
-        self.assertIn("conanfile.py (Pkg/None@None/None): CONFIGURE VAR=42", client.out)
+        self.assertIn("conanfile.py (Pkg/None): CONFIGURE VAR=42", client.out)
 
         client.run("info . --lockfile")
-        self.assertIn("conanfile.py (Pkg/None@None/None): CONFIGURE VAR=42", client.out)
+        self.assertIn("conanfile.py (Pkg/None): CONFIGURE VAR=42", client.out)
 
     def create_test(self):
         client = self.client

--- a/conans/test/functional/old/libcxx_setting_test.py
+++ b/conans/test/functional/old/libcxx_setting_test.py
@@ -93,7 +93,7 @@ class ConanFileToolsTest(ConanFile):
         client.save({"conanfile.py": conanfile})
         # Also check that it not fails the config method with Visual Studio, because of the lack of libcxx
         client.run('install . -s compiler="Visual Studio" -s compiler.version=14')
-        self.assertIn("conanfile.py (test/1.9@None/None): Generated conaninfo.txt", client.out)
+        self.assertIn("conanfile.py (test/1.9): Generated conaninfo.txt", client.out)
 
         conaninfo = load(os.path.join(client.current_folder, "conaninfo.txt"))
         self.assertNotIn("libcxx", conaninfo)

--- a/conans/test/functional/old/short_paths_test.py
+++ b/conans/test/functional/old/short_paths_test.py
@@ -92,7 +92,7 @@ class TestConan(ConanFile):
         # try local flow still works, but no pkg id available
         client.run("install .")
         client.run("package .")
-        self.assertIn("conanfile.py (test/1.0@None/None): Package 'package' created", client.out)
+        self.assertIn("conanfile.py (test/1.0): Package 'package' created", client.out)
 
         # try export-pkg with package folder
         client.run("remove test/1.0@danimtb/testing --force")

--- a/conans/test/integration/hook_test.py
+++ b/conans/test/integration/hook_test.py
@@ -22,29 +22,29 @@ from conans.model.ref import ConanFileReference
 def pre_export(output, conanfile, conanfile_path, reference, **kwargs):
     assert conanfile
     output.info("conanfile_path=%s" % conanfile_path)
-    output.info("reference=%s" % reference.full_repr())
+    output.info("reference=%s" % reference.full_str())
 
 def post_export(output, conanfile, conanfile_path, reference, **kwargs):
     assert conanfile
     output.info("conanfile_path=%s" % conanfile_path)
-    output.info("reference=%s" % reference.full_repr())
+    output.info("reference=%s" % reference.full_str())
 
 def pre_source(output, conanfile, conanfile_path, **kwargs):
     assert conanfile
     output.info("conanfile_path=%s" % conanfile_path)
     if conanfile.in_local_cache:
-        output.info("reference=%s" % kwargs["reference"].full_repr())
+        output.info("reference=%s" % kwargs["reference"].full_str())
 
 def post_source(output, conanfile, conanfile_path, **kwargs):
     assert conanfile
     output.info("conanfile_path=%s" % conanfile_path)
     if conanfile.in_local_cache:
-        output.info("reference=%s" % kwargs["reference"].full_repr())
+        output.info("reference=%s" % kwargs["reference"].full_str())
 
 def pre_build(output, conanfile, **kwargs):
     assert conanfile
     if conanfile.in_local_cache:
-        output.info("reference=%s" % kwargs["reference"].full_repr())
+        output.info("reference=%s" % kwargs["reference"].full_str())
         output.info("package_id=%s" % kwargs["package_id"])
     else:
         output.info("conanfile_path=%s" % kwargs["conanfile_path"])
@@ -52,7 +52,7 @@ def pre_build(output, conanfile, **kwargs):
 def post_build(output, conanfile, **kwargs):
     assert conanfile
     if conanfile.in_local_cache:
-        output.info("reference=%s" % kwargs["reference"].full_repr())
+        output.info("reference=%s" % kwargs["reference"].full_str())
         output.info("package_id=%s" % kwargs["package_id"])
     else:
         output.info("conanfile_path=%s" % kwargs["conanfile_path"])
@@ -61,84 +61,84 @@ def pre_package(output, conanfile, conanfile_path, **kwargs):
     assert conanfile
     output.info("conanfile_path=%s" % conanfile_path)
     if conanfile.in_local_cache:
-        output.info("reference=%s" % kwargs["reference"].full_repr())
+        output.info("reference=%s" % kwargs["reference"].full_str())
         output.info("package_id=%s" % kwargs["package_id"])
 
 def post_package(output, conanfile, conanfile_path, **kwargs):
     assert conanfile
     output.info("conanfile_path=%s" % conanfile_path)
     if conanfile.in_local_cache:
-        output.info("reference=%s" % kwargs["reference"].full_repr())
+        output.info("reference=%s" % kwargs["reference"].full_str())
         output.info("package_id=%s" % kwargs["package_id"])
 
 def pre_upload(output, conanfile_path, reference, remote, **kwargs):
     output.info("conanfile_path=%s" % conanfile_path)
-    output.info("reference=%s" % reference.full_repr())
+    output.info("reference=%s" % reference.full_str())
     output.info("remote.name=%s" % remote.name)
 
 def post_upload(output, conanfile_path, reference, remote, **kwargs):
     output.info("conanfile_path=%s" % conanfile_path)
-    output.info("reference=%s" % reference.full_repr())
+    output.info("reference=%s" % reference.full_str())
     output.info("remote.name=%s" % remote.name)
 
 def pre_upload_recipe(output, conanfile_path, reference, remote, **kwargs):
     output.info("conanfile_path=%s" % conanfile_path)
-    output.info("reference=%s" % reference.full_repr())
+    output.info("reference=%s" % reference.full_str())
     output.info("remote.name=%s" % remote.name)
 
 def post_upload_recipe(output, conanfile_path, reference, remote, **kwargs):
     output.info("conanfile_path=%s" % conanfile_path)
-    output.info("reference=%s" % reference.full_repr())
+    output.info("reference=%s" % reference.full_str())
     output.info("remote.name=%s" % remote.name)
 
 def pre_upload_package(output, conanfile_path, reference, package_id, remote, **kwargs):
     output.info("conanfile_path=%s" % conanfile_path)
-    output.info("reference=%s" % reference.full_repr())
+    output.info("reference=%s" % reference.full_str())
     output.info("package_id=%s" % package_id)
     output.info("remote.name=%s" % remote.name)
 
 def post_upload_package(output, conanfile_path, reference, package_id, remote, **kwargs):
     output.info("conanfile_path=%s" % conanfile_path)
-    output.info("reference=%s" % reference.full_repr())
+    output.info("reference=%s" % reference.full_str())
     output.info("package_id=%s" % package_id)
     output.info("remote.name=%s" % remote.name)
 
 def pre_download(output, reference, remote, **kwargs):
-    output.info("reference=%s" % reference.full_repr())
+    output.info("reference=%s" % reference.full_str())
     output.info("remote.name=%s" % remote.name)
 
 def post_download(output, conanfile_path, reference, remote, **kwargs):
     output.info("conanfile_path=%s" % conanfile_path)
-    output.info("reference=%s" % reference.full_repr())
+    output.info("reference=%s" % reference.full_str())
     output.info("remote.name=%s" % remote.name)
 
 def pre_download_recipe(output, reference, remote, **kwargs):
-    output.info("reference=%s" % reference.full_repr())
+    output.info("reference=%s" % reference.full_str())
     output.info("remote.name=%s" % remote.name)
 
 def post_download_recipe(output, conanfile_path, reference, remote, **kwargs):
     output.info("conanfile_path=%s" % conanfile_path)
-    output.info("reference=%s" % reference.full_repr())
+    output.info("reference=%s" % reference.full_str())
     output.info("remote.name=%s" % remote.name)
 
 def pre_download_package(output, conanfile_path, reference, package_id, remote, **kwargs):
     output.info("conanfile_path=%s" % conanfile_path)
-    output.info("reference=%s" % reference.full_repr())
+    output.info("reference=%s" % reference.full_str())
     output.info("package_id=%s" % package_id)
     output.info("remote.name=%s" % remote.name)
 
 def post_download_package(output, conanfile_path, reference, package_id, remote, **kwargs):
     output.info("conanfile_path=%s" % conanfile_path)
-    output.info("reference=%s" % reference.full_repr())
+    output.info("reference=%s" % reference.full_str())
     output.info("package_id=%s" % package_id)
     output.info("remote.name=%s" % remote.name)
     
 def pre_package_info(output, conanfile, reference, **kwargs):
-    output.info("reference=%s" % reference.full_repr())
+    output.info("reference=%s" % reference.full_str())
     output.info("conanfile.cpp_info.defines=%s" % conanfile.cpp_info.defines)
 
 def post_package_info(output, conanfile, reference, **kwargs):
-    output.info("reference=%s" % reference.full_repr())
+    output.info("reference=%s" % reference.full_str())
     output.info("conanfile.cpp_info.defines=%s" % conanfile.cpp_info.defines)
 """
 

--- a/conans/test/integration/manifest_validation_test.py
+++ b/conans/test/integration/manifest_validation_test.py
@@ -14,7 +14,7 @@ from conans.util.files import load, md5, save
 
 def export_folder(base, ref):
     try:
-        ref = ConanFileReference.loads(str(ref))
+        ref = ConanFileReference.loads(repr(ref))
     except Exception:
         pass
     path = ref.dir_repr() if isinstance(ref, ConanFileReference) else ref

--- a/conans/test/integration/order_libs_test.py
+++ b/conans/test/integration/order_libs_test.py
@@ -105,7 +105,7 @@ class HelloReuseConan(ConanFile):
         self._export("MyProject", ["SDL2_ttf"], export=False)
 
         self.client.run("install . --build missing")
-        self.assertIn("conanfile.py (MyProject/1.0@None/None): Generated conaninfo.txt",
+        self.assertIn("conanfile.py (MyProject/1.0): Generated conaninfo.txt",
                       self.client.out)
 
         expected_libs = ['SDL2_ttf', 'freeType', 'SDL2', 'rt', 'pthread', 'dl',

--- a/conans/test/integration/revisions_test.py
+++ b/conans/test/integration/revisions_test.py
@@ -1094,7 +1094,7 @@ class SearchingPackagesWithRevisions(unittest.TestCase):
         data = client.search("lib*", remote="default")
         items = data["results"][0]["items"]
         self.assertEqual(2, len(items))
-        expected = [repr(pref1b.ref), repr(pref2b.ref)]
+        expected = [str(pref1b.ref), str(pref2b.ref)]
 
         self.assertEqual(expected, [i["recipe"]["id"] for i in items])
 

--- a/conans/test/integration/revisions_test.py
+++ b/conans/test/integration/revisions_test.py
@@ -160,10 +160,10 @@ class InstallingPackagesWithRevisionsTest(unittest.TestCase):
         self.c_v2.remove_all()
 
         # Create an alias to the first revision
-        self.c_v2.run("alias lib/latest@conan/stable {}".format(pref.ref.full_repr()))
+        self.c_v2.run("alias lib/latest@conan/stable {}".format(pref.ref.full_str()))
         alias_ref = ConanFileReference.loads("lib/latest@conan/stable")
         exported = load(self.c_v2.cache.package_layout(alias_ref).conanfile())
-        self.assertIn('alias = "{}"'.format(pref.ref.full_repr()), exported)
+        self.assertIn('alias = "{}"'.format(pref.ref.full_str()), exported)
 
         self.c_v2.upload_all(ConanFileReference.loads("lib/latest@conan/stable"))
         self.c_v2.remove_all()
@@ -344,7 +344,7 @@ class InstallingPackagesWithRevisionsTest(unittest.TestCase):
             new_client.upload_all(self.ref)
 
             # Repeat the install --update pointing to the new reference
-            client.run("install {} --update".format(pref.ref.full_repr()))
+            client.run("install {} --update".format(pref.ref.full_str()))
             self.assertIn("{} from 'default' - Downloaded".format(self.ref), client.out)
 
     @parameterized.expand([(True,), (False,)])
@@ -370,7 +370,7 @@ class InstallingPackagesWithRevisionsTest(unittest.TestCase):
     def test_json_output(self):
         client = TurboTestClient()
         client.save({"conanfile.py": str(GenConanfile())})
-        client.run("create . {} --json file.json".format(self.ref.full_repr()))
+        client.run("create . {} --json file.json".format(self.ref.full_str()))
         json_path = os.path.join(client.current_folder, "file.json")
         import json
         data = json.loads(load(json_path))
@@ -555,14 +555,14 @@ class RemoveWithRevisionsTest(unittest.TestCase):
 
         # If I remove the ref, the revision is gone, of course
         ref1 = client.export(self.ref)
-        client.run("remove {} -f".format(ref1.copy_clear_rev().full_repr()))
+        client.run("remove {} -f".format(ref1.copy_clear_rev().full_str()))
         self.assertFalse(client.recipe_exists(self.ref))
 
         # If I remove a ref with a wrong revision, the revision is not removed
         ref1 = client.export(self.ref)
         fakeref = ref1.copy_with_rev("fakerev")
-        full_ref = fakeref.full_repr() if not v1 else str(fakeref)
-        client.run("remove {} -f".format(fakeref.full_repr()), assert_error=True)
+        full_ref = fakeref.full_str() if not v1 else str(fakeref)
+        client.run("remove {} -f".format(fakeref.full_str()), assert_error=True)
         self.assertIn("ERROR: Recipe not found: '%s'" % full_ref, client.out)
         self.assertTrue(client.recipe_exists(self.ref))
 
@@ -577,25 +577,25 @@ class RemoveWithRevisionsTest(unittest.TestCase):
 
         # If I remove the ref without RREV, the packages are also removed
         pref1 = client.create(self.ref)
-        client.run("remove {} -f".format(pref1.ref.copy_clear_rev().full_repr()))
+        client.run("remove {} -f".format(pref1.ref.copy_clear_rev().full_str()))
         self.assertFalse(client.package_exists(pref1))
 
         # If I remove the ref with fake RREV, the packages are not removed
         pref1 = client.create(self.ref)
         fakeref = pref1.ref.copy_with_rev("fakerev")
-        str_ref = fakeref.full_repr() if not v1 else str(fakeref)
-        client.run("remove {} -f".format(fakeref.full_repr()), assert_error=True)
+        str_ref = fakeref.full_str() if not v1 else str(fakeref)
+        client.run("remove {} -f".format(fakeref.full_str()), assert_error=True)
         self.assertTrue(client.package_exists(pref1))
         self.assertIn("Recipe not found: '{}'".format(str_ref), client.out)
 
         # If I remove the ref with valid RREV, the packages are removed
         pref1 = client.create(self.ref)
-        client.run("remove {} -f".format(pref1.ref.full_repr()))
+        client.run("remove {} -f".format(pref1.ref.full_str()))
         self.assertFalse(client.package_exists(pref1))
 
         # If I remove the ref without RREV but specifying PREV it raises
         pref1 = client.create(self.ref)
-        command = "remove {} -f -p {}#{}".format(pref1.ref.copy_clear_rev().full_repr(),
+        command = "remove {} -f -p {}#{}".format(pref1.ref.copy_clear_rev().full_str(),
                                                  pref1.id, pref1.revision)
         client.run(command, assert_error=True)
         self.assertTrue(client.package_exists(pref1))
@@ -603,14 +603,14 @@ class RemoveWithRevisionsTest(unittest.TestCase):
 
         # A wrong PREV doesn't remove the PREV
         pref1 = client.create(self.ref)
-        command = "remove {} -f -p {}#fakeprev".format(pref1.ref.full_repr(), pref1.id)
+        command = "remove {} -f -p {}#fakeprev".format(pref1.ref.full_str(), pref1.id)
         client.run(command, assert_error=True)
         self.assertTrue(client.package_exists(pref1))
         self.assertIn("Binary package not found", client.out)
 
         # Everything correct, removes the unique local package revision
         pref1 = client.create(self.ref)
-        command = "remove {} -f -p {}#{}".format(pref1.ref.full_repr(), pref1.id, pref1.revision)
+        command = "remove {} -f -p {}#{}".format(pref1.ref.full_str(), pref1.id, pref1.revision)
         client.run(command)
         self.assertFalse(client.package_exists(pref1))
 
@@ -654,7 +654,7 @@ class RemoveWithRevisionsTest(unittest.TestCase):
         remover_client = self.c_v1 if v1 else self.c_v2
 
         # Remove ref without revision in a remote
-        command = "remove {} -f -r default".format(pref1.ref.full_repr())
+        command = "remove {} -f -r default".format(pref1.ref.full_str())
         if v1:
             remover_client.run(command, assert_error=True)
             self.assertIn("Revisions not enabled in the client", remover_client.out)
@@ -727,7 +727,7 @@ class RemoveWithRevisionsTest(unittest.TestCase):
                       remover_client.out)
 
         # Remove package with RREV and PREV
-        command = "remove {} -p {}#{} -f -r default".format(pref2.ref.full_repr(),
+        command = "remove {} -p {}#{} -f -r default".format(pref2.ref.full_str(),
                                                             pref2.id, pref2.revision)
         if v1:
             remover_client.run(command, assert_error=True)
@@ -742,11 +742,11 @@ class RemoveWithRevisionsTest(unittest.TestCase):
             self.assertFalse(self.server.package_exists(pref2))
 
             # Try to remove a missing revision
-            command = "remove {} -p {}#fakerev -f -r default".format(pref2.ref.full_repr(),
+            command = "remove {} -p {}#fakerev -f -r default".format(pref2.ref.full_str(),
                                                                      pref2.id)
             remover_client.run(command, assert_error=True)
             fakeref = pref2.copy_with_revs(pref2.ref.revision, "fakerev")
-            self.assertIn("Binary package not found: '{}'".format(fakeref.full_repr()),
+            self.assertIn("Binary package not found: '{}'".format(fakeref.full_str()),
                           remover_client.out)
 
 
@@ -789,7 +789,7 @@ class SearchingPackagesWithRevisions(unittest.TestCase):
         ref = client.export(self.ref, conanfile=GenConanfile().
                             with_build_msg("I'm your father, rev2"))
 
-        data = client.search(ref.full_repr(), args="--outdated")
+        data = client.search(ref.full_str(), args="--outdated")
         self.assertEqual([], data["results"][0]["items"][0]["packages"])
 
         client.search("{}#fakerev".format(ref), args="--outdated", assert_error=True)
@@ -875,11 +875,11 @@ class SearchingPackagesWithRevisions(unittest.TestCase):
         client = self.c_v1 if v1 else self.c_v2
 
         if v1:
-            client.search(revision_ref.full_repr(), remote="all", assert_error=True)
+            client.search(revision_ref.full_str(), remote="all", assert_error=True)
             self.assertIn("ERROR: Revisions not enabled in the client, "
                           "specify a reference without revision", client.out)
         else:
-            data = client.search(revision_ref.full_repr(), remote="all")
+            data = client.search(revision_ref.full_str(), remote="all")
             oss_r1 = [p["settings"]["os"] for p in data["results"][0]["items"][0]["packages"]]
             oss_r2 = [p["settings"]["os"] for p in data["results"][1]["items"][0]["packages"]]
             self.assertEqual(["Windows"], oss_r1)
@@ -998,11 +998,11 @@ class SearchingPackagesWithRevisions(unittest.TestCase):
         client = self.c_v1 if v1 else self.c_v2
         client.remove_all()
         if v1:
-            client.search(pref.ref.full_repr(), remote="default", assert_error=True)
+            client.search(pref.ref.full_str(), remote="default", assert_error=True)
             self.assertIn("ERROR: Revisions not enabled in the client, specify "
                           "a reference without revision", client.out)
         else:
-            data = client.search(pref.ref.full_repr(), remote="default")
+            data = client.search(pref.ref.full_str(), remote="default")
             items = data["results"][0]["items"][0]["packages"]
             self.assertEqual(1, len(items))
             oss = items[0]["settings"]["os"]
@@ -1022,10 +1022,10 @@ class SearchingPackagesWithRevisions(unittest.TestCase):
         pref2 = client.create(self.ref, GenConanfile().with_setting("os").with_build_msg("Rev2"),
                               args="-s os=Linux")
 
-        client.run("search {}".format(pref1.ref.full_repr()), assert_error=True)
-        self.assertIn("Recipe not found: '{}'".format(pref1.ref.full_repr()), client.out)
+        client.run("search {}".format(pref1.ref.full_str()), assert_error=True)
+        self.assertIn("Recipe not found: '{}'".format(pref1.ref.full_str()), client.out)
 
-        client.run("search {}".format(pref2.ref.full_repr()))
+        client.run("search {}".format(pref2.ref.full_str()))
         self.assertIn("Existing packages for recipe {}:".format(pref2.ref), client.out)
         self.assertIn("os: Linux", client.out)
 
@@ -1061,7 +1061,7 @@ class SearchingPackagesWithRevisions(unittest.TestCase):
         client.export(ref2)
 
         # Search for the recipes
-        data = client.search("{}*".format(self.ref.full_repr()))
+        data = client.search("{}*".format(self.ref.full_str()))
         items = data["results"][0]["items"]
         self.assertEqual(1, len(items))
         expected = [str(self.ref)]
@@ -1094,7 +1094,7 @@ class SearchingPackagesWithRevisions(unittest.TestCase):
         data = client.search("lib*", remote="default")
         items = data["results"][0]["items"]
         self.assertEqual(2, len(items))
-        expected = [str(pref1b.ref), str(pref2b.ref)]
+        expected = [repr(pref1b.ref), repr(pref2b.ref)]
 
         self.assertEqual(expected, [i["recipe"]["id"] for i in items])
 
@@ -1124,18 +1124,18 @@ class SearchingPackagesWithRevisions(unittest.TestCase):
 
         client = self.c_v1 if v1 else self.c_v2
 
-        data = client.search("{}*".format(pref2_lib.ref.full_repr()), remote="default")
+        data = client.search("{}*".format(pref2_lib.ref.full_str()), remote="default")
         items = data["results"][0]["items"]
         expected = [str(self.ref)]
         self.assertEqual(expected, [i["recipe"]["id"] for i in items])
 
-        data = client.search("{}".format(pref2_lib.ref.full_repr()).replace("1.0", "*"),
+        data = client.search("{}".format(pref2_lib.ref.full_str()).replace("1.0", "*"),
                              remote="default")
         items = data["results"][0]["items"]
         expected = [str(self.ref)]
         self.assertEqual(expected, [i["recipe"]["id"] for i in items])
 
-        data = client.search("*{}".format(pref2_lib.ref.full_repr()).replace("1.0", "*"),
+        data = client.search("*{}".format(pref2_lib.ref.full_str()).replace("1.0", "*"),
                              remote="default")
         items = data["results"][0]["items"]
         expected = [str(self.ref)]
@@ -1162,7 +1162,7 @@ class SearchingPackagesWithRevisions(unittest.TestCase):
         self.assertIn("{} (No time)".format(pref.ref.revision), c_v1.out)
 
         pref_rev = pref.copy_with_revs(pref.ref.revision, None)
-        c_v1.run("search {} --revisions".format(pref_rev.full_repr()))
+        c_v1.run("search {} --revisions".format(pref_rev.full_str()))
         self.assertIn("{} (No time)".format(pref.revision), c_v1.out)
 
     def search_revisions_remotely_with_v1_server_test(self):
@@ -1180,7 +1180,7 @@ class SearchingPackagesWithRevisions(unittest.TestCase):
         self.assertIn("The remote doesn't support revisions", c_v1.out)
 
         pref_rev = pref.copy_with_revs(pref.ref.revision, None)
-        c_v1.run("search {} --revisions -r default".format(pref_rev.full_repr()),
+        c_v1.run("search {} --revisions -r default".format(pref_rev.full_str()),
                  assert_error=True)
         self.assertIn("The remote doesn't support revisions", c_v1.out)
 
@@ -1193,7 +1193,7 @@ class SearchingPackagesWithRevisions(unittest.TestCase):
         c_v2.upload_all(self.ref)
         pref_rev = pref.copy_with_revs(pref.ref.revision, None)
 
-        c_v2.run("search {} --revisions -r default".format(pref_rev.full_repr()))
+        c_v2.run("search {} --revisions -r default".format(pref_rev.full_str()))
         # I don't want to mock here because I want to run this test against Artifactory
         self.assertIn("83c38d3b4e5f1b8450434436eec31b00 (", c_v2.out)
         self.assertIn(" UTC)", c_v2.out)
@@ -1451,7 +1451,7 @@ class ServerRevisionsIndexes(unittest.TestCase):
                           ref3.revision)
 
         # Delete the latest from the server
-        self.c_v2.run("remove {} -r default -f".format(ref3.full_repr()))
+        self.c_v2.run("remove {} -r default -f".format(ref3.full_str()))
         revs = [r.revision for r in self.server.server_store.get_recipe_revisions(self.ref)]
         self.assertEqual(revs, [ref2.revision, ref1.revision])
         self.assertEqual(self.server.server_store.get_last_revision(self.ref).revision,
@@ -1493,7 +1493,7 @@ class ServerRevisionsIndexes(unittest.TestCase):
                           pref3.revision)
 
         # Delete the latest from the server
-        self.c_v2.run("remove {} -p {}#{} -r default -f".format(pref3.ref.full_repr(),
+        self.c_v2.run("remove {} -p {}#{} -r default -f".format(pref3.ref.full_str(),
                                                                 pref3.id, pref3.revision))
         revs = [r.revision
                 for r in self.server.server_store.get_package_revisions(pref)]
@@ -1513,9 +1513,9 @@ class ServerRevisionsIndexes(unittest.TestCase):
         ref3 = self.c_v2.export(self.ref, conanfile=GenConanfile().with_build_msg("I'm rev3"))
         self.c_v2.upload_all(ref3)
 
-        self.c_v2.run("remove {} -r default -f".format(ref1.full_repr()))
-        self.c_v2.run("remove {} -r default -f".format(ref2.full_repr()))
-        self.c_v2.run("remove {} -r default -f".format(ref3.full_repr()))
+        self.c_v2.run("remove {} -r default -f".format(ref1.full_str()))
+        self.c_v2.run("remove {} -r default -f".format(ref2.full_str()))
+        self.c_v2.run("remove {} -r default -f".format(ref3.full_str()))
 
         self.assertRaises(RecipeNotFoundException,
                           self.server.server_store.get_recipe_revisions, self.ref)
@@ -1543,7 +1543,7 @@ class ServerRevisionsIndexes(unittest.TestCase):
         self.c_v2.upload_all(self.ref)
 
         # Delete the package revisions (all of them have the same ref#rev and id)
-        command = "remove {} -p {}#{{}} -r default -f".format(pref3.ref.full_repr(), pref3.id)
+        command = "remove {} -p {}#{{}} -r default -f".format(pref3.ref.full_str(), pref3.id)
         self.c_v2.run(command.format(pref3.revision))
         self.c_v2.run(command.format(pref2.revision))
         self.c_v2.run(command.format(pref1.revision))

--- a/conans/test/integration/same_userchannel_test.py
+++ b/conans/test/integration/same_userchannel_test.py
@@ -93,14 +93,14 @@ class HelloReuseConan(ConanFile):
 
     def test_local_commands(self):
         self.client.run("install .", assert_error=True)
-        self.assertIn("ERROR: conanfile.py (Hello/0.1@None/None): "
+        self.assertIn("ERROR: conanfile.py (Hello/0.1): "
                       "Error in requirements() method, line 10", self.client.out)
         self.assertIn("ConanException: CONAN_USERNAME environment "
                       "variable not defined, but self.user is used", self.client.out)
 
         os.environ["CONAN_USERNAME"] = "lasote"
         self.client.run("install .", assert_error=True)
-        self.assertIn("ERROR: conanfile.py (Hello/0.1@None/None): "
+        self.assertIn("ERROR: conanfile.py (Hello/0.1): "
                       "Error in requirements() method, line 10", self.client.out)
         self.assertIn("ConanException: CONAN_CHANNEL environment "
                       "variable not defined, but self.channel is used", self.client.out)

--- a/conans/test/unittests/client/rest/rest_client_v2/test_get_package_manifest.py
+++ b/conans/test/unittests/client/rest/rest_client_v2/test_get_package_manifest.py
@@ -27,6 +27,6 @@ class GetPackageManifestTestCase(unittest.TestCase):
 
             # Exception tells me about the originating error and the request I was doing.
             self.assertIn("Error retrieving manifest file for package '{}'"
-                          " from remote ({})".format(pref.full_repr(), remote_url),
+                          " from remote ({})".format(pref.full_str(), remote_url),
                           str(exc.exception))
             self.assertIn("invalid literal for int() with base 10", str(exc.exception))

--- a/conans/test/unittests/tools/files_patch_test.py
+++ b/conans/test/unittests/tools/files_patch_test.py
@@ -185,7 +185,7 @@ class ToolsFilesPatchTest(unittest.TestCase):
         client.run("install .")
         client.run("build .", assert_error=True)
         self.assertIn("patch: error: no patch data found!", client.out)
-        self.assertIn("ERROR: conanfile.py (test/1.9.10@None/None): "
+        self.assertIn("ERROR: conanfile.py (test/1.9.10): "
                       "Error in build() method, line 12", client.out)
         self.assertIn("Failed to parse patch: string", client.out)
 

--- a/conans/test/utils/tools.py
+++ b/conans/test/utils/tools.py
@@ -913,7 +913,7 @@ class TurboTestClient(TestClient):
     def export(self, ref, conanfile=None, args=None, assert_error=False):
         conanfile = str(conanfile) if conanfile else str(GenConanfile())
         self.save({"conanfile.py": conanfile})
-        self.run("export . {} {}".format(ref.full_repr(), args or ""),
+        self.run("export . {} {}".format(ref.full_str(), args or ""),
                  assert_error=assert_error)
         rrev = self.cache.package_layout(ref).recipe_revision()
         return ref.copy_with_rev(rrev)
@@ -921,7 +921,7 @@ class TurboTestClient(TestClient):
     def create(self, ref, conanfile=None, args=None, assert_error=False):
         conanfile = str(conanfile) if conanfile else str(GenConanfile())
         self.save({"conanfile.py": conanfile})
-        self.run("create . {} {} --json {}".format(ref.full_repr(),
+        self.run("create . {} {} --json {}".format(ref.full_str(),
                                                    args or "", self.tmp_json_name),
                  assert_error=assert_error)
         rrev = self.cache.package_layout(ref).recipe_revision()
@@ -936,7 +936,7 @@ class TurboTestClient(TestClient):
 
     def upload_all(self, ref, remote=None, args=None, assert_error=False):
         remote = remote or list(self.servers.keys())[0]
-        self.run("upload {} -c --all -r {} {}".format(ref.full_repr(), remote, args or ""),
+        self.run("upload {} -c --all -r {} {}".format(ref.full_str(), remote, args or ""),
                  assert_error=assert_error)
         if not assert_error:
             remote_rrev, _ = self.servers[remote].server_store.get_last_revision(ref)
@@ -1115,7 +1115,7 @@ class GenConanfile(object):
     def _requirements_line(self):
         if not self._requirements:
             return ""
-        line = ", ".join(['"{}"'.format(r.full_repr()) for r in self._requirements])
+        line = ", ".join(['"{}"'.format(r.full_str()) for r in self._requirements])
         tmp = "requires = %s" % line
         return tmp
 

--- a/conans/util/tracer.py
+++ b/conans/util/tracer.py
@@ -72,7 +72,7 @@ def _file_document(name, path):
 def log_recipe_upload(ref, duration, files_uploaded, remote_name):
     files_uploaded = files_uploaded or {}
     files_uploaded = [_file_document(name, path) for name, path in files_uploaded.items()]
-    _append_action("UPLOADED_RECIPE", {"_id": str(ref),
+    _append_action("UPLOADED_RECIPE", {"_id": repr(ref.copy_clear_rev()),
                                        "duration": duration,
                                        "files": files_uploaded,
                                        "remote": remote_name})
@@ -82,7 +82,7 @@ def log_package_upload(pref, duration, files_uploaded, remote):
     """files_uploaded is a dict with relative path as keys and abs path as values"""
     files_uploaded = files_uploaded or {}
     files_uploaded = [_file_document(name, path) for name, path in files_uploaded.items()]
-    _append_action("UPLOADED_PACKAGE", {"_id": str(pref),
+    _append_action("UPLOADED_PACKAGE", {"_id": repr(pref.copy_clear_revs()),
                                         "duration": duration,
                                         "files": files_uploaded,
                                         "remote": remote.name})
@@ -92,7 +92,7 @@ def log_recipe_download(ref, duration, remote_name, files_downloaded):
     assert(isinstance(ref, ConanFileReference))
     files_downloaded = files_downloaded or {}
     files_downloaded = [_file_document(name, path) for name, path in files_downloaded.items()]
-    _append_action("DOWNLOADED_RECIPE", {"_id": str(ref),
+    _append_action("DOWNLOADED_RECIPE", {"_id": repr(ref.copy_clear_rev()),
                                          "duration": duration,
                                          "remote": remote_name,
                                          "files": files_downloaded})
@@ -102,7 +102,7 @@ def log_recipe_sources_download(ref, duration, remote_name, files_downloaded):
     assert(isinstance(ref, ConanFileReference))
     files_downloaded = files_downloaded or {}
     files_downloaded = [_file_document(name, path) for name, path in files_downloaded.items()]
-    _append_action("DOWNLOADED_RECIPE_SOURCES", {"_id": str(ref),
+    _append_action("DOWNLOADED_RECIPE_SOURCES", {"_id": repr(ref.copy_clear_rev()),
                                                  "duration": duration,
                                                  "remote": remote_name,
                                                  "files": files_downloaded})
@@ -111,7 +111,7 @@ def log_recipe_sources_download(ref, duration, remote_name, files_downloaded):
 def log_package_download(pref, duration, remote, files_downloaded):
     files_downloaded = files_downloaded or {}
     files_downloaded = [_file_document(name, path) for name, path in files_downloaded.items()]
-    _append_action("DOWNLOADED_PACKAGE", {"_id": str(pref),
+    _append_action("DOWNLOADED_PACKAGE", {"_id": repr(pref.copy_clear_revs()),
                                           "duration": duration,
                                           "remote": remote.name,
                                           "files": files_downloaded})
@@ -119,18 +119,18 @@ def log_package_download(pref, duration, remote, files_downloaded):
 
 def log_recipe_got_from_local_cache(ref):
     assert(isinstance(ref, ConanFileReference))
-    _append_action("GOT_RECIPE_FROM_LOCAL_CACHE", {"_id": str(ref)})
+    _append_action("GOT_RECIPE_FROM_LOCAL_CACHE", {"_id": repr(ref.copy_clear_rev())})
 
 
 def log_package_got_from_local_cache(pref):
     assert(isinstance(pref, PackageReference))
-    _append_action("GOT_PACKAGE_FROM_LOCAL_CACHE", {"_id": str(pref)})
+    _append_action("GOT_PACKAGE_FROM_LOCAL_CACHE", {"_id": repr(pref.copy_clear_revs())})
 
 
 def log_package_built(pref, duration, log_run=None):
     assert(isinstance(pref, PackageReference))
     _append_action("PACKAGE_BUILT_FROM_SOURCES",
-                   {"_id": str(pref), "duration": duration, "log": log_run})
+                   {"_id": repr(pref.copy_clear_revs()), "duration": duration, "log": log_run})
 
 
 def log_client_rest_api_call(url, method, duration, headers):

--- a/conans/util/tracer.py
+++ b/conans/util/tracer.py
@@ -11,6 +11,9 @@ from conans.model.ref import ConanFileReference, PackageReference
 from conans.util.files import md5sum, sha1sum
 from conans.util.log import logger
 
+
+# FIXME: Conan 2.0 the traces should have all the revisions information also.
+
 TRACER_ACTIONS = ["UPLOADED_RECIPE", "UPLOADED_PACKAGE",
                   "DOWNLOADED_RECIPE", "DOWNLOADED_RECIPE_SOURCES", "DOWNLOADED_PACKAGE",
                   "PACKAGE_BUILT_FROM_SOURCES",


### PR DESCRIPTION
Changelog: Fix: Incomplete references (for local conanfile.py files) are not printed with `@None/None` anymore.
Docs: omit

- Preparation for the PR about omitting user and channel
- Improved representation of references:
     - `repr(ref)` as the python recommends, is the complete representation of a reference, including the "None" if they are there.
     - `str(ref)` is the "print" representation, it omits the `None` user and channel if present, without revisions
     - a method `ref.full_str()` is introduced to nicely print a reference with revisions
     - The `full_repr()` has been removed, by definition `repr` should be always "full".
     - Some `str(ref)` that was used internally in data structures, e.g, dict keys, has been replacing (compatibility) with `repr(ref.copy_clear_rev())` because the meaning is more correct.

@PYVERS: Macos@py27, Windows@py36, Linux@py27, py34
@TAGS: svn, slow
@REVISIONS: 1