### PR TITLE
Write generators only once

### DIFF
--- a/conans/client/generators/__init__.py
+++ b/conans/client/generators/__init__.py
@@ -88,7 +88,7 @@ registered_generators.add("markdown", MarkdownGenerator)
 def write_generators(conanfile, path, output):
     """ produces auxiliary files, required to build a project or a package.
     """
-    for generator_name in conanfile.generators:
+    for generator_name in set(conanfile.generators):
         try:
             generator_class = registered_generators[generator_name]
         except KeyError:

--- a/conans/test/functional/conanfile/generators_list_test.py
+++ b/conans/test/functional/conanfile/generators_list_test.py
@@ -1,0 +1,62 @@
+import textwrap
+import unittest
+
+from conans.test.utils.tools import TestClient
+
+
+class ConanfileRepeatedGeneratorsTestCase(unittest.TestCase):
+
+    def test_conanfile_txt(self):
+        conanfile = textwrap.dedent("""
+            [generators]
+            cmake
+            cmake_find_package
+            cmake
+        """)
+
+        t = TestClient()
+        t.save({'conanfile.txt': conanfile})
+        t.run("install conanfile.txt")
+        self.assertEqual(str(t.out).count("Generator cmake created"), 1)
+
+    def test_conanfile_py(self):
+        conanfile = textwrap.dedent("""
+            from conans import ConanFile
+
+            class Recipe(ConanFile):
+                generators = "cmake", "cmake_find_package", "cmake"
+        """)
+        t = TestClient()
+        t.save({'conanfile.py': conanfile})
+        t.run("install conanfile.py")
+        self.assertEqual(str(t.out).count("Generator cmake created"), 1)
+
+    def test_python_requires_inheritance(self):
+        pyreq = textwrap.dedent("""
+            from conans import ConanFile
+
+            class Recipe(ConanFile):
+                pass
+
+            class BaseConan(object):
+                generators = "cmake", "cmake_find_package"
+        """)
+        conanfile = textwrap.dedent("""
+            from conans import ConanFile
+
+            class Recipe(ConanFile):
+                python_requires = "base/1.0"
+                python_requires_extend = "base.BaseConan"
+
+                generators = "cmake", "cmake_find_package"
+
+                def init(self):
+                    base = self.python_requires["base"].module.BaseConan
+                    self.generators = base.generators + self.generators
+        """)
+
+        t = TestClient()
+        t.save({'pyreq.py': pyreq, 'conanfile.py': conanfile})
+        t.run("export pyreq.py base/1.0@")
+        t.run("install conanfile.py")
+        self.assertEqual(str(t.out).count("Generator cmake created"), 1)


### PR DESCRIPTION
Changelog: omit
Docs: omit

This PR ensures that generators are written only once even if they are repeated

closes https://github.com/conan-io/docs/issues/1680
