### PR TITLE
Handle unknown statement while parsing profile. Fixes #6931

### DIFF
--- a/conans/client/profile_loader.py
+++ b/conans/client/profile_loader.py
@@ -1,7 +1,7 @@
 import os
 from collections import OrderedDict, defaultdict
 
-from conans.errors import ConanException, ConanV2Exception
+from conans.errors import ConanException, ConanV2Exception, ConanParsingError
 from conans.model.env_info import EnvValues, unquote
 from conans.model.options import OptionsValues
 from conans.model.profile import Profile
@@ -38,7 +38,10 @@ class ProfileParser(object):
                 include = include[:-1]
                 self.includes.append(include)
             else:
-                name, value = line.split("=", 1)
+                try:
+                    name, value = line.split("=", 1)
+                except ValueError as error:
+                    raise ConanParsingError("Error while parsing line %i: '%s'" % (counter, line))
                 name = name.strip()
                 if " " in name:
                     raise ConanException("The names of the variables cannot contain spaces")

--- a/conans/client/profile_loader.py
+++ b/conans/client/profile_loader.py
@@ -1,7 +1,7 @@
 import os
 from collections import OrderedDict, defaultdict
 
-from conans.errors import ConanException, ConanV2Exception, ConanParsingError
+from conans.errors import ConanException, ConanV2Exception
 from conans.model.env_info import EnvValues, unquote
 from conans.model.options import OptionsValues
 from conans.model.profile import Profile
@@ -41,7 +41,7 @@ class ProfileParser(object):
                 try:
                     name, value = line.split("=", 1)
                 except ValueError as error:
-                    raise ConanParsingError("Error while parsing line %i: '%s'" % (counter, line))
+                    raise ConanException("Error while parsing line %i: '%s'" % (counter, line))
                 name = name.strip()
                 if " " in name:
                     raise ConanException("The names of the variables cannot contain spaces")

--- a/conans/errors.py
+++ b/conans/errors.py
@@ -136,10 +136,6 @@ class ConanConnectionError(ConanException):
     pass
 
 
-class ConanParsingError(ConanException):
-    pass
-
-
 class ConanOutdatedClient(ConanException):
     pass
 

--- a/conans/errors.py
+++ b/conans/errors.py
@@ -136,6 +136,10 @@ class ConanConnectionError(ConanException):
     pass
 
 
+class ConanParsingError(ConanException):
+    pass
+
+
 class ConanOutdatedClient(ConanException):
     pass
 

--- a/conans/test/functional/command/install/install_test.py
+++ b/conans/test/functional/command/install/install_test.py
@@ -488,7 +488,7 @@ class Pkg(ConanFile):
         client.run("install . -pr=myotherprofile")
         self.assertIn("PKGOS=FreeBSD", client.out)
         client.run("install . -pr=./myotherprofile", assert_error=True)
-        self.assertIn("Error parsing the profile", client.out)
+        self.assertIn("Error while parsing line 0", client.out)
 
     def install_with_path_errors_test(self):
         client = TestClient()

--- a/conans/test/unittests/client/profile_loader/profile_loader_test.py
+++ b/conans/test/unittests/client/profile_loader/profile_loader_test.py
@@ -66,6 +66,17 @@ os=$OTHERVAR
 os=thing""")
 
 
+        txt = """
+includes(a/path/to\profile.txt)
+"""
+        with self.assertRaises(ConanException):
+            try:
+                ProfileParser(txt)
+            except Exception as error:
+                self.assertIn("Error while parsing line 1", error.args[0])
+                raise
+
+
 class ProfileTest(unittest.TestCase):
 
     def profile_loads_test(self):


### PR DESCRIPTION
Changelog: Bugfix: Provide a more descriptive error when an unknown statement is added to a profile
Docs: omit

Closes: #6931

Tested with the example provided in the [examples repository](https://github.com/conan-io/examples/tree/master/features/emscripten)

I replaced the first line:
```
include(default)
```

By:
```
includes(default)
```

When running `conan` before this change, the command output is:
```sh
✗ ./build.sh
+ conan remove 'conan-hello-emscripten/*' -f
WARN: No package recipe matches 'conan-hello-emscripten/*'
+ conan create . conan/testing -pr emscripten.profile --build missing
ERROR: Error reading 'emscripten.profile' profile: Error parsing the profile text file: not enough values to unpack (expected 2, got 1)
```

After this change:
```sh
✗ ./build.sh
+ conan remove 'conan-hello-emscripten/*' -f
WARN: No package recipe matches 'conan-hello-emscripten/*'
+ conan create . conan/testing -pr emscripten.profile --build missing
ERROR: Error reading 'emscripten.profile' profile: Error while parsing line 0: 'includes(default)'
```