### PR TITLE
Fix: Version ranges resolution using references without user/channel

### DIFF
--- a/conans/search/search.py
+++ b/conans/search/search.py
@@ -108,7 +108,7 @@ def search_recipes(cache, pattern=None, ignorecase=True):
     refs = [ConanFileReference.load_dir_repr(folder) for folder in subdirs]
     refs.extend(cache.editable_packages.edited_refs.keys())
     if pattern:
-        refs = [r for r in refs if _partial_match(pattern, r)]
+        refs = [r for r in refs if _partial_match(pattern, repr(r))]
     refs = sorted(refs)
     return refs
 
@@ -117,7 +117,7 @@ def _partial_match(pattern, ref):
     """
     Finds if pattern matches any of partial sums of tokens of conan reference
     """
-    tokens = str(ref).replace('/', ' / ').replace('@', ' @ ').replace('#', ' # ').split()
+    tokens = ref.replace('/', ' / ').replace('@', ' @ ').replace('#', ' # ').split()
 
     def partial_sums(iterable):
         partial = ''

--- a/conans/search/search.py
+++ b/conans/search/search.py
@@ -113,11 +113,11 @@ def search_recipes(cache, pattern=None, ignorecase=True):
     return refs
 
 
-def _partial_match(pattern, ref):
+def _partial_match(pattern, reference):
     """
     Finds if pattern matches any of partial sums of tokens of conan reference
     """
-    tokens = ref.replace('/', ' / ').replace('@', ' @ ').replace('#', ' # ').split()
+    tokens = reference.replace('/', ' / ').replace('@', ' @ ').replace('#', ' # ').split()
 
     def partial_sums(iterable):
         partial = ''

--- a/conans/test/functional/graph/version_range_no_userchannel_test.py
+++ b/conans/test/functional/graph/version_range_no_userchannel_test.py
@@ -1,11 +1,18 @@
 # coding=utf-8
 
+import textwrap
 import unittest
 
 from conans.test.utils.tools import TestClient, GenConanfile
 
 
 class VersionRangeNoUserChannelTestCase(unittest.TestCase):
+    conanfile = textwrap.dedent("""
+        from conans import ConanFile
+        
+        class LibB(ConanFile):
+            requires = "{}"
+    """)
 
     def test_match(self):
         t = TestClient()
@@ -13,7 +20,7 @@ class VersionRangeNoUserChannelTestCase(unittest.TestCase):
         t.run("export . libB/1.0@")
 
         # Use version ranges without user/channel
-        t.save({"conanfile.py": GenConanfile().with_require_plain("libB/[~1.x]")})
+        t.save({"conanfile.py": self.conanfile.format("libB/[~1.x]")})
         t.run("info . --only requires")
         self.assertIn("Version range '~1.x' required by 'conanfile.py'"
                       " resolved to 'libB/1.0' in local cache", t.out)
@@ -24,7 +31,7 @@ class VersionRangeNoUserChannelTestCase(unittest.TestCase):
         t.run("export . libB/1.0@user/channel")
 
         # Use version ranges without user/channel
-        t.save({"conanfile.py": GenConanfile().with_require_plain("libB/[~1.x]")})
+        t.save({"conanfile.py": self.conanfile.format("libB/[~1.x]")})
         t.run("info . --only requires", assert_error=True)
         self.assertIn("ERROR: Version range '~1.x' from requirement 'libB/[~1.x]' required"
                       " by 'conanfile.py' could not be resolved in local cache", t.out)
@@ -35,7 +42,7 @@ class VersionRangeNoUserChannelTestCase(unittest.TestCase):
         t.run("export . libB/1.0@")
 
         # Use version ranges with user/channel
-        t.save({"conanfile.py": GenConanfile().with_require_plain("libB/[~1.x]@user/channel")})
+        t.save({"conanfile.py": self.conanfile.format("libB/[~1.x]@user/channel")})
         t.run("info . --only requires", assert_error=True)
         self.assertIn("ERROR: Version range '~1.x' from requirement 'libB/[~1.x]@user/channel'"
                       " required by 'conanfile.py' could not be resolved in local cache", t.out)

--- a/conans/test/functional/graph/version_range_no_userchannel_test.py
+++ b/conans/test/functional/graph/version_range_no_userchannel_test.py
@@ -1,0 +1,41 @@
+# coding=utf-8
+
+import unittest
+
+from conans.test.utils.tools import TestClient, GenConanfile
+
+
+class VersionRangeNoUserChannelTestCase(unittest.TestCase):
+
+    def test_match(self):
+        t = TestClient()
+        t.save({"conanfile.py": GenConanfile(), })
+        t.run("export . libB/1.0@")
+
+        # Use version ranges without user/channel
+        t.save({"conanfile.py": GenConanfile().with_require_plain("libB/[~1.x]")})
+        t.run("info . --only requires")
+        self.assertIn("Version range '~1.x' required by 'conanfile.py'"
+                      " resolved to 'libB/1.0' in local cache", t.out)
+
+    def test_no_match(self):
+        t = TestClient()
+        t.save({"conanfile.py": GenConanfile(), })
+        t.run("export . libB/1.0@user/channel")
+
+        # Use version ranges without user/channel
+        t.save({"conanfile.py": GenConanfile().with_require_plain("libB/[~1.x]")})
+        t.run("info . --only requires", assert_error=True)
+        self.assertIn("ERROR: Version range '~1.x' from requirement 'libB/[~1.x]' required"
+                      " by 'conanfile.py' could not be resolved in local cache", t.out)
+
+    def test_no_match_with_userchannel(self):
+        t = TestClient()
+        t.save({"conanfile.py": GenConanfile(), })
+        t.run("export . libB/1.0@")
+
+        # Use version ranges with user/channel
+        t.save({"conanfile.py": GenConanfile().with_require_plain("libB/[~1.x]@user/channel")})
+        t.run("info . --only requires", assert_error=True)
+        self.assertIn("ERROR: Version range '~1.x' from requirement 'libB/[~1.x]@user/channel'"
+                      " required by 'conanfile.py' could not be resolved in local cache", t.out)


### PR DESCRIPTION
Changelog: Fix: Version ranges resolution using references without user/channel
Docs: omit

It was using `str` for the references from the folders and the pattern (`libB/*@_/_`) was not able to match them.
