### PR TITLE
Bugfix: fix iOS CMake architecture #7157

### DIFF
--- a/conans/client/build/cmake_flags.py
+++ b/conans/client/build/cmake_flags.py
@@ -1,4 +1,5 @@
 import os
+import platform
 from collections import OrderedDict
 
 from conans.client import tools
@@ -294,9 +295,12 @@ class CMakeDefinitionsBuilder(object):
         definitions.update(build_type_definition(self._forced_build_type, build_type,
                                                  self._generator, self._output))
 
-        if str(os_) == "Macos":
-            if arch == "x86":
-                definitions["CMAKE_OSX_ARCHITECTURES"] = "i386"
+        if tools.is_apple_os(os_):
+            definitions["CMAKE_OSX_ARCHITECTURES"] = tools.to_apple_arch(arch)
+            # xcrun is only available on macOS, otherwise it's cross-compiling and it needs to be
+            # set within CMake toolchain
+            if platform.system == "Darwin":
+                definitions["CMAKE_OSX_SYSROOT"] = tools.XCRun(self._conanfile.settings).sdk_path
 
         definitions.update(self._cmake_cross_build_defines())
         definitions.update(self._get_cpp_standard_vars())

--- a/conans/client/build/cmake_flags.py
+++ b/conans/client/build/cmake_flags.py
@@ -299,7 +299,7 @@ class CMakeDefinitionsBuilder(object):
             definitions["CMAKE_OSX_ARCHITECTURES"] = tools.to_apple_arch(arch)
             # xcrun is only available on macOS, otherwise it's cross-compiling and it needs to be
             # set within CMake toolchain
-            if platform.system == "Darwin":
+            if platform.system() == "Darwin":
                 definitions["CMAKE_OSX_SYSROOT"] = tools.XCRun(self._conanfile.settings).sdk_path
 
         definitions.update(self._cmake_cross_build_defines())

--- a/conans/test/unittests/client/build/cmake_test.py
+++ b/conans/test/unittests/client/build/cmake_test.py
@@ -1307,8 +1307,9 @@ build_type: [ Release]
                            ("iOS", "7.0",),
                            ("watchOS", "4.0",),
                            ("tvOS", "11.0",)])
-    @mock.patch('platform.system', return_value="Macos")
-    def test_cmake_system_version_osx(self, the_os, os_version, _):
+    @mock.patch("platform.system", return_value="Darwin")
+    @mock.patch("conans.client.tools.apple.XCRun.sdk_path", return_value='/opt')
+    def test_cmake_system_version_osx(self, the_os, os_version, _, __):
         settings = Settings.loads(get_default_settings_yml())
         settings.os = the_os
 


### PR DESCRIPTION
backport of #7157 to **release/1.26**

closes: #7156 

Changelog: Bugfix: Fix iOS CMake architecture.
Docs: omit

need to set [CMAKE_OSX_ARCHITECTURES](https://cmake.org/cmake/help/latest/variable/CMAKE_OSX_ARCHITECTURES.html) and [CMAKE_OSX_SYSROOT](https://cmake.org/cmake/help/latest/variable/CMAKE_OSX_SYSROOT.html)

- [x] Refer to the issue that supports this Pull Request.
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 

<sup>**Note:** By default this PR will skip the slower tests and will use a limited set of python versions. Check [here](https://github.com/conan-io/conan/blob/develop/.github/PR_INCREASE_TESTING.md) how to increase the testing level by writing some tags in the current PR body text.</sup>
