### PR TITLE
Fix: parse GCC 10 version from command line

### DIFF
--- a/conans/client/conf/detect.py
+++ b/conans/client/conf/detect.py
@@ -23,7 +23,7 @@ def _gcc_compiler(output, compiler_exe="gcc"):
         if ret != 0:
             return None
         compiler = "gcc"
-        installed_version = re.search("([0-9](\.[0-9])?)", out).group()
+        installed_version = re.search("([0-9]+(\.[0-9])?)", out).group()
         # Since GCC 7.1, -dumpversion return the major version number
         # only ("7"). We must use -dumpfullversion to get the full version
         # number ("7.1.1").

--- a/conans/test/unittests/client/conf/detect/test_gcc_compiler.py
+++ b/conans/test/unittests/client/conf/detect/test_gcc_compiler.py
@@ -1,0 +1,19 @@
+import unittest
+
+import mock
+from parameterized import parameterized
+
+from conans.client.conf.detect import _gcc_compiler
+from conans.test.utils.tools import TestBufferConanOutput
+
+
+class GCCCompilerTestCase(unittest.TestCase):
+
+    @parameterized.expand([("10",), ("4.2",), ('7', )])
+    def test_detect_gcc_10(self, version):
+        output = TestBufferConanOutput()
+        with mock.patch("platform.system", return_value="Linux"):
+            with mock.patch("conans.client.conf.detect.detect_runner", return_value=(0, version)):
+                compiler, installed_version = _gcc_compiler(output)
+        self.assertEqual(compiler, 'gcc')
+        self.assertEqual(installed_version, version)


### PR DESCRIPTION
Changelog: Bugfix: Parse function of GCC version from command line now works with versions `>=10`
Docs: omit

closes #6538 
closes #6539 
