### PR TITLE
Call post_package hook before computing the manifest

### DIFF
--- a/conans/client/packager.py
+++ b/conans/client/packager.py
@@ -25,16 +25,17 @@ def export_pkg(conanfile, package_id, src_package_folder, package_folder, hook_m
     copier = FileCopier([src_package_folder], package_folder)
     copier("*", symlinks=True)
 
-    save(os.path.join(package_folder, CONANINFO), conanfile.info.dumps())
-    manifest = FileTreeManifest.create(package_folder)
-    manifest.save(package_folder)
-
-    _report_files_from_manifest(output, manifest)
-
-    output.success("Package '%s' created" % package_id)
     conanfile.package_folder = package_folder
     hook_manager.execute("post_package", conanfile=conanfile, conanfile_path=conanfile_path,
                          reference=ref, package_id=package_id)
+
+    save(os.path.join(package_folder, CONANINFO), conanfile.info.dumps())
+    manifest = FileTreeManifest.create(package_folder)
+    manifest.save(package_folder)
+    _report_files_from_manifest(output, manifest)
+
+    output.success("Package '%s' created" % package_id)
+
     prev = manifest.summary_hash
     output.info("Created package revision %s" % prev)
     return prev
@@ -82,12 +83,15 @@ def create_package(conanfile, package_id, source_folder, build_folder, package_f
             raise
         raise ConanException(e)
 
+    hook_manager.execute("post_package", conanfile=conanfile, conanfile_path=conanfile_path,
+                         reference=ref, package_id=package_id)
+
     manifest = _create_aux_files(install_folder, package_folder, conanfile, copy_info)
     _report_files_from_manifest(package_output, manifest)
     package_id = package_id or os.path.basename(package_folder)
+
     output.success("Package '%s' created" % package_id)
-    hook_manager.execute("post_package", conanfile=conanfile, conanfile_path=conanfile_path,
-                         reference=ref, package_id=package_id)
+
     prev = manifest.summary_hash
     output.info("Created package revision %s" % prev)
     return prev

--- a/conans/paths/package_layouts/package_cache_layout.py
+++ b/conans/paths/package_layouts/package_cache_layout.py
@@ -102,7 +102,7 @@ class PackageCacheLayout(object):
     @short_path
     def package(self, pref):
         assert isinstance(pref, PackageReference)
-        assert pref.ref == self._ref
+        assert pref.ref == self._ref, "{!r} != {!r}".format(pref.ref, self._ref)
         return os.path.join(self._base_folder, PACKAGES_FOLDER, pref.id)
 
     def scm_folder(self):

--- a/conans/test/functional/hooks/test_post_package.py
+++ b/conans/test/functional/hooks/test_post_package.py
@@ -19,7 +19,7 @@ class PostPackageTestCase(unittest.TestCase):
         t = TurboTestClient()
 
         def post_package_hook(conanfile, **kwargs):
-            # There shouldn't be a digest yet
+            # There shouldn't be a manifest yet
             post_package_hook.manifest_path = os.path.join(conanfile.package_folder, CONAN_MANIFEST)
             self.assertFalse(os.path.exists(post_package_hook.manifest_path))
 
@@ -29,9 +29,11 @@ class PostPackageTestCase(unittest.TestCase):
         with patch.object(HookManager, "load_hooks", new=mocked_load_hooks):
             pref = t.create(ConanFileReference.loads("name/version@user/channel"))
 
+        # Check that we are considering the same file
         package_layout = t.cache.package_layout(pref.ref)
         self.assertEqual(post_package_hook.manifest_path,
                          os.path.join(package_layout.package(pref), CONAN_MANIFEST))
+        # Now the file exists
         self.assertTrue(os.path.exists(post_package_hook.manifest_path))
 
     def test_export_pkg_command(self):
@@ -40,7 +42,7 @@ class PostPackageTestCase(unittest.TestCase):
         t = TurboTestClient()
 
         def post_package_hook(conanfile, **kwargs):
-            # There shouldn't be a digest yet
+            # There shouldn't be a manifest yet
             post_package_hook.manifest_path = os.path.join(conanfile.package_folder, CONAN_MANIFEST)
             self.assertFalse(os.path.exists(post_package_hook.manifest_path))
 
@@ -51,7 +53,9 @@ class PostPackageTestCase(unittest.TestCase):
             pref = t.export_pkg(ref=ConanFileReference.loads("name/version@user/channel"),
                                 args="--package-folder=.")
 
+        # Check that we are considering the same file
         package_layout = t.cache.package_layout(pref.ref)
         self.assertEqual(post_package_hook.manifest_path,
                          os.path.join(package_layout.package(pref), CONAN_MANIFEST))
+        # Now the file exists
         self.assertTrue(os.path.exists(post_package_hook.manifest_path))

--- a/conans/test/functional/hooks/test_post_package.py
+++ b/conans/test/functional/hooks/test_post_package.py
@@ -1,0 +1,41 @@
+# coding=utf-8
+
+import os
+import textwrap
+import unittest
+
+from mock import patch
+
+from conans.client.hook_manager import HookManager
+from conans.model.ref import ConanFileReference
+from conans.paths import CONAN_MANIFEST
+from conans.test.utils.tools import TestClient
+
+
+class PostPackageTestCase(unittest.TestCase):
+
+    def test_manifest_creation(self):
+        """ Test that 'post_package' hook is called before computing the manifest
+        """
+
+        ref = ConanFileReference.loads("name/version@user/channel")
+        conanfile = textwrap.dedent("""\
+            from conans import ConanFile
+
+            class MyLib(ConanFile):
+                pass
+        """)
+
+        t = TestClient()
+        t.save({'conanfile.py': conanfile})
+
+        def mocked_post_package(conanfile, **kwargs):
+            # There shouldn't be a digest yet
+            self.assertFalse(os.path.exists(os.path.join(conanfile.package_folder, CONAN_MANIFEST)))
+
+        def mocked_load_hooks(hook_manager):
+            hook_manager.hooks["post_package"] = [("_", mocked_post_package)]
+
+        with patch.object(HookManager, "load_hooks", new=mocked_load_hooks):
+            t.run("create . {}".format(ref))
+        self.assertTrue(os.path.exists(os.path.join(conanfile.package_folder, CONAN_MANIFEST)))

--- a/conans/test/functional/hooks/test_post_package.py
+++ b/conans/test/functional/hooks/test_post_package.py
@@ -17,11 +17,14 @@ class PostPackageTestCase(unittest.TestCase):
         """ Test that 'post_package' hook is called before computing the manifest
         """
         t = TurboTestClient()
+        filename = "hook_file"
 
         def post_package_hook(conanfile, **kwargs):
             # There shouldn't be a manifest yet
             post_package_hook.manifest_path = os.path.join(conanfile.package_folder, CONAN_MANIFEST)
             self.assertFalse(os.path.exists(post_package_hook.manifest_path))
+            # Add a file
+            open(os.path.join(conanfile.package_folder, filename), "w").close()
 
         def mocked_load_hooks(hook_manager):
             hook_manager.hooks["post_package"] = [("_", post_package_hook)]
@@ -33,18 +36,24 @@ class PostPackageTestCase(unittest.TestCase):
         package_layout = t.cache.package_layout(pref.ref)
         self.assertEqual(post_package_hook.manifest_path,
                          os.path.join(package_layout.package(pref), CONAN_MANIFEST))
-        # Now the file exists
+        # Now the file exists and contains info about created file
         self.assertTrue(os.path.exists(post_package_hook.manifest_path))
+        with open(post_package_hook.manifest_path) as f:
+            content = f.read()
+            self.assertIn(filename, content)
 
     def test_export_pkg_command(self):
         """ Test that 'post_package' hook is called before computing the manifest
         """
         t = TurboTestClient()
+        filename = "hook_file"
 
         def post_package_hook(conanfile, **kwargs):
             # There shouldn't be a manifest yet
             post_package_hook.manifest_path = os.path.join(conanfile.package_folder, CONAN_MANIFEST)
             self.assertFalse(os.path.exists(post_package_hook.manifest_path))
+            # Add a file
+            open(os.path.join(conanfile.package_folder, filename), "w").close()
 
         def mocked_load_hooks(hook_manager):
             hook_manager.hooks["post_package"] = [("_", post_package_hook)]
@@ -57,5 +66,8 @@ class PostPackageTestCase(unittest.TestCase):
         package_layout = t.cache.package_layout(pref.ref)
         self.assertEqual(post_package_hook.manifest_path,
                          os.path.join(package_layout.package(pref), CONAN_MANIFEST))
-        # Now the file exists
+        # Now the file exists and contains info about created file
         self.assertTrue(os.path.exists(post_package_hook.manifest_path))
+        with open(post_package_hook.manifest_path) as f:
+            content = f.read()
+            self.assertIn(filename, content)

--- a/conans/test/utils/tools.py
+++ b/conans/test/utils/tools.py
@@ -906,6 +906,22 @@ class TurboTestClient(TestClient):
     def remove_all(self):
         self.run("remove '*' -f")
 
+    def export_pkg(self, ref, conanfile=None, args=None, assert_error=False):
+        conanfile = str(conanfile) if conanfile else str(GenConanfile())
+        self.save({"conanfile.py": conanfile})
+        self.run("export-pkg . {} {} --json {}".format(ref.full_str(),
+                                                       args or "", self.tmp_json_name),
+                 assert_error=assert_error)
+        rrev = self.cache.package_layout(ref).recipe_revision()
+        json_path = os.path.join(self.current_folder, self.tmp_json_name)
+        data = json.loads(load(json_path))
+        if assert_error:
+            return None
+        package_id = data["installed"][0]["packages"][0]["id"]
+        package_ref = PackageReference(ref, package_id)
+        prev = self.cache.package_layout(ref.copy_clear_rev()).package_revision(package_ref)
+        return package_ref.copy_with_revs(rrev, prev)
+
     def recipe_exists(self, ref):
         return self.cache.package_layout(ref).recipe_exists()
 


### PR DESCRIPTION
Changelog: Fix: Call `post_package` hook before computing the manifest
Docs: omit

With this PR the hook `post_package` runs before computing the manifest, so example [here](https://docs.conan.io/en/latest/extending/hooks.html#id3) would work as documented:

```python
 import os
 from conans import tools

 SIGNATURE = "this is my signature"

 def post_package(output, conanfile, conanfile_path, **kwargs):
     sign_path = os.path.join(conanfile.package_folder, ".sign")
     tools.save(sign_path, SIGNATURE)
     output.success("Package signed successfully")
```

closes #5588 
