### PR TITLE
Fix Sun C/C++ Compiler Version Detection

### DIFF
--- a/conans/client/conf/detect.py
+++ b/conans/client/conf/detect.py
@@ -57,7 +57,11 @@ def _sun_cc_compiler(output, compiler_exe="cc"):
     try:
         _, out = detect_runner('%s -V' % compiler_exe)
         compiler = "sun-cc"
-        installed_version = re.search("([0-9]+\.[0-9]+)", out).group()
+        installed_version = re.search("Sun C.*([0-9]+\.[0-9]+)", out)
+        if installed_version:
+            installed_version = installed_version.group(1)
+        else:
+            installed_version = re.search("([0-9]+\.[0-9]+)", out).group()
         if installed_version:
             output.success("Found %s %s" % (compiler, installed_version))
             return compiler, installed_version


### PR DESCRIPTION
This fix the bug where the output of `suncc -V` reads:
```
cc: Studio 12.5 Sun C 5.14 SunOS_sparc 2016/05/31
```
and causes 12.5 rather than 5.14 to be captured as the version number of the C compiler.

Changelog: (Bugfix):

Fix https://github.com/conan-io/conan/issues/6749
