### PR TITLE
Use pep508 environment markers for conditional requirements

### DIFF
--- a/conans/requirements.txt
+++ b/conans/requirements.txt
@@ -14,3 +14,7 @@ deprecation>=2.0, <2.1
 tqdm>=4.28.1, <5
 Jinja2>=2.3, <3
 python-dateutil>=2.7.0, <3
+idna==2.6 ; sys_platform == "darwin" # Solving conflict, somehow is installing 2.7 when requests require 2.6
+cryptography>=1.3.4, <2.4.0 ; sys_platform == "darwin"
+pyOpenSSL>=16.0.0, <19.0.0 ; sys_platform == "darwin"
+

--- a/conans/requirements_osx.txt
+++ b/conans/requirements_osx.txt
@@ -1,3 +1,0 @@
-idna==2.6 # Solving conflict, somehow is installing 2.7 when requests require 2.6
-cryptography>=1.3.4, <2.4.0
-pyOpenSSL>=16.0.0, <19.0.0

--- a/setup.py
+++ b/setup.py
@@ -27,8 +27,6 @@ def get_requires(filename):
 
 
 project_requirements = get_requires("conans/requirements.txt")
-if platform.system() == "Darwin":
-    project_requirements.extend(get_requires("conans/requirements_osx.txt"))
 project_requirements.extend(get_requires("conans/requirements_server.txt"))
 dev_requirements = get_requires("conans/requirements_dev.txt")
 # The tests utils are used by conan-package-tools


### PR DESCRIPTION
Changelog: Fix: Use pep508 environment markers for defining Conan pip requirements.
Docs: Omit

- [x] Refer to the issue that supports this Pull Request.
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 

Close #6797 

#PYVERS: Macos@py27