### PR TITLE
fix build order with build=missing with lockfiles

### DIFF
--- a/conans/model/graph_lock.py
+++ b/conans/model/graph_lock.py
@@ -273,7 +273,7 @@ class GraphLock(object):
                 if (pref.id == PACKAGE_ID_UNKNOWN or pref.is_compatible_with(node_pref) or
                         node.binary == BINARY_BUILD or node.id in affected or
                         node.recipe == RECIPE_CONSUMER):
-                    self._upsert_node(node)
+                    lock_node.pref = node.pref
                 else:
                     raise ConanException("Mismatch between lock and graph:\nLock:  %s\nGraph: %s"
                                          % (repr(pref), repr(node.pref)))


### PR DESCRIPTION
Changelog: Bugfix: Do not re-evaluate lockfiles nodes, only update the package reference, otherwise the build-requires are broken.
Docs: Omit

Fix https://github.com/conan-io/conan/issues/6484

#tags: slow
#revisions: 1
