### PR TITLE
Support multiple file patterns in self.copy

### DIFF
--- a/conans/test/unittests/client/file_copier_test.py
+++ b/conans/test/unittests/client/file_copier_test.py
@@ -16,10 +16,13 @@ class FileCopierTest(unittest.TestCase):
         sub2 = os.path.join(folder1, "subdir2")
         save(os.path.join(sub1, "file1.txt"), "Hello1")
         save(os.path.join(sub1, "file2.c"), "Hello2")
+        save(os.path.join(sub1, "file3.cpp"), "Hello3")
         save(os.path.join(sub1, "sub1/file1.txt"), "Hello1 sub")
         save(os.path.join(sub1, "sub1/file2.c"), "Hello2 sub")
+        save(os.path.join(sub1, "sub1/file3.cpp"), "Hello3 sub")
         save(os.path.join(sub2, "file1.txt"), "2 Hello1")
         save(os.path.join(sub2, "file2.c"), "2 Hello2")
+        save(os.path.join(sub2, "file3.cpp"), "3 Hello3")
 
         folder2 = temp_folder()
         copier = FileCopier([folder1], folder2)
@@ -35,6 +38,15 @@ class FileCopierTest(unittest.TestCase):
         self.assertEqual("Hello1", load(os.path.join(folder2, "texts/file1.txt")))
         self.assertEqual("Hello1 sub", load(os.path.join(folder2, "texts/sub1/file1.txt")))
         self.assertNotIn("subdir2", os.listdir(os.path.join(folder2, "texts")))
+
+        folder2 = temp_folder()
+        copier = FileCopier([folder1], folder2)
+        copier(["*.c", "*.cpp"], "code", "subdir1")
+        self.assertEqual("Hello2", load(os.path.join(folder2, "code/file2.c")))
+        self.assertEqual("Hello3", load(os.path.join(folder2, "code/file3.cpp")))
+        self.assertEqual("Hello2 sub", load(os.path.join(folder2, "code/sub1/file2.c")))
+        self.assertEqual("Hello3 sub", load(os.path.join(folder2, "code/sub1/file3.cpp")))
+        self.assertNotIn("subdir2", os.listdir(os.path.join(folder2, "code")))
 
     @unittest.skipUnless(platform.system() != "Windows", "Requires Symlinks")
     def basic_with_linked_dir_test(self):


### PR DESCRIPTION
Changelog: Feature: Support multiple file patterns in self.copy
Docs: https://github.com/conan-io/docs/pull/XXXX

This is a very rough way to support multiple file patterns in `self.copy`. My original use case was something as simple as copying both `*.h` and `*.hpp` files to the package folder without having to repeat the information. The feature was apparently requested in #5354 but it is unclear whether this pull request can close the issue or whether it required another solution.

For a first draft I decided to go with the simple solution:
* Make the `pattern` parameter take either a `str` parameter as it does today, or a `list` one.
* Loop over the patterns to find files to copy, and copy them without changing the algorithm further.

The only optimization I implemented so far is a set trick to avoid copying files twice when a file matches several patterns. It could probably be improved further by considering the list of patterns in `_filter_files` instead of `_copy`, but since there is some logic in `_copy` that depends on the pattern to call `link_folders` I decided that I would go for the simpler solution first.

It's worth nothing that being able to feel a list of patterns to singular `pattern` doesn't feel super right, but this specific parameter is often positional, so I don't think that it is that much of an issue either.

Are you interested in pursuing such a PR?

---

- [x] Refer to the issue that supports this Pull Request: there seems to be a need in #5354.
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 
