### PR TITLE
Add support for cpp_info.system_libs to QMake generator

### DIFF
--- a/conans/client/generators/qmake.py
+++ b/conans/client/generators/qmake.py
@@ -18,6 +18,7 @@ class DepsCppQmake(object):
         self.build_paths = multiline(cpp_info.build_paths)
 
         self.libs = " ".join('-l%s' % lib for lib in cpp_info.libs)
+        self.system_libs = " ".join('-l%s' % lib for lib in cpp_info.system_libs)
         self.defines = " \\\n    ".join('"%s"' % d for d in cpp_info.defines)
         self.cxxflags = " ".join(cpp_info.cxxflags)
         self.cflags = " ".join(cpp_info.cflags)
@@ -38,6 +39,7 @@ class QmakeGenerator(Generator):
 
         template = ('CONAN_INCLUDEPATH{dep_name}{build_type} += {deps.include_paths}\n'
                     'CONAN_LIBS{dep_name}{build_type} += {deps.libs}\n'
+                    'CONAN_SYSTEMLIBS{dep_name}{build_type} += {deps.system_libs}\n'
                     'CONAN_LIBDIRS{dep_name}{build_type} += {deps.lib_paths}\n'
                     'CONAN_BINDIRS{dep_name}{build_type} += {deps.bin_paths}\n'
                     'CONAN_RESDIRS{dep_name}{build_type} += {deps.res_paths}\n'
@@ -91,6 +93,12 @@ class QmakeGenerator(Generator):
         LIBS += $$CONAN_LIBDIRS_DEBUG
         BINDIRS += $$CONAN_BINDIRS_DEBUG
         DEFINES += $$CONAN_DEFINES_DEBUG
+    }
+    LIBS += $$CONAN_SYSTEMLIBS
+    CONFIG(release, debug|release) {
+        LIBS += $$CONAN_SYSTEMLIBS_RELEASE
+    } else {
+        LIBS += $$CONAN_SYSTEMLIBS_DEBUG
     }
     QMAKE_CXXFLAGS += $$CONAN_QMAKE_CXXFLAGS
     QMAKE_CFLAGS += $$CONAN_QMAKE_CFLAGS

--- a/conans/test/unittests/client/generators/qmake_test.py
+++ b/conans/test/unittests/client/generators/qmake_test.py
@@ -1,0 +1,27 @@
+import platform
+import unittest
+
+from conans.client.generators.qmake import QmakeGenerator
+from conans.model.build_info import CppInfo, DepCppInfo
+from conans.model.conan_file import ConanFile
+from conans.model.env_info import EnvValues
+from conans.model.settings import Settings
+from conans.test.utils.mocks import TestBufferConanOutput
+
+
+class QmakeGeneratorTest(unittest.TestCase):
+
+    def system_libs_test(self):
+        # https://github.com/conan-io/conan/issues/7558
+        conanfile = ConanFile(TestBufferConanOutput(), None)
+        conanfile.initialize(Settings({}), EnvValues())
+        cpp_info = CppInfo("MyPkg", "/rootpath")
+        cpp_info.libs = ["mypkg"]
+        cpp_info.system_libs = ["pthread"]
+        conanfile.deps_cpp_info.add("MyPkg", DepCppInfo(cpp_info))
+        generator = QmakeGenerator(conanfile)
+        content = generator.content
+        qmake_lines = content.splitlines()
+        self.assertIn('CONAN_LIBS += -lmypkg', qmake_lines)
+        self.assertIn('CONAN_SYSTEMLIBS += -lpthread', qmake_lines)
+


### PR DESCRIPTION
Changelog: Bugfix: Add support for `cpp_info.system_libs` to _QMake_ generator.
Docs: Omit

Fix #7558

- [x] Refer to the issue that supports this Pull Request.
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 

<sup>**Note:** By default this PR will skip the slower tests and will use a limited set of python versions. Check [here](https://github.com/conan-io/conan/blob/develop/.github/PR_INCREASE_TESTING.md) how to increase the testing level by writing some tags in the current PR body text.</sup>
