### PR TITLE
use io.open(..., encoding=utf-8) to open log file

### DIFF
--- a/conans/client/runner.py
+++ b/conans/client/runner.py
@@ -64,7 +64,7 @@ class ConanRunner(object):
                     stream_output.write("Logging command output to file '%s'\n" % log_filepath)
                 with io.open(log_filepath, "a+", encoding="utf-8") as log_handler:
                     if self._print_commands_to_output:
-                        log_handler.write(call_message)
+                        log_handler.write(call_message.decode('utf-8'))
                     return self._pipe_os_call(command, stream_output, log_handler, cwd)
             else:
                 return self._pipe_os_call(command, stream_output, None, cwd)

--- a/conans/client/runner.py
+++ b/conans/client/runner.py
@@ -64,7 +64,7 @@ class ConanRunner(object):
                     stream_output.write("Logging command output to file '%s'\n" % log_filepath)
                 with io.open(log_filepath, "a+", encoding="utf-8") as log_handler:
                     if self._print_commands_to_output:
-                        log_handler.write(call_message.decode('utf-8'))
+                        log_handler.write(call_message.decode('utf-8') if six.PY2 else call_message)
                     return self._pipe_os_call(command, stream_output, log_handler, cwd)
             else:
                 return self._pipe_os_call(command, stream_output, None, cwd)

--- a/conans/client/runner.py
+++ b/conans/client/runner.py
@@ -96,7 +96,7 @@ class ConanRunner(object):
                 if log_handler:
                     # Write decoded in PY2 causes some ASCII encoding problems
                     # tried to open the log_handler binary but same result.
-                    log_handler.write(line if six.PY2 else decoded_line)
+                    log_handler.write(line.decode('utf-8') if six.PY2 else decoded_line)
 
         get_stream_lines(proc.stdout)
         # get_stream_lines(proc.stderr)

--- a/conans/client/runner.py
+++ b/conans/client/runner.py
@@ -50,7 +50,7 @@ class ConanRunner(object):
                 return self._simple_os_call(command, cwd)
             elif log_filepath:
                 stream_output.write("Logging command output to file '%s'\n" % log_filepath)
-                with safe_file(log_filepath, "a+", encoding="utf-8") as log_handler:
+                with safe_file(log_filepath, "a+") as log_handler:
                     if self._print_commands_to_output:
                         log_handler.write(call_message)
                     return self._pipe_os_call(command, stream_output, log_handler, cwd)

--- a/conans/client/runner.py
+++ b/conans/client/runner.py
@@ -1,7 +1,6 @@
 import io
 import os
 import sys
-
 from subprocess import PIPE, Popen, STDOUT
 
 import six
@@ -63,7 +62,7 @@ class ConanRunner(object):
             elif log_filepath:
                 if stream_output:
                     stream_output.write("Logging command output to file '%s'\n" % log_filepath)
-                with open(log_filepath, "a+") as log_handler:
+                with io.open(log_filepath, "a+", encoding="utf-8") as log_handler:
                     if self._print_commands_to_output:
                         log_handler.write(call_message)
                     return self._pipe_os_call(command, stream_output, log_handler, cwd)

--- a/conans/client/runner.py
+++ b/conans/client/runner.py
@@ -7,7 +7,7 @@ import six
 
 from conans.errors import ConanException
 from conans.unicode import get_cwd
-from conans.util.files import SafeOutput
+from conans.util.files import safe_stream, safe_file
 from conans.util.runners import pyinstaller_bundle_env_cleaned
 
 
@@ -33,7 +33,7 @@ class ConanRunner(object):
                   "use six.StringIO() instead ***")
 
         stream_output = output if output and hasattr(output, "write") else self._output or sys.stdout
-        stream_output = SafeOutput.stream(stream_output, flush=hasattr(output, "flush"))
+        stream_output = safe_stream(stream_output, flush=hasattr(output, "flush"))
 
         if not self._generate_run_log_file:
             log_filepath = None
@@ -50,7 +50,7 @@ class ConanRunner(object):
                 return self._simple_os_call(command, cwd)
             elif log_filepath:
                 stream_output.write("Logging command output to file '%s'\n" % log_filepath)
-                with SafeOutput.file(log_filepath, "a+", encoding="utf-8") as log_handler:
+                with safe_file(log_filepath, "a+", encoding="utf-8") as log_handler:
                     if self._print_commands_to_output:
                         log_handler.write(call_message)
                     return self._pipe_os_call(command, stream_output, log_handler, cwd)

--- a/conans/client/runner.py
+++ b/conans/client/runner.py
@@ -7,7 +7,7 @@ import six
 
 from conans.errors import ConanException
 from conans.unicode import get_cwd
-from conans.util.files import decode_text
+from conans.util.files import decode_text, SafeOutput
 from conans.util.runners import pyinstaller_bundle_env_cleaned
 
 
@@ -62,9 +62,9 @@ class ConanRunner(object):
             elif log_filepath:
                 if stream_output:
                     stream_output.write("Logging command output to file '%s'\n" % log_filepath)
-                with io.open(log_filepath, "a+", encoding="utf-8") as log_handler:
+                with SafeOutput.file(log_filepath, "a+", encoding="utf-8") as log_handler:
                     if self._print_commands_to_output:
-                        log_handler.write(call_message.decode('utf-8') if six.PY2 else call_message)
+                        log_handler.write(call_message)
                     return self._pipe_os_call(command, stream_output, log_handler, cwd)
             else:
                 return self._pipe_os_call(command, stream_output, None, cwd)
@@ -96,7 +96,7 @@ class ConanRunner(object):
                 if log_handler:
                     # Write decoded in PY2 causes some ASCII encoding problems
                     # tried to open the log_handler binary but same result.
-                    log_handler.write(line.decode('utf-8') if six.PY2 else decoded_line)
+                    log_handler.write(line)
 
         get_stream_lines(proc.stdout)
         # get_stream_lines(proc.stderr)

--- a/conans/util/files.py
+++ b/conans/util/files.py
@@ -457,9 +457,8 @@ class _SafeOutput(object):
         self._stream.flush()
 
 
-@contextmanager
 def safe_stream(stream, flush=False):
-    yield _SafeOutput(stream, flush=flush)
+    return _SafeOutput(stream, flush=flush)
 
 
 @contextmanager

--- a/conans/util/files.py
+++ b/conans/util/files.py
@@ -435,22 +435,28 @@ def merge_directories(src, dst, excluded=None):
 
 class SafeOutput(object):
 
-    def __init__(self, stream):
+    def __init__(self, stream, flush):
         self._stream = stream
+        self._flush = flush
 
     def write(self, text):
         self._stream.write(text.decode('utf-8') if six.PY2 else text)
+        if self._flush:
+            self.flush()
+
+    def flush(self):
+        self._stream.flush()
 
     @staticmethod
     @contextmanager
-    def file(filename, mode, encoding):
+    def file(filename, mode, encoding, flush=False):
         handler = io.open(filename, mode=mode, encoding=encoding)
         try:
-            yield SafeOutput.stream(handler)
+            yield SafeOutput.stream(handler, flush=flush)
         finally:
             handler.close()
 
     @staticmethod
     @contextmanager
-    def stream(stream):
-        yield SafeOutput(stream)
+    def stream(stream, flush=False):
+        yield SafeOutput(stream, flush=flush)

--- a/conans/util/files.py
+++ b/conans/util/files.py
@@ -435,20 +435,22 @@ def merge_directories(src, dst, excluded=None):
 
 class SafeOutput(object):
 
-    def __init__(self, filename, mode='w', encoding='utf-8'):
-        self._handler = io.open(filename, mode=mode, encoding=encoding)
+    def __init__(self, stream):
+        self._stream = stream
 
     def write(self, text):
-        self._handler.write(text.decode('utf-8') if six.PY2 else text)
-
-    def close(self):
-        self._handler.close()
+        self._stream.write(text.decode('utf-8') if six.PY2 else text)
 
     @staticmethod
     @contextmanager
     def file(filename, mode, encoding):
-        f = SafeOutput(filename, mode=mode, encoding=encoding)
+        handler = io.open(filename, mode=mode, encoding=encoding)
         try:
-            yield f
+            yield SafeOutput.stream(handler)
         finally:
-            f.close()
+            handler.close()
+
+    @staticmethod
+    @contextmanager
+    def stream(stream):
+        yield SafeOutput(stream)


### PR DESCRIPTION
Changelog: Fix: Open the file to print the logs using `encoding=utf-8` to allow wider set of characters
Docs: omit

closes #6696 