### PR TITLE
refactor to give access to config to Rest layer

### DIFF
--- a/conans/client/conan_api.py
+++ b/conans/client/conan_api.py
@@ -49,7 +49,6 @@ from conans.client.store.localdb import LocalDB
 from conans.client.userio import UserIO
 from conans.errors import (ConanException, RecipeNotFoundException,
                            PackageNotFoundException, NoRestV2Available, NotFoundException)
-from conans.model.conan_file import get_env_context_manager
 from conans.model.editable_layout import get_editable_abs_path
 from conans.model.graph_info import GraphInfo, GRAPH_INFO_FILE
 from conans.model.graph_lock import GraphLockFile, LOCKFILE
@@ -167,8 +166,7 @@ class ConanApp(object):
         self.requester = ConanRequester(self.config, http_requester)
         # To handle remote connections
         artifacts_properties = self.cache.read_artifacts_properties()
-        rest_client_factory = RestApiClientFactory(self.out, self.requester,
-                                                   revisions_enabled=self.config.revisions_enabled,
+        rest_client_factory = RestApiClientFactory(self.out, self.requester, self.config,
                                                    artifacts_properties=artifacts_properties)
         # To store user and token
         localdb = LocalDB.create(self.cache.localdb)
@@ -178,7 +176,7 @@ class ConanApp(object):
         self.remote_manager = RemoteManager(self.cache, auth_manager, self.out, self.hook_manager)
 
         # Adjust global tool variables
-        set_global_instances(self.out, self.requester)
+        set_global_instances(self.out, self.requester, self.config)
 
         self.runner = runner or ConanRunner(self.config.print_commands_to_output,
                                             self.config.generate_run_log_file,

--- a/conans/client/rest/conan_requester.py
+++ b/conans/client/rest/conan_requester.py
@@ -34,8 +34,6 @@ class ConanRequester(object):
         self._cacert_path = config.cacert_path
         self._client_cert_path = config.client_cert_path
         self._client_cert_key_path = config.client_cert_key_path
-        self._retry = config.retry
-        self._retry_wait = config.retry_wait
 
         self._no_proxy_match = [el.strip() for el in
                                 self.proxies.pop("no_proxy_match", "").split(",") if el]
@@ -62,14 +60,6 @@ class ConanRequester(object):
                                              self._client_cert_key_path)
             else:
                 self._client_certificates = self._client_cert_path
-
-    @property
-    def retry(self):
-        return self._retry
-
-    @property
-    def retry_wait(self):
-        return self._retry_wait
 
     def _should_skip_proxy(self, url):
 

--- a/conans/client/rest/rest_client.py
+++ b/conans/client/rest/rest_client.py
@@ -8,17 +8,17 @@ from conans.util.log import logger
 
 class RestApiClientFactory(object):
 
-    def __init__(self, output, requester, revisions_enabled, artifacts_properties=None):
+    def __init__(self, output, requester, config, artifacts_properties=None):
         self._output = output
         self._requester = requester
-        self._revisions_enabled = revisions_enabled
+        self._config = config
         self._artifacts_properties = artifacts_properties
         self._cached_capabilities = {}
 
     def new(self, remote, token, refresh_token, custom_headers):
         tmp = RestApiClient(remote, token, refresh_token, custom_headers,
-                            self._output, self._requester,
-                            self._revisions_enabled, self._cached_capabilities,
+                            self._output, self._requester, self._config,
+                            self._cached_capabilities,
                             self._artifacts_properties)
         return tmp
 
@@ -29,7 +29,7 @@ class RestApiClient(object):
     """
 
     def __init__(self, remote, token, refresh_token, custom_headers, output, requester,
-                 revisions_enabled, cached_capabilities, artifacts_properties=None):
+                 config, cached_capabilities, artifacts_properties=None):
 
         # Set to instance
         self._token = token
@@ -41,7 +41,8 @@ class RestApiClient(object):
 
         self._verify_ssl = remote.verify_ssl
         self._artifacts_properties = artifacts_properties
-        self._revisions_enabled = revisions_enabled
+        self._revisions_enabled = config.revisions_enabled
+        self._config = config
 
         # This dict is shared for all the instances of RestApiClient
         self._cached_capabilities = cached_capabilities
@@ -50,7 +51,8 @@ class RestApiClient(object):
         capabilities = self._cached_capabilities.get(self._remote_url)
         if capabilities is None:
             tmp = RestV1Methods(self._remote_url, self._token, self._custom_headers, self._output,
-                                self._requester, self._verify_ssl, self._artifacts_properties)
+                                self._requester, self._config, self._verify_ssl,
+                                self._artifacts_properties)
             capabilities = tmp.server_capabilities(user, password)
             self._cached_capabilities[self._remote_url] = capabilities
             logger.debug("REST: Cached capabilities for the remote: %s" % capabilities)
@@ -64,12 +66,12 @@ class RestApiClient(object):
         if self._revisions_enabled and revisions:
             checksum_deploy = self._capable(CHECKSUM_DEPLOY)
             return RestV2Methods(self._remote_url, self._token, self._custom_headers, self._output,
-                                 self._requester, self._verify_ssl, self._artifacts_properties,
-                                 checksum_deploy, matrix_params)
+                                 self._requester, self._config, self._verify_ssl,
+                                 self._artifacts_properties, checksum_deploy, matrix_params)
         else:
             return RestV1Methods(self._remote_url, self._token, self._custom_headers, self._output,
-                                 self._requester, self._verify_ssl, self._artifacts_properties,
-                                 matrix_params)
+                                 self._requester, self._config, self._verify_ssl,
+                                 self._artifacts_properties, matrix_params)
 
     def get_recipe_manifest(self, ref):
         return self._get_api().get_recipe_manifest(ref)

--- a/conans/client/rest/rest_client_common.py
+++ b/conans/client/rest/rest_client_common.py
@@ -56,13 +56,14 @@ def handle_return_deserializer(deserializer=None):
 
 class RestCommonMethods(object):
 
-    def __init__(self, remote_url, token, custom_headers, output, requester, verify_ssl,
+    def __init__(self, remote_url, token, custom_headers, output, requester, config, verify_ssl,
                  artifacts_properties=None, matrix_params=False):
         self.token = token
         self.remote_url = remote_url
         self.custom_headers = custom_headers
         self._output = output
         self.requester = requester
+        self._config = config
         self.verify_ssl = verify_ssl
         self._artifacts_properties = artifacts_properties
         self._matrix_params = matrix_params

--- a/conans/client/rest/rest_client_v1.py
+++ b/conans/client/rest/rest_client_v1.py
@@ -41,7 +41,7 @@ class RestV1Methods(RestCommonMethods):
         Its a generator, so it yields elements for memory performance
         """
         output = self._output if not quiet else None
-        downloader = FileDownloader(self.requester, output, self.verify_ssl)
+        downloader = FileDownloader(self.requester, output, self.verify_ssl, self._config)
         # Take advantage of filenames ordering, so that conan_package.tgz and conan_export.tgz
         # can be < conanfile, conaninfo, and sent always the last, so smaller files go first
         for filename, resource_url in sorted(file_urls.items(), reverse=True):
@@ -146,7 +146,7 @@ class RestV1Methods(RestCommonMethods):
     def _upload_files(self, file_urls, files, output, retry, retry_wait, display_name=None):
         t1 = time.time()
         failed = []
-        uploader = FileUploader(self.requester, output, self.verify_ssl)
+        uploader = FileUploader(self.requester, output, self.verify_ssl, self._config)
         # conan_package.tgz and conan_export.tgz are uploaded first to avoid uploading conaninfo.txt
         # or conanamanifest.txt with missing files due to a network failure
         for filename, resource_url in sorted(file_urls.items()):
@@ -176,7 +176,7 @@ class RestV1Methods(RestCommonMethods):
 
         It writes downloaded files to disk (appending to file, only keeps chunks in memory)
         """
-        downloader = FileDownloader(self.requester, self._output, self.verify_ssl)
+        downloader = FileDownloader(self.requester, self._output, self.verify_ssl, self._config)
         ret = {}
         # Take advantage of filenames ordering, so that conan_package.tgz and conan_export.tgz
         # can be < conanfile, conaninfo, and sent always the last, so smaller files go first
@@ -258,7 +258,7 @@ class RestV1Methods(RestCommonMethods):
                         ret.append(tmp)
             return sorted(ret)
         else:
-            downloader = FileDownloader(self.requester, None, self.verify_ssl)
+            downloader = FileDownloader(self.requester, None, self.verify_ssl, self._config)
             auth, _ = self._file_server_capabilities(urls[path])
             content = downloader.download(urls[path], auth=auth)
 

--- a/conans/client/rest/rest_client_v2.py
+++ b/conans/client/rest/rest_client_v2.py
@@ -18,11 +18,11 @@ from conans.util.log import logger
 
 class RestV2Methods(RestCommonMethods):
 
-    def __init__(self, remote_url, token, custom_headers, output, requester, verify_ssl,
+    def __init__(self, remote_url, token, custom_headers, output, requester, config, verify_ssl,
                  artifacts_properties=None, checksum_deploy=False, matrix_params=False):
 
         super(RestV2Methods, self).__init__(remote_url, token, custom_headers, output, requester,
-                                            verify_ssl, artifacts_properties, matrix_params)
+                                            config, verify_ssl, artifacts_properties, matrix_params)
         self._checksum_deploy = checksum_deploy
 
     @property
@@ -38,7 +38,7 @@ class RestV2Methods(RestCommonMethods):
 
     def _get_remote_file_contents(self, url):
         # We don't want traces in output of these downloads, they are ugly in output
-        downloader = FileDownloader(self.requester, None, self.verify_ssl)
+        downloader = FileDownloader(self.requester, None, self.verify_ssl, self._config)
         contents = downloader.download(url, auth=self.auth)
         return contents
 
@@ -176,7 +176,7 @@ class RestV2Methods(RestCommonMethods):
     def _upload_files(self, files, urls, retry, retry_wait, display_name=None):
         t1 = time.time()
         failed = []
-        uploader = FileUploader(self.requester, self._output, self.verify_ssl)
+        uploader = FileUploader(self.requester, self._output, self.verify_ssl, self._config)
         # conan_package.tgz and conan_export.tgz are uploaded first to avoid uploading conaninfo.txt
         # or conanamanifest.txt with missing files due to a network failure
         for filename in sorted(files):
@@ -203,7 +203,7 @@ class RestV2Methods(RestCommonMethods):
             logger.debug("\nUPLOAD: All uploaded! Total time: %s\n" % str(time.time() - t1))
 
     def _download_and_save_files(self, urls, dest_folder, files):
-        downloader = FileDownloader(self.requester, self._output, self.verify_ssl)
+        downloader = FileDownloader(self.requester, self._output, self.verify_ssl, self._config)
         # Take advantage of filenames ordering, so that conan_package.tgz and conan_export.tgz
         # can be < conanfile, conaninfo, and sent always the last, so smaller files go first
         for filename in sorted(files, reverse=True):

--- a/conans/client/rest/uploader_downloader.py
+++ b/conans/client/rest/uploader_downloader.py
@@ -16,17 +16,17 @@ from conans.util.tracer import log_download
 
 class FileUploader(object):
 
-    def __init__(self, requester, output, verify, chunk_size=1000):
-        self.chunk_size = chunk_size
-        self.output = output
-        self.requester = requester
-        self.verify = verify
+    def __init__(self, requester, output, verify, config):
+        self._output = output
+        self._requester = requester
+        self._config = config
+        self._verify_ssl = verify
 
     def upload(self, url, abs_path, auth=None, dedup=False, retry=None, retry_wait=None,
                headers=None, display_name=None):
-        retry = retry if retry is not None else self.requester.retry
+        retry = retry if retry is not None else self._config.retry
         retry = retry if retry is not None else 1
-        retry_wait = retry_wait if retry_wait is not None else self.requester.retry_wait
+        retry_wait = retry_wait if retry_wait is not None else self._config.retry_wait
         retry_wait = retry_wait if retry_wait is not None else 5
 
         # Send always the header with the Sha1
@@ -36,8 +36,8 @@ class FileUploader(object):
             dedup_headers = {"X-Checksum-Deploy": "true"}
             if headers:
                 dedup_headers.update(headers)
-            response = self.requester.put(url, data="", verify=self.verify, headers=dedup_headers,
-                                          auth=auth)
+            response = self._requester.put(url, data="", verify=self._verify_ssl,
+                                           headers=dedup_headers, auth=auth)
             if response.status_code == 400:
                 raise RequestErrorException(response_to_str(response))
 
@@ -51,9 +51,9 @@ class FileUploader(object):
             if response.status_code == 201:  # Artifactory returns 201 if the file is there
                 return response
 
-        ret = call_with_retry(self.output, retry, retry_wait, self._upload_file, url,
-                              abs_path=abs_path, headers=headers, auth=auth,
-                              display_name=display_name)
+        ret = _call_with_retry(self._output, retry, retry_wait, self._upload_file, url,
+                               abs_path=abs_path, headers=headers, auth=auth,
+                               display_name=display_name)
         return ret
 
     def _upload_file(self, url, abs_path,  headers, auth, display_name=None):
@@ -74,13 +74,13 @@ class FileUploader(object):
                 yield chunk
 
         with open(abs_path, mode='rb') as file_handler:
-            progress = progress_bar.Progress(file_size, self.output, description, post_description)
+            progress = progress_bar.Progress(file_size, self._output, description, post_description)
             chunk_size = 1024
             data = progress.update(load_in_chunks(file_handler, chunk_size), chunk_size)
             iterable_to_file = IterableToFileAdapter(data, file_size)
             try:
-                response = self.requester.put(url, data=iterable_to_file, verify=self.verify,
-                                              headers=headers, auth=auth)
+                response = self._requester.put(url, data=iterable_to_file, verify=self._verify_ssl,
+                                               headers=headers, auth=auth)
 
                 if response.status_code == 400:
                     raise RequestErrorException(response_to_str(response))
@@ -120,17 +120,17 @@ class IterableToFileAdapter(object):
 
 class FileDownloader(object):
 
-    def __init__(self, requester, output, verify, chunk_size=1000):
-        self.chunk_size = chunk_size
-        self.output = output
-        self.requester = requester
-        self.verify = verify
+    def __init__(self, requester, output, verify, config):
+        self._output = output
+        self._requester = requester
+        self._verify_ssl = verify
+        self._config = config
 
     def download(self, url, file_path=None, auth=None, retry=None, retry_wait=None, overwrite=False,
                  headers=None):
-        retry = retry if retry is not None else self.requester.retry
+        retry = retry if retry is not None else self._config.retry
         retry = retry if retry is not None else 2
-        retry_wait = retry_wait if retry_wait is not None else self.requester.retry_wait
+        retry_wait = retry_wait if retry_wait is not None else self._config.retry_wait
         retry_wait = retry_wait if retry_wait is not None else 0
 
         if file_path and not os.path.isabs(file_path):
@@ -138,21 +138,21 @@ class FileDownloader(object):
 
         if file_path and os.path.exists(file_path):
             if overwrite:
-                if self.output:
-                    self.output.warn("file '%s' already exists, overwriting" % file_path)
+                if self._output:
+                    self._output.warn("file '%s' already exists, overwriting" % file_path)
             else:
                 # Should not happen, better to raise, probably we had to remove
                 # the dest folder before
                 raise ConanException("Error, the file to download already exists: '%s'" % file_path)
 
-        return call_with_retry(self.output, retry, retry_wait, self._download_file, url, auth,
-                               headers, file_path)
+        return _call_with_retry(self._output, retry, retry_wait, self._download_file, url, auth,
+                                headers, file_path)
 
     def _download_file(self, url, auth, headers, file_path):
         t1 = time.time()
         try:
-            response = self.requester.get(url, stream=True, verify=self.verify, auth=auth,
-                                          headers=headers)
+            response = self._requester.get(url, stream=True, verify=self._verify_ssl, auth=auth,
+                                           headers=headers)
         except Exception as exc:
             raise ConanException("Error downloading file %s: '%s'" % (url, exc))
 
@@ -195,7 +195,7 @@ class FileDownloader(object):
             total_length = response.headers.get('content-length') or len(response.content)
             total_length = int(total_length)
             description = "Downloading {}".format(os.path.basename(file_path)) if file_path else None
-            progress = progress_bar.Progress(total_length, self.output, description)
+            progress = progress_bar.Progress(total_length, self._output, description)
 
             chunk_size = 1024 if not file_path else 1024 * 100
             encoding = response.headers.get('content-encoding')
@@ -223,7 +223,7 @@ class FileDownloader(object):
                                        % str(e))
 
 
-def call_with_retry(out, retry, retry_wait, method, *args, **kwargs):
+def _call_with_retry(out, retry, retry_wait, method, *args, **kwargs):
     for counter in range(retry + 1):
         try:
             return method(*args, **kwargs)

--- a/conans/client/tools/net.py
+++ b/conans/client/tools/net.py
@@ -58,14 +58,15 @@ def download(url, filename, verify=True, out=None, retry=None, retry_wait=None, 
 
     out = default_output(out, 'conans.client.tools.net.download')
     requester = default_requester(requester, 'conans.client.tools.net.download')
+    from conans.tools import _global_config as config
 
     # It might be possible that users provide their own requester
-    retry = retry if retry is not None else getattr(requester, "retry", None)
+    retry = retry if retry is not None else config.retry
     retry = retry if retry is not None else 1
-    retry_wait = retry_wait if retry_wait is not None else getattr(requester, "retry_wait", None)
+    retry_wait = retry_wait if retry_wait is not None else config.retry_wait
     retry_wait = retry_wait if retry_wait is not None else 5
 
-    downloader = FileDownloader(requester=requester, output=out, verify=verify)
+    downloader = FileDownloader(requester=requester, output=out, verify=verify, config=config)
     downloader.download(url, filename, retry=retry, retry_wait=retry_wait, overwrite=overwrite,
                         auth=auth, headers=headers)
     out.writeln("")

--- a/conans/test/functional/command/config_install_test.py
+++ b/conans/test/functional/command/config_install_test.py
@@ -448,11 +448,11 @@ class Pkg(ConanFile):
         fake_url = "https://fakeurl.com/myconf.zip"
 
         def download_verify_false(obj, url, filename, **kwargs):  # @UnusedVariable
-            self.assertFalse(obj.verify)
+            self.assertFalse(obj._verify_ssl)
             self._create_zip(filename)
 
         def download_verify_true(obj, url, filename, **kwargs):  # @UnusedVariable
-            self.assertTrue(obj.verify)
+            self.assertTrue(obj._verify_ssl)
             self._create_zip(filename)
 
         with patch.object(FileDownloader, 'download', new=download_verify_false):

--- a/conans/test/functional/remote/rest_api_test.py
+++ b/conans/test/functional/remote/rest_api_test.py
@@ -72,7 +72,7 @@ class RestApiTest(unittest.TestCase):
             config = ConanClientConfigParser(filename)
             requester = ConanRequester(config, requests)
             client_factory = RestApiClientFactory(TestBufferConanOutput(), requester=requester,
-                                                  revisions_enabled=False)
+                                                  config=config)
             localdb = LocalDBMock()
 
             mocked_user_io = UserIO(out=TestBufferConanOutput())

--- a/conans/test/functional/remote/retry_test.py
+++ b/conans/test/functional/remote/retry_test.py
@@ -14,7 +14,7 @@ from conans.test.utils.tools import TestBufferConanOutput
 from conans.util.files import save
 
 
-class response_type:
+class _ResponseMock:
     def __init__(self, status_code, content):
         self.status_code = status_code
         self.content = content
@@ -35,12 +35,18 @@ class response_type:
 
 class _RequesterMock:
     def __init__(self, status_code, content):
-        self.response = response_type(status_code, content)
+        self.response = _ResponseMock(status_code, content)
         self.retry = 0
         self.retry_wait = 0
 
     def put(self, *args, **kwargs):
         return self.response
+
+
+class _ConfigMock:
+    def __init__(self):
+        self.retry = 0
+        self.retry_wait = 0
 
 
 class RetryDownloadTests(unittest.TestCase):
@@ -52,7 +58,7 @@ class RetryDownloadTests(unittest.TestCase):
     def test_error_401(self):
         output = TestBufferConanOutput()
         uploader = FileUploader(requester=_RequesterMock(401, "content"), output=output,
-                                verify=False)
+                                verify=False, config=_ConfigMock())
         with six.assertRaisesRegex(self, AuthenticationException, "content"):
             uploader.upload(url="fake", abs_path=self.filename, retry=2)
         output_lines = str(output).splitlines()
@@ -63,7 +69,7 @@ class RetryDownloadTests(unittest.TestCase):
     def test_error_403_forbidden(self):
         output = TestBufferConanOutput()
         uploader = FileUploader(requester=_RequesterMock(403, "content"), output=output,
-                                verify=False)
+                                verify=False, config=_ConfigMock())
         with six.assertRaisesRegex(self, ForbiddenException, "content"):
             auth = namedtuple("auth", "token")
             uploader.upload(url="fake", abs_path=self.filename, retry=2, auth=auth("token"))
@@ -75,7 +81,7 @@ class RetryDownloadTests(unittest.TestCase):
     def test_error_403_authentication(self):
         output = TestBufferConanOutput()
         uploader = FileUploader(requester=_RequesterMock(403, "content"), output=output,
-                                verify=False)
+                                verify=False, config=_ConfigMock())
         with six.assertRaisesRegex(self, AuthenticationException, "content"):
             auth = namedtuple("auth", "token")
             uploader.upload(url="fake", abs_path=self.filename, retry=2, auth=auth(None))
@@ -86,15 +92,13 @@ class RetryDownloadTests(unittest.TestCase):
 
     def test_error_requests(self):
         class _RequesterMock:
-            retry = 0
-            retry_wait = 0
 
             def put(self, *args, **kwargs):
                 raise Exception("any exception")
 
         output = TestBufferConanOutput()
         uploader = FileUploader(requester=_RequesterMock(), output=output,
-                                verify=False)
+                                verify=False, config=_ConfigMock())
         with six.assertRaisesRegex(self, Exception, "any exception"):
             uploader.upload(url="fake", abs_path=self.filename, retry=2)
         output_lines = str(output).splitlines()
@@ -105,7 +109,7 @@ class RetryDownloadTests(unittest.TestCase):
     def test_error_500(self):
         output = TestBufferConanOutput()
         uploader = FileUploader(requester=_RequesterMock(500, "content"), output=output,
-                                verify=False)
+                                verify=False, config=_ConfigMock())
         with six.assertRaisesRegex(self, Exception, "500 Server Error: content"):
             uploader.upload(url="fake", abs_path=self.filename, retry=2)
         output_lines = str(output).splitlines()

--- a/conans/test/functional/remote/token_refresh_test.py
+++ b/conans/test/functional/remote/token_refresh_test.py
@@ -1,4 +1,5 @@
 import unittest
+from collections import namedtuple
 
 from mock import Mock
 
@@ -51,10 +52,6 @@ class ResponseAuthenticationRequired(object):
 
 class RequesterWithTokenMock(object):
 
-    def __init__(self):
-        self.retry = 1
-        self.retry_wait = 1
-
     def get(self, url, **kwargs):
         if not kwargs["auth"].token or kwargs["auth"].token == "expired":
             return ResponseAuthenticationRequired()
@@ -83,8 +80,9 @@ class TestTokenRefresh(unittest.TestCase):
         mocked_user_io.get_password = Mock(return_value="mypassword")
 
         requester = RequesterWithTokenMock()
+        config = namedtuple("ConfigMock", "revisions_enabled")(False)
         self.rest_client_factory = RestApiClientFactory(mocked_user_io.out,
-                                                        requester, revisions_enabled=False,
+                                                        requester, config=config,
                                                         artifacts_properties=None)
         self.localdb = LocalDBMock()
         self.auth_manager = ConanApiAuthManager(self.rest_client_factory, mocked_user_io,

--- a/conans/test/unittests/client/rest/rest_client_v1/test_get_package_manifest.py
+++ b/conans/test/unittests/client/rest/rest_client_v1/test_get_package_manifest.py
@@ -21,7 +21,7 @@ class GetPackageManifestTestCase(unittest.TestCase):
              patch.object(RestV1Methods, "_download_files", return_value=returned_files):
 
             v1 = RestV1Methods(remote_url, token=None, custom_headers=None, output=None,
-                               requester=None, verify_ssl=None)
+                               requester=None, config=None, verify_ssl=None)
             with self.assertRaises(ConanException) as exc:
                 v1.get_package_manifest(pref=pref)
 

--- a/conans/test/unittests/client/rest/rest_client_v2/test_get_package_manifest.py
+++ b/conans/test/unittests/client/rest/rest_client_v2/test_get_package_manifest.py
@@ -21,7 +21,7 @@ class GetPackageManifestTestCase(unittest.TestCase):
              patch.object(ClientV2Router, "package_manifest", return_value=None):
 
             v2 = RestV2Methods(remote_url, token=None, custom_headers=None, output=None,
-                               requester=None, verify_ssl=None)
+                               requester=None, config=None, verify_ssl=None)
             with self.assertRaises(ConanException) as exc:
                 v2.get_package_manifest(pref=pref)
 

--- a/conans/test/unittests/client/rest/uploader_test.py
+++ b/conans/test/unittests/client/rest/uploader_test.py
@@ -10,53 +10,43 @@ from conans.test.utils.tools import TestBufferConanOutput
 from conans.util.files import save
 
 
+class _ConfigMock:
+    def __init__(self):
+        self.retry = 0
+        self.retry_wait = 0
+
+
+class _MockRequester(object):
+    def __init__(self, code):
+        self._code = code
+
+    def put(self, *args, **kwargs):
+        return namedtuple("response", "status_code content")(self._code, "tururu")
+
+
 class UploaderUnitTest(unittest.TestCase):
 
     def test_401_raises_unauthoirzed_exception(self):
-
-        class MockRequester(object):
-            retry = 0
-            retry_wait = 0
-
-            def put(self, *args, **kwargs):
-                return namedtuple("response", "status_code content")(401, "tururu")
-
         out = TestBufferConanOutput()
-        uploader = FileUploader(MockRequester(), out, verify=False)
+        uploader = FileUploader(_MockRequester(401), out, verify=False, config=_ConfigMock())
         f = tempfile.mktemp()
         save(f, "some contents")
         with six.assertRaisesRegex(self, AuthenticationException, "tururu"):
             uploader.upload("fake_url", f)
 
     def test_403_raises_unauthoirzed_exception_if_no_token(self):
-
-        class MockRequester(object):
-            retry = 0
-            retry_wait = 0
-
-            def put(self, *args, **kwargs):
-                return namedtuple("response", "status_code content")(403, "tururu")
-
         out = TestBufferConanOutput()
         auth = namedtuple("auth", "token")(None)
-        uploader = FileUploader(MockRequester(), out, verify=False)
+        uploader = FileUploader(_MockRequester(403), out, verify=False, config=_ConfigMock())
         f = tempfile.mktemp()
         save(f, "some contents")
         with six.assertRaisesRegex(self, AuthenticationException, "tururu"):
             uploader.upload("fake_url", f, auth=auth)
 
     def test_403_raises_forbidden_exception_if_token(self):
-
-        class MockRequester(object):
-            retry = 0
-            retry_wait = 0
-
-            def put(self, *args, **kwargs):
-                return namedtuple("response", "status_code content")(403, "tururu")
-
         out = TestBufferConanOutput()
         auth = namedtuple("auth", "token")("SOMETOKEN")
-        uploader = FileUploader(MockRequester(), out, verify=False)
+        uploader = FileUploader(_MockRequester(403), out, verify=False, config=_ConfigMock())
         f = tempfile.mktemp()
         save(f, "some contents")
         with six.assertRaisesRegex(self, ForbiddenException, "tururu"):

--- a/conans/test/unittests/util/tools_test.py
+++ b/conans/test/unittests/util/tools_test.py
@@ -441,8 +441,8 @@ class HelloConan(ConanFile):
 
     @unittest.skipUnless(platform.system() == "Windows", "Requires Windows")
     def vcvars_env_not_duplicated_path_test(self):
-        """vcvars is not looking at the current values of the env vars, with PATH it is a problem because you
-        can already have set some of the vars and accumulate unnecessary entries."""
+        """vcvars is not looking at the current values of the env vars, with PATH it is a problem
+        because you can already have set some of the vars and accumulate unnecessary entries."""
         settings = Settings.loads(default_settings_yml)
         settings.os = "Windows"
         settings.compiler = "Visual Studio"
@@ -684,6 +684,24 @@ ProgramFiles(x86)=C:\Program Files (x86)
             self.assertIn('^&^& PATH=\\^"/cygdrive/other/path:/cygdrive/path/to/somewhere:$PATH\\^" '
                           '^&^& MYVAR=34 ^&^& a_command.bat ^', conanfile._conan_runner.command)
 
+    def download_retries_errors_test(self):
+        out = TestBufferConanOutput()
+
+        # Retry arguments override defaults
+        with six.assertRaisesRegex(self, ConanException, "Error downloading"):
+            tools.download("http://fakeurl3.es/nonexists",
+                           os.path.join(temp_folder(), "file.txt"), out=out,
+                           requester=requests,
+                           retry=2, retry_wait=1)
+        self.assertEqual(str(out).count("Waiting 1 seconds to retry..."), 2)
+
+        # Not found error
+        with six.assertRaisesRegex(self, NotFoundException, "Not found: "):
+            tools.download("http://google.es/FILE_NOT_FOUND",
+                           os.path.join(temp_folder(), "README.txt"), out=out,
+                           requester=requests,
+                           retry=2, retry_wait=0)
+
     @attr("slow")
     def download_retries_test(self):
         http_server = StoppableThreadBottle()
@@ -714,44 +732,6 @@ ProgramFiles(x86)=C:\Program Files (x86)
 
         out = TestBufferConanOutput()
 
-        # Connection error
-        # Default behaviour
-        with six.assertRaisesRegex(self, ConanException, "Error downloading"):
-            tools.download("http://fakeurl3.es/nonexists",
-                           os.path.join(temp_folder(), "file.txt"), out=out,
-                           requester=requests)
-        self.assertEqual(str(out).count("Waiting 5 seconds to retry..."), 1)
-
-        # Retry arguments override defaults
-        with six.assertRaisesRegex(self, ConanException, "Error downloading"):
-            tools.download("http://fakeurl3.es/nonexists",
-                           os.path.join(temp_folder(), "file.txt"), out=out,
-                           requester=requests,
-                           retry=2, retry_wait=1)
-        self.assertEqual(str(out).count("Waiting 1 seconds to retry..."), 2)
-
-        # Retry default values from the config
-        class MockRequester(object):
-            retry = 2
-            retry_wait = 0
-
-            def get(self, *args, **kwargs):
-                return requests.get(*args, **kwargs)
-
-        with six.assertRaisesRegex(self, ConanException, "Error downloading"):
-            tools.download("http://fakeurl3.es/nonexists",
-                           os.path.join(temp_folder(), "file.txt"), out=out,
-                           requester=MockRequester())
-        self.assertEqual(str(out).count("Waiting 0 seconds to retry..."), 2)
-
-        # Not found error
-        with six.assertRaisesRegex(self, NotFoundException, "Not found: "):
-            tools.download("http://google.es/FILE_NOT_FOUND",
-                           os.path.join(temp_folder(), "README.txt"), out=out,
-                           requester=requests,
-                           retry=2, retry_wait=0)
-
-        # And OK
         dest = os.path.join(temp_folder(), "manual.html")
         tools.download("http://localhost:%s/manual.html" % http_server.port, dest, out=out, retry=3,
                        retry_wait=0, requester=requests)
@@ -773,16 +753,17 @@ ProgramFiles(x86)=C:\Program Files (x86)
         # Not authorized
         with self.assertRaises(ConanException):
             tools.download("http://localhost:%s/basic-auth/user/passwd" % http_server.port, dest,
-                           overwrite=True, requester=requests, out=out)
+                           overwrite=True, requester=requests, out=out, retry=0, retry_wait=0)
 
         # Authorized
         tools.download("http://localhost:%s/basic-auth/user/passwd" % http_server.port, dest,
-                       auth=("user", "passwd"), overwrite=True, requester=requests, out=out)
+                       auth=("user", "passwd"), overwrite=True, requester=requests, out=out,
+                       retry=0, retry_wait=0)
 
         # Authorized using headers
         tools.download("http://localhost:%s/basic-auth/user/passwd" % http_server.port, dest,
                        headers={"Authorization": "Basic dXNlcjpwYXNzd2Q="}, overwrite=True,
-                       requester=requests, out=out)
+                       requester=requests, out=out, retry=0, retry_wait=0)
         http_server.stop()
 
     @parameterized.expand([
@@ -890,7 +871,7 @@ ProgramFiles(x86)=C:\Program Files (x86)
         # Test: Works with filename parameter instead of '?file=1'
         with tools.chdir(tools.mkdir_tmp()):
             tools.get("http://localhost:%s/?file=1" % thread.port, filename="sample.tar.gz",
-                      requester=requests, output=out)
+                      requester=requests, output=out, retry=0, retry_wait=0)
             self.assertTrue(os.path.exists("test_folder"))
 
         # Test: Use a different endpoint but still not the filename one
@@ -898,9 +879,10 @@ ProgramFiles(x86)=C:\Program Files (x86)
             from zipfile import BadZipfile
             with self.assertRaises(BadZipfile):
                 tools.get("http://localhost:%s/this_is_not_the_file_name" % thread.port,
-                          requester=requests, output=out)
+                          requester=requests, output=out, retry=0, retry_wait=0)
             tools.get("http://localhost:%s/this_is_not_the_file_name" % thread.port,
-                      filename="sample.tar.gz", requester=requests, output=out)
+                      filename="sample.tar.gz", requester=requests, output=out,
+                      retry=0, retry_wait=0)
             self.assertTrue(os.path.exists("test_folder"))
         thread.stop()
 
@@ -934,17 +916,17 @@ ProgramFiles(x86)=C:\Program Files (x86)
         out = TestBufferConanOutput()
         with tools.chdir(tools.mkdir_tmp()):
             tools.get("http://localhost:%s/test.txt.gz" % thread.port, requester=requests,
-                      output=out)
+                      output=out, retry=0, retry_wait=0)
             self.assertTrue(os.path.exists("test.txt"))
             self.assertEqual(load("test.txt"), "hello world zipped!")
         with tools.chdir(tools.mkdir_tmp()):
             tools.get("http://localhost:%s/test.txt.gz" % thread.port, requester=requests,
-                      output=out, destination="myfile.doc")
+                      output=out, destination="myfile.doc", retry=0, retry_wait=0)
             self.assertTrue(os.path.exists("myfile.doc"))
             self.assertEqual(load("myfile.doc"), "hello world zipped!")
         with tools.chdir(tools.mkdir_tmp()):
             tools.get("http://localhost:%s/test.txt.gz" % thread.port, requester=requests,
-                      output=out, destination="mytemp/myfile.txt")
+                      output=out, destination="mytemp/myfile.txt", retry=0, retry_wait=0)
             self.assertTrue(os.path.exists("mytemp/myfile.txt"))
             self.assertEqual(load("mytemp/myfile.txt"), "hello world zipped!")
 

--- a/conans/tools.py
+++ b/conans/tools.py
@@ -33,19 +33,18 @@ from conans.client.tools.version import Version
 # This global variables are intended to store the configuration of the running Conan application
 _global_output = None
 _global_requester = None
+_global_config = None
 
 
-def set_global_instances(the_output, the_requester):
+def set_global_instances(the_output, the_requester, config):
     global _global_output
     global _global_requester
-
-    old_output, old_requester = _global_output, _global_requester
+    global _global_config
 
     # TODO: pass here the configuration file, and make the work here (explicit!)
     _global_output = the_output
     _global_requester = the_requester
-
-    return old_output, old_requester
+    _global_config = config
 
 
 def get_global_instances():
@@ -53,7 +52,8 @@ def get_global_instances():
 
 
 # Assign a default, will be overwritten in the factory of the ConanAPI
-set_global_instances(the_output=ConanOutput(sys.stdout, sys.stderr, True), the_requester=requests)
+set_global_instances(the_output=ConanOutput(sys.stdout, sys.stderr, True), the_requester=requests,
+                     config=None)
 
 
 """


### PR DESCRIPTION
Changelog: Omit
Docs: Omit

The rest HTTP layer never had direct access to config. We want to give it, for example to be able to cache file downloads as defined by the configuration "download_cache" path. It makes sense to pass the whole config object (if not the whole app, but at the moment at least the config).

This is just a refactor to pass the config object to the HttpClients v1 and v2 (and common), so they could use it, and also moving the "retry" configuration out of the ``ConanRequester`` and to the config, where it belongs.

#revisions: 1
#tags: slow
