### PR TITLE
Use output provided by user when calling self.run() with win_bash=True

### DIFF
--- a/conans/client/tools/win.py
+++ b/conans/client/tools/win.py
@@ -575,7 +575,7 @@ def unix_path(path, path_flavor=None):
     return None
 
 
-def run_in_windows_bash(conanfile, bashcmd, cwd=None, subsystem=None, msys_mingw=True, env=None,
+def run_in_windows_bash(conanfile, bashcmd, output=True, cwd=None, subsystem=None, msys_mingw=True, env=None,
                         with_login=True):
     """ Will run a unix command inside a bash terminal
         It requires to have MSYS2, CYGWIN, or WSL
@@ -650,4 +650,4 @@ def run_in_windows_bash(conanfile, bashcmd, cwd=None, subsystem=None, msys_mingw
 
         # https://github.com/conan-io/conan/issues/2839 (subprocess=True)
         with environment_append(normalized_env):
-            return conanfile._conan_runner(wincmd, output=conanfile.output, subprocess=True)
+            return conanfile._conan_runner(wincmd, output=output, subprocess=True)

--- a/conans/model/conan_file.py
+++ b/conans/model/conan_file.py
@@ -257,8 +257,8 @@ class ConanFile(object):
         def _run():
             if not win_bash:
                 return self._conan_runner(command, output, os.path.abspath(RUN_LOG_NAME), cwd)
-            # FIXME: run in windows bash is not using output
-            return tools.run_in_windows_bash(self, bashcmd=command, cwd=cwd, subsystem=subsystem,
+
+            return tools.run_in_windows_bash(self, bashcmd=command, output=output, cwd=cwd, subsystem=subsystem,
                                              msys_mingw=msys_mingw, with_login=with_login)
         if run_environment:
             with tools.run_environment(self):


### PR DESCRIPTION
Changelog: Feature: Use output provided by user when calling self.run() with win_bash=True
Docs: Omit

- [x] Refer to the issue that supports this Pull Request.
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [x] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 

<sup>**Note:** By default this PR will skip the slower tests and will use a limited set of python versions. Check [here](https://github.com/conan-io/conan/blob/develop/.github/PR_INCREASE_TESTING.md) how to increase the testing level by writing some tags in the current PR body text.</sup>
Fixes #5670