### PR TITLE
fix download multi-url

### DIFF
--- a/conans/client/tools/net.py
+++ b/conans/client/tools/net.py
@@ -13,11 +13,12 @@ def get(url, md5='', sha1='', sha256='', destination=".", filename="", keep_perm
     """ high level downloader + unzipper + (optional hash checker) + delete temporary zip
     """
 
-    url = [url] if not isinstance(url, (list, tuple)) else url
-    if not filename and ("?" in url[0] or "=" in url[0]):
-        raise ConanException("Cannot deduce file name from the url: '{}'. Use 'filename' "
-                             "parameter.".format(url[0]))
-    filename = filename or os.path.basename(url[0])
+    if not filename:  # deduce filename from the URL
+        url_base = url[0] if isinstance(url, (list, tuple)) else url
+        if "?" in url_base or "=" in url_base:
+            raise ConanException("Cannot deduce file name from the url: '{}'. Use 'filename' "
+                                 "parameter.".format(url_base))
+        filename = os.path.basename(url_base)
 
     download(url, filename, out=output, requester=requester, verify=verify, retry=retry,
              retry_wait=retry_wait, overwrite=overwrite, auth=auth, headers=headers,

--- a/conans/test/functional/cache/download_cache_test.py
+++ b/conans/test/functional/cache/download_cache_test.py
@@ -122,8 +122,7 @@ class DownloadCacheTest(unittest.TestCase):
            """ % http_server.port)
         client.save({"conanfile.py": conanfile})
         client.run("source .", assert_error=True)
-        self.assertIn("ConanException: Could not download from the URL http://localhost:{}/myfile."
-                      "txt: md5 signature failed for".format(http_server.port), client.out)
+        self.assertIn("ConanException: md5 signature failed for", client.out)
         self.assertIn("Provided signature: kk", client.out)
         self.assertIn("Computed signature: 9893532233caff98cd083a116b013c0b", client.out)
         self.assertEqual(1, len(os.listdir(cache_folder)))  # Nothing was cached

--- a/conans/test/unittests/util/tools_test.py
+++ b/conans/test/unittests/util/tools_test.py
@@ -474,8 +474,7 @@ class HelloConan(ConanFile):
 
         # Not found error
         with six.assertRaisesRegex(self, ConanException,
-                                   "Could not download from the URL http://google.es/FILE_NOT_FOUND:"
-                                   " Not found: http://google.es/FILE_NOT_FOUND."):
+                                   "Not found: http://google.es/FILE_NOT_FOUND"):
             tools.download("http://google.es/FILE_NOT_FOUND",
                            os.path.join(temp_folder(), "README.txt"), out=out,
                            requester=requests,


### PR DESCRIPTION
Changelog: Omit
Docs: Omit

#tags: slow

Several changes:

- Do not alter at all the behavior when len(url) == 1
- Avoid warnings of shadowing parameters
- Avoid useless ``downloader`` parameter, already in closure
- Capture a broader ``Exception``, as the ``requests`` library might throw connection errors that are not ``ConanException``
- Use the ``for-else`` idiom instead of counter.