### PR TITLE
Add support for system_libs and frameworks for Qbs generator

### DIFF
--- a/conans/client/generators/qbs.py
+++ b/conans/client/generators/qbs.py
@@ -9,7 +9,10 @@ class DepsCppQbs(object):
                                             for p in cpp_info.include_paths)
         self.lib_paths = delimiter.join('"%s"' % p.replace("\\", "/")
                                         for p in cpp_info.lib_paths)
-        self.libs = delimiter.join('"%s"' % l for l in cpp_info.libs)
+        self.libs = delimiter.join('"%s"' % l for l in (cpp_info.libs + cpp_info.system_libs))
+        self.framework_paths = delimiter.join('"%s"' % p.replace("\\", "/")
+                                              for p in cpp_info.framework_paths)
+        self.frameworks = delimiter.join('"%s"' % f for f in cpp_info.frameworks)
         self.defines = delimiter.join('"%s"' % d for d in cpp_info.defines)
         self.cxxflags = delimiter.join('"%s"' % d
                                        for d in cpp_info.cxxflags)
@@ -39,6 +42,8 @@ class QbsGenerator(Generator):
                     '            cpp.libraryPaths: [{deps.lib_paths}]\n'
                     '            cpp.systemIncludePaths: [{deps.bin_paths}]\n'
                     '            cpp.dynamicLibraries: [{deps.libs}]\n'
+                    '            cpp.frameworkPaths: [{deps.framework_paths}]\n'
+                    '            cpp.frameworks: [{deps.frameworks}]\n'
                     '            cpp.defines: [{deps.defines}]\n'
                     '            cpp.cxxFlags: [{deps.cxxflags}]\n'
                     '            cpp.cFlags: [{deps.cflags}]\n'


### PR DESCRIPTION
Changelog: Feature: Added support for `cpp_info.system_libs`, `cpp_info.framework_paths` and `cpp_info.frameworks` for ``qbs`` generator.
Docs: Omit

partially implements #6008

- [x] Refer to the issue that supports this Pull Request.
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 

<sup>**Note:** By default this PR will skip the slower tests and will use a limited set of python versions. Check [here](https://github.com/conan-io/conan/blob/develop/.github/PR_INCREASE_TESTING.md) how to increase the testing level by writing some tags in the current PR body text.</sup>
