### PR TITLE
FileCopier: avoid repeated copies of absolute paths.

### DIFF
--- a/conans/client/file_copier.py
+++ b/conans/client/file_copier.py
@@ -67,6 +67,12 @@ class FileCopier(object):
         if symlinks is not None:
             links = symlinks
 
+        if os.path.isabs(src):
+            # Avoid repeatedly copying absolute paths
+            return self._copy(os.curdir, pattern, src, dst, links,
+                              ignore_case, excludes, keep_path,
+                              excluded_folders=[self._dst_folder])
+
         files = []
         for src_folder in self._src_folders:
             excluded = [self._dst_folder]


### PR DESCRIPTION
Changelog: Bugfix: avoid repeated copies of absolute paths when using self.copy().
Docs: Omit

- [ ] Refer to the issue that supports this Pull Request.
No. I tried creating an issue but the "Submit new issue" button stayed greyed-out. However, hopefully this change is minor enough that creating an issue for it isn't necessary.
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
My team have occasionally written conanfiles that do this:
`def imports(self):
   self.copy('foo', src=os.path.join(self.deps_cpp_info['bar'].rootpath, 'baz'))`
What isn't obvious to developers is that self.copy() will iterate over all dependencies and repeat the copy for each one. This is suboptimal. We've ended up using functions from distutils but we'd prefer to be able to use self.copy().
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one.
No. This change shouldn't be observable other than speeding things up in some cases.