### PR TITLE
Remove py34

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,6 @@ language: python
 matrix:
     include:
         - python: 2.7
-        - python: 3.4
-          if: branch =~ ^release.* OR branch =~ ^master
         - python: 3.5
           if: branch =~ ^release.* OR branch =~ ^master
         - python: 3.6

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,7 +6,6 @@
     environment:
       matrix:
         - PYTHON: "C:\\Python27"
-        - PYTHON: "C:\\Python34"
         - PYTHON: "C:\\Python35"
     build: false
     cache:


### PR DESCRIPTION
Changelog: Fix: Dropped support for python 3.4.  That version is widely being dropped by the python community. Since Conan 1.19, the tests won't be run with python 3.4 and we won't be aware if something is not working correctly.
Docs: https://github.com/conan-io/docs/pull/1424

Note: The files in this PR are not really affecting the conan CI that runs an external library where the python 3.4 has been deactivated already.