### PR TITLE
Feature: on Mac, Intel C++ is based on Apple Clang

### DIFF
--- a/conans/client/conf/__init__.py
+++ b/conans/client/conf/__init__.py
@@ -83,7 +83,7 @@ _t_default_settings_yml = Template(textwrap.dedent("""
                       "8", "9", "10"]
             libcxx: [libstdc++, libstdc++11, libc++, c++_shared, c++_static]
             cppstd: [None, 98, gnu98, 11, gnu11, 14, gnu14, 17, gnu17, 20, gnu20]
-        apple-clang:
+        apple-clang: &apple_clang
             version: ["5.0", "5.1", "6.0", "6.1", "7.0", "7.3", "8.0", "8.1", "9.0", "9.1", "10.0", "11.0"]
             libcxx: [libstdc++, libc++]
             cppstd: [None, 98, gnu98, 11, gnu11, 14, gnu14, 17, gnu17, 20, gnu20]
@@ -96,6 +96,8 @@ _t_default_settings_yml = Template(textwrap.dedent("""
                     exception: [None]
                 Visual Studio:
                     <<: *visual_studio
+                apple-clang:
+                    <<: *apple_clang
         qcc:
             version: ["4.4", "5.4"]
             libcxx: [cxx, gpp, cpp, cpp-ne, accp, acpp-ne, ecpp, ecpp-ne]


### PR DESCRIPTION
e.g. it allows **-stdlib=libc++**

related: #5699 

reference: 
https://software.intel.com/en-us/get-started-with-cpp-compiler-for-osx-parallel-studio-xe
https://software.intel.com/en-us/cpp-compiler-developer-guide-and-reference-stdlib

Changelog: Feature: on Mac, Intel C++ is based on Apple Clang
Docs: https://github.com/conan-io/docs/pull/1637

- [x] Refer to the issue that supports this Pull Request.
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 

<sup>**Note:** By default this PR will skip the slower tests and will use a limited set of python versions. Check [here](https://github.com/conan-io/conan/blob/develop/.github/PR_INCREASE_TESTING.md) how to increase the testing level by writing some tags in the current PR body text.</sup>
