### PR TITLE
[fix] Test more package names converted to CamelCase in 'conan new -t' command

### DIFF
--- a/conans/client/cmd/new.py
+++ b/conans/client/cmd/new.py
@@ -250,7 +250,7 @@ def cmd_new(ref, header=False, pure_c=False, test=False, exports_sources=False, 
             user, channel = tokens[1].split("/")
         else:
             user, channel = "user", "channel"
-        package_name = re.sub(r"(?:^|_)(\w)", lambda x: x.group(1).upper(), name)
+        package_name = re.sub(r"(?:^|[\W_])(\w)", lambda x: x.group(1).upper(), name)
     except ValueError:
         raise ConanException("Bad parameter, please use full package name,"
                              "e.g.: MyLib/1.2.3@user/testing")

--- a/conans/client/cmd/new.py
+++ b/conans/client/cmd/new.py
@@ -250,9 +250,7 @@ def cmd_new(ref, header=False, pure_c=False, test=False, exports_sources=False, 
             user, channel = tokens[1].split("/")
         else:
             user, channel = "user", "channel"
-
-        pattern = re.compile('[\W_]+')
-        package_name = pattern.sub('', name).capitalize()
+        package_name = re.sub(r"(?:^|_)(\w)", lambda x: x.group(1).upper(), name)
     except ValueError:
         raise ConanException("Bad parameter, please use full package name,"
                              "e.g.: MyLib/1.2.3@user/testing")


### PR DESCRIPTION
Changelog: Bugfix: Variable `package_name` in `conan new -t <template>` command contains a _CamelCase_ version of the name of the package.
Docs: https://github.com/conan-io/docs/pull/1663

