### PR TITLE
Do not fail with 'conan remove -r remote -p' if there are no packages in the remote

### DIFF
--- a/conans/client/rest/rest_client_v1.py
+++ b/conans/client/rest/rest_client_v1.py
@@ -307,7 +307,7 @@ class RestV1Methods(RestCommonMethods):
     @handle_return_deserializer()
     def remove_packages(self, ref, package_ids=None):
         """ Remove any packages specified by package_ids"""
-        pcks = self.search_packages(ref, query=None)
+        pcks = self.search_packages(ref.copy_clear_rev(), query=None)
         if pcks:
             self.check_credentials()
             payload = {"package_ids": package_ids}

--- a/conans/client/rest/rest_client_v1.py
+++ b/conans/client/rest/rest_client_v1.py
@@ -1,6 +1,7 @@
 import os
 import time
 import traceback
+from collections import namedtuple
 
 from six.moves.urllib.parse import parse_qs, urljoin, urlparse, urlsplit
 
@@ -306,10 +307,13 @@ class RestV1Methods(RestCommonMethods):
     @handle_return_deserializer()
     def remove_packages(self, ref, package_ids=None):
         """ Remove any packages specified by package_ids"""
-        self.check_credentials()
-        payload = {"package_ids": package_ids}
-        url = self.router.remove_packages(ref)
-        return self._post_json(url, payload)
+        pcks = self.search_packages(ref, query=None)
+        if pcks:
+            self.check_credentials()
+            payload = {"package_ids": package_ids}
+            url = self.router.remove_packages(ref)
+            return self._post_json(url, payload)
+        return namedtuple("_", ['status_code', 'content'])(200, b'')
 
     @handle_return_deserializer()
     def remove_conanfile(self, ref):

--- a/conans/client/rest/rest_client_v1.py
+++ b/conans/client/rest/rest_client_v1.py
@@ -307,7 +307,7 @@ class RestV1Methods(RestCommonMethods):
     @handle_return_deserializer()
     def remove_packages(self, ref, package_ids=None):
         """ Remove any packages specified by package_ids"""
-        pcks = self.search_packages(ref.copy_clear_rev(), query=None)
+        pcks = self.search_packages(ref, query=None)
         if pcks:
             self.check_credentials()
             payload = {"package_ids": package_ids}

--- a/conans/client/rest/rest_client_v1.py
+++ b/conans/client/rest/rest_client_v1.py
@@ -311,7 +311,7 @@ class RestV1Methods(RestCommonMethods):
         payload = {"package_ids": package_ids}
         url = self.router.remove_packages(ref)
         ret = self._post_json(url, payload)
-        if package_ids is None and ret.status_code == 404:
+        if package_ids is not None and ret.status_code == 404:
             # Check if it is a 404 because there are no packages
             pcks = self.search_packages(ref, query=None)
             if not pcks:

--- a/conans/client/rest/rest_client_v1.py
+++ b/conans/client/rest/rest_client_v1.py
@@ -311,7 +311,7 @@ class RestV1Methods(RestCommonMethods):
         payload = {"package_ids": package_ids}
         url = self.router.remove_packages(ref)
         ret = self._post_json(url, payload)
-        if ret.status_code == 404:
+        if package_ids is None and ret.status_code == 404:
             # Check if it is a 404 because there are no packages
             pcks = self.search_packages(ref, query=None)
             if not pcks:

--- a/conans/client/rest/rest_client_v1.py
+++ b/conans/client/rest/rest_client_v1.py
@@ -307,13 +307,16 @@ class RestV1Methods(RestCommonMethods):
     @handle_return_deserializer()
     def remove_packages(self, ref, package_ids=None):
         """ Remove any packages specified by package_ids"""
-        pcks = self.search_packages(ref, query=None)
-        if pcks:
-            self.check_credentials()
-            payload = {"package_ids": package_ids}
-            url = self.router.remove_packages(ref)
-            return self._post_json(url, payload)
-        return namedtuple("_", ['status_code', 'content'])(200, b'')
+        self.check_credentials()
+        payload = {"package_ids": package_ids}
+        url = self.router.remove_packages(ref)
+        ret = self._post_json(url, payload)
+        if ret.status_code == 404:
+            # Check if it is a 404 because there are no packages
+            pcks = self.search_packages(ref, query=None)
+            if not pcks:
+                return namedtuple("_", ['status_code', 'content'])(200, b'')
+        return ret
 
     @handle_return_deserializer()
     def remove_conanfile(self, ref):

--- a/conans/client/rest/rest_client_v2.py
+++ b/conans/client/rest/rest_client_v2.py
@@ -232,7 +232,7 @@ class RestV2Methods(RestCommonMethods):
         # V2 === revisions, do not remove files, it will create a new revision if the files changed
         return
 
-    def remove_packages(self, ref, package_ids=None):
+    def remove_packages(self, ref, package_ids):
         """ Remove any packages specified by package_ids"""
         self.check_credentials()
 
@@ -250,10 +250,14 @@ class RestV2Methods(RestCommonMethods):
                 response = self.requester.delete(url, auth=self.auth, verify=self.verify_ssl,
                                                  headers=self.custom_headers)
                 if response.status_code == 404:
-                    # Check if it is a 404 because there are no packages
-                    package_search_url = self.router.search_packages(ref)
-                    if not self.get_json(package_search_url):
-                        return
+                    # Double check if it is a 404 because there are no packages
+                    try:
+                        package_search_url = self.router.search_packages(ref)
+                        if not self.get_json(package_search_url):
+                            return
+                    except Exception as e:
+                        logger.warning("Unexpected error searching {} packages"
+                                       " in remote {}: {}".format(ref, self.remote_url, e))
                 if response.status_code != 200:  # Error message is text
                     # To be able to access ret.text (ret.content are bytes)
                     response.charset = "utf-8"

--- a/conans/client/rest/rest_client_v2.py
+++ b/conans/client/rest/rest_client_v2.py
@@ -246,13 +246,16 @@ class RestV2Methods(RestCommonMethods):
         for ref in refs:
             assert ref.revision is not None, "remove_packages needs RREV"
             if not package_ids:
-                url = self.router.remove_all_packages(ref)
-                response = self.requester.delete(url, auth=self.auth, headers=self.custom_headers,
-                                                 verify=self.verify_ssl)
-                if response.status_code != 200:  # Error message is text
-                    # To be able to access ret.text (ret.content are bytes)
-                    response.charset = "utf-8"
-                    raise get_exception_from_error(response.status_code)(response.text)
+                # Check there are packages to remove
+                package_search_url = self.router.search_packages(ref)
+                if self.get_json(package_search_url):
+                    url = self.router.remove_all_packages(ref)
+                    response = self.requester.delete(url, auth=self.auth, verify=self.verify_ssl,
+                                                     headers=self.custom_headers)
+                    if response.status_code != 200:  # Error message is text
+                        # To be able to access ret.text (ret.content are bytes)
+                        response.charset = "utf-8"
+                        raise get_exception_from_error(response.status_code)(response.text)
             else:
                 for pid in package_ids:
                     pref = PackageReference(ref, pid)

--- a/conans/client/rest/rest_client_v2.py
+++ b/conans/client/rest/rest_client_v2.py
@@ -246,16 +246,18 @@ class RestV2Methods(RestCommonMethods):
         for ref in refs:
             assert ref.revision is not None, "remove_packages needs RREV"
             if not package_ids:
-                # Check there are packages to remove
-                package_search_url = self.router.search_packages(ref)
-                if self.get_json(package_search_url):
-                    url = self.router.remove_all_packages(ref)
-                    response = self.requester.delete(url, auth=self.auth, verify=self.verify_ssl,
-                                                     headers=self.custom_headers)
-                    if response.status_code != 200:  # Error message is text
-                        # To be able to access ret.text (ret.content are bytes)
-                        response.charset = "utf-8"
-                        raise get_exception_from_error(response.status_code)(response.text)
+                url = self.router.remove_all_packages(ref)
+                response = self.requester.delete(url, auth=self.auth, verify=self.verify_ssl,
+                                                 headers=self.custom_headers)
+                if response.status_code == 404:
+                    # Check if it is a 404 because there are no packages
+                    package_search_url = self.router.search_packages(ref)
+                    if not self.get_json(package_search_url):
+                        return
+                if response.status_code != 200:  # Error message is text
+                    # To be able to access ret.text (ret.content are bytes)
+                    response.charset = "utf-8"
+                    raise get_exception_from_error(response.status_code)(response.text)
             else:
                 for pid in package_ids:
                     pref = PackageReference(ref, pid)

--- a/conans/test/functional/command/remote_test.py
+++ b/conans/test/functional/command/remote_test.py
@@ -3,9 +3,10 @@ import re
 import unittest
 from collections import OrderedDict
 
+from conans.model.ref import ConanFileReference
+from conans.test.utils.genconanfile import GenConanfile
 from conans.test.utils.tools import NO_SETTINGS_PACKAGE_ID, TestClient, TestServer
 from conans.util.files import load
-from conans.model.ref import ConanFileReference
 
 
 class RemoteTest(unittest.TestCase):
@@ -21,12 +22,7 @@ class RemoteTest(unittest.TestCase):
         self.client = TestClient(servers=self.servers, users=self.users)
 
     def test_removed_references(self):
-        conanfile = """
-from conans import ConanFile
-class HelloConan(ConanFile):
-    pass
-"""
-        self.client.save({"conanfile.py": conanfile})
+        self.client.save({"conanfile.py": GenConanfile()})
         self.client.run("create . lib/1.0@lasote/channel")
         self.client.run('upload "*" -c -r remote1')
         self.client.run('upload "*" -c -r remote2')
@@ -86,7 +82,7 @@ class HelloConan(ConanFile):
 
     def list_raw_test(self):
         self.client.run("remote list --raw")
-        output = re.sub(r"http:\/\/fake.+\.com", "http://fake.com", str(self.client.out))
+        output = re.sub(r"http://fake.+\.com", "http://fake.com", str(self.client.out))
         self.assertIn("remote0 http://fake.com True", output)
         self.assertIn("remote1 http://fake.com True", output)
         self.assertIn("remote2 http://fake.com True", output)
@@ -342,12 +338,10 @@ class HelloConan(ConanFile):
         client = TestClient()
 
         client.run("remote disable invalid_remote", assert_error=True)
-        self.assertIn("ERROR: Remote 'invalid_remote' not found in remotes",
-                      client.out)
+        self.assertIn("ERROR: Remote 'invalid_remote' not found in remotes", client.out)
 
         client.run("remote enable invalid_remote", assert_error=True)
-        self.assertIn("ERROR: Remote 'invalid_remote' not found in remotes",
-                      client.out)
+        self.assertIn("ERROR: Remote 'invalid_remote' not found in remotes", client.out)
 
         client.run("remote disable invalid_wildcard_*")
 
@@ -390,12 +384,10 @@ class HelloConan(ConanFile):
         self.client.run("remote list")
         url = str(self.client.out).split()[1]
         self.client.run("remote add newname %s" % url, assert_error=True)
-        self.assertIn("Remote 'remote0' already exists with same URL",
-                      self.client.out)
+        self.assertIn("Remote 'remote0' already exists with same URL", self.client.out)
 
         self.client.run("remote update remote1 %s" % url, assert_error=True)
-        self.assertIn("Remote 'remote0' already exists with same URL",
-                      self.client.out)
+        self.assertIn("Remote 'remote0' already exists with same URL", self.client.out)
 
     def basic_refs_test(self):
         self.client.run("remote add_ref Hello/0.1@user/testing remote0")
@@ -468,9 +460,7 @@ class HelloConan(ConanFile):
         """
         Check that 'conan remote' commands work with editable packages
         """
-        self.client.save({"conanfile.py": """from conans import ConanFile
-class Conan(ConanFile):
-    pass"""})
+        self.client.save({"conanfile.py": GenConanfile()})
         self.client.run("create . pkg/1.1@lasote/stable")
         self.client.run("upload pkg/1.1@lasote/stable --all -c --remote remote1")
         self.client.run("remove -f pkg/1.1@lasote/stable")
@@ -503,3 +493,9 @@ class Conan(ConanFile):
         self.client.run("remote list")
         self.assertNotIn("remote1", self.client.out)
         self.assertNotIn("remote0", self.client.out)
+
+    def test_remove_package_empty(self):
+        self.client.save({"conanfile.py": GenConanfile("name", "version")})
+        self.client.run("export . name/version@lasote/stable")
+        self.client.run("upload name/version@lasote/stable --remote remote1")
+        self.client.run("remove -f -p -r remote1 name/version@lasote/stable")

--- a/conans/test/functional/command/remote_test.py
+++ b/conans/test/functional/command/remote_test.py
@@ -82,7 +82,7 @@ class RemoteTest(unittest.TestCase):
 
     def list_raw_test(self):
         self.client.run("remote list --raw")
-        output = re.sub(r"http://fake.+\.com", "http://fake.com", str(self.client.out))
+        output = re.sub(r"http://fake.+.com", "http://fake.com", str(self.client.out))
         self.assertIn("remote0 http://fake.com True", output)
         self.assertIn("remote1 http://fake.com True", output)
         self.assertIn("remote2 http://fake.com True", output)

--- a/conans/test/functional/remote/rest_api_test.py
+++ b/conans/test/functional/remote/rest_api_test.py
@@ -7,13 +7,13 @@ from mock import Mock
 from nose.plugins.attrib import attr
 
 from conans import DEFAULT_REVISION_V1
-from conans.client.userio import UserIO
-from conans.client.remote_manager import Remote
 from conans.client.conf import ConanClientConfigParser
+from conans.client.remote_manager import Remote
 from conans.client.rest.auth_manager import ConanApiAuthManager
 from conans.client.rest.conan_requester import ConanRequester
 from conans.client.rest.rest_client import RestApiClientFactory
 from conans.client.rest.rest_client_v1 import complete_url
+from conans.client.userio import UserIO
 from conans.model.info import ConanInfo
 from conans.model.manifest import FileTreeManifest
 from conans.model.ref import ConanFileReference, PackageReference
@@ -231,10 +231,13 @@ class RestApiTest(unittest.TestCase):
         for sha in ["1", "2", "3", "4", "5"]:
             # Upload an package
             pref = PackageReference(ref, sha, DEFAULT_REVISION_V1)
-            self._upload_package(pref)
+            self._upload_package(pref, {CONANINFO: ""})
             folder = self.server.server_store.package(pref)
             self.assertTrue(os.path.exists(folder))
             folders[sha] = folder
+
+        data = self.api.search_packages(ref, None)
+        self.assertEqual(len(data), 5)
 
         self.api.remove_packages(ref, ["1"])
         self.assertTrue(os.path.exists(self.server.server_store.base_folder(ref)))


### PR DESCRIPTION
Changelog: Bugfix: Do not fail for `conan remove -r remote -p` when there are no packages in the remote.
Docs: omit

Check there are no packages before trying to remove the package folder in the server. It prevents a 404 error.

close https://github.com/conan-io/conan/issues/7332

#REVISIONS: 1