### PR TITLE
 Improve conan copy UX

### DIFF
--- a/conans/client/cmd/copy.py
+++ b/conans/client/cmd/copy.py
@@ -31,6 +31,10 @@ def cmd_copy(ref, user_channel, package_ids, cache, user_io, remote_manager, loa
 
 def package_copy(src_ref, user_channel, package_ids, cache, user_io, short_paths=False,
                  force=False):
+    ref = ConanFileReference.loads(user_channel)
+    if ref.name or ref.version:
+        raise ConanException("Destination must contain user/channel only.")
+
     dest_ref = ConanFileReference.loads("%s/%s@%s" % (src_ref.name,
                                                       src_ref.version,
                                                       user_channel))

--- a/conans/client/cmd/copy.py
+++ b/conans/client/cmd/copy.py
@@ -31,13 +31,12 @@ def cmd_copy(ref, user_channel, package_ids, cache, user_io, remote_manager, loa
 
 def package_copy(src_ref, user_channel, package_ids, cache, user_io, short_paths=False,
                  force=False):
-    ref = ConanFileReference.loads(user_channel)
-    if ref.name or ref.version:
+
+    ref = "%s/%s@%s" % (src_ref.name, src_ref.version, user_channel)
+    if ref.count('@') > 1:
         raise ConanException("Destination must contain user/channel only.")
 
-    dest_ref = ConanFileReference.loads("%s/%s@%s" % (src_ref.name,
-                                                      src_ref.version,
-                                                      user_channel))
+    dest_ref = ConanFileReference.loads(ref)
     # Generate metadata
     src_layout = cache.package_layout(src_ref, short_paths)
     src_metadata = src_layout.load_metadata()

--- a/conans/test/functional/command/copy_test.py
+++ b/conans/test/functional/command/copy_test.py
@@ -1,5 +1,6 @@
 import os
 import unittest
+import textwrap
 
 from conans.model.ref import ConanFileReference
 from conans.test.utils.tools import TestClient, TestServer
@@ -102,3 +103,15 @@ class Pkg(ConanFile):
         client.run("copy pkg/0.1@user/channel other/channel -p {} --all".format("mimic"),
                    assert_error=True)
         self.assertIn("Cannot specify both --all and --package", client.out)
+
+    def test_copy_full_reference(self):
+        conanfile = textwrap.dedent("""
+            from conans import ConanFile
+            class Pkg(ConanFile):
+                settings = "os"
+        """)
+        client = TestClient()
+        client.save({"conanfile.py": conanfile})
+        client.run("export . pkg/0.1@user/channel")
+        client.run("copy pkg/0.1@user/channel pkg/0.1@other/branch", assert_error=True)
+        self.assertIn("Destination must contain user/channel only.", client.out)


### PR DESCRIPTION
Changelog: Fix: Conan copy shows better description when using full reference for destination.
Docs: Omit

Related to #7736

- [ ] Refer to the issue that supports this Pull Request.
- [ ] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [ ] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [ ] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 

<sup>**Note:** By default this PR will skip the slower tests and will use a limited set of python versions. Check [here](https://github.com/conan-io/conan/blob/develop/.github/PR_INCREASE_TESTING.md) how to increase the testing level by writing some tags in the current PR body text.</sup>
