### PR TITLE
relax pluginbase requirements

### DIFF
--- a/conans/requirements_server.txt
+++ b/conans/requirements_server.txt
@@ -1,3 +1,3 @@
 # Server
 bottle>=0.12.8, < 0.13
-pluginbase>=0.5, < 1.0
+pluginbase>=0.5


### PR DESCRIPTION
Changelog: Fix: Relax ``pluginbase`` requirement to ``pluginbase>=0.5``, including latest 1.0.0 .
Docs: Omit

Related issue: #7440 

Note that some distros have some open bugs related to the pluginbase requirements. See for example https://bugs.gentoo.org/733026 in Gentoo or https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=845463 in Debian.  This PR will help to fix those bugs.



- [x] Refer to the issue that supports this Pull Request.
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 

<sup>**Note:** By default this PR will skip the slower tests and will use a limited set of python versions. Check [here](https://github.com/conan-io/conan/blob/develop/.github/PR_INCREASE_TESTING.md) how to increase the testing level by writing some tags in the current PR body text.</sup>
