### PR TITLE
use win_bash in configure --help

### DIFF
--- a/conans/client/build/autotools_environment.py
+++ b/conans/client/build/autotools_environment.py
@@ -192,7 +192,7 @@ class AutoToolsBuildEnvironment(object):
         from six import StringIO  # Python 2 and 3 compatible
         mybuf = StringIO()
         try:
-            self._conanfile.run("%s/configure --help" % configure_path, output=mybuf)
+            self._conanfile.run("%s/configure --help" % configure_path, win_bash=self._win_bash, output=mybuf)
         except ConanException as e:
             self._conanfile.output.warn("Error running `configure --help`: %s" % e)
             return ""


### PR DESCRIPTION
Changelog: Bugfix: The `AutoToolsBuildEnvironment` build helper now uses the `win_bash` parameter of the constructor when calling to `configure()`.
Docs: omit
