### PR TITLE
set component version

### DIFF
--- a/conans/client/installer.py
+++ b/conans/client/installer.py
@@ -572,7 +572,8 @@ class BinaryInstaller(object):
         add_env_conaninfo(conan_file, subtree_libnames)
 
     def _call_package_info(self, conanfile, package_folder, ref):
-        conanfile.cpp_info = CppInfo(conanfile.name, package_folder, conanfile.version)
+        conanfile.cpp_info = CppInfo(conanfile.name, package_folder)
+        conanfile.cpp_info.version = conanfile.version
         conanfile.cpp_info.description = conanfile.description
         conanfile.env_info = EnvInfo()
         conanfile.user_info = UserInfo()

--- a/conans/client/installer.py
+++ b/conans/client/installer.py
@@ -595,6 +595,8 @@ class BinaryInstaller(object):
                     self._hook_manager.execute("pre_package_info", conanfile=conanfile,
                                                reference=ref)
                     conanfile.package_info()
+                    for comp_name in conanfile.cpp_info.components:
+                        conanfile.cpp_info.components[comp_name].version = conanfile.cpp_info.version
                     if conanfile._conan_dep_cpp_info is None:
                         try:
                             conanfile.cpp_info._raise_incorrect_components_definition(

--- a/conans/client/installer.py
+++ b/conans/client/installer.py
@@ -572,8 +572,7 @@ class BinaryInstaller(object):
         add_env_conaninfo(conan_file, subtree_libnames)
 
     def _call_package_info(self, conanfile, package_folder, ref):
-        conanfile.cpp_info = CppInfo(conanfile.name, package_folder)
-        conanfile.cpp_info.version = conanfile.version
+        conanfile.cpp_info = CppInfo(conanfile.name, package_folder, conanfile.version)
         conanfile.cpp_info.description = conanfile.description
         conanfile.env_info = EnvInfo()
         conanfile.user_info = UserInfo()
@@ -595,8 +594,6 @@ class BinaryInstaller(object):
                     self._hook_manager.execute("pre_package_info", conanfile=conanfile,
                                                reference=ref)
                     conanfile.package_info()
-                    for comp_name in conanfile.cpp_info.components:
-                        conanfile.cpp_info.components[comp_name].version = conanfile.cpp_info.version
                     if conanfile._conan_dep_cpp_info is None:
                         try:
                             conanfile.cpp_info._raise_incorrect_components_definition(

--- a/conans/model/build_info.py
+++ b/conans/model/build_info.py
@@ -166,7 +166,7 @@ class _CppInfo(object):
 
 class Component(_CppInfo):
 
-    def __init__(self, rootpath):
+    def __init__(self, rootpath, version = None):
         super(Component, self).__init__()
         self.rootpath = rootpath
         self.includedirs.append(DEFAULT_INCLUDE)
@@ -176,6 +176,7 @@ class Component(_CppInfo):
         self.builddirs.append(DEFAULT_BUILD)
         self.frameworkdirs.append(DEFAULT_FRAMEWORK)
         self.requires = []
+        self.version = version
 
 
 class CppInfo(_CppInfo):
@@ -185,7 +186,7 @@ class CppInfo(_CppInfo):
     Defined in user CONANFILE, directories are relative at user definition time
     """
 
-    def __init__(self, ref_name, root_folder):
+    def __init__(self, ref_name, root_folder, version = None):
         super(CppInfo, self).__init__()
         self._ref_name = ref_name
         self._name = ref_name
@@ -196,7 +197,8 @@ class CppInfo(_CppInfo):
         self.resdirs.append(DEFAULT_RES)
         self.builddirs.append(DEFAULT_BUILD)
         self.frameworkdirs.append(DEFAULT_FRAMEWORK)
-        self.components = DefaultOrderedDict(lambda: Component(self.rootpath))
+        self.version = version
+        self.components = DefaultOrderedDict(lambda: Component(self.rootpath, self.version))
         # public_deps is needed to accumulate list of deps for cmake targets
         self.public_deps = []
         self._configs = {}

--- a/conans/model/build_info.py
+++ b/conans/model/build_info.py
@@ -166,7 +166,7 @@ class _CppInfo(object):
 
 class Component(_CppInfo):
 
-    def __init__(self, rootpath, version = None):
+    def __init__(self, rootpath, version):
         super(Component, self).__init__()
         self.rootpath = rootpath
         self.includedirs.append(DEFAULT_INCLUDE)
@@ -186,7 +186,7 @@ class CppInfo(_CppInfo):
     Defined in user CONANFILE, directories are relative at user definition time
     """
 
-    def __init__(self, ref_name, root_folder, version = None):
+    def __init__(self, ref_name, root_folder):
         super(CppInfo, self).__init__()
         self._ref_name = ref_name
         self._name = ref_name
@@ -197,7 +197,6 @@ class CppInfo(_CppInfo):
         self.resdirs.append(DEFAULT_RES)
         self.builddirs.append(DEFAULT_BUILD)
         self.frameworkdirs.append(DEFAULT_FRAMEWORK)
-        self.version = version
         self.components = DefaultOrderedDict(lambda: Component(self.rootpath, self.version))
         # public_deps is needed to accumulate list of deps for cmake targets
         self.public_deps = []

--- a/conans/test/functional/generators/components/pkg_config_test.py
+++ b/conans/test/functional/generators/components/pkg_config_test.py
@@ -80,6 +80,8 @@ class PkgConfigGeneratorWithComponentsTest(unittest.TestCase):
         self.assertNotIn("Requires:", client.load(os.path.join(client.current_folder, "bye.pc")))
         self.assertIn("Requires: bye hello",
                       client.load(os.path.join(client.current_folder, "greetings.pc")))
+        for f in ["hello.pc", "bye.pc", "greetings.pc", "world.pc", "helloworld.pc", "worldall.pc"]:
+            self.assertIn("Version: 0.0.1", client.load(os.path.join(client.current_folder, f)))
         libs = self._get_libs_from_pkg_config("greetings", client.current_folder)
         self.assertListEqual(["-lbye", "-lhello"], libs)
 
@@ -113,6 +115,8 @@ class PkgConfigGeneratorWithComponentsTest(unittest.TestCase):
         self.assertListEqual(["-lHelloworld", "-lhello"], libs)
         libs = self._get_libs_from_pkg_config("World", client.current_folder)
         self.assertListEqual(["-lWorldall", "-lbye", "-lHelloworld", "-lhello"], libs)
+        for f in ["Hello.pc", "Bye.pc", "Greetings.pc", "World.pc", "Helloworld.pc", "Worldall.pc"]:
+            self.assertIn("Version: 0.0.1", client.load(os.path.join(client.current_folder, f)))
 
     def pkg_config_components_test(self):
         client = TestClient()
@@ -142,6 +146,8 @@ class PkgConfigGeneratorWithComponentsTest(unittest.TestCase):
         self.assertIn("Requires: helloworld worldall", world_pc)
         libs = self._get_libs_from_pkg_config("world", client.current_folder)
         self.assertListEqual(["-lworldall", "-lhelloworld", "-lhello", "-lbye"], libs)
+        for f in ["hello.pc", "bye.pc", "greetings.pc", "world.pc", "helloworld.pc", "worldall.pc"]:
+            self.assertIn("Version: 0.0.1", client.load(os.path.join(client.current_folder, f)))
 
     def recipe_with_components_requiring_recipe_without_components_test(self):
         client = TestClient()
@@ -177,6 +183,8 @@ class PkgConfigGeneratorWithComponentsTest(unittest.TestCase):
         self.assertListEqual(["-lhelloworld", "-lhello", "-lbye"], libs)
         libs = self._get_libs_from_pkg_config("worldall", client.current_folder)
         self.assertListEqual(["-lworldall", "-lhelloworld", "-lhello", "-lbye"], libs)
+        for f in ["greetings.pc", "world.pc", "helloworld.pc", "worldall.pc"]:
+            self.assertIn("Version: 0.0.1", client.load(os.path.join(client.current_folder, f)))
 
     def same_names_test(self):
         client = TestClient()
@@ -196,6 +204,7 @@ class PkgConfigGeneratorWithComponentsTest(unittest.TestCase):
         client.run("create .")
         client.run("install hello/0.0.1@ -g pkg_config")
         self.assertNotIn("Requires:", client.load(os.path.join(client.current_folder, "hello.pc")))
+        self.assertIn("Version: 0.0.1", client.load(os.path.join(client.current_folder, "hello.pc")))
 
     def component_not_found_same_name_as_pkg_require_test(self):
         zlib = GenConanfile("zlib", "0.1").with_setting("build_type")\


### PR DESCRIPTION
fixes #7467

Changelog: Bugfix: Propagate the global version of the recipe for components.
Docs: Omit

- [X] Refer to the issue that supports this Pull Request.
- [ ] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [X] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [X] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 

<sup>**Note:** By default this PR will skip the slower tests and will use a limited set of python versions. Check [here](https://github.com/conan-io/conan/blob/develop/.github/PR_INCREASE_TESTING.md) how to increase the testing level by writing some tags in the current PR body text.</sup>
