### PR TITLE
renaming new cmake build helper for toolchain

### DIFF
--- a/conans/__init__.py
+++ b/conans/__init__.py
@@ -2,6 +2,7 @@
 # to allow refactors
 from conans.client.build.autotools_environment import AutoToolsBuildEnvironment
 from conans.client.build.cmake import CMake
+from conans.client.build.cmake_toolchain_build_helper import CMakeCmd
 from conans.client.toolchain.cmake import CMakeToolchain
 from conans.client.build.meson import Meson
 from conans.client.build.msbuild import MSBuild

--- a/conans/client/build/cmake.py
+++ b/conans/client/build/cmake.py
@@ -22,21 +22,7 @@ from conans.util.files import mkdir, get_abs_path, walk, decode_text
 from conans.util.runners import version_runner
 
 
-def CMake(conanfile, *args, **kwargs):
-    from conans import ConanFile
-    if not isinstance(conanfile, ConanFile):
-        raise ConanException("First argument of CMake() has to be ConanFile. Use CMake(self)")
-
-    # If there is a toolchain, then use the toolchain helper one
-    toolchain = getattr(conanfile, "toolchain", None)
-    if toolchain:
-        from conans.client.build.cmake_toolchain_build_helper import CMakeToolchainBuildHelper
-        return CMakeToolchainBuildHelper(conanfile, *args, **kwargs)
-    else:
-        return CMakeBuildHelper(conanfile, *args, **kwargs)
-
-
-class CMakeBuildHelper(object):
+class CMake(object):
 
     def __init__(self, conanfile, generator=None, cmake_system_name=True,
                  parallel=True, build_type=None, toolset=None, make_program=None,
@@ -446,6 +432,3 @@ class CMakeBuildHelper(object):
             return Version(version_str)
         except Exception as e:
             raise ConanException("Error retrieving CMake version: '{}'".format(e))
-
-
-CMake.get_version = CMakeBuildHelper.get_version

--- a/conans/client/build/cmake_toolchain_build_helper.py
+++ b/conans/client/build/cmake_toolchain_build_helper.py
@@ -36,7 +36,7 @@ def _compute_build_flags(conanfile, generator, parallel, msbuild_verbosity):
     return args
 
 
-class CMakeToolchainBuildHelper(object):
+class CMakeCmd(object):
     """ CMake helper to use together with the toolchain feature. It implements a very simple
     wrapper to call the cmake executable, but without passing compile flags, preprocessor
     definitions... all that is set by the toolchain. Only the generator and the CMAKE_TOOLCHAIN_FILE

--- a/conans/test/functional/build_helpers/cmake_flags_test.py
+++ b/conans/test/functional/build_helpers/cmake_flags_test.py
@@ -7,7 +7,7 @@ from textwrap import dedent
 from nose.plugins.attrib import attr
 from parameterized.parameterized import parameterized
 
-from conans.client.build.cmake import CMakeBuildHelper
+from conans.client.build.cmake import CMake
 from conans.model.version import Version
 from conans.test.utils.deprecation import catch_deprecation_warning
 from conans.test.utils.tools import TestClient
@@ -404,7 +404,7 @@ conan_set_std()
 
         def conan_set_std_branch():
             # Replicate logic from cmake_common definition of 'macro(conan_set_std)'
-            cmake_version = CMakeBuildHelper.get_version()
+            cmake_version = CMake.get_version()
             return cmake_version < Version("3.12")
 
         with catch_deprecation_warning(self):

--- a/conans/test/functional/build_helpers/cmake_test.py
+++ b/conans/test/functional/build_helpers/cmake_test.py
@@ -5,7 +5,7 @@ import unittest
 from conans.test.utils.tools import TestClient
 
 
-class CMakeBuildHelper(unittest.TestCase):
+class CMakeBuildHelperTest(unittest.TestCase):
     def get_version_test(self):
         client = TestClient()
         conanfile = textwrap.dedent("""
@@ -17,3 +17,19 @@ class CMakeBuildHelper(unittest.TestCase):
         client.save({"conanfile.py": conanfile})
         client.run("create . pkg/0.1@user/testing")
         self.assertIn("CMAKE_VERSION: 3", client.out)
+
+    def test_inheriting_cmake_build_helper(self):
+        # https://github.com/conan-io/conan/issues/7196
+        base = textwrap.dedent("""
+            import conans
+
+            class CMake(conans.CMake):
+                pass
+
+            class BaseConanFile(conans.ConanFile):
+                pass
+            """)
+        client = TestClient()
+        client.save({"conanfile.py": base})
+        client.run("export . pkg/0.1@")
+        self.assertIn("pkg/0.1: Exported revision", client.out)

--- a/conans/test/functional/py_requires/python_requires_test.py
+++ b/conans/test/functional/py_requires/python_requires_test.py
@@ -155,11 +155,11 @@ class PyRequiresExtendTest(unittest.TestCase):
         self.assertIn("'base' is not a python_require", client.out)
 
         conanfile = textwrap.dedent("""
-                    from conans import ConanFile
-                    class Pkg(ConanFile):
-                        python_requires = "helper/1.0@user/channel"
-                        python_requires_extend = "base.HelloConan"
-                    """)
+            from conans import ConanFile
+            class Pkg(ConanFile):
+                python_requires = "helper/1.0@user/channel"
+                python_requires_extend = "base.HelloConan"
+            """)
         client.save({"conanfile.py": conanfile})
         client.run("create . pkg/0.1@user/channel", assert_error=True)
         self.assertIn("'base' is not a python_require", client.out)

--- a/conans/test/functional/toolchain/test_basic.py
+++ b/conans/test/functional/toolchain/test_basic.py
@@ -41,11 +41,11 @@ class BasicTest(unittest.TestCase):
 
     def test_declarative_new_helper(self):
         conanfile = textwrap.dedent("""
-            from conans import ConanFile, CMake
+            from conans import ConanFile, CMakeCmd
             class Pkg(ConanFile):
                 toolchain = "cmake"
                 def build(self):
-                    cmake = CMake(self)
+                    cmake = CMakeCmd(self)
                     cmake.configure()
             """)
         client = TestClient()

--- a/conans/test/functional/toolchain/test_cmake.py
+++ b/conans/test/functional/toolchain/test_cmake.py
@@ -16,7 +16,7 @@ from conans.test.utils.tools import TestClient
 class Base(unittest.TestCase):
 
     conanfile = textwrap.dedent("""
-        from conans import ConanFile, CMake, CMakeToolchain
+        from conans import ConanFile, CMakeCmd, CMakeToolchain
 
         class App(ConanFile):
             settings = "os", "arch", "compiler", "build_type"
@@ -33,7 +33,7 @@ class Base(unittest.TestCase):
                 return tc
 
             def build(self):
-                cmake = CMake(self)
+                cmake = CMakeCmd(self)
                 cmake.configure()
                 cmake.build()
         """)
@@ -331,7 +331,7 @@ class CMakeInstallTest(unittest.TestCase):
 
     def test_install(self):
         conanfile = textwrap.dedent("""
-            from conans import ConanFile, CMake, CMakeToolchain
+            from conans import ConanFile, CMakeCmd, CMakeToolchain
 
             class App(ConanFile):
                 settings = "os", "arch", "compiler", "build_type"
@@ -341,11 +341,11 @@ class CMakeInstallTest(unittest.TestCase):
                     return CMakeToolchain(self)
 
                 def build(self):
-                    cmake = CMake(self)
+                    cmake = CMakeCmd(self)
                     cmake.configure()
 
                 def package(self):
-                    cmake = CMake(self)
+                    cmake = CMakeCmd(self)
                     cmake.install()
             """)
 


### PR DESCRIPTION
Changelog: Bugfix: Rename new toolchain build helper to ``CMakeCmd`` to allow inheritance
Docs: https://github.com/conan-io/docs/pull/XXXX

Fix https://github.com/conan-io/conan/issues/7196

#tags: slow
