### PR TITLE
Fix link order issues for CMake targets (only 'cmake_find_package')

### DIFF
--- a/conans/client/generators/cmake_find_package.py
+++ b/conans/client/generators/cmake_find_package.py
@@ -27,7 +27,9 @@ if(NOT ${{CMAKE_VERSION}} VERSION_LESS "3.0")
         {find_dependencies_block}
 
         add_library({name}::{name} INTERFACE IMPORTED)
-        target_link_libraries({name}::{name} INTERFACE ${{{name}_LIBRARIES_TARGETS}} ${{{name}_SYSTEM_LIBS}} "${{{name}_LINKER_FLAGS_LIST}}")
+        # target_link_libraries({name}::{name} INTERFACE ${{{name}_LIBRARIES_TARGETS}} ${{{name}_SYSTEM_LIBS}} "${{{name}_LINKER_FLAGS_LIST}}")
+        set_property(TARGET {name}::{name} PROPERTY INTERFACE_LINK_LIBRARIES ${{{name}_LIBRARIES_TARGETS}} ${{{name}_SYSTEM_LIBS}} "${{{name}_LINKER_FLAGS_LIST}}")
+    
         
         # Some more data has to be assigned to the targets (or to the _INTERFACE IMPORTED_ one if there are no actual targets)
         set(_TARGETS_TO_POPULATE "${{{name}_LIBRARIES_ACTUAL_TARGETS}}")

--- a/conans/client/generators/cmake_find_package.py
+++ b/conans/client/generators/cmake_find_package.py
@@ -29,6 +29,20 @@ if(NOT ${{CMAKE_VERSION}} VERSION_LESS "3.0")
         add_library({name}::{name} INTERFACE IMPORTED)
         target_link_libraries({name}::{name} INTERFACE ${{{name}_LIBRARIES_TARGETS}} ${{{name}_SYSTEM_LIBS}} "${{{name}_LINKER_FLAGS_LIST}}")
         
+        # Some more data has to be assigned to the targets (or to the _INTERFACE IMPORTED_ one if there are no actual targets)
+        set(_TARGETS_TO_POPULATE "${{{name}_LIBRARIES_ACTUAL_TARGETS}}")
+        if (NOT _TARGETS_TO_POPULATE)
+            set(_TARGETS_TO_POPULATE "{name}::{name}")
+        endif()
+        
+        if({name}_INCLUDE_DIRS)
+            set_target_properties(${{_TARGETS_TO_POPULATE}} PROPERTIES INTERFACE_INCLUDE_DIRECTORIES "${{{name}_INCLUDE_DIRS}}")
+        endif()
+        #set_property(TARGET {name}::{name} PROPERTY INTERFACE_LINK_LIBRARIES ${{{name}_LIBRARIES_TARGETS}} ${{{name}_SYSTEM_LIBS}} "${{{name}_LINKER_FLAGS_LIST}}")
+        set_target_properties(${{_TARGETS_TO_POPULATE}} PROPERTIES 
+            INTERFACE_COMPILE_DEFINITIONS "${{{name}_COMPILE_DEFINITIONS}}"
+            INTERFACE_COMPILE_OPTIONS "${{{name}_COMPILE_OPTIONS_LIST}}")
+           
     endif()
 endif()
 """
@@ -73,7 +87,7 @@ def find_dependency_lines(name, public_deps_names, find_modules):
         if find_modules:
             lines.append("")
             lines.append("find_dependency(%s REQUIRED)" % dep_name)
-            lines.append("foreach(_actual_target ${%s_LIBRARIES_ACTUAL_TARGETS})" % (name))
+            lines.append("foreach(_actual_target ${%s_LIBRARIES_ACTUAL_TARGETS})" % name)
             lines.append("    target_link_libraries(${_actual_target} INTERFACE ${%s_LIBRARIES_TARGETS})" % dep_name)
             lines.append('    message("${_actual_target} ---> ${%s_LIBRARIES_TARGETS}")' % dep_name)
             lines.append("endforeach()")

--- a/conans/client/generators/cmake_find_package_common.py
+++ b/conans/client/generators/cmake_find_package_common.py
@@ -8,6 +8,7 @@ set({name}_LINKER_FLAGS{build_type_suffix}_LIST "{deps.sharedlinkflags_list}" "{
 set({name}_COMPILE_DEFINITIONS{build_type_suffix} {deps.compile_definitions})
 set({name}_COMPILE_OPTIONS{build_type_suffix}_LIST "{deps.cxxflags_list}" "{deps.cflags_list}")
 set({name}_LIBRARIES_TARGETS{build_type_suffix} "") # Will be filled later, if CMake 3
+set({name}_LIBRARIES_ACTUAL_TARGETS{build_type_suffix} "") # Will be filled later, if CMake 3
 set({name}_LIBRARIES{build_type_suffix} "") # Will be filled later
 set({name}_LIBS{build_type_suffix} "") # Same as {name}_LIBRARIES
 set({name}_SYSTEM_LIBS{build_type_suffix} {deps.system_libs})
@@ -60,6 +61,7 @@ foreach(_LIBRARY_NAME ${{{name}_LIBRARY_LIST{build_type_suffix}}})
                 message(STATUS "Skipping already existing target: ${{_LIB_NAME}}")
             endif()
             list(APPEND {name}_LIBRARIES_TARGETS{build_type_suffix} ${{_LIB_NAME}})
+            list(APPEND {name}_LIBRARIES_ACTUAL_TARGETS{build_type_suffix} ${{_LIB_NAME}})
         endif()
         message(STATUS "Found: ${{CONAN_FOUND_LIBRARY}}")
     else()

--- a/conans/test/functional/generators/cmake_find_package_test.py
+++ b/conans/test/functional/generators/cmake_find_package_test.py
@@ -411,7 +411,15 @@ cmake_minimum_required(VERSION 3.1)
 find_package(MYHELLO2)
 
 get_target_property(tmp MYHELLO2::MYHELLO2 INTERFACE_LINK_LIBRARIES)
-message("Target libs: ${tmp}")
+message("Target libs (hello2): ${tmp}")
+
+get_target_property(tmp MYHELLO::MYHELLO INTERFACE_LINK_LIBRARIES)
+message("Target libs (hello): ${tmp}")
+
+get_target_property(tmp CONAN_LIB::MYHELLO2_hello INTERFACE_LINK_LIBRARIES)
+message("Target libs (CONAN_LIB::MYHELLO2_hello): ${tmp}")
+
+
 """
         conanfile = """
 from conans import ConanFile, CMake
@@ -430,8 +438,9 @@ class Conan(ConanFile):
         client.run("build .")
         self.assertIn('Found MYHELLO2: 1.0 (found version "1.0")', client.out)
         self.assertIn('Found MYHELLO: 1.0 (found version "1.0")', client.out)
-        self.assertIn("Target libs: CONAN_LIB::MYHELLO2_hello;;;CONAN_LIB::MYHELLO_hello",
-                      client.out)
+        self.assertIn("Target libs (hello2): CONAN_LIB::MYHELLO2_hello;;", client.out)
+        self.assertIn("Target libs (hello): CONAN_LIB::MYHELLO_hello;;", client.out)
+        self.assertIn("Target libs (CONAN_LIB::MYHELLO2_hello): CONAN_LIB::MYHELLO_hello", client.out)
 
     def cpp_info_config_test(self):
         conanfile = textwrap.dedent("""


### PR DESCRIPTION
Changelog: (Feature | Fix | Bugfix): Describe here your pull request
Docs: https://github.com/conan-io/docs/pull/XXXX

Declare dependencies between different targets from dependencies using `target_link_libraries`, then the _IMPORTED_ `package::package` target includes just the list of all the targets in the package. It ensures link order.

Fixes https://github.com/conan-io/conan/issues/6280

- [ ] What if there is no actual target? What if a _proxy recipe_? Are there proxy recipes?

- [ ] Shall I create a _fake_ target (like the `Threads` one) always so it works even if there is no target (neither library itself, nor a system one)?  -- I need something to propagate compile options, include dirs,...

- [ ] Convert _system libraries_ into actual targets? It will simplify a lot the source in `cmake_find_package_common.py` file

#TAGS: slow