### PR TITLE
Add 'cpp_info.<config>' information to 'cmake_find_package[_multi]' generators

### DIFF
--- a/conans/client/generators/cmake_find_package_multi.py
+++ b/conans/client/generators/cmake_find_package_multi.py
@@ -103,7 +103,13 @@ endif()
             ret["{}Config.cmake".format(depname)] = self._find_for_dep(depname, cpp_info)
             ret["{}Targets.cmake".format(depname)] = self.targets_file.format(name=depname)
 
-            find_lib = target_template.format(name=depname, deps=deps,
+            # If any config matches the build_type one
+            deps_extra = None
+            for config, config_cpp_info in cpp_info.configs.items():
+                if config.lower() == build_type.lower():
+                    deps_extra = DepsCppCmake(config_cpp_info)
+
+            find_lib = target_template.format(name=depname, deps=deps, deps_extra=deps_extra,
                                               build_type_suffix=build_type_suffix)
             ret["{}Target-{}.cmake".format(depname, build_type.lower())] = find_lib
             ret["{}ConfigVersion.cmake".format(depname)] = self.version_template.\

--- a/conans/client/generators/cmake_find_package_multi.py
+++ b/conans/client/generators/cmake_find_package_multi.py
@@ -102,7 +102,7 @@ endif()
             # If any config matches the build_type one, add it to the cpp_info
             dep_cpp_info = extend(cpp_info, build_type.lower())
 
-            depname = dep_cpp_info.get_name("cmake_find_package_multi")
+            depname = cpp_info.get_name("cmake_find_package_multi")
             ret["{}Config.cmake".format(depname)] = self._find_for_dep(depname, dep_cpp_info)
             ret["{}Targets.cmake".format(depname)] = self.targets_file.format(name=depname)
 

--- a/conans/client/generators/cmake_find_package_multi.py
+++ b/conans/client/generators/cmake_find_package_multi.py
@@ -99,19 +99,19 @@ endif()
         build_type = self.conanfile.settings.get_safe("build_type")
         build_type_suffix = "_{}".format(build_type.upper()) if build_type else ""
         for _, cpp_info in self.deps_build_info.dependencies:
-            depname = cpp_info.get_name("cmake_find_package_multi")
-            ret["{}Config.cmake".format(depname)] = self._find_for_dep(depname, cpp_info)
-            ret["{}Targets.cmake".format(depname)] = self.targets_file.format(name=depname)
-
             # If any config matches the build_type one, add it to the cpp_info
             dep_cpp_info = extend(cpp_info, build_type.lower())
-            deps = DepsCppCmake(dep_cpp_info)
 
+            depname = dep_cpp_info.get_name("cmake_find_package_multi")
+            ret["{}Config.cmake".format(depname)] = self._find_for_dep(depname, dep_cpp_info)
+            ret["{}Targets.cmake".format(depname)] = self.targets_file.format(name=depname)
+
+            deps = DepsCppCmake(dep_cpp_info)
             find_lib = target_template.format(name=depname, deps=deps,
                                               build_type_suffix=build_type_suffix)
             ret["{}Target-{}.cmake".format(depname, build_type.lower())] = find_lib
             ret["{}ConfigVersion.cmake".format(depname)] = self.version_template.\
-                format(version=cpp_info.version)
+                format(version=dep_cpp_info.version)
         return ret
 
     def _build_type_suffix(self, build_type):

--- a/conans/client/generators/cmake_find_package_multi.py
+++ b/conans/client/generators/cmake_find_package_multi.py
@@ -1,28 +1,8 @@
-from itertools import chain
-
 from conans.client.generators.cmake import DepsCppCmake
 from conans.client.generators.cmake_find_package import find_dependency_lines
 from conans.client.generators.cmake_find_package_common import target_template
+from conans.client.generators.cmake_multi import extend
 from conans.model import Generator
-
-
-class _CppInfoCombined(object):
-    """ Behaves like a DepsCppCmake object, but concatenates the values returned from
-        several objects
-    """
-    def __init__(self, cpp_info):
-        self._cpp_info_list = [cpp_info]
-
-    def append(self, cpp_info):
-        self._cpp_info_list.append(cpp_info)
-
-    def __getattr__(self, item):
-        value = getattr(self._cpp_info_list[0], item)
-        if isinstance(value, (list, tuple, set)):
-            return list(chain(*[getattr(it, item) for it in self._cpp_info_list]))
-        else:
-            # TODO: Which one shall I return? The last one will be more specific (if it is the config one)
-            return getattr(self._cpp_info_list[-1], item)
 
 
 class CMakeFindPackageMultiGenerator(Generator):
@@ -120,16 +100,14 @@ endif()
         build_type_suffix = "_{}".format(build_type.upper()) if build_type else ""
         for _, cpp_info in self.deps_build_info.dependencies:
             depname = cpp_info.get_name("cmake_find_package_multi")
-            deps = _CppInfoCombined(cpp_info)
             ret["{}Config.cmake".format(depname)] = self._find_for_dep(depname, cpp_info)
             ret["{}Targets.cmake".format(depname)] = self.targets_file.format(name=depname)
 
-            # If any config matches the build_type one
-            for config, config_cpp_info in cpp_info.configs.items():
-                if config.lower() == build_type.lower():
-                    deps.append(config_cpp_info)
+            # If any config matches the build_type one, add it to the cpp_info
+            dep_cpp_info = extend(cpp_info, build_type.lower())
+            deps = DepsCppCmake(dep_cpp_info)
 
-            find_lib = target_template.format(name=depname, deps=DepsCppCmake(deps),
+            find_lib = target_template.format(name=depname, deps=deps,
                                               build_type_suffix=build_type_suffix)
             ret["{}Target-{}.cmake".format(depname, build_type.lower())] = find_lib
             ret["{}ConfigVersion.cmake".format(depname)] = self.version_template.\

--- a/conans/client/generators/cmake_multi.py
+++ b/conans/client/generators/cmake_multi.py
@@ -15,6 +15,7 @@ def extend(cpp_info, config):
         def add_lists(seq1, seq2):
             return seq1 + [s for s in seq2 if s not in seq1]
         result = CppInfo(config_info.rootpath)
+        result.filter_empty = cpp_info.filter_empty
         result.includedirs = add_lists(cpp_info.includedirs, config_info.includedirs)
         result.libdirs = add_lists(cpp_info.libdirs, config_info.libdirs)
         result.bindirs = add_lists(cpp_info.bindirs, config_info.bindirs)

--- a/conans/test/functional/generators/cmake_find_package_multi_test.py
+++ b/conans/test/functional/generators/cmake_find_package_multi_test.py
@@ -348,3 +348,40 @@ class Conan(ConanFile):
             self.assertIn("hello found: 1", client.out)
         else:
             self.assertIn("hello found: 0", client.out)
+
+    def cpp_info_config_test(self):
+        conanfile = textwrap.dedent("""
+            from conans import ConanFile
+            
+            class Requirement(ConanFile):
+                name = "requirement"
+                version = "version"
+            
+                settings = "os", "arch", "compiler", "build_type"
+            
+                def package_info(self):
+                    self.cpp_info.libs = ["lib_both"]
+                    self.cpp_info.debug.libs = ["lib_debug"]
+                    self.cpp_info.release.libs = ["lib_release"]
+                    
+                    self.cpp_info.cxxflags = ["-req_both"]
+                    self.cpp_info.debug.cxxflags = ["-req_debug"]
+                    self.cpp_info.release.cxxflags = ["-req_release"]
+        """)
+        t = TestClient()
+        t.save({"conanfile.py": conanfile})
+        t.run("create . -s build_type=Release")
+        t.run("create . -s build_type=Debug")
+
+        t.run("install requirement/version@ -g cmake_find_package_multi -s build_type=Release")
+        t.run("install requirement/version@ -g cmake_find_package_multi -s build_type=Debug")
+        content_release = t.load("requirementTarget-release.cmake")
+        content_debug = t.load("requirementTarget-debug.cmake")
+
+        self.assertIn('set(requirement_COMPILE_OPTIONS_RELEASE_LIST "-req_both;-req_release" "")',
+                      content_release)
+        self.assertIn('set(requirement_COMPILE_OPTIONS_DEBUG_LIST "-req_both;-req_debug" "")',
+                      content_debug)
+
+        self.assertIn('set(requirement_LIBRARY_LIST_RELEASE lib_both lib_release)', content_release)
+        self.assertIn('set(requirement_LIBRARY_LIST_DEBUG lib_both lib_debug)', content_debug)

--- a/conans/test/unittests/client/generators/cmake_test.py
+++ b/conans/test/unittests/client/generators/cmake_test.py
@@ -596,5 +596,6 @@ class CMakeBuildModulesTest(unittest.TestCase):
         self.assertNotIn("not-a-cmake-module.pc", content["my_pkg2Target-release.cmake"])
         self.assertIn('set(my_pkg_BUILD_MODULES_PATHS_RELEASE "dummy_root_folder1/my-module.cmake")',
                       content["my_pkgTarget-release.cmake"])
-        self.assertIn('set(my_pkg2_BUILD_MODULES_PATHS_RELEASE "dummy_root_folder2/other-mod.cmake")',
+        self.assertIn('set(my_pkg2_BUILD_MODULES_PATHS_RELEASE "dummy_root_folder2/other-mod.cmake"'
+                      '\n\t\t\t"dummy_root_folder2/release-mod.cmake")',
                       content["my_pkg2Target-release.cmake"])

--- a/conans/test/unittests/client/generators/cmake_test.py
+++ b/conans/test/unittests/client/generators/cmake_test.py
@@ -534,7 +534,6 @@ class CMakeBuildModulesTest(unittest.TestCase):
         cpp_info.name = ref.name
         cpp_info.build_modules = ["other-mod.cmake", "not-a-cmake-module.pc"]
         cpp_info.release.build_modules = ["release-mod.cmake"]
-        cpp_info.release.filter_empty = False  # For testing purposes only
         self.conanfile.deps_cpp_info.update(cpp_info, ref.name)
 
     def cmake_test(self):
@@ -587,7 +586,8 @@ class CMakeBuildModulesTest(unittest.TestCase):
                       content["Findmy_pkg2.cmake"])
         self.assertIn('set(my_pkg_BUILD_MODULES_PATHS "dummy_root_folder1/my-module.cmake")',
                       content["Findmy_pkg.cmake"])
-        self.assertIn('set(my_pkg2_BUILD_MODULES_PATHS "dummy_root_folder2/other-mod.cmake")',
+        self.assertIn('set(my_pkg2_BUILD_MODULES_PATHS "dummy_root_folder2/other-mod.cmake"'
+                      '\n\t\t\t"dummy_root_folder2/release-mod.cmake")',
                       content["Findmy_pkg2.cmake"])
 
     def cmake_find_package_multi_test(self):


### PR DESCRIPTION
Changelog: Fix: Add `cpp_info.<config>` information to `cmake_find_package_multi` and `cmake_find_package` generators
Docs: https://github.com/conan-io/docs/pull/1508

- [x] At least update docs at "Note" [here](https://docs.conan.io/en/latest/creating_packages/package_approaches.html)

Closes https://github.com/conan-io/conan/issues/6136

---

When a recipe contains information specific per configuration:

```python
class Requirement(ConanFile):
    name = "requirement"
    version = "version"
            
    settings = "os", "arch", "compiler", "build_type"
            
    def package_info(self):
        self.cpp_info.libs = ["lib_both"]
        self.cpp_info.debug.libs = ["lib_debug"]
        self.cpp_info.release.libs = ["lib_release"]
                    
        self.cpp_info.cxxflags = ["-req_both"]
        self.cpp_info.debug.cxxflags = ["-req_debug"]
        self.cpp_info.release.cxxflags = ["-req_release"]
```

this information is now propagated to the corresponding build-type file (see tests)

