### PR TITLE
fix applying generator_platform based on version instead of actual generator

### DIFF
--- a/conans/client/build/cmake.py
+++ b/conans/client/build/cmake.py
@@ -324,19 +324,21 @@ class CMakeBuildHelper(object):
                 if "--" not in args:
                     args.append("--")
                 args.append("-j%i" % cpu_count(self._conanfile.output))
-            elif "Visual Studio" in self.generator and \
-                    compiler_version and Version(compiler_version) >= "10":
-                if "--" not in args:
-                    args.append("--")
-                # Parallel for building projects in the solution
-                args.append("/m:%i" % cpu_count(output=self._conanfile.output))
+            elif "Visual Studio" in self.generator:
+                compiler_version = re.search("Visual Studio ([0-9]*)", self.generator).group(1)
+                if Version(compiler_version) >= "10":
+                    if "--" not in args:
+                        args.append("--")
+                    # Parallel for building projects in the solution
+                    args.append("/m:%i" % cpu_count(output=self._conanfile.output))
 
         if self.generator and self.msbuild_verbosity:
-            if "Visual Studio" in self.generator and \
-                    compiler_version and Version(compiler_version) >= "10":
-                if "--" not in args:
-                    args.append("--")
-                args.append("/verbosity:%s" % self.msbuild_verbosity)
+            if "Visual Studio" in self.generator:
+                compiler_version = re.search("Visual Studio ([0-9]*)", self.generator).group(1)
+                if Version(compiler_version) >= "10":
+                    if "--" not in args:
+                        args.append("--")
+                    args.append("/verbosity:%s" % self.msbuild_verbosity)
 
         arg_list = join_arguments([
             args_to_string([build_dir]),

--- a/conans/client/build/cmake.py
+++ b/conans/client/build/cmake.py
@@ -1,5 +1,6 @@
 import os
 import platform
+import re
 from itertools import chain
 
 from six import StringIO  # Python 2 and 3 compatible
@@ -180,10 +181,11 @@ class CMakeBuildHelper(object):
         generator_platform = self.generator_platform
 
         if self.generator_platform and 'Visual Studio' in generator:
-            # FIXME: Conan 2.0 We are adding the platform to the generator instead of using the -A argument
-            #   to keep previous implementation, but any modern CMake will support (and recommend) passing the
-            #   platform in its own argument.
-            compiler_version = self._settings.get_safe("compiler.version")
+            # FIXME: Conan 2.0 We are adding the platform to the generator instead of using
+            #  the -A argument to keep previous implementation, but any modern CMake will support
+            #  (and recommend) passing the platform in its own argument.
+            # Get the version from the generator, as it could have been defined by user argument
+            compiler_version = re.search("Visual Studio ([0-9]*)", generator).group(1)
             if Version(compiler_version) < "16" and self._settings.get_safe("os") != "WindowsCE":
                 if self.generator_platform == "x64":
                     generator += " Win64" if not generator.endswith(" Win64") else ""

--- a/conans/client/build/cmake.py
+++ b/conans/client/build/cmake.py
@@ -317,7 +317,6 @@ class CMakeBuildHelper(object):
         if target is not None:
             args = ["--target", target] + args
 
-        compiler_version = self._settings.get_safe("compiler.version")
         if self.generator and self.parallel:
             if ("Makefiles" in self.generator or "Ninja" in self.generator) and \
                     "NMake" not in self.generator:

--- a/conans/test/unittests/client/build/cmake_test.py
+++ b/conans/test/unittests/client/build/cmake_test.py
@@ -259,6 +259,12 @@ class CMakeTest(unittest.TestCase):
 
         cmake = CMake(conanfile, generator="Visual Studio 16 2019")
         self.assertIn('-G "Visual Studio 16 2019" -A "x64"', cmake.command_line)
+        cmake.build()
+        self.assertIn("/verbosity:minimal", conanfile.command)
+        cmake = CMake(conanfile, generator="Visual Studio 9 2008")
+        self.assertIn('-G "Visual Studio 9 2008 Win64"', cmake.command_line)
+        cmake.build()
+        self.assertNotIn("verbosity", conanfile.command)
 
     def cmake_generator_platform_gcc_test(self):
         settings = Settings.loads(get_default_settings_yml())

--- a/conans/test/unittests/client/build/cmake_test.py
+++ b/conans/test/unittests/client/build/cmake_test.py
@@ -202,7 +202,7 @@ class CMakeTest(unittest.TestCase):
         conanfile.settings = settings
 
         cmake = CMake(conanfile)
-        self.assertIn('-G "Visual Studio 15 2017" -A "x64"', cmake.command_line)
+        self.assertIn('-G "Visual Studio 15 2017 Win64"', cmake.command_line)
         self.assertIn('-T "Intel C++ Compiler 19.0', cmake.command_line)
 
     def cmake_custom_generator_intel_test(self):
@@ -245,6 +245,20 @@ class CMakeTest(unittest.TestCase):
         with tools.environment_append({"CONAN_CMAKE_GENERATOR_PLATFORM": "Win64"}):
             cmake = CMake(conanfile)
             self.assertIn('-G "Visual Studio 15 2017" -A "Win64"', cmake.command_line)
+
+    def cmake_generator_argument_test(self):
+        settings = Settings.loads(get_default_settings_yml())
+        settings.os = "Windows"
+        settings.compiler = "Visual Studio"
+        settings.compiler.version = "15"
+        settings.compiler.toolset = "v141"
+        settings.arch = "x86_64"
+
+        conanfile = ConanFileMock()
+        conanfile.settings = settings
+
+        cmake = CMake(conanfile, generator="Visual Studio 16 2019")
+        self.assertIn('-G "Visual Studio 16 2019" -A "x64"', cmake.command_line)
 
     def cmake_generator_platform_gcc_test(self):
         settings = Settings.loads(get_default_settings_yml())


### PR DESCRIPTION
Changelog: Bugfix: CMake build helper: Use actual CMake generator version to append platform generator, instead of the Conan setting `compiler.version`.
Docs: Omit

Close https://github.com/conan-io/conan/issues/7683
