### PR TITLE
Bugfix: Added support for '.' in pkg_name for python_requires_extend

### DIFF
--- a/conans/client/graph/python_requires.py
+++ b/conans/client/graph/python_requires.py
@@ -94,7 +94,7 @@ class PyRequireLoader(object):
             if isinstance(py_requires_extend, str):
                 py_requires_extend = [py_requires_extend, ]
             for p in py_requires_extend:
-                pkg_name, base_class_name = p.split(".")
+                pkg_name, base_class_name = p.rsplit(".", 1)
                 base_class = getattr(py_requires[pkg_name].module, base_class_name)
                 conanfile.__bases__ = (base_class,) + conanfile.__bases__
         conanfile.python_requires = py_requires


### PR DESCRIPTION
Closes #7241 

Changelog: (Bugfix): Added support for '.' in pkg_name for python_requires_extend

- [x] Refer to the issue that supports this Pull Request.
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 

<sup>**Note:** By default this PR will skip the slower tests and will use a limited set of python versions. Check [here](https://github.com/conan-io/conan/blob/develop/.github/PR_INCREASE_TESTING.md) how to increase the testing level by writing some tags in the current PR body text.</sup>
