### PR TITLE
Fix 'conan config' type argument

### DIFF
--- a/conans/client/command.py
+++ b/conans/client/command.py
@@ -557,7 +557,7 @@ class Command(object):
 
         install_subparser.add_argument("--verify-ssl", nargs="?", default="True",
                                        help='Verify SSL connection when downloading file')
-        install_subparser.add_argument("--type", "-t", choices=["git"],
+        install_subparser.add_argument("--type", "-t", choices=["git", "dir", "file", "url"],
                                        help='Type of remote config')
         install_subparser.add_argument("--args", "-a",
                                        help='String with extra arguments for "git clone"')


### PR DESCRIPTION
The automatic type detection is fragile. `os.path.isfile` only detects regular files. But there is no reason for conan not to support installing configs from non-regular files. ~~An example of a non-regular file is a named pipe created by `<(zip -r - settings.yml)`.~~ This example won't work, as `lseek` is not implemented for the named pipe. I think the type argument should be fixed nevertheless?

Reference: https://github.com/conan-io/conan/blob/5065683ed8b854e6985991fd8a69e8648039070e/conans/client/conf/config_installer.py#L170-L193