### PR TITLE
[refact] Run 'conanfile::build()' only once in the sources

### DIFF
--- a/conans/client/build/build.py
+++ b/conans/client/build/build.py
@@ -1,0 +1,14 @@
+
+from conans.errors import conanfile_exception_formatter
+from conans.model.conan_file import get_env_context_manager
+
+
+def build_conanfile(conanfile, hook_manager, **hook_kwargs):
+    hook_manager.execute("pre_build", **hook_kwargs)
+
+    with get_env_context_manager(conanfile):
+        conanfile.output.highlight("Running build()")
+        with conanfile_exception_formatter(str(conanfile), "build"):
+            conanfile.build()
+
+    hook_manager.execute("post_build", **hook_kwargs)

--- a/conans/client/build/build.py
+++ b/conans/client/build/build.py
@@ -3,7 +3,7 @@ from conans.errors import conanfile_exception_formatter
 from conans.model.conan_file import get_env_context_manager
 
 
-def build_conanfile(conanfile, hook_manager, **hook_kwargs):
+def run_build_method(conanfile, hook_manager, **hook_kwargs):
     hook_manager.execute("pre_build", conanfile=conanfile, **hook_kwargs)
 
     with get_env_context_manager(conanfile):

--- a/conans/client/build/build.py
+++ b/conans/client/build/build.py
@@ -1,11 +1,15 @@
 
+import os
+
 from conans.errors import conanfile_exception_formatter
 from conans.model.conan_file import get_env_context_manager
+from conans.util.log import logger
 
 
 def run_build_method(conanfile, hook_manager, **hook_kwargs):
     hook_manager.execute("pre_build", conanfile=conanfile, **hook_kwargs)
 
+    logger.debug("Call conanfile.build() with files in build folder: %s", os.listdir(conanfile.build_folder))
     with get_env_context_manager(conanfile):
         conanfile.output.highlight("Calling build()")
         with conanfile_exception_formatter(str(conanfile), "build"):

--- a/conans/client/build/build.py
+++ b/conans/client/build/build.py
@@ -4,11 +4,11 @@ from conans.model.conan_file import get_env_context_manager
 
 
 def build_conanfile(conanfile, hook_manager, **hook_kwargs):
-    hook_manager.execute("pre_build", **hook_kwargs)
+    hook_manager.execute("pre_build", conanfile=conanfile, **hook_kwargs)
 
     with get_env_context_manager(conanfile):
         conanfile.output.highlight("Running build()")
         with conanfile_exception_formatter(str(conanfile), "build"):
             conanfile.build()
 
-    hook_manager.execute("post_build", **hook_kwargs)
+    hook_manager.execute("post_build", conanfile=conanfile, **hook_kwargs)

--- a/conans/client/build/build.py
+++ b/conans/client/build/build.py
@@ -7,7 +7,7 @@ def build_conanfile(conanfile, hook_manager, **hook_kwargs):
     hook_manager.execute("pre_build", conanfile=conanfile, **hook_kwargs)
 
     with get_env_context_manager(conanfile):
-        conanfile.output.highlight("Running build()")
+        conanfile.output.highlight("Calling build()")
         with conanfile_exception_formatter(str(conanfile), "build"):
             conanfile.build()
 

--- a/conans/client/cmd/build.py
+++ b/conans/client/cmd/build.py
@@ -1,6 +1,6 @@
 import os
 
-from conans.client.build.build import build_conanfile
+from conans.client.build.build import run_build_method
 from conans.errors import (ConanException, NotFoundException, conanfile_exception_formatter)
 from conans.model.conan_file import get_env_context_manager
 from conans.paths import CONANFILE, CONANFILE_TXT
@@ -45,7 +45,7 @@ def cmd_build(app, conanfile_path, source_folder, build_folder, package_folder, 
         conan_file.source_folder = source_folder
         conan_file.package_folder = package_folder
         conan_file.install_folder = install_folder
-        build_conanfile(conan_file, app.hook_manager, conanfile_path=conanfile_path)
+        run_build_method(conan_file, app.hook_manager, conanfile_path=conanfile_path)
         if test:
             with get_env_context_manager(conan_file):
                 conan_file.output.highlight("Running test()")

--- a/conans/client/cmd/build.py
+++ b/conans/client/cmd/build.py
@@ -1,5 +1,6 @@
 import os
 
+from conans.client.build.build import build_conanfile
 from conans.errors import (ConanException, NotFoundException, conanfile_exception_formatter)
 from conans.model.conan_file import get_env_context_manager
 from conans.paths import CONANFILE, CONANFILE_TXT
@@ -44,15 +45,9 @@ def cmd_build(app, conanfile_path, source_folder, build_folder, package_folder, 
         conan_file.source_folder = source_folder
         conan_file.package_folder = package_folder
         conan_file.install_folder = install_folder
-        app.hook_manager.execute("pre_build", conanfile=conan_file,
-                                 conanfile_path=conanfile_path)
-        with get_env_context_manager(conan_file):
-            conan_file.output.highlight("Running build()")
-            with conanfile_exception_formatter(str(conan_file), "build"):
-                conan_file.build()
-            app.hook_manager.execute("post_build", conanfile=conan_file,
-                                     conanfile_path=conanfile_path)
-            if test:
+        build_conanfile(conan_file, app.hook_manager, conanfile=conan_file, conanfile_path=conanfile_path)
+        if test:
+            with get_env_context_manager(conan_file):
                 conan_file.output.highlight("Running test()")
                 with conanfile_exception_formatter(str(conan_file), "test"):
                     conan_file.test()

--- a/conans/client/cmd/build.py
+++ b/conans/client/cmd/build.py
@@ -45,7 +45,7 @@ def cmd_build(app, conanfile_path, source_folder, build_folder, package_folder, 
         conan_file.source_folder = source_folder
         conan_file.package_folder = package_folder
         conan_file.install_folder = install_folder
-        build_conanfile(conan_file, app.hook_manager, conanfile=conan_file, conanfile_path=conanfile_path)
+        build_conanfile(conan_file, app.hook_manager, conanfile_path=conanfile_path)
         if test:
             with get_env_context_manager(conan_file):
                 conan_file.output.highlight("Running test()")

--- a/conans/client/installer.py
+++ b/conans/client/installer.py
@@ -3,7 +3,7 @@ import shutil
 import time
 
 from conans.client import tools
-from conans.client.build.build import build_conanfile
+from conans.client.build.build import run_build_method
 from conans.client.file_copier import report_copied_files
 from conans.client.generators import TXTGenerator, write_generators
 from conans.client.graph.graph import BINARY_BUILD, BINARY_CACHE, BINARY_DOWNLOAD, BINARY_EDITABLE, \
@@ -115,7 +115,7 @@ class _PackageBuilder(object):
 
         try:
             logger.debug("Call conanfile.build() with files in build folder: %s", os.listdir(build_folder))
-            build_conanfile(conanfile, self._hook_manager, reference=pref.ref, package_id=pref.id)
+            run_build_method(conanfile, self._hook_manager, reference=pref.ref, package_id=pref.id)
             self._output.success("Package '%s' built" % pref.id)
             self._output.info("Build folder %s" % build_folder)
         except Exception as exc:

--- a/conans/client/installer.py
+++ b/conans/client/installer.py
@@ -104,24 +104,23 @@ class _PackageBuilder(object):
             logger.debug("BUILD: Copied to %s", build_folder)
             logger.debug("BUILD: Files copied %s", ",".join(os.listdir(build_folder)))
 
-    def _build(self, conanfile, pref, build_folder):
+    def _build(self, conanfile, pref):
         # Read generators from conanfile and generate the needed files
         logger.info("GENERATORS: Writing generators")
-        write_generators(conanfile, build_folder, self._output)
+        write_generators(conanfile, conanfile.build_folder, self._output)
 
         # Build step might need DLLs, binaries as protoc to generate source files
         # So execute imports() before build, storing the list of copied_files
-        copied_files = run_imports(conanfile, build_folder)
+        copied_files = run_imports(conanfile, conanfile.build_folder)
 
         try:
-            logger.debug("Call conanfile.build() with files in build folder: %s", os.listdir(build_folder))
             run_build_method(conanfile, self._hook_manager, reference=pref.ref, package_id=pref.id)
             self._output.success("Package '%s' built" % pref.id)
-            self._output.info("Build folder %s" % build_folder)
+            self._output.info("Build folder %s" % conanfile.build_folder)
         except Exception as exc:
             self._output.writeln("")
             self._output.error("Package '%s' build failed" % pref.id)
-            self._output.warn("Build folder %s" % build_folder)
+            self._output.warn("Build folder %s" % conanfile.build_folder)
             if isinstance(exc, ConanExceptionInUserConanfileMethod):
                 raise exc
             raise ConanException(exc)
@@ -195,7 +194,7 @@ class _PackageBuilder(object):
                         conanfile.package_folder = package_folder
                         # In local cache, install folder always is build_folder
                         conanfile.install_folder = build_folder
-                        self._build(conanfile, pref, build_folder)
+                        self._build(conanfile, pref)
                         clean_dirty(build_folder)
 
                     prev = self._package(conanfile, pref, package_layout, conanfile_path, build_folder, package_folder)

--- a/conans/client/installer.py
+++ b/conans/client/installer.py
@@ -115,7 +115,7 @@ class _PackageBuilder(object):
 
         try:
             logger.debug("Call conanfile.build() with files in build folder: %s", os.listdir(build_folder))
-            build_conanfile(conanfile, self._hook_manager, conanfile=conanfile, reference=pref.ref, package_id=pref.id)
+            build_conanfile(conanfile, self._hook_manager, reference=pref.ref, package_id=pref.id)
             self._output.success("Package '%s' built" % pref.id)
             self._output.info("Build folder %s" % build_folder)
         except Exception as exc:

--- a/conans/test/functional/options/options_test.py
+++ b/conans/test/functional/options/options_test.py
@@ -49,7 +49,7 @@ class Pkg(ConanFile):
                      "test_package/conanfile.py": test})
         client.run("create . Pkg/0.1@user/testing -o *:shared=True")
         self.assertIn("Pkg/0.1@user/testing: Calling build()", client.out)
-        self.assertIn("Pkg/0.1@user/testing (test package): Running build()", client.out)
+        self.assertIn("Pkg/0.1@user/testing (test package): Calling build()", client.out)
 
     def general_scope_priorities_test(self):
         client = TestClient()

--- a/conans/test/unittests/tools/files_patch_test.py
+++ b/conans/test/unittests/tools/files_patch_test.py
@@ -253,7 +253,7 @@ class ToolsFilesPatchTest(unittest.TestCase):
         foo_content = client.load("foo.txt")
         self.assertIn(dedent("""For us, there is no spring.
 Just the wind that smells fresh before the storm."""), foo_content)
-        self.assertIn("Running build()", client.out)
+        self.assertIn("Calling build()", client.out)
         self.assertNotIn("Warning", client.out)
 
     def _save_files(self, file_content):


### PR DESCRIPTION
Changelog: omit
Docs: omit

A refact to call the function `conanfile::build()` in a single place (easy to see the environment applied)

This changes the order of some outputs related to the hooks and a message (all of them commented in the PR), but I'd think it is not breaking, is it?