### PR TITLE
Required Conan version

### DIFF
--- a/conans/client/command.py
+++ b/conans/client/command.py
@@ -15,6 +15,7 @@ from conans.client.cmd.uploader import UPLOAD_POLICY_FORCE, \
     UPLOAD_POLICY_NO_OVERWRITE, UPLOAD_POLICY_NO_OVERWRITE_RECIPE, UPLOAD_POLICY_SKIP
 from conans.client.conan_api import Conan, default_manifest_folder, _make_abs_path, ProfileData
 from conans.client.conf.config_installer import is_config_install_scheduled
+from conans.client.conf.required_version import check_required_conan_version
 from conans.client.conan_command_output import CommandOutputer
 from conans.client.output import Color
 from conans.client.printer import Printer
@@ -2031,6 +2032,7 @@ class Command(object):
             if is_config_install_scheduled(self._conan) and \
                (command != "config" or (command == "config" and args[0] != "install")):
                 self._conan.config_install(None, None)
+            check_required_conan_version(self._conan, self._out)
 
             method(args[0][1:])
         except KeyboardInterrupt as exc:

--- a/conans/client/command.py
+++ b/conans/client/command.py
@@ -15,7 +15,6 @@ from conans.client.cmd.uploader import UPLOAD_POLICY_FORCE, \
     UPLOAD_POLICY_NO_OVERWRITE, UPLOAD_POLICY_NO_OVERWRITE_RECIPE, UPLOAD_POLICY_SKIP
 from conans.client.conan_api import Conan, default_manifest_folder, _make_abs_path, ProfileData
 from conans.client.conf.config_installer import is_config_install_scheduled
-from conans.client.conf.required_version import check_required_conan_version
 from conans.client.conan_command_output import CommandOutputer
 from conans.client.output import Color
 from conans.client.printer import Printer
@@ -2032,7 +2031,6 @@ class Command(object):
             if is_config_install_scheduled(self._conan) and \
                (command != "config" or (command == "config" and args[0] != "install")):
                 self._conan.config_install(None, None)
-            check_required_conan_version(self._conan, self._out)
 
             method(args[0][1:])
         except KeyboardInterrupt as exc:

--- a/conans/client/conan_api.py
+++ b/conans/client/conan_api.py
@@ -20,6 +20,7 @@ from conans.client.cmd.test import install_build_and_test
 from conans.client.cmd.uploader import CmdUpload
 from conans.client.cmd.user import user_set, users_clean, users_list, token_present
 from conans.client.conanfile.package import run_package_method
+from conans.client.conf.required_version import check_required_conan_version
 from conans.client.graph.graph import RECIPE_EDITABLE
 from conans.client.graph.graph_binaries import GraphBinariesAnalyzer
 from conans.client.graph.graph_manager import GraphManager
@@ -233,6 +234,7 @@ class ConanAPIV1(object):
         # Migration system
         migrator = ClientMigrator(self.cache_folder, Version(client_version), self.out)
         migrator.migrate()
+        check_required_conan_version(self.cache_folder, self.out)
         if not get_env(CONAN_V2_MODE_ENVVAR, False):
             # FIXME Remove in Conan 2.0
             sys.path.append(os.path.join(self.cache_folder, "python"))

--- a/conans/client/conf/__init__.py
+++ b/conans/client/conf/__init__.py
@@ -177,6 +177,7 @@ _t_default_client_conf = Template(textwrap.dedent("""
     {% endif %}
 
     # config_install_interval = 1h
+    # required_conan_version = >=1.26
 
     [storage]
     # This is the default path, but you can write your own. It must be an absolute path or a
@@ -261,6 +262,7 @@ class ConanClientConfigParser(ConfigParser, object):
             ("CONAN_MSBUILD_VERBOSITY", "msbuild_verbosity", None),
             ("CONAN_CACERT_PATH", "cacert_path", None),
             ("CONAN_DEFAULT_PACKAGE_ID_MODE", "default_package_id_mode", None),
+            ("CONAN_REQUIRED_CONAN_VERSION", "required_conan_version", None),
             # ("CONAN_DEFAULT_PROFILE_PATH", "default_profile", DEFAULT_PROFILE_NAME),
         ],
         "hooks": [
@@ -709,3 +711,10 @@ class ConanClientConfigParser(ConfigParser, object):
         except Exception as e:
             raise ConanException("Incorrect definition of general.config_install_interval: %s"
                                  % interval)
+
+    @property
+    def required_conan_version(self):
+        try:
+            return self.get_item("general.required_conan_version")
+        except ConanException:
+            return None

--- a/conans/client/conf/__init__.py
+++ b/conans/client/conf/__init__.py
@@ -262,7 +262,6 @@ class ConanClientConfigParser(ConfigParser, object):
             ("CONAN_MSBUILD_VERBOSITY", "msbuild_verbosity", None),
             ("CONAN_CACERT_PATH", "cacert_path", None),
             ("CONAN_DEFAULT_PACKAGE_ID_MODE", "default_package_id_mode", None),
-            ("CONAN_REQUIRED_CONAN_VERSION", "required_conan_version", None),
             # ("CONAN_DEFAULT_PROFILE_PATH", "default_profile", DEFAULT_PROFILE_NAME),
         ],
         "hooks": [

--- a/conans/client/conf/required_version.py
+++ b/conans/client/conf/required_version.py
@@ -1,5 +1,5 @@
 from conans.client.cache.cache import ClientCache
-from conans.client.graph.range_resolver import satisfying
+from semver import satisfies, Range
 from conans import __version__ as client_version
 from conans.errors import ConanException
 
@@ -19,10 +19,12 @@ def check_required_conan_version(cache_folder, out):
     cache = ClientCache(cache_folder, out)
     required_version = cache.config.required_conan_version
     if required_version:
-        output = ""
-        result = satisfying([client_version], required_version, output)
+        try:
+            Range(required_version, False)
+        except ValueError:
+            raise ConanException("The required version expression '{}' is not valid."
+                                 .format(required_version))
+        result = satisfies(client_version, required_version)
         if not result:
-            raise ConanException("The current Conan version ({}) does not match to the required version ({})."
-                     .format(client_version, required_version))
-        elif result != client_version:
-            raise ConanException(result)
+            raise ConanException("The current Conan version ({}) does not match to the required"
+                                 " version ({}).".format(client_version, required_version))

--- a/conans/client/conf/required_version.py
+++ b/conans/client/conf/required_version.py
@@ -1,27 +1,28 @@
 from conans.client.cache.cache import ClientCache
 from conans.client.graph.range_resolver import satisfying
 from conans import __version__ as client_version
+from conans.errors import ConanException
 
 
-def check_required_conan_version(api, out):
+def check_required_conan_version(cache_folder, out):
     """ Check if the required Conan version in config file matches to the current Conan version
 
             When required_conan_version is not configured, it's skipped
             When required_conan_version is configured, Conan's version must matches the required
             version
-            When it doesn't match, a Warning is raised
+            When it doesn't match, an ConanException is raised
 
-        :param api: Conan API instance
+        :param cache_folder: Conan cache folder
         :param out: Output stream
         :return: None
     """
-    cache = ClientCache(api.cache_folder, api.out)
+    cache = ClientCache(cache_folder, out)
     required_version = cache.config.required_conan_version
     if required_version:
         output = ""
         result = satisfying([client_version], required_version, output)
         if not result:
-            out.warn("The current Conan version ({}) does not match to the required version ({})."
+            raise ConanException("The current Conan version ({}) does not match to the required version ({})."
                      .format(client_version, required_version))
         elif result != client_version:
-            out.warn(result)
+            raise ConanException(result)

--- a/conans/client/conf/required_version.py
+++ b/conans/client/conf/required_version.py
@@ -1,0 +1,27 @@
+from conans.client.cache.cache import ClientCache
+from conans.client.graph.range_resolver import satisfying
+from conans import __version__ as client_version
+
+
+def check_required_conan_version(api, out):
+    """ Check if the required Conan version in config file matches to the current Conan version
+
+            When required_conan_version is not configured, it's skipped
+            When required_conan_version is configured, Conan's version must matches the required
+            version
+            When it doesn't match, a Warning is raised
+
+        :param api: Conan API instance
+        :param out: Output stream
+        :return: None
+    """
+    cache = ClientCache(api.cache_folder, api.out)
+    required_version = cache.config.required_conan_version
+    if required_version:
+        output = ""
+        result = satisfying([client_version], required_version, output)
+        if not result:
+            out.warn("The current Conan version ({}) does not match to the required version ({})."
+                     .format(client_version, required_version))
+        elif result != client_version:
+            out.warn(result)

--- a/conans/test/functional/configuration/required_version_test.py
+++ b/conans/test/functional/configuration/required_version_test.py
@@ -1,0 +1,40 @@
+import unittest
+from conans.test.utils.tools import TestClient
+from conans import __version__ as client_version
+
+
+class RequiredVersionTest(unittest.TestCase):
+
+    def setUp(self):
+        self.client = TestClient()
+
+    def test_wrong_version(self):
+        # include_prerelease is required due the suffix -dev
+        required_version = ">=10.0.0,include_prerelease=True"
+        self.client.run("config set general.required_conan_version={}".format(required_version))
+        self.client.run("help")
+        self.assertIn("WARN: The current Conan version ({}) "
+                      "does not match to the required version ({})."
+                      .format(client_version, required_version), self.client.out)
+
+    def test_exact_version(self):
+        self.client.run("config set general.required_conan_version={}".format(client_version))
+        self.client.run("help")
+        self.assertNotIn("WARN", self.client.out)
+
+    def test_lesser_version(self):
+        self.client.run("config set general.required_conan_version=<3,include_prerelease=True")
+        self.client.run("help")
+        self.assertNotIn("WARN", self.client.out)
+
+    def test_greater_version(self):
+        self.client.run("config set general.required_conan_version=>0.1.0,include_prerelease=True")
+        self.client.run("help")
+        self.assertNotIn("WARN", self.client.out)
+
+    def test_bad_format(self):
+        required_version = "1.0.0.0-foobar"
+        self.client.run("config set general.required_conan_version={}".format(required_version))
+        self.client.run("help", assert_error=True)
+        self.assertIn("ERROR: version range expression '1.0.0.0-foobar' is not valid",
+                      self.client.out)

--- a/conans/test/functional/configuration/required_version_test.py
+++ b/conans/test/functional/configuration/required_version_test.py
@@ -15,12 +15,12 @@ class RequiredVersionTest(unittest.TestCase):
             client.run("help")
         self.assertIn("The current Conan version ({}) "
                       "does not match to the required version ({})."
-                      .format( "1.26.0", required_version), str(error.exception))
+                      .format("1.26.0", required_version), str(error.exception))
 
     @mock.patch("conans.client.conf.required_version.client_version", "1.22.0")
     def test_exact_version(self):
         client = TestClient()
-        client.run("config set general.required_conan_version={}".format("1.22.0"))
+        client.run("config set general.required_conan_version=1.22.0")
         client.run("help")
         self.assertNotIn("ERROR", client.out)
 
@@ -44,5 +44,5 @@ class RequiredVersionTest(unittest.TestCase):
         client.run("config set general.required_conan_version={}".format(required_version))
         with self.assertRaises(ConanException) as error:
             client.run("help", assert_error=True)
-        self.assertIn("version range expression '1.0.0.0-foobar' is not valid",
+        self.assertIn("The required version expression '{}' is not valid.".format(required_version),
                       str(error.exception))


### PR DESCRIPTION
The general configuration `required_conan_version` validates the current Conan client version to the required version.

If the current version is out of the range, a warning message
is displayed before executing any command.

Changelog: Feature: Configuration for checking the required Conan client version.
Docs: https://github.com/conan-io/docs/pull/1740

closes #7136

/cc @memsharded 

- [x] Refer to the issue that supports this Pull Request.
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [x] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 

<sup>**Note:** By default this PR will skip the slower tests and will use a limited set of python versions. Check [here](https://github.com/conan-io/conan/blob/develop/.github/PR_INCREASE_TESTING.md) how to increase the testing level by writing some tags in the current PR body text.</sup>
