### PR TITLE
Don't suppress all 'os.makedirs' exceptions.

### DIFF
--- a/conans/util/files.py
+++ b/conans/util/files.py
@@ -161,10 +161,14 @@ def _generic_algorithm_sum(file_path, algorithm_name):
 
 
 def save_append(path, content, encoding="utf-8"):
-    try:
-        os.makedirs(os.path.dirname(path))
-    except Exception:
-        pass
+    if os.path.dirname(path) != '':
+        try:
+            mkdir(os.path.dirname(path))
+        except Exception as e:
+            # cannot import this at the top due to cyclic dependencies
+            from conans.errors import ConanException
+            raise ConanException("Couldn't create folder '{}': {}\n"
+                                 .format(os.path.dirname(path), str(e)))
 
     with open(path, "ab") as handle:
         handle.write(to_file_bytes(content, encoding=encoding))
@@ -179,10 +183,14 @@ def save(path, content, only_if_modified=False, encoding="utf-8"):
         only_if_modified: file won't be modified if the content hasn't changed
         encoding: target file text encoding
     """
-    try:
-        os.makedirs(os.path.dirname(path))
-    except Exception:
-        pass
+    if os.path.dirname(path) != '':
+        try:
+            mkdir(os.path.dirname(path))
+        except Exception as e:
+            # cannot import this at the top due to cyclic dependencies
+            from conans.errors import ConanException
+            raise ConanException("Couldn't create folder '{}': {}\n"
+                                 .format(os.path.dirname(path), str(e)))
 
     new_content = to_file_bytes(content, encoding)
 


### PR DESCRIPTION
os.makedirs can raise a number of exceptions, one of which (already
exists) could safely be ignored while we were silencing all possible
exceptions.

As an example of an issue that this could cause, if the ".conan"
directory was located in a directory the user doesn't have write
permission to, conans.util.files.save would raise a FileNotFoundError,
which is misleading.

Fixes #7281.

Changelog: (Feature | Fix | Bugfix): Describe here your pull request
Docs: https://github.com/conan-io/docs/pull/XXXX

- [x] Refer to the issue that supports this Pull Request.
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 

<sup>**Note:** By default this PR will skip the slower tests and will use a limited set of python versions. Check [here](https://github.com/conan-io/conan/blob/develop/.github/PR_INCREASE_TESTING.md) how to increase the testing level by writing some tags in the current PR body text.</sup>
