### PR TITLE
Added deps_cpp_info modification test

### DIFF
--- a/conans/test/integration/package_info_test.py
+++ b/conans/test/integration/package_info_test.py
@@ -1,7 +1,10 @@
+import os
+import textwrap
 import unittest
 
+from conans.model.ref import ConanFileReference, PackageReference
 from conans.paths import CONANFILE, CONANFILE_TXT
-from conans.test.utils.tools import TestClient
+from conans.test.utils.tools import TestClient, NO_SETTINGS_PACKAGE_ID
 
 
 class TestPackageInfo(unittest.TestCase):
@@ -46,3 +49,73 @@ class HelloConan(ConanFile):
 
         client.run("install . -o *:switch=0 --build Lib3")
         self.assertIn("Lib3/1.0@conan/stable: WARN: Env var MYVAR=foo", client.out)
+
+    def deps_cpp_info_test(self):
+        """
+        Check that deps_cpp_info information can be modified. This should be fixed
+        """
+        conanfile_dep = textwrap.dedent("""
+            from conans import ConanFile
+
+            class Conan(ConanFile):
+                name = "dep"
+                version = "1.0"
+
+                def package_info(self):
+                    self.cpp_info.filter_empty = False
+                    self.cpp_info.includedirs.append("my_include")
+                    self.cpp_info.defines.append("SOMETHING")
+                    self.cpp_info.libs = ["my_lib"]
+            """)
+
+        conanfile_direct_dep = textwrap.dedent("""
+            from conans import ConanFile
+
+            class Conan(ConanFile):
+                name = "direct_dep"
+                version = "1.0"
+                requires = "dep/1.0@user/channel"
+
+                def build(self):
+                    self.output.info("%s" % self.deps_cpp_info.includedirs)
+                    self.output.info("%s" % self.deps_cpp_info.defines)
+                    self.output.info("%s" % self.deps_cpp_info.libs)
+                    self.deps_cpp_info["dep"].defines = ["ELSE"]
+                    self.deps_cpp_info["dep"].includedirs = ["other_include"]
+                    self.deps_cpp_info["dep"].libs.append("other_lib")
+            """)
+
+        conanfile = textwrap.dedent("""
+            from conans import ConanFile
+
+            class Conan(ConanFile):
+                name = "consumer"
+                version = "1.0"
+                requires = "direct_dep/1.0@user/channel"
+
+                def build(self):
+                    self.output.info("%s" % self.deps_cpp_info.includedirs)
+                    self.output.info("%s" % self.deps_cpp_info.defines)
+                    self.output.info("%s" % self.deps_cpp_info.libs)
+            """)
+
+        client = TestClient()
+        client.save({"conanfile_dep.py": conanfile_dep,
+                     "conanfile_direct_dep.py": conanfile_direct_dep,
+                     "conanfile.py": conanfile})
+        client.run("export conanfile_dep.py user/channel")
+        client.run("export conanfile_direct_dep.py user/channel")
+        client.run("create conanfile.py user/channel --build missing")
+        dep_pref = PackageReference(ConanFileReference("dep", "1.0", "user", "channel"),
+                                    NO_SETTINGS_PACKAGE_ID)
+        package_folder = client.cache.package_layout(dep_pref.ref).package(dep_pref)
+        expected_includes = [os.path.join(package_folder, "include"),
+                             os.path.join(package_folder, "my_include")]
+        self.assertIn("direct_dep/1.0@user/channel: %s" % expected_includes, client.out)
+        self.assertIn("direct_dep/1.0@user/channel: %s" % ["SOMETHING"], client.out)
+        self.assertIn("direct_dep/1.0@user/channel: %s" % ["my_lib"], client.out)
+        expected_includes.append(os.path.join(package_folder, "other_include"))
+        self.assertNotIn("consumer/1.0@user/channel: %s"
+                         % os.path.join(package_folder, "other_include"), client.out)  # OK
+        self.assertIn("consumer/1.0@user/channel: %s" % ["ELSE"], client.out)  # FIXME
+        self.assertIn("consumer/1.0@user/channel: %s" % ["my_lib", "other_lib"], client.out)  # FIXME


### PR DESCRIPTION
Changelog: omit
Docs: omit

This test shows that the current ``DepsCppInfo`` class allows modification of information of the computed graph affecting the downstream consumers. This behavior is fixed in the PR #5408

- [x] Refer to the issue that supports this Pull Request: Related to PR #5408
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 

<sup>**Note:** By default this PR will skip the slower tests and will use a limited set of python versions. Check [here](https://github.com/conan-io/conan/blob/develop/.github/PR_INCREASE_TESTING.md) how to increase the testing level by writing some tags in the current PR body text.</sup>
