### PR TITLE
Accept logging level names (#5765)

### DIFF
--- a/conans/client/conf/__init__.py
+++ b/conans/client/conf/__init__.py
@@ -8,7 +8,6 @@ from conans.model.env_info import unquote
 from conans.paths import DEFAULT_PROFILE_NAME, conan_expand_user, CACERT_FILE
 from conans.util.env_reader import get_env
 from conans.util.files import load
-from conans.util.log import get_log_level_by_name
 import logging
 
 
@@ -507,7 +506,7 @@ class ConanClientConfigParser(ConfigParser, object):
             if level is None:
                 level = self.get_item("log.level")
             try:
-                parsed_level = get_log_level_by_name(level)
+                parsed_level = ConanClientConfigParser.get_log_level_by_name(level)
                 level = parsed_level if parsed_level is not None else int(level)
             except Exception:
                 level = logging.CRITICAL
@@ -576,3 +575,16 @@ class ConanClientConfigParser(ConfigParser, object):
             return log_run_to_output.lower() in ("1", "true")
         except ConanException:
             return True
+
+    @staticmethod
+    def get_log_level_by_name(level_name):
+        levels = {
+            "critical": logging.CRITICAL,
+            "error": logging.ERROR,
+            "warning": logging.WARNING,
+            "warn": logging.WARNING,
+            "info": logging.INFO,
+            "debug": logging.DEBUG,
+            "notset": logging.NOTSET
+        }
+        return levels.get(str(level_name).lower())

--- a/conans/client/conf/__init__.py
+++ b/conans/client/conf/__init__.py
@@ -8,6 +8,7 @@ from conans.model.env_info import unquote
 from conans.paths import DEFAULT_PROFILE_NAME, conan_expand_user, CACERT_FILE
 from conans.util.env_reader import get_env
 from conans.util.files import load
+from conans.util.log import get_log_level_by_name
 import logging
 
 
@@ -98,7 +99,7 @@ default_client_conf = """
 [log]
 run_to_output = True        # environment CONAN_LOG_RUN_TO_OUTPUT
 run_to_file = False         # environment CONAN_LOG_RUN_TO_FILE
-level = 50                  # environment CONAN_LOGGING_LEVEL
+level = critical            # environment CONAN_LOGGING_LEVEL
 # trace_file =              # environment CONAN_TRACE_FILE
 print_run_commands = False  # environment CONAN_PRINT_RUN_COMMANDS
 
@@ -506,7 +507,8 @@ class ConanClientConfigParser(ConfigParser, object):
             if level is None:
                 level = self.get_item("log.level")
             try:
-                level = int(level)
+                parsed_level = get_log_level_by_name(level)
+                level = parsed_level if parsed_level is not None else int(level)
             except Exception:
                 level = logging.CRITICAL
             return level

--- a/conans/test/unittests/util/client_conf_test.py
+++ b/conans/test/unittests/util/client_conf_test.py
@@ -63,57 +63,69 @@ class ClientConfTest(unittest.TestCase):
         config = ConanClientConfigParser(os.path.join(tmp_dir, CONAN_CONF))
         self.assertEqual(config.proxies["no_proxy"], "localhost")
 
-    def test_log_level_numbers(self):
-        tmp_dir = temp_folder()
-        save(os.path.join(tmp_dir, CONAN_CONF), default_client_conf_log.format("level = 10"))
-        save(os.path.join(tmp_dir, DEFAULT_PROFILE_NAME), default_profile)
-        config = ConanClientConfigParser(os.path.join(tmp_dir, CONAN_CONF))
+
+class ClientConfLogTest(unittest.TestCase):
+
+    def setUp(self):
+        self.tmp_dir = temp_folder()
+        save(os.path.join(self.tmp_dir, DEFAULT_PROFILE_NAME), default_profile)
+
+    def test_log_level_numbers_debug(self):
+        save(os.path.join(self.tmp_dir, CONAN_CONF), default_client_conf_log.format("level = 10"))
+        config = ConanClientConfigParser(os.path.join(self.tmp_dir, CONAN_CONF))
         self.assertEqual(logging.DEBUG, config.logging_level)
 
-        save(os.path.join(tmp_dir, CONAN_CONF), default_client_conf_log.format("level = 50"))
-        config = ConanClientConfigParser(os.path.join(tmp_dir, CONAN_CONF))
+    def test_log_level_numbers_critical(self):
+        save(os.path.join(self.tmp_dir, CONAN_CONF), default_client_conf_log.format("level = 50"))
+        config = ConanClientConfigParser(os.path.join(self.tmp_dir, CONAN_CONF))
         self.assertEqual(logging.CRITICAL, config.logging_level)
 
-        save(os.path.join(tmp_dir, CONAN_CONF), default_client_conf_log.format("level = wakawaka"))
-        config = ConanClientConfigParser(os.path.join(tmp_dir, CONAN_CONF))
+    def test_log_level_numbers_invalid(self):
+        save(os.path.join(self.tmp_dir, CONAN_CONF), default_client_conf_log.format("level = wakawaka"))
+        config = ConanClientConfigParser(os.path.join(self.tmp_dir, CONAN_CONF))
         self.assertEqual(logging.CRITICAL, config.logging_level)
 
+    def test_log_level_numbers_env_var_debug(self):
         with environment_append({"CONAN_LOGGING_LEVEL": "10"}):
-            save(os.path.join(tmp_dir, CONAN_CONF), default_client_conf)
-            config = ConanClientConfigParser(os.path.join(tmp_dir, CONAN_CONF))
+            save(os.path.join(self.tmp_dir, CONAN_CONF), default_client_conf)
+            config = ConanClientConfigParser(os.path.join(self.tmp_dir, CONAN_CONF))
             self.assertEqual(logging.DEBUG, config.logging_level)
 
+    def test_log_level_numbers_env_var_debug(self):
         with environment_append({"CONAN_LOGGING_LEVEL": "WakaWaka"}):
-            save(os.path.join(tmp_dir, CONAN_CONF), default_client_conf)
-            config = ConanClientConfigParser(os.path.join(tmp_dir, CONAN_CONF))
+            save(os.path.join(self.tmp_dir, CONAN_CONF), default_client_conf)
+            config = ConanClientConfigParser(os.path.join(self.tmp_dir, CONAN_CONF))
             self.assertEqual(logging.CRITICAL, config.logging_level)
 
-    def test_log_level_names(self):
-        tmp_dir = temp_folder()
-        save(os.path.join(tmp_dir, CONAN_CONF), default_client_conf_log.format("level = debug"))
-        save(os.path.join(tmp_dir, DEFAULT_PROFILE_NAME), default_profile)
-        config = ConanClientConfigParser(os.path.join(tmp_dir, CONAN_CONF))
+    def test_log_level_names_debug(self):
+        save(os.path.join(self.tmp_dir, CONAN_CONF), default_client_conf_log.format("level = debug"))
+        config = ConanClientConfigParser(os.path.join(self.tmp_dir, CONAN_CONF))
         self.assertEqual(logging.DEBUG, config.logging_level)
 
-        save(os.path.join(tmp_dir, CONAN_CONF), default_client_conf_log.format("level = Critical"))
-        config = ConanClientConfigParser(os.path.join(tmp_dir, CONAN_CONF))
+    def test_log_level_names_critical(self):
+        save(os.path.join(self.tmp_dir, CONAN_CONF), default_client_conf_log.format("level = Critical"))
+        config = ConanClientConfigParser(os.path.join(self.tmp_dir, CONAN_CONF))
         self.assertEqual(logging.CRITICAL, config.logging_level)
 
-        save(os.path.join(tmp_dir, CONAN_CONF), default_client_conf_log.format("level = wakawaka"))
-        config = ConanClientConfigParser(os.path.join(tmp_dir, CONAN_CONF))
+    def test_log_level_names_invalid(self):
+        save(os.path.join(self.tmp_dir, CONAN_CONF), default_client_conf_log.format("level = wakawaka"))
+        config = ConanClientConfigParser(os.path.join(self.tmp_dir, CONAN_CONF))
         self.assertEqual(logging.CRITICAL, config.logging_level)
 
+    def test_log_level_names_env_var_debug(self):
         with environment_append({"CONAN_LOGGING_LEVEL": "Debug"}):
-            save(os.path.join(tmp_dir, CONAN_CONF), default_client_conf)
-            config = ConanClientConfigParser(os.path.join(tmp_dir, CONAN_CONF))
+            save(os.path.join(self.tmp_dir, CONAN_CONF), default_client_conf)
+            config = ConanClientConfigParser(os.path.join(self.tmp_dir, CONAN_CONF))
             self.assertEqual(logging.DEBUG, config.logging_level)
 
+    def test_log_level_names_env_var_warning(self):
         with environment_append({"CONAN_LOGGING_LEVEL": "WARNING"}):
-            save(os.path.join(tmp_dir, CONAN_CONF), default_client_conf)
-            config = ConanClientConfigParser(os.path.join(tmp_dir, CONAN_CONF))
+            save(os.path.join(self.tmp_dir, CONAN_CONF), default_client_conf)
+            config = ConanClientConfigParser(os.path.join(self.tmp_dir, CONAN_CONF))
             self.assertEqual(logging.WARNING, config.logging_level)
 
+    def test_log_level_names_env_var_invalid(self):
         with environment_append({"CONAN_LOGGING_LEVEL": "WakaWaka"}):
-            save(os.path.join(tmp_dir, CONAN_CONF), default_client_conf)
-            config = ConanClientConfigParser(os.path.join(tmp_dir, CONAN_CONF))
+            save(os.path.join(self.tmp_dir, CONAN_CONF), default_client_conf)
+            config = ConanClientConfigParser(os.path.join(self.tmp_dir, CONAN_CONF))
             self.assertEqual(logging.CRITICAL, config.logging_level)

--- a/conans/test/unittests/util/client_conf_test.py
+++ b/conans/test/unittests/util/client_conf_test.py
@@ -70,15 +70,15 @@ class ClientConfLogTest(unittest.TestCase):
         self.tmp_dir = temp_folder()
         save(os.path.join(self.tmp_dir, DEFAULT_PROFILE_NAME), default_profile)
 
-    def test_log_level_numbers_debug(self):
-        save(os.path.join(self.tmp_dir, CONAN_CONF), default_client_conf_log.format("level = 10"))
-        config = ConanClientConfigParser(os.path.join(self.tmp_dir, CONAN_CONF))
-        self.assertEqual(logging.DEBUG, config.logging_level)
-
     def test_log_level_numbers_critical(self):
         save(os.path.join(self.tmp_dir, CONAN_CONF), default_client_conf_log.format("level = 50"))
         config = ConanClientConfigParser(os.path.join(self.tmp_dir, CONAN_CONF))
         self.assertEqual(logging.CRITICAL, config.logging_level)
+
+    def test_log_level_numbers_debug(self):
+        save(os.path.join(self.tmp_dir, CONAN_CONF), default_client_conf_log.format("level = 10"))
+        config = ConanClientConfigParser(os.path.join(self.tmp_dir, CONAN_CONF))
+        self.assertEqual(logging.DEBUG, config.logging_level)
 
     def test_log_level_numbers_invalid(self):
         save(os.path.join(self.tmp_dir, CONAN_CONF), default_client_conf_log.format("level = wakawaka"))

--- a/conans/test/unittests/util/client_conf_test.py
+++ b/conans/test/unittests/util/client_conf_test.py
@@ -69,6 +69,10 @@ class ClientConfLogTest(unittest.TestCase):
     def setUp(self):
         self.tmp_dir = temp_folder()
         save(os.path.join(self.tmp_dir, DEFAULT_PROFILE_NAME), default_profile)
+        try:
+            del os.environ["CONAN_LOGGING_LEVEL"]
+        except:
+            pass
 
     def test_log_level_numbers_critical(self):
         save(os.path.join(self.tmp_dir, CONAN_CONF), default_client_conf_log.format("level = 50"))

--- a/conans/test/unittests/util/client_conf_test.py
+++ b/conans/test/unittests/util/client_conf_test.py
@@ -19,17 +19,6 @@ trace_file = "Path/with/quotes"
 
 '''
 
-default_client_conf_log = '''[storage]
-path: ~/.conan/data
-
-[log]
-trace_file = "foo/bar/quotes"
-{}
-
-[general]
-
-'''
-
 default_profile = '''
 [settings]
 arch=x86_64
@@ -62,6 +51,18 @@ class ClientConfTest(unittest.TestCase):
         save(os.path.join(tmp_dir, CONAN_CONF), "[proxies]\nno_proxy=localhost")
         config = ConanClientConfigParser(os.path.join(tmp_dir, CONAN_CONF))
         self.assertEqual(config.proxies["no_proxy"], "localhost")
+
+
+default_client_conf_log = '''[storage]
+path: ~/.conan/data
+
+[log]
+trace_file = "foo/bar/quotes"
+{}
+
+[general]
+
+'''
 
 
 class ClientConfLogTest(unittest.TestCase):

--- a/conans/util/log.py
+++ b/conans/util/log.py
@@ -36,19 +36,6 @@ def configure_logger(logging_level=logging.CRITICAL, logging_file=None):
     return logger
 
 
-def get_log_level_by_name(level_name):
-    levels = {
-        "critical": logging.CRITICAL,
-        "error": logging.ERROR,
-        "warning": logging.WARNING,
-        "warn": logging.WARNING,
-        "info": logging.INFO,
-        "debug": logging.DEBUG,
-        "notset": logging.NOTSET
-    }
-    return levels.get(str(level_name).lower())
-
-
 logger = configure_logger()
 
 # CRITICAL = 50

--- a/conans/util/log.py
+++ b/conans/util/log.py
@@ -36,6 +36,19 @@ def configure_logger(logging_level=logging.CRITICAL, logging_file=None):
     return logger
 
 
+def get_log_level_by_name(level_name):
+    levels = {
+        "critical": logging.CRITICAL,
+        "error": logging.ERROR,
+        "warning": logging.WARNING,
+        "warn": logging.WARNING,
+        "info": logging.INFO,
+        "debug": logging.DEBUG,
+        "notset": logging.NOTSET
+    }
+    return levels.get(str(level_name).lower())
+
+
 logger = configure_logger()
 
 # CRITICAL = 50


### PR DESCRIPTION
Now any user can set Conan logging level using common names as debug, info, critical ...

Related Issue: #5765 
Changelog: Feature: Accept logging level as logging names
Docs: https://github.com/conan-io/docs/pull/1419

- [x] Refer to the issue that supports this Pull Request.
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [x] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 

<sup>**Note:** By default this PR will skip the slower tests and will use a limited set of python versions. Check [here](https://github.com/conan-io/conan/blob/develop/.github/PR_INCREASE_TESTING.md) how to increase the testing level by writing some tags in the current PR body text.</sup>
