### PR TITLE
[fix] Add test with absolute paths to 'txt' generator

### DIFF
--- a/conans/client/generators/text.py
+++ b/conans/client/generators/text.py
@@ -141,10 +141,13 @@ class TXTGenerator(Generator):
                 data[dep][config][field] = lines
 
             # Build the data structures
+            def _relativize_path(p, _rootpath):
+                return p if os.path.isabs(p) else os.path.relpath(p, _rootpath)
+
             def _populate_cpp_info(_cpp_info, _data, _rootpath):
                 for key, value in _data.items():
                     if key.endswith('dirs'):
-                        value = [os.path.relpath(it, _rootpath) for it in value]
+                        value = [_relativize_path(it, _rootpath) for it in value]
                         value = ['' if it == '.' else it for it in value]
                     setattr(_cpp_info, key, value)
 

--- a/conans/test/unittests/client/generators/txt/test_abs_paths.py
+++ b/conans/test/unittests/client/generators/txt/test_abs_paths.py
@@ -1,0 +1,43 @@
+import platform
+import unittest
+
+from conans.client.generators.text import TXTGenerator
+from conans.model.build_info import CppInfo
+from conans.model.conan_file import ConanFile
+from conans.model.env_info import EnvValues
+from conans.model.ref import ConanFileReference
+from conans.model.settings import Settings
+from conans.test.utils.tools import TestBufferConanOutput
+
+
+class AbsPathsTestCase(unittest.TestCase):
+
+    @unittest.skipIf(platform.system() == "Windows", "Uses unix-like paths")
+    def test_abs_path_unix(self):
+        conanfile = ConanFile(TestBufferConanOutput(), None)
+        conanfile.initialize(Settings({}), EnvValues())
+        ref = ConanFileReference.loads("pkg/0.1")
+        cpp_info = CppInfo(ref.name, "/rootdir")
+        cpp_info.includedirs = ["/an/absolute/dir"]
+        cpp_info.filter_empty = False
+        conanfile.deps_cpp_info.add(ref.name, cpp_info)
+
+        master_content = TXTGenerator(conanfile).content
+        after_cpp_info, _, _, _ = TXTGenerator.loads(master_content, filter_empty=False)
+        self.assertListEqual(after_cpp_info[ref.name].includedirs, ["../an/absolute/dir"])
+        self.assertListEqual(after_cpp_info[ref.name].include_paths, ["/rootdir/../an/absolute/dir"])
+
+    @unittest.skipUnless(platform.system() == "Windows", "Uses windows-like paths")
+    def test_absolute_directory(self):
+        conanfile = ConanFile(TestBufferConanOutput(), None)
+        conanfile.initialize(Settings({}), EnvValues())
+        ref = ConanFileReference.loads("pkg/0.1")
+        cpp_info = CppInfo(ref.name, "C:/my/root/path")
+        cpp_info.includedirs = ["D:/my/path/to/something"]
+        cpp_info.filter_empty = False
+        conanfile.deps_cpp_info.add(ref.name, cpp_info)
+
+        master_content = TXTGenerator(conanfile).content
+        after_cpp_info, _, _, _ = TXTGenerator.loads(master_content, filter_empty=False)
+        self.assertListEqual(after_cpp_info[ref.name].includedirs, ["D:/my/path/to/something"])
+        self.assertListEqual(after_cpp_info[ref.name].include_paths, ["D:/my/path/to/something"])

--- a/conans/test/unittests/client/generators/txt/test_abs_paths.py
+++ b/conans/test/unittests/client/generators/txt/test_abs_paths.py
@@ -24,8 +24,8 @@ class AbsPathsTestCase(unittest.TestCase):
 
         master_content = TXTGenerator(conanfile).content
         after_cpp_info, _, _, _ = TXTGenerator.loads(master_content, filter_empty=False)
-        self.assertListEqual(after_cpp_info[ref.name].includedirs, ["../an/absolute/dir"])
-        self.assertListEqual(after_cpp_info[ref.name].include_paths, ["/rootdir/../an/absolute/dir"])
+        self.assertListEqual(after_cpp_info[ref.name].includedirs, ["/an/absolute/dir"])
+        self.assertListEqual(after_cpp_info[ref.name].include_paths, ["/an/absolute/dir"])
 
     @unittest.skipUnless(platform.system() == "Windows", "Uses windows-like paths")
     def test_absolute_directory(self):


### PR DESCRIPTION
Changelog: (Feature | Fix | Bugfix): Describe here your pull request
Docs: https://github.com/conan-io/docs/pull/XXXX

- [ ] Refer to the issue that supports this Pull Request.
- [ ] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [ ] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [ ] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 

<sup>**Note:** By default this PR will skip the slower tests and will use a limited set of python versions. Check [here](https://github.com/conan-io/conan/blob/develop/.github/PR_INCREASE_TESTING.md) how to increase the testing level by writing some tags in the current PR body text.</sup>
