### PR TITLE
[feature] define namespaces attribute for cmake find generators

### DIFF
--- a/conans/client/generators/cmake_find_package_multi.py
+++ b/conans/client/generators/cmake_find_package_multi.py
@@ -29,8 +29,8 @@ class CMakeFindPackageMultiGenerator(CMakeFindPackageGenerator):
         """)
 
     targets_template = textwrap.dedent("""
-        if(NOT TARGET {name}::{name})
-            add_library({name}::{name} INTERFACE IMPORTED)
+        if(NOT TARGET {namespace}::{name})
+            add_library({namespace}::{name} INTERFACE IMPORTED)
         endif()
 
         # Load the debug and release library finders
@@ -44,25 +44,25 @@ class CMakeFindPackageMultiGenerator(CMakeFindPackageGenerator):
 
     target_properties = """
 # Assign target properties
-set_property(TARGET {name}::{name}
+set_property(TARGET {namespace}::{name}
              PROPERTY INTERFACE_LINK_LIBRARIES
                  $<$<CONFIG:Release>:${{{name}_LIBRARIES_TARGETS_RELEASE}} ${{{name}_LINKER_FLAGS_RELEASE_LIST}}>
                  $<$<CONFIG:RelWithDebInfo>:${{{name}_LIBRARIES_TARGETS_RELWITHDEBINFO}} ${{{name}_LINKER_FLAGS_RELWITHDEBINFO_LIST}}>
                  $<$<CONFIG:MinSizeRel>:${{{name}_LIBRARIES_TARGETS_MINSIZEREL}} ${{{name}_LINKER_FLAGS_MINSIZEREL_LIST}}>
                  $<$<CONFIG:Debug>:${{{name}_LIBRARIES_TARGETS_DEBUG}} ${{{name}_LINKER_FLAGS_DEBUG_LIST}}>)
-set_property(TARGET {name}::{name}
+set_property(TARGET {namespace}::{name}
              PROPERTY INTERFACE_INCLUDE_DIRECTORIES
                  $<$<CONFIG:Release>:${{{name}_INCLUDE_DIRS_RELEASE}}>
                  $<$<CONFIG:RelWithDebInfo>:${{{name}_INCLUDE_DIRS_RELWITHDEBINFO}}>
                  $<$<CONFIG:MinSizeRel>:${{{name}_INCLUDE_DIRS_MINSIZEREL}}>
                  $<$<CONFIG:Debug>:${{{name}_INCLUDE_DIRS_DEBUG}}>)
-set_property(TARGET {name}::{name}
+set_property(TARGET {namespace}::{name}
              PROPERTY INTERFACE_COMPILE_DEFINITIONS
                  $<$<CONFIG:Release>:${{{name}_COMPILE_DEFINITIONS_RELEASE}}>
                  $<$<CONFIG:RelWithDebInfo>:${{{name}_COMPILE_DEFINITIONS_RELWITHDEBINFO}}>
                  $<$<CONFIG:MinSizeRel>:${{{name}_COMPILE_DEFINITIONS_MINSIZEREL}}>
                  $<$<CONFIG:Debug>:${{{name}_COMPILE_DEFINITIONS_DEBUG}}>)
-set_property(TARGET {name}::{name}
+set_property(TARGET {namespace}::{name}
              PROPERTY INTERFACE_COMPILE_OPTIONS
                  $<$<CONFIG:Release>:${{{name}_COMPILE_OPTIONS_RELEASE_LIST}}>
                  $<$<CONFIG:RelWithDebInfo>:${{{name}_COMPILE_OPTIONS_RELWITHDEBINFO_LIST}}>
@@ -156,14 +156,14 @@ set_property(TARGET {name}::{name}
     components_targets_tpl = Template(textwrap.dedent("""\
         {%- for comp_name, comp in components %}
 
-        if(NOT TARGET {{ pkg_name }}::{{ comp_name }})
-            add_library({{ pkg_name }}::{{ comp_name }} INTERFACE IMPORTED)
+        if(NOT TARGET {{ namespace }}::{{ comp_name }})
+            add_library({{ namespace }}::{{ comp_name }} INTERFACE IMPORTED)
         endif()
 
         {%- endfor %}
 
-        if(NOT TARGET {{ pkg_name }}::{{ pkg_name }})
-            add_library({{ pkg_name }}::{{ pkg_name }} INTERFACE IMPORTED)
+        if(NOT TARGET {{ namespace }}::{{ pkg_name }})
+            add_library({{ namespace }}::{{ pkg_name }} INTERFACE IMPORTED)
         endif()
 
         # Load the debug and release library finders
@@ -176,7 +176,7 @@ set_property(TARGET {name}::{name}
 
         if({{ pkg_name }}_FIND_COMPONENTS)
             foreach(_FIND_COMPONENT {{ '${'+pkg_name+'_FIND_COMPONENTS}' }})
-                list(FIND {{ pkg_name }}_COMPONENTS_{{ build_type }} "{{ pkg_name }}::${_FIND_COMPONENT}" _index)
+                list(FIND {{ pkg_name }}_COMPONENTS_{{ build_type }} "{{ namespace }}::${_FIND_COMPONENT}" _index)
                 if(${_index} EQUAL -1)
                     conan_message(FATAL_ERROR "Conan: Component '${_FIND_COMPONENT}' NOT found in package '{{ pkg_name }}'")
                 else()
@@ -190,7 +190,7 @@ set_property(TARGET {name}::{name}
         ########## MACROS ###########################################################################
         #############################################################################################
         {{ conan_message }}
-        
+
         # Requires CMake > 3.0
         if(${CMAKE_VERSION} VERSION_LESS "3.0")
             message(FATAL_ERROR "The 'cmake_find_package_multi' generator only works with CMake > 3.0")
@@ -223,22 +223,22 @@ set_property(TARGET {name}::{name}
         {%- for comp_name, comp in components %}
         ########## COMPONENT {{ comp_name }} TARGET PROPERTIES ######################################
 
-        set_property(TARGET {{ pkg_name }}::{{ comp_name }} PROPERTY INTERFACE_LINK_LIBRARIES
+        set_property(TARGET {{ namespace }}::{{ comp_name }} PROPERTY INTERFACE_LINK_LIBRARIES
                          $<$<CONFIG:Release>:{{ '${'+pkg_name+'_'+comp_name+'_LINK_LIBS_RELEASE}' }} {{ '${'+pkg_name+'_'+comp_name+'_LINKER_FLAGS_LIST_RELEASE}' }}>
                          $<$<CONFIG:RelWithDebInfo>:{{ '${'+pkg_name+'_'+comp_name+'_LINK_LIBS_RELWITHDEBINFO}' }} {{ '${'+pkg_name+'_'+comp_name+'_LINKER_FLAGS_LIST_RELWITHDEBINFO}' }}>
                          $<$<CONFIG:MinSizeRel>:{{ '${'+pkg_name+'_'+comp_name+'_LINK_LIBS_MINSIZEREL}' }} {{ '${'+pkg_name+'_'+comp_name+'_LINKER_FLAGS_LIST_MINSIZEREL}' }}>
                          $<$<CONFIG:Debug>:{{ '${'+pkg_name+'_'+comp_name+'_LINK_LIBS_DEBUG}' }} {{ '${'+pkg_name+'_'+comp_name+'_LINKER_FLAGS_LIST_DEBUG}' }}>)
-        set_property(TARGET {{ pkg_name }}::{{ comp_name }} PROPERTY INTERFACE_INCLUDE_DIRECTORIES
+        set_property(TARGET {{ namespace }}::{{ comp_name }} PROPERTY INTERFACE_INCLUDE_DIRECTORIES
                          $<$<CONFIG:Release>:{{ '${'+pkg_name+'_'+comp_name+'_INCLUDE_DIRS_RELEASE}' }}>
                          $<$<CONFIG:RelWithDebInfo>:{{ '${'+pkg_name+'_'+comp_name+'_INCLUDE_DIRS_RELWITHDEBINFO}' }}>
                          $<$<CONFIG:MinSizeRel>:{{ '${'+pkg_name+'_'+comp_name+'_INCLUDE_DIRS_MINSIZEREL}' }}>
                          $<$<CONFIG:Debug>:{{ '${'+pkg_name+'_'+comp_name+'_INCLUDE_DIRS_DEBUG}' }}>)
-        set_property(TARGET {{ pkg_name }}::{{ comp_name }} PROPERTY INTERFACE_COMPILE_DEFINITIONS
+        set_property(TARGET {{ namespace }}::{{ comp_name }} PROPERTY INTERFACE_COMPILE_DEFINITIONS
                          $<$<CONFIG:Release>:{{ '${'+pkg_name+'_'+comp_name+'_COMPILE_DEFINITIONS_RELEASE}' }}>
                          $<$<CONFIG:RelWithDebInfo>:{{ '${'+pkg_name+'_'+comp_name+'_COMPILE_DEFINITIONS_RELWITHDEBINFO}' }}>
                          $<$<CONFIG:MinSizeRel>:{{ '${'+pkg_name+'_'+comp_name+'_COMPILE_DEFINITIONS_MINSIZEREL}' }}>
                          $<$<CONFIG:Debug>:{{ '${'+pkg_name+'_'+comp_name+'_COMPILE_DEFINITIONS_DEBUG}' }}>)
-        set_property(TARGET {{ pkg_name }}::{{ comp_name }} PROPERTY INTERFACE_COMPILE_OPTIONS
+        set_property(TARGET {{ namespace }}::{{ comp_name }} PROPERTY INTERFACE_COMPILE_OPTIONS
                          $<$<CONFIG:Release>:{{ '${'+pkg_name+'_'+comp_name+'_COMPILE_OPTIONS_LIST_RELEASE}' }}>
                          $<$<CONFIG:RelWithDebInfo>:{{ '${'+pkg_name+'_'+comp_name+'_COMPILE_OPTIONS_LIST_RELWITHDEBINFO}' }}>
                          $<$<CONFIG:MinSizeRel>:{{ '${'+pkg_name+'_'+comp_name+'_COMPILE_OPTIONS_LIST_MINSIZEREL}' }}>
@@ -250,7 +250,7 @@ set_property(TARGET {name}::{name}
         ########## GLOBAL TARGET PROPERTIES #########################################################
 
         if(NOT {{ pkg_name }}_{{ pkg_name }}_TARGET_PROPERTIES)
-            set_property(TARGET {{ pkg_name }}::{{ pkg_name }} PROPERTY INTERFACE_LINK_LIBRARIES
+            set_property(TARGET {{ namespace }}::{{ pkg_name }} PROPERTY INTERFACE_LINK_LIBRARIES
                              $<$<CONFIG:Release>:{{ '${'+pkg_name+'_COMPONENTS_RELEASE}' }}>
                              $<$<CONFIG:RelWithDebInfo>:{{ '${'+pkg_name+'_COMPONENTS_RELWITHDEBINFO}' }}>
                              $<$<CONFIG:MinSizeRel>:{{ '${'+pkg_name+'_COMPONENTS_MINSIZEREL}' }}>
@@ -269,6 +269,7 @@ set_property(TARGET {name}::{name}
         build_type_suffix = "_{}".format(build_type) if build_type else ""
         for pkg_name, cpp_info in self.deps_build_info.dependencies:
             pkg_findname = self._get_name(cpp_info)
+            namespace = self._get_namespace(cpp_info)
             pkg_version = cpp_info.version
             pkg_public_deps = [self._get_name(self.deps_build_info[public_dep]) for public_dep in
                                cpp_info.public_deps]
@@ -280,7 +281,7 @@ set_property(TARGET {name}::{name}
                 ret["{}Config.cmake".format(pkg_findname)] = self._config(pkg_findname,
                                                                           cpp_info.version,
                                                                           public_deps_names)
-                ret["{}Targets.cmake".format(pkg_findname)] = self.targets_template.format(name=pkg_findname)
+                ret["{}Targets.cmake".format(pkg_findname)] = self.targets_template.format(namespace=namespace, name=pkg_findname)
 
                 # If any config matches the build_type one, add it to the cpp_info
                 dep_cpp_info = extend(cpp_info, build_type.lower())
@@ -303,6 +304,7 @@ set_property(TARGET {name}::{name}
                                                                  deps_names=pkg_public_deps_names)
                 variables = self.components_target_build_type_tpl.render(
                     pkg_name=pkg_findname,
+                    namespace=namespace,
                     global_target_variables=global_target_variables,
                     pkg_components=pkg_components,
                     build_type=build_type,
@@ -313,11 +315,13 @@ set_property(TARGET {name}::{name}
                 ret["{}Target-{}.cmake".format(pkg_findname, build_type.lower())] = variables
                 targets = self.components_targets_tpl.render(
                     pkg_name=pkg_findname,
+                    namespace=namespace,
                     components=components,
                     build_type=build_type
                 )
                 ret["{}Targets.cmake".format(pkg_findname)] = targets
                 target_config = self.components_config_tpl.render(
+                    namespace=namespace,
                     pkg_name=pkg_findname,
                     components=components,
                     pkg_public_deps=pkg_public_deps,

--- a/conans/client/generators/cmake_find_package_multi.py
+++ b/conans/client/generators/cmake_find_package_multi.py
@@ -279,6 +279,7 @@ set_property(TARGET {namespace}::{name}
                 public_deps_names = [self.deps_build_info[dep].get_name("cmake_find_package_multi")
                                      for dep in cpp_info.public_deps]
                 ret["{}Config.cmake".format(pkg_findname)] = self._config(pkg_findname,
+                  namespace,
                                                                           cpp_info.version,
                                                                           public_deps_names)
                 ret["{}Targets.cmake".format(pkg_findname)] = self.targets_template.format(namespace=namespace, name=pkg_findname)
@@ -330,7 +331,7 @@ set_property(TARGET {namespace}::{name}
                 ret["{}Config.cmake".format(pkg_findname)] = target_config
         return ret
 
-    def _config(self, name, version, public_deps_names):
+    def _config(self, name, namespace, version, public_deps_names):
         # Builds the XXXConfig.cmake file for one package
 
         # The common macros
@@ -341,7 +342,8 @@ set_property(TARGET {namespace}::{name}
         ])
 
         # Define the targets properties
-        targets_props = self.target_properties.format(name=name)
+        targets_props = self.target_properties.format(
+          namespace=namespace, name=name)
 
         # The find_dependencies_block
         find_dependencies_block = ""

--- a/conans/model/build_info.py
+++ b/conans/model/build_info.py
@@ -44,6 +44,7 @@ class _CppInfo(object):
     def __init__(self):
         self._name = None
         self.names = {}
+        self.namespaces = {}
         self.system_libs = []  # Ordered list of system libraries
         self.includedirs = []  # Ordered list of include paths
         self.srcdirs = []  # Ordered list of source paths
@@ -144,6 +145,12 @@ class _CppInfo(object):
 
     def get_name(self, generator):
         return self.names.get(generator, self._name)
+
+    def get_namespace(self, generator):
+        result = self.namespaces.get(generator)
+        if result:
+            return result
+        return self.get_name(generator)
 
     # Compatibility for 'cppflags' (old style property to allow decoration)
     def get_cppflags(self):

--- a/conans/test/functional/generators/cmake_find_package_multi_test.py
+++ b/conans/test/functional/generators/cmake_find_package_multi_test.py
@@ -408,3 +408,85 @@ class Conan(ConanFile):
 
         self.assertIn('set(requirement_LIBRARY_LIST_RELEASE lib_both lib_release)', content_release)
         self.assertIn('set(requirement_LIBRARY_LIST_DEBUG lib_both lib_debug)', content_debug)
+
+    def cpp_info_namespaces_test(self):
+        client = TestClient()
+        client.run("new hello/1.0 -s")
+        indent = '\n        '
+        replace_in_file(
+            os.path.join(client.current_folder, "conanfile.py"),
+            search='self.cpp_info.libs = ["hello"]',
+            replace=indent.join([
+                'self.cpp_info.name = "hello_1"',
+                'self.cpp_info.namespaces["cmake_find_package_multi"] = "MYHELLO"',
+                'self.cpp_info.components["1"].names["cmake_find_package_multi"] = "HELLO1"',
+                'self.cpp_info.components["1"].libs = [ "hello" ]'
+            ]),
+            output=client.out
+        )
+        client.run("create .")
+
+        client.run("new hello2/1.0 -s")
+        replace_in_file(
+            os.path.join(client.current_folder, "src/CMakeLists.txt"),
+            search='add_library(hello hello.cpp)',
+            replace='add_library(hello2 hello.cpp)',
+            output=client.out
+        )
+        replace_in_file(os.path.join(client.current_folder, "conanfile.py"),
+            search='self.cpp_info.libs = ["hello"]',
+            replace=indent.join([
+                'self.cpp_info.name = "hello_2"',
+                'self.cpp_info.namespaces["cmake_find_package_multi"] = "MYHELLO"',
+                'self.cpp_info.components["2"].names["cmake_find_package_multi"] = "HELLO2"',
+                'self.cpp_info.components["2"].libs = [ "hello2" ]',
+                'self.cpp_info.components["2"].requires = [ "hello::1"]',
+            ]),
+            output=client.out
+        )
+        replace_in_file(os.path.join(client.current_folder, "conanfile.py"),
+            search='exports_sources = "src/*"',
+            replace='exports_sources = "src/*"\n    requires = "hello/1.0"',
+            output=client.out
+        )
+        client.run("create .")
+
+        cmakelists = """
+project(consumer)
+cmake_minimum_required(VERSION 3.1)
+find_package(hello_2)
+get_target_property(tmp MYHELLO::HELLO2 INTERFACE_LINK_LIBRARIES)
+message("Target libs (hello2): ${tmp}")
+get_target_property(tmp MYHELLO::HELLO1 INTERFACE_LINK_LIBRARIES)
+message("Target libs (hello): ${tmp}")
+"""
+        conanfile = """
+from conans import ConanFile, CMake
+class Conan(ConanFile):
+    requires = "hello2/1.0"
+    generators = "cmake_find_package_multi"
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        """
+        client.save({"conanfile.py": conanfile, "CMakeLists.txt": cmakelists})
+        client.run("install .")
+        client.run("build . -g cmake_find_package_multi")
+
+        print('~' * 120)
+        print(client.out)
+        print('~' * 120)
+
+        self.assertIn('Found hello_2: 1.0 (found version "1.0")', client.out)
+        self.assertIn('Found hello_1: 1.0 (found version "1.0")', client.out)
+        self.assertIn("Target libs (hello2): "
+                      "CONAN_LIB::hello_2_HELLO2_hello2;MYHELLO::HELLO1;"
+                      "$<$<STREQUAL:$<TARGET_PROPERTY:TYPE>,SHARED_LIBRARY>:>;"
+                      "$<$<STREQUAL:$<TARGET_PROPERTY:TYPE>,MODULE_LIBRARY>:>;"
+                      "$<$<STREQUAL:$<TARGET_PROPERTY:TYPE>,EXECUTABLE>:>",
+                      client.out)
+        self.assertIn("Target libs (hello): CONAN_LIB::hello_1_HELLO1_hello;"
+                      "$<$<STREQUAL:$<TARGET_PROPERTY:TYPE>,SHARED_LIBRARY>:>;"
+                      "$<$<STREQUAL:$<TARGET_PROPERTY:TYPE>,MODULE_LIBRARY>:>;"
+                      "$<$<STREQUAL:$<TARGET_PROPERTY:TYPE>,EXECUTABLE>:>",
+                      client.out)

--- a/conans/test/functional/generators/cmake_find_package_multi_test.py
+++ b/conans/test/functional/generators/cmake_find_package_multi_test.py
@@ -465,27 +465,28 @@ from conans import ConanFile, CMake
 class Conan(ConanFile):
     requires = "hello2/1.0"
     generators = "cmake_find_package_multi"
+    settings = "build_type"
     def build(self):
         cmake = CMake(self)
         cmake.configure()
         """
         client.save({"conanfile.py": conanfile, "CMakeLists.txt": cmakelists})
         client.run("install .")
-        client.run("build . -g cmake_find_package_multi")
+        client.run("build .")
 
         print('~' * 120)
         print(client.out)
         print('~' * 120)
 
-        self.assertIn('Found hello_2: 1.0 (found version "1.0")', client.out)
-        self.assertIn('Found hello_1: 1.0 (found version "1.0")', client.out)
+        self.assertIn('Library hello2 found', client.out)
+        self.assertIn('Library hello found', client.out)
         self.assertIn("Target libs (hello2): "
-                      "CONAN_LIB::hello_2_HELLO2_hello2;MYHELLO::HELLO1;"
+                      "$<$<CONFIG:Release>:CONAN_LIB::hello_2_HELLO2_hello2;MYHELLO::HELLO1;"
                       "$<$<STREQUAL:$<TARGET_PROPERTY:TYPE>,SHARED_LIBRARY>:>;"
                       "$<$<STREQUAL:$<TARGET_PROPERTY:TYPE>,MODULE_LIBRARY>:>;"
                       "$<$<STREQUAL:$<TARGET_PROPERTY:TYPE>,EXECUTABLE>:>",
                       client.out)
-        self.assertIn("Target libs (hello): CONAN_LIB::hello_1_HELLO1_hello;"
+        self.assertIn("Target libs (hello): $<$<CONFIG:Release>:CONAN_LIB::hello_1_HELLO1_hello;"
                       "$<$<STREQUAL:$<TARGET_PROPERTY:TYPE>,SHARED_LIBRARY>:>;"
                       "$<$<STREQUAL:$<TARGET_PROPERTY:TYPE>,MODULE_LIBRARY>:>;"
                       "$<$<STREQUAL:$<TARGET_PROPERTY:TYPE>,EXECUTABLE>:>",

--- a/conans/test/functional/generators/cmake_find_package_test.py
+++ b/conans/test/functional/generators/cmake_find_package_test.py
@@ -556,12 +556,12 @@ class Conan(ConanFile):
         self.assertIn('Found hello_2: 1.0 (found version "1.0")', client.out)
         self.assertIn('Found hello_1: 1.0 (found version "1.0")', client.out)
         self.assertIn("Target libs (hello2): "
-                      "CONAN_LIB::MYHELLO_HELLO2_hello2;MYHELLO::HELLO1;"
+                      "CONAN_LIB::hello_2_HELLO2_hello2;MYHELLO::HELLO1;"
                       "$<$<STREQUAL:$<TARGET_PROPERTY:TYPE>,SHARED_LIBRARY>:>;"
                       "$<$<STREQUAL:$<TARGET_PROPERTY:TYPE>,MODULE_LIBRARY>:>;"
                       "$<$<STREQUAL:$<TARGET_PROPERTY:TYPE>,EXECUTABLE>:>",
                       client.out)
-        self.assertIn("Target libs (hello): CONAN_LIB::MYHELLO_HELLO1_hello;"
+        self.assertIn("Target libs (hello): CONAN_LIB::hello_1_HELLO1_hello;"
                       "$<$<STREQUAL:$<TARGET_PROPERTY:TYPE>,SHARED_LIBRARY>:>;"
                       "$<$<STREQUAL:$<TARGET_PROPERTY:TYPE>,MODULE_LIBRARY>:>;"
                       "$<$<STREQUAL:$<TARGET_PROPERTY:TYPE>,EXECUTABLE>:>",

--- a/conans/test/functional/generators/cmake_find_package_test.py
+++ b/conans/test/functional/generators/cmake_find_package_test.py
@@ -485,6 +485,88 @@ class Conan(ConanFile):
                       "$<$<STREQUAL:$<TARGET_PROPERTY:TYPE>,EXECUTABLE>:>",
                       client.out)
 
+    def cpp_info_namespaces_test(self):
+        client = TestClient()
+        client.run("new hello/1.0 -s")
+        indent = '\n        '
+        replace_in_file(
+            os.path.join(client.current_folder, "conanfile.py"),
+            search='self.cpp_info.libs = ["hello"]',
+            replace=indent.join([
+                'self.cpp_info.name = "hello_1"',
+                'self.cpp_info.namespaces["cmake_find_package"] = "MYHELLO"',
+                'self.cpp_info.components["1"].names["cmake_find_package"] = "HELLO1"',
+                'self.cpp_info.components["1"].libs = [ "hello" ]'
+            ]),
+            output=client.out
+        )
+        client.run("create .")
+
+        client.run("new hello2/1.0 -s")
+        replace_in_file(
+            os.path.join(client.current_folder, "src/CMakeLists.txt"),
+            search='add_library(hello hello.cpp)',
+            replace='add_library(hello2 hello.cpp)',
+            output=client.out
+        )
+        replace_in_file(os.path.join(client.current_folder, "conanfile.py"),
+            search='self.cpp_info.libs = ["hello"]',
+            replace=indent.join([
+                'self.cpp_info.name = "hello_2"',
+                'self.cpp_info.namespaces["cmake_find_package"] = "MYHELLO"',
+                'self.cpp_info.components["2"].names["cmake_find_package"] = "HELLO2"',
+                'self.cpp_info.components["2"].libs = [ "hello2" ]',
+                'self.cpp_info.components["2"].requires = [ "hello::1"]',
+            ]),
+            output=client.out
+        )
+        replace_in_file(os.path.join(client.current_folder, "conanfile.py"),
+            search='exports_sources = "src/*"',
+            replace='exports_sources = "src/*"\n    requires = "hello/1.0"',
+            output=client.out
+        )
+        client.run("create .")
+
+        cmakelists = """
+project(consumer)
+cmake_minimum_required(VERSION 3.1)
+find_package(hello_2)
+get_target_property(tmp MYHELLO::HELLO2 INTERFACE_LINK_LIBRARIES)
+message("Target libs (hello2): ${tmp}")
+get_target_property(tmp MYHELLO::HELLO1 INTERFACE_LINK_LIBRARIES)
+message("Target libs (hello): ${tmp}")
+"""
+        conanfile = """
+from conans import ConanFile, CMake
+class Conan(ConanFile):
+    requires = "hello2/1.0"
+    generators = "cmake_find_package"
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        """
+        client.save({"conanfile.py": conanfile, "CMakeLists.txt": cmakelists})
+        client.run("install .")
+        client.run("build .")
+
+        print('~' * 120)
+        print(client.out)
+        print('~' * 120)
+
+        self.assertIn('Found hello_2: 1.0 (found version "1.0")', client.out)
+        self.assertIn('Found hello_1: 1.0 (found version "1.0")', client.out)
+        self.assertIn("Target libs (hello2): "
+                      "CONAN_LIB::MYHELLO_HELLO2_hello2;MYHELLO::HELLO1;"
+                      "$<$<STREQUAL:$<TARGET_PROPERTY:TYPE>,SHARED_LIBRARY>:>;"
+                      "$<$<STREQUAL:$<TARGET_PROPERTY:TYPE>,MODULE_LIBRARY>:>;"
+                      "$<$<STREQUAL:$<TARGET_PROPERTY:TYPE>,EXECUTABLE>:>",
+                      client.out)
+        self.assertIn("Target libs (hello): CONAN_LIB::MYHELLO_HELLO1_hello;"
+                      "$<$<STREQUAL:$<TARGET_PROPERTY:TYPE>,SHARED_LIBRARY>:>;"
+                      "$<$<STREQUAL:$<TARGET_PROPERTY:TYPE>,MODULE_LIBRARY>:>;"
+                      "$<$<STREQUAL:$<TARGET_PROPERTY:TYPE>,EXECUTABLE>:>",
+                      client.out)
+
     def cpp_info_config_test(self):
         conanfile = textwrap.dedent("""
             from conans import ConanFile


### PR DESCRIPTION
Changelog: Feature: Adds "namespaces" to cppinfo attribute, and changes cmake_find_package and cmake_find_package_multi generators so that they support it (see [issue 7385](https://github.com/conan-io/conan/issues/7385) and [this PR](https://github.com/conan-io/conan/pull/7320) for a related feature). 
Docs: https://github.com/conan-io/docs/pull/1772

- [x] Refer to the issue that supports this Pull Request.
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [x] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 