### PR TITLE
cmake_paths generator appends Conan paths to CMAKE_MODULE_PATH and CM…

### DIFF
--- a/conans/client/generators/cmake_paths.py
+++ b/conans/client/generators/cmake_paths.py
@@ -25,9 +25,9 @@ class CMakePathsGenerator(Generator):
         #    if the user used the "cmake_find_package" will find the auto-generated
         # 4. The CMake installation dir/Modules ones.
         deps = DepsCppCmake(self.deps_build_info)
-        lines.append("set(CMAKE_MODULE_PATH {deps.build_paths} ${{CMAKE_MODULE_PATH}} "
+        lines.append("list(APPEND CMAKE_MODULE_PATH {deps.build_paths} ${{CMAKE_MODULE_PATH}} "
                      "${{CMAKE_CURRENT_LIST_DIR}})".format(deps=deps))
-        lines.append("set(CMAKE_PREFIX_PATH {deps.build_paths} ${{CMAKE_PREFIX_PATH}} "
+        lines.append("list(APPEND CMAKE_PREFIX_PATH {deps.build_paths} ${{CMAKE_PREFIX_PATH}} "
                      "${{CMAKE_CURRENT_LIST_DIR}})".format(deps=deps))
 
         return "\n".join(lines)

--- a/conans/test/functional/generators/cmake_paths_test.py
+++ b/conans/test/functional/generators/cmake_paths_test.py
@@ -21,9 +21,9 @@ class CMakePathsGeneratorTest(unittest.TestCase):
         contents = client.load("conan_paths.cmake")
         expected = 'set(CONAN_LIB2_ROOT "{pfolder2}")\r\n' \
                    'set(CONAN_LIB1_ROOT "{pfolder1}")\r\n' \
-                   'set(CMAKE_MODULE_PATH "{pfolder2}/"\r\n\t\t\t"{pfolder1}/" ' \
+                   'list(APPEND CMAKE_MODULE_PATH "{pfolder2}/"\r\n\t\t\t"{pfolder1}/" ' \
                    '${{CMAKE_MODULE_PATH}} ${{CMAKE_CURRENT_LIST_DIR}})\r\n' \
-                   'set(CMAKE_PREFIX_PATH "{pfolder2}/"\r\n\t\t\t"{pfolder1}/" ' \
+                   'list(APPEND CMAKE_PREFIX_PATH "{pfolder2}/"\r\n\t\t\t"{pfolder1}/" ' \
                    '${{CMAKE_PREFIX_PATH}} ${{CMAKE_CURRENT_LIST_DIR}})'
         if platform.system() != "Windows":
             expected = expected.replace("\r", "")


### PR DESCRIPTION
…AKE_PREFIX_PATH rather than overrides those variables

It is not unrare when CMAKE_MODULE_PATH and/or CMAKE_PREFIX_PATH are passed
to CMake via command line or set by CMake initial cache script thus it's
less intrusive if cmake_paths generator appends Conan paths to aforementioned
variables rather than overrides them.

Changelog: (Feature | Fix | Bugfix): Describe here your pull request
Docs: https://github.com/conan-io/docs/pull/XXXX

- [ ] Refer to the issue that supports this Pull Request.
- [ ] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [ ] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [ ] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 

<sup>**Note:** By default this PR will skip the slower tests and will use a limited set of python versions. Check [here](https://github.com/conan-io/conan/blob/develop/.github/PR_INCREASE_TESTING.md) how to increase the testing level by writing some tags in the current PR body text.</sup>
