### PR TITLE
Try to resume interrupted downloads in FileDownloader by using HTTP range requests

### DIFF
--- a/conans/client/rest/file_downloader.py
+++ b/conans/client/rest/file_downloader.py
@@ -43,8 +43,17 @@ class FileDownloader(object):
         return _call_with_retry(self._output, retry, retry_wait, self._download_file, url, auth,
                                 headers, file_path)
 
-    def _download_file(self, url, auth, headers, file_path):
+    def _download_file(self, url, auth, headers, file_path, try_resume=False):
         t1 = time.time()
+        if try_resume and file_path and os.path.exists(file_path):
+            range_start = os.path.getsize(file_path)
+        else:
+            range_start = 0
+
+        if range_start:
+            headers = headers.copy() if headers else {}
+            headers["range"] = "bytes={}-".format(range_start)
+
         try:
             response = self._requester.get(url, stream=True, verify=self._verify_ssl, auth=auth,
                                            headers=headers)
@@ -69,10 +78,11 @@ class FileDownloader(object):
 
         def write_chunks(chunks, path):
             ret = None
-            downloaded_size = 0
+            downloaded_size = range_start
             if path:
                 mkdir(os.path.dirname(path))
-                with open(path, 'wb') as file_handler:
+                mode = "ab" if range_start else "wb"
+                with open(path, mode) as file_handler:
                     for chunk in chunks:
                         assert ((six.PY3 and isinstance(chunk, bytes)) or
                                 (six.PY2 and isinstance(chunk, str)))
@@ -89,7 +99,7 @@ class FileDownloader(object):
         try:
             logger.debug("DOWNLOAD: %s" % url)
             total_length = response.headers.get('content-length') or len(response.content)
-            total_length = int(total_length)
+            total_length = range_start + int(total_length)
             description = "Downloading {}".format(os.path.basename(file_path)) if file_path else None
             progress = progress_bar.Progress(total_length, self._output, description)
 
@@ -97,13 +107,22 @@ class FileDownloader(object):
             encoding = response.headers.get('content-encoding')
             gzip = (encoding == "gzip")
 
+            # TODO: refactor Progress to allow setting an initial progress
+            progress._processed_size = range_start
+            progress._pb_update(range_start)
+
             written_chunks, total_downloaded_size = write_chunks(
                 progress.update(read_response(chunk_size)),
                 file_path
             )
 
             response.close()
-            if total_downloaded_size != total_length and not gzip:
+            if (
+                total_length > total_downloaded_size > range_start
+                and response.headers.get("accept-ranges") == "bytes"
+            ):
+                written_chunks = self._download_file(url, auth, headers, file_path, try_resume=True)
+            elif total_downloaded_size != total_length and not gzip:
                 raise ConanException("Transfer interrupted before "
                                      "complete: %s < %s" % (total_downloaded_size, total_length))
 

--- a/conans/client/rest/file_downloader.py
+++ b/conans/client/rest/file_downloader.py
@@ -124,8 +124,8 @@ class FileDownloader(object):
 
             response.close()
             if (
-                total_length > total_downloaded_size > range_start
-                and response.headers.get("accept-ranges") == "bytes"
+                file_path and total_length > total_downloaded_size > range_start
+                and response.headers.get("Accept-Ranges") == "bytes"
             ):
                 written_chunks = self._download_file(url, auth, headers, file_path, try_resume=True)
             elif (

--- a/conans/test/unittests/client/rest/downloader_test.py
+++ b/conans/test/unittests/client/rest/downloader_test.py
@@ -1,0 +1,82 @@
+import re
+import tempfile
+import unittest
+
+import six
+
+from conans.client.rest.file_downloader import FileDownloader
+from conans.test.utils.tools import TestBufferConanOutput
+from conans.util.files import load
+
+
+class _ConfigMock:
+    def __init__(self):
+        self.retry = 0
+        self.retry_wait = 0
+
+
+class MockResponse(object):
+    def __init__(self, data, transfer_size=None):
+        self.data = data
+        self.ok = True
+        self.status_code = 200
+        self.start = 0
+        self.size = len(self.data)
+        self.transfer_size = transfer_size or self.size
+        assert self.transfer_size <= self.size
+        self.headers = {"content-length": self.size, "content-encoding": "gzip",
+                        "accept-ranges": "bytes"}
+
+    def iter_content(self, size):
+        transfer_size = min(size, self.transfer_size)
+        pos = self.start
+        if pos >= len(self.data):
+            yield six.b("")
+        yield self.data[pos:pos + transfer_size]
+        pos += transfer_size
+
+    def close(self):
+        pass
+
+
+class MockRequester(object):
+    retry = 0
+    retry_wait = 0
+
+    def __init__(self, response):
+        self._response = response
+
+    def get(self, *_args, **kwargs):
+        headers = kwargs.get("headers") or {}
+        transfer_range = headers.get("range", "")
+        match = re.match(r"bytes=([0-9]+)-", transfer_range)
+        if match:
+            start = int(match.groups()[0])
+            assert start <= self._response.size
+            self._response.start = start
+
+        return self._response
+
+
+class DownloaderUnitTest(unittest.TestCase):
+    def setUp(self):
+        self.target = tempfile.mktemp()
+        self.out = TestBufferConanOutput()
+
+    def test_download_file_ok(self):
+        expected_content = six.b("some data")
+        requester = MockRequester(MockResponse(expected_content))
+        downloader = FileDownloader(requester=requester, output=self.out, verify=None,
+                                    config=_ConfigMock())
+        downloader.download("fake_url", file_path=self.target)
+        actual_content = load(self.target, binary=True)
+        self.assertEqual(expected_content, actual_content)
+
+    def test_download_file_interrupted(self):
+        expected_content = six.b("some data")
+        requester = MockRequester(MockResponse(expected_content, transfer_size=4))
+        downloader = FileDownloader(requester=requester, output=self.out, verify=None,
+                                    config=_ConfigMock())
+        downloader.download("fake_url", file_path=self.target)
+        actual_content = load(self.target, binary=True)
+        self.assertEqual(expected_content, actual_content)

--- a/conans/util/progress_bar.py
+++ b/conans/util/progress_bar.py
@@ -49,6 +49,10 @@ class Progress(object):
                                   file=self._output, unit="B", leave=False, dynamic_ncols=False,
                                   ascii=True, unit_scale=True, unit_divisor=1024)
 
+    def initial_value(self, value):
+        self._processed_size = value
+        self._pb_update(value)
+
     def _pb_update(self, chunk_size):
         if self._tqdm_bar is not None:
             self._tqdm_bar.update(chunk_size)


### PR DESCRIPTION
Changelog: Feature: Resume interrupted file downloads if server supports it.
Docs: Omit

Close #5708
Close #3610, 

- [x] Refer to the issue that supports this Pull Request.
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 
