### PR TITLE
Feature/markdown cmake gen info

### DIFF
--- a/conans/client/generators/json_generator.py
+++ b/conans/client/generators/json_generator.py
@@ -13,7 +13,7 @@ def serialize_cpp_info(cpp_info):
         "libs",
         "system_libs",
         "defines", "cflags", "cxxflags", "sharedlinkflags", "exelinkflags",
-        "frameworks", "framework_paths"
+        "frameworks", "framework_paths", "names", "filenames"
     ]
     res = {}
     for key in keys:

--- a/conans/client/generators/markdown.py
+++ b/conans/client/generators/markdown.py
@@ -54,12 +54,13 @@ generator_cmake_tpl = textwrap.dedent("""
 generator_cmake_find_package_tpl = textwrap.dedent("""
     ### Generator ``cmake_find_package``
     {% set cmake_find_package_name = cpp_info.get_name("cmake_find_package") %}
-    Generates the file Find{{ cmake_find_package_name }}.cmake
+    {% set cmake_find_package_filename = cpp_info.get_filename("cmake_find_package") %}
+    Generates the file Find{{ cmake_find_package_filename }}.cmake
 
     Add these lines to your *CMakeLists.txt*:
 
     ```cmake
-    find_package({{ cmake_find_package_name }})
+    find_package({{ cmake_find_package_filename }})
 
     # Use the global target
     target_link_libraries(<library_name> {{ cmake_find_package_name }}::{{ cmake_find_package_name }})

--- a/conans/client/generators/markdown.py
+++ b/conans/client/generators/markdown.py
@@ -75,12 +75,15 @@ requirement_tpl = Template(textwrap.dedent("""
 
 
     ### Generator ``cmake_find_package``
+    {% set cmake_find_package_filename = cpp_info.get_filename("cmake_find_package") %}
     {% set cmake_find_package_name = cpp_info.get_name("cmake_find_package") %}
+
+    Generates the file Find{{ cmake_find_package_filename }}.cmake
 
     Add these lines to your *CMakeLists.txt*
 
     ```cmake
-    find_package({{ cmake_find_package_name }})
+    find_package({{ cmake_find_package_filename }})
 
     target_link_libraries(<library_name> {{ cmake_find_package_name }}::{{ cmake_find_package_name }})
     ```

--- a/conans/client/generators/markdown.py
+++ b/conans/client/generators/markdown.py
@@ -53,19 +53,20 @@ generator_cmake_tpl = textwrap.dedent("""
 
 generator_cmake_find_package_tpl = textwrap.dedent("""
     ### Generator ``cmake_find_package``
-    Generates the file Find{{ cpp_info.get_filename("cmake_find_package") }}.cmake
+    {% set cmake_find_package_name = cpp_info.get_name("cmake_find_package") %}
+    Generates the file Find{{ cmake_find_package_name }}.cmake
 
-    Add these lines to your *CMakeLists.txt*
-    
+    Add these lines to your *CMakeLists.txt*:
+
     ```cmake
-    find_package({{ cpp_info.get_filename("cmake_find_package") }})
+    find_package({{ cmake_find_package_name }})
 
     # Use the global target
-    target_link_libraries(<library_name> {{ cpp_info.get_name("cmake_find_package") }}::{{ cpp_info.get_name("cmake_find_package") }})
+    target_link_libraries(<library_name> {{ cmake_find_package_name }}::{{ cmake_find_package_name }})
     {% if cpp_info.components %}
     # Or link just one of its components
     {% for cmp_name, cmp_cpp_info in cpp_info.components.items() -%}
-    target_link_libraries(<library_name> {{ cpp_info.get_name("cmake_find_package") }}::{{ cmp_cpp_info.get_name("cmake_find_package") }})
+    target_link_libraries(<library_name> {{ cmake_find_package_name }}::{{ cmp_cpp_info.get_name("cmake_find_package") }})
     {% endfor %}
     {%- endif %}
     ```

--- a/conans/test/functional/generators/json_test.py
+++ b/conans/test/functional/generators/json_test.py
@@ -69,14 +69,14 @@ class HelloConan(ConanFile):
             class Lib(ConanFile):
                 settings = "os", "arch"
                 generators = "json"
-                
+
                 def package_info(self):
                     self.env_info.MY_ENV_VAR = "foo"
                     self.user_info.my_var = "my_value"
-                    
+
                     self.cpp_info.debug.defines = ["LIB_DEBUG"]
                     self.cpp_info.release.defines = ["LIB_RELEASE"]
-                    
+
                     self.cpp_info.debug.libs = ["Hello_d"]
                     self.cpp_info.release.libs = ["Hello"]
             """)
@@ -139,3 +139,27 @@ class HelloConan(ConanFile):
         my_json = json.loads(my_json)
         self.assertListEqual(my_json["dependencies"][0]["libs"], ["LIB1"])
         self.assertListEqual(my_json["dependencies"][0]["system_libs"], ["SYSTEM_LIB1"])
+
+    def test_generate_json_filenames(self):
+        conanfile = textwrap.dedent("""
+            from conans import ConanFile
+            class HelloConan(ConanFile):
+                def package_info(self):
+                    self.cpp_info.filenames['cmake_find_package'] = 'FooBar'
+                    self.cpp_info.names['cmake_find_package'] = 'foobar'
+                    self.cpp_info.names['cmake_find_package_multi'] = 'foobar_multi'
+                    self.cpp_info.names['pkg_config'] = 'foobar_cfg'
+            """)
+        client = TestClient()
+        client.save({"conanfile.py": conanfile})
+        client.run("create . bar/0.1.0@user/testing")
+        client.run("install bar/0.1.0@user/testing -g json")
+        conan_json = client.load("conanbuildinfo.json")
+        content = json.loads(conan_json)
+
+        deps = content["dependencies"][0]
+        self.assertEqual("foobar", deps["names"]["cmake_find_package"])
+        self.assertEqual("foobar_multi", deps["names"]["cmake_find_package_multi"])
+        self.assertEqual("foobar_cfg", deps["names"]["pkg_config"])
+        self.assertEqual("FooBar", deps["filenames"]["cmake_find_package"])
+        self.assertEqual("bar", deps["name"])

--- a/conans/test/functional/generators/markdown_test.py
+++ b/conans/test/functional/generators/markdown_test.py
@@ -1,0 +1,27 @@
+import textwrap
+import unittest
+
+from conans.test.utils.tools import TestClient
+from conans.client.tools.files import load
+
+
+class MarkDownGeneratorTest(unittest.TestCase):
+
+    def test_cmake_find_filename(self):
+        conanfile = textwrap.dedent("""
+                    from conans import ConanFile
+                    class HelloConan(ConanFile):
+                        def package_info(self):
+                            self.cpp_info.filenames['cmake_find_package'] = 'FooBar'
+                            self.cpp_info.names['cmake_find_package'] = 'foobar'
+                            self.cpp_info.names['cmake_find_package_multi'] = 'foobar_multi'
+                            self.cpp_info.names['pkg_config'] = 'foobar_cfg'
+                    """)
+        client = TestClient()
+        client.save({"conanfile.py": conanfile})
+        client.run("create . bar/0.1.0@user/testing")
+        client.run("install bar/0.1.0@user/testing -g markdown")
+        content = client.load("bar.md")
+
+        self.assertIn("Generates the file FindFooBar.cmake", content)
+        self.assertIn("find_package(FooBar)", content)


### PR DESCRIPTION
Changelog: Feature: List `cpp_info.names` and `cpp_info.filenames` in JSON and Markdown generator.
Docs: https://github.com/conan-io/docs/pull/1844

Closes #7525

Now anyone can read easily what will be produced when mixing cpp_info.name + cpp_info.names + cpp_info.filenames. The current feature works good and solves the cmake targets, but is almost unreadable when you don't know the feature in details. I hope these generators can show the final result without much knowledgement about the feature.



- [ ] Refer to the issue that supports this Pull Request.
- [ ] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [ ] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [ ] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 

<sup>**Note:** By default this PR will skip the slower tests and will use a limited set of python versions. Check [here](https://github.com/conan-io/conan/blob/develop/.github/PR_INCREASE_TESTING.md) how to increase the testing level by writing some tags in the current PR body text.</sup>
