### PR TITLE
Fix upload behaviour when using revisions for packages

### DIFF
--- a/conans/client/cmd/uploader.py
+++ b/conans/client/cmd/uploader.py
@@ -188,14 +188,13 @@ class CmdUpload(object):
                 prefs = []
                 # Gather all the complete PREFS with PREV
                 for package in packages_ids:
-                    package_id = package.split("#")[0] if "#" in package else package
-                    package_rev = package.split("#")[1] if "#" in package else None
+                    package_id, prev = package.split("#") if "#" in package else (package, None)
                     if package_id not in metadata.packages:
                         raise ConanException("Binary package %s:%s not found"
                                              % (str(ref), package_id))
-                    if package_rev and package_rev != metadata.packages[package_id].revision:
+                    if prev and prev != metadata.packages[package_id].revision:
                         raise ConanException("Binary package %s:%s#%s not found"
-                                             % (str(ref), package_id, package_rev))
+                                             % (str(ref), package_id, prev))
                     # Filter packages that don't match the recipe revision
                     if self._cache.config.revisions_enabled and ref.revision:
                         rec_rev = metadata.packages[package_id].recipe_revision

--- a/conans/client/cmd/uploader.py
+++ b/conans/client/cmd/uploader.py
@@ -181,10 +181,15 @@ class CmdUpload(object):
                                              "no packages can be uploaded" % str(ref))
                 prefs = []
                 # Gather all the complete PREFS with PREV
-                for package_id in packages_ids:
+                for package in packages_ids:
+                    package_id = package.split("#")[0] if "#" in package else package
+                    package_rev = package.split("#")[1] if "#" in package else None
                     if package_id not in metadata.packages:
                         raise ConanException("Binary package %s:%s not found"
                                              % (str(ref), package_id))
+                    if package_rev and package_rev != metadata.packages[package_id].revision:
+                        raise ConanException("Binary package %s:%s#%s not found"
+                                             % (str(ref), package_id, package_rev))
                     # Filter packages that don't match the recipe revision
                     if self._cache.config.revisions_enabled and ref.revision:
                         rec_rev = metadata.packages[package_id].recipe_revision

--- a/conans/client/cmd/uploader.py
+++ b/conans/client/cmd/uploader.py
@@ -124,6 +124,9 @@ class CmdUpload(object):
         if package_id or check_valid_ref(reference_or_pattern):
             # Upload package
             ref = ConanFileReference.loads(reference_or_pattern)
+            if ref.revision and not self._cache.config.revisions_enabled:
+                raise ConanException("Revisions not enabled in the client, specify a "
+                                     "reference without revision")
             refs = [ref, ]
             confirm = True
         else:

--- a/conans/client/cmd/uploader.py
+++ b/conans/client/cmd/uploader.py
@@ -141,6 +141,9 @@ class CmdUpload(object):
 
         for ref in refs:
             metadata = self._cache.package_layout(ref).load_metadata()
+            if ref.revision and ref.revision != metadata.recipe.revision:
+                raise ConanException("Recipe revision {} does not match with the one stored in the "
+                                     "cache {}".format(ref.revision, metadata.recipe.revision))
             ref = ref.copy_with_rev(metadata.recipe.revision)
             remote = remotes.selected
             if remote:

--- a/conans/client/cmd/uploader.py
+++ b/conans/client/cmd/uploader.py
@@ -145,8 +145,8 @@ class CmdUpload(object):
         for ref in refs:
             metadata = self._cache.package_layout(ref).load_metadata()
             if ref.revision and ref.revision != metadata.recipe.revision:
-                raise ConanException("Recipe revision {} does not match with the one stored in the "
-                                     "cache {}".format(ref.revision, metadata.recipe.revision))
+                raise ConanException("Recipe revision %s does not match with the one stored in the "
+                                     "cache %s" % (str(ref.revision), str(metadata.recipe.revision)))
             ref = ref.copy_with_rev(metadata.recipe.revision)
             remote = remotes.selected
             if remote:

--- a/conans/client/cmd/uploader.py
+++ b/conans/client/cmd/uploader.py
@@ -145,8 +145,8 @@ class CmdUpload(object):
         for ref in refs:
             metadata = self._cache.package_layout(ref).load_metadata()
             if ref.revision and ref.revision != metadata.recipe.revision:
-                raise ConanException("Recipe revision %s does not match with the one stored in the "
-                                     "cache %s" % (str(ref.revision), str(metadata.recipe.revision)))
+                raise ConanException("Recipe revision {} does not match the one stored in the cache {}"
+                                     .format(ref.revision, metadata.recipe.revision))
             ref = ref.copy_with_rev(metadata.recipe.revision)
             remote = remotes.selected
             if remote:

--- a/conans/client/command.py
+++ b/conans/client/command.py
@@ -1365,7 +1365,7 @@ class Command(object):
                 raise ConanException("'--query' argument cannot be used together with '--package'")
         else:
             reference = repr(pref.ref)
-            package_id = pref.id
+            package_id = "{}#{}".format(pref.id, pref.revision) if pref.revision else pref.id
 
             if args.package:
                 raise ConanException("Use a full package reference (preferred) or the `--package`"

--- a/conans/test/functional/command/upload_test.py
+++ b/conans/test/functional/command/upload_test.py
@@ -841,8 +841,8 @@ class Pkg(ConanFile):
         client = TurboTestClient(default_server_user=True, revisions_enabled=True)
         pref = client.create(ref, conanfile=GenConanfile())
         client.run("upload pkg/1.0@user/channel#fakerevision --confirm", assert_error=True)
-        self.assertIn("ERROR: Recipe revision fakerevision does not match with the one "
-                      "stored in the cache {}".format(pref.ref.revision), client.out)
+        self.assertIn("ERROR: Recipe revision fakerevision does not match the one stored in the cache {}".
+                      format(pref.ref.revision), client.out)
 
         client.run("upload pkg/1.0@user/channel#{} --confirm".format(pref.ref.revision))
         search_result = client.search("pkg/1.0@user/channel --revisions -r default")[0]

--- a/conans/test/functional/command/upload_test.py
+++ b/conans/test/functional/command/upload_test.py
@@ -826,3 +826,46 @@ class Pkg(ConanFile):
         client.run("user -c")
         client.run("upload Hello0/1.2.1@user/testing --all -r default")
         self.assertIn("Uploaded conan recipe 'Hello0/1.2.1@user/testing' to 'default'", client.out)
+
+    @unittest.skipIf(get_env("TESTING_REVISIONS_ENABLED", False), "No sense with revs")
+    def upload_with_rev_revs_disabled_test(self):
+        client = TestClient(default_server_user=True, revisions_enabled=False)
+        client.run("upload pkg/1.0@user/channel#fakerevision --confirm", assert_error=True)
+        self.assertIn(
+            "ERROR: Revisions not enabled in the client, specify a reference without revision",
+            client.out)
+
+    @unittest.skipUnless(get_env("TESTING_REVISIONS_ENABLED", False), "Only revisions")
+    def upload_with_recipe_revision_test(self):
+        ref = ConanFileReference.loads("pkg/1.0@user/channel")
+        client = TurboTestClient(default_server_user=True, revisions_enabled=True)
+        pref = client.create(ref, conanfile=GenConanfile())
+        client.run("upload pkg/1.0@user/channel#fakerevision --confirm", assert_error=True)
+        self.assertIn("ERROR: Recipe revision fakerevision does not match with the one "
+                      "stored in the cache {}".format(pref.ref.revision), client.out)
+
+        client.run("upload pkg/1.0@user/channel#{} --confirm".format(pref.ref.revision))
+        search_result = client.search("pkg/1.0@user/channel --revisions -r default")[0]
+        self.assertIn(pref.ref.revision, search_result["revision"])
+
+    @unittest.skipUnless(get_env("TESTING_REVISIONS_ENABLED", False), "Only revisions")
+    def upload_with_package_revision_test(self):
+        ref = ConanFileReference.loads("pkg/1.0@user/channel")
+        client = TurboTestClient(default_server_user=True, revisions_enabled=True)
+        pref = client.create(ref, conanfile=GenConanfile())
+        client.run(
+            "upload pkg/1.0@user/channel#{}:{}#fakeprev --confirm".format(pref.ref.revision, pref.id),
+            assert_error=True)
+        self.assertIn(
+            "ERROR: Binary package pkg/1.0@user/channel:{}#fakeprev not found".format(pref.id),
+            client.out)
+
+        client.run(
+            "upload pkg/1.0@user/channel#{}:{}#{} --confirm".format(pref.ref.revision, pref.id,
+                                                                    pref.revision))
+        search_result = client.search("pkg/1.0@user/channel --revisions -r default")[0]
+        self.assertIn(pref.ref.revision, search_result["revision"])
+        search_result = client.search(
+            "pkg/1.0@user/channel#{}:{} --revisions  -r default".format(pref.ref.revision, pref.id))[
+            0]
+        self.assertIn(pref.revision, search_result["revision"])


### PR DESCRIPTION
Changelog: Bugfix: Upload correct packages when specifying revisions and fail with incorrect ones. 
Docs: Omit

When uploading using recipe revisions or package revisions all that information was obviated. You could even upload a package with a fake revision or specify the revision even with revisions disabled and the command did not fail. This PR fixes that behaviour so doing something like:

`conan upload pkg/0.1@user/channel#rrev:pkgid#prev` 

will check those fields to upload the correct package that must match with the one that's stored in the cache

- [X] Refer to the issue that supports this Pull Request.
- [X] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [X] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [X] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 

<sup>**Note:** By default this PR will skip the slower tests and will use a limited set of python versions. Check [here](https://github.com/conan-io/conan/blob/develop/.github/PR_INCREASE_TESTING.md) how to increase the testing level by writing some tags in the current PR body text.</sup>
