### PR TITLE
Allow short_paths usage for Cygwin

### DIFF
--- a/conans/paths/package_layouts/package_cache_layout.py
+++ b/conans/paths/package_layouts/package_cache_layout.py
@@ -1,13 +1,12 @@
 # coding=utf-8
 
 import os
-import platform
 import threading
 from contextlib import contextmanager
 
-
 import fasteners
 
+from conans.client.tools.oss import detected_os
 from conans.errors import NotFoundException, ConanException
 from conans.errors import RecipeNotFoundException, PackageNotFoundException
 from conans.model.manifest import FileTreeManifest
@@ -23,7 +22,7 @@ from conans.util.log import logger
 
 
 def short_path(func):
-    if platform.system() == "Windows":
+    if detected_os() == "Windows":
         from conans.util.windows import path_shortener
 
         def wrap(self, *args, **kwargs):

--- a/conans/paths/package_layouts/package_cache_layout.py
+++ b/conans/paths/package_layouts/package_cache_layout.py
@@ -1,12 +1,13 @@
 # coding=utf-8
 
 import os
+import platform
 import threading
 from contextlib import contextmanager
 
 import fasteners
 
-from conans.client.tools.oss import detected_os
+from conans.client.tools.oss import OSInfo
 from conans.errors import NotFoundException, ConanException
 from conans.errors import RecipeNotFoundException, PackageNotFoundException
 from conans.model.manifest import FileTreeManifest
@@ -22,7 +23,7 @@ from conans.util.log import logger
 
 
 def short_path(func):
-    if detected_os() == "Windows":
+    if platform.system() == "Windows" or OSInfo().is_cygwin:  # Not for other subsystems
         from conans.util.windows import path_shortener
 
         def wrap(self, *args, **kwargs):


### PR DESCRIPTION
Changelog: Feature: Short paths feature is available for Cygwin
Docs: https://github.com/conan-io/docs/pull/XXXX

Closes https://github.com/conan-io/conan/issues/6660

This enables the **short paths feature for Cygwin** (we don't want to open it for any Windows subsytem checking for `OSInfo().is_windows` unless someone requests it)