### PR TITLE
Capture the expected exception

### DIFF
--- a/conans/model/info.py
+++ b/conans/model/info.py
@@ -30,9 +30,11 @@ class RequirementInfo(object):
         self._indirect = indirect
 
         try:
-            getattr(self, default_package_id_mode)()
+            func_package_id_mode = getattr(self, default_package_id_mode)
         except AttributeError:
             raise ConanException("'%s' is not a known package_id_mode" % default_package_id_mode)
+        else:
+            func_package_id_mode()
 
     def copy(self):
         # Useful for build_id()
@@ -285,9 +287,11 @@ class PythonRequireInfo(object):
         self._revision = None
 
         try:
-            getattr(self, default_package_id_mode)()
+            func_package_id_mode = getattr(self, default_package_id_mode)
         except AttributeError:
             raise ConanException("'%s' is not a known package_id_mode" % default_package_id_mode)
+        else:
+            func_package_id_mode()
 
     @property
     def sha(self):


### PR DESCRIPTION
Changelog: omit
Docs: omit

Misleading exception. It was the origin of https://github.com/conan-io/conan/issues/6609 and https://github.com/conan-io/conan/issues/6562
