### PR TITLE
fix build_id() output folders in conan info

### DIFF
--- a/conans/client/conan_command_output.py
+++ b/conans/client/conan_command_output.py
@@ -141,9 +141,8 @@ class CommandOutputer(object):
                 package_layout = self._cache.package_layout(ref, conanfile.short_paths)
                 item_data["export_folder"] = package_layout.export()
                 item_data["source_folder"] = package_layout.source()
-                # @todo: check if this is correct or if it must always be package_id
-                package_id = build_id(conanfile) or package_id
-                pref = PackageReference(ref, package_id)
+                pref_build_id = build_id(conanfile) or package_id
+                pref = PackageReference(ref, pref_build_id)
                 item_data["build_folder"] = package_layout.build(pref)
 
                 pref = PackageReference(ref, package_id)

--- a/conans/test/functional/command/info_folders_test.py
+++ b/conans/test/functional/command/info_folders_test.py
@@ -4,7 +4,6 @@ import re
 import subprocess
 import textwrap
 import unittest
-from textwrap import dedent
 
 from conans.client import tools
 from conans.model.ref import ConanFileReference, PackageReference
@@ -54,7 +53,7 @@ class InfoFoldersTest(unittest.TestCase):
         client = TestClient()
         client.save({CONANFILE: conanfile_py})
         client.run("export . %s" % self.user_channel)
-        client.run("info %s --paths" % (self.reference1))
+        client.run("info %s --paths" % self.reference1)
         base_path = os.path.join("MyPackage", "0.1.0", "myUser", "testing")
         output = client.out
         self.assertIn(os.path.join(base_path, "export"), output)
@@ -94,7 +93,7 @@ class InfoFoldersTest(unittest.TestCase):
         self._prepare_deps(client)
 
         for ref in [self.reference2, "."]:
-            client.run("info %s --paths" % (ref))
+            client.run("info %s --paths" % ref)
             output = client.out
 
             base_path = os.path.join("MyPackage", "0.1.0", "myUser", "testing")
@@ -130,7 +129,7 @@ class InfoFoldersTest(unittest.TestCase):
         client = TestClient()
         client.save({CONANFILE: conanfile_py})
         client.run("export . %s" % self.user_channel)
-        client.run("info %s --paths --only=build_folder" % (self.reference1))
+        client.run("info %s --paths --only=build_folder" % self.reference1)
         base_path = os.path.join("MyPackage", "0.1.0", "myUser", "testing")
         output = client.out
         self.assertNotIn("export", output)
@@ -233,7 +232,7 @@ class InfoFoldersTest(unittest.TestCase):
         cache_folder = temp_folder(False)
         short_folder = os.path.join(temp_folder(False), ".cn")
 
-        conanfile = dedent("""
+        conanfile = textwrap.dedent("""
             from conans import ConanFile
 
             class Conan(ConanFile):

--- a/conans/test/functional/command/info_folders_test.py
+++ b/conans/test/functional/command/info_folders_test.py
@@ -2,6 +2,7 @@ import os
 import platform
 import re
 import subprocess
+import textwrap
 import unittest
 from textwrap import dedent
 
@@ -60,6 +61,33 @@ class InfoFoldersTest(unittest.TestCase):
         self.assertIn(os.path.join(base_path, "source"), output)
         self.assertIn(os.path.join(base_path, "build", NO_SETTINGS_PACKAGE_ID), output)
         self.assertIn(os.path.join(base_path, "package", NO_SETTINGS_PACKAGE_ID), output)
+
+    def test_build_id(self):
+        # https://github.com/conan-io/conan/issues/6915
+        client = TestClient()
+        conanfile = textwrap.dedent("""
+            from conans import ConanFile
+
+            class Pkg(ConanFile):
+                options = {"myOption": [True, False]}
+                def build_id(self):
+                    self.info_build.options.myOption = "Any"
+            """)
+        client.save({CONANFILE: conanfile})
+        client.run("export . pkg/0.1@user/testing")
+        client.run("info pkg/0.1@user/testing --paths -o pkg:myOption=True")
+        out = str(client.out).replace("\\", "/")
+        self.assertIn("ID: e8618d1abf841d16789cf55a0978a47d83fb859f", out)
+        self.assertIn("BuildID: 5c5eb4795e3cae1cbe06f4592b1bbd864ac68131", out)
+        self.assertIn("pkg/0.1/user/testing/build/5c5eb4795e3cae1cbe06f4592b1bbd864ac68131", out)
+        self.assertIn("pkg/0.1/user/testing/package/e8618d1abf841d16789cf55a0978a47d83fb859f", out)
+
+        client.run("info pkg/0.1@user/testing --paths -o pkg:myOption=False")
+        out = str(client.out).replace("\\", "/")
+        self.assertIn("ID: 5ab84d6acfe1f23c4fae0ab88f26e3a396351ac9", out)
+        self.assertIn("BuildID: 5c5eb4795e3cae1cbe06f4592b1bbd864ac68131", out)
+        self.assertIn("pkg/0.1/user/testing/build/5c5eb4795e3cae1cbe06f4592b1bbd864ac68131", out)
+        self.assertIn("pkg/0.1/user/testing/package/5ab84d6acfe1f23c4fae0ab88f26e3a396351ac9", out)
 
     def test_deps_basic(self):
         client = TestClient()


### PR DESCRIPTION
Changelog: Bugfix: Fix the output of ``conan info`` package folder when using ``build_id()`` method.
Docs: Omit

Close https://github.com/conan-io/conan/issues/6915
