### PR TITLE
Add GLOBAL to conan targets so they can be used with ALIAS in CMake

### DIFF
--- a/conans/client/generators/cmake_common.py
+++ b/conans/client/generators/cmake_common.py
@@ -241,7 +241,7 @@ class CMakeCommonMacros:
                 if(CONAN_FOUND_LIBRARY)
                     conan_message(STATUS "Library ${_LIBRARY_NAME} found ${CONAN_FOUND_LIBRARY}")
                     set(_LIB_NAME CONAN_LIB::${package_name}_${_LIBRARY_NAME}${build_type})
-                    add_library(${_LIB_NAME} UNKNOWN IMPORTED)
+                    add_library(${_LIB_NAME} UNKNOWN IMPORTED GLOBAL)
                     set_target_properties(${_LIB_NAME} PROPERTIES IMPORTED_LOCATION ${CONAN_FOUND_LIBRARY})
                     string(REPLACE " " ";" deps_list "${deps}")
                     set_property(TARGET ${_LIB_NAME} PROPERTY INTERFACE_LINK_LIBRARIES ${deps_list})

--- a/conans/client/generators/cmake_common.py
+++ b/conans/client/generators/cmake_common.py
@@ -152,7 +152,7 @@ _target_template = """
                                   CONAN_PACKAGE_TARGETS_{uname}_MINSIZEREL "${{CONAN_SYSTEM_LIBS_{uname}_MINSIZEREL}} {deps}"
                                   "minsizerel" {pkg_name})
 
-    add_library({name} INTERFACE IMPORTED)
+    add_library({name} INTERFACE IMPORTED GLOBAL)
 
     # Property INTERFACE_LINK_FLAGS do not work, necessary to add to INTERFACE_LINK_LIBRARIES
     set_property(TARGET {name} PROPERTY INTERFACE_LINK_LIBRARIES ${{CONAN_PACKAGE_TARGETS_{uname}}} ${{CONAN_SHARED_LINKER_FLAGS_{uname}_LIST}} ${{CONAN_EXE_LINKER_FLAGS_{uname}_LIST}}

--- a/conans/client/generators/cmake_find_package.py
+++ b/conans/client/generators/cmake_find_package.py
@@ -35,7 +35,7 @@ class CMakeFindPackageGenerator(Generator):
 if(NOT ${{CMAKE_VERSION}} VERSION_LESS "3.0")
     # Target approach
     if(NOT TARGET {name}::{name})
-        add_library({name}::{name} INTERFACE IMPORTED)
+        add_library({name}::{name} INTERFACE IMPORTED GLOBAL)
         {assign_target_properties_block}
         {find_dependencies_block}
     endif()

--- a/conans/client/generators/cmake_find_package_common.py
+++ b/conans/client/generators/cmake_find_package_common.py
@@ -98,7 +98,7 @@ class CMakeFindPackageCommonMacros:
                         set(_LIB_NAME CONAN_LIB::${package_name}_${_LIBRARY_NAME}${build_type})
                         if(NOT TARGET ${_LIB_NAME})
                             # Create a micro-target for each lib/a found
-                            add_library(${_LIB_NAME} UNKNOWN IMPORTED)
+                            add_library(${_LIB_NAME} UNKNOWN IMPORTED GLOBAL)
                             set_target_properties(${_LIB_NAME} PROPERTIES IMPORTED_LOCATION ${CONAN_FOUND_LIBRARY})
                         else()
                             conan_message(STATUS "Skipping already existing target: ${_LIB_NAME}")

--- a/conans/client/generators/cmake_find_package_multi.py
+++ b/conans/client/generators/cmake_find_package_multi.py
@@ -21,7 +21,7 @@ include(${{CMAKE_CURRENT_LIST_DIR}}/{name}Targets.cmake)
 
     targets_file = """
 if(NOT TARGET {name}::{name})
-    add_library({name}::{name} INTERFACE IMPORTED)
+    add_library({name}::{name} INTERFACE IMPORTED GLOBAL)
 endif()
 
 # Load the debug and release library finders

--- a/conans/test/unittests/client/generators/cmake_test.py
+++ b/conans/test/unittests/client/generators/cmake_test.py
@@ -380,8 +380,8 @@ class CMakeCppInfoNameTest(unittest.TestCase):
         content = content.replace("set(CONAN_DEPENDENCIES my_pkg my_pkg2)", "")
         self.assertNotIn("my_pkg", content)
         self.assertNotIn("MY_PKG", content)
-        self.assertIn('add_library(CONAN_PKG::MyPkG INTERFACE IMPORTED)', content)
-        self.assertIn('add_library(CONAN_PKG::MyPkG2 INTERFACE IMPORTED)', content)
+        self.assertIn('add_library(CONAN_PKG::MyPkG INTERFACE IMPORTED GLOBAL)', content)
+        self.assertIn('add_library(CONAN_PKG::MyPkG2 INTERFACE IMPORTED GLOBAL)', content)
         self.assertNotIn('CONAN_PKG::my_pkg', content)
         self.assertNotIn('CONAN_PKG::my_pkg2', content)
 
@@ -392,9 +392,9 @@ class CMakeCppInfoNameTest(unittest.TestCase):
                       content["conanbuildinfo_debug.cmake"])
         self.assertNotIn("my_pkg", content["conanbuildinfo_multi.cmake"])
         self.assertNotIn("MY_PKG", content["conanbuildinfo_multi.cmake"])
-        self.assertIn('add_library(CONAN_PKG::MyPkG INTERFACE IMPORTED)',
+        self.assertIn('add_library(CONAN_PKG::MyPkG INTERFACE IMPORTED GLOBAL)',
                       content["conanbuildinfo_multi.cmake"])
-        self.assertIn('add_library(CONAN_PKG::MyPkG2 INTERFACE IMPORTED)',
+        self.assertIn('add_library(CONAN_PKG::MyPkG2 INTERFACE IMPORTED GLOBAL)',
                       content["conanbuildinfo_multi.cmake"])
         self.assertNotIn('CONAN_PKG::my_pkg', content["conanbuildinfo_multi.cmake"])
         self.assertNotIn('CONAN_PKG::my_pkg2', content["conanbuildinfo_multi.cmake"])
@@ -408,8 +408,8 @@ class CMakeCppInfoNameTest(unittest.TestCase):
         self.assertNotIn("MY_PKG", content["FindMyPkG.cmake"])
         self.assertNotIn("my_pkg", content["FindMyPkG2.cmake"])
         self.assertNotIn("MY_PKG", content["FindMyPkG2.cmake"])
-        self.assertIn("add_library(MyPkG::MyPkG INTERFACE IMPORTED)", content["FindMyPkG.cmake"])
-        self.assertIn("add_library(MyPkG2::MyPkG2 INTERFACE IMPORTED)", content["FindMyPkG2.cmake"])
+        self.assertIn("add_library(MyPkG::MyPkG INTERFACE IMPORTED GLOBAL)", content["FindMyPkG.cmake"])
+        self.assertIn("add_library(MyPkG2::MyPkG2 INTERFACE IMPORTED GLOBAL)", content["FindMyPkG2.cmake"])
         self.assertIn("find_dependency(MyPkG REQUIRED)", content["FindMyPkG2.cmake"])
 
     def cmake_find_package_multi_test(self):
@@ -423,9 +423,9 @@ class CMakeCppInfoNameTest(unittest.TestCase):
         self.assertNotIn("MY_PKG", content["MyPkGConfig.cmake"])
         self.assertNotIn("my_pkg", content["MyPkG2Config.cmake"])
         self.assertNotIn("MY_PKG", content["MyPkG2Config.cmake"])
-        self.assertIn("add_library(MyPkG::MyPkG INTERFACE IMPORTED)",
+        self.assertIn("add_library(MyPkG::MyPkG INTERFACE IMPORTED GLOBAL)",
                       content["MyPkGTargets.cmake"])
-        self.assertIn("add_library(MyPkG2::MyPkG2 INTERFACE IMPORTED)",
+        self.assertIn("add_library(MyPkG2::MyPkG2 INTERFACE IMPORTED GLOBAL)",
                       content["MyPkG2Targets.cmake"])
         self.assertIn("find_dependency(MyPkG REQUIRED NO_MODULE)", content["MyPkG2Config.cmake"])
 
@@ -463,17 +463,17 @@ class CMakeCppInfoNamesTest(unittest.TestCase):
         content = generator.content
         self.assertNotIn("MyPkG", content)
         self.assertNotIn("MyPkG2", content)
-        self.assertIn('add_library(CONAN_PKG::MyCMakeName INTERFACE IMPORTED)', content)
-        self.assertIn('add_library(CONAN_PKG::MyCMakeName2 INTERFACE IMPORTED)', content)
+        self.assertIn('add_library(CONAN_PKG::MyCMakeName INTERFACE IMPORTED GLOBAL)', content)
+        self.assertIn('add_library(CONAN_PKG::MyCMakeName2 INTERFACE IMPORTED GLOBAL)', content)
 
     def cmake_multi_test(self):
         generator = CMakeMultiGenerator(self.conanfile)
         content = generator.content
         self.assertNotIn("MyPkG", content["conanbuildinfo_multi.cmake"])
         self.assertNotIn("MyPkG2", content["conanbuildinfo_multi.cmake"])
-        self.assertIn('add_library(CONAN_PKG::MyCMakeMultiName INTERFACE IMPORTED)',
+        self.assertIn('add_library(CONAN_PKG::MyCMakeMultiName INTERFACE IMPORTED GLOBAL)',
                       content["conanbuildinfo_multi.cmake"])
-        self.assertIn('add_library(CONAN_PKG::MyCMakeMultiName2 INTERFACE IMPORTED)',
+        self.assertIn('add_library(CONAN_PKG::MyCMakeMultiName2 INTERFACE IMPORTED GLOBAL)',
                       content["conanbuildinfo_multi.cmake"])
 
     def cmake_find_package_test(self):
@@ -483,9 +483,9 @@ class CMakeCppInfoNamesTest(unittest.TestCase):
         self.assertIn("FindMyCMakeFindPackageName2.cmake", content.keys())
         self.assertNotIn("MyPkG", content["FindMyCMakeFindPackageName.cmake"])
         self.assertNotIn("MyPkG2", content["FindMyCMakeFindPackageName2.cmake"])
-        self.assertIn("add_library(MyCMakeFindPackageName::MyCMakeFindPackageName INTERFACE IMPORTED)",
+        self.assertIn("add_library(MyCMakeFindPackageName::MyCMakeFindPackageName INTERFACE IMPORTED GLOBAL)",
                       content["FindMyCMakeFindPackageName.cmake"])
-        self.assertIn("add_library(MyCMakeFindPackageName2::MyCMakeFindPackageName2 INTERFACE IMPORTED)",
+        self.assertIn("add_library(MyCMakeFindPackageName2::MyCMakeFindPackageName2 INTERFACE IMPORTED GLOBAL)",
                       content["FindMyCMakeFindPackageName2.cmake"])
         self.assertIn("find_dependency(MyCMakeFindPackageName REQUIRED)",
                       content["FindMyCMakeFindPackageName2.cmake"])
@@ -505,10 +505,10 @@ class CMakeCppInfoNamesTest(unittest.TestCase):
         self.assertNotIn("MyPkG", content["MyCMakeFindPackageMultiNameConfig.cmake"])
         self.assertNotIn("MyPkG", content["MyCMakeFindPackageMultiName2Config.cmake"])
         self.assertIn(
-            "add_library(MyCMakeFindPackageMultiName::MyCMakeFindPackageMultiName INTERFACE IMPORTED)",
+            "add_library(MyCMakeFindPackageMultiName::MyCMakeFindPackageMultiName INTERFACE IMPORTED GLOBAL)",
             content["MyCMakeFindPackageMultiNameTargets.cmake"])
         self.assertIn(
-            "add_library(MyCMakeFindPackageMultiName2::MyCMakeFindPackageMultiName2 INTERFACE IMPORTED)",
+            "add_library(MyCMakeFindPackageMultiName2::MyCMakeFindPackageMultiName2 INTERFACE IMPORTED GLOBAL)",
             content["MyCMakeFindPackageMultiName2Targets.cmake"])
         self.assertIn("find_dependency(MyCMakeFindPackageMultiName REQUIRED NO_MODULE)",
                       content["MyCMakeFindPackageMultiName2Config.cmake"])


### PR DESCRIPTION
Changelog: Feature: Set conan generated CMake targets as `GLOBAL` so that they can be used with an `ALIAS` for consumers.
Docs: https://github.com/conan-io/docs/pull/1534

Making an `ALIAS` of an `IMPORTED` target is possible in CMake for versions `>v3.10.3` (`>v3.14 `in case they are `UNKNOWN` too) but they have to be set as `GLOBAL`. 
This PR sets those targets defined by Conan as `GLOBAL` so they can take advantage of this for consumers with modern CMake versions.

fixes: #3482

#tags: slow


- [X] Refer to the issue that supports this Pull Request.
- [X] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [X] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [X] I've followed the PEP8 style guides for Python code.
- [X] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 

<sup>**Note:** By default this PR will skip the slower tests and will use a limited set of python versions. Check [here](https://github.com/conan-io/conan/blob/develop/.github/PR_INCREASE_TESTING.md) how to increase the testing level by writing some tags in the current PR body text.</sup>
