### PR TITLE
Use reference with recipe revision for build order

### DIFF
--- a/conans/client/graph/graph.py
+++ b/conans/client/graph/graph.py
@@ -284,7 +284,7 @@ class DepsGraph(object):
             new_level = []
             for n in level:
                 if n.binary == BINARY_BUILD and n.pref not in total_prefs:
-                    new_level.append((n.id, n.pref.copy_with_revs(n.pref.ref.revision, None)))
+                    new_level.append((n.id, n.pref.copy_clear_rev()))
                     total_prefs.add(n.pref)
             if new_level:
                 result.append(new_level)

--- a/conans/client/graph/graph.py
+++ b/conans/client/graph/graph.py
@@ -284,7 +284,7 @@ class DepsGraph(object):
             new_level = []
             for n in level:
                 if n.binary == BINARY_BUILD and n.pref not in total_prefs:
-                    new_level.append((n.id, n.pref.copy_clear_rev()))
+                    new_level.append((n.id, n.pref.copy_with_revs(n.pref.ref.revision, None)))
                     total_prefs.add(n.pref)
             if new_level:
                 result.append(new_level)

--- a/conans/client/graph/graph.py
+++ b/conans/client/graph/graph.py
@@ -284,7 +284,7 @@ class DepsGraph(object):
             new_level = []
             for n in level:
                 if n.binary == BINARY_BUILD and n.pref not in total_prefs:
-                    new_level.append((n.id, n.pref.copy_clear_rev()))
+                    new_level.append((n.id, n.pref.copy_clear_prev()))
                     total_prefs.add(n.pref)
             if new_level:
                 result.append(new_level)

--- a/conans/client/rest/client_routes.py
+++ b/conans/client/rest/client_routes.py
@@ -87,7 +87,7 @@ class ClientV1Router(ClientCommonRouter):
 
     def package_snapshot(self, pref):
         """get recipe manifest url"""
-        return self.base_url + self._for_package(pref.copy_clear_rev())
+        return self.base_url + self._for_package(pref.copy_clear_revs())
 
     def recipe_manifest(self, ref):
         """get recipe manifest url"""
@@ -95,7 +95,7 @@ class ClientV1Router(ClientCommonRouter):
 
     def package_manifest(self, pref):
         """get manifest url"""
-        return self.base_url + _format_pref(routes.v1_package_digest, pref.copy_clear_rev())
+        return self.base_url + _format_pref(routes.v1_package_digest, pref.copy_clear_revs())
 
     def recipe_download_urls(self, ref):
         """ urls to download the recipe"""

--- a/conans/model/ref.py
+++ b/conans/model/ref.py
@@ -290,8 +290,7 @@ class PackageReference(namedtuple("PackageReference", "ref id revision")):
         return PackageReference(self.ref.copy_with_rev(revision), self.id, p_revision)
 
     def copy_clear_rev(self):
-        ref = self.ref.copy_clear_rev()
-        return PackageReference(ref, self.id, revision=None)
+        return self.copy_with_revs(self.ref.revision, None)
 
     def copy_clear_revs(self):
         return self.copy_with_revs(None, None)

--- a/conans/model/ref.py
+++ b/conans/model/ref.py
@@ -289,7 +289,7 @@ class PackageReference(namedtuple("PackageReference", "ref id revision")):
     def copy_with_revs(self, revision, p_revision):
         return PackageReference(self.ref.copy_with_rev(revision), self.id, p_revision)
 
-    def copy_clear_rev(self):
+    def copy_clear_prev(self):
         return self.copy_with_revs(self.ref.revision, None)
 
     def copy_clear_revs(self):

--- a/conans/test/functional/graph_lock/graph_lock_ci_test.py
+++ b/conans/test/functional/graph_lock/graph_lock_ci_test.py
@@ -441,6 +441,8 @@ class GraphLockCITest(unittest.TestCase):
         while to_build:
             _, pkg_ref = to_build[0].pop(0)
             pkg_ref = PackageReference.loads(pkg_ref)
+            self.assertIsNotNone(pkg_ref.ref.revision)
+            self.assertIsNone(pkg_ref.revision)
             client_aux = TestClient(cache_folder=client.cache_folder)
             client_aux.run("config set general.default_package_id_mode=full_package_mode")
             client_aux.save({LOCKFILE: lock_fileaux})

--- a/conans/test/integration/revisions_test.py
+++ b/conans/test/integration/revisions_test.py
@@ -1485,12 +1485,12 @@ class ServerRevisionsIndexes(unittest.TestCase):
         self.assertEqual(pref2.ref.revision, pref3.ref.revision)
         self.assertEqual(pref3.ref.revision, server_pref3.revision)
 
-        pref = pref1.copy_clear_rev().copy_with_revs(pref1.ref.revision, None)
+        pref = pref1.copy_clear_prev().copy_with_revs(pref1.ref.revision, None)
         revs = [r.revision
                 for r in self.server.server_store.get_package_revisions(pref)]
         self.assertEqual(revs, [pref3.revision, pref2.revision, pref1.revision])
         self.assertEqual(self.server.server_store.get_last_package_revision(pref).revision,
-                          pref3.revision)
+                         pref3.revision)
 
         # Delete the latest from the server
         self.c_v2.run("remove {} -p {}#{} -r default -f".format(pref3.ref.full_str(),
@@ -1552,7 +1552,7 @@ class ServerRevisionsIndexes(unittest.TestCase):
             pref4 = self.c_v2.create(self.ref, conanfile=conanfile)
         self.c_v2.upload_all(self.ref)
 
-        pref = pref1.copy_clear_rev().copy_with_revs(pref1.ref.revision, None)
+        pref = pref1.copy_clear_prev().copy_with_revs(pref1.ref.revision, None)
         revs = [r.revision
                 for r in self.server.server_store.get_package_revisions(pref)]
         self.assertEqual(revs, [pref4.revision])

--- a/conans/test/integration/revisions_test.py
+++ b/conans/test/integration/revisions_test.py
@@ -424,10 +424,10 @@ class RevisionsInLocalCacheTest(unittest.TestCase):
         msg = "Removing the local binary packages from different recipe revisions"
         if v1:
             self.assertNotIn(msg, client.out)
-            self.assertTrue(client.package_exists(pref_outdated.copy_clear_rev()))
+            self.assertTrue(client.package_exists(pref_outdated.copy_clear_revs()))
         else:
             self.assertIn(msg, client.out)
-            self.assertFalse(client.package_exists(pref_outdated.copy_clear_rev()))
+            self.assertFalse(client.package_exists(pref_outdated.copy_clear_revs()))
 
         self.assertTrue(client.package_exists(pref_ok))
 
@@ -492,18 +492,18 @@ class RemoveWithRevisionsTest(unittest.TestCase):
         layout = self.c_v1.cache.package_layout(pref.ref.copy_clear_rev())
 
         # Assert pref (outdated) is in the cache
-        self.assertTrue(layout.package_exists(pref.copy_clear_rev()))
+        self.assertTrue(layout.package_exists(pref.copy_clear_revs()))
 
         # Assert pref2 is also in the cache
-        self.assertTrue(layout.package_exists(pref2.copy_clear_rev()))
+        self.assertTrue(layout.package_exists(pref2.copy_clear_revs()))
 
         self.c_v1.run("remove {} --outdated -f".format(pref.ref))
 
         # Assert pref (outdated) is not in the cache anymore
-        self.assertFalse(layout.package_exists(pref.copy_clear_rev()))
+        self.assertFalse(layout.package_exists(pref.copy_clear_revs()))
 
         # Assert pref2 is in the cache
-        self.assertTrue(layout.package_exists(pref2.copy_clear_rev()))
+        self.assertTrue(layout.package_exists(pref2.copy_clear_revs()))
 
     @parameterized.expand([(True,), (False,)])
     def test_remove_oudated_packages_remote(self, v1):


### PR DESCRIPTION
Changelog: Bugfix: Fix `conan graph build-order` output so it uses references including its recipe revision
Docs: omit

#REVISIONS: 1

- [x] Refer to the issue that supports this Pull Request: Coming from the investigation done in https://github.com/conan-io/examples/pull/35
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [x] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 

If this fix is right, then https://github.com/conan-io/examples/pull/35 should be closed

<sup>**Note:** By default this PR will skip the slower tests and will use a limited set of python versions. Check [here](https://github.com/conan-io/conan/blob/develop/.github/PR_INCREASE_TESTING.md) how to increase the testing level by writing some tags in the current PR body text.</sup>
