### PR TITLE
Fixes cpp_info.name vs. cpp_info.names issue in pkg_config generator

### DIFF
--- a/conans/client/generators/pkg_config.py
+++ b/conans/client/generators/pkg_config.py
@@ -35,12 +35,7 @@ class PkgConfigGenerator(Generator):
     def content(self):
         ret = {}
         for depname, cpp_info in self.deps_build_info.dependencies:
-            # the name for the pc will be converted to lowercase when cpp_info.name is specified
-            # but with cpp_info.names["pkg_config"] will be literal
-            if cpp_info.name and cpp_info.get_name("pkg_config") != cpp_info.name:
-                name = cpp_info.get_name("pkg_config")
-            else:
-                name = cpp_info.name.lower() if cpp_info.name != depname else depname
+            name = _get_name(depname, cpp_info)
             ret["%s.pc" % name] = self.single_pc_file_contents(name, cpp_info)
         return ret
 
@@ -88,11 +83,22 @@ class PkgConfigGenerator(Generator):
              ["-D%s" % d for d in cpp_info.defines]]))
 
         if cpp_info.public_deps:
-            pkg_config_names = [self.deps_build_info[public_dep].get_name("pkg_config") for
-                                public_dep in cpp_info.public_deps]
+            pkg_config_names = []
+            for public_dep in cpp_info.public_deps:
+                pkg_config_names.append(_get_name(public_dep, self.deps_build_info[public_dep]))
             public_deps = " ".join(pkg_config_names)
             lines.append("Requires: %s" % public_deps)
         return "\n".join(lines) + "\n"
+
+
+def _get_name(depname, cpp_info):
+    # the name for the pc will be converted to lowercase when cpp_info.name is specified
+    # but with cpp_info.names["pkg_config"] will be literal
+    if "pkg_config" in cpp_info.names:
+        name = cpp_info.names["pkg_config"]
+    else:
+        name = cpp_info.name.lower() if cpp_info.name != depname else depname
+    return name
 
 
 def _concat_if_not_empty(groups):

--- a/conans/test/unittests/client/generators/pkg_config_test.py
+++ b/conans/test/unittests/client/generators/pkg_config_test.py
@@ -85,6 +85,7 @@ Cflags: -I${includedir} -Flag1=23 -DMYDEFINE1
     def pkg_config_custom_names_test(self):
         conanfile = ConanFile(TestBufferConanOutput(), None)
         conanfile.initialize(Settings({}), EnvValues())
+
         ref = ConanFileReference.loads("MyPkg/0.1@lasote/stables")
         cpp_info = CppInfo("dummy_root_folder1")
         cpp_info.name = "my_pkg"
@@ -116,6 +117,25 @@ Cflags: -I${includedir} -Flag1=23 -DMYDEFINE1
         cpp_info.cxxflags = ["-cxxflag"]
         cpp_info.public_deps = ["MyPkg", "MyPkg1"]
         conanfile.deps_cpp_info.update(cpp_info, ref.name)
+
+        ref = ConanFileReference.loads("zlib/1.2.11@lasote/stable")
+        cpp_info = CppInfo("dummy_root_folder_zlib")
+        cpp_info.name = "ZLIB"
+        cpp_info.defines = ["MYZLIBDEFINE2"]
+        cpp_info.version = "1.2.11"
+        conanfile.deps_cpp_info.update(cpp_info, ref.name)
+
+        ref = ConanFileReference.loads("bzip2/0.1@lasote/stables")
+        cpp_info = CppInfo("dummy_root_folder2")
+        cpp_info.name = "BZip2"
+        cpp_info.names["pkg_config"] = "BZip2"
+        cpp_info.defines = ["MYDEFINE2"]
+        cpp_info.version = "2.3"
+        cpp_info.exelinkflags = ["-exelinkflag"]
+        cpp_info.sharedlinkflags = ["-sharedlinkflag"]
+        cpp_info.cxxflags = ["-cxxflag"]
+        cpp_info.public_deps = ["MyPkg", "MyPkg1", "zlib"]
+        conanfile.deps_cpp_info.update(cpp_info, ref.name)
         generator = PkgConfigGenerator(conanfile)
         files = generator.content
 
@@ -128,9 +148,8 @@ Description: Conan package: my_pkg2_custom_name
 Version: 2.3
 Libs: -L${libdir} -sharedlinkflag -exelinkflag
 Cflags: -I${includedir} -cxxflag -DMYDEFINE2
-Requires: my_pkg_custom_name my_pkg1_custom_name
+Requires: my_pkg_custom_name my_pkg1_custom_name zlib
 """)
-
         self.assertEqual(files["my_pkg1_custom_name.pc"], """prefix=dummy_root_folder1
 libdir=${prefix}/lib
 includedir=${prefix}/include
@@ -141,7 +160,6 @@ Version: 1.7
 Libs: -L${libdir}
 Cflags: -I${includedir} -Flag1=21 -DMYDEFINE11
 """)
-
         self.assertEqual(files["my_pkg_custom_name.pc"], """prefix=dummy_root_folder1
 libdir=${prefix}/lib
 includedir=${prefix}/include
@@ -151,6 +169,17 @@ Description: My cool description
 Version: 1.3
 Libs: -L${libdir}
 Cflags: -I${includedir} -Flag1=23 -DMYDEFINE1
+""")
+        self.assertEqual(files["BZip2.pc"], """prefix=dummy_root_folder2
+libdir=${prefix}/lib
+includedir=${prefix}/include
+
+Name: BZip2
+Description: Conan package: BZip2
+Version: 2.3
+Libs: -L${libdir} -sharedlinkflag -exelinkflag
+Cflags: -I${includedir} -cxxflag -DMYDEFINE2
+Requires: my_pkg_custom_name my_pkg1_custom_name
 """)
 
     def apple_frameworks_test(self):

--- a/conans/test/unittests/client/generators/pkg_config_test.py
+++ b/conans/test/unittests/client/generators/pkg_config_test.py
@@ -148,7 +148,7 @@ Description: Conan package: my_pkg2_custom_name
 Version: 2.3
 Libs: -L${libdir} -sharedlinkflag -exelinkflag
 Cflags: -I${includedir} -cxxflag -DMYDEFINE2
-Requires: my_pkg_custom_name my_pkg1_custom_name zlib
+Requires: my_pkg_custom_name my_pkg1_custom_name
 """)
         self.assertEqual(files["my_pkg1_custom_name.pc"], """prefix=dummy_root_folder1
 libdir=${prefix}/lib
@@ -179,7 +179,7 @@ Description: Conan package: BZip2
 Version: 2.3
 Libs: -L${libdir} -sharedlinkflag -exelinkflag
 Cflags: -I${includedir} -cxxflag -DMYDEFINE2
-Requires: my_pkg_custom_name my_pkg1_custom_name
+Requires: my_pkg_custom_name my_pkg1_custom_name zlib
 """)
 
     def apple_frameworks_test(self):


### PR DESCRIPTION
Changelog: Bugfix: Fixes `cpp_info.name` vs. `cpp_info.names` issue in `pkg_config` generator
Docs: omit

**TARGET THIS TO NEW RELEASE BRANCH** Done!

- [x] Refer to the issue that supports this Pull Request: closes #6211 closes #6222 
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [x] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 

<sup>**Note:** By default this PR will skip the slower tests and will use a limited set of python versions. Check [here](https://github.com/conan-io/conan/blob/develop/.github/PR_INCREASE_TESTING.md) how to increase the testing level by writing some tags in the current PR body text.</sup>
