### PR TITLE
Populate 'requires' returned by server's search enpoint

### DIFF
--- a/conans/client/conan_api.py
+++ b/conans/client/conan_api.py
@@ -877,10 +877,12 @@ class ConanAPIV1(object):
             if remote_ref.ordered_packages:
                 for package_id, properties in remote_ref.ordered_packages.items():
                     package_recipe_hash = properties.get("recipe_hash", None)
+                    # Artifactory uses field 'requires', conan_center 'full_requires'
+                    requires = properties.get("requires", []) or properties.get("full_requires", [])
                     search_recorder.add_package(remote_name, ref,
                                                 package_id, properties.get("options", []),
                                                 properties.get("settings", []),
-                                                properties.get("full_requires", []),
+                                                requires,
                                                 remote_ref.recipe_hash != package_recipe_hash)
         return search_recorder.get_info()
 


### PR DESCRIPTION
Changelog: Fix: Populate `requires` returned by the servers from the search endpoint using `requires` (Artifactory) or `full_requires` (conan_server) fields.
Docs: omit

Closes https://github.com/conan-io/conan/issues/6859
Close https://github.com/conan-io/conan/issues/6879

We cannot change `conan_server` implementation (breaking) and we cannot change Artifactory to return `full_requires` field
