### PR TITLE
[WIP] Added new toolchain-based Meson helper

### DIFF
--- a/conans/__init__.py
+++ b/conans/__init__.py
@@ -3,7 +3,9 @@
 from conans.client.build.autotools_environment import AutoToolsBuildEnvironment
 from conans.client.build.cmake import CMake
 from conans.client.toolchain.cmake import CMakeToolchain
+from conans.client.toolchain.meson import MesonMachineFile, MesonToolchain, MesonDefaultToolchain
 from conans.client.build.meson import Meson
+from conans.client.build.mesonx import MesonX
 from conans.client.build.msbuild import MSBuild
 from conans.client.build.visual_environment import VisualStudioBuildEnvironment
 from conans.client.run_environment import RunEnvironment

--- a/conans/client/build/mesonx.py
+++ b/conans/client/build/mesonx.py
@@ -15,14 +15,6 @@ from conans.model.version import Version
 from conans.util.files import decode_text, get_abs_path, mkdir
 from conans.util.runners import version_runner
 
-# TODO:
-# - add pkg_config_path to configure properly (cross scenario and native) or move it to machine file generation
-# - fix env variables reading for native\cross (once it's possible)
-# - cleanup comments
-# - add tests
-# - Can we use Py3.x? meson requires Python 3.5+
-# - deal with typings (remove? add everywhere?)
-
 # Differences from stock Meson integration:
 # - does not override 'default_library' if no 'shared' options was set
 # - saves `build_dir` in __init__
@@ -34,7 +26,15 @@ from conans.util.runners import version_runner
 # - requires pkg-config generator
 # - install_folder is always added to pkg-config search paths now (since pc generator is required now)
 
-# Question:
+# TODO:
+# - add pkg_config_path to configure properly (cross scenario and native) or move it to machine file generation
+# - fix env variables reading for native\cross once it's possible (i.e when <https://github.com/conan-io/conan/issues/7091> is fixed)
+# - cleanup comments
+# - add tests
+# - Can we use Py3.x? meson requires Python 3.5+
+# - deal with typings (remove? add everywhere?)
+
+# Questions:
 # - Should we keep `cross-file`/`native-file` kwarg or should they be moved to `options` instead?
 # - Same q as ^ for pkg-config-paths
 # - How should the user extend `_get_cpu_family_and_endianness_from_arch` in case he has a custom unknown arch?
@@ -434,10 +434,18 @@ class MesonX(object):
         args = args or []
         targets = targets or []
 
-        minimum_version = '0.55.0' if targets else '0.54.0'
+        # FIXME: remove this check and the block below once <https://github.com/mesonbuild/meson/issues/6740> is merged.
+        # Update version if necessary
+        if targets:
+            raise ConanException('Targets are not supported by `meson compile` yet')
+
+        # minimum_version = '0.55.0' if targets else '0.54.0'
+        # if self._version >= minimum_version:
+        #     self._run_meson_command(subcommand='compile', args=targets + args)
+
+        minimum_version = '0.54.0'
         if self._version >= minimum_version:
-            combined_args = targets + args # order is important, since args might contain `-- -posix-like -positional-args`
-            self._run_meson_command(subcommand='compile', args=combined_args)
+            self._run_meson_command(subcommand='compile', args=args)
         else:
             self._validate_ninja_usage_and_warn_agnostic_method_unavailable(minimum_version)
             meson_target = next( (t for t in targets if ':' in t), None)

--- a/conans/client/build/mesonx.py
+++ b/conans/client/build/mesonx.py
@@ -506,7 +506,6 @@ class MesonX(object):
         options['libexecdir'] = DEFAULT_BIN
         options['includedir'] = DEFAULT_INCLUDE
 
-        # C++ standard
         cppstd = cppstd_from_settings(self._conanfile.settings)
         cppstd_conan2meson = {
             '98': 'c++03', 'gnu98': 'gnu++03',
@@ -518,12 +517,10 @@ class MesonX(object):
         if cppstd:
             options['cpp_std'] = cppstd_conan2meson[cppstd]
 
-        # shared
         shared = self._so('shared')
         if shared != None:
             options['default_library'] = shared
 
-        # fpic
         if self._os and 'Windows' not in self._os:
             fpic = self._so('fPIC')
             if fpic != None:

--- a/conans/client/build/mesonx.py
+++ b/conans/client/build/mesonx.py
@@ -17,7 +17,14 @@ from conans.util.runners import version_runner
 # TODO:
 # - add pkg_config_path to configure (cross scenario and native)
 # - fix env variables reading for native\cross
-# - add proper versions to meson checks
+# - cleanup comments
+
+# Difference from Meson:
+# - does not override 'default_library' if no 'shared' options was set
+# - saves `build_dir` in __init__
+# - cleaned up interface: removed old arguments, removed build_dir and etc
+# - added machine file support
+# - added machine file generation for `toolchain`
 
 class MesonMachineFile:
     def __init__(self,
@@ -25,11 +32,11 @@ class MesonMachineFile:
                  path = None,
                  config: ConfigParser = None):
         if not name:
-            raise ConanException("`name` is empty: machine file must have a unique name supplied")
+            raise ConanException('`name` is empty: machine file must have a unique name supplied')
         self.name = name
 
         if path and config:
-            raise ConanException("Both `path` and `config` were supplied: only one should be used")
+            raise ConanException('Both `path` and `config` were supplied: only one should be used')
         if path:
             config = ConfigParser()
             config.read(path)
@@ -74,7 +81,7 @@ class MesonDefaultToolchainGenerator(object):
             mt.native_files += [MesonMachineFile(name='default.ini', config=self._dict_to_config(self._create_native()))]
         if self._conanfile.settings_target:
             mt.cross_files += [MesonMachineFile(name='default.ini', config=self._dict_to_config(self._create_cross()))]
-        if not self._conanfile.settings_build and not self._conanfile.settings_target:
+        if not hasattr(self._conanfile, 'settings_build') and not hasattr(self._conanfile, 'settings_target'):
             tmp_mt = self._create_machine_files_from_settings(force_cross)
             mt.native_files += tmp_mt.native_files
             mt.cross_files += tmp_mt.cross_files
@@ -120,14 +127,15 @@ class MesonDefaultToolchainGenerator(object):
             }
         }
 
-        if atr_or_for_build('os'):
-            os = atr_or_for_build('os')
-            arch = atr_or_for_build('arch')
+        if atr_or_for_build(settings, 'os'):
+            os = atr_or_for_build(settings, 'os')
+            arch = atr_or_for_build(settings, 'arch')
+            cpu_family, endian = _get_cpu_family_and_endianness_from_arch(settings.arch)
             config_template['build_machine'] = {
-                'system': elf._get_system_from_os(os),
-                'cpu_family': self._get_cpu_family_from_arch(arch),
+                'system': self._get_system_from_os(os),
                 'cpu': arch,
-                'endian': self._get_endian_from_arch(arch),
+                'cpu_family': cpu_family,
+                'endian': endian,
             }
 
         return config_template
@@ -158,11 +166,13 @@ class MesonDefaultToolchainGenerator(object):
             },
             'host_machine': {
                 'system': elf._get_system_from_os(settings.os),
-                'cpu_family': self._get_cpu_family_from_arch(settings.arch),
-                'cpu': settings.arch,
-                'endian': self._get_endian_from_arch(settings.arch),
+                'cpu': settings.arch
             }
         }
+
+        cpu_family, endian =  _get_cpu_family_and_endianness_from_arch(settings.arch)
+        config_template['host_machine']['cpu_family'] = cpu_family
+        config_template['host_machine']['endian'] = endian
 
         if not config['binaries']['c'] and not config['binaries']['cpp']:
             raise ConanException(f'CC and CXX are undefined: C or C++ compiler must be defined when cross-building')
@@ -200,40 +210,51 @@ class MesonDefaultToolchainGenerator(object):
             return os
 
     @staticmethod
-    def _get_cpu_family_from_arch(arch: str) -> str:
+    def _get_cpu_family_and_endianness_from_arch(arch: str):
         """
         Converts from `conan/conans/client/conf/__init__.py` to `https://mesonbuild.com/Reference-tables.html#cpu-families`
         """
-        arch_to_cpu_family = {
-            'x86': 'x86',
-            'x86_64': 'x86_64',
-            'mips': 'mips',
-            'mips64': 'mips64',
-            'armv8': 'aarch64'
+        arch_to_cpu = {
+            'x86' : ('x86', 'little'),
+            'x86_64' : ('x86_64',  'little'),
+            'x86' : ('x86', 'little'),
+            'ppc32be' : ('ppc', 'big'),
+            'ppc32' : ('ppc', 'little'),
+            'ppc64le' : ('ppc64', 'little'),
+            'ppc64' : ('ppc64', 'big'),
+            'armv4' : ('arm', 'little'),
+            'armv4i' : ('arm', 'little'),
+            'armv5el' : ('arm', 'little'),
+            'armv5hf' : ('arm', 'little'),
+            'armv6' : ('arm', 'little'),
+            'armv7' : ('arm', 'little'),
+            'armv7hf' : ('arm', 'little'),
+            'armv7s' : ('arm', 'little'),
+            'armv7k' : ('arm', 'little'),
+            'armv8_32' : ('arm', 'little'),
+            'armv8' : ('aarch64', 'little'),
+            'armv8.3' : ('aarch64', 'little'),
+            'sparc' : ('sparc', 'big'),
+            'sparcv9' : ('sparc64', 'big'),
+            'mips' : ('mips', 'big'),
+            'mips64' : ('mips64', ,'big'),
+            'avr' : ('avr', 'little'),
+            's390' : ('s390', ,'big'),
+            's390x' : ('s390', 'big'),
+            'wasm' : ('wasm', 'little'),
         }
 
-        if (arch not in arch_to_cpu_family):
-            if (arch.startswith('arm')):
-                return 'arm'
-            else:
-                raise ConanException('Unknown arch: {}'.format(arch))
+        if (arch not in arch_to_cpu):
+            raise ConanException('Unknown arch: {}'.format(arch))
 
         return arch_to_cpu_family[arch]
-
-    @staticmethod
-    def _get_endian_from_arch(arch: str) -> str:
-        if (arch.endswith('el') or arch.endswith('le')):
-            return 'little'
-        if (arch.endswith('be')):
-            return 'big'
-        return 'little'
 
 class MesonX(object):
     def __init__(self, conanfile, build_dir=None, backend=None, append_vcvars=False):
         """
         :param conanfile: Conanfile instance
         :param backend: Generator name to use or none to autodetect.
-               Possible values: ninja,vs,vs2010,vs2015,vs2017,vs2019,xcode
+               Possible values: ninja, vs, vs2010, vs2015, vs2017, vs2019, xcode
         :param build_type: Overrides default build type comming from settings
         """
         self._conanfile = conanfile
@@ -242,88 +263,111 @@ class MesonX(object):
 
         self._build_dir = build_dir
 
-        self._os = self._ss("os")
-        self._compiler = self._ss("compiler")
-        self._compiler_version = self._ss("compiler.version")
-        self._build_type = self._ss("build_type")
+        self._os = self._ss('os')
+        self._compiler = self._ss('compiler')
+        self._compiler_version = self._ss('compiler.version')
+        self._build_type = self._ss('build_type')
 
         # Meson recommends to use ninja by default
-        self.backend = backend or "ninja"
+        self.backend = backend or 'ninja'
 
     @staticmethod
     def get_version():
         try:
-            out = version_runner(["meson", "--version"])
+            out = version_runner(['meson', '--version'])
             version_line = decode_text(out).split('\n', 1)[0]
             version_str = version_line.rsplit(' ', 1)[-1]
             return Version(version_str)
         except Exception as e:
-            raise ConanException("Error retrieving Meson version: '{}'".format(e))
+            raise ConanException('Error retrieving Meson version: `{}`'.format(e))
 
     @property
     def build_folder(self):
         return self.build_dir
 
     def get_default_toolchain(self, force_cross: boolean = False) -> MesonToolchain:
-        MesonDefaultToolchainGenerator(self._conanfile).generate(force_cross)
+        """
+        Should be used in the recipe's `toolchain()` method
+        """
+        return MesonDefaultToolchainGenerator(self._conanfile).generate(force_cross)
 
     def get_native_files(self):
         bdir = Path(self.build_dir)
         if not bdir.exists:
-            raise ConanException("Build directory does not exist: `{}`".format(self.build_dir))
+            raise ConanException('Build directory does not exist: `{}`'.format(self.build_dir))
         if not (bdir \ 'native').exists:
             return []
         return list((bdir \ 'native').glob('*'))
-        
+
     def get_cross_files(self):
         bdir = Path(self.build_dir)
         if not bdir.exists:
-            raise ConanException("Build directory does not exist: `{}`".format(self.build_dir))
+            raise ConanException('Build directory does not exist: `{}`'.format(self.build_dir))
         if not (bdir \ 'cross').exists:
             return []
         return list((bdir \ 'cross').glob('*'))
 
-    def configure(self, args=None, defs=None, build_type=None, pkg_config_paths=None, cache_build_folder=None, source_folder=None):
+    def configure(self, source_folder=None, cache_build_folder=None, build_type=None, pkg_config_paths=None, args=[], options=[], native_files=[], cross_files=[]):
         if not self._conanfile.should_configure:
             return
 
-        args = args or []
-        defs = defs or {}
-
-        options = self._get_default_options()
-        # overwrite default values with user's inputs
-        options.update(defs)
-
-        if build_type and build_type != self._settings.get_safe("build_type"):
-            self._conanfile.output.warn(
-                'Set build type "{}" is different than the settings build_type "{}"'.format(build_type, settings_build_type))
-        resolved_build_type = build_type or self._settings.get_safe("build_type")
-
         source_dir, self.build_dir = self._get_dirs(source_folder, build_folder, cache_build_folder)
-
-        if pkg_config_paths:
-            pc_paths = os.pathsep.join(get_abs_path(f, self._conanfile.install_folder)
-                                       for f in pkg_config_paths)
-        else:
-            pc_paths = self._conanfile.install_folder
-
         mkdir(self.build_dir)
 
+        resolved_options = self._get_default_options()
+        # overwrite default values with user's inputs
+        resolved_options.update(options)
+        resolved_options.update({'backend': '{}'.format(self.backend)})
+
+        if build_type and build_type != self._settings.get_safe('build_type'):
+            self._conanfile.output.warn(
+                'Set build type "{}" is different than the settings build_type "{}"'.format(build_type, settings_build_type))
+        resolved_build_type = build_type or self._settings.get_safe('build_type')
+        if resolved_build_type:
+            resolved_options.update({'buildtype': '{}'.format(resolved_build_type)})
+
+        if native_files:
+            args += ['--native-file={}'.format(f) for f in native_files]
+        if cross_files:
+            args += ['--cross-file={}'.format(f) for f in cross_files]
+
+        pc_paths = []
+        if 'pkg_config' in self._conanfile.generators:
+            # Add install folder to search paths only if there is a corresponding generator
+            pc_paths += [self._conanfile.install_folder]
+        if pkg_config_paths:
+            pc_paths += [get_abs_path(f, self._conanfile.install_folder) for f in pkg_config_paths]
+
         arg_list = join_arguments([
-            "--backend={}".format(self.backend),
-            "--buildtype={}".format(resolved_build_type) if resolved_build_type else None,
-            defs_to_string(options),
+            defs_to_string(resolved_options),
             args_to_string(args),
         ])
         command = 'meson setup "{}" "{}" {}'.format(source_dir, self.build_dir, arg_list)
-        with environment_append({"PKG_CONFIG_PATH": pc_paths}):
+
+        env_vars_to_clean = {
+            'CC',
+            'CXX',
+            'CCFLAGS',
+            'CXXFLAGS',
+            'CPPFLAGS',
+            'LDFLAGS',
+            'AR',
+            'AS',
+            'STRIP',
+            'RANLIB',
+        }
+        env_dict = {ev: None for ev in env_vars_to_clean}
+        env_dict.update({'{}_FOR_BUILD'.format(ev): None for ev in env_vars_to_clean})
+        env_dict.update({'PKG_CONFIG_PATH': os.pathsep.join(pc_paths)})
+
+        with environment_append(env_dict):
             self._run(command)
 
     def build(self, args=None, targets=None):
         if not self._conanfile.should_build:
             return
 
-        minimum_meson_version = '0.60.0' if targets else '0.50.0'
+        minimum_meson_version = '0.55.0' if targets else '0.54.0'
         if self._can_use_meson_method(minimum_meson_version):
             combined_args = (args or []) + (targets or [])
             self._run_meson_command(subcommand='compile', args=combined_args)
@@ -336,7 +380,7 @@ class MesonX(object):
         if not self._conanfile.should_install:
             return
 
-        if self._can_use_meson_method('0.50.0'):
+        if self._can_use_meson_method('0.47.0'):
             self._run_meson_command(subcommand='install', args=args)
         else:
             if self.backend != 'ninja':
@@ -347,7 +391,7 @@ class MesonX(object):
         if not self._conanfile.should_test:
             return
 
-        if self._can_use_meson_method('0.50.0'):
+        if self._can_use_meson_method('0.42.0'):
             self._run_meson_command(subcommand='test', args=args)
         else:
             if self.backend != 'ninja':
@@ -365,11 +409,10 @@ class MesonX(object):
     @staticmethod
     def _can_use_meson_method(minimum_version: str):
         return self.get_version() >= minimum_version
-        
-        
+
     @staticmethod
     def _raise_not_supported_with_meson_and_ninja(minimum_version: str):
-        raise ConanException("This method is not implemented yet for `{}` backend. Change your backend to `ninja` or update your `meson`. Minimum required `meson` version is {}".format(self.backend, minimum_version))
+        raise ConanException('This method is not implemented yet for `{}` backend. Change your backend to `ninja` or update your `meson`. Minimum required `meson` version is {}'.format(self.backend, minimum_version))
 
     def _get_dirs(self, source_folder, build_folder, cache_build_folder):
         build_ret = get_abs_path(build_folder, self._conanfile.build_folder)
@@ -403,33 +446,33 @@ class MesonX(object):
             options['cpp_std'] = cppstd_conan2meson[cppstd]
 
         # shared
-        shared = self._so("shared")
+        shared = self._so('shared')
         if shared != None:
             options['default_library'] = shared
 
         # fpic
-        if self._os and "Windows" not in self._os:
-            fpic = self._so("fPIC")
+        if self._os and 'Windows' not in self._os:
+            fpic = self._so('fPIC')
             if fpic != None:
-                shared = self._so("shared")
+                shared = self._so('shared')
                 options['b_staticpic'] = fpic or shared
 
         return options
 
     @staticmethod
     def _get_meson_buildtype(build_type):
-        build_types = {"RelWithDebInfo": "debugoptimized",
-                       "MinSizeRel": "release",
-                       "Debug": "debug",
-                       "Release": "release"}
+        build_types = {'RelWithDebInfo': 'debugoptimized',
+                       'MinSizeRel': 'release',
+                       'Debug': 'debug',
+                       'Release': 'release'}
         if build_type not in build_types:
-            raise ConanException("Unknown build type: {}".format(build_type))
+            raise ConanException('Unknown build type: {}'.format(build_type))
         return build_types[build_type]
 
     @property
     def _vcvars_needed(self):
-        return (self._compiler == "Visual Studio" and self.backend == "ninja" and
-                platform.system() == "Windows")
+        return (self._compiler == 'Visual Studio' and self.backend == 'ninja' and
+                platform.system() == 'Windows')
 
     def _run(self, command):
         if self._vcvars_needed:
@@ -439,11 +482,10 @@ class MesonX(object):
         else:
             self._conanfile.run(command)
 
-    def _run_ninja_targets(self, args=None, targets=None):
-        if self.backend != "ninja":
-            raise ConanException("Internal error: this command should not be invoked non-'ninja' backend")
+    def _run_ninja_targets(self, args=[], targets=None):
+        if self.backend != 'ninja':
+            raise ConanException('Internal error: this command should not be invoked non-`ninja` backend')
 
-        args = args or []
         build_dir = self.build_dir or self._conanfile.build_folder
 
         arg_list = join_arguments([
@@ -451,10 +493,9 @@ class MesonX(object):
             args_to_string(args),
             args_to_string(targets)
         ])
-        self._run("ninja {}".format(arg_list))
+        self._run('ninja {}'.format(arg_list))
 
-    def _run_meson_command(self, subcommand=None, args=None):
-        args = args or []
+    def _run_meson_command(self, subcommand=None, args=[]):
         build_dir = self.build_dir or self._conanfile.build_folder
 
         arg_list = join_arguments([
@@ -462,4 +503,4 @@ class MesonX(object):
             '-C "()"'.format(build_dir),
             args_to_string(args)
         ])
-        self._run("meson {}".format(arg_list))
+        self._run('meson {}'.format(arg_list))

--- a/conans/client/build/mesonx.py
+++ b/conans/client/build/mesonx.py
@@ -159,18 +159,9 @@ class MesonX(object):
         args = args or []
         targets = targets or []
 
-        # FIXME: remove this check and the block below once <https://github.com/mesonbuild/meson/issues/6740> is merged.
-        # Update version if necessary
-        if targets:
-            raise ConanException('Targets are not supported by `meson compile` yet')
-
-        # minimum_version = '0.55.0' if targets else '0.54.0'
-        # if self._version >= minimum_version:
-        #     self._run_meson_command(subcommand='compile', args=targets + args)
-
-        minimum_version = '0.54.0'
+        minimum_version = '0.55.0' if targets else '0.54.0'
         if self._version >= minimum_version:
-            self._run_meson_command(subcommand='compile', args=args)
+            self._run_meson_command(subcommand='compile', args=args + targets)
         else:
             self._validate_ninja_usage_and_warn_agnostic_method_unavailable(minimum_version)
             meson_target = next( (t for t in targets if ':' in t), None)
@@ -178,7 +169,7 @@ class MesonX(object):
                 raise ConanException('Your targets contain meson syntax which is not supported by ninja: `{}`'.format(meson_target))
             self._run_ninja_targets(targets=targets,
                                     args=self._filter_non_ninja_args(args=args,
-                                                                     ninja_args=['-j*', '-l*']))
+                                                                     ninja_args=['-j*', '-l*', '--verbose']))
 
     def install(self, args=None):
         if not self._conanfile.should_install:
@@ -257,7 +248,7 @@ class MesonX(object):
 
         build_dir = self._conanfile.build_folder
         if self._build_subdir:
-            build_dir = str(Path(self._conanfile.build_folder) / _build_subdir)
+            build_dir = str(Path(self._conanfile.build_folder) / self._build_subdir)
         return (source_dir, build_dir)
 
     def _get_default_options(self):

--- a/conans/client/build/mesonx.py
+++ b/conans/client/build/mesonx.py
@@ -1,0 +1,465 @@
+import os
+import platform
+from pathlib import Path
+from configparser import ConfigParser
+
+from conans.client import tools
+from conans.client.build import defs_to_string, join_arguments
+from conans.client.build.cppstd_flags import cppstd_from_settings
+from conans.client.tools.env import environment_append, _environment_add
+from conans.client.tools.oss import args_to_string
+from conans.errors import ConanException
+from conans.model.build_info import DEFAULT_BIN, DEFAULT_INCLUDE, DEFAULT_LIB
+from conans.model.version import Version
+from conans.util.files import decode_text, get_abs_path, mkdir
+from conans.util.runners import version_runner
+
+# TODO:
+# - add pkg_config_path to configure (cross scenario and native)
+# - fix env variables reading for native\cross
+# - add proper versions to meson checks
+
+class MesonMachineFile:
+    def __init__(self,
+                 name,
+                 path = None,
+                 config: ConfigParser = None):
+        if not name:
+            raise ConanException("`name` is empty: machine file must have a unique name supplied")
+        self.name = name
+
+        if path and config:
+            raise ConanException("Both `path` and `config` were supplied: only one should be used")
+        if path:
+            config = ConfigParser()
+            config.read(path)
+        options = config
+
+    def dump(self, output: str):
+        outpath = Path(output)
+        if not outpath.exists:
+            outpath.mkdir(parents=True)
+        with open(outpath/self.name, 'w') as f:
+            options.write(f)
+
+class MesonToolchain:
+    native_files = [] # Type: List[MesonMachineFile]
+    cross_files = [] # Type: List[MesonMachineFile]
+
+    def __init__(self, native_files = [], cross_files = []):
+        self.native_files = native_files
+        self.cross_files = cross_files
+
+    def dump(self, output: str):
+      if (native_files):
+        outpath = Path(output) \ 'native'
+        if not outpath.exists:
+            outpath.mkdir(parents=True)
+        for f in native_files:
+          f.dump(outpath)
+      if (cross_files):
+        outpath = Path(output) \ 'cross'
+        if not outpath.exists:
+            outpath.mkdir(parents=True)
+        for f in cross_files:
+          f.dump(outpath)
+
+class MesonDefaultToolchainGenerator(object):
+    def __init__(self, conanfile):
+        self._conanfile = conanfile
+
+    def generate(self, force_cross = False) -> MesonToolchain:
+        mt = MesonToolchain()
+        if self._conanfile.settings_build:
+            mt.native_files += [MesonMachineFile(name='default.ini', config=self._dict_to_config(self._create_native()))]
+        if self._conanfile.settings_target:
+            mt.cross_files += [MesonMachineFile(name='default.ini', config=self._dict_to_config(self._create_cross()))]
+        if not self._conanfile.settings_build and not self._conanfile.settings_target:
+            tmp_mt = self._create_machine_files_from_settings(force_cross)
+            mt.native_files += tmp_mt.native_files
+            mt.cross_files += tmp_mt.cross_files
+        return mt
+
+    @staticmethod
+    def _dict_to_config(machine_dict: dict) -> ConfigParser:
+        return ConfigParser().read_dict(self._filter_none(machine_dict))
+
+    @staticmethod
+    def _filter_undefined(config):
+        return {section_name: {key: value for key, value in section.items() if value is not None}
+                for section_name, section in config.items()}
+
+    @staticmethod
+    def _create_native(settings) -> dict:
+        def none_if_empty(input: str):
+            return input if input.strip() else None
+        def env_or_for_build(input: str):
+            return os.environ.get('{}_FOR_BUILD'.format(input)) or os.environ.get(input)
+        def atr_or_for_build(settings, input: str):
+            for_build_attr = '{}_build'.format(input)
+            return settings.get_safe(for_build_attr) or settings.get_safe(input)
+
+        # `_FOR_BUILD` logic is mirroring built-in meson environment variables handling logic
+        config_template = {
+            'binaries': {
+                'c': env_or_for_build('CC'),
+                'cpp': env_or_for_build('CXX'),
+                'c_ld': env_or_for_build('LD'),
+                'cpp_ld': env_or_for_build'LD'),
+                'ar': env_or_for_build('AR'),
+                'strip': env_or_for_build('STRIP'),
+                'as': env_or_for_build('AS'),
+                'ranlib': env_or_for_build('RANLIB'),
+                'pkgconfig': tools.which('pkg-config')
+            },
+            'properties': {
+                'c_args': none_if_empty(env_or_for_build('CPPFLAGS', '') + ' ' + env_or_for_build('CFLAGS', '')),
+                'cpp_args': none_if_empty(env_or_for_build('CPPFLAGS', '') + ' ' + env_or_for_build('CXXFLAGS', '')),
+                'c_link_args': env_or_for_build('LDFLAGS'),
+                'cpp_link_args': env_or_for_build('LDFLAGS'),
+            }
+        }
+
+        if atr_or_for_build('os'):
+            os = atr_or_for_build('os')
+            arch = atr_or_for_build('arch')
+            config_template['build_machine'] = {
+                'system': elf._get_system_from_os(os),
+                'cpu_family': self._get_cpu_family_from_arch(arch),
+                'cpu': arch,
+                'endian': self._get_endian_from_arch(arch),
+            }
+
+        return config_template
+
+    @staticmethod
+    def _create_cross(settings, build_folder) -> dict:
+        def none_if_empty(str):
+            return str if str.strip() else None
+
+        config_template = {
+            'binaries': {
+                'c': os.environ.get('CC'),
+                'cpp': os.environ.get('CXX'),
+                'c_ld': os.environ.get('LD'),
+                'cpp_ld': os.environ.get('LD'),
+                'ar': os.environ.get('AR'),
+                'strip': os.environ.get('STRIP'),
+                'as': os.environ.get('AS'),
+                'ranlib': os.environ.get('RANLIB'),
+                'pkgconfig': tools.which('pkg-config')
+            },
+            'properties': {
+                'c_args': none_if_empty(os.environ.get('CPPFLAGS', '') + ' ' + os.environ.get('CFLAGS', '')),
+                'cpp_args': none_if_empty(os.environ.get('CPPFLAGS', '') + ' ' + os.environ.get('CXXFLAGS', '')),
+                'c_link_args': os.environ.get('LDFLAGS'),
+                'cpp_link_args': os.environ.get('LDFLAGS'),
+                'needs_exe_wrapper': tools.cross_building(settings),
+            },
+            'host_machine': {
+                'system': elf._get_system_from_os(settings.os),
+                'cpu_family': self._get_cpu_family_from_arch(settings.arch),
+                'cpu': settings.arch,
+                'endian': self._get_endian_from_arch(settings.arch),
+            }
+        }
+
+        if not config['binaries']['c'] and not config['binaries']['cpp']:
+            raise ConanException(f'CC and CXX are undefined: C or C++ compiler must be defined when cross-building')
+
+        return config_template
+
+    @staticmethod
+    def _create_machine_files_from_settings(settings, force_cross: boolean) -> MesonToolchain:
+        is_cross = force_cross
+        has_for_build = False
+
+        if not is_cross:
+            has_for_build = any(map(lambda e: os.environ.get(e), ['CC_FOR_BUILD', 'CXX_FOR_BUILD'])
+            is_cross = has_for_build or any(map(lambda a: has_attr(settings, a), ['os_build', 'arch_build']))
+
+        native_files = []
+        if has_for_build or not is_cross:
+            native_files += [MesonMachineFile(name='default.ini', config=self._create_native(settings))]
+
+        cross_files = []
+        if is_cross:
+            cross_files += [MesonMachineFile(name='default.ini', config=self._create_cross(settings))]
+
+        return MesonToolchain(native_files=native_files, cross_files=cross_files)
+
+    @staticmethod
+    def _get_system_from_os(os: str) -> str:
+        """
+        Converts from `conan/conans/client/conf/__init__.py` to `https://mesonbuild.com/Reference-tables.html#operating-system-names`
+        """
+        os = os.lower()
+        if (os == 'macos' or os == 'ios'):
+            return 'darwin'
+        else:
+            return os
+
+    @staticmethod
+    def _get_cpu_family_from_arch(arch: str) -> str:
+        """
+        Converts from `conan/conans/client/conf/__init__.py` to `https://mesonbuild.com/Reference-tables.html#cpu-families`
+        """
+        arch_to_cpu_family = {
+            'x86': 'x86',
+            'x86_64': 'x86_64',
+            'mips': 'mips',
+            'mips64': 'mips64',
+            'armv8': 'aarch64'
+        }
+
+        if (arch not in arch_to_cpu_family):
+            if (arch.startswith('arm')):
+                return 'arm'
+            else:
+                raise ConanException('Unknown arch: {}'.format(arch))
+
+        return arch_to_cpu_family[arch]
+
+    @staticmethod
+    def _get_endian_from_arch(arch: str) -> str:
+        if (arch.endswith('el') or arch.endswith('le')):
+            return 'little'
+        if (arch.endswith('be')):
+            return 'big'
+        return 'little'
+
+class MesonX(object):
+    def __init__(self, conanfile, build_dir=None, backend=None, append_vcvars=False):
+        """
+        :param conanfile: Conanfile instance
+        :param backend: Generator name to use or none to autodetect.
+               Possible values: ninja,vs,vs2010,vs2015,vs2017,vs2019,xcode
+        :param build_type: Overrides default build type comming from settings
+        """
+        self._conanfile = conanfile
+        self._settings = conanfile.settings
+        self._append_vcvars = append_vcvars
+
+        self._build_dir = build_dir
+
+        self._os = self._ss("os")
+        self._compiler = self._ss("compiler")
+        self._compiler_version = self._ss("compiler.version")
+        self._build_type = self._ss("build_type")
+
+        # Meson recommends to use ninja by default
+        self.backend = backend or "ninja"
+
+    @staticmethod
+    def get_version():
+        try:
+            out = version_runner(["meson", "--version"])
+            version_line = decode_text(out).split('\n', 1)[0]
+            version_str = version_line.rsplit(' ', 1)[-1]
+            return Version(version_str)
+        except Exception as e:
+            raise ConanException("Error retrieving Meson version: '{}'".format(e))
+
+    @property
+    def build_folder(self):
+        return self.build_dir
+
+    def get_default_toolchain(self, force_cross: boolean = False) -> MesonToolchain:
+        MesonDefaultToolchainGenerator(self._conanfile).generate(force_cross)
+
+    def get_native_files(self):
+        bdir = Path(self.build_dir)
+        if not bdir.exists:
+            raise ConanException("Build directory does not exist: `{}`".format(self.build_dir))
+        if not (bdir \ 'native').exists:
+            return []
+        return list((bdir \ 'native').glob('*'))
+        
+    def get_cross_files(self):
+        bdir = Path(self.build_dir)
+        if not bdir.exists:
+            raise ConanException("Build directory does not exist: `{}`".format(self.build_dir))
+        if not (bdir \ 'cross').exists:
+            return []
+        return list((bdir \ 'cross').glob('*'))
+
+    def configure(self, args=None, defs=None, build_type=None, pkg_config_paths=None, cache_build_folder=None, source_folder=None):
+        if not self._conanfile.should_configure:
+            return
+
+        args = args or []
+        defs = defs or {}
+
+        options = self._get_default_options()
+        # overwrite default values with user's inputs
+        options.update(defs)
+
+        if build_type and build_type != self._settings.get_safe("build_type"):
+            self._conanfile.output.warn(
+                'Set build type "{}" is different than the settings build_type "{}"'.format(build_type, settings_build_type))
+        resolved_build_type = build_type or self._settings.get_safe("build_type")
+
+        source_dir, self.build_dir = self._get_dirs(source_folder, build_folder, cache_build_folder)
+
+        if pkg_config_paths:
+            pc_paths = os.pathsep.join(get_abs_path(f, self._conanfile.install_folder)
+                                       for f in pkg_config_paths)
+        else:
+            pc_paths = self._conanfile.install_folder
+
+        mkdir(self.build_dir)
+
+        arg_list = join_arguments([
+            "--backend={}".format(self.backend),
+            "--buildtype={}".format(resolved_build_type) if resolved_build_type else None,
+            defs_to_string(options),
+            args_to_string(args),
+        ])
+        command = 'meson setup "{}" "{}" {}'.format(source_dir, self.build_dir, arg_list)
+        with environment_append({"PKG_CONFIG_PATH": pc_paths}):
+            self._run(command)
+
+    def build(self, args=None, targets=None):
+        if not self._conanfile.should_build:
+            return
+
+        minimum_meson_version = '0.60.0' if targets else '0.50.0'
+        if self._can_use_meson_method(minimum_meson_version):
+            combined_args = (args or []) + (targets or [])
+            self._run_meson_command(subcommand='compile', args=combined_args)
+        else:
+            if self.backend != 'ninja':
+                self._raise_not_supported_with_meson_and_ninja(minimum_meson_version)
+            self._run_ninja_targets(targets=targets, args=args)
+
+    def install(self, args=None):
+        if not self._conanfile.should_install:
+            return
+
+        if self._can_use_meson_method('0.50.0'):
+            self._run_meson_command(subcommand='install', args=args)
+        else:
+            if self.backend != 'ninja':
+                self._raise_not_supported_with_meson_and_ninja(minimum_meson_version)
+            self._run_ninja_targets(targets=['install'], args=args)
+
+    def test(self, args=None):
+        if not self._conanfile.should_test:
+            return
+
+        if self._can_use_meson_method('0.50.0'):
+            self._run_meson_command(subcommand='test', args=args)
+        else:
+            if self.backend != 'ninja':
+                self._raise_not_supported_with_meson_and_ninja(minimum_meson_version)
+            self._run_ninja_targets(targets=['test'], args=args)
+
+    def _ss(self, setname):
+        """safe setting"""
+        return self._conanfile.settings.get_safe(setname)
+
+    def _so(self, setname):
+        """safe option"""
+        return self._conanfile.options.get_safe(setname)
+
+    @staticmethod
+    def _can_use_meson_method(minimum_version: str):
+        return self.get_version() >= minimum_version
+        
+        
+    @staticmethod
+    def _raise_not_supported_with_meson_and_ninja(minimum_version: str):
+        raise ConanException("This method is not implemented yet for `{}` backend. Change your backend to `ninja` or update your `meson`. Minimum required `meson` version is {}".format(self.backend, minimum_version))
+
+    def _get_dirs(self, source_folder, build_folder, cache_build_folder):
+        build_ret = get_abs_path(build_folder, self._conanfile.build_folder)
+        source_ret = get_abs_path(source_folder, self._conanfile.source_folder)
+
+        if self._conanfile.in_local_cache and cache_build_folder:
+            build_ret = get_abs_path(cache_build_folder, self._conanfile.build_folder)
+
+        return source_ret, build_ret
+
+    def _get_default_options(self) -> dict:
+        options = dict()
+        if self._conanfile.package_folder:
+            options['prefix'] = self._conanfile.package_folder
+        options['libdir'] = DEFAULT_LIB
+        options['bindir'] = DEFAULT_BIN
+        options['sbindir'] = DEFAULT_BIN
+        options['libexecdir'] = DEFAULT_BIN
+        options['includedir'] = DEFAULT_INCLUDE
+
+        # C++ standard
+        cppstd = cppstd_from_settings(self._conanfile.settings)
+        cppstd_conan2meson = {
+            '98': 'c++03', 'gnu98': 'gnu++03',
+            '11': 'c++11', 'gnu11': 'gnu++11',
+            '14': 'c++14', 'gnu14': 'gnu++14',
+            '17': 'c++17', 'gnu17': 'gnu++17',
+            '20': 'c++1z', 'gnu20': 'gnu++1z'
+        }
+        if cppstd:
+            options['cpp_std'] = cppstd_conan2meson[cppstd]
+
+        # shared
+        shared = self._so("shared")
+        if shared != None:
+            options['default_library'] = shared
+
+        # fpic
+        if self._os and "Windows" not in self._os:
+            fpic = self._so("fPIC")
+            if fpic != None:
+                shared = self._so("shared")
+                options['b_staticpic'] = fpic or shared
+
+        return options
+
+    @staticmethod
+    def _get_meson_buildtype(build_type):
+        build_types = {"RelWithDebInfo": "debugoptimized",
+                       "MinSizeRel": "release",
+                       "Debug": "debug",
+                       "Release": "release"}
+        if build_type not in build_types:
+            raise ConanException("Unknown build type: {}".format(build_type))
+        return build_types[build_type]
+
+    @property
+    def _vcvars_needed(self):
+        return (self._compiler == "Visual Studio" and self.backend == "ninja" and
+                platform.system() == "Windows")
+
+    def _run(self, command):
+        if self._vcvars_needed:
+            vcvars_dict = tools.vcvars_dict(self._settings, output=self._conanfile.output)
+            with _environment_add(vcvars_dict, post=self._append_vcvars):
+                self._conanfile.run(command)
+        else:
+            self._conanfile.run(command)
+
+    def _run_ninja_targets(self, args=None, targets=None):
+        if self.backend != "ninja":
+            raise ConanException("Internal error: this command should not be invoked non-'ninja' backend")
+
+        args = args or []
+        build_dir = self.build_dir or self._conanfile.build_folder
+
+        arg_list = join_arguments([
+            '-C "{}"'.format(build_dir),
+            args_to_string(args),
+            args_to_string(targets)
+        ])
+        self._run("ninja {}".format(arg_list))
+
+    def _run_meson_command(self, subcommand=None, args=None):
+        args = args or []
+        build_dir = self.build_dir or self._conanfile.build_folder
+
+        arg_list = join_arguments([
+            subcommand,
+            '-C "()"'.format(build_dir),
+            args_to_string(args)
+        ])
+        self._run("meson {}".format(arg_list))

--- a/conans/client/build/mesonx.py
+++ b/conans/client/build/mesonx.py
@@ -326,6 +326,9 @@ class MesonX(object):
         # Needed for internal checks
         self._compiler = self._ss('compiler')
 
+        # Cache version value for future use
+        self._version = self.get_version()
+
         # Meson recommends to use ninja by default
         self.backend = backend or 'ninja'
 
@@ -432,7 +435,7 @@ class MesonX(object):
         targets = targets or []
 
         minimum_version = '0.55.0' if targets else '0.54.0'
-        if self.get_version() >= minimum_version:
+        if self._version >= minimum_version:
             combined_args = targets + args # order is important, since args might contain `-- -posix-like -positional-args`
             self._run_meson_command(subcommand='compile', args=combined_args)
         else:
@@ -451,7 +454,7 @@ class MesonX(object):
         args = args or []
 
         minimum_version = '0.47.0'
-        if self.get_version() >= minimum_version:
+        if self._version >= minimum_version:
             self._run_meson_command(subcommand='install', args=args)
         else:
             self._validate_ninja_usage_and_warn_agnostic_method_unavailable(minimum_version)
@@ -468,7 +471,7 @@ class MesonX(object):
 
     def is_configured(self):
         _, build_dir = self._get_resolve_dirs()
-        if self.get_version() >= '0.50.0':
+        if self._version >= '0.50.0':
             return (Path(build_dir) / 'meson-info' / 'meson-info.json').exists()
         else:
             return (Path(build_dir) / 'meson-private' / 'coredata.dat').exists()

--- a/conans/client/build/mesonx.py
+++ b/conans/client/build/mesonx.py
@@ -264,11 +264,6 @@ class MesonX(object):
         options = dict()
         if self._conanfile.package_folder:
             options['prefix'] = self._conanfile.package_folder
-        options['libdir'] = DEFAULT_LIB
-        options['bindir'] = DEFAULT_BIN
-        options['sbindir'] = DEFAULT_BIN
-        options['libexecdir'] = DEFAULT_BIN
-        options['includedir'] = DEFAULT_INCLUDE
 
         cppstd = cppstd_from_settings(self._conanfile.settings)
         if cppstd != None:
@@ -283,7 +278,7 @@ class MesonX(object):
             self._conanfile.output.warn("Toolchain: Ignoring fPIC option defined for Windows")
         else:
             fpic = self._so('fPIC')
-            if fpic != None:
+            if fpic is not None:
                 shared = self._so('shared')
                 options['b_staticpic'] = fpic or shared
 

--- a/conans/client/build/mesonx.py
+++ b/conans/client/build/mesonx.py
@@ -1,12 +1,12 @@
 import os
 import platform
-import typing as T
 from configparser import ConfigParser
 from pathlib import Path
 
 from conans.client import tools
 from conans.client.build import defs_to_string, join_arguments
 from conans.client.build.cppstd_flags import cppstd_from_settings
+from conans.client.toolchain.meson import MesonMachineFile, MesonToolchain, MesonDefaultToolchain
 from conans.client.tools.env import environment_append, _environment_add, no_op
 from conans.client.tools.oss import args_to_string
 from conans.errors import ConanException
@@ -17,7 +17,7 @@ from conans.util.runners import version_runner
 
 # Differences from stock Meson integration:
 # - does not override 'default_library' if no 'shared' options was set
-# - saves `build_dir` in __init__
+# - saves `build_subdir` in __init__
 # - cleaned up interface: removed old arguments, removed build_dir and etc
 # - added machine file support
 # - added machine file generation for `toolchain`
@@ -41,276 +41,7 @@ from conans.util.runners import version_runner
 # - Should we generate machine files in dump() or in __init__()?
 # - Move `MesonDefaultToolchainGenerator` to `MesonDefaultToolchain`?
 
-class MesonMachineFile():
-    """
-    A wrapper for meson machine files for the use in `MesonToolchain`.
-    Note: Meson requires that all ini values are quoted. E.g. `name = 'value'`
-    """
-    def __init__(self,
-                 name: str,
-                 path: str = None,
-                 config: ConfigParser = None):
-        if not name:
-            raise ConanException('`name` is empty: machine file must have a unique name supplied')
-        self.name = name
-
-        if path and config:
-            raise ConanException('Both `path` and `config` were supplied: only one should be used')
-        if path:
-            config = ConfigParser()
-            config.read(path)
-        self.options = config
-
-    def dump(self, install_dir: str):
-        outpath = Path(install_dir)
-        if not outpath.exists():
-            outpath.mkdir(parents=True)
-        with open(outpath/self.name, 'w') as f:
-            self.options.write(f)
-
-class MesonToolchain(object):
-    """
-    A wrapper for `MesonMachineFile` for the use in `ConanFile.toolchain()`.
-    Uses only supplied machine files and does *not* generate any files by itself.
-    """
-    native_file_subdir = 'native'
-    cross_file_subdir = 'native'
-
-    def __init__(self, native_files = None, cross_files = None ):
-        self.native_files = native_files or []
-        self.cross_files = cross_files or []
-
-    def __iter__(self):
-        for i in [self.native_files, self.cross_files]:
-            yield i
-
-    def dump(self, install_dir: str):
-        def dump_files(files, outpath: str):
-            if not files:
-                pass
-            if not outpath.exists():
-                outpath.mkdir(parents=True)
-            for f in self.native_files:
-                f.dump(outpath)
-
-        dump_files(self.native_files, Path(install_dir) / self.native_file_subdir)
-        dump_files(self.cross_files, Path(install_dir) / self.cross_file_subdir)
-
-class MesonDefaultToolchain(MesonToolchain):
-    """
-    A wrapper for `MesonMachineFile` for the use in `ConanFile.toolchain()`.
-    Generates default machine files.
-    """
-    def __init__(self, conanfile, force_cross=False):
-        mt_gen = MesonDefaultToolchainGenerator(conanfile)
-        native_files, cross_files = mt_gen.generate(force_cross)
-        super(MesonDefaultToolchain, self).__init__(native_files, cross_files)
-
-class MesonDefaultToolchainGenerator(object):
-    """
-    Generates machine files from conan profiles
-    """
-    def __init__(self, conanfile):
-        self._conanfile = conanfile
-
-    def generate(self, force_cross: bool = False) -> MesonToolchain:
-        mt = MesonToolchain()
-        has_settings_build = hasattr(self._conanfile, 'settings_build') and self._conanfile.settings_build
-        has_settings_target = hasattr(self._conanfile, 'settings_target') and self._conanfile.settings_target
-        if has_settings_build:
-            mt.native_files += [MesonMachineFile(name='default.ini', config=self._dict_to_config(self._create_native(self._conanfile.settings_build, True)))]
-        if has_settings_target:
-            mt.cross_files += [MesonMachineFile(name='default.ini', config=self._dict_to_config(self._create_cross(self._conanfile.settings_target)))]
-        if not has_settings_build and not has_settings_target:
-            tmp_native_files, tmp_cross_files = self._create_machine_files_from_settings(self._conanfile.settings, force_cross)
-            mt.native_files += tmp_native_files
-            mt.cross_files += tmp_cross_files
-        return mt
-
-    def _dict_to_config(self, machine_dict: dict) -> ConfigParser:
-        config = ConfigParser()
-        config.read_dict(self._to_ini(machine_dict))
-        return config
-
-    def _to_ini(self, config):
-        """
-        Fixes `config` to be compatible with meson machine file format.
-        """
-        return {
-            section_name: {
-                key: self._to_ini_value(value) for key, value in section.items() if value is not None
-            } for section_name, section in config.items()
-        }
-
-    def _to_ini_value(self, value):
-        """
-        Fixes value to be compatible with meson machine file format:
-        meson requires all values to be quoted. E.g. `name = 'value'`.
-        """
-        if isinstance(value, bool):
-            return str(value).lower()
-        if isinstance(value, str):
-            return "'{}'".format(value)
-        return value
-
-    def _create_native(self, settings, is_separate_profile: bool) -> dict:
-        # FIXME: Rewrite this once <https://github.com/conan-io/conan/issues/7091> is fixed
-        def none_if_empty(input: str):
-            stripped_input = input.strip()
-            return stripped_input if stripped_input else None
-        def env_or_for_build(input: str, is_separate_profile, default_val = None):
-            if is_separate_profile:
-                return os.environ.get(input, default_val)
-            else:
-                return os.environ.get('{}_FOR_BUILD'.format(input), default_val)
-        def atr_or_for_build(settings, input: str, is_separate_profile):
-            if is_separate_profile:
-                return settings.get_safe(input)
-            else:
-                return settings.get_safe('{}_build'.format(input))
-
-        config_template = {
-            'binaries': {
-                'c': env_or_for_build('CC', is_separate_profile),
-                'cpp': env_or_for_build('CXX', is_separate_profile),
-                'ld': env_or_for_build('LD', is_separate_profile),
-                'ar': env_or_for_build('AR', is_separate_profile),
-                'strip': env_or_for_build('STRIP', is_separate_profile),
-                'as': env_or_for_build('AS', is_separate_profile),
-                'ranlib': env_or_for_build('RANLIB', is_separate_profile),
-                'pkgconfig': tools.which('pkg-config') # FIXME: See below
-            },
-            'properties': {
-                'c_args': none_if_empty(env_or_for_build('CPPFLAGS', is_separate_profile, '') + ' ' + env_or_for_build('CFLAGS', is_separate_profile, '')),
-                'cpp_args': none_if_empty(env_or_for_build('CPPFLAGS', is_separate_profile, '') + ' ' + env_or_for_build('CXXFLAGS', is_separate_profile, '')),
-                'c_link_args': env_or_for_build('LDFLAGS', is_separate_profile),
-                'cpp_link_args': env_or_for_build('LDFLAGS', is_separate_profile),
-                'pkg_config_path': env_or_for_build('PKG_CONFIG_PATH', is_separate_profile),
-            }
-        }
-
-        if atr_or_for_build(settings, 'os', is_separate_profile):
-            resolved_os = atr_or_for_build(settings, 'os', is_separate_profile)
-            arch = atr_or_for_build(settings, 'arch', is_separate_profile)
-            cpu_family, endian = self._get_cpu_family_and_endianness_from_arch(str(arch))
-            config_template['build_machine'] = {
-                'system': self._get_system_from_os(str(resolved_os)),
-                'cpu': str(arch),
-                'cpu_family': cpu_family,
-                'endian': endian,
-            }
-
-        return config_template
-
-    def _create_cross(self, settings) -> dict:
-        def none_if_empty(input: str):
-            stripped_input = input.strip()
-            return stripped_input if stripped_input else None
-
-        config_template = {
-            'binaries': {
-                'c': os.environ.get('CC'),
-                'cpp': os.environ.get('CXX'),
-                'ld': os.environ.get('LD'),
-                'ar': os.environ.get('AR'),
-                'strip': os.environ.get('STRIP'),
-                'as': os.environ.get('AS'),
-                'ranlib': os.environ.get('RANLIB'),
-                'pkgconfig': tools.which('pkg-config') # FIXME: Do we need this at all? Is possible for `pkg-config` to be different than a system one?
-            },
-            'properties': {
-                'c_args': none_if_empty(os.environ.get('CPPFLAGS', '') + ' ' + os.environ.get('CFLAGS', '')),
-                'cpp_args': none_if_empty(os.environ.get('CPPFLAGS', '') + ' ' + os.environ.get('CXXFLAGS', '')),
-                'c_link_args': os.environ.get('LDFLAGS'),
-                'cpp_link_args': os.environ.get('LDFLAGS'),
-                'pkg_config_path': os.environ.get('PKG_CONFIG_PATH'),
-                'needs_exe_wrapper': tools.cross_building(settings),
-            },
-            'host_machine': {
-                'system': self._get_system_from_os(str(settings.os)),
-                'cpu': str(settings.arch)
-            }
-        }
-
-        cpu_family, endian = self._get_cpu_family_and_endianness_from_arch(str(settings.arch))
-        config_template['host_machine']['cpu_family'] = cpu_family
-        config_template['host_machine']['endian'] = endian
-
-        if not config_template['binaries']['c'] and not config_template['binaries']['cpp']:
-            raise ConanException(f'CC and CXX are undefined: C or C++ compiler must be defined when cross-building')
-
-        return config_template
-
-    def _create_machine_files_from_settings(self, settings, force_cross: bool):
-        is_cross = force_cross
-        has_for_build = False
-
-        if not is_cross:
-            has_for_build = any(map(lambda e: os.environ.get(e), ['CC_FOR_BUILD', 'CXX_FOR_BUILD']))
-            is_cross = has_for_build or any(map(lambda a: hasattr(settings, a), ['os_build', 'arch_build']))
-
-        native_files = []
-        if has_for_build or not is_cross:
-            native_files += [MesonMachineFile(name='default.ini', config=self._dict_to_config(self._create_native(settings, False)))]
-
-        cross_files = []
-        if is_cross:
-            cross_files += [MesonMachineFile(name='default.ini', config=self._dict_to_config(self._create_cross(settings)))]
-
-        return (native_files, cross_files)
-
-    @staticmethod
-    def _get_system_from_os(os: str) -> str:
-        """
-        Converts from `conan/conans/client/conf/__init__.py` to `https://mesonbuild.com/Reference-tables.html#operating-system-names`
-        """
-        os = os.lower()
-        if (os == 'macos' or os == 'ios'):
-            return 'darwin'
-        else:
-            return os
-
-    @staticmethod
-    def _get_cpu_family_and_endianness_from_arch(arch: str):
-        """
-        Converts from `conan/conans/client/conf/__init__.py` to `https://mesonbuild.com/Reference-tables.html#cpu-families`
-        """
-        arch_to_cpu = {
-            'x86' : ('x86', 'little'),
-            'x86_64' : ('x86_64',  'little'),
-            'x86' : ('x86', 'little'),
-            'ppc32be' : ('ppc', 'big'),
-            'ppc32' : ('ppc', 'little'),
-            'ppc64le' : ('ppc64', 'little'),
-            'ppc64' : ('ppc64', 'big'),
-            'armv4' : ('arm', 'little'),
-            'armv4i' : ('arm', 'little'),
-            'armv5el' : ('arm', 'little'),
-            'armv5hf' : ('arm', 'little'),
-            'armv6' : ('arm', 'little'),
-            'armv7' : ('arm', 'little'),
-            'armv7hf' : ('arm', 'little'),
-            'armv7s' : ('arm', 'little'),
-            'armv7k' : ('arm', 'little'),
-            'armv8_32' : ('arm', 'little'),
-            'armv8' : ('aarch64', 'little'),
-            'armv8.3' : ('aarch64', 'little'),
-            'sparc' : ('sparc', 'big'),
-            'sparcv9' : ('sparc64', 'big'),
-            'mips' : ('mips', 'big'),
-            'mips64' : ('mips64', 'big'),
-            'avr' : ('avr', 'little'),
-            's390' : ('s390', 'big'),
-            's390x' : ('s390', 'big'),
-            'wasm' : ('wasm', 'little'),
-        }
-
-        if (arch not in arch_to_cpu):
-            raise ConanException('Unknown arch: {}'.format(arch))
-
-        return arch_to_cpu[arch]
-
-class MesonX(object):
+class MesonX():
     def __init__(self, conanfile, build_subdir: str = None, backend: str = None, append_vcvars: bool = False) -> None:
         if self.get_version() < '0.42.0':
             raise ConanException('`meson` is too old: minimum required version `0.42.0` vs current version `{}`'.format(self.get_version()))
@@ -361,13 +92,8 @@ class MesonX(object):
             if any(map(lambda a: a.startswith('--{}'.format(arg_name)) or a.startswith('-D{}'.format(arg_name)), args)):
                 raise ConanException('Don\'t pass `{}` via `args`: {}'.format(arg_name, use_instead_msg))
 
-        source_dir = self._conanfile.source_folder
-        if source_subdir:
-            source_dir = str(Path(self._conanfile.source_folder) / source_subdir)
-
-        build_dir = self._conanfile.build_folder
-        if self._build_subdir:
-            build_dir = str(Path(self._conanfile.build_folder) /self._build_subdir)
+        # FIXME: meson forbids in-source builds: should we do smth about it?
+        source_dir, build_dir = self._get_resolved_dirs(source_subdir)
         mkdir(build_dir)
 
         resolved_options = self._get_default_options()
@@ -375,16 +101,15 @@ class MesonX(object):
         resolved_options.update(options)
 
         check_arg_not_in_opts_or_args('backend', 'use `backend` kwarg in the class constructor instead')
-        resolved_options.update({'backend': '{}'.format(self.backend)})
 
         check_arg_not_in_opts_or_args('buildtype', 'use `build_type` kwarg instead')
-        settings_bulld_type = self._settings.get_safe('build_type')
-        if build_type and build_type != settings_bulld_type:
+        settings_build_type = self._settings.get_safe('build_type')
+        if build_type and build_type != settings_build_type:
             self._conanfile.output.warn(
-                'Set build type "{}" is different than the settings build_type "{}"'.format(build_type, settings_bulld_type))
-        resolved_build_type = build_type or settings_bulld_type
+                'Set build type "{}" is different than the settings build_type "{}"'.format(build_type, settings_build_type))
+        resolved_build_type = build_type or settings_build_type
         if resolved_build_type:
-            resolved_options.update({'buildtype': '{}'.format(resolved_build_type)})
+            resolved_options.update({'buildtype': '{}'.format(self._get_meson_buildtype(resolved_build_type))})
 
         check_arg_not_in_opts_or_args('pkg_config_path', 'use `pkg_config_paths` kwarg instead')
         pc_paths = [self._conanfile.install_folder]
@@ -394,12 +119,12 @@ class MesonX(object):
 
         check_arg_not_in_opts_or_args('native-file', 'use `native_files` kwarg instead')
         check_arg_not_in_opts_or_args('cross-file', 'use `cross_files` kwarg instead')
-        resolved_native_files = self._get_default_machine_files(Path(build_dir) / MesonToolchain.get_native_file_subdir()) + native_files
-        resolved_cross_files = self._get_default_machine_files(Path(build_dir) / MesonToolchain.get_cross_file_subdir()) + cross_files
+        resolved_native_files = self._get_default_machine_files(Path(build_dir) / MesonToolchain.native_file_subdir) + native_files
+        resolved_cross_files = self._get_default_machine_files(Path(build_dir) / MesonToolchain.cross_file_subdir) + cross_files
         if resolved_native_files:
-            resolved_options['native-file'] = resolved_native_files
+            args = ['--native-file={}'.format(f) for f in resolved_native_files] + args
         if resolved_cross_files:
-            resolved_options['cross-file'] = resolved_cross_files
+            args = ['--cross-file={}'.format(f) for f in resolved_cross_files] + args
         if not resolved_native_files and not resolved_cross_files:
             self._conanfile.output.warn('No machine files were generated or supplied. Using a system compiler instead.')
 
@@ -453,7 +178,7 @@ class MesonX(object):
                 raise ConanException('Your targets contain meson syntax which is not supported by ninja: `{}`'.format(meson_target))
             self._run_ninja_targets(targets=targets,
                                     args=self._filter_non_ninja_args(args=args,
-                                                                     ninja_args=['--verbose', '-v', '-j*', '-l*']))
+                                                                     ninja_args=['-j*', '-l*']))
 
     def install(self, args=None):
         if not self._conanfile.should_install:
@@ -478,7 +203,7 @@ class MesonX(object):
         self._run_meson_command(subcommand='test', args=args)
 
     def is_configured(self):
-        _, build_dir = self._get_resolve_dirs()
+        _, build_dir = self._get_resolved_dirs()
         if self._version >= '0.50.0':
             return (Path(build_dir) / 'meson-info' / 'meson-info.json').exists()
         else:
@@ -533,7 +258,7 @@ class MesonX(object):
         build_dir = self._conanfile.build_folder
         if self._build_subdir:
             build_dir = str(Path(self._conanfile.build_folder) / _build_subdir)
-        return (source_dir, source_dir)
+        return (source_dir, build_dir)
 
     def _get_default_options(self) -> dict:
         options = dict()
@@ -546,31 +271,29 @@ class MesonX(object):
         options['includedir'] = DEFAULT_INCLUDE
 
         cppstd = cppstd_from_settings(self._conanfile.settings)
-        cppstd_conan2meson = {
-            '98': 'c++03', 'gnu98': 'gnu++03',
-            '11': 'c++11', 'gnu11': 'gnu++11',
-            '14': 'c++14', 'gnu14': 'gnu++14',
-            '17': 'c++17', 'gnu17': 'gnu++17',
-            '20': 'c++1z', 'gnu20': 'gnu++1z'
-        }
-        if cppstd:
-            options['cpp_std'] = cppstd_conan2meson[cppstd]
+        if cppstd != None:
+            options['cpp_std'] = self._get_meson_cppstd(cppstd)
 
         shared = self._so('shared')
         if shared != None:
-            options['default_library'] = shared
+            options['default_library'] = 'shared' if shared else 'static'
 
         host_os = self._ss('os')
-        if host_os and 'Windows' not in host_os:
+        if host_os and 'Windows' in host_os:
+            self._conanfile.output.warn("Toolchain: Ignoring fPIC option defined for Windows")
+        else:
             fpic = self._so('fPIC')
             if fpic != None:
                 shared = self._so('shared')
                 options['b_staticpic'] = fpic or shared
 
+        options['b_ndebug'] = 'if-release'
+        options['backend'] = self.backend
+
         return options
 
     @staticmethod
-    def _get_default_machine_files(self, machine_files_dir):
+    def _get_default_machine_files(machine_files_dir):
         machine_files_path = Path(machine_files_dir)
         return list(machine_files_path.glob('*')) if machine_files_path.exists() else []
 
@@ -585,6 +308,19 @@ class MesonX(object):
             return '"-D{}={}"'.format(key, ', '.join(['\'{}\''.format(v) for v in value]))
         else:
             return '-D{}="{}"'.format(key, value)
+
+    @staticmethod
+    def _get_meson_cppstd(cppstd):
+        cppstd_conan2meson = {
+            '98': 'c++03', 'gnu98': 'gnu++03',
+            '11': 'c++11', 'gnu11': 'gnu++11',
+            '14': 'c++14', 'gnu14': 'gnu++14',
+            '17': 'c++17', 'gnu17': 'gnu++17',
+            '20': 'c++1z', 'gnu20': 'gnu++1z'
+        }
+        if cppstd not in cppstd_conan2meson:
+            raise ConanException('Unknown cppstd: {}'.format(cppstd))
+        return cppstd_conan2meson[cppstd]
 
     @staticmethod
     def _get_meson_buildtype(build_type):
@@ -617,7 +353,7 @@ class MesonX(object):
         targets = targets or []
         args = args or []
 
-        build_dir = self.build_dir or self._conanfile.build_folder
+        _, build_dir = self._get_resolved_dirs()
 
         arg_list = join_arguments([
             '-C "{}"'.format(build_dir),
@@ -629,7 +365,7 @@ class MesonX(object):
     def _run_meson_command(self, subcommand, args=None):
         args = args or []
 
-        build_dir = self.build_dir or self._conanfile.build_folder
+        _, build_dir = self._get_resolved_dirs()
 
         arg_list = join_arguments([
             subcommand,

--- a/conans/client/build/mesonx.py
+++ b/conans/client/build/mesonx.py
@@ -28,8 +28,8 @@ from conans.util.runners import version_runner
 # - cleaned up interface: removed old arguments, removed build_dir and etc
 # - added machine file support
 # - added machine file generation for `toolchain`
-# - backend-agnostic meson methods are used by default now with ninja as a fallback for older meson versions.
-# - env variables with dependency search paths are not appended when executing meson
+# - backend-agnostic meson methods are used by default with ninja as a fallback for older meson versions.
+# - env variables with dependency search paths are not appended when executing meson commands
 # - requires pkg-config generator
 
 
@@ -289,6 +289,9 @@ class MesonX(object):
         # Meson recommends to use ninja by default
         self.backend = backend or 'ninja'
 
+        if not 'pkg_config' in self._conanfile.generators:
+            raise ConanException('`pkg_config` generator is required for Meson integration')
+
     @staticmethod
     def get_version() -> Version:
         try:
@@ -359,10 +362,7 @@ class MesonX(object):
 
         if 'pkg_config_path' in options:
             raise ConanException('Don\'t pass `pkg_config_path` via `options`: use `pkg_config_paths` kwarg instead')
-        pc_paths = []
-        if 'pkg_config' in self._conanfile.generators:
-            # Add install folder to search paths only if there is a corresponding generator
-            pc_paths += [self._conanfile.install_folder]
+        pc_paths = [self._conanfile.install_folder]
         if pkg_config_paths:
             pc_paths += [get_abs_path(f, self._conanfile.install_folder) for f in pkg_config_paths]
         resolved_options.update({'pkg_config_path': '{}'.format(os.pathsep.join(pc_paths))})

--- a/conans/client/build/mesonx.py
+++ b/conans/client/build/mesonx.py
@@ -313,10 +313,11 @@ class MesonX(object):
         """
         return MesonDefaultToolchainGenerator(self._conanfile).generate(force_cross)
 
-    def configure(self, source_folder=None, cache_build_folder=None, build_type=None, pkg_config_paths=None, options=None, native_files=None, cross_files=None):
+    def configure(self, source_folder=None, cache_build_folder=None, build_type=None, pkg_config_paths=None, native_files=None, cross_files=None, options=None, args=None):
         if not self._conanfile.should_configure:
             return
 
+        args = args or []
         options = options or []
         native_files = native_files or []
         cross_files = cross_files or []
@@ -324,7 +325,7 @@ class MesonX(object):
         def check_arg_not_in_opts_or_args(arg_name, use_instead_msg):
             if arg_name in options:
                 raise ConanException('Don\'t pass `{}` via `options`: {}'.format(arg_name, use_instead_msg))
-            if any(map(lambda a: a.startswith('--{}'.format(arg_name)) or a.startswith('-D{}'.format(arg_name), args))):
+            if any(map(lambda a: a.startswith('--{}'.format(arg_name)) or a.startswith('-D{}'.format(arg_name)), args)):
                 raise ConanException('Don\'t pass `{}` via `args`: {}'.format(arg_name, use_instead_msg))
 
         source_dir, self.build_dir = self._get_dirs(source_folder, build_folder, cache_build_folder)
@@ -362,7 +363,7 @@ class MesonX(object):
             resolved_options['cross-file'] = resolved_cross_files
 
         arg_list = join_arguments([
-            self._options_to_string(resolved_options)
+            self._options_to_string(resolved_options),
             args_to_string(args),
         ])
 

--- a/conans/client/build/mesonx.py
+++ b/conans/client/build/mesonx.py
@@ -1,7 +1,9 @@
 import os
 import platform
-from configparser import ConfigParser
-from pathlib import Path
+import sys
+if sys.version_info[0] == 3 and sys.version_info[1] >= 5:
+    from configparser import ConfigParser
+    from pathlib import Path
 
 from conans.client import tools
 from conans.client.build import defs_to_string, join_arguments
@@ -31,8 +33,6 @@ from conans.util.runners import version_runner
 # - fix env variables reading for native\cross once it's possible (i.e when <https://github.com/conan-io/conan/issues/7091> is fixed)
 # - cleanup comments
 # - add tests
-# - Can we use Py3.x? meson requires Python 3.5+
-# - deal with typings (remove? add everywhere?)
 
 # Questions:
 # - Should we keep `cross-file`/`native-file` kwarg or should they be moved to `options` instead?
@@ -41,8 +41,8 @@ from conans.util.runners import version_runner
 # - Should we generate machine files in dump() or in __init__()?
 # - Move `MesonDefaultToolchainGenerator` to `MesonDefaultToolchain`?
 
-class MesonX():
-    def __init__(self, conanfile, build_subdir: str = None, backend: str = None, append_vcvars: bool = False) -> None:
+class MesonX(object):
+    def __init__(self, conanfile, build_subdir = None, backend = None, append_vcvars = False):
         if self.get_version() < '0.42.0':
             raise ConanException('`meson` is too old: minimum required version `0.42.0` vs current version `{}`'.format(self.get_version()))
         if not 'pkg_config' in conanfile.generators:
@@ -64,7 +64,7 @@ class MesonX():
         self.backend = backend or 'ninja'
 
     @staticmethod
-    def get_version() -> Version:
+    def get_version():
         try:
             out = version_runner(['meson', '--version'])
             version_line = decode_text(out).split('\n', 1)[0]
@@ -217,7 +217,7 @@ class MesonX():
         """safe option"""
         return self._conanfile.options.get_safe(setname)
 
-    def _validate_ninja_usage_and_warn_agnostic_method_unavailable(self, minimum_version: str):
+    def _validate_ninja_usage_and_warn_agnostic_method_unavailable(self, minimum_version):
         if self.backend != 'ninja':
             raise ConanException('This method is not implemented yet for `{}` backend. Change your backend to `ninja` or update your `meson`.\n'.format(self.backend) +
                                  'Minimum required `meson` version is {}'.format(minimum_version))
@@ -260,7 +260,7 @@ class MesonX():
             build_dir = str(Path(self._conanfile.build_folder) / _build_subdir)
         return (source_dir, build_dir)
 
-    def _get_default_options(self) -> dict:
+    def _get_default_options(self):
         options = dict()
         if self._conanfile.package_folder:
             options['prefix'] = self._conanfile.package_folder

--- a/conans/client/toolchain/base.py
+++ b/conans/client/toolchain/base.py
@@ -1,5 +1,5 @@
 from conans.client.toolchain.cmake import CMakeToolchain
-from conans.client.toolchain.cmake import MesonDefaultToolchain
+from conans.client.toolchain.meson import MesonDefaultToolchain
 from conans.errors import conanfile_exception_formatter, ConanException
 
 

--- a/conans/client/toolchain/base.py
+++ b/conans/client/toolchain/base.py
@@ -1,4 +1,5 @@
 from conans.client.toolchain.cmake import CMakeToolchain
+from conans.client.toolchain.cmake import MesonDefaultToolchain
 from conans.errors import conanfile_exception_formatter, ConanException
 
 
@@ -10,7 +11,10 @@ def write_toolchain(conanfile, path, output):
                 tc = conanfile.toolchain()
         else:
             try:
-                toolchain = {"cmake": CMakeToolchain}[conanfile.toolchain]
+                toolchain = {
+                    "cmake": CMakeToolchain,
+                    "meson": MesonDefaultToolchain,
+                }[conanfile.toolchain]
             except KeyError:
                 raise ConanException("Unknown toolchain '%s'" % conanfile.toolchain)
             tc = toolchain(conanfile)

--- a/conans/client/toolchain/meson.py
+++ b/conans/client/toolchain/meson.py
@@ -1,0 +1,297 @@
+import os
+import platform
+from configparser import ConfigParser
+from pathlib import Path
+
+from conans.client import tools
+from conans.errors import ConanException
+from conans.util.files import mkdir
+
+class MesonMachineFile():
+    """
+    A wrapper for meson machine files for the use in `MesonToolchain`.
+    Note: Meson requires that all ini values are quoted. E.g. `name = 'value'`
+    """
+    def __init__(self,
+                 name: str,
+                 path: str = None,
+                 config: ConfigParser = None):
+        if not name:
+            raise ConanException('`name` is empty: machine file must have a unique name supplied')
+        self.name = name
+
+        if path and config:
+            raise ConanException('Both `path` and `config` were supplied: only one should be used')
+        if path:
+            config = ConfigParser()
+            config.read(path)
+        self.options = config
+
+    def dump(self, install_dir: str):
+        outpath = Path(install_dir)
+        if not outpath.exists():
+            outpath.mkdir(parents=True)
+        with open(outpath/self.name, 'w') as f:
+            self.options.write(f)
+
+class MesonToolchain():
+    """
+    A wrapper for `MesonMachineFile` for the use in `ConanFile.toolchain()`.
+    Uses only supplied machine files and does *not* generate any files by itself.
+    """
+    native_file_subdir = 'native'
+    cross_file_subdir = 'cross'
+
+    def __init__(self, native_files = None, cross_files = None ):
+        self.native_files = native_files or []
+        self.cross_files = cross_files or []
+
+    def __iter__(self):
+        for i in [self.native_files, self.cross_files]:
+            yield i
+
+    def dump(self, install_dir: str):
+        def dump_files(files, outpath: str):
+            if not files:
+                pass
+            if not outpath.exists():
+                outpath.mkdir(parents=True)
+            for f in files:
+                f.dump(outpath)
+
+        dump_files(self.native_files, Path(install_dir) / self.native_file_subdir)
+        dump_files(self.cross_files, Path(install_dir) / self.cross_file_subdir)
+
+class MesonDefaultToolchain(MesonToolchain):
+    """
+    A wrapper for `MesonMachineFile` for the use in `ConanFile.toolchain()`.
+    Generates default machine files.
+    """
+    def __init__(self, conanfile, force_cross=False):
+        mt_gen = MesonDefaultToolchainGenerator(conanfile)
+        native_files, cross_files = mt_gen.generate(force_cross)
+        super(MesonDefaultToolchain, self).__init__(native_files, cross_files)
+
+class MesonDefaultToolchainGenerator():
+    """
+    Generates machine files from conan profiles
+    """
+    def __init__(self, conanfile):
+        self._conanfile = conanfile
+
+    def generate(self, force_cross: bool = False) -> MesonToolchain:
+        mt = MesonToolchain()
+        has_settings_build = hasattr(self._conanfile, 'settings_build') and self._conanfile.settings_build
+        has_settings_target = hasattr(self._conanfile, 'settings_target') and self._conanfile.settings_target
+        ## Uncomment once  <https://github.com/conan-io/conan/issues/7091> is fixed
+        # if has_settings_build:
+        #    mt.native_files += [MesonMachineFile(name='default.ini', config=self._dict_to_config(self._create_native(self._conanfile.settings_build, True)))]
+        if has_settings_target:
+            mt.cross_files += [MesonMachineFile(name='default.ini', config=self._dict_to_config(self._create_cross(self._conanfile.settings_target)))]
+        if not has_settings_build and not has_settings_target:
+            tmp_native_files, tmp_cross_files = self._create_machine_files_from_settings(self._conanfile.settings, force_cross)
+            mt.native_files += tmp_native_files
+            mt.cross_files += tmp_cross_files
+        return mt
+
+    def _dict_to_config(self, machine_dict: dict) -> ConfigParser:
+        config = ConfigParser()
+        config.read_dict(self._to_ini(machine_dict))
+        return config
+
+    def _to_ini(self, config):
+        """
+        Fixes `config` to be compatible with meson machine file format.
+        """
+        return {
+            section_name: {
+                key: self._to_ini_value(value) for key, value in section.items() if value is not None
+            } for section_name, section in config.items()
+        }
+
+    def _to_ini_value(self, value):
+        """
+        Fixes value to be compatible with meson machine file format:
+        meson requires all values to be quoted. E.g. `name = 'value'`.
+        """
+        if isinstance(value, bool):
+            return str(value).lower()
+        if isinstance(value, str):
+            return "'{}'".format(value)
+        return value
+
+    def _create_native(self, settings, is_separate_profile: bool) -> dict:        
+        """
+        Parameters:
+            is_separate_profile: true, if machine file is generated from a separate conan profile 
+                                 (`--profile=native` or `--profile:build=native`);
+                                 false, if generated from a common profile during a cross build (`--profile=cross`)
+        
+        Uses `ENV_FOR_BUILD` and `settings.*_build` if `is_separate_profile` is true 
+        and `ENV` and `settings.*` otherwise.
+        """
+
+        # FIXME: Rewrite this once <https://github.com/conan-io/conan/issues/7091> is fixed
+        def none_if_empty(input: str):
+            stripped_input = input.strip()
+            return stripped_input if stripped_input else None
+        def env_or_for_build(input: str, is_separate_profile, default_val = None):
+            if is_separate_profile:
+                return os.environ.get(input, default_val)
+            else:
+                return os.environ.get('{}_FOR_BUILD'.format(input), default_val)
+        def atr_or_for_build(settings, input: str, is_separate_profile):
+            if is_separate_profile:
+                return settings.get_safe(input)
+            else:
+                return settings.get_safe('{}_build'.format(input))
+
+        config_template = {
+            'binaries': {
+                'c': env_or_for_build('CC', is_separate_profile),
+                'cpp': env_or_for_build('CXX', is_separate_profile),
+                'ld': env_or_for_build('LD', is_separate_profile),
+                'ar': env_or_for_build('AR', is_separate_profile),
+                'strip': env_or_for_build('STRIP', is_separate_profile),
+                'as': env_or_for_build('AS', is_separate_profile),
+                'ranlib': env_or_for_build('RANLIB', is_separate_profile),
+                'pkgconfig': tools.which('pkg-config') # FIXME: See below
+            },
+            'properties': {
+                'c_args': none_if_empty(env_or_for_build('CPPFLAGS', is_separate_profile, '') + ' ' + env_or_for_build('CFLAGS', is_separate_profile, '')),
+                'cpp_args': none_if_empty(env_or_for_build('CPPFLAGS', is_separate_profile, '') + ' ' + env_or_for_build('CXXFLAGS', is_separate_profile, '')),
+                'c_link_args': env_or_for_build('LDFLAGS', is_separate_profile),
+                'cpp_link_args': env_or_for_build('LDFLAGS', is_separate_profile),
+                'pkg_config_path': env_or_for_build('PKG_CONFIG_PATH', is_separate_profile),
+            }
+        }
+
+        if atr_or_for_build(settings, 'os', is_separate_profile):
+            resolved_os = atr_or_for_build(settings, 'os', is_separate_profile)
+            arch = atr_or_for_build(settings, 'arch', is_separate_profile)
+            cpu_family, endian = self._get_cpu_family_and_endianness_from_arch(str(arch))
+            config_template['build_machine'] = {
+                'system': self._get_system_from_os(str(resolved_os)),
+                'cpu': str(arch),
+                'cpu_family': cpu_family,
+                'endian': endian,
+            }
+
+        return config_template
+
+    def _create_cross(self, settings) -> dict:
+        def none_if_empty(input: str):
+            stripped_input = input.strip()
+            return stripped_input if stripped_input else None
+
+        config_template = {
+            'binaries': {
+                'c': os.environ.get('CC'),
+                'cpp': os.environ.get('CXX'),
+                'ld': os.environ.get('LD'),
+                'ar': os.environ.get('AR'),
+                'strip': os.environ.get('STRIP'),
+                'as': os.environ.get('AS'),
+                'ranlib': os.environ.get('RANLIB'),
+                'pkgconfig': tools.which('pkg-config') # FIXME: Do we need this at all? Is possible for `pkg-config` to be different than a system one?
+            },
+            'properties': {
+                'c_args': none_if_empty(os.environ.get('CPPFLAGS', '') + ' ' + os.environ.get('CFLAGS', '')),
+                'cpp_args': none_if_empty(os.environ.get('CPPFLAGS', '') + ' ' + os.environ.get('CXXFLAGS', '')),
+                'c_link_args': os.environ.get('LDFLAGS'),
+                'cpp_link_args': os.environ.get('LDFLAGS'),
+                'pkg_config_path': os.environ.get('PKG_CONFIG_PATH'),
+                'needs_exe_wrapper': tools.cross_building(settings),
+            },
+            'host_machine': {
+                'system': self._get_system_from_os(str(settings.os)),
+                'cpu': str(settings.arch)
+            }
+        }
+
+        cpu_family, endian = self._get_cpu_family_and_endianness_from_arch(str(settings.arch))
+        config_template['host_machine']['cpu_family'] = cpu_family
+        config_template['host_machine']['endian'] = endian
+
+        if not config_template['binaries']['c'] and not config_template['binaries']['cpp']:
+            self._conanfile.output.warn('CC and CXX are undefined. Using a system compiler instead.')
+            divined_c_compiler = tools.which('gcc') or tools.which('cc') 
+            divined_cpp_compiler = tools.which('g++') or tools.which('c++') 
+            if not divined_c_compiler and not divined_cpp_compiler:
+                raise ConanException('Failed to divine system compiler.')
+            if divined_c_compiler:
+                config_template['binaries']['c'] = divined_c_compiler
+            if divined_cpp_compiler:
+                config_template['binaries']['cpp'] = divined_cpp_compiler
+
+        return config_template
+
+    def _create_machine_files_from_settings(self, settings, force_cross: bool):
+        is_cross = tools.cross_building(settings) or force_cross
+        has_for_build = False
+
+        if not is_cross:
+            has_for_build = any(map(lambda e: os.environ.get(e), ['CC_FOR_BUILD', 'CXX_FOR_BUILD']))
+            is_cross = has_for_build
+
+        native_files = []
+        if has_for_build or not is_cross:
+            is_separate_profile = not is_cross
+            native_files += [MesonMachineFile(name='default.ini', config=self._dict_to_config(self._create_native(settings, is_separate_profile)))]
+
+        cross_files = []
+        if is_cross:
+            cross_files += [MesonMachineFile(name='default.ini', config=self._dict_to_config(self._create_cross(settings)))]
+
+        return (native_files, cross_files)
+
+    @staticmethod
+    def _get_system_from_os(os: str) -> str:
+        """
+        Converts from `conan/conans/client/conf/__init__.py` to `https://mesonbuild.com/Reference-tables.html#operating-system-names`
+        """
+        os = os.lower()
+        if (os == 'macos' or os == 'ios'):
+            return 'darwin'
+        else:
+            return os
+
+    @staticmethod
+    def _get_cpu_family_and_endianness_from_arch(arch: str):
+        """
+        Converts from `conan/conans/client/conf/__init__.py` to `https://mesonbuild.com/Reference-tables.html#cpu-families`
+        """
+        arch_to_cpu = {
+            'x86' : ('x86', 'little'),
+            'x86_64' : ('x86_64',  'little'),
+            'x86' : ('x86', 'little'),
+            'ppc32be' : ('ppc', 'big'),
+            'ppc32' : ('ppc', 'little'),
+            'ppc64le' : ('ppc64', 'little'),
+            'ppc64' : ('ppc64', 'big'),
+            'armv4' : ('arm', 'little'),
+            'armv4i' : ('arm', 'little'),
+            'armv5el' : ('arm', 'little'),
+            'armv5hf' : ('arm', 'little'),
+            'armv6' : ('arm', 'little'),
+            'armv7' : ('arm', 'little'),
+            'armv7hf' : ('arm', 'little'),
+            'armv7s' : ('arm', 'little'),
+            'armv7k' : ('arm', 'little'),
+            'armv8_32' : ('arm', 'little'),
+            'armv8' : ('aarch64', 'little'),
+            'armv8.3' : ('aarch64', 'little'),
+            'sparc' : ('sparc', 'big'),
+            'sparcv9' : ('sparc64', 'big'),
+            'mips' : ('mips', 'big'),
+            'mips64' : ('mips64', 'big'),
+            'avr' : ('avr', 'little'),
+            's390' : ('s390', 'big'),
+            's390x' : ('s390', 'big'),
+            'wasm' : ('wasm', 'little'),
+        }
+
+        if (arch not in arch_to_cpu):
+            raise ConanException('Unknown arch: {}'.format(arch))
+
+        return arch_to_cpu[arch]

--- a/conans/test/functional/toolchain/test_meson.py
+++ b/conans/test/functional/toolchain/test_meson.py
@@ -1,0 +1,242 @@
+# coding=utf-8
+
+import os
+import platform
+import textwrap
+import unittest
+
+from nose.plugins.attrib import attr
+from parameterized.parameterized import parameterized
+
+from conans.model.ref import ConanFileReference, PackageReference
+from conans.test.utils.tools import TestClient
+
+from conans import MesonX
+
+@attr("toolchain")
+class Base(unittest.TestCase):
+
+    conanfile = textwrap.dedent("""
+        from conans import ConanFile, MesonX, MesonDefaultToolchain, MesonMachineFile, tools
+        from configparser import ConfigParser
+
+        class App(ConanFile):
+            settings = "os", "arch", "compiler", "build_type"
+            requires = "hello/0.1"
+            generators = "pkg_config"
+            options = {"shared": [True, False], "fPIC": [True, False]}
+            default_options = {"shared": False, "fPIC": True}
+
+            def toolchain(self):
+                tc = MesonDefaultToolchain(self)
+
+                config = ConfigParser()
+                config.read_dict({
+                    "properties": {
+                        "user_option": '"FOO"'
+                    }
+                })
+
+                machine_file = MesonMachineFile(name="user_override", config=config)
+                if tools.cross_building(self.settings):
+                    tc.cross_files += [machine_file]
+                else:
+                    tc.native_files += [machine_file]
+                return tc
+
+            def build(self):
+                meson = MesonX(self)
+                meson.configure(source_subdir="src")
+                meson.build()
+        """)
+
+    lib_h = textwrap.dedent("""
+        #pragma once
+        #ifdef WIN32
+          #define APP_LIB_EXPORT __declspec(dllexport)
+        #else
+          #define APP_LIB_EXPORT
+        #endif
+        APP_LIB_EXPORT void app();
+        """)
+
+    lib_cpp = textwrap.dedent("""
+        #include <iostream>
+        #include "app.h"
+        #include "hello.h"
+
+        void app() {
+            std::cout << "Hello: " << HELLO_MSG << std::endl;
+            #ifdef NDEBUG
+            std::cout << "App: Release!" <<std::endl;
+            #else
+            std::cout << "App: Debug!" <<std::endl;
+            #endif
+            std::cout << "USER_OPTION_VALUE: " << USER_OPTION_VALUE << "\\n";
+        }
+        """)
+
+    app = textwrap.dedent("""
+        #include "app.h"
+
+        int main() {
+            app();
+        }
+        """)
+
+    meson = textwrap.dedent("""
+        project('test','cpp')
+        
+        message('>> buildtype:', get_option('buildtype'))
+        message('>> cpp_std:', get_option('cpp_std'))
+        message('>> b_staticpic:', get_option('b_staticpic'))
+        message('>> prefix:', get_option('prefix'))
+        message('>> default_library:', get_option('default_library'))
+
+        dep_hello = dependency('hello', method: 'pkg-config', include_type: 'system')
+
+        cpp_flags_lib = []
+        user_option_value = meson.get_external_property('user_option', '')
+        if user_option_value != ''
+            cpp_flags_lib += ['-DUSER_OPTION_VALUE="' + user_option_value + '"']
+        endif
+
+        lib_app_lib = library(
+            'app_lib', 
+            sources: ['app_lib.cpp'],
+            cpp_args: cpp_flags_lib,
+            dependencies: dep_hello
+        )
+
+        exe_app = executable(
+            'app', 
+            sources: ['app.cpp'],
+            link_with: lib_app_lib
+        )
+        """)
+
+    def setUp(self):
+        self.client = TestClient(path_with_spaces=False)
+        conanfile = textwrap.dedent("""
+            from conans import ConanFile
+            from conans.tools import save
+            import os
+            class Pkg(ConanFile):
+                settings = "build_type"
+                generators = "pkg_config"
+
+                def package(self):
+                    save(os.path.join(self.package_folder, "include/hello.h"),
+                         '#define HELLO_MSG "%s"' % self.settings.build_type)
+            """)
+        self.client.save({"conanfile.py": conanfile})
+        self.client.run("create . hello/0.1@ -s build_type=Debug")
+        self.client.run("create . hello/0.1@ -s build_type=Release")
+
+        # Prepare the actual consumer package
+        self.client.save({"conanfile.py": self.conanfile,
+                          "src/meson.build": self.meson,
+                          "src/app.cpp": self.app,
+                          "src/app_lib.cpp": self.lib_cpp,
+                          "src/app.h": self.lib_h})
+
+    def _run_build(self, settings=None, options=None):
+        # Build the profile according to the settings provided
+        settings = settings or {}
+        settings = " ".join('-s %s="%s"' % (k, v) for k, v in settings.items() if v)
+        options = " ".join("-o %s=%s" % (k, v) for k, v in options.items()) if options else ""
+
+        # Run the configure corresponding to this test case
+        build_directory = os.path.join(self.client.current_folder, "build").replace("\\", "/")
+        with self.client.chdir(build_directory):
+            self.client.run("install .. %s %s" % (settings, options))
+            install_out = self.client.out
+            self.client.run("build ..")
+        return install_out
+
+@unittest.skipUnless(platform.system() == "Linux", "Only for Linux")
+class LinuxTest(Base):
+    @parameterized.expand([("Debug",  "14", "x86", "libstdc++", True),
+                           ("Release", "gnu14", "x86_64", "libstdc++11", False)])
+    def test_toolchain_linux(self, build_type, cppstd, arch, libcxx, shared):
+        settings = {"compiler": "gcc",
+                    "compiler.cppstd": cppstd,
+                    "compiler.libcxx": libcxx,
+                    "arch": arch,
+                    "build_type": build_type}
+        self._run_build(settings, {"shared": shared})
+
+        #self.assertIn('CMake command: cmake -G "Unix Makefiles" '
+                      #'-DCMAKE_TOOLCHAIN_FILE="conan_toolchain.cmake"', self.client.out)
+        if shared:
+            self.assertIn("libapp_lib.so", self.client.out)
+        else:
+            self.assertIn("libapp_lib.a", self.client.out)
+
+        out = str(self.client.out).splitlines()
+        shared_str = "shared" if shared else "static"
+        vals = {"cpp_std": MesonX._get_meson_cppstd(cppstd),
+                "buildtype": MesonX._get_meson_buildtype(build_type),
+                "b_staticpic": "True", # True by default
+                "default_library": shared_str,
+                }
+        for k, v in vals.items():
+            self.assertIn("Message: >> %s: %s" % (k, v), out)
+
+        self.client.run_command("build/app")
+        self.assertIn("Hello: %s" % build_type, self.client.out)
+        self.assertIn("App: %s!" % build_type, self.client.out)
+        self.assertIn("USER_OPTION_VALUE: FOO", self.client.out)
+
+@attr("toolchain")
+class MesonInstallTest(unittest.TestCase):
+
+    def test_install(self):
+        conanfile = textwrap.dedent("""
+            from conans import ConanFile, MesonX
+
+            class App(ConanFile):
+                settings = "os", "arch", "compiler", "build_type"
+                exports_sources = "src/meson.build", "src/header.h"
+
+                generators = "pkg_config"
+                toolchain = "meson"
+
+                def build(self):
+                    meson = MesonX(self)
+                    meson.configure(source_subdir="src")
+
+                def package(self):
+                    meson = MesonX(self)
+                    meson.install()
+            """)
+
+        meson = textwrap.dedent("""
+            project('App C', 'c')
+
+            src_inc_files = files('header.h')
+            install_headers(src_inc_files, install_dir: 'include')
+            """)
+        client = TestClient(path_with_spaces=False)
+        client.save({"conanfile.py": conanfile,
+                     "src/meson.build": meson,
+                     "src/header.h": "# my header file"})
+
+        # FIXME: This is broken, because the toolchain at install time, doesn't have the package
+        # folder yet. We need to define the layout for local development
+        """
+        with client.chdir("build"):
+            client.run("install ..")
+            client.run("build ..")
+            client.run("package .. -pf=mypkg")  # -pf=mypkg ignored
+        self.assertTrue(os.path.exists(os.path.join(client.current_folder, "build",
+                                                    "include", "header.h")))"""
+
+        # The create flow must work
+        client.run("create . pkg/0.1@")
+        self.assertIn("pkg/0.1 package(): Packaged 1 '.h' file: header.h", client.out)
+        ref = ConanFileReference.loads("pkg/0.1")
+        layout = client.cache.package_layout(ref)
+        package_id = layout.conan_packages()[0]
+        package_folder = layout.package(PackageReference(ref, package_id))
+        self.assertTrue(os.path.exists(os.path.join(package_folder, "include", "header.h")))

--- a/conans/test/functional/toolchain/test_meson.py
+++ b/conans/test/functional/toolchain/test_meson.py
@@ -2,6 +2,7 @@
 
 import os
 import platform
+import sys
 import textwrap
 import unittest
 
@@ -14,6 +15,7 @@ from conans.test.utils.tools import TestClient
 from conans import MesonX
 
 @attr("toolchain")
+@unittest.skipUnless(sys.version_info.major == 3 and sys.version_info.minor >= 5, "Requires Python 3.5+")
 class Base(unittest.TestCase):
 
     conanfile = textwrap.dedent("""
@@ -189,6 +191,7 @@ class LinuxTest(Base):
         self.assertIn("USER_OPTION_VALUE: FOO", self.client.out)
 
 @attr("toolchain")
+@unittest.skipUnless(sys.version_info.major == 3 and sys.version_info.minor >= 5, "Requires Python 3.5+")
 class MesonInstallTest(unittest.TestCase):
 
     def test_install(self):


### PR DESCRIPTION
Changelog: (Feature | Fix | Bugfix): Describe here your pull request
Docs: **TODO** <s>https://github.com/conan-io/docs/pull/XXXX</s>
Fixes: https://github.com/conan-io/conan/issues/7026

- [x] Refer to the issue that supports this Pull Request.
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 

<sup>**Note:** By default this PR will skip the slower tests and will use a limited set of python versions. Check [here](https://github.com/conan-io/conan/blob/develop/.github/PR_INCREASE_TESTING.md) how to increase the testing level by writing some tags in the current PR body text.</sup>

Differences from stock Meson integration:
- does not override `default_library` if no `shared` options was set
- saves `build_subdir` in `__init__`
- cleaned up interface: removed old arguments, removed build_dir and etc
- added machine file support
- added machine file generation for `toolchain`
- backend-agnostic meson methods are used by default with ninja as a fallback for older meson versions.
- uses only command options to pass info to meson during configuration.
- env variables with dependency search paths are not appended when executing meson commands
- requires pkg-config generator
- install_folder is always added to pkg-config search paths now (since pc generator is required now)

Limitations:
Can't read `--profile:build`, thus works only in cases when `native` compiler is not required by meson project.

TODO:
- [ ] fix env variables reading for native\cross once it's possible (i.e when <https://github.com/conan-io/conan/issues/7091> is fixed)
- [ ] add pkg_config_path to configure properly (cross scenario and native) or move it to machine file generation
- [ ] cleanup comments
- [ ] add tests
- [x] deal with typings (remove)

Questions:
- <s>Can we use Py3.x? meson requires Python 3.5+</s> Can use 3.5, but it should not leak in global scope.
- Should we keep `cross-file`/`native-file` kwarg or should they be moved to `options` instead?
- Same question as ^ for pkg-config-paths
- How should the user extend `_get_cpu_family_and_endianness_from_arch` in case he has a custom unknown arch?
- Should we generate machine files in `dump()` or in `__init__()`?
- Move `MesonDefaultToolchainGenerator` to `MesonDefaultToolchain`?
