### PR TITLE
Revert PR #6288 

### DIFF
--- a/conans/client/generators/cmake.py
+++ b/conans/client/generators/cmake.py
@@ -78,8 +78,8 @@ class CMakeGenerator(Generator):
         sections.append(CMakeCommonMacros.apple_frameworks_macro)
 
         # Per requirement variables
-        for name, dep_cpp_info in self.deps_build_info.dependencies:
-            dep_name = dep_cpp_info.get_name("cmake", name)
+        for _, dep_cpp_info in self.deps_build_info.dependencies:
+            dep_name = dep_cpp_info.get_name("cmake")
             deps = DepsCppCmake(dep_cpp_info)
             dep_flags = cmake_dependency_vars(dep_name, deps=deps)
             sections.append(dep_flags)

--- a/conans/client/generators/cmake_common.py
+++ b/conans/client/generators/cmake_common.py
@@ -190,14 +190,14 @@ def generate_targets_section(dependencies, generator_name):
                    '    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${CONAN_CMD_C_FLAGS}")\n'
                    '    set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} ${CONAN_CMD_SHARED_LINKER_FLAGS}")\n')
     dependencies_dict = {name: dep_info for name, dep_info in dependencies}
-    for name, dep_info in dependencies:
-        dep_name = dep_info.get_name(generator_name, name)
-        use_deps = ["CONAN_PKG::%s" % dependencies_dict[d].get_name(generator_name, d) for d in dep_info.public_deps]
+    for _, dep_info in dependencies:
+        dep_name = dep_info.get_name(generator_name)
+        use_deps = ["CONAN_PKG::%s" % dependencies_dict[d].get_name(generator_name) for d in dep_info.public_deps]
         deps = "" if not use_deps else " ".join(use_deps)
         section.append(_target_template.format(name="CONAN_PKG::%s" % dep_name, deps=deps,
                                                uname=dep_name.upper(), pkg_name=dep_name))
 
-    all_targets = " ".join(["CONAN_PKG::%s" % dep_info.get_name(generator_name, name) for name, dep_info in dependencies])
+    all_targets = " ".join(["CONAN_PKG::%s" % dep_info.get_name(generator_name) for _, dep_info in dependencies])
     section.append('    set(CONAN_TARGETS %s)\n' % all_targets)
     section.append('endmacro()\n')
     return section

--- a/conans/client/generators/cmake_multi.py
+++ b/conans/client/generators/cmake_multi.py
@@ -50,8 +50,8 @@ class CMakeMultiGenerator(Generator):
         sections = []
 
         # Per requirement variables
-        for name, dep_cpp_info in self.deps_build_info.dependencies:
-            dep_name = dep_cpp_info.get_name("cmake_multi", name)
+        for _, dep_cpp_info in self.deps_build_info.dependencies:
+            dep_name = dep_cpp_info.get_name("cmake_multi")
             # Only the specific of the build_type
             dep_cpp_info = extend(dep_cpp_info, build_type)
             deps = DepsCppCmake(dep_cpp_info)

--- a/conans/client/generators/cmake_paths.py
+++ b/conans/client/generators/cmake_paths.py
@@ -14,8 +14,8 @@ class CMakePathsGenerator(Generator):
         # The CONAN_XXX_ROOT variables are needed because the FindXXX.cmake or XXXConfig.cmake
         # in a package could have been "patched" with the `cmake.patch_config_paths()`
         # replacing absolute paths with CONAN_XXX_ROOT variables.
-        for name, dep_cpp_info in self.deps_build_info.dependencies:
-            var_name = "CONAN_{}_ROOT".format(dep_cpp_info.get_name("cmake_paths", name).upper())
+        for _, dep_cpp_info in self.deps_build_info.dependencies:
+            var_name = "CONAN_{}_ROOT".format(dep_cpp_info.get_name("cmake_paths").upper())
             lines.append('set({} {})'.format(var_name, DepsCppCmake(dep_cpp_info).rootpath))
 
         # We want to prioritize the FindXXX.cmake files:

--- a/conans/model/build_info.py
+++ b/conans/model/build_info.py
@@ -109,9 +109,8 @@ class _CppInfo(object):
             self._framework_paths = self._filter_paths(self.frameworkdirs)
         return self._framework_paths
 
-    def get_name(self, generator, pkg_name=None):
-        fallback_name = self.name if generator not in ["cmake", "cmake_multi", "cmake_paths"] else pkg_name  # FIXME: Remove in v1.22 (https://github.com/conan-io/conan/issues/6269#issuecomment-570182130)
-        return self.names.get(generator, fallback_name)
+    def get_name(self, generator):
+        return self.names.get(generator, self.name)
 
     # Compatibility for 'cppflags' (old style property to allow decoration)
     @deprecation.deprecated(deprecated_in="1.13", removed_in="2.0", details="Use 'cxxflags' instead")

--- a/conans/test/unittests/client/generators/cmake_paths_test.py
+++ b/conans/test/unittests/client/generators/cmake_paths_test.py
@@ -66,7 +66,7 @@ class CMakePathsGeneratorTest(unittest.TestCase):
         cpp_info.name = "PkgCMakeName"
         conanfile.deps_cpp_info.update(cpp_info, "pkg_reference_name")
         generator = CMakePathsGenerator(conanfile)
-        self.assertIn('set(CONAN_PKG_REFERENCE_NAME_ROOT', generator.content)
+        self.assertIn('set(CONAN_PKGCMAKENAME_ROOT', generator.content)
 
     def cpp_info_names_test(self):
         settings = _MockSettings("Release")

--- a/conans/test/unittests/client/generators/cmake_test.py
+++ b/conans/test/unittests/client/generators/cmake_test.py
@@ -378,25 +378,26 @@ class CMakeCppInfoNameTest(unittest.TestCase):
         content = generator.content
         self.assertIn("set(CONAN_DEPENDENCIES my_pkg my_pkg2)", content)
         content = content.replace("set(CONAN_DEPENDENCIES my_pkg my_pkg2)", "")
-        self.assertNotIn("MyPkG", content)
-        self.assertNotIn("MYPKG", content)
-        self.assertIn('add_library(CONAN_PKG::my_pkg INTERFACE IMPORTED)', content)
-        self.assertIn('add_library(CONAN_PKG::my_pkg2 INTERFACE IMPORTED)', content)
-        self.assertNotIn('CONAN_PKG::MyPkG', content)
-        self.assertNotIn('CONAN_PKG::MyPkG2', content)
+        self.assertNotIn("my_pkg", content)
+        self.assertNotIn("MY_PKG", content)
+        self.assertIn('add_library(CONAN_PKG::MyPkG INTERFACE IMPORTED)', content)
+        self.assertIn('add_library(CONAN_PKG::MyPkG2 INTERFACE IMPORTED)', content)
+        self.assertNotIn('CONAN_PKG::my_pkg', content)
+        self.assertNotIn('CONAN_PKG::my_pkg2', content)
 
     def cmake_multi_test(self):
         generator = CMakeMultiGenerator(self.conanfile)
         content = generator.content
         self.assertIn("set(CONAN_DEPENDENCIES_DEBUG my_pkg my_pkg2)",
                       content["conanbuildinfo_debug.cmake"])
-        self.assertNotIn("MyPkG", content["conanbuildinfo_multi.cmake"])
-        self.assertIn('add_library(CONAN_PKG::my_pkg INTERFACE IMPORTED)',
+        self.assertNotIn("my_pkg", content["conanbuildinfo_multi.cmake"])
+        self.assertNotIn("MY_PKG", content["conanbuildinfo_multi.cmake"])
+        self.assertIn('add_library(CONAN_PKG::MyPkG INTERFACE IMPORTED)',
                       content["conanbuildinfo_multi.cmake"])
-        self.assertIn('add_library(CONAN_PKG::my_pkg2 INTERFACE IMPORTED)',
+        self.assertIn('add_library(CONAN_PKG::MyPkG2 INTERFACE IMPORTED)',
                       content["conanbuildinfo_multi.cmake"])
-        self.assertNotIn('CONAN_PKG::MyPkG', content["conanbuildinfo_multi.cmake"])
-        self.assertNotIn('CONAN_PKG::MyPkG2', content["conanbuildinfo_multi.cmake"])
+        self.assertNotIn('CONAN_PKG::my_pkg', content["conanbuildinfo_multi.cmake"])
+        self.assertNotIn('CONAN_PKG::my_pkg2', content["conanbuildinfo_multi.cmake"])
 
     def cmake_find_package_test(self):
         generator = CMakeFindPackageGenerator(self.conanfile)


### PR DESCRIPTION


This reverts commit 1bdbf183bb7ed48d2ee4ec87b10b34afb69bdbe6.

Changelog: Fix: Generators `cmake` and `cmake_multi` use the name defined in `cpp_info.name` (reverts change from 1.21.1 as stated)
Docs: omit

