### PR TITLE
[ci] Python 3.8

### DIFF
--- a/conans/client/cmd/export.py
+++ b/conans/client/cmd/export.py
@@ -1,6 +1,7 @@
 import ast
 import os
 import shutil
+import sys
 
 import six
 
@@ -17,6 +18,7 @@ from conans.util.files import is_dirty, load, rmdir, save, set_dirty, remove, mk
     merge_directories
 from conans.util.log import logger
 
+isPY38 = bool(sys.version_info.major == 3 and sys.version_info.minor == 8)
 
 def export_alias(package_layout, target_ref, output, revisions_enabled):
     revision_mode = "hash"
@@ -303,7 +305,14 @@ def _replace_scm_data_in_conanfile(conanfile_path, scm_data):
                                 else:
                                     next_line = tree.body[i_body+1].lineno - 1
                             else:
-                                next_line = statements[i+1].lineno - 1
+                                # Next statement can be a comment or anything else
+                                next_statement = statements[i+1]
+                                if isPY38 and isinstance(next_statement, ast.Expr):
+                                    # Python 3.8 properly parses multiline comments with start and end lines,
+                                    #  here we preserve the same (wrong) implementation of previous releases
+                                    next_line = next_statement.end_lineno - 1
+                                else:
+                                    next_line = next_statement.lineno - 1
                                 next_line_content = lines[next_line].strip()
                                 if (next_line_content.endswith('"""') or
                                         next_line_content.endswith("'''")):

--- a/conans/client/cmd/export.py
+++ b/conans/client/cmd/export.py
@@ -201,9 +201,9 @@ def _check_settings_for_warnings(conanfile, output):
     if not conanfile.settings:
         return
     try:
-        if not 'os_build' in conanfile.settings:
+        if 'os_build' not in conanfile.settings:
             return
-        if not 'os' in conanfile.settings:
+        if 'os' not in conanfile.settings:
             return
 
         output.writeln("*"*60, front=Color.BRIGHT_RED)

--- a/conans/client/conf/detect.py
+++ b/conans/client/conf/detect.py
@@ -10,7 +10,8 @@ from conans.model.version import Version
 
 
 def _execute(command):
-    proc = Popen(command, shell=True, bufsize=1, stdout=PIPE, stderr=STDOUT)
+    proc = Popen(command, shell=True, bufsize=1, universal_newlines=True, stdout=PIPE,
+                 stderr=STDOUT)
 
     output_buffer = []
     while True:


### PR DESCRIPTION
Changelog: Bugfix: Fix broken compression of .tgz files due to Python 3.8 changing tar default schema.
Changelog: Fix: Recipe substitution for `scm` (old behavior) fixed for multiline comments in Python 3.8
Docs: https://github.com/conan-io/docs/pull/1526

#PYVERS: py38
#tags: slow, svn
#revisions: 1