### PR TITLE
Fixed GCC 5 warn about libcxx and tests

### DIFF
--- a/conans/client/conf/detect.py
+++ b/conans/client/conf/detect.py
@@ -44,10 +44,6 @@ def _gcc_compiler(output, compiler_exe="gcc"):
         # number ("7.1.1").
         if installed_version:
             output.success("Found %s %s" % (compiler, installed_version))
-            major = installed_version.split(".")[0]
-            if int(major) >= 5:
-                output.info("gcc>=5, using the major as version")
-                installed_version = major
             return compiler, installed_version
     except Exception:
         return None
@@ -65,10 +61,6 @@ def _clang_compiler(output, compiler_exe="clang"):
         installed_version = re.search("([0-9]+\.[0-9])", out).group()
         if installed_version:
             output.success("Found %s %s" % (compiler, installed_version))
-            major = installed_version.split(".")[0]
-            if int(major) >= 8 and compiler == "clang":
-                output.info("clang>=8, using the major as version")
-                installed_version = major
             return compiler, installed_version
     except Exception:
         return None
@@ -125,6 +117,17 @@ def _get_default_compiler(output):
         return gcc or clang
 
 
+def _get_profile_compiler_version(compiler, version, output):
+    major = version.split(".")[0]
+    if compiler == "clang" and int(major) >= 8:
+        output.info("clang>=8, using the major as version")
+        return major
+    elif compiler == "gcc" and int(major) >= 5:
+        output.info("gcc>=5, using the major as version")
+        return major
+    return version
+
+
 def _detect_compiler_version(result, output, profile_path):
     try:
         compiler, version = _get_default_compiler(output)
@@ -134,7 +137,8 @@ def _detect_compiler_version(result, output, profile_path):
         output.error("Unable to find a working compiler")
     else:
         result.append(("compiler", compiler))
-        result.append(("compiler.version", version))
+        result.append(("compiler.version",
+                       _get_profile_compiler_version(compiler, version, output)))
         if compiler == "apple-clang":
             result.append(("compiler.libcxx", "libc++"))
         elif compiler == "gcc":

--- a/conans/test/functional/command/profile_test.py
+++ b/conans/test/functional/command/profile_test.py
@@ -12,11 +12,6 @@ class ProfileTest(unittest.TestCase):
     def reuse_output_test(self):
         client = TestClient()
         client.run("profile new myprofile --detect")
-
-        if "WARNING: GCC OLD ABI COMPATIBILITY" in client.out:
-            self.assertIn("edit the myprofile profile at", client.out)
-            self.assertIn("profiles/myprofile", client.out)
-
         client.run("profile update options.Pkg:myoption=123 myprofile")
         client.run("profile update env.Pkg2:myenv=123 myprofile")
         client.run("profile show myprofile")
@@ -75,8 +70,9 @@ class ProfileTest(unittest.TestCase):
         client = TestClient()
         client.run("profile new ./MyProfile --detect")
         if "WARNING: GCC OLD ABI COMPATIBILITY" in client.out:
-            self.assertIn("edit the MyProfile profile at", client.out)
-            self.assertIn(os.path.join(client.current_folder, "MyProfile"), client.out)
+            self.assertIn("Or edit '{}/MyProfile' and "
+                          "set compiler.libcxx=libstdc++11".format(client.current_folder),
+                          client.out)
 
         pr_path = os.path.join(client.current_folder, "MyProfile")
 


### PR DESCRIPTION
Changelog: Bugfix: When a profile was detected, for GCC 5.X the warning message about the default `libcxx` was not shown.
Docs: omit

When GCC == 5.X, the comparison ` if Version(version) >= Version("5.1"):` was never true, because `version` had always the major version only. In CI the GCC version is `5.3`, so the tests were never doing the assert because the warning was never printed.