### PR TITLE
Fix #7694, translate settings.os value 'Macos' to 'Darwin' for CMAKE_…

### DIFF
--- a/conans/client/build/cmake_flags.py
+++ b/conans/client/build/cmake_flags.py
@@ -205,7 +205,8 @@ class CMakeDefinitionsBuilder(object):
             if cross_building(self._conanfile):  # We are cross building
                 if os_ != os_build:
                     if os_:  # the_os is the host (regular setting)
-                        definitions["CMAKE_SYSTEM_NAME"] = {"iOS": "Darwin",
+                        definitions["CMAKE_SYSTEM_NAME"] = {"Macos": "Darwin",
+                                                            "iOS": "Darwin",
                                                             "tvOS": "Darwin",
                                                             "watchOS": "Darwin",
                                                             "Neutrino": "QNX"}.get(os_, os_)


### PR DESCRIPTION
Changelog: Bugfix: Translate `settings.os` value `Macos` to `Darwin` for `CMAKE_SYSTEM_NAME` to allow compiling CMake-based packages for MacOS.
Docs: omit

Fixes #7694 

…SYSTEM_NAME to allow compiling CMake-based packages for Mac OS

- [X] Refer to the issue that supports this Pull Request.
- [ ] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [X] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [X] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 

<sup>**Note:** By default this PR will skip the slower tests and will use a limited set of python versions. Check [here](https://github.com/conan-io/conan/blob/develop/.github/PR_INCREASE_TESTING.md) how to increase the testing level by writing some tags in the current PR body text.</sup>
