### PR TITLE
Keep default of 'CppInfo.filter_empty' after reading from 'conanbuildinfo.txt'

### DIFF
--- a/conans/client/graph/graph_manager.py
+++ b/conans/client/graph/graph_manager.py
@@ -406,7 +406,7 @@ def load_deps_info(current_path, conanfile, required):
     info_file_path = os.path.join(current_path, BUILD_INFO)
     try:
         deps_cpp_info, deps_user_info, deps_env_info, user_info_build = \
-            TXTGenerator.loads(load(info_file_path))
+            TXTGenerator.loads(load(info_file_path), filter_empty=True)
         conanfile.deps_cpp_info = deps_cpp_info
         conanfile.deps_user_info = deps_user_info
         conanfile.deps_env_info = deps_env_info

--- a/conans/test/functional/deps_cpp_info_test.py
+++ b/conans/test/functional/deps_cpp_info_test.py
@@ -1,0 +1,30 @@
+import textwrap
+import unittest
+
+from conans.test.utils.genconanfile import GenConanfile
+from conans.test.utils.tools import TestClient
+
+
+class DepsCppInfoTest(unittest.TestCase):
+
+    def test(self):
+        # https://github.com/conan-io/conan/issues/7598
+        client = TestClient()
+
+        client.save({"conanfile.py": GenConanfile()})
+        client.run("create . dep/0.1@user/testing")
+
+        conanfile = textwrap.dedent("""
+            from conans import ConanFile
+            class Pkg(ConanFile):
+                requires = "dep/0.1@user/testing"
+                def build(self):
+                    self.output.info("DEPS_CPP_INFO_BIN: %s" % self.deps_cpp_info["dep"].bin_paths)
+            """)
+        client.save({"conanfile.py":conanfile})
+        client.run("create . pkg/0.1@user/testing")
+        self.assertIn("pkg/0.1@user/testing: DEPS_CPP_INFO_BIN: []", client.out)
+        client.run("install .")
+        client.run("build .")
+        self.assertIn("pkg/0.1@user/testing: DEPS_CPP_INFO_BIN: []", client.out)
+

--- a/conans/test/functional/deps_cpp_info_test.py
+++ b/conans/test/functional/deps_cpp_info_test.py
@@ -26,5 +26,5 @@ class DepsCppInfoTest(unittest.TestCase):
         self.assertIn("pkg/0.1@user/testing: DEPS_CPP_INFO_BIN: []", client.out)
         client.run("install .")
         client.run("build .")
-        self.assertIn("pkg/0.1@user/testing: DEPS_CPP_INFO_BIN: []", client.out)
+        self.assertIn("conanfile.py: DEPS_CPP_INFO_BIN: []", client.out)
 

--- a/conans/test/functional/deps_cpp_info_test.py
+++ b/conans/test/functional/deps_cpp_info_test.py
@@ -21,10 +21,9 @@ class DepsCppInfoTest(unittest.TestCase):
                 def build(self):
                     self.output.info("DEPS_CPP_INFO_BIN: %s" % self.deps_cpp_info["dep"].bin_paths)
             """)
-        client.save({"conanfile.py":conanfile})
+        client.save({"conanfile.py": conanfile})
         client.run("create . pkg/0.1@user/testing")
         self.assertIn("pkg/0.1@user/testing: DEPS_CPP_INFO_BIN: []", client.out)
         client.run("install .")
         client.run("build .")
         self.assertIn("conanfile.py: DEPS_CPP_INFO_BIN: []", client.out)
-


### PR DESCRIPTION
Changelog: Bugfix: Fix regression in ``deps_cpp_info`` incorrectly adding directories when reading from ``conanbuildinfo.txt`` file.
Docs: Omit

Close https://github.com/conan-io/conan/issues/7598

So far the test is red, need the fix
