### PR TITLE
Flag to skip auth if already authenticated

### DIFF
--- a/conans/client/cmd/user.py
+++ b/conans/client/cmd/user.py
@@ -18,6 +18,12 @@ def users_list(localdb_file, remotes):
     return remotes_info
 
 
+def token_present(localdb_file, remote, user):
+    localdb = LocalDB.create(localdb_file)
+    current_user, token = localdb.get_login(remote.url)
+    return token is not None and (user is None or user == current_user)
+
+
 def users_clean(localdb_file):
     LocalDB.create(localdb_file, clean=True)
 

--- a/conans/client/command.py
+++ b/conans/client/command.py
@@ -1112,11 +1112,15 @@ class Command(object):
                             action=OnceArgument)
         parser.add_argument("-j", "--json", default=None, action=OnceArgument,
                             help='json file path where the user list will be written to')
+        parser.add_argument("-s", "--skip-auth", default=False, action='store_true',
+                            help='Skips the authentication with the server if it '
+                                 'have access credentials. It doesn\'t check if the '
+                                 'current credentials are valid')
         args = parser.parse_args(*args)
 
-        if args.clean and any((args.name, args.remote, args.password, args.json)):
+        if args.clean and any((args.name, args.remote, args.password, args.json, args.skip_auth)):
             raise ConanException("'--clean' argument cannot be used together with 'name', "
-                                 "'--password', '--remote' or '--json'")
+                                 "'--password', '--remote', '--json' or '--skip.auth'")
         elif args.json and any((args.name, args.password)):
             raise ConanException("'--json' cannot be used together with 'name' or '--password'")
 
@@ -1138,7 +1142,8 @@ class Command(object):
                 password = args.password
                 remote_name, prev_user, user = self._conan.authenticate(name,
                                                                         remote_name=remote_name,
-                                                                        password=password)
+                                                                        password=password,
+                                                                        skip_auth=args.skip_auth)
 
                 self._outputer.print_user_set(remote_name, prev_user, user)
         except ConanException as exc:

--- a/conans/client/command.py
+++ b/conans/client/command.py
@@ -1113,9 +1113,9 @@ class Command(object):
         parser.add_argument("-j", "--json", default=None, action=OnceArgument,
                             help='json file path where the user list will be written to')
         parser.add_argument("-s", "--skip-auth", default=False, action='store_true',
-                            help='Skips the authentication with the server if it '
-                                 'have access credentials. It doesn\'t check if the '
-                                 'current credentials are valid')
+                            help='Skips the authentication with the server if there are local '
+                                 'stored credentials. It doesn\'t check if the '
+                                 'current credentials are valid or not')
         args = parser.parse_args(*args)
 
         if args.clean and any((args.name, args.remote, args.password, args.json, args.skip_auth)):

--- a/conans/client/conan_api.py
+++ b/conans/client/conan_api.py
@@ -16,7 +16,7 @@ from conans.client.cmd.profile import (cmd_profile_create, cmd_profile_delete_ke
 from conans.client.cmd.search import Search
 from conans.client.cmd.test import PackageTester
 from conans.client.cmd.uploader import CmdUpload
-from conans.client.cmd.user import user_set, users_clean, users_list
+from conans.client.cmd.user import user_set, users_clean, users_list, token_present
 from conans.client.conf import ConanClientConfigParser
 from conans.client.graph.graph import RECIPE_EDITABLE
 from conans.client.graph.graph_manager import GraphManager
@@ -817,10 +817,16 @@ class ConanAPIV1(object):
                  self._user_io, self._remote_manager, self._loader, remotes, force=force)
 
     @api_method
-    def authenticate(self, name, password, remote_name):
+    def authenticate(self, name, password, remote_name, skip_auth=False):
+        # FIXME: 2.0 rename "name" to "user".
+        # FIXME: 2.0 probably we should return also if we have been authenticated or not (skipped)
+        remote = self.get_remote_by_name(remote_name)
+
+        if skip_auth and token_present(self._cache.localdb, remote, name):
+            return remote.name, name, name
         if not password:
             name, password = self._user_io.request_login(remote_name=remote_name, username=name)
-        remote = self.get_remote_by_name(remote_name)
+
         _, remote_name, prev_user, user = self._remote_manager.authenticate(remote, name, password)
         return remote_name, prev_user, user
 

--- a/conans/client/conan_api.py
+++ b/conans/client/conan_api.py
@@ -820,6 +820,10 @@ class ConanAPIV1(object):
     def authenticate(self, name, password, remote_name, skip_auth=False):
         # FIXME: 2.0 rename "name" to "user".
         # FIXME: 2.0 probably we should return also if we have been authenticated or not (skipped)
+        # FIXME: 2.0 remove the skip_auth argument, that behavior will be done by:
+        #      "conan user USERNAME -r remote" that will use the local credentials (and verify that are valid)
+        #      against the server. Currently it only "associate" the USERNAME with the remote without
+        #      checking anything else
         remote = self.get_remote_by_name(remote_name)
 
         if skip_auth and token_present(self._cache.localdb, remote, name):

--- a/conans/test/functional/command/user_test.py
+++ b/conans/test/functional/command/user_test.py
@@ -3,6 +3,10 @@ import os
 import unittest
 from collections import OrderedDict
 
+import mock
+
+from conans.client.tools import environment_append
+
 from conans.client.store.localdb import LocalDB
 from conans.test.utils.tools import TestClient, TestServer
 from conans.util.files import load
@@ -350,3 +354,32 @@ class ConanLib(ConanFile):
                                 "user_name": "lasote"
                             }
                         ]}, info)
+
+    def test_skip_auth(self):
+        default_server = TestServer(users={"lasote": "mypass", "danimtb": "passpass"})
+        servers = OrderedDict()
+        servers["default"] = default_server
+        client = TestClient(servers=servers)
+        # Regular auth
+        client.run("user lasote -r default -p mypass")
+
+        # Now skip the auth
+        client.run("user lasote -r default -p BAD_PASS --skip-auth")
+        self.assertIn("User of remote 'default' is already 'lasote'", client.out)
+
+        client.run("user lasote -r default -p BAD_PASS", assert_error=True)
+        self.assertIn("Wrong user or password", client.out)
+
+        # Login again correctly
+        client.run("user lasote -r default -p mypass")
+
+        # If we try to skip the auth for a user not logged, it will fail, because
+        # we don't have credentials for that user
+        client.run("user danimtb -r default -p BAD_PASS --skip-auth", assert_error=True)
+        self.assertIn("Wrong user or password", client.out)
+
+        # Login again correctly
+        client.run("user lasote -r default -p mypass")
+
+        # Now try to skip without specifying user
+        client.run("user -r default -p BAD_PASS --skip-auth")

--- a/conans/test/functional/command/user_test.py
+++ b/conans/test/functional/command/user_test.py
@@ -3,10 +3,6 @@ import os
 import unittest
 from collections import OrderedDict
 
-import mock
-
-from conans.client.tools import environment_append
-
 from conans.client.store.localdb import LocalDB
 from conans.test.utils.tools import TestClient, TestServer
 from conans.util.files import load
@@ -218,7 +214,6 @@ class ConanLib(ConanFile):
         self.assertNotIn("[Authenticated]", client.out)
 
     def json_test(self):
-
         def _compare_dicts(first_dict, second_dict):
             self.assertTrue(set(first_dict), set(second_dict))
 


### PR DESCRIPTION
Changelog: Feature: New parameter ``--skip-auth`` for the ``conan user`` command to avoid trying to authenticate when the client already has credentials stored. 
Docs: https://github.com/conan-io/docs/pull/1377

Close https://github.com/conan-io/conan/issues/5443