### PR TITLE
[conan_v2_mode] Fail if build_type or compiler is not defined for build helpers

### DIFF
--- a/conans/client/build/autotools_environment.py
+++ b/conans/client/build/autotools_environment.py
@@ -43,9 +43,6 @@ class AutoToolsBuildEnvironment(object):
         self._os_target, self._arch_target = get_target_os_arch(conanfile)
 
         self._build_type = conanfile.settings.get_safe("build_type")
-        if not self._build_type:
-            conan_v2_behavior("build_type setting should be defined.",
-                              v1_behavior=self._conanfile.output.warn)
 
         self._compiler = conanfile.settings.get_safe("compiler")
         if not self._compiler:
@@ -233,6 +230,9 @@ class AutoToolsBuildEnvironment(object):
     def make(self, args="", make_program=None, target=None, vars=None):
         if not self._conanfile.should_build:
             return
+        if not self._build_type:
+            conan_v2_behavior("build_type setting should be defined.",
+                              v1_behavior=self._conanfile.output.warn)
         make_program = os.getenv("CONAN_MAKE_PROGRAM") or make_program or "make"
         with environment_append(vars or self.vars):
             str_args = args_to_string(args)

--- a/conans/client/build/autotools_environment.py
+++ b/conans/client/build/autotools_environment.py
@@ -17,6 +17,7 @@ from conans.client.tools.oss import OSInfo, args_to_string, cpu_count, cross_bui
 from conans.client.tools.win import unix_path
 from conans.errors import ConanException
 from conans.model.build_info import DEFAULT_BIN, DEFAULT_INCLUDE, DEFAULT_LIB, DEFAULT_SHARE
+from conans.util.conan_v2_mode import conan_v2_behavior
 from conans.util.files import get_abs_path
 
 
@@ -40,8 +41,17 @@ class AutoToolsBuildEnvironment(object):
         self._os = conanfile.settings.get_safe("os")
         self._arch = conanfile.settings.get_safe("arch")
         self._os_target, self._arch_target = get_target_os_arch(conanfile)
+
         self._build_type = conanfile.settings.get_safe("build_type")
+        if not self._build_type:
+            conan_v2_behavior("build_type setting should be defined.",
+                              v1_behavior=self._conanfile.output.warn)
+
         self._compiler = conanfile.settings.get_safe("compiler")
+        if not self._compiler:
+            conan_v2_behavior("Compiler setting should be defined.",
+                              v1_behavior=self._conanfile.output.warn)
+
         self._compiler_version = conanfile.settings.get_safe("compiler.version")
         self._compiler_runtime = conanfile.settings.get_safe("compiler.runtime")
         self._libcxx = conanfile.settings.get_safe("compiler.libcxx")

--- a/conans/client/build/autotools_environment.py
+++ b/conans/client/build/autotools_environment.py
@@ -49,7 +49,7 @@ class AutoToolsBuildEnvironment(object):
 
         self._compiler = conanfile.settings.get_safe("compiler")
         if not self._compiler:
-            conan_v2_behavior("Compiler setting should be defined.",
+            conan_v2_behavior("compiler setting should be defined.",
                               v1_behavior=self._conanfile.output.warn)
 
         self._compiler_version = conanfile.settings.get_safe("compiler.version")

--- a/conans/client/build/cmake.py
+++ b/conans/client/build/cmake.py
@@ -243,7 +243,7 @@ class CMakeBuildHelper(object):
     def _run(self, command):
         compiler = self._settings.get_safe("compiler")
         if not compiler:
-            conan_v2_behavior("Compiler setting should be defined.",
+            conan_v2_behavior("compiler setting should be defined.",
                               v1_behavior=self._conanfile.output.warn)
         the_os = self._settings.get_safe("os")
         is_clangcl = the_os == "Windows" and compiler == "clang"

--- a/conans/client/build/cmake.py
+++ b/conans/client/build/cmake.py
@@ -78,9 +78,6 @@ class CMakeBuildHelper(object):
         self._conanfile = conanfile
         self._settings = conanfile.settings
         self._build_type = build_type or conanfile.settings.get_safe("build_type")
-        if not self._build_type:
-            conan_v2_behavior("build_type setting should be defined.",
-                              v1_behavior=self._conanfile.output.warn)
         self._cmake_program = os.getenv("CONAN_CMAKE_PROGRAM") or cmake_program or "cmake"
 
         self.generator_platform = generator_platform
@@ -307,6 +304,9 @@ class CMakeBuildHelper(object):
     def build(self, args=None, build_dir=None, target=None):
         if not self._conanfile.should_build:
             return
+        if not self._build_type:
+            conan_v2_behavior("build_type setting should be defined.",
+                              v1_behavior=self._conanfile.output.warn)
         self._build(args, build_dir, target)
 
     def _build(self, args=None, build_dir=None, target=None):

--- a/conans/client/build/cmake.py
+++ b/conans/client/build/cmake.py
@@ -17,6 +17,7 @@ from conans.client.tools.env import environment_append, _environment_add
 from conans.client.tools.oss import cpu_count, args_to_string
 from conans.errors import ConanException
 from conans.model.version import Version
+from conans.util.conan_v2_mode import conan_v2_behavior
 from conans.util.config_parser import get_bool_from_text
 from conans.util.files import mkdir, get_abs_path, walk, decode_text
 from conans.util.runners import version_runner
@@ -77,6 +78,9 @@ class CMakeBuildHelper(object):
         self._conanfile = conanfile
         self._settings = conanfile.settings
         self._build_type = build_type or conanfile.settings.get_safe("build_type")
+        if not self._build_type:
+            conan_v2_behavior("build_type setting should be defined.",
+                              v1_behavior=self._conanfile.output.warn)
         self._cmake_program = os.getenv("CONAN_CMAKE_PROGRAM") or cmake_program or "cmake"
 
         self.generator_platform = generator_platform
@@ -238,6 +242,9 @@ class CMakeBuildHelper(object):
 
     def _run(self, command):
         compiler = self._settings.get_safe("compiler")
+        if not compiler:
+            conan_v2_behavior("Compiler setting should be defined.",
+                              v1_behavior=self._conanfile.output.warn)
         the_os = self._settings.get_safe("os")
         is_clangcl = the_os == "Windows" and compiler == "clang"
         is_msvc = compiler == "Visual Studio"

--- a/conans/client/build/cmake_toolchain_build_helper.py
+++ b/conans/client/build/cmake_toolchain_build_helper.py
@@ -9,6 +9,7 @@ from conans.client.tools.files import chdir
 from conans.client.tools.oss import cpu_count, args_to_string
 from conans.errors import ConanException
 from conans.model.version import Version
+from conans.util.conan_v2_mode import conan_v2_behavior
 from conans.util.files import mkdir
 
 
@@ -102,6 +103,9 @@ class CMakeToolchainBuildHelper(object):
                                          "single-config build systems")
 
         bt = build_type or self._conanfile.settings.get_safe("build_type")
+        if not bt:
+            conan_v2_behavior("build_type setting should be defined.",
+                              v1_behavior=self._conanfile.output.warn)
 
         if bt and self._is_multiconfiguration:
             build_config = "--config %s" % bt

--- a/conans/client/build/meson.py
+++ b/conans/client/build/meson.py
@@ -33,7 +33,7 @@ class Meson(object):
 
         self._compiler = self._ss("compiler")
         if not self._compiler:
-            conan_v2_behavior("Compiler setting should be defined.",
+            conan_v2_behavior("compiler setting should be defined.",
                               v1_behavior=self._conanfile.output.warn)
 
         self._compiler_version = self._ss("compiler.version")
@@ -63,7 +63,7 @@ class Meson(object):
             '17': 'c++17', 'gnu17': 'gnu++17',
             '20': 'c++1z', 'gnu20': 'gnu++1z'
         }
-        
+
         if cppstd:
             self.options['cpp_std'] = cppstd_conan2meson[cppstd]
 

--- a/conans/client/build/meson.py
+++ b/conans/client/build/meson.py
@@ -11,6 +11,7 @@ from conans.client.tools.oss import args_to_string
 from conans.errors import ConanException
 from conans.model.build_info import DEFAULT_BIN, DEFAULT_INCLUDE, DEFAULT_LIB
 from conans.model.version import Version
+from conans.util.conan_v2_mode import conan_v2_behavior
 from conans.util.files import decode_text, get_abs_path, mkdir
 from conans.util.runners import version_runner
 
@@ -29,9 +30,18 @@ class Meson(object):
         self._append_vcvars = append_vcvars
 
         self._os = self._ss("os")
+
         self._compiler = self._ss("compiler")
+        if not self._compiler:
+            conan_v2_behavior("Compiler setting should be defined.",
+                              v1_behavior=self._conanfile.output.warn)
+
         self._compiler_version = self._ss("compiler.version")
+
         self._build_type = self._ss("build_type")
+        if not self._build_type:
+            conan_v2_behavior("build_type setting should be defined.",
+                              v1_behavior=self._conanfile.output.warn)
 
         self.backend = backend or "ninja"  # Other backends are poorly supported, not default other.
 

--- a/conans/client/build/meson.py
+++ b/conans/client/build/meson.py
@@ -39,9 +39,6 @@ class Meson(object):
         self._compiler_version = self._ss("compiler.version")
 
         self._build_type = self._ss("build_type")
-        if not self._build_type:
-            conan_v2_behavior("build_type setting should be defined.",
-                              v1_behavior=self._conanfile.output.warn)
 
         self.backend = backend or "ninja"  # Other backends are poorly supported, not default other.
 
@@ -217,6 +214,9 @@ class Meson(object):
     def build(self, args=None, build_dir=None, targets=None):
         if not self._conanfile.should_build:
             return
+        if not self._build_type:
+            conan_v2_behavior("build_type setting should be defined.",
+                              v1_behavior=self._conanfile.output.warn)
         self._run_ninja_targets(args=args, build_dir=build_dir, targets=targets)
 
     def install(self, args=None, build_dir=None):

--- a/conans/test/conan_v2/build_helpers/autotools.py
+++ b/conans/test/conan_v2/build_helpers/autotools.py
@@ -1,0 +1,41 @@
+import textwrap
+import platform
+import unittest
+
+from conans.test.utils.conan_v2_tests import ConanV2ModeTestCase
+
+
+class AutotoolsBuildHelperTestCase(ConanV2ModeTestCase):
+
+    @unittest.skipUnless(platform.system() == "Linux", "Requires make")
+    def test_no_build_type(self):
+        t = self.get_client()
+        conanfile = textwrap.dedent("""
+            from conans import ConanFile, AutoToolsBuildEnvironment
+            class Pkg(ConanFile):
+                settings = "os", "arch", "compiler"
+                def build(self):
+                  autotools = AutoToolsBuildEnvironment(self)
+                  autotools.configure()
+                  autotools.make()
+        """)
+        t.save({"conanfile.py": conanfile})
+        t.run("create . pkg/0.1@user/testing", assert_error=True)
+        self.assertIn("Conan v2 incompatible: build_type setting should be defined.", t.out)
+
+    @unittest.skipUnless(platform.system() == "Linux", "Requires make")
+    def test_no_compiler(self):
+        t = self.get_client()
+        conanfile = textwrap.dedent("""
+            from conans import ConanFile, AutoToolsBuildEnvironment
+
+            class Pkg(ConanFile):
+                settings = "os", "arch", "build_type"
+                def build(self):
+                  autotools = AutoToolsBuildEnvironment(self)
+                  autotools.configure()
+                  autotools.make()
+        """)
+        t.save({"conanfile.py": conanfile})
+        t.run("create . pkg/0.1@user/testing", assert_error=True)
+        self.assertIn("Conan v2 incompatible: compiler setting should be defined.", t.out)

--- a/conans/test/conan_v2/build_helpers/cmake.py
+++ b/conans/test/conan_v2/build_helpers/cmake.py
@@ -1,0 +1,50 @@
+import textwrap
+
+from conans.test.utils.conan_v2_tests import ConanV2ModeTestCase
+
+
+class CMakeBuildHelperTestCase(ConanV2ModeTestCase):
+
+    def test_no_build_type(self):
+        t = self.get_client()
+        conanfile = textwrap.dedent("""
+            from conans import ConanFile, CMake
+            class Pkg(ConanFile):
+                settings = "os", "arch", "compiler"
+                def build(self):
+                    cmake = CMake(self)
+                    cmake.build()
+        """)
+        t.save({"conanfile.py": conanfile})
+        t.run("create . pkg/0.1@user/testing", assert_error=True)
+        self.assertIn("Conan v2 incompatible: build_type setting should be defined.", t.out)
+
+    def test_no_compiler(self):
+        t = self.get_client()
+        conanfile = textwrap.dedent("""
+            from conans import ConanFile, CMake
+            
+            class Pkg(ConanFile):
+                settings = "os", "arch", "build_type"
+                def build(self):
+                    cmake = CMake(self)
+                    cmake.build()
+        """)
+        t.save({"conanfile.py": conanfile})
+        t.run("create . pkg/0.1@user/testing", assert_error=True)
+        self.assertIn("Conan v2 incompatible: compiler setting should be defined.", t.out)
+
+    def test_toolchain_no_build_type(self):
+        t = self.get_client()
+        conanfile = textwrap.dedent("""
+            from conans import ConanFile, CMake
+            class Pkg(ConanFile):
+                toolchain = "cmake"
+    
+                def build(self):
+                    cmake = CMake(self)
+                    cmake.build()
+        """)
+        t.save({"conanfile.py": conanfile})
+        t.run("create . pkg/0.1@user/testing", assert_error=True)
+        self.assertIn("Conan v2 incompatible: build_type setting should be defined.", t.out)

--- a/conans/test/conan_v2/build_helpers/meson.py
+++ b/conans/test/conan_v2/build_helpers/meson.py
@@ -15,6 +15,7 @@ class MesonBuildHelperTestCase(ConanV2ModeTestCase):
                 settings = "os", "arch", "compiler"
                 def build(self):
                      meson = Meson(self)
+                     meson.build()
         """)
         t.save({"conanfile.py": conanfile})
         t.run("create . pkg/0.1@user/testing", assert_error=True)
@@ -29,6 +30,7 @@ class MesonBuildHelperTestCase(ConanV2ModeTestCase):
                 settings = "os", "arch", "build_type"
                 def build(self):
                      meson = Meson(self)
+                     meson.build()
         """)
         t.save({"conanfile.py": conanfile})
         t.run("create . pkg/0.1@user/testing", assert_error=True)

--- a/conans/test/conan_v2/build_helpers/meson.py
+++ b/conans/test/conan_v2/build_helpers/meson.py
@@ -1,0 +1,35 @@
+import textwrap
+import platform
+import unittest
+
+from conans.test.utils.conan_v2_tests import ConanV2ModeTestCase
+
+
+class MesonBuildHelperTestCase(ConanV2ModeTestCase):
+
+    def test_no_build_type(self):
+        t = self.get_client()
+        conanfile = textwrap.dedent("""
+            from conans import ConanFile, Meson
+            class Pkg(ConanFile):
+                settings = "os", "arch", "compiler"
+                def build(self):
+                     meson = Meson(self)
+        """)
+        t.save({"conanfile.py": conanfile})
+        t.run("create . pkg/0.1@user/testing", assert_error=True)
+        self.assertIn("Conan v2 incompatible: build_type setting should be defined.", t.out)
+
+    def test_no_compiler(self):
+        t = self.get_client()
+        conanfile = textwrap.dedent("""
+            from conans import ConanFile, Meson
+
+            class Pkg(ConanFile):
+                settings = "os", "arch", "build_type"
+                def build(self):
+                     meson = Meson(self)
+        """)
+        t.save({"conanfile.py": conanfile})
+        t.run("create . pkg/0.1@user/testing", assert_error=True)
+        self.assertIn("Conan v2 incompatible: compiler setting should be defined.", t.out)


### PR DESCRIPTION
Changelog: Feature: When using `CONAN_V2_MODE` if build_type or compiler are not defined Conan will raise an error.
Docs: https://github.com/conan-io/docs/pull/1783

- [X] Refer to the issue that supports this Pull Request.
- [X] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [X] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [X] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 

<sup>**Note:** By default this PR will skip the slower tests and will use a limited set of python versions. Check [here](https://github.com/conan-io/conan/blob/develop/.github/PR_INCREASE_TESTING.md) how to increase the testing level by writing some tags in the current PR body text.</sup>
