### PR TITLE
Only append generator_platform if needed

### DIFF
--- a/conans/client/build/cmake.py
+++ b/conans/client/build/cmake.py
@@ -159,10 +159,10 @@ class CMake(object):
             compiler_version = self._settings.get_safe("compiler.version")
             if Version(compiler_version) < "16" and self._settings.get_safe("os") != "WindowsCE":
                 if self.generator_platform == "x64":
-                    generator += " Win64"
+                    generator += " Win64" if not generator.endswith(" Win64") else ""
                     generator_platform = None
                 elif self.generator_platform == "ARM":
-                    generator += " ARM"
+                    generator += " ARM" if not generator.endswith(" ARM") else ""
                     generator_platform = None
                 elif self.generator_platform == "Win32":
                     generator_platform = None

--- a/conans/test/unittests/client/build/cmake_test.py
+++ b/conans/test/unittests/client/build/cmake_test.py
@@ -1439,3 +1439,21 @@ build_type: [ Release]
         conanfile.settings = settings
         cmake = CMake(conanfile)
         self.assertEqual(cmake.definitions["CMAKE_SYSTEM_VERSION"], "8.0")
+
+    def test_cmake_vs_arch(self):
+        settings = Settings.loads(default_settings_yml)
+        settings.os = "Windows"
+        settings.arch = "x86_64"
+        settings.compiler = "Visual Studio"
+        settings.compiler.version = "15"
+
+        conanfile = ConanFileMock()
+        conanfile.settings = settings
+
+        cmake = CMake(conanfile, generator="Visual Studio 15 2017 Win64", toolset="v141,host=x64")
+        self.assertIn('-G "Visual Studio 15 2017 Win64"', cmake.command_line)
+        self.assertIn('-T "v141,host=x64"', cmake.command_line)
+
+        cmake = CMake(conanfile, generator="Visual Studio 15 2017", generator_platform="x64", toolset="v141,host=x64")
+        self.assertIn('-G "Visual Studio 15 2017 Win64"', cmake.command_line)
+        self.assertIn('-T "v141,host=x64"', cmake.command_line)


### PR DESCRIPTION
Changelog: Bugfix: Conan should not append generator_platform to the Visual Studio generator if it is already specified by the user.
Docs: omit

Conan should not append generator_platform to the Visual Studio generator if it is already specified by the user - otherwise this breaks builds and means all users must upgrade to use the same version of Conan (there is no way to structure the call to CMake's constructor such that it works with Conan both before and after this change).