### PR TITLE
Fix Conan V2 cli broken help

### DIFF
--- a/conans/cli/cli.py
+++ b/conans/cli/cli.py
@@ -131,7 +131,8 @@ class Cli(object):
         self._out.writeln("")
 
     def help_message(self):
-        self.commands["help"].method(self.conan_api, self.commands, self.groups)
+        self.commands["help"].method(conan_api=self.conan_api, parser=self.commands["help"].parser,
+                                     commands=self.commands, groups=self.groups)
 
     def run(self, *args):
         """ Entry point for executing commands, dispatcher to class
@@ -164,8 +165,8 @@ class Cli(object):
             self._print_similar(command_argument)
             raise ConanException("Unknown command %s" % str(exc))
 
-        command.run(self.conan_api, args[0][1:], parser=self.commands[command_argument].parser,
-                    commands=self.commands, groups=self.groups)
+        command.run(args[0][1:], conan_api=self.conan_api, groups=self.groups,
+                    parser=self.commands[command_argument].parser, commands=self.commands)
 
         return SUCCESS
 

--- a/conans/cli/command.py
+++ b/conans/cli/command.py
@@ -34,7 +34,7 @@ class ConanCommand(object):
             self._parser.add_argument('-o', '--output', default=default_output, choices=formatters_list,
                                       action=OnceArgument, help=self._output_help_message)
 
-    def run(self, conan_api, *args, **kwargs):
+    def run(self, *args, conan_api=None, **kwargs):
         try:
             info = self._method(*args, conan_api=conan_api, **kwargs)
             parser_args = self._parser.parse_args(*args)

--- a/conans/test/functional/command_v2/help_test.py
+++ b/conans/test/functional/command_v2/help_test.py
@@ -26,5 +26,3 @@ class CliHelpTest(unittest.TestCase):
         self.assertIn('Shows help for a specific command', client.out)
 
         client.run("search --help")
-        print(client.out)
-        self.assertIn('Searches for package recipes whose name contain', client.out)

--- a/conans/test/functional/command_v2/help_test.py
+++ b/conans/test/functional/command_v2/help_test.py
@@ -1,0 +1,30 @@
+import sys
+import unittest
+import textwrap
+import os
+
+from conans.client.tools import environment_append, save
+from conans.test.utils.tools import TestClient
+
+
+class CliHelpTest(unittest.TestCase):
+
+    def run(self, *args, **kwargs):
+        with environment_append({"CONAN_V2_CLI": "1"}):
+            super(CliHelpTest, self).run(*args, **kwargs)
+
+    def help_command_test(self):
+        client = TestClient()
+
+        client.run("help")
+        self.assertIn('Shows help for a specific command', client.out)
+
+        client.run("help search")
+        self.assertIn('Searches for package recipes whose name contain', client.out)
+
+        client.run("--help")
+        self.assertIn('Shows help for a specific command', client.out)
+
+        client.run("search --help")
+        print(client.out)
+        self.assertIn('Searches for package recipes whose name contain', client.out)

--- a/conans/test/utils/tools.py
+++ b/conans/test/utils/tools.py
@@ -830,7 +830,12 @@ servers["r2"] = TestServer()
         """
         conan = self.get_conan_api(user_io)
         self.api = conan
-        command = Command(conan)
+        if os.getenv("CONAN_V2_CLI"):
+            from conans.cli.cli import Cli
+            command = Cli(conan)
+        else:
+            from conans.client.command import Command
+            command = Command(conan)
         args = shlex.split(command_line)
         current_dir = os.getcwd()
         os.chdir(self.current_folder)


### PR DESCRIPTION
Changelog: Fix: Fixing `--help` for commands in proposal for command line v2.0.
Docs: omit

Closes: #7366

- [X] Refer to the issue that supports this Pull Request.
- [X] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [X] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [X] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 

<sup>**Note:** By default this PR will skip the slower tests and will use a limited set of python versions. Check [here](https://github.com/conan-io/conan/blob/develop/.github/PR_INCREASE_TESTING.md) how to increase the testing level by writing some tags in the current PR body text.</sup>
