### PR TITLE
Add some notes on how to run tests against a real Artifactory

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -208,6 +208,21 @@ To run specific tests, you can specify the test name too, something like:
 
 The ``--nocapture`` argument can be useful to see some output that otherwise is captured by nosetests.
 
+Also you can run tests against an instance of Artifactory. Those test should add the attribute
+``artifactory_ready``. To run those tests locally some environment variables must be defined. For
+example for an Artifactory instance that is running on the localhost with default user and password
+configured the variables could take the values.
+
+```bash
+CONAN_TEST_WITH_ARTIFACTORY=1
+ARTIFACTORY_DEFAULT_URL=http://localhost:8081/artifactory
+ARTIFACTORY_DEFAULT_USER=admin
+ARTIFACTORY_DEFAULT_PASSWORD=password
+```
+
+Please note that running those tests agains a real instance of Artifactory will manipulate the
+repositories of the server so please don't use a separate server for testing purpouses.
+
 License
 -------
 

--- a/README.rst
+++ b/README.rst
@@ -215,10 +215,10 @@ variables could take the values:
 
 .. code-block:: bash
 
-    $ CONAN_TEST_WITH_ARTIFACTORY=1
-    $ ARTIFACTORY_DEFAULT_URL=http://localhost:8081/artifactory
-    $ ARTIFACTORY_DEFAULT_USER=admin
-    $ ARTIFACTORY_DEFAULT_PASSWORD=password
+    $ export CONAN_TEST_WITH_ARTIFACTORY=1
+    $ export ARTIFACTORY_DEFAULT_URL=http://localhost:8081/artifactory
+    $ export ARTIFACTORY_DEFAULT_USER=admin
+    $ export ARTIFACTORY_DEFAULT_PASSWORD=password
 
 Please note that running those tests against a real instance of Artifactory will manipulate the
 repositories of the server so please use a separate server for testing purposes.

--- a/README.rst
+++ b/README.rst
@@ -208,10 +208,10 @@ To run specific tests, you can specify the test name too, something like:
 
 The ``--nocapture`` argument can be useful to see some output that otherwise is captured by nosetests.
 
-Also you can run tests against an instance of Artifactory. Those test should add the attribute
-``artifactory_ready``. To run those tests locally some environment variables must be defined. For
-example for an Artifactory instance that is running on the localhost with default user and password
-configured the variables could take the values.
+Also, you can run tests against an instance of Artifactory. Those tests should add the attribute
+``artifactory_ready``. Some environment variables have to be defined to run them. For example, for an
+Artifactory instance that is running on the localhost with default user and password configured, the
+variables could take the values:
 
 .. code-block:: bash
 
@@ -220,8 +220,8 @@ configured the variables could take the values.
     $ ARTIFACTORY_DEFAULT_USER=admin
     $ ARTIFACTORY_DEFAULT_PASSWORD=password
 
-Please note that running those tests agains a real instance of Artifactory will manipulate the
-repositories of the server so please don't use a separate server for testing purpouses.
+Please note that running those tests against a real instance of Artifactory will manipulate the
+repositories of the server so please use a separate server for testing purposes.
 
 License
 -------

--- a/README.rst
+++ b/README.rst
@@ -213,12 +213,12 @@ Also you can run tests against an instance of Artifactory. Those test should add
 example for an Artifactory instance that is running on the localhost with default user and password
 configured the variables could take the values.
 
-```bash
-CONAN_TEST_WITH_ARTIFACTORY=1
-ARTIFACTORY_DEFAULT_URL=http://localhost:8081/artifactory
-ARTIFACTORY_DEFAULT_USER=admin
-ARTIFACTORY_DEFAULT_PASSWORD=password
-```
+.. code-block:: bash
+
+    $ CONAN_TEST_WITH_ARTIFACTORY=1
+    $ ARTIFACTORY_DEFAULT_URL=http://localhost:8081/artifactory
+    $ ARTIFACTORY_DEFAULT_USER=admin
+    $ ARTIFACTORY_DEFAULT_PASSWORD=password
 
 Please note that running those tests agains a real instance of Artifactory will manipulate the
 repositories of the server so please don't use a separate server for testing purpouses.

--- a/README.rst
+++ b/README.rst
@@ -209,7 +209,13 @@ To run specific tests, you can specify the test name too, something like:
 The ``--nocapture`` argument can be useful to see some output that otherwise is captured by nosetests.
 
 Also, you can run tests against an instance of Artifactory. Those tests should add the attribute
-``artifactory_ready``. Some environment variables have to be defined to run them. For example, for an
+``artifactory_ready``.
+
+.. code-block:: bash
+
+    $ python -m nose . -A artifactory_ready
+
+Some environment variables have to be defined to run them. For example, for an
 Artifactory instance that is running on the localhost with default user and password configured, the
 variables could take the values:
 
@@ -220,8 +226,9 @@ variables could take the values:
     $ export ARTIFACTORY_DEFAULT_USER=admin
     $ export ARTIFACTORY_DEFAULT_PASSWORD=password
 
-Please note that running those tests against a real instance of Artifactory will manipulate the
-repositories of the server so please use a separate server for testing purposes.
+``ARTIFACTORY_DEFAULT_URL`` is the base url for the Artifactory repo, not one for an specific
+repository. Running the tests with a real Artifactory instance will create repos on the fly so please
+use a separate server for testing purposes.
 
 License
 -------


### PR DESCRIPTION
Changelog: Feature: Instructions on how to run conan tests against a real Artifactory server.
Docs: omit

- [ ] Refer to the issue that supports this Pull Request.
- [X] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [X] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [X] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 

<sup>**Note:** By default this PR will skip the slower tests and will use a limited set of python versions. Check [here](https://github.com/conan-io/conan/blob/develop/.github/PR_INCREASE_TESTING.md) how to increase the testing level by writing some tags in the current PR body text.</sup>
