### PR TITLE
Bugfix: correctly set CMAKE_OSX_SYSROOT and CMAKE_OSX_ARCHITECTURES

### DIFF
--- a/conans/client/build/cmake_flags.py
+++ b/conans/client/build/cmake_flags.py
@@ -295,7 +295,7 @@ class CMakeDefinitionsBuilder(object):
                                                  self._generator, self._output))
 
         # don't attempt to override variables set within toolchain
-        if tools.is_apple_os(os_) and "CONAN_CMAKE_TOOLCHAIN_FILE" not in os.environ:
+        if tools.is_apple_os(os_) and "CONAN_CMAKE_TOOLCHAIN_FILE" not in os.environ and "CMAKE_TOOLCHAIN_FILE" not in definitions:
             apple_arch = tools.to_apple_arch(arch)
             if apple_arch:
                 definitions["CMAKE_OSX_ARCHITECTURES"] = apple_arch

--- a/conans/client/build/cmake_flags.py
+++ b/conans/client/build/cmake_flags.py
@@ -294,12 +294,18 @@ class CMakeDefinitionsBuilder(object):
         definitions.update(build_type_definition(self._forced_build_type, build_type,
                                                  self._generator, self._output))
 
-        if tools.is_apple_os(os_):
-            definitions["CMAKE_OSX_ARCHITECTURES"] = tools.to_apple_arch(arch)
+        # don't attempt to override variables set within toolchain
+        if tools.is_apple_os(os_) and "CONAN_CMAKE_TOOLCHAIN_FILE" not in os.environ:
+            apple_arch = tools.to_apple_arch(arch)
+            if apple_arch:
+                definitions["CMAKE_OSX_ARCHITECTURES"] = apple_arch
             # xcrun is only available on macOS, otherwise it's cross-compiling and it needs to be
-            # set within CMake toolchain
-            if platform.system() == "Darwin":
-                definitions["CMAKE_OSX_SYSROOT"] = tools.XCRun(self._conanfile.settings).sdk_path
+            # set within CMake toolchain. also, if SDKROOT is set, CMake will use it, and it's not
+            # needed to run xcrun.
+            if platform.system() == "Darwin" and "SDKROOT" not in os.environ:
+                sdk_path = tools.XCRun(self._conanfile.settings).sdk_path
+                if sdk_path:
+                    definitions["CMAKE_OSX_SYSROOT"] = sdk_path
 
         definitions.update(self._cmake_cross_build_defines())
         definitions.update(self._get_cpp_standard_vars())

--- a/conans/client/tools/apple.py
+++ b/conans/client/tools/apple.py
@@ -32,13 +32,11 @@ def apple_sdk_name(settings):
                 'iOS': 'iphonesimulator',
                 'watchOS': 'watchsimulator',
                 'tvOS': 'appletvsimulator'}.get(str(os_))
-    elif str(arch).startswith('arm'):
-        return {'iOS': 'iphoneos',
-                'watchOS': 'watchos',
-                'tvOS': 'appletvos'}.get(str(os_))
     else:
-        return None
-
+        return {'Macos': 'macosx',
+                'iOS': 'iphoneos',
+                'watchOS': 'watchos',
+                'tvOS': 'appletvos'}.get(str(os_), None)
 
 def apple_deployment_target_env(os_, os_version):
     """environment variable name which controls deployment target"""

--- a/conans/test/functional/build_helpers/cmake_apple_test.py
+++ b/conans/test/functional/build_helpers/cmake_apple_test.py
@@ -1,0 +1,59 @@
+import platform
+import unittest
+from parameterized import parameterized
+
+from conans.client.build.cmake import CMake
+from conans.client.conf import get_default_settings_yml
+from conans.model.settings import Settings
+from conans.test.utils.mocks import MockSettings, ConanFileMock
+
+
+@unittest.skipUnless(platform.system() == "Darwin", "Only for MacOS")
+class CMakeAppleTest(unittest.TestCase):
+    @parameterized.expand([('x86', 'Macos', 'i386', 'MacOSX.platform'),
+                           ('x86_64', 'Macos', 'x86_64', 'MacOSX.platform'),
+                           ('armv7', 'Macos', 'armv7', 'MacOSX.platform'),
+                           ('armv8', 'Macos', 'arm64', 'MacOSX.platform'),
+                           ('x86', 'iOS', 'i386', 'iPhoneSimulator.platform'),
+                           ('x86_64', 'iOS', 'x86_64', 'iPhoneSimulator.platform'),
+                           ('armv7', 'iOS', 'armv7', 'iPhoneOS.platform'),
+                           ('armv8', 'iOS', 'arm64', 'iPhoneOS.platform'),
+                           ('x86', 'watchOS', 'i386', 'WatchSimulator.platform'),
+                           ('x86_64', 'watchOS', 'x86_64', 'WatchSimulator.platform'),
+                           ('armv7', 'watchOS', 'armv7', 'WatchOS.platform'),
+                           ('armv8', 'watchOS', 'arm64', 'WatchOS.platform'),
+                           ('x86', 'tvOS', 'i386', 'AppleTVSimulator.platform'),
+                           ('x86_64', 'tvOS', 'x86_64', 'AppleTVSimulator.platform'),
+                           ('armv7', 'tvOS', 'armv7', 'AppleTVOS.platform'),
+                           ('armv8', 'tvOS', 'arm64', 'AppleTVOS.platform')
+                           ])
+    def test_cmake_definitions(self, conan_arch, conan_os, expected_arch, expected_os):
+        settings = Settings.loads(get_default_settings_yml())
+        settings.os = conan_os
+        settings.compiler = "apple-clang"
+        settings.compiler.version = "11.0"
+        settings.arch = conan_arch
+
+        conanfile = ConanFileMock()
+        conanfile.settings = settings
+        cmake = CMake(conanfile)
+
+        self.assertEqual(cmake.definitions["CMAKE_OSX_ARCHITECTURES"], expected_arch)
+        self.assertIn(expected_os, cmake.definitions["CMAKE_OSX_SYSROOT"])
+
+    @parameterized.expand([('iOS', 'iPhoneOS.platform'),
+                           ('Macos', 'MacOSX.platform'),
+                           ('watchOS', 'WatchOS.platform'),
+                           ('tvOS', 'AppleTVOS.platform')
+                           ])
+    def test_custom_settings(self, conan_os, expected_os):
+        settings = MockSettings({"os": conan_os,
+                                 "compiler": "apple-clang",
+                                 "compiler.version": "11.0",
+                                 "arch": "ios_fat"})
+        conanfile = ConanFileMock()
+        conanfile.settings = settings
+        cmake = CMake(conanfile)
+
+        self.assertNotIn("CMAKE_OSX_ARCHITECTURES", cmake.definitions)
+        self.assertIn(expected_os, cmake.definitions["CMAKE_OSX_SYSROOT"])

--- a/conans/test/unittests/util/apple_test.py
+++ b/conans/test/unittests/util/apple_test.py
@@ -42,7 +42,6 @@ class AppleTest(unittest.TestCase):
         self.assertIsNone(tools.to_apple_arch('mips'))
 
     def test_apple_sdk_name(self):
-
         self.assertEqual(tools.apple_sdk_name(FakeSettings('Macos', 'x86')), 'macosx')
         self.assertEqual(tools.apple_sdk_name(FakeSettings('Macos', 'x86_64')), 'macosx')
         self.assertEqual(tools.apple_sdk_name(FakeSettings('iOS', 'x86_64')), 'iphonesimulator')
@@ -52,6 +51,13 @@ class AppleTest(unittest.TestCase):
         self.assertEqual(tools.apple_sdk_name(FakeSettings('tvOS', 'x86')), 'appletvsimulator')
         self.assertEqual(tools.apple_sdk_name(FakeSettings('tvOS', 'armv8')), 'appletvos')
         self.assertIsNone(tools.apple_sdk_name(FakeSettings('Windows', 'x86')))
+
+    def test_apple_sdk_name_custom_settings(self):
+        self.assertEqual(tools.apple_sdk_name(FakeSettings('Macos', 'ios_fat')), 'macosx')
+        self.assertEqual(tools.apple_sdk_name(FakeSettings('iOS', 'ios_fat')), 'iphoneos')
+        self.assertEqual(tools.apple_sdk_name(FakeSettings('watchOS', 'ios_fat')), 'watchos')
+        self.assertEqual(tools.apple_sdk_name(FakeSettings('tvOS', 'ios_fat')), 'appletvos')
+        self.assertIsNone(tools.apple_sdk_name(FakeSettings('ConanOS', 'ios_fat')))
 
     def test_deployment_target_env_name(self):
         self.assertEqual(tools.apple_deployment_target_env('Macos', "10.1"),


### PR DESCRIPTION
closes: #7493 

Changelog: Bugfix: correctly set `CMAKE_OSX_SYSROOT` and `CMAKE_OSX_ARCHITECTURES`.
Docs: omit

what exactly has been fixed?

- custom setting (e.g. `arch=ios_far`) will not result in `-DCMAKE_OSX_ARCHITECTURES="None"`
- return correct SDK root (e.g. `iPhoneOS.platform`) for custom settings (e.g. `os=iOS` and `arch=ios_fat`)
- it's redundant to invoke `xcrun` if environment variable `SDKROOT` was set - CMake will use it anyway
- don't try to set `CMAKE_OSX_ARCHITECTURES`/`CMAKE_OSX_SYSROOT` if toolchain file is used (see comment as well)

- [x] Refer to the issue that supports this Pull Request.
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 

<sup>**Note:** By default this PR will skip the slower tests and will use a limited set of python versions. Check [here](https://github.com/conan-io/conan/blob/develop/.github/PR_INCREASE_TESTING.md) how to increase the testing level by writing some tags in the current PR body text.</sup>
