### PR TITLE
#6547 Raise exception for unknown compiler

### DIFF
--- a/conans/client/tools/settings.py
+++ b/conans/client/tools/settings.py
@@ -49,6 +49,9 @@ def check_min_cppstd(conanfile, cppstd, gnu_extensions=False):
         return cppstd_default(compiler, compiler_version)
 
     current_cppstd = deduced_cppstd()
+    if current_cppstd is None:
+        raise ConanException("Could not detect the current default cppstd because "
+                             "the compiler is unknown.")
     check_required_gnu_extension(current_cppstd)
 
     if less_than(current_cppstd, cppstd):

--- a/conans/client/tools/settings.py
+++ b/conans/client/tools/settings.py
@@ -13,6 +13,7 @@ def check_min_cppstd(conanfile, cppstd, gnu_extensions=False):
            default from cppstd_default)
         3. If not settings.compiler is present (not declared in settings) will raise because it
            cannot compare.
+        4. If can not detect the default cppstd for settings.compiler, a exception will be raised.
 
     :param conanfile: ConanFile instance with cppstd to be compared
     :param cppstd: Minimal cppstd version required
@@ -46,12 +47,13 @@ def check_min_cppstd(conanfile, cppstd, gnu_extensions=False):
         if not compiler or not compiler_version:
             raise ConanException("Could not obtain cppstd because there is no declared "
                                  "compiler in the 'settings' field of the recipe.")
-        return cppstd_default(compiler, compiler_version)
+        cppstd = cppstd_default(compiler, compiler_version)
+        if cppstd is None:
+            raise ConanException("Could not detect the current default cppstd for "
+                                 "the compiler {}-{}.".format(compiler, compiler_version))
+        return cppstd
 
     current_cppstd = deduced_cppstd()
-    if current_cppstd is None:
-        raise ConanException("Could not detect the current default cppstd because "
-                             "the compiler is unknown.")
     check_required_gnu_extension(current_cppstd)
 
     if less_than(current_cppstd, cppstd):

--- a/conans/client/tools/settings.py
+++ b/conans/client/tools/settings.py
@@ -49,8 +49,9 @@ def check_min_cppstd(conanfile, cppstd, gnu_extensions=False):
                                  "compiler in the 'settings' field of the recipe.")
         cppstd = cppstd_default(compiler, compiler_version)
         if cppstd is None:
-            raise ConanException("Could not detect the current default cppstd for "
-                                 "the compiler {}-{}.".format(compiler, compiler_version))
+            raise ConanInvalidConfiguration("Could not detect the current default cppstd for "
+                                            "the compiler {}-{}.".format(compiler,
+                                                                         compiler_version))
         return cppstd
 
     current_cppstd = deduced_cppstd()

--- a/conans/test/unittests/client/tools/cppstd_required_test.py
+++ b/conans/test/unittests/client/tools/cppstd_required_test.py
@@ -92,7 +92,7 @@ class CheckMinCppStdTests(unittest.TestCase):
 
     def test_unknown_compiler_declared(self):
         conanfile = self._create_conanfile("sun-cc", "5.13", "Linux", None, "libstdc++")
-        with self.assertRaises(ConanException) as raises:
+        with self.assertRaises(ConanInvalidConfiguration) as raises:
             check_min_cppstd(conanfile, "14", False)
         self.assertEqual("Could not detect the current default cppstd for "
                          "the compiler sun-cc-5.13.", str(raises.exception))

--- a/conans/test/unittests/client/tools/cppstd_required_test.py
+++ b/conans/test/unittests/client/tools/cppstd_required_test.py
@@ -94,8 +94,8 @@ class CheckMinCppStdTests(unittest.TestCase):
         conanfile = self._create_conanfile("sun-cc", "5.13", "Linux", None, "libstdc++")
         with self.assertRaises(ConanException) as raises:
             check_min_cppstd(conanfile, "14", False)
-        self.assertEqual("Could not detect the current default cppstd because "
-                         "the compiler is unknown.", str(raises.exception))
+        self.assertEqual("Could not detect the current default cppstd for "
+                         "the compiler sun-cc-5.13.", str(raises.exception))
 
 
 class ValidMinCppstdTests(unittest.TestCase):

--- a/conans/test/unittests/client/tools/cppstd_required_test.py
+++ b/conans/test/unittests/client/tools/cppstd_required_test.py
@@ -90,6 +90,13 @@ class CheckMinCppStdTests(unittest.TestCase):
         self.assertEqual("Could not obtain cppstd because there is no declared compiler in the "
                          "'settings' field of the recipe.", str(raises.exception))
 
+    def test_unknown_compiler_declared(self):
+        conanfile = self._create_conanfile("sun-cc", "5.13", "Linux", None, "libstdc++")
+        with self.assertRaises(ConanException) as raises:
+            check_min_cppstd(conanfile, "14", False)
+        self.assertEqual("Could not detect the current default cppstd because "
+                         "the compiler is unknown.", str(raises.exception))
+
 
 class ValidMinCppstdTests(unittest.TestCase):
 


### PR DESCRIPTION
Changelog: Fix: check_min_cppstd raises an exception for unknown compiler
Docs: https://github.com/conan-io/docs/pull/1559

fixes #6547 

- [x] Refer to the issue that supports this Pull Request.
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 

<sup>**Note:** By default this PR will skip the slower tests and will use a limited set of python versions. Check [here](https://github.com/conan-io/conan/blob/develop/.github/PR_INCREASE_TESTING.md) how to increase the testing level by writing some tags in the current PR body text.</sup>
