### PR TITLE
fix bug in windows_store vcvars

### DIFF
--- a/conans/client/tools/win.py
+++ b/conans/client/tools/win.py
@@ -421,18 +421,18 @@ def vcvars_command(settings, arch=None, compiler_version=None, force=False, vcva
             if vcvars_ver:
                 command.append("-vcvars_ver=%s" % vcvars_ver)
 
-    if os_setting == 'WindowsStore':
-        os_version_setting = settings.get_safe("os.version")
-        if os_version_setting == '8.1':
-            command.append('store 8.1')
-        elif os_version_setting == '10.0':
-            windows_10_sdk = find_windows_10_sdk()
-            if not windows_10_sdk:
-                raise ConanException("cross-compiling for WindowsStore 10 (UWP), "
-                                     "but Windows 10 SDK wasn't found")
-            command.append('store %s' % windows_10_sdk)
-        else:
-            raise ConanException('unsupported Windows Store version %s' % os_version_setting)
+        if os_setting == 'WindowsStore':
+            os_version_setting = settings.get_safe("os.version")
+            if os_version_setting == '8.1':
+                command.append('store 8.1')
+            elif os_version_setting == '10.0':
+                windows_10_sdk = find_windows_10_sdk()
+                if not windows_10_sdk:
+                    raise ConanException("cross-compiling for WindowsStore 10 (UWP), "
+                                         "but Windows 10 SDK wasn't found")
+                command.append('store %s' % windows_10_sdk)
+            else:
+                raise ConanException('unsupported Windows Store version %s' % os_version_setting)
     return " ".join(command)
 
 

--- a/conans/test/unittests/util/tools_test.py
+++ b/conans/test/unittests/util/tools_test.py
@@ -446,20 +446,10 @@ class HelloConan(ConanFile):
         settings.compiler = "Visual Studio"
         settings.compiler.version = "14"
         cmd = tools.vcvars_command(settings, output=self.output)
-        output = TestBufferConanOutput()
-        runner = ConanRunner(print_commands_to_output=True, output=output)
-        runner(cmd + " && set vs140comntools")
-        self.assertIn("vcvarsall.bat", str(output))
-        self.assertIn("VS140COMNTOOLS=", str(output))
+        self.assertIn("store 8.1", cmd)
         with tools.environment_append({"VisualStudioVersion": "14"}):
-            output = TestBufferConanOutput()
-            runner = ConanRunner(print_commands_to_output=True, output=output)
             cmd = tools.vcvars_command(settings, output=self.output)
-            runner(cmd + " && set vs140comntools")
-            self.assertNotIn("vcvarsall.bat", str(output))
-            self.assertNotIn("store 8.1", str(output))
-            self.assertIn("Conan:vcvars already set", str(output))
-            self.assertIn("VS140COMNTOOLS=", str(output))
+            self.assertEqual("echo Conan:vcvars already set", cmd)
 
     @unittest.skipUnless(platform.system() == "Windows", "Requires Windows")
     def vcvars_env_not_duplicated_path_test(self):


### PR DESCRIPTION
Changelog: Fix: Avoid WindowsStore ``tools.vcvars()`` management when the environment is already set.
Docs: Omit
