### PR TITLE
[refactor] Move all configure-related methods to a function

### DIFF
--- a/conans/client/cmd/build.py
+++ b/conans/client/cmd/build.py
@@ -1,6 +1,6 @@
 import os
 
-from conans.client.build.build import run_build_method
+from conans.client.conanfile.build import run_build_method
 from conans.errors import (ConanException, NotFoundException, conanfile_exception_formatter)
 from conans.model.conan_file import get_env_context_manager
 from conans.paths import CONANFILE, CONANFILE_TXT

--- a/conans/client/conanfile/build.py
+++ b/conans/client/conanfile/build.py
@@ -1,4 +1,3 @@
-
 import os
 
 from conans.errors import conanfile_exception_formatter

--- a/conans/client/conanfile/configure.py
+++ b/conans/client/conanfile/configure.py
@@ -1,0 +1,31 @@
+from conans.errors import (conanfile_exception_formatter)
+from conans.model.conan_file import get_env_context_manager
+from conans.util.conan_v2_mode import conan_v2_behavior
+
+
+def run_configure_method(conanfile, down_options, down_ref, ref):
+    """ Run all the config-related functions for the given conanfile object """
+
+    # Avoid extra time manipulating the sys.path for python
+    with get_env_context_manager(conanfile, without_python=True):
+        if hasattr(conanfile, "config"):
+            conan_v2_behavior("config() has been deprecated. "
+                              "Use config_options() and configure()",
+                              v1_behavior=conanfile.output.warn)
+            with conanfile_exception_formatter(str(conanfile), "config"):
+                conanfile.config()
+
+        with conanfile_exception_formatter(str(conanfile), "config_options"):
+            conanfile.config_options()
+
+        conanfile.options.propagate_upstream(down_options, down_ref, ref)
+
+        if hasattr(conanfile, "config"):
+            with conanfile_exception_formatter(str(conanfile), "config"):
+                conanfile.config()
+
+        with conanfile_exception_formatter(str(conanfile), "configure"):
+            conanfile.configure()
+
+        conanfile.settings.validate()  # All has to be ok!
+        conanfile.options.validate()

--- a/conans/client/graph/graph_builder.py
+++ b/conans/client/graph/graph_builder.py
@@ -1,12 +1,12 @@
 import time
 
+from conans.client.conanfile.configure import run_configure_method
 from conans.client.graph.graph import DepsGraph, Node, RECIPE_EDITABLE, CONTEXT_HOST, CONTEXT_BUILD
 from conans.errors import (ConanException, ConanExceptionInUserConanfileMethod,
                            conanfile_exception_formatter)
 from conans.model.conan_file import get_env_context_manager
 from conans.model.ref import ConanFileReference
 from conans.model.requires import Requirements, Requirement
-from conans.util.conan_v2_mode import conan_v2_behavior
 from conans.util.log import logger
 
 
@@ -321,27 +321,9 @@ class DepsGraphBuilder(object):
         """
         conanfile, ref = node.conanfile, node.ref
         try:
-            # Avoid extra time manipulating the sys.path for python
+            run_configure_method(conanfile, down_options, down_ref, ref)
+
             with get_env_context_manager(conanfile, without_python=True):
-                if hasattr(conanfile, "config"):
-                    conan_v2_behavior("config() has been deprecated. "
-                                      "Use config_options() and configure()",
-                                      v1_behavior=conanfile.output.warn)
-                    with conanfile_exception_formatter(str(conanfile), "config"):
-                        conanfile.config()
-                with conanfile_exception_formatter(str(conanfile), "config_options"):
-                    conanfile.config_options()
-                conanfile.options.propagate_upstream(down_options, down_ref, ref)
-                if hasattr(conanfile, "config"):
-                    with conanfile_exception_formatter(str(conanfile), "config"):
-                        conanfile.config()
-
-                with conanfile_exception_formatter(str(conanfile), "configure"):
-                    conanfile.configure()
-
-                conanfile.settings.validate()  # All has to be ok!
-                conanfile.options.validate()
-
                 # Update requirements (overwrites), computing new upstream
                 if hasattr(conanfile, "requirements"):
                     # If re-evaluating the recipe, in a diamond graph, with different options,

--- a/conans/client/graph/graph_manager.py
+++ b/conans/client/graph/graph_manager.py
@@ -285,7 +285,7 @@ class GraphManager(object):
                 continue
             # Packages with PACKAGE_ID_UNKNOWN might be built in the future, need build requires
             if (node.binary not in (BINARY_BUILD, BINARY_EDITABLE, BINARY_UNKNOWN)
-                and node.recipe != RECIPE_CONSUMER):
+                    and node.recipe != RECIPE_CONSUMER):
                 continue
             package_build_requires = self._get_recipe_build_requires(node.conanfile, default_context)
             str_ref = str(node.ref)
@@ -293,8 +293,8 @@ class GraphManager(object):
             profile_build_requires = profile_build_requires or {}
             for pattern, build_requires in profile_build_requires.items():
                 if ((node.recipe == RECIPE_CONSUMER and pattern == "&") or
-                    (node.recipe != RECIPE_CONSUMER and pattern == "&!") or
-                    fnmatch.fnmatch(str_ref, pattern)):
+                        (node.recipe != RECIPE_CONSUMER and pattern == "&!") or
+                        fnmatch.fnmatch(str_ref, pattern)):
                     for build_require in build_requires:
                         br_key = (build_require.name, default_context)
                         if br_key in package_build_requires:  # Override defined

--- a/conans/client/graph/graph_manager.py
+++ b/conans/client/graph/graph_manager.py
@@ -285,7 +285,7 @@ class GraphManager(object):
                 continue
             # Packages with PACKAGE_ID_UNKNOWN might be built in the future, need build requires
             if (node.binary not in (BINARY_BUILD, BINARY_EDITABLE, BINARY_UNKNOWN)
-                    and node.recipe != RECIPE_CONSUMER):
+                and node.recipe != RECIPE_CONSUMER):
                 continue
             package_build_requires = self._get_recipe_build_requires(node.conanfile, default_context)
             str_ref = str(node.ref)
@@ -293,8 +293,8 @@ class GraphManager(object):
             profile_build_requires = profile_build_requires or {}
             for pattern, build_requires in profile_build_requires.items():
                 if ((node.recipe == RECIPE_CONSUMER and pattern == "&") or
-                        (node.recipe != RECIPE_CONSUMER and pattern == "&!") or
-                        fnmatch.fnmatch(str_ref, pattern)):
+                    (node.recipe != RECIPE_CONSUMER and pattern == "&!") or
+                    fnmatch.fnmatch(str_ref, pattern)):
                     for build_require in build_requires:
                         br_key = (build_require.name, default_context)
                         if br_key in package_build_requires:  # Override defined

--- a/conans/client/installer.py
+++ b/conans/client/installer.py
@@ -4,7 +4,7 @@ import time
 from multiprocessing.pool import ThreadPool
 
 from conans.client import tools
-from conans.client.build.build import run_build_method
+from conans.client.conanfile.build import run_build_method
 from conans.client.file_copier import report_copied_files
 from conans.client.generators import TXTGenerator, write_generators
 from conans.client.graph.graph import BINARY_BUILD, BINARY_CACHE, BINARY_DOWNLOAD, BINARY_EDITABLE, \


### PR DESCRIPTION
Changelog: omit
Docs: omit

This PR moves all the `config`, `config_options` and `configure` calls into a function `run_configure_method`. In this function I'll implement the try/catch for the new _build-exception_:
 1. it keeps exactly the same logic from `graph_builder.py` (logic from `_config_node` function)
 1. it adds calls to for logic under `load_consumer_conanfile` function.

IMO it is safe to introduce (2) as it is introducing calls to `config()` (which is already deprecated and I don't know any recipe using it) and another call to `conanfile.options.propagate_upstream` but it will execute nothing as all its arguments are `None`.

---

I can keep existing behavior, but I prefer not to add an `if/else` to this new `run_configure_method` function.