### PR TITLE
Add (recover) quotes around link flags

### DIFF
--- a/conans/client/generators/cmake_find_package.py
+++ b/conans/client/generators/cmake_find_package.py
@@ -104,9 +104,9 @@ class CMakeFindPackageGenerator(Generator):
         set({{ pkg_name }}_{{ comp_name }}_BUILD_MODULES_PATHS {{ comp.build_modules_paths }})
         set({{ pkg_name }}_{{ comp_name }}_DEPENDENCIES {{ comp.public_deps }})
         set({{ pkg_name }}_{{ comp_name }}_LINKER_FLAGS_LIST
-                $<$<STREQUAL:$<TARGET_PROPERTY:TYPE>,SHARED_LIBRARY>:{{ comp.sharedlinkflags_list }}>
-                $<$<STREQUAL:$<TARGET_PROPERTY:TYPE>,MODULE_LIBRARY>:{{ comp.sharedlinkflags_list }}>
-                $<$<STREQUAL:$<TARGET_PROPERTY:TYPE>,EXECUTABLE>:{{ comp.exelinkflags_list }}>
+                "$<$<STREQUAL:$<TARGET_PROPERTY:TYPE>,SHARED_LIBRARY>:{{ comp.sharedlinkflags_list }}>"
+                "$<$<STREQUAL:$<TARGET_PROPERTY:TYPE>,MODULE_LIBRARY>:{{ comp.sharedlinkflags_list }}>"
+                "$<$<STREQUAL:$<TARGET_PROPERTY:TYPE>,EXECUTABLE>:{{ comp.exelinkflags_list }}>"
         )
 
         {%- endfor %}

--- a/conans/client/generators/cmake_find_package_common.py
+++ b/conans/client/generators/cmake_find_package_common.py
@@ -9,9 +9,9 @@ set({name}_INCLUDES{build_type_suffix} {deps.include_paths})
 set({name}_RES_DIRS{build_type_suffix} {deps.res_paths})
 set({name}_DEFINITIONS{build_type_suffix} {deps.defines})
 set({name}_LINKER_FLAGS{build_type_suffix}_LIST
-        $<$<STREQUAL:$<TARGET_PROPERTY:TYPE>,SHARED_LIBRARY>:{deps.sharedlinkflags_list}>
-        $<$<STREQUAL:$<TARGET_PROPERTY:TYPE>,MODULE_LIBRARY>:{deps.sharedlinkflags_list}>
-        $<$<STREQUAL:$<TARGET_PROPERTY:TYPE>,EXECUTABLE>:{deps.exelinkflags_list}>
+        "$<$<STREQUAL:$<TARGET_PROPERTY:TYPE>,SHARED_LIBRARY>:{deps.sharedlinkflags_list}>"
+        "$<$<STREQUAL:$<TARGET_PROPERTY:TYPE>,MODULE_LIBRARY>:{deps.sharedlinkflags_list}>"
+        "$<$<STREQUAL:$<TARGET_PROPERTY:TYPE>,EXECUTABLE>:{deps.exelinkflags_list}>"
 )
 set({name}_COMPILE_DEFINITIONS{build_type_suffix} {deps.compile_definitions})
 set({name}_COMPILE_OPTIONS{build_type_suffix}_LIST "{deps.cxxflags_list}" "{deps.cflags_list}")

--- a/conans/test/functional/generators/cmake_apple_frameworks_test.py
+++ b/conans/test/functional/generators/cmake_apple_frameworks_test.py
@@ -4,7 +4,8 @@ import unittest
 
 from conans.model.ref import ConanFileReference
 from conans.test.utils.tools import TestClient
-
+from parameterized import parameterized
+import os
 
 @unittest.skipUnless(platform.system() == "Darwin", "Only for MacOS")
 class CMakeAppleFrameworksTestCase(unittest.TestCase):
@@ -23,7 +24,7 @@ class CMakeAppleFrameworksTestCase(unittest.TestCase):
         class App(ConanFile):
             requires = "{}"
             generators = "{{generator}}"
-            
+
             def build(self):
                 cmake = CMake(self)
                 cmake.configure()
@@ -45,7 +46,7 @@ class CMakeAppleFrameworksTestCase(unittest.TestCase):
 
             include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
             conan_basic_setup()
-            
+
             message(">>> CONAN_FRAMEWORKS_FOUND_LIB: ${CONAN_FRAMEWORKS_FOUND_LIB}")
         """)
 
@@ -60,7 +61,7 @@ class CMakeAppleFrameworksTestCase(unittest.TestCase):
             project(Testing CXX)
 
             find_package(lib)
-            
+
             message(">>> CONAN_FRAMEWORKS_FOUND_LIB: ${lib_FRAMEWORKS_FOUND}")
         """)
 
@@ -272,3 +273,96 @@ class CMakeAppleOwnFrameworksTestCase(unittest.TestCase):
                      "test_package/timer.cpp": self.timer_cpp})
         client.run("create .")
         self.assertIn("Hello World Release!", client.out)
+
+    @parameterized.expand([('cmake', False),
+                           ('cmake_find_package', False), ('cmake_find_package', True), ])
+    def test_frameworks_exelinkflags(self, generator, use_components):
+        # FIXME: Conan 2.0. 'cpp_info' object has a 'frameworks' key
+        conanfile = textwrap.dedent("""
+            from conans import ConanFile
+
+            class Recipe(ConanFile):
+                settings = "os", "arch", "compiler", "build_type"
+                options = {'use_components': [True, False]}
+                default_options = {'use_components': False}
+
+                def package_info(self):
+                    if not self.options.use_components:
+                        self.cpp_info.exelinkflags.extend(['-framework Foundation'])
+                        #self.cpp_info.frameworks.extend(['Foundation'])
+                    else:
+                        self.cpp_info.components["cmp"].exelinkflags.extend(['-framework Foundation'])
+                        #self.cpp_info.components["cmp"].frameworks.extend(['Foundation'])
+        """)
+        tp_cmakelists = textwrap.dedent("""
+            cmake_minimum_required(VERSION 3.0)
+            project(test_package)
+
+            include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
+            conan_basic_setup(TARGETS)
+
+            if(USE_FIND_PACKAGE)
+                message(">> USE_FIND_PACKAGE")
+                find_package(name)
+                add_executable(${PROJECT_NAME} test_package.cpp)
+                if (USE_COMPONENTS)
+                    message(">> USE_COMPONENTS")
+                    target_link_libraries(${PROJECT_NAME} name::cmp)
+                else()
+                    message(">> not USE_COMPONENTS")
+                    target_link_libraries(${PROJECT_NAME} name::name)
+                endif()
+            else()
+                message(">> not USE_FIND_PACKAGE")
+                add_executable(${PROJECT_NAME} test_package.cpp)
+                target_link_libraries(${PROJECT_NAME} CONAN_PKG::name)
+            endif()
+        """)
+        tp_conanfile = textwrap.dedent("""
+            from conans import ConanFile, CMake
+
+            class TestPackage(ConanFile):
+                settings = "os", "arch", "compiler", "build_type"
+                generators = "cmake", "cmake_find_package"
+                options = {'use_find_package': [True, False]}
+                requires = "name/version"
+
+                def build(self):
+                    cmake = CMake(self)
+                    cmake.definitions["USE_FIND_PACKAGE"] = self.options.use_find_package
+                    cmake.definitions["USE_COMPONENTS"] = self.options["name"].use_components
+                    cmake.configure()
+                    cmake.build()
+
+                def test(self):
+                    pass
+        """)
+        tp_main = textwrap.dedent("""
+            int main() {}
+        """)
+
+        t = TestClient()
+        t.save({'conanfile.py': conanfile,
+                'test_package/conanfile.py': tp_conanfile,
+                'test_package/CMakeLists.txt': tp_cmakelists,
+                'test_package/test_package.cpp': tp_main})
+        t.run("export conanfile.py name/version@")
+
+        with t.chdir('test_package/build'):
+            if generator == 'cmake':
+                assert not use_components
+                t.run("install .. --build=missing"
+                      " -o name:use_components=False -o use_find_package=False")
+                t.run("build ..")
+                self.assertIn(">> not USE_FIND_PACKAGE", t.out)
+            else:
+                assert generator == 'cmake_find_package'
+                t.run("install .. --build=missing"
+                      " -o name:use_components={} -o use_find_package=True".format(use_components))
+                t.run("build ..")
+                self.assertIn(">> USE_FIND_PACKAGE", t.out)
+                self.assertIn(">> {}USE_COMPONENTS".format("" if use_components else "not "), t.out)
+
+            # Check we are using the framework
+            link_txt = t.load(os.path.join('CMakeFiles', 'test_package.dir', 'link.txt'))
+            self.assertIn("-framework Foundation", link_txt)

--- a/conans/test/functional/generators/cmake_apple_frameworks_test.py
+++ b/conans/test/functional/generators/cmake_apple_frameworks_test.py
@@ -1,11 +1,13 @@
+import os
 import platform
 import textwrap
 import unittest
 
+from parameterized import parameterized
+
 from conans.model.ref import ConanFileReference
 from conans.test.utils.tools import TestClient
-from parameterized import parameterized
-import os
+
 
 @unittest.skipUnless(platform.system() == "Darwin", "Only for MacOS")
 class CMakeAppleFrameworksTestCase(unittest.TestCase):


### PR DESCRIPTION
Changelog: Bugfix: Recover quotes around linker flags in CMake generators, fix failure with Macos frameworks
Docs: omit

In PR https://github.com/conan-io/conan/pull/6780 we lost the quotes we were adding around frameworks, without them CMake generated files are not valid, and the link step fails (https://github.com/conan-io/conan/issues/7321).

**Note.-** This is reintroduced for backward compatibility, but the proper way to declare the frameworks is to add them to the `cpp_info.frameworks` dedicated list:

```python
                def package_info(self):
                    if not self.options.use_components:
                        # self.cpp_info.exelinkflags.extend(['-framework Foundation'])
                        self.cpp_info.frameworks.extend(['Foundation'])
                    else:
                        # self.cpp_info.components["cmp"].exelinkflags.extend(['-framework Foundation'])
                        self.cpp_info.components["cmp"].frameworks.extend(['Foundation'])
```

Fix #7321
Close #1251