### PR TITLE
Pass username and password as extra options to SVN commands

### DIFF
--- a/conans/client/tools/scm.py
+++ b/conans/client/tools/scm.py
@@ -289,6 +289,9 @@ class SVN(SCMBase):
                 extra_options += " --trust-server-cert-failures=unknown-ca"
             else:
                 extra_options += " --trust-server-cert"
+        if self._username and self._password:
+            extra_options += " --username=" + self._username
+            extra_options += " --password=" + self._password
         return super(SVN, self).run(command="{} {}".format(command, extra_options))
 
     def _show_item(self, item, target='.'):


### PR DESCRIPTION
Changelog: Bugfix: `SVN` uses `username` and `password` if provided
Docs: omig

closes https://github.com/conan-io/conan/issues/5599

@tags: svn, slow