### PR TITLE
Bugfix: Intel Compiler install location detection on Windows

### DIFF
--- a/conans/client/tools/intel.py
+++ b/conans/client/tools/intel.py
@@ -36,9 +36,13 @@ def intel_installation_path(version, arch):
         else:
             raise ConanException("don't know how to find Intel compiler on %s" % arch)
         if is_win64():
-            base = r"SOFTWARE\WOW6432Node\Intel\Suites\{version}".format(version=version)
+            base = r"SOFTWARE\WOW6432Node"
         else:
-            base = r"SOFTWARE\Intel\Suites\{version}".format(version=version)
+            base = r"SOFTWARE"
+        intel_version = version if "." in version else version + ".0"
+        base = r"{base}\Intel\Suites\{intel_version}".format(
+            base=base, intel_version=intel_version
+        )
         from six.moves import winreg  # @UnresolvedImport
         path = base + r"\Defaults\C++\{arch}".format(arch=intel_arch)
         subkey = _system_registry_key(winreg.HKEY_LOCAL_MACHINE, path, "SubKey")


### PR DESCRIPTION
The bug of a missing trailing ".0" seems to have crept back in during the rebasing of #6735.

Changelog: Bugfix: Intel Compiler install location detection on Windows.
Docs: omit

- [x] Refer to the issue that supports this Pull Request.
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.

<sup>**Note:** By default this PR will skip the slower tests and will use a limited set of python versions. Check [here](https://github.com/conan-io/conan/blob/develop/.github/PR_INCREASE_TESTING.md) how to increase the testing level by writing some tags in the current PR body text.</sup>
