### PR TITLE
pkg_config generator: do not modify value in the shared 'cpp_info' object

### DIFF
--- a/conans/client/generators/pkg_config.py
+++ b/conans/client/generators/pkg_config.py
@@ -44,8 +44,8 @@ class PkgConfigGenerator(Generator):
         generator_components = []
         for comp_name, comp in self.sorted_components(cpp_info).items():
             comp_genname = self._get_name(cpp_info.components[comp_name])
-            comp.public_deps = self._get_component_requires(pkg_name, comp)
-            generator_components.append((comp_genname, comp))
+            comp_requires_gennames = self._get_component_requires(pkg_name, comp)
+            generator_components.append((comp_genname, comp, comp_requires_gennames))
         generator_components.reverse()  # From the less dependent to most one
         return generator_components
 
@@ -76,19 +76,22 @@ class PkgConfigGenerator(Generator):
         for depname, cpp_info in self.deps_build_info.dependencies:
             pkg_genname = cpp_info.get_name(PkgConfigGenerator.name)
             if not cpp_info.components:
-                ret["%s.pc" % pkg_genname] = self.single_pc_file_contents(pkg_genname, cpp_info)
+                ret["%s.pc" % pkg_genname] = self.single_pc_file_contents(pkg_genname, cpp_info, None)
             else:
                 components = self._get_components(depname, cpp_info)
-                for comp_genname, comp in components:
+                for comp_genname, comp, comp_requires_gennames in components:
                     ret["%s.pc" % comp_genname] = self.single_pc_file_contents(
-                        "%s-%s" % (pkg_genname, comp_genname), comp, is_component=True)
-                comp_gennames = [comp_genname for comp_genname, _ in components]
+                        "%s-%s" % (pkg_genname, comp_genname),
+                        comp,
+                        comp_requires_gennames,
+                        is_component=True)
+                comp_gennames = [comp_genname for comp_genname, _, _ in components]
                 if pkg_genname not in comp_gennames:
                     ret["%s.pc" % pkg_genname] = self.global_pc_file_contents(pkg_genname, cpp_info,
                                                                               comp_gennames)
         return ret
 
-    def single_pc_file_contents(self, name, cpp_info, is_component=False):
+    def single_pc_file_contents(self, name, cpp_info, comp_requires_gennames, is_component=False):
         prefix_path = cpp_info.rootpath.replace("\\", "/")
         lines = ['prefix=%s' % prefix_path]
 
@@ -135,9 +138,9 @@ class PkgConfigGenerator(Generator):
              cpp_info.cflags,
              ["-D%s" % d for d in cpp_info.defines]]))
 
-        if cpp_info.public_deps:
+        if comp_requires_gennames:
             if is_component:
-                pkg_config_names = cpp_info.public_deps
+                pkg_config_names = comp_requires_gennames
             else:
                 pkg_config_names = []
                 for public_dep in cpp_info.public_deps:

--- a/conans/client/generators/pkg_config.py
+++ b/conans/client/generators/pkg_config.py
@@ -84,8 +84,8 @@ class PkgConfigGenerator(Generator):
                         "%s-%s" % (pkg_genname, comp_genname), comp, is_component=True)
                 comp_gennames = [comp_genname for comp_genname, _ in components]
                 if pkg_genname not in comp_gennames:
-                    cpp_info.public_deps = comp_gennames
-                    ret["%s.pc" % pkg_genname] = self.global_pc_file_contents(pkg_genname, cpp_info)
+                    ret["%s.pc" % pkg_genname] = self.global_pc_file_contents(pkg_genname, cpp_info,
+                                                                              comp_gennames)
         return ret
 
     def single_pc_file_contents(self, name, cpp_info, is_component=False):
@@ -148,14 +148,14 @@ class PkgConfigGenerator(Generator):
         return "\n".join(lines) + "\n"
 
     @staticmethod
-    def global_pc_file_contents(name, cpp_info):
+    def global_pc_file_contents(name, cpp_info, comp_gennames):
         lines = ["Name: %s" % name]
         description = cpp_info.description or "Conan package: %s" % name
         lines.append("Description: %s" % description)
         lines.append("Version: %s" % cpp_info.version)
 
-        if cpp_info.public_deps:
-            public_deps = " ".join(cpp_info.public_deps)
+        if comp_gennames:
+            public_deps = " ".join(comp_gennames)
             lines.append("Requires: %s" % public_deps)
         return "\n".join(lines) + "\n"
 

--- a/conans/client/generators/pkg_config.py
+++ b/conans/client/generators/pkg_config.py
@@ -76,7 +76,8 @@ class PkgConfigGenerator(Generator):
         for depname, cpp_info in self.deps_build_info.dependencies:
             pkg_genname = cpp_info.get_name(PkgConfigGenerator.name)
             if not cpp_info.components:
-                ret["%s.pc" % pkg_genname] = self.single_pc_file_contents(pkg_genname, cpp_info, None)
+                ret["%s.pc" % pkg_genname] = self.single_pc_file_contents(pkg_genname, cpp_info,
+                                                                          cpp_info.public_deps)
             else:
                 components = self._get_components(depname, cpp_info)
                 for comp_genname, comp, comp_requires_gennames in components:

--- a/conans/test/functional/generators/components/pkg_config_test.py
+++ b/conans/test/functional/generators/components/pkg_config_test.py
@@ -1,11 +1,8 @@
 import os
-import platform
 import textwrap
 import unittest
 
-from nose.plugins.attrib import attr
-
-from conans.client.tools import which, PkgConfig, environment_append
+from conans.client.tools import PkgConfig, environment_append
 from conans.model.ref import ConanFileReference
 from conans.test.utils.genconanfile import GenConanfile
 from conans.test.utils.tools import TestClient


### PR DESCRIPTION
Changelog: Fix: Do not override value of `public_deps` in `pkg_config` generator.
Docs: omit

close https://github.com/conan-io/conan/issues/7474

The issue happens only when the `cmake`/`cmake_find_pakcage` generator is generated after `pkg_config` one. The order of generators is not always the same (not reproducible).

Support for components in `pkg_config` generator was introduced here: https://github.com/conan-io/conan/pull/7413