### PR TITLE
removing toolset from msbuild generator and toolchain

### DIFF
--- a/conans/client/generators/msbuild.py
+++ b/conans/client/generators/msbuild.py
@@ -2,7 +2,7 @@ import os
 import textwrap
 from xml.dom import minidom
 
-from conans.client.tools import msvs_toolset, VALID_LIB_EXTENSIONS
+from conans.client.tools import VALID_LIB_EXTENSIONS
 from conans.errors import ConanException
 from conans.model import Generator
 from conans.util.files import load
@@ -71,13 +71,10 @@ class MSBuildGenerator(Generator):
 
     @ staticmethod
     def _name_condition(settings):
-        toolset = msvs_toolset(settings)
-
         props = [("Configuration", settings.build_type),
                  # FIXME: This probably requires mapping ARM architectures
                  ("Platform", {'x86': 'Win32',
-                               'x86_64': 'x64'}.get(settings.get_safe("arch"))),
-                 ("PlatformToolset", toolset)]
+                               'x86_64': 'x64'}.get(settings.get_safe("arch")))]
 
         name = "".join("_%s" % v for _, v in props if v is not None)
         condition = " And ".join("'$(%s)' == '%s'" % (k, v) for k, v in props if v is not None)
@@ -123,9 +120,9 @@ class MSBuildGenerator(Generator):
 
     def _pkg_config_props(self, name, cpp_info):
         # returns a .props file with the variables definition for one package for one configuration
-        def has_valid_ext(lib):
-            ext = os.path.splitext(lib)[1]
-            return ext in VALID_LIB_EXTENSIONS
+        def add_valid_ext(libname):
+            ext = os.path.splitext(libname)[1]
+            return '%s;' % libname if ext in VALID_LIB_EXTENSIONS else '%s.lib;' % libname
 
         fields = {
             'name': name,
@@ -133,10 +130,8 @@ class MSBuildGenerator(Generator):
             'res_dirs': "".join("%s;" % p for p in cpp_info.res_paths),
             'include_dirs': "".join("%s;" % p for p in cpp_info.include_paths),
             'lib_dirs': "".join("%s;" % p for p in cpp_info.lib_paths),
-            'libs': "".join(['%s.lib;' % lib if not has_valid_ext(lib)
-                             else '%s;' % lib for lib in cpp_info.libs]),
-            'system_libs': "".join(['%s.lib;' % sys_dep if not has_valid_ext(sys_dep)
-                                    else '%s;' % sys_dep for sys_dep in cpp_info.system_libs]),
+            'libs': "".join([add_valid_ext(lib) for lib in cpp_info.libs]),
+            'system_libs': "".join([add_valid_ext(sys_dep) for sys_dep in cpp_info.system_libs]),
             'definitions': "".join("%s;" % d for d in cpp_info.defines),
             'compiler_flags': " ".join(cpp_info.cxxflags + cpp_info.cflags),
             'linker_flags': " ".join(cpp_info.sharedlinkflags),

--- a/conans/client/toolchain/msbuild.py
+++ b/conans/client/toolchain/msbuild.py
@@ -2,7 +2,6 @@ import os
 import textwrap
 from xml.dom import minidom
 
-from conans.client.tools import msvs_toolset
 from conans.errors import ConanException
 from conans.util.files import save, load
 
@@ -15,13 +14,10 @@ class MSBuildToolchain(object):
 
     @ staticmethod
     def _name_condition(settings):
-        toolset = msvs_toolset(settings)
-
         props = [("Configuration", settings.build_type),
                  # FIXME: This probably requires mapping ARM architectures
                  ("Platform", {'x86': 'Win32',
-                               'x86_64': 'x64'}.get(settings.get_safe("arch"))),
-                 ("PlatformToolset", toolset)]
+                               'x86_64': 'x64'}.get(settings.get_safe("arch")))]
 
         name = "".join("_%s" % v for _, v in props if v is not None)
         condition = " And ".join("'$(%s)' == '%s'" % (k, v) for k, v in props if v is not None)

--- a/conans/test/functional/generators/msbuild_test.py
+++ b/conans/test/functional/generators/msbuild_test.py
@@ -111,29 +111,28 @@ myproject_vcxproj = r"""<?xml version="1.0" encoding="utf-8"?>
   </ImportGroup>
   <ImportGroup Label="Shared">
   </ImportGroup>
+  <ImportGroup Label="PropertySheets">
+    <Import Project="..\conan_Hello3.props" />
+  </ImportGroup>
   <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props"
     Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')"
     Label="LocalAppDataPlatform" />
-    <Import Project="..\conan_Hello3.props" />
   </ImportGroup>
   <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props"
     Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')"
     Label="LocalAppDataPlatform" />
-    <Import Project="..\conan_Hello3.props" />
   </ImportGroup>
   <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props"
     Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')"
     Label="LocalAppDataPlatform" />
-    <Import Project="..\conan_Hello3.props" />
   </ImportGroup>
   <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props"
     Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')"
     Label="LocalAppDataPlatform" />
-    <Import Project="..\conan_Hello3.props" />
   </ImportGroup>
   <PropertyGroup Label="UserMacros" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
@@ -291,29 +290,28 @@ myapp_vcxproj = r"""<?xml version="1.0" encoding="utf-8"?>
   </ImportGroup>
   <ImportGroup Label="Shared">
   </ImportGroup>
+  <ImportGroup Label="PropertySheets">
+    <Import Project="..\conan_Hello1.props" />
+  </ImportGroup>
   <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props"
     Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')"
     Label="LocalAppDataPlatform" />
-    <Import Project="..\conan_Hello1.props" />
   </ImportGroup>
   <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props"
     Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')"
     Label="LocalAppDataPlatform" />
-    <Import Project="..\conan_Hello1.props" />
   </ImportGroup>
   <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props"
     Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')"
     Label="LocalAppDataPlatform" />
-    <Import Project="..\conan_Hello1.props" />
   </ImportGroup>
   <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props"
     Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')"
     Label="LocalAppDataPlatform" />
-    <Import Project="..\conan_Hello1.props" />
   </ImportGroup>
   <PropertyGroup Label="UserMacros" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">

--- a/conans/test/functional/toolchain/test_msbuild.py
+++ b/conans/test/functional/toolchain/test_msbuild.py
@@ -23,14 +23,6 @@ Global
         Release|x86 = Release|x86
     EndGlobalSection
     GlobalSection(ProjectConfigurationPlatforms) = postSolution
-        {6F392A05-B151-490C-9505-B2A49720C4D9}.Debug|x64.ActiveCfg = Debug|x64
-        {6F392A05-B151-490C-9505-B2A49720C4D9}.Debug|x64.Build.0 = Debug|x64
-        {6F392A05-B151-490C-9505-B2A49720C4D9}.Debug|x86.ActiveCfg = Debug|Win32
-        {6F392A05-B151-490C-9505-B2A49720C4D9}.Debug|x86.Build.0 = Debug|Win32
-        {6F392A05-B151-490C-9505-B2A49720C4D9}.Release|x64.ActiveCfg = Release|x64
-        {6F392A05-B151-490C-9505-B2A49720C4D9}.Release|x64.Build.0 = Release|x64
-        {6F392A05-B151-490C-9505-B2A49720C4D9}.Release|x86.ActiveCfg = Release|Win32
-        {6F392A05-B151-490C-9505-B2A49720C4D9}.Release|x86.Build.0 = Release|Win32
         {B58316C0-C78A-4E9B-AE8F-5D6368CE3840}.Debug|x64.ActiveCfg = Debug|x64
         {B58316C0-C78A-4E9B-AE8F-5D6368CE3840}.Debug|x64.Build.0 = Debug|x64
         {B58316C0-C78A-4E9B-AE8F-5D6368CE3840}.Debug|x86.ActiveCfg = Debug|Win32
@@ -325,7 +317,7 @@ class WinTest(unittest.TestCase):
         # Run the configure corresponding to this test case
         client.run("install . %s -if=conan" % (settings, ))
         self.assertIn("conanfile.py: MSBuildToolchain created "
-                      "conan_toolchain_release_win32_v141.props", client.out)
+                      "conan_toolchain_release_win32.props", client.out)
         vs_path = vs_installation_path("15")
         vcvars_path = os.path.join(vs_path, "VC/Auxiliary/Build/vcvarsall.bat")
 
@@ -369,11 +361,12 @@ class WinTest(unittest.TestCase):
 
         # Run the configure corresponding to this test case
         client.run("install . %s -if=conan" % (settings, ))
-        self.assertIn("conanfile.py: MSBuildToolchain created conan_toolchain_debug_x64_v140.props",
+        self.assertIn("conanfile.py: MSBuildToolchain created conan_toolchain_debug_x64.props",
                       client.out)
         vs_path = vs_installation_path("15")
         vcvars_path = os.path.join(vs_path, "VC/Auxiliary/Build/vcvarsall.bat")
 
+        # FIXME: This is cheating, pass the toolset on the command line, nothing that devs would do
         cmd = ('set "VSCMD_START_DIR=%%CD%%" && '
                '"%s" x64 && '
                'msbuild "MyProject.sln" /p:Configuration=Debug /p:PlatformToolset="v140"'


### PR DESCRIPTION
Changelog: Fix: Remove toolset variability from the ``msbuild`` generator and ``MSBuildToolchain``.
Docs: Omit


From: https://github.com/conan-io/conan/issues/7824
