### PR TITLE
Set runtime for intel compiler with visual

### DIFF
--- a/conans/client/settings_preprocessor.py
+++ b/conans/client/settings_preprocessor.py
@@ -50,12 +50,20 @@ def _check_cppstd(settings):
 
 def _fill_runtime(settings):
     try:
+        runtime = "MDd" if settings.get_safe("build_type") == "Debug" else "MD"
         if settings.compiler == "Visual Studio":
-            if settings.get_safe("compiler.runtime") is None:
-                settings.compiler.runtime = "MDd" if settings.get_safe("build_type") == "Debug" \
-                                                  else "MD"
-                logger.info("Setting 'compiler.runtime' not declared, automatically "
-                            "adjusted to '%s'" % settings.compiler.runtime)
+            runtime_key = "compiler.runtime"
+            if settings.get_safe(runtime_key) is None:
+                settings.compiler.runtime = runtime
+        elif settings.compiler == "intel" and settings.get_safe("compiler.base") == "Visual Studio":
+            runtime_key = "compiler.base.runtime"
+            if settings.get_safe(runtime_key) is None:
+                settings.compiler.base.runtime = runtime
+        else:
+            return
+
+        logger.info("Setting '{}' not declared, automatically adjusted to '{}'".format(
+                runtime, deduced_runtime))
     except Exception:  # If the settings structure doesn't match these general
         # asumptions, like unexistant runtime
         pass

--- a/conans/client/settings_preprocessor.py
+++ b/conans/client/settings_preprocessor.py
@@ -63,7 +63,7 @@ def _fill_runtime(settings):
             return
 
         logger.info("Setting '{}' not declared, automatically adjusted to '{}'".format(
-                runtime, deduced_runtime))
+                runtime_key, runtime))
     except Exception:  # If the settings structure doesn't match these general
         # asumptions, like unexistant runtime
         pass

--- a/conans/test/unittests/client/settings_preprocessor_test.py
+++ b/conans/test/unittests/client/settings_preprocessor_test.py
@@ -1,0 +1,68 @@
+# coding=utf-8
+
+import unittest
+
+from mock import mock
+
+from conans import Settings
+from conans.client.conf import default_settings_yml
+from conans.client.settings_preprocessor import preprocess
+from conans.test.utils.conanfile import MockSettings
+
+
+class SettingsCompilerIntelVisualPreprocessorTest(unittest.TestCase):
+
+    def setUp(self):
+        self.settings = Settings.loads(default_settings_yml)
+        self.settings.compiler = "intel"
+        self.settings.compiler.base = "Visual Studio"
+
+    def release_build_type_runtime_test(self):
+        self.settings.build_type = "Release"
+        preprocess(self.settings)
+        self.assertEqual(self.settings.compiler.base.runtime, "MD")
+
+    def debug_build_type_runtime_test(self):
+        self.settings.build_type = "Debug"
+        preprocess(self.settings)
+        self.assertEqual(self.settings.compiler.base.runtime, "MDd")
+
+    def different_base_compiler_test(self):
+        self.settings.compiler.base = "gcc"
+        self.settings.build_type = "Debug"
+        preprocess(self.settings)
+        self.assertIsNone(self.settings.compiler.base.get_safe("runtime"))
+
+    def custom_base_runtime_set_test(self):
+        self.settings.build_type = "Debug"
+        self.settings.compiler.base.runtime = "MT"
+        preprocess(self.settings)
+        self.assertEqual(self.settings.compiler.base.runtime, "MT")
+
+class SettingsCompilerVisualPreprocessorTest(unittest.TestCase):
+
+    def setUp(self):
+        self.settings = Settings.loads(default_settings_yml)
+        self.settings.compiler = "Visual Studio"
+
+    def release_build_type_runtime_test(self):
+        self.settings.build_type = "Release"
+        preprocess(self.settings)
+        self.assertEqual(self.settings.compiler.runtime, "MD")
+
+    def debug_build_type_runtime_test(self):
+        self.settings.build_type = "Debug"
+        preprocess(self.settings)
+        self.assertEqual(self.settings.compiler.runtime, "MDd")
+
+    def different_base_compiler_test(self):
+        self.settings.compiler = "gcc"
+        self.settings.build_type = "Debug"
+        preprocess(self.settings)
+        self.assertIsNone(self.settings.compiler.get_safe("runtime"))
+
+    def custom_base_runtime_set_test(self):
+        self.settings.build_type = "Debug"
+        self.settings.compiler.runtime = "MT"
+        preprocess(self.settings)
+        self.assertEqual(self.settings.compiler.runtime, "MT")


### PR DESCRIPTION
Changelog: Feature: Deduce `compiler.base.runtime` for Intel compiler settings when using Visual Studio as the base compiler
Docs: omit

- [x] Refer to the issue that supports this Pull Request: closes #6343
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [x] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 

<sup>**Note:** By default this PR will skip the slower tests and will use a limited set of python versions. Check [here](https://github.com/conan-io/conan/blob/develop/.github/PR_INCREASE_TESTING.md) how to increase the testing level by writing some tags in the current PR body text.</sup>
