### PR TITLE
Use clean_dirty after removing packages, remove entry from metadata

### DIFF
--- a/conans/client/cmd/export.py
+++ b/conans/client/cmd/export.py
@@ -17,7 +17,7 @@ from conans.model.scm import SCM, get_scm_data
 from conans.paths import CONANFILE, DATA_YML
 from conans.search.search import search_recipes, search_packages
 from conans.util.files import is_dirty, load, rmdir, save, set_dirty, remove, mkdir, \
-    merge_directories
+    merge_directories, clean_dirty
 from conans.util.log import logger
 
 isPY38 = bool(sys.version_info.major == 3 and sys.version_info.minor == 8)
@@ -178,6 +178,7 @@ def cmd_export(app, conanfile_path, name, version, user, channel, keep_source,
             if is_dirty(source_folder):
                 output.info("Source folder is corrupted, forcing removal")
                 rmdir(source_folder)
+                clean_dirty(source_folder)
             elif modified_recipe and not keep_source:
                 output.info("Package recipe modified in export, forcing source folder removal")
                 output.info("Use the --keep-source, -k option to skip it")
@@ -216,14 +217,14 @@ def _check_settings_for_warnings(conanfile, output):
         if 'os' not in conanfile.settings:
             return
 
-        output.writeln("*"*60, front=Color.BRIGHT_RED)
+        output.writeln("*" * 60, front=Color.BRIGHT_RED)
         output.writeln("  This package defines both 'os' and 'os_build' ",
                        front=Color.BRIGHT_RED)
         output.writeln("  Please use 'os' for libraries and 'os_build'",
                        front=Color.BRIGHT_RED)
         output.writeln("  only for build-requires used for cross-building",
                        front=Color.BRIGHT_RED)
-        output.writeln("*"*60, front=Color.BRIGHT_RED)
+        output.writeln("*" * 60, front=Color.BRIGHT_RED)
     except ConanException:
         pass
 
@@ -336,10 +337,10 @@ def _replace_scm_data_in_conanfile(conanfile_path, scm_data):
                                 if i_body + 1 == len(tree.body):  # Last statement over all
                                     next_line = len(lines)
                                 else:
-                                    next_line = tree.body[i_body+1].lineno - 1
+                                    next_line = tree.body[i_body + 1].lineno - 1
                             else:
                                 # Next statement can be a comment or anything else
-                                next_statement = statements[i+1]
+                                next_statement = statements[i + 1]
                                 if isPY38 and isinstance(next_statement, ast.Expr):
                                     # Python 3.8 properly parses multiline comments with start
                                     # and end lines, here we preserve the same (wrong)
@@ -349,11 +350,11 @@ def _replace_scm_data_in_conanfile(conanfile_path, scm_data):
                                     next_line = next_statement.lineno - 1
                                 next_line_content = lines[next_line].strip()
                                 if (next_line_content.endswith('"""') or
-                                        next_line_content.endswith("'''")):
+                                    next_line_content.endswith("'''")):
                                     next_line += 1
                         except IndexError:
                             next_line = stmt.lineno
-                        replace = [line for line in lines[(stmt.lineno-1):next_line]]
+                        replace = [line for line in lines[(stmt.lineno - 1):next_line]]
                         to_replace.append("".join(replace).lstrip())
                         comments = [line.strip('\n') for line in replace
                                     if line.strip().startswith("#") or not line.strip()]
@@ -461,7 +462,7 @@ def export_source(conanfile, origin_folder, destination_source_folder):
                              "use 'export_sources()' instead")
 
     if isinstance(conanfile.exports_sources, str):
-        conanfile.exports_sources = (conanfile.exports_sources, )
+        conanfile.exports_sources = (conanfile.exports_sources,)
 
     included_sources, excluded_sources = _classify_patterns(conanfile.exports_sources)
     copier = FileCopier([origin_folder], destination_source_folder)
@@ -478,7 +479,7 @@ def export_recipe(conanfile, origin_folder, destination_folder):
     if callable(conanfile.exports):
         raise ConanException("conanfile 'exports' shouldn't be a method, use 'export()' instead")
     if isinstance(conanfile.exports, str):
-        conanfile.exports = (conanfile.exports, )
+        conanfile.exports = (conanfile.exports,)
 
     output = conanfile.output
     package_output = ScopedOutput("%s exports" % output.scope, output)

--- a/conans/client/installer.py
+++ b/conans/client/installer.py
@@ -78,6 +78,7 @@ class _PackageBuilder(object):
         if is_dirty(build_folder):
             self._output.warn("Build folder is dirty, removing it: %s" % build_folder)
             rmdir(build_folder)
+            clean_dirty(build_folder)
 
         # Decide if the build folder should be kept
         skip_build = conanfile.develop and keep_build

--- a/conans/client/source.py
+++ b/conans/client/source.py
@@ -12,7 +12,7 @@ from conans.model.scm import SCM, get_scm_data
 from conans.paths import CONANFILE, CONAN_MANIFEST, EXPORT_SOURCES_TGZ_NAME, EXPORT_TGZ_NAME
 from conans.util.conan_v2_mode import conan_v2_property
 from conans.util.files import (set_dirty, is_dirty, mkdir, rmdir, set_dirty_context_manager,
-                               merge_directories)
+                               merge_directories, clean_dirty)
 
 
 def complete_recipe_sources(remote_manager, cache, conanfile, ref, remotes):
@@ -72,7 +72,7 @@ def config_source(export_folder, export_source_folder, scm_sources_folder,
     local cache.
     """
 
-    def remove_source(raise_error=True):
+    def remove_source():
         output.warn("This can take a while for big packages")
         try:
             rmdir(src_folder)
@@ -83,15 +83,16 @@ def config_source(export_folder, export_source_folder, scm_sources_folder,
                 msg = str(e_rm).decode("latin1")  # Windows prints some chars in latin1
             output.error("Unable to remove source folder %s\n%s" % (src_folder, msg))
             output.warn("**** Please delete it manually ****")
-            if raise_error or isinstance(e_rm, KeyboardInterrupt):
-                raise ConanException("Unable to remove source folder")
+            raise ConanException("Unable to remove source folder")
 
     if is_dirty(src_folder):
         output.warn("Trying to remove corrupted source folder")
         remove_source()
+        clean_dirty(src_folder)
     elif conanfile.build_policy_always:
         output.warn("Detected build_policy 'always', trying to remove source folder")
         remove_source()
+        clean_dirty(src_folder)
 
     if not os.path.exists(src_folder):  # No source folder, need to get it
         with set_dirty_context_manager(src_folder):

--- a/conans/client/source.py
+++ b/conans/client/source.py
@@ -92,7 +92,6 @@ def config_source(export_folder, export_source_folder, scm_sources_folder,
     elif conanfile.build_policy_always:
         output.warn("Detected build_policy 'always', trying to remove source folder")
         remove_source()
-        clean_dirty(src_folder)
 
     if not os.path.exists(src_folder):  # No source folder, need to get it
         with set_dirty_context_manager(src_folder):

--- a/conans/test/functional/command/export/export_dirty_test.py
+++ b/conans/test/functional/command/export/export_dirty_test.py
@@ -75,7 +75,7 @@ class ExportDirtyTest(unittest.TestCase):
         self.client.run("export . lasote/stable")
         self.assertIn("Source folder is corrupted, forcing removal", self.client.out)
         self.client.run("install Hello0/0.1@lasote/stable --build")
-        self.assertIn("WARN: Trying to remove corrupted source folder", self.client.out)
+        self.assertNotIn("WARN: Trying to remove corrupted source folder", self.client.out)
 
     def test_install_remove(self):
         # install is also able to remove dirty source folders


### PR DESCRIPTION
Changelog: omit
Docs: omit

 * Use `clean_dirty` after removing _dirty folder_, it removes the `xxxxx.dirty` file too. It is a pattern repeated in several places that we could turn into a function
 * After removing a package from the cache (_"The package {} doesn't belong to the installed recipe revision, removing folder"_), update the `metadata.json` accordingly.
