### PR TITLE
fix version in cmake_find_package_multi

### DIFF
--- a/conans/client/generators/cmake_find_package_multi.py
+++ b/conans/client/generators/cmake_find_package_multi.py
@@ -101,18 +101,17 @@ set_property(TARGET {name}::{name}
         build_type = str(self.conanfile.settings.build_type)
         build_type_suffix = "_{}".format(build_type.upper()) if build_type else ""
         for _, cpp_info in self.deps_build_info.dependencies:
-            # If any config matches the build_type one, add it to the cpp_info
-            dep_cpp_info = extend(cpp_info, build_type.lower())
-
             depname = cpp_info.get_name("cmake_find_package_multi")
             public_deps_names = [self.deps_build_info[dep].get_name("cmake_find_package_multi")
                                  for dep in cpp_info.public_deps]
             ret["{}Config.cmake".format(depname)] = self._config(depname, cpp_info.version,
                                                                  public_deps_names)
             ret["{}ConfigVersion.cmake".format(depname)] = self.config_version_template.\
-                format(version=dep_cpp_info.version)
+                format(version=cpp_info.version)
             ret["{}Targets.cmake".format(depname)] = self.targets_template.format(name=depname)
 
+            # If any config matches the build_type one, add it to the cpp_info
+            dep_cpp_info = extend(cpp_info, build_type.lower())
             deps = DepsCppCmake(dep_cpp_info)
             deps_names = ";".join(["{n}::{n}".format(n=n) for n in public_deps_names])
             find_lib = target_template.format(name=depname, deps=deps,

--- a/conans/test/unittests/client/generators/cmake_find_package_multi_test.py
+++ b/conans/test/unittests/client/generators/cmake_find_package_multi_test.py
@@ -1,0 +1,29 @@
+import unittest
+
+from conans.client.generators import CMakeFindPackageMultiGenerator
+from conans.model.build_info import CppInfo
+from conans.model.conan_file import ConanFile
+from conans.model.env_info import EnvValues
+from conans.model.ref import ConanFileReference
+from conans.test.unittests.client.generators.cmake_test import _MockSettings
+from conans.test.utils.tools import TestBufferConanOutput
+
+
+class CMakeFindPackageMultiTest(unittest.TestCase):
+
+    def cmake_find_package_multi_version_test(self):
+        # https://github.com/conan-io/conan/issues/6908
+        settings_mock = _MockSettings(build_type="Debug")
+        conanfile = ConanFile(TestBufferConanOutput(), None)
+        conanfile.initialize(settings_mock, EnvValues())
+        ref = ConanFileReference.loads("my_pkg/0.1@user/stable")
+        cpp_info = CppInfo("")
+        cpp_info.name = ref.name
+        cpp_info.version = ref.version
+        cpp_info.debug.libs = ["mylib"]
+        conanfile.deps_cpp_info.update(cpp_info, ref.name)
+
+        generator = CMakeFindPackageMultiGenerator(conanfile)
+        content = generator.content
+        config_version = content["my_pkgConfigVersion.cmake"]
+        self.assertIn('set(PACKAGE_VERSION "0.1")', config_version)


### PR DESCRIPTION
Changelog: Bugfix: Generate correct PACKAGE_VERSION in ``cmake_find_package_multi`` generator for multi-config packages.
Docs: Omit

Fix https://github.com/conan-io/conan/issues/6908
