### PR TITLE
Fix copying symlink to directories (2)

### DIFF
--- a/conans/client/generators/deploy.py
+++ b/conans/client/generators/deploy.py
@@ -33,7 +33,8 @@ class DeployGenerator(Generator):
 
         for dep_name in self.conanfile.deps_cpp_info.deps:
             rootpath = self.conanfile.deps_cpp_info[dep_name].rootpath
-            for root, _, files in os.walk(os.path.normpath(rootpath)):
+            for root, dirs, files in os.walk(os.path.normpath(rootpath)):
+                files += [d for d in dirs if os.path.islink(os.path.join(root, d))]
                 for f in files:
                     if f in FILTERED_FILES:
                         continue
@@ -52,5 +53,6 @@ class DeployGenerator(Generator):
                         os.symlink(linkto, dst)
                     else:
                         shutil.copy(src, dst)
-                    copied_files.append(dst)
+                    if f not in dirs:
+                        copied_files.append(dst)
         return self.deploy_manifest_content(copied_files)

--- a/conans/test/functional/generators/deploy_test.py
+++ b/conans/test/functional/generators/deploy_test.py
@@ -147,6 +147,7 @@ class DeployGeneratorSymbolicLinkTest(unittest.TestCase):
     def setUp(self):
         conanfile = GenConanfile()
         conanfile.with_package_file("include/header.h", "whatever", link="include/header.h.lnk")
+        conanfile.with_package_folder("one_folder", link="other_folder")
         self.ref = ConanFileReference("name", "version", "user", "channel")
 
         self.client = TurboTestClient()
@@ -166,6 +167,14 @@ class DeployGeneratorSymbolicLinkTest(unittest.TestCase):
         self.assertFalse(os.path.islink(header_path))
         linkto = os.path.join(os.path.dirname(link_path), os.readlink(link_path))
         self.assertEqual(linkto, header_path)
+
+        folder_path = os.path.join(base_path, "one_folder")
+        link_folder_path = os.path.join(base_path, "other_folder")
+        self.assertTrue(os.path.islink(link_folder_path))
+        self.assertFalse(os.path.islink(folder_path))
+        linkto_folder = os.path.join(os.path.dirname(link_folder_path),
+                                     os.readlink(link_folder_path))
+        self.assertEqual(linkto_folder, folder_path)
 
     def test_existing_link_symbolic_links(self):
         self.client.current_folder = temp_folder()

--- a/conans/test/functional/generators/deploy_test.py
+++ b/conans/test/functional/generators/deploy_test.py
@@ -220,7 +220,7 @@ class DeployGeneratorSymbolicLinkTest(unittest.TestCase):
         self.assertEqual(linkto, header_path)
 
 
-@unittest.skipIf(platform.system() == "Windows", "Permissions in NIX systems only")
+@unittest.skipIf(platform.system() == "Windows", "Symlinks in NIX systems only")
 class DeployGeneratorSymbolicLinkFolderTest(unittest.TestCase):
 
     def setUp(self):

--- a/conans/test/functional/generators/deploy_test.py
+++ b/conans/test/functional/generators/deploy_test.py
@@ -147,7 +147,6 @@ class DeployGeneratorSymbolicLinkTest(unittest.TestCase):
     def setUp(self):
         conanfile = GenConanfile()
         conanfile.with_package_file("include/header.h", "whatever", link="include/header.h.lnk")
-        conanfile.with_package_folder("one_folder", link="other_folder")
         self.ref = ConanFileReference("name", "version", "user", "channel")
 
         self.client = TurboTestClient()
@@ -167,14 +166,6 @@ class DeployGeneratorSymbolicLinkTest(unittest.TestCase):
         self.assertFalse(os.path.islink(header_path))
         linkto = os.path.join(os.path.dirname(link_path), os.readlink(link_path))
         self.assertEqual(linkto, header_path)
-
-        folder_path = os.path.join(base_path, "one_folder")
-        link_folder_path = os.path.join(base_path, "other_folder")
-        self.assertTrue(os.path.islink(link_folder_path))
-        self.assertFalse(os.path.islink(folder_path))
-        linkto_folder = os.path.join(os.path.dirname(link_folder_path),
-                                     os.readlink(link_folder_path))
-        self.assertEqual(linkto_folder, folder_path)
 
     def test_existing_link_symbolic_links(self):
         self.client.current_folder = temp_folder()

--- a/conans/test/functional/generators/deploy_test.py
+++ b/conans/test/functional/generators/deploy_test.py
@@ -1,6 +1,7 @@
 import os
 import platform
 import stat
+import textwrap
 import unittest
 
 from conans import load
@@ -217,3 +218,37 @@ class DeployGeneratorSymbolicLinkTest(unittest.TestCase):
         self.assertFalse(os.path.islink(header_path))
         linkto = os.path.join(os.path.dirname(link_path), os.readlink(link_path))
         self.assertEqual(linkto, header_path)
+
+
+@unittest.skipIf(platform.system() == "Windows", "Permissions in NIX systems only")
+class DeployGeneratorSymbolicLinkFolderTest(unittest.TestCase):
+
+    def setUp(self):
+        conanfile = textwrap.dedent("""
+        import os
+        from conans import ConanFile, tools
+
+        class TestConan(ConanFile):
+
+            def package(self):
+                folder_path = os.path.join(self.package_folder, "one_folder")
+                tools.mkdir(folder_path)
+                link_folder_path = os.path.join(self.package_folder, "other_folder")
+                with tools.chdir(os.path.dirname(folder_path)):
+                    os.symlink(os.path.basename(folder_path), link_folder_path)
+        """)
+        self.ref = ConanFileReference("name", "version", "user", "channel")
+        self.client = TurboTestClient()
+        self.client.create(self.ref, conanfile)
+
+    def test_symbolic_links(self):
+        self.client.current_folder = temp_folder()
+        self.client.run("install %s -g deploy" % self.ref.full_str())
+        base_path = os.path.join(self.client.current_folder, "name")
+        folder_path = os.path.join(base_path, "one_folder")
+        link_folder_path = os.path.join(base_path, "other_folder")
+        self.assertTrue(os.path.islink(link_folder_path))
+        self.assertFalse(os.path.islink(folder_path))
+        linkto_folder = os.path.join(os.path.dirname(link_folder_path),
+                                     os.readlink(link_folder_path))
+        self.assertEqual(linkto_folder, folder_path)

--- a/conans/test/functional/generators/deploy_test.py
+++ b/conans/test/functional/generators/deploy_test.py
@@ -225,17 +225,17 @@ class DeployGeneratorSymbolicLinkFolderTest(unittest.TestCase):
 
     def setUp(self):
         conanfile = textwrap.dedent("""
-        import os
-        from conans import ConanFile, tools
+            import os
+            from conans import ConanFile, tools
 
-        class TestConan(ConanFile):
+            class TestConan(ConanFile):
 
-            def package(self):
-                folder_path = os.path.join(self.package_folder, "one_folder")
-                tools.mkdir(folder_path)
-                link_folder_path = os.path.join(self.package_folder, "other_folder")
-                with tools.chdir(os.path.dirname(folder_path)):
-                    os.symlink(os.path.basename(folder_path), link_folder_path)
+                def package(self):
+                    folder_path = os.path.join(self.package_folder, "one_folder")
+                    tools.mkdir(folder_path)
+                    link_folder_path = os.path.join(self.package_folder, "other_folder")
+                    with tools.chdir(os.path.dirname(folder_path)):
+                        os.symlink(os.path.basename(folder_path), link_folder_path)
         """)
         self.ref = ConanFileReference("name", "version", "user", "channel")
         self.client = TurboTestClient()

--- a/conans/test/utils/genconanfile.py
+++ b/conans/test/utils/genconanfile.py
@@ -28,8 +28,6 @@ class GenConanfile(object):
         self._package_files = {}
         self._package_files_env = {}
         self._package_files_link = {}
-        self._package_folders = []
-        self._package_folders_link = {}
         self._build_messages = []
         self._scm = {}
         self._requires = []
@@ -123,14 +121,6 @@ class GenConanfile(object):
             self._package_files_link[file_name] = link
         if env_var:
             self._package_files_env[file_name] = env_var
-        return self
-
-    def with_package_folder(self, folder_name, link=None):
-        self.with_import("import os")
-        self.with_import("from conans import tools")
-        self._package_folders.append(folder_name)
-        if link:
-            self._package_folders_link[folder_name] = link
         return self
 
     def with_build_msg(self, msg):
@@ -277,9 +267,9 @@ class GenConanfile(object):
     def _package_method(self):
         lines = []
         if self._package_files:
-            lines.extend(['        tools.save(os.path.join(self.package_folder, "{}"), "{}")'
-                          ''.format(key, value)
-                          for key, value in self._package_files.items()])
+            lines = ['        tools.save(os.path.join(self.package_folder, "{}"), "{}")'
+                     ''.format(key, value)
+                     for key, value in self._package_files.items()]
 
         if self._package_files_env:
             lines.extend(['        tools.save(os.path.join(self.package_folder, "{}"), '
@@ -291,16 +281,6 @@ class GenConanfile(object):
                           '            os.symlink(os.path.basename("{}"), '
                           'os.path.join(self.package_folder, "{}"))'.format(key, key, value)
                           for key, value in self._package_files_link.items()])
-        if self._package_folders:
-            lines.extend(['        tools.mkdir(os.path.join(self.package_folder, "{}"))'
-                          ''.format(folder) for folder in self._package_folders])
-        if self._package_folders_link:
-            lines.extend(['        with tools.chdir(os.path.dirname('
-                          'os.path.join(self.package_folder, "{}"))):\n'
-                          '            os.symlink(os.path.basename("{}"), '
-                          'os.path.join(self.package_folder, "{}"))'
-                          ''.format(key, key, value)
-                          for key, value in self._package_folders_link.items()])
 
         if not lines:
             return ""

--- a/conans/test/utils/genconanfile.py
+++ b/conans/test/utils/genconanfile.py
@@ -28,6 +28,8 @@ class GenConanfile(object):
         self._package_files = {}
         self._package_files_env = {}
         self._package_files_link = {}
+        self._package_folders = []
+        self._package_folders_link = {}
         self._build_messages = []
         self._scm = {}
         self._requires = []
@@ -121,6 +123,14 @@ class GenConanfile(object):
             self._package_files_link[file_name] = link
         if env_var:
             self._package_files_env[file_name] = env_var
+        return self
+
+    def with_package_folder(self, folder_name, link=None):
+        self.with_import("import os")
+        self.with_import("from conans import tools")
+        self._package_folders.append(folder_name)
+        if link:
+            self._package_folders_link[folder_name] = link
         return self
 
     def with_build_msg(self, msg):
@@ -267,9 +277,9 @@ class GenConanfile(object):
     def _package_method(self):
         lines = []
         if self._package_files:
-            lines = ['        tools.save(os.path.join(self.package_folder, "{}"), "{}")'
-                     ''.format(key, value)
-                     for key, value in self._package_files.items()]
+            lines.extend(['        tools.save(os.path.join(self.package_folder, "{}"), "{}")'
+                          ''.format(key, value)
+                          for key, value in self._package_files.items()])
 
         if self._package_files_env:
             lines.extend(['        tools.save(os.path.join(self.package_folder, "{}"), '
@@ -281,6 +291,16 @@ class GenConanfile(object):
                           '            os.symlink(os.path.basename("{}"), '
                           'os.path.join(self.package_folder, "{}"))'.format(key, key, value)
                           for key, value in self._package_files_link.items()])
+        if self._package_folders:
+            lines.extend(['        tools.mkdir(os.path.join(self.package_folder, "{}"))'
+                          ''.format(folder) for folder in self._package_folders])
+        if self._package_folders_link:
+            lines.extend(['        with tools.chdir(os.path.dirname('
+                          'os.path.join(self.package_folder, "{}"))):\n'
+                          '            os.symlink(os.path.basename("{}"), '
+                          'os.path.join(self.package_folder, "{}"))'
+                          ''.format(key, key, value)
+                          for key, value in self._package_folders_link.items()])
 
         if not lines:
             return ""


### PR DESCRIPTION
Changelog: Bugfix: Copy symbolic links to directory with deploy generator.
Docs: https://github.com/conan-io/docs/pull/1830

(corrected user compared to #7654 to accept CLA)

fixes #7647 
(no updated tests)

- [x] Refer to the issue that supports this Pull Request.
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [x] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 

<sup>**Note:** By default this PR will skip the slower tests and will use a limited set of python versions. Check [here](https://github.com/conan-io/conan/blob/develop/.github/PR_INCREASE_TESTING.md) how to increase the testing level by writing some tags in the current PR body text.</sup>
