### PR TITLE
Fix range resolver with different user/channel

### DIFF
--- a/conans/client/graph/range_resolver.py
+++ b/conans/client/graph/range_resolver.py
@@ -162,9 +162,6 @@ class RangeResolver(object):
             # Searching for just the name is much faster in remotes like Artifactory
             found_refs, remote_name = self._search_remotes(search_ref, remotes)
             if found_refs:
-                found_refs = [r for r in found_refs
-                              if r.user == search_ref.user and r.channel == search_ref.channel]
-            if found_refs:
                 self._result.append("%s versions found in '%s' remote" % (search_ref, remote_name))
             else:
                 self._result.append("%s versions not found in remotes")

--- a/conans/client/graph/range_resolver.py
+++ b/conans/client/graph/range_resolver.py
@@ -1,4 +1,3 @@
-import fnmatch
 import re
 
 from conans.errors import ConanException
@@ -145,19 +144,15 @@ class RangeResolver(object):
             return self._resolve_version(version_range, local_found)
 
     def _search_remotes(self, search_ref, remotes):
-        remote = remotes.selected
-        if remote:
-            search_result = self._remote_manager.search_recipes(remote, search_ref.name,
-                                                                ignorecase=False)
-            return search_result, remote.name
-
         for remote in remotes.values():
-            search_result = self._remote_manager.search_recipes(remote, search_ref.name,
-                                                                ignorecase=False)
-            search_result = [ref for ref in search_result
-                             if ref.user == search_ref.user and ref.channel == search_ref.channel]
-            if search_result:
-                return search_result, remote.name
+            if not remotes.selected or remote == remotes.selected:
+                search_result = self._remote_manager.search_recipes(remote, search_ref.name,
+                                                                    ignorecase=False)
+                search_result = [ref for ref in search_result
+                                 if ref.user == search_ref.user and
+                                 ref.channel == search_ref.channel]
+                if search_result:
+                    return search_result, remote.name
         return None, None
 
     def _resolve_remote(self, search_ref, version_range, remotes):

--- a/conans/client/graph/range_resolver.py
+++ b/conans/client/graph/range_resolver.py
@@ -1,3 +1,4 @@
+import fnmatch
 import re
 
 from conans.errors import ConanException
@@ -143,14 +144,18 @@ class RangeResolver(object):
         if local_found:
             return self._resolve_version(version_range, local_found)
 
-    def _search_remotes(self, pattern, remotes):
+    def _search_remotes(self, search_ref, remotes):
         remote = remotes.selected
         if remote:
-            search_result = self._remote_manager.search_recipes(remote, pattern, ignorecase=False)
+            search_result = self._remote_manager.search_recipes(remote, search_ref.name,
+                                                                ignorecase=False)
             return search_result, remote.name
 
         for remote in remotes.values():
-            search_result = self._remote_manager.search_recipes(remote, pattern, ignorecase=False)
+            search_result = self._remote_manager.search_recipes(remote, search_ref.name,
+                                                                ignorecase=False)
+            search_result = [ref for ref in search_result
+                             if ref.user == search_ref.user and ref.channel == search_ref.channel]
             if search_result:
                 return search_result, remote.name
         return None, None
@@ -160,7 +165,7 @@ class RangeResolver(object):
         found_refs, remote_name = self._cached_remote_found.get(search_ref, (None, None))
         if found_refs is None:
             # Searching for just the name is much faster in remotes like Artifactory
-            found_refs, remote_name = self._search_remotes(search_ref.name, remotes)
+            found_refs, remote_name = self._search_remotes(search_ref, remotes)
             if found_refs:
                 found_refs = [r for r in found_refs
                               if r.user == search_ref.user and r.channel == search_ref.channel]


### PR DESCRIPTION
Changelog: Bugfix: Using the version ranges mechanism Conan wasn't able to resolve the correct reference if a library with the same name but different user/channel was found in an earlier remote.
Docs: omit

Closes #5649 