### PR TITLE
fixing python_requires with build_id (#6563)

### DIFF
--- a/conans/model/info.py
+++ b/conans/model/info.py
@@ -352,7 +352,8 @@ class PythonRequiresInfo(object):
 
     def copy(self):
         # For build_id() implementation
-        return PythonRequiresInfo(self._refs, self._default_package_id_mode)
+        refs = [r._ref for r in self._refs] if self._refs else None
+        return PythonRequiresInfo(refs, self._default_package_id_mode)
 
     def __bool__(self):
         return bool(self._refs)

--- a/conans/test/functional/py_requires/python_requires_test.py
+++ b/conans/test/functional/py_requires/python_requires_test.py
@@ -752,3 +752,21 @@ class PyRequiresExtendTest(unittest.TestCase):
         client2.run("build .")
         self.assertIn("conanfile.py: Build: tool header: myheader", client2.out)
         self.assertIn("conanfile.py: Build: tool other: otherheader", client2.out)
+
+    def test_build_id(self):
+        client = TestClient(default_server_user=True)
+        self._define_base(client)
+        reuse = textwrap.dedent("""
+            from conans import ConanFile
+            class PkgTest(ConanFile):
+                python_requires = "base/1.1@user/testing"
+                python_requires_extend = "base.MyConanfileBase"
+                def build_id(self):
+                    pass
+            """)
+        client.save({"conanfile.py": reuse}, clean_first=True)
+        client.run("create . Pkg/0.1@user/testing")
+        self.assertIn("Pkg/0.1@user/testing: My cool source!", client.out)
+        self.assertIn("Pkg/0.1@user/testing: My cool build!", client.out)
+        self.assertIn("Pkg/0.1@user/testing: My cool package!", client.out)
+        self.assertIn("Pkg/0.1@user/testing: My cool package_info!", client.out)


### PR DESCRIPTION
Changelog: Bugfix: Fixed crashing of recipes using both ``python_requires`` and ``build_id()``.
Docs: Omit

Cherry-pick https://github.com/conan-io/conan/pull/6563
Closes #6609 