### PR TITLE
Added support for template dir in `conan new`

### DIFF
--- a/conans/client/cmd/new.py
+++ b/conans/client/cmd/new.py
@@ -254,7 +254,7 @@ def _get_files_from_template_dir(template_dir, name, version, package_name):
         for f in fs:
             rel_d = os.path.relpath(d, template_dir)
             rel_f = os.path.join(rel_d, f)
-            files += [rel_f]
+            files.append(rel_f)
 
     out_files = dict()
     for f in files:

--- a/conans/client/cmd/new.py
+++ b/conans/client/cmd/new.py
@@ -246,8 +246,9 @@ def _render_template(text, name, version, package_name):
     return t.render(**context)
 
 def _get_files_from_template_dir(template_dir, name, version, package_name):
-    if not os.path.isfile(os.path.join(template_dir, "conanfile.py")):
-        raise ConanException("Template is missing 'conanfile.py': {}".format(template_dir))
+    if (not os.path.isfile(os.path.join(template_dir, "conanfile.py")) 
+        and not os.path.isfile(os.path.join(template_dir, "conanfile.txt"))):
+        raise ConanException("Template is missing a recipe file: {}".format(template_dir))
 
     files = []
     for d, _, fs in os.walk(template_dir):
@@ -292,9 +293,9 @@ def cmd_new(ref, header=False, pure_c=False, test=False, exports_sources=False, 
         raise ConanException("'pure_c' is incompatible with 'header' and 'sources'")
     if bare and (header or exports_sources):
         raise ConanException("'bare' is incompatible with 'header' and 'sources'")
-    if template and (header or exports_sources or bare):
+    if template and (header or exports_sources or bare or pure_c):
         raise ConanException("'template' is incompatible with 'header', "
-                             "'sources', and 'bare'")
+                             "'sources', 'pure-c' and 'bare'")
 
     if header:
         files = {"conanfile.py": conanfile_header.format(name=name, version=version,
@@ -312,6 +313,7 @@ def cmd_new(ref, header=False, pure_c=False, test=False, exports_sources=False, 
         is_file_template = os.path.basename(template).endswith('.py')
         if is_file_template:
             if not os.path.isabs(template):
+                # FIXME: Conan 2.0. The old path should be removed
                 old_path = os.path.join(cache.cache_folder, "templates", template)
                 new_path = os.path.join(cache.cache_folder, "templates", "cmd_new", template)
                 template = new_path if os.path.isfile(new_path) else old_path

--- a/conans/client/cmd/new.py
+++ b/conans/client/cmd/new.py
@@ -259,8 +259,6 @@ def _get_files_from_template_dir(template_dir, name, version, package_name):
     out_files = dict()
     for f in files:
         f_path = os.path.join(template_dir, f)
-        if not os.path.isfile(f_path):
-            continue
         rendered_path = _render_template(f, name=name, version=version, package_name=package_name)
         rendered_file = _render_template(load(f_path), name=name, version=version, package_name=package_name)
         out_files[rendered_path] = rendered_file

--- a/conans/client/cmd/new.py
+++ b/conans/client/cmd/new.py
@@ -3,6 +3,7 @@ import re
 
 from jinja2 import Template
 
+from conans import __version__ as client_version
 from conans.client.cmd.new_ci import ci_get_files
 from conans.errors import ConanException
 from conans.model.ref import ConanFileReference
@@ -236,11 +237,17 @@ test_package/build
 
 """
 
+def _render_template(text, name, version, package_name):
+    context = {'name': name, 
+               'version': version, 
+               'package_name': package_name,
+               'conan_version': client_version}
+    t = Template(text, keep_trailing_newline=True)
+    return t.render(**context)
+
 def _get_files_from_template_dir(template_dir, name, version, package_name):
     if not os.path.isfile(os.path.join(template_dir, "conanfile.py")):
         raise ConanException("Template is missing 'conanfile.py': {}".format(template_dir))
-
-    render_args = {'name': name, 'version': version, 'package_name': package_name}
 
     files = []
     for d, _, fs in os.walk(template_dir):
@@ -254,10 +261,8 @@ def _get_files_from_template_dir(template_dir, name, version, package_name):
         f_path = os.path.join(template_dir, f)
         if not os.path.isfile(f_path):
             continue
-        t = Template(f, keep_trailing_newline=True)
-        rendered_path = t.render(**render_args)
-        t = Template(load(f_path), keep_trailing_newline=True)
-        rendered_file = t.render(**render_args)
+        rendered_path = _render_template(f, name=name, version=version, package_name=package_name)
+        rendered_file = _render_template(load(f_path), name=name, version=version, package_name=package_name)
         out_files[rendered_path] = rendered_file
 
     return out_files
@@ -289,10 +294,8 @@ def cmd_new(ref, header=False, pure_c=False, test=False, exports_sources=False, 
         raise ConanException("'pure_c' is incompatible with 'header' and 'sources'")
     if bare and (header or exports_sources):
         raise ConanException("'bare' is incompatible with 'header' and 'sources'")
-    if template and template_dir:
-        raise ConanException("'template' and 'template_dir' are incompatible options")
-    if (template or template_dir) and (header or exports_sources or bare):
-        raise ConanException("'template' and 'template-dir' arguments are incompatible with 'header', "
+    if template and (header or exports_sources or bare):
+        raise ConanException("'template' is incompatible with 'header', "
                              "'sources', and 'bare'")
 
     if header:
@@ -308,25 +311,29 @@ def cmd_new(ref, header=False, pure_c=False, test=False, exports_sources=False, 
         files = {"conanfile.py": conanfile_bare.format(name=name, version=version,
                                                        package_name=package_name)}
     elif template:
-        if not os.path.isabs(template):
-            template = os.path.join(cache.cache_folder, "templates", template)
-        if not os.path.isfile(template):
-            raise ConanException("Template doesn't exist: %s" % template)
-        conanfile_template = load(template)
-        t = Template(conanfile_template)
-        replaced = t.render(name=name, version=version, package_name=package_name)
-        files = {"conanfile.py": replaced}
-    elif template_dir:
-        if not os.path.isabs(template_dir):
-            template_dir = os.path.join(cache.cache_folder, "templates", template_dir)
-        if not os.path.isdir(template_dir):
-            raise ConanException("Template directory doesn't exist: {}".format(template_dir))
-        template_dir = os.path.normpath(template_dir)
-
-        files = _get_files_from_template_dir(template_dir=template_dir,
-                                             name=name,
-                                             version=version,
-                                             package_name=package_name)
+        is_file_template = os.path.basename(template).endswith('.py')
+        if is_file_template:
+            if not os.path.isabs(template):
+                old_path = os.path.join(cache.cache_folder, "templates", template)
+                new_path = os.path.join(cache.cache_folder, "templates", "cmd_new", template)
+                template = new_path if os.path.isfile(new_path) else old_path
+            if not os.path.isfile(template):
+                raise ConanException("Template doesn't exist: %s" % template)
+            replaced = _render_template(load(template), 
+                                        name=name, 
+                                        version=version, 
+                                        package_name=package_name)
+            files = {"conanfile.py": replaced}
+        else:
+            if not os.path.isabs(template):
+                template = os.path.join(cache.cache_folder, "templates", "cmd_new", template)
+            if not os.path.isdir(template):
+                raise ConanException("Template doesn't exist: {}".format(template))
+            template = os.path.normpath(template)
+            files = _get_files_from_template_dir(template_dir=template,
+                                                 name=name,
+                                                 version=version,
+                                                 package_name=package_name)
     else:
         files = {"conanfile.py": conanfile.format(name=name, version=version,
                                                   package_name=package_name)}

--- a/conans/client/cmd/new.py
+++ b/conans/client/cmd/new.py
@@ -315,7 +315,7 @@ def cmd_new(ref, header=False, pure_c=False, test=False, exports_sources=False, 
             if not os.path.isabs(template):
                 # FIXME: Conan 2.0. The old path should be removed
                 old_path = os.path.join(cache.cache_folder, "templates", template)
-                new_path = os.path.join(cache.cache_folder, "templates", "cmd_new", template)
+                new_path = os.path.join(cache.cache_folder, "templates", "command/new", template)
                 template = new_path if os.path.isfile(new_path) else old_path
             if not os.path.isfile(template):
                 raise ConanException("Template doesn't exist: %s" % template)
@@ -326,7 +326,7 @@ def cmd_new(ref, header=False, pure_c=False, test=False, exports_sources=False, 
             files = {"conanfile.py": replaced}
         else:
             if not os.path.isabs(template):
-                template = os.path.join(cache.cache_folder, "templates", "cmd_new", template)
+                template = os.path.join(cache.cache_folder, "templates", "command/new", template)
             if not os.path.isdir(template):
                 raise ConanException("Template doesn't exist: {}".format(template))
             template = os.path.normpath(template)

--- a/conans/client/cmd/new.py
+++ b/conans/client/cmd/new.py
@@ -271,7 +271,7 @@ def cmd_new(ref, header=False, pure_c=False, test=False, exports_sources=False, 
             osx_clang_versions=None, shared=None, upload_url=None, gitignore=None,
             gitlab_gcc_versions=None, gitlab_clang_versions=None,
             circleci_gcc_versions=None, circleci_clang_versions=None, circleci_osx_versions=None,
-            template=None, template_dir=None, cache=None):
+            template=None, cache=None):
     try:
         tokens = ref.split("@")
         name, version = tokens[0].split("/")

--- a/conans/client/command.py
+++ b/conans/client/command.py
@@ -171,9 +171,9 @@ class Command(object):
                                  'the "source()" method')
         parser.add_argument("-b", "--bare", action='store_true', default=False,
                             help='Create the minimum package recipe, without build() method. '
-                            'Useful in combination with "export-pkg" command')        
+                            'Useful in combination with "export-pkg" command')
         parser.add_argument("-m", "--template",
-                            help='Use the given template for conanfile.py')
+                            help='Use the given template to generate a conan project')
         parser.add_argument("-cis", "--ci-shared", action='store_true',
                             default=False,
                             help='Package will have a "shared" option to be used in CI')

--- a/conans/client/command.py
+++ b/conans/client/command.py
@@ -224,9 +224,7 @@ class Command(object):
                         circleci_gcc_versions=args.ci_circleci_gcc,
                         circleci_clang_versions=args.ci_circleci_clang,
                         circleci_osx_versions=args.ci_circleci_osx,
-                        template=args.template,
-                        template_dir=args.template_dir
-                        )
+                        template=args.template)
 
     def inspect(self, *args):
         """

--- a/conans/client/command.py
+++ b/conans/client/command.py
@@ -173,7 +173,7 @@ class Command(object):
                             help='Create the minimum package recipe, without build() method. '
                             'Useful in combination with "export-pkg" command')        
         parser.add_argument("-m", "--template",
-                            help='Use the given template from the local cache for conanfile.py')
+                            help='Use the given template for conanfile.py')
         parser.add_argument("-cis", "--ci-shared", action='store_true',
                             default=False,
                             help='Package will have a "shared" option to be used in CI')

--- a/conans/client/command.py
+++ b/conans/client/command.py
@@ -171,12 +171,9 @@ class Command(object):
                                  'the "source()" method')
         parser.add_argument("-b", "--bare", action='store_true', default=False,
                             help='Create the minimum package recipe, without build() method. '
-                            'Useful in combination with "export-pkg" command')
-        template_args = parser.add_mutually_exclusive_group()
-        template_args.add_argument("-m", "--template",
-                                   help='Use the given template from the local cache for conanfile.py')
-        template_args.add_argument("-md", "--template-dir",
-                                   help='Use the given template directory from the local cache to generate a conan project')
+                            'Useful in combination with "export-pkg" command')        
+        parser.add_argument("-m", "--template",
+                            help='Use the given template from the local cache for conanfile.py')
         parser.add_argument("-cis", "--ci-shared", action='store_true',
                             default=False,
                             help='Package will have a "shared" option to be used in CI')

--- a/conans/client/command.py
+++ b/conans/client/command.py
@@ -172,8 +172,11 @@ class Command(object):
         parser.add_argument("-b", "--bare", action='store_true', default=False,
                             help='Create the minimum package recipe, without build() method. '
                             'Useful in combination with "export-pkg" command')
-        parser.add_argument("-m", "--template",
-                            help='Use the given template from the local cache for conanfile.py')
+        template_args = parser.add_mutually_exclusive_group()
+        template_args.add_argument("-m", "--template",
+                                   help='Use the given template from the local cache for conanfile.py')
+        template_args.add_argument("-md", "--template-dir",
+                                   help='Use the given template directory from the local cache to generate a conan project')
         parser.add_argument("-cis", "--ci-shared", action='store_true',
                             default=False,
                             help='Package will have a "shared" option to be used in CI')
@@ -224,7 +227,9 @@ class Command(object):
                         circleci_gcc_versions=args.ci_circleci_gcc,
                         circleci_clang_versions=args.ci_circleci_clang,
                         circleci_osx_versions=args.ci_circleci_osx,
-                        template=args.template)
+                        template=args.template,
+                        template_dir=args.template_dir
+                        )
 
     def inspect(self, *args):
         """

--- a/conans/client/conan_api.py
+++ b/conans/client/conan_api.py
@@ -249,7 +249,7 @@ class ConanAPIV1(object):
             osx_clang_versions=None, shared=None, upload_url=None, gitignore=None,
             gitlab_gcc_versions=None, gitlab_clang_versions=None,
             circleci_gcc_versions=None, circleci_clang_versions=None, circleci_osx_versions=None,
-            template=None):
+            template=None, template_dir=None):
         from conans.client.cmd.new import cmd_new
         cwd = os.path.abspath(cwd or get_cwd())
         files = cmd_new(name, header=header, pure_c=pure_c, test=test,
@@ -264,7 +264,8 @@ class ConanAPIV1(object):
                         circleci_gcc_versions=circleci_gcc_versions,
                         circleci_clang_versions=circleci_clang_versions,
                         circleci_osx_versions=circleci_osx_versions,
-                        template=template, cache=self.app.cache)
+                        template=template, template_dir=template_dir, 
+                        cache=self.app.cache)
 
         save_files(cwd, files)
         for f in sorted(files):

--- a/conans/client/conan_api.py
+++ b/conans/client/conan_api.py
@@ -249,7 +249,7 @@ class ConanAPIV1(object):
             osx_clang_versions=None, shared=None, upload_url=None, gitignore=None,
             gitlab_gcc_versions=None, gitlab_clang_versions=None,
             circleci_gcc_versions=None, circleci_clang_versions=None, circleci_osx_versions=None,
-            template=None, template_dir=None):
+            template=None):
         from conans.client.cmd.new import cmd_new
         cwd = os.path.abspath(cwd or get_cwd())
         files = cmd_new(name, header=header, pure_c=pure_c, test=test,
@@ -264,8 +264,7 @@ class ConanAPIV1(object):
                         circleci_gcc_versions=circleci_gcc_versions,
                         circleci_clang_versions=circleci_clang_versions,
                         circleci_osx_versions=circleci_osx_versions,
-                        template=template, template_dir=template_dir, 
-                        cache=self.app.cache)
+                        template=template, cache=self.app.cache)
 
         save_files(cwd, files)
         for f in sorted(files):

--- a/conans/test/functional/command/new_test.py
+++ b/conans/test/functional/command/new_test.py
@@ -31,7 +31,7 @@ class NewCommandTest(unittest.TestCase):
 
     def template_dir_test(self):
         client = TestClient()
-        template_dir = "templates/cmd_new/t_dir"
+        template_dir = "templates/command/new/t_dir"
         template_recipe = textwrap.dedent("""
             class {{package_name}}Conan(ConanFile):
                 name = "{{name}}"

--- a/conans/test/functional/command/new_test.py
+++ b/conans/test/functional/command/new_test.py
@@ -4,6 +4,7 @@ import unittest
 
 from parameterized import parameterized
 
+from conans import __version__ as client_version
 from conans.test.utils.test_files import temp_folder
 from conans.test.utils.tools import TestClient
 from conans.tools import save
@@ -18,6 +19,7 @@ class NewCommandTest(unittest.TestCase):
             class {{package_name}}Conan(ConanFile):
                 name = "{{name}}"
                 version = "{{version}}"
+                conan_version = "{{conan_version}}"
         """)
         save(os.path.join(client.cache_folder, "templates/mytemplate.py"), template1)
         client.run("new hello/0.1 --template=mytemplate.py")
@@ -25,14 +27,16 @@ class NewCommandTest(unittest.TestCase):
         self.assertIn("class HelloConan(ConanFile):", conanfile)
         self.assertIn('name = "hello"', conanfile)
         self.assertIn('version = "0.1"', conanfile)
+        self.assertIn('conan_version = "{}"'.format(client_version), conanfile)
 
     def template_dir_test(self):
         client = TestClient()
-        template_dir = "templates/t_dir"
+        template_dir = "templates/cmd_new/t_dir"
         template_recipe = textwrap.dedent("""
             class {{package_name}}Conan(ConanFile):
                 name = "{{name}}"
                 version = "{{version}}"
+                conan_version = "{{conan_version}}"
         """)
         save(os.path.join(client.cache_folder, template_dir + "/conanfile.py"), template_recipe)
 
@@ -40,19 +44,22 @@ class NewCommandTest(unittest.TestCase):
             package_name={{package_name}}
             name={{name}}
             version={{version}}
+            conan_version={{conan_version}}
         """)
         save(os.path.join(client.cache_folder, template_dir + "/{{name}}/hello.txt"), template_txt)
 
-        client.run("new hello/0.1 --template-dir=t_dir")
+        client.run("new hello/0.1 --template=t_dir")
         conanfile = client.load("conanfile.py")
         self.assertIn("class HelloConan(ConanFile):", conanfile)
         self.assertIn('name = "hello"', conanfile)
         self.assertIn('version = "0.1"', conanfile)
+        self.assertIn('conan_version = "{}"'.format(client_version), conanfile)
 
         hellotxt = client.load("hello/hello.txt")
         self.assertIn("package_name=Hello", hellotxt)
         self.assertIn("name=hello", hellotxt)
-        self.assertIn("version=0.1", hellotxt)
+        self.assertIn('version=0.1', hellotxt)
+        self.assertIn("conan_version={}".format(client_version), hellotxt)
 
     def template_test_package_test(self):
         client = TestClient()
@@ -85,18 +92,11 @@ class NewCommandTest(unittest.TestCase):
         client = TestClient()
         client.run("new hello/0.1 -m=mytemplate.py", assert_error=True)
         self.assertIn("ERROR: Template doesn't exist", client.out)
+        client.run("new hello/0.1 -m=mytemplate", assert_error=True)
+        self.assertIn("ERROR: Template doesn't exist", client.out)
         client.run("new hello/0.1 --template=mytemplate.py --bare", assert_error=True)
-        self.assertIn("ERROR: 'template' and 'template-dir' arguments are incompatible", client.out)
+        self.assertIn("ERROR: 'template' is incompatible", client.out)
         client.run("new hello/0.1 --template", assert_error=True)
-        self.assertIn("ERROR: Exiting with code: 2", client.out)
-
-    def template_dir_errors_test(self):
-        client = TestClient()
-        client.run("new hello/0.1 -md=mytemplate", assert_error=True)
-        self.assertIn("ERROR: Template directory doesn't exist", client.out)
-        client.run("new hello/0.1 --template-dir=mytemplate --bare", assert_error=True)
-        self.assertIn("ERROR: 'template' and 'template-dir' arguments are incompatible", client.out)
-        client.run("new hello/0.1 --template-dir", assert_error=True)
         self.assertIn("ERROR: Exiting with code: 2", client.out)
 
     def new_test(self):


### PR DESCRIPTION
Changelog: Feature: Added support for template dir in `conan new`.
Docs: https://github.com/conan-io/docs/pull/1752

Implements/Fixes #6346 

Added a new `--template-dir` argument to `conan new`.

Usage:
```
conan new [-md TEMPLATE_DIR, --template-dir TEMPLATE_DIR] name
```

```
--template-dir    Use the given template directory from the local cache to generate a conan project
```

Template directory functions similarly to `--template TEMPLATE`, but takes directory as input instead. All files in this directory, their paths and names are processed via jinja.

- [x] Refer to the issue that supports this Pull Request.
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [x] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 

<sup>**Note:** By default this PR will skip the slower tests and will use a limited set of python versions. Check [here](https://github.com/conan-io/conan/blob/develop/.github/PR_INCREASE_TESTING.md) how to increase the testing level by writing some tags in the current PR body text.</sup>
