### PR TITLE
avoiding concurrent modification of package metadata (#6524)

### DIFF
--- a/conans/paths/package_layouts/package_cache_layout.py
+++ b/conans/paths/package_layouts/package_cache_layout.py
@@ -2,6 +2,7 @@
 
 import os
 import platform
+import threading
 from contextlib import contextmanager
 
 
@@ -170,16 +171,25 @@ class PackageCacheLayout(object):
             raise RecipeNotFoundException(self._ref)
         return PackageMetadata.loads(text)
 
+    _metadata_locks = {}  # Needs to be shared among all instances
+
     @contextmanager
     def update_metadata(self):
-        lockfile = self.package_metadata() + ".lock"
+        metadata_path = self.package_metadata()
+        lockfile = metadata_path + ".lock"
         with fasteners.InterProcessLock(lockfile, logger=logger):
+            lock_name = self.package_metadata()  # The path is the thing that defines mutex
+            thread_lock = PackageCacheLayout._metadata_locks.setdefault(lock_name, threading.Lock())
+            thread_lock.acquire()
             try:
-                metadata = self.load_metadata()
-            except RecipeNotFoundException:
-                metadata = PackageMetadata()
-            yield metadata
-            save(self.package_metadata(), metadata.dumps())
+                try:
+                    metadata = self.load_metadata()
+                except RecipeNotFoundException:
+                    metadata = PackageMetadata()
+                yield metadata
+                save(metadata_path, metadata.dumps())
+            finally:
+                thread_lock.release()
 
     # Locks
     def conanfile_read_lock(self, output):


### PR DESCRIPTION
Changelog: Bugfix: Fixing locking system for metadata file so it can be accessed concurrently.
Docs: omit

Backport of #6524

- [X] Refer to the issue that supports this Pull Request.
- [X] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [X] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [X] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 

#TAGS: slow
#REVISIONS: 1

<sup>**Note:** By default this PR will skip the slower tests and will use a limited set of python versions. Check [here](https://github.com/conan-io/conan/blob/develop/.github/PR_INCREASE_TESTING.md) how to increase the testing level by writing some tags in the current PR body text.</sup>