### PR TITLE
Feature: handle C++ standard for Intel C++ compiler

### DIFF
--- a/conans/client/build/cppstd_flags.py
+++ b/conans/client/build/cppstd_flags.py
@@ -22,13 +22,17 @@ def cppstd_from_settings(settings):
     return compiler_cppstd or cppstd
 
 
-def cppstd_flag(compiler, compiler_version, cppstd):
+def cppstd_flag(compiler, compiler_version, cppstd, compiler_base=None):
     if not compiler or not compiler_version or not cppstd:
         return ""
+
+    cppstd_intel = _cppstd_intel_visualstudio if compiler_base == "Visual Studio" else \
+        _cppstd_intel_gcc
     func = {"gcc": _cppstd_gcc,
             "clang": _cppstd_clang,
             "apple-clang": _cppstd_apple_clang,
-            "Visual Studio": _cppstd_visualstudio}.get(str(compiler), None)
+            "Visual Studio": _cppstd_visualstudio,
+            "intel": cppstd_intel}.get(str(compiler), None)
     flag = None
     if func:
         flag = func(str(compiler_version), str(cppstd))
@@ -38,21 +42,27 @@ def cppstd_flag(compiler, compiler_version, cppstd):
 def cppstd_flag_new(settings):
     compiler = settings.get_safe("compiler")
     compiler_version = settings.get_safe("compiler.version")
+    compiler_base = settings.get_safe("compiler.base")
     cppstd = cppstd_from_settings(settings)
-    return cppstd_flag(compiler, compiler_version, cppstd)
+    return cppstd_flag(compiler, compiler_version, cppstd, compiler_base)
 
 
 def cppstd_default(settings):
     if getattr(settings, "get_safe", None):
         compiler = settings.get_safe("compiler")
         compiler_version = settings.get_safe("compiler.version")
+        compiler_base = settings.get_safe("compiler.base")
     else:
         compiler = str(settings.compiler)
         compiler_version = str(settings.compiler.version)
+        compiler_base = str(settings.compiler.base)
+    intel_cppstd_default = _intel_visual_cppstd_default if compiler_base == "Visual Studio" \
+        else _intel_gcc_cppstd_default
     default = {"gcc": _gcc_cppstd_default(compiler_version),
                "clang": _clang_cppstd_default(compiler_version),
                "apple-clang": "gnu98",  # Confirmed in apple-clang 9.1 with a simple "auto i=1;"
-               "Visual Studio": _visual_cppstd_default(compiler_version)}.get(str(compiler), None)
+               "Visual Studio": _visual_cppstd_default(compiler_version),
+               "intel": intel_cppstd_default(compiler_version)}.get(str(compiler), None)
     return default
 
 
@@ -69,6 +79,14 @@ def _visual_cppstd_default(compiler_version):
     if Version(compiler_version) >= "14":  # VS 2015 update 3 only
         return "14"
     return None
+
+
+def _intel_visual_cppstd_default(_):
+    return None
+
+
+def _intel_gcc_cppstd_default(_):
+    return "gnu98"
 
 
 def _cppstd_visualstudio(visual_version, cppstd):
@@ -215,3 +233,40 @@ def _cppstd_gcc(gcc_version, cppstd):
             "17": v17, "gnu17": vgnu17,
             "20": v20, "gnu20": vgnu20}.get(cppstd)
     return "-std=%s" % flag if flag else None
+
+
+def _cppstd_intel_common(intel_version, cppstd, vgnu98, vgnu0x):
+    # https://software.intel.com/en-us/cpp-compiler-developer-guide-and-reference-std-qstd
+    # https://software.intel.com/en-us/articles/intel-cpp-compiler-release-notes
+    # NOTE: there are only gnu++98 and gnu++0x, and only for Linux/macOS
+    v98 = v11 = v14 = v17 = v20 = None
+    vgnu11 = vgnu14 = vgnu17 = vgnu20 = None
+
+    if Version(intel_version) >= "12":
+        v11 = "c++0x"
+        vgnu11 = vgnu0x
+    if Version(intel_version) >= "14":
+        v11 = "c++11"
+        vgnu11 = vgnu0x
+    if Version(intel_version) >= "16":
+        v14 = "c++14"
+    if Version(intel_version) >= "18":
+        v17 = "c++17"
+    if Version(intel_version) >= "19.1":
+        v20 = "c++20"
+
+    return {"98": v98, "gnu98": vgnu98,
+            "11": v11, "gnu11": vgnu11,
+            "14": v14, "gnu14": vgnu14,
+            "17": v17, "gnu17": vgnu17,
+            "20": v20, "gnu20": vgnu20}.get(cppstd)
+
+
+def _cppstd_intel_gcc(intel_version, cppstd):
+    flag = _cppstd_intel_common(intel_version, cppstd, "gnu++98", "gnu++0x")
+    return "-std=%s" % flag if flag else None
+
+
+def _cppstd_intel_visualstudio(intel_version, cppstd):
+    flag = _cppstd_intel_common(intel_version, cppstd, None, None)
+    return "/Qstd=%s" % flag if flag else None

--- a/conans/test/unittests/client/build/cpp_std_flags_test.py
+++ b/conans/test/unittests/client/build/cpp_std_flags_test.py
@@ -5,16 +5,20 @@ from conans.test.utils.conanfile import MockSettings
 from conans.tools import cppstd_flag
 
 
-def _make_cppstd_flag(compiler, compiler_version, cppstd):
+def _make_cppstd_flag(compiler, compiler_version, cppstd=None, compiler_base=None):
     settings = MockSettings({"compiler": compiler,
                              "compiler.version": compiler_version,
                              "compiler.cppstd": cppstd})
+    if compiler_base:
+        settings.values["compiler.base"] = compiler_base
     return cppstd_flag(settings)
 
 
-def _make_cppstd_default(compiler, compiler_version):
+def _make_cppstd_default(compiler, compiler_version, compiler_base=None):
     settings = MockSettings({"compiler": compiler,
                              "compiler.version": compiler_version})
+    if compiler_base:
+        settings.values["compiler.base"] = compiler_base
     return cppstd_default(settings)
 
 
@@ -208,3 +212,83 @@ class CompilerFlagsTest(unittest.TestCase):
         self.assertEqual(_make_cppstd_default("Visual Studio", "13"), None)
         self.assertEqual(_make_cppstd_default("Visual Studio", "14"), "14")
         self.assertEqual(_make_cppstd_default("Visual Studio", "15"), "14")
+
+    def test_intel_visual_cppstd_defaults(self):
+        self.assertEquals(_make_cppstd_default("intel", "19", "Visual Studio"), None)
+
+    def test_intel_gcc_cppstd_defaults(self):
+        self.assertEquals(_make_cppstd_default("intel", "19", "gcc"), 'gnu98')
+
+    def test_intel_visual_cppstd_flag(self):
+        self.assertEquals(_make_cppstd_flag("intel", "19.1", "gnu98", "Visual Studio"), None)
+        self.assertEquals(_make_cppstd_flag("intel", "19.1", "11", "Visual Studio"), '/Qstd=c++11')
+        self.assertEquals(_make_cppstd_flag("intel", "19.1", "14", "Visual Studio"), '/Qstd=c++14')
+        self.assertEquals(_make_cppstd_flag("intel", "19.1", "17", "Visual Studio"), '/Qstd=c++17')
+        self.assertEquals(_make_cppstd_flag("intel", "19.1", "20", "Visual Studio"), '/Qstd=c++20')
+
+        self.assertEquals(_make_cppstd_flag("intel", "19", "gnu98", "Visual Studio"), None)
+        self.assertEquals(_make_cppstd_flag("intel", "19", "11", "Visual Studio"), '/Qstd=c++11')
+        self.assertEquals(_make_cppstd_flag("intel", "19", "14", "Visual Studio"), '/Qstd=c++14')
+        self.assertEquals(_make_cppstd_flag("intel", "19", "17", "Visual Studio"), '/Qstd=c++17')
+        self.assertEquals(_make_cppstd_flag("intel", "19", "20", "Visual Studio"), None)
+
+        self.assertEquals(_make_cppstd_flag("intel", "17", "gnu98", "Visual Studio"), None)
+        self.assertEquals(_make_cppstd_flag("intel", "17", "11", "Visual Studio"), '/Qstd=c++11')
+        self.assertEquals(_make_cppstd_flag("intel", "17", "14", "Visual Studio"), '/Qstd=c++14')
+        self.assertEquals(_make_cppstd_flag("intel", "17", "17", "Visual Studio"), None)
+        self.assertEquals(_make_cppstd_flag("intel", "17", "20", "Visual Studio"), None)
+
+        self.assertEquals(_make_cppstd_flag("intel", "15", "gnu98", "Visual Studio"), None)
+        self.assertEquals(_make_cppstd_flag("intel", "15", "11", "Visual Studio"), '/Qstd=c++11')
+        self.assertEquals(_make_cppstd_flag("intel", "15", "14", "Visual Studio"), None)
+        self.assertEquals(_make_cppstd_flag("intel", "15", "17", "Visual Studio"), None)
+        self.assertEquals(_make_cppstd_flag("intel", "15", "20", "Visual Studio"), None)
+
+        self.assertEquals(_make_cppstd_flag("intel", "12", "gnu98", "Visual Studio"), None)
+        self.assertEquals(_make_cppstd_flag("intel", "12", "11", "Visual Studio"), '/Qstd=c++0x')
+        self.assertEquals(_make_cppstd_flag("intel", "12", "14", "Visual Studio"), None)
+        self.assertEquals(_make_cppstd_flag("intel", "12", "17", "Visual Studio"), None)
+        self.assertEquals(_make_cppstd_flag("intel", "12", "20", "Visual Studio"), None)
+
+        self.assertEquals(_make_cppstd_flag("intel", "11", "gnu98", "Visual Studio"), None)
+        self.assertEquals(_make_cppstd_flag("intel", "11", "11", "Visual Studio"), None)
+        self.assertEquals(_make_cppstd_flag("intel", "11", "14", "Visual Studio"), None)
+        self.assertEquals(_make_cppstd_flag("intel", "11", "17", "Visual Studio"), None)
+        self.assertEquals(_make_cppstd_flag("intel", "11", "20", "Visual Studio"), None)
+
+    def test_intel_gcc_cppstd_flag(self):
+        self.assertEquals(_make_cppstd_flag("intel", "19.1", "gnu98", "gcc"), '-std=gnu++98')
+        self.assertEquals(_make_cppstd_flag("intel", "19.1", "11", "gcc"), '-std=c++11')
+        self.assertEquals(_make_cppstd_flag("intel", "19.1", "14", "gcc"), '-std=c++14')
+        self.assertEquals(_make_cppstd_flag("intel", "19.1", "17", "gcc"), '-std=c++17')
+        self.assertEquals(_make_cppstd_flag("intel", "19.1", "20", "gcc"), '-std=c++20')
+
+        self.assertEquals(_make_cppstd_flag("intel", "19", "gnu98", "gcc"), '-std=gnu++98')
+        self.assertEquals(_make_cppstd_flag("intel", "19", "11", "gcc"), '-std=c++11')
+        self.assertEquals(_make_cppstd_flag("intel", "19", "14", "gcc"), '-std=c++14')
+        self.assertEquals(_make_cppstd_flag("intel", "19", "17", "gcc"), '-std=c++17')
+        self.assertEquals(_make_cppstd_flag("intel", "19", "20", "gcc"), None)
+
+        self.assertEquals(_make_cppstd_flag("intel", "17", "gnu98", "gcc"), '-std=gnu++98')
+        self.assertEquals(_make_cppstd_flag("intel", "17", "11", "gcc"), '-std=c++11')
+        self.assertEquals(_make_cppstd_flag("intel", "17", "14", "gcc"), '-std=c++14')
+        self.assertEquals(_make_cppstd_flag("intel", "17", "17", "gcc"), None)
+        self.assertEquals(_make_cppstd_flag("intel", "17", "20", "gcc"), None)
+
+        self.assertEquals(_make_cppstd_flag("intel", "15", "gnu98", "gcc"), '-std=gnu++98')
+        self.assertEquals(_make_cppstd_flag("intel", "15", "11", "gcc"), '-std=c++11')
+        self.assertEquals(_make_cppstd_flag("intel", "15", "14", "gcc"), None)
+        self.assertEquals(_make_cppstd_flag("intel", "15", "17", "gcc"), None)
+        self.assertEquals(_make_cppstd_flag("intel", "15", "20", "gcc"), None)
+
+        self.assertEquals(_make_cppstd_flag("intel", "12", "gnu98", "gcc"), '-std=gnu++98')
+        self.assertEquals(_make_cppstd_flag("intel", "12", "11", "gcc"), '-std=c++0x')
+        self.assertEquals(_make_cppstd_flag("intel", "12", "14", "gcc"), None)
+        self.assertEquals(_make_cppstd_flag("intel", "12", "17", "gcc"), None)
+        self.assertEquals(_make_cppstd_flag("intel", "12", "20", "gcc"), None)
+
+        self.assertEquals(_make_cppstd_flag("intel", "11", "gnu98", "gcc"), '-std=gnu++98')
+        self.assertEquals(_make_cppstd_flag("intel", "11", "11", "gcc"), None)
+        self.assertEquals(_make_cppstd_flag("intel", "11", "14", "gcc"), None)
+        self.assertEquals(_make_cppstd_flag("intel", "11", "17", "gcc"), None)
+        self.assertEquals(_make_cppstd_flag("intel", "11", "20", "gcc"), None)


### PR DESCRIPTION
related: #5699
the PR goes on top of recently merged #6744 

Changelog: Feature: handle C++ standard flag for Intel C++ compiler
Docs:omit

- [x] Refer to the issue that supports this Pull Request.
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 

<sup>**Note:** By default this PR will skip the slower tests and will use a limited set of python versions. Check [here](https://github.com/conan-io/conan/blob/develop/.github/PR_INCREASE_TESTING.md) how to increase the testing level by writing some tags in the current PR body text.</sup>
