### PR TITLE
Adding the improved dot file generator feature.

### DIFF
--- a/conans/client/graph/grapher.py
+++ b/conans/client/graph/grapher.py
@@ -11,9 +11,20 @@ from conans.errors import ConanException
 class ConanGrapher(object):
 
     def __init__(self, deps_graph):
+        """
+        Object to write the Conan dependency graph into a Graphviz Dot file
+        (https://www.graphviz.org/doc/info/lang.html)
+
+        :param deps_graph: Conan built-in Dependency Graph
+        """
         self._deps_graph = deps_graph
 
     def graph(self):
+        """
+        Creates the Dot file content.
+
+        :return: String with a content of the Dot file for the defined deps_graph.
+        """
         dot_graph = ['strict digraph {']
         dot_graph.append(self._dot_configuration)
         dot_graph.append('\n')
@@ -29,9 +40,21 @@ class ConanGrapher(object):
         return ''.join(dot_graph)
 
     def graph_file(self, output_filename):
+        """
+        Writes the defined deps_graph tree into a Dot file.
+
+        :param output_filename: filename of the output Dot file.
+        """
         save(output_filename, self.graph())
 
     def _add_single_nodes_to_graph(self, dot_graph):
+        """
+        Creates a nodes representation with all the fields to be displayed in the Dot file and
+        fills-in the nodes of the Dot graph (dot_graph) with this information.
+
+        :param dot_graph: String containing the DOT file structure (the Dot configuration)
+        :return: A Map of nodes identified by its display_name with all the useful fields.
+        """
         # Store list of build_requires nodes
         build_time_nodes = self._deps_graph.build_time_nodes()
 
@@ -113,6 +136,13 @@ class ConanGrapher(object):
         return nodes
 
     def _add_adjacency_matrix(self, nodes, dot_graph):
+        """
+        Fills in the adjancency matrix into the dot_graph string in the following form
+            "node_id" -> {"dep_1_id" "dep_2_id" ... "dep_n_id"}
+
+        :param nodes: A Map of nodes identified by its display_name with all the useful fields.
+        :param dot_graph: String containing the DOT file structure (the DOT configuration and nodes)
+        """
         for id in sorted(nodes.keys()):
             depends = nodes[id]['node'].neighbors()
             if depends:

--- a/conans/client/graph/grapher.py
+++ b/conans/client/graph/grapher.py
@@ -78,7 +78,7 @@ class ConanGrapher(object):
 
     node [
       style = "filled",
-      fontname = "Migu 1M",
+      fontname = "Helvetica",
       fontsize = "18",
       shape=rect,
       fillcolor=azure2,

--- a/conans/client/graph/grapher.py
+++ b/conans/client/graph/grapher.py
@@ -146,15 +146,12 @@ class ConanGrapher(object):
         for id in sorted(nodes.keys()):
             depends = nodes[id]['node'].neighbors()
             if depends:
-                deps_links = ""
-                for dep_node in depends:
-                    dep_node_id = dep_node.conanfile.display_name
-                    deps_links += ' "%s"' % dep_node_id
+                dep_links = " ".join('"%s"' % str(d.ref) for d in depends)
 
                 # Add nodes to matrix
                 dot_graph.append('    "{}" -> {{{}}}\n'.format(
                     id,
-                    deps_links
+                    dep_links
                 ))
 
     _dot_configuration = """

--- a/conans/client/graph/grapher.py
+++ b/conans/client/graph/grapher.py
@@ -73,7 +73,7 @@ class ConanGrapher(object):
       rankdir = TD,
       splines = ortho,
       ranksep = 1,
-      nodesep = 1
+      nodesep = 0.7
     ];
 
     node [

--- a/conans/client/graph/grapher.py
+++ b/conans/client/graph/grapher.py
@@ -7,6 +7,7 @@ from conans.client.installer import build_id
 from conans.util.files import save
 from conans.errors import ConanException
 
+
 class ConanGrapher(object):
 
     def __init__(self, deps_graph):
@@ -72,30 +73,29 @@ class ConanGrapher(object):
                 node_channel = ""
 
             nodes[node_id] = {
-              "node": node,
-              "name": node_name,
-              "version": node_version,
-              "user": node_user,
-              "channel": node_channel,
-              "is_root": node_id == root_id,
-              "build_requires": node in build_time_nodes
+                "node": node,
+                "name": node_name,
+                "version": node_version,
+                "user": node_user,
+                "channel": node_channel,
+                "is_root": node_id == root_id,
+                "build_requires": node in build_time_nodes
             }
-
 
         # Then iterate over the ordered set of nodes & write to dot graph
         for id in sorted(nodes.keys()):
             if nodes[id]['version'] and nodes[id]['user'] and nodes[id]['channel']:
-                dot_node = self._dot_node_template_with_user_channel\
-                                                  .replace("%NODE_NAME%", nodes[id]['name']) \
-                                                  .replace("%NODE_VERSION%", nodes[id]['version']) \
-                                                  .replace("%NODE_USER%", nodes[id]['user']) \
-                                                  .replace("%NODE_CHANNEL%", nodes[id]['channel'])
+                dot_node = self._dot_node_template_with_user_channel \
+                    .replace("%NODE_NAME%", nodes[id]['name']) \
+                    .replace("%NODE_VERSION%", nodes[id]['version']) \
+                    .replace("%NODE_USER%", nodes[id]['user']) \
+                    .replace("%NODE_CHANNEL%", nodes[id]['channel'])
             elif nodes[id]['version']:
                 dot_node = self._dot_node_template.replace("%NODE_NAME%", nodes[id]['name']) \
-                                                  .replace("%NODE_VERSION%", nodes[id]['version'])
+                    .replace("%NODE_VERSION%", nodes[id]['version'])
             else:
                 dot_node = self._dot_node_template_without_version_user_channel \
-                                                  .replace("%NODE_NAME%", nodes[id]['name'])
+                    .replace("%NODE_NAME%", nodes[id]['name'])
             # Color the nodes
             if nodes[id]['is_root']:
                 dot_node = self._dot_node_colors_template_root_node + dot_node
@@ -120,7 +120,8 @@ class ConanGrapher(object):
                 deps_links = ""
                 for dep_node in depends:
                     if dep_node.conanfile.name and dep_node.conanfile.version:
-                        dep_node_id = "{}/{}".format(dep_node.conanfile.name, dep_node.conanfile.version)
+                        dep_node_id = "{}/{}".format(dep_node.conanfile.name,
+                                                     dep_node.conanfile.version)
                     elif dep_node.conanfile.name:
                         dep_node_id = dep_node.conanfile.name
                     else:
@@ -173,6 +174,7 @@ class ConanGrapher(object):
        <tr><td align="center"><font point-size="12">%NODE_VERSION%</font></td></tr>
      </table>>];"""
 
+
 class ConanHTMLGrapher(object):
     def __init__(self, deps_graph, cache_folder):
         self._deps_graph = deps_graph
@@ -220,7 +222,7 @@ class ConanHTMLGrapher(object):
             fulllabel.append("<ul>")
             fulllabel = "".join(fulllabel)
 
-            if node in build_time_nodes:   # TODO: May use build_require_context information
+            if node in build_time_nodes:  # TODO: May use build_require_context information
                 shape = "ellipse"
             else:
                 shape = "box"

--- a/conans/client/graph/grapher.py
+++ b/conans/client/graph/grapher.py
@@ -17,7 +17,7 @@ class ConanGrapher(object):
         graph_lines.append('\n')
         # First, create the nodes
         for node in self._deps_graph.nodes:
-            node_id = self._create_dot_node_name_from_display_name(node.conanfile.display_name)
+            node_id = node.conanfile.display_name
             node_name = node.conanfile.name if node.conanfile.name else node.conanfile.display_name
             node_version = node.conanfile.version if node.conanfile.version else ""
             try:
@@ -42,26 +42,18 @@ class ConanGrapher(object):
             else:
                 dot_node = self._dot_node_main_node_template
 
-            graph_lines.append('%s %s\n' % (node_id, dot_node))
+            graph_lines.append('    "%s" %s\n' % (node_id, dot_node))
 
         # Then, the adjacency matrix
         for node in self._deps_graph.nodes:
             depends = node.neighbors()
-            dot_node = self._create_dot_node_name_from_display_name(node.conanfile.display_name)
+            dot_node = node.conanfile.display_name
             if depends:
-                depends = " ".join('"%s"' % self._create_dot_node_name_from_display_name(str(d.ref))
-                                                for d in depends)
+                depends = " ".join('"%s"' % str(d.ref) for d in depends)
                 graph_lines.append('    "%s" -> {%s}\n' % (dot_node, depends))
 
         graph_lines.append('}\n')
         return ''.join(graph_lines)
-
-    def _create_dot_node_name_from_display_name(self, display_name):
-        """
-        Convert the display_name into a dot-label-like format (i.e. letters, numbers and '_')
-        :rtype: String containing the info to be used as a dot node label.
-        """
-        return re.sub(r"[^A-Za-z0-9]", "_", display_name)
 
     def graph_file(self, output_filename):
         save(output_filename, self.graph())

--- a/conans/client/graph/grapher.py
+++ b/conans/client/graph/grapher.py
@@ -15,13 +15,20 @@ class ConanGrapher(object):
         graph_lines = ['strict digraph {']
         graph_lines.append(self._dot_configuration)
         graph_lines.append('\n')
-        # First, create the nodes
-        graph_nodes = self._deps_graph.by_levels()
+
+        # Store list of build_requires nodes
         build_time_nodes = self._deps_graph.build_time_nodes()
+
+        # Store the root node
+        root_id = self._deps_graph.root.conanfile.display_name
+
+        # First, create the nodes
         for node in self._deps_graph.nodes:
+            # Node id is name/version, unless there's no name & version
             node_id = node.conanfile.display_name
             node_name = node.conanfile.name if node.conanfile.name else node.conanfile.display_name
             node_version = node.conanfile.version if node.conanfile.version else ""
+
             try:
                 node_user = node.conanfile.user
             except ConanException:
@@ -47,11 +54,16 @@ class ConanGrapher(object):
             else:
                 dot_node = self._dot_node_template_without_name_version_user_channel
 
-            if node in build_time_nodes:   # TODO: May use build_require_context information
-                dot_node = self._dot_node_template_build_requires + dot_node
-            else:
-                dot_node = self._dot_node_template_requires + dot_node
+            # Color the nodes
+            if node_id == root_id:  # root node
+                dot_node = self._dot_node_colors_template_root_node + dot_node
+            elif node in build_time_nodes:  # build_requires
+                # TODO: May use build_require_context information
+                dot_node = self._dot_node_colors_template_build_requires + dot_node
+            else:  # requires
+                dot_node = self._dot_node_colors_template_requires + dot_node
 
+            # Add single node to graph
             graph_lines.append('    "%s" %s\n' % (node_id, dot_node))
 
         # Then, the adjacency matrix
@@ -88,8 +100,9 @@ class ConanGrapher(object):
     edge [
       style = solid,
     ];"""
-    _dot_node_template_build_requires = """[ fillcolor=lightyellow, color=gold """
-    _dot_node_template_requires = """[ fillcolor=azure, color=dodgerblue """
+    _dot_node_colors_template_root_node = """[ fillcolor=mintcream, color=limegreen """
+    _dot_node_colors_template_build_requires = """[ fillcolor=lightyellow, color=gold """
+    _dot_node_colors_template_requires = """[ fillcolor=azure, color=dodgerblue """
     _dot_node_template_without_name_version_user_channel = """ """
     _dot_node_template_without_version_user_channel = """ label=<
      <table border="0" cellborder="0" cellspacing="0">

--- a/conans/client/graph/grapher.py
+++ b/conans/client/graph/grapher.py
@@ -52,15 +52,14 @@ class ConanGrapher(object):
             if node.conanfile.name and node.conanfile.version:
                 node_name = node.conanfile.name
                 node_version = node.conanfile.version
-                node_id = "{}/{}".format(node.conanfile.name, node.conanfile.version)
             elif node.conanfile.name:
                 node_name = node.conanfile.name
                 node_version = ""
-                node_id = node_name
             else:
                 node_name = node.conanfile.display_name
                 node_version = ""
-                node_id = node_name
+
+            node_id = node.conanfile.display_name
 
             try:
                 node_user = node.conanfile.user
@@ -119,14 +118,7 @@ class ConanGrapher(object):
             if depends:
                 deps_links = ""
                 for dep_node in depends:
-                    if dep_node.conanfile.name and dep_node.conanfile.version:
-                        dep_node_id = "{}/{}".format(dep_node.conanfile.name,
-                                                     dep_node.conanfile.version)
-                    elif dep_node.conanfile.name:
-                        dep_node_id = dep_node.conanfile.name
-                    else:
-                        dep_node_id = dep_node.conanfile.display_name
-
+                    dep_node_id = dep_node.conanfile.display_name
                     deps_links += ' "%s"' % dep_node_id
 
                 # Add nodes to matrix
@@ -148,19 +140,17 @@ class ConanGrapher(object):
       style = "filled",
       fontname = "Helvetica",
       fontsize = "18",
-      shape=rect,
-      fillcolor=azure2,
-      color=dodgerblue4
+      shape=rect
     ];
     edge [
-      style = solid,
+      style = solid
     ];"""
     _dot_node_colors_template_root_node = """[ fillcolor=mintcream, color=limegreen """
     _dot_node_colors_template_build_requires = """[ fillcolor=lightyellow, color=gold """
     _dot_node_colors_template_requires = """[ fillcolor=azure, color=dodgerblue """
     _dot_node_template_without_version_user_channel = """ label=<
      <table border="0" cellborder="0" cellspacing="0">
-       <tr><td align="center"><b>%NODE_NAME%</b></td></tr></i></td></tr>
+       <tr><td align="center"><b>%NODE_NAME%</b></td></tr>
      </table>>];"""
     _dot_node_template_with_user_channel = """ label=<
      <table border="0" cellborder="0" cellspacing="0">

--- a/conans/client/graph/grapher.py
+++ b/conans/client/graph/grapher.py
@@ -60,12 +60,7 @@ class ConanGrapher(object):
 
         # Store the root node
         root_node = self._deps_graph.root
-        if root_node.conanfile.name and root_node.conanfile.version:
-            root_id = "{}/{}".format(root_node.conanfile.name, root_node.conanfile.version)
-        elif root_node.conanfile.name:
-            root_id = root_node.conanfile.name
-        else:
-            root_id = root_node.conanfile.display_name
+        root_id = root_node.conanfile.display_name
 
         # Store nodes in ordered dict, for deterministic output to dot file
         nodes = {}

--- a/conans/client/graph/grapher.py
+++ b/conans/client/graph/grapher.py
@@ -81,15 +81,15 @@ class ConanGrapher(object):
       fontname = "Migu 1M",
       fontsize = "18",
       shape=rect,
-      fillcolor=goldenrod1,
-      color=goldenrod4
+      fillcolor=azure2,
+      color=dodgerblue4
     ];
 
     edge [
       style = solid,
     ];
     """
-    _dot_node_main_node_template = """ [ fillcolor=gray95, color=gray20cona]; """
+    _dot_node_main_node_template = """ [ fillcolor=goldenrod1, color=goldenrod4]; """
     _dot_node_template_with_user_channel = """ [ label=<
      <table border="0" cellborder="0" cellspacing="0">
        <tr><td align="center"><b>%NODE_NAME%</b></td></tr>

--- a/conans/client/graph/grapher.py
+++ b/conans/client/graph/grapher.py
@@ -12,7 +12,7 @@ class ConanGrapher(object):
         self._deps_graph = deps_graph
 
     def graph(self):
-        graph_lines = ['strict digraph {\n']
+        graph_lines = ['strict digraph {']
         graph_lines.append(self._dot_configuration)
         graph_lines.append('\n')
         # First, create the nodes
@@ -67,7 +67,6 @@ class ConanGrapher(object):
       ranksep = 1,
       nodesep = 0.7
     ];
-
     node [
       style = "filled",
       fontname = "Helvetica",
@@ -76,25 +75,22 @@ class ConanGrapher(object):
       fillcolor=azure2,
       color=dodgerblue4
     ];
-
     edge [
       style = solid,
-    ];
-    """
-    _dot_node_main_node_template = """ [ fillcolor=goldenrod1, color=goldenrod4]; """
+    ];"""
+    _dot_node_main_node_template = """ [ fillcolor=goldenrod1, color=goldenrod4];"""
     _dot_node_template_with_user_channel = """ [ label=<
      <table border="0" cellborder="0" cellspacing="0">
        <tr><td align="center"><b>%NODE_NAME%</b></td></tr>
        <tr><td align="center"><font point-size="12">%NODE_VERSION%</font></td></tr>
        <tr><td align="center"><i><font point-size="12">%NODE_USER%/%NODE_CHANNEL%</font></i></td></tr>
-     </table>>];
-    """
+     </table>>];"""
     _dot_node_template = """ [ label=<
      <table border="0" cellborder="0" cellspacing="0">
        <tr><td align="left"><b>%NODE_NAME%</b></td></tr>
        <tr><td align="center"><font point-size="12">%NODE_VERSION%</font></td></tr>
-     </table>>];
-    """
+     </table>>];"""
+
 class ConanHTMLGrapher(object):
     def __init__(self, deps_graph, cache_folder):
         self._deps_graph = deps_graph

--- a/conans/test/functional/command/info_test.py
+++ b/conans/test/functional/command/info_test.py
@@ -136,7 +136,16 @@ class InfoTest(unittest.TestCase):
             self.assertEqual(ref.channel, "stable")
 
         def check_digraph_line(line):
-            self.assertTrue(dot_regex.match(line))
+
+            self.assertTrue(dot_regex.match(line) or
+                            dot_format_section_regex.match(line) or
+                            dot_format_value_regex.match(line) or
+                            dot_node_format_regex.match(line) or
+                            dot_node_format_body_regex.match(line)
+                            )
+
+            if (not dot_regex.match(line)):
+                return
 
             node_matches = node_regex.findall(line)
 
@@ -164,6 +173,10 @@ class InfoTest(unittest.TestCase):
 
         node_regex = re.compile(r'"([^"]+)"')
         dot_regex = re.compile(r'^\s+"[^"]+" -> {"[^"]+"( "[^"]+")*}$')
+        dot_format_section_regex = re.compile(r'^\s+(graph|edge|node)+\s+\[')
+        dot_format_value_regex = re.compile(r'^\s+[a-zA-Z]+\s+=\s[a-zA-Z]+\,+|^\s+];$')
+        dot_node_format_regex = re.compile(r'\s+"([^"]+)"\s+\[\s+label=\<')
+        dot_node_format_body_regex = re.compile(r'\s+(<[a-zA-Z0-9=\=\s\\ / \-"]+>|[a-zA-Z0-9\s\.])+')
 
         self.client.run("info . --graph", assert_error=True)
 

--- a/conans/test/functional/command/info_test.py
+++ b/conans/test/functional/command/info_test.py
@@ -136,10 +136,9 @@ class InfoTest(unittest.TestCase):
             self.assertEqual(ref.channel, "stable")
 
         def check_digraph_line(line):
-
             self.assertTrue(dot_regex.match(line) or
                             dot_format_section_regex.match(line) or
-                            dot_format_value_regex.match(line) or
+                            dot_format_section_value_regex.match(line) or
                             dot_node_format_regex.match(line) or
                             dot_node_format_body_regex.match(line)
                             )
@@ -152,7 +151,7 @@ class InfoTest(unittest.TestCase):
             parent_reference = node_matches[0]
             deps_ref = [ConanFileReference.loads(references) for references in node_matches[1:]]
 
-            if parent_reference == "conanfile.py (Hello0/0.1)":
+            if parent_reference == "Hello0/0.1":
                 parent_ref = ConanFileReference("Hello0", None, None, None, validate=False)
             else:
                 parent_ref = ConanFileReference.loads(parent_reference)
@@ -172,11 +171,13 @@ class InfoTest(unittest.TestCase):
         create_export(test_deps, "Hello0")
 
         node_regex = re.compile(r'"([^"]+)"')
-        dot_regex = re.compile(r'^\s+"[^"]+" -> {"[^"]+"( "[^"]+")*}$')
-        dot_format_section_regex = re.compile(r'^\s+(graph|edge|node)+\s+\[')
-        dot_format_value_regex = re.compile(r'^\s+[a-zA-Z]+\s+=\s[a-zA-Z]+\,+|^\s+];$')
-        dot_node_format_regex = re.compile(r'\s+"([^"]+)"\s+\[\s+label=\<')
-        dot_node_format_body_regex = re.compile(r'\s+(<[a-zA-Z0-9=\=\s\\ / \-"]+>|[a-zA-Z0-9\s\.])+')
+        dot_regex = re.compile(r'\s+"[^"]+" -> {(\s*"[^"]+")*}$')
+        dot_format_section_regex = re.compile(r'\s+(graph|edge|node)+\s+\[$')
+        dot_format_section_value_regex = re.compile(r'\s+[a-zA-Z]+\s*=\s*[a-zA-Z"0-9.]+\,*|^\s+];$')
+        dot_node_format_regex = \
+            re.compile(r'\s+"([^"]+)"\s+\[\s*(\s*[a-zA-Z]+\s*=\s*[a-zA-Z"0-9.]+\,*)*\s*label=<$')
+        dot_node_format_body_regex =\
+            re.compile(r'\s+(<[a-zA-Z0-9=\s\\\/\-"]+>|[a-zA-Z0-9\s\./]|>];)+$')
 
         self.client.run("info . --graph", assert_error=True)
 

--- a/conans/test/functional/command/info_test.py
+++ b/conans/test/functional/command/info_test.py
@@ -151,7 +151,7 @@ class InfoTest(unittest.TestCase):
             parent_reference = node_matches[0]
             deps_ref = [ConanFileReference.loads(references) for references in node_matches[1:]]
 
-            if parent_reference == "Hello0/0.1":
+            if parent_reference == "conanfile.py (Hello0/0.1)":
                 parent_ref = ConanFileReference("Hello0", None, None, None, validate=False)
             else:
                 parent_ref = ConanFileReference.loads(parent_reference)

--- a/conans/test/functional/command/info_test.py
+++ b/conans/test/functional/command/info_test.py
@@ -155,7 +155,7 @@ class InfoTest(unittest.TestCase):
         def check_file(filename):
             with open(filename) as dot_file_contents:
                 lines = dot_file_contents.readlines()
-                self.assertEqual(lines[0], "digraph {\n")
+                self.assertEqual(lines[0], "strict digraph {\n")
                 for line in lines[1:-1]:
                     check_digraph_line(line)
                 self.assertEqual(lines[-1], "}\n")


### PR DESCRIPTION
Changelog: (Feature): This pull request contains an improved version of the `dot` output generation for the dependency graph. It cosiders the following facts
- Each node is connected as much as 1 times with any other node (the graph is not `strict`). 
- Each dependency is colorized in blue (following Conan colors)
- The root of the graph is colorized in yellow. 
- The edges are collocated improving the readability (not the size of the plot)

Apart from this, some additional stylish settings have been defined
- The nodes are a little bit separated (better reading)
- The font is less 'coding-style' 

Considering the following `conanfile.py`:

```python
from conans import ConanFile, CMake

class MyPkg(ConanFile):
    name = "mypkg"
    version = "1.2.3-rc1"
        
    def requirements(self):
        self.requires("openexr/2.4.0")
        self.requires("libjpeg/9d")
        self.requires("leptonica/1.78.0")
        self.requires("openssl/1.1.1f")
        self.requires("zlib/1.2.11")
        self.requires("libtiff/4.1.0")
        self.requires("cimg/2.8.3")
        self.requires("folly/2019.10.21.00")
        self.requires("zstd/1.4.3")
        self.requires("opencv/4.1.1@conan/stable")
        
    def build_requirements(self):
        self.build_requires("nasm/2.14")
        self.build_requires("gtest/1.8.1", force_host_context=True)  # 'host' context (our library will link with it
```

The original output when running

```
conan info . --graph=deps.dot
dot deps.dot -Tpng -o deps.png
```
was
![image](https://user-images.githubusercontent.com/1688725/78689008-28cc7f80-78f6-11ea-9d52-8807b610c205.png)

and the improved one is 

![image](https://user-images.githubusercontent.com/1688725/78690200-72699a00-78f7-11ea-96b3-d362e5feec0d.png)

## Additional changes

Apart from the changes indicated above, additional changes in collaboration with my colleague @saimusdev, which was also interested on this feature has been added.
- A clear differenciation based on colors for the following items
  - The package for which the diagraph is going to be plotted (in green)
  - The Build_Deps (in yellow)
- Some reordering of the nodes to have always 100% reproducible graphs. It was observed that from one ran to another, the graph was not estrictly the same. The origin for this was that the inner graph is not always created following the same ordering, and therfore, the dot file also changed. To avoid this
  - The nodes are ordered (alphabetically)
  - The dependencies are ordered (alphabetically)
- Improved documentation in the modified class. 

With this latest changes, the Diagraph shown below looks now like

![image](https://user-images.githubusercontent.com/1688725/78979906-15e7c400-7b1d-11ea-9937-c22e7b3392de.png)

Closes: #6814
Docs: This contribution has no reflection in the documentation because i found no (graphical) reference to it. Because this change is only an aesthetic change in the generated dot file, i consider not needed to create nothing special on this.

- [x] Refer to the issue that supports this Pull Request.
- [ ] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 

<sup>**Note:** By default this PR will skip the slower tests and will use a limited set of python versions. Check [here](https://github.com/conan-io/conan/blob/develop/.github/PR_INCREASE_TESTING.md) how to increase the testing level by writing some tags in the current PR body text.</sup>
