### PR TITLE
Feature: add Intel 19.1 (2020)

### DIFF
--- a/conans/client/conf/__init__.py
+++ b/conans/client/conf/__init__.py
@@ -88,7 +88,7 @@ _t_default_settings_yml = Template(textwrap.dedent("""
             libcxx: [libstdc++, libc++]
             cppstd: [None, 98, gnu98, 11, gnu11, 14, gnu14, 17, gnu17, 20, gnu20]
         intel:
-            version: ["11", "12", "13", "14", "15", "16", "17", "18", "19"]
+            version: ["11", "12", "13", "14", "15", "16", "17", "18", "19", "19.1"]
             base:
                 gcc:
                     <<: *gcc


### PR DESCRIPTION
add new Intel C++ compiler release to the default **settings.yml**
https://software.intel.com/en-us/articles/intel-c-compiler-191-for-windows-release-notes-for-intel-parallel-studio-xe-2020
https://software.intel.com/en-us/articles/intel-c-compiler-191-for-linux-release-notes-for-intel-parallel-studio-xe-2020

related: #5699 

Changelog: Feature: add Intel 19.1 (2020)
Docs: omit


- [x] Refer to the issue that supports this Pull Request.
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 

<sup>**Note:** By default this PR will skip the slower tests and will use a limited set of python versions. Check [here](https://github.com/conan-io/conan/blob/develop/.github/PR_INCREASE_TESTING.md) how to increase the testing level by writing some tags in the current PR body text.</sup>
