### PR TITLE
Raise when symlinks use different drive in Windows

### DIFF
--- a/conans/client/file_copier.py
+++ b/conans/client/file_copier.py
@@ -175,7 +175,11 @@ class FileCopier(object):
             link = os.readlink(src_link)
             # Absoluted path symlinks are a problem, convert it to relative
             if os.path.isabs(link):
-                link = os.path.relpath(link, os.path.dirname(src_link))
+                try:
+                    link = os.path.relpath(link, os.path.dirname(src_link))
+                except ValueError:
+                    # https://github.com/conan-io/conan/issues/6197 fails if Windows and other Drive
+                    continue
 
             dst_link = os.path.join(dst, linked_folder)
             try:

--- a/conans/client/file_copier.py
+++ b/conans/client/file_copier.py
@@ -3,6 +3,7 @@ import os
 import shutil
 from collections import defaultdict
 
+from conans.errors import ConanException
 from conans.util.files import mkdir, walk
 
 
@@ -177,9 +178,10 @@ class FileCopier(object):
             if os.path.isabs(link):
                 try:
                     link = os.path.relpath(link, os.path.dirname(src_link))
-                except ValueError:
+                except ValueError as e:
                     # https://github.com/conan-io/conan/issues/6197 fails if Windows and other Drive
-                    continue
+                    raise ConanException("Symlink '%s' pointing to '%s' couldn't be made relative:"
+                                         " %s" % (src_link, link, str(e)))
 
             dst_link = os.path.join(dst, linked_folder)
             try:


### PR DESCRIPTION
Changelog: Fix: Raise error for symlinks in Windows pointing to a different unit.
Docs: Omit

Close #6197

Note this is almost impossible to test: it requires Administrator permissions to create a unit X: and then mklink to it to reproduce
