### PR TITLE
meson: Add preliminary support for cross builds

### DIFF
--- a/conans/test/unittests/client/build/meson_test.py
+++ b/conans/test/unittests/client/build/meson_test.py
@@ -71,34 +71,37 @@ class MesonTest(unittest.TestCase):
             'includedir': 'include',
             'cpp_std': 'none'
         }
-
+        build_dir = os.path.join(self.tempdir, "build")
         meson.configure(source_dir=os.path.join(self.tempdir, "../subdir"),
-                        build_dir=os.path.join(self.tempdir, "build"))
+                        build_dir=build_dir)
         source_expected = os.path.join(self.tempdir, "../subdir")
-        build_expected = os.path.join(self.tempdir, "build")
-        cmd_expected = 'meson "%s" "%s" --backend=ninja %s --buildtype=release' \
-                       % (source_expected, build_expected, defs_to_string(defs))
+        build_expected = build_dir
+        cross_file = os.path.join(build_dir, "cross_file.txt")
+        cmd_expected = 'meson "%s" "%s" --backend=ninja %s --buildtype=release --cross-file=%s' \
+                       % (source_expected, build_expected, defs_to_string(defs), cross_file)
         self._check_commands(cmd_expected, conan_file.command)
 
-        meson.configure(build_dir=os.path.join(self.tempdir, "build"))
+        meson.configure(build_dir=build_dir)
         source_expected = os.path.join(self.tempdir, "my_cache_source_folder")
-        build_expected = os.path.join(self.tempdir, "build")
-        cmd_expected = 'meson "%s" "%s" --backend=ninja %s --buildtype=release' \
-                       % (source_expected, build_expected, defs_to_string(defs))
+        build_expected = build_dir
+        cmd_expected = 'meson "%s" "%s" --backend=ninja %s --buildtype=release --cross-file=%s' \
+                       % (source_expected, build_expected, defs_to_string(defs), cross_file)
         self._check_commands(cmd_expected, conan_file.command)
 
         meson.configure()
         source_expected = os.path.join(self.tempdir, "my_cache_source_folder")
         build_expected = os.path.join(self.tempdir, "my_cache_build_folder")
-        cmd_expected = 'meson "%s" "%s" --backend=ninja %s --buildtype=release' \
-                       % (source_expected, build_expected, defs_to_string(defs))
+        cross_file = os.path.join(build_expected, "cross_file.txt")
+        cmd_expected = 'meson "%s" "%s" --backend=ninja %s --buildtype=release --cross-file=%s' \
+                       % (source_expected, build_expected, defs_to_string(defs), cross_file)
         self._check_commands(cmd_expected, conan_file.command)
 
         meson.configure(source_folder="source", build_folder="build")
         build_expected = os.path.join(self.tempdir, "my_cache_build_folder", "build")
         source_expected = os.path.join(self.tempdir, "my_cache_source_folder", "source")
-        cmd_expected = 'meson "%s" "%s" --backend=ninja %s --buildtype=release' \
-                       % (source_expected, build_expected, defs_to_string(defs))
+        cross_file = os.path.join(build_expected, "cross_file.txt")
+        cmd_expected = 'meson "%s" "%s" --backend=ninja %s --buildtype=release --cross-file=%s' \
+                       % (source_expected, build_expected, defs_to_string(defs), cross_file)
         self._check_commands(cmd_expected, conan_file.command)
 
         conan_file.in_local_cache = True
@@ -106,8 +109,9 @@ class MesonTest(unittest.TestCase):
                         cache_build_folder="rel_only_cache")
         build_expected = os.path.join(self.tempdir, "my_cache_build_folder", "rel_only_cache")
         source_expected = os.path.join(self.tempdir, "my_cache_source_folder", "source")
-        cmd_expected = 'meson "%s" "%s" --backend=ninja %s --buildtype=release' \
-                       % (source_expected, build_expected, defs_to_string(defs))
+        cross_file = os.path.join(build_expected, "cross_file.txt")
+        cmd_expected = 'meson "%s" "%s" --backend=ninja %s --buildtype=release --cross-file=%s' \
+                       % (source_expected, build_expected, defs_to_string(defs), cross_file)
         self._check_commands(cmd_expected, conan_file.command)
 
         conan_file.in_local_cache = False
@@ -115,16 +119,18 @@ class MesonTest(unittest.TestCase):
                         cache_build_folder="rel_only_cache")
         build_expected = os.path.join(self.tempdir, "my_cache_build_folder", "build")
         source_expected = os.path.join(self.tempdir, "my_cache_source_folder", "source")
-        cmd_expected = 'meson "%s" "%s" --backend=ninja %s --buildtype=release' \
-                       % (source_expected, build_expected, defs_to_string(defs))
+        cross_file = os.path.join(build_expected, "cross_file.txt")
+        cmd_expected = 'meson "%s" "%s" --backend=ninja %s --buildtype=release --cross-file=%s' \
+                       % (source_expected, build_expected, defs_to_string(defs), cross_file)
         self._check_commands(cmd_expected, conan_file.command)
 
         conan_file.in_local_cache = True
         meson.configure(build_dir="build", cache_build_folder="rel_only_cache")
         build_expected = os.path.join(self.tempdir, "my_cache_build_folder", "rel_only_cache")
         source_expected = os.path.join(self.tempdir, "my_cache_source_folder")
-        cmd_expected = 'meson "%s" "%s" --backend=ninja %s --buildtype=release' \
-                       % (source_expected, build_expected, defs_to_string(defs))
+        cross_file = os.path.join(build_expected, "cross_file.txt")
+        cmd_expected = 'meson "%s" "%s" --backend=ninja %s --buildtype=release --cross-file=%s' \
+                       % (source_expected, build_expected, defs_to_string(defs), cross_file)
         self._check_commands(cmd_expected, conan_file.command)
 
         args = ['--werror', '--warnlevel 3']
@@ -133,9 +139,10 @@ class MesonTest(unittest.TestCase):
                         defs={'default_library': 'static'})
         build_expected = os.path.join(self.tempdir, "my_cache_build_folder", "build")
         source_expected = os.path.join(self.tempdir, "my_cache_source_folder", "source")
-        cmd_expected = 'meson "%s" "%s" --backend=ninja %s %s --buildtype=release' \
+        cross_file = os.path.join(build_expected, "cross_file.txt")
+        cmd_expected = 'meson "%s" "%s" --backend=ninja %s %s --buildtype=release --cross-file=%s' \
                        % (source_expected, build_expected, args_to_string(args),
-                          defs_to_string(defs))
+                          defs_to_string(defs), cross_file)
         self._check_commands(cmd_expected, conan_file.command)
 
         # Raise mixing


### PR DESCRIPTION
This currently works for compiling glib for aarch64 on x86_64,
but probably not for anything else yet. But it should be
simpler to add more architectures when needed than the situation
today. Improves #4529.

Changelog: (Fix): Make cross-compiling with meson work in some cases

- [x] Refer to the issue that supports this Pull Request.
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 

<sup>**Note:** By default this PR will skip the slower tests and will use a limited set of python versions. Check [here](https://github.com/conan-io/conan/blob/develop/.github/PR_INCREASE_TESTING.md) how to increase the testing level by writing some tags in the current PR body text.</sup>
