### PR TITLE
Fix: make instructions more reliable

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -137,14 +137,6 @@ Without tox
     $ python -m pip install -r conans/requirements_server.txt
     $ python -m pip install -r conans/requirements_dev.txt
 
-
-Only in OSX:
-
-.. code-block:: bash
-
-    $ python -m pip install -r conans/requirements_osx.txt # You can omit this one if not running OSX
-
-
 If you are not Windows and you are not using a python virtual environment, you will need to run these
 commands using `sudo`.
 

--- a/README.rst
+++ b/README.rst
@@ -117,14 +117,14 @@ Using tox
 
 .. code-block:: bash
 
-    $ tox
+    $ python -m tox
 
 It will install the needed requirements and launch `nose` skipping some heavy and slow tests.
 If you want to run the full test suite:
 
 .. code-block:: bash
 
-    $ tox -e full
+    $ python -m tox -e full
 
 Without tox
 -----------
@@ -133,16 +133,16 @@ Without tox
 
 .. code-block:: bash
 
-    $ pip install -r conans/requirements.txt
-    $ pip install -r conans/requirements_server.txt
-    $ pip install -r conans/requirements_dev.txt
+    $ python -m pip install -r conans/requirements.txt
+    $ python -m pip install -r conans/requirements_server.txt
+    $ python -m pip install -r conans/requirements_dev.txt
 
 
 Only in OSX:
 
 .. code-block:: bash
 
-    $ pip install -r conans/requirements_osx.txt # You can omit this one if not running OSX
+    $ python -m pip install -r conans/requirements_osx.txt # You can omit this one if not running OSX
 
 
 If you are not Windows and you are not using a python virtual environment, you will need to run these
@@ -188,7 +188,7 @@ You can run the actual tests like this:
 
 .. code-block:: bash
 
-    $ nosetests .
+    $ python -m nose .
 
 
 There are a couple of test attributes defined, as ``slow`` that you can use
@@ -196,7 +196,7 @@ to filter the tests, and do not execute them:
 
 .. code-block:: bash
 
-    $ nosetests . -a !slow
+    $ python -m nose . -a !slow
 
 A few minutes later it should print ``OK``:
 
@@ -212,7 +212,7 @@ To run specific tests, you can specify the test name too, something like:
 
 .. code-block:: bash
 
-    $ nosetests conans.test.command.config_install_test:ConfigInstallTest.install_file_test --nocapture
+    $ python -m nose conans.test.command.config_install_test:ConfigInstallTest.install_file_test --nocapture
 
 The ``--nocapture`` argument can be useful to see some output that otherwise is captured by nosetests.
 


### PR DESCRIPTION
use `python -m <module>` to run commands (like **pip**, **tox**, **nose**).
I've been struggling a lot with instructions not working as is, so I'd propose to update our README to make it more reliable and friendly for newbies.

more explanation: https://snarky.ca/why-you-should-use-python-m-pip/
TL;DR: sometimes tools like pip, tox, nosetests are just not in path. sometimes they belong not to the same interpreter that you want.

Changelog: omit
Docs: omit

- [ ] Refer to the issue that supports this Pull Request.
- [ ] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [ ] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [ ] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 

<sup>**Note:** By default this PR will skip the slower tests and will use a limited set of python versions. Check [here](https://github.com/conan-io/conan/blob/develop/.github/PR_INCREASE_TESTING.md) how to increase the testing level by writing some tags in the current PR body text.</sup>
