### PR TITLE
fixing pkg_config empty dirs

### DIFF
--- a/conans/client/generators/pkg_config.py
+++ b/conans/client/generators/pkg_config.py
@@ -97,16 +97,19 @@ class PkgConfigGenerator(Generator):
         lines = ['prefix=%s' % prefix_path]
 
         libdir_vars = []
-        dir_lines, varnames = _generate_dir_lines(prefix_path, "libdir", cpp_info.libdirs)
-        if dir_lines:
-            libdir_vars = varnames
-            lines.extend(dir_lines)
+        if cpp_info.lib_paths:  # Make sure it is not empty
+            dir_lines, varnames = _generate_dir_lines(prefix_path, "libdir", cpp_info.libdirs)
+            if dir_lines:
+                libdir_vars = varnames
+                lines.extend(dir_lines)
 
         includedir_vars = []
-        dir_lines, varnames = _generate_dir_lines(prefix_path, "includedir", cpp_info.includedirs)
-        if dir_lines:
-            includedir_vars = varnames
-            lines.extend(dir_lines)
+        if cpp_info.include_paths:  # Make sure it is not empty
+            dir_lines, varnames = _generate_dir_lines(prefix_path, "includedir",
+                                                      cpp_info.includedirs)
+            if dir_lines:
+                includedir_vars = varnames
+                lines.extend(dir_lines)
 
         lines.append("")
         lines.append("Name: %s" % name)
@@ -121,7 +124,8 @@ class PkgConfigGenerator(Generator):
         if not hasattr(self.conanfile, 'settings_build'):
             os_build = os_build or self.conanfile.settings.get_safe("os")
 
-        rpaths = rpath_flags(self.conanfile.settings, os_build, ["${%s}" % libdir for libdir in libdir_vars])
+        rpaths = rpath_flags(self.conanfile.settings, os_build,
+                             ["${%s}" % libdir for libdir in libdir_vars])
         frameworks = format_frameworks(cpp_info.frameworks, self.conanfile.settings)
         framework_paths = format_framework_paths(cpp_info.framework_paths, self.conanfile.settings)
 

--- a/conans/test/functional/generators/pkg_config_test.py
+++ b/conans/test/functional/generators/pkg_config_test.py
@@ -15,30 +15,21 @@ class PkgGeneratorTest(unittest.TestCase):
         conanfile = """
 import os
 from conans import ConanFile
-from conans.tools import save
 
 class PkgConfigConan(ConanFile):
     name = "MyLib"
     version = "0.1"
 
-    def _dirs(self):
+    def package_info(self):
+        self.cpp_info.frameworkdirs = []
+        self.cpp_info.filter_empty = False
         libname = "mylib"
         fake_dir = os.path.join("/", "my_absoulte_path", "fake")
         include_dir = os.path.join(fake_dir, libname, "include")
         lib_dir = os.path.join(fake_dir, libname, "lib")
         lib_dir2 = os.path.join(self.package_folder, "lib2")
-        return include_dir, (lib_dir, lib_dir2)
-
-    def package(self):
-        include_dir, libdirs = self._dirs()
-        for p in [include_dir, *libdirs]:
-            save(os.path.join(self.package_folder, p, "file"), "")
-
-    def package_info(self):
-        self.cpp_info.frameworkdirs = []
-        include_dir, libdirs = self._dirs()
         self.cpp_info.includedirs = [include_dir]
-        self.cpp_info.libdirs = libdirs
+        self.cpp_info.libdirs = [lib_dir, lib_dir2]
 """
         client = TestClient()
         client.save({"conanfile.py": conanfile})

--- a/conans/test/functional/generators/pkg_config_test.py
+++ b/conans/test/functional/generators/pkg_config_test.py
@@ -25,6 +25,7 @@ class PkgConfigConan(ConanFile):
         self.cpp_info.includedirs = []
         self.cpp_info.libdirs = []
         self.cpp_info.bindirs = []
+        self.cpp_info.frameworkdirs = []
         self.cpp_info.libs = []
         libname = "mylib"
         fake_dir = os.path.join("/", "my_absoulte_path", "fake")

--- a/conans/test/unittests/client/generators/pkg_config_test.py
+++ b/conans/test/unittests/client/generators/pkg_config_test.py
@@ -16,7 +16,7 @@ class PkgGeneratorTest(unittest.TestCase):
         conanfile = ConanFile(TestBufferConanOutput(), None)
         conanfile.initialize(Settings({}), EnvValues())
         ref = ConanFileReference.loads("MyPkg/0.1@lasote/stables")
-        cpp_info = CppInfo(ref.name, "dummy_root_folder1")
+        cpp_info = CppInfo(ref.name, "/dummy_root_folder1")
         cpp_info.filter_empty = False
         cpp_info.name = "my_pkg"
         cpp_info.defines = ["MYDEFINE1"]
@@ -26,7 +26,7 @@ class PkgGeneratorTest(unittest.TestCase):
         conanfile.deps_cpp_info.add(ref.name, cpp_info)
 
         ref = ConanFileReference.loads("MyPkg1/0.1@lasote/stables")
-        cpp_info = CppInfo(ref.name, "dummy_root_folder1")
+        cpp_info = CppInfo(ref.name, "/dummy_root_folder1")
         cpp_info.filter_empty = False
         cpp_info.name = "MYPKG1"
         cpp_info.defines = ["MYDEFINE11"]
@@ -37,7 +37,7 @@ class PkgGeneratorTest(unittest.TestCase):
         conanfile.deps_cpp_info.add(ref.name, cpp_info)
 
         ref = ConanFileReference.loads("MyPkg2/0.1@lasote/stables")
-        cpp_info = CppInfo(ref.name, "dummy_root_folder2")
+        cpp_info = CppInfo(ref.name, "/dummy_root_folder2")
         cpp_info.filter_empty = False
         cpp_info.defines = ["MYDEFINE2"]
         cpp_info.version = "2.3"
@@ -49,7 +49,7 @@ class PkgGeneratorTest(unittest.TestCase):
         generator = PkgConfigGenerator(conanfile)
         files = generator.content
 
-        self.assertEqual(files["MyPkg2.pc"], """prefix=dummy_root_folder2
+        self.assertEqual(files["MyPkg2.pc"], """prefix=/dummy_root_folder2
 libdir=${prefix}/lib
 includedir=${prefix}/include
 
@@ -61,7 +61,7 @@ Cflags: -I${includedir} -cxxflag -DMYDEFINE2
 Requires: my_pkg
 """)
 
-        self.assertEqual(files["mypkg1.pc"], """prefix=dummy_root_folder1
+        self.assertEqual(files["mypkg1.pc"], """prefix=/dummy_root_folder1
 libdir=${prefix}/lib
 includedir=${prefix}/include
 
@@ -73,7 +73,7 @@ Cflags: -I${includedir} -Flag1=21 -DMYDEFINE11
 Requires: my_pkg
 """)
 
-        self.assertEqual(files["my_pkg.pc"], """prefix=dummy_root_folder1
+        self.assertEqual(files["my_pkg.pc"], """prefix=/dummy_root_folder1
 libdir=${prefix}/lib
 includedir=${prefix}/include
 
@@ -89,7 +89,7 @@ Cflags: -I${includedir} -Flag1=23 -DMYDEFINE1
         conanfile.initialize(Settings({}), EnvValues())
 
         ref = ConanFileReference.loads("MyPkg/0.1@lasote/stables")
-        cpp_info = CppInfo(ref.name, "dummy_root_folder1")
+        cpp_info = CppInfo(ref.name, "/dummy_root_folder1")
         cpp_info.filter_empty = False
         cpp_info.name = "my_pkg"
         cpp_info.names["pkg_config"] = "my_pkg_custom_name"
@@ -100,7 +100,7 @@ Cflags: -I${includedir} -Flag1=23 -DMYDEFINE1
         conanfile.deps_cpp_info.add(ref.name, cpp_info)
 
         ref = ConanFileReference.loads("MyPkg1/0.1@lasote/stables")
-        cpp_info = CppInfo(ref.name, "dummy_root_folder1")
+        cpp_info = CppInfo(ref.name, "/dummy_root_folder1")
         cpp_info.filter_empty = False
         cpp_info.name = "MYPKG1"
         cpp_info.names["pkg_config"] = "my_pkg1_custom_name"
@@ -111,7 +111,7 @@ Cflags: -I${includedir} -Flag1=23 -DMYDEFINE1
         conanfile.deps_cpp_info.add(ref.name, cpp_info)
 
         ref = ConanFileReference.loads("MyPkg2/0.1@lasote/stables")
-        cpp_info = CppInfo(ref.name, "dummy_root_folder2")
+        cpp_info = CppInfo(ref.name, "/dummy_root_folder2")
         cpp_info.filter_empty = False
         cpp_info.names["pkg_config"] = "my_pkg2_custom_name"
         cpp_info.defines = ["MYDEFINE2"]
@@ -123,7 +123,7 @@ Cflags: -I${includedir} -Flag1=23 -DMYDEFINE1
         conanfile.deps_cpp_info.add(ref.name, cpp_info)
 
         ref = ConanFileReference.loads("zlib/1.2.11@lasote/stable")
-        cpp_info = CppInfo(ref.name, "dummy_root_folder_zlib")
+        cpp_info = CppInfo(ref.name, "/dummy_root_folder_zlib")
         cpp_info.filter_empty = False
         cpp_info.name = "ZLIB"
         cpp_info.defines = ["MYZLIBDEFINE2"]
@@ -131,7 +131,7 @@ Cflags: -I${includedir} -Flag1=23 -DMYDEFINE1
         conanfile.deps_cpp_info.add(ref.name, cpp_info)
 
         ref = ConanFileReference.loads("bzip2/0.1@lasote/stables")
-        cpp_info = CppInfo(ref.name, "dummy_root_folder2")
+        cpp_info = CppInfo(ref.name, "/dummy_root_folder2")
         cpp_info.filter_empty = False
         cpp_info.name = "BZip2"
         cpp_info.names["pkg_config"] = "BZip2"
@@ -145,7 +145,7 @@ Cflags: -I${includedir} -Flag1=23 -DMYDEFINE1
         generator = PkgConfigGenerator(conanfile)
         files = generator.content
 
-        self.assertEqual(files["my_pkg2_custom_name.pc"], """prefix=dummy_root_folder2
+        self.assertEqual(files["my_pkg2_custom_name.pc"], """prefix=/dummy_root_folder2
 libdir=${prefix}/lib
 includedir=${prefix}/include
 
@@ -156,7 +156,7 @@ Libs: -L${libdir} -sharedlinkflag -exelinkflag
 Cflags: -I${includedir} -cxxflag -DMYDEFINE2
 Requires: my_pkg_custom_name my_pkg1_custom_name
 """)
-        self.assertEqual(files["my_pkg1_custom_name.pc"], """prefix=dummy_root_folder1
+        self.assertEqual(files["my_pkg1_custom_name.pc"], """prefix=/dummy_root_folder1
 libdir=${prefix}/lib
 includedir=${prefix}/include
 
@@ -166,7 +166,7 @@ Version: 1.7
 Libs: -L${libdir}
 Cflags: -I${includedir} -Flag1=21 -DMYDEFINE11
 """)
-        self.assertEqual(files["my_pkg_custom_name.pc"], """prefix=dummy_root_folder1
+        self.assertEqual(files["my_pkg_custom_name.pc"], """prefix=/dummy_root_folder1
 libdir=${prefix}/lib
 includedir=${prefix}/include
 
@@ -176,7 +176,7 @@ Version: 1.3
 Libs: -L${libdir}
 Cflags: -I${includedir} -Flag1=23 -DMYDEFINE1
 """)
-        self.assertEqual(files["BZip2.pc"], """prefix=dummy_root_folder2
+        self.assertEqual(files["BZip2.pc"], """prefix=/dummy_root_folder2
 libdir=${prefix}/lib
 includedir=${prefix}/include
 
@@ -196,7 +196,7 @@ Requires: my_pkg_custom_name my_pkg1_custom_name zlib
         conanfile.initialize(Settings({}), EnvValues())
         conanfile.settings = settings
         ref = ConanFileReference.loads("MyPkg/0.1@lasote/stables")
-        cpp_info = CppInfo(ref.name, "dummy_root_folder1")
+        cpp_info = CppInfo(ref.name, "/dummy_root_folder1")
         cpp_info.filter_empty = False
         cpp_info.frameworks = ['AudioUnit', 'AudioToolbox']
         cpp_info.version = "1.3"
@@ -206,13 +206,13 @@ Requires: my_pkg_custom_name my_pkg1_custom_name zlib
         generator = PkgConfigGenerator(conanfile)
         files = generator.content
 
-        self.assertEqual(files["MyPkg.pc"], """prefix=dummy_root_folder1
+        self.assertEqual(files["MyPkg.pc"], """prefix=/dummy_root_folder1
 libdir=${prefix}/lib
 includedir=${prefix}/include
 
 Name: MyPkg
 Description: My cool description
 Version: 1.3
-Libs: -L${libdir} -Wl,-rpath,"${libdir}" -framework AudioUnit -framework AudioToolbox -F dummy_root_folder1/Frameworks
+Libs: -L${libdir} -Wl,-rpath,"${libdir}" -framework AudioUnit -framework AudioToolbox -F /dummy_root_folder1/Frameworks
 Cflags: -I${includedir}
 """)

--- a/conans/test/unittests/client/generators/pkg_config_test.py
+++ b/conans/test/unittests/client/generators/pkg_config_test.py
@@ -17,6 +17,7 @@ class PkgGeneratorTest(unittest.TestCase):
         conanfile.initialize(Settings({}), EnvValues())
         ref = ConanFileReference.loads("MyPkg/0.1@lasote/stables")
         cpp_info = CppInfo(ref.name, "dummy_root_folder1")
+        cpp_info.filter_empty = False
         cpp_info.name = "my_pkg"
         cpp_info.defines = ["MYDEFINE1"]
         cpp_info.cflags.append("-Flag1=23")
@@ -26,6 +27,7 @@ class PkgGeneratorTest(unittest.TestCase):
 
         ref = ConanFileReference.loads("MyPkg1/0.1@lasote/stables")
         cpp_info = CppInfo(ref.name, "dummy_root_folder1")
+        cpp_info.filter_empty = False
         cpp_info.name = "MYPKG1"
         cpp_info.defines = ["MYDEFINE11"]
         cpp_info.cflags.append("-Flag1=21")
@@ -36,6 +38,7 @@ class PkgGeneratorTest(unittest.TestCase):
 
         ref = ConanFileReference.loads("MyPkg2/0.1@lasote/stables")
         cpp_info = CppInfo(ref.name, "dummy_root_folder2")
+        cpp_info.filter_empty = False
         cpp_info.defines = ["MYDEFINE2"]
         cpp_info.version = "2.3"
         cpp_info.exelinkflags = ["-exelinkflag"]
@@ -87,6 +90,7 @@ Cflags: -I${includedir} -Flag1=23 -DMYDEFINE1
 
         ref = ConanFileReference.loads("MyPkg/0.1@lasote/stables")
         cpp_info = CppInfo(ref.name, "dummy_root_folder1")
+        cpp_info.filter_empty = False
         cpp_info.name = "my_pkg"
         cpp_info.names["pkg_config"] = "my_pkg_custom_name"
         cpp_info.defines = ["MYDEFINE1"]
@@ -97,6 +101,7 @@ Cflags: -I${includedir} -Flag1=23 -DMYDEFINE1
 
         ref = ConanFileReference.loads("MyPkg1/0.1@lasote/stables")
         cpp_info = CppInfo(ref.name, "dummy_root_folder1")
+        cpp_info.filter_empty = False
         cpp_info.name = "MYPKG1"
         cpp_info.names["pkg_config"] = "my_pkg1_custom_name"
         cpp_info.defines = ["MYDEFINE11"]
@@ -107,6 +112,7 @@ Cflags: -I${includedir} -Flag1=23 -DMYDEFINE1
 
         ref = ConanFileReference.loads("MyPkg2/0.1@lasote/stables")
         cpp_info = CppInfo(ref.name, "dummy_root_folder2")
+        cpp_info.filter_empty = False
         cpp_info.names["pkg_config"] = "my_pkg2_custom_name"
         cpp_info.defines = ["MYDEFINE2"]
         cpp_info.version = "2.3"
@@ -118,6 +124,7 @@ Cflags: -I${includedir} -Flag1=23 -DMYDEFINE1
 
         ref = ConanFileReference.loads("zlib/1.2.11@lasote/stable")
         cpp_info = CppInfo(ref.name, "dummy_root_folder_zlib")
+        cpp_info.filter_empty = False
         cpp_info.name = "ZLIB"
         cpp_info.defines = ["MYZLIBDEFINE2"]
         cpp_info.version = "1.2.11"
@@ -125,6 +132,7 @@ Cflags: -I${includedir} -Flag1=23 -DMYDEFINE1
 
         ref = ConanFileReference.loads("bzip2/0.1@lasote/stables")
         cpp_info = CppInfo(ref.name, "dummy_root_folder2")
+        cpp_info.filter_empty = False
         cpp_info.name = "BZip2"
         cpp_info.names["pkg_config"] = "BZip2"
         cpp_info.defines = ["MYDEFINE2"]
@@ -189,6 +197,7 @@ Requires: my_pkg_custom_name my_pkg1_custom_name zlib
         conanfile.settings = settings
         ref = ConanFileReference.loads("MyPkg/0.1@lasote/stables")
         cpp_info = CppInfo(ref.name, "dummy_root_folder1")
+        cpp_info.filter_empty = False
         cpp_info.frameworks = ['AudioUnit', 'AudioToolbox']
         cpp_info.version = "1.3"
         cpp_info.description = "My cool description"
@@ -204,6 +213,6 @@ includedir=${prefix}/include
 Name: MyPkg
 Description: My cool description
 Version: 1.3
-Libs: -L${libdir} -Wl,-rpath,"${libdir}" -framework AudioUnit -framework AudioToolbox
+Libs: -L${libdir} -Wl,-rpath,"${libdir}" -framework AudioUnit -framework AudioToolbox -F dummy_root_folder1/Frameworks
 Cflags: -I${includedir}
 """)


### PR DESCRIPTION
Changelog: Bugfix: Fix ``pkg_config`` generator adding to .pc files empty include and lib dirs.
Docs: Omit

Fix https://github.com/conan-io/conan/issues/7701
