### PR TITLE
Use cpp_info.name lower case in pkg-config generator when defined

### DIFF
--- a/conans/client/generators/pkg_config.py
+++ b/conans/client/generators/pkg_config.py
@@ -34,12 +34,12 @@ class PkgConfigGenerator(Generator):
     @property
     def content(self):
         ret = {}
-        for _, cpp_info in self.deps_build_info.dependencies:
-            ret["%s.pc" % cpp_info.name] = self.single_pc_file_contents(cpp_info)
+        for depname, cpp_info in self.deps_build_info.dependencies:
+            name = cpp_info.name.lower() if cpp_info.name != depname else depname
+            ret["%s.pc" % name] = self.single_pc_file_contents(name, cpp_info)
         return ret
 
-    def single_pc_file_contents(self, cpp_info):
-        name = cpp_info.name
+    def single_pc_file_contents(self, name, cpp_info):
         prefix_path = cpp_info.rootpath.replace("\\", "/")
         lines = ['prefix=%s' % prefix_path]
 

--- a/conans/test/unittests/client/generators/pkg_config_test.py
+++ b/conans/test/unittests/client/generators/pkg_config_test.py
@@ -22,8 +22,18 @@ class PkgGeneratorTest(unittest.TestCase):
         cpp_info.cflags.append("-Flag1=23")
         cpp_info.version = "1.3"
         cpp_info.description = "My cool description"
-
         conanfile.deps_cpp_info.update(cpp_info, ref.name)
+
+        ref = ConanFileReference.loads("MyPkg1/0.1@lasote/stables")
+        cpp_info = CppInfo("dummy_root_folder1")
+        cpp_info.name = "MYPKG1"
+        cpp_info.defines = ["MYDEFINE11"]
+        cpp_info.cflags.append("-Flag1=21")
+        cpp_info.version = "1.7"
+        cpp_info.description = "My other cool description"
+        cpp_info.public_deps = ["MyPkg"]
+        conanfile.deps_cpp_info.update(cpp_info, ref.name)
+
         ref = ConanFileReference.loads("MyPkg2/0.1@lasote/stables")
         cpp_info = CppInfo("dummy_root_folder2")
         cpp_info.name = ref.name
@@ -46,6 +56,18 @@ Description: Conan package: MyPkg2
 Version: 2.3
 Libs: -L${libdir} -sharedlinkflag -exelinkflag
 Cflags: -I${includedir} -cxxflag -DMYDEFINE2
+Requires: MyPkg
+""")
+
+        self.assertEqual(files["mypkg1.pc"], """prefix=dummy_root_folder1
+libdir=${prefix}/lib
+includedir=${prefix}/include
+
+Name: mypkg1
+Description: My other cool description
+Version: 1.7
+Libs: -L${libdir}
+Cflags: -I${includedir} -Flag1=21 -DMYDEFINE11
 Requires: MyPkg
 """)
 


### PR DESCRIPTION
Changelog: Bugfix: Use cpp_info.name lower case in pkg-config generator when defined
Docs: omit

- [x] Refer to the issue that supports this Pull Request: closes #5984 
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 

<sup>**Note:** By default this PR will skip the slower tests and will use a limited set of python versions. Check [here](https://github.com/conan-io/conan/blob/develop/.github/PR_INCREASE_TESTING.md) how to increase the testing level by writing some tags in the current PR body text.</sup>
