### PR TITLE
Do not enforce using explicit build types with cmake_multi.

### DIFF
--- a/conans/client/generators/cmake_common.py
+++ b/conans/client/generators/cmake_common.py
@@ -966,25 +966,12 @@ cmake_macros = "\n".join([
 
 cmake_macros_multi = "\n".join([
     textwrap.dedent("""
-        if(EXISTS ${CMAKE_CURRENT_LIST_DIR}/conanbuildinfo_release.cmake)
-            include(${CMAKE_CURRENT_LIST_DIR}/conanbuildinfo_release.cmake)
-        else()
-            message(FATAL_ERROR "No conanbuildinfo_release.cmake, please install the Release conf first")
-        endif()
-
-        if(EXISTS ${CMAKE_CURRENT_LIST_DIR}/conanbuildinfo_debug.cmake)
-            include(${CMAKE_CURRENT_LIST_DIR}/conanbuildinfo_debug.cmake)
-        else()
-            message(FATAL_ERROR "No conanbuildinfo_debug.cmake, please install the Debug conf first")
-        endif()
-
-        if(EXISTS ${CMAKE_CURRENT_LIST_DIR}/conanbuildinfo_minsizerel.cmake)
-            include(${CMAKE_CURRENT_LIST_DIR}/conanbuildinfo_minsizerel.cmake)
-        endif()
-
-        if(EXISTS ${CMAKE_CURRENT_LIST_DIR}/conanbuildinfo_relwithdebinfo.cmake)
-            include(${CMAKE_CURRENT_LIST_DIR}/conanbuildinfo_relwithdebinfo.cmake)
-        endif()
+        ### load generated conanbuildinfo files.
+        foreach(_name release debug minsizerel relwithdebinfo)
+            if(EXISTS ${CMAKE_CURRENT_LIST_DIR}/conanbuildinfo_${_name}.cmake)
+                include(${CMAKE_CURRENT_LIST_DIR}/conanbuildinfo_${_name}.cmake)
+            endif()
+        endforeach()
         """),
     CMakeCommonMacros.conan_set_vs_runtime_preserve_build_type,
     CMakeCommonMacros.conan_set_find_paths_multi,


### PR DESCRIPTION
cmake_multi enforced existence of conanbuildinfo_release.cmake &
conanbuildinfo_debug.cmake had to be present or the build would fail if
conanbuildinfo_multi.cmake was loaded. This is now changed so that
only generated conanbuildinfo files are loaded.

Fixes #7253

Changelog: Fix: Avoid requiring the existence of all ``conanbuildinfo_xxx.cmake`` files in ``cmake_multi`` generator.
Docs: Omit

- [X] Refer to the issue that supports this Pull Request.
- [X] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [X] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [X] I've followed the PEP8 style guides for Python code.

<sup>**Note:** By default this PR will skip the slower tests and will use a limited set of python versions. Check [here](https://github.com/conan-io/conan/blob/develop/.github/PR_INCREASE_TESTING.md) how to increase the testing level by writing some tags in the current PR body text.</sup>
