### PR TITLE
Use patterns in server query when resolving version ranges 

### DIFF
--- a/conans/client/graph/range_resolver.py
+++ b/conans/client/graph/range_resolver.py
@@ -161,7 +161,7 @@ class RangeResolver(object):
         found_refs, remote_name = self._cached_remote_found.get(search_ref, (None, None))
         if found_refs is None:
             # Searching for just the name is much faster in remotes like Artifactory
-            found_refs, remote_name = self._search_remotes(search_ref, remotes)
+            found_refs, remote_name = self._search_remotes(str(search_ref), remotes)
             if found_refs:
                 self._result.append("%s versions found in '%s' remote" % (search_ref, remote_name))
             else:

--- a/conans/client/graph/range_resolver.py
+++ b/conans/client/graph/range_resolver.py
@@ -150,11 +150,8 @@ class RangeResolver(object):
     def _search_remotes(self, search_ref, remotes):
         for remote in remotes.values():
             if not remotes.selected or remote == remotes.selected:
-                search_result = self._remote_manager.search_recipes(remote, search_ref.name,
+                search_result = self._remote_manager.search_recipes(remote, search_ref,
                                                                     ignorecase=False)
-                search_result = [ref for ref in search_result
-                                 if ref.user == search_ref.user and
-                                 ref.channel == search_ref.channel]
                 if search_result:
                     return search_result, remote.name
         return None, None

--- a/conans/client/graph/range_resolver.py
+++ b/conans/client/graph/range_resolver.py
@@ -150,7 +150,7 @@ class RangeResolver(object):
     def _search_remotes(self, search_ref, remotes):
         for remote in remotes.values():
             if not remotes.selected or remote == remotes.selected:
-                search_result = self._remote_manager.search_recipes(remote, search_ref,
+                search_result = self._remote_manager.search_recipes(remote, str(search_ref),
                                                                     ignorecase=False)
                 if search_result:
                     return search_result, remote.name
@@ -161,7 +161,7 @@ class RangeResolver(object):
         found_refs, remote_name = self._cached_remote_found.get(search_ref, (None, None))
         if found_refs is None:
             # Searching for just the name is much faster in remotes like Artifactory
-            found_refs, remote_name = self._search_remotes(str(search_ref), remotes)
+            found_refs, remote_name = self._search_remotes(search_ref, remotes)
             if found_refs:
                 self._result.append("%s versions found in '%s' remote" % (search_ref, remote_name))
             else:

--- a/conans/test/unittests/client/graph/version_ranges_graph_test.py
+++ b/conans/test/unittests/client/graph/version_ranges_graph_test.py
@@ -1,4 +1,4 @@
-from collections import OrderedDict, Counter
+from collections import OrderedDict
 from collections import namedtuple
 
 import six

--- a/conans/test/unittests/client/graph/version_ranges_graph_test.py
+++ b/conans/test/unittests/client/graph/version_ranges_graph_test.py
@@ -1,4 +1,4 @@
-from collections import OrderedDict
+from collections import OrderedDict, Counter
 from collections import namedtuple
 
 import six
@@ -105,7 +105,7 @@ class VersionRangesTest(GraphTest):
             deps_graph = self.build_graph(GenConanfile().with_name("Hello").with_version("1.2")
                                                         .with_require(req),
                                           update=True)
-            self.assertEqual(self.remote_manager.count, {'Say': 1})
+            self.assertEqual(self.remote_manager.count, {'Say/*@myuser/testing': 1})
             self.assertEqual(2, len(deps_graph.nodes))
             hello = _get_nodes(deps_graph, "Hello")[0]
             say = _get_nodes(deps_graph, "Say")[0]
@@ -151,7 +151,7 @@ class HelloConan(ConanFile):
                                                   Edge(dep1, say), Edge(dep2, say)})
 
         # Most important check: counter of calls to remote
-        self.assertEqual(self.remote_manager.count, {'Say': 1})
+        self.assertEqual(self.remote_manager.count, {'Say/*@myuser/testing': 1})
 
     @parameterized.expand([("", "0.3", None, None, False),
                            ('"Say/1.1@myuser/testing"', "1.1", False, True, False),


### PR DESCRIPTION
Changelog: Fix: Use patterns in server query when resolving version ranges.
Docs: omit

Closes: https://github.com/conan-io/conan/issues/7672

After a poor performance in resolution of version ranges in Artifactory was reported (https://github.com/conan-io/conan/issues/5432), Conan introduced a workaround for the issue in https://github.com/conan-io/conan/pull/5433. With these changes now the query to Artifactory server was made removing the patterns: 
`
http://localhost:8081/artifactory/api/conan/conan/v2/conans/search?q=cgal
`
instead of:
`
http://localhost:8081/artifactory/api/conan/conan/v2/conans/search?q=cgal%2F%2A%40user%2Fchannel&ignorecase=False
`
and then the ranges were resolved with all the packages on the client side.

This is causing a security gap as defining exclude patterns in Artifactory will not work as those patterns are not sent any more to the server as reported here: https://github.com/conan-io/conan/issues/7672. This branch reverts those changes. 

Please, @Daniel-Roberts-Bose could you try this branch and check if the performance issues are still happening?

- [X] Refer to the issue that supports this Pull Request.
- [X] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [X] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [X] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 

<sup>**Note:** By default this PR will skip the slower tests and will use a limited set of python versions. Check [here](https://github.com/conan-io/conan/blob/develop/.github/PR_INCREASE_TESTING.md) how to increase the testing level by writing some tags in the current PR body text.</sup>
