### PR TITLE
Feature/6207 config single file

### DIFF
--- a/conans/client/conf/config_installer.py
+++ b/conans/client/conf/config_installer.py
@@ -183,8 +183,6 @@ class _ConfigOrigin(object):
                 config.type = "git"
             elif os.path.isdir(uri):
                 config.type = "dir"
-            # elif is_compressed_file(uri):
-            #     config.type = "compressed"
             elif os.path.isfile(uri):
                 config.type = "file"
             elif uri.startswith("http"):
@@ -207,7 +205,6 @@ def _process_config(config, cache, output, requester):
             _process_git_repo(config, cache, output)
         elif config.type == "dir":
             _process_folder(config, config.uri, cache, output)
-        # elif config.type == "compressed":
         elif config.type == "file":
             if is_compressed_file(config.uri):
                 with tmp_config_install_folder(cache) as tmp_folder:

--- a/conans/client/conf/config_installer.py
+++ b/conans/client/conf/config_installer.py
@@ -210,8 +210,8 @@ def _process_config(config, cache, output, requester):
         elif config.type == "file":
             from zipfile import is_zipfile
             if is_zipfile(config.uri):
-                    with tmp_config_install_folder(cache) as tmp_folder:
-                        _process_zip_file(config, config.uri, cache, output, tmp_folder)
+                with tmp_config_install_folder(cache) as tmp_folder:
+                    _process_zip_file(config, config.uri, cache, output, tmp_folder)
             else:
                 dirname, filename = os.path.dirname(config.uri), os.path.basename(config.uri)
                 _process_file(dirname, filename, config, cache, output, dirname)

--- a/conans/client/conf/config_installer.py
+++ b/conans/client/conf/config_installer.py
@@ -86,6 +86,45 @@ def _filecopy(src, filename, dst):
     shutil.copyfile(src, dst)
 
 
+def _process_file(directory, filename, config, cache, output, folder):
+    if filename == "settings.yml":
+        output.info("Installing settings.yml")
+        _filecopy(directory, filename, cache.cache_folder)
+    elif filename == "conan.conf":
+        output.info("Processing conan.conf")
+        _handle_conan_conf(cache.config, os.path.join(directory, filename))
+    elif filename == "remotes.txt":
+        output.info("Defining remotes from remotes.txt")
+        _handle_remotes(cache, os.path.join(directory, filename))
+    elif filename in ("registry.txt", "registry.json"):
+        try:
+            os.remove(cache.remotes_path)
+        except OSError:
+            pass
+        finally:
+            _filecopy(directory, filename, cache.cache_folder)
+            migrate_registry_file(cache, output)
+    elif filename == "remotes.json":
+        # Fix for Conan 2.0
+        raise ConanException("remotes.json install is not supported yet. Use 'remotes.txt'")
+    # TODO : do we need this ? in which case we need to copy all the folder source
+    # TODO : into the conan configuration file ?
+    # else:
+    #     # This is ugly, should be removed in Conan 2.0
+    #     if filename in ("README.md", "LICENSE.txt"):
+    #         output.info("Skip %s" % filename)
+    #     else:
+    #         relpath = os.path.relpath(directory, folder)
+    #         if config.target_folder:
+    #             target_folder = os.path.join(cache.cache_folder, config.target_folder,
+    #                                          relpath)
+    #         else:
+    #             target_folder = os.path.join(cache.cache_folder, relpath)
+    #         mkdir(target_folder)
+    #         output.info("Copying file %s to %s" % (filename, target_folder))
+    #         _filecopy(directory, filename, target_folder)
+
+
 def _process_folder(config, folder, cache, output):
     if not os.path.isdir(folder):
         raise ConanException("No such directory: '%s'" % str(folder))
@@ -96,40 +135,7 @@ def _process_folder(config, folder, cache, output):
         if ".git" in root:
             continue
         for f in files:
-            if f == "settings.yml":
-                output.info("Installing settings.yml")
-                _filecopy(root, f, cache.cache_folder)
-            elif f == "conan.conf":
-                output.info("Processing conan.conf")
-                _handle_conan_conf(cache.config, os.path.join(root, f))
-            elif f == "remotes.txt":
-                output.info("Defining remotes from remotes.txt")
-                _handle_remotes(cache, os.path.join(root, f))
-            elif f in ("registry.txt", "registry.json"):
-                try:
-                    os.remove(cache.remotes_path)
-                except OSError:
-                    pass
-                finally:
-                    _filecopy(root, f, cache.cache_folder)
-                    migrate_registry_file(cache, output)
-            elif f == "remotes.json":
-                # Fix for Conan 2.0
-                raise ConanException("remotes.json install is not supported yet. Use 'remotes.txt'")
-            else:
-                # This is ugly, should be removed in Conan 2.0
-                if root == folder and f in ("README.md", "LICENSE.txt"):
-                    output.info("Skip %s" % f)
-                    continue
-                relpath = os.path.relpath(root, folder)
-                if config.target_folder:
-                    target_folder = os.path.join(cache.cache_folder, config.target_folder,
-                                                 relpath)
-                else:
-                    target_folder = os.path.join(cache.cache_folder, relpath)
-                mkdir(target_folder)
-                output.info("Copying file %s to %s" % (f, target_folder))
-                _filecopy(root, f, target_folder)
+            _process_file(root, f, config, cache, output, folder)
 
 
 def _process_download(config, cache, output, requester):
@@ -202,8 +208,13 @@ def _process_config(config, cache, output, requester):
         elif config.type == "dir":
             _process_folder(config, config.uri, cache, output)
         elif config.type == "file":
-            with tmp_config_install_folder(cache) as tmp_folder:
-                _process_zip_file(config, config.uri, cache, output, tmp_folder)
+            from zipfile import is_zipfile
+            if is_zipfile(config.uri):
+                    with tmp_config_install_folder(cache) as tmp_folder:
+                        _process_zip_file(config, config.uri, cache, output, tmp_folder)
+            else:
+                dirname, filename = os.path.dirname(config.uri), os.path.basename(config.uri)
+                _process_file(dirname, filename, config, cache, output, dirname)
         elif config.type == "url":
             _process_download(config, cache, output, requester=requester)
         else:

--- a/conans/client/conf/config_installer.py
+++ b/conans/client/conf/config_installer.py
@@ -183,8 +183,8 @@ class _ConfigOrigin(object):
                 config.type = "git"
             elif os.path.isdir(uri):
                 config.type = "dir"
-            elif is_compressed_file(uri):
-                config.type = "compressed"
+            # elif is_compressed_file(uri):
+            #     config.type = "compressed"
             elif os.path.isfile(uri):
                 config.type = "file"
             elif uri.startswith("http"):
@@ -207,12 +207,14 @@ def _process_config(config, cache, output, requester):
             _process_git_repo(config, cache, output)
         elif config.type == "dir":
             _process_folder(config, config.uri, cache, output)
-        elif config.type == "compressed":
-            with tmp_config_install_folder(cache) as tmp_folder:
-                _process_zip_file(config, config.uri, cache, output, tmp_folder)
+        # elif config.type == "compressed":
         elif config.type == "file":
-            dirname, filename = os.path.dirname(config.uri), os.path.basename(config.uri)
-            _process_file(dirname, filename, config, cache, output, dirname)
+            if is_compressed_file(config.uri):
+                with tmp_config_install_folder(cache) as tmp_folder:
+                    _process_zip_file(config, config.uri, cache, output, tmp_folder)
+            else:
+                dirname, filename = os.path.dirname(config.uri), os.path.basename(config.uri)
+                _process_file(dirname, filename, config, cache, output, dirname)
         elif config.type == "url":
             _process_download(config, cache, output, requester=requester)
         else:

--- a/conans/client/tools/files.py
+++ b/conans/client/tools/files.py
@@ -57,15 +57,12 @@ def is_compressed_file(filename):
     import zipfile
     import tarfile
     import binascii
-    from os.path import isfile
-    if not isfile(filename):
-        return False
-    if zipfile.is_zipfile(filename) or tarfile.is_tarfile(filename):
-        return True
     # test gzip magic number
     with open(filename, 'rb') as fd:
         if binascii.hexlify(fd.read(2)) == b'1f8b':
             return True
+    if zipfile.is_zipfile(filename) or tarfile.is_tarfile(filename):
+        return True
     return False
 
 

--- a/conans/client/tools/files.py
+++ b/conans/client/tools/files.py
@@ -57,6 +57,9 @@ def is_compressed_file(filename):
     import zipfile
     import tarfile
     import binascii
+    from os.path import isfile
+    if not isfile(filename):
+        return False
     if zipfile.is_zipfile(filename) or tarfile.is_tarfile(filename):
         return True
     # test gzip magic number

--- a/conans/client/tools/files.py
+++ b/conans/client/tools/files.py
@@ -53,6 +53,19 @@ def human_size(size_bytes):
     return "%s%s" % (formatted_size, suffix)
 
 
+def is_compressed_file(filename):
+    import zipfile
+    import tarfile
+    import binascii
+    if zipfile.is_zipfile(filename) or tarfile.is_tarfile(filename):
+        return True
+    # test gzip magic number
+    with open(filename, 'rb') as fd:
+        if binascii.hexlify(fd.read(2)) == b'1f8b':
+            return True
+    return False
+
+
 def unzip(filename, destination=".", keep_permissions=False, pattern=None, output=None):
     """
     Unzip a zipped file
@@ -101,42 +114,41 @@ def unzip(filename, destination=".", keep_permissions=False, pattern=None, outpu
         def print_progress(_, __):
             pass
 
-    if zipfile.is_zipfile(filename):
-        with zipfile.ZipFile(filename, "r") as z:
-            if not pattern:
-                zip_info = z.infolist()
-            else:
-                zip_info = [zi for zi in z.infolist() if fnmatch(zi.filename, pattern)]
-            uncompress_size = sum((file_.file_size for file_ in zip_info))
-            if uncompress_size > 100000:
-                output.info("Unzipping %s, this can take a while" % human_size(uncompress_size))
-            else:
-                output.info("Unzipping %s" % human_size(uncompress_size))
-            extracted_size = 0
+    with zipfile.ZipFile(filename, "r") as z:
+        if not pattern:
+            zip_info = z.infolist()
+        else:
+            zip_info = [zi for zi in z.infolist() if fnmatch(zi.filename, pattern)]
+        uncompress_size = sum((file_.file_size for file_ in zip_info))
+        if uncompress_size > 100000:
+            output.info("Unzipping %s, this can take a while" % human_size(uncompress_size))
+        else:
+            output.info("Unzipping %s" % human_size(uncompress_size))
+        extracted_size = 0
 
-            print_progress.last_size = -1
-            if platform.system() == "Windows":
-                for file_ in zip_info:
-                    extracted_size += file_.file_size
-                    print_progress(extracted_size, uncompress_size)
-                    try:
-                        z.extract(file_, full_path)
-                    except Exception as e:
-                        output.error("Error extract %s\n%s" % (file_.filename, str(e)))
-            else:  # duplicated for, to avoid a platform check for each zipped file
-                for file_ in zip_info:
-                    extracted_size += file_.file_size
-                    print_progress(extracted_size, uncompress_size)
-                    try:
-                        z.extract(file_, full_path)
-                        if keep_permissions:
-                            # Could be dangerous if the ZIP has been created in a non nix system
-                            # https://bugs.python.org/issue15795
-                            perm = file_.external_attr >> 16 & 0xFFF
-                            os.chmod(os.path.join(full_path, file_.filename), perm)
-                    except Exception as e:
-                        output.error("Error extract %s\n%s" % (file_.filename, str(e)))
-            output.writeln("")
+        print_progress.last_size = -1
+        if platform.system() == "Windows":
+            for file_ in zip_info:
+                extracted_size += file_.file_size
+                print_progress(extracted_size, uncompress_size)
+                try:
+                    z.extract(file_, full_path)
+                except Exception as e:
+                    output.error("Error extract %s\n%s" % (file_.filename, str(e)))
+        else:  # duplicated for, to avoid a platform check for each zipped file
+            for file_ in zip_info:
+                extracted_size += file_.file_size
+                print_progress(extracted_size, uncompress_size)
+                try:
+                    z.extract(file_, full_path)
+                    if keep_permissions:
+                        # Could be dangerous if the ZIP has been created in a non nix system
+                        # https://bugs.python.org/issue15795
+                        perm = file_.external_attr >> 16 & 0xFFF
+                        os.chmod(os.path.join(full_path, file_.filename), perm)
+                except Exception as e:
+                    output.error("Error extract %s\n%s" % (file_.filename, str(e)))
+        output.writeln("")
 
 
 def untargz(filename, destination=".", pattern=None):

--- a/conans/test/functional/command/config_install_test.py
+++ b/conans/test/functional/command/config_install_test.py
@@ -222,15 +222,18 @@ class Pkg(ConanFile):
         self.assertTrue(os.path.isdir(profile_folder))
         src_setting_file = os.path.join(profile_folder, "settings.yml")
         src_remote_file = os.path.join(profile_folder, "remotes.txt")
+
         # Install profile_folder without settings.yml + remotes.txt in order to install them manually
-        with tempfile.TemporaryDirectory() as tmp_dir:
-            dest_setting_file = os.path.join(tmp_dir, "settings.yml")
-            dest_remote_file = os.path.join(tmp_dir, "remotes.txt")
-            shutil.move(src_setting_file, dest_setting_file)
-            shutil.move(src_remote_file, dest_remote_file)
-            self.client.run('config install "%s"' % profile_folder)
-            shutil.move(dest_setting_file, src_setting_file)
-            shutil.move(dest_remote_file, src_remote_file)
+        tmp_dir = tempfile.mkdtemp()
+        dest_setting_file = os.path.join(tmp_dir, "settings.yml")
+        dest_remote_file = os.path.join(tmp_dir, "remotes.txt")
+        shutil.move(src_setting_file, dest_setting_file)
+        shutil.move(src_remote_file, dest_remote_file)
+        self.client.run('config install "%s"' % profile_folder)
+        shutil.move(dest_setting_file, src_setting_file)
+        shutil.move(dest_remote_file, src_remote_file)
+        shutil.rmtree(tmp_dir)
+
         for cmd_option in ["", "--type=file"]:
             self.client.run('config install "%s" %s' % (src_setting_file, cmd_option))
             self.client.run('config install "%s" %s' % (src_remote_file, cmd_option))


### PR DESCRIPTION
Changelog: Feature: Allow ``conan config install`` of a single file
Docs: https://github.com/conan-io/docs/pull/1908

Close https://github.com/conan-io/conan/issues/6207

* Add the possibility to specify a configuration for the command `conan config install`
* Copy only the configuration files in the directory, for the command `conan config install dirname`

Question :
* For what purpose, do we need the files copy, when the directory is pass by parameter ?

- [X] Refer to the issue that supports this Pull Request.
- [ ] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [ ] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one.