### PR TITLE
Fix/astroid less 2

### DIFF
--- a/conans/requirements.txt
+++ b/conans/requirements.txt
@@ -8,7 +8,7 @@ fasteners>=0.14.1
 six>=1.10.0
 node-semver==0.6.1
 distro>=1.0.2, <1.2.0
-pylint>=1.9.3,!=2.3.0, <2.4.0
+pylint>=1.9.3, <2.0
 future>=0.16.0, <0.19.0
 pygments>=2.0, <3.0
 astroid>=1.6.5, <2.0

--- a/conans/requirements.txt
+++ b/conans/requirements.txt
@@ -11,7 +11,7 @@ distro>=1.0.2, <1.2.0
 pylint>=1.9.3,!=2.3.0
 future>=0.16.0, <0.19.0
 pygments>=2.0, <3.0
-astroid>=1.6.5
+astroid>=1.6.5, <2.0
 deprecation>=2.0, <2.1
 tqdm>=4.28.1, <5
 Jinja2>=2.3, <3

--- a/conans/requirements.txt
+++ b/conans/requirements.txt
@@ -8,7 +8,7 @@ fasteners>=0.14.1
 six>=1.10.0
 node-semver==0.6.1
 distro>=1.0.2, <1.2.0
-pylint>=1.9.3,!=2.3.0
+pylint>=1.9.3,!=2.3.0, <2.4.0
 future>=0.16.0, <0.19.0
 pygments>=2.0, <3.0
 astroid>=1.6.5, <2.0


### PR DESCRIPTION
Changelog: Fix: Fixed range of pylint and astroid requirements to keep compatibility with python 2
Docs: omit


> pylint 2: Dropped support for Python 2. This release will work only on Python 3.4+.

> astroid 2.0 is currently available for Python 3 only. If you want Python 2 support, older versions of astroid will still supported until 2020.

#PYVERS: Windows@py27