### PR TITLE
fix autotools build helper in xbuild

### DIFF
--- a/conans/client/tools/oss.py
+++ b/conans/client/tools/oss.py
@@ -576,6 +576,9 @@ def get_build_os_arch(conanfile):
 def get_target_os_arch(conanfile):
     """ Returns the value for the 'os' and 'arch' settings for the target context """
     if hasattr(conanfile, 'settings_target'):
-        return conanfile.settings_target.get_safe('os'), conanfile.settings_target.get_safe('arch')
+        settings_target = conanfile.settings_target
+        if settings_target is not None:
+            return settings_target.get_safe('os'), settings_target.get_safe('arch')
+        return None, None
     else:
         return conanfile.settings.get_safe('os_target'), conanfile.settings.get_safe('arch_target')

--- a/conans/test/functional/cross_building/build_helper_test.py
+++ b/conans/test/functional/cross_building/build_helper_test.py
@@ -1,0 +1,25 @@
+import textwrap
+import unittest
+
+from conans.test.utils.tools import TestClient
+
+
+class BuildHelperTest(unittest.TestCase):
+    def test_autotools_helper(self):
+        client = TestClient()
+        conanfile = textwrap.dedent("""
+            from conans import ConanFile, AutoToolsBuildEnvironment
+
+            class Pkg(ConanFile):
+                def build(self):
+                    AutoToolsBuildEnvironment(self)
+
+        """)
+        client.save({"conanfile.py": conanfile,
+                     "host": "",
+                     "build": ""})
+        client.run("create . pkg/1.0@ --profile:build=build --profile:host=host")
+        self.assertIn("Configuration (profile_host):", client.out)
+        self.assertIn("Configuration (profile_build):", client.out)
+        self.assertIn("pkg/1.0: Calling build()", client.out)
+        self.assertIn("pkg/1.0: Created package", client.out)


### PR DESCRIPTION
Changelog: Bugfix: Fix broken ``AutoToolsBuildEnvironment`` when a profile:build is defined.
Docs: omit

Fix https://github.com/conan-io/conan/issues/7025

#tags: slow