### PR TITLE
Requirement override using build metadata

### DIFF
--- a/conans/model/requires.py
+++ b/conans/model/requires.py
@@ -146,7 +146,6 @@ class Requirements(OrderedDict):
 
                     output.warn(msg)
                     req.ref = other_ref
-
             new_reqs[name] = req
         return new_reqs
 

--- a/conans/model/version.py
+++ b/conans/model/version.py
@@ -143,7 +143,12 @@ class Version(str):
         equals = all(get_el(other.as_list, ind) == get_el(self.as_list, ind)
                      for ind in range(0, max(len(other.as_list), len(self.as_list))))
         if equals:
-            return 0
+            if self.build == other.build:
+                return 0
+            if self.build > other.build:
+                return -1
+            else:
+                return 1
 
         # Check greater than or less than
         other_list = other.as_list

--- a/conans/test/functional/command/create_test.py
+++ b/conans/test/functional/command/create_test.py
@@ -6,7 +6,7 @@ from parameterized.parameterized import parameterized
 
 from conans.client import tools
 from conans.model.ref import ConanFileReference, PackageReference
-from conans.test.utils.tools import TestClient, NO_SETTINGS_PACKAGE_ID
+from conans.test.utils.tools import TestClient, NO_SETTINGS_PACKAGE_ID, GenConanfile
 from conans.util.files import load
 
 
@@ -37,6 +37,30 @@ PkgA/0.1@user/testing"""
         self.assertIn("[libs];LibB;LibA", txt)
         cmake = client.load("conanbuildinfo.cmake")
         self.assertIn("set(CONAN_LIBS LibB LibA ${CONAN_LIBS})", cmake)
+
+    def can_override_even_versions_with_build_metadata_test(self):
+        # https://github.com/conan-io/conan/issues/5900
+
+        client = TestClient()
+        client.save({"conanfile.py":
+                    GenConanfile().with_name("libcore").with_version("1.0+abc")})
+        client.run("create .")
+        client.save({"conanfile.py":
+                    GenConanfile().with_name("libcore").with_version("1.0+xyz")})
+        client.run("create .")
+
+        client.save({"conanfile.py":
+                    GenConanfile().with_name("intermediate").
+                    with_version("1.0").with_require_plain("libcore/1.0+abc")})
+        client.run("create .")
+
+        client.save({"conanfile.py":
+                    GenConanfile().with_name("consumer").
+                    with_version("1.0").with_require_plain("intermediate/1.0").
+                    with_require_plain("libcore/1.0+xyz")})
+        client.run("create .")
+        self.assertIn("WARN: intermediate/1.0: requirement libcore/1.0+abc "
+                      "overridden by consumer/1.0 to libcore/1.0+xyz", client.out)
 
     def transitive_same_name_test(self):
         # https://github.com/conan-io/conan/issues/1366

--- a/conans/test/unittests/model/version_test.py
+++ b/conans/test/unittests/model/version_test.py
@@ -55,6 +55,14 @@ class VersionTest(unittest.TestCase):
         self.assertFalse(Version("4.0.0.1") == "4")
         self.assertTrue(Version("4.0.0.1") >= "4")
 
+    def test_build_metadata_is_not_equal(self):
+        # https://github.com/conan-io/conan/issues/5900
+        self.assertNotEqual(Version("4.0.0+abc"), Version("4.0.0+xyz"))
+        # Shouldn't be an "official" order for build metadata, but as they cannot be equal
+        # the order is alphabetic
+        self.assertTrue(Version("4.0.0+abc") > Version("4.0.0+xyz"))
+        self.assertTrue(Version("4.0.0+xyz") < Version("4.0.0+abc"))
+
     def text_test(self):
         v1 = Version("master+build2")
         self.assertEqual(v1.major(), "master")


### PR DESCRIPTION
Changelog: Bugfix: The dependency overriding mechanism was not working properly when using the same version with different build metadata (`1.2.0+xyz` vs `1.2.0+abc`). 
Docs: omit

Closes #5900


#REVISIONS: 1