### PR TITLE
Fix conan info --build-order deprecation message.

### DIFF
--- a/conans/client/command.py
+++ b/conans/client/command.py
@@ -682,7 +682,7 @@ class Command(object):
 
         if args.build_order:
             self._out.warn("Usage of `--build-order` argument is deprecated and can return"
-                           " wrong results. Use `conan graph build-order ...` instead.")
+                           " wrong results. Use `conan lock build-order ...` instead.")
 
         if args.install_folder and (args.profile_host or args.settings_host
                                     or args.options_host or args.env_host):

--- a/conans/test/functional/command/info/info_test.py
+++ b/conans/test/functional/command/info/info_test.py
@@ -541,10 +541,10 @@ class AConan(ConanFile):
                       self.client.out)
         self.client.run("info . -bo=Dev1/0.1@lasote/stable")
         self.assertEqual("WARN: Usage of `--build-order` argument is deprecated and can return wrong"
-                         " results. Use `conan graph build-order ...` instead.\n\n", self.client.out)
+                         " results. Use `conan lock build-order ...` instead.\n\n", self.client.out)
         self.client.run("info . -bo=LibG/0.1@lasote/stable")
         self.assertEqual("WARN: Usage of `--build-order` argument is deprecated and can return wrong"
-                         " results. Use `conan graph build-order ...` instead.\n\n", self.client.out)
+                         " results. Use `conan lock build-order ...` instead.\n\n", self.client.out)
 
         self.client.run("info . --build-order=ALL")
         self.assertIn("[LibA/0.1@lasote/stable, LibE/0.1@lasote/stable, LibF/0.1@lasote/stable], "


### PR DESCRIPTION
Changelog: Fix: Fix `conan info --build-order` deprecation message.
Docs: omit

Related to: #7569 and https://github.com/conan-io/conan/pull/7570

- [ ] Refer to the issue that supports this Pull Request.
- [X] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [X] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [X] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 

<sup>**Note:** By default this PR will skip the slower tests and will use a limited set of python versions. Check [here](https://github.com/conan-io/conan/blob/develop/.github/PR_INCREASE_TESTING.md) how to increase the testing level by writing some tags in the current PR body text.</sup>
