### PR TITLE
do not use overrides in public_deps in cmake

### DIFF
--- a/conans/client/installer.py
+++ b/conans/client/installer.py
@@ -466,7 +466,8 @@ class BinaryInstaller(object):
         conanfile.user_info = UserInfo()
 
         # Get deps_cpp_info from upstream nodes
-        public_deps = [name for name, req in conanfile.requires.items() if not req.private]
+        public_deps = [name for name, req in conanfile.requires.items() if not req.private
+                       and not req.override]
         conanfile.cpp_info.public_deps = public_deps
         # Once the node is build, execute package info, so it has access to the
         # package folder and artifacts


### PR DESCRIPTION
Changelog: Bugfix: Fixed bug when overriden dependencies that don't exist and make the CMake generated code crash
Docs: omit

Backport of https://github.com/conan-io/conan/pull/5945
Close #5680
