### PR TITLE
fixing remote clean without user/channel

### DIFF
--- a/conans/client/cache/cache.py
+++ b/conans/client/cache/cache.py
@@ -75,7 +75,7 @@ class ClientCache(object):
 
     def all_refs(self):
         subdirs = list_folder_subdirs(basedir=self._store_folder, level=4)
-        return [ConanFileReference(*folder.split("/")) for folder in subdirs]
+        return [ConanFileReference.load_dir_repr(folder) for folder in subdirs]
 
     @property
     def store(self):

--- a/conans/test/functional/command/remote_test.py
+++ b/conans/test/functional/command/remote_test.py
@@ -3,7 +3,6 @@ import re
 import unittest
 from collections import OrderedDict
 
-from conans.test.utils.conanfile import TestConanFile
 from conans.test.utils.tools import NO_SETTINGS_PACKAGE_ID, TestClient, TestServer
 from conans.util.files import load
 from conans.model.ref import ConanFileReference
@@ -87,7 +86,7 @@ class HelloConan(ConanFile):
 
     def list_raw_test(self):
         self.client.run("remote list --raw")
-        output = re.sub("http:\/\/fake.+\.com", "http://fake.com", str(self.client.out))
+        output = re.sub(r"http:\/\/fake.+\.com", "http://fake.com", str(self.client.out))
         self.assertIn("remote0 http://fake.com True", output)
         self.assertIn("remote1 http://fake.com True", output)
         self.assertIn("remote2 http://fake.com True", output)

--- a/conans/test/functional/command/remote_test.py
+++ b/conans/test/functional/command/remote_test.py
@@ -166,6 +166,14 @@ class HelloConan(ConanFile):
         self.client.run("remote list_ref")
         self.assertEqual("", self.client.out)
 
+    def remove_remote_no_user_test(self):
+        self.client.run("remote add_ref Hello/0.1 remote0")
+        self.client.run("remote remove remote0")
+        self.client.run("remote list")
+        self.assertNotIn("remote0", self.client.out)
+        self.client.run("remote list_ref")
+        self.assertEqual("", self.client.out)
+
     def add_force_test(self):
         client = TestClient()
         client.run("remote add r1 https://r1")

--- a/conans/test/functional/command/remote_test.py
+++ b/conans/test/functional/command/remote_test.py
@@ -3,6 +3,7 @@ import re
 import unittest
 from collections import OrderedDict
 
+from conans.test.utils.conanfile import TestConanFile
 from conans.test.utils.tools import NO_SETTINGS_PACKAGE_ID, TestClient, TestServer
 from conans.util.files import load
 from conans.model.ref import ConanFileReference
@@ -151,6 +152,14 @@ class HelloConan(ConanFile):
 
     def clean_remote_test(self):
         self.client.run("remote add_ref Hello/0.1@user/testing remote0")
+        self.client.run("remote clean")
+        self.client.run("remote list")
+        self.assertEqual("", self.client.out)
+        self.client.run("remote list_ref")
+        self.assertEqual("", self.client.out)
+
+    def clean_remote_no_user_test(self):
+        self.client.run("remote add_ref Hello/0.1 remote0")
         self.client.run("remote clean")
         self.client.run("remote list")
         self.assertEqual("", self.client.out)


### PR DESCRIPTION
Changelog: Bugfix: Broken cache package collection for packages without user/channel
Docs: omit

Close #5606

@tags: slow, svn