### PR TITLE
Remove python 2 category from Pypi

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -44,27 +44,28 @@ Please read https://docs.conan.io/en/latest/installation.html
 From binaries
 -------------
 
-We have installers for `most platforms here <http://conan.io>`__ but you
+We have installers for `most platforms here <http://conan.io>`_ but you
 can run **conan** from sources if you want.
 
 From pip
 --------
 
-Conan is compatible with Python 2 and Python 3.
+Conan is compatible with Python >= 3.5 (older versions can work, but they are
+`not supported <https://docs.conan.io/en/latest/installation.html#python-2-deprecation-notice>`_)
 
 - Install pip following `pip docs`_.
 - Install conan:
 
-    .. code-block:: bash
+  .. code-block:: bash
 
-        $ pip install conan
+      $ pip install conan
 
-You can also use `test.pypi.org <https://test.pypi.org/project/conan/#history>`_ repository to install development (non-stable) Conan versions:
+  You can also use `test.pypi.org <https://test.pypi.org/project/conan/#history>`_ repository to install development (non-stable) Conan versions:
 
 
-    .. code-block:: bash
+  .. code-block:: bash
 
-        $ pip install --index-url https://test.pypi.org/simple/ conan
+      $ pip install --index-url https://test.pypi.org/simple/ conan
 
 
 From Homebrew (OSx)
@@ -92,9 +93,9 @@ You can run **conan** client and server in Windows, MacOS, and Linux.
 
 - **Install in editable mode**
 
-    .. code-block:: bash
+  .. code-block:: bash
 
-        $ cd conan && sudo pip install -e .
+      $ cd conan && sudo pip install -e .
 
   If you are in Windows, using ``sudo`` is not required.
 

--- a/README.rst
+++ b/README.rst
@@ -24,7 +24,7 @@ Conan is a package manager for C and C++ developers:
   (CMake, MSBuild, Makefiles, Meson, etc).
 - Extensible: Its python based recipes, together with extensions points allows for great power and flexibility.
 - Large and active community, especially in Github (https://github.com/conan-io/conan) and Slack (https://cpplang.now.sh/ #conan channel).
-  This community also creates and maintains packages in Conan-center and Bincrafters repositories in Bintray.
+  This community also creates and maintains packages in ConanCenter and Bincrafters repositories in Bintray.
 - Stable. Used in production by many companies, since 1.0 there is a commitment not to break package recipes and documented behavior.
 
 
@@ -39,53 +39,22 @@ Conan is a package manager for C and C++ developers:
 Setup
 =====
 
-Please read https://docs.conan.io/en/latest/installation.html
+Please read https://docs.conan.io/en/latest/installation.html to know how to
+install and start using Conan. TL;DR: 
 
-From binaries
--------------
+.. code-block::
 
-We have installers for `most platforms here <http://conan.io>`_ but you
-can run **conan** from sources if you want.
-
-From pip
---------
-
-Conan is compatible with Python >= 3.5 (older versions can work, but they are
-`not supported <https://docs.conan.io/en/latest/installation.html#python-2-deprecation-notice>`_)
-
-- Install pip following `pip docs`_.
-- Install conan:
-
-  .. code-block:: bash
-
-      $ pip install conan
-
-  You can also use `test.pypi.org <https://test.pypi.org/project/conan/#history>`_ repository to install development (non-stable) Conan versions:
+   $ pip install conan
 
 
-  .. code-block:: bash
+Install a development version
+-----------------------------
 
-      $ pip install --index-url https://test.pypi.org/simple/ conan
-
-
-From Homebrew (OSx)
--------------------
-
-- Install Homebrew following `brew homepage`_.
-
-  .. code-block:: bash
-
-      $ brew update
-      $ brew install conan
-
-From source
------------
-
-You can run **conan** client and server in Windows, MacOS, and Linux.
+You can run **Conan** client and server in Windows, MacOS, and Linux.
 
 - **Install pip following** `pip docs`_.
 
-- **Clone conan repository:**
+- **Clone Conan repository:**
 
   .. code-block:: bash
 
@@ -99,7 +68,7 @@ You can run **conan** client and server in Windows, MacOS, and Linux.
 
   If you are in Windows, using ``sudo`` is not required.
 
-- **You are ready, try to run conan:**
+- **You are ready, try to run Conan:**
 
   .. code-block::
 
@@ -185,7 +154,7 @@ Before you can run the tests, you need to set a few environment variables first.
 
     $ export PYTHONPATH=$PYTHONPATH:$(pwd)
 
-On Windows it would be (while being in the conan root directory):
+On Windows it would be (while being in the Conan root directory):
 
 .. code-block:: bash
 
@@ -266,4 +235,3 @@ License
 
 .. _`pip docs`: https://pip.pypa.io/en/stable/installing/
 
-.. _`brew homepage`: http://brew.sh/

--- a/setup.py
+++ b/setup.py
@@ -38,12 +38,12 @@ exclude_test_packages = ["conans.test.{}*".format(d)
 
 
 def load_version():
-    '''Loads a file content'''
+    """ Loads a file content """
     filename = os.path.abspath(os.path.join(os.path.dirname(os.path.abspath(__file__)),
                                             "conans", "__init__.py"))
     with open(filename, "rt") as version_file:
         conan_init = version_file.read()
-        version = re.search("__version__ = '([0-9a-z.-]+)'", conan_init).group(1)
+        version = re.search(r"__version__ = '([0-9a-z.-]+)'", conan_init).group(1)
         return version
 
 
@@ -81,10 +81,10 @@ setup(
         'Intended Audience :: Developers',
         'Topic :: Software Development :: Build Tools',
         'License :: OSI Approved :: MIT License',
-        'Programming Language :: Python :: 2',
-        'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.6'
+        'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8'
     ],
 
     # What does your project relate to?


### PR DESCRIPTION
Changelog: omit
Docs: omit

Remove `Python :: 2` category from Pypi (https://github.com/conan-io/conan/issues/6784#issuecomment-608312987)

