### PR TITLE
Fix: set toolset for MSBuild in case of Intel C++

### DIFF
--- a/conans/client/build/msbuild.py
+++ b/conans/client/build/msbuild.py
@@ -5,7 +5,8 @@ import re
 from conans.client import tools
 from conans.client.build.visual_environment import (VisualStudioBuildEnvironment,
                                                     vs_build_type_flags, vs_std_cpp)
-from conans.client.tools.env import environment_append
+from conans.client.tools.env import environment_append, no_op
+from conans.client.tools.intel import compilervars
 from conans.client.tools.oss import cpu_count
 from conans.client.tools.win import vcvars_command
 from conans.errors import ConanException
@@ -95,7 +96,12 @@ class MSBuild(object):
                                        verbosity=verbosity,
                                        user_property_file_name=user_property_file_name)
             command = "%s && %s" % (vcvars, command)
-            return self._conanfile.run(command)
+            context = no_op()
+            if self._conanfile.settings.get_safe("compiler") == "Intel" and \
+                self._conanfile.settings.get_safe("compiler.base") == "Visual Studio":
+                context = compilervars(self._conanfile.settings, arch)
+            with context:
+                return self._conanfile.run(command)
 
     def get_command(self, project_file, props_file_path=None, targets=None, upgrade_project=True,
                     build_type=None, arch=None, parallel=True, toolset=None, platforms=None,

--- a/conans/client/tools/win.py
+++ b/conans/client/tools/win.py
@@ -132,8 +132,13 @@ MSVS_DEFAULT_TOOLSETS_INVERSE = {"v142": "16",
 def msvs_toolset(settings):
     toolset = settings.get_safe("compiler.toolset")
     if not toolset:
-        vs_version = settings.get_safe("compiler.version")
-        toolset = MSVS_DEFAULT_TOOLSETS.get(vs_version)
+        compiler_version = settings.get_safe("compiler.version")
+        if settings.get_safe("compiler") == "intel":
+            compiler_version = compiler_version if "." in compiler_version else \
+                "%s.0" % compiler_version
+            toolset = "Intel C++ Compiler " + compiler_version
+        else:
+            toolset = MSVS_DEFAULT_TOOLSETS.get(compiler_version)
     return toolset
 
 
@@ -382,8 +387,11 @@ def vcvars_command(conanfile=None, arch=None, compiler_version=None, force=False
     arch_setting = arch or conanfile.settings.get_safe("arch")
 
     compiler = conanfile.settings.get_safe("compiler")
+    compiler_base = conanfile.settings.get_safe("compiler.base")
     if compiler == 'Visual Studio':
         compiler_version = compiler_version or conanfile.settings.get_safe("compiler.version")
+    elif compiler_base == "Visual Studio":
+        compiler_version = compiler_version or conanfile.settings.get_safe("compiler.base.version")
     else:
         # vcvars might be still needed for other compilers, e.g. clang-cl or Intel C++,
         # as they might be using Microsoft STL and other tools

--- a/conans/test/unittests/client/build/msbuild_test.py
+++ b/conans/test/unittests/client/build/msbuild_test.py
@@ -338,3 +338,16 @@ class MSBuildTest(unittest.TestCase):
         msbuild.build("project_file.sln", arch="x86", property_file_name=props_file_path)
         self.assertIn("vcvarsall.bat\" x86", conanfile.command)
         self.assertIn("/p:Platform=\"x86\"", conanfile.command)
+
+    def test_intel(self):
+        settings = MockSettings({"build_type": "Debug",
+                                 "compiler": "intel",
+                                 "compiler.version": "19.1",
+                                 "compiler.base": "Visual Studio",
+                                 "compiler.base.version": "15",
+                                 "arch": "x86_64"})
+        expected_toolset = "Intel C++ Compiler 19.1"
+        conanfile = MockConanfile(settings)
+        msbuild = MSBuild(conanfile)
+        command = msbuild.get_command("project_should_flags_test_file.sln")
+        self.assertIn('/p:PlatformToolset="%s"' % expected_toolset, command)


### PR DESCRIPTION
/cc @danimtb @ohanar 

related: #5699
~~WIP as I can't get it working (yet)~~
~~running build from conan:~~
~~TRACKER : : error TRK0005: Failed to locate: "icl.exe". The system cannot find the file specified.~~

~~running plain **msbuild.exe** from the `x86 Native Tools Command Prompt` builds the project successfully.~~
~~I am currently testing on the modified **lcms/2.9** recipe, which uses `MSBuild` helper.~~
~~probably, there is some difference in environment.~~
~~if you can check locally as well, would be great.~~

Changelog: Fix: Set toolset for MSBuild in case of Intel C++.
Docs: omit

- [x] Refer to the issue that supports this Pull Request.
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 

<sup>**Note:** By default this PR will skip the slower tests and will use a limited set of python versions. Check [here](https://github.com/conan-io/conan/blob/develop/.github/PR_INCREASE_TESTING.md) how to increase the testing level by writing some tags in the current PR body text.</sup>
