### PR TITLE
[refact] What if... we use an inheritance based approach for CMake toolchains?

### DIFF
--- a/conans/client/build/cmake_toolchain_build_helper.py
+++ b/conans/client/build/cmake_toolchain_build_helper.py
@@ -4,7 +4,7 @@ import platform
 from conans.client import tools
 from conans.client.build import defs_to_string, join_arguments
 from conans.client.build.cmake_flags import is_multi_configuration, get_generator
-from conans.client.toolchain.cmake import CMakeToolchain
+from conans.client.toolchain.cmake.base import CMakeToolchainBase
 from conans.client.tools.files import chdir
 from conans.client.tools.oss import cpu_count, args_to_string
 from conans.errors import ConanException
@@ -74,7 +74,7 @@ class CMakeToolchainBuildHelper(object):
         if self._build_folder:
             build_folder = os.path.join(self._conanfile.build_folder, self._build_folder)
 
-        defs = {"CMAKE_TOOLCHAIN_FILE": CMakeToolchain.filename}
+        defs = {"CMAKE_TOOLCHAIN_FILE": CMakeToolchainBase.filename}
 
         mkdir(build_folder)
         arg_list = join_arguments([

--- a/conans/client/toolchain/cmake/__init__.py
+++ b/conans/client/toolchain/cmake/__init__.py
@@ -1,0 +1,16 @@
+from conans.client.tools import cross_building
+from .native import CMakeNativeToolchain
+from .android import CMakeAndroidToolchain
+
+
+def CMakeToolchain(conanfile, *args, **kwargs):
+    if not cross_building(conanfile):
+        return CMakeNativeToolchain(conanfile, *args, **kwargs)
+    else:
+        # Exceptions to cross-building scenarios
+        if conanfile.settings.os == 'Windows' and conanfile.settings_build.os == 'Windows':
+            return CMakeNativeToolchain(conanfile, *args, **kwargs)
+
+        # Actual cross-building
+        if conanfile.settings.os == 'Android':
+            return CMakeAndroidToolchain(conanfile, *args, **kwargs)

--- a/conans/client/toolchain/cmake/__init__.py
+++ b/conans/client/toolchain/cmake/__init__.py
@@ -1,16 +1,17 @@
 from conans.client.tools import cross_building
-from .native import CMakeNativeToolchain
+from conans.errors import ConanException
 from .android import CMakeAndroidToolchain
+from .native import CMakeNativeToolchain
 
 
 def CMakeToolchain(conanfile, *args, **kwargs):
-    if not cross_building(conanfile):
+    skip_x64_x86 = conanfile.settings.os in ['Windows', 'Linux']
+    if not cross_building(conanfile, skip_x64_x86=skip_x64_x86):
         return CMakeNativeToolchain(conanfile, *args, **kwargs)
     else:
-        # Exceptions to cross-building scenarios
-        if conanfile.settings.os == 'Windows' and conanfile.settings_build.os == 'Windows':
-            return CMakeNativeToolchain(conanfile, *args, **kwargs)
-
-        # Actual cross-building
         if conanfile.settings.os == 'Android':
             return CMakeAndroidToolchain(conanfile, *args, **kwargs)
+        else:
+            # TODO: We need to provide a way to inject a toolchain from the outside
+            raise ConanException("No toolchain available to cross-compile"
+                                 " to 'os={}'".format(conanfile.settings.os))

--- a/conans/client/toolchain/cmake/__init__.py
+++ b/conans/client/toolchain/cmake/__init__.py
@@ -1,17 +1,11 @@
-from conans.client.tools import cross_building
-from conans.errors import ConanException
 from .android import CMakeAndroidToolchain
-from .native import CMakeNativeToolchain
+from .generic import CMakeGenericToolchain
 
 
 def CMakeToolchain(conanfile, *args, **kwargs):
-    skip_x64_x86 = conanfile.settings.get_safe('os') in ['Windows', 'Linux']
-    if not cross_building(conanfile, skip_x64_x86=skip_x64_x86):
-        return CMakeNativeToolchain(conanfile, *args, **kwargs)
+    os_ = conanfile.settings.get_safe('os')
+    if os_ == 'Android':
+        # assert cross_building(conanfile)  # FIXME: Conan v2.0, two-profiles approach by default
+        return CMakeAndroidToolchain(conanfile, *args, **kwargs)
     else:
-        os_ = conanfile.settings.get_safe('os')
-        if os_ == 'Android':
-            return CMakeAndroidToolchain(conanfile, *args, **kwargs)
-        else:
-            # TODO: We need to provide a way to inject a toolchain from the outside
-            raise ConanException("No toolchain available to cross-compile to 'os={}'".format(os_))
+        return CMakeGenericToolchain(conanfile, *args, **kwargs)

--- a/conans/client/toolchain/cmake/__init__.py
+++ b/conans/client/toolchain/cmake/__init__.py
@@ -5,13 +5,13 @@ from .native import CMakeNativeToolchain
 
 
 def CMakeToolchain(conanfile, *args, **kwargs):
-    skip_x64_x86 = conanfile.settings.os in ['Windows', 'Linux']
+    skip_x64_x86 = conanfile.settings.get_safe('os') in ['Windows', 'Linux']
     if not cross_building(conanfile, skip_x64_x86=skip_x64_x86):
         return CMakeNativeToolchain(conanfile, *args, **kwargs)
     else:
-        if conanfile.settings.os == 'Android':
+        os_ = conanfile.settings.get_safe('os')
+        if os_ == 'Android':
             return CMakeAndroidToolchain(conanfile, *args, **kwargs)
         else:
             # TODO: We need to provide a way to inject a toolchain from the outside
-            raise ConanException("No toolchain available to cross-compile"
-                                 " to 'os={}'".format(conanfile.settings.os))
+            raise ConanException("No toolchain available to cross-compile to 'os={}'".format(os_))

--- a/conans/client/toolchain/cmake/android.py
+++ b/conans/client/toolchain/cmake/android.py
@@ -1,0 +1,5 @@
+from .base import CMakeToolchainBase
+
+
+class CMakeAndroidToolchain(CMakeToolchainBase):
+    pass

--- a/conans/client/toolchain/cmake/base.py
+++ b/conans/client/toolchain/cmake/base.py
@@ -1,0 +1,5 @@
+class CMakeToolchainBase(object):
+    filename = "conan_toolchain.cmake"
+
+    def __init__(self, conanfile, *args, **kwargs):
+        self._conanfile = conanfile

--- a/conans/client/toolchain/cmake/base.py
+++ b/conans/client/toolchain/cmake/base.py
@@ -1,5 +1,37 @@
+import os
+
+from jinja2 import Template
+
+from conans.util.files import save
+
+
 class CMakeToolchainBase(object):
     filename = "conan_toolchain.cmake"
+    project_include_filename = "conan_project_include.cmake"
+
+    _template_project_include = None
+    _template_toolchain = None
 
     def __init__(self, conanfile, *args, **kwargs):
         self._conanfile = conanfile
+
+    def _get_template_context_data(self):
+        """ Returns two dictionaries, the context for the '_template_toolchain' and
+            the context for the '_template_project_include' templates.
+        """
+        return {}, {}
+
+    def write_toolchain_files(self):
+        tpl_toolchain_context, tpl_project_include_context = self._get_template_context_data()
+
+        # Make it absolute, wrt to current folder, set by the caller
+        conan_project_include_cmake = os.path.abspath(self.project_include_filename)
+        conan_project_include_cmake = conan_project_include_cmake.replace("\\", "/")
+        t = Template(self._template_project_include)
+        content = t.render(**tpl_project_include_context)
+        save(conan_project_include_cmake, content)
+
+        t = Template(self._template_toolchain)
+        content = t.render(conan_project_include_cmake=conan_project_include_cmake,
+                           **tpl_toolchain_context)
+        save(self.filename, content)

--- a/conans/client/toolchain/cmake/generic.py
+++ b/conans/client/toolchain/cmake/generic.py
@@ -37,7 +37,7 @@ class Variables(OrderedDict):
         return ret
 
 
-class CMakeNativeToolchain(CMakeToolchainBase):
+class CMakeGenericToolchain(CMakeToolchainBase):
     _template_toolchain = textwrap.dedent("""
         # Conan automatically generated toolchain file
         # DO NOT EDIT MANUALLY, it will be overwritten
@@ -234,7 +234,7 @@ class CMakeNativeToolchain(CMakeToolchainBase):
 
     def __init__(self, conanfile, generator=None, generator_platform=None, build_type=None,
                  toolset=None, parallel=True):
-        super(CMakeNativeToolchain, self).__init__(conanfile)
+        super(CMakeGenericToolchain, self).__init__(conanfile)
 
         self.fpic = self._deduce_fpic()
         self.vs_static_runtime = self._deduce_vs_static_runtime()
@@ -349,7 +349,7 @@ class CMakeNativeToolchain(CMakeToolchainBase):
 
     def _get_template_context_data(self):
         tpl_toolchain_context, tpl_project_include_context = \
-            super(CMakeNativeToolchain, self)._get_template_context_data()
+            super(CMakeGenericToolchain, self)._get_template_context_data()
         tpl_toolchain_context.update({
             "variables": self.variables,
             "variables_config": self.variables.configuration_types,

--- a/conans/client/toolchain/cmake/native.py
+++ b/conans/client/toolchain/cmake/native.py
@@ -1,15 +1,11 @@
-import os
 import textwrap
 from collections import OrderedDict, defaultdict
-
-from jinja2 import Template
 
 from conans.client.build.cmake_flags import get_generator, get_generator_platform, get_toolset, \
     is_multi_configuration
 from conans.client.build.compiler_flags import architecture_flag
 from conans.client.tools import cpu_count
 from conans.errors import ConanException
-from conans.util.files import save
 from .base import CMakeToolchainBase
 
 
@@ -351,19 +347,10 @@ class CMakeNativeToolchain(CMakeToolchainBase):
                 cppstd_extensions = "OFF"
         return cppstd, cppstd_extensions
 
-    def write_toolchain_files(self):
-        # Make it absolute, wrt to current folder, set by the caller
-        conan_project_include_cmake = os.path.abspath("conan_project_include.cmake")
-        conan_project_include_cmake = conan_project_include_cmake.replace("\\", "/")
-        t = Template(self._template_project_include)
-        content = t.render(vs_static_runtime=self.vs_static_runtime)
-        save(conan_project_include_cmake, content)
-
-        # TODO: I need the profile_host and profile_build here!
-        # TODO: What if the compiler is a build require?
-        # TODO: Add all the stuff related to settings (ALL settings or just _MY_ settings?)
-
-        context = {
+    def _get_template_context_data(self):
+        tpl_toolchain_context, tpl_project_include_context = \
+            super(CMakeNativeToolchain, self)._get_template_context_data()
+        tpl_toolchain_context.update({
             "variables": self.variables,
             "variables_config": self.variables.configuration_types,
             "preprocessor_definitions": self.preprocessor_definitions,
@@ -383,7 +370,6 @@ class CMakeNativeToolchain(CMakeToolchainBase):
             "cppstd_extensions": self.cppstd_extensions,
             "shared_libs": self._build_shared_libs,
             "architecture": self.architecture
-        }
-        t = Template(self._template_toolchain)
-        content = t.render(conan_project_include_cmake=conan_project_include_cmake, **context)
-        save(self.filename, content)
+        })
+        tpl_project_include_context.update({'vs_static_runtime': self.vs_static_runtime})
+        return tpl_toolchain_context, tpl_project_include_context

--- a/conans/client/toolchain/cmake/native.py
+++ b/conans/client/toolchain/cmake/native.py
@@ -4,12 +4,13 @@ from collections import OrderedDict, defaultdict
 
 from jinja2 import Template
 
-from conans.client.build.cmake_flags import get_generator, get_generator_platform,  get_toolset, \
+from conans.client.build.cmake_flags import get_generator, get_generator_platform, get_toolset, \
     is_multi_configuration
 from conans.client.build.compiler_flags import architecture_flag
 from conans.client.tools import cpu_count
 from conans.errors import ConanException
 from conans.util.files import save
+from .base import CMakeToolchainBase
 
 
 # https://stackoverflow.com/questions/30503631/cmake-in-which-order-are-files-parsed-cache-toolchain-etc
@@ -40,9 +41,7 @@ class Variables(OrderedDict):
         return ret
 
 
-class CMakeToolchain(object):
-    filename = "conan_toolchain.cmake"
-
+class CMakeNativeToolchain(CMakeToolchainBase):
     _template_toolchain = textwrap.dedent("""
         # Conan automatically generated toolchain file
         # DO NOT EDIT MANUALLY, it will be overwritten
@@ -239,7 +238,7 @@ class CMakeToolchain(object):
 
     def __init__(self, conanfile, generator=None, generator_platform=None, build_type=None,
                  toolset=None, parallel=True):
-        self._conanfile = conanfile
+        super(CMakeNativeToolchain, self).__init__(conanfile)
 
         self.fpic = self._deduce_fpic()
         self.vs_static_runtime = self._deduce_vs_static_runtime()
@@ -306,7 +305,7 @@ class CMakeToolchain(object):
     def _deduce_vs_static_runtime(self):
         settings = self._conanfile.settings
         if (settings.get_safe("compiler") == "Visual Studio" and
-                "MT" in settings.get_safe("compiler.runtime")):
+            "MT" in settings.get_safe("compiler.runtime")):
             return True
         return False
 


### PR DESCRIPTION
Changelog: omit
Docs: omit

Main motivations here:

The generated toolchain file will be different for different cross-compiling scenarios. Probably some variables that make sense for some target architectures don't make sense for others (CMAKE_CXX_FLAGS). And for sure values will be different. 

I think that this _inheritance based_ approach will help us to keep source code cleaner:

The template itself:
 * the base template file can be simpler: probably a base template for variables and definitions that affect to every CMake based compilation: `set(...)`, `add_definitions(..)`, `BUILD_SHARED_LIBS`, `CMAKE_POSITION_INDEPENDENT_CODE`,... (or at least I'm pretty sure that, if they don't apply for a target platform, they will be ignored)
 * each inherited class can extend/append to that file the things that are specific to the target architecture. For example, the native one will add `-m64` to CONAN_CXX_FLAGS, while the Android one doesn't want to add anything there.

The logic inside the functions:
 * common logic can be implemented in the base file, but specific logic for a target platform can override the function and we will get rid of many nasty `if/else` to handle specific systems, cross-compiling logic, exceptional values,... 

At least this is the intention...


#tags: slow