### PR TITLE
adds support for transitive deps for b2 generator

### DIFF
--- a/conans/client/generators/b2.py
+++ b/conans/client/generators/b2.py
@@ -130,15 +130,14 @@ class B2Generator(Generator):
             return []
         name = name.lower()
         result = []
+        deps = ['/%s//libs' % dep for dep in info.public_deps]
         if info.libs:
             for lib in info.libs:
                 result += [self.conanbuildinfo_variation_lib_template.format(
-                    name=name, lib=lib, variation=self.b2_variation_id)]
-            result += [self.conanbuildinfo_variation_alias_template.format(
-                name=name, libs=" ".join(info.libs), variation=self.b2_variation_id)]
-        else:
-            result += [self.conanbuildinfo_variation_alias_template.format(
-                name=name, libs="", variation=self.b2_variation_id)]
+                    name=name, lib=lib, deps=" ".join(deps), variation=self.b2_variation_id)]
+            deps.extend(info.libs)
+        result += [self.conanbuildinfo_variation_alias_template.format(
+            name=name, libs=" ".join(deps), variation=self.b2_variation_id)]
 
         return result
 
@@ -413,7 +412,7 @@ constant-if {var}({name},{variation}) :
     conanbuildinfo_variation_lib_template = """\
 if $(__define_targets__) {{
     call-in-project $({name}-mod) : lib {lib}
-        :
+        : {deps}
         : <name>{lib} <search>$(libdirs({name},{variation})) $(requirements({name},{variation}))
         :
         : $(usage-requirements({name},{variation})) ;

--- a/conans/test/unittests/client/generators/b2_test.py
+++ b/conans/test/unittests/client/generators/b2_test.py
@@ -298,7 +298,7 @@ constant-if usage-requirements(mypkg2,32,x86,17,gnu,linux,gcc-6.3,release) :
 # mypkg
 if $(__define_targets__) {
     call-in-project $(mypkg-mod) : lib MyLib1
-        :
+        : ''' + '''
         : <name>MyLib1 <search>$(libdirs(mypkg,32,x86,17,gnu,linux,gcc-6.3,release)) $(requirements(mypkg,32,x86,17,gnu,linux,gcc-6.3,release))
         :
         : $(usage-requirements(mypkg,32,x86,17,gnu,linux,gcc-6.3,release)) ;
@@ -315,7 +315,7 @@ if $(__define_targets__) {
 # mypkg2
 if $(__define_targets__) {
     call-in-project $(mypkg2-mod) : lib MyLib2
-        :
+        : /MyPkg//libs
         : <name>MyLib2 <search>$(libdirs(mypkg2,32,x86,17,gnu,linux,gcc-6.3,release)) $(requirements(mypkg2,32,x86,17,gnu,linux,gcc-6.3,release))
         :
         : $(usage-requirements(mypkg2,32,x86,17,gnu,linux,gcc-6.3,release)) ;
@@ -323,7 +323,7 @@ if $(__define_targets__) {
 
 if $(__define_targets__) {
     call-in-project $(mypkg2-mod) : alias libs
-        : MyLib2
+        : /MyPkg//libs MyLib2
         : $(requirements(mypkg2,32,x86,17,gnu,linux,gcc-6.3,release))
         :
         : $(usage-requirements(mypkg2,32,x86,17,gnu,linux,gcc-6.3,release)) ;


### PR DESCRIPTION
Changelog: Fix: b2 generator doesn't specify transitive dependencies in its output

- [ ] Refer to the issue that supports this Pull Request.
- [ ] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [X] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [X] I've followed the PEP8 style guides for Python code.
