### PR TITLE
 Lock buggy urllib3 versions only

### DIFF
--- a/conans/requirements.txt
+++ b/conans/requirements.txt
@@ -1,6 +1,6 @@
 PyJWT>=1.4.0, <2.0.0
 requests>=2.8.1, <3.0.0
-urllib3<1.25.4
+urllib3!=1.25.4,!=1.25.5
 colorama>=0.3.3, <0.5.0
 PyYAML>=3.11, <6.0
 patch==1.16


### PR DESCRIPTION
Changelog: omit
Docs: omit

Closes #5802 

urllib3 version 1.25.6 has been released and doesn't contain the bug, so forbid the two buggy versions but unlock the version

---

From the `urllib3` changelog:
>1.25.6 (2019-09-24)
>Fix issue where tilde (~) characters were incorrectly percent-encoded in the path. (Pull https://github.com/urllib3/urllib3/pull/1692)