### PR TITLE
Opt-in to store SCM evaluated data into 'conandata.yml' file

### DIFF
--- a/conans/client/cmd/export.py
+++ b/conans/client/cmd/export.py
@@ -3,6 +3,7 @@ import os
 import shutil
 
 import six
+import yaml
 
 from conans.client.file_copier import FileCopier
 from conans.client.output import Color, ScopedOutput
@@ -59,6 +60,7 @@ def cmd_export(app, conanfile_path, name, version, user, channel, keep_source,
     """
     loader, cache, hook_manager, output = app.loader, app.cache, app.hook_manager, app.out
     revisions_enabled = app.config.revisions_enabled
+    scm_to_conandata = app.config.scm_to_conandata
     conanfile = loader.load_export(conanfile_path, name, version, user, channel)
 
     # FIXME: Conan 2.0, deprecate CONAN_USER AND CONAN_CHANNEL and remove this try excepts
@@ -123,8 +125,8 @@ def cmd_export(app, conanfile_path, name, version, user, channel, keep_source,
         # Calculate the "auto" values and replace in conanfile.py
         scm_data, local_src_folder = _capture_scm_auto_fields(conanfile,
                                                               os.path.dirname(conanfile_path),
-                                                              package_layout.export(), output,
-                                                              ignore_dirty)
+                                                              package_layout, output,
+                                                              ignore_dirty, scm_to_conandata)
         # Clear previous scm_folder
         modified_recipe = False
         scm_sources_folder = package_layout.scm_sources()
@@ -218,7 +220,7 @@ def _check_settings_for_warnings(conanfile, output):
         pass
 
 
-def _capture_scm_auto_fields(conanfile, conanfile_dir, destination_folder, output, ignore_dirty):
+def _capture_scm_auto_fields(conanfile, conanfile_dir, package_layout, output, ignore_dirty, scm_to_conandata):
     """Deduce the values for the scm auto fields or functions assigned to 'url' or 'revision'
        and replace the conanfile.py contents.
        Returns a tuple with (scm_data, path_to_scm_local_directory)"""
@@ -232,7 +234,7 @@ def _capture_scm_auto_fields(conanfile, conanfile_dir, destination_folder, outpu
 
     if not captured:
         # We replace not only "auto" values, also evaluated functions (e.g from a python_require)
-        _replace_scm_data_in_conanfile(os.path.join(destination_folder, "conanfile.py"), scm_data)
+        _replace_scm_data_in_recipe(package_layout, scm_data, scm_to_conandata)
         return scm_data, None
 
     if not scm.is_pristine() and not ignore_dirty:
@@ -260,9 +262,27 @@ def _capture_scm_auto_fields(conanfile, conanfile_dir, destination_folder, outpu
         output.success("Revision deduced by 'auto': %s" % scm_data.revision)
 
     local_src_path = scm.get_local_path_to_url(scm_data.url)
-    _replace_scm_data_in_conanfile(os.path.join(destination_folder, "conanfile.py"), scm_data)
+    _replace_scm_data_in_recipe(package_layout, scm_data, scm_to_conandata)
 
     return scm_data, local_src_path
+
+
+def _replace_scm_data_in_recipe(package_layout, scm_data, scm_to_conandata):
+    if scm_to_conandata:
+        conandata_path = os.path.join(package_layout.export(), DATA_YML)
+        conandata_yml = {}
+        if os.path.exists(conandata_path):
+            conandata_yml = yaml.safe_load(load(conandata_path))
+            if '.conan' in conandata_yml:
+                raise ConanException("Field '.conan' inside '{}' file is reserved to Conan usage.".format(DATA_YML))
+        scm_data_copied = scm_data.copy()
+        scm_data_copied.pop('username', None)
+        scm_data_copied.pop('password', None)
+        conandata_yml['.conan'] = {'scm_data': scm_data_copied}
+
+        yaml.safe_dump(conandata_yml, default_flow_style=False)
+    else:
+        _replace_scm_data_in_conanfile(package_layout.conanfile(), scm_data)
 
 
 def _replace_scm_data_in_conanfile(conanfile_path, scm_data):

--- a/conans/client/cmd/export.py
+++ b/conans/client/cmd/export.py
@@ -278,7 +278,7 @@ def _replace_scm_data_in_recipe(package_layout, scm_data, scm_to_conandata):
         scm_data_copied = scm_data.as_dict()
         scm_data_copied.pop('username', None)
         scm_data_copied.pop('password', None)
-        conandata_yml['.conan'] = {'scm_data': scm_data_copied}
+        conandata_yml['.conan'] = {'scm': scm_data_copied}
 
         save(conandata_path, yaml.safe_dump(conandata_yml, default_flow_style=False))
     else:

--- a/conans/client/cmd/export.py
+++ b/conans/client/cmd/export.py
@@ -275,12 +275,12 @@ def _replace_scm_data_in_recipe(package_layout, scm_data, scm_to_conandata):
             conandata_yml = yaml.safe_load(load(conandata_path))
             if '.conan' in conandata_yml:
                 raise ConanException("Field '.conan' inside '{}' file is reserved to Conan usage.".format(DATA_YML))
-        scm_data_copied = scm_data.copy()
+        scm_data_copied = scm_data.as_dict()
         scm_data_copied.pop('username', None)
         scm_data_copied.pop('password', None)
         conandata_yml['.conan'] = {'scm_data': scm_data_copied}
 
-        yaml.safe_dump(conandata_yml, default_flow_style=False)
+        save(conandata_path, yaml.safe_dump(conandata_yml, default_flow_style=False))
     else:
         _replace_scm_data_in_conanfile(package_layout.conanfile(), scm_data)
 

--- a/conans/client/conan_api.py
+++ b/conans/client/conan_api.py
@@ -188,7 +188,7 @@ class ConanApp(object):
         self.range_resolver = RangeResolver(self.cache, self.remote_manager)
         self.python_requires = ConanPythonRequire(self.proxy, self.range_resolver)
         self.pyreq_loader = PyRequireLoader(self.proxy, self.range_resolver)
-        self.loader = ConanFileLoader(self.runner, self.out, self.python_requires, self.pyreq_loader, self.config)
+        self.loader = ConanFileLoader(self.runner, self.out, self.python_requires, self.pyreq_loader)
 
         self.binaries_analyzer = GraphBinariesAnalyzer(self.cache, self.out, self.remote_manager)
         self.graph_manager = GraphManager(self.out, self.cache, self.remote_manager, self.loader,

--- a/conans/client/conan_api.py
+++ b/conans/client/conan_api.py
@@ -188,7 +188,7 @@ class ConanApp(object):
         self.range_resolver = RangeResolver(self.cache, self.remote_manager)
         self.python_requires = ConanPythonRequire(self.proxy, self.range_resolver)
         self.pyreq_loader = PyRequireLoader(self.proxy, self.range_resolver)
-        self.loader = ConanFileLoader(self.runner, self.out, self.python_requires, self.pyreq_loader)
+        self.loader = ConanFileLoader(self.runner, self.out, self.python_requires, self.pyreq_loader, self.config)
 
         self.binaries_analyzer = GraphBinariesAnalyzer(self.cache, self.out, self.remote_manager)
         self.graph_manager = GraphManager(self.out, self.cache, self.remote_manager, self.loader,

--- a/conans/client/conf/__init__.py
+++ b/conans/client/conf/__init__.py
@@ -155,6 +155,7 @@ default_package_id_mode = semver_direct_mode # environment CONAN_DEFAULT_PACKAGE
 # temp_test_folder = True             # environment CONAN_TEMP_TEST_FOLDER
 
 # cacert_path                         # environment CONAN_CACERT_PATH
+# scm_to_conandata                    # environment CONAN_SCM_TO_CONANDATA
 
 [storage]
 # This is the default path, but you can write your own. It must be an absolute path or a
@@ -389,6 +390,16 @@ class ConanClientConfigParser(ConfigParser, object):
                 except ConanException:
                     return False
             return revisions_enabled.lower() in ("1", "true")
+        except ConanException:
+            return False
+
+    @property
+    def scm_to_conandata(self):
+        try:
+            scm_to_conandata = get_env("CONAN_SCM_TO_CONANDATA")
+            if scm_to_conandata is None:
+                scm_to_conandata = self.get_item("general.scm_to_conandata")
+            return scm_to_conandata.lower() in ("1", "true")
         except ConanException:
             return False
 

--- a/conans/client/loader.py
+++ b/conans/client/loader.py
@@ -65,7 +65,6 @@ class ConanFileLoader(object):
             if conan_data and '.conan' in conan_data:
                 scm_data = conan_data['.conan'].get('scm_data')
                 if scm_data:
-                    assert hasattr(conanfile, 'scm')  # TODO: Remove the assert, just in case, but this has to be true
                     conanfile.scm.update(scm_data)
 
             self._cached_conanfile_classes[conanfile_path] = (conanfile, lock_python_requires, module)

--- a/conans/client/loader.py
+++ b/conans/client/loader.py
@@ -63,7 +63,7 @@ class ConanFileLoader(object):
             conan_data = self._load_data(conanfile_path)
             conanfile.conan_data = conan_data
             if conan_data and '.conan' in conan_data:
-                scm_data = conan_data['.conan'].get('scm_data')
+                scm_data = conan_data['.conan'].get('scm')
                 if scm_data:
                     conanfile.scm.update(scm_data)
 

--- a/conans/client/loader.py
+++ b/conans/client/loader.py
@@ -59,10 +59,16 @@ class ConanFileLoader(object):
             if self._pyreq_loader:
                 self._pyreq_loader.load_py_requires(conanfile, lock_python_requires, self)
 
-            conanfile.conan_data = self._load_data(conanfile_path)
+            # Load and populate dynamic fields from the data file
+            conan_data = self._load_data(conanfile_path)
+            conanfile.conan_data = conan_data
+            if conan_data and '.conan' in conan_data:
+                scm_data = conan_data['.conan'].get('scm_data')
+                if scm_data:
+                    assert hasattr(conanfile, 'scm')  # TODO: Remove the assert, just in case, but this has to be true
+                    conanfile.scm.update(scm_data)
 
-            self._cached_conanfile_classes[conanfile_path] = (conanfile, lock_python_requires,
-                                                              module)
+            self._cached_conanfile_classes[conanfile_path] = (conanfile, lock_python_requires, module)
             return conanfile(self._output, self._runner, display, user, channel), module
         except ConanException as e:
             raise ConanException("Error loading conanfile at '{}': {}".format(conanfile_path, e))

--- a/conans/model/scm.py
+++ b/conans/model/scm.py
@@ -61,7 +61,7 @@ class SCMData(object):
             return self.revision
         raise ConanException("Not implemented recipe revision for %s" % self.type)
 
-    def __repr__(self):
+    def as_dict(self):
         d = {"url": self.url, "revision": self.revision, "username": self.username,
              "password": self.password, "type": self.type,
              "subfolder": self.subfolder, "submodule": self.submodule}
@@ -70,6 +70,10 @@ class SCMData(object):
         if self.verify_ssl != self.VERIFY_SSL_DEFAULT:
             d.update({"verify_ssl": self.verify_ssl})
         d = {k: v for k, v in d.items() if v is not None}
+        return d
+
+    def __repr__(self):
+        d = self.as_dict()
 
         def _kv_to_string(key, value):
             if isinstance(value, bool):

--- a/conans/test/functional/scm/test_scm_to_conandata.py
+++ b/conans/test/functional/scm/test_scm_to_conandata.py
@@ -1,28 +1,18 @@
 import os
+import tempfile
 import textwrap
 import unittest
 
 import yaml
 
-from conans.model.ref import ConanFileReference
-from conans.paths import DATA_YML
-from conans.test.utils.tools import TestClient, create_local_git_repo
-from conans.util.files import load, save_files
-import codecs
-import os
-import shutil
-import tempfile
-import unittest
-from conans.test.utils.tools import NO_SETTINGS_PACKAGE_ID, TestBufferConanOutput, TestClient
-import uuid
-
-import six
-
-from conans.client.cmd.export import _replace_scm_data_in_conanfile
 from conans.client.graph.python_requires import ConanPythonRequire
 from conans.client.loader import ConanFileLoader
-from conans.test.utils.tools import try_remove_readonly
+from conans.model.ref import ConanFileReference
+from conans.paths import DATA_YML
+from conans.test.utils.tools import TestBufferConanOutput, TestClient
+from conans.test.utils.tools import create_local_git_repo
 from conans.util.files import load
+from conans.util.files import save_files
 
 
 class SCMDataToConanDataTestCase(unittest.TestCase):
@@ -107,7 +97,7 @@ class SCMDataToConanDataTestCase(unittest.TestCase):
                        "username": "myuser", "password": os.environ.get("SECRET", None),}
         """)
         t = TestClient()
-        save_files({'conanfile.py': conanfile,
+        t.save({'conanfile.py': conanfile,
                 DATA_YML: yaml.safe_dump({'.conan': {'scm_data': {}}}, default_flow_style=False)})
 
         # Without activating the behavior, it works

--- a/conans/test/functional/scm/test_scm_to_conandata.py
+++ b/conans/test/functional/scm/test_scm_to_conandata.py
@@ -39,14 +39,16 @@ class SCMDataToConanDataTestCase(unittest.TestCase):
         self.assertEqual(exported_conanfile, conanfile)
         exported_conandata = load(os.path.join(package_layout.export(), DATA_YML))
         conan_data = yaml.safe_load(exported_conandata)
-        self.assertDictEqual(conan_data['.conan']['scm_data'], {"type": "git", "url": "myurl", "revision": "myrev"})
+        self.assertDictEqual(conan_data['.conan']['scm'], {"type": "git", "url": "myurl", "revision": "myrev"})
 
         # Check the recipe gets the proper values
         t.run("inspect name/version@ -a scm")
         self.assertIn("password: None", t.out)
+        self.assertIn("username: myuser", t.out)
         with environment_append({"SECRET": "42"}):
             t.run("inspect name/version@ -a scm")
             self.assertIn("password: 42", t.out)
+            self.assertIn("username: myuser", t.out)
 
     def test_save_special_chars(self):
         conanfile = textwrap.dedent("""
@@ -68,8 +70,8 @@ class SCMDataToConanDataTestCase(unittest.TestCase):
         self.assertEqual(exported_conanfile, conanfile)
         exported_conandata = load(os.path.join(package_layout.export(), DATA_YML))
         conan_data = yaml.safe_load(exported_conandata)
-        self.assertDictEqual(conan_data['.conan']['scm_data'], {"type": "git", "url": 'weir"d', "revision": 123,
-                                                                "subfolder": "weir\"d", "submodule": "don't"})
+        self.assertDictEqual(conan_data['.conan']['scm'], {"type": "git", "url": 'weir"d', "revision": 123,
+                                                           "subfolder": "weir\"d", "submodule": "don't"})
 
         # Check the recipe gets the proper values
         t.run("inspect name/version@ -a scm")
@@ -100,8 +102,8 @@ class SCMDataToConanDataTestCase(unittest.TestCase):
         self.assertEqual(exported_conanfile, conanfile)
         exported_conandata = load(os.path.join(package_layout.export(), DATA_YML))
         conan_data = yaml.safe_load(exported_conandata)
-        self.assertDictEqual(conan_data['.conan']['scm_data'], {"type": "git", "url": 'https://myrepo.com.git',
-                                                                "revision": commit})
+        self.assertDictEqual(conan_data['.conan']['scm'], {"type": "git", "url": 'https://myrepo.com.git',
+                                                           "revision": commit})
 
         # Check the recipe gets the proper values
         t.run("inspect name/version@ -a scm")
@@ -145,7 +147,7 @@ class ParseSCMFromConanDataTestCase(unittest.TestCase):
         """)
         conan_data = {
             'something_else': {},
-            '.conan': {'scm_data': {
+            '.conan': {'scm': {
                 'type': 'git',
                 'url': 'http://myrepo.com',
                 'shallow': False,
@@ -156,4 +158,4 @@ class ParseSCMFromConanDataTestCase(unittest.TestCase):
                                  DATA_YML: yaml.safe_dump(conan_data, default_flow_style=False)})
 
         conanfile, _ = self.loader.load_basic_module(conanfile_path=os.path.join(test_folder, 'conanfile.py'))
-        self.assertDictEqual(conanfile.scm, conan_data['.conan']['scm_data'])
+        self.assertDictEqual(conanfile.scm, conan_data['.conan']['scm'])

--- a/conans/test/functional/scm/test_scm_to_conandata.py
+++ b/conans/test/functional/scm/test_scm_to_conandata.py
@@ -1,0 +1,147 @@
+import os
+import textwrap
+import unittest
+
+import yaml
+
+from conans.model.ref import ConanFileReference
+from conans.paths import DATA_YML
+from conans.test.utils.tools import TestClient, create_local_git_repo
+from conans.util.files import load, save_files
+import codecs
+import os
+import shutil
+import tempfile
+import unittest
+from conans.test.utils.tools import NO_SETTINGS_PACKAGE_ID, TestBufferConanOutput, TestClient
+import uuid
+
+import six
+
+from conans.client.cmd.export import _replace_scm_data_in_conanfile
+from conans.client.graph.python_requires import ConanPythonRequire
+from conans.client.loader import ConanFileLoader
+from conans.test.utils.tools import try_remove_readonly
+from conans.util.files import load
+
+
+class SCMDataToConanDataTestCase(unittest.TestCase):
+    ref = ConanFileReference.loads("name/version@")
+
+    def test_plain_recipe(self):
+        conanfile = textwrap.dedent("""
+            import os
+            from conans import ConanFile
+            
+            class Recipe(ConanFile):
+                scm = {"type": "git", "url": "myurl", "revision": "myrev",
+                       "username": "myuser", "password": os.environ.get("SECRET", None),}
+        """)
+        t = TestClient()
+        t.save({'conanfile.py': conanfile})
+        t.run("config set general.scm_to_conandata=1")
+        t.run("export . name/version@")
+
+        # Check exported files
+        package_layout = t.cache.package_layout(self.ref)
+        exported_conanfile = load(package_layout.conanfile())
+        self.assertEqual(exported_conanfile, conanfile)
+        exported_conandata = load(os.path.join(package_layout.export(), DATA_YML))
+        conan_data = yaml.safe_load(exported_conandata)
+        self.assertDictEqual(conan_data['.conan']['scm_data'], {"type": "git", "url": "myurl", "revision": "myrev"})
+
+    def test_save_special_chars(self):
+        conanfile = textwrap.dedent("""
+            import os
+            from conans import ConanFile
+
+            class Recipe(ConanFile):
+                scm = {"type": "git", "url": 'weir"d', "revision": 123,
+                       "subfolder": "weir\\"d", "submodule": "don't"}
+        """)
+        t = TestClient()
+        t.save({'conanfile.py': conanfile})
+        t.run("config set general.scm_to_conandata=1")
+        t.run("export . name/version@")
+
+        # Check exported files
+        package_layout = t.cache.package_layout(self.ref)
+        exported_conanfile = load(package_layout.conanfile())
+        self.assertEqual(exported_conanfile, conanfile)
+        exported_conandata = load(os.path.join(package_layout.export(), DATA_YML))
+        conan_data = yaml.safe_load(exported_conandata)
+        self.assertDictEqual(conan_data['.conan']['scm_data'], {"type": "git", "url": 'weir"d', "revision": 123,
+                                                                "subfolder": "weir\"d", "submodule": "don't"})
+
+    def test_auto_is_replaced(self):
+        conanfile = textwrap.dedent("""
+            import os
+            from conans import ConanFile
+
+            class Recipe(ConanFile):
+                scm = {"type": "git", "url": "auto", "revision": "auto"}
+        """)
+        t = TestClient()
+        t.save({'conanfile.py': conanfile})
+        _, commit = create_local_git_repo(folder=t.current_folder)
+        t.run_command('git remote add origin https://myrepo.com.git')
+        t.run("config set general.scm_to_conandata=1")
+        t.run("export . name/version@")
+
+        # Check exported files
+        package_layout = t.cache.package_layout(self.ref)
+        exported_conanfile = load(package_layout.conanfile())
+        self.assertEqual(exported_conanfile, conanfile)
+        exported_conandata = load(os.path.join(package_layout.export(), DATA_YML))
+        conan_data = yaml.safe_load(exported_conandata)
+        self.assertDictEqual(conan_data['.conan']['scm_data'], {"type": "git", "url": 'https://myrepo.com.git',
+                                                                "revision": commit})
+
+    def test_existing_field(self):
+        conanfile = textwrap.dedent("""
+            import os
+            from conans import ConanFile
+
+            class Recipe(ConanFile):
+                scm = {"type": "git", "url": "myurl", "revision": "myrev",
+                       "username": "myuser", "password": os.environ.get("SECRET", None),}
+        """)
+        t = TestClient()
+        save_files({'conanfile.py': conanfile,
+                DATA_YML: yaml.safe_dump({'.conan': {'scm_data': {}}}, default_flow_style=False)})
+
+        # Without activating the behavior, it works
+        t.run("export . name/version@")
+
+        # It fails with it activated
+        t.run("config set general.scm_to_conandata=1")
+        t.run("export . name/version@", assert_error=True)
+        self.assertIn("ERROR: Field '.conan' inside 'conandata.yml' file is reserved to Conan usage.", t.out)
+
+
+class ParseSCMFromConanDataTestCase(unittest.TestCase):
+    loader = ConanFileLoader(runner=None, output=TestBufferConanOutput(),
+                             python_requires=ConanPythonRequire(None, None))
+
+    def test_parse_data(self):
+        conanfile = textwrap.dedent("""
+            import os
+            from conans import ConanFile
+
+            class Recipe(ConanFile):
+                scm = {"type": "git", "url": "auto", "revision": "auto"}
+        """)
+        conan_data = {
+            'something_else': {},
+            '.conan': {'scm_data': {
+                'type': 'git',
+                'url': 'http://myrepo.com',
+                'shallow': False,
+                'revision': 'abcdefghijk'
+            }}}
+        test_folder = tempfile.mkdtemp()
+        save_files(test_folder, {'conanfile.py': conanfile,
+                                 DATA_YML: yaml.safe_dump(conan_data, default_flow_style=False)})
+
+        conanfile, _ = self.loader.load_basic_module(conanfile_path=os.path.join(test_folder, 'conanfile.py'))
+        self.assertDictEqual(conanfile.scm, conan_data['.conan']['scm_data'])

--- a/conans/test/unittests/client/cmd/export/test_capture_export_scm_data.py
+++ b/conans/test/unittests/client/cmd/export/test_capture_export_scm_data.py
@@ -12,9 +12,10 @@ from conans.model.ref import ConanFileReference
 from conans.test.utils.test_files import temp_folder
 from conans.test.utils.tools import create_local_git_repo, TestBufferConanOutput
 from conans.util.files import save
+from conans.paths.package_layouts.package_cache_layout import PackageCacheLayout
 
 
-@mock.patch("conans.client.cmd.export._replace_scm_data_in_conanfile", return_value=None)
+@mock.patch("conans.client.cmd.export._replace_scm_data_in_recipe", return_value=None)
 class CaptureExportSCMDataTest(unittest.TestCase):
 
     def setUp(self):
@@ -45,9 +46,10 @@ class CaptureExportSCMDataTest(unittest.TestCase):
         scm_data, _ = _capture_scm_auto_fields(
             conanfile=conanfile,
             conanfile_dir=self.conanfile_dir,
-            destination_folder="",
+            package_layout="",
             output=output,
-            ignore_dirty=True)
+            ignore_dirty=True,
+            scm_to_conandata=False)
 
         self.assertEqual(scm_data.url, url)
         self.assertEqual(scm_data.revision, self.rev)
@@ -71,9 +73,10 @@ class CaptureExportSCMDataTest(unittest.TestCase):
         scm_data, _ = _capture_scm_auto_fields(
             conanfile=conanfile,
             conanfile_dir=self.conanfile_dir,
-            destination_folder="",
+            package_layout="",
             output=output,
-            ignore_dirty=False)
+            ignore_dirty=False,
+            scm_to_conandata=False)
 
         self.assertEqual(scm_data.url, url)
         if is_pristine:
@@ -100,9 +103,10 @@ class CaptureExportSCMDataTest(unittest.TestCase):
         scm_data, _ = _capture_scm_auto_fields(
                     conanfile=conanfile,
                     conanfile_dir=self.conanfile_dir,
-                    destination_folder="",
+                    package_layout="",
                     output=output,
-                    ignore_dirty=True)
+                    ignore_dirty=True,
+                    scm_to_conandata=False)
 
         self.assertEqual(scm_data.url, url)
         self.assertEqual(scm_data.revision, self.rev)

--- a/conans/test/unittests/client/cmd/export/test_capture_export_scm_data.py
+++ b/conans/test/unittests/client/cmd/export/test_capture_export_scm_data.py
@@ -46,7 +46,7 @@ class CaptureExportSCMDataTest(unittest.TestCase):
         scm_data, _ = _capture_scm_auto_fields(
             conanfile=conanfile,
             conanfile_dir=self.conanfile_dir,
-            package_layout="",
+            package_layout=None,
             output=output,
             ignore_dirty=True,
             scm_to_conandata=False)
@@ -73,7 +73,7 @@ class CaptureExportSCMDataTest(unittest.TestCase):
         scm_data, _ = _capture_scm_auto_fields(
             conanfile=conanfile,
             conanfile_dir=self.conanfile_dir,
-            package_layout="",
+            package_layout=None,
             output=output,
             ignore_dirty=False,
             scm_to_conandata=False)
@@ -103,7 +103,7 @@ class CaptureExportSCMDataTest(unittest.TestCase):
         scm_data, _ = _capture_scm_auto_fields(
                     conanfile=conanfile,
                     conanfile_dir=self.conanfile_dir,
-                    package_layout="",
+                    package_layout=None,
                     output=output,
                     ignore_dirty=True,
                     scm_to_conandata=False)


### PR DESCRIPTION
Changelog: Feature: Add opt-in `scm_to_conandata` for the SCM feature: Conan will store the data from the SCM attribute in the `conandata.yml` file (except the fields `username` and `password`)
Docs: https://github.com/conan-io/docs/pull/1522

Add an opt-in to store the fields evaluated from the `scm` attribute into the `conandata.yml` file (all fields except `username` and `password`). This way the recipe itself, the `conanfile.py` is not modified by Conan. Note.- This could be the default behavior for Conan 2.0 and remove the previous implementation.

closes #6275

- [x] Fields in the `conandata.yml` file (to be defined):

   ```yml
   .conan:
       scm:
           url: ....
           revision: ...
   ```

- [x] Config variable name: `general.scm_to_conandata`