### PR TITLE
Fix trailing blanks in virtualenv varaibles (related to 5924)

### DIFF
--- a/conans/test/functional/generators/virtualenv_test.py
+++ b/conans/test/functional/generators/virtualenv_test.py
@@ -217,8 +217,8 @@ class VirtualEnvIntegrationTestCase(unittest.TestCase):
 
         _, environment = self._run_virtualenv(generator)
 
-        self.assertEqual(environment["CFLAGS"], "-O2 ")  # FIXME: Trailing blank
-        self.assertEqual(environment["CL"], "-MD -DNDEBUG -O2 -Ob2 ")  # FIXME: Trailing blank
+        self.assertEqual(environment["CFLAGS"], "-O2")
+        self.assertEqual(environment["CL"], "-MD -DNDEBUG -O2 -Ob2")
 
         with environment_append({"CFLAGS": "cflags", "CL": "cl"}):
             _, environment = self._run_virtualenv(generator)


### PR DESCRIPTION
Bugfix:
Fixes trailing blank in #5924 
Docs: https://github.com/conan-io/docs/pull/XXXX

- [ ] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [ ] Refer to the issue that supports this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 
