### PR TITLE
Require user input to continue working with Python 2

### DIFF
--- a/conans/client/command.py
+++ b/conans/client/command.py
@@ -1,11 +1,12 @@
+import argparse
 import inspect
 import json
 import os
 import sys
-
-import argparse
 from argparse import ArgumentError
 from difflib import get_close_matches
+
+from six.moves import input as raw_input
 
 from conans import __version__ as client_version
 from conans.client.cmd.uploader import UPLOAD_POLICY_FORCE, \
@@ -1897,21 +1898,34 @@ class Command(object):
         self._out.writeln("")
 
     def _warn_python_version(self):
+        import textwrap
+
+        width = 70
         version = sys.version_info
         if version.major == 2:
-            self._out.writeln("*"*70, front=Color.BRIGHT_RED)
-            self._out.writeln("Python 2 will soon be deprecated. It is strongly "
-                              "recommended to use Python >= 3.5 with Conan:",
-                              front=Color.BRIGHT_RED)
-            self._out.writeln("https://docs.conan.io/en/latest/installation.html"
-                              "#python-2-deprecation-notice", front=Color.BRIGHT_RED)
-            self._out.writeln("*"*70, front=Color.BRIGHT_RED)
+            self._out.writeln("*"*width, front=Color.BRIGHT_RED)
+
+            self._out.writeln(textwrap.fill("Python 2 is deprecated as of 01/01/2020 and Conan has"
+                                            " stopped supporting it oficially. We strongly recommend"
+                                            " you to use Python >= 3.5 with Conan.", width), front=Color.BRIGHT_RED)
+            self._out.writeln("*"*width, front=Color.BRIGHT_RED)
+
+            if os.environ.get('USE_UNSUPPORTED_CONAN_WITH_PYTHON_2', 0):
+                self._out.warn(textwrap.fill("Python 2 deprecation notice has been bypassed"
+                                             " by envvar 'USE_UNSUPPORTED_CONAN_WITH_PYTHON_2'", width))
+            else:
+                self._out.write(textwrap.fill("Understood the risk, keep going [y/N]: ", width,
+                                              drop_whitespace=False), front=Color.BRIGHT_RED)
+                ret = raw_input().lower()
+                if ret not in ["yes", "ye", "y"]:
+                    self._out.writeln(textwrap.fill("Wise choice. Stopping here!", width))
+                    sys.exit(0)
         elif version.minor == 4:
-            self._out.writeln("*"*70, front=Color.BRIGHT_RED)
-            self._out.writeln("Python 3.4 support has been dropped. It is strongly "
-                              "recommended to use Python >= 3.5 with Conan",
+            self._out.writeln("*"*width, front=Color.BRIGHT_RED)
+            self._out.writeln(textwrap.fill("Python 3.4 support has been dropped. It is strongly "
+                                            "recommended to use Python >= 3.5 with Conan", width),
                               front=Color.BRIGHT_RED)
-            self._out.writeln("*"*70, front=Color.BRIGHT_RED)
+            self._out.writeln("*"*width, front=Color.BRIGHT_RED)
 
     def run(self, *args):
         """HIDDEN: entry point for executing commands, dispatcher to class

--- a/conans/client/command.py
+++ b/conans/client/command.py
@@ -1907,7 +1907,9 @@ class Command(object):
 
             self._out.writeln(textwrap.fill("Python 2 is deprecated as of 01/01/2020 and Conan has"
                                             " stopped supporting it oficially. We strongly recommend"
-                                            " you to use Python >= 3.5 with Conan.", width), front=Color.BRIGHT_RED)
+                                            " you to use Python >= 3.5. Conan will completely stop"
+                                            " working with Python 2 in the following releases", width),
+                              front=Color.BRIGHT_RED)
             self._out.writeln("*"*width, front=Color.BRIGHT_RED)
             if os.environ.get('USE_UNSUPPORTED_CONAN_WITH_PYTHON_2', 0):
                 # IMPORTANT: This environment variable is not a silver buller. Python 2 is currently deprecated

--- a/conans/client/command.py
+++ b/conans/client/command.py
@@ -1911,9 +1911,16 @@ class Command(object):
             self._out.writeln("*"*width, front=Color.BRIGHT_RED)
 
             if os.environ.get('USE_UNSUPPORTED_CONAN_WITH_PYTHON_2', 0):
+                # IMPORTANT: This environment variable is not a silver buller. Python 2 is currently deprecated
+                # and some libraries we use as dependencies have stopped supporting it. Conan might fail to run
+                # and we are no longer fixing errors related to Python 2.
                 self._out.warn(textwrap.fill("Python 2 deprecation notice has been bypassed"
                                              " by envvar 'USE_UNSUPPORTED_CONAN_WITH_PYTHON_2'", width))
             else:
+                self._out.writeln(textwrap.fill("If you really need to run Conan with Python 2 in your"
+                                                " CI without this interactive input, please contact us"
+                                                " at info@conan.io", width), front=Color.BRIGHT_RED)
+                self._out.writeln("*" * width, front=Color.BRIGHT_RED)
                 self._out.write(textwrap.fill("Understood the risk, keep going [y/N]: ", width,
                                               drop_whitespace=False), front=Color.BRIGHT_RED)
                 ret = raw_input().lower()

--- a/conans/client/command.py
+++ b/conans/client/command.py
@@ -1913,8 +1913,8 @@ class Command(object):
                 # IMPORTANT: This environment variable is not a silver buller. Python 2 is currently deprecated
                 # and some libraries we use as dependencies have stopped supporting it. Conan might fail to run
                 # and we are no longer fixing errors related to Python 2.
-                self._out.warn(textwrap.fill("Python 2 deprecation notice has been bypassed"
-                                             " by envvar 'USE_UNSUPPORTED_CONAN_WITH_PYTHON_2'", width))
+                self._out.writeln(textwrap.fill("Python 2 deprecation notice has been bypassed"
+                                                " by envvar 'USE_UNSUPPORTED_CONAN_WITH_PYTHON_2'", width))
             else:
                 self._out.writeln(textwrap.fill("If you really need to run Conan with Python 2 in your"
                                                 " CI without this interactive input, please contact us"

--- a/conans/client/command.py
+++ b/conans/client/command.py
@@ -1909,8 +1909,6 @@ class Command(object):
                                             " stopped supporting it oficially. We strongly recommend"
                                             " you to use Python >= 3.5 with Conan.", width), front=Color.BRIGHT_RED)
             self._out.writeln("*"*width, front=Color.BRIGHT_RED)
-
-            self._out.writeln(os.environ)
             if os.environ.get('USE_UNSUPPORTED_CONAN_WITH_PYTHON_2', 0):
                 # IMPORTANT: This environment variable is not a silver buller. Python 2 is currently deprecated
                 # and some libraries we use as dependencies have stopped supporting it. Conan might fail to run

--- a/conans/client/command.py
+++ b/conans/client/command.py
@@ -1910,6 +1910,7 @@ class Command(object):
                                             " you to use Python >= 3.5 with Conan.", width), front=Color.BRIGHT_RED)
             self._out.writeln("*"*width, front=Color.BRIGHT_RED)
 
+            self._out.writeln(os.environ)
             if os.environ.get('USE_UNSUPPORTED_CONAN_WITH_PYTHON_2', 0):
                 # IMPORTANT: This environment variable is not a silver buller. Python 2 is currently deprecated
                 # and some libraries we use as dependencies have stopped supporting it. Conan might fail to run

--- a/conans/test/functional/configuration/python_version_test.py
+++ b/conans/test/functional/configuration/python_version_test.py
@@ -17,11 +17,9 @@ class PythonVersionTest(unittest.TestCase):
 
     @unittest.skipUnless(six.PY2, "Requires Python 2.7")
     def test_py2_warning_message(self):
-        self._validate_message("Python 2 will soon be deprecated. It is strongly " \
-                               "recommended to use Python >= 3.5 with Conan")
+        self._validate_message("Python 2 is deprecated as of 01/01/2020 and Conan has stopped\nsupporting it oficially")
 
-    @unittest.skipUnless(sys.version_info.major == 3 and sys.version_info.minor == 4,
-                         "Requires Python 3.4")
+    @unittest.skipUnless(sys.version_info.major == 3 and sys.version_info.minor == 4, "Requires Python 3.4")
     def test_py34_warning_message(self):
-        self._validate_message("Python 3.4 support has been dropped. It is strongly " \
+        self._validate_message("Python 3.4 support has been dropped. It is strongly "
                                "recommended to use Python >= 3.5 with Conan")

--- a/conans/test/functional/graph_lock/graph_lock_test.py
+++ b/conans/test/functional/graph_lock/graph_lock_test.py
@@ -645,6 +645,7 @@ class GraphLockWarningsTestCase(unittest.TestCase):
         # Using the graphlock there is no warning message
         client.run("graph build-order conan.lock")
         self.assertNotIn("overridden", client.out)
+        self.assertNotIn("WARN", client.out)
 
 
 class GraphLockBuildRequireErrorTestCase(unittest.TestCase):

--- a/conans/test/functional/graph_lock/graph_lock_test.py
+++ b/conans/test/functional/graph_lock/graph_lock_test.py
@@ -645,7 +645,6 @@ class GraphLockWarningsTestCase(unittest.TestCase):
         # Using the graphlock there is no warning message
         client.run("graph build-order conan.lock")
         self.assertNotIn("overridden", client.out)
-        self.assertNotIn("WARN", client.out)
 
 
 class GraphLockBuildRequireErrorTestCase(unittest.TestCase):


### PR DESCRIPTION
Changelog: Feature: Force the user to read that Python 2 has been deprecated
Docs: https://github.com/conan-io/docs/pull/1523

closes https://github.com/conan-io/conan/issues/6170


![image](https://user-images.githubusercontent.com/1406456/72433257-31029c00-3799-11ea-8cdd-85dd18d7806e.png)


