### PR TITLE
Print similar commands on the unknown command error

### DIFF
--- a/conans/client/command.py
+++ b/conans/client/command.py
@@ -6,6 +6,7 @@ import sys
 import argparse
 import six
 from argparse import ArgumentError
+from difflib import get_close_matches
 
 from conans import __version__ as client_version
 from conans.client.cmd.uploader import UPLOAD_POLICY_FORCE, \
@@ -1831,6 +1832,25 @@ class Command(object):
                     result[method_name] = method
         return result
 
+    def _print_similar(self, command):
+        """ looks for a similar commands and prints them if found
+        """
+        matches = get_close_matches(
+            word=command, possibilities=self._commands().keys(), n=5, cutoff=0.75)
+
+        if len(matches) == 0:
+            return
+
+        if len(matches) > 1:
+            self._user_io.out.writeln("The most similar commands are")
+        else:
+            self._user_io.out.writeln("The most similar command is")
+
+        for match in matches:
+            print("    %s" % match)
+
+        self._user_io.out.writeln("")
+
     def _warn_python2(self):
         if six.PY2:
             self._out.writeln("")
@@ -1846,6 +1866,7 @@ class Command(object):
         """
         ret_code = SUCCESS
         try:
+            self._warn_python2()
             try:
                 command = args[0][0]
                 commands = self._commands()
@@ -1854,10 +1875,16 @@ class Command(object):
                 if command in ["-v", "--version"]:
                     self._out.success("Conan version %s" % client_version)
                     return False
-                self._warn_python2()
-                self._show_help()
                 if command in ["-h", "--help"]:
+                    self._show_help()
                     return False
+
+                self._user_io.out.writeln(
+                    "'%s' is not a Conan command. See 'conan --help'" % command)
+                self._user_io.out.writeln("")
+
+                self._print_similar(command)
+
                 raise ConanException("Unknown command %s" % str(exc))
             except IndexError:  # No parameters
                 self._show_help()

--- a/conans/client/command.py
+++ b/conans/client/command.py
@@ -1882,7 +1882,7 @@ class Command(object):
                     return False
 
                 self._out.writeln(
-                    "'%s' is not a Conan command. See 'conan --help'" % command)
+                    "'%s' is not a Conan command. See 'conan --help'." % command)
                 self._out.writeln("")
 
                 self._print_similar(command)

--- a/conans/client/command.py
+++ b/conans/client/command.py
@@ -1866,7 +1866,6 @@ class Command(object):
         """
         ret_code = SUCCESS
         try:
-            self._warn_python2()
             try:
                 command = args[0][0]
                 commands = self._commands()
@@ -1875,6 +1874,9 @@ class Command(object):
                 if command in ["-v", "--version"]:
                     self._out.success("Conan version %s" % client_version)
                     return False
+
+                self._warn_python2()
+
                 if command in ["-h", "--help"]:
                     self._show_help()
                     return False

--- a/conans/client/command.py
+++ b/conans/client/command.py
@@ -1842,14 +1842,14 @@ class Command(object):
             return
 
         if len(matches) > 1:
-            self._user_io.out.writeln("The most similar commands are")
+            self._out.writeln("The most similar commands are")
         else:
-            self._user_io.out.writeln("The most similar command is")
+            self._out.writeln("The most similar command is")
 
         for match in matches:
-            print("    %s" % match)
+            self._out.writeln("    %s" % match)
 
-        self._user_io.out.writeln("")
+        self._out.writeln("")
 
     def _warn_python2(self):
         if six.PY2:
@@ -1881,9 +1881,9 @@ class Command(object):
                     self._show_help()
                     return False
 
-                self._user_io.out.writeln(
+                self._out.writeln(
                     "'%s' is not a Conan command. See 'conan --help'" % command)
-                self._user_io.out.writeln("")
+                self._out.writeln("")
 
                 self._print_similar(command)
 

--- a/conans/test/functional/command/help_test.py
+++ b/conans/test/functional/command/help_test.py
@@ -1,5 +1,6 @@
 import sys
 import unittest
+import textwrap
 
 from six import StringIO
 
@@ -19,6 +20,52 @@ class BasicClientTest(unittest.TestCase):
 
         client.run("some_unknown_command123", assert_error=True)
         self.assertIn("ERROR: Unknown command 'some_unknown_command123'", client.out)
+
+    def unknown_command_test(self):
+        client = TestClient()
+
+        client.run("some_unknown_command123", assert_error=True)
+        expected_output = textwrap.dedent(
+            """\
+                'some_unknown_command123' is not a Conan command. See 'conan --help'.
+
+                ERROR: Unknown command 'some_unknown_command123'
+            """)
+        self.assertIn(
+            expected_output, client.out)
+
+        # Check for a single suggestion
+        client.run("instal", assert_error=True)
+
+        expected_output = textwrap.dedent(
+            """\
+                'instal' is not a Conan command. See 'conan --help'.
+
+                The most similar command is
+                    install
+
+                ERROR: Unknown command 'instal'
+            """)
+        self.assertIn(
+            expected_output, client.out)
+
+        # Check for multiple suggestions
+        client.run("remoe", assert_error=True)
+        self.assertIn(
+            "", client.out)
+
+        expected_output = textwrap.dedent(
+            """\
+                'remoe' is not a Conan command. See 'conan --help'.
+
+                The most similar commands are
+                    remove
+                    remote
+
+                ERROR: Unknown command 'remoe'
+            """)
+        self.assertIn(
+            expected_output, client.out)
 
     def help_cmd_test(self):
         client = TestClient()


### PR DESCRIPTION
Changelog: UX: Make the error on incorrect command input more helpful
Docs: omit

Closes #5724 
