### PR TITLE
Markdown generator

### DIFF
--- a/conans/client/generators/__init__.py
+++ b/conans/client/generators/__init__.py
@@ -17,6 +17,7 @@ from .deploy import DeployGenerator
 from .gcc import GCCGenerator
 from .json_generator import JsonGenerator
 from .make import MakeGenerator
+from .markdown import MarkdownGenerator
 from .premake import PremakeGenerator
 from .qbs import QbsGenerator
 from .qmake import QmakeGenerator
@@ -81,6 +82,8 @@ registered_generators.add("b2", B2Generator)
 registered_generators.add("premake", PremakeGenerator)
 registered_generators.add("make", MakeGenerator)
 registered_generators.add("deploy", DeployGenerator)
+registered_generators.add("md", MarkdownGenerator)
+registered_generators.add("markdown", MarkdownGenerator)
 
 
 def write_generators(conanfile, path, output):

--- a/conans/client/generators/__init__.py
+++ b/conans/client/generators/__init__.py
@@ -82,7 +82,6 @@ registered_generators.add("b2", B2Generator)
 registered_generators.add("premake", PremakeGenerator)
 registered_generators.add("make", MakeGenerator)
 registered_generators.add("deploy", DeployGenerator)
-registered_generators.add("md", MarkdownGenerator)
 registered_generators.add("markdown", MarkdownGenerator)
 
 

--- a/conans/client/generators/markdown.py
+++ b/conans/client/generators/markdown.py
@@ -1,0 +1,94 @@
+from jinja2 import Template
+import textwrap
+from conans.model import Generator
+from conans.client.graph.graph import RECIPE_VIRTUAL
+
+
+requirement_tpl = Template(textwrap.dedent("""
+    # {{ name }}/{{ cpp_info.version }}
+
+    ---
+    **Note.-** If this package belongs to ConanCenter, you can find more information [here](https://conan.io/center/{{ name }}/{{ cpp_info.version }}/).
+
+    ---
+
+    Information for consumers:
+
+    {%- if cpp_info.libs %}
+    * Libraries: ``{{ "``, ``".join(cpp_info.libs) }}``
+    {%- endif %}
+    {%- if cpp_info.system_libs %}
+    * Systems libs: ``{{ "``, ``".join(cpp_info.system_libs) }}``
+    {%- endif %}
+    {%- if cpp_info.defines %}
+    * Preprocessor definitions: ``{{ "``, ``".join(cpp_info.defines) }}``
+    {%- endif %}
+    {%- if cpp_info.cflags %}
+    * C_FLAGS: ``{{ "``, ``".join(cpp_info.cflags) }}``
+    {%- endif %}
+    {%- if cpp_info.cxxflags %}
+    * CXX_FLAGS: ``{{ "``, ``".join(cpp_info.cxxflags) }}``
+    {%- endif %}
+
+    Read below how to use this package using different
+    [generators](https://docs.conan.io/en/latest/reference/generators.html). In order to use
+    these generators they have to be listed in the _conanfile.py_ file or using the command
+    line ``--generator/-g`` in the ``conan install`` command.
+
+
+    ## ``cmake`` generator
+
+    Add these lines to your *CMakeLists.txt*
+
+    ```cmake
+    include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
+    conan_basic_setup(TARGETS)
+
+    target_link_libraries(<library_name> {{ cpp_info.get_name("cmake") }}::{{ name }})
+    ```
+
+
+    ## ``cmake_find_package`` generator
+    {% set cmake_find_package_name = cpp_info.get_name("cmake_find_package") %}
+
+    Add these lines to your *CMakeLists.txt*
+
+    ```cmake
+    find_package({{ cmake_find_package_name }})
+
+    target_link_libraries(<library_name> {{ cmake_find_package_name }}::{{ cmake_find_package_name }})
+    ```
+
+    If you are using the
+    [CMake build helper](https://docs.conan.io/en/latest/reference/build_helpers/cmake.html) then
+    you need to use the ``cmake`` generator too to adjust the value of CMake variables based on the
+    value of Conan ones:
+
+    ```cmake
+    include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
+    conan_basic_setup(TARGETS)
+
+    find_package({{ cmake_find_package_name }})
+
+    target_link_libraries(<library_name> {{ cmake_find_package_name }}::{{ cmake_find_package_name }})
+    ```
+
+
+"""))
+
+
+class MarkdownGenerator(Generator):
+
+    @property
+    def filename(self):
+        pass
+
+    @property
+    def content(self):
+        ret = {}
+        for name, cpp_info in self.conanfile.deps_cpp_info.dependencies:
+            ret["{}.md".format(name)] = requirement_tpl.render(
+                name=name,
+                cpp_info=cpp_info
+            )
+        return ret

--- a/conans/client/generators/markdown.py
+++ b/conans/client/generators/markdown.py
@@ -24,7 +24,7 @@ requirement_tpl = Template(textwrap.dedent("""
     {%- if required_by %}
     * ``{{ name }}`` is required by:
     {%- for dep_name, dep_cpp_info in required_by %}
-    [{{ dep_name }}/{{ dep_cpp_info.version }}]({{ dep_name }}.md)
+    [{{ dep_name }}/{{ dep_cpp_info.version }}]({{ dep_name }}.md){% if not loop.last %}, {% endif %}
     {%- endfor %}
     {%- endif %}
     {% endif %}


### PR DESCRIPTION
Changelog: Feature: Add `markdown` generator, it exposes useful information to consume the installed packages.
Docs: https://github.com/conan-io/docs/pull/1638

This PR adds a ``markdown``/``md`` generator to generate a Markdown file for each of the dependencies installed by Conan.

Besides showing useful information about each package and how to use it with different generators (add copy/paste snippet), it is trying to help with a pain some users may be facing right now: with the addition of ``cpp_info.names["<generator>"]]`` we usually need to have a look to the actual ``conanfile.py`` of the recipe or to the generated ``FindXXXX.cmake`` file in order to know the name of the target.

yea or nay? other ideas based on this one?



![Mar-29-2020 19-49-23](https://user-images.githubusercontent.com/1406456/77856300-73fbd980-71f6-11ea-9f41-cf151734d482.gif)
