### PR TITLE
Make 'conans.CMake' a class again

### DIFF
--- a/conans/client/build/cmake.py
+++ b/conans/client/build/cmake.py
@@ -45,6 +45,11 @@ class CMake(object):
     def __init__(self, *args, **kwargs):
         super(CMake, self).__init__(*args, **kwargs)
 
+    @staticmethod
+    def get_version():
+        # FIXME: Conan 2.0 This function is require for python2
+        return CMakeBuildHelper.get_version()
+
 
 class CMakeBuildHelper(object):
 
@@ -456,6 +461,3 @@ class CMakeBuildHelper(object):
             return Version(version_str)
         except Exception as e:
             raise ConanException("Error retrieving CMake version: '{}'".format(e))
-
-
-CMake.get_version = CMakeBuildHelper.get_version

--- a/conans/client/build/cmake.py
+++ b/conans/client/build/cmake.py
@@ -22,18 +22,28 @@ from conans.util.files import mkdir, get_abs_path, walk, decode_text
 from conans.util.runners import version_runner
 
 
-def CMake(conanfile, *args, **kwargs):
-    from conans import ConanFile
-    if not isinstance(conanfile, ConanFile):
-        raise ConanException("First argument of CMake() has to be ConanFile. Use CMake(self)")
+class CMake(object):
+    def __new__(cls, conanfile, *args, **kwargs):
+        """ Inject the proper CMake base class in the hierarchy """
+        from conans import ConanFile
+        if not isinstance(conanfile, ConanFile):
+            raise ConanException("First argument of CMake() has to be ConanFile. Use CMake(self)")
 
-    # If there is a toolchain, then use the toolchain helper one
-    toolchain = getattr(conanfile, "toolchain", None)
-    if toolchain:
+        # If already injected, create and return
         from conans.client.build.cmake_toolchain_build_helper import CMakeToolchainBuildHelper
-        return CMakeToolchainBuildHelper(conanfile, *args, **kwargs)
-    else:
-        return CMakeBuildHelper(conanfile, *args, **kwargs)
+        if CMakeToolchainBuildHelper in cls.__bases__ or CMakeBuildHelper in cls.__bases__:
+            return super(CMake, cls).__new__(cls)
+
+        # If not, add the proper CMake implementation
+        if hasattr(conanfile, "toolchain"):
+            CustomCMakeClass = type("CustomCMakeClass", (cls, CMakeToolchainBuildHelper), {})
+        else:
+            CustomCMakeClass = type("CustomCMakeClass", (cls, CMakeBuildHelper), {})
+
+        return CustomCMakeClass.__new__(CustomCMakeClass, conanfile, *args, **kwargs)
+
+    def __init__(self, *args, **kwargs):
+        super(CMake, self).__init__(*args, **kwargs)
 
 
 class CMakeBuildHelper(object):

--- a/conans/test/functional/build_helpers/cmake_test.py
+++ b/conans/test/functional/build_helpers/cmake_test.py
@@ -5,28 +5,75 @@ from conans.test.utils.tools import TestClient
 
 
 class CMakeBuildHelper(unittest.TestCase):
-    def get_version_test(self):
+    def test_get_version_no_toolchain(self):
         client = TestClient()
         conanfile = textwrap.dedent("""
         from conans import ConanFile, CMake
         class Pkg(ConanFile):
             def build(self):
                 self.output.info("CMAKE_VERSION: %s" % CMake.get_version())
+                cmake = CMake(self)
+                self.output.info("CMAKE_VERSION (obj): %s" % cmake.get_version())
         """)
         client.save({"conanfile.py": conanfile})
         client.run("create . pkg/0.1@user/testing")
         self.assertIn("CMAKE_VERSION: 3", client.out)
+        self.assertIn("CMAKE_VERSION (obj): 3", client.out)
 
-    def test_inheriting_cmake_build_helper(self):
+    def test_get_version_toolchain(self):
+        client = TestClient()
+        conanfile = textwrap.dedent("""
+        from conans import ConanFile, CMake
+        class Pkg(ConanFile):
+            toolchain = "cmake"
+
+            def build(self):
+                self.output.info("CMAKE_VERSION: %s" % CMake.get_version())
+                cmake = CMake(self)
+                self.output.info("CMAKE_VERSION (obj): %s" % cmake.get_version())
+        """)
+        client.save({"conanfile.py": conanfile})
+        client.run("create . pkg/0.1@user/testing")
+        self.assertIn("CMAKE_VERSION: 3", client.out)
+        self.assertIn("CMAKE_VERSION (obj): 3", client.out)
+
+    def test_inheriting_cmake_build_helper_no_toolchain(self):
         # https://github.com/conan-io/conan/issues/7196
         base = textwrap.dedent("""
             import conans
             class CMake(conans.CMake):
                 pass
             class BaseConanFile(conans.ConanFile):
-                pass
-            """)
+                def build(self):
+                    self.output.info("CMAKE_VERSION: %s" % conans.CMake.get_version())
+                    cmake = CMake(self)
+                    self.output.info("CMAKE_VERSION (obj): %s" % cmake.get_version())
+        """)
+
         client = TestClient()
         client.save({"conanfile.py": base})
-        client.run("export . pkg/0.1@")
+        client.run("create . pkg/0.1@")
         self.assertIn("pkg/0.1: Exported revision", client.out)
+        self.assertIn("CMAKE_VERSION: 3", client.out)
+        self.assertIn("CMAKE_VERSION (obj): 3", client.out)
+
+    def test_inheriting_cmake_build_helper_toolchain(self):
+        # https://github.com/conan-io/conan/issues/7196
+        base = textwrap.dedent("""
+            import conans
+            class CMake(conans.CMake):
+                pass
+            class BaseConanFile(conans.ConanFile):
+                toolchain = "cmake"
+                def build(self):
+                    self.output.info("CMAKE_VERSION: %s" % conans.CMake.get_version())
+                    cmake = CMake(self)
+                    self.output.info("CMAKE_VERSION (obj): %s" % cmake.get_version())
+        """)
+
+        client = TestClient()
+        client.save({"conanfile.py": base})
+        client.run("create . pkg/0.1@")
+        self.assertIn("pkg/0.1: Exported revision", client.out)
+        self.assertIn("CMAKE_VERSION: 3", client.out)
+        self.assertIn("CMAKE_VERSION (obj): 3", client.out)

--- a/conans/test/functional/build_helpers/cmake_test.py
+++ b/conans/test/functional/build_helpers/cmake_test.py
@@ -1,7 +1,6 @@
 import textwrap
 import unittest
 
-
 from conans.test.utils.tools import TestClient
 
 
@@ -17,3 +16,17 @@ class CMakeBuildHelper(unittest.TestCase):
         client.save({"conanfile.py": conanfile})
         client.run("create . pkg/0.1@user/testing")
         self.assertIn("CMAKE_VERSION: 3", client.out)
+
+    def test_inheriting_cmake_build_helper(self):
+        # https://github.com/conan-io/conan/issues/7196
+        base = textwrap.dedent("""
+            import conans
+            class CMake(conans.CMake):
+                pass
+            class BaseConanFile(conans.ConanFile):
+                pass
+            """)
+        client = TestClient()
+        client.save({"conanfile.py": base})
+        client.run("export . pkg/0.1@")
+        self.assertIn("pkg/0.1: Exported revision", client.out)


### PR DESCRIPTION
Changelog: omit
Docs: omit

Fix #7196
Closes #7198

Implements a factory-like method using class `__new__` function... just because Conan 2.0 will remove this trick

![image](https://camo.githubusercontent.com/2325bce4a0a457fdc21f5c429de439d4de0cf953/68747470733a2f2f6d65646961312e74656e6f722e636f6d2f696d616765732f64383230343831656631346231636432613136666634653736363064656235662f74656e6f722e6769663f6974656d69643d39323339353539)

#tags: slow

