### PR TITLE
Feature: Add `conan config init` command

### DIFF
--- a/conans/client/cache/remote_registry.py
+++ b/conans/client/cache/remote_registry.py
@@ -307,16 +307,17 @@ class RemoteRegistry(object):
         else:
             self._output.warn("The URL is empty. It must contain scheme and hostname.")
 
-    def load_remotes(self):
+    def initialize_remotes(self):
         if not os.path.exists(self._filename):
             self._output.warn("Remotes registry file missing, "
                               "creating default one in %s" % self._filename)
             remotes = Remotes.defaults()
             remotes.save(self._filename)
-        else:
-            content = load(self._filename)
-            remotes = Remotes.loads(content)
-        return remotes
+
+    def load_remotes(self):
+        self.initialize_remotes()
+        content = load(self._filename)
+        return Remotes.loads(content)
 
     def add(self, remote_name, url, verify_ssl=True, insert=None, force=None):
         self._validate_url(url)

--- a/conans/client/cache/remote_registry.py
+++ b/conans/client/cache/remote_registry.py
@@ -1,6 +1,7 @@
 import fnmatch
 import json
 import os
+import stat
 from collections import OrderedDict, namedtuple
 from six.moves.urllib.parse import urlparse
 
@@ -313,6 +314,12 @@ class RemoteRegistry(object):
                               "creating default one in %s" % self._filename)
             remotes = Remotes.defaults()
             remotes.save(self._filename)
+
+    def reset_remotes(self):
+        if os.path.exists(self._filename):
+            os.chmod(self._filename, stat.S_IWRITE)
+            os.remove(self._filename)
+        self.initialize_remotes()
 
     def load_remotes(self):
         self.initialize_remotes()

--- a/conans/client/command.py
+++ b/conans/client/command.py
@@ -546,6 +546,7 @@ class Command(object):
                                                                   'from a local or remote zip file')
         rm_subparser = subparsers.add_parser('rm', help='Remove an existing config element')
         set_subparser = subparsers.add_parser('set', help='Set a value for a configuration item')
+        subparsers.add_parser('init', help='Initializes Conan configuration files')
 
         get_subparser.add_argument("item", nargs="?", help="Item to print")
         home_subparser.add_argument("-j", "--json", default=None, action=OnceArgument,
@@ -594,6 +595,8 @@ class Command(object):
             return self._conan.config_install(args.item, verify_ssl, args.type, args.args,
                                               source_folder=args.source_folder,
                                               target_folder=args.target_folder)
+        elif args.subcommand == 'init':
+            return self._conan.config_init()
 
     def info(self, *args):
         """

--- a/conans/client/command.py
+++ b/conans/client/command.py
@@ -546,7 +546,7 @@ class Command(object):
                                                                   'from a local or remote zip file')
         rm_subparser = subparsers.add_parser('rm', help='Remove an existing config element')
         set_subparser = subparsers.add_parser('set', help='Set a value for a configuration item')
-        subparsers.add_parser('init', help='Initializes Conan configuration files')
+        init_subparser = subparsers.add_parser('init', help='Initializes Conan configuration files')
 
         get_subparser.add_argument("item", nargs="?", help="Item to print")
         home_subparser.add_argument("-j", "--json", default=None, action=OnceArgument,
@@ -568,6 +568,8 @@ class Command(object):
                                        help='Install to that path in the conan cache')
         rm_subparser.add_argument("item", help="Item to remove")
         set_subparser.add_argument("item", help="'item=value' to set")
+        init_subparser.add_argument('-f', '--force', default=False, action='store_true',
+                            help='Overwrite existing Conan configuration files')
 
         args = parser.parse_args(*args)
 
@@ -596,7 +598,7 @@ class Command(object):
                                               source_folder=args.source_folder,
                                               target_folder=args.target_folder)
         elif args.subcommand == 'init':
-            return self._conan.config_init()
+            return self._conan.config_init(force=args.force)
 
     def info(self, *args):
         """

--- a/conans/client/conan_api.py
+++ b/conans/client/conan_api.py
@@ -615,6 +615,7 @@ class ConanAPIV1(object):
     def config_init(self):
         self.app.cache.registry.initialize_remotes()
         self.app.cache.settings
+        self.app.cache.default_profile
 
     def _info_args(self, reference_or_path, install_folder, profile_host, profile_build, lockfile=None):
         cwd = get_cwd()

--- a/conans/client/conan_api.py
+++ b/conans/client/conan_api.py
@@ -612,10 +612,17 @@ class ConanAPIV1(object):
         return self.cache_folder
 
     @api_method
-    def config_init(self):
-        self.app.cache.registry.initialize_remotes()
-        self.app.cache.settings
-        self.app.cache.default_profile
+    def config_init(self, force=False):
+        if force:
+            self.app.cache.reset_config()
+            self.app.cache.registry.reset_remotes()
+            self.app.cache.reset_default_profile()
+            self.app.cache.reset_settings()
+        else:
+            self.app.cache.initialize_config()
+            self.app.cache.registry.initialize_remotes()
+            self.app.cache.initialize_default_profile()
+            self.app.cache.initialize_settings()
 
     def _info_args(self, reference_or_path, install_folder, profile_host, profile_build, lockfile=None):
         cwd = get_cwd()

--- a/conans/client/conan_api.py
+++ b/conans/client/conan_api.py
@@ -611,6 +611,12 @@ class ConanAPIV1(object):
     def config_home(self):
         return self.cache_folder
 
+    @api_method
+    def config_init(self):
+        self.app.cache.registry.initialize_remotes()
+        self.app.cache.settings
+        return
+
     def _info_args(self, reference_or_path, install_folder, profile_host, profile_build, lockfile=None):
         cwd = get_cwd()
         if check_valid_ref(reference_or_path):

--- a/conans/client/conan_api.py
+++ b/conans/client/conan_api.py
@@ -615,7 +615,6 @@ class ConanAPIV1(object):
     def config_init(self):
         self.app.cache.registry.initialize_remotes()
         self.app.cache.settings
-        return
 
     def _info_args(self, reference_or_path, install_folder, profile_host, profile_build, lockfile=None):
         cwd = get_cwd()

--- a/conans/test/functional/command/config_test.py
+++ b/conans/test/functional/command/config_test.py
@@ -126,6 +126,12 @@ class ConfigTest(unittest.TestCase):
             client = TestClient(cache_folder=cache_folder)
             self.assertEqual(client.cache.config.short_paths_home, short_path_home_folder)
 
+    def test_init(self):
+        self.client.run('config init')
+        self.assertTrue(os.path.exists(self.client.cache.conan_conf_path))
+        self.assertTrue(os.path.exists(self.client.cache.remotes_path))
+        self.assertTrue(os.path.exists(self.client.cache.settings_path))
+
     def _assert_dict_subset(self, expected, actual):
         actual = {k: v for k, v in actual.items() if k in expected}
         self.assertDictEqual(expected, actual)

--- a/conans/test/functional/command/config_test.py
+++ b/conans/test/functional/command/config_test.py
@@ -131,6 +131,7 @@ class ConfigTest(unittest.TestCase):
         self.assertTrue(os.path.exists(self.client.cache.conan_conf_path))
         self.assertTrue(os.path.exists(self.client.cache.remotes_path))
         self.assertTrue(os.path.exists(self.client.cache.settings_path))
+        self.assertTrue(os.path.exists(self.client.cache.default_profile_path))
 
     def _assert_dict_subset(self, expected, actual):
         actual = {k: v for k, v in actual.items() if k in expected}

--- a/conans/test/functional/command/config_test.py
+++ b/conans/test/functional/command/config_test.py
@@ -5,7 +5,7 @@ import six
 
 from conans.errors import ConanException
 from conans.test.utils.tools import TestClient
-from conans.util.files import load
+from conans.util.files import load, save_append
 from conans.test.utils.test_files import temp_folder
 from conans.client.tools import environment_append
 
@@ -132,6 +132,24 @@ class ConfigTest(unittest.TestCase):
         self.assertTrue(os.path.exists(self.client.cache.remotes_path))
         self.assertTrue(os.path.exists(self.client.cache.settings_path))
         self.assertTrue(os.path.exists(self.client.cache.default_profile_path))
+
+    def test_init_overwrite(self):
+        # create and add dummy content to the config files
+        self.client.run('config init')
+        dummy_content = 'DUMMY CONTENT. SHOULD BE REMOVED!'
+        save_append(self.client.cache.conan_conf_path, dummy_content)
+        save_append(self.client.cache.remotes_path, dummy_content)
+        save_append(self.client.cache.settings_path, dummy_content)
+        save_append(self.client.cache.default_profile_path, dummy_content)
+
+        # overwrite files
+        self.client.run('config init --force')
+
+        self.assertNotIn(dummy_content, load(self.client.cache.conan_conf_path))
+        self.assertNotIn(dummy_content, load(self.client.cache.remotes_path))
+        self.assertNotIn(dummy_content, load(self.client.cache.conan_conf_path))
+        self.assertNotIn(dummy_content, load(self.client.cache.settings_path))
+        self.assertNotIn(dummy_content, load(self.client.cache.default_profile_path))
 
     def _assert_dict_subset(self, expected, actual):
         actual = {k: v for k, v in actual.items() if k in expected}

--- a/conans/test/functional/settings/conan_settings_preprocessor_test.py
+++ b/conans/test/functional/settings/conan_settings_preprocessor_test.py
@@ -39,7 +39,7 @@ class HelloConan(ConanFile):
 
     def test_runtime_not_present_ok(self):
         # Generate the settings.yml
-        self.client.run("install Hello0/0.1@lasote/channel --build missing")
+        self.client.run("config init")
         default_settings = load(self.client.cache.settings_path)
         default_settings = default_settings.replace("runtime:", "# runtime:")
         save(self.client.cache.settings_path, default_settings)


### PR DESCRIPTION
Changelog: Feature: Add `conan config init` command.
Docs: https://github.com/conan-io/docs/pull/1704

- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [x] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 

**Background**:
We need to customize the `settings.yml` file, because we need to add the `distro` setting as described in https://docs.conan.io/en/latest/extending/custom_settings.html#adding-new-settings. 
We don't like to maintain our own `settings.yml`, because this means for every new release of `clang` or `gcc` we would need to update the `settings.yml`.

To automatically create the `settings.yml` (and the other configuration files) I propose to introduce the `conan config init` command.

Our workflow:
1. Run `conan config init`
2. A script will change the `settings.yml`
3. Run `conan install [...]` or other conan commands.






