### PR TITLE
Test self.copy() return value when packaging

### DIFF
--- a/conans/test/functional/command/package_test.py
+++ b/conans/test/functional/command/package_test.py
@@ -290,7 +290,7 @@ class MyConan(ConanFile):
 
     def empty_package_folder_test(self):
         """ When the package folder is empty, then an warning should appear
-            and no files must be listed
+            and no files must be listed. Also, self.copy() return value should be empty.
         """
         conanfile = """from conans import ConanFile
 import os
@@ -304,6 +304,8 @@ class Pkg(ConanFile):
 
     def package(self):
         self.output.info("yet another conan package")
+        files = self.copy("kk*")
+        self.output.info("Files copied  %s" % files)
 """
         client = TestClient()
         client.save({"conanfile.py": conanfile})
@@ -312,3 +314,4 @@ class Pkg(ConanFile):
         self.assertIn("yet another conan package", client.out)
         self.assertIn("package(): WARN: No files in this package!", client.out)
         self.assertNotIn("package(): Packaged", client.out)
+        self.assertIn("Files copied  []", client.out)


### PR DESCRIPTION
Changelog: Feature: Document return value of `self.copy()` in the `package()` method.
Docs: https://github.com/conan-io/docs/pull/1773

- [x] Refer to the issue that supports this Pull Request: closes #7347
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [x] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 

<sup>**Note:** By default this PR will skip the slower tests and will use a limited set of python versions. Check [here](https://github.com/conan-io/conan/blob/develop/.github/PR_INCREASE_TESTING.md) how to increase the testing level by writing some tags in the current PR body text.</sup>
