### PR TITLE
Skip cmake test step execution if cross compiling

### DIFF
--- a/conans/client/build/cmake.py
+++ b/conans/client/build/cmake.py
@@ -278,6 +278,7 @@ class CMake(object):
         if not self._conanfile.should_test:
             return
         if cross_building(self._conanfile.settings):  # We are cross building
+            settings = self._conanfile.settings
             os_build, arch_build, _, _ = get_cross_building_settings(settings)
             os_host = settings.get_safe("os")
             arch_host = settings.get_safe("arch")

--- a/conans/client/build/cmake.py
+++ b/conans/client/build/cmake.py
@@ -6,6 +6,8 @@ from itertools import chain
 from six import StringIO  # Python 2 and 3 compatible
 
 from conans.client import tools
+from conans.client.tools import cross_building
+from conans.client.tools.oss import get_cross_building_settings
 from conans.client.build import defs_to_string, join_arguments
 from conans.client.build.cmake_flags import CMakeDefinitionsBuilder, \
     get_generator, is_multi_configuration, verbose_definition, verbose_definition_name, \
@@ -275,6 +277,12 @@ class CMake(object):
     def test(self, args=None, build_dir=None, target=None, output_on_failure=False):
         if not self._conanfile.should_test:
             return
+        if cross_building(self._conanfile.settings):  # We are cross building
+            os_build, arch_build, _, _ = get_cross_building_settings(settings)
+            os_host = settings.get_safe("os")
+            arch_host = settings.get_safe("arch")
+            if os_host != os_build or arch_host != arch_build:
+                return
         if not target:
             target = "RUN_TESTS" if self.is_multi_configuration else "test"
 

--- a/conans/client/build/cmake.py
+++ b/conans/client/build/cmake.py
@@ -277,12 +277,12 @@ class CMake(object):
     def test(self, args=None, build_dir=None, target=None, output_on_failure=False):
         if not self._conanfile.should_test:
             return
-        if cross_building(self._conanfile.settings):  # We are cross building
+        if cross_building(self._conanfile.settings):  
             settings = self._conanfile.settings
             os_build, arch_build, _, _ = get_cross_building_settings(settings)
             os_host = settings.get_safe("os")
             arch_host = settings.get_safe("arch")
-            if os_host != os_build or arch_host != arch_build:
+            if (os_host and os_build and os_host != os_build) or (arch_host and arch_build and arch_host != arch_build):
                 return
         if not target:
             target = "RUN_TESTS" if self.is_multi_configuration else "test"


### PR DESCRIPTION
Changelog: Feature: Skip cmake test step execution if cross compiling
Docs: Omit

- [ ] Refer to the issue that supports this Pull Request.
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 

Cross compiled unit tests will not run on build hosts (in most casest).
This change will not run the cmake test step if the build is a cross compile build.
Maybe there is a better way to achieve this ... 
