### PR TITLE
6273/short paths home validation

### DIFF
--- a/conans/client/conf/__init__.py
+++ b/conans/client/conf/__init__.py
@@ -416,8 +416,10 @@ class ConanClientConfigParser(ConfigParser, object):
     def short_paths_home(self):
         short_paths_home = get_env("CONAN_USER_HOME_SHORT")
         if short_paths_home:
-            current_dir = os.path.dirname(self.filename)
-            if current_dir == os.path.commonprefix([current_dir, short_paths_home]):
+            current_dir = os.path.dirname(os.path.normpath(os.path.normcase(self.filename)))
+            short_paths_dir = os.path.normpath(os.path.normcase(short_paths_home))
+            if current_dir == short_paths_dir  or \
+                    short_paths_dir.startswith(current_dir + os.path.sep):
                 raise ConanException("Short path home '{}' (defined by conan.conf variable "
                                      "'user_home_short', or environment variable "
                                      "'CONAN_USER_HOME_SHORT') cannot be a subdirectory of "

--- a/conans/test/functional/command/config_test.py
+++ b/conans/test/functional/command/config_test.py
@@ -118,6 +118,14 @@ class ConfigTest(unittest.TestCase):
             with six.assertRaisesRegex(self, ConanException, "cannot be a subdirectory of the conan cache"):
                 TestClient(cache_folder=cache_folder)
 
+    def test_config_home_short_home_dir_contains_cache_dir(self):
+        # https://github.com/conan-io/conan/issues/6273
+        cache_folder = os.path.join(temp_folder(), "custom")
+        short_path_home_folder = cache_folder + '_short'
+        with environment_append({"CONAN_USER_HOME_SHORT": short_path_home_folder}):
+            client = TestClient(cache_folder=cache_folder)
+            self.assertEqual(client.cache.config.short_paths_home, short_path_home_folder)
+
     def _assert_dict_subset(self, expected, actual):
         actual = {k: v for k, v in actual.items() if k in expected}
         self.assertDictEqual(expected, actual)


### PR DESCRIPTION
This PR is a clean copy of [this one](https://github.com/conan-io/conan/pull/6276) pointing to the correct branch.

Changelog: Bugfix: Enhance validation of the `short_paths_home` property to correctly handle the scenarios where it is set to a path that contains the value of the Conan cache path, but is not a subdirectory of it.
Docs: Omit

Fixes: #6273 

- [X] Refer to the issue that supports this Pull Request.
- [X] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [X] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [X] I've followed the PEP8 style guides for Python code.
- NA I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 

<sup>**Note:** By default this PR will skip the slower tests and will use a limited set of python versions. Check [here](https://github.com/conan-io/conan/blob/develop/.github/PR_INCREASE_TESTING.md) how to increase the testing level by writing some tags in the current PR body text.</sup>