### PR TITLE
Upgrade python six to allow 1.14.0 (#6507)

### DIFF
--- a/conans/requirements.txt
+++ b/conans/requirements.txt
@@ -5,7 +5,7 @@ colorama>=0.3.3, <0.5.0
 PyYAML>=3.11, <6.0
 patch-ng==1.17.2
 fasteners>=0.14.1
-six>=1.10.0,<1.13.0
+six>=1.10.0,<=1.14.0
 node-semver==0.6.1
 distro>=1.0.2, <1.2.0
 future>=0.16.0, <0.19.0


### PR DESCRIPTION
Changelog: Fix: Increase ``six`` version to allow more modern releases.
Docs: Omit

From https://github.com/conan-io/conan/pull/6507