### PR TITLE
SystemPackageTool.installed()

### DIFF
--- a/conans/client/tools/system_pm.py
+++ b/conans/client/tools/system_pm.py
@@ -143,6 +143,9 @@ class SystemPackageTool(object):
             return parsed_packages
         return packages
 
+    def installed(self, package_name):
+        return self._tool.installed(package_name)
+
     def _installed(self, packages):
         if not packages:
             return True

--- a/conans/test/unittests/client/tools/system_pm_test.py
+++ b/conans/test/unittests/client/tools/system_pm_test.py
@@ -443,8 +443,10 @@ class SystemPackageToolTest(unittest.TestCase):
             expected_package = "chocolatey"
         # The expected should be installed on development/testing machines
         self.assertTrue(spt._tool.installed(expected_package))
+        self.assertTrue(spt.installed(expected_package))
         # This package hopefully doesn't exist
         self.assertFalse(spt._tool.installed("oidfjgesiouhrgioeurhgielurhgaeiorhgioearhgoaeirhg"))
+        self.assertFalse(spt.installed("oidfjgesiouhrgioeurhgielurhgaeiorhgioearhgoaeirhg"))
 
     def system_package_tool_fail_when_not_0_returned_test(self):
         def get_linux_error_message():


### PR DESCRIPTION
Changelog: Bugfix: Implement ``SystemPackageTool.installed(package_name)`` as described in the documentation.
Docs: Omit

Close #6196

