### PR TITLE
Update the lockfile passed as an argument when using conan install with lockfiles

### DIFF
--- a/conans/client/conan_api.py
+++ b/conans/client/conan_api.py
@@ -532,7 +532,7 @@ class ConanAPIV1(object):
                          update=update, manifest_folder=manifest_folder,
                          manifest_verify=manifest_verify,
                          manifest_interactive=manifest_interactive,
-                         generators=generators, use_lock=lockfile, recorder=recorder)
+                         generators=generators, lockfile=lockfile, recorder=recorder)
             return recorder.get_info(self.app.config.revisions_enabled)
         except ConanException as exc:
             recorder.error = True

--- a/conans/client/manager.py
+++ b/conans/client/manager.py
@@ -12,6 +12,7 @@ from conans.client.source import complete_recipe_sources
 from conans.client.tools import cross_building, get_cross_building_settings
 from conans.errors import ConanException
 from conans.model.ref import ConanFileReference
+from conans.model.graph_lock import LOCKFILE
 from conans.paths import CONANINFO
 from conans.util.files import normalize, save
 
@@ -101,6 +102,7 @@ def deps_install(app, ref_or_path, install_folder, graph_info, remotes=None, bui
             content = normalize(conanfile.info.dumps())
             save(os.path.join(install_folder, CONANINFO), content)
             output.info("Generated %s" % CONANINFO)
+            lockfile = LOCKFILE if lockfile is None else lockfile
             graph_info.save(install_folder, lockfile=lockfile)
             output.info("Generated graphinfo")
         if not no_imports:

--- a/conans/client/manager.py
+++ b/conans/client/manager.py
@@ -19,7 +19,7 @@ from conans.util.files import normalize, save
 def deps_install(app, ref_or_path, install_folder, graph_info, remotes=None, build_modes=None,
                  update=False, manifest_folder=None, manifest_verify=False,
                  manifest_interactive=False, generators=None, no_imports=False,
-                 create_reference=None, keep_build=False, use_lock=False, recorder=None):
+                 create_reference=None, keep_build=False, lockfile=None, recorder=None):
     """ Fetch and build all dependencies for the given reference
     @param app: The ConanApp instance with all collaborators
     @param ref_or_path: ConanFileReference or path to user space conanfile
@@ -96,12 +96,12 @@ def deps_install(app, ref_or_path, install_folder, graph_info, remotes=None, bui
             tmp.extend([g for g in generators if g not in tmp])
             conanfile.generators = tmp
             write_generators(conanfile, install_folder, output)
-        if not isinstance(ref_or_path, ConanFileReference) or use_lock:
+        if not isinstance(ref_or_path, ConanFileReference) or lockfile is not None:
             # Write conaninfo
             content = normalize(conanfile.info.dumps())
             save(os.path.join(install_folder, CONANINFO), content)
             output.info("Generated %s" % CONANINFO)
-            graph_info.save(install_folder)
+            graph_info.save(install_folder, lockfile=lockfile)
             output.info("Generated graphinfo")
         if not no_imports:
             run_imports(conanfile, install_folder)

--- a/conans/model/graph_info.py
+++ b/conans/model/graph_info.py
@@ -47,7 +47,7 @@ class GraphInfo(object):
 
         return GraphInfo(options=options, root_ref=root_ref)
 
-    def save(self, folder, filename=None):
+    def save(self, folder, filename=None, lockfile=LOCKFILE):
         filename = filename or GRAPH_INFO_FILE
         p = os.path.join(folder, filename)
         serialized_graph_str = self._dumps()
@@ -55,7 +55,7 @@ class GraphInfo(object):
 
         # A bit hacky, but to avoid repetition by now
         graph_lock_file = GraphLockFile(self.profile_host, self.profile_build, self.graph_lock)
-        graph_lock_file.save(os.path.join(folder, LOCKFILE))
+        graph_lock_file.save(os.path.join(folder, lockfile))
 
     def save_lock(self, lockfile):
         graph_lock_file = GraphLockFile(self.profile_host, self.profile_build, self.graph_lock)


### PR DESCRIPTION
Changelog: Fix: Update the lockfile passed as an argument to the install command instead of the default `conan.lock`.
Docs: omit

Closes: #6845

- [X] Refer to the issue that supports this Pull Request.
- [X] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [X] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [X] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 

<sup>**Note:** By default this PR will skip the slower tests and will use a limited set of python versions. Check [here](https://github.com/conan-io/conan/blob/develop/.github/PR_INCREASE_TESTING.md) how to increase the testing level by writing some tags in the current PR body text.</sup>

#REVISIONS: 1
