### PR TITLE
Put back graph clean-modified subcommand

### DIFF
--- a/conans/client/command.py
+++ b/conans/client/command.py
@@ -1782,6 +1782,9 @@ class Command(object):
         build_order_cmd.add_argument("--json", action=OnceArgument,
                                      help="generate output file in json format")
 
+        clean_cmd = subparsers.add_parser('clean-modified', help='Clean modified')
+        clean_cmd.add_argument('lockfile', help='lockfile folder')
+
         lock_cmd = subparsers.add_parser('lock', help='create a lockfile')
         lock_cmd.add_argument("path_or_reference", help="Path to a folder containing a recipe"
                               " (conanfile.py or conanfile.txt) or to a recipe file. e.g., "
@@ -1803,6 +1806,8 @@ class Command(object):
             if args.json:
                 json_file = _make_abs_path(args.json)
                 save(json_file, json.dumps(build_order, indent=True))
+        elif args.subcommand == "clean-modified":
+            self._conan.lock_clean_modified(args.lockfile)
         elif args.subcommand == "lock":
             self._conan.create_lock(args.path_or_reference,
                                     remote_name=args.remote,

--- a/conans/client/conan_api.py
+++ b/conans/client/conan_api.py
@@ -1229,7 +1229,7 @@ class ConanAPIV1(object):
     def lock_clean_modified(self, lockfile, cwd=None):
         cwd = cwd or os.getcwd()
         lockfile = _make_abs_path(lockfile, cwd)
-        lock = GraphLockFile.load(lockfile)
+        lock = GraphLockFile.load(lockfile, self.app.config.revisions_enabled)
         lock.graph_lock.clean_modified()
         lock.save(lockfile)
 

--- a/conans/client/conan_api.py
+++ b/conans/client/conan_api.py
@@ -1226,6 +1226,14 @@ class ConanAPIV1(object):
         return build_order
 
     @api_method
+    def lock_clean_modified(self, lockfile, cwd=None):
+        cwd = cwd or os.getcwd()
+        lockfile = _make_abs_path(lockfile, cwd)
+        lock = GraphLockFile.load(lockfile)
+        lock.graph_lock.clean_modified()
+        lock.save(lockfile)
+
+    @api_method
     def create_lock(self, reference, remote_name=None, settings=None, options=None, env=None,
                     profile_names=None, update=False, lockfile=None, build=None,):
         reference, graph_info = self._info_args(reference, None, profile_names,

--- a/conans/model/graph_lock.py
+++ b/conans/model/graph_lock.py
@@ -112,7 +112,7 @@ class GraphLockNode(object):
         if self.python_requires:
             result["python_requires"] = [repr(r) for r in self.python_requires]
         if self.modified:
-            result["modified"] = self.modified
+            result["modified"] = True
         if self.requires:
             result["requires"] = self.requires
         if self.build_requires:
@@ -218,6 +218,12 @@ class GraphLock(object):
         for id_, node in new_lock._nodes.items():
             if node.modified:
                 self._nodes[id_] = node
+
+    def clean_modified(self):
+        """ remove all the "modified" flags from the lockfile
+        """
+        for _, node in self._nodes.items():
+            node.modified = False
 
     def _closure_affected(self):
         """ returns all the IDs of the nodes that depend directly or indirectly of some

--- a/conans/model/graph_lock.py
+++ b/conans/model/graph_lock.py
@@ -112,7 +112,7 @@ class GraphLockNode(object):
         if self.python_requires:
             result["python_requires"] = [repr(r) for r in self.python_requires]
         if self.modified:
-            result["modified"] = True
+            result["modified"] = self.modified
         if self.requires:
             result["requires"] = self.requires
         if self.build_requires:
@@ -223,7 +223,7 @@ class GraphLock(object):
         """ remove all the "modified" flags from the lockfile
         """
         for _, node in self._nodes.items():
-            node.modified = False
+            node.modified = None
 
     def _closure_affected(self):
         """ returns all the IDs of the nodes that depend directly or indirectly of some

--- a/conans/test/functional/graph_lock/graph_lock_ci_test.py
+++ b/conans/test/functional/graph_lock/graph_lock_ci_test.py
@@ -8,6 +8,7 @@ from conans.model.ref import PackageReference
 from conans.test.utils.tools import TestClient, TestServer
 from conans.util.env_reader import get_env
 from conans.util.files import load
+from conans.model.ref import PackageReference
 
 
 class GraphLockCITest(unittest.TestCase):
@@ -108,6 +109,7 @@ class GraphLockCITest(unittest.TestCase):
                 client_aux = TestClient(cache_folder=client.cache_folder,
                                         servers={"default": test_server})
                 client_aux.save({LOCKFILE: lock_fileaux})
+                client_aux.run("graph clean-modified .")
                 client_aux.run("install %s --build=%s --lockfile"
                                % (pkg_ref.ref, pkg_ref.ref.name))
                 lock_fileaux = load(os.path.join(client_aux.current_folder, LOCKFILE))
@@ -235,6 +237,7 @@ class GraphLockCITest(unittest.TestCase):
                 client_aux = TestClient(cache_folder=client.cache_folder,
                                         servers={"default": test_server})
                 client_aux.save({LOCKFILE: lock_fileaux})
+                client_aux.run("graph clean-modified .")
                 client_aux.run("install %s --build=%s --lockfile"
                                % (pkg_ref.ref, pkg_ref.ref.name))
                 lock_fileaux = client_aux.load(LOCKFILE)
@@ -370,6 +373,7 @@ class GraphLockCITest(unittest.TestCase):
                 client_aux = TestClient(cache_folder=client.cache_folder)
                 client_aux.run("config set general.default_package_id_mode=full_package_mode")
                 client_aux.save({LOCKFILE: lock_fileaux})
+                client_aux.run("graph clean-modified .")
                 client_aux.run("install %s --build=%s --lockfile"
                                % (pkg_ref.ref, pkg_ref.ref.name))
                 lock_fileaux = client_aux.load(LOCKFILE)
@@ -473,6 +477,7 @@ class GraphLockCITest(unittest.TestCase):
             client_aux = TestClient(cache_folder=client.cache_folder)
             client_aux.run("config set general.default_package_id_mode=full_package_mode")
             client_aux.save({LOCKFILE: lock_fileaux})
+            client_aux.run("graph clean-modified .")
             client_aux.run("install %s --build=%s --lockfile"
                            % (pkg_ref.ref, pkg_ref.ref.name))
             lock_fileaux = load(os.path.join(client_aux.current_folder, LOCKFILE))


### PR DESCRIPTION
Changelog: Implement ``conan graph clean-modified`` subcommand to be able to clean the modified state of a lockfile and re-use it later for more operations.

Docs: https://github.com/conan-io/docs/pull/1542


This reverts commit 9f3e486f98c72c1aaec16c0692ec711d0bae2cd6.

Seen with @memsharded, there is a use-case for reintroducing this subcommand: when sharing lockfiles with devs and further CI jobs (especially needed when one does not want to use latest recipe revisions, thus regenerating locks from scratch is not acceptable).

Closes #6436 


- [x] Refer to the issue that supports this Pull Request.
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [x] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 


