### PR TITLE
[tools] All tools use a conafile/ self argument as the first argument

### DIFF
--- a/conans/client/build/msbuild.py
+++ b/conans/client/build/msbuild.py
@@ -12,7 +12,7 @@ from conans.client.tools.win import vcvars_command
 from conans.errors import ConanException
 from conans.model.conan_file import ConanFile
 from conans.model.version import Version
-from conans.tools import vcvars_command as tools_vcvars_command
+from conans.client.tools.win import vcvars_command as tools_vcvars_command
 from conans.util.env_reader import get_env
 from conans.util.files import decode_text, save
 from conans.util.runners import version_runner

--- a/conans/client/conan_api.py
+++ b/conans/client/conan_api.py
@@ -61,7 +61,6 @@ from conans.model.workspace import Workspace
 from conans.paths import BUILD_INFO, CONANINFO, get_conan_user_home
 from conans.paths.package_layouts.package_cache_layout import PackageCacheLayout
 from conans.search.search import search_recipes
-from conans.tools import set_global_instances
 from conans.unicode import get_cwd
 from conans.util.conan_v2_mode import CONAN_V2_MODE_ENVVAR
 from conans.util.env_reader import get_env
@@ -190,9 +189,6 @@ class ConanApp(object):
         # Handle remote connections
         self.remote_manager = RemoteManager(self.cache, auth_manager, self.out, self.hook_manager)
 
-        # Adjust global tool variables
-        set_global_instances(self.out, self.requester, self.config)
-
         self.runner = runner or ConanRunner(self.config.print_commands_to_output,
                                             self.config.generate_run_log_file,
                                             self.config.log_run_to_output,
@@ -202,7 +198,7 @@ class ConanApp(object):
         self.range_resolver = RangeResolver(self.cache, self.remote_manager)
         self.python_requires = ConanPythonRequire(self.proxy, self.range_resolver)
         self.pyreq_loader = PyRequireLoader(self.proxy, self.range_resolver)
-        self.loader = ConanFileLoader(self.runner, self.out, self.python_requires, self.pyreq_loader)
+        self.loader = ConanFileLoader(self.runner, self.out, self.python_requires, self.pyreq_loader, self.requester, self.config)
 
         self.binaries_analyzer = GraphBinariesAnalyzer(self.cache, self.out, self.remote_manager)
         self.graph_manager = GraphManager(self.out, self.cache, self.remote_manager, self.loader,

--- a/conans/client/conanfile/package.py
+++ b/conans/client/conanfile/package.py
@@ -9,7 +9,7 @@ from conans.errors import ConanException, ConanExceptionInUserConanfileMethod, \
 from conans.model.conan_file import get_env_context_manager
 from conans.model.manifest import FileTreeManifest
 from conans.paths import CONANINFO
-from conans.tools import chdir
+from conans.tools.files import chdir
 from conans.util.conan_v2_mode import conan_v2_property
 from conans.util.files import save, mkdir, rmdir
 from conans.util.log import logger

--- a/conans/client/loader.py
+++ b/conans/client/loader.py
@@ -25,13 +25,15 @@ from conans.util.files import load
 
 
 class ConanFileLoader(object):
-    def __init__(self, runner, output, python_requires, pyreq_loader=None):
+    def __init__(self, runner, output, python_requires, pyreq_loader=None, requester=None, config=None):
         self._runner = runner
         self._output = output
         self._pyreq_loader = pyreq_loader
         self._python_requires = python_requires
         sys.modules["conans"].python_requires = python_requires
         self._cached_conanfile_classes = {}
+        self._requester = requester
+        self._config = config
 
     def load_basic(self, conanfile_path, lock_python_requires=None, user=None, channel=None,
                    display=""):
@@ -62,6 +64,8 @@ class ConanFileLoader(object):
                 self._pyreq_loader.load_py_requires(conanfile, lock_python_requires, self)
 
             conanfile.recipe_folder = os.path.dirname(conanfile_path)
+            conanfile.requester = self._requester
+            conanfile.config = self._config
 
             # If the scm is inherited, create my own instance
             if hasattr(conanfile, "scm") and "scm" not in conanfile.__class__.__dict__:

--- a/conans/client/tools/net.py
+++ b/conans/client/tools/net.py
@@ -52,7 +52,7 @@ def ftp_download(ip, filename, login='', password=''):
 
 
 def download(url, filename, verify=True, out=None, retry=None, retry_wait=None, overwrite=False,
-             auth=None, headers=None, requester=None, md5='', sha1='', sha256=''):
+             auth=None, headers=None, requester=None, config=None, md5='', sha1='', sha256=''):
     """Retrieves a file from a given URL into a file with a given filename.
        It uses certificates from a list of known verifiers for https downloads,
        but this can be optionally disabled.
@@ -79,7 +79,6 @@ def download(url, filename, verify=True, out=None, retry=None, retry_wait=None, 
     """
     out = default_output(out, 'conans.client.tools.net.download')
     requester = default_requester(requester, 'conans.client.tools.net.download')
-    from conans.tools import _global_config as config
 
     # It might be possible that users provide their own requester
     retry = retry if retry is not None else config.retry

--- a/conans/test/functional/tools/cpu_count_test.py
+++ b/conans/test/functional/tools/cpu_count_test.py
@@ -4,21 +4,22 @@ from conans.paths import CONANFILE
 from conans.test.utils.tools import TestClient
 
 conanfile = """
-from conans import ConanFile, tools
+from conans import ConanFile
+from conans.tools.oss import cpu_count
 
 class AConan(ConanFile):
     name = "Hello0"
     version = "0.1"
 
     def build(self):
-        self.output.warn("CPU COUNT=> %s" % tools.cpu_count())
+        self.output.warn("CPU COUNT=> %s" % cpu_count(self))
 
 """
 
 
 class CPUCountTest(unittest.TestCase):
 
-    def cpu_count_override_test(self):
+    def test_cpu_count_override(self):
         self.client = TestClient()
         self.client.save({CONANFILE: conanfile})
         self.client.run("config set general.cpu_count=5")

--- a/conans/test/unittests/util/tools_test.py
+++ b/conans/test/unittests/util/tools_test.py
@@ -29,7 +29,6 @@ from conans.model.settings import Settings
 from conans.test.utils.conanfile import ConanFileMock
 from conans.test.utils.test_files import temp_folder
 from conans.test.utils.tools import StoppableThreadBottle, TestBufferConanOutput, TestClient
-from conans.tools import get_global_instances
 from conans.util.env_reader import get_env
 from conans.util.files import load, md5, mkdir, save
 from conans.util.runners import check_output_runner
@@ -238,37 +237,6 @@ class HelloConan(ConanFile):
         with tools.environment_append({"CONAN_RUN_TESTS": "1"}):
             client.run("install .")
             client.run("build .")
-
-    def test_global_tools_overrided(self):
-        client = TestClient()
-
-        conanfile = """
-from conans import ConanFile, tools
-
-class HelloConan(ConanFile):
-    name = "Hello"
-    version = "0.1"
-
-    def build(self):
-        assert(tools._global_requester != None)
-        assert(tools._global_output != None)
-        """
-        client.save({"conanfile.py": conanfile})
-
-        client.run("install .")
-        client.run("build .")
-
-        # Not test the real commmand get_command if it's setting the module global vars
-        tmp = temp_folder()
-        conf = get_default_client_conf().replace("\n[proxies]", "\n[proxies]\nhttp = http://myproxy.com")
-        os.mkdir(os.path.join(tmp, ".conan"))
-        save(os.path.join(tmp, ".conan", CONAN_CONF), conf)
-        with tools.environment_append({"CONAN_USER_HOME": tmp}):
-            conan_api, _, _ = ConanAPIV1.factory()
-        conan_api.remote_list()
-        global_output, global_requester = get_global_instances()
-        self.assertEqual(global_requester.proxies, {"http": "http://myproxy.com"})
-        self.assertIsNotNone(global_output.warn)
 
     def test_environment_nested(self):
         with tools.environment_append({"A": "1", "Z": "40"}):

--- a/conans/tools.py
+++ b/conans/tools.py
@@ -24,37 +24,9 @@ from conans.client.tools.apple import *
 from conans.client.tools.android import *
 # Tools form conans.util
 from conans.util.env_reader import get_env
-from conans.util.files import _generic_algorithm_sum, load, md5, md5sum, mkdir, relative_dirs, \
-    rmdir, save as files_save, save_append, sha1sum, sha256sum, to_file_bytes, touch
 from conans.util.log import logger
 from conans.client.tools.version import Version
 from conans.client.build.cppstd_flags import cppstd_flag_new as cppstd_flag  # pylint: disable=unused-import
-
-
-# This global variables are intended to store the configuration of the running Conan application
-_global_output = None
-_global_requester = None
-_global_config = None
-
-
-def set_global_instances(the_output, the_requester, config):
-    global _global_output
-    global _global_requester
-    global _global_config
-
-    # TODO: pass here the configuration file, and make the work here (explicit!)
-    _global_output = the_output
-    _global_requester = the_requester
-    _global_config = config
-
-
-def get_global_instances():
-    return _global_output, _global_requester
-
-
-# Assign a default, will be overwritten in the factory of the ConanAPI
-set_global_instances(the_output=ConanOutput(sys.stdout, sys.stderr, True), the_requester=requests,
-                     config=None)
 
 
 """
@@ -62,172 +34,33 @@ From here onwards only currification is expected, no logic
 """
 
 
-def save(path, content, append=False):
-    # TODO: All this three functions: save, save_append and this one should be merged into one.
-    if append:
-        save_append(path=path, content=content)
-    else:
-        files_save(path=path, content=content, only_if_modified=False)
 
 
 # From conans.client.tools.net
-ftp_download = tools_net.ftp_download
 
 
-def download(*args, **kwargs):
-    return tools_net.download(out=_global_output, requester=_global_requester, *args, **kwargs)
-
-
-def get(*args, **kwargs):
-    return tools_net.get(output=_global_output, requester=_global_requester, *args, **kwargs)
 
 
 # from conans.client.tools.files
-chdir = tools_files.chdir
-human_size = tools_files.human_size
-untargz = tools_files.untargz
-check_with_algorithm_sum = tools_files.check_with_algorithm_sum
-check_sha1 = tools_files.check_sha1
-check_md5 = tools_files.check_md5
-check_sha256 = tools_files.check_sha256
-patch = tools_files.patch
-replace_prefix_in_pc_file = tools_files.replace_prefix_in_pc_file
-collect_libs = tools_files.collect_libs
-which = tools_files.which
-unix2dos = tools_files.unix2dos
-dos2unix = tools_files.dos2unix
-fix_symlinks = tools_files.fix_symlinks
 
 
-def unzip(*args, **kwargs):
-    return tools_files.unzip(output=_global_output, *args, **kwargs)
-
-
-def replace_in_file(*args, **kwargs):
-    return tools_files.replace_in_file(output=_global_output, *args, **kwargs)
-
-
-def replace_path_in_file(*args, **kwargs):
-    return tools_files.replace_path_in_file(output=_global_output, *args, **kwargs)
 
 
 # from conans.client.tools.oss
-args_to_string = tools_oss.args_to_string
-detected_architecture = tools_oss.detected_architecture
-detected_os = tools_oss.detected_os
-OSInfo = tools_oss.OSInfo
-cross_building = tools_oss.cross_building
-get_cross_building_settings = tools_oss.get_cross_building_settings
-get_gnu_triplet = tools_oss.get_gnu_triplet
 
 
-def cpu_count(*args, **kwargs):
-    return tools_oss.cpu_count(output=_global_output, *args, **kwargs)
 
 
-# from conans.client.tools.system_pm
-class SystemPackageTool(tools_system_pm.SystemPackageTool):
-    def __init__(self, *args, **kwargs):
-        super(SystemPackageTool, self).__init__(output=_global_output, *args, **kwargs)
 
 
-class NullTool(tools_system_pm.NullTool):
-    def __init__(self, *args, **kwargs):
-        super(NullTool, self).__init__(output=_global_output, *args, **kwargs)
-
-
-class AptTool(tools_system_pm.AptTool):
-    def __init__(self, *args, **kwargs):
-        super(AptTool, self).__init__(output=_global_output, *args, **kwargs)
-
-
-class DnfTool(tools_system_pm.DnfTool):
-    def __init__(self, *args, **kwargs):
-        super(DnfTool, self).__init__(output=_global_output, *args, **kwargs)
-
-
-class YumTool(tools_system_pm.YumTool):
-    def __init__(self, *args, **kwargs):
-        super(YumTool, self).__init__(output=_global_output, *args, **kwargs)
-
-
-class BrewTool(tools_system_pm.BrewTool):
-    def __init__(self, *args, **kwargs):
-        super(BrewTool, self).__init__(output=_global_output, *args, **kwargs)
-
-
-class PkgTool(tools_system_pm.PkgTool):
-    def __init__(self, *args, **kwargs):
-        super(PkgTool, self).__init__(output=_global_output, *args, **kwargs)
-
-
-class ChocolateyTool(tools_system_pm.ChocolateyTool):
-    def __init__(self, *args, **kwargs):
-        super(ChocolateyTool, self).__init__(output=_global_output, *args, **kwargs)
-
-
-class PkgUtilTool(tools_system_pm.PkgUtilTool):
-    def __init__(self, *args, **kwargs):
-        super(PkgUtilTool, self).__init__(output=_global_output, *args, **kwargs)
-
-
-class PacManTool(tools_system_pm.PacManTool):
-    def __init__(self, *args, **kwargs):
-        super(PacManTool, self).__init__(output=_global_output, *args, **kwargs)
-
-
-class ZypperTool(tools_system_pm.ZypperTool):
-    def __init__(self, *args, **kwargs):
-        super(ZypperTool, self).__init__(output=_global_output, *args, **kwargs)
 
 
 # from conans.client.tools.win
-vs_installation_path = tools_win.vs_installation_path
-vswhere = tools_win.vswhere
-vs_comntools = tools_win.vs_comntools
-find_windows_10_sdk = tools_win.find_windows_10_sdk
-escape_windows_cmd = tools_win.escape_windows_cmd
-get_cased_path = tools_win.get_cased_path
-MSYS2 = tools_win.MSYS2
-MSYS = tools_win.MSYS
-CYGWIN = tools_win.CYGWIN
-WSL = tools_win.WSL
-SFU = tools_win.SFU
-unix_path = tools_win.unix_path
-run_in_windows_bash = tools_win.run_in_windows_bash
-msvs_toolset = tools_win.msvs_toolset
-
-
-@contextmanager
-def vcvars(*args, **kwargs):
-    with tools_win.vcvars(output=_global_output, *args, **kwargs):
-        yield
-
-
-def msvc_build_command(*args, **kwargs):
-    return tools_win.msvc_build_command(output=_global_output, *args, **kwargs)
-
-
-def build_sln_command(*args, **kwargs):
-    return tools_win.build_sln_command(output=_global_output, *args, **kwargs)
-
-
-def vcvars_command(*args, **kwargs):
-    return tools_win.vcvars_command(output=_global_output, *args, **kwargs)
-
-
-def vcvars_dict(*args, **kwargs):
-    return tools_win.vcvars_dict(output=_global_output, *args, **kwargs)
-
-
-def latest_vs_version_installed(*args, **kwargs):
-    return tools_win.latest_vs_version_installed(output=_global_output, *args, **kwargs)
 
 
 
-# Ready to use objects.
-try:
-    os_info = OSInfo()
-except Exception as exc:
-    logger.error(exc)
-    _global_output.error("Error detecting os_info")
+
+
+
+
+

--- a/conans/tools/files.py
+++ b/conans/tools/files.py
@@ -1,0 +1,38 @@
+from conans.client.tools import files as tools_files
+
+
+chdir = tools_files.chdir
+human_size = tools_files.human_size
+untargz = tools_files.untargz
+check_with_algorithm_sum = tools_files.check_with_algorithm_sum
+check_sha1 = tools_files.check_sha1
+check_md5 = tools_files.check_md5
+check_sha256 = tools_files.check_sha256
+patch = tools_files.patch
+replace_prefix_in_pc_file = tools_files.replace_prefix_in_pc_file
+collect_libs = tools_files.collect_libs
+which = tools_files.which
+unix2dos = tools_files.unix2dos
+dos2unix = tools_files.dos2unix
+fix_symlinks = tools_files.fix_symlinks
+
+def save(path, content, append=False):
+    # TODO: All this three functions: save, save_append and this one should be merged into one.
+    from conans.util import files
+    if append:
+        files.save_append(path=path, content=content)
+    else:
+        files.save(path=path, content=content, only_if_modified=False)
+
+
+def unzip(conanfile, *args, **kwargs):
+    return tools_files.unzip(output=conanfile.conanfile, *args, **kwargs)
+
+
+def replace_in_file(conanfile, *args, **kwargs):
+    return tools_files.replace_in_file(output=conanfile.output, *args, **kwargs)
+
+
+def replace_path_in_file(conanfile, *args, **kwargs):
+    return tools_files.replace_path_in_file(output=conanfile.output, *args, **kwargs)
+

--- a/conans/tools/net.py
+++ b/conans/tools/net.py
@@ -1,0 +1,11 @@
+from conans.client.tools import net as tools_net
+
+ftp_download = tools_net.ftp_download
+
+
+def download(conanfile, *args, **kwargs):
+    return tools_net.download(out=conanfile.output, requester=conanfile.requester, config=conanfile.config, *args, **kwargs)
+
+
+def get(conanfile, *args, **kwargs):
+    return tools_net.get(output=conanfile.output, requester=conanfile.requester, *args, **kwargs)

--- a/conans/tools/oss.py
+++ b/conans/tools/oss.py
@@ -1,0 +1,22 @@
+from conans.client.tools import oss as tools_oss, default_output
+from conans.util.log import logger
+
+args_to_string = tools_oss.args_to_string
+detected_architecture = tools_oss.detected_architecture
+detected_os = tools_oss.detected_os
+OSInfo = tools_oss.OSInfo
+cross_building = tools_oss.cross_building
+get_cross_building_settings = tools_oss.get_cross_building_settings
+get_gnu_triplet = tools_oss.get_gnu_triplet
+
+
+def cpu_count(conanfile, *args, **kwargs):
+    return tools_oss.cpu_count(output=conanfile.output, *args, **kwargs)
+
+# Ready to use objects.
+try:
+    os_info = OSInfo()
+except Exception as exc:
+    logger.error(exc)
+    output = default_output(None, None)
+    output.error("Error detecting os_info")

--- a/conans/tools/packager.py
+++ b/conans/tools/packager.py
@@ -1,0 +1,56 @@
+from conans.client.tools import system_pm as tools_system_pm
+
+
+class SystemPackageTool(tools_system_pm.SystemPackageTool):
+    def __init__(self, conanfile, *args, **kwargs):
+        super(SystemPackageTool, self).__init__(output=conanfile.output, *args, **kwargs)
+
+
+class NullTool(tools_system_pm.NullTool):
+    def __init__(self, conanfile, *args, **kwargs):
+        super(NullTool, self).__init__(output=conanfile.output, *args, **kwargs)
+
+
+class AptTool(tools_system_pm.AptTool):
+    def __init__(self, conanfile, *args, **kwargs):
+        super(AptTool, self).__init__(output=conanfile.output, *args, **kwargs)
+
+
+class DnfTool(tools_system_pm.DnfTool):
+    def __init__(self, conanfile, *args, **kwargs):
+        super(DnfTool, self).__init__(output=conanfile.output, *args, **kwargs)
+
+
+class YumTool(tools_system_pm.YumTool):
+    def __init__(self, conanfile, *args, **kwargs):
+        super(YumTool, self).__init__(output=conanfile.output, *args, **kwargs)
+
+
+class BrewTool(tools_system_pm.BrewTool):
+    def __init__(self, conanfile, *args, **kwargs):
+        super(BrewTool, self).__init__(output=conanfile.output, *args, **kwargs)
+
+
+class PkgTool(tools_system_pm.PkgTool):
+    def __init__(self, conanfile, *args, **kwargs):
+        super(PkgTool, self).__init__(output=conanfile.output, *args, **kwargs)
+
+
+class ChocolateyTool(tools_system_pm.ChocolateyTool):
+    def __init__(self, conanfile, *args, **kwargs):
+        super(ChocolateyTool, self).__init__(output=conanfile.output, *args, **kwargs)
+
+
+class PkgUtilTool(tools_system_pm.PkgUtilTool):
+    def __init__(self, conanfile, *args, **kwargs):
+        super(PkgUtilTool, self).__init__(output=conanfile.output, *args, **kwargs)
+
+
+class PacManTool(tools_system_pm.PacManTool):
+    def __init__(self, conanfile, *args, **kwargs):
+        super(PacManTool, self).__init__(output=conanfile.output, *args, **kwargs)
+
+
+class ZypperTool(tools_system_pm.ZypperTool):
+    def __init__(self, conanfile, *args, **kwargs):
+        super(ZypperTool, self).__init__(output=conanfile.output, *args, **kwargs)

--- a/conans/tools/win.py
+++ b/conans/tools/win.py
@@ -1,0 +1,45 @@
+from contextlib import contextmanager
+
+from conans.client.tools import win as tools_win
+
+vs_installation_path = tools_win.vs_installation_path
+vswhere = tools_win.vswhere
+vs_comntools = tools_win.vs_comntools
+find_windows_10_sdk = tools_win.find_windows_10_sdk
+escape_windows_cmd = tools_win.escape_windows_cmd
+get_cased_path = tools_win.get_cased_path
+unix_path = tools_win.unix_path
+run_in_windows_bash = tools_win.run_in_windows_bash
+msvs_toolset = tools_win.msvs_toolset
+
+MSYS2 = tools_win.MSYS2
+MSYS = tools_win.MSYS
+CYGWIN = tools_win.CYGWIN
+WSL = tools_win.WSL
+SFU = tools_win.SFU
+
+
+@contextmanager
+def vcvars(conanfile, *args, **kwargs):
+    with tools_win.vcvars(output=conanfile.output, *args, **kwargs):
+        yield
+
+
+def msvc_build_command(conanfile, *args, **kwargs):
+    return tools_win.msvc_build_command(output=conanfile.output, *args, **kwargs)
+
+
+def build_sln_command(conanfile, *args, **kwargs):
+    return tools_win.build_sln_command(output=conanfile.output, *args, **kwargs)
+
+
+def vcvars_command(conanfile, *args, **kwargs):
+    return tools_win.vcvars_command(output=conanfile.output, *args, **kwargs)
+
+
+def vcvars_dict(conanfile, *args, **kwargs):
+    return tools_win.vcvars_dict(output=conanfile.output, *args, **kwargs)
+
+
+def latest_vs_version_installed(conanfile, *args, **kwargs):
+    return tools_win.latest_vs_version_installed(output=conanfile.output, *args, **kwargs)

--- a/conans/util/fallbacks.py
+++ b/conans/util/fallbacks.py
@@ -1,15 +1,18 @@
 # coding=utf-8
 
 import warnings
+import sys
+
+from conans.client.output import colorama_initialize, ConanOutput
+from conans.errors import ConanException
 
 
 def default_output(output, fn_name=None):
     if output is None:
         fn_str = " to function '{}'".format(fn_name) if fn_name else ''
         warnings.warn("Provide the output argument explicitly{}".format(fn_str))
-
-        from conans.tools import _global_output
-        return _global_output
+        out = ConanOutput(sys.stdout, sys.stderr, colorama_initialize())
+        return out
 
     return output
 
@@ -19,7 +22,8 @@ def default_requester(requester, fn_name=None):
         fn_str = " to function '{}'".format(fn_name) if fn_name else ''
         warnings.warn("Provide the requester argument explicitly{}".format(fn_str))
 
-        from conans.tools import _global_requester
-        return _global_requester
+        # Generate a default requester is more complex ...
+        # ConanRequester(self.config, http_requester)
+        raise ConanException("Ops! There is no default requester.")
 
     return requester


### PR DESCRIPTION
3º option:

* All tools use a conafile/ self argument as the first argument. Access/inject what is necessary via a conanfile private reference to collaborators (output, requester, config

This reminds me C language, an opaque context passed to all methods.

* PROS
  * More organized in terms for method contract, all use the same first argument
  * "Namespace" give a better organization

* CONS
  * Require more effort and change in the code base (e.g net is very fragile)
  * Conanfile is more then a Conan file now, it's the Client and the File together.
  * It is not possible to use these tools without a ConanFile object. (thanks Javi)
  

/cc @memsharded 

related to #7105