### PR TITLE
remove clean modified command

### DIFF
--- a/conans/client/command.py
+++ b/conans/client/command.py
@@ -1708,9 +1708,6 @@ class Command(object):
         build_order_cmd.add_argument("--json", action=OnceArgument,
                                      help="generate output file in json format")
 
-        clean_cmd = subparsers.add_parser('clean-modified', help='Clean modified')
-        clean_cmd.add_argument('lockfile', help='lockfile folder')
-
         lock_cmd = subparsers.add_parser('lock', help='create a lockfile')
         lock_cmd.add_argument("path_or_reference", help="Path to a folder containing a recipe"
                               " (conanfile.py or conanfile.txt) or to a recipe file. e.g., "
@@ -1732,8 +1729,6 @@ class Command(object):
             if args.json:
                 json_file = _make_abs_path(args.json)
                 save(json_file, json.dumps(build_order, indent=True))
-        elif args.subcommand == "clean-modified":
-            self._conan.lock_clean_modified(args.lockfile)
         elif args.subcommand == "lock":
             self._conan.create_lock(args.path_or_reference,
                                     remote_name=args.remote,

--- a/conans/client/conan_api.py
+++ b/conans/client/conan_api.py
@@ -1239,14 +1239,6 @@ class ConanAPIV1(object):
         return deps_graph.new_build_order()
 
     @api_method
-    def lock_clean_modified(self, lockfile, cwd=None):
-        cwd = cwd or os.getcwd()
-        lockfile = _make_abs_path(lockfile, cwd)
-        lock = GraphLockFile.load(lockfile)
-        lock.graph_lock.clean_modified()
-        lock.save(lockfile)
-
-    @api_method
     def create_lock(self, reference, remote_name=None, settings=None, options=None, env=None,
                     profile_names=None, update=False, lockfile=None, build=None,):
         reference, graph_info = self._info_args(reference, None, profile_names,

--- a/conans/client/installer.py
+++ b/conans/client/installer.py
@@ -437,7 +437,7 @@ class BinaryInstaller(object):
         builder = _PackageBuilder(self._cache, output, self._hook_manager, self._remote_manager)
         pref = builder.build_package(node, keep_build, self._recorder, remotes)
         if node.graph_lock_node:
-            node.graph_lock_node.modified = True
+            node.graph_lock_node.modified = BINARY_BUILD
         return pref
 
     @staticmethod

--- a/conans/model/graph_lock.py
+++ b/conans/model/graph_lock.py
@@ -96,7 +96,7 @@ class GraphLockNode(object):
         if self.python_requires:
             result["python_requires"] = [repr(r) for r in self.python_requires]
         if self.modified:
-            result["modified"] = True
+            result["modified"] = self.modified
         if self.requires:
             result["requires"] = self.requires
         return result
@@ -158,18 +158,13 @@ class GraphLock(object):
         and raise
         """
         for id_, node in new_lock._nodes.items():
-            if node.modified:
+            if node.modified == BINARY_BUILD:
                 old_node = self._nodes[id_]
                 if old_node.modified:
                     if not old_node.pref.is_compatible_with(node.pref):
                         raise ConanException("Lockfile had already modified %s" % str(node.pref))
+                node.modified = True
                 self._nodes[id_] = node
-
-    def clean_modified(self):
-        """ remove all the "modified" flags from the lockfile
-        """
-        for _, node in self._nodes.items():
-            node.modified = False
 
     def _closure_affected(self):
         """ returns all the IDs of the nodes that depend directly or indirectly of some

--- a/conans/model/graph_lock.py
+++ b/conans/model/graph_lock.py
@@ -153,9 +153,9 @@ class GraphLock(object):
 
     def update_lock(self, new_lock):
         """ update the lockfile with the contents of other one that was branched from this
-        one and had some node re-built. Only nodes marked as "modified" in the new one are
-        processed, and if the current lockfile already has it modified, it is a conflict,
-        and raise
+        one and had some node re-built. Only nodes marked as modified == BINARY_BUILD (has
+        been re-built, will be processed and updated, and set modified = True. The BINARY_BUILD
+        value is a temporary one when packages are being rebuilt.
         """
         for id_, node in new_lock._nodes.items():
             if node.modified == BINARY_BUILD:

--- a/conans/test/functional/graph_lock/graph_lock_ci_test.py
+++ b/conans/test/functional/graph_lock/graph_lock_ci_test.py
@@ -3,10 +3,11 @@ import os
 import textwrap
 import unittest
 
+from conans.client.graph.graph import BINARY_BUILD
 from conans.model.graph_lock import LOCKFILE
+from conans.model.ref import PackageReference
 from conans.test.utils.tools import TestClient, TestServer
 from conans.util.files import load
-from conans.model.ref import PackageReference
 
 
 class GraphLockCITest(unittest.TestCase):
@@ -94,7 +95,7 @@ class GraphLockCITest(unittest.TestCase):
         self.assertIn("PkgD/0.1@user/channel#d3d184611fb757faa65e4d4203198579:"
                       "7e4312d9a6d3726436d62a6b508f361d13e65354#55f822331b182e54b5144e578ba9135b",
                       lock_fileb)
-        self.assertIn('"modified": true', lock_fileb)
+        self.assertIn('"modified": "%s"' % BINARY_BUILD, lock_fileb)
         # Go back to main orchestrator
         client.save({"new_lock/%s" % LOCKFILE: lock_fileb})
         client.run("graph update-lock . new_lock")
@@ -110,7 +111,6 @@ class GraphLockCITest(unittest.TestCase):
                                         servers={"default": test_server})
                 client_aux.run("config set general.revisions_enabled=True")
                 client_aux.save({LOCKFILE: lock_fileaux})
-                client_aux.run("graph clean-modified .")
                 client_aux.run("install %s --build=%s --lockfile"
                                % (pkg_ref.ref, pkg_ref.ref.name))
                 lock_fileaux = load(os.path.join(client_aux.current_folder, LOCKFILE))
@@ -224,7 +224,7 @@ class GraphLockCITest(unittest.TestCase):
         self.assertIn("PkgD/0.1@user/channel#d3d184611fb757faa65e4d4203198579:"
                       "d80dd9662f447164906643ab88a1ed4e7b12925b#50246cbe82411551e5ebc5bcc75f1a9a",
                       lock_fileb)
-        self.assertIn('"modified": true', lock_fileb)
+        self.assertIn('"modified": "%s"' % BINARY_BUILD, lock_fileb)
         # Go back to main orchestrator
         client.save({"new_lock/%s" % LOCKFILE: lock_fileb})
         client.run("graph update-lock . new_lock")
@@ -240,7 +240,6 @@ class GraphLockCITest(unittest.TestCase):
                                         servers={"default": test_server})
                 client_aux.run("config set general.revisions_enabled=True")
                 client_aux.save({LOCKFILE: lock_fileaux})
-                client_aux.run("graph clean-modified .")
                 client_aux.run("install %s --build=%s --lockfile"
                                % (pkg_ref.ref, pkg_ref.ref.name))
                 lock_fileaux = load(os.path.join(client_aux.current_folder, LOCKFILE))
@@ -344,7 +343,6 @@ class GraphLockCITest(unittest.TestCase):
                 client_aux = TestClient(cache_folder=client.cache_folder)
                 client_aux.run("config set general.default_package_id_mode=full_package_mode")
                 client_aux.save({LOCKFILE: lock_fileaux})
-                client_aux.run("graph clean-modified .")
                 client_aux.run("install %s --build=%s --lockfile"
                                % (pkg_ref.ref, pkg_ref.ref.name))
                 lock_fileaux = load(os.path.join(client_aux.current_folder, LOCKFILE))
@@ -446,7 +444,6 @@ class GraphLockCITest(unittest.TestCase):
             client_aux = TestClient(cache_folder=client.cache_folder)
             client_aux.run("config set general.default_package_id_mode=full_package_mode")
             client_aux.save({LOCKFILE: lock_fileaux})
-            client_aux.run("graph clean-modified .")
             client_aux.run("install %s --build=%s --lockfile"
                            % (pkg_ref.ref, pkg_ref.ref.name))
             lock_fileaux = load(os.path.join(client_aux.current_folder, LOCKFILE))


### PR DESCRIPTION
Changelog: Fix: Remove ``conan graph clean-modified`` command, it is automatic and no longer necessary.
Docs: https://github.com/conan-io/docs/pull/1378


