### PR TITLE
Bugfix: set CMAKE_OSX_DEPLOYMENT_TARGET for iOS, watchOS, tvOS

### DIFF
--- a/conans/client/build/cmake_flags.py
+++ b/conans/client/build/cmake_flags.py
@@ -5,6 +5,7 @@ from conans.client import tools
 from conans.client.build.compiler_flags import architecture_flag, parallel_compiler_cl_flag
 from conans.client.build.cppstd_flags import cppstd_flag, cppstd_from_settings
 from conans.client.tools import cross_building
+from conans.client.tools.apple import is_apple_os
 from conans.client.tools.oss import get_cross_building_settings
 from conans.errors import ConanException
 from conans.model.build_info import DEFAULT_BIN, DEFAULT_INCLUDE, DEFAULT_LIB, DEFAULT_SHARE
@@ -201,7 +202,7 @@ class CMakeDefinitionsBuilder(object):
                         definitions["CMAKE_SYSTEM_NAME"] = "Generic"
         if os_ver:
             definitions["CMAKE_SYSTEM_VERSION"] = os_ver
-            if str(os_) == "Macos":
+            if is_apple_os(os_):
                 definitions["CMAKE_OSX_DEPLOYMENT_TARGET"] = os_ver
 
         # system processor

--- a/conans/test/unittests/client/build/cmake_test.py
+++ b/conans/test/unittests/client/build/cmake_test.py
@@ -1269,17 +1269,24 @@ build_type: [ Release]
         for key, value in install_defintions.items():
             self.assertEqual(cmake.definitions[key], value)
 
+    @parameterized.expand([("Macos", "10.9",),
+                           ("iOS", "7.0",),
+                           ("watchOS", "4.0",),
+                           ("tvOS", "11.0",)])
     @mock.patch('platform.system', return_value="Macos")
-    def test_cmake_system_version_osx(self, _):
+    def test_cmake_system_version_osx(self, the_os, os_version, _):
         settings = Settings.loads(default_settings_yml)
-        settings.os = "Macos"
+        settings.os = the_os
 
         # No version defined
         conanfile = ConanFileMock()
         conanfile.settings = settings
         cmake = CMake(conanfile)
         self.assertFalse("CMAKE_OSX_DEPLOYMENT_TARGET" in cmake.definitions)
-        self.assertFalse("CMAKE_SYSTEM_NAME" in cmake.definitions)
+        if the_os == "Macos":
+            self.assertFalse("CMAKE_SYSTEM_NAME" in cmake.definitions)
+        else:
+            self.assertTrue("CMAKE_SYSTEM_NAME" in cmake.definitions)
         self.assertFalse("CMAKE_SYSTEM_VERSION" in cmake.definitions)
 
         # Version defined using Conan env variable
@@ -1291,12 +1298,12 @@ build_type: [ Release]
             self.assertEqual(cmake.definitions["CMAKE_OSX_DEPLOYMENT_TARGET"], "23")
 
         # Version defined in settings
-        settings.os.version = "10.9"
+        settings.os.version = os_version
         conanfile = ConanFileMock()
         conanfile.settings = settings
         cmake = CMake(conanfile)
-        self.assertEqual(cmake.definitions["CMAKE_SYSTEM_VERSION"], "10.9")
-        self.assertEqual(cmake.definitions["CMAKE_OSX_DEPLOYMENT_TARGET"], "10.9")
+        self.assertEqual(cmake.definitions["CMAKE_SYSTEM_VERSION"], os_version)
+        self.assertEqual(cmake.definitions["CMAKE_OSX_DEPLOYMENT_TARGET"], os_version)
 
         # Version defined in settings AND using Conan env variable
         with tools.environment_append({"CONAN_CMAKE_SYSTEM_VERSION": "23"}):


### PR DESCRIPTION
closes: #6542
Changelog: Bugfix: set CMAKE_OSX_DEPLOYMENT_TARGET for iOS, watchOS, tvOS
Docs: omit

- [x] Refer to the issue that supports this Pull Request.
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 

<sup>**Note:** By default this PR will skip the slower tests and will use a limited set of python versions. Check [here](https://github.com/conan-io/conan/blob/develop/.github/PR_INCREASE_TESTING.md) how to increase the testing level by writing some tags in the current PR body text.</sup>
