### PR TITLE
Add support for Python3.8

### DIFF
--- a/conans/client/cmd/export.py
+++ b/conans/client/cmd/export.py
@@ -1,6 +1,7 @@
 import ast
 import os
 import shutil
+import sys
 
 import six
 
@@ -17,6 +18,7 @@ from conans.util.files import is_dirty, load, rmdir, save, set_dirty, remove, mk
     merge_directories
 from conans.util.log import logger
 
+isPY38 = bool(sys.version_info.major == 3 and sys.version_info.minor == 8)
 
 def export_alias(package_layout, target_ref, output, revisions_enabled):
     revision_mode = "hash"
@@ -303,7 +305,14 @@ def _replace_scm_data_in_conanfile(conanfile_path, scm_data):
                                 else:
                                     next_line = tree.body[i_body+1].lineno - 1
                             else:
-                                next_line = statements[i+1].lineno - 1
+                                # Next statement can be a comment or anything else
+                                next_statement = statements[i+1]
+                                if isPY38 and isinstance(next_statement, ast.Expr):
+                                    # Python 3.8 properly parses multiline comments with start and end lines,
+                                    #  here we preserve the same (wrong) implementation of previous releases
+                                    next_line = next_statement.end_lineno - 1
+                                else:
+                                    next_line = next_statement.lineno - 1
                                 next_line_content = lines[next_line].strip()
                                 if (next_line_content.endswith('"""') or
                                         next_line_content.endswith("'''")):

--- a/conans/client/conf/detect.py
+++ b/conans/client/conf/detect.py
@@ -1,6 +1,7 @@
 import os
 import platform
 import re
+import sys
 from subprocess import PIPE, Popen, STDOUT
 
 from conans.client.output import Color
@@ -8,9 +9,13 @@ from conans.client.tools import detected_os, OSInfo
 from conans.client.tools.win import latest_visual_studio_version_installed
 from conans.model.version import Version
 
+isPY38 = bool(sys.version_info.major == 3 and sys.version_info.minor == 8)
+
 
 def _execute(command):
-    proc = Popen(command, shell=True, bufsize=1, stdout=PIPE, stderr=STDOUT)
+    # In Python 3.8, open() emits RuntimeWarning if buffering=1 for binary mode.
+    bufsize = -1 if isPY38 else 1
+    proc = Popen(command, shell=True, bufsize=bufsize, stdout=PIPE, stderr=STDOUT)
 
     output_buffer = []
     while True:

--- a/conans/server/service/v2/service_v2.py
+++ b/conans/server/service/v2/service_v2.py
@@ -2,7 +2,7 @@ import os
 
 from bottle import FileUpload, static_file
 
-from conans.errors import RecipeNotFoundException, PackageNotFoundException
+from conans.errors import RecipeNotFoundException, PackageNotFoundException, NotFoundException
 from conans.server.service.common.common import CommonService
 from conans.server.service.mime import get_mime_type
 from conans.server.store.server_store import ServerStore
@@ -19,7 +19,10 @@ class ConanServiceV2(CommonService):
     # RECIPE METHODS
     def get_recipe_file_list(self, ref,  auth_user):
         self._authorizer.check_read_conan(auth_user, ref)
-        file_list = self._server_store.get_recipe_file_list(ref)
+        try:
+            file_list = self._server_store.get_recipe_file_list(ref)
+        except NotFoundException:
+            raise RecipeNotFoundException(ref)
         if not file_list:
             raise RecipeNotFoundException(ref, print_rev=True)
 

--- a/conans/test/functional/remote/multi_remote_test.py
+++ b/conans/test/functional/remote/multi_remote_test.py
@@ -36,12 +36,14 @@ class ExportsSourcesMissingTest(unittest.TestCase):
         self.assertIn("Probably it was installed from a remote that is no longer available.",
                       client2.out)
 
-        # Failure because remote is disconnected
-        client2 = TestClient(servers=servers, users={"new_server": [("user", "password")]})
+        # Failure because remote removed the package
+        client2 = TestClient(servers=servers, users={"new_server": [("user", "password")],
+                                                     "default":  [("user", "password")]})
         client2.run("install pkg/0.1@user/testing")
-        client2.run("remote add default http://someweird__conan_URL -f")
+        client2.run("remove * -r=default -f")
         client2.run("upload pkg/0.1@user/testing --all -r=new_server", assert_error=True)
-        self.assertIn("Unable to connect to default=http://someweird__conan_URL", client2.out)
+        self.assertIn("ERROR: Recipe not found: 'pkg/0.1@user/testing'. [Remote: default]",
+                      client2.out)
         self.assertIn("The 'pkg/0.1@user/testing' package has 'exports_sources' but sources "
                       "not found in local cache.", client2.out)
         self.assertIn("Probably it was installed from a remote that is no longer available.",
@@ -57,7 +59,8 @@ class MultiRemotesTest(unittest.TestCase):
         self.servers["default"] = default_server
         self.servers["local"] = local_server
 
-    def _create(self, client, number, version, deps=None, export=True, modifier=""):
+    @staticmethod
+    def _create(client, number, version, deps=None, export=True, modifier=""):
         files = cpp_hello_conan_files(number, version, deps, build=False)
         # To avoid building
         files = {CONANFILE: files[CONANFILE].replace("config(", "config2(") + modifier}
@@ -208,13 +211,13 @@ class MultiRemoteTest(unittest.TestCase):
         client.run("user lasote -p mypass -r s1")
         client.run("upload MyLib* -r s1 -c")
 
-        servers["s1"].fake_url = "http://asdlhaljksdhlajkshdljakhsd"  # Do not exist
+        servers["s1"].fake_url = "http://asdlhaljksdhlajkshdljakhsd.com"  # Do not exist
         client2 = TestClient(servers=servers, users=self.users)
         err = client2.run("install MyLib/0.1@conan/testing --build=missing", assert_error=True)
         self.assertTrue(err)
         self.assertIn("MyLib/0.1@conan/testing: Trying with 's0'...", client2.out)
         self.assertIn("MyLib/0.1@conan/testing: Trying with 's1'...", client2.out)
-        self.assertIn("Unable to connect to s1=http://asdlhaljksdhlajkshdljakhsd", client2.out)
+        self.assertIn("Unable to connect to s1=http://asdlhaljksdhlajkshdljakhsd.com", client2.out)
         # s2 is not even tried
         self.assertNotIn("MyLib/0.1@conan/testing: Trying with 's2'...", client2.out)
 

--- a/conans/util/files.py
+++ b/conans/util/files.py
@@ -317,7 +317,9 @@ def gzopen_without_timestamps(name, mode="r", fileobj=None, compresslevel=None, 
         raise
 
     try:
-        t = tarfile.TarFile.taropen(name, mode, fileobj, **kwargs)
+        # Format is forced because in Python3.8, it changed and it generates different tarfiles
+        # with different checksums, which break hashes of tgzs
+        t = tarfile.TarFile.taropen(name, mode, fileobj, format=tarfile.GNU_FORMAT, **kwargs)
     except IOError:
         fileobj.close()
         if mode == 'r':


### PR DESCRIPTION
Cherry-pick changesets:
 * #6355
 * #6341

---

Changelog: Bugfix: Fix broken compression of .tgz files due to Python 3.8 changing tar default schema.
Changelog: Fix: Recipe substitution for scm (old behavior) fixed for multiline comments in Python 3.8
Docs: omit

I omit the docs, with this release we don't want to remove python 3.8 warnings from the docs

#tags: slow, svn
#revisions: 1