### PR TITLE
MSBuild::build - Take into account 'useEnv' argument from user input

### DIFF
--- a/conans/client/build/msbuild.py
+++ b/conans/client/build/msbuild.py
@@ -154,6 +154,8 @@ class MSBuild(object):
 
         if use_env:
             command.append('/p:UseEnv=true')
+        else:
+            command.append('/p:UseEnv=false')
 
         if msvc_arch:
             command.append('/p:Platform="%s"' % msvc_arch)

--- a/conans/test/unittests/util/build_sln_command_test.py
+++ b/conans/test/unittests/util/build_sln_command_test.py
@@ -47,7 +47,7 @@ class BuildSLNCommandTest(unittest.TestCase):
             self.assertEqual(len(w), 1)
             self.assertTrue(issubclass(w[0].category, DeprecationWarning))
 
-        self.assertIn('/p:Configuration="Debug" /p:Platform="x86"', command)
+        self.assertIn('/p:Configuration="Debug" /p:UseEnv=false /p:Platform="x86"', command)
         self.assertIn("WARN: ***** The configuration Debug|x86 does not exist in this solution *****",
                       new_out.getvalue())
 
@@ -63,7 +63,7 @@ class BuildSLNCommandTest(unittest.TestCase):
             self.assertEqual(len(w), 1)
             self.assertTrue(issubclass(w[0].category, DeprecationWarning))
 
-        self.assertIn('/p:Configuration="Debug" /p:Platform="Win32"', command)
+        self.assertIn('/p:Configuration="Debug" /p:UseEnv=false /p:Platform="Win32"', command)
         self.assertNotIn("WARN", new_out.getvalue())
         self.assertNotIn("ERROR", new_out.getvalue())
 
@@ -215,6 +215,7 @@ class BuildSLNCommandTest(unittest.TestCase):
             self.assertTrue(issubclass(w[0].category, DeprecationWarning))
 
         self.assertTrue(command.startswith('msbuild "dummy.sln" /p:Configuration="Debug" '
+                                           '/p:UseEnv=false '
                                            '/p:Platform="ARM" '
                                            '/p:PlatformToolset="v110" '
                                            '/verbosity:minimal '
@@ -238,6 +239,7 @@ class BuildSLNCommandTest(unittest.TestCase):
             self.assertTrue(issubclass(w[0].category, DeprecationWarning))
 
         self.assertTrue(command.startswith('msbuild "dummy.sln" /p:Configuration="Debug" '
+                                           '/p:UseEnv=false '
                                            '/p:Platform="ARM" '
                                            '/verbosity:minimal '
                                            '/p:ForceImportBeforeCppTargets='), command)

--- a/conans/test/unittests/util/tools_test.py
+++ b/conans/test/unittests/util/tools_test.py
@@ -285,7 +285,8 @@ class HelloConan(ConanFile):
                                            arch="x86", output=self.output)
             self.assertEqual(len(w), 2)
             self.assertTrue(issubclass(w[0].category, DeprecationWarning))
-        self.assertIn('msbuild "project.sln" /p:Configuration="Debug" /p:Platform="x86"', cmd)
+        self.assertIn('msbuild "project.sln" /p:Configuration="Debug" '
+                      '/p:UseEnv=false /p:Platform="x86"', cmd)
         self.assertIn('vcvarsall.bat', cmd)
 
         # tests errors if args not defined
@@ -310,7 +311,8 @@ class HelloConan(ConanFile):
             cmd = tools.msvc_build_command(settings, "project.sln", output=self.output)
             self.assertEqual(len(w), 2)
             self.assertTrue(issubclass(w[0].category, DeprecationWarning))
-        self.assertIn('msbuild "project.sln" /p:Configuration="Debug" /p:Platform="x86"', cmd)
+        self.assertIn('msbuild "project.sln" /p:Configuration="Debug" '
+                      '/p:UseEnv=false /p:Platform="x86"', cmd)
         self.assertIn('vcvarsall.bat', cmd)
 
     @unittest.skipUnless(platform.system() == "Windows", "Requires vswhere")


### PR DESCRIPTION
Changelog: Fix: Use the value of argument `useEnv` provided by the user to the `MSBuild` helper also to adjust `/p:UseEnv=false` when the arg is `False`.
Docs: omit

`VisualStudioBuildEnvironment` defaults `useEnv=True`, then if the user calls with `MSBuild.build(...., use_env=False,...)` the input was not taken into account. This PR complements the functionality introduced in https://github.com/conan-io/conan/pull/4655



@tags: slow