### PR TITLE
Fix shallow copy: 1.18.1

### DIFF
--- a/conans/client/tools/scm.py
+++ b/conans/client/tools/scm.py
@@ -144,13 +144,16 @@ class Git(SCMBase):
 
         return output
 
-    def checkout(self, element):
+    def checkout(self, element, submodule=None):
+        # Element can be a tag, branch or commit
         self.check_repo()
         output = self.run('checkout "%s"' % element)
-        # Element can be a tag, branch or commit
+        self.checkout_submodules(submodule)
+
         return output
 
     def checkout_submodules(self, submodule=None):
+        """Do the checkout only for submodules"""
         if submodule:
             if submodule == "shallow":
                 output = self.run("submodule sync")

--- a/conans/client/tools/scm.py
+++ b/conans/client/tools/scm.py
@@ -148,7 +148,7 @@ class Git(SCMBase):
         # Element can be a tag, branch or commit
         self.check_repo()
         output = self.run('checkout "%s"' % element)
-        self.checkout_submodules(submodule)
+        output += self.checkout_submodules(submodule)
 
         return output
 

--- a/conans/client/tools/scm.py
+++ b/conans/client/tools/scm.py
@@ -144,23 +144,26 @@ class Git(SCMBase):
 
         return output
 
-    def checkout(self, element, submodule=None):
+    def checkout(self, element):
         self.check_repo()
         output = self.run('checkout "%s"' % element)
+        # Element can be a tag, branch or commit
+        return output
 
+    def checkout_submodules(self, submodule=None):
         if submodule:
             if submodule == "shallow":
-                output += self.run("submodule sync")
+                output = self.run("submodule sync")
                 output += self.run("submodule update --init")
+                return output
             elif submodule == "recursive":
-                output += self.run("submodule sync --recursive")
+                output = self.run("submodule sync --recursive")
                 output += self.run("submodule update --init --recursive")
+                return output
             else:
                 raise ConanException("Invalid 'submodule' attribute value in the 'scm'. "
                                      "Unknown value '%s'. Allowed values: ['shallow', 'recursive']"
                                      % submodule)
-        # Element can be a tag, branch or commit
-        return output
 
     def excluded_files(self):
         ret = []

--- a/conans/client/tools/scm.py
+++ b/conans/client/tools/scm.py
@@ -154,19 +154,20 @@ class Git(SCMBase):
 
     def checkout_submodules(self, submodule=None):
         """Do the checkout only for submodules"""
-        if submodule:
-            if submodule == "shallow":
-                output = self.run("submodule sync")
-                output += self.run("submodule update --init")
-                return output
-            elif submodule == "recursive":
-                output = self.run("submodule sync --recursive")
-                output += self.run("submodule update --init --recursive")
-                return output
-            else:
-                raise ConanException("Invalid 'submodule' attribute value in the 'scm'. "
-                                     "Unknown value '%s'. Allowed values: ['shallow', 'recursive']"
-                                     % submodule)
+        if not submodule:
+            return ""
+        if submodule == "shallow":
+            output = self.run("submodule sync")
+            output += self.run("submodule update --init")
+            return output
+        elif submodule == "recursive":
+            output = self.run("submodule sync --recursive")
+            output += self.run("submodule update --init --recursive")
+            return output
+        else:
+            raise ConanException("Invalid 'submodule' attribute value in the 'scm'. "
+                                 "Unknown value '%s'. Allowed values: ['shallow', 'recursive']"
+                                 % submodule)
 
     def excluded_files(self):
         ret = []

--- a/conans/model/scm.py
+++ b/conans/model/scm.py
@@ -95,7 +95,8 @@ class SCM(object):
                 # it's completely safe to do here, as clone without branch expects empty directory
                 rmdir(os.path.join(self.repo_folder, ".git"))
                 output += self.repo.clone(url=self._data.url, shallow=False)
-                output += self.repo.checkout(element=self._data.revision)
+                output += self.repo.checkout(element=self._data.revision,
+                                             submodule=self._data.submodule)
 
             self.repo.checkout_submodules(submodule=self._data.submodule)
         else:

--- a/conans/model/scm.py
+++ b/conans/model/scm.py
@@ -89,7 +89,8 @@ class SCM(object):
         output = ""
         if self._data.type == "git":
             try:
-                output += self.repo.clone(url=self._data.url, branch=self._data.revision, shallow=True)
+                output += self.repo.clone(url=self._data.url, branch=self._data.revision,
+                                          shallow=True)
             except subprocess.CalledProcessError:
                 # remove the .git directory, otherwise, fallback clone cannot be successful
                 # it's completely safe to do here, as clone without branch expects empty directory
@@ -97,8 +98,8 @@ class SCM(object):
                 output += self.repo.clone(url=self._data.url, shallow=False)
                 output += self.repo.checkout(element=self._data.revision,
                                              submodule=self._data.submodule)
-
-            self.repo.checkout_submodules(submodule=self._data.submodule)
+            else:
+                output += self.repo.checkout_submodules(submodule=self._data.submodule)
         else:
             output += self.repo.checkout(url=self._data.url, revision=self._data.revision)
         return output

--- a/conans/model/scm.py
+++ b/conans/model/scm.py
@@ -95,8 +95,9 @@ class SCM(object):
                 # it's completely safe to do here, as clone without branch expects empty directory
                 rmdir(os.path.join(self.repo_folder, ".git"))
                 output += self.repo.clone(url=self._data.url, shallow=False)
-            output += self.repo.checkout(element=self._data.revision,
-                                         submodule=self._data.submodule)
+                output += self.repo.checkout(element=self._data.revision)
+
+            self.repo.checkout_submodules(submodule=self._data.submodule)
         else:
             output += self.repo.checkout(url=self._data.url, revision=self._data.revision)
         return output

--- a/conans/test/functional/scm/scm_test.py
+++ b/conans/test/functional/scm/scm_test.py
@@ -302,10 +302,10 @@ other_folder/excluded_subfolder
 
         # "remote" git
         if remote == "local":
-            remote, _ = create_local_git_repo(tags=[revision] if is_tag else None,
-                                              files={"conans/model/username.py": "foo"})
+            remote, rev = create_local_git_repo(tags=[revision] if is_tag else None,
+                                                files={"conans/model/username.py": "foo"})
             if revision is None:  # Get the generated commit
-                revision = Git(remote).get_commit()
+                revision = rev
 
         # Use explicit URL to avoid local optimization (scm_folder.txt)
         conanfile = '''
@@ -321,9 +321,6 @@ class ConanLib(ConanFile):
         assert os.path.exists(os.path.join(self.build_folder, "conans", "model", "username.py"))
 ''' % (remote, revision)
         self.client.save({"conanfile.py": conanfile})
-        create_local_git_repo(folder=self.client.current_folder, tags=[revision])
-        ret_code = self.client.run_command('git remote add origin "{}"'.format(remote))
-        self.assertEqual(ret_code, 0)
         self.client.run("create . user/channel")
 
     def test_install_checked_out(self):


### PR DESCRIPTION
Changelog: Bugfix: The `scm` feature was trying to run a checkout after a shallow clone.
Docs: omit

Closes #5570 

@TAGS: svn, slow
@REVISIONS: 1