### PR TITLE
Add support for Solaris sparc and x86.

### DIFF
--- a/conans/client/tools/oss.py
+++ b/conans/client/tools/oss.py
@@ -48,6 +48,16 @@ def detected_os():
 def detected_architecture():
     # FIXME: Very weak check but not very common to run conan in other architectures
     machine = platform.machine()
+
+    if OSInfo().is_solaris:
+        # under intel solaris, platform.machine()=='i86pc' so we need to handle it early to suport 64-bit
+        processor = platform.processor()
+        kernel_bitness, elf = platform.architecture()
+        if "sparc" in processor:
+            return "sparcv9" if kernel_bitness == "64bit" else "sparc"
+        elif "i386" in processor:
+            return "x86_64" if kernel_bitness == "64bit" else "x86"
+ 
     if "ppc64le" in machine:
         return "ppc64le"
     elif "ppc64" in machine:

--- a/conans/test/unittests/util/detected_architecture_test.py
+++ b/conans/test/unittests/util/detected_architecture_test.py
@@ -51,3 +51,19 @@ class DetectedArchitectureTest(unittest.TestCase):
                 mock.patch("conans.client.tools.oss.OSInfo.get_aix_conf", mock.MagicMock(return_value='64')),\
                 mock.patch('subprocess.check_output', mock.MagicMock(return_value='7.1.0.0')):
             self.assertEqual('ppc64', detected_architecture())
+
+
+    def test_solaris(self):
+        with mock.patch("platform.machine", mock.MagicMock(return_value='sun4v')),\
+                mock.patch("platform.processor", mock.MagicMock(return_value='sparc')),\
+                mock.patch("platform.system", mock.MagicMock(return_value='SunOS')),\
+                mock.patch("platform.architecture", mock.MagicMock(return_value=('64bit', 'ELF'))),\
+                mock.patch("platform.release", mock.MagicMock(return_value='5.11')):
+            self.assertEqual('sparcv9', detected_architecture())
+
+        with mock.patch("platform.machine", mock.MagicMock(return_value='i86pc')),\
+                mock.patch("platform.processor", mock.MagicMock(return_value='i386')),\
+                mock.patch("platform.system", mock.MagicMock(return_value='SunOS')),\
+                mock.patch("platform.architecture", mock.MagicMock(return_value=('64bit', 'ELF'))),\
+                mock.patch("platform.release", mock.MagicMock(return_value='5.11')):
+            self.assertEqual('x86_64', detected_architecture())


### PR DESCRIPTION
Changelog: (Bugfix): Fix support for building on the Solaris OS

Docs: Omit

Issue:  https://github.com/conan-io/conan/issues/5629

Under Solaris, ```platform.machine()``` returns strings that Conan was not expecting.  In this PR code is added to handle Solaris OS first, as on Intel Solaris the string returned is "i86pc" this would return "x86" rather than the 64-bit architecture "x86_64".
