### PR TITLE
Rename retry

### DIFF
--- a/conans/client/tools/files.py
+++ b/conans/client/tools/files.py
@@ -383,3 +383,22 @@ def unix2dos(filepath):
 
 def dos2unix(filepath):
     _replace_with_separator(filepath, "\n")
+
+def rename(src, dst, retry=5, output=None):
+    """
+    rename a file or folder with retrying
+    :param src: Path to the file or folder
+    :param dst: Destination file or folder
+    :param retry: Number to retry
+    :param output: output
+    :return:
+    """
+    output = default_output(output, 'conans.client.tools.files.rename')
+    for r in range(retry):
+        try:
+            os.rename(src, dst)
+            break
+        except Exception as e:
+            output.warn("rename failed, error: {0} occured, retrying: {1}".format(e, r+1))
+            if r+1 == retry:
+                raise ConanException("rename_retry failed")

--- a/conans/tools.py
+++ b/conans/tools.py
@@ -94,6 +94,7 @@ collect_libs = tools_files.collect_libs
 which = tools_files.which
 unix2dos = tools_files.unix2dos
 dos2unix = tools_files.dos2unix
+rename = tools_files.rename
 
 
 def unzip(*args, **kwargs):


### PR DESCRIPTION
Changelog: (Feature): os.rename() function frequently raises "Access is denied" exception on windows. This PR provides a function to rename file or folder with retrying to avoid the exception on windows. 
Docs: https://github.com/conan-io/docs/pull/1390

- [x] Refer to the issue that supports this Pull Request.
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [x] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 

<sup>**Note:** By default this PR will skip the slower tests and will use a limited set of python versions. Check [here](https://github.com/conan-io/conan/blob/develop/.github/PR_INCREASE_TESTING.md) how to increase the testing level by writing some tags in the current PR body text.</sup>
