### PR TITLE
Move outside cmake_flags definitions of CONAN_EXPORTED

### DIFF
--- a/conans/client/build/cmake.py
+++ b/conans/client/build/cmake.py
@@ -11,7 +11,7 @@ from conans.client.build.cmake_flags import CMakeDefinitionsBuilder, \
     get_generator, is_multi_configuration, verbose_definition, verbose_definition_name, \
     cmake_install_prefix_var_name, get_toolset, build_type_definition, \
     cmake_in_local_cache_var_name, runtime_definition_var_name, get_generator_platform, \
-    is_generator_platform_supported, is_toolset_supported, in_local_cache_definition
+    is_generator_platform_supported, is_toolset_supported
 from conans.client.output import ConanOutput
 from conans.client.tools.oss import cpu_count, args_to_string
 from conans.errors import ConanException
@@ -63,19 +63,17 @@ class CMake(object):
                                           make_program=make_program, parallel=parallel,
                                           generator=self.generator,
                                           set_cmake_flags=set_cmake_flags,
+                                          forced_build_type=build_type,
                                           output=self._conanfile.output)
         # FIXME CONAN 2.0: CMake() interface should be always the constructor and self.definitions.
         # FIXME CONAN 2.0: Avoid properties and attributes to make the user interface more clear
 
         self.definitions = builder.get_definitions()
         self.definitions["CONAN_EXPORTED"] = "1"
-        self.definitions.update(in_local_cache_definition(self._conanfile.in_local_cache))
 
         self.toolset = toolset or get_toolset(self._settings)
         self.build_dir = None
         self.msbuild_verbosity = os.getenv("CONAN_MSBUILD_VERBOSITY") or msbuild_verbosity
-
-        self.build_type = self._build_type
 
     @property
     def build_folder(self):
@@ -92,11 +90,9 @@ class CMake(object):
     @build_type.setter
     def build_type(self, build_type):
         settings_build_type = self._settings.get_safe("build_type")
-        if build_type != settings_build_type:
-            self._conanfile.output.warn("Forced CMake build type ('%s') different from the settings"
-                                        " build type ('%s')" % (build_type, settings_build_type))
         self.definitions.pop("CMAKE_BUILD_TYPE", None)
-        self.definitions.update(build_type_definition(build_type, self.generator))
+        self.definitions.update(build_type_definition(build_type, settings_build_type,
+                                                      self.generator, self._conanfile.output))
         self._build_type = build_type
 
     @property

--- a/conans/client/build/cmake.py
+++ b/conans/client/build/cmake.py
@@ -11,7 +11,7 @@ from conans.client.build.cmake_flags import CMakeDefinitionsBuilder, \
     get_generator, is_multi_configuration, verbose_definition, verbose_definition_name, \
     cmake_install_prefix_var_name, get_toolset, build_type_definition, \
     cmake_in_local_cache_var_name, runtime_definition_var_name, get_generator_platform, \
-    is_generator_platform_supported, is_toolset_supported
+    is_generator_platform_supported, is_toolset_supported, in_local_cache_definition
 from conans.client.output import ConanOutput
 from conans.client.tools.oss import cpu_count, args_to_string
 from conans.errors import ConanException
@@ -63,15 +63,19 @@ class CMake(object):
                                           make_program=make_program, parallel=parallel,
                                           generator=self.generator,
                                           set_cmake_flags=set_cmake_flags,
-                                          forced_build_type=build_type,
                                           output=self._conanfile.output)
         # FIXME CONAN 2.0: CMake() interface should be always the constructor and self.definitions.
         # FIXME CONAN 2.0: Avoid properties and attributes to make the user interface more clear
 
         self.definitions = builder.get_definitions()
+        self.definitions["CONAN_EXPORTED"] = "1"
+        self.definitions.update(in_local_cache_definition(self._conanfile.in_local_cache))
+
         self.toolset = toolset or get_toolset(self._settings)
         self.build_dir = None
         self.msbuild_verbosity = os.getenv("CONAN_MSBUILD_VERBOSITY") or msbuild_verbosity
+
+        self.build_type = self._build_type
 
     @property
     def build_folder(self):

--- a/conans/client/build/cmake_flags.py
+++ b/conans/client/build/cmake_flags.py
@@ -128,15 +128,13 @@ def build_type_definition(build_type, generator):
 class CMakeDefinitionsBuilder(object):
 
     def __init__(self, conanfile, cmake_system_name=True, make_program=None,
-                 parallel=True, generator=None, set_cmake_flags=False,
-                 forced_build_type=None, output=None):
+                 parallel=True, generator=None, set_cmake_flags=False, output=None):
         self._conanfile = conanfile
         self._forced_cmake_system_name = cmake_system_name
         self._make_program = make_program
         self._parallel = parallel
         self._generator = generator
         self._set_cmake_flags = set_cmake_flags
-        self._forced_build_type = forced_build_type
         self._output = output
 
     def _ss(self, setname):
@@ -277,17 +275,9 @@ class CMakeDefinitionsBuilder(object):
         os_ = self._ss("os")
         libcxx = self._ss("compiler.libcxx")
         runtime = self._ss("compiler.runtime")
-        build_type = self._ss("build_type")
 
         definitions = OrderedDict()
         definitions.update(runtime_definition(runtime))
-
-        if self._forced_build_type and self._forced_build_type != build_type:
-            self._output.warn("Forced CMake build type ('%s') different from the settings build "
-                              "type ('%s')" % (self._forced_build_type, build_type))
-            build_type = self._forced_build_type
-
-        definitions.update(build_type_definition(build_type, self._generator))
 
         if str(os_) == "Macos":
             if arch == "x86":
@@ -295,9 +285,6 @@ class CMakeDefinitionsBuilder(object):
 
         definitions.update(self._cmake_cross_build_defines())
         definitions.update(self._get_cpp_standard_vars())
-
-        definitions["CONAN_EXPORTED"] = "1"
-        definitions.update(in_local_cache_definition(self._conanfile.in_local_cache))
 
         if compiler:
             definitions["CONAN_COMPILER"] = compiler

--- a/conans/test/functional/build_helpers/cmake_flags_test.py
+++ b/conans/test/functional/build_helpers/cmake_flags_test.py
@@ -445,7 +445,7 @@ conan_basic_setup()
         self.assertNotIn("Conan: Adjusting fPIC flag", client.out)
 
     def header_only_generator_test(self):
-        """ Test cmake.install() is possible although Generetaor could not be deduced from
+        """ Test cmake.install() is possible although Generator could not be deduced from
         settings
         """
         conanfile = dedent("""
@@ -474,8 +474,7 @@ conan_basic_setup()
         client.run("create . danimtb/testing")
         if platform.system() == "Windows":
             self.assertIn("WARN: CMake generator could not be deduced from settings", client.out)
-            self.assertIn('Configure command: -DCONAN_EXPORTED="1" -DCONAN_IN_LOCAL_CACHE="ON" '
-                          '-DCMAKE_INSTALL_PREFIX=', client.out)
+            self.assertIn('Configure command: -DCMAKE_INSTALL_PREFIX=', client.out)
         else:
-            self.assertIn('Configure command: -G "Unix Makefiles" -DCONAN_EXPORTED="1" '
-                          '-DCONAN_IN_LOCAL_CACHE="ON" -DCMAKE_INSTALL_PREFIX=', client.out)
+            self.assertIn('Configure command: -G "Unix Makefiles" '
+                          '-DCMAKE_INSTALL_PREFIX=', client.out)

--- a/conans/test/functional/build_helpers/cmake_flags_test.py
+++ b/conans/test/functional/build_helpers/cmake_flags_test.py
@@ -445,7 +445,7 @@ conan_basic_setup()
         self.assertNotIn("Conan: Adjusting fPIC flag", client.out)
 
     def header_only_generator_test(self):
-        """ Test cmake.install() is possible although Generator could not be deduced from
+        """ Test cmake.install() is possible although Generetaor could not be deduced from
         settings
         """
         conanfile = dedent("""
@@ -474,7 +474,8 @@ conan_basic_setup()
         client.run("create . danimtb/testing")
         if platform.system() == "Windows":
             self.assertIn("WARN: CMake generator could not be deduced from settings", client.out)
-            self.assertIn('Configure command: -DCMAKE_INSTALL_PREFIX=', client.out)
+            self.assertIn('Configure command: -DCONAN_IN_LOCAL_CACHE="ON" '
+                          '-DCMAKE_INSTALL_PREFIX=', client.out)
         else:
             self.assertIn('Configure command: -G "Unix Makefiles" '
-                          '-DCMAKE_INSTALL_PREFIX=', client.out)
+                          '-DCONAN_IN_LOCAL_CACHE="ON" -DCMAKE_INSTALL_PREFIX=', client.out)

--- a/conans/test/unittests/client/build/cmake_test.py
+++ b/conans/test/unittests/client/build/cmake_test.py
@@ -411,16 +411,17 @@ class CMakeTest(unittest.TestCase):
                           if platform.system() != "Linux" else ""
             generator = "MinGW Makefiles" if platform.system() == "Windows" else "Unix Makefiles"
 
-            flags = '-DCONAN_EXPORTED="1"{} -DCONAN_COMPILER="gcc" ' \
-                    '-DCONAN_COMPILER_VERSION="6.3" ' \
+            flags = '{linux_stuff}' \
+                    '-DCONAN_COMPILER="gcc" -DCONAN_COMPILER_VERSION="6.3" ' \
                     '-DCONAN_CXX_FLAGS="-m32" -DCONAN_SHARED_LINKER_FLAGS="-m32" ' \
-                    '-DCONAN_C_FLAGS="-m32" -DCMAKE_EXPORT_NO_PACKAGE_REGISTRY="ON"'
+                    '-DCONAN_C_FLAGS="-m32" ' \
+                    '-DCMAKE_EXPORT_NO_PACKAGE_REGISTRY="ON" ' \
+                    '-DCONAN_EXPORTED="1"{{}} -DCMAKE_BUILD_TYPE="Release"'.format(linux_stuff=linux_stuff)
             flags_in_local_cache = flags.format(' -D' + cmake_in_local_cache_var_name + '="ON"')
             flags_no_local_cache = flags.format(' -D' + cmake_in_local_cache_var_name + '="OFF"')
 
-            base_cmd = 'cmake -G "{generator}" -DCMAKE_BUILD_TYPE="Release" {linux_stuff}' \
-                       '{{flags}} -Wno-dev'
-            base_cmd = base_cmd.format(generator=generator, linux_stuff=linux_stuff)
+            base_cmd = 'cmake -G "{generator}" {{flags}} -Wno-dev'
+            base_cmd = base_cmd.format(generator=generator)
             full_cmd = "cd {build_expected} && {base_cmd} {source_expected}"
 
             build_expected = quote_var("build")
@@ -582,7 +583,7 @@ class CMakeTest(unittest.TestCase):
                          if (platform.system() != os and cmake_system_name) else "")
                 cmake = CMake(conanfile, generator=generator, cmake_system_name=cmake_system_name,
                               set_cmake_flags=set_cmake_flags)
-                new_text = text.replace("-DCONAN_EXPORTED", "%s-DCONAN_EXPORTED" % cross)
+                new_text = text.replace("-DCONAN_COMPILER=", "%s-DCONAN_COMPILER=" % cross)
                 if "Visual Studio" in text:
                     cores = ('-DCONAN_CXX_FLAGS="/MP{0}" '
                              '-DCONAN_C_FLAGS="/MP{0}" '.format(tools.cpu_count(conanfile.output)))
@@ -592,64 +593,75 @@ class CMakeTest(unittest.TestCase):
                 self.assertEqual(new_text, cmake.command_line)
                 self.assertEqual(build_config, cmake.build_config)
 
-        check('-G "Visual Studio 12 2013" -DCONAN_EXPORTED="1" -DCONAN_IN_LOCAL_CACHE="OFF" '
+        check('-G "Visual Studio 12 2013" '
               '-DCONAN_COMPILER="Visual Studio" -DCONAN_COMPILER_VERSION="12" '
-              '-DCMAKE_EXPORT_NO_PACKAGE_REGISTRY="ON" -Wno-dev',
+              '-DCMAKE_EXPORT_NO_PACKAGE_REGISTRY="ON" -DCONAN_EXPORTED="1" '
+              '-DCONAN_IN_LOCAL_CACHE="OFF" -Wno-dev',
               "")
 
-        check('-G "Custom Generator" -DCONAN_EXPORTED="1" -DCONAN_IN_LOCAL_CACHE="OFF" '
+        check('-G "Custom Generator" '
               '-DCONAN_COMPILER="Visual Studio" -DCONAN_COMPILER_VERSION="12" '
-              '-DCMAKE_EXPORT_NO_PACKAGE_REGISTRY="ON" -Wno-dev',
+              '-DCMAKE_EXPORT_NO_PACKAGE_REGISTRY="ON" -DCONAN_EXPORTED="1" '
+              '-DCONAN_IN_LOCAL_CACHE="OFF" -Wno-dev',
               '', generator="Custom Generator")
 
-        check('-G "Custom Generator" -DCONAN_EXPORTED="1" -DCONAN_IN_LOCAL_CACHE="OFF" '
+        check('-G "Custom Generator" '
               '-DCONAN_COMPILER="Visual Studio" -DCONAN_COMPILER_VERSION="12" '
-              '-DCMAKE_EXPORT_NO_PACKAGE_REGISTRY="ON" -Wno-dev',
+              '-DCMAKE_EXPORT_NO_PACKAGE_REGISTRY="ON" -DCONAN_EXPORTED="1" '
+              '-DCONAN_IN_LOCAL_CACHE="OFF" -Wno-dev',
               '', generator="Custom Generator", set_cmake_flags=True)
 
         settings.build_type = "Debug"
-        check('-G "Visual Studio 12 2013" -DCONAN_EXPORTED="1" -DCONAN_IN_LOCAL_CACHE="OFF" '
+        check('-G "Visual Studio 12 2013" '
               '-DCONAN_COMPILER="Visual Studio" -DCONAN_COMPILER_VERSION="12" '
-              '-DCMAKE_EXPORT_NO_PACKAGE_REGISTRY="ON" -Wno-dev',
+              '-DCMAKE_EXPORT_NO_PACKAGE_REGISTRY="ON" -DCONAN_EXPORTED="1" '
+              '-DCONAN_IN_LOCAL_CACHE="OFF" -Wno-dev',
               '--config Debug')
 
         settings.arch = "x86_64"
-        check('-G "Visual Studio 12 2013 Win64" -DCONAN_EXPORTED="1" -DCONAN_IN_LOCAL_CACHE="OFF" '
+        check('-G "Visual Studio 12 2013 Win64" '
               '-DCONAN_COMPILER="Visual Studio" -DCONAN_COMPILER_VERSION="12" '
-              '-DCMAKE_EXPORT_NO_PACKAGE_REGISTRY="ON" -Wno-dev',
+              '-DCMAKE_EXPORT_NO_PACKAGE_REGISTRY="ON" -DCONAN_EXPORTED="1" '
+              '-DCONAN_IN_LOCAL_CACHE="OFF" -Wno-dev',
               '--config Debug')
 
         settings.compiler = "gcc"
         settings.compiler.version = "4.8"
         generator = "MinGW Makefiles" if platform.system() == "Windows" else "Unix Makefiles"
-        check('-G "%s" -DCMAKE_BUILD_TYPE="Debug" -DCONAN_EXPORTED="1" -DCONAN_IN_LOCAL_CACHE="OFF" '
+        check('-G "%s" '
               '-DCONAN_COMPILER="gcc" -DCONAN_COMPILER_VERSION="4.8" -DCONAN_CXX_FLAGS="-m64" '
               '-DCONAN_SHARED_LINKER_FLAGS="-m64" -DCONAN_C_FLAGS="-m64" '
-              '-DCMAKE_EXPORT_NO_PACKAGE_REGISTRY="ON" -Wno-dev' % generator, "")
+              '-DCMAKE_EXPORT_NO_PACKAGE_REGISTRY="ON" -DCONAN_EXPORTED="1" '
+              '-DCONAN_IN_LOCAL_CACHE="OFF" -DCMAKE_BUILD_TYPE="Debug" -Wno-dev' % generator, "")
 
         settings.os = "Linux"
         settings.arch = "x86"
-        check('-G "%s" -DCMAKE_BUILD_TYPE="Debug"'
-              ' -DCONAN_EXPORTED="1" -DCONAN_IN_LOCAL_CACHE="OFF" -DCONAN_COMPILER="gcc" '
+        check('-G "%s" '
+              '-DCONAN_COMPILER="gcc" '
               '-DCONAN_COMPILER_VERSION="4.8" -DCONAN_CXX_FLAGS="-m32" '
               '-DCONAN_SHARED_LINKER_FLAGS="-m32" -DCONAN_C_FLAGS="-m32" '
-              '-DCMAKE_EXPORT_NO_PACKAGE_REGISTRY="ON" -Wno-dev' % generator,
+              '-DCMAKE_EXPORT_NO_PACKAGE_REGISTRY="ON" '
+              '-DCONAN_EXPORTED="1" -DCONAN_IN_LOCAL_CACHE="OFF" -DCMAKE_BUILD_TYPE="Debug" '
+              '-Wno-dev' % generator,
               "")
 
         settings.arch = "x86_64"
-        check('-G "%s" -DCMAKE_BUILD_TYPE="Debug"'
-              ' -DCONAN_EXPORTED="1" -DCONAN_IN_LOCAL_CACHE="OFF" -DCONAN_COMPILER="gcc" '
+        check('-G "%s" '
+              '-DCONAN_COMPILER="gcc" '
               '-DCONAN_COMPILER_VERSION="4.8" -DCONAN_CXX_FLAGS="-m64" '
               '-DCONAN_SHARED_LINKER_FLAGS="-m64" -DCONAN_C_FLAGS="-m64" '
-              '-DCMAKE_EXPORT_NO_PACKAGE_REGISTRY="ON" -Wno-dev' % generator,
+              '-DCMAKE_EXPORT_NO_PACKAGE_REGISTRY="ON" '
+              '-DCONAN_EXPORTED="1" -DCONAN_IN_LOCAL_CACHE="OFF" -DCMAKE_BUILD_TYPE="Debug" '
+              '-Wno-dev' % generator,
               "")
 
-        check('-G "%s" -DCMAKE_BUILD_TYPE="Debug"'
-              ' -DCONAN_EXPORTED="1" -DCONAN_IN_LOCAL_CACHE="OFF" -DCONAN_COMPILER="gcc" '
+        check('-G "%s" '
+              '-DCONAN_COMPILER="gcc" '
               '-DCONAN_COMPILER_VERSION="4.8" -DCONAN_CXX_FLAGS="-m64" '
               '-DCONAN_SHARED_LINKER_FLAGS="-m64" -DCONAN_C_FLAGS="-m64" '
               '-DCMAKE_CXX_FLAGS="-m64" -DCMAKE_SHARED_LINKER_FLAGS="-m64" -DCMAKE_C_FLAGS="-m64" '
               '-DCMAKE_EXPORT_NO_PACKAGE_REGISTRY="ON" '
+              '-DCONAN_EXPORTED="1" -DCONAN_IN_LOCAL_CACHE="OFF" -DCMAKE_BUILD_TYPE="Debug" '
               '-Wno-dev' % generator,
               "", set_cmake_flags=True)
 
@@ -657,55 +669,67 @@ class CMakeTest(unittest.TestCase):
         settings.compiler = "clang"
         settings.compiler.version = "3.8"
         settings.arch = "x86"
-        check('-G "%s" -DCMAKE_BUILD_TYPE="Debug"'
-              ' -DCONAN_EXPORTED="1" -DCONAN_IN_LOCAL_CACHE="OFF" -DCONAN_COMPILER="clang" '
+        check('-G "%s" '
+              '-DCONAN_COMPILER="clang" '
               '-DCONAN_COMPILER_VERSION="3.8" -DCONAN_CXX_FLAGS="-m32" '
               '-DCONAN_SHARED_LINKER_FLAGS="-m32" -DCONAN_C_FLAGS="-m32" '
-              '-DCMAKE_EXPORT_NO_PACKAGE_REGISTRY="ON" -Wno-dev' % generator,
+              '-DCMAKE_EXPORT_NO_PACKAGE_REGISTRY="ON" '
+              '-DCONAN_EXPORTED="1" -DCONAN_IN_LOCAL_CACHE="OFF" -DCMAKE_BUILD_TYPE="Debug" '
+              '-Wno-dev' % generator,
               "")
 
         settings.arch = "x86_64"
-        check('-G "%s" -DCMAKE_BUILD_TYPE="Debug"'
-              ' -DCONAN_EXPORTED="1" -DCONAN_IN_LOCAL_CACHE="OFF" -DCONAN_COMPILER="clang" '
+        check('-G "%s" '
+              '-DCONAN_COMPILER="clang" '
               '-DCONAN_COMPILER_VERSION="3.8" -DCONAN_CXX_FLAGS="-m64" '
               '-DCONAN_SHARED_LINKER_FLAGS="-m64" -DCONAN_C_FLAGS="-m64" '
-              '-DCMAKE_EXPORT_NO_PACKAGE_REGISTRY="ON" -Wno-dev' % generator,
+              '-DCMAKE_EXPORT_NO_PACKAGE_REGISTRY="ON" '
+              '-DCONAN_EXPORTED="1" -DCONAN_IN_LOCAL_CACHE="OFF" -DCMAKE_BUILD_TYPE="Debug" '
+              '-Wno-dev' % generator,
               "")
 
         settings.os = "SunOS"
         settings.compiler = "sun-cc"
         settings.compiler.version = "5.10"
         settings.arch = "x86"
-        check('-G "%s" -DCMAKE_BUILD_TYPE="Debug"'
-              ' -DCONAN_EXPORTED="1" -DCONAN_IN_LOCAL_CACHE="OFF" -DCONAN_COMPILER="sun-cc" '
+        check('-G "%s" '
+              '-DCONAN_COMPILER="sun-cc" '
               '-DCONAN_COMPILER_VERSION="5.10" -DCONAN_CXX_FLAGS="-m32" '
               '-DCONAN_SHARED_LINKER_FLAGS="-m32" -DCONAN_C_FLAGS="-m32" '
-              '-DCMAKE_EXPORT_NO_PACKAGE_REGISTRY="ON" -Wno-dev' % generator,
+              '-DCMAKE_EXPORT_NO_PACKAGE_REGISTRY="ON" '
+              '-DCONAN_EXPORTED="1" -DCONAN_IN_LOCAL_CACHE="OFF" -DCMAKE_BUILD_TYPE="Debug" '
+              '-Wno-dev' % generator,
               "")
 
         settings.arch = "x86_64"
-        check('-G "%s" -DCMAKE_BUILD_TYPE="Debug"'
-              ' -DCONAN_EXPORTED="1" -DCONAN_IN_LOCAL_CACHE="OFF" -DCONAN_COMPILER="sun-cc" '
+        check('-G "%s" '
+              '-DCONAN_COMPILER="sun-cc" '
               '-DCONAN_COMPILER_VERSION="5.10" -DCONAN_CXX_FLAGS="-m64" '
               '-DCONAN_SHARED_LINKER_FLAGS="-m64" -DCONAN_C_FLAGS="-m64" '
-              '-DCMAKE_EXPORT_NO_PACKAGE_REGISTRY="ON" -Wno-dev' % generator,
+              '-DCMAKE_EXPORT_NO_PACKAGE_REGISTRY="ON" '
+              '-DCONAN_EXPORTED="1" -DCONAN_IN_LOCAL_CACHE="OFF" -DCMAKE_BUILD_TYPE="Debug" '
+              '-Wno-dev' % generator,
               "")
 
         settings.arch = "sparc"
 
-        check('-G "%s" -DCMAKE_BUILD_TYPE="Debug" -DCONAN_EXPORTED="1" -DCONAN_IN_LOCAL_CACHE="OFF" '
+        check('-G "%s" '
               '-DCONAN_COMPILER="sun-cc" '
               '-DCONAN_COMPILER_VERSION="5.10" -DCONAN_CXX_FLAGS="-m32" '
               '-DCONAN_SHARED_LINKER_FLAGS="-m32" -DCONAN_C_FLAGS="-m32" '
-              '-DCMAKE_EXPORT_NO_PACKAGE_REGISTRY="ON" -Wno-dev' % generator,
+              '-DCMAKE_EXPORT_NO_PACKAGE_REGISTRY="ON" '
+              '-DCONAN_EXPORTED="1" -DCONAN_IN_LOCAL_CACHE="OFF" -DCMAKE_BUILD_TYPE="Debug" '
+              '-Wno-dev' % generator,
               "")
 
         settings.arch = "sparcv9"
-        check('-G "%s" -DCMAKE_BUILD_TYPE="Debug" -DCONAN_EXPORTED="1" -DCONAN_IN_LOCAL_CACHE="OFF" '
+        check('-G "%s" '
               '-DCONAN_COMPILER="sun-cc" '
               '-DCONAN_COMPILER_VERSION="5.10" -DCONAN_CXX_FLAGS="-m64" '
               '-DCONAN_SHARED_LINKER_FLAGS="-m64" -DCONAN_C_FLAGS="-m64" '
-              '-DCMAKE_EXPORT_NO_PACKAGE_REGISTRY="ON" -Wno-dev' % generator,
+              '-DCMAKE_EXPORT_NO_PACKAGE_REGISTRY="ON" '
+              '-DCONAN_EXPORTED="1" -DCONAN_IN_LOCAL_CACHE="OFF" -DCMAKE_BUILD_TYPE="Debug" '
+              '-Wno-dev' % generator,
               "")
 
         settings.compiler = "Visual Studio"
@@ -713,28 +737,32 @@ class CMakeTest(unittest.TestCase):
         settings.os = "WindowsStore"
         settings.os.version = "8.1"
         settings.build_type = "Debug"
-        check('-G "Visual Studio 12 2013" -DCONAN_EXPORTED="1" -DCONAN_IN_LOCAL_CACHE="OFF" '
+        check('-G "Visual Studio 12 2013" '
               '-DCONAN_COMPILER="Visual Studio" -DCONAN_COMPILER_VERSION="12" '
-              '-DCMAKE_EXPORT_NO_PACKAGE_REGISTRY="ON" -Wno-dev',
+              '-DCMAKE_EXPORT_NO_PACKAGE_REGISTRY="ON" '
+              '-DCONAN_EXPORTED="1" -DCONAN_IN_LOCAL_CACHE="OFF" -Wno-dev',
               "--config Debug")
 
         settings.os.version = "10.0"
-        check('-G "Visual Studio 12 2013" -DCONAN_EXPORTED="1" -DCONAN_IN_LOCAL_CACHE="OFF" '
+        check('-G "Visual Studio 12 2013" '
               '-DCONAN_COMPILER="Visual Studio" -DCONAN_COMPILER_VERSION="12" '
-              '-DCMAKE_EXPORT_NO_PACKAGE_REGISTRY="ON" -Wno-dev',
+              '-DCMAKE_EXPORT_NO_PACKAGE_REGISTRY="ON" '
+              '-DCONAN_EXPORTED="1" -DCONAN_IN_LOCAL_CACHE="OFF" -Wno-dev',
               "--config Debug")
 
         settings.compiler.version = "15"
         settings.arch = "armv8"
-        check('-G "Visual Studio 15 2017 ARM" -DCONAN_EXPORTED="1" -DCONAN_IN_LOCAL_CACHE="OFF" '
+        check('-G "Visual Studio 15 2017 ARM" '
               '-DCONAN_COMPILER="Visual Studio" -DCONAN_COMPILER_VERSION="15" '
-              '-DCMAKE_EXPORT_NO_PACKAGE_REGISTRY="ON" -Wno-dev',
+              '-DCMAKE_EXPORT_NO_PACKAGE_REGISTRY="ON" '
+              '-DCONAN_EXPORTED="1" -DCONAN_IN_LOCAL_CACHE="OFF" -Wno-dev',
               "--config Debug")
 
         settings.arch = "x86_64"
-        check('-G "Visual Studio 15 2017 Win64" -DCONAN_EXPORTED="1" -DCONAN_IN_LOCAL_CACHE="OFF" '
+        check('-G "Visual Studio 15 2017 Win64" '
               '-DCONAN_COMPILER="Visual Studio" -DCONAN_COMPILER_VERSION="15" '
-              '-DCMAKE_EXPORT_NO_PACKAGE_REGISTRY="ON" -Wno-dev',
+              '-DCMAKE_EXPORT_NO_PACKAGE_REGISTRY="ON" '
+              '-DCONAN_EXPORTED="1" -DCONAN_IN_LOCAL_CACHE="OFF" -Wno-dev',
               "--config Debug")
 
         settings.compiler = "Visual Studio"
@@ -745,9 +773,9 @@ class CMakeTest(unittest.TestCase):
         settings.build_type = "Debug"
         check('-G "Visual Studio 9 2008" '
               '-A "Your platform name (ARMv4I)" '
-              '-DCONAN_EXPORTED="1" -DCONAN_IN_LOCAL_CACHE="OFF" '
               '-DCONAN_COMPILER="Visual Studio" -DCONAN_COMPILER_VERSION="9" '
-              '-DCMAKE_EXPORT_NO_PACKAGE_REGISTRY="ON" -Wno-dev',
+              '-DCMAKE_EXPORT_NO_PACKAGE_REGISTRY="ON" '
+              '-DCONAN_EXPORTED="1" -DCONAN_IN_LOCAL_CACHE="OFF" -Wno-dev',
               "--config Debug")
 
     def deleted_os_test(self):
@@ -771,11 +799,13 @@ build_type: [ Release]
         generator = "Unix" if platform.system() != "Windows" else "MinGW"
         cross = ("-DCMAKE_SYSTEM_NAME=\"Linux\" -DCMAKE_SYSROOT=\"/path/to/sysroot\" "
                  if platform.system() != "Linux" else "")
-        self.assertEqual('-G "%s Makefiles" %s-DCONAN_EXPORTED="1" -DCONAN_IN_LOCAL_CACHE="OFF" '
+        self.assertEqual('-G "%s Makefiles" %s'
                          '-DCONAN_COMPILER="gcc" '
                          '-DCONAN_COMPILER_VERSION="4.9" -DCONAN_CXX_FLAGS="-m64" '
                          '-DCONAN_SHARED_LINKER_FLAGS="-m64" -DCONAN_C_FLAGS="-m64" '
-                         '-DCMAKE_EXPORT_NO_PACKAGE_REGISTRY="ON" -Wno-dev' % (generator, cross),
+                         '-DCMAKE_EXPORT_NO_PACKAGE_REGISTRY="ON" '
+                         '-DCONAN_EXPORTED="1" -DCONAN_IN_LOCAL_CACHE="OFF" '
+                         '-Wno-dev' % (generator, cross),
                          cmake.command_line)
 
     def test_sysroot(self):
@@ -863,10 +893,11 @@ build_type: [ Release]
 
         cmake.configure()
 
-        self.assertEqual('cd {0} && cmake -G "MinGW Makefiles" '
-                         '{1} -DCONAN_EXPORTED="1" -DCONAN_IN_LOCAL_CACHE="OFF"'
+        self.assertEqual('cd {0} && cmake -G "MinGW Makefiles"'
+                         ' {1}'
                          ' -DCONAN_COMPILER="{2}" -DCONAN_COMPILER_VERSION="{3}"'
                          ' -DCMAKE_EXPORT_NO_PACKAGE_REGISTRY="ON"'
+                         ' -DCONAN_EXPORTED="1" -DCONAN_IN_LOCAL_CACHE="OFF"'
                          ' -Wno-dev {0}'.format(dot_dir, cross, settings.compiler,
                                                 settings.compiler.version),
                          conanfile.command)
@@ -903,10 +934,12 @@ build_type: [ Release]
         else:
             escaped_args = "'--foo \"bar\"' -DSHARED=\"True\" '/source'"
 
-        self.assertEqual('cd {0} && cmake -G "MinGW Makefiles" -DCMAKE_BUILD_TYPE="Debug" '
-                         '{1} -DCONAN_EXPORTED="1" -DCONAN_IN_LOCAL_CACHE="OFF" '
+        self.assertEqual('cd {0} && cmake -G "MinGW Makefiles" '
+                         '{1} '
                          '-DCONAN_COMPILER="{2}" -DCONAN_COMPILER_VERSION="{3}" '
                          '-DCMAKE_EXPORT_NO_PACKAGE_REGISTRY="ON" '
+                         '-DCONAN_EXPORTED="1" -DCONAN_IN_LOCAL_CACHE="OFF" '
+                         '-DCMAKE_BUILD_TYPE="Debug" '
                          '-Wno-dev {4}'.format(tempdir, cross, settings.compiler,
                                                settings.compiler.version, escaped_args),
                          conanfile.command)


### PR DESCRIPTION
Changelog: omit
Docs: omit
 
This is a refactor around the `CMakeDefinitionsBuilder` class to make it easier to work with the toolchains (they will use the same class to generate the CMake variables). Changes:
 * `CONAN_EXPORTED` is moved to the build helper
 * minor refactor around `CMAKE_BUILD_TYPE` to reuse code

#TAGS: slow