### PR TITLE
Meson cross again > 1.24 remove duplicate #6410

### DIFF
--- a/conans/client/build/meson.py
+++ b/conans/client/build/meson.py
@@ -131,7 +131,7 @@ class Meson(object):
             'x86': ('x86', 'x86', 'little'),
             'x86_64': ('x86_64', 'x86_64', 'little'),
         }
-        host_cpu_family,host_cpu ,host_endian = cpu_translate[str(self._conanfile.settings_build.arch)]
+        build_cpu_family,build_cpu ,build_endian = cpu_translate[str(self._conanfile.settings_build.arch)]
 
         os_build=str(self._conanfile.settings_build.os_build).lower()
         os_host=str(self._conanfile.settings_build.os).lower()
@@ -149,12 +149,12 @@ class Meson(object):
         libdir = environ_append['PKG_CONFIG_PATH']
 
         with open(cross_filename, "w") as fd:
-            fd.write(F"""
+            fd.write("""
                 [build_machine]
                 system = '{os_build}'
-                cpu_family = '{host_cpu_family}'
-                cpu = '{host_cpu}'
-                endian = '{host_endian}'
+                cpu_family = '{build_cpu_family}'
+                cpu = '{build_cpu}'
+                endian = '{build_endian}'
 
                 [host_machine]
                 system = '{os_host}'
@@ -163,7 +163,7 @@ class Meson(object):
                 endian = '{endian}'
 
                 [properties]
-                needs_exe_wrapper = '{self.exe_wrapper}'
+                needs_exe_wrapper = '{exe_wrapper}'
                 cpp_args = [{cxxflags}]
                 c_args = [{cflags}]
                 pkg_config_libdir='{libdir}'
@@ -176,7 +176,26 @@ class Meson(object):
                 strip = '{strip}'
                 ranlib = '{ranlib}'
                 pkgconfig = 'pkg-config'
-            """)
+                """.format(
+                    os_build=os_build,
+                    build_cpu_family=build_cpu_family,
+                    build_cpu=build_cpu,
+                    build_endian=build_endian,
+                    os_host=os_host,
+                    cpu_family=cpu_family,
+                    cpu=cpu,
+                    endian=endian,
+                    exe_wrapper=self.exe_wrapper,
+                    cxxflags=cxxflags,
+                    cflags=cflags,
+                    libdir=libdir,
+                    cc=cc,
+                    cpp=cpp,
+                    ar=ar,
+                    ld=ld,
+                    strip=strip,
+                    ranlib=ranlib,
+                ))
         environ_append.update({'CC': None,
                                'CXX': None,
                                'CFLAGS': None,

--- a/conans/client/build/meson.py
+++ b/conans/client/build/meson.py
@@ -28,7 +28,7 @@ class Meson(object):
         self._conanfile = conanfile
         self._settings = conanfile.settings
         self._append_vcvars = append_vcvars
-        self.exe_wrapper='false'
+        self.exe_wrapper = 'false'
         if exe_wrapper:
         self.exe_wrapper = exe_wrapper or self.exe_wrapper
         self._os = self._ss("os")

--- a/conans/client/build/meson.py
+++ b/conans/client/build/meson.py
@@ -146,7 +146,7 @@ class Meson(object):
         ld = os.environ.get('LD', 'ld')
         ar = os.environ.get('AR', 'ar')
         strip = os.environ.get('STRIP', 'strip')
-        ranlib = os.environ.get('RANLIB','ranlib')
+        ranlib = os.environ.get('RANLIB', 'ranlib')
         libdir = environ_append['PKG_CONFIG_PATH']
 
         with open(cross_filename, "w") as fd:

--- a/conans/client/build/meson.py
+++ b/conans/client/build/meson.py
@@ -17,7 +17,7 @@ from conans.util.runners import version_runner
 
 class Meson(object):
 
-    def __init__(self, conanfile, backend=None, build_type=None, append_vcvars=False,exe_wrapper=None):
+    def __init__(self, conanfile, backend=None, build_type=None, append_vcvars=False, exe_wrapper=None):
         """
         :param conanfile: Conanfile instance (or settings for retro compatibility)
         :param backend: Generator name to use or none to autodetect.

--- a/conans/client/build/meson.py
+++ b/conans/client/build/meson.py
@@ -240,9 +240,10 @@ class Meson(object):
         cross_option = None
         environ_append = {"PKG_CONFIG_PATH": pc_paths}
         if tools.cross_building(self._conanfile.settings):
-            cross_filename = os.path.join(self.build_dir, "cross_file.txt")
-            cross_option = "--cross-file=%s" % cross_filename
-            self._configure_cross_compile(cross_filename, environ_append)
+            if not "--cross-file" in args:
+                cross_filename = os.path.join(self.build_dir, "cross_file.txt")
+                cross_option = "--cross-file=%s" % cross_filename
+                self._configure_cross_compile(cross_filename, environ_append)
 
         arg_list = join_arguments([
             "--backend=%s" % self.backend,

--- a/conans/client/build/meson.py
+++ b/conans/client/build/meson.py
@@ -235,7 +235,7 @@ class Meson(object):
 
     def configure(self, args=None, defs=None, source_dir=None, build_dir=None,
                   pkg_config_paths=None, cache_build_folder=None,
-                  build_folder=None, source_folder=None):
+                  build_folder=None, source_folder=None,no_generated_cross_file=None):
         if not self._conanfile.should_configure:
             return
         args = args or []
@@ -265,17 +265,17 @@ class Meson(object):
         cross_option = None
         environ_append = {"PKG_CONFIG_PATH": pc_paths}
         if tools.cross_building(self._conanfile.settings):
-            if not "--cross-file" in args:
+            if not no_generated_cross_file:
                 cross_filename = os.path.join(self.build_dir, "cross_file.txt")
                 cross_option = "--cross-file=%s" % cross_filename
                 self._configure_cross_compile(cross_filename, environ_append)
 
         arg_list = join_arguments([
+            cross_option,
             "--backend=%s" % self.backend,
             self.flags,
             args_to_string(args),
             build_type,
-            cross_option,
         ])
         command = 'meson "%s" "%s" %s' % (source_dir, self.build_dir, arg_list)
         with environment_append(environ_append):

--- a/conans/client/build/meson.py
+++ b/conans/client/build/meson.py
@@ -132,7 +132,7 @@ class Meson(object):
             'x86_64': ('x86_64', 'x86_64', 'little'),
         }
         if hasattr(self._conanfile,'settings_build'):
-            build_cpu_family,build_cpu ,build_endian = cpu_translate[str(self._conanfile.settings_build.arch)]
+            build_cpu_family, build_cpu, build_endian = cpu_translate[str(self._conanfile.settings_build.arch)]
             os_build = str(self._conanfile.settings_build.os_build).lower()
 
         os_host = str(self._conanfile.settings.os).lower()

--- a/conans/client/build/meson.py
+++ b/conans/client/build/meson.py
@@ -122,6 +122,44 @@ class Meson(object):
     def flags(self):
         return defs_to_string(self.options)
 
+    def _configure_cross_compile(self, cross_filename, environ_append):
+        cpu_translate = {
+            'armv8': ('aarch64', 'aarch64', 'little'),
+            'x86': ('x86', 'x86', 'little'),
+            'x86_64': ('x86_64', 'x86_64', 'little'),
+        }
+        cpu_family, cpu, endian = cpu_translate[str(self._conanfile.settings.arch)]
+        cflags = ', '.join(repr(x) for x in os.environ.get('CFLAGS', '').split(' '))
+        cc = os.environ.get('CC', 'cc')
+        cpp = os.environ.get('CXX', 'c++')
+        with open(cross_filename, "w") as fd:
+            fd.write("""
+                [host_machine]
+                system = '{os}'
+                cpu_family = '{cpu_family}'
+                cpu = '{cpu}'
+                endian = '{endian}'
+
+                [properties]
+                needs_exe_wrapper = true
+                c_args = [{cflags}]
+                [binaries]
+                c = '{cc}'
+                cpp = '{cpp}'
+                pkgconfig = 'pkg-config'
+            """.format(os=self._os.lower(),
+                       cpu_family=cpu_family,
+                       cpu=cpu,
+                       endian=endian,
+                       cflags=cflags,
+                       cc=cc,
+                       cpp=cpp))
+        environ_append.update({'CC': None,
+                               'CXX': None,
+                               'CFLAGS': None,
+                               'CXXFLAGS': None,
+                               'CPPFLAGS': None})
+
     def configure(self, args=None, defs=None, source_dir=None, build_dir=None,
                   pkg_config_paths=None, cache_build_folder=None,
                   build_folder=None, source_folder=None):
@@ -151,15 +189,24 @@ class Meson(object):
               "Release": "release"}.get(str(self.build_type), "")
 
         build_type = "--buildtype=%s" % bt
+        cross_option = None
+        environ_append = {"PKG_CONFIG_PATH": pc_paths}
+        is_cross = tools.cross_building(self._conanfile.settings)
+        if is_cross:
+            cross_filename = os.path.join(self.build_dir, "cross_file.txt")
+            cross_option = "--cross-file=%s" % cross_filename
+            self._configure_cross_compile(cross_filename, environ_append)
+
         arg_list = join_arguments([
             "--backend=%s" % self.backend,
             self.flags,
             args_to_string(args),
-            build_type
+            build_type,
+            cross_option,
         ])
         command = 'meson "%s" "%s" %s' % (source_dir, self.build_dir, arg_list)
-        with environment_append({"PKG_CONFIG_PATH": pc_paths}):
-            self._run(command)
+        with environment_append(environ_append):
+            self._run(command, use_auto_tools=not is_cross)
 
     @property
     def _vcvars_needed(self):
@@ -167,7 +214,8 @@ class Meson(object):
                 platform.system() == "Windows")
 
     def _run(self, command):
-        def _build():
+        with tools.vcvars(self._settings,
+                          output=self._conanfile.output) if self._vcvars_needed else tools.no_op():
             env_build = AutoToolsBuildEnvironment(self._conanfile)
             with environment_append(env_build.vars):
                 self._conanfile.run(command)

--- a/conans/client/build/meson.py
+++ b/conans/client/build/meson.py
@@ -30,7 +30,7 @@ class Meson(object):
         self._append_vcvars = append_vcvars
         self.exe_wrapper='false'
         if exe_wrapper:
-            self.exe_wrapper=exe_wrapper
+        self.exe_wrapper = exe_wrapper or self.exe_wrapper
         self._os = self._ss("os")
         self._compiler = self._ss("compiler")
         self._compiler_version = self._ss("compiler.version")

--- a/conans/client/build/meson.py
+++ b/conans/client/build/meson.py
@@ -133,9 +133,9 @@ class Meson(object):
         }
         if hasattr(self._conanfile,'settings_build'):
             build_cpu_family,build_cpu ,build_endian = cpu_translate[str(self._conanfile.settings_build.arch)]
-            os_build=str(self._conanfile.settings_build.os_build).lower()
+            os_build = str(self._conanfile.settings_build.os_build).lower()
 
-        os_host=str(self._conanfile.settings.os).lower()
+        os_host = str(self._conanfile.settings.os).lower()
         cpu_family, cpu, endian = cpu_translate[str(self._conanfile.settings.arch)]
 
         cflags = ', '.join(repr(x) for x in os.environ.get('CFLAGS', '').split(' '))
@@ -158,10 +158,10 @@ class Meson(object):
                     cpu = '{build_cpu}'
                     endian = '{build_endian}'
                 """.format(
-                    os_build=os_build,
-                    build_cpu_family=build_cpu_family,
-                    build_cpu=build_cpu,
-                    build_endian=build_endian,
+                    os_build = os_build,
+                    build_cpu_family = build_cpu_family,
+                    build_cpu = build_cpu,
+                    build_endian = build_endian,
                 ))
             fd.write("""
                 [host_machine]
@@ -185,20 +185,20 @@ class Meson(object):
                 ranlib = '{ranlib}'
                 pkgconfig = 'pkg-config'
                 """.format(
-                    os_host=os_host,
-                    cpu_family=cpu_family,
-                    cpu=cpu,
-                    endian=endian,
-                    exe_wrapper=self.exe_wrapper,
-                    cxxflags=cxxflags,
-                    cflags=cflags,
-                    libdir=libdir,
-                    cc=cc,
-                    cpp=cpp,
-                    ar=ar,
-                    ld=ld,
-                    strip=strip,
-                    ranlib=ranlib,
+                    os_host = os_host,
+                    cpu_family = cpu_family,
+                    cpu = cpu,
+                    endian = endian,
+                    exe_wrapper = self.exe_wrapper,
+                    cxxflags = cxxflags,
+                    cflags = cflags,
+                    libdir = libdir,
+                    cc = cc,
+                    cpp = cpp,
+                    ar = ar,
+                    ld = ld,
+                    strip = strip,
+                    ranlib = ranlib,
                 ))
         environ_append.update({'CC': None,
                                'CXX': None,

--- a/conans/client/build/meson.py
+++ b/conans/client/build/meson.py
@@ -144,7 +144,7 @@ class Meson(object):
         cc = os.environ.get('CC', 'cc')
         cpp = os.environ.get('CXX', 'c++')
         ld = os.environ.get('LD','ld')
-        ar = os.environ.get('AR','ar')
+        ar = os.environ.get('AR', 'ar')
         strip = os.environ.get('STRIP', 'strip')
         ranlib = os.environ.get('RANLIB','ranlib')
         libdir = environ_append['PKG_CONFIG_PATH']

--- a/conans/client/build/meson.py
+++ b/conans/client/build/meson.py
@@ -147,7 +147,6 @@ class Meson(object):
         strip = os.environ.get('STRIP','strip')
         ranlib = os.environ.get('RANLIB','ranlib')
         libdir = environ_append['PKG_CONFIG_PATH']
-        #self.needs_exe_wrapper='true'
 
         with open(cross_filename, "w") as fd:
             fd.write(F"""

--- a/conans/client/build/meson.py
+++ b/conans/client/build/meson.py
@@ -126,10 +126,36 @@ class Meson(object):
         return defs_to_string(self.options)
 
     def _configure_cross_compile(self, cross_filename, environ_append):
+
+        arm=('arm','arm','little')
         cpu_translate = {
-            'armv8': ('aarch64', 'aarch64', 'little'),
-            'x86': ('x86', 'x86', 'little'),
-            'x86_64': ('x86_64', 'x86_64', 'little'),
+            'x86' : ('x86', 'x86', 'little'),
+            'x86_64' : ('x86_64', 'x86_64', 'little'),
+            'x86' : ('x86','x86','little'),
+            'ppc32be' : ('ppc','ppc','big'),
+            'ppc32' : ('ppc','ppc','little'),
+            'ppc64le' : ('ppc64','ppc64','little'),
+            'ppc64' : ('ppc64','ppc64','big'),
+            'armv4' : arm,
+            'armv4i' : arm,
+            'armv5el' : arm,
+            'armv5hf' : arm,
+            'armv6' : arm,
+            'armv7' : arm,
+            'armv7hf' : arm,
+            'armv7s' : arm,
+            'armv7k' : arm,
+            'armv8_32' : arm,
+            'armv8' : ('aarch64', 'aarch64', 'little'),
+            'armv8.3' : ('aarch64', 'aarch64', 'little'),
+            'sparc' : ('sparc','sparc','big'),
+            'sparcv9' : ('sparc64','sparc64','big'),
+            'mips' : ('mips','mips','big'),
+            'mips64' : ('mips64','mips64','big'),
+            'avr' : ('avr','avr','little'),
+            's390' : ('s390','s390','big'),
+            's390x' : ('s390','s390','big'),
+            'wasm' : ('wasm','wasm','little'),
         }
         if hasattr(self._conanfile,'settings_build'):
             build_cpu_family, build_cpu, build_endian = cpu_translate[str(self._conanfile.settings_build.arch)]

--- a/conans/client/build/meson.py
+++ b/conans/client/build/meson.py
@@ -143,7 +143,7 @@ class Meson(object):
 
         cc = os.environ.get('CC', 'cc')
         cpp = os.environ.get('CXX', 'c++')
-        ld = os.environ.get('LD','ld')
+        ld = os.environ.get('LD', 'ld')
         ar = os.environ.get('AR', 'ar')
         strip = os.environ.get('STRIP', 'strip')
         ranlib = os.environ.get('RANLIB','ranlib')

--- a/conans/client/build/meson.py
+++ b/conans/client/build/meson.py
@@ -7,7 +7,7 @@ from conans.client.build import defs_to_string, join_arguments
 from conans.client.build.autotools_environment import AutoToolsBuildEnvironment
 from conans.client.build.cppstd_flags import cppstd_from_settings
 from conans.client.tools.env import environment_append, _environment_add
-from conans.client.tools.oss import args_to_string
+from conans.client.tools.oss import args_to_string, get_build_os_arch
 from conans.errors import ConanException
 from conans.model.build_info import DEFAULT_BIN, DEFAULT_INCLUDE, DEFAULT_LIB
 from conans.model.version import Version
@@ -28,6 +28,7 @@ class Meson(object):
         self._conanfile = conanfile
         self._settings = conanfile.settings
         self._append_vcvars = append_vcvars
+        self.exe_wrapper='false'
         self.exe_wrapper = exe_wrapper or self.exe_wrapper
         self._os = self._ss("os")
         self._compiler = self._ss("compiler")
@@ -157,7 +158,7 @@ class Meson(object):
         }
         if hasattr(self._conanfile,'settings_build'):
             build_cpu_family, build_cpu, build_endian = cpu_translate[str(self._conanfile.settings_build.arch)]
-            os_build = get_build_os_arch(self._conanfile).lower()
+            os_build, _ = get_build_os_arch(self._conanfile)
 
         os_host = str(self._conanfile.settings.os).lower()
         cpu_family, cpu, endian = cpu_translate[str(self._conanfile.settings.arch)]
@@ -182,7 +183,7 @@ class Meson(object):
                     cpu = '{build_cpu}'
                     endian = '{build_endian}'
                 """.format(
-                    os_build = os_build,
+                    os_build = os_build.lower(),
                     build_cpu_family = build_cpu_family,
                     build_cpu = build_cpu,
                     build_endian = build_endian,

--- a/conans/client/build/meson.py
+++ b/conans/client/build/meson.py
@@ -145,7 +145,7 @@ class Meson(object):
         cpp = os.environ.get('CXX', 'c++')
         ld = os.environ.get('LD','ld')
         ar = os.environ.get('AR','ar')
-        strip = os.environ.get('STRIP','strip')
+        strip = os.environ.get('STRIP', 'strip')
         ranlib = os.environ.get('RANLIB','ranlib')
         libdir = environ_append['PKG_CONFIG_PATH']
 

--- a/conans/client/build/meson.py
+++ b/conans/client/build/meson.py
@@ -28,8 +28,6 @@ class Meson(object):
         self._conanfile = conanfile
         self._settings = conanfile.settings
         self._append_vcvars = append_vcvars
-        self.exe_wrapper = 'false'
-        if exe_wrapper:
         self.exe_wrapper = exe_wrapper or self.exe_wrapper
         self._os = self._ss("os")
         self._compiler = self._ss("compiler")
@@ -159,7 +157,7 @@ class Meson(object):
         }
         if hasattr(self._conanfile,'settings_build'):
             build_cpu_family, build_cpu, build_endian = cpu_translate[str(self._conanfile.settings_build.arch)]
-            os_build = str(self._conanfile.settings_build.os_build).lower()
+            os_build = get_build_os_arch(self._conanfile).lower()
 
         os_host = str(self._conanfile.settings.os).lower()
         cpu_family, cpu, endian = cpu_translate[str(self._conanfile.settings.arch)]

--- a/conans/test/unittests/client/build/meson_test.py
+++ b/conans/test/unittests/client/build/meson_test.py
@@ -76,34 +76,37 @@ class MesonTest(unittest.TestCase):
             'libexecdir': 'bin',
             'includedir': 'include'
         }
-
+        build_dir = os.path.join(self.tempdir, "build")
         meson.configure(source_dir=os.path.join(self.tempdir, "../subdir"),
-                        build_dir=os.path.join(self.tempdir, "build"))
+                        build_dir=build_dir)
         source_expected = os.path.join(self.tempdir, "../subdir")
-        build_expected = os.path.join(self.tempdir, "build")
-        cmd_expected = 'meson "%s" "%s" --backend=ninja %s --buildtype=release' \
-                       % (source_expected, build_expected, defs_to_string(defs))
+        build_expected = build_dir
+        cross_file = os.path.join(build_dir, "cross_file.txt")
+        cmd_expected = 'meson "%s" "%s" --backend=ninja %s --buildtype=release --cross-file=%s' \
+                       % (source_expected, build_expected, defs_to_string(defs), cross_file)
         self._check_commands(cmd_expected, conan_file.command)
 
-        meson.configure(build_dir=os.path.join(self.tempdir, "build"))
+        meson.configure(build_dir=build_dir)
         source_expected = os.path.join(self.tempdir, "my_cache_source_folder")
-        build_expected = os.path.join(self.tempdir, "build")
-        cmd_expected = 'meson "%s" "%s" --backend=ninja %s --buildtype=release' \
-                       % (source_expected, build_expected, defs_to_string(defs))
+        build_expected = build_dir
+        cmd_expected = 'meson "%s" "%s" --backend=ninja %s --buildtype=release --cross-file=%s' \
+                       % (source_expected, build_expected, defs_to_string(defs), cross_file)
         self._check_commands(cmd_expected, conan_file.command)
 
         meson.configure()
         source_expected = os.path.join(self.tempdir, "my_cache_source_folder")
         build_expected = os.path.join(self.tempdir, "my_cache_build_folder")
-        cmd_expected = 'meson "%s" "%s" --backend=ninja %s --buildtype=release' \
-                       % (source_expected, build_expected, defs_to_string(defs))
+        cross_file = os.path.join(build_expected, "cross_file.txt")
+        cmd_expected = 'meson "%s" "%s" --backend=ninja %s --buildtype=release --cross-file=%s' \
+                       % (source_expected, build_expected, defs_to_string(defs), cross_file)
         self._check_commands(cmd_expected, conan_file.command)
 
         meson.configure(source_folder="source", build_folder="build")
         build_expected = os.path.join(self.tempdir, "my_cache_build_folder", "build")
         source_expected = os.path.join(self.tempdir, "my_cache_source_folder", "source")
-        cmd_expected = 'meson "%s" "%s" --backend=ninja %s --buildtype=release' \
-                       % (source_expected, build_expected, defs_to_string(defs))
+        cross_file = os.path.join(build_expected, "cross_file.txt")
+        cmd_expected = 'meson "%s" "%s" --backend=ninja %s --buildtype=release --cross-file=%s' \
+                       % (source_expected, build_expected, defs_to_string(defs), cross_file)
         self._check_commands(cmd_expected, conan_file.command)
 
         conan_file.in_local_cache = True
@@ -111,8 +114,9 @@ class MesonTest(unittest.TestCase):
                         cache_build_folder="rel_only_cache")
         build_expected = os.path.join(self.tempdir, "my_cache_build_folder", "rel_only_cache")
         source_expected = os.path.join(self.tempdir, "my_cache_source_folder", "source")
-        cmd_expected = 'meson "%s" "%s" --backend=ninja %s --buildtype=release' \
-                       % (source_expected, build_expected, defs_to_string(defs))
+        cross_file = os.path.join(build_expected, "cross_file.txt")
+        cmd_expected = 'meson "%s" "%s" --backend=ninja %s --buildtype=release --cross-file=%s' \
+                       % (source_expected, build_expected, defs_to_string(defs), cross_file)
         self._check_commands(cmd_expected, conan_file.command)
 
         conan_file.in_local_cache = False
@@ -120,16 +124,18 @@ class MesonTest(unittest.TestCase):
                         cache_build_folder="rel_only_cache")
         build_expected = os.path.join(self.tempdir, "my_cache_build_folder", "build")
         source_expected = os.path.join(self.tempdir, "my_cache_source_folder", "source")
-        cmd_expected = 'meson "%s" "%s" --backend=ninja %s --buildtype=release' \
-                       % (source_expected, build_expected, defs_to_string(defs))
+        cross_file = os.path.join(build_expected, "cross_file.txt")
+        cmd_expected = 'meson "%s" "%s" --backend=ninja %s --buildtype=release --cross-file=%s' \
+                       % (source_expected, build_expected, defs_to_string(defs), cross_file)
         self._check_commands(cmd_expected, conan_file.command)
 
         conan_file.in_local_cache = True
         meson.configure(build_dir="build", cache_build_folder="rel_only_cache")
         build_expected = os.path.join(self.tempdir, "my_cache_build_folder", "rel_only_cache")
         source_expected = os.path.join(self.tempdir, "my_cache_source_folder")
-        cmd_expected = 'meson "%s" "%s" --backend=ninja %s --buildtype=release' \
-                       % (source_expected, build_expected, defs_to_string(defs))
+        cross_file = os.path.join(build_expected, "cross_file.txt")
+        cmd_expected = 'meson "%s" "%s" --backend=ninja %s --buildtype=release --cross-file=%s' \
+                       % (source_expected, build_expected, defs_to_string(defs), cross_file)
         self._check_commands(cmd_expected, conan_file.command)
 
         args = ['--werror', '--warnlevel 3']
@@ -138,9 +144,10 @@ class MesonTest(unittest.TestCase):
                         defs={'default_library': 'static'})
         build_expected = os.path.join(self.tempdir, "my_cache_build_folder", "build")
         source_expected = os.path.join(self.tempdir, "my_cache_source_folder", "source")
-        cmd_expected = 'meson "%s" "%s" --backend=ninja %s %s --buildtype=release' \
+        cross_file = os.path.join(build_expected, "cross_file.txt")
+        cmd_expected = 'meson "%s" "%s" --backend=ninja %s %s --buildtype=release --cross-file=%s' \
                        % (source_expected, build_expected, args_to_string(args),
-                          defs_to_string(defs))
+                          defs_to_string(defs), cross_file)
         self._check_commands(cmd_expected, conan_file.command)
 
         # Raise mixing


### PR DESCRIPTION
This currently works for compiling glib / gstreamer / gst-plugins-base for aarch64 on x86_64,

This PR is currently being used in production as it makes more sense to fix meson in conan than to add custom cross compile instructions to all meson packages.

And perhaps also on other targets. Improves #4529 and #6410 
Docs: https://github.com/conan-io/docs/pull/XXXX

Changelog: (Fix): Make cross-compiling with meson work in some cases
- [x] Refer to the issue that supports this Pull Request.
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 

<sup>**Note:** By default this PR will skip the slower tests and will use a limited set of python versions. Check [here](https://github.com/conan-io/conan/blob/develop/.github/PR_INCREASE_TESTING.md) how to increase the testing level by writing some tags in the current PR body text.</sup>
