### PR TITLE
Add deprecation notice to 'conan info --build-order'

### DIFF
--- a/conans/client/command.py
+++ b/conans/client/command.py
@@ -587,7 +587,8 @@ class Command(object):
         parser.add_argument("--paths", action='store_true', default=False,
                             help='Show package paths in local cache')
         parser.add_argument("-bo", "--build-order",
-                            help='given a modified reference, return an ordered list to build (CI)',
+                            help="given a modified reference, return an ordered list to build (CI)."
+                                 " [DEPRECATED: use 'conan graph build-order ...' instead]",
                             nargs=1, action=Extender)
         parser.add_argument("-g", "--graph", action=OnceArgument,
                             help='Creates file with project dependencies graph. It will generate '
@@ -615,6 +616,10 @@ class Command(object):
 
         _add_common_install_arguments(parser, build_help=build_help)
         args = parser.parse_args(*args)
+
+        if args.build_order:
+            self._out.warn("Usage of `--build-order` argument is deprecated and can return"
+                           " wrong results. Use `conan graph build-order ...` instead.")
 
         if args.install_folder and (args.profile or args.settings or args.options or args.env):
             raise ArgumentError(None,

--- a/conans/test/functional/command/info_test.py
+++ b/conans/test/functional/command/info_test.py
@@ -432,8 +432,7 @@ class MyTest(ConanFile):
                       self.client.out)
 
         self.client.run("info Hello1/0.1@lasote/stable -bo=Hello0/0.1@lasote/stable")
-        self.assertEqual("[Hello0/0.1@lasote/stable], [Hello1/0.1@lasote/stable]\n",
-                         self.client.out)
+        self.assertIn("[Hello0/0.1@lasote/stable], [Hello1/0.1@lasote/stable]\n", self.client.out)
 
         self.client.run("info Hello1/0.1@lasote/stable -bo=Hello0/0.1@lasote/stable "
                         "--json=file.json")
@@ -516,9 +515,11 @@ class AConan(ConanFile):
         self.assertIn("[LibF/0.1@lasote/stable], [LibC/0.1@lasote/stable]",
                       self.client.out)
         self.client.run("info . -bo=Dev1/0.1@lasote/stable")
-        self.assertEqual("\n", self.client.out)
+        self.assertEqual("WARN: Usage of `--build-order` argument is deprecated and can return wrong"
+                         " results. Use `conan graph build-order ...` instead.\n\n", self.client.out)
         self.client.run("info . -bo=LibG/0.1@lasote/stable")
-        self.assertEqual("\n", self.client.out)
+        self.assertEqual("WARN: Usage of `--build-order` argument is deprecated and can return wrong"
+                         " results. Use `conan graph build-order ...` instead.\n\n", self.client.out)
 
         self.client.run("info . --build-order=ALL")
         self.assertIn("[LibA/0.1@lasote/stable, LibE/0.1@lasote/stable, LibF/0.1@lasote/stable], "


### PR DESCRIPTION
Changelog: Fix: Deprecate argument `--build-order` in `conan info` command.
Docs: https://github.com/conan-io/docs/pull/1451

Add deprecation notice to `conan info --build-order`. It will keep working as it is now, but some related issues might not be fixed (https://github.com/conan-io/conan/issues/5474)

close https://github.com/conan-io/conan/issues/5474