### PR TITLE
#6489 Raise ConanException for invalid package folder on export-pkg

### DIFF
--- a/conans/client/conan_api.py
+++ b/conans/client/conan_api.py
@@ -391,9 +391,6 @@ class ConanAPIV1(object):
                     raise ConanException("package folder definition incompatible with build "
                                          "and source folders")
                 package_folder = _make_abs_path(package_folder, cwd)
-                if not os.path.exists(package_folder):
-                    raise ConanException("The package folder '{}' does not exist."
-                                         .format(package_folder))
 
             build_folder = _make_abs_path(build_folder, cwd)
             if install_folder:
@@ -422,6 +419,13 @@ class ConanAPIV1(object):
                        remotes=remotes)
             if lockfile:
                 graph_info.save_lock(lockfile)
+
+            for folder, path in {"source": source_folder, "build": build_folder,
+                                 "package": package_folder}.items():
+                if path and not os.path.exists(path):
+                    raise ConanException("The {} folder '{}' does not exist."
+                                         .format(folder, path))
+
             return recorder.get_info(self.app.config.revisions_enabled)
         except ConanException as exc:
             recorder.error = True

--- a/conans/client/conan_api.py
+++ b/conans/client/conan_api.py
@@ -403,7 +403,7 @@ class ConanAPIV1(object):
                                            default=os.path.dirname(conanfile_path))
 
             for folder, path in {"source": source_folder, "build": build_folder,
-                                 "install": install_folder, "package": package_folder}.items():
+                                 "package": package_folder}.items():
                 if path and not os.path.exists(path):
                     raise ConanException("The {} folder '{}' does not exist."
                                          .format(folder, path))

--- a/conans/client/conan_api.py
+++ b/conans/client/conan_api.py
@@ -391,6 +391,9 @@ class ConanAPIV1(object):
                     raise ConanException("package folder definition incompatible with build "
                                          "and source folders")
                 package_folder = _make_abs_path(package_folder, cwd)
+                if not os.path.exists(package_folder):
+                    raise ConanException("The package folder '{}' does not exist."
+                                         .format(package_folder))
 
             build_folder = _make_abs_path(build_folder, cwd)
             if install_folder:

--- a/conans/client/conan_api.py
+++ b/conans/client/conan_api.py
@@ -402,6 +402,12 @@ class ConanAPIV1(object):
             source_folder = _make_abs_path(source_folder, cwd,
                                            default=os.path.dirname(conanfile_path))
 
+            for folder, path in {"source": source_folder, "build": build_folder,
+                                 "install": install_folder, "package": package_folder}.items():
+                if path and not os.path.exists(path):
+                    raise ConanException("The {} folder '{}' does not exist."
+                                         .format(folder, path))
+
             lockfile = _make_abs_path(lockfile, cwd) if lockfile else None
             # Checks that no both settings and info files are specified
             graph_info = get_graph_info(profile_names, settings, options, env, cwd, install_folder,
@@ -419,13 +425,6 @@ class ConanAPIV1(object):
                        remotes=remotes)
             if lockfile:
                 graph_info.save_lock(lockfile)
-
-            for folder, path in {"source": source_folder, "build": build_folder,
-                                 "package": package_folder}.items():
-                if path and not os.path.exists(path):
-                    raise ConanException("The {} folder '{}' does not exist."
-                                         .format(folder, path))
-
             return recorder.get_info(self.app.config.revisions_enabled)
         except ConanException as exc:
             recorder.error = True

--- a/conans/test/functional/command/export_pkg_test.py
+++ b/conans/test/functional/command/export_pkg_test.py
@@ -482,6 +482,15 @@ class TestConan(ConanFile):
 
     def test_export_pkg_json(self):
 
+        def _check_json_output_no_folder():
+            json_path = os.path.join(self.client.current_folder, "output.json")
+            self.assertTrue(os.path.exists(json_path))
+            json_content = load(json_path)
+            output = json.loads(json_content)
+            self.assertEqual(True, output["error"])
+            self.assertEqual([], output["installed"])
+            self.assertEqual(2, len(output))
+
         def _check_json_output(with_error=False):
             json_path = os.path.join(self.client.current_folder, "output.json")
             self.assertTrue(os.path.exists(json_path))
@@ -513,7 +522,7 @@ class MyConan(ConanFile):
         self.client.run("export-pkg . danimtb/testing -bf build -sf sources "
                         "--json output.json", assert_error=True)
 
-        _check_json_output(with_error=True)
+        _check_json_output_no_folder()
 
         # Deafult folders
         self.client.run("export-pkg . danimtb/testing --json output.json --force")
@@ -622,7 +631,7 @@ class TestConan(ConanFile):
     def test_invalid_folder(self):
         """ source, build and package path must exists, otherwise, raise ConanException
         """
-        for folder in ["source", "install", "build", "package"]:
+        for folder in ["source", "build", "package"]:
             client = TestClient()
             client.save({CONANFILE: GenConanfile().with_name("foo").with_version("0.1.0")})
 

--- a/conans/test/functional/command/export_pkg_test.py
+++ b/conans/test/functional/command/export_pkg_test.py
@@ -12,6 +12,7 @@ from conans.paths import CONANFILE
 from conans.test.utils.tools import NO_SETTINGS_PACKAGE_ID, TestClient, GenConanfile
 from conans.util.env_reader import get_env
 from conans.util.files import load, mkdir, is_dirty
+from conans.errors import ConanException
 
 
 class ExportPkgTest(unittest.TestCase):
@@ -480,7 +481,7 @@ class TestConan(ConanFile):
         self.assertIn("set(CONAN_LIBS_HELLO1 mycoollib)", cmakeinfo)
         self.assertIn("set(CONAN_LIBS mycoollib ${CONAN_LIBS})", cmakeinfo)
 
-    def export_pkg_json_test(self):
+    def test_export_pkg_json(self):
 
         def _check_json_output(with_error=False):
             json_path = os.path.join(self.client.current_folder, "output.json")
@@ -530,7 +531,7 @@ class MyConan(ConanFile):
         self.client.run("export-pkg . danimtb/testing -pf package --json output.json --force")
         _check_json_output()
 
-    def json_with_dependencies_test(self):
+    def test_json_with_dependencies(self):
 
         def _check_json_output(with_error=False):
             json_path = os.path.join(self.client.current_folder, "output.json")
@@ -618,3 +619,13 @@ class TestConan(ConanFile):
         self.assertFalse(is_dirty(package_folder))
         client.run("install pkg/0.1@")
         self.assertIn("pkg/0.1: Already installed!", client.out)
+
+    def test_invalid_package_folder(self):
+        """ package folder must exists, otherwise, raise ConanException
+        """
+        client = TestClient()
+        client.save({CONANFILE: GenConanfile().with_name("foo").with_version("0.1.0")})
+
+        with self.assertRaisesRegex(ConanException,
+                                    "ERROR: The package folder 'pkg' does not exist."):
+            client.run("export-pkg . foo/0.1.0@user/testing -pf=pkg")

--- a/conans/test/functional/command/export_pkg_test.py
+++ b/conans/test/functional/command/export_pkg_test.py
@@ -619,12 +619,14 @@ class TestConan(ConanFile):
         client.run("install pkg/0.1@")
         self.assertIn("pkg/0.1: Already installed!", client.out)
 
-    def test_invalid_package_folder(self):
-        """ package folder must exists, otherwise, raise ConanException
+    def test_invalid_folder(self):
+        """ source, build and package path must exists, otherwise, raise ConanException
         """
-        client = TestClient()
-        client.save({CONANFILE: GenConanfile().with_name("foo").with_version("0.1.0")})
+        for folder in ["source", "install", "build", "package"]:
+            client = TestClient()
+            client.save({CONANFILE: GenConanfile().with_name("foo").with_version("0.1.0")})
 
-        client.run("export-pkg . foo/0.1.0@user/testing -pf=pkg", assert_error=True)
-        self.assertIn("ERROR: The package folder '{}' does not exist."
-                      .format(os.path.join(client.current_folder, "pkg")), client.out)
+            client.run("export-pkg . foo/0.1.0@user/testing -{}f={}".format(folder[0], folder),
+                       assert_error=True)
+            self.assertIn("ERROR: The {} folder '{}' does not exist."
+                          .format(folder, os.path.join(client.current_folder, folder)), client.out)

--- a/conans/test/functional/command/export_pkg_test.py
+++ b/conans/test/functional/command/export_pkg_test.py
@@ -12,7 +12,6 @@ from conans.paths import CONANFILE
 from conans.test.utils.tools import NO_SETTINGS_PACKAGE_ID, TestClient, GenConanfile
 from conans.util.env_reader import get_env
 from conans.util.files import load, mkdir, is_dirty
-from conans.errors import ConanException
 
 
 class ExportPkgTest(unittest.TestCase):
@@ -626,6 +625,6 @@ class TestConan(ConanFile):
         client = TestClient()
         client.save({CONANFILE: GenConanfile().with_name("foo").with_version("0.1.0")})
 
-        with self.assertRaisesRegex(ConanException,
-                                    "ERROR: The package folder 'pkg' does not exist."):
-            client.run("export-pkg . foo/0.1.0@user/testing -pf=pkg")
+        client.run("export-pkg . foo/0.1.0@user/testing -pf=pkg", assert_error=True)
+        self.assertIn("ERROR: The package folder '{}' does not exist."
+                      .format(os.path.join(client.current_folder, "pkg")), client.out)


### PR DESCRIPTION
Hi! This PR is related to #6489. 

When the package folder doesn't exist for the command export-pkg, a ConanException must be raised.

Changelog: Fix: Raises ConanException when package folder is invalid for export-pkg
Docs: https://github.com/conan-io/docs/pull/1624

fixes #6489

- [x] Refer to the issue that supports this Pull Request.
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 

<sup>**Note:** By default this PR will skip the slower tests and will use a limited set of python versions. Check [here](https://github.com/conan-io/conan/blob/develop/.github/PR_INCREASE_TESTING.md) how to increase the testing level by writing some tags in the current PR body text.</sup>
