### PR TITLE
Relax python six dependency to allow 1.15.

### DIFF
--- a/conans/requirements.txt
+++ b/conans/requirements.txt
@@ -5,7 +5,7 @@ colorama>=0.3.3, <0.5.0
 PyYAML>=3.11, <6.0
 patch-ng>=1.17.4, <1.18
 fasteners>=0.14.1
-six>=1.10.0,<=1.14.0
+six>=1.10.0,<=1.15.0
 node-semver==0.6.1
 distro>=1.0.2, <1.2.0
 future>=0.16.0, <0.19.0


### PR DESCRIPTION
The diff between six-1.14.0 and six-1.15.0 only changes the order of the checks isinstance(x, text_type) and isinstance(x, binary_type) in functions ensure_binary and ensure_string.

1. Since text_type and binary_type are disjoint types this can't affect any logic.
2. None of the two functions is used by conan right now.