### PR TITLE
Bugfix: respect winsdk_version for WindowsStore

### DIFF
--- a/conans/client/tools/win.py
+++ b/conans/client/tools/win.py
@@ -478,13 +478,14 @@ def vcvars_command(conanfile=None, arch=None, compiler_version=None, force=False
         if os_setting == 'WindowsStore':
             os_version_setting = conanfile.settings.get_safe("os.version")
             if os_version_setting == '8.1':
-                command.append('store 8.1')
+                winsdk_version = winsdk_version or "8.1"
+                command.append('store %s' % winsdk_version)
             elif os_version_setting == '10.0':
-                windows_10_sdk = find_windows_10_sdk()
-                if not windows_10_sdk:
+                winsdk_version = winsdk_version or find_windows_10_sdk()
+                if not winsdk_version:
                     raise ConanException("cross-compiling for WindowsStore 10 (UWP), "
                                          "but Windows 10 SDK wasn't found")
-                command.append('store %s' % windows_10_sdk)
+                command.append('store %s' % winsdk_version)
             else:
                 raise ConanException('unsupported Windows Store version %s' % os_version_setting)
     return " ".join(command)

--- a/conans/test/unittests/client/tools/win/vcvars_store_test.py
+++ b/conans/test/unittests/client/tools/win/vcvars_store_test.py
@@ -50,6 +50,21 @@ class VCVarsStoreTest(unittest.TestCase):
         self.assertIn('store', command)
         self.assertIn(sdk_version, command)
 
+    def test_10_custom_winsdk(self):
+        settings = Settings.loads(get_default_settings_yml())
+        settings.compiler = 'Visual Studio'
+        settings.compiler.version = '14'
+        settings.arch = 'x86'
+        settings.os = 'WindowsStore'
+        settings.os.version = '10.0'
+
+        sdk_version = '10.0.18362.0'
+        command = tools.vcvars_command(settings, winsdk_version=sdk_version, output=self.output)
+        self.assertIn('vcvarsall.bat', command)
+        self.assertIn('x86', command)
+        self.assertIn('store', command)
+        self.assertIn(sdk_version, command)
+
     def test_invalid(self):
         fake_settings_yml = """
         os:


### PR DESCRIPTION
closes: #7305 

Changelog: Bugfix: Respect `winsdk_version` for WindowsStore.
Docs: omit

- [x] Refer to the issue that supports this Pull Request.
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 

<sup>**Note:** By default this PR will skip the slower tests and will use a limited set of python versions. Check [here](https://github.com/conan-io/conan/blob/develop/.github/PR_INCREASE_TESTING.md) how to increase the testing level by writing some tags in the current PR body text.</sup>
