### PR TITLE
Fix error parsing `system_libs` from `conanbuildinfo.txt` file

### DIFF
--- a/conans/client/generators/text.py
+++ b/conans/client/generators/text.py
@@ -108,8 +108,12 @@ class TXTGenerator(Generator):
                     var_name, config = tokens
                 else:
                     config = None
-                tokens = var_name.split("_", 1)
-                field = tokens[0]
+                if 'system_libs' in var_name:
+                    tokens = var_name.split("system_libs_", 1)
+                    field = 'system_libs'
+                else:
+                    tokens = var_name.split("_", 1)
+                    field = tokens[0]
                 dep = tokens[1] if len(tokens) == 2 else None
                 if field == "cppflags":
                     field = "cxxflags"

--- a/conans/test/unittests/client/generators/text_test.py
+++ b/conans/test/unittests/client/generators/text_test.py
@@ -44,3 +44,21 @@ class TextGeneratorTest(unittest.TestCase):
 
             [cxxflags_MyPkg]
             -cxxflag_parent"""), txt_out)
+
+    def test_load_sytem_libs(self):
+        content = textwrap.dedent("""
+            [system_libs]
+            main
+            
+            [system_libs_requirement]
+            requirement
+
+            [system_libs_requirement_other]
+            requirement_other
+        """)
+
+        deps_cpp_info, _, _ = TXTGenerator.loads(content)
+        self.assertEqual(deps_cpp_info.system_libs, ["main", ])
+        a = deps_cpp_info["requirement"]
+        self.assertEqual(deps_cpp_info["requirement"].system_libs, ["requirement", ])
+        self.assertEqual(deps_cpp_info["requirement_other"].system_libs, ["requirement_other", ])


### PR DESCRIPTION
Changelog: Bugfix: Fix error parsing `system_libs` from `conanbuildinfo.txt` file
Docs: omit

Closes https://github.com/conan-io/conan/issues/6610
