### PR TITLE
[bug] [xbuild] build_requires from host profile is applied to other build requires

### DIFF
--- a/conans/client/graph/graph_manager.py
+++ b/conans/client/graph/graph_manager.py
@@ -312,10 +312,13 @@ class GraphManager(object):
                                                          br_list,
                                                          check_updates, update, remotes,
                                                          profile_host, profile_build, graph_lock)
-
+                if default_context == CONTEXT_BUILD:
+                    profile_build_build_requires = profile_build.build_requires
+                else:
+                    profile_build_build_requires = {}
                 self._recurse_build_requires(graph, builder,
                                              check_updates, update, build_mode,
-                                             remotes, profile_build_requires, recorder,
+                                             remotes, profile_build_build_requires, recorder,
                                              profile_host, profile_build, graph_lock,
                                              nodes_subset=nodessub, root=node)
 

--- a/conans/client/graph/graph_manager.py
+++ b/conans/client/graph/graph_manager.py
@@ -290,7 +290,6 @@ class GraphManager(object):
             package_build_requires = self._get_recipe_build_requires(node.conanfile, default_context)
             str_ref = str(node.ref)
             new_profile_build_requires = []
-            profile_build_requires = profile_build_requires or {}
             for pattern, build_requires in profile_build_requires.items():
                 if ((node.recipe == RECIPE_CONSUMER and pattern == "&") or
                         (node.recipe != RECIPE_CONSUMER and pattern == "&!") or

--- a/conans/client/graph/graph_manager.py
+++ b/conans/client/graph/graph_manager.py
@@ -311,13 +311,11 @@ class GraphManager(object):
                                                          br_list,
                                                          check_updates, update, remotes,
                                                          profile_host, profile_build, graph_lock)
-                if default_context == CONTEXT_BUILD:
-                    profile_build_build_requires = profile_build.build_requires
-                else:
-                    profile_build_build_requires = {}
+                build_requires = profile_build.build_requires if default_context == CONTEXT_BUILD \
+                    else profile_build_requires
                 self._recurse_build_requires(graph, builder,
                                              check_updates, update, build_mode,
-                                             remotes, profile_build_build_requires, recorder,
+                                             remotes, build_requires, recorder,
                                              profile_host, profile_build, graph_lock,
                                              nodes_subset=nodessub, root=node)
 

--- a/conans/test/functional/cross_building/build_requires_from_profile_test.py
+++ b/conans/test/functional/cross_building/build_requires_from_profile_test.py
@@ -23,6 +23,9 @@ class BuildRequiresFromProfile(unittest.TestCase):
         compiler.version=11.0
         compiler.libcxx=libc++
         build_type=Release
+
+        [build_requires]
+        br3/version
     """)
 
     library_conanfile = textwrap.dedent("""
@@ -35,14 +38,19 @@ class BuildRequiresFromProfile(unittest.TestCase):
             build_requires = "br1/version"
     """)
 
-    def test_br_from_profile(self):
+    def test_br_from_profile_host_and_profile_build(self):
         t = TestClient()
         t.save({'profile_host': self.profile_host,
                 'profile_build': self.profile_build,
                 'library.py': self.library_conanfile,
                 'br1.py': GenConanfile(),
-                'br2.py': GenConanfile()})
+                'br2.py': GenConanfile(),
+                'br3.py': GenConanfile()})
         t.run("export br1.py br1/version@")
         t.run("export br2.py br2/version@")
+        t.run("export br3.py br3/version@")
         t.run("create library.py --profile:host=profile_host --profile:build=profile_build --build *")
         self.assertNotIn("br1/version: Applying build-requirement: br2/version", t.out)
+        self.assertIn("br1/version: Applying build-requirement: br3/version", t.out)
+        self.assertIn("library/version: Applying build-requirement: br2/version", t.out)
+        self.assertIn("library/version: Applying build-requirement: br1/version", t.out)

--- a/conans/test/functional/cross_building/build_requires_from_profile_test.py
+++ b/conans/test/functional/cross_building/build_requires_from_profile_test.py
@@ -1,6 +1,6 @@
 import unittest
 import textwrap
-from conans.test.utils.tools import TestClient, TestServer, GenConanfile
+from conans.test.utils.tools import TestClient, GenConanfile
 
 
 class BuildRequiresFromProfile(unittest.TestCase):
@@ -52,6 +52,5 @@ class BuildRequiresFromProfile(unittest.TestCase):
         t.run("create library.py --profile:host=profile_host --profile:build=profile_build --build *")
         self.assertNotIn("br1/version: Applying build-requirement: br2/version", t.out)
         self.assertIn("br1/version: Applying build-requirement: br3/version", t.out)
-        self.assertIn("br2/version: Applying build-requirement: br3/version", t.out)
         self.assertIn("library/version: Applying build-requirement: br2/version", t.out)
         self.assertIn("library/version: Applying build-requirement: br1/version", t.out)

--- a/conans/test/functional/cross_building/build_requires_from_profile_test.py
+++ b/conans/test/functional/cross_building/build_requires_from_profile_test.py
@@ -3,7 +3,6 @@ import textwrap
 from conans.test.utils.tools import TestClient, TestServer, GenConanfile
 
 
-
 class BuildRequiresFromProfile(unittest.TestCase):
     profile_host = textwrap.dedent("""
         [settings]
@@ -46,5 +45,4 @@ class BuildRequiresFromProfile(unittest.TestCase):
         t.run("export br1.py br1/version@")
         t.run("export br2.py br2/version@")
         t.run("create library.py --profile:host=profile_host --profile:build=profile_build --build *")
-
-        self.assertNotIn("br1/version: Applying build-requirement", t.out)
+        self.assertNotIn("br1/version: Applying build-requirement: br2/version", t.out)

--- a/conans/test/functional/cross_building/build_requires_from_profile_test.py
+++ b/conans/test/functional/cross_building/build_requires_from_profile_test.py
@@ -52,5 +52,6 @@ class BuildRequiresFromProfile(unittest.TestCase):
         t.run("create library.py --profile:host=profile_host --profile:build=profile_build --build *")
         self.assertNotIn("br1/version: Applying build-requirement: br2/version", t.out)
         self.assertIn("br1/version: Applying build-requirement: br3/version", t.out)
+        self.assertIn("br2/version: Applying build-requirement: br3/version", t.out)
         self.assertIn("library/version: Applying build-requirement: br2/version", t.out)
         self.assertIn("library/version: Applying build-requirement: br1/version", t.out)

--- a/conans/test/functional/cross_building/build_requires_from_profile_test.py
+++ b/conans/test/functional/cross_building/build_requires_from_profile_test.py
@@ -1,0 +1,50 @@
+import unittest
+import textwrap
+from conans.test.utils.tools import TestClient, TestServer, GenConanfile
+
+
+
+class BuildRequiresFromProfile(unittest.TestCase):
+    profile_host = textwrap.dedent("""
+        [settings]
+        os=Windows
+        arch=x86_64
+        compiler=Visual Studio
+        compiler.version=16
+
+        [build_requires]
+        br2/version
+    """)
+
+    profile_build = textwrap.dedent("""
+        [settings]
+        os=Macos
+        arch=x86_64
+        compiler=apple-clang
+        compiler.version=11.0
+        compiler.libcxx=libc++
+        build_type=Release
+    """)
+
+    library_conanfile = textwrap.dedent("""
+        from conans import ConanFile
+
+        class Recipe(ConanFile):
+            name = "library"
+            version = "version"
+
+            build_requires = "br1/version"
+    """)
+
+    def test_br_from_profile(self):
+        t = TestClient()
+        t.save({'profile_host': self.profile_host,
+                'profile_build': self.profile_build,
+                'library.py': self.library_conanfile,
+                'br1.py': GenConanfile(),
+                'br2.py': GenConanfile()})
+        t.run("export br1.py br1/version@")
+        t.run("export br2.py br2/version@")
+        t.run("create library.py --profile:host=profile_host --profile:build=profile_build --build *")
+
+        self.assertNotIn("br1/version: Applying build-requirement", t.out)


### PR DESCRIPTION
Changelog: Fix: Packages listed as `build_requires` in recipes that belong to the _host_ context don't add as `build_requires` those listed in the _host_ profile.
Docs: omit

The BR that is declared in the `profile_host` is incorrectly applied to the other build_requires that is declared in the `library` recipe.

closes https://github.com/conan-io/conan/issues/7214