### PR TITLE
Fix SyntaxWarning when comparing a literal with for identity in Python 3.8

### DIFF
--- a/conans/client/tools/win.py
+++ b/conans/client/tools/win.py
@@ -280,7 +280,7 @@ def vswhere(all_=False, prerelease=False, products=None, requires=None, version=
         arguments.append("-requires")
         arguments.extend(requires)
 
-    if len(version) is not 0:
+    if len(version) != 0:
         arguments.append("-version")
         arguments.append(version)
 
@@ -290,7 +290,7 @@ def vswhere(all_=False, prerelease=False, products=None, requires=None, version=
     if legacy:
         arguments.append("-legacy")
 
-    if len(property_) is not 0:
+    if len(property_) != 0:
         arguments.append("-property")
         arguments.append(property_)
 


### PR DESCRIPTION
Changelog: Fix: Fix SyntaxWarning when comparing a literal with for identity in Python 3.8
Docs: None

Since version 3.8 CPython emits a `SyntaxWarning` when one tries to compare a literal with `is` or `is not` (it is mentioned [int eh changelog](https://docs.python.org/3/whatsnew/3.8.html#changes-in-python-behavior)). I run into such a warning when installing the Conan from its `develop` branch on Windows:

```
d:\morwenn\projets\conan\conans\client\tools\win.py:283: SyntaxWarning: "is not" with a literal. Did you mean "!="?
  if len(version) is not 0:
d:\morwenn\projets\conan\conans\client\tools\win.py:293: SyntaxWarning: "is not" with a literal. Did you mean "!="?
  if len(property_) is not 0:
```

Like most `SyntaxWarning` it is likely to become an error in the future, so it is better to fix it sooner rather than later.

- [ ] Refer to the issue that supports this Pull Request: None
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 

<sup>**Note:** By default this PR will skip the slower tests and will use a limited set of python versions. Check [here](https://github.com/conan-io/conan/blob/develop/.github/PR_INCREASE_TESTING.md) how to increase the testing level by writing some tags in the current PR body text.</sup>
