### PR TITLE
Use the final package folder as the 'conanfile.package_folder' attribute for the 'pre_package' hook

### DIFF
--- a/conans/client/packager.py
+++ b/conans/client/packager.py
@@ -15,7 +15,7 @@ from conans.util.log import logger
 def export_pkg(conanfile, package_id, src_package_folder, package_folder, hook_manager,
                conanfile_path, ref):
     mkdir(package_folder)
-    conanfile.package_folder = src_package_folder
+    conanfile.package_folder = package_folder
     output = conanfile.output
     output.info("Exporting to cache existing package from user folder")
     output.info("Package folder %s" % package_folder)


### PR DESCRIPTION
Changelog: Bugfix: Use the final package folder as the `conanfile.package_folder` attribute for the `pre_package` hook.
Docs: omit

This is a bugfix for the experimental `hooks` feature.

The `package_folder` assigned to the `conanfile` object (to use its value in the `pre_package` hook) uses a different value for the `export-pkg` workflow and for the `create_package` one. (The current value was introduced here https://github.com/conan-io/conan/pull/3555/files#diff-94888d4df1b14d7fdea15cb92ad304ecR17)

IMO, it makes sense to use always the `package_folder` there (the folder where the package will be stored).
