### PR TITLE
raise if targets is not a list

### DIFF
--- a/conans/client/build/msbuild.py
+++ b/conans/client/build/msbuild.py
@@ -103,6 +103,8 @@ class MSBuild(object):
                     user_property_file_name=None):
 
         targets = targets or []
+        if not isinstance(targets, (list, tuple)):
+            raise TypeError("targets argument should be a list")
         properties = properties or {}
         command = []
 

--- a/conans/test/unittests/client/build/msbuild_test.py
+++ b/conans/test/unittests/client/build/msbuild_test.py
@@ -124,6 +124,12 @@ class MSBuildTest(unittest.TestCase):
             msbuild.get_command("dummy.sln", output_binary_log=True)
         self.assertIn(except_text, str(exc.exception))
 
+    def error_targets_argument_Test(self):
+        conanfile = MockConanfile(MockSettings({}))
+        msbuild = MSBuild(conanfile)
+        with self.assertRaises(TypeError):
+            msbuild.get_command("dummy.sln", targets="sometarget")
+
     @unittest.skipUnless(platform.system() == "Windows", "Requires MSBuild")
     def get_version_test(self):
         settings = MockSettings({"build_type": "Debug",


### PR DESCRIPTION
Changelog: Fix: Raise an error if ``MSBuild`` argument ``targets`` is not a list, instead of splitting a string passed as argument instead of a list.
Docs: omit

Close https://github.com/conan-io/conan/issues/6553
