### PR TITLE
Remove GLOBAL from targets to avoid conflict when using add_subdirectory

### DIFF
--- a/conans/client/generators/cmake_common.py
+++ b/conans/client/generators/cmake_common.py
@@ -163,7 +163,7 @@ _target_template = """
                                   CONAN_PACKAGE_TARGETS_{uname}_MINSIZEREL "${{_CONAN_PKG_LIBS_{uname}_DEPENDENCIES_MINSIZEREL}}"
                                   "minsizerel" {pkg_name})
 
-    add_library({name} INTERFACE IMPORTED GLOBAL)
+    add_library({name} INTERFACE IMPORTED)
 
     # Property INTERFACE_LINK_FLAGS do not work, necessary to add to INTERFACE_LINK_LIBRARIES
     set_property(TARGET {name} PROPERTY INTERFACE_LINK_LIBRARIES ${{CONAN_PACKAGE_TARGETS_{uname}}} ${{_CONAN_PKG_LIBS_{uname}_DEPENDENCIES}} ${{CONAN_SHARED_LINKER_FLAGS_{uname}_LIST}} ${{CONAN_EXE_LINKER_FLAGS_{uname}_LIST}}
@@ -252,7 +252,7 @@ class CMakeCommonMacros:
                 if(CONAN_FOUND_LIBRARY)
                     conan_message(STATUS "Library ${_LIBRARY_NAME} found ${CONAN_FOUND_LIBRARY}")
                     set(_LIB_NAME CONAN_LIB::${package_name}_${_LIBRARY_NAME}${build_type})
-                    add_library(${_LIB_NAME} UNKNOWN IMPORTED GLOBAL)
+                    add_library(${_LIB_NAME} UNKNOWN IMPORTED)
                     set_target_properties(${_LIB_NAME} PROPERTIES IMPORTED_LOCATION ${CONAN_FOUND_LIBRARY})
                     set(CONAN_FULLPATH_LIBS ${CONAN_FULLPATH_LIBS} ${_LIB_NAME})
                     set(_CONAN_ACTUAL_TARGETS ${_CONAN_ACTUAL_TARGETS} ${_LIB_NAME})

--- a/conans/client/generators/cmake_find_package.py
+++ b/conans/client/generators/cmake_find_package.py
@@ -35,7 +35,7 @@ class CMakeFindPackageGenerator(Generator):
 if(NOT ${{CMAKE_VERSION}} VERSION_LESS "3.0")
     # Target approach
     if(NOT TARGET {name}::{name})
-        add_library({name}::{name} INTERFACE IMPORTED GLOBAL)
+        add_library({name}::{name} INTERFACE IMPORTED)
         {assign_target_properties_block}
         {find_dependencies_block}
     endif()

--- a/conans/client/generators/cmake_find_package_common.py
+++ b/conans/client/generators/cmake_find_package_common.py
@@ -108,7 +108,7 @@ class CMakeFindPackageCommonMacros:
                         set(_LIB_NAME CONAN_LIB::${package_name}_${_LIBRARY_NAME}${build_type})
                         if(NOT TARGET ${_LIB_NAME})
                             # Create a micro-target for each lib/a found
-                            add_library(${_LIB_NAME} UNKNOWN IMPORTED GLOBAL)
+                            add_library(${_LIB_NAME} UNKNOWN IMPORTED)
                             set_target_properties(${_LIB_NAME} PROPERTIES IMPORTED_LOCATION ${CONAN_FOUND_LIBRARY})
                             set(_CONAN_ACTUAL_TARGETS ${_CONAN_ACTUAL_TARGETS} ${_LIB_NAME})
                         else()

--- a/conans/client/generators/cmake_find_package_multi.py
+++ b/conans/client/generators/cmake_find_package_multi.py
@@ -21,7 +21,7 @@ include(${{CMAKE_CURRENT_LIST_DIR}}/{name}Targets.cmake)
 
     targets_file = """
 if(NOT TARGET {name}::{name})
-    add_library({name}::{name} INTERFACE IMPORTED GLOBAL)
+    add_library({name}::{name} INTERFACE IMPORTED)
 endif()
 
 # Load the debug and release library finders

--- a/conans/test/unittests/client/generators/cmake_test.py
+++ b/conans/test/unittests/client/generators/cmake_test.py
@@ -463,17 +463,17 @@ class CMakeCppInfoNamesTest(unittest.TestCase):
         content = generator.content
         self.assertNotIn("MyPkG", content)
         self.assertNotIn("MyPkG2", content)
-        self.assertIn('add_library(CONAN_PKG::MyCMakeName INTERFACE IMPORTED GLOBAL)', content)
-        self.assertIn('add_library(CONAN_PKG::MyCMakeName2 INTERFACE IMPORTED GLOBAL)', content)
+        self.assertIn('add_library(CONAN_PKG::MyCMakeName INTERFACE IMPORTED)', content)
+        self.assertIn('add_library(CONAN_PKG::MyCMakeName2 INTERFACE IMPORTED)', content)
 
     def cmake_multi_test(self):
         generator = CMakeMultiGenerator(self.conanfile)
         content = generator.content
         self.assertNotIn("MyPkG", content["conanbuildinfo_multi.cmake"])
         self.assertNotIn("MyPkG2", content["conanbuildinfo_multi.cmake"])
-        self.assertIn('add_library(CONAN_PKG::MyCMakeMultiName INTERFACE IMPORTED GLOBAL)',
+        self.assertIn('add_library(CONAN_PKG::MyCMakeMultiName INTERFACE IMPORTED)',
                       content["conanbuildinfo_multi.cmake"])
-        self.assertIn('add_library(CONAN_PKG::MyCMakeMultiName2 INTERFACE IMPORTED GLOBAL)',
+        self.assertIn('add_library(CONAN_PKG::MyCMakeMultiName2 INTERFACE IMPORTED)',
                       content["conanbuildinfo_multi.cmake"])
 
     def cmake_find_package_test(self):
@@ -483,9 +483,9 @@ class CMakeCppInfoNamesTest(unittest.TestCase):
         self.assertIn("FindMyCMakeFindPackageName2.cmake", content.keys())
         self.assertNotIn("MyPkG", content["FindMyCMakeFindPackageName.cmake"])
         self.assertNotIn("MyPkG2", content["FindMyCMakeFindPackageName2.cmake"])
-        self.assertIn("add_library(MyCMakeFindPackageName::MyCMakeFindPackageName INTERFACE IMPORTED GLOBAL)",
+        self.assertIn("add_library(MyCMakeFindPackageName::MyCMakeFindPackageName INTERFACE IMPORTED)",
                       content["FindMyCMakeFindPackageName.cmake"])
-        self.assertIn("add_library(MyCMakeFindPackageName2::MyCMakeFindPackageName2 INTERFACE IMPORTED GLOBAL)",
+        self.assertIn("add_library(MyCMakeFindPackageName2::MyCMakeFindPackageName2 INTERFACE IMPORTED)",
                       content["FindMyCMakeFindPackageName2.cmake"])
         self.assertIn("find_dependency(MyCMakeFindPackageName REQUIRED)",
                       content["FindMyCMakeFindPackageName2.cmake"])
@@ -505,10 +505,10 @@ class CMakeCppInfoNamesTest(unittest.TestCase):
         self.assertNotIn("MyPkG", content["MyCMakeFindPackageMultiNameConfig.cmake"])
         self.assertNotIn("MyPkG", content["MyCMakeFindPackageMultiName2Config.cmake"])
         self.assertIn(
-            "add_library(MyCMakeFindPackageMultiName::MyCMakeFindPackageMultiName INTERFACE IMPORTED GLOBAL)",
+            "add_library(MyCMakeFindPackageMultiName::MyCMakeFindPackageMultiName INTERFACE IMPORTED)",
             content["MyCMakeFindPackageMultiNameTargets.cmake"])
         self.assertIn(
-            "add_library(MyCMakeFindPackageMultiName2::MyCMakeFindPackageMultiName2 INTERFACE IMPORTED GLOBAL)",
+            "add_library(MyCMakeFindPackageMultiName2::MyCMakeFindPackageMultiName2 INTERFACE IMPORTED)",
             content["MyCMakeFindPackageMultiName2Targets.cmake"])
         self.assertIn("find_dependency(MyCMakeFindPackageMultiName REQUIRED NO_MODULE)",
                       content["MyCMakeFindPackageMultiName2Config.cmake"])

--- a/conans/test/unittests/client/generators/cmake_test.py
+++ b/conans/test/unittests/client/generators/cmake_test.py
@@ -380,8 +380,8 @@ class CMakeCppInfoNameTest(unittest.TestCase):
         content = content.replace("set(CONAN_DEPENDENCIES my_pkg my_pkg2)", "")
         self.assertNotIn("my_pkg", content)
         self.assertNotIn("MY_PKG", content)
-        self.assertIn('add_library(CONAN_PKG::MyPkG INTERFACE IMPORTED GLOBAL)', content)
-        self.assertIn('add_library(CONAN_PKG::MyPkG2 INTERFACE IMPORTED GLOBAL)', content)
+        self.assertIn('add_library(CONAN_PKG::MyPkG INTERFACE IMPORTED)', content)
+        self.assertIn('add_library(CONAN_PKG::MyPkG2 INTERFACE IMPORTED)', content)
         self.assertNotIn('CONAN_PKG::my_pkg', content)
         self.assertNotIn('CONAN_PKG::my_pkg2', content)
 
@@ -392,9 +392,9 @@ class CMakeCppInfoNameTest(unittest.TestCase):
                       content["conanbuildinfo_debug.cmake"])
         self.assertNotIn("my_pkg", content["conanbuildinfo_multi.cmake"])
         self.assertNotIn("MY_PKG", content["conanbuildinfo_multi.cmake"])
-        self.assertIn('add_library(CONAN_PKG::MyPkG INTERFACE IMPORTED GLOBAL)',
+        self.assertIn('add_library(CONAN_PKG::MyPkG INTERFACE IMPORTED)',
                       content["conanbuildinfo_multi.cmake"])
-        self.assertIn('add_library(CONAN_PKG::MyPkG2 INTERFACE IMPORTED GLOBAL)',
+        self.assertIn('add_library(CONAN_PKG::MyPkG2 INTERFACE IMPORTED)',
                       content["conanbuildinfo_multi.cmake"])
         self.assertNotIn('CONAN_PKG::my_pkg', content["conanbuildinfo_multi.cmake"])
         self.assertNotIn('CONAN_PKG::my_pkg2', content["conanbuildinfo_multi.cmake"])
@@ -408,8 +408,8 @@ class CMakeCppInfoNameTest(unittest.TestCase):
         self.assertNotIn("MY_PKG", content["FindMyPkG.cmake"])
         self.assertNotIn("my_pkg", content["FindMyPkG2.cmake"])
         self.assertNotIn("MY_PKG", content["FindMyPkG2.cmake"])
-        self.assertIn("add_library(MyPkG::MyPkG INTERFACE IMPORTED GLOBAL)", content["FindMyPkG.cmake"])
-        self.assertIn("add_library(MyPkG2::MyPkG2 INTERFACE IMPORTED GLOBAL)", content["FindMyPkG2.cmake"])
+        self.assertIn("add_library(MyPkG::MyPkG INTERFACE IMPORTED)", content["FindMyPkG.cmake"])
+        self.assertIn("add_library(MyPkG2::MyPkG2 INTERFACE IMPORTED)", content["FindMyPkG2.cmake"])
         self.assertIn("find_dependency(MyPkG REQUIRED)", content["FindMyPkG2.cmake"])
 
     def cmake_find_package_multi_test(self):
@@ -423,9 +423,9 @@ class CMakeCppInfoNameTest(unittest.TestCase):
         self.assertNotIn("MY_PKG", content["MyPkGConfig.cmake"])
         self.assertNotIn("my_pkg", content["MyPkG2Config.cmake"])
         self.assertNotIn("MY_PKG", content["MyPkG2Config.cmake"])
-        self.assertIn("add_library(MyPkG::MyPkG INTERFACE IMPORTED GLOBAL)",
+        self.assertIn("add_library(MyPkG::MyPkG INTERFACE IMPORTED)",
                       content["MyPkGTargets.cmake"])
-        self.assertIn("add_library(MyPkG2::MyPkG2 INTERFACE IMPORTED GLOBAL)",
+        self.assertIn("add_library(MyPkG2::MyPkG2 INTERFACE IMPORTED)",
                       content["MyPkG2Targets.cmake"])
         self.assertIn("find_dependency(MyPkG REQUIRED NO_MODULE)", content["MyPkG2Config.cmake"])
 


### PR DESCRIPTION
Changelog: Fix: remove `GLOBAL` from targets to avoid conflicts when using `add_subdirectory`.
Docs: Omit

Fixes: #6480

- [X] Refer to the issue that supports this Pull Request.
- [X] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [X] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [X] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 

<sup>**Note:** By default this PR will skip the slower tests and will use a limited set of python versions. Check [here](https://github.com/conan-io/conan/blob/develop/.github/PR_INCREASE_TESTING.md) how to increase the testing level by writing some tags in the current PR body text.</sup>
