### PR TITLE
Fix copying symlink to directories

### DIFF
--- a/conans/client/generators/deploy.py
+++ b/conans/client/generators/deploy.py
@@ -33,7 +33,8 @@ class DeployGenerator(Generator):
 
         for dep_name in self.conanfile.deps_cpp_info.deps:
             rootpath = self.conanfile.deps_cpp_info[dep_name].rootpath
-            for root, _, files in os.walk(os.path.normpath(rootpath)):
+            for root, dirs, files in os.walk(os.path.normpath(rootpath)):
+                files += [d for d in dirs if os.path.islink(os.path.join(root, d))]
                 for f in files:
                     if f in FILTERED_FILES:
                         continue
@@ -52,5 +53,6 @@ class DeployGenerator(Generator):
                         os.symlink(linkto, dst)
                     else:
                         shutil.copy(src, dst)
-                    copied_files.append(dst)
+                    if f not in dirs:
+                        copied_files.append(dst)
         return self.deploy_manifest_content(copied_files)


### PR DESCRIPTION
UPDATED: see #7655 

Changelog: Bugfix: Copy symbolic links to directory with deploy generator.
Docs: https://github.com/conan-io/docs/pull/1829

fixes #7647 
(no updated tests, though)

- [x] Refer to the issue that supports this Pull Request.
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [x] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 

<sup>**Note:** By default this PR will skip the slower tests and will use a limited set of python versions. Check [here](https://github.com/conan-io/conan/blob/develop/.github/PR_INCREASE_TESTING.md) how to increase the testing level by writing some tags in the current PR body text.</sup>
