### PR TITLE
Remove autmotic tags for issues

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.md
+++ b/.github/ISSUE_TEMPLATE/bug.md
@@ -2,7 +2,6 @@
 name: 'Bug Report'
 about: 'Report a bug, something does not work as it supposed to'
 title: '[bug] SHORT DESCRIPTION'
-labels: 'type: bug'
 ---
 
 <!--

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -2,7 +2,6 @@
 name: 'Feature Request'
 about: 'Request a new feature or suggest a change'
 title: '[feature] SHORT DESCRIPTION'
-labels: 'type: feature'
 ---
 
 <!-- What is your suggestion? Please be as specific as possible! -->

--- a/.github/ISSUE_TEMPLATE/question.md
+++ b/.github/ISSUE_TEMPLATE/question.md
@@ -2,7 +2,6 @@
 name: 'Question'
 about: 'If something needs clarification'
 title: '[question] SHORT DESCRIPTION'
-labels: 'type: question'
 ---
 
 <!-- What is your question? Please be as specific as possible! -->


### PR DESCRIPTION
Remove automatic tags when creating a new issue

Changelog: Omit
Docs: Omit

- [ ] Refer to the issue that supports this Pull Request.
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [ ] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 

<sup>**Note:** By default this PR will skip the slower tests and will use a limited set of python versions. Check [here](https://github.com/conan-io/conan/blob/develop/.github/PR_INCREASE_TESTING.md) how to increase the testing level by writing some tags in the current PR body text.</sup>
