### PR TITLE
Update docs in 'conan info -bo'

### DIFF
--- a/conans/client/command.py
+++ b/conans/client/command.py
@@ -644,7 +644,7 @@ class Command(object):
                             help='Show package paths in local cache')
         parser.add_argument("-bo", "--build-order",
                             help="given a modified reference, return an ordered list to build (CI)."
-                                 " [DEPRECATED: use 'conan graph build-order ...' instead]",
+                                 " [DEPRECATED: use 'conan lock build-order ...' instead]",
                             nargs=1, action=Extender)
         parser.add_argument("-g", "--graph", action=OnceArgument,
                             help='Creates file with project dependencies graph. It will generate '


### PR DESCRIPTION
Changelog: Fix: Update docs in `conan info -bo` command.
Docs: omit

closes https://github.com/conan-io/conan/issues/7569