### PR TITLE
Adds support of URL-like git ssh syntax

### DIFF
--- a/conans/client/tools/scm.py
+++ b/conans/client/tools/scm.py
@@ -78,6 +78,8 @@ class SCMBase(object):
         netloc = parsed.hostname
         if parsed.port:
             netloc += ":{}".format(parsed.port)
+        if parsed.username and parsed.scheme == "ssh":
+            netloc = "{}@{}".format(parsed.username, netloc)
         replaced = parsed._replace(netloc=netloc)
         return replaced.geturl()
 

--- a/conans/test/unittests/client/tools/scm/test_scm_base.py
+++ b/conans/test/unittests/client/tools/scm/test_scm_base.py
@@ -29,6 +29,10 @@ class RemoveCredentialsTest(unittest.TestCase):
         self.assertEqual('ssh://git@github.com:2222/conan-io/conan.git',
                          SCMBase._remove_credentials_url(
                              'ssh://git@github.com:2222/conan-io/conan.git'))
+        # URL-like syntax with a password
+        self.assertEqual('ssh://git@github.com:2222/conan-io/conan.git',
+                         SCMBase._remove_credentials_url(
+                             'ssh://git:password@github.com:2222/conan-io/conan.git'))
         # scp-like syntax
         self.assertEqual('git@github.com:conan-io/conan.git',
                          SCMBase._remove_credentials_url(

--- a/conans/test/unittests/client/tools/scm/test_scm_base.py
+++ b/conans/test/unittests/client/tools/scm/test_scm_base.py
@@ -25,6 +25,11 @@ class RemoveCredentialsTest(unittest.TestCase):
 
     def test_ssh(self):
         # Here, for ssh, we don't want to remove the user ('git' in this example)
+        # URL-like syntax
+        self.assertEqual('ssh://git@github.com:2222/conan-io/conan.git',
+                         SCMBase._remove_credentials_url(
+                             'ssh://git@github.com:2222/conan-io/conan.git'))
+        # scp-like syntax
         self.assertEqual('git@github.com:conan-io/conan.git',
                          SCMBase._remove_credentials_url(
                              'git@github.com:conan-io/conan.git'))


### PR DESCRIPTION
Changelog: Fix: Adds support of URL-like git ssh syntax.
Docs: omit

This PR fixes adds support of URL-like addresses mentioned #5833 (as for me, it was a regression introduced in #4207)

According to https://git-scm.com/book/en/v2/Git-on-the-Server-The-Protocols git supports two kinds of addresses, URL-like: ssh://[user@]server/project.git and scp-like: [user@]server:project.git

- [x] Refer to the issue that supports this Pull Request.
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 

#PYVERS: Macos@py27, Windows@py36, Linux@py27


closes #5833 