### PR TITLE
Remove the hardcoded settings warning

### DIFF
--- a/conans/model/conan_file.py
+++ b/conans/model/conan_file.py
@@ -133,19 +133,6 @@ class ConanFile(object):
         self.requires = create_requirements(self)
         self.settings = create_settings(self, settings)
 
-        try:
-            if self.settings.os_build and self.settings.os:
-                self.output.writeln("*"*60, front=Color.BRIGHT_RED)
-                self.output.writeln("  This package defines both 'os' and 'os_build' ",
-                                    front=Color.BRIGHT_RED)
-                self.output.writeln("  Please use 'os' for libraries and 'os_build'",
-                                    front=Color.BRIGHT_RED)
-                self.output.writeln("  only for build-requires used for cross-building",
-                                    front=Color.BRIGHT_RED)
-                self.output.writeln("*"*60, front=Color.BRIGHT_RED)
-        except ConanException:
-            pass
-
         if 'cppstd' in self.settings.fields:
             self.output.warn("Setting 'cppstd' is deprecated in favor of 'compiler.cppstd',"
                              " please update your recipe.")

--- a/conans/test/functional/command/source_test.py
+++ b/conans/test/functional/command/source_test.py
@@ -89,17 +89,6 @@ class Pkg(ConanFile):
         client.run("create . Pkg/0.1@user/testing")
         self.assertIn("PATCH: this is my patch", client.out)
 
-    def source_warning_os_build_test(self):
-        # https://github.com/conan-io/conan/issues/2368
-        conanfile = '''from conans import ConanFile
-class ConanLib(ConanFile):
-    pass
-'''
-        client = TestClient()
-        client.save({CONANFILE: conanfile})
-        client.run("source .")
-        self.assertNotIn("This package defines both 'os' and 'os_build'", client.out)
-
     def source_reference_test(self):
         client = TestClient()
         client.run("source lib/1.0@conan/stable", assert_error=True)


### PR DESCRIPTION
Changelog: Fix: Move the warning about mixing 'os' and 'os_build' settings to hooks
Docs: omit

Closes #4602
The check is moved to hooks: https://github.com/conan-io/hooks/pull/78