### PR TITLE
Use `sh` instead of `bash`

### DIFF
--- a/conans/client/generators/virtualenv.py
+++ b/conans/client/generators/virtualenv.py
@@ -10,8 +10,6 @@ from conans.model import Generator
 
 sh_activate_tpl = Template(textwrap.dedent("""
     #!/usr/bin/env sh
-    # DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
-    # DIR="$( cd "$( dirname "$_" )" >/dev/null 2>&1 && pwd )"
 
     {%- for it in modified_vars %}
     export CONAN_OLD_{{it}}="${{it}}"

--- a/conans/client/generators/virtualenv.py
+++ b/conans/client/generators/virtualenv.py
@@ -9,7 +9,7 @@ from conans.model import Generator
 
 
 sh_activate_tpl = Template(textwrap.dedent("""
-    #!/usr/bin/env bash
+    #!/usr/bin/env sh
     # DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
     # DIR="$( cd "$( dirname "$_" )" >/dev/null 2>&1 && pwd )"
 
@@ -28,7 +28,7 @@ sh_activate_tpl = Template(textwrap.dedent("""
 """))
 
 sh_deactivate_tpl = Template(textwrap.dedent("""
-    #!/usr/bin/env bash
+    #!/usr/bin/env sh
     export PS1="$CONAN_OLD_PS1"
     unset CONAN_OLD_PS1
 


### PR DESCRIPTION
Changelog: omit
Docs: omit

https://github.com/conan-io/conan/pull/5989#discussion_r354673933

I would say everything on there are standard shell commands, nothing bash specifics, right? @jgsogo 
It might happen that bash is not in the system.