### PR TITLE
pyinstaller will print error on python 3.8 or higher

### DIFF
--- a/pyinstaller.py
+++ b/pyinstaller.py
@@ -4,6 +4,7 @@ import os
 import platform
 import shutil
 import subprocess
+import sys
 from distutils import dir_util
 
 from conans import __version__
@@ -127,6 +128,10 @@ def pyinstall(source_folder):
 
 
 if __name__ == "__main__":
+    if sys.version_info.major == 3 and sys.version_info.minor >= 8:
+        print("pyinstaller does not yet support python 3.8, "
+              "see: https://github.com/pyinstaller/pyinstaller/issues/4311", file=sys.stderr)
+        exit(1)
     source_folder = os.path.abspath(os.path.dirname(os.path.abspath(__file__)))
     output_folder = pyinstall(source_folder)
     print("\n**************Conan binaries created!******************\n"


### PR DESCRIPTION
Changelog: Fix: Added print to stderr and exit into pyinstaller script when it detects python usage of python 3.8 or higher. Currently pyinstaller does not support python 3.8. https://github.com/pyinstaller/pyinstaller/issues/4311
Docs: Omit

fixes #6325 



- [X] Refer to the issue that supports this Pull Request.
- [X] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [X] I've followed the PEP8 style guides for Python code.
