### PR TITLE
Feature: allow to skip x86_64 -> x86 in cross_building (same os)

### DIFF
--- a/conans/client/tools/oss.py
+++ b/conans/client/tools/oss.py
@@ -416,9 +416,13 @@ class OSInfo(object):
             return None
 
 
-def cross_building(settings, self_os=None, self_arch=None):
+def cross_building(settings, self_os=None, self_arch=None, skip_x64_x86=False):
     ret = get_cross_building_settings(settings, self_os, self_arch)
     build_os, build_arch, host_os, host_arch = ret
+
+    if skip_x64_x86 and host_os is not None and (build_os == host_os) and \
+            host_arch is not None and (build_arch == "x86_64") and (host_arch == "x86"):
+        return False
 
     if host_os is not None and (build_os != host_os):
         return True

--- a/conans/test/unittests/client/tools/oss/cross_building_test.py
+++ b/conans/test/unittests/client/tools/oss/cross_building_test.py
@@ -1,0 +1,109 @@
+# -*- coding: utf-8 -*-
+
+from mock import mock
+import unittest
+
+from conans.client.conf import default_settings_yml
+from conans.client.tools.oss import cross_building
+from conans.model.settings import Settings
+
+
+class CrossBuildingTest(unittest.TestCase):
+    def test_same(self):
+        settings = Settings.loads(default_settings_yml)
+        settings.os = "FreeBSD"
+        settings.arch = "x86_64"
+        self.assertFalse(cross_building(settings, self_os="FreeBSD", self_arch="x86_64"))
+
+        with mock.patch("platform.system", mock.MagicMock(return_value='FreeBSD')),\
+             mock.patch("platform.machine", mock.MagicMock(return_value="x86_64")):
+            self.assertFalse(cross_building(settings))
+
+        settings.os_build = "FreeBSD"
+        settings.arch = "x86_64"
+        self.assertFalse(cross_building(settings))
+
+    def test_different_os(self):
+        settings = Settings.loads(default_settings_yml)
+        settings.os = "Linux"
+        settings.arch = "x86_64"
+        self.assertTrue(cross_building(settings, self_os="FreeBSD", self_arch="x86_64"))
+
+        with mock.patch("platform.system", mock.MagicMock(return_value='FreeBSD')),\
+             mock.patch("platform.machine", mock.MagicMock(return_value="x86_64")):
+            self.assertTrue(cross_building(settings))
+
+        settings.os_build = "FreeBSD"
+        settings.arch_build = "x86_64"
+        self.assertTrue(cross_building(settings))
+
+    def test_different_arch(self):
+        settings = Settings.loads(default_settings_yml)
+        settings.os = "FreeBSD"
+        settings.arch = "x86"
+        self.assertTrue(cross_building(settings, self_os="FreeBSD", self_arch="x86_64"))
+
+        with mock.patch("platform.system", mock.MagicMock(return_value='FreeBSD')), \
+             mock.patch("platform.machine", mock.MagicMock(return_value="x86_64")):
+            self.assertTrue(cross_building(settings))
+
+        settings.os_build = "FreeBSD"
+        settings.arch_build = "x86_64"
+        self.assertTrue(cross_building(settings))
+
+    def test_x64_x86(self):
+        settings = Settings.loads(default_settings_yml)
+        settings.os = "FreeBSD"
+        settings.arch = "x86"
+        self.assertFalse(cross_building(settings,  self_os="FreeBSD",
+                                        self_arch="x86_64", skip_x64_x86=True))
+        self.assertTrue(cross_building(settings, self_os="FreeBSD",
+                                       self_arch="x86_64", skip_x64_x86=False))
+
+        with mock.patch("platform.system", mock.MagicMock(return_value='FreeBSD')), \
+             mock.patch("platform.machine", mock.MagicMock(return_value="x86_64")):
+            self.assertFalse(cross_building(settings, skip_x64_x86=True))
+            self.assertTrue(cross_building(settings, skip_x64_x86=False))
+
+        settings.os_build = "FreeBSD"
+        settings.arch_build = "x86_64"
+        self.assertFalse(cross_building(settings, skip_x64_x86=True))
+        self.assertTrue(cross_building(settings, skip_x64_x86=False))
+
+    def test_x86_x64(self):
+        settings = Settings.loads(default_settings_yml)
+        settings.os = "FreeBSD"
+        settings.arch = "x86_64"
+        self.assertTrue(cross_building(settings,  self_os="FreeBSD",
+                                       self_arch="x86", skip_x64_x86=True))
+        self.assertTrue(cross_building(settings, self_os="FreeBSD",
+                                       self_arch="x86", skip_x64_x86=False))
+
+        with mock.patch("platform.system", mock.MagicMock(return_value='FreeBSD')), \
+             mock.patch("platform.machine", mock.MagicMock(return_value="x86")):
+            self.assertTrue(cross_building(settings, skip_x64_x86=True))
+            self.assertTrue(cross_building(settings, skip_x64_x86=False))
+
+        settings.os_build = "FreeBSD"
+        settings.arch_build = "x86"
+        self.assertTrue(cross_building(settings, skip_x64_x86=True))
+        self.assertTrue(cross_building(settings, skip_x64_x86=False))
+
+    def test_x86_64_different_os(self):
+        settings = Settings.loads(default_settings_yml)
+        settings.os = "Linux"
+        settings.arch = "x86"
+        self.assertTrue(cross_building(settings,  self_os="FreeBSD",
+                                       self_arch="x86_64", skip_x64_x86=True))
+        self.assertTrue(cross_building(settings, self_os="FreeBSD",
+                                       self_arch="x86_64", skip_x64_x86=False))
+
+        with mock.patch("platform.system", mock.MagicMock(return_value='FreeBSD')), \
+             mock.patch("platform.machine", mock.MagicMock(return_value="x86_64")):
+            self.assertTrue(cross_building(settings, skip_x64_x86=True))
+            self.assertTrue(cross_building(settings, skip_x64_x86=False))
+
+        settings.os_build = "FreeBSD"
+        settings.arch_build = "x86_64"
+        self.assertTrue(cross_building(settings, skip_x64_x86=True))
+        self.assertTrue(cross_building(settings, skip_x64_x86=False))


### PR DESCRIPTION
closes: #5870 
Changelog: Feature: allow to skip x86_64 -> x86 in cross_building (same os)
Docs: TODO
- [ ] Refer to the issue that supports this Pull Request.
- [ ] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [ ] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [ ] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 

<sup>**Note:** By default this PR will skip the slower tests and will use a limited set of python versions. Check [here](https://github.com/conan-io/conan/blob/develop/.github/PR_INCREASE_TESTING.md) how to increase the testing level by writing some tags in the current PR body text.</sup>
