### PR TITLE
Auto origin deduced as none if no origin

### DIFF
--- a/conans/client/cmd/export.py
+++ b/conans/client/cmd/export.py
@@ -257,6 +257,8 @@ def _capture_scm_auto_fields(conanfile, conanfile_dir, package_layout, output, i
         if scm.is_local_repository():
             output.warn("Repo origin looks like a local path: %s" % origin)
         output.success("Repo origin deduced by 'auto': %s" % origin)
+        if origin is None:
+            output.warn("origin is None, upload' command will prevent uploading recipes with None values in these fields.")
         scm_data.url = origin
 
     if scm_data.revision == "auto":

--- a/conans/client/cmd/export.py
+++ b/conans/client/cmd/export.py
@@ -252,11 +252,8 @@ def _capture_scm_auto_fields(conanfile, conanfile_dir, package_layout, output, i
         origin = scm.get_qualified_remote_url(remove_credentials=True)
         local_src_path = scm.get_local_path_to_url(origin)
         return scm_data, local_src_path
-
     if scm_data.url == "auto":
         origin = scm.get_qualified_remote_url(remove_credentials=True)
-        if not origin:
-            raise ConanException("Repo origin cannot be deduced")
         if scm.is_local_repository():
             output.warn("Repo origin looks like a local path: %s" % origin)
         output.success("Repo origin deduced by 'auto': %s" % origin)
@@ -270,7 +267,6 @@ def _capture_scm_auto_fields(conanfile, conanfile_dir, package_layout, output, i
 
     local_src_path = scm.get_local_path_to_url(scm_data.url)
     _replace_scm_data_in_recipe(package_layout, scm_data, scm_to_conandata)
-
     return scm_data, local_src_path
 
 

--- a/conans/client/cmd/export.py
+++ b/conans/client/cmd/export.py
@@ -257,9 +257,15 @@ def _capture_scm_auto_fields(conanfile, conanfile_dir, package_layout, output, i
         if scm.is_local_repository():
             output.warn("Repo origin looks like a local path: %s" % origin)
         output.success("Repo origin deduced by 'auto': %s" % origin)
-        if origin is None:
-            output.warn("origin is None, upload' command will prevent uploading recipes with None values in these fields.")
-        scm_data.url = origin
+        if origin:
+            scm_data.url = origin
+        else:
+            output.warn(
+                "origin is auto, upload' command will prevent uploading recipes with None values in these fields.")
+
+    if scm_data.url is None:
+        output.warn(
+            "origin is None, upload' command will prevent uploading recipes with None values in these fields.")
 
     if scm_data.revision == "auto":
         # If it is pristine by default we don't replace the "auto" unless forcing

--- a/conans/client/cmd/uploader.py
+++ b/conans/client/cmd/uploader.py
@@ -295,8 +295,8 @@ class CmdUpload(object):
         if policy != UPLOAD_POLICY_FORCE:
             # Check SCM data for auto fields
             if hasattr(conanfile, "scm") and (
-                    conanfile.scm.get("url") == "auto" or conanfile.scm.get("revision") == "auto"):
-                raise ConanException("The recipe has 'scm.url' or 'scm.revision' with 'auto' "
+                    conanfile.scm.get("url") == None or conanfile.scm.get("url") == "auto" or conanfile.scm.get("revision") == "auto"):
+                raise ConanException("The recipe has 'scm.url' with None or 'auto', or 'scm.revision' with 'auto' "
                                      "values. Use '--force' to ignore this error or export again "
                                      "the recipe ('conan export' or 'conan create') in a "
                                      "repository with no-uncommitted changes or by "

--- a/conans/client/tools/scm.py
+++ b/conans/client/tools/scm.py
@@ -191,7 +191,7 @@ class Git(SCMBase):
             name, url = remote.split(None, 1)
             if name == remote_name:
                 url, _ = url.rsplit(None, 1)
-                if remove_credentials and not os.path.exists(url):  # only if not local
+                if url and remove_credentials and not os.path.exists(url):  # only if not local
                     url = self._remove_credentials_url(url)
                 if os.path.exists(url):  # Windows local directory
                     url = url.replace("\\", "/")
@@ -200,7 +200,10 @@ class Git(SCMBase):
 
     def is_local_repository(self):
         url = self.get_remote_url()
-        return os.path.exists(url)
+        if url:
+            return os.path.exists(url)
+        else:
+            return None
 
     def get_commit(self):
         self.check_repo()
@@ -342,7 +345,7 @@ class SVN(SCMBase):
 
     def get_remote_url(self, remove_credentials=False):
         url = self._show_item('url')
-        if remove_credentials and not os.path.exists(url):  # only if not local
+        if url and remove_credentials and not os.path.exists(url):  # only if not local
             url = self._remove_credentials_url(url)
         return url
 
@@ -354,8 +357,11 @@ class SVN(SCMBase):
 
     def is_local_repository(self):
         url = self.get_remote_url()
-        return (url.startswith(self.file_protocol) and
+        if url:
+            return (url.startswith(self.file_protocol) and
                 os.path.exists(unquote(url[len(self.file_protocol):])))
+        else:
+            return True
 
     def is_pristine(self):
         # Check if working copy is pristine/consistent

--- a/conans/test/functional/scm/scm_test.py
+++ b/conans/test/functional/scm/scm_test.py
@@ -1033,7 +1033,7 @@ class SCMBlockUploadTest(unittest.TestCase):
         # The upload has to fail, no "auto" fields are allowed
         client.run("upload lib/0.1@user/channel -r default", assert_error=True)
         self.assertIn("ERROR: lib/0.1@user/channel: Upload recipe to 'default' failed: "
-                      "The recipe has 'scm.url' or 'scm.revision' with 'auto' values. "
+                      "The recipe has 'scm.url' with None or 'auto', or 'scm.revision' with 'auto' values. "
                       "Use '--force' to ignore", client.out)
         # The upload with --force should work
         client.run("upload lib/0.1@user/channel -r default --force")

--- a/conans/test/functional/scm/scm_test.py
+++ b/conans/test/functional/scm/scm_test.py
@@ -127,7 +127,7 @@ class ConanLib(ConanFile):
         conanfile = base_git.format(directory="None", url=_quoted("auto"), revision="auto")
         self.client.save({"conanfile.py": conanfile, "myfile.txt": "My file is copied"})
         create_local_git_repo(folder=self.client.current_folder)
-        self.client.run("export . user/channel", assert_error=False)
+        self.client.run("export . user/channel")
         self.assertIn("Repo origin deduced by 'auto': None", self.client.out)
         self.assertIn("Revision deduced by 'auto'", self.client.out)
 

--- a/conans/test/functional/scm/scm_test.py
+++ b/conans/test/functional/scm/scm_test.py
@@ -128,7 +128,8 @@ class ConanLib(ConanFile):
         self.client.save({"conanfile.py": conanfile, "myfile.txt": "My file is copied"})
         create_local_git_repo(folder=self.client.current_folder)
         self.client.run("export . user/channel", assert_error=True)
-        self.assertIn("Repo origin cannot be deduced", self.client.out)
+        self.assertIn("Repo origin deduced by 'auto': None", self.client.out)
+        self.assertIn("Revision deduced by 'auto'", self.client.out)
 
         self.client.run_command('git remote add origin https://myrepo.com.git')
 

--- a/conans/test/functional/scm/scm_test.py
+++ b/conans/test/functional/scm/scm_test.py
@@ -127,7 +127,7 @@ class ConanLib(ConanFile):
         conanfile = base_git.format(directory="None", url=_quoted("auto"), revision="auto")
         self.client.save({"conanfile.py": conanfile, "myfile.txt": "My file is copied"})
         create_local_git_repo(folder=self.client.current_folder)
-        self.client.run("export . user/channel", assert_error=True)
+        self.client.run("export . user/channel", assert_error=False)
         self.assertIn("Repo origin deduced by 'auto': None", self.client.out)
         self.assertIn("Revision deduced by 'auto'", self.client.out)
 

--- a/conans/test/functional/scm/test_command_export.py
+++ b/conans/test/functional/scm/test_command_export.py
@@ -58,6 +58,6 @@ class ExportCommandTestCase(unittest.TestCase):
                                                                     rev_value=rev_value)})
         self.client = TestClient()
         self.client.current_folder = self.path
-        self.client.run("export . lib/version@user/channel", assert_error=bool(auto_url))
+        self.client.run("export . lib/version@user/channel")
         if auto_url:
-            self.assertIn("ERROR: Repo origin cannot be deduced", self.client.out)
+            self.assertIn("Repo origin deduced by 'auto': None", self.client.out)


### PR DESCRIPTION
Changelog: Fix: Do not modify `scm` attribute when the `origin` remote cannot be deduced.
Changelog: Bugfix: Do not allow uploading packages with missing information in the `scm` attribute.
Docs: omit

▶️  See https://github.com/conan-io/conan/pull/7095 for additional implementation on top of this PR.
▶️ Updated CLI: https://github.com/conan-io/conan/pull/7107


closes https://github.com/conan-io/conan/issues/7033

- [x] Refer to the issue that supports this Pull Request.
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.

<sup>**Note:** By default this PR will skip the slower tests and will use a limited set of python versions. Check [here](https://github.com/conan-io/conan/blob/develop/.github/PR_INCREASE_TESTING.md) how to increase the testing level by writing some tags in the current PR body text.</sup>
