### PR TITLE
[toolchain] Fix toolchain install prefix

### DIFF
--- a/conans/client/toolchain/cmake.py
+++ b/conans/client/toolchain/cmake.py
@@ -155,7 +155,7 @@ class CMakeToolchain(object):
 
         # Install prefix
         {% if install_prefix -%}
-        set(CMAKE_INSTALL_PREFIX {{install_prefix}} CACHE STRING "" FORCE)
+        set(CMAKE_INSTALL_PREFIX "{{install_prefix}}" CACHE STRING "" FORCE)
         {%- endif %}
 
         # Variables


### PR DESCRIPTION
Changelog: Fix: Use quotes around the install path, it can contain spaces.
Docs: omit

#tags: slow