### PR TITLE
[refactor] Rename 'profile' to 'profile_host'

### DIFF
--- a/conans/client/cmd/test.py
+++ b/conans/client/cmd/test.py
@@ -17,7 +17,7 @@ def install_build_and_test(app, conanfile_abs_path, reference, graph_info,
     and builds the test_package/conanfile.py running the test() method.
     """
     base_folder = os.path.dirname(conanfile_abs_path)
-    test_build_folder, delete_after_build = _build_folder(test_build_folder, graph_info.profile,
+    test_build_folder, delete_after_build = _build_folder(test_build_folder, graph_info.profile_host,
                                                           base_folder)
     rmdir(test_build_folder)
     if build_modes is None:

--- a/conans/client/conan_api.py
+++ b/conans/client/conan_api.py
@@ -1187,10 +1187,10 @@ class ConanAPIV1(object):
         old_lock = GraphLockFile.load(old_lockfile, True)
         new_lockfile = _make_abs_path(new_lockfile, cwd)
         new_lock = GraphLockFile.load(new_lockfile, True)
-        if old_lock.profile.dumps() != new_lock.profile.dumps():
+        if old_lock.profile_host.dumps() != new_lock.profile_host.dumps():
             raise ConanException("Profiles of lockfiles are different\n%s:\n%s\n%s:\n%s"
-                                 % (old_lockfile, old_lock.profile.dumps(),
-                                    new_lockfile, new_lock.profile.dumps()))
+                                 % (old_lockfile, old_lock.profile_host.dumps(),
+                                    new_lockfile, new_lock.profile_host.dumps()))
         old_lock.graph_lock.update_lock(new_lock.graph_lock)
         old_lock.save(old_lockfile)
 

--- a/conans/client/conan_api.py
+++ b/conans/client/conan_api.py
@@ -456,7 +456,7 @@ class ConanAPIV1(object):
                                     self.app.cache, self.app.out)
 
         self.app.out.info("Configuration:")
-        self.app.out.writeln(graph_info.profile.dumps())
+        self.app.out.writeln(graph_info.profile_host.dumps())
 
         self.app.cache.editable_packages.override(workspace.get_editable_dict())
 
@@ -1251,8 +1251,8 @@ def get_graph_info(profile_names, settings, options, env, cwd, install_folder, c
             graph_info.root = root_ref
         lockfile = lockfile if os.path.isfile(lockfile) else os.path.join(lockfile, LOCKFILE)
         graph_lock_file = GraphLockFile.load(lockfile, cache.config.revisions_enabled)
-        graph_info.profile = graph_lock_file.profile
-        graph_info.profile.process_settings(cache, preprocess=False)
+        graph_info.profile_host = graph_lock_file.profile_host
+        graph_info.profile_host.process_settings(cache, preprocess=False)
         graph_info.graph_lock = graph_lock_file.graph_lock
         output.info("Using lockfile: '{}'".format(lockfile))
         return graph_info
@@ -1266,8 +1266,8 @@ def get_graph_info(profile_names, settings, options, env, cwd, install_folder, c
         graph_info = None
     else:
         graph_lock_file = GraphLockFile.load(install_folder, cache.config.revisions_enabled)
-        graph_info.profile = graph_lock_file.profile
-        graph_info.profile.process_settings(cache, preprocess=False)
+        graph_info.profile_host = graph_lock_file.profile_host
+        graph_info.profile_host.process_settings(cache, preprocess=False)
 
     if profile_names or settings or options or env or not graph_info:
         if graph_info:
@@ -1281,7 +1281,7 @@ def get_graph_info(profile_names, settings, options, env, cwd, install_folder, c
         profile = profile_from_args(profile_names, settings, options, env, cwd, cache)
         profile.process_settings(cache)
         root_ref = ConanFileReference(name, version, user, channel, validate=False)
-        graph_info = GraphInfo(profile=profile, root_ref=root_ref)
+        graph_info = GraphInfo(profile_host=profile, root_ref=root_ref)
         # Preprocess settings and convert to real settings
     return graph_info
 

--- a/conans/client/graph/graph_builder.py
+++ b/conans/client/graph/graph_builder.py
@@ -20,7 +20,7 @@ class DepsGraphBuilder(object):
         self._resolver = resolver
         self._recorder = recorder
 
-    def load_graph(self, root_node, check_updates, update, remotes, processed_profile,
+    def load_graph(self, root_node, check_updates, update, remotes, profile_host,
                    graph_lock=None):
         check_updates = check_updates or update
         dep_graph = DepsGraph()
@@ -36,12 +36,12 @@ class DepsGraphBuilder(object):
         t1 = time.time()
         self._load_deps(dep_graph, root_node, Requirements(), None, None,
                         check_updates, update, remotes,
-                        processed_profile, graph_lock)
+                        profile_host, graph_lock)
         logger.debug("GRAPH: Time to load deps %s" % (time.time() - t1))
         return dep_graph
 
     def extend_build_requires(self, graph, node, build_requires_refs, check_updates, update,
-                              remotes, processed_profile, graph_lock):
+                              remotes, profile_host, graph_lock):
 
         # The options that will be defined in the node will be the real options values that have
         # been already propagated downstream from the dependency graph. This will override any
@@ -63,7 +63,7 @@ class DepsGraphBuilder(object):
             name = require.ref.name
             require.build_require = True
             self._handle_require(name, node, require, graph, check_updates, update,
-                                 remotes, processed_profile, new_reqs, new_options, graph_lock)
+                                 remotes, profile_host, new_reqs, new_options, graph_lock)
 
         new_nodes = set(n for n in graph.nodes if n.package_id is None)
         # This is to make sure that build_requires have precedence over the normal requires
@@ -99,7 +99,7 @@ class DepsGraphBuilder(object):
                                     list(conanfile.requires.values())))
 
     def _load_deps(self, dep_graph, node, down_reqs, down_ref, down_options,
-                   check_updates, update, remotes, processed_profile, graph_lock):
+                   check_updates, update, remotes, profile_host, graph_lock):
         """ expands the dependencies of the node, recursively
 
         param node: Node object to be expanded in this step
@@ -124,10 +124,10 @@ class DepsGraphBuilder(object):
             if require.override:
                 continue
             self._handle_require(name, node, require, dep_graph, check_updates, update,
-                                 remotes, processed_profile, new_reqs, new_options, graph_lock)
+                                 remotes, profile_host, new_reqs, new_options, graph_lock)
 
     def _handle_require(self, name, node, require, dep_graph, check_updates, update,
-                        remotes, processed_profile, new_reqs, new_options, graph_lock):
+                        remotes, profile_host, new_reqs, new_options, graph_lock):
         # Handle a requirement of a node. There are 2 possibilities
         #    node -(require)-> new_node (creates a new node in the graph)
         #    node -(require)-> previous (creates a diamond with a previously existing node)
@@ -145,7 +145,7 @@ class DepsGraphBuilder(object):
         if not previous or ((require.build_require or require.private) and not previous_closure):
             # new node, must be added and expanded (node -> new_node)
             new_node = self._create_new_node(node, dep_graph, require, name, check_updates, update,
-                                             remotes, processed_profile, graph_lock)
+                                             remotes, profile_host, graph_lock)
 
             # The closure of a new node starts with just itself
             new_node.public_closure = OrderedDict([(name, new_node)])
@@ -172,7 +172,7 @@ class DepsGraphBuilder(object):
 
             # RECURSION, keep expanding (depth-first) the new node
             self._load_deps(dep_graph, new_node, new_reqs, node.ref, new_options, check_updates,
-                            update, remotes, processed_profile, graph_lock)
+                            update, remotes, profile_host, graph_lock)
             if not require.private and not require.build_require:
                 node.transitive_closure.update(new_node.transitive_closure)
 
@@ -206,7 +206,7 @@ class DepsGraphBuilder(object):
             # configuration of upstream versions and options
             if not graph_lock and self._recurse(previous.public_closure, new_reqs, new_options):
                 self._load_deps(dep_graph, previous, new_reqs, node.ref, new_options, check_updates,
-                                update, remotes, processed_profile, graph_lock)
+                                update, remotes, profile_host, graph_lock)
 
     @staticmethod
     def _conflicting_references(previous_ref, new_ref, consumer_ref=None):
@@ -305,7 +305,7 @@ class DepsGraphBuilder(object):
         return new_options
 
     def _create_new_node(self, current_node, dep_graph, requirement, name_req,
-                         check_updates, update, remotes, processed_profile, graph_lock,
+                         check_updates, update, remotes, profile, graph_lock,
                          alias_ref=None):
         """ creates and adds a new node to the dependency graph
         """
@@ -323,7 +323,7 @@ class DepsGraphBuilder(object):
 
         locked_id = requirement.locked_id
         lock_python_requires = graph_lock.python_requires(locked_id) if locked_id else None
-        dep_conanfile = self._loader.load_conanfile(conanfile_path, processed_profile,
+        dep_conanfile = self._loader.load_conanfile(conanfile_path, profile,
                                                     ref=requirement.ref,
                                                     lock_python_requires=lock_python_requires)
         if recipe_status == RECIPE_EDITABLE:
@@ -336,7 +336,7 @@ class DepsGraphBuilder(object):
             dep_graph.aliased[alias_ref] = requirement.ref
             return self._create_new_node(current_node, dep_graph, requirement,
                                          name_req, check_updates, update,
-                                         remotes, processed_profile, graph_lock,
+                                         remotes, profile, graph_lock,
                                          alias_ref=alias_ref)
 
         logger.debug("GRAPH: new_node: %s" % str(new_ref))

--- a/conans/client/installer.py
+++ b/conans/client/installer.py
@@ -367,7 +367,7 @@ class BinaryInstaller(object):
                 write_generators(node.conanfile, build_folder, output)
                 save(os.path.join(build_folder, CONANINFO), node.conanfile.info.dumps())
                 output.info("Generated %s" % CONANINFO)
-                graph_info_node = GraphInfo(graph_info.profile, root_ref=node.ref)
+                graph_info_node = GraphInfo(graph_info.profile_host, root_ref=node.ref)
                 graph_info_node.options = node.conanfile.options.values
                 graph_info_node.graph_lock = graph_info.graph_lock
                 graph_info_node.save(build_folder)

--- a/conans/client/loader.py
+++ b/conans/client/loader.py
@@ -112,11 +112,11 @@ class ConanFileLoader(object):
         return conanfile
 
     @staticmethod
-    def _initialize_conanfile(conanfile, processed_profile):
+    def _initialize_conanfile(conanfile, profile):
         # Prepare the settings for the loaded conanfile
         # Mixing the global settings with the specified for that name if exist
-        tmp_settings = processed_profile.processed_settings.copy()
-        package_settings_values = processed_profile.package_settings_values
+        tmp_settings = profile.processed_settings.copy()
+        package_settings_values = profile.package_settings_values
         if package_settings_values:
             pkg_settings = package_settings_values.get(conanfile.name)
             if pkg_settings is None:
@@ -130,9 +130,9 @@ class ConanFileLoader(object):
             if pkg_settings:
                 tmp_settings.values = Values.from_list(pkg_settings)
 
-        conanfile.initialize(tmp_settings, processed_profile.env_values)
+        conanfile.initialize(tmp_settings, profile.env_values)
 
-    def load_consumer(self, conanfile_path, processed_profile, name=None, version=None, user=None,
+    def load_consumer(self, conanfile_path, profile_host, name=None, version=None, user=None,
                       channel=None, test=None, lock_python_requires=None):
         """ loads a conanfile.py in user space. Might have name/version or not
         """
@@ -150,14 +150,14 @@ class ConanFileLoader(object):
         conanfile.output.scope = conanfile.display_name
         conanfile.in_local_cache = False
         try:
-            self._initialize_conanfile(conanfile, processed_profile)
+            self._initialize_conanfile(conanfile, profile_host)
 
             # The consumer specific
             conanfile.develop = True
-            processed_profile.user_options.descope_options(conanfile.name)
-            conanfile.options.initialize_upstream(processed_profile.user_options,
+            profile_host.user_options.descope_options(conanfile.name)
+            conanfile.options.initialize_upstream(profile_host.user_options,
                                                   name=conanfile.name)
-            processed_profile.user_options.clear_unscoped_options()
+            profile_host.user_options.clear_unscoped_options()
 
             return conanfile
         except ConanInvalidConfiguration:
@@ -165,7 +165,7 @@ class ConanFileLoader(object):
         except Exception as e:  # re-raise with file name
             raise ConanException("%s: %s" % (conanfile_path, str(e)))
 
-    def load_conanfile(self, conanfile_path, processed_profile, ref, lock_python_requires=None):
+    def load_conanfile(self, conanfile_path, profile, ref, lock_python_requires=None):
         """ load a conanfile with a full reference, name, version, user and channel are obtained
         from the reference, not evaluated. Main way to load from the cache
         """
@@ -174,33 +174,33 @@ class ConanFileLoader(object):
         conanfile.name = ref.name
         conanfile.version = ref.version
 
-        if processed_profile.dev_reference and processed_profile.dev_reference == ref:
+        if profile.dev_reference and profile.dev_reference == ref:
             conanfile.develop = True
         try:
-            self._initialize_conanfile(conanfile, processed_profile)
+            self._initialize_conanfile(conanfile, profile)
             return conanfile
         except ConanInvalidConfiguration:
             raise
         except Exception as e:  # re-raise with file name
             raise ConanException("%s: %s" % (conanfile_path, str(e)))
 
-    def load_conanfile_txt(self, conan_txt_path, processed_profile, ref=None):
+    def load_conanfile_txt(self, conan_txt_path, profile_host, ref=None):
         if not os.path.exists(conan_txt_path):
             raise NotFoundException("Conanfile not found!")
 
         contents = load(conan_txt_path)
         path, basename = os.path.split(conan_txt_path)
         display_name = "%s (%s)" % (basename, ref) if ref and ref.name else basename
-        conanfile = self._parse_conan_txt(contents, path, display_name, processed_profile)
+        conanfile = self._parse_conan_txt(contents, path, display_name, profile_host)
         return conanfile
 
-    def _parse_conan_txt(self, contents, path, display_name, processed_profile):
+    def _parse_conan_txt(self, contents, path, display_name, profile):
         conanfile = ConanFile(self._output, self._runner, display_name)
-        conanfile.initialize(Settings(), processed_profile.env_values)
+        conanfile.initialize(Settings(), profile.env_values)
         # It is necessary to copy the settings, because the above is only a constraint of
         # conanfile settings, and a txt doesn't define settings. Necessary for generators,
         # as cmake_multi, that check build_type.
-        conanfile.settings = processed_profile.processed_settings.copy_values()
+        conanfile.settings = profile.processed_settings.copy_values()
 
         try:
             parser = ConanFileTextLoader(contents)
@@ -219,20 +219,20 @@ class ConanFileLoader(object):
 
         options = OptionsValues.loads(parser.options)
         conanfile.options.values = options
-        conanfile.options.initialize_upstream(processed_profile.user_options)
+        conanfile.options.initialize_upstream(profile.user_options)
 
         # imports method
         conanfile.imports = parser.imports_method(conanfile)
         return conanfile
 
-    def load_virtual(self, references, processed_profile, scope_options=True,
+    def load_virtual(self, references, profile_host, scope_options=True,
                      build_requires_options=None):
         # If user don't specify namespace in options, assume that it is
         # for the reference (keep compatibility)
         conanfile = ConanFile(self._output, self._runner, display_name="virtual")
-        conanfile.initialize(processed_profile.processed_settings.copy(),
-                             processed_profile.env_values)
-        conanfile.settings = processed_profile.processed_settings.copy_values()
+        conanfile.initialize(profile_host.processed_settings.copy(),
+                             profile_host.env_values)
+        conanfile.settings = profile_host.processed_settings.copy_values()
 
         for reference in references:
             conanfile.requires.add_ref(reference)
@@ -241,11 +241,11 @@ class ConanFileLoader(object):
         #   conan install zlib/1.2.8@lasote/stable -o shared=True
         if scope_options:
             assert len(references) == 1
-            processed_profile.user_options.scope_options(references[0].name)
+            profile_host.user_options.scope_options(references[0].name)
         if build_requires_options:
             conanfile.options.initialize_upstream(build_requires_options)
         else:
-            conanfile.options.initialize_upstream(processed_profile.user_options)
+            conanfile.options.initialize_upstream(profile_host.user_options)
 
         conanfile.generators = []  # remove the default txt generator
         return conanfile

--- a/conans/client/manager.py
+++ b/conans/client/manager.py
@@ -42,7 +42,7 @@ def deps_install(app, ref_or_path, install_folder, graph_info, remotes=None, bui
         generators.add("txt")  # Add txt generator by default
 
     out.info("Configuration:")
-    out.writeln(graph_info.profile.dumps())
+    out.writeln(graph_info.profile_host.dumps())
     deps_graph = graph_manager.load_graph(ref_or_path, create_reference, graph_info, build_modes,
                                           False, update, remotes, recorder)
     root_node = deps_graph.root
@@ -54,8 +54,8 @@ def deps_install(app, ref_or_path, install_folder, graph_info, remotes=None, bui
     print_graph(deps_graph, out)
 
     try:
-        if cross_building(graph_info.profile.processed_settings):
-            settings = get_cross_building_settings(graph_info.profile.processed_settings)
+        if cross_building(graph_info.profile_host.processed_settings):
+            settings = get_cross_building_settings(graph_info.profile_host.processed_settings)
             message = "Cross-build from '%s:%s' to '%s:%s'" % settings
             out.writeln(message, Color.BRIGHT_MAGENTA)
     except ConanException:  # Setting os doesn't exist

--- a/conans/model/graph_info.py
+++ b/conans/model/graph_info.py
@@ -14,11 +14,11 @@ GRAPH_INFO_FILE = "graph_info.json"
 
 class GraphInfo(object):
 
-    def __init__(self, profile=None, options=None, root_ref=None):
+    def __init__(self, profile_host=None, options=None, root_ref=None):
         # This field is a temporary hack, to store dependencies options for the local flow
         self.options = options
         self.root = root_ref
-        self.profile = profile
+        self.profile_host = profile_host
         self.graph_lock = None
 
     @staticmethod
@@ -55,11 +55,11 @@ class GraphInfo(object):
         save(p, serialized_graph_str)
 
         # A bit hacky, but to avoid repetition by now
-        graph_lock_file = GraphLockFile(self.profile, self.graph_lock)
+        graph_lock_file = GraphLockFile(self.profile_host, self.graph_lock)
         graph_lock_file.save(os.path.join(folder, LOCKFILE))
 
     def save_lock(self, lockfile):
-        graph_lock_file = GraphLockFile(self.profile, self.graph_lock)
+        graph_lock_file = GraphLockFile(self.profile_host, self.graph_lock)
         graph_lock_file.save(lockfile)
 
     def _dumps(self):

--- a/conans/model/graph_lock.py
+++ b/conans/model/graph_lock.py
@@ -18,8 +18,8 @@ LOCKFILE_VERSION = "0.1"
 
 class GraphLockFile(object):
 
-    def __init__(self, profile, graph_lock):
-        self.profile = profile
+    def __init__(self, profile_host, graph_lock):
+        self.profile_host = profile_host
         self.graph_lock = graph_lock
 
     @staticmethod
@@ -44,12 +44,12 @@ class GraphLockFile(object):
         if version:
             version = Version(version)
             # Do something with it, migrate, raise...
-        profile = graph_json["profile"]
+        profile_host = graph_json.get("profile_host") or graph_json["profile"]
         # FIXME: Reading private very ugly
-        profile, _ = _load_profile(profile, None, None)
+        profile_host, _ = _load_profile(profile_host, None, None)
         graph_lock = GraphLock.from_dict(graph_json["graph_lock"])
         graph_lock.revisions_enabled = revisions_enabled
-        graph_lock_file = GraphLockFile(profile, graph_lock)
+        graph_lock_file = GraphLockFile(profile_host, graph_lock)
         return graph_lock_file
 
     def save(self, path):
@@ -59,7 +59,7 @@ class GraphLockFile(object):
         save(path, serialized_graph_str)
 
     def dumps(self):
-        result = {"profile": self.profile.dumps(),
+        result = {"profile_host": self.profile_host.dumps(),
                   "graph_lock": self.graph_lock.as_dict(),
                   "version": LOCKFILE_VERSION}
         return json.dumps(result, indent=True)

--- a/conans/test/functional/old/create_package_test.py
+++ b/conans/test/functional/old/create_package_test.py
@@ -9,7 +9,7 @@ from conans.client.packager import run_package_method
 from conans.model.ref import ConanFileReference, PackageReference
 from conans.paths import CONANFILE, CONANINFO
 from conans.test.utils.test_files import hello_source_files
-from conans.test.utils.tools import TestBufferConanOutput, TestClient, test_processed_profile
+from conans.test.utils.tools import TestBufferConanOutput, TestClient, test_profile
 
 
 myconan1 = """
@@ -79,7 +79,7 @@ class ExporterTest(unittest.TestCase):
         shutil.copytree(reg_folder, build_folder)
 
         loader = ConanFileLoader(None, TestBufferConanOutput(), ConanPythonRequire(None, None))
-        conanfile = loader.load_consumer(conanfile_path, test_processed_profile())
+        conanfile = loader.load_consumer(conanfile_path, test_profile())
 
         run_package_method(conanfile, None, build_folder, build_folder, package_folder,
                            install_folder, Mock(), conanfile_path, ref, copy_info=True)

--- a/conans/test/unittests/client/conanfile_loader_test.py
+++ b/conans/test/unittests/client/conanfile_loader_test.py
@@ -19,7 +19,7 @@ from conans.model.profile import Profile
 from conans.model.requires import Requirements
 from conans.model.settings import Settings
 from conans.test.utils.test_files import temp_folder
-from conans.test.utils.tools import test_processed_profile,\
+from conans.test.utils.tools import test_profile,\
     TestBufferConanOutput
 from conans.util.files import save
 
@@ -44,7 +44,7 @@ class BasePackage(ConanFile):
         self.assertEqual(conan_file.short_paths, True)
 
         result = loader.load_consumer(conanfile_path,
-                                      processed_profile=test_processed_profile())
+                                      profile_host=test_profile())
         self.assertEqual(result.short_paths, True)
 
     def requires_init_test(self):
@@ -60,7 +60,7 @@ class MyTest(ConanFile):
         for requires in ("''", "[]", "()", "None"):
             save(conanfile_path, conanfile.format(requires))
             result = loader.load_consumer(conanfile_path,
-                                          processed_profile=test_processed_profile())
+                                          profile_host=test_profile())
             result.requirements()
             self.assertEqual("MyPkg/0.1@user/channel", str(result.requires))
 
@@ -136,7 +136,7 @@ OpenCV2:other_option=Cosa
         file_path = os.path.join(tmp_dir, "file.txt")
         save(file_path, file_content)
         loader = ConanFileLoader(None, TestBufferConanOutput(), None)
-        ret = loader.load_conanfile_txt(file_path, test_processed_profile())
+        ret = loader.load_conanfile_txt(file_path, test_profile())
         options1 = OptionsValues.loads("""OpenCV:use_python=True
 OpenCV:other_option=False
 OpenCV2:use_python2=1
@@ -167,7 +167,7 @@ OpenCV/2.4.104phil/stable
         save(file_path, file_content)
         loader = ConanFileLoader(None, TestBufferConanOutput(), None)
         with six.assertRaisesRegex(self, ConanException, "The reference has too many '/'"):
-            loader.load_conanfile_txt(file_path, test_processed_profile())
+            loader.load_conanfile_txt(file_path, test_profile())
 
         file_content = '''[requires]
 OpenCV/2.4.10@phil/stable111111111111111111111111111111111111111111111111111111111111111
@@ -179,7 +179,7 @@ OpenCV/bin/* - ./bin
         save(file_path, file_content)
         loader = ConanFileLoader(None, TestBufferConanOutput(), None)
         with six.assertRaisesRegex(self, ConanException, "is too long. Valid names must contain"):
-            loader.load_conanfile_txt(file_path, test_processed_profile())
+            loader.load_conanfile_txt(file_path, test_profile())
 
     def load_imports_arguments_test(self):
         file_content = '''
@@ -194,7 +194,7 @@ licenses, * -> ./licenses @ root_package=Pkg, folder=True, ignore_case=True, exc
         file_path = os.path.join(tmp_dir, "file.txt")
         save(file_path, file_content)
         loader = ConanFileLoader(None, TestBufferConanOutput(), None)
-        ret = loader.load_conanfile_txt(file_path, test_processed_profile())
+        ret = loader.load_conanfile_txt(file_path, test_profile())
 
         ret.copy = Mock()
         ret.imports()

--- a/conans/test/unittests/client/graph/version_ranges_graph_test.py
+++ b/conans/test/unittests/client/graph/version_ranges_graph_test.py
@@ -10,7 +10,7 @@ from conans.model.requires import Requirements
 from conans.test.unittests.model.transitive_reqs_test import GraphTest
 from conans.test.utils.tools import GenConanfile, TurboTestClient, TestServer, \
     NO_SETTINGS_PACKAGE_ID
-from conans.test.utils.tools import test_processed_profile
+from conans.test.utils.tools import test_profile
 
 
 def _get_nodes(graph, name):
@@ -48,10 +48,10 @@ class VersionRangesTest(GraphTest):
 
     def build_graph(self, content, update=False):
         self.loader._cached_conanfile_classes = {}
-        processed_profile = test_processed_profile()
-        root_conan = self.retriever.root(str(content), processed_profile)
+        profile = test_profile()
+        root_conan = self.retriever.root(str(content), profile)
         deps_graph = self.builder.load_graph(root_conan, update, update, self.remotes,
-                                             processed_profile)
+                                             profile)
         self.output.write("\n".join(self.resolver.output))
         return deps_graph
 

--- a/conans/test/unittests/model/fake_retriever.py
+++ b/conans/test/unittests/model/fake_retriever.py
@@ -13,10 +13,10 @@ class Retriever(object):
         self.loader = loader
         self.folder = temp_folder()
 
-    def root(self, content, processed_profile):
+    def root(self, content, profile):
         conan_path = os.path.join(self.folder, "data", "root.py")
         save(conan_path, content)
-        conanfile = self.loader.load_consumer(conan_path, processed_profile)
+        conanfile = self.loader.load_consumer(conan_path, profile)
         node = Node(None, conanfile, "rootpath")
         node.recipe = RECIPE_CONSUMER
         return node

--- a/conans/test/unittests/model/transitive_reqs_test.py
+++ b/conans/test/unittests/model/transitive_reqs_test.py
@@ -99,7 +99,7 @@ class GraphTest(unittest.TestCase):
         profile = test_profile(profile=profile)
         root_conan = self.retriever.root(str(content), profile)
         deps_graph = self.builder.load_graph(root_conan, False, False, self.remotes,
-                                             profile)
+                                             profile_host=profile)
 
         build_mode = BuildMode([], self.output)
         self.binaries_analyzer.evaluate_graph(deps_graph, build_mode=build_mode,
@@ -1474,7 +1474,7 @@ class ConsumerConan(ConanFile):
     def build_graph(self, content):
         profile = test_profile()
         root_conan = self.retriever.root(content, profile)
-        deps_graph = self.builder.load_graph(root_conan, False, False, None, profile)
+        deps_graph = self.builder.load_graph(root_conan, False, False, None, profile_host=profile)
         return deps_graph
 
     def test_avoid_duplicate_expansion(self):

--- a/conans/test/unittests/model/transitive_reqs_test.py
+++ b/conans/test/unittests/model/transitive_reqs_test.py
@@ -23,7 +23,7 @@ from conans.model.settings import Settings, bad_value_msg
 from conans.model.values import Values
 from conans.test.unittests.model.fake_retriever import Retriever
 from conans.test.utils.tools import (NO_SETTINGS_PACKAGE_ID, TestBufferConanOutput,
-                                     test_processed_profile, GenConanfile)
+                                     test_profile, GenConanfile)
 
 hello_ref = ConanFileReference.loads("Hello/1.2@user/testing")
 say_ref = ConanFileReference.loads("Say/0.1@user/testing")
@@ -96,10 +96,10 @@ class GraphTest(unittest.TestCase):
         profile = Profile()
         profile.processed_settings = full_settings
         profile.options = OptionsValues.loads(options)
-        processed_profile = test_processed_profile(profile=profile)
-        root_conan = self.retriever.root(str(content), processed_profile)
+        profile = test_profile(profile=profile)
+        root_conan = self.retriever.root(str(content), profile)
         deps_graph = self.builder.load_graph(root_conan, False, False, self.remotes,
-                                             processed_profile)
+                                             profile)
 
         build_mode = BuildMode([], self.output)
         self.binaries_analyzer.evaluate_graph(deps_graph, build_mode=build_mode,
@@ -1472,9 +1472,9 @@ class ConsumerConan(ConanFile):
         self.retriever.save_recipe(libd_ref, self.libd_content)
 
     def build_graph(self, content):
-        processed_profile = test_processed_profile()
-        root_conan = self.retriever.root(content, processed_profile)
-        deps_graph = self.builder.load_graph(root_conan, False, False, None, processed_profile)
+        profile = test_profile()
+        root_conan = self.retriever.root(content, profile)
+        deps_graph = self.builder.load_graph(root_conan, False, False, None, profile)
         return deps_graph
 
     def test_avoid_duplicate_expansion(self):
@@ -1849,10 +1849,10 @@ class ChatConan(ConanFile):
         self.retriever.save_recipe(say_ref, say_content)
         self.retriever.save_recipe(hello_ref, hello_content)
 
-        processed_profile = test_processed_profile(profile=profile)
-        root_conan = self.retriever.root(chat_content, processed_profile)
+        profile = test_profile(profile=profile)
+        root_conan = self.retriever.root(chat_content, profile)
         deps_graph = self.builder.load_graph(root_conan, False, False, None,
-                                             processed_profile=processed_profile)
+                                             profile_host=profile)
 
         build_mode = BuildMode([], self.output)
         self.binaries_analyzer.evaluate_graph(deps_graph, build_mode=build_mode,

--- a/conans/test/unittests/tools/files_patch_test.py
+++ b/conans/test/unittests/tools/files_patch_test.py
@@ -8,7 +8,7 @@ from conans.client.graph.python_requires import ConanPythonRequire
 from conans.client.loader import ConanFileLoader
 from conans.test.utils.test_files import temp_folder
 from conans.test.utils.tools import TestClient, TestBufferConanOutput,\
-    test_processed_profile
+    test_profile
 from conans.util.files import save, load
 
 base_conanfile = '''
@@ -268,7 +268,7 @@ Just the wind that smells fresh before the storm."""), foo_content)
 
     def _build_and_check(self, tmp_dir, file_path, text_file, msg):
         loader = ConanFileLoader(None, TestBufferConanOutput(), ConanPythonRequire(None, None))
-        ret = loader.load_consumer(file_path, test_processed_profile())
+        ret = loader.load_consumer(file_path, test_profile())
         curdir = os.path.abspath(os.curdir)
         os.chdir(tmp_dir)
         try:

--- a/conans/test/utils/tools.py
+++ b/conans/test/utils/tools.py
@@ -76,7 +76,7 @@ def inc_package_manifest_timestamp(cache, package_reference, inc_time):
     manifest.save(path)
 
 
-def test_processed_profile(profile=None, settings=None):
+def test_profile(profile=None, settings=None):
     if profile is None:
         profile = Profile()
     if profile.processed_settings is None:


### PR DESCRIPTION
Changelog: omit
Docs: omit

 * Remove `processed_profile`
 * Rename `profile` to `profile_host` in the places where it will make sense to have a `profile_build` too