### PR TITLE
#5493 conan get reference is not found

### DIFF
--- a/conans/errors.py
+++ b/conans/errors.py
@@ -196,7 +196,7 @@ class RecipeNotFoundException(NotFoundException):
 
     def __str__(self):
         tmp = self.ref.full_str() if self.print_rev else str(self.ref)
-        return "Recipe not found: '{}'".format(tmp, self.remote_message())
+        return "Recipe not found: '{}'{}".format(tmp, self.remote_message())
 
 
 class PackageNotFoundException(NotFoundException):

--- a/conans/test/functional/command/conan_get_test.py
+++ b/conans/test/functional/command/conan_get_test.py
@@ -166,3 +166,9 @@ class ConanGetTest(unittest.TestCase):
                                                              pkg_id=NO_SETTINGS_PACKAGE_ID))
         self.assertIn("WARN: Usage of `--package` argument is deprecated. Use a full reference "
                       "instead: `conan get [...] ", self.client.out)
+
+    def test_get_not_found_reference(self):
+        """ Conan get must return 'Recipe not found' when the server answer is 404
+        """
+        self.client.run('get foobar/0.1.0@qux/channel -r default', assert_error=True)
+        self.assertIn("Recipe not found: 'foobar/0.1.0@qux/channel'. [Remote: default]", self.client.out)


### PR DESCRIPTION
Changelog: Fix: Show friendly message when can't get remote path
Docs: Omit
fixes: https://github.com/conan-io/conan/issues/5493

- [ ] Refer to the issue that supports this Pull Request.
- [ ] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [ ] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [ ] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 

<sup>**Note:** By default this PR will skip the slower tests and will use a limited set of python versions. Check [here](https://github.com/conan-io/conan/blob/develop/.github/PR_INCREASE_TESTING.md) how to increase the testing level by writing some tags in the current PR body text.</sup>
