### PR TITLE
#7297 fix config install when scheduled

### DIFF
--- a/conans/client/command.py
+++ b/conans/client/command.py
@@ -2044,8 +2044,8 @@ class Command(object):
                 self._print_similar(command)
                 raise ConanException("Unknown command %s" % str(exc))
 
-            if is_config_install_scheduled(self._conan) and \
-               (command != "config" or (command == "config" and args[0][1] != "install")):
+            if (command != "config" or (command == "config" and args[0][1] != "install")) and \
+               is_config_install_scheduled(self._conan):
                 self._conan.config_install(None, None)
 
             method(args[0][1:])

--- a/conans/client/command.py
+++ b/conans/client/command.py
@@ -2044,7 +2044,8 @@ class Command(object):
                 self._print_similar(command)
                 raise ConanException("Unknown command %s" % str(exc))
 
-            if (command != "config" or (command == "config" and args[0][1] != "install")) and \
+            if (command != "config" or
+               (command == "config" and len(args[0]) > 1 and args[0][1] != "install")) and \
                is_config_install_scheduled(self._conan):
                 self._conan.config_install(None, None)
 

--- a/conans/client/command.py
+++ b/conans/client/command.py
@@ -2045,7 +2045,7 @@ class Command(object):
                 raise ConanException("Unknown command %s" % str(exc))
 
             if is_config_install_scheduled(self._conan) and \
-               (command != "config" or (command == "config" and args[0] != "install")):
+               (command != "config" or (command == "config" and args[0][1] != "install")):
                 self._conan.config_install(None, None)
 
             method(args[0][1:])

--- a/conans/client/conf/__init__.py
+++ b/conans/client/conf/__init__.py
@@ -707,7 +707,7 @@ class ConanClientConfigParser(ConfigParser, object):
                 return timedelta(hours=float(value))
             else:
                 return timedelta(days=float(value))
-        except Exception as e:
+        except Exception:
             raise ConanException("Incorrect definition of general.config_install_interval: %s"
                                  % interval)
 

--- a/conans/test/functional/command/config_install_test.py
+++ b/conans/test/functional/command/config_install_test.py
@@ -642,7 +642,7 @@ class ConfigInstallSchedTest(unittest.TestCase):
                       self.client.out)
 
     def test_config_install_remove_git_repo(self):
-        """ config_install_interval breaks when remote git has been removed
+        """ config_install_interval must break when remote git has been removed
         """
         with self.client.chdir(self.folder):
             self.client.run_command('git init .')
@@ -652,11 +652,19 @@ class ConfigInstallSchedTest(unittest.TestCase):
             self.client.run_command('git commit -m "mymsg"')
         self.client.run('config install "%s/.git" --type git' % self.folder)
         self.assertIn("Processing conan.conf", self.client.out)
-        self.assertIn("Repo cloned!", self.client.out)
-        shutil.rmtree(self.folder)
+        self.assertIn("Repo cloned!", self.client.out)  # git clone executed by scheduled task
+        folder_name = self.folder
+        new_name = self.folder + "_test"
+        os.rename(self.folder, new_name)
         with patch("conans.client.command.is_config_install_scheduled", return_value=True):
             self.client.run("config --help", assert_error=True)
-        self.assertIn("ERROR: Failed conan config install: Can't clone repo", self.client.out)
+            # scheduled task has been executed. Without a remote, the user should fix the config
+            self.assertIn("ERROR: Failed conan config install: Can't clone repo", self.client.out)
+
+            # restore the remote
+            os.rename(new_name, folder_name)
+            self.client.run("config --help")
+            self.assertIn("Repo cloned!", self.client.out)
 
     def test_config_install_remove_config_repo(self):
         """ config_install_interval should not run when config list is empty
@@ -670,16 +678,22 @@ class ConfigInstallSchedTest(unittest.TestCase):
         self.client.run('config install "%s/.git" --type git' % self.folder)
         self.assertIn("Processing conan.conf", self.client.out)
         self.assertIn("Repo cloned!", self.client.out)
-        with patch("conans.client.command.is_config_install_scheduled", return_value=True):
+        # force scheduled time for all commands
+        with patch("conans.client.conf.config_installer._is_scheduled_intervals", return_value=True):
             self.client.run("config --help")
-            self.assertIn("Repo cloned!", self.client.out)
+            self.assertIn("Repo cloned!", self.client.out)  # git clone executed by scheduled task
 
+            # config install must not run scheduled config
             self.client.run("config install --remove 0")
             self.assertEqual("", self.client.out)
-
             self.client.run("config install --list")
             self.assertEqual("", self.client.out)
 
-        self.client.run("help")
-        self.assertIn("WARN: Skipping scheduled config install, "
-                      "no config listed in config_install file", self.client.out)
+            last_change = os.path.getmtime(self.client.cache.config_install_file)
+            # without a config in configs file, scheduler only emits a warning
+            self.client.run("help")
+            self.assertIn("WARN: Skipping scheduled config install, "
+                          "no config listed in config_install file", self.client.out)
+            self.assertNotIn("Repo cloned!", self.client.out)
+            # ... and updates the next schedule
+            self.assertGreater(os.path.getmtime(self.client.cache.config_install_file), last_change)


### PR DESCRIPTION
There was a bug which considered `config install` as command which was able to trigger a new config command when the scheduler was ready.

This PR won't prevent the error when the remote git has been removed and it's listed as config remote, the scheduler will continue to fail. However, you will be able to run `conan config install -r 0`, or any `conan config install xxx` without problem now.

Changelog: Fix: Conan config install does not trigger scheduled config command.
Docs: Omit

Fixes: #7297 

/cc @michaelmaguire @memsharded 

- [ ] Refer to the issue that supports this Pull Request.
- [ ] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [ ] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [ ] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 

<sup>**Note:** By default this PR will skip the slower tests and will use a limited set of python versions. Check [here](https://github.com/conan-io/conan/blob/develop/.github/PR_INCREASE_TESTING.md) how to increase the testing level by writing some tags in the current PR body text.</sup>
