### PR TITLE
pkg_config generator: fix case handling

### DIFF
--- a/conans/client/generators/pkg_config.py
+++ b/conans/client/generators/pkg_config.py
@@ -35,12 +35,7 @@ class PkgConfigGenerator(Generator):
     def content(self):
         ret = {}
         for depname, cpp_info in self.deps_build_info.dependencies:
-            # the name for the pc will be converted to lowercase when cpp_info.name is specified
-            # but with cpp_info.names["pkg_config"] will be literal
-            if cpp_info.name and cpp_info.get_name("pkg_config") != cpp_info.name:
-                name = cpp_info.get_name("pkg_config")
-            else:
-                name = cpp_info.name.lower() if cpp_info.name != depname else depname
+            name = cpp_info.get_name("pkg_config")
             ret["%s.pc" % name] = self.single_pc_file_contents(name, cpp_info)
         return ret
 

--- a/conans/test/unittests/client/generators/pkg_config_test.py
+++ b/conans/test/unittests/client/generators/pkg_config_test.py
@@ -59,11 +59,11 @@ Cflags: -I${includedir} -cxxflag -DMYDEFINE2
 Requires: my_pkg
 """)
 
-        self.assertEqual(files["mypkg1.pc"], """prefix=dummy_root_folder1
+        self.assertEqual(files["MYPKG1.pc"], """prefix=dummy_root_folder1
 libdir=${prefix}/lib
 includedir=${prefix}/include
 
-Name: mypkg1
+Name: MYPKG1
 Description: My other cool description
 Version: 1.7
 Libs: -L${libdir}

--- a/conans/test/unittests/client/generators/pkg_config_test.py
+++ b/conans/test/unittests/client/generators/pkg_config_test.py
@@ -116,8 +116,32 @@ Cflags: -I${includedir} -Flag1=23 -DMYDEFINE1
         cpp_info.cxxflags = ["-cxxflag"]
         cpp_info.public_deps = ["MyPkg", "MyPkg1"]
         conanfile.deps_cpp_info.update(cpp_info, ref.name)
+
+        ref = ConanFileReference.loads("bzip2/0.1@lasote/stables")
+        cpp_info = CppInfo("dummy_root_folder2")
+        cpp_info.name = "BZip2"
+        cpp_info.names["pkg_config"] = "BZip2"
+        cpp_info.defines = ["MYDEFINE2"]
+        cpp_info.version = "2.3"
+        cpp_info.exelinkflags = ["-exelinkflag"]
+        cpp_info.sharedlinkflags = ["-sharedlinkflag"]
+        cpp_info.cxxflags = ["-cxxflag"]
+        cpp_info.public_deps = ["MyPkg", "MyPkg1"]
+        conanfile.deps_cpp_info.update(cpp_info, ref.name)
         generator = PkgConfigGenerator(conanfile)
         files = generator.content
+
+        self.assertEqual(files["BZip2.pc"], """prefix=dummy_root_folder2
+libdir=${prefix}/lib
+includedir=${prefix}/include
+
+Name: BZip2
+Description: Conan package: BZip2
+Version: 2.3
+Libs: -L${libdir} -sharedlinkflag -exelinkflag
+Cflags: -I${includedir} -cxxflag -DMYDEFINE2
+Requires: my_pkg_custom_name my_pkg1_custom_name
+""")
 
         self.assertEqual(files["my_pkg2_custom_name.pc"], """prefix=dummy_root_folder2
 libdir=${prefix}/lib


### PR DESCRIPTION
fixes up #5988 now that #6033 is merged

There is no reason to force pkg-config file to be lower case, and no reason either to use the same casing as the package name or cpp_info.name
Typical failing use case is bzip2 https://github.com/conan-io/conan-center-index/blob/master/recipes/bzip2/1.0.8/conanfile.py for which `ConanFile.name` and `self.cpp_info.name` differ only by casing, and pkg_config file should be called `BZip2.pc`

It also fixes the incoherence between the content of the `.pc` file's `Requires:` and the requirements `.pc` file names:
https://github.com/conan-io/conan/blob/5a1c5d57d1208d265bde3d7bbb89ce7a906a4c1c/conans/client/generators/pkg_config.py#L85-L88

Thanks @Morwenn for pointing this out!

- [ ] Refer to the issue that supports this Pull Request.
- [X] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [X] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [X] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 

<sup>**Note:** By default this PR will skip the slower tests and will use a limited set of python versions. Check [here](https://github.com/conan-io/conan/blob/develop/.github/PR_INCREASE_TESTING.md) how to increase the testing level by writing some tags in the current PR body text.</sup>
