### PR TITLE
[refactor] Make macros/functions in 'cmake_common' available to reuse

### DIFF
--- a/conans/client/generators/cmake.py
+++ b/conans/client/generators/cmake.py
@@ -1,6 +1,6 @@
 from conans.client.generators.cmake_common import cmake_dependencies, cmake_dependency_vars, \
     cmake_global_vars, cmake_macros, cmake_package_info, cmake_settings_info, cmake_user_info_vars, \
-    generate_targets_section, apple_frameworks_macro
+    generate_targets_section, CMakeCommonMacros
 from conans.model import Generator
 from conans.paths import BUILD_INFO_CMAKE
 
@@ -75,7 +75,7 @@ class CMakeGenerator(Generator):
     @property
     def content(self):
         sections = ["include(CMakeParseArguments)"]
-        sections.append(apple_frameworks_macro)
+        sections.append(CMakeCommonMacros.apple_frameworks_macro)
 
         # Per requirement variables
         for _, dep_cpp_info in self.deps_build_info.dependencies:

--- a/conans/client/generators/cmake_common.py
+++ b/conans/client/generators/cmake_common.py
@@ -1,3 +1,5 @@
+import textwrap
+
 _cmake_single_dep_vars = """
 set(CONAN_{dep}_ROOT{build_type} {deps.rootpath})
 set(CONAN_INCLUDE_DIRS_{dep}{build_type} {deps.include_paths})
@@ -201,400 +203,455 @@ def generate_targets_section(dependencies, generator_name):
     return section
 
 
-_cmake_common_macros = """
-function(conan_message MESSAGE_OUTPUT)
-    if(NOT CONAN_CMAKE_SILENT_OUTPUT)
-        message(${ARGV${0}})
-    endif()
-endfunction()
-
-function(conan_find_libraries_abs_path libraries package_libdir libraries_abs_path)
-    foreach(_LIBRARY_NAME ${libraries})
-        unset(CONAN_FOUND_LIBRARY CACHE)
-        find_library(CONAN_FOUND_LIBRARY NAME ${_LIBRARY_NAME} PATHS ${package_libdir}
-                     NO_DEFAULT_PATH NO_CMAKE_FIND_ROOT_PATH)
-        if(CONAN_FOUND_LIBRARY)
-            conan_message(STATUS "Library ${_LIBRARY_NAME} found ${CONAN_FOUND_LIBRARY}")
-            set(CONAN_FULLPATH_LIBS ${CONAN_FULLPATH_LIBS} ${CONAN_FOUND_LIBRARY})
-        else()
-            conan_message(STATUS "Library ${_LIBRARY_NAME} not found in package, might be system one")
-            set(CONAN_FULLPATH_LIBS ${CONAN_FULLPATH_LIBS} ${_LIBRARY_NAME})
-        endif()
-    endforeach()
-    unset(CONAN_FOUND_LIBRARY CACHE)
-    set(${libraries_abs_path} ${CONAN_FULLPATH_LIBS} PARENT_SCOPE)
-endfunction()
-
-function(conan_package_library_targets libraries package_libdir libraries_abs_path deps build_type package_name)
-    foreach(_LIBRARY_NAME ${libraries})
-        unset(CONAN_FOUND_LIBRARY CACHE)
-        find_library(CONAN_FOUND_LIBRARY NAME ${_LIBRARY_NAME} PATHS ${package_libdir}
-                     NO_DEFAULT_PATH NO_CMAKE_FIND_ROOT_PATH)
-        if(CONAN_FOUND_LIBRARY)
-            conan_message(STATUS "Library ${_LIBRARY_NAME} found ${CONAN_FOUND_LIBRARY}")
-            set(_LIB_NAME CONAN_LIB::${package_name}_${_LIBRARY_NAME}${build_type})
-            add_library(${_LIB_NAME} UNKNOWN IMPORTED)
-            set_target_properties(${_LIB_NAME} PROPERTIES IMPORTED_LOCATION ${CONAN_FOUND_LIBRARY})
-            string(REPLACE " " ";" deps_list "${deps}")
-            set_property(TARGET ${_LIB_NAME} PROPERTY INTERFACE_LINK_LIBRARIES ${deps_list})
-            set(CONAN_FULLPATH_LIBS ${CONAN_FULLPATH_LIBS} ${_LIB_NAME})
-        else()
-            conan_message(STATUS "Library ${_LIBRARY_NAME} not found in package, might be system one")
-            set(CONAN_FULLPATH_LIBS ${CONAN_FULLPATH_LIBS} ${_LIBRARY_NAME})
-        endif()
-    endforeach()
-    unset(CONAN_FOUND_LIBRARY CACHE)
-    set(${libraries_abs_path} ${CONAN_FULLPATH_LIBS} PARENT_SCOPE)
-endfunction()
-
-macro(conan_set_libcxx)
-    if(DEFINED CONAN_LIBCXX)
-        conan_message(STATUS "Conan: C++ stdlib: ${CONAN_LIBCXX}")
-        if(CONAN_COMPILER STREQUAL "clang" OR CONAN_COMPILER STREQUAL "apple-clang")
-            if(CONAN_LIBCXX STREQUAL "libstdc++" OR CONAN_LIBCXX STREQUAL "libstdc++11" )
-                set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -stdlib=libstdc++")
-            elseif(CONAN_LIBCXX STREQUAL "libc++")
-                set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -stdlib=libc++")
+class CMakeCommonMacros:
+    # Group definition of CMake macros and functions used for many different generators
+    conan_message = textwrap.dedent("""
+        function(conan_message MESSAGE_OUTPUT)
+            if(NOT CONAN_CMAKE_SILENT_OUTPUT)
+                message(${ARGV${0}})
             endif()
-        endif()
-        if(CONAN_COMPILER STREQUAL "sun-cc")
-            if(CONAN_LIBCXX STREQUAL "libCstd")
-                set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -library=Cstd")
-            elseif(CONAN_LIBCXX STREQUAL "libstdcxx")
-                set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -library=stdcxx4")
-            elseif(CONAN_LIBCXX STREQUAL "libstlport")
-                set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -library=stlport4")
-            elseif(CONAN_LIBCXX STREQUAL "libstdc++")
-                set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -library=stdcpp")
+        endfunction()
+    """)
+
+    conan_find_libraries_abs_path = textwrap.dedent("""
+        function(conan_find_libraries_abs_path libraries package_libdir libraries_abs_path)
+            foreach(_LIBRARY_NAME ${libraries})
+                unset(CONAN_FOUND_LIBRARY CACHE)
+                find_library(CONAN_FOUND_LIBRARY NAME ${_LIBRARY_NAME} PATHS ${package_libdir}
+                             NO_DEFAULT_PATH NO_CMAKE_FIND_ROOT_PATH)
+                if(CONAN_FOUND_LIBRARY)
+                    conan_message(STATUS "Library ${_LIBRARY_NAME} found ${CONAN_FOUND_LIBRARY}")
+                    set(CONAN_FULLPATH_LIBS ${CONAN_FULLPATH_LIBS} ${CONAN_FOUND_LIBRARY})
+                else()
+                    conan_message(STATUS "Library ${_LIBRARY_NAME} not found in package, might be system one")
+                    set(CONAN_FULLPATH_LIBS ${CONAN_FULLPATH_LIBS} ${_LIBRARY_NAME})
+                endif()
+            endforeach()
+            unset(CONAN_FOUND_LIBRARY CACHE)
+            set(${libraries_abs_path} ${CONAN_FULLPATH_LIBS} PARENT_SCOPE)
+        endfunction()
+    """)
+
+    conan_package_library_targets = textwrap.dedent("""
+        function(conan_package_library_targets libraries package_libdir libraries_abs_path deps build_type package_name)
+            foreach(_LIBRARY_NAME ${libraries})
+                unset(CONAN_FOUND_LIBRARY CACHE)
+                find_library(CONAN_FOUND_LIBRARY NAME ${_LIBRARY_NAME} PATHS ${package_libdir}
+                             NO_DEFAULT_PATH NO_CMAKE_FIND_ROOT_PATH)
+                if(CONAN_FOUND_LIBRARY)
+                    conan_message(STATUS "Library ${_LIBRARY_NAME} found ${CONAN_FOUND_LIBRARY}")
+                    set(_LIB_NAME CONAN_LIB::${package_name}_${_LIBRARY_NAME}${build_type})
+                    add_library(${_LIB_NAME} UNKNOWN IMPORTED)
+                    set_target_properties(${_LIB_NAME} PROPERTIES IMPORTED_LOCATION ${CONAN_FOUND_LIBRARY})
+                    string(REPLACE " " ";" deps_list "${deps}")
+                    set_property(TARGET ${_LIB_NAME} PROPERTY INTERFACE_LINK_LIBRARIES ${deps_list})
+                    set(CONAN_FULLPATH_LIBS ${CONAN_FULLPATH_LIBS} ${_LIB_NAME})
+                else()
+                    conan_message(STATUS "Library ${_LIBRARY_NAME} not found in package, might be system one")
+                    set(CONAN_FULLPATH_LIBS ${CONAN_FULLPATH_LIBS} ${_LIBRARY_NAME})
+                endif()
+            endforeach()
+            unset(CONAN_FOUND_LIBRARY CACHE)
+            set(${libraries_abs_path} ${CONAN_FULLPATH_LIBS} PARENT_SCOPE)
+        endfunction()
+    """)
+
+    conan_set_libcxx = textwrap.dedent("""
+        macro(conan_set_libcxx)
+            if(DEFINED CONAN_LIBCXX)
+                conan_message(STATUS "Conan: C++ stdlib: ${CONAN_LIBCXX}")
+                if(CONAN_COMPILER STREQUAL "clang" OR CONAN_COMPILER STREQUAL "apple-clang")
+                    if(CONAN_LIBCXX STREQUAL "libstdc++" OR CONAN_LIBCXX STREQUAL "libstdc++11" )
+                        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -stdlib=libstdc++")
+                    elseif(CONAN_LIBCXX STREQUAL "libc++")
+                        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -stdlib=libc++")
+                    endif()
+                endif()
+                if(CONAN_COMPILER STREQUAL "sun-cc")
+                    if(CONAN_LIBCXX STREQUAL "libCstd")
+                        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -library=Cstd")
+                    elseif(CONAN_LIBCXX STREQUAL "libstdcxx")
+                        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -library=stdcxx4")
+                    elseif(CONAN_LIBCXX STREQUAL "libstlport")
+                        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -library=stlport4")
+                    elseif(CONAN_LIBCXX STREQUAL "libstdc++")
+                        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -library=stdcpp")
+                    endif()
+                endif()
+                if(CONAN_LIBCXX STREQUAL "libstdc++11")
+                    add_definitions(-D_GLIBCXX_USE_CXX11_ABI=1)
+                elseif(CONAN_LIBCXX STREQUAL "libstdc++")
+                    add_definitions(-D_GLIBCXX_USE_CXX11_ABI=0)
+                endif()
             endif()
-        endif()
-        if(CONAN_LIBCXX STREQUAL "libstdc++11")
-            add_definitions(-D_GLIBCXX_USE_CXX11_ABI=1)
-        elseif(CONAN_LIBCXX STREQUAL "libstdc++")
-            add_definitions(-D_GLIBCXX_USE_CXX11_ABI=0)
-        endif()
-    endif()
-endmacro()
+        endmacro()
+    """)
 
-macro(conan_set_std)
-    # Do not warn "Manually-specified variables were not used by the project"
-    set(ignorevar "${CONAN_STD_CXX_FLAG}${CONAN_CMAKE_CXX_STANDARD}${CONAN_CMAKE_CXX_EXTENSIONS}")
-    if (CMAKE_VERSION VERSION_LESS "3.1" OR
-        (CMAKE_VERSION VERSION_LESS "3.12" AND ("${CONAN_CMAKE_CXX_STANDARD}" STREQUAL "20" OR "${CONAN_CMAKE_CXX_STANDARD}" STREQUAL "gnu20")))
-    if(CONAN_STD_CXX_FLAG)
-        conan_message(STATUS "Conan setting CXX_FLAGS flags: ${CONAN_STD_CXX_FLAG}")
-        set(CMAKE_CXX_FLAGS "${CONAN_STD_CXX_FLAG} ${CMAKE_CXX_FLAGS}")
-    endif()
-    else()
-        if(CONAN_CMAKE_CXX_STANDARD)
-            conan_message(STATUS "Conan setting CPP STANDARD: ${CONAN_CMAKE_CXX_STANDARD} WITH EXTENSIONS ${CONAN_CMAKE_CXX_EXTENSIONS}")
-            set(CMAKE_CXX_STANDARD ${CONAN_CMAKE_CXX_STANDARD})
-            set(CMAKE_CXX_EXTENSIONS ${CONAN_CMAKE_CXX_EXTENSIONS})
-        endif()
-    endif()
-endmacro()
-
-macro(conan_set_rpath)
-    if(APPLE)
-        # https://cmake.org/Wiki/CMake_RPATH_handling
-        # CONAN GUIDE: All generated libraries should have the id and dependencies to other
-        # dylibs without path, just the name, EX:
-        # libMyLib1.dylib:
-        #     libMyLib1.dylib (compatibility version 0.0.0, current version 0.0.0)
-        #     libMyLib0.dylib (compatibility version 0.0.0, current version 0.0.0)
-        #     /usr/lib/libc++.1.dylib (compatibility version 1.0.0, current version 120.0.0)
-        #     /usr/lib/libSystem.B.dylib (compatibility version 1.0.0, current version 1197.1.1)
-        set(CMAKE_SKIP_RPATH 1)  # AVOID RPATH FOR *.dylib, ALL LIBS BETWEEN THEM AND THE EXE
-                                 # SHOULD BE ON THE LINKER RESOLVER PATH (./ IS ONE OF THEM)
-        # Policy CMP0068
-        # We want the old behavior, in CMake >= 3.9 CMAKE_SKIP_RPATH won't affect the install_name in OSX
-        set(CMAKE_INSTALL_NAME_DIR "")
-    endif()
-endmacro()
-
-macro(conan_set_fpic)
-    if(DEFINED CONAN_CMAKE_POSITION_INDEPENDENT_CODE)
-        conan_message(STATUS "Conan: Adjusting fPIC flag (${CONAN_CMAKE_POSITION_INDEPENDENT_CODE})")
-        set(CMAKE_POSITION_INDEPENDENT_CODE ${CONAN_CMAKE_POSITION_INDEPENDENT_CODE})
-    endif()
-endmacro()
-
-macro(conan_output_dirs_setup)
-    set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/bin)
-    set(CMAKE_RUNTIME_OUTPUT_DIRECTORY_RELEASE ${CMAKE_RUNTIME_OUTPUT_DIRECTORY})
-    set(CMAKE_RUNTIME_OUTPUT_DIRECTORY_RELWITHDEBINFO ${CMAKE_RUNTIME_OUTPUT_DIRECTORY})
-    set(CMAKE_RUNTIME_OUTPUT_DIRECTORY_MINSIZEREL ${CMAKE_RUNTIME_OUTPUT_DIRECTORY})
-    set(CMAKE_RUNTIME_OUTPUT_DIRECTORY_DEBUG ${CMAKE_RUNTIME_OUTPUT_DIRECTORY})
-
-    set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/lib)
-    set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY_RELEASE ${CMAKE_ARCHIVE_OUTPUT_DIRECTORY})
-    set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY_RELWITHDEBINFO ${CMAKE_ARCHIVE_OUTPUT_DIRECTORY})
-    set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY_MINSIZEREL ${CMAKE_ARCHIVE_OUTPUT_DIRECTORY})
-    set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY_DEBUG ${CMAKE_ARCHIVE_OUTPUT_DIRECTORY})
-
-    set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/lib)
-    set(CMAKE_LIBRARY_OUTPUT_DIRECTORY_RELEASE ${CMAKE_LIBRARY_OUTPUT_DIRECTORY})
-    set(CMAKE_LIBRARY_OUTPUT_DIRECTORY_RELWITHDEBINFO ${CMAKE_LIBRARY_OUTPUT_DIRECTORY})
-    set(CMAKE_LIBRARY_OUTPUT_DIRECTORY_MINSIZEREL ${CMAKE_LIBRARY_OUTPUT_DIRECTORY})
-    set(CMAKE_LIBRARY_OUTPUT_DIRECTORY_DEBUG ${CMAKE_LIBRARY_OUTPUT_DIRECTORY})
-endmacro()
-
-macro(conan_split_version VERSION_STRING MAJOR MINOR)
-    #make a list from the version string
-    string(REPLACE "." ";" VERSION_LIST "${VERSION_STRING}")
-
-    #write output values
-    list(LENGTH VERSION_LIST _version_len)
-    list(GET VERSION_LIST 0 ${MAJOR})
-    if(${_version_len} GREATER 1)
-        list(GET VERSION_LIST 1 ${MINOR})
-    endif()
-endmacro()
-
-macro(conan_error_compiler_version)
-    message(FATAL_ERROR "Detected a mismatch for the compiler version between your conan profile settings and CMake: \n"
-                        "Compiler version specified in your conan profile: ${CONAN_COMPILER_VERSION}\n"
-                        "Compiler version detected in CMake: ${VERSION_MAJOR}.${VERSION_MINOR}\n"
-                        "Please check your conan profile settings (conan profile show [default|your_profile_name])"
-           )
-endmacro()
-
-set(_CONAN_CURRENT_DIR ${CMAKE_CURRENT_LIST_DIR})
-function(conan_get_compiler CONAN_INFO_COMPILER CONAN_INFO_COMPILER_VERSION)
-    conan_message(STATUS "Current conanbuildinfo.cmake directory: " ${_CONAN_CURRENT_DIR})
-    if(NOT EXISTS ${_CONAN_CURRENT_DIR}/conaninfo.txt)
-        conan_message(STATUS "WARN: conaninfo.txt not found")
-        return()
-    endif()
-
-    file (READ "${_CONAN_CURRENT_DIR}/conaninfo.txt" CONANINFO)
-
-    string(REGEX MATCH "compiler=([-A-Za-z0-9_ ]+)" _MATCHED ${CONANINFO})
-    if(DEFINED CMAKE_MATCH_1)
-        string(STRIP "${CMAKE_MATCH_1}" _CONAN_INFO_COMPILER)
-        set(${CONAN_INFO_COMPILER} ${_CONAN_INFO_COMPILER} PARENT_SCOPE)
-    endif()
-
-    string(REGEX MATCH "compiler.version=([-A-Za-z0-9_.]+)" _MATCHED ${CONANINFO})
-    if(DEFINED CMAKE_MATCH_1)
-        string(STRIP "${CMAKE_MATCH_1}" _CONAN_INFO_COMPILER_VERSION)
-        set(${CONAN_INFO_COMPILER_VERSION} ${_CONAN_INFO_COMPILER_VERSION} PARENT_SCOPE)
-    endif()
-endfunction()
-
-function(check_compiler_version)
-    conan_split_version(${CMAKE_CXX_COMPILER_VERSION} VERSION_MAJOR VERSION_MINOR)
-    if(DEFINED CONAN_SETTINGS_COMPILER_TOOLSET)
-       conan_message(STATUS "Conan: Skipping compiler check: Declared 'compiler.toolset'")
-       return()
-    endif()
-    if(CMAKE_CXX_COMPILER_ID MATCHES MSVC)
-        # MSVC_VERSION is defined since 2.8.2 at least
-        # https://cmake.org/cmake/help/v2.8.2/cmake.html#variable:MSVC_VERSION
-        # https://cmake.org/cmake/help/v3.14/variable/MSVC_VERSION.html
-        if(
-            # 1920-1929 = VS 16.0 (v142 toolset)
-            (CONAN_COMPILER_VERSION STREQUAL "16" AND NOT((MSVC_VERSION GREATER 1919) AND (MSVC_VERSION LESS 1930))) OR
-            # 1910-1919 = VS 15.0 (v141 toolset)
-            (CONAN_COMPILER_VERSION STREQUAL "15" AND NOT((MSVC_VERSION GREATER 1909) AND (MSVC_VERSION LESS 1920))) OR
-            # 1900      = VS 14.0 (v140 toolset)
-            (CONAN_COMPILER_VERSION STREQUAL "14" AND NOT(MSVC_VERSION EQUAL 1900)) OR
-            # 1800      = VS 12.0 (v120 toolset)
-            (CONAN_COMPILER_VERSION STREQUAL "12" AND NOT VERSION_MAJOR STREQUAL "18") OR
-            # 1700      = VS 11.0 (v110 toolset)
-            (CONAN_COMPILER_VERSION STREQUAL "11" AND NOT VERSION_MAJOR STREQUAL "17") OR
-            # 1600      = VS 10.0 (v100 toolset)
-            (CONAN_COMPILER_VERSION STREQUAL "10" AND NOT VERSION_MAJOR STREQUAL "16") OR
-            # 1500      = VS  9.0 (v90 toolset)
-            (CONAN_COMPILER_VERSION STREQUAL "9" AND NOT VERSION_MAJOR STREQUAL "15") OR
-            # 1400      = VS  8.0 (v80 toolset)
-            (CONAN_COMPILER_VERSION STREQUAL "8" AND NOT VERSION_MAJOR STREQUAL "14") OR
-            # 1310      = VS  7.1, 1300      = VS  7.0
-            (CONAN_COMPILER_VERSION STREQUAL "7" AND NOT VERSION_MAJOR STREQUAL "13") OR
-            # 1200      = VS  6.0
-            (CONAN_COMPILER_VERSION STREQUAL "6" AND NOT VERSION_MAJOR STREQUAL "12") )
-            conan_error_compiler_version()
-        endif()
-    elseif(CONAN_COMPILER STREQUAL "gcc")
-        set(_CHECK_VERSION ${VERSION_MAJOR}.${VERSION_MINOR})
-        if(NOT ${CONAN_COMPILER_VERSION} VERSION_LESS 5.0)
-            conan_message(STATUS "Conan: Compiler GCC>=5, checking major version ${CONAN_COMPILER_VERSION}")
-            conan_split_version(${CONAN_COMPILER_VERSION} CONAN_COMPILER_MAJOR CONAN_COMPILER_MINOR)
-            if("${CONAN_COMPILER_MINOR}" STREQUAL "")
-                set(_CHECK_VERSION ${VERSION_MAJOR})
+    conan_set_std = textwrap.dedent("""
+        macro(conan_set_std)
+            # Do not warn "Manually-specified variables were not used by the project"
+            set(ignorevar "${CONAN_STD_CXX_FLAG}${CONAN_CMAKE_CXX_STANDARD}${CONAN_CMAKE_CXX_EXTENSIONS}")
+            if (CMAKE_VERSION VERSION_LESS "3.1" OR
+                (CMAKE_VERSION VERSION_LESS "3.12" AND ("${CONAN_CMAKE_CXX_STANDARD}" STREQUAL "20" OR "${CONAN_CMAKE_CXX_STANDARD}" STREQUAL "gnu20")))
+            if(CONAN_STD_CXX_FLAG)
+                conan_message(STATUS "Conan setting CXX_FLAGS flags: ${CONAN_STD_CXX_FLAG}")
+                set(CMAKE_CXX_FLAGS "${CONAN_STD_CXX_FLAG} ${CMAKE_CXX_FLAGS}")
             endif()
-        endif()
-        conan_message(STATUS "Conan: Checking correct version: ${_CHECK_VERSION}")
-        if(NOT ${_CHECK_VERSION} VERSION_EQUAL CONAN_COMPILER_VERSION)
-            conan_error_compiler_version()
-        endif()
-    elseif(CONAN_COMPILER STREQUAL "clang")
-        set(_CHECK_VERSION ${VERSION_MAJOR}.${VERSION_MINOR})
-        if(NOT ${CONAN_COMPILER_VERSION} VERSION_LESS 8.0)
-            conan_message(STATUS "Conan: Compiler Clang>=8, checking major version ${CONAN_COMPILER_VERSION}")
-            conan_split_version(${CONAN_COMPILER_VERSION} CONAN_COMPILER_MAJOR CONAN_COMPILER_MINOR)
-            if("${CONAN_COMPILER_MINOR}" STREQUAL "")
-                set(_CHECK_VERSION ${VERSION_MAJOR})
+            else()
+                if(CONAN_CMAKE_CXX_STANDARD)
+                    conan_message(STATUS "Conan setting CPP STANDARD: ${CONAN_CMAKE_CXX_STANDARD} WITH EXTENSIONS ${CONAN_CMAKE_CXX_EXTENSIONS}")
+                    set(CMAKE_CXX_STANDARD ${CONAN_CMAKE_CXX_STANDARD})
+                    set(CMAKE_CXX_EXTENSIONS ${CONAN_CMAKE_CXX_EXTENSIONS})
+                endif()
             endif()
-        endif()
-        conan_message(STATUS "Conan: Checking correct version: ${_CHECK_VERSION}")
-        if(NOT ${_CHECK_VERSION} VERSION_EQUAL CONAN_COMPILER_VERSION)
-            conan_error_compiler_version()
-        endif()
-    elseif(CONAN_COMPILER STREQUAL "apple-clang" OR CONAN_COMPILER STREQUAL "sun-cc")
-        conan_split_version(${CONAN_COMPILER_VERSION} CONAN_COMPILER_MAJOR CONAN_COMPILER_MINOR)
-        if(NOT ${VERSION_MAJOR}.${VERSION_MINOR} VERSION_EQUAL ${CONAN_COMPILER_MAJOR}.${CONAN_COMPILER_MINOR})
-           conan_error_compiler_version()
-        endif()
-    else()
-        conan_message(STATUS "WARN: Unknown compiler '${CONAN_COMPILER}', skipping the version check...")
-    endif()
-endfunction()
+        endmacro()
+    """)
 
-function(conan_check_compiler)
-    if(CONAN_DISABLE_CHECK_COMPILER)
-        conan_message(STATUS "WARN: Disabled conan compiler checks")
-        return()
-    endif()
-    if(NOT DEFINED CMAKE_CXX_COMPILER_ID)
-        if(DEFINED CMAKE_C_COMPILER_ID)
-            conan_message(STATUS "This project seems to be plain C, using '${CMAKE_C_COMPILER_ID}' compiler")
-            set(CMAKE_CXX_COMPILER_ID ${CMAKE_C_COMPILER_ID})
-            set(CMAKE_CXX_COMPILER_VERSION ${CMAKE_C_COMPILER_VERSION})
-        else()
-            message(FATAL_ERROR "This project seems to be plain C, but no compiler defined")
-        endif()
-    endif()
-    if(NOT CMAKE_CXX_COMPILER_ID AND NOT CMAKE_C_COMPILER_ID)
-        # This use case happens when compiler is not identified by CMake, but the compilers are there and work
-        conan_message(STATUS "*** WARN: CMake was not able to identify a C or C++ compiler ***")
-        conan_message(STATUS "*** WARN: Disabling compiler checks. Please make sure your settings match your environment ***")
-        return()
-    endif()
-    if(NOT DEFINED CONAN_COMPILER)
-        conan_get_compiler(CONAN_COMPILER CONAN_COMPILER_VERSION)
-        if(NOT DEFINED CONAN_COMPILER)
-            conan_message(STATUS "WARN: CONAN_COMPILER variable not set, please make sure yourself that "
-                          "your compiler and version matches your declared settings")
-            return()
-        endif()
-    endif()
+    conan_set_rpath = textwrap.dedent("""
+        macro(conan_set_rpath)
+            if(APPLE)
+                # https://cmake.org/Wiki/CMake_RPATH_handling
+                # CONAN GUIDE: All generated libraries should have the id and dependencies to other
+                # dylibs without path, just the name, EX:
+                # libMyLib1.dylib:
+                #     libMyLib1.dylib (compatibility version 0.0.0, current version 0.0.0)
+                #     libMyLib0.dylib (compatibility version 0.0.0, current version 0.0.0)
+                #     /usr/lib/libc++.1.dylib (compatibility version 1.0.0, current version 120.0.0)
+                #     /usr/lib/libSystem.B.dylib (compatibility version 1.0.0, current version 1197.1.1)
+                set(CMAKE_SKIP_RPATH 1)  # AVOID RPATH FOR *.dylib, ALL LIBS BETWEEN THEM AND THE EXE
+                                         # SHOULD BE ON THE LINKER RESOLVER PATH (./ IS ONE OF THEM)
+                # Policy CMP0068
+                # We want the old behavior, in CMake >= 3.9 CMAKE_SKIP_RPATH won't affect the install_name in OSX
+                set(CMAKE_INSTALL_NAME_DIR "")
+            endif()
+        endmacro()
+    """)
 
-    if(NOT CMAKE_HOST_SYSTEM_NAME STREQUAL ${CMAKE_SYSTEM_NAME})
-        set(CROSS_BUILDING 1)
-    endif()
+    conan_set_fpic = textwrap.dedent("""
+        macro(conan_set_fpic)
+            if(DEFINED CONAN_CMAKE_POSITION_INDEPENDENT_CODE)
+                conan_message(STATUS "Conan: Adjusting fPIC flag (${CONAN_CMAKE_POSITION_INDEPENDENT_CODE})")
+                set(CMAKE_POSITION_INDEPENDENT_CODE ${CONAN_CMAKE_POSITION_INDEPENDENT_CODE})
+            endif()
+        endmacro()
+    """)
 
-    # If using VS, verify toolset
-    if (CONAN_COMPILER STREQUAL "Visual Studio")
-        if (CONAN_SETTINGS_COMPILER_TOOLSET MATCHES "LLVM" OR
-            CONAN_SETTINGS_COMPILER_TOOLSET MATCHES "clang")
-            set(EXPECTED_CMAKE_CXX_COMPILER_ID "Clang")
-        elseif (CONAN_SETTINGS_COMPILER_TOOLSET MATCHES "Intel")
-            set(EXPECTED_CMAKE_CXX_COMPILER_ID "Intel")
-        else()
-            set(EXPECTED_CMAKE_CXX_COMPILER_ID "MSVC")
-        endif()
+    conan_output_dirs_setup = textwrap.dedent("""
+        macro(conan_output_dirs_setup)
+            set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/bin)
+            set(CMAKE_RUNTIME_OUTPUT_DIRECTORY_RELEASE ${CMAKE_RUNTIME_OUTPUT_DIRECTORY})
+            set(CMAKE_RUNTIME_OUTPUT_DIRECTORY_RELWITHDEBINFO ${CMAKE_RUNTIME_OUTPUT_DIRECTORY})
+            set(CMAKE_RUNTIME_OUTPUT_DIRECTORY_MINSIZEREL ${CMAKE_RUNTIME_OUTPUT_DIRECTORY})
+            set(CMAKE_RUNTIME_OUTPUT_DIRECTORY_DEBUG ${CMAKE_RUNTIME_OUTPUT_DIRECTORY})
+        
+            set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/lib)
+            set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY_RELEASE ${CMAKE_ARCHIVE_OUTPUT_DIRECTORY})
+            set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY_RELWITHDEBINFO ${CMAKE_ARCHIVE_OUTPUT_DIRECTORY})
+            set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY_MINSIZEREL ${CMAKE_ARCHIVE_OUTPUT_DIRECTORY})
+            set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY_DEBUG ${CMAKE_ARCHIVE_OUTPUT_DIRECTORY})
+        
+            set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/lib)
+            set(CMAKE_LIBRARY_OUTPUT_DIRECTORY_RELEASE ${CMAKE_LIBRARY_OUTPUT_DIRECTORY})
+            set(CMAKE_LIBRARY_OUTPUT_DIRECTORY_RELWITHDEBINFO ${CMAKE_LIBRARY_OUTPUT_DIRECTORY})
+            set(CMAKE_LIBRARY_OUTPUT_DIRECTORY_MINSIZEREL ${CMAKE_LIBRARY_OUTPUT_DIRECTORY})
+            set(CMAKE_LIBRARY_OUTPUT_DIRECTORY_DEBUG ${CMAKE_LIBRARY_OUTPUT_DIRECTORY})
+        endmacro()
+    """)
 
-        if (NOT CMAKE_CXX_COMPILER_ID MATCHES ${EXPECTED_CMAKE_CXX_COMPILER_ID})
-            message(FATAL_ERROR "Incorrect '${CONAN_COMPILER}'. Toolset specifies compiler as '${EXPECTED_CMAKE_CXX_COMPILER_ID}' "
-                                "but CMake detected '${CMAKE_CXX_COMPILER_ID}'")
-        endif()
+    conan_split_version = textwrap.dedent("""
+        macro(conan_split_version VERSION_STRING MAJOR MINOR)
+            #make a list from the version string
+            string(REPLACE "." ";" VERSION_LIST "${VERSION_STRING}")
+        
+            #write output values
+            list(LENGTH VERSION_LIST _version_len)
+            list(GET VERSION_LIST 0 ${MAJOR})
+            if(${_version_len} GREATER 1)
+                list(GET VERSION_LIST 1 ${MINOR})
+            endif()
+        endmacro()
+    """)
 
-    # Avoid checks when cross compiling, apple-clang crashes because its APPLE but not apple-clang
-    # Actually CMake is detecting "clang" when you are using apple-clang, only if CMP0025 is set to NEW will detect apple-clang
-    elseif((CONAN_COMPILER STREQUAL "gcc" AND NOT CMAKE_CXX_COMPILER_ID MATCHES "GNU") OR
-        (CONAN_COMPILER STREQUAL "apple-clang" AND NOT CROSS_BUILDING AND (NOT APPLE OR NOT CMAKE_CXX_COMPILER_ID MATCHES "Clang")) OR
-        (CONAN_COMPILER STREQUAL "clang" AND NOT CMAKE_CXX_COMPILER_ID MATCHES "Clang") OR
-        (CONAN_COMPILER STREQUAL "sun-cc" AND NOT CMAKE_CXX_COMPILER_ID MATCHES "SunPro") )
-        message(FATAL_ERROR "Incorrect '${CONAN_COMPILER}', is not the one detected by CMake: '${CMAKE_CXX_COMPILER_ID}'")
-    endif()
+    conan_error_compiler_version = textwrap.dedent("""
+        macro(conan_error_compiler_version)
+            message(FATAL_ERROR "Detected a mismatch for the compiler version between your conan profile settings and CMake: \\n"
+                                "Compiler version specified in your conan profile: ${CONAN_COMPILER_VERSION}\\n"
+                                "Compiler version detected in CMake: ${VERSION_MAJOR}.${VERSION_MINOR}\\n"
+                                "Please check your conan profile settings (conan profile show [default|your_profile_name])"
+                   )
+        endmacro()
+    """)
+
+    conan_get_compiler = textwrap.dedent("""
+        function(conan_get_compiler CONAN_INFO_COMPILER CONAN_INFO_COMPILER_VERSION)
+            conan_message(STATUS "Current conanbuildinfo.cmake directory: " ${_CONAN_CURRENT_DIR})
+            if(NOT EXISTS ${_CONAN_CURRENT_DIR}/conaninfo.txt)
+                conan_message(STATUS "WARN: conaninfo.txt not found")
+                return()
+            endif()
+        
+            file (READ "${_CONAN_CURRENT_DIR}/conaninfo.txt" CONANINFO)
+        
+            string(REGEX MATCH "compiler=([-A-Za-z0-9_ ]+)" _MATCHED ${CONANINFO})
+            if(DEFINED CMAKE_MATCH_1)
+                string(STRIP "${CMAKE_MATCH_1}" _CONAN_INFO_COMPILER)
+                set(${CONAN_INFO_COMPILER} ${_CONAN_INFO_COMPILER} PARENT_SCOPE)
+            endif()
+        
+            string(REGEX MATCH "compiler.version=([-A-Za-z0-9_.]+)" _MATCHED ${CONANINFO})
+            if(DEFINED CMAKE_MATCH_1)
+                string(STRIP "${CMAKE_MATCH_1}" _CONAN_INFO_COMPILER_VERSION)
+                set(${CONAN_INFO_COMPILER_VERSION} ${_CONAN_INFO_COMPILER_VERSION} PARENT_SCOPE)
+            endif()
+        endfunction()
+    """)
+    check_compiler_version = textwrap.dedent("""
+        function(check_compiler_version)
+            conan_split_version(${CMAKE_CXX_COMPILER_VERSION} VERSION_MAJOR VERSION_MINOR)
+            if(DEFINED CONAN_SETTINGS_COMPILER_TOOLSET)
+               conan_message(STATUS "Conan: Skipping compiler check: Declared 'compiler.toolset'")
+               return()
+            endif()
+            if(CMAKE_CXX_COMPILER_ID MATCHES MSVC)
+                # MSVC_VERSION is defined since 2.8.2 at least
+                # https://cmake.org/cmake/help/v2.8.2/cmake.html#variable:MSVC_VERSION
+                # https://cmake.org/cmake/help/v3.14/variable/MSVC_VERSION.html
+                if(
+                    # 1920-1929 = VS 16.0 (v142 toolset)
+                    (CONAN_COMPILER_VERSION STREQUAL "16" AND NOT((MSVC_VERSION GREATER 1919) AND (MSVC_VERSION LESS 1930))) OR
+                    # 1910-1919 = VS 15.0 (v141 toolset)
+                    (CONAN_COMPILER_VERSION STREQUAL "15" AND NOT((MSVC_VERSION GREATER 1909) AND (MSVC_VERSION LESS 1920))) OR
+                    # 1900      = VS 14.0 (v140 toolset)
+                    (CONAN_COMPILER_VERSION STREQUAL "14" AND NOT(MSVC_VERSION EQUAL 1900)) OR
+                    # 1800      = VS 12.0 (v120 toolset)
+                    (CONAN_COMPILER_VERSION STREQUAL "12" AND NOT VERSION_MAJOR STREQUAL "18") OR
+                    # 1700      = VS 11.0 (v110 toolset)
+                    (CONAN_COMPILER_VERSION STREQUAL "11" AND NOT VERSION_MAJOR STREQUAL "17") OR
+                    # 1600      = VS 10.0 (v100 toolset)
+                    (CONAN_COMPILER_VERSION STREQUAL "10" AND NOT VERSION_MAJOR STREQUAL "16") OR
+                    # 1500      = VS  9.0 (v90 toolset)
+                    (CONAN_COMPILER_VERSION STREQUAL "9" AND NOT VERSION_MAJOR STREQUAL "15") OR
+                    # 1400      = VS  8.0 (v80 toolset)
+                    (CONAN_COMPILER_VERSION STREQUAL "8" AND NOT VERSION_MAJOR STREQUAL "14") OR
+                    # 1310      = VS  7.1, 1300      = VS  7.0
+                    (CONAN_COMPILER_VERSION STREQUAL "7" AND NOT VERSION_MAJOR STREQUAL "13") OR
+                    # 1200      = VS  6.0
+                    (CONAN_COMPILER_VERSION STREQUAL "6" AND NOT VERSION_MAJOR STREQUAL "12") )
+                    conan_error_compiler_version()
+                endif()
+            elseif(CONAN_COMPILER STREQUAL "gcc")
+                set(_CHECK_VERSION ${VERSION_MAJOR}.${VERSION_MINOR})
+                if(NOT ${CONAN_COMPILER_VERSION} VERSION_LESS 5.0)
+                    conan_message(STATUS "Conan: Compiler GCC>=5, checking major version ${CONAN_COMPILER_VERSION}")
+                    conan_split_version(${CONAN_COMPILER_VERSION} CONAN_COMPILER_MAJOR CONAN_COMPILER_MINOR)
+                    if("${CONAN_COMPILER_MINOR}" STREQUAL "")
+                        set(_CHECK_VERSION ${VERSION_MAJOR})
+                    endif()
+                endif()
+                conan_message(STATUS "Conan: Checking correct version: ${_CHECK_VERSION}")
+                if(NOT ${_CHECK_VERSION} VERSION_EQUAL CONAN_COMPILER_VERSION)
+                    conan_error_compiler_version()
+                endif()
+            elseif(CONAN_COMPILER STREQUAL "clang")
+                set(_CHECK_VERSION ${VERSION_MAJOR}.${VERSION_MINOR})
+                if(NOT ${CONAN_COMPILER_VERSION} VERSION_LESS 8.0)
+                    conan_message(STATUS "Conan: Compiler Clang>=8, checking major version ${CONAN_COMPILER_VERSION}")
+                    conan_split_version(${CONAN_COMPILER_VERSION} CONAN_COMPILER_MAJOR CONAN_COMPILER_MINOR)
+                    if("${CONAN_COMPILER_MINOR}" STREQUAL "")
+                        set(_CHECK_VERSION ${VERSION_MAJOR})
+                    endif()
+                endif()
+                conan_message(STATUS "Conan: Checking correct version: ${_CHECK_VERSION}")
+                if(NOT ${_CHECK_VERSION} VERSION_EQUAL CONAN_COMPILER_VERSION)
+                    conan_error_compiler_version()
+                endif()
+            elseif(CONAN_COMPILER STREQUAL "apple-clang" OR CONAN_COMPILER STREQUAL "sun-cc")
+                conan_split_version(${CONAN_COMPILER_VERSION} CONAN_COMPILER_MAJOR CONAN_COMPILER_MINOR)
+                if(NOT ${VERSION_MAJOR}.${VERSION_MINOR} VERSION_EQUAL ${CONAN_COMPILER_MAJOR}.${CONAN_COMPILER_MINOR})
+                   conan_error_compiler_version()
+                endif()
+            else()
+                conan_message(STATUS "WARN: Unknown compiler '${CONAN_COMPILER}', skipping the version check...")
+            endif()
+        endfunction()
+    """)
+
+    conan_check_compiler = textwrap.dedent("""
+        function(conan_check_compiler)
+            if(CONAN_DISABLE_CHECK_COMPILER)
+                conan_message(STATUS "WARN: Disabled conan compiler checks")
+                return()
+            endif()
+            if(NOT DEFINED CMAKE_CXX_COMPILER_ID)
+                if(DEFINED CMAKE_C_COMPILER_ID)
+                    conan_message(STATUS "This project seems to be plain C, using '${CMAKE_C_COMPILER_ID}' compiler")
+                    set(CMAKE_CXX_COMPILER_ID ${CMAKE_C_COMPILER_ID})
+                    set(CMAKE_CXX_COMPILER_VERSION ${CMAKE_C_COMPILER_VERSION})
+                else()
+                    message(FATAL_ERROR "This project seems to be plain C, but no compiler defined")
+                endif()
+            endif()
+            if(NOT CMAKE_CXX_COMPILER_ID AND NOT CMAKE_C_COMPILER_ID)
+                # This use case happens when compiler is not identified by CMake, but the compilers are there and work
+                conan_message(STATUS "*** WARN: CMake was not able to identify a C or C++ compiler ***")
+                conan_message(STATUS "*** WARN: Disabling compiler checks. Please make sure your settings match your environment ***")
+                return()
+            endif()
+            if(NOT DEFINED CONAN_COMPILER)
+                conan_get_compiler(CONAN_COMPILER CONAN_COMPILER_VERSION)
+                if(NOT DEFINED CONAN_COMPILER)
+                    conan_message(STATUS "WARN: CONAN_COMPILER variable not set, please make sure yourself that "
+                                  "your compiler and version matches your declared settings")
+                    return()
+                endif()
+            endif()
+        
+            if(NOT CMAKE_HOST_SYSTEM_NAME STREQUAL ${CMAKE_SYSTEM_NAME})
+                set(CROSS_BUILDING 1)
+            endif()
+        
+            # If using VS, verify toolset
+            if (CONAN_COMPILER STREQUAL "Visual Studio")
+                if (CONAN_SETTINGS_COMPILER_TOOLSET MATCHES "LLVM" OR
+                    CONAN_SETTINGS_COMPILER_TOOLSET MATCHES "clang")
+                    set(EXPECTED_CMAKE_CXX_COMPILER_ID "Clang")
+                elseif (CONAN_SETTINGS_COMPILER_TOOLSET MATCHES "Intel")
+                    set(EXPECTED_CMAKE_CXX_COMPILER_ID "Intel")
+                else()
+                    set(EXPECTED_CMAKE_CXX_COMPILER_ID "MSVC")
+                endif()
+        
+                if (NOT CMAKE_CXX_COMPILER_ID MATCHES ${EXPECTED_CMAKE_CXX_COMPILER_ID})
+                    message(FATAL_ERROR "Incorrect '${CONAN_COMPILER}'. Toolset specifies compiler as '${EXPECTED_CMAKE_CXX_COMPILER_ID}' "
+                                        "but CMake detected '${CMAKE_CXX_COMPILER_ID}'")
+                endif()
+        
+            # Avoid checks when cross compiling, apple-clang crashes because its APPLE but not apple-clang
+            # Actually CMake is detecting "clang" when you are using apple-clang, only if CMP0025 is set to NEW will detect apple-clang
+            elseif((CONAN_COMPILER STREQUAL "gcc" AND NOT CMAKE_CXX_COMPILER_ID MATCHES "GNU") OR
+                (CONAN_COMPILER STREQUAL "apple-clang" AND NOT CROSS_BUILDING AND (NOT APPLE OR NOT CMAKE_CXX_COMPILER_ID MATCHES "Clang")) OR
+                (CONAN_COMPILER STREQUAL "clang" AND NOT CMAKE_CXX_COMPILER_ID MATCHES "Clang") OR
+                (CONAN_COMPILER STREQUAL "sun-cc" AND NOT CMAKE_CXX_COMPILER_ID MATCHES "SunPro") )
+                message(FATAL_ERROR "Incorrect '${CONAN_COMPILER}', is not the one detected by CMake: '${CMAKE_CXX_COMPILER_ID}'")
+            endif()
+        
+        
+            if(NOT DEFINED CONAN_COMPILER_VERSION)
+                conan_message(STATUS "WARN: CONAN_COMPILER_VERSION variable not set, please make sure yourself "
+                                     "that your compiler version matches your declared settings")
+                return()
+            endif()
+            check_compiler_version()
+        endfunction()
+    """)
+
+    conan_set_flags = textwrap.dedent("""
+        macro(conan_set_flags build_type)
+            set(CMAKE_CXX_FLAGS${build_type} "${CMAKE_CXX_FLAGS${build_type}} ${CONAN_CXX_FLAGS${build_type}}")
+            set(CMAKE_C_FLAGS${build_type} "${CMAKE_C_FLAGS${build_type}} ${CONAN_C_FLAGS${build_type}}")
+            set(CMAKE_SHARED_LINKER_FLAGS${build_type} "${CMAKE_SHARED_LINKER_FLAGS${build_type}} ${CONAN_SHARED_LINKER_FLAGS${build_type}}")
+            set(CMAKE_EXE_LINKER_FLAGS${build_type} "${CMAKE_EXE_LINKER_FLAGS${build_type}} ${CONAN_EXE_LINKER_FLAGS${build_type}}")
+        endmacro()
+    """)
+
+    conan_global_flags = textwrap.dedent("""
+        macro(conan_global_flags)
+            if(CONAN_SYSTEM_INCLUDES)
+                include_directories(SYSTEM ${CONAN_INCLUDE_DIRS}
+                                           "$<$<CONFIG:Release>:${CONAN_INCLUDE_DIRS_RELEASE}>"
+                                           "$<$<CONFIG:RelWithDebInfo>:${CONAN_INCLUDE_DIRS_RELWITHDEBINFO}>"
+                                           "$<$<CONFIG:MinSizeRel>:${CONAN_INCLUDE_DIRS_MINSIZEREL}>"
+                                           "$<$<CONFIG:Debug>:${CONAN_INCLUDE_DIRS_DEBUG}>")
+            else()
+                include_directories(${CONAN_INCLUDE_DIRS}
+                                    "$<$<CONFIG:Release>:${CONAN_INCLUDE_DIRS_RELEASE}>"
+                                    "$<$<CONFIG:RelWithDebInfo>:${CONAN_INCLUDE_DIRS_RELWITHDEBINFO}>"
+                                    "$<$<CONFIG:MinSizeRel>:${CONAN_INCLUDE_DIRS_MINSIZEREL}>"
+                                    "$<$<CONFIG:Debug>:${CONAN_INCLUDE_DIRS_DEBUG}>")
+            endif()
+        
+            link_directories(${CONAN_LIB_DIRS})
+        
+            conan_find_libraries_abs_path("${CONAN_LIBS_DEBUG}" "${CONAN_LIB_DIRS_DEBUG}"
+                                          CONAN_LIBS_DEBUG)
+            conan_find_libraries_abs_path("${CONAN_LIBS_RELEASE}" "${CONAN_LIB_DIRS_RELEASE}"
+                                          CONAN_LIBS_RELEASE)
+            conan_find_libraries_abs_path("${CONAN_LIBS_RELWITHDEBINFO}" "${CONAN_LIB_DIRS_RELWITHDEBINFO}"
+                                          CONAN_LIBS_RELWITHDEBINFO)
+            conan_find_libraries_abs_path("${CONAN_LIBS_MINSIZEREL}" "${CONAN_LIB_DIRS_MINSIZEREL}"
+                                          CONAN_LIBS_MINSIZEREL)
+        
+            add_compile_options(${CONAN_DEFINES}
+                                "$<$<CONFIG:Debug>:${CONAN_DEFINES_DEBUG}>"
+                                "$<$<CONFIG:Release>:${CONAN_DEFINES_RELEASE}>"
+                                "$<$<CONFIG:RelWithDebInfo>:${CONAN_DEFINES_RELWITHDEBINFO}>"
+                                "$<$<CONFIG:MinSizeRel>:${CONAN_DEFINES_MINSIZEREL}>")
+        
+            conan_set_flags("")
+            conan_set_flags("_RELEASE")
+            conan_set_flags("_DEBUG")
+        
+        endmacro()
+    """)
+
+    conan_target_link_libraries = textwrap.dedent("""
+        macro(conan_target_link_libraries target)
+            if(CONAN_TARGETS)
+                target_link_libraries(${target} ${CONAN_TARGETS})
+            else()
+                target_link_libraries(${target} ${CONAN_LIBS})
+                foreach(_LIB ${CONAN_LIBS_RELEASE})
+                    target_link_libraries(${target} optimized ${_LIB})
+                endforeach()
+                foreach(_LIB ${CONAN_LIBS_DEBUG})
+                    target_link_libraries(${target} debug ${_LIB})
+                endforeach()
+            endif()
+        endmacro()
+    """)
+
+    conan_include_build_modules = textwrap.dedent("""
+        macro(conan_include_build_modules)
+            if(CMAKE_BUILD_TYPE)
+                if(${CMAKE_BUILD_TYPE} MATCHES "Debug")
+                    set(CONAN_BUILD_MODULES_PATHS ${CONAN_BUILD_MODULES_PATHS_DEBUG} ${CONAN_BUILD_MODULES_PATHS})
+                elseif(${CMAKE_BUILD_TYPE} MATCHES "Release")
+                    set(CONAN_BUILD_MODULES_PATHS ${CONAN_BUILD_MODULES_PATHS_RELEASE} ${CONAN_BUILD_MODULES_PATHS})
+                elseif(${CMAKE_BUILD_TYPE} MATCHES "RelWithDebInfo")
+                    set(CONAN_BUILD_MODULES_PATHS ${CONAN_BUILD_MODULES_PATHS_RELWITHDEBINFO} ${CONAN_BUILD_MODULES_PATHS})
+                elseif(${CMAKE_BUILD_TYPE} MATCHES "MinSizeRel")
+                    set(CONAN_BUILD_MODULES_PATHS ${CONAN_BUILD_MODULES_PATHS_MINSIZEREL} ${CONAN_BUILD_MODULES_PATHS})
+                endif()
+            endif()
+        
+            foreach(_BUILD_MODULE_PATH ${CONAN_BUILD_MODULES_PATHS})
+                include(${_BUILD_MODULE_PATH})
+            endforeach()
+        endmacro()
+    """)
 
 
-    if(NOT DEFINED CONAN_COMPILER_VERSION)
-        conan_message(STATUS "WARN: CONAN_COMPILER_VERSION variable not set, please make sure yourself "
-                             "that your compiler version matches your declared settings")
-        return()
-    endif()
-    check_compiler_version()
-endfunction()
+_cmake_common_macros = "\n".join([
+    CMakeCommonMacros.conan_message,
+    CMakeCommonMacros.conan_find_libraries_abs_path,
+    CMakeCommonMacros.conan_package_library_targets,
+    CMakeCommonMacros.conan_set_libcxx,
+    CMakeCommonMacros.conan_set_std,
+    CMakeCommonMacros.conan_set_rpath,
+    CMakeCommonMacros.conan_set_fpic,
+    CMakeCommonMacros.conan_output_dirs_setup,
+    CMakeCommonMacros.conan_split_version,
+    CMakeCommonMacros.conan_error_compiler_version,
+    "set(_CONAN_CURRENT_DIR ${CMAKE_CURRENT_LIST_DIR})",
+    CMakeCommonMacros.conan_get_compiler,
+    CMakeCommonMacros.check_compiler_version,
+    CMakeCommonMacros.conan_check_compiler,
+    CMakeCommonMacros.conan_set_flags,
+    CMakeCommonMacros.conan_global_flags,
+    CMakeCommonMacros.conan_target_link_libraries,
+    CMakeCommonMacros.conan_include_build_modules,
+])
 
-macro(conan_set_flags build_type)
-    set(CMAKE_CXX_FLAGS${build_type} "${CMAKE_CXX_FLAGS${build_type}} ${CONAN_CXX_FLAGS${build_type}}")
-    set(CMAKE_C_FLAGS${build_type} "${CMAKE_C_FLAGS${build_type}} ${CONAN_C_FLAGS${build_type}}")
-    set(CMAKE_SHARED_LINKER_FLAGS${build_type} "${CMAKE_SHARED_LINKER_FLAGS${build_type}} ${CONAN_SHARED_LINKER_FLAGS${build_type}}")
-    set(CMAKE_EXE_LINKER_FLAGS${build_type} "${CMAKE_EXE_LINKER_FLAGS${build_type}} ${CONAN_EXE_LINKER_FLAGS${build_type}}")
-endmacro()
-
-macro(conan_global_flags)
-    if(CONAN_SYSTEM_INCLUDES)
-        include_directories(SYSTEM ${CONAN_INCLUDE_DIRS}
-                                   "$<$<CONFIG:Release>:${CONAN_INCLUDE_DIRS_RELEASE}>"
-                                   "$<$<CONFIG:RelWithDebInfo>:${CONAN_INCLUDE_DIRS_RELWITHDEBINFO}>"
-                                   "$<$<CONFIG:MinSizeRel>:${CONAN_INCLUDE_DIRS_MINSIZEREL}>"
-                                   "$<$<CONFIG:Debug>:${CONAN_INCLUDE_DIRS_DEBUG}>")
-    else()
-        include_directories(${CONAN_INCLUDE_DIRS}
-                            "$<$<CONFIG:Release>:${CONAN_INCLUDE_DIRS_RELEASE}>"
-                            "$<$<CONFIG:RelWithDebInfo>:${CONAN_INCLUDE_DIRS_RELWITHDEBINFO}>"
-                            "$<$<CONFIG:MinSizeRel>:${CONAN_INCLUDE_DIRS_MINSIZEREL}>"
-                            "$<$<CONFIG:Debug>:${CONAN_INCLUDE_DIRS_DEBUG}>")
-    endif()
-
-    link_directories(${CONAN_LIB_DIRS})
-
-    conan_find_libraries_abs_path("${CONAN_LIBS_DEBUG}" "${CONAN_LIB_DIRS_DEBUG}"
-                                  CONAN_LIBS_DEBUG)
-    conan_find_libraries_abs_path("${CONAN_LIBS_RELEASE}" "${CONAN_LIB_DIRS_RELEASE}"
-                                  CONAN_LIBS_RELEASE)
-    conan_find_libraries_abs_path("${CONAN_LIBS_RELWITHDEBINFO}" "${CONAN_LIB_DIRS_RELWITHDEBINFO}"
-                                  CONAN_LIBS_RELWITHDEBINFO)
-    conan_find_libraries_abs_path("${CONAN_LIBS_MINSIZEREL}" "${CONAN_LIB_DIRS_MINSIZEREL}"
-                                  CONAN_LIBS_MINSIZEREL)
-
-    add_compile_options(${CONAN_DEFINES}
-                        "$<$<CONFIG:Debug>:${CONAN_DEFINES_DEBUG}>"
-                        "$<$<CONFIG:Release>:${CONAN_DEFINES_RELEASE}>"
-                        "$<$<CONFIG:RelWithDebInfo>:${CONAN_DEFINES_RELWITHDEBINFO}>"
-                        "$<$<CONFIG:MinSizeRel>:${CONAN_DEFINES_MINSIZEREL}>")
-
-    conan_set_flags("")
-    conan_set_flags("_RELEASE")
-    conan_set_flags("_DEBUG")
-
-endmacro()
-
-macro(conan_target_link_libraries target)
-    if(CONAN_TARGETS)
-        target_link_libraries(${target} ${CONAN_TARGETS})
-    else()
-        target_link_libraries(${target} ${CONAN_LIBS})
-        foreach(_LIB ${CONAN_LIBS_RELEASE})
-            target_link_libraries(${target} optimized ${_LIB})
-        endforeach()
-        foreach(_LIB ${CONAN_LIBS_DEBUG})
-            target_link_libraries(${target} debug ${_LIB})
-        endforeach()
-    endif()
-endmacro()
-
-macro(conan_include_build_modules)
-    if(CMAKE_BUILD_TYPE)
-        if(${CMAKE_BUILD_TYPE} MATCHES "Debug")
-            set(CONAN_BUILD_MODULES_PATHS ${CONAN_BUILD_MODULES_PATHS_DEBUG} ${CONAN_BUILD_MODULES_PATHS})
-        elseif(${CMAKE_BUILD_TYPE} MATCHES "Release")
-            set(CONAN_BUILD_MODULES_PATHS ${CONAN_BUILD_MODULES_PATHS_RELEASE} ${CONAN_BUILD_MODULES_PATHS})
-        elseif(${CMAKE_BUILD_TYPE} MATCHES "RelWithDebInfo")
-            set(CONAN_BUILD_MODULES_PATHS ${CONAN_BUILD_MODULES_PATHS_RELWITHDEBINFO} ${CONAN_BUILD_MODULES_PATHS})
-        elseif(${CMAKE_BUILD_TYPE} MATCHES "MinSizeRel")
-            set(CONAN_BUILD_MODULES_PATHS ${CONAN_BUILD_MODULES_PATHS_MINSIZEREL} ${CONAN_BUILD_MODULES_PATHS})
-        endif()
-    endif()
-
-    foreach(_BUILD_MODULE_PATH ${CONAN_BUILD_MODULES_PATHS})
-        include(${_BUILD_MODULE_PATH})
-    endforeach()
-endmacro()
-"""
 
 apple_frameworks_macro = """
 macro(conan_find_apple_frameworks FRAMEWORKS_FOUND FRAMEWORKS)

--- a/conans/client/generators/cmake_common.py
+++ b/conans/client/generators/cmake_common.py
@@ -630,6 +630,25 @@ class CMakeCommonMacros:
         endmacro()
     """)
 
+    conan_set_vs_runtime = textwrap.dedent("""
+        macro(conan_set_vs_runtime)
+            if(CONAN_LINK_RUNTIME)
+                foreach(flag CMAKE_C_FLAGS_RELEASE CMAKE_CXX_FLAGS_RELEASE
+                             CMAKE_C_FLAGS_RELWITHDEBINFO CMAKE_CXX_FLAGS_RELWITHDEBINFO
+                             CMAKE_C_FLAGS_MINSIZEREL CMAKE_CXX_FLAGS_MINSIZEREL)
+                    if(DEFINED ${flag})
+                        string(REPLACE "/MD" ${CONAN_LINK_RUNTIME} ${flag} "${${flag}}")
+                    endif()
+                endforeach()
+                foreach(flag CMAKE_C_FLAGS_DEBUG CMAKE_CXX_FLAGS_DEBUG)
+                    if(DEFINED ${flag})
+                        string(REPLACE "/MDd" ${CONAN_LINK_RUNTIME} ${flag} "${${flag}}")
+                    endif()
+                endforeach()
+            endif()
+        endmacro()
+    """)
+
 
 _cmake_common_macros = "\n".join([
     CMakeCommonMacros.conan_message,
@@ -784,22 +803,7 @@ macro(conan_set_find_library_paths)
     set(CMAKE_LIBRARY_PATH ${CONAN_LIB_DIRS} ${CMAKE_LIBRARY_PATH})
 endmacro()
 
-macro(conan_set_vs_runtime)
-    if(CONAN_LINK_RUNTIME)
-        foreach(flag CMAKE_C_FLAGS_RELEASE CMAKE_CXX_FLAGS_RELEASE
-                     CMAKE_C_FLAGS_RELWITHDEBINFO CMAKE_CXX_FLAGS_RELWITHDEBINFO
-                     CMAKE_C_FLAGS_MINSIZEREL CMAKE_CXX_FLAGS_MINSIZEREL)
-            if(DEFINED ${flag})
-                string(REPLACE "/MD" ${CONAN_LINK_RUNTIME} ${flag} "${${flag}}")
-            endif()
-        endforeach()
-        foreach(flag CMAKE_C_FLAGS_DEBUG CMAKE_CXX_FLAGS_DEBUG)
-            if(DEFINED ${flag})
-                string(REPLACE "/MDd" ${CONAN_LINK_RUNTIME} ${flag} "${${flag}}")
-            endif()
-        endforeach()
-    endif()
-endmacro()
+""" + CMakeCommonMacros.conan_set_vs_runtime + """
 
 macro(conan_flags_setup)
     # Macro maintained for backwards compatibility
@@ -832,26 +836,7 @@ if(EXISTS ${CMAKE_CURRENT_LIST_DIR}/conanbuildinfo_relwithdebinfo.cmake)
     include(${CMAKE_CURRENT_LIST_DIR}/conanbuildinfo_relwithdebinfo.cmake)
 endif()
 
-macro(conan_set_vs_runtime)
-    # This conan_set_vs_runtime is MORE opinionated than the regular one. It will
-    # Leave the defaults MD (MDd) or replace them with MT (MTd) but taking into account the
-    # debug, forcing MXd for debug builds. It will generate MSVCRT warnings if the dependencies
-    # are installed with "conan install" and the wrong build time.
-    if(CONAN_LINK_RUNTIME MATCHES "MT")
-        foreach(flag CMAKE_C_FLAGS_RELEASE CMAKE_CXX_FLAGS_RELEASE
-                     CMAKE_C_FLAGS_RELWITHDEBINFO CMAKE_CXX_FLAGS_RELWITHDEBINFO
-                     CMAKE_C_FLAGS_MINSIZEREL CMAKE_CXX_FLAGS_MINSIZEREL)
-            if(DEFINED ${flag})
-                string(REPLACE "/MD" "/MT" ${flag} "${${flag}}")
-            endif()
-        endforeach()
-        foreach(flag CMAKE_C_FLAGS_DEBUG CMAKE_CXX_FLAGS_DEBUG)
-            if(DEFINED ${flag})
-                string(REPLACE "/MDd" "/MTd" ${flag} "${${flag}}")
-            endif()
-        endforeach()
-    endif()
-endmacro()
+""" + CMakeCommonMacros.conan_set_vs_runtime + """
 
 macro(conan_set_find_paths)
     if(CMAKE_BUILD_TYPE)

--- a/conans/client/generators/cmake_common.py
+++ b/conans/client/generators/cmake_common.py
@@ -649,6 +649,40 @@ class CMakeCommonMacros:
         endmacro()
     """)
 
+    conan_set_find_paths = textwrap.dedent("""
+        macro(conan_set_find_paths)
+            # CMAKE_MODULE_PATH does not have Debug/Release config, but there are variables
+            # CONAN_CMAKE_MODULE_PATH_DEBUG to be used by the consumer
+            # CMake can find findXXX.cmake files in the root of packages
+            set(CMAKE_MODULE_PATH ${CONAN_CMAKE_MODULE_PATH} ${CMAKE_MODULE_PATH})
+        
+            # Make find_package() to work
+            set(CMAKE_PREFIX_PATH ${CONAN_CMAKE_MODULE_PATH} ${CMAKE_PREFIX_PATH})
+        
+            # Set the find root path (cross build)
+            set(CMAKE_FIND_ROOT_PATH ${CONAN_CMAKE_FIND_ROOT_PATH} ${CMAKE_FIND_ROOT_PATH})
+            if(CONAN_CMAKE_FIND_ROOT_PATH_MODE_PROGRAM)
+                set(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM ${CONAN_CMAKE_FIND_ROOT_PATH_MODE_PROGRAM})
+            endif()
+            if(CONAN_CMAKE_FIND_ROOT_PATH_MODE_LIBRARY)
+                set(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ${CONAN_CMAKE_FIND_ROOT_PATH_MODE_LIBRARY})
+            endif()
+            if(CONAN_CMAKE_FIND_ROOT_PATH_MODE_INCLUDE)
+                set(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ${CONAN_CMAKE_FIND_ROOT_PATH_MODE_INCLUDE})
+            endif()
+        endmacro()
+    """)
+
+    conan_set_find_library_paths = textwrap.dedent("""
+        macro(conan_set_find_library_paths)
+            # CMAKE_INCLUDE_PATH, CMAKE_LIBRARY_PATH does not have Debug/Release config, but there are variables
+            # CONAN_INCLUDE_DIRS_DEBUG/RELEASE CONAN_LIB_DIRS_DEBUG/RELEASE to be used by the consumer
+            # For find_library
+            set(CMAKE_INCLUDE_PATH ${CONAN_INCLUDE_DIRS} ${CMAKE_INCLUDE_PATH})
+            set(CMAKE_LIBRARY_PATH ${CONAN_LIB_DIRS} ${CMAKE_LIBRARY_PATH})
+        endmacro()
+    """)
+
 
 _cmake_common_macros = "\n".join([
     CMakeCommonMacros.conan_message,
@@ -772,39 +806,12 @@ endmacro()
     return result
 
 
-cmake_macros = _conan_basic_setup_common(["conan_set_find_library_paths()"]) + """
-macro(conan_set_find_paths)
-    # CMAKE_MODULE_PATH does not have Debug/Release config, but there are variables
-    # CONAN_CMAKE_MODULE_PATH_DEBUG to be used by the consumer
-    # CMake can find findXXX.cmake files in the root of packages
-    set(CMAKE_MODULE_PATH ${CONAN_CMAKE_MODULE_PATH} ${CMAKE_MODULE_PATH})
-
-    # Make find_package() to work
-    set(CMAKE_PREFIX_PATH ${CONAN_CMAKE_MODULE_PATH} ${CMAKE_PREFIX_PATH})
-
-    # Set the find root path (cross build)
-    set(CMAKE_FIND_ROOT_PATH ${CONAN_CMAKE_FIND_ROOT_PATH} ${CMAKE_FIND_ROOT_PATH})
-    if(CONAN_CMAKE_FIND_ROOT_PATH_MODE_PROGRAM)
-        set(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM ${CONAN_CMAKE_FIND_ROOT_PATH_MODE_PROGRAM})
-    endif()
-    if(CONAN_CMAKE_FIND_ROOT_PATH_MODE_LIBRARY)
-        set(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ${CONAN_CMAKE_FIND_ROOT_PATH_MODE_LIBRARY})
-    endif()
-    if(CONAN_CMAKE_FIND_ROOT_PATH_MODE_INCLUDE)
-        set(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ${CONAN_CMAKE_FIND_ROOT_PATH_MODE_INCLUDE})
-    endif()
-endmacro()
-
-macro(conan_set_find_library_paths)
-    # CMAKE_INCLUDE_PATH, CMAKE_LIBRARY_PATH does not have Debug/Release config, but there are variables
-    # CONAN_INCLUDE_DIRS_DEBUG/RELEASE CONAN_LIB_DIRS_DEBUG/RELEASE to be used by the consumer
-    # For find_library
-    set(CMAKE_INCLUDE_PATH ${CONAN_INCLUDE_DIRS} ${CMAKE_INCLUDE_PATH})
-    set(CMAKE_LIBRARY_PATH ${CONAN_LIB_DIRS} ${CMAKE_LIBRARY_PATH})
-endmacro()
-
-""" + CMakeCommonMacros.conan_set_vs_runtime + """
-
+cmake_macros = "\n".join([
+    _conan_basic_setup_common(["conan_set_find_library_paths()"]),
+    CMakeCommonMacros.conan_set_find_paths,
+    CMakeCommonMacros.conan_set_find_library_paths,
+    CMakeCommonMacros.conan_set_vs_runtime
+    ]) + """
 macro(conan_flags_setup)
     # Macro maintained for backwards compatibility
     conan_set_find_library_paths()

--- a/conans/client/generators/cmake_multi.py
+++ b/conans/client/generators/cmake_multi.py
@@ -2,7 +2,7 @@ from conans.client.generators.cmake import DepsCppCmake
 from conans.client.generators.cmake_common import (cmake_dependencies, cmake_dependency_vars,
                                                    cmake_global_vars, cmake_macros_multi,
                                                    cmake_package_info, cmake_user_info_vars,
-                                                   generate_targets_section, apple_frameworks_macro)
+                                                   generate_targets_section, CMakeCommonMacros)
 from conans.model import Generator
 from conans.model.build_info import CppInfo
 
@@ -73,7 +73,7 @@ class CMakeMultiGenerator(Generator):
     @property
     def _content_multi(self):
         sections = ["include(CMakeParseArguments)"]
-        sections.append(apple_frameworks_macro)
+        sections.append(CMakeCommonMacros.apple_frameworks_macro)
 
         # USER DECLARED VARS
         sections.append("\n### Definition of user declared vars (user_info) ###\n")


### PR DESCRIPTION
Changelog: omit
Docs: omit

Store each macro/function definition in a different variable so I can use the ones I need in the PR of the toolchains (https://github.com/conan-io/conan/pull/5919#discussion_r348399679)

#TAGS: slow
