### PR TITLE
Fix double space for link_order_test in MacOs

### DIFF
--- a/conans/test/functional/generators/link_order_test.py
+++ b/conans/test/functional/generators/link_order_test.py
@@ -232,8 +232,9 @@ class LinkOrderTest(unittest.TestCase):
         libs = []
         for it in content.splitlines():
             # This is for Linux and Mac
-            if 'main.cpp.o  -o example' in it:
-                _, links = it.split("main.cpp.o  -o example")
+            line = ' '.join(it.split())
+            if 'main.cpp.o -o example' in line:
+                _, links = line.split("main.cpp.o -o example")
                 for it_lib in links.split():
                     if it_lib.startswith("-l"):
                         libs.append(it_lib[2:])

--- a/conans/test/functional/generators/link_order_test.py
+++ b/conans/test/functional/generators/link_order_test.py
@@ -353,7 +353,7 @@ class LinkOrderTest(unittest.TestCase):
             extra_build = "--config Release" if platform.system() == "Windows" else ""  # Windows VS
             t.run_command("cmake --build . {}".format(extra_build), assert_error=True)
             # Remove double spaces from output that appear in some platforms
-            str_out = line = ' '.join(str(t.out).split())
+            str_out = ' '.join(str(t.out).split())
             # Get the actual link order from the CMake call
             libs = self._get_link_order_from_cmake(str_out)
         return libs

--- a/conans/test/functional/generators/link_order_test.py
+++ b/conans/test/functional/generators/link_order_test.py
@@ -232,8 +232,10 @@ class LinkOrderTest(unittest.TestCase):
         libs = []
         for it in content.splitlines():
             # This is for Linux and Mac
-            if 'main.cpp.o -o example' in it:
-                _, links = it.split("main.cpp.o -o example")
+            # Remove double spaces from output that appear in some platforms
+            line = ' '.join(it.split())
+            if 'main.cpp.o -o example' in line:
+                _, links = line.split("main.cpp.o -o example")
                 for it_lib in links.split():
                     if it_lib.startswith("-l"):
                         libs.append(it_lib[2:])
@@ -352,10 +354,8 @@ class LinkOrderTest(unittest.TestCase):
                           " -DCMAKE_BUILD_TYPE=Release".format(extra_cmake))
             extra_build = "--config Release" if platform.system() == "Windows" else ""  # Windows VS
             t.run_command("cmake --build . {}".format(extra_build), assert_error=True)
-            # Remove double spaces from output that appear in some platforms
-            str_out = ' '.join(str(t.out).split())
             # Get the actual link order from the CMake call
-            libs = self._get_link_order_from_cmake(str_out)
+            libs = self._get_link_order_from_cmake(str(t.out))
         return libs
 
     @parameterized.expand([(None,), ("Xcode",)])

--- a/conans/test/functional/generators/link_order_test.py
+++ b/conans/test/functional/generators/link_order_test.py
@@ -232,9 +232,8 @@ class LinkOrderTest(unittest.TestCase):
         libs = []
         for it in content.splitlines():
             # This is for Linux and Mac
-            line = ' '.join(it.split())
-            if 'main.cpp.o -o example' in line:
-                _, links = line.split("main.cpp.o -o example")
+            if 'main.cpp.o -o example' in it:
+                _, links = it.split("main.cpp.o -o example")
                 for it_lib in links.split():
                     if it_lib.startswith("-l"):
                         libs.append(it_lib[2:])
@@ -353,8 +352,10 @@ class LinkOrderTest(unittest.TestCase):
                           " -DCMAKE_BUILD_TYPE=Release".format(extra_cmake))
             extra_build = "--config Release" if platform.system() == "Windows" else ""  # Windows VS
             t.run_command("cmake --build . {}".format(extra_build), assert_error=True)
+            # Remove double spaces from output that appear in some platforms
+            str_out = line = ' '.join(str(t.out).split())
             # Get the actual link order from the CMake call
-            libs = self._get_link_order_from_cmake(str(t.out))
+            libs = self._get_link_order_from_cmake(str_out)
         return libs
 
     @parameterized.expand([(None,), ("Xcode",)])


### PR DESCRIPTION
Changelog: omit
Docs: omit

Looks like the new MacOs node returns single spaces instead of double spaces in the output and some tests are failing. This removes the double spaces in the output.
