### PR TITLE
Profile include order

### DIFF
--- a/conans/client/profile_loader.py
+++ b/conans/client/profile_loader.py
@@ -119,7 +119,7 @@ def _load_profile(text, profile_path, default_folder):
         inherited_profile = Profile()
         cwd = os.path.dirname(os.path.abspath(profile_path)) if profile_path else None
         profile_parser = ProfileParser(text)
-        inherited_vars = profile_parser.vars
+        inherited_vars = profile_parser.vars.copy()
         # Iterate the includes and call recursive to get the profile and variables
         # from parent profiles
         for include in profile_parser.includes:

--- a/conans/client/profile_loader.py
+++ b/conans/client/profile_loader.py
@@ -14,6 +14,11 @@ from conans.util.log import logger
 class ProfileParser(object):
 
     def __init__(self, text):
+        """ divides the text in 3 items:
+        - self.vars: Dictionary with variable=value declarations
+        - self.includes: List of other profiles to include
+        - self.profile_text: the remaining, containing settings, options, env, etc
+        """
         self.vars = OrderedDict()  # Order matters, if user declares F=1 and then FOO=12,
         # and in profile MYVAR=$FOO, it will
         self.includes = []
@@ -39,33 +44,36 @@ class ProfileParser(object):
                 value = unquote(value)
                 self.vars[name] = value
 
-    def apply_vars(self, repl_vars):
-        self.vars = self._apply_in_vars(repl_vars)
-        self.includes = self._apply_in_includes(repl_vars)
-        self.profile_text = self._apply_in_profile_text(repl_vars)
+    def apply_vars(self):
+        self._apply_in_vars()
+        self._apply_in_profile_text()
 
-    def _apply_in_vars(self, repl_vars):
+    def get_includes(self):
+        # Replace over includes seems insane and it is not documented. I am leaving it now
+        # afraid of breaking, but should be removed Conan 2.0
+        for include in self.includes:
+            for repl_key, repl_value in self.vars.items():
+                include = include.replace("$%s" % repl_key, repl_value)
+            yield include
+
+    def update_vars(self, included_vars):
+        """ update the variables dict with new ones from included profiles,
+        but keeping (higher priority) existing values"""
+        included_vars.update(self.vars)
+        self.vars = included_vars
+
+    def _apply_in_vars(self):
         tmp_vars = OrderedDict()
         for key, value in self.vars.items():
-            for repl_key, repl_value in repl_vars.items():
+            for repl_key, repl_value in self.vars.items():
                 key = key.replace("$%s" % repl_key, repl_value)
                 value = value.replace("$%s" % repl_key, repl_value)
             tmp_vars[key] = value
-        return tmp_vars
+        self.vars = tmp_vars
 
-    def _apply_in_includes(self, repl_vars):
-        tmp_includes = []
-        for include in self.includes:
-            for repl_key, repl_value in repl_vars.items():
-                include = include.replace("$%s" % repl_key, repl_value)
-            tmp_includes.append(include)
-        return tmp_includes
-
-    def _apply_in_profile_text(self, repl_vars):
-        tmp_text = self.profile_text
-        for repl_key, repl_value in repl_vars.items():
-            tmp_text = tmp_text.replace("$%s" % repl_key, repl_value)
-        return tmp_text
+    def _apply_in_profile_text(self):
+        for k, v in self.vars.items():
+            self.profile_text = self.profile_text.replace("$%s" % k, v)
 
 
 def get_profile_path(profile_name, default_folder, cwd, exists=True):
@@ -114,27 +122,25 @@ def _load_profile(text, profile_path, default_folder):
     """ Parse and return a Profile object from a text config like representation.
         cwd is needed to be able to load the includes
     """
-
     try:
         inherited_profile = Profile()
         cwd = os.path.dirname(os.path.abspath(profile_path)) if profile_path else None
         profile_parser = ProfileParser(text)
-        inherited_vars = profile_parser.vars.copy()
         # Iterate the includes and call recursive to get the profile and variables
         # from parent profiles
-        for include in profile_parser.includes:
+        for include in profile_parser.get_includes():
             # Recursion !!
-            profile, declared_vars = read_profile(include, cwd, default_folder)
+            profile, included_vars = read_profile(include, cwd, default_folder)
             inherited_profile.update(profile)
-            inherited_vars.update(declared_vars)
+            profile_parser.update_vars(included_vars)
 
         # Apply the automatic PROFILE_DIR variable
         if cwd:
-            inherited_vars["PROFILE_DIR"] = os.path.abspath(cwd).replace('\\', '/')
+            profile_parser.vars["PROFILE_DIR"] = os.path.abspath(cwd).replace('\\', '/')
             # Allows PYTHONPATH=$PROFILE_DIR/pythontools
 
         # Replace the variables from parents in the current profile
-        profile_parser.apply_vars(inherited_vars)
+        profile_parser.apply_vars()
 
         # Current profile before update with parents (but parent variables already applied)
         doc = ConfigParser(profile_parser.profile_text,
@@ -144,10 +150,7 @@ def _load_profile(text, profile_path, default_folder):
         # Merge the inherited profile with the readed from current profile
         _apply_inner_profile(doc, inherited_profile)
 
-        # Return the inherited vars to apply them in the parent profile if exists
-        inherited_vars.update(profile_parser.vars)
-        return inherited_profile, inherited_vars
-
+        return inherited_profile, profile_parser.vars
     except ConanException:
         raise
     except Exception as exc:

--- a/conans/test/unittests/client/profile_loader/profile_loader_test.py
+++ b/conans/test/unittests/client/profile_loader/profile_loader_test.py
@@ -340,3 +340,25 @@ PYTHONPATH=$PROFILE_DIR/my_python_tools
 
         profile, _ = read_profile("Myprofile.txt", None, tmp)
         assert_path(profile)
+
+    def include_order_test(self):
+        tmp = temp_folder()
+
+        def save_profile(txt, name):
+            abs_profile_path = os.path.join(tmp, name)
+            save(abs_profile_path, txt)
+
+        profile1 = """
+MYVAR=fromProfile1
+        """
+        save_profile(profile1, "profile1.txt")
+
+        profile2 = """
+include(./profile1.txt)
+MYVAR=fromProfile2
+        """
+        save_profile(profile2, "profile2.txt")
+        profile, variables = read_profile("./profile2.txt", tmp, None)
+
+        self.assertEqual(variables, {"MYVAR": "fromProfile2",
+                                     "PROFILE_DIR": tmp.replace('\\', '/')})


### PR DESCRIPTION
Changelog: Fix: Included profiles could overwrite variables in the current profile

Fix profile include order variable overwriting
If you had a setup like this:

*myinclude*
```
MYVAR=foo
```

*myprofile*
```
include(myinclude)
MYVAR=bar
```

The end result would be MYVAR=foo which is *very* confusing behavior. I think most users would expect MYVAR to be bar.

This was caused by inherited_vars being a reference and not a copy. Explicity copying the profile_parser.vars fixes the problem which leads me to think this is the original intent of this function since it matches what my expection would be as well.

- [ ] Refer to the issue that supports this Pull Request.
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
