### PR TITLE
order search

### DIFF
--- a/conans/client/cmd/search.py
+++ b/conans/client/cmd/search.py
@@ -26,12 +26,12 @@ class Search(object):
                 for remote in self._remotes.values():
                     refs = self._remote_manager.search_recipes(remote, pattern, ignorecase)
                     if refs:
-                        references[remote.name] = refs
+                        references[remote.name] = sorted(refs)
                 return references
         # single remote
         remote = self._remotes[remote_name]
         refs = self._remote_manager.search_recipes(remote, pattern, ignorecase)
-        references[remote.name] = refs
+        references[remote.name] = sorted(refs)
         return references
 
     remote_ref = namedtuple('remote_ref', 'ordered_packages recipe_hash')

--- a/conans/search/search.py
+++ b/conans/search/search.py
@@ -49,14 +49,14 @@ def filter_packages(query, package_infos):
         postfix = infix_to_postfix(query) if query else []
         result = OrderedDict()
         for package_id, info in package_infos.items():
-            if evaluate_postfix_with_info(postfix, info):
+            if _evaluate_postfix_with_info(postfix, info):
                 result[package_id] = info
         return result
     except Exception as exc:
         raise ConanException("Invalid package query: %s. %s" % (query, exc))
 
 
-def evaluate_postfix_with_info(postfix, conan_vars_info):
+def _evaluate_postfix_with_info(postfix, conan_vars_info):
 
     # Evaluate conaninfo with the expression
 
@@ -65,12 +65,12 @@ def evaluate_postfix_with_info(postfix, conan_vars_info):
         Uses conan_vars_info in the closure to evaluate it"""
         name, value = expression.split("=", 1)
         value = value.replace("\"", "")
-        return evaluate(name, value, conan_vars_info)
+        return _evaluate(name, value, conan_vars_info)
 
     return evaluate_postfix(postfix, evaluate_info)
 
 
-def evaluate(prop_name, prop_value, conan_vars_info):
+def _evaluate(prop_name, prop_value, conan_vars_info):
     """
     Evaluates a single prop_name, prop_value like "os", "Windows" against
     conan_vars_info.serialize_min()

--- a/conans/server/service/common/search.py
+++ b/conans/server/service/common/search.py
@@ -100,7 +100,8 @@ class SearchService(object):
 
         subdirs = list_folder_subdirs(basedir=self._server_store.store, level=5)
         if not pattern:
-            return sorted([ConanFileReference(*folder.split("/")) for folder in subdirs])
+            return sorted([ConanFileReference(*folder.split("/")).copy_clear_rev()
+                           for folder in subdirs])
         else:
             ret = set()
             for subdir in subdirs:

--- a/conans/test/functional/command/download_test.py
+++ b/conans/test/functional/command/download_test.py
@@ -10,10 +10,7 @@ from conans.util.files import load
 class DownloadTest(unittest.TestCase):
 
     def download_recipe_test(self):
-        server = TestServer()
-        servers = {"default": server}
-        client = TurboTestClient(servers=servers, users={"default": [("lasote", "mypass")]})
-
+        client = TurboTestClient(default_server_user={"lasote": "pass"})
         # Test download of the recipe only
         conanfile = """from conans import ConanFile
 class Pkg(ConanFile):

--- a/conans/test/unittests/server/service/service_test.py
+++ b/conans/test/unittests/server/service/service_test.py
@@ -218,7 +218,7 @@ class ConanServiceTest(unittest.TestCase):
         save_files(self.server_store.export(ref4), {"dummy.txt": "//"})
 
         info = self.search_service.search()
-        expected = [ref3, ref4, self.ref, ref2]
+        expected = [r.copy_clear_rev() for r in [ref3, ref4, self.ref, ref2]]
         self.assertEqual(expected, info)
 
         info = self.search_service.search(pattern="Assimp*", ignorecase=False)

--- a/conans/test/utils/tools.py
+++ b/conans/test/utils/tools.py
@@ -642,13 +642,26 @@ class TestClient(object):
 
     def __init__(self, cache_folder=None, current_folder=None, servers=None, users=None,
                  requester_class=None, runner=None, path_with_spaces=True,
-                 revisions_enabled=None, cpu_count=1):
+                 revisions_enabled=None, cpu_count=1, default_server_user=None):
         """
         current_folder: Current execution folder
         servers: dict of {remote_name: TestServer}
         logins is a list of (user, password) for auto input in order
         if required==> [("lasote", "mypass"), ("other", "otherpass")]
         """
+        if default_server_user is not None:
+            if servers is not None:
+                raise Exception("Cannot define both 'servers' and 'default_server_user'")
+            if users is not None:
+                raise Exception("Cannot define both 'users' and 'default_server_user'")
+            if default_server_user is True:
+                server_users = {"user": "password"}
+                users = {"default": [("user", "password")]}
+            else:
+                server_users = default_server_user
+                users = {"default": list(default_server_user.items())}
+            server = TestServer(users=server_users)
+            servers = {"default": server}
 
         self.users = users
         if self.users is None:
@@ -865,7 +878,7 @@ class TurboTestClient(TestClient):
     tmp_json_name = ".tmp_json"
 
     def __init__(self, *args, **kwargs):
-        if "users" not in kwargs:
+        if "users" not in kwargs and "default_server_user" not in kwargs:
             from collections import defaultdict
             kwargs["users"] = defaultdict(lambda: [("conan", "password")])
 


### PR DESCRIPTION
Changelog: Fix: Output  search result for remotes in order by version, as local search
Docs: omit

Fix #5720


@tags: slow