### PR TITLE
[tests] Create default cache once, then copy it

### DIFF
--- a/conans/client/build/cmake_flags.py
+++ b/conans/client/build/cmake_flags.py
@@ -173,7 +173,6 @@ class CMakeDefinitionsBuilder(object):
         return definitions
 
     def _cmake_cross_build_defines(self):
-
         os_ = self._ss("os")
         arch = self._ss("arch")
         os_ver_str = "os.api_level" if os_ == "Android" else "os.version"

--- a/conans/test/functional/command/profile_test.py
+++ b/conans/test/functional/command/profile_test.py
@@ -25,13 +25,13 @@ class ProfileTest(unittest.TestCase):
         self.assertIn("conanfile.txt: Generated conaninfo.txt", client.out)
 
     def empty_test(self):
-        client = TestClient()
+        client = TestClient(cache_autopopulate=False)
         client.run("profile list")
         self.assertIn("No profiles defined", client.out)
 
     def list_test(self):
         client = TestClient()
-        profiles = ["profile1", "profile2", "profile3",
+        profiles = ["default", "profile1", "profile2", "profile3",
                     "nested" + os.path.sep + "profile4",
                     "nested" + os.path.sep + "two" + os.path.sep + "profile5",
                     "nested" + os.path.sep + "profile6"]

--- a/conans/test/functional/settings/conan_settings_preprocessor_test.py
+++ b/conans/test/functional/settings/conan_settings_preprocessor_test.py
@@ -28,7 +28,6 @@ class HelloConan(ConanFile):
 
     def test_runtime_auto(self):
         # Ensure that compiler.runtime is not declared
-        self.client.run("profile new --detect default")
         default_profile = load(self.client.cache.default_profile_path)
         self.assertNotIn(default_profile, "compiler.runtime")
         self.client.run("install Hello0/0.1@lasote/channel --build missing")

--- a/conans/test/utils/conan_v2_tests.py
+++ b/conans/test/utils/conan_v2_tests.py
@@ -16,7 +16,7 @@ class ConanV2ModeTestCase(unittest.TestCase):
         t = TestClient(*args, **kwargs)
         if use_settings_v1:
             t.save({os.path.join(t.cache_folder, CONAN_SETTINGS):
-                        get_default_settings_yml(force_v1=True)})
+                    get_default_settings_yml(force_v1=True)})
         return t
 
     def run(self, *args, **kwargs):

--- a/conans/test/utils/test_files.py
+++ b/conans/test/utils/test_files.py
@@ -28,7 +28,7 @@ def wait_until_removed(folder):
         raise Exception("Could remove folder %s: %s" % (folder, latest_exception))
 
 
-def temp_folder(path_with_spaces=True):
+def temp_folder(path_with_spaces=True, create_dir=True):
     t = tempfile.mkdtemp(suffix='conans', dir=CONAN_TEST_FOLDER)
     # Make sure that the temp folder is correctly cased, as tempfile return lowercase for Win
     t = get_cased_path(t)
@@ -41,7 +41,8 @@ def temp_folder(path_with_spaces=True):
     else:
         path = "path with spaces"
     nt = os.path.join(t, path)
-    os.makedirs(nt)
+    if create_dir:
+        os.makedirs(nt)
     return nt
 
 

--- a/conans/test/utils/tools.py
+++ b/conans/test/utils/tools.py
@@ -8,6 +8,7 @@ import stat
 import subprocess
 import sys
 import tempfile
+import textwrap
 import threading
 import time
 import unittest
@@ -49,6 +50,7 @@ from conans.test.utils.server_launcher import (TESTING_REMOTE_PRIVATE_PASS,
                                                TESTING_REMOTE_PRIVATE_USER,
                                                TestServerLauncher)
 from conans.test.utils.test_files import temp_folder
+from conans.util.conan_v2_mode import CONAN_V2_MODE_ENVVAR
 from conans.util.env_reader import get_env
 from conans.util.files import mkdir, save_files
 from conans.util.runners import check_output_runner
@@ -489,7 +491,8 @@ class TestBufferConanOutput(ConanOutput):
         return value in self.__repr__()
 
 
-def create_local_git_repo(files=None, branch=None, submodules=None, folder=None, commits=1, tags=None):
+def create_local_git_repo(files=None, branch=None, submodules=None, folder=None, commits=1,
+                          tags=None):
     tmp = folder or temp_folder()
     tmp = get_cased_path(tmp)
     if files:
@@ -616,7 +619,6 @@ class LocalDBMock(object):
 
 
 class MockedUserIO(UserIO):
-
     """
     Mock for testing. If get_username or get_password is requested will raise
     an exception except we have a value to return.
@@ -659,6 +661,23 @@ class MockedUserIO(UserIO):
         return tmp
 
 
+def _copy_cache_folder(target_folder):
+    # Some variables affect to cache population (take a different default folder)
+    cache_key = hash(os.environ.get(CONAN_V2_MODE_ENVVAR, None))
+    master_folder = _copy_cache_folder.master.setdefault(cache_key, temp_folder(create_dir=False))
+    if not os.path.exists(master_folder):
+        # Create and populate the cache folder with the defaults
+        cache = ClientCache(master_folder, TestBufferConanOutput())
+        cache.initialize_config()
+        cache.registry.initialize_remotes()
+        cache.initialize_default_profile()
+        cache.initialize_settings()
+    shutil.copytree(master_folder, target_folder)
+
+
+_copy_cache_folder.master = dict()  # temp_folder(create_dir=False)
+
+
 class TestClient(object):
     """ Test wrap of the conans application to launch tests in the same way as
     in command line
@@ -666,7 +685,8 @@ class TestClient(object):
 
     def __init__(self, cache_folder=None, current_folder=None, servers=None, users=None,
                  requester_class=None, runner=None, path_with_spaces=True,
-                 revisions_enabled=None, cpu_count=1, default_server_user=None):
+                 revisions_enabled=None, cpu_count=1, default_server_user=None,
+                 cache_autopopulate=True):
         """
         current_folder: Current execution folder
         servers: dict of {remote_name: TestServer}
@@ -692,16 +712,23 @@ class TestClient(object):
         if self.users is None:
             self.users = {"default": [(TESTING_REMOTE_PRIVATE_USER, TESTING_REMOTE_PRIVATE_PASS)]}
 
-        self.cache_folder = cache_folder or temp_folder(path_with_spaces)
+        if cache_autopopulate and (not cache_folder or not os.path.exists(cache_folder)):
+            # Copy a cache folder already populated
+            self.cache_folder = cache_folder or temp_folder(path_with_spaces, create_dir=False)
+            _copy_cache_folder(self.cache_folder)
+        else:
+            self.cache_folder = cache_folder or temp_folder(path_with_spaces)
+
         self.requester_class = requester_class
         self.runner = runner
 
         if servers and len(servers) > 1 and not isinstance(servers, OrderedDict):
-            raise Exception("""Testing framework error: Servers should be an OrderedDict. e.g:
-servers = OrderedDict()
-servers["r1"] = server
-servers["r2"] = TestServer()
-""")
+            raise Exception(textwrap.dedent("""
+                Testing framework error: Servers should be an OrderedDict. e.g:
+                    servers = OrderedDict()
+                    servers["r1"] = server
+                    servers["r2"] = TestServer()
+            """))
 
         self.servers = servers or {}
         if servers is not False:  # Do not mess with registry remotes
@@ -767,7 +794,7 @@ servers["r2"] = TestServer()
     def tune_conan_conf(self, cache_folder, cpu_count, revisions_enabled):
         # Create the default
         cache = self.cache
-        cache.config
+        _ = cache.config
 
         if cpu_count:
             replace_in_file(cache.conan_conf_path,
@@ -866,7 +893,7 @@ servers["r2"] = TestServer()
             exc_message = "\n{header}\n{cmd}\n{output_header}\n{output}\n{output_footer}\n".format(
                 header='{:-^80}'.format(msg),
                 output_header='{:-^80}'.format(" Output: "),
-                output_footer='-'*80,
+                output_footer='-' * 80,
                 cmd=command,
                 output=self.out
             )
@@ -908,7 +935,6 @@ servers["r2"] = TestServer()
 
 
 class TurboTestClient(TestClient):
-
     tmp_json_name = ".tmp_json"
 
     def __init__(self, *args, **kwargs):


### PR DESCRIPTION
Changelog: omit
Docs: omit

This PR creates the Conan cache for the `TestClient` once and then copy it to every instance of this class (given the same value for the envvar `CONAN_V2_MODE`). It should unblock https://github.com/conan-io/conan/pull/5740, now the _autodetection_ is performed only once and testing time shouldn't be affected by those changes.

#TAGS: svn, slow
#REVISIONS: 1