### PR TITLE
fixing missing download of conan_sources.tgz for export_sources() method

### DIFF
--- a/conans/client/source.py
+++ b/conans/client/source.py
@@ -25,7 +25,7 @@ def complete_recipe_sources(remote_manager, cache, conanfile, ref, remotes):
     if os.path.exists(sources_folder):
         return None
 
-    if conanfile.exports_sources is None:
+    if conanfile.exports_sources is None and not hasattr(conanfile, "export_sources"):
         mkdir(sources_folder)
         return None
 

--- a/conans/test/functional/command/export/exports_method_test.py
+++ b/conans/test/functional/command/export/exports_method_test.py
@@ -214,7 +214,7 @@ class ExportsSourcesMethodTest(unittest.TestCase):
         # https://github.com/conan-io/conan/issues/7377
         client = TestClient(default_server_user=True)
         conanfile = textwrap.dedent("""
-            from conans import ConanFile, load
+            from conans import ConanFile, tools
 
             class MethodConan(ConanFile):
                 def export_sources(self):

--- a/conans/test/functional/command/export/exports_method_test.py
+++ b/conans/test/functional/command/export/exports_method_test.py
@@ -209,3 +209,25 @@ class ExportsSourcesMethodTest(unittest.TestCase):
         client.run("export . pkg/0.1@", assert_error=True)
         self.assertIn("ERROR: conanfile 'exports_sources' shouldn't be a method, "
                       "use 'export_sources()' instead", client.out)
+
+    def test_exports_sources_upload_error(self):
+        # https://github.com/conan-io/conan/issues/7377
+        client = TestClient(default_server_user=True)
+        conanfile = textwrap.dedent("""
+            from conans import ConanFile, load
+            class MethodConan(ConanFile):
+                def export_sources(self):
+                    self.copy("*")
+                def build(self):
+                    self.output.info("CONTENT: %s" % load("myfile.txt"))
+            """)
+        client.save({"conanfile.py": conanfile,
+                     "myfile.txt": "mycontent"})
+        client.run("export . pkg/0.1@")
+        self.assertIn("pkg/0.1 export_sources() method: Copied 1 '.txt' file: myfile.txt",
+                      client.out)
+        client.run("upload pkg/0.1@")
+        client.run("remove * -f")
+        client.run("install pkg/0.1@ --build")
+        self.assertIn("Downloading conan_sources.tgz", client.out)
+        self.assertIn("pkg/0.1: CONTENT: mycontent", client.out)

--- a/conans/test/functional/command/export/exports_method_test.py
+++ b/conans/test/functional/command/export/exports_method_test.py
@@ -220,7 +220,7 @@ class ExportsSourcesMethodTest(unittest.TestCase):
                 def export_sources(self):
                     self.copy("*")
                 def build(self):
-                    self.output.info("CONTENT: %s" % load("myfile.txt"))
+                    self.output.info("CONTENT: %s" % tools.load("myfile.txt"))
             """)
         client.save({"conanfile.py": conanfile,
                      "myfile.txt": "mycontent"})

--- a/conans/test/functional/command/export/exports_method_test.py
+++ b/conans/test/functional/command/export/exports_method_test.py
@@ -215,6 +215,7 @@ class ExportsSourcesMethodTest(unittest.TestCase):
         client = TestClient(default_server_user=True)
         conanfile = textwrap.dedent("""
             from conans import ConanFile, load
+
             class MethodConan(ConanFile):
                 def export_sources(self):
                     self.copy("*")


### PR DESCRIPTION
Changelog: BugFix: Fix missing download of ``conan_sources.tgz`` created using ``export_sources()`` method.
Docs: Omit


Fix https://github.com/conan-io/conan/issues/7377