### PR TITLE
Fix cmake tool when using MSVC target without compiler.version setting

### DIFF
--- a/conans/client/build/cmake.py
+++ b/conans/client/build/cmake.py
@@ -157,6 +157,10 @@ class CMake(object):
             #   to keep previous implementation, but any modern CMake will support (and recommend) passing the
             #   platform in its own argument.
             compiler_version = self._settings.get_safe("compiler.version")
+            # If compiler.version is not part of the settings, compiler_version will be None,
+            # resulting in "AttributeError: 'NoneType' object has no attribute 'strip'"
+            if compiler_version == None:
+                compiler_version = "16" # acceptable workaround value
             if Version(compiler_version) < "16" and self._settings.get_safe("os") != "WindowsCE":
                 if self.generator_platform == "x64":
                     generator += " Win64" if not generator.endswith(" Win64") else ""


### PR DESCRIPTION
Changelog: Bugfix: Fix cmake tool when using MSVC target without compiler.version setting

Like the title says. I am using the cmake tool to build executables that are compiler-independent, as they are meant to be used in other recipes as compilation tools themselves. My recipes only use settings = 'os_build', 'arch_build' in these cases, without 'compiler', so 'compiler.version' is not available and causes an "AttributeError: 'NoneType' object has no attribute 'strip'" error because of that, only with MSVC targets.

The reason why I do not wish to add the compiler to the settings is because I want the resulting package to match regardless of the compiler, since it is not a build artifact meant to be linked into a project, but really compilation tools called as part of the build process. The quickest way to make it work was to simply put a default value if compiler.version was not available.
