### PR TITLE
make the unknown binaries explicit

### DIFF
--- a/conans/client/graph/graph.py
+++ b/conans/client/graph/graph.py
@@ -21,6 +21,7 @@ BINARY_BUILD = "Build"
 BINARY_MISSING = "Missing"
 BINARY_SKIP = "Skip"
 BINARY_EDITABLE = "Editable"
+BINARY_UNKNOWN = "Unknown"
 
 
 class Node(object):

--- a/conans/client/graph/graph_binaries.py
+++ b/conans/client/graph/graph_binaries.py
@@ -291,14 +291,14 @@ class GraphBinariesAnalyzer(object):
             if node.recipe in (RECIPE_CONSUMER, RECIPE_VIRTUAL):
                 continue
             if node.package_id == PACKAGE_ID_UNKNOWN:
-                assert node.binary is None
+                assert node.binary is None, "Node.binary should be None"
                 node.binary = BINARY_UNKNOWN
                 continue
             self._evaluate_node(node, build_mode, update, remotes)
             self._handle_private(node)
 
     def reevaluate_node(self, node, remotes, build_mode, update):
-        assert node.binary is None
+        assert node.binary == BINARY_UNKNOWN
         output = node.conanfile.output
         node._package_id = None  # Invalidate it, so it can be re-computed
         default_package_id_mode = self._cache.config.default_package_id_mode
@@ -308,6 +308,7 @@ class GraphBinariesAnalyzer(object):
         if node.recipe in (RECIPE_CONSUMER, RECIPE_VIRTUAL):
             return
         assert node.package_id != PACKAGE_ID_UNKNOWN
+        node.binary = None  # Necessary to invalidate so it is properly evaluated
         self._evaluate_node(node, build_mode, update, remotes)
         output.info("Binary for updated ID from: %s" % node.binary)
         if node.binary == BINARY_BUILD:

--- a/conans/client/graph/graph_binaries.py
+++ b/conans/client/graph/graph_binaries.py
@@ -3,7 +3,7 @@ import os
 from conans.client.graph.graph import (BINARY_BUILD, BINARY_CACHE, BINARY_DOWNLOAD, BINARY_MISSING,
                                        BINARY_SKIP, BINARY_UPDATE,
                                        RECIPE_EDITABLE, BINARY_EDITABLE,
-                                       RECIPE_CONSUMER, RECIPE_VIRTUAL)
+                                       RECIPE_CONSUMER, RECIPE_VIRTUAL, BINARY_UNKNOWN)
 from conans.errors import NoRemoteAvailable, NotFoundException, conanfile_exception_formatter
 from conans.model.info import ConanInfo, PACKAGE_ID_UNKNOWN
 from conans.model.manifest import FileTreeManifest
@@ -156,10 +156,6 @@ class GraphBinariesAnalyzer(object):
         assert node.package_id != PACKAGE_ID_UNKNOWN, "Node.package_id shouldn't be Unknown"
         assert node.prev is None, "Node.prev should be None"
 
-        if node.package_id == PACKAGE_ID_UNKNOWN:
-            node.binary = BINARY_MISSING
-            return
-
         ref, conanfile = node.ref, node.conanfile
 
         # If it has lock
@@ -296,6 +292,7 @@ class GraphBinariesAnalyzer(object):
                 continue
             if node.package_id == PACKAGE_ID_UNKNOWN:
                 assert node.binary is None
+                node.binary = BINARY_UNKNOWN
                 continue
             self._evaluate_node(node, build_mode, update, remotes)
             self._handle_private(node)

--- a/conans/client/graph/graph_manager.py
+++ b/conans/client/graph/graph_manager.py
@@ -4,8 +4,8 @@ from collections import OrderedDict
 
 from conans.client.generators.text import TXTGenerator
 from conans.client.graph.build_mode import BuildMode
-from conans.client.graph.graph import BINARY_BUILD, Node,\
-    RECIPE_CONSUMER, RECIPE_VIRTUAL, BINARY_EDITABLE
+from conans.client.graph.graph import BINARY_BUILD, Node, \
+    RECIPE_CONSUMER, RECIPE_VIRTUAL, BINARY_EDITABLE, BINARY_UNKNOWN
 from conans.client.graph.graph_builder import DepsGraphBuilder
 from conans.errors import ConanException, conanfile_exception_formatter
 from conans.model.conan_file import get_env_context_manager
@@ -14,7 +14,6 @@ from conans.model.graph_lock import GraphLock, GraphLockFile
 from conans.model.ref import ConanFileReference
 from conans.paths import BUILD_INFO
 from conans.util.files import load
-from conans.model.info import PACKAGE_ID_UNKNOWN
 
 
 class _RecipeBuildRequires(OrderedDict):
@@ -232,8 +231,8 @@ class GraphManager(object):
             if node.recipe == RECIPE_VIRTUAL:
                 continue
             # Packages with PACKAGE_ID_UNKNOWN might be built in the future, need build requires
-            if (node.binary not in (BINARY_BUILD, BINARY_EDITABLE)
-                    and node.recipe != RECIPE_CONSUMER and node.package_id != PACKAGE_ID_UNKNOWN):
+            if (node.binary not in (BINARY_BUILD, BINARY_EDITABLE, BINARY_UNKNOWN)
+                    and node.recipe != RECIPE_CONSUMER):
                 continue
             package_build_requires = self._get_recipe_build_requires(node.conanfile)
             str_ref = str(node.ref)

--- a/conans/client/installer.py
+++ b/conans/client/installer.py
@@ -6,7 +6,7 @@ from conans.client import tools
 from conans.client.file_copier import report_copied_files
 from conans.client.generators import TXTGenerator, write_generators
 from conans.client.graph.graph import BINARY_BUILD, BINARY_CACHE, BINARY_DOWNLOAD, BINARY_EDITABLE, \
-    BINARY_MISSING, BINARY_SKIP, BINARY_UPDATE
+    BINARY_MISSING, BINARY_SKIP, BINARY_UPDATE, BINARY_UNKNOWN
 from conans.client.importer import remove_imports, run_imports
 from conans.client.packager import run_package_method, update_package_metadata
 from conans.client.recorder.action_recorder import INSTALL_ERROR_BUILDING, INSTALL_ERROR_MISSING, \
@@ -326,7 +326,7 @@ class BinaryInstaller(object):
                         continue
                     assert ref.revision is not None, "Installer should receive RREV always"
                     _handle_system_requirements(conan_file, node.pref, self._cache, output)
-                    if node.package_id == PACKAGE_ID_UNKNOWN:
+                    if node.binary == BINARY_UNKNOWN:
                         self._binaries_analyzer.reevaluate_node(node, remotes, build_mode, update)
                     self._handle_node_cache(node, keep_build, processed_package_refs, remotes)
 


### PR DESCRIPTION
Changelog: Omit
Docs: Omit

Follow up of https://github.com/conan-io/conan/pull/4958. The model for "unknown" binary package-ID was "Missing", which is not true. I have added a explicit one (an internal refactor, doesn't affect behavior)
