### PR TITLE
getattr to get retry and retry_wait from config

### DIFF
--- a/conans/client/tools/net.py
+++ b/conans/client/tools/net.py
@@ -60,7 +60,7 @@ def download(url, filename, verify=True, out=None, retry=None, retry_wait=None, 
     requester = default_requester(requester, 'conans.client.tools.net.download')
     from conans.tools import _global_config as config
 
-    # It might be possible that users provide their own requester 
+    # It might be possible that users provide their own requester
     retry = retry if retry is not None else getattr(config, "retry", None)
     retry = retry if retry is not None else 1
     retry_wait = retry_wait if retry_wait is not None else getattr(config, "retry_wait", None)

--- a/conans/client/tools/net.py
+++ b/conans/client/tools/net.py
@@ -60,7 +60,7 @@ def download(url, filename, verify=True, out=None, retry=None, retry_wait=None, 
     requester = default_requester(requester, 'conans.client.tools.net.download')
     from conans.tools import _global_config as config
 
-    # It might be possible that users provide their own requester
+    # It might be possible that users provide their own requester 
     retry = retry if retry is not None else getattr(config, "retry", None)
     retry = retry if retry is not None else 1
     retry_wait = retry_wait if retry_wait is not None else getattr(config, "retry_wait", None)

--- a/conans/client/tools/net.py
+++ b/conans/client/tools/net.py
@@ -61,9 +61,9 @@ def download(url, filename, verify=True, out=None, retry=None, retry_wait=None, 
     from conans.tools import _global_config as config
 
     # It might be possible that users provide their own requester
-    retry = retry if retry is not None else config.retry
+    retry = retry if retry is not None else getattr(config, "retry", None)
     retry = retry if retry is not None else 1
-    retry_wait = retry_wait if retry_wait is not None else config.retry_wait
+    retry_wait = retry_wait if retry_wait is not None else getattr(config, "retry_wait", None)
     retry_wait = retry_wait if retry_wait is not None else 5
 
     downloader = FileDownloader(requester=requester, output=out, verify=verify, config=config)


### PR DESCRIPTION
Changelog: Fix: Get `retry` and `retry_wait` attributes with `getattr` instead of retreiving them directly to avoid failure when config is `None`.
Docs: Omit

- [X] Refer to the issue that supports this Pull Request.
- [X] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [X] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [X] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 

<sup>**Note:** By default this PR will skip the slower tests and will use a limited set of python versions. Check [here](https://github.com/conan-io/conan/blob/develop/.github/PR_INCREASE_TESTING.md) how to increase the testing level by writing some tags in the current PR body text.</sup>

#TAGS: slow