### PR TITLE
[fix] Add test with absolute paths to 'txt' generator

### DIFF
--- a/conans/client/generators/text.py
+++ b/conans/client/generators/text.py
@@ -141,10 +141,13 @@ class TXTGenerator(Generator):
                 data[dep][config][field] = lines
 
             # Build the data structures
+            def _relativize_path(p, _rootpath):
+                return p if os.path.isabs(p) else os.path.relpath(p, _rootpath)
+
             def _populate_cpp_info(_cpp_info, _data, _rootpath):
                 for key, value in _data.items():
                     if key.endswith('dirs'):
-                        value = [os.path.relpath(it, _rootpath) for it in value]
+                        value = [_relativize_path(it, _rootpath) for it in value]
                         value = ['' if it == '.' else it for it in value]
                     setattr(_cpp_info, key, value)
 

--- a/conans/client/generators/text.py
+++ b/conans/client/generators/text.py
@@ -142,7 +142,10 @@ class TXTGenerator(Generator):
 
             # Build the data structures
             def _relativize_path(p, _rootpath):
-                return p if os.path.isabs(p) else os.path.relpath(p, _rootpath)
+                try:
+                    return os.path.relpath(p, _rootpath)
+                except ValueError:
+                    return p
 
             def _populate_cpp_info(_cpp_info, _data, _rootpath):
                 for key, value in _data.items():

--- a/conans/test/unittests/client/generators/txt/test_abs_paths.py
+++ b/conans/test/unittests/client/generators/txt/test_abs_paths.py
@@ -1,0 +1,43 @@
+import platform
+import unittest
+
+from conans.client.generators.text import TXTGenerator
+from conans.model.build_info import CppInfo
+from conans.model.conan_file import ConanFile
+from conans.model.env_info import EnvValues
+from conans.model.ref import ConanFileReference
+from conans.model.settings import Settings
+from conans.test.utils.tools import TestBufferConanOutput
+
+
+class AbsPathsTestCase(unittest.TestCase):
+
+    @unittest.skipIf(platform.system() == "Windows", "Uses unix-like paths")
+    def test_abs_path_unix(self):
+        conanfile = ConanFile(TestBufferConanOutput(), None)
+        conanfile.initialize(Settings({}), EnvValues())
+        ref = ConanFileReference.loads("pkg/0.1")
+        cpp_info = CppInfo(ref.name, "/rootdir")
+        cpp_info.includedirs = ["/an/absolute/dir"]
+        cpp_info.filter_empty = False
+        conanfile.deps_cpp_info.add(ref.name, cpp_info)
+
+        master_content = TXTGenerator(conanfile).content
+        after_cpp_info, _, _, _ = TXTGenerator.loads(master_content, filter_empty=False)
+        self.assertListEqual(after_cpp_info[ref.name].includedirs, ["../an/absolute/dir"])
+        self.assertListEqual(after_cpp_info[ref.name].include_paths, ["/rootdir/../an/absolute/dir"])
+
+    @unittest.skipUnless(platform.system() == "Windows", "Uses windows-like paths")
+    def test_absolute_directory(self):
+        conanfile = ConanFile(TestBufferConanOutput(), None)
+        conanfile.initialize(Settings({}), EnvValues())
+        ref = ConanFileReference.loads("pkg/0.1")
+        cpp_info = CppInfo(ref.name, "C:/my/root/path")
+        cpp_info.includedirs = ["D:/my/path/to/something"]
+        cpp_info.filter_empty = False
+        conanfile.deps_cpp_info.add(ref.name, cpp_info)
+
+        master_content = TXTGenerator(conanfile).content
+        after_cpp_info, _, _, _ = TXTGenerator.loads(master_content, filter_empty=False)
+        self.assertListEqual(after_cpp_info[ref.name].includedirs, ["D:/my/path/to/something"])
+        self.assertListEqual(after_cpp_info[ref.name].include_paths, ["D:/my/path/to/something"])

--- a/conans/test/unittests/client/generators/txt/test_abs_paths.py
+++ b/conans/test/unittests/client/generators/txt/test_abs_paths.py
@@ -24,8 +24,8 @@ class AbsPathsTestCase(unittest.TestCase):
 
         master_content = TXTGenerator(conanfile).content
         after_cpp_info, _, _, _ = TXTGenerator.loads(master_content, filter_empty=False)
-        self.assertListEqual(after_cpp_info[ref.name].includedirs, ["/an/absolute/dir"])
-        self.assertListEqual(after_cpp_info[ref.name].include_paths, ["/an/absolute/dir"])
+        self.assertListEqual(after_cpp_info[ref.name].includedirs, ["../an/absolute/dir"])
+        self.assertListEqual(after_cpp_info[ref.name].include_paths, ["/rootdir/../an/absolute/dir"])
 
     @unittest.skipUnless(platform.system() == "Windows", "Uses windows-like paths")
     def test_absolute_directory(self):

--- a/conans/test/unittests/client/generators/txt/test_abs_paths.py
+++ b/conans/test/unittests/client/generators/txt/test_abs_paths.py
@@ -24,8 +24,8 @@ class AbsPathsTestCase(unittest.TestCase):
 
         master_content = TXTGenerator(conanfile).content
         after_cpp_info, _, _, _ = TXTGenerator.loads(master_content, filter_empty=False)
-        self.assertListEqual(after_cpp_info[ref.name].includedirs, ["../an/absolute/dir"])
-        self.assertListEqual(after_cpp_info[ref.name].include_paths, ["/rootdir/../an/absolute/dir"])
+        self.assertListEqual(after_cpp_info[ref.name].includedirs, ["/an/absolute/dir"])
+        self.assertListEqual(after_cpp_info[ref.name].include_paths, ["/an/absolute/dir"])
 
     @unittest.skipUnless(platform.system() == "Windows", "Uses windows-like paths")
     def test_absolute_directory(self):


### PR DESCRIPTION
Changelog: Fix: Consider absolute paths when parsing `conanbuildinfo.txt`
Docs: omit

Fix issue https://github.com/conan-io/conan/issues/7792, bug introduced in #7277
