### PR TITLE
Fix Conan inspect when remote.json is not created

### DIFF
--- a/conans/client/conan_api.py
+++ b/conans/client/conan_api.py
@@ -73,7 +73,7 @@ def api_method(f):
         quiet = kwargs.pop("quiet", False)
         old_curdir = get_cwd()
         old_output = api.user_io.out
-        quiet_output = ConanOutput(StringIO(), api.color) if quiet else None
+        quiet_output = ConanOutput(StringIO(), color=api.color) if quiet else None
         try:
             api.create_app(quiet_output=quiet_output)
             log_command(f.__name__, kwargs)

--- a/conans/test/functional/command/inspect_test.py
+++ b/conans/test/functional/command/inspect_test.py
@@ -445,5 +445,4 @@ class InspectRawTest(unittest.TestCase):
         client.run("export . user/channel")
         os.remove(client.cache.remotes_path)
         client.run("inspect MyPkg/1.2.3@user/channel --raw=version")
-        self.assertIn("WARN: Remotes registry file missing, creating default one", client.out)
-        self.assertIn("There are no packages matching the 'MyPkg' pattern", client.out)
+        self.assertIn("1.2.3", client.out)

--- a/conans/test/functional/command/inspect_test.py
+++ b/conans/test/functional/command/inspect_test.py
@@ -438,3 +438,12 @@ class InspectRawTest(unittest.TestCase):
         client.save({"conanfile.py": conanfile})
         client.run("inspect . --raw=default_options")
         self.assertEqual("dict=True\nlist=False", client.out)
+
+    def test_initial_inspect_without_registry_test(self):
+        client = TestClient()
+        client.save({"conanfile.py": self.conanfile})
+        client.run("export . user/channel")
+        os.remove(client.cache.remotes_path)
+        client.run("inspect MyPkg/1.2.3@user/channel --raw=version")
+        self.assertIn("WARN: Remotes registry file missing, creating default one", client.out)
+        self.assertIn("There are no packages matching the 'MyPkg' pattern", client.out)


### PR DESCRIPTION
Changelog: Fix: inspect command can be executed without remote.json (#6558)
Docs: Omit

fixes #6558

- [x] Refer to the issue that supports this Pull Request.
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 

<sup>**Note:** By default this PR will skip the slower tests and will use a limited set of python versions. Check [here](https://github.com/conan-io/conan/blob/develop/.github/PR_INCREASE_TESTING.md) how to increase the testing level by writing some tags in the current PR body text.</sup>
