### PR TITLE
set_name and set_version can use given name and version

### DIFF
--- a/conans/client/loader.py
+++ b/conans/client/loader.py
@@ -94,20 +94,6 @@ class ConanFileLoader(object):
         """ loads the basic conanfile object and evaluates its name and version
         """
         conanfile, _ = self.load_basic_module(conanfile_path, lock_python_requires, user, channel)
-        conanfile.recipe_folder = os.path.dirname(conanfile_path)
-
-        if hasattr(conanfile, "set_name"):
-            if conanfile.name:
-                raise ConanException("Conanfile defined package 'name', set_name() redundant")
-            with conanfile_exception_formatter("conanfile.py", "set_name"):
-                conanfile.set_name()
-        if hasattr(conanfile, "set_version"):
-            if conanfile.version:
-                raise ConanException("Conanfile defined package 'version', set_version() redundant")
-            with conanfile_exception_formatter("conanfile.py", "set_version"):
-                conanfile.set_version()
-        # Make sure this is nowhere else available
-        del conanfile.recipe_folder
 
         # Export does a check on existing name & version
         if name:
@@ -120,6 +106,22 @@ class ConanFileLoader(object):
                 raise ConanException("Package recipe with version %s!=%s"
                                      % (version, conanfile.version))
             conanfile.version = version
+
+        conanfile.recipe_folder = os.path.dirname(conanfile_path)
+        if hasattr(conanfile, "set_name"):
+            with conanfile_exception_formatter("conanfile.py", "set_name"):
+                conanfile.set_name()
+            if name and name != conanfile.name:
+                raise ConanException("Package recipe with name %s!=%s" % (name, conanfile.name))
+        if hasattr(conanfile, "set_version"):
+            with conanfile_exception_formatter("conanfile.py", "set_version"):
+                conanfile.set_version()
+            if version and version != conanfile.version:
+                raise ConanException("Package recipe with version %s!=%s"
+                                     % (version, conanfile.version))
+        # Make sure this is nowhere else available
+        del conanfile.recipe_folder
+
         return conanfile
 
     def load_export(self, conanfile_path, name, version, user, channel, lock_python_requires=None):

--- a/conans/test/functional/conanfile/get_name_version_test.py
+++ b/conans/test/functional/conanfile/get_name_version_test.py
@@ -85,6 +85,30 @@ class GetVersionNameTest(unittest.TestCase):
         client.run("install . other/1.2@", assert_error=True)
         self.assertIn("ERROR: Package recipe with name other!=pkg", client.out)
 
+    def set_version_name_only_not_cli_test(self):
+        client = TestClient()
+        conanfile = textwrap.dedent("""
+            from conans import ConanFile
+            class Lib(ConanFile):
+                def set_name(self):
+                    self.name = self.name or "pkg"
+                def set_version(self):
+                    self.version = self.version or "2.0"
+            """)
+        client.save({"conanfile.py": conanfile})
+        client.run("export . other/1.1@user/testing")
+        self.assertIn("other/1.1@user/testing: Exported", client.out)
+        client.run("export . 1.1@user/testing")
+        self.assertIn("pkg/1.1@user/testing: Exported", client.out)
+        client.run("export . user/testing")
+        self.assertIn("pkg/2.0@user/testing: Exported", client.out)
+
+        # Local flow should also work
+        client.run("install . other/1.2@")
+        self.assertIn("conanfile.py (other/1.2)", client.out)
+        client.run("install .")
+        self.assertIn("conanfile.py (pkg/2.0)", client.out)
+
     def set_version_name_crash_test(self):
         client = TestClient()
         conanfile = textwrap.dedent("""


### PR DESCRIPTION
Changelog: Feature: Allow access to ``self.name`` and ``self.version`` in ``set_name()`` and ``set_version()`` methods.
Docs: https://github.com/conan-io/docs/pull/1710


Close https://github.com/conan-io/conan/issues/6939