### PR TITLE
fix unathorized transfers

### DIFF
--- a/conans/client/rest/uploader_downloader.py
+++ b/conans/client/rest/uploader_downloader.py
@@ -45,7 +45,7 @@ class FileUploader(object):
                 raise AuthenticationException(response_to_str(response))
 
             if response.status_code == 403:
-                if auth.token is None:
+                if auth is None or auth.token is None:
                     raise AuthenticationException(response_to_str(response))
                 raise ForbiddenException(response_to_str(response))
             if response.status_code == 201:  # Artifactory returns 201 if the file is there
@@ -86,7 +86,7 @@ class FileUploader(object):
                     raise AuthenticationException(response_to_str(response))
 
                 if response.status_code == 403:
-                    if auth.token is None:
+                    if auth is None or auth.token is None:
                         raise AuthenticationException(response_to_str(response))
                     raise ForbiddenException(response_to_str(response))
 
@@ -157,7 +157,7 @@ class FileDownloader(object):
             if response.status_code == 404:
                 raise NotFoundException("Not found: %s" % url)
             elif response.status_code == 403:
-                if auth.token is None:
+                if auth is None or auth.token is None:
                     raise AuthenticationException(response_to_str(response))
                 raise ForbiddenException(response_to_str(response))
             elif response.status_code == 401:

--- a/conans/client/rest/uploader_downloader.py
+++ b/conans/client/rest/uploader_downloader.py
@@ -157,7 +157,8 @@ class FileDownloader(object):
             if response.status_code == 404:
                 raise NotFoundException("Not found: %s" % url)
             elif response.status_code == 403:
-                if auth is None or auth.token is None:
+                if auth is None or (hasattr(auth, "token") and auth.token is None):
+                    # TODO: This is a bit weird, why this conversion? Need to investigate
                     raise AuthenticationException(response_to_str(response))
                 raise ForbiddenException(response_to_str(response))
             elif response.status_code == 401:

--- a/conans/test/unittests/client/rest/uploader_test.py
+++ b/conans/test/unittests/client/rest/uploader_test.py
@@ -10,54 +10,41 @@ from conans.test.utils.tools import TestBufferConanOutput
 from conans.util.files import save
 
 
+class MockRequester(object):
+    retry = 0
+    retry_wait = 0
+
+    def __init__(self, response):
+        self._response = response
+
+    def put(self, *args, **kwargs):
+        return namedtuple("response", "status_code content")(self._response, "tururu")
+
+
 class UploaderUnitTest(unittest.TestCase):
+    def setUp(self):
+        self.f = tempfile.mktemp()
+        save(self.f, "some contents")
+        self.out = TestBufferConanOutput()
 
     def test_401_raises_unauthoirzed_exception(self):
-
-        class MockRequester(object):
-            retry = 0
-            retry_wait = 0
-
-            def put(self, *args, **kwargs):
-                return namedtuple("response", "status_code content")(401, "tururu")
-
-        out = TestBufferConanOutput()
-        uploader = FileUploader(MockRequester(), out, verify=False)
-        f = tempfile.mktemp()
-        save(f, "some contents")
+        uploader = FileUploader(MockRequester(401), self.out, verify=False)
         with six.assertRaisesRegex(self, AuthenticationException, "tururu"):
-            uploader.upload("fake_url", f)
+            uploader.upload("fake_url", self.f)
 
     def test_403_raises_unauthoirzed_exception_if_no_token(self):
-
-        class MockRequester(object):
-            retry = 0
-            retry_wait = 0
-
-            def put(self, *args, **kwargs):
-                return namedtuple("response", "status_code content")(403, "tururu")
-
-        out = TestBufferConanOutput()
         auth = namedtuple("auth", "token")(None)
-        uploader = FileUploader(MockRequester(), out, verify=False)
-        f = tempfile.mktemp()
-        save(f, "some contents")
+        uploader = FileUploader(MockRequester(403), self.out, verify=False)
         with six.assertRaisesRegex(self, AuthenticationException, "tururu"):
-            uploader.upload("fake_url", f, auth=auth)
+            uploader.upload("fake_url", self.f, auth=auth)
+
+    def test_403_raises_unauthorized_exception_if_no_auth(self):
+        uploader = FileUploader(MockRequester(403), self.out, verify=False)
+        with six.assertRaisesRegex(self, AuthenticationException, "tururu"):
+            uploader.upload("fake_url", self.f)
 
     def test_403_raises_forbidden_exception_if_token(self):
-
-        class MockRequester(object):
-            retry = 0
-            retry_wait = 0
-
-            def put(self, *args, **kwargs):
-                return namedtuple("response", "status_code content")(403, "tururu")
-
-        out = TestBufferConanOutput()
         auth = namedtuple("auth", "token")("SOMETOKEN")
-        uploader = FileUploader(MockRequester(), out, verify=False)
-        f = tempfile.mktemp()
-        save(f, "some contents")
+        uploader = FileUploader(MockRequester(403), self.out, verify=False)
         with six.assertRaisesRegex(self, ForbiddenException, "tururu"):
-            uploader.upload("fake_url", f, auth=auth)
+            uploader.upload("fake_url", self.f, auth=auth)

--- a/conans/test/unittests/util/tools_test.py
+++ b/conans/test/unittests/util/tools_test.py
@@ -10,7 +10,7 @@ from collections import namedtuple
 import mock
 import requests
 import six
-from bottle import request, static_file
+from bottle import request, static_file, HTTPError
 from mock.mock import mock_open, patch
 from nose.plugins.attrib import attr
 from parameterized import parameterized
@@ -783,6 +783,25 @@ ProgramFiles(x86)=C:\Program Files (x86)
         tools.download("http://localhost:%s/basic-auth/user/passwd" % http_server.port, dest,
                        headers={"Authorization": "Basic dXNlcjpwYXNzd2Q="}, overwrite=True,
                        requester=requests, out=out)
+        http_server.stop()
+
+    @attr("slow")
+    def download_unathorized_test(self):
+        http_server = StoppableThreadBottle()
+
+        @http_server.server.get('/forbidden')
+        def get_forbidden():
+            return HTTPError(403, "Access denied.")
+
+        http_server.run_server()
+
+        out = TestBufferConanOutput()
+        dest = os.path.join(temp_folder(), "manual.html")
+        # Not authorized
+        with self.assertRaises(ConanException):
+            tools.download("http://localhost:%s/forbidden" % http_server.port, dest,
+                           requester=requests, out=out)
+
         http_server.stop()
 
     @parameterized.expand([

--- a/conans/test/unittests/util/tools_test.py
+++ b/conans/test/unittests/util/tools_test.py
@@ -25,7 +25,7 @@ from conans.client.runner import ConanRunner
 from conans.client.tools.files import replace_in_file, which
 from conans.client.tools.oss import check_output, OSInfo
 from conans.client.tools.win import vcvars_dict, vswhere
-from conans.errors import ConanException, NotFoundException
+from conans.errors import ConanException, NotFoundException, AuthenticationException
 from conans.model.build_info import CppInfo
 from conans.model.settings import Settings
 from conans.test.utils.conanfile import ConanFileMock
@@ -798,7 +798,7 @@ ProgramFiles(x86)=C:\Program Files (x86)
         out = TestBufferConanOutput()
         dest = os.path.join(temp_folder(), "manual.html")
         # Not authorized
-        with self.assertRaises(ConanException):
+        with six.assertRaisesRegex(self, AuthenticationException, "403"):
             tools.download("http://localhost:%s/forbidden" % http_server.port, dest,
                            requester=requests, out=out)
 


### PR DESCRIPTION
Changelog: Bugfix: Fix uninformative crash when ``tools.download()`` gets a 403 and it is not providing an ``auth`` field.
Docs: Omit

Close #6316
#tags: slow
