### PR TITLE
Feature: change signature of compilervars functions

### DIFF
--- a/conans/client/build/cmake.py
+++ b/conans/client/build/cmake.py
@@ -226,7 +226,7 @@ class CMake(object):
         elif is_intel:
             if self.generator in ["Ninja", "NMake Makefiles", "NMake Makefiles JOM",
                                   "Unix Makefiles"]:
-                compilervars_dict = tools.compilervars_dict(self._settings, force=True)
+                compilervars_dict = tools.compilervars_dict(self._conanfile, force=True)
                 context = _environment_add(compilervars_dict, post=self._append_vcvars)
         with context:
             self._conanfile.run(command)

--- a/conans/client/tools/intel.py
+++ b/conans/client/tools/intel.py
@@ -53,13 +53,14 @@ def intel_installation_path(version, arch):
     return installation_path
 
 
-def compilervars_command(settings, arch=None, compiler_version=None, force=False):
+def compilervars_command(conanfile, arch=None, compiler_version=None, force=False):
     """
     https://software.intel.com/en-us/intel-system-studio-cplusplus-compiler-user-and-reference-guide-using-compilervars-file
     :return:
     """
     if "PSTLROOT" in os.environ and not force:
         return "echo Conan:compilervars already set"
+    settings = conanfile.settings
     compiler_version = compiler_version or settings.get_safe("compiler.version")
     arch = arch or settings.get_safe("arch")
     system = platform.system()
@@ -96,8 +97,8 @@ def compilervars_command(settings, arch=None, compiler_version=None, force=False
     return command
 
 
-def compilervars_dict(settings, arch=None, compiler_version=None, force=False, only_diff=True):
-    cmd = compilervars_command(settings, arch, compiler_version, force)
+def compilervars_dict(conanfile, arch=None, compiler_version=None, force=False, only_diff=True):
+    cmd = compilervars_command(conanfile, arch, compiler_version, force)
     return env_diff(cmd, only_diff)
 
 

--- a/conans/test/unittests/client/tools/intel/compilervars_test.py
+++ b/conans/test/unittests/client/tools/intel/compilervars_test.py
@@ -7,20 +7,21 @@ from conans.client.conf import get_default_settings_yml
 from conans.client.tools.env import environment_append
 from conans.client.tools.intel import compilervars_command
 from conans.errors import ConanException
+from conans.test.utils.conanfile import MockConanfile
 
 
 class CompilerVarsTest(unittest.TestCase):
     def test_already_set(self):
         with environment_append({"PSTLROOT": "1"}):
             settings = Settings.loads(get_default_settings_yml())
-            cvars = compilervars_command(settings)
+            cvars = compilervars_command(MockConanfile(settings))
             self.assertEqual("echo Conan:compilervars already set", cvars)
 
     def test_bas_os(self):
         settings = Settings.loads(get_default_settings_yml())
         settings.os = "SunOS"
         with self.assertRaises(ConanException):
-            compilervars_command(settings)
+            compilervars_command(MockConanfile(settings))
 
     def test_win(self):
         install_dir = "C:\\Intel"
@@ -33,23 +34,23 @@ class CompilerVarsTest(unittest.TestCase):
             settings.compiler.base = "Visual Studio"
             settings.arch = "ppc32"
             with self.assertRaises(ConanException):
-                compilervars_command(settings)
+                compilervars_command(MockConanfile(settings))
 
             path = os.path.join(install_dir, "bin", "compilervars.bat")
 
             settings.arch = "x86"
-            cvars = compilervars_command(settings)
+            cvars = compilervars_command(MockConanfile(settings))
             expected = '"%s" -arch ia32' % path
             self.assertEqual(expected, cvars)
 
             settings.compiler.base.version = "16"
-            cvars = compilervars_command(settings)
+            cvars = compilervars_command(MockConanfile(settings))
             expected = '"%s" -arch ia32 vs2019' % path
             self.assertEqual(expected, cvars)
 
             settings.arch = "x86_64"
             expected = '"%s" -arch intel64 vs2019' % path
-            cvars = compilervars_command(settings)
+            cvars = compilervars_command(MockConanfile(settings))
             self.assertEqual(expected, cvars)
 
 
@@ -64,12 +65,12 @@ class CompilerVarsTest(unittest.TestCase):
             settings.compiler.base = "gcc"
             settings.arch = "ppc32"
             with self.assertRaises(ConanException):
-                compilervars_command(settings)
+                compilervars_command(MockConanfile(settings))
 
             path = os.path.join(install_dir, "bin", "compilervars.sh")
 
             settings.arch = "x86"
-            cvars = compilervars_command(settings)
+            cvars = compilervars_command(MockConanfile(settings))
             expected = 'COMPILERVARS_PLATFORM=linux COMPILERVARS_ARCHITECTURE=ia32 . ' \
                        '"%s" -arch ia32 -platform linux' % path
             self.assertEqual(expected, cvars)
@@ -77,7 +78,7 @@ class CompilerVarsTest(unittest.TestCase):
             settings.arch = "x86_64"
             expected = 'COMPILERVARS_PLATFORM=linux COMPILERVARS_ARCHITECTURE=intel64 . ' \
                        '"%s" -arch intel64 -platform linux' % path
-            cvars = compilervars_command(settings)
+            cvars = compilervars_command(MockConanfile(settings))
             self.assertEqual(expected, cvars)
 
     def test_mac(self):
@@ -91,12 +92,12 @@ class CompilerVarsTest(unittest.TestCase):
             settings.compiler.base = "apple-clang"
             settings.arch = "ppc32"
             with self.assertRaises(ConanException):
-                compilervars_command(settings)
+                compilervars_command(MockConanfile(settings))
 
             path = os.path.join(install_dir, "bin", "compilervars.sh")
 
             settings.arch = "x86"
-            cvars = compilervars_command(settings)
+            cvars = compilervars_command(MockConanfile(settings))
             expected = 'COMPILERVARS_PLATFORM=mac COMPILERVARS_ARCHITECTURE=ia32 . ' \
                        '"%s" -arch ia32 -platform mac' % path
             self.assertEqual(expected, cvars)
@@ -104,5 +105,5 @@ class CompilerVarsTest(unittest.TestCase):
             settings.arch = "x86_64"
             expected = 'COMPILERVARS_PLATFORM=mac COMPILERVARS_ARCHITECTURE=intel64 . ' \
                        '"%s" -arch intel64 -platform mac' % path
-            cvars = compilervars_command(settings)
+            cvars = compilervars_command(MockConanfile(settings))
             self.assertEqual(expected, cvars)


### PR DESCRIPTION
Changelog: Omit 
Docs: Omit

change signature of compilervars functions (introduced in this release https://github.com/conan-io/conan/pull/6735)

- [x] Refer to the issue that supports this Pull Request.
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [x] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 

<sup>**Note:** By default this PR will skip the slower tests and will use a limited set of python versions. Check [here](https://github.com/conan-io/conan/blob/develop/.github/PR_INCREASE_TESTING.md) how to increase the testing level by writing some tags in the current PR body text.</sup>
