### PR TITLE
define install_folder to be usable by custom generators

### DIFF
--- a/conans/client/manager.py
+++ b/conans/client/manager.py
@@ -96,6 +96,7 @@ class ConanManager(object):
             manifest_manager.print_log()
 
         if install_folder:
+            conanfile.install_folder = install_folder
             # Write generators
             output = conanfile.output if conanfile.display_name != "virtual" else self._user_io.out
             if generators is not False:


### PR DESCRIPTION
Changelog: BugFix: Fix crash with custom generators using ``install_folder``
Docs: Omit

Close #5568

@tags: slow