### PR TITLE
Feature/package id cmake checks

### DIFF
--- a/conans/client/generators/cmake_common.py
+++ b/conans/client/generators/cmake_common.py
@@ -230,7 +230,7 @@ class CMakeCommonMacros:
                 cmake_policy(GET "${policy_id}" _policy)
                 set(policy "${_policy}" PARENT_SCOPE)
             else()
-                set(policy "" PARENT_SCOPE) 
+                set(policy "" PARENT_SCOPE)
             endif()
         endfunction()
     """)
@@ -374,13 +374,13 @@ class CMakeCommonMacros:
             set(CMAKE_RUNTIME_OUTPUT_DIRECTORY_RELWITHDEBINFO ${CMAKE_RUNTIME_OUTPUT_DIRECTORY})
             set(CMAKE_RUNTIME_OUTPUT_DIRECTORY_MINSIZEREL ${CMAKE_RUNTIME_OUTPUT_DIRECTORY})
             set(CMAKE_RUNTIME_OUTPUT_DIRECTORY_DEBUG ${CMAKE_RUNTIME_OUTPUT_DIRECTORY})
-        
+
             set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/lib)
             set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY_RELEASE ${CMAKE_ARCHIVE_OUTPUT_DIRECTORY})
             set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY_RELWITHDEBINFO ${CMAKE_ARCHIVE_OUTPUT_DIRECTORY})
             set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY_MINSIZEREL ${CMAKE_ARCHIVE_OUTPUT_DIRECTORY})
             set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY_DEBUG ${CMAKE_ARCHIVE_OUTPUT_DIRECTORY})
-        
+
             set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/lib)
             set(CMAKE_LIBRARY_OUTPUT_DIRECTORY_RELEASE ${CMAKE_LIBRARY_OUTPUT_DIRECTORY})
             set(CMAKE_LIBRARY_OUTPUT_DIRECTORY_RELWITHDEBINFO ${CMAKE_LIBRARY_OUTPUT_DIRECTORY})
@@ -393,7 +393,7 @@ class CMakeCommonMacros:
         macro(conan_split_version VERSION_STRING MAJOR MINOR)
             #make a list from the version string
             string(REPLACE "." ";" VERSION_LIST "${VERSION_STRING}")
-        
+
             #write output values
             list(LENGTH VERSION_LIST _version_len)
             list(GET VERSION_LIST 0 ${MAJOR})
@@ -420,15 +420,17 @@ class CMakeCommonMacros:
                 conan_message(STATUS "WARN: conaninfo.txt not found")
                 return()
             endif()
-        
+
             file (READ "${_CONAN_CURRENT_DIR}/conaninfo.txt" CONANINFO)
-        
-            string(REGEX MATCH "compiler=([-A-Za-z0-9_ ]+)" _MATCHED ${CONANINFO})
+
+            # MATCHALL will match all, including the last one, which is the full_settings one
+            string(REGEX MATCHALL "compiler=([-A-Za-z0-9_ ]+)" _MATCHED ${CONANINFO})
             if(DEFINED CMAKE_MATCH_1)
                 string(STRIP "${CMAKE_MATCH_1}" _CONAN_INFO_COMPILER)
                 set(${CONAN_INFO_COMPILER} ${_CONAN_INFO_COMPILER} PARENT_SCOPE)
             endif()
-        
+
+            # MATCHALL will match all, including the last one, which is the full_settings one
             string(REGEX MATCH "compiler.version=([-A-Za-z0-9_.]+)" _MATCHED ${CONANINFO})
             if(DEFINED CMAKE_MATCH_1)
                 string(STRIP "${CMAKE_MATCH_1}" _CONAN_INFO_COMPILER_VERSION)
@@ -536,11 +538,11 @@ class CMakeCommonMacros:
                     return()
                 endif()
             endif()
-        
+
             if(NOT CMAKE_HOST_SYSTEM_NAME STREQUAL ${CMAKE_SYSTEM_NAME})
                 set(CROSS_BUILDING 1)
             endif()
-        
+
             # If using VS, verify toolset
             if (CONAN_COMPILER STREQUAL "Visual Studio")
                 if (CONAN_SETTINGS_COMPILER_TOOLSET MATCHES "LLVM" OR
@@ -551,12 +553,12 @@ class CMakeCommonMacros:
                 else()
                     set(EXPECTED_CMAKE_CXX_COMPILER_ID "MSVC")
                 endif()
-        
+
                 if (NOT CMAKE_CXX_COMPILER_ID MATCHES ${EXPECTED_CMAKE_CXX_COMPILER_ID})
                     message(FATAL_ERROR "Incorrect '${CONAN_COMPILER}'. Toolset specifies compiler as '${EXPECTED_CMAKE_CXX_COMPILER_ID}' "
                                         "but CMake detected '${CMAKE_CXX_COMPILER_ID}'")
                 endif()
-        
+
             # Avoid checks when cross compiling, apple-clang crashes because its APPLE but not apple-clang
             # Actually CMake is detecting "clang" when you are using apple-clang, only if CMP0025 is set to NEW will detect apple-clang
             elseif((CONAN_COMPILER STREQUAL "gcc" AND NOT CMAKE_CXX_COMPILER_ID MATCHES "GNU") OR
@@ -565,8 +567,8 @@ class CMakeCommonMacros:
                 (CONAN_COMPILER STREQUAL "sun-cc" AND NOT CMAKE_CXX_COMPILER_ID MATCHES "SunPro") )
                 message(FATAL_ERROR "Incorrect '${CONAN_COMPILER}', is not the one detected by CMake: '${CMAKE_CXX_COMPILER_ID}'")
             endif()
-        
-        
+
+
             if(NOT DEFINED CONAN_COMPILER_VERSION)
                 conan_message(STATUS "WARN: CONAN_COMPILER_VERSION variable not set, please make sure yourself "
                                      "that your compiler version matches your declared settings")
@@ -600,9 +602,9 @@ class CMakeCommonMacros:
                                     "$<$<CONFIG:MinSizeRel>:${CONAN_INCLUDE_DIRS_MINSIZEREL}>"
                                     "$<$<CONFIG:Debug>:${CONAN_INCLUDE_DIRS_DEBUG}>")
             endif()
-        
+
             link_directories(${CONAN_LIB_DIRS})
-        
+
             conan_find_libraries_abs_path("${CONAN_LIBS_DEBUG}" "${CONAN_LIB_DIRS_DEBUG}"
                                           CONAN_LIBS_DEBUG)
             conan_find_libraries_abs_path("${CONAN_LIBS_RELEASE}" "${CONAN_LIB_DIRS_RELEASE}"
@@ -611,17 +613,17 @@ class CMakeCommonMacros:
                                           CONAN_LIBS_RELWITHDEBINFO)
             conan_find_libraries_abs_path("${CONAN_LIBS_MINSIZEREL}" "${CONAN_LIB_DIRS_MINSIZEREL}"
                                           CONAN_LIBS_MINSIZEREL)
-        
+
             add_compile_options(${CONAN_DEFINES}
                                 "$<$<CONFIG:Debug>:${CONAN_DEFINES_DEBUG}>"
                                 "$<$<CONFIG:Release>:${CONAN_DEFINES_RELEASE}>"
                                 "$<$<CONFIG:RelWithDebInfo>:${CONAN_DEFINES_RELWITHDEBINFO}>"
                                 "$<$<CONFIG:MinSizeRel>:${CONAN_DEFINES_MINSIZEREL}>")
-        
+
             conan_set_flags("")
             conan_set_flags("_RELEASE")
             conan_set_flags("_DEBUG")
-        
+
         endmacro()
     """)
 
@@ -654,7 +656,7 @@ class CMakeCommonMacros:
                     set(CONAN_BUILD_MODULES_PATHS ${CONAN_BUILD_MODULES_PATHS_MINSIZEREL} ${CONAN_BUILD_MODULES_PATHS})
                 endif()
             endif()
-        
+
             foreach(_BUILD_MODULE_PATH ${CONAN_BUILD_MODULES_PATHS})
                 include(${_BUILD_MODULE_PATH})
             endforeach()
@@ -737,10 +739,10 @@ class CMakeCommonMacros:
             # CONAN_CMAKE_MODULE_PATH_DEBUG to be used by the consumer
             # CMake can find findXXX.cmake files in the root of packages
             set(CMAKE_MODULE_PATH ${CONAN_CMAKE_MODULE_PATH} ${CMAKE_MODULE_PATH})
-        
+
             # Make find_package() to work
             set(CMAKE_PREFIX_PATH ${CONAN_CMAKE_MODULE_PATH} ${CMAKE_PREFIX_PATH})
-        
+
             # Set the find root path (cross build)
             set(CMAKE_FIND_ROOT_PATH ${CONAN_CMAKE_FIND_ROOT_PATH} ${CMAKE_FIND_ROOT_PATH})
             if(CONAN_CMAKE_FIND_ROOT_PATH_MODE_PROGRAM)
@@ -932,17 +934,17 @@ cmake_macros_multi = "\n".join([
         else()
             message(FATAL_ERROR "No conanbuildinfo_release.cmake, please install the Release conf first")
         endif()
-        
+
         if(EXISTS ${CMAKE_CURRENT_LIST_DIR}/conanbuildinfo_debug.cmake)
             include(${CMAKE_CURRENT_LIST_DIR}/conanbuildinfo_debug.cmake)
         else()
             message(FATAL_ERROR "No conanbuildinfo_debug.cmake, please install the Debug conf first")
         endif()
-        
+
         if(EXISTS ${CMAKE_CURRENT_LIST_DIR}/conanbuildinfo_minsizerel.cmake)
             include(${CMAKE_CURRENT_LIST_DIR}/conanbuildinfo_minsizerel.cmake)
         endif()
-        
+
         if(EXISTS ${CMAKE_CURRENT_LIST_DIR}/conanbuildinfo_relwithdebinfo.cmake)
             include(${CMAKE_CURRENT_LIST_DIR}/conanbuildinfo_relwithdebinfo.cmake)
         endif()

--- a/conans/client/generators/cmake_common.py
+++ b/conans/client/generators/cmake_common.py
@@ -431,7 +431,7 @@ class CMakeCommonMacros:
             endif()
 
             # MATCHALL will match all, including the last one, which is the full_settings one
-            string(REGEX MATCH "compiler.version=([-A-Za-z0-9_.]+)" _MATCHED ${CONANINFO})
+            string(REGEX MATCHALL "compiler.version=([-A-Za-z0-9_.]+)" _MATCHED ${CONANINFO})
             if(DEFINED CMAKE_MATCH_1)
                 string(STRIP "${CMAKE_MATCH_1}" _CONAN_INFO_COMPILER_VERSION)
                 set(${CONAN_INFO_COMPILER_VERSION} ${_CONAN_INFO_COMPILER_VERSION} PARENT_SCOPE)

--- a/conans/client/generators/cmake_common.py
+++ b/conans/client/generators/cmake_common.py
@@ -424,14 +424,14 @@ class CMakeCommonMacros:
             file (READ "${_CONAN_CURRENT_DIR}/conaninfo.txt" CONANINFO)
 
             # MATCHALL will match all, including the last one, which is the full_settings one
-            string(REGEX MATCHALL "compiler=([-A-Za-z0-9_ ]+)" _MATCHED ${CONANINFO})
+            string(REGEX MATCH "full_settings.*" _FULL_SETTINGS_MATCHED ${CONANINFO})
+            string(REGEX MATCH "compiler=([-A-Za-z0-9_ ]+)" _MATCHED ${_FULL_SETTINGS_MATCHED})
             if(DEFINED CMAKE_MATCH_1)
                 string(STRIP "${CMAKE_MATCH_1}" _CONAN_INFO_COMPILER)
                 set(${CONAN_INFO_COMPILER} ${_CONAN_INFO_COMPILER} PARENT_SCOPE)
             endif()
 
-            # MATCHALL will match all, including the last one, which is the full_settings one
-            string(REGEX MATCHALL "compiler.version=([-A-Za-z0-9_.]+)" _MATCHED ${CONANINFO})
+            string(REGEX MATCH "compiler.version=([-A-Za-z0-9_.]+)" _MATCHED ${_FULL_SETTINGS_MATCHED})
             if(DEFINED CMAKE_MATCH_1)
                 string(STRIP "${CMAKE_MATCH_1}" _CONAN_INFO_COMPILER_VERSION)
                 set(${CONAN_INFO_COMPILER_VERSION} ${_CONAN_INFO_COMPILER_VERSION} PARENT_SCOPE)

--- a/conans/test/functional/generators/cmake_test.py
+++ b/conans/test/functional/generators/cmake_test.py
@@ -66,7 +66,7 @@ CONAN_BASIC_SETUP()
 
         client.run('install .')
         client.run_command('cmake .')
-        print(client.out)
+        self.assertIn("Conan: Checking correct version:", client.out)
 
     @attr("slow")
     @unittest.skipUnless(platform.system() == "Windows", "Requires MSBuild")

--- a/conans/test/functional/generators/cmake_test.py
+++ b/conans/test/functional/generators/cmake_test.py
@@ -14,29 +14,32 @@ class CMakeGeneratorTest(unittest.TestCase):
 
     def test_no_check_compiler(self):
         # https://github.com/conan-io/conan/issues/4268
-        file_content = '''from conans import ConanFile, CMake
+        file_content = textwrap.dedent("""
+            from conans import ConanFile, CMake
 
-class ConanFileToolsTest(ConanFile):
-    generators = "cmake"
+            class ConanFileToolsTest(ConanFile):
+                generators = "cmake"
 
-    def build(self):
-        cmake = CMake(self)
-        cmake.configure()
-    '''
+                def build(self):
+                    cmake = CMake(self)
+                    cmake.configure()
+                """)
 
-        cmakelists = '''cmake_minimum_required(VERSION 2.8)
-PROJECT(conanzlib LANGUAGES NONE)
-set(CONAN_DISABLE_CHECK_COMPILER TRUE)
+        cmakelists = textwrap.dedent("""
+            cmake_minimum_required(VERSION 2.8)
+            PROJECT(conanzlib LANGUAGES NONE)
+            set(CONAN_DISABLE_CHECK_COMPILER TRUE)
 
-include(conanbuildinfo.cmake)
-CONAN_BASIC_SETUP()
-'''
+            include(conanbuildinfo.cmake)
+            CONAN_BASIC_SETUP()
+            """)
         client = TestClient()
         client.save({"conanfile.py": file_content,
                      "CMakeLists.txt": cmakelists})
 
         client.run('install .')
         client.run('build .')
+        self.assertIn("WARN: Disabled conan compiler checks", client.out)
 
     @unittest.skipIf(platform.system() != "Linux", "Only linux")
     def test_check_compiler_package_id(self):
@@ -71,32 +74,32 @@ CONAN_BASIC_SETUP()
     @attr("slow")
     @unittest.skipUnless(platform.system() == "Windows", "Requires MSBuild")
     def skip_check_if_toolset_test(self):
-        file_content = '''from conans import ConanFile, CMake
+        file_content = textwrap.dedent("""
+            from conans import ConanFile, CMake
 
-class ConanFileToolsTest(ConanFile):
-    generators = "cmake"
-    exports_sources = "CMakeLists.txt"
-    settings = "os", "arch", "compiler"
+            class ConanFileToolsTest(ConanFile):
+                generators = "cmake"
+                exports_sources = "CMakeLists.txt"
+                settings = "os", "arch", "compiler"
 
-    def build(self):
-        cmake = CMake(self)
-        cmake.configure()
-        cmake.build()
-    '''
+                def build(self):
+                    cmake = CMake(self)
+                    cmake.configure()
+                    cmake.build()
+                """)
         client = TestClient()
-        cmakelists = '''
-set(CMAKE_CXX_COMPILER_WORKS 1)
-set(CMAKE_CXX_ABI_COMPILED 1)
-PROJECT(Hello)
-cmake_minimum_required(VERSION 2.8)
-include("${CMAKE_BINARY_DIR}/conanbuildinfo.cmake")
-CONAN_BASIC_SETUP()
-'''
+        cmakelists = textwrap.dedent("""
+            set(CMAKE_CXX_COMPILER_WORKS 1)
+            set(CMAKE_CXX_ABI_COMPILED 1)
+            PROJECT(Hello)
+            cmake_minimum_required(VERSION 2.8)
+            include("${CMAKE_BINARY_DIR}/conanbuildinfo.cmake")
+            CONAN_BASIC_SETUP()
+            """)
         client.save({"conanfile.py": file_content,
                      "CMakeLists.txt": cmakelists})
-        client.run("create . lib/1.0@user/channel -s compiler='Visual Studio' -s compiler.toolset=v140")
+        client.run("create . lib/1.0@ -s compiler='Visual Studio' -s compiler.toolset=v140")
         self.assertIn("Conan: Skipping compiler check: Declared 'compiler.toolset'", client.out)
-
 
     @attr('slow')
     def no_output_test(self):
@@ -173,7 +176,8 @@ CONAN_BASIC_SETUP()
         content = client.load("conanbuildinfo.cmake")
         self.assertIn("set(CONAN_LIBS ${CONAN_LIBS} ${CONAN_SYSTEM_LIBS} ${CONAN_FRAMEWORKS_FOUND})",
                       content)
-        self.assertIn("set(CONAN_LIBS_MYLIB ${CONAN_PKG_LIBS_MYLIB} ${CONAN_SYSTEM_LIBS_MYLIB} ${CONAN_FRAMEWORKS_FOUND_MYLIB})",
+        self.assertIn("set(CONAN_LIBS_MYLIB ${CONAN_PKG_LIBS_MYLIB} "
+                      "${CONAN_SYSTEM_LIBS_MYLIB} ${CONAN_FRAMEWORKS_FOUND_MYLIB})",
                       content)
         self.assertIn("set(CONAN_PKG_LIBS_MYLIB lib1)", content)
         self.assertIn("set(CONAN_SYSTEM_LIBS sys1 ${CONAN_SYSTEM_LIBS})", content)
@@ -203,38 +207,38 @@ CONAN_BASIC_SETUP()
         client.create(myotherlib_ref, myotherlib)
 
         consumer = textwrap.dedent("""
-                    import os
-                    from conans import ConanFile, CMake
+            import os
+            from conans import ConanFile, CMake
 
-                    class Consumer(ConanFile):
-                        requires = "myotherlib/1.0@us/ch"
-                        generators = "cmake"
-                        settings = "os", "compiler", "arch", "build_type"
-                        exports_sources = ["CMakeLists.txt"]
+            class Consumer(ConanFile):
+                requires = "myotherlib/1.0@us/ch"
+                generators = "cmake"
+                settings = "os", "compiler", "arch", "build_type"
+                exports_sources = ["CMakeLists.txt"]
 
-                        def build(self):
-                            cmake = CMake(self)
-                            cmake.configure()
-                            cmake.build()
-                        """)
+                def build(self):
+                    cmake = CMake(self)
+                    cmake.configure()
+                    cmake.build()
+                """)
         cmakelists = textwrap.dedent("""
-                    cmake_minimum_required(VERSION 3.1)
-                    project(consumer CXX)
-                    include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
-                    conan_basic_setup("TARGETS")
+            cmake_minimum_required(VERSION 3.1)
+            project(consumer CXX)
+            include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
+            conan_basic_setup("TARGETS")
 
-                    get_target_property(ml_pkg_libs CONAN_PKG::mylib INTERFACE_LINK_LIBRARIES)
-                    message("CONAN_PKG::mylib libs: ${ml_pkg_libs}")
-                    get_target_property(ml_lib1_libs CONAN_LIB::mylib_lib1 INTERFACE_LINK_LIBRARIES)
-                    message("CONAN_LIB::mylib_lib1 libs: ${ml_lib1_libs}")
-                    get_target_property(ml_lib11_libs CONAN_LIB::mylib_lib11 INTERFACE_LINK_LIBRARIES)
-                    message("CONAN_LIB::mylib_lib11 libs: ${ml_lib11_libs}")
+            get_target_property(ml_pkg_libs CONAN_PKG::mylib INTERFACE_LINK_LIBRARIES)
+            message("CONAN_PKG::mylib libs: ${ml_pkg_libs}")
+            get_target_property(ml_lib1_libs CONAN_LIB::mylib_lib1 INTERFACE_LINK_LIBRARIES)
+            message("CONAN_LIB::mylib_lib1 libs: ${ml_lib1_libs}")
+            get_target_property(ml_lib11_libs CONAN_LIB::mylib_lib11 INTERFACE_LINK_LIBRARIES)
+            message("CONAN_LIB::mylib_lib11 libs: ${ml_lib11_libs}")
 
-                    get_target_property(mol_pkg_libs CONAN_PKG::myotherlib INTERFACE_LINK_LIBRARIES)
-                    message("CONAN_PKG::myotherlib libs: ${mol_pkg_libs}")
-                    get_target_property(ml_lib2_libs CONAN_LIB::myotherlib_lib2 INTERFACE_LINK_LIBRARIES)
-                    message("CONAN_LIB::myotherlib_lib2 libs: ${ml_lib2_libs}")
-                    """)
+            get_target_property(mol_pkg_libs CONAN_PKG::myotherlib INTERFACE_LINK_LIBRARIES)
+            message("CONAN_PKG::myotherlib libs: ${mol_pkg_libs}")
+            get_target_property(ml_lib2_libs CONAN_LIB::myotherlib_lib2 INTERFACE_LINK_LIBRARIES)
+            message("CONAN_LIB::myotherlib_lib2 libs: ${ml_lib2_libs}")
+            """)
 
         client.save({"conanfile.py": consumer, "CMakeLists.txt": cmakelists})
         client.run("create conanfile.py consumer/1.0@us/ch")
@@ -249,8 +253,10 @@ CONAN_BASIC_SETUP()
 
         self.assertNotIn("Library sys2 not found in package, might be system one", client.out)
         self.assertIn("CONAN_PKG::myotherlib libs: "
-                      "CONAN_LIB::myotherlib_lib2;sys2;CONAN_PKG::mylib;$<$<CONFIG:Release>:;CONAN_PKG::mylib;>;"
-                      "$<$<CONFIG:RelWithDebInfo>:;CONAN_PKG::mylib;>;$<$<CONFIG:MinSizeRel>:;CONAN_PKG::mylib;>;"
+                      "CONAN_LIB::myotherlib_lib2;sys2;CONAN_PKG::mylib;"
+                      "$<$<CONFIG:Release>:;CONAN_PKG::mylib;>;"
+                      "$<$<CONFIG:RelWithDebInfo>:;CONAN_PKG::mylib;>;"
+                      "$<$<CONFIG:MinSizeRel>:;CONAN_PKG::mylib;>;"
                       "$<$<CONFIG:Debug>:;CONAN_PKG::mylib;>",
                       client.out)
         self.assertIn("CONAN_LIB::myotherlib_lib2 libs: ;sys2;;CONAN_PKG::mylib", client.out)


### PR DESCRIPTION
Changelog: Bugfix: Use the real settings value to check the compiler and compiler version in the ``cmake`` generator local flow when the ``package_id()`` method changes values.
Docs: Omit

Fix: https://github.com/conan-io/conan/issues/6658
