### PR TITLE
Add support for all Linux distros using apt

### DIFF
--- a/conans/client/tools/oss.py
+++ b/conans/client/tools/oss.py
@@ -181,7 +181,7 @@ class OSInfo(object):
         if not self.is_linux:
             return False
 
-        apt_location = which('apt')
+        apt_location = which('apt-get')
         if apt_location:
             # Check if we actually have the official apt package. The '--help'
             # argument ensures that we run apt-get successfully.

--- a/conans/client/tools/oss.py
+++ b/conans/client/tools/oss.py
@@ -178,8 +178,9 @@ class OSInfo(object):
 
     @property
     def with_apt(self):
-        apt_distros = ("debian", "ubuntu", "knoppix", "linuxmint", "raspbian", "neon", "pop", "elementary")
-        return self.is_linux and self.linux_distro in apt_distros
+        apt_path = '/usr/bin/apt'
+        sys_has_apt = os.path.isfile(apt_path) and os.access(apt_path, os.X_OK)
+        return self.is_linux and sys_has_apt
 
     @property
     def with_yum(self):

--- a/conans/client/tools/oss.py
+++ b/conans/client/tools/oss.py
@@ -183,14 +183,14 @@ class OSInfo(object):
 
         apt_location = which('apt-get')
         if apt_location:
-            # Check if we actually have the official apt package. The '--help'
-            # argument ensures that we run apt-get successfully.
+            # Check if we actually have the official apt package.
             try:
-                output = check_output_runner([apt_location, '--help'])
+                output = check_output_runner([apt_location, 'moo'])
             except CalledProcessErrorWithStderr:
                 return False
             else:
-                return 'This APT has Super Cow Powers.' in output
+                # Yes, we have mooed today. :-) MOOOOOOOO.
+                return True
         else:
             return False
 

--- a/conans/client/tools/oss.py
+++ b/conans/client/tools/oss.py
@@ -9,7 +9,7 @@ from collections import namedtuple
 
 from conans.client.tools.env import environment_append
 from conans.client.tools.files import load, which
-from conans.errors import ConanException
+from conans.errors import CalledProcessErrorWithStderr, ConanException
 from conans.model.version import Version
 from conans.util.runners import check_output_runner
 
@@ -186,11 +186,11 @@ class OSInfo(object):
             # Check if we actually have the official apt package. The '--help'
             # argument ensures that we run apt-get successfully.
             try:
-                output = subprocess.run([apt_location, '--help'], capture_output=True, check=True)
-            except subprocess.CalledProcessError:
+                output = check_output_runner([apt_location, '--help'])
+            except CalledProcessErrorWithStderr:
                 return False
             else:
-                return 'This APT has Super Cow Powers.' in str(output.stdout)
+                return 'This APT has Super Cow Powers.' in output
         else:
             return False
 

--- a/conans/client/tools/oss.py
+++ b/conans/client/tools/oss.py
@@ -178,7 +178,7 @@ class OSInfo(object):
 
     @property
     def with_apt(self):
-        apt_distros = ("debian", "ubuntu", "knoppix", "linuxmint", "raspbian", "neon", "pop")
+        apt_distros = ("debian", "ubuntu", "knoppix", "linuxmint", "raspbian", "neon", "pop", "elementary")
         return self.is_linux and self.linux_distro in apt_distros
 
     @property

--- a/conans/client/tools/oss.py
+++ b/conans/client/tools/oss.py
@@ -178,9 +178,21 @@ class OSInfo(object):
 
     @property
     def with_apt(self):
-        apt_path = '/usr/bin/apt'
-        sys_has_apt = os.path.isfile(apt_path) and os.access(apt_path, os.X_OK)
-        return self.is_linux and sys_has_apt
+        if not self.is_linux:
+            return False
+
+        apt_location = which('apt')
+        if apt_location:
+            # Check if we actually have the official apt package. The '--help'
+            # argument ensures that we run apt-get successfully.
+            try:
+                output = subprocess.run([apt_location, '--help'], capture_output=True, check=True)
+            except subprocess.CalledProcessError:
+                return False
+            else:
+                return 'This APT has Super Cow Powers.' in str(output.stdout)
+        else:
+            return False
 
     @property
     def with_yum(self):


### PR DESCRIPTION
Fixes #7307

Changelog: Feature: Checking if a Linux distro uses `apt` is now based on the existence of `apt` in the system, instead of checking if the distro currently being used is in a hard-coded list of distros known to use `apt`.
Docs: omit