### PR TITLE
Fix cmake target name in markdown generator

### DIFF
--- a/conans/client/generators/markdown.py
+++ b/conans/client/generators/markdown.py
@@ -67,7 +67,7 @@ requirement_tpl = Template(textwrap.dedent("""
     include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
     conan_basic_setup(TARGETS)
 
-    target_link_libraries(<library_name> {{ cpp_info.get_name("cmake") }}::{{ name }})
+    target_link_libraries(<library_name> CONAN_PKG::{{ cpp_info.get_name("cmake") }})
     ```
 
 


### PR DESCRIPTION
closes: #6773

Changelog: Bugfix: correct the `cmake` generator target name in the `markdown` generator output
Docs: omit

- [x] Refer to the issue that supports this Pull Request.
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 

<sup>**Note:** By default this PR will skip the slower tests and will use a limited set of python versions. Check [here](https://github.com/conan-io/conan/blob/develop/.github/PR_INCREASE_TESTING.md) how to increase the testing level by writing some tags in the current PR body text.</sup>
