### PR TITLE
Fix/range resolver without userchannel

### DIFF
--- a/conans/client/graph/range_resolver.py
+++ b/conans/client/graph/range_resolver.py
@@ -152,9 +152,8 @@ class RangeResolver(object):
         for remote in remotes.values():
             if not remotes.selected or remote == remotes.selected:
                 result = self._remote_manager.search_recipes(remote, pattern, ignorecase=False)
-                if search_ref.user is None:  # need to filter out the user/channel
-                    result = [s for s in result
-                              if s.user == search_ref.user and s.channel == search_ref.channel]
+                result = [ref for ref in result
+                          if ref.user == search_ref.user and ref.channel == search_ref.channel]
                 if result:
                     return result, remote.name
         return None, None

--- a/conans/client/graph/range_resolver.py
+++ b/conans/client/graph/range_resolver.py
@@ -148,12 +148,15 @@ class RangeResolver(object):
             return self._resolve_version(version_range, local_found)
 
     def _search_remotes(self, search_ref, remotes):
+        pattern = str(search_ref)
         for remote in remotes.values():
             if not remotes.selected or remote == remotes.selected:
-                search_result = self._remote_manager.search_recipes(remote, str(search_ref),
-                                                                    ignorecase=False)
-                if search_result:
-                    return search_result, remote.name
+                result = self._remote_manager.search_recipes(remote, pattern, ignorecase=False)
+                if search_ref.user is None:  # need to filter out the user/channel
+                    result = [s for s in result
+                              if s.user == search_ref.user and s.channel == search_ref.channel]
+                if result:
+                    return result, remote.name
         return None, None
 
     def _resolve_remote(self, search_ref, version_range, remotes):

--- a/conans/test/functional/graph/version_range_no_userchannel_test.py
+++ b/conans/test/functional/graph/version_range_no_userchannel_test.py
@@ -1,18 +1,11 @@
 # coding=utf-8
 
-import textwrap
 import unittest
 
 from conans.test.utils.tools import TestClient, GenConanfile
 
 
 class VersionRangeNoUserChannelTestCase(unittest.TestCase):
-    conanfile = textwrap.dedent("""
-        from conans import ConanFile
-        
-        class LibB(ConanFile):
-            requires = "{}"
-    """)
 
     def test_match(self):
         t = TestClient()
@@ -20,29 +13,47 @@ class VersionRangeNoUserChannelTestCase(unittest.TestCase):
         t.run("export . libB/1.0@")
 
         # Use version ranges without user/channel
-        t.save({"conanfile.py": self.conanfile.format("libB/[~1.x]")})
+        t.save({"conanfile.py": GenConanfile().with_require("libB/[~1.x]")})
         t.run("info . --only requires")
         self.assertIn("Version range '~1.x' required by 'conanfile.py'"
                       " resolved to 'libB/1.0' in local cache", t.out)
 
     def test_no_match(self):
         t = TestClient()
-        t.save({"conanfile.py": GenConanfile(), })
+        t.save({"conanfile.py": GenConanfile()})
         t.run("export . libB/1.0@user/channel")
 
         # Use version ranges without user/channel
-        t.save({"conanfile.py": self.conanfile.format("libB/[~1.x]")})
+        t.save({"conanfile.py": GenConanfile().with_require("libB/[~1.x]")})
         t.run("info . --only requires", assert_error=True)
         self.assertIn("ERROR: Version range '~1.x' from requirement 'libB/[~1.x]' required"
                       " by 'conanfile.py' could not be resolved in local cache", t.out)
 
     def test_no_match_with_userchannel(self):
         t = TestClient()
-        t.save({"conanfile.py": GenConanfile(), })
+        t.save({"conanfile.py": GenConanfile()})
         t.run("export . libB/1.0@")
 
         # Use version ranges with user/channel
-        t.save({"conanfile.py": self.conanfile.format("libB/[~1.x]@user/channel")})
+        t.save({"conanfile.py": GenConanfile().with_require("libB/[~1.x]@user/channel")})
         t.run("info . --only requires", assert_error=True)
         self.assertIn("ERROR: Version range '~1.x' from requirement 'libB/[~1.x]@user/channel'"
                       " required by 'conanfile.py' could not be resolved in local cache", t.out)
+
+    def test_mixed_user_channel(self):
+        # https://github.com/conan-io/conan/issues/7846
+        t = TestClient(default_server_user=True)
+        t.save({"conanfile.py": GenConanfile()})
+        t.run("create . pkg/1.0@")
+        t.run("create . pkg/1.1@")
+        t.run("create . pkg/2.0@")
+        t.run("create . pkg/1.0@user/testing")
+        t.run("create . pkg/1.1@user/testing")
+        t.run("create . pkg/2.0@user/testing")
+        t.run("upload * --all --confirm")
+        t.run("remove * -f")
+
+        t.run('install "pkg/[>0 <2]@"')
+        self.assertIn("pkg/1.1 from 'default' - Downloaded", t.out)
+        t.run('install "pkg/[>0 <2]@user/testing"')
+        self.assertIn("pkg/1.1@user/testing from 'default' - Downloaded", t.out)


### PR DESCRIPTION
Changelog: Bugfix: Fix regression introduced in 1.30 (https://github.com/conan-io/conan/pull/7673), with incorrect matches of user/channel for version ranges.
Docs: Omit

Fix https://github.com/conan-io/conan/issues/7846


