### PR TITLE
Set cmake project version variables

### DIFF
--- a/conans/client/build/cmake_flags.py
+++ b/conans/client/build/cmake_flags.py
@@ -273,6 +273,7 @@ class CMakeDefinitionsBuilder(object):
 
         compiler = self._ss("compiler")
         compiler_version = self._ss("compiler.version")
+        version = self._ss("version")
         arch = self._ss("arch")
         os_ = self._ss("os")
         libcxx = self._ss("compiler.libcxx")
@@ -303,6 +304,13 @@ class CMakeDefinitionsBuilder(object):
             definitions["CONAN_COMPILER"] = compiler
         if compiler_version:
             definitions["CONAN_COMPILER_VERSION"] = str(compiler_version)
+        if version:
+            definitions['PROJECT_VERSION'] = str(version)
+            version_numbers = str(version).split(".")
+            definitions['PROJECT_VERSION_MAJOR'] = str(version_numbers[0]) if len(version_numbers) > 0 else ""
+            definitions['PROJECT_VERSION_MINOR'] = str(version_numbers[1]) if len(version_numbers) > 1 else ""
+            definitions['PROJECT_VERSION_PATCH'] = str(version_numbers[2]) if len(version_numbers) > 2 else ""
+            definitions['PROJECT_VERSION_TWEAK'] = str(version_numbers[3]) if len(version_numbers) > 3 else ""
 
         # C, CXX, LINK FLAGS
         if compiler == "Visual Studio":

--- a/conans/client/build/cmake_flags.py
+++ b/conans/client/build/cmake_flags.py
@@ -273,7 +273,6 @@ class CMakeDefinitionsBuilder(object):
 
         compiler = self._ss("compiler")
         compiler_version = self._ss("compiler.version")
-        version = self._ss("version")
         arch = self._ss("arch")
         os_ = self._ss("os")
         libcxx = self._ss("compiler.libcxx")
@@ -304,6 +303,9 @@ class CMakeDefinitionsBuilder(object):
             definitions["CONAN_COMPILER"] = compiler
         if compiler_version:
             definitions["CONAN_COMPILER_VERSION"] = str(compiler_version)
+
+        # CMake Project Version setting
+        version = self._conanfile.version
         if version:
             definitions['PROJECT_VERSION'] = str(version)
             version_numbers = str(version).split(".")


### PR DESCRIPTION
Changelog: Feature: Set cmake project version variables
Docs: Omit

- [ ] Refer to the issue that supports this Pull Request.
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 

CMake allows to define versions with the project macro (https://cmake.org/cmake/help/latest/command/project.html#command:project).
As the versions are already defined in the conan version property this is duplicated information.
This patch passes conan version numbers to cmake (as defaults). It is still possible to override the versions in cmake again. 