### PR TITLE
[meson] Fixes for `test` and `install` + `meson_test` & `meson_install`

### DIFF
--- a/conans/client/build/meson.py
+++ b/conans/client/build/meson.py
@@ -178,9 +178,7 @@ class Meson(object):
         else:
             _build()
 
-    def build(self, args=None, build_dir=None, targets=None):
-        if not self._conanfile.should_build:
-            return
+    def _run_ninja_targets(self, args=None, build_dir=None, targets=None):
         if self.backend != "ninja":
             raise ConanException("Build only supported with 'ninja' backend")
 
@@ -194,6 +192,22 @@ class Meson(object):
         ])
         self._run("ninja %s" % arg_list)
 
+    def _run_meson_command(self, subcommand=None, args=None, build_dir=None):
+        args = args or []
+        build_dir = build_dir or self.build_dir or self._conanfile.build_folder
+
+        arg_list = join_arguments([
+            subcommand,
+            '-C "%s"' % build_dir,
+            args_to_string(args)
+        ])
+        self._run("meson %s" % arg_list)
+
+    def build(self, args=None, build_dir=None, targets=None):
+        if not self._conanfile.should_build:
+            return
+        self._run_ninja_targets(args=args, build_dir=build_dir, targets=targets)
+
     def install(self, args=None, build_dir=None):
         if not self._conanfile.should_install:
             return
@@ -201,14 +215,24 @@ class Meson(object):
         if not self.options.get('prefix'):
             raise ConanException("'prefix' not defined for 'meson.install()'\n"
                                  "Make sure 'package_folder' is defined")
-        self.build(args=args, build_dir=build_dir, targets=["install"])
+        self._run_ninja_targets(args=args, build_dir=build_dir, targets=["install"])
 
     def test(self, args=None, build_dir=None, targets=None):
         if not self._conanfile.should_test:
             return
         if not targets:
             targets = ["test"]
-        self.build(args=args, build_dir=build_dir, targets=targets)
+        self._run_ninja_targets(args=args, build_dir=build_dir, targets=targets)
+
+    def meson_install(self, args=None, build_dir=None):
+        if not self._conanfile.should_install:
+            return
+        self._run_meson_command(subcommand='install', args=args, build_dir=build_dir)
+
+    def meson_test(self, args=None, build_dir=None):
+        if not self._conanfile.should_test:
+            return
+        self._run_meson_command(subcommand='test', args=args, build_dir=build_dir)
 
     @staticmethod
     def get_version():

--- a/conans/test/unittests/client/build/meson_test.py
+++ b/conans/test/unittests/client/build/meson_test.py
@@ -34,6 +34,8 @@ class MesonTest(unittest.TestCase):
         conan_file.settings = Settings()
         conan_file.should_configure = False
         conan_file.should_build = False
+        conan_file.should_test = False
+        conan_file.should_install = False
         conan_file.package_folder = os.path.join(self.tempdir, "my_cache_package_folder")
         meson = Meson(conan_file)
         meson.configure()
@@ -43,6 +45,10 @@ class MesonTest(unittest.TestCase):
         meson.test()
         self.assertIsNone(conan_file.command)
         meson.install()
+        self.assertIsNone(conan_file.command)
+        meson.meson_test()
+        self.assertIsNone(conan_file.command)
+        meson.meson_install()
         self.assertIsNone(conan_file.command)
 
     def folders_test(self):
@@ -148,6 +154,14 @@ class MesonTest(unittest.TestCase):
 
         meson.install()
         self.assertEqual("ninja -C \"%s\" %s" % (build_expected, args_to_string(["install"])),
+                         conan_file.command)
+
+        meson.meson_test()
+        self.assertEqual("meson test -C \"%s\"" % build_expected,
+                         conan_file.command)
+
+        meson.meson_install()
+        self.assertEqual("meson install -C \"%s\"" % build_expected,
                          conan_file.command)
 
     def prefix_test(self):


### PR DESCRIPTION
Changelog: (Feature | Bugfix):
- Fixed inability to run execute `test` and `install` separately, that is, without `build` step.
- Added `meson_test()` method, which executes `meson test` (compared to `ninja test` in `test()`). `meson test` have multiple options for additional test configuration (https://mesonbuild.com/Unit-tests.html#testing-tool).
- Added `meson_install()` method, which executes `meson install` (compared to `ninja install` in `install()`). `meson install` have multiple options for additional installation configuration (https://mesonbuild.com/Installing.html#custom-install-behaviour).

Docs: https://github.com/conan-io/docs/pull/1568

- [ ] Refer to the issue that supports this Pull Request.
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [ ] I've followed the PEP8 style guides for Python code.
- [x] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 

<sup>**Note:** By default this PR will skip the slower tests and will use a limited set of python versions. Check [here](https://github.com/conan-io/conan/blob/develop/.github/PR_INCREASE_TESTING.md) how to increase the testing level by writing some tags in the current PR body text.</sup>
