### PR TITLE
Feature/direct path

### DIFF
--- a/conans/model/build_info.py
+++ b/conans/model/build_info.py
@@ -77,7 +77,7 @@ class _CppInfo(object):
     def _filter_paths(self, paths):
         abs_paths = [os.path.join(self.rootpath, p)
                      if not os.path.isabs(p) else p for p in paths]
-        abs_paths = [p if os.path.isdir(p) else conan_v2_behavior(str(p) + " is not a directory")
+        abs_paths = [p if os.path.isdir(p) else conan_v2_behavior("Warning: " + str(p) + " is not a directory")
         for p in abs_paths]
         if self.filter_empty:
             return [p for p in abs_paths if os.path.isdir(p)]

--- a/conans/model/build_info.py
+++ b/conans/model/build_info.py
@@ -78,7 +78,7 @@ class _CppInfo(object):
         abs_paths = [os.path.join(self.rootpath, p)
                      if not os.path.isabs(p) else p for p in paths]
         abs_paths = [
-                    p if os.path.isdir(p)
+                    p if (p and os.path.isdir(p))
                     else conan_v2_behavior("Warning: " + str(p) + " is not a directory")
                     for p in abs_paths]
         if self.filter_empty:

--- a/conans/model/build_info.py
+++ b/conans/model/build_info.py
@@ -77,6 +77,8 @@ class _CppInfo(object):
     def _filter_paths(self, paths):
         abs_paths = [os.path.join(self.rootpath, p)
                      if not os.path.isabs(p) else p for p in paths]
+        abs_paths = [p if os.path.isdir(p) else conan_v2_behavior(str(p) + " is not a directory")
+        for p in abs_paths]
         if self.filter_empty:
             return [p for p in abs_paths if os.path.isdir(p)]
         else:

--- a/conans/model/build_info.py
+++ b/conans/model/build_info.py
@@ -82,7 +82,7 @@ class _CppInfo(object):
                     else conan_v2_behavior("Warning: " + str(p) + " is not a directory")
                     for p in abs_paths]
         if self.filter_empty:
-            return [p for p in abs_paths if os.path.isdir(p)]
+            return [p for p in abs_paths if (p and os.path.isdir(p))]
         else:
             return abs_paths
 

--- a/conans/model/build_info.py
+++ b/conans/model/build_info.py
@@ -77,8 +77,10 @@ class _CppInfo(object):
     def _filter_paths(self, paths):
         abs_paths = [os.path.join(self.rootpath, p)
                      if not os.path.isabs(p) else p for p in paths]
-        abs_paths = [p if os.path.isdir(p) else conan_v2_behavior("Warning: " + str(p) + " is not a directory")
-        for p in abs_paths]
+        abs_paths = [
+                    p if os.path.isdir(p)
+                    else conan_v2_behavior("Warning: " + str(p) + " is not a directory")
+                    for p in abs_paths]
         if self.filter_empty:
             return [p for p in abs_paths if os.path.isdir(p)]
         else:
@@ -508,3 +510,4 @@ class DepsCppInfo(_BaseDepsCppInfo):
         super(DepsCppInfo, self).update(cpp_info)
         for config, cpp_info in cpp_info.configs.items():
             self.configs.setdefault(config, _BaseDepsCppInfo()).update(cpp_info)
+


### PR DESCRIPTION
Changelog: (Feature): Issue #6813 
```os.path.isdir``` returns False if the file doesn't exist. So a separate check for the cases where it is a not a directory, but a file, or just doesn't exist needs to be made if different warnings are to be generated for the two cases.
Docs: 

- [x] Refer to the issue that supports this Pull Request.
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 

<sup>**Note:** By default this PR will skip the slower tests and will use a limited set of python versions. Check [here](https://github.com/conan-io/conan/blob/develop/.github/PR_INCREASE_TESTING.md) how to increase the testing level by writing some tags in the current PR body text.</sup>
