### PR TITLE
Fix: `conan config install` - overwrite read-only files / don't copy file permissions

### DIFF
--- a/conans/client/conf/config_installer.py
+++ b/conans/client/conf/config_installer.py
@@ -1,6 +1,7 @@
 import json
 import os
 import shutil
+import stat
 from datetime import datetime
 from dateutil.tz import gettz
 
@@ -80,6 +81,7 @@ def _filecopy(src, filename, dst):
     src = os.path.join(src, filename)
     dst = os.path.join(dst, filename)
     if os.path.exists(dst):
+        os.chmod(dst, stat.S_IWRITE)  # make file writable
         os.remove(dst)
     shutil.copy(src, dst)
 

--- a/conans/client/conf/config_installer.py
+++ b/conans/client/conf/config_installer.py
@@ -15,7 +15,7 @@ from conans.client.cache.remote_registry import load_registry_txt,\
 from conans.client.tools import Git
 from conans.client.tools.files import unzip
 from conans.errors import ConanException
-from conans.util.files import mkdir, rmdir, walk, save, touch
+from conans.util.files import mkdir, rmdir, walk, save, touch, remove
 from conans.client.cache.cache import ClientCache
 
 
@@ -81,8 +81,7 @@ def _filecopy(src, filename, dst):
     src = os.path.join(src, filename)
     dst = os.path.join(dst, filename)
     if os.path.exists(dst):
-        os.chmod(dst, stat.S_IWRITE)  # make file writable
-        os.remove(dst)
+        remove(dst)
     shutil.copyfile(src, dst)
 
 

--- a/conans/client/conf/config_installer.py
+++ b/conans/client/conf/config_installer.py
@@ -83,7 +83,7 @@ def _filecopy(src, filename, dst):
     if os.path.exists(dst):
         os.chmod(dst, stat.S_IWRITE)  # make file writable
         os.remove(dst)
-    shutil.copy(src, dst)
+    shutil.copyfile(src, dst)
 
 
 def _process_folder(config, folder, cache, output):

--- a/conans/test/functional/command/config_install_test.py
+++ b/conans/test/functional/command/config_install_test.py
@@ -1,7 +1,6 @@
 import json
 import os
 import shutil
-import stat
 import textwrap
 import time
 import unittest
@@ -17,8 +16,7 @@ from conans.client.rest.file_downloader import FileDownloader
 from conans.errors import ConanException
 from conans.test.utils.test_files import temp_folder
 from conans.test.utils.tools import TestClient, StoppableThreadBottle
-from conans.util.files import load, mkdir, save, save_files
-
+from conans.util.files import load, mkdir, save, save_files, make_file_read_only
 
 win_profile = """[settings]
     os: Windows
@@ -533,7 +531,7 @@ class Pkg(ConanFile):
         source_folder = self._create_profile_folder()
         self.client.run('config install "%s"' % source_folder)
         # make existing settings.yml read-only
-        os.chmod(self.client.cache.settings_path, stat.S_IREAD | stat.S_IRGRP | stat.S_IROTH)
+        make_file_read_only(self.client.cache.settings_path)
         self.assertFalse(os.access(self.client.cache.settings_path, os.W_OK))
 
         # config install should overwrite the existing read-only file
@@ -543,8 +541,7 @@ class Pkg(ConanFile):
     def test_dont_copy_file_permissions(self):
         source_folder = self._create_profile_folder()
         # make source settings.yml read-only
-        os.chmod(os.path.join(source_folder, 'remotes.txt'),
-                 stat.S_IREAD | stat.S_IRGRP | stat.S_IROTH)
+        make_file_read_only(os.path.join(source_folder, 'remotes.txt'))
 
         self.client.run('config install "%s"' % source_folder)
         self.assertTrue(os.access(self.client.cache.settings_path, os.W_OK))

--- a/conans/test/functional/command/config_install_test.py
+++ b/conans/test/functional/command/config_install_test.py
@@ -530,14 +530,23 @@ class Pkg(ConanFile):
         http_server.stop()
 
     def test_overwrite_read_only_file(self):
-        folder = self._create_profile_folder()
-        self.client.run('config install "%s"' % folder)
+        source_folder = self._create_profile_folder()
+        self.client.run('config install "%s"' % source_folder)
         # make existing settings.yml read-only
         os.chmod(self.client.cache.settings_path, stat.S_IREAD | stat.S_IRGRP | stat.S_IROTH)
         self.assertFalse(os.access(self.client.cache.settings_path, os.W_OK))
 
         # config install should overwrite the existing read-only file
-        self.client.run('config install "%s"' % folder)
+        self.client.run('config install "%s"' % source_folder)
+        self.assertTrue(os.access(self.client.cache.settings_path, os.W_OK))
+
+    def test_dont_copy_file_permissions(self):
+        source_folder = self._create_profile_folder()
+        # make source settings.yml read-only
+        os.chmod(os.path.join(source_folder, 'remotes.txt'),
+                 stat.S_IREAD | stat.S_IRGRP | stat.S_IROTH)
+
+        self.client.run('config install "%s"' % source_folder)
         self.assertTrue(os.access(self.client.cache.settings_path, os.W_OK))
 
 

--- a/conans/util/files.py
+++ b/conans/util/files.py
@@ -31,12 +31,16 @@ def walk(top, **kwargs):
     return os.walk(top, **kwargs)
 
 
-def make_read_only(path):
-    for root, _, files in walk(path):
+def make_read_only(folder_path):
+    for root, _, files in walk(folder_path):
         for f in files:
             full_path = os.path.join(root, f)
-            mode = os.stat(full_path).st_mode
-            os.chmod(full_path, mode & ~ stat.S_IWRITE)
+            make_file_read_only(full_path)
+
+
+def make_file_read_only(file_path):
+    mode = os.stat(file_path).st_mode
+    os.chmod(file_path, mode & ~ stat.S_IWRITE)
 
 
 _DIRTY_FOLDER = ".dirty"


### PR DESCRIPTION
Changelog: Fix: ``conan config install`` can overwrite read-only files and won't copy permissions.
Docs: omit

- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.

Issue when running `conan config install [...]` (existing `settings.yml` is read-only!)
```
Installing settings.yml
Traceback (most recent call last):
 File "conan\conans\client\command.py", line 1607, in run
 File "conan\conans\client\command.py", line 478, in config
 File "conan\conans\client\conan_api.py", line 92, in wrapper
 File "conan\conans\client\conan_api.py", line 621, in config_install
 File "conan\conans\client\conf\config_installer.py", line 230, in configuration_install
 File "conan\conans\client\conf\config_installer.py", line 182, in _process_config
 File "conan\conans\client\conf\config_installer.py", line 85, in _process_folder
 File "shutil.py", line 241, in copy
 File "shutil.py", line 121, in copyfile
PermissionError: [Errno 13] Permission denied: 'D:\\TC\\work\\3895a438cac8f82f\\.conan\\settings.yml
```

In Linux the issue doesn't occur.
In my case the cause was a read only permission in the "source" configuration directory. In my mind `conan config install` should overwrite read-only files (in conan cache) and shouldn't copy file permissions.