### PR TITLE
#7328 Add 'outdated' column in search table

### DIFF
--- a/conans/assets/templates/search_table_html.py
+++ b/conans/assets/templates/search_table_html.py
@@ -25,7 +25,7 @@ content = """
 
         <table id="results" class="table table-striped table-bordered" style="width:100%">
             <thead>
-                {%- set headers = results.get_headers(keys=['remote', 'package_id']) %}
+                {%- set headers = results.get_headers(keys=['remote', 'package_id', 'outdated']) %}
                 {%- set headers2rows = headers.row(n_rows=2) %}
                 <tr>
                     {%- for category, subheaders in headers2rows %}

--- a/conans/test/functional/command/search_test.py
+++ b/conans/test/functional/command/search_test.py
@@ -387,12 +387,14 @@ helloTest/1.4.10@myuser/stable""".format(remote)
         html = ''.join([line.strip() for line in self.client.load("table.html").splitlines()])
         self.assertIn("<h1>Hello/1.4.10@myuser/testing</h1>", html)
         self.assertIn("<td>LinuxPackageSHA</td>"
+                      "<td>False</td>"
                       "<td>Linux</td>"
                       "<td>x86</td>"
                       "<td>gcc</td>"
                       "<td>libstdc++11</td>"
                       "<td>4.5</td>", html)
         self.assertIn("<td>WindowsPackageSHA</td>"
+                      "<td>True</td>"
                       "<td>Windows</td>"
                       "<td>x64</td>"
                       "<td>Visual Studio</td>"
@@ -411,6 +413,7 @@ helloTest/1.4.10@myuser/stable""".format(remote)
         self.assertIn("<h1>Hello/1.4.10@myuser/testing</h1>", html)
         self.assertIn("<td>local</td>"
                       "<td>LinuxPackageSHA</td>"
+                      "<td>False</td>"
                       "<td>Linux</td>"
                       "<td>x86</td>"
                       "<td>gcc</td>"
@@ -418,6 +421,7 @@ helloTest/1.4.10@myuser/stable""".format(remote)
                       "<td>4.5</td>", html)
         self.assertIn("<td>search_able</td>"
                       "<td>WindowsPackageSHA</td>"
+                      "<td>True</td>"
                       "<td>Windows</td>"
                       "<td>x64</td>"
                       "<td>Visual Studio</td>"

--- a/conans/test/functional/command/search_test.py
+++ b/conans/test/functional/command/search_test.py
@@ -1306,8 +1306,6 @@ class Test(ConanFile):
         self.assertIn("ERROR: The client doesn't have the revisions feature enabled", client.out)
 
 
-
-
 @unittest.skipUnless(get_env("TESTING_REVISIONS_ENABLED", False),
                      "set TESTING_REVISIONS_ENABLED=1")
 class SearchRevisionsTest(unittest.TestCase):


### PR DESCRIPTION
Changelog: Fix: Show outdated packages when running `search --table`.
Docs: https://github.com/conan-io/docs/pull/1771

This hotfix adds the column *outdated* to the default HTML table generated by `search --table`. That was the usual behavior until Conan 1.24. After that, the new format removed the colors which indicated if a package is outdated (yellow) or not (green).

fixes #7328

/cc @memsharded @jgsogo 

- [x] Refer to the issue that supports this Pull Request.
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [x] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 

<sup>**Note:** By default this PR will skip the slower tests and will use a limited set of python versions. Check [here](https://github.com/conan-io/conan/blob/develop/.github/PR_INCREASE_TESTING.md) how to increase the testing level by writing some tags in the current PR body text.</sup>
