### PR TITLE
Fix: handle compiler flags for Intel C++ (AutoToolsBuildEnvironment, Meson)

### DIFF
--- a/conans/client/build/autotools_environment.py
+++ b/conans/client/build/autotools_environment.py
@@ -241,15 +241,15 @@ class AutoToolsBuildEnvironment(object):
         """Not the -L"""
         ret = copy.copy(self._deps_cpp_info.sharedlinkflags)
         ret.extend(self._deps_cpp_info.exelinkflags)
-        ret.extend(format_frameworks(self._deps_cpp_info.frameworks, compiler=self._compiler))
-        ret.extend(format_framework_paths(self._deps_cpp_info.framework_paths, compiler=self._compiler))
-        arch_flag = architecture_flag(compiler=self._compiler, os=self._os, arch=self._arch)
+        ret.extend(format_frameworks(self._deps_cpp_info.frameworks, self._conanfile.settings))
+        ret.extend(format_framework_paths(self._deps_cpp_info.framework_paths, self._conanfile.settings))
+        arch_flag = architecture_flag(self._conanfile.settings)
         if arch_flag:
             ret.append(arch_flag)
 
-        sysf = sysroot_flag(self._deps_cpp_info.sysroot, win_bash=self._win_bash,
-                            subsystem=self.subsystem,
-                            compiler=self._compiler)
+        sysf = sysroot_flag(self._deps_cpp_info.sysroot, self._conanfile.settings,
+                            win_bash=self._win_bash,
+                            subsystem=self.subsystem)
         if sysf:
             ret.append(sysf)
 
@@ -257,22 +257,22 @@ class AutoToolsBuildEnvironment(object):
             os_build, _ = get_build_os_arch(self._conanfile)
             if not hasattr(self._conanfile, 'settings_build'):
                 os_build = os_build or self._os
-            ret.extend(rpath_flags(os_build, self._compiler, self._deps_cpp_info.lib_paths))
+            ret.extend(rpath_flags(self._conanfile.settings, os_build, self._deps_cpp_info.lib_paths))
 
         return ret
 
     def _configure_flags(self):
         ret = copy.copy(self._deps_cpp_info.cflags)
-        arch_flag = architecture_flag(compiler=self._compiler, os=self._os, arch=self._arch)
+        arch_flag = architecture_flag(self._conanfile.settings)
         if arch_flag:
             ret.append(arch_flag)
-        btfs = build_type_flags(compiler=self._compiler, build_type=self._build_type,
-                                vs_toolset=self._conanfile.settings.get_safe("compiler.toolset"))
+        btfs = build_type_flags(self._conanfile.settings)
         if btfs:
             ret.extend(btfs)
-        srf = sysroot_flag(self._deps_cpp_info.sysroot, win_bash=self._win_bash,
-                           subsystem=self.subsystem,
-                           compiler=self._compiler)
+        srf = sysroot_flag(self._deps_cpp_info.sysroot,
+                           self._conanfile.settings,
+                           win_bash=self._win_bash,
+                           subsystem=self.subsystem)
         if srf:
             ret.append(srf)
         if self._compiler_runtime:
@@ -282,7 +282,7 @@ class AutoToolsBuildEnvironment(object):
 
     def _configure_cxx_flags(self):
         ret = copy.copy(self._deps_cpp_info.cxxflags)
-        cxxf = libcxx_flag(compiler=self._compiler, libcxx=self._libcxx)
+        cxxf = libcxx_flag(self._conanfile.settings)
         if cxxf:
             ret.append(cxxf)
         return ret
@@ -297,7 +297,7 @@ class AutoToolsBuildEnvironment(object):
             ret.append(btf)
 
         # CXX11 ABI
-        abif = libcxx_define(compiler=self._compiler, libcxx=self._libcxx)
+        abif = libcxx_define(self._conanfile.settings)
         if abif:
             ret.append(abif)
         return ret
@@ -313,18 +313,22 @@ class AutoToolsBuildEnvironment(object):
                         ret.append(arg)
             return ret
 
-        lib_paths = format_library_paths(self.library_paths, win_bash=self._win_bash,
-                                         subsystem=self.subsystem, compiler=self._compiler)
-        include_paths = format_include_paths(self.include_paths, win_bash=self._win_bash,
-                                             subsystem=self.subsystem, compiler=self._compiler)
+        lib_paths = format_library_paths(self.library_paths,
+                                         self._conanfile.settings,
+                                         win_bash=self._win_bash,
+                                         subsystem=self.subsystem)
+        include_paths = format_include_paths(self.include_paths,
+                                             self._conanfile.settings,
+                                             win_bash=self._win_bash,
+                                             subsystem=self.subsystem)
 
         ld_flags = append(self.link_flags, lib_paths)
         cpp_flags = append(include_paths, format_defines(self.defines))
-        libs = format_libraries(self.libs, compiler=self._compiler)
+        libs = format_libraries(self.libs, self._conanfile.settings)
 
         tmp_compilation_flags = copy.copy(self.flags)
         if self.fpic:
-            tmp_compilation_flags.append(pic_flag(self._compiler))
+            tmp_compilation_flags.append(pic_flag(self._conanfile.settings))
 
         cxx_flags = append(tmp_compilation_flags, self.cxx_flags, self.cppstd_flag)
         c_flags = tmp_compilation_flags

--- a/conans/client/build/cmake_flags.py
+++ b/conans/client/build/cmake_flags.py
@@ -301,7 +301,7 @@ class CMakeDefinitionsBuilder(object):
                 definitions['CONAN_CXX_FLAGS'] = flag
                 definitions['CONAN_C_FLAGS'] = flag
         else:  # arch_flag is only set for non Visual Studio
-            arch_flag = architecture_flag(compiler=compiler, os=os_, arch=arch)
+            arch_flag = architecture_flag(self._conanfile.settings)
             if arch_flag:
                 definitions['CONAN_CXX_FLAGS'] = arch_flag
                 definitions['CONAN_SHARED_LINKER_FLAGS'] = arch_flag

--- a/conans/client/build/compiler_flags.py
+++ b/conans/client/build/compiler_flags.py
@@ -9,24 +9,39 @@
     #   -LIBPATH, -D, -I, -ZI and so on.
 
 """
+
+from conans.client.tools.apple import is_apple_os
 from conans.client.tools.oss import cpu_count
 from conans.client.tools.win import unix_path
 
 
-def rpath_flags(os_build, compiler, lib_paths):
+GCC_LIKE = ['clang', 'apple-clang', 'gcc']
+
+
+def _base_compiler(settings):
+    return settings.get_safe("compiler.base") or settings.get_safe("compiler")
+
+
+# FIXME : pass conanfile instead of settings and os_build
+def rpath_flags(settings, os_build, lib_paths):
+    compiler = _base_compiler(settings)
     if not os_build:
         return []
-    if compiler in ("clang", "apple-clang", "gcc"):
-        rpath_separator = "," if os_build in ["Macos", "iOS", "watchOS", "tvOS"] else "="
+    if compiler in GCC_LIKE:
+        rpath_separator = "," if is_apple_os(os_build) else "="
         return ['-Wl,-rpath%s"%s"' % (rpath_separator, x.replace("\\", "/"))
                 for x in lib_paths if x]
     return []
 
 
-def architecture_flag(compiler, arch, os=None):
+def architecture_flag(settings):
     """
     returns flags specific to the target architecture and compiler
     """
+    compiler = settings.get_safe("compiler")
+    compiler_base = settings.get_safe("compiler.base")
+    arch = settings.get_safe("arch")
+    the_os = settings.get_safe("os")
     if not compiler or not arch:
         return ""
 
@@ -37,20 +52,27 @@ def architecture_flag(compiler, arch, os=None):
             return '-m32'
         elif str(arch) in ['s390']:
             return '-m31'
-        elif os == 'AIX':
+        elif str(the_os) == 'AIX':
             if str(arch) in ['ppc32']:
                 return '-maix32'
             elif str(arch) in ['ppc64']:
                 return '-maix64'
+    elif str(compiler) == "intel":
+        # https://software.intel.com/en-us/cpp-compiler-developer-guide-and-reference-m32-m64-qm32-qm64
+        if str(arch) == "x86":
+            return "/Qm32" if str(compiler_base) == "Visual Studio" else "-m32"
+        elif str(arch) == "x86_64":
+            return "/Qm64" if str(compiler_base) == "Visual Studio" else "-m64"
     return ""
 
 
-def libcxx_define(compiler, libcxx):
-
+def libcxx_define(settings):
+    compiler = _base_compiler(settings)
+    libcxx = settings.get_safe("compiler.libcxx")
     if not compiler or not libcxx:
         return ""
 
-    if str(compiler) in ['gcc', 'clang', 'apple-clang']:
+    if str(compiler) in GCC_LIKE:
         if str(libcxx) == 'libstdc++':
             return '_GLIBCXX_USE_CXX11_ABI=0'
         elif str(libcxx) == 'libstdc++11':
@@ -58,10 +80,12 @@ def libcxx_define(compiler, libcxx):
     return ""
 
 
-def libcxx_flag(compiler, libcxx):
+def libcxx_flag(settings):
     """
     returns flag specific to the target C++ standard library
     """
+    compiler = _base_compiler(settings)
+    libcxx = settings.get_safe("compiler.libcxx")
     if not compiler or not libcxx:
         return ""
     if str(compiler) in ['clang', 'apple-clang']:
@@ -79,20 +103,24 @@ def libcxx_flag(compiler, libcxx):
     return ""
 
 
-def pic_flag(compiler=None):
+def pic_flag(settings):
     """
     returns PIC (position independent code) flags, such as -fPIC
     """
+    compiler = _base_compiler(settings)
     if not compiler or compiler == 'Visual Studio':
         return ""
     return '-fPIC'
 
 
-def build_type_flags(compiler, build_type, vs_toolset=None):
+def build_type_flags(settings):
     """
     returns flags specific to the build type (Debug, Release, etc.)
     (-s, -g, /Zi, etc.)
     """
+    compiler = _base_compiler(settings)
+    build_type = settings.get_safe("build_type")
+    vs_toolset = settings.get_safe("compiler.toolset")
     if not compiler or not build_type:
         return ""
 
@@ -144,16 +172,17 @@ def build_type_define(build_type=None):
     returns definitions specific to the build type (Debug, Release, etc.)
     like DEBUG, _DEBUG, NDEBUG
     """
-    return 'NDEBUG' if build_type == 'Release' else ""
+    return 'NDEBUG' if build_type in ['Release', 'RelWithDebInfo', 'MinSizeRel'] else ""
 
 
-def adjust_path(path, win_bash=False, subsystem=None, compiler=None):
+def adjust_path(path, settings, win_bash=False, subsystem=None):
     """
     adjusts path to be safely passed to the compiler command line
     for Windows bash, ensures path is in format according to the subsystem
     for path with spaces, places double quotes around it
     converts slashes to backslashes, or vice versa
     """
+    compiler = _base_compiler(settings)
     if str(compiler) == 'Visual Studio':
         path = path.replace('/', '\\')
     else:
@@ -163,9 +192,10 @@ def adjust_path(path, win_bash=False, subsystem=None, compiler=None):
     return '"%s"' % path if ' ' in path else path
 
 
-def sysroot_flag(sysroot, win_bash=False, subsystem=None, compiler=None):
+def sysroot_flag(sysroot, settings, win_bash=False, subsystem=None):
+    compiler = _base_compiler(settings)
     if str(compiler) != 'Visual Studio' and sysroot:
-        sysroot = adjust_path(sysroot, win_bash=win_bash, subsystem=subsystem, compiler=compiler)
+        sysroot = adjust_path(sysroot, settings, win_bash=win_bash, subsystem=subsystem)
         return '--sysroot=%s' % sysroot
     return ""
 
@@ -184,23 +214,26 @@ include_path_option = "-I"
 visual_linker_option_separator = "-link"  # Further options will apply to the linker
 
 
-def format_include_paths(include_paths, win_bash=False, subsystem=None, compiler=None):
-    return ["%s%s" % (include_path_option, adjust_path(include_path, win_bash=win_bash,
-                                                       subsystem=subsystem, compiler=compiler))
+def format_include_paths(include_paths, settings, win_bash=False, subsystem=None):
+    return ["%s%s" % (include_path_option, adjust_path(include_path, settings, win_bash=win_bash,
+                                                       subsystem=subsystem))
             for include_path in include_paths if include_path]
 
 
-def format_library_paths(library_paths, win_bash=False, subsystem=None, compiler=None):
+def format_library_paths(library_paths, settings, win_bash=False, subsystem=None):
+    compiler = _base_compiler(settings)
     pattern = "-LIBPATH:%s" if str(compiler) == 'Visual Studio' else "-L%s"
-    return [pattern % adjust_path(library_path, win_bash=win_bash,
-                                  subsystem=subsystem, compiler=compiler)
+    return [pattern % adjust_path(library_path, settings, win_bash=win_bash,
+                                  subsystem=subsystem)
             for library_path in library_paths if library_path]
 
 
-def format_libraries(libraries, compiler=None):
+def format_libraries(libraries, settings):
     result = []
+    compiler = settings.get_safe("compiler")
+    compiler_base = settings.get_safe("compiler.base")
     for library in libraries:
-        if str(compiler) == 'Visual Studio':
+        if str(compiler) == 'Visual Studio' or str(compiler_base) == 'Visual Studio':
             if not library.endswith(".lib"):
                 library += ".lib"
             result.append(library)
@@ -213,21 +246,25 @@ def parallel_compiler_cl_flag(output=None):
     return "/MP%s" % cpu_count(output=output)
 
 
-def format_frameworks(frameworks, compiler=None):
+def format_frameworks(frameworks, settings):
     """
     returns an appropriate compiler flags to link with Apple Frameworks
     or an empty array, if Apple Frameworks aren't supported by the given compiler
     """
-    if str(compiler) not in ["clang", "gcc", "apple-clang"]:
+    compiler = settings.get_safe("compiler")
+    compiler_base = settings.get_safe("compiler.base")
+    if (str(compiler) not in GCC_LIKE) and (str(compiler_base) not in GCC_LIKE):
         return []
     return ["-framework %s" % framework for framework in frameworks]
 
 
-def format_framework_paths(framework_paths, compiler=None):
+def format_framework_paths(framework_paths, settings):
     """
     returns an appropriate compiler flags to specify Apple Frameworks search paths
     or an empty array, if Apple Frameworks aren't supported by the given compiler
     """
-    if str(compiler) not in ["clang", "gcc", "apple-clang"]:
+    compiler = settings.get_safe("compiler")
+    compiler_base = settings.get_safe("compiler.base")
+    if (str(compiler) not in GCC_LIKE) and (str(compiler_base) not in GCC_LIKE):
         return []
-    return ["-F %s" % adjust_path(framework_path) for framework_path in framework_paths]
+    return ["-F %s" % adjust_path(framework_path, settings) for framework_path in framework_paths]

--- a/conans/client/build/visual_environment.py
+++ b/conans/client/build/visual_environment.py
@@ -139,8 +139,7 @@ def vs_build_type_flags(settings, with_flags=True):
         ret.extend(format_defines([btd]))
     if with_flags:
         # When using to build a vs project we don't want to adjust these flags
-        btfs = build_type_flags("Visual Studio", build_type=build_type,
-                                vs_toolset=settings.get_safe("compiler.toolset"))
+        btfs = build_type_flags(settings)
         if btfs:
             ret.extend(btfs)
 

--- a/conans/client/generators/pkg_config.py
+++ b/conans/client/generators/pkg_config.py
@@ -69,9 +69,10 @@ class PkgConfigGenerator(Generator):
         if not hasattr(self.conanfile, 'settings_build'):
             os_build = os_build or self.conanfile.settings.get_safe("os")
 
-        rpaths = rpath_flags(os_build, self.compiler, ["${%s}" % libdir for libdir in libdir_vars])
-        frameworks = format_frameworks(cpp_info.frameworks, compiler=self.compiler)
-        framework_paths = format_framework_paths(cpp_info.framework_paths, compiler=self.compiler)
+        rpaths = rpath_flags(self.conanfile.settings, os_build, ["${%s}" % libdir for libdir in libdir_vars])
+        frameworks = format_frameworks(cpp_info.frameworks, self.conanfile.settings)
+        framework_paths = format_framework_paths(cpp_info.framework_paths, self.conanfile.settings)
+
         lines.append("Libs: %s" % _concat_if_not_empty([libdirs_flags,
                                                         libnames_flags,
                                                         shared_flags,

--- a/conans/client/generators/xcode.py
+++ b/conans/client/generators/xcode.py
@@ -29,7 +29,7 @@ FRAMEWORK_SEARCH_PATHS = $(inherited) {rootpaths} {framework_paths}
         self.cxx_compiler_flags = " ".join(deps_cpp_info.cxxflags)
         self.linker_flags = " ".join(deps_cpp_info.sharedlinkflags)
         self.rootpaths = " ".join('"%s"' % d.replace("\\", "/") for d in deps_cpp_info.rootpaths)
-        self.frameworks = " ".join(format_frameworks(deps_cpp_info.frameworks, compiler="apple-clang"))
+        self.frameworks = " ".join(format_frameworks(deps_cpp_info.frameworks, self.conanfile.settings))
         self.framework_paths = " ".join(deps_cpp_info.framework_paths)
         self.system_libs = " ".join(['-l%s' % lib for lib in deps_cpp_info.system_libs])
 

--- a/conans/test/functional/build_helpers/visual_environment_test.py
+++ b/conans/test/functional/build_helpers/visual_environment_test.py
@@ -154,12 +154,12 @@ class TestConan(ConanFile):
 
         result = {"Debug": "['-Zi', '-Ob0', '-Od']",
                   "Release": "['-DNDEBUG', '-O2', '-Ob2']",
-                  "RelWithDebInfo": "['-Zi', '-O2', '-Ob1']",
-                  "MinSizeRel": "['-O1', '-Ob1']"}
+                  "RelWithDebInfo": "['-DNDEBUG', '-Zi', '-O2', '-Ob1']",
+                  "MinSizeRel": "['-DNDEBUG', '-O1', '-Ob1']"}
         result_toolset_clang = {"Debug": "['-gline-tables-only', '-fno-inline', '-O0']",
                                 "Release": "['-DNDEBUG', '-O2']",
-                                "RelWithDebInfo": "['-gline-tables-only', '-O2', '-fno-inline']",
-                                "MinSizeRel": "[]"}
+                                "RelWithDebInfo": "['-DNDEBUG', '-gline-tables-only', '-O2', '-fno-inline']",
+                                "MinSizeRel": "['-DNDEBUG']"}
 
         for build_type in ["Debug", "Release", "RelWithDebInfo", "MinSizeRel"]:
             client.run("create . danimtb/testing -pr=profile -s build_type=%s" % build_type)

--- a/conans/test/unittests/client/build/compiler_flags_test.py
+++ b/conans/test/unittests/client/build/compiler_flags_test.py
@@ -8,6 +8,7 @@ from parameterized.parameterized import parameterized
 from conans.client.build.compiler_flags import adjust_path, architecture_flag, build_type_define, \
     build_type_flags, format_defines, format_include_paths, format_libraries, \
     format_library_paths, libcxx_define, libcxx_flag, pic_flag, sysroot_flag
+from conans.test.utils.conanfile import MockSettings
 
 
 class CompilerFlagsTest(unittest.TestCase):
@@ -34,8 +35,22 @@ class CompilerFlagsTest(unittest.TestCase):
                            ("gcc", "ppc32", "AIX", "-maix32"),
                            ("gcc", "ppc64", "AIX", "-maix64"),
                            ])
-    def test_arch_flag(self, compiler, arch, os, flag):
-        self.assertEqual(architecture_flag(compiler=compiler, arch=arch, os=os), flag)
+    def test_arch_flag(self, compiler, arch, the_os, flag):
+        settings = MockSettings({"compiler": compiler,
+                                 "arch": arch,
+                                 "os": the_os})
+        self.assertEqual(architecture_flag(settings), flag)
+
+    @parameterized.expand([("gcc", "x86", "-m32"),
+                           ("gcc", "x86_64", "-m64"),
+                           ("Visual Studio", "x86", "/Qm32"),
+                           ("Visual Studio", "x86_64", "/Qm64"),
+                           ])
+    def test_arch_flag_intel(self, base, arch, flag):
+        settings = MockSettings({"compiler": "intel",
+                                 "compiler.base": base,
+                                 "arch": arch})
+        self.assertEqual(architecture_flag(settings), flag)
 
     @parameterized.expand([("gcc", "libstdc++", "_GLIBCXX_USE_CXX11_ABI=0"),
                            ("gcc", "libstdc++11", "_GLIBCXX_USE_CXX11_ABI=1"),
@@ -45,7 +60,9 @@ class CompilerFlagsTest(unittest.TestCase):
                            ("Visual Studio", None, ""),
                            ])
     def test_libcxx_define(self, compiler, libcxx, define):
-        self.assertEqual(libcxx_define(compiler=compiler, libcxx=libcxx), define)
+        settings = MockSettings({"compiler": compiler,
+                                 "compiler.libcxx": libcxx})
+        self.assertEqual(libcxx_define(settings), define)
 
     @parameterized.expand([("gcc", "libstdc++", ""),
                            ("gcc", "libstdc++11", ""),
@@ -62,7 +79,9 @@ class CompilerFlagsTest(unittest.TestCase):
                            ("sun-cc", "libstdc++", "-library=stdcpp")
                            ])
     def test_libcxx_flags(self, compiler, libcxx, flag):
-        self.assertEqual(libcxx_flag(compiler=compiler, libcxx=libcxx), flag)
+        settings = MockSettings({"compiler": compiler,
+                                 "compiler.libcxx": libcxx})
+        self.assertEqual(libcxx_flag(settings), flag)
 
     @parameterized.expand([("cxx",),
                            ("gpp",),
@@ -73,18 +92,26 @@ class CompilerFlagsTest(unittest.TestCase):
                            ("ecpp",),
                            ("ecpp-ne",)])
     def test_libcxx_flags_qnx(self, libcxx):
-        arch_flags = libcxx_flag(compiler='qcc', libcxx=libcxx)
+        settings = MockSettings({"compiler": "qcc",
+                                 "compiler.libcxx": libcxx})
+        arch_flags = libcxx_flag(settings)
         self.assertEqual(arch_flags, '-Y _%s' % libcxx)
 
     def test_pic_flags(self):
-        flag = pic_flag()
+        flag = pic_flag(MockSettings({}))
         self.assertEqual(flag, '')
 
-        flags = pic_flag(compiler='gcc')
+        flags = pic_flag(MockSettings({"compiler": 'gcc'}))
         self.assertEqual(flags, '-fPIC')
 
-        flags = pic_flag(compiler='Visual Studio')
+        flags = pic_flag(MockSettings({"compiler": 'Visual Studio'}))
         self.assertEqual(flags, "")
+
+        flags = pic_flag(MockSettings({"compiler": 'intel', "compiler.base": "gcc"}))
+        self.assertEqual(flags, '-fPIC')
+
+        flags = pic_flag(MockSettings({"compiler": 'intel', "compiler.base": "Visual Studio"}))
+        self.assertEqual(flags, '')
 
     @parameterized.expand([("Visual Studio", "Debug", None, "-Zi -Ob0 -Od"),
                            ("Visual Studio", "Release", None, "-O2 -Ob2"),
@@ -112,58 +139,78 @@ class CompilerFlagsTest(unittest.TestCase):
                            ("sun-cc", "MinSizeRel", None, "-xO2 -xspace"),
                            ])
     def test_build_type_flags(self, compiler, build_type, vs_toolset, flags):
-        self.assertEqual(' '.join(build_type_flags(compiler=compiler, build_type=build_type, vs_toolset=vs_toolset)),
+        settings = MockSettings({"compiler": compiler,
+                                 "build_type": build_type,
+                                 "compiler.toolset": vs_toolset})
+        self.assertEqual(' '.join(build_type_flags(settings)),
                          flags)
 
     def test_build_type_define(self):
         define = build_type_define(build_type='Release')
         self.assertEqual(define, 'NDEBUG')
 
-    def test_adjust_path(self):
-        self.assertEqual('home/www', adjust_path('home\\www'))
-        self.assertEqual('home/www', adjust_path('home\\www', compiler='gcc'))
+        define = build_type_define(build_type='Debug')
+        self.assertEqual(define, '')
 
-        self.assertEqual('"home/www root"', adjust_path('home\\www root'))
-        self.assertEqual('"home/www root"', adjust_path('home\\www root', compiler='gcc'))
+        define = build_type_define(build_type='MinSizeRel')
+        self.assertEqual(define, 'NDEBUG')
+
+        define = build_type_define(build_type='RelWithDebInfo')
+        self.assertEqual(define, 'NDEBUG')
+
+    def test_adjust_path(self):
+        settings = MockSettings({"compiler": 'gcc'})
+        self.assertEqual('home/www', adjust_path('home\\www', MockSettings({})))
+        self.assertEqual('home/www', adjust_path('home\\www', settings))
+
+        self.assertEqual('"home/www root"', adjust_path('home\\www root', MockSettings({})))
+        self.assertEqual('"home/www root"', adjust_path('home\\www root', settings))
 
     @unittest.skipUnless(platform.system() == "Windows", "requires Windows")
     def test_adjust_path_visual_studio(self):
         #  NOTE : test cannot be run on *nix systems, as adjust_path uses
         # tools.unix_path which is Windows-only
-        self.assertEqual('home\\www', adjust_path('home/www', compiler='Visual Studio'))
+        settings = MockSettings({"compiler": 'Visual Studio'})
+        self.assertEqual('home\\www', adjust_path('home/www', settings))
         self.assertEqual('"home\\www root"',
-                          adjust_path('home/www root', compiler='Visual Studio'))
+                         adjust_path('home/www root', settings))
         self.assertEqual('home/www',
-                          adjust_path('home\\www', compiler='Visual Studio', win_bash=True))
+                         adjust_path('home\\www', settings, win_bash=True))
         self.assertEqual('home/www',
-                          adjust_path('home/www', compiler='Visual Studio', win_bash=True))
+                         adjust_path('home/www', settings, win_bash=True))
         self.assertEqual('"home/www root"',
-                          adjust_path('home\\www root', compiler='Visual Studio', win_bash=True))
+                         adjust_path('home\\www root', settings, win_bash=True))
         self.assertEqual('"home/www root"',
-                          adjust_path('home/www root', compiler='Visual Studio', win_bash=True))
+                         adjust_path('home/www root', settings, win_bash=True))
 
     def test_sysroot_flag(self):
-        sysroot = sysroot_flag(sysroot=None)
+        sysroot = sysroot_flag(sysroot=None, settings=MockSettings({}))
         self.assertEqual(sysroot, "")
 
-        sysroot = sysroot_flag(sysroot='sys/root', compiler='Visual Studio')
+        sysroot = sysroot_flag(sysroot='sys/root',
+                               settings=MockSettings({"compiler": "Visual Studio"}))
         self.assertEqual(sysroot, "")
 
-        sysroot = sysroot_flag(sysroot='sys/root')
+        sysroot = sysroot_flag(sysroot='sys/root', settings=MockSettings({}))
         self.assertEqual(sysroot, "--sysroot=sys/root")
 
     def test_format_defines(self):
         self.assertEqual(['-DFOO', '-DBAR=1'], format_defines(['FOO', 'BAR=1']))
 
     def test_format_include_paths(self):
-        self.assertEqual(['-Ipath1', '-I"with spaces"'], format_include_paths(['path1', 'with spaces']))
+        self.assertEqual(['-Ipath1', '-I"with spaces"'],
+                         format_include_paths(['path1', 'with spaces'], MockSettings({})))
 
     def test_format_library_paths(self):
-        self.assertEqual(['-Lpath1', '-L"with spaces"'], format_library_paths(['path1', 'with spaces']))
+        self.assertEqual(['-Lpath1', '-L"with spaces"'],
+                         format_library_paths(['path1', 'with spaces'], MockSettings({})))
         self.assertEqual(['-LIBPATH:path1', '-LIBPATH:"with spaces"'],
-                          format_library_paths(['path1', 'with spaces'], compiler='Visual Studio'))
+                         format_library_paths(['path1', 'with spaces'],
+                                              MockSettings({"compiler": "Visual Studio"})))
 
     def test_format_libraries(self):
-        self.assertEqual(['-llib1', '-llib2'], format_libraries(['lib1', 'lib2']))
-        self.assertEqual(['lib1.lib', 'lib2.lib'], format_libraries(['lib1', 'lib2'],
-                                                                     compiler='Visual Studio'))
+        self.assertEqual(['-llib1', '-llib2'],
+                         format_libraries(['lib1', 'lib2'], MockSettings({})))
+        self.assertEqual(['lib1.lib', 'lib2.lib'],
+                         format_libraries(['lib1', 'lib2'],
+                                          MockSettings({"compiler": "Visual Studio"})))

--- a/conans/test/unittests/client/generators/compiler_args_test.py
+++ b/conans/test/unittests/client/generators/compiler_args_test.py
@@ -101,7 +101,8 @@ class CompilerArgsTest(unittest.TestCase):
         gcc = GCCGenerator(conan_file)
         # GCC generator ignores the compiler setting, it is always gcc
         self.assertEqual('-Dmydefine1 -Ipath/to/include1 cxx_flag1 c_flag1 -m32 -O3 -s '
-                         '-DNDEBUG -Wl,-rpath="path/to/lib1" -Lpath/to/lib1 -lmylib',
+                         '-DNDEBUG -Wl,-rpath="path/to/lib1" -Lpath/to/lib1 -lmylib '
+                         '-D_GLIBCXX_USE_CXX11_ABI=0 -std=gnu++17',
                           gcc.content)
 
     def compiler_args_test(self):


### PR DESCRIPTION
related: #5699

this PR adds handling of compiler flags (e.g. PIC, arch, etc.) for Intel C++ compiler.
since for Intel C++ compiler flags are different for various compiler bases, I have changed most of the internal interfaces in **compiler_flags** module to accept **settings** object.
this should allow more flexibility.
this mostly impacts the `AutoToolsBuildEnvironmentHelper`, but also few generators and other build helpers using the **compiler_flags** functions.

locally tested on a few recipes: libiconv, libxml2, OpenSSL

Changelog: Fix: Handle compiler flags for Intel C++ (AutoToolsBuildEnvironment, Meson).
Docs: omit

- [x] Refer to the issue that supports this Pull Request.
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 

<sup>**Note:** By default this PR will skip the slower tests and will use a limited set of python versions. Check [here](https://github.com/conan-io/conan/blob/develop/.github/PR_INCREASE_TESTING.md) how to increase the testing level by writing some tags in the current PR body text.</sup>
