### PR TITLE
[Fix] package_id should be used for 'recipe_revision_mode'

### DIFF
--- a/conans/model/info.py
+++ b/conans/model/info.py
@@ -141,8 +141,8 @@ class RequirementInfo(object):
         self.version = self.full_version
         self.user = self.full_user
         self.channel = self.full_channel
+        self.package_id = self.full_package_id
         self.recipe_revision = self.full_recipe_revision
-        self.package_id = None
         self.package_revision = None
 
     def package_revision_mode(self):

--- a/conans/test/unittests/model/info_test.py
+++ b/conans/test/unittests/model/info_test.py
@@ -139,9 +139,9 @@ class ConanInfoTest(unittest.TestCase):
                                   "zlib/0.3@lasote/testing#RREV1")
         info = ConanInfo.loads(info2)
         info.requires.recipe_revision_mode()
-        self.assertEqual(info.requires.dumps(), "bzip2/1.2.3-alpha1+build123@lasote/testing\n"
-                                                "poco/2.3.4+build123@lasote/stable\n"
-                                                "zlib/0.3@lasote/testing#RREV1")
+        self.assertEqual(info.requires.dumps(), "bzip2/1.2.3-alpha1+build123@lasote/testing:sha1\n"
+                                                "poco/2.3.4+build123@lasote/stable:sha3\n"
+                                                "zlib/0.3@lasote/testing#RREV1:sha2")
         info2 = "[full_requires]\nzlib/0.3@lasote/testing#RREV1:sha2#PREV1"
         info = ConanInfo.loads(info2)
         info.requires.package_revision_mode()


### PR DESCRIPTION
Changelog: Fix: ``package_id`` should be used for ``recipe_revision_mode``
Docs: https://github.com/conan-io/docs/pull/1410

@TAGS: slow
@REVISIONS: 1