### PR TITLE
Fix typo

### DIFF
--- a/conans/client/tools/net.py
+++ b/conans/client/tools/net.py
@@ -12,7 +12,7 @@ def get(url, md5='', sha1='', sha256='', destination=".", filename="", keep_perm
     """ high level downloader + unzipper + (optional hash checker) + delete temporary zip
     """
     if not filename and ("?" in url or "=" in url):
-        raise ConanException("Cannot deduce file name form url. Use 'filename' parameter.")
+        raise ConanException("Cannot deduce file name from url. Use 'filename' parameter.")
 
     filename = filename or os.path.basename(url)
     download(url, filename, out=output, requester=requester, verify=verify, retry=retry,

--- a/conans/test/unittests/util/tools_test.py
+++ b/conans/test/unittests/util/tools_test.py
@@ -884,7 +884,7 @@ ProgramFiles(x86)=C:\Program Files (x86)
         out = TestBufferConanOutput()
         # Test: File name cannot be deduced from '?file=1'
         with six.assertRaisesRegex(self, ConanException,
-                                   "Cannot deduce file name form url. Use 'filename' parameter."):
+                                   "Cannot deduce file name from url. Use 'filename' parameter."):
             tools.get("http://localhost:%s/?file=1" % thread.port, output=out)
 
         # Test: Works with filename parameter instead of '?file=1'


### PR DESCRIPTION
Changelog: Fix: Fix typo in error message from ``tools.get()``
Docs: Omit