### PR TITLE
Bugfix: enable C++20 on Apple Clang

### DIFF
--- a/conans/client/build/cppstd_flags.py
+++ b/conans/client/build/cppstd_flags.py
@@ -118,6 +118,10 @@ def _cppstd_apple_clang(clang_version, cppstd):
         v17 = "c++17"
         vgnu17 = "gnu++17"
 
+    if Version(clang_version) >= "10.0":
+        v20 = "c++2a"
+        vgnu20 = "gnu++2a"
+
     flag = {"98": v98, "gnu98": vgnu98,
             "11": v11, "gnu11": vgnu11,
             "14": v14, "gnu14": vgnu14,

--- a/conans/test/unittests/client/build/cpp_std_flags_test.py
+++ b/conans/test/unittests/client/build/cpp_std_flags_test.py
@@ -172,9 +172,12 @@ class CompilerFlagsTest(unittest.TestCase):
         self.assertEqual(_make_cppstd_flag("apple-clang", "9.1", "11"), '-std=c++11')
         self.assertEqual(_make_cppstd_flag("apple-clang", "9.1", "14"), '-std=c++14')
         self.assertEqual(_make_cppstd_flag("apple-clang", "9.1", "17"), "-std=c++17")
+        self.assertEqual(_make_cppstd_flag("apple-clang", "9.1", "20"), None)
 
         self.assertEqual(_make_cppstd_flag("apple-clang", "10.0", "17"), "-std=c++17")
+        self.assertEqual(_make_cppstd_flag("apple-clang", "10.0", "20"), "-std=c++2a")
         self.assertEqual(_make_cppstd_flag("apple-clang", "11.0", "17"), "-std=c++17")
+        self.assertEqual(_make_cppstd_flag("apple-clang", "11.0", "20"), "-std=c++2a")
 
     def test_apple_clang_cppstd_defaults(self):
         self.assertEqual(_make_cppstd_default("apple-clang", "2"), "gnu98")


### PR DESCRIPTION
closes: #6856 

nothing useful in [Release Notes](https://developer.apple.com/documentation/xcode_release_notes), so borrowed from [cmake](https://github.com/Kitware/CMake/blob/9116daf2cd69579bf6880059caf23eb3098c5515/Modules/Compiler/AppleClang-OBJCXX.cmake#L38)

Changelog: Bugfix: enable C++20 on Apple Clang.
Docs: omit

- [x] Refer to the issue that supports this Pull Request.
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 

<sup>**Note:** By default this PR will skip the slower tests and will use a limited set of python versions. Check [here](https://github.com/conan-io/conan/blob/develop/.github/PR_INCREASE_TESTING.md) how to increase the testing level by writing some tags in the current PR body text.</sup>
