### PR TITLE
Fix 'conan config' type argument

### DIFF
--- a/conans/client/command.py
+++ b/conans/client/command.py
@@ -564,7 +564,7 @@ class Command(object):
 
         install_subparser.add_argument("--verify-ssl", nargs="?", default="True",
                                        help='Verify SSL connection when downloading file')
-        install_subparser.add_argument("--type", "-t", choices=["git"],
+        install_subparser.add_argument("--type", "-t", choices=["git", "dir", "file", "url"],
                                        help='Type of remote config')
         install_subparser.add_argument("--args", "-a",
                                        help='String with extra arguments for "git clone"')

--- a/conans/client/conf/config_installer.py
+++ b/conans/client/conf/config_installer.py
@@ -87,6 +87,8 @@ def _filecopy(src, filename, dst):
 
 
 def _process_folder(config, folder, cache, output):
+    if not os.path.isdir(folder):
+        raise ConanException("No such directory: '%s'" % str(folder))
     if config.source_folder:
         folder = os.path.join(folder, config.source_folder)
     for root, dirs, files in walk(folder):

--- a/conans/test/functional/command/config_install_test.py
+++ b/conans/test/functional/command/config_install_test.py
@@ -205,21 +205,23 @@ class Pkg(ConanFile):
         self.client.run("create . Pkg/0.1@user/testing")
         self.assertIn("A is 3", self.client.out)
 
-    def install_file_test(self):
+    def test_install_file_test(self):
         """ should install from a file in current dir
         """
         zippath = self._create_zip()
-        self.client.run('config install "%s"' % zippath)
-        self._check("file, %s, True, None" % zippath)
-        self.assertTrue(os.path.exists(zippath))
+        for type in ["", "--type=file"]:
+            self.client.run('config install "%s" %s' % (zippath, type))
+            self._check("file, %s, True, None" % zippath)
+            self.assertTrue(os.path.exists(zippath))
 
-    def install_dir_test(self):
+    def test_install_dir_test(self):
         """ should install from a dir in current dir
         """
         folder = self._create_profile_folder()
         self.assertTrue(os.path.isdir(folder))
-        self.client.run('config install "%s"' % folder)
-        self._check("dir, %s, True, None" % folder)
+        for type in ["", "--type=dir"]:
+            self.client.run('config install "%s" %s' % (folder, type))
+            self._check("dir, %s, True, None" % folder)
 
     def install_source_target_folders_test(self):
         folder = temp_folder()
@@ -302,20 +304,21 @@ class Pkg(ConanFile):
         self.assertEqual(load(os.path.join(self.client.cache.profiles_path, "linux")).splitlines(),
                          linux_profile.splitlines())
 
-    def install_url_test(self):
+    def test_install_url(self):
         """ should install from a URL
         """
 
-        def my_download(obj, url, filename, **kwargs):  # @UnusedVariable
-            self._create_zip(filename)
+        for type in ["", "--type=url"]:
+            def my_download(obj, url, filename, **kwargs):  # @UnusedVariable
+                self._create_zip(filename)
 
-        with patch.object(FileDownloader, 'download', new=my_download):
-            self.client.run("config install http://myfakeurl.com/myconf.zip")
-            self._check("url, http://myfakeurl.com/myconf.zip, True, None")
+            with patch.object(FileDownloader, 'download', new=my_download):
+                self.client.run("config install http://myfakeurl.com/myconf.zip %s" % type)
+                self._check("url, http://myfakeurl.com/myconf.zip, True, None")
 
-            # repeat the process to check
-            self.client.run("config install http://myfakeurl.com/myconf.zip")
-            self._check("url, http://myfakeurl.com/myconf.zip, True, None")
+                # repeat the process to check
+                self.client.run("config install http://myfakeurl.com/myconf.zip %s" % type)
+                self._check("url, http://myfakeurl.com/myconf.zip, True, None")
 
     def install_change_only_verify_ssl_test(self):
         def my_download(obj, url, filename, **kwargs):  # @UnusedVariable
@@ -390,10 +393,26 @@ class Pkg(ConanFile):
         check_path = os.path.join(folder, ".git")
         self._check("git, %s, True, -c init.templateDir=value" % check_path)
 
-    def force_git_type_test(self):
+    def test_force_git_type(self):
         client = TestClient()
         client.run('config install httpnonexisting --type=git', assert_error=True)
         self.assertIn("Can't clone repo", client.out)
+
+    def test_force_dir_type(self):
+        client = TestClient()
+        # invalid directory is not an error
+        client.run('config install httpnonexisting --type=dir')
+
+    def test_force_file_type(self):
+        client = TestClient()
+        client.run('config install httpnonexisting --type=file', assert_error=True)
+        self.assertIn("No such file or directory: 'httpnonexisting'", client.out)
+
+    def test_force_url_type(self):
+        client = TestClient()
+        client.run('config install httpnonexisting --type=url', assert_error=True)
+        self.assertIn("Error downloading file httpnonexisting: 'Invalid URL 'httpnonexisting'",
+                      client.out)
 
     def reinstall_error_test(self):
         """ should use configured URL in conan.conf

--- a/conans/test/functional/command/config_install_test.py
+++ b/conans/test/functional/command/config_install_test.py
@@ -400,8 +400,9 @@ class Pkg(ConanFile):
 
     def test_force_dir_type(self):
         client = TestClient()
-        # invalid directory is not an error
-        client.run('config install httpnonexisting --type=dir')
+        client.run('config install httpnonexisting --type=dir', assert_error=True)
+        self.assertIn("ERROR: Failed conan config install: No such directory: 'httpnonexisting'",
+                      client.out)
 
     def test_force_file_type(self):
         client = TestClient()


### PR DESCRIPTION
Changelog: Fix: Support installing configs from non-regular files.
Docs: https://github.com/conan-io/docs/pull/1818

NOTE this PR comes from #7124

- [ ] Refer to the issue that supports this Pull Request.
- [ ] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [ ] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [ ] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 

<sup>**Note:** By default this PR will skip the slower tests and will use a limited set of python versions. Check [here](https://github.com/conan-io/conan/blob/develop/.github/PR_INCREASE_TESTING.md) how to increase the testing level by writing some tags in the current PR body text.</sup>
