### PR TITLE
lockfiles with --base do not provide build-order

### DIFF
--- a/conans/client/conan_api.py
+++ b/conans/client/conan_api.py
@@ -1287,6 +1287,10 @@ class ConanAPIV1(object):
         lockfile = _make_abs_path(lockfile, cwd)
 
         graph_lock_file = GraphLockFile.load(lockfile, self.app.cache.config.revisions_enabled)
+        if graph_lock_file.profile_host is None:
+            raise ConanException("Lockfiles with --base do not contain profile information, "
+                                 "cannot be used. Create a full lockfile")
+
         graph_lock = graph_lock_file.graph_lock
         build_order = graph_lock.build_order()
         return build_order

--- a/conans/test/functional/graph_lock/build_order_test.py
+++ b/conans/test/functional/graph_lock/build_order_test.py
@@ -18,6 +18,14 @@ class BuildOrderTest(unittest.TestCase):
         jsonbo = json.loads(client.load("bo.json"))
         self.assertEqual([], jsonbo)
 
+    def test_base_graph(self):
+        client = TestClient()
+        client.save({"conanfile.py": GenConanfile("test4", "0.1")})
+        client.run("lock create conanfile.py --base --lockfile-out=conan.lock")
+        client.run("lock build-order conan.lock --json=bo.json", assert_error=True)
+        self.assertIn("Lockfiles with --base do not contain profile information, "
+                      "cannot be used. Create a full lockfile", client.out)
+
     @parameterized.expand([(True,), (False,)])
     def build_not_locked_test(self, export):
         # https://github.com/conan-io/conan/issues/5727


### PR DESCRIPTION
Changelog: Feature: Provide useful information trying to compute the build order using a `--base` lockfile.
Docs: omit

closes https://github.com/conan-io/conan/issues/7517