### PR TITLE
[refact] Reorder table with conan.conf variables

### DIFF
--- a/conans/client/conan_api.py
+++ b/conans/client/conan_api.py
@@ -19,7 +19,6 @@ from conans.client.cmd.search import Search
 from conans.client.cmd.test import install_build_and_test
 from conans.client.cmd.uploader import CmdUpload
 from conans.client.cmd.user import user_set, users_clean, users_list, token_present
-from conans.client.conf import ConanClientConfigParser
 from conans.client.graph.graph import RECIPE_EDITABLE
 from conans.client.graph.graph_binaries import GraphBinariesAnalyzer
 from conans.client.graph.graph_manager import GraphManager
@@ -570,11 +569,10 @@ class ConanAPIV1(object):
 
     @api_method
     def config_get(self, item):
-        config_parser = ConanClientConfigParser(self.app.cache.conan_conf_path)
         if item == "storage.path":
-            result = config_parser.storage_path
+            result = self.app.config.storage_path
         else:
-            result = config_parser.get_item(item)
+            result = self.app.config.get_item(item)
         self.app.out.info(result)
         return result
 

--- a/conans/client/conf/__init__.py
+++ b/conans/client/conf/__init__.py
@@ -212,18 +212,18 @@ class ConanClientConfigParser(ConfigParser):
     _table_vars = {
         # Environment variable | conan.conf variable | Default value
         "log": [
-            ("CONAN_LOG_RUN_TO_OUTPUT", "run_to_output", "True"),
-            ("CONAN_LOG_RUN_TO_FILE", "run_to_file", "False"),
-            ("CONAN_LOGGING_LEVEL", "level", "50"),
+            ("CONAN_LOG_RUN_TO_OUTPUT", "run_to_output", True),
+            ("CONAN_LOG_RUN_TO_FILE", "run_to_file", False),
+            ("CONAN_LOGGING_LEVEL", "level", logging.CRITICAL),
             ("CONAN_TRACE_FILE", "trace_file", None),
-            ("CONAN_PRINT_RUN_COMMANDS", "print_run_commands", "False"),
+            ("CONAN_PRINT_RUN_COMMANDS", "print_run_commands", False),
         ],
         "general": [
-            ("CONAN_COMPRESSION_LEVEL", "compression_level", "9"),
-            ("CONAN_NON_INTERACTIVE", "non_interactive", "False"),
-            ("CONAN_SKIP_BROKEN_SYMLINKS_CHECK", "skip_broken_symlinks_check", "False"),
-            ("CONAN_CACHE_NO_LOCKS", "cache_no_locks", "False"),
-            ("CONAN_SYSREQUIRES_SUDO", "sysrequires_sudo", "False"),
+            ("CONAN_COMPRESSION_LEVEL", "compression_level", 9),
+            ("CONAN_NON_INTERACTIVE", "non_interactive", False),
+            ("CONAN_SKIP_BROKEN_SYMLINKS_CHECK", "skip_broken_symlinks_check", False),
+            ("CONAN_CACHE_NO_LOCKS", "cache_no_locks", False),
+            ("CONAN_SYSREQUIRES_SUDO", "sysrequires_sudo", False),
             ("CONAN_SYSREQUIRES_MODE", "sysrequires_mode", None),
             ("CONAN_REQUEST_TIMEOUT", "request_timeout", None),
             ("CONAN_RETRY", "retry", None),
@@ -234,7 +234,7 @@ class ConanClientConfigParser(ConfigParser):
             ("CONAN_USER_HOME_SHORT", "user_home_short", None),
             ("CONAN_USE_ALWAYS_SHORT_PATHS", "use_always_short_paths", None),
             ("CONAN_VERBOSE_TRACEBACK", "verbose_traceback", None),
-            ("CONAN_ERROR_ON_OVERRIDE", "error_on_override", "False"),
+            ("CONAN_ERROR_ON_OVERRIDE", "error_on_override", False),
             # http://www.vtk.org/Wiki/CMake_Cross_Compiling
             ("CONAN_CMAKE_GENERATOR", "cmake_generator", None),
             ("CONAN_CMAKE_GENERATOR_PLATFORM", "cmake_generator_platform", None),
@@ -249,11 +249,12 @@ class ConanClientConfigParser(ConfigParser):
             ("CONAN_BASH_PATH", "bash_path", None),
             ("CONAN_MAKE_PROGRAM", "conan_make_program", None),
             ("CONAN_CMAKE_PROGRAM", "conan_cmake_program", None),
-            ("CONAN_TEMP_TEST_FOLDER", "temp_test_folder", "False"),
-            ("CONAN_SKIP_VS_PROJECTS_UPGRADE", "skip_vs_projects_upgrade", "False"),
+            ("CONAN_TEMP_TEST_FOLDER", "temp_test_folder", False),
+            ("CONAN_SKIP_VS_PROJECTS_UPGRADE", "skip_vs_projects_upgrade", False),
             ("CONAN_MSBUILD_VERBOSITY", "msbuild_verbosity", None),
             ("CONAN_CACERT_PATH", "cacert_path", None),
             ("CONAN_DEFAULT_PACKAGE_ID_MODE", "default_package_id_mode", None),
+            # ("CONAN_DEFAULT_PROFILE_PATH", "default_profile", DEFAULT_PROFILE_NAME),
         ],
         "hooks": [
             ("CONAN_HOOKS", "", None),
@@ -273,11 +274,13 @@ class ConanClientConfigParser(ConfigParser):
                 var_name = ".".join([section, var_name]) if var_name else section
                 value = self._env_c(var_name, env_var, default_value)
                 if value is not None:
-                    ret[env_var] = value
+                    ret[env_var] = str(value)
         return ret
 
     def _env_c(self, var_name, env_var_name, default_value):
-        """ Returns the value Conan will use: first tries with environment, then 'conan.conf' """
+        """ Returns the value Conan will use: first tries with environment variable,
+            then value written in 'conan.conf' and fallback to 'default_value'
+        """
         env = os.environ.get(env_var_name, None)
         if env is not None:
             return env

--- a/conans/client/conf/__init__.py
+++ b/conans/client/conf/__init__.py
@@ -353,7 +353,7 @@ class ConanClientConfigParser(ConfigParser, object):
         with open(self.filename, "w") as f:
             self.write(f)
 
-    def get_conf(self, varname):
+    def _get_conf(self, varname):
         """Gets the section from config file or raises an exception"""
         try:
             return self.items(varname)
@@ -502,7 +502,7 @@ class ConanClientConfigParser(ConfigParser, object):
                 current_dir = os.path.dirname(self.filename)
                 # if env var is declared, any specified path will be relative to CONAN_USER_HOME
                 # even with the ~/
-                result = dict(self.get_conf("storage"))["path"]
+                result = dict(self._get_conf("storage"))["path"]
                 if result.startswith("."):
                     result = os.path.abspath(os.path.join(current_dir, result))
                 elif result[:2] == "~/":
@@ -520,7 +520,7 @@ class ConanClientConfigParser(ConfigParser, object):
     @property
     def proxies(self):
         try:  # optional field, might not exist
-            proxies = self.get_conf("proxies")
+            proxies = self._get_conf("proxies")
         except Exception:
             return None
         result = {}
@@ -573,7 +573,7 @@ class ConanClientConfigParser(ConfigParser, object):
         hooks = get_env("CONAN_HOOKS", list())
         if not hooks:
             try:
-                hooks = self.get_conf("hooks")
+                hooks = self._get_conf("hooks")
                 hooks = [k for k, _ in hooks]
             except Exception:
                 hooks = []

--- a/conans/client/conf/__init__.py
+++ b/conans/client/conf/__init__.py
@@ -17,12 +17,12 @@ _t_default_settings_yml = Template(textwrap.dedent("""
     # Only for cross building, 'os_build/arch_build' is the system that runs Conan
     os_build: [Windows, WindowsStore, Linux, Macos, FreeBSD, SunOS, AIX]
     arch_build: [x86, x86_64, ppc32be, ppc32, ppc64le, ppc64, armv5el, armv5hf, armv6, armv7, armv7hf, armv7s, armv7k, armv8, armv8_32, armv8.3, sparc, sparcv9, mips, mips64, avr, s390, s390x, sh4le]
-    
+
     # Only for building cross compilation tools, 'os_target/arch_target' is the system for
     # which the tools generate code
     os_target: [Windows, Linux, Macos, Android, iOS, watchOS, tvOS, FreeBSD, SunOS, AIX, Arduino, Neutrino]
     arch_target: [x86, x86_64, ppc32be, ppc32, ppc64le, ppc64, armv5el, armv5hf, armv6, armv7, armv7hf, armv7s, armv7k, armv8, armv8_32, armv8.3, sparc, sparcv9, mips, mips64, avr, s390, s390x, asm.js, wasm, sh4le]
-    
+
     # Rest of the settings are "host" settings:
     # - For native building/cross building: Where the library/program will run.
     # - For building cross compilation tools: Where the cross compiler will run.
@@ -100,9 +100,9 @@ _t_default_settings_yml = Template(textwrap.dedent("""
         qcc:
             version: ["4.4", "5.4"]
             libcxx: [cxx, gpp, cpp, cpp-ne, accp, acpp-ne, ecpp, ecpp-ne]
-    
+
     build_type: [None, Debug, Release, RelWithDebInfo, MinSizeRel]
-    
+
     {% if not conan_v2 %}
     cppstd: [None, 98, gnu98, 11, gnu11, 14, gnu14, 17, gnu17, 20, gnu20]  # Deprecated, use compiler.cppstd
     {% endif %}
@@ -121,7 +121,7 @@ _t_default_client_conf = Template(textwrap.dedent("""
     level = critical            # environment CONAN_LOGGING_LEVEL
     # trace_file =              # environment CONAN_TRACE_FILE
     print_run_commands = False  # environment CONAN_PRINT_RUN_COMMANDS
-    
+
     [general]
     default_profile = {{default_profile}}
     compression_level = 9                 # environment CONAN_COMPRESSION_LEVEL
@@ -142,10 +142,10 @@ _t_default_client_conf = Template(textwrap.dedent("""
     # skip_vs_projects_upgrade = False    # environment CONAN_SKIP_VS_PROJECTS_UPGRADE
     # non_interactive = False             # environment CONAN_NON_INTERACTIVE
     # skip_broken_symlinks_check = False  # environment CONAN_SKIP_BROKEN_SYMLINKS_CHECK
-    
+
     # conan_make_program = make           # environment CONAN_MAKE_PROGRAM (overrides the make program used in AutoToolsBuildEnvironment.make)
     # conan_cmake_program = cmake         # environment CONAN_CMAKE_PROGRAM (overrides the make program used in CMake.cmake_program)
-    
+
     # cmake_generator                     # environment CONAN_CMAKE_GENERATOR
     # cmake generator platform            # environment CONAN_CMAKE_GENERATOR_PLATFORM
     # http://www.vtk.org/Wiki/CMake_Cross_Compiling
@@ -157,27 +157,27 @@ _t_default_client_conf = Template(textwrap.dedent("""
     # cmake_find_root_path_mode_program   # environment CONAN_CMAKE_FIND_ROOT_PATH_MODE_PROGRAM
     # cmake_find_root_path_mode_library   # environment CONAN_CMAKE_FIND_ROOT_PATH_MODE_LIBRARY
     # cmake_find_root_path_mode_include   # environment CONAN_CMAKE_FIND_ROOT_PATH_MODE_INCLUDE
-    
+
     # msbuild_verbosity = minimal         # environment CONAN_MSBUILD_VERBOSITY
-    
+
     # cpu_count = 1             # environment CONAN_CPU_COUNT
-    
+
     # Change the default location for building test packages to a temporary folder
     # which is deleted after the test.
     # temp_test_folder = True             # environment CONAN_TEMP_TEST_FOLDER
-    
+
     # cacert_path                         # environment CONAN_CACERT_PATH
     # scm_to_conandata                    # environment CONAN_SCM_TO_CONANDATA
     {% if conan_v2 %}
     revisions_enabled = 1
     {% endif %}
-    
+
     [storage]
     # This is the default path, but you can write your own. It must be an absolute path or a
     # path beginning with "~" (if the environment var CONAN_USER_HOME is specified, this directory, even
     # with "~/", will be relative to the conan user home, not to the system user home)
     path = ./data
-    
+
     [proxies]
     # Empty (or missing) section will try to use system proxies.
     # As documented in https://requests.readthedocs.io/en/master/user/advanced/#proxies - but see below
@@ -190,12 +190,12 @@ _t_default_client_conf = Template(textwrap.dedent("""
     #   hostname.to.be.proxied.com = http://user:pass@10.10.1.10:3128
     # You can skip the proxy for the matching (fnmatch) urls (comma-separated)
     # no_proxy_match = *bintray.com*, https://myserver.*
-    
+
     {% if not conan_v2 %}{# no hooks by default in Conan v2 #}
     [hooks]    # environment CONAN_HOOKS
     attribute_checker
     {% endif %}
-    
+
     # Default settings now declared in the default profile
     """))
 
@@ -318,12 +318,12 @@ class ConanClientConfigParser(ConfigParser, object):
 
     def set_item(self, key, value):
         tokens = key.split(".", 1)
+        if len(tokens) == 1:  # defining full section
+            raise ConanException("You can't set a full section, please specify a section.key=value")
+
         section_name = tokens[0]
         if not self.has_section(section_name):
             self.add_section(section_name)
-
-        if len(tokens) == 1:  # defining full section
-            raise ConanException("You can't set a full section, please specify a key=value")
 
         key = tokens[1]
         try:

--- a/conans/client/conf/__init__.py
+++ b/conans/client/conf/__init__.py
@@ -1,17 +1,16 @@
+import logging
 import os
+import textwrap
 
+from jinja2 import Template
 from six.moves.configparser import ConfigParser, NoSectionError
 
 from conans.errors import ConanException
 from conans.model.env_info import unquote
 from conans.paths import DEFAULT_PROFILE_NAME, conan_expand_user, CACERT_FILE
+from conans.util.conan_v2_mode import CONAN_V2_MODE_ENVVAR
 from conans.util.env_reader import get_env
 from conans.util.files import load
-import logging
-from jinja2 import Template
-import textwrap
-from conans.util.conan_v2_mode import CONAN_V2_MODE_ENVVAR
-
 
 _t_default_settings_yml = Template(textwrap.dedent("""
     # Only for cross building, 'os_build/arch_build' is the system that runs Conan

--- a/conans/client/conf/__init__.py
+++ b/conans/client/conf/__init__.py
@@ -204,12 +204,7 @@ def get_default_client_conf(force_v1=False):
     return _t_default_client_conf.render(conan_v2=conan_v2, default_profile=DEFAULT_PROFILE_NAME)
 
 
-class ConanClientConfigParser(ConfigParser, object):
-
-    def __init__(self, filename):
-        ConfigParser.__init__(self, allow_no_value=True)
-        self.read(filename)
-        self.filename = filename
+class ConanClientConfigParser(ConfigParser):
 
     # So keys are not converted to lowercase, we override the default optionxform
     optionxform = str
@@ -264,6 +259,11 @@ class ConanClientConfigParser(ConfigParser, object):
             ("CONAN_HOOKS", "", None),
         ]
     }
+
+    def __init__(self, filename):
+        super(ConanClientConfigParser, self).__init__(allow_no_value=True)
+        self.read(filename)
+        self.filename = filename
 
     @property
     def env_vars(self):

--- a/conans/client/conf/__init__.py
+++ b/conans/client/conf/__init__.py
@@ -214,67 +214,67 @@ class ConanClientConfigParser(ConfigParser, object):
     # So keys are not converted to lowercase, we override the default optionxform
     optionxform = str
 
+    _table_vars = {
+        # Environment variable | conan.conf variable | Default value
+        "log": [
+            ("CONAN_LOG_RUN_TO_OUTPUT", "run_to_output", "True"),
+            ("CONAN_LOG_RUN_TO_FILE", "run_to_file", "False"),
+            ("CONAN_LOGGING_LEVEL", "level", "50"),
+            ("CONAN_TRACE_FILE", "trace_file", None),
+            ("CONAN_PRINT_RUN_COMMANDS", "print_run_commands", "False"),
+        ],
+        "general": [
+            ("CONAN_COMPRESSION_LEVEL", "compression_level", "9"),
+            ("CONAN_NON_INTERACTIVE", "non_interactive", "False"),
+            ("CONAN_SKIP_BROKEN_SYMLINKS_CHECK", "skip_broken_symlinks_check", "False"),
+            ("CONAN_CACHE_NO_LOCKS", "cache_no_locks", "False"),
+            ("CONAN_SYSREQUIRES_SUDO", "sysrequires_sudo", "False"),
+            ("CONAN_SYSREQUIRES_MODE", "sysrequires_mode", None),
+            ("CONAN_REQUEST_TIMEOUT", "request_timeout", None),
+            ("CONAN_RETRY", "retry", None),
+            ("CONAN_RETRY_WAIT", "retry_wait", None),
+            ("CONAN_VS_INSTALLATION_PREFERENCE", "vs_installation_preference", None),
+            ("CONAN_CPU_COUNT", "cpu_count", None),
+            ("CONAN_READ_ONLY_CACHE", "read_only_cache", None),
+            ("CONAN_USER_HOME_SHORT", "user_home_short", None),
+            ("CONAN_USE_ALWAYS_SHORT_PATHS", "use_always_short_paths", None),
+            ("CONAN_VERBOSE_TRACEBACK", "verbose_traceback", None),
+            ("CONAN_ERROR_ON_OVERRIDE", "error_on_override", "False"),
+            # http://www.vtk.org/Wiki/CMake_Cross_Compiling
+            ("CONAN_CMAKE_GENERATOR", "cmake_generator", None),
+            ("CONAN_CMAKE_GENERATOR_PLATFORM", "cmake_generator_platform", None),
+            ("CONAN_CMAKE_TOOLCHAIN_FILE", "cmake_toolchain_file", None),
+            ("CONAN_CMAKE_SYSTEM_NAME", "cmake_system_name", None),
+            ("CONAN_CMAKE_SYSTEM_VERSION", "cmake_system_version", None),
+            ("CONAN_CMAKE_SYSTEM_PROCESSOR", "cmake_system_processor", None),
+            ("CONAN_CMAKE_FIND_ROOT_PATH", "cmake_find_root_path", None),
+            ("CONAN_CMAKE_FIND_ROOT_PATH_MODE_PROGRAM", "cmake_find_root_path_mode_program", None),
+            ("CONAN_CMAKE_FIND_ROOT_PATH_MODE_LIBRARY", "cmake_find_root_path_mode_library", None),
+            ("CONAN_CMAKE_FIND_ROOT_PATH_MODE_INCLUDE", "cmake_find_root_path_mode_include", None),
+            ("CONAN_BASH_PATH", "bash_path", None),
+            ("CONAN_MAKE_PROGRAM", "conan_make_program", None),
+            ("CONAN_CMAKE_PROGRAM", "conan_cmake_program", None),
+            ("CONAN_TEMP_TEST_FOLDER", "temp_test_folder", "False"),
+            ("CONAN_SKIP_VS_PROJECTS_UPGRADE", "skip_vs_projects_upgrade", "False"),
+            ("CONAN_MSBUILD_VERBOSITY", "msbuild_verbosity", None),
+            ("CONAN_CACERT_PATH", "cacert_path", None),
+            ("CONAN_DEFAULT_PACKAGE_ID_MODE", "default_package_id_mode", None),
+        ],
+        "hooks": [
+            ("CONAN_HOOKS", "", None),
+        ]
+    }
+
     @property
     def env_vars(self):
-        ret = {"CONAN_LOG_RUN_TO_OUTPUT": self._env_c("log.run_to_output", "CONAN_LOG_RUN_TO_OUTPUT", "True"),
-               "CONAN_LOG_RUN_TO_FILE": self._env_c("log.run_to_file", "CONAN_LOG_RUN_TO_FILE", "False"),
-               "CONAN_LOGGING_LEVEL": self._env_c("log.level", "CONAN_LOGGING_LEVEL", "50"),
-               "CONAN_TRACE_FILE": self._env_c("log.trace_file", "CONAN_TRACE_FILE", None),
-               "CONAN_PRINT_RUN_COMMANDS": self._env_c("log.print_run_commands", "CONAN_PRINT_RUN_COMMANDS", "False"),
-               "CONAN_COMPRESSION_LEVEL": self._env_c("general.compression_level", "CONAN_COMPRESSION_LEVEL", "9"),
-               "CONAN_NON_INTERACTIVE": self._env_c("general.non_interactive", "CONAN_NON_INTERACTIVE", "False"),
-               "CONAN_SKIP_BROKEN_SYMLINKS_CHECK": self._env_c("general.skip_broken_symlinks_check", "CONAN_SKIP_BROKEN_SYMLINKS_CHECK", "False"),
-               "CONAN_CACHE_NO_LOCKS": self._env_c("general.cache_no_locks", "CONAN_CACHE_NO_LOCKS", "False"),
-               "CONAN_SYSREQUIRES_SUDO": self._env_c("general.sysrequires_sudo", "CONAN_SYSREQUIRES_SUDO", "False"),
-               "CONAN_SYSREQUIRES_MODE": self._env_c("general.sysrequires_mode", "CONAN_SYSREQUIRES_MODE", None),
-               "CONAN_REQUEST_TIMEOUT": self._env_c("general.request_timeout", "CONAN_REQUEST_TIMEOUT", None),
-               "CONAN_RETRY": self._env_c("general.retry", "CONAN_RETRY", None),
-               "CONAN_RETRY_WAIT": self._env_c("general.retry_wait", "CONAN_RETRY_WAIT", None),
-               "CONAN_VS_INSTALLATION_PREFERENCE": self._env_c("general.vs_installation_preference", "CONAN_VS_INSTALLATION_PREFERENCE", None),
-               "CONAN_CPU_COUNT": self._env_c("general.cpu_count", "CONAN_CPU_COUNT", None),
-               "CONAN_READ_ONLY_CACHE": self._env_c("general.read_only_cache", "CONAN_READ_ONLY_CACHE", None),
-               "CONAN_USER_HOME_SHORT": self._env_c("general.user_home_short", "CONAN_USER_HOME_SHORT", None),
-               "CONAN_USE_ALWAYS_SHORT_PATHS": self._env_c("general.use_always_short_paths", "CONAN_USE_ALWAYS_SHORT_PATHS", None),
-               "CONAN_VERBOSE_TRACEBACK": self._env_c("general.verbose_traceback", "CONAN_VERBOSE_TRACEBACK", None),
-               "CONAN_ERROR_ON_OVERRIDE": self._env_c("general.error_on_override", "CONAN_ERROR_ON_OVERRIDE", "False"),
-               # http://www.vtk.org/Wiki/CMake_Cross_Compiling
-               "CONAN_CMAKE_GENERATOR": self._env_c("general.cmake_generator", "CONAN_CMAKE_GENERATOR", None),
-               "CONAN_CMAKE_GENERATOR_PLATFORM": self._env_c("general.cmake_generator_platform", "CONAN_CMAKE_GENERATOR_PLATFORM", None),
-               "CONAN_CMAKE_TOOLCHAIN_FILE": self._env_c("general.cmake_toolchain_file", "CONAN_CMAKE_TOOLCHAIN_FILE", None),
-               "CONAN_CMAKE_SYSTEM_NAME": self._env_c("general.cmake_system_name", "CONAN_CMAKE_SYSTEM_NAME", None),
-               "CONAN_CMAKE_SYSTEM_VERSION": self._env_c("general.cmake_system_version", "CONAN_CMAKE_SYSTEM_VERSION", None),
-               "CONAN_CMAKE_SYSTEM_PROCESSOR": self._env_c("general.cmake_system_processor",
-                                                           "CONAN_CMAKE_SYSTEM_PROCESSOR",
-                                                           None),
-               "CONAN_CMAKE_FIND_ROOT_PATH": self._env_c("general.cmake_find_root_path",
-                                                         "CONAN_CMAKE_FIND_ROOT_PATH",
-                                                         None),
-               "CONAN_CMAKE_FIND_ROOT_PATH_MODE_PROGRAM": self._env_c("general.cmake_find_root_path_mode_program",
-                                                                      "CONAN_CMAKE_FIND_ROOT_PATH_MODE_PROGRAM",
-                                                                      None),
-               "CONAN_CMAKE_FIND_ROOT_PATH_MODE_LIBRARY": self._env_c("general.cmake_find_root_path_mode_library",
-                                                                      "CONAN_CMAKE_FIND_ROOT_PATH_MODE_LIBRARY",
-                                                                      None),
-               "CONAN_CMAKE_FIND_ROOT_PATH_MODE_INCLUDE": self._env_c("general.cmake_find_root_path_mode_include",
-                                                                      "CONAN_CMAKE_FIND_ROOT_PATH_MODE_INCLUDE",
-                                                                      None),
-
-               "CONAN_BASH_PATH": self._env_c("general.bash_path", "CONAN_BASH_PATH", None),
-               "CONAN_MAKE_PROGRAM": self._env_c("general.conan_make_program", "CONAN_MAKE_PROGRAM", None),
-               "CONAN_CMAKE_PROGRAM": self._env_c("general.conan_cmake_program", "CONAN_CMAKE_PROGRAM", None),
-               "CONAN_TEMP_TEST_FOLDER": self._env_c("general.temp_test_folder", "CONAN_TEMP_TEST_FOLDER", "False"),
-               "CONAN_SKIP_VS_PROJECTS_UPGRADE": self._env_c("general.skip_vs_projects_upgrade", "CONAN_SKIP_VS_PROJECTS_UPGRADE", "False"),
-               "CONAN_HOOKS": self._env_c("hooks", "CONAN_HOOKS", None),
-               "CONAN_MSBUILD_VERBOSITY": self._env_c("general.msbuild_verbosity",
-                                                      "CONAN_MSBUILD_VERBOSITY",
-                                                      None),
-               "CONAN_CACERT_PATH": self._env_c("general.cacert_path", "CONAN_CACERT_PATH", None),
-               "CONAN_DEFAULT_PACKAGE_ID_MODE": self._env_c("general.default_package_id_mode",
-                                                            "CONAN_DEFAULT_PACKAGE_ID_MODE", None),
-               }
-
-        # Filter None values
-        return {name: value for name, value in ret.items() if value is not None}
+        ret = {}
+        for section, values in self._table_vars.items():
+            for env_var, var_name, default_value in values:
+                var_name = ".".join([section, var_name]) if var_name else section
+                value = self._env_c(var_name, env_var, default_value)
+                if value is not None:
+                    ret[env_var] = value
+        return ret
 
     def _env_c(self, var_name, env_var_name, default_value):
         env = os.environ.get(env_var_name, None)

--- a/conans/client/conf/__init__.py
+++ b/conans/client/conf/__init__.py
@@ -277,6 +277,7 @@ class ConanClientConfigParser(ConfigParser):
         return ret
 
     def _env_c(self, var_name, env_var_name, default_value):
+        """ Returns the value Conan will use: first tries with environment, then 'conan.conf' """
         env = os.environ.get(env_var_name, None)
         if env is not None:
             return env
@@ -286,6 +287,7 @@ class ConanClientConfigParser(ConfigParser):
             return default_value
 
     def get_item(self, item):
+        """ Return the value stored in 'conan.conf' """
         if not item:
             return load(self.filename)
 

--- a/conans/client/conf/__init__.py
+++ b/conans/client/conf/__init__.py
@@ -204,7 +204,7 @@ def get_default_client_conf(force_v1=False):
     return _t_default_client_conf.render(conan_v2=conan_v2, default_profile=DEFAULT_PROFILE_NAME)
 
 
-class ConanClientConfigParser(ConfigParser):
+class ConanClientConfigParser(ConfigParser, object):
 
     # So keys are not converted to lowercase, we override the default optionxform
     optionxform = str

--- a/conans/test/functional/command/config_test.py
+++ b/conans/test/functional/command/config_test.py
@@ -39,7 +39,7 @@ class ConfigTest(unittest.TestCase):
         self.client.run("config get storage.what", assert_error=True)
         self.assertIn("'what' doesn't exist in [storage]", self.client.out)
         self.client.run('config set proxies=https:', assert_error=True)
-        self.assertIn("You can't set a full section, please specify a key=value",
+        self.assertIn("You can't set a full section, please specify a section.key=value",
                       self.client.out)
 
         self.client.run('config set proxies.http:Value', assert_error=True)


### PR DESCRIPTION
Changelog: omit
Docs: omit

Move the table with environment variable names and _conan.conf_ name to a class attribute (avoid writing the envvar twice)
