### PR TITLE
Implement recipe_folder attribute

### DIFF
--- a/conans/client/loader.py
+++ b/conans/client/loader.py
@@ -60,6 +60,8 @@ class ConanFileLoader(object):
             if self._pyreq_loader:
                 self._pyreq_loader.load_py_requires(conanfile, lock_python_requires, self)
 
+            conanfile.recipe_folder = os.path.dirname(conanfile_path)
+
             # If the scm is inherited, create my own instance
             if hasattr(conanfile, "scm") and "scm" not in conanfile.__class__.__dict__:
                 if isinstance(conanfile.scm, dict):
@@ -112,7 +114,6 @@ class ConanFileLoader(object):
                                      % (version, conanfile.version))
             conanfile.version = version
 
-        conanfile.recipe_folder = os.path.dirname(conanfile_path)
         if hasattr(conanfile, "set_name"):
             with conanfile_exception_formatter("conanfile.py", "set_name"):
                 conanfile.set_name()
@@ -124,8 +125,6 @@ class ConanFileLoader(object):
             if version and version != conanfile.version:
                 raise ConanException("Package recipe with version %s!=%s"
                                      % (version, conanfile.version))
-        # Make sure this is nowhere else available
-        del conanfile.recipe_folder
 
         return conanfile
 

--- a/conans/test/functional/conanfile/folders_access_test.py
+++ b/conans/test/functional/conanfile/folders_access_test.py
@@ -226,33 +226,34 @@ class TestFoldersAccess(unittest.TestCase):
 
 
 class RecipeFolderTest(unittest.TestCase):
+    recipe_conanfile = textwrap.dedent("""
+        from conans import ConanFile, load
+        import os
+        class Pkg(ConanFile):
+            exports = "file.txt"
+            def init(self):
+                r = load(os.path.join(self.recipe_folder, "file.txt"))
+                self.output.info("INIT: {}".format(r))
+            def set_name(self):
+                r = load(os.path.join(self.recipe_folder, "file.txt"))
+                self.output.info("SET_NAME: {}".format(r))
+            def configure(self):
+                r = load(os.path.join(self.recipe_folder, "file.txt"))
+                self.output.info("CONFIGURE: {}".format(r))
+            def requirements(self):
+                r = load(os.path.join(self.recipe_folder, "file.txt"))
+                self.output.info("REQUIREMENTS: {}".format(r))
+            def package(self):
+                r = load(os.path.join(self.recipe_folder, "file.txt"))
+                self.output.info("PACKAGE: {}".format(r))
+            def package_info(self):
+                r = load(os.path.join(self.recipe_folder, "file.txt"))
+                self.output.info("PACKAGE_INFO: {}".format(r))
+        """)
+
     def recipe_folder_test(self):
         client = TestClient()
-        recipe_conanfile = textwrap.dedent("""
-            from conans import ConanFile, load
-            import os
-            class Pkg(ConanFile):
-                exports = "file.txt"
-                def init(self):
-                    r = load(os.path.join(self.recipe_folder, "file.txt"))
-                    self.output.info("INIT: {}".format(r))
-                def set_name(self):
-                    r = load(os.path.join(self.recipe_folder, "file.txt"))
-                    self.output.info("SET_NAME: {}".format(r))
-                def configure(self):
-                    r = load(os.path.join(self.recipe_folder, "file.txt"))
-                    self.output.info("CONFIGURE: {}".format(r))
-                def requirements(self):
-                    r = load(os.path.join(self.recipe_folder, "file.txt"))
-                    self.output.info("REQUIREMENTS: {}".format(r))
-                def package(self):
-                    r = load(os.path.join(self.recipe_folder, "file.txt"))
-                    self.output.info("PACKAGE: {}".format(r))
-                def package_info(self):
-                    r = load(os.path.join(self.recipe_folder, "file.txt"))
-                    self.output.info("PACKAGE_INFO: {}".format(r))
-            """)
-        client.save({"conanfile.py": recipe_conanfile,
+        client.save({"conanfile.py": self.recipe_conanfile,
                      "file.txt": "MYFILE!"})
         client.run("export . pkg/0.1@user/testing")
         self.assertIn("INIT: MYFILE!", client.out)
@@ -265,3 +266,13 @@ class RecipeFolderTest(unittest.TestCase):
         self.assertIn("pkg/0.1@user/testing: REQUIREMENTS: MYFILE!", client.out)
         self.assertIn("pkg/0.1@user/testing: PACKAGE: MYFILE!", client.out)
         self.assertIn("pkg/0.1@user/testing: PACKAGE_INFO: MYFILE!", client.out)
+
+    def local_flow_test(self):
+        client = TestClient()
+        client.save({"conanfile.py": self.recipe_conanfile,
+                     "file.txt": "MYFILE!"})
+        client.run("install .")
+        self.assertIn("INIT: MYFILE!", client.out)
+        self.assertIn("SET_NAME: MYFILE!", client.out)
+        self.assertIn("conanfile.py: CONFIGURE: MYFILE!", client.out)
+        self.assertIn("conanfile.py: REQUIREMENTS: MYFILE!", client.out)

--- a/conans/test/functional/conanfile/folders_access_test.py
+++ b/conans/test/functional/conanfile/folders_access_test.py
@@ -2,6 +2,7 @@ import os
 import textwrap
 import unittest
 
+from conans.test.utils.genconanfile import GenConanfile
 from conans.test.utils.tools import TestClient
 from conans.util.files import mkdir
 
@@ -276,3 +277,18 @@ class RecipeFolderTest(unittest.TestCase):
         self.assertIn("SET_NAME: MYFILE!", client.out)
         self.assertIn("conanfile.py: CONFIGURE: MYFILE!", client.out)
         self.assertIn("conanfile.py: REQUIREMENTS: MYFILE!", client.out)
+
+    def editable_test(self):
+        client = TestClient()
+        client.save({"pkg/conanfile.py": self.recipe_conanfile,
+                     "pkg/file.txt": "MYFILE!",
+                     "consumer/conanfile.py":
+                         GenConanfile().with_require_plain("pkg/0.1@user/stable")})
+        client.run("editable add pkg pkg/0.1@user/stable")
+
+        client.run("install consumer")
+        self.assertIn("pkg/0.1@user/stable: INIT: MYFILE!", client.out)
+        self.assertIn("pkg/0.1@user/stable: CONFIGURE: MYFILE!", client.out)
+        self.assertIn("pkg/0.1@user/stable: REQUIREMENTS: MYFILE!", client.out)
+        self.assertIn("pkg/0.1@user/stable from user folder - Editable", client.out)
+        self.assertIn("pkg/0.1@user/stable: PACKAGE_INFO: MYFILE!", client.out)

--- a/conans/test/functional/hooks/hook_test.py
+++ b/conans/test/functional/hooks/hook_test.py
@@ -10,33 +10,40 @@ from conans import ConanFile
 class AConan(ConanFile):
     name = "basic"
     version = "0.1"
-    
+
     def package_info(self):
         self.cpp_info.defines = ["ACONAN"]
 """
 
 complete_hook = """
+import os
 from conans.model.ref import ConanFileReference
 
 
 def pre_export(output, conanfile, conanfile_path, reference, **kwargs):
     assert conanfile
+    assert conanfile.recipe_folder == os.path.dirname(conanfile_path)
     output.info("conanfile_path=%s" % conanfile_path)
     output.info("reference=%s" % reference.full_str())
 
 def post_export(output, conanfile, conanfile_path, reference, **kwargs):
     assert conanfile
+    # In this case the recipe folder is different than the final export folder
+    # TODO: If export_folder will be defined it should match
+    assert conanfile.recipe_folder != os.path.dirname(conanfile_path)
     output.info("conanfile_path=%s" % conanfile_path)
     output.info("reference=%s" % reference.full_str())
 
 def pre_source(output, conanfile, conanfile_path, **kwargs):
     assert conanfile
+    assert conanfile.recipe_folder == os.path.dirname(conanfile_path)
     output.info("conanfile_path=%s" % conanfile_path)
     if conanfile.in_local_cache:
         output.info("reference=%s" % kwargs["reference"].full_str())
 
 def post_source(output, conanfile, conanfile_path, **kwargs):
     assert conanfile
+    assert conanfile.recipe_folder == os.path.dirname(conanfile_path)
     output.info("conanfile_path=%s" % conanfile_path)
     if conanfile.in_local_cache:
         output.info("reference=%s" % kwargs["reference"].full_str())
@@ -59,6 +66,7 @@ def post_build(output, conanfile, **kwargs):
 
 def pre_package(output, conanfile, conanfile_path, **kwargs):
     assert conanfile
+    assert conanfile.recipe_folder == os.path.dirname(conanfile_path)
     output.info("conanfile_path=%s" % conanfile_path)
     if conanfile.in_local_cache:
         output.info("reference=%s" % kwargs["reference"].full_str())
@@ -66,6 +74,7 @@ def pre_package(output, conanfile, conanfile_path, **kwargs):
 
 def post_package(output, conanfile, conanfile_path, **kwargs):
     assert conanfile
+    assert conanfile.recipe_folder == os.path.dirname(conanfile_path)
     output.info("conanfile_path=%s" % conanfile_path)
     if conanfile.in_local_cache:
         output.info("reference=%s" % kwargs["reference"].full_str())
@@ -132,7 +141,7 @@ def post_download_package(output, conanfile_path, reference, package_id, remote,
     output.info("reference=%s" % reference.full_str())
     output.info("package_id=%s" % package_id)
     output.info("remote.name=%s" % remote.name)
-    
+
 def pre_package_info(output, conanfile, reference, **kwargs):
     output.info("reference=%s" % reference.full_str())
     output.info("conanfile.cpp_info.defines=%s" % conanfile.cpp_info.defines)


### PR DESCRIPTION
Changelog: Feature: Define ``recipe_folder`` attribute pointing to the folder containing ``conanfile.py``
Docs: https://github.com/conan-io/docs/pull/1785

Close https://github.com/conan-io/conan/issues/7312
Close https://github.com/conan-io/conan/issues/7315

Would help with:
- #7268
- #7355 

@jgsogo the most important point of this PR is if we really want to allow this, or what Pandora box this could open, and allow too crazy things.