### PR TITLE
WIP: meson: Add preliminary support for cross builds

### DIFF
--- a/conans/client/build/meson.py
+++ b/conans/client/build/meson.py
@@ -122,6 +122,7 @@ class Meson(object):
         cpu_translate = {
             'armv8': ('aarch64', 'aarch64', 'little'),
             'x86': ('x86', 'x86', 'little'),
+            'x86_64': ('x86_64', 'x86_64', 'little')
         }
         cpu_family, cpu, endian = cpu_translate[str(self._conanfile.settings.arch)]
         cflags = ', '.join(repr(x) for x in os.environ.get('CFLAGS', '').split(' '))

--- a/conans/client/build/meson.py
+++ b/conans/client/build/meson.py
@@ -118,6 +118,43 @@ class Meson(object):
     def flags(self):
         return defs_to_string(self.options)
 
+    def _configure_cross_compile(self, cross_filename, environ_append):
+        cpu_translate = {
+            'armv8': ('aarch64', 'aarch64', 'little'),
+            'x86': ('x86', 'x86', 'little'),
+        }
+        cpu_family, cpu, endian = cpu_translate[str(self._conanfile.settings.arch)]
+        cflags = ', '.join(repr(x) for x in os.environ.get('CFLAGS', '').split(' '))
+        cc = os.environ.get('CC', 'cc')
+        cpp = os.environ.get('CXX', 'c++')
+        with open(cross_filename, "w") as fd:
+            fd.write("""
+                [host_machine]
+                system = '{os}'
+                cpu_family = '{cpu_family}'
+                cpu = '{cpu}'
+                endian = '{endian}'
+
+                [properties]
+                needs_exe_wrapper = true
+                c_args = [{cflags}]
+
+                [binaries]
+                c = '{cc}'
+                cpp = '{cpp}'
+            """.format(os=self._os.lower(),
+                       cpu_family=cpu_family,
+                       cpu=cpu,
+                       endian=endian,
+                       cflags=cflags,
+                       cc=cc,
+                       cpp=cpp))
+        environ_append.update({'CC': None,
+                               'CXX': None,
+                               'CFLAGS': None,
+                               'CXXFLAGS': None,
+                               'CPPFLAGS': None})
+
     def configure(self, args=None, defs=None, source_dir=None, build_dir=None,
                   pkg_config_paths=None, cache_build_folder=None,
                   build_folder=None, source_folder=None):
@@ -147,14 +184,22 @@ class Meson(object):
               "Release": "release"}.get(str(self.build_type), "")
 
         build_type = "--buildtype=%s" % bt
+        cross_option = None
+        environ_append = {"PKG_CONFIG_PATH": pc_paths}
+        if tools.cross_building(self._conanfile.settings):
+            cross_filename = os.path.join(self.build_dir, "cross_file.txt")
+            cross_option = "--cross-file=%s" % cross_filename
+            self._configure_cross_compile(cross_filename, environ_append)
+
         arg_list = join_arguments([
             "--backend=%s" % self.backend,
             self.flags,
             args_to_string(args),
-            build_type
+            build_type,
+            cross_option,
         ])
         command = 'meson "%s" "%s" %s' % (source_dir, self.build_dir, arg_list)
-        with environment_append({"PKG_CONFIG_PATH": pc_paths}):
+        with environment_append(environ_append):
             self._run(command)
 
     @property

--- a/conans/test/unittests/client/build/meson_test.py
+++ b/conans/test/unittests/client/build/meson_test.py
@@ -100,7 +100,7 @@ class MesonTest(unittest.TestCase):
         build_expected = os.path.join(self.tempdir, "my_cache_build_folder", "build")
         source_expected = os.path.join(self.tempdir, "my_cache_source_folder", "source")
         cross_file = os.path.join(build_expected, "cross_file.txt")
-        cmd_expected = 'meson "%s" "%s" --backend=ninja %s --buildtype=releas --cross-file=%s' \
+        cmd_expected = 'meson "%s" "%s" --backend=ninja %s --buildtype=release --cross-file=%s' \
                        % (source_expected, build_expected, defs_to_string(defs), cross_file)
         self._check_commands(cmd_expected, conan_file.command)
 

--- a/conans/test/unittests/client/build/meson_test.py
+++ b/conans/test/unittests/client/build/meson_test.py
@@ -71,18 +71,19 @@ class MesonTest(unittest.TestCase):
             'includedir': 'include',
             'cpp_std': 'none'
         }
-
+        build_dir = os.path.join(self.tempdir, "build")
         meson.configure(source_dir=os.path.join(self.tempdir, "../subdir"),
-                        build_dir=os.path.join(self.tempdir, "build"))
+                        build_dir=build_dir)
         source_expected = os.path.join(self.tempdir, "../subdir")
-        build_expected = os.path.join(self.tempdir, "build")
-        cmd_expected = 'meson "%s" "%s" --backend=ninja %s --buildtype=release' \
-                       % (source_expected, build_expected, defs_to_string(defs))
+        build_expected = build_dir
+        cross_file = os.path.join(build_dir, "cross_file.txt")
+        cmd_expected = 'meson "%s" "%s" --backend=ninja %s --buildtype=release --cross-file=%s' \
+                       % (source_expected, build_expected, defs_to_string(defs), cross_file)
         self._check_commands(cmd_expected, conan_file.command)
 
-        meson.configure(build_dir=os.path.join(self.tempdir, "build"))
+        meson.configure(build_dir=build_dir)
         source_expected = os.path.join(self.tempdir, "my_cache_source_folder")
-        build_expected = os.path.join(self.tempdir, "build")
+        build_expected = build_dir
         cmd_expected = 'meson "%s" "%s" --backend=ninja %s --buildtype=release' \
                        % (source_expected, build_expected, defs_to_string(defs))
         self._check_commands(cmd_expected, conan_file.command)

--- a/conans/test/unittests/client/build/meson_test.py
+++ b/conans/test/unittests/client/build/meson_test.py
@@ -84,22 +84,22 @@ class MesonTest(unittest.TestCase):
         meson.configure(build_dir=build_dir)
         source_expected = os.path.join(self.tempdir, "my_cache_source_folder")
         build_expected = build_dir
-        cmd_expected = 'meson "%s" "%s" --backend=ninja %s --buildtype=release' \
-                       % (source_expected, build_expected, defs_to_string(defs))
+        cmd_expected = 'meson "%s" "%s" --backend=ninja %s --buildtype=release --cross-file=%s' \
+                       % (source_expected, build_expected, defs_to_string(defs), cross_file)
         self._check_commands(cmd_expected, conan_file.command)
 
         meson.configure()
         source_expected = os.path.join(self.tempdir, "my_cache_source_folder")
         build_expected = os.path.join(self.tempdir, "my_cache_build_folder")
-        cmd_expected = 'meson "%s" "%s" --backend=ninja %s --buildtype=release' \
-                       % (source_expected, build_expected, defs_to_string(defs))
+        cmd_expected = 'meson "%s" "%s" --backend=ninja %s --buildtype=release --cross-file=%s' \
+                       % (source_expected, build_expected, defs_to_string(defs), cross_file)
         self._check_commands(cmd_expected, conan_file.command)
 
         meson.configure(source_folder="source", build_folder="build")
         build_expected = os.path.join(self.tempdir, "my_cache_build_folder", "build")
         source_expected = os.path.join(self.tempdir, "my_cache_source_folder", "source")
-        cmd_expected = 'meson "%s" "%s" --backend=ninja %s --buildtype=release' \
-                       % (source_expected, build_expected, defs_to_string(defs))
+        cmd_expected = 'meson "%s" "%s" --backend=ninja %s --buildtype=releas --cross-file=%s' \
+                       % (source_expected, build_expected, defs_to_string(defs), cross_file)
         self._check_commands(cmd_expected, conan_file.command)
 
         conan_file.in_local_cache = True
@@ -107,8 +107,8 @@ class MesonTest(unittest.TestCase):
                         cache_build_folder="rel_only_cache")
         build_expected = os.path.join(self.tempdir, "my_cache_build_folder", "rel_only_cache")
         source_expected = os.path.join(self.tempdir, "my_cache_source_folder", "source")
-        cmd_expected = 'meson "%s" "%s" --backend=ninja %s --buildtype=release' \
-                       % (source_expected, build_expected, defs_to_string(defs))
+        cmd_expected = 'meson "%s" "%s" --backend=ninja %s --buildtype=release --cross-file=%s' \
+                       % (source_expected, build_expected, defs_to_string(defs), cross_file)
         self._check_commands(cmd_expected, conan_file.command)
 
         conan_file.in_local_cache = False
@@ -116,16 +116,16 @@ class MesonTest(unittest.TestCase):
                         cache_build_folder="rel_only_cache")
         build_expected = os.path.join(self.tempdir, "my_cache_build_folder", "build")
         source_expected = os.path.join(self.tempdir, "my_cache_source_folder", "source")
-        cmd_expected = 'meson "%s" "%s" --backend=ninja %s --buildtype=release' \
-                       % (source_expected, build_expected, defs_to_string(defs))
+        cmd_expected = 'meson "%s" "%s" --backend=ninja %s --buildtype=release --cross-file=%s' \
+                       % (source_expected, build_expected, defs_to_string(defs), cross_file)
         self._check_commands(cmd_expected, conan_file.command)
 
         conan_file.in_local_cache = True
         meson.configure(build_dir="build", cache_build_folder="rel_only_cache")
         build_expected = os.path.join(self.tempdir, "my_cache_build_folder", "rel_only_cache")
         source_expected = os.path.join(self.tempdir, "my_cache_source_folder")
-        cmd_expected = 'meson "%s" "%s" --backend=ninja %s --buildtype=release' \
-                       % (source_expected, build_expected, defs_to_string(defs))
+        cmd_expected = 'meson "%s" "%s" --backend=ninja %s --buildtype=release --cross-file=%s' \
+                       % (source_expected, build_expected, defs_to_string(defs), cross_file)
         self._check_commands(cmd_expected, conan_file.command)
 
         args = ['--werror', '--warnlevel 3']
@@ -134,9 +134,9 @@ class MesonTest(unittest.TestCase):
                         defs={'default_library': 'static'})
         build_expected = os.path.join(self.tempdir, "my_cache_build_folder", "build")
         source_expected = os.path.join(self.tempdir, "my_cache_source_folder", "source")
-        cmd_expected = 'meson "%s" "%s" --backend=ninja %s %s --buildtype=release' \
+        cmd_expected = 'meson "%s" "%s" --backend=ninja %s %s --buildtype=release --cross-file=%s' \
                        % (source_expected, build_expected, args_to_string(args),
-                          defs_to_string(defs))
+                          defs_to_string(defs), cross_file)
         self._check_commands(cmd_expected, conan_file.command)
 
         # Raise mixing

--- a/conans/test/unittests/client/build/meson_test.py
+++ b/conans/test/unittests/client/build/meson_test.py
@@ -91,6 +91,7 @@ class MesonTest(unittest.TestCase):
         meson.configure()
         source_expected = os.path.join(self.tempdir, "my_cache_source_folder")
         build_expected = os.path.join(self.tempdir, "my_cache_build_folder")
+        cross_file = os.path.join(build_expected, "cross_file.txt")
         cmd_expected = 'meson "%s" "%s" --backend=ninja %s --buildtype=release --cross-file=%s' \
                        % (source_expected, build_expected, defs_to_string(defs), cross_file)
         self._check_commands(cmd_expected, conan_file.command)
@@ -98,6 +99,7 @@ class MesonTest(unittest.TestCase):
         meson.configure(source_folder="source", build_folder="build")
         build_expected = os.path.join(self.tempdir, "my_cache_build_folder", "build")
         source_expected = os.path.join(self.tempdir, "my_cache_source_folder", "source")
+        cross_file = os.path.join(build_expected, "cross_file.txt")
         cmd_expected = 'meson "%s" "%s" --backend=ninja %s --buildtype=releas --cross-file=%s' \
                        % (source_expected, build_expected, defs_to_string(defs), cross_file)
         self._check_commands(cmd_expected, conan_file.command)
@@ -107,6 +109,7 @@ class MesonTest(unittest.TestCase):
                         cache_build_folder="rel_only_cache")
         build_expected = os.path.join(self.tempdir, "my_cache_build_folder", "rel_only_cache")
         source_expected = os.path.join(self.tempdir, "my_cache_source_folder", "source")
+        cross_file = os.path.join(build_expected, "cross_file.txt")
         cmd_expected = 'meson "%s" "%s" --backend=ninja %s --buildtype=release --cross-file=%s' \
                        % (source_expected, build_expected, defs_to_string(defs), cross_file)
         self._check_commands(cmd_expected, conan_file.command)
@@ -116,6 +119,7 @@ class MesonTest(unittest.TestCase):
                         cache_build_folder="rel_only_cache")
         build_expected = os.path.join(self.tempdir, "my_cache_build_folder", "build")
         source_expected = os.path.join(self.tempdir, "my_cache_source_folder", "source")
+        cross_file = os.path.join(build_expected, "cross_file.txt")
         cmd_expected = 'meson "%s" "%s" --backend=ninja %s --buildtype=release --cross-file=%s' \
                        % (source_expected, build_expected, defs_to_string(defs), cross_file)
         self._check_commands(cmd_expected, conan_file.command)
@@ -124,6 +128,7 @@ class MesonTest(unittest.TestCase):
         meson.configure(build_dir="build", cache_build_folder="rel_only_cache")
         build_expected = os.path.join(self.tempdir, "my_cache_build_folder", "rel_only_cache")
         source_expected = os.path.join(self.tempdir, "my_cache_source_folder")
+        cross_file = os.path.join(build_expected, "cross_file.txt")
         cmd_expected = 'meson "%s" "%s" --backend=ninja %s --buildtype=release --cross-file=%s' \
                        % (source_expected, build_expected, defs_to_string(defs), cross_file)
         self._check_commands(cmd_expected, conan_file.command)
@@ -134,6 +139,7 @@ class MesonTest(unittest.TestCase):
                         defs={'default_library': 'static'})
         build_expected = os.path.join(self.tempdir, "my_cache_build_folder", "build")
         source_expected = os.path.join(self.tempdir, "my_cache_source_folder", "source")
+        cross_file = os.path.join(build_expected, "cross_file.txt")
         cmd_expected = 'meson "%s" "%s" --backend=ninja %s %s --buildtype=release --cross-file=%s' \
                        % (source_expected, build_expected, args_to_string(args),
                           defs_to_string(defs), cross_file)


### PR DESCRIPTION
This currently works for compiling glib for aarch64 on x86_64,
but probably not for anything else yet. But it should be
simpler to add more architectures when needed than the situation
today.  Improves #4529

Changelog: (Feature): Add preliminary support for cross builds using meson
Docs: https://github.com/conan-io/docs/pull/XXXX

- [x] Refer to the issue that supports this Pull Request.
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 

<sup>**Note:** By default this PR will skip the slower tests and will use a limited set of python versions. Check [here](https://github.com/conan-io/conan/blob/develop/.github/PR_INCREASE_TESTING.md) how to increase the testing level by writing some tags in the current PR body text.</sup>
