### PR TITLE
implementing __contains__ for option in self.info.options

### DIFF
--- a/conans/model/info.py
+++ b/conans/model/info.py
@@ -617,10 +617,10 @@ class ConanInfo(object):
             self.settings.compiler.cppstd = self.full_settings.compiler.cppstd
 
     def shared_library_package_id(self):
-        if self.full_options.shared:
+        if "shared" in self.full_options and self.full_options.shared:
             for dep_name in self.requires.pkg_names:
                 dep_options = self.full_options[dep_name]
-                if "shared" not in dep_options or not self.full_options[dep_name].shared:
+                if "shared" not in dep_options or not dep_options.shared:
                     self.requires[dep_name].package_revision_mode()
 
     def parent_compatible(self, *_, **kwargs):

--- a/conans/model/options.py
+++ b/conans/model/options.py
@@ -22,8 +22,8 @@ def option_not_exist_msg(option_name, existing_options):
     """ Someone is referencing an option that is not available in the current package
     options
     """
-    result = ["'options.%s' doesn't exist" % option_name]
-    result.append("Possible options are %s" % existing_options or "none")
+    result = ["'options.%s' doesn't exist" % option_name,
+              "Possible options are %s" % existing_options or "none"]
     return "\n".join(result)
 
 
@@ -212,6 +212,9 @@ class OptionsValues(object):
     def clear_unscoped_options(self):
         self._package_values.clear()
 
+    def __contains__(self, item):
+        return item in self._package_values
+
     def __getitem__(self, item):
         return self._reqs_options.setdefault(item, PackageOptionValues())
 
@@ -283,16 +286,14 @@ class OptionsValues(object):
 
     @property
     def sha(self):
-        result = []
-        result.append(self._package_values.sha)
+        result = [self._package_values.sha]
         for key in sorted(list(self._reqs_options.keys())):
             result.append(self._reqs_options[key].sha)
         return sha1('\n'.join(result).encode())
 
     def serialize(self):
-        ret = {}
-        ret["options"] = self._package_values.serialize()
-        ret["req_options"] = {}
+        ret = {"options": self._package_values.serialize(),
+               "req_options": {}}
         for name, values in self._reqs_options.items():
             ret["req_options"][name] = values.serialize()
         return ret

--- a/conans/model/options.py
+++ b/conans/model/options.py
@@ -22,7 +22,7 @@ def option_not_exist_msg(option_name, existing_options):
     """ Someone is referencing an option that is not available in the current package
     options
     """
-    result = ["'options.%s' doesn't exist" % option_name,
+    result = ["option '%s' doesn't exist" % option_name,
               "Possible options are %s" % existing_options or "none"]
     return "\n".join(result)
 
@@ -59,6 +59,7 @@ class PackageOptionValues(object):
     def __init__(self):
         self._dict = {}  # {option_name: PackageOptionValue}
         self._modified = {}
+        self._freeze = False
 
     def __bool__(self):
         return bool(self._dict)
@@ -71,7 +72,7 @@ class PackageOptionValues(object):
 
     def __getattr__(self, attr):
         if attr not in self._dict:
-            return None
+            raise ConanException(option_not_exist_msg(attr, list(self._dict.keys())))
         return self._dict[attr]
 
     def __delattr__(self, attr):

--- a/conans/test/functional/command/info/info_options_test.py
+++ b/conans/test/functional/command/info/info_options_test.py
@@ -6,8 +6,7 @@ from conans.test.utils.tools import TestClient
 class InfoOptionsTest(unittest.TestCase):
 
     def info_options_test(self):
-        """ packages with dash
-        """
+        # packages with dash
         client = TestClient()
         client.run('new My-Package/1.3@myuser/testing -t')
         # assert they are correct at least
@@ -23,9 +22,9 @@ class InfoOptionsTest(unittest.TestCase):
 
         # errors
         client.run("info . -o shared2=True", assert_error=True)
-        self.assertIn("'options.shared2' doesn't exist", client.out)
+        self.assertIn("option 'shared2' doesn't exist", client.out)
         client.run("info . -o My-Package:shared2=True", assert_error=True)
-        self.assertIn("'options.shared2' doesn't exist", client.out)
+        self.assertIn("option 'shared2' doesn't exist", client.out)
 
     def info_wrong_options_test(self):
         # https://github.com/conan-io/conan/issues/2202

--- a/conans/test/functional/options/options_test.py
+++ b/conans/test/functional/options/options_test.py
@@ -336,3 +336,16 @@ class LibB(ConanFile):
             client.run("create . pkg/0.1@user/testing %s" % options)
             self.assertIn("liba/0.1@user/testing:5ab84d6acfe1f23c4fae0ab88f26e3a396351ac9 - Cache",
                           client.out)
+
+    def missing_shared_option_package_id_test(self):
+        client = TestClient()
+
+        consumer = textwrap.dedent("""
+            from conans import ConanFile
+            class Pkg(ConanFile):
+                def package_id(self):
+                    self.info.shared_library_package_id()
+            """)
+        client.save({"conanfile.py": consumer})
+        client.run("create . pkg/0.1@user/testing")
+        self.assertIn("pkg/0.1@user/testing: Created package ", client.out)

--- a/conans/test/functional/options/options_test.py
+++ b/conans/test/functional/options/options_test.py
@@ -15,11 +15,7 @@ class Pkg(ConanFile):
     def configure(self):
         self.output.info("BUILD SHARED: %s" % self.options.shared)
 """
-        test = """from conans import ConanFile
-class Pkg(ConanFile):
-    def test(self):
-        pass
-"""
+        test = GenConanfile().with_test("pass")
         client.save({"conanfile.py": conanfile})
         client.run("create . Pkg/0.1@user/testing -o *:shared=1")
         self.assertIn("Pkg/0.1@user/testing: BUILD SHARED: 1", client.out)
@@ -33,23 +29,19 @@ class Pkg(ConanFile):
         client.run("create . Pkg/0.1@user/testing -o Pkg:shared=2")
         self.assertIn("Pkg/0.1@user/testing: BUILD SHARED: 2", client.out)
         client.run("create . Pkg/0.1@user/testing -o shared=1", assert_error=True)
-        self.assertIn("'options.shared' doesn't exist", client.out)
+        self.assertIn("option 'shared' doesn't exist", client.out)
 
-        conanfile = """from conans import ConanFile
-class Pkg(ConanFile):
-    pass
-"""
-        client.save({"conanfile.py": conanfile}, clean_first=True)
+        client.save({"conanfile.py": GenConanfile()}, clean_first=True)
         client.run("create . Pkg/0.1@user/testing -o *:shared=True")
         self.assertIn("Pkg/0.1@user/testing: Calling build()", client.out)
         client.run("create . Pkg/0.1@user/testing -o shared=False", assert_error=True)
-        self.assertIn("'options.shared' doesn't exist", client.out)
+        self.assertIn("option 'shared' doesn't exist", client.out)
         # With test_package
         client.save({"conanfile.py": conanfile,
                      "test_package/conanfile.py": test})
-        client.run("create . Pkg/0.1@user/testing -o *:shared=True")
-        self.assertIn("Pkg/0.1@user/testing: Calling build()", client.out)
-        self.assertIn("Pkg/0.1@user/testing (test package): Calling build()", client.out)
+        client.run("create . Pkg/0.1@user/testing -o *:shared=True", assert_error=True)
+        self.assertIn("ERROR: Pkg/0.1@user/testing: 'True' is not a valid 'options.shared' value",
+                      client.out)
 
     def general_scope_priorities_test(self):
         client = TestClient()
@@ -59,12 +51,8 @@ class Pkg(ConanFile):
     def configure(self):
         self.output.info("BUILD SHARED: %s" % self.options.shared)
 """
-        test = """from conans import ConanFile
-class Pkg(ConanFile):
-    def test(self):
-        pass
-"""
-        client.save({"conanfile.py": conanfile})
+        test = GenConanfile().with_test("pass")
+        client.save({"conanfile.py": test})
         # Consumer has priority
         client.run("create . Pkg/0.1@user/testing -o *:shared=1 -o shared=2")
         self.assertIn("Pkg/0.1@user/testing: BUILD SHARED: 2", client.out)

--- a/conans/test/functional/package_id/package_id_test.py
+++ b/conans/test/functional/package_id/package_id_test.py
@@ -91,7 +91,7 @@ class TestConan(ConanFile):
                 def package_id(self):
                     if "fpic" in self.options:
                         self.output.info("fpic is an option!!!")
-                    if "fpic" in self.info.options:
+                    if "fpic" in self.info.options:  # Not documented
                         self.output.info("fpic is an info.option!!!")
                     if "other" not in self.options:
                         self.output.info("other is not an option!!!")

--- a/conans/test/functional/package_id/package_id_test.py
+++ b/conans/test/functional/package_id/package_id_test.py
@@ -89,16 +89,19 @@ class TestConan(ConanFile):
                 options = {"fpic": [True, False]}
                 default_options = {"fpic": True}
                 def package_id(self):
-                    if "fpic" in self.info.options:
+                    if "fpic" in self.options:
                         self.output.info("fpic is an option!!!")
-                    if "other" not in self.info.options:
+                    if "fpic" in self.info.options:
+                        self.output.info("fpic is an info.option!!!")
+                    if "other" not in self.options:
                         self.output.info("other is not an option!!!")
-                    if not self.info.options.whatever:
-                        self.output.info("whatever is not an option!!!")
+                    if "other" not in self.info.options:
+                        self.output.info("other is not an info.option!!!")
             """)
         client = TestClient()
         client.save({"conanfile.py": conanfile})
         client.run("create . Pkg/0.1@user/testing")
         self.assertIn("fpic is an option!!!", client.out)
+        self.assertIn("fpic is an info.option!!!", client.out)
         self.assertIn("other is not an option!!!", client.out)
-        self.assertIn("whatever is not an option!!!", client.out)
+        self.assertIn("other is not an info.option!!!", client.out)

--- a/conans/test/functional/package_id/package_id_test.py
+++ b/conans/test/functional/package_id/package_id_test.py
@@ -93,9 +93,12 @@ class TestConan(ConanFile):
                         self.output.info("fpic is an option!!!")
                     if "other" not in self.info.options:
                         self.output.info("other is not an option!!!")
+                    if not self.info.options.whatever:
+                        self.output.info("whatever is not an option!!!")
             """)
         client = TestClient()
         client.save({"conanfile.py": conanfile})
         client.run("create . Pkg/0.1@user/testing")
         self.assertIn("fpic is an option!!!", client.out)
         self.assertIn("other is not an option!!!", client.out)
+        self.assertIn("whatever is not an option!!!", client.out)

--- a/conans/test/functional/package_id/package_id_test.py
+++ b/conans/test/functional/package_id/package_id_test.py
@@ -97,6 +97,15 @@ class TestConan(ConanFile):
                         self.output.info("other is not an option!!!")
                     if "other" not in self.info.options:
                         self.output.info("other is not an info.option!!!")
+                    try:
+                        self.options.whatever
+                    except Exception as e:
+                        self.output.error("OPTIONS: %s" % e)
+                    try:
+                        self.info.options.whatever
+                    except Exception as e:
+                        self.output.error("INFO: %s" % e)
+
             """)
         client = TestClient()
         client.save({"conanfile.py": conanfile})
@@ -105,3 +114,5 @@ class TestConan(ConanFile):
         self.assertIn("fpic is an info.option!!!", client.out)
         self.assertIn("other is not an option!!!", client.out)
         self.assertIn("other is not an info.option!!!", client.out)
+        self.assertIn("ERROR: OPTIONS: option 'whatever' doesn't exist", client.out)
+        self.assertIn("ERROR: INFO: option 'whatever' doesn't exist", client.out)

--- a/conans/test/functional/package_id/package_id_test.py
+++ b/conans/test/functional/package_id/package_id_test.py
@@ -95,7 +95,7 @@ class TestConan(ConanFile):
                         self.output.info("fpic is an info.option!!!")
                     if "other" not in self.options:
                         self.output.info("other is not an option!!!")
-                    if "other" not in self.info.options:
+                    if "other" not in self.info.options:  # Not documented
                         self.output.info("other is not an info.option!!!")
                     try:
                         self.options.whatever

--- a/conans/test/functional/settings/remove_subsetting_test.py
+++ b/conans/test/functional/settings/remove_subsetting_test.py
@@ -27,7 +27,7 @@ class Pkg(ConanFile):
         client.current_folder = build_folder
         client.run("install ..")
         client.run("build ..", assert_error=True)
-        self.assertIn("ConanException: 'options.opt2' doesn't exist", client.out)
+        self.assertIn("ConanException: option 'opt2' doesn't exist", client.out)
         self.assertIn("Possible options are ['opt1']", client.out)
 
     def remove_setting_test(self):


### PR DESCRIPTION
Changelog: Fix: Implement missing ``__contains__`` method, so checking ``if "myoption" in self.info.options`` is possible in ``package_id()``.
Docs: Omit

Fix https://github.com/conan-io/conan/issues/7299


