### PR TITLE
Fixed anonymous access with Artifactory

### DIFF
--- a/conans/client/rest/rest_client.py
+++ b/conans/client/rest/rest_client.py
@@ -4,6 +4,7 @@ from conans import CHECKSUM_DEPLOY, REVISIONS, ONLY_V2
 from conans.client.rest.rest_client_v1 import RestV1Methods
 from conans.client.rest.rest_client_v2 import RestV2Methods
 from conans.errors import OnlyV2Available
+from conans.util.log import logger
 
 
 class RestApiClient(object):
@@ -33,6 +34,7 @@ class RestApiClient(object):
                                 self.requester, self.verify_ssl, self._put_headers)
             _, _, cap = tmp.server_info()
             self._cached_capabilities[self.remote_url] = cap
+            logger.debug("REST: Cached capabilities for the remote: %s" % cap)
             if not self._revisions_enabled and ONLY_V2 in cap:
                 raise OnlyV2Available(self.remote_url)
 
@@ -83,7 +85,10 @@ class RestApiClient(object):
         return self._get_api().upload_package(pref, files_to_upload, deleted, retry, retry_wait)
 
     def authenticate(self, user, password):
-        return self._get_api().authenticate(user, password)
+        apiv1 = RestV1Methods(self.remote_url, self.token, self.custom_headers, self._output,
+                              self.requester, self.verify_ssl, self._put_headers)
+        # Use v1 for the capabilities because the "ping" could be also protected
+        return apiv1.authenticate(user, password)
 
     def check_credentials(self):
         return self._get_api().check_credentials()

--- a/conans/client/rest/rest_client.py
+++ b/conans/client/rest/rest_client.py
@@ -87,7 +87,8 @@ class RestApiClient(object):
     def authenticate(self, user, password):
         apiv1 = RestV1Methods(self.remote_url, self.token, self.custom_headers, self._output,
                               self.requester, self.verify_ssl, self._put_headers)
-        # Use v1 for the capabilities because the "ping" could be also protected
+        # Use v1 for the auth because the "ping" could be also protected so we don't know if
+        # we can use v2
         return apiv1.authenticate(user, password)
 
     def check_credentials(self):

--- a/conans/client/rest/rest_client_common.py
+++ b/conans/client/rest/rest_client_common.py
@@ -111,9 +111,9 @@ class RestCommonMethods(object):
 
         ret = self.requester.get(url, auth=self.auth, headers=self.custom_headers,
                                  verify=self.verify_ssl)
-        if ret.status_code == 404:
-            raise NotFoundException("Not implemented endpoint")
 
+        if not ret.ok:
+            raise get_exception_from_error(ret.status_code)("")
         version_check = ret.headers.get('X-Conan-Client-Version-Check', None)
         server_version = ret.headers.get('X-Conan-Server-Version', None)
         server_capabilities = ret.headers.get('X-Conan-Server-Capabilities', "")

--- a/conans/test/functional/old/conan_trace_file_test.py
+++ b/conans/test/functional/old/conan_trace_file_test.py
@@ -123,7 +123,7 @@ class HelloConan(ConanFile):
             self.assertEqual(num_post, 2)  # 2 get urls
 
         num_get = len([it for it in actions if "REST_API_CALL" in it and "GET" in it])
-        self.assertEqual(num_get, 10)
+        self.assertEqual(num_get, 9)
 
         # Check masked signature
         for action in actions:

--- a/conans/test/functional/remote/server_error_test.py
+++ b/conans/test/functional/remote/server_error_test.py
@@ -14,7 +14,8 @@ class Error200NoJson(unittest.TestCase):
 
             def get(self, *args, **kwargs):  # @UnusedVariable
                 # Response must be binary, it is decoded in RestClientCommon
-                return namedtuple("Response", "status_code headers content")(200, {}, b'<>')
+                return namedtuple("Response", "status_code headers content ok")(200, {}, b'<>',
+                                                                                True)
 
         # https://github.com/conan-io/conan/issues/3432
         client = TestClient(servers={"default": TestServer()},
@@ -33,7 +34,8 @@ class Error200NoJson(unittest.TestCase):
             def get(self, *args, **kwargs):  # @UnusedVariable
                 # Response must be binary, it is decoded in RestClientCommon
                 headers = {"Content-Type": "application/json"}
-                return namedtuple("Response", "status_code headers content")(200, headers, b'<>')
+                return namedtuple("Response", "status_code headers content ok")(200, headers,
+                                                                                b'<>', True)
 
         # https://github.com/conan-io/conan/issues/3432
         client = TestClient(servers={"default": TestServer()},
@@ -51,8 +53,8 @@ class Error200NoJson(unittest.TestCase):
             def get(self, *args, **kwargs):  # @UnusedVariable
                 # Response must be binary, it is decoded in RestClientCommon
                 headers = {"Content-Type": "application/json"}
-                return namedtuple("Response", "status_code headers content")(200, headers,
-                                                                             b'[1, 2, 3]')
+                return namedtuple("Response", "status_code headers content ok")(200, headers,
+                                                                                b'[1, 2, 3]', True)
 
         # https://github.com/conan-io/conan/issues/3432
         client = TestClient(servers={"default": TestServer()},


### PR DESCRIPTION
Changelog: Bugfix: When Artifactory doesn't have the anonymous access activated, the conan client wasn't able to capture the server capabilities and therefore never used the `revisions` mechanism.
Docs: omit

Closes #5687 

@REVISIONS: 1