### PR TITLE
Adding CMake ABI support for armv5el and armv5hf architecture

### DIFF
--- a/conans/client/tools/android.py
+++ b/conans/client/tools/android.py
@@ -2,7 +2,9 @@
 
 def to_android_abi(arch):
     """converts conan-style architecture into Android-NDK ABI"""
-    return {'armv5': 'armeabi',
+    return {'armv5el': 'armeabi',
+            'armv5hf': 'armeabi',
+            'armv5': 'armeabi',
             'armv6': 'armeabi-v6',
             'armv7': 'armeabi-v7a',
             'armv7hf': 'armeabi-v7a',


### PR DESCRIPTION
Changelog: BugFix: Add ``armv5hf`` and ``armv5el`` to the Android ABI architectures.
Docs: Omit

Makes CMake support compiling for older Android ARM CPU by mapping `armv5el` and `armv5hf` architectures to the `armeabi` ABI. Without this, CMake is going to complain for an unknown ABI when `arch` is set to `armv5el` or `armv5hf` in the Conan profile, as CMake expects `CMAKE_ANDROID_ARCH_ABI` to be set to [one of the values documented here](https://cmake.org/cmake/help/latest/variable/CMAKE_ANDROID_ARCH_ABI.html).

- [ ] ~~Refer to the issue that supports this Pull Request.~~
- [ ] ~~If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.~~
- [X] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [X] I've followed the PEP8 style guides for Python code.
- [ ] ~~I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one.~~ (no interface was changed)

I have skipped most of the above steps because this is such a tiny modification that even this pull request contains more work already than those two lines added to the mapping function (maybe not if we count using the modification version) :)