### PR TITLE
Fix temp file handling

### DIFF
--- a/conans/test/unittests/util/tools_test.py
+++ b/conans/test/unittests/util/tools_test.py
@@ -729,6 +729,17 @@ class HelloConan(ConanFile):
 
         thread.stop()
 
+    def check_output_runner_test(self):
+        import tempfile
+        original_temp = tempfile.gettempdir()
+        patched_temp = os.path.join(original_temp, "dir with spaces")
+        payload = "hello world"
+        with patch("tempfile.mktemp") as mktemp:
+            mktemp.return_value = patched_temp
+            output = check_output_runner(["echo", payload], stderr=subprocess.STDOUT)
+            self.assertIn(payload, str(output))
+
+
     def unix_to_dos_unit_test(self):
 
         def save_file(contents):

--- a/conans/util/runners.py
+++ b/conans/util/runners.py
@@ -81,7 +81,7 @@ def check_output_runner(cmd, stderr=None):
         # We don't want stderr to print warnings that will mess the pristine outputs
         stderr = stderr or subprocess.PIPE
         cmd = cmd if isinstance(cmd, six.string_types) else subprocess.list2cmdline(cmd)
-        command = "{} > {}".format(cmd, tmp_file)
+        command = '{} > "{}"'.format(cmd, tmp_file)
         logger.info("Calling command: {}".format(command))
         process = subprocess.Popen(command, shell=True, stderr=stderr)
         stdout, stderr = process.communicate()


### PR DESCRIPTION
Changelog: Bugfix: Fix check_output_runner() to handle dirs with whitespaces. 
Docs: Omit

Close #6694 

- [x] Refer to the issue that supports this Pull Request.
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [x] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 

If TEMP/TMPDIR envs point to a directory that contains whitespaces, check_output_runner() fails. Generated filename needs to be quoted for it to be passed in into shell properly.