### PR TITLE
export intel_installation_path and compilervars* from tools module

### DIFF
--- a/conans/client/tools/intel.py
+++ b/conans/client/tools/intel.py
@@ -71,7 +71,9 @@ def compilervars_command(conanfile, arch=None, compiler_version=None, force=Fals
     cvars = "compilervars.bat" if system == "Windows" else "compilervars.sh"
     command = os.path.join(intel_installation_path(version=compiler_version, arch=arch), "bin", cvars)
     command = '"%s"' % command
-    if system != "Windows":
+    if system == "Windows":
+        command = "call " + command
+    else:
         command = ". " + command  # dot is more portable than source
     if arch == "x86_64":
         command += " -arch intel64"

--- a/conans/tools.py
+++ b/conans/tools.py
@@ -20,6 +20,7 @@ from conans.client.tools.env import *  # pylint: disable=unused-import
 from conans.client.tools.pkg_config import *  # pylint: disable=unused-import
 from conans.client.tools.scm import *  # pylint: disable=unused-import
 from conans.client.tools.settings import *  # pylint: disable=unused-import
+from conans.client.tools.intel import *  # pylint: disable=unused-import
 from conans.client.tools.apple import *
 from conans.client.tools.android import *
 # Tools form conans.util


### PR DESCRIPTION
Changelog: Feature: Expose intel_installation_path, compilervars, compilervars_dict, and compilervars_command under tools module in order to support usage of the intel compiler.
Docs: https://github.com/conan-io/docs/pull/1815

closes: #7554

- [x] Refer to the issue that supports this Pull Request.
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [x] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 
