### PR TITLE
Use 'six.string_types' to check if default options are strings

### DIFF
--- a/conans/model/conan_file.py
+++ b/conans/model/conan_file.py
@@ -1,6 +1,8 @@
 import os
 from contextlib import contextmanager
 
+import six
+
 from conans.client import tools
 from conans.client.output import ScopedOutput
 from conans.client.tools.env import environment_append, no_op, pythonpath
@@ -23,7 +25,7 @@ def create_options(conanfile):
         if default_options:
             if isinstance(default_options, (list, tuple, dict)):
                 default_values = OptionsValues(default_options)
-            elif isinstance(default_options, str):
+            elif isinstance(default_options, six.string_types):
                 default_values = OptionsValues.loads(default_options)
             else:
                 raise ConanException("Please define your default_options as list, "

--- a/conans/test/integration/options_test.py
+++ b/conans/test/integration/options_test.py
@@ -2,7 +2,6 @@ import os
 import textwrap
 import unittest
 
-from conans.client.tools.env import environment_append
 from conans.paths import CONANINFO
 from conans.test.utils.tools import NO_SETTINGS_PACKAGE_ID, TestClient, GenConanfile
 from conans.util.files import load
@@ -207,18 +206,16 @@ class MyConanFile(ConanFile):
 
     def test_default_options_unicode(self):
         conanfile = textwrap.dedent("""
-            import os
             from conans import ConanFile
             
             class Recipe(ConanFile):
                 options = {"config": "ANY"}
-                default_options = {"config": os.environ["OPTION_VALUE"]}
+                default_options = {"config": u"unicode_option_value"}
         """)
 
         t = TestClient()
         t.save({"conanfile.py": conanfile})
-        with environment_append({"OPTION_VALUE": "whatever"}):
-            t.run("export . name/version@")
+        t.run("export . name/version@")
 
         print(t.out)
         self.assertIn("name/version: Exported revision:", t.out)

--- a/conans/test/integration/options_test.py
+++ b/conans/test/integration/options_test.py
@@ -2,6 +2,7 @@ import os
 import textwrap
 import unittest
 
+from conans.client.tools.env import environment_append
 from conans.paths import CONANINFO
 from conans.test.utils.tools import NO_SETTINGS_PACKAGE_ID, TestClient, GenConanfile
 from conans.util.files import load
@@ -203,6 +204,24 @@ class MyConanFile(ConanFile):
         self.assertIn("Boolean evaluation", client.out)
         self.assertNotIn("None evaluation", client.out)
         self.assertNotIn("String evaluation", client.out)
+
+    def test_default_options_unicode(self):
+        conanfile = textwrap.dedent("""
+            import os
+            from conans import ConanFile
+            
+            class Recipe(ConanFile):
+                options = {"config": "ANY"}
+                default_options = {"config": os.environ["OPTION_VALUE"]}
+        """)
+
+        t = TestClient()
+        t.save({"conanfile.py": conanfile})
+        with environment_append({"OPTION_VALUE": "whatever"}):
+            t.run("export . name/version@")
+
+        print(t.out)
+        self.assertIn("name/version: Exported revision:", t.out)
 
     def general_scope_options_test(self):
         # https://github.com/conan-io/conan/issues/2538

--- a/conans/test/integration/options_test.py
+++ b/conans/test/integration/options_test.py
@@ -204,22 +204,6 @@ class MyConanFile(ConanFile):
         self.assertNotIn("None evaluation", client.out)
         self.assertNotIn("String evaluation", client.out)
 
-    def test_default_options_unicode(self):
-        conanfile = textwrap.dedent("""
-            from conans import ConanFile
-            
-            class Recipe(ConanFile):
-                options = {"config": "ANY"}
-                default_options = {"config": u"unicode_option_value"}
-        """)
-
-        t = TestClient()
-        t.save({"conanfile.py": conanfile})
-        t.run("export . name/version@")
-
-        print(t.out)
-        self.assertIn("name/version: Exported revision:", t.out)
-
     def general_scope_options_test(self):
         # https://github.com/conan-io/conan/issues/2538
         client = TestClient()


### PR DESCRIPTION
Changelog: Fix: use `six.string_types` to check if _default options_ are strings
Docs: omit

I'm not able to reproduce the issue in our CI, but I think that it is safe to merge this change.

closes #6321 
