### PR TITLE
Remove Exceptions on empty user/channel

### DIFF
--- a/conans/model/conan_file.py
+++ b/conans/model/conan_file.py
@@ -183,18 +183,12 @@ class ConanFile(object):
     def channel(self):
         if not self._conan_channel:
             self._conan_channel = os.getenv("CONAN_CHANNEL") or self.default_channel
-            if not self._conan_channel:
-                raise ConanException("CONAN_CHANNEL environment variable not defined, "
-                                     "but self.channel is used in conanfile")
         return self._conan_channel
 
     @property
     def user(self):
         if not self._conan_user:
             self._conan_user = os.getenv("CONAN_USERNAME") or self.default_user
-            if not self._conan_user:
-                raise ConanException("CONAN_USERNAME environment variable not defined, "
-                                     "but self.user is used in conanfile")
         return self._conan_user
 
     def collect_libs(self, folder=None):

--- a/conans/test/integration/same_userchannel_test.py
+++ b/conans/test/integration/same_userchannel_test.py
@@ -93,17 +93,13 @@ class HelloReuseConan(ConanFile):
 
     def test_local_commands(self):
         self.client.run("install .", assert_error=True)
-        self.assertIn("ERROR: conanfile.py (Hello/0.1): "
-                      "Error in requirements() method, line 10", self.client.out)
-        self.assertIn("ConanException: CONAN_USERNAME environment "
-                      "variable not defined, but self.user is used", self.client.out)
+        self.assertIn("Failed requirement 'Say/0.1@None/None'", self.client.out)
+        self.assertNotIn("ERROR: conanfile.py (Hello/0.1): "
+                         "Error in requirements() method, line 10", self.client.out)
 
         os.environ["CONAN_USERNAME"] = "lasote"
         self.client.run("install .", assert_error=True)
-        self.assertIn("ERROR: conanfile.py (Hello/0.1): "
-                      "Error in requirements() method, line 10", self.client.out)
-        self.assertIn("ConanException: CONAN_CHANNEL environment "
-                      "variable not defined, but self.channel is used", self.client.out)
+        self.assertIn("Failed requirement 'Say/0.1@lasote/None'", self.client.out)
 
         os.environ["CONAN_CHANNEL"] = "stable"
         self.client.run("install .")
@@ -129,7 +125,7 @@ class SayConan(ConanFile):
     version = "0.1"
     build_policy = "missing"
     default_user = "userfoo"
-    
+
     def build(self):
         self.output.info("Building %s/%s" % (self.user, self.channel) )
 


### PR DESCRIPTION
Changelog: Bugfix: Allow access to `user`/`channel` when they're empty.
Docs: omit

Closes #5749 
