### PR TITLE
Remove traceback from ConanException message rasing in executing hooks

### DIFF
--- a/conans/client/hook_manager.py
+++ b/conans/client/hook_manager.py
@@ -57,8 +57,7 @@ class HookManager(object):
                 output = ScopedOutput("[HOOK - %s] %s()" % (name, method_name), self.output)
                 method(output=output, **kwargs)
             except Exception as e:
-                raise ConanException("[HOOK - %s] %s(): %s\n%s" % (name, method_name, str(e),
-                                                                   traceback.format_exc()))
+                raise ConanException("[HOOK - %s] %s(): %s" % (name, method_name, str(e)))
 
     def load_hooks(self):
         for name in self._hook_names:


### PR DESCRIPTION
Changelog: Fix: remove traceback from exception message raised by execute method of HookManager.
Docs: Omit

Close #5019

- [x] Refer to the issue that supports this Pull Request.
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 


