### PR TITLE
#6597 Add optional value for get_safe

### DIFF
--- a/conans/model/options.py
+++ b/conans/model/options.py
@@ -391,8 +391,9 @@ class PackageOptions(object):
     def loads(text):
         return PackageOptions(yaml.safe_load(text) or {})
 
-    def get_safe(self, field):
-        return self._data.get(field)
+    def get_safe(self, field, default=None):
+        result = self._data.get(field)
+        return default if result is None else result
 
     def validate(self):
         for child in self._data.values():

--- a/conans/model/options.py
+++ b/conans/model/options.py
@@ -392,8 +392,7 @@ class PackageOptions(object):
         return PackageOptions(yaml.safe_load(text) or {})
 
     def get_safe(self, field, default=None):
-        result = self._data.get(field)
-        return default if result is None else result
+        return self._data.get(field, default)
 
     def validate(self):
         for child in self._data.values():

--- a/conans/model/settings.py
+++ b/conans/model/settings.py
@@ -202,16 +202,16 @@ class Settings(object):
         self._data = {str(k): SettingsItem(v, "%s.%s" % (name, k))
                       for k, v in definition.items()}
 
-    def get_safe(self, name):
+    def get_safe(self, name, default=None):
         try:
             tmp = self
             for prop in name.split("."):
                 tmp = getattr(tmp, prop, None)
         except ConanException:
-            return None
+            return default
         if tmp is not None and tmp.value and tmp.value != "None":  # In case of subsettings is None
             return str(tmp)
-        return None
+        return default
 
     def copy(self):
         """ deepcopy, recursive

--- a/conans/test/unittests/model/options_test.py
+++ b/conans/test/unittests/model/options_test.py
@@ -227,6 +227,19 @@ Poco:deps_bundled=True""")
                                                      ("OpenSSL.*:fake_option", "FuzzBuzz"),
                                                      ])
 
+    def test_get_safe_options(self):
+        self.assertEqual(True, self.sut.get_safe("static"))
+        self.assertEqual(3, self.sut.get_safe("optimized"))
+        self.assertEqual("NOTDEF", self.sut.get_safe("path"))
+        self.assertEqual(None, self.sut.get_safe("unknown"))
+        self.sut.path = "None"
+        self.sut.static = False
+        self.assertEqual(False, self.sut.get_safe("static"))
+        self.assertEqual("None", self.sut.get_safe("path"))
+        self.assertEqual(False, self.sut.get_safe("static", True))
+        self.assertEqual("None", self.sut.get_safe("path", True))
+        self.assertEqual(True, self.sut.get_safe("unknown", True))
+
 
 class OptionsValuesPropagationUpstreamNone(unittest.TestCase):
 

--- a/conans/test/unittests/model/settings_test.py
+++ b/conans/test/unittests/model/settings_test.py
@@ -100,6 +100,9 @@ class SettingsLoadsTest(unittest.TestCase):
         self.assertEqual(settings.os, "Windows")
         self.assertEqual(settings.get_safe("compiler.version"), None)
         self.assertEqual(settings.get_safe("build_type"), None)
+        self.assertEqual("Release", settings.get_safe("build_type", "Release"))
+        self.assertEqual(False, settings.get_safe("build_type", False))
+        self.assertEqual("Windows", settings.get_safe("os", "Linux"))
 
     def test_none_subsetting(self):
         yml = """os:


### PR DESCRIPTION
Changelog: Feature: `settings.get_safe` and `options.get_safe` accept a default value
Docs: https://github.com/conan-io/docs/pull/1631

closes #6597

- [x] Refer to the issue that supports this Pull Request.
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 

<sup>**Note:** By default this PR will skip the slower tests and will use a limited set of python versions. Check [here](https://github.com/conan-io/conan/blob/develop/.github/PR_INCREASE_TESTING.md) how to increase the testing level by writing some tags in the current PR body text.</sup>
