### PR TITLE
Fix vcvars_arch usage before assignment.

### DIFF
--- a/conans/client/tools/win.py
+++ b/conans/client/tools/win.py
@@ -360,6 +360,7 @@ def vcvars_command(settings, arch=None, compiler_version=None, force=False, vcva
         raise ConanException("compiler.version setting required for vcvars not defined")
 
     # https://msdn.microsoft.com/en-us/library/f2ccy3wt.aspx
+    vcvars_arch = None
     arch_setting = arch_setting or 'x86_64'
     arch_build = settings.get_safe("arch_build") or detected_architecture()
     if os_setting == 'WindowsCE':


### PR DESCRIPTION
Changelog: Bugfix: Fix vcvars_arch usage before assignment, that can cause a crash in ``tools.vcvars_command()`` that is also used internally by ``MSBuild`` helper.
Docs:  Omit

Fixes: #6674

- [x] Refer to the issue that supports this Pull Request.
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [x] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 

