### PR TITLE
Update patch-ng version to 1.17.4

### DIFF
--- a/conans/requirements.txt
+++ b/conans/requirements.txt
@@ -3,7 +3,7 @@ requests>=2.8.1, <3.0.0
 urllib3!=1.25.4,!=1.25.5
 colorama>=0.3.3, <0.5.0
 PyYAML>=3.11, <6.0
-patch-ng==1.17.2
+patch-ng==1.17.4
 fasteners>=0.14.1
 six>=1.10.0,<=1.14.0
 node-semver==0.6.1


### PR DESCRIPTION
There was a bug in python-ng which caused the error reported on #6676. The version 1.17.4 contains a [proper fix](https://github.com/conan-io/python-patch-ng/compare/1.17.3..1.17.4#diff-44c6f49e5175cc4af816be655c256be5)

Changelog: Fix: Apply patches over read-only files on Windows
Docs: Omit

fixes #6676

- [x] Refer to the issue that supports this Pull Request.
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [ ] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 

<sup>**Note:** By default this PR will skip the slower tests and will use a limited set of python versions. Check [here](https://github.com/conan-io/conan/blob/develop/.github/PR_INCREASE_TESTING.md) how to increase the testing level by writing some tags in the current PR body text.</sup>
