### PR TITLE
fix inspect with set_name() set_version()

### DIFF
--- a/conans/client/conan_api.py
+++ b/conans/client/conan_api.py
@@ -263,12 +263,12 @@ class ConanAPIV1(object):
             ref = ConanFileReference.loads(path)
         except ConanException:
             conanfile_path = _get_conanfile_path(path, get_cwd(), py=True)
-            conanfile = self.app.loader.load_basic(conanfile_path)
+            conanfile = self.app.loader.load_named(conanfile_path, None, None, None, None)
         else:
             update = True if remote_name else False
             result = self.app.proxy.get_recipe(ref, update, update, remotes, ActionRecorder())
             conanfile_path, _, _, ref = result
-            conanfile = self.app.loader.load_basic(conanfile_path)
+            conanfile = self.app.loader.load_named(conanfile_path, None, None, None, None)
             conanfile.name = ref.name
             conanfile.version = ref.version
 

--- a/conans/client/conan_api.py
+++ b/conans/client/conan_api.py
@@ -268,7 +268,7 @@ class ConanAPIV1(object):
             update = True if remote_name else False
             result = self.app.proxy.get_recipe(ref, update, update, remotes, ActionRecorder())
             conanfile_path, _, _, ref = result
-            conanfile = self.app.loader.load_named(conanfile_path, None, None, None, None)
+            conanfile = self.app.loader.load_basic(conanfile_path)
             conanfile.name = ref.name
             conanfile.version = ref.version
 

--- a/conans/test/functional/command/inspect_test.py
+++ b/conans/test/functional/command/inspect_test.py
@@ -3,7 +3,7 @@ import os
 import textwrap
 import unittest
 
-from conans.test.utils.tools import TestClient, TestServer
+from conans.test.utils.tools import TestClient, TestServer, GenConanfile
 
 
 class ConanInspectTest(unittest.TestCase):
@@ -55,12 +55,7 @@ class Pkg(base.Pkg):
     def name_version_test(self):
         server = TestServer()
         client = TestClient(servers={"default": server}, users={"default": [("lasote", "mypass")]})
-        conanfile = """from conans import ConanFile
-class Pkg(ConanFile):
-    name = "MyPkg"
-    version = "1.2.3"
-"""
-        client.save({"conanfile.py": conanfile})
+        client.save({"conanfile.py": GenConanfile().with_name("MyPkg").with_version("1.2.3")})
         client.run("inspect . -a=name")
         self.assertIn("name: MyPkg", client.out)
         client.run("inspect . -a=version")
@@ -84,6 +79,22 @@ class Pkg(ConanFile):
         client.run("inspect MyPkg/1.2.3@lasote/testing -a=name -r=default")
         self.assertIn("name: MyPkg", client.out)
         client.run("inspect MyPkg/1.2.3@lasote/testing -a=version -r=default")
+        self.assertIn("version: 1.2.3", client.out)
+
+    def set_name_version_test(self):
+        client = TestClient()
+        conanfile = textwrap.dedent("""
+            from conans import ConanFile
+            class Pkg(ConanFile):
+                def set_name(self):
+                    self.name = "MyPkg"
+                def set_version(self):
+                    self.version = "1.2.3"
+            """)
+        client.save({"conanfile.py": conanfile})
+        client.run("inspect . -a=name")
+        self.assertIn("name: MyPkg", client.out)
+        client.run("inspect . -a=version")
         self.assertIn("version: 1.2.3", client.out)
 
     def attributes_display_test(self):


### PR DESCRIPTION
Changelog: Bugfix: ``conan inspect`` now is able to properly show name and version coming from ``set_name()`` and ``set_version()`` methods.
Docs: Omit

Close #6213