### PR TITLE
improving error message for options in conanfile_txt

### DIFF
--- a/conans/client/loader.py
+++ b/conans/client/loader.py
@@ -238,7 +238,10 @@ class ConanFileLoader(object):
 
         conanfile.generators = parser.generators
 
-        options = OptionsValues.loads(parser.options)
+        try:
+            options = OptionsValues.loads(parser.options)
+        except Exception:
+            raise ConanException("Error while parsing [options] in conanfile")
         conanfile.options.values = options
         conanfile.options.initialize_upstream(profile.user_options)
 

--- a/conans/client/loader.py
+++ b/conans/client/loader.py
@@ -241,7 +241,8 @@ class ConanFileLoader(object):
         try:
             options = OptionsValues.loads(parser.options)
         except Exception:
-            raise ConanException("Error while parsing [options] in conanfile")
+            raise ConanException("Error while parsing [options] in conanfile\n"
+                                 "Options should be specified as 'pkg:option=value'")
         conanfile.options.values = options
         conanfile.options.initialize_upstream(profile.user_options)
 


### PR DESCRIPTION
Changelog: Fix: Improve error message when ``[options]`` are not specified correctly in conanfile.txt.
Docs: Omit

Close https://github.com/conan-io/conan/issues/6793