### PR TITLE
Fix exception for Python 2

### DIFF
--- a/conans/__init__.py
+++ b/conans/__init__.py
@@ -21,5 +21,5 @@ OAUTH_TOKEN = "oauth_token"
 SERVER_CAPABILITIES = [COMPLEX_SEARCH_CAPABILITY, REVISIONS]  # Server is always with revisions
 DEFAULT_REVISION_V1 = "0"
 
-__version__ = '1.24.0'
+__version__ = '1.24.1'
 

--- a/conans/util/windows.py
+++ b/conans/util/windows.py
@@ -89,7 +89,7 @@ def path_shortener(path, short_paths):
         domainname = "%s\%s" % (userdomain, username) if userdomain else username
         cmd = r'cacls %s /E /G "%s":F' % (short_home, domainname)
         subprocess.check_output(cmd, stderr=subprocess.STDOUT)  # Ignoring any returned output, quiet
-    except (subprocess.CalledProcessError, FileNotFoundError):
+    except (subprocess.CalledProcessError, EnvironmentError):
         # cmd can fail if trying to set ACL in non NTFS drives, ignoring it.
         pass
 


### PR DESCRIPTION
Changelog: Bugfix: Avoid `FileNotFoundError` as it is not compatible with Python 2.
Docs: omit

Closes https://github.com/conan-io/conan/issues/6784
