### PR TITLE
Add user_info_build to JSON generator

### DIFF
--- a/conans/client/generators/json_generator.py
+++ b/conans/client/generators/json_generator.py
@@ -22,6 +22,13 @@ def serialize_cpp_info(cpp_info):
     return res
 
 
+def serialize_user_info(user_info):
+    res = {}
+    for key, value in user_info.items():
+        res[key] = value.vars
+    return res
+
+
 class JsonGenerator(Generator):
     @property
     def filename(self):
@@ -31,17 +38,14 @@ class JsonGenerator(Generator):
     def content(self):
         info = {}
         info["deps_env_info"] = self.deps_env_info.vars
-        info["deps_user_info"] = self.get_deps_user_info()
+        info["deps_user_info"] = serialize_user_info(self.deps_user_info)
         info["dependencies"] = self.get_dependencies_info()
         info["settings"] = self.get_settings()
         info["options"] = self.get_options()
-        return json.dumps(info, indent=2)
+        if self._user_info_build:
+            info["user_info_build"] = serialize_user_info(self._user_info_build)
 
-    def get_deps_user_info(self):
-        res = {}
-        for key, value in self.deps_user_info.items():
-            res[key] = value.vars
-        return res
+        return json.dumps(info, indent=2)
 
     def get_dependencies_info(self):
         res = []


### PR DESCRIPTION
Changelog: Feature: Add `user_info_build` field to JSON generator.
Docs: omit

(Not adding docs as it is from experimental feature)

closes https://github.com/conan-io/conan/issues/7448
