### PR TITLE
Pass dependency version to CMake layer in conanbuildinfo.cmake

### DIFF
--- a/conans/client/generators/cmake.py
+++ b/conans/client/generators/cmake.py
@@ -35,6 +35,8 @@ class DepsCppCmake(object):
             """
             return '"%s"' % ";".join(p.replace('\\', '/').replace('$', '\\$') for p in values)
 
+        self.version = cpp_info.version
+
         self.include_paths = join_paths(cpp_info.include_paths)
         self.include_path = join_paths_single_var(cpp_info.include_paths)
         self.lib_paths = join_paths(cpp_info.lib_paths)

--- a/conans/client/generators/cmake_common.py
+++ b/conans/client/generators/cmake_common.py
@@ -4,6 +4,8 @@ _cmake_single_dep_vars = """
 #################
 ###  {dep}
 #################
+set(CONAN_{dep}_VERSION{build_type} {deps.version})
+
 set(CONAN_{dep}_ROOT{build_type} {deps.rootpath})
 set(CONAN_INCLUDE_DIRS_{dep}{build_type} {deps.include_paths})
 set(CONAN_LIB_DIRS_{dep}{build_type} {deps.lib_paths})


### PR DESCRIPTION
This is useful to run configure_file() on a conanfile.txt.in (as part of
an example) to automatically have the dependency versions updated.
Other usecases might include version dependent switches in the CMake
layer.

Since the information is available in cpp_info.version anyways, it is
straightforward to pass it on the CMake.

Changelog: (Feature): Pass dependency version to CMake layer in conanbuildinfo.cmake
Docs: https://github.com/conan-io/docs/pull/XXXX

- [] Refer to the issue that supports this Pull Request.
- [] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 

<sup>**Note:** By default this PR will skip the slower tests and will use a limited set of python versions. Check [here](https://github.com/conan-io/conan/blob/develop/.github/PR_INCREASE_TESTING.md) how to increase the testing level by writing some tags in the current PR body text.</sup>
