### PR TITLE
Add support for CLICOLOR/CLICOLOR_FORCE/NO_COLOR output controls

### DIFF
--- a/conans/client/output.py
+++ b/conans/client/output.py
@@ -8,12 +8,29 @@ from conans.util.files import decode_text
 
 
 def colorama_initialize():
+    if "NO_COLOR" in os.environ:
+        return False
+
+    clicolor_force = get_env("CLICOLOR_FORCE")
+    if clicolor_force is not None and clicolor_force != "0":
+        import colorama
+        colorama.init(convert=False, strip=False)
+        return True
+
+    isatty = hasattr(sys.stdout, "isatty") and sys.stdout.isatty()
+
+    clicolor = get_env("CLICOLOR")
+    if clicolor is not None:
+        if clicolor == "0" or not isatty:
+            return False
+        import colorama
+        colorama.init()
+        return True
+
     # Respect color env setting or check tty if unset
     color_set = "CONAN_COLOR_DISPLAY" in os.environ
     if ((color_set and get_env("CONAN_COLOR_DISPLAY", 1))
-            or (not color_set
-                and hasattr(sys.stdout, "isatty")
-                and sys.stdout.isatty())):
+            or (not color_set and isatty)):
         import colorama
         if get_env("PYCHARM_HOSTED"):  # in PyCharm disable convert/strip
             colorama.init(convert=False, strip=False)

--- a/conans/test/unittests/client/conan_output_test.py
+++ b/conans/test/unittests/client/conan_output_test.py
@@ -5,7 +5,7 @@ from types import MethodType
 
 from six import StringIO
 
-from conans.client.output import ConanOutput
+from conans.client.output import ConanOutput, colorama_initialize
 from mock import mock
 
 
@@ -28,3 +28,107 @@ class ConanOutputTest(unittest.TestCase):
             out.write("Hello world")
             sleep.assert_any_call(0.02)
         self.assertEqual("Hello world", stream.getvalue())
+
+    def test_output_color(self):
+        # Output is not a terminal, no overrides.
+        # Color generation disabled.
+        with mock.patch("colorama.init") as init:
+            isatty = False
+            env = {}
+            with mock.patch("sys.stdout.isatty", return_value=isatty), \
+                 mock.patch.dict("os.environ", env, clear=True):
+                assert not colorama_initialize()
+                init.assert_not_called()
+
+        # Output is a terminal, no overrides.
+        # Color generation enabled, colorama will not strip colors.
+        with mock.patch("colorama.init") as init:
+            isatty = True
+            env = {}
+            with mock.patch("sys.stdout.isatty", return_value=isatty), \
+                 mock.patch.dict("os.environ", env, clear=True):
+                assert colorama_initialize()
+                init.assert_called_once_with()
+
+        # Output is not a terminal, prevent color generation (CONAN_COLOR_DISPLAY=0).
+        # Color generation disabled.
+        with mock.patch("colorama.init") as init:
+            isatty = False
+            env = {"CONAN_COLOR_DISPLAY": "0"}
+            with mock.patch("sys.stdout.isatty", return_value=isatty), \
+                 mock.patch.dict("os.environ", env, clear=True):
+                assert not colorama_initialize()
+                init.assert_not_called()
+
+        # Output is a terminal, prevent color generation (CONAN_COLOR_DISPLAY=0).
+        # Color generation disabled.
+        with mock.patch("colorama.init") as init:
+            isatty = True
+            env = {"CONAN_COLOR_DISPLAY": "0"}
+            with mock.patch("sys.stdout.isatty", return_value=isatty), \
+                 mock.patch.dict("os.environ", env, clear=True):
+                assert not colorama_initialize()
+                init.assert_not_called()
+
+        # Output is not a terminal, force color generation (CONAN_COLOR_DISPLAY=1).
+        # Color generation enabled, colorama will strip colors.
+        with mock.patch("colorama.init") as init:
+            isatty = False
+            env = {"CONAN_COLOR_DISPLAY": "1"}
+            with mock.patch("sys.stdout.isatty", return_value=isatty), \
+                 mock.patch.dict("os.environ", env, clear=True):
+                assert colorama_initialize()
+                init.assert_called_once_with()
+
+        # Output is a terminal, force color generation (CONAN_COLOR_DISPLAY=1).
+        # Color generation enabled, colorama will not strip colors.
+        with mock.patch("colorama.init") as init:
+            isatty = True
+            env = {"CONAN_COLOR_DISPLAY": "1"}
+            with mock.patch("sys.stdout.isatty", return_value=isatty), \
+                 mock.patch.dict("os.environ", env, clear=True):
+                assert colorama_initialize()
+                init.assert_called_once_with()
+
+        # Output is not a terminal, no forced color generation, prevent color stripping
+        # (PYCHARM_HOSTED=1).
+        # Color generation disabled.
+        with mock.patch("colorama.init") as init:
+            isatty = False
+            env = {"PYCHARM_HOSTED": "1"}
+            with mock.patch("sys.stdout.isatty", return_value=isatty), \
+                 mock.patch.dict("os.environ", env, clear=True):
+                assert not colorama_initialize()
+                init.assert_not_called()
+
+        # Output is not a terminal, force color generation (CONAN_COLOR_DISPLAY=1),
+        # prevent color stripping (PYCHARM_HOSTED=1).
+        # Color generation enabled, colorama will not strip colors (forced).
+        with mock.patch("colorama.init") as init:
+            isatty = False
+            env = {"PYCHARM_HOSTED": "1", "CONAN_COLOR_DISPLAY": "1"}
+            with mock.patch("sys.stdout.isatty", return_value=isatty), \
+                 mock.patch.dict("os.environ", env, clear=True):
+                assert colorama_initialize()
+                init.assert_called_once_with(convert=False, strip=False)
+
+        # Output is a terminal, prevent color generation (CONAN_COLOR_DISPLAY=0), prevent
+        # color stripping (PYCHARM_HOSTED=1).
+        # Color generation disabled.
+        with mock.patch("colorama.init") as init:
+            isatty = True
+            env = {"PYCHARM_HOSTED": "1", "CONAN_COLOR_DISPLAY": "0"}
+            with mock.patch("sys.stdout.isatty", return_value=isatty), \
+                 mock.patch.dict("os.environ", env, clear=True):
+                assert not colorama_initialize()
+                init.assert_not_called()
+
+        # Output is a terminal, prevent color stripping (PYCHARM_HOSTED=1).
+        # Color generation enabled, colorama will not strip colors.
+        with mock.patch("colorama.init") as init:
+            isatty = True
+            env = {"PYCHARM_HOSTED": "1"}
+            with mock.patch("sys.stdout.isatty", return_value=isatty), \
+                 mock.patch.dict("os.environ", env, clear=True):
+                assert colorama_initialize()
+                init.assert_called_once_with(convert=False, strip=False)

--- a/conans/test/unittests/client/conan_output_test.py
+++ b/conans/test/unittests/client/conan_output_test.py
@@ -30,6 +30,10 @@ class ConanOutputTest(unittest.TestCase):
         self.assertEqual("Hello world", stream.getvalue())
 
     def test_output_color(self):
+        #########################################################
+        # Color control with CONAN_COLOR_DISPLAY/PYCHARM_HOSTED #
+        #########################################################
+
         # Output is not a terminal, no overrides.
         # Color generation disabled.
         with mock.patch("colorama.init") as init:
@@ -132,3 +136,126 @@ class ConanOutputTest(unittest.TestCase):
                  mock.patch.dict("os.environ", env, clear=True):
                 assert colorama_initialize()
                 init.assert_called_once_with(convert=False, strip=False)
+
+        #######################################################
+        # Color control with CLICOLOR/CLICOLOR_FORCE/NO_COLOR #
+        #######################################################
+
+        # Output is a terminal, prevent color generation (NO_COLOR).
+        # Color generation disabled.
+        with mock.patch("colorama.init") as init:
+            isatty = True
+            env = {"NO_COLOR": ""}
+            with mock.patch("sys.stdout.isatty", return_value=isatty), \
+                 mock.patch.dict("os.environ", env, clear=True):
+                assert not colorama_initialize()
+                init.assert_not_called()
+
+        # Output is a terminal, prevent color generation (CLICOLOR=0).
+        # Color generation disabled.
+        with mock.patch("colorama.init") as init:
+            isatty = True
+            env = {"CLICOLOR": "0"}
+            with mock.patch("sys.stdout.isatty", return_value=isatty), \
+                 mock.patch.dict("os.environ", env, clear=True):
+                assert not colorama_initialize()
+                init.assert_not_called()
+
+        # Output is a terminal, prevent color generation (CLICOLOR=0), override
+        # CONAN_COLOR_DISPLAY=1.
+        # Color generation disabled.
+        with mock.patch("colorama.init") as init:
+            isatty = True
+            env = {"CLICOLOR": "0", "CONAN_COLOR_DISPLAY": "1"}
+            with mock.patch("sys.stdout.isatty", return_value=isatty), \
+                 mock.patch.dict("os.environ", env, clear=True):
+                assert not colorama_initialize()
+                init.assert_not_called()
+
+        # Output is a terminal, request color generation (CLICOLOR=1).
+        # Color generation enabled, colorama will not strip colors.
+        with mock.patch("colorama.init") as init:
+            isatty = True
+            env = {"CLICOLOR": "1"}
+            with mock.patch("sys.stdout.isatty", return_value=isatty), \
+                 mock.patch.dict("os.environ", env, clear=True):
+                assert colorama_initialize()
+                init.assert_called_once_with()
+
+        # Output is not a terminal, request color generation (CLICOLOR=1).
+        # Color generation disabled.
+        with mock.patch("colorama.init") as init:
+            isatty = False
+            env = {"CLICOLOR": "1"}
+            with mock.patch("sys.stdout.isatty", return_value=isatty), \
+                 mock.patch.dict("os.environ", env, clear=True):
+                assert not colorama_initialize()
+                init.assert_not_called()
+
+        # Output is not a terminal, force color generation (CLICOLOR_FORCE=1),
+        # prevent color stripping (CLICOLOR_FORCE=1).
+        # Color generation enabled, colorama will not strip colors (forced).
+        with mock.patch("colorama.init") as init:
+            isatty = False
+            env = {"CLICOLOR_FORCE": "1"}
+            with mock.patch("sys.stdout.isatty", return_value=isatty), \
+                 mock.patch.dict("os.environ", env, clear=True):
+                assert colorama_initialize()
+                init.assert_called_once_with(convert=False, strip=False)
+
+        # Output is a terminal, force enable color generation (CLICOLOR_FORCE=1),
+        # override CLICOLOR=0, prevent color stripping (CLICOLOR_FORCE=1).
+        # Color generation enabled, colorama will not strip colors.
+        with mock.patch("colorama.init") as init:
+            isatty = True
+            env = {"CLICOLOR_FORCE": "1", "CLICOLOR": "0"}
+            with mock.patch("sys.stdout.isatty", return_value=isatty), \
+                 mock.patch.dict("os.environ", env, clear=True):
+                assert colorama_initialize()
+                init.assert_called_once_with(convert=False, strip=False)
+
+        # Output is a terminal, force enable color generation (CLICOLOR_FORCE=1),
+        # override CONAN_COLOR_DISPLAY=0, prevent color stripping (CLICOLOR_FORCE=1).
+        # Color generation enabled, colorama will not strip colors.
+        with mock.patch("colorama.init") as init:
+            isatty = True
+            env = {"CLICOLOR_FORCE": "1", "CONAN_COLOR_DISPLAY": "0"}
+            with mock.patch("sys.stdout.isatty", return_value=isatty), \
+                 mock.patch.dict("os.environ", env, clear=True):
+                assert colorama_initialize()
+                init.assert_called_once_with(convert=False, strip=False)
+
+        # Output is not a terminal, disable forced color generation (CLICOLOR_FORCE=0).
+        # Color generation disabled.
+        with mock.patch("colorama.init") as init:
+            isatty = False
+            env = {"CLICOLOR_FORCE": "0"}
+            with mock.patch("sys.stdout.isatty", return_value=isatty), \
+                 mock.patch.dict("os.environ", env, clear=True):
+                assert not colorama_initialize()
+                init.assert_not_called()
+
+        # Output is a terminal, disable forced color generation (CLICOLOR_FORCE=0).
+        # Color generation enabled, colorama will not strip colors.
+        with mock.patch("colorama.init") as init:
+            isatty = True
+            env = {"CLICOLOR_FORCE": "0"}
+            with mock.patch("sys.stdout.isatty", return_value=isatty), \
+                 mock.patch.dict("os.environ", env, clear=True):
+                assert colorama_initialize()
+                init.assert_called_once_with()
+
+        # Output is a terminal, prevent color generation (NO_COLOR), overriding other
+        # controls.
+        # Color generation disabled.
+        with mock.patch("colorama.init") as init:
+            isatty = True
+            env = {
+                "CLICOLOR": "1", "CLICOLOR_FORCE": "1",
+                "CONAN_COLOR_DISPLAY": "1", "PYCHARM_HOSTED": "1",
+                "NO_COLOR": "1"
+            }
+            with mock.patch("sys.stdout.isatty", return_value=isatty), \
+                 mock.patch.dict("os.environ", env, clear=True):
+                assert not colorama_initialize()
+                init.assert_not_called()


### PR DESCRIPTION
Changelog: Feature: Add support for the `CLICOLOR`/`CLICOLOR_FORCE`/`NO_COLOR` output colorization control variables.
Docs: https://github.com/conan-io/docs/pull/1728

- [x] Refer to the issue that supports this Pull Request.
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [x] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 

<sup>**Note:** By default this PR will skip the slower tests and will use a limited set of python versions. Check [here](https://github.com/conan-io/conan/blob/develop/.github/PR_INCREASE_TESTING.md) how to increase the testing level by writing some tags in the current PR body text.</sup>

This was motivated on my part due to wanting colorized output in Gitlab CI displays. I found CMake could be forced to output colors with `CLICOLOR_FORCE=1`, and similar to the final comments of #4718, I found Conan could be forced to output colors with the combination of `CONAN_COLOR_DISPLAY=1` and `PYCHARM_HOSTED=1`, resulting in the following at the top of the config:
```yaml
variables:
  CLICOLOR_FORCE: "1"
  CONAN_COLOR_DISPLAY: "1"
  PYCHARM_HOSTED: "1"
```
This works because in the current output logic `CONAN_COLOR_DISPLAY=1` enables the generation of color codes even through the output is not a tty, and `PYCHARM_HOSTED=1` sets up colorama so that it doesn't strip these color codes when it detects that the output is not going to a tty. This setup is a little awkward though, because the CI project otherwise has nothing to do with pycharm. This PR enables the following config to have the same effect:
```yaml
variables:
  CLICOLOR_FORCE: "1"
```

It turns out the `CLICOLOR_FORCE` variable [used by CMake](https://gitlab.kitware.com/cmake/cmake/-/blob/3414ee155e0423284a9171497d7724828fd324a5/Source/kwsys/Terminal.c#L169) has some historical usage on UNIX systems, and there is also a "specification" that describes how [`CLICOLOR` and `CLICOLOR_FORCE`](https://bixense.com/clicolors/) should be expected to work. Another notable user of this is [Ninja](https://github.com/ninja-build/ninja/blob/70c8d75055b4fcb0ee6d9a41b908c554534725f6/src/line_printer.cc#L53).

This PR implements `CLICOLOR` and `CLICOLOR_FORCE` alongside the current color control variables. It also adds support for [`NO_COLOR`](https://no-color.org/), which force disables color output, even in cases it would normally be enabled. Some notable users of this include [npm](https://github.com/npm/cli/blob/9c7161de7218b63d487131a4fb67e942b772820e/lib/config/defaults.js#L136) and [Homebrew](https://github.com/Homebrew/brew/blob/9eed1e4e7e47813a9280a5e26b5955c2bbaa1dba/Library/Homebrew/env_config.rb#L186).

The first commit adds some tests for the current logic, to help ensure that there is no change in behavior when only the current controls are used. These tests use some mocks over colorama initialization rather than any sort of output testing, as it seems like those sorts of tests could get messy if they need to run on both Linux and Windows. Also AFAICT, how colorama is initialized is what ultimately determines the behavior of colorized output.

In the current implementation, the new variables are checked before the current variables and, if they are used, take precedence. For example, `NO_COLOR=1` overrides `CONAN_COLOR_DISPLAY=1 & PYCHARM_HOSTED=1`, and `CLICOLOR_FORCE=1` overrides `CONAN_COLOR_DISPLAY=0`. Note that the output falls back to the original behavior when `NO_COLOR` and `CLICOLOR` are unset and either `CLICOLOR_FORCE` is unset or `CLICOLOR_FORCE=0`.

The second commit also extends the tests with various combinations of the current variables and new variables to hopefully cover all of the effective logic branches.

This should provide a solution for #4718 and should also handle the concern in https://github.com/conan-io/conan/issues/4718#issuecomment-478537269, as something like `NO_COLOR=1 conan --version` could be used to disable colors for parsing needs even if running in an environment with a global `CLICOLOR_FORCE=1`.
