### PR TITLE
Deprecation of CONAN_USERNAME and CONAN_CHANNEL: fix error message

### DIFF
--- a/conans/model/conan_file.py
+++ b/conans/model/conan_file.py
@@ -184,8 +184,7 @@ class ConanFile(object):
         if not self._conan_channel:
             self._conan_channel = os.getenv("CONAN_CHANNEL") or self.default_channel
             if not self._conan_channel:
-                raise ConanException("CONAN_CHANNEL environment variable not defined, "
-                                     "but self.channel is used in conanfile")
+                raise ConanException("channel not defined, but self.channel is used in conanfile")
         return self._conan_channel
 
     @property
@@ -193,8 +192,7 @@ class ConanFile(object):
         if not self._conan_user:
             self._conan_user = os.getenv("CONAN_USERNAME") or self.default_user
             if not self._conan_user:
-                raise ConanException("CONAN_USERNAME environment variable not defined, "
-                                     "but self.user is used in conanfile")
+                raise ConanException("user not defined, but self.user is used in conanfile")
         return self._conan_user
 
     def collect_libs(self, folder=None):

--- a/conans/test/integration/same_userchannel_test.py
+++ b/conans/test/integration/same_userchannel_test.py
@@ -95,15 +95,15 @@ class HelloReuseConan(ConanFile):
         self.client.run("install .", assert_error=True)
         self.assertIn("ERROR: conanfile.py (Hello/0.1): "
                       "Error in requirements() method, line 10", self.client.out)
-        self.assertIn("ConanException: CONAN_USERNAME environment "
-                      "variable not defined, but self.user is used", self.client.out)
+        self.assertIn("ConanException: user not defined, but self.user is used in"
+                      " conanfile", self.client.out)
 
         os.environ["CONAN_USERNAME"] = "lasote"
         self.client.run("install .", assert_error=True)
         self.assertIn("ERROR: conanfile.py (Hello/0.1): "
                       "Error in requirements() method, line 10", self.client.out)
-        self.assertIn("ConanException: CONAN_CHANNEL environment "
-                      "variable not defined, but self.channel is used", self.client.out)
+        self.assertIn("ConanException: channel not defined, but self.channel is used in"
+                      " conanfile", self.client.out)
 
         os.environ["CONAN_CHANNEL"] = "stable"
         self.client.run("install .")


### PR DESCRIPTION
Changelog: omit
Docs: omit

if CONAN_USERNAME and CONAN_CHANNEL are deprecated, the error shouldn't talk about them.

Taken from https://github.com/conan-io/conan/pull/5750