### PR TITLE
Import 'collections.Iterable' py2/3 compatible

### DIFF
--- a/conans/util/misc.py
+++ b/conans/util/misc.py
@@ -2,7 +2,7 @@ import six
 
 try:
     from collections.abc import Iterable
-except ImportError:  # python2 fallback
+except ImportError:  # FIXME: Remove if Python2 support is removed
     from collections import Iterable
 
 

--- a/conans/util/misc.py
+++ b/conans/util/misc.py
@@ -1,4 +1,8 @@
 import six
+try:
+    from collections import Iterable
+except ImportError:
+    from collections.abc import Iterable
 
 
 def make_tuple(value):
@@ -12,7 +16,7 @@ def make_tuple(value):
     if isinstance(value, six.string_types):
         return value,
 
-    if isinstance(value, six.moves.collections_abc.Iterable):
+    if isinstance(value, Iterable):
         return tuple(value)
     else:
         return value,

--- a/conans/util/misc.py
+++ b/conans/util/misc.py
@@ -1,8 +1,9 @@
 import six
+
 try:
-    from collections import Iterable
-except ImportError:
     from collections.abc import Iterable
+except ImportError:  # python2 fallback
+    from collections import Iterable
 
 
 def make_tuple(value):


### PR DESCRIPTION
Changelog: Bugfix: Fix import of `collections.Iterable` compatible with Python2.
Docs: omit

close https://github.com/conan-io/conan/issues/7520

#PYVERS: Linux@py27, py36
