### PR TITLE
fixing some broken tests for python 3.8

### DIFF
--- a/conans/server/service/v2/service_v2.py
+++ b/conans/server/service/v2/service_v2.py
@@ -2,7 +2,7 @@ import os
 
 from bottle import FileUpload, static_file
 
-from conans.errors import RecipeNotFoundException, PackageNotFoundException
+from conans.errors import RecipeNotFoundException, PackageNotFoundException, NotFoundException
 from conans.server.service.common.common import CommonService
 from conans.server.service.mime import get_mime_type
 from conans.server.store.server_store import ServerStore
@@ -19,7 +19,10 @@ class ConanServiceV2(CommonService):
     # RECIPE METHODS
     def get_recipe_file_list(self, ref,  auth_user):
         self._authorizer.check_read_conan(auth_user, ref)
-        file_list = self._server_store.get_recipe_file_list(ref)
+        try:
+            file_list = self._server_store.get_recipe_file_list(ref)
+        except NotFoundException:
+            raise RecipeNotFoundException(ref)
         if not file_list:
             raise RecipeNotFoundException(ref, print_rev=True)
 

--- a/conans/util/files.py
+++ b/conans/util/files.py
@@ -317,7 +317,9 @@ def gzopen_without_timestamps(name, mode="r", fileobj=None, compresslevel=None, 
         raise
 
     try:
-        t = tarfile.TarFile.taropen(name, mode, fileobj, **kwargs)
+        # Format is forced because in Python3.8, it changed and it generates different tarfiles
+        # with different checksums, which break hashes of tgzs
+        t = tarfile.TarFile.taropen(name, mode, fileobj, format=tarfile.GNU_FORMAT, **kwargs)
     except IOError:
         fileobj.close()
         if mode == 'r':


### PR DESCRIPTION
Changelog: Bugfix: Fix broken compression of .tgz files due to Python 3.8 changing tar default schema.
Docs: Omit

It seems that running under VPN or something can make some tests using URLs with .com to resolve with a 403 (cloudfare)

Also, Python 3.8 changed the default tgz tarfile format, breaking our checksums of tgz artifacts.

#tags: slow
#revisions: 1