### PR TITLE
[refact] Refact/toolchain templates

### DIFF
--- a/conans/client/toolchain/cmake/__init__.py
+++ b/conans/client/toolchain/cmake/__init__.py
@@ -2,10 +2,10 @@ from .android import CMakeAndroidToolchain
 from .generic import CMakeGenericToolchain
 
 
-def CMakeToolchain(conanfile, *args, **kwargs):
+def CMakeToolchain(conanfile, **kwargs):
     os_ = conanfile.settings.get_safe('os')
     if os_ == 'Android':
         # assert cross_building(conanfile)  # FIXME: Conan v2.0, two-profiles approach by default
-        return CMakeAndroidToolchain(conanfile, *args, **kwargs)
+        return CMakeAndroidToolchain(conanfile, **kwargs)
     else:
-        return CMakeGenericToolchain(conanfile, *args, **kwargs)
+        return CMakeGenericToolchain(conanfile, **kwargs)

--- a/conans/client/toolchain/cmake/base.py
+++ b/conans/client/toolchain/cmake/base.py
@@ -1,7 +1,9 @@
 import os
+import textwrap
 from collections import OrderedDict, defaultdict
 
-from jinja2 import Template
+from jinja2 import DictLoader
+from jinja2 import Environment
 
 from conans.util.files import save
 
@@ -33,8 +35,94 @@ class CMakeToolchainBase(object):
     filename = "conan_toolchain.cmake"
     project_include_filename = "conan_project_include.cmake"
 
-    _template_project_include = None
-    _template_toolchain = None
+    _toolchain_macros_tpl = textwrap.dedent("""
+        {% macro iterate_configs(var_config, action) -%}
+            {% for it, values in var_config.items() -%}
+                {%- set genexpr = namespace(str='') %}
+                {%- for conf, value in values -%}
+                    {%- set genexpr.str = genexpr.str +
+                                          '$<IF:$<CONFIG:' + conf + '>,"' + value|string + '",' %}
+                    {%- if loop.last %}{% set genexpr.str = genexpr.str + '""' -%}{%- endif -%}
+                {%- endfor -%}
+                {% for i in range(values|count) %}{%- set genexpr.str = genexpr.str + '>' %}{%- endfor -%}
+                {% if action=='set' %}
+                set({{ it }} {{ genexpr.str }})
+                {% elif action=='add_definitions' %}
+                add_definitions(-D{{ it }}={{ genexpr.str }})
+                {% endif %}
+            {%- endfor %}
+        {% endmacro %}
+        """)
+
+    _base_toolchain_tpl = textwrap.dedent("""
+        {% import 'toolchain_macros' as toolchain_macros %}
+
+        # Conan automatically generated toolchain file
+        # DO NOT EDIT MANUALLY, it will be overwritten
+
+        # Avoid including toolchain file several times (bad if appending to variables like
+        #   CMAKE_CXX_FLAGS. See https://github.com/android/ndk/issues/323
+        if(CONAN_TOOLCHAIN_INCLUDED)
+          return()
+        endif()
+        set(CONAN_TOOLCHAIN_INCLUDED TRUE)
+
+        {% block before_try_compile %}
+        {% endblock %}
+
+        get_property( _CMAKE_IN_TRY_COMPILE GLOBAL PROPERTY IN_TRY_COMPILE )
+        if(_CMAKE_IN_TRY_COMPILE)
+            message(STATUS "Running toolchain IN_TRY_COMPILE")
+            return()
+        endif()
+
+        message("Using Conan toolchain through ${CMAKE_TOOLCHAIN_FILE}.")
+
+        {% if conan_project_include_cmake %}
+        if(CMAKE_VERSION VERSION_LESS "3.15")
+            message(WARNING
+                " CMake version less than 3.15 doesn't support CMAKE_PROJECT_INCLUDE variable\\n"
+                " used by Conan toolchain to work. In order to get the same behavior you will\\n"
+                " need to manually include the generated file after your 'project()' call in the\\n"
+                " main CMakeLists.txt file:\\n"
+                " \\n"
+                "     project(YourProject C CXX)\\n"
+                "     include(\\"\\${CMAKE_BINARY_DIR}/conan_project_include.cmake\\")\\n"
+                " \\n"
+                " This file contains some definitions and extra adjustments that depend on\\n"
+                " the build_type and it cannot be done in the toolchain.")
+        else()
+            # Will be executed after the 'project()' command
+            set(CMAKE_PROJECT_INCLUDE "{{ conan_project_include_cmake }}")
+        endif()
+        {% endif %}
+
+        {% block main %}
+        {% endblock %}
+
+        # Install prefix
+        {% if install_prefix -%}
+        set(CMAKE_INSTALL_PREFIX {{install_prefix}} CACHE STRING "" FORCE)
+        {%- endif %}
+
+        # Variables
+        {% for it, value in variables.items() -%}
+        set({{ it }} "{{ value }}")
+        {%- endfor %}
+        # Variables  per configuration
+        {{ toolchain_macros.iterate_configs(variables_config, action='set') }}
+
+        # Preprocessor definitions
+        {% for it, value in preprocessor_definitions.items() -%}
+        # add_compile_definitions only works in cmake >= 3.12
+        add_definitions(-D{{ it }}="{{ value }}")
+        {%- endfor %}
+        # Preprocessor definitions per configuration
+        {{ toolchain_macros.iterate_configs(preprocessor_definitions_config, action='add_definitions') }}
+
+        {% block footer %}
+        {% endblock %}
+        """)
 
     def __init__(self, conanfile, *args, **kwargs):
         self._conanfile = conanfile
@@ -46,6 +134,12 @@ class CMakeToolchainBase(object):
         except AttributeError:
             # FIXME: In the local flow, we don't know the package_folder
             self.install_prefix = None
+
+    def _get_templates(self):
+        return {
+            'toolchain_macros': self._toolchain_macros_tpl,
+            'base_toolchain': self._base_toolchain_tpl
+        }
 
     def _get_template_context_data(self):
         """ Returns two dictionaries, the context for the '_template_toolchain' and
@@ -61,15 +155,21 @@ class CMakeToolchainBase(object):
         return ctxt_toolchain, {}
 
     def write_toolchain_files(self):
+        # Prepare templates to be loaded
+        dict_loader = DictLoader(self._get_templates())
+        env = Environment(loader=dict_loader)
+
         ctxt_toolchain, ctxt_project_include = self._get_template_context_data()
+        if ctxt_project_include:
+            # Make it absolute, wrt to current folder, set by the caller
+            conan_project_include_cmake = os.path.abspath(self.project_include_filename)
+            conan_project_include_cmake = conan_project_include_cmake.replace("\\", "/")
+            t = env.get_template(self.project_include_filename)
+            content = t.render(**ctxt_project_include)
+            save(conan_project_include_cmake, content)
 
-        # Make it absolute, wrt to current folder, set by the caller
-        conan_project_include_cmake = os.path.abspath(self.project_include_filename)
-        conan_project_include_cmake = conan_project_include_cmake.replace("\\", "/")
-        t = Template(self._template_project_include)
-        content = t.render(**ctxt_project_include)
-        save(conan_project_include_cmake, content)
+            ctxt_toolchain.update({'conan_project_include_cmake': conan_project_include_cmake})
 
-        t = Template(self._template_toolchain)
-        content = t.render(conan_project_include_cmake=conan_project_include_cmake, **ctxt_toolchain)
+        t = env.get_template(self.filename)
+        content = t.render(**ctxt_toolchain)
         save(self.filename, content)

--- a/conans/client/toolchain/cmake/base.py
+++ b/conans/client/toolchain/cmake/base.py
@@ -105,7 +105,7 @@ class CMakeToolchainBase(object):
         {%- endif %}
 
         # Variables
-        {% for it, value in variables.items() -%}
+        {% for it, value in variables.items() %}
         set({{ it }} "{{ value }}")
         {%- endfor %}
         # Variables  per configuration

--- a/conans/client/toolchain/cmake/base.py
+++ b/conans/client/toolchain/cmake/base.py
@@ -133,9 +133,6 @@ class CMakeToolchainBase(object):
         {%- endfor %}
         # Preprocessor definitions per configuration
         {{ toolchain_macros.iterate_configs(preprocessor_definitions_config, action='add_definitions') }}
-
-        {% block footer %}
-        {% endblock %}
         """)
 
     def __init__(self, conanfile, **kwargs):

--- a/conans/client/toolchain/cmake/base.py
+++ b/conans/client/toolchain/cmake/base.py
@@ -1,8 +1,32 @@
 import os
+from collections import OrderedDict, defaultdict
 
 from jinja2 import Template
 
 from conans.util.files import save
+
+
+class Variables(OrderedDict):
+    _configuration_types = None  # Needed for py27 to avoid infinite recursion
+
+    def __init__(self):
+        super(Variables, self).__init__()
+        self._configuration_types = {}
+
+    def __getattribute__(self, config):
+        try:
+            return super(Variables, self).__getattribute__(config)
+        except AttributeError:
+            return self._configuration_types.setdefault(config, dict())
+
+    @property
+    def configuration_types(self):
+        # Reverse index for the configuration_types variables
+        ret = defaultdict(list)
+        for conf, definitions in self._configuration_types.items():
+            for k, v in definitions.items():
+                ret[k].append((conf, v))
+        return ret
 
 
 class CMakeToolchainBase(object):
@@ -14,24 +38,38 @@ class CMakeToolchainBase(object):
 
     def __init__(self, conanfile, *args, **kwargs):
         self._conanfile = conanfile
+        self.variables = Variables()
+        self.preprocessor_definitions = Variables()
+        try:
+            # This is only defined in the cache, not in the local flow
+            self.install_prefix = self._conanfile.package_folder.replace("\\", "/")
+        except AttributeError:
+            # FIXME: In the local flow, we don't know the package_folder
+            self.install_prefix = None
 
     def _get_template_context_data(self):
         """ Returns two dictionaries, the context for the '_template_toolchain' and
             the context for the '_template_project_include' templates.
         """
-        return {}, {}
+        ctxt_toolchain = {
+            "variables": self.variables,
+            "variables_config": self.variables.configuration_types,
+            "preprocessor_definitions": self.preprocessor_definitions,
+            "preprocessor_definitions_config": self.preprocessor_definitions.configuration_types,
+            "install_prefix": self.install_prefix,
+        }
+        return ctxt_toolchain, {}
 
     def write_toolchain_files(self):
-        tpl_toolchain_context, tpl_project_include_context = self._get_template_context_data()
+        ctxt_toolchain, ctxt_project_include = self._get_template_context_data()
 
         # Make it absolute, wrt to current folder, set by the caller
         conan_project_include_cmake = os.path.abspath(self.project_include_filename)
         conan_project_include_cmake = conan_project_include_cmake.replace("\\", "/")
         t = Template(self._template_project_include)
-        content = t.render(**tpl_project_include_context)
+        content = t.render(**ctxt_project_include)
         save(conan_project_include_cmake, content)
 
         t = Template(self._template_toolchain)
-        content = t.render(conan_project_include_cmake=conan_project_include_cmake,
-                           **tpl_toolchain_context)
+        content = t.render(conan_project_include_cmake=conan_project_include_cmake, **ctxt_toolchain)
         save(self.filename, content)

--- a/conans/client/toolchain/cmake/generic.py
+++ b/conans/client/toolchain/cmake/generic.py
@@ -18,18 +18,13 @@ class CMakeGenericToolchain(CMakeToolchainBase):
         {% extends 'base_toolchain' %}
 
         {% block before_try_compile %}
+            {{ super() }}
             {% if generator_platform %}set(CMAKE_GENERATOR_PLATFORM "{{ generator_platform }}" CACHE STRING "" FORCE){% endif %}
             {% if toolset %}set(CMAKE_GENERATOR_TOOLSET "{{ toolset }}" CACHE STRING "" FORCE){% endif %}
-            {# build_type (Release, Debug, etc) is only defined for single-config generators #}
-            {% if build_type %}set(CMAKE_BUILD_TYPE "{{ build_type }}" CACHE STRING "Choose the type of build." FORCE){% endif %}
         {% endblock %}
 
         {% block main %}
-            set(CMAKE_EXPORT_NO_PACKAGE_REGISTRY ON)
-
-            # To support the cmake_find_package generators
-            set(CMAKE_MODULE_PATH {{ cmake_module_path }} ${CMAKE_MODULE_PATH})
-            set(CMAKE_PREFIX_PATH {{ cmake_prefix_path }} ${CMAKE_PREFIX_PATH})
+            {{ super() }}
 
             {% if shared_libs -%}
                 message(STATUS "Conan toolchain: Setting BUILD_SHARED_LIBS= {{ shared_libs }}")
@@ -126,10 +121,6 @@ class CMakeGenericToolchain(CMakeToolchainBase):
         self.fpic = self._deduce_fpic()
         self.vs_static_runtime = self._deduce_vs_static_runtime()
         self.parallel = parallel
-
-        # To find the generated cmake_find_package finders
-        self.cmake_prefix_path = "${CMAKE_BINARY_DIR}"
-        self.cmake_module_path = "${CMAKE_BINARY_DIR}"
 
         self.generator = generator or get_generator(self._conanfile)
         self.generator_platform = (generator_platform or
@@ -238,11 +229,8 @@ class CMakeGenericToolchain(CMakeToolchainBase):
         ctxt_toolchain, ctxt_project_include = \
             super(CMakeGenericToolchain, self)._get_template_context_data()
         ctxt_toolchain.update({
-            "build_type": self.build_type,
             "generator_platform": self.generator_platform,
             "toolset": self.toolset,
-            "cmake_prefix_path": self.cmake_prefix_path,
-            "cmake_module_path": self.cmake_module_path,
             "fpic": self.fpic,
             "skip_rpath": self.skip_rpath,
             "set_libcxx": self.set_libcxx,

--- a/conans/client/toolchain/cmake/generic.py
+++ b/conans/client/toolchain/cmake/generic.py
@@ -67,9 +67,7 @@ class CMakeGenericToolchain(CMakeToolchainBase):
                 set(CMAKE_CXX_STANDARD {{ cppstd }})
                 set(CMAKE_CXX_EXTENSIONS {{ cppstd_extensions }})
             {%- endif %}
-        {% endblock %}
 
-        {% block footer %}
             set(CMAKE_CXX_FLAGS_INIT "${CONAN_CXX_FLAGS}" CACHE STRING "" FORCE)
             set(CMAKE_C_FLAGS_INIT "${CONAN_C_FLAGS}" CACHE STRING "" FORCE)
             set(CMAKE_SHARED_LINKER_FLAGS_INIT "${CONAN_SHARED_LINKER_FLAGS}" CACHE STRING "" FORCE)

--- a/conans/client/toolchain/cmake/generic.py
+++ b/conans/client/toolchain/cmake/generic.py
@@ -14,17 +14,7 @@ from .base import CMakeToolchainBase
 
 
 class CMakeGenericToolchain(CMakeToolchainBase):
-    _template_toolchain = textwrap.dedent("""
-        # Conan automatically generated toolchain file
-        # DO NOT EDIT MANUALLY, it will be overwritten
-
-        # Avoid including toolchain file several times (bad if appending to variables like
-        #   CMAKE_CXX_FLAGS. See https://github.com/android/ndk/issues/323
-        if(CONAN_TOOLCHAIN_INCLUDED)
-          return()
-        endif()
-        set(CONAN_TOOLCHAIN_INCLUDED TRUE)
-
+    _before_try_compile_tpl = textwrap.dedent("""
         # Configure
         {%- if generator_platform %}
         set(CMAKE_GENERATOR_PLATFORM "{{ generator_platform }}" CACHE STRING "" FORCE)
@@ -37,32 +27,9 @@ class CMakeGenericToolchain(CMakeToolchainBase):
         {%- if build_type %}
         set(CMAKE_BUILD_TYPE "{{ build_type }}" CACHE STRING "Choose the type of build." FORCE)
         {%- endif %}
+        """)
 
-        get_property( _CMAKE_IN_TRY_COMPILE GLOBAL PROPERTY IN_TRY_COMPILE )
-        if(_CMAKE_IN_TRY_COMPILE)
-            message(STATUS "Running toolchain IN_TRY_COMPILE")
-            return()
-        endif()
-
-        message("Using Conan toolchain through ${CMAKE_TOOLCHAIN_FILE}.")
-
-        if(CMAKE_VERSION VERSION_LESS "3.15")
-            message(WARNING
-                " CMake version less than 3.15 doesn't support CMAKE_PROJECT_INCLUDE variable\\n"
-                " used by Conan toolchain to work. In order to get the same behavior you will\\n"
-                " need to manually include the generated file after your 'project()' call in the\\n"
-                " main CMakeLists.txt file:\\n"
-                " \\n"
-                "     project(YourProject C CXX)\\n"
-                "     include(\\"\\${CMAKE_BINARY_DIR}/conan_project_include.cmake\\")\\n"
-                " \\n"
-                " This file contains some definitions and extra adjustments that depend on\\n"
-                " the build_type and it cannot be done in the toolchain.")
-        else()
-            # Will be executed after the 'project()' command
-            set(CMAKE_PROJECT_INCLUDE "{{ conan_project_include_cmake }}")
-        endif()
-
+    _main_tpl = textwrap.dedent("""
         # We are going to adjust automagically many things as requested by Conan
         #   these are the things done by 'conan_basic_setup()'
         set(CMAKE_EXPORT_NO_PACKAGE_REGISTRY ON)
@@ -123,55 +90,28 @@ class CMakeGenericToolchain(CMakeToolchainBase):
         set(CMAKE_CXX_STANDARD {{ cppstd }})
         set(CMAKE_CXX_EXTENSIONS {{ cppstd_extensions }})
         {%- endif %}
+        """)
 
-        # Install prefix
-        {% if install_prefix -%}
-        set(CMAKE_INSTALL_PREFIX {{install_prefix}} CACHE STRING "" FORCE)
-        {%- endif %}
+    _toolchain_tpl = textwrap.dedent("""
+        {% extends 'base_toolchain' %}
 
-        # Variables
-        {% for it, value in variables.items() -%}
-        set({{ it }} "{{ value }}")
-        {%- endfor %}
-        # Variables  per configuration
-        {% for it, values in variables_config.items() -%}
-            {%- set genexpr = namespace(str='') %}
-            {%- for conf, value in values -%}
-                {%- set genexpr.str = genexpr.str +
-                                      '$<IF:$<CONFIG:' + conf + '>,"' + value|string + '",' %}
-                {%- if loop.last %}{% set genexpr.str = genexpr.str + '""' -%}{%- endif -%}
-            {%- endfor -%}
-            {% for i in range(values|count) %}{%- set genexpr.str = genexpr.str + '>' %}
-            {%- endfor -%}
-        set({{ it }} {{ genexpr.str }})
-        {%- endfor %}
+        {% block before_try_compile %}
+        {% include 'before_try_compile' %}
+        {% endblock %}
 
-        # Preprocessor definitions
-        {% for it, value in preprocessor_definitions.items() -%}
-        # add_compile_definitions only works in cmake >= 3.12
-        add_definitions(-D{{ it }}="{{ value }}")
-        {%- endfor %}
-        # Preprocessor definitions per configuration
-        {% for it, values in preprocessor_definitions_config.items() -%}
-            {%- set genexpr = namespace(str='') %}
-            {%- for conf, value in values -%}
-                {%- set genexpr.str = genexpr.str +
-                                      '$<IF:$<CONFIG:' + conf + '>,"' + value|string + '",' %}
-                {%- if loop.last %}{% set genexpr.str = genexpr.str + '""' -%}{%- endif -%}
-            {%- endfor -%}
-            {% for i in range(values|count) %}{%- set genexpr.str = genexpr.str + '>' %}
-            {%- endfor -%}
-        add_definitions(-D{{ it }}={{ genexpr.str }})
-        {%- endfor %}
+        {% block main %}
+        {% include 'main' %}
+        {% endblock %}
 
-
+        {% block footer %}
         set(CMAKE_CXX_FLAGS_INIT "${CONAN_CXX_FLAGS}" CACHE STRING "" FORCE)
         set(CMAKE_C_FLAGS_INIT "${CONAN_C_FLAGS}" CACHE STRING "" FORCE)
         set(CMAKE_SHARED_LINKER_FLAGS_INIT "${CONAN_SHARED_LINKER_FLAGS}" CACHE STRING "" FORCE)
         set(CMAKE_EXE_LINKER_FLAGS_INIT "${CONAN_EXE_LINKER_FLAGS}" CACHE STRING "" FORCE)
-    """)
+        {% endblock %}
+        """)
 
-    _template_project_include = textwrap.dedent("""
+    _project_include_filename_tpl = textwrap.dedent("""
         # When using a Conan toolchain, this file is included as the last step of `project()` calls.
         #  https://cmake.org/cmake/help/latest/variable/CMAKE_PROJECT_INCLUDE.html
 
@@ -206,7 +146,7 @@ class CMakeGenericToolchain(CMakeToolchainBase):
             endforeach()
         endif()
         {% endif %}
-    """)
+        """)
 
     def __init__(self, conanfile, generator=None, generator_platform=None, build_type=None,
                  toolset=None, parallel=True):
@@ -246,6 +186,16 @@ class CMakeGenericToolchain(CMakeToolchainBase):
         # TODO: I would want to have here the path to the compiler too
         build_type = build_type or self._conanfile.settings.get_safe("build_type")
         self.build_type = build_type if not is_multi_configuration(self.generator) else None
+
+    def _get_templates(self):
+        templates = super(CMakeGenericToolchain, self)._get_templates()
+        templates.update({
+            'before_try_compile': self._before_try_compile_tpl,
+            'main': self._main_tpl,
+            CMakeToolchainBase.filename: self._toolchain_tpl,
+            CMakeToolchainBase.project_include_filename: self._project_include_filename_tpl
+        })
+        return templates
 
     def _deduce_fpic(self):
         fpic = self._conanfile.options.get_safe("fPIC")


### PR DESCRIPTION
Changelog: omit
Docs: omit

~~After https://github.com/conan-io/conan/pull/7850~~

We can take some advantage of Jinja to organize the templates for the toolchains. More can be done, but I prefer to wait until we have other toolchains.

 * There is a `base_toolchain` in the parent class that _writes_ the variables that belong to the parent class (those that were moved in #7850).
 * The base `base_toolchain` template provides three blocks to add more data to the toolchain file (we should argue if these blocks are needed, but it is what we have right now):
   + `before_try_compile`: all configuration that is taken into account for every try-compile work
   + `main`: all configuration that is taken into account only for the project to build
   + `footer`: a placeholder after variables and preprocessor definitions (probably it can be removed in favor of `main`).
 * Child toolchains can extend that base template an populate the required blocks:

   + `CMakeGenericToolchain` is including some external templates for `before_try_compile` and `main` block while defining the block `footer` in the template (the difference is more for demo purpose than something needed):

       ```
       {% extends 'base_toolchain' %}

       {% block before_try_compile %}
       {% include 'before_try_compile' %}
       {% endblock %}

       {% block main %}
       {% include 'main' %}
       {% endblock %}

       {% block footer %}
       set(CMAKE_CXX_FLAGS_INIT "${CONAN_CXX_FLAGS}" CACHE STRING "" FORCE)
       set(CMAKE_C_FLAGS_INIT "${CONAN_C_FLAGS}" CACHE STRING "" FORCE)
       set(CMAKE_SHARED_LINKER_FLAGS_INIT "${CONAN_SHARED_LINKER_FLAGS}" CACHE STRING "" FORCE)
       set(CMAKE_EXE_LINKER_FLAGS_INIT "${CONAN_EXE_LINKER_FLAGS}" CACHE STRING "" FORCE)
       {% endblock %}
       ```

   + `CMakeAndroidToolchain` will [define everything in the template file](https://github.com/conan-io/conan/pull/7843/files#diff-20e8dfdd1e3b1978c7fcd373efc8f17aR7) (WIP) adding nothing to the `before_try_compile` block:

      ```
        {% extends 'base_toolchain' %}

        {% block main %}
        {{ super() }}

        # shared libs
        {% if shared_libs -%}
        message(STATUS "Conan toolchain: Setting BUILD_SHARED_LIBS= {{ shared_libs }}")
        set(BUILD_SHARED_LIBS {{ shared_libs }})
        {%- endif %}

        # Parallel builds
        {% if parallel -%}
        set(CONAN_CXX_FLAGS "${CONAN_CXX_FLAGS} {{ parallel }}")
        set(CONAN_C_FLAGS "${CONAN_C_FLAGS} {{ parallel }}")
        {%- endif %}

        # C++ Standard
        {% if cppstd -%}
        message(STATUS "Conan C++ Standard {{ cppstd }} with extensions {{ cppstd_extensions }}}")
        set(CMAKE_CXX_STANDARD {{ cppstd }})
        set(CMAKE_CXX_EXTENSIONS {{ cppstd_extensions }})
        {%- endif %}
        {% endblock %}

        {% block footer %}
        set(CMAKE_CXX_FLAGS_INIT "${CONAN_CXX_FLAGS}" CACHE STRING "" FORCE)
        set(CMAKE_C_FLAGS_INIT "${CONAN_C_FLAGS}" CACHE STRING "" FORCE)
        set(CMAKE_SHARED_LINKER_FLAGS_INIT "${CONAN_SHARED_LINKER_FLAGS}" CACHE STRING "" FORCE)
        set(CMAKE_EXE_LINKER_FLAGS_INIT "${CONAN_EXE_LINKER_FLAGS}" CACHE STRING "" FORCE)
        {% endblock %}
      ```

In the future, with a better understanding of the toolchains and the variables they need/use, we can iterate this templates and simplify them or move them to the specific mixin that will take care of the information.