### PR TITLE
Fix cmake target name in markdown generator

### DIFF
--- a/conans/client/generators/markdown.py
+++ b/conans/client/generators/markdown.py
@@ -67,7 +67,7 @@ requirement_tpl = Template(textwrap.dedent("""
     include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
     conan_basic_setup(TARGETS)
 
-    target_link_libraries(<library_name> {{ cpp_info.get_name("cmake") }}::{{ name }})
+    target_link_libraries(<library_name> CONAN_PKG::{{ cpp_info.get_name("cmake") }})
     ```
 
 


### PR DESCRIPTION
closes: #6773

Changelog: Bugfix: correct the `cmake` generator target name in the `markdown` generator output.
Docs: omit