### PR TITLE
Update Sun C compiler version in settings.yml

### DIFF
--- a/conans/client/conf/__init__.py
+++ b/conans/client/conf/__init__.py
@@ -55,7 +55,7 @@ _t_default_settings_yml = Template(textwrap.dedent("""
     arch: [x86, x86_64, ppc32be, ppc32, ppc64le, ppc64, armv4, armv4i, armv5el, armv5hf, armv6, armv7, armv7hf, armv7s, armv7k, armv8, armv8_32, armv8.3, sparc, sparcv9, mips, mips64, avr, s390, s390x, asm.js, wasm, sh4le]
     compiler:
         sun-cc:
-            version: ["5.10", "5.11", "5.12", "5.13", "5.14"]
+            version: ["5.10", "5.11", "5.12", "5.13", "5.14", "5.15"]
             threads: [None, posix]
             libcxx: [libCstd, libstdcxx, libstlport, libstdc++]
         gcc: &gcc


### PR DESCRIPTION
Changelog: Fix: Add Sun C compiler version 5.15 into default settings.yml.
Docs: Omit

Since June 2017, the Oracle Developer Studio 12.6 has Sun C compiler version 5.15. This is missing in the default settings.yml.


