### PR TITLE
fixing lockfiles

### DIFF
--- a/conans/client/graph/graph_binaries.py
+++ b/conans/client/graph/graph_binaries.py
@@ -355,6 +355,8 @@ class GraphBinariesAnalyzer(object):
             if node.package_id == PACKAGE_ID_UNKNOWN:
                 assert node.binary is None, "Node.binary should be None"
                 node.binary = BINARY_UNKNOWN
+                # annotate pattern, so unused patterns in --build are not displayed as errors
+                build_mode.forced(node.conanfile, node.ref)
                 continue
             self._evaluate_node(node, build_mode, update, remotes)
         deps_graph.mark_private_skippable(nodes_subset=nodes_subset, root=root)

--- a/conans/client/graph/graph_binaries.py
+++ b/conans/client/graph/graph_binaries.py
@@ -206,8 +206,8 @@ class GraphBinariesAnalyzer(object):
                     node.binary = BINARY_BUILD
 
             if locked:
-                locked.package_id = node.package_id
-                locked.prev = node.prev
+                # package_id was not locked, this means a base lockfile that is being completed
+                locked.complete_base_node(node.package_id, node.prev)
 
     def _process_node(self, node, pref, build_mode, update, remotes):
         # Check that this same reference hasn't already been checked

--- a/conans/model/graph_lock.py
+++ b/conans/model/graph_lock.py
@@ -196,9 +196,15 @@ class GraphLockNode(object):
             value = DEFAULT_REVISION_V1
         if self._prev is not None:
             raise ConanException("Trying to modify locked package {}".format(repr(self._ref)))
-        if self._prev != value:
+        if value is not None:
             self._modified = True  # Only for conan_build_info
         self._prev = value
+
+    def complete_base_node(self, package_id, prev):
+        # completing a node from a base lockfile shouldn't mark the node as modified
+        self.package_id = package_id
+        self.prev = prev
+        self._modified = None
 
     @property
     def options(self):
@@ -463,7 +469,7 @@ class GraphLock(object):
             if current.ref:
                 if node.ref.copy_clear_rev() != current.ref.copy_clear_rev():
                     raise ConanException("Incompatible reference")
-            if current.package_id is None:
+            if current.package_id is None or current.package_id == PACKAGE_ID_UNKNOWN:
                 current.package_id = node.package_id
             if current.prev is None:
                 current.prev = node.prev

--- a/conans/test/functional/graph_lock/graph_lock_ci_test.py
+++ b/conans/test/functional/graph_lock/graph_lock_ci_test.py
@@ -374,6 +374,52 @@ class GraphLockCITest(unittest.TestCase):
         self.assertIn("PkgB/0.1@user/channel: PACKAGE_INFO OPTION: 4!!", client2.out)
         self.assertIn("PkgA/0.1@user/channel: PACKAGE_INFO OPTION: 5!!", client2.out)
 
+    @unittest.skipUnless(get_env("TESTING_REVISIONS_ENABLED", False), "Only revisions")
+    def test_package_revisions_unkown_id_update(self):
+        # https://github.com/conan-io/conan/issues/7588
+        client = TestClient()
+        client.run("config set general.default_package_id_mode=package_revision_mode")
+        files = {
+            "pkga/conanfile.py": conanfile.format(requires=""),
+            "pkga/myfile.txt": "HelloA",
+            "pkgb/conanfile.py": conanfile.format(requires='requires="PkgA/[*]@user/channel"'),
+            "pkgb/myfile.txt": "HelloB",
+            "pkgc/conanfile.py": conanfile.format(requires='requires="PkgB/[*]@user/channel"'),
+            "pkgc/myfile.txt": "HelloC",
+            "pkgd/conanfile.py": conanfile.format(requires='requires="PkgC/[*]@user/channel"'),
+            "pkgd/myfile.txt": "HelloD",
+        }
+        client.save(files)
+        client.run("export pkga PkgA/0.1@user/channel")
+        client.run("export pkgb PkgB/0.1@user/channel")
+        client.run("export pkgc PkgC/0.1@user/channel")
+        client.run("export pkgd PkgD/0.1@user/channel")
+
+        client.run("lock create --reference=PkgD/0.1@user/channel --lockfile-out=conan.lock")
+        lockfile = json.loads(client.load("conan.lock"))
+        nodes = lockfile["graph_lock"]["nodes"]
+        self.assertEqual(nodes["3"]["ref"], "PkgB/0.1@user/channel#fa97c46bf83849a5db4564327b3cfada")
+        self.assertEqual(nodes["3"]["package_id"], "Package_ID_unknown")
+
+        client.run("install PkgA/0.1@user/channel --build=PkgA/0.1@user/channel "
+                   "--lockfile=conan.lock --lockfile-out=conan_out.lock")
+        client.run("lock update conan.lock conan_out.lock")
+
+        client.run("install PkgB/0.1@user/channel --build=PkgB/0.1@user/channel "
+                   "--lockfile=conan.lock --lockfile-out=conan_out.lock")
+        lockfile = json.loads(client.load("conan_out.lock"))
+        nodes = lockfile["graph_lock"]["nodes"]
+        self.assertEqual(nodes["3"]["ref"], "PkgB/0.1@user/channel#fa97c46bf83849a5db4564327b3cfada")
+        self.assertEqual(nodes["3"]["package_id"], "6e9742c2106791c1c777da8ccfb12a1408385d8d")
+        self.assertEqual(nodes["3"]["prev"], "f971905c142e0de728f32a7237553622")
+
+        client.run("lock update conan.lock conan_out.lock")
+        lockfile = json.loads(client.load("conan.lock"))
+        nodes = lockfile["graph_lock"]["nodes"]
+        self.assertEqual(nodes["3"]["ref"], "PkgB/0.1@user/channel#fa97c46bf83849a5db4564327b3cfada")
+        self.assertEqual(nodes["3"]["package_id"], "6e9742c2106791c1c777da8ccfb12a1408385d8d")
+        self.assertEqual(nodes["3"]["prev"], "f971905c142e0de728f32a7237553622")
+
 
 class CIPythonRequiresTest(unittest.TestCase):
     python_req = textwrap.dedent("""

--- a/conans/test/functional/graph_lock/lock_recipe_test.py
+++ b/conans/test/functional/graph_lock/lock_recipe_test.py
@@ -51,6 +51,7 @@ class LockRecipeTest(unittest.TestCase):
             self.assertEqual(pkg_node["package_id"], "cb054d0b3e1ca595dc66bc2339d40f1f8f04ab31")
             self.assertEqual(pkg_node["prev"], "0")
         self.assertEqual(pkg_node["options"], "")
+        self.assertIsNone(pkg_node.get("modified"))
 
         client.run("lock create conanfile.py -s os=Windows "
                    "--lockfile-out=windows.lock --lockfile=conan.lock")

--- a/conans/test/functional/graph_lock/lock_recipe_test.py
+++ b/conans/test/functional/graph_lock/lock_recipe_test.py
@@ -200,3 +200,6 @@ class LockRecipeTest(unittest.TestCase):
                    "--lockfile-out=libb_release.lock --build=missing")
         libb_release = client.load("libb_release.lock")
         self.assertIn('"ref": "libb/0.1#c2a641589d4b617387124f011905a97b"', libb_release)
+
+        client.run("create pkgb libb/0.1@ --lockfile=libb_release.lock")
+        self.assertIn("libb/0.1: Created package", client.out)

--- a/conans/test/functional/graph_lock/lock_recipe_test.py
+++ b/conans/test/functional/graph_lock/lock_recipe_test.py
@@ -204,8 +204,6 @@ class LockRecipeTest(unittest.TestCase):
         client.run("create pkgb libb/0.1@ --lockfile=libb_release.lock")
         self.assertIn("libb/0.1: Created package", client.out)
 
-    import os
-    os.environ["TESTING_REVISIONS_ENABLED"] = "1"
     @unittest.skipUnless(get_env("TESTING_REVISIONS_ENABLED", False), "Only revisions")
     def missing_configuration_test(self):
         client = TestClient()


### PR DESCRIPTION
Changelog: Bugfix: Avoid marking as "modified" packages in a lockfile computed from a base lockfile.
Changelog: Bugfix: Update correctly "Package_ID_Unknown" nodes when using ``conan lock update`` and ``package_revision_mode``.
Docs: Omit

Fix https://github.com/conan-io/conan/issues/7588
Fix https://github.com/conan-io/conan/issues/7562


#revisions: 1
