### PR TITLE
Add build policy help to graph build-order

### DIFF
--- a/conans/client/command.py
+++ b/conans/client/command.py
@@ -1778,7 +1778,7 @@ class Command(object):
         build_order_cmd = subparsers.add_parser('build-order', help='Returns build-order')
         build_order_cmd.add_argument('lockfile', help='lockfile folder')
         build_order_cmd.add_argument("-b", "--build", action=Extender, nargs="?",
-                                     help="nodes to build")
+                                     help=_help_build_policies.format("never"))
         build_order_cmd.add_argument("--json", action=OnceArgument,
                                      help="generate output file in json format")
 


### PR DESCRIPTION
Changelog: Fix: Add build policy help for `--build` argument when used in `conan graph build-order` command.
Docs: https://github.com/conan-io/docs/pull/1584

- [X] Refer to the issue that supports this Pull Request.
- [X] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [X] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [X] I've followed the PEP8 style guides for Python code.
- [X] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 

<sup>**Note:** By default this PR will skip the slower tests and will use a limited set of python versions. Check [here](https://github.com/conan-io/conan/blob/develop/.github/PR_INCREASE_TESTING.md) how to increase the testing level by writing some tags in the current PR body text.</sup>
