### PR TITLE
[release/1.25] meson: do not always overwrite default cpp_std

### DIFF
--- a/conans/client/build/meson.py
+++ b/conans/client/build/meson.py
@@ -47,14 +47,15 @@ class Meson(object):
         # C++ standard
         cppstd = cppstd_from_settings(self._conanfile.settings)
         cppstd_conan2meson = {
-            None: 'none',
             '98': 'c++03', 'gnu98': 'gnu++03',
             '11': 'c++11', 'gnu11': 'gnu++11',
             '14': 'c++14', 'gnu14': 'gnu++14',
             '17': 'c++17', 'gnu17': 'gnu++17',
             '20': 'c++1z', 'gnu20': 'gnu++1z'
         }
-        self.options['cpp_std'] = cppstd_conan2meson[cppstd]
+        
+        if cppstd:
+            self.options['cpp_std'] = cppstd_conan2meson[cppstd]
 
         # shared
         shared = self._so("shared")

--- a/conans/test/unittests/client/build/meson_test.py
+++ b/conans/test/unittests/client/build/meson_test.py
@@ -74,8 +74,7 @@ class MesonTest(unittest.TestCase):
             'bindir': 'bin',
             'sbindir': 'bin',
             'libexecdir': 'bin',
-            'includedir': 'include',
-            'cpp_std': 'none'
+            'includedir': 'include'
         }
 
         meson.configure(source_dir=os.path.join(self.tempdir, "../subdir"),


### PR DESCRIPTION
Changelog: Bugfix: Previously conan always set ``cpp_std`` option in meson project, even if ``cppstd`` option was not set in conan profile. Now it sets the option only if ``cppstd`` profile option has a concrete value.
Docs: Omit

backport of 1.26 merged fix in https://github.com/conan-io/conan/pull/6895