### PR TITLE
[feat] Take into account 'requires' information to propagate only those components

### DIFF
--- a/conans/client/generators/cmake_find_package.py
+++ b/conans/client/generators/cmake_find_package.py
@@ -238,8 +238,7 @@ class CMakeFindPackageGenerator(GeneratorComponentsMixin, Generator):
         self._validate_components(cpp_info)
 
         public_deps = self.get_public_deps(cpp_info)
-
-        deps_names = ';'.join(["{}::{}".format(*self._get_require_name(*it)) for it in public_deps if it[0] != cpp_info.name])
+        deps_names = ';'.join(["{}::{}".format(*self._get_require_name(*it)) for it in public_deps])
         pkg_public_deps_filenames = [self._get_filename(self.deps_build_info[it[0]]) for it in public_deps]
 
         pkg_version = cpp_info.version

--- a/conans/client/generators/cmake_find_package.py
+++ b/conans/client/generators/cmake_find_package.py
@@ -238,7 +238,8 @@ class CMakeFindPackageGenerator(GeneratorComponentsMixin, Generator):
         self._validate_components(cpp_info)
 
         public_deps = self.get_public_deps(cpp_info)
-        deps_names = ';'.join(["{}::{}".format(*it) for it in public_deps])
+
+        deps_names = ';'.join(["{}::{}".format(*self._get_require_name(*it)) for it in public_deps if it[0] != cpp_info.name])
         pkg_public_deps_filenames = [self._get_filename(self.deps_build_info[it[0]]) for it in public_deps]
 
         pkg_version = cpp_info.version

--- a/conans/client/generators/cmake_find_package.py
+++ b/conans/client/generators/cmake_find_package.py
@@ -1,17 +1,17 @@
-from jinja2 import Template
 import textwrap
+
+from jinja2 import Template
 
 from conans.client.generators.cmake import DepsCppCmake
 from conans.client.generators.cmake_find_package_common import (target_template,
                                                                 CMakeFindPackageCommonMacros,
                                                                 find_transitive_dependencies)
 from conans.client.generators.cmake_multi import extend
-from conans.errors import ConanException
 from conans.model import Generator
-from conans.model.build_info import COMPONENT_SCOPE
+from conans.model.conan_generator import GeneratorComponentsMixin
 
 
-class CMakeFindPackageGenerator(Generator):
+class CMakeFindPackageGenerator(GeneratorComponentsMixin, Generator):
     name = "cmake_find_package"
 
     find_template = textwrap.dedent("""
@@ -224,11 +224,13 @@ class CMakeFindPackageGenerator(Generator):
         return ret
 
     def _get_components(self, pkg_name, cpp_info):
-        generator_components = super(CMakeFindPackageGenerator, self)._get_components(pkg_name, cpp_info)
+        generator_components = super(CMakeFindPackageGenerator, self)._get_components(pkg_name,
+                                                                                      cpp_info)
         ret = []
         for comp_genname, comp, comp_requires_gennames in generator_components:
             deps_cpp_cmake = DepsCppCmake(comp)
-            deps_cpp_cmake.public_deps = " ".join(["{}::{}".format(*it) for it in comp_requires_gennames])
+            deps_cpp_cmake.public_deps = " ".join(
+                ["{}::{}".format(*it) for it in comp_requires_gennames])
             ret.append((comp_genname, deps_cpp_cmake))
         return ret
 
@@ -266,7 +268,7 @@ class CMakeFindPackageGenerator(Generator):
                 CMakeFindPackageCommonMacros.conan_message,
                 CMakeFindPackageCommonMacros.apple_frameworks_macro,
                 CMakeFindPackageCommonMacros.conan_package_library_targets,
-                ])
+            ])
 
             # compose the cpp_info with its "debug" or "release" specific config
             dep_cpp_info = cpp_info

--- a/conans/client/generators/cmake_find_package.py
+++ b/conans/client/generators/cmake_find_package.py
@@ -224,10 +224,9 @@ class CMakeFindPackageGenerator(GeneratorComponentsMixin, Generator):
         return ret
 
     def _get_components(self, pkg_name, cpp_info):
-        generator_components = super(CMakeFindPackageGenerator, self)._get_components(pkg_name,
-                                                                                      cpp_info)
+        components = super(CMakeFindPackageGenerator, self)._get_components(pkg_name, cpp_info)
         ret = []
-        for comp_genname, comp, comp_requires_gennames in generator_components:
+        for comp_genname, comp, comp_requires_gennames in components:
             deps_cpp_cmake = DepsCppCmake(comp)
             deps_cpp_cmake.public_deps = " ".join(
                 ["{}::{}".format(*it) for it in comp_requires_gennames])
@@ -236,15 +235,13 @@ class CMakeFindPackageGenerator(GeneratorComponentsMixin, Generator):
 
     def _find_for_dep(self, pkg_name, pkg_findname, pkg_filename, cpp_info):
         # return the content of the FindXXX.cmake file for the package "pkg_name"
-        # deps_names = ';'.join(["{}::{}".format(*it) for it in self.get_public_deps(cpp_info)])
-        # print(deps_names)
+        self._validate_components(cpp_info)
+
+        public_deps = self.get_public_deps(cpp_info)
+        deps_names = ';'.join(["{}::{}".format(*it) for it in public_deps])
+        pkg_public_deps_filenames = [self._get_filename(self.deps_build_info[it[0]]) for it in public_deps]
 
         pkg_version = cpp_info.version
-        pkg_public_deps_filenames = [self._get_filename(self.deps_build_info[public_dep])
-                                     for public_dep in cpp_info.public_deps]
-        pkg_public_deps_names = [self._get_name(self.deps_build_info[public_dep])
-                                 for public_dep in cpp_info.public_deps]
-        deps_names = ";".join(["{n}::{n}".format(n=n) for n in pkg_public_deps_names])
         if cpp_info.components:
             components = self._get_components(pkg_name, cpp_info)
             # Note these are in reversed order, from more dependent to less dependent
@@ -287,7 +284,7 @@ class CMakeFindPackageGenerator(GeneratorComponentsMixin, Generator):
 
             # The find_transitive_dependencies block
             find_dependencies_block = ""
-            if dep_cpp_info.public_deps:
+            if pkg_public_deps_filenames:
                 # Here we are generating FindXXX, so find_modules=True
                 f = find_transitive_dependencies(pkg_public_deps_filenames, find_modules=True)
                 # proper indentation

--- a/conans/client/generators/cmake_find_package.py
+++ b/conans/client/generators/cmake_find_package.py
@@ -236,6 +236,9 @@ class CMakeFindPackageGenerator(GeneratorComponentsMixin, Generator):
 
     def _find_for_dep(self, pkg_name, pkg_findname, pkg_filename, cpp_info):
         # return the content of the FindXXX.cmake file for the package "pkg_name"
+        # deps_names = ';'.join(["{}::{}".format(*it) for it in self.get_public_deps(cpp_info)])
+        # print(deps_names)
+
         pkg_version = cpp_info.version
         pkg_public_deps_filenames = [self._get_filename(self.deps_build_info[public_dep])
                                      for public_dep in cpp_info.public_deps]

--- a/conans/client/generators/cmake_find_package_multi.py
+++ b/conans/client/generators/cmake_find_package_multi.py
@@ -1,5 +1,6 @@
-from jinja2 import Template
 import textwrap
+
+from jinja2 import Template
 
 from conans.client.generators import CMakeFindPackageGenerator
 from conans.client.generators.cmake import DepsCppCmake
@@ -7,9 +8,6 @@ from conans.client.generators.cmake_find_package_common import (find_transitive_
                                                                 target_template,
                                                                 CMakeFindPackageCommonMacros)
 from conans.client.generators.cmake_multi import extend
-from conans.errors import ConanException
-from conans.model import Generator
-from conans.model.build_info import COMPONENT_SCOPE
 
 
 class CMakeFindPackageMultiGenerator(CMakeFindPackageGenerator):
@@ -314,7 +312,7 @@ set_property(TARGET {name}::{name}
                 cpp_info = extend(cpp_info, build_type.lower())
                 pkg_info = DepsCppCmake(cpp_info)
                 deps_names = ";".join(["{n}::{n}".format(n=n) for n in pkg_public_deps_names])
-                components = self._get_components(pkg_name, pkg_findname, cpp_info)
+                components = self._get_components(pkg_name, cpp_info)
                 # Note these are in reversed order, from more dependent to less dependent
                 pkg_components = " ".join(["{p}::{c}".format(p=pkg_findname, c=comp_findname) for
                                            comp_findname, _ in reversed(components)])

--- a/conans/client/generators/cmake_find_package_multi.py
+++ b/conans/client/generators/cmake_find_package_multi.py
@@ -282,9 +282,9 @@ set_property(TARGET {name}::{name}
             pkg_version = cpp_info.version
 
             public_deps = self.get_public_deps(cpp_info)
-            deps_names = ';'.join(["{}::{}".format(*self._get_require_name(*it)) for it in public_deps if it[0] != cpp_info.name])
+            deps_names = ';'.join(["{}::{}".format(*self._get_require_name(*it)) for it in public_deps])
             pkg_public_deps_filenames = [self._get_filename(self.deps_build_info[it[0]]) for it in
-                                         public_deps if it[0] != cpp_info.name]
+                                         public_deps]
             ret["{}ConfigVersion.cmake".format(pkg_filename)] = self.config_version_template. \
                 format(version=pkg_version)
             if not cpp_info.components:

--- a/conans/client/generators/cmake_find_package_multi.py
+++ b/conans/client/generators/cmake_find_package_multi.py
@@ -282,7 +282,7 @@ set_property(TARGET {name}::{name}
             pkg_version = cpp_info.version
 
             public_deps = self.get_public_deps(cpp_info)
-            deps_names = ';'.join(["{}::{}".format(*it) for it in public_deps])
+            deps_names = ';'.join(["{}::{}".format(*self._get_require_name(*it)) for it in public_deps if it[0] != cpp_info.name])
             pkg_public_deps_filenames = [self._get_filename(self.deps_build_info[it[0]]) for it in
                                          public_deps if it[0] != cpp_info.name]
             ret["{}ConfigVersion.cmake".format(pkg_filename)] = self.config_version_template. \

--- a/conans/client/generators/pkg_config.py
+++ b/conans/client/generators/pkg_config.py
@@ -35,40 +35,12 @@ class PkgConfigGenerator(Generator):
     def compiler(self):
         return self.conanfile.settings.get_safe("compiler")
 
-    @classmethod
-    def _get_name(cls, obj):
-        get_name = getattr(obj, "get_name")
-        return get_name(cls.name)
-
     def _get_components(self, pkg_name, cpp_info):
-        generator_components = []
-        for comp_name, comp in self.sorted_components(cpp_info).items():
-            comp_genname = self._get_name(cpp_info.components[comp_name])
-            comp_requires_gennames = self._get_component_requires(pkg_name, comp)
-            generator_components.append((comp_genname, comp, comp_requires_gennames))
-        generator_components.reverse()  # From the less dependent to most one
-        return generator_components
-
-    def _get_component_requires(self, pkg_name, comp):
-        comp_requires_gennames = []
-        for require in comp.requires:
-            if COMPONENT_SCOPE in require:
-                comp_require_pkg_name, comp_require_comp_name = require.split(COMPONENT_SCOPE)
-                comp_require_pkg = self.deps_build_info[comp_require_pkg_name]
-                comp_require_pkg_genname = self._get_name(comp_require_pkg)
-                if comp_require_comp_name == comp_require_pkg_name:
-                    comp_require_comp_genname = comp_require_pkg_genname
-                elif comp_require_comp_name in self.deps_build_info[comp_require_pkg_name].components:
-                    comp_require_comp = comp_require_pkg.components[comp_require_comp_name]
-                    comp_require_comp_genname = self._get_name(comp_require_comp)
-                else:
-                    raise ConanException("Component '%s' not found in '%s' package requirement"
-                                         % (require, comp_require_pkg_name))
-            else:
-                comp_require_comp = self.deps_build_info[pkg_name].components[require]
-                comp_require_comp_genname = self._get_name(comp_require_comp)
-            comp_requires_gennames.append(comp_require_comp_genname)
-        return comp_requires_gennames
+        generator_components = super(PkgConfigGenerator, self)._get_components(pkg_name, cpp_info)
+        ret = []
+        for comp_genname, comp, comp_requires_gennames in generator_components:
+            ret.append((comp_genname, comp, [it[1] for it in comp_requires_gennames]))
+        return ret
 
     @property
     def content(self):

--- a/conans/client/generators/pkg_config.py
+++ b/conans/client/generators/pkg_config.py
@@ -49,12 +49,12 @@ class PkgConfigGenerator(GeneratorComponentsMixin, Generator):
             self._validate_components(cpp_info)
             if not cpp_info.components:
                 public_deps = self.get_public_deps(cpp_info)
-                deps_names = [self._get_require_name(*it)[1] for it in public_deps if it[0] != cpp_info.name]
-                ret["%s.pc" % pkg_genname] = self._single_pc_file_contents(pkg_genname, cpp_info, deps_names)
+                deps_names = [self._get_require_name(*it)[1] for it in public_deps]
+                ret["%s.pc" % pkg_genname] = self._pc_file_content(pkg_genname, cpp_info, deps_names)
             else:
                 components = self._get_components(depname, cpp_info)
                 for comp_genname, comp, comp_requires_gennames in components:
-                    ret["%s.pc" % comp_genname] = self._single_pc_file_contents(
+                    ret["%s.pc" % comp_genname] = self._pc_file_content(
                         "%s-%s" % (pkg_genname, comp_genname),
                         comp,
                         comp_requires_gennames)
@@ -64,7 +64,7 @@ class PkgConfigGenerator(GeneratorComponentsMixin, Generator):
                                                                               comp_gennames)
         return ret
 
-    def _single_pc_file_contents(self, name, cpp_info, requires_gennames):
+    def _pc_file_content(self, name, cpp_info, requires_gennames):
         prefix_path = cpp_info.rootpath.replace("\\", "/")
         lines = ['prefix=%s' % prefix_path]
 

--- a/conans/client/generators/pkg_config.py
+++ b/conans/client/generators/pkg_config.py
@@ -46,6 +46,7 @@ class PkgConfigGenerator(GeneratorComponentsMixin, Generator):
         ret = {}
         for depname, cpp_info in self.deps_build_info.dependencies:
             pkg_genname = cpp_info.get_name(PkgConfigGenerator.name)
+            self._validate_components(cpp_info)
             if not cpp_info.components:
                 ret["%s.pc" % pkg_genname] = self.single_pc_file_contents(pkg_genname, cpp_info,
                                                                           cpp_info.public_deps)

--- a/conans/client/generators/pkg_config.py
+++ b/conans/client/generators/pkg_config.py
@@ -49,8 +49,17 @@ class PkgConfigGenerator(GeneratorComponentsMixin, Generator):
             self._validate_components(cpp_info)
             if not cpp_info.components:
                 public_deps = self.get_public_deps(cpp_info)
-                requirements = [self._get_name(self.deps_build_info[it[0]].components[it[1]]) for it
-                                in public_deps if it[0] != cpp_info.name]
+                requirements = []
+                for pkg, cmp in public_deps:
+                    if pkg == cpp_info.name:
+                        continue
+                    pkg_cpp_info = self.deps_build_info[pkg]
+                    if cmp in pkg_cpp_info.components:
+                        requirements.append(self._get_name(pkg_cpp_info.components[cmp]))
+                    else:
+                        assert pkg == cmp
+                        requirements.append(self._get_name(pkg_cpp_info))
+
                 ret["%s.pc" % pkg_genname] = self._single_pc_file_contents(pkg_genname, cpp_info,
                                                                            requirements)
             else:

--- a/conans/client/generators/pkg_config.py
+++ b/conans/client/generators/pkg_config.py
@@ -2,9 +2,8 @@ import os
 
 from conans.client.build.compiler_flags import rpath_flags, format_frameworks, format_framework_paths
 from conans.client.tools.oss import get_build_os_arch
-from conans.errors import ConanException
 from conans.model import Generator
-from conans.model.build_info import COMPONENT_SCOPE
+from conans.model.conan_generator import GeneratorComponentsMixin
 
 """
 PC FILE EXAMPLE:
@@ -24,7 +23,7 @@ Requires.private: gthread-2.0 >= 2.40
 """
 
 
-class PkgConfigGenerator(Generator):
+class PkgConfigGenerator(GeneratorComponentsMixin, Generator):
     name = "pkg_config"
 
     @property
@@ -93,7 +92,8 @@ class PkgConfigGenerator(Generator):
         if not hasattr(self.conanfile, 'settings_build'):
             os_build = os_build or self.conanfile.settings.get_safe("os")
 
-        rpaths = rpath_flags(self.conanfile.settings, os_build, ["${%s}" % libdir for libdir in libdir_vars])
+        rpaths = rpath_flags(self.conanfile.settings, os_build,
+                             ["${%s}" % libdir for libdir in libdir_vars])
         frameworks = format_frameworks(cpp_info.frameworks, self.conanfile.settings)
         framework_paths = format_framework_paths(cpp_info.framework_paths, self.conanfile.settings)
 

--- a/conans/client/generators/pkg_config.py
+++ b/conans/client/generators/pkg_config.py
@@ -49,19 +49,8 @@ class PkgConfigGenerator(GeneratorComponentsMixin, Generator):
             self._validate_components(cpp_info)
             if not cpp_info.components:
                 public_deps = self.get_public_deps(cpp_info)
-                requirements = []
-                for pkg, cmp in public_deps:
-                    if pkg == cpp_info.name:
-                        continue
-                    pkg_cpp_info = self.deps_build_info[pkg]
-                    if cmp in pkg_cpp_info.components:
-                        requirements.append(self._get_name(pkg_cpp_info.components[cmp]))
-                    else:
-                        assert pkg == cmp
-                        requirements.append(self._get_name(pkg_cpp_info))
-
-                ret["%s.pc" % pkg_genname] = self._single_pc_file_contents(pkg_genname, cpp_info,
-                                                                           requirements)
+                deps_names = [self._get_require_name(*it)[1] for it in public_deps if it[0] != cpp_info.name]
+                ret["%s.pc" % pkg_genname] = self._single_pc_file_contents(pkg_genname, cpp_info, deps_names)
             else:
                 components = self._get_components(depname, cpp_info)
                 for comp_genname, comp, comp_requires_gennames in components:

--- a/conans/model/build_info.py
+++ b/conans/model/build_info.py
@@ -242,55 +242,64 @@ class CppInfo(_CppInfo):
         return self._configs.setdefault(config, _get_cpp_info())
 
     def _raise_incorrect_components_definition(self, package_name, package_requires):
-        if not self.components:
+        if not self.components and not self.requires:
             return
+
         # Raise if mixing components
-        if (self.includedirs != [DEFAULT_INCLUDE] or
-            self.libdirs != [DEFAULT_LIB] or
-            self.bindirs != [DEFAULT_BIN] or
-            self.resdirs != [DEFAULT_RES] or
-            self.builddirs != [DEFAULT_BUILD] or
-            self.frameworkdirs != [DEFAULT_FRAMEWORK] or
-            self.libs or
-            self.system_libs or
-            self.frameworks or
-            self.defines or
-            self.cflags or
-            self.cxxflags or
-            self.sharedlinkflags or
-            self.exelinkflags or
-            self.build_modules or
-            self.requires):
+        if self.components and \
+            (self.includedirs != [DEFAULT_INCLUDE] or
+             self.libdirs != [DEFAULT_LIB] or
+             self.bindirs != [DEFAULT_BIN] or
+             self.resdirs != [DEFAULT_RES] or
+             self.builddirs != [DEFAULT_BUILD] or
+             self.frameworkdirs != [DEFAULT_FRAMEWORK] or
+             self.libs or
+             self.system_libs or
+             self.frameworks or
+             self.defines or
+             self.cflags or
+             self.cxxflags or
+             self.sharedlinkflags or
+             self.exelinkflags or
+             self.build_modules or
+             self.requires):
             raise ConanException("self.cpp_info.components cannot be used with self.cpp_info "
                                  "global values at the same time")
         if self._configs:
             raise ConanException("self.cpp_info.components cannot be used with self.cpp_info configs"
                                  " (release/debug/...) at the same time")
 
-        # Raise on component name
-        for comp_name, comp in self.components.items():
-            if comp_name == package_name:
-                raise ConanException("Component name cannot be the same as the package name: '%s'"
-                                     % comp_name)
-
-        # check that requires are used in components and check that components exists in requires
-        comp_requires = set()
-        for comp_name, comp in self.components.items():
-            for comp_require in comp.requires:
-                if COMPONENT_SCOPE in comp_require:
-                    comp_requires.add(
-                        comp_require[:comp_require.find(COMPONENT_SCOPE)])
         pkg_requires = [require.ref.name for require in package_requires.values()]
-        # Raise on components requires without package requires
-        for pkg_require in pkg_requires:
-            if pkg_require not in comp_requires:
-                raise ConanException("Package require '%s' not used in components requires"
-                                     % pkg_require)
-        # Raise on components requires requiring inexistent package requires
-        for comp_require in comp_requires:
-            if comp_require not in pkg_requires:
-                raise ConanException("Package require '%s' declared in components requires "
-                                     "but not defined as a recipe requirement" % comp_require)
+
+        def _check_components_requires_instersection(comp_requires):
+            reqs = [it.split(COMPONENT_SCOPE)[0] for it in comp_requires if COMPONENT_SCOPE in it]
+            # Raise on components requires without package requires
+            for pkg_require in pkg_requires:
+                if pkg_require not in reqs:
+                    raise ConanException("Package require '%s' not used in components requires"
+                                         % pkg_require)
+            # Raise on components requires requiring inexistent package requires
+            for comp_require in reqs:
+                if comp_require not in pkg_requires:
+                    raise ConanException("Package require '%s' declared in components requires "
+                                         "but not defined as a recipe requirement" % comp_require)
+
+        if self.components:
+            # Raise on component name
+            for comp_name, comp in self.components.items():
+                if comp_name == package_name:
+                    raise ConanException(
+                        "Component name cannot be the same as the package name: '%s'"
+                        % comp_name)
+
+            # check that requires are used in components and check that components exists in requires
+            requires_from_components = set()
+            for comp_name, comp in self.components.items():
+                requires_from_components.update(comp.requires)
+
+            _check_components_requires_instersection(requires_from_components)
+        else:
+            _check_components_requires_instersection(self.requires)
 
 
 class _BaseDepsCppInfo(_CppInfo):

--- a/conans/model/build_info.py
+++ b/conans/model/build_info.py
@@ -64,6 +64,7 @@ class _CppInfo(object):
         self.filenames = {}  # name of filename to create for various generators
         self.rootpath = ""
         self.sysroot = ""
+        self.requires = []
         self._build_modules_paths = None
         self._include_paths = None
         self._lib_paths = None
@@ -258,7 +259,8 @@ class CppInfo(_CppInfo):
             self.cxxflags or
             self.sharedlinkflags or
             self.exelinkflags or
-            self.build_modules):
+            self.build_modules or
+            self.requires):
             raise ConanException("self.cpp_info.components cannot be used with self.cpp_info "
                                  "global values at the same time")
         if self._configs:
@@ -310,6 +312,7 @@ class _BaseDepsCppInfo(_CppInfo):
         self.libs = merge_lists(self.libs, dep_cpp_info.libs)
         self.frameworks = merge_lists(self.frameworks, dep_cpp_info.frameworks)
         self.build_modules = merge_lists(self.build_modules, dep_cpp_info.build_modules_paths)
+        self.requires = merge_lists(self.requires, dep_cpp_info.requires)
         self.rootpaths.append(dep_cpp_info.rootpath)
 
         # Note these are in reverse order
@@ -367,6 +370,7 @@ class DepCppInfo(object):
         self._cflags = None
         self._sharedlinkflags = None
         self._exelinkflags = None
+        self._requires = None
 
         self._include_paths = None
         self._lib_paths = None
@@ -523,6 +527,10 @@ class DepCppInfo(object):
     @property
     def exelinkflags(self):
         return self._aggregated_values("exelinkflags")
+
+    @property
+    def requires(self):
+        return self._aggregated_values("requires")
 
 
 class DepsCppInfo(_BaseDepsCppInfo):

--- a/conans/model/conan_generator.py
+++ b/conans/model/conan_generator.py
@@ -91,8 +91,6 @@ class GeneratorComponentsMixin(object):
         return pkg_name, cmp_name
 
     def _get_components(self, pkg_name, cpp_info):
-        self._validate_components(cpp_info)  # TODO: Move it somewhere else, we need to validate root 'cpp_info.requires'
-
         ret = []
         for comp_name, comp in self.sorted_components(cpp_info).items():
             comp_genname = self._get_name(cpp_info.components[comp_name])
@@ -104,8 +102,12 @@ class GeneratorComponentsMixin(object):
         return ret
 
     def get_public_deps(self, cpp_info):
-        requires = cpp_info.requires or cpp_info.public_deps
         ret = []
-        for req in requires:
-            ret.append(self._get_require_name(req, req))
+        if cpp_info.requires:
+            for req in cpp_info.requires:
+                pkg, cmp = req.split(COMPONENT_SCOPE) if COMPONENT_SCOPE in req else (cpp_info.name, req)
+                ret.append((pkg, cmp))
+        else:
+            for req in cpp_info.public_deps:
+                ret.append((req, req))
         return ret

--- a/conans/model/conan_generator.py
+++ b/conans/model/conan_generator.py
@@ -51,6 +51,10 @@ class Generator(object):
     def filename(self):
         raise NotImplementedError()
 
+
+class GeneratorComponentsMixin(object):
+
+    @classmethod
     def sorted_components(self, cpp_info):
         return cpp_info._get_sorted_components()
 

--- a/conans/model/conan_generator.py
+++ b/conans/model/conan_generator.py
@@ -2,9 +2,13 @@ from abc import ABCMeta, abstractproperty
 
 import six
 
+from conans.errors import ConanException
+from conans.model.build_info import COMPONENT_SCOPE
+
 
 @six.add_metaclass(ABCMeta)
 class Generator(object):
+    name = None
 
     def __init__(self, conanfile):
         self.conanfile = conanfile
@@ -14,6 +18,10 @@ class Generator(object):
         self._env_info = conanfile.env_info
         self._deps_user_info = conanfile.deps_user_info
         self._user_info_build = getattr(conanfile, 'user_info_build', None)
+
+    @classmethod
+    def _get_name(cls, obj):
+        return obj.get_name(cls.name)
 
     @property
     def deps_build_info(self):
@@ -45,3 +53,49 @@ class Generator(object):
 
     def sorted_components(self, cpp_info):
         return cpp_info._get_sorted_components()
+
+    def _validate_components(self, cpp_info):
+        """ Check that all required components are provided by the dependencies """
+
+        def _check_component_in_requirements(require):
+            if COMPONENT_SCOPE in require:
+                req_name, req_comp_name = require.split(COMPONENT_SCOPE)
+                if req_name == req_comp_name:
+                    return
+                if req_comp_name not in self.deps_build_info[req_name].components:
+                    raise ConanException("Component '%s' not found in '%s' package requirement"
+                                         % (require, req_name))
+
+        for comp_name, comp in cpp_info.components.items():
+            for cmp_require in comp.requires:
+                _check_component_in_requirements(cmp_require)
+
+        # for pkg_require in cpp_info.requires:
+        #     _check_component_in_requirements(pkg_require)
+
+    def _get_components(self, pkg_name, cpp_info):
+        self._validate_components(cpp_info)
+
+        ret = []
+        for comp_name, comp in self.sorted_components(cpp_info).items():
+            comp_genname = self._get_name(cpp_info.components[comp_name])
+            comp_requires_gennames = self._get_component_requires(pkg_name, comp)
+            ret.append((comp_genname, comp, comp_requires_gennames))
+        ret.reverse()
+        return ret
+
+    def _get_component_requires(self, pkg_name, comp):
+        comp_requires = []
+        for require in comp.requires:
+            comp_require_pkg_name, comp_require_comp_name = pkg_name, require
+            if COMPONENT_SCOPE in require:
+                comp_require_pkg_name, comp_require_comp_name = require.split(COMPONENT_SCOPE)
+
+            comp_require_pkg = self.deps_build_info[comp_require_pkg_name]
+            comp_require_pkg_findname = self._get_name(comp_require_pkg)
+            if comp_require_comp_name in comp_require_pkg.components:
+                comp_require_comp_findname = self._get_name(comp_require_pkg.components[comp_require_comp_name])
+            else:
+                comp_require_comp_findname = comp_require_pkg_findname
+            comp_requires.append((comp_require_pkg_findname, comp_require_comp_findname))
+        return comp_requires

--- a/conans/model/conan_generator.py
+++ b/conans/model/conan_generator.py
@@ -51,6 +51,9 @@ class Generator(object):
     def filename(self):
         raise NotImplementedError()
 
+    def get_public_deps(self, cpp_info):
+        return cpp_info.public_deps
+
 
 class GeneratorComponentsMixin(object):
 
@@ -74,8 +77,8 @@ class GeneratorComponentsMixin(object):
             for cmp_require in comp.requires:
                 _check_component_in_requirements(cmp_require)
 
-        # for pkg_require in cpp_info.requires:
-        #     _check_component_in_requirements(pkg_require)
+        for pkg_require in cpp_info.requires:
+            _check_component_in_requirements(pkg_require)
 
     def _get_require_name(self, pkg_name, req):
         pkg, cmp = req.split(COMPONENT_SCOPE) if COMPONENT_SCOPE in req else (pkg_name, req)
@@ -88,7 +91,7 @@ class GeneratorComponentsMixin(object):
         return pkg_name, cmp_name
 
     def _get_components(self, pkg_name, cpp_info):
-        self._validate_components(cpp_info)
+        self._validate_components(cpp_info)  # TODO: Move it somewhere else, we need to validate root 'cpp_info.requires'
 
         ret = []
         for comp_name, comp in self.sorted_components(cpp_info).items():
@@ -98,4 +101,11 @@ class GeneratorComponentsMixin(object):
                 comp_requires_gennames.append(self._get_require_name(pkg_name, require))
             ret.append((comp_genname, comp, comp_requires_gennames))
         ret.reverse()
+        return ret
+
+    def get_public_deps(self, cpp_info):
+        requires = cpp_info.requires or cpp_info.public_deps
+        ret = []
+        for req in requires:
+            ret.append(self._get_require_name(req, req))
         return ret

--- a/conans/model/conan_generator.py
+++ b/conans/model/conan_generator.py
@@ -101,13 +101,10 @@ class GeneratorComponentsMixin(object):
         ret.reverse()
         return ret
 
-    def get_public_deps(self, cpp_info):
-        ret = []
+    @classmethod
+    def get_public_deps(cls, cpp_info):
         if cpp_info.requires:
-            for req in cpp_info.requires:
-                pkg, cmp = req.split(COMPONENT_SCOPE) if COMPONENT_SCOPE in req else (cpp_info.name, req)
-                ret.append((pkg, cmp))
+            deps = [it for it in cpp_info.requires if COMPONENT_SCOPE in it]
+            return [it.split(COMPONENT_SCOPE) for it in deps]
         else:
-            for req in cpp_info.public_deps:
-                ret.append((req, req))
-        return ret
+            return [(it, it) for it in cpp_info.public_deps]

--- a/conans/model/conan_generator.py
+++ b/conans/model/conan_generator.py
@@ -77,29 +77,25 @@ class GeneratorComponentsMixin(object):
         # for pkg_require in cpp_info.requires:
         #     _check_component_in_requirements(pkg_require)
 
+    def _get_require_name(self, pkg_name, req):
+        pkg, cmp = req.split(COMPONENT_SCOPE) if COMPONENT_SCOPE in req else (pkg_name, req)
+        pkg_build_info = self.deps_build_info[pkg]
+        pkg_name = self._get_name(pkg_build_info)
+        if cmp in pkg_build_info.components:
+            cmp_name = self._get_name(pkg_build_info.components[cmp])
+        else:
+            cmp_name = pkg_name
+        return pkg_name, cmp_name
+
     def _get_components(self, pkg_name, cpp_info):
         self._validate_components(cpp_info)
 
         ret = []
         for comp_name, comp in self.sorted_components(cpp_info).items():
             comp_genname = self._get_name(cpp_info.components[comp_name])
-            comp_requires_gennames = self._get_component_requires(pkg_name, comp)
+            comp_requires_gennames = []
+            for require in comp.requires:
+                comp_requires_gennames.append(self._get_require_name(pkg_name, require))
             ret.append((comp_genname, comp, comp_requires_gennames))
         ret.reverse()
         return ret
-
-    def _get_component_requires(self, pkg_name, comp):
-        comp_requires = []
-        for require in comp.requires:
-            comp_require_pkg_name, comp_require_comp_name = pkg_name, require
-            if COMPONENT_SCOPE in require:
-                comp_require_pkg_name, comp_require_comp_name = require.split(COMPONENT_SCOPE)
-
-            comp_require_pkg = self.deps_build_info[comp_require_pkg_name]
-            comp_require_pkg_findname = self._get_name(comp_require_pkg)
-            if comp_require_comp_name in comp_require_pkg.components:
-                comp_require_comp_findname = self._get_name(comp_require_pkg.components[comp_require_comp_name])
-            else:
-                comp_require_comp_findname = comp_require_pkg_findname
-            comp_requires.append((comp_require_pkg_findname, comp_require_comp_findname))
-        return comp_requires

--- a/conans/test/functional/generators/components/cmake_find_package_multi_test.py
+++ b/conans/test/functional/generators/components/cmake_find_package_multi_test.py
@@ -414,7 +414,7 @@ class CMakeGeneratorsWithComponentsTest(unittest.TestCase):
         self.assertIn("Hello World debug!", client.out)
         self.assertIn("Bye World debug!", client.out)
 
-    def test_find_package_components_test(self):
+    def find_package_components_test(self):
         client = TestClient()
         self._create_greetings(client)
         conanfile2 = textwrap.dedent("""

--- a/conans/test/functional/generators/components/cmake_find_package_multi_test.py
+++ b/conans/test/functional/generators/components/cmake_find_package_multi_test.py
@@ -414,7 +414,7 @@ class CMakeGeneratorsWithComponentsTest(unittest.TestCase):
         self.assertIn("Hello World debug!", client.out)
         self.assertIn("Bye World debug!", client.out)
 
-    def find_package_components_test(self):
+    def test_find_package_components_test(self):
         client = TestClient()
         self._create_greetings(client)
         conanfile2 = textwrap.dedent("""

--- a/conans/test/functional/generators/components/propagate_specific_components_test.py
+++ b/conans/test/functional/generators/components/propagate_specific_components_test.py
@@ -1,5 +1,6 @@
-import unittest
 import textwrap
+import unittest
+
 from conans.test.utils.tools import TestClient
 
 
@@ -46,24 +47,43 @@ class PropagateSpecificComponents(unittest.TestCase):
 
     def test_wrong_component(self):
         """ If the requirement doesn't provide the component, it fails """
-        cf = '/private/var/folders/fc/6mvcrc952dqcjfhl4c7c11ph0000gn/T/tmpa6tmtp3nconans/path with spaces'
-        t = TestClient(cache_folder=self.cache_folder, current_folder=cf)
+        t = TestClient(cache_folder=self.cache_folder)
         t.save({'conanfile.py': textwrap.dedent("""
             from conans import ConanFile
 
             class Recipe(ConanFile):
                 requires = "top/version"
                 def package_info(self):
-                    self.cpp_info.requires = ["top::wrong"]
+                    self.cpp_info.requires = ["top::not-existing"]
         """)})
         t.run('create conanfile.py wrong/version@')
-        t.run('install wrong/version@ -g cmake_find_package')
-        self.assertIn('TODO: Define message here', t.out)
+        for generator in ['pkg_config', 'cmake_find_package', 'cmake_find_package_multi']:
+            t.run('install wrong/version@ -g {}'.format(generator), assert_error=True)
+            self.assertIn("ERROR: Component 'top::not-existing' not found in 'top'"
+                          " package requirement", t.out)
 
     def test_cmake_find_package(self):
-        cf = '/private/var/folders/fc/6mvcrc952dqcjfhl4c7c11ph0000gn/T/tmpn_ig2dbcconans/path with spaces'
-        t = TestClient(cache_folder=self.cache_folder, current_folder=cf)
+        t = TestClient(cache_folder=self.cache_folder)
         t.run('install middle/version@ -g cmake_find_package')
-        c = t.load('Findmiddle.cmake')
-        print(c)
-        self.fail("AAA")
+        content = t.load('Findmiddle.cmake')
+        self.assertIn("find_dependency(top REQUIRED)", content)
+        self.assertNotIn("top::top", content)
+        self.assertNotIn("top::cmp2", content)
+        self.assertIn("top::cmp1", content)
+
+    def test_cmake_find_package_multi(self):
+        t = TestClient(cache_folder=self.cache_folder)
+        t.run('install middle/version@ -g cmake_find_package_multi')
+        content = t.load('middleConfig.cmake')
+        self.assertIn("find_dependency(top REQUIRED NO_MODULE)", content)
+        self.assertIn("find_package(top REQUIRED NO_MODULE)", content)
+
+        content = t.load('middleTarget-release.cmake')
+        self.assertNotIn("top::top", content)
+        self.assertNotIn("top::cmp2", content)
+        self.assertIn("top::cmp1", content)
+
+    def test_pkg_config(self):
+        t = TestClient(cache_folder=self.cache_folder)
+        t.run('install middle/version@ -g pkg_config')
+        content = t.load('middle.pc')

--- a/conans/test/functional/generators/components/propagate_specific_components_test.py
+++ b/conans/test/functional/generators/components/propagate_specific_components_test.py
@@ -87,3 +87,4 @@ class PropagateSpecificComponents(unittest.TestCase):
         t = TestClient(cache_folder=self.cache_folder)
         t.run('install middle/version@ -g pkg_config')
         content = t.load('middle.pc')
+        self.assertIn('Requires: cmp1', content)

--- a/conans/test/functional/generators/components/propagate_specific_components_test.py
+++ b/conans/test/functional/generators/components/propagate_specific_components_test.py
@@ -1,0 +1,67 @@
+import unittest
+import textwrap
+from conans.test.utils.tools import TestClient
+
+@unittest.skip
+class PropagateSpecificComponents(unittest.TestCase):
+    """
+        Feature: recipes can declare the components they are consuming from their requirements,
+        only those components should be propagated to their own consumers. If required components
+        doesn't exist, Conan will fail:
+         * Resolved versions/revisions of the requirement might provide different components or
+           no components at all.
+    """
+
+    top = textwrap.dedent("""
+        from conans import ConanFile
+
+        class Recipe(ConanFile):
+            name = "top"
+
+            def package_info(self):
+                self.cpp_info.components["cmp1"].libs = ["top_cmp1"]
+                self.cpp_info.components["cmp2"].libs = ["top_cmp2"]
+    """)
+
+    middle = textwrap.dedent("""
+        from conans import ConanFile
+
+        class Recipe(ConanFile):
+            name = "middle"
+            requires = "top/version"
+            def package_info(self):
+                self.cpp_info.requires = ["top::cmp1"]
+    """)
+
+    @classmethod
+    def setUpClass(cls):
+        client = TestClient()
+        client.save({
+            'top.py': cls.top,
+            'middle.py': cls.middle
+        })
+        client.run('create top.py top/version@')
+        client.run('create middle.py middle/version@')
+        cls.cache_folder = client.cache_folder
+
+    def test_wrong_component(self):
+        """ If the requirement doesn't provide the component, it fails """
+        t = TestClient(cache_folder=self.cache_folder)
+        t.save({'conanfile.py': textwrap.dedent("""
+            from conans import ConanFile
+
+            class Recipe(ConanFile):
+                requires = "top/version"
+                def package_info(self):
+                    self.cpp_info.requires = ["top::wrong"]
+        """)})
+        t.run('', assert_error=True) # TODO: Anything that triggers component validation
+        self.assertIn('TODO: Define message here', t.out)
+
+    def test_cmake_find_package(self):
+        cf = '/private/var/folders/fc/6mvcrc952dqcjfhl4c7c11ph0000gn/T/tmpn_ig2dbcconans/path with spaces'
+        t = TestClient(cache_folder=self.cache_folder, current_folder=cf)
+        t.run('install middle/version@ -g cmake_find_package')
+        c = t.load('Findmiddle.cmake')
+        print(c)
+        self.fail("AAA")

--- a/conans/test/functional/generators/components/propagate_specific_components_test.py
+++ b/conans/test/functional/generators/components/propagate_specific_components_test.py
@@ -34,16 +34,15 @@ class PropagateSpecificComponents(unittest.TestCase):
                 self.cpp_info.requires = ["top::cmp1"]
     """)
 
-    @classmethod
-    def setUpClass(cls):
+    def setUp(self):
         client = TestClient()
         client.save({
-            'top.py': cls.top,
-            'middle.py': cls.middle
+            'top.py': self.top,
+            'middle.py': self.middle
         })
         client.run('create top.py top/version@')
         client.run('create middle.py middle/version@')
-        cls.cache_folder = client.cache_folder
+        self.cache_folder = client.cache_folder
 
     def test_cmake_find_package(self):
         t = TestClient(cache_folder=self.cache_folder)

--- a/conans/test/functional/generators/components/propagate_specific_components_test.py
+++ b/conans/test/functional/generators/components/propagate_specific_components_test.py
@@ -2,7 +2,7 @@ import unittest
 import textwrap
 from conans.test.utils.tools import TestClient
 
-@unittest.skip
+
 class PropagateSpecificComponents(unittest.TestCase):
     """
         Feature: recipes can declare the components they are consuming from their requirements,
@@ -46,7 +46,8 @@ class PropagateSpecificComponents(unittest.TestCase):
 
     def test_wrong_component(self):
         """ If the requirement doesn't provide the component, it fails """
-        t = TestClient(cache_folder=self.cache_folder)
+        cf = '/private/var/folders/fc/6mvcrc952dqcjfhl4c7c11ph0000gn/T/tmpa6tmtp3nconans/path with spaces'
+        t = TestClient(cache_folder=self.cache_folder, current_folder=cf)
         t.save({'conanfile.py': textwrap.dedent("""
             from conans import ConanFile
 
@@ -55,7 +56,8 @@ class PropagateSpecificComponents(unittest.TestCase):
                 def package_info(self):
                     self.cpp_info.requires = ["top::wrong"]
         """)})
-        t.run('', assert_error=True) # TODO: Anything that triggers component validation
+        t.run('create conanfile.py wrong/version@')
+        t.run('install wrong/version@ -g cmake_find_package')
         self.assertIn('TODO: Define message here', t.out)
 
     def test_cmake_find_package(self):


### PR DESCRIPTION
Changelog: Feature: Allow packages that do not declare components to depend on other packages components and manage transitivity correctly, with the new ``self.cpp_info.requires`` attribute.
Docs: https://github.com/conan-io/docs/pull/1864

On top of https://github.com/conan-io/conan/pull/7641
Closes https://github.com/conan-io/conan/issues/7475

This PR introduces a new feature. Generators `cmake_find_package[_multi]` and `pkg_config` (those that implement components) will take into account the requirements and components listed in the `requires` field and will use only those targets when adding dependencies to the consumers.

### Example 1

```python
class Recipe:
    names = "middle"
    requires = "top/version"

    def package_info(self):
        self.cpp_info.components["middle1"].requires = ["top::cmp1"]
```

will generate this equivalent CMake lines:

```cmake
add_library(middle::middle INTERFACE IMPORTED)
find_dependency(top)
set_property(TARGET middle::middle PROPERTY INTERFACE_LINK_LIBRARIES top::cmp1)
```

before it was using `top::top`

### Example 2

As we don't want to force every recipe to use components in order to take advantage of this feature, there is a new `cpp_info.requires` property that offers the same capabilities as the one defined in the components:

```python
class Recipe:
    names = "middle"
    requires = "top/version"

    def package_info(self):
        self.cpp_info.requires = ["top::cmp1"]
```

will generate this equivalent CMake lines:

```cmake
add_library(middle::middle INTERFACE IMPORTED)
find_dependency(top)
set_property(TARGET middle::middle PROPERTY INTERFACE_LINK_LIBRARIES top::cmp1)
```