### PR TITLE
Add system libs and frameworks to components targets

### DIFF
--- a/conans/client/generators/cmake_find_package.py
+++ b/conans/client/generators/cmake_find_package.py
@@ -149,15 +149,7 @@ class CMakeFindPackageGenerator(Generator):
                                       ""
                                       "{{ pkg_name }}_{{ comp_name }}")
 
-        foreach(_FRAMEWORK {{ '${'+pkg_name+'_'+comp_name+'_FRAMEWORKS_FOUND}' }})
-            list(APPEND {{ pkg_name+'_'+comp_name+'_LIB_TARGETS' }} ${_FRAMEWORK})
-        endforeach()
-
-        foreach(_SYSTEM_LIB {{ '${'+pkg_name+'_'+comp_name+'_SYSTEM_LIBS}' }})
-            list(APPEND {{ pkg_name+'_'+comp_name+'_LIB_TARGETS' }} ${_SYSTEM_LIB})
-        endforeach()
-
-        set({{ pkg_name }}_{{ comp_name }}_LINK_LIBS {{ '${'+pkg_name+'_'+comp_name+'_LIB_TARGETS}' }} {{ '${'+pkg_name+'_'+comp_name+'_DEPENDENCIES}' }})
+        set({{ pkg_name }}_{{ comp_name }}_LINK_LIBS {{ '${'+pkg_name+'_'+comp_name+'_LIB_TARGETS}' }} {{ '${'+pkg_name+'_'+comp_name+'_LIBS_FRAMEWORKS_DEPS}' }})
 
         set(CMAKE_MODULE_PATH {{ comp.build_paths }} ${CMAKE_MODULE_PATH})
         set(CMAKE_PREFIX_PATH {{ comp.build_paths }} ${CMAKE_PREFIX_PATH})

--- a/conans/client/generators/cmake_find_package.py
+++ b/conans/client/generators/cmake_find_package.py
@@ -149,7 +149,7 @@ class CMakeFindPackageGenerator(Generator):
                                       ""
                                       "{{ pkg_name }}_{{ comp_name }}")
 
-        set({{ pkg_name }}_{{ comp_name }}_LINK_LIBS {{ '${'+pkg_name+'_'+comp_name+'_LIB_TARGETS}' }} {{ '${'+pkg_name+'_'+comp_name+'_DEPENDENCIES}' }})
+        set({{ pkg_name }}_{{ comp_name }}_LINK_LIBS {{ '${'+pkg_name+'_'+comp_name+'_LIB_TARGETS}' }} {{ '${'+pkg_name+'_'+comp_name+'_SYSTEM_LIBS}' }} {{ '${'+pkg_name+'_'+comp_name+'_DEPENDENCIES}' }})
 
         set(CMAKE_MODULE_PATH {{ comp.build_paths }} ${CMAKE_MODULE_PATH})
         set(CMAKE_PREFIX_PATH {{ comp.build_paths }} ${CMAKE_PREFIX_PATH})

--- a/conans/client/generators/cmake_find_package.py
+++ b/conans/client/generators/cmake_find_package.py
@@ -149,7 +149,15 @@ class CMakeFindPackageGenerator(Generator):
                                       ""
                                       "{{ pkg_name }}_{{ comp_name }}")
 
-        set({{ pkg_name }}_{{ comp_name }}_LINK_LIBS {{ '${'+pkg_name+'_'+comp_name+'_LIB_TARGETS}' }} {{ '${'+pkg_name+'_'+comp_name+'_SYSTEM_LIBS}' }} {{ '${'+pkg_name+'_'+comp_name+'_DEPENDENCIES}' }})
+        foreach(_FRAMEWORK {{ '${'+pkg_name+'_'+comp_name+'_FRAMEWORKS_FOUND}' }})
+            list(APPEND {{ pkg_name+'_'+comp_name+'_LIB_TARGETS' }} ${_FRAMEWORK})
+        endforeach()
+
+        foreach(_SYSTEM_LIB {{ '${'+pkg_name+'_'+comp_name+'_SYSTEM_LIBS}' }})
+            list(APPEND {{ pkg_name+'_'+comp_name+'_LIB_TARGETS' }} ${_SYSTEM_LIB})
+        endforeach()
+
+        set({{ pkg_name }}_{{ comp_name }}_LINK_LIBS {{ '${'+pkg_name+'_'+comp_name+'_LIB_TARGETS}' }} {{ '${'+pkg_name+'_'+comp_name+'_DEPENDENCIES}' }})
 
         set(CMAKE_MODULE_PATH {{ comp.build_paths }} ${CMAKE_MODULE_PATH})
         set(CMAKE_PREFIX_PATH {{ comp.build_paths }} ${CMAKE_PREFIX_PATH})

--- a/conans/client/generators/cmake_find_package_multi.py
+++ b/conans/client/generators/cmake_find_package_multi.py
@@ -148,7 +148,15 @@ set_property(TARGET {name}::{name}
                                       "{{ build_type }}"
                                       "{{ pkg_name }}_{{ comp_name }}")
 
-        set({{ pkg_name }}_{{ comp_name }}_LINK_LIBS_{{ build_type }} {{ '${'+pkg_name+'_'+comp_name+'_LIB_TARGETS_'+build_type+'}' }} {{ '${'+pkg_name+'_'+comp_name+'_SYSTEM_LIBS_'+build_type+'}' }} {{ '${'+pkg_name+'_'+comp_name+'_DEPENDENCIES_'+build_type+'}' }})
+        foreach(_FRAMEWORK {{ '${'+pkg_name+'_'+comp_name+'_FRAMEWORKS_FOUND_'+build_type+'}' }})
+            list(APPEND {{ pkg_name+'_'+comp_name+'_LIB_TARGETS_'+build_type }} ${_FRAMEWORK})
+        endforeach()
+
+        foreach(_SYSTEM_LIB {{ '${'+pkg_name+'_'+comp_name+'_SYSTEM_LIBS_'+build_type+'}' }})
+            list(APPEND {{ pkg_name+'_'+comp_name+'_LIB_TARGETS_'+build_type }} ${_SYSTEM_LIB})
+        endforeach()
+
+        set({{ pkg_name }}_{{ comp_name }}_LINK_LIBS_{{ build_type }} {{ '${'+pkg_name+'_'+comp_name+'_LIB_TARGETS_'+build_type+'}' }} {{ '${'+pkg_name+'_'+comp_name+'_DEPENDENCIES_'+build_type+'}' }})
 
         {%- endfor %}
         """))

--- a/conans/client/generators/cmake_find_package_multi.py
+++ b/conans/client/generators/cmake_find_package_multi.py
@@ -148,15 +148,7 @@ set_property(TARGET {name}::{name}
                                       "{{ build_type }}"
                                       "{{ pkg_name }}_{{ comp_name }}")
 
-        foreach(_FRAMEWORK {{ '${'+pkg_name+'_'+comp_name+'_FRAMEWORKS_FOUND_'+build_type+'}' }})
-            list(APPEND {{ pkg_name+'_'+comp_name+'_LIB_TARGETS_'+build_type }} ${_FRAMEWORK})
-        endforeach()
-
-        foreach(_SYSTEM_LIB {{ '${'+pkg_name+'_'+comp_name+'_SYSTEM_LIBS_'+build_type+'}' }})
-            list(APPEND {{ pkg_name+'_'+comp_name+'_LIB_TARGETS_'+build_type }} ${_SYSTEM_LIB})
-        endforeach()
-
-        set({{ pkg_name }}_{{ comp_name }}_LINK_LIBS_{{ build_type }} {{ '${'+pkg_name+'_'+comp_name+'_LIB_TARGETS_'+build_type+'}' }} {{ '${'+pkg_name+'_'+comp_name+'_DEPENDENCIES_'+build_type+'}' }})
+        set({{ pkg_name }}_{{ comp_name }}_LINK_LIBS_{{ build_type }} {{ '${'+pkg_name+'_'+comp_name+'_LIB_TARGETS_'+build_type+'}' }} {{ '${'+pkg_name+'_'+comp_name+'_LIBS_FRAMEWORKS_DEPS_'+build_type+'}' }})
 
         {%- endfor %}
         """))

--- a/conans/client/generators/cmake_find_package_multi.py
+++ b/conans/client/generators/cmake_find_package_multi.py
@@ -148,7 +148,7 @@ set_property(TARGET {name}::{name}
                                       "{{ build_type }}"
                                       "{{ pkg_name }}_{{ comp_name }}")
 
-        set({{ pkg_name }}_{{ comp_name }}_LINK_LIBS_{{ build_type }} {{ '${'+pkg_name+'_'+comp_name+'_LIB_TARGETS_'+build_type+'}' }} {{ '${'+pkg_name+'_'+comp_name+'_DEPENDENCIES_'+build_type+'}' }})
+        set({{ pkg_name }}_{{ comp_name }}_LINK_LIBS_{{ build_type }} {{ '${'+pkg_name+'_'+comp_name+'_LIB_TARGETS_'+build_type+'}' }} {{ '${'+pkg_name+'_'+comp_name+'_SYSTEM_LIBS_'+build_type+'}' }} {{ '${'+pkg_name+'_'+comp_name+'_DEPENDENCIES_'+build_type+'}' }})
 
         {%- endfor %}
         """))

--- a/conans/test/functional/generators/cmake_find_package_multi_test.py
+++ b/conans/test/functional/generators/cmake_find_package_multi_test.py
@@ -408,3 +408,48 @@ class Conan(ConanFile):
 
         self.assertIn('set(requirement_LIBRARY_LIST_RELEASE lib_both lib_release)', content_release)
         self.assertIn('set(requirement_LIBRARY_LIST_DEBUG lib_both lib_debug)', content_debug)
+
+    def components_system_libs_test(self):
+        conanfile = textwrap.dedent("""
+            from conans import ConanFile
+
+            class Requirement(ConanFile):
+                name = "requirement"
+                version = "system"
+
+                settings = "os", "arch", "compiler", "build_type"
+
+                def package_info(self):
+                    self.cpp_info.components["component"].system_libs = ["system_lib_component"]
+        """)
+        t = TestClient()
+        t.save({"conanfile.py": conanfile})
+        t.run("create .")
+
+        conanfile = textwrap.dedent("""
+            from conans import ConanFile, tools, CMake
+            class Consumer(ConanFile):
+                name = "consumer"
+                version = "0.1"
+                requires = "requirement/system"
+                generators = "cmake_find_package_multi"
+                exports_sources = "CMakeLists.txt"
+                settings = "os", "arch", "compiler", "build_type"
+
+                def build(self):
+                    cmake = CMake(self)
+                    cmake.configure()
+        """)
+
+        cmakelists = textwrap.dedent("""
+            project(consumer)
+            cmake_minimum_required(VERSION 3.1)
+            find_package(requirement)
+            get_target_property(tmp requirement::component INTERFACE_LINK_LIBRARIES)
+            message("component libs: ${tmp}")
+        """)
+
+        t.save({"conanfile.py": conanfile, "CMakeLists.txt": cmakelists})
+        t.run("create . --build missing -s build_type=Release")
+
+        self.assertIn("component libs: $<$<CONFIG:Release>:system_lib_component", t.out)

--- a/conans/test/functional/generators/cmake_find_package_test.py
+++ b/conans/test/functional/generators/cmake_find_package_test.py
@@ -615,3 +615,48 @@ class Conan(ConanFile):
         content = t.load("Findrequirement.cmake")
         self.assertIn('set(requirement_COMPILE_OPTIONS_LIST "-req_both;-req_debug" "")', content)
         self.assertIn('set(requirement_LIBRARY_LIST lib_both lib_debug)', content)
+
+    def components_system_libs_test(self):
+        conanfile = textwrap.dedent("""
+            from conans import ConanFile
+
+            class Requirement(ConanFile):
+                name = "requirement"
+                version = "system"
+
+                settings = "os", "arch", "compiler", "build_type"
+
+                def package_info(self):
+                    self.cpp_info.components["component"].system_libs = ["system_lib_component"]
+        """)
+        t = TestClient()
+        t.save({"conanfile.py": conanfile})
+        t.run("create .")
+
+        conanfile = textwrap.dedent("""
+            from conans import ConanFile, tools, CMake
+            class Consumer(ConanFile):
+                name = "consumer"
+                version = "0.1"
+                requires = "requirement/system"
+                generators = "cmake_find_package"
+                exports_sources = "CMakeLists.txt"
+                settings = "os", "arch", "compiler"
+
+                def build(self):
+                    cmake = CMake(self)
+                    cmake.configure()
+        """)
+
+        cmakelists = textwrap.dedent("""
+            project(consumer)
+            cmake_minimum_required(VERSION 3.1)
+            find_package(requirement)
+            get_target_property(tmp requirement::component INTERFACE_LINK_LIBRARIES)
+            message("component libs: ${tmp}")
+        """)
+
+        t.save({"conanfile.py": conanfile, "CMakeLists.txt": cmakelists})
+        t.run("create . --build missing")
+
+        self.assertIn("component libs: system_lib_component;", t.out)


### PR DESCRIPTION
Changelog: Fix: Add system libs and frameworks to components targets in `cmake_find_package` and `cmake_find_package_multi` generators.
Docs: omit

When system_libs were added to components like in this recipe: https://github.com/conan-io/conan-center-index/blob/a5605be7613edeb705801440b69db2709e16be79/recipes/xorg/all/conanfile.py#L28 those libs are not added to the components targets, that's the reason why this is failing: https://travis-ci.org/github/conan-io/examples/jobs/721587427

- [X] Refer to the issue that supports this Pull Request.
- [X] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [X] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [X] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 

<sup>**Note:** By default this PR will skip the slower tests and will use a limited set of python versions. Check [here](https://github.com/conan-io/conan/blob/develop/.github/PR_INCREASE_TESTING.md) how to increase the testing level by writing some tags in the current PR body text.</sup>
