### PR TITLE
Bringing back build colourisation

### DIFF
--- a/conans/client/runner.py
+++ b/conans/client/runner.py
@@ -108,7 +108,6 @@ class ConanRunner(object):
 
         if capture_output:
             get_stream_lines(proc.stdout)
-        # get_stream_lines(proc.stderr)
 
         proc.communicate()
         ret = proc.returncode

--- a/conans/client/runner.py
+++ b/conans/client/runner.py
@@ -76,10 +76,9 @@ class ConanRunner(object):
             # piping both stdout, stderr and then later only reading one will hang the process
             # if the other fills the pip. So piping stdout, and redirecting stderr to stdout,
             # so both are merged and use just a single get_stream_lines() call
-            capture_output = False
-            if log_handler or not self._log_run_to_output or (
-                stream_output and isinstance(stream_output._stream, six.StringIO)):
-                capture_output = True
+            capture_output = log_handler or not self._log_run_to_output or (
+                    stream_output and isinstance(stream_output._stream, six.StringIO))
+            if capture_output:
                 proc = Popen(command, shell=isinstance(command, six.string_types), stdout=PIPE,
                              stderr=STDOUT, cwd=cwd)
             else:

--- a/conans/client/runner.py
+++ b/conans/client/runner.py
@@ -2,7 +2,6 @@ import io
 import os
 import subprocess
 import sys
-
 from subprocess import PIPE, Popen, STDOUT
 
 import six
@@ -77,11 +76,14 @@ class ConanRunner(object):
             # piping both stdout, stderr and then later only reading one will hang the process
             # if the other fills the pip. So piping stdout, and redirecting stderr to stdout,
             # so both are merged and use just a single get_stream_lines() call
-            capture_output = True
-            if type(stream_output._stream) == six.StringIO or self._log_run_to_output:
-                proc = Popen(command, shell=isinstance(command, six.string_types), stdout=PIPE, stderr=STDOUT, cwd=cwd)
+            capture_output = False
+            if log_handler or not self._log_run_to_output or (
+                stream_output and type(stream_output._stream) == six.StringIO):
+
+                capture_output = True
+                proc = Popen(command, shell=isinstance(command, six.string_types), stdout=PIPE,
+                             stderr=STDOUT, cwd=cwd)
             else:
-                capture_output = False
                 proc = Popen(command, shell=isinstance(command, six.string_types), cwd=cwd)
 
         except Exception as e:

--- a/conans/client/runner.py
+++ b/conans/client/runner.py
@@ -1,5 +1,6 @@
 import io
 import os
+import subprocess
 import sys
 
 from subprocess import PIPE, Popen, STDOUT

--- a/conans/client/runner.py
+++ b/conans/client/runner.py
@@ -79,7 +79,6 @@ class ConanRunner(object):
             capture_output = False
             if log_handler or not self._log_run_to_output or (
                 stream_output and isinstance(stream_output._stream, six.StringIO)):
-
                 capture_output = True
                 proc = Popen(command, shell=isinstance(command, six.string_types), stdout=PIPE,
                              stderr=STDOUT, cwd=cwd)

--- a/conans/client/runner.py
+++ b/conans/client/runner.py
@@ -78,7 +78,7 @@ class ConanRunner(object):
             # so both are merged and use just a single get_stream_lines() call
             capture_output = False
             if log_handler or not self._log_run_to_output or (
-                stream_output and type(stream_output._stream) == six.StringIO):
+                stream_output and isinstance(stream_output._stream, six.StringIO)):
 
                 capture_output = True
                 proc = Popen(command, shell=isinstance(command, six.string_types), stdout=PIPE,

--- a/conans/client/runner.py
+++ b/conans/client/runner.py
@@ -77,7 +77,13 @@ class ConanRunner(object):
             # piping both stdout, stderr and then later only reading one will hang the process
             # if the other fills the pip. So piping stdout, and redirecting stderr to stdout,
             # so both are merged and use just a single get_stream_lines() call
-            proc = Popen(command, shell=isinstance(command, six.string_types), stdout=PIPE, stderr=STDOUT, cwd=cwd)
+            capture_output = True
+            if type(stream_output._stream) == six.StringIO or self._log_run_to_output:
+                proc = Popen(command, shell=isinstance(command, six.string_types), stdout=PIPE, stderr=STDOUT, cwd=cwd)
+            else:
+                capture_output = False
+                proc = Popen(command, shell=isinstance(command, six.string_types), cwd=cwd)
+
         except Exception as e:
             raise ConanException("Error while executing '%s'\n\t%s" % (command, str(e)))
 
@@ -100,7 +106,8 @@ class ConanRunner(object):
                     # tried to open the log_handler binary but same result.
                     log_handler.write(line if six.PY2 else decoded_line)
 
-        get_stream_lines(proc.stdout)
+        if capture_output:
+            get_stream_lines(proc.stdout)
         # get_stream_lines(proc.stderr)
 
         proc.communicate()


### PR DESCRIPTION
Changelog: Fix: Do not capture output for normal conan run (no logging or testing) when launching processes via `ConanRunner` so that color from build tools output is not lost.
Docs: omit

This is a proposal for recovering `ConanRunner` colorisation. Maybe we just want to capture the `stdout` using `Popen` and therefore disabling color codes when we are running the tests (the stream will be a StringIO) or when we explicitly set `run_to_file=True` or `run_to_output=False`.

Closes: https://github.com/conan-io/conan/issues/5597

- [X] Refer to the issue that supports this Pull Request.
- [X] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [X] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [X] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 

<sup>**Note:** By default this PR will skip the slower tests and will use a limited set of python versions. Check [here](https://github.com/conan-io/conan/blob/develop/.github/PR_INCREASE_TESTING.md) how to increase the testing level by writing some tags in the current PR body text.</sup>
