### PR TITLE
[refactor] Remove TestConanFile in favor of GenConanFile

### DIFF
--- a/conans/test/functional/build_requires/build_requires_test.py
+++ b/conans/test/functional/build_requires/build_requires_test.py
@@ -58,12 +58,12 @@ class BuildRequiresTest(unittest.TestCase):
         libA_ref = ConanFileReference.loads("LibA/0.1@user/testing")
 
         t = TestClient()
-        t.save({"conanfile.py": GenConanfile()
-               .with_package_info(cpp_info={"libs": ["mylibcatch0.1lib"]},
-                                  env_info={"MYENV": ["myenvcatch0.1env"]})})
-        t.run("create . {}".format(catch_ref))
+        t.save({"conanfile.py":
+                    GenConanfile().with_package_info(cpp_info={"libs": ["mylibcatch0.1lib"]},
+                                                     env_info={"MYENV": ["myenvcatch0.1env"]})})
+        t.run("create . catch/0.1@user/testing")
         t.save({"conanfile.py": GenConanfile().with_requirement(catch_ref, private=True)})
-        t.run("create . {}".format(libA_ref))
+        t.run("create . LibA/0.1@user/testing")
         t.save({"conanfile.py": GenConanfile().with_requirement(libA_ref)
                                               .with_build_requirement(catch_ref)})
         t.run("install .")
@@ -78,21 +78,20 @@ class BuildRequiresTest(unittest.TestCase):
         self.assertIn("mylibcatch0.1lib", conanbuildinfo)
 
     def test_build_requires_diamond(self):
-        libA_ref = ConanFileReference.loads("LibA/0.1@user/testing")
-        libB_ref = ConanFileReference.loads("LibB/0.1@user/testing")
-        libC_ref = ConanFileReference.loads("LibC/0.1@user/testing")
+        libA_ref = ConanFileReference.loads("libA/0.1@user/testing")
+        libB_ref = ConanFileReference.loads("libB/0.1@user/testing")
 
         t = TestClient()
         t.save({"conanfile.py": GenConanfile()})
-        t.run("create . {}".format(libA_ref))
+        t.run("create . libA/0.1@user/testing")
 
         t.save({"conanfile.py": GenConanfile().with_requirement(libA_ref)})
-        t.run("create . {}".format(libB_ref))
+        t.run("create . libB/0.1@user/testing")
 
         t.save({"conanfile.py": GenConanfile().with_build_requirement(libB_ref)
                                               .with_build_requirement(libA_ref)})
-        t.run("create . {}".format(libC_ref))
-        self.assertIn("LibC/0.1@user/testing: Created package", t.out)
+        t.run("create . libC/0.1@user/testing")
+        self.assertIn("libC/0.1@user/testing: Created package", t.out)
 
     def create_with_tests_and_build_requires_test(self):
         client = TestClient()

--- a/conans/test/functional/build_requires/build_requires_test.py
+++ b/conans/test/functional/build_requires/build_requires_test.py
@@ -3,10 +3,10 @@ import unittest
 
 from parameterized.parameterized import parameterized
 
+from conans.model.ref import ConanFileReference
 from conans.paths import CONANFILE
-from conans.test.utils.tools import TestClient
+from conans.test.utils.tools import TestClient, GenConanfile
 from conans.util.files import load
-from conans.test.utils.conanfile import TestConanFile
 
 tool_conanfile = """from conans import ConanFile
 
@@ -54,15 +54,18 @@ class BuildRequiresTest(unittest.TestCase):
 
     def test_consumer(self):
         # https://github.com/conan-io/conan/issues/5425
+        catch_ref = ConanFileReference.loads("catch/0.1@user/testing")
+        libA_ref = ConanFileReference.loads("LibA/0.1@user/testing")
+
         t = TestClient()
-        t.save({"conanfile.py": str(TestConanFile("catch", "0.1", info=True))})
-        t.run("create . catch/0.1@user/testing")
-        t.save({"conanfile.py": str(TestConanFile("LibA", "0.1",
-                                                  private_requires=["catch/0.1@user/testing"]))})
-        t.run("create . LibA/0.1@user/testing")
-        t.save({"conanfile.py": str(TestConanFile("LibC", "0.1",
-                                                  requires=["LibA/0.1@user/testing"],
-                                                  build_requires=["catch/0.1@user/testing"]))})
+        t.save({"conanfile.py": GenConanfile()
+               .with_package_info(cpp_info={"libs": ["mylibcatch0.1lib"]},
+                                  env_info={"MYENV": ["myenvcatch0.1env"]})})
+        t.run("create . {}".format(catch_ref))
+        t.save({"conanfile.py": GenConanfile().with_requirement(catch_ref, private=True)})
+        t.run("create . {}".format(libA_ref))
+        t.save({"conanfile.py": GenConanfile().with_requirement(libA_ref)
+                                              .with_build_requirement(catch_ref)})
         t.run("install .")
         self.assertIn("catch/0.1@user/testing from local cache", t.out)
         self.assertIn("catch/0.1@user/testing:5ab84d6acfe1f23c4fae0ab88f26e3a396351ac9 - Skip",
@@ -75,19 +78,21 @@ class BuildRequiresTest(unittest.TestCase):
         self.assertIn("mylibcatch0.1lib", conanbuildinfo)
 
     def test_build_requires_diamond(self):
+        libA_ref = ConanFileReference.loads("LibA/0.1@user/testing")
+        libB_ref = ConanFileReference.loads("LibB/0.1@user/testing")
+        libC_ref = ConanFileReference.loads("LibC/0.1@user/testing")
+
         t = TestClient()
-        t.save({"conanfile.py": str(TestConanFile("libA", "0.1"))})
-        t.run("create . libA/0.1@user/testing")
+        t.save({"conanfile.py": GenConanfile()})
+        t.run("create . {}".format(libA_ref))
 
-        t.save({"conanfile.py": str(TestConanFile("libB", "0.1",
-                                                  requires=["libA/0.1@user/testing"]))})
-        t.run("create . libB/0.1@user/testing")
+        t.save({"conanfile.py": GenConanfile().with_requirement(libA_ref)})
+        t.run("create . {}".format(libB_ref))
 
-        t.save({"conanfile.py": str(TestConanFile("libC", "0.1",
-                                                  build_requires=["libB/0.1@user/testing",
-                                                                  "libA/0.1@user/testing"]))})
-        t.run("create . libC/0.1@user/testing")
-        self.assertIn("libC/0.1@user/testing: Created package", t.out)
+        t.save({"conanfile.py": GenConanfile().with_build_requirement(libB_ref)
+                                              .with_build_requirement(libA_ref)})
+        t.run("create . {}".format(libC_ref))
+        self.assertIn("LibC/0.1@user/testing: Created package", t.out)
 
     def create_with_tests_and_build_requires_test(self):
         client = TestClient()

--- a/conans/test/functional/command/export_pkg_test.py
+++ b/conans/test/functional/command/export_pkg_test.py
@@ -2,16 +2,15 @@ import json
 import os
 import platform
 import unittest
+from textwrap import dedent
 
 from parameterized import parameterized
 
 from conans.model.ref import ConanFileReference, PackageReference
 from conans.paths import CONANFILE
-from conans.test.utils.conanfile import TestConanFile
-from conans.test.utils.tools import NO_SETTINGS_PACKAGE_ID, TestClient
+from conans.test.utils.tools import NO_SETTINGS_PACKAGE_ID, TestClient, GenConanfile
 from conans.util.env_reader import get_env
 from conans.util.files import load, mkdir
-from textwrap import dedent
 
 
 class ExportPkgTest(unittest.TestCase):
@@ -22,7 +21,7 @@ class ExportPkgTest(unittest.TestCase):
                             requester_class=None,
                             users={"default": [("lasote", "mypass")]})
 
-        client.save({"conanfile.py": str(TestConanFile("Pkg", "0.1"))})
+        client.save({"conanfile.py": str(GenConanfile().with_name("Pkg").with_version("0.1"))})
         client.run("install .")
         client.run("export-pkg . Pkg/0.1@user/testing")
 
@@ -34,7 +33,7 @@ class ExportPkgTest(unittest.TestCase):
             [build_requires]
             some/other@pkg/notexists
             """)
-        client.save({"conanfile.py": str(TestConanFile("Pkg", "0.1")),
+        client.save({"conanfile.py": str(GenConanfile()),
                      "myprofile": profile})
         client.run("export-pkg . Pkg/0.1@user/testing -pr=myprofile")
 
@@ -436,13 +435,16 @@ class TestConan(ConanFile):
                       client.out)
 
     def test_with_deps(self):
+        hello_ref = ConanFileReference.loads("Hello/0.1@lasote/stable")
         client = TestClient()
-        conanfile = TestConanFile()
+        conanfile = GenConanfile().with_name("Hello").with_version("0.1")
         client.save({"conanfile.py": str(conanfile)})
         client.run("export . lasote/stable")
         client.run("install Hello/0.1@lasote/stable --build")
-        conanfile = TestConanFile(name="Hello1", requires=["Hello/0.1@lasote/stable"])
-        conanfile = str(conanfile) + """    def package_info(self):
+        conanfile = GenConanfile().with_name("Hello1").with_version("0.1")\
+                                  .with_requirement(hello_ref)
+
+        conanfile = str(conanfile) + """\n    def package_info(self):
         self.cpp_info.libs = self.collect_libs()
     def package(self):
         self.copy("*")

--- a/conans/test/functional/command/info_test.py
+++ b/conans/test/functional/command/info_test.py
@@ -7,9 +7,8 @@ import unittest
 from conans.model.ref import ConanFileReference
 from conans.paths import CONANFILE
 from conans.test.utils.cpp_test_files import cpp_hello_conan_files
-from conans.test.utils.tools import TestClient
+from conans.test.utils.tools import TestClient, GenConanfile
 from conans.util.files import load, save
-from conans.test.utils.conanfile import TestConanFile
 
 
 class InfoTest(unittest.TestCase):
@@ -22,7 +21,7 @@ class InfoTest(unittest.TestCase):
         client.run("info nothing/0.1@user/testing", assert_error=True)
         self.assertEqual(os.listdir(client.cache.store), [])
         # This used to fail in Windows, because of the different case
-        client.save({"conanfile.py": TestConanFile("Nothing", "0.1")})
+        client.save({"conanfile.py": GenConanfile().with_name("Nothing").with_version("0.1")})
         client.run("export . user/testing")
 
     def failed_info_test(self):
@@ -627,7 +626,7 @@ class MyTest(ConanFile):
 
     def wrong_graph_info_test(self):
         # https://github.com/conan-io/conan/issues/4443
-        conanfile = TestConanFile()
+        conanfile = GenConanfile().with_name("Hello").with_version("0.1")
         client = TestClient()
         client.save({"conanfile.py": str(conanfile)})
         client.run("install .")
@@ -645,11 +644,11 @@ class MyTest(ConanFile):
     def previous_lockfile_error_test(self):
         # https://github.com/conan-io/conan/issues/5479
         client = TestClient()
-        client.save({"conanfile.py": TestConanFile("pkg", "0.1")})
+        client.save({"conanfile.py": GenConanfile().with_name("pkg").with_version("0.1")})
         client.run("create . user/testing")
-        client.save({"conanfile.py": TestConanFile("other", "0.1",
-                                                   options="{'shared': [True, False]}",
-                                                   default_options='shared=False')})
+        client.save({"conanfile.py": GenConanfile().with_name("other").with_version("0.1")
+                                                   .with_option("shared", [True, False])
+                                                   .with_default_option("shared", False)})
         client.run("install . -o shared=True")
         client.run("info pkg/0.1@user/testing")
         self.assertIn("pkg/0.1@user/testing", client.out)

--- a/conans/test/functional/command/install_test.py
+++ b/conans/test/functional/command/install_test.py
@@ -7,10 +7,9 @@ from conans.client.tools.oss import detected_os
 from conans.model.info import ConanInfo
 from conans.model.ref import ConanFileReference, PackageReference
 from conans.paths import CONANFILE, CONANFILE_TXT, CONANINFO
-from conans.test.utils.conanfile import TestConanFile
 from conans.test.utils.cpp_test_files import cpp_hello_conan_files
 from conans.test.utils.tools import NO_SETTINGS_PACKAGE_ID
-from conans.test.utils.tools import TestClient, TestServer
+from conans.test.utils.tools import TestClient, TestServer, GenConanfile
 from conans.util.files import load, mkdir, rmdir
 
 
@@ -27,7 +26,7 @@ class InstallTest(unittest.TestCase):
         # it will be cleared
         client = TestClient(servers={"default": TestServer()},
                             users={"default": [("lasote", "mypass")]})
-        client.save({"conanfile.py": TestConanFile("Hello", "0.1")})
+        client.save({"conanfile.py": GenConanfile().with_name("Hello").with_version("0.1")})
         client.run("create . lasote/testing")
         client.run("upload * --all --confirm")
         client.run('remove "*" -f')
@@ -592,7 +591,7 @@ class TestConan(ConanFile):
         # https://github.com/conan-io/conan/issues/4871
         servers = {"default": TestServer()}
         client = TestClient(servers=servers, users={"default": [("lasote", "mypass")]})
-        client.save({"conanfile.py": str(TestConanFile("Pkg", "0.1"))})
+        client.save({"conanfile.py": str(GenConanfile().with_name("Pkg").with_version("0.1"))})
         client.run("create . lasote/testing")
         client.run("upload * --confirm --all")
 

--- a/conans/test/functional/command/upload_test.py
+++ b/conans/test/functional/command/upload_test.py
@@ -1,10 +1,10 @@
+import itertools
 import os
 import platform
 import stat
 import unittest
 from collections import OrderedDict
 
-import itertools
 from mock import mock, patch
 from nose.plugins.attrib import attr
 
@@ -13,7 +13,6 @@ from conans.client.tools.env import environment_append
 from conans.errors import ConanException
 from conans.model.ref import ConanFileReference, PackageReference
 from conans.paths import EXPORT_SOURCES_TGZ_NAME, PACKAGE_TGZ_NAME
-from conans.test.utils.conanfile import TestConanFile
 from conans.test.utils.cpp_test_files import cpp_hello_conan_files
 from conans.test.utils.tools import NO_SETTINGS_PACKAGE_ID, TestClient, TestServer, \
     TurboTestClient, GenConanfile
@@ -79,7 +78,7 @@ class UploadTest(unittest.TestCase):
     def test_upload_not_existing(self):
         client = TestClient(servers={"default": TestServer()},
                             users={"default": [("lasote", "mypass")]})
-        client.save({"conanfile.py": str(TestConanFile("Hello", "0.1"))})
+        client.save({"conanfile.py": str(GenConanfile())})
         client.run("export . Hello/0.1@lasote/testing")
         client.run("upload Hello/0.1@lasote/testing -p=123", assert_error=True)
         self.assertIn("ERROR: Binary package Hello/0.1@lasote/testing:123 not found", client.out)

--- a/conans/test/functional/editable/layouts_test.py
+++ b/conans/test/functional/editable/layouts_test.py
@@ -7,9 +7,8 @@ import unittest
 
 from conans.model.editable_layout import LAYOUTS_FOLDER
 from conans.model.ref import ConanFileReference
-from conans.test.utils.conanfile import TestConanFile
 from conans.test.utils.test_files import temp_folder
-from conans.test.utils.tools import TestClient
+from conans.test.utils.tools import TestClient, GenConanfile
 from conans.util.files import load, save_files, save
 
 
@@ -22,12 +21,12 @@ class LayoutTest(unittest.TestCase):
                     [build_folder]
                     build
                     """)
-        client.save({"conanfile.py": TestConanFile("lib", "1.0"),
+        client.save({"conanfile.py": GenConanfile().with_name("lib").with_version("1.0"),
                      "mylayout": layout})
         client.run("editable add . {} --layout mylayout".format(ref))
         client2 = TestClient(cache_folder=client.cache_folder)
-        client2.save({"conanfile.py": TestConanFile("app", "1.0",
-                                                    requires=["lib/1.0@conan/stable"])})
+        client2.save({"conanfile.py": GenConanfile().with_name("app").with_version("1.0")
+                                                    .with_requirement(ref)})
         client2.run("create . user/testing")
         graph_info = os.path.join(client.current_folder, "build", "graph_info.json")
         self.assertTrue(os.path.exists(graph_info))

--- a/conans/test/functional/editable/transitive_editable_test.py
+++ b/conans/test/functional/editable/transitive_editable_test.py
@@ -3,8 +3,8 @@
 import os
 import unittest
 
-from conans.test.utils.tools import TestClient
-from conans.test.utils.conanfile import TestConanFile
+from conans.model.ref import ConanFileReference
+from conans.test.utils.tools import TestClient, GenConanfile
 from conans.util.files import mkdir
 
 
@@ -12,19 +12,24 @@ class TransitiveEditableTest(unittest.TestCase):
 
     def test_transitive_editables(self):
         # https://github.com/conan-io/conan/issues/4445
+        libc_ref = ConanFileReference.loads("LibC/0.1@user/testing")
+        libb_ref = ConanFileReference.loads("LibB/0.1@user/testing")
+
         client = TestClient()
-        conanfileC = TestConanFile("LibC", "0.1")
+        conanfileC = GenConanfile()
         client.save({"conanfile.py": str(conanfileC)})
         client.run("editable add . LibC/0.1@user/testing")
 
         client2 = TestClient(client.cache_folder)
-        conanfileB = TestConanFile("LibB", "0.1", requires=["LibC/0.1@user/testing"])
+        conanfileB = GenConanfile().with_name("LibB").with_version("0.1")\
+                                   .with_requirement(libc_ref)
 
         client2.save({"conanfile.py": str(conanfileB)})
         client2.run("create . user/testing")
 
-        conanfileA = TestConanFile("LibA", "0.1", requires=["LibB/0.1@user/testing",
-                                                            "LibC/0.1@user/testing"])
+        conanfileA = GenConanfile().with_name("LibA").with_version("0.1")\
+                                   .with_requirement(libb_ref)\
+                                   .with_requirement(libc_ref)
         client2.save({"conanfile.py": str(conanfileA)})
         client2.run("install .")
         client2.current_folder = os.path.join(client2.current_folder, "build")

--- a/conans/test/functional/graph/full_revision_mode_test.py
+++ b/conans/test/functional/graph/full_revision_mode_test.py
@@ -1,13 +1,16 @@
 import unittest
 from textwrap import dedent
 
-from conans.test.utils.tools import TestClient
-from conans.test.utils.conanfile import TestConanFile
+from conans.model.ref import ConanFileReference
+from conans.test.utils.tools import TestClient, GenConanfile
 
 
 class FullRevisionModeTest(unittest.TestCase):
 
     def recipe_revision_mode_test(self):
+        liba_ref = ConanFileReference.loads("liba/0.1@user/testing")
+        libb_ref = ConanFileReference.loads("libb/0.1@user/testing")
+
         clienta = TestClient()
         clienta.run("config set general.default_package_id_mode=recipe_revision_mode")
         conanfilea = dedent("""
@@ -23,13 +26,13 @@ class FullRevisionModeTest(unittest.TestCase):
         clienta.run("create . liba/0.1@user/testing")
 
         clientb = TestClient(cache_folder=clienta.cache_folder)
-        clientb.save({"conanfile.py": str(TestConanFile("libb", "0.1",
-                                                        requires=["liba/0.1@user/testing"]))})
+        clientb.save({"conanfile.py": str(GenConanfile().with_name("libb").with_version("0.1")
+                                                        .with_requirement(liba_ref))})
         clientb.run("create . user/testing")
 
         clientc = TestClient(cache_folder=clienta.cache_folder)
-        clientc.save({"conanfile.py": str(TestConanFile("libc", "0.1",
-                                                        requires=["libb/0.1@user/testing"]))})
+        clientc.save({"conanfile.py": str(GenConanfile().with_name("libc").with_version("0.1")
+                                                        .with_requirement(libb_ref))})
         clientc.run("install . user/testing")
 
         # Do a minor change to the recipe, it will change the recipe revision

--- a/conans/test/functional/graph/graph_manager_base.py
+++ b/conans/test/functional/graph/graph_manager_base.py
@@ -18,9 +18,8 @@ from conans.model.options import OptionsValues
 from conans.model.profile import Profile
 from conans.model.ref import ConanFileReference
 from conans.test.unittests.model.transitive_reqs_test import MockRemoteManager
-from conans.test.utils.conanfile import TestConanFile
 from conans.test.utils.test_files import temp_folder
-from conans.test.utils.tools import TestBufferConanOutput
+from conans.test.utils.tools import TestBufferConanOutput, GenConanfile
 from conans.util.files import save
 
 
@@ -42,10 +41,12 @@ class GraphManagerTest(unittest.TestCase):
         self.binary_installer = BinaryInstaller(cache, self.output, self.remote_manager, recorder,
                                                 hook_manager)
 
-    def _cache_recipe(self, reference, test_conanfile, revision=None):
-        if isinstance(test_conanfile, TestConanFile):
-            test_conanfile.info = True
-        ref = ConanFileReference.loads(reference)
+    def _cache_recipe(self, ref, test_conanfile, revision=None):
+        if isinstance(test_conanfile, GenConanfile):
+            name, version = test_conanfile._name, test_conanfile._version
+            test_conanfile = test_conanfile.with_package_info(
+                cpp_info={"libs": ["mylib{}{}lib".format(name, version)]},
+                env_info={"MYENV": ["myenv{}{}env".format(name, version)]})
         save(self.cache.package_layout(ref).conanfile(), str(test_conanfile))
         with self.cache.package_layout(ref).update_metadata() as metadata:
             metadata.recipe.revision = revision or "123"

--- a/conans/test/functional/graph/graph_manager_test.py
+++ b/conans/test/functional/graph/graph_manager_test.py
@@ -300,7 +300,7 @@ class TransitiveGraphTest(GraphManagerTest):
         with six.assertRaisesRegex(self, ConanException, "Loop detected: 'base/aaa@user/testing' "
                                    "requires 'base/aaa@user/testing'"):
             self.build_graph(GenConanfile().with_name("base").with_version("aaa")
-                                           .with_requirement(ref1), ref=ref, create_ref=ref)
+                                           .with_require(ref1), ref=ref, create_ref=ref)
 
     @parameterized.expand([("recipe", ), ("profile", )])
     def test_basic_build_require(self, build_require):

--- a/conans/test/functional/graph/graph_manager_test.py
+++ b/conans/test/functional/graph/graph_manager_test.py
@@ -1,18 +1,17 @@
 import six
 from parameterized import parameterized
 
-
 from conans.client.graph.graph import RECIPE_CONSUMER, RECIPE_INCACHE
 from conans.errors import ConanException
 from conans.model.ref import ConanFileReference
 from conans.test.functional.graph.graph_manager_base import GraphManagerTest
-from conans.test.utils.conanfile import TestConanFile
+from conans.test.utils.tools import GenConanfile
 
 
 class TransitiveGraphTest(GraphManagerTest):
     def test_basic(self):
         # say/0.1
-        deps_graph = self.build_graph(TestConanFile("Say", "0.1"))
+        deps_graph = self.build_graph(GenConanfile().with_name("Say").with_version("0.1"))
         self.assertEqual(1, len(deps_graph.nodes))
         node = deps_graph.root
         self.assertEqual(node.conanfile.name, "Say")
@@ -21,10 +20,10 @@ class TransitiveGraphTest(GraphManagerTest):
 
     def test_transitive(self):
         # app -> libb0.1
-        libb_ref = "libb/0.1@user/testing"
-        self._cache_recipe(libb_ref, TestConanFile("libb", "0.1"))
-        deps_graph = self.build_graph(TestConanFile("app", "0.1",
-                                                    requires=[libb_ref]))
+        libb_ref = ConanFileReference.loads("libb/0.1@user/testing")
+        self._cache_recipe(libb_ref, GenConanfile().with_name("libb").with_version("0.1"))
+        deps_graph = self.build_graph(GenConanfile().with_name("app").with_version("0.1")\
+                                                    .with_requirement(libb_ref))
         self.assertEqual(2, len(deps_graph.nodes))
         app = deps_graph.root
         self.assertEqual(app.conanfile.name, "app")
@@ -47,11 +46,13 @@ class TransitiveGraphTest(GraphManagerTest):
 
     def test_transitive_two_levels(self):
         # app -> libb0.1 -> liba0.1
-        liba_ref = "liba/0.1@user/testing"
-        libb_ref = "libb/0.1@user/testing"
-        self._cache_recipe(liba_ref, TestConanFile("liba", "0.1"))
-        self._cache_recipe(libb_ref, TestConanFile("libb", "0.1", requires=[liba_ref]))
-        deps_graph = self.build_graph(TestConanFile("app", "0.1", requires=[libb_ref]))
+        liba_ref = ConanFileReference.loads("liba/0.1@user/testing")
+        libb_ref = ConanFileReference.loads("libb/0.1@user/testing")
+        self._cache_recipe(liba_ref, GenConanfile().with_name("liba").with_version("0.1"))
+        self._cache_recipe(libb_ref, GenConanfile().with_name("libb").with_version("0.1")
+                                                   .with_requirement(liba_ref))
+        deps_graph = self.build_graph(GenConanfile().with_name("app").with_version("0.1")
+                                                    .with_requirement(libb_ref))
 
         self.assertEqual(3, len(deps_graph.nodes))
         app = deps_graph.root
@@ -69,13 +70,17 @@ class TransitiveGraphTest(GraphManagerTest):
     def test_diamond(self):
         # app -> libb0.1 -> liba0.1
         #    \-> libc0.1 ->/
-        liba_ref = "liba/0.1@user/testing"
-        libb_ref = "libb/0.1@user/testing"
-        libc_ref = "libc/0.1@user/testing"
-        self._cache_recipe(liba_ref, TestConanFile("liba", "0.1"))
-        self._cache_recipe(libb_ref, TestConanFile("libb", "0.1", requires=[liba_ref]))
-        self._cache_recipe(libc_ref, TestConanFile("libc", "0.1", requires=[liba_ref]))
-        deps_graph = self.build_graph(TestConanFile("app", "0.1", requires=[libb_ref, libc_ref]))
+        liba_ref = ConanFileReference.loads("liba/0.1@user/testing")
+        libb_ref = ConanFileReference.loads("libb/0.1@user/testing")
+        libc_ref = ConanFileReference.loads("libc/0.1@user/testing")
+        self._cache_recipe(liba_ref, GenConanfile().with_name("liba").with_version("0.1"))
+        self._cache_recipe(libb_ref, GenConanfile().with_name("libb").with_version("0.1")
+                                                   .with_requirement(liba_ref))
+        self._cache_recipe(libc_ref, GenConanfile().with_name("libc").with_version("0.1")
+                                                   .with_requirement(liba_ref))
+        deps_graph = self.build_graph(GenConanfile().with_name("app").with_version("0.1")
+                                                   .with_requirement(libb_ref)
+                                                   .with_requirement(libc_ref))
 
         self.assertEqual(4, len(deps_graph.nodes))
         app = deps_graph.root
@@ -96,19 +101,27 @@ class TransitiveGraphTest(GraphManagerTest):
     def test_consecutive_diamonds(self):
         # app -> libe0.1 -> libd0.1 -> libb0.1 -> liba0.1
         #    \-> libf0.1 ->/    \-> libc0.1 ->/
-        liba_ref = "liba/0.1@user/testing"
-        libb_ref = "libb/0.1@user/testing"
-        libc_ref = "libc/0.1@user/testing"
-        libd_ref = "libd/0.1@user/testing"
-        libe_ref = "libe/0.1@user/testing"
-        libf_ref = "libf/0.1@user/testing"
-        self._cache_recipe(liba_ref, TestConanFile("liba", "0.1"))
-        self._cache_recipe(libb_ref, TestConanFile("libb", "0.1", requires=[liba_ref]))
-        self._cache_recipe(libc_ref, TestConanFile("libc", "0.1", requires=[liba_ref]))
-        self._cache_recipe(libd_ref, TestConanFile("libd", "0.1", requires=[libb_ref, libc_ref]))
-        self._cache_recipe(libe_ref, TestConanFile("libe", "0.1", requires=[libd_ref]))
-        self._cache_recipe(libf_ref, TestConanFile("libf", "0.1", requires=[libd_ref]))
-        deps_graph = self.build_graph(TestConanFile("app", "0.1", requires=[libe_ref, libf_ref]))
+        liba_ref = ConanFileReference.loads("liba/0.1@user/testing")
+        libb_ref = ConanFileReference.loads("libb/0.1@user/testing")
+        libc_ref = ConanFileReference.loads("libc/0.1@user/testing")
+        libd_ref = ConanFileReference.loads("libd/0.1@user/testing")
+        libe_ref = ConanFileReference.loads("libe/0.1@user/testing")
+        libf_ref = ConanFileReference.loads("libf/0.1@user/testing")
+        self._cache_recipe(liba_ref, GenConanfile().with_name("liba").with_version("0.1"))
+        self._cache_recipe(libb_ref, GenConanfile().with_name("libb").with_version("0.1")
+                                                   .with_requirement(liba_ref))
+        self._cache_recipe(libc_ref, GenConanfile().with_name("libc").with_version("0.1")
+                                                   .with_requirement(liba_ref))
+        self._cache_recipe(libd_ref, GenConanfile().with_name("libd").with_version("0.1")
+                                                   .with_requirement(libb_ref)
+                                                   .with_requirement(libc_ref))
+        self._cache_recipe(libe_ref, GenConanfile().with_name("libe").with_version("0.1")
+                                                   .with_requirement(libd_ref))
+        self._cache_recipe(libf_ref, GenConanfile().with_name("libf").with_version("0.1")
+                                                   .with_requirement(libd_ref))
+        deps_graph = self.build_graph(GenConanfile().with_name("app").with_version("0.1")
+                                                    .with_requirement(libe_ref)
+                                                    .with_requirement(libf_ref))
 
         self.assertEqual(7, len(deps_graph.nodes))
         app = deps_graph.root
@@ -138,16 +151,21 @@ class TransitiveGraphTest(GraphManagerTest):
         # app -> libb0.1 -> liba0.1
         #    \-> libc0.1 ->/
         #    \-> libd0.1 ->/
-        liba_ref = "liba/0.1@user/testing"
-        libb_ref = "libb/0.1@user/testing"
-        libc_ref = "libc/0.1@user/testing"
-        libd_ref = "libd/0.1@user/testing"
-        self._cache_recipe(liba_ref, TestConanFile("liba", "0.1"))
-        self._cache_recipe(libb_ref, TestConanFile("libb", "0.1", requires=[liba_ref]))
-        self._cache_recipe(libc_ref, TestConanFile("libc", "0.1", requires=[liba_ref]))
-        self._cache_recipe(libd_ref, TestConanFile("libd", "0.1", requires=[liba_ref]))
-        deps_graph = self.build_graph(TestConanFile("app", "0.1",
-                                                    requires=[libb_ref, libc_ref, libd_ref]))
+        liba_ref = ConanFileReference.loads("liba/0.1@user/testing")
+        libb_ref = ConanFileReference.loads("libb/0.1@user/testing")
+        libc_ref = ConanFileReference.loads("libc/0.1@user/testing")
+        libd_ref = ConanFileReference.loads("libd/0.1@user/testing")
+        self._cache_recipe(liba_ref, GenConanfile().with_name("liba").with_version("0.1"))
+        self._cache_recipe(libb_ref, GenConanfile().with_name("libb").with_version("0.1")
+                                                   .with_requirement(liba_ref))
+        self._cache_recipe(libc_ref, GenConanfile().with_name("libc").with_version("0.1")
+                                                   .with_requirement(liba_ref))
+        self._cache_recipe(libd_ref, GenConanfile().with_name("libd").with_version("0.1")
+                                                   .with_requirement(liba_ref))
+        deps_graph = self.build_graph(GenConanfile().with_name("app").with_version("0.1")
+                                                    .with_requirement(libb_ref)
+                                                    .with_requirement(libc_ref)
+                                                    .with_requirement(libd_ref))
 
         self.assertEqual(5, len(deps_graph.nodes))
         app = deps_graph.root
@@ -171,16 +189,21 @@ class TransitiveGraphTest(GraphManagerTest):
         # app --------> libb0.1 -> liba0.1
         #    \--------> libc0.1 ->/
         #     \-> libd0.1 ->/
-        liba_ref = "liba/0.1@user/testing"
-        libb_ref = "libb/0.1@user/testing"
-        libc_ref = "libc/0.1@user/testing"
-        libd_ref = "libd/0.1@user/testing"
-        self._cache_recipe(liba_ref, TestConanFile("liba", "0.1"))
-        self._cache_recipe(libb_ref, TestConanFile("libb", "0.1", requires=[liba_ref]))
-        self._cache_recipe(libc_ref, TestConanFile("libc", "0.1", requires=[liba_ref]))
-        self._cache_recipe(libd_ref, TestConanFile("libd", "0.1", requires=[libc_ref]))
-        deps_graph = self.build_graph(TestConanFile("app", "0.1",
-                                                    requires=[libb_ref, libc_ref, libd_ref]))
+        liba_ref = ConanFileReference.loads("liba/0.1@user/testing")
+        libb_ref = ConanFileReference.loads("libb/0.1@user/testing")
+        libc_ref = ConanFileReference.loads("libc/0.1@user/testing")
+        libd_ref = ConanFileReference.loads("libd/0.1@user/testing")
+        self._cache_recipe(liba_ref, GenConanfile().with_name("liba").with_version("0.1"))
+        self._cache_recipe(libb_ref, GenConanfile().with_name("libb").with_version("0.1")
+                                                   .with_requirement(liba_ref))
+        self._cache_recipe(libc_ref, GenConanfile().with_name("libc").with_version("0.1")
+                                                   .with_requirement(liba_ref))
+        self._cache_recipe(libd_ref, GenConanfile().with_name("libd").with_version("0.1")
+                                                   .with_requirement(libc_ref))
+        deps_graph = self.build_graph(GenConanfile().with_name("app").with_version("0.1")
+                                                    .with_requirement(libb_ref)
+                                                    .with_requirement(libc_ref)
+                                                    .with_requirement(libd_ref))
 
         self.assertEqual(5, len(deps_graph.nodes))
         app = deps_graph.root
@@ -205,14 +228,18 @@ class TransitiveGraphTest(GraphManagerTest):
         # app -> libb0.1  -> libc0.1 -> libd0.1
         #    \--------------->/          /
         #     \------------------------>/
-        libb_ref = "libb/0.1@user/testing"
-        libc_ref = "libc/0.1@user/testing"
-        libd_ref = "libd/0.1@user/testing"
-        self._cache_recipe(libd_ref, TestConanFile("libd", "0.1"))
-        self._cache_recipe(libc_ref, TestConanFile("libc", "0.1", requires=[libd_ref]))
-        self._cache_recipe(libb_ref, TestConanFile("libb", "0.1", requires=[libc_ref]))
-        deps_graph = self.build_graph(TestConanFile("liba", "0.1",
-                                                    requires=[libd_ref, libc_ref, libb_ref]))
+        libb_ref = ConanFileReference.loads("libb/0.1@user/testing")
+        libc_ref = ConanFileReference.loads("libc/0.1@user/testing")
+        libd_ref = ConanFileReference.loads("libd/0.1@user/testing")
+        self._cache_recipe(libd_ref, GenConanfile().with_name("libd").with_version("0.1"))
+        self._cache_recipe(libc_ref, GenConanfile().with_name("libc").with_version("0.1")
+                                                   .with_requirement(libd_ref))
+        self._cache_recipe(libb_ref, GenConanfile().with_name("libb").with_version("0.1")
+                                                   .with_requirement(libc_ref))
+        deps_graph = self.build_graph(GenConanfile().with_name("liba").with_version("0.1")
+                                                    .with_requirement(libd_ref)
+                                                    .with_requirement(libc_ref)
+                                                    .with_requirement(libb_ref))
 
         self.assertEqual(4, len(deps_graph.nodes))
         liba = deps_graph.root
@@ -233,49 +260,60 @@ class TransitiveGraphTest(GraphManagerTest):
     def test_diamond_conflict(self):
         # app -> libb0.1 -> liba0.1
         #    \-> libc0.1 -> liba0.2
-        liba_ref = "liba/0.1@user/testing"
-        liba_ref2 = "liba/0.2@user/testing"
-        libb_ref = "libb/0.1@user/testing"
-        libc_ref = "libc/0.1@user/testing"
-        self._cache_recipe(liba_ref, TestConanFile("liba", "0.1"))
-        self._cache_recipe(liba_ref2, TestConanFile("liba", "0.2"))
-        self._cache_recipe(libb_ref, TestConanFile("libb", "0.1", requires=[liba_ref]))
-        self._cache_recipe(libc_ref, TestConanFile("libc", "0.1", requires=[liba_ref2]))
+        liba_ref = ConanFileReference.loads("liba/0.1@user/testing")
+        liba_ref2 = ConanFileReference.loads("liba/0.2@user/testing")
+        libb_ref = ConanFileReference.loads("libb/0.1@user/testing")
+        libc_ref = ConanFileReference.loads("libc/0.1@user/testing")
+        self._cache_recipe(liba_ref, GenConanfile().with_name("liba").with_version("0.1"))
+        self._cache_recipe(liba_ref2, GenConanfile().with_name("liba").with_version("0.2"))
+        self._cache_recipe(libb_ref, GenConanfile().with_name("libb").with_version("0.1")
+                                                   .with_requirement(liba_ref))
+        self._cache_recipe(libc_ref, GenConanfile().with_name("libc").with_version("0.1")
+                                                   .with_requirement(liba_ref2))
         with six.assertRaisesRegex(self, ConanException,
                                    "Requirement liba/0.2@user/testing conflicts"):
-            self.build_graph(TestConanFile("app", "0.1", requires=[libb_ref, libc_ref]))
+            self.build_graph(GenConanfile().with_name("app").with_version("0.1")
+                                           .with_requirement(libb_ref)
+                                           .with_requirement(libc_ref))
 
     def test_loop(self):
         # app -> libc0.1 -> libb0.1 -> liba0.1 ->|
         #             \<-------------------------|
-        liba_ref = "liba/0.1@user/testing"
-        libb_ref = "libb/0.1@user/testing"
-        libc_ref = "libc/0.1@user/testing"
-        self._cache_recipe(liba_ref, TestConanFile("liba", "0.1", requires=[libc_ref]))
-        self._cache_recipe(libb_ref, TestConanFile("libb", "0.1", requires=[liba_ref]))
-        self._cache_recipe(libc_ref, TestConanFile("libc", "0.1", requires=[libb_ref]))
+        liba_ref = ConanFileReference.loads("liba/0.1@user/testing")
+        libb_ref = ConanFileReference.loads("libb/0.1@user/testing")
+        libc_ref = ConanFileReference.loads("libc/0.1@user/testing")
+        self._cache_recipe(liba_ref, GenConanfile().with_name("liba").with_version("0.1")
+                                                   .with_requirement(libc_ref))
+        self._cache_recipe(libb_ref, GenConanfile().with_name("libb").with_version("0.1")
+                                                   .with_requirement(liba_ref))
+        self._cache_recipe(libc_ref, GenConanfile().with_name("libc").with_version("0.1")
+                                                   .with_requirement(libb_ref))
         with six.assertRaisesRegex(self, ConanException, "Loop detected: 'liba/0.1@user/testing' "
                                    "requires 'libc/0.1@user/testing'"):
-            self.build_graph(TestConanFile("app", "0.1", requires=[libc_ref]))
+            self.build_graph(GenConanfile().with_name("app").with_version("0.1")
+                                           .with_requirement(libc_ref))
 
     def test_self_loop(self):
-        ref1 = "base/1.0@user/testing"
-        self._cache_recipe(ref1, TestConanFile("base", "0.1"))
+        ref1 = ConanFileReference.loads("base/1.0@user/testing")
+        self._cache_recipe(ref1, GenConanfile().with_name("base").with_version("1.0"))
         ref = ConanFileReference.loads("base/aaa@user/testing")
         with six.assertRaisesRegex(self, ConanException, "Loop detected: 'base/aaa@user/testing' "
                                    "requires 'base/aaa@user/testing'"):
-            self.build_graph(TestConanFile("base", "aaa", requires=[ref1]), ref=ref, create_ref=ref)
+            self.build_graph(GenConanfile().with_name("base").with_version("aaa")
+                                           .with_requirement(ref1), ref=ref, create_ref=ref)
 
     @parameterized.expand([("recipe", ), ("profile", )])
     def test_basic_build_require(self, build_require):
         # app -(br)-> tool0.1
-        self._cache_recipe("tool/0.1@user/testing", TestConanFile("tool", "0.1"))
+        tool_ref = ConanFileReference.loads("tool/0.1@user/testing")
+        self._cache_recipe(tool_ref, GenConanfile().with_name("tool")
+                                                                  .with_version("0.1"))
         if build_require == "recipe":
-            deps_graph = self.build_graph(TestConanFile("app", "0.1",
-                                                        build_requires=["tool/0.1@user/testing"]))
+            deps_graph = self.build_graph(GenConanfile().with_name("app").with_version("0.1")
+                                                        .with_build_requirement(tool_ref))
         else:
             profile_build_requires = {"*": [ConanFileReference.loads("tool/0.1@user/testing")]}
-            deps_graph = self.build_graph(TestConanFile("app", "0.1"),
+            deps_graph = self.build_graph(GenConanfile().with_name("app").with_version("0.1"),
                                           profile_build_requires=profile_build_requires)
 
         # Build requires always apply to the consumer
@@ -290,12 +328,14 @@ class TransitiveGraphTest(GraphManagerTest):
 
     def test_transitive_build_require_recipe(self):
         # app -> lib -(br)-> tool
-        self._cache_recipe("tool/0.1@user/testing", TestConanFile("tool", "0.1"))
-        self._cache_recipe("lib/0.1@user/testing",
-                           TestConanFile("lib", "0.1",
-                                         build_requires=["tool/0.1@user/testing"]))
-        deps_graph = self.build_graph(TestConanFile("app", "0.1",
-                                                    requires=["lib/0.1@user/testing"]))
+        tool_ref = ConanFileReference.loads("tool/0.1@user/testing")
+        lib_ref = ConanFileReference.loads("lib/0.1@user/testing")
+
+        self._cache_recipe(tool_ref, GenConanfile().with_name("tool").with_version("0.1"))
+        self._cache_recipe(lib_ref, GenConanfile().with_name("lib").with_version("0.1")
+                                                  .with_build_requirement(tool_ref))
+        deps_graph = self.build_graph(GenConanfile().with_name("app").with_version("0.1")
+                                                    .with_requirement(lib_ref))
 
         self.assertEqual(3, len(deps_graph.nodes))
         app = deps_graph.root
@@ -312,28 +352,34 @@ class TransitiveGraphTest(GraphManagerTest):
     def test_loop_build_require(self):
         # app -> lib -(br)-> tool ->|
         #          \<---------------|
-        lib_ref = "lib/0.1@user/testing"
-        self._cache_recipe("tool/0.1@user/testing", TestConanFile("tool", "0.1", requires=[lib_ref]))
-        self._cache_recipe(lib_ref,
-                           TestConanFile("lib", "0.1",
-                                         build_requires=["tool/0.1@user/testing"]))
+        lib_ref = ConanFileReference.loads("lib/0.1@user/testing")
+        tool_ref = ConanFileReference.loads("tool/0.1@user/testing")
+
+        self._cache_recipe(tool_ref, GenConanfile().with_name("tool").with_version("0.1")
+                                                   .with_requirement(lib_ref))
+        self._cache_recipe(lib_ref, GenConanfile().with_name("lib").with_version("0.1")
+                                                  .with_build_requirement(tool_ref))
 
         with six.assertRaisesRegex(self, ConanException, "Loop detected: 'tool/0.1@user/testing' "
                                    "requires 'lib/0.1@user/testing'"):
-            self.build_graph(TestConanFile("app", "0.1", requires=["lib/0.1@user/testing"]))
+            self.build_graph(GenConanfile().with_name("app").with_version("0.1")
+                                           .with_requirement(lib_ref))
 
     def test_transitive_build_require_recipe_profile(self):
         # app -> lib -(br)-> gtest -(br)-> mingw
         # profile \---(br)-> mingw
         # app -(br)-> mingw
-        self._cache_recipe("mingw/0.1@user/testing", TestConanFile("mingw", "0.1"))
-        self._cache_recipe("gtest/0.1@user/testing", TestConanFile("gtest", "0.1"))
-        self._cache_recipe("lib/0.1@user/testing",
-                           TestConanFile("lib", "0.1",
-                                         build_requires=["gtest/0.1@user/testing"]))
-        profile_build_requires = {"*": [ConanFileReference.loads("mingw/0.1@user/testing")]}
-        deps_graph = self.build_graph(TestConanFile("app", "0.1",
-                                                    requires=["lib/0.1@user/testing"]),
+        mingw_ref = ConanFileReference.loads("mingw/0.1@user/testing")
+        gtest_ref = ConanFileReference.loads("gtest/0.1@user/testing")
+        lib_ref = ConanFileReference.loads("lib/0.1@user/testing")
+
+        self._cache_recipe(mingw_ref, GenConanfile().with_name("mingw").with_version("0.1"))
+        self._cache_recipe(gtest_ref, GenConanfile().with_name("gtest").with_version("0.1"))
+        self._cache_recipe(lib_ref, GenConanfile().with_name("lib").with_version("0.1")
+                                                  .with_build_requirement(gtest_ref))
+        profile_build_requires = {"*": [mingw_ref]}
+        deps_graph = self.build_graph(GenConanfile().with_name("app").with_version("0.1")
+                                                    .with_requirement(lib_ref),
                                       profile_build_requires=profile_build_requires)
 
         self.assertEqual(6, len(deps_graph.nodes))
@@ -360,35 +406,43 @@ class TransitiveGraphTest(GraphManagerTest):
                          dependents=[app], closure=[])
 
     def test_conflict_transitive_build_requires(self):
-        zlib_ref = "zlib/0.1@user/testing"
-        zlib_ref2 = "zlib/0.2@user/testing"
-        self._cache_recipe(zlib_ref, TestConanFile("zlib", "0.1"))
-        self._cache_recipe(zlib_ref2, TestConanFile("zlib", "0.2"))
+        zlib_ref = ConanFileReference.loads("zlib/0.1@user/testing")
+        zlib_ref2 = ConanFileReference.loads("zlib/0.2@user/testing")
+        gtest_ref = ConanFileReference.loads("gtest/0.1@user/testing")
+        lib_ref = ConanFileReference.loads("lib/0.1@user/testing")
 
-        self._cache_recipe("gtest/0.1@user/testing", TestConanFile("gtest", "0.1",
-                                                                   requires=[zlib_ref2]))
-        self._cache_recipe("lib/0.1@user/testing",
-                           TestConanFile("lib", "0.1", requires=[zlib_ref],
-                                         build_requires=["gtest/0.1@user/testing"]))
+        self._cache_recipe(zlib_ref, GenConanfile().with_name("zlib").with_version("0.1"))
+        self._cache_recipe(zlib_ref2, GenConanfile().with_name("zlib").with_version("0.2"))
+
+        self._cache_recipe(gtest_ref, GenConanfile().with_name("gtest").with_version("0.1")
+                                                    .with_requirement(zlib_ref2))
+        self._cache_recipe(lib_ref, GenConanfile().with_name("lib").with_version("0.1")
+                                                  .with_requirement(zlib_ref)
+                                                  .with_build_requirement(gtest_ref))
 
         with six.assertRaisesRegex(self, ConanException,
                                    "Requirement zlib/0.2@user/testing conflicts"):
-            self.build_graph(TestConanFile("app", "0.1", requires=["lib/0.1@user/testing"]))
+            self.build_graph(GenConanfile().with_name("app").with_version("0.1")
+                                           .with_requirement(lib_ref))
 
     def test_not_conflict_transitive_build_requires(self):
         # Same as above, but gtest->(build_require)->zlib2
-        zlib_ref = "zlib/0.1@user/testing"
-        zlib_ref2 = "zlib/0.2@user/testing"
-        self._cache_recipe(zlib_ref, TestConanFile("zlib", "0.1"))
-        self._cache_recipe(zlib_ref2, TestConanFile("zlib", "0.2"))
+        zlib_ref = ConanFileReference.loads("zlib/0.1@user/testing")
+        zlib_ref2 = ConanFileReference.loads("zlib/0.2@user/testing")
+        gtest_ref = ConanFileReference.loads("gtest/0.1@user/testing")
+        lib_ref = ConanFileReference.loads("lib/0.1@user/testing")
 
-        self._cache_recipe("gtest/0.1@user/testing", TestConanFile("gtest", "0.1",
-                                                                   build_requires=[zlib_ref2]))
-        self._cache_recipe("lib/0.1@user/testing",
-                           TestConanFile("lib", "0.1", requires=[zlib_ref],
-                                         build_requires=["gtest/0.1@user/testing"]))
+        self._cache_recipe(zlib_ref, GenConanfile().with_name("zlib").with_version("0.1"))
+        self._cache_recipe(zlib_ref2, GenConanfile().with_name("zlib").with_version("0.2"))
 
-        graph = self.build_graph(TestConanFile("app", "0.1", requires=["lib/0.1@user/testing"]))
+        self._cache_recipe(gtest_ref, GenConanfile().with_name("gtest").with_version("0.1")
+                                                    .with_build_requirement(zlib_ref2))
+        self._cache_recipe(lib_ref, GenConanfile().with_name("lib").with_version("0.1")
+                                                  .with_requirement(zlib_ref)
+                                                  .with_build_requirement(gtest_ref))
+
+        graph = self.build_graph(GenConanfile().with_name("app").with_version("0.1")
+                                               .with_requirement(lib_ref))
 
         self.assertEqual(5, len(graph.nodes))
         app = graph.root
@@ -407,19 +461,23 @@ class TransitiveGraphTest(GraphManagerTest):
 
     def test_diamond_no_option_conflict_build_requires(self):
         # Same as above, but gtest->(build_require)->zlib2
-        zlib_ref = "zlib/0.1@user/testing"
-        self._cache_recipe(zlib_ref, TestConanFile("zlib", "0.1",
-                                                   options='{"shared": [True, False]}',
-                                                   default_options='shared=False'))
+        zlib_ref = ConanFileReference.loads("zlib/0.1@user/testing")
+        gtest_ref = ConanFileReference.loads("gtest/0.1@user/testing")
+        lib_ref = ConanFileReference.loads("lib/0.1@user/testing")
 
-        self._cache_recipe("gtest/0.1@user/testing",
-                           TestConanFile("gtest", "0.1", requires=[zlib_ref],
-                                         default_options='zlib:shared=True'))
-        self._cache_recipe("lib/0.1@user/testing",
-                           TestConanFile("lib", "0.1", requires=[zlib_ref],
-                                         build_requires=["gtest/0.1@user/testing"]))
+        self._cache_recipe(zlib_ref, GenConanfile().with_name("zlib").with_version("0.1")
+                                                   .with_option("shared", [True, False])
+                                                   .with_default_option("shared", False))
 
-        graph = self.build_graph(TestConanFile("app", "0.1", requires=["lib/0.1@user/testing"]))
+        self._cache_recipe(gtest_ref, GenConanfile().with_name("gtest").with_version("0.1")
+                                                    .with_requirement(zlib_ref)
+                                                    .with_default_option("zlib:shared", True))
+        self._cache_recipe(lib_ref, GenConanfile().with_name("lib").with_version("0.1")
+                                                  .with_requirement(zlib_ref)
+                                                  .with_build_requirement(gtest_ref))
+
+        graph = self.build_graph(GenConanfile().with_name("app").with_version("0.1")
+                                               .with_requirement(lib_ref))
 
         self.assertEqual(4, len(graph.nodes))
         app = graph.root
@@ -440,42 +498,53 @@ class TransitiveGraphTest(GraphManagerTest):
 
     def test_diamond_option_conflict_build_requires(self):
         # Same as above, but gtest->(build_require)->zlib2
-        zlib_ref = "zlib/0.1@user/testing"
-        self._cache_recipe(zlib_ref, TestConanFile("zlib", "0.1",
-                                                   options='{"shared": [True, False]}',
-                                                   default_options='shared=False'))
+        zlib_ref = ConanFileReference.loads("zlib/0.1@user/testing")
+        gtest_ref = ConanFileReference.loads("gtest/0.1@user/testing")
+        lib_ref = ConanFileReference.loads("lib/0.1@user/testing")
+
+        self._cache_recipe(zlib_ref, GenConanfile().with_name("zlib").with_version("0.1")
+                                                   .with_option("shared", [True, False])
+                                                   .with_default_option("shared", False))
         configure = """
     def configure(self):
         self.options["zlib"].shared=True
         """
-        gtest = str(TestConanFile("gtest", "0.1", requires=[zlib_ref])) + configure
-        self._cache_recipe("gtest/0.1@user/testing", gtest)
-        self._cache_recipe("lib/0.1@user/testing",
-                           TestConanFile("lib", "0.1", requires=[zlib_ref],
-                                         build_requires=["gtest/0.1@user/testing"]))
+        gtest = str(GenConanfile().with_name("gtest").with_version("0.1")
+                                  .with_requirement(zlib_ref)) + configure
+        self._cache_recipe(gtest_ref, gtest)
+        self._cache_recipe(lib_ref, GenConanfile().with_name("lib").with_version("0.1")
+                                                  .with_requirement(zlib_ref)
+                                                  .with_build_requirement(gtest_ref))
 
         with six.assertRaisesRegex(self, ConanException,
                                    "tried to change zlib/0.1@user/testing option shared to True"):
-            self.build_graph(TestConanFile("app", "0.1", requires=["lib/0.1@user/testing"]))
+            self.build_graph(GenConanfile().with_name("app").with_version("0.1")
+                                           .with_requirement(lib_ref))
 
     def test_consecutive_diamonds_build_requires(self):
         # app -> libe0.1 -------------> libd0.1 -> libb0.1 -------------> liba0.1
         #    \-(build-require)-> libf0.1 ->/    \-(build-require)->libc0.1 ->/
-        liba_ref = "liba/0.1@user/testing"
-        libb_ref = "libb/0.1@user/testing"
-        libc_ref = "libc/0.1@user/testing"
-        libd_ref = "libd/0.1@user/testing"
-        libe_ref = "libe/0.1@user/testing"
-        libf_ref = "libf/0.1@user/testing"
-        self._cache_recipe(liba_ref, TestConanFile("liba", "0.1"))
-        self._cache_recipe(libb_ref, TestConanFile("libb", "0.1", requires=[liba_ref]))
-        self._cache_recipe(libc_ref, TestConanFile("libc", "0.1", requires=[liba_ref]))
-        self._cache_recipe(libd_ref, TestConanFile("libd", "0.1", requires=[libb_ref],
-                                                   build_requires=[libc_ref]))
-        self._cache_recipe(libe_ref, TestConanFile("libe", "0.1", requires=[libd_ref]))
-        self._cache_recipe(libf_ref, TestConanFile("libf", "0.1", requires=[libd_ref]))
-        deps_graph = self.build_graph(TestConanFile("app", "0.1", requires=[libe_ref],
-                                                    build_requires=[libf_ref]))
+        liba_ref = ConanFileReference.loads("liba/0.1@user/testing")
+        libb_ref = ConanFileReference.loads("libb/0.1@user/testing")
+        libc_ref = ConanFileReference.loads("libc/0.1@user/testing")
+        libd_ref = ConanFileReference.loads("libd/0.1@user/testing")
+        libe_ref = ConanFileReference.loads("libe/0.1@user/testing")
+        libf_ref = ConanFileReference.loads("libf/0.1@user/testing")
+        self._cache_recipe(liba_ref, GenConanfile().with_name("liba").with_version("0.1"))
+        self._cache_recipe(libb_ref, GenConanfile().with_name("libb").with_version("0.1")
+                                                   .with_requirement(liba_ref))
+        self._cache_recipe(libc_ref, GenConanfile().with_name("libc").with_version("0.1")
+                                                   .with_requirement(liba_ref))
+        self._cache_recipe(libd_ref, GenConanfile().with_name("libd").with_version("0.1")
+                                                   .with_requirement(libb_ref)
+                                                   .with_build_requirement(libc_ref))
+        self._cache_recipe(libe_ref, GenConanfile().with_name("libe").with_version("0.1")
+                                                   .with_requirement(libd_ref))
+        self._cache_recipe(libf_ref, GenConanfile().with_name("libf").with_version("0.1")
+                                                   .with_requirement(libd_ref))
+        deps_graph = self.build_graph(GenConanfile().with_name("app").with_version("0.1")
+                                                    .with_requirement(libe_ref)
+                                                    .with_build_requirement(libf_ref))
 
         self.assertEqual(7, len(deps_graph.nodes))
         app = deps_graph.root
@@ -504,21 +573,27 @@ class TransitiveGraphTest(GraphManagerTest):
     def test_consecutive_diamonds_private(self):
         # app -> libe0.1 -------------> libd0.1 -> libb0.1 -------------> liba0.1
         #    \-(private-req)-> libf0.1 ->/    \-(private-req)->libc0.1 ->/
-        liba_ref = "liba/0.1@user/testing"
-        libb_ref = "libb/0.1@user/testing"
-        libc_ref = "libc/0.1@user/testing"
-        libd_ref = "libd/0.1@user/testing"
-        libe_ref = "libe/0.1@user/testing"
-        libf_ref = "libf/0.1@user/testing"
-        self._cache_recipe(liba_ref, TestConanFile("liba", "0.1"))
-        self._cache_recipe(libb_ref, TestConanFile("libb", "0.1", requires=[liba_ref]))
-        self._cache_recipe(libc_ref, TestConanFile("libc", "0.1", requires=[liba_ref]))
-        self._cache_recipe(libd_ref, TestConanFile("libd", "0.1", requires=[libb_ref],
-                                                   private_requires=[libc_ref]))
-        self._cache_recipe(libe_ref, TestConanFile("libe", "0.1", requires=[libd_ref]))
-        self._cache_recipe(libf_ref, TestConanFile("libf", "0.1", requires=[libd_ref]))
-        deps_graph = self.build_graph(TestConanFile("app", "0.1", requires=[libe_ref],
-                                                    private_requires=[libf_ref]))
+        liba_ref = ConanFileReference.loads("liba/0.1@user/testing")
+        libb_ref = ConanFileReference.loads("libb/0.1@user/testing")
+        libc_ref = ConanFileReference.loads("libc/0.1@user/testing")
+        libd_ref = ConanFileReference.loads("libd/0.1@user/testing")
+        libe_ref = ConanFileReference.loads("libe/0.1@user/testing")
+        libf_ref = ConanFileReference.loads("libf/0.1@user/testing")
+        self._cache_recipe(liba_ref, GenConanfile().with_name("liba").with_version("0.1"))
+        self._cache_recipe(libb_ref, GenConanfile().with_name("libb").with_version("0.1")
+                                                   .with_requirement(liba_ref))
+        self._cache_recipe(libc_ref, GenConanfile().with_name("libc").with_version("0.1")
+                                                   .with_requirement(liba_ref))
+        self._cache_recipe(libd_ref, GenConanfile().with_name("libd").with_version("0.1")
+                                                   .with_requirement(libb_ref)
+                                                   .with_requirement(libc_ref, private=True))
+        self._cache_recipe(libe_ref, GenConanfile().with_name("libe").with_version("0.1")
+                                                   .with_requirement(libd_ref))
+        self._cache_recipe(libf_ref, GenConanfile().with_name("libf").with_version("0.1")
+                                                   .with_requirement(libd_ref))
+        deps_graph = self.build_graph(GenConanfile().with_name("app").with_version("0.1")
+                                                    .with_requirement(libe_ref)
+                                                    .with_requirement(libf_ref, private=True))
 
         self.assertEqual(7, len(deps_graph.nodes))
         app = deps_graph.root
@@ -549,17 +624,21 @@ class TransitiveGraphTest(GraphManagerTest):
         # app --------> libb0.1 ---------> liba0.1
         #    \--------> libc0.1 ----------->/
         #    \-(build_require)-> libd0.1 ->/
-        liba_ref = "liba/0.1@user/testing"
-        libb_ref = "libb/0.1@user/testing"
-        libc_ref = "libc/0.1@user/testing"
-        libd_ref = "libd/0.1@user/testing"
-        self._cache_recipe(liba_ref, TestConanFile("liba", "0.1"))
-        self._cache_recipe(libb_ref, TestConanFile("libb", "0.1", requires=[liba_ref]))
-        self._cache_recipe(libc_ref, TestConanFile("libc", "0.1", requires=[liba_ref]))
-        self._cache_recipe(libd_ref, TestConanFile("libd", "0.1", requires=[liba_ref]))
-        deps_graph = self.build_graph(TestConanFile("app", "0.1",
-                                                    requires=[libb_ref, libc_ref],
-                                                    build_requires=[libd_ref]))
+        liba_ref = ConanFileReference.loads("liba/0.1@user/testing")
+        libb_ref = ConanFileReference.loads("libb/0.1@user/testing")
+        libc_ref = ConanFileReference.loads("libc/0.1@user/testing")
+        libd_ref = ConanFileReference.loads("libd/0.1@user/testing")
+        self._cache_recipe(liba_ref, GenConanfile().with_name("liba").with_version("0.1"))
+        self._cache_recipe(libb_ref, GenConanfile().with_name("libb").with_version("0.1")
+                                                   .with_requirement(liba_ref))
+        self._cache_recipe(libc_ref, GenConanfile().with_name("libc").with_version("0.1")
+                                                   .with_requirement(liba_ref))
+        self._cache_recipe(libd_ref, GenConanfile().with_name("libd").with_version("0.1")
+                                                   .with_requirement(liba_ref))
+        deps_graph = self.build_graph(GenConanfile().with_name("app").with_version("0.1")
+                                                    .with_requirement(libb_ref)
+                                                    .with_requirement(libc_ref)
+                                                    .with_build_requirement(libd_ref))
 
         self.assertEqual(5, len(deps_graph.nodes))
         app = deps_graph.root
@@ -580,42 +659,50 @@ class TransitiveGraphTest(GraphManagerTest):
                          dependents=[libb, libc, libd], closure=[])
 
     def test_conflict_private(self):
-        liba_ref = "liba/0.1@user/testing"
-        liba_ref2 = "liba/0.2@user/testing"
-        libb_ref = "libb/0.1@user/testing"
-        libc_ref = "libc/0.1@user/testing"
-        self._cache_recipe(liba_ref, TestConanFile("liba", "0.1"))
-        self._cache_recipe(liba_ref2, TestConanFile("liba", "0.2"))
-        self._cache_recipe(libb_ref, TestConanFile("libb", "0.1", requires=[liba_ref]))
-        self._cache_recipe(libc_ref, TestConanFile("libc", "0.1", requires=[liba_ref2]))
+        liba_ref = ConanFileReference.loads("liba/0.1@user/testing")
+        liba_ref2 = ConanFileReference.loads("liba/0.2@user/testing")
+        libb_ref = ConanFileReference.loads("libb/0.1@user/testing")
+        libc_ref = ConanFileReference.loads("libc/0.1@user/testing")
+        self._cache_recipe(liba_ref, GenConanfile().with_name("liba").with_version("0.1"))
+        self._cache_recipe(liba_ref2, GenConanfile().with_name("liba").with_version("0.2"))
+        self._cache_recipe(libb_ref, GenConanfile().with_name("libb").with_version("0.1")
+                                                   .with_requirement(liba_ref))
+        self._cache_recipe(libc_ref, GenConanfile().with_name("libc").with_version("0.1")
+                                                   .with_requirement(liba_ref2))
         with six.assertRaisesRegex(self, ConanException,
                                    "Requirement liba/0.2@user/testing conflicts"):
-            self.build_graph(TestConanFile("app", "0.1", private_requires=[libb_ref, libc_ref]))
+            self.build_graph(GenConanfile().with_name("app").with_version("0.1")
+                                           .with_requirement(libb_ref, private=True)
+                                           .with_requirement(libc_ref, private=True))
 
     def test_loop_private(self):
         # app -> lib -(private)-> tool ->|
         #          \<-----(private)------|
-        lib_ref = "lib/0.1@user/testing"
-        self._cache_recipe("tool/0.1@user/testing", TestConanFile("tool", "0.1",
-                                                                  private_requires=[lib_ref]))
-        self._cache_recipe(lib_ref,
-                           TestConanFile("lib", "0.1",
-                                         private_requires=["tool/0.1@user/testing"]))
+        lib_ref = ConanFileReference.loads("lib/0.1@user/testing")
+        tool_ref = ConanFileReference.loads("tool/0.1@user/testing")
+
+        self._cache_recipe(tool_ref, GenConanfile().with_name("tool").with_version("0.1")
+                                                   .with_requirement(lib_ref, private=True))
+        self._cache_recipe(lib_ref, GenConanfile().with_name("lib").with_version("0.1")
+                                                  .with_requirement(tool_ref, private=True))
         with six.assertRaisesRegex(self, ConanException, "Loop detected: 'tool/0.1@user/testing' "
                                    "requires 'lib/0.1@user/testing'"):
-            self.build_graph(TestConanFile("app", "0.1", requires=[lib_ref]))
+            self.build_graph(GenConanfile().with_name("app").with_version("0.1")
+                                           .with_requirement(lib_ref))
 
     def test_build_require_private(self):
         # app -> lib -(br)-> tool -(private)-> zlib
-        zlib_ref = "zlib/0.1@user/testing"
-        self._cache_recipe(zlib_ref, TestConanFile("zlib", "0.1"))
-        self._cache_recipe("tool/0.1@user/testing", TestConanFile("tool", "0.1",
-                                                                  private_requires=[zlib_ref]))
-        self._cache_recipe("lib/0.1@user/testing",
-                           TestConanFile("lib", "0.1",
-                                         build_requires=["tool/0.1@user/testing"]))
-        deps_graph = self.build_graph(TestConanFile("app", "0.1",
-                                                    requires=["lib/0.1@user/testing"]))
+        zlib_ref = ConanFileReference.loads("zlib/0.1@user/testing")
+        tool_ref = ConanFileReference.loads("tool/0.1@user/testing")
+        lib_ref = ConanFileReference.loads("lib/0.1@user/testing")
+
+        self._cache_recipe(zlib_ref, GenConanfile().with_name("zlib").with_version("0.1"))
+        self._cache_recipe(tool_ref, GenConanfile().with_name("tool").with_version("0.1")
+                                                   .with_requirement(zlib_ref, private=True))
+        self._cache_recipe(lib_ref, GenConanfile().with_name("lib").with_version("0.1")
+                                                  .with_build_requirement(tool_ref))
+        deps_graph = self.build_graph(GenConanfile().with_name("app").with_version("0.1")
+                                                    .with_requirement(lib_ref))
 
         self.assertEqual(4, len(deps_graph.nodes))
         app = deps_graph.root
@@ -639,44 +726,54 @@ class TransitiveGraphTest(GraphManagerTest):
         # https://github.com/conan-io/conan/issues/4931
         # cheetah -> gazelle -> grass
         #    \--(private)------0.2----/
-        self._cache_recipe("grass/0.1@user/testing", TestConanFile("grass", "0.1"))
-        self._cache_recipe("grass/0.2@user/testing", TestConanFile("grass", "0.2"))
-        self._cache_recipe("gazelle/0.1@user/testing",
-                           TestConanFile("gazelle", "0.1",
-                                         requires=["grass/0.1@user/testing"]))
+        grass01_ref = ConanFileReference.loads("grass/0.1@user/testing")
+        grass02_ref = ConanFileReference.loads("grass/0.2@user/testing")
+        gazelle_ref = ConanFileReference.loads("gazelle/0.1@user/testing")
+
+        self._cache_recipe(grass01_ref, GenConanfile().with_name("grass").with_version("0.1"))
+        self._cache_recipe(grass02_ref, GenConanfile().with_name("grass").with_version("0.2"))
+        self._cache_recipe(gazelle_ref, GenConanfile().with_name("gazelle").with_version("0.1")
+                                                      .with_requirement(grass01_ref))
 
         with six.assertRaisesRegex(self, ConanException,
                                    "Requirement grass/0.2@user/testing conflicts"):
-            self.build_graph(TestConanFile("cheetah", "0.1", requires=["gazelle/0.1@user/testing"],
-                                           private_requires=["grass/0.2@user/testing"]))
+            self.build_graph(GenConanfile().with_name("cheetah").with_version("0.1")
+                                           .with_requirement(gazelle_ref)
+                                           .with_requirement(grass02_ref, private=True))
 
     def test_build_require_conflict(self):
         # https://github.com/conan-io/conan/issues/4931
         # cheetah -> gazelle -> grass
         #    \--(br)------0.2----/
-        self._cache_recipe("grass/0.1@user/testing", TestConanFile("grass", "0.1"))
-        self._cache_recipe("grass/0.2@user/testing", TestConanFile("grass", "0.2"))
-        self._cache_recipe("gazelle/0.1@user/testing",
-                           TestConanFile("gazelle", "0.1",
-                                         requires=["grass/0.1@user/testing"]))
+        grass01_ref = ConanFileReference.loads("grass/0.1@user/testing")
+        grass02_ref = ConanFileReference.loads("grass/0.2@user/testing")
+        gazelle_ref = ConanFileReference.loads("gazelle/0.1@user/testing")
+
+        self._cache_recipe(grass01_ref, GenConanfile().with_name("grass").with_version("0.1"))
+        self._cache_recipe(grass02_ref, GenConanfile().with_name("grass").with_version("0.2"))
+        self._cache_recipe(gazelle_ref, GenConanfile().with_name("gazelle").with_version("0.1")
+                                                      .with_requirement(grass01_ref))
 
         with six.assertRaisesRegex(self, ConanException,
                                    "Requirement grass/0.2@user/testing conflicts"):
-            self.build_graph(TestConanFile("cheetah", "0.1", requires=["gazelle/0.1@user/testing"],
-                                           build_requires=["grass/0.2@user/testing"]))
+            self.build_graph(GenConanfile().with_name("cheetah").with_version("0.1")
+                                           .with_requirement(gazelle_ref)
+                                           .with_build_requirement(grass02_ref))
 
     def test_build_require_link_order(self):
         # https://github.com/conan-io/conan/issues/4931
         # cheetah -> gazelle -> grass
         #    \--(br)------------/
-        self._cache_recipe("grass/0.1@user/testing", TestConanFile("grass", "0.1"))
-        self._cache_recipe("gazelle/0.1@user/testing",
-                           TestConanFile("gazelle", "0.1",
-                                         requires=["grass/0.1@user/testing"]))
+        grass01_ref = ConanFileReference.loads("grass/0.1@user/testing")
+        gazelle_ref = ConanFileReference.loads("gazelle/0.1@user/testing")
 
-        deps_graph = self.build_graph(TestConanFile("cheetah", "0.1",
-                                                    requires=["gazelle/0.1@user/testing"],
-                                                    build_requires=["grass/0.1@user/testing"]))
+        self._cache_recipe(grass01_ref, GenConanfile().with_name("grass").with_version("0.1"))
+        self._cache_recipe(gazelle_ref, GenConanfile().with_name("gazelle").with_version("0.1")
+                           .with_requirement(grass01_ref))
+
+        deps_graph = self.build_graph(GenConanfile().with_name("cheetah").with_version("0.1")
+                                                    .with_requirement(gazelle_ref)
+                                                    .with_build_requirement(grass01_ref))
 
         self.assertEqual(3, len(deps_graph.nodes))
         cheetah = deps_graph.root
@@ -691,18 +788,26 @@ class TransitiveGraphTest(GraphManagerTest):
 
     @parameterized.expand([(True, ), (False, )])
     def test_dont_skip_private(self, private_first):
-        liba_ref = "liba/0.1@user/testing"
-        libb_ref = "libb/0.1@user/testing"
-        libc_ref = "libc/0.1@user/testing"
+        liba_ref = ConanFileReference.loads("liba/0.1@user/testing")
+        libb_ref = ConanFileReference.loads("libb/0.1@user/testing")
+        libc_ref = ConanFileReference.loads("libc/0.1@user/testing")
 
-        self._cache_recipe(liba_ref, TestConanFile("liba", "0.1"))
-        self._cache_recipe(libb_ref, TestConanFile("libb", "0.1", requires=[liba_ref]))
+        self._cache_recipe(liba_ref, GenConanfile().with_name("liba").with_version("0.1"))
+        self._cache_recipe(libb_ref, GenConanfile().with_name("libb").with_version("0.1")
+                                                   .with_requirement(liba_ref))
 
-        libc = TestConanFile("libc", "0.1", requires=[libb_ref],
-                             private_requires=[liba_ref], private_first=private_first)
+        if private_first:
+            libc = GenConanfile().with_name("libc").with_version("0.1")\
+                                 .with_requirement(liba_ref, private=True) \
+                                 .with_requirement(libb_ref)
+        else:
+            libc = GenConanfile().with_name("libc").with_version("0.1")\
+                                 .with_requirement(libb_ref) \
+                                 .with_requirement(liba_ref, private=True)
+
         self._cache_recipe(libc_ref, libc)
-
-        deps_graph = self.build_graph(TestConanFile("app", "0.1", requires=[libc_ref]))
+        deps_graph = self.build_graph(GenConanfile().with_name("app").with_version("0.1")
+                                                    .with_requirement(libc_ref))
 
         self.assertEqual(4, len(deps_graph.nodes))
         app = deps_graph.root
@@ -730,19 +835,26 @@ class TransitiveGraphTest(GraphManagerTest):
 
     @parameterized.expand([(True, ), (False, )])
     def test_dont_conflict_private(self, private_first):
-        liba_ref = "liba/0.1@user/testing"
-        liba_ref2 = "liba/0.2@user/testing"
-        libb_ref = "libb/0.1@user/testing"
-        libc_ref = "libc/0.1@user/testing"
+        liba_ref = ConanFileReference.loads("liba/0.1@user/testing")
+        liba_ref2 = ConanFileReference.loads("liba/0.2@user/testing")
+        libb_ref = ConanFileReference.loads("libb/0.1@user/testing")
+        libc_ref = ConanFileReference.loads("libc/0.1@user/testing")
 
-        self._cache_recipe(liba_ref, TestConanFile("liba", "0.1"))
-        self._cache_recipe(liba_ref2, TestConanFile("liba", "0.2"))
-        self._cache_recipe(libb_ref, TestConanFile("libb", "0.1", private_requires=[liba_ref]))
-        self._cache_recipe(libc_ref, TestConanFile("libc", "0.1", requires=[libb_ref],
-                                                   private_requires=[liba_ref2],
-                                                   private_first=private_first))
+        self._cache_recipe(liba_ref, GenConanfile().with_name("liba").with_version("0.1"))
+        self._cache_recipe(liba_ref2, GenConanfile().with_name("liba").with_version("0.2"))
+        self._cache_recipe(libb_ref, GenConanfile().with_name("libb").with_version("0.1")
+                                                   .with_requirement(liba_ref, private=True))
+        if private_first:
+            self._cache_recipe(libc_ref, GenConanfile().with_name("libc").with_version("0.1")
+                                                       .with_requirement(liba_ref2, private=True)
+                                                       .with_requirement(libb_ref))
+        else:
+            self._cache_recipe(libc_ref, GenConanfile().with_name("libc").with_version("0.1")
+                                                       .with_requirement(libb_ref)
+                                                       .with_requirement(liba_ref2, private=True))
 
-        deps_graph = self.build_graph(TestConanFile("app", "0.1", requires=[libc_ref]))
+        deps_graph = self.build_graph(GenConanfile().with_name("app").with_version("0.1")
+                                                    .with_requirement(libc_ref))
 
         self.assertEqual(5, len(deps_graph.nodes))
         app = deps_graph.root
@@ -771,14 +883,17 @@ class TransitiveGraphTest(GraphManagerTest):
                          dependents=[libc], closure=[])
 
     def test_consecutive_private(self):
-        liba_ref = "liba/0.1@user/testing"
-        libb_ref = "libb/0.1@user/testing"
-        libc_ref = "libc/0.1@user/testing"
+        liba_ref = ConanFileReference.loads("liba/0.1@user/testing")
+        libb_ref = ConanFileReference.loads("libb/0.1@user/testing")
+        libc_ref = ConanFileReference.loads("libc/0.1@user/testing")
 
-        self._cache_recipe(liba_ref, TestConanFile("liba", "0.1"))
-        self._cache_recipe(libb_ref, TestConanFile("libb", "0.1", private_requires=[liba_ref]))
-        self._cache_recipe(libc_ref, TestConanFile("libc", "0.1", private_requires=[libb_ref]))
-        deps_graph = self.build_graph(TestConanFile("app", "0.1", requires=[libc_ref]))
+        self._cache_recipe(liba_ref, GenConanfile().with_name("liba").with_version("0.1"))
+        self._cache_recipe(libb_ref, GenConanfile().with_name("libb").with_version("0.1")
+                                                   .with_requirement(liba_ref, private=True))
+        self._cache_recipe(libc_ref, GenConanfile().with_name("libc").with_version("0.1")
+                                                   .with_requirement(libb_ref, private=True))
+        deps_graph = self.build_graph(GenConanfile().with_name("app").with_version("0.1")
+                                                    .with_requirement(libc_ref))
 
         self.assertEqual(4, len(deps_graph.nodes))
         app = deps_graph.root

--- a/conans/test/functional/graph/graph_manager_test.py
+++ b/conans/test/functional/graph/graph_manager_test.py
@@ -295,7 +295,7 @@ class TransitiveGraphTest(GraphManagerTest):
 
     def test_self_loop(self):
         ref1 = ConanFileReference.loads("base/1.0@user/testing")
-        self._cache_recipe(ref1, GenConanfile().with_name("base").with_version("1.0"))
+        self._cache_recipe(ref1, GenConanfile().with_name("base").with_version("0.1"))
         ref = ConanFileReference.loads("base/aaa@user/testing")
         with six.assertRaisesRegex(self, ConanException, "Loop detected: 'base/aaa@user/testing' "
                                    "requires 'base/aaa@user/testing'"):

--- a/conans/test/functional/graph/half_diamond_test.py
+++ b/conans/test/functional/graph/half_diamond_test.py
@@ -1,9 +1,9 @@
 import os
 import unittest
 
+from conans.model.ref import ConanFileReference
 from conans.paths import CONANFILE
-from conans.test.utils.conanfile import TestConanFile
-from conans.test.utils.tools import TestClient
+from conans.test.utils.tools import TestClient, GenConanfile
 from conans.util.files import load
 
 
@@ -14,9 +14,14 @@ class HalfDiamondTest(unittest.TestCase):
 
     def _export(self, name, deps=None, export=True):
 
-        conanfile = TestConanFile(name, "0.1", requires=deps,
-                                  options={"potato": [True, False]},
-                                  default_options="potato=True")
+        conanfile = GenConanfile().with_name(name).with_version("0.1")\
+                                  .with_option("potato", [True, False])\
+                                  .with_default_option("potato", True)
+        if deps:
+            for dep in deps:
+                ref = ConanFileReference.loads(dep)
+                conanfile = conanfile.with_requirement(ref)
+
         conanfile = str(conanfile) + """
     def config_options(self):
         del self.options.potato

--- a/conans/test/functional/graph/package_id_modes_test.py
+++ b/conans/test/functional/graph/package_id_modes_test.py
@@ -1,6 +1,7 @@
 from conans.client.tools import environment_append
+from conans.model.ref import ConanFileReference
 from conans.test.functional.graph.graph_manager_base import GraphManagerTest
-from conans.test.utils.conanfile import TestConanFile
+from conans.test.utils.tools import GenConanfile
 
 
 class PackageIDGraphTests(GraphManagerTest):
@@ -21,10 +22,12 @@ class PackageIDGraphTests(GraphManagerTest):
         configs.append((mode, "liba/1.1.1@user/stable", "b41d6c026473cffed4abded4b0eaa453497be1d2"))
 
         def _assert_recipe_mode(ref_arg, package_id_arg):
-            libb_ref = "libb/0.1@user/testing"
-            self._cache_recipe(ref, TestConanFile("liba", "0.1.1"))
-            self._cache_recipe(libb_ref, TestConanFile("libb", "0.1", requires=[ref_arg]))
-            deps_graph = self.build_graph(TestConanFile("app", "0.1", requires=[libb_ref]))
+            libb_ref = ConanFileReference.loads("libb/0.1@user/testing")
+            self._cache_recipe(ref_arg, GenConanfile().with_name("liba").with_version("0.1.1"))
+            self._cache_recipe(libb_ref, GenConanfile().with_name("libb").with_version("0.1")
+                                                       .with_requirement(ref_arg))
+            deps_graph = self.build_graph(GenConanfile().with_name("app").with_version("0.1")
+                                                        .with_requirement(libb_ref))
 
             self.assertEqual(3, len(deps_graph.nodes))
             app = deps_graph.root
@@ -36,20 +39,22 @@ class PackageIDGraphTests(GraphManagerTest):
 
         for package_id_mode, ref, package_id in configs:
             self.cache.config.set_item("general.default_package_id_mode", package_id_mode)
-            _assert_recipe_mode(ref, package_id)
+            _assert_recipe_mode(ConanFileReference.loads(ref), package_id)
 
         for package_id_mode, ref, package_id in configs:
             with environment_append({"CONAN_DEFAULT_PACKAGE_ID_MODE": package_id_mode}):
-                _assert_recipe_mode(ref, package_id)
+                _assert_recipe_mode(ConanFileReference.loads(ref), package_id)
 
     def test_package_revision_mode(self):
         self.cache.config.set_item("general.default_package_id_mode", "package_revision_mode")
-        liba_ref1 = "liba/0.1.1@user/testing"
-        libb_ref = "libb/0.1@user/testing"
-        self._cache_recipe(liba_ref1, TestConanFile("liba", "0.1.1"))
-        self._cache_recipe(libb_ref, TestConanFile("libb", "0.1", requires=[liba_ref1]))
+        liba_ref1 = ConanFileReference.loads("liba/0.1.1@user/testing")
+        libb_ref = ConanFileReference.loads("libb/0.1@user/testing")
+        self._cache_recipe(liba_ref1, GenConanfile().with_name("liba").with_version("0.1.1"))
+        self._cache_recipe(libb_ref, GenConanfile().with_name("libb").with_version("0.1")
+                                                   .with_requirement(liba_ref1))
 
-        deps_graph = self.build_graph(TestConanFile("app", "0.1", requires=[libb_ref]),
+        deps_graph = self.build_graph(GenConanfile().with_name("app").with_version("0.1")
+                                                    .with_requirement(libb_ref),
                                       install=False)
 
         self.assertEqual(3, len(deps_graph.nodes))

--- a/conans/test/functional/graph/private_deps_test.py
+++ b/conans/test/functional/graph/private_deps_test.py
@@ -7,10 +7,8 @@ from conans.model.info import ConanInfo
 from conans.model.ref import ConanFileReference
 from conans.paths import BUILD_INFO_CMAKE, CONANINFO
 from conans.test.utils.cpp_test_files import cpp_hello_conan_files
-from conans.test.utils.tools import NO_SETTINGS_PACKAGE_ID, TestClient, TestServer
+from conans.test.utils.tools import NO_SETTINGS_PACKAGE_ID, TestClient, TestServer, GenConanfile
 from conans.util.files import load
-from textwrap import dedent
-from conans.test.utils.conanfile import TestConanFile
 
 
 class PrivateBinariesTest(unittest.TestCase):
@@ -169,22 +167,30 @@ class V3D(ConanFile):
         self.assertNotIn("bzip2", conanbuildinfo)
 
     def test_private_dont_skip(self):
+        liba_ref = ConanFileReference.loads("LibA/0.1@conan/stable")
+
         client = TestClient()
-        client.save({"conanfile.py": str(TestConanFile("LibA", "0.1", info=True))})
+        client.save({"conanfile.py":
+                         str(GenConanfile().with_name("LibA").with_version("0.1")
+                             .with_package_info(cpp_info={"libs": ["mylibLibA0.1lib"]},
+                                                env_info={"MYENV": ["myenvLibA0.1env"]}))})
         client.run("create . LibA/0.1@conan/stable")
 
-        client.save({"conanfile.py": str(TestConanFile("LibB", "0.1",
-                                                       requires=["LibA/0.1@conan/stable"]))})
+        client.save({"conanfile.py": str(GenConanfile().with_name("LibB").with_version("0.1")
+                                                       .with_requirement(liba_ref))})
         client.run("create . LibB/0.1@conan/stable")
 
-        client.save({"conanfile.py": str(TestConanFile("LibC", "0.1",
-                                                       private_requires=["LibA/0.1@conan/stable"]))})
+        client.save({"conanfile.py": str(GenConanfile().with_name("LibC").with_version("0.1")
+                                                       .with_requirement(liba_ref, private=True))})
         client.run("create . LibC/0.1@conan/stable")
 
         for requires in (["LibB/0.1@conan/stable", "LibC/0.1@conan/stable"],
                          ["LibC/0.1@conan/stable", "LibB/0.1@conan/stable"]):
-            client.save({"conanfile.py": str(TestConanFile("LibD", "0.1",
-                                                           requires=requires))})
+            conanfile = GenConanfile().with_name("LibD").with_version("0.1")
+            for it in requires:
+                ref = ConanFileReference.loads(it)
+                conanfile = conanfile.with_requirement(ref)
+            client.save({"conanfile.py": conanfile})
             client.run("install . -g cmake")
             self.assertIn("LibA/0.1@conan/stable:5ab84d6acfe1f23c4fae0ab88f26e3a396351ac9 - Cache",
                           client.out)

--- a/conans/test/functional/graph/transitive_deps_test.py
+++ b/conans/test/functional/graph/transitive_deps_test.py
@@ -5,9 +5,9 @@ import unittest
 
 from parameterized import parameterized
 
+from conans.model.ref import ConanFileReference
 from conans.model.ref import PackageReference
-from conans.test.utils.conanfile import TestConanFile
-from conans.test.utils.tools import TestClient
+from conans.test.utils.tools import TestClient, GenConanfile
 from conans.util.files import load
 
 
@@ -17,15 +17,18 @@ class TransitiveDepsTest(unittest.TestCase):
         # Create dependency graph: C -> B -> A
         self.t = TestClient()
 
-        self.t.save({"A/conanfile.py": str(TestConanFile("AAAA", "1.0"))})
+        self.t.save({"A/conanfile.py": GenConanfile().with_name("AAAA").with_version("1.0")})
         self.t.run("export A user/channel")
 
-        self.t.save({"B/conanfile.py": str(TestConanFile("BBBB", "1.0",
-                                                         requires=["AAAA/1.0@user/channel"]))})
+        aaaa_ref = ConanFileReference.loads("AAAA/1.0@user/channel")
+        self.t.save({"B/conanfile.py": GenConanfile().with_name("BBBB").with_version("1.0")\
+                                                     .with_requirement(aaaa_ref)})
         self.t.run("export B user/channel")
-        self.t.save({"C/conanfile.py":
-                     str(TestConanFile("CCCC", "1.0", requires=["BBBB/1.0@user/channel"])) +
-                    "    generators='cmake'"})
+
+        bbbb_ref = ConanFileReference.loads("BBBB/1.0@user/channel")
+        self.t.save({"C/conanfile.py": GenConanfile().with_name("CCCC").with_version("1.0")\
+                                                     .with_requirement(bbbb_ref)\
+                                                     .with_generator("cmake")})
         self.t.run("export C user/channel")
 
     @parameterized.expand([(True, ), (False, )])
@@ -33,8 +36,11 @@ class TransitiveDepsTest(unittest.TestCase):
         deps = sorted(["AAAA/1.0@user/channel", "CCCC/1.0@user/channel"], reverse=inverse_order)
 
         # Create D -> A,C
-        self.t.save({"D/conanfile.py": str(TestConanFile("DDDD", "1.0",
-                                                         requires=deps))})
+        conanfile = GenConanfile().with_name("DDDD").with_version("1.0")
+        for dep in deps:
+            ref = ConanFileReference.loads(dep)
+            conanfile = conanfile.with_requirement(ref)
+        self.t.save({"D/conanfile.py": conanfile})
         self.t.run("create ./D user/channel --build=missing")
 
         # C is being built

--- a/conans/test/functional/graph/version_range_error_test.py
+++ b/conans/test/functional/graph/version_range_error_test.py
@@ -1,14 +1,15 @@
 import unittest
 
+from conans.model.ref import ConanFileReference
 from conans.paths import CONANFILE
-from conans.test.utils.conanfile import TestConanFile
-from conans.test.utils.tools import TestClient
+from conans.test.utils.tools import TestClient, GenConanfile
 
 
 class VersionRangesErrorTest(unittest.TestCase):
     def verbose_version_test(self):
         client = TestClient()
-        conanfile = TestConanFile("MyPkg", "0.1", requires=["MyOtherPkg/[~0.1]@user/testing"])
+        conanfile = GenConanfile().with_name("MyPkg").with_version("0.1")\
+                                  .with_requirement_plain("MyOtherPkg/[~0.1]@user/testing")
         client.save({CONANFILE: str(conanfile)})
         client.run("install . --build", assert_error=True)
         self.assertIn("from requirement 'MyOtherPkg/[~0.1]@user/testing'", client.out)
@@ -17,7 +18,11 @@ class VersionRangesErrorTest(unittest.TestCase):
         client = TestClient()
 
         def add(name, version, requires=None):
-            conanfile = TestConanFile(name, version, requires=requires)
+            conanfile = GenConanfile().with_name(name).with_version(version)
+            if requires:
+                for req in requires:
+                    ref = ConanFileReference.loads(req)
+                    conanfile = conanfile.with_requirement(ref)
             client.save({CONANFILE: str(conanfile)})
             client.run("export . user/testing")
 

--- a/conans/test/functional/graph_lock/graph_lock_test.py
+++ b/conans/test/functional/graph_lock/graph_lock_test.py
@@ -5,21 +5,20 @@ import unittest
 
 from conans.model.graph_lock import LOCKFILE, LOCKFILE_VERSION
 from conans.model.ref import ConanFileReference
-from conans.test.utils.conanfile import TestConanFile
-from conans.test.utils.tools import TestClient, TestServer
+from conans.test.utils.tools import TestClient, TestServer, GenConanfile
 from conans.util.files import load
 
 
 class GraphLockErrorsTest(unittest.TestCase):
     def missing_lock_error_test(self):
         client = TestClient()
-        client.save({"conanfile.py": str(TestConanFile("PkgA", "0.1"))})
+        client.save({"conanfile.py": str(GenConanfile().with_name("PkgA").with_version("0.1"))})
         client.run("install . --lockfile", assert_error=True)
         self.assertIn("ERROR: Missing lockfile in", client.out)
 
     def update_different_profile_test(self):
         client = TestClient()
-        client.save({"conanfile.py": str(TestConanFile("PkgA", "0.1"))})
+        client.save({"conanfile.py": str(GenConanfile().with_name("PkgA").with_version("0.1"))})
         client.run("install . -if=conf1 -s os=Windows")
         client.run("install . -if=conf2 -s os=Linux")
         client.run("graph update-lock conf1 conf2", assert_error=True)
@@ -29,7 +28,8 @@ class GraphLockErrorsTest(unittest.TestCase):
 
 
 class GraphLockCustomFilesTest(unittest.TestCase):
-    consumer = TestConanFile("PkgB", "0.1", requires=["PkgA/[>=0.1]@user/channel"])
+    consumer = GenConanfile().with_name("PkgB").with_version("0.1")\
+                             .with_requirement_plain("PkgA/[>=0.1]@user/channel")
     pkg_b_revision = "180919b324d7823f2683af9381d11431"
     pkg_b_id = "5bf1ba84b5ec8663764a406f08a7f9ae5d3d5fb5"
     pkg_b_package_revision = "#2913f67cea630aee496fe70fd38b5b0f"
@@ -40,15 +40,15 @@ class GraphLockCustomFilesTest(unittest.TestCase):
         lock_file_json = json.loads(lock_file)
         self.assertEqual(lock_file_json["version"], LOCKFILE_VERSION)
         self.assertEqual(2, len(lock_file_json["graph_lock"]["nodes"]))
-        self.assertIn("PkgA/0.1@user/channel#b55538d56afb03f068a054f11310ce5a:"
-                      "5ab84d6acfe1f23c4fae0ab88f26e3a396351ac9#6d56ca1040e37a13b75bc286f3e1a5ad",
+        self.assertIn("PkgA/0.1@user/channel#fa090239f8ba41ad559f8e934494ee2a:"
+                      "5ab84d6acfe1f23c4fae0ab88f26e3a396351ac9#0d561e10e25511b9bfa339d06360d7c1",
                       lock_file)
         self.assertIn('"%s:%s%s"' % (ref_b, self.pkg_b_id, rev_b), lock_file)
 
     def test(self):
         client = TestClient()
         self.client = client
-        client.save({"conanfile.py": str(TestConanFile("PkgA", "0.1"))})
+        client.save({"conanfile.py": str(GenConanfile().with_name("PkgA").with_version("0.1"))})
         client.run("create . PkgA/0.1@user/channel")
 
         # Use a consumer with a version rang
@@ -57,7 +57,7 @@ class GraphLockCustomFilesTest(unittest.TestCase):
         self._check_lock("PkgB/0.1@")
 
         # If we create a new PkgA version
-        client.save({"conanfile.py": str(TestConanFile("PkgA", "0.2"))})
+        client.save({"conanfile.py": str(GenConanfile().with_name("PkgA").with_version("0.2"))})
         client.run("create . PkgA/0.2@user/channel")
         client.save({"conanfile.py": self.consumer})
         client.run("install . --lockfile=custom.lock")
@@ -65,18 +65,19 @@ class GraphLockCustomFilesTest(unittest.TestCase):
 
 
 class GraphLockVersionRangeTest(unittest.TestCase):
-    consumer = TestConanFile("PkgB", "0.1", requires=["PkgA/[>=0.1]@user/channel"])
-    pkg_b_revision = "180919b324d7823f2683af9381d11431"
+    consumer = GenConanfile().with_name("PkgB").with_version("0.1")\
+                             .with_requirement_plain("PkgA/[>=0.1]@user/channel")
+    pkg_b_revision = "3b2aab3a9cd211f6e5575ed84bcb669b"
     pkg_b_id = "5bf1ba84b5ec8663764a406f08a7f9ae5d3d5fb5"
-    pkg_b_package_revision = "#2913f67cea630aee496fe70fd38b5b0f"
-    modified_pkg_b_revision = "e161d0bf1cd009d1815961619854119d"
-    modified_pkg_b_package_revision = "#a986ef401af61f8fc9f32695f475123e"
+    pkg_b_package_revision = "#96ed6206dbaf09b60d3c36acd1a6351d"
+    modified_pkg_b_revision = "5a00596c704e7f96ad13f538b21270a2"
+    modified_pkg_b_package_revision = "#6405a8dcd0e7fc6c2dee6fad9d01d7f4"
     graph_lock_command = "install ."
 
     def setUp(self):
         client = TestClient()
         self.client = client
-        client.save({"conanfile.py": str(TestConanFile("PkgA", "0.1"))})
+        client.save({"conanfile.py": str(GenConanfile().with_name("PkgA").with_version("0.1"))})
         client.run("create . PkgA/0.1@user/channel")
 
         # Use a consumer with a version range
@@ -86,7 +87,7 @@ class GraphLockVersionRangeTest(unittest.TestCase):
         self._check_lock("PkgB/0.1@")
 
         # If we create a new PkgA version
-        client.save({"conanfile.py": str(TestConanFile("PkgA", "0.2"))})
+        client.save({"conanfile.py": str(GenConanfile().with_name("PkgA").with_version("0.2"))})
         client.run("create . PkgA/0.2@user/channel")
         client.save({"conanfile.py": str(self.consumer)})
 
@@ -94,8 +95,8 @@ class GraphLockVersionRangeTest(unittest.TestCase):
         lock_file = load(os.path.join(self.client.current_folder, LOCKFILE))
         lock_file_json = json.loads(lock_file)
         self.assertEqual(2, len(lock_file_json["graph_lock"]["nodes"]))
-        self.assertIn("PkgA/0.1@user/channel#b55538d56afb03f068a054f11310ce5a:"
-                      "5ab84d6acfe1f23c4fae0ab88f26e3a396351ac9#6d56ca1040e37a13b75bc286f3e1a5ad",
+        self.assertIn("PkgA/0.1@user/channel#fa090239f8ba41ad559f8e934494ee2a:"
+                      "5ab84d6acfe1f23c4fae0ab88f26e3a396351ac9#0d561e10e25511b9bfa339d06360d7c1",
                       lock_file)
         self.assertIn('"%s:%s%s"' % (repr(ConanFileReference.loads(ref_b)), self.pkg_b_id, rev_b), lock_file)
 
@@ -181,12 +182,13 @@ class GraphLockVersionRangeTest(unittest.TestCase):
 
 
 class GraphLockBuildRequireVersionRangeTest(GraphLockVersionRangeTest):
-    consumer = TestConanFile("PkgB", "0.1", build_requires=["PkgA/[>=0.1]@user/channel"])
-    pkg_b_revision = "4e4df18e796d2a1bfc7bbce7f8865ecd"
+    consumer = GenConanfile().with_name("PkgB").with_version("0.1")\
+                             .with_build_requirement_plain("PkgA/[>=0.1]@user/channel")
+    pkg_b_revision = "b6f49e5ba6dd3d64af09a2f288e71330"
     pkg_b_id = "5ab84d6acfe1f23c4fae0ab88f26e3a396351ac9"
-    pkg_b_package_revision = "#4d2f336ae4c2979e2e56d28aed4c2ebb"
-    modified_pkg_b_revision = "e171fce5bb7af66e2315f78ea104c638"
-    modified_pkg_b_package_revision = "#7e88c21f05a1fd1f8529e7fad0d7a2e3"
+    pkg_b_package_revision = "#33a5634bbd9ec26b369d3900d91ea9a0"
+    modified_pkg_b_revision = "62a38c702f14cb9de952bb22b40d6ecc"
+    modified_pkg_b_package_revision = "#b7850e289326d594fbc10088d55f5259"
 
 
 class GraphLockVersionRangeInfoTest(GraphLockVersionRangeTest):
@@ -209,7 +211,7 @@ class GraphLockRevisionTest(unittest.TestCase):
         # Important to activate revisions
         client.run("config set general.revisions_enabled=True")
         self.client = client
-        client.save({"conanfile.py": str(TestConanFile("PkgA", "0.1"))})
+        client.save({"conanfile.py": str(GenConanfile().with_name("PkgA").with_version("0.1"))})
         client.run("create . PkgA/0.1@user/channel")
         client.run("upload PkgA/0.1@user/channel --all")
 
@@ -231,7 +233,12 @@ class GraphLockRevisionTest(unittest.TestCase):
         self._check_lock("PkgB/0.1@")
 
         # If we create a new PkgA revision, for example adding info
-        client.save({"conanfile.py": str(TestConanFile("PkgA", "0.1", info=True))})
+        client.save({"conanfile.py":
+                         str(GenConanfile().with_name("PkgA").with_version("0.1")
+                             .with_package_info(
+                             cpp_info={"libs": ["mylibPkgA0.1lib"]},
+                             env_info={"MYENV": ["myenvPkgA0.1env"]}))})
+
         client.run("create . PkgA/0.1@user/channel")
         client.save({"conanfile.py": str(consumer)})
 
@@ -239,8 +246,8 @@ class GraphLockRevisionTest(unittest.TestCase):
         lock_file = load(os.path.join(self.client.current_folder, LOCKFILE))
         lock_file_json = json.loads(lock_file)
         self.assertEqual(2, len(lock_file_json["graph_lock"]["nodes"]))
-        self.assertIn("PkgA/0.1@user/channel#b55538d56afb03f068a054f11310ce5a:"
-                      "5ab84d6acfe1f23c4fae0ab88f26e3a396351ac9#6d56ca1040e37a13b75bc286f3e1a5ad",
+        self.assertIn("PkgA/0.1@user/channel#fa090239f8ba41ad559f8e934494ee2a:"
+                      "5ab84d6acfe1f23c4fae0ab88f26e3a396351ac9#0d561e10e25511b9bfa339d06360d7c1",
                       lock_file)
         self.assertIn('"%s:%s%s"' % (repr(ConanFileReference.loads(ref_b)),
                                      self.pkg_b_id, rev_b), lock_file)
@@ -262,7 +269,7 @@ class GraphLockRevisionTest(unittest.TestCase):
 
         # Info also works
         client.run("info . --lockfile")
-        self.assertIn("Revision: b55538d56afb03f068a054f11310ce5a", client.out)
+        self.assertIn("Revision: fa090239f8ba41ad559f8e934494ee2a", client.out)
 
     def export_lock_test(self):
         # locking a version range at export

--- a/conans/test/functional/old/package_integrity_test.py
+++ b/conans/test/functional/old/package_integrity_test.py
@@ -2,9 +2,8 @@ import os
 import unittest
 
 from conans.model.ref import ConanFileReference, PackageReference
-from conans.test.utils.conanfile import TestConanFile
-from conans.test.utils.tools import TestClient, TestServer,\
-    NO_SETTINGS_PACKAGE_ID
+from conans.test.utils.tools import TestClient, TestServer, \
+    NO_SETTINGS_PACKAGE_ID, GenConanfile
 from conans.util.files import set_dirty
 
 
@@ -12,7 +11,7 @@ class PackageIngrityTest(unittest.TestCase):
 
     def remove_locks_test(self):
         client = TestClient()
-        client.save({"conanfile.py": str(TestConanFile())})
+        client.save({"conanfile.py": str(GenConanfile().with_name("Hello").with_version("0.1"))})
         client.run("create . lasote/testing")
         self.assertNotIn('does not contain a number!', client.out)
         ref = ConanFileReference.loads("Hello/0.1@lasote/testing")
@@ -33,7 +32,7 @@ class PackageIngrityTest(unittest.TestCase):
         test_server = TestServer([], users={"lasote": "mypass"})
         client = TestClient(servers={"default": test_server},
                             users={"default": [("lasote", "mypass")]})
-        client.save({"conanfile.py": str(TestConanFile())})
+        client.save({"conanfile.py": str(GenConanfile().with_name("Hello").with_version("0.1"))})
         client.run("create . lasote/testing")
         ref = ConanFileReference.loads("Hello/0.1@lasote/testing")
         pref = PackageReference(ref, NO_SETTINGS_PACKAGE_ID)

--- a/conans/test/functional/old/test_migrations.py
+++ b/conans/test/functional/old/test_migrations.py
@@ -10,9 +10,8 @@ from conans.client.output import ConanOutput
 from conans.client.tools.version import Version
 from conans.migrations import CONAN_VERSION
 from conans.model.ref import ConanFileReference
-from conans.test.utils.conanfile import TestConanFile
 from conans.test.utils.test_files import temp_folder
-from conans.test.utils.tools import TestClient
+from conans.test.utils.tools import TestClient, GenConanfile
 from conans.util.files import load, save
 
 
@@ -37,7 +36,7 @@ class TestMigrations(unittest.TestCase):
     def test_migrate_revision_metadata(self):
         # https://github.com/conan-io/conan/issues/4898
         client = TestClient()
-        client.save({"conanfile.py": str(TestConanFile("Hello", "0.1"))})
+        client.save({"conanfile.py": str(GenConanfile().with_name("Hello").with_version("0.1"))})
         client.run("create . user/testing")
         ref = ConanFileReference.loads("Hello/0.1@user/testing")
         layout1 = client.cache.package_layout(ref)
@@ -60,10 +59,10 @@ class TestMigrations(unittest.TestCase):
         client.run("search")  # This will fire a migration
 
         metadata_ref1 = client.cache.package_layout(ref).load_metadata()
-        self.assertEqual(metadata_ref1.recipe.revision, "2e48797069e65568befd81854aa8aaf0")
+        self.assertEqual(metadata_ref1.recipe.revision, "f9e0ab84b47b946f4c7c848d8f82d14e")
         pkg_metadata = metadata_ref1.packages["5ab84d6acfe1f23c4fae0ab88f26e3a396351ac9"]
-        self.assertEqual(pkg_metadata.recipe_revision, "2e48797069e65568befd81854aa8aaf0")
-        self.assertEqual(pkg_metadata.revision, "38d05b42210ca2becb43a05f9265abbe")
+        self.assertEqual(pkg_metadata.recipe_revision, "f9e0ab84b47b946f4c7c848d8f82d14e")
+        self.assertEqual(pkg_metadata.revision, "fa1923ec4342a0d9dc33eff7250432e8")
         self.assertEqual(list(metadata_ref1.packages.keys()),
                          ["5ab84d6acfe1f23c4fae0ab88f26e3a396351ac9"])
 

--- a/conans/test/functional/python_requires/python_requires_test.py
+++ b/conans/test/functional/python_requires/python_requires_test.py
@@ -7,17 +7,16 @@ from parameterized import parameterized
 
 from conans.model.ref import ConanFileReference
 from conans.paths import CONANFILE
-from conans.util.files import load
-from conans.test.utils.conanfile import TestConanFile
 from conans.test.utils.tools import TestClient, TestServer, \
-    NO_SETTINGS_PACKAGE_ID, create_local_git_repo
+    NO_SETTINGS_PACKAGE_ID, create_local_git_repo, GenConanfile
+from conans.util.files import load
 
 
 class PythonExtendTest(unittest.TestCase):
     def test_with_python_requires(self):
         # https://github.com/conan-io/conan/issues/5140
         client = TestClient()
-        client.save({"conanfile.py": TestConanFile("dep", "0.1")})
+        client.save({"conanfile.py": GenConanfile().with_name("dep").with_version("0.1")})
         client.run("export . user/testing")
         conanfile = textwrap.dedent("""
             from conans import ConanFile, python_requires
@@ -707,7 +706,8 @@ class Project(base_class.PythonRequires2, base_class2.PythonRequires22):
 
     def local_build_test(self):
         client = TestClient()
-        client.save({"conanfile.py": "var=42\n"+str(TestConanFile("Tool", "0.1"))})
+        client.save({"conanfile.py": "var=42\n"+
+                                     str(GenConanfile().with_name("Tool").with_version("0.1"))})
         client.run("export . Tool/0.1@user/channel")
 
         conanfile = """from conans import ConanFile, python_requires

--- a/conans/test/integration/package_id_test.py
+++ b/conans/test/integration/package_id_test.py
@@ -4,9 +4,8 @@ import unittest
 from conans.model.info import ConanInfo
 from conans.model.ref import ConanFileReference, PackageReference
 from conans.paths import CONANINFO
-from conans.test.utils.conanfile import TestConanFile
 from conans.test.utils.deprecation import catch_deprecation_warning
-from conans.test.utils.tools import TestClient
+from conans.test.utils.tools import TestClient, GenConanfile
 from conans.util.env_reader import get_env
 from conans.util.files import load
 
@@ -32,12 +31,19 @@ class Pkg(ConanFile):
         self.assertNotIn("arch_build=None", conaninfo)
 
     def _export(self, name, version, package_id_text=None, requires=None,
-                channel=None, default_option_value="off", settings=None):
-        conanfile = TestConanFile(name, version, requires=requires,
-                                  options={"an_option": ["on", "off"]},
-                                  default_options=[("an_option", "%s" % default_option_value)],
-                                  package_id=package_id_text,
-                                  settings=settings)
+                channel=None, default_option_value='"off"', settings=None):
+        conanfile = GenConanfile().with_name(name).with_version(version)\
+                                  .with_option(option_name="an_option", values=["on", "off"])\
+                                  .with_default_option("an_option", default_option_value)\
+                                  .with_package_id(package_id_text)
+        if settings:
+            for setting in settings:
+                conanfile = conanfile.with_setting(setting)
+
+        if requires:
+            for require in requires:
+                conanfile = conanfile.with_requirement(ConanFileReference.loads(require))
+
         self.client.save({"conanfile.py": str(conanfile)}, clean_first=True)
         revisions_enabled = self.client.cache.config.revisions_enabled
         self.client.disable_revisions()
@@ -57,7 +63,8 @@ class Pkg(ConanFile):
                      requires=["Hello/1.2.0@lasote/stable"])
 
         # Build the dependencies with --build missing
-        self.client.save({"conanfile.txt": "[requires]\nHello2/2.3.8@lasote/stable"}, clean_first=True)
+        self.client.save({"conanfile.txt": "[requires]\nHello2/2.3.8@lasote/stable"},
+                         clean_first=True)
         self.client.run("install . --build missing")
         self.assertIn("Hello2/2.Y.Z", [line.strip() for line in self.conaninfo.splitlines()])
 
@@ -89,13 +96,15 @@ class Pkg(ConanFile):
                           self.client.out)
 
         # Try to change user and channel too, should be the same, not rebuilt needed
-        self._export("Hello", "1.5.0", package_id_text=None, requires=None, channel="memsharded/testing")
+        self._export("Hello", "1.5.0", package_id_text=None, requires=None,
+                     channel="memsharded/testing")
         self.client.run("install Hello/1.5.0@memsharded/testing --build missing")
         self._export("Hello2", "2.3.8",
                      package_id_text='self.info.requires["Hello"].semver()',
                      requires=["Hello/1.5.0@memsharded/testing"])
 
-        self.client.save({"conanfile.txt": "[requires]\nHello2/2.3.8@lasote/stable"}, clean_first=True)
+        self.client.save({"conanfile.txt": "[requires]\nHello2/2.3.8@lasote/stable"},
+                         clean_first=True)
 
         if not self.client.cache.config.revisions_enabled:
             self.client.run("install .")
@@ -114,18 +123,21 @@ class Pkg(ConanFile):
                      requires=["Hello/1.2.0@lasote/stable"])
 
         # Build the dependencies with --build missing
-        self.client.save({"conanfile.txt": "[requires]\nHello2/2.3.8@lasote/stable"}, clean_first=True)
+        self.client.save({"conanfile.txt": "[requires]\nHello2/2.3.8@lasote/stable"},
+                         clean_first=True)
         self.client.run("install . --build missing")
         self.assertIn("Hello2/2.3.8", self.conaninfo)
 
         # If we change the user and channel should not be needed to rebuild
-        self._export("Hello", "1.2.0", package_id_text=None, requires=None, channel="memsharded/testing")
+        self._export("Hello", "1.2.0", package_id_text=None, requires=None,
+                     channel="memsharded/testing")
         self.client.run("install Hello/1.2.0@memsharded/testing --build missing")
         self._export("Hello2", "2.3.8",
                      package_id_text='self.info.requires["Hello"].full_version_mode()',
                      requires=["Hello/1.2.0@memsharded/testing"])
 
-        self.client.save({"conanfile.txt": "[requires]\nHello2/2.3.8@lasote/stable"}, clean_first=True)
+        self.client.save({"conanfile.txt": "[requires]\nHello2/2.3.8@lasote/stable"},
+                         clean_first=True)
         if not self.client.cache.config.revisions_enabled:
             self.client.run("install .")
             self.assertIn("Hello2/2.3.8@lasote/stable:3ec60bb399a8bcb937b7af196f6685ba878aab02",
@@ -145,7 +157,8 @@ class Pkg(ConanFile):
                      package_id_text='self.info.requires["Hello"].full_version_mode()',
                      requires=["Hello/1.5.0@lasote/stable"])
 
-        self.client.save({"conanfile.txt": "[requires]\nHello2/2.3.8@lasote/stable"}, clean_first=True)
+        self.client.save({"conanfile.txt": "[requires]\nHello2/2.3.8@lasote/stable"},
+                         clean_first=True)
         with self.assertRaises(Exception):
             self.client.run("install .")
         self.assertIn("Can't find a 'Hello2/2.3.8@lasote/stable' package", self.client.out)
@@ -157,30 +170,36 @@ class Pkg(ConanFile):
                      requires=["Hello/1.2.0@lasote/stable"])
 
         # Build the dependencies with --build missing
-        self.client.save({"conanfile.txt": "[requires]\nHello2/2.3.8@lasote/stable"}, clean_first=True)
+        self.client.save({"conanfile.txt": "[requires]\nHello2/2.3.8@lasote/stable"},
+                         clean_first=True)
         self.client.run("install . --build missing")
         self.assertIn("Hello2/2.3.8", self.conaninfo)
 
         # If we change the user and channel should be needed to rebuild
-        self._export("Hello", "1.2.0", package_id_text=None, requires=None, channel="memsharded/testing")
+        self._export("Hello", "1.2.0", package_id_text=None, requires=None,
+                     channel="memsharded/testing")
         self.client.run("install Hello/1.2.0@memsharded/testing --build missing")
         self._export("Hello2", "2.3.8",
                      package_id_text='self.info.requires["Hello"].full_recipe_mode()',
                      requires=["Hello/1.2.0@memsharded/testing"])
 
-        self.client.save({"conanfile.txt": "[requires]\nHello2/2.3.8@lasote/stable"}, clean_first=True)
+        self.client.save({"conanfile.txt": "[requires]\nHello2/2.3.8@lasote/stable"},
+                         clean_first=True)
         with self.assertRaises(Exception):
             self.client.run("install .")
         self.assertIn("Can't find a 'Hello2/2.3.8@lasote/stable' package", self.client.out)
 
-        # If we change only the package ID from hello (one more defaulted option to True) should not affect
-        self._export("Hello", "1.2.0", package_id_text=None, requires=None, default_option_value="on")
+        # If we change only the package ID from hello (one more defaulted option
+        #  to True) should not affect
+        self._export("Hello", "1.2.0", package_id_text=None, requires=None,
+                     default_option_value='"on"')
         self.client.run("install Hello/1.2.0@lasote/stable --build missing")
         self._export("Hello2", "2.3.8",
                      package_id_text='self.info.requires["Hello"].full_recipe_mode()',
                      requires=["Hello/1.2.0@lasote/stable"])
 
-        self.client.save({"conanfile.txt": "[requires]\nHello2/2.3.8@lasote/stable"}, clean_first=True)
+        self.client.save({"conanfile.txt": "[requires]\nHello2/2.3.8@lasote/stable"},
+                         clean_first=True)
 
         self.client.run("install .")
 
@@ -191,14 +210,18 @@ class Pkg(ConanFile):
                      requires=["Hello/1.2.0@lasote/stable"])
 
         # Build the dependencies with --build missing
-        self.client.save({"conanfile.txt": "[requires]\nHello2/2.3.8@lasote/stable"}, clean_first=True)
+        self.client.save({"conanfile.txt": "[requires]\nHello2/2.3.8@lasote/stable"},
+                         clean_first=True)
         self.client.run("install . --build missing")
         self.assertIn("Hello2/2.3.8", self.conaninfo)
 
-        # If we change only the package ID from hello (one more defaulted option to True) should affect
-        self._export("Hello", "1.2.0", package_id_text=None, requires=None, default_option_value="on")
+        # If we change only the package ID from hello (one more defaulted option
+        #  to True) should affect
+        self._export("Hello", "1.2.0", package_id_text=None, requires=None,
+                     default_option_value='"on"')
         self.client.run("install Hello/1.2.0@lasote/stable --build missing")
-        self.client.save({"conanfile.txt": "[requires]\nHello2/2.3.8@lasote/stable"}, clean_first=True)
+        self.client.save({"conanfile.txt": "[requires]\nHello2/2.3.8@lasote/stable"},
+                         clean_first=True)
         with self.assertRaises(Exception):
             self.client.run("install .")
         self.assertIn("Can't find a 'Hello2/2.3.8@lasote/stable' package", self.client.out)
@@ -211,7 +234,8 @@ class Pkg(ConanFile):
                      requires=["Hello/1.2.0@lasote/stable"])
 
         # Build the dependencies with --build missing
-        self.client.save({"conanfile.txt": "[requires]\nHello2/2.3.8@lasote/stable"}, clean_first=True)
+        self.client.save({"conanfile.txt": "[requires]\nHello2/2.3.8@lasote/stable"},
+                         clean_first=True)
         self.client.run("install . --build missing")
         self.assertIn("Hello2/2.3.8", self.conaninfo)
 
@@ -222,7 +246,8 @@ class Pkg(ConanFile):
                      package_id_text='self.info.requires["HelloNew"].unrelated_mode()',
                      requires=["HelloNew/1.2.0@lasote/stable"])
 
-        self.client.save({"conanfile.txt": "[requires]\nHello2/2.3.8@lasote/stable"}, clean_first=True)
+        self.client.save({"conanfile.txt": "[requires]\nHello2/2.3.8@lasote/stable"},
+                         clean_first=True)
         # Not needed to rebuild Hello2, it doesn't matter its requires
         if not self.client.cache.config.revisions_enabled:
             self.client.run("install .")
@@ -240,7 +265,7 @@ class Pkg(ConanFile):
         for package_id in [None, "self.info.vs_toolset_compatible()"]:
             self._export("Hello", "1.2.0", package_id_text=package_id,
                          channel="user/testing",
-                         settings='"compiler"')
+                         settings=["compiler", ])
             self.client.run('install Hello/1.2.0@user/testing '
                             ' -s compiler="Visual Studio" '
                             ' -s compiler.version=14 --build')
@@ -268,7 +293,7 @@ class Pkg(ConanFile):
         # By default is the same to build with native visual or the toolchain
         self._export("Hello", "1.2.0", package_id_text="self.info.vs_toolset_incompatible()",
                      channel="user/testing",
-                     settings='"compiler"',
+                     settings=["compiler", ],
                      )
         self.client.run('install Hello/1.2.0@user/testing '
                         ' -s compiler="Visual Studio" '
@@ -287,7 +312,7 @@ class Pkg(ConanFile):
             self.client.run("remove * -f")
             self._export("Hello", "1.2.0", package_id_text=package_id_text,
                          channel="user/testing",
-                         settings='"os", "os_build", "arch", "arch_build"')
+                         settings=["os", "os_build", "arch", "arch_build"])
             self.client.run('install Hello/1.2.0@user/testing '
                             ' -s os="Windows" '
                             ' -s os_build="Linux"'
@@ -342,7 +367,7 @@ class Pkg(ConanFile):
         self.client.run("remove * -f")
         self._export("Hello", "1.2.0",
                      channel="user/testing",
-                     settings='"os_build", "arch_build"')
+                     settings=["os_build", "arch_build"])
         self.client.run('install Hello/1.2.0@user/testing '
                         ' -s os_build="Linux"'
                         ' -s arch_build="x86"'
@@ -359,7 +384,7 @@ class Pkg(ConanFile):
     def test_standard_version_default_matching(self):
         self._export("Hello", "1.2.0",
                      channel="user/testing",
-                     settings='"compiler"')
+                     settings=["compiler", ])
 
         self.client.run('install Hello/1.2.0@user/testing '
                         ' -s compiler="gcc" -s compiler.libcxx=libstdc++11'
@@ -367,7 +392,7 @@ class Pkg(ConanFile):
 
         self._export("Hello", "1.2.0",
                      channel="user/testing",
-                     settings='"compiler", "cppstd"')
+                     settings=["compiler", "cppstd", ])
 
         with catch_deprecation_warning(self):
             self.client.run('info Hello/1.2.0@user/testing  -s compiler="gcc" '
@@ -390,7 +415,7 @@ class Pkg(ConanFile):
     def test_std_non_matching_with_cppstd(self):
         self._export("Hello", "1.2.0", package_id_text="self.info.default_std_non_matching()",
                      channel="user/testing",
-                     settings='"compiler", "cppstd"'
+                     settings=["compiler", "cppstd", ]
                      )
         self.client.run('install Hello/1.2.0@user/testing'
                         ' -s compiler="gcc" -s compiler.libcxx=libstdc++11'
@@ -406,7 +431,7 @@ class Pkg(ConanFile):
     def test_std_non_matching_with_compiler_cppstd(self):
         self._export("Hello", "1.2.0", package_id_text="self.info.default_std_non_matching()",
                      channel="user/testing",
-                     settings='"compiler"'
+                     settings=["compiler", ]
                      )
         self.client.run('install Hello/1.2.0@user/testing '
                         ' -s compiler="gcc" -s compiler.libcxx=libstdc++11'
@@ -420,7 +445,7 @@ class Pkg(ConanFile):
     def test_std_matching_with_compiler_cppstd(self):
         self._export("Hello", "1.2.0", package_id_text="self.info.default_std_matching()",
                      channel="user/testing",
-                     settings='"compiler"'
+                     settings=["compiler", ]
                      )
         self.client.run('install Hello/1.2.0@user/testing '
                         ' -s compiler="gcc" -s compiler.libcxx=libstdc++11'

--- a/conans/test/unittests/client/graph/version_ranges_graph_test.py
+++ b/conans/test/unittests/client/graph/version_ranges_graph_test.py
@@ -8,7 +8,7 @@ from conans.errors import ConanException
 from conans.model.ref import ConanFileReference
 from conans.model.requires import Requirements
 from conans.test.unittests.model.transitive_reqs_test import GraphTest
-from conans.test.utils.conanfile import TestConanFile
+from conans.test.utils.tools import TestClient, GenConanfile
 from conans.test.utils.tools import test_processed_profile
 
 
@@ -41,7 +41,7 @@ class VersionRangesTest(GraphTest):
         super(VersionRangesTest, self).setUp()
 
         for v in ["0.1", "0.2", "0.3", "1.1", "1.1.2", "1.2.1", "2.1", "2.2.1"]:
-            say_content = TestConanFile("Say", v)
+            say_content = GenConanfile().with_name("Say").with_version(v)
             say_ref = ConanFileReference.loads("Say/%s@myuser/testing" % v)
             self.retriever.save_recipe(say_ref, say_content)
 
@@ -65,8 +65,9 @@ class VersionRangesTest(GraphTest):
                                ("~=2", "2.2.1"),
                                ("~=2.1", "2.1"),
                                ]:
-            deps_graph = self.build_graph(TestConanFile("Hello", "1.2",
-                                                        requires=["Say/[%s]@myuser/testing" % expr]))
+            req = ConanFileReference.loads("Say/[%s]@myuser/testing" % expr)
+            deps_graph = self.build_graph(GenConanfile().with_name("Hello").with_version("1.2")
+                                                        .with_requirement(req))
 
             self.assertEqual(2, len(deps_graph.nodes))
             hello = _get_nodes(deps_graph, "Hello")[0]
@@ -98,8 +99,9 @@ class VersionRangesTest(GraphTest):
                                ("~=2", "2.2.1"),
                                ("~=2.1", "2.1"),
                                ]:
-            deps_graph = self.build_graph(TestConanFile("Hello", "1.2",
-                                                        requires=["Say/[%s]@myuser/testing" % expr]),
+            req = ConanFileReference.loads("Say/[%s]@myuser/testing" % expr)
+            deps_graph = self.build_graph(GenConanfile().with_name("Hello").with_version("1.2")
+                                                        .with_requirement(req),
                                           update=True)
             self.assertEqual(self.remote_manager.count, {'Say': 1})
             self.assertEqual(2, len(deps_graph.nodes))
@@ -163,8 +165,8 @@ class HelloConan(ConanFile):
                            ('("Say/[>=0.2 <=1.0]@myuser/testing", "override")', "0.3", True, True),
                            ])
     def transitive_test(self, version_range, solution, override, valid):
-        hello_text = TestConanFile("Hello", "1.2",
-                                   requires=["Say/[>0.1, <1]@myuser/testing"])
+        hello_text = GenConanfile().with_name("Hello").with_version("1.2")\
+                                   .with_requirement_plain("Say/[>0.1, <1]@myuser/testing")
         hello_ref = ConanFileReference.loads("Hello/1.2@myuser/testing")
         self.retriever.save_recipe(hello_ref, hello_text)
 
@@ -210,7 +212,7 @@ class ChatConan(ConanFile):
         self.assertEqual(_clear_revs(conanfile.requires), Requirements(str(say_ref)))
 
     def duplicated_error_test(self):
-        content = TestConanFile("log4cpp", "1.1.1")
+        content = GenConanfile().with_name("log4cpp").with_version("1.1.1")
         log4cpp_ref = ConanFileReference.loads("log4cpp/1.1.1@myuser/testing")
         self.retriever.save_recipe(log4cpp_ref, content)
 

--- a/conans/test/unittests/model/transitive_reqs_test.py
+++ b/conans/test/unittests/model/transitive_reqs_test.py
@@ -35,7 +35,7 @@ bye_ref = ConanFileReference.loads("Bye/0.2@user/testing")
 say_content = GenConanfile().with_name("Say").with_version("0.1")
 say_content2 = GenConanfile().with_name("Say").with_version("0.2")
 hello_content = GenConanfile().with_name("Hello").with_version("1.2")\
-                              .with_requirement_plain(say_ref)
+                              .with_requirement(say_ref)
 chat_content = GenConanfile().with_name("Chat").with_version("2.3")\
                              .with_requirement(hello_ref)
 bye_content = GenConanfile().with_name("Bye").with_version("0.1")\

--- a/conans/test/unittests/model/transitive_reqs_test.py
+++ b/conans/test/unittests/model/transitive_reqs_test.py
@@ -6,6 +6,7 @@ from mock import Mock
 
 from conans import DEFAULT_REVISION_V1
 from conans.client.cache.cache import ClientCache
+from conans.client.cache.remote_registry import Remotes
 from conans.client.conf import default_settings_yml
 from conans.client.graph.build_mode import BuildMode
 from conans.client.graph.graph_binaries import GraphBinariesAnalyzer
@@ -21,24 +22,26 @@ from conans.model.requires import Requirements
 from conans.model.settings import Settings, bad_value_msg
 from conans.model.values import Values
 from conans.test.unittests.model.fake_retriever import Retriever
-from conans.test.utils.conanfile import TestConanFile
 from conans.test.utils.tools import (NO_SETTINGS_PACKAGE_ID, TestBufferConanOutput,
-                                     test_processed_profile)
-from conans.client.cache.remote_registry import Remotes
-
-say_content = TestConanFile("Say", "0.1")
-say_content2 = TestConanFile("Say", "0.2")
-hello_content = TestConanFile("Hello", "1.2", requires=["Say/0.1@user/testing"])
-chat_content = TestConanFile("Chat", "2.3", requires=["Hello/1.2@user/testing"])
-bye_content = TestConanFile("Bye", "0.1", requires=["Say/0.1@user/testing"])
-bye_content2 = TestConanFile("Bye", "0.2", requires=["Say/0.2@user/testing"])
-
+                                     test_processed_profile, GenConanfile)
 
 hello_ref = ConanFileReference.loads("Hello/1.2@user/testing")
 say_ref = ConanFileReference.loads("Say/0.1@user/testing")
 say_ref2 = ConanFileReference.loads("Say/0.2@user/testing")
 chat_ref = ConanFileReference.loads("Chat/2.3@user/testing")
 bye_ref = ConanFileReference.loads("Bye/0.2@user/testing")
+
+
+say_content = GenConanfile().with_name("Say").with_version("0.1")
+say_content2 = GenConanfile().with_name("Say").with_version("0.2")
+hello_content = GenConanfile().with_name("Hello").with_version("1.2")\
+                              .with_requirement_plain(say_ref)
+chat_content = GenConanfile().with_name("Chat").with_version("2.3")\
+                             .with_requirement(hello_ref)
+bye_content = GenConanfile().with_name("Bye").with_version("0.1")\
+                            .with_requirement(say_ref)
+bye_content2 = GenConanfile().with_name("Bye").with_version("0.2")\
+                             .with_requirement(say_ref2)
 
 
 def _get_nodes(graph, name):
@@ -1090,9 +1093,9 @@ class HelloConan(ConanFile):
         zlib_ref = ConanFileReference.loads("Zlib/0.1@user/testing")
         png_ref = ConanFileReference.loads("png/0.1@user/testing")
         base_ref = ConanFileReference.loads("Base/0.1@user/testing")
-        self.retriever.save_recipe(zlib_ref, TestConanFile("ZLib", "0.1"))
-        self.retriever.save_recipe(base_ref, TestConanFile("Base", "0.1"))
-        self.retriever.save_recipe(png_ref, TestConanFile("png", "0.1"))
+        self.retriever.save_recipe(zlib_ref, GenConanfile().with_name("ZLib").with_version("0.1"))
+        self.retriever.save_recipe(base_ref, GenConanfile().with_name("Base").with_version("0.1"))
+        self.retriever.save_recipe(png_ref, GenConanfile().with_name("png").with_version("0.1"))
         self.retriever.save_recipe(say_ref, say_content)
         self.retriever.save_recipe(hello_ref, hello_content)
 
@@ -1100,8 +1103,9 @@ class HelloConan(ConanFile):
     Previous requirements: [Base/0.1@user/testing, png/0.1@user/testing]
     New requirements: [Base/0.1@user/testing, Zlib/0.1@user/testing]"""
         try:
-            self.build_graph(TestConanFile("Chat", "2.3", requires=["Say/0.1@user/testing",
-                                                                    "Hello/1.2@user/testing"]))
+            self.build_graph(GenConanfile().with_name("Chat").with_version("2.3")
+                                           .with_requirement(say_ref)
+                                           .with_requirement(hello_ref))
             self.assert_(False, "Exception not thrown")
         except ConanException as e:
             self.assertEqual(str(e), expected)
@@ -1543,14 +1547,16 @@ class LibDConan(ConanFile):
         then, the other downstream is discarded there, no need to propagate twice
         upstream
         """
+        libb_ref = ConanFileReference.loads("LibB/0.1@user/testing")
         libd_ref = ConanFileReference.loads("LibD/0.1@user/testing")
-        self.retriever.save_recipe(libd_ref, TestConanFile("LibD", "0.1",
-                                                           requires=["LibB/0.1@user/testing"],
-                                                           default_options="LibA:shared=True"))
         libc_ref = ConanFileReference.loads("LibC/0.1@user/testing")
-        self.retriever.save_recipe(libc_ref, TestConanFile("LibC", "0.1",
-                                                           requires=["LibB/0.1@user/testing"],
-                                                           default_options="LibA:shared=False"))
+
+        self.retriever.save_recipe(libd_ref, GenConanfile().with_name("LibD").with_version("0.1")
+                                                           .with_requirement(libb_ref)
+                                                           .with_default_option("LibA:shared", True))
+        self.retriever.save_recipe(libc_ref, GenConanfile().with_name("LibC").with_version("0.1")
+                                                           .with_requirement(libb_ref)
+                                                           .with_default_option("LibA:shared", False))
 
         with six.assertRaisesRegex(self, ConanException,
                                    "LibD/0.1@user/testing tried to change LibB/0.1@user/testing "

--- a/conans/test/utils/conanfile.py
+++ b/conans/test/utils/conanfile.py
@@ -56,61 +56,6 @@ class MockConanfile(ConanFile):
             self.runner(*args, **kwargs)
 
 
-class TestConanFile(object):
-    def __init__(self, name="Hello", version="0.1", settings=None, requires=None, options=None,
-                 default_options=None, package_id=None, build_requires=None, info=None,
-                 private_requires=None, private_first=False):
-        self.name = name
-        self.version = version
-        self.settings = settings
-        self.requires = requires
-        self.private_requires = private_requires
-        self.build_requires = build_requires
-        self.options = options
-        self.default_options = default_options
-        self.package_id = package_id
-        self.info = info
-        self.private_first = private_first
-
-    def __repr__(self):
-        base = """from conans import ConanFile
-
-class {name}Conan(ConanFile):
-    name = "{name}"
-    version = "{version}"
-""".format(name=self.name, version=self.version)
-        if self.settings:
-            base += "    settings = %s\n" % self.settings
-        if self.requires or self.private_requires:
-            if self.private_first:
-                reqs_list = ["('%s', 'private')" % r for r in self.private_requires or []]
-                reqs_list.extend(['"%s"' % r for r in self.requires or []])
-            else:
-                reqs_list = ['"%s"' % r for r in self.requires or []]
-                reqs_list.extend(["('%s', 'private')" % r for r in self.private_requires or []])
-            reqs_list.append("")
-            base += "    requires = %s\n" % (", ".join(reqs_list))
-        if self.build_requires:
-            base += "    build_requires = %s\n" % (", ".join('"%s"' % r
-                                                             for r in self.build_requires))
-        if self.options:
-            base += "    options = %s\n" % str(self.options)
-        if self.default_options:
-            if isinstance(self.default_options, str):
-                base += "    default_options = '%s'\n" % str(self.default_options)
-            else:
-                base += "    default_options = %s\n" % str(self.default_options)
-        if self.package_id:
-            base += "    def package_id(self):\n        %s\n" % self.package_id
-        if self.info:
-            base += """
-    def package_info(self):
-        self.cpp_info.libs = ["mylib{name}{version}lib"]
-        self.env_info.MYENV = ["myenv{name}{version}env"]
-""".format(name=self.name, version=self.version)
-        return base
-
-
 class ConanFileMock(ConanFile):
 
     def __init__(self, shared=None, options=None, options_values=None):

--- a/conans/test/utils/tools.py
+++ b/conans/test/utils/tools.py
@@ -996,6 +996,7 @@ class GenConanfile(object):
         self._package_files_env = {}
         self._build_messages = []
         self._scm = {}
+        self._requires = []
         self._requirements = []
         self._build_requirements = []
         self._revision_mode = None
@@ -1020,6 +1021,10 @@ class GenConanfile(object):
 
     def with_generator(self, generator):
         self._generators.append(generator)
+        return self
+
+    def with_require(self, ref, private=False, override=False):
+        self._requires.append((ref.full_str(), private, override))
         return self
 
     def with_requirement(self, ref, private=False, override=False):
@@ -1146,6 +1151,21 @@ class GenConanfile(object):
         return tmp
 
     @property
+    def _requires_line(self):
+        if not self._requires:
+            return ""
+        items = []
+        for ref, private, override in self._requires:
+            if private or override:
+                private_str = ", 'private'" if private else ""
+                override_str = ", 'override'" if override else ""
+                items.append('("{}"{}{})'.format(ref, private_str, override_str))
+            else:
+                items.append('"{}"'.format(ref))
+        tmp = "requires = ({})".format(", ".join(items))
+        return tmp
+
+    @property
     def _requirements_method(self):
         if not self._requirements:
             return ""
@@ -1228,6 +1248,8 @@ class GenConanfile(object):
             ret.append("    {}".format(self._version_line))
         if self._generators_line:
             ret.append("    {}".format(self._generators_line))
+        if self._requires_line:
+            ret.append("    {}".format(self._requires_line))
         if self._requirements_method:
             ret.append("    {}".format(self._requirements_method))
         if self._build_requires_line:

--- a/conans/test/utils/tools.py
+++ b/conans/test/utils/tools.py
@@ -1127,9 +1127,14 @@ class GenConanfile(object):
             return ""
         line = ", ".join('"%s": %s' % (k, v) for k, v in self._options.items())
         tmp = "options = {%s}" % line
-        if self._default_options:
-            line = ", ".join('"%s": %s' % (k, v) for k, v in self._default_options.items())
-            tmp += "\n    default_options = {%s}" % line
+        return tmp
+
+    @property
+    def _default_options_line(self):
+        if not self._default_options:
+            return ""
+        line = ", ".join('"%s": %s' % (k, v) for k, v in self._default_options.items())
+        tmp = "default_options = {%s}" % line
         return tmp
 
     @property
@@ -1235,6 +1240,8 @@ class GenConanfile(object):
             ret.append("    {}".format(self._settings_line))
         if self._options_line:
             ret.append("    {}".format(self._options_line))
+        if self._default_options_line:
+            ret.append("    {}".format(self._default_options_line))
         if self._build_method:
             ret.append("    {}".format(self._build_method))
         if self._package_method:


### PR DESCRIPTION
Changelog: omit
Docs: omit

Unifying test code: `TestConanFile` is deprecated in favor of `GenConanfile`

closes #5525 

@tags: slow