### PR TITLE
Teach cross_buiding() about non-x86 architectures

### DIFF
--- a/conans/client/tools/oss.py
+++ b/conans/client/tools/oss.py
@@ -465,6 +465,10 @@ def cross_building(conanfile=None, self_os=None, self_arch=None, skip_x64_x86=Fa
     if host_os is not None and (build_os != host_os):
         return True
     if host_arch is not None and (build_arch != host_arch):
+        if host_arch == 'ppc32' and build_arch == 'ppc64':
+            return False
+        elif host_arch == 'sparc' and build_arch == 'sparcv9':
+            return False
         return True
 
     return False


### PR DESCRIPTION
 Teach cross_buiding() about non-x86 architectures that can build 32-bit binaries on 64-bit machines.  Essentially, there is currently a special case for building 32-bit x86 on machines that report 64-bit (amd64) - this PR extends that to sparc (typically Solaris) and ppc (typically AIX).

Changelog: (Bugfix):  Add support for building 32-bit binaries on 64-bit architectures sparcv9 and ppc64. 

https://github.com/conan-io/conan/issues/6665


- [x] Refer to the issue that supports this Pull Request.
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [x] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. N/A

