### PR TITLE
try to fix package_id with package_revision_mode and mixed modes

### DIFF
--- a/conans/client/graph/graph.py
+++ b/conans/client/graph/graph.py
@@ -86,6 +86,24 @@ class Node(object):
         self._ancestors = _NodeOrderedDict()  # set{ref.name}
         self._id = None  # Unique ID (uuid at the moment) of a node in the graph
         self.graph_lock_node = None  # the locking information can be None
+        self.id_direct_prefs = None
+        self.id_indirect_prefs = None
+
+    def package_id_transitive_reqs(self):
+        """
+        accumulate the direct and transitive requirements prefs necessary to compute the
+        package_id
+        :return: set(prefs) of direct deps, set(prefs) of transitive deps
+        """
+        self.id_direct_prefs = set()  # of PackageReference
+        self.id_indirect_prefs = set()  # of PackageReference, avoid duplicates
+        for neighbor in self.neighbors():
+            self.id_direct_prefs.add(neighbor.pref)
+            self.id_indirect_prefs.update(neighbor.id_direct_prefs)
+            self.id_indirect_prefs.update(neighbor.id_indirect_prefs)
+        # Make sure not duplicated, totally necessary
+        self.id_indirect_prefs.difference_update(self.id_direct_prefs)
+        return self.id_direct_prefs, self.id_indirect_prefs
 
     @property
     def id(self):

--- a/conans/client/graph/graph.py
+++ b/conans/client/graph/graph.py
@@ -89,22 +89,6 @@ class Node(object):
         self.id_direct_prefs = None
         self.id_indirect_prefs = None
 
-    def package_id_transitive_reqs(self):
-        """
-        accumulate the direct and transitive requirements prefs necessary to compute the
-        package_id
-        :return: set(prefs) of direct deps, set(prefs) of transitive deps
-        """
-        self.id_direct_prefs = set()  # of PackageReference
-        self.id_indirect_prefs = set()  # of PackageReference, avoid duplicates
-        for neighbor in self.neighbors():
-            self.id_direct_prefs.add(neighbor.pref)
-            self.id_indirect_prefs.update(neighbor.id_direct_prefs)
-            self.id_indirect_prefs.update(neighbor.id_indirect_prefs)
-        # Make sure not duplicated, totally necessary
-        self.id_indirect_prefs.difference_update(self.id_direct_prefs)
-        return self.id_direct_prefs, self.id_indirect_prefs
-
     @property
     def id(self):
         return self._id

--- a/conans/client/graph/graph_binaries.py
+++ b/conans/client/graph/graph_binaries.py
@@ -272,8 +272,8 @@ class GraphBinariesAnalyzer(object):
         """
         node.id_direct_prefs = set()  # of PackageReference
         node.id_indirect_prefs = set()  # of PackageReference, avoid duplicates
-        neigbors = [d.dst for d in node.dependencies if not d.build_require]
-        for neighbor in neigbors:
+        neighbors = [d.dst for d in node.dependencies if not d.build_require]
+        for neighbor in neighbors:
             node.id_direct_prefs.add(neighbor.pref)
             node.id_indirect_prefs.update(neighbor.id_direct_prefs)
             node.id_indirect_prefs.update(neighbor.id_indirect_prefs)

--- a/conans/client/graph/graph_binaries.py
+++ b/conans/client/graph/graph_binaries.py
@@ -263,6 +263,23 @@ class GraphBinariesAnalyzer(object):
         conanfile.options.clear_unused(transitive_reqs)
         conanfile.options.freeze()
 
+    @staticmethod
+    def package_id_transitive_reqs(node):
+        """
+        accumulate the direct and transitive requirements prefs necessary to compute the
+        package_id
+        :return: set(prefs) of direct deps, set(prefs) of transitive deps
+        """
+        node.id_direct_prefs = set()  # of PackageReference
+        node.id_indirect_prefs = set()  # of PackageReference, avoid duplicates
+        for neighbor in node.neighbors():
+            node.id_direct_prefs.add(neighbor.pref)
+            node.id_indirect_prefs.update(neighbor.id_direct_prefs)
+            node.id_indirect_prefs.update(neighbor.id_indirect_prefs)
+        # Make sure not duplicated, totally necessary
+        node.id_indirect_prefs.difference_update(node.id_direct_prefs)
+        return node.id_direct_prefs, node.id_indirect_prefs
+
     def _compute_package_id(self, node, default_package_id_mode, default_python_requires_id_mode):
         """
         Compute the binary package ID of this node
@@ -283,7 +300,7 @@ class GraphBinariesAnalyzer(object):
             # Make sure not duplicated
             indirect_reqs.difference_update(direct_reqs)
         else:
-            direct_reqs, indirect_reqs = node.package_id_transitive_reqs()
+            direct_reqs, indirect_reqs = self.package_id_transitive_reqs(node)
 
         python_requires = getattr(conanfile, "python_requires", None)
         if python_requires:

--- a/conans/client/graph/graph_binaries.py
+++ b/conans/client/graph/graph_binaries.py
@@ -283,16 +283,7 @@ class GraphBinariesAnalyzer(object):
             # Make sure not duplicated
             indirect_reqs.difference_update(direct_reqs)
         else:
-            node.id_direct_prefs = set()  # of PackageReference
-            node.id_indirect_prefs = set()  # of PackageReference, avoid duplicates
-            for neighbor in neighbors:
-                node.id_direct_prefs.add(neighbor.pref)
-                node.id_indirect_prefs.update(neighbor.id_direct_prefs)
-                node.id_indirect_prefs.update(neighbor.id_indirect_prefs)
-            # Make sure not duplicated, totally necessary
-            node.id_indirect_prefs.difference_update(node.id_direct_prefs)
-            direct_reqs = node.id_direct_prefs
-            indirect_reqs = node.id_indirect_prefs
+            direct_reqs, indirect_reqs = node.package_id_transitive_reqs()
 
         python_requires = getattr(conanfile, "python_requires", None)
         if python_requires:

--- a/conans/client/graph/graph_binaries.py
+++ b/conans/client/graph/graph_binaries.py
@@ -272,7 +272,8 @@ class GraphBinariesAnalyzer(object):
         """
         node.id_direct_prefs = set()  # of PackageReference
         node.id_indirect_prefs = set()  # of PackageReference, avoid duplicates
-        for neighbor in node.neighbors():
+        neigbors = [d.dst for d in node.dependencies if not d.build_require]
+        for neighbor in neigbors:
             node.id_direct_prefs.add(neighbor.pref)
             node.id_indirect_prefs.update(neighbor.id_direct_prefs)
             node.id_indirect_prefs.update(neighbor.id_indirect_prefs)

--- a/conans/client/installer.py
+++ b/conans/client/installer.py
@@ -507,19 +507,19 @@ class BinaryInstaller(object):
             node.graph_lock_node.modified = GraphLockNode.MODIFIED_BUILT
         return pref
 
-    @staticmethod
-    def _propagate_info(node, using_build_profile, fixed_package_id):
+    def _propagate_info(self, node, using_build_profile, fixed_package_id):
         if fixed_package_id:
             # if using config.full_transitive_package_id, it is necessary to recompute
             # the node transitive information necessary to compute the package_id
             # as it will be used by reevaluate_node() when package_revision_mode is used and
             # PACKAGE_ID_UNKNOWN happens due to unknown revisions
-            node.package_id_transitive_reqs()
+            self._binaries_analyzer.package_id_transitive_reqs(node)
         # Get deps_cpp_info from upstream nodes
         node_order = [n for n in node.public_closure if n.binary != BINARY_SKIP]
         # List sort is stable, will keep the original order of the closure, but prioritize levels
         conan_file = node.conanfile
-        conan_file._conan_using_build_profile = using_build_profile  # FIXME: Not the best place to assign it
+        # FIXME: Not the best place to assign the _conan_using_build_profile
+        conan_file._conan_using_build_profile = using_build_profile
         transitive = [it for it in node.transitive_closure.values()]
 
         br_host = []

--- a/conans/client/installer.py
+++ b/conans/client/installer.py
@@ -395,13 +395,14 @@ class BinaryInstaller(object):
         self._raise_missing(missing)
         processed_package_refs = set()
         self._download(downloads, processed_package_refs)
+        fix_package_id = self._cache.config.full_transitive_package_id
 
         for level in nodes_by_level:
             for node in level:
                 ref, conan_file = node.ref, node.conanfile
                 output = conan_file.output
 
-                self._propagate_info(node, using_build_profile)
+                self._propagate_info(node, using_build_profile, fix_package_id)
                 if node.binary == BINARY_EDITABLE:
                     self._handle_node_editable(node, graph_info)
                     # Need a temporary package revision for package_revision_mode
@@ -415,12 +416,9 @@ class BinaryInstaller(object):
                         self._binaries_analyzer.reevaluate_node(node, remotes, build_mode, update)
                     _handle_system_requirements(conan_file, node.pref, self._cache, output)
                     self._handle_node_cache(node, keep_build, processed_package_refs, remotes)
-                # After a node has been managed, better reset its transitive info
-                if self._binaries_analyzer._fixed_package_id:
-                    node.package_id_transitive_reqs()
 
         # Finally, propagate information to root node (ref=None)
-        self._propagate_info(root_node, using_build_profile)
+        self._propagate_info(root_node, using_build_profile, fix_package_id)
 
     def _handle_node_editable(self, node, graph_info):
         # Get source of information
@@ -510,7 +508,13 @@ class BinaryInstaller(object):
         return pref
 
     @staticmethod
-    def _propagate_info(node, using_build_profile):
+    def _propagate_info(node, using_build_profile, fixed_package_id):
+        if fixed_package_id:
+            # if using config.full_transitive_package_id, it is necessary to recompute
+            # the node transitive information necessary to compute the package_id
+            # as it will be used by reevaluate_node() when package_revision_mode is used and
+            # PACKAGE_ID_UNKNOWN happens due to unknown revisions
+            node.package_id_transitive_reqs()
         # Get deps_cpp_info from upstream nodes
         node_order = [n for n in node.public_closure if n.binary != BINARY_SKIP]
         # List sort is stable, will keep the original order of the closure, but prioritize levels

--- a/conans/client/installer.py
+++ b/conans/client/installer.py
@@ -415,6 +415,9 @@ class BinaryInstaller(object):
                         self._binaries_analyzer.reevaluate_node(node, remotes, build_mode, update)
                     _handle_system_requirements(conan_file, node.pref, self._cache, output)
                     self._handle_node_cache(node, keep_build, processed_package_refs, remotes)
+                # After a node has been managed, better reset its transitive info
+                if self._binaries_analyzer._fixed_package_id:
+                    node.package_id_transitive_reqs()
 
         # Finally, propagate information to root node (ref=None)
         self._propagate_info(root_node, using_build_profile)

--- a/conans/test/functional/package_id/package_id_requires_modes_test.py
+++ b/conans/test/functional/package_id/package_id_requires_modes_test.py
@@ -1,4 +1,5 @@
 import os
+import textwrap
 import unittest
 
 from conans.model.info import ConanInfo
@@ -528,8 +529,16 @@ class PackageIDErrorTest(unittest.TestCase):
                     .with_package_id(pkg_revision_mode)})
         client.run("export . dep2/1.0@user/testing")
 
-        client.save({"conanfile.py": GenConanfile().with_require_plain("dep2/1.0@user/testing")})
+        consumer = textwrap.dedent("""
+            from conans import ConanFile
+            class Consumer(ConanFile):
+                requires = "dep2/1.0@user/testing"
+                def build(self):
+                    self.output.info("PKGNAMES: %s" % sorted(self.info.requires.pkg_names))
+                """)
+        client.save({"conanfile.py": consumer})
         client.run('create . consumer/1.0@user/testing --build')
+        self.assertIn("consumer/1.0@user/testing: PKGNAMES: ['dep1', 'dep2']", client.out)
         self.assertIn("consumer/1.0@user/testing: Created", client.out)
 
     def package_revision_mode_editable_test(self):

--- a/conans/test/functional/package_id/package_id_requires_modes_test.py
+++ b/conans/test/functional/package_id/package_id_requires_modes_test.py
@@ -525,19 +525,22 @@ class PackageIDErrorTest(unittest.TestCase):
         client.run("export . dep1/1.0@user/testing")
 
         pkg_revision_mode = "self.info.requires.full_version_mode()"
+        package_id_print = "self.output.info('PkgNames: %s' % sorted(self.info.requires.pkg_names))"
         client.save({"conanfile.py": GenConanfile().with_require_plain("dep1/1.0@user/testing")
-                    .with_package_id(pkg_revision_mode)})
+                    .with_package_id(pkg_revision_mode)
+                    .with_package_id(package_id_print)})
         client.run("export . dep2/1.0@user/testing")
 
         consumer = textwrap.dedent("""
             from conans import ConanFile
             class Consumer(ConanFile):
                 requires = "dep2/1.0@user/testing"
-                def build(self):
+                def package_id(self):
                     self.output.info("PKGNAMES: %s" % sorted(self.info.requires.pkg_names))
                 """)
         client.save({"conanfile.py": consumer})
         client.run('create . consumer/1.0@user/testing --build')
+        self.assertIn("dep2/1.0@user/testing: PkgNames: ['dep1']", client.out)
         self.assertIn("consumer/1.0@user/testing: PKGNAMES: ['dep1', 'dep2']", client.out)
         self.assertIn("consumer/1.0@user/testing: Created", client.out)
 

--- a/conans/test/functional/package_id/package_id_requires_modes_test.py
+++ b/conans/test/functional/package_id/package_id_requires_modes_test.py
@@ -513,6 +513,25 @@ class PackageIDErrorTest(unittest.TestCase):
         client.run('create . consumer/1.0@user/testing --build')
         self.assertIn("consumer/1.0@user/testing: Created", client.out)
 
+    def transitive_multi_mode2_package_id_test(self):
+        # https://github.com/conan-io/conan/issues/6942
+        client = TestClient()
+        client.run("config set general.default_package_id_mode=package_revision_mode")
+        # This is mandatory, otherwise it doesn't work
+        client.run("config set general.full_transitive_package_id=True")
+
+        client.save({"conanfile.py": GenConanfile()})
+        client.run("export . dep1/1.0@user/testing")
+
+        pkg_revision_mode = "self.info.requires.full_version_mode()"
+        client.save({"conanfile.py": GenConanfile().with_require_plain("dep1/1.0@user/testing")
+                    .with_package_id(pkg_revision_mode)})
+        client.run("export . dep2/1.0@user/testing")
+
+        client.save({"conanfile.py": GenConanfile().with_require_plain("dep2/1.0@user/testing")})
+        client.run('create . consumer/1.0@user/testing --build')
+        self.assertIn("consumer/1.0@user/testing: Created", client.out)
+
     def package_revision_mode_editable_test(self):
         # Package revision mode crash when using editables
         client = TestClient()

--- a/conans/test/functional/package_id/package_id_requires_modes_test.py
+++ b/conans/test/functional/package_id/package_id_requires_modes_test.py
@@ -544,6 +544,38 @@ class PackageIDErrorTest(unittest.TestCase):
         self.assertIn("consumer/1.0@user/testing: PKGNAMES: ['dep1', 'dep2']", client.out)
         self.assertIn("consumer/1.0@user/testing: Created", client.out)
 
+    def transitive_multi_mode_build_requires_test(self):
+        # https://github.com/conan-io/conan/issues/6942
+        client = TestClient()
+        client.run("config set general.default_package_id_mode=package_revision_mode")
+        client.run("config set general.full_transitive_package_id=True")
+
+        client.save({"conanfile.py": GenConanfile()})
+        client.run("export . dep1/1.0@user/testing")
+        client.run("create . tool/1.0@user/testing")
+
+        pkg_revision_mode = "self.info.requires.full_version_mode()"
+        package_id_print = "self.output.info('PkgNames: %s' % sorted(self.info.requires.pkg_names))"
+        client.save({"conanfile.py": GenConanfile().with_require_plain("dep1/1.0@user/testing")
+                    .with_build_require_plain("tool/1.0@user/testing")
+                    .with_package_id(pkg_revision_mode)
+                    .with_package_id(package_id_print)})
+        client.run("export . dep2/1.0@user/testing")
+
+        consumer = textwrap.dedent("""
+            from conans import ConanFile
+            class Consumer(ConanFile):
+                requires = "dep2/1.0@user/testing"
+                build_requires = "tool/1.0@user/testing"
+                def package_id(self):
+                    self.output.info("PKGNAMES: %s" % sorted(self.info.requires.pkg_names))
+                """)
+        client.save({"conanfile.py": consumer})
+        client.run('create . consumer/1.0@user/testing --build')
+        self.assertIn("dep2/1.0@user/testing: PkgNames: ['dep1']", client.out)
+        self.assertIn("consumer/1.0@user/testing: PKGNAMES: ['dep1', 'dep2']", client.out)
+        self.assertIn("consumer/1.0@user/testing: Created", client.out)
+
     def package_revision_mode_editable_test(self):
         # Package revision mode crash when using editables
         client = TestClient()


### PR DESCRIPTION
Changelog: Bugfix: Fix crash while computing the ``package_id`` of a package when different ``package_id_mode`` are mixed and include ``package_revision_mode``.
Docs: Omit

Continuation of https://github.com/conan-io/conan/pull/6947
Fix #6942

#tags: slow

cc/ @fulara 