### PR TITLE
extra .props file in MSBuild helper

### DIFF
--- a/conans/client/build/msbuild.py
+++ b/conans/client/build/msbuild.py
@@ -177,7 +177,11 @@ class MSBuild(object):
             command.append('/verbosity:%s' % verbosity)
 
         if props_file_path or user_property_file_name:
-            paths = [os.path.abspath(p) for p in (props_file_path, user_property_file_name) if p]
+            paths = [os.path.abspath(props_file_path)] if props_file_path else []
+            if isinstance(user_property_file_name, list):
+                paths.extend([os.path.abspath(p) for p in user_property_file_name])
+            elif user_property_file_name:
+                paths.append(os.path.abspath(user_property_file_name))
             paths = ";".join(paths)
             command.append('/p:ForceImportBeforeCppTargets="%s"' % paths)
 

--- a/conans/client/build/msbuild.py
+++ b/conans/client/build/msbuild.py
@@ -72,6 +72,7 @@ class MSBuild(object):
         :param verbosity: Specifies verbosity level (/verbosity: parameter)
         :param definitions: Dictionary with additional compiler definitions to be applied during
         the build. Use value of None to set compiler definition with no value.
+        :param user_property_file_name: Specify a user provided .props file with custom definitions
         :return: status code of the MSBuild command invocation
         """
         property_file_name = property_file_name or "conan_build.props"

--- a/conans/test/functional/build_helpers/msbuild_test.py
+++ b/conans/test/functional/build_helpers/msbuild_test.py
@@ -151,6 +151,73 @@ class HelloConan(ConanFile):
         content = load(conan_props)
         self.assertIn("<RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>", content)
 
+    @attr('slow')
+    @unittest.skipUnless(platform.system() == "Windows", "Requires MSBuild")
+    def user_properties_multifile_test(self):
+        conan_build_vs = textwrap.dedent("""
+            from conans import ConanFile, MSBuild
+
+            class HelloConan(ConanFile):
+                exports = "*"
+                settings = "os", "build_type", "arch", "compiler"
+
+                def build(self):
+                    msbuild = MSBuild(self)
+                    msbuild.build("MyProject.sln", verbosity="normal",
+                                  definitions={"MyCustomDef": "MyCustomValue"},
+                                  user_property_file_name=["myuser.props", "myuser2.props"])
+
+                def package(self):
+                    self.copy(pattern="*.exe")
+            """)
+        client = TestClient()
+
+        files = get_vs_project_files()
+        files[CONANFILE] = conan_build_vs
+        props = textwrap.dedent("""<?xml version="1.0" encoding="utf-8"?>
+            <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+              <ImportGroup Label="PropertySheets" />
+              <PropertyGroup Label="UserMacros" />
+              <ItemDefinitionGroup>
+                <ClCompile>
+                    <PreprocessorDefinitions>MyCustomDef2=MyValue2;%(PreprocessorDefinitions)
+                    </PreprocessorDefinitions>
+                </ClCompile>
+              </ItemDefinitionGroup>
+              <ItemGroup />
+            </Project>
+            """)
+        props2 = textwrap.dedent("""<?xml version="1.0" encoding="utf-8"?>
+            <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+              <ImportGroup Label="PropertySheets" />
+              <PropertyGroup Label="UserMacros" />
+              <ItemDefinitionGroup>
+                <ClCompile>
+                  <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
+                </ClCompile>
+              </ItemDefinitionGroup>
+              <ItemGroup />
+            </Project>
+            """)
+        files["myuser.props"] = props
+        files["myuser2.props"] = props2
+
+        client.save(files)
+        client.run('create . Hello/1.2.1@lasote/stable')
+        self.assertNotIn("/EHsc /MD", client.out)
+        self.assertIn("/EHsc /MT", client.out)
+        self.assertIn("/D MyCustomDef=MyCustomValue", client.out)
+        self.assertIn("/D MyCustomDef2=MyValue2", client.out)
+        self.assertIn("Packaged 1 '.exe' file: MyProject.exe", client.out)
+
+        full_ref = "Hello/1.2.1@lasote/stable:6cc50b139b9c3d27b3e9042d5f5372d327b3a9f7"
+        pref = PackageReference.loads(full_ref)
+        build_folder = client.cache.package_layout(pref.ref).build(pref)
+        self.assertTrue(os.path.exists(os.path.join(build_folder, "myuser.props")))
+        conan_props = os.path.join(build_folder, "conan_build.props")
+        content = load(conan_props)
+        self.assertIn("<RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>", content)
+
     @unittest.skipUnless(platform.system() == "Windows", "Requires MSBuild")
     def reuse_msbuild_object_test(self):
         # https://github.com/conan-io/conan/issues/2865

--- a/conans/test/functional/build_helpers/msbuild_test.py
+++ b/conans/test/functional/build_helpers/msbuild_test.py
@@ -1,5 +1,6 @@
 import os
 import platform
+import textwrap
 import unittest
 
 from nose.plugins.attrib import attr
@@ -11,6 +12,7 @@ from conans.paths import CONANFILE
 from conans.test.utils.tools import TestClient
 from conans.test.utils.visual_project_files import get_vs_project_files
 from conans.test.utils.deprecation import catch_deprecation_warning
+from conans.util.files import load
 
 
 class MSBuildTest(unittest.TestCase):
@@ -96,6 +98,56 @@ class HelloConan(ConanFile):
         pref = PackageReference.loads(full_ref)
         build_folder = client.cache.package_layout(pref.ref).build(pref)
         self.assertTrue(os.path.exists(os.path.join(build_folder, "mp.props")))
+
+    @attr('slow')
+    @unittest.skipUnless(platform.system() == "Windows", "Requires MSBuild")
+    def user_properties_file_test(self):
+        conan_build_vs = textwrap.dedent("""
+            from conans import ConanFile, MSBuild
+        
+            class HelloConan(ConanFile):
+                exports = "*"
+                settings = "os", "build_type", "arch", "compiler"
+        
+                def build(self):
+                    msbuild = MSBuild(self)
+                    msbuild.build("MyProject.sln", verbosity="normal",
+                        user_property_file_name="myuser.props")
+        
+                def package(self):
+                    self.copy(pattern="*.exe")
+            """)
+        client = TestClient()
+
+        files = get_vs_project_files()
+        files[CONANFILE] = conan_build_vs
+        props = textwrap.dedent("""<?xml version="1.0" encoding="utf-8"?>
+            <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+              <ImportGroup Label="PropertySheets" />
+              <PropertyGroup Label="UserMacros" />
+              <ItemDefinitionGroup>
+                <ClCompile>
+                  <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
+                </ClCompile>
+              </ItemDefinitionGroup>
+              <ItemGroup />
+            </Project>
+            """)
+        files["myuser.props"] = props
+
+        client.save(files)
+        client.run('create . Hello/1.2.1@lasote/stable')
+        self.assertNotIn("/EHsc /MD", client.out)
+        self.assertIn("/EHsc /MT", client.out)
+        self.assertIn("Packaged 1 '.exe' file: MyProject.exe", client.out)
+
+        full_ref = "Hello/1.2.1@lasote/stable:6cc50b139b9c3d27b3e9042d5f5372d327b3a9f7"
+        pref = PackageReference.loads(full_ref)
+        build_folder = client.cache.package_layout(pref.ref).build(pref)
+        self.assertTrue(os.path.exists(os.path.join(build_folder, "myuser.props")))
+        conan_props = os.path.join(build_folder, "conan_build.props")
+        content = load(conan_props)
+        self.assertIn("<RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>", content)
 
     @unittest.skipUnless(platform.system() == "Windows", "Requires MSBuild")
     def reuse_msbuild_object_test(self):

--- a/conans/test/functional/build_helpers/msbuild_test.py
+++ b/conans/test/functional/build_helpers/msbuild_test.py
@@ -112,7 +112,8 @@ class HelloConan(ConanFile):
                 def build(self):
                     msbuild = MSBuild(self)
                     msbuild.build("MyProject.sln", verbosity="normal",
-                        user_property_file_name="myuser.props")
+                                  definitions={"MyCustomDef": "MyCustomValue"},
+                                  user_property_file_name="myuser.props")
         
                 def package(self):
                     self.copy(pattern="*.exe")
@@ -139,6 +140,7 @@ class HelloConan(ConanFile):
         client.run('create . Hello/1.2.1@lasote/stable')
         self.assertNotIn("/EHsc /MD", client.out)
         self.assertIn("/EHsc /MT", client.out)
+        self.assertIn("/D MyCustomDef=MyCustomValue", client.out)
         self.assertIn("Packaged 1 '.exe' file: MyProject.exe", client.out)
 
         full_ref = "Hello/1.2.1@lasote/stable:6cc50b139b9c3d27b3e9042d5f5372d327b3a9f7"


### PR DESCRIPTION
Changelog: Feature: Allow defining an extra user-defined properties .props file in ``MSBuild`` build helper.
Docs: https://github.com/conan-io/conan/pull/6374

Close https://github.com/conan-io/conan/issues/6053

#tags: slow
