### PR TITLE
relax msbuild generator to not fail in Linux

### DIFF
--- a/conans/client/generators/msbuild.py
+++ b/conans/client/generators/msbuild.py
@@ -87,8 +87,8 @@ class MSBuildGenerator(Generator):
                                'x86_64': 'x64'}.get(settings.get_safe("arch"))),
                  ("PlatformToolset", toolset)]
 
-        name = "".join("_%s" % v for _, v in props)
-        condition = " And ".join("'$(%s)' == '%s'" % (k, v) for k, v in props)
+        name = "".join("_%s" % v for _, v in props if v is not None)
+        condition = " And ".join("'$(%s)' == '%s'" % (k, v) for k, v in props if v is not None)
         return name.lower(), condition
 
     def _general(self, name_general, deps):
@@ -192,8 +192,6 @@ class MSBuildGenerator(Generator):
     @property
     def content(self):
         print("*** The 'msbuild' generator is EXPERIMENTAL ***")
-        if self.conanfile.settings.compiler != "Visual Studio":
-            raise ConanException("The 'msbuild' generator only works with Visual Studio compiler")
         if not self.conanfile.settings.get_safe("build_type"):
             raise ConanException("The 'msbuild' generator requires a 'build_type' setting value")
         result = {}

--- a/conans/test/functional/generators/msbuild_test.py
+++ b/conans/test/functional/generators/msbuild_test.py
@@ -490,3 +490,33 @@ class MSBuildGeneratorTest(unittest.TestCase):
         client.run("install mypkg/0.1@ -g msbuild -s build_type=None", assert_error=True)
         self.assertIn("ERROR: The 'msbuild' generator requires a 'build_type' setting value",
                       client.out)
+
+
+class TestMSBuild(unittest.TestCase):
+    def test_generator_linux(self):
+        client = TestClient()
+        client.save({"conanfile.py": GenConanfile()})
+        client.run("create . pkg/1.0@")
+
+        conanfile = textwrap.dedent("""
+            from conans import ConanFile
+            class Pkg(ConanFile):
+                settings = "os", "compiler", "arch", "build_type"
+                generators = "msbuild"
+                requires = "pkg/1.0"
+            """)
+        client.save({"conanfile.py": conanfile})
+
+        client.run('install . -s os=Windows -s compiler="Visual Studio" -s compiler.version=15'
+                   ' -s compiler.runtime=MD')
+        self.assertIn("conanfile.py: Generator msbuild created conan_deps.props", client.out)
+        client.run("install . -s os=Linux -s compiler=gcc -s compiler.version=5.2 '"
+                   "'-s compiler.libcxx=libstdc++")
+
+        self.assertIn("conanfile.py: Generator msbuild created conan_deps.props", client.out)
+        self.assertIn("conanfile.py: Generator msbuild created conan_pkg.props", client.out)
+        self.assertIn("conanfile.py: Generator msbuild created conan_pkg_release_x64.props",
+                      client.out)
+
+        pkg_props = client.load("conan_pkg.props")
+        self.assertIn('Project="conan_pkg_release_x64.props"', pkg_props)

--- a/conans/test/functional/generators/msbuild_test.py
+++ b/conans/test/functional/generators/msbuild_test.py
@@ -479,32 +479,15 @@ class MSBuildGeneratorTest(unittest.TestCase):
     def install_reference_gcc_test(self):
         client = TestClient()
         client.save({"conanfile.py": GenConanfile()})
-        client.run("create . mypkg/0.1@ -s compiler=gcc")
-        client.run("install mypkg/0.1@ -s compiler=gcc -g msbuild", assert_error=True)
-        self.assertIn("The 'msbuild' generator only works with Visual Studio compiler", client.out)
-
-    def no_build_type_error_test(self):
-        client = TestClient()
-        client.save({"conanfile.py": GenConanfile()})
-        client.run("create . mypkg/0.1@")
-        client.run("install mypkg/0.1@ -g msbuild -s build_type=None", assert_error=True)
-        self.assertIn("ERROR: The 'msbuild' generator requires a 'build_type' setting value",
-                      client.out)
-
-
-class TestMSBuild(unittest.TestCase):
-    def test_generator_linux(self):
-        client = TestClient()
-        client.save({"conanfile.py": GenConanfile()})
         client.run("create . pkg/1.0@")
 
         conanfile = textwrap.dedent("""
-            from conans import ConanFile
-            class Pkg(ConanFile):
-                settings = "os", "compiler", "arch", "build_type"
-                generators = "msbuild"
-                requires = "pkg/1.0"
-            """)
+                    from conans import ConanFile
+                    class Pkg(ConanFile):
+                        settings = "os", "compiler", "arch", "build_type"
+                        generators = "msbuild"
+                        requires = "pkg/1.0"
+                    """)
         client.save({"conanfile.py": conanfile})
 
         client.run('install . -s os=Windows -s compiler="Visual Studio" -s compiler.version=15'
@@ -520,3 +503,11 @@ class TestMSBuild(unittest.TestCase):
 
         pkg_props = client.load("conan_pkg.props")
         self.assertIn('Project="conan_pkg_release_x64.props"', pkg_props)
+
+    def no_build_type_error_test(self):
+        client = TestClient()
+        client.save({"conanfile.py": GenConanfile()})
+        client.run("create . mypkg/0.1@")
+        client.run("install mypkg/0.1@ -g msbuild -s build_type=None", assert_error=True)
+        self.assertIn("ERROR: The 'msbuild' generator requires a 'build_type' setting value",
+                      client.out)


### PR DESCRIPTION
Changelog: Fix: Relax ``msbuild`` generator to not raise in Linux.
Docs: omit


Follow up from https://github.com/conan-io/conan/pull/7359
