### PR TITLE
CONAN_SYSTEM_INCLUDES to work in more situations

### DIFF
--- a/conans/client/generators/cmake_common.py
+++ b/conans/client/generators/cmake_common.py
@@ -190,11 +190,21 @@ _target_template = """
                                                                  $<$<STREQUAL:$<TARGET_PROPERTY:TYPE>,SHARED_LIBRARY>:${{CONAN_SHARED_LINKER_FLAGS_{uname}_DEBUG_LIST}}>
                                                                  $<$<STREQUAL:$<TARGET_PROPERTY:TYPE>,MODULE_LIBRARY>:${{CONAN_SHARED_LINKER_FLAGS_{uname}_DEBUG_LIST}}>
                                                                  $<$<STREQUAL:$<TARGET_PROPERTY:TYPE>,EXECUTABLE>:${{CONAN_EXE_LINKER_FLAGS_{uname}_DEBUG_LIST}}>>)
-    set_property(TARGET {name} PROPERTY INTERFACE_INCLUDE_DIRECTORIES ${{CONAN_INCLUDE_DIRS_{uname}}}
-                                                                      $<$<CONFIG:Release>:${{CONAN_INCLUDE_DIRS_{uname}_RELEASE}}>
-                                                                      $<$<CONFIG:RelWithDebInfo>:${{CONAN_INCLUDE_DIRS_{uname}_RELWITHDEBINFO}}>
-                                                                      $<$<CONFIG:MinSizeRel>:${{CONAN_INCLUDE_DIRS_{uname}_MINSIZEREL}}>
-                                                                      $<$<CONFIG:Debug>:${{CONAN_INCLUDE_DIRS_{uname}_DEBUG}}>)
+
+    if(CONAN_SYSTEM_INCLUDES)
+        target_include_directories( {name} SYSTEM INTERFACE ${{CONAN_INCLUDE_DIRS_{uname}}}
+                                                            $<$<CONFIG:Release>:${{CONAN_INCLUDE_DIRS_{uname}_RELEASE}}>
+                                                            $<$<CONFIG:RelWithDebInfo>:${{CONAN_INCLUDE_DIRS_{uname}_RELWITHDEBINFO}}>
+                                                            $<$<CONFIG:MinSizeRel>:${{CONAN_INCLUDE_DIRS_{uname}_MINSIZEREL}}>
+                                                            $<$<CONFIG:Debug>:${{CONAN_INCLUDE_DIRS_{uname}_DEBUG}}>)
+    else()
+        target_include_directories( {name} INTERFACE ${{CONAN_INCLUDE_DIRS_{uname}}}
+                                                     $<$<CONFIG:Release>:${{CONAN_INCLUDE_DIRS_{uname}_RELEASE}}>
+                                                     $<$<CONFIG:RelWithDebInfo>:${{CONAN_INCLUDE_DIRS_{uname}_RELWITHDEBINFO}}>
+                                                     $<$<CONFIG:MinSizeRel>:${{CONAN_INCLUDE_DIRS_{uname}_MINSIZEREL}}>
+                                                     $<$<CONFIG:Debug>:${{CONAN_INCLUDE_DIRS_{uname}_DEBUG}}>)
+    endif()
+
     set_property(TARGET {name} PROPERTY INTERFACE_COMPILE_DEFINITIONS ${{CONAN_COMPILE_DEFINITIONS_{uname}}}
                                                                       $<$<CONFIG:Release>:${{CONAN_COMPILE_DEFINITIONS_{uname}_RELEASE}}>
                                                                       $<$<CONFIG:RelWithDebInfo>:${{CONAN_COMPILE_DEFINITIONS_{uname}_RELWITHDEBINFO}}>

--- a/conans/client/generators/cmake_find_package.py
+++ b/conans/client/generators/cmake_find_package.py
@@ -29,8 +29,11 @@ class CMakeFindPackageGenerator(Generator):
             if(NOT TARGET {name}::{name})
                 add_library({name}::{name} INTERFACE IMPORTED)
                 if({name}_INCLUDE_DIRS)
-                    set_target_properties({name}::{name} PROPERTIES INTERFACE_INCLUDE_DIRECTORIES
-                                          "${{{name}_INCLUDE_DIRS}}")
+                    if(CONAN_SYSTEM_INCLUDES)
+                        target_include_directories({name}::{name} SYSTEM INTERFACE "${{{name}_INCLUDE_DIRS}}")
+                    else()
+                        target_include_directories({name}::{name} INTERFACE "${{{name}_INCLUDE_DIRS}}")
+                    endif()
                 endif()
                 set_property(TARGET {name}::{name} PROPERTY INTERFACE_LINK_LIBRARIES
                              "${{{name}_LIBRARIES_TARGETS}};${{{name}_LINKER_FLAGS_LIST}}")

--- a/conans/client/generators/cmake_find_package_multi.py
+++ b/conans/client/generators/cmake_find_package_multi.py
@@ -46,12 +46,19 @@ set_property(TARGET {name}::{name}
                  $<$<CONFIG:RelWithDebInfo>:${{{name}_LIBRARIES_TARGETS_RELWITHDEBINFO}} ${{{name}_LINKER_FLAGS_RELWITHDEBINFO_LIST}}>
                  $<$<CONFIG:MinSizeRel>:${{{name}_LIBRARIES_TARGETS_MINSIZEREL}} ${{{name}_LINKER_FLAGS_MINSIZEREL_LIST}}>
                  $<$<CONFIG:Debug>:${{{name}_LIBRARIES_TARGETS_DEBUG}} ${{{name}_LINKER_FLAGS_DEBUG_LIST}}>)
-set_property(TARGET {name}::{name}
-             PROPERTY INTERFACE_INCLUDE_DIRECTORIES
-                 $<$<CONFIG:Release>:${{{name}_INCLUDE_DIRS_RELEASE}}>
-                 $<$<CONFIG:RelWithDebInfo>:${{{name}_INCLUDE_DIRS_RELWITHDEBINFO}}>
-                 $<$<CONFIG:MinSizeRel>:${{{name}_INCLUDE_DIRS_MINSIZEREL}}>
-                 $<$<CONFIG:Debug>:${{{name}_INCLUDE_DIRS_DEBUG}}>)
+if(CONAN_SYSTEM_INCLUDES)
+    target_include_directories({name}::{name} SYSTEM INTERFACE
+                     $<$<CONFIG:Release>:${{{name}_INCLUDE_DIRS_RELEASE}}>
+                     $<$<CONFIG:RelWithDebInfo>:${{{name}_INCLUDE_DIRS_RELWITHDEBINFO}}>
+                     $<$<CONFIG:MinSizeRel>:${{{name}_INCLUDE_DIRS_MINSIZEREL}}>
+                     $<$<CONFIG:Debug>:${{{name}_INCLUDE_DIRS_DEBUG}}>)
+else()
+    target_include_directories({name}::{name} INTERFACE
+                     $<$<CONFIG:Release>:${{{name}_INCLUDE_DIRS_RELEASE}}>
+                     $<$<CONFIG:RelWithDebInfo>:${{{name}_INCLUDE_DIRS_RELWITHDEBINFO}}>
+                     $<$<CONFIG:MinSizeRel>:${{{name}_INCLUDE_DIRS_MINSIZEREL}}>
+                     $<$<CONFIG:Debug>:${{{name}_INCLUDE_DIRS_DEBUG}}>)
+endif()
 set_property(TARGET {name}::{name}
              PROPERTY INTERFACE_COMPILE_DEFINITIONS
                  $<$<CONFIG:Release>:${{{name}_COMPILE_DEFINITIONS_RELEASE}}>


### PR DESCRIPTION
Changelog: Feature: CONAN_SYSTEM_INCLUDES to work for cmake_find_package and cmake_find_package
Docs: https://github.com/conan-io/docs/pull/XXXX

- [x] Refer to the issue that supports this Pull Request.
- [ ] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [ ] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 

<sup>**Note:** By default this PR will skip the slower tests and will use a limited set of python versions. Check [here](https://github.com/conan-io/conan/blob/develop/.github/PR_INCREASE_TESTING.md) how to increase the testing level by writing some tags in the current PR body text.</sup>
