### PR TITLE
simplify dll_export test

### DIFF
--- a/conans/test/functional/command/export/export_path_test.py
+++ b/conans/test/functional/command/export/export_path_test.py
@@ -32,7 +32,7 @@ class ExportPathTest(unittest.TestCase):
         expected_sums = {'hello.cpp': '4f005274b2fdb25e6113b69774dac184',
                          'main.cpp': '0479f3c223c9a656a718f3148e044124',
                          'CMakeLists.txt': '10d907c160c360b28f6991397a5aa9b4',
-                         'conanfile.py': '355949fbf0b4fc32b8f1c5a338dfe1ae',
+                         'conanfile.py': '1ad1f4b995ae7ffdb00d53ff49e1366f',
                          'executable': '68b329da9893e34099c7d8ad5cb9c940',
                          'helloHello0.h': 'd0a6868b5df17a6ae6e61ebddb0c9eb3'}
         self.assertEqual(expected_sums, manif.file_sums)
@@ -60,7 +60,7 @@ class ExportPathTest(unittest.TestCase):
         expected_sums = {'hello.cpp': '4f005274b2fdb25e6113b69774dac184',
                          'main.cpp': '0479f3c223c9a656a718f3148e044124',
                          'CMakeLists.txt': '10d907c160c360b28f6991397a5aa9b4',
-                         'conanfile.py': '355949fbf0b4fc32b8f1c5a338dfe1ae',
+                         'conanfile.py': '1ad1f4b995ae7ffdb00d53ff49e1366f',
                          'executable': '68b329da9893e34099c7d8ad5cb9c940',
                          'helloHello0.h': 'd0a6868b5df17a6ae6e61ebddb0c9eb3'}
         self.assertEqual(expected_sums, manif.file_sums)
@@ -93,7 +93,7 @@ class ExportPathTest(unittest.TestCase):
         expected_sums = {'source/hello.cpp': '4f005274b2fdb25e6113b69774dac184',
                          'source/main.cpp': '0479f3c223c9a656a718f3148e044124',
                          'source/CMakeLists.txt': '10d907c160c360b28f6991397a5aa9b4',
-                         'conanfile.py': '3ac566eb5b2e4df4417003f0e606e237',
+                         'conanfile.py': '073cdeb3d07fc62180ba510ad7b4794d',
                          'source/executable': '68b329da9893e34099c7d8ad5cb9c940',
                          'source/helloHello0.h': 'd0a6868b5df17a6ae6e61ebddb0c9eb3'}
         self.assertEqual(expected_sums, manif.file_sums)
@@ -129,7 +129,7 @@ class ExportPathTest(unittest.TestCase):
         expected_sums = {'source/hello.cpp': '4f005274b2fdb25e6113b69774dac184',
                          'source/main.cpp': '0479f3c223c9a656a718f3148e044124',
                          'source/CMakeLists.txt': '10d907c160c360b28f6991397a5aa9b4',
-                         'conanfile.py': '3ac566eb5b2e4df4417003f0e606e237',
+                         'conanfile.py': '073cdeb3d07fc62180ba510ad7b4794d',
                          'source/executable': '68b329da9893e34099c7d8ad5cb9c940',
                          'source/helloHello0.h': 'd0a6868b5df17a6ae6e61ebddb0c9eb3'}
         self.assertEqual(expected_sums, manif.file_sums)

--- a/conans/test/functional/command/export/export_path_test.py
+++ b/conans/test/functional/command/export/export_path_test.py
@@ -34,7 +34,7 @@ class ExportPathTest(unittest.TestCase):
                          'CMakeLists.txt': '10d907c160c360b28f6991397a5aa9b4',
                          'conanfile.py': '355949fbf0b4fc32b8f1c5a338dfe1ae',
                          'executable': '68b329da9893e34099c7d8ad5cb9c940',
-                         'helloHello0.h': '9448df034392fc8781a47dd03ae71bdd'}
+                         'helloHello0.h': 'd0a6868b5df17a6ae6e61ebddb0c9eb3'}
         self.assertEqual(expected_sums, manif.file_sums)
 
     def test_rel_path(self):
@@ -62,7 +62,7 @@ class ExportPathTest(unittest.TestCase):
                          'CMakeLists.txt': '10d907c160c360b28f6991397a5aa9b4',
                          'conanfile.py': '355949fbf0b4fc32b8f1c5a338dfe1ae',
                          'executable': '68b329da9893e34099c7d8ad5cb9c940',
-                         'helloHello0.h': '9448df034392fc8781a47dd03ae71bdd'}
+                         'helloHello0.h': 'd0a6868b5df17a6ae6e61ebddb0c9eb3'}
         self.assertEqual(expected_sums, manif.file_sums)
 
     def test_path(self):
@@ -95,7 +95,7 @@ class ExportPathTest(unittest.TestCase):
                          'source/CMakeLists.txt': '10d907c160c360b28f6991397a5aa9b4',
                          'conanfile.py': '3ac566eb5b2e4df4417003f0e606e237',
                          'source/executable': '68b329da9893e34099c7d8ad5cb9c940',
-                         'source/helloHello0.h': '9448df034392fc8781a47dd03ae71bdd'}
+                         'source/helloHello0.h': 'd0a6868b5df17a6ae6e61ebddb0c9eb3'}
         self.assertEqual(expected_sums, manif.file_sums)
 
     def test_combined(self):
@@ -131,5 +131,5 @@ class ExportPathTest(unittest.TestCase):
                          'source/CMakeLists.txt': '10d907c160c360b28f6991397a5aa9b4',
                          'conanfile.py': '3ac566eb5b2e4df4417003f0e606e237',
                          'source/executable': '68b329da9893e34099c7d8ad5cb9c940',
-                         'source/helloHello0.h': '9448df034392fc8781a47dd03ae71bdd'}
+                         'source/helloHello0.h': 'd0a6868b5df17a6ae6e61ebddb0c9eb3'}
         self.assertEqual(expected_sums, manif.file_sums)

--- a/conans/test/functional/command/export/export_test.py
+++ b/conans/test/functional/command/export/export_test.py
@@ -251,7 +251,7 @@ class ExportTest(unittest.TestCase):
                          'CMakeLists.txt': '10d907c160c360b28f6991397a5aa9b4',
                          'conanfile.py': '355949fbf0b4fc32b8f1c5a338dfe1ae',
                          'executable': '68b329da9893e34099c7d8ad5cb9c940',
-                         'helloHello0.h': '9448df034392fc8781a47dd03ae71bdd'}
+                         'helloHello0.h': 'd0a6868b5df17a6ae6e61ebddb0c9eb3'}
         self.assertEqual(expected_sums, manif.file_sums)
 
     def test_case_sensitive(self):
@@ -325,7 +325,7 @@ class OpenSSLConan(ConanFile):
                          'CMakeLists.txt': '10d907c160c360b28f6991397a5aa9b4',
                          'conanfile.py': '355949fbf0b4fc32b8f1c5a338dfe1ae',
                          'executable': '68b329da9893e34099c7d8ad5cb9c940',
-                         'helloHello0.h': '9448df034392fc8781a47dd03ae71bdd'}
+                         'helloHello0.h': 'd0a6868b5df17a6ae6e61ebddb0c9eb3'}
         self.assertEqual(expected_sums, digest2.file_sums)
 
         for f in file_list:
@@ -359,7 +359,7 @@ class OpenSSLConan(ConanFile):
                          'CMakeLists.txt': '10d907c160c360b28f6991397a5aa9b4',
                          'conanfile.py': 'ad17cf00b3142728b03ac37782b9acd9',
                          'executable': '68b329da9893e34099c7d8ad5cb9c940',
-                         'helloHello0.h': '9448df034392fc8781a47dd03ae71bdd'}
+                         'helloHello0.h': 'd0a6868b5df17a6ae6e61ebddb0c9eb3'}
         self.assertEqual(expected_sums, digest3.file_sums)
 
         # for f in file_list:

--- a/conans/test/functional/command/export/export_test.py
+++ b/conans/test/functional/command/export/export_test.py
@@ -249,7 +249,7 @@ class ExportTest(unittest.TestCase):
         expected_sums = {'hello.cpp': '4f005274b2fdb25e6113b69774dac184',
                          'main.cpp': '0479f3c223c9a656a718f3148e044124',
                          'CMakeLists.txt': '10d907c160c360b28f6991397a5aa9b4',
-                         'conanfile.py': '355949fbf0b4fc32b8f1c5a338dfe1ae',
+                         'conanfile.py': '1ad1f4b995ae7ffdb00d53ff49e1366f',
                          'executable': '68b329da9893e34099c7d8ad5cb9c940',
                          'helloHello0.h': 'd0a6868b5df17a6ae6e61ebddb0c9eb3'}
         self.assertEqual(expected_sums, manif.file_sums)
@@ -323,7 +323,7 @@ class OpenSSLConan(ConanFile):
         expected_sums = {'hello.cpp': '4f005274b2fdb25e6113b69774dac184',
                          'main.cpp': '0479f3c223c9a656a718f3148e044124',
                          'CMakeLists.txt': '10d907c160c360b28f6991397a5aa9b4',
-                         'conanfile.py': '355949fbf0b4fc32b8f1c5a338dfe1ae',
+                         'conanfile.py': '1ad1f4b995ae7ffdb00d53ff49e1366f',
                          'executable': '68b329da9893e34099c7d8ad5cb9c940',
                          'helloHello0.h': 'd0a6868b5df17a6ae6e61ebddb0c9eb3'}
         self.assertEqual(expected_sums, digest2.file_sums)
@@ -357,7 +357,7 @@ class OpenSSLConan(ConanFile):
         expected_sums = {'hello.cpp': '4f005274b2fdb25e6113b69774dac184',
                          'main.cpp': '0479f3c223c9a656a718f3148e044124',
                          'CMakeLists.txt': '10d907c160c360b28f6991397a5aa9b4',
-                         'conanfile.py': 'ad17cf00b3142728b03ac37782b9acd9',
+                         'conanfile.py': 'e309305959502e16f8a57439bb6a4107',
                          'executable': '68b329da9893e34099c7d8ad5cb9c940',
                          'helloHello0.h': 'd0a6868b5df17a6ae6e61ebddb0c9eb3'}
         self.assertEqual(expected_sums, digest3.file_sums)

--- a/conans/test/functional/graph/private_deps_test.py
+++ b/conans/test/functional/graph/private_deps_test.py
@@ -207,9 +207,8 @@ class PrivateDepsTest(unittest.TestCase):
 
     def _export_upload(self, name=0, version=None, deps=None, msg=None, static=True, build=True,
                        upload=True):
-        dll_export = self.client.default_compiler_visual_studio and not static
         files = cpp_hello_conan_files(name, version, deps, msg=msg, static=static,
-                                      private_includes=True, dll_export=dll_export, build=build,
+                                      private_includes=True, build=build,
                                       cmake_targets=False)
         ref = ConanFileReference(name, version, "lasote", "stable")
         self.client.save(files, clean_first=True)

--- a/conans/test/functional/remote/rest_api_test.py
+++ b/conans/test/functional/remote/rest_api_test.py
@@ -117,7 +117,7 @@ class RestApiTest(unittest.TestCase):
 
         # Get the conans digest
         digest = self.api.get_recipe_manifest(ref)
-        self.assertEqual(digest.summary_hash, "e925757129f5c49ecb2e8c84ce17e294")
+        self.assertEqual(digest.summary_hash, "0acb2be9768f174f223c81568da74fbe")
         self.assertEqual(digest.time, 123123123)
 
     def get_package_test(self):

--- a/conans/test/integration/basic_build_test.py
+++ b/conans/test/integration/basic_build_test.py
@@ -33,9 +33,7 @@ class BasicBuildTest(unittest.TestCase):
 
 def build(tester, cmd, static, pure_c, use_cmake, lang):
     client = TestClient()
-    dll_export = client.default_compiler_visual_studio and not static
-    files = cpp_hello_conan_files("Hello0", "0.1", dll_export=dll_export,
-                                  pure_c=pure_c, use_cmake=use_cmake)
+    files = cpp_hello_conan_files("Hello0", "0.1", pure_c=pure_c, use_cmake=use_cmake)
 
     client.save(files)
     client.run(cmd)

--- a/conans/test/integration/shared_chain_test.py
+++ b/conans/test/integration/shared_chain_test.py
@@ -17,8 +17,7 @@ class SharedChainTest(unittest.TestCase):
 
     def _export_upload(self, name, version=None, deps=None):
         conan = TestClient(servers=self.servers, users={"default": [("lasote", "mypass")]})
-        dll_export = conan.default_compiler_visual_studio
-        files = cpp_hello_conan_files(name, version, deps, static=False, dll_export=dll_export)
+        files = cpp_hello_conan_files(name, version, deps, static=False)
         conan.save(files)
 
         conan.run("create . lasote/stable")

--- a/conans/test/utils/cpp_test_files.py
+++ b/conans/test/utils/cpp_test_files.py
@@ -145,7 +145,7 @@ class {name}Conan(ConanFile):
 
     def package(self):
         self.copy(pattern="*.h", dst="include", keep_path=False)
-        self.copy(pattern="*.lib", dst="lib", keep_path=False)
+        self.copy(pattern="*.lib", dst="lib", keep_path=False, excludes="*say*")
         self.copy(pattern="*lib*.a", dst="lib", keep_path=False)
         self.copy(pattern="*.dll", dst="bin", keep_path=False)
         self.copy(pattern="*.dylib", dst="lib", keep_path=False)

--- a/conans/test/utils/cpp_test_files.py
+++ b/conans/test/utils/cpp_test_files.py
@@ -238,7 +238,13 @@ void hello{name}(){{
 header = """
 #pragma once
 {includes}
-{export}void hello{name}();
+
+#ifdef _WIN32
+  #define HELLO_EXPORT __declspec(dllexport)
+#else
+  #define HELLO_EXPORT
+#endif
+HELLO_EXPORT void hello{name}();
 """
 
 main = """
@@ -255,7 +261,7 @@ executable = """
 
 
 def cpp_hello_source_files(name="Hello", deps=None, private_includes=False, msg=None,
-                           dll_export=False, need_patch=False, pure_c=False, cmake_targets=False,
+                           need_patch=False, pure_c=False, cmake_targets=False,
                            with_exe=False):
     """
     param number: integer, defining name of the conans Hello0, Hello1, HelloX
@@ -265,8 +271,6 @@ def cpp_hello_source_files(name="Hello", deps=None, private_includes=False, msg=
                             downstream consumers
     param msg: the message to append to Hello/Hola, will be equal the number
                by default
-    param dll_export: Adds __declspec(dllexport) to the .h declaration
-                      (to be exported to lib with a dll)
     param need_patch: It will generated wrong CMakeLists and main.cpp files,
                       so they will need to be fixed/patched in the source() method.
                       Such method just have to replace_in_file in those two files to have a
@@ -285,9 +289,7 @@ def cpp_hello_source_files(name="Hello", deps=None, private_includes=False, msg=
     ext = ".c" if pure_c else ".cpp"
     ret["main%s" % ext] = main.format(name=name)
     includes = "\n".join(['#include "hello%s.h"' % d for d in deps])
-    export = "__declspec(dllexport) " if dll_export else ""
     ret["hello%s.h" % name] = header.format(name=name,
-                                            export=export,
                                             includes=(includes if not private_includes else ""))
 
     other_calls = "\n".join(["hello%s();" % d for d in deps])
@@ -317,7 +319,7 @@ def cpp_hello_source_files(name="Hello", deps=None, private_includes=False, msg=
 
 
 def cpp_hello_conan_files(name="Hello", version="0.1", deps=None, language=0, static=True,
-                          private_includes=False, msg=None, dll_export=False, need_patch=False,
+                          private_includes=False, msg=None, need_patch=False,
                           pure_c=False, config=True, build=True,
                           use_cmake=True, cmake_targets=False, no_copy_source=False,
                           use_additional_infos=0, settings=None, with_exe=True):
@@ -327,8 +329,6 @@ def cpp_hello_conan_files(name="Hello", version="0.1", deps=None, language=0, st
     param version: string with the version of the current conans "0.1" by default
     param deps: [] list of string of the form "0/0.1@user/channel"
     param language: 0 = English, 1 = Spanish
-    param dll_export: Adds __declspec(dllexport) to the .h declaration
-                      (to be exported to lib with a dll)
 
     e.g. (3, [4, 7]) means that a Hello3 conans will be created, with message
          "Hello 3", that depends both in Hello4 and Hello7.
@@ -352,7 +352,7 @@ def cpp_hello_conan_files(name="Hello", version="0.1", deps=None, language=0, st
     requires = ", ".join(requires)
 
     base_files = cpp_hello_source_files(name, code_deps, private_includes, msg=msg,
-                                        dll_export=dll_export, need_patch=need_patch,
+                                        need_patch=need_patch,
                                         pure_c=pure_c, cmake_targets=cmake_targets,
                                         with_exe=with_exe)
     libcxx_remove = "del self.settings.compiler.libcxx" if pure_c else ""

--- a/conans/test/utils/tools.py
+++ b/conans/test/utils/tools.py
@@ -614,11 +614,6 @@ class TestClient(object):
             else:
                 registry.add(name, server)
 
-    @property
-    def default_compiler_visual_studio(self):
-        settings = self.cache.default_profile.settings
-        return settings.get("compiler", None) == "Visual Studio"
-
     @contextmanager
     def chdir(self, newdir):
         old_dir = self.current_folder


### PR DESCRIPTION
Changelog: omit
Docs: omit

Small refactor simplification of tests, using C++ dll_export idiom instead of python custom code.

#tags: slow