### PR TITLE
package_id_unknown transitive failures fix

### DIFF
--- a/conans/client/graph/graph_binaries.py
+++ b/conans/client/graph/graph_binaries.py
@@ -294,6 +294,8 @@ class GraphBinariesAnalyzer(object):
 
         direct_reqs, indirect_reqs = self.package_id_transitive_reqs(node)
 
+        # FIXME: Conan v2.0 This is introducing a bug for backwards compatibility, it will add
+        #   only the requirements available in the 'neighbour.info' object, not all the closure
         if not self._fixed_package_id:
             old_indirect = set()
             for neighbor in neighbors:

--- a/conans/client/graph/graph_binaries.py
+++ b/conans/client/graph/graph_binaries.py
@@ -291,17 +291,15 @@ class GraphBinariesAnalyzer(object):
         # A bit risky to be done now
         conanfile = node.conanfile
         neighbors = node.neighbors()
+
+        direct_reqs, indirect_reqs = self.package_id_transitive_reqs(node)
+
         if not self._fixed_package_id:
-            direct_reqs = []  # of PackageReference
-            indirect_reqs = set()  # of PackageReference, avoid duplicates
+            old_indirect = set()
             for neighbor in neighbors:
-                ref, nconan = neighbor.ref, neighbor.conanfile
-                direct_reqs.append(neighbor.pref)
-                indirect_reqs.update(nconan.info.requires.refs())
-            # Make sure not duplicated
+                old_indirect.update((p.ref, p.id) for p in neighbor.conanfile.info.requires.refs())
+            indirect_reqs = set(p for p in indirect_reqs if (p.ref, p.id) in old_indirect)
             indirect_reqs.difference_update(direct_reqs)
-        else:
-            direct_reqs, indirect_reqs = self.package_id_transitive_reqs(node)
 
         python_requires = getattr(conanfile, "python_requires", None)
         if python_requires:

--- a/conans/test/functional/package_id/package_id_requires_modes_test.py
+++ b/conans/test/functional/package_id/package_id_requires_modes_test.py
@@ -592,3 +592,35 @@ class PackageIDErrorTest(unittest.TestCase):
         client2.save({"conanfile.py": GenConanfile().with_require_plain("dep2/1.0@user/testing")})
         client2.run('create . consumer/1.0@user/testing --build')
         self.assertIn("consumer/1.0@user/testing: Created", client2.out)
+
+
+class PackageRevisionModeTestCase(unittest.TestCase):
+
+    def test_transtive_package_revision_mode(self):
+        t = TestClient()
+        t.save({
+            'package1.py': GenConanfile("pkg1"),
+            'package2.py': GenConanfile("pkg2").with_require_plain("pkg1/1.0"),
+            'package3.py': textwrap.dedent("""
+                from conans import ConanFile
+                class Recipe(ConanFile):
+                    requires = "pkg2/1.0"
+                    def package_id(self):
+                        self.info.requires["pkg1"].package_revision_mode()
+            """)
+        })
+        t.run("create package1.py pkg1/1.0@")
+        t.run("create package2.py pkg2/1.0@")
+
+        # If we only build pkg1, we get a new packageID for pkg3
+        t.run("create package3.py pkg3/1.0@ --build=pkg1", assert_error=True)
+        self.assertIn("pkg3/1.0:Package_ID_unknown - Unknown", t.out)
+        self.assertIn("pkg3/1.0: Updated ID: 283642385cc7b64ec7b5903f6895107e0848d238", t.out)
+        self.assertIn("ERROR: Missing binary: pkg3/1.0:283642385cc7b64ec7b5903f6895107e0848d238",
+                      t.out)
+
+        # If we build both, we get the new package
+        t.run("create package3.py pkg3/1.0@ --build=pkg1 --build=pkg3")
+        self.assertIn("pkg3/1.0:Package_ID_unknown - Unknown", t.out)
+        self.assertIn("pkg3/1.0: Updated ID: 283642385cc7b64ec7b5903f6895107e0848d238", t.out)
+        self.assertIn("pkg3/1.0: Package '283642385cc7b64ec7b5903f6895107e0848d238' created", t.out)


### PR DESCRIPTION
Changelog: Bugfix: Avoid crash while computing ``package_id`` when using ``package_revision_mode``, and also incorrectly using installed binaries and reporting them installed after the re-computation of ``package_id`` resolved to a different binary.
Docs: Omit

Close https://github.com/conan-io/conan/pull/7306
Close #7270

#tags: slow
#revisions: 1