### PR TITLE
Add JSON output option to the "config home" subcommand

### DIFF
--- a/conans/client/command.py
+++ b/conans/client/command.py
@@ -557,7 +557,7 @@ class Command(object):
             conan_home = self._conan.config_home()
             self._out.info(conan_home)
             if args.json:
-                self._outputer.json_output(conan_home, args.json, os.getcwd())
+                self._outputer.json_output({"home": conan_home}, args.json, os.getcwd())
             return conan_home
         elif args.subcommand == "install":
             verify_ssl = get_bool_from_text(args.verify_ssl)

--- a/conans/client/command.py
+++ b/conans/client/command.py
@@ -511,15 +511,15 @@ class Command(object):
         subparsers.required = True
 
         get_subparser = subparsers.add_parser('get', help='Get the value of configuration item')
-        subparsers.add_parser('home', help='Retrieve the Conan home directory')
+        home_subparser = subparsers.add_parser('home', help='Retrieve the Conan home directory')
         install_subparser = subparsers.add_parser('install', help='Install a full configuration '
                                                                   'from a local or remote zip file')
         rm_subparser = subparsers.add_parser('rm', help='Remove an existing config element')
         set_subparser = subparsers.add_parser('set', help='Set a value for a configuration item')
 
-        rm_subparser.add_argument("item", help="Item to remove")
         get_subparser.add_argument("item", nargs="?", help="Item to print")
-        set_subparser.add_argument("item", help="'item=value' to set")
+        home_subparser.add_argument("-j", "--json", default=None, action=OnceArgument,
+                                    help='json file path where the config home will be written to')
         install_subparser.add_argument("item", nargs="?",
                                        help="git repository, local folder or zip file (local or "
                                        "http) where the configuration is stored")
@@ -535,6 +535,8 @@ class Command(object):
                                        'specified origin')
         install_subparser.add_argument("-tf", "--target-folder",
                                        help='Install to that path in the conan cache')
+        rm_subparser.add_argument("item", help="Item to remove")
+        set_subparser.add_argument("item", help="'item=value' to set")
 
         args = parser.parse_args(*args)
 
@@ -554,6 +556,8 @@ class Command(object):
         elif args.subcommand == "home":
             conan_home = self._conan.config_home()
             self._out.info(conan_home)
+            if args.json:
+                self._outputer.json_output({"home": conan_home}, args.json, os.getcwd())
             return conan_home
         elif args.subcommand == "install":
             verify_ssl = get_bool_from_text(args.verify_ssl)

--- a/conans/client/command.py
+++ b/conans/client/command.py
@@ -557,7 +557,7 @@ class Command(object):
             conan_home = self._conan.config_home()
             self._out.info(conan_home)
             if args.json:
-                self._outputer.json_output({"home": conan_home}, args.json, os.getcwd())
+                self._outputer.json_output(conan_home, args.json, os.getcwd())
             return conan_home
         elif args.subcommand == "install":
             verify_ssl = get_bool_from_text(args.verify_ssl)

--- a/conans/test/functional/command/config_test.py
+++ b/conans/test/functional/command/config_test.py
@@ -100,8 +100,7 @@ class ConfigTest(unittest.TestCase):
         self.client.run("config home")
         self.assertIn(self.client.cache.cache_folder, self.client.out)
         self.client.run("config home --json home.json")
-        self._assert_dict_subset({"home": self.client.cache.cache_folder},
-                                 json.loads(self.client.load("home.json")))
+        self.assertEqual(self.client.cache.cache_folder, json.loads(self.client.load("home.json")))
 
     def test_config_home_custom_home_dir(self):
         cache_folder = os.path.join(temp_folder(), "custom")
@@ -110,14 +109,10 @@ class ConfigTest(unittest.TestCase):
             client.run("config home")
             self.assertIn(cache_folder, client.out)
             client.run("config home --json home.json")
-            self._assert_dict_subset({"home": cache_folder}, json.loads(client.load("home.json")))
+            self.assertEqual(cache_folder, json.loads(client.load("home.json")))
 
     def test_config_home_short_home_dir(self):
         cache_folder = os.path.join(temp_folder(), "custom")
         with environment_append({"CONAN_USER_HOME_SHORT": cache_folder}):
             with six.assertRaisesRegex(self, ConanException, "cannot be a subdirectory of the conan cache"):
                 TestClient(cache_folder=cache_folder)
-
-    def _assert_dict_subset(self, expected, actual):
-        actual = {k: v for k, v in actual.items() if k in expected}
-        self.assertDictEqual(expected, actual)

--- a/conans/test/functional/command/config_test.py
+++ b/conans/test/functional/command/config_test.py
@@ -1,3 +1,4 @@
+import json
 import os
 import unittest
 import six
@@ -98,6 +99,9 @@ class ConfigTest(unittest.TestCase):
     def test_config_home_default(self):
         self.client.run("config home")
         self.assertIn(self.client.cache.cache_folder, self.client.out)
+        self.client.run("config home --json home.json")
+        self._assert_dict_subset({"home": self.client.cache.cache_folder},
+                                 json.loads(self.client.load("home.json")))
 
     def test_config_home_custom_home_dir(self):
         cache_folder = os.path.join(temp_folder(), "custom")
@@ -105,9 +109,15 @@ class ConfigTest(unittest.TestCase):
             client = TestClient(cache_folder=cache_folder)
             client.run("config home")
             self.assertIn(cache_folder, client.out)
+            client.run("config home --json home.json")
+            self._assert_dict_subset({"home": cache_folder}, json.loads(client.load("home.json")))
 
     def test_config_home_short_home_dir(self):
         cache_folder = os.path.join(temp_folder(), "custom")
         with environment_append({"CONAN_USER_HOME_SHORT": cache_folder}):
             with six.assertRaisesRegex(self, ConanException, "cannot be a subdirectory of the conan cache"):
                 TestClient(cache_folder=cache_folder)
+
+    def _assert_dict_subset(self, expected, actual):
+        actual = {k: v for k, v in actual.items() if k in expected}
+        self.assertDictEqual(expected, actual)

--- a/conans/test/functional/command/config_test.py
+++ b/conans/test/functional/command/config_test.py
@@ -100,7 +100,8 @@ class ConfigTest(unittest.TestCase):
         self.client.run("config home")
         self.assertIn(self.client.cache.cache_folder, self.client.out)
         self.client.run("config home --json home.json")
-        self.assertEqual(self.client.cache.cache_folder, json.loads(self.client.load("home.json")))
+        self._assert_dict_subset({"home": self.client.cache.cache_folder},
+                                 json.loads(self.client.load("home.json")))
 
     def test_config_home_custom_home_dir(self):
         cache_folder = os.path.join(temp_folder(), "custom")
@@ -109,10 +110,14 @@ class ConfigTest(unittest.TestCase):
             client.run("config home")
             self.assertIn(cache_folder, client.out)
             client.run("config home --json home.json")
-            self.assertEqual(cache_folder, json.loads(client.load("home.json")))
+            self._assert_dict_subset({"home": cache_folder}, json.loads(client.load("home.json")))
 
     def test_config_home_short_home_dir(self):
         cache_folder = os.path.join(temp_folder(), "custom")
         with environment_append({"CONAN_USER_HOME_SHORT": cache_folder}):
             with six.assertRaisesRegex(self, ConanException, "cannot be a subdirectory of the conan cache"):
                 TestClient(cache_folder=cache_folder)
+
+    def _assert_dict_subset(self, expected, actual):
+        actual = {k: v for k, v in actual.items() if k in expected}
+        self.assertDictEqual(expected, actual)


### PR DESCRIPTION
Changelog: Feature: JSON output to the "config home" subcommand with ``--json`` argument.
Docs: omit

As the issue referred to making command output more future-proof it can be written to file in JSON format (with the actual path contained in the `home` attribute).

Tests have been extended to make sure that the expected output is contained in the JSON file created.

Fixes #5943

- [x] Refer to the issue that supports this Pull Request.
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 

<sup>**Note:** By default this PR will skip the slower tests and will use a limited set of python versions. Check [here](https://github.com/conan-io/conan/blob/develop/.github/PR_INCREASE_TESTING.md) how to increase the testing level by writing some tags in the current PR body text.</sup>
