### PR TITLE
new apple frameworks test #6499

### DIFF
--- a/conans/client/generators/cmake_common.py
+++ b/conans/client/generators/cmake_common.py
@@ -771,7 +771,6 @@ class CMakeCommonMacros:
                         list(APPEND ${FRAMEWORKS_FOUND} ${CONAN_FRAMEWORK_${_FRAMEWORK}_FOUND})
                     else()
                         message(FATAL_ERROR "Framework library ${_FRAMEWORK} not found in paths: ${CONAN_FRAMEWORK_DIRS${SUFFIX}}")
-                        message(FATAL_ERROR "Framework library ${_FRAMEWORK} not found in paths: ${CONAN_FRAMEWORK_DIRS}")
                     endif()
                 endforeach()
             endif()

--- a/conans/client/generators/cmake_common.py
+++ b/conans/client/generators/cmake_common.py
@@ -34,7 +34,7 @@ set(CONAN_SHARED_LINKER_FLAGS_{dep}{build_type}_LIST "{deps.sharedlinkflags_list
 set(CONAN_EXE_LINKER_FLAGS_{dep}{build_type}_LIST "{deps.exelinkflags_list}")
 
 # Apple Frameworks
-conan_find_apple_frameworks(CONAN_FRAMEWORKS_FOUND_{dep}{build_type} "${{CONAN_FRAMEWORKS_{dep}{build_type}}}")
+conan_find_apple_frameworks(CONAN_FRAMEWORKS_FOUND_{dep}{build_type} "${{CONAN_FRAMEWORKS_{dep}{build_type}}}" "_{dep}")
 # Append to aggregated values variable
 set(CONAN_LIBS_{dep}{build_type} ${{CONAN_PKG_LIBS_{dep}{build_type}}} ${{CONAN_SYSTEM_LIBS_{dep}{build_type}}} ${{CONAN_FRAMEWORKS_FOUND_{dep}{build_type}}})
 """
@@ -115,7 +115,7 @@ set(CONAN_EXE_LINKER_FLAGS{build_type} "{deps.exelinkflags} ${{CONAN_EXE_LINKER_
 set(CONAN_C_FLAGS{build_type} "{deps.cflags} ${{CONAN_C_FLAGS{build_type}}}")
 
 # Apple Frameworks
-conan_find_apple_frameworks(CONAN_FRAMEWORKS_FOUND{build_type} "${{CONAN_FRAMEWORKS{build_type}}}")
+conan_find_apple_frameworks(CONAN_FRAMEWORKS_FOUND{build_type} "${{CONAN_FRAMEWORKS{build_type}}}" "")
 # Append to aggregated values variable: Use CONAN_LIBS instead of CONAN_PKG_LIBS to include user appended vars
 set(CONAN_LIBS{build_type} ${{CONAN_LIBS{build_type}}} ${{CONAN_SYSTEM_LIBS{build_type}}} ${{CONAN_FRAMEWORKS_FOUND{build_type}}})
 """
@@ -747,29 +747,30 @@ class CMakeCommonMacros:
     """)
 
     apple_frameworks_macro = textwrap.dedent("""
-        macro(conan_find_apple_frameworks FRAMEWORKS_FOUND FRAMEWORKS)
+        macro(conan_find_apple_frameworks FRAMEWORKS_FOUND FRAMEWORKS SUFFIX)
             if(APPLE)
                 if(CMAKE_BUILD_TYPE)
                     if(${CMAKE_BUILD_TYPE} MATCHES "Debug")
-                        set(CONAN_FRAMEWORKS ${CONAN_FRAMEWORKS_DEBUG} ${CONAN_FRAMEWORKS})
-                        set(CONAN_FRAMEWORK_DIRS ${CONAN_FRAMEWORK_DIRS_DEBUG} ${CONAN_FRAMEWORK_DIRS})
+                        set(CONAN_FRAMEWORKS${SUFFIX} ${CONAN_FRAMEWORKS${SUFFIX}_DEBUG} ${CONAN_FRAMEWORKS${SUFFIX}})
+                        set(CONAN_FRAMEWORK_DIRS${SUFFIX} ${CONAN_FRAMEWORK_DIRS${SUFFIX}_DEBUG} ${CONAN_FRAMEWORK_DIRS${SUFFIX}})
                     elseif(${CMAKE_BUILD_TYPE} MATCHES "Release")
-                        set(CONAN_FRAMEWORKS ${CONAN_FRAMEWORKS_RELEASE} ${CONAN_FRAMEWORKS})
-                        set(CONAN_FRAMEWORK_DIRS ${CONAN_FRAMEWORK_DIRS_RELEASE} ${CONAN_FRAMEWORK_DIRS})
+                        set(CONAN_FRAMEWORKS${SUFFIX} ${CONAN_FRAMEWORKS${SUFFIX}_RELEASE} ${CONAN_FRAMEWORKS${SUFFIX}})
+                        set(CONAN_FRAMEWORK_DIRS${SUFFIX} ${CONAN_FRAMEWORK_DIRS${SUFFIX}_RELEASE} ${CONAN_FRAMEWORK_DIRS${SUFFIX}})
                     elseif(${CMAKE_BUILD_TYPE} MATCHES "RelWithDebInfo")
-                        set(CONAN_FRAMEWORKS ${CONAN_FRAMEWORKS_RELWITHDEBINFO} ${CONAN_FRAMEWORKS})
-                        set(CONAN_FRAMEWORK_DIRS ${CONAN_FRAMEWORK_DIRS_RELWITHDEBINFO} ${CONAN_FRAMEWORK_DIRS})
+                        set(CONAN_FRAMEWORKS${SUFFIX} ${CONAN_FRAMEWORKS${SUFFIX}_RELWITHDEBINFO} ${CONAN_FRAMEWORKS${SUFFIX}})
+                        set(CONAN_FRAMEWORK_DIRS${SUFFIX} ${CONAN_FRAMEWORK_DIRS_RELWITHDEBINFO} ${CONAN_FRAMEWORK_DIRS})
                     elseif(${CMAKE_BUILD_TYPE} MATCHES "MinSizeRel")
-                        set(CONAN_FRAMEWORKS ${CONAN_FRAMEWORKS_MINSIZEREL} ${CONAN_FRAMEWORKS})
-                        set(CONAN_FRAMEWORK_DIRS ${CONAN_FRAMEWORK_DIRS_MINSIZEREL} ${CONAN_FRAMEWORK_DIRS})
+                        set(CONAN_FRAMEWORKS${SUFFIX} ${CONAN_FRAMEWORKS${SUFFIX}_MINSIZEREL} ${CONAN_FRAMEWORKS${SUFFIX}})
+                        set(CONAN_FRAMEWORK_DIRS${SUFFIX} ${CONAN_FRAMEWORK_DIRS${SUFFIX}_MINSIZEREL} ${CONAN_FRAMEWORK_DIRS${SUFFIX}})
                     endif()
                 endif()
                 foreach(_FRAMEWORK ${FRAMEWORKS})
                     # https://cmake.org/pipermail/cmake-developers/2017-August/030199.html
-                    find_library(CONAN_FRAMEWORK_${_FRAMEWORK}_FOUND NAME ${_FRAMEWORK} PATHS ${CONAN_FRAMEWORK_DIRS})
+                    find_library(CONAN_FRAMEWORK_${_FRAMEWORK}_FOUND NAME ${_FRAMEWORK} PATHS ${CONAN_FRAMEWORK_DIRS${SUFFIX}})
                     if(CONAN_FRAMEWORK_${_FRAMEWORK}_FOUND)
                         list(APPEND ${FRAMEWORKS_FOUND} ${CONAN_FRAMEWORK_${_FRAMEWORK}_FOUND})
                     else()
+                        message(FATAL_ERROR "Framework library ${_FRAMEWORK} not found in paths: ${CONAN_FRAMEWORK_DIRS${SUFFIX}}")
                         message(FATAL_ERROR "Framework library ${_FRAMEWORK} not found in paths: ${CONAN_FRAMEWORK_DIRS}")
                     endif()
                 endforeach()

--- a/conans/client/generators/text.py
+++ b/conans/client/generators/text.py
@@ -153,7 +153,7 @@ class TXTGenerator(Generator):
                     '[exelinkflags{dep}{config}]\n{deps.exelinkflags}\n\n'
                     '[sysroot{dep}{config}]\n{deps.sysroot}\n\n'
                     '[frameworks{dep}{config}]\n{deps.frameworks}\n\n'
-                    '[framework_paths{dep}{config}]\n{deps.framework_paths}\n\n')
+                    '[frameworkdirs{dep}{config}]\n{deps.framework_paths}\n\n')
 
         sections = []
         deps = DepsCppTXT(self.deps_build_info)

--- a/conans/test/functional/generators/cmake_apple_frameworks_test.py
+++ b/conans/test/functional/generators/cmake_apple_frameworks_test.py
@@ -73,131 +73,138 @@ class CMakeAppleFrameworksTestCase(unittest.TestCase):
 
 @unittest.skipUnless(platform.system() == "Darwin", "Only for MacOS")
 class CMakeAppleOwnFrameworksTestCase(unittest.TestCase):
+    conanfile = textwrap.dedent("""
+                from conans import ConanFile, CMake, tools
+
+                class AppleframeworkConan(ConanFile):
+                    settings = "os", "compiler", "build_type", "arch"
+                    generators = "cmake"
+                    exports_sources = "src/*"
+                    name = "mylibrary"
+                    version = "1.0"
+                    def build(self):
+                        cmake = CMake(self)
+                        xcrun = tools.XCRun(self.settings)
+                        cmake.definitions.update({
+                            'CMAKE_OSX_SYSROOT' : xcrun.sdk_path,
+                            'CMAKE_OSX_ARCHITECTURES' : tools.to_apple_arch(self.settings.arch),
+                        })
+                        cmake.configure(source_folder="src")
+                        cmake.build()
+                        cmake.install()
+                        self.run("otool -L '%s/lib/hello.framework/hello'" % self.build_folder)
+                        self.run("otool -L '%s/hello.framework/hello'" % self.package_folder)
+
+                    def package_info(self):
+                        self.cpp_info.frameworkdirs.append(self.package_folder)
+                        self.cpp_info.frameworks.append("hello")
+                """)
+    cmake = textwrap.dedent("""
+                cmake_minimum_required(VERSION 2.8)
+                project(MyHello CXX)
+
+                include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
+                conan_basic_setup()
+
+                # set @rpaths for libraries to link against
+                SET(CMAKE_SKIP_RPATH FALSE)
+                #SET(CMAKE_SKIP_BUILD_RPATH  FALSE)
+                #SET(CMAKE_INSTALL_RPATH "@rpath/")
+                #SET(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
+
+                add_library(hello SHARED hello.cpp hello.h)
+                set_target_properties(hello PROPERTIES
+                  FRAMEWORK TRUE
+                  FRAMEWORK_VERSION A
+                  MACOSX_FRAMEWORK_IDENTIFIER com.cmake.hello
+                  MACOSX_FRAMEWORK_INFO_PLIST src/Info.plist
+                  # "current version" in semantic format in Mach-O binary file
+                  VERSION 1.6.0
+                  # "compatibility version" in semantic format in Mach-O binary file
+                  SOVERSION 1.6.0
+                  PUBLIC_HEADER hello.h
+                  INSTALL_NAME_DIR "@rpath"
+                  MACOSX_RPATH TRUE
+                )
+                install(TARGETS hello DESTINATION ".")
+            """)
+    hello_h = textwrap.dedent("""
+                #pragma once
+
+                #ifdef WIN32
+                  #define HELLO_EXPORT __declspec(dllexport)
+                #else
+                  #define HELLO_EXPORT __attribute__((visibility("default")))
+                #endif
+
+                #ifdef __cplusplus
+                extern "C" {
+                #endif
+                class HELLO_EXPORT Hello
+                {
+                    public:
+                        static void hello();
+                };
+                #ifdef __cplusplus
+                }
+                #endif
+            """)
+    hello_cpp = textwrap.dedent("""
+                #include <iostream>
+                #include "hello.h"
+
+                void Hello::hello(){
+                    #ifdef NDEBUG
+                    std::cout << "Hello World Release!" <<std::endl;
+                    #else
+                    std::cout << "Hello World Debug!" <<std::endl;
+                    #endif
+                }
+            """)
+    infoplist = textwrap.dedent("""
+                <?xml version="1.0" encoding="UTF-8"?>
+                <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+                         "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+                <plist version="1.0">
+                <dict>
+                    <key>CFBundleDisplayName</key>
+                    <string>hello</string>
+                    <key>CFBundleExecutable</key>
+                    <string>hello</string>
+                    <key>CFBundleIdentifier</key>
+                    <string>com.test.hello</string>
+                    <key>CFBundleInfoDictionaryVersion</key>
+                    <string>6.0</string>
+                    <key>CFBundleName</key>
+                    <string>hello</string>
+                    <key>CFBundlePackageType</key>
+                    <string>FMWK</string>
+                    <key>CFBundleShortVersionString</key>
+                    <string>1.6.0</string>
+                    <key>CFBundleVersion</key>
+                    <string>1.6.0</string>
+                    <key>Flavor_ID</key>
+                    <string>0</string>
+                    <key>NSAppTransportSecurity</key>
+                    <dict>
+                        <key>NSAllowsArbitraryLoads</key>
+                        <true/>
+                    </dict>
+                    <key>NSPrincipalClass</key>
+                    <string></string>
+                </dict>
+                </plist>
+            """)
+    timer_cpp = textwrap.dedent("""
+        #include <hello/hello.h>
+        int main(){
+            Hello::hello();
+        }
+        """)
 
     def test_apple_own_framework_cmake(self):
         client = TestClient()
-        conanfile = textwrap.dedent("""
-            from conans import ConanFile, CMake, tools
 
-            class AppleframeworkConan(ConanFile):
-                settings = "os", "compiler", "build_type", "arch"
-                generators = "cmake"
-                exports_sources = "src/*"
-                name = "mylibrary"
-                version = "1.0"
-                def build(self):
-                    cmake = CMake(self)
-                    xcrun = tools.XCRun(self.settings)
-                    cmake.definitions.update({
-                        'CMAKE_OSX_SYSROOT' : xcrun.sdk_path,
-                        'CMAKE_OSX_ARCHITECTURES' : tools.to_apple_arch(self.settings.arch),
-                    })
-                    cmake.configure(source_folder="src")
-                    cmake.build()
-                    cmake.install()
-                    self.run("otool -L '%s/lib/hello.framework/hello'" % self.build_folder)
-                    self.run("otool -L '%s/hello.framework/hello'" % self.package_folder)
-            
-                def package_info(self):
-                    self.cpp_info.frameworkdirs.append(self.package_folder)
-                    self.cpp_info.frameworks.append("hello")
-            """)
-        cmake = textwrap.dedent("""
-            cmake_minimum_required(VERSION 2.8)
-            project(MyHello CXX)
-
-            include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
-            conan_basic_setup()
-
-            # set @rpaths for libraries to link against
-            SET(CMAKE_SKIP_RPATH FALSE)
-            #SET(CMAKE_SKIP_BUILD_RPATH  FALSE)
-            #SET(CMAKE_INSTALL_RPATH "@rpath/")
-            #SET(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
-
-            add_library(hello SHARED hello.cpp hello.h)
-            set_target_properties(hello PROPERTIES
-              FRAMEWORK TRUE
-              FRAMEWORK_VERSION A
-              MACOSX_FRAMEWORK_IDENTIFIER com.cmake.hello
-              MACOSX_FRAMEWORK_INFO_PLIST src/Info.plist
-              # "current version" in semantic format in Mach-O binary file
-              VERSION 1.6.0
-              # "compatibility version" in semantic format in Mach-O binary file
-              SOVERSION 1.6.0
-              PUBLIC_HEADER hello.h
-              INSTALL_NAME_DIR "@rpath"
-              MACOSX_RPATH TRUE
-            )    
-            install(TARGETS hello DESTINATION ".")
-        """)
-        hello_h = textwrap.dedent("""
-            #pragma once
-
-            #ifdef WIN32
-              #define HELLO_EXPORT __declspec(dllexport)
-            #else
-              #define HELLO_EXPORT __attribute__((visibility("default")))
-            #endif
-            
-            #ifdef __cplusplus
-            extern "C" {
-            #endif
-            class HELLO_EXPORT Hello
-            {
-                public:
-                    static void hello();
-            };
-            #ifdef __cplusplus
-            }
-            #endif
-        """)
-        hello_cpp = textwrap.dedent("""
-            #include <iostream>
-            #include "hello.h"
-            
-            void Hello::hello(){
-                #ifdef NDEBUG
-                std::cout << "Hello World Release!" <<std::endl;
-                #else
-                std::cout << "Hello World Debug!" <<std::endl;
-                #endif
-            }
-        """)
-        infoplist = textwrap.dedent("""
-            <?xml version="1.0" encoding="UTF-8"?>
-            <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
-                     "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-            <plist version="1.0">
-            <dict>
-                <key>CFBundleDisplayName</key>
-                <string>hello</string>
-                <key>CFBundleExecutable</key>
-                <string>hello</string>
-                <key>CFBundleIdentifier</key>
-                <string>com.test.hello</string>
-                <key>CFBundleInfoDictionaryVersion</key>
-                <string>6.0</string>
-                <key>CFBundleName</key>
-                <string>hello</string>
-                <key>CFBundlePackageType</key>
-                <string>FMWK</string>
-                <key>CFBundleShortVersionString</key>
-                <string>1.6.0</string>
-                <key>CFBundleVersion</key>
-                <string>1.6.0</string>
-                <key>Flavor_ID</key>
-                <string>0</string>
-                <key>NSAppTransportSecurity</key>
-                <dict>
-                    <key>NSAllowsArbitraryLoads</key>
-                    <true/>
-                </dict>
-                <key>NSPrincipalClass</key>
-                <string></string>
-            </dict>
-            </plist>
-        """)
         test_cmake = textwrap.dedent("""
             project(Testing CXX)
             include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
@@ -206,12 +213,7 @@ class CMakeAppleOwnFrameworksTestCase(unittest.TestCase):
             add_executable(timer timer.cpp)
             target_link_libraries(timer ${CONAN_LIBS})
         """)
-        timer_cpp = textwrap.dedent("""
-            #include <hello/hello.h>
-            int main(){
-                Hello::hello();
-            }
-            """)
+
         test_conanfile = textwrap.dedent("""
             from conans import ConanFile, CMake
             class TestPkg(ConanFile):
@@ -223,13 +225,50 @@ class CMakeAppleOwnFrameworksTestCase(unittest.TestCase):
                 def test(self):
                     self.run("bin/timer", run_environment=True)
             """)
-        client.save({'conanfile.py': conanfile,
-                     "src/CMakeLists.txt": cmake,
-                     "src/hello.h": hello_h,
-                     "src/hello.cpp": hello_cpp,
-                     "src/Info.plist": infoplist,
+        client.save({'conanfile.py': self.conanfile,
+                     "src/CMakeLists.txt": self.cmake,
+                     "src/hello.h": self.hello_h,
+                     "src/hello.cpp": self.hello_cpp,
+                     "src/Info.plist": self.infoplist,
                      "test_package/conanfile.py": test_conanfile,
                      'test_package/CMakeLists.txt': test_cmake,
-                     "test_package/timer.cpp": timer_cpp})
+                     "test_package/timer.cpp": self.timer_cpp})
+        client.run("create .")
+        self.assertIn("Hello World Release!", client.out)
+
+    def test_apple_own_framework_cmake_find_package_multi(self):
+        client = TestClient()
+
+        test_cmake = textwrap.dedent("""
+            project(Testing CXX)
+            set(CMAKE_RUNTIME_OUTPUT_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/bin")
+            set(CMAKE_RUNTIME_OUTPUT_DIRECTORY_DEBUG "${CMAKE_CURRENT_BINARY_DIR}/bin")
+            set(CMAKE_RUNTIME_OUTPUT_DIRECTORY_RELEASE "${CMAKE_CURRENT_BINARY_DIR}/bin")
+            find_package(mylibrary REQUIRED)
+            message(">>> CONAN_FRAMEWORKS_FOUND_MYLIBRARY: ${CONAN_FRAMEWORKS_FOUND_MYLIBRARY}")
+            add_executable(timer timer.cpp)
+            target_link_libraries(timer mylibrary::mylibrary)
+        """)
+
+        test_conanfile = textwrap.dedent("""
+            from conans import ConanFile, CMake
+            class TestPkg(ConanFile):
+                generators = "cmake_find_package_multi"
+                settings = "build_type",
+                def build(self):
+                    cmake = CMake(self)
+                    cmake.configure()
+                    cmake.build()
+                def test(self):
+                    self.run("bin/timer", run_environment=True)
+            """)
+        client.save({'conanfile.py': self.conanfile,
+                     "src/CMakeLists.txt": self.cmake,
+                     "src/hello.h": self.hello_h,
+                     "src/hello.cpp": self.hello_cpp,
+                     "src/Info.plist": self.infoplist,
+                     "test_package/conanfile.py": test_conanfile,
+                     'test_package/CMakeLists.txt': test_cmake,
+                     "test_package/timer.cpp": self.timer_cpp})
         client.run("create .")
         self.assertIn("Hello World Release!", client.out)

--- a/conans/test/functional/generators/cmake_apple_frameworks_test.py
+++ b/conans/test/functional/generators/cmake_apple_frameworks_test.py
@@ -202,12 +202,12 @@ class CMakeAppleOwnFrameworksTestCase(unittest.TestCase):
             project(Testing CXX)
             include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
             conan_basic_setup()
-            message(">>> CONAN_FRAMEWORKS_FOUND_LIB: ${CONAN_FRAMEWORKS_FOUND_LIB}")
+            message(">>> CONAN_FRAMEWORKS_FOUND_MYLIBRARY: ${CONAN_FRAMEWORKS_FOUND_MYLIBRARY}")
             add_executable(timer timer.cpp)
             target_link_libraries(timer ${CONAN_LIBS})
         """)
         timer_cpp = textwrap.dedent("""
-            #include <hello.h>
+            #include <hello/hello.h>
             int main(){
                 Hello::hello();
             }
@@ -221,7 +221,7 @@ class CMakeAppleOwnFrameworksTestCase(unittest.TestCase):
                     cmake.configure()
                     cmake.build()
                 def test(self):
-                    self.run("/bin/timer")
+                    self.run("bin/timer", run_environment=True)
             """)
         client.save({'conanfile.py': conanfile,
                      "src/CMakeLists.txt": cmake,

--- a/conans/test/functional/generators/cmake_apple_frameworks_test.py
+++ b/conans/test/functional/generators/cmake_apple_frameworks_test.py
@@ -83,7 +83,8 @@ class CMakeAppleOwnFrameworksTestCase(unittest.TestCase):
                 settings = "os", "compiler", "build_type", "arch"
                 generators = "cmake"
                 exports_sources = "src/*"
-            
+                name = "mylibrary"
+                version = "1.0"
                 def build(self):
                     cmake = CMake(self)
                     xcrun = tools.XCRun(self.settings)
@@ -94,8 +95,8 @@ class CMakeAppleOwnFrameworksTestCase(unittest.TestCase):
                     cmake.configure(source_folder="src")
                     cmake.build()
                     cmake.install()
-                    self.run("otool -L %s/lib/hello.framework/hello" % self.build_folder)
-                    self.run("otool -L %s/hello.framework/hello" % self.package_folder)
+                    self.run("otool -L '%s/lib/hello.framework/hello'" % self.build_folder)
+                    self.run("otool -L '%s/hello.framework/hello'" % self.package_folder)
             
                 def package_info(self):
                     self.cpp_info.frameworkdirs.append(self.package_folder)
@@ -212,8 +213,9 @@ class CMakeAppleOwnFrameworksTestCase(unittest.TestCase):
             }
             """)
         test_conanfile = textwrap.dedent("""
-            from conans import ConanFile
+            from conans import ConanFile, CMake
             class TestPkg(ConanFile):
+                generators = "cmake"
                 def build(self):
                     cmake = CMake(self)
                     cmake.configure()

--- a/conans/test/unittests/client/generators/cmake_test.py
+++ b/conans/test/unittests/client/generators/cmake_test.py
@@ -340,7 +340,7 @@ endmacro()""", macro)
         generator = CMakeGenerator(conanfile)
         content = generator.content
         self.assertIn('find_library(CONAN_FRAMEWORK_${_FRAMEWORK}_FOUND NAME ${_FRAMEWORK} PATHS'
-                      ' ${CONAN_FRAMEWORK_DIRS})', content)
+                      ' ${CONAN_FRAMEWORK_DIRS${SUFFIX}})', content)
         self.assertIn('set(CONAN_FRAMEWORK_DIRS "path/to/Frameworks1"\n\t\t\t"path/to/Frameworks2" '
                       '${CONAN_FRAMEWORK_DIRS})', content)
         self.assertIn('set(CONAN_LIBS ${CONAN_LIBS} ${CONAN_SYSTEM_LIBS} '


### PR DESCRIPTION
Changelog: Bugfix: improve Apple frameworks lookups with CMake integration
Docs: omit

updated version of #6499
closes: #6416
code from https://github.com/Paultergeist/conan_apple_framework

- [ ] Refer to the issue that supports this Pull Request.
- [ ] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [ ] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [ ] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 

<sup>**Note:** By default this PR will skip the slower tests and will use a limited set of python versions. Check [here](https://github.com/conan-io/conan/blob/develop/.github/PR_INCREASE_TESTING.md) how to increase the testing level by writing some tags in the current PR body text.</sup>
