### PR TITLE
#5572 Retrieve Conan home directory

### DIFF
--- a/conans/client/command.py
+++ b/conans/client/command.py
@@ -508,11 +508,13 @@ class Command(object):
         subparsers = parser.add_subparsers(dest='subcommand', help='sub-command help')
         subparsers.required = True
 
+        get_subparser = subparsers.add_parser('get', help='Get the value of configuration item')
+        subparsers.add_parser('home', help='Retrieve the Conan home directory')
+        install_subparser = subparsers.add_parser('install', help='Install a full configuration '
+                                                                  'from a local or remote zip file')
         rm_subparser = subparsers.add_parser('rm', help='Remove an existing config element')
         set_subparser = subparsers.add_parser('set', help='Set a value for a configuration item')
-        get_subparser = subparsers.add_parser('get', help='Get the value of configuration item')
-        install_subparser = subparsers.add_parser('install', help='install a full configuration '
-                                                                  'from a local or remote zip file')
+
         rm_subparser.add_argument("item", help="Item to remove")
         get_subparser.add_argument("item", nargs="?", help="Item to print")
         set_subparser.add_argument("item", help="'item=value' to set")
@@ -547,6 +549,8 @@ class Command(object):
             return self._conan.config_get(args.item)
         elif args.subcommand == "rm":
             return self._conan.config_rm(args.item)
+        elif args.subcommand == "home":
+            return self._conan.config_home()
         elif args.subcommand == "install":
             verify_ssl = get_bool_from_text(args.verify_ssl)
             return self._conan.config_install(args.item, verify_ssl, args.type, args.args,

--- a/conans/client/command.py
+++ b/conans/client/command.py
@@ -550,7 +550,9 @@ class Command(object):
         elif args.subcommand == "rm":
             return self._conan.config_rm(args.item)
         elif args.subcommand == "home":
-            return self._conan.config_home()
+            conan_home = self._conan.config_home()
+            self._out.info(conan_home)
+            return conan_home
         elif args.subcommand == "install":
             verify_ssl = get_bool_from_text(args.verify_ssl)
             return self._conan.config_install(args.item, verify_ssl, args.type, args.args,

--- a/conans/client/conan_api.py
+++ b/conans/client/conan_api.py
@@ -601,6 +601,11 @@ class ConanAPIV1(object):
                                      args=args,
                                      source_folder=source_folder, target_folder=target_folder)
 
+    @api_method
+    def config_home(self):
+        self.app.out.info(self.cache_folder)
+        return self.cache_folder
+
     def _info_args(self, reference_or_path, install_folder, profile_names, settings, options, env,
                    lockfile=None):
         cwd = get_cwd()

--- a/conans/client/conan_api.py
+++ b/conans/client/conan_api.py
@@ -603,7 +603,6 @@ class ConanAPIV1(object):
 
     @api_method
     def config_home(self):
-        self.app.out.info(self.cache_folder)
         return self.cache_folder
 
     def _info_args(self, reference_or_path, install_folder, profile_names, settings, options, env,

--- a/conans/test/functional/command/config_test.py
+++ b/conans/test/functional/command/config_test.py
@@ -3,6 +3,8 @@ import unittest
 
 from conans.test.utils.tools import TestClient
 from conans.util.files import load
+from conans.test.utils.test_files import temp_folder
+from conans.client.tools import environment_append
 
 
 class ConfigTest(unittest.TestCase):
@@ -90,3 +92,21 @@ class ConfigTest(unittest.TestCase):
     def missing_subarguments_test(self):
         self.client.run("config", assert_error=True)
         self.assertIn("ERROR: Exiting with code: 2", self.client.out)
+
+    def test_config_home_default(self):
+        self.client.run("config home")
+        self.assertIn(self.client.cache.cache_folder, self.client.out)
+
+    def test_config_home_custom_home_dir(self):
+        cache_folder = os.path.join(temp_folder(), "custom")
+        with environment_append({"CONAN_USER_HOME": cache_folder}):
+            client = TestClient(cache_folder=cache_folder)
+            client.run("config home")
+            self.assertIn(cache_folder, client.out)
+
+    def test_config_home_short_home_dir(self):
+        cache_folder = os.path.join(temp_folder(), "custom")
+        with environment_append({"CONAN_USER_HOME_SHORT": cache_folder}):
+            client = TestClient(cache_folder=cache_folder)
+            client.run("config home")
+            self.assertIn(cache_folder, client.out)

--- a/conans/test/functional/conan_api/config.py
+++ b/conans/test/functional/conan_api/config.py
@@ -5,9 +5,15 @@ from conans.client import conan_api
 
 class ConfigTest(unittest.TestCase):
 
+    def setUp(self):
+        self.conan, _, _ = conan_api.ConanAPIV1.factory()
+
     def config_rm_test(self):
-        conan, _, _ = conan_api.ConanAPIV1.factory()
-        conan.config_set("proxies.https", "http://10.10.1.10:1080")
-        self.assertIn("proxies", conan._cache.config.sections())
-        conan.config_rm('proxies')
-        self.assertNotIn("proxies", conan._cache.config.sections())
+        self.conan.config_set("proxies.https", "http://10.10.1.10:1080")
+        self.assertIn("proxies", self.conan._cache.config.sections())
+        self.conan.config_rm('proxies')
+        self.assertNotIn("proxies", self.conan._cache.config.sections())
+
+    def test_config_home(self):
+        conan_home = self.conan.config_home()
+        self.assertEqual(self.conan.cache_folder, conan_home)


### PR DESCRIPTION
- Add `config home` command to retrieve Conan home dir
- Add functional tests to validate `config home`

Changelog: Feature: Retrieve Conan home directory
Docs: https://github.com/conan-io/docs/pull/1387

closes https://github.com/conan-io/conan/issues/5572

- [x] Refer to the issue that supports this Pull Request.
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [x] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 

<sup>**Note:** By default this PR will skip the slower tests and will use a limited set of python versions. Check [here](https://github.com/conan-io/conan/blob/develop/.github/PR_INCREASE_TESTING.md) how to increase the testing level by writing some tags in the current PR body text.</sup>
