### PR TITLE
Manage the dirty state in "conan export-pkg" command

### DIFF
--- a/conans/client/cmd/export_pkg.py
+++ b/conans/client/cmd/export_pkg.py
@@ -3,9 +3,8 @@ import os
 from conans.client import packager
 from conans.client.graph.graph_manager import load_deps_info
 from conans.errors import ConanException
-from conans.model.conan_file import get_env_context_manager
 from conans.model.ref import PackageReference
-from conans.util.files import rmdir
+from conans.util.files import rmdir, set_dirty_context_manager
 
 
 def export_pkg(app, recorder, full_ref, source_folder, build_folder, package_folder, install_folder,
@@ -45,11 +44,12 @@ def export_pkg(app, recorder, full_ref, source_folder, build_folder, package_fol
     recipe_hash = layout.recipe_manifest().summary_hash
     conanfile.info.recipe_hash = recipe_hash
     conanfile.develop = True
-    if package_folder:
-        prev = packager.export_pkg(conanfile, package_id, package_folder, dest_package_folder,
-                                   hook_manager, conan_file_path, ref)
-    else:
-        with get_env_context_manager(conanfile):
+
+    with set_dirty_context_manager(dest_package_folder):
+        if package_folder:
+            prev = packager.export_pkg(conanfile, package_id, package_folder, dest_package_folder,
+                                       hook_manager, conan_file_path, ref)
+        else:
             prev = packager.run_package_method(conanfile, package_id, source_folder, build_folder,
                                                dest_package_folder, install_folder, hook_manager,
                                                conan_file_path, ref, local=True)

--- a/conans/client/cmd/export_pkg.py
+++ b/conans/client/cmd/export_pkg.py
@@ -3,6 +3,7 @@ import os
 from conans.client import packager
 from conans.client.graph.graph_manager import load_deps_info
 from conans.errors import ConanException
+from conans.model.conan_file import get_env_context_manager
 from conans.model.ref import PackageReference
 from conans.util.files import rmdir, set_dirty_context_manager
 
@@ -50,9 +51,11 @@ def export_pkg(app, recorder, full_ref, source_folder, build_folder, package_fol
             prev = packager.export_pkg(conanfile, package_id, package_folder, dest_package_folder,
                                        hook_manager, conan_file_path, ref)
         else:
-            prev = packager.run_package_method(conanfile, package_id, source_folder, build_folder,
-                                               dest_package_folder, install_folder, hook_manager,
-                                               conan_file_path, ref, local=True)
+            # FIXME: Remove this get_env_context_manager() when merging to master
+            with get_env_context_manager(conanfile):
+                prev = packager.run_package_method(conanfile, package_id, source_folder, build_folder,
+                                                   dest_package_folder, install_folder, hook_manager,
+                                                   conan_file_path, ref, local=True)
 
     packager.update_package_metadata(prev, layout, package_id, full_ref.revision)
     pref = PackageReference(pref.ref, pref.id, prev)


### PR DESCRIPTION
Changelog: Bugfix: Manage the dirty state of the cache package folder with conan export-pkg.
Docs: Omit

Backport of https://github.com/conan-io/conan/pull/6498