### PR TITLE
refactoring runners and pyinstaller SCM fix

### DIFF
--- a/conans/client/build/cmake.py
+++ b/conans/client/build/cmake.py
@@ -1,6 +1,5 @@
 import os
 import platform
-import subprocess
 from itertools import chain
 
 from six import StringIO  # Python 2 and 3 compatible
@@ -20,6 +19,7 @@ from conans.model.conan_file import ConanFile
 from conans.model.version import Version
 from conans.util.config_parser import get_bool_from_text
 from conans.util.files import mkdir, get_abs_path, walk, decode_text
+from conans.util.runners import version_runner
 
 
 class CMake(object):
@@ -381,7 +381,7 @@ class CMake(object):
     @staticmethod
     def get_version():
         try:
-            out, _ = subprocess.Popen(["cmake", "--version"], stdout=subprocess.PIPE).communicate()
+            out = version_runner(["cmake", "--version"])
             version_line = decode_text(out).split('\n', 1)[0]
             version_str = version_line.rsplit(' ', 1)[-1]
             return Version(version_str)

--- a/conans/client/build/meson.py
+++ b/conans/client/build/meson.py
@@ -1,5 +1,4 @@
 import os
-import subprocess
 
 from conans.client import tools
 from conans.client.build import defs_to_string, join_arguments
@@ -11,6 +10,7 @@ from conans.errors import ConanException
 from conans.model.build_info import DEFAULT_BIN, DEFAULT_INCLUDE, DEFAULT_LIB
 from conans.model.version import Version
 from conans.util.files import decode_text, get_abs_path, mkdir
+from conans.util.runners import version_runner
 
 
 class Meson(object):
@@ -203,7 +203,7 @@ class Meson(object):
     @staticmethod
     def get_version():
         try:
-            out, _ = subprocess.Popen(["meson", "--version"], stdout=subprocess.PIPE).communicate()
+            out = version_runner(["meson", "--version"])
             version_line = decode_text(out).split('\n', 1)[0]
             version_str = version_line.rsplit(' ', 1)[-1]
             return Version(version_str)

--- a/conans/client/build/msbuild.py
+++ b/conans/client/build/msbuild.py
@@ -1,7 +1,6 @@
 import copy
 import os
 import re
-import subprocess
 
 from conans.client import tools
 from conans.client.build.visual_environment import (VisualStudioBuildEnvironment,
@@ -15,6 +14,7 @@ from conans.model.version import Version
 from conans.tools import vcvars_command as tools_vcvars_command
 from conans.util.env_reader import get_env
 from conans.util.files import decode_text, save
+from conans.util.runners import version_runner
 
 
 class MSBuild(object):
@@ -236,7 +236,7 @@ class MSBuild(object):
         vcvars = tools_vcvars_command(settings)
         command = "%s && %s" % (vcvars, msbuild_cmd)
         try:
-            out, _ = subprocess.Popen(command, stdout=subprocess.PIPE, shell=True).communicate()
+            out = version_runner(command, shell=True)
             version_line = decode_text(out).split("\n")[-1]
             prog = re.compile("(\d+\.){2,3}\d+")
             result = prog.match(version_line).group()

--- a/conans/client/conf/detect.py
+++ b/conans/client/conf/detect.py
@@ -1,28 +1,12 @@
 import os
 import platform
 import re
-from subprocess import PIPE, Popen, STDOUT
 
 from conans.client.output import Color
 from conans.client.tools import detected_os, OSInfo
 from conans.client.tools.win import latest_visual_studio_version_installed
 from conans.model.version import Version
-
-
-def _execute(command):
-    proc = Popen(command, shell=True, bufsize=1, universal_newlines=True, stdout=PIPE,
-                 stderr=STDOUT)
-
-    output_buffer = []
-    while True:
-        line = proc.stdout.readline()
-        if not line:
-            break
-        # output.write(line)
-        output_buffer.append(str(line))
-
-    proc.communicate()
-    return proc.returncode, "".join(output_buffer)
+from conans.util.runners import detect_runner
 
 
 def _gcc_compiler(output, compiler_exe="gcc"):
@@ -30,12 +14,12 @@ def _gcc_compiler(output, compiler_exe="gcc"):
     try:
         if platform.system() == "Darwin":
             # In Mac OS X check if gcc is a fronted using apple-clang
-            _, out = _execute("%s --version" % compiler_exe)
+            _, out = detect_runner("%s --version" % compiler_exe)
             out = out.lower()
             if "clang" in out:
                 return None
 
-        ret, out = _execute('%s -dumpversion' % compiler_exe)
+        ret, out = detect_runner('%s -dumpversion' % compiler_exe)
         if ret != 0:
             return None
         compiler = "gcc"
@@ -52,7 +36,7 @@ def _gcc_compiler(output, compiler_exe="gcc"):
 
 def _clang_compiler(output, compiler_exe="clang"):
     try:
-        ret, out = _execute('%s --version' % compiler_exe)
+        ret, out = detect_runner('%s --version' % compiler_exe)
         if ret != 0:
             return None
         if "Apple" in out:
@@ -69,7 +53,7 @@ def _clang_compiler(output, compiler_exe="clang"):
 
 def _sun_cc_compiler(output, compiler_exe="cc"):
     try:
-        _, out = _execute('%s -V' % compiler_exe)
+        _, out = detect_runner('%s -V' % compiler_exe)
         compiler = "sun-cc"
         installed_version = re.search("([0-9]+\.[0-9]+)", out).group()
         if installed_version:

--- a/conans/client/runner.py
+++ b/conans/client/runner.py
@@ -1,7 +1,7 @@
 import io
 import os
 import sys
-from contextlib import contextmanager
+
 from subprocess import PIPE, Popen, STDOUT
 
 import six
@@ -9,6 +9,7 @@ import six
 from conans.errors import ConanException
 from conans.unicode import get_cwd
 from conans.util.files import decode_text
+from conans.util.runners import pyinstaller_bundle_env_cleaned
 
 
 class _UnbufferedWrite(object):
@@ -119,28 +120,3 @@ class ConanRunner(object):
             finally:
                 os.chdir(old_dir)
             return result
-
-
-if getattr(sys, 'frozen', False) and 'LD_LIBRARY_PATH' in os.environ:
-
-    # http://pyinstaller.readthedocs.io/en/stable/runtime-information.html#ld-library-path-libpath-considerations
-    pyinstaller_bundle_dir = os.environ['LD_LIBRARY_PATH'].replace(
-        os.environ.get('LD_LIBRARY_PATH_ORIG', ''), ''
-    ).strip(';:')
-
-    @contextmanager
-    def pyinstaller_bundle_env_cleaned():
-        """Removes the pyinstaller bundle directory from LD_LIBRARY_PATH
-
-        :return: None
-        """
-        ld_library_path = os.environ['LD_LIBRARY_PATH']
-        os.environ['LD_LIBRARY_PATH'] = ld_library_path.replace(pyinstaller_bundle_dir,
-                                                                '').strip(';:')
-        yield
-        os.environ['LD_LIBRARY_PATH'] = ld_library_path
-
-else:
-    @contextmanager
-    def pyinstaller_bundle_env_cleaned():
-        yield

--- a/conans/client/tools/apple.py
+++ b/conans/client/tools/apple.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 import os
 
-from conans.client.tools.oss import check_output
+from conans.util.runners import check_output_runner
 
 
 def is_apple_os(os_):
@@ -73,7 +73,7 @@ class XCRun(object):
 
     def _invoke(self, args):
         def cmd_output(cmd):
-            return check_output(cmd).strip()
+            return check_output_runner(cmd).strip()
 
         command = ['xcrun', '-find']
         if self.sdk:

--- a/conans/client/tools/oss.py
+++ b/conans/client/tools/oss.py
@@ -3,17 +3,14 @@ import os
 import platform
 import subprocess
 import sys
-import tempfile
-from subprocess import PIPE
 
 import math
-import six
 
 from conans.client.tools.env import environment_append
 from conans.client.tools.files import load, which
-from conans.errors import ConanException, CalledProcessErrorWithStderr
+from conans.errors import ConanException
 from conans.model.version import Version
-from conans.util.log import logger
+from conans.util.runners import check_output_runner
 
 
 def args_to_string(args):
@@ -197,7 +194,7 @@ class OSInfo(object):
         if self.is_linux:
             return self.linux_distro in ["arch", "manjaro"]
         elif self.is_windows and which('uname.exe'):
-            uname = check_output(['uname.exe', '-s'])
+            uname = check_output_runner(['uname.exe', '-s'])
             return uname.startswith('MSYS_NT') and which('pacman.exe')
         return False
 
@@ -346,7 +343,7 @@ class OSInfo(object):
     @staticmethod
     def get_aix_version():
         try:
-            ret = check_output("oslevel").strip()
+            ret = check_output_runner("oslevel").strip()
             return Version(ret)
         except Exception:
             return Version("%s.%s" % (platform.version(), platform.release()))
@@ -370,7 +367,7 @@ class OSInfo(object):
         try:
             # the uname executable is many times located in the same folder as bash.exe
             with environment_append({"PATH": [os.path.dirname(custom_bash_path)]}):
-                ret = check_output(command).strip().lower()
+                ret = check_output_runner(command).strip().lower()
                 return ret
         except Exception:
             return None
@@ -382,7 +379,7 @@ class OSInfo(object):
             raise ConanException("Command only for AIX operating system")
 
         try:
-            ret = check_output("getconf%s" % options).strip()
+            ret = check_output_runner("getconf%s" % options).strip()
             return ret
         except Exception:
             return None
@@ -538,35 +535,3 @@ def get_gnu_triplet(os_, arch, compiler=None):
             op_system += "_ilp32"  # https://wiki.linaro.org/Platform/arm64-ilp32
 
     return "%s-%s" % (machine, op_system)
-
-
-def check_output(cmd, folder=None, return_code=False, stderr=None):
-    tmp_file = tempfile.mktemp()
-    try:
-        # We don't want stderr to print warnings that will mess the pristine outputs
-        stderr = stderr or PIPE
-        cmd = cmd if isinstance(cmd, six.string_types) else subprocess.list2cmdline(cmd)
-        command = "{} > {}".format(cmd, tmp_file)
-        logger.info("Calling command: {}".format(command))
-        process = subprocess.Popen(command, shell=True, stderr=stderr, cwd=folder)
-        stdout, stderr = process.communicate()
-        logger.info("Return code: {}".format(int(process.returncode)))
-
-        if return_code:
-            return process.returncode
-
-        if process.returncode:
-            # Only in case of error, we print also the stderr to know what happened
-            raise CalledProcessErrorWithStderr(process.returncode, cmd, output=stderr)
-
-        output = load(tmp_file)
-        try:
-            logger.info("Output: in file:{}\nstdout: {}\nstderr:{}".format(output, stdout, stderr))
-        except Exception as exc:
-            logger.error("Error logging command output: {}".format(exc))
-        return output
-    finally:
-        try:
-            os.unlink(tmp_file)
-        except Exception:
-            pass

--- a/conans/client/tools/pkg_config.py
+++ b/conans/client/tools/pkg_config.py
@@ -3,14 +3,14 @@
 
 import subprocess
 
-from conans.client.tools.oss import check_output
 from conans.errors import ConanException
+from conans.util.runners import check_output_runner
 
 
 class PkgConfig(object):
     @staticmethod
     def _cmd_output(command):
-        return check_output(command).strip()
+        return check_output_runner(command).strip()
 
     def __init__(self, library, pkg_config_executable='pkg-config', static=False, msvc_syntax=False, variables=None,
                  print_errors=True):

--- a/conans/client/tools/scm.py
+++ b/conans/client/tools/scm.py
@@ -3,29 +3,22 @@ import platform
 import re
 import subprocess
 import xml.etree.ElementTree as ET
-from subprocess import CalledProcessError, PIPE, STDOUT
+from subprocess import CalledProcessError
 
 from six.moves.urllib.parse import quote_plus, unquote, urlparse
 
-from conans.client.tools import check_output
 from conans.client.tools.env import environment_append, no_op
 from conans.client.tools.files import chdir
 from conans.errors import ConanException
 from conans.model.version import Version
 from conans.util.files import decode_text, to_file_bytes, walk, mkdir
-
-
-def _run_muted(cmd, folder=None):
-    with chdir(folder) if folder else no_op():
-        process = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-        process.communicate()
-        return process.returncode
+from conans.util.runners import check_output_runner, version_runner, muted_runner, input_runner
 
 
 def _check_repo(cmd, folder, msg=None):
     msg = msg or "Not a valid '{}' repository".format(cmd[0])
     try:
-        ret = _run_muted(cmd, folder=folder)
+        ret = muted_runner(cmd, folder=folder)
     except Exception:
         raise ConanException(msg)
     else:
@@ -39,7 +32,7 @@ class SCMBase(object):
     @classmethod
     def get_version(cls):
         try:
-            out, _ = subprocess.Popen([cls.cmd_command, "--version"], stdout=subprocess.PIPE).communicate()
+            out = version_runner([cls.cmd_command, "--version"])
             version_line = decode_text(out).split('\n', 1)[0]
             version_str = version_line.split(' ', 3)[2]
             return Version(version_str)
@@ -63,7 +56,7 @@ class SCMBase(object):
         with chdir(self.folder) if self.folder else no_op():
             with environment_append({"LC_ALL": "en_US.UTF-8"}) if self._force_eng else no_op():
                 if not self._runner:
-                    return check_output(command).strip()
+                    return check_output_runner(command).strip()
                 else:
                     return self._runner(command)
 
@@ -178,11 +171,9 @@ class Git(SCMBase):
                           for folder, dirpaths, fs in walk(self.folder)
                           for el in fs + dirpaths]
             if file_paths:
-                p = subprocess.Popen(['git', 'check-ignore', '--stdin'],
-                                     stdout=PIPE, stdin=PIPE, stderr=STDOUT, cwd=self.folder)
                 paths = to_file_bytes("\n".join(file_paths))
-
-                grep_stdout = decode_text(p.communicate(input=paths)[0])
+                out = input_runner(['git', 'check-ignore', '--stdin'], paths, self.folder)
+                grep_stdout = decode_text(out)
                 ret = grep_stdout.splitlines()
         except (CalledProcessError, IOError, OSError) as e:
             if self._output:
@@ -272,7 +263,7 @@ class SVN(SCMBase):
 
     def __init__(self, folder=None, runner=None, *args, **kwargs):
         def runner_no_strip(command):
-            return check_output(command)
+            return check_output_runner(command)
         runner = runner or runner_no_strip
         super(SVN, self).__init__(folder=folder, runner=runner, *args, **kwargs)
 

--- a/conans/client/tools/win.py
+++ b/conans/client/tools/win.py
@@ -9,13 +9,14 @@ import deprecation
 
 from conans.client.tools import which
 from conans.client.tools.env import environment_append
-from conans.client.tools.oss import OSInfo, detected_architecture, check_output
+from conans.client.tools.oss import OSInfo, detected_architecture
 from conans.errors import ConanException
 from conans.model.version import Version
 from conans.unicode import get_cwd
 from conans.util.env_reader import get_env
 from conans.util.fallbacks import default_output
 from conans.util.files import mkdir_tmp, save
+from conans.util.runners import check_output_runner
 
 
 def _visual_compiler_cygwin(output, version):
@@ -298,7 +299,7 @@ def vswhere(all_=False, prerelease=False, products=None, requires=None, version=
         arguments.append("-nologo")
 
     try:
-        output = check_output(arguments).strip()
+        output = check_output_runner(arguments).strip()
         # Ignore the "description" field, that even decoded contains non valid charsets for json
         # (ignored ones)
         output = "\n".join([line for line in output.splitlines()
@@ -443,7 +444,7 @@ def vcvars_dict(settings, arch=None, compiler_version=None, force=False, filter_
                          compiler_version=compiler_version, force=force,
                          vcvars_ver=vcvars_ver, winsdk_version=winsdk_version, output=output)
     cmd += " && set"
-    ret = check_output(cmd)
+    ret = check_output_runner(cmd)
     new_env = {}
     for line in ret.splitlines():
         line = line.strip()

--- a/conans/test/functional/command/info_folders_test.py
+++ b/conans/test/functional/command/info_folders_test.py
@@ -6,12 +6,11 @@ import unittest
 from textwrap import dedent
 
 from conans.client import tools
-from conans.client.tools.oss import check_output
 from conans.model.ref import ConanFileReference, PackageReference
 from conans.paths import CONANFILE
 from conans.test.utils.test_files import temp_folder
-from conans.test.utils.tools import NO_SETTINGS_PACKAGE_ID, TestClient, \
-    TestServer
+from conans.test.utils.tools import NO_SETTINGS_PACKAGE_ID, TestClient, TestServer
+from conans.util.runners import check_output_runner
 
 conanfile_py = """
 from conans import ConanFile
@@ -181,7 +180,8 @@ class InfoFoldersTest(unittest.TestCase):
 
         # Retrieve ACLs from short_folder
         try:
-            short_folder_acls = check_output("cacls %s" % short_folder, stderr=subprocess.STDOUT)
+            short_folder_acls = check_output_runner("cacls %s" % short_folder,
+                                                    stderr=subprocess.STDOUT)
         except subprocess.CalledProcessError as e:
             raise Exception("Error %s getting ACL from short_folder: '%s'." % (e, short_folder))
 

--- a/conans/test/functional/environment/run_environment_test.py
+++ b/conans/test/functional/environment/run_environment_test.py
@@ -5,10 +5,10 @@ import textwrap
 import unittest
 
 from conans.client import tools
-from conans.client.tools.oss import check_output
 from conans.paths import CONANFILE
 from conans.test.utils.cpp_test_files import cpp_hello_conan_files
 from conans.test.utils.tools import TestClient, TestServer
+from conans.util.runners import check_output_runner
 
 
 class RunEnvironmentTest(unittest.TestCase):
@@ -134,7 +134,8 @@ class RunEnvironmentSharedTest(unittest.TestCase):
         # This test is excluded from OSX, because of the SIP protection. CMake helper will
         # launch a subprocess with shell=True, which CLEANS the DYLD_LIBRARY_PATH. Injecting its
         # value via run_environment=True doesn't work, because it prepends its value to:
-        # command = "cd [folder] && cmake [cmd]" => "DYLD_LIBRARY_PATH=[path] cd [folder] && cmake [cmd]"
+        # command = "cd [folder] && cmake [cmd]" =>
+        #                 "DYLD_LIBRARY_PATH=[path] cd [folder] && cmake [cmd]"
         # and then only applies to the change directory "cd"
         # If CMake binary is in user folder, it is not under SIP, and it can work. For cmake
         # installed in system folders, then no possible form of "DYLD_LIBRARY_PATH=[folders] cmake"
@@ -177,10 +178,10 @@ class RunEnvironmentSharedTest(unittest.TestCase):
                 command = "activate_run.bat && say_hello"
             else:
                 # It is not necessary to use the DYLD_LIBRARY_PATH in OSX because the activate_run.sh
-                # will work perfectly. It is inside the bash, so the loader will use DYLD_LIBRARY_PATH
+                # will work perfectly. It is inside bash, so the loader will use DYLD_LIBRARY_PATH
                 # values. It also works in command line with export DYLD_LIBRARY_PATH=[path] and then
                 # running, or in the same line "$ DYLD_LIBRARY_PATH=[path] say_hello"
                 command = "bash -c 'source activate_run.sh && say_hello'"
 
-            output = check_output(command)
+            output = check_output_runner(command)
             self.assertIn("Hello Tool!", output)

--- a/conans/test/functional/generators/virtualbuildenv_test.py
+++ b/conans/test/functional/generators/virtualbuildenv_test.py
@@ -3,9 +3,8 @@ import platform
 import textwrap
 import unittest
 
-from conans import load
-from conans.client.tools.oss import check_output
 from conans.test.utils.tools import TestClient
+from conans.util.runners import check_output_runner
 
 
 class VirtualBuildEnvTest(unittest.TestCase):
@@ -65,16 +64,16 @@ class TestConan(ConanFile):
         client = TestClient(path_with_spaces=False)
         client.save({"conanfile.py": conanfile})
         client.run("install .")
-        output = check_output(env_cmd)
+        output = check_output_runner(env_cmd)
         normal_environment = env_output_to_dict(output)
         client.run("install .")
         act_build_file = os.path.join(client.current_folder, "activate_build.%s" % extension)
         deact_build_file = os.path.join(client.current_folder, "deactivate_build.%s" % extension)
         self.assertTrue(os.path.exists(act_build_file))
         self.assertTrue(os.path.exists(deact_build_file))
-        output = check_output(get_cmd(act_build_file))
+        output = check_output_runner(get_cmd(act_build_file))
         activate_environment = env_output_to_dict(output)
         self.assertNotEqual(normal_environment, activate_environment)
-        output = check_output(get_cmd(deact_build_file))
+        output = check_output_runner(get_cmd(deact_build_file))
         deactivate_environment = env_output_to_dict(output)
         self.assertDictEqual(normal_environment, deactivate_environment)

--- a/conans/test/unittests/client/tools/os_info/osinfo_test.py
+++ b/conans/test/unittests/client/tools/os_info/osinfo_test.py
@@ -58,7 +58,8 @@ class OSInfoTest(unittest.TestCase):
             self.assertFalse(OSInfo().is_aix)
 
             with environment_append({"CONAN_BASH_PATH": "/fake/bash.exe"}):
-                with mock.patch('conans.client.tools.oss.check_output', new=self.subprocess_check_output_mock):
+                with mock.patch('conans.client.tools.oss.check_output_runner',
+                                new=self.subprocess_check_output_mock):
                     self.assertEqual(OSInfo.uname(), self._uname.lower())
                     self.assertEqual(OSInfo.detect_windows_subsystem(), CYGWIN)
 
@@ -76,7 +77,8 @@ class OSInfoTest(unittest.TestCase):
             self.assertFalse(OSInfo().is_aix)
 
             with environment_append({"CONAN_BASH_PATH": "/fake/bash.exe"}):
-                with mock.patch('conans.client.tools.oss.check_output', new=self.subprocess_check_output_mock):
+                with mock.patch('conans.client.tools.oss.check_output_runner',
+                                new=self.subprocess_check_output_mock):
                     self.assertEqual(OSInfo.uname(), self._uname.lower())
                     self.assertEqual(OSInfo.detect_windows_subsystem(), MSYS)
 
@@ -93,7 +95,8 @@ class OSInfoTest(unittest.TestCase):
             self.assertFalse(OSInfo().is_solaris)
 
             with environment_append({"CONAN_BASH_PATH": "/fake/bash.exe"}):
-                with mock.patch('conans.client.tools.oss.check_output', new=self.subprocess_check_output_mock):
+                with mock.patch('conans.client.tools.oss.check_output_runner',
+                                new=self.subprocess_check_output_mock):
                     self.assertEqual(OSInfo.uname(), self._uname.lower())
                     self.assertEqual(OSInfo.detect_windows_subsystem(), MSYS2)
 
@@ -111,7 +114,8 @@ class OSInfoTest(unittest.TestCase):
             self.assertFalse(OSInfo().is_aix)
 
             with environment_append({"CONAN_BASH_PATH": "/fake/bash.exe"}):
-                with mock.patch('conans.client.tools.oss.check_output', new=self.subprocess_check_output_mock):
+                with mock.patch('conans.client.tools.oss.check_output_runner',
+                                new=self.subprocess_check_output_mock):
                     self.assertEqual(OSInfo.uname(), self._uname.lower())
                     self.assertEqual(OSInfo.detect_windows_subsystem(), MSYS2)
 
@@ -129,7 +133,8 @@ class OSInfoTest(unittest.TestCase):
             self.assertFalse(OSInfo().is_aix)
 
             with environment_append({"CONAN_BASH_PATH": "/fake/bash.exe"}):
-                with mock.patch('conans.client.tools.oss.check_output', new=self.subprocess_check_output_mock):
+                with mock.patch('conans.client.tools.oss.check_output_runner',
+                                new=self.subprocess_check_output_mock):
                     self.assertEqual(OSInfo.uname(), self._uname.lower())
                     self.assertEqual(OSInfo.detect_windows_subsystem(), MSYS2)
 
@@ -218,7 +223,8 @@ class OSInfoTest(unittest.TestCase):
         self._version = '7.1.0.0'
 
         with mock.patch("platform.system", mock.MagicMock(return_value='AIX')), \
-                mock.patch('conans.client.tools.oss.check_output', new=self.subprocess_check_output_mock):
+                mock.patch('conans.client.tools.oss.check_output_runner',
+                           new=self.subprocess_check_output_mock):
             self.assertFalse(OSInfo().is_windows)
             self.assertFalse(OSInfo().is_cygwin)
             self.assertFalse(OSInfo().is_msys)

--- a/conans/test/unittests/util/detect_test.py
+++ b/conans/test/unittests/util/detect_test.py
@@ -7,9 +7,9 @@ from parameterized import parameterized
 
 from conans.client import tools
 from conans.client.conf.detect import detect_defaults_settings
-from conans.client.tools.oss import check_output
 from conans.paths import DEFAULT_PROFILE_NAME
 from conans.test.utils.tools import TestBufferConanOutput
+from conans.util.runners import check_output_runner
 
 
 class DetectTest(unittest.TestCase):
@@ -35,7 +35,7 @@ class DetectTest(unittest.TestCase):
         """
         # See: https://github.com/conan-io/conan/issues/2231
         try:
-            output = check_output(["gcc", "--version"], stderr=subprocess.STDOUT)
+            output = check_output_runner(["gcc", "--version"], stderr=subprocess.STDOUT)
         except subprocess.CalledProcessError:
             # gcc is not installed or there is any error (no test scenario)
             return

--- a/conans/test/unittests/util/tools_test.py
+++ b/conans/test/unittests/util/tools_test.py
@@ -655,7 +655,8 @@ ProgramFiles(x86)=C:\Program Files (x86)
             return output_with_newline_and_spaces
 
         with mock.patch('conans.client.tools.win.vcvars_command', new=vcvars_command_mock):
-            with patch('conans.client.tools.win.check_output', new=subprocess_check_output_mock):
+            with patch('conans.client.tools.win.check_output_runner',
+                       new=subprocess_check_output_mock):
                 vcvars = tools.vcvars_dict(None, only_diff=False, output=self.output)
                 self.assertEqual(vcvars["PROCESSOR_ARCHITECTURE"], "AMD64")
                 self.assertEqual(vcvars["PROCESSOR_IDENTIFIER"],

--- a/conans/test/unittests/util/tools_test.py
+++ b/conans/test/unittests/util/tools_test.py
@@ -23,7 +23,7 @@ from conans.client.conf import default_client_conf, default_settings_yml
 from conans.client.output import ConanOutput
 from conans.client.runner import ConanRunner
 from conans.client.tools.files import replace_in_file, which
-from conans.client.tools.oss import check_output, OSInfo
+from conans.client.tools.oss import OSInfo
 from conans.client.tools.win import vcvars_dict, vswhere
 from conans.errors import ConanException, NotFoundException, AuthenticationException
 from conans.model.build_info import CppInfo
@@ -34,6 +34,7 @@ from conans.test.utils.tools import StoppableThreadBottle, TestBufferConanOutput
 from conans.tools import get_global_instances
 from conans.util.env_reader import get_env
 from conans.util.files import load, md5, mkdir, save
+from conans.util.runners import check_output_runner
 
 
 class ConfigMock:
@@ -981,12 +982,12 @@ ProgramFiles(x86)=C:\Program Files (x86)
 
         fp = save_file(b"a line\notherline\n")
         if platform.system() != "Windows":
-            output = check_output(["file", fp], stderr=subprocess.STDOUT)
+            output = check_output_runner(["file", fp], stderr=subprocess.STDOUT)
             self.assertIn("ASCII text", str(output))
             self.assertNotIn("CRLF", str(output))
 
             tools.unix2dos(fp)
-            output = check_output(["file", fp], stderr=subprocess.STDOUT)
+            output = check_output_runner(["file", fp], stderr=subprocess.STDOUT)
             self.assertIn("ASCII text", str(output))
             self.assertIn("CRLF", str(output))
         else:
@@ -1000,12 +1001,12 @@ ProgramFiles(x86)=C:\Program Files (x86)
 
         fp = save_file(b"a line\r\notherline\r\n")
         if platform.system() != "Windows":
-            output = check_output(["file", fp], stderr=subprocess.STDOUT)
+            output = check_output_runner(["file", fp], stderr=subprocess.STDOUT)
             self.assertIn("ASCII text", str(output))
             self.assertIn("CRLF", str(output))
 
             tools.dos2unix(fp)
-            output = check_output(["file", fp], stderr=subprocess.STDOUT)
+            output = check_output_runner(["file", fp], stderr=subprocess.STDOUT)
             self.assertIn("ASCII text", str(output))
             self.assertNotIn("CRLF", str(output))
         else:

--- a/conans/test/utils/tools.py
+++ b/conans/test/utils/tools.py
@@ -34,7 +34,6 @@ from conans.client.rest.uploader_downloader import IterableToFileAdapter
 from conans.client.tools import environment_append
 from conans.client.tools.files import chdir
 from conans.client.tools.files import replace_in_file
-from conans.client.tools.oss import check_output
 from conans.client.tools.scm import Git, SVN
 from conans.client.tools.win import get_cased_path
 from conans.client.userio import UserIO
@@ -51,6 +50,7 @@ from conans.test.utils.test_files import temp_folder
 from conans.util.env_reader import get_env
 from conans.util.files import mkdir, save_files
 from conans.client.runner import ConanRunner
+from conans.util.runners import check_output_runner
 
 NO_SETTINGS_PACKAGE_ID = "5ab84d6acfe1f23c4fae0ab88f26e3a396351ac9"
 
@@ -534,10 +534,10 @@ def create_local_svn_checkout(files, repo_url, rel_project_path=None,
             subprocess.check_output("svn add .", shell=True)
             subprocess.check_output('svn commit -m "{}"'.format(commit_msg), shell=True)
             if SVN.get_version() >= SVN.API_CHANGE_VERSION:
-                rev = check_output("svn info --show-item revision").strip()
+                rev = check_output_runner("svn info --show-item revision").strip()
             else:
                 import xml.etree.ElementTree as ET
-                output = check_output("svn info --xml").strip()
+                output = check_output_runner("svn info --xml").strip()
                 root = ET.fromstring(output)
                 rev = root.findall("./entry")[0].get("revision")
         project_url = repo_url + "/" + quote(rel_project_path.replace("\\", "/"))

--- a/conans/util/runners.py
+++ b/conans/util/runners.py
@@ -1,0 +1,77 @@
+import os
+import subprocess
+import tempfile
+
+import six
+
+from conans.client.tools.files import load
+from conans.errors import CalledProcessErrorWithStderr
+from conans.util.log import logger
+
+
+def version_runner(cmd, shell=False):
+    # Used by build helpers like CMake and Meson and MSBuild to get the version
+    out, _ = subprocess.Popen(cmd, stdout=subprocess.PIPE, shell=shell).communicate()
+    return out
+
+
+def muted_runner(cmd, folder=None):
+    # Used by tools/scm
+    process = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, cwd=folder)
+    process.communicate()
+    return process.returncode
+
+
+def input_runner(cmd, run_input, folder):
+    # used in git excluded files from .gitignore
+    p = subprocess.Popen(cmd, stdout=subprocess.PIPE, stdin=subprocess.PIPE,
+                         stderr=subprocess.STDOUT, cwd=folder)
+    out, _ = p.communicate(input=run_input)
+    return out
+
+
+def detect_runner(command):
+    # Running detect.py automatic detection of profile
+    proc = subprocess.Popen(command, shell=True, bufsize=1, universal_newlines=True,
+                            stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+
+    output_buffer = []
+    while True:
+        line = proc.stdout.readline()
+        if not line:
+            break
+        # output.write(line)
+        output_buffer.append(str(line))
+
+    proc.communicate()
+    return proc.returncode, "".join(output_buffer)
+
+
+def check_output_runner(cmd, stderr=None):
+    # Used to run several utilities, like Pacman detect, AIX version, uname,
+    tmp_file = tempfile.mktemp()
+    try:
+        # We don't want stderr to print warnings that will mess the pristine outputs
+        stderr = stderr or subprocess.PIPE
+        cmd = cmd if isinstance(cmd, six.string_types) else subprocess.list2cmdline(cmd)
+        command = "{} > {}".format(cmd, tmp_file)
+        logger.info("Calling command: {}".format(command))
+        process = subprocess.Popen(command, shell=True, stderr=stderr)
+        stdout, stderr = process.communicate()
+        logger.info("Return code: {}".format(int(process.returncode)))
+
+        if process.returncode:
+            # Only in case of error, we print also the stderr to know what happened
+            raise CalledProcessErrorWithStderr(process.returncode, cmd, output=stderr)
+
+        output = load(tmp_file)
+        try:
+            logger.info("Output: in file:{}\nstdout: {}\nstderr:{}".format(output, stdout, stderr))
+        except Exception as exc:
+            logger.error("Error logging command output: {}".format(exc))
+        return output
+    finally:
+        try:
+            os.unlink(tmp_file)
+        except OSError:
+            pass


### PR DESCRIPTION
Changelog: Fix: Cleaning ``LD_LIBRARY_PATH`` environment in ``SCM`` commands for "pyinstaller" installations, as SSL can fail due to using old SSL stuff from Conan instead from git/svn

Docs: Omit

It contains mostly a refactor, centralizing executions and subprocess stuff (not all of it, but most of it from production code). The only functional change is to introduce the pyinstaller fix in the SCM run() method.

Close #6161

#tags: slow
