### PR TITLE
python-requires extending skipping name-version

### DIFF
--- a/conans/client/loader.py
+++ b/conans/client/loader.py
@@ -67,23 +67,20 @@ class ConanFileLoader(object):
         conanfile = self.load_class(conanfile_path, lock_python_requires)
 
         # Export does a check on existing name & version
-        if "name" in conanfile.__dict__:
-            if name and name != conanfile.name:
-                raise ConanException("Package recipe exported with name %s!=%s"
-                                     % (name, conanfile.name))
-        elif not name:
-            raise ConanException("conanfile didn't specify name")
-        else:
+        if name and conanfile.name and name != conanfile.name:
+            raise ConanException("Package recipe exported with name %s!=%s" % (name, conanfile.name))
+        if name:
             conanfile.name = name
-
-        if "version" in conanfile.__dict__:
-            if version and version != conanfile.version:
-                raise ConanException("Package recipe exported with version %s!=%s"
-                                     % (version, conanfile.version))
-        elif not version:
-            raise ConanException("conanfile didn't specify version")
-        else:
+        if version and conanfile.version and version != conanfile.version:
+            raise ConanException("Package recipe exported with version %s!=%s"
+                                 % (version, conanfile.version))
+        if version:
             conanfile.version = version
+
+        if not conanfile.name:
+            raise ConanException("conanfile didn't specify name")
+        if not conanfile.version:
+            raise ConanException("conanfile didn't specify version")
         ref = ConanFileReference(conanfile.name, conanfile.version, user, channel)
         return conanfile(self._output, self._runner, str(ref), ref.user, ref.channel)
 


### PR DESCRIPTION
Changelog: (Feature | Fix | Bugfix): Describe here your pull request
Docs: https://github.com/conan-io/docs/pull/XXXX

To discuss with @lasote.

This is also derivative of the work in python-requires.

- It is not documented that the name and version are not inherited from python-requires classes
- There are no tests validating that name and version are not inherited
- The example have name and version with a weird name saying it will not be inherited.

I'd suggest:
- Remove the custom code to skip inherit name and version. The way to avoid inheriting it is already well defined and documented, do not inherit from the package recipe. The new python-requires will further simplify this.
- The code of ``loader.load_export`` and ``loader.load_consumer`` will become more similar, could be factorized (in a later stage)
- It might be breaking for some weird, badly formed corner cases. Python-requires are still experimental, so to consider if we can start cleaning this.


