### PR TITLE
moving logic from cmake to python for cmake toolchain

### DIFF
--- a/conans/client/toolchain/cmake.py
+++ b/conans/client/toolchain/cmake.py
@@ -124,10 +124,10 @@ class CMakeToolchain(object):
 
         # C++ Standard Library
         {%- if set_libcxx %}
-        set(CONAN_CXX_FLAGS "${CONAN_CXX_FLAGS} set_libcxx")
+        set(CONAN_CXX_FLAGS "${CONAN_CXX_FLAGS} {{ set_libcxx }}")
         {%- endif %}
         {%- if glibcxx %}
-        add_definitions(-D_GLIBCXX_USE_CXX11_ABI=glibcxx)
+        add_definitions(-D_GLIBCXX_USE_CXX11_ABI={{ glibcxx }})
         {%- endif %}
 
         {% if install_prefix %}


### PR DESCRIPTION
Changelog: Omit
Docs: Omit

Small improvement to experimental ``CMakeToolchain``, producing less cmake code and moving the logic to python.

