### PR TITLE
Add nvcc to settings & build helpers

### DIFF
--- a/conans/client/build/autotools_environment.py
+++ b/conans/client/build/autotools_environment.py
@@ -43,6 +43,7 @@ class AutoToolsBuildEnvironment(object):
         self._compiler = conanfile.settings.get_safe("compiler")
         self._compiler_version = conanfile.settings.get_safe("compiler.version")
         self._compiler_runtime = conanfile.settings.get_safe("compiler.runtime")
+        self._compiler_base = conanfile.settings.get_safe("compiler.base")
         self._libcxx = conanfile.settings.get_safe("compiler.libcxx")
         self._cppstd = cppstd_from_settings(conanfile.settings)
 
@@ -286,7 +287,9 @@ class AutoToolsBuildEnvironment(object):
             ret.append(btf)
 
         # CXX11 ABI
-        abif = libcxx_define(compiler=self._compiler, libcxx=self._libcxx)
+        abif = libcxx_define(compiler=self._compiler,
+                             compiler_base=self._compiler_base,
+                             libcxx=self._libcxx)
         if abif:
             ret.append(abif)
         return ret
@@ -313,7 +316,7 @@ class AutoToolsBuildEnvironment(object):
 
         tmp_compilation_flags = copy.copy(self.flags)
         if self.fpic:
-            tmp_compilation_flags.append(pic_flag(self._compiler))
+            tmp_compilation_flags.append(pic_flag(self._compiler, self._compiler_base))
 
         cxx_flags = append(tmp_compilation_flags, self.cxx_flags, self.cppstd_flag)
         c_flags = tmp_compilation_flags

--- a/conans/client/build/autotools_environment.py
+++ b/conans/client/build/autotools_environment.py
@@ -8,7 +8,7 @@ from conans.client.build.compiler_flags import (architecture_flag, build_type_de
                                                 format_include_paths, format_libraries,
                                                 format_library_paths, libcxx_define, libcxx_flag,
                                                 pic_flag, rpath_flags, sysroot_flag)
-from conans.client.build.cppstd_flags import cppstd_flag, cppstd_from_settings
+from conans.client.build.cppstd_flags import cppstd_flag, cppstd_from_settings, libcxx_from_settings
 from conans.client.tools.env import environment_append
 from conans.client.tools.oss import OSInfo, args_to_string, cpu_count, cross_building, \
     detected_architecture, detected_os, get_gnu_triplet
@@ -44,7 +44,7 @@ class AutoToolsBuildEnvironment(object):
         self._compiler_version = conanfile.settings.get_safe("compiler.version")
         self._compiler_runtime = conanfile.settings.get_safe("compiler.runtime")
         self._compiler_base = conanfile.settings.get_safe("compiler.base")
-        self._libcxx = conanfile.settings.get_safe("compiler.libcxx")
+        self._libcxx = libcxx_from_settings(conanfile.settings)
         self._cppstd = cppstd_from_settings(conanfile.settings)
 
         # Set the generic objects before mapping to env vars to let the user

--- a/conans/client/build/cppstd_flags.py
+++ b/conans/client/build/cppstd_flags.py
@@ -3,6 +3,22 @@ import warnings
 from conans.errors import ConanException
 from conans.model.version import Version
 
+def libcxx_from_settings(settings):
+    libcxx = settings.get_safe("compiler.libcxx")
+    libcxx_base = settings.get_safe("compiler.base.libcxx")
+
+    if not libcxx and not libcxx_base:
+        return None
+
+    if libcxx and libcxx_base:
+        # Both should never arrive with a value to build_helpers
+        warnings.warn("Both settings, 'compiler.libcxx' and 'compiler.base.libcxx', should never "
+                      "arrive with values to build_helpers")
+        if libcxx != libcxx_base:
+            raise ConanException("Can't decide value for libcxx, settings mismatch: "
+                                 "'compiler.libcxx={}', 'compiler.base.libcxx={}'".format(
+                libcxx, libcxx_base))
+    return libcxx_base or libcxx
 
 def cppstd_from_settings(settings):
     cppstd = settings.get_safe("cppstd")

--- a/conans/client/conf/__init__.py
+++ b/conans/client/conf/__init__.py
@@ -75,17 +75,17 @@ compiler:
                   LLVM-vs2013, LLVM-vs2013_xp, LLVM-vs2014, LLVM-vs2014_xp,
                   LLVM-vs2017, LLVM-vs2017_xp, v141, v141_xp, v141_clang_c2, v142]
         cppstd: [None, 14, 17, 20]
-    clang:
+    clang: &clang
         version: ["3.3", "3.4", "3.5", "3.6", "3.7", "3.8", "3.9", "4.0",
                   "5.0", "6.0", "7.0", "7.1",
                   "8", "9", "10"]
         libcxx: [libstdc++, libstdc++11, libc++, c++_shared, c++_static]
         cppstd: [None, 98, gnu98, 11, gnu11, 14, gnu14, 17, gnu17, 20, gnu20]
-    apple-clang:
+    apple-clang: &apple-clang
         version: ["5.0", "5.1", "6.0", "6.1", "7.0", "7.3", "8.0", "8.1", "9.0", "9.1", "10.0", "11.0"]
         libcxx: [libstdc++, libc++]
         cppstd: [None, 98, gnu98, 11, gnu11, 14, gnu14, 17, gnu17, 20, gnu20]
-    intel:
+    intel: &intel
         version: ["11", "12", "13", "14", "15", "16", "17", "18", "19"]
         base:
             gcc:
@@ -94,6 +94,25 @@ compiler:
                 exception: [None]
             Visual Studio:
                 <<: *visual_studio
+    nvcc:
+        version: ["6.0", "6.5", 
+                  "7.0", "7.5", 
+                  "8.0", 
+                  "9.0", "9.1", "9.2", 
+                  "10.0", "10.1", "10.2"]
+        base:
+            gcc:
+                <<: *gcc
+            intel:
+                <<: *intel              
+            clang:
+                <<: *clang
+            apple-clang:
+                <<: *apple-clang
+            Visual Studio:
+                <<: *visual_studio
+        libcxx: [None, libcu++]
+        cppstd: [None, 03, 11, 14]
     qcc:
         version: ["4.4", "5.4"]
         libcxx: [cxx, gpp, cpp, cpp-ne, accp, acpp-ne, ecpp, ecpp-ne]

--- a/conans/client/generators/compiler_args.py
+++ b/conans/client/generators/compiler_args.py
@@ -5,7 +5,7 @@ from conans.client.build.compiler_flags import (architecture_flag, build_type_de
                                                 rpath_flags, sysroot_flag,
                                                 visual_linker_option_separator, visual_runtime,
                                                 format_frameworks, format_framework_paths)
-from conans.client.build.cppstd_flags import cppstd_flag, cppstd_from_settings
+from conans.client.build.cppstd_flags import cppstd_flag, cppstd_from_settings, libcxx_from_settings
 from conans.model import Generator
 from conans.paths import BUILD_INFO_COMPILER_ARGS
 
@@ -85,7 +85,7 @@ class CompilerArgsGenerator(Generator):
         return " ".join(flag for flag in flags if flag)
 
     def _libcxx_flags(self):
-        libcxx = self.conanfile.settings.get_safe("compiler.libcxx")
+        libcxx = libcxx_from_settings(self.conanfile.settings)
         compiler = self.conanfile.settings.get_safe("compiler")
         compiler_base = self.conanfile.settings.get_safe("compiler.base")
 

--- a/conans/client/generators/compiler_args.py
+++ b/conans/client/generators/compiler_args.py
@@ -66,9 +66,14 @@ class CompilerArgsGenerator(Generator):
         flags.extend(self._deps_build_info.sharedlinkflags)
         flags.extend(self._deps_build_info.exelinkflags)
         flags.extend(self._libcxx_flags())
-        flags.extend(format_frameworks(self._deps_build_info.frameworks, compiler=self.compiler))
+        flags.extend(format_frameworks(self._deps_build_info.frameworks,
+                                       compiler=self.compiler,
+                                       compiler_base=self.conanfile.settings.get_safe(
+                                           "compiler.base")))
         flags.extend(format_framework_paths(self._deps_build_info.framework_paths,
-                                            compiler=self.compiler))
+                                            compiler=self.compiler,
+                                            compiler_base=self.conanfile.settings.get_safe(
+                                           "compiler.base")))
         cppstd = cppstd_from_settings(self.conanfile.settings)
         flags.append(cppstd_flag(self.conanfile.settings.get_safe("compiler"),
                                  self.conanfile.settings.get_safe("compiler.version"),
@@ -82,12 +87,13 @@ class CompilerArgsGenerator(Generator):
     def _libcxx_flags(self):
         libcxx = self.conanfile.settings.get_safe("compiler.libcxx")
         compiler = self.conanfile.settings.get_safe("compiler")
+        compiler_base = self.conanfile.settings.get_safe("compiler.base")
 
         lib_flags = []
-        if libcxx:
-            stdlib_define = libcxx_define(compiler=compiler, libcxx=libcxx)
+        stdlib_define = libcxx_define(compiler=compiler, compiler_base=compiler_base, libcxx=libcxx)
+        if stdlib_define:
             lib_flags.extend(format_defines([stdlib_define]))
-            cxxf = libcxx_flag(compiler=compiler, libcxx=libcxx)
+            cxxf = libcxx_flag(compiler=compiler, compiler_base=compiler_base, libcxx=libcxx)
             if cxxf:
                 lib_flags.append(cxxf)
 

--- a/conans/client/generators/compiler_args.py
+++ b/conans/client/generators/compiler_args.py
@@ -4,7 +4,7 @@ from conans.client.build.compiler_flags import (architecture_flag, build_type_de
                                                 format_library_paths, libcxx_define, libcxx_flag,
                                                 rpath_flags, sysroot_flag,
                                                 visual_linker_option_separator, visual_runtime,
-                                                format_frameworks, format_framework_paths)
+                                                format_frameworks, format_framework_paths, format_flags)
 from conans.client.build.cppstd_flags import cppstd_flag, cppstd_from_settings, libcxx_from_settings
 from conans.model import Generator
 from conans.paths import BUILD_INFO_COMPILER_ARGS
@@ -32,8 +32,8 @@ class CompilerArgsGenerator(Generator):
         flags.extend(format_include_paths(self._deps_build_info.include_paths,
                                           compiler=self.compiler))
 
-        flags.extend(self._deps_build_info.cxxflags)
-        flags.extend(self._deps_build_info.cflags)
+        flags.extend(format_flags(self._deps_build_info.cxxflags, self.compiler))
+        flags.extend(format_flags(self._deps_build_info.cflags, self.compiler))
 
         arch_flag = architecture_flag(arch=self.conanfile.settings.get_safe("arch"),
                                       os=self.conanfile.settings.get_safe("os"),

--- a/conans/client/generators/pkg_config.py
+++ b/conans/client/generators/pkg_config.py
@@ -71,8 +71,12 @@ class PkgConfigGenerator(Generator):
         the_os = (self.conanfile.settings.get_safe("os_build") or
                   self.conanfile.settings.get_safe("os"))
         rpaths = rpath_flags(the_os, self.compiler, ["${%s}" % libdir for libdir in libdir_vars])
-        frameworks = format_frameworks(cpp_info.frameworks, compiler=self.compiler)
-        framework_paths = format_framework_paths(cpp_info.framework_paths, compiler=self.compiler)
+        frameworks = format_frameworks(cpp_info.frameworks, compiler=self.compiler,
+                                       compiler_base=self.settings.get_safe("compiler.base"))
+        framework_paths = format_framework_paths(cpp_info.framework_paths,
+                                                 compiler=self.compiler,
+                                                 compiler_base=self.settings.get_safe(
+                                                     "compiler.base"))
         lines.append("Libs: %s" % _concat_if_not_empty([libdirs_flags,
                                                         libnames_flags,
                                                         shared_flags,

--- a/conans/client/tools/settings.py
+++ b/conans/client/tools/settings.py
@@ -46,7 +46,9 @@ def check_min_cppstd(conanfile, cppstd, gnu_extensions=False):
         if not compiler or not compiler_version:
             raise ConanException("Could not obtain cppstd because there is no declared "
                                  "compiler in the 'settings' field of the recipe.")
-        return cppstd_default(compiler, compiler_version)
+        compiler_base = conanfile.settings.get_safe("compiler.base")
+        compiler_base_version = conanfile.settings.get_safe("compiler.base.version")
+        return cppstd_default(compiler, compiler_version, compiler_base, compiler_base_version)
 
     current_cppstd = deduced_cppstd()
     check_required_gnu_extension(current_cppstd)

--- a/conans/model/info.py
+++ b/conans/model/info.py
@@ -593,10 +593,13 @@ class ConanInfo(object):
         same as specifying None, packages are the same
         """
 
-        if (self.full_settings.compiler and
-                self.full_settings.compiler.version):
+        if self.full_settings.compiler and self.full_settings.compiler.version:
+            compiler_base = self.full_settings.compiler.base
+            compiler_base_version = compiler_base.version if compiler_base else None
             default = cppstd_default(str(self.full_settings.compiler),
-                                     str(self.full_settings.compiler.version))
+                                     str(self.full_settings.compiler.version),
+                                     str(compiler_base),
+                                     str(compiler_base_version))
 
             if str(self.full_settings.cppstd) == default:
                 self.settings.cppstd = None

--- a/conans/test/functional/settings/cppstd/default_cppstd_test.py
+++ b/conans/test/functional/settings/cppstd/default_cppstd_test.py
@@ -104,7 +104,7 @@ class SettingsCppStdTests(DefaultCppTestCase):
 
     def test_value_default(self):
         # Explicit value (equals to default) passed to setting 'cppstd'
-        cppstd = cppstd_default(self.compiler, self.compiler_version)
+        cppstd = cppstd_default(self.compiler, self.compiler_version, None, None)
         with catch_deprecation_warning(self):
             id_with, output = self._get_id(with_cppstd=True, settings_values={"cppstd": cppstd})
         self.assertIn(">>>> settings: ['compiler', 'cppstd', 'os']", output)
@@ -144,7 +144,7 @@ class SettingsCompilerCppStdTests(DefaultCppTestCase):
 
     def test_value_default(self):
         # Explicit value (equals to default) passed to setting 'compiler.cppstd'
-        cppstd = cppstd_default(self.compiler, self.compiler_version)
+        cppstd = cppstd_default(self.compiler, self.compiler_version, None, None)
         id_with, output = self._get_id(settings_values={"compiler.cppstd": cppstd})
         self.assertIn(">>>> settings: ['compiler', 'os']", output)
         self.assertIn(">>>> cppstd: None", output)

--- a/conans/test/unittests/client/build/compiler_flags_test.py
+++ b/conans/test/unittests/client/build/compiler_flags_test.py
@@ -129,7 +129,7 @@ class CompilerFlagsTest(unittest.TestCase):
                            ("apple-clang", "Release", None, "-O3"),
                            ("apple-clang", "RelWithDebInfo", None, "-O2 -g"),
                            ("apple-clang", "MinSizeRel", None, "-Os"),
-                           ("nvcc", "Debug", None, "-g"),
+                           ("nvcc", "Debug", None, "-O0 -g"),
                            ("nvcc", "Release", None, "-O3"),
                            ("nvcc", "RelWithDebInfo", None, "-O2 -g"),
                            ("nvcc", "MinSizeRel", None, ""),

--- a/conans/test/unittests/client/build/cpp_std_flags_test.py
+++ b/conans/test/unittests/client/build/cpp_std_flags_test.py
@@ -49,12 +49,12 @@ class CompilerFlagsTest(unittest.TestCase):
         self.assertEqual(cppstd_flag("gcc", "8", "20"), '-std=c++2a')
 
     def test_gcc_cppstd_defaults(self):
-        self.assertEqual(cppstd_default("gcc", "4"), "gnu98")
-        self.assertEqual(cppstd_default("gcc", "5"), "gnu98")
-        self.assertEqual(cppstd_default("gcc", "6"), "gnu14")
-        self.assertEqual(cppstd_default("gcc", "6.1"), "gnu14")
-        self.assertEqual(cppstd_default("gcc", "7.3"), "gnu14")
-        self.assertEqual(cppstd_default("gcc", "8.1"), "gnu14")
+        self.assertEqual(cppstd_default("gcc", "4", None, None), "gnu98")
+        self.assertEqual(cppstd_default("gcc", "5", None, None), "gnu98")
+        self.assertEqual(cppstd_default("gcc", "6", None, None), "gnu14")
+        self.assertEqual(cppstd_default("gcc", "6.1", None, None), "gnu14")
+        self.assertEqual(cppstd_default("gcc", "7.3", None, None), "gnu14")
+        self.assertEqual(cppstd_default("gcc", "8.1", None, None), "gnu14")
 
     def test_clang_cppstd_flags(self):
         self.assertEqual(cppstd_flag("clang", "2.0", "98"), None)
@@ -106,16 +106,16 @@ class CompilerFlagsTest(unittest.TestCase):
         self.assertEqual(cppstd_flag("clang", "8", "20"), '-std=c++2a')
 
     def test_clang_cppstd_defaults(self):
-        self.assertEqual(cppstd_default("clang", "2"), "gnu98")
-        self.assertEqual(cppstd_default("clang", "2.1"), "gnu98")
-        self.assertEqual(cppstd_default("clang", "3.0"), "gnu98")
-        self.assertEqual(cppstd_default("clang", "3.1"), "gnu98")
-        self.assertEqual(cppstd_default("clang", "3.4"), "gnu98")
-        self.assertEqual(cppstd_default("clang", "3.5"), "gnu98")
-        self.assertEqual(cppstd_default("clang", "5"), "gnu98")
-        self.assertEqual(cppstd_default("clang", "5.1"), "gnu98")
-        self.assertEqual(cppstd_default("clang", "6"), "gnu14")
-        self.assertEqual(cppstd_default("clang", "7"), "gnu14")
+        self.assertEqual(cppstd_default("clang", "2", None, None), "gnu98")
+        self.assertEqual(cppstd_default("clang", "2.1", None, None), "gnu98")
+        self.assertEqual(cppstd_default("clang", "3.0", None, None), "gnu98")
+        self.assertEqual(cppstd_default("clang", "3.1", None, None), "gnu98")
+        self.assertEqual(cppstd_default("clang", "3.4", None, None), "gnu98")
+        self.assertEqual(cppstd_default("clang", "3.5", None, None), "gnu98")
+        self.assertEqual(cppstd_default("clang", "5", None, None), "gnu98")
+        self.assertEqual(cppstd_default("clang", "5.1", None, None), "gnu98")
+        self.assertEqual(cppstd_default("clang", "6", None, None), "gnu14")
+        self.assertEqual(cppstd_default("clang", "7", None, None), "gnu14")
 
     def test_apple_clang_cppstd_flags(self):
         self.assertEqual(cppstd_flag("apple-clang", "3.9", "98"), None)
@@ -162,16 +162,16 @@ class CompilerFlagsTest(unittest.TestCase):
         self.assertEqual(cppstd_flag("apple-clang", "11.0", "17"), "-std=c++17")
 
     def test_apple_clang_cppstd_defaults(self):
-        self.assertEqual(cppstd_default("apple-clang", "2"), "gnu98")
-        self.assertEqual(cppstd_default("apple-clang", "3"), "gnu98")
-        self.assertEqual(cppstd_default("apple-clang", "4"), "gnu98")
-        self.assertEqual(cppstd_default("apple-clang", "5"), "gnu98")
-        self.assertEqual(cppstd_default("apple-clang", "6"), "gnu98")
-        self.assertEqual(cppstd_default("apple-clang", "7"), "gnu98")
-        self.assertEqual(cppstd_default("apple-clang", "8"), "gnu98")
-        self.assertEqual(cppstd_default("apple-clang", "9"), "gnu98")
-        self.assertEqual(cppstd_default("apple-clang", "10"), "gnu98")
-        self.assertEqual(cppstd_default("apple-clang", "11"), "gnu98")
+        self.assertEqual(cppstd_default("apple-clang", "2", None, None), "gnu98")
+        self.assertEqual(cppstd_default("apple-clang", "3", None, None), "gnu98")
+        self.assertEqual(cppstd_default("apple-clang", "4", None, None), "gnu98")
+        self.assertEqual(cppstd_default("apple-clang", "5", None, None), "gnu98")
+        self.assertEqual(cppstd_default("apple-clang", "6", None, None), "gnu98")
+        self.assertEqual(cppstd_default("apple-clang", "7", None, None), "gnu98")
+        self.assertEqual(cppstd_default("apple-clang", "8", None, None), "gnu98")
+        self.assertEqual(cppstd_default("apple-clang", "9", None, None), "gnu98")
+        self.assertEqual(cppstd_default("apple-clang", "10", None, None), "gnu98")
+        self.assertEqual(cppstd_default("apple-clang", "11", None, None), "gnu98")
 
     def test_visual_cppstd_flags(self):
         self.assertEqual(cppstd_flag("Visual Studio", "12", "11"), None)
@@ -188,8 +188,64 @@ class CompilerFlagsTest(unittest.TestCase):
         self.assertEqual(cppstd_flag("Visual Studio", "17", "20"), '/std:c++latest')
 
     def test_visual_cppstd_defaults(self):
-        self.assertEqual(cppstd_default("Visual Studio", "11"), None)
-        self.assertEqual(cppstd_default("Visual Studio", "12"), None)
-        self.assertEqual(cppstd_default("Visual Studio", "13"), None)
-        self.assertEqual(cppstd_default("Visual Studio", "14"), "14")
-        self.assertEqual(cppstd_default("Visual Studio", "15"), "14")
+        self.assertEqual(cppstd_default("Visual Studio", "11", None, None), None)
+        self.assertEqual(cppstd_default("Visual Studio", "12", None, None), None)
+        self.assertEqual(cppstd_default("Visual Studio", "13", None, None), None)
+        self.assertEqual(cppstd_default("Visual Studio", "14", None, None), "14")
+        self.assertEqual(cppstd_default("Visual Studio", "15", None, None), "14")
+
+    def test_nvcc_cppstd_flags(self):
+        self.assertEqual(cppstd_flag("nvcc", "6.5", "03"), None)
+        self.assertEqual(cppstd_flag("nvcc", "6.5", "11"), "-std=c++11")
+        self.assertEqual(cppstd_flag("nvcc", "6.5", "14"), None)
+
+        self.assertEqual(cppstd_flag("nvcc", "7.0", "03"), None)
+        self.assertEqual(cppstd_flag("nvcc", "7.0", "11"), "-std=c++11")
+        self.assertEqual(cppstd_flag("nvcc", "7.0", "14"), None)
+
+        self.assertEqual(cppstd_flag("nvcc", "7.5", "03"), None)
+        self.assertEqual(cppstd_flag("nvcc", "7.5", "11"), "-std=c++11")
+        self.assertEqual(cppstd_flag("nvcc", "7.5", "14"), None)
+
+        self.assertEqual(cppstd_flag("nvcc", "8.0", "03"), None)
+        self.assertEqual(cppstd_flag("nvcc", "8.0", "11"), "-std=c++11")
+        self.assertEqual(cppstd_flag("nvcc", "8.0", "14"), None)
+
+        self.assertEqual(cppstd_flag("nvcc", "9.0", "03"), "-std=c++03")
+        self.assertEqual(cppstd_flag("nvcc", "9.0", "11"), "-std=c++11")
+        self.assertEqual(cppstd_flag("nvcc", "9.0", "14"), "-std=c++14")
+
+        self.assertEqual(cppstd_flag("nvcc", "9.1", "03"), "-std=c++03")
+        self.assertEqual(cppstd_flag("nvcc", "9.1", "11"), "-std=c++11")
+        self.assertEqual(cppstd_flag("nvcc", "9.1", "14"), "-std=c++14")
+
+        self.assertEqual(cppstd_flag("nvcc", "9.2", "03"), "-std=c++03")
+        self.assertEqual(cppstd_flag("nvcc", "9.2", "11"), "-std=c++11")
+        self.assertEqual(cppstd_flag("nvcc", "9.2", "14"), "-std=c++14")
+
+        self.assertEqual(cppstd_flag("nvcc", "10.0", "03"), "-std=c++03")
+        self.assertEqual(cppstd_flag("nvcc", "10.0", "11"), "-std=c++11")
+        self.assertEqual(cppstd_flag("nvcc", "10.0", "14"), "-std=c++14")
+
+        self.assertEqual(cppstd_flag("nvcc", "10.1", "03"), "-std=c++03")
+        self.assertEqual(cppstd_flag("nvcc", "10.1", "11"), "-std=c++11")
+        self.assertEqual(cppstd_flag("nvcc", "10.1", "14"), "-std=c++14")
+
+        self.assertEqual(cppstd_flag("nvcc", "10.2", "03"), "-std=c++03")
+        self.assertEqual(cppstd_flag("nvcc", "10.2", "11"), "-std=c++11")
+        self.assertEqual(cppstd_flag("nvcc", "10.2", "14"), "-std=c++14")
+
+    def test_nvcc_cppstd_defaults(self):
+        self.assertEqual(cppstd_default("nvcc", None, "gcc", "4.8"), "gnu98")
+        self.assertEqual(cppstd_default("nvcc", None, "gcc", "5"), "gnu98")
+        self.assertEqual(cppstd_default("nvcc", None, "gcc", "6"), "gnu14")
+        self.assertEqual(cppstd_default("nvcc", None, "gcc", "6.1"), "gnu14")
+        self.assertEqual(cppstd_default("nvcc", None, "gcc", "7.3"), "gnu14")
+        self.assertEqual(cppstd_default("nvcc", None, "gcc", "8.1"), "gnu14")
+        self.assertEqual(cppstd_default("nvcc", None, "clang", "5"), "gnu98")
+        self.assertEqual(cppstd_default("nvcc", None, "clang", "6"), "gnu14")
+        self.assertEqual(cppstd_default("nvcc", None, "clang", "7"), "gnu14")
+        self.assertEqual(cppstd_default("nvcc", None, "Visual Studio", "13"), None)
+        self.assertEqual(cppstd_default("nvcc", None, "Visual Studio", "14"), "14")
+        self.assertEqual(cppstd_default("nvcc", None, "Visual Studio", "15"), "14")
+        self.assertEqual(cppstd_default("nvcc", None, "Visual Studio", "16"), "14")


### PR DESCRIPTION
Adds `nvcc` to `settings.yml` following the `intel` compiler model (with host compilers as `compiler.base` subsetting).
Added logic to generate flags for `nvcc`. Added parameters to pass `base` compiler since most of the time we require to get first, the parameters of the `base` compiler, and then add the decoraton of `nvcc`.


Changelog: (Feature): Fixes https://github.com/conan-io/conan/issues/6244
Docs: https://github.com/conan-io/docs/pull/XXXX

- [x] Refer to the issue that supports this Pull Request.
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request: _Provide an initial implementation to get feedback._
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [ ] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 

<sup>**Note:** By default this PR will skip the slower tests and will use a limited set of python versions. Check [here](https://github.com/conan-io/conan/blob/develop/.github/PR_INCREASE_TESTING.md) how to increase the testing level by writing some tags in the current PR body text.</sup>
