### PR TITLE
Allowing broken symlinks in packages (it has consequences)

### DIFF
--- a/conans/client/cmd/uploader.py
+++ b/conans/client/cmd/uploader.py
@@ -583,19 +583,18 @@ def compress_files(files, symlinks, name, dest_dir, output=None):
                                                      "Compressing %s" % name) as pg_file_list:
             for filename, abs_path in pg_file_list:
                 info = tarfile.TarInfo(name=filename)
-                info.size = os.stat(abs_path).st_size
-                info.mode = os.stat(abs_path).st_mode & mask
                 if os.path.islink(abs_path):
                     info.type = tarfile.SYMTYPE
                     info.size = 0  # A symlink shouldn't have size
                     info.linkname = os.readlink(abs_path)  # @UndefinedVariable
                     tgz.addfile(tarinfo=info)
                 else:
+                    info.mode = os.stat(abs_path).st_mode & mask
+                    info.size = os.stat(abs_path).st_size
                     with open(abs_path, 'rb') as file_handler:
                         tgz.addfile(tarinfo=info, fileobj=file_handler)
         tgz.close()
 
     duration = time.time() - t1
     log_compressed_files(files, duration, tgz_path)
-
     return tgz_path

--- a/conans/client/cmd/uploader.py
+++ b/conans/client/cmd/uploader.py
@@ -584,13 +584,15 @@ def compress_files(files, symlinks, name, dest_dir, output=None):
             for filename, abs_path in pg_file_list:
                 info = tarfile.TarInfo(name=filename)
                 if os.path.islink(abs_path):
+                    info.mode = os.lstat(abs_path).st_mode & mask
                     info.type = tarfile.SYMTYPE
                     info.size = 0  # A symlink shouldn't have size
                     info.linkname = os.readlink(abs_path)  # @UndefinedVariable
                     tgz.addfile(tarinfo=info)
                 else:
-                    info.mode = os.stat(abs_path).st_mode & mask
-                    info.size = os.stat(abs_path).st_size
+                    os_stat = os.stat(abs_path)
+                    info.mode = os_stat.st_mode & mask
+                    info.size = os_stat.st_size
                     with open(abs_path, 'rb') as file_handler:
                         tgz.addfile(tarinfo=info, fileobj=file_handler)
         tgz.close()

--- a/conans/client/cmd/uploader.py
+++ b/conans/client/cmd/uploader.py
@@ -597,4 +597,5 @@ def compress_files(files, symlinks, name, dest_dir, output=None):
 
     duration = time.time() - t1
     log_compressed_files(files, duration, tgz_path)
+
     return tgz_path

--- a/conans/model/manifest.py
+++ b/conans/model/manifest.py
@@ -119,9 +119,6 @@ class FileTreeManifest(object):
 
         file_dict = {}
         for name, filepath in files.items():
-            if os.path.islink(filepath):
-                # We cannot add links to the manifest, as they may point to different files
-                continue
             file_dict[name] = md5sum(filepath)
 
         if exports_sources_folder:

--- a/conans/util/files.py
+++ b/conans/util/files.py
@@ -145,6 +145,8 @@ def sha256sum(file_path):
 
 
 def _generic_algorithm_sum(file_path, algorithm_name):
+    if os.path.islink(file_path):
+        return 0
 
     with open(file_path, 'rb') as fh:
         m = hashlib.new(algorithm_name)
@@ -339,7 +341,6 @@ def tar_extract(fileobj, destination_dir):
 
     def safemembers(members):
         base = realpath(abspath(destination_dir))
-
         for finfo in members:
             if badpath(finfo.name, base) or finfo.islnk():
                 logger.warning("file:%s is skipped since it's not safe." % str(finfo.name))

--- a/conans/util/files.py
+++ b/conans/util/files.py
@@ -341,6 +341,7 @@ def tar_extract(fileobj, destination_dir):
 
     def safemembers(members):
         base = realpath(abspath(destination_dir))
+
         for finfo in members:
             if badpath(finfo.name, base) or finfo.islnk():
                 logger.warning("file:%s is skipped since it's not safe." % str(finfo.name))

--- a/conans/util/tracer.py
+++ b/conans/util/tracer.py
@@ -69,8 +69,6 @@ def _append_action(action_name, props):
 # ############## LOG METHODS ######################
 
 def _file_document(name, path):
-    if os.path.islink(path):
-        return {"name": name, "path": path, "md5": 0, "sha1": 0}
     return {"name": name, "path": path, "md5": md5sum(path), "sha1": sha1sum(path)}
 
 

--- a/conans/util/tracer.py
+++ b/conans/util/tracer.py
@@ -69,6 +69,8 @@ def _append_action(action_name, props):
 # ############## LOG METHODS ######################
 
 def _file_document(name, path):
+    if os.path.islink(path):
+        return {"name": name, "path": path, "md5": 0, "sha1": 0}
     return {"name": name, "path": path, "md5": md5sum(path), "sha1": sha1sum(path)}
 
 


### PR DESCRIPTION
Changelog: (Feature | Fix | Bugfix): Describe here your pull request
Docs: https://github.com/conan-io/docs/pull/XXXX

closes #6120 

If we allow broken symlinks into the packages, we cannot compute the md5/sha1 for them. Maybe we should stop computing the hash for all the symlinks (broken or not) because they might point to files not handled by Conan with different hashes at different times.

When the user uses symlinks that are outside the package, it's up to the user to keep track of the content of the files they are pointing to. The only thing we can do is to warn the user about these files and make it an opt-in (with the config `CONAN_SKIP_BROKEN_SYMLINKS_CHECK`).

We need to decide here:
 * What should be the checksum of a symlink inside a package
 * If we are going to package symlinks that point outside the package (IMHO, this is almost the same as packaging broken symlinks)
 * If `CONAN_SKIP_BROKEN_SYMLINKS_CHECK` is the proper flag to opt-in this behavior



