### PR TITLE
conan export command help line update

### DIFF
--- a/conans/client/command.py
+++ b/conans/client/command.py
@@ -1034,8 +1034,9 @@ class Command(object):
                                          formatter_class=SmartFormatter)
         parser.add_argument("path", help=_PATH_HELP)
         parser.add_argument("reference", nargs='?', default=None,
-                            help="user/channel, or Pkg/version@user/channel (if name "
-                                 "and version are not declared in the conanfile.py")
+                            help="user/channel, Pkg/version@user/channel (if name "
+                                 "and version are not declared in the conanfile.py) "
+                                 "Pkg/version@ if user/channel is not relevant.")
         parser.add_argument('-k', '-ks', '--keep-source', default=False, action='store_true',
                             help=_KEEP_SOURCE_HELP)
         parser.add_argument("-l", "--lockfile", action=OnceArgument,


### PR DESCRIPTION
Changelog: Fix: Extend help message indicating how to run `conan export` without `user/channel`.
Docs: https://github.com/conan-io/docs/pull/1859

Indicates now how to export without user/channel.

- [x] Refer to the issue that supports this Pull Request.
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [x] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 

The change is cosmetic as the feature is already implemented, but not well covered by documentation (neither web not command line help).