### PR TITLE
Remove carriage returns from build info json file

### DIFF
--- a/conans/build_info/build_info.py
+++ b/conans/build_info/build_info.py
@@ -206,8 +206,7 @@ class BuildInfoCreator(object):
                 return sorted(artifacts, key=lambda u: u.get("name") or u.get("id"))
             raise TypeError
 
-        with open(self._build_info_file, "w") as f:
-            f.write(json.dumps(ret, indent=4, default=dump_custom_types))
+        save(self._build_info_file, json.dumps(ret, indent=4, default=dump_custom_types))
 
 
 def create_build_info(output, build_info_file, lockfile, user, password, apikey):
@@ -301,8 +300,6 @@ def update_build_info(buildinfo, output_file):
     for it in buildinfo:
         with open(it) as json_data:
             data = json.load(json_data)
-
         build_info = merge_buildinfo(build_info, data)
 
-    with open(output_file, "w") as f:
-        f.write(json.dumps(build_info, indent=4))
+    save(output_file, json.dumps(build_info, indent=4))


### PR DESCRIPTION
Changelog: Bugfix: Remove carriage returns from build info `.json` file to avoid Artifactory errors in some cases when publishing the build info to the remote.
Docs: Omit

It looks like in some cases the build info publishing failed with an `ERROR: 400: Bad Request` if the file contained carriage returns.

Closes #6103

- [X] Refer to the issue that supports this Pull Request.
- [X] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [X] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [X] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 

<sup>**Note:** By default this PR will skip the slower tests and will use a limited set of python versions. Check [here](https://github.com/conan-io/conan/blob/develop/.github/PR_INCREASE_TESTING.md) how to increase the testing level by writing some tags in the current PR body text.</sup>
