### PR TITLE
cross build arch check in cmake build helper

### DIFF
--- a/conans/client/build/cmake_flags.py
+++ b/conans/client/build/cmake_flags.py
@@ -182,7 +182,7 @@ class CMakeDefinitionsBuilder(object):
         env_sn = {"False": False, "True": True, "": None}.get(env_sn, env_sn)
         cmake_system_name = env_sn or self._forced_cmake_system_name
 
-        os_build, _, _, _ = get_cross_building_settings(self._conanfile)
+        os_build, arch_build, _, _ = get_cross_building_settings(self._conanfile)
         compiler = self._ss("compiler")
         libcxx = self._ss("compiler.libcxx")
 
@@ -203,7 +203,7 @@ class CMakeDefinitionsBuilder(object):
             definitions["CMAKE_SYSTEM_NAME"] = cmake_system_name
         else:  # detect if we are cross building and the system name and version
             if cross_building(self._conanfile):  # We are cross building
-                if os_ != os_build:
+                if os_ != os_build and arch != arch_build:
                     if os_:  # the_os is the host (regular setting)
                         definitions["CMAKE_SYSTEM_NAME"] = {"Macos": "Darwin",
                                                             "iOS": "Darwin",

--- a/conans/client/build/cmake_flags.py
+++ b/conans/client/build/cmake_flags.py
@@ -182,7 +182,7 @@ class CMakeDefinitionsBuilder(object):
         env_sn = {"False": False, "True": True, "": None}.get(env_sn, env_sn)
         cmake_system_name = env_sn or self._forced_cmake_system_name
 
-        os_build, arch_build, _, _ = get_cross_building_settings(self._conanfile)
+        os_build, _, _, _ = get_cross_building_settings(self._conanfile)
         compiler = self._ss("compiler")
         libcxx = self._ss("compiler.libcxx")
 
@@ -203,15 +203,14 @@ class CMakeDefinitionsBuilder(object):
             definitions["CMAKE_SYSTEM_NAME"] = cmake_system_name
         else:  # detect if we are cross building and the system name and version
             if cross_building(self._conanfile):  # We are cross building
-                if os_ != os_build and arch != arch_build:
-                    if os_:  # the_os is the host (regular setting)
-                        definitions["CMAKE_SYSTEM_NAME"] = {"Macos": "Darwin",
-                                                            "iOS": "Darwin",
-                                                            "tvOS": "Darwin",
-                                                            "watchOS": "Darwin",
-                                                            "Neutrino": "QNX"}.get(os_, os_)
-                    else:
-                        definitions["CMAKE_SYSTEM_NAME"] = "Generic"
+                if os_ and os_ != os_build:
+                    definitions["CMAKE_SYSTEM_NAME"] = {"Macos": "Darwin",
+                                                        "iOS": "Darwin",
+                                                        "tvOS": "Darwin",
+                                                        "watchOS": "Darwin",
+                                                        "Neutrino": "QNX"}.get(os_, os_)
+                else:
+                    definitions["CMAKE_SYSTEM_NAME"] = "Generic"
         if os_ver:
             definitions["CMAKE_SYSTEM_VERSION"] = os_ver
             if is_apple_os(os_):

--- a/conans/client/build/cmake_flags.py
+++ b/conans/client/build/cmake_flags.py
@@ -202,7 +202,8 @@ class CMakeDefinitionsBuilder(object):
         if cmake_system_name is not True:  # String not empty
             definitions["CMAKE_SYSTEM_NAME"] = cmake_system_name
         else:  # detect if we are cross building and the system name and version
-            if cross_building(self._conanfile):  # We are cross building
+            skip_x64_x86 = os_ in ['Windows', 'Linux']
+            if cross_building(self._conanfile, skip_x64_x86=skip_x64_x86):  # We are cross building
                 cmake_system_name_map = {"Macos": "Darwin",
                                          "iOS": "Darwin",
                                          "tvOS": "Darwin",
@@ -210,8 +211,7 @@ class CMakeDefinitionsBuilder(object):
                                          "Neutrino": "QNX",
                                          "": "Generic",
                                          None: "Generic"}
-                if os_ != os_build or os_ != "Windows":
-                    definitions["CMAKE_SYSTEM_NAME"] = cmake_system_name_map.get(os_, os_)
+                definitions["CMAKE_SYSTEM_NAME"] = cmake_system_name_map.get(os_, os_)
 
         if os_ver:
             definitions["CMAKE_SYSTEM_VERSION"] = os_ver

--- a/conans/client/build/cmake_flags.py
+++ b/conans/client/build/cmake_flags.py
@@ -203,19 +203,15 @@ class CMakeDefinitionsBuilder(object):
             definitions["CMAKE_SYSTEM_NAME"] = cmake_system_name
         else:  # detect if we are cross building and the system name and version
             if cross_building(self._conanfile):  # We are cross building
-                if os_ != os_build:
-                    if os_:
-                        definitions["CMAKE_SYSTEM_NAME"] = {"Macos": "Darwin",
-                                                            "iOS": "Darwin",
-                                                            "tvOS": "Darwin",
-                                                            "watchOS": "Darwin",
-                                                            "Neutrino": "QNX"}.get(os_, os_)
-                    else:
-                        definitions["CMAKE_SYSTEM_NAME"] = "Generic"
-                elif not os_:
-                    # Host and build OS are the same. Difference is architecture. Only case
-                    # that should set CMAKE_SYSTEM_NAME is Linux
-                    definitions["CMAKE_SYSTEM_NAME"] = "Generic"
+                cmake_system_name_map = {"Macos": "Darwin",
+                                         "iOS": "Darwin",
+                                         "tvOS": "Darwin",
+                                         "watchOS": "Darwin",
+                                         "Neutrino": "QNX",
+                                         "": "Generic",
+                                         None: "Generic"}
+                if os_ != os_build or os_ != "Windows":
+                    definitions["CMAKE_SYSTEM_NAME"] = cmake_system_name_map.get(os_, os_)
 
         if os_ver:
             definitions["CMAKE_SYSTEM_VERSION"] = os_ver

--- a/conans/client/build/cmake_flags.py
+++ b/conans/client/build/cmake_flags.py
@@ -203,14 +203,20 @@ class CMakeDefinitionsBuilder(object):
             definitions["CMAKE_SYSTEM_NAME"] = cmake_system_name
         else:  # detect if we are cross building and the system name and version
             if cross_building(self._conanfile):  # We are cross building
-                if os_ and os_ != os_build:
-                    definitions["CMAKE_SYSTEM_NAME"] = {"Macos": "Darwin",
-                                                        "iOS": "Darwin",
-                                                        "tvOS": "Darwin",
-                                                        "watchOS": "Darwin",
-                                                        "Neutrino": "QNX"}.get(os_, os_)
-                else:
+                if os_ != os_build:
+                    if os_:
+                        definitions["CMAKE_SYSTEM_NAME"] = {"Macos": "Darwin",
+                                                            "iOS": "Darwin",
+                                                            "tvOS": "Darwin",
+                                                            "watchOS": "Darwin",
+                                                            "Neutrino": "QNX"}.get(os_, os_)
+                    else:
+                        definitions["CMAKE_SYSTEM_NAME"] = "Generic"
+                elif os_ == "Linux":
+                    # Host and build OS are the same. Difference is architecture. Only case
+                    # that should set CMAKE_SYSTEM_NAME is Linux
                     definitions["CMAKE_SYSTEM_NAME"] = "Generic"
+
         if os_ver:
             definitions["CMAKE_SYSTEM_VERSION"] = os_ver
             if is_apple_os(os_):

--- a/conans/client/build/cmake_flags.py
+++ b/conans/client/build/cmake_flags.py
@@ -212,7 +212,7 @@ class CMakeDefinitionsBuilder(object):
                                                             "Neutrino": "QNX"}.get(os_, os_)
                     else:
                         definitions["CMAKE_SYSTEM_NAME"] = "Generic"
-                elif os_ == "Linux":
+                elif not os_:
                     # Host and build OS are the same. Difference is architecture. Only case
                     # that should set CMAKE_SYSTEM_NAME is Linux
                     definitions["CMAKE_SYSTEM_NAME"] = "Generic"

--- a/conans/test/unittests/client/build/cmake_test.py
+++ b/conans/test/unittests/client/build/cmake_test.py
@@ -632,9 +632,12 @@ class CMakeTest(unittest.TestCase):
             os_ver = str(settings.os.version) if settings.get_safe('os.version') else None
             for cmake_system_name in (True, False):
                 cross_ver = ("-DCMAKE_SYSTEM_VERSION=\"%s\" " % os_ver) if os_ver else ""
-                cross = ("-DCMAKE_SYSTEM_NAME=\"%s\" %s-DCMAKE_SYSROOT=\"/path/to/sysroot\" "
-                         % ({"Macos": "Darwin"}.get(the_os, the_os), cross_ver)
-                         if ((platform.system() != the_os or arch != detected_architecture()) and cmake_system_name) else "")
+                # FIXME: This test is complicated to maintain and see the logic, lets simplify it
+                cross = ""
+                if cmake_system_name and (platform.system() != the_os or
+                                          (arch != detected_architecture() and the_os != "Windows")):
+                    cross = ("-DCMAKE_SYSTEM_NAME=\"%s\" %s-DCMAKE_SYSROOT=\"/path/to/sysroot\" "
+                             % ({"Macos": "Darwin"}.get(the_os, the_os), cross_ver))
                 cmake = CMake(conanfile, generator=generator, cmake_system_name=cmake_system_name,
                               set_cmake_flags=set_cmake_flags)
                 new_text = text.replace("-DCONAN_IN_LOCAL_CACHE", "%s-DCONAN_IN_LOCAL_CACHE" % cross)

--- a/conans/test/unittests/client/build/cmake_test.py
+++ b/conans/test/unittests/client/build/cmake_test.py
@@ -460,8 +460,9 @@ class CMakeTest(unittest.TestCase):
         conanfile.source_folder = os.path.join(self.tempdir, "my_cache_source_folder")
         conanfile.build_folder = os.path.join(self.tempdir, "my_cache_build_folder")
         with tools.chdir(self.tempdir):
-            linux_stuff = '-DCMAKE_SYSTEM_NAME="Linux" ' \
-                          '-DCMAKE_SYSROOT="/path/to/sysroot" '
+            linux_stuff = ""
+            if platform.system() != "Linux":
+                linux_stuff = '-DCMAKE_SYSTEM_NAME="Linux" -DCMAKE_SYSROOT="/path/to/sysroot" '
             generator = "MinGW Makefiles" if platform.system() == "Windows" else "Unix Makefiles"
 
             flags = '{} -DCONAN_COMPILER="gcc" ' \
@@ -634,8 +635,9 @@ class CMakeTest(unittest.TestCase):
                 cross_ver = ("-DCMAKE_SYSTEM_VERSION=\"%s\" " % os_ver) if os_ver else ""
                 # FIXME: This test is complicated to maintain and see the logic, lets simplify it
                 cross = ""
-                if cmake_system_name and (platform.system() != the_os or
-                                          (arch != detected_architecture() and the_os != "Windows")):
+                if cmake_system_name and (the_os != platform.system() or
+                                          (arch != detected_architecture()
+                                           and the_os not in ("Windows", "Linux"))):
                     cross = ("-DCMAKE_SYSTEM_NAME=\"%s\" %s-DCMAKE_SYSROOT=\"/path/to/sysroot\" "
                              % ({"Macos": "Darwin"}.get(the_os, the_os), cross_ver))
                 cmake = CMake(conanfile, generator=generator, cmake_system_name=cmake_system_name,


### PR DESCRIPTION
Changelog: Bugfix: Check comparing the host and the build architecture to decide if cross building and set `CMAKE_SYSTEM_NAME` in the ``CMake`` build helper.
Docs: Omit

#tags: slow

Close https://github.com/conan-io/conan/issues/7826