### PR TITLE
fix upload package id

### DIFF
--- a/conans/client/cmd/uploader.py
+++ b/conans/client/cmd/uploader.py
@@ -93,7 +93,7 @@ class CmdUpload(object):
     def _collects_refs_to_upload(self, package_id, reference_or_pattern, confirm):
         """ validate inputs and compute the refs (without revisions) to be uploaded
         """
-        if package_id and not check_valid_ref(reference_or_pattern):
+        if package_id and not check_valid_ref(reference_or_pattern, strict_mode=False):
             raise ConanException("-p parameter only allowed with a valid recipe reference, "
                                  "not with a pattern")
 

--- a/conans/test/functional/command/remove_test.py
+++ b/conans/test/functional/command/remove_test.py
@@ -17,7 +17,7 @@ from conans.server.store.server_store import ServerStore
 from conans.test.utils.cpp_test_files import cpp_hello_conan_files
 from conans.test.utils.test_files import temp_folder
 from conans.test.utils.tools import NO_SETTINGS_PACKAGE_ID, TestBufferConanOutput, TestClient, \
-    TestServer
+    TestServer, GenConanfile
 from conans.util.env_reader import get_env
 from conans.util.files import load
 
@@ -493,24 +493,14 @@ class RemoveWithoutUserChannel(unittest.TestCase):
         self.client = TestClient(servers=servers, users={"default": [("lasote", "password")]})
 
     def local_test(self):
-        conanfile = textwrap.dedent("""
-        from conans import ConanFile
-        class Test(ConanFile):
-            pass
-        """)
-        self.client.save({"conanfile.py": conanfile})
+        self.client.save({"conanfile.py": GenConanfile()})
         self.client.run("create . lib/1.0@")
         self.client.run("remove lib/1.0 -f")
         folder = self.client.cache.package_layout(ConanFileReference.loads("lib/1.0@")).export()
         self.assertFalse(os.path.exists(folder))
 
     def remote_test(self):
-        conanfile = textwrap.dedent("""
-        from conans import ConanFile
-        class Test(ConanFile):
-            pass
-        """)
-        self.client.save({"conanfile.py": conanfile})
+        self.client.save({"conanfile.py": GenConanfile()})
         self.client.run("create . lib/1.0@")
         self.client.run("upload lib/1.0 -r default -c --all")
         self.client.run("remove lib/1.0 -f")

--- a/conans/test/functional/command/upload_test.py
+++ b/conans/test/functional/command/upload_test.py
@@ -729,7 +729,6 @@ class Pkg(ConanFile):
 
         client.run('create . lib/1.0@')
         self.assertIn("lib/1.0: Package '{}' created".format(NO_SETTINGS_PACKAGE_ID), client.out)
-
         client.run('upload lib/1.0 -c --all')
         self.assertIn("Uploaded conan recipe 'lib/1.0' to 'default'", client.out)
 
@@ -740,3 +739,8 @@ class Pkg(ConanFile):
 
         path = server.server_store.package(pref)
         self.assertIn("/lib/1.0/_/_/0/package", path.replace("\\", "/"))
+
+        # Should be possible with explicit package
+        client.run('upload lib/1.0:5ab84d6acfe1f23c4fae0ab88f26e3a396351ac9')
+        self.assertIn("Uploading package 1/1: 5ab84d6acfe1f23c4fae0ab88f26e3a396351ac9 to 'default'",
+                      client.out)


### PR DESCRIPTION
Changelog: Fix: ``conan upload`` with a reference without user and channel and package id ``name/version:package_id`` should work
Docs: omit

Fix #5822

#tags: slow
