### PR TITLE
#6029 Force Six version to 1.12.0

### DIFF
--- a/conans/requirements.txt
+++ b/conans/requirements.txt
@@ -5,7 +5,7 @@ colorama>=0.3.3, <0.5.0
 PyYAML>=3.11, <6.0
 patch-ng==1.17.1
 fasteners>=0.14.1
-six>=1.10.0
+six==1.12.0
 node-semver==0.6.1
 distro>=1.0.2, <1.2.0
 pylint>=1.9.3, <2.0; python_version < '3'


### PR DESCRIPTION
This is another alternative for #6029. If you don't want to wait for Astroid release, we can force Six version.

Changelog: Bugfix: Fix Six package version to be compatible with Astroid
Docs: Omit
fixes #6029

- [x] Refer to the issue that supports this Pull Request.
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 

<sup>**Note:** By default this PR will skip the slower tests and will use a limited set of python versions. Check [here](https://github.com/conan-io/conan/blob/develop/.github/PR_INCREASE_TESTING.md) how to increase the testing level by writing some tags in the current PR body text.</sup>
