### PR TITLE
Update node-semver

### DIFF
--- a/conans/requirements.txt
+++ b/conans/requirements.txt
@@ -6,7 +6,8 @@ PyYAML>=3.11, <6.0
 patch-ng>=1.17.4, <1.18
 fasteners>=0.14.1
 six>=1.10.0,<=1.15.0
-node-semver==0.6.1
+node-semver>=0.8.0 ; python_version > '3'
+node-semver>=0.6.1, <0.8.0 ; python_version <= '2.7'
 distro>=1.0.2, <1.2.0
 future>=0.16.0, <0.19.0
 pygments>=2.0, <3.0

--- a/conans/test/unittests/client/tools/test_version.py
+++ b/conans/test/unittests/client/tools/test_version.py
@@ -107,5 +107,11 @@ class ToolVersionExtraComponentsTests(unittest.TestCase):
 
         # Unknown release field, not fail (loose=True) and don't affect compare
         self.assertTrue(Version.loose)
-        self.assertTrue(Version("1.2.3.4") == Version("1.2.3"))
+
+        # node-semver for PY2 has only <= 0.7.0 version, 0.8.0 fixed 4-digit support
+        if six.PY2:
+            self.assertTrue(Version("1.2.3.4") == Version("1.2.3"))
+        else:
+            self.assertFalse(Version("1.2.3.4") == Version("1.2.3"))
+            self.assertTrue(Version("1.2.3.4") >= Version("1.2.3"))
 


### PR DESCRIPTION
Changelog: Feature: Updated node-semver 0.8.0 dependency, which fixed support for 4-digit versions (https://github.com/podhmo/python-semver/pull/35).
Docs: none
