### PR TITLE
Opt-out for Git shallow clone in SCM feature

### DIFF
--- a/conans/client/source.py
+++ b/conans/client/source.py
@@ -240,7 +240,8 @@ def _run_scm(conanfile, src_folder, local_sources_path, output, cache):
     else:
         output.info("Getting sources from url: '%s' (shallow=%s)" % (scm_data.url, scm_data.shallow))
         scm = SCM(scm_data, dest_dir, output)
-        scm.checkout()
+        out = scm.checkout()
+        output.info(out)
 
     if cache:
         # This is a bit weird. Why after a SCM should we remove files. Maybe check conan 2.0

--- a/conans/client/source.py
+++ b/conans/client/source.py
@@ -238,7 +238,7 @@ def _run_scm(conanfile, src_folder, local_sources_path, output, cache):
         output.info("Getting sources from folder: %s" % local_sources_path)
         merge_directories(local_sources_path, dest_dir, excluded=excluded)
     else:
-        output.info("Getting sources from url: '%s'" % scm_data.url)
+        output.info("Getting sources from url: '%s' (shallow=%s)" % (scm_data.url, scm_data.shallow))
         scm = SCM(scm_data, dest_dir, output)
         scm.checkout()
 

--- a/conans/client/source.py
+++ b/conans/client/source.py
@@ -238,10 +238,9 @@ def _run_scm(conanfile, src_folder, local_sources_path, output, cache):
         output.info("Getting sources from folder: %s" % local_sources_path)
         merge_directories(local_sources_path, dest_dir, excluded=excluded)
     else:
-        output.info("Getting sources from url: '%s' (shallow=%s)" % (scm_data.url, scm_data.shallow))
+        output.info("Getting sources from url: '%s'" % scm_data.url)
         scm = SCM(scm_data, dest_dir, output)
-        out = scm.checkout()
-        output.info(out)
+        scm.checkout()
 
     if cache:
         # This is a bit weird. Why after a SCM should we remove files. Maybe check conan 2.0

--- a/conans/model/scm.py
+++ b/conans/model/scm.py
@@ -19,7 +19,7 @@ def get_scm_data(conanfile):
 def _get_dict_value(data, key, expected_type, default=None):
     if key in data:
         r = data.get(key)
-        if not isinstance(r, expected_type):
+        if r is not None and not isinstance(r, expected_type):  # None has to be a valid value
             type_str = "' or '".join([it.__name__ for it in expected_type]) \
                 if isinstance(expected_type, tuple) else expected_type.__name__
             raise ConanException("SCM value for '{}' must be of type '{}'"
@@ -36,7 +36,7 @@ class SCMData(object):
         data = getattr(conanfile, "scm")
         self.type = _get_dict_value(data, "type", string_types)
         self.url = _get_dict_value(data, "url", string_types)
-        self.revision = _get_dict_value(data, "revision", (string_types, int))
+        self.revision = _get_dict_value(data, "revision", string_types + (int, ))
         self.verify_ssl = _get_dict_value(data, "verify_ssl", bool, SCMData.VERIFY_SSL_DEFAULT)
         self.username = _get_dict_value(data, "username", string_types)
         self.password = _get_dict_value(data, "password", string_types)

--- a/conans/model/scm.py
+++ b/conans/model/scm.py
@@ -27,7 +27,7 @@ class SCMData(object):
             self.password = data.get("password")
             self.subfolder = data.get("subfolder")
             self.submodule = data.get("submodule")
-            self.shallow_clone = data.get("shallow")
+            self.shallow = data.get("shallow")
         else:
             raise ConanException("Not SCM enabled in conanfile")
 
@@ -48,7 +48,7 @@ class SCMData(object):
     def __repr__(self):
         d = {"url": self.url, "revision": self.revision, "username": self.username,
              "password": self.password, "type": self.type, "verify_ssl": self.verify_ssl,
-             "subfolder": self.subfolder, "submodule": self.submodule, "shallow": self.shallow_clone}
+             "subfolder": self.subfolder, "submodule": self.submodule, "shallow": self.shallow}
         d = {k: v for k, v in d.items() if v is not None}
         return json.dumps(d, sort_keys=True)
 
@@ -92,13 +92,13 @@ class SCM(object):
             def use_not_shallow():
                 out = self.repo.clone(url=self._data.url, shallow=False)
                 out += self.repo.checkout(element=self._data.revision,
-                                             submodule=self._data.submodule)
+                                          submodule=self._data.submodule)
                 return out
 
             def use_shallow():
                 try:
                     out = self.repo.clone(url=self._data.url, branch=self._data.revision,
-                                             shallow=True)
+                                          shallow=True)
                 except subprocess.CalledProcessError:
                     # remove the .git directory, otherwise, fallback clone cannot be successful
                     # it's completely safe to do here, as clone without branch expects
@@ -109,7 +109,7 @@ class SCM(object):
                     out += self.repo.checkout_submodules(submodule=self._data.submodule)
                 return out
 
-            if self._data.shallow_clone:
+            if self._data.shallow:
                 output += use_shallow()
             else:
                 output += use_not_shallow()

--- a/conans/model/scm.py
+++ b/conans/model/scm.py
@@ -16,6 +16,13 @@ def get_scm_data(conanfile):
 
 class SCMData(object):
 
+    @staticmethod
+    def _boolean(value, default):
+        if value is None:
+            return default
+        else:
+            return "True" if value in [True, "True"] else "False"
+
     def __init__(self, conanfile):
         data = getattr(conanfile, "scm", None)
         if data is not None and isinstance(data, dict):
@@ -27,7 +34,7 @@ class SCMData(object):
             self.password = data.get("password")
             self.subfolder = data.get("subfolder")
             self.submodule = data.get("submodule")
-            self.shallow = data.get("shallow")
+            self._shallow = SCMData._boolean(data.get("shallow"), None)
         else:
             raise ConanException("Not SCM enabled in conanfile")
 
@@ -45,10 +52,16 @@ class SCMData(object):
             return self.revision
         raise ConanException("Not implemented recipe revision for %s" % self.type)
 
+    @property
+    def shallow(self):
+        return self._shallow in [None, "True"]
+
     def __repr__(self):
         d = {"url": self.url, "revision": self.revision, "username": self.username,
              "password": self.password, "type": self.type, "verify_ssl": self.verify_ssl,
-             "subfolder": self.subfolder, "submodule": self.submodule, "shallow": self.shallow}
+             "subfolder": self.subfolder, "submodule": self.submodule}
+        if self._shallow is not None:
+            d.update({"shallow": self._shallow})
         d = {k: v for k, v in d.items() if v is not None}
         return json.dumps(d, sort_keys=True)
 

--- a/conans/test/functional/scm/scm_test.py
+++ b/conans/test/functional/scm/scm_test.py
@@ -520,9 +520,11 @@ class ConanLib(ConanFile):
                 "subfolder": "mysubfolder"}
         conanfile = namedtuple("ConanfileMock", "scm")(data)
         scm_data = SCMData(conanfile)
-        the_json = str(scm_data)
-        data2 = json.loads(the_json)
-        self.assertEqual(data, data2)
+
+        expected_output = '{"password": "mypassword", "revision": "myrevision",' \
+                          ' "subfolder": "mysubfolder", "type": "git", "url": "myurl",' \
+                          ' "username": "myusername"}'
+        self.assertEqual(str(scm_data), expected_output)
 
     def test_git_delegated_function(self):
         conanfile = """
@@ -898,16 +900,6 @@ class ConanLib(ConanFile):
         self.client.run("create . user/channel")
         self.assertIn("SOURCE METHOD CALLED", self.client.out)
         self.assertIn("BUILD METHOD CALLED", self.client.out)
-
-    def test_scm_serialization(self):
-        data = {"url": "myurl", "revision": "23", "username": "myusername",
-                "password": "mypassword", "type": "svn", "verify_ssl": False,
-                "subfolder": "mysubfolder"}
-        conanfile = namedtuple("ConanfileMock", "scm")(data)
-        scm_data = SCMData(conanfile)
-        the_json = str(scm_data)
-        data2 = json.loads(the_json)
-        self.assertEqual(data, data2)
 
 
 @attr('svn')

--- a/conans/test/functional/scm/test_fields_validation.py
+++ b/conans/test/functional/scm/test_fields_validation.py
@@ -40,7 +40,7 @@ class SCMDataFieldsValdation(unittest.TestCase):
 
         str_type_name = 'str' if six.PY3 else 'basestring'
         self.assertIn("ERROR: SCM value for 'revision' must be of type"
-                      " 'str' or 'int' (found 'bool')".format(str_type_name), client.out)
+                      " '{}' or 'int' (found 'bool')".format(str_type_name), client.out)
 
     def test_fail_boolean(self):
         conanfile = textwrap.dedent("""

--- a/conans/test/functional/scm/test_fields_validation.py
+++ b/conans/test/functional/scm/test_fields_validation.py
@@ -37,3 +37,15 @@ class SCMDataFieldsValdation(unittest.TestCase):
 
         self.assertIn("ERROR: SCM value for 'verify_ssl' must be of type 'bool' (found 'str')",
                       client.out)
+
+    def test_ok_none(self):
+        conanfile = textwrap.dedent("""
+            from conans import ConanFile
+
+            class Lib(ConanFile):
+                scm = {"type": "git", "revision": None, "shallow": False}
+        """)
+
+        client = TestClient()
+        client.save({'conanfile.py': conanfile})
+        client.run("export . name/version@user/channel")

--- a/conans/test/functional/scm/test_fields_validation.py
+++ b/conans/test/functional/scm/test_fields_validation.py
@@ -3,6 +3,8 @@
 import textwrap
 import unittest
 
+import six
+
 from conans.test.utils.tools import TestClient
 
 
@@ -20,8 +22,9 @@ class SCMDataFieldsValdation(unittest.TestCase):
         client.save({'conanfile.py': conanfile})
         client.run("export . name/version@user/channel", assert_error=True)
 
-        self.assertIn("ERROR: SCM value for 'username' must be of type 'str' (found 'bool')",
-                      client.out)
+        str_type_name = 'str' if six.PY3 else 'basestring'
+        self.assertIn("ERROR: SCM value for 'username' must be of"
+                      " type '{}' (found 'bool')".format(str_type_name), client.out)
 
     def test_fail_boolean(self):
         conanfile = textwrap.dedent("""

--- a/conans/test/functional/scm/test_fields_validation.py
+++ b/conans/test/functional/scm/test_fields_validation.py
@@ -1,0 +1,39 @@
+# coding=utf-8
+
+import textwrap
+import unittest
+
+from conans.test.utils.tools import TestClient
+
+
+class SCMDataFieldsValdation(unittest.TestCase):
+
+    def test_fail_string(self):
+        conanfile = textwrap.dedent("""
+            from conans import ConanFile
+            
+            class Lib(ConanFile):
+                scm = {"type": "git", "revision": "123", "username": True}
+        """)
+
+        client = TestClient()
+        client.save({'conanfile.py': conanfile})
+        client.run("export . name/version@user/channel", assert_error=True)
+
+        self.assertIn("ERROR: SCM value for 'username' must be of type 'str' (found 'bool')",
+                      client.out)
+
+    def test_fail_boolean(self):
+        conanfile = textwrap.dedent("""
+            from conans import ConanFile
+
+            class Lib(ConanFile):
+                scm = {"type": "git", "revision": "123", "verify_ssl": "True"}
+        """)
+
+        client = TestClient()
+        client.save({'conanfile.py': conanfile})
+        client.run("export . name/version@user/channel", assert_error=True)
+
+        self.assertIn("ERROR: SCM value for 'verify_ssl' must be of type 'bool' (found 'str')",
+                      client.out)

--- a/conans/test/functional/scm/test_fields_validation.py
+++ b/conans/test/functional/scm/test_fields_validation.py
@@ -13,7 +13,7 @@ class SCMDataFieldsValdation(unittest.TestCase):
     def test_fail_string(self):
         conanfile = textwrap.dedent("""
             from conans import ConanFile
-            
+
             class Lib(ConanFile):
                 scm = {"type": "git", "revision": "123", "username": True}
         """)
@@ -25,6 +25,22 @@ class SCMDataFieldsValdation(unittest.TestCase):
         str_type_name = 'str' if six.PY3 else 'basestring'
         self.assertIn("ERROR: SCM value for 'username' must be of"
                       " type '{}' (found 'bool')".format(str_type_name), client.out)
+
+    def test_fail_revision(self):
+        conanfile = textwrap.dedent("""
+            from conans import ConanFile
+
+            class Lib(ConanFile):
+                scm = {"type": "git", "revision": True}
+        """)
+
+        client = TestClient()
+        client.save({'conanfile.py': conanfile})
+        client.run("export . name/version@user/channel", assert_error=True)
+
+        str_type_name = 'str' if six.PY3 else 'basestring'
+        self.assertIn("ERROR: SCM value for 'revision' must be of type"
+                      " 'str' or 'int' (found 'bool')".format(str_type_name), client.out)
 
     def test_fail_boolean(self):
         conanfile = textwrap.dedent("""

--- a/conans/test/functional/scm/test_git_shallow.py
+++ b/conans/test/functional/scm/test_git_shallow.py
@@ -1,13 +1,14 @@
 # coding=utf-8
 
+import os
 import textwrap
 import unittest
-import os
 
 from parameterized.parameterized import parameterized_class
+
 from conans.model.ref import ConanFileReference
 from conans.test.utils.tools import TestClient, create_local_git_repo
-from conans.util.files import load, rmdir
+from conans.util.files import load
 
 
 @parameterized_class([{"shallow": True}, {"shallow": False}, {"shallow": None}, ])

--- a/conans/test/functional/scm/test_git_shallow.py
+++ b/conans/test/functional/scm/test_git_shallow.py
@@ -49,12 +49,10 @@ class GitShallowTestCase(unittest.TestCase):
 
         client.run("export . {}".format(self.ref))
         content = load(client.cache.package_layout(self.ref).conanfile())
-        if self.shallow is None:
+        if self.shallow is None or self.shallow:
             self.assertNotIn("shallow", content)
-        elif self.shallow:
-            self.assertIn('"shallow": "True"', content)
         else:
-            self.assertIn('"shallow": "False"', content)
+            self.assertIn('"shallow": False', content)
 
         client.run("inspect {} -a scm".format(self.ref))  # Check we get a loadable conanfile.py
 

--- a/conans/test/functional/scm/test_git_shallow.py
+++ b/conans/test/functional/scm/test_git_shallow.py
@@ -27,7 +27,7 @@ class GitShallowTestCase(unittest.TestCase):
                     out = self.run("git describe --tags", output=mybuf)
                     self.output.info(">>> tags: {{}}".format(mybuf.getvalue()))
                 except ConanException:
-                    pass
+                    self.output.info(">>> describe-fails")
     """)
 
     ref = ConanFileReference.loads("name/version@user/channel")
@@ -58,8 +58,7 @@ class GitShallowTestCase(unittest.TestCase):
 
         client.run("inspect {} -a scm".format(self.ref))  # Check we get a loadable conanfile.py
 
-    @parameterized.expand([("c6cc15fa2f4b576bd70c9df11942e61e5cc7d746", False),
-                           ("0.22.1", True)])
+    @parameterized.expand([("c6cc15fa2f4b576bd", False), ("0.22.1", True)])
     def test_remote_build(self, revision, shallow_works):
         # Shallow works only with branches or tags
         client = TestClient()
@@ -71,6 +70,6 @@ class GitShallowTestCase(unittest.TestCase):
         client.run("create . {}".format(self.ref))
 
         if (self.shallow is None or self.shallow) and shallow_works:
-            self.assertNotIn(">>> tags:", client.out)
+            self.assertIn(">>> describe-fails", client.out)
         else:
             self.assertIn(">>> tags: 0.22.1", client.out)

--- a/conans/test/functional/scm/test_git_shallow.py
+++ b/conans/test/functional/scm/test_git_shallow.py
@@ -11,7 +11,7 @@ from conans.test.utils.tools import TestClient, create_local_git_repo
 from conans.util.files import load
 
 
-@parameterized_class([{"shallow": True}, {"shallow": False}, {"shallow": None}, ])
+@parameterized_class([{"shallow": True}, {"shallow": False}, {"shallow": None}, {"shallow": "None"}])
 class GitShallowTestCase(unittest.TestCase):
     conanfile = textwrap.dedent("""
         from conans import ConanFile
@@ -49,7 +49,7 @@ class GitShallowTestCase(unittest.TestCase):
 
         client.run("export . {}".format(self.ref))
         content = load(client.cache.package_layout(self.ref).conanfile())
-        if self.shallow is None or self.shallow:
+        if self.shallow in [None, True, "None"]:
             self.assertNotIn("shallow", content)
         else:
             self.assertIn('"shallow": False', content)
@@ -67,7 +67,7 @@ class GitShallowTestCase(unittest.TestCase):
 
         client.run("create . {}".format(self.ref))
 
-        if (self.shallow is None or self.shallow) and shallow_works:
+        if self.shallow in [None, True, "None"] and shallow_works:
             self.assertIn(">>> describe-fails", client.out)
         else:
             self.assertIn(">>> tags: 0.22.1", client.out)

--- a/conans/test/functional/scm/test_git_shallow.py
+++ b/conans/test/functional/scm/test_git_shallow.py
@@ -1,0 +1,72 @@
+# coding=utf-8
+
+import textwrap
+import unittest
+import os
+
+from parameterized.parameterized import parameterized_class
+from conans.model.ref import ConanFileReference
+from conans.test.utils.tools import TestClient, create_local_git_repo
+from conans.util.files import load, rmdir
+
+
+@parameterized_class([{"shallow": True}, {"shallow": False}, {"shallow": None}, ])
+class GitShallowTestCase(unittest.TestCase):
+    conanfile = textwrap.dedent("""
+        from conans import ConanFile
+        from conans.errors import ConanException
+        from six import StringIO
+        
+        class Lib(ConanFile):
+            scm = {{"type": "git", "url": "auto", "revision": "auto", {shallow_attrib} }}
+            
+            def build(self):
+                mybuf = StringIO()
+                try:
+                    out = self.run("git describe --tags", output=mybuf)
+                    self.output.info(">>> tags: {{}}".format(mybuf.getvalue()))
+                except ConanException:
+                    pass
+    """)
+
+    ref = ConanFileReference.loads("name/version@user/channel")
+
+    def setUp(self):
+        self.client = TestClient()
+
+        # Create a local repo
+        shallow_attrib_str = ""
+        if self.shallow is not None:
+            shallow_attrib_str = '"shallow": {}'.format(self.shallow)
+        files = {'conanfile.py': self.conanfile.format(shallow_attrib=shallow_attrib_str)}
+        url, _ = create_local_git_repo(files=files, commits=4, tags=['v0', ])
+        self.client.run_command('git clone "{}" .'.format(url))
+
+    def test_export(self):
+        # Check the shallow value is substituted with the proper value
+        self.client.run("export . {}".format(self.ref))
+        content = load(self.client.cache.package_layout(self.ref).conanfile())
+        if self.shallow is None:
+            self.assertNotIn("shallow", content)
+        elif self.shallow:
+            self.assertIn('"shallow": "True"', content)
+        else:
+            self.assertIn('"shallow": "False"', content)
+
+        self.client.run("inspect {} -a scm".format(self.ref))  # Check we get a loadable conanfile.py
+
+    def test_local_build(self):
+        self.client.run("install . -if if")
+        self.client.run("build . -if if -bf bf")
+
+        self.assertIn(">>> tags: v0", self.client.out)
+
+    def test_remote_build(self):
+        self.client.run("export . {}".format(self.ref))
+        os.unlink(self.client.cache.package_layout(self.ref).scm_folder())
+        self.client.run("install {} --build".format(self.ref))
+
+        if self.shallow is None or self.shallow:
+            self.assertNotIn(">>> tags: v0", self.client.out)
+        else:
+            self.assertIn(">>> tags: v0", self.client.out)

--- a/conans/test/functional/scm/test_git_shallow.py
+++ b/conans/test/functional/scm/test_git_shallow.py
@@ -8,7 +8,7 @@ from parameterized.parameterized import parameterized_class
 
 from conans.model.ref import ConanFileReference
 from conans.test.utils.tools import TestClient, create_local_git_repo
-from conans.util.files import load
+from conans.util.files import load, rmdir
 
 
 @parameterized_class([{"shallow": True}, {"shallow": False}, {"shallow": None}, ])
@@ -64,7 +64,7 @@ class GitShallowTestCase(unittest.TestCase):
 
     def test_remote_build(self):
         self.client.run("export . {}".format(self.ref))
-        os.unlink(self.client.cache.package_layout(self.ref).scm_folder())
+        rmdir(os.path.join(self.client.current_folder, ".git"))
         self.client.run("install {} --build".format(self.ref))
 
         if self.shallow is None or self.shallow:

--- a/conans/test/functional/scm/test_verify_ssl.py
+++ b/conans/test/functional/scm/test_verify_ssl.py
@@ -10,7 +10,8 @@ from conans.test.utils.tools import TestClient, create_local_git_repo
 from conans.util.files import load
 
 
-@parameterized_class([{"verify_ssl": True}, {"verify_ssl": False}, {"verify_ssl": None}, ])
+@parameterized_class([{"verify_ssl": True}, {"verify_ssl": False},
+                      {"verify_ssl": None},{"verify_ssl": "None"}, ])
 class GitVerifySSLTestCase(unittest.TestCase):
     conanfile = textwrap.dedent("""
         from conans import ConanFile
@@ -37,7 +38,7 @@ class GitVerifySSLTestCase(unittest.TestCase):
         # Check the shallow value is substituted with the proper value
         self.client.run("export . {}".format(self.ref))
         content = load(self.client.cache.package_layout(self.ref).conanfile())
-        if self.verify_ssl is None or self.verify_ssl:
+        if self.verify_ssl in [None, True, "None"]:
             self.assertNotIn("verify_ssl", content)
         else:
             self.assertIn('"verify_ssl": False', content)

--- a/conans/test/functional/scm/test_verify_ssl.py
+++ b/conans/test/functional/scm/test_verify_ssl.py
@@ -1,0 +1,45 @@
+# coding=utf-8
+
+import textwrap
+import unittest
+
+from parameterized.parameterized import parameterized_class
+
+from conans.model.ref import ConanFileReference
+from conans.test.utils.tools import TestClient, create_local_git_repo
+from conans.util.files import load
+
+
+@parameterized_class([{"verify_ssl": True}, {"verify_ssl": False}, {"verify_ssl": None}, ])
+class GitVerifySSLTestCase(unittest.TestCase):
+    conanfile = textwrap.dedent("""
+        from conans import ConanFile
+
+        class Lib(ConanFile):
+            scm = {{"type": "git", "url": "auto", "revision": "auto", {verify_ssl_attrib} }}
+
+    """)
+
+    ref = ConanFileReference.loads("name/version@user/channel")
+
+    def setUp(self):
+        self.client = TestClient()
+
+        # Create a local repo
+        verify_ssl_attrib_str = ""
+        if self.verify_ssl is not None:
+            verify_ssl_attrib_str = '"verify_ssl": {}'.format(self.verify_ssl)
+        files = {'conanfile.py': self.conanfile.format(verify_ssl_attrib=verify_ssl_attrib_str)}
+        url, _ = create_local_git_repo(files=files, commits=4, tags=['v0', ])
+        self.client.run_command('git clone "{}" .'.format(url))
+
+    def test_export(self):
+        # Check the shallow value is substituted with the proper value
+        self.client.run("export . {}".format(self.ref))
+        content = load(self.client.cache.package_layout(self.ref).conanfile())
+        if self.verify_ssl is None or self.verify_ssl:
+            self.assertNotIn("verify_ssl", content)
+        else:
+            self.assertIn('"verify_ssl": False', content)
+
+        self.client.run("inspect {} -a scm".format(self.ref))  # Check we get a loadable conanfile.py

--- a/conans/test/unittests/model/scm/detect_repo_test.py
+++ b/conans/test/unittests/model/scm/detect_repo_test.py
@@ -24,14 +24,14 @@ class SCMDetectRepoTest(unittest.TestCase):
 
     def test_svn(self):
         with mock.patch("conans.client.tools.scm.SVN.check_repo", return_value=None):
-            r = SCM.detect_scm(folder=tempfile.gettempdir())
+            r = SCM.detect_scm(folder=self.folder)
             self.assertEqual(r, "svn")
 
     def test_git(self):
         with mock.patch("conans.client.tools.scm.Git.check_repo", return_value=None):
-            r = SCM.detect_scm(folder=tempfile.gettempdir())
+            r = SCM.detect_scm(folder=self.folder)
             self.assertEqual(r, "git")
 
     def test_none(self):
-        r = SCM.detect_scm(folder=tempfile.gettempdir())
+        r = SCM.detect_scm(folder=self.folder)
         self.assertEqual(r, None)

--- a/conans/test/unittests/model/scm/scm_data_test.py
+++ b/conans/test/unittests/model/scm/scm_data_test.py
@@ -26,7 +26,8 @@ class GetDictValueTestCase(unittest.TestCase):
         with six.assertRaisesRegex(self, ConanException, exception_msg.format(found="int")):
             _get_dict_value({"str": 23}, "str", six.string_types)
 
-        with six.assertRaisesRegex(self, ConanException, exception_msg.format(found="bytes")):
+        if six.PY3:  # For py2, bytes is instance of str
+            with six.assertRaisesRegex(self, ConanException, exception_msg.format(found="bytes")):
                 _get_dict_value({"str": b"value"}, "str", six.string_types)
 
         with six.assertRaisesRegex(self, ConanException, exception_msg.format(found="bool")):

--- a/conans/test/unittests/model/scm/scm_data_test.py
+++ b/conans/test/unittests/model/scm/scm_data_test.py
@@ -1,0 +1,67 @@
+# coding=utf-8
+
+import unittest
+from collections import namedtuple
+
+import six
+
+from conans.errors import ConanException
+from conans.model.scm import _get_dict_value, SCMData
+
+
+class GetDictValueTestCase(unittest.TestCase):
+
+    def test_string_type(self):
+        self.assertEqual(_get_dict_value({"str": "value"}, "str", six.string_types), "value")
+        self.assertEqual(_get_dict_value({"str": u"value"}, "str", six.string_types), "value")
+
+        def get_string():
+            return "value"
+        self.assertEqual(_get_dict_value({"str": get_string()}, "str", six.string_types), "value")
+
+    def test_no_string_type(self):
+        with six.assertRaisesRegex(self, ConanException, "must be of type 'str' \(found 'int'\)"):
+            _get_dict_value({"str": 23}, "str", six.string_types)
+
+        with six.assertRaisesRegex(self, ConanException, "must be of type 'str' \(found 'bytes'\)"):
+            _get_dict_value({"str": b"value"}, "str", six.string_types)
+
+        with six.assertRaisesRegex(self, ConanException, "must be of type 'str' \(found 'bool'\)"):
+            _get_dict_value({"str": True}, "str", six.string_types)
+
+        with six.assertRaisesRegex(self, ConanException, "must be of type 'str' \(found 'NoneType'\)"):
+            _get_dict_value({"str": None}, "str", six.string_types)
+
+        with six.assertRaisesRegex(self, ConanException, "must be of type 'str' \(found 'function'\)"):
+            _get_dict_value({"str": lambda: "value"}, "str", six.string_types)
+
+    def test_boolean_type(self):
+        self.assertEqual(_get_dict_value({"key": True}, "key", bool), True)
+        self.assertEqual(_get_dict_value({"key": False}, "key", bool), False)
+
+    def test_no_boolean_type(self):
+        with six.assertRaisesRegex(self, ConanException, "must be of type 'bool' \(found 'NoneType'\)"):
+            _get_dict_value({"key": None}, "key", bool)
+
+        with six.assertRaisesRegex(self, ConanException, "must be of type 'bool' \(found 'int'\)"):
+            _get_dict_value({"key": 123}, "key", bool)
+
+        with six.assertRaisesRegex(self, ConanException, "must be of type 'bool' \(found 'str'\)"):
+            _get_dict_value({"key": "str"}, "key", bool)
+
+
+class SCMDataToStringTestCase(unittest.TestCase):
+    data = {"url": "http://my.url",
+            "revision": 123,
+            "shallow": False,
+            "username": 'weir"d',
+            "type": "weir\"d",
+            "password": "don't"}
+
+    def test_scmdata_string(self):
+        fake_class = namedtuple("Conanfile", ["scm"])
+        conanfile = fake_class(scm=self.data)
+
+        self.assertEqual(str(SCMData(conanfile)), '{"password": "don\'t", "revision": "123",'
+                                                  ' "shallow": False, "type": "weir\\"d",'
+                                                  ' "url": "http://my.url", "username": "weir\\"d"}')

--- a/conans/test/unittests/model/scm/scm_data_test.py
+++ b/conans/test/unittests/model/scm/scm_data_test.py
@@ -18,21 +18,21 @@ class GetDictValueTestCase(unittest.TestCase):
         def get_string():
             return "value"
         self.assertEqual(_get_dict_value({"str": get_string()}, "str", six.string_types), "value")
+        self.assertEqual(_get_dict_value({"str": None}, "str", six.string_types), None)
 
     def test_no_string_type(self):
-        with six.assertRaisesRegex(self, ConanException, "must be of type 'str' \(found 'int'\)"):
+        str_type_name = 'str' if six.PY3 else 'basestring'
+        exception_msg = "must be of type '{}' \(found '{{found}}'\)".format(str_type_name)
+        with six.assertRaisesRegex(self, ConanException, exception_msg.format(found="int")):
             _get_dict_value({"str": 23}, "str", six.string_types)
 
-        with six.assertRaisesRegex(self, ConanException, "must be of type 'str' \(found 'bytes'\)"):
-            _get_dict_value({"str": b"value"}, "str", six.string_types)
+        with six.assertRaisesRegex(self, ConanException, exception_msg.format(found="bytes")):
+                _get_dict_value({"str": b"value"}, "str", six.string_types)
 
-        with six.assertRaisesRegex(self, ConanException, "must be of type 'str' \(found 'bool'\)"):
+        with six.assertRaisesRegex(self, ConanException, exception_msg.format(found="bool")):
             _get_dict_value({"str": True}, "str", six.string_types)
 
-        with six.assertRaisesRegex(self, ConanException, "must be of type 'str' \(found 'NoneType'\)"):
-            _get_dict_value({"str": None}, "str", six.string_types)
-
-        with six.assertRaisesRegex(self, ConanException, "must be of type 'str' \(found 'function'\)"):
+        with six.assertRaisesRegex(self, ConanException, exception_msg.format(found="function")):
             _get_dict_value({"str": lambda: "value"}, "str", six.string_types)
 
     def test_boolean_type(self):
@@ -40,9 +40,6 @@ class GetDictValueTestCase(unittest.TestCase):
         self.assertEqual(_get_dict_value({"key": False}, "key", bool), False)
 
     def test_no_boolean_type(self):
-        with six.assertRaisesRegex(self, ConanException, "must be of type 'bool' \(found 'NoneType'\)"):
-            _get_dict_value({"key": None}, "key", bool)
-
         with six.assertRaisesRegex(self, ConanException, "must be of type 'bool' \(found 'int'\)"):
             _get_dict_value({"key": 123}, "key", bool)
 


### PR DESCRIPTION
Changelog: Feature: Add opt-out for Git shallow clone in `SCM` feature
Docs: https://github.com/conan-io/docs/pull/1400

closes https://github.com/conan-io/conan/issues/5631

---

This PR introduces also:
 * validation of SCM data values
 * prevent bug using `scm::verify_ssl` and scm `auto` values
