### PR TITLE
Minor improvement to TurboTestClient

### DIFF
--- a/conans/test/utils/tools.py
+++ b/conans/test/utils/tools.py
@@ -837,7 +837,7 @@ servers["r2"] = TestServer()
             added_modules = set(sys.modules).difference(old_modules)
             for added in added_modules:
                 sys.modules.pop(added, None)
-        self._handle_cli_result(command, assert_error=assert_error, error=error)
+        self._handle_cli_result(command_line, assert_error=assert_error, error=error)
         return error
 
     def run_command(self, command, cwd=None, assert_error=False):

--- a/conans/test/utils/tools.py
+++ b/conans/test/utils/tools.py
@@ -885,132 +885,6 @@ servers["r2"] = TestServer()
                 shutil.copy2(s, d)
 
 
-class TurboTestClient(TestClient):
-
-    tmp_json_name = ".tmp_json"
-
-    def __init__(self, *args, **kwargs):
-        if "users" not in kwargs and "default_server_user" not in kwargs:
-            from collections import defaultdict
-            kwargs["users"] = defaultdict(lambda: [("conan", "password")])
-
-        super(TurboTestClient, self).__init__(*args, **kwargs)
-
-    def export(self, ref, conanfile=None, args=None, assert_error=False):
-        conanfile = str(conanfile) if conanfile else GenConanfile()
-        self.save({"conanfile.py": conanfile})
-        self.run("export . {} {}".format(ref.full_str(), args or ""),
-                 assert_error=assert_error)
-        rrev = self.cache.package_layout(ref).recipe_revision()
-        return ref.copy_with_rev(rrev)
-
-    def create(self, ref, conanfile=None, args=None, assert_error=False):
-        conanfile = str(conanfile) if conanfile else GenConanfile()
-        self.save({"conanfile.py": conanfile})
-        self.run("create . {} {} --json {}".format(ref.full_str(),
-                                                   args or "", self.tmp_json_name),
-                 assert_error=assert_error)
-        rrev = self.cache.package_layout(ref).recipe_revision()
-        json_path = os.path.join(self.current_folder, self.tmp_json_name)
-        data = json.loads(load(json_path))
-        if assert_error:
-            return None
-        package_id = data["installed"][0]["packages"][0]["id"]
-        package_ref = PackageReference(ref, package_id)
-        prev = self.cache.package_layout(ref.copy_clear_rev()).package_revision(package_ref)
-        return package_ref.copy_with_revs(rrev, prev)
-
-    def upload_all(self, ref, remote=None, args=None, assert_error=False):
-        remote = remote or list(self.servers.keys())[0]
-        self.run("upload {} -c --all -r {} {}".format(ref.full_str(), remote, args or ""),
-                 assert_error=assert_error)
-        if not assert_error:
-            remote_rrev, _ = self.servers[remote].server_store.get_last_revision(ref)
-            return ref.copy_with_rev(remote_rrev)
-        return
-
-    def remove_all(self):
-        self.run("remove '*' -f")
-
-    def export_pkg(self, ref, conanfile=None, args=None, assert_error=False):
-        conanfile = str(conanfile) if conanfile else GenConanfile()
-        self.save({"conanfile.py": conanfile})
-        self.run("export-pkg . {} {} --json {}".format(ref.full_str(),
-                                                       args or "", self.tmp_json_name),
-                 assert_error=assert_error)
-        rrev = self.cache.package_layout(ref).recipe_revision()
-        json_path = os.path.join(self.current_folder, self.tmp_json_name)
-        data = json.loads(load(json_path))
-        if assert_error:
-            return None
-        package_id = data["installed"][0]["packages"][0]["id"]
-        package_ref = PackageReference(ref, package_id)
-        prev = self.cache.package_layout(ref.copy_clear_rev()).package_revision(package_ref)
-        return package_ref.copy_with_revs(rrev, prev)
-
-    def recipe_exists(self, ref):
-        return self.cache.package_layout(ref).recipe_exists()
-
-    def package_exists(self, pref):
-        return self.cache.package_layout(pref.ref).package_exists(pref)
-
-    def recipe_revision(self, ref):
-        return self.cache.package_layout(ref).recipe_revision()
-
-    def package_revision(self, pref):
-        return self.cache.package_layout(pref.ref).package_revision(pref)
-
-    def search(self, pattern, remote=None, assert_error=False, args=None):
-        remote = " -r={}".format(remote) if remote else ""
-        self.run("search {} --json {} {} {}".format(pattern, self.tmp_json_name, remote,
-                                                    args or ""),
-                 assert_error=assert_error)
-        json_path = os.path.join(self.current_folder, self.tmp_json_name)
-        data = json.loads(load(json_path))
-        return data
-
-    def massive_uploader(self, ref, revisions, num_prev, remote=None):
-        """Uploads N revisions with M package revisions. The revisions can be specified like:
-            revisions = [{"os": "Windows"}, {"os": "Linux"}], \
-                        [{"os": "Macos"}], \
-                        [{"os": "Solaris"}, {"os": "FreeBSD"}]
-
-            IMPORTANT: Different settings keys will cause different recipe revisions
-        """
-        remote = remote or "default"
-        ret = []
-        for i, settings_groups in enumerate(revisions):
-            tmp = []
-            for settings in settings_groups:
-                conanfile_gen = GenConanfile(). \
-                    with_build_msg("REV{}".format(i)). \
-                    with_package_file("file", env_var="MY_VAR")
-                for s in settings.keys():
-                    conanfile_gen = conanfile_gen.with_setting(s)
-                for k in range(num_prev):
-                    args = " ".join(["-s {}={}".format(key, value)
-                                     for key, value in settings.items()])
-                    with environment_append({"MY_VAR": str(k)}):
-                        pref = self.create(ref, conanfile=conanfile_gen, args=args)
-                        self.upload_all(ref, remote=remote)
-                        tmp.append(pref)
-                ret.append(tmp)
-        return ret
-
-    def init_git_repo(self, files=None, branch=None, submodules=None, origin_url=None):
-        _, commit = create_local_git_repo(files, branch, submodules, self.current_folder)
-        if origin_url:
-            self.run_command('git remote add origin {}'.format(origin_url))
-        return commit
-
-    def init_svn_repo(self, subpath, files=None, repo_url=None):
-        if not repo_url:
-            repo_url = create_remote_svn_repo(temp_folder())
-        _, rev = create_local_svn_checkout(files, repo_url, folder=self.current_folder,
-                                           rel_project_path=subpath, delete_checkout=False)
-        return rev
-
-
 class GenConanfile(object):
     """
     USAGE:
@@ -1319,6 +1193,132 @@ class GenConanfile(object):
         if len(ret) == 2:
             ret.append("    pass")
         return "\n".join(ret)
+
+
+class TurboTestClient(TestClient):
+
+    tmp_json_name = ".tmp_json"
+
+    def __init__(self, *args, **kwargs):
+        if "users" not in kwargs and "default_server_user" not in kwargs:
+            from collections import defaultdict
+            kwargs["users"] = defaultdict(lambda: [("conan", "password")])
+
+        super(TurboTestClient, self).__init__(*args, **kwargs)
+
+    def export(self, ref, conanfile=None, args=None, assert_error=False):
+        conanfile = str(conanfile) if conanfile else GenConanfile()
+        self.save({"conanfile.py": conanfile})
+        self.run("export . {} {}".format(ref.full_str(), args or ""),
+                 assert_error=assert_error)
+        rrev = self.cache.package_layout(ref).recipe_revision()
+        return ref.copy_with_rev(rrev)
+
+    def create(self, ref, conanfile=None, args=None, assert_error=False):
+        conanfile = str(conanfile) if conanfile else GenConanfile()
+        self.save({"conanfile.py": conanfile})
+        self.run("create . {} {} --json {}".format(ref.full_str(),
+                                                   args or "", self.tmp_json_name),
+                 assert_error=assert_error)
+        rrev = self.cache.package_layout(ref).recipe_revision()
+        json_path = os.path.join(self.current_folder, self.tmp_json_name)
+        data = json.loads(load(json_path))
+        if assert_error:
+            return None
+        package_id = data["installed"][0]["packages"][0]["id"]
+        package_ref = PackageReference(ref, package_id)
+        prev = self.cache.package_layout(ref.copy_clear_rev()).package_revision(package_ref)
+        return package_ref.copy_with_revs(rrev, prev)
+
+    def upload_all(self, ref, remote=None, args=None, assert_error=False):
+        remote = remote or list(self.servers.keys())[0]
+        self.run("upload {} -c --all -r {} {}".format(ref.full_str(), remote, args or ""),
+                 assert_error=assert_error)
+        if not assert_error:
+            remote_rrev, _ = self.servers[remote].server_store.get_last_revision(ref)
+            return ref.copy_with_rev(remote_rrev)
+        return
+
+    def remove_all(self):
+        self.run("remove '*' -f")
+
+    def export_pkg(self, ref, conanfile=None, args=None, assert_error=False):
+        conanfile = str(conanfile) if conanfile else GenConanfile()
+        self.save({"conanfile.py": conanfile})
+        self.run("export-pkg . {} {} --json {}".format(ref.full_str(),
+                                                       args or "", self.tmp_json_name),
+                 assert_error=assert_error)
+        rrev = self.cache.package_layout(ref).recipe_revision()
+        json_path = os.path.join(self.current_folder, self.tmp_json_name)
+        data = json.loads(load(json_path))
+        if assert_error:
+            return None
+        package_id = data["installed"][0]["packages"][0]["id"]
+        package_ref = PackageReference(ref, package_id)
+        prev = self.cache.package_layout(ref.copy_clear_rev()).package_revision(package_ref)
+        return package_ref.copy_with_revs(rrev, prev)
+
+    def recipe_exists(self, ref):
+        return self.cache.package_layout(ref).recipe_exists()
+
+    def package_exists(self, pref):
+        return self.cache.package_layout(pref.ref).package_exists(pref)
+
+    def recipe_revision(self, ref):
+        return self.cache.package_layout(ref).recipe_revision()
+
+    def package_revision(self, pref):
+        return self.cache.package_layout(pref.ref).package_revision(pref)
+
+    def search(self, pattern, remote=None, assert_error=False, args=None):
+        remote = " -r={}".format(remote) if remote else ""
+        self.run("search {} --json {} {} {}".format(pattern, self.tmp_json_name, remote,
+                                                    args or ""),
+                 assert_error=assert_error)
+        json_path = os.path.join(self.current_folder, self.tmp_json_name)
+        data = json.loads(load(json_path))
+        return data
+
+    def massive_uploader(self, ref, revisions, num_prev, remote=None):
+        """Uploads N revisions with M package revisions. The revisions can be specified like:
+            revisions = [{"os": "Windows"}, {"os": "Linux"}], \
+                        [{"os": "Macos"}], \
+                        [{"os": "Solaris"}, {"os": "FreeBSD"}]
+
+            IMPORTANT: Different settings keys will cause different recipe revisions
+        """
+        remote = remote or "default"
+        ret = []
+        for i, settings_groups in enumerate(revisions):
+            tmp = []
+            for settings in settings_groups:
+                conanfile_gen = GenConanfile(). \
+                    with_build_msg("REV{}".format(i)). \
+                    with_package_file("file", env_var="MY_VAR")
+                for s in settings.keys():
+                    conanfile_gen = conanfile_gen.with_setting(s)
+                for k in range(num_prev):
+                    args = " ".join(["-s {}={}".format(key, value)
+                                     for key, value in settings.items()])
+                    with environment_append({"MY_VAR": str(k)}):
+                        pref = self.create(ref, conanfile=conanfile_gen, args=args)
+                        self.upload_all(ref, remote=remote)
+                        tmp.append(pref)
+                ret.append(tmp)
+        return ret
+
+    def init_git_repo(self, files=None, branch=None, submodules=None, origin_url=None):
+        _, commit = create_local_git_repo(files, branch, submodules, self.current_folder)
+        if origin_url:
+            self.run_command('git remote add origin {}'.format(origin_url))
+        return commit
+
+    def init_svn_repo(self, subpath, files=None, repo_url=None):
+        if not repo_url:
+            repo_url = create_remote_svn_repo(temp_folder())
+        _, rev = create_local_svn_checkout(files, repo_url, folder=self.current_folder,
+                                           rel_project_path=subpath, delete_checkout=False)
+        return rev
 
 
 class StoppableThreadBottle(threading.Thread):

--- a/conans/test/utils/tools.py
+++ b/conans/test/utils/tools.py
@@ -1206,17 +1206,17 @@ class TurboTestClient(TestClient):
 
         super(TurboTestClient, self).__init__(*args, **kwargs)
 
-    def export(self, ref, conanfile=None, args=None, assert_error=False):
-        conanfile = str(conanfile) if conanfile else GenConanfile()
-        self.save({"conanfile.py": conanfile})
+    def export(self, ref, conanfile=GenConanfile(), args=None, assert_error=False):
+        if conanfile:
+            self.save({"conanfile.py": conanfile})
         self.run("export . {} {}".format(ref.full_str(), args or ""),
                  assert_error=assert_error)
         rrev = self.cache.package_layout(ref).recipe_revision()
         return ref.copy_with_rev(rrev)
 
-    def create(self, ref, conanfile=None, args=None, assert_error=False):
-        conanfile = str(conanfile) if conanfile else GenConanfile()
-        self.save({"conanfile.py": conanfile})
+    def create(self, ref, conanfile=GenConanfile(), args=None, assert_error=False):
+        if conanfile:
+            self.save({"conanfile.py": conanfile})
         self.run("create . {} {} --json {}".format(ref.full_str(),
                                                    args or "", self.tmp_json_name),
                  assert_error=assert_error)
@@ -1242,9 +1242,9 @@ class TurboTestClient(TestClient):
     def remove_all(self):
         self.run("remove '*' -f")
 
-    def export_pkg(self, ref, conanfile=None, args=None, assert_error=False):
-        conanfile = str(conanfile) if conanfile else GenConanfile()
-        self.save({"conanfile.py": conanfile})
+    def export_pkg(self, ref, conanfile=GenConanfile(), args=None, assert_error=False):
+        if conanfile:
+            self.save({"conanfile.py": conanfile})
         self.run("export-pkg . {} {} --json {}".format(ref.full_str(),
                                                        args or "", self.tmp_json_name),
                  assert_error=assert_error)


### PR DESCRIPTION
Changelog: omit
Docs: omit

I needed to change the order of `TurboTestClient` and `GenConanFile` in the source file, so the diff is crap 😞 , but the only change here is the way argument `conanfile` is handled in `GenConanFile` methods:

This PR sets (for `create`, `export`, `export_pkg`:

```python
    def create(self, ref, conanfile=GenConanfile(), args=None, assert_error=False):
        if conanfile:
            self.save({"conanfile.py": conanfile})
```

It was:

```python
    def create(self, ref, conanfile=None, args=None, assert_error=False):
        conanfile = str(conanfile) if conanfile else GenConanfile()
        self.save({"conanfile.py": conanfile})
```

The new way allows the user to use `TurboTestClient` with existing `conanfile.py` file using `client.create(conanfile=None,...)`