### PR TITLE
#5819 Show warning message for Python 3.4

### DIFF
--- a/conans/client/command.py
+++ b/conans/client/command.py
@@ -137,7 +137,7 @@ class Command(object):
         try:
             commands = self._commands()
             method = commands[args.command]
-            self._warn_python2()
+            self._warn_python_version()
             method(["--help"])
         except KeyError:
             raise ConanException("Unknown command '%s'" % args.command)
@@ -205,7 +205,7 @@ class Command(object):
                             help='Define URL of the repository to upload')
 
         args = parser.parse_args(*args)
-        self._warn_python2()
+        self._warn_python_version()
         self._conan.new(args.name, header=args.header, pure_c=args.pure_c, test=args.test,
                         exports_sources=args.sources, bare=args.bare,
                         visual_versions=args.ci_appveyor_win,
@@ -284,7 +284,7 @@ class Command(object):
 
         _add_common_install_arguments(parser, build_help=_help_build_policies)
         args = parser.parse_args(*args)
-        self._warn_python2()
+        self._warn_python_version()
         return self._conan.test(args.path, args.reference, args.profile, args.settings,
                                 args.options, args.env, args.remote, args.update,
                                 build_modes=args.build, test_build_folder=args.test_build_folder,
@@ -327,7 +327,7 @@ class Command(object):
         _add_common_install_arguments(parser, build_help=_help_build_policies)
 
         args = parser.parse_args(*args)
-        self._warn_python2()
+        self._warn_python_version()
 
         name, version, user, channel, _ = get_reference_fields(args.reference,
                                                                user_channel_input=True)
@@ -404,7 +404,7 @@ class Command(object):
                 raise ConanException("Use a full package reference (preferred) or the `--package`"
                                      " command argument, but not both.")
 
-        self._warn_python2()
+        self._warn_python_version()
         return self._conan.download(reference=reference, packages=packages_list,
                                     remote_name=args.remote, recipe=args.recipe)
 
@@ -717,7 +717,7 @@ class Command(object):
         except ConanException:
             pass
 
-        self._warn_python2()
+        self._warn_python_version()
         return self._conan.source(args.path, args.source_folder, args.install_folder)
 
     def build(self, *args):
@@ -761,7 +761,7 @@ class Command(object):
         parser.add_argument("-sf", "--source-folder", action=OnceArgument, help=_SOURCE_FOLDER_HELP)
         args = parser.parse_args(*args)
 
-        self._warn_python2()
+        self._warn_python_version()
 
         if args.build or args.configure or args.install or args.test:
             build, config, install, test = (bool(args.build), bool(args.configure),
@@ -816,7 +816,7 @@ class Command(object):
         except ConanException:
             pass
 
-        self._warn_python2()
+        self._warn_python_version()
         return self._conan.package(path=args.path,
                                    build_folder=args.build_folder,
                                    package_folder=args.package_folder,
@@ -856,7 +856,7 @@ class Command(object):
                                           "containing a conanfile.py or conanfile.txt file.")
         except ConanException:
             pass
-        self._warn_python2()
+        self._warn_python_version()
         return self._conan.imports(args.path, args.import_folder, args.install_folder)
 
     def export_pkg(self, *args):
@@ -907,7 +907,7 @@ class Command(object):
 
         args = parser.parse_args(*args)
 
-        self._warn_python2()
+        self._warn_python_version()
         name, version, user, channel, _ = get_reference_fields(args.reference,
                                                                user_channel_input=True)
         cwd = os.getcwd()
@@ -958,7 +958,7 @@ class Command(object):
                             "Lockfile will be updated with the exported package")
 
         args = parser.parse_args(*args)
-        self._warn_python2()
+        self._warn_python_version()
         name, version, user, channel, _ = get_reference_fields(args.reference,
                                                                user_channel_input=True)
 
@@ -1004,7 +1004,7 @@ class Command(object):
                             help='Remove system_reqs folders')
         args = parser.parse_args(*args)
 
-        self._warn_python2()
+        self._warn_python_version()
 
         if args.packages is not None and args.query:
             raise ConanException("'-q' and '-p' parameters can't be used at the same time")
@@ -1085,7 +1085,7 @@ class Command(object):
             if args.all:
                 raise ConanException("'--all' argument cannot be used together with full reference")
 
-        self._warn_python2()
+        self._warn_python_version()
 
         return self._conan.copy(reference=reference, user_channel=args.user_channel,
                                 force=args.force, packages=packages_list or args.all)
@@ -1355,7 +1355,7 @@ class Command(object):
             raise ConanException("'--skip-upload' argument cannot be used together "
                                  "with '--no-overwrite'")
 
-        self._warn_python2()
+        self._warn_python_version()
 
         if args.force:
             policy = UPLOAD_POLICY_FORCE
@@ -1637,7 +1637,7 @@ class Command(object):
         parser.add_argument('target', help='Target reference. e.g.: mylib/1.12@user/channel')
         args = parser.parse_args(*args)
 
-        self._warn_python2()
+        self._warn_python_version()
 
         self._conan.export_alias(args.reference, args.target)
 
@@ -1705,7 +1705,7 @@ class Command(object):
         subparsers.add_parser('list', help='List packages in editable mode')
 
         args = parser.parse_args(*args)
-        self._warn_python2()
+        self._warn_python_version()
 
         if args.subcommand == "add":
             self._conan.editable_add(args.path, args.reference, args.layout, cwd=os.getcwd())
@@ -1756,7 +1756,7 @@ class Command(object):
                                       lockfile=False)
 
         args = parser.parse_args(*args)
-        self._warn_python2()
+        self._warn_python_version()
 
         if args.subcommand == "update-lock":
             self._conan.update_lock(args.old_lockfile, args.new_lockfile)
@@ -1864,10 +1864,21 @@ class Command(object):
         if six.PY2:
             self._out.writeln("")
             self._out.writeln("Python 2 will soon be deprecated. It is strongly "
-                              "recommended to use Python 3 with Conan:", front=Color.BRIGHT_YELLOW)
+                              "recommended to use Python >= 3.5 with Conan:", front=Color.BRIGHT_YELLOW)
             self._out.writeln("https://docs.conan.io/en/latest/installation.html"
                               "#python-2-deprecation-notice", front=Color.BRIGHT_YELLOW)
             self._out.writeln("")
+
+    def _warn_python34(self):
+        if six.PY34:
+            self._out.writeln("")
+            self._out.writeln("Python 3.4 support has been dropped. It is strongly "
+                              "recommended to use Python >= 3.5 with Conan", front=Color.BRIGHT_YELLOW)
+            self._out.writeln("")
+
+    def _warn_python_version(self):
+        self._warn_python2()
+        self._warn_python34()
 
     def run(self, *args):
         """HIDDEN: entry point for executing commands, dispatcher to class
@@ -1884,7 +1895,7 @@ class Command(object):
                     self._out.success("Conan version %s" % client_version)
                     return False
 
-                self._warn_python2()
+                self._warn_python_version()
 
                 if command in ["-h", "--help"]:
                     self._show_help()

--- a/conans/test/functional/configuration/python_version_test.py
+++ b/conans/test/functional/configuration/python_version_test.py
@@ -15,8 +15,8 @@ class PythonVersionTest(unittest.TestCase):
 
     @unittest.skipUnless(six.PY2, "Requires Python 2.7")
     def test_py2_warning_message(self):
-        self._validate_message("Python 2 will soon be deprecated. " \
-                               " It is strongly recommended to use Python >= 3.5 with Conan")
+        self._validate_message("Python 2 will soon be deprecated. It is strongly " \
+                               "recommended to use Python >= 3.5 with Conan")
 
     @unittest.skipUnless(six.PY34, "Requires Python 3.4")
     def test_py34_warning_message(self):

--- a/conans/test/functional/configuration/python_version_test.py
+++ b/conans/test/functional/configuration/python_version_test.py
@@ -1,0 +1,24 @@
+import six
+import unittest
+
+from conans.test.utils.tools import TestClient
+
+
+class PythonVersionTest(unittest.TestCase):
+
+    def setUp(self):
+        self.client = TestClient()
+
+    def _validate_message(self, expected_message):
+        self.client.run("--help")
+        self.assertIn(expected_message, str(self.client.out))
+
+    @unittest.skipUnless(six.PY2, "Requires Python 2.7")
+    def test_py2_warning_message(self):
+        self._validate_message("Python 2 will soon be deprecated. " \
+                               " It is strongly recommended to use Python >= 3.5 with Conan")
+
+    @unittest.skipUnless(six.PY34, "Requires Python 3.4")
+    def test_py34_warning_message(self):
+        self._validate_message("Python 3.4 support has been dropped. It is strongly " \
+                               "recommended to use Python >= 3.5 with Conan")


### PR DESCRIPTION
- Add new warning message for python 3.4 which is no longer supported
- Added funcional tests to validate both python 3.4 and 2.x

Changelog: Feature: Show warning message for Python 3.4 
Docs: https://github.com/conan-io/docs/pull/1424

- [x] Refer to the issue that supports this Pull Request.
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 

<sup>**Note:** By default this PR will skip the slower tests and will use a limited set of python versions. Check [here](https://github.com/conan-io/conan/blob/develop/.github/PR_INCREASE_TESTING.md) how to increase the testing level by writing some tags in the current PR body text.</sup>
