### PR TITLE
refactor GraphBinariesAnalyzer

### DIFF
--- a/conans/client/graph/graph_binaries.py
+++ b/conans/client/graph/graph_binaries.py
@@ -19,7 +19,8 @@ class GraphBinariesAnalyzer(object):
         self._out = output
         self._remote_manager = remote_manager
 
-    def _check_update(self, upstream_manifest, package_folder, output, node):
+    @staticmethod
+    def _check_update(upstream_manifest, package_folder, output, node):
         read_manifest = FileTreeManifest.load(package_folder)
         if upstream_manifest != read_manifest:
             if upstream_manifest.time > read_manifest.time:
@@ -28,6 +29,125 @@ class GraphBinariesAnalyzer(object):
                 return True
             else:
                 output.warn("Current package is newer than remote upstream one")
+
+    @staticmethod
+    def _evaluate_build(node, build_mode):
+        ref, conanfile = node.ref, node.conanfile
+        with_deps_to_build = False
+        # For cascade mode, we need to check also the "modified" status of the lockfile if exists
+        # modified nodes have already been built, so they shouldn't be built again
+        if build_mode.cascade and not (node.graph_lock_node and node.graph_lock_node.modified):
+            for dep in node.dependencies:
+                dep_node = dep.dst
+                if (dep_node.binary == BINARY_BUILD or
+                        (dep_node.graph_lock_node and dep_node.graph_lock_node.modified)):
+                    with_deps_to_build = True
+                    break
+        if build_mode.forced(conanfile, ref, with_deps_to_build):
+            conanfile.output.info('Forced build from source')
+            node.binary = BINARY_BUILD
+            node.prev = None
+            return True
+
+    def _evaluate_clean_pkg_folder_dirty(self, node, package_layout, package_folder, pref):
+        # Check if dirty, to remove it
+        with package_layout.package_lock(pref):
+            assert node.recipe != RECIPE_EDITABLE, "Editable package shouldn't reach this code"
+            if is_dirty(package_folder):
+                node.conanfile.output.warn("Package is corrupted, removing folder: %s"
+                                           % package_folder)
+                rmdir(package_folder)  # Do not remove if it is EDITABLE
+                return
+
+            if self._cache.config.revisions_enabled:
+                metadata = package_layout.load_metadata()
+                rec_rev = metadata.packages[pref.id].recipe_revision
+                if rec_rev and rec_rev != node.ref.revision:
+                    node.conanfile.output.warn("The package {} doesn't belong to the installed "
+                                               "recipe revision, removing folder".format(pref))
+                    rmdir(package_folder)
+                return metadata
+
+    def _evaluate_cache_pkg(self, node, package_layout, pref, metadata, remote, remotes, update,
+                            package_folder):
+        if update:
+            output = node.conanfile.output
+            if remote:
+                try:
+                    tmp = self._remote_manager.get_package_manifest(pref, remote)
+                    upstream_manifest, pref = tmp
+                except NotFoundException:
+                    output.warn("Can't update, no package in remote")
+                except NoRemoteAvailable:
+                    output.warn("Can't update, no remote defined")
+                else:
+                    if self._check_update(upstream_manifest, package_folder, output, node):
+                        node.binary = BINARY_UPDATE
+                        node.prev = pref.revision  # With revision
+            elif remotes:
+                pass  # Current behavior: no remote explicit or in metadata, do not update
+            else:
+                output.warn("Can't update, no remote defined")
+        if not node.binary:
+            node.binary = BINARY_CACHE
+            metadata = metadata or package_layout.load_metadata()
+            node.prev = metadata.packages[pref.id].revision
+            assert node.prev, "PREV for %s is None: %s" % (str(pref), metadata.dumps())
+
+    def _evaluate_remote_pkg(self, node, pref, remote, remotes, build_mode):
+        remote_info = None
+        if remote:
+            try:
+                remote_info, pref = self._remote_manager.get_package_info(pref, remote)
+            except NotFoundException:
+                pass
+            except Exception:
+                node.conanfile.output.error("Error downloading binary package: '{}'".format(pref))
+                raise
+
+        # If the "remote" came from the registry but the user didn't specified the -r, with
+        # revisions iterate all remotes
+        if not remote or (not remote_info and self._cache.config.revisions_enabled):
+            for r in remotes.values():
+                try:
+                    remote_info, pref = self._remote_manager.get_package_info(pref, r)
+                except NotFoundException:
+                    pass
+                else:
+                    if remote_info:
+                        remote = r
+                        break
+
+        if remote_info:
+            node.binary = BINARY_DOWNLOAD
+            node.prev = pref.revision
+            recipe_hash = remote_info.recipe_hash
+        else:
+            recipe_hash = None
+            if build_mode.allowed(node.conanfile):
+                node.binary = BINARY_BUILD
+            else:
+                node.binary = BINARY_MISSING
+            node.prev = None
+
+        return recipe_hash, remote
+
+    @staticmethod
+    def _evaluate_is_cached(node, pref, evaluated_nodes):
+        previous_nodes = evaluated_nodes.get(pref)
+        if previous_nodes:
+            previous_nodes.append(node)
+            previous_node = previous_nodes[0]
+            # The previous node might have been skipped, but current one not necessarily
+            # keep the original node.binary value (before being skipped), and if it will be
+            # defined as SKIP again by self._handle_private(node) if it is really private
+            if previous_node.binary == BINARY_SKIP:
+                node.binary = previous_node.binary_non_skip
+            else:
+                node.binary = previous_node.binary
+            node.binary_remote = previous_node.binary_remote
+            node.prev = previous_node.prev
+            return True
 
     def _evaluate_node(self, node, build_mode, update, evaluated_nodes, remotes):
         assert node.binary is None, "Node.binary should be None"
@@ -48,145 +168,52 @@ class GraphBinariesAnalyzer(object):
             pref = PackageReference(ref, node.package_id)
 
         # Check that this same reference hasn't already been checked
-        previous_nodes = evaluated_nodes.get(pref)
-        if previous_nodes:
-            previous_nodes.append(node)
-            previous_node = previous_nodes[0]
-            # The previous node might have been skipped, but current one not necessarily
-            # keep the original node.binary value (before being skipped), and if it will be
-            # defined as SKIP again by self._handle_private(node) if it is really private
-            if previous_node.binary == BINARY_SKIP:
-                node.binary = previous_node.binary_non_skip
-            else:
-                node.binary = previous_node.binary
-            node.binary_remote = previous_node.binary_remote
-            node.prev = previous_node.prev
+        if self._evaluate_is_cached(node, pref, evaluated_nodes):
             return
         evaluated_nodes[pref] = [node]
 
-        output = conanfile.output
-
         if node.recipe == RECIPE_EDITABLE:
-            node.binary = BINARY_EDITABLE
-            # TODO: PREV?
+            node.binary = BINARY_EDITABLE  # TODO: PREV?
             return
 
-        with_deps_to_build = False
-        # For cascade mode, we need to check also the "modified" status of the lockfile if exists
-        # modified nodes have already been built, so they shouldn't be built again
-        if build_mode.cascade and not (node.graph_lock_node and node.graph_lock_node.modified):
-            for dep in node.dependencies:
-                dep_node = dep.dst
-                if (dep_node.binary == BINARY_BUILD or
-                        (dep_node.graph_lock_node and dep_node.graph_lock_node.modified)):
-                    with_deps_to_build = True
-                    break
-        if build_mode.forced(conanfile, ref, with_deps_to_build):
-            output.info('Forced build from source')
-            node.binary = BINARY_BUILD
-            node.prev = None
+        if self._evaluate_build(node, build_mode):
             return
 
-        package_folder = self._cache.package_layout(pref.ref,
-                                                    short_paths=conanfile.short_paths).package(pref)
-
-        # Check if dirty, to remove it
-        with self._cache.package_layout(pref.ref).package_lock(pref):
-            assert node.recipe != RECIPE_EDITABLE, "Editable package shouldn't reach this code"
-            if is_dirty(package_folder):
-                output.warn("Package is corrupted, removing folder: %s" % package_folder)
-                rmdir(package_folder)  # Do not remove if it is EDITABLE
-
-            if self._cache.config.revisions_enabled:
-                metadata = self._cache.package_layout(pref.ref).load_metadata()
-                rec_rev = metadata.packages[pref.id].recipe_revision
-                if rec_rev and rec_rev != node.ref.revision:
-                    output.warn("The package {} doesn't belong "
-                                "to the installed recipe revision, removing folder".format(pref))
-                    rmdir(package_folder)
+        package_layout = self._cache.package_layout(pref.ref, short_paths=conanfile.short_paths)
+        package_folder = package_layout.package(pref)
+        metadata = self._evaluate_clean_pkg_folder_dirty(node, package_layout, package_folder, pref)
 
         remote = remotes.selected
         if not remote:
-            # If the remote_name is not given, follow the binary remote, or
-            # the recipe remote
+            # If the remote_name is not given, follow the binary remote, or the recipe remote
             # If it is defined it won't iterate (might change in conan2.0)
-            metadata = self._cache.package_layout(pref.ref).load_metadata()
+            metadata = metadata or package_layout.load_metadata()
             remote_name = metadata.packages[pref.id].remote or metadata.recipe.remote
             remote = remotes.get(remote_name)
 
-        if os.path.exists(package_folder):
-            if update:
-                if remote:
-                    try:
-                        tmp = self._remote_manager.get_package_manifest(pref, remote)
-                        upstream_manifest, pref = tmp
-                    except NotFoundException:
-                        output.warn("Can't update, no package in remote")
-                    except NoRemoteAvailable:
-                        output.warn("Can't update, no remote defined")
-                    else:
-                        if self._check_update(upstream_manifest, package_folder, output, node):
-                            node.binary = BINARY_UPDATE
-                            node.prev = pref.revision  # With revision
-                            if build_mode.outdated:
-                                info, pref = self._remote_manager.get_package_info(pref, remote)
-                                package_hash = info.recipe_hash
-                elif remotes:
-                    pass
-                else:
-                    output.warn("Can't update, no remote defined")
-            if not node.binary:
-                node.binary = BINARY_CACHE
-                metadata = self._cache.package_layout(pref.ref).load_metadata()
-                node.prev = metadata.packages[pref.id].revision
-                assert node.prev, "PREV for %s is None: %s" % (str(pref), metadata.dumps())
-                package_hash = ConanInfo.load_from_package(package_folder).recipe_hash
-
+        if os.path.exists(package_folder):  # Binary already in cache, check for updates
+            self._evaluate_cache_pkg(node, package_layout, pref, metadata,  remote, remotes, update,
+                                     package_folder)
+            recipe_hash = None
         else:  # Binary does NOT exist locally
-            remote_info = None
-            if remote:
-                try:
-                    remote_info, pref = self._remote_manager.get_package_info(pref, remote)
-                except NotFoundException:
-                    pass
-                except Exception:
-                    conanfile.output.error("Error downloading binary package: '{}'".format(pref))
-                    raise
-
-            # If the "remote" came from the registry but the user didn't specified the -r, with
-            # revisions iterate all remotes
-
-            if not remote or (not remote_info and self._cache.config.revisions_enabled):
-                for r in remotes.values():
-                    try:
-                        remote_info, pref = self._remote_manager.get_package_info(pref, r)
-                    except NotFoundException:
-                        pass
-                    else:
-                        if remote_info:
-                            remote = r
-                            break
-
-            if remote_info:
-                node.binary = BINARY_DOWNLOAD
-                node.prev = pref.revision
-                package_hash = remote_info.recipe_hash
-            else:
-                if build_mode.allowed(conanfile):
-                    node.binary = BINARY_BUILD
-                else:
-                    node.binary = BINARY_MISSING
-                node.prev = None
+            # Returned remote might be different than the passed one if iterating remotes
+            recipe_hash, remote = self._evaluate_remote_pkg(node, pref, remote, remotes, build_mode)
 
         if build_mode.outdated:
             if node.binary in (BINARY_CACHE, BINARY_DOWNLOAD, BINARY_UPDATE):
-                local_recipe_hash = self._cache.package_layout(ref).recipe_manifest().summary_hash
-                if local_recipe_hash != package_hash:
-                    output.info("Outdated package!")
+                if node.binary == BINARY_UPDATE:
+                    info, pref = self._remote_manager.get_package_info(pref, remote)
+                    recipe_hash = info.recipe_hash
+                elif node.binary == BINARY_CACHE:
+                    recipe_hash = ConanInfo.load_from_package(package_folder).recipe_hash
+
+                local_recipe_hash = package_layout.recipe_manifest().summary_hash
+                if local_recipe_hash != recipe_hash:
+                    conanfile.output.info("Outdated package!")
                     node.binary = BINARY_BUILD
                     node.prev = None
                 else:
-                    output.info("Package is up to date")
+                    conanfile.output.info("Package is up to date")
 
         node.binary_remote = remote
 


### PR DESCRIPTION
Changelog: Omit
Docs: Omit

This is a pure refactor, breaking a very large function into smaller pieces. It might be also slightly faster:
- Re-using package layout objects
- Re-using metatada
- Avoiding reading manifest files if not needed.

#tags: slow
