### PR TITLE
Fix capture output when running tests that call the ConanRunner in the conanfile

### DIFF
--- a/conans/client/runner.py
+++ b/conans/client/runner.py
@@ -14,7 +14,7 @@ from conans.util.runners import pyinstaller_bundle_env_cleaned
 
 class _UnbufferedWrite(object):
     def __init__(self, stream):
-        self._stream = stream._stream
+        self._stream = stream._stream if hasattr(stream, "_stream") else stream
 
     def write(self, *args, **kwargs):
         self._stream.write(*args, **kwargs)

--- a/conans/client/runner.py
+++ b/conans/client/runner.py
@@ -14,7 +14,7 @@ from conans.util.runners import pyinstaller_bundle_env_cleaned
 
 class _UnbufferedWrite(object):
     def __init__(self, stream):
-        self._stream = stream
+        self._stream = stream._stream
 
     def write(self, *args, **kwargs):
         self._stream.write(*args, **kwargs)
@@ -43,7 +43,7 @@ class ConanRunner(object):
                   "use six.StringIO() instead ***")
 
         stream_output = output if output and hasattr(output, "write") else self._output or sys.stdout
-        if hasattr(output, "flush"):
+        if hasattr(stream_output, "flush"):
             # We do not want output from different streams to get mixed (sys.stdout, os.system)
             stream_output = _UnbufferedWrite(stream_output)
 

--- a/conans/test/functional/conanfile/runner_test.py
+++ b/conans/test/functional/conanfile/runner_test.py
@@ -1,4 +1,5 @@
 import os
+import textwrap
 import unittest
 
 import six
@@ -180,3 +181,15 @@ class ConanFileToolsTest(ConanFile):
         client.run("build .", assert_error=True)
         self.assertIn("Error while executing 'mkdir test_folder'", client.out)
         self.assertFalse(os.path.exists(test_folder))
+
+    def runner_capture_output_test(self):
+        conanfile = textwrap.dedent("""
+            from conans import ConanFile
+            class Pkg(ConanFile):
+                def source(self):
+                    self.run("echo 'hello Conan!'")
+        """)
+        client = TestClient()
+        client.save({"conanfile.py": conanfile})
+        client.run("source .")
+        self.assertIn("hello Conan!", client.out)


### PR DESCRIPTION
Changelog: Fix: Fix capture output when running tests that call the ConanRunner in the conanfile.
Docs: omit

When the ConanRunner was called inside the conanfile the output was not correctly captured depending the case, making imposible to make tests that check the self.run method output. This was because _UnbufferedWrite was encapsulating the ConanOutput and checking if the output had to be captured was returning the wrong results: https://github.com/conan-io/conan/blob/558a2ce6af4731ee5d1a3f791c5a672e83ec1282/conans/client/runner.py#L79-L85 (because the stream_output._stream was not an instance of six.StringIO but of TestBufferConanOutput or ConanOutput)