### PR TITLE
Fixing readout of backslashes for virtualenv generator (#6301)

### DIFF
--- a/conans/client/generators/virtualenv.py
+++ b/conans/client/generators/virtualenv.py
@@ -15,7 +15,7 @@ sh_activate_tpl = Template(textwrap.dedent("""
     export CONAN_OLD_{{it}}="${{it}}"
     {%- endfor %}
 
-    while read line; do
+    while read -r line; do
         LINE="$(eval echo $line)";
         export "$LINE";
     done < "{{ environment_file }}"


### PR DESCRIPTION
Changelog: (Bugfix): Fixing readout of backslashes for virtualenv generator (#6301 )