### PR TITLE
Using getLogger to return the Conan logger instead of returning from import

### DIFF
--- a/conans/cli/cli.py
+++ b/conans/cli/cli.py
@@ -3,6 +3,7 @@ import os
 import pkgutil
 import signal
 import sys
+import logging
 from collections import defaultdict
 from difflib import get_close_matches
 from inspect import getmembers
@@ -14,7 +15,8 @@ from conans.cli.exit_codes import SUCCESS, ERROR_MIGRATION, ERROR_GENERAL, USER_
 from conans.client.conan_api import Conan
 from conans.errors import ConanException, ConanInvalidConfiguration, ConanMigrationError
 from conans.util.files import exception_message_safe
-from conans.util.log import logger
+
+logger = logging.getLogger("conans")
 
 
 class Cli(object):

--- a/conans/client/build/cmake_flags.py
+++ b/conans/client/build/cmake_flags.py
@@ -1,5 +1,6 @@
 import os
 import platform
+import logging
 from collections import OrderedDict
 
 from conans.client import tools
@@ -11,7 +12,8 @@ from conans.client.tools.oss import get_cross_building_settings
 from conans.errors import ConanException
 from conans.model.build_info import DEFAULT_BIN, DEFAULT_INCLUDE, DEFAULT_LIB, DEFAULT_SHARE
 from conans.util.env_reader import get_env
-from conans.util.log import logger
+
+logger = logging.getLogger("conans")
 
 verbose_definition_name = "CMAKE_VERBOSE_MAKEFILE"
 cmake_install_prefix_var_name = "CMAKE_INSTALL_PREFIX"

--- a/conans/client/cmd/build.py
+++ b/conans/client/cmd/build.py
@@ -1,11 +1,14 @@
 import os
+import logging
 
 from conans.client.conanfile.build import run_build_method
 from conans.errors import (ConanException, NotFoundException, conanfile_exception_formatter)
 from conans.model.conan_file import get_env_context_manager
 from conans.paths import CONANFILE, CONANFILE_TXT
 from conans.util.files import mkdir
-from conans.util.log import logger
+
+
+logger = logging.getLogger("conans")
 
 
 def cmd_build(app, conanfile_path, source_folder, build_folder, package_folder, install_folder,

--- a/conans/client/cmd/export.py
+++ b/conans/client/cmd/export.py
@@ -2,6 +2,7 @@ import ast
 import os
 import shutil
 import sys
+import logging
 
 import six
 import yaml
@@ -18,7 +19,8 @@ from conans.paths import CONANFILE, DATA_YML
 from conans.search.search import search_recipes, search_packages
 from conans.util.files import is_dirty, load, rmdir, save, set_dirty, remove, mkdir, \
     merge_directories
-from conans.util.log import logger
+
+logger = logging.getLogger("conans")
 
 isPY38 = bool(sys.version_info.major == 3 and sys.version_info.minor == 8)
 

--- a/conans/client/cmd/uploader.py
+++ b/conans/client/cmd/uploader.py
@@ -3,6 +3,7 @@ import stat
 import tarfile
 import time
 import traceback
+import logging
 from collections import defaultdict
 from multiprocessing.pool import ThreadPool
 
@@ -19,9 +20,10 @@ from conans.paths import (CONAN_MANIFEST, CONANFILE, EXPORT_SOURCES_TGZ_NAME,
 from conans.search.search import search_packages, search_recipes
 from conans.util.files import (load, clean_dirty, is_dirty,
                                gzopen_without_timestamps, set_dirty_context_manager)
-from conans.util.log import logger
 from conans.util.tracer import (log_recipe_upload, log_compressed_files,
                                 log_package_upload)
+
+logger = logging.getLogger("conans")
 
 
 UPLOAD_POLICY_FORCE = "force-upload"

--- a/conans/client/command.py
+++ b/conans/client/command.py
@@ -4,6 +4,7 @@ import json
 import os
 import signal
 import sys
+import logging
 from argparse import ArgumentError
 from difflib import get_close_matches
 
@@ -26,10 +27,11 @@ from conans.unicode import get_cwd
 from conans.util.config_parser import get_bool_from_text
 from conans.util.files import exception_message_safe
 from conans.util.files import save
-from conans.util.log import logger
 from conans.assets import templates
 from conans.cli.exit_codes import SUCCESS, ERROR_MIGRATION, ERROR_GENERAL, USER_CTRL_C, \
     ERROR_SIGTERM, USER_CTRL_BREAK, ERROR_INVALID_CONFIGURATION
+
+logger = logging.getLogger("conans")
 
 
 class Extender(argparse.Action):

--- a/conans/client/conan_api.py
+++ b/conans/client/conan_api.py
@@ -1,6 +1,7 @@
 import json
 import os
 import sys
+import logging
 from collections import OrderedDict
 from collections import namedtuple
 
@@ -172,9 +173,11 @@ class ConanApp(object):
             self.user_io.disable_input()
 
         # Adjust CONAN_LOGGING_LEVEL with the env readed
-        conans.util.log.logger = configure_logger(self.config.logging_level,
-                                                  self.config.logging_file)
-        conans.util.log.logger.debug("INIT: Using config '%s'" % self.cache.conan_conf_path)
+        configure_logger(self.config.logging_level,
+                         self.config.logging_file)
+
+        logger = logging.getLogger("conans")
+        logger.debug("INIT: Using config '%s'" % self.cache.conan_conf_path)
 
         self.hook_manager = HookManager(self.cache.hooks_path, self.config.hooks, self.out)
         # Wraps an http_requester to inject proxies, certs, etc

--- a/conans/client/conanfile/build.py
+++ b/conans/client/conanfile/build.py
@@ -1,8 +1,10 @@
 import os
+import logging
 
 from conans.errors import conanfile_exception_formatter
 from conans.model.conan_file import get_env_context_manager
-from conans.util.log import logger
+
+logger = logging.getLogger("conans")
 
 
 def run_build_method(conanfile, hook_manager, **hook_kwargs):

--- a/conans/client/conanfile/package.py
+++ b/conans/client/conanfile/package.py
@@ -1,5 +1,6 @@
 import os
 import shutil
+import logging
 
 from conans.client.file_copier import FileCopier
 from conans.client.output import ScopedOutput
@@ -12,8 +13,8 @@ from conans.paths import CONANINFO
 from conans.tools import chdir
 from conans.util.conan_v2_mode import conan_v2_property
 from conans.util.files import save, mkdir, rmdir
-from conans.util.log import logger
 
+logger = logging.getLogger("conans")
 
 def run_package_method(conanfile, package_id, source_folder, build_folder, package_folder,
                        install_folder, hook_manager, conanfile_path, ref, local=False,

--- a/conans/client/generators/text.py
+++ b/conans/client/generators/text.py
@@ -1,6 +1,7 @@
 import os
 import re
 import traceback
+import logging
 from collections import defaultdict, OrderedDict
 
 from conans.errors import ConanException
@@ -9,8 +10,8 @@ from conans.model.build_info import CppInfo, DepsCppInfo, DepCppInfo
 from conans.model.env_info import DepsEnvInfo
 from conans.model.user_info import DepsUserInfo
 from conans.paths import BUILD_INFO
-from conans.util.log import logger
 
+logger = logging.getLogger("conans")
 
 class RootCppTXT(object):
     def __init__(self, cpp_info):

--- a/conans/client/graph/graph_builder.py
+++ b/conans/client/graph/graph_builder.py
@@ -1,4 +1,5 @@
 import time
+import logging
 
 from conans.client.conanfile.configure import run_configure_method
 from conans.client.graph.graph import DepsGraph, Node, RECIPE_EDITABLE, CONTEXT_HOST, CONTEXT_BUILD
@@ -7,7 +8,8 @@ from conans.errors import (ConanException, ConanExceptionInUserConanfileMethod,
 from conans.model.conan_file import get_env_context_manager
 from conans.model.ref import ConanFileReference
 from conans.model.requires import Requirements, Requirement
-from conans.util.log import logger
+
+logger = logging.getLogger("conans")
 
 
 class DepsGraphBuilder(object):

--- a/conans/client/installer.py
+++ b/conans/client/installer.py
@@ -2,6 +2,7 @@ import os
 import shutil
 import textwrap
 import time
+import logging
 from multiprocessing.pool import ThreadPool
 
 from conans.client import tools
@@ -35,8 +36,9 @@ from conans.util.conan_v2_mode import CONAN_V2_MODE_ENVVAR
 from conans.util.env_reader import get_env
 from conans.util.files import (clean_dirty, is_dirty, make_read_only, mkdir, rmdir, save, set_dirty,
                                set_dirty_context_manager)
-from conans.util.log import logger
 from conans.util.tracer import log_package_built, log_package_got_from_local_cache
+
+logger = logging.getLogger("conans")
 
 
 def build_id(conan_file):

--- a/conans/client/profile_loader.py
+++ b/conans/client/profile_loader.py
@@ -1,4 +1,5 @@
 import os
+import logging
 from collections import OrderedDict, defaultdict
 
 from conans.errors import ConanException, ConanV2Exception
@@ -9,7 +10,8 @@ from conans.model.ref import ConanFileReference
 from conans.util.conan_v2_mode import conan_v2_behavior
 from conans.util.config_parser import ConfigParser
 from conans.util.files import load, mkdir
-from conans.util.log import logger
+
+logger = logging.getLogger("conans")
 
 
 class ProfileParser(object):

--- a/conans/client/remote_manager.py
+++ b/conans/client/remote_manager.py
@@ -2,6 +2,7 @@ import os
 import shutil
 import time
 import traceback
+import logging
 
 from requests.exceptions import ConnectionError
 
@@ -16,11 +17,12 @@ from conans.util import progress_bar
 from conans.util.env_reader import get_env
 from conans.util.files import make_read_only, mkdir, rmdir, tar_extract, touch_folder, \
     merge_directories, md5sum, sha1sum
-from conans.util.log import logger
 # FIXME: Eventually, when all output is done, tracer functions should be moved to the recorder class
 from conans.util.tracer import (log_package_download,
                                 log_recipe_download, log_recipe_sources_download,
                                 log_uncompressed_file)
+
+logger = logging.getLogger("conans")
 
 
 class RemoteManager(object):

--- a/conans/client/remover.py
+++ b/conans/client/remover.py
@@ -1,4 +1,5 @@
 import os
+import logging
 
 from conans.client.cache.remote_registry import Remote
 from conans.errors import ConanException, PackageNotFoundException, RecipeNotFoundException
@@ -6,7 +7,8 @@ from conans.errors import NotFoundException
 from conans.model.ref import ConanFileReference, PackageReference, check_valid_ref
 from conans.paths import SYSTEM_REQS, rm_conandir
 from conans.search.search import filter_outdated, search_packages, search_recipes
-from conans.util.log import logger
+
+logger = logging.getLogger("conans")
 
 
 class DiskRemover(object):

--- a/conans/client/rest/auth_manager.py
+++ b/conans/client/rest/auth_manager.py
@@ -12,11 +12,13 @@ Flow:
 """
 
 import hashlib
+import logging
 from uuid import getnode as get_mac
 
 from conans.client.cmd.user import update_localdb
 from conans.errors import AuthenticationException, ConanException, ForbiddenException
-from conans.util.log import logger
+
+logger = logging.getLogger("conans")
 
 LOGIN_RETRIES = 3
 

--- a/conans/client/rest/file_downloader.py
+++ b/conans/client/rest/file_downloader.py
@@ -2,6 +2,7 @@ import os
 import re
 import time
 import traceback
+import logging
 
 import six
 
@@ -10,8 +11,9 @@ from conans.errors import AuthenticationException, ConanConnectionError, ConanEx
     NotFoundException, ForbiddenException, RequestErrorException
 from conans.util import progress_bar
 from conans.util.files import mkdir
-from conans.util.log import logger
 from conans.util.tracer import log_download
+
+logger = logging.getLogger("conans")
 
 
 class FileDownloader(object):

--- a/conans/client/rest/rest_client.py
+++ b/conans/client/rest/rest_client.py
@@ -1,9 +1,12 @@
+import logging
+
 from conans import CHECKSUM_DEPLOY, REVISIONS, ONLY_V2, OAUTH_TOKEN, MATRIX_PARAMS
 from conans.client.rest.rest_client_v1 import RestV1Methods
 from conans.client.rest.rest_client_v2 import RestV2Methods
 from conans.errors import OnlyV2Available, AuthenticationException
 from conans.search.search import filter_packages
-from conans.util.log import logger
+
+logger = logging.getLogger("conans")
 
 
 class RestApiClientFactory(object):

--- a/conans/client/rest/rest_client_common.py
+++ b/conans/client/rest/rest_client_common.py
@@ -1,4 +1,5 @@
 import json
+import logging
 
 from requests.auth import AuthBase, HTTPBasicAuth
 
@@ -8,7 +9,8 @@ from conans.errors import (EXCEPTION_CODE_MAPPING, ConanException,
                            PackageNotFoundException)
 from conans.model.ref import ConanFileReference
 from conans.util.files import decode_text
-from conans.util.log import logger
+
+logger = logging.getLogger("conans")
 
 
 class JWTAuth(AuthBase):

--- a/conans/client/rest/rest_client_v1.py
+++ b/conans/client/rest/rest_client_v1.py
@@ -1,6 +1,7 @@
 import os
 import time
 import traceback
+import logging
 from collections import namedtuple
 
 from six.moves.urllib.parse import parse_qs, urljoin, urlparse, urlsplit
@@ -18,7 +19,8 @@ from conans.model.manifest import FileTreeManifest
 from conans.paths import CONANINFO, CONAN_MANIFEST, EXPORT_SOURCES_TGZ_NAME, EXPORT_TGZ_NAME, \
     PACKAGE_TGZ_NAME
 from conans.util.files import decode_text
-from conans.util.log import logger
+
+logger = logging.getLogger("conans")
 
 
 def complete_url(base_url, url):

--- a/conans/client/rest/rest_client_v2.py
+++ b/conans/client/rest/rest_client_v2.py
@@ -1,6 +1,7 @@
 import os
 import time
 import traceback
+import logging
 
 from conans import DEFAULT_REVISION_V1
 from conans.client.remote_manager import check_compressed_files
@@ -16,7 +17,8 @@ from conans.model.manifest import FileTreeManifest
 from conans.model.ref import PackageReference
 from conans.paths import EXPORT_SOURCES_TGZ_NAME, EXPORT_TGZ_NAME, PACKAGE_TGZ_NAME
 from conans.util.files import decode_text
-from conans.util.log import logger
+
+logger = logging.getLogger("conans")
 
 
 class RestV2Methods(RestCommonMethods):

--- a/conans/client/settings_preprocessor.py
+++ b/conans/client/settings_preprocessor.py
@@ -1,7 +1,10 @@
+import logging
+
 from conans.client.build.cppstd_flags import cppstd_flag
 from conans.errors import ConanException
 from conans.util.conan_v2_mode import conan_v2_behavior
-from conans.util.log import logger
+
+logger = logging.getLogger("conans")
 
 
 def preprocess(settings):

--- a/conans/model/env_info.py
+++ b/conans/model/env_info.py
@@ -1,9 +1,11 @@
 import copy
 import re
+import logging
 from collections import OrderedDict, defaultdict
 
 from conans.errors import ConanException
-from conans.util.log import logger
+
+logger = logging.getLogger("conans")
 
 
 def unquote(text):

--- a/conans/paths/package_layouts/package_cache_layout.py
+++ b/conans/paths/package_layouts/package_cache_layout.py
@@ -3,6 +3,7 @@
 import os
 import platform
 import threading
+import logging
 from contextlib import contextmanager
 
 import fasteners
@@ -19,7 +20,8 @@ from conans.paths import CONANFILE, SYSTEM_REQS, EXPORT_FOLDER, EXPORT_SRC_FOLDE
     BUILD_FOLDER, PACKAGES_FOLDER, SYSTEM_REQS_FOLDER, PACKAGE_METADATA, SCM_SRC_FOLDER
 from conans.util.files import load, save, rmdir
 from conans.util.locks import Lock, NoLock, ReadLock, SimpleLock, WriteLock
-from conans.util.log import logger
+
+logger = logging.getLogger("conans")
 
 
 def short_path(func):

--- a/conans/search/query_parse.py
+++ b/conans/search/query_parse.py
@@ -1,4 +1,6 @@
-from conans.util.log import logger
+import logging
+
+logger = logging.getLogger("conans")
 
 
 def is_operator(el):

--- a/conans/search/search.py
+++ b/conans/search/search.py
@@ -1,5 +1,6 @@
 import os
 import re
+import logging
 from collections import OrderedDict
 from fnmatch import translate
 
@@ -9,7 +10,8 @@ from conans.model.ref import ConanFileReference, PackageReference
 from conans.paths import CONANINFO
 from conans.search.query_parse import evaluate_postfix, infix_to_postfix
 from conans.util.files import list_folder_subdirs, load
-from conans.util.log import logger
+
+logger = logging.getLogger("conans")
 
 
 def filter_outdated(packages_infos, recipe_hash):

--- a/conans/server/conf/__init__.py
+++ b/conans/server/conf/__init__.py
@@ -5,6 +5,7 @@ Server's configuration variables
 import os
 import random
 import string
+import logging
 from datetime import timedelta
 
 import six
@@ -18,7 +19,8 @@ from conans.server.store.disk_adapter import ServerDiskAdapter
 from conans.server.store.server_store import ServerStore
 from conans.util.env_reader import get_env
 from conans.util.files import mkdir, save
-from conans.util.log import logger
+
+logger = logging.getLogger("conans")
 
 MIN_CLIENT_COMPATIBLE_VERSION = '0.25.0'
 

--- a/conans/server/migrate.py
+++ b/conans/server/migrate.py
@@ -1,8 +1,11 @@
+import logging
+
 from conans import __version__ as SERVER_VERSION
 from conans.model.version import Version
 from conans.server.conf import ConanServerConfigParser
 from conans.server.migrations import ServerMigrator
-from conans.util.log import logger
+
+logger = logging.getLogger("conans")
 
 
 def migrate_and_get_server_config(base_folder, force_migration=False):

--- a/conans/server/migrations.py
+++ b/conans/server/migrations.py
@@ -1,5 +1,6 @@
 import os
 import shutil
+import logging
 
 from conans import DEFAULT_REVISION_V1
 from conans.migrations import Migrator
@@ -8,7 +9,8 @@ from conans.paths import PACKAGES_FOLDER
 from conans.server.revision_list import RevisionList
 from conans.server.store.server_store import REVISIONS_FILE
 from conans.util.files import list_folder_subdirs, mkdir, rmdir, save
-from conans.util.log import logger
+
+logger = logging.getLogger("conans")
 
 
 class ServerMigrator(Migrator):

--- a/conans/server/rest/bottle_plugins/authorization_header.py
+++ b/conans/server/rest/bottle_plugins/authorization_header.py
@@ -1,10 +1,11 @@
 import inspect
+import logging
 from abc import ABCMeta, abstractmethod
 
 import six
 from bottle import PluginError, request
 
-from conans.util.log import logger
+logger = logging.getLogger("conans")
 
 
 @six.add_metaclass(ABCMeta)

--- a/conans/server/rest/bottle_plugins/return_handler.py
+++ b/conans/server/rest/bottle_plugins/return_handler.py
@@ -1,9 +1,11 @@
 import traceback
+import logging
 
 from bottle import HTTPResponse
 
 from conans.errors import ConanException
-from conans.util.log import logger
+
+logger = logging.getLogger("conans")
 
 
 class ReturnHandlerPlugin(object):

--- a/conans/server/service/common/search.py
+++ b/conans/server/service/common/search.py
@@ -1,5 +1,6 @@
 import os
 import re
+import logging
 from fnmatch import translate
 
 from conans import load
@@ -10,7 +11,8 @@ from conans.model.ref import PackageReference, ConanFileReference
 from conans.paths import CONANINFO
 from conans.search.search import filter_packages, _partial_match
 from conans.util.files import list_folder_subdirs
-from conans.util.log import logger
+
+logger = logging.getLogger("conans")
 
 
 def _get_local_infos_min(server_store, ref, look_in_all_rrevs):

--- a/conans/server/service/v1/upload_download_service.py
+++ b/conans/server/service/v1/upload_download_service.py
@@ -1,10 +1,12 @@
 import os
+import logging
 
 import jwt
 
 from conans.errors import NotFoundException, RequestErrorException
-from conans.util.log import logger
 from conans.util.files import mkdir
+
+logger = logging.getLogger("conans")
 
 
 class FileUploadDownloadService(object):

--- a/conans/tools.py
+++ b/conans/tools.py
@@ -10,6 +10,8 @@
     the currification.
 """
 
+import logging
+
 import requests
 
 from conans.client.output import ConanOutput
@@ -26,10 +28,11 @@ from conans.client.tools.android import *
 from conans.util.env_reader import get_env
 from conans.util.files import _generic_algorithm_sum, load, md5, md5sum, mkdir, relative_dirs, \
     rmdir, save as files_save, save_append, sha1sum, sha256sum, to_file_bytes, touch
-from conans.util.log import logger
 from conans.client.tools.version import Version
 from conans.client.build.cppstd_flags import cppstd_flag_new as cppstd_flag  # pylint: disable=unused-import
 
+
+logger = logging.getLogger("conans")
 
 # This global variables are intended to store the configuration of the running Conan application
 _global_output = None

--- a/conans/util/files.py
+++ b/conans/util/files.py
@@ -8,14 +8,14 @@ import stat
 import sys
 import tarfile
 import tempfile
-
+import logging
 
 from os.path import abspath, join as joinpath, realpath
 from contextlib import contextmanager
 
 import six
 
-from conans.util.log import logger
+logger = logging.getLogger("conans")
 
 
 def walk(top, **kwargs):

--- a/conans/util/locks.py
+++ b/conans/util/locks.py
@@ -1,10 +1,12 @@
 import os
 import time
+import logging
 
 import fasteners
 
 from conans.util.files import load, save
-from conans.util.log import logger
+
+logger = logging.getLogger("conans")
 
 
 class NoLock(object):

--- a/conans/util/log.py
+++ b/conans/util/log.py
@@ -35,9 +35,6 @@ def configure_logger(logging_level=logging.CRITICAL, logging_file=None):
     logger.setLevel(logging_level)
     return logger
 
-
-logger = configure_logger()
-
 # CRITICAL = 50
 # FATAL = CRITICAL
 # ERROR = 40

--- a/conans/util/log.py
+++ b/conans/util/log.py
@@ -33,7 +33,6 @@ def configure_logger(logging_level=logging.CRITICAL, logging_file=None):
         logger.removeHandler(hand)
     logger.addHandler(hdlr)
     logger.setLevel(logging_level)
-    return logger
 
 # CRITICAL = 50
 # FATAL = CRITICAL

--- a/conans/util/runners.py
+++ b/conans/util/runners.py
@@ -2,13 +2,15 @@ import os
 import subprocess
 import sys
 import tempfile
+import logging
 from contextlib import contextmanager
 
 import six
 
 from conans.client.tools.files import load
 from conans.errors import CalledProcessErrorWithStderr
-from conans.util.log import logger
+
+logger = logging.getLogger("conans")
 
 
 if getattr(sys, 'frozen', False) and 'LD_LIBRARY_PATH' in os.environ:

--- a/conans/util/tracer.py
+++ b/conans/util/tracer.py
@@ -2,6 +2,7 @@ import copy
 import json
 import os
 import time
+import logging
 from os.path import isdir
 
 import fasteners
@@ -9,7 +10,8 @@ import fasteners
 from conans.errors import ConanException
 from conans.model.ref import ConanFileReference, PackageReference
 from conans.util.files import md5sum, sha1sum
-from conans.util.log import logger
+
+logger = logging.getLogger("conans")
 
 
 # FIXME: Conan 2.0 the traces should have all the revisions information also.

--- a/conans/util/windows.py
+++ b/conans/util/windows.py
@@ -1,14 +1,17 @@
 import os
 import subprocess
 import tempfile
+import logging
 
 from conans.client.tools.oss import OSInfo
 from conans.errors import ConanException
 from conans.util.env_reader import get_env
 from conans.util.files import decode_text
 from conans.util.files import load, mkdir, rmdir, save
-from conans.util.log import logger
 from conans.util.sha import sha256
+
+
+logger = logging.getLogger("conans")
 
 CONAN_LINK = ".conan_link"
 CONAN_REAL_PATH = "real_path.txt"


### PR DESCRIPTION
Changelog: Fix: Get the Conan logger via `logging.getLogger("conans")` instead of returning from `configure_logger`. `configure_logger` was being called when imports were processed before the logging level was set.
Docs: Omit

Just replacing `from conans.util.log import logger` occurrences with `logger = logging.getLogger("conans")`

- [ ] Refer to the issue that supports this Pull Request.
- [X] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [X] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [X] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 

<sup>**Note:** By default this PR will skip the slower tests and will use a limited set of python versions. Check [here](https://github.com/conan-io/conan/blob/develop/.github/PR_INCREASE_TESTING.md) how to increase the testing level by writing some tags in the current PR body text.</sup>
