### PR TITLE
Revert changes from PR 7586

### DIFF
--- a/conans/client/conf/detect.py
+++ b/conans/client/conf/detect.py
@@ -4,7 +4,7 @@ import re
 
 from conans.client.build.compiler_id import UNKNOWN_COMPILER, LLVM_GCC, detect_compiler_id
 from conans.client.output import Color
-from conans.client.tools import detected_os, OSInfo, which
+from conans.client.tools import detected_os, OSInfo
 from conans.client.tools.win import latest_visual_studio_version_installed
 from conans.model.version import Version
 from conans.util.conan_v2_mode import CONAN_V2_MODE_ENVVAR
@@ -82,59 +82,6 @@ def _sun_cc_compiler(output, compiler_exe="cc"):
         return None
 
 
-def _get_compiler_exe(exe):
-    # get real compiler executable from the alias like /usr/bin/cc (/usr/bin/c++)
-    compiler = which(exe)
-    if not compiler:
-        return None
-    # careful: avoid broken links and don't call readlink on Windows
-    if os.path.islink(compiler) and os.path.exists(compiler) and os.name == 'posix':
-        try:
-            compiler = os.readlink(compiler)
-        except IOError:
-            return None  # can't read link (e.g. due to the permissions)
-    return compiler
-
-
-def _choose_compiler_by_platform_priority(vs, cc, gcc, clang, sun_cc):
-    # historically, the compiler priority used to be different for platforms in conan
-    if detected_os() == "Windows":
-        return vs or cc or gcc or clang
-    elif platform.system() == "Darwin":
-        return clang or cc or gcc
-    elif platform.system() == "SunOS":
-        return sun_cc or cc or gcc or clang
-    else:
-        return cc or gcc or clang
-
-
-def _get_gcc_clang_suncc(output, command):
-    gcc = _gcc_compiler(output, command)
-    clang = _clang_compiler(output, command)
-    sun_cc = None
-    if platform.system() == "SunOS":
-        sun_cc = _sun_cc_compiler(output, command)
-    return gcc, clang, sun_cc
-
-
-def _get_compiler_from_command(output, command):
-    if "gcc" in command.lower() or ("g++" in command.lower() and not "clang" in command.lower()):
-        gcc = _gcc_compiler(output, command)
-        if platform.system() == "Darwin" and gcc is None:
-            output.error(
-                "%s detected as a frontend using apple-clang. Compiler not supported" % command
-            )
-        return gcc
-    if "clang" in command.lower():
-        return _clang_compiler(output, command)
-    if platform.system() == "SunOS" and command.lower() == "cc":
-        return _sun_cc_compiler(output, command)
-
-    # the compiler command doesn't contain an obvious name hint like "gcc" or "clang", so brute-force
-    gcc, clang, sun_cc = _get_gcc_clang_suncc(output, command)
-    return _choose_compiler_by_platform_priority(None, None, gcc, clang, sun_cc)
-
-
 def _get_default_compiler(output):
     """
     find the default compiler on the build machine
@@ -154,15 +101,25 @@ def _get_default_compiler(output):
         command = cc or cxx
         if v2_mode:
             compiler = _get_compiler_and_version(output, command)
+            if compiler:
+                return compiler
         else:
-            compiler = _get_compiler_from_command(output, command)
-        if compiler:
-            return compiler
+            if "gcc" in command:
+                gcc = _gcc_compiler(output, command)
+                if platform.system() == "Darwin" and gcc is None:
+                    output.error(
+                        "%s detected as a frontend using apple-clang. Compiler not supported" % command
+                    )
+                return gcc
+            if "clang" in command.lower():
+                return _clang_compiler(output, command)
+            if platform.system() == "SunOS" and command.lower() == "cc":
+                return _sun_cc_compiler(output, command)
         # I am not able to find its version
         output.error("Not able to automatically detect '%s' version" % command)
         return None
 
-    vs = sun_cc = None
+    vs = cc = sun_cc = None
     if detected_os() == "Windows":
         version = latest_visual_studio_version_installed(output)
         vs = ('Visual Studio', version) if version else None
@@ -172,18 +129,19 @@ def _get_default_compiler(output):
         gcc = _get_compiler_and_version(output, "gcc")
         clang = _get_compiler_and_version(output, "clang")
     else:
-        cc = _get_compiler_exe("cc")
-        cxx = _get_compiler_exe("c++")
-        if cc or cxx:
-            output.info("cc and cxx: %s, %s " % (cc or "None", cxx or "None"))
-            command = cxx or cxx
-            compiler = _get_compiler_from_command(output, command)
-            if compiler:
-                return compiler
-        cc = None
-        gcc, clang, sun_cc = _get_gcc_clang_suncc(output, command=None)
+        gcc = _gcc_compiler(output)
+        clang = _clang_compiler(output)
+        if platform.system() == "SunOS":
+            sun_cc = _sun_cc_compiler(output)
 
-    return _choose_compiler_by_platform_priority(vs, cc, gcc, clang, sun_cc)
+    if detected_os() == "Windows":
+        return vs or cc or gcc or clang
+    elif platform.system() == "Darwin":
+        return clang or cc or gcc
+    elif platform.system() == "SunOS":
+        return sun_cc or cc or gcc or clang
+    else:
+        return cc or gcc or clang
 
 
 def _get_profile_compiler_version(compiler, version, output):


### PR DESCRIPTION
Changelog: omit
Docs: omit

This PR reverts the changes from: https://github.com/conan-io/conan/pull/7586
It was necessary as this test: https://github.com/conan-io/test/blob/master/conan_tests/external_tools/meson_test.py was failing for Windows. 
The reason is that if `cc` or `c++` are in the path in Windows they will be detected as the default compilers and this changes the behaviour from previous versions. We are reverting this for the moment and will be testing the compiler auto-detection further.