### PR TITLE
Fix json output serialization for cpp_info components

### DIFF
--- a/conans/client/recorder/action_recorder.py
+++ b/conans/client/recorder/action_recorder.py
@@ -35,9 +35,7 @@ def _cpp_info_to_dict(cpp_info):
             doc["configs"] = configs_data
             continue
         if it == "components":
-            doc[it] = {}
-            for comp_name, comp in value.items():
-                doc[it][comp_name] = _cpp_info_to_dict(comp)
+            doc[it] = {comp_name: _cpp_info_to_dict(comp) for comp_name, comp in value.items()}
             continue
 
         doc[it] = value

--- a/conans/client/recorder/action_recorder.py
+++ b/conans/client/recorder/action_recorder.py
@@ -34,6 +34,11 @@ def _cpp_info_to_dict(cpp_info):
                 configs_data[cfg_name] = _cpp_info_to_dict(cfg_cpp_info)
             doc["configs"] = configs_data
             continue
+        if it == "components":
+            doc[it] = {}
+            for comp_name, comp in value.items():
+                doc[it][comp_name] = _cpp_info_to_dict(comp)
+            continue
 
         doc[it] = value
     return doc

--- a/conans/test/functional/command/create_test.py
+++ b/conans/test/functional/command/create_test.py
@@ -518,17 +518,17 @@ class MyPkg(ConanFile):
     def test_compoents_json_output(self):
         self.client = TestClient()
         conanfile = textwrap.dedent("""
-        from conans import ConanFile
+            from conans import ConanFile
 
-        class MyTest(ConanFile):
-            name = "pkg"
-            version = "0.1"
-            settings = "build_type"
+            class MyTest(ConanFile):
+                name = "pkg"
+                version = "0.1"
+                settings = "build_type"
 
-            def package_info(self):
-                self.cpp_info.components["pkg1"].libs = ["libpkg1"]
-                self.cpp_info.components["pkg2"].libs = ["libpkg2"]
-                self.cpp_info.components["pkg2"].requires = ["pkg1"]
+                def package_info(self):
+                    self.cpp_info.components["pkg1"].libs = ["libpkg1"]
+                    self.cpp_info.components["pkg2"].libs = ["libpkg2"]
+                    self.cpp_info.components["pkg2"].requires = ["pkg1"]
             """)
         self.client.save({"conanfile.py": conanfile})
         self.client.run("create . --json jsonfile.json")

--- a/conans/test/functional/command/create_test.py
+++ b/conans/test/functional/command/create_test.py
@@ -1,3 +1,4 @@
+import json
 import os
 import textwrap
 import unittest
@@ -513,3 +514,29 @@ class MyPkg(ConanFile):
         self.assertNotIn("/_", conaninfo)
         self.assertIn("[full_requires]\n    Hello/0.1:{}\n".format(NO_SETTINGS_PACKAGE_ID),
                       conaninfo)
+
+    def test_compoents_json_output(self):
+        self.client = TestClient()
+        conanfile = textwrap.dedent("""
+        from conans import ConanFile
+
+        class MyTest(ConanFile):
+            name = "pkg"
+            version = "0.1"
+            settings = "build_type"
+
+            def package_info(self):
+                self.cpp_info.components["pkg1"].libs = ["libpkg1"]
+                self.cpp_info.components["pkg2"].libs = ["libpkg2"]
+                self.cpp_info.components["pkg2"].requires = ["pkg1"]
+            """)
+        self.client.save({"conanfile.py": conanfile})
+        self.client.run("create . --json jsonfile.json")
+        path = os.path.join(self.client.current_folder, "jsonfile.json")
+        content = self.client.load(path)
+        data = json.loads(content)
+        cpp_info_data = data["installed"][0]["packages"][0]["cpp_info"]
+        self.assertIn("libpkg1", cpp_info_data["components"]["pkg1"]["libs"])
+        self.assertNotIn("requires", cpp_info_data["components"]["pkg1"])
+        self.assertIn("libpkg2", cpp_info_data["components"]["pkg2"]["libs"])
+        self.assertListEqual(["pkg1"], cpp_info_data["components"]["pkg2"]["requires"])


### PR DESCRIPTION
Changelog: Bugfix: Fix json output serialization for ``cpp_info.components``.
Docs: Omit

- [x] Refer to the issue that supports this Pull Request: https://github.com/conan-io/conan-center-index/pull/1541#issuecomment-624709335
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [x] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 

<sup>**Note:** By default this PR will skip the slower tests and will use a limited set of python versions. Check [here](https://github.com/conan-io/conan/blob/develop/.github/PR_INCREASE_TESTING.md) how to increase the testing level by writing some tags in the current PR body text.</sup>
