### PR TITLE
#5958 New tool: cppstd minimum version required

### DIFF
--- a/conans/client/tools/__init__.py
+++ b/conans/client/tools/__init__.py
@@ -15,6 +15,8 @@ from .pkg_config import *
 # noinspection PyUnresolvedReferences
 from .scm import *
 # noinspection PyUnresolvedReferences
+from .settings import *
+# noinspection PyUnresolvedReferences
 from .system_pm import *
 # noinspection PyUnresolvedReferences
 from .win import *

--- a/conans/client/tools/settings.py
+++ b/conans/client/tools/settings.py
@@ -1,7 +1,6 @@
 from conans.errors import ConanInvalidConfiguration
 from conans.client.build.cppstd_flags import cppstd_flag, cppstd_from_settings
 from conans.client.tools.oss import OSInfo
-from conans.model.conan_file import ConanFile
 
 
 def check_min_cppstd(conanfile, cppstd, gnu_extensions=False):
@@ -14,8 +13,8 @@ def check_min_cppstd(conanfile, cppstd, gnu_extensions=False):
     :param cppstd: Minimal cppstd version required
     :param gnu_extensions: GNU extension is required (e.g gnu17). This option ONLY works on Linux.
     """
-    assert isinstance(conanfile, ConanFile), "conanfile must be a ConanFile object"
     assert (cppstd is not None), "Cannot check invalid cppstd version"
+    assert (cppstd is not None), "conanfile must be a ConanFile object"
 
     def less_than(lhs, rhs):
         def extract_cpp_version(cppstd):

--- a/conans/client/tools/settings.py
+++ b/conans/client/tools/settings.py
@@ -32,8 +32,8 @@ def check_min_cppstd(conanfile, cppstd, gnu_extensions=False):
         rhs = add_millennium(extract_cpp_version(rhs))
         return lhs < rhs
 
-    def check_required_gnu_extension():
-        if not gnu_extensions or "gnu" in current_cppstd:
+    def check_required_gnu_extension(_cppstd):
+        if not gnu_extensions or "gnu" in _cppstd:
             return
         oss = conanfile.settings.get_safe("os")
         if not oss:
@@ -56,7 +56,7 @@ def check_min_cppstd(conanfile, cppstd, gnu_extensions=False):
 
     current_cppstd = deduced_cppstd()
 
-    check_required_gnu_extension()
+    check_required_gnu_extension(current_cppstd)
 
     if less_than(current_cppstd, cppstd):
         raise ConanInvalidConfiguration("Current cppstd ({}) is lower than the required C++ "

--- a/conans/client/tools/settings.py
+++ b/conans/client/tools/settings.py
@@ -16,7 +16,7 @@ def check_min_cppstd(conanfile, cppstd, gnu_extensions=False):
 
     :param conanfile: ConanFile instance with cppstd to be compared
     :param cppstd: Minimal cppstd version required
-    :param gnu_extensions: GNU extension is required (e.g gnu17). This option ONLY works on Linux.
+    :param gnu_extensions: GNU extension is required (e.g gnu17)
     """
     if not str(cppstd).isdigit():
         raise ConanException("cppstd parameter must be a number")

--- a/conans/client/tools/settings.py
+++ b/conans/client/tools/settings.py
@@ -3,8 +3,19 @@ from conans.client.build.cppstd_flags import cppstd_flag, cppstd_from_settings
 
 
 def cppstd_minimum_required(conanfile, cppstd_version):
+    """ Validate if current cppstd fits the minimal version required.
+
+        In case cppstd_version doesn't fit the minimal version, a
+        ConanInvalidConfiguration exception will be raised.
+
+    :param conanfile: ConanFile instance with cppstd
+    :param cppstd_version: Minimal cppstd version required
+    """
+    def extract_cpp_version(cppstd):
+        return int(str(cppstd).replace("gnu", ""))
+
     cppstd = cppstd_from_settings(conanfile.settings)
-    if cppstd and str(conanfile.settings.compiler.cppstd) < cppstd_version:
+    if cppstd and extract_cpp_version(cppstd) < extract_cpp_version(cppstd_version):
         raise ConanInvalidConfiguration("Current cppstd ({}) is lower than required c++ standard "
                                         "({}).".format(cppstd, cppstd_version))
     elif not cppstd_flag(conanfile.settings.compiler, conanfile.settings.compiler.version,

--- a/conans/client/tools/settings.py
+++ b/conans/client/tools/settings.py
@@ -15,6 +15,7 @@ def check_min_cppstd(conanfile, cppstd, gnu_extensions=False):
     """
     assert (cppstd is not None), "Cannot check invalid cppstd version"
     assert (conanfile is not None), "conanfile must be a ConanFile object"
+    assert (str(cppstd).isdigit()), "cppstd must be a number"
 
     def less_than(lhs, rhs):
         def extract_cpp_version(cppstd):

--- a/conans/client/tools/settings.py
+++ b/conans/client/tools/settings.py
@@ -1,0 +1,13 @@
+from conans.errors import ConanInvalidConfiguration
+from conans.client.build.cppstd_flags import cppstd_flag, cppstd_from_settings
+
+
+def cppstd_minimum_required(conanfile, cppstd_version):
+    cppstd = cppstd_from_settings(conanfile.settings)
+    if cppstd and str(conanfile.settings.compiler.cppstd) < cppstd_version:
+        raise ConanInvalidConfiguration("Current cppstd ({}) is lower than required c++ standard "
+                                        "({}).".format(cppstd, cppstd_version))
+    elif not cppstd_flag(conanfile.settings.compiler, conanfile.settings.compiler.version,
+                         cppstd_version):
+       raise ConanInvalidConfiguration("Current compiler does not not support the required "
+                                       "c++ standard ({}).".format(cppstd_version))

--- a/conans/client/tools/settings.py
+++ b/conans/client/tools/settings.py
@@ -1,24 +1,35 @@
 from conans.errors import ConanInvalidConfiguration
 from conans.client.build.cppstd_flags import cppstd_flag, cppstd_from_settings
+from conans.client.tools.oss import OSInfo
 
 
-def cppstd_minimum_required(conanfile, cppstd_version):
+def cppstd_minimum_required(conanfile, cppstd, gnu_extensions=False):
     """ Validate if current cppstd fits the minimal version required.
 
-        In case cppstd_version doesn't fit the minimal version, a
-        ConanInvalidConfiguration exception will be raised.
+        In case the current cppstd doesn't fit the minimal version required
+        by cppstd, a ConanInvalidConfiguration exception will be raised.
 
-    :param conanfile: ConanFile instance with cppstd
-    :param cppstd_version: Minimal cppstd version required
+    :param conanfile: ConanFile instance with cppstd to be compared
+    :param cppstd: Minimal cppstd version required
+    :param gnu_extensions: GNU extension is required (e.g gnu17). This option ONLY works on Linux.
     """
     def extract_cpp_version(cppstd):
         return int(str(cppstd).replace("gnu", ""))
 
-    cppstd = cppstd_from_settings(conanfile.settings)
-    if cppstd and extract_cpp_version(cppstd) < extract_cpp_version(cppstd_version):
+    current_cppstd = cppstd_from_settings(conanfile.settings)
+    if current_cppstd and gnu_extensions and "gnu" not in current_cppstd and OSInfo().is_linux:
+        raise ConanInvalidConfiguration("Current cppstd ({}) does not have GNU extensions, which is"
+                                        " required on Linux platform.".format(current_cppstd))
+    elif current_cppstd and extract_cpp_version(current_cppstd) < extract_cpp_version(cppstd):
         raise ConanInvalidConfiguration("Current cppstd ({}) is lower than required c++ standard "
-                                        "({}).".format(cppstd, cppstd_version))
-    elif not cppstd_flag(conanfile.settings.compiler, conanfile.settings.compiler.version,
-                         cppstd_version):
-        raise ConanInvalidConfiguration("Current compiler does not not support the required "
-                                        "c++ standard ({}).".format(cppstd_version))
+                                        "({}).".format(current_cppstd, cppstd))
+    else:
+        if OSInfo().is_linux and gnu_extensions and "gnu" not in cppstd:
+            cppstd = "gnu" + cppstd
+        result = cppstd_flag(conanfile.settings.compiler, conanfile.settings.compiler.version,
+                             cppstd)
+        if not result:
+            raise ConanInvalidConfiguration("Current compiler does not support the required "
+                                            "c++ standard ({}).".format(cppstd))
+        elif OSInfo().is_linux and gnu_extensions and "gnu" not in result:
+            raise ConanInvalidConfiguration("Current compiler does not support GNU extensions.")

--- a/conans/client/tools/settings.py
+++ b/conans/client/tools/settings.py
@@ -1,4 +1,4 @@
-from conans.errors import ConanInvalidConfiguration
+from conans.errors import ConanInvalidConfiguration, ConanException
 from conans.client.build.cppstd_flags import cppstd_flag, cppstd_from_settings
 from conans.client.tools.oss import OSInfo
 
@@ -13,9 +13,12 @@ def check_min_cppstd(conanfile, cppstd, gnu_extensions=False):
     :param cppstd: Minimal cppstd version required
     :param gnu_extensions: GNU extension is required (e.g gnu17). This option ONLY works on Linux.
     """
-    assert (cppstd is not None), "Cannot check invalid cppstd version"
-    assert (conanfile is not None), "conanfile must be a ConanFile object"
-    assert (str(cppstd).isdigit()), "cppstd must be a number"
+    if not cppstd:
+        raise ConanException("Cannot check invalid cppstd version")
+    if not conanfile:
+        raise ConanException("conanfile must be a ConanFile object")
+    if not str(cppstd).isdigit():
+        raise ConanException("cppstd must be a number")
 
     def less_than(lhs, rhs):
         def extract_cpp_version(cppstd):

--- a/conans/client/tools/settings.py
+++ b/conans/client/tools/settings.py
@@ -33,3 +33,18 @@ def cppstd_minimum_required(conanfile, cppstd, gnu_extensions=False):
                                             "c++ standard ({}).".format(cppstd))
         elif OSInfo().is_linux and gnu_extensions and "gnu" not in result:
             raise ConanInvalidConfiguration("Current compiler does not support GNU extensions.")
+
+
+def valid_minimum_cppstd(conanfile, cppstd, gnu_extensions=False):
+    """ Validate if current cppstd fits the minimal version required.
+
+    :param conanfile: ConanFile instance with cppstd to be compared
+    :param cppstd: Minimal cppstd version required
+    :param gnu_extensions: GNU extension is required (e.g gnu17). This option ONLY works on Linux.
+    :return: True, if current cppstd matches the required cppstd version. Otherwise, False.
+    """
+    try:
+        cppstd_minimum_required(conanfile, cppstd, gnu_extensions)
+    except ConanInvalidConfiguration:
+        return False
+    return True

--- a/conans/client/tools/settings.py
+++ b/conans/client/tools/settings.py
@@ -14,7 +14,7 @@ def cppstd_minimum_required(conanfile, cppstd, gnu_extensions=False):
     :param gnu_extensions: GNU extension is required (e.g gnu17). This option ONLY works on Linux.
     """
     def extract_cpp_version(cppstd):
-        return int(str(cppstd).replace("gnu", ""))
+        return str(cppstd).replace("gnu", "")
 
     current_cppstd = cppstd_from_settings(conanfile.settings)
     if current_cppstd and gnu_extensions and "gnu" not in current_cppstd and OSInfo().is_linux:

--- a/conans/client/tools/settings.py
+++ b/conans/client/tools/settings.py
@@ -35,7 +35,7 @@ def check_min_cppstd(conanfile, cppstd, gnu_extensions=False):
             raise ConanInvalidConfiguration("Current compiler does not support GNU extensions.")
 
 
-def valid_minimum_cppstd(conanfile, cppstd, gnu_extensions=False):
+def valid_min_cppstd(conanfile, cppstd, gnu_extensions=False):
     """ Validate if current cppstd fits the minimal version required.
 
     :param conanfile: ConanFile instance with cppstd to be compared

--- a/conans/client/tools/settings.py
+++ b/conans/client/tools/settings.py
@@ -32,7 +32,7 @@ def check_min_cppstd(conanfile, cppstd, gnu_extensions=False):
         raise ConanInvalidConfiguration("Current cppstd ({}) does not have GNU extensions, which is"
                                         " required on Linux platform.".format(current_cppstd))
     elif current_cppstd and less_than(current_cppstd, cppstd):
-        raise ConanInvalidConfiguration("Current cppstd ({}) is lower than required c++ standard "
+        raise ConanInvalidConfiguration("Current cppstd ({}) is lower than required C++ standard "
                                         "({}).".format(current_cppstd, cppstd))
     else:
         if OSInfo().is_linux and gnu_extensions and "gnu" not in cppstd:
@@ -42,7 +42,7 @@ def check_min_cppstd(conanfile, cppstd, gnu_extensions=False):
                              cppstd)
         if not result:
             raise ConanInvalidConfiguration("Current compiler does not support the required "
-                                            "c++ standard ({}).".format(cppstd))
+                                            "C++ standard ({}).".format(cppstd))
         elif OSInfo().is_linux and gnu_extensions and "gnu" not in result:
             raise ConanInvalidConfiguration("Current compiler does not support GNU extensions.")
 

--- a/conans/client/tools/settings.py
+++ b/conans/client/tools/settings.py
@@ -4,7 +4,7 @@ from conans.client.tools.oss import OSInfo
 
 
 def check_min_cppstd(conanfile, cppstd, gnu_extensions=False):
-    """ Validate if current cppstd fits the minimal version required.
+    """ Check if current cppstd fits the minimal version required.
 
         In case the current cppstd doesn't fit the minimal version required
         by cppstd, a ConanInvalidConfiguration exception will be raised.
@@ -44,7 +44,7 @@ def valid_min_cppstd(conanfile, cppstd, gnu_extensions=False):
     :return: True, if current cppstd matches the required cppstd version. Otherwise, False.
     """
     try:
-        cppstd_minimum_required(conanfile, cppstd, gnu_extensions)
+        check_min_cppstd(conanfile, cppstd, gnu_extensions)
     except ConanInvalidConfiguration:
         return False
     return True

--- a/conans/client/tools/settings.py
+++ b/conans/client/tools/settings.py
@@ -14,7 +14,7 @@ def check_min_cppstd(conanfile, cppstd, gnu_extensions=False):
     :param gnu_extensions: GNU extension is required (e.g gnu17). This option ONLY works on Linux.
     """
     assert (cppstd is not None), "Cannot check invalid cppstd version"
-    assert (cppstd is not None), "conanfile must be a ConanFile object"
+    assert (conanfile is not None), "conanfile must be a ConanFile object"
 
     def less_than(lhs, rhs):
         def extract_cpp_version(cppstd):

--- a/conans/client/tools/settings.py
+++ b/conans/client/tools/settings.py
@@ -9,5 +9,5 @@ def cppstd_minimum_required(conanfile, cppstd_version):
                                         "({}).".format(cppstd, cppstd_version))
     elif not cppstd_flag(conanfile.settings.compiler, conanfile.settings.compiler.version,
                          cppstd_version):
-       raise ConanInvalidConfiguration("Current compiler does not not support the required "
-                                       "c++ standard ({}).".format(cppstd_version))
+        raise ConanInvalidConfiguration("Current compiler does not not support the required "
+                                        "c++ standard ({}).".format(cppstd_version))

--- a/conans/client/tools/settings.py
+++ b/conans/client/tools/settings.py
@@ -31,8 +31,14 @@ def check_min_cppstd(conanfile, cppstd, gnu_extensions=False):
         rhs = add_millennium(extract_cpp_version(rhs))
         return lhs < rhs
 
+    def is_linux(conanfile):
+        os = conanfile.settings.get_safe("os_build")
+        if os is not None:
+            return os == "Linux"
+        return OSInfo().is_linux
+
     current_cppstd = cppstd_from_settings(conanfile.settings)
-    if current_cppstd and gnu_extensions and "gnu" not in current_cppstd and OSInfo().is_linux:
+    if current_cppstd and gnu_extensions and "gnu" not in current_cppstd and is_linux(conanfile):
         raise ConanInvalidConfiguration("Current cppstd ({}) does not have GNU extensions, which is"
                                         " required on Linux platform.".format(current_cppstd))
     elif current_cppstd and less_than(current_cppstd, cppstd):

--- a/conans/client/tools/settings.py
+++ b/conans/client/tools/settings.py
@@ -28,20 +28,14 @@ def check_min_cppstd(conanfile, cppstd, gnu_extensions=False):
         def add_millennium(_cppstd):
             return "19%s" % _cppstd if _cppstd == "98" else "20%s" % _cppstd
 
-        def extract_revision(_cppstd):
-            return {"1z": "17",
-                    "1x": "11",
-                    "1y": "14",
-                    "0x": "11"}.get(_cppstd, _cppstd)
-
-        lhs = add_millennium(extract_cpp_version(extract_revision(lhs)))
-        rhs = add_millennium(extract_cpp_version(extract_revision(rhs)))
+        lhs = add_millennium(extract_cpp_version(lhs))
+        rhs = add_millennium(extract_cpp_version(rhs))
         return lhs < rhs
 
     def check_required_gnu_extension(_cppstd):
         if not gnu_extensions or "gnu" in _cppstd:
             return
-        oss = conanfile.settings.get_safe("os") or conanfile.settings.get_safe("os_build")
+        oss = conanfile.settings.get_safe("os")
         if not oss:
             raise ConanException("The 'os' setting is not declared and it is needed to "
                                  "check if the gnu extension is required.")

--- a/conans/client/tools/settings.py
+++ b/conans/client/tools/settings.py
@@ -3,7 +3,7 @@ from conans.client.build.cppstd_flags import cppstd_flag, cppstd_from_settings
 from conans.client.tools.oss import OSInfo
 
 
-def cppstd_minimum_required(conanfile, cppstd, gnu_extensions=False):
+def check_min_cppstd(conanfile, cppstd, gnu_extensions=False):
     """ Validate if current cppstd fits the minimal version required.
 
         In case the current cppstd doesn't fit the minimal version required

--- a/conans/client/tools/settings.py
+++ b/conans/client/tools/settings.py
@@ -33,13 +33,7 @@ def check_min_cppstd(conanfile, cppstd, gnu_extensions=False):
         return lhs < rhs
 
     def check_required_gnu_extension(_cppstd):
-        if not gnu_extensions or "gnu" in _cppstd:
-            return
-        oss = conanfile.settings.get_safe("os")
-        if not oss:
-            raise ConanException("The 'os' setting is not declared and it is needed to "
-                                 "check if the gnu extension is required.")
-        if oss == "Linux":
+        if gnu_extensions and "gnu" not in _cppstd:
             raise ConanInvalidConfiguration("The cppstd GNU extension is required")
 
     def deduced_cppstd():

--- a/conans/test/functional/tools/cppstd_minimum_version_test.py
+++ b/conans/test/functional/tools/cppstd_minimum_version_test.py
@@ -1,4 +1,5 @@
 import unittest
+from parameterized import parameterized
 from textwrap import dedent
 
 from conans.test.utils.tools import TestClient
@@ -33,32 +34,36 @@ class CppStdMinimumVersionTests(unittest.TestCase):
         self.client = TestClient()
         self.client.save({"conanfile.py": CppStdMinimumVersionTests.CONANFILE})
 
-    def test_cppstd_from_settings(self):
-        profile = CppStdMinimumVersionTests.PROFILE.replace("{}", "compiler.cppstd=17")
+    @parameterized.expand(["17", "gnu17"])
+    def test_cppstd_from_settings(self, cppstd):
+        profile = CppStdMinimumVersionTests.PROFILE.replace("{}", "compiler.cppstd=%s" % cppstd)
         self.client.save({"myprofile":  profile})
         self.client.run("create . user/channel -pr myprofile")
         self.assertIn("valid standard", self.client.out)
 
-    def test_invalid_cppstd_from_settings(self):
-        profile = CppStdMinimumVersionTests.PROFILE.replace("{}", "compiler.cppstd=11")
+    @parameterized.expand(["11", "gnu11"])
+    def test_invalid_cppstd_from_settings(self, cppstd):
+        profile = CppStdMinimumVersionTests.PROFILE.replace("{}", "compiler.cppstd=%s" % cppstd)
         self.client.save({"myprofile": profile})
         self.client.run("create . user/channel -pr myprofile", assert_error=True)
-        self.assertIn("Invalid configuration: Current cppstd (11) is lower than required c++ "
-                      "standard (17).", self.client.out)
+        self.assertIn("Invalid configuration: Current cppstd (%s) is lower than required c++ "
+                      "standard (17)." % cppstd, self.client.out)
 
-    def test_cppstd_from_arguments(self):
+    @parameterized.expand(["17", "gnu17"])
+    def test_cppstd_from_arguments(self, cppstd):
         profile = CppStdMinimumVersionTests.PROFILE.replace("{}", "")
         self.client.save({"myprofile": profile})
-        self.client.run("create . user/channel -pr myprofile -s compiler.cppstd=17")
+        self.client.run("create . user/channel -pr myprofile -s compiler.cppstd=%s" % cppstd)
         self.assertIn("valid standard", self.client.out)
 
-    def test_invalid_cppstd_from_arguments(self):
+    @parameterized.expand(["11", "gnu11"])
+    def test_invalid_cppstd_from_arguments(self, cppstd):
         profile = CppStdMinimumVersionTests.PROFILE.replace("{}", "")
         self.client.save({"myprofile": profile})
-        self.client.run("create . user/channel --pr myprofile -s compiler.cppstd=11",
+        self.client.run("create . user/channel --pr myprofile -s compiler.cppstd=%s" % cppstd,
                         assert_error=True)
-        self.assertIn("Invalid configuration: Current cppstd (11) is lower than required c++ "
-                      "standard (17).", self.client.out)
+        self.assertIn("Invalid configuration: Current cppstd (%s) is lower than required c++ "
+                      "standard (17)." % cppstd, self.client.out)
 
     def test_cppstd_from_compiler(self):
         profile = CppStdMinimumVersionTests.PROFILE.replace("{}", "")

--- a/conans/test/functional/tools/cppstd_minimum_version_test.py
+++ b/conans/test/functional/tools/cppstd_minimum_version_test.py
@@ -12,7 +12,7 @@ class CppStdMinimumVersionTests(unittest.TestCase):
     CONANFILE = dedent("""
         import os
         from conans import ConanFile
-        from conans.tools import cppstd_minimum_required
+        from conans.tools import check_min_cppstd
 
         class Fake(ConanFile):
             name = "fake"
@@ -20,7 +20,7 @@ class CppStdMinimumVersionTests(unittest.TestCase):
             settings = "compiler"
 
             def configure(self):
-                cppstd_minimum_required(self, "17", False)
+                check_min_cppstd(self, "17", False)
                 self.output.info("valid standard")
         """)
 
@@ -159,7 +159,7 @@ class ValidMinimumCppSTDTests(unittest.TestCase):
     CONANFILE = dedent("""
         import os
         from conans import ConanFile
-        from conans.tools import valid_minimum_cppstd
+        from conans.tools import valid_min_cppstd
 
         class Fake(ConanFile):
             name = "fake"
@@ -167,7 +167,7 @@ class ValidMinimumCppSTDTests(unittest.TestCase):
             settings = "compiler"
 
             def configure(self):
-                if valid_minimum_cppstd(self, "17", False):
+                if valid_min_cppstd(self, "17", False):
                     self.output.info("effective standard")
                 else:
                     self.output.error("invalid standard")

--- a/conans/test/functional/tools/cppstd_minimum_version_test.py
+++ b/conans/test/functional/tools/cppstd_minimum_version_test.py
@@ -152,3 +152,144 @@ class CppStdMinimumVersionTests(unittest.TestCase):
                 self.client.run("create . user/channel -pr myprofile", assert_error=True)
                 self.assertIn("Invalid configuration: Current compiler does not support the "
                               "required c++ standard (%s)." % expected, self.client.out)
+
+
+class ValidMinimumCppSTDTests(unittest.TestCase):
+
+    CONANFILE = dedent("""
+        import os
+        from conans import ConanFile
+        from conans.tools import valid_minimum_cppstd
+
+        class Fake(ConanFile):
+            name = "fake"
+            version = "0.2"
+            settings = "compiler"
+
+            def configure(self):
+                if valid_minimum_cppstd(self, "17", False):
+                    self.output.info("effective standard")
+                else:
+                    self.output.error("invalid standard")
+        """)
+
+    PROFILE = dedent("""
+        [settings]
+        compiler=gcc
+        compiler.version=9
+        compiler.libcxx=libstdc++
+        {}
+        """)
+
+    def setUp(self):
+        self.client = TestClient()
+        self.client.save({"conanfile.py": ValidMinimumCppSTDTests.CONANFILE})
+
+    @parameterized.expand(["17", "gnu17"])
+    def test_cppstd_from_settings(self, cppstd):
+        profile = ValidMinimumCppSTDTests.PROFILE.replace("{}", "compiler.cppstd=%s" % cppstd)
+        self.client.save({"myprofile":  profile})
+        self.client.run("create . user/channel -pr myprofile")
+        self.assertIn("effective standard", self.client.out)
+
+    @parameterized.expand(["11", "gnu11"])
+    def test_invalid_cppstd_from_settings(self, cppstd):
+        profile = ValidMinimumCppSTDTests.PROFILE.replace("{}", "compiler.cppstd=%s" % cppstd)
+        self.client.save({"myprofile": profile})
+        self.client.run("create . user/channel -pr myprofile")
+        self.assertIn("invalid standard", self.client.out)
+
+    @parameterized.expand(["17", "gnu17"])
+    def test_cppstd_from_arguments(self, cppstd):
+        profile = ValidMinimumCppSTDTests.PROFILE.replace("{}", "")
+        self.client.save({"myprofile": profile})
+        self.client.run("create . user/channel -pr myprofile -s compiler.cppstd=%s" % cppstd)
+        self.assertIn("effective standard", self.client.out)
+
+    @parameterized.expand(["11", "gnu11"])
+    def test_invalid_cppstd_from_arguments(self, cppstd):
+        profile = ValidMinimumCppSTDTests.PROFILE.replace("{}", "")
+        self.client.save({"myprofile": profile})
+        self.client.run("create . user/channel --pr myprofile -s compiler.cppstd=%s" % cppstd)
+        self.assertIn("invalid standard", self.client.out)
+
+    def test_cppstd_from_compiler(self):
+        profile = ValidMinimumCppSTDTests.PROFILE.replace("{}", "")
+        self.client.save({"myprofile": profile})
+        self.client.run("create . user/channel -pr myprofile")
+        self.assertIn("effective standard", self.client.out)
+
+    def test_invalid_cppstd_from_compiler(self):
+        profile = ValidMinimumCppSTDTests.PROFILE.replace("{}", "").replace("9", "4.9")
+        self.client.save({"myprofile": profile})
+        self.client.run("create . user/channel -pr myprofile")
+        self.assertIn("invalid standard", self.client.out)
+
+    @parameterized.expand([["gnu17", "Linux"], ["gnu17", "Windows"]])
+    def test_valid_gnu_extensions_from_settings(self, cppstd, os):
+        self.client.save({"conanfile.py": ValidMinimumCppSTDTests.CONANFILE.replace("False",
+                                                                                      "True")})
+        with mock.patch("platform.system", mock.MagicMock(return_value=os)):
+            with mock.patch.object(OSInfo, '_get_linux_distro_info'):
+                profile = ValidMinimumCppSTDTests.PROFILE.replace("{}", "compiler.cppstd=%s" %
+                                                                    cppstd)
+                self.client.save({"myprofile": profile})
+                self.client.run("create . user/channel -pr myprofile")
+                self.assertIn("effective standard", self.client.out)
+
+    @parameterized.expand([
+        ["17", "Linux", "invalid standard"],
+        ["17", "Windows", "effective standard"]])
+    def test_invalid_gnu_extensions_from_settings(self, cppstd, system, expected):
+        self.client.save({"conanfile.py": ValidMinimumCppSTDTests.CONANFILE.replace("False",
+                                                                                      "True")})
+        with mock.patch("platform.system", mock.MagicMock(return_value=system)):
+            with mock.patch.object(OSInfo, '_get_linux_distro_info'):
+                profile = ValidMinimumCppSTDTests.PROFILE.replace("{}", "compiler.cppstd=%s" %
+                                                                    cppstd)
+                self.client.save({"myprofile": profile})
+                self.client.run("create . user/channel -pr myprofile")
+                self.assertIn(expected, self.client.out)
+
+    @parameterized.expand([["gnu17", "Linux"], ["gnu17", "Windows"]])
+    def test_gnu_extensions_from_arguments(self, cppstd, os):
+        self.client.save({"conanfile.py": ValidMinimumCppSTDTests.CONANFILE.replace("False",
+                                                                                      "True")})
+        self.client.save({"myprofile": ValidMinimumCppSTDTests.PROFILE.replace("{}", "")})
+        with mock.patch("platform.system", mock.MagicMock(return_value=os)):
+            with mock.patch.object(OSInfo, '_get_linux_distro_info'):
+                self.client.run("create . user/channel -pr myprofile -s compiler.cppstd=%s" %
+                                cppstd)
+                self.assertIn("effective standard", self.client.out)
+
+    @parameterized.expand([["17", "Linux", "invalid standard"],
+                          ["17", "Windows", "effective standard"]])
+    def test_invalid_gnu_extensions_from_arguments(self, cppstd, os, expected):
+        self.client.save({"conanfile.py": ValidMinimumCppSTDTests.CONANFILE.replace("False",
+                                                                                    "True")})
+        self.client.save({"myprofile": ValidMinimumCppSTDTests.PROFILE.replace("{}", "")})
+        with mock.patch("platform.system", mock.MagicMock(return_value=os)):
+            with mock.patch.object(OSInfo, '_get_linux_distro_info'):
+                self.client.run("create . user/channel --pr myprofile -s compiler.cppstd=%s" %
+                                cppstd)
+                self.assertIn(expected, self.client.out)
+
+    def test_gnu_extensions_from_compiler(self):
+        self.client.save({"conanfile.py": ValidMinimumCppSTDTests.CONANFILE.replace("False",
+                                                                                    "True")})
+        self.client.save({"myprofile": CppStdMinimumVersionTests.PROFILE.replace("{}", "")})
+        with mock.patch("platform.system", mock.MagicMock(return_value="Linux")):
+            with mock.patch.object(OSInfo, '_get_linux_distro_info'):
+                self.client.run("create . user/channel -pr myprofile")
+                self.assertIn("effective standard", self.client.out)
+
+    @parameterized.expand(["Linux", "Windows"])
+    def test_invalid_gnu_extensions_from_compiler(self, os):
+        self.client.save({"conanfile.py": ValidMinimumCppSTDTests.CONANFILE.replace("False",
+                                                                                      "True")})
+        self.client.save({"myprofile": ValidMinimumCppSTDTests.PROFILE.replace("{}", "")
+                                                                      .replace("9", "4.9")})
+        with mock.patch("platform.system", mock.MagicMock(return_value=os)):
+            with mock.patch.object(OSInfo, '_get_linux_distro_info'):
+                self.client.run("create . user/channel -pr myprofile")
+                self.assertIn("invalid standard", self.client.out)

--- a/conans/test/functional/tools/cppstd_minimum_version_test.py
+++ b/conans/test/functional/tools/cppstd_minimum_version_test.py
@@ -47,5 +47,5 @@ class CppStdMinimumVersionTests(unittest.TestCase):
         profile = CppStdMinimumVersionTests.PROFILE.replace("{}", "compiler.cppstd=%s" % cppstd)
         self.client.save({"myprofile": profile})
         self.client.run("create . user/channel -pr myprofile", assert_error=True)
-        self.assertIn("Invalid configuration: Current cppstd (%s) is lower than required c++ "
+        self.assertIn("Invalid configuration: Current cppstd (%s) is lower than required C++ "
                       "standard (17)." % cppstd, self.client.out)

--- a/conans/test/functional/tools/cppstd_minimum_version_test.py
+++ b/conans/test/functional/tools/cppstd_minimum_version_test.py
@@ -1,0 +1,74 @@
+import unittest
+from textwrap import dedent
+
+from conans.test.utils.tools import TestClient
+
+
+class CppStdMinimumVersionTests(unittest.TestCase):
+
+    CONANFILE = dedent("""
+        import os
+        from conans import ConanFile
+        from conans.tools import cppstd_minimum_required
+
+        class Fake(ConanFile):
+            name = "fake"
+            version = "0.1"
+            settings = "compiler"
+
+            def configure(self):
+                cppstd_minimum_required(self, "17")
+                self.output.info("valid standard")
+        """)
+
+    PROFILE = dedent("""
+        [settings]
+        compiler=gcc
+        compiler.version=9
+        compiler.libcxx=libstdc++
+        {}
+        """)
+
+    def setUp(self):
+        self.client = TestClient()
+        self.client.save({"conanfile.py": CppStdMinimumVersionTests.CONANFILE})
+
+    def test_cppstd_from_settings(self):
+        profile = CppStdMinimumVersionTests.PROFILE.replace("{}", "compiler.cppstd=17")
+        self.client.save({"myprofile":  profile})
+        self.client.run("create . user/channel -pr myprofile")
+        self.assertIn("valid standard", self.client.out)
+
+    def test_invalid_cppstd_from_settings(self):
+        profile = CppStdMinimumVersionTests.PROFILE.replace("{}", "compiler.cppstd=11")
+        self.client.save({"myprofile": profile})
+        self.client.run("create . user/channel -pr myprofile", assert_error=True)
+        self.assertIn("Invalid configuration: Current cppstd (11) is lower than required c++ "
+                      "standard (17).", self.client.out)
+
+    def test_cppstd_from_arguments(self):
+        profile = CppStdMinimumVersionTests.PROFILE.replace("{}", "")
+        self.client.save({"myprofile": profile})
+        self.client.run("create . user/channel -pr myprofile -s compiler.cppstd=17")
+        self.assertIn("valid standard", self.client.out)
+
+    def test_invalid_cppstd_from_arguments(self):
+        profile = CppStdMinimumVersionTests.PROFILE.replace("{}", "")
+        self.client.save({"myprofile": profile})
+        self.client.run("create . user/channel --pr myprofile -s compiler.cppstd=11",
+                        assert_error=True)
+        self.assertIn("Invalid configuration: Current cppstd (11) is lower than required c++ "
+                      "standard (17).", self.client.out)
+
+    def test_cppstd_from_compiler(self):
+        profile = CppStdMinimumVersionTests.PROFILE.replace("{}", "")
+        self.client.save({"myprofile": profile})
+        self.client.run("create . user/channel -pr myprofile")
+        self.assertIn("valid standard", self.client.out)
+
+    def test_invalid_cppstd_from_compiler(self):
+        profile = CppStdMinimumVersionTests.PROFILE.replace("{}", "").replace("9", "4.9")
+        self.client.save({"myprofile": profile})
+        self.client.run("create . user/channel -pr myprofile", assert_error=True)
+        self.assertIn("Invalid configuration: Current compiler does not not support the required "
+                      "c++ standard (17).", self.client.out)

--- a/conans/test/functional/tools/cppstd_minimum_version_test.py
+++ b/conans/test/functional/tools/cppstd_minimum_version_test.py
@@ -1,4 +1,5 @@
 import unittest
+import mock
 from parameterized import parameterized
 from textwrap import dedent
 
@@ -18,7 +19,7 @@ class CppStdMinimumVersionTests(unittest.TestCase):
             settings = "compiler"
 
             def configure(self):
-                cppstd_minimum_required(self, "17")
+                cppstd_minimum_required(self, "17", False)
                 self.output.info("valid standard")
         """)
 
@@ -75,5 +76,69 @@ class CppStdMinimumVersionTests(unittest.TestCase):
         profile = CppStdMinimumVersionTests.PROFILE.replace("{}", "").replace("9", "4.9")
         self.client.save({"myprofile": profile})
         self.client.run("create . user/channel -pr myprofile", assert_error=True)
-        self.assertIn("Invalid configuration: Current compiler does not not support the required "
+        self.assertIn("Invalid configuration: Current compiler does not support the required "
                       "c++ standard (17).", self.client.out)
+
+    @parameterized.expand([["gnu17", "Linux"], ["gnu17", "Windows"]])
+    def test_valid_gnu_extensions_from_settings(self, cppstd, os):
+        self.client.save({"conanfile.py": CppStdMinimumVersionTests.CONANFILE.replace("False",
+                                                                                      "True")})
+        with mock.patch("platform.system", mock.MagicMock(return_value=os)):
+            profile = CppStdMinimumVersionTests.PROFILE.replace("{}", "compiler.cppstd=%s" % cppstd)
+            self.client.save({"myprofile": profile})
+            self.client.run("create . user/channel -pr myprofile")
+            self.assertIn("valid standard", self.client.out)
+
+    @parameterized.expand([
+        ["17", "Linux", "Invalid configuration: Current cppstd (17) does not have GNU extensions, "
+                        "which is required on Linux platform.", True],
+        ["17", "Windows", "valid standard", False]])
+    def test_invalid_gnu_extensions_from_settings(self, cppstd, system, expected, error):
+        self.client.save({"conanfile.py": CppStdMinimumVersionTests.CONANFILE.replace("False",
+                                                                                      "True")})
+        with mock.patch("platform.system", mock.MagicMock(return_value=system)):
+            profile = CppStdMinimumVersionTests.PROFILE.replace("{}", "compiler.cppstd=%s" % cppstd)
+            self.client.save({"myprofile": profile})
+            self.client.run("create . user/channel -pr myprofile", assert_error=error)
+            self.assertIn(expected, self.client.out)
+
+    @parameterized.expand([["gnu17", "Linux"], ["gnu17", "Windows"]])
+    def test_gnu_extensions_from_arguments(self, cppstd, os):
+        self.client.save({"conanfile.py": CppStdMinimumVersionTests.CONANFILE.replace("False",
+                                                                                      "True")})
+        self.client.save({"myprofile": CppStdMinimumVersionTests.PROFILE.replace("{}", "")})
+        with mock.patch("platform.system", mock.MagicMock(return_value=os)):
+            self.client.run("create . user/channel -pr myprofile -s compiler.cppstd=%s" % cppstd)
+            self.assertIn("valid standard", self.client.out)
+
+    @parameterized.expand([["17", "Linux", "Invalid configuration: Current cppstd (17) does not "
+                           "have GNU extensions, which is required on Linux platform.", True],
+                          ["17", "Windows", "valid standard", False]])
+    def test_invalid_gnu_extensions_from_arguments(self, cppstd, os, expected, error):
+        self.client.save({"conanfile.py": CppStdMinimumVersionTests.CONANFILE.replace("False",
+                                                                                      "True")})
+        self.client.save({"myprofile": CppStdMinimumVersionTests.PROFILE.replace("{}", "")})
+        with mock.patch("platform.system", mock.MagicMock(return_value=os)):
+            self.client.run("create . user/channel --pr myprofile -s compiler.cppstd=%s" % cppstd,
+                            assert_error=error)
+            self.assertIn(expected, self.client.out)
+
+    def test_gnu_extensions_from_compiler(self):
+        self.client.save({"conanfile.py": CppStdMinimumVersionTests.CONANFILE.replace("False",
+                                                                                      "True")})
+        self.client.save({"myprofile": CppStdMinimumVersionTests.PROFILE.replace("{}", "")})
+        with mock.patch("platform.system", mock.MagicMock(return_value="Linux")):
+            self.client.run("create . user/channel -pr myprofile")
+            self.assertIn("valid standard", self.client.out)
+
+    @parameterized.expand([["Linux", "gnu17"],
+                           ["Windows", "17"]])
+    def test_invalid_gnu_extensions_from_compiler(self, os, expected):
+        self.client.save({"conanfile.py": CppStdMinimumVersionTests.CONANFILE.replace("False",
+                                                                                      "True")})
+        self.client.save({"myprofile": CppStdMinimumVersionTests.PROFILE.replace("{}", "")
+                                                                        .replace("9", "4.9")})
+        with mock.patch("platform.system", mock.MagicMock(return_value=os)):
+            self.client.run("create . user/channel -pr myprofile", assert_error=True)
+            self.assertIn("Invalid configuration: Current compiler does not support the "
+                          "required c++ standard (%s)." % expected, self.client.out)

--- a/conans/test/functional/tools/cppstd_minimum_version_test.py
+++ b/conans/test/functional/tools/cppstd_minimum_version_test.py
@@ -4,6 +4,7 @@ from parameterized import parameterized
 from textwrap import dedent
 
 from conans.test.utils.tools import TestClient
+from conans.client.tools import OSInfo
 
 
 class CppStdMinimumVersionTests(unittest.TestCase):
@@ -84,10 +85,12 @@ class CppStdMinimumVersionTests(unittest.TestCase):
         self.client.save({"conanfile.py": CppStdMinimumVersionTests.CONANFILE.replace("False",
                                                                                       "True")})
         with mock.patch("platform.system", mock.MagicMock(return_value=os)):
-            profile = CppStdMinimumVersionTests.PROFILE.replace("{}", "compiler.cppstd=%s" % cppstd)
-            self.client.save({"myprofile": profile})
-            self.client.run("create . user/channel -pr myprofile")
-            self.assertIn("valid standard", self.client.out)
+            with mock.patch.object(OSInfo, '_get_linux_distro_info'):
+                profile = CppStdMinimumVersionTests.PROFILE.replace("{}", "compiler.cppstd=%s" %
+                                                                    cppstd)
+                self.client.save({"myprofile": profile})
+                self.client.run("create . user/channel -pr myprofile")
+                self.assertIn("valid standard", self.client.out)
 
     @parameterized.expand([
         ["17", "Linux", "Invalid configuration: Current cppstd (17) does not have GNU extensions, "
@@ -97,10 +100,12 @@ class CppStdMinimumVersionTests(unittest.TestCase):
         self.client.save({"conanfile.py": CppStdMinimumVersionTests.CONANFILE.replace("False",
                                                                                       "True")})
         with mock.patch("platform.system", mock.MagicMock(return_value=system)):
-            profile = CppStdMinimumVersionTests.PROFILE.replace("{}", "compiler.cppstd=%s" % cppstd)
-            self.client.save({"myprofile": profile})
-            self.client.run("create . user/channel -pr myprofile", assert_error=error)
-            self.assertIn(expected, self.client.out)
+            with mock.patch.object(OSInfo, '_get_linux_distro_info'):
+                profile = CppStdMinimumVersionTests.PROFILE.replace("{}", "compiler.cppstd=%s" %
+                                                                    cppstd)
+                self.client.save({"myprofile": profile})
+                self.client.run("create . user/channel -pr myprofile", assert_error=error)
+                self.assertIn(expected, self.client.out)
 
     @parameterized.expand([["gnu17", "Linux"], ["gnu17", "Windows"]])
     def test_gnu_extensions_from_arguments(self, cppstd, os):
@@ -108,8 +113,10 @@ class CppStdMinimumVersionTests(unittest.TestCase):
                                                                                       "True")})
         self.client.save({"myprofile": CppStdMinimumVersionTests.PROFILE.replace("{}", "")})
         with mock.patch("platform.system", mock.MagicMock(return_value=os)):
-            self.client.run("create . user/channel -pr myprofile -s compiler.cppstd=%s" % cppstd)
-            self.assertIn("valid standard", self.client.out)
+            with mock.patch.object(OSInfo, '_get_linux_distro_info'):
+                self.client.run("create . user/channel -pr myprofile -s compiler.cppstd=%s" %
+                                cppstd)
+                self.assertIn("valid standard", self.client.out)
 
     @parameterized.expand([["17", "Linux", "Invalid configuration: Current cppstd (17) does not "
                            "have GNU extensions, which is required on Linux platform.", True],
@@ -128,8 +135,9 @@ class CppStdMinimumVersionTests(unittest.TestCase):
                                                                                       "True")})
         self.client.save({"myprofile": CppStdMinimumVersionTests.PROFILE.replace("{}", "")})
         with mock.patch("platform.system", mock.MagicMock(return_value="Linux")):
-            self.client.run("create . user/channel -pr myprofile")
-            self.assertIn("valid standard", self.client.out)
+            with mock.patch.object(OSInfo, '_get_linux_distro_info'):
+                self.client.run("create . user/channel -pr myprofile")
+                self.assertIn("valid standard", self.client.out)
 
     @parameterized.expand([["Linux", "gnu17"],
                            ["Windows", "17"]])
@@ -139,6 +147,7 @@ class CppStdMinimumVersionTests(unittest.TestCase):
         self.client.save({"myprofile": CppStdMinimumVersionTests.PROFILE.replace("{}", "")
                                                                         .replace("9", "4.9")})
         with mock.patch("platform.system", mock.MagicMock(return_value=os)):
-            self.client.run("create . user/channel -pr myprofile", assert_error=True)
-            self.assertIn("Invalid configuration: Current compiler does not support the "
-                          "required c++ standard (%s)." % expected, self.client.out)
+            with mock.patch.object(OSInfo, '_get_linux_distro_info'):
+                self.client.run("create . user/channel -pr myprofile", assert_error=True)
+                self.assertIn("Invalid configuration: Current compiler does not support the "
+                              "required c++ standard (%s)." % expected, self.client.out)

--- a/conans/test/functional/tools/cppstd_minimum_version_test.py
+++ b/conans/test/functional/tools/cppstd_minimum_version_test.py
@@ -47,5 +47,5 @@ class CppStdMinimumVersionTests(unittest.TestCase):
         profile = CppStdMinimumVersionTests.PROFILE.replace("{}", "compiler.cppstd=%s" % cppstd)
         self.client.save({"myprofile": profile})
         self.client.run("create . user/channel -pr myprofile", assert_error=True)
-        self.assertIn("Invalid configuration: Current cppstd (%s) is lower than required C++ "
+        self.assertIn("Invalid configuration: Current cppstd (%s) is lower than the required C++ "
                       "standard (17)." % cppstd, self.client.out)

--- a/conans/test/functional/tools/cppstd_minimum_version_test.py
+++ b/conans/test/functional/tools/cppstd_minimum_version_test.py
@@ -126,9 +126,10 @@ class CppStdMinimumVersionTests(unittest.TestCase):
                                                                                       "True")})
         self.client.save({"myprofile": CppStdMinimumVersionTests.PROFILE.replace("{}", "")})
         with mock.patch("platform.system", mock.MagicMock(return_value=os)):
-            self.client.run("create . user/channel --pr myprofile -s compiler.cppstd=%s" % cppstd,
-                            assert_error=error)
-            self.assertIn(expected, self.client.out)
+            with mock.patch.object(OSInfo, '_get_linux_distro_info'):
+                self.client.run("create . user/channel --pr myprofile -s compiler.cppstd=%s" % cppstd,
+                                assert_error=error)
+                self.assertIn(expected, self.client.out)
 
     def test_gnu_extensions_from_compiler(self):
         self.client.save({"conanfile.py": CppStdMinimumVersionTests.CONANFILE.replace("False",

--- a/conans/test/unittests/client/tools/cppstd_required_test.py
+++ b/conans/test/unittests/client/tools/cppstd_required_test.py
@@ -34,6 +34,14 @@ class UserProneTests(unittest.TestCase):
             valid_min_cppstd(None, "17", False)
         self.assertEqual("conanfile must be a ConanFile object", str(raises.exception))
 
+    def test_check_cppstd_type(self):
+        """ cppstd must be a number
+        """
+        conanfile = MockConanfile(MockSettings({}))
+        with self.assertRaises(AssertionError) as raises:
+            check_min_cppstd(conanfile, "gnu17", False)
+        self.assertEqual("cppstd must be a number", str(raises.exception))
+
 
 class CheckMinCppStdTests(unittest.TestCase):
 
@@ -49,14 +57,14 @@ class CheckMinCppStdTests(unittest.TestCase):
         conanfile = MockConanfile(settings)
         return conanfile
 
-    @parameterized.expand(["98", "gnu98", "11", "gnu11", "14", "gnu14", "17", "gnu17"])
+    @parameterized.expand(["98", "11", "14", "17"])
     def test_check_min_cppstd_from_settings(self, cppstd):
         """ check_min_cppstd must accept cppstd less/equal than cppstd in settings
         """
         conanfile = self._create_conanfile("gcc", "9", "Linux", "17", "libstdc++")
         check_min_cppstd(conanfile, cppstd, False)
 
-    @parameterized.expand(["98", "gnu98", "11", "gnu11", "14", "gnu14"])
+    @parameterized.expand(["98", "11", "14"])
     def test_check_min_cppstd_from_outdated_settings(self, cppstd):
         """ check_min_cppstd must raise when cppstd is greater when supported on settings
         """
@@ -66,7 +74,7 @@ class CheckMinCppStdTests(unittest.TestCase):
         self.assertEqual("Current cppstd ({}) is lower than required C++ standard "
                          "(17).".format(cppstd), str(raises.exception))
 
-    @parameterized.expand(["98", "gnu98", "11", "gnu11", "14", "gnu14", "17", "gnu17"])
+    @parameterized.expand(["98", "11", "14", "17"])
     def test_check_min_cppstd_from_settings_with_extension(self, cppstd):
         """ current cppstd in settings must has GNU extension when extensions is enabled
         """
@@ -81,7 +89,7 @@ class CheckMinCppStdTests(unittest.TestCase):
                 self.assertEqual("Current cppstd (17) does not have GNU extensions, which is "
                                  "required on Linux platform.", str(raises.exception))
 
-    @parameterized.expand(["98", "gnu98", "11", "gnu11", "14", "gnu14", "17", "gnu17"])
+    @parameterized.expand(["98", "11", "14", "17"])
     def test_check_min_cppstd_from_settings_with_extension_windows(self, cppstd):
         """ GNU extensions has no effect on Windows for check_min_cppstd
         """
@@ -109,7 +117,7 @@ class CheckMinCppStdTests(unittest.TestCase):
             with mock.patch.object(OSInfo, '_get_linux_distro_info'):
                 with mock.patch("conans.client.tools.settings.cppstd_flag", return_value="17"):
                     with self.assertRaises(ConanInvalidConfiguration) as raises:
-                        check_min_cppstd(conanfile, "gnu17", True)
+                        check_min_cppstd(conanfile, "17", True)
                     self.assertEqual("Current compiler does not support GNU extensions.",
                                      str(raises.exception))
 
@@ -128,21 +136,21 @@ class ValidMinCppstdTests(unittest.TestCase):
         conanfile = MockConanfile(settings)
         return conanfile
 
-    @parameterized.expand(["98", "gnu98", "11", "gnu11", "14", "gnu14", "17", "gnu17"])
+    @parameterized.expand(["98", "11", "14", "17"])
     def test_valid_min_cppstd_from_settings(self, cppstd):
         """ valid_min_cppstd must accept cppstd less/equal than cppstd in settings
         """
         conanfile = self._create_conanfile("gcc", "9", "Linux", "17", "libstdc++")
         self.assertTrue(valid_min_cppstd(conanfile, cppstd, False))
 
-    @parameterized.expand(["98", "gnu98", "11", "gnu11", "14", "gnu14"])
+    @parameterized.expand(["98", "11", "14"])
     def test_valid_min_cppstd_from_outdated_settings(self, cppstd):
         """ valid_min_cppstd returns False when cppstd is greater when supported on settings
         """
         conanfile = self._create_conanfile("gcc", "9", "Linux", cppstd, "libstdc++")
         self.assertFalse(valid_min_cppstd(conanfile, "17", False))
 
-    @parameterized.expand(["98", "gnu98", "11", "gnu11", "14", "gnu14", "17", "gnu17"])
+    @parameterized.expand(["98", "11", "14", "17"])
     def test_valid_min_cppstd_from_settings_with_extension(self, cppstd):
         """ valid_min_cppstd must returns True when current cppstd in settings has GNU extension and
             extensions is enabled
@@ -156,7 +164,7 @@ class ValidMinCppstdTests(unittest.TestCase):
                 conanfile.settings.values["compiler.cppstd"] = "17"
                 self.assertFalse(valid_min_cppstd(conanfile, cppstd, True))
 
-    @parameterized.expand(["98", "gnu98", "11", "gnu11", "14", "gnu14", "17", "gnu17"])
+    @parameterized.expand(["98", "11", "14", "17"])
     def test_valid_min_cppstd_from_settings_with_extension_windows(self, cppstd):
         """ GNU extensions has no effect on Windows for valid_min_cppstd
         """

--- a/conans/test/unittests/client/tools/cppstd_required_test.py
+++ b/conans/test/unittests/client/tools/cppstd_required_test.py
@@ -1,0 +1,104 @@
+import unittest
+from mock import mock
+from parameterized import parameterized
+
+from conans.test.utils.conanfile import MockConanfile, MockSettings
+from conans.client.tools import OSInfo
+from conans.errors import ConanInvalidConfiguration
+
+from conans.tools import check_min_cppstd, valid_min_cppstd
+
+
+class CheckMinCppStdTests(unittest.TestCase):
+
+    def setUp(self):
+        self.conanfile = self._create_conanfile("gcc", "9", "Linux", "17", "libcxx")
+
+    def _create_conanfile(self, compiler, version, os, cppstd, libcxx=None):
+        settings = MockSettings({"arch": "x86_64",
+                                 "build_type": "Debug",
+                                 "os": os,
+                                 "compiler": compiler,
+                                 "compiler.version": version,
+                                 "compiler.cppstd": cppstd})
+        if libcxx:
+            settings.values["compiler.libcxx"] = libcxx
+        conanfile = MockConanfile(settings)
+        return conanfile
+
+    def test_check_none_cppstd(self):
+        """ Cppstd must use a valid number as described in settings.yml
+        """
+        with self.assertRaises(AssertionError) as asserts:
+            check_min_cppstd(self.conanfile, None, False)
+        self.assertEqual("Cannot check invalid cppstd version", str(asserts.exception))
+
+    def test_check_none_conanfile(self):
+        """ conanfile must be a ConanFile object
+        """
+        with self.assertRaises(AssertionError) as raises:
+            check_min_cppstd(None, "17", False)
+        self.assertEqual("conanfile must be a ConanFile object", str(raises.exception))
+
+    @parameterized.expand(["98", "gnu98", "11", "gnu11", "14", "gnu14", "17", "gnu17"])
+    def test_check_min_cppstd_from_settings(self, cppstd):
+        """ check_min_cppstd must accept cppstd less/equal than cppstd in settings
+        """
+        check_min_cppstd(self.conanfile, cppstd, False)
+
+    @parameterized.expand(["98", "gnu98", "11", "gnu11", "14", "gnu14"])
+    def test_check_min_cppstd_from_outdated_settings(self, cppstd):
+        """ check_min_cppstd must raise when cppstd is greater when supported on settings
+        """
+        self.conanfile.settings.values["compiler.cppstd"] = cppstd
+        with self.assertRaises(ConanInvalidConfiguration) as raises:
+            check_min_cppstd(self.conanfile, "17", False)
+        self.assertEqual("Current cppstd ({}) is lower than required c++ standard " 
+                         "(17).".format(cppstd), str(raises.exception))
+
+    @parameterized.expand(["98", "gnu98", "11", "gnu11", "14", "gnu14", "17", "gnu17"])
+    def test_check_min_cppstd_from_settings_with_extension(self, cppstd):
+        """ current cppstd in settings must has GNU extension when extensions is enabled
+        """
+        with mock.patch("platform.system", mock.MagicMock(return_value="Linux")):
+            with mock.patch.object(OSInfo, '_get_linux_distro_info'):
+                self.conanfile.settings.values["compiler.cppstd"] = "gnu17"
+                check_min_cppstd(self.conanfile, cppstd, True)
+
+                self.conanfile.settings.values["compiler.cppstd"] = "17"
+                with self.assertRaises(ConanInvalidConfiguration) as raises:
+                    check_min_cppstd(self.conanfile, cppstd, True)
+                self.assertEqual("Current cppstd (17) does not have GNU extensions, which is "
+                                 "required on Linux platform.", str(raises.exception))
+
+    @parameterized.expand(["98", "gnu98", "11", "gnu11", "14", "gnu14", "17", "gnu17"])
+    def test_check_min_cppstd_from_settings_with_extension_windows(self, cppstd):
+        """ GNU extensions has no effect on Windows
+        """
+        with mock.patch("platform.system", mock.MagicMock(return_value="Windows")):
+            self.conanfile.settings.values["compiler.cppstd"] = "gnu17"
+            check_min_cppstd(self.conanfile, cppstd, True)
+
+            self.conanfile.settings.values["compiler.cppstd"] = "17"
+            check_min_cppstd(self.conanfile, cppstd, True)
+
+    def test_check_min_cppstd_unsupported_standard(self):
+        """ check_min_cppstd must raise when the compiler does not support a standard
+        """
+        del self.conanfile.settings.values["compiler.cppstd"]
+        with self.assertRaises(ConanInvalidConfiguration) as raises:
+            check_min_cppstd(self.conanfile, "42", False)
+        self.assertEqual("Current compiler does not support the required c++ standard (42).",
+                         str(raises.exception))
+
+    @mock.patch("conans.client.build.cppstd_flags.cppstd_flag", return_value="42")
+    def test_check_min_cppstd_gnu_compiler_extension(self, _):
+        """ Current compiler must support GNU extension on Linux when extensions is required
+        """
+        del self.conanfile.settings.values["compiler.cppstd"]
+        with mock.patch("platform.system", mock.MagicMock(return_value="Linux")):
+            with mock.patch.object(OSInfo, '_get_linux_distro_info'):
+                with self.assertRaises(ConanInvalidConfiguration) as raises:
+                    check_min_cppstd(self.conanfile, "gnu42", True)
+                self.assertEqual("Current compiler does not support GNU extensions.",
+                                 str(raises.exception))

--- a/conans/test/unittests/client/tools/cppstd_required_test.py
+++ b/conans/test/unittests/client/tools/cppstd_required_test.py
@@ -169,7 +169,7 @@ class ValidMinCppstdTests(unittest.TestCase):
         """ GNU extensions has no effect on Windows for valid_min_cppstd
         """
         with mock.patch("platform.system", mock.MagicMock(return_value="Windows")):
-            conanfile = self._create_conanfile("gcc", "9", "Linux", "gnu17", "libstdc++")
+            conanfile = self._create_conanfile("gcc", "9", "Windows", "gnu17", "libstdc++")
             self.assertTrue(valid_min_cppstd(conanfile, cppstd, True))
 
             conanfile.settings.values["compiler.cppstd"] = "17"
@@ -190,3 +190,14 @@ class ValidMinCppstdTests(unittest.TestCase):
             with mock.patch.object(OSInfo, '_get_linux_distro_info'):
                 with mock.patch("conans.client.tools.settings.cppstd_flag", return_value="1z"):
                     self.assertFalse(valid_min_cppstd(conanfile, "20", True))
+
+    @parameterized.expand(["98", "11", "14", "17"])
+    def test_min_cppstd_mingw_windows(self, cppstd):
+        """ GNU extensions has no effect on Windows when running MingW and cross-building for Linux
+        """
+        with mock.patch("platform.system", mock.MagicMock(return_value="Windows")):
+            conanfile = self._create_conanfile("gcc", "9", "Linux", "gnu17", "libstdc++")
+            self.assertTrue(valid_min_cppstd(conanfile, cppstd, True))
+
+            conanfile.settings.values["compiler.cppstd"] = "17"
+            self.assertTrue(valid_min_cppstd(conanfile, cppstd, True))

--- a/conans/test/unittests/client/tools/cppstd_required_test.py
+++ b/conans/test/unittests/client/tools/cppstd_required_test.py
@@ -11,30 +11,31 @@ from conans.tools import check_min_cppstd, valid_min_cppstd
 
 class UserProneTests(unittest.TestCase):
 
-    def setUp(self):
-        self.conanfile = MockConanfile(MockSettings({}))
-
-    @parameterized.expand(["check_min_cppstd", "valid_min_cppstd"])
-    def test_check_none_cppstd(self, method):
+    def test_check_none_cppstd(self):
         """ Cppstd must use a valid number as described in settings.yml
         """
+        conanfile = MockConanfile(MockSettings({}))
         with self.assertRaises(AssertionError) as asserts:
-            eval(method)(self.conanfile, None, False)
+            check_min_cppstd(conanfile, None, False)
         self.assertEqual("Cannot check invalid cppstd version", str(asserts.exception))
 
-    @parameterized.expand(["check_min_cppstd", "valid_min_cppstd"])
-    def test_check_none_conanfile(self, method):
+        with self.assertRaises(AssertionError) as asserts:
+            valid_min_cppstd(conanfile, None, False)
+        self.assertEqual("Cannot check invalid cppstd version", str(asserts.exception))
+
+    def test_check_none_conanfile(self):
         """ conanfile must be a ConanFile object
         """
         with self.assertRaises(AssertionError) as raises:
-            eval(method)(None, "17", False)
+            check_min_cppstd(None, "17", False)
+        self.assertEqual("conanfile must be a ConanFile object", str(raises.exception))
+
+        with self.assertRaises(AssertionError) as raises:
+            valid_min_cppstd(None, "17", False)
         self.assertEqual("conanfile must be a ConanFile object", str(raises.exception))
 
 
 class CheckMinCppStdTests(unittest.TestCase):
-
-    def setUp(self):
-        self.conanfile = self._create_conanfile("gcc", "9", "Linux", "17", "libcxx")
 
     def _create_conanfile(self, compiler, version, os, cppstd, libcxx=None):
         settings = MockSettings({"arch": "x86_64",
@@ -52,16 +53,17 @@ class CheckMinCppStdTests(unittest.TestCase):
     def test_check_min_cppstd_from_settings(self, cppstd):
         """ check_min_cppstd must accept cppstd less/equal than cppstd in settings
         """
-        check_min_cppstd(self.conanfile, cppstd, False)
+        conanfile = self._create_conanfile("gcc", "9", "Linux", "17", "libstdc++")
+        check_min_cppstd(conanfile, cppstd, False)
 
     @parameterized.expand(["98", "gnu98", "11", "gnu11", "14", "gnu14"])
     def test_check_min_cppstd_from_outdated_settings(self, cppstd):
         """ check_min_cppstd must raise when cppstd is greater when supported on settings
         """
-        self.conanfile.settings.values["compiler.cppstd"] = cppstd
+        conanfile = self._create_conanfile("gcc", "9", "Linux", cppstd, "libstdc++")
         with self.assertRaises(ConanInvalidConfiguration) as raises:
-            check_min_cppstd(self.conanfile, "17", False)
-        self.assertEqual("Current cppstd ({}) is lower than required c++ standard " 
+            check_min_cppstd(conanfile, "17", False)
+        self.assertEqual("Current cppstd ({}) is lower than required C++ standard "
                          "(17).".format(cppstd), str(raises.exception))
 
     @parameterized.expand(["98", "gnu98", "11", "gnu11", "14", "gnu14", "17", "gnu17"])
@@ -70,12 +72,12 @@ class CheckMinCppStdTests(unittest.TestCase):
         """
         with mock.patch("platform.system", mock.MagicMock(return_value="Linux")):
             with mock.patch.object(OSInfo, '_get_linux_distro_info'):
-                self.conanfile.settings.values["compiler.cppstd"] = "gnu17"
-                check_min_cppstd(self.conanfile, cppstd, True)
+                conanfile = self._create_conanfile("gcc", "9", "Linux", "gnu17", "libstdc++")
+                check_min_cppstd(conanfile, cppstd, True)
 
-                self.conanfile.settings.values["compiler.cppstd"] = "17"
+                conanfile.settings.values["compiler.cppstd"] = "17"
                 with self.assertRaises(ConanInvalidConfiguration) as raises:
-                    check_min_cppstd(self.conanfile, cppstd, True)
+                    check_min_cppstd(conanfile, cppstd, True)
                 self.assertEqual("Current cppstd (17) does not have GNU extensions, which is "
                                  "required on Linux platform.", str(raises.exception))
 
@@ -84,38 +86,35 @@ class CheckMinCppStdTests(unittest.TestCase):
         """ GNU extensions has no effect on Windows for check_min_cppstd
         """
         with mock.patch("platform.system", mock.MagicMock(return_value="Windows")):
-            self.conanfile.settings.values["compiler.cppstd"] = "gnu17"
-            check_min_cppstd(self.conanfile, cppstd, True)
+            conanfile = self._create_conanfile("gcc", "9", "Windows", "gnu17", "libstdc++")
+            check_min_cppstd(conanfile, cppstd, True)
 
-            self.conanfile.settings.values["compiler.cppstd"] = "17"
-            check_min_cppstd(self.conanfile, cppstd, True)
+            conanfile.settings.values["compiler.cppstd"] = "17"
+            check_min_cppstd(conanfile, cppstd, True)
 
     def test_check_min_cppstd_unsupported_standard(self):
         """ check_min_cppstd must raise when the compiler does not support a standard
         """
-        del self.conanfile.settings.values["compiler.cppstd"]
+        conanfile = self._create_conanfile("gcc", "9", "Linux", None, "libstdc++")
         with self.assertRaises(ConanInvalidConfiguration) as raises:
-            check_min_cppstd(self.conanfile, "42", False)
-        self.assertEqual("Current compiler does not support the required c++ standard (42).",
+            check_min_cppstd(conanfile, "42", False)
+        self.assertEqual("Current compiler does not support the required C++ standard (42).",
                          str(raises.exception))
 
     def test_check_min_cppstd_gnu_compiler_extension(self):
         """ Current compiler must support GNU extension on Linux when extensions is required
         """
-        del self.conanfile.settings.values["compiler.cppstd"]
+        conanfile = self._create_conanfile("gcc", "9", "Linux", None, "libstdc++")
         with mock.patch("platform.system", mock.MagicMock(return_value="Linux")):
             with mock.patch.object(OSInfo, '_get_linux_distro_info'):
-                with mock.patch("conans.client.tools.settings.cppstd_flag", return_value="42"):
+                with mock.patch("conans.client.tools.settings.cppstd_flag", return_value="17"):
                     with self.assertRaises(ConanInvalidConfiguration) as raises:
-                        check_min_cppstd(self.conanfile, "gnu42", True)
+                        check_min_cppstd(conanfile, "gnu17", True)
                     self.assertEqual("Current compiler does not support GNU extensions.",
                                      str(raises.exception))
 
 
 class ValidMinCppstdTests(unittest.TestCase):
-
-    def setUp(self):
-        self.conanfile = self._create_conanfile("gcc", "9", "Linux", "17", "libcxx")
 
     def _create_conanfile(self, compiler, version, os, cppstd, libcxx=None):
         settings = MockSettings({"arch": "x86_64",
@@ -133,51 +132,53 @@ class ValidMinCppstdTests(unittest.TestCase):
     def test_valid_min_cppstd_from_settings(self, cppstd):
         """ valid_min_cppstd must accept cppstd less/equal than cppstd in settings
         """
-        self.assertTrue(valid_min_cppstd(self.conanfile, cppstd, False))
+        conanfile = self._create_conanfile("gcc", "9", "Linux", "17", "libstdc++")
+        self.assertTrue(valid_min_cppstd(conanfile, cppstd, False))
 
     @parameterized.expand(["98", "gnu98", "11", "gnu11", "14", "gnu14"])
     def test_valid_min_cppstd_from_outdated_settings(self, cppstd):
         """ valid_min_cppstd returns False when cppstd is greater when supported on settings
         """
-        self.conanfile.settings.values["compiler.cppstd"] = cppstd
-        self.assertFalse(valid_min_cppstd(self.conanfile, "17", False))
+        conanfile = self._create_conanfile("gcc", "9", "Linux", cppstd, "libstdc++")
+        self.assertFalse(valid_min_cppstd(conanfile, "17", False))
 
     @parameterized.expand(["98", "gnu98", "11", "gnu11", "14", "gnu14", "17", "gnu17"])
     def test_valid_min_cppstd_from_settings_with_extension(self, cppstd):
         """ valid_min_cppstd must returns True when current cppstd in settings has GNU extension and
             extensions is enabled
         """
+
         with mock.patch("platform.system", mock.MagicMock(return_value="Linux")):
             with mock.patch.object(OSInfo, '_get_linux_distro_info'):
-                self.conanfile.settings.values["compiler.cppstd"] = "gnu17"
-                self.assertTrue(valid_min_cppstd(self.conanfile, cppstd, True))
+                conanfile = self._create_conanfile("gcc", "9", "Linux", "gnu17", "libstdc++")
+                self.assertTrue(valid_min_cppstd(conanfile, cppstd, True))
 
-                self.conanfile.settings.values["compiler.cppstd"] = "17"
-                self.assertFalse(valid_min_cppstd(self.conanfile, cppstd, True))
+                conanfile.settings.values["compiler.cppstd"] = "17"
+                self.assertFalse(valid_min_cppstd(conanfile, cppstd, True))
 
     @parameterized.expand(["98", "gnu98", "11", "gnu11", "14", "gnu14", "17", "gnu17"])
     def test_valid_min_cppstd_from_settings_with_extension_windows(self, cppstd):
         """ GNU extensions has no effect on Windows for valid_min_cppstd
         """
         with mock.patch("platform.system", mock.MagicMock(return_value="Windows")):
-            self.conanfile.settings.values["compiler.cppstd"] = "gnu17"
-            self.assertTrue(valid_min_cppstd(self.conanfile, cppstd, True))
+            conanfile = self._create_conanfile("gcc", "9", "Linux", "gnu17", "libstdc++")
+            self.assertTrue(valid_min_cppstd(conanfile, cppstd, True))
 
-            self.conanfile.settings.values["compiler.cppstd"] = "17"
-            self.assertTrue(valid_min_cppstd(self.conanfile, cppstd, True))
+            conanfile.settings.values["compiler.cppstd"] = "17"
+            self.assertTrue(valid_min_cppstd(conanfile, cppstd, True))
 
     def test_valid_min_cppstd_unsupported_standard(self):
         """ valid_min_cppstd must returns False when the compiler does not support a standard
         """
-        del self.conanfile.settings.values["compiler.cppstd"]
-        self.assertFalse(valid_min_cppstd(self.conanfile, "42", False))
+        conanfile = self._create_conanfile("gcc", "9", "Linux", None, "libstdc++")
+        self.assertFalse(valid_min_cppstd(conanfile, "42", False))
 
     def test_valid_min_cppstd_gnu_compiler_extension(self):
         """ valid_min_cppstd must returns False when current compiler does not support GNU extension
             on Linux and extensions is required
         """
-        del self.conanfile.settings.values["compiler.cppstd"]
+        conanfile = self._create_conanfile("gcc", "9", "Linux", None, "libstdc++")
         with mock.patch("platform.system", mock.MagicMock(return_value="Linux")):
             with mock.patch.object(OSInfo, '_get_linux_distro_info'):
-                with mock.patch("conans.client.tools.settings.cppstd_flag", return_value="42"):
-                    self.assertFalse(valid_min_cppstd(self.conanfile, "gnu42", True))
+                with mock.patch("conans.client.tools.settings.cppstd_flag", return_value="1z"):
+                    self.assertFalse(valid_min_cppstd(conanfile, "20", True))

--- a/conans/test/unittests/client/tools/cppstd_required_test.py
+++ b/conans/test/unittests/client/tools/cppstd_required_test.py
@@ -55,26 +55,13 @@ class CheckMinCppStdTests(unittest.TestCase):
     def test_check_min_cppstd_from_settings_with_extension(self, cppstd):
         """ current cppstd in settings must has GNU extension when extensions is enabled
         """
-        with mock.patch("platform.system", mock.MagicMock(return_value="Linux")):
-            with mock.patch.object(OSInfo, '_get_linux_distro_info'):
-                conanfile = self._create_conanfile("gcc", "9", "Linux", "gnu17", "libstdc++")
-                check_min_cppstd(conanfile, cppstd, True)
+        conanfile = self._create_conanfile("gcc", "9", "Linux", "gnu17", "libstdc++")
+        check_min_cppstd(conanfile, cppstd, True)
 
-                conanfile.settings.values["compiler.cppstd"] = "17"
-                with self.assertRaises(ConanException) as raises:
-                    check_min_cppstd(conanfile, cppstd, True)
-                self.assertEqual("The cppstd GNU extension is required", str(raises.exception))
-
-    @parameterized.expand(["98", "11", "14", "17"])
-    def test_check_min_cppstd_from_settings_with_extension_windows(self, cppstd):
-        """ GNU extensions has no effect on Windows for check_min_cppstd
-        """
-        with mock.patch("platform.system", mock.MagicMock(return_value="Windows")):
-            conanfile = self._create_conanfile("gcc", "9", "Windows", "gnu17", "libstdc++")
+        conanfile.settings.values["compiler.cppstd"] = "17"
+        with self.assertRaises(ConanException) as raises:
             check_min_cppstd(conanfile, cppstd, True)
-
-            conanfile.settings.values["compiler.cppstd"] = "17"
-            check_min_cppstd(conanfile, cppstd, True)
+        self.assertEqual("The cppstd GNU extension is required", str(raises.exception))
 
     def test_check_min_cppstd_unsupported_standard(self):
         """ check_min_cppstd must raise when the compiler does not support a standard
@@ -137,25 +124,11 @@ class ValidMinCppstdTests(unittest.TestCase):
         """ valid_min_cppstd must returns True when current cppstd in settings has GNU extension and
             extensions is enabled
         """
+        conanfile = self._create_conanfile("gcc", "9", "Linux", "gnu17", "libstdc++")
+        self.assertTrue(valid_min_cppstd(conanfile, cppstd, True))
 
-        with mock.patch("platform.system", mock.MagicMock(return_value="Linux")):
-            with mock.patch.object(OSInfo, '_get_linux_distro_info'):
-                conanfile = self._create_conanfile("gcc", "9", "Linux", "gnu17", "libstdc++")
-                self.assertTrue(valid_min_cppstd(conanfile, cppstd, True))
-
-                conanfile.settings.values["compiler.cppstd"] = "17"
-                self.assertFalse(valid_min_cppstd(conanfile, cppstd, True))
-
-    @parameterized.expand(["98", "11", "14", "17"])
-    def test_valid_min_cppstd_from_settings_with_extension_windows(self, cppstd):
-        """ GNU extensions has no effect on Windows for valid_min_cppstd
-        """
-        with mock.patch("platform.system", mock.MagicMock(return_value="Windows")):
-            conanfile = self._create_conanfile("gcc", "9", "Windows", "gnu17", "libstdc++")
-            self.assertTrue(valid_min_cppstd(conanfile, cppstd, True))
-
-            conanfile.settings.values["compiler.cppstd"] = "17"
-            self.assertTrue(valid_min_cppstd(conanfile, cppstd, True))
+        conanfile.settings.values["compiler.cppstd"] = "17"
+        self.assertFalse(valid_min_cppstd(conanfile, cppstd, True))
 
     def test_valid_min_cppstd_unsupported_standard(self):
         """ valid_min_cppstd must returns False when the compiler does not support a standard

--- a/conans/test/unittests/client/tools/cppstd_required_test.py
+++ b/conans/test/unittests/client/tools/cppstd_required_test.py
@@ -61,7 +61,7 @@ class CheckMinCppStdTests(unittest.TestCase):
                 check_min_cppstd(conanfile, cppstd, True)
 
                 conanfile.settings.values["compiler.cppstd"] = "17"
-                with self.assertRaises(ConanInvalidConfiguration) as raises:
+                with self.assertRaises(ConanException) as raises:
                     check_min_cppstd(conanfile, cppstd, True)
                 self.assertEqual("The cppstd GNU extension is required", str(raises.exception))
 
@@ -92,7 +92,7 @@ class CheckMinCppStdTests(unittest.TestCase):
         with mock.patch("platform.system", mock.MagicMock(return_value="Linux")):
             with mock.patch.object(OSInfo, '_get_linux_distro_info'):
                 with mock.patch("conans.client.tools.settings.cppstd_default", return_value="17"):
-                    with self.assertRaises(ConanInvalidConfiguration) as raises:
+                    with self.assertRaises(ConanException) as raises:
                         check_min_cppstd(conanfile, "17", True)
                     self.assertEqual("The cppstd GNU extension is required", str(raises.exception))
 
@@ -170,7 +170,7 @@ class ValidMinCppstdTests(unittest.TestCase):
         conanfile = self._create_conanfile("gcc", "9", "Linux", None, "libstdc++")
         with mock.patch("platform.system", mock.MagicMock(return_value="Linux")):
             with mock.patch.object(OSInfo, '_get_linux_distro_info'):
-                with mock.patch("conans.client.tools.settings.cppstd_default", return_value="1z"):
+                with mock.patch("conans.client.tools.settings.cppstd_default", return_value="gnu1z"):
                     self.assertFalse(valid_min_cppstd(conanfile, "20", True))
 
     @parameterized.expand(["98", "11", "14", "17"])

--- a/conans/test/unittests/client/tools/cppstd_required_test.py
+++ b/conans/test/unittests/client/tools/cppstd_required_test.py
@@ -4,33 +4,33 @@ from parameterized import parameterized
 
 from conans.test.utils.conanfile import MockConanfile, MockSettings
 from conans.client.tools import OSInfo
-from conans.errors import ConanInvalidConfiguration
+from conans.errors import ConanInvalidConfiguration, ConanException
 
 from conans.tools import check_min_cppstd, valid_min_cppstd
 
 
-class UserProneTests(unittest.TestCase):
+class UserInputTests(unittest.TestCase):
 
     def test_check_none_cppstd(self):
         """ Cppstd must use a valid number as described in settings.yml
         """
         conanfile = MockConanfile(MockSettings({}))
-        with self.assertRaises(AssertionError) as asserts:
+        with self.assertRaises(ConanException) as asserts:
             check_min_cppstd(conanfile, None, False)
         self.assertEqual("Cannot check invalid cppstd version", str(asserts.exception))
 
-        with self.assertRaises(AssertionError) as asserts:
+        with self.assertRaises(ConanException) as asserts:
             valid_min_cppstd(conanfile, None, False)
         self.assertEqual("Cannot check invalid cppstd version", str(asserts.exception))
 
     def test_check_none_conanfile(self):
         """ conanfile must be a ConanFile object
         """
-        with self.assertRaises(AssertionError) as raises:
+        with self.assertRaises(ConanException) as raises:
             check_min_cppstd(None, "17", False)
         self.assertEqual("conanfile must be a ConanFile object", str(raises.exception))
 
-        with self.assertRaises(AssertionError) as raises:
+        with self.assertRaises(ConanException) as raises:
             valid_min_cppstd(None, "17", False)
         self.assertEqual("conanfile must be a ConanFile object", str(raises.exception))
 
@@ -38,7 +38,7 @@ class UserProneTests(unittest.TestCase):
         """ cppstd must be a number
         """
         conanfile = MockConanfile(MockSettings({}))
-        with self.assertRaises(AssertionError) as raises:
+        with self.assertRaises(ConanException) as raises:
             check_min_cppstd(conanfile, "gnu17", False)
         self.assertEqual("cppstd must be a number", str(raises.exception))
 

--- a/conans/test/unittests/client/tools/cppstd_required_test.py
+++ b/conans/test/unittests/client/tools/cppstd_required_test.py
@@ -9,6 +9,28 @@ from conans.errors import ConanInvalidConfiguration
 from conans.tools import check_min_cppstd, valid_min_cppstd
 
 
+class UserProneTests(unittest.TestCase):
+
+    def setUp(self):
+        self.conanfile = MockConanfile(MockSettings({}))
+
+    @parameterized.expand(["check_min_cppstd", "valid_min_cppstd"])
+    def test_check_none_cppstd(self, method):
+        """ Cppstd must use a valid number as described in settings.yml
+        """
+        with self.assertRaises(AssertionError) as asserts:
+            eval(method)(self.conanfile, None, False)
+        self.assertEqual("Cannot check invalid cppstd version", str(asserts.exception))
+
+    @parameterized.expand(["check_min_cppstd", "valid_min_cppstd"])
+    def test_check_none_conanfile(self, method):
+        """ conanfile must be a ConanFile object
+        """
+        with self.assertRaises(AssertionError) as raises:
+            eval(method)(None, "17", False)
+        self.assertEqual("conanfile must be a ConanFile object", str(raises.exception))
+
+
 class CheckMinCppStdTests(unittest.TestCase):
 
     def setUp(self):
@@ -25,20 +47,6 @@ class CheckMinCppStdTests(unittest.TestCase):
             settings.values["compiler.libcxx"] = libcxx
         conanfile = MockConanfile(settings)
         return conanfile
-
-    def test_check_none_cppstd(self):
-        """ Cppstd must use a valid number as described in settings.yml
-        """
-        with self.assertRaises(AssertionError) as asserts:
-            check_min_cppstd(self.conanfile, None, False)
-        self.assertEqual("Cannot check invalid cppstd version", str(asserts.exception))
-
-    def test_check_none_conanfile(self):
-        """ conanfile must be a ConanFile object
-        """
-        with self.assertRaises(AssertionError) as raises:
-            check_min_cppstd(None, "17", False)
-        self.assertEqual("conanfile must be a ConanFile object", str(raises.exception))
 
     @parameterized.expand(["98", "gnu98", "11", "gnu11", "14", "gnu14", "17", "gnu17"])
     def test_check_min_cppstd_from_settings(self, cppstd):
@@ -73,7 +81,7 @@ class CheckMinCppStdTests(unittest.TestCase):
 
     @parameterized.expand(["98", "gnu98", "11", "gnu11", "14", "gnu14", "17", "gnu17"])
     def test_check_min_cppstd_from_settings_with_extension_windows(self, cppstd):
-        """ GNU extensions has no effect on Windows
+        """ GNU extensions has no effect on Windows for check_min_cppstd
         """
         with mock.patch("platform.system", mock.MagicMock(return_value="Windows")):
             self.conanfile.settings.values["compiler.cppstd"] = "gnu17"
@@ -91,14 +99,85 @@ class CheckMinCppStdTests(unittest.TestCase):
         self.assertEqual("Current compiler does not support the required c++ standard (42).",
                          str(raises.exception))
 
-    @mock.patch("conans.client.build.cppstd_flags.cppstd_flag", return_value="42")
-    def test_check_min_cppstd_gnu_compiler_extension(self, _):
+    def test_check_min_cppstd_gnu_compiler_extension(self):
         """ Current compiler must support GNU extension on Linux when extensions is required
         """
         del self.conanfile.settings.values["compiler.cppstd"]
         with mock.patch("platform.system", mock.MagicMock(return_value="Linux")):
             with mock.patch.object(OSInfo, '_get_linux_distro_info'):
-                with self.assertRaises(ConanInvalidConfiguration) as raises:
-                    check_min_cppstd(self.conanfile, "gnu42", True)
-                self.assertEqual("Current compiler does not support GNU extensions.",
-                                 str(raises.exception))
+                with mock.patch("conans.client.tools.settings.cppstd_flag", return_value="42"):
+                    with self.assertRaises(ConanInvalidConfiguration) as raises:
+                        check_min_cppstd(self.conanfile, "gnu42", True)
+                    self.assertEqual("Current compiler does not support GNU extensions.",
+                                     str(raises.exception))
+
+
+class ValidMinCppstdTests(unittest.TestCase):
+
+    def setUp(self):
+        self.conanfile = self._create_conanfile("gcc", "9", "Linux", "17", "libcxx")
+
+    def _create_conanfile(self, compiler, version, os, cppstd, libcxx=None):
+        settings = MockSettings({"arch": "x86_64",
+                                 "build_type": "Debug",
+                                 "os": os,
+                                 "compiler": compiler,
+                                 "compiler.version": version,
+                                 "compiler.cppstd": cppstd})
+        if libcxx:
+            settings.values["compiler.libcxx"] = libcxx
+        conanfile = MockConanfile(settings)
+        return conanfile
+
+    @parameterized.expand(["98", "gnu98", "11", "gnu11", "14", "gnu14", "17", "gnu17"])
+    def test_valid_min_cppstd_from_settings(self, cppstd):
+        """ valid_min_cppstd must accept cppstd less/equal than cppstd in settings
+        """
+        self.assertTrue(valid_min_cppstd(self.conanfile, cppstd, False))
+
+    @parameterized.expand(["98", "gnu98", "11", "gnu11", "14", "gnu14"])
+    def test_valid_min_cppstd_from_outdated_settings(self, cppstd):
+        """ valid_min_cppstd returns False when cppstd is greater when supported on settings
+        """
+        self.conanfile.settings.values["compiler.cppstd"] = cppstd
+        self.assertFalse(valid_min_cppstd(self.conanfile, "17", False))
+
+    @parameterized.expand(["98", "gnu98", "11", "gnu11", "14", "gnu14", "17", "gnu17"])
+    def test_valid_min_cppstd_from_settings_with_extension(self, cppstd):
+        """ valid_min_cppstd must returns True when current cppstd in settings has GNU extension and
+            extensions is enabled
+        """
+        with mock.patch("platform.system", mock.MagicMock(return_value="Linux")):
+            with mock.patch.object(OSInfo, '_get_linux_distro_info'):
+                self.conanfile.settings.values["compiler.cppstd"] = "gnu17"
+                self.assertTrue(valid_min_cppstd(self.conanfile, cppstd, True))
+
+                self.conanfile.settings.values["compiler.cppstd"] = "17"
+                self.assertFalse(valid_min_cppstd(self.conanfile, cppstd, True))
+
+    @parameterized.expand(["98", "gnu98", "11", "gnu11", "14", "gnu14", "17", "gnu17"])
+    def test_valid_min_cppstd_from_settings_with_extension_windows(self, cppstd):
+        """ GNU extensions has no effect on Windows for valid_min_cppstd
+        """
+        with mock.patch("platform.system", mock.MagicMock(return_value="Windows")):
+            self.conanfile.settings.values["compiler.cppstd"] = "gnu17"
+            self.assertTrue(valid_min_cppstd(self.conanfile, cppstd, True))
+
+            self.conanfile.settings.values["compiler.cppstd"] = "17"
+            self.assertTrue(valid_min_cppstd(self.conanfile, cppstd, True))
+
+    def test_valid_min_cppstd_unsupported_standard(self):
+        """ valid_min_cppstd must returns False when the compiler does not support a standard
+        """
+        del self.conanfile.settings.values["compiler.cppstd"]
+        self.assertFalse(valid_min_cppstd(self.conanfile, "42", False))
+
+    def test_valid_min_cppstd_gnu_compiler_extension(self):
+        """ valid_min_cppstd must returns False when current compiler does not support GNU extension
+            on Linux and extensions is required
+        """
+        del self.conanfile.settings.values["compiler.cppstd"]
+        with mock.patch("platform.system", mock.MagicMock(return_value="Linux")):
+            with mock.patch.object(OSInfo, '_get_linux_distro_info'):
+                with mock.patch("conans.client.tools.settings.cppstd_flag", return_value="42"):
+                    self.assertFalse(valid_min_cppstd(self.conanfile, "gnu42", True))

--- a/conans/tools.py
+++ b/conans/tools.py
@@ -15,7 +15,7 @@ import requests
 from conans.client.output import ConanOutput
 # Tools from conans.client.tools
 from conans.client.tools import files as tools_files, net as tools_net, oss as tools_oss, \
-    system_pm as tools_system_pm, win as tools_win, settings as tools_settings
+    system_pm as tools_system_pm, win as tools_win
 from conans.client.tools.env import *  # pylint: disable=unused-import
 from conans.client.tools.pkg_config import *  # pylint: disable=unused-import
 from conans.client.tools.scm import *  # pylint: disable=unused-import

--- a/conans/tools.py
+++ b/conans/tools.py
@@ -15,10 +15,11 @@ import requests
 from conans.client.output import ConanOutput
 # Tools from conans.client.tools
 from conans.client.tools import files as tools_files, net as tools_net, oss as tools_oss, \
-    system_pm as tools_system_pm, win as tools_win
+    system_pm as tools_system_pm, win as tools_win, settings as tools_settings
 from conans.client.tools.env import *  # pylint: disable=unused-import
 from conans.client.tools.pkg_config import *  # pylint: disable=unused-import
 from conans.client.tools.scm import *  # pylint: disable=unused-import
+from conans.client.tools.settings import *  # pylint: disable=unused-import
 from conans.client.tools.apple import *
 from conans.client.tools.android import *
 # Tools form conans.util
@@ -192,11 +193,6 @@ WSL = tools_win.WSL
 SFU = tools_win.SFU
 unix_path = tools_win.unix_path
 run_in_windows_bash = tools_win.run_in_windows_bash
-
-
-# from conans.client.tools.settings
-cppstd_minimum_required = tools_settings.cppstd_minimum_required
-valid_minimum_cppstd = tools_settings.valid_minimum_cppstd
 
 
 @contextmanager

--- a/conans/tools.py
+++ b/conans/tools.py
@@ -15,7 +15,7 @@ import requests
 from conans.client.output import ConanOutput
 # Tools from conans.client.tools
 from conans.client.tools import files as tools_files, net as tools_net, oss as tools_oss, \
-    system_pm as tools_system_pm, win as tools_win
+    system_pm as tools_system_pm, win as tools_win, settings as tools_settings
 from conans.client.tools.env import *  # pylint: disable=unused-import
 from conans.client.tools.pkg_config import *  # pylint: disable=unused-import
 from conans.client.tools.scm import *  # pylint: disable=unused-import
@@ -192,6 +192,10 @@ WSL = tools_win.WSL
 SFU = tools_win.SFU
 unix_path = tools_win.unix_path
 run_in_windows_bash = tools_win.run_in_windows_bash
+
+
+# from conans.client.tools.settings
+cppstd_minimum_required = tools_settings.cppstd_minimum_required
 
 
 @contextmanager

--- a/conans/tools.py
+++ b/conans/tools.py
@@ -20,6 +20,7 @@ from conans.client.tools.env import *  # pylint: disable=unused-import
 from conans.client.tools.pkg_config import *  # pylint: disable=unused-import
 from conans.client.tools.scm import *  # pylint: disable=unused-import
 from conans.client.tools.settings import *  # pylint: disable=unused-import
+from conans.client.tools.settings import *  # pylint: disable=unused-import
 from conans.client.tools.apple import *
 from conans.client.tools.android import *
 # Tools form conans.util

--- a/conans/tools.py
+++ b/conans/tools.py
@@ -196,6 +196,7 @@ run_in_windows_bash = tools_win.run_in_windows_bash
 
 # from conans.client.tools.settings
 cppstd_minimum_required = tools_settings.cppstd_minimum_required
+valid_minimum_cppstd = tools_settings.valid_minimum_cppstd
 
 
 @contextmanager

--- a/conans/tools.py
+++ b/conans/tools.py
@@ -20,7 +20,6 @@ from conans.client.tools.env import *  # pylint: disable=unused-import
 from conans.client.tools.pkg_config import *  # pylint: disable=unused-import
 from conans.client.tools.scm import *  # pylint: disable=unused-import
 from conans.client.tools.settings import *  # pylint: disable=unused-import
-from conans.client.tools.settings import *  # pylint: disable=unused-import
 from conans.client.tools.apple import *
 from conans.client.tools.android import *
 # Tools form conans.util


### PR DESCRIPTION
Add a new tool: `cppstd_minimum_version`:

- Receive a ConanFile instance and handle its settings to detect the current cppstd, from profile or from arguments.
- If it is not able to detect by settings, then it will extract from current compiler (from profile) and compare if such compiler version is able to manipulate the required cppstd.
- Any failure will result in an InvalidConfiguration error.
- Why not only returning False and the user take care about the exception? 
  Because the error can be caused by compiler or settings, so we would need to return 2 elements (result + message) and the user will (probably) forward the message as an InvalidConfiguration.

NOTE: This feature should be affected by https://github.com/conan-io/conan/pull/5440

Changelog: Feature: Detect if cppstd version supported by current build
Docs: https://github.com/conan-io/docs/pull/1467

closes #5958
closes #4943 
closes #5440


- [x] Refer to the issue that supports this Pull Request.
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [x] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 

<sup>**Note:** By default this PR will skip the slower tests and will use a limited set of python versions. Check [here](https://github.com/conan-io/conan/blob/develop/.github/PR_INCREASE_TESTING.md) how to increase the testing level by writing some tags in the current PR body text.</sup>
