### PR TITLE
add new CONAN_BASIC_SETUP function to makefile generator

### DIFF
--- a/conans/client/build/compiler_flags.py
+++ b/conans/client/build/compiler_flags.py
@@ -11,7 +11,7 @@
 """
 
 from conans.client.tools.apple import is_apple_os
-from conans.client.tools.oss import cpu_count
+from conans.client.tools.oss import cpu_count, get_build_os_arch
 from conans.client.tools.win import unix_path
 
 
@@ -32,6 +32,14 @@ def rpath_flags(settings, os_build, lib_paths):
         return ['-Wl,-rpath%s"%s"' % (rpath_separator, x.replace("\\", "/"))
                 for x in lib_paths if x]
     return []
+
+
+def rpath_flags(conanfile, lib_paths):
+    os_build, _ = get_build_os_arch(conanfile)
+    if not hasattr(conanfile, 'settings_build'):
+        os_build = os_build or conanfile.settings.get_safe("os")
+    rpath_sep = "," if is_apple_os(os_build) else "="
+    return ['-Wl,-rpath%s"%s"' % (rpath_sep, path.replace("\\", "/")) for path in lib_paths if path]
 
 
 def architecture_flag(settings):

--- a/conans/client/build/compiler_flags.py
+++ b/conans/client/build/compiler_flags.py
@@ -34,14 +34,6 @@ def rpath_flags(settings, os_build, lib_paths):
     return []
 
 
-def rpath_flags(conanfile, lib_paths):
-    os_build, _ = get_build_os_arch(conanfile)
-    if not hasattr(conanfile, 'settings_build'):
-        os_build = os_build or conanfile.settings.get_safe("os")
-    rpath_sep = "," if is_apple_os(os_build) else "="
-    return ['-Wl,-rpath%s"%s"' % (rpath_sep, path.replace("\\", "/")) for path in lib_paths if path]
-
-
 def architecture_flag(settings):
     """
     returns flags specific to the target architecture and compiler

--- a/conans/client/generators/make.py
+++ b/conans/client/generators/make.py
@@ -25,6 +25,7 @@ class MakeGenerator(Generator):
     def content(self):
 
         content = [
+            "",
             "#-------------------------------------------------------------------#",
             "#             Makefile variables from Conan Dependencies            #",
             "#-------------------------------------------------------------------#",
@@ -51,28 +52,22 @@ class MakeGenerator(Generator):
             CONAN_LDLIBS        += $(addprefix -l,$(CONAN_SYSTEM_LIBS))
             CONAN_LDLIBS        += $(addprefix -l,$(CONAN_LIBS))
 
-            CONAN_SET_SHARED = {{set_shared}}
-            ifeq ($(CONAN_SET_SHARED),True)
-                CONAN_LDFLAGS += $(CONAN_SHARED_LINKER_FLAGS)
-            else
-                CONAN_LDFLAGS += $(CONAN_EXE_LINKER_FLAGS)
-            endif
-
-            # Call this function in your Makefile to have Conan variables added to standard variables
-            # Example:  $(call CONAN_BASIC_SETUP)
+            # Call the following function to have Conan variables added to standard variables
+            # 1 optional parameter : type of target being built : EXE or SHARED
+            # Appends either CONAN_EXELINKFLAGS or CONAN_SHAREDLINKFLAGS to LDFLAGS
+            # Example 1:  $(call CONAN_BASIC_SETUP)
+            # Example 2:  $(call CONAN_BASIC_SETUP, EXE)
+            # Example 3:  $(call CONAN_BASIC_SETUP, SHARED)
 
             CONAN_BASIC_SETUP = \\
                 $(eval CFLAGS   += $(CONAN_CFLAGS)) ; \\
                 $(eval CXXFLAGS += $(CONAN_CXXFLAGS)) ; \\
                 $(eval CPPFLAGS += $(CONAN_CPPFLAGS)) ; \\
                 $(eval LDFLAGS  += $(CONAN_LDFLAGS)) ; \\
+                $(eval LDFLAGS  += $(CONAN_$(1)LINKFLAGS)) ; \\
                 $(eval LDLIBS   += $(CONAN_LDLIBS)) ;
         """)
-        t = Template(additional_content)
-        context = {
-            "set_shared": True if self.conanfile.options.get_safe("shared") else False,
-        }
-        return t.render(context)
+        return additional_content
 
     def create_deps_content(self):
         deps_content = self.create_content_from_deps()

--- a/conans/client/generators/make.py
+++ b/conans/client/generators/make.py
@@ -1,7 +1,6 @@
 import textwrap
 
 from conans.client.build.compiler_flags import rpath_flags
-from conans.client.tools.oss import get_build_os_arch
 from conans.model import Generator
 from conans.paths import BUILD_INFO_MAKE
 

--- a/conans/client/generators/make.py
+++ b/conans/client/generators/make.py
@@ -1,3 +1,5 @@
+import textwrap
+
 from conans.model import Generator
 from conans.paths import BUILD_INFO_MAKE
 
@@ -25,9 +27,30 @@ class MakeGenerator(Generator):
             "",
         ]
 
+        additional_content = textwrap.dedent("""
+            CONAN_CPPFLAGS      += $(addprefix -I,$(CONAN_INCLUDE_DIRS))
+            CONAN_CPPFLAGS      += $(addprefix -D,$(CONAN_DEFINES))
+            CONAN_LDFLAGS       += $(addprefix -L,$(CONAN_LIB_DIRS))
+            CONAN_LDLIBS        += $(addprefix -l,$(CONAN_LIBS))
+            CONAN_LDLIBS        += $(addprefix -l,$(CONAN_SYSTEM_LIBS))
+
+            # Call this function in your Makefile to have Conan variables added to standard variables
+            # Example:  $(call CONAN_TC_SETUP)
+
+            CONAN_BASIC_SETUP =  \
+                $(eval CFLAGS   += $(CONAN_CFLAGS)) ; \
+                $(eval CXXFLAGS += $(CONAN_CXXFLAGS)) ; \
+                $(eval CPPFLAGS += $(CONAN_CPPFLAGS)) ; \
+                $(eval LDFLAGS  += $(CONAN_LDFLAGS)) ; \
+                $(eval LDLIBS   += $(CONAN_LDLIBS)) ;
+        """)
+
         for line_as_list in self.create_deps_content():
             content.append("".join(line_as_list))
 
+        content.append(self.makefile_newline)
+        content.append(additional_content)
+        content.append(self.makefile_newline)
         content.append("#-------------------------------------------------------------------#")
         content.append(self.makefile_newline)
         return self.makefile_newline.join(content)

--- a/conans/client/generators/make.py
+++ b/conans/client/generators/make.py
@@ -1,8 +1,7 @@
 import textwrap
 
-from jinja2 import Template
-
 from conans.client.build.compiler_flags import rpath_flags
+from conans.client.tools.oss import get_build_os_arch
 from conans.model import Generator
 from conans.paths import BUILD_INFO_MAKE
 
@@ -81,7 +80,8 @@ class MakeGenerator(Generator):
         return content
 
     def create_content_from_dep(self, pkg_name, cpp_info):
-        rpath_flags_ = rpath_flags(self._conanfile, cpp_info.lib_paths)
+        os_host = self._conanfile.settings.get_safe("os")
+        rpath_flags_ = rpath_flags(self._conanfile.settings, os_host, cpp_info.lib_paths)
 
         vars_info = [("ROOT", self.assignment_if_absent, [cpp_info.rootpath]),
                      ("SYSROOT", self.assignment_if_absent, [cpp_info.sysroot]),

--- a/conans/test/functional/generators/make_test.py
+++ b/conans/test/functional/generators/make_test.py
@@ -141,18 +141,15 @@ class MakeGeneratorTest(unittest.TestCase):
         if target == "exe":
             client.run("install . danimtb/testing")
             client.run_command("make exe")
-            print(client.out)
             client.run_command("./out/hellowrapper.bin")
             self.assertIn("Hello World Release!", client.out)
         elif target == "shared":
             client.run("install . danimtb/testing -o hellowrapper:shared=True")
             client.run_command("make shared")
-            print(client.out)
             client.run_command("nm -C out/libhellowrapper.so | grep 'hellowrapper()'")
             self.assertIn("hellowrapper()", client.out)
         elif target == "static":
             client.run("install . danimtb/testing -o hellowrapper:shared=False")
             client.run_command("make static")
-            print(client.out)
             client.run_command("nm -C out/libhellowrapper.a | grep 'hellowrapper()'")
             self.assertIn("hellowrapper()", client.out)

--- a/conans/test/functional/generators/make_test.py
+++ b/conans/test/functional/generators/make_test.py
@@ -15,7 +15,7 @@ class MakeGeneratorTest(unittest.TestCase):
 
     @unittest.skipUnless(platform.system() == "Linux", "Requires make")
     @parameterized.expand(["exe", "shared", "static"])
-    # @attr('slow')
+    @attr('slow')
     def complete_creation_reuse_test(self, target):
 
         # Create myhello to serve as a dependency. It must have fPIC.

--- a/conans/test/functional/generators/make_test.py
+++ b/conans/test/functional/generators/make_test.py
@@ -83,11 +83,6 @@ class MakeGeneratorTest(unittest.TestCase):
 
             $(call CONAN_BASIC_SETUP)
 
-            $(info >> CONAN_RPATHFLAGS: $(CONAN_RPATHFLAGS))
-            $(info >> CONAN_CXXFLAGS: $(CONAN_CXXFLAGS))
-            $(info >> CONAN_CPPFLAGS: $(CONAN_CPPFLAGS))
-            $(info >> CONAN_LDFLAGS: $(CONAN_LDFLAGS))
-            $(info >> CONAN_LDLIBS: $(CONAN_LDLIBS))
             #-------------------------------------------------
             #     Make Rules
             #-------------------------------------------------

--- a/conans/test/functional/generators/make_test.py
+++ b/conans/test/functional/generators/make_test.py
@@ -5,15 +5,20 @@ import textwrap
 
 from nose.plugins.attrib import attr
 
-from conans.client.tools import replace_in_file
 from conans.test.utils.tools import TestClient
+from conans.client.tools import replace_in_file
+
+from parameterized.parameterized import parameterized
 
 
 class MakeGeneratorTest(unittest.TestCase):
 
-    @attr('slow')
     @unittest.skipUnless(platform.system() == "Linux", "Requires make")
-    def complete_creation_reuse_test(self):
+    @parameterized.expand(["exe", "shared", "static"])
+    # @attr('slow')
+    def complete_creation_reuse_test(self, target):
+
+        # Create myhello to serve as a dependency. It must have fPIC.
         client = TestClient(path_with_spaces=False)
         client.run("new myhello/1.0.0 --sources")
         conanfile_path = os.path.join(client.current_folder, "conanfile.py")
@@ -22,6 +27,8 @@ class MakeGeneratorTest(unittest.TestCase):
         replace_in_file(conanfile_path, "{\"shared\": False}", "{\"shared\": False, \"fPIC\": True}",
                         output=client.out)
         client.run("create . danimtb/testing")
+
+        # Prepare the actual consumer package
         hellowrapper_include = textwrap.dedent("""
             #pragma once
 
@@ -38,101 +45,7 @@ class MakeGeneratorTest(unittest.TestCase):
             }
             """)
 
-        makefile = textwrap.dedent("""
-            include conanbuildinfo.mak
-
-            #----------------------------------------
-            #     Make variables for a sample App
-            #----------------------------------------
-
-            INCLUDE_DIRS        = ./include
-            CXX_SRCS            = src/hellowrapper.cpp
-            CXX_OBJ_FILES       = hellowrapper.o
-            STATIC_LIB_FILENAME = libhellowrapper.a
-            SHARED_LIB_FILENAME = libhellowrapper.so
-            CXXFLAGS           += -fPIC
-
-            #----------------------------------------
-            #     Prepare flags from variables
-            #----------------------------------------
-
-            CPPFLAGS            += $(addprefix -I, $(INCLUDE_DIRS))
-            SHAREDLINKFLAGS     += $(CONAN_SHAREDLINKFLAGS)
-
-            #----------------------------------------
-            #     Append CONAN_ variables to standards
-            #----------------------------------------
-
-            $(call CONAN_TC_SETUP)
-
-            #----------------------------------------
-            #     Make Commands
-            #----------------------------------------
-
-            COMPILE_CXX_COMMAND         ?= \
-                g++ -c $(CPPFLAGS) $(CXXFLAGS) $< -o $@
-
-            CREATE_SHARED_LIB_COMMAND   ?= \
-                g++ -shared $(CXX_OBJ_FILES) \
-                $(CXXFLAGS) $(LDFLAGS) $(LDLIBS) $(SHAREDLINKFLAGS) \
-                -o $(SHARED_LIB_FILENAME)
-
-            CREATE_STATIC_LIB_COMMAND   ?= \
-                ar rcs $(STATIC_LIB_FILENAME) $(CXX_OBJ_FILES)
-
-
-            #----------------------------------------
-            #     Make Rules
-            #----------------------------------------
-
-            .PHONY                  :   static shared
-            static                  :   $(STATIC_LIB_FILENAME)
-            shared                  :   $(SHARED_LIB_FILENAME)
-
-            $(SHARED_LIB_FILENAME)  :   $(CXX_OBJ_FILES)
-                $(CREATE_SHARED_LIB_COMMAND)
-
-            $(STATIC_LIB_FILENAME)  :   $(CXX_OBJ_FILES)
-                $(CREATE_STATIC_LIB_COMMAND)
-
-            $(CXX_OBJ_FILES)        :   $(CXX_SRCS)
-                $(COMPILE_CXX_COMMAND)
-            """)
-
-        conanfile = textwrap.dedent("""
-            from conans import ConanFile
-
-            class HelloWrapper(ConanFile):
-                name = "hellowrapper"
-                version = "1.0"
-                settings = "os", "compiler", "build_type", "arch"
-                requires = "myhello/1.0.0@danimtb/testing"
-                generators = "make"
-                exports_sources = "include/hellowrapper.h", "src/hellowrapper.cpp", "Makefile"
-                options = {"shared": [True, False]}
-                default_options = {"shared": False}
-
-                def build(self):
-                    make_command = "make shared" if self.options.shared else "make static"
-                    self.run(make_command)
-
-                def package(self):
-                    self.copy("*.h", dst="include", src="include")
-                    self.copy("*.so", dst="lib", keep_path=False)
-                    self.copy("*.a", dst="lib", keep_path=False)
-
-                def package_info(self):
-                    self.cpp_info.libs = ["hellowrapper"]
-            """)
-
-        client.save({"include/hellowrapper.h": hellowrapper_include,
-                     "src/hellowrapper.cpp": hellowrapper_impl,
-                     "Makefile": makefile,
-                     "conanfile.py": conanfile}, clean_first=True)
-        client.run("create . danimtb/testing")
-        # Test also shared
-        client.run("create . danimtb/testing -o hellowrapper:shared=True")
-
+        # only used for the executable test case
         main = textwrap.dedent("""
             #include "hellowrapper.h"
             int main()
@@ -145,77 +58,106 @@ class MakeGeneratorTest(unittest.TestCase):
         makefile = textwrap.dedent("""
             include conanbuildinfo.mak
 
-            #----------------------------------------
+            #-------------------------------------------------
             #     Make variables for a sample App
-            #----------------------------------------
+            #-------------------------------------------------
 
-            CXX_SRCS        = src/main.cpp
-            CXX_OBJ_FILES   = main.o
-            EXE_FILENAME    = main
-            CXXFLAGS       += -fPIC
-            EXELINKFLAGS   += -fPIE
+            OUT_DIR             ?= out
+            SRC_DIR             ?= src
+            INCLUDE_DIR         ?= include
 
-            #----------------------------------------
-            #     Prepare flags from variables
-            #----------------------------------------
+            PROJECT_NAME        = hellowrapper
+            EXE_FILENAME        = $(PROJECT_NAME).bin
+            STATIC_LIB_FILENAME = lib$(PROJECT_NAME).a
+            SHARED_LIB_FILENAME = lib$(PROJECT_NAME).so
 
-            EXELINKFLAGS        += $(CONAN_EXELINKFLAGS)
+            SRCS                += $(wildcard $(SRC_DIR)/*.cpp)
+            OBJS                += $(patsubst $(SRC_DIR)/%.cpp,$(OUT_DIR)/%.o,$(SRCS))
+            CPPFLAGS            += $(addprefix -I,$(INCLUDE_DIR))
+            CXXFLAGS            += -fPIC
+            LDFLAGS             += -fPIC
 
-            #----------------------------------------
+            #-------------------------------------------------
             #     Append CONAN_ variables to standards
-            #----------------------------------------
+            #-------------------------------------------------
 
-            $(call CONAN_TC_SETUP)
+            $(call CONAN_BASIC_SETUP)
 
-
-            #----------------------------------------
-            #     Make Commands
-            #----------------------------------------
-
-            COMPILE_CXX_COMMAND         ?= \
-                g++ -c $(CPPFLAGS) $(CXXFLAGS) $< -o $@
-
-            CREATE_EXE_COMMAND          ?= \
-                g++ $(CXX_OBJ_FILES) \
-                $(CXXFLAGS) $(LDFLAGS) $(LDLIBS) $(EXELINKFLAGS) \
-                -o $(EXE_FILENAME)
-
-
-            #----------------------------------------
+            $(info >> CONAN_RPATHFLAGS: $(CONAN_RPATHFLAGS))
+            $(info >> CONAN_CXXFLAGS: $(CONAN_CXXFLAGS))
+            $(info >> CONAN_CPPFLAGS: $(CONAN_CPPFLAGS))
+            $(info >> CONAN_LDFLAGS: $(CONAN_LDFLAGS))
+            $(info >> CONAN_LDLIBS: $(CONAN_LDLIBS))
+            #-------------------------------------------------
             #     Make Rules
-            #----------------------------------------
+            #-------------------------------------------------
 
-            .PHONY                  :   exe
-            exe                     :   $(EXE_FILENAME)
+            .PHONY               : exe static shared
 
-            $(EXE_FILENAME)         :   $(CXX_OBJ_FILES)
-                $(CREATE_EXE_COMMAND)
+            exe                  : $(OBJS)
+            	$(CXX) $(OBJS) $(LDFLAGS) $(LDLIBS) -o $(OUT_DIR)/$(EXE_FILENAME)
 
-            $(CXX_OBJ_FILES)        :   $(CXX_SRCS)
-                $(COMPILE_CXX_COMMAND)
+            static               : $(OBJS)
+            	$(AR) $(ARFLAGS) $(OUT_DIR)/$(STATIC_LIB_FILENAME) $(OBJS)
+
+            shared               : $(OBJS)
+            	$(CXX) -shared $(OBJS) $(LDFLAGS) $(LDLIBS) -o $(OUT_DIR)/$(SHARED_LIB_FILENAME)
+
+            $(OUT_DIR)/%.o       : $(SRC_DIR)/%.cpp $(OUT_DIR)
+            	$(CXX) $(CXXFLAGS) $(CPPFLAGS) -c $< -o $@
+
+            $(OUT_DIR):
+            	-mkdir $@
             """)
 
-        conanfile_txt = textwrap.dedent("""
-            [requires]
-            hellowrapper/1.0@danimtb/testing
+        if target == "exe":
+            options = ''
+            default_options = ''
+        else:
+            options = 'options = {"shared": [True, False]}'
+            default_options = 'default_options = {"shared": False}'
 
-            [generators]
-            make
-            """)
-        
-        client.save({"src/main.cpp": main,
-                     "Makefile": makefile,
-                     "conanfile.txt": conanfile_txt},
-                    clean_first=True)
+        conanfile = textwrap.dedent("""
+            from conans import ConanFile
 
-        client.run("install .")
-        client.run_command("make exe")
-        client.run_command("./main")
-        self.assertIn("Hello World Release!", client.out)
+            class HelloWrapper(ConanFile):
+                name = "hellowrapper"
+                version = "1.0"
+                settings = "os", "compiler", "build_type", "arch"
+                requires = "myhello/1.0.0@danimtb/testing"
+                generators = "make"
+                exports_sources = "include/hellowrapper.h", "src/hellowrapper.cpp", "Makefile"
+                {options}
+                {default_options}
 
-        # Test it also builds with shared lib
-        client.run("install . -o hellowrapper:shared=True")
-        client.run_command("rm main main.o")
-        client.run_command("make exe")
-        client.run_command("ldd main")
-        self.assertIn("libhellowrapper.so", client.out)
+            """.format(options=options, default_options=default_options))
+
+        files_to_save = {
+            "include/hellowrapper.h": hellowrapper_include,
+            "src/hellowrapper.cpp": hellowrapper_impl,
+            "Makefile": makefile,
+            "conanfile.py": conanfile
+        }
+        if target == "exe":
+            files_to_save["src/main.cpp"] = main
+
+        client.save(files_to_save, clean_first=True)
+
+        if target == "exe":
+            client.run("install . danimtb/testing")
+            client.run_command("make exe")
+            print(client.out)
+            client.run_command("./out/hellowrapper.bin")
+            self.assertIn("Hello World Release!", client.out)
+        elif target == "shared":
+            client.run("install . danimtb/testing -o hellowrapper:shared=True")
+            client.run_command("make shared")
+            print(client.out)
+            client.run_command("nm -C out/libhellowrapper.so | grep 'hellowrapper()'")
+            self.assertIn("hellowrapper()", client.out)
+        elif target == "static":
+            client.run("install . danimtb/testing -o hellowrapper:shared=False")
+            client.run_command("make static")
+            print(client.out)
+            client.run_command("nm -C out/libhellowrapper.a | grep 'hellowrapper()'")
+            self.assertIn("hellowrapper()", client.out)

--- a/conans/test/unittests/client/generators/make_test.py
+++ b/conans/test/unittests/client/generators/make_test.py
@@ -1,8 +1,7 @@
+import re
 import os
 import unittest
 import textwrap
-
-from jinja2 import Template
 
 from conans.client.generators import MakeGenerator
 from conans.model.build_info import CppInfo
@@ -43,11 +42,626 @@ class _MockSettings(object):
         return {}
 
 
+EXPECTED_OUT_1 = textwrap.dedent("""
+#-------------------------------------------------------------------#
+#             Makefile variables from Conan Dependencies            #
+#-------------------------------------------------------------------#
+
+CONAN_ROOT_MYPKG1 ?=  \\
+_/path with spaces
+
+CONAN_SYSROOT_MYPKG1 ?=  \\
+
+
+CONAN_RPATHFLAGS_MYPKG1 +=  \\
+-Wl,-rpath="_/path with spaces/lib1"
+
+CONAN_INCLUDE_DIRS_MYPKG1 +=  \\
+_/path with spaces/include1
+
+CONAN_LIB_DIRS_MYPKG1 +=  \\
+_/path with spaces/lib1
+
+CONAN_BIN_DIRS_MYPKG1 +=  \\
+_/path with spaces/bin1
+
+CONAN_BUILD_DIRS_MYPKG1 +=  \\
+_/path with spaces/
+
+CONAN_RES_DIRS_MYPKG1 +=  \\
+
+
+CONAN_LIBS_MYPKG1 +=  \\
+libfoo
+
+CONAN_SYSTEM_LIBS_MYPKG1 +=  \\
+system_lib1
+
+CONAN_DEFINES_MYPKG1 +=  \\
+MYDEFINE1
+
+CONAN_CFLAGS_MYPKG1 +=  \\
+-fgimple
+
+CONAN_CXXFLAGS_MYPKG1 +=  \\
+-fdollars-in-identifiers
+
+CONAN_SHAREDLINKFLAGS_MYPKG1 +=  \\
+-framework Cocoa
+
+CONAN_EXELINKFLAGS_MYPKG1 +=  \\
+-framework QuartzCore
+
+CONAN_FRAMEWORKS_MYPKG1 +=  \\
+AudioUnit
+
+CONAN_FRAMEWORK_PATHS_MYPKG1 +=  \\
+_/path with spaces/SystemFrameworks
+
+CONAN_ROOT_MYPKG2 ?=  \\
+_/path with spaces
+
+CONAN_SYSROOT_MYPKG2 ?=  \\
+
+
+CONAN_RPATHFLAGS_MYPKG2 +=  \\
+-Wl,-rpath="_/path with spaces/lib2"
+
+CONAN_INCLUDE_DIRS_MYPKG2 +=  \\
+_/path with spaces/include2
+
+CONAN_LIB_DIRS_MYPKG2 +=  \\
+_/path with spaces/lib2
+
+CONAN_BIN_DIRS_MYPKG2 +=  \\
+_/path with spaces/bin2
+
+CONAN_BUILD_DIRS_MYPKG2 +=  \\
+_/path with spaces/
+
+CONAN_RES_DIRS_MYPKG2 +=  \\
+
+
+CONAN_LIBS_MYPKG2 +=  \\
+libbar
+
+CONAN_SYSTEM_LIBS_MYPKG2 +=  \\
+system_lib2
+
+CONAN_DEFINES_MYPKG2 +=  \\
+MYDEFINE2
+
+CONAN_CFLAGS_MYPKG2 +=  \\
+-fno-asm
+
+CONAN_CXXFLAGS_MYPKG2 +=  \\
+-pthread
+
+CONAN_SHAREDLINKFLAGS_MYPKG2 +=  \\
+-framework AudioFoundation
+
+CONAN_EXELINKFLAGS_MYPKG2 +=  \\
+-framework VideoToolbox
+
+CONAN_FRAMEWORKS_MYPKG2 +=  \\
+
+
+CONAN_FRAMEWORK_PATHS_MYPKG2 +=  \\
+
+
+CONAN_ROOTPATH +=  \\
+$(CONAN_ROOTPATH_MYPKG1) \\
+$(CONAN_ROOTPATH_MYPKG2)
+
+CONAN_SYSROOT +=  \\
+$(CONAN_SYSROOT_MYPKG1) \\
+$(CONAN_SYSROOT_MYPKG2)
+
+CONAN_RPATHFLAGS +=  \\
+$(CONAN_RPATHFLAGS_MYPKG1) \\
+$(CONAN_RPATHFLAGS_MYPKG2)
+
+CONAN_INCLUDE_DIRS +=  \\
+$(CONAN_INCLUDE_DIRS_MYPKG1) \\
+$(CONAN_INCLUDE_DIRS_MYPKG2)
+
+CONAN_LIB_DIRS +=  \\
+$(CONAN_LIB_DIRS_MYPKG1) \\
+$(CONAN_LIB_DIRS_MYPKG2)
+
+CONAN_BIN_DIRS +=  \\
+$(CONAN_BIN_DIRS_MYPKG1) \\
+$(CONAN_BIN_DIRS_MYPKG2)
+
+CONAN_BUILD_DIRS +=  \\
+$(CONAN_BUILD_DIRS_MYPKG1) \\
+$(CONAN_BUILD_DIRS_MYPKG2)
+
+CONAN_RES_DIRS +=  \\
+$(CONAN_RES_DIRS_MYPKG1) \\
+$(CONAN_RES_DIRS_MYPKG2)
+
+CONAN_LIBS +=  \\
+$(CONAN_LIBS_MYPKG1) \\
+$(CONAN_LIBS_MYPKG2)
+
+CONAN_DEFINES +=  \\
+$(CONAN_DEFINES_MYPKG1) \\
+$(CONAN_DEFINES_MYPKG2)
+
+CONAN_CFLAGS +=  \\
+$(CONAN_CFLAGS_MYPKG1) \\
+$(CONAN_CFLAGS_MYPKG2)
+
+CONAN_CXXFLAGS +=  \\
+$(CONAN_CXXFLAGS_MYPKG1) \\
+$(CONAN_CXXFLAGS_MYPKG2)
+
+CONAN_SHAREDLINKFLAGS +=  \\
+$(CONAN_SHAREDLINKFLAGS_MYPKG1) \\
+$(CONAN_SHAREDLINKFLAGS_MYPKG2)
+
+CONAN_EXELINKFLAGS +=  \\
+$(CONAN_EXELINKFLAGS_MYPKG1) \\
+$(CONAN_EXELINKFLAGS_MYPKG2)
+
+CONAN_FRAMEWORKS +=  \\
+$(CONAN_FRAMEWORKS_MYPKG1) \\
+$(CONAN_FRAMEWORKS_MYPKG2)
+
+CONAN_FRAMEWORK_PATHS +=  \\
+$(CONAN_FRAMEWORK_PATHS_MYPKG1) \\
+$(CONAN_FRAMEWORK_PATHS_MYPKG2)
+
+CONAN_SYSTEM_LIBS +=  \\
+$(CONAN_SYSTEM_LIBS_MYPKG1) \\
+$(CONAN_SYSTEM_LIBS_MYPKG2)
+
+
+CONAN_CPPFLAGS      += $(addprefix -I,$(CONAN_INCLUDE_DIRS))
+CONAN_CPPFLAGS      += $(addprefix -D,$(CONAN_DEFINES))
+CONAN_LDFLAGS       += $(addprefix -L,$(CONAN_LIB_DIRS))
+CONAN_LDFLAGS       += $(CONAN_RPATHFLAGS)
+CONAN_LDLIBS        += $(addprefix -l,$(CONAN_SYSTEM_LIBS))
+CONAN_LDLIBS        += $(addprefix -l,$(CONAN_LIBS))
+
+# Call the following function to have Conan variables added to standard variables
+# 1 optional parameter : type of target being built : EXE or SHARED
+# Appends either CONAN_EXELINKFLAGS or CONAN_SHAREDLINKFLAGS to LDFLAGS
+# Example 1:  $(call CONAN_BASIC_SETUP)
+# Example 2:  $(call CONAN_BASIC_SETUP, EXE)
+# Example 2:  $(call CONAN_BASIC_SETUP, SHARED)
+
+CONAN_BASIC_SETUP = \\
+    $(eval CFLAGS   += $(CONAN_CFLAGS)) ; \\
+    $(eval CXXFLAGS += $(CONAN_CXXFLAGS)) ; \\
+    $(eval CPPFLAGS += $(CONAN_CPPFLAGS)) ; \\
+    $(eval LDFLAGS  += $(CONAN_LDFLAGS)) ; \\
+    $(eval LDFLAGS  += $(CONAN_$(1)LINKFLAGS)) ; \\
+    $(eval LDLIBS   += $(CONAN_LDLIBS)) ;
+
+
+
+#-------------------------------------------------------------------#
+
+""")
+
+EXPECTED_OUT_2 = textwrap.dedent("""
+#-------------------------------------------------------------------#
+#             Makefile variables from Conan Dependencies            #
+#-------------------------------------------------------------------#
+
+CONAN_ROOT_MYPKG1 ?=  \\
+_/path with spaces
+
+CONAN_SYSROOT_MYPKG1 ?=  \\
+
+
+CONAN_RPATHFLAGS_MYPKG1 +=  \\
+-Wl,-rpath="_/path with spaces/lib1"
+
+CONAN_INCLUDE_DIRS_MYPKG1 +=  \\
+_/path with spaces/include1
+
+CONAN_LIB_DIRS_MYPKG1 +=  \\
+_/path with spaces/lib1
+
+CONAN_BIN_DIRS_MYPKG1 +=  \\
+_/path with spaces/bin1
+
+CONAN_BUILD_DIRS_MYPKG1 +=  \\
+_/path with spaces/
+
+CONAN_RES_DIRS_MYPKG1 +=  \\
+
+
+CONAN_LIBS_MYPKG1 +=  \\
+libfoo
+
+CONAN_SYSTEM_LIBS_MYPKG1 +=  \\
+system_lib1
+
+CONAN_DEFINES_MYPKG1 +=  \\
+MYDEFINE1
+
+CONAN_CFLAGS_MYPKG1 +=  \\
+-fgimple
+
+CONAN_CXXFLAGS_MYPKG1 +=  \\
+-fdollars-in-identifiers
+
+CONAN_SHAREDLINKFLAGS_MYPKG1 +=  \\
+-framework Cocoa
+
+CONAN_EXELINKFLAGS_MYPKG1 +=  \\
+-framework QuartzCore
+
+CONAN_FRAMEWORKS_MYPKG1 +=  \\
+AudioUnit
+
+CONAN_FRAMEWORK_PATHS_MYPKG1 +=  \\
+_/path with spaces/SystemFrameworks
+
+CONAN_ROOT_MYPKG2 ?=  \\
+_/path with spaces
+
+CONAN_SYSROOT_MYPKG2 ?=  \\
+
+
+CONAN_RPATHFLAGS_MYPKG2 +=  \\
+-Wl,-rpath="_/path with spaces/lib2"
+
+CONAN_INCLUDE_DIRS_MYPKG2 +=  \\
+_/path with spaces/include2
+
+CONAN_LIB_DIRS_MYPKG2 +=  \\
+_/path with spaces/lib2
+
+CONAN_BIN_DIRS_MYPKG2 +=  \\
+_/path with spaces/bin2
+
+CONAN_BUILD_DIRS_MYPKG2 +=  \\
+_/path with spaces/
+
+CONAN_RES_DIRS_MYPKG2 +=  \\
+
+
+CONAN_LIBS_MYPKG2 +=  \\
+libbar
+
+CONAN_SYSTEM_LIBS_MYPKG2 +=  \\
+system_lib2
+
+CONAN_DEFINES_MYPKG2 +=  \\
+MYDEFINE2
+
+CONAN_CFLAGS_MYPKG2 +=  \\
+-fno-asm
+
+CONAN_CXXFLAGS_MYPKG2 +=  \\
+-pthread
+
+CONAN_SHAREDLINKFLAGS_MYPKG2 +=  \\
+-framework AudioFoundation
+
+CONAN_EXELINKFLAGS_MYPKG2 +=  \\
+-framework VideoToolbox
+
+CONAN_FRAMEWORKS_MYPKG2 +=  \\
+
+
+CONAN_FRAMEWORK_PATHS_MYPKG2 +=  \\
+
+
+CONAN_ROOTPATH +=  \\
+$(CONAN_ROOTPATH_MYPKG1) \\
+$(CONAN_ROOTPATH_MYPKG2)
+
+CONAN_SYSROOT +=  \\
+$(CONAN_SYSROOT_MYPKG1) \\
+$(CONAN_SYSROOT_MYPKG2)
+
+CONAN_RPATHFLAGS +=  \\
+$(CONAN_RPATHFLAGS_MYPKG1) \\
+$(CONAN_RPATHFLAGS_MYPKG2)
+
+CONAN_INCLUDE_DIRS +=  \\
+$(CONAN_INCLUDE_DIRS_MYPKG1) \\
+$(CONAN_INCLUDE_DIRS_MYPKG2)
+
+CONAN_LIB_DIRS +=  \\
+$(CONAN_LIB_DIRS_MYPKG1) \\
+$(CONAN_LIB_DIRS_MYPKG2)
+
+CONAN_BIN_DIRS +=  \\
+$(CONAN_BIN_DIRS_MYPKG1) \\
+$(CONAN_BIN_DIRS_MYPKG2)
+
+CONAN_BUILD_DIRS +=  \\
+$(CONAN_BUILD_DIRS_MYPKG1) \\
+$(CONAN_BUILD_DIRS_MYPKG2)
+
+CONAN_RES_DIRS +=  \\
+$(CONAN_RES_DIRS_MYPKG1) \\
+$(CONAN_RES_DIRS_MYPKG2)
+
+CONAN_LIBS +=  \\
+$(CONAN_LIBS_MYPKG1) \\
+$(CONAN_LIBS_MYPKG2)
+
+CONAN_DEFINES +=  \\
+$(CONAN_DEFINES_MYPKG1) \\
+$(CONAN_DEFINES_MYPKG2)
+
+CONAN_CFLAGS +=  \\
+$(CONAN_CFLAGS_MYPKG1) \\
+$(CONAN_CFLAGS_MYPKG2)
+
+CONAN_CXXFLAGS +=  \\
+$(CONAN_CXXFLAGS_MYPKG1) \\
+$(CONAN_CXXFLAGS_MYPKG2)
+
+CONAN_SHAREDLINKFLAGS +=  \\
+$(CONAN_SHAREDLINKFLAGS_MYPKG1) \\
+$(CONAN_SHAREDLINKFLAGS_MYPKG2)
+
+CONAN_EXELINKFLAGS +=  \\
+$(CONAN_EXELINKFLAGS_MYPKG1) \\
+$(CONAN_EXELINKFLAGS_MYPKG2)
+
+CONAN_FRAMEWORKS +=  \\
+$(CONAN_FRAMEWORKS_MYPKG1) \\
+$(CONAN_FRAMEWORKS_MYPKG2)
+
+CONAN_FRAMEWORK_PATHS +=  \\
+$(CONAN_FRAMEWORK_PATHS_MYPKG1) \\
+$(CONAN_FRAMEWORK_PATHS_MYPKG2)
+
+CONAN_SYSTEM_LIBS +=  \\
+$(CONAN_SYSTEM_LIBS_MYPKG1) \\
+$(CONAN_SYSTEM_LIBS_MYPKG2)
+
+
+CONAN_CPPFLAGS      += $(addprefix -I,$(CONAN_INCLUDE_DIRS))
+CONAN_CPPFLAGS      += $(addprefix -D,$(CONAN_DEFINES))
+CONAN_LDFLAGS       += $(addprefix -L,$(CONAN_LIB_DIRS))
+CONAN_LDFLAGS       += $(CONAN_RPATHFLAGS)
+CONAN_LDLIBS        += $(addprefix -l,$(CONAN_SYSTEM_LIBS))
+CONAN_LDLIBS        += $(addprefix -l,$(CONAN_LIBS))
+
+# Call the following function to have Conan variables added to standard variables
+# 1 optional parameter : type of target being built : EXE or SHARED
+# Appends either CONAN_EXELINKFLAGS or CONAN_SHAREDINKFLAGS to LDFLAGS
+# Example 1:  $(call CONAN_BASIC_SETUP)
+# Example 2:  $(call CONAN_BASIC_SETUP, EXE)
+# Example 2:  $(call CONAN_BASIC_SETUP, SHARED)
+
+CONAN_BASIC_SETUP = \\
+    $(eval CFLAGS   += $(CONAN_CFLAGS)) ; \\
+    $(eval CXXFLAGS += $(CONAN_CXXFLAGS)) ; \\
+    $(eval CPPFLAGS += $(CONAN_CPPFLAGS)) ; \\
+    $(eval LDFLAGS  += $(CONAN_LDFLAGS)) ; \\
+    $(eval LDFLAGS  += $(CONAN_$(1)LINKFLAGS)) ; \\
+    $(eval LDLIBS   += $(CONAN_LDLIBS)) ;
+
+
+
+#-------------------------------------------------------------------#
+
+""")
+
+EXPECTED_OUT_3 = textwrap.dedent("""
+#-------------------------------------------------------------------#
+#             Makefile variables from Conan Dependencies            #
+#-------------------------------------------------------------------#
+
+CONAN_ROOT_MYPKG1 ?=  \\
+_/path with spaces
+
+CONAN_SYSROOT_MYPKG1 ?=  \\
+
+
+CONAN_RPATHFLAGS_MYPKG1 +=  \\
+-Wl,-rpath,"_/path with spaces/lib1"
+
+CONAN_INCLUDE_DIRS_MYPKG1 +=  \\
+_/path with spaces/include1
+
+CONAN_LIB_DIRS_MYPKG1 +=  \\
+_/path with spaces/lib1
+
+CONAN_BIN_DIRS_MYPKG1 +=  \\
+_/path with spaces/bin1
+
+CONAN_BUILD_DIRS_MYPKG1 +=  \\
+_/path with spaces/
+
+CONAN_RES_DIRS_MYPKG1 +=  \\
+
+
+CONAN_LIBS_MYPKG1 +=  \\
+libfoo
+
+CONAN_SYSTEM_LIBS_MYPKG1 +=  \\
+system_lib1
+
+CONAN_DEFINES_MYPKG1 +=  \\
+MYDEFINE1
+
+CONAN_CFLAGS_MYPKG1 +=  \\
+-fgimple
+
+CONAN_CXXFLAGS_MYPKG1 +=  \\
+-fdollars-in-identifiers
+
+CONAN_SHAREDLINKFLAGS_MYPKG1 +=  \\
+-framework Cocoa
+
+CONAN_EXELINKFLAGS_MYPKG1 +=  \\
+-framework QuartzCore
+
+CONAN_FRAMEWORKS_MYPKG1 +=  \\
+AudioUnit
+
+CONAN_FRAMEWORK_PATHS_MYPKG1 +=  \\
+_/path with spaces/SystemFrameworks
+
+CONAN_ROOT_MYPKG2 ?=  \\
+_/path with spaces
+
+CONAN_SYSROOT_MYPKG2 ?=  \\
+
+
+CONAN_RPATHFLAGS_MYPKG2 +=  \\
+-Wl,-rpath,"_/path with spaces/lib2"
+
+CONAN_INCLUDE_DIRS_MYPKG2 +=  \\
+_/path with spaces/include2
+
+CONAN_LIB_DIRS_MYPKG2 +=  \\
+_/path with spaces/lib2
+
+CONAN_BIN_DIRS_MYPKG2 +=  \\
+_/path with spaces/bin2
+
+CONAN_BUILD_DIRS_MYPKG2 +=  \\
+_/path with spaces/
+
+CONAN_RES_DIRS_MYPKG2 +=  \\
+
+
+CONAN_LIBS_MYPKG2 +=  \\
+libbar
+
+CONAN_SYSTEM_LIBS_MYPKG2 +=  \\
+system_lib2
+
+CONAN_DEFINES_MYPKG2 +=  \\
+MYDEFINE2
+
+CONAN_CFLAGS_MYPKG2 +=  \\
+-fno-asm
+
+CONAN_CXXFLAGS_MYPKG2 +=  \\
+-pthread
+
+CONAN_SHAREDLINKFLAGS_MYPKG2 +=  \\
+-framework AudioFoundation
+
+CONAN_EXELINKFLAGS_MYPKG2 +=  \\
+-framework VideoToolbox
+
+CONAN_FRAMEWORKS_MYPKG2 +=  \\
+
+
+CONAN_FRAMEWORK_PATHS_MYPKG2 +=  \\
+
+
+CONAN_ROOTPATH +=  \\
+$(CONAN_ROOTPATH_MYPKG1) \\
+$(CONAN_ROOTPATH_MYPKG2)
+
+CONAN_SYSROOT +=  \\
+$(CONAN_SYSROOT_MYPKG1) \\
+$(CONAN_SYSROOT_MYPKG2)
+
+CONAN_RPATHFLAGS +=  \\
+$(CONAN_RPATHFLAGS_MYPKG1) \\
+$(CONAN_RPATHFLAGS_MYPKG2)
+
+CONAN_INCLUDE_DIRS +=  \\
+$(CONAN_INCLUDE_DIRS_MYPKG1) \\
+$(CONAN_INCLUDE_DIRS_MYPKG2)
+
+CONAN_LIB_DIRS +=  \\
+$(CONAN_LIB_DIRS_MYPKG1) \\
+$(CONAN_LIB_DIRS_MYPKG2)
+
+CONAN_BIN_DIRS +=  \\
+$(CONAN_BIN_DIRS_MYPKG1) \\
+$(CONAN_BIN_DIRS_MYPKG2)
+
+CONAN_BUILD_DIRS +=  \\
+$(CONAN_BUILD_DIRS_MYPKG1) \\
+$(CONAN_BUILD_DIRS_MYPKG2)
+
+CONAN_RES_DIRS +=  \\
+$(CONAN_RES_DIRS_MYPKG1) \\
+$(CONAN_RES_DIRS_MYPKG2)
+
+CONAN_LIBS +=  \\
+$(CONAN_LIBS_MYPKG1) \\
+$(CONAN_LIBS_MYPKG2)
+
+CONAN_DEFINES +=  \\
+$(CONAN_DEFINES_MYPKG1) \\
+$(CONAN_DEFINES_MYPKG2)
+
+CONAN_CFLAGS +=  \\
+$(CONAN_CFLAGS_MYPKG1) \\
+$(CONAN_CFLAGS_MYPKG2)
+
+CONAN_CXXFLAGS +=  \\
+$(CONAN_CXXFLAGS_MYPKG1) \\
+$(CONAN_CXXFLAGS_MYPKG2)
+
+CONAN_SHAREDLINKFLAGS +=  \\
+$(CONAN_SHAREDLINKFLAGS_MYPKG1) \\
+$(CONAN_SHAREDLINKFLAGS_MYPKG2)
+
+CONAN_EXELINKFLAGS +=  \\
+$(CONAN_EXELINKFLAGS_MYPKG1) \\
+$(CONAN_EXELINKFLAGS_MYPKG2)
+
+CONAN_FRAMEWORKS +=  \\
+$(CONAN_FRAMEWORKS_MYPKG1) \\
+$(CONAN_FRAMEWORKS_MYPKG2)
+
+CONAN_FRAMEWORK_PATHS +=  \\
+$(CONAN_FRAMEWORK_PATHS_MYPKG1) \\
+$(CONAN_FRAMEWORK_PATHS_MYPKG2)
+
+CONAN_SYSTEM_LIBS +=  \\
+$(CONAN_SYSTEM_LIBS_MYPKG1) \\
+$(CONAN_SYSTEM_LIBS_MYPKG2)
+
+
+CONAN_CPPFLAGS      += $(addprefix -I,$(CONAN_INCLUDE_DIRS))
+CONAN_CPPFLAGS      += $(addprefix -D,$(CONAN_DEFINES))
+CONAN_LDFLAGS       += $(addprefix -L,$(CONAN_LIB_DIRS))
+CONAN_LDFLAGS       += $(CONAN_RPATHFLAGS)
+CONAN_LDLIBS        += $(addprefix -l,$(CONAN_SYSTEM_LIBS))
+CONAN_LDLIBS        += $(addprefix -l,$(CONAN_LIBS))
+
+# Call the following function to have Conan variables added to standard variables
+# 1 optional parameter : type of target being built : EXE or SHARED
+# Appends either CONAN_EXELINKFLAGS or CONAN_SHAREDLINKFLAGS to LDFLAGS
+# Example 1:  $(call CONAN_BASIC_SETUP)
+# Example 2:  $(call CONAN_BASIC_SETUP, EXE)
+# Example 2:  $(call CONAN_BASIC_SETUP, SHARED)
+
+CONAN_BASIC_SETUP = \\
+    $(eval CFLAGS   += $(CONAN_CFLAGS)) ; \\
+    $(eval CXXFLAGS += $(CONAN_CXXFLAGS)) ; \\
+    $(eval CPPFLAGS += $(CONAN_CPPFLAGS)) ; \\
+    $(eval LDFLAGS  += $(CONAN_LDFLAGS)) ; \\
+    $(eval LDFLAGS  += $(CONAN_$(1)LINKFLAGS)) ; \\
+    $(eval LDLIBS   += $(CONAN_LDLIBS)) ;
+
+
+
+#-------------------------------------------------------------------#
+
+""")
+
+
 class MakeGeneratorTest(unittest.TestCase):
-    @parameterized.expand([("gcc", "Linux", False),
-                           ("gcc", "Linux", True),
-                           ("gcc", "Macos", False)])
-    def variables_setup_test(self, compiler_, os_, shared_):
+    @parameterized.expand([
+        ("gcc", "Linux", False, EXPECTED_OUT_1),
+        ("gcc", "Linux", True, EXPECTED_OUT_2),
+        ("gcc", "Macos", False, EXPECTED_OUT_3),
+    ])
+    def variables_setup_test(self, compiler_, os_, shared_, expected):
         tmp_folder1 = temp_folder()
         tmp_folder2 = temp_folder()
         save(os.path.join(tmp_folder1, "include1", "file.h"), "")
@@ -95,239 +709,6 @@ class MakeGeneratorTest(unittest.TestCase):
         conanfile.deps_cpp_info.add(ref.name, cpp_info)
         generator = MakeGenerator(conanfile)
         content = generator.content
-
-        expected_template = Template(textwrap.dedent("""
-            CONAN_ROOT_MYPKG1 ?=  \\
-            {{conan_root_mypkg1}}
-
-            CONAN_SYSROOT_MYPKG1 ?=  \\
-
-
-            CONAN_RPATHFLAGS_MYPKG1 +=  \\
-            {{conan_rpath_flags_mypkg1}}
-
-            CONAN_INCLUDE_DIRS_MYPKG1 +=  \\
-            {{conan_include_dirs_mypkg1}}
-
-            CONAN_LIB_DIRS_MYPKG1 +=  \\
-            {{conan_lib_dirs_mypkg1}}
-
-            CONAN_BIN_DIRS_MYPKG1 +=  \\
-            {{conan_bin_dirs_mypkg1}}
-
-            CONAN_BUILD_DIRS_MYPKG1 +=  \\
-            {{conan_build_dirs_mypkg1}}
-
-            CONAN_RES_DIRS_MYPKG1 +=  \\
-
-
-            CONAN_LIBS_MYPKG1 +=  \\
-            libfoo
-
-            CONAN_SYSTEM_LIBS_MYPKG1 +=  \\
-            system_lib1
-
-            CONAN_DEFINES_MYPKG1 +=  \\
-            MYDEFINE1
-
-            CONAN_CFLAGS_MYPKG1 +=  \\
-            -fgimple
-
-            CONAN_CXXFLAGS_MYPKG1 +=  \\
-            -fdollars-in-identifiers
-
-            CONAN_SHAREDLINKFLAGS_MYPKG1 +=  \\
-            -framework Cocoa
-
-            CONAN_EXELINKFLAGS_MYPKG1 +=  \\
-            -framework QuartzCore
-
-            CONAN_FRAMEWORKS_MYPKG1 +=  \\
-            AudioUnit
-
-            CONAN_FRAMEWORK_PATHS_MYPKG1 +=  \\
-            {{conan_framework_dirs_mypkg1}}
-
-            CONAN_ROOT_MYPKG2 ?=  \\
-            {{conan_root_mypkg2}}
-
-            CONAN_SYSROOT_MYPKG2 ?=  \\
-
-
-            CONAN_RPATHFLAGS_MYPKG2 +=  \\
-            {{conan_rpath_flags_mypkg2}}
-
-            CONAN_INCLUDE_DIRS_MYPKG2 +=  \\
-            {{conan_include_dirs_mypkg2}}
-
-            CONAN_LIB_DIRS_MYPKG2 +=  \\
-            {{conan_lib_dirs_mypkg2}}
-
-            CONAN_BIN_DIRS_MYPKG2 +=  \\
-            {{conan_bin_dirs_mypkg2}}
-
-            CONAN_BUILD_DIRS_MYPKG2 +=  \\
-            {{conan_build_dirs_mypkg2}}
-
-            CONAN_RES_DIRS_MYPKG2 +=  \\
-
-
-            CONAN_LIBS_MYPKG2 +=  \\
-            libbar
-
-            CONAN_SYSTEM_LIBS_MYPKG2 +=  \\
-            system_lib2
-
-            CONAN_DEFINES_MYPKG2 +=  \\
-            MYDEFINE2
-
-            CONAN_CFLAGS_MYPKG2 +=  \\
-            -fno-asm
-
-            CONAN_CXXFLAGS_MYPKG2 +=  \\
-            -pthread
-
-            CONAN_SHAREDLINKFLAGS_MYPKG2 +=  \\
-            -framework AudioFoundation
-
-            CONAN_EXELINKFLAGS_MYPKG2 +=  \\
-            -framework VideoToolbox
-
-            CONAN_FRAMEWORKS_MYPKG2 +=  \\
-
-
-            CONAN_FRAMEWORK_PATHS_MYPKG2 +=  \\
-
-
-            CONAN_ROOTPATH +=  \\
-            $(CONAN_ROOTPATH_MYPKG1) \\
-            $(CONAN_ROOTPATH_MYPKG2)
-
-            CONAN_SYSROOT +=  \\
-            $(CONAN_SYSROOT_MYPKG1) \\
-            $(CONAN_SYSROOT_MYPKG2)
-
-            CONAN_RPATHFLAGS +=  \\
-            $(CONAN_RPATHFLAGS_MYPKG1) \\
-            $(CONAN_RPATHFLAGS_MYPKG2)
-
-            CONAN_INCLUDE_DIRS +=  \\
-            $(CONAN_INCLUDE_DIRS_MYPKG1) \\
-            $(CONAN_INCLUDE_DIRS_MYPKG2)
-
-            CONAN_LIB_DIRS +=  \\
-            $(CONAN_LIB_DIRS_MYPKG1) \\
-            $(CONAN_LIB_DIRS_MYPKG2)
-
-            CONAN_BIN_DIRS +=  \\
-            $(CONAN_BIN_DIRS_MYPKG1) \\
-            $(CONAN_BIN_DIRS_MYPKG2)
-
-            CONAN_BUILD_DIRS +=  \\
-            $(CONAN_BUILD_DIRS_MYPKG1) \\
-            $(CONAN_BUILD_DIRS_MYPKG2)
-
-            CONAN_RES_DIRS +=  \\
-            $(CONAN_RES_DIRS_MYPKG1) \\
-            $(CONAN_RES_DIRS_MYPKG2)
-
-            CONAN_LIBS +=  \\
-            $(CONAN_LIBS_MYPKG1) \\
-            $(CONAN_LIBS_MYPKG2)
-
-            CONAN_DEFINES +=  \\
-            $(CONAN_DEFINES_MYPKG1) \\
-            $(CONAN_DEFINES_MYPKG2)
-
-            CONAN_CFLAGS +=  \\
-            $(CONAN_CFLAGS_MYPKG1) \\
-            $(CONAN_CFLAGS_MYPKG2)
-
-            CONAN_CXXFLAGS +=  \\
-            $(CONAN_CXXFLAGS_MYPKG1) \\
-            $(CONAN_CXXFLAGS_MYPKG2)
-
-            CONAN_SHAREDLINKFLAGS +=  \\
-            $(CONAN_SHAREDLINKFLAGS_MYPKG1) \\
-            $(CONAN_SHAREDLINKFLAGS_MYPKG2)
-
-            CONAN_EXELINKFLAGS +=  \\
-            $(CONAN_EXELINKFLAGS_MYPKG1) \\
-            $(CONAN_EXELINKFLAGS_MYPKG2)
-
-            CONAN_FRAMEWORKS +=  \\
-            $(CONAN_FRAMEWORKS_MYPKG1) \\
-            $(CONAN_FRAMEWORKS_MYPKG2)
-
-            CONAN_FRAMEWORK_PATHS +=  \\
-            $(CONAN_FRAMEWORK_PATHS_MYPKG1) \\
-            $(CONAN_FRAMEWORK_PATHS_MYPKG2)
-
-            CONAN_SYSTEM_LIBS +=  \\
-            $(CONAN_SYSTEM_LIBS_MYPKG1) \\
-            $(CONAN_SYSTEM_LIBS_MYPKG2)
-
-
-            CONAN_CPPFLAGS      += $(addprefix -I,$(CONAN_INCLUDE_DIRS))
-            CONAN_CPPFLAGS      += $(addprefix -D,$(CONAN_DEFINES))
-            CONAN_LDFLAGS       += $(addprefix -L,$(CONAN_LIB_DIRS))
-            CONAN_LDFLAGS       += $(CONAN_RPATHFLAGS)
-            CONAN_LDLIBS        += $(addprefix -l,$(CONAN_SYSTEM_LIBS))
-            CONAN_LDLIBS        += $(addprefix -l,$(CONAN_LIBS))
-
-            CONAN_SET_SHARED = {{set_shared}}
-            ifeq ($(CONAN_SET_SHARED),True)
-                CONAN_LDFLAGS += $(CONAN_SHARED_LINKER_FLAGS)
-            else
-                CONAN_LDFLAGS += $(CONAN_EXE_LINKER_FLAGS)
-            endif
-
-            # Call this function in your Makefile to have Conan variables added to standard variables
-            # Example:  $(call CONAN_BASIC_SETUP)
-
-            CONAN_BASIC_SETUP = \\
-                $(eval CFLAGS   += $(CONAN_CFLAGS)) ; \\
-                $(eval CXXFLAGS += $(CONAN_CXXFLAGS)) ; \\
-                $(eval CPPFLAGS += $(CONAN_CPPFLAGS)) ; \\
-                $(eval LDFLAGS  += $(CONAN_LDFLAGS)) ; \\
-                $(eval LDLIBS   += $(CONAN_LDLIBS)) ;
-
-        """))
-        tmp_folder1 = tmp_folder1.replace('\\', '/')
-        tmp_folder2 = tmp_folder2.replace('\\', '/')
-
-        root1 = tmp_folder1
-        root2 = tmp_folder2
-
-        inc1 = "{0}/{1}".format(root1, "include1")
-        inc2 = "{0}/{1}".format(root2, "include2")
-
-        lib1 = "{0}/{1}".format(root1, "lib1")
-        lib2 = "{0}/{1}".format(root2, "lib2")
-
-        bin1 = "{0}/{1}".format(root1, "bin1")
-        bin2 = "{0}/{1}".format(root2, "bin2")
-
-        rsep = "," if os_ == "Macos" else "="
-        rpath1 = '-Wl,-rpath{0}"{1}/{2}"'.format(rsep, tmp_folder1, "lib1")
-        rpath2 = '-Wl,-rpath{0}"{1}/{2}"'.format(rsep, tmp_folder2, "lib2")
-
-        context = {
-            "conan_root_mypkg1": root1,
-            "conan_rpath_flags_mypkg1": rpath1,
-            "conan_include_dirs_mypkg1": inc1,
-            "conan_lib_dirs_mypkg1": lib1,
-            "conan_bin_dirs_mypkg1": bin1,
-            "conan_build_dirs_mypkg1": root1 + "/",
-            "conan_root_mypkg2": root2,
-            "conan_rpath_flags_mypkg2": rpath2,
-            "conan_include_dirs_mypkg2": inc2,
-            "conan_lib_dirs_mypkg2": lib2,
-            "conan_bin_dirs_mypkg2": bin2,
-            "conan_build_dirs_mypkg2": root2 + "/",
-            "conan_framework_dirs_mypkg1": root1 + "/SystemFrameworks",
-            "set_shared": shared_,
-        }
-        expected_content = expected_template.render(context)
         self.maxDiff = None
-        self.assertIn(expected_content, content)
+        tmpdirpattern = re.compile(r"/tmp/[^/]*")
+        self.assertIn(re.sub(tmpdirpattern, "_", expected), re.sub(tmpdirpattern, "_", content))

--- a/conans/test/unittests/client/generators/make_test.py
+++ b/conans/test/unittests/client/generators/make_test.py
@@ -1,20 +1,53 @@
 import os
 import unittest
+import textwrap
+
+from jinja2 import Template
 
 from conans.client.generators import MakeGenerator
 from conans.model.build_info import CppInfo
 from conans.model.conan_file import ConanFile
 from conans.model.env_info import EnvValues
 from conans.model.ref import ConanFileReference
-from conans.model.settings import Settings
 from conans.test.utils.test_files import temp_folder
 from conans.test.utils.mocks import TestBufferConanOutput
 from conans.util.files import save
 
+from parameterized.parameterized import parameterized
+
+
+class _MockSettings(object):
+    build_type = None
+    compiler = None
+    os_ = None
+    os_build = None
+    fields = []
+
+    def __init__(self, compiler, os_):
+        self.compiler = compiler
+        self.os_ = os_
+        self.os_build = os_
+
+    def constraint(self, _):
+        return self
+
+    def get_safe(self, name):
+        if name == "compiler":
+            return self.compiler
+        if name == "os":
+            return self.os_
+
+        return None
+
+    def items(self):
+        return {}
+
 
 class MakeGeneratorTest(unittest.TestCase):
-
-    def variables_setup_test(self):
+    @parameterized.expand([("gcc", "Linux", False),
+                           ("gcc", "Linux", True),
+                           ("gcc", "Macos", False)])
+    def variables_setup_test(self, compiler_, os_, shared_):
         tmp_folder1 = temp_folder()
         tmp_folder2 = temp_folder()
         save(os.path.join(tmp_folder1, "include1", "file.h"), "")
@@ -25,8 +58,11 @@ class MakeGeneratorTest(unittest.TestCase):
         save(os.path.join(tmp_folder2, "bin2", "file.bin"), "")
         save(os.path.join(tmp_folder1, "SystemFrameworks", "file.bin"), "")
 
+        settings_mock = _MockSettings(compiler=compiler_, os_=os_)
         conanfile = ConanFile(TestBufferConanOutput(), None)
-        conanfile.initialize(Settings({}), EnvValues())
+        conanfile.options = {"shared": [True, False]}
+        conanfile.default_options = {"shared": shared_}
+        conanfile.initialize(settings_mock, EnvValues())
         ref = ConanFileReference.loads("MyPkg1/0.1@lasote/stables")
         cpp_info = CppInfo(ref.name, tmp_folder1)
         cpp_info.defines = ["MYDEFINE1"]
@@ -60,185 +96,238 @@ class MakeGeneratorTest(unittest.TestCase):
         generator = MakeGenerator(conanfile)
         content = generator.content
 
-        content_template = """
-CONAN_ROOT_MYPKG1 ?=  \\
-{conan_root_mypkg1}
+        expected_template = Template(textwrap.dedent("""
+            CONAN_ROOT_MYPKG1 ?=  \\
+            {{conan_root_mypkg1}}
 
-CONAN_SYSROOT_MYPKG1 ?=  \\
-
-
-CONAN_INCLUDE_DIRS_MYPKG1 +=  \\
-{conan_include_dirs_mypkg1}
-
-CONAN_LIB_DIRS_MYPKG1 +=  \\
-{conan_lib_dirs_mypkg1}
-
-CONAN_BIN_DIRS_MYPKG1 +=  \\
-{conan_bin_dirs_mypkg1}
-
-CONAN_BUILD_DIRS_MYPKG1 +=  \\
-{conan_build_dirs_mypkg1}
-
-CONAN_RES_DIRS_MYPKG1 +=  \\
+            CONAN_SYSROOT_MYPKG1 ?=  \\
 
 
-CONAN_LIBS_MYPKG1 +=  \\
-libfoo
+            CONAN_RPATHFLAGS_MYPKG1 +=  \\
+            {{conan_rpath_flags_mypkg1}}
 
-CONAN_SYSTEM_LIBS_MYPKG1 +=  \\
-system_lib1
+            CONAN_INCLUDE_DIRS_MYPKG1 +=  \\
+            {{conan_include_dirs_mypkg1}}
 
-CONAN_DEFINES_MYPKG1 +=  \\
-MYDEFINE1
+            CONAN_LIB_DIRS_MYPKG1 +=  \\
+            {{conan_lib_dirs_mypkg1}}
 
-CONAN_CFLAGS_MYPKG1 +=  \\
--fgimple
+            CONAN_BIN_DIRS_MYPKG1 +=  \\
+            {{conan_bin_dirs_mypkg1}}
 
-CONAN_CXXFLAGS_MYPKG1 +=  \\
--fdollars-in-identifiers
+            CONAN_BUILD_DIRS_MYPKG1 +=  \\
+            {{conan_build_dirs_mypkg1}}
 
-CONAN_SHAREDLINKFLAGS_MYPKG1 +=  \\
--framework Cocoa
-
-CONAN_EXELINKFLAGS_MYPKG1 +=  \\
--framework QuartzCore
-
-CONAN_FRAMEWORKS_MYPKG1 +=  \\
-AudioUnit
-
-CONAN_FRAMEWORK_PATHS_MYPKG1 +=  \\
-{conan_framework_dirs_mypkg1}
-
-CONAN_ROOT_MYPKG2 ?=  \\
-{conan_root_mypkg2}
-
-CONAN_SYSROOT_MYPKG2 ?=  \\
+            CONAN_RES_DIRS_MYPKG1 +=  \\
 
 
-CONAN_INCLUDE_DIRS_MYPKG2 +=  \\
-{conan_include_dirs_mypkg2}
+            CONAN_LIBS_MYPKG1 +=  \\
+            libfoo
 
-CONAN_LIB_DIRS_MYPKG2 +=  \\
-{conan_lib_dirs_mypkg2}
+            CONAN_SYSTEM_LIBS_MYPKG1 +=  \\
+            system_lib1
 
-CONAN_BIN_DIRS_MYPKG2 +=  \\
-{conan_bin_dirs_mypkg2}
+            CONAN_DEFINES_MYPKG1 +=  \\
+            MYDEFINE1
 
-CONAN_BUILD_DIRS_MYPKG2 +=  \\
-{conan_build_dirs_mypkg2}
+            CONAN_CFLAGS_MYPKG1 +=  \\
+            -fgimple
 
-CONAN_RES_DIRS_MYPKG2 +=  \\
+            CONAN_CXXFLAGS_MYPKG1 +=  \\
+            -fdollars-in-identifiers
 
+            CONAN_SHAREDLINKFLAGS_MYPKG1 +=  \\
+            -framework Cocoa
 
-CONAN_LIBS_MYPKG2 +=  \\
-libbar
+            CONAN_EXELINKFLAGS_MYPKG1 +=  \\
+            -framework QuartzCore
 
-CONAN_SYSTEM_LIBS_MYPKG2 +=  \\
-system_lib2
+            CONAN_FRAMEWORKS_MYPKG1 +=  \\
+            AudioUnit
 
-CONAN_DEFINES_MYPKG2 +=  \\
-MYDEFINE2
+            CONAN_FRAMEWORK_PATHS_MYPKG1 +=  \\
+            {{conan_framework_dirs_mypkg1}}
 
-CONAN_CFLAGS_MYPKG2 +=  \\
--fno-asm
+            CONAN_ROOT_MYPKG2 ?=  \\
+            {{conan_root_mypkg2}}
 
-CONAN_CXXFLAGS_MYPKG2 +=  \\
--pthread
-
-CONAN_SHAREDLINKFLAGS_MYPKG2 +=  \\
--framework AudioFoundation
-
-CONAN_EXELINKFLAGS_MYPKG2 +=  \\
--framework VideoToolbox
-
-CONAN_FRAMEWORKS_MYPKG2 +=  \\
+            CONAN_SYSROOT_MYPKG2 ?=  \\
 
 
-CONAN_FRAMEWORK_PATHS_MYPKG2 +=  \\
+            CONAN_RPATHFLAGS_MYPKG2 +=  \\
+            {{conan_rpath_flags_mypkg2}}
+
+            CONAN_INCLUDE_DIRS_MYPKG2 +=  \\
+            {{conan_include_dirs_mypkg2}}
+
+            CONAN_LIB_DIRS_MYPKG2 +=  \\
+            {{conan_lib_dirs_mypkg2}}
+
+            CONAN_BIN_DIRS_MYPKG2 +=  \\
+            {{conan_bin_dirs_mypkg2}}
+
+            CONAN_BUILD_DIRS_MYPKG2 +=  \\
+            {{conan_build_dirs_mypkg2}}
+
+            CONAN_RES_DIRS_MYPKG2 +=  \\
 
 
-CONAN_ROOTPATH +=  \\
-$(CONAN_ROOTPATH_MYPKG1) \\
-$(CONAN_ROOTPATH_MYPKG2)
+            CONAN_LIBS_MYPKG2 +=  \\
+            libbar
 
-CONAN_SYSROOT +=  \\
-$(CONAN_SYSROOT_MYPKG1) \\
-$(CONAN_SYSROOT_MYPKG2)
+            CONAN_SYSTEM_LIBS_MYPKG2 +=  \\
+            system_lib2
 
-CONAN_INCLUDE_DIRS +=  \\
-$(CONAN_INCLUDE_DIRS_MYPKG1) \\
-$(CONAN_INCLUDE_DIRS_MYPKG2)
+            CONAN_DEFINES_MYPKG2 +=  \\
+            MYDEFINE2
 
-CONAN_LIB_DIRS +=  \\
-$(CONAN_LIB_DIRS_MYPKG1) \\
-$(CONAN_LIB_DIRS_MYPKG2)
+            CONAN_CFLAGS_MYPKG2 +=  \\
+            -fno-asm
 
-CONAN_BIN_DIRS +=  \\
-$(CONAN_BIN_DIRS_MYPKG1) \\
-$(CONAN_BIN_DIRS_MYPKG2)
+            CONAN_CXXFLAGS_MYPKG2 +=  \\
+            -pthread
 
-CONAN_BUILD_DIRS +=  \\
-$(CONAN_BUILD_DIRS_MYPKG1) \\
-$(CONAN_BUILD_DIRS_MYPKG2)
+            CONAN_SHAREDLINKFLAGS_MYPKG2 +=  \\
+            -framework AudioFoundation
 
-CONAN_RES_DIRS +=  \\
-$(CONAN_RES_DIRS_MYPKG1) \\
-$(CONAN_RES_DIRS_MYPKG2)
+            CONAN_EXELINKFLAGS_MYPKG2 +=  \\
+            -framework VideoToolbox
 
-CONAN_LIBS +=  \\
-$(CONAN_LIBS_MYPKG1) \\
-$(CONAN_LIBS_MYPKG2)
+            CONAN_FRAMEWORKS_MYPKG2 +=  \\
 
-CONAN_DEFINES +=  \\
-$(CONAN_DEFINES_MYPKG1) \\
-$(CONAN_DEFINES_MYPKG2)
 
-CONAN_CFLAGS +=  \\
-$(CONAN_CFLAGS_MYPKG1) \\
-$(CONAN_CFLAGS_MYPKG2)
+            CONAN_FRAMEWORK_PATHS_MYPKG2 +=  \\
 
-CONAN_CXXFLAGS +=  \\
-$(CONAN_CXXFLAGS_MYPKG1) \\
-$(CONAN_CXXFLAGS_MYPKG2)
 
-CONAN_SHAREDLINKFLAGS +=  \\
-$(CONAN_SHAREDLINKFLAGS_MYPKG1) \\
-$(CONAN_SHAREDLINKFLAGS_MYPKG2)
+            CONAN_ROOTPATH +=  \\
+            $(CONAN_ROOTPATH_MYPKG1) \\
+            $(CONAN_ROOTPATH_MYPKG2)
 
-CONAN_EXELINKFLAGS +=  \\
-$(CONAN_EXELINKFLAGS_MYPKG1) \\
-$(CONAN_EXELINKFLAGS_MYPKG2)
+            CONAN_SYSROOT +=  \\
+            $(CONAN_SYSROOT_MYPKG1) \\
+            $(CONAN_SYSROOT_MYPKG2)
 
-CONAN_FRAMEWORKS +=  \\
-$(CONAN_FRAMEWORKS_MYPKG1) \\
-$(CONAN_FRAMEWORKS_MYPKG2)
+            CONAN_RPATHFLAGS +=  \\
+            $(CONAN_RPATHFLAGS_MYPKG1) \\
+            $(CONAN_RPATHFLAGS_MYPKG2)
 
-CONAN_FRAMEWORK_PATHS +=  \\
-$(CONAN_FRAMEWORK_PATHS_MYPKG1) \\
-$(CONAN_FRAMEWORK_PATHS_MYPKG2)
-"""
-        root1 = tmp_folder1.replace('\\', '/')
-        root2 = tmp_folder2.replace('\\', '/')
+            CONAN_INCLUDE_DIRS +=  \\
+            $(CONAN_INCLUDE_DIRS_MYPKG1) \\
+            $(CONAN_INCLUDE_DIRS_MYPKG2)
 
-        inc1 = os.path.join(tmp_folder1, 'include1').replace('\\', '/')
-        inc2 = os.path.join(tmp_folder2, 'include2').replace('\\', '/')
+            CONAN_LIB_DIRS +=  \\
+            $(CONAN_LIB_DIRS_MYPKG1) \\
+            $(CONAN_LIB_DIRS_MYPKG2)
 
-        lib1 = os.path.join(tmp_folder1, 'lib1').replace('\\', '/')
-        lib2 = os.path.join(tmp_folder2, 'lib2').replace('\\', '/')
+            CONAN_BIN_DIRS +=  \\
+            $(CONAN_BIN_DIRS_MYPKG1) \\
+            $(CONAN_BIN_DIRS_MYPKG2)
 
-        bin1 = os.path.join(tmp_folder1, 'bin1').replace('\\', '/')
-        bin2 = os.path.join(tmp_folder2, 'bin2').replace('\\', '/')
+            CONAN_BUILD_DIRS +=  \\
+            $(CONAN_BUILD_DIRS_MYPKG1) \\
+            $(CONAN_BUILD_DIRS_MYPKG2)
 
-        expected_content = content_template.format(conan_root_mypkg1=root1,
-                                                   conan_include_dirs_mypkg1=inc1,
-                                                   conan_lib_dirs_mypkg1=lib1,
-                                                   conan_bin_dirs_mypkg1=bin1,
-                                                   conan_build_dirs_mypkg1=root1 + "/",
-                                                   conan_root_mypkg2=root2,
-                                                   conan_include_dirs_mypkg2=inc2,
-                                                   conan_lib_dirs_mypkg2=lib2,
-                                                   conan_bin_dirs_mypkg2=bin2,
-                                                   conan_build_dirs_mypkg2=root2 + "/",
-                                                   conan_framework_dirs_mypkg1=root1 + "/SystemFrameworks")
+            CONAN_RES_DIRS +=  \\
+            $(CONAN_RES_DIRS_MYPKG1) \\
+            $(CONAN_RES_DIRS_MYPKG2)
+
+            CONAN_LIBS +=  \\
+            $(CONAN_LIBS_MYPKG1) \\
+            $(CONAN_LIBS_MYPKG2)
+
+            CONAN_DEFINES +=  \\
+            $(CONAN_DEFINES_MYPKG1) \\
+            $(CONAN_DEFINES_MYPKG2)
+
+            CONAN_CFLAGS +=  \\
+            $(CONAN_CFLAGS_MYPKG1) \\
+            $(CONAN_CFLAGS_MYPKG2)
+
+            CONAN_CXXFLAGS +=  \\
+            $(CONAN_CXXFLAGS_MYPKG1) \\
+            $(CONAN_CXXFLAGS_MYPKG2)
+
+            CONAN_SHAREDLINKFLAGS +=  \\
+            $(CONAN_SHAREDLINKFLAGS_MYPKG1) \\
+            $(CONAN_SHAREDLINKFLAGS_MYPKG2)
+
+            CONAN_EXELINKFLAGS +=  \\
+            $(CONAN_EXELINKFLAGS_MYPKG1) \\
+            $(CONAN_EXELINKFLAGS_MYPKG2)
+
+            CONAN_FRAMEWORKS +=  \\
+            $(CONAN_FRAMEWORKS_MYPKG1) \\
+            $(CONAN_FRAMEWORKS_MYPKG2)
+
+            CONAN_FRAMEWORK_PATHS +=  \\
+            $(CONAN_FRAMEWORK_PATHS_MYPKG1) \\
+            $(CONAN_FRAMEWORK_PATHS_MYPKG2)
+
+            CONAN_SYSTEM_LIBS +=  \\
+            $(CONAN_SYSTEM_LIBS_MYPKG1) \\
+            $(CONAN_SYSTEM_LIBS_MYPKG2)
+
+
+            CONAN_CPPFLAGS      += $(addprefix -I,$(CONAN_INCLUDE_DIRS))
+            CONAN_CPPFLAGS      += $(addprefix -D,$(CONAN_DEFINES))
+            CONAN_LDFLAGS       += $(addprefix -L,$(CONAN_LIB_DIRS))
+            CONAN_LDFLAGS       += $(CONAN_RPATHFLAGS)
+            CONAN_LDLIBS        += $(addprefix -l,$(CONAN_SYSTEM_LIBS))
+            CONAN_LDLIBS        += $(addprefix -l,$(CONAN_LIBS))
+
+            CONAN_SET_SHARED = {{set_shared}}
+            ifeq ($(CONAN_SET_SHARED),True)
+                CONAN_LDFLAGS += $(CONAN_SHARED_LINKER_FLAGS)
+            else
+                CONAN_LDFLAGS += $(CONAN_EXE_LINKER_FLAGS)
+            endif
+
+            # Call this function in your Makefile to have Conan variables added to standard variables
+            # Example:  $(call CONAN_BASIC_SETUP)
+
+            CONAN_BASIC_SETUP = \\
+                $(eval CFLAGS   += $(CONAN_CFLAGS)) ; \\
+                $(eval CXXFLAGS += $(CONAN_CXXFLAGS)) ; \\
+                $(eval CPPFLAGS += $(CONAN_CPPFLAGS)) ; \\
+                $(eval LDFLAGS  += $(CONAN_LDFLAGS)) ; \\
+                $(eval LDLIBS   += $(CONAN_LDLIBS)) ;
+
+        """))
+        tmp_folder1 = tmp_folder1.replace('\\', '/')
+        tmp_folder2 = tmp_folder2.replace('\\', '/')
+
+        root1 = tmp_folder1
+        root2 = tmp_folder2
+
+        inc1 = "{0}/{1}".format(root1, "include1")
+        inc2 = "{0}/{1}".format(root2, "include2")
+
+        lib1 = "{0}/{1}".format(root1, "lib1")
+        lib2 = "{0}/{1}".format(root2, "lib2")
+
+        bin1 = "{0}/{1}".format(root1, "bin1")
+        bin2 = "{0}/{1}".format(root2, "bin2")
+
+        rsep = "," if os_ == "Macos" else "="
+        rpath1 = '-Wl,-rpath{0}"{1}/{2}"'.format(rsep, tmp_folder1, "lib1")
+        rpath2 = '-Wl,-rpath{0}"{1}/{2}"'.format(rsep, tmp_folder2, "lib2")
+
+        context = {
+            "conan_root_mypkg1": root1,
+            "conan_rpath_flags_mypkg1": rpath1,
+            "conan_include_dirs_mypkg1": inc1,
+            "conan_lib_dirs_mypkg1": lib1,
+            "conan_bin_dirs_mypkg1": bin1,
+            "conan_build_dirs_mypkg1": root1 + "/",
+            "conan_root_mypkg2": root2,
+            "conan_rpath_flags_mypkg2": rpath2,
+            "conan_include_dirs_mypkg2": inc2,
+            "conan_lib_dirs_mypkg2": lib2,
+            "conan_bin_dirs_mypkg2": bin2,
+            "conan_build_dirs_mypkg2": root2 + "/",
+            "conan_framework_dirs_mypkg1": root1 + "/SystemFrameworks",
+            "set_shared": shared_,
+        }
+        expected_content = expected_template.render(context)
         self.maxDiff = None
         self.assertIn(expected_content, content)

--- a/conans/test/unittests/client/generators/make_test.py
+++ b/conans/test/unittests/client/generators/make_test.py
@@ -230,7 +230,7 @@ CONAN_LDLIBS        += $(addprefix -l,$(CONAN_LIBS))
 # Appends either CONAN_EXELINKFLAGS or CONAN_SHAREDLINKFLAGS to LDFLAGS
 # Example 1:  $(call CONAN_BASIC_SETUP)
 # Example 2:  $(call CONAN_BASIC_SETUP, EXE)
-# Example 2:  $(call CONAN_BASIC_SETUP, SHARED)
+# Example 3:  $(call CONAN_BASIC_SETUP, SHARED)
 
 CONAN_BASIC_SETUP = \\
     $(eval CFLAGS   += $(CONAN_CFLAGS)) ; \\
@@ -431,10 +431,10 @@ CONAN_LDLIBS        += $(addprefix -l,$(CONAN_LIBS))
 
 # Call the following function to have Conan variables added to standard variables
 # 1 optional parameter : type of target being built : EXE or SHARED
-# Appends either CONAN_EXELINKFLAGS or CONAN_SHAREDINKFLAGS to LDFLAGS
+# Appends either CONAN_EXELINKFLAGS or CONAN_SHAREDLINKFLAGS to LDFLAGS
 # Example 1:  $(call CONAN_BASIC_SETUP)
 # Example 2:  $(call CONAN_BASIC_SETUP, EXE)
-# Example 2:  $(call CONAN_BASIC_SETUP, SHARED)
+# Example 3:  $(call CONAN_BASIC_SETUP, SHARED)
 
 CONAN_BASIC_SETUP = \\
     $(eval CFLAGS   += $(CONAN_CFLAGS)) ; \\
@@ -638,7 +638,7 @@ CONAN_LDLIBS        += $(addprefix -l,$(CONAN_LIBS))
 # Appends either CONAN_EXELINKFLAGS or CONAN_SHAREDLINKFLAGS to LDFLAGS
 # Example 1:  $(call CONAN_BASIC_SETUP)
 # Example 2:  $(call CONAN_BASIC_SETUP, EXE)
-# Example 2:  $(call CONAN_BASIC_SETUP, SHARED)
+# Example 3:  $(call CONAN_BASIC_SETUP, SHARED)
 
 CONAN_BASIC_SETUP = \\
     $(eval CFLAGS   += $(CONAN_CFLAGS)) ; \\

--- a/conans/test/unittests/client/generators/make_test.py
+++ b/conans/test/unittests/client/generators/make_test.py
@@ -656,12 +656,12 @@ CONAN_BASIC_SETUP = \\
 
 
 class MakeGeneratorTest(unittest.TestCase):
-    @unittest.skipUnless(platform.system() in ["Linux", "Macos"], "Requires make")
     @parameterized.expand([
         ("gcc", "Linux", False, EXPECTED_OUT_1),
         ("gcc", "Linux", True, EXPECTED_OUT_2),
         ("gcc", "Macos", False, EXPECTED_OUT_3),
     ])
+    @unittest.skipUnless(platform.system() in ["Linux", "Macos"], "Requires make")
     def variables_setup_test(self, compiler_, os_, shared_, expected):
         tmp_folder1 = temp_folder()
         tmp_folder2 = temp_folder()

--- a/conans/test/unittests/client/generators/make_test.py
+++ b/conans/test/unittests/client/generators/make_test.py
@@ -1,4 +1,4 @@
-import re
+import platform
 import os
 import unittest
 import textwrap
@@ -656,6 +656,7 @@ CONAN_BASIC_SETUP = \\
 
 
 class MakeGeneratorTest(unittest.TestCase):
+    @unittest.skipUnless(platform.system() in ["Linux", "Macos"], "Requires make")
     @parameterized.expand([
         ("gcc", "Linux", False, EXPECTED_OUT_1),
         ("gcc", "Linux", True, EXPECTED_OUT_2),

--- a/conans/test/unittests/client/generators/make_test.py
+++ b/conans/test/unittests/client/generators/make_test.py
@@ -48,25 +48,25 @@ EXPECTED_OUT_1 = textwrap.dedent("""
 #-------------------------------------------------------------------#
 
 CONAN_ROOT_MYPKG1 ?=  \\
-_/path with spaces
+/tmp1
 
 CONAN_SYSROOT_MYPKG1 ?=  \\
 
 
 CONAN_RPATHFLAGS_MYPKG1 +=  \\
--Wl,-rpath="_/path with spaces/lib1"
+-Wl,-rpath="/tmp1/lib1"
 
 CONAN_INCLUDE_DIRS_MYPKG1 +=  \\
-_/path with spaces/include1
+/tmp1/include1
 
 CONAN_LIB_DIRS_MYPKG1 +=  \\
-_/path with spaces/lib1
+/tmp1/lib1
 
 CONAN_BIN_DIRS_MYPKG1 +=  \\
-_/path with spaces/bin1
+/tmp1/bin1
 
 CONAN_BUILD_DIRS_MYPKG1 +=  \\
-_/path with spaces/
+/tmp1/
 
 CONAN_RES_DIRS_MYPKG1 +=  \\
 
@@ -96,28 +96,28 @@ CONAN_FRAMEWORKS_MYPKG1 +=  \\
 AudioUnit
 
 CONAN_FRAMEWORK_PATHS_MYPKG1 +=  \\
-_/path with spaces/SystemFrameworks
+/tmp1/SystemFrameworks
 
 CONAN_ROOT_MYPKG2 ?=  \\
-_/path with spaces
+/tmp2
 
 CONAN_SYSROOT_MYPKG2 ?=  \\
 
 
 CONAN_RPATHFLAGS_MYPKG2 +=  \\
--Wl,-rpath="_/path with spaces/lib2"
+-Wl,-rpath="/tmp2/lib2"
 
 CONAN_INCLUDE_DIRS_MYPKG2 +=  \\
-_/path with spaces/include2
+/tmp2/include2
 
 CONAN_LIB_DIRS_MYPKG2 +=  \\
-_/path with spaces/lib2
+/tmp2/lib2
 
 CONAN_BIN_DIRS_MYPKG2 +=  \\
-_/path with spaces/bin2
+/tmp2/bin2
 
 CONAN_BUILD_DIRS_MYPKG2 +=  \\
-_/path with spaces/
+/tmp2/
 
 CONAN_RES_DIRS_MYPKG2 +=  \\
 
@@ -252,25 +252,25 @@ EXPECTED_OUT_2 = textwrap.dedent("""
 #-------------------------------------------------------------------#
 
 CONAN_ROOT_MYPKG1 ?=  \\
-_/path with spaces
+/tmp1
 
 CONAN_SYSROOT_MYPKG1 ?=  \\
 
 
 CONAN_RPATHFLAGS_MYPKG1 +=  \\
--Wl,-rpath="_/path with spaces/lib1"
+-Wl,-rpath="/tmp1/lib1"
 
 CONAN_INCLUDE_DIRS_MYPKG1 +=  \\
-_/path with spaces/include1
+/tmp1/include1
 
 CONAN_LIB_DIRS_MYPKG1 +=  \\
-_/path with spaces/lib1
+/tmp1/lib1
 
 CONAN_BIN_DIRS_MYPKG1 +=  \\
-_/path with spaces/bin1
+/tmp1/bin1
 
 CONAN_BUILD_DIRS_MYPKG1 +=  \\
-_/path with spaces/
+/tmp1/
 
 CONAN_RES_DIRS_MYPKG1 +=  \\
 
@@ -300,28 +300,28 @@ CONAN_FRAMEWORKS_MYPKG1 +=  \\
 AudioUnit
 
 CONAN_FRAMEWORK_PATHS_MYPKG1 +=  \\
-_/path with spaces/SystemFrameworks
+/tmp1/SystemFrameworks
 
 CONAN_ROOT_MYPKG2 ?=  \\
-_/path with spaces
+/tmp2
 
 CONAN_SYSROOT_MYPKG2 ?=  \\
 
 
 CONAN_RPATHFLAGS_MYPKG2 +=  \\
--Wl,-rpath="_/path with spaces/lib2"
+-Wl,-rpath="/tmp2/lib2"
 
 CONAN_INCLUDE_DIRS_MYPKG2 +=  \\
-_/path with spaces/include2
+/tmp2/include2
 
 CONAN_LIB_DIRS_MYPKG2 +=  \\
-_/path with spaces/lib2
+/tmp2/lib2
 
 CONAN_BIN_DIRS_MYPKG2 +=  \\
-_/path with spaces/bin2
+/tmp2/bin2
 
 CONAN_BUILD_DIRS_MYPKG2 +=  \\
-_/path with spaces/
+/tmp2/
 
 CONAN_RES_DIRS_MYPKG2 +=  \\
 
@@ -456,25 +456,25 @@ EXPECTED_OUT_3 = textwrap.dedent("""
 #-------------------------------------------------------------------#
 
 CONAN_ROOT_MYPKG1 ?=  \\
-_/path with spaces
+/tmp1
 
 CONAN_SYSROOT_MYPKG1 ?=  \\
 
 
 CONAN_RPATHFLAGS_MYPKG1 +=  \\
--Wl,-rpath,"_/path with spaces/lib1"
+-Wl,-rpath,"/tmp1/lib1"
 
 CONAN_INCLUDE_DIRS_MYPKG1 +=  \\
-_/path with spaces/include1
+/tmp1/include1
 
 CONAN_LIB_DIRS_MYPKG1 +=  \\
-_/path with spaces/lib1
+/tmp1/lib1
 
 CONAN_BIN_DIRS_MYPKG1 +=  \\
-_/path with spaces/bin1
+/tmp1/bin1
 
 CONAN_BUILD_DIRS_MYPKG1 +=  \\
-_/path with spaces/
+/tmp1/
 
 CONAN_RES_DIRS_MYPKG1 +=  \\
 
@@ -504,28 +504,28 @@ CONAN_FRAMEWORKS_MYPKG1 +=  \\
 AudioUnit
 
 CONAN_FRAMEWORK_PATHS_MYPKG1 +=  \\
-_/path with spaces/SystemFrameworks
+/tmp1/SystemFrameworks
 
 CONAN_ROOT_MYPKG2 ?=  \\
-_/path with spaces
+/tmp2
 
 CONAN_SYSROOT_MYPKG2 ?=  \\
 
 
 CONAN_RPATHFLAGS_MYPKG2 +=  \\
--Wl,-rpath,"_/path with spaces/lib2"
+-Wl,-rpath,"/tmp2/lib2"
 
 CONAN_INCLUDE_DIRS_MYPKG2 +=  \\
-_/path with spaces/include2
+/tmp2/include2
 
 CONAN_LIB_DIRS_MYPKG2 +=  \\
-_/path with spaces/lib2
+/tmp2/lib2
 
 CONAN_BIN_DIRS_MYPKG2 +=  \\
-_/path with spaces/bin2
+/tmp2/bin2
 
 CONAN_BUILD_DIRS_MYPKG2 +=  \\
-_/path with spaces/
+/tmp2/
 
 CONAN_RES_DIRS_MYPKG2 +=  \\
 
@@ -710,5 +710,7 @@ class MakeGeneratorTest(unittest.TestCase):
         generator = MakeGenerator(conanfile)
         content = generator.content
         self.maxDiff = None
-        tmpdirpattern = re.compile(r"/tmp/[^/]*")
-        self.assertIn(re.sub(tmpdirpattern, "_", expected), re.sub(tmpdirpattern, "_", content))
+        sanitized_content = content\
+            .replace(tmp_folder1, "/tmp1")\
+            .replace(tmp_folder2, "/tmp2")
+        self.assertIn(expected, sanitized_content)


### PR DESCRIPTION
Changelog: (Feature): Add a new CONAN_BASIC_SETUP function to makefile generator which appends conan variables to standard gnu make variables, including the appropriate flag prefixes.  Closes https://github.com/conan-io/conan/issues/7405.

Changelog: (Feature): Add rpath support to Makefile generator.

Docs: https://github.com/conan-io/docs/pull/XXXX

Also of note, this is consistent with the latest draft of the Make toolchain which has a similar/complementary function `CONAN_TC_SETUP`. 

- [x] Refer to the issue that supports this Pull Request.
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 

<sup>**Note:** By default this PR will skip the slower tests and will use a limited set of python versions. Check [here](https://github.com/conan-io/conan/blob/develop/.github/PR_INCREASE_TESTING.md) how to increase the testing level by writing some tags in the current PR body text.</sup>
