### PR TITLE
Feature/move settings warning

### DIFF
--- a/conans/client/cmd/export.py
+++ b/conans/client/cmd/export.py
@@ -6,7 +6,7 @@ import six
 
 from conans.client.cmd.export_linter import conan_linter
 from conans.client.file_copier import FileCopier
-from conans.client.output import ScopedOutput
+from conans.client.output import Color, ScopedOutput
 from conans.client.remover import DiskRemover
 from conans.errors import ConanException
 from conans.model.manifest import FileTreeManifest
@@ -54,7 +54,6 @@ def check_casing_conflict(cache, ref):
 
 def cmd_export(app, conanfile_path, name, version, user, channel, keep_source,
                export=True, graph_lock=None, ignore_dirty=False):
-
     """ Export the recipe
     param conanfile_path: the original source directory of the user containing a
                        conanfile.py
@@ -95,6 +94,8 @@ def cmd_export(app, conanfile_path, name, version, user, channel, keep_source,
         if graph_lock:
             graph_lock.update_exported_ref(node_id, ref)
         return ref
+
+    _check_for_warnings(conanfile, output)
 
     hook_manager.execute("pre_export", conanfile=conanfile, conanfile_path=conanfile_path,
                          reference=package_layout.ref)
@@ -191,6 +192,25 @@ def cmd_export(app, conanfile_path, name, version, user, channel, keep_source,
     if graph_lock:
         graph_lock.update_exported_ref(node_id, ref)
     return ref
+
+
+def _check_for_warnings(conanfile, output):
+    try:
+        if not 'os_build' in conanfile.settings:
+            return
+        if not 'os' in conanfile.settings:
+            return
+
+        output.writeln("*"*60, front=Color.BRIGHT_RED)
+        output.writeln("  This package defines both 'os' and 'os_build' ",
+                       front=Color.BRIGHT_RED)
+        output.writeln("  Please use 'os' for libraries and 'os_build'",
+                       front=Color.BRIGHT_RED)
+        output.writeln("  only for build-requires used for cross-building",
+                       front=Color.BRIGHT_RED)
+        output.writeln("*"*60, front=Color.BRIGHT_RED)
+    except ConanException:
+        pass
 
 
 def _capture_scm_auto_fields(conanfile, conanfile_dir, destination_folder, output, ignore_dirty):

--- a/conans/client/cmd/export.py
+++ b/conans/client/cmd/export.py
@@ -95,7 +95,7 @@ def cmd_export(app, conanfile_path, name, version, user, channel, keep_source,
             graph_lock.update_exported_ref(node_id, ref)
         return ref
 
-    _check_for_warnings(conanfile, output)
+    _check_settings_for_warnings(conanfile, output)
 
     hook_manager.execute("pre_export", conanfile=conanfile, conanfile_path=conanfile_path,
                          reference=package_layout.ref)
@@ -194,7 +194,9 @@ def cmd_export(app, conanfile_path, name, version, user, channel, keep_source,
     return ref
 
 
-def _check_for_warnings(conanfile, output):
+def _check_settings_for_warnings(conanfile, output):
+    if not conanfile.settings:
+        return
     try:
         if not 'os_build' in conanfile.settings:
             return

--- a/conans/model/conan_file.py
+++ b/conans/model/conan_file.py
@@ -2,7 +2,7 @@ import os
 from contextlib import contextmanager
 
 from conans.client import tools
-from conans.client.output import Color, ScopedOutput
+from conans.client.output import ScopedOutput
 from conans.client.tools.env import environment_append, no_op, pythonpath
 from conans.client.tools.oss import OSInfo
 from conans.errors import ConanException, ConanInvalidConfiguration
@@ -134,19 +134,6 @@ class ConanFile(object):
         self.options = create_options(self)
         self.requires = create_requirements(self)
         self.settings = create_settings(self, settings)
-
-        try:
-            if self.settings.os_build and self.settings.os:
-                self.output.writeln("*"*60, front=Color.BRIGHT_RED)
-                self.output.writeln("  This package defines both 'os' and 'os_build' ",
-                                    front=Color.BRIGHT_RED)
-                self.output.writeln("  Please use 'os' for libraries and 'os_build'",
-                                    front=Color.BRIGHT_RED)
-                self.output.writeln("  only for build-requires used for cross-building",
-                                    front=Color.BRIGHT_RED)
-                self.output.writeln("*"*60, front=Color.BRIGHT_RED)
-        except ConanException:
-            pass
 
         if 'cppstd' in self.settings.fields:
             self.output.warn("Setting 'cppstd' is deprecated in favor of 'compiler.cppstd',"

--- a/conans/test/unittests/client/cmd/export_test.py
+++ b/conans/test/unittests/client/cmd/export_test.py
@@ -27,7 +27,6 @@ class HelloConan(ConanFile):
     def package(self):
         self.copy("*.h", "include")
 """
-
         client = TestClient()
         client.save({"conanfile.py": mixed_conanfile})
         client.run("export . Hello/0.1")

--- a/conans/test/unittests/client/cmd/export_test.py
+++ b/conans/test/unittests/client/cmd/export_test.py
@@ -13,6 +13,44 @@ from conans.test.utils.tools import TestClient, TestServer, TurboTestClient
 from conans.util.files import load, save
 
 
+class ExportTest(unittest.TestCase):
+
+    def export_warning_test(self):
+        mixed_conanfile = """
+from conans import ConanFile
+
+class HelloConan(ConanFile):
+    name = "Hello"
+    version = "0.1"
+    exports = "*.h", "*.cpp"
+    settings = "os", "os_build"
+    def package(self):
+        self.copy("*.h", "include")
+"""
+
+        client = TestClient()
+        client.save({"conanfile.py": mixed_conanfile})
+        client.run("export . Hello/0.1")
+        self.assertIn("This package defines both 'os' and 'os_build'", client.out)
+
+    def export_no_warning_test(self):
+        conanfile = """
+from conans import ConanFile
+
+class HelloConan(ConanFile):
+    name = "Hello"
+    version = "0.1"
+    exports = "*.h", "*.cpp"
+    settings = "os"
+    def package(self):
+        self.copy("*.h", "include")
+"""
+        client = TestClient()
+        client.save({"conanfile.py": conanfile})
+        client.run("export . Hello/0.1")
+        self.assertNotIn("This package defines both 'os' and 'os_build'", client.out)
+
+
 class ReplaceSCMDataInConanfileTest(unittest.TestCase):
     conanfile = """
 from conans import ConanFile
@@ -48,7 +86,8 @@ class ConanLib(ConanFile):
         scm_data = SCMData(conanfile=namedtuple('_', 'scm')(scm=scm_data))
         _replace_scm_data_in_conanfile(self.conanfile_path, scm_data)
         self.assertEqual(load(self.conanfile_path), target_conanfile)
-        _parse_conanfile(conan_file_path=self.conanfile_path)  # Check that the resulting file is valid python code.
+        # Check that the resulting file is valid python code.
+        _parse_conanfile(conan_file_path=self.conanfile_path)
 
     def test_conanfile_after_scm(self):
         scm_data = {'type': 'git',
@@ -87,14 +126,14 @@ class ConanLib(ConanFile):
         conanfile = '''from conans import ConanFile
 
 def get_conanfile():
-    
+
     class BaseConanFile(ConanFile):
         scm = {
-            "type": "git", 
+            "type": "git",
             "url": "auto",
             "revision": "auto"
         }
-    
+
     return BaseConanFile
 
 class Baseline(ConanFile):


### PR DESCRIPTION
Changelog: Fix: Move the warning about mixing 'os' and 'os_build' to just before the pre_export stage
Docs: omit

Closes #4602, #5760, https://github.com/conan-io/hooks/pull/78, https://github.com/conan-io/hooks/issues/77

If required we can move the `stdcpp` global setting to the same place too. But it depends on the `conan info` test for some reason:
https://github.com/conan-io/conan/blob/develop/conans/test/functional/settings/cppstd/compiler_cppstd_test.py#L133