### PR TITLE
Remove sources when new scm changes are copied

### DIFF
--- a/conans/client/cmd/export.py
+++ b/conans/client/cmd/export.py
@@ -133,6 +133,10 @@ def cmd_export(app, conanfile_path, name, version, user, channel, keep_source,
             # Copy the local scm folder to scm_sources in the cache
             mkdir(scm_sources_folder)
             _export_scm(scm_data, local_src_folder, scm_sources_folder, output)
+            # Remove the sources, we want to get the new exported changes from the scm_sources
+            # again: https://github.com/conan-io/conan/issues/5195#issuecomment-551840597
+            sources_folder = package_layout.source()
+            rmdir(sources_folder)
 
         # Execute post-export hook before computing the digest
         hook_manager.execute("post_export", conanfile=conanfile, reference=package_layout.ref,

--- a/conans/client/cmd/export.py
+++ b/conans/client/cmd/export.py
@@ -145,7 +145,7 @@ def cmd_export(app, conanfile_path, name, version, user, channel, keep_source,
 
         # Compute the new digest
         manifest = FileTreeManifest.create(package_layout.export(), package_layout.export_sources())
-        modified_recipe = modified_recipe or not previous_manifest or previous_manifest != manifest
+        modified_recipe |= not previous_manifest or previous_manifest != manifest
         if modified_recipe:
             output.success('A new %s version was exported' % CONANFILE)
             output.info('Folder: %s' % package_layout.export())


### PR DESCRIPTION
Changelog: Bugfix: Using the `scm` feature with `auto` fields was not using correctly the freeze sources from the local user directory from the second call to `conan create`.
Docs: omit

Closes #5195 again