### PR TITLE
[editables] Store full path to 'conanfile.py'

### DIFF
--- a/conans/client/cache/cache.py
+++ b/conans/client/cache/cache.py
@@ -98,15 +98,10 @@ class ClientCache(object):
         assert isinstance(ref, ConanFileReference), "It is a {}".format(type(ref))
         edited_ref = self.editable_packages.get(ref.copy_clear_rev())
         if edited_ref:
-            base_path = edited_ref["path"]
+            conanfile_path = edited_ref["path"]
             layout_file = edited_ref["layout"]
-            if os.path.isfile(base_path):
-                conanfile_name = os.path.basename(base_path)
-                base_path = os.path.dirname(base_path)
-                return PackageEditableLayout(base_path, layout_file, ref, conanfile_name)
-            else:
-                # FIXME: Remove in Conan 2.0, introduced for <= 1.25 backward compatibility
-                return PackageEditableLayout(base_path, layout_file, ref)
+            return PackageEditableLayout(os.path.dirname(conanfile_path), layout_file, ref,
+                                         conanfile_path)
         else:
             check_ref_case(ref, self.store)
             base_folder = os.path.normpath(os.path.join(self.store, ref.dir_repr()))

--- a/conans/client/cache/cache.py
+++ b/conans/client/cache/cache.py
@@ -77,7 +77,7 @@ class ClientCache(object):
         # paths
         self._store_folder = self.config.storage_path or self.cache_folder
         # Just call it to make it raise in case of short_paths misconfiguration
-        self.config.short_paths_home
+        _ = self.config.short_paths_home
 
     def all_refs(self):
         subdirs = list_folder_subdirs(basedir=self._store_folder, level=4)
@@ -100,7 +100,13 @@ class ClientCache(object):
         if edited_ref:
             base_path = edited_ref["path"]
             layout_file = edited_ref["layout"]
-            return PackageEditableLayout(base_path, layout_file, ref)
+            if os.path.isfile(base_path):
+                conanfile_name = os.path.basename(base_path)
+                base_path = os.path.dirname(base_path)
+                return PackageEditableLayout(base_path, layout_file, ref, conanfile_name)
+            else:
+                # FIXME: Remove in Conan 2.0, introduced for <= 1.25 backward compatibility
+                return PackageEditableLayout(base_path, layout_file, ref)
         else:
             check_ref_case(ref, self.store)
             base_folder = os.path.normpath(os.path.join(self.store, ref.dir_repr()))
@@ -274,6 +280,7 @@ class ClientCache(object):
         if os.path.exists(self.settings_path):
             remove(self.settings_path)
         self.initialize_settings()
+
 
 def _mix_settings_with_env(settings):
     """Reads CONAN_ENV_XXXX variables from environment

--- a/conans/client/conan_api.py
+++ b/conans/client/conan_api.py
@@ -1203,7 +1203,7 @@ class ConanAPIV1(object):
         layout_abs_path = get_editable_abs_path(layout, cwd, self.app.cache.cache_folder)
         if layout_abs_path:
             self.app.out.success("Using layout file: %s" % layout_abs_path)
-        self.app.cache.editable_packages.add(ref, os.path.dirname(target_path), layout_abs_path)
+        self.app.cache.editable_packages.add(ref, target_path, layout_abs_path)
 
     @api_method
     def editable_remove(self, reference):

--- a/conans/model/workspace.py
+++ b/conans/model/workspace.py
@@ -1,5 +1,4 @@
 import os
-
 from collections import OrderedDict
 
 import yaml
@@ -8,6 +7,7 @@ from conans.client.graph.graph import RECIPE_EDITABLE
 from conans.errors import ConanException
 from conans.model.editable_layout import get_editable_abs_path, EditableLayout
 from conans.model.ref import ConanFileReference
+from conans.paths import CONANFILE
 from conans.util.files import load, save
 
 
@@ -106,8 +106,13 @@ class Workspace(object):
             save(cmake_path, cmake)
 
     def get_editable_dict(self):
-        return {ref: {"path": ws_package.root_folder, "layout": ws_package.layout}
-                for ref, ws_package in self._workspace_packages.items()}
+        ret = {}
+        for ref, ws_package in self._workspace_packages.items():
+            path = ws_package.root_folder
+            if os.path.isdir(path):
+                path = os.path.join(path, CONANFILE)
+            ret[ref] = {"path": path, "layout": ws_package.layout}
+        return ret
 
     def __getitem__(self, ref):
         return self._workspace_packages.get(ref)

--- a/conans/paths/package_layouts/package_editable_layout.py
+++ b/conans/paths/package_layouts/package_editable_layout.py
@@ -11,12 +11,12 @@ from conans.paths import CONANFILE
 
 class PackageEditableLayout(object):
 
-    def __init__(self, base_folder, layout_file, ref, conanfile_name=CONANFILE):
+    def __init__(self, base_folder, layout_file, ref, conanfile_path):
         assert isinstance(ref, ConanFileReference)
         self._ref = ref
         self._base_folder = base_folder
         self._layout_file = layout_file
-        self._conanfile_name = conanfile_name
+        self._conanfile_path = conanfile_path
 
     @property
     def ref(self):
@@ -30,7 +30,7 @@ class PackageEditableLayout(object):
         """ Path to the conanfile. We can agree that an editable package
             needs to be a Conan package
         """
-        return os.path.join(self._base_folder, self._conanfile_name)
+        return self._conanfile_path
 
     def editable_cpp_info(self):
         if self._layout_file:

--- a/conans/paths/package_layouts/package_editable_layout.py
+++ b/conans/paths/package_layouts/package_editable_layout.py
@@ -11,12 +11,12 @@ from conans.paths import CONANFILE
 
 class PackageEditableLayout(object):
 
-    def __init__(self, base_folder, layout_file, ref, conanfile=CONANFILE):
+    def __init__(self, base_folder, layout_file, ref, conanfile_name=CONANFILE):
         assert isinstance(ref, ConanFileReference)
         self._ref = ref
         self._base_folder = base_folder
         self._layout_file = layout_file
-        self._conanfile_name = conanfile
+        self._conanfile_name = conanfile_name
 
     @property
     def ref(self):

--- a/conans/paths/package_layouts/package_editable_layout.py
+++ b/conans/paths/package_layouts/package_editable_layout.py
@@ -11,11 +11,12 @@ from conans.paths import CONANFILE
 
 class PackageEditableLayout(object):
 
-    def __init__(self, base_folder, layout_file, ref):
+    def __init__(self, base_folder, layout_file, ref, conanfile=CONANFILE):
         assert isinstance(ref, ConanFileReference)
         self._ref = ref
         self._base_folder = base_folder
         self._layout_file = layout_file
+        self._conanfile_name = conanfile
 
     @property
     def ref(self):
@@ -29,7 +30,7 @@ class PackageEditableLayout(object):
         """ Path to the conanfile. We can agree that an editable package
             needs to be a Conan package
         """
-        return os.path.join(self._base_folder, CONANFILE)
+        return os.path.join(self._base_folder, self._conanfile_name)
 
     def editable_cpp_info(self):
         if self._layout_file:

--- a/conans/test/functional/editable/editable_add_test.py
+++ b/conans/test/functional/editable/editable_add_test.py
@@ -75,3 +75,5 @@ class CreateEditablePackageTest(unittest.TestCase):
         t.save(files={'othername.py': self.conanfile})
         t.run('editable add ./othername.py {}'.format(ref))
         self.assertIn("Reference 'lib/version@user/name' in editable mode", t.out)
+        t.run('install {}'.format(ref))
+        self.assertIn("Installing package: {}".format(ref), t.out)

--- a/conans/test/functional/editable/editable_add_test.py
+++ b/conans/test/functional/editable/editable_add_test.py
@@ -64,7 +64,14 @@ class CreateEditablePackageTest(unittest.TestCase):
         self.assertIn("ERROR: Name and version from reference (wrong/version@user/channel) and "
                       "target conanfile.py (lib/version) must match", t.out)
 
-    def missing_subarguments_test(self):
+    def test_missing_subarguments(self):
         t = TestClient()
         t.run("editable", assert_error=True)
         self.assertIn("ERROR: Exiting with code: 2", t.out)
+
+    def test_conanfile_name(self):
+        ref = ConanFileReference.loads('lib/version@user/name')
+        t = TestClient()
+        t.save(files={'othername.py': self.conanfile})
+        t.run('editable add ./othername.py {}'.format(ref))
+        self.assertIn("Reference 'lib/version@user/name' in editable mode", t.out)

--- a/conans/test/functional/test_migrations.py
+++ b/conans/test/functional/test_migrations.py
@@ -5,7 +5,9 @@ import unittest
 from six import StringIO
 
 from conans import __version__
-from conans.client.migrations import migrate_plugins_to_hooks, migrate_to_default_profile
+from conans.client.cache.editable import EDITABLE_PACKAGES_FILE
+from conans.client.migrations import migrate_plugins_to_hooks, migrate_to_default_profile, \
+    migrate_editables_use_conanfile_name
 from conans.client.output import ConanOutput
 from conans.client.tools.version import Version
 from conans.migrations import CONAN_VERSION
@@ -154,7 +156,7 @@ the old general
             cache = TestClient(cache_folder=old_user_home, cpu_count=False).cache
             assert old_conan_folder == cache.cache_folder
             return old_user_home, old_conan_folder, old_conf_path, \
-                old_attribute_checker_plugin, cache
+                   old_attribute_checker_plugin, cache
 
         output = ConanOutput(StringIO())
         _, old_cf, old_cp, old_acp, cache = _create_old_layout()
@@ -175,3 +177,27 @@ the old general
         conf_content = load(old_cp)
         self.assertNotIn("[plugins]", conf_content)
         self.assertIn("[hooks]", conf_content)
+
+    def test_migration_editables_to_conanfile_name(self):
+        # Create the old editable_packages.json file (and user workspace)
+        tmp_folder = temp_folder()
+        conanfile1 = os.path.join(tmp_folder, 'dir1/conanfile.py')
+        conanfile2 = os.path.join(tmp_folder, 'dir2/conanfile.py')
+        save(conanfile1, "anything")
+        save(conanfile2, "anything")
+        save(os.path.join(tmp_folder, EDITABLE_PACKAGES_FILE),
+             json.dumps({"name/version": {"path": os.path.dirname(conanfile1), "layout": None},
+                         "other/version@user/testing": {"path": os.path.dirname(conanfile2),
+                                                        "layout": "anyfile"}}))
+
+        cache = TestClient(cache_folder=tmp_folder).cache
+        migrate_editables_use_conanfile_name(cache, None)
+
+        # Now we have same info and full paths
+        with open(os.path.join(tmp_folder, EDITABLE_PACKAGES_FILE)) as f:
+            data = json.load(f)
+
+        self.assertEqual(data["name/version"]["path"], conanfile1)
+        self.assertEqual(data["name/version"]["layout"], None)
+        self.assertEqual(data["other/version@user/testing"]["path"], conanfile2)
+        self.assertEqual(data["other/version@user/testing"]["layout"], "anyfile")

--- a/conans/test/functional/test_migrations.py
+++ b/conans/test/functional/test_migrations.py
@@ -181,8 +181,8 @@ the old general
     def test_migration_editables_to_conanfile_name(self):
         # Create the old editable_packages.json file (and user workspace)
         tmp_folder = temp_folder()
-        conanfile1 = os.path.join(tmp_folder, 'dir1/conanfile.py')
-        conanfile2 = os.path.join(tmp_folder, 'dir2/conanfile.py')
+        conanfile1 = os.path.join(tmp_folder, 'dir1', 'conanfile.py')
+        conanfile2 = os.path.join(tmp_folder, 'dir2', 'conanfile.py')
         save(conanfile1, "anything")
         save(conanfile2, "anything")
         save(os.path.join(tmp_folder, EDITABLE_PACKAGES_FILE),


### PR DESCRIPTION
Changelog: Fix: Adding a package as editable stores full path to `conanfile.py`.
Docs: omit

On the local folder, the name of the `conanfile` is not always `conanfile.py|txt`

Closes https://github.com/conan-io/conan/issues/6905