### PR TITLE
Set environment variables in conaninfo.txt when using export-pkg

### DIFF
--- a/conans/client/cmd/export_pkg.py
+++ b/conans/client/cmd/export_pkg.py
@@ -43,6 +43,11 @@ def export_pkg(app, recorder, full_ref, source_folder, build_folder, package_fol
 
     recipe_hash = layout.recipe_manifest().summary_hash
     conanfile.info.recipe_hash = recipe_hash
+
+    for package_name, env_vars in conanfile._conan_env_values.data.items():
+        for name, value in env_vars.items():
+                conanfile.info.env_values.add(name, value, package_name)
+
     conanfile.develop = True
     with set_dirty_context_manager(dest_package_folder):
         if package_folder:

--- a/conans/client/cmd/export_pkg.py
+++ b/conans/client/cmd/export_pkg.py
@@ -38,7 +38,6 @@ def export_pkg(app, recorder, full_ref, source_folder, build_folder, package_fol
     from conans.client.conan_api import existing_info_files
     if install_folder and existing_info_files(install_folder):
         load_deps_info(install_folder, conanfile, required=True)
-
     package_id = pkg_node.package_id
     output.info("Packaging to %s" % package_id)
     pref = PackageReference(ref, package_id)
@@ -54,7 +53,6 @@ def export_pkg(app, recorder, full_ref, source_folder, build_folder, package_fol
 
     recipe_hash = layout.recipe_manifest().summary_hash
     conanfile.info.recipe_hash = recipe_hash
-
     conanfile.develop = True
     with set_dirty_context_manager(dest_package_folder):
         if package_folder:

--- a/conans/client/cmd/export_pkg.py
+++ b/conans/client/cmd/export_pkg.py
@@ -46,7 +46,7 @@ def export_pkg(app, recorder, full_ref, source_folder, build_folder, package_fol
 
     for package_name, env_vars in conanfile._conan_env_values.data.items():
         for name, value in env_vars.items():
-                conanfile.info.env_values.add(name, value, package_name)
+            conanfile.info.env_values.add(name, value, package_name)
 
     conanfile.develop = True
     with set_dirty_context_manager(dest_package_folder):

--- a/conans/client/cmd/export_pkg.py
+++ b/conans/client/cmd/export_pkg.py
@@ -1,10 +1,12 @@
 import os
 
 from conans.client import packager
+from conans.client.graph.graph import BINARY_SKIP
 from conans.client.graph.graph_manager import load_deps_info
 from conans.errors import ConanException
 from conans.model.ref import PackageReference
 from conans.util.files import rmdir, set_dirty_context_manager
+from conans.client.installer import add_env_conaninfo
 
 
 def export_pkg(app, recorder, full_ref, source_folder, build_folder, package_folder, install_folder,
@@ -24,11 +26,20 @@ def export_pkg(app, recorder, full_ref, source_folder, build_folder, package_fol
     # this is a bit tricky, but works. The root (virtual), has only 1 neighbor,
     # which is the exported pkg
     nodes = deps_graph.root.neighbors()
-    conanfile = nodes[0].conanfile
+    pkg_node = nodes[0]
+    conanfile = pkg_node.conanfile
+
+    def _init_conanfile_infos():
+        node_order = [n for n in pkg_node.public_closure if n.binary != BINARY_SKIP]
+        subtree_libnames = [pkg_node.ref.name for node in node_order]
+        add_env_conaninfo(conanfile, subtree_libnames)
+
+    _init_conanfile_infos()
     from conans.client.conan_api import existing_info_files
     if install_folder and existing_info_files(install_folder):
         load_deps_info(install_folder, conanfile, required=True)
-    package_id = nodes[0].package_id
+
+    package_id = pkg_node.package_id
     output.info("Packaging to %s" % package_id)
     pref = PackageReference(ref, package_id)
     layout = cache.package_layout(ref, short_paths=conanfile.short_paths)
@@ -44,10 +55,6 @@ def export_pkg(app, recorder, full_ref, source_folder, build_folder, package_fol
     recipe_hash = layout.recipe_manifest().summary_hash
     conanfile.info.recipe_hash = recipe_hash
 
-    for package_name, env_vars in conanfile._conan_env_values.data.items():
-        for name, value in env_vars.items():
-            conanfile.info.env_values.add(name, value, package_name)
-
     conanfile.develop = True
     with set_dirty_context_manager(dest_package_folder):
         if package_folder:
@@ -62,6 +69,6 @@ def export_pkg(app, recorder, full_ref, source_folder, build_folder, package_fol
     pref = PackageReference(pref.ref, pref.id, prev)
     if graph_info.graph_lock:
         # after the package has been created we need to update the node PREV
-        nodes[0].prev = pref.revision
+        pkg_node.prev = pref.revision
         graph_info.graph_lock.update_check_graph(deps_graph, output)
     recorder.package_exported(pref)

--- a/conans/client/cmd/export_pkg.py
+++ b/conans/client/cmd/export_pkg.py
@@ -31,7 +31,7 @@ def export_pkg(app, recorder, full_ref, source_folder, build_folder, package_fol
 
     def _init_conanfile_infos():
         node_order = [n for n in pkg_node.public_closure if n.binary != BINARY_SKIP]
-        subtree_libnames = [pkg_node.ref.name for node in node_order]
+        subtree_libnames = [node.ref.name for node in node_order]
         add_env_conaninfo(conanfile, subtree_libnames)
 
     _init_conanfile_infos()

--- a/conans/client/installer.py
+++ b/conans/client/installer.py
@@ -45,6 +45,14 @@ def build_id(conan_file):
     return None
 
 
+def add_env_conaninfo(conan_file, subtree_libnames):
+    for package_name, env_vars in conan_file._conan_env_values.data.items():
+        for name, value in env_vars.items():
+            if not package_name or package_name in subtree_libnames or \
+                    package_name == conan_file.name:
+                conan_file.info.env_values.add(name, value, package_name)
+
+
 class _PackageBuilder(object):
     def __init__(self, cache, output, hook_manager, remote_manager):
         self._cache = cache
@@ -495,11 +503,7 @@ class BinaryInstaller(object):
         # Update the info but filtering the package values that not apply to the subtree
         # of this current node and its dependencies.
         subtree_libnames = [node.ref.name for node in node_order]
-        for package_name, env_vars in conan_file._conan_env_values.data.items():
-            for name, value in env_vars.items():
-                if not package_name or package_name in subtree_libnames or \
-                   package_name == conan_file.name:
-                    conan_file.info.env_values.add(name, value, package_name)
+        add_env_conaninfo(conan_file, subtree_libnames)
 
     def _call_package_info(self, conanfile, package_folder, ref):
         conanfile.cpp_info = CppInfo(package_folder)

--- a/conans/test/functional/command/export_pkg_test.py
+++ b/conans/test/functional/command/export_pkg_test.py
@@ -167,6 +167,23 @@ class HelloPythonConan(ConanFile):
         client.run("export-pkg . Hello/0.1@lasote/stable -pr=myprofile")
         self.assertIn("Hello/0.1@lasote/stable: ENV-VALUE: MYCUSTOMVALUE!!!", client.out)
 
+    def test_profile_environment_conaninfo(self):
+        # https://github.com/conan-io/conan/issues/6603
+        profile = dedent("""
+            [env]
+            MYCUSTOMVAR=MYCUSTOMVALUE
+            """)
+        client = TestClient()
+        client.save({"conanfile.py": GenConanfile().with_name("Hello").with_version("0.1"),
+                     "myprofile": profile})
+        client.run("export-pkg . Hello/0.1@lasote/stable -pr=myprofile")
+        ref = ConanFileReference.loads("Hello/0.1@lasote/stable")
+        pkg_folder = client.cache.package_layout(ref).packages()
+        folders = os.listdir(pkg_folder)
+        pkg_folder = os.path.join(pkg_folder, folders[0])
+        conaninfo = load(os.path.join(pkg_folder, "conaninfo.txt"))
+        self.assertIn("MYCUSTOMVAR=MYCUSTOMVALUE", conaninfo)
+
     def test_options_install(self):
         # https://github.com/conan-io/conan/issues/2242
         conanfile = """from conans import ConanFile


### PR DESCRIPTION
Changelog: Bugfix: Environment variables from the profiles are not set in the _conaninfo.txt_ file of the packages exported with the `export-pkg` command.
Docs: Omit

Closes: #6603

- [X] Refer to the issue that supports this Pull Request.
- [X] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [X] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [X] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 

<sup>**Note:** By default this PR will skip the slower tests and will use a limited set of python versions. Check [here](https://github.com/conan-io/conan/blob/develop/.github/PR_INCREASE_TESTING.md) how to increase the testing level by writing some tags in the current PR body text.</sup>
