### PR TITLE
'conan inspect': json-serialize sets as lists

### DIFF
--- a/conans/client/command.py
+++ b/conans/client/command.py
@@ -260,7 +260,13 @@ class Command(object):
         result = self._conan.inspect(args.path_or_reference, attributes, args.remote, quiet=quiet)
         Printer(self._out).print_inspect(result, raw=args.raw)
         if args.json:
-            json_output = json.dumps(result)
+
+            def dump_custom_types(obj):
+                if isinstance(obj, set):
+                    return list(obj)
+                raise TypeError
+
+            json_output = json.dumps(result, default=dump_custom_types)
             if not os.path.isabs(args.json):
                 json_output_file = os.path.join(get_cwd(), args.json)
             else:

--- a/conans/client/command.py
+++ b/conans/client/command.py
@@ -263,7 +263,7 @@ class Command(object):
 
             def dump_custom_types(obj):
                 if isinstance(obj, set):
-                    return list(obj)
+                    return sorted(list(obj))
                 raise TypeError
 
             json_output = json.dumps(result, default=dump_custom_types)

--- a/conans/test/functional/command/inspect_test.py
+++ b/conans/test/functional/command/inspect_test.py
@@ -464,3 +464,15 @@ class InspectRawTest(unittest.TestCase):
         os.remove(client.cache.remotes_path)
         client.run("inspect MyPkg/1.2.3@user/channel --raw=version")
         self.assertEqual("1.2.3", client.out)
+
+    def test_inspect_settings_set(self):
+        client = TestClient()
+        client.save({"conanfile.py": textwrap.dedent("""
+            from conans import ConanFile
+
+            class Recipe(ConanFile):
+                settings = {"os", "compiler"}
+        """)})
+        client.run("inspect . --json=file.json")
+        contents = client.load("file.json")
+        self.assertIn('"settings": ["compiler", "os"]', contents)


### PR DESCRIPTION
Changelog: Fix: JSON-serialize sets as a list when using `conan inspect --json`.
Docs: omit

The attribute `settings` in the `conanfile.py` should be a list/tuple, but we've found several times this issue in Conan Center. IMO if it works when using other commands, we cannot fail in this one.

