### PR TITLE
#6693 Check for description in JSON output

### DIFF
--- a/conans/client/command.py
+++ b/conans/client/command.py
@@ -583,7 +583,7 @@ class Command(object):
         """
 
         info_only_options = ["id", "build_id", "remote", "url", "license", "requires", "update",
-                             "required", "date", "author", "None"]
+                             "required", "date", "author", "description", "None"]
         path_only_options = ["export_folder", "build_folder", "package_folder", "source_folder"]
         str_path_only_options = ", ".join(['"%s"' % field for field in path_only_options])
         str_only_options = ", ".join(['"%s"' % field for field in info_only_options])

--- a/conans/client/conan_command_output.py
+++ b/conans/client/conan_command_output.py
@@ -170,6 +170,7 @@ class CommandOutputer(object):
             _add_if_exists("homepage")
             _add_if_exists("license", as_list=True)
             _add_if_exists("author")
+            _add_if_exists("description")
             _add_if_exists("topics", as_list=True)
 
             if isinstance(ref, ConanFileReference):

--- a/conans/client/printer.py
+++ b/conans/client/printer.py
@@ -98,6 +98,7 @@ class Printer(object):
                 self._out.writeln("    %s: %s" % (lead_str, licenses_str), Color.BRIGHT_GREEN)
 
             _print("author", name="Author")
+            _print("description", name="Description")
 
             if show("topics") and "topics" in it:
                 self._out.writeln("    Topics: %s" % ", ".join(it["topics"]), Color.BRIGHT_GREEN)

--- a/conans/test/functional/command/info_test.py
+++ b/conans/test/functional/command/info_test.py
@@ -56,12 +56,14 @@ class InfoTest(unittest.TestCase):
             files[CONANFILE] = files[CONANFILE].replace('version = "0.1"',
                                                         'version = "0.1"\n'
                                                         '    url= "myurl"\n'
-                                                        '    license = "MIT"')
+                                                        '    license = "MIT"\n'
+                                                        '    description = "blah"')
         else:
             files[CONANFILE] = files[CONANFILE].replace('version = "0.1"',
                                                         'version = "0.1"\n'
                                                         '    url= "myurl"\n'
-                                                        '    license = "MIT", "GPL"')
+                                                        '    license = "MIT", "GPL"\n'
+                                                        '    description = "foobar"')
 
         self.client.save(files)
         if export:
@@ -293,7 +295,7 @@ class MyTest(ConanFile):
         self.assertNotIn("virtual", self.client.out)
         self.assertNotIn("Required", self.client.out)
 
-    def reuse_test(self):
+    def test_reuse(self):
         self.client = TestClient()
         self._create("Hello0", "0.1")
         self._create("Hello1", "0.1", ["Hello0/0.1@lasote/stable"])
@@ -377,6 +379,20 @@ class MyTest(ConanFile):
 
         self.assertIn(expected_output, clean_output(self.client.out))
 
+        self.client.run("info . -u --only=url --only=license --only=description")
+        expected_output = textwrap.dedent(
+            """\
+            Hello0/0.1@lasote/stable
+                URL: myurl
+                License: MIT
+            Hello1/0.1@lasote/stable
+                URL: myurl
+                License: MIT
+            conanfile.py (Hello2/0.1)
+                URL: myurl
+                Licenses: MIT, GPL""")
+        self.assertIn(expected_output, clean_output(self.client.out))
+
     def test_json_info_outputs(self):
         self.client = TestClient()
         self._create("LibA", "0.1")
@@ -396,7 +412,9 @@ class MyTest(ConanFile):
         content = json.loads(load(json_file))
         self.assertEqual(content[0]["reference"], "LibA/0.1@lasote/stable")
         self.assertEqual(content[0]["license"][0], "MIT")
+        self.assertEqual(content[0]["description"], "blah")
         self.assertEqual(content[1]["url"], "myurl")
+        self.assertEqual(content[1]["required_by"][0], "conanfile.py (LibD/0.1)")
         self.assertEqual(content[1]["required_by"][0], "conanfile.py (LibD/0.1)")
 
     def build_order_test(self):

--- a/conans/test/functional/command/info_test.py
+++ b/conans/test/functional/command/info_test.py
@@ -427,7 +427,6 @@ class MyTest(ConanFile):
         self.assertEqual(content[0]["description"], "blah")
         self.assertEqual(content[1]["url"], "myurl")
         self.assertEqual(content[1]["required_by"][0], "conanfile.py (LibD/0.1)")
-        self.assertEqual(content[1]["required_by"][0], "conanfile.py (LibD/0.1)")
 
     def build_order_test(self):
         self.client = TestClient()

--- a/conans/test/functional/command/info_test.py
+++ b/conans/test/functional/command/info_test.py
@@ -63,7 +63,9 @@ class InfoTest(unittest.TestCase):
                                                         'version = "0.1"\n'
                                                         '    url= "myurl"\n'
                                                         '    license = "MIT", "GPL"\n'
-                                                        '    description = "foobar"')
+                                                        '    description = """Yo no creo en brujas,\n'
+                                                        '                 pero que las hay,\n'
+                                                        '                 las hay"""')
 
         self.client.save(files)
         if export:
@@ -334,7 +336,9 @@ class MyTest(ConanFile):
             conanfile.py (Hello2/0.1)
                 URL: myurl
                 Licenses: MIT, GPL
-                Description: foobar
+                Description: Yo no creo en brujas,
+                             pero que las hay,
+                             las hay
                 Requires:
                     Hello1/0.1@lasote/stable""")
 
@@ -396,7 +400,9 @@ class MyTest(ConanFile):
             conanfile.py (Hello2/0.1)
                 URL: myurl
                 Licenses: MIT, GPL
-                Description: foobar""")
+                Description: Yo no creo en brujas,
+                             pero que las hay,
+                             las hay""")
         self.assertIn(expected_output, clean_output(self.client.out))
 
     def test_json_info_outputs(self):

--- a/conans/test/functional/command/info_test.py
+++ b/conans/test/functional/command/info_test.py
@@ -313,6 +313,7 @@ class MyTest(ConanFile):
                 Remote: None
                 URL: myurl
                 License: MIT
+                Description: blah
                 Recipe: No remote%s
                 Binary: Missing
                 Binary remote: None
@@ -322,6 +323,7 @@ class MyTest(ConanFile):
                 Remote: None
                 URL: myurl
                 License: MIT
+                Description: blah
                 Recipe: No remote%s
                 Binary: Missing
                 Binary remote: None
@@ -332,6 +334,7 @@ class MyTest(ConanFile):
             conanfile.py (Hello2/0.1)
                 URL: myurl
                 Licenses: MIT, GPL
+                Description: foobar
                 Requires:
                     Hello1/0.1@lasote/stable""")
 
@@ -385,12 +388,15 @@ class MyTest(ConanFile):
             Hello0/0.1@lasote/stable
                 URL: myurl
                 License: MIT
+                Description: blah
             Hello1/0.1@lasote/stable
                 URL: myurl
                 License: MIT
+                Description: blah
             conanfile.py (Hello2/0.1)
                 URL: myurl
-                Licenses: MIT, GPL""")
+                Licenses: MIT, GPL
+                Description: foobar""")
         self.assertIn(expected_output, clean_output(self.client.out))
 
     def test_json_info_outputs(self):


### PR DESCRIPTION
Add the field "description" as valid for the command Conan info.

Changelog: Feature: Conan info command allows description on the output
Docs: https://github.com/conan-io/docs/pull/1627

closes #6693

- [x] Refer to the issue that supports this Pull Request.
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 

<sup>**Note:** By default this PR will skip the slower tests and will use a limited set of python versions. Check [here](https://github.com/conan-io/conan/blob/develop/.github/PR_INCREASE_TESTING.md) how to increase the testing level by writing some tags in the current PR body text.</sup>
