### PR TITLE
Multi-generators cannot be used without 'build_type' setting

### DIFF
--- a/conans/client/generators/cmake_find_package_multi.py
+++ b/conans/client/generators/cmake_find_package_multi.py
@@ -95,7 +95,7 @@ endif()
     @property
     def content(self):
         ret = {}
-        build_type = self.conanfile.settings.get_safe("build_type")
+        build_type = self.conanfile.settings.build_type
         build_type_suffix = "_{}".format(build_type.upper()) if build_type else ""
         for _, cpp_info in self.deps_build_info.dependencies:
             depname = cpp_info.get_name("cmake_find_package_multi")
@@ -109,9 +109,6 @@ endif()
             ret["{}ConfigVersion.cmake".format(depname)] = self.version_template.\
                 format(version=cpp_info.version)
         return ret
-
-    def _build_type_suffix(self, build_type):
-        return
 
     def _find_for_dep(self, name, cpp_info):
         lines = []

--- a/conans/client/generators/cmake_find_package_multi.py
+++ b/conans/client/generators/cmake_find_package_multi.py
@@ -95,7 +95,7 @@ endif()
     @property
     def content(self):
         ret = {}
-        build_type = self.conanfile.settings.build_type
+        build_type = str(self.conanfile.settings.build_type)
         build_type_suffix = "_{}".format(build_type.upper()) if build_type else ""
         for _, cpp_info in self.deps_build_info.dependencies:
             depname = cpp_info.get_name("cmake_find_package_multi")

--- a/conans/client/generators/visualstudio_multi.py
+++ b/conans/client/generators/visualstudio_multi.py
@@ -15,7 +15,7 @@ class _VSSettings(object):
             raise ConanException("Undefined Visual Studio version %s" %
                                  settings.get_safe("compiler.version"))
 
-        self._props = [("Configuration", settings.get_safe("build_type")),
+        self._props = [("Configuration", settings.build_type),
                        ("Platform", {'x86': 'Win32',
                                      'x86_64': 'x64'}.get(settings.get_safe("arch"))),
                        ("PlatformToolset", toolset)]

--- a/conans/test/functional/generators/cmake_find_package_multi_test.py
+++ b/conans/test/functional/generators/cmake_find_package_multi_test.py
@@ -348,32 +348,3 @@ class Conan(ConanFile):
             self.assertIn("hello found: 1", client.out)
         else:
             self.assertIn("hello found: 0", client.out)
-
-    def test_no_build_type_test(self):
-        client = TestClient()
-        client.run("new req/version")
-        client.run("create .")
-
-        cmakelists = textwrap.dedent("""
-            cmake_minimum_required(VERSION 3.1)
-            project(consumer)
-            find_package(req)
-            message(STATUS "hello found: ${{hello_FOUND}}")
-        """)
-
-        conanfile = textwrap.dedent("""
-            from conans import ConanFile, CMake
-
-            class Conan(ConanFile):
-                settings = "os", "arch", "compiler"
-                requires = "req/version"
-                generators = "cmake_find_package_multi"
-
-                def build(self):
-                    cmake = CMake(self)
-                    cmake.configure()
-        """)
-
-        client.save({"conanfile.py": conanfile, "CMakeLists.txt": cmakelists})
-        client.run("install .", assert_error=True)
-        self.assertIn("ERROR: 'settings.build_type' doesn't exist", client.out)

--- a/conans/test/functional/generators/multi_generators_test.py
+++ b/conans/test/functional/generators/multi_generators_test.py
@@ -1,39 +1,24 @@
-
-import os
-import platform
-import unittest
 import textwrap
-from nose.plugins.attrib import attr
+import unittest
+
 from parameterized import parameterized
 
-from conans import MSBuild, tools
-from conans.client.runner import ConanRunner
-from conans.test.utils.conanfile import MockConanfile, MockSettings
-from conans.test.utils.tools import TestClient, TestBufferConanOutput
-from conans.test.utils.visual_project_files import get_vs_project_files
+from conans.test.utils.tools import TestClient
 
 
 class MultiGeneratorsTestCase(unittest.TestCase):
 
-    @parameterized.expand([("cmake_find_package_multi",), ("visual_studio_multi", ), ("cmake_multi", )])
+    @parameterized.expand([("cmake_find_package_multi",),
+                           ("visual_studio_multi", ),
+                           ("cmake_multi", )])
     def test_no_build_type_test(self, generator):
         client = TestClient()
-        client.run("new req/version")
-        client.run("create .")
-
-        cmakelists = textwrap.dedent("""
-            cmake_minimum_required(VERSION 3.1)
-            project(consumer)
-            find_package(req)
-            message(STATUS "hello found: ${{hello_FOUND}}")
-        """)
 
         conanfile = textwrap.dedent("""
             from conans import ConanFile, CMake
 
             class Conan(ConanFile):
                 settings = "os", "arch", "compiler"
-                requires = "req/version"
                 generators = "{generator}"
 
                 def build(self):
@@ -41,6 +26,7 @@ class MultiGeneratorsTestCase(unittest.TestCase):
                     cmake.configure()
         """.format(generator=generator))
 
-        client.save({"conanfile.py": conanfile, "CMakeLists.txt": cmakelists})
-        client.run("install .", assert_error=True)
+        client.save({"conanfile.py": conanfile})
+        client.run('install . -s compiler="Visual Studio"'
+                   ' -s compiler.version=15 -s compiler.toolset=v100', assert_error=True)
         self.assertIn("ERROR: 'settings.build_type' doesn't exist", client.out)

--- a/conans/test/functional/generators/multi_generators_test.py
+++ b/conans/test/functional/generators/multi_generators_test.py
@@ -1,0 +1,46 @@
+
+import os
+import platform
+import unittest
+import textwrap
+from nose.plugins.attrib import attr
+from parameterized import parameterized
+
+from conans import MSBuild, tools
+from conans.client.runner import ConanRunner
+from conans.test.utils.conanfile import MockConanfile, MockSettings
+from conans.test.utils.tools import TestClient, TestBufferConanOutput
+from conans.test.utils.visual_project_files import get_vs_project_files
+
+
+class MultiGeneratorsTestCase(unittest.TestCase):
+
+    @parameterized.expand([("cmake_find_package_multi",), ("visual_studio_multi", ), ("cmake_multi", )])
+    def test_no_build_type_test(self, generator):
+        client = TestClient()
+        client.run("new req/version")
+        client.run("create .")
+
+        cmakelists = textwrap.dedent("""
+            cmake_minimum_required(VERSION 3.1)
+            project(consumer)
+            find_package(req)
+            message(STATUS "hello found: ${{hello_FOUND}}")
+        """)
+
+        conanfile = textwrap.dedent("""
+            from conans import ConanFile, CMake
+
+            class Conan(ConanFile):
+                settings = "os", "arch", "compiler"
+                requires = "req/version"
+                generators = "{generator}"
+
+                def build(self):
+                    cmake = CMake(self)
+                    cmake.configure()
+        """.format(generator=generator))
+
+        client.save({"conanfile.py": conanfile, "CMakeLists.txt": cmakelists})
+        client.run("install .", assert_error=True)
+        self.assertIn("ERROR: 'settings.build_type' doesn't exist", client.out)


### PR DESCRIPTION
Changelog: Fix: Multi-generators cannot be used without `build_type` setting. A failure is forced to `cmake_find_package_multi` and `visual_studio_multi` as it was in `cmake_multi`.
Docs: omit

closes https://github.com/conan-io/conan/issues/6135

This PR forces in all the _multi-generators_ the same failure that we were triggering for the `cmake_multi` one.

Currently, the full error shown to the user that runs the `conan install` is:

```bash
[...]

conanfile.py: ERROR: Generator cmake_multi(file:None) failed
'settings.build_type' doesn't exist
'settings' possible configurations are ['arch', 'compiler', 'os']
ERROR: 'settings.build_type' doesn't exist
'settings' possible configurations are ['arch', 'compiler', 'os']
```

Let me know if we want to improve it to add a more meaningful message.


#tags: slow