### PR TITLE
[bugfix] multiple remotes with single conan upload

### DIFF
--- a/conans/client/cmd/uploader.py
+++ b/conans/client/cmd/uploader.py
@@ -201,12 +201,11 @@ class CmdUpload(object):
                                            all_packages, query)
 
         if parallel_upload:
-            self._upload_thread_pool = ThreadPool(8)
             self._user_io.disable_input()
-        else:
-            self._upload_thread_pool = ThreadPool(1)
 
         for remote, refs in refs_by_remote.items():
+            self._upload_thread_pool = ThreadPool(8 if parallel_upload else 1)
+
             self._output.info("Uploading to remote '{}':".format(remote.name))
 
             def upload_ref(ref_conanfile_prefs):

--- a/conans/client/cmd/uploader.py
+++ b/conans/client/cmd/uploader.py
@@ -23,6 +23,7 @@ from conans.util.log import logger
 from conans.util.tracer import log_recipe_upload, log_compressed_files, log_package_upload
 from conans.tools import cpu_count
 
+
 UPLOAD_POLICY_FORCE = "force-upload"
 UPLOAD_POLICY_NO_OVERWRITE = "no-overwrite"
 UPLOAD_POLICY_NO_OVERWRITE_RECIPE = "no-overwrite-recipe"

--- a/conans/client/cmd/uploader.py
+++ b/conans/client/cmd/uploader.py
@@ -223,16 +223,17 @@ class CmdUpload(object):
                                          [(ref, conanfile, prefs) for (ref, conanfile, prefs) in
                                           refs])
 
-            if len(self._exceptions_list) > 0:
-                for exc, ref, trace in self._exceptions_list:
-                    t = "recipe" if isinstance(ref, ConanFileReference) else "package"
-                    msg = "%s: Upload %s to '%s' failed: %s\n" % (str(ref), t, remote.name, str(exc))
-                    if get_env("CONAN_VERBOSE_TRACEBACK", False):
-                        msg += trace
-                    self._output.error(msg)
-                raise ConanException("Errors uploading some packages")
         self._upload_thread_pool.close()
         self._upload_thread_pool.join()
+
+        if len(self._exceptions_list) > 0:
+            for exc, ref, trace in self._exceptions_list:
+                t = "recipe" if isinstance(ref, ConanFileReference) else "package"
+                msg = "%s: Upload %s to '%s' failed: %s\n" % (str(ref), t, remote.name, str(exc))
+                if get_env("CONAN_VERBOSE_TRACEBACK", False):
+                    msg += trace
+                self._output.error(msg)
+            raise ConanException("Errors uploading some packages")
 
         logger.debug("UPLOAD: Time manager upload: %f" % (time.time() - t1))
 

--- a/conans/test/functional/remote/multi_remote_checks_test.py
+++ b/conans/test/functional/remote/multi_remote_checks_test.py
@@ -79,6 +79,22 @@ class Pkg(ConanFile):
         client.run("remote list_ref")
         self.assertIn("Pkg/0.1@lasote/testing: server3", client.out)
 
+    def test_multiple_remotes_single_upload(self):
+        servers = OrderedDict([("server1", TestServer()),
+                               ("server2", TestServer())])
+        client = TestClient(servers=servers, users={"server1": [("lasote", "mypass")],
+                                                    "server2": [("lasote", "mypass")]})
+        conanfile = """from conans import ConanFile
+class Pkg(ConanFile):
+    settings = "build_type"
+    """
+        client.save({"conanfile.py": conanfile})
+        client.run("create . Pkg/0.1@lasote/testing -s build_type=Release")
+        client.run("create . Pkg2/0.1@lasote/testing -s build_type=Release")
+        client.run("remote add_ref Pkg/0.1@lasote/testing server1")
+        client.run("remote add_ref Pkg2/0.1@lasote/testing server2")
+        client.run("upload Pkg* --all --confirm")
+
     def test_binary_packages_mixed(self):
         servers = OrderedDict([("server1", TestServer()),
                                ("server2", TestServer()),


### PR DESCRIPTION
Changelog: Bugfix: Fixed bug where uploading to multiple remotes in a single conan upload command would fail.
Docs: omit

Fixes #7780 

This bug was due to closing and reusing a thread pool in a loop. Instead, a separate thread pool will be created at each loop iteration.

- [x] Refer to the issue that supports this Pull Request.
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 

<sup>**Note:** By default this PR will skip the slower tests and will use a limited set of python versions. Check [here](https://github.com/conan-io/conan/blob/develop/.github/PR_INCREASE_TESTING.md) how to increase the testing level by writing some tags in the current PR body text.</sup>
