### PR TITLE
Update Poco reference for command new

### DIFF
--- a/conans/client/command.py
+++ b/conans/client/command.py
@@ -150,8 +150,8 @@ class Command(object):
         parser = argparse.ArgumentParser(description=self.new.__doc__,
                                          prog="conan new",
                                          formatter_class=SmartFormatter)
-        parser.add_argument("name", help='Package name, e.g.: "Poco/1.7.3" or complete reference'
-                                         ' for CI scripts: "Poco/1.7.3@conan/stable"')
+        parser.add_argument("name", help='Package name, e.g.: "poco/1.9.4" or complete reference'
+                                         ' for CI scripts: "poco/1.9.4@user/channel"')
         parser.add_argument("-t", "--test", action='store_true', default=False,
                             help='Create test_package skeleton to test package')
         parser.add_argument("-i", "--header", action='store_true', default=False,


### PR DESCRIPTION
Changelog: Fix: Use CCI package reference for command example
Docs: Omit

- [ ] Refer to the issue that supports this Pull Request.
- [ ] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [ ] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [ ] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 

<sup>**Note:** By default this PR will skip the slower tests and will use a limited set of python versions. Check [here](https://github.com/conan-io/conan/blob/develop/.github/PR_INCREASE_TESTING.md) how to increase the testing level by writing some tags in the current PR body text.</sup>
