### PR TITLE
Add Depends item for every public_dep of the conanfiles deps

### DIFF
--- a/conans/client/generators/qbs.py
+++ b/conans/client/generators/qbs.py
@@ -9,7 +9,7 @@ class DepsCppQbs(object):
                                             for p in cpp_info.include_paths)
         self.lib_paths = delimiter.join('"%s"' % p.replace("\\", "/")
                                         for p in cpp_info.lib_paths)
-        self.libs = delimiter.join('"%s"' % l for l in (cpp_info.libs + cpp_info.system_libs))
+        self.libs = delimiter.join('"%s"' % lib for lib in (cpp_info.libs + cpp_info.system_libs))
         self.framework_paths = delimiter.join('"%s"' % p.replace("\\", "/")
                                               for p in cpp_info.framework_paths)
         self.frameworks = delimiter.join('"%s"' % f for f in cpp_info.frameworks)
@@ -54,7 +54,7 @@ class QbsGenerator(Generator):
                     '        }}\n'
                     '    }}\n')
 
-        depends_template = ('            Depends {{ name: "{dep}" }}\n')
+        depends_template = '            Depends {{ name: "{dep}" }}\n'
 
         sections = []
         all_flags = template.format(dep="ConanBasicSetup", deps=deps, depends_items="")

--- a/conans/client/generators/qbs.py
+++ b/conans/client/generators/qbs.py
@@ -26,6 +26,8 @@ class DepsCppQbs(object):
 
 
 class QbsGenerator(Generator):
+    name = "qbs"
+
     @property
     def filename(self):
         return BUILD_INFO_QBS
@@ -48,17 +50,24 @@ class QbsGenerator(Generator):
                     '            cpp.cxxFlags: [{deps.cxxflags}]\n'
                     '            cpp.cFlags: [{deps.cflags}]\n'
                     '            cpp.linkerFlags: [{deps.linkerFlags}]\n'
+                    '{depends_items}'
                     '        }}\n'
                     '    }}\n')
 
+        depends_template = ('            Depends {{ name: "{dep}" }}\n')
+
         sections = []
-        all_flags = template.format(dep="ConanBasicSetup", deps=deps)
+        all_flags = template.format(dep="ConanBasicSetup", deps=deps, depends_items="")
         sections.append(all_flags)
         template_deps = template + '    // {dep} root path: {deps.rootpath}\n'
 
         for dep_name, dep_cpp_info in self.deps_build_info.dependencies:
             deps = DepsCppQbs(dep_cpp_info)
-            dep_flags = template_deps.format(dep=dep_name, deps=deps)
+            depends_items = ""
+            for public_dep in dep_cpp_info.public_deps:
+                name = self.deps_build_info[public_dep].get_name(QbsGenerator.name)
+                depends_items += depends_template.format(dep=name)
+            dep_flags = template_deps.format(dep=dep_name, deps=deps, depends_items=depends_items)
             sections.append(dep_flags)
 
         output = 'import qbs 1.0\n\nProject {\n'

--- a/conans/test/functional/generators/qbs_test.py
+++ b/conans/test/functional/generators/qbs_test.py
@@ -1,0 +1,19 @@
+import unittest
+
+from conans.test.utils.genconanfile import GenConanfile
+from conans.test.utils.tools import TestClient
+
+
+class QbsGeneratorTest(unittest.TestCase):
+
+    def test(self):
+        client = TestClient()
+
+        client.run("new dep/0.1 -b")
+        client.run("create . user/testing")
+        pkg = GenConanfile("pkg", "0.1").with_requires("dep/0.1@user/testing")
+        client.save({"conanfile.py": pkg}, clean_first=True)
+        client.run("create . user/testing")
+        client.run("install pkg/0.1@user/testing -g=qbs")
+        qbs = client.load("conanbuildinfo.qbs")
+        self.assertIn('Depends { name: "dep" }', qbs)


### PR DESCRIPTION
Changelog: Feature: Added [Depends](https://doc.qt.io/qbs/qml-qbslanguageitems-depends.html) items for every public dependency of conanfiles requires/dependencies. 
Docs: https://github.com/conan-io/docs/pull/1847

Fixes #7728.

The usage of `publilc_deps` is based on the implementation of the pkg_config generator.

- [x] Refer to the issue that supports this Pull Request.
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [x] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 

<sup>**Note:** By default this PR will skip the slower tests and will use a limited set of python versions. Check [here](https://github.com/conan-io/conan/blob/develop/.github/PR_INCREASE_TESTING.md) how to increase the testing level by writing some tags in the current PR body text.</sup>
