### PR TITLE
fix import of iterable in six library

### DIFF
--- a/conans/util/misc.py
+++ b/conans/util/misc.py
@@ -1,5 +1,9 @@
 import six
 
+try:
+    from collections.abc import Iterable
+except ImportError:  # FIXME: Remove if Python2 support is removed
+    from collections import Iterable
 
 def make_tuple(value):
     """ Converts the value into a tuple if the value is an iterable with the following exceptions:
@@ -12,7 +16,7 @@ def make_tuple(value):
     if isinstance(value, six.string_types):
         return value,
 
-    if isinstance(value, six.moves.collections_abc.Iterable):
+    if isinstance(value, Iterable):
         return tuple(value)
     else:
         return value,


### PR DESCRIPTION
Changelog: Fix: Fix import of ``six.moves.collections_abc`` non existing for some six versions.
Docs: Omit

Backport of #7545 (for 1.29)
Close https://github.com/conan-io/conan/issues/7621