### PR TITLE
Possibility to change the default CONAN_SYSREQUIRES_MODE for SystemPackageTool

### DIFF
--- a/conans/client/conf/__init__.py
+++ b/conans/client/conf/__init__.py
@@ -227,7 +227,7 @@ class ConanClientConfigParser(ConfigParser, object):
                "CONAN_SKIP_BROKEN_SYMLINKS_CHECK": self._env_c("general.skip_broken_symlinks_check", "CONAN_SKIP_BROKEN_SYMLINKS_CHECK", "False"),
                "CONAN_CACHE_NO_LOCKS": self._env_c("general.cache_no_locks", "CONAN_CACHE_NO_LOCKS", "False"),
                "CONAN_SYSREQUIRES_SUDO": self._env_c("general.sysrequires_sudo", "CONAN_SYSREQUIRES_SUDO", "False"),
-               "CONAN_SYSREQUIRES_MODE": self._env_c("general.sysrequires_mode", "CONAN_SYSREQUIRES_MODE", "enabled"),
+               "CONAN_SYSREQUIRES_MODE": self._env_c("general.sysrequires_mode", "CONAN_SYSREQUIRES_MODE", None),
                "CONAN_REQUEST_TIMEOUT": self._env_c("general.request_timeout", "CONAN_REQUEST_TIMEOUT", None),
                "CONAN_RETRY": self._env_c("general.retry", "CONAN_RETRY", None),
                "CONAN_RETRY_WAIT": self._env_c("general.retry_wait", "CONAN_RETRY_WAIT", None),

--- a/conans/client/tools/system_pm.py
+++ b/conans/client/tools/system_pm.py
@@ -84,7 +84,7 @@ class SystemPackageTool(object):
         """
             Get the system package tool update command
         """
-        mode = self._get_sysrequire_mode(self._default_mode)
+        mode = self._get_sysrequire_mode()
         if mode in ("disabled", "verify"):
             self._output.info("Not updating system_requirements. CONAN_SYSREQUIRES_MODE=%s" % mode)
             return
@@ -103,7 +103,7 @@ class SystemPackageTool(object):
         packages = [packages] if isinstance(packages, str) else list(packages)
         packages = self._get_package_names(packages, arch_names)
 
-        mode = self._get_sysrequire_mode(self._default_mode)
+        mode = self._get_sysrequire_mode()
 
         if mode in ("verify", "disabled"):
             # Report to output packages need to be installed

--- a/conans/client/tools/system_pm.py
+++ b/conans/client/tools/system_pm.py
@@ -46,16 +46,6 @@ class SystemPackageTool(object):
         return get_env("CONAN_SYSREQUIRES_SUDO", True)
 
     @staticmethod
-    def _get_sysrequire_mode(default_mode):
-        allowed_modes = ("enabled", "verify", "disabled")
-        mode = get_env("CONAN_SYSREQUIRES_MODE", default_mode)
-        mode_lower = mode.lower()
-        if mode_lower not in allowed_modes:
-            raise ConanException("CONAN_SYSREQUIRES_MODE=%s is not allowed, allowed modes=%r"
-                                 % (mode, allowed_modes))
-        return mode_lower
-
-    @staticmethod
     def _create_tool(os_info, output):
         if os_info.with_apt:
             return AptTool(output=output)
@@ -75,6 +65,15 @@ class SystemPackageTool(object):
             return ZypperTool(output=output)
         else:
             return NullTool(output=output)
+
+    def _get_sysrequire_mode(self):
+        allowed_modes = ("enabled", "verify", "disabled")
+        mode = get_env("CONAN_SYSREQUIRES_MODE", self._default_mode)
+        mode_lower = mode.lower()
+        if mode_lower not in allowed_modes:
+            raise ConanException("CONAN_SYSREQUIRES_MODE=%s is not allowed, allowed modes=%r"
+                                 % (mode, allowed_modes))
+        return mode_lower
 
     def add_repository(self, repository, repo_key=None, update=True):
         self._tool.add_repository(repository, repo_key=repo_key)

--- a/conans/client/tools/system_pm.py
+++ b/conans/client/tools/system_pm.py
@@ -11,7 +11,8 @@ from conans.util.fallbacks import default_output
 
 class SystemPackageTool(object):
 
-    def __init__(self, runner=None, os_info=None, tool=None, recommends=False, output=None, conanfile=None, default_mode="enabled"):
+    def __init__(self, runner=None, os_info=None, tool=None, recommends=False, output=None,
+                 conanfile=None, default_mode="enabled"):
         output = output if output else conanfile.output if conanfile else None
         self._output = default_output(output, 'conans.client.tools.system_pm.SystemPackageTool')
         os_info = os_info or OSInfo()

--- a/conans/test/unittests/client/tools/system_pm_test.py
+++ b/conans/test/unittests/client/tools/system_pm_test.py
@@ -429,6 +429,18 @@ class SystemPackageToolTest(unittest.TestCase):
             self.assertNotIn("CONAN_SYSREQUIRES_MODE", str(exc.exception))
             self.assertEqual(7, runner.calls)
 
+        # Check default_mode. The environment variable is not set and should behave like
+        # the default_mode
+        packages = ["verify_package", "verify_another_package", "verify_yet_another_package"]
+        runner = RunnerMultipleMock(["sudo -A apt-get update"])
+        spt = SystemPackageTool(runner=runner, tool=AptTool(output=self.out), output=self.out, 
+                                default_mode="verify")
+        with self.assertRaises(ConanException) as exc:
+            spt.install(packages)
+        self.assertIn("Aborted due to CONAN_SYSREQUIRES_MODE=", str(exc.exception))
+        self.assertIn('\n'.join(packages), self.out)
+        self.assertEqual(3, runner.calls)
+
     def system_package_tool_installed_test(self):
         if (platform.system() != "Linux" and platform.system() != "Macos" and
                 platform.system() != "Windows"):

--- a/conans/test/unittests/client/tools/system_pm_test.py
+++ b/conans/test/unittests/client/tools/system_pm_test.py
@@ -431,15 +431,19 @@ class SystemPackageToolTest(unittest.TestCase):
 
         # Check default_mode. The environment variable is not set and should behave like
         # the default_mode
-        packages = ["verify_package", "verify_another_package", "verify_yet_another_package"]
-        runner = RunnerMultipleMock(["sudo -A apt-get update"])
-        spt = SystemPackageTool(runner=runner, tool=AptTool(output=self.out), output=self.out, 
-                                default_mode="verify")
-        with self.assertRaises(ConanException) as exc:
-            spt.install(packages)
-        self.assertIn("Aborted due to CONAN_SYSREQUIRES_MODE=", str(exc.exception))
-        self.assertIn('\n'.join(packages), self.out)
-        self.assertEqual(3, runner.calls)
+        with tools.environment_append({
+            "CONAN_SYSREQUIRES_MODE": None,
+            "CONAN_SYSREQUIRES_SUDO": "True"
+        }):
+            packages = ["verify_package", "verify_another_package", "verify_yet_another_package"]
+            runner = RunnerMultipleMock(["sudo -A apt-get update"])
+            spt = SystemPackageTool(runner=runner, tool=AptTool(output=self.out), output=self.out, 
+                                    default_mode="verify")
+            with self.assertRaises(ConanException) as exc:
+                spt.install(packages)
+            self.assertIn("Aborted due to CONAN_SYSREQUIRES_MODE=", str(exc.exception))
+            self.assertIn('\n'.join(packages), self.out)
+            self.assertEqual(3, runner.calls)
 
     def system_package_tool_installed_test(self):
         if (platform.system() != "Linux" and platform.system() != "Macos" and


### PR DESCRIPTION
Changelog: Feature: Set the default `CONAN_SYSREQUIRES_MODE` in `SystemPackageTool` to be able to create a recipe that does not install system requirements by default if the `CONAN_SYSREQUIRES_MODE` is not set.
Docs: https://github.com/conan-io/docs/pull/XXXX

The purpose of this feature is to have the option to add a recipe for example to c3i where this variable should be set to `enabled` but if someone is requiring this dependency not forcing to install the system requirements if the `CONAN_SYSREQUIRES_MODE` environment variable is not set.

- [X] Refer to the issue that supports this Pull Request.
- [X] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [X] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [X] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 

<sup>**Note:** By default this PR will skip the slower tests and will use a limited set of python versions. Check [here](https://github.com/conan-io/conan/blob/develop/.github/PR_INCREASE_TESTING.md) how to increase the testing level by writing some tags in the current PR body text.</sup>
