### PR TITLE
Relax patch-ng dependency

### DIFF
--- a/conans/requirements.txt
+++ b/conans/requirements.txt
@@ -3,7 +3,7 @@ requests>=2.8.1, <3.0.0
 urllib3!=1.25.4,!=1.25.5
 colorama>=0.3.3, <0.5.0
 PyYAML>=3.11, <6.0
-patch-ng>=1.17.2, <1.18
+patch-ng>=1.17.4, <1.18
 fasteners>=0.14.1
 six>=1.10.0,<=1.14.0
 node-semver==0.6.1

--- a/conans/requirements.txt
+++ b/conans/requirements.txt
@@ -3,7 +3,7 @@ requests>=2.8.1, <3.0.0
 urllib3!=1.25.4,!=1.25.5
 colorama>=0.3.3, <0.5.0
 PyYAML>=3.11, <6.0
-patch-ng>=1.17, <1.18
+patch-ng>=1.17.2, <1.18
 fasteners>=0.14.1
 six>=1.10.0,<=1.14.0
 node-semver==0.6.1

--- a/conans/requirements.txt
+++ b/conans/requirements.txt
@@ -3,7 +3,7 @@ requests>=2.8.1, <3.0.0
 urllib3!=1.25.4,!=1.25.5
 colorama>=0.3.3, <0.5.0
 PyYAML>=3.11, <6.0
-patch-ng==1.17.2
+patch-ng>=1.17, <1.18
 fasteners>=0.14.1
 six>=1.10.0,<=1.14.0
 node-semver==0.6.1


### PR DESCRIPTION
Changelog: omit
Docs: omit

I'm proposing to relax `patch-ng` dependency. A change is needed to get new `1.17.4` (not released yet) that fixes issue https://github.com/conan-io/conan/issues/6676
Probably it is a good idea to _relax this requirement_ so it is not needed to release a new Conan version to have this kind of patches available, even though not all of our users will get the new version if they don't force the update of the requirement. The way to force a new version would be to modify the minor version and then change the requirement in Conan.
