### PR TITLE
cli2.0: subcommands framework + conan user command

### DIFF
--- a/conans/cli/cli.py
+++ b/conans/cli/cli.py
@@ -1,17 +1,16 @@
+import importlib
 import os
+import pkgutil
 import signal
 import sys
 from collections import defaultdict
 from difflib import get_close_matches
-from inspect import getmembers, isclass
-import importlib
-import pkgutil
+from inspect import getmembers
 
 from conans import __version__ as client_version
 from conans.cli.command import ConanSubCommand
 from conans.cli.exit_codes import SUCCESS, ERROR_MIGRATION, ERROR_GENERAL, USER_CTRL_C, \
     ERROR_SIGTERM, USER_CTRL_BREAK, ERROR_INVALID_CONFIGURATION
-from conans.util.env_reader import get_env
 from conans.client.conan_api import Conan
 from conans.errors import ConanException, ConanInvalidConfiguration, ConanMigrationError
 from conans.util.files import exception_message_safe

--- a/conans/cli/cli.py
+++ b/conans/cli/cli.py
@@ -165,7 +165,8 @@ class Cli(object):
             raise ConanException("Unknown command %s" % str(exc))
 
         command.run(self.conan_api, args[0][1:], parser=self.commands[command_argument].parser,
-                    commands=self.commands, groups=self.groups)
+                    subparsers=self.commands[command_argument].subparsers, commands=self.commands,
+                    groups=self.groups)
 
         return SUCCESS
 

--- a/conans/cli/command.py
+++ b/conans/cli/command.py
@@ -118,22 +118,18 @@ class ConanCommand(BaseConanCommand):
         self._subcommands[subcommand.name] = subcommand
 
     def run(self, *args, conan_api, **kwargs):
-        try:
-            info = self._method(*args, conan_api=conan_api, **kwargs)
-            if not self._subcommands:
-                parser_args = self._parser.parse_args(*args)
-                if info:
-                    self._formatters[parser_args.output](info, conan_api.out)
+        info = self._method(*args, conan_api=conan_api, **kwargs)
+        if not self._subcommands:
+            parser_args = self._parser.parse_args(*args)
+            if info:
+                self._formatters[parser_args.output](info, conan_api.out)
+        else:
+            arg_list, = args
+            subcommand = arg_list[0]
+            if subcommand in self._subcommands:
+                self._subcommands[subcommand].run(*args, conan_api=conan_api, **kwargs)
             else:
-                arg_list, = args
-                subcommand = arg_list[0]
-                if subcommand in self._subcommands:
-                    self._subcommands[subcommand].run(*args, conan_api=conan_api, **kwargs)
-                else:
-                    self._parser.parse_args(*args)
-
-        except Exception:
-            raise
+                self._parser.parse_args(*args)
 
     @property
     def group(self):

--- a/conans/cli/command.py
+++ b/conans/cli/command.py
@@ -144,14 +144,11 @@ class ConanSubCommand(BaseConanCommand):
         self._name = "-".join(method.__name__.split("_")[1:])
 
     def run(self, *args, conan_api, **kwargs):
-        try:
-            info = self._method(*args, conan_api=conan_api, parser=self._parent_parser,
-                                subparser=self._parser)
-            parser_args = self._parent_parser.parse_args(*args)
-            if info:
-                self._formatters[parser_args.output](info, conan_api.out)
-        except Exception:
-            raise
+        info = self._method(*args, conan_api=conan_api, parser=self._parent_parser,
+                            subparser=self._parser)
+        parser_args = self._parent_parser.parse_args(*args)
+        if info:
+            self._formatters[parser_args.output](info, conan_api.out)
 
     def set_parser(self, parent_parser, subcommand_parser):
         self._parser = subcommand_parser.add_parser(self._name, help=self._doc)

--- a/conans/cli/command.py
+++ b/conans/cli/command.py
@@ -117,7 +117,7 @@ class ConanCommand(BaseConanCommand):
         subcommand.set_parser(self._parser, self._subcommand_parser)
         self._subcommands[subcommand.name] = subcommand
 
-    def run(self, conan_api, *args, **kwargs):
+    def run(self, *args, conan_api, **kwargs):
         try:
             info = self._method(*args, conan_api=conan_api, **kwargs)
             if not self._subcommands:
@@ -128,7 +128,7 @@ class ConanCommand(BaseConanCommand):
                 arg_list, = args
                 subcommand = arg_list[0]
                 if subcommand in self._subcommands:
-                    self._subcommands[subcommand].run(conan_api, *args, **kwargs)
+                    self._subcommands[subcommand].run(*args, conan_api=conan_api, **kwargs)
                 else:
                     self._parser.parse_args(*args)
 
@@ -147,7 +147,7 @@ class ConanSubCommand(BaseConanCommand):
         self._parser = None
         self._name = "-".join(method.__name__.split("_")[1:])
 
-    def run(self, conan_api, *args, **kwargs):
+    def run(self, *args, conan_api, **kwargs):
         try:
             info = self._method(*args, conan_api=conan_api, parser=self._parent_parser,
                                 subparser=self._parser)

--- a/conans/cli/commands/help.py
+++ b/conans/cli/commands/help.py
@@ -38,7 +38,7 @@ def output_help_cli(out, commands, groups):
     out.writeln('Conan commands. Type "conan <command> -h" for help', Color.BRIGHT_YELLOW)
 
 
-@conan_command(group="Misc commands", formatters={"cli": output_help_cli})
+@conan_command(group="Misc", formatters={"cli": output_help_cli})
 def help(*args, conan_api, parser, commands, groups, **kwargs):
     """
     Shows help for a specific command.

--- a/conans/cli/commands/search.py
+++ b/conans/cli/commands/search.py
@@ -36,7 +36,7 @@ def apiv2_search_recipes(query, remote_patterns=None, local_cache=False):
     return search_results
 
 
-@conan_command(group="Consumer commands", formatters={"cli": output_search_cli,
+@conan_command(group="Consumer", formatters={"cli": output_search_cli,
                                                       "json": output_search_json})
 def search(*args, conan_api, parser, **kwargs):
     """

--- a/conans/cli/commands/search.py
+++ b/conans/cli/commands/search.py
@@ -2,8 +2,7 @@ import json
 
 from conans.client.output import Color
 from conans.errors import NoRemoteAvailable
-from conans.cli.cli import Extender
-from conans.cli.command import conan_command
+from conans.cli.command import conan_command, Extender
 
 
 def output_search_cli(info, out):

--- a/conans/cli/commands/user.py
+++ b/conans/cli/commands/user.py
@@ -97,7 +97,7 @@ def user_update(*args, conan_api, parser, subparser):
     return {}
 
 
-@conan_command(group="Misc commands")
+@conan_command(group="Misc")
 def user(*args, conan_api, parser, **kwargs):
     """
     Authenticates against a remote with user/pass, caching the auth token.

--- a/conans/cli/commands/user.py
+++ b/conans/cli/commands/user.py
@@ -1,7 +1,6 @@
 import json
 
-from conans.cli.cli import Extender, OnceArgument
-from conans.cli.command import conan_command
+from conans.cli.command import conan_command, conan_subcommand, Extender, OnceArgument
 
 
 def output_user_list_json(info, out):
@@ -18,20 +17,86 @@ def output_user_list_cli(info, out):
         out.writeln(output_str)
 
 
-list_formatters = {"cli": output_user_list_cli,
-                   "json": output_user_list_json}
+@conan_subcommand(formatters={"cli": output_user_list_cli, "json": output_user_list_json})
+def user_list(*args, conan_api, parser, **kwargs):
+    """
+    List users and remotes they are associated to.
+    """
+    parser.add_argument("-r", "--remotes", action=Extender, nargs="?",
+                        help="Remotes to show the users from. Multiple remotes can be "
+                             "specified: -r remote1 -r remote2. Also wildcards can be "
+                             "used. -r '*' will show the users for all the remotes. "
+                             "If no remote is specified it will show the users for all "
+                             "the remotes")
+    args = parser.parse_args(*args)
+    if not args.remotes or "*" in args.remotes:
+        info = {"results": {"remote1": {"user": "someuser1", "authenticated": True},
+                            "remote2": {"user": "someuser2", "authenticated": False},
+                            "remote3": {"user": "someuser3", "authenticated": False},
+                            "remote4": {"user": "someuser4", "authenticated": True}}}
+    else:
+        info = {"results": {"remote1": {"user": "someuser1", "authenticated": True}}}
+    return info
 
-subcommands = [{"name": "list", "help": "List users and remotes they are associated to"},
-               {"name": "add", "help": "Add user authentication for a remote"},
-               {"name": "remove", "help": "Remove associated user from remote"},
-               {"name": "update", "help": "Update the current user for a remote"}]
 
-formatters = {"list": list_formatters}
+@conan_subcommand()
+def user_add(*args, conan_api, parser, **kwargs):
+    """
+    Add user authentication for a remote.
+    """
+    parser.add_argument("name",
+                        help="Username")
+    parser.add_argument("-p", "--password", action=OnceArgument,
+                        help="User password. Use double quotes if password with "
+                             "spacing, and escape quotes if existing. If empty, the "
+                             "password is requested interactively (not exposed)")
+    parser.add_argument("-s", "--skip-auth", action=OnceArgument,
+                        help="Skips the authentication with the server if there are "
+                             "local stored credentials. It doesn't check if the "
+                             "current credentials are valid or not.")
+    args = parser.parse_args(*args)
+    return {}
 
 
-@conan_command(group="Misc commands", formatters=formatters, subcommands=subcommands)
-def user(*args, conan_api, parser, subparsers, **kwargs):
-    # list, add, remove, update
+@conan_subcommand()
+def user_remove(*args, conan_api, parser, **kwargs):
+    """
+    Remove associated user from remote.
+    """
+    parser.add_argument("-r", "--remotes", action=Extender, nargs="?", required=True,
+                        help="Remotes to remove the users from. Multiple remotes can be "
+                             "specified: -r remote1 -r remote2. Also wildcards can be "
+                             "used. -r '*' will remove the users for all the remotes.")
+    args = parser.parse_args(*args)
+    return {}
+
+
+@conan_subcommand()
+def user_update(*args, conan_api, parser, **kwargs):
+    """
+    Update the current user for a remote.
+    """
+    parser.add_argument("-r", "--remotes", action=Extender, nargs="?", required=True,
+                        help="Remotes to remove the users from. Multiple remotes can "
+                             "be specified: -r remote1 -r remote2. Also wildcards can "
+                             "be used. -r '*' will remove the users for all the "
+                             "remotes.")
+    parser.add_argument("-n", "--name", action=OnceArgument,
+                        help="Name of the new user. If no name is specified the "
+                             "command will update the current user.")
+    parser.add_argument("-p", "--password", action=OnceArgument, required=True,
+                        const="",
+                        type=str,
+                        help="Update user password. Use double quotes if password "
+                             "with spacing, and escape quotes if existing. If "
+                             "empty, the password is requested interactively "
+                             "(not exposed)")
+    args = parser.parse_args(*args)
+    return {}
+
+
+@conan_command(group="Misc commands")
+def user(*args, conan_api, parser, **kwargs):
     """
     Authenticates against a remote with user/pass, caching the auth token.
 
@@ -40,58 +105,4 @@ def user(*args, conan_api, parser, subparsers, **kwargs):
     Changing the user, or introducing the password is only necessary to
     perform changes in remote packages.
     """
-    # list subcommand
-    subparsers["list"].add_argument("-r", "--remotes", action=Extender, nargs="?",
-                                    help="Remotes to show the users from. Multiple remotes can be "
-                                         "specified: -r remote1 -r remote2. Also wildcards can be "
-                                         "used. -r '*' will show the users for all the remotes. "
-                                         "If no remote is specified it will show the users for all "
-                                         "the remotes")
-
-    # add subcommand
-    subparsers["add"].add_argument("name",
-                                   help="Username you want to use.")
-    subparsers["add"].add_argument("-p", "--password", action=OnceArgument,
-                                   help="User password. Use double quotes if password with "
-                                        "spacing, and escape quotes if existing. If empty, the "
-                                        "password is requested interactively (not exposed)")
-    subparsers["add"].add_argument("-s", "--skip-auth", action=OnceArgument,
-                                   help="Skips the authentication with the server if there are "
-                                        "local stored credentials. It doesn't check if the "
-                                        "current credentials are valid or not.")
-
-    # remove subcommand
-    subparsers["remove"].add_argument("-r", "--remotes", action=Extender, nargs="?", required=True,
-                                      help="Remotes to remove the users from. Multiple remotes can be "
-                                           "specified: -r remote1 -r remote2. Also wildcards can be "
-                                           "used. -r '*' will remove the users for all the remotes.")
-
-    # update subcommand
-    subparsers["update"].add_argument("-r", "--remotes", action=Extender, nargs="?", required=True,
-                                      help="Remotes to remove the users from. Multiple remotes can "
-                                           "be specified: -r remote1 -r remote2. Also wildcards can "
-                                           "be used. -r '*' will remove the users for all the "
-                                           "remotes.")
-    subparsers["update"].add_argument("-n", "--name", action=OnceArgument,
-                                      help="Name of the new user. If no name is specified the "
-                                           "command will update the current user.")
-    subparsers["update"].add_argument("-p", "--password", action=OnceArgument, required=True,
-                                      const="",
-                                      type=str,
-                                      help="Update user password. Use double quotes if password "
-                                           "with spacing, and escape quotes if existing. If "
-                                           "empty, the password is requested interactively "
-                                           "(not exposed)")
-
-    args = parser.parse_args(*args)
-    info = {}
-    if args.subcommand == "list":
-        if "*" in args.remotes:
-            info = {"results": {"remote1": {"user": "someuser1", "authenticated": True},
-                                "remote2": {"user": "someuser2", "authenticated": False},
-                                "remote3": {"user": "someuser3", "authenticated": False},
-                                "remote4": {"user": "someuser4", "authenticated": True}}}
-        else:
-            info = {"results": {"remote1": {"user": "someuser1", "authenticated": True}}}
-
-    return info
+    return

--- a/conans/cli/commands/user.py
+++ b/conans/cli/commands/user.py
@@ -59,11 +59,6 @@ def user_add(*args, conan_api, parser, subparser):
                                 "password is requested interactively (not exposed)")
     subparser.add_argument("-f", "--force", action='store_true', default=False,
                            help="Force addition, will update if existing.")
-    # TODO: check if still necessary
-    subparser.add_argument("-s", "--skip-auth", action=OnceArgument,
-                           help="Skips the authentication with the server if there are "
-                                "local stored credentials. It doesn't check if the "
-                                "current credentials are valid or not.")
     args = parser.parse_args(*args)
     return {}
 

--- a/conans/cli/commands/user.py
+++ b/conans/cli/commands/user.py
@@ -25,7 +25,7 @@ def user_list(*args, conan_api, parser, subparser):
     subparser.add_argument("-r", "--remote", action=Extender, nargs="?",
                            help="Remotes to show the users from. Multiple remotes can be "
                                 "specified: -r remote1 -r remote2. Also wildcards can be "
-                                "used. -r '*' will show the users for all the remotes. "
+                                "used. -r \"*\" will show the users for all the remotes. "
                                 "If no remote is specified it will show the users for all "
                                 "the remotes")
     args = parser.parse_args(*args)
@@ -70,7 +70,7 @@ def user_remove(*args, conan_api, parser, subparser):
     """
     subparser.add_argument("remote",
                            help="Remote name. Accepts 'fnmatch' style wildcards. "
-                                "To remove the user for all remotes use: conan remote remove '*'")
+                                "To remove the user for all remotes use: conan remote remove \"*\"")
     args = parser.parse_args(*args)
     return {}
 

--- a/conans/cli/commands/user.py
+++ b/conans/cli/commands/user.py
@@ -1,0 +1,58 @@
+import json
+
+from conans.client.output import Color
+from conans.cli.cli import Extender
+from conans.cli.command import conan_command
+
+
+def output_user_list_json(info, out):
+    results = info["results"]
+    myjson = json.dumps(results, indent=4)
+    out.writeln(myjson)
+
+
+def output_user_list_cli(info, out):
+    results = info["results"]
+    output_str = "user: {} authenticated: {}".format(results["user"], results["authenticated"])
+    out.writeln(output_str)
+
+
+list_formatters = {"cli": output_user_list_cli,
+                   "json": output_user_list_json}
+
+subcommands = [{"name": "list", "help": "List users and remotes they are associated to"},
+               {"name": "add", "help": "Add user authentication for a remote"},
+               {"name": "remove", "help": "Remove associated user from remote"},
+               {"name": "update", "help": "Update the current user for a remote"}]
+
+formatters = {"list": list_formatters}
+
+
+@conan_command(group="Misc commands", formatters=formatters, subcommands=subcommands)
+def user(*args, conan_api, parser, subparsers, **kwargs):
+    # list, add, remove, update
+    """
+    Authenticates against a remote with user/pass, caching the auth token.
+
+    Useful to avoid the user and password being requested later. e.g. while
+    you're uploading a package.  You can have one user for each remote.
+    Changing the user, or introducing the password is only necessary to
+    perform changes in remote packages.
+    """
+    # list subcommand
+    subparsers["list"].add_argument("-r", "--remotes", action=Extender, nargs="?",
+                                    help="Show the user for the selected remote")
+
+    # add subcommand
+    subparsers["add"].add_argument("name",
+                                   help="Username you want to use. If no name is provided it")
+    subparsers["add"].add_argument("-p", "--password", action=Extender, nargs="?",
+                                   help="User password. Use double quotes if password with "
+                                        "spacing, and escape quotes if existing. If empty, the "
+                                        "password is requested interactively (not exposed)")
+    args = parser.parse_args(*args)
+    info = {}
+    if args.subcommand == "list":
+        info = {"results": {"user": "someuser", "authenticated": True}}
+
+    return info

--- a/conans/cli/commands/user.py
+++ b/conans/cli/commands/user.py
@@ -11,9 +11,9 @@ def output_user_list_json(info, out):
 
 def output_user_list_cli(info, out):
     results = info["results"]
-    for remote, user_info in results.items():
-        output_str = "user: {} authenticated: {}".format(user_info["user"],
-                                                         user_info["authenticated"])
+    for remote_name, user_info in results.items():
+        output_str = "remote: {} user: {}".format(remote_name,
+                                                  user_info["user"])
         out.writeln(output_str)
 
 
@@ -22,34 +22,44 @@ def user_list(*args, conan_api, parser, subparser):
     """
     List users and remotes they are associated to.
     """
-    subparser.add_argument("-r", "--remotes", action=Extender, nargs="?",
+    subparser.add_argument("-r", "--remote", action=Extender, nargs="?",
                            help="Remotes to show the users from. Multiple remotes can be "
                                 "specified: -r remote1 -r remote2. Also wildcards can be "
                                 "used. -r '*' will show the users for all the remotes. "
                                 "If no remote is specified it will show the users for all "
                                 "the remotes")
     args = parser.parse_args(*args)
-    if not args.remotes or "*" in args.remotes:
-        info = {"results": {"remote1": {"user": "someuser1", "authenticated": True},
-                            "remote2": {"user": "someuser2", "authenticated": False},
-                            "remote3": {"user": "someuser3", "authenticated": False},
-                            "remote4": {"user": "someuser4", "authenticated": True}}}
+    if not args.remote or "*" in args.remote:
+        info = {"results": {"remote1": {"user": "someuser1"},
+                            "remote2": {"user": "someuser2"},
+                            "remote3": {"user": "someuser3"},
+                            "remote4": {"user": "someuser4"}}}
     else:
-        info = {"results": {"remote1": {"user": "someuser1", "authenticated": True}}}
+        info = {"results": {"remote1": {"user": "someuser1"}}}
     return info
 
 
+# no user associated with remote yet
 @conan_subcommand()
 def user_add(*args, conan_api, parser, subparser):
     """
     Add user authentication for a remote.
     """
-    subparser.add_argument("name",
-                           help="Username")
+    subparser.add_argument("remote", help="Remote name")
+    # conan user add command should ask for the name and password in case none of them are
+    # passed as arguments. If just --name, ask for password. If --password is passed ask for
+    # username
+    subparser.add_argument("-n", "--name", action=OnceArgument,
+                           help="User password. Use double quotes if password with "
+                                "spacing, and escape quotes if existing. If empty, the "
+                                "password is requested interactively (not exposed)")
     subparser.add_argument("-p", "--password", action=OnceArgument,
                            help="User password. Use double quotes if password with "
                                 "spacing, and escape quotes if existing. If empty, the "
                                 "password is requested interactively (not exposed)")
+    subparser.add_argument("-f", "--force", action='store_true', default=False,
+                           help="Force addition, will update if existing.")
+    # TODO: check if still necessary
     subparser.add_argument("-s", "--skip-auth", action=OnceArgument,
                            help="Skips the authentication with the server if there are "
                                 "local stored credentials. It doesn't check if the "
@@ -63,10 +73,9 @@ def user_remove(*args, conan_api, parser, subparser):
     """
     Remove associated user from remote.
     """
-    subparser.add_argument("-r", "--remotes", action=Extender, nargs="?", required=True,
-                           help="Remotes to remove the users from. Multiple remotes can be "
-                                "specified: -r remote1 -r remote2. Also wildcards can be "
-                                "used. -r '*' will remove the users for all the remotes.")
+    subparser.add_argument("remote",
+                           help="Remote name. Accepts 'fnmatch' style wildcards. "
+                                "To remove the user for all remotes use: conan remote remove '*'")
     args = parser.parse_args(*args)
     return {}
 
@@ -74,19 +83,17 @@ def user_remove(*args, conan_api, parser, subparser):
 @conan_subcommand()
 def user_update(*args, conan_api, parser, subparser):
     """
-    Update the current user for a remote.
+    Update the current user for a remote. If not 'user' and 'password' are passed it will ask
+    for them interactively.
     """
-    subparser.add_argument("-r", "--remotes", action=Extender, nargs="?", required=True,
-                           help="Remotes to remove the users from. Multiple remotes can "
-                                "be specified: -r remote1 -r remote2. Also wildcards can "
-                                "be used. -r '*' will remove the users for all the "
-                                "remotes.")
+    subparser.add_argument("remote", help="Remote name")
+    # changing the name of the user forces a password change, it will be requested interactively
+    # if not passed as an argument
+
     subparser.add_argument("-n", "--name", action=OnceArgument,
                            help="Name of the new user. If no name is specified the "
                                 "command will update the current user.")
-    subparser.add_argument("-p", "--password", action=OnceArgument, required=True,
-                           const="",
-                           type=str,
+    subparser.add_argument("-p", "--password", nargs="?", const="", type=str, action=OnceArgument,
                            help="Update user password. Use double quotes if password "
                                 "with spacing, and escape quotes if existing. If "
                                 "empty, the password is requested interactively "

--- a/conans/cli/commands/user.py
+++ b/conans/cli/commands/user.py
@@ -53,7 +53,7 @@ def user_add(*args, conan_api, parser, subparser):
                            help="User password. Use double quotes if password with "
                                 "spacing, and escape quotes if existing. If empty, the "
                                 "password is requested interactively (not exposed)")
-    subparser.add_argument("-p", "--password", action=OnceArgument,
+    subparser.add_argument("-p", "--password", action=OnceArgument, nargs="?",
                            help="User password. Use double quotes if password with "
                                 "spacing, and escape quotes if existing. If empty, the "
                                 "password is requested interactively (not exposed)")
@@ -88,7 +88,7 @@ def user_update(*args, conan_api, parser, subparser):
     subparser.add_argument("-n", "--name", action=OnceArgument,
                            help="Name of the new user. If no name is specified the "
                                 "command will update the current user.")
-    subparser.add_argument("-p", "--password", nargs="?", const="", type=str, action=OnceArgument,
+    subparser.add_argument("-p", "--password", nargs="?", action=OnceArgument,
                            help="Update user password. Use double quotes if password "
                                 "with spacing, and escape quotes if existing. If "
                                 "empty, the password is requested interactively "

--- a/conans/cli/commands/user.py
+++ b/conans/cli/commands/user.py
@@ -18,16 +18,16 @@ def output_user_list_cli(info, out):
 
 
 @conan_subcommand(formatters={"cli": output_user_list_cli, "json": output_user_list_json})
-def user_list(*args, conan_api, parser, **kwargs):
+def user_list(*args, conan_api, parser, subparser):
     """
     List users and remotes they are associated to.
     """
-    parser.add_argument("-r", "--remotes", action=Extender, nargs="?",
-                        help="Remotes to show the users from. Multiple remotes can be "
-                             "specified: -r remote1 -r remote2. Also wildcards can be "
-                             "used. -r '*' will show the users for all the remotes. "
-                             "If no remote is specified it will show the users for all "
-                             "the remotes")
+    subparser.add_argument("-r", "--remotes", action=Extender, nargs="?",
+                           help="Remotes to show the users from. Multiple remotes can be "
+                                "specified: -r remote1 -r remote2. Also wildcards can be "
+                                "used. -r '*' will show the users for all the remotes. "
+                                "If no remote is specified it will show the users for all "
+                                "the remotes")
     args = parser.parse_args(*args)
     if not args.remotes or "*" in args.remotes:
         info = {"results": {"remote1": {"user": "someuser1", "authenticated": True},
@@ -40,57 +40,57 @@ def user_list(*args, conan_api, parser, **kwargs):
 
 
 @conan_subcommand()
-def user_add(*args, conan_api, parser, **kwargs):
+def user_add(*args, conan_api, parser, subparser):
     """
     Add user authentication for a remote.
     """
-    parser.add_argument("name",
-                        help="Username")
-    parser.add_argument("-p", "--password", action=OnceArgument,
-                        help="User password. Use double quotes if password with "
-                             "spacing, and escape quotes if existing. If empty, the "
-                             "password is requested interactively (not exposed)")
-    parser.add_argument("-s", "--skip-auth", action=OnceArgument,
-                        help="Skips the authentication with the server if there are "
-                             "local stored credentials. It doesn't check if the "
-                             "current credentials are valid or not.")
+    subparser.add_argument("name",
+                           help="Username")
+    subparser.add_argument("-p", "--password", action=OnceArgument,
+                           help="User password. Use double quotes if password with "
+                                "spacing, and escape quotes if existing. If empty, the "
+                                "password is requested interactively (not exposed)")
+    subparser.add_argument("-s", "--skip-auth", action=OnceArgument,
+                           help="Skips the authentication with the server if there are "
+                                "local stored credentials. It doesn't check if the "
+                                "current credentials are valid or not.")
     args = parser.parse_args(*args)
     return {}
 
 
 @conan_subcommand()
-def user_remove(*args, conan_api, parser, **kwargs):
+def user_remove(*args, conan_api, parser, subparser):
     """
     Remove associated user from remote.
     """
-    parser.add_argument("-r", "--remotes", action=Extender, nargs="?", required=True,
-                        help="Remotes to remove the users from. Multiple remotes can be "
-                             "specified: -r remote1 -r remote2. Also wildcards can be "
-                             "used. -r '*' will remove the users for all the remotes.")
+    subparser.add_argument("-r", "--remotes", action=Extender, nargs="?", required=True,
+                           help="Remotes to remove the users from. Multiple remotes can be "
+                                "specified: -r remote1 -r remote2. Also wildcards can be "
+                                "used. -r '*' will remove the users for all the remotes.")
     args = parser.parse_args(*args)
     return {}
 
 
 @conan_subcommand()
-def user_update(*args, conan_api, parser, **kwargs):
+def user_update(*args, conan_api, parser, subparser):
     """
     Update the current user for a remote.
     """
-    parser.add_argument("-r", "--remotes", action=Extender, nargs="?", required=True,
-                        help="Remotes to remove the users from. Multiple remotes can "
-                             "be specified: -r remote1 -r remote2. Also wildcards can "
-                             "be used. -r '*' will remove the users for all the "
-                             "remotes.")
-    parser.add_argument("-n", "--name", action=OnceArgument,
-                        help="Name of the new user. If no name is specified the "
-                             "command will update the current user.")
-    parser.add_argument("-p", "--password", action=OnceArgument, required=True,
-                        const="",
-                        type=str,
-                        help="Update user password. Use double quotes if password "
-                             "with spacing, and escape quotes if existing. If "
-                             "empty, the password is requested interactively "
-                             "(not exposed)")
+    subparser.add_argument("-r", "--remotes", action=Extender, nargs="?", required=True,
+                           help="Remotes to remove the users from. Multiple remotes can "
+                                "be specified: -r remote1 -r remote2. Also wildcards can "
+                                "be used. -r '*' will remove the users for all the "
+                                "remotes.")
+    subparser.add_argument("-n", "--name", action=OnceArgument,
+                           help="Name of the new user. If no name is specified the "
+                                "command will update the current user.")
+    subparser.add_argument("-p", "--password", action=OnceArgument, required=True,
+                           const="",
+                           type=str,
+                           help="Update user password. Use double quotes if password "
+                                "with spacing, and escape quotes if existing. If "
+                                "empty, the password is requested interactively "
+                                "(not exposed)")
     args = parser.parse_args(*args)
     return {}
 


### PR DESCRIPTION
Changelog: Feature: Complete cli2.0 framework to handle sub-commands and add `conan user` command for cli 2.0
Docs: omit

Base of discussion for:
- Implementation of commands with subcommands in cli 2.0.
- Implementation of `conan user` command.

~~With the current proposal adding commands with subcommands and formatters for these subcommands would look something like this:~~ (outdated, see: https://github.com/conan-io/conan/pull/7372#issuecomment-661179943)

```python
def output_user_list_json(info, out):
    ...

def output_user_list_cli(info, out):
    ...

list_formatters = {"cli": output_user_list_cli,
                   "json": output_user_list_json}

subcommands = [{"name": "list", "help": "List users and remotes they are associated to"},
               {"name": "add", "help": "Add user authentication for a remote"},
               {"name": "remove", "help": "Remove associated user from remote"},
               {"name": "update", "help": "Update the current user for a remote"}]

formatters = {"list": list_formatters}


@conan_command(group="Misc commands", formatters=formatters, subcommands=subcommands)
def user(*args, conan_api, parser, subparsers, **kwargs):
    # list, add, remove, update
    """
    Authenticates against a remote with user/pass, caching the auth token.

    Useful to avoid the user and password being requested later. e.g. while
    you're uploading a package.  You can have one user for each remote.
    Changing the user, or introducing the password is only necessary to
    perform changes in remote packages.
    """
    # list subcommand
    subparsers["list"].add_argument(...

    # add subcommand
    subparsers["add"].add_argument(...

    # remove subcommand
    subparsers["remove"].add_argument(...
    ....
    args = parser.parse_args(*args)
    info = {}
    if args.subcommand == "list":
        info=...
    return info
```

Also, the new proposal of the user command is done using subcommands:

**Conan v1:**
```
➜  cli2.0 conan user --help
usage: conan user [-h] [-c] [-p [PASSWORD]] [-r REMOTE] [-j JSON] [-s] [name]

Authenticates against a remote with user/pass, caching the auth token.

Useful to avoid the user and password being requested later. e.g. while
you're uploading a package.  You can have one user for each remote.
Changing the user, or introducing the password is only necessary to
perform changes in remote packages.

positional arguments:
  name                  Username you want to use. If no name is provided it
                        will show the current user

optional arguments:
  -h, --help            show this help message and exit
  -c, --clean           Remove user and tokens for all remotes
  -p [PASSWORD], --password [PASSWORD]
                        User password. Use double quotes if password with
                        spacing, and escape quotes if existing. If empty, the
                        password is requested interactively (not exposed)
  -r REMOTE, --remote REMOTE
                        Use the specified remote server
  -j JSON, --json JSON  json file path where the user list will be written to
  -s, --skip-auth       Skips the authentication with the server if there are
                        local stored credentials. It doesn't check if the
                        current credentials are valid or not
```

**Conan v2:**

```
usage: conan user [-h] {list,add,remove,update} ...

Authenticates against a remote with user/pass, caching the auth token.

Useful to avoid the user and password being requested later. e.g. while
you're uploading a package.  You can have one user for each remote.
Changing the user, or introducing the password is only necessary to
perform changes in remote packages.

positional arguments:
  {list,add,remove,update}
                        sub-command help
    list                List users and remotes they are associated to
    add                 Add user authentication for a remote
    remove              Remove associated user from remote
    update              Update the current user for a remote

optional arguments:
  -h, --help            show this help message and exit
```

Also removing `--skip-auth`: https://github.com/conan-io/conan/issues/5443#issuecomment-514965707