### PR TITLE
custom cert paths

### DIFF
--- a/conans/client/conf/__init__.py
+++ b/conans/client/conf/__init__.py
@@ -569,16 +569,33 @@ class ConanClientConfigParser(ConfigParser, object):
 
     @property
     def client_cert_path(self):
-        # TODO: Really parameterize the client cert location
-        folder = os.path.dirname(self.filename)
-        CLIENT_CERT = "client.crt"
-        return os.path.normpath(os.path.join(folder, CLIENT_CERT))
+        cache_folder = os.path.dirname(self.filename)
+        try:
+            path = self.get_item("general.client_cert_path")
+        except ConanException:
+            path = os.path.join(cache_folder, "client.crt")
+        else:
+            # For explicit cacert files, the file should already exist
+            path = os.path.join(cache_folder, path)
+            if not os.path.exists(path):
+                raise ConanException("Configured file for 'client_cert_path'"
+                                     " doesn't exists: '{}'".format(path))
+        return os.path.normpath(path)
 
     @property
     def client_cert_key_path(self):
-        CLIENT_KEY = "client.key"
-        folder = os.path.dirname(self.filename)
-        return os.path.normpath(os.path.join(folder, CLIENT_KEY))
+        cache_folder = os.path.dirname(self.filename)
+        try:
+            path = self.get_item("general.client_cert_key_path")
+        except ConanException:
+            path = os.path.join(cache_folder, "client.key")
+        else:
+            # For explicit cacert files, the file should already exist
+            path = os.path.join(cache_folder, path)
+            if not os.path.exists(path):
+                raise ConanException("Configured file for 'client_cert_key_path'"
+                                     " doesn't exists: '{}'".format(path))
+        return os.path.normpath(path)
 
     @property
     def hooks(self):

--- a/conans/test/functional/configuration/client_certs_test.py
+++ b/conans/test/functional/configuration/client_certs_test.py
@@ -2,22 +2,21 @@ import os
 import unittest
 
 from conans.client import tools
+from conans.test.utils.test_files import temp_folder
 from conans.test.utils.tools import TestClient
+from conans.util.files import save
 
 
 class ClientCertsTest(unittest.TestCase):
+    class MyHttpRequester(object):
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def get(self, _, **kwargs):
+            return kwargs.get("cert", None)
 
     def pic_client_certs_test(self):
-
-        class MyRequester(object):
-
-            def __init__(*args, **kwargs):
-                pass
-
-            def get(self, _, **kwargs):
-                return kwargs.get("cert", None)
-
-        client = TestClient(requester_class=MyRequester)
+        client = TestClient(requester_class=self.MyHttpRequester)
         self.assertIsNone(client.requester.get("url"))
 
         config = client.cache.config
@@ -32,3 +31,19 @@ class ClientCertsTest(unittest.TestCase):
 
         # assert that the cacert file is created
         self.assertTrue(os.path.exists(config.cacert_path))
+
+    def pic_custom_path_client_certs_test(self):
+        folder = temp_folder()
+        mycert_path = os.path.join(folder, "mycert.crt")
+        mykey_path = os.path.join(folder, "mycert.key")
+        save(mycert_path, "Fake Cert")
+        save(mykey_path, "Fake Key")
+
+        client = TestClient(requester_class=self.MyHttpRequester)
+        client.run('config set general.client_cert_path="%s"' % mycert_path)
+        client.run('config set general.client_cert_key_path="%s"' % mykey_path)
+
+        self.assertEqual(client.requester.get("url"), (mycert_path, mykey_path))
+
+        # assert that the cacert file is created
+        self.assertTrue(os.path.exists(client.cache.config.cacert_path))


### PR DESCRIPTION
Changelog: Feature: Allow ``conan.conf`` user configuration of paths to client certificate and key, outside of the Conan cache.
Docs: https://github.com/conan-io/docs/pull/1791

Implements half of https://github.com/conan-io/conan/issues/4353
