### PR TITLE
Refactor/init git

### DIFF
--- a/conans/test/functional/py_requires/python_requires_test.py
+++ b/conans/test/functional/py_requires/python_requires_test.py
@@ -9,7 +9,6 @@ from parameterized import parameterized
 from conans.model.ref import ConanFileReference
 from conans.paths import CONANFILE
 from conans.test.utils.tools import TestClient, GenConanfile
-from conans.test.utils.scm import create_local_git_repo
 
 
 class PyRequiresExtendTest(unittest.TestCase):
@@ -295,8 +294,7 @@ class PyRequiresExtendTest(unittest.TestCase):
             class MyConanfileBase(SomeBase, ConanFile):
                 pass
             """)
-        create_local_git_repo({"conanfile.py": conanfile}, branch="my_release",
-                              folder=client.current_folder)
+        client.init_git_repo({"conanfile.py": conanfile}, branch="my_release")
         client.run("export . base/1.1@user/testing")
 
         reuse = textwrap.dedent("""
@@ -326,8 +324,7 @@ class PyRequiresExtendTest(unittest.TestCase):
             class MyConanfileBase(SomeBase, ConanFile):
                 pass
             """)
-        create_local_git_repo({"conanfile.py": conanfile}, branch="my_release",
-                              folder=client.current_folder)
+        client.init_git_repo({"conanfile.py": conanfile}, branch="my_release")
         client.run("export . base/1.1@user/testing")
         client.run("get base/1.1@user/testing")
         self.assertIn('"url": "somerepo"', client.out)
@@ -363,8 +360,8 @@ class PyRequiresExtendTest(unittest.TestCase):
             class MyConanfileBase(SomeBase, ConanFile):
                 pass
             """)
-        _, base_rev = create_local_git_repo({"conanfile.py": conanfile}, branch="my_release",
-                                            folder=os.path.join(client.current_folder, "base"))
+        base_rev = client.init_git_repo({"conanfile.py": conanfile}, branch="my_release",
+                                        folder="base")
         client.run("config set general.scm_to_conandata=1")
         client.run("export base base/1.1@user/testing")
 
@@ -375,10 +372,10 @@ class PyRequiresExtendTest(unittest.TestCase):
                 python_requires = "base/1.1@user/testing"
                 python_requires_extend = "base.SomeBase"
             """)
-        _, reuse1_rev = create_local_git_repo({"conanfile.py": reuse % "reuse1"}, branch="release",
-                                              folder=os.path.join(client.current_folder, "reuse1"))
-        _, reuse2_rev = create_local_git_repo({"conanfile.py": reuse % "reuse2"}, branch="release",
-                                              folder=os.path.join(client.current_folder, "reuse2"))
+        reuse1_rev = client.init_git_repo({"conanfile.py": reuse % "reuse1"}, branch="release",
+                                          folder="reuse1")
+        reuse2_rev = client.init_git_repo({"conanfile.py": reuse % "reuse2"}, branch="release",
+                                          folder="reuse2")
         client.run("export reuse1 reuse1/1.1@user/testing")
         client.run("export reuse2 reuse2/1.1@user/testing")
 

--- a/conans/test/functional/scm/test_scm_to_conandata.py
+++ b/conans/test/functional/scm/test_scm_to_conandata.py
@@ -12,7 +12,6 @@ from conans.model.ref import ConanFileReference
 from conans.paths import DATA_YML
 from conans.test.utils.tools import TestClient
 from conans.test.utils.mocks import TestBufferConanOutput
-from conans.test.utils.scm import create_local_git_repo
 from conans.util.files import load
 from conans.util.files import save_files
 
@@ -95,8 +94,7 @@ class SCMDataToConanDataTestCase(unittest.TestCase):
                 scm = {"type": "git", "url": "auto", "revision": "auto"}
         """)
         t = TestClient()
-        t.save({'conanfile.py': conanfile})
-        _, commit = create_local_git_repo(folder=t.current_folder)
+        commit = t.init_git_repo({'conanfile.py': conanfile})
         t.run_command('git remote add origin https://myrepo.com.git')
         t.run("config set general.scm_to_conandata=1")
         t.run("export . name/version@")

--- a/conans/test/utils/scm.py
+++ b/conans/test/utils/scm.py
@@ -16,7 +16,7 @@ from conans.util.runners import check_output_runner
 
 
 def create_local_git_repo(files=None, branch=None, submodules=None, folder=None, commits=1,
-                          tags=None):
+                          tags=None, origin_url=None):
     tmp = folder or temp_folder()
     tmp = get_cased_path(tmp)
     if files:
@@ -41,6 +41,9 @@ def create_local_git_repo(files=None, branch=None, submodules=None, folder=None,
         for submodule in submodules:
             git.run('submodule add "%s"' % submodule)
         git.run('commit -m "add submodules"')
+
+    if origin_url:
+        git.run('remote add origin {}'.format(origin_url))
 
     return tmp.replace("\\", "/"), git.get_revision()
 

--- a/conans/test/utils/tools.py
+++ b/conans/test/utils/tools.py
@@ -730,6 +730,15 @@ class TestClient(object):
         rrev = self.cache.package_layout(ref).recipe_revision()
         return ref.copy_with_rev(rrev)
 
+    def init_git_repo(self, files=None, branch=None, submodules=None, folder=None, origin_url=None):
+        if folder is not None:
+            folder = os.path.join(self.current_folder, folder)
+        else:
+            folder = self.current_folder
+        _, commit = create_local_git_repo(files, branch, submodules, folder=folder,
+                                          origin_url=origin_url)
+        return commit
+
 
 class TurboTestClient(TestClient):
     tmp_json_name = ".tmp_json"
@@ -828,12 +837,6 @@ class TurboTestClient(TestClient):
                         tmp.append(pref)
                 ret.append(tmp)
         return ret
-
-    def init_git_repo(self, files=None, branch=None, submodules=None, origin_url=None):
-        _, commit = create_local_git_repo(files, branch, submodules, self.current_folder)
-        if origin_url:
-            self.run_command('git remote add origin {}'.format(origin_url))
-        return commit
 
     def init_svn_repo(self, subpath, files=None, repo_url=None):
         if not repo_url:


### PR DESCRIPTION
Changelog: omit
Docs: omit

Moving functionality from TurboTestClient => TestClient.
Final goal is to unify both, have only 1.
Used the ``TestClient.git_init_repo()`` more, instead of the ``create_local_git_repo()``

#tags: slow, svn
