### PR TITLE
Less verbose cmake_find_package

### DIFF
--- a/conans/client/generators/cmake_find_package.py
+++ b/conans/client/generators/cmake_find_package.py
@@ -82,16 +82,23 @@ def find_dependency_lines(name, public_deps_names, find_modules):
                     "  set_property(TARGET %s APPEND PROPERTY %s ${tmp})" % (lib_t, prop),
                     'endif()']
 
+        lines.append("if(NOT %s_FOUND)" % dep_name)
+
         if find_modules:
-            lines.append("find_dependency(%s REQUIRED)" % dep_name)
+            lines.append("  find_dependency(%s REQUIRED)" % dep_name)
         else:
             # https://github.com/conan-io/conan/issues/4994
             # https://github.com/conan-io/conan/issues/5040
-            lines.append('if(${CMAKE_VERSION} VERSION_LESS "3.9.0")')
-            lines.append('  find_package(%s REQUIRED NO_MODULE)' % dep_name)
-            lines.append("else()")
-            lines.append('  find_dependency(%s REQUIRED NO_MODULE)' % dep_name)
-            lines.append("endif()")
+            lines.append('  if(${CMAKE_VERSION} VERSION_LESS "3.9.0")')
+            lines.append('    find_package(%s REQUIRED NO_MODULE)' % dep_name)
+            lines.append("  else()")
+            lines.append('    find_dependency(%s REQUIRED NO_MODULE)' % dep_name)
+            lines.append("  endif()")
+
+        lines.append("else()")
+        lines.append("  message(STATUS \"Dependency %s already found\")" % dep_name)
+        lines.append("endif()")
+
 
         lines.extend(property_lines("INTERFACE_LINK_LIBRARIES"))
         lines.extend(property_lines("INTERFACE_COMPILE_DEFINITIONS"))


### PR DESCRIPTION
find_package would repeat messages for common packages within the dependencies DAG. This commit skips the dependency find_package if the package was already found.

Changelog: Fix: cmake_find_package no longer seeks to find packages which are already found.
Docs: https://github.com/conan-io/docs/pull/XXXX

- [ ] Refer to the issue that supports this Pull Request.
- [ ] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [ ] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [ ] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 

<sup>**Note:** By default this PR will skip the slower tests and will use a limited set of python versions. Check [here](https://github.com/conan-io/conan/blob/develop/.github/PR_INCREASE_TESTING.md) how to increase the testing level by writing some tags in the current PR body text.</sup>
