### PR TITLE
removing global generator_manager

### DIFF
--- a/conans/client/conan_api.py
+++ b/conans/client/conan_api.py
@@ -201,11 +201,12 @@ class ConanApp(object):
 
         self.proxy = ConanProxy(self.cache, self.out, self.remote_manager)
         self.range_resolver = RangeResolver(self.cache, self.remote_manager)
-        self.generators = GeneratorManager()
-        self.python_requires = ConanPythonRequire(self.proxy, self.range_resolver, self.generators)
+        self.generator_manager = GeneratorManager()
+        self.python_requires = ConanPythonRequire(self.proxy, self.range_resolver,
+                                                  self.generator_manager)
         self.pyreq_loader = PyRequireLoader(self.proxy, self.range_resolver)
         self.loader = ConanFileLoader(self.runner, self.out, self.python_requires,
-                                      self.generators, self.pyreq_loader)
+                                      self.generator_manager, self.pyreq_loader)
 
         self.binaries_analyzer = GraphBinariesAnalyzer(self.cache, self.out, self.remote_manager)
         self.graph_manager = GraphManager(self.out, self.cache, self.remote_manager, self.loader,

--- a/conans/client/conan_api.py
+++ b/conans/client/conan_api.py
@@ -22,6 +22,7 @@ from conans.client.cmd.uploader import CmdUpload
 from conans.client.cmd.user import user_set, users_clean, users_list, token_present
 from conans.client.conanfile.package import run_package_method
 from conans.client.conf.required_version import check_required_conan_version
+from conans.client.generators import GeneratorManager
 from conans.client.graph.graph import RECIPE_EDITABLE
 from conans.client.graph.graph_binaries import GraphBinariesAnalyzer
 from conans.client.graph.graph_manager import GraphManager
@@ -200,9 +201,11 @@ class ConanApp(object):
 
         self.proxy = ConanProxy(self.cache, self.out, self.remote_manager)
         self.range_resolver = RangeResolver(self.cache, self.remote_manager)
-        self.python_requires = ConanPythonRequire(self.proxy, self.range_resolver)
+        self.generators = GeneratorManager()
+        self.python_requires = ConanPythonRequire(self.proxy, self.range_resolver, self.generators)
         self.pyreq_loader = PyRequireLoader(self.proxy, self.range_resolver)
-        self.loader = ConanFileLoader(self.runner, self.out, self.python_requires, self.pyreq_loader)
+        self.loader = ConanFileLoader(self.runner, self.out, self.python_requires,
+                                      self.generators, self.pyreq_loader)
 
         self.binaries_analyzer = GraphBinariesAnalyzer(self.cache, self.out, self.remote_manager)
         self.graph_manager = GraphManager(self.out, self.cache, self.remote_manager, self.loader,

--- a/conans/client/graph/python_requires.py
+++ b/conans/client/graph/python_requires.py
@@ -147,8 +147,8 @@ class PyRequireLoader(object):
 
 
 class ConanPythonRequire(object):
-    def __init__(self, proxy, range_resolver, generators=None):
-        self._generators = generators
+    def __init__(self, proxy, range_resolver, generator_manager=None):
+        self._generator_manager = generator_manager
         self._cached_requires = {}  # {reference: PythonRequire}
         self._proxy = proxy
         self._range_resolver = range_resolver
@@ -186,7 +186,7 @@ class ConanPythonRequire(object):
                                             recorder=ActionRecorder())
             path, _, _, new_ref = result
             module, conanfile = parse_conanfile(conanfile_path=path, python_requires=self,
-                                                generators=self._generators)
+                                                generators=self._generator_manager)
 
             # Check for alias
             if getattr(conanfile, "alias", None):

--- a/conans/client/graph/python_requires.py
+++ b/conans/client/graph/python_requires.py
@@ -147,7 +147,8 @@ class PyRequireLoader(object):
 
 
 class ConanPythonRequire(object):
-    def __init__(self, proxy, range_resolver):
+    def __init__(self, proxy, range_resolver, generators=None):
+        self._generators = generators
         self._cached_requires = {}  # {reference: PythonRequire}
         self._proxy = proxy
         self._range_resolver = range_resolver
@@ -184,7 +185,8 @@ class ConanPythonRequire(object):
                                             remotes=self._remotes,
                                             recorder=ActionRecorder())
             path, _, _, new_ref = result
-            module, conanfile = parse_conanfile(conanfile_path=path, python_requires=self)
+            module, conanfile = parse_conanfile(conanfile_path=path, python_requires=self,
+                                                generators=self._generators)
 
             # Check for alias
             if getattr(conanfile, "alias", None):

--- a/conans/client/installer.py
+++ b/conans/client/installer.py
@@ -67,7 +67,7 @@ class _PackageBuilder(object):
         self._output = output
         self._hook_manager = hook_manager
         self._remote_manager = remote_manager
-        self._generators = generators
+        self._generator_manager = generators
 
     def _get_build_folder(self, conanfile, package_layout, pref, keep_build, recorder):
         # Build folder can use a different package_ID if build_id() is defined.
@@ -125,7 +125,7 @@ class _PackageBuilder(object):
     def _build(self, conanfile, pref):
         # Read generators from conanfile and generate the needed files
         logger.info("GENERATORS: Writing generators")
-        self._generators.write_generators(conanfile, conanfile.build_folder, self._output)
+        self._generator_manager.write_generators(conanfile, conanfile.build_folder, self._output)
 
         logger.info("TOOLCHAIN: Writing toolchain")
         write_toolchain(conanfile, conanfile.build_folder, self._output)
@@ -291,7 +291,7 @@ class BinaryInstaller(object):
         self._recorder = recorder
         self._binaries_analyzer = app.binaries_analyzer
         self._hook_manager = app.hook_manager
-        self._generators = app.generators
+        self._generator_manager = app.generator_manager
 
     def install(self, deps_graph, remotes, build_mode, update, keep_build=False, graph_info=None):
         # order by levels and separate the root node (ref=None) from the rest
@@ -455,7 +455,7 @@ class BinaryInstaller(object):
             if build_folder is not None:
                 build_folder = os.path.join(base_path, build_folder)
                 output = node.conanfile.output
-                self._generators.write_generators(node.conanfile, build_folder, output)
+                self._generator_manager.write_generators(node.conanfile, build_folder, output)
                 write_toolchain(node.conanfile, build_folder, output)
                 save(os.path.join(build_folder, CONANINFO), node.conanfile.info.dumps())
                 output.info("Generated %s" % CONANINFO)
@@ -521,7 +521,7 @@ class BinaryInstaller(object):
                                         python_require.conanfile, python_require.ref, remotes)
 
         builder = _PackageBuilder(self._cache, output, self._hook_manager, self._remote_manager,
-                                  self._generators)
+                                  self._generator_manager)
         pref = builder.build_package(node, keep_build, self._recorder, remotes)
         if node.graph_lock_node:
             node.graph_lock_node.prev = pref.revision

--- a/conans/client/loader.py
+++ b/conans/client/loader.py
@@ -8,7 +8,6 @@ import uuid
 import yaml
 
 from conans.client.conf.required_version import validate_conan_version
-from conans.client.generators import registered_generators
 from conans.client.loader_txt import ConanFileTextLoader
 from conans.client.tools.files import chdir
 from conans.errors import ConanException, NotFoundException, ConanInvalidConfiguration, \
@@ -25,8 +24,9 @@ from conans.util.files import load
 
 
 class ConanFileLoader(object):
-    def __init__(self, runner, output, python_requires, pyreq_loader=None):
+    def __init__(self, runner, output, python_requires, generators=None, pyreq_loader=None):
         self._runner = runner
+        self._generators = generators
         self._output = output
         self._pyreq_loader = pyreq_loader
         self._python_requires = python_requires
@@ -52,7 +52,8 @@ class ConanFileLoader(object):
             self._python_requires.locked_versions = {r.name: r for r in lock_python_requires}
         try:
             self._python_requires.valid = True
-            module, conanfile = parse_conanfile(conanfile_path, self._python_requires)
+            module, conanfile = parse_conanfile(conanfile_path, self._python_requires,
+                                                self._generators)
             self._python_requires.valid = False
 
             self._python_requires.locked_versions = None
@@ -294,7 +295,7 @@ class ConanFileLoader(object):
         return conanfile
 
 
-def _parse_module(conanfile_module, module_id):
+def _parse_module(conanfile_module, module_id, generators):
     """ Parses a python in-memory module, to extract the classes, mainly the main
     class defining the Recipe, but also process possible existing generators
     @param conanfile_module: the module to be processed
@@ -312,7 +313,7 @@ def _parse_module(conanfile_module, module_id):
             else:
                 raise ConanException("More than 1 conanfile in the file")
         elif issubclass(attr, Generator) and attr != Generator:
-            registered_generators.add(attr.__name__, attr, custom=True)
+            generators.add(attr.__name__, attr, custom=True)
 
     if result is None:
         raise ConanException("No subclass of ConanFile")
@@ -320,11 +321,11 @@ def _parse_module(conanfile_module, module_id):
     return result
 
 
-def parse_conanfile(conanfile_path, python_requires):
+def parse_conanfile(conanfile_path, python_requires, generators):
     with python_requires.capture_requires() as py_requires:
         module, filename = _parse_conanfile(conanfile_path)
         try:
-            conanfile = _parse_module(module, filename)
+            conanfile = _parse_module(module, filename, generators)
 
             # Check for duplicates
             # TODO: move it into PythonRequires

--- a/conans/client/loader.py
+++ b/conans/client/loader.py
@@ -24,9 +24,9 @@ from conans.util.files import load
 
 
 class ConanFileLoader(object):
-    def __init__(self, runner, output, python_requires, generators=None, pyreq_loader=None):
+    def __init__(self, runner, output, python_requires, generator_manager=None, pyreq_loader=None):
         self._runner = runner
-        self._generators = generators
+        self._generator_manager = generator_manager
         self._output = output
         self._pyreq_loader = pyreq_loader
         self._python_requires = python_requires
@@ -53,7 +53,7 @@ class ConanFileLoader(object):
         try:
             self._python_requires.valid = True
             module, conanfile = parse_conanfile(conanfile_path, self._python_requires,
-                                                self._generators)
+                                                self._generator_manager)
             self._python_requires.valid = False
 
             self._python_requires.locked_versions = None
@@ -295,7 +295,7 @@ class ConanFileLoader(object):
         return conanfile
 
 
-def _parse_module(conanfile_module, module_id, generators):
+def _parse_module(conanfile_module, module_id, generator_manager):
     """ Parses a python in-memory module, to extract the classes, mainly the main
     class defining the Recipe, but also process possible existing generators
     @param conanfile_module: the module to be processed
@@ -313,7 +313,7 @@ def _parse_module(conanfile_module, module_id, generators):
             else:
                 raise ConanException("More than 1 conanfile in the file")
         elif issubclass(attr, Generator) and attr != Generator:
-            generators.add(attr.__name__, attr, custom=True)
+            generator_manager.add(attr.__name__, attr, custom=True)
 
     if result is None:
         raise ConanException("No subclass of ConanFile")
@@ -321,11 +321,11 @@ def _parse_module(conanfile_module, module_id, generators):
     return result
 
 
-def parse_conanfile(conanfile_path, python_requires, generators):
+def parse_conanfile(conanfile_path, python_requires, generator_manager):
     with python_requires.capture_requires() as py_requires:
         module, filename = _parse_conanfile(conanfile_path)
         try:
-            conanfile = _parse_module(module, filename, generators)
+            conanfile = _parse_module(module, filename, generator_manager)
 
             # Check for duplicates
             # TODO: move it into PythonRequires

--- a/conans/client/manager.py
+++ b/conans/client/manager.py
@@ -1,6 +1,5 @@
 import os
 
-from conans.client.generators import write_generators
 from conans.client.graph.build_mode import BuildMode
 from conans.client.graph.graph import RECIPE_CONSUMER, RECIPE_VIRTUAL
 from conans.client.graph.printer import print_graph
@@ -98,7 +97,7 @@ def deps_install(app, ref_or_path, install_folder, graph_info, remotes=None, bui
             tmp = list(conanfile.generators)  # Add the command line specified generators
             tmp.extend([g for g in generators if g not in tmp])
             conanfile.generators = tmp
-            write_generators(conanfile, install_folder, output)
+            app.generators.write_generators(conanfile, install_folder, output)
             write_toolchain(conanfile, install_folder, output)
         if not isinstance(ref_or_path, ConanFileReference):
             # Write conaninfo

--- a/conans/client/manager.py
+++ b/conans/client/manager.py
@@ -97,7 +97,7 @@ def deps_install(app, ref_or_path, install_folder, graph_info, remotes=None, bui
             tmp = list(conanfile.generators)  # Add the command line specified generators
             tmp.extend([g for g in generators if g not in tmp])
             conanfile.generators = tmp
-            app.generators.write_generators(conanfile, install_folder, output)
+            app.generator_manager.write_generators(conanfile, install_folder, output)
             write_toolchain(conanfile, install_folder, output)
         if not isinstance(ref_or_path, ConanFileReference):
             # Write conaninfo

--- a/conans/test/functional/graph/graph_manager_base.py
+++ b/conans/test/functional/graph/graph_manager_base.py
@@ -7,6 +7,7 @@ from mock import Mock
 
 from conans.client.cache.cache import ClientCache
 from conans.client.cache.remote_registry import Remotes
+from conans.client.generators import GeneratorManager
 from conans.client.graph.build_mode import BuildMode
 from conans.client.graph.graph_binaries import GraphBinariesAnalyzer
 from conans.client.graph.graph_manager import GraphManager
@@ -45,11 +46,12 @@ class GraphManagerTest(unittest.TestCase):
         binaries = GraphBinariesAnalyzer(cache, self.output, self.remote_manager)
         self.manager = GraphManager(self.output, cache, self.remote_manager, self.loader, proxy,
                                     self.resolver, binaries)
+        generators = GeneratorManager()
         hook_manager = Mock()
         app_type = namedtuple("ConanApp", "cache out remote_manager hook_manager graph_manager"
-                              " binaries_analyzer")
+                              " binaries_analyzer generators")
         app = app_type(self.cache, self.output, self.remote_manager, hook_manager, self.manager,
-                       binaries)
+                       binaries, generators)
         return app
 
     def recipe_cache(self, reference, requires=None):

--- a/conans/test/unittests/client/cmd/ast_replacement_scm_test.py
+++ b/conans/test/unittests/client/cmd/ast_replacement_scm_test.py
@@ -58,7 +58,7 @@ class LibConan(ConanFile):
 
         try:
             # Check it is loadable by Conan machinery
-            _, conanfile = parse_conanfile(conanfile, python_requires=self.python_requires)
+            _, conanfile = parse_conanfile(conanfile, python_requires=self.python_requires, None)
         except Exception as e:
             self.fail("Invalid conanfile: {}".format(e))
         else:

--- a/conans/test/unittests/client/cmd/ast_replacement_scm_test.py
+++ b/conans/test/unittests/client/cmd/ast_replacement_scm_test.py
@@ -59,7 +59,7 @@ class LibConan(ConanFile):
         try:
             # Check it is loadable by Conan machinery
             _, conanfile = parse_conanfile(conanfile, python_requires=self.python_requires,
-                                           generators=None)
+                                           generator_manager=None)
         except Exception as e:
             self.fail("Invalid conanfile: {}".format(e))
         else:

--- a/conans/test/unittests/client/cmd/ast_replacement_scm_test.py
+++ b/conans/test/unittests/client/cmd/ast_replacement_scm_test.py
@@ -58,7 +58,8 @@ class LibConan(ConanFile):
 
         try:
             # Check it is loadable by Conan machinery
-            _, conanfile = parse_conanfile(conanfile, python_requires=self.python_requires, None)
+            _, conanfile = parse_conanfile(conanfile, python_requires=self.python_requires,
+                                           generators=None)
         except Exception as e:
             self.fail("Invalid conanfile: {}".format(e))
         else:


### PR DESCRIPTION
Changelog: Omit
Docs: Omit

Get rid of global ``registered_generators`` and make it an object that is instantiated in the ``ConanApp``, as any other functional collaborator.

#tags: slow

