### PR TITLE
reuse and extend from python_requires with dots

### DIFF
--- a/conans/client/graph/python_requires.py
+++ b/conans/client/graph/python_requires.py
@@ -94,7 +94,7 @@ class PyRequireLoader(object):
             if isinstance(py_requires_extend, str):
                 py_requires_extend = [py_requires_extend, ]
             for p in py_requires_extend:
-                pkg_name, base_class_name = p.split(".")
+                pkg_name, base_class_name = p.rsplit(".", 1)
                 base_class = getattr(py_requires[pkg_name].module, base_class_name)
                 conanfile.__bases__ = (base_class,) + conanfile.__bases__
         conanfile.python_requires = py_requires

--- a/conans/test/functional/py_requires/python_requires_test.py
+++ b/conans/test/functional/py_requires/python_requires_test.py
@@ -54,6 +54,26 @@ class PyRequiresExtendTest(unittest.TestCase):
         self.assertIn("Pkg/0.1@user/testing: Package installed "
                       "69265e58ddc68274e0c5510905003ff78c9db5de", client.out)
 
+    def reuse_dot_test(self):
+        client = TestClient(default_server_user=True)
+        conanfile = textwrap.dedent("""
+            from conans import ConanFile
+            class MyConanfileBase(ConanFile):
+                def build(self):
+                    self.output.info("My cool build!")
+            """)
+        client.save({"conanfile.py": conanfile})
+        client.run("export . my.base/1.1@user/testing")
+        reuse = textwrap.dedent("""
+            from conans import ConanFile
+            class PkgTest(ConanFile):
+                python_requires = "my.base/1.1@user/testing"
+                python_requires_extend = "my.base.MyConanfileBase"
+            """)
+        client.save({"conanfile.py": reuse}, clean_first=True)
+        client.run("create . Pkg/0.1@user/testing")
+        self.assertIn("Pkg/0.1@user/testing: My cool build!", client.out)
+
     def with_alias_test(self):
         client = TestClient()
         self._define_base(client)


### PR DESCRIPTION
Changelog: Bugfix: Allow to extend classes with ``python_requires_extend`` from packages that contain "." dots in the package name.
Docs: Omit

Completes https://github.com/conan-io/conan/pull/7242
Close #7241