### PR TITLE
raw argument is ignored when searching for a specific reference

### DIFF
--- a/conans/client/command.py
+++ b/conans/client/command.py
@@ -1249,7 +1249,7 @@ class Command(object):
                 # Show revisions of a ref
                 if ref:
                     info = self._conan.get_recipe_revisions(repr(ref), remote_name=args.remote)
-                    self._outputer.print_revisions(ref, info, remote_name=args.remote)
+                    self._outputer.print_revisions(ref, info, args.raw, remote_name=args.remote)
                     return
 
                 # Show revisions of pref
@@ -1259,7 +1259,7 @@ class Command(object):
                     pass
                 else:
                     info = self._conan.get_package_revisions(repr(pref), remote_name=args.remote)
-                    self._outputer.print_revisions(ref, info, remote_name=args.remote)
+                    self._outputer.print_revisions(ref, info, args.raw, remote_name=args.remote)
                     return
 
                 # A pattern: Listing references by pattern but showing revisions
@@ -1286,7 +1286,7 @@ class Command(object):
                                                    outdated=args.outdated)
                 # search is done for one reference
                 self._outputer.print_search_packages(info["results"], ref, args.query,
-                                                     args.table, outdated=args.outdated)
+                                                     args.table, args.raw, outdated=args.outdated)
             else:
                 if args.table:
                     raise ConanException("'--table' argument can only be used with a reference")

--- a/conans/client/conan_command_output.py
+++ b/conans/client/conan_command_output.py
@@ -234,18 +234,19 @@ class CommandOutputer(object):
         printer = Printer(self._output)
         printer.print_search_recipes(search_info, pattern, raw, all_remotes_search)
 
-    def print_search_packages(self, search_info, reference, packages_query, table,
+    def print_search_packages(self, search_info, reference, packages_query, table, raw,
                               outdated=False):
         if table:
             html_binary_graph(search_info, reference, table)
         else:
             printer = Printer(self._output)
-            printer.print_search_packages(search_info, reference, packages_query,
+            printer.print_search_packages(search_info, reference, packages_query, raw,
                                           outdated=outdated)
 
-    def print_revisions(self, reference, revisions, remote_name=None):
+    def print_revisions(self, reference, revisions, raw, remote_name=None):
         remote_test = " at remote '%s'" % remote_name if remote_name else ""
-        self._output.info("Revisions for '%s'%s:" % (reference, remote_test))
+        if not raw:
+            self._output.info("Revisions for '%s'%s:" % (reference, remote_test))
         lines = ["%s (%s)" % (r["revision"],
                               iso8601_to_str(r["time"]) if r["time"] else "No time")
                  for r in revisions]

--- a/conans/client/printer.py
+++ b/conans/client/printer.py
@@ -155,12 +155,12 @@ class Printer(object):
                     ref = ConanFileReference.loads(reference)
                     self._out.writeln(ref.full_str())
 
-    def print_search_packages(self, search_info, ref, packages_query,
-                              outdated=False):
+    def print_search_packages(self, search_info, ref, packages_query, raw, outdated=False):
         assert(isinstance(ref, ConanFileReference))
-        self._out.info("Existing packages for recipe %s:\n" % str(ref))
+        if not raw:
+            self._out.info("Existing packages for recipe %s:\n" % str(ref))
         for remote_info in search_info:
-            if remote_info["remote"]:
+            if remote_info["remote"] and not raw:
                 self._out.info("Existing recipe in remote '%s':\n" % remote_info["remote"])
 
             if not remote_info["items"][0]["packages"]:
@@ -170,7 +170,8 @@ class Printer(object):
                 elif remote_info["items"][0]["recipe"]:
                     warn_msg = "There are no %spackages for reference '%s', but package recipe " \
                                "found." % ("outdated " if outdated else "", str(ref))
-                self._out.info(warn_msg)
+                if not raw:
+                    self._out.info(warn_msg)
                 continue
 
             ref = remote_info["items"][0]["recipe"]["id"]

--- a/conans/test/functional/command/search_test.py
+++ b/conans/test/functional/command/search_test.py
@@ -379,6 +379,8 @@ helloTest/1.4.10@myuser/stable""".format(remote)
                          "Hello/1.4.12@myuser/testing\n"
                          "Hello/1.5.10@myuser/testing\n"
                          "helloTest/1.4.10@myuser/stable\n", self.client.out)
+        self.client.run("search Hello/1.4.10@myuser/testing --raw")
+        self.assertNotIn("Existing packages for recipe", self.client.out)
 
     def search_html_table_test(self):
         self.client.run("search Hello/1.4.10@myuser/testing --table=table.html")
@@ -1343,6 +1345,10 @@ class Test(ConanFile):
         self.assertEqual(j[0]["revision"], "a94417fca6b55779c3b158f2ff50c40a")
         self.assertIsNotNone(j[0]["time"])
         self.assertEqual(len(j), 1)
+
+        # raw argument
+        client.run("search lib/1.0@user/testing --raw --revisions")
+        self.assertNotIn("Revisions for", client.out)
 
     def search_package_revisions_test(self):
         test_server = TestServer(users={"user": "password"})  # exported users and passwords


### PR DESCRIPTION
Changelog: Bugfix: --raw argument is ignored when searching for a specific reference
Docs: Omit

- [X] Refer to the issue that supports this Pull Request.
- [X] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [X] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [X] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 

The `--raw` argument is ignored when searching for a specific reference with or without `--revisions` regardless if there's `user/channel` present or not.

Closes #6077 

<sup>**Note:** By default this PR will skip the slower tests and will use a limited set of python versions. Check [here](https://github.com/conan-io/conan/blob/develop/.github/PR_INCREASE_TESTING.md) how to increase the testing level by writing some tags in the current PR body text.</sup>
