### PR TITLE
Refactor auth/rest layer: Concurrency

### DIFF
--- a/conans/client/remote_manager.py
+++ b/conans/client/remote_manager.py
@@ -186,11 +186,11 @@ class RemoteManager(object):
         packages = filter_packages(query, packages)
         return packages
 
-    def remove(self, ref, remote):
+    def remove_recipe(self, ref, remote):
         """
         Removed conans or packages from remote
         """
-        return self._call_remote(remote, "remove", ref)
+        return self._call_remote(remote, "remove_recipe", ref)
 
     def remove_packages(self, ref, remove_ids, remote):
         """
@@ -238,11 +238,10 @@ class RemoteManager(object):
                 pref = pref.copy_with_revs(pref.ref.revision, DEFAULT_REVISION_V1)
         return pref
 
-    def _call_remote(self, remote, method, *argc, **argv):
+    def _call_remote(self, remote, method, *args, **kwargs):
         assert(isinstance(remote, Remote))
-        self._auth_manager.remote = remote
         try:
-            return getattr(self._auth_manager, method)(*argc, **argv)
+            return self._auth_manager.call_rest_api_method(remote, method, *args, **kwargs)
         except ConnectionError as exc:
             raise ConanConnectionError("%s\n\nUnable to connect to %s=%s"
                                        % (str(exc), remote.name, remote.url))

--- a/conans/client/remover.py
+++ b/conans/client/remover.py
@@ -94,7 +94,7 @@ class ConanRemover(object):
     def _remote_remove(self, ref, package_ids, remote):
         assert(isinstance(remote, Remote))
         if package_ids is None:
-            result = self._remote_manager.remove(ref, remote)
+            result = self._remote_manager.remove_recipe(ref, remote)
             return result
         else:
             tmp = self._remote_manager.remove_packages(ref, package_ids, remote)

--- a/conans/client/rest/auth_manager.py
+++ b/conans/client/rest/auth_manager.py
@@ -5,7 +5,6 @@ methods if receives AuthenticationException from RestApiClient.
 
 
 Flow:
-
     Directly invoke a REST method in RestApiClient, example: get_conan.
     if receives AuthenticationException (not open method) will ask user for login and password
     and will invoke RestApiClient.get_token() (with LOGIN_RETRIES retries) and retry to call
@@ -19,226 +18,107 @@ from conans.client.cmd.user import update_localdb
 from conans.errors import AuthenticationException, ConanException, ForbiddenException
 from conans.util.log import logger
 
+LOGIN_RETRIES = 3
 
-def input_credentials_if_unauthorized(func):
-    """Decorator. Handles AuthenticationException and request user
-    to input a user and a password"""
-    LOGIN_RETRIES = 3
 
-    def wrapper(self, *args, **kwargs):
+class ConanApiAuthManager(object):
+
+    def __init__(self, rest_client_factory, user_io, localdb):
+        self._user_io = user_io
+        self._rest_client_factory = rest_client_factory
+        self._localdb = localdb
+
+    def call_rest_api_method(self, remote, method_name, *args, **kwargs):
+        """Handles AuthenticationException and request user to input a user and a password"""
+        user, token, refresh_token = self._localdb.get_login(remote.url)
+        rest_client = self._get_rest_client(remote)
+
+        if method_name == "authenticate":
+            return self._authenticate(remote, *args, **kwargs)
+
         try:
-            # Set custom headers of mac_digest and username
-            self.set_custom_headers(self.user)
-            ret = func(self, *args, **kwargs)
+            ret = getattr(rest_client, method_name)(*args, **kwargs)
             return ret
         except ForbiddenException:
-            raise ForbiddenException("Permission denied for user: '%s'" % self.user)
+            raise ForbiddenException("Permission denied for user: '%s'" % user)
         except AuthenticationException:
             # User valid but not enough permissions
-            if self.user is None or self._rest_client.token is None:
+            if user is None or token is None:
                 # token is None when you change user with user command
                 # Anonymous is not enough, ask for a user
-                remote = self.remote
                 self._user_io.out.info('Please log in to "%s" to perform this action. '
                                        'Execute "conan user" command.' % remote.name)
                 if "bintray" in remote.url:
                     self._user_io.out.info('If you don\'t have an account sign up here: '
                                            'https://bintray.com/signup/oss')
-                return retry_with_new_token(self, *args, **kwargs)
-            elif self._rest_client.token and self._rest_client.refresh_token:
+                return self._retry_with_new_token(user, remote, method_name, *args, **kwargs)
+            elif token and refresh_token:
                 # If we have a refresh token try to refresh the access token
                 try:
-                    self.authenticate(self.user, None)
+                    self._authenticate(remote, user, None)
                 except AuthenticationException as exc:
                     logger.info("Cannot refresh the token, cleaning and retrying: {}".format(exc))
-                    self._clear_user_tokens(self.user)
-                # Set custom headers of mac_digest and username
-                self.set_custom_headers(self.user)
-                return wrapper(self, *args, **kwargs)
+                    self._clear_user_tokens_in_db(user, remote)
+                return self.call_rest_api_method(remote, method_name, *args, **kwargs)
             else:
                 # Token expired or not valid, so clean the token and repeat the call
                 # (will be anonymous call but exporting who is calling)
                 logger.info("Token expired or not valid, cleaning the saved token and retrying")
-                self._clear_user_tokens(self.user)
-                # Set custom headers of mac_digest and username
-                self.set_custom_headers(self.user)
-                return wrapper(self, *args, **kwargs)
+                self._clear_user_tokens_in_db(user, remote)
+                return self._retry_with_new_token(user, remote, method_name, *args, **kwargs)
 
-    def retry_with_new_token(self, *args, **kwargs):
+    def _retry_with_new_token(self, user, remote, method_name, *args, **kwargs):
         """Try LOGIN_RETRIES to obtain a password from user input for which
         we can get a valid token from api_client. If a token is returned,
         credentials are stored in localdb and rest method is called"""
         for _ in range(LOGIN_RETRIES):
-            user, password = self._user_io.request_login(self._remote.name, self.user)
+            input_user, input_password = self._user_io.request_login(remote.name, user)
             try:
-                self.authenticate(user, password)
+                self._authenticate(remote, input_user, input_password)
             except AuthenticationException:
-                if self.user is None:
+                if user is None:
                     self._user_io.out.error('Wrong user or password')
                 else:
-                    self._user_io.out.error(
-                        'Wrong password for user "%s"' % self.user)
-                    self._user_io.out.info(
-                        'You can change username with "conan user <username>"')
+                    self._user_io.out.error('Wrong password for user "%s"' % user)
+                    self._user_io.out.info('You can change username with "conan user <username>"')
             else:
-                self.user = user
-                # Set custom headers of mac_digest and username
-                self.set_custom_headers(user)
-                return wrapper(self, *args, **kwargs)
+                return self.call_rest_api_method(remote, method_name, *args, **kwargs)
 
         raise AuthenticationException("Too many failed login attempts, bye!")
-    return wrapper
 
+    def _get_rest_client(self, remote):
+        username, token, refresh_token = self._localdb.get_login(remote.url)
+        custom_headers = {'X-Client-Anonymous-Id': self._get_mac_digest(),
+                          'X-Client-Id': str(username or "")}
+        return self._rest_client_factory.new(remote, token, refresh_token, custom_headers)
 
-class ConanApiAuthManager(object):
-
-    def __init__(self, rest_client, user_io, localdb):
-        self._user_io = user_io
-        self._rest_client = rest_client
-        self._localdb = localdb
-        self._remote = None
-
-    @property
-    def remote(self):
-        return self._remote
-
-    @remote.setter
-    def remote(self, remote):
-        self._remote = remote
-        self._rest_client.remote_url = remote.url
-        self._rest_client.verify_ssl = remote.verify_ssl
-        tmp = self._localdb.get_login(remote.url)
-        self.user, self._rest_client.token, self._rest_client.refresh_token = tmp
-
-    def _clear_user_tokens(self, user):
-        self._rest_client.refresh_token = None
-        self._rest_client.token = None
+    def _clear_user_tokens_in_db(self, user, remote):
         try:
-            self._localdb.store(user, token=None, refresh_token=None, remote_url=self._remote.url)
+            self._localdb.store(user, token=None, refresh_token=None, remote_url=remote.url)
         except Exception as e:
-            self._user_io.out.error(
-                'Your credentials could not be stored in local cache\n')
+            self._user_io.out.error('Your credentials could not be stored in local cache\n')
             self._user_io.out.debug(str(e) + '\n')
 
     @staticmethod
-    def get_mac_digest():
+    def _get_mac_digest():
         sha1 = hashlib.sha1()
         sha1.update(str(get_mac()).encode())
         return str(sha1.hexdigest())
 
-    def set_custom_headers(self, username):
-        # First identifies our machine, second the username even if it was not
-        # authenticated
-        custom_headers = self._rest_client.custom_headers
-        custom_headers['X-Client-Anonymous-Id'] = self.get_mac_digest()
-        custom_headers['X-Client-Id'] = str(username or "")
-
-    # ######### CONAN API METHODS ##########
-    @input_credentials_if_unauthorized
-    def check_credentials(self):
-        self._rest_client.check_credentials()
-
-    @input_credentials_if_unauthorized
-    def upload_recipe(self, ref, files_to_upload, deleted, retry, retry_wait):
-        return self._rest_client.upload_recipe(ref, files_to_upload, deleted, retry, retry_wait)
-
-    @input_credentials_if_unauthorized
-    def upload_package(self, pref, files_to_upload, deleted, retry, retry_wait):
-        return self._rest_client.upload_package(pref, files_to_upload, deleted, retry, retry_wait)
-
-    @input_credentials_if_unauthorized
-    def get_recipe_manifest(self, ref):
-        return self._rest_client.get_recipe_manifest(ref)
-
-    @input_credentials_if_unauthorized
-    def get_package_manifest(self, pref):
-        return self._rest_client.get_package_manifest(pref)
-
-    @input_credentials_if_unauthorized
-    def get_package(self, pref, dest_folder):
-        return self._rest_client.get_package(pref, dest_folder)
-
-    @input_credentials_if_unauthorized
-    def get_recipe(self, ref, dest_folder):
-        return self._rest_client.get_recipe(ref, dest_folder)
-
-    @input_credentials_if_unauthorized
-    def get_recipe_snapshot(self, ref):
-        return self._rest_client.get_recipe_snapshot(ref)
-
-    @input_credentials_if_unauthorized
-    def get_recipe_sources(self, ref, dest_folder):
-        return self._rest_client.get_recipe_sources(ref, dest_folder)
-
-    @input_credentials_if_unauthorized
-    def download_files_to_folder(self, urls, dest_folder):
-        return self._rest_client.download_files_to_folder(urls, dest_folder)
-
-    @input_credentials_if_unauthorized
-    def get_package_info(self, pref):
-        return self._rest_client.get_package_info(pref)
-
-    @input_credentials_if_unauthorized
-    def get_package_snapshot(self, pref):
-        return self._rest_client.get_package_snapshot(pref)
-
-    @input_credentials_if_unauthorized
-    def search(self, pattern, ignorecase):
-        return self._rest_client.search(pattern, ignorecase)
-
-    @input_credentials_if_unauthorized
-    def search_packages(self, ref, query):
-        return self._rest_client.search_packages(ref, query)
-
-    @input_credentials_if_unauthorized
-    def remove(self, ref):
-        return self._rest_client.remove_conanfile(ref)
-
-    @input_credentials_if_unauthorized
-    def remove_packages(self, ref, package_ids):
-        return self._rest_client.remove_packages(ref, package_ids)
-
-    @input_credentials_if_unauthorized
-    def get_recipe_path(self, ref, path):
-        return self._rest_client.get_recipe_path(ref, path)
-
-    @input_credentials_if_unauthorized
-    def get_package_path(self, pref, path):
-        return self._rest_client.get_package_path(pref, path)
-
-    @input_credentials_if_unauthorized
-    def get_recipe_revisions(self, ref):
-        return self._rest_client.get_recipe_revisions(ref)
-
-    @input_credentials_if_unauthorized
-    def get_package_revisions(self, pref):
-        return self._rest_client.get_package_revisions(pref)
-
-    @input_credentials_if_unauthorized
-    def get_latest_recipe_revision(self, ref):
-        return self._rest_client.get_latest_recipe_revision(ref)
-
-    @input_credentials_if_unauthorized
-    def get_latest_package_revision(self, pref):
-        return self._rest_client.get_latest_package_revision(pref)
-
-    def authenticate(self, user, password):
-        if user is None:  # The user is already in DB, just need the passwd
-            prev_user = self._localdb.get_username(self._remote.url)
+    def _authenticate(self, remote, user, password):
+        rest_client = self._get_rest_client(remote)
+        if user is None:  # The user is already in DB, just need the password
+            prev_user = self._localdb.get_username(remote.url)
             if prev_user is None:
-                raise ConanException("User for remote '%s' is not defined" % self._remote.name)
+                raise ConanException("User for remote '%s' is not defined" % remote.name)
             else:
                 user = prev_user
-
         try:
-            token, refresh_token = self._rest_client.authenticate(user, password)
+            token, refresh_token = rest_client.authenticate(user, password)
         except UnicodeDecodeError:
             raise ConanException("Password contains not allowed symbols")
 
         # Store result in DB
         remote_name, prev_user, user = update_localdb(self._localdb, user, token, refresh_token,
-                                                      self._remote)
-        self._rest_client.token = token
-        self._rest_client.refresh_token = refresh_token
-
-        return token, refresh_token, remote_name, prev_user, user
+                                                      remote)
+        return remote_name, prev_user, user

--- a/conans/client/rest/rest_client.py
+++ b/conans/client/rest/rest_client.py
@@ -105,6 +105,7 @@ class RestApiClient(object):
 
     def upload_package(self, pref, files_to_upload, deleted, retry, retry_wait):
         return self._get_api().upload_package(pref, files_to_upload, deleted, retry, retry_wait)
+
     def authenticate(self, user, password):
         api_v1 = RestV1Methods(self._remote_url, self._token, self._custom_headers, self._output,
                                self._requester, self._verify_ssl, self._artifacts_properties)

--- a/conans/client/rest/rest_client.py
+++ b/conans/client/rest/rest_client.py
@@ -6,50 +6,68 @@ from conans.search.search import filter_packages
 from conans.util.log import logger
 
 
+class RestApiClientFactory(object):
+
+    def __init__(self, output, requester, revisions_enabled, artifacts_properties=None):
+        self._output = output
+        self._requester = requester
+        self._revisions_enabled = revisions_enabled
+        self._artifacts_properties = artifacts_properties
+        self._cached_capabilities = {}
+
+    def new(self, remote, token, refresh_token, custom_headers):
+        tmp = RestApiClient(remote, token, refresh_token, custom_headers,
+                            self._output, self._requester,
+                            self._revisions_enabled, self._cached_capabilities,
+                            self._artifacts_properties)
+        return tmp
+
+
 class RestApiClient(object):
     """
         Rest Api Client for handle remote.
     """
 
-    def __init__(self, output, requester, revisions_enabled, artifacts_properties=None):
+    def __init__(self, remote, token, refresh_token, custom_headers, output, requester,
+                 revisions_enabled, cached_capabilities, artifacts_properties=None):
 
         # Set to instance
-        self.token = None
-        self.refresh_token = None
-        self.remote_url = None
-        self.custom_headers = {}  # Can set custom headers to each request
+        self._token = token
+        self._refresh_token = refresh_token
+        self._remote_url = remote.url
+        self._custom_headers = custom_headers
         self._output = output
         self.requester = requester
 
-        # Remote manager will set it to True or False dynamically depending on the remote
-        self.verify_ssl = True
+        self._verify_ssl = remote.verify_ssl
         self._artifacts_properties = artifacts_properties
         self._revisions_enabled = revisions_enabled
 
-        self._cached_capabilities = {}
+        # This dict is shared for all the instances of RestApiClient
+        self._cached_capabilities = cached_capabilities
 
     def _capable(self, capability):
-        capabilities = self._cached_capabilities.get(self.remote_url)
+        capabilities = self._cached_capabilities.get(self._remote_url)
         if capabilities is None:
-            tmp = RestV1Methods(self.remote_url, self.token, self.custom_headers, self._output,
-                                self.requester, self.verify_ssl, self._artifacts_properties)
+            tmp = RestV1Methods(self._remote_url, self._token, self._custom_headers, self._output,
+                                self.requester, self._verify_ssl, self._artifacts_properties)
             capabilities = tmp.server_capabilities()
-            self._cached_capabilities[self.remote_url] = capabilities
+            self._cached_capabilities[self._remote_url] = capabilities
             logger.debug("REST: Cached capabilities for the remote: %s" % capabilities)
             if not self._revisions_enabled and ONLY_V2 in capabilities:
-                raise OnlyV2Available(self.remote_url)
+                raise OnlyV2Available(self._remote_url)
         return capability in capabilities
 
     def _get_api(self):
         revisions = self._capable(REVISIONS)
         if self._revisions_enabled and revisions:
             checksum_deploy = self._capable(CHECKSUM_DEPLOY)
-            return RestV2Methods(self.remote_url, self.token, self.custom_headers, self._output,
-                                 self.requester, self.verify_ssl, self._artifacts_properties,
+            return RestV2Methods(self._remote_url, self._token, self._custom_headers, self._output,
+                                 self.requester, self._verify_ssl, self._artifacts_properties,
                                  checksum_deploy)
         else:
-            return RestV1Methods(self.remote_url, self.token, self.custom_headers, self._output,
-                                 self.requester, self.verify_ssl, self._artifacts_properties)
+            return RestV1Methods(self._remote_url, self._token, self._custom_headers, self._output,
+                                 self.requester, self._verify_ssl, self._artifacts_properties)
 
     def get_recipe_manifest(self, ref):
         return self._get_api().get_recipe_manifest(ref)
@@ -89,11 +107,11 @@ class RestApiClient(object):
         return self._get_api().upload_package(pref, files_to_upload, deleted, retry, retry_wait)
 
     def authenticate(self, user, password):
-        api_v1 = RestV1Methods(self.remote_url, self.token, self.custom_headers, self._output,
-                               self.requester, self.verify_ssl, self._artifacts_properties)
+        api_v1 = RestV1Methods(self._remote_url, self._token, self._custom_headers, self._output,
+                               self.requester, self._verify_ssl, self._artifacts_properties)
 
-        if self.refresh_token and self.token:
-            token, refresh_token = api_v1.refresh_token(self.token, self.refresh_token)
+        if self._refresh_token and self._token:
+            token, refresh_token = api_v1.refresh_token(self._token, self._refresh_token)
         else:
             try:
                 # Check capabilities can raise also 401 until the new Artifactory is released
@@ -122,7 +140,7 @@ class RestApiClient(object):
         package_infos = self._get_api().search_packages(reference, query=None)
         return filter_packages(query, package_infos)
 
-    def remove_conanfile(self, ref):
+    def remove_recipe(self, ref):
         return self._get_api().remove_conanfile(ref)
 
     def remove_packages(self, ref, package_ids=None):

--- a/conans/client/rest/rest_client.py
+++ b/conans/client/rest/rest_client.py
@@ -37,7 +37,7 @@ class RestApiClient(object):
         self._remote_url = remote.url
         self._custom_headers = custom_headers
         self._output = output
-        self.requester = requester
+        self._requester = requester
 
         self._verify_ssl = remote.verify_ssl
         self._artifacts_properties = artifacts_properties
@@ -50,7 +50,7 @@ class RestApiClient(object):
         capabilities = self._cached_capabilities.get(self._remote_url)
         if capabilities is None:
             tmp = RestV1Methods(self._remote_url, self._token, self._custom_headers, self._output,
-                                self.requester, self._verify_ssl, self._artifacts_properties)
+                                self._requester, self._verify_ssl, self._artifacts_properties)
             capabilities = tmp.server_capabilities()
             self._cached_capabilities[self._remote_url] = capabilities
             logger.debug("REST: Cached capabilities for the remote: %s" % capabilities)
@@ -63,11 +63,11 @@ class RestApiClient(object):
         if self._revisions_enabled and revisions:
             checksum_deploy = self._capable(CHECKSUM_DEPLOY)
             return RestV2Methods(self._remote_url, self._token, self._custom_headers, self._output,
-                                 self.requester, self._verify_ssl, self._artifacts_properties,
+                                 self._requester, self._verify_ssl, self._artifacts_properties,
                                  checksum_deploy)
         else:
             return RestV1Methods(self._remote_url, self._token, self._custom_headers, self._output,
-                                 self.requester, self._verify_ssl, self._artifacts_properties)
+                                 self._requester, self._verify_ssl, self._artifacts_properties)
 
     def get_recipe_manifest(self, ref):
         return self._get_api().get_recipe_manifest(ref)
@@ -105,10 +105,9 @@ class RestApiClient(object):
 
     def upload_package(self, pref, files_to_upload, deleted, retry, retry_wait):
         return self._get_api().upload_package(pref, files_to_upload, deleted, retry, retry_wait)
-
     def authenticate(self, user, password):
         api_v1 = RestV1Methods(self._remote_url, self._token, self._custom_headers, self._output,
-                               self.requester, self._verify_ssl, self._artifacts_properties)
+                               self._requester, self._verify_ssl, self._artifacts_properties)
 
         if self._refresh_token and self._token:
             token, refresh_token = api_v1.refresh_token(self._token, self._refresh_token)

--- a/conans/test/functional/command/remote_verify_ssl_test.py
+++ b/conans/test/functional/command/remote_verify_ssl_test.py
@@ -16,7 +16,7 @@ class RequesterMockTrue(object):
         pass
 
     def get(self, url, *args, **kwargs):
-        assert("cacert.pem" in kwargs["verify"])
+        assert "cacert.pem" in kwargs["verify"], "TEST FAILURE: cacert.pem not in verify kwarg"
         return resp
 
 
@@ -26,7 +26,7 @@ class RequesterMockFalse(object):
         pass
 
     def get(self, url, *args, **kwargs):
-        assert(kwargs["verify"] is False)
+        assert kwargs["verify"] is False, "TEST FAILURE: verify arg is not False"
         return resp
 
 
@@ -48,7 +48,7 @@ class VerifySSLTest(unittest.TestCase):
         self.client.run("remote list")
         self.assertIn("Verify SSL: True", self.client.out)
 
-        # Verify that SSL is checked in requrests
+        # Verify that SSL is checked in requests
         self.client.run("search op* -r myremote")
 
         # Verify that SSL is not checked in requests

--- a/conans/test/functional/remote/rest_api_test.py
+++ b/conans/test/functional/remote/rest_api_test.py
@@ -3,12 +3,16 @@ import platform
 import unittest
 
 import requests
+from mock import Mock
 from nose.plugins.attrib import attr
 
 from conans import DEFAULT_REVISION_V1
+from conans.client.userio import UserIO
+from conans.client.remote_manager import Remote
 from conans.client.conf import ConanClientConfigParser
+from conans.client.rest.auth_manager import ConanApiAuthManager
 from conans.client.rest.conan_requester import ConanRequester
-from conans.client.rest.rest_client import RestApiClient
+from conans.client.rest.rest_client import RestApiClientFactory
 from conans.client.rest.rest_client_v1 import complete_url
 from conans.model.info import ConanInfo
 from conans.model.manifest import FileTreeManifest
@@ -16,7 +20,7 @@ from conans.model.ref import ConanFileReference, PackageReference
 from conans.paths import CONANFILE, CONANINFO, CONAN_MANIFEST
 from conans.test.utils.server_launcher import TestServerLauncher
 from conans.test.utils.test_files import hello_source_files, temp_folder
-from conans.test.utils.tools import TestBufferConanOutput
+from conans.test.utils.tools import TestBufferConanOutput, LocalDBMock
 from conans.util.env_reader import get_env
 from conans.util.files import md5, save
 
@@ -67,13 +71,21 @@ class RestApiTest(unittest.TestCase):
             save(filename, "")
             config = ConanClientConfigParser(filename)
             requester = ConanRequester(config, requests)
-            cls.api = RestApiClient(TestBufferConanOutput(), requester=requester,
-                                    revisions_enabled=False)
-            cls.api.remote_url = "http://127.0.0.1:%s" % str(cls.server.port)
+            client_factory = RestApiClientFactory(TestBufferConanOutput(), requester=requester,
+                                                  revisions_enabled=False)
+            localdb = LocalDBMock()
 
-            # Authenticate user
-            token, _ = cls.api.authenticate("private_user", "private_pass")
-            cls.api.token = token
+            mocked_user_io = UserIO(out=TestBufferConanOutput())
+            mocked_user_io.get_username = Mock(return_value="private_user")
+            mocked_user_io.get_password = Mock(return_value="private_pass")
+
+            cls.auth_manager = ConanApiAuthManager(client_factory, mocked_user_io, localdb)
+            cls.remote = Remote("myremote", "http://127.0.0.1:%s" % str(cls.server.port), True,
+                                True)
+            cls.auth_manager._authenticate(cls.remote, user="private_user",
+                                           password="private_pass")
+            cls.api = client_factory.new(cls.remote, localdb.access_token, localdb.refresh_token,
+                                         {})
 
     @classmethod
     def tearDownClass(cls):
@@ -205,7 +217,7 @@ class RestApiTest(unittest.TestCase):
         path1 = self.server.server_store.base_folder(ref)
         self.assertTrue(os.path.exists(path1))
         # Remove conans and packages
-        self.api.remove_conanfile(ref)
+        self.api.remove_recipe(ref)
         self.assertFalse(os.path.exists(path1))
 
     @unittest.skipIf(get_env("TESTING_REVISIONS_ENABLED", False), "Not prepared with revs")

--- a/conans/test/functional/remote/token_refresh_test.py
+++ b/conans/test/functional/remote/token_refresh_test.py
@@ -4,29 +4,10 @@ from mock import Mock
 
 from conans.client.cache.remote_registry import Remote
 from conans.client.rest.auth_manager import ConanApiAuthManager
-from conans.client.rest.rest_client import RestApiClient
+from conans.client.rest.rest_client import RestApiClientFactory
 from conans.model.ref import ConanFileReference
-from conans.test.utils.tools import TestBufferConanOutput
+from conans.test.utils.tools import TestBufferConanOutput, LocalDBMock
 from conans.client.userio import UserIO
-
-
-class LocalDBMock(object):
-
-    def __init__(self):
-        self.user = None
-        self.access_token = None
-        self.refresh_token = None
-
-    def get_login(self, _):
-        return self.user, self.access_token, self.refresh_token
-
-    def get_username(self, _):
-        return self.user
-
-    def store(self, user, access_token, refresh_token, _):
-        self.user = user
-        self.access_token = access_token
-        self.refresh_token = refresh_token
 
 
 common_headers = {"X-Conan-Server-Capabilities": "oauth_token", "Content-Type": "application/json"}
@@ -102,16 +83,18 @@ class TestTokenRefresh(unittest.TestCase):
         mocked_user_io.get_password = Mock(return_value="mypassword")
 
         requester = RequesterWithTokenMock()
-        self.rest_client = RestApiClient(mocked_user_io.out,
-                                         requester, revisions_enabled=False, artifacts_properties=None)
+        self.rest_client_factory = RestApiClientFactory(mocked_user_io.out,
+                                                        requester, revisions_enabled=False,
+                                                        artifacts_properties=None)
         self.localdb = LocalDBMock()
-        self.auth_manager = ConanApiAuthManager(self.rest_client, mocked_user_io, self.localdb)
-        self.auth_manager.remote = Remote("myremote", "myurl", True, True)
-        self.auth_manager.user = None
+        self.auth_manager = ConanApiAuthManager(self.rest_client_factory, mocked_user_io,
+                                                self.localdb)
+        self.remote = Remote("myremote", "myurl", True, True)
+        self.ref = ConanFileReference.loads("lib/1.0@conan/stable")
 
     def test_auth_with_token(self):
         """Test that if the capability is there, then we use the new endpoint"""
-        self.auth_manager.get_recipe(ConanFileReference.loads("lib/1.0@conan/stable"), ".")
+        self.auth_manager.call_rest_api_method(self.remote, "get_recipe", self.ref, ".")
         self.assertEqual(self.localdb.user, "myuser")
         self.assertEqual(self.localdb.access_token, "access_token")
         self.assertEqual(self.localdb.refresh_token, "refresh_token")
@@ -122,10 +105,8 @@ class TestTokenRefresh(unittest.TestCase):
         """
         self.localdb.access_token = "expired"
         self.localdb.refresh_token = "refresh_token"
-        self.rest_client.token = self.localdb.access_token
-        self.rest_client.refresh_token = self.localdb.refresh_token
 
-        self.auth_manager.get_recipe(ConanFileReference.loads("lib/1.0@conan/stable"), ".")
+        self.auth_manager.call_rest_api_method(self.remote, "get_recipe", self.ref, ".")
         self.assertEqual(self.localdb.user, "myuser")
         self.assertEqual(self.localdb.access_token, "refreshed_access_token")
         self.assertEqual(self.localdb.refresh_token, "refresh_token")

--- a/conans/test/utils/tools.py
+++ b/conans/test/utils/tools.py
@@ -596,6 +596,25 @@ class SVNLocalRepoTestCase(unittest.TestCase):
             shutil.rmtree(tmp_folder, ignore_errors=False, onerror=try_remove_readonly)
 
 
+class LocalDBMock(object):
+
+    def __init__(self, user=None, access_token=None, refresh_token=None):
+        self.user = user
+        self.access_token = access_token
+        self.refresh_token = refresh_token
+
+    def get_login(self, _):
+        return self.user, self.access_token, self.refresh_token
+
+    def get_username(self, _):
+        return self.user
+
+    def store(self, user, access_token, refresh_token, _):
+        self.user = user
+        self.access_token = access_token
+        self.refresh_token = refresh_token
+
+
 class MockedUserIO(UserIO):
 
     """


### PR DESCRIPTION
Changelog: omit
Docs: omit
Closes #5957 
Unlock #5856 

- The `conan_api` now uses `RestApiClientFactory` instead of a `RestApiClient`. The factory receives the "immutable" collaborators: `self.out`, `self.requester`,  `revisions_enabled` and `artifacts_properties`. On the other hand, a new `RestApiClient` is created for every request to be made, passing at that moment the `remote`, the `username`, `token` and `refresh_token`. 
- The capabilities cache is shared, on the `RestApiClientFactory`.
- The `ConanApiAuthManager` has been simplified:
    - It is not a decorator anymore.
    - All the rest methods are called from the `remote_manager` using `call_rest_api_method` (not need to declare the interface of the rest_api in this module anymore).
     - Renamed "remove" and "remove_conanfile" methods to "remove_recipe" so all of them have the same name in the different rest layers (allows proxy calls without redeclaration of methods).
- Removed state from `ConanApiAuthManager` and `RestApiClient`. All the methods/attributes are private.

 
#TAGS: slow
#REVISIONS: 1
