### PR TITLE
Feature/name version conanbuildinfo txt

### DIFF
--- a/conans/client/generators/text.py
+++ b/conans/client/generators/text.py
@@ -13,6 +13,7 @@ from conans.util.log import logger
 
 class DepsCppTXT(object):
     def __init__(self, cpp_info):
+        self.version = cpp_info.version
         self.include_paths = "\n".join(p.replace("\\", "/")
                                        for p in cpp_info.include_paths)
         self.lib_paths = "\n".join(p.replace("\\", "/")
@@ -126,12 +127,13 @@ class TXTGenerator(Generator):
                     cpp_info = deps_cpp_info
                 else:
                     cpp_info = deps_cpp_info._dependencies.setdefault(dep, CppInfo(root_folder=""))
+                    cpp_info.name = dep  # Recover the name field
 
                 for config, fields in configs_cpp_info.items():
                     item_to_apply = cpp_info if not config else getattr(cpp_info, config)
 
                     for key, value in fields.items():
-                        if key in ['rootpath', 'sysroot']:
+                        if key in ['rootpath', 'sysroot', 'version']:
                             value = value[0]
                         setattr(item_to_apply, key, value)
             return deps_cpp_info
@@ -170,7 +172,8 @@ class TXTGenerator(Generator):
             sections.append(all_flags)
 
         # Makes no sense to have an accumulated rootpath
-        template_deps = template + '[rootpath{dep}]\n{deps.rootpath}\n\n'
+        template_deps = (template + '[rootpath{dep}]\n{deps.rootpath}\n\n' +
+                         '[version{dep}]\n{deps.version}\n\n')
 
         for dep_name, dep_cpp_info in self.deps_build_info.dependencies:
             dep = "_" + dep_name

--- a/conans/client/generators/text.py
+++ b/conans/client/generators/text.py
@@ -14,6 +14,7 @@ from conans.util.log import logger
 class DepsCppTXT(object):
     def __init__(self, cpp_info):
         self.version = cpp_info.version
+        self.name = cpp_info.name
         self.include_paths = "\n".join(p.replace("\\", "/")
                                        for p in cpp_info.include_paths)
         self.lib_paths = "\n".join(p.replace("\\", "/")
@@ -127,13 +128,12 @@ class TXTGenerator(Generator):
                     cpp_info = deps_cpp_info
                 else:
                     cpp_info = deps_cpp_info._dependencies.setdefault(dep, CppInfo(root_folder=""))
-                    cpp_info.name = dep  # Recover the name field
 
                 for config, fields in configs_cpp_info.items():
                     item_to_apply = cpp_info if not config else getattr(cpp_info, config)
 
                     for key, value in fields.items():
-                        if key in ['rootpath', 'sysroot', 'version']:
+                        if key in ['rootpath', 'sysroot', 'version', 'name']:
                             value = value[0]
                         setattr(item_to_apply, key, value)
             return deps_cpp_info
@@ -173,6 +173,7 @@ class TXTGenerator(Generator):
 
         # Makes no sense to have an accumulated rootpath
         template_deps = (template + '[rootpath{dep}]\n{deps.rootpath}\n\n' +
+                         '[name{dep}]\n{deps.name}\n\n' +
                          '[version{dep}]\n{deps.version}\n\n')
 
         for dep_name, dep_cpp_info in self.deps_build_info.dependencies:

--- a/conans/test/functional/command/test_package_test.py
+++ b/conans/test/functional/command/test_package_test.py
@@ -125,7 +125,13 @@ class TestPackageTest(unittest.TestCase):
 
     def check_version_test(self):
         client = TestClient()
-        client.save({CONANFILE: GenConanfile()})
+        dep = textwrap.dedent("""
+            from conans import ConanFile
+            class Dep(ConanFile):
+                def package_info(self):
+                    self.cpp_info.name = "MyDep"
+            """)
+        client.save({CONANFILE: dep})
         client.run("create . dep/1.1@")
         conanfile = textwrap.dedent("""
             from conans import ConanFile
@@ -134,6 +140,8 @@ class TestPackageTest(unittest.TestCase):
                 def build(self):
                     info = self.deps_cpp_info["dep"]
                     self.output.info("BUILD Dep %s VERSION %s" % (info.name, info.version))
+                def package_info(self):
+                    self.cpp_info.name = "MyHello"
             """)
         test_conanfile = textwrap.dedent("""
             from conans import ConanFile
@@ -148,6 +156,6 @@ class TestPackageTest(unittest.TestCase):
         client.save({"conanfile.py": conanfile,
                      "test_package/conanfile.py": test_conanfile})
         client.run("create . hello/0.1@")
-        self.assertIn("hello/0.1: BUILD Dep dep VERSION 1.1", client.out)
-        self.assertIn("hello/0.1 (test package): BUILD HELLO hello VERSION 0.1", client.out)
-        self.assertIn("hello/0.1 (test package): TEST HELLO hello VERSION 0.1", client.out)
+        self.assertIn("hello/0.1: BUILD Dep MyDep VERSION 1.1", client.out)
+        self.assertIn("hello/0.1 (test package): BUILD HELLO MyHello VERSION 0.1", client.out)
+        self.assertIn("hello/0.1 (test package): TEST HELLO MyHello VERSION 0.1", client.out)


### PR DESCRIPTION
Changelog: Bugfix: Include name and version in the data from ``conanbuildinfo.txt``, so it is available in ``self.deps_cpp_info["dep"].version`` and ``self.deps_cpp_info["dep"].name``, so it can be used in ``conan build`` and in ``test_package/conanfile.py``.
Docs: https://github.com/conan-io/docs/pull/1626

Close https://github.com/conan-io/conan/issues/6695