### PR TITLE
Bugfix: support frameworks and framework_paths in qmake generator

### DIFF
--- a/conans/client/generators/qmake.py
+++ b/conans/client/generators/qmake.py
@@ -19,6 +19,9 @@ class DepsCppQmake(object):
 
         self.libs = " ".join('-l%s' % lib for lib in cpp_info.libs)
         self.system_libs = " ".join('-l%s' % lib for lib in cpp_info.system_libs)
+        self.frameworks = " ".join('-framework %s' % framework for framework in cpp_info.frameworks)
+        self.framework_paths = " ".join('-F%s' % framework_path for framework_path in
+                                        cpp_info.framework_paths)
         self.defines = " \\\n    ".join('"%s"' % d for d in cpp_info.defines)
         self.cxxflags = " ".join(cpp_info.cxxflags)
         self.cflags = " ".join(cpp_info.cflags)
@@ -40,6 +43,8 @@ class QmakeGenerator(Generator):
         template = ('CONAN_INCLUDEPATH{dep_name}{build_type} += {deps.include_paths}\n'
                     'CONAN_LIBS{dep_name}{build_type} += {deps.libs}\n'
                     'CONAN_SYSTEMLIBS{dep_name}{build_type} += {deps.system_libs}\n'
+                    'CONAN_FRAMEWORKS{dep_name}{build_type} += {deps.frameworks}\n'
+                    'CONAN_FRAMEWORK_PATHS{dep_name}{build_type} += {deps.framework_paths}\n'
                     'CONAN_LIBDIRS{dep_name}{build_type} += {deps.lib_paths}\n'
                     'CONAN_BINDIRS{dep_name}{build_type} += {deps.bin_paths}\n'
                     'CONAN_RESDIRS{dep_name}{build_type} += {deps.res_paths}\n'
@@ -99,6 +104,15 @@ class QmakeGenerator(Generator):
         LIBS += $$CONAN_SYSTEMLIBS_RELEASE
     } else {
         LIBS += $$CONAN_SYSTEMLIBS_DEBUG
+    }
+    LIBS += $$CONAN_FRAMEWORKS
+    LIBS += $$CONAN_FRAMEWORK_PATHS
+    CONFIG(release, debug|release) {
+        LIBS += $$CONAN_FRAMEWORKS_RELEASE
+        LIBS += $$CONAN_FRAMEWORK_PATHS_RELEASE
+    } else {
+        LIBS += $$CONAN_FRAMEWORKS_DEBUG
+        LIBS += $$CONAN_FRAMEWORK_PATHS_DEBUG
     }
     QMAKE_CXXFLAGS += $$CONAN_QMAKE_CXXFLAGS
     QMAKE_CFLAGS += $$CONAN_QMAKE_CFLAGS

--- a/conans/test/unittests/client/generators/qmake_test.py
+++ b/conans/test/unittests/client/generators/qmake_test.py
@@ -1,4 +1,4 @@
-import platform
+import os
 import unittest
 
 from conans.client.generators.qmake import QmakeGenerator
@@ -25,3 +25,16 @@ class QmakeGeneratorTest(unittest.TestCase):
         self.assertIn('CONAN_LIBS += -lmypkg', qmake_lines)
         self.assertIn('CONAN_SYSTEMLIBS += -lpthread', qmake_lines)
 
+    def frameworks_test(self):
+        conanfile = ConanFile(TestBufferConanOutput(), None)
+        conanfile.initialize(Settings({}), EnvValues())
+        framework_path = os.getcwd()  # must exist, otherwise filtered by framework_paths
+        cpp_info = CppInfo("MyPkg", "/rootpath")
+        cpp_info.frameworks = ["HelloFramework"]
+        cpp_info.frameworkdirs = [framework_path]
+        conanfile.deps_cpp_info.add("MyPkg", DepCppInfo(cpp_info))
+        generator = QmakeGenerator(conanfile)
+        content = generator.content
+        qmake_lines = content.splitlines()
+        self.assertIn('CONAN_FRAMEWORKS += -framework HelloFramework', qmake_lines)
+        self.assertIn('CONAN_FRAMEWORK_PATHS += -F%s' % framework_path, qmake_lines)


### PR DESCRIPTION
closes: #7564

Changelog: Bugfix: Support `frameworks` and `framework_paths` in _qmake_ generator.
Docs: omit

- [x] Refer to the issue that supports this Pull Request.
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 

<sup>**Note:** By default this PR will skip the slower tests and will use a limited set of python versions. Check [here](https://github.com/conan-io/conan/blob/develop/.github/PR_INCREASE_TESTING.md) how to increase the testing level by writing some tags in the current PR body text.</sup>
