### PR TITLE
Fix several issues with download command and revisions

### DIFF
--- a/conans/client/command.py
+++ b/conans/client/command.py
@@ -403,11 +403,12 @@ class Command(object):
         else:
             reference = repr(pref.ref)
             if pref.ref.user is None:
-                if pref.revision:
+                if pref.ref.revision:
                     reference = "%s/%s@#%s" % (pref.ref.name, pref.ref.version, pref.ref.revision)
                 else:
                     reference += "@"
-            packages_list = [pref.id]
+            pkgref = "{}#{}".format(pref.id, pref.revision) if pref.revision else "{}".format(pref.id)
+            packages_list = [pkgref]
             if args.package:
                 raise ConanException("Use a full package reference (preferred) or the `--package`"
                                      " command argument, but not both.")

--- a/conans/client/command.py
+++ b/conans/client/command.py
@@ -403,7 +403,10 @@ class Command(object):
         else:
             reference = repr(pref.ref)
             if pref.ref.user is None:
-                reference += "@"
+                if pref.revision:
+                    reference = "%s/%s@#%s" % (pref.ref.name, pref.ref.version, pref.ref.revision)
+                else:
+                    reference += "@"
             packages_list = [pref.id]
             if args.package:
                 raise ConanException("Use a full package reference (preferred) or the `--package`"

--- a/conans/client/command.py
+++ b/conans/client/command.py
@@ -407,7 +407,7 @@ class Command(object):
                     reference = "%s/%s@#%s" % (pref.ref.name, pref.ref.version, pref.ref.revision)
                 else:
                     reference += "@"
-            pkgref = "{}#{}".format(pref.id, pref.revision) if pref.revision else "{}".format(pref.id)
+            pkgref = "{}#{}".format(pref.id, pref.revision) if pref.revision else pref.id
             packages_list = [pkgref]
             if args.package:
                 raise ConanException("Use a full package reference (preferred) or the `--package`"

--- a/conans/client/conan_api.py
+++ b/conans/client/conan_api.py
@@ -430,6 +430,9 @@ class ConanAPIV1(object):
         # Install packages without settings (fixed ids or all)
         if check_valid_ref(reference):
             ref = ConanFileReference.loads(reference)
+            if ref.revision and not self.app.config.revisions_enabled:
+                raise ConanException("Revisions not enabled in the client, specify a "
+                                     "reference without revision")
             if packages and ref.revision is None:
                 for package_id in packages:
                     if "#" in package_id:

--- a/conans/test/functional/command/download_test.py
+++ b/conans/test/functional/command/download_test.py
@@ -225,11 +225,7 @@ class Pkg(ConanFile):
     @unittest.skipIf(get_env("TESTING_REVISIONS_ENABLED", False), "No sense with revs")
     def download_revs_disabled_with_rrev_test(self):
         # https://github.com/conan-io/conan/issues/6106
-        client = TestClient(default_server_user=True, revisions_enabled=False)
-        client.save({"conanfile.py": GenConanfile()})
-        client.run("create . pkg/1.0@user/channel")
-        client.run("upload * --all --confirm")
-        client.run("remove * -f")
+        client = TestClient(revisions_enabled=False)
         client.run("download pkg/1.0@user/channel#fakerevision", assert_error=True)
         self.assertIn(
             "ERROR: Revisions not enabled in the client, specify a reference without revision",

--- a/conans/test/functional/command/download_test.py
+++ b/conans/test/functional/command/download_test.py
@@ -241,6 +241,8 @@ class Pkg(ConanFile):
         client.run("remove * -f")
         client.run("download pkg/1.0@user/channel#{}".format(pref.ref.revision))
         self.assertIn("pkg/1.0@user/channel: Package installed {}".format(pref.id), client.out)
+        search_result = client.search("pkg/1.0@user/channel --revisions")[0]
+        self.assertIn(pref.ref.revision, search_result["revision"])
 
     def download_revs_enabled_with_prev_test(self):
         # https://github.com/conan-io/conan/issues/6106
@@ -253,3 +255,8 @@ class Pkg(ConanFile):
                                                                    pref.id,
                                                                    pref.revision))
         self.assertIn("pkg/1.0@user/channel: Package installed {}".format(pref.id), client.out)
+        search_result = client.search("pkg/1.0@user/channel --revisions")[0]
+        self.assertIn(pref.ref.revision, search_result["revision"])
+        search_result = client.search(
+            "pkg/1.0@user/channel#{}:{} --revisions".format(pref.ref.revision, pref.id))[0]
+        self.assertIn(pref.revision, search_result["revision"])

--- a/conans/test/functional/command/download_test.py
+++ b/conans/test/functional/command/download_test.py
@@ -244,7 +244,10 @@ class Pkg(ConanFile):
         ref = ConanFileReference.loads("pkg/1.0@user/channel")
         client = TurboTestClient(default_server_user=True, revisions_enabled=True)
         pref = client.create(ref, conanfile=GenConanfile())
-        client.run("upload * --all --confirm")
+        client.run("upload pkg/1.0@user/channel --all --confirm")
+        # create new revision from recipe
+        client.create(ref, conanfile=GenConanfile().with_build_msg("new revision"))
+        client.run("upload pkg/1.0@user/channel --all --confirm")
         client.run("remove * -f")
         client.run("download pkg/1.0@user/channel#{}".format(pref.ref.revision))
         self.assertIn("pkg/1.0@user/channel: Package installed {}".format(pref.id), client.out)
@@ -257,7 +260,10 @@ class Pkg(ConanFile):
         client = TurboTestClient(servers=servers, revisions_enabled=True,
                                  users={"default": [("user", "password")]})
         pref = client.create(ref, conanfile=GenConanfile())
-        client.run("upload * --all --confirm")
+        client.run("upload pkg/1.0@ --all --confirm")
+        # create new revision from recipe
+        client.create(ref, conanfile=GenConanfile().with_build_msg("new revision"))
+        client.run("upload pkg/1.0@ --all --confirm")
         client.run("remove * -f")
         client.run("download pkg/1.0@#{}".format(pref.ref.revision))
         self.assertIn("pkg/1.0: Package installed {}".format(pref.id), client.out)
@@ -270,7 +276,9 @@ class Pkg(ConanFile):
         ref = ConanFileReference.loads("pkg/1.0@user/channel")
         client = TurboTestClient(default_server_user=True, revisions_enabled=True)
         pref = client.create(ref, conanfile=GenConanfile())
-        client.run("upload * --all --confirm")
+        client.run("upload pkg/1.0@user/channel --all --confirm")
+        client.create(ref, conanfile=GenConanfile().with_build_msg("new revision"))
+        client.run("upload pkg/1.0@user/channel --all --confirm")
         client.run("remove * -f")
         client.run("download pkg/1.0@user/channel#{}:{}#{}".format(pref.ref.revision,
                                                                    pref.id,

--- a/conans/test/functional/command/download_test.py
+++ b/conans/test/functional/command/download_test.py
@@ -232,7 +232,7 @@ class Pkg(ConanFile):
             client.out)
 
     @unittest.skipUnless(get_env("TESTING_REVISIONS_ENABLED", False), "Only revisions")
-    def download_revs_enabled_with_rrev_test(self):
+    def download_revs_enabled_with_fake_rrev_test(self):
         client = TestClient(default_server_user=True, revisions_enabled=True)
         client.save({"conanfile.py": GenConanfile()})
         client.run("create . pkg/1.0@user/channel")
@@ -241,6 +241,8 @@ class Pkg(ConanFile):
         client.run("download pkg/1.0@user/channel#fakerevision", assert_error=True)
         self.assertIn("ERROR: Recipe not found: 'pkg/1.0@user/channel'", client.out)
 
+    @unittest.skipUnless(get_env("TESTING_REVISIONS_ENABLED", False), "Only revisions")
+    def download_revs_enabled_with_rrev_test(self):
         ref = ConanFileReference.loads("pkg/1.0@user/channel")
         client = TurboTestClient(default_server_user=True, revisions_enabled=True)
         pref = client.create(ref, conanfile=GenConanfile())
@@ -254,6 +256,8 @@ class Pkg(ConanFile):
         search_result = client.search("pkg/1.0@user/channel --revisions")[0]
         self.assertIn(pref.ref.revision, search_result["revision"])
 
+    @unittest.skipUnless(get_env("TESTING_REVISIONS_ENABLED", False), "Only revisions")
+    def download_revs_enabled_with_rrev_no_user_channel_test(self):
         ref = ConanFileReference.loads("pkg/1.0@")
         servers = {"default": TestServer([("*/*@*/*", "*")], [("*/*@*/*", "*")],
                                          users={"user": "password"})}

--- a/conans/test/functional/command/download_test.py
+++ b/conans/test/functional/command/download_test.py
@@ -237,6 +237,14 @@ class Pkg(ConanFile):
 
     @unittest.skipUnless(get_env("TESTING_REVISIONS_ENABLED", False), "Only revisions")
     def download_revs_enabled_with_rrev_test(self):
+        client = TestClient(default_server_user=True, revisions_enabled=True)
+        client.save({"conanfile.py": GenConanfile()})
+        client.run("create . pkg/1.0@user/channel")
+        client.run("upload * --all --confirm")
+        client.run("remove * -f")
+        client.run("download pkg/1.0@user/channel#fakerevision", assert_error=True)
+        self.assertIn("ERROR: Recipe not found: 'pkg/1.0@user/channel'", client.out)
+
         ref = ConanFileReference.loads("pkg/1.0@user/channel")
         client = TurboTestClient(default_server_user=True, revisions_enabled=True)
         pref = client.create(ref, conanfile=GenConanfile())

--- a/conans/test/functional/command/download_test.py
+++ b/conans/test/functional/command/download_test.py
@@ -244,6 +244,20 @@ class Pkg(ConanFile):
         search_result = client.search("pkg/1.0@user/channel --revisions")[0]
         self.assertIn(pref.ref.revision, search_result["revision"])
 
+        ref = ConanFileReference.loads("pkg/1.0@")
+        servers = {"default": TestServer([("*/*@*/*", "*")], [("*/*@*/*", "*")],
+                                         users={"user": "password"})}
+        client = TurboTestClient(servers=servers, revisions_enabled=True,
+                                 users={"default": [("user", "password")]})
+        pref = client.create(ref, conanfile=GenConanfile())
+        client.run("upload * --all --confirm")
+        client.run("remove * -f")
+        client.run("download pkg/1.0@#{}".format(pref.ref.revision))
+        self.assertIn("pkg/1.0: Package installed {}".format(pref.id), client.out)
+        search_result = client.search("pkg/1.0@ --revisions")[0]
+        self.assertIn(pref.ref.revision, search_result["revision"])
+
+
     def download_revs_enabled_with_prev_test(self):
         # https://github.com/conan-io/conan/issues/6106
         ref = ConanFileReference.loads("pkg/1.0@user/channel")

--- a/conans/test/functional/command/download_test.py
+++ b/conans/test/functional/command/download_test.py
@@ -5,6 +5,7 @@ from collections import OrderedDict
 from conans.model.ref import ConanFileReference
 from conans.test.utils.tools import (TestClient, TestServer, NO_SETTINGS_PACKAGE_ID, TurboTestClient,
                                      GenConanfile)
+from conans.util.env_reader import get_env
 from conans.util.files import load
 
 
@@ -221,6 +222,7 @@ class Pkg(ConanFile):
         self.assertIn("pkg/1.0: Downloading pkg/1.0:%s" % NO_SETTINGS_PACKAGE_ID, client.out)
         self.assertIn("pkg/1.0: Package installed %s" % NO_SETTINGS_PACKAGE_ID, client.out)
 
+    @unittest.skipIf(get_env("TESTING_REVISIONS_ENABLED", False), "No sense with revs")
     def download_revs_disabled_with_rrev_test(self):
         # https://github.com/conan-io/conan/issues/6106
         client = TestClient(default_server_user=True, revisions_enabled=False)
@@ -233,6 +235,7 @@ class Pkg(ConanFile):
             "ERROR: Revisions not enabled in the client, specify a reference without revision",
             client.out)
 
+    @unittest.skipUnless(get_env("TESTING_REVISIONS_ENABLED", False), "Only revisions")
     def download_revs_enabled_with_rrev_test(self):
         ref = ConanFileReference.loads("pkg/1.0@user/channel")
         client = TurboTestClient(default_server_user=True, revisions_enabled=True)
@@ -257,7 +260,7 @@ class Pkg(ConanFile):
         search_result = client.search("pkg/1.0@ --revisions")[0]
         self.assertIn(pref.ref.revision, search_result["revision"])
 
-
+    @unittest.skipUnless(get_env("TESTING_REVISIONS_ENABLED", False), "Only revisions")
     def download_revs_enabled_with_prev_test(self):
         # https://github.com/conan-io/conan/issues/6106
         ref = ConanFileReference.loads("pkg/1.0@user/channel")

--- a/conans/test/utils/tools.py
+++ b/conans/test/utils/tools.py
@@ -1236,7 +1236,8 @@ class TurboTestClient(TestClient):
     def create(self, ref, conanfile=GenConanfile(), args=None, assert_error=False):
         if conanfile:
             self.save({"conanfile.py": conanfile})
-        self.run("create . {} {} --json {}".format(ref.full_str(),
+        full_str = "{}@".format(ref.full_str()) if not ref.user else ref.full_str()
+        self.run("create . {} {} --json {}".format(full_str,
                                                    args or "", self.tmp_json_name),
                  assert_error=assert_error)
         rrev = self.cache.package_layout(ref).recipe_revision()


### PR DESCRIPTION
Changelog: Bugfix: Fix different problems when using `conan download` with revisions. 
Docs: Omit

This PR fixes the following problems when using revisions with `conan download` command:

- If you had revisions disabled and added a revision to download command it did not fail but even create the revision in the cache.
- With revisions enabled but without user and channel the command failed.
- When revisions enabled and specifying a recipe revision it did not download the correct recipe revision but the last one.
- When revisions enabled and specifying a package revision it did not download the correct package revision.

It also fixes that when using `create` in the `TurboTestClient` without user and channel the command failed.

Closes #6106 


- [X] Refer to the issue that supports this Pull Request.
- [X] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [X] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [X] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 

<sup>**Note:** By default this PR will skip the slower tests and will use a limited set of python versions. Check [here](https://github.com/conan-io/conan/blob/develop/.github/PR_INCREASE_TESTING.md) how to increase the testing level by writing some tags in the current PR body text.</sup>