### PR TITLE
Include prerrelease versions when resolving required_conan_version

### DIFF
--- a/conans/client/conf/required_version.py
+++ b/conans/client/conf/required_version.py
@@ -5,7 +5,7 @@ from conans.errors import ConanException
 
 
 def validate_conan_version(required_range):
-    result = satisfies(client_version, required_range, loose=True)
+    result = satisfies(client_version, required_range, loose=True, include_prerelease=True)
     if not result:
         raise ConanException("Current Conan version ({}) does not satisfy "
                              "the defined one ({}).".format(client_version, required_range))

--- a/conans/test/functional/conanfile/required_conan_version_test.py
+++ b/conans/test/functional/conanfile/required_conan_version_test.py
@@ -29,6 +29,9 @@ class RequiredConanVersionTest(unittest.TestCase):
         with mock.patch("conans.client.conf.required_version.client_version", "101.0"):
             client.run("export . pkg/1.0@")
 
+        with mock.patch("conans.client.conf.required_version.client_version", "101.0-dev"):
+            client.run("export . pkg/1.0@")
+
         client.run("install pkg/1.0@", assert_error=True)
         self.assertIn("Current Conan version (%s) does not satisfy the defined one (>=100.0)"
                       % __version__, client.out)


### PR DESCRIPTION
Changelog: Fix: Add pre-release versions when resolving `required_conan_version`.
Docs: omit

When resolving `required_conan_version`, Conan did not take into account the prerelease versions, so for example 1.29.0-dev was not being resolved as `>=1.28.0` so [this](https://travis-ci.org/github/conan-io/examples/jobs/716516466) was failing.

- [ ] Refer to the issue that supports this Pull Request.
- [X] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [X] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [X] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 

<sup>**Note:** By default this PR will skip the slower tests and will use a limited set of python versions. Check [here](https://github.com/conan-io/conan/blob/develop/.github/PR_INCREASE_TESTING.md) how to increase the testing level by writing some tags in the current PR body text.</sup>
