### PR TITLE
Fix Jinja2 minimum version required. 

### DIFF
--- a/conans/requirements.txt
+++ b/conans/requirements.txt
@@ -12,7 +12,7 @@ future>=0.16.0, <0.19.0
 pygments>=2.0, <3.0
 deprecation>=2.0, <2.1
 tqdm>=4.28.1, <5
-Jinja2>=2.3, <3
+Jinja2>=2.9, <3
 python-dateutil>=2.7.0, <3
 idna==2.6 ; sys_platform == "darwin" # Solving conflict, somehow is installing 2.7 when requests require 2.6
 cryptography>=1.3.4, <2.4.0 ; sys_platform == "darwin"


### PR DESCRIPTION
Changelog: Omit
Docs: Omit

Fixes #7822 by setting the minimum Jinja2 version to 2.9

PR #6832 added the use of select_autoescape which was introduced in Jinja2 v2.9

- [x] Refer to the issue that supports this Pull Request.
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 