### PR TITLE
Fix scm base dir without ignore dirty

### DIFF
--- a/conans/client/cmd/export.py
+++ b/conans/client/cmd/export.py
@@ -220,8 +220,8 @@ def _capture_scm_auto_fields(conanfile, conanfile_dir, destination_folder, outpu
                     "'scm.revision' auto fields. Use --ignore-dirty to force it. The 'conan "
                     "upload' command will prevent uploading recipes with 'auto' values in these "
                     "fields.")
-        local_src_path = scm.get_local_path_to_url(scm_data.url) \
-            if scm_data.url != "auto" else conanfile_dir
+        origin = scm.get_qualified_remote_url(remove_credentials=True)
+        local_src_path = scm.get_local_path_to_url(origin)
         return scm_data, local_src_path
 
     if scm_data.url == "auto":

--- a/conans/test/functional/scm/scm_test.py
+++ b/conans/test/functional/scm/scm_test.py
@@ -2,7 +2,6 @@ import os
 import textwrap
 import unittest
 from collections import namedtuple
-from textwrap import dedent
 
 from nose.plugins.attrib import attr
 from parameterized.parameterized import parameterized

--- a/conans/test/functional/scm/scm_test.py
+++ b/conans/test/functional/scm/scm_test.py
@@ -1,6 +1,8 @@
 import os
+import textwrap
 import unittest
 from collections import namedtuple
+from textwrap import dedent
 
 from nose.plugins.attrib import attr
 from parameterized.parameterized import parameterized
@@ -170,6 +172,36 @@ class ConanLib(ConanFile):
         folder = self.client.cache.package_layout(ref).source()
         self.assertTrue(os.path.exists(os.path.join(folder, "mysub", "myfile.txt")))
         self.assertFalse(os.path.exists(os.path.join(folder, "mysub", "conanfile.py")))
+
+    def test_ignore_dirty_subfolder(self):
+        # https://github.com/conan-io/conan/issues/6070
+        conanfile = textwrap.dedent("""
+            import os
+            from conans import ConanFile, tools
+
+            class ConanLib(ConanFile):
+                name = "lib"
+                version = "0.1"
+                short_paths = True
+                scm = {
+                    "type": "git",
+                    "url": "auto",
+                    "revision": "auto",
+                }
+
+                def build(self):
+                    path = os.path.join("base_file.txt")
+                    assert os.path.exists(path)
+        """)
+        self.client.save({"test/main/conanfile.py": conanfile, "base_file.txt": "foo"})
+        create_local_git_repo(folder=self.client.current_folder)
+        self.client.run_command('git remote add origin https://myrepo.com.git')
+
+        # Introduce changes
+        self.client.save({"dirty_file.txt": "foo"})
+        # The build() method will verify that the files from the repository are copied ok
+        self.client.run("create test/main/conanfile.py user/channel")
+        self.assertIn("Package '{}' created".format(NO_SETTINGS_PACKAGE_ID), self.client.out)
 
     def test_auto_conanfile_no_root(self):
         """


### PR DESCRIPTION
Changelog: Bugfix: Using `scm` with `auto` values with a `conanfile.py` not being in the root scm folder it failed to export the right source code directory if not using `--ignore-dirty` and the repo was not pristine.
Docs: omit

Closes #6070

#TAGS: svn, slow