### PR TITLE
Add Conan version to HTML output

### DIFF
--- a/conans/assets/templates/info_graph_html.py
+++ b/conans/assets/templates/info_graph_html.py
@@ -1,3 +1,4 @@
+# coding=utf-8
 
 content = """
 <html lang="en">

--- a/conans/assets/templates/info_graph_html.py
+++ b/conans/assets/templates/info_graph_html.py
@@ -131,7 +131,7 @@ content = """
         <div class="container-fluid">
             <div class="info">
                 <p>
-                      Conan <b>v{{ version  }}</b> © {{ year }} JFrog LTD. <a>https://conan.io</a>
+                      Conan <b>v{{ version  }}</b> © <script>document.write(new Date().getFullYear())</script> JFrog LTD. <a>https://conan.io</a>
                 </p>
             </div>
         </div>

--- a/conans/assets/templates/info_graph_html.py
+++ b/conans/assets/templates/info_graph_html.py
@@ -126,5 +126,14 @@ content = """
             });
         </script>
     </body>
+    <footer>
+        <div class="container-fluid">
+            <div class="info">
+                <p>
+                      Conan <b>v{{ version  }}</b> © {{ year }} JFrog LTD. <a>https://conan.io</a>
+                </p>
+            </div>
+        </div>
+    </footer>
 </html>
 """

--- a/conans/assets/templates/info_graph_html.py
+++ b/conans/assets/templates/info_graph_html.py
@@ -1,5 +1,3 @@
-# coding=utf-8
-
 content = """
 <html lang="en">
     <head>
@@ -131,7 +129,7 @@ content = """
         <div class="container-fluid">
             <div class="info">
                 <p>
-                      Conan <b>v{{ version  }}</b> © <script>document.write(new Date().getFullYear())</script> JFrog LTD. <a>https://conan.io</a>
+                      Conan <b>v{{ version  }}</b> <script>document.write(new Date().getFullYear())</script> JFrog LTD. <a>https://conan.io</a>
                 </p>
             </div>
         </div>

--- a/conans/assets/templates/search_table_html.py
+++ b/conans/assets/templates/search_table_html.py
@@ -104,7 +104,7 @@ content = """
         <div class="container-fluid">
             <div class="info">
                 <p>
-                      Conan <b>v{{ version  }}</b> © {{ year }} JFrog LTD. <a>https://conan.io</a>
+                      Conan <b>v{{ version  }}</b> © <script>document.write(new Date().getFullYear())</script> JFrog LTD. <a>https://conan.io</a>
                 </p>
             </div>
         </div>

--- a/conans/assets/templates/search_table_html.py
+++ b/conans/assets/templates/search_table_html.py
@@ -1,5 +1,3 @@
-# coding=utf-8
-
 content = """
 <!DOCTYPE html>
 <html lang="en">
@@ -104,7 +102,7 @@ content = """
         <div class="container-fluid">
             <div class="info">
                 <p>
-                      Conan <b>v{{ version  }}</b> © <script>document.write(new Date().getFullYear())</script> JFrog LTD. <a>https://conan.io</a>
+                      Conan <b>v{{ version  }}</b> <script>document.write(new Date().getFullYear())</script> JFrog LTD. <a>https://conan.io</a>
                 </p>
             </div>
         </div>

--- a/conans/assets/templates/search_table_html.py
+++ b/conans/assets/templates/search_table_html.py
@@ -99,5 +99,14 @@ content = """
         </script>
     </div>
     </body>
+    <footer>
+        <div class="container-fluid">
+            <div class="info">
+                <p>
+                      Conan <b>v{{ version  }}</b> © {{ year }} JFrog LTD. <a>https://conan.io</a>
+                </p>
+            </div>
+        </div>
+    </footer>
 </html>
 """

--- a/conans/assets/templates/search_table_html.py
+++ b/conans/assets/templates/search_table_html.py
@@ -1,3 +1,4 @@
+# coding=utf-8
 
 content = """
 <!DOCTYPE html>

--- a/conans/client/conan_command_output.py
+++ b/conans/client/conan_command_output.py
@@ -1,6 +1,5 @@
 import json
 import os
-from datetime import datetime
 from collections import OrderedDict
 
 from conans.client.graph.graph import RECIPE_CONSUMER, RECIPE_VIRTUAL
@@ -234,7 +233,7 @@ class CommandOutputer(object):
         template_folder = os.path.dirname(template.filename)
         save(graph_filename,
              template.render(graph=graph, assets=assets, base_template_path=template_folder,
-                             version=client_version, year=datetime.today().year))
+                             version=client_version))
 
     def json_info(self, deps_graph, json_output, cwd, show_paths):
         data = self._grab_info_data(deps_graph, grab_paths=show_paths)

--- a/conans/client/conan_command_output.py
+++ b/conans/client/conan_command_output.py
@@ -1,5 +1,6 @@
 import json
 import os
+from datetime import datetime
 from collections import OrderedDict
 
 from conans.client.graph.graph import RECIPE_CONSUMER, RECIPE_VIRTUAL
@@ -13,6 +14,7 @@ from conans.unicode import get_cwd
 from conans.util.dates import iso8601_to_str
 from conans.util.env_reader import get_env
 from conans.util.files import save
+from conans import __version__ as client_version
 
 
 class CommandOutputer(object):
@@ -231,7 +233,8 @@ class CommandOutputer(object):
 
         template_folder = os.path.dirname(template.filename)
         save(graph_filename,
-             template.render(graph=graph, assets=assets, base_template_path=template_folder))
+             template.render(graph=graph, assets=assets, base_template_path=template_folder,
+                             version=client_version, year=datetime.today().year))
 
     def json_info(self, deps_graph, json_output, cwd, show_paths):
         data = self._grab_info_data(deps_graph, grab_paths=show_paths)

--- a/conans/search/binary_html_table.py
+++ b/conans/search/binary_html_table.py
@@ -1,8 +1,10 @@
 import os
 from collections import OrderedDict, defaultdict
+from datetime import datetime
 
 from conans.model.ref import PackageReference
 from conans.util.files import save
+from conans import __version__ as client_version
 
 
 class RowResult(object):
@@ -151,5 +153,6 @@ def html_binary_graph(search_info, reference, table_filename, template):
 
     # Render and save
     template_folder = os.path.dirname(template.filename)
-    content = template.render(search=search, results=results, base_template_path=template_folder)
+    content = template.render(search=search, results=results, base_template_path=template_folder,
+                              version=client_version, year=datetime.today().year)
     save(table_filename, content)

--- a/conans/search/binary_html_table.py
+++ b/conans/search/binary_html_table.py
@@ -1,6 +1,5 @@
 import os
 from collections import OrderedDict, defaultdict
-from datetime import datetime
 
 from conans.model.ref import PackageReference
 from conans.util.files import save
@@ -154,5 +153,5 @@ def html_binary_graph(search_info, reference, table_filename, template):
     # Render and save
     template_folder = os.path.dirname(template.filename)
     content = template.render(search=search, results=results, base_template_path=template_folder,
-                              version=client_version, year=datetime.today().year)
+                              version=client_version)
     save(table_filename, content)

--- a/conans/test/functional/command/info/info_test.py
+++ b/conans/test/functional/command/info/info_test.py
@@ -3,12 +3,14 @@ import os
 import re
 import textwrap
 import unittest
+from datetime import datetime
 
 from conans.model.ref import ConanFileReference
 from conans.paths import CONANFILE
 from conans.test.utils.cpp_test_files import cpp_hello_conan_files
 from conans.test.utils.tools import TestClient, GenConanfile
 from conans.util.files import load, save
+from conans import __version__ as client_version
 
 
 class InfoTest(unittest.TestCase):
@@ -199,6 +201,8 @@ class InfoTest(unittest.TestCase):
         self.assertIn("<body>", html)
         self.assertIn("{ from: 0, to: 1 }", html)
         self.assertIn("id: 0,\n                        label: 'Hello0/0.1',", html)
+        self.assertIn("Conan <b>v{}</b> © {} JFrog LTD. <a>https://conan.io</a>"
+                      .format(client_version, datetime.today().year), html)
 
     def graph_html_embedded_visj_test(self):
         client = TestClient()

--- a/conans/test/functional/command/info/info_test.py
+++ b/conans/test/functional/command/info/info_test.py
@@ -1,4 +1,3 @@
-# coding=utf-8
 import json
 import os
 import re
@@ -202,7 +201,7 @@ class InfoTest(unittest.TestCase):
         self.assertIn("<body>", html)
         self.assertIn("{ from: 0, to: 1 }", html)
         self.assertIn("id: 0,\n                        label: 'Hello0/0.1',", html)
-        self.assertIn("Conan <b>v{}</b> © <script>document.write(new Date().getFullYear())</script> JFrog LTD. <a>https://conan.io</a>"
+        self.assertIn("Conan <b>v{}</b> <script>document.write(new Date().getFullYear())</script> JFrog LTD. <a>https://conan.io</a>"
                       .format(client_version, datetime.today().year), html)
 
     def graph_html_embedded_visj_test(self):

--- a/conans/test/functional/command/info/info_test.py
+++ b/conans/test/functional/command/info/info_test.py
@@ -1,3 +1,4 @@
+# coding=utf-8
 import json
 import os
 import re
@@ -201,7 +202,7 @@ class InfoTest(unittest.TestCase):
         self.assertIn("<body>", html)
         self.assertIn("{ from: 0, to: 1 }", html)
         self.assertIn("id: 0,\n                        label: 'Hello0/0.1',", html)
-        self.assertIn("Conan <b>v{}</b> © {} JFrog LTD. <a>https://conan.io</a>"
+        self.assertIn("Conan <b>v{}</b> © <script>document.write(new Date().getFullYear())</script> JFrog LTD. <a>https://conan.io</a>"
                       .format(client_version, datetime.today().year), html)
 
     def graph_html_embedded_visj_test(self):

--- a/conans/test/functional/command/search_test.py
+++ b/conans/test/functional/command/search_test.py
@@ -403,7 +403,7 @@ helloTest/1.4.10@myuser/stable""".format(remote)
                       "<td>Visual Studio</td>"
                       "<td></td>"
                       "<td>8.1</td>", html)
-        self.assertIn("Conan <b>v{}</b> © <script>document.write(new Date().getFullYear())</script> JFrog LTD. <a>https://conan.io</a>"
+        self.assertIn("Conan <b>v{}</b> <script>document.write(new Date().getFullYear())</script> JFrog LTD. <a>https://conan.io</a>"
                       .format(client_version), html)
 
     def search_html_table_all_test(self):

--- a/conans/test/functional/command/search_test.py
+++ b/conans/test/functional/command/search_test.py
@@ -385,7 +385,7 @@ helloTest/1.4.10@myuser/stable""".format(remote)
         self.client.run("search Hello/1.4.10@myuser/testing --raw")
         self.assertNotIn("Existing packages for recipe", self.client.out)
 
-    def test_search_html_table_test(self):
+    def search_html_table_test(self):
         self.client.run("search Hello/1.4.10@myuser/testing --table=table.html")
         html = ''.join([line.strip() for line in self.client.load("table.html").splitlines()])
         self.assertIn("<h1>Hello/1.4.10@myuser/testing</h1>", html)

--- a/conans/test/functional/command/search_test.py
+++ b/conans/test/functional/command/search_test.py
@@ -4,6 +4,7 @@ import shutil
 import textwrap
 import time
 import unittest
+from datetime import datetime
 from collections import OrderedDict
 
 from mock import patch
@@ -19,6 +20,8 @@ from conans.util.dates import iso8601_to_str, from_timestamp_to_iso8601
 from conans.util.env_reader import get_env
 from conans.util.files import list_folder_subdirs, load
 from conans.util.files import save
+from conans import __version__ as client_version
+
 
 conan_vars1 = '''
 [settings]
@@ -400,6 +403,8 @@ helloTest/1.4.10@myuser/stable""".format(remote)
                       "<td>Visual Studio</td>"
                       "<td></td>"
                       "<td>8.1</td>", html)
+        self.assertIn("Conan <b>v{}</b> © {} JFrog LTD. <a>https://conan.io</a>"
+                      .format(client_version, datetime.today().year), html)
 
     def search_html_table_all_test(self):
         os.rmdir(self.servers["local"].server_store.store)

--- a/conans/test/functional/command/search_test.py
+++ b/conans/test/functional/command/search_test.py
@@ -1,10 +1,10 @@
+# coding=utf-8
 import json
 import os
 import shutil
 import textwrap
 import time
 import unittest
-from datetime import datetime
 from collections import OrderedDict
 
 from mock import patch
@@ -385,7 +385,7 @@ helloTest/1.4.10@myuser/stable""".format(remote)
         self.client.run("search Hello/1.4.10@myuser/testing --raw")
         self.assertNotIn("Existing packages for recipe", self.client.out)
 
-    def search_html_table_test(self):
+    def test_search_html_table_test(self):
         self.client.run("search Hello/1.4.10@myuser/testing --table=table.html")
         html = ''.join([line.strip() for line in self.client.load("table.html").splitlines()])
         self.assertIn("<h1>Hello/1.4.10@myuser/testing</h1>", html)
@@ -403,8 +403,8 @@ helloTest/1.4.10@myuser/stable""".format(remote)
                       "<td>Visual Studio</td>"
                       "<td></td>"
                       "<td>8.1</td>", html)
-        self.assertIn("Conan <b>v{}</b> © {} JFrog LTD. <a>https://conan.io</a>"
-                      .format(client_version, datetime.today().year), html)
+        self.assertIn("Conan <b>v{}</b> © <script>document.write(new Date().getFullYear())</script> JFrog LTD. <a>https://conan.io</a>"
+                      .format(client_version), html)
 
     def search_html_table_all_test(self):
         os.rmdir(self.servers["local"].server_store.store)


### PR DESCRIPTION
closes #7365

Changelog: Feature: Show Conan version on HTML output.
Docs: https://github.com/conan-io/docs/pull/1782

Preview:
* conan search zlib/1.2.11@ --table index.html
![Screenshot_2020-07-28 Conan zlib 1 2 11](https://user-images.githubusercontent.com/4870173/88718929-df987980-d0f8-11ea-87ea-bf00d4782fc9.png)

* conan info zlib/1.2.11@ --graph index.html
![Screenshot_2020-07-28 Screenshot](https://user-images.githubusercontent.com/4870173/88719081-19698000-d0f9-11ea-9e1d-00d038f3ecd1.png)



- [x] Refer to the issue that supports this Pull Request.
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 

<sup>**Note:** By default this PR will skip the slower tests and will use a limited set of python versions. Check [here](https://github.com/conan-io/conan/blob/develop/.github/PR_INCREASE_TESTING.md) how to increase the testing level by writing some tags in the current PR body text.</sup>
