### PR TITLE
Add '.editorconfig'

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,15 @@
+# https://editorconfig.org/
+
+root = true
+
+[*]
+indent_style = space
+indent_size = 4
+insert_final_newline = true
+trim_trailing_whitespace = true
+end_of_line = lf
+charset = utf-8
+
+# Docstrings and comments use max_line_length = 79
+[*.py]
+max_line_length = 119

--- a/.editorconfig
+++ b/.editorconfig
@@ -12,4 +12,4 @@ charset = utf-8
 
 # Docstrings and comments use max_line_length = 79
 [*.py]
-max_line_length = 119
+max_line_length = 101


### PR DESCRIPTION
Changelog: omit
Docs: omit

From time to time I see some PRs doing some reformat (besides the functionality they try to implement) and I wonder if we all are using the same configuration in our editor.

Most common editors will use it: https://editorconfig.org/
Initial values are taken from https://github.com/django/django/blob/master/.editorconfig and the 101 columns we are already using.
