### PR TITLE
Bugfix: Request text mode to Popen to avoid buffering warning (python 3.8)

### DIFF
--- a/conans/client/conf/detect.py
+++ b/conans/client/conf/detect.py
@@ -10,7 +10,8 @@ from conans.model.version import Version
 
 
 def _execute(command):
-    proc = Popen(command, shell=True, bufsize=1, stdout=PIPE, stderr=STDOUT)
+    proc = Popen(command, shell=True, bufsize=1, universal_newlines=True, stdout=PIPE,
+                 stderr=STDOUT)
 
     output_buffer = []
     while True:


### PR DESCRIPTION
Changelog: Fix: Avoid warning in "detect" process with Python 3.8, due to Popen with ``bufsize=1``
Docs: omit

Closes #6332

This is a possible solution to the issue, the other one is to remove the bufsize argument but seeing that the code parses line by line this seems more appropriate.

From the commit message:

Python 3.8 started reporting warnings when binary files are opened with
bufsize > 0, see https://bugs.python.org/issue32236 for the change and
https://github.com/benoitc/gunicorn/issues/2091 for a similar issue.

The error message was:

py.warnings: WARNING: /usr/lib/python3.8/subprocess.py:844: RuntimeWarning: line buffering (buffering=1) isn't supported in binary mode, the default buffer size will be used



----

- [x] Refer to the issue that supports this Pull Request.
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [x I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 

<sup>**Note:** By default this PR will skip the slower tests and will use a limited set of python versions. Check [here](https://github.com/conan-io/conan/blob/develop/.github/PR_INCREASE_TESTING.md) how to increase the testing level by writing some tags in the current PR body text.</sup>
