### PR TITLE
prefix intel functions with intel_ because they are now exposed via tools

### DIFF
--- a/conans/client/build/cmake.py
+++ b/conans/client/build/cmake.py
@@ -258,8 +258,8 @@ class CMakeBuildHelper(object):
         elif is_intel:
             if self.generator in ["Ninja", "NMake Makefiles", "NMake Makefiles JOM",
                                   "Unix Makefiles"]:
-                compilervars_dict = tools.compilervars_dict(self._conanfile, force=True)
-                context = _environment_add(compilervars_dict, post=self._append_vcvars)
+                intel_compilervars_dict = tools.intel_compilervars_dict(self._conanfile, force=True)
+                context = _environment_add(intel_compilervars_dict, post=self._append_vcvars)
         with context:
             self._conanfile.run(command)
 

--- a/conans/client/build/msbuild.py
+++ b/conans/client/build/msbuild.py
@@ -6,7 +6,7 @@ from conans.client import tools
 from conans.client.build.visual_environment import (VisualStudioBuildEnvironment,
                                                     vs_build_type_flags, vs_std_cpp)
 from conans.client.tools.env import environment_append, no_op
-from conans.client.tools.intel import compilervars
+from conans.client.tools.intel import intel_compilervars
 from conans.client.tools.oss import cpu_count
 from conans.client.tools.win import vcvars_command
 from conans.errors import ConanException
@@ -99,7 +99,7 @@ class MSBuild(object):
             context = no_op()
             if self._conanfile.settings.get_safe("compiler") == "Intel" and \
                 self._conanfile.settings.get_safe("compiler.base") == "Visual Studio":
-                context = compilervars(self._conanfile.settings, arch)
+                context = intel_compilervars(self._conanfile.settings, arch)
             with context:
                 return self._conanfile.run(command)
 

--- a/conans/client/tools/intel.py
+++ b/conans/client/tools/intel.py
@@ -57,7 +57,7 @@ def intel_installation_path(version, arch):
     return installation_path
 
 
-def compilervars_command(conanfile, arch=None, compiler_version=None, force=False):
+def intel_compilervars_command(conanfile, arch=None, compiler_version=None, force=False):
     """
     https://software.intel.com/en-us/intel-system-studio-cplusplus-compiler-user-and-reference-guide-using-compilervars-file
     :return:
@@ -103,13 +103,13 @@ def compilervars_command(conanfile, arch=None, compiler_version=None, force=Fals
     return command
 
 
-def compilervars_dict(conanfile, arch=None, compiler_version=None, force=False, only_diff=True):
-    cmd = compilervars_command(conanfile, arch, compiler_version, force)
+def intel_compilervars_dict(conanfile, arch=None, compiler_version=None, force=False, only_diff=True):
+    cmd = intel_compilervars_command(conanfile, arch, compiler_version, force)
     return env_diff(cmd, only_diff)
 
 
 @contextmanager
-def compilervars(*args, **kwargs):
-    new_env = compilervars_dict(*args, **kwargs)
+def intel_compilervars(*args, **kwargs):
+    new_env = intel_compilervars_dict(*args, **kwargs)
     with environment_append(new_env):
         yield

--- a/conans/test/unittests/client/build/cmake_test.py
+++ b/conans/test/unittests/client/build/cmake_test.py
@@ -1408,7 +1408,7 @@ build_type: [ Release]
                            ('NMake Makefiles JOM',),
                            ('Unix Makefiles',),
                            ])
-    def test_compilervars_applied(self, generator):
+    def test_intel_compilervars_applied(self, generator):
         conanfile = ConanFileMock()
         settings = Settings.loads(get_default_settings_yml())
         settings.os = "Windows"
@@ -1419,17 +1419,17 @@ build_type: [ Release]
 
         cmake = CMake(conanfile, generator=generator)
 
-        with mock.patch("conans.client.tools.compilervars_dict") as cvars_mock:
+        with mock.patch("conans.client.tools.intel_compilervars_dict") as cvars_mock:
             cvars_mock.__enter__ = mock.MagicMock(return_value=(mock.MagicMock(), None))
             cvars_mock.__exit__ = mock.MagicMock(return_value=None)
             cmake.configure()
-            self.assertTrue(cvars_mock.called, "compilervars weren't called")
+            self.assertTrue(cvars_mock.called, "intel_compilervars weren't called")
 
-        with mock.patch("conans.client.tools.compilervars_dict") as cvars_mock:
+        with mock.patch("conans.client.tools.intel_compilervars_dict") as cvars_mock:
             cvars_mock.__enter__ = mock.MagicMock(return_value=(mock.MagicMock(), None))
             cvars_mock.__exit__ = mock.MagicMock(return_value=None)
             cmake.build()
-            self.assertTrue(cvars_mock.called, "compilervars weren't called")
+            self.assertTrue(cvars_mock.called, "intel_compilervars weren't called")
 
     def test_cmake_program(self):
         conanfile = ConanFileMock()

--- a/conans/test/unittests/client/tools/intel/compilervars_test.py
+++ b/conans/test/unittests/client/tools/intel/compilervars_test.py
@@ -5,7 +5,7 @@ import unittest
 from conans import Settings
 from conans.client.conf import get_default_settings_yml
 from conans.client.tools.env import environment_append
-from conans.client.tools.intel import compilervars_command
+from conans.client.tools.intel import intel_compilervars_command
 from conans.errors import ConanException
 from conans.test.utils.mocks import MockConanfile
 
@@ -14,14 +14,14 @@ class CompilerVarsTest(unittest.TestCase):
     def test_already_set(self):
         with environment_append({"PSTLROOT": "1"}):
             settings = Settings.loads(get_default_settings_yml())
-            cvars = compilervars_command(MockConanfile(settings))
-            self.assertEqual("echo Conan:compilervars already set", cvars)
+            cvars = intel_compilervars_command(MockConanfile(settings))
+            self.assertEqual("echo Conan:intel_compilervars already set", cvars)
 
     def test_bas_os(self):
         settings = Settings.loads(get_default_settings_yml())
         settings.os = "SunOS"
         with self.assertRaises(ConanException):
-            compilervars_command(MockConanfile(settings))
+            intel_compilervars_command(MockConanfile(settings))
 
     def test_win(self):
         install_dir = "C:\\Intel"
@@ -34,23 +34,23 @@ class CompilerVarsTest(unittest.TestCase):
             settings.compiler.base = "Visual Studio"
             settings.arch = "ppc32"
             with self.assertRaises(ConanException):
-                compilervars_command(MockConanfile(settings))
+                intel_compilervars_command(MockConanfile(settings))
 
             path = os.path.join(install_dir, "bin", "compilervars.bat")
 
             settings.arch = "x86"
-            cvars = compilervars_command(MockConanfile(settings))
+            cvars = intel_compilervars_command(MockConanfile(settings))
             expected = '"%s" -arch ia32' % path
             self.assertEqual(expected, cvars)
 
             settings.compiler.base.version = "16"
-            cvars = compilervars_command(MockConanfile(settings))
+            cvars = intel_compilervars_command(MockConanfile(settings))
             expected = '"%s" -arch ia32 vs2019' % path
             self.assertEqual(expected, cvars)
 
             settings.arch = "x86_64"
             expected = '"%s" -arch intel64 vs2019' % path
-            cvars = compilervars_command(MockConanfile(settings))
+            cvars = intel_compilervars_command(MockConanfile(settings))
             self.assertEqual(expected, cvars)
 
 
@@ -65,12 +65,12 @@ class CompilerVarsTest(unittest.TestCase):
             settings.compiler.base = "gcc"
             settings.arch = "ppc32"
             with self.assertRaises(ConanException):
-                compilervars_command(MockConanfile(settings))
+                intel_compilervars_command(MockConanfile(settings))
 
             path = os.path.join(install_dir, "bin", "compilervars.sh")
 
             settings.arch = "x86"
-            cvars = compilervars_command(MockConanfile(settings))
+            cvars = intel_compilervars_command(MockConanfile(settings))
             expected = 'COMPILERVARS_PLATFORM=linux COMPILERVARS_ARCHITECTURE=ia32 . ' \
                        '"%s" -arch ia32 -platform linux' % path
             self.assertEqual(expected, cvars)
@@ -78,7 +78,7 @@ class CompilerVarsTest(unittest.TestCase):
             settings.arch = "x86_64"
             expected = 'COMPILERVARS_PLATFORM=linux COMPILERVARS_ARCHITECTURE=intel64 . ' \
                        '"%s" -arch intel64 -platform linux' % path
-            cvars = compilervars_command(MockConanfile(settings))
+            cvars = intel_compilervars_command(MockConanfile(settings))
             self.assertEqual(expected, cvars)
 
     def test_mac(self):
@@ -92,12 +92,12 @@ class CompilerVarsTest(unittest.TestCase):
             settings.compiler.base = "apple-clang"
             settings.arch = "ppc32"
             with self.assertRaises(ConanException):
-                compilervars_command(MockConanfile(settings))
+                intel_compilervars_command(MockConanfile(settings))
 
             path = os.path.join(install_dir, "bin", "compilervars.sh")
 
             settings.arch = "x86"
-            cvars = compilervars_command(MockConanfile(settings))
+            cvars = intel_compilervars_command(MockConanfile(settings))
             expected = 'COMPILERVARS_PLATFORM=mac COMPILERVARS_ARCHITECTURE=ia32 . ' \
                        '"%s" -arch ia32 -platform mac' % path
             self.assertEqual(expected, cvars)
@@ -105,5 +105,5 @@ class CompilerVarsTest(unittest.TestCase):
             settings.arch = "x86_64"
             expected = 'COMPILERVARS_PLATFORM=mac COMPILERVARS_ARCHITECTURE=intel64 . ' \
                        '"%s" -arch intel64 -platform mac' % path
-            cvars = compilervars_command(MockConanfile(settings))
+            cvars = intel_compilervars_command(MockConanfile(settings))
             self.assertEqual(expected, cvars)


### PR DESCRIPTION
Changelog: Fix: prefix intel functions with intel_ because they are now exposed via tools. Fixes https://github.com/conan-io/conan/issues/7820.
Docs: https://github.com/conan-io/docs/pull/1875

- [x] Refer to the issue that supports this Pull Request.
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [x] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 

<sup>**Note:** By default this PR will skip the slower tests and will use a limited set of python versions. Check [here](https://github.com/conan-io/conan/blob/develop/.github/PR_INCREASE_TESTING.md) how to increase the testing level by writing some tags in the current PR body text.</sup>
