### PR TITLE
Rollback (and simplify) changes from #7048

### DIFF
--- a/conans/client/cmd/export.py
+++ b/conans/client/cmd/export.py
@@ -252,20 +252,19 @@ def _capture_scm_auto_fields(conanfile, conanfile_dir, package_layout, output, i
         origin = scm.get_qualified_remote_url(remove_credentials=True)
         local_src_path = scm.get_local_path_to_url(origin)
         return scm_data, local_src_path
+
     if scm_data.url == "auto":
         origin = scm.get_qualified_remote_url(remove_credentials=True)
+        if not origin:
+            output.warn("Repo origin cannot be deduced, 'auto' fields won't be replaced."
+                        " 'conan upload' command will prevent uploading recipes with 'auto'"
+                        " values in these fields.")
+            local_src_path = scm.get_local_path_to_url(origin)
+            return scm_data, local_src_path
         if scm.is_local_repository():
             output.warn("Repo origin looks like a local path: %s" % origin)
         output.success("Repo origin deduced by 'auto': %s" % origin)
-        if origin:
-            scm_data.url = origin
-        else:
-            output.warn(
-                "origin is auto, upload' command will prevent uploading recipes with None values in these fields.")
-
-    if scm_data.url is None:
-        output.warn(
-            "origin is None, upload' command will prevent uploading recipes with None values in these fields.")
+        scm_data.url = origin
 
     if scm_data.revision == "auto":
         # If it is pristine by default we don't replace the "auto" unless forcing
@@ -275,6 +274,7 @@ def _capture_scm_auto_fields(conanfile, conanfile_dir, package_layout, output, i
 
     local_src_path = scm.get_local_path_to_url(scm_data.url)
     _replace_scm_data_in_recipe(package_layout, scm_data, scm_to_conandata)
+
     return scm_data, local_src_path
 
 

--- a/conans/client/cmd/uploader.py
+++ b/conans/client/cmd/uploader.py
@@ -295,12 +295,14 @@ class CmdUpload(object):
         if policy != UPLOAD_POLICY_FORCE:
             # Check SCM data for auto fields
             if hasattr(conanfile, "scm") and (
-                    conanfile.scm.get("url") == None or conanfile.scm.get("url") == "auto" or conanfile.scm.get("revision") == "auto"):
-                raise ConanException("The recipe has 'scm.url' with None or 'auto', or 'scm.revision' with 'auto' "
-                                     "values. Use '--force' to ignore this error or export again "
-                                     "the recipe ('conan export' or 'conan create') in a "
-                                     "repository with no-uncommitted changes or by "
-                                     "using the '--ignore-dirty' option")
+                  conanfile.scm.get("url") == "auto" or conanfile.scm.get("revision") == "auto" or
+                  conanfile.scm.get("type") is None or conanfile.scm.get("url") is None or
+                  conanfile.scm.get("revision") is None):
+                raise ConanException("The recipe contains invalid data in the 'scm' attribute"
+                                     " (some 'auto' values or missing fields 'type', 'url' or"
+                                     " 'revision'). Use '--force' to ignore this error or export"
+                                     " again the recipe ('conan export' or 'conan create') to"
+                                     " fix these issues.")
 
             remote_manifest = self._check_recipe_date(ref, remote, local_manifest)
         if policy == UPLOAD_POLICY_SKIP:

--- a/conans/client/source.py
+++ b/conans/client/source.py
@@ -185,8 +185,11 @@ def _run_cache_scm(conanfile, scm_sources_folder, src_folder, output):
         merge_directories(scm_sources_folder, dest_dir)
     else:
         output.info("SCM: Getting sources from url: '%s'" % scm_data.url)
-        scm = SCM(scm_data, dest_dir, output)
-        scm.checkout()
+        try:
+            scm = SCM(scm_data, dest_dir, output)
+            scm.checkout()
+        except Exception as e:
+            raise ConanException("Couldn't checkout SCM: %s" % str(e))
         # This is a bit weird. Why after a SCM should we remove files.
         # Maybe check conan 2.0
         # TODO: Why removing in the cache? There is no danger.

--- a/conans/client/tools/scm.py
+++ b/conans/client/tools/scm.py
@@ -191,7 +191,7 @@ class Git(SCMBase):
             name, url = remote.split(None, 1)
             if name == remote_name:
                 url, _ = url.rsplit(None, 1)
-                if url and remove_credentials and not os.path.exists(url):  # only if not local
+                if remove_credentials and not os.path.exists(url):  # only if not local
                     url = self._remove_credentials_url(url)
                 if os.path.exists(url):  # Windows local directory
                     url = url.replace("\\", "/")
@@ -200,10 +200,7 @@ class Git(SCMBase):
 
     def is_local_repository(self):
         url = self.get_remote_url()
-        if url:
-            return os.path.exists(url)
-        else:
-            return None
+        return os.path.exists(url)
 
     def get_commit(self):
         self.check_repo()
@@ -345,7 +342,7 @@ class SVN(SCMBase):
 
     def get_remote_url(self, remove_credentials=False):
         url = self._show_item('url')
-        if url and remove_credentials and not os.path.exists(url):  # only if not local
+        if remove_credentials and not os.path.exists(url):  # only if not local
             url = self._remove_credentials_url(url)
         return url
 
@@ -357,11 +354,8 @@ class SVN(SCMBase):
 
     def is_local_repository(self):
         url = self.get_remote_url()
-        if url:
-            return (url.startswith(self.file_protocol) and
+        return (url.startswith(self.file_protocol) and
                 os.path.exists(unquote(url[len(self.file_protocol):])))
-        else:
-            return True
 
     def is_pristine(self):
         # Check if working copy is pristine/consistent

--- a/conans/test/functional/scm/scm_test.py
+++ b/conans/test/functional/scm/scm_test.py
@@ -128,8 +128,8 @@ class ConanLib(ConanFile):
         self.client.save({"conanfile.py": conanfile, "myfile.txt": "My file is copied"})
         create_local_git_repo(folder=self.client.current_folder)
         self.client.run("export . user/channel")
-        self.assertIn("Repo origin deduced by 'auto': None", self.client.out)
-        self.assertIn("Revision deduced by 'auto'", self.client.out)
+        self.assertIn("WARN: Repo origin cannot be deduced, 'auto' fields won't be replaced",
+                      self.client.out)
 
         self.client.run_command('git remote add origin https://myrepo.com.git')
 
@@ -1032,9 +1032,10 @@ class SCMBlockUploadTest(unittest.TestCase):
                       "Use --ignore-dirty to force it.", client.out)
         # The upload has to fail, no "auto" fields are allowed
         client.run("upload lib/0.1@user/channel -r default", assert_error=True)
-        self.assertIn("ERROR: lib/0.1@user/channel: Upload recipe to 'default' failed: "
-                      "The recipe has 'scm.url' with None or 'auto', or 'scm.revision' "
-                      "with 'auto' values. Use '--force' to ignore", client.out)
+        self.assertIn("ERROR: lib/0.1@user/channel: Upload recipe to 'default' failed:"
+                      " The recipe contains invalid data in the 'scm' attribute (some 'auto'"
+                      " values or missing fields 'type', 'url' or 'revision'). Use '--force'"
+                      " to ignore", client.out)
         # The upload with --force should work
         client.run("upload lib/0.1@user/channel -r default --force")
         self.assertIn("Uploaded conan recipe", client.out)
@@ -1085,10 +1086,9 @@ class SCMBlockUploadTest(unittest.TestCase):
         client.save({"conanfile.py": conanfile})
         create_local_git_repo(folder=client.current_folder)
         client.run("create . pkg/0.1@user/channel")
-        self.assertIn("pkg/0.1@user/channel: WARN: origin is None, upload' command", client.out)
-
         client.run("upload pkg/0.1@user/channel -r default", assert_error=True)
-        self.assertIn("ERROR: pkg/0.1@user/channel: Upload recipe to 'default' failed: "
-                      "The recipe has 'scm.url' with None or 'auto', or 'scm.revision' "
-                      "with 'auto' values. Use '--force' to ignore", client.out)
+        self.assertIn("ERROR: pkg/0.1@user/channel: Upload recipe to 'default' failed: The recipe"
+                      " contains invalid data in the 'scm' attribute (some 'auto' values or"
+                      " missing fields 'type', 'url' or 'revision'). Use '--force' to ignore",
+                      client.out)
         client.run("upload pkg/0.1@user/channel -r default --force")

--- a/conans/test/functional/scm/test_command_export.py
+++ b/conans/test/functional/scm/test_command_export.py
@@ -60,4 +60,5 @@ class ExportCommandTestCase(unittest.TestCase):
         self.client.current_folder = self.path
         self.client.run("export . lib/version@user/channel")
         if auto_url:
-            self.assertIn("Repo origin deduced by 'auto': None", self.client.out)
+            self.assertIn("WARN: Repo origin cannot be deduced, 'auto' fields won't be replaced.",
+                          self.client.out)


### PR DESCRIPTION
Changelog: Omit
Docs: Omit

- [x] Organize changelogs for both PRs

 * Do not modify the `conanfile.py` if the `scm.url="auto"` substitution fails (when origin is `None`). Same behavior we had when working on a dirty repository
 * Do not modify the implementation of Git and SVN tools
 * Upload is forbidden if `type`, `url` or `revision` is not present (or `None`) in the SCM attribute
 * Add tests from https://github.com/conan-io/conan/pull/7094