### PR TITLE
remove dst symlink before copy in deploy generator

### DIFF
--- a/conans/client/generators/deploy.py
+++ b/conans/client/generators/deploy.py
@@ -44,7 +44,13 @@ class DeployGenerator(Generator):
                     mkdir(os.path.dirname(dst))
                     if os.path.islink(src) and os.path.exists(dst):
                         os.unlink(dst)
-                    shutil.copy(src, dst, follow_symlinks=False)
-
+                    if os.path.islink(src):
+                        link_target = os.readlink(src)
+                        if not os.path.isabs(link_target):
+                            link_target = os.path.join(os.path.dirname(src), link_target)
+                        linkto = os.path.relpath(link_target, os.path.dirname(src))
+                        os.symlink(linkto, dst)
+                    else:
+                        shutil.copy(src, dst)
                     copied_files.append(dst)
         return self.deploy_manifest_content(copied_files)

--- a/conans/client/generators/deploy.py
+++ b/conans/client/generators/deploy.py
@@ -42,7 +42,6 @@ class DeployGenerator(Generator):
                                        os.path.relpath(root, rootpath), f)
                     dst = os.path.normpath(dst)
                     mkdir(os.path.dirname(dst))
-                    print('copy to {}, is link: {}, exists {}'.format(dst, os.path.islink(src), os.path.exists(dst)))
                     if os.path.islink(src) and (os.path.exists(dst) or os.path.islink(dst)):
                         os.unlink(dst)
                     if os.path.islink(src):
@@ -50,7 +49,6 @@ class DeployGenerator(Generator):
                         if not os.path.isabs(link_target):
                             link_target = os.path.join(os.path.dirname(src), link_target)
                         linkto = os.path.relpath(link_target, os.path.dirname(src))
-                        print('linkto %s'%linkto)
                         os.symlink(linkto, dst)
                     else:
                         shutil.copy(src, dst)

--- a/conans/client/generators/deploy.py
+++ b/conans/client/generators/deploy.py
@@ -42,6 +42,8 @@ class DeployGenerator(Generator):
                                        os.path.relpath(root, rootpath), f)
                     dst = os.path.normpath(dst)
                     mkdir(os.path.dirname(dst))
+                    if os.path.islink(src) and os.path.exists(dst):
+                        os.unlink(dst)
                     shutil.copy(src, dst, follow_symlinks=False)
 
                     copied_files.append(dst)

--- a/conans/client/generators/deploy.py
+++ b/conans/client/generators/deploy.py
@@ -42,13 +42,7 @@ class DeployGenerator(Generator):
                                        os.path.relpath(root, rootpath), f)
                     dst = os.path.normpath(dst)
                     mkdir(os.path.dirname(dst))
-                    if os.path.islink(src):
-                        link_target = os.readlink(src)
-                        if not os.path.isabs(link_target):
-                            link_target = os.path.join(os.path.dirname(src), link_target)
-                        linkto = os.path.relpath(link_target, os.path.dirname(src))
-                        os.symlink(linkto, dst)
-                    else:
-                        shutil.copy(src, dst)
+                    shutil.copy(src, dst, follow_symlinks=False)
+
                     copied_files.append(dst)
         return self.deploy_manifest_content(copied_files)

--- a/conans/client/generators/deploy.py
+++ b/conans/client/generators/deploy.py
@@ -42,13 +42,15 @@ class DeployGenerator(Generator):
                                        os.path.relpath(root, rootpath), f)
                     dst = os.path.normpath(dst)
                     mkdir(os.path.dirname(dst))
-                    if os.path.islink(src) and os.path.exists(dst):
+                    print('copy to {}, is link: {}, exists {}'.format(dst, os.path.islink(src), os.path.exists(dst)))
+                    if os.path.islink(src) and (os.path.exists(dst) or os.path.islink(dst)):
                         os.unlink(dst)
                     if os.path.islink(src):
                         link_target = os.readlink(src)
                         if not os.path.isabs(link_target):
                             link_target = os.path.join(os.path.dirname(src), link_target)
                         linkto = os.path.relpath(link_target, os.path.dirname(src))
+                        print('linkto %s'%linkto)
                         os.symlink(linkto, dst)
                     else:
                         shutil.copy(src, dst)


### PR DESCRIPTION
- ~~We are not supporting python2 any more. the `follow_symlinks=False` do exactly what we expected. #6994~~ revert to not to break python2
- it fix #7037. we should remove old symlink before create new one.


- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.

<sup>**Note:** By default this PR will skip the slower tests and will use a limited set of python versions. Check [here](https://github.com/conan-io/conan/blob/develop/.github/PR_INCREASE_TESTING.md) how to increase the testing level by writing some tags in the current PR body text.</sup>
