### PR TITLE
avoiding complex search in servers

### DIFF
--- a/conans/client/rest/rest_client.py
+++ b/conans/client/rest/rest_client.py
@@ -1,5 +1,3 @@
-from collections import defaultdict
-
 from conans import CHECKSUM_DEPLOY, REVISIONS, ONLY_V2, OAUTH_TOKEN, COMPLEX_SEARCH_CAPABILITY
 from conans.client.rest.rest_client_v1 import RestV1Methods
 from conans.client.rest.rest_client_v2 import RestV2Methods
@@ -30,19 +28,22 @@ class RestApiClient(object):
 
         self._cached_capabilities = {}
 
-    def _get_api(self):
-        if self.remote_url not in self._cached_capabilities:
+    def _capable(self, capability):
+        capabilities = self._cached_capabilities.get(self.remote_url)
+        if capabilities is None:
             tmp = RestV1Methods(self.remote_url, self.token, self.custom_headers, self._output,
                                 self.requester, self.verify_ssl, self._put_headers)
-            cap = tmp.server_capabilities()
-            self._cached_capabilities[self.remote_url] = cap
-            logger.debug("REST: Cached capabilities for the remote: %s" % cap)
-            if not self._revisions_enabled and ONLY_V2 in cap:
+            capabilities = tmp.server_capabilities()
+            self._cached_capabilities[self.remote_url] = capabilities
+            logger.debug("REST: Cached capabilities for the remote: %s" % capabilities)
+            if not self._revisions_enabled and ONLY_V2 in capabilities:
                 raise OnlyV2Available(self.remote_url)
+        return capability in capabilities
 
-        if self._revisions_enabled and REVISIONS in self._cached_capabilities.get(self.remote_url,
-                                                                                  []):
-            checksum_deploy = CHECKSUM_DEPLOY in self._cached_capabilities.get(self.remote_url, [])
+    def _get_api(self):
+        revisions = self._capable(REVISIONS)
+        if self._revisions_enabled and revisions:
+            checksum_deploy = self._capable(CHECKSUM_DEPLOY)
             return RestV2Methods(self.remote_url, self.token, self.custom_headers, self._output,
                                  self.requester, self.verify_ssl, self._put_headers,
                                  checksum_deploy)
@@ -94,7 +95,7 @@ class RestApiClient(object):
         if self.refresh_token and self.token:
             token, refresh_token = api_v1.refresh_token(self.token, self.refresh_token)
         else:
-            if OAUTH_TOKEN in self._cached_capabilities.get(self.remote_url, []):
+            if self._capable(OAUTH_TOKEN):
                 # Artifactory >= 6.13.X
                 token, refresh_token = api_v1.authenticate_oauth(user, password)
             else:
@@ -110,11 +111,10 @@ class RestApiClient(object):
         return self._get_api().search(pattern, ignorecase)
 
     def search_packages(self, reference, query):
-        package_infos = self._get_api().search_packages(reference, query)
-        if query and COMPLEX_SEARCH_CAPABILITY not in self._cached_capabilities.get(self.remote_url,
-                                                                                    []):
-            return filter_packages(query, package_infos)
-        return package_infos
+        # Do not send the query to the server, as it will fail
+        # https://github.com/conan-io/conan/issues/4951
+        package_infos = self._get_api().search_packages(reference, query=None)
+        return filter_packages(query, package_infos)
 
     def remove_conanfile(self, ref):
         return self._get_api().remove_conanfile(ref)

--- a/conans/test/functional/old/conan_trace_file_test.py
+++ b/conans/test/functional/old/conan_trace_file_test.py
@@ -123,7 +123,7 @@ class HelloConan(ConanFile):
             self.assertEqual(num_post, 2)  # 2 get urls
 
         num_get = len([it for it in actions if "REST_API_CALL" in it and "GET" in it])
-        self.assertEqual(num_get, 9)
+        self.assertEqual(num_get, 10)
 
         # Check masked signature
         for action in actions:


### PR DESCRIPTION
Changelog: Fix: Avoid doing complex ``conan search --query`` in the server, do them always in the client.
Docs: omit

Fix: #4951

#tags: slow
