### PR TITLE
range resolver: use multiple remotes to resolve package dependencies

### DIFF
--- a/conans/client/graph/range_resolver.py
+++ b/conans/client/graph/range_resolver.py
@@ -167,17 +167,18 @@ class RangeResolver(object):
         if search_result is None:
             # Searching for just the name is much faster in remotes like Artifactory
             search_result = search_result_tmp = self._search_remotes(search_ref, remotes)
-            for remote_name,found_refs in search_result_tmp.items():
-                if found_refs:
-                    self._result.append("%s versions found in '%s' remote" % (search_ref, remote_name))
-                else:
-                    self._result.append("%s versions not found in remotes")
-                # We don't want here to resolve the revision that should be done in the proxy
-                # as any other regular flow
-                found_refs = [ref.copy_clear_rev() for ref in found_refs or []]
-                search_result[remote_name] = found_refs
-                # Empty list, just in case it returns None
-            self._cached_remote_found[search_ref] = search_result
+            if search_result_tmp:
+                for remote_name,found_refs in search_result_tmp.items():
+                    if found_refs:
+                        self._result.append("%s versions found in '%s' remote" % (search_ref, remote_name))
+                    else:
+                        self._result.append("%s versions not found in remotes")
+                    # We don't want here to resolve the revision that should be done in the proxy
+                    # as any other regular flow
+                    found_refs = [ref.copy_clear_rev() for ref in found_refs or []]
+                    search_result[remote_name] = found_refs
+                    # Empty list, just in case it returns None
+                self._cached_remote_found[search_ref] = search_result
         if search_result:
             for remote_name,found_refs in search_result.items():
                 result = self._resolve_version(version_range, found_refs), remote_name

--- a/conans/client/graph/range_resolver.py
+++ b/conans/client/graph/range_resolver.py
@@ -163,8 +163,8 @@ class RangeResolver(object):
 
     def _resolve_remote(self, search_ref, version_range, remotes):
         # We should use ignorecase=False, we want the exact case!
-        found_refs_remote_dict = self._cached_remote_found.get(search_ref, (None))
-        if found_refs_remote_dict is None:
+        search_result = self._cached_remote_found.get(search_ref, (None))
+        if search_result is None:
             # Searching for just the name is much faster in remotes like Artifactory
             search_result = search_result_tmp = self._search_remotes(search_ref, remotes)
             for remote_name,found_refs in search_result_tmp.items():
@@ -175,10 +175,10 @@ class RangeResolver(object):
                 # We don't want here to resolve the revision that should be done in the proxy
                 # as any other regular flow
                 found_refs = [ref.copy_clear_rev() for ref in found_refs or []]
-                search_result[remote_name]=found_refs
+                search_result[remote_name] = found_refs
                 # Empty list, just in case it returns None
             self._cached_remote_found[search_ref] = search_result
-        if found_refs:
+        if search_result:
             for remote_name,found_refs in search_result.items():
                 result = self._resolve_version(version_range, found_refs), remote_name
                 if result[0] != None:


### PR DESCRIPTION
Suggested bugfix for issue #6743 : Querying all remotes for dependencies when using version ranges
