### PR TITLE
Fixed pylint requirements, py37

### DIFF
--- a/conans/requirements.txt
+++ b/conans/requirements.txt
@@ -8,10 +8,12 @@ fasteners>=0.14.1
 six>=1.10.0
 node-semver==0.6.1
 distro>=1.0.2, <1.2.0
-pylint>=1.9.3, <2.0
+pylint>=1.9.3, <2.0; python_version < '3'
+pylint>=2.0,!=2.3.0; python_version >= '3'
 future>=0.16.0, <0.19.0
 pygments>=2.0, <3.0
-astroid>=1.6.5, <2.0
+astroid>=1.6.5, <2.0; python_version < '3'
+astroid>=1.6.5; python_version >= '3'
 deprecation>=2.0, <2.1
 tqdm>=4.28.1, <5
 Jinja2>=2.3, <3

--- a/conans/requirements.txt
+++ b/conans/requirements.txt
@@ -13,7 +13,7 @@ pylint>=2.0,!=2.3.0; python_version >= '3'
 future>=0.16.0, <0.19.0
 pygments>=2.0, <3.0
 astroid>=1.6.5, <2.0; python_version < '3'
-astroid>=1.6.5; python_version >= '3'
+astroid>=2.0; python_version >= '3'
 deprecation>=2.0, <2.1
 tqdm>=4.28.1, <5
 Jinja2>=2.3, <3

--- a/conans/requirements.txt
+++ b/conans/requirements.txt
@@ -13,7 +13,7 @@ pylint>=2.0,!=2.3.0; python_version >= '3'
 future>=0.16.0, <0.19.0
 pygments>=2.0, <3.0
 astroid>=1.6.5, <2.0; python_version < '3'
-astroid>=2.0; python_version >= '3'
+astroid>=2.2.0; python_version >= '3'
 deprecation>=2.0, <2.1
 tqdm>=4.28.1, <5
 Jinja2>=2.3, <3


### PR DESCRIPTION
Changelog: omit
Docs: omit

the downgrade of pylint breaks linux py37. Introduced condition.