### PR TITLE
Fix Artifactory remote remove all packages from a recipe

### DIFF
--- a/conans/client/rest/rest_client_v1.py
+++ b/conans/client/rest/rest_client_v1.py
@@ -308,6 +308,7 @@ class RestV1Methods(RestCommonMethods):
     def remove_packages(self, ref, package_ids):
         """ Remove any packages specified by package_ids"""
         self.check_credentials()
+        package_ids = None if len(package_ids) == 0 else package_ids
         payload = {"package_ids": package_ids}
         url = self.router.remove_packages(ref)
         ret = self._post_json(url, payload)

--- a/conans/server/service/common/common.py
+++ b/conans/server/service/common/common.py
@@ -29,6 +29,9 @@ class CommonService(object):
     def remove_packages(self, ref, package_ids_filter):
         """If the revision is not specified it will remove the packages from all the recipes
         (v1 compatibility)"""
+        # https://github.com/conan-io/conan/pull/7687
+        if package_ids_filter is None:
+            package_ids_filter = []
         for package_id in package_ids_filter:
             pref = PackageReference(ref, package_id)
             self._authorizer.check_delete_package(self._auth_user, pref)

--- a/conans/test/functional/command/remove_test.py
+++ b/conans/test/functional/command/remove_test.py
@@ -500,15 +500,15 @@ class RemoveTest(unittest.TestCase):
                             build_folders={"H1": [1, 2], "H2": [1, 2], "B": [1, 2], "O": [1, 2]},
                             src_folders={"H1": True, "H2": True, "B": True, "O": True})
 
+
+class ArtifactoryRemoveCase(unittest.TestCase):
     @attr("artifactory_ready")
     def test_remove_packages(self):
         ref = ConanFileReference.loads("Hello/0.1@conan/testing")
         client = TurboTestClient(servers={"default": TestServer()})
-        pref = client.create(ref, conanfile=GenConanfile().with_package_file("somefile", "foo"))
+        client.create(ref, conanfile=GenConanfile().with_package_file("somefile", "foo"))
         client.run("upload * --all --confirm")
-        package_folder = client.cache.package_layout(pref.ref).package(pref)
-        package_file_path = os.path.join(package_folder, "myfile.sh")
-        client.run("remove '*' -f --packages")
+        client.run("remove 'Hello/0.1@conan/testing' -f --packages")
         client.run("search 'Hello/0.1@conan/testing' -r default")
         self.assertNotIn("There are no packages for reference 'Hello/0.1@conan/testing', but package recipe found.", self.client.out)
 

--- a/conans/test/functional/command/remove_test.py
+++ b/conans/test/functional/command/remove_test.py
@@ -502,15 +502,17 @@ class RemoveTest(unittest.TestCase):
 
 
 class ArtifactoryRemoveCase(unittest.TestCase):
+    # https://www.jfrog.com/jira/browse/RTFACT-16410
     @attr("artifactory_ready")
     def test_remove_packages(self):
         ref = ConanFileReference.loads("Hello/0.1@conan/testing")
         client = TurboTestClient(servers={"default": TestServer()})
         client.create(ref, conanfile=GenConanfile().with_package_file("somefile", "foo"))
         client.run("upload * --all --confirm")
-        client.run("remove 'Hello/0.1@conan/testing' -f --packages")
+        client.run("remove 'Hello/0.1@conan/testing' -f --packages -r default")
         client.run("search 'Hello/0.1@conan/testing' -r default")
-        self.assertNotIn("There are no packages for reference 'Hello/0.1@conan/testing', but package recipe found.", self.client.out)
+        self.assertIn("There are no packages for reference 'Hello/0.1@conan/testing', but package "
+                      "recipe found.", client.out)
 
 
 class RemoveWithoutUserChannel(unittest.TestCase):


### PR DESCRIPTION
Changelog: Fix: Using `--packages` argument to remove all the packages from a recipe did not work unless an specific _package_id_ was added to the argument. This happened with revisions disabled (v1 API).
Docs: omit

With revisions enabled this seems to work fine.

Closes: https://github.com/conan-io/conan/issues/1314
Also: https://www.jfrog.com/jira/browse/RTFACT-16410

- [X] Refer to the issue that supports this Pull Request.
- [X] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [X] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [X] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 

<sup>**Note:** By default this PR will skip the slower tests and will use a limited set of python versions. Check [here](https://github.com/conan-io/conan/blob/develop/.github/PR_INCREASE_TESTING.md) how to increase the testing level by writing some tags in the current PR body text.</sup>
