### PR TITLE
#6628 Preserve symlinks for deploy generator

### DIFF
--- a/conans/client/generators/deploy.py
+++ b/conans/client/generators/deploy.py
@@ -2,12 +2,12 @@ import calendar
 import os
 import shutil
 import time
-import six
 
 from conans.model import Generator
 from conans.model.manifest import FileTreeManifest
 from conans.paths import BUILD_INFO_DEPLOY
 from conans.util.files import mkdir, md5sum
+
 
 FILTERED_FILES = ["conaninfo.txt", "conanmanifest.txt"]
 
@@ -42,13 +42,10 @@ class DeployGenerator(Generator):
                                        os.path.relpath(root, rootpath), f)
                     dst = os.path.normpath(dst)
                     mkdir(os.path.dirname(dst))
-                    if six.PY2:
-                        if os.path.islink(src):
-                            linkto = os.readlink(src)
-                            os.symlink(linkto, dst)
-                        else:
-                            shutil.copy(src, dst)
+                    if os.path.islink(src):
+                        linkto = os.path.relpath(os.readlink(src), os.path.dirname(src))
+                        os.symlink(linkto, dst)
                     else:
-                        shutil.copy(src, dst, follow_symlinks=False)
+                        shutil.copy(src, dst)
                     copied_files.append(dst)
         return self.deploy_manifest_content(copied_files)

--- a/conans/client/generators/deploy.py
+++ b/conans/client/generators/deploy.py
@@ -2,6 +2,7 @@ import calendar
 import os
 import shutil
 import time
+import six
 
 from conans.model import Generator
 from conans.model.manifest import FileTreeManifest
@@ -41,6 +42,13 @@ class DeployGenerator(Generator):
                                        os.path.relpath(root, rootpath), f)
                     dst = os.path.normpath(dst)
                     mkdir(os.path.dirname(dst))
-                    shutil.copy(src, dst)
+                    if six.PY2:
+                        if os.path.islink(src):
+                            linkto = os.readlink(src)
+                            os.symlink(linkto, dst)
+                        else:
+                            shutil.copy(src, dst)
+                    else:
+                        shutil.copy(src, dst, follow_symlinks=False)
                     copied_files.append(dst)
         return self.deploy_manifest_content(copied_files)

--- a/conans/test/functional/generators/deploy_test.py
+++ b/conans/test/functional/generators/deploy_test.py
@@ -140,6 +140,7 @@ class DeployGeneratorPermissionsTest(unittest.TestCase):
         self.assertTrue(stat_info.st_mode & stat.S_IXUSR)
 
 
+@unittest.skipIf(platform.system() == "Windows", "Permissions in NIX systems only")
 class DeployGeneratorSymbolicLinkTest(unittest.TestCase):
 
     def setUp(self):

--- a/conans/test/functional/generators/deploy_test.py
+++ b/conans/test/functional/generators/deploy_test.py
@@ -138,3 +138,28 @@ class DeployGeneratorPermissionsTest(unittest.TestCase):
         header1_path = os.path.join(base1_path, "include", "header1.h")
         stat_info = os.stat(header1_path)
         self.assertTrue(stat_info.st_mode & stat.S_IXUSR)
+
+
+class DeployGeneratorSymbolibLinkTest(unittest.TestCase):
+
+    def setUp(self):
+        conanfile = GenConanfile()
+        conanfile.with_package_file("include/header.h", "whatever")
+        self.ref = ConanFileReference("name", "version", "user", "channel")
+
+        self.client = TurboTestClient()
+        self.client.create(self.ref, conanfile)
+        layout = self.client.cache.package_layout(self.ref)
+        package_folder = layout.package(PackageReference(self.ref, NO_SETTINGS_PACKAGE_ID))
+        self.header_path = os.path.join(package_folder, "include", "header.h")
+
+    def test_symbolic_links(self):
+        link_path = self.header_path + ".lnk"
+        os.symlink(self.header_path, link_path)
+        self.client.current_folder = temp_folder()
+        self.client.run("install %s -g deploy" % self.ref.full_str())
+        base_path = os.path.join(self.client.current_folder, "name")
+        header_path = os.path.join(base_path, "include", "header.h")
+        link_path = os.path.join(base_path, "include", "header.h.lnk")
+        self.assertTrue(os.path.islink(link_path))
+        self.assertFalse(os.path.islink(header_path))

--- a/conans/test/functional/generators/deploy_test.py
+++ b/conans/test/functional/generators/deploy_test.py
@@ -140,7 +140,7 @@ class DeployGeneratorPermissionsTest(unittest.TestCase):
         self.assertTrue(stat_info.st_mode & stat.S_IXUSR)
 
 
-class DeployGeneratorSymbolibLinkTest(unittest.TestCase):
+class DeployGeneratorSymbolicLinkTest(unittest.TestCase):
 
     def setUp(self):
         conanfile = GenConanfile()
@@ -163,3 +163,5 @@ class DeployGeneratorSymbolibLinkTest(unittest.TestCase):
         link_path = os.path.join(base_path, "include", "header.h.lnk")
         self.assertTrue(os.path.islink(link_path))
         self.assertFalse(os.path.islink(header_path))
+        linkto = os.path.join(os.path.dirname(link_path), os.readlink(link_path))
+        self.assertEqual(linkto, header_path)


### PR DESCRIPTION
- Do not copy symlink when installing by deploy generators, but follow them.

Changelog: Fix: Preserve symbolic links for deploy generator.
Docs: https://github.com/conan-io/docs/pull/1681

fixes #6628 

/cc @michaelplatingsarm

- [x] Refer to the issue that supports this Pull Request.
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [x] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 

<sup>**Note:** By default this PR will skip the slower tests and will use a limited set of python versions. Check [here](https://github.com/conan-io/conan/blob/develop/.github/PR_INCREASE_TESTING.md) how to increase the testing level by writing some tags in the current PR body text.</sup>
