### PR TITLE
[test] Take into account other env-vars that can modify detected profile

### DIFF
--- a/conans/test/utils/tools.py
+++ b/conans/test/utils/tools.py
@@ -454,7 +454,8 @@ if get_env("CONAN_TEST_WITH_ARTIFACTORY", False):
 
 def _copy_cache_folder(target_folder):
     # Some variables affect to cache population (take a different default folder)
-    cache_key = hash(os.environ.get(CONAN_V2_MODE_ENVVAR, None))
+    vars = [CONAN_V2_MODE_ENVVAR, 'CC', 'CXX', 'PATH']
+    cache_key = hash(map(str, [os.environ.get(it, None) for it in vars]))
     master_folder = _copy_cache_folder.master.setdefault(cache_key, temp_folder(create_dir=False))
     if not os.path.exists(master_folder):
         # Create and populate the cache folder with the defaults

--- a/conans/test/utils/tools.py
+++ b/conans/test/utils/tools.py
@@ -455,7 +455,7 @@ if get_env("CONAN_TEST_WITH_ARTIFACTORY", False):
 def _copy_cache_folder(target_folder):
     # Some variables affect to cache population (take a different default folder)
     vars = [CONAN_V2_MODE_ENVVAR, 'CC', 'CXX', 'PATH']
-    cache_key = hash(map(str, [os.environ.get(it, None) for it in vars]))
+    cache_key = hash('|'.join(map(str, [os.environ.get(it, None) for it in vars])))
     master_folder = _copy_cache_folder.master.setdefault(cache_key, temp_folder(create_dir=False))
     if not os.path.exists(master_folder):
         # Create and populate the cache folder with the defaults


### PR DESCRIPTION
Changelog: omit
Docs: omit

Not only `CONAN_V2_MODE`, but other environment variables can affect the detected profile. Here I'm adding some of them, so when writing a test we don't need to write explicitly `cache_autopopulate=False` when instantiating the profile. Even if this is something that the test writer should take care of, we can pay some time and run the detection again if some of these variables changes.

**Note.-** IMO, we should move everything related to autodetection to some isolated module to have a better understanding of inputs and outputs, now these functions are spread in the codebase.