### PR TITLE
_installed should return true only if all packages are installed

### DIFF
--- a/conans/client/tools/system_pm.py
+++ b/conans/client/tools/system_pm.py
@@ -150,12 +150,14 @@ class SystemPackageTool(object):
     def _installed(self, packages):
         if not packages:
             return True
-
+        
+        all_pkgs_installed = True
         for pkg in packages:
             if self._tool.installed(pkg):
                 self._output.info("Package already installed: %s" % pkg)
-                return True
-        return False
+            else:
+                all_pkgs_installed = False
+        return all_pkgs_installed
 
     def _install_any(self, packages):
         if len(packages) == 1:


### PR DESCRIPTION
fixes #7594: System packages will not be installed if one of the packages is already installed.

*install* function call self._installed, which return true if one or more packages is install, and *install* return doing nothing.

Changelog: (Feature | Fix | Bugfix): Describe here your pull request
Docs: https://github.com/conan-io/docs/pull/XXXX

- [ ] Refer to the issue that supports this Pull Request.
- [ ] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [ ] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [ ] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 

<sup>**Note:** By default this PR will skip the slower tests and will use a limited set of python versions. Check [here](https://github.com/conan-io/conan/blob/develop/.github/PR_INCREASE_TESTING.md) how to increase the testing level by writing some tags in the current PR body text.</sup>
