### PR TITLE
non destroy environment_append

### DIFF
--- a/conans/client/build/autotools_environment.py
+++ b/conans/client/build/autotools_environment.py
@@ -154,7 +154,7 @@ class AutoToolsBuildEnvironment(object):
             # If we are using pkg_config generator automate the pcs location, otherwise it could
             # read wrong files
             pkg_env = {"PKG_CONFIG_PATH": [self._conanfile.install_folder]} \
-                if "pkg_config" in self._conanfile.generators else {}
+                if "pkg_config" in self._conanfile.generators else None
 
         configure_dir = self._adjust_path(configure_dir)
 

--- a/conans/client/build/cmake.py
+++ b/conans/client/build/cmake.py
@@ -212,7 +212,7 @@ class CMake(object):
             # read wrong files
             set_env = "pkg_config" in self._conanfile.generators \
                       and "PKG_CONFIG_PATH" not in os.environ
-            pkg_env = {"PKG_CONFIG_PATH": self._conanfile.install_folder} if set_env else {}
+            pkg_env = {"PKG_CONFIG_PATH": self._conanfile.install_folder} if set_env else None
 
         with environment_append(pkg_env):
             command = "cd %s && %s %s" % (args_to_string([self.build_dir]), self._cmake_program,

--- a/conans/client/tools/win.py
+++ b/conans/client/tools/win.py
@@ -589,7 +589,7 @@ def run_in_windows_bash(conanfile, bashcmd, cwd=None, subsystem=None, msys_mingw
                                 "MINGW64"),
                     "MSYS2_PATH_TYPE": "inherit"}
     else:
-        env_vars = {}
+        env_vars = None
 
     with environment_append(env_vars):
 


### PR DESCRIPTION
Changelog: Bugfix: The ``environment_append()`` helper does not modify the argument anymore, which caused problems if the argument was reused.
Docs: omit

The ``environment_append()`` was destroying the argument, which is dangerous, because this context is called for every recipe method. I have tracked the uses and calls, and it seems that it is always getting a temporary copy as argument, so shouldn't be really causing bugs, but it seems it is worth fixing it.


#tags: slow, svn