### PR TITLE
fix user_info getattr

### DIFF
--- a/conans/model/user_info.py
+++ b/conans/model/user_info.py
@@ -11,7 +11,10 @@ class UserInfo(object):
         if name.startswith("_") and name.endswith("_"):
             return super(UserInfo, self).__getattr__(name)
 
-        return self._values_[name]
+        try:
+            return self._values_[name]
+        except KeyError:
+            raise AttributeError
 
     def __setattr__(self, name, value):
         if name.startswith("_") and name.endswith("_"):

--- a/conans/test/functional/conanfile/user_info_test.py
+++ b/conans/test/functional/conanfile/user_info_test.py
@@ -1,4 +1,5 @@
 import os
+import textwrap
 import unittest
 
 from conans.paths import CONANFILE
@@ -8,25 +9,20 @@ from conans.test.utils.tools import TestClient
 class UserInfoTest(unittest.TestCase):
 
     def test_user_info_propagation(self):
-
         client = TestClient()
 
         def export_lib(name, requires, infolines):
-            base = '''
-import os
-from conans import ConanFile
+            base = textwrap.dedent("""
+                from conans import ConanFile
 
-class MyConanfile(ConanFile):
-    name = "%s"
-    version = "0.1"
-    requires = "%s"
+                class MyConanfile(ConanFile):
+                    name = "%s"
+                    version = "0.1"
+                    requires = "%s"
 
-    def build(self):
-        pass
-
-    def package_info(self):
-        %s
-    '''
+                    def package_info(self):
+                        %s
+                    """)
             client.save({CONANFILE: base % (name, requires, infolines)}, clean_first=True)
             client.run("export . lasote/stable")
 
@@ -36,24 +32,27 @@ class MyConanfile(ConanFile):
         export_lib("LIB_C", "LIB_B/0.1@lasote/stable", "self.user_info.VAR1=2")
         export_lib("LIB_D", "LIB_C/0.1@lasote/stable", "self.user_info.var1=2")
 
-        reuse = '''
-import os
-from conans import ConanFile
+        reuse = textwrap.dedent("""
+            from conans import ConanFile
 
-class MyConanfile(ConanFile):
-    name = "reuse"
-    version = "0.1"
-    requires = "LIB_D/0.1@lasote/stable"
+            class MyConanfile(ConanFile):
+                requires = "LIB_D/0.1@lasote/stable"
 
-    def build(self):
-        assert(self.deps_user_info["LIB_A"].VAR1=="2")
-        assert(self.deps_user_info["LIB_B"].VAR1=="2")
-        assert(self.deps_user_info["LIB_B"].VAR2=="3")
-        assert(self.deps_user_info["LIB_C"].VAR1=="2")
-        assert(self.deps_user_info["LIB_D"].var1=="2")
-    '''
+                def build(self):
+                    assert(self.deps_user_info["LIB_A"].VAR1=="2")
+                    assert(self.deps_user_info["LIB_B"].VAR1=="2")
+                    assert(self.deps_user_info["LIB_B"].VAR2=="3")
+                    assert(self.deps_user_info["LIB_C"].VAR1=="2")
+                    assert(self.deps_user_info["LIB_D"].var1=="2")
+                    # Idiomatic way to check for attribute existence
+                    # https://github.com/conan-io/conan/issues/7130
+                    assert(hasattr(self.deps_user_info["LIB_A"], "VAR1"))
+                    assert(not hasattr(self.deps_user_info["LIB_A"], "NONEXIST"))
+                    assert(getattr(self.deps_user_info["LIB_A"], "VAR1"))
+                    assert(not getattr(self.deps_user_info["LIB_A"], "NONEXIST", None))
+                """)
         client.save({CONANFILE: reuse}, clean_first=True)
-        client.run("export . lasote/stable")
+        client.run("export . reuse/0.1@lasote/stable")
         client.run('install reuse/0.1@lasote/stable --build -g txt')
 
         # Assert generator TXT


### PR DESCRIPTION
Changelog: Bugfix: Getting attribute of ``self.deps_user_info["dep"]`` now raise ``AttributeError`` instead of a (wrong) ``KeyError``, enabling ``hasattr()`` and correct ``getattr()`` behaviors.
Docs: omit

Fix: https://github.com/conan-io/conan/issues/7130