### PR TITLE
tools.PkgConfig: expose version

### DIFF
--- a/conans/client/tools/pkg_config.py
+++ b/conans/client/tools/pkg_config.py
@@ -100,3 +100,7 @@ class PkgConfig(object):
             for name in variable_names:
                 self._variables[name] = self._parse_output('variable=%s' % name)
         return self._variables
+
+    @property
+    def version(self):
+        return self._get_option('modversion')

--- a/conans/test/unittests/util/pkg_config_test.py
+++ b/conans/test/unittests/util/pkg_config_test.py
@@ -57,6 +57,8 @@ class PkgConfigTest(unittest.TestCase):
             self.assertEqual(frozenset(pkg_config.libs_only_other), frozenset(['-Wl,--whole-archive']))
 
             self.assertEqual(pkg_config.variables['prefix'], '/usr/local')
+
+            self.assertEqual(frozenset(pkg_config.version), frozenset(['6.6.6']))
         os.unlink(filename)
 
     def test_define_prefix(self):
@@ -81,6 +83,8 @@ class PkgConfigTest(unittest.TestCase):
             self.assertEqual(frozenset(pkg_config.libs_only_other), frozenset(['-Wl,--whole-archive']))
 
             self.assertEqual(pkg_config.variables['prefix'], '/home/conan')
+
+            self.assertEqual(frozenset(pkg_config.version), frozenset(['6.6.6']))
         os.unlink(filename)
 
     def rpaths_libs_test(self):


### PR DESCRIPTION
Changelog: Feature: `PkgConfig` tools now exposes the packages's version as property.
Docs: https://github.com/conan-io/docs/pull/1820

- [ ] Refer to the issue that supports this Pull Request.
- [ ] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [X] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [X] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 

<sup>**Note:** By default this PR will skip the slower tests and will use a limited set of python versions. Check [here](https://github.com/conan-io/conan/blob/develop/.github/PR_INCREASE_TESTING.md) how to increase the testing level by writing some tags in the current PR body text.</sup>
