### PR TITLE
Add Pop!_OS to the list of APT based distros

### DIFF
--- a/conans/client/tools/oss.py
+++ b/conans/client/tools/oss.py
@@ -178,7 +178,7 @@ class OSInfo(object):
 
     @property
     def with_apt(self):
-        apt_distros = ("debian", "ubuntu", "knoppix", "linuxmint", "raspbian", "neon")
+        apt_distros = ("debian", "ubuntu", "knoppix", "linuxmint", "raspbian", "neon", "pop")
         return self.is_linux and self.linux_distro in apt_distros
 
     @property


### PR DESCRIPTION
Changelog: Feature: Add Pop!_OS to the list of APT based distributions.
Docs: Omit

There is no documentation about `tools.os_info.with_apt` as far as I can see?

https://pop.system76.com/

- [x] Refer to the issue that supports this Pull Request
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 

<sup>**Note:** By default this PR will skip the slower tests and will use a limited set of python versions. Check [here](https://github.com/conan-io/conan/blob/develop/.github/PR_INCREASE_TESTING.md) how to increase the testing level by writing some tags in the current PR body text.</sup>

______

Fixes https://github.com/conan-io/conan-center-index/issues/1995

![Screenshot_20200622_232231](https://user-images.githubusercontent.com/1593194/85340480-78c6e580-b4e6-11ea-9120-8e2a9db07122.png)

![Screenshot_20200623_000214](https://user-images.githubusercontent.com/1593194/85340490-7d8b9980-b4e6-11ea-9328-f489c9a3b4ff.png)




