### PR TITLE
Apply lockfile before updating downstream requires

### DIFF
--- a/conans/client/graph/graph_builder.py
+++ b/conans/client/graph/graph_builder.py
@@ -8,6 +8,7 @@ from conans.model.conan_file import get_env_context_manager
 from conans.model.ref import ConanFileReference
 from conans.model.requires import Requirements, Requirement
 from conans.util.log import logger
+from conans.util.env_reader import get_env
 
 
 class DepsGraphBuilder(object):
@@ -115,11 +116,16 @@ class DepsGraphBuilder(object):
         param down_ref: ConanFileReference of who is depending on current node for this expansion
         """
         # basic node configuration: calling configure() and requirements()
-        new_reqs, new_options = self._config_node(dep_graph, node, down_reqs, down_ref,
-                                                  down_options)
+        new_options = self._config_node(dep_graph, node, down_ref, down_options)
 
+        # TODO: version ranges should be expanded before applying the graph-lock
+
+        # Work on requires if there is a graph_lock available
         if graph_lock:
             graph_lock.lock_node(node, node.conanfile.requires.values())
+
+        # Check for requires and overrides
+        new_reqs = node.conanfile.requires.update(down_reqs, self._output, node.ref, down_ref)
 
         # if there are version-ranges, resolve them before expanding each of the requirements
         self._resolve_deps(dep_graph, node, update, remotes)
@@ -250,7 +256,7 @@ class DepsGraphBuilder(object):
                         return True
         return False
 
-    def _config_node(self, graph, node, down_reqs, down_ref, down_options):
+    def _config_node(self, graph, node, down_ref, down_options):
         """ update settings and option in the current ConanFile, computing actual
         requirement values, cause they can be overridden by downstream requires
         param settings: dict of settings values => {"os": "windows"}
@@ -299,7 +305,6 @@ class DepsGraphBuilder(object):
                 if graph.aliased:
                     for req in conanfile.requires.values():
                         req.ref = graph.aliased.get(req.ref, req.ref)
-                new_down_reqs = conanfile.requires.update(down_reqs, self._output, ref, down_ref)
         except ConanExceptionInUserConanfileMethod:
             raise
         except ConanException as e:
@@ -307,7 +312,7 @@ class DepsGraphBuilder(object):
         except Exception as e:
             raise ConanException(e)
 
-        return new_down_reqs, new_options
+        return new_options
 
     def _create_new_node(self, current_node, dep_graph, requirement, name_req,
                          check_updates, update, remotes, processed_profile, graph_lock,

--- a/conans/client/graph/graph_builder.py
+++ b/conans/client/graph/graph_builder.py
@@ -115,11 +115,16 @@ class DepsGraphBuilder(object):
         param down_ref: ConanFileReference of who is depending on current node for this expansion
         """
         # basic node configuration: calling configure() and requirements()
-        new_reqs, new_options = self._config_node(dep_graph, node, down_reqs, down_ref,
-                                                  down_options, graph_lock)
+        new_options = self._config_node(dep_graph, node, down_ref, down_options)
 
-        # if there are version-ranges, resolve them before expanding each of the requirements
-        self._resolve_deps(dep_graph, node, update, remotes)
+        if graph_lock:
+            graph_lock.lock_node(node, node.conanfile.requires.values())
+            new_reqs = None
+        else:
+            # propagation of requirements only necessary if not locked
+            new_reqs = node.conanfile.requires.update(down_reqs, self._output, node.ref, down_ref)
+            # if there are version-ranges, resolve them before expanding each of the requirements
+            self._resolve_deps(dep_graph, node, update, remotes)
 
         # Expand each one of the current requirements
         for name, require in node.conanfile.requires.items():
@@ -206,7 +211,7 @@ class DepsGraphBuilder(object):
 
             # Recursion is only necessary if the inputs conflict with the current "previous"
             # configuration of upstream versions and options
-            if self._recurse(previous.public_closure, new_reqs, new_options):
+            if not graph_lock and self._recurse(previous.public_closure, new_reqs, new_options):
                 self._load_deps(dep_graph, previous, new_reqs, node.ref, new_options, check_updates,
                                 update, remotes, processed_profile, graph_lock)
 
@@ -247,13 +252,14 @@ class DepsGraphBuilder(object):
                         return True
         return False
 
-    def _config_node(self, graph, node, down_reqs, down_ref, down_options, graph_lock):
+    @staticmethod
+    def _config_node(graph, node, down_ref, down_options):
         """ update settings and option in the current ConanFile, computing actual
         requirement values, cause they can be overridden by downstream requires
         param settings: dict of settings values => {"os": "windows"}
         """
+        conanfile, ref = node.conanfile, node.ref
         try:
-            conanfile, ref = node.conanfile, node.ref
             # Avoid extra time manipulating the sys.path for python
             with get_env_context_manager(conanfile, without_python=True):
                 if hasattr(conanfile, "config"):
@@ -296,11 +302,6 @@ class DepsGraphBuilder(object):
                 if graph.aliased:
                     for req in conanfile.requires.values():
                         req.ref = graph.aliased.get(req.ref, req.ref)
-
-                if graph_lock:
-                    graph_lock.lock_node(node, node.conanfile.requires.values())
-
-                new_down_reqs = conanfile.requires.update(down_reqs, self._output, ref, down_ref)
         except ConanExceptionInUserConanfileMethod:
             raise
         except ConanException as e:
@@ -308,7 +309,7 @@ class DepsGraphBuilder(object):
         except Exception as e:
             raise ConanException(e)
 
-        return new_down_reqs, new_options
+        return new_options
 
     def _create_new_node(self, current_node, dep_graph, requirement, name_req,
                          check_updates, update, remotes, processed_profile, graph_lock,

--- a/conans/client/graph/graph_builder.py
+++ b/conans/client/graph/graph_builder.py
@@ -115,16 +115,8 @@ class DepsGraphBuilder(object):
         param down_ref: ConanFileReference of who is depending on current node for this expansion
         """
         # basic node configuration: calling configure() and requirements()
-        new_options = self._config_node(dep_graph, node, down_ref, down_options)
-
-        if graph_lock:
-            graph_lock.lock_node(node, node.conanfile.requires.values())
-
-        try:
-            # Check for requires and overrides
-            new_reqs = node.conanfile.requires.update(down_reqs, self._output, node.ref, down_ref)
-        except ConanException as e:
-            raise ConanException("%s: %s" % (node.ref or "Conanfile", str(e)))
+        new_reqs, new_options = self._config_node(dep_graph, node, down_reqs, down_ref,
+                                                  down_options, graph_lock)
 
         # if there are version-ranges, resolve them before expanding each of the requirements
         self._resolve_deps(dep_graph, node, update, remotes)
@@ -255,7 +247,7 @@ class DepsGraphBuilder(object):
                         return True
         return False
 
-    def _config_node(self, graph, node, down_ref, down_options):
+    def _config_node(self, graph, node, down_reqs, down_ref, down_options, graph_lock):
         """ update settings and option in the current ConanFile, computing actual
         requirement values, cause they can be overridden by downstream requires
         param settings: dict of settings values => {"os": "windows"}
@@ -304,6 +296,11 @@ class DepsGraphBuilder(object):
                 if graph.aliased:
                     for req in conanfile.requires.values():
                         req.ref = graph.aliased.get(req.ref, req.ref)
+
+                if graph_lock:
+                    graph_lock.lock_node(node, node.conanfile.requires.values())
+
+                new_down_reqs = conanfile.requires.update(down_reqs, self._output, ref, down_ref)
         except ConanExceptionInUserConanfileMethod:
             raise
         except ConanException as e:
@@ -311,7 +308,7 @@ class DepsGraphBuilder(object):
         except Exception as e:
             raise ConanException(e)
 
-        return new_options
+        return new_down_reqs, new_options
 
     def _create_new_node(self, current_node, dep_graph, requirement, name_req,
                          check_updates, update, remotes, processed_profile, graph_lock,

--- a/conans/model/requires.py
+++ b/conans/model/requires.py
@@ -144,7 +144,6 @@ class Requirements(OrderedDict):
                     if error_on_override and not other_req.override:
                         raise ConanException(msg)
 
-                    msg = "%s %s" % (own_ref, msg)
                     output.warn(msg)
                     req.ref = other_ref
 

--- a/conans/model/requires.py
+++ b/conans/model/requires.py
@@ -138,8 +138,8 @@ class Requirements(OrderedDict):
                 # update dependency
                 other_ref = other_req.ref
                 if other_ref and other_ref != req.ref:
-                    msg = "requirement %s overridden by %s to %s " \
-                          % (req.ref, down_ref or "your conanfile", other_ref)
+                    msg = "%s: requirement %s overridden by %s to %s " \
+                          % (own_ref, req.ref, down_ref or "your conanfile", other_ref)
 
                     if error_on_override and not other_req.override:
                         raise ConanException(msg)

--- a/conans/test/functional/graph/conflict_diamond_test.py
+++ b/conans/test/functional/graph/conflict_diamond_test.py
@@ -51,7 +51,7 @@ class ConflictDiamondTest(unittest.TestCase):
                      ["Hello1/0.1@lasote/stable", "Hello2/0.1@lasote/stable",
                       "Hello0/0.1@lasote/stable"], export=False)
         self.client.run("install . --build missing", assert_error=False)
-        self.assertIn("Hello2/0.1@lasote/stable requirement Hello0/0.2@lasote/stable overridden"
+        self.assertIn("Hello2/0.1@lasote/stable: requirement Hello0/0.2@lasote/stable overridden"
                       " by Hello3/0.1 to Hello0/0.1@lasote/stable",
                       self.client.out)
 
@@ -81,7 +81,7 @@ class ConflictDiamondTest(unittest.TestCase):
                                           '("Hello0/0.1@lasote/stable", "override"),)')
             self.client.save({CONANFILE: conanfile})
             self.client.run("install . --build missing")
-            self.assertIn("Hello2/0.1@lasote/stable requirement Hello0/0.2@lasote/stable overridden"
+            self.assertIn("Hello2/0.1@lasote/stable: requirement Hello0/0.2@lasote/stable overridden"
                           " by Hello3/0.1 to Hello0/0.1@lasote/stable",
                           self.client.out)
 

--- a/conans/test/functional/graph_lock/graph_lock_test.py
+++ b/conans/test/functional/graph_lock/graph_lock_test.py
@@ -400,7 +400,7 @@ class GraphLockWarningsTestCase(unittest.TestCase):
 
         # Building the graphlock we get the message
         client.run("graph lock meta.py")
-        self.assertIn("WARN: ffmpeg/1.0 requirement harfbuzz/[>=1.0] overridden by meta/1.0"
+        self.assertIn("WARN: ffmpeg/1.0: requirement harfbuzz/[>=1.0] overridden by meta/1.0"
                       " to harfbuzz/1.0", client.out)
 
         # Using the graphlock there is no warning message

--- a/conans/test/functional/graph_lock/graph_lock_test.py
+++ b/conans/test/functional/graph_lock/graph_lock_test.py
@@ -379,3 +379,27 @@ class GraphLockPythonRequiresTest(unittest.TestCase):
         client.run("export-pkg . Pkg/0.1@user/channel --install-folder=.  --lockfile")
         self.assertIn("Pkg/0.1@user/channel: CONFIGURE VAR=42", client.out)
         self._check_lock("Pkg/0.1@user/channel#332c2615c2ff9f78fc40682e733e5aa5")
+
+
+class GraphLockWarningsTestCase(unittest.TestCase):
+
+    def test_override(self):
+        client = TestClient()
+        harfbuzz_ref = ConanFileReference.loads("harfbuzz/1.0")
+        ffmpeg_ref = ConanFileReference.loads("ffmpeg/1.0")
+        harfbuzz_ref2 = harfbuzz_ref.copy_with_rev('f6aa6ab1b36fd9d454de25deaff4ef23')
+        client.save({"harfbuzz.py": GenConanfile().with_name("harfbuzz").with_version("1.0"),
+                     "ffmpeg.py": GenConanfile().with_name("ffmpeg").with_version("1.0")
+                                                .with_requirement(harfbuzz_ref),
+                     "meta.py": GenConanfile().with_name("meta").with_version("1.0")
+                                              .with_requirement(ffmpeg_ref)
+                                              .with_requirement_plain(harfbuzz_ref2)
+                     })
+        client.run("export harfbuzz.py")
+        client.run("export ffmpeg.py")
+        client.run("export meta.py")
+
+        client.run("graph lock meta.py")
+        client.run("graph build-order conan.lock")
+
+        self.assertNotIn("overridden", client.out)

--- a/conans/test/unittests/model/transitive_reqs_test.py
+++ b/conans/test/unittests/model/transitive_reqs_test.py
@@ -436,7 +436,7 @@ class ChatConan(ConanFile):
         self.retriever.save_recipe(bye_ref, bye_content2)
         deps_graph = self.build_graph(chat_content)
 
-        self.assertIn("Hello/1.2@user/testing requirement Say/0.1@user/testing overridden by "
+        self.assertIn("Hello/1.2@user/testing: requirement Say/0.1@user/testing overridden by "
                       "your conanfile to Say/0.2@user/testing", self.output)
         self.assertNotIn("Conflict", self.output)
         self.assertEqual(4, len(deps_graph.nodes))
@@ -1496,7 +1496,7 @@ class LibDConan(ConanFile):
 
         with six.assertRaisesRegex(self, ConanException, "Conflict in LibB/0.1@user/testing"):
             self.build_graph(self.consumer_content)
-        self.assertIn("LibB/0.1@user/testing requirement LibA/0.1@user/testing overridden by "
+        self.assertIn("LibB/0.1@user/testing: requirement LibA/0.1@user/testing overridden by "
                       "LibD/0.1@user/testing to LibA/0.2@user/testing", str(self.output))
         self.assertEqual(1, str(self.output).count("LibA requirements()"))
         self.assertEqual(1, str(self.output).count("LibA configure()"))


### PR DESCRIPTION
Changelog: Fix: Apply lockfile to the node before updating with downstream requirements
Docs: omit

If we apply the graphlock to the requires declared in the recipe, they will be populated with some data (recipe revisions) and will match the requirements downstream that already contains graphlock information.

I'm using a version range ``harfbuzz/[>=1.0]`` in the requirement because it is resolved to a fixed version with the graphlock. With a regular requires ``harfbuzz/1.0`` the behavior would be the same.

Fix https://github.com/conan-io/conan/issues/5754

--- 
**Not fixed here:** 

 * ⚠️ If we require a specific revision, like ``harfbuzz/1.0#12345`` then the diamond will be resolved and the requirement overridden with a misleading message:

   ```
   WARN: ffmpeg/1.0 requirement harfbuzz/1.0 overridden by meta/1.0 to harfbuzz/1.0 
   ```

   This happens with and without revisions enabled. It would be helpful to add the revisions to the output message (only if revisions are the difference between both references)