### PR TITLE
remove ProcessedProfile class

### DIFF
--- a/conans/client/graph/graph_manager.py
+++ b/conans/client/graph/graph_manager.py
@@ -8,7 +8,6 @@ from conans.client.graph.graph import BINARY_BUILD, Node,\
     RECIPE_CONSUMER, RECIPE_VIRTUAL, BINARY_EDITABLE
 from conans.client.graph.graph_binaries import GraphBinariesAnalyzer
 from conans.client.graph.graph_builder import DepsGraphBuilder
-from conans.client.loader import ProcessedProfile
 from conans.errors import ConanException, conanfile_exception_formatter
 from conans.model.conan_file import get_env_context_manager
 from conans.model.graph_info import GraphInfo
@@ -74,7 +73,7 @@ class GraphManager(object):
             profile.process_settings(self._cache, preprocess=False)
             # This is the hack of recovering the options from the graph_info
             profile.options.update(graph_info.options)
-        processed_profile = ProcessedProfile(profile, None)
+        processed_profile = profile
         if conanfile_path.endswith(".py"):
             lock_python_requires = None
             if graph_lock and not test:  # Only lock python requires if it is not test_package
@@ -117,7 +116,8 @@ class GraphManager(object):
 
         # Computing the full dependency graph
         profile = graph_info.profile
-        processed_profile = ProcessedProfile(profile, create_reference)
+        processed_profile = profile
+        processed_profile.dev_reference = create_reference
         ref = None
         graph_lock = graph_info.graph_lock
         if isinstance(reference, list):  # Install workspace with multiple root nodes

--- a/conans/client/loader.py
+++ b/conans/client/loader.py
@@ -20,17 +20,6 @@ from conans.paths import DATA_YML
 from conans.util.files import load
 
 
-class ProcessedProfile(object):
-    def __init__(self, profile, create_reference=None):
-        self._settings = profile.processed_settings
-        self._user_options = profile.options.copy()
-
-        self._package_settings = profile.package_settings_values
-        self._env_values = profile.env_values
-        # Make sure the paths are normalized first, so env_values can be just a copy
-        self._dev_reference = create_reference
-
-
 class ConanFileLoader(object):
     def __init__(self, runner, output, python_requires):
         self._runner = runner
@@ -64,7 +53,8 @@ class ConanFileLoader(object):
         except ConanException as e:
             raise ConanException("Error loading conanfile at '{}': {}".format(conanfile_path, e))
 
-    def _load_data(self, conanfile_path):
+    @staticmethod
+    def _load_data(conanfile_path):
         data_path = os.path.join(os.path.dirname(conanfile_path), DATA_YML)
         if not os.path.exists(data_path):
             return None
@@ -104,14 +94,14 @@ class ConanFileLoader(object):
     def _initialize_conanfile(conanfile, processed_profile):
         # Prepare the settings for the loaded conanfile
         # Mixing the global settings with the specified for that name if exist
-        tmp_settings = processed_profile._settings.copy()
-        if (processed_profile._package_settings and
-                conanfile.name in processed_profile._package_settings):
+        tmp_settings = processed_profile.processed_settings.copy()
+        if (processed_profile.package_settings_values and
+                conanfile.name in processed_profile.package_settings_values):
             # Update the values, keeping old ones (confusing assign)
-            values_tuple = processed_profile._package_settings[conanfile.name]
+            values_tuple = processed_profile.package_settings_values[conanfile.name]
             tmp_settings.values = Values.from_list(values_tuple)
 
-        conanfile.initialize(tmp_settings, processed_profile._env_values)
+        conanfile.initialize(tmp_settings, processed_profile.env_values)
 
     def load_consumer(self, conanfile_path, processed_profile, name=None, version=None, user=None,
                       channel=None, test=None, lock_python_requires=None):
@@ -140,10 +130,10 @@ class ConanFileLoader(object):
 
             # The consumer specific
             conanfile.develop = True
-            processed_profile._user_options.descope_options(conanfile.name)
-            conanfile.options.initialize_upstream(processed_profile._user_options,
+            processed_profile.user_options.descope_options(conanfile.name)
+            conanfile.options.initialize_upstream(processed_profile.user_options,
                                                   name=conanfile.name)
-            processed_profile._user_options.clear_unscoped_options()
+            processed_profile.user_options.clear_unscoped_options()
 
             return conanfile
         except ConanInvalidConfiguration:
@@ -156,7 +146,7 @@ class ConanFileLoader(object):
         conanfile_class.name = ref.name
         conanfile_class.version = ref.version
         conanfile = conanfile_class(self._output, self._runner, str(ref), ref.user, ref.channel)
-        if processed_profile._dev_reference and processed_profile._dev_reference == ref:
+        if processed_profile.dev_reference and processed_profile.dev_reference == ref:
             conanfile.develop = True
         try:
             self._initialize_conanfile(conanfile, processed_profile)
@@ -178,11 +168,11 @@ class ConanFileLoader(object):
 
     def _parse_conan_txt(self, contents, path, display_name, processed_profile):
         conanfile = ConanFile(self._output, self._runner, display_name)
-        conanfile.initialize(Settings(), processed_profile._env_values)
+        conanfile.initialize(Settings(), processed_profile.env_values)
         # It is necessary to copy the settings, because the above is only a constraint of
         # conanfile settings, and a txt doesn't define settings. Necessary for generators,
         # as cmake_multi, that check build_type.
-        conanfile.settings = processed_profile._settings.copy_values()
+        conanfile.settings = processed_profile.processed_settings.copy_values()
 
         try:
             parser = ConanFileTextLoader(contents)
@@ -201,7 +191,7 @@ class ConanFileLoader(object):
 
         options = OptionsValues.loads(parser.options)
         conanfile.options.values = options
-        conanfile.options.initialize_upstream(processed_profile._user_options)
+        conanfile.options.initialize_upstream(processed_profile.user_options)
 
         # imports method
         conanfile.imports = parser.imports_method(conanfile)
@@ -212,8 +202,9 @@ class ConanFileLoader(object):
         # If user don't specify namespace in options, assume that it is
         # for the reference (keep compatibility)
         conanfile = ConanFile(self._output, self._runner, display_name="virtual")
-        conanfile.initialize(processed_profile._settings.copy(), processed_profile._env_values)
-        conanfile.settings = processed_profile._settings.copy_values()
+        conanfile.initialize(processed_profile.processed_settings.copy(),
+                             processed_profile.env_values)
+        conanfile.settings = processed_profile.processed_settings.copy_values()
 
         for reference in references:
             conanfile.requires.add(repr(reference))  # Convert to string necessary
@@ -221,11 +212,11 @@ class ConanFileLoader(object):
         #   conan install zlib/1.2.8@lasote/stable -o shared=True
         if scope_options:
             assert len(references) == 1
-            processed_profile._user_options.scope_options(references[0].name)
+            processed_profile.user_options.scope_options(references[0].name)
         if build_requires_options:
             conanfile.options.initialize_upstream(build_requires_options)
         else:
-            conanfile.options.initialize_upstream(processed_profile._user_options)
+            conanfile.options.initialize_upstream(processed_profile.user_options)
 
         conanfile.generators = []  # remove the default txt generator
         return conanfile

--- a/conans/model/profile.py
+++ b/conans/model/profile.py
@@ -13,13 +13,32 @@ class Profile(object):
     """
 
     def __init__(self):
-        # Sections
-        self.processed_settings = None
+        # Input sections, as defined by user profile files and command line
         self.settings = OrderedDict()
         self.package_settings = defaultdict(OrderedDict)
         self.env_values = EnvValues()
         self.options = OptionsValues()
         self.build_requires = OrderedDict()  # ref pattern: list of ref
+
+        # Cached processed values
+        self.processed_settings = None  # Settings with values, and smart completion
+        self._user_options = None
+        self._package_settings_values = None
+        self.dev_reference = None  # Reference of the package being develop
+
+    @property
+    def user_options(self):
+        if self._user_options is None:
+            self._user_options = self.options.copy()
+        return self._user_options
+
+    @property
+    def package_settings_values(self):
+        if self._package_settings_values is None:
+            self._package_settings_values = {}
+            for pkg, settings in self.package_settings.items():
+                self._package_settings_values[pkg] = list(settings.items())
+        return self._package_settings_values
 
     def process_settings(self, cache, preprocess=True):
         self.processed_settings = cache.settings.copy()
@@ -42,13 +61,6 @@ class Profile(object):
                     raise ConanException("Error in resulting settings for package"
                                          " '{}': {}\n{}".format(pkg, e, '\n'.join(pkg_profile)))
                 # TODO: Assign the _validated_ settings and do not compute again
-
-    @property
-    def package_settings_values(self):
-        result = {}
-        for pkg, settings in self.package_settings.items():
-            result[pkg] = list(settings.items())
-        return result
 
     def dumps(self):
         result = ["[settings]"]

--- a/conans/test/unittests/client/conanfile_loader_test.py
+++ b/conans/test/unittests/client/conanfile_loader_test.py
@@ -225,20 +225,21 @@ class MyTest(ConanFile):
         profile.package_settings = {"MyPackage": OrderedDict([("os", "Windows")])}
         loader = ConanFileLoader(None, TestBufferConanOutput(), ConanPythonRequire(None, None))
 
-        recipe = loader.load_consumer(conanfile_path,
-                                      test_processed_profile(profile))
+        recipe = loader.load_consumer(conanfile_path, profile)
         self.assertEqual(recipe.settings.os, "Windows")
 
         # Apply Linux for MyPackage
+        profile = Profile()
+        profile.processed_settings = Settings({"os": ["Windows", "Linux"]})
         profile.package_settings = {"MyPackage": OrderedDict([("os", "Linux")])}
-        recipe = loader.load_consumer(conanfile_path,
-                                      test_processed_profile(profile))
+        recipe = loader.load_consumer(conanfile_path, profile)
         self.assertEqual(recipe.settings.os, "Linux")
 
         # If the package name is different from the conanfile one, it wont apply
+        profile = Profile()
+        profile.processed_settings = Settings({"os": ["Windows", "Linux"]})
         profile.package_settings = {"OtherPACKAGE": OrderedDict([("os", "Linux")])}
-        recipe = loader.load_consumer(conanfile_path,
-                                      test_processed_profile(profile))
+        recipe = loader.load_consumer(conanfile_path, profile)
         self.assertIsNone(recipe.settings.os.value)
 
 

--- a/conans/test/unittests/client/loader_test.py
+++ b/conans/test/unittests/client/loader_test.py
@@ -18,34 +18,8 @@ class LoadConanfileTxtTest(unittest.TestCase):
     def setUp(self):
         settings = Settings()
         self.profile = Profile()
-        self.profile._settings = settings
-        self.profile._user_options = None
-        self.profile._env_values = None
-        self.conanfile_txt_path = os.path.join(temp_folder(), "conanfile.txt")
-        output = TestBufferConanOutput()
-        self.loader = ConanFileLoader(None, output, None)
+        self.profile.processed_settings = settings
 
-    def env_test(self):
-        env_values = EnvValues()
-        env_values.add("PREPEND_PATH", ["hello", "bye"])
-        env_values.add("VAR", ["var_value"])
-        self.profile._env_values = env_values
-        save(self.conanfile_txt_path, "")
-        conanfile = self.loader.load_conanfile_txt(self.conanfile_txt_path, self.profile)
-        self.assertEqual(conanfile.env, {"PREPEND_PATH": ["hello", "bye"], "VAR": ["var_value"]})
-
-
-class LoadConanfileTest(unittest.TestCase):
-
-    def setUp(self):
-        settings = Settings()
-        self.profile = Profile()
-        self.profile._settings = settings
-        self.profile._user_options = None
-        self.profile._env_values = None
-        self.profile._dev_reference = None
-        self.profile._package_settings = None
-        self.conanfile_path = os.path.join(temp_folder(), "conanfile.py")
         output = TestBufferConanOutput()
         self.loader = ConanFileLoader(None, output, ConanPythonRequire(None, None))
 
@@ -53,8 +27,19 @@ class LoadConanfileTest(unittest.TestCase):
         env_values = EnvValues()
         env_values.add("PREPEND_PATH", ["hello", "bye"])
         env_values.add("VAR", ["var_value"])
-        self.profile._env_values = env_values
-        save(self.conanfile_path,
+        self.profile.env_values = env_values
+        conanfile_txt_path = os.path.join(temp_folder(), "conanfile.txt")
+        save(conanfile_txt_path, "")
+        conanfile = self.loader.load_conanfile_txt(conanfile_txt_path, self.profile)
+        self.assertEqual(conanfile.env, {"PREPEND_PATH": ["hello", "bye"], "VAR": ["var_value"]})
+
+    def conanfile_py_env_test(self):
+        conanfile_path = os.path.join(temp_folder(), "conanfile.py")
+        env_values = EnvValues()
+        env_values.add("PREPEND_PATH", ["hello", "bye"])
+        env_values.add("VAR", ["var_value"])
+        self.profile.env_values = env_values
+        save(conanfile_path,
              textwrap.dedent("""
                 from conans import ConanFile
 
@@ -63,5 +48,5 @@ class LoadConanfileTest(unittest.TestCase):
                     version = "1.0"
              """))
         ref = ConanFileReference("hello", "1.0", "user", "channel")
-        conanfile = self.loader.load_conanfile(self.conanfile_path, self.profile, ref)
+        conanfile = self.loader.load_conanfile(conanfile_path, self.profile, ref)
         self.assertEqual(conanfile.env, {"PREPEND_PATH": ["hello", "bye"], "VAR": ["var_value"]})

--- a/conans/test/unittests/model/profile_test.py
+++ b/conans/test/unittests/model/profile_test.py
@@ -65,6 +65,7 @@ MyPackage:os=Windows
         self.assertEqual(np.package_settings_values,
                          {"MyPackage": [("os", "Windows"), ("OTHER", "2")]})
 
+        np._package_settings_values = None  # invalidate caching
         np.update_package_settings({"MyPackage": [("compiler", "2"), ("compiler.version", "3")]})
         self.assertEqual(np.package_settings_values,
                          {"MyPackage": [("os", "Windows"), ("OTHER", "2"),

--- a/conans/test/utils/tools.py
+++ b/conans/test/utils/tools.py
@@ -30,7 +30,6 @@ from conans.client.cache.remote_registry import Remotes
 from conans.client.command import Command
 from conans.client.conan_api import Conan
 from conans.client.hook_manager import HookManager
-from conans.client.loader import ProcessedProfile
 from conans.client.output import ConanOutput
 from conans.client.rest.conan_requester import ConanRequester
 from conans.client.rest.uploader_downloader import IterableToFileAdapter
@@ -91,7 +90,7 @@ def test_processed_profile(profile=None, settings=None):
         profile = Profile()
     if profile.processed_settings is None:
         profile.processed_settings = settings or Settings()
-    return ProcessedProfile(profile=profile)
+    return profile
 
 
 class TestingResponse(object):


### PR DESCRIPTION
Changelog: Omit
Docs: Omit

@tags: slow, svn


this was a pending refactor to remove the ProcessedProfile class that reads a bit artificial. @jgsogo did a try to remove it, but without implementing the caching, this PR is doing that.

Please @lasote check if the code is more clear this way or not:

- Removed some ugly access of private members
- Doing caching directly in Profile
- Did NOT do a rename ``processed_profile`` => ``profile`` variables, to avoid excessive noise in the PR, can be done later