### PR TITLE
Remove FTP test in 'master' for MacOS (avoid false positives)

### DIFF
--- a/conans/test/unittests/client/tools/net_test.py
+++ b/conans/test/unittests/client/tools/net_test.py
@@ -1,6 +1,7 @@
 # coding=utf-8
 
 import os
+import platform
 import shutil
 import tempfile
 import unittest
@@ -27,6 +28,8 @@ class ToolsNetTest(unittest.TestCase):
         net.ftp_download("test.rebex.net", filename, "demo", "password")
         self.assertTrue(os.path.exists(os.path.basename(filename)))
 
+    # FIXME. This was removed cause failures in CI, but doesn't make sense to fail only on OSX
+    @unittest.skipIf(platform.system() == "Darwin", "Fails in Macos")
     def test_ftp_anonymous(self):
         filename = "1KB.zip"
         net.ftp_download("speedtest.tele2.net", filename)
@@ -34,7 +37,7 @@ class ToolsNetTest(unittest.TestCase):
 
     def test_ftp_invalid_path(self):
         with six.assertRaisesRegex(self, ConanException,
-                                     "550 The system cannot find the file specified."):
+                                   "550 The system cannot find the file specified."):
             net.ftp_download("test.rebex.net", "invalid-file", "demo", "password")
         self.assertFalse(os.path.exists("invalid-file"))
 


### PR DESCRIPTION
Remove FTP test in 'master' for MacOS (avoid false positives)

The proposed changes match exactly the file currently in `develop`