### PR TITLE
Fixes bad powershell separators on Linux

### DIFF
--- a/conans/client/envvars/environment.py
+++ b/conans/client/envvars/environment.py
@@ -127,8 +127,10 @@ def _format_values(flavor, variables, append_with_spaces):
     :return:
     """
 
-    if flavor in [BAT_FLAVOR, PS1_FLAVOR]:
+    if flavor in [BAT_FLAVOR, PS1_FLAVOR] and platform.system() == "Windows":
         path_sep, quote_elements = ";", False
+    elif flavor == PS1_FLAVOR:
+        path_sep, quote_elements = ":", False
     else:
         path_sep, quote_elements = ":", True
 

--- a/conans/test/unittests/client/generators/virtualbuildenv_test.py
+++ b/conans/test/unittests/client/generators/virtualbuildenv_test.py
@@ -46,6 +46,13 @@ class VirtualBuildEnvGeneratorGCCTest(unittest.TestCase):
         self.assertIn('LDFLAGS="--sysroot=/path/to/sysroot ${LDFLAGS+ $LDFLAGS}"', content)
         self.assertIn('LIBS="${LIBS+ $LIBS}"', content)
 
+        content = self.result["environment_build.ps1.env"]
+        self.assertIn('CPPFLAGS=-DNDEBUG $env:CPPFLAGS', content)
+        self.assertIn('CXXFLAGS=-O3 -s --sysroot=/path/to/sysroot $env:CXXFLAGS', content)
+        self.assertIn('CFLAGS=-O3 -s --sysroot=/path/to/sysroot $env:CFLAGS', content)
+        self.assertIn('LDFLAGS=--sysroot=/path/to/sysroot $env:LDFLAGS', content)
+        self.assertIn('LIBS=$env:LIBS', content)
+
         if platform.system() == "Windows":
             content = self.result["environment_build.bat.env"]
             self.assertIn('CPPFLAGS=-DNDEBUG %CPPFLAGS%', content)
@@ -53,10 +60,3 @@ class VirtualBuildEnvGeneratorGCCTest(unittest.TestCase):
             self.assertIn('CFLAGS=-O3 -s --sysroot=/path/to/sysroot %CFLAGS%', content)
             self.assertIn('LDFLAGS=--sysroot=/path/to/sysroot %LDFLAGS%', content)
             self.assertIn('LIBS=%LIBS%', content)
-
-            content = self.result["environment_build.ps1.env"]
-            self.assertIn('CPPFLAGS=-DNDEBUG $env:CPPFLAGS', content)
-            self.assertIn('CXXFLAGS=-O3 -s --sysroot=/path/to/sysroot $env:CXXFLAGS', content)
-            self.assertIn('CFLAGS=-O3 -s --sysroot=/path/to/sysroot $env:CFLAGS', content)
-            self.assertIn('LDFLAGS=--sysroot=/path/to/sysroot $env:LDFLAGS', content)
-            self.assertIn('LIBS=$env:LIBS', content)

--- a/conans/test/unittests/client/generators/virtualenv_test.py
+++ b/conans/test/unittests/client/generators/virtualenv_test.py
@@ -49,15 +49,18 @@ class VirtualEnvGeneratorTest(unittest.TestCase):
 
         if platform.system() == "Windows":
             self.assertIn("PATH=another_path;%PATH%", self.result["environment.bat.env"])
-            self.assertIn('PATH2=p1;p2;$env:PATH2', self.result["environment.ps1.env"])
+            self.assertIn('PATH2=p1;p2;%PATH2%', self.result["environment.bat.env"])
 
-            self.assertIn("PATH=another_path;%PATH%", self.result["environment.bat.env"])
+            self.assertIn("PATH=another_path;$env:PATH", self.result["environment.ps1.env"])
             self.assertIn('PATH2=p1;p2;$env:PATH2', self.result["environment.ps1.env"])
+        else:
+            self.assertIn('PATH=another_path:$env:PATH', self.result["environment.ps1.env"])
+            self.assertIn('PATH2=p1:p2:$env:PATH2', self.result["environment.ps1.env"])
 
     def test_list_with_spaces(self):
         self.assertIn("CL", VirtualEnvGenerator.append_with_spaces)
         self.assertIn("CL=\"cl1 cl2 ${CL+ $CL}\"", self.result['environment.sh.env'])
-
+        self.assertIn('CL=cl1 cl2 $env:CL', self.result["environment.ps1.env"])
+        
         if platform.system() == "Windows":
             self.assertIn("CL=cl1 cl2 %CL%", self.result["environment.bat.env"])
-            self.assertIn('CL=cl1 cl2 $env:CL', self.result["environment.ps1.env"])

--- a/conans/test/unittests/client/generators/virtualrunenv_test.py
+++ b/conans/test/unittests/client/generators/virtualrunenv_test.py
@@ -56,3 +56,8 @@ class VirtualRunEnvGeneratorTest(unittest.TestCase):
             self.assertIn('DYLD_LIBRARY_PATH=lib1;lib2;$env:DYLD_LIBRARY_PATH', content)
             self.assertIn('LD_LIBRARY_PATH=lib1;lib2;$env:LD_LIBRARY_PATH', content)
             self.assertIn('PATH=bin1;bin2;$env:PATH', content)
+        else:
+            content = self.result[self.environment_ps1_env]
+            self.assertIn('DYLD_LIBRARY_PATH=lib1:lib2:$env:DYLD_LIBRARY_PATH', content)
+            self.assertIn('LD_LIBRARY_PATH=lib1:lib2:$env:LD_LIBRARY_PATH', content)
+            self.assertIn('PATH=bin1:bin2:$env:PATH', content)


### PR DESCRIPTION
Changelog: Bugfix: Powershell files generated by `virtualenv` generators use proper path separators.
Docs: Omit

Closes #7471 

- [x] Refer to the issue that supports this Pull Request.
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [x] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 

<sup>**Note:** By default this PR will skip the slower tests and will use a limited set of python versions. Check [here](https://github.com/conan-io/conan/blob/develop/.github/PR_INCREASE_TESTING.md) how to increase the testing level by writing some tags in the current PR body text.</sup>
