### PR TITLE
only 1 thread for parallel download tests

### DIFF
--- a/conans/test/functional/command/download/download_parallel_test.py
+++ b/conans/test/functional/command/download/download_parallel_test.py
@@ -7,8 +7,9 @@ class DownloadParallelTest(unittest.TestCase):
 
     def basic_parallel_download_test(self):
         client = TestClient(default_server_user=True)
+        threads = 1  # At the moment, not really parallel until output implements mutex
         counter = 4
-        client.run("config set general.parallel_download=%s" % counter)
+        client.run("config set general.parallel_download=%s" % threads)
         client.save({"conanfile.py": GenConanfile().with_option("myoption", '"ANY"')})
 
         for i in range(counter):
@@ -18,7 +19,7 @@ class DownloadParallelTest(unittest.TestCase):
 
         # Lets download the packages
         client.run("download pkg/0.1@user/testing")
-        self.assertIn("Downloading binary packages in %s parallel threads" % counter, client.out)
+        self.assertIn("Downloading binary packages in %s parallel threads" % threads, client.out)
         self.assertIn("pkg/0.1@user/testing: Package installed "
                       "74ca4e392408c388db596b086fca5ebf64d825c0", client.out)
         self.assertIn("pkg/0.1@user/testing: Package installed "

--- a/conans/test/functional/command/install/install_parallel_test.py
+++ b/conans/test/functional/command/install/install_parallel_test.py
@@ -7,8 +7,9 @@ class InstallParallelTest(unittest.TestCase):
 
     def basic_parallel_install_test(self):
         client = TestClient(default_server_user=True)
+        threads = 1  # At the moment, not really parallel until output implements mutex
         counter = 4
-        client.run("config set general.parallel_download=%s" % counter)
+        client.run("config set general.parallel_download=%s" % threads)
         client.save({"conanfile.py": GenConanfile()})
 
         for i in range(counter):
@@ -24,6 +25,6 @@ class InstallParallelTest(unittest.TestCase):
 
         client.save({"conanfile.txt": conanfile_txt}, clean_first=True)
         client.run("install .")
-        self.assertIn("Downloading binary packages in %s parallel threads" % counter, client.out)
+        self.assertIn("Downloading binary packages in %s parallel threads" % threads, client.out)
         for i in range(counter):
             self.assertIn("pkg%s/0.1@user/testing: Package installed" % i, client.out)


### PR DESCRIPTION
Changelog: Omit
Docs: Omit

We don't want tests to fail randomly at CI. So better have something consistent until the tests and the output of parallel is correctly implemented.