### PR TITLE
run tools.unix_path only in Windows

### DIFF
--- a/conans/client/tools/win.py
+++ b/conans/client/tools/win.py
@@ -577,6 +577,9 @@ def unix_path(path, path_flavor=None):
     if not path:
         return None
 
+    if not OSInfo().is_windows:
+        return path
+
     if os.path.exists(path):
         path = get_cased_path(path)  # if the path doesn't exist (and abs) we cannot guess the casing
 

--- a/conans/test/unittests/util/unix_path_test.py
+++ b/conans/test/unittests/util/unix_path_test.py
@@ -41,18 +41,30 @@ class GetCasedPath(unittest.TestCase):
 
 class UnixPathTest(unittest.TestCase):
 
+    def test_none(self):
+        self.assertEqual(None, tools.unix_path(path=None))
+
+    @unittest.skipIf(platform.system() == "Windows", "All but Windows")
+    def test_not_windows(self):
+        path = 'C:\\Windows\\System32'
+        self.assertEqual(path, tools.unix_path(path))
+
+    @unittest.skipUnless(platform.system() == "Windows", "Only windows")
     def test_msys_path(self):
         self.assertEqual('/c/windows/system32', tools.unix_path('C:\\Windows\\System32',
                                                                 path_flavor=tools.MSYS2))
 
+    @unittest.skipUnless(platform.system() == "Windows", "Only windows")
     def test_cygwin_path(self):
         self.assertEqual('/cygdrive/c/windows/system32', tools.unix_path('C:\\Windows\\System32',
                                                                          path_flavor=tools.CYGWIN))
 
+    @unittest.skipUnless(platform.system() == "Windows", "Only windows")
     def test_wsl_path(self):
         self.assertEqual('/mnt/c/Windows/System32', tools.unix_path('C:\\Windows\\System32',
                                                                     path_flavor=tools.WSL))
 
+    @unittest.skipUnless(platform.system() == "Windows", "Only windows")
     def test_sfu_path(self):
         self.assertEqual('/dev/fs/C/windows/system32', tools.unix_path('C:\\Windows\\System32',
                                                                        path_flavor=tools.SFU))


### PR DESCRIPTION
Changelog: Fix: `tools.unix_path` is noop in all platforms but Windows (already documented behavior).
Docs: omit

~~I'm not adding a changelog as~~ this is the documented behavior, this is just ensuring that the function is a noop for any other system but Windows.

Closes https://github.com/conan-io/conan/issues/6900