### PR TITLE
[tools] tools as attribute object

### DIFF
--- a/conans/client/build/msbuild.py
+++ b/conans/client/build/msbuild.py
@@ -12,7 +12,7 @@ from conans.client.tools.win import vcvars_command
 from conans.errors import ConanException
 from conans.model.conan_file import ConanFile
 from conans.model.version import Version
-from conans.tools import vcvars_command as tools_vcvars_command
+from conans.client.tools.win import vcvars_command as tools_vcvars_command
 from conans.util.env_reader import get_env
 from conans.util.files import decode_text, save
 from conans.util.runners import version_runner

--- a/conans/client/loader.py
+++ b/conans/client/loader.py
@@ -25,13 +25,14 @@ from conans.util.files import load
 
 
 class ConanFileLoader(object):
-    def __init__(self, runner, output, python_requires, pyreq_loader=None):
+    def __init__(self, runner, output, python_requires, pyreq_loader=None, tools=None):
         self._runner = runner
         self._output = output
         self._pyreq_loader = pyreq_loader
         self._python_requires = python_requires
         sys.modules["conans"].python_requires = python_requires
         self._cached_conanfile_classes = {}
+        self._tools = tools
 
     def load_basic(self, conanfile_path, lock_python_requires=None, user=None, channel=None,
                    display=""):
@@ -62,6 +63,7 @@ class ConanFileLoader(object):
                 self._pyreq_loader.load_py_requires(conanfile, lock_python_requires, self)
 
             conanfile.recipe_folder = os.path.dirname(conanfile_path)
+            conanfile.tools = self._tools
 
             # If the scm is inherited, create my own instance
             if hasattr(conanfile, "scm") and "scm" not in conanfile.__class__.__dict__:

--- a/conans/client/tools/net.py
+++ b/conans/client/tools/net.py
@@ -52,7 +52,7 @@ def ftp_download(ip, filename, login='', password=''):
 
 
 def download(url, filename, verify=True, out=None, retry=None, retry_wait=None, overwrite=False,
-             auth=None, headers=None, requester=None, md5='', sha1='', sha256=''):
+             auth=None, headers=None, requester=None, config=None, md5='', sha1='', sha256=''):
     """Retrieves a file from a given URL into a file with a given filename.
        It uses certificates from a list of known verifiers for https downloads,
        but this can be optionally disabled.
@@ -79,7 +79,6 @@ def download(url, filename, verify=True, out=None, retry=None, retry_wait=None, 
     """
     out = default_output(out, 'conans.client.tools.net.download')
     requester = default_requester(requester, 'conans.client.tools.net.download')
-    from conans.tools import _global_config as config
 
     # It might be possible that users provide their own requester
     retry = retry if retry is not None else config.retry

--- a/conans/test/functional/generators/cmake_generator_test.py
+++ b/conans/test/functional/generators/cmake_generator_test.py
@@ -7,7 +7,7 @@ from conans.test.utils.tools import TestClient, TestBufferConanOutput
 
 
 CONAN_RECIPE = """
-from conans import ConanFile, CMake
+from conans import ConanFile
 
 class FooConan(ConanFile):
     name = "foo"
@@ -16,7 +16,7 @@ class FooConan(ConanFile):
     generators = "cmake"
 
     def build(self):
-        cmake = CMake(self)
+        cmake = self.tools.CMake(self)
         cmake.configure()
 """
 

--- a/conans/test/functional/tools/cppstd_minimum_version_test.py
+++ b/conans/test/functional/tools/cppstd_minimum_version_test.py
@@ -10,7 +10,6 @@ class CppStdMinimumVersionTests(unittest.TestCase):
     CONANFILE = dedent("""
         import os
         from conans import ConanFile
-        from conans.tools import check_min_cppstd, valid_min_cppstd
 
         class Fake(ConanFile):
             name = "fake"
@@ -18,7 +17,7 @@ class CppStdMinimumVersionTests(unittest.TestCase):
             settings = "compiler"
 
             def configure(self):
-                check_min_cppstd(self, "17", False)
+                self.tools.check_min_cppstd(self, "17", False)
                 self.output.info("valid standard")
                 assert valid_min_cppstd(self, "17", False)
         """)

--- a/conans/test/functional/tools/cpu_count_test.py
+++ b/conans/test/functional/tools/cpu_count_test.py
@@ -4,24 +4,30 @@ from conans.paths import CONANFILE
 from conans.test.utils.tools import TestClient
 
 conanfile = """
-from conans import ConanFile, tools
+from conans import ConanFile
 
 class AConan(ConanFile):
     name = "Hello0"
     version = "0.1"
 
     def build(self):
-        self.output.warn("CPU COUNT=> %s" % tools.cpu_count())
+        self.output.warn("CPU COUNT=> %s" % self.tools.cpu_count())
 
 """
 
 
 class CPUCountTest(unittest.TestCase):
 
-    def cpu_count_override_test(self):
+    def test_cpu_count_override(self):
         self.client = TestClient()
         self.client.save({CONANFILE: conanfile})
         self.client.run("config set general.cpu_count=5")
         self.client.run("export . lasote/stable")
         self.client.run("install Hello0/0.1@lasote/stable --build missing")
         self.assertIn("CPU COUNT=> 5", self.client.out)
+
+    def test_cpu_count_default(self):
+        self.client = TestClient()
+        self.client.save({CONANFILE: conanfile})
+        self.client.run("create . user/channel")
+        self.assertIn("CPU COUNT=>", self.client.out)

--- a/conans/test/functional/tools/fix_symlinks_test.py
+++ b/conans/test/functional/tools/fix_symlinks_test.py
@@ -14,14 +14,14 @@ class FixSymlinksTestCase(unittest.TestCase):
     conanfile = textwrap.dedent("""
         import os
         import shutil
-        from conans import ConanFile, tools
+        from conans import ConanFile
 
         class Recipe(ConanFile):
             options = {"raise_if_error": [True, False]}
             default_options = {"raise_if_error": False}
 
             def build(self):
-                tools.save(os.path.join(self.build_folder, "build.txt"), "contents")
+                self.tools.save(os.path.join(self.build_folder, "build.txt"), "contents")
 
             def package(self):
                 os.symlink('/dev/null', os.path.join(self.package_folder, "black_hole"))
@@ -31,13 +31,13 @@ class FixSymlinksTestCase(unittest.TestCase):
                            os.path.join(self.package_folder, "outside_symlink.txt"))
 
                 # Files: A regular file with symlinks to it
-                tools.save(os.path.join(self.package_folder, "regular.txt"), "contents")
+                self.tools.save(os.path.join(self.package_folder, "regular.txt"), "contents")
                 os.symlink(os.path.join(self.package_folder, "regular.txt"),
                            os.path.join(self.package_folder, "absolute_symlink.txt"))
                 os.symlink("regular.txt", os.path.join(self.package_folder, "relative_symlink.txt"))
 
                 # Files: A broken symlink
-                tools.save(os.path.join(self.package_folder, "file.txt"), "contents")
+                self.tools.save(os.path.join(self.package_folder, "file.txt"), "contents")
                 os.symlink(os.path.join(self.package_folder, "file.txt"),
                            os.path.join(self.package_folder, "broken.txt"))
                 os.unlink(os.path.join(self.package_folder, "file.txt"))
@@ -46,13 +46,13 @@ class FixSymlinksTestCase(unittest.TestCase):
                 os.symlink(self.build_folder, os.path.join(self.package_folder, "outside_folder"))
 
                 # Folder: a regular folder and symlinks to it
-                tools.save(os.path.join(self.package_folder, "folder", "file.txt"), "contents")
+                self.tools.save(os.path.join(self.package_folder, "folder", "file.txt"), "contents")
                 os.symlink(os.path.join(self.package_folder, "folder"),
                            os.path.join(self.package_folder, "absolute"))
                 os.symlink("folder", os.path.join(self.package_folder, "relative"))
 
                 # Folder: broken symlink
-                tools.save(os.path.join(self.package_folder, "tmp", "file.txt"), "contents")
+                self.tools.save(os.path.join(self.package_folder, "tmp", "file.txt"), "contents")
                 os.symlink(os.path.join(self.package_folder, "tmp"),
                            os.path.join(self.package_folder, "broken_folder"))
                 shutil.rmtree(os.path.join(self.package_folder, "tmp"))
@@ -62,7 +62,7 @@ class FixSymlinksTestCase(unittest.TestCase):
                            os.path.join(self.package_folder, "abs_to_file_in_folder.txt"))
 
                 # --> Run the tool
-                tools.fix_symlinks(self, raise_if_error=self.options.raise_if_error)
+                self.tools.fix_symlinks(self, raise_if_error=self.options.raise_if_error)
     """)
 
     def test_error_reported(self):

--- a/conans/tools.py
+++ b/conans/tools.py
@@ -29,6 +29,7 @@ from conans.util.files import _generic_algorithm_sum, load, md5, md5sum, mkdir, 
 from conans.util.log import logger
 from conans.client.tools.version import Version
 from conans.client.build.cppstd_flags import cppstd_flag_new as cppstd_flag  # pylint: disable=unused-import
+from conans.client.build.cmake import CMake
 
 
 class Tools(object):
@@ -73,17 +74,12 @@ class Tools(object):
         self.detected_architecture = tools_oss.detected_architecture
         self.detected_os = tools_oss.detected_os
         self.OSInfo = tools_oss.OSInfo
+        self.os_info = self.OSInfo()
         self.cross_building = tools_oss.cross_building
         self.get_cross_building_settings = tools_oss.get_cross_building_settings
         self.get_gnu_triplet = tools_oss.get_gnu_triplet
 
-        # Ready to use objects.
-        try:
-            self.os_info = self.OSInfo()
-        except Exception as exc:
-            logger.error(exc)
-            self.output.error("Error detecting os_info")
-
+        self.CMake = CMake
 
 # This global variables are intended to store the configuration of the running Conan application
 #_global_output = None
@@ -221,3 +217,12 @@ MSYS = tools_win.MSYS
 CYGWIN = tools_win.CYGWIN
 WSL = tools_win.WSL
 SFU = tools_win.SFU
+
+# Ready to use objects.
+try:
+    os_info = tools_oss.OSInfo()
+except Exception as exc:
+    logger.error(exc)
+    # no global access for output, fragile
+    output = ConanOutput(sys.stdout, sys.stderr, True)
+    output.error("Error detecting os_info")

--- a/conans/tools.py
+++ b/conans/tools.py
@@ -31,203 +31,193 @@ from conans.client.tools.version import Version
 from conans.client.build.cppstd_flags import cppstd_flag_new as cppstd_flag  # pylint: disable=unused-import
 
 
+class Tools(object):
+
+    def __init__(self, output, requester, config):
+        self.output = ConanOutput(sys.stdout, sys.stderr, True) if output is None else output
+        self.requester = requester
+        self.config = config
+        # from conans.client.tools.files
+
+        # INFO: It can be loaded dynamically e.g. dir(tools_files) ...
+
+        self.chdir = tools_files.chdir
+        self.human_size = tools_files.human_size
+        self.untargz = tools_files.untargz
+        self.check_with_algorithm_sum = tools_files.check_with_algorithm_sum
+        self.check_sha1 = tools_files.check_sha1
+        self.check_md5 = tools_files.check_md5
+        self.check_sha256 = tools_files.check_sha256
+        self.replace_prefix_in_pc_file = tools_files.replace_prefix_in_pc_file
+        self.collect_libs = tools_files.collect_libs
+        self.which = tools_files.which
+        self.unix2dos = tools_files.unix2dos
+        self.dos2unix = tools_files.dos2unix
+        self.fix_symlinks = tools_files.fix_symlinks
+        self.patch = tools_files.patch
+        self.load = tools_files.load
+
+        # from conans.client.tools.win
+        self.vs_installation_path = tools_win.vs_installation_path
+        self.vswhere = tools_win.vswhere
+        self.vs_comntools = tools_win.vs_comntools
+        self.find_windows_10_sdk = tools_win.find_windows_10_sdk
+        self.escape_windows_cmd = tools_win.escape_windows_cmd
+        self.get_cased_path = tools_win.get_cased_path
+        self.unix_path = tools_win.unix_path
+        self.run_in_windows_bash = tools_win.run_in_windows_bash
+        self.msvs_toolset = tools_win.msvs_toolset
+
+        # from conans.client.tools.oss
+        self.args_to_string = tools_oss.args_to_string
+        self.detected_architecture = tools_oss.detected_architecture
+        self.detected_os = tools_oss.detected_os
+        self.OSInfo = tools_oss.OSInfo
+        self.cross_building = tools_oss.cross_building
+        self.get_cross_building_settings = tools_oss.get_cross_building_settings
+        self.get_gnu_triplet = tools_oss.get_gnu_triplet
+
+        # Ready to use objects.
+        try:
+            self.os_info = self.OSInfo()
+        except Exception as exc:
+            logger.error(exc)
+            self.output.error("Error detecting os_info")
+
+
 # This global variables are intended to store the configuration of the running Conan application
-_global_output = None
-_global_requester = None
-_global_config = None
+#_global_output = None
+#_global_requester = None
+#_global_config = None
 
 
-def set_global_instances(the_output, the_requester, config):
-    global _global_output
-    global _global_requester
-    global _global_config
+#def set_global_instances(the_output, the_requester, config):
+#    global _global_output
+#    global _global_requester
+#    global _global_config
 
     # TODO: pass here the configuration file, and make the work here (explicit!)
-    _global_output = the_output
-    _global_requester = the_requester
-    _global_config = config
+#    _global_output = the_output
+#    _global_requester = the_requester
+#    _global_config = config
 
 
-def get_global_instances():
-    return _global_output, _global_requester
-
+#def get_global_instances():
+#    return _global_output, _global_requester
 
 # Assign a default, will be overwritten in the factory of the ConanAPI
-set_global_instances(the_output=ConanOutput(sys.stdout, sys.stderr, True), the_requester=requests,
-                     config=None)
+#set_global_instances(the_output=ConanOutput(sys.stdout, sys.stderr, True), the_requester=requests,
+#                     config=None)
 
 
-"""
-From here onwards only currification is expected, no logic
-"""
+    """
+    From here onwards only currification is expected, no logic
+    """
 
 
-def save(path, content, append=False):
-    # TODO: All this three functions: save, save_append and this one should be merged into one.
-    if append:
-        save_append(path=path, content=content)
-    else:
-        files_save(path=path, content=content, only_if_modified=False)
+    def save(self, path, content, append=False):
+        # TODO: All this three functions: save, save_append and this one should be merged into one.
+        if append:
+            save_append(path=path, content=content)
+        else:
+            files_save(path=path, content=content, only_if_modified=False)
 
 
-# From conans.client.tools.net
-ftp_download = tools_net.ftp_download
+    # From conans.client.tools.net
+    ftp_download = tools_net.ftp_download
 
 
-def download(*args, **kwargs):
-    return tools_net.download(out=_global_output, requester=_global_requester, *args, **kwargs)
+    def download(self, *args, **kwargs):
+        return tools_net.download(out=self.output, requester=self.requester, config=self.config, *args, **kwargs)
 
 
-def get(*args, **kwargs):
-    return tools_net.get(output=_global_output, requester=_global_requester, *args, **kwargs)
+    def get(self, *args, **kwargs):
+        return tools_net.get(output=self.output, requester=self.requester, *args, **kwargs)
+
+    def unzip(self, *args, **kwargs):
+        return tools_files.unzip(output=self.output, *args, **kwargs)
 
 
-# from conans.client.tools.files
-chdir = tools_files.chdir
-human_size = tools_files.human_size
-untargz = tools_files.untargz
-check_with_algorithm_sum = tools_files.check_with_algorithm_sum
-check_sha1 = tools_files.check_sha1
-check_md5 = tools_files.check_md5
-check_sha256 = tools_files.check_sha256
-patch = tools_files.patch
-replace_prefix_in_pc_file = tools_files.replace_prefix_in_pc_file
-collect_libs = tools_files.collect_libs
-which = tools_files.which
-unix2dos = tools_files.unix2dos
-dos2unix = tools_files.dos2unix
-fix_symlinks = tools_files.fix_symlinks
+    def replace_in_file(self, *args, **kwargs):
+        return tools_files.replace_in_file(output=self.output, *args, **kwargs)
 
 
-def unzip(*args, **kwargs):
-    return tools_files.unzip(output=_global_output, *args, **kwargs)
+    def replace_path_in_file(self, *args, **kwargs):
+        return tools_files.replace_path_in_file(output=self.output, *args, **kwargs)
+
+    def cpu_count(self, *args, **kwargs):
+        return tools_oss.cpu_count(output=self.output, *args, **kwargs)
+
+    @contextmanager
+    def vcvars(self, *args, **kwargs):
+        with tools_win.vcvars(output=self.output, *args, **kwargs):
+            yield
+
+    def msvc_build_command(self, *args, **kwargs):
+        return tools_win.msvc_build_command(output=self.output, *args, **kwargs)
 
 
-def replace_in_file(*args, **kwargs):
-    return tools_files.replace_in_file(output=_global_output, *args, **kwargs)
+    def build_sln_command(self, *args, **kwargs):
+        return tools_win.build_sln_command(output=self.output, *args, **kwargs)
+
+    def vcvars_command(self, *args, **kwargs):
+        return tools_win.vcvars_command(output=self.output, *args, **kwargs)
+
+    def vcvars_dict(self, *args, **kwargs):
+        return tools_win.vcvars_dict(output=self.output, *args, **kwargs)
+
+    def latest_vs_version_installed(self, *args, **kwargs):
+        return tools_win.latest_vs_version_installed(output=self.output, *args, **kwargs)
+
+    class SystemPackageTool(tools_system_pm.SystemPackageTool):
+
+        def __init__(self, *args, **kwargs):
+            super(Tools.SystemPackageTool, self).__init__(output=self.output, *args, **kwargs)
+
+    class NullTool(tools_system_pm.NullTool):
+        def __init__(self, *args, **kwargs):
+            super(Tools.NullTool, self).__init__(output=self.output, *args, **kwargs)
+
+    class AptTool(tools_system_pm.AptTool):
+        def __init__(self, *args, **kwargs):
+            super(Tools.AptTool, self).__init__(output=self.output, *args, **kwargs)
+
+    class DnfTool(tools_system_pm.DnfTool):
+        def __init__(self, *args, **kwargs):
+            super(Tools.DnfTool, self).__init__(output=self.output, *args, **kwargs)
+
+    class YumTool(tools_system_pm.YumTool):
+        def __init__(self, *args, **kwargs):
+            super(Tools.YumTool, self).__init__(output=self.output, *args, **kwargs)
+
+    class BrewTool(tools_system_pm.BrewTool):
+        def __init__(self, *args, **kwargs):
+            super(Tools.BrewTool, self).__init__(output=self.output, *args, **kwargs)
+
+    class PkgTool(tools_system_pm.PkgTool):
+        def __init__(self, *args, **kwargs):
+            super(Tools.PkgTool, self).__init__(output=self.output, *args, **kwargs)
+
+    class ChocolateyTool(tools_system_pm.ChocolateyTool):
+        def __init__(self, *args, **kwargs):
+            super(Tools.ChocolateyTool, self).__init__(output=self.output, *args, **kwargs)
+
+    class PkgUtilTool(tools_system_pm.PkgUtilTool):
+        def __init__(self, *args, **kwargs):
+            super(Tools.PkgUtilTool, self).__init__(output=self.output, *args, **kwargs)
+
+    class PacManTool(tools_system_pm.PacManTool):
+        def __init__(self, *args, **kwargs):
+            super(Tools.PacManTool, self).__init__(output=self.output, *args, **kwargs)
+
+    class ZypperTool(tools_system_pm.ZypperTool):
+        def __init__(self, *args, **kwargs):
+            super(Tools.ZypperTool, self).__init__(output=self.output, *args, **kwargs)
 
 
-def replace_path_in_file(*args, **kwargs):
-    return tools_files.replace_path_in_file(output=_global_output, *args, **kwargs)
 
-
-# from conans.client.tools.oss
-args_to_string = tools_oss.args_to_string
-detected_architecture = tools_oss.detected_architecture
-detected_os = tools_oss.detected_os
-OSInfo = tools_oss.OSInfo
-cross_building = tools_oss.cross_building
-get_cross_building_settings = tools_oss.get_cross_building_settings
-get_gnu_triplet = tools_oss.get_gnu_triplet
-
-
-def cpu_count(*args, **kwargs):
-    return tools_oss.cpu_count(output=_global_output, *args, **kwargs)
-
-
-# from conans.client.tools.system_pm
-class SystemPackageTool(tools_system_pm.SystemPackageTool):
-    def __init__(self, *args, **kwargs):
-        super(SystemPackageTool, self).__init__(output=_global_output, *args, **kwargs)
-
-
-class NullTool(tools_system_pm.NullTool):
-    def __init__(self, *args, **kwargs):
-        super(NullTool, self).__init__(output=_global_output, *args, **kwargs)
-
-
-class AptTool(tools_system_pm.AptTool):
-    def __init__(self, *args, **kwargs):
-        super(AptTool, self).__init__(output=_global_output, *args, **kwargs)
-
-
-class DnfTool(tools_system_pm.DnfTool):
-    def __init__(self, *args, **kwargs):
-        super(DnfTool, self).__init__(output=_global_output, *args, **kwargs)
-
-
-class YumTool(tools_system_pm.YumTool):
-    def __init__(self, *args, **kwargs):
-        super(YumTool, self).__init__(output=_global_output, *args, **kwargs)
-
-
-class BrewTool(tools_system_pm.BrewTool):
-    def __init__(self, *args, **kwargs):
-        super(BrewTool, self).__init__(output=_global_output, *args, **kwargs)
-
-
-class PkgTool(tools_system_pm.PkgTool):
-    def __init__(self, *args, **kwargs):
-        super(PkgTool, self).__init__(output=_global_output, *args, **kwargs)
-
-
-class ChocolateyTool(tools_system_pm.ChocolateyTool):
-    def __init__(self, *args, **kwargs):
-        super(ChocolateyTool, self).__init__(output=_global_output, *args, **kwargs)
-
-
-class PkgUtilTool(tools_system_pm.PkgUtilTool):
-    def __init__(self, *args, **kwargs):
-        super(PkgUtilTool, self).__init__(output=_global_output, *args, **kwargs)
-
-
-class PacManTool(tools_system_pm.PacManTool):
-    def __init__(self, *args, **kwargs):
-        super(PacManTool, self).__init__(output=_global_output, *args, **kwargs)
-
-
-class ZypperTool(tools_system_pm.ZypperTool):
-    def __init__(self, *args, **kwargs):
-        super(ZypperTool, self).__init__(output=_global_output, *args, **kwargs)
-
-
-# from conans.client.tools.win
-vs_installation_path = tools_win.vs_installation_path
-vswhere = tools_win.vswhere
-vs_comntools = tools_win.vs_comntools
-find_windows_10_sdk = tools_win.find_windows_10_sdk
-escape_windows_cmd = tools_win.escape_windows_cmd
-get_cased_path = tools_win.get_cased_path
 MSYS2 = tools_win.MSYS2
 MSYS = tools_win.MSYS
 CYGWIN = tools_win.CYGWIN
 WSL = tools_win.WSL
 SFU = tools_win.SFU
-unix_path = tools_win.unix_path
-run_in_windows_bash = tools_win.run_in_windows_bash
-msvs_toolset = tools_win.msvs_toolset
-
-
-@contextmanager
-def vcvars(*args, **kwargs):
-    with tools_win.vcvars(output=_global_output, *args, **kwargs):
-        yield
-
-
-def msvc_build_command(*args, **kwargs):
-    return tools_win.msvc_build_command(output=_global_output, *args, **kwargs)
-
-
-def build_sln_command(*args, **kwargs):
-    return tools_win.build_sln_command(output=_global_output, *args, **kwargs)
-
-
-def vcvars_command(*args, **kwargs):
-    return tools_win.vcvars_command(output=_global_output, *args, **kwargs)
-
-
-def vcvars_dict(*args, **kwargs):
-    return tools_win.vcvars_dict(output=_global_output, *args, **kwargs)
-
-
-def latest_vs_version_installed(*args, **kwargs):
-    return tools_win.latest_vs_version_installed(output=_global_output, *args, **kwargs)
-
-
-
-# Ready to use objects.
-try:
-    os_info = OSInfo()
-except Exception as exc:
-    logger.error(exc)
-    _global_output.error("Error detecting os_info")

--- a/conans/util/fallbacks.py
+++ b/conans/util/fallbacks.py
@@ -3,23 +3,21 @@
 import warnings
 
 
-def default_output(output, fn_name=None):
+def default_output(output, fn_name=None, tools=None):
     if output is None:
         fn_str = " to function '{}'".format(fn_name) if fn_name else ''
         warnings.warn("Provide the output argument explicitly{}".format(fn_str))
 
-        from conans.tools import _global_output
-        return _global_output
+        return tools.output
 
     return output
 
 
-def default_requester(requester, fn_name=None):
+def default_requester(requester, fn_name=None, tools=None):
     if requester is None:
         fn_str = " to function '{}'".format(fn_name) if fn_name else ''
         warnings.warn("Provide the requester argument explicitly{}".format(fn_str))
 
-        from conans.tools import _global_requester
-        return _global_requester
+        return tools.requester
 
     return requester


### PR DESCRIPTION
Related to #7105 

/cc @memsharded 

* Use a conanfile attribute object:

The idea here:

- Create a Tools class in conans.tools, which is loaded by ConanApp.
- Tools can be accessed by self.tools (where self is a ConanFile instance)
- All globals (output, requests and config) are member of Tools
- All regular methods in conans.tools are now part of self.tools

TODO:

- Reorganize Conan.tools imports
- Solve SystemPackageTool, NullTool, ... as they require Output object. It would be nice: apt = self.tools.AptTools() # no self.output needed


* PROS
  * Easy to maintain
  * Don't need to import Tools anymore
  * No more globals, need a Tools instance

* CONS
  * Strongly coupled to ConanFile and its loader
  * Very implicit, load more modules than you want
  * Without a ConanFile, will be hard to use Tools in an external project/package (e.g. CPT)