### PR TITLE
Adds name attribute to CppInfo

### DIFF
--- a/conans/client/installer.py
+++ b/conans/client/installer.py
@@ -464,6 +464,7 @@ class BinaryInstaller(object):
 
     def _call_package_info(self, conanfile, package_folder, ref):
         conanfile.cpp_info = CppInfo(package_folder)
+        conanfile.cpp_info.name = conanfile.name
         conanfile.cpp_info.version = conanfile.version
         conanfile.cpp_info.description = conanfile.description
         conanfile.env_info = EnvInfo()

--- a/conans/model/build_info.py
+++ b/conans/model/build_info.py
@@ -16,6 +16,7 @@ class _CppInfo(object):
     specific systems will be produced from this info
     """
     def __init__(self):
+        self.name = None
         self.includedirs = []  # Ordered list of include paths
         self.srcdirs = []  # Ordered list of source paths
         self.libdirs = []  # Directories to find libraries

--- a/conans/test/integration/package_info_test.py
+++ b/conans/test/integration/package_info_test.py
@@ -1,3 +1,4 @@
+import textwrap
 import unittest
 
 from conans.paths import CONANFILE, CONANFILE_TXT
@@ -46,3 +47,44 @@ class HelloConan(ConanFile):
 
         client.run("install . -o *:switch=0 --build Lib3")
         self.assertIn("Lib3/1.0@conan/stable: WARN: Env var MYVAR=foo", client.out)
+
+    def package_info_name_test(self):
+        dep = textwrap.dedent("""
+            import os
+            from conans import ConanFile
+
+
+            class Dep(ConanFile):
+
+                def package_info(self):
+                    self.cpp_info.name = "MyCustomGreatName"
+                """)
+        intermediate = textwrap.dedent("""
+            import os
+            from conans import ConanFile
+
+
+            class Intermediate(ConanFile):
+                requires = "dep/1.0@us/ch"
+                """)
+        consumer = textwrap.dedent("""
+            from conans import ConanFile
+
+
+            class Consumer(ConanFile):
+                requires = "intermediate/1.0@us/ch"
+
+                def build(self):
+                    for dep_key, dep_value in self.deps_cpp_info.dependencies:
+                        self.output.info("%s name: %s" % (dep_key, dep_value.name))
+                """)
+
+        client = TestClient()
+        client.save({"conanfile_dep.py": dep,
+                     "conanfile_intermediate.py": intermediate,
+                     "conanfile_consumer.py": consumer})
+        client.run("create conanfile_dep.py dep/1.0@us/ch")
+        client.run("create conanfile_intermediate.py intermediate/1.0@us/ch")
+        client.run("create conanfile_consumer.py consumer/1.0@us/ch")
+        self.assertIn("intermediate name: intermediate", client.out)
+        self.assertIn("dep name: MyCustomGreatName", client.out)

--- a/conans/test/unittests/model/build_info_test.py
+++ b/conans/test/unittests/model/build_info_test.py
@@ -173,3 +173,11 @@ VAR2=23
         self.assertEqual(info.lib_paths, [os.path.join(folder, "lib"), abs_lib])
         self.assertEqual(info.bin_paths, [abs_bin,
                                           os.path.join(folder, "local_bindir")])
+
+    def cpp_info_name_test(self):
+        folder = temp_folder()
+        info = CppInfo(folder)
+        info.name = "MyName"
+        deps_cpp_info = DepsCppInfo()
+        deps_cpp_info.update(info, "myname")
+        self.assertIn("MyName", deps_cpp_info["myname"].name)


### PR DESCRIPTION
Changelog: Feature: Adds `name` attribute to `CppInfo`

- [x] Refer to the issue that supports this Pull Request: related to #5090 
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 

<sup>**Note:** By default this PR will skip the slower tests and will use a limited set of python versions. Check [here](https://github.com/conan-io/conan/blob/develop/.github/PR_INCREASE_TESTING.md) how to increase the testing level by writing some tags in the current PR body text.</sup>
