### PR TITLE
Conan info checks updates exist from upstream remotes (#5738)

### DIFF
--- a/conans/client/conan_api.py
+++ b/conans/client/conan_api.py
@@ -657,6 +657,7 @@ class ConanAPIV1(object):
         remotes = self.app.cache.registry.load_remotes()
         remotes.select(remote_name)
         # FIXME: Using update as check_update?
+        # TODO (uilian): https://github.com/conan-io/conan/issues/5738
         self.app.python_requires.enable_remotes(check_updates=update, remotes=remotes)
         deps_graph, conanfile = self.app.graph_manager.load_graph(reference, None, graph_info, build,
                                                                update, False, remotes,

--- a/conans/client/conan_api.py
+++ b/conans/client/conan_api.py
@@ -656,11 +656,9 @@ class ConanAPIV1(object):
         recorder = ActionRecorder()
         remotes = self.app.cache.registry.load_remotes()
         remotes.select(remote_name)
-        # FIXME: Using update as check_update?
-        # TODO (uilian): https://github.com/conan-io/conan/issues/5738
-        self.app.python_requires.enable_remotes(check_updates=update, remotes=remotes)
+        self.app.python_requires.enable_remotes(update=True, remotes=remotes)
         deps_graph, conanfile = self.app.graph_manager.load_graph(reference, None, graph_info, build,
-                                                               update, False, remotes,
+                                                               update, update, remotes,
                                                                recorder)
 
         if install_folder:

--- a/conans/test/functional/remote/multi_remote_test.py
+++ b/conans/test/functional/remote/multi_remote_test.py
@@ -56,14 +56,14 @@ class MultiRemotesTest(unittest.TestCase):
 
         # Execute info method in client_b, should advise that there is an update
         client_b.run("info Hello0/0.0@lasote/stable -u")
-        self.assertIn("Recipe: Update available", client_b.out)
+        self.assertIn("Recipe: Updated", client_b.out)
         self.assertIn("Binary: Cache", client_b.out)
 
         # Now try to update the package with install -u
         client_b.run("remote list_ref")
         self.assertIn(": local", str(client_b.out))
         client_b.run("install Hello0/0.0@lasote/stable -u --build")
-        self.assertIn("Hello0/0.0@lasote/stable from 'local' - Updated", client_b.out)
+        self.assertIn("Hello0/0.0@lasote/stable from 'local' - Cache", client_b.out)
         client_b.run("remote list_ref")
         self.assertIn(": local", str(client_b.out))
 
@@ -80,10 +80,10 @@ class MultiRemotesTest(unittest.TestCase):
 
         # But if we connect to default, should tell us that there is an update IN DEFAULT!
         client_b.run("info Hello0/0.0@lasote/stable -r default -u")
-        self.assertIn("Remote: local", client_b.out)
-        self.assertIn("Recipe: Update available", client_b.out)
+        self.assertIn("Remote: default", client_b.out)
+        self.assertIn("Recipe: Updated", client_b.out)
         client_b.run("remote list_ref")
-        self.assertIn(": local", str(client_b.out))
+        self.assertIn(": default", str(client_b.out))
 
         # Well, now try to update the package with -r default -u
         client_b.run("install Hello0/0.0@lasote/stable -r default -u --build")

--- a/conans/test/functional/remote/multi_remote_test.py
+++ b/conans/test/functional/remote/multi_remote_test.py
@@ -73,22 +73,18 @@ class MultiRemotesTest(unittest.TestCase):
         self._create(client_a, "Hello0", "0.0", modifier="\n\n")
         client_a.run("upload Hello0/0.0@lasote/stable -r default")
 
-        # Now client_b checks for updates without -r parameter
-        client_b.run("info Hello0/0.0@lasote/stable -u")
+        # Conan info should not update without -u
+        client_b.run("info Hello0/0.0@lasote/stable -r default")
         self.assertIn("Remote: local", client_b.out)
         self.assertIn("Recipe: Cache", client_b.out)
-
-        # But if we connect to default, should tell us that there is an update IN DEFAULT!
-        client_b.run("info Hello0/0.0@lasote/stable -r default -u")
-        self.assertIn("Remote: default", client_b.out)
-        self.assertIn("Recipe: Updated", client_b.out)
         client_b.run("remote list_ref")
-        self.assertIn(": default", str(client_b.out))
+        self.assertIn(": local", str(client_b.out))
 
         # Well, now try to update the package with -r default -u
         client_b.run("install Hello0/0.0@lasote/stable -r default -u --build")
-        self.assertIn("Hello0/0.0@lasote/stable: Calling build()",
-                      str(client_b.out))
+        self.assertIn("Hello0/0.0@lasote/stable: Calling build()", str(client_b.out))
+
+        # Info update won't result in new update because conan install already did it
         client_b.run("info Hello0/0.0@lasote/stable -u")
         self.assertIn("Recipe: Cache", client_b.out)
         self.assertIn("Binary: Cache", client_b.out)


### PR DESCRIPTION
- Force update when running `conan info --update`
- Add functional test to validate `info --update` scenario

Changelog: Fix: Conan info checks updates exist from upstream remotes (#5738)
Docs: Omit
fixes: #5738

- [x] Refer to the issue that supports this Pull Request.
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [x] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 

<sup>**Note:** By default this PR will skip the slower tests and will use a limited set of python versions. Check [here](https://github.com/conan-io/conan/blob/develop/.github/PR_INCREASE_TESTING.md) how to increase the testing level by writing some tags in the current PR body text.</sup>
