### PR TITLE
Add missing GCC version to settings.yml

### DIFF
--- a/conans/client/conf/__init__.py
+++ b/conans/client/conf/__init__.py
@@ -64,7 +64,8 @@ _t_default_settings_yml = Template(textwrap.dedent("""
                       "6", "6.1", "6.2", "6.3", "6.4",
                       "7", "7.1", "7.2", "7.3", "7.4",
                       "8", "8.1", "8.2", "8.3",
-                      "9", "9.1", "9.2", "9.3"]
+                      "9", "9.1", "9.2", "9.3",
+                      "10"]
             libcxx: [libstdc++, libstdc++11]
             threads: [None, posix, win32] #  Windows MinGW
             exception: [None, dwarf2, sjlj, seh] # Windows MinGW


### PR DESCRIPTION
This version is already apt package, g++-10, in Ubuntu 20.04.

Changelog: Fix: Adds missing version GCC 10 to default settings.
Docs: https://github.com/conan-io/docs/pull/1675

Fix https://github.com/conan-io/conan/issues/6910
Fix https://github.com/conan-io/conan/issues/6920

- [ ] Refer to the issue that supports this Pull Request.
- [ ] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [ ] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [ ] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 

<sup>**Note:** By default this PR will skip the slower tests and will use a limited set of python versions. Check [here](https://github.com/conan-io/conan/blob/develop/.github/PR_INCREASE_TESTING.md) how to increase the testing level by writing some tags in the current PR body text.</sup>
