### PR TITLE
Feature: allow to specify encoding for load, save, replace_in_files

### DIFF
--- a/conans/client/tools/files.py
+++ b/conans/client/tools/files.py
@@ -247,28 +247,30 @@ def _manage_text_not_found(search, file_path, strict, function_name, output):
         return False
 
 
-def replace_in_file(file_path, search, replace, strict=True, output=None):
+def replace_in_file(file_path, search, replace, strict=True, output=None, encoding_in="auto",
+                    encoding_out="utf-8"):
     output = default_output(output, 'conans.client.tools.files.replace_in_file')
 
-    content = load(file_path)
+    content = load(file_path, encoding=encoding_in)
     if -1 == content.find(search):
         _manage_text_not_found(search, file_path, strict, "replace_in_file", output=output)
     content = content.replace(search, replace)
-    content = content.encode("utf-8")
-    with open(file_path, "wb") as handle:
-        handle.write(content)
+    content = content.encode(encoding_out)
+    save(file_path, content, only_if_modified=False, encoding=encoding_out)
 
 
-def replace_path_in_file(file_path, search, replace, strict=True, windows_paths=None, output=None):
+def replace_path_in_file(file_path, search, replace, strict=True, windows_paths=None, output=None,
+                         encoding_in="auto", encoding_out="utf-8"):
     output = default_output(output, 'conans.client.tools.files.replace_path_in_file')
 
     if windows_paths is False or (windows_paths is None and platform.system() != "Windows"):
-        return replace_in_file(file_path, search, replace, strict=strict, output=output)
+        return replace_in_file(file_path, search, replace, strict=strict, output=output,
+                               encoding_in=encoding_in, encoding_out=encoding_out)
 
     def normalized_text(text):
         return text.replace("\\", "/").lower()
 
-    content = load(file_path)
+    content = load(file_path, encoding=encoding_in)
     normalized_content = normalized_text(content)
     normalized_search = normalized_text(search)
     index = normalized_content.find(normalized_search)
@@ -281,9 +283,8 @@ def replace_path_in_file(file_path, search, replace, strict=True, windows_paths=
         normalized_content = normalized_text(content)
         index = normalized_content.find(normalized_search)
 
-    content = content.encode("utf-8")
-    with open(file_path, "wb") as handle:
-        handle.write(content)
+    content = content.encode(encoding_out)
+    save(file_path, content, only_if_modified=False, encoding=encoding_out)
 
     return True
 

--- a/conans/client/tools/files.py
+++ b/conans/client/tools/files.py
@@ -247,10 +247,11 @@ def _manage_text_not_found(search, file_path, strict, function_name, output):
         return False
 
 
-def replace_in_file(file_path, search, replace, strict=True, output=None, encoding_in="auto",
-                    encoding_out="utf-8"):
+def replace_in_file(file_path, search, replace, strict=True, output=None, encoding=None):
     output = default_output(output, 'conans.client.tools.files.replace_in_file')
 
+    encoding_in = encoding or "auto"
+    encoding_out = encoding or "utf-8"
     content = load(file_path, encoding=encoding_in)
     if -1 == content.find(search):
         _manage_text_not_found(search, file_path, strict, "replace_in_file", output=output)
@@ -260,16 +261,18 @@ def replace_in_file(file_path, search, replace, strict=True, output=None, encodi
 
 
 def replace_path_in_file(file_path, search, replace, strict=True, windows_paths=None, output=None,
-                         encoding_in="auto", encoding_out="utf-8"):
+                         encoding=None):
     output = default_output(output, 'conans.client.tools.files.replace_path_in_file')
 
     if windows_paths is False or (windows_paths is None and platform.system() != "Windows"):
         return replace_in_file(file_path, search, replace, strict=strict, output=output,
-                               encoding_in=encoding_in, encoding_out=encoding_out)
+                               encoding=encoding)
 
     def normalized_text(text):
         return text.replace("\\", "/").lower()
 
+    encoding_in = encoding or "auto"
+    encoding_out = encoding or "utf-8"
     content = load(file_path, encoding=encoding_in)
     normalized_content = normalized_text(content)
     normalized_search = normalized_text(search)

--- a/conans/test/unittests/client/util/files/decode_text_test.py
+++ b/conans/test/unittests/client/util/files/decode_text_test.py
@@ -20,5 +20,14 @@ class DecodeTextTest(unittest.TestCase):
                            (b'\x2b\x2f\x76\x2B\x41',),
                            (b'\x2b\x2f\x76\x2F\x41',),
                            (b'\x2b\x2f\x76\x38\x2d\x41',)])
-    def test_encodings(self, text):
+    def test_audo_encodings(self, text):
         self.assertEqual('A', decode_text(text))
+
+    @parameterized.expand([(b'\x41', "utf_8_sig"),
+                           (b'\x00\x41', "utf_16_be"),
+                           (b'\x41\x00', "utf_16_le"),
+                           (b'\x00\x00\x00\x41', "utf_32_be"),
+                           (b'\x41\x00\x00\x00', "utf_32_le"),
+                           (b'\x41', "utf_7")])
+    def test_explicit_encodings(self, text, encoding):
+        self.assertEqual('A', decode_text(text, encoding))

--- a/conans/util/files.py
+++ b/conans/util/files.py
@@ -64,7 +64,7 @@ def set_dirty_context_manager(folder):
     clean_dirty(folder)
 
 
-def decode_text(text):
+def _detect_encoding(text):
     import codecs
     encodings = {codecs.BOM_UTF8: "utf_8_sig",
                  codecs.BOM_UTF16_BE: "utf_16_be",
@@ -79,17 +79,28 @@ def decode_text(text):
     for bom in sorted(encodings, key=len, reverse=True):
         if text.startswith(bom):
             try:
-                return text[len(bom):].decode(encodings[bom])
+                return encodings[bom], len(bom)
             except UnicodeDecodeError:
                 continue
     decoders = ["utf-8", "Windows-1252"]
     for decoder in decoders:
         try:
-            return text.decode(decoder)
+            text.decode(decoder)
+            return decoder, 0
         except UnicodeDecodeError:
             continue
-    logger.warning("can't decode %s" % str(text))
-    return text.decode("utf-8", "ignore")  # Ignore not compatible characters
+    return None, 0
+
+
+def decode_text(text, encoding="auto"):
+    bom_length = 0
+    if encoding == "auto":
+        encoding, bom_length = _detect_encoding(text)
+    if encoding:
+        return text[bom_length:].decode(encoding)
+    else:
+        logger.warning("can't decode %s" % str(text))
+        return text.decode("utf-8", "ignore")  # Ignore not compatible characters
 
 
 def touch(fname, times=None):
@@ -146,33 +157,34 @@ def _generic_algorithm_sum(file_path, algorithm_name):
         return m.hexdigest()
 
 
-def save_append(path, content):
+def save_append(path, content, encoding="utf-8"):
     try:
         os.makedirs(os.path.dirname(path))
     except Exception:
         pass
 
     with open(path, "ab") as handle:
-        handle.write(to_file_bytes(content))
+        handle.write(to_file_bytes(content, encoding=encoding))
 
 
-def save(path, content, only_if_modified=False):
+def save(path, content, only_if_modified=False, encoding="utf-8"):
     """
     Saves a file with given content
     Params:
         path: path to write file to
         content: contents to save in the file
         only_if_modified: file won't be modified if the content hasn't changed
+        encoding: target file text encoding
     """
     try:
         os.makedirs(os.path.dirname(path))
     except Exception:
         pass
 
-    new_content = to_file_bytes(content)
+    new_content = to_file_bytes(content, encoding)
 
     if only_if_modified and os.path.exists(path):
-        old_content = load(path, binary=True)
+        old_content = load(path, binary=True, encoding=encoding)
         if old_content == new_content:
             return
 
@@ -184,25 +196,25 @@ def mkdir_tmp():
     return tempfile.mkdtemp(suffix='tmp_conan')
 
 
-def to_file_bytes(content):
+def to_file_bytes(content, encoding="utf-8"):
     if six.PY3:
         if not isinstance(content, bytes):
-            content = bytes(content, "utf-8")
+            content = bytes(content, encoding)
     elif isinstance(content, unicode):
-        content = content.encode("utf-8")
+        content = content.encode(encoding)
     return content
 
 
-def save_files(path, files, only_if_modified=False):
+def save_files(path, files, only_if_modified=False, encoding="utf-8"):
     for name, content in list(files.items()):
-        save(os.path.join(path, name), content, only_if_modified=only_if_modified)
+        save(os.path.join(path, name), content, only_if_modified=only_if_modified, encoding=encoding)
 
 
-def load(path, binary=False):
+def load(path, binary=False, encoding="auto"):
     """ Loads a file content """
     with open(path, 'rb') as handle:
         tmp = handle.read()
-        return tmp if binary else decode_text(tmp)
+        return tmp if binary else decode_text(tmp, encoding)
 
 
 def relative_dirs(path):

--- a/conans/util/files.py
+++ b/conans/util/files.py
@@ -96,11 +96,10 @@ def decode_text(text, encoding="auto"):
     bom_length = 0
     if encoding == "auto":
         encoding, bom_length = _detect_encoding(text)
-    if encoding:
-        return text[bom_length:].decode(encoding)
-    else:
-        logger.warning("can't decode %s" % str(text))
-        return text.decode("utf-8", "ignore")  # Ignore not compatible characters
+        if encoding is None:
+            logger.warning("can't decode %s" % str(text))
+            return text.decode("utf-8", "ignore")  # Ignore not compatible characters
+    return text[bom_length:].decode(encoding)
 
 
 def touch(fname, times=None):


### PR DESCRIPTION
closes: #5840 
Changelog: Feature: Allow to specify encoding for `tools.load`, `tools.save` and `tools.replace_in_files`
Docs: https://github.com/conan-io/docs/pull/1446

add encoding argument to the:

- `tools.load`
- `tools.save`
- `tools.save_append`
- `tools.save_files`
- `tools.replace_in_file`
- `tools.replace_path_in_file`
- `tools.to_file_bytes`

the `auto` encoding is for auto-detect

Q: Should I touch `replace_prefix_in_pc_file` and `dos2unix`/`unix2dos` as well?

- [x] Refer to the issue that supports this Pull Request.
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [x] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 

<sup>**Note:** By default this PR will skip the slower tests and will use a limited set of python versions. Check [here](https://github.com/conan-io/conan/blob/develop/.github/PR_INCREASE_TESTING.md) how to increase the testing level by writing some tags in the current PR body text.</sup>
