### PR TITLE
chore(ci): add python 3.8 for build

### DIFF
--- a/.ci/travis/install.sh
+++ b/.ci/travis/install.sh
@@ -20,24 +20,24 @@ if [[ "$(uname -s)" == 'Darwin' ]]; then
 
     case "${PYVER}" in
         py27)
-            pyenv install 2.7.10
-            pyenv virtualenv 2.7.10 conan
-            ;;
-        py33)
-            pyenv install 3.3.6
-            pyenv virtualenv 3.3.6 conan
-            ;;
-        py34)
-            pyenv install 3.4.3
-            pyenv virtualenv 3.4.3 conan
+            pyenv install 2.7.17
+            pyenv virtualenv 2.7.17 conan
             ;;
         py35)
-            pyenv install 3.5.0
-            pyenv virtualenv 3.5.0 conan
+            pyenv install 3.5.9
+            pyenv virtualenv 3.5.9 conan
             ;;
         py36)
-            pyenv install 3.6.0
-            pyenv virtualenv 3.6.0 conan
+            pyenv install 3.6.10
+            pyenv virtualenv 3.6.10 conan
+            ;;
+        py37)
+            pyenv install 3.7.6
+            pyenv virtualenv 3.7.6 conan
+            ;;
+        py38)
+            pyenv install 3.8.1
+            pyenv virtualenv 3.8.1 conan
             ;;
 
     esac

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 os: linux
-sudo: required
 dist: trusty
 language: python
 
@@ -10,7 +9,9 @@ matrix:
           if: branch =~ ^release.* OR branch =~ ^master
         - python: 3.6
         - python: 3.7
-          dist: xenial
+          dist: bionic
+        - python: 3.8
+          dist: bionic
         - language: generic
           os: osx
           osx_image: xcode8.3
@@ -28,7 +29,7 @@ before_script:
   - export PYTHONPATH=$PYTHONPATH:$(pwd)
 
 # command to run tests
-script: 
+script:
   - ulimit -n 2048 # Error with py3 and OSX, max file descriptors
   - ./.ci/travis/run.sh
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,7 +6,7 @@
     environment:
       matrix:
         - PYTHON: "C:\\Python27"
-        - PYTHON: "C:\\Python35"
+        - PYTHON: "C:\\Python38"
     build: false
     cache:
         - C:\mingw64-> appveyor.yml
@@ -20,7 +20,7 @@
 -
     environment:
       matrix:
-        - PYTHON: "C:\\Python35"
+        - PYTHON: "C:\\Python38"
     build: false
     cache:
         - C:\mingw64-> appveyor.yml


### PR DESCRIPTION
Upgrade CI to include python 3.8.

Homebrew already shipped the formula with python 3.8 (https://github.com/Homebrew/homebrew-core/pull/49001)

- [ ] Refer to the issue that supports this Pull Request.
- [ ] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [ ] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 

<sup>**Note:** By default this PR will skip the slower tests and will use a limited set of python versions. Check [here](https://github.com/conan-io/conan/blob/develop/.github/PR_INCREASE_TESTING.md) how to increase the testing level by writing some tags in the current PR body text.</sup>
