### PR TITLE
different error msg for svn or git not in path

### DIFF
--- a/conans/client/tools/scm.py
+++ b/conans/client/tools/scm.py
@@ -15,8 +15,8 @@ from conans.util.runners import check_output_runner, version_runner, muted_runne
     pyinstaller_bundle_env_cleaned
 
 
-def _check_repo(cmd, folder, msg=None):
-    msg = msg or "Not a valid '{}' repository".format(cmd[0])
+def _check_repo(cmd, folder):
+    msg = "Not a valid '{0}' repository or '{0}' not found.".format(cmd[0])
     try:
         ret = muted_runner(cmd, folder=folder)
     except Exception:

--- a/conans/test/unittests/client/tools/scm/test_git.py
+++ b/conans/test/unittests/client/tools/scm/test_git.py
@@ -394,11 +394,10 @@ class GitToolsTests(unittest.TestCase):
         self.assertIsNone(tag)
 
     def test_get_tag_no_git_repo(self):
-        """
-        Try to get tag out of a git repo
-        """
+        # Try to get tag out of a git repo
         git = Git(folder=temp_folder())
-        with six.assertRaisesRegex(self, ConanException, "Not a valid 'git' repository"):
+        with six.assertRaisesRegex(self, ConanException,
+                                   "Not a valid 'git' repository or 'git' not found"):
             git.get_tag()
 
     def test_excluded_files(self):
@@ -406,4 +405,5 @@ class GitToolsTests(unittest.TestCase):
         save(os.path.join(folder, "file"), "some contents")
         git = Git(folder)
         with tools.environment_append({"PATH": ""}):
-            git.excluded_files()
+            excluded = git.excluded_files()
+            self.assertEqual(excluded, [])


### PR DESCRIPTION
Changelog: Fix: Improve error message when svn or git are not in the installed or in the path.
Docs: Omit

Close https://github.com/conan-io/conan/issues/7191