### PR TITLE
optional management of package-id for shared libraries

### DIFF
--- a/conans/model/info.py
+++ b/conans/model/info.py
@@ -475,3 +475,10 @@ class ConanInfo(object):
 
         if self.full_settings.compiler.cppstd:
             self.settings.compiler.cppstd = self.full_settings.compiler.cppstd
+
+    def shared_library_package_id(self):
+        if self.full_options.shared:
+            for dep_name in self.requires.pkg_names:
+                dep_options = self.full_options[dep_name]
+                if "shared" not in dep_options or not self.full_options[dep_name].shared:
+                    self.requires[dep_name].package_revision_mode()

--- a/conans/model/options.py
+++ b/conans/model/options.py
@@ -63,6 +63,9 @@ class PackageOptionValues(object):
     def __bool__(self):
         return bool(self._dict)
 
+    def __contains__(self, key):
+        return key in self._dict
+
     def __nonzero__(self):
         return self.__bool__()
 


### PR DESCRIPTION
Changelog: Feature: Implement ``self.info.shared_library_package_id()`` to better manage shared libraries package-ID, specially when they depend on static libraries
Docs: https://github.com/conan-io/docs/pull/1442



#tags: slow
