### PR TITLE
Simplify conan_build_info --v2 arguments

### DIFF
--- a/conans/build_info/build_info.py
+++ b/conans/build_info/build_info.py
@@ -37,12 +37,12 @@ def _parse_profile(contents):
 
 
 class BuildInfoCreator(object):
-    def __init__(self, output, build_info_file, lockfile, multi_module=True, skip_env=True,
+    def __init__(self, output, build_info_file, lockfile, capture_env=False,
                  user=None, password=None, apikey=None):
         self._build_info_file = build_info_file
         self._lockfile = lockfile
-        self._multi_module = multi_module
-        self._skip_env = skip_env
+        self._multi_module = True
+        self._capture_env = capture_env
         self._user = user
         self._password = password
         self._apikey = apikey
@@ -208,7 +208,7 @@ class BuildInfoCreator(object):
                "buildAgent": {"name": "Conan Client", "version": "1.X"},
                "modules": list(modules.values())}
 
-        if not self._skip_env:
+        if self._capture_env:
             excluded = ["secret", "key", "password"]
             environment = {"buildInfo.env.{}".format(k): v for k, v in os.environ.items() if
                            k not in excluded}
@@ -224,9 +224,9 @@ class BuildInfoCreator(object):
             f.write(json.dumps(ret, indent=4, default=dump_custom_types))
 
 
-def create_build_info(output, build_info_file, lockfile, multi_module, skip_env, user, password,
+def create_build_info(output, build_info_file, lockfile, capture_env, user, password,
                       apikey):
-    bi = BuildInfoCreator(output, build_info_file, lockfile, multi_module, skip_env, user, password,
+    bi = BuildInfoCreator(output, build_info_file, lockfile, capture_env, user, password,
                           apikey)
     bi.create()
 

--- a/conans/build_info/build_info.py
+++ b/conans/build_info/build_info.py
@@ -213,10 +213,8 @@ class BuildInfoCreator(object):
             f.write(json.dumps(ret, indent=4, default=dump_custom_types))
 
 
-def create_build_info(output, build_info_file, lockfile, user, password,
-                      apikey):
-    bi = BuildInfoCreator(output, build_info_file, lockfile, user, password,
-                          apikey)
+def create_build_info(output, build_info_file, lockfile, user, password, apikey):
+    bi = BuildInfoCreator(output, build_info_file, lockfile, user, password, apikey)
     bi.create()
 
 

--- a/conans/build_info/build_info.py
+++ b/conans/build_info/build_info.py
@@ -37,11 +37,9 @@ def _parse_profile(contents):
 
 
 class BuildInfoCreator(object):
-    def __init__(self, output, build_info_file, lockfile, capture_env=False,
-                 user=None, password=None, apikey=None):
+    def __init__(self, output, build_info_file, lockfile, user=None, password=None, apikey=None):
         self._build_info_file = build_info_file
         self._lockfile = lockfile
-        self._capture_env = capture_env
         self._user = user
         self._password = password
         self._apikey = apikey
@@ -207,12 +205,6 @@ class BuildInfoCreator(object):
                "buildAgent": {"name": "Conan Client", "version": "1.X"},
                "modules": list(modules.values())}
 
-        if self._capture_env:
-            excluded = ["secret", "key", "password"]
-            environment = {"buildInfo.env.{}".format(k): v for k, v in os.environ.items() if
-                           k not in excluded}
-            ret["properties"] = environment
-
         def dump_custom_types(obj):
             if isinstance(obj, set):
                 artifacts = [{k: v for k, v in o._asdict().items() if v is not None} for o in obj]
@@ -223,9 +215,9 @@ class BuildInfoCreator(object):
             f.write(json.dumps(ret, indent=4, default=dump_custom_types))
 
 
-def create_build_info(output, build_info_file, lockfile, capture_env, user, password,
+def create_build_info(output, build_info_file, lockfile, user, password,
                       apikey):
-    bi = BuildInfoCreator(output, build_info_file, lockfile, capture_env, user, password,
+    bi = BuildInfoCreator(output, build_info_file, lockfile, user, password,
                           apikey)
     bi.create()
 

--- a/conans/build_info/build_info.py
+++ b/conans/build_info/build_info.py
@@ -41,7 +41,6 @@ class BuildInfoCreator(object):
                  user=None, password=None, apikey=None):
         self._build_info_file = build_info_file
         self._lockfile = lockfile
-        self._multi_module = True
         self._capture_env = capture_env
         self._user = user
         self._password = password
@@ -172,16 +171,16 @@ class BuildInfoCreator(object):
                 recipe_key = self._get_reference(pref)
                 modules[recipe_key]["id"] = recipe_key
                 modules[recipe_key]["artifacts"].update(
-                    self._get_recipe_artifacts(pref, add_prefix=not self._multi_module,
+                    self._get_recipe_artifacts(pref, add_prefix=False,
                                                use_id=False))
                 # TODO: what about `python_requires`?
                 # TODO: can we associate any properties to the recipe? Profile/options may be different per lockfile
 
                 # Create module for the package_id
-                package_key = self._get_package_reference(pref) if self._multi_module else recipe_key
+                package_key = self._get_package_reference(pref)
                 modules[package_key]["id"] = package_key
                 modules[package_key]["artifacts"].update(
-                    self._get_package_artifacts(pref, add_prefix=not self._multi_module,
+                    self._get_package_artifacts(pref, add_prefix=False,
                                                 use_id=False))
 
                 # Recurse requires

--- a/conans/build_info/command.py
+++ b/conans/build_info/command.py
@@ -77,8 +77,6 @@ def runv2():
     parser_create.add_argument("build_info_file", type=str,
                                help="build info json for output")
     parser_create.add_argument("--lockfile", type=str, required=True, help="input lockfile")
-    parser_create.add_argument("--capture-env", default=False, action="store_true",
-                               help="capture or not the environment")
     parser_create.add_argument("--user", type=str, nargs="?", default=None, help="user")
     parser_create.add_argument("--password", type=str, nargs="?", default=None, help="password")
     parser_create.add_argument("--apikey", type=str, nargs="?", default=None, help="apikey")
@@ -116,7 +114,7 @@ def runv2():
         if args.subcommand == "create":
             check_credential_arguments()
             create_build_info(output, args.build_info_file, args.lockfile,
-                              args.capture_env, args.user, args.password, args.apikey)
+                              args.user, args.password, args.apikey)
         if args.subcommand == "update":
             update_build_info(args.buildinfo, args.output_file)
         if args.subcommand == "publish":

--- a/conans/build_info/command.py
+++ b/conans/build_info/command.py
@@ -77,10 +77,7 @@ def runv2():
     parser_create.add_argument("build_info_file", type=str,
                                help="build info json for output")
     parser_create.add_argument("--lockfile", type=str, required=True, help="input lockfile")
-    parser_create.add_argument("--multi-module", nargs="?", default=True,
-                               help="if enabled, the module_id will be identified by the "
-                                    "recipe reference plus the package ID")
-    parser_create.add_argument("--skip-env", nargs="?", default=True,
+    parser_create.add_argument("--capture-env", default=False, action="store_true",
                                help="capture or not the environment")
     parser_create.add_argument("--user", type=str, nargs="?", default=None, help="user")
     parser_create.add_argument("--password", type=str, nargs="?", default=None, help="password")
@@ -118,8 +115,8 @@ def runv2():
             stop_build_info(output)
         if args.subcommand == "create":
             check_credential_arguments()
-            create_build_info(output, args.build_info_file, args.lockfile, args.multi_module,
-                              args.skip_env, args.user, args.password, args.apikey)
+            create_build_info(output, args.build_info_file, args.lockfile,
+                              args.capture_env, args.user, args.password, args.apikey)
         if args.subcommand == "update":
             update_build_info(args.buildinfo, args.output_file)
         if args.subcommand == "publish":

--- a/conans/test/integration/test_build_info_creation.py
+++ b/conans/test/integration/test_build_info_creation.py
@@ -116,14 +116,14 @@ class MyBuildInfoCreation(unittest.TestCase):
         run()
 
         user_channel = "@" + user_channel if len(user_channel) > 2 else user_channel
-        with open(os.path.join(client.current_folder, "buildinfo1.json")) as f:
-            buildinfo = json.load(f)
-            self.assertEqual(buildinfo["name"], "MyBuildName")
-            self.assertEqual(buildinfo["number"], "42")
-            ids_list = [item["id"] for item in buildinfo["modules"]]
-            self.assertTrue("PkgB/0.1{}".format(user_channel) in ids_list)
-            self.assertTrue("PkgB/0.1{}:09f152eb7b3e0a6e15a2a3f464245864ae8f8644".format(
-                user_channel) in ids_list)
+        f = client.load("buildinfo1.json")
+        buildinfo = json.loads(f)
+        self.assertEqual(buildinfo["name"], "MyBuildName")
+        self.assertEqual(buildinfo["number"], "42")
+        ids_list = [item["id"] for item in buildinfo["modules"]]
+        self.assertTrue("PkgB/0.1{}".format(user_channel) in ids_list)
+        self.assertTrue("PkgB/0.1{}:09f152eb7b3e0a6e15a2a3f464245864ae8f8644".format(
+            user_channel) in ids_list)
 
         sys.argv = ["conan_build_info", "--v2", "update",
                     os.path.join(client.current_folder, "buildinfo1.json"),
@@ -131,17 +131,17 @@ class MyBuildInfoCreation(unittest.TestCase):
                     "--output-file", os.path.join(client.current_folder, "mergedbuildinfo.json")]
         run()
 
-        with open(os.path.join(client.current_folder, "mergedbuildinfo.json")) as f:
-            buildinfo = json.load(f)
-            self.assertEqual(buildinfo["name"], "MyBuildName")
-            self.assertEqual(buildinfo["number"], "42")
-            ids_list = [item["id"] for item in buildinfo["modules"]]
-            self.assertTrue("PkgC/0.1{}".format(user_channel) in ids_list)
-            self.assertTrue("PkgB/0.1{}".format(user_channel) in ids_list)
-            self.assertTrue("PkgC/0.1{}:09f152eb7b3e0a6e15a2a3f464245864ae8f8644".format(
-                user_channel) in ids_list)
-            self.assertTrue("PkgB/0.1{}:09f152eb7b3e0a6e15a2a3f464245864ae8f8644".format(
-                user_channel) in ids_list)
+        f = client.load("mergedbuildinfo.json")
+        buildinfo = json.loads(f)
+        self.assertEqual(buildinfo["name"], "MyBuildName")
+        self.assertEqual(buildinfo["number"], "42")
+        ids_list = [item["id"] for item in buildinfo["modules"]]
+        self.assertTrue("PkgC/0.1{}".format(user_channel) in ids_list)
+        self.assertTrue("PkgB/0.1{}".format(user_channel) in ids_list)
+        self.assertTrue("PkgC/0.1{}:09f152eb7b3e0a6e15a2a3f464245864ae8f8644".format(
+            user_channel) in ids_list)
+        self.assertTrue("PkgB/0.1{}:09f152eb7b3e0a6e15a2a3f464245864ae8f8644".format(
+            user_channel) in ids_list)
 
         sys.argv = ["conan_build_info", "--v2", "publish",
                     os.path.join(client.current_folder, "mergedbuildinfo.json"), "--url",


### PR DESCRIPTION
Changelog: Bugfix: Removing `--skip-env`  and `--multi-module` arguments  for `conan_build_info --v2`. Now the environment is not captured (will be handled by the Artifactory plugin) and recipes and packages are saved as different modules in build info.
Docs: https://github.com/conan-io/docs/pull/1486

This PR simplifies Conan build info creation by always saving the information in different modules for recipes and packages (removes the old `--multi-module` argument).  Also, it will not capture environment information by default (removes the old `--skip-env` argument because the environment information will be handled by the Jenkins Artifactory plugin once this command is integrated into the plugin).

Closes #6144 by removing the arguments.

- [X] Refer to the issue that supports this Pull Request.
- [X] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [X] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [X] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 

<sup>**Note:** By default this PR will skip the slower tests and will use a limited set of python versions. Check [here](https://github.com/conan-io/conan/blob/develop/.github/PR_INCREASE_TESTING.md) how to increase the testing level by writing some tags in the current PR body text.</sup>
