### PR TITLE
Hotfix/complex search client

### DIFF
--- a/conans/client/rest/rest_client.py
+++ b/conans/client/rest/rest_client.py
@@ -110,7 +110,7 @@ class RestApiClient(object):
     def search_packages(self, reference, query):
         # Do not send the query to the server, as it will fail
         # https://github.com/conan-io/conan/issues/4951
-        package_infos = self._get_api().search_packages(reference, query)
+        package_infos = self._get_api().search_packages(reference, query=None)
         return filter_packages(query, package_infos)
 
     def remove_conanfile(self, ref):

--- a/conans/client/rest/rest_client.py
+++ b/conans/client/rest/rest_client.py
@@ -1,6 +1,4 @@
-from collections import defaultdict
-
-from conans import CHECKSUM_DEPLOY, REVISIONS, ONLY_V2, OAUTH_TOKEN, COMPLEX_SEARCH_CAPABILITY
+from conans import CHECKSUM_DEPLOY, REVISIONS, ONLY_V2, OAUTH_TOKEN
 from conans.client.rest.rest_client_v1 import RestV1Methods
 from conans.client.rest.rest_client_v2 import RestV2Methods
 from conans.errors import OnlyV2Available
@@ -110,11 +108,10 @@ class RestApiClient(object):
         return self._get_api().search(pattern, ignorecase)
 
     def search_packages(self, reference, query):
+        # Do not send the query to the server, as it will fail
+        # https://github.com/conan-io/conan/issues/4951
         package_infos = self._get_api().search_packages(reference, query)
-        if query and COMPLEX_SEARCH_CAPABILITY not in self._cached_capabilities.get(self.remote_url,
-                                                                                    []):
-            return filter_packages(query, package_infos)
-        return package_infos
+        return filter_packages(query, package_infos)
 
     def remove_conanfile(self, ref):
         return self._get_api().remove_conanfile(ref)

--- a/conans/test/functional/command/search_test.py
+++ b/conans/test/functional/command/search_test.py
@@ -8,14 +8,13 @@ from collections import OrderedDict
 
 from mock import patch
 
-from conans import COMPLEX_SEARCH_CAPABILITY, DEFAULT_REVISION_V1
+from conans import DEFAULT_REVISION_V1
 from conans.model.manifest import FileTreeManifest
 from conans.model.package_metadata import PackageMetadata
 from conans.model.ref import ConanFileReference, PackageReference
 from conans.paths import CONANINFO, EXPORT_FOLDER, PACKAGES_FOLDER
 from conans.server.revision_list import RevisionList
-from conans.test.utils.tools import TestClient, TestServer, NO_SETTINGS_PACKAGE_ID, TurboTestClient, \
-    GenConanfile
+from conans.test.utils.tools import TestClient, TestServer, NO_SETTINGS_PACKAGE_ID, GenConanfile
 from conans.util.dates import iso8601_to_str, from_timestamp_to_iso8601
 from conans.util.env_reader import get_env
 from conans.util.files import list_folder_subdirs, load
@@ -133,7 +132,7 @@ class SearchTest(unittest.TestCase):
     def setUp(self):
         self.servers = OrderedDict()
         self.servers["local"] = TestServer(server_capabilities=[])
-        self.servers["search_able"] = TestServer(server_capabilities=[COMPLEX_SEARCH_CAPABILITY])
+        self.servers["search_able"] = TestServer(server_capabilities=[])
 
         self.client = TestClient(servers=self.servers)
 


### PR DESCRIPTION
Changelog: Fix: Force ``conan search --query`` queries to be resolved always in the client to avoid servers failures due to unsupported syntax
Docs: omit

Close #4951

Backport of https://github.com/conan-io/conan/pull/5960 for the 1.19.3 minor