### PR TITLE
add tests to support Make toolchain with mingw on windows

### DIFF
--- a/conans/client/toolchain/make.py
+++ b/conans/client/toolchain/make.py
@@ -119,11 +119,10 @@ class MakeToolchain(object):
         # Call this function in your Makefile to have Conan variables added to the standard variables
         # Example:  $(call CONAN_TC_SETUP)
 
-        CONAN_TC_SETUP =  \\
-            $(eval CFLAGS += $(CONAN_TC_CFLAGS)) ; \\
-            $(eval CXXFLAGS += $(CONAN_TC_CXXFLAGS)) ; \\
-            $(eval CPPFLAGS += $(CONAN_TC_CPPFLAGS)) ; \\
-            $(eval LDFLAGS += $(CONAN_TC_LDFLAGS)) ;
+        CONAN_TC_SETUP = $(eval CFLAGS += $(CONAN_TC_CFLAGS)) ; \\
+                         $(eval CXXFLAGS += $(CONAN_TC_CXXFLAGS)) ; \\
+                         $(eval CPPFLAGS += $(CONAN_TC_CPPFLAGS)) ; \\
+                         $(eval LDFLAGS += $(CONAN_TC_LDFLAGS)) ;
 
     """)
 

--- a/conans/test/functional/toolchain/test_make.py
+++ b/conans/test/functional/toolchain/test_make.py
@@ -6,6 +6,7 @@ import unittest
 from nose.plugins.attrib import attr
 
 from conans.test.utils.tools import TestClient
+from conans.client.tools import which
 
 from parameterized.parameterized import parameterized
 
@@ -184,6 +185,7 @@ class MakeToolchainTest(unittest.TestCase):
         ("static", "Release"),
     ])
     @unittest.skipUnless(platform.system() in ["Windows"], "Requires mingw32-make")
+    @unittest.skipIf(which("mingw32-make") is None, "Needs mingw32-make")
     def test_toolchain_windows(self, target, build_type):
         client = TestClient(path_with_spaces=False)
 

--- a/conans/test/functional/toolchain/test_make.py
+++ b/conans/test/functional/toolchain/test_make.py
@@ -12,19 +12,20 @@ from parameterized.parameterized import parameterized
 
 @attr("slow")
 @attr("toolchain")
-@unittest.skipUnless(platform.system() == "Linux", "Only for Linux")
-class LinuxTest(unittest.TestCase):
-    @parameterized.expand([("exe", "Release"),
-                           ("exe", "Debug"),
-                           ("exe", "Release"),
-                           ("shared", "Release"),
-                           ("static", "Release"),
-                           ])
-    def test_toolchain_linux(self, target, build_type):
+class MakeToolchainTest(unittest.TestCase):
+    @parameterized.expand([
+        ("exe", "Release"),
+        ("exe", "Debug"),
+        ("exe", "Release"),
+        ("shared", "Release"),
+        ("static", "Release"),
+    ])
+    @unittest.skipUnless(platform.system() in ["Linux", "Macos"], "Requires make")
+    def test_toolchain_posix(self, target, build_type):
         client = TestClient(path_with_spaces=False)
 
         settings = {
-            "build_type": build_type
+            "build_type": build_type,
         }
         options = {
             "fPIC": "True",
@@ -173,4 +174,171 @@ class LinuxTest(unittest.TestCase):
         elif target == "static":
             client.run_command("make static")
             client.run_command("nm -C out/libhello.a | grep 'hello()'")
+            self.assertIn("hello()", client.out)
+
+    @parameterized.expand([
+        ("exe", "Release"),
+        ("exe", "Debug"),
+        ("exe", "Release"),
+        ("shared", "Release"),
+        ("static", "Release"),
+    ])
+    @unittest.skipUnless(platform.system() in ["Windows"], "Requires mingw32-make")
+    def test_toolchain_windows(self, target, build_type):
+        client = TestClient(path_with_spaces=False)
+
+        settings = {
+            "arch": "x86",
+            "build_type": build_type,
+            "compiler": "gcc",
+            "compiler.version": "9",
+            "compiler.libcxx": "libstdc++11",
+        }
+        options = {
+            "fPIC": "True",
+        }
+
+        if target == "exe":
+            conanfile_options = 'options = {"fPIC": [True, False]}'
+            conanfile_default_options = 'default_options = {"fPIC": True}'
+        else:
+            conanfile_options = 'options = {"shared": [True, False], "fPIC": [True, False]}'
+            conanfile_default_options = 'default_options = {"shared": False, "fPIC": True}'
+            if target == "shared":
+                options["shared"] = True
+
+        settings_str = " ".join('-s %s="%s"' % (k, v) for k, v in settings.items() if v)
+        options_str = " ".join("-o %s=%s" % (k, v) for k, v in options.items()) if options else ""
+
+        conanfile = textwrap.dedent("""
+            from conans import ConanFile, MakeToolchain
+            class App(ConanFile):
+                settings = "os", "arch", "compiler", "build_type"
+                {options}
+                {default_options}
+                def toolchain(self):
+                    tc = MakeToolchain(self)
+                    tc.variables["TEST_VAR"] = "TestVarValue"
+                    tc.preprocessor_definitions["TEST_DEFINITION"] = "TestPpdValue"
+                    tc.write_toolchain_files()
+
+                def build(self):
+                    self.run("make -C ..")
+
+            """).format(options=conanfile_options, default_options=conanfile_default_options)
+
+        hello_h = textwrap.dedent("""
+            #pragma once
+            #define HELLO_MSG "{0}"
+            #ifdef WIN32
+              #define APP_LIB_EXPORT __declspec(dllexport)
+            #else
+              #define APP_LIB_EXPORT
+            #endif
+            APP_LIB_EXPORT void hello();
+            """.format(build_type))
+
+        hello_cpp = textwrap.dedent("""
+            #include <iostream>
+            #include "hello.h"
+
+            void hello() {
+                std::cout << "Hello World " << HELLO_MSG << "!" << std::endl;
+                #ifdef NDEBUG
+                std::cout << "App: Release!" << std::endl;
+                #else
+                std::cout << "App: Debug!" << std::endl;
+                #endif
+                std::cout << "TEST_DEFINITION: " << TEST_DEFINITION << "\\n";
+            }
+            """)
+
+        # only used for the executable test case
+        main = textwrap.dedent("""
+            #include "hello.h"
+            int main() {
+                hello();
+            }
+            """)
+
+        makefile = textwrap.dedent("""
+            include conan_toolchain.mak
+
+            #-------------------------------------------------
+            #     Make variables for a sample App
+            #-------------------------------------------------
+
+            OUT_DIR             ?= out
+            SRC_DIR             ?= src
+            INCLUDE_DIR         ?= include
+
+            PROJECT_NAME        = hello
+            EXE_FILENAME        = $(PROJECT_NAME).bin
+            STATIC_LIB_FILENAME = lib$(PROJECT_NAME).a
+            SHARED_LIB_FILENAME = lib$(PROJECT_NAME).so
+
+            SRCS                += $(wildcard $(SRC_DIR)/*.cpp)
+            OBJS                += $(patsubst $(SRC_DIR)/%.cpp,$(OUT_DIR)/%.o,$(SRCS))
+            CPPFLAGS            += $(addprefix -I,$(INCLUDE_DIR))
+
+            #-------------------------------------------------
+            #     Append CONAN_ variables to standards
+            #-------------------------------------------------
+
+            $(call CONAN_TC_SETUP)
+
+            # The above function should append CONAN_TC flags to standard flags
+            $(info >> CFLAGS: $(CFLAGS))
+            $(info >> CXXFLAGS: $(CXXFLAGS))
+            $(info >> CPPFLAGS: $(CPPFLAGS))
+            $(info >> LDFLAGS: $(LDFLAGS))
+            $(info >> LDLIBS: $(LDLIBS))
+            $(info >> TEST_VAR: $(TEST_VAR))
+
+            #-------------------------------------------------
+            #     Make Rules
+            #-------------------------------------------------
+
+
+            .PHONY               : exe static shared
+
+            exe                  : $(OBJS)
+            	$(CXX) -v $(OBJS) $(LDFLAGS) $(LDLIBS) -o $(OUT_DIR)/$(EXE_FILENAME)
+
+            static               : $(OBJS)
+            	$(AR) $(ARFLAGS) $(OUT_DIR)/$(STATIC_LIB_FILENAME) $(OBJS)
+
+            shared               : $(OBJS)
+            	$(CXX) -shared $(OBJS) $(LDFLAGS) $(LDLIBS) -o $(OUT_DIR)/$(SHARED_LIB_FILENAME)
+
+            $(OUT_DIR)/%.o       : $(SRC_DIR)/%.cpp $(OUT_DIR)
+            	$(CXX) $(CXXFLAGS) $(CPPFLAGS) -c $< -o $@
+
+            $(OUT_DIR):
+            	-mkdir $@
+            """)
+
+        files_to_save = {
+            "conanfile.py": conanfile,
+            "Makefile": makefile,
+            "src/hello.cpp": hello_cpp,
+            "include/hello.h": hello_h
+        }
+        if target == "exe":
+            files_to_save["src/main.cpp"] = main
+
+        client.save(files_to_save, clean_first=True)
+        client.run("install . hello/0.1@ %s %s" % (settings_str, options_str))
+
+        if target == "exe":
+            client.run_command("mingw32-make exe")
+            client.run_command("out\\hello.bin")
+            self.assertIn("Hello World {}!".format(build_type), client.out)
+        elif target == "shared":
+            client.run_command("mingw32-make shared")
+            client.run_command("nm -C out/libhello.so | find \"hello()\"")
+            self.assertIn("hello()", client.out)
+        elif target == "static":
+            client.run_command("mingw32-make static")
+            client.run_command("nm -C out/libhello.a | find \"hello()\"")
             self.assertIn("hello()", client.out)

--- a/conans/test/functional/toolchain/test_make.py
+++ b/conans/test/functional/toolchain/test_make.py
@@ -10,6 +10,8 @@ from conans.client.tools import which
 
 from parameterized.parameterized import parameterized
 
+from conans.util.files import mkdir
+
 
 @attr("slow")
 @attr("toolchain")
@@ -190,7 +192,7 @@ class MakeToolchainTest(unittest.TestCase):
         client = TestClient(path_with_spaces=False)
 
         settings = {
-            "arch": "x86",
+            "arch": "x86_64",
             "build_type": build_type,
             "compiler": "gcc",
             "compiler.version": "9",
@@ -332,6 +334,7 @@ class MakeToolchainTest(unittest.TestCase):
         client.save(files_to_save, clean_first=True)
         client.run("install . hello/0.1@ %s %s" % (settings_str, options_str))
 
+        mkdir(os.path.join(client.current_folder, "out"))
         if target == "exe":
             client.run_command("mingw32-make exe")
             client.run_command("out\\hello.bin")

--- a/conans/test/unittests/client/toolchain/test_make.py
+++ b/conans/test/unittests/client/toolchain/test_make.py
@@ -84,11 +84,10 @@ endif
 # Call this function in your Makefile to have Conan variables added to the standard variables
 # Example:  $(call CONAN_TC_SETUP)
 
-CONAN_TC_SETUP =  \\
-    $(eval CFLAGS += $(CONAN_TC_CFLAGS)) ; \\
-    $(eval CXXFLAGS += $(CONAN_TC_CXXFLAGS)) ; \\
-    $(eval CPPFLAGS += $(CONAN_TC_CPPFLAGS)) ; \\
-    $(eval LDFLAGS += $(CONAN_TC_LDFLAGS)) ;
+CONAN_TC_SETUP = $(eval CFLAGS += $(CONAN_TC_CFLAGS)) ; \\
+                 $(eval CXXFLAGS += $(CONAN_TC_CXXFLAGS)) ; \\
+                 $(eval CPPFLAGS += $(CONAN_TC_CPPFLAGS)) ; \\
+                 $(eval LDFLAGS += $(CONAN_TC_LDFLAGS)) ;
 """)
 
 EXPECTED_OUT_2 = textwrap.dedent("""
@@ -137,11 +136,10 @@ endif
 # Call this function in your Makefile to have Conan variables added to the standard variables
 # Example:  $(call CONAN_TC_SETUP)
 
-CONAN_TC_SETUP =  \\
-    $(eval CFLAGS += $(CONAN_TC_CFLAGS)) ; \\
-    $(eval CXXFLAGS += $(CONAN_TC_CXXFLAGS)) ; \\
-    $(eval CPPFLAGS += $(CONAN_TC_CPPFLAGS)) ; \\
-    $(eval LDFLAGS += $(CONAN_TC_LDFLAGS)) ;
+CONAN_TC_SETUP = $(eval CFLAGS += $(CONAN_TC_CFLAGS)) ; \\
+                 $(eval CXXFLAGS += $(CONAN_TC_CXXFLAGS)) ; \\
+                 $(eval CPPFLAGS += $(CONAN_TC_CPPFLAGS)) ; \\
+                 $(eval LDFLAGS += $(CONAN_TC_LDFLAGS)) ;
 """)
 
 EXPECTED_OUT_3 = textwrap.dedent("""
@@ -193,11 +191,10 @@ endif
 # Call this function in your Makefile to have Conan variables added to the standard variables
 # Example:  $(call CONAN_TC_SETUP)
 
-CONAN_TC_SETUP =  \\
-    $(eval CFLAGS += $(CONAN_TC_CFLAGS)) ; \\
-    $(eval CXXFLAGS += $(CONAN_TC_CXXFLAGS)) ; \\
-    $(eval CPPFLAGS += $(CONAN_TC_CPPFLAGS)) ; \\
-    $(eval LDFLAGS += $(CONAN_TC_LDFLAGS)) ;
+CONAN_TC_SETUP = $(eval CFLAGS += $(CONAN_TC_CFLAGS)) ; \\
+                 $(eval CXXFLAGS += $(CONAN_TC_CXXFLAGS)) ; \\
+                 $(eval CPPFLAGS += $(CONAN_TC_CPPFLAGS)) ; \\
+                 $(eval LDFLAGS += $(CONAN_TC_LDFLAGS)) ;
 """)
 
 EXPECTED_OUT_4 = textwrap.dedent("""
@@ -250,15 +247,13 @@ endif
 # Call this function in your Makefile to have Conan variables added to the standard variables
 # Example:  $(call CONAN_TC_SETUP)
 
-CONAN_TC_SETUP =  \\
-    $(eval CFLAGS += $(CONAN_TC_CFLAGS)) ; \\
-    $(eval CXXFLAGS += $(CONAN_TC_CXXFLAGS)) ; \\
-    $(eval CPPFLAGS += $(CONAN_TC_CPPFLAGS)) ; \\
-    $(eval LDFLAGS += $(CONAN_TC_LDFLAGS)) ;
+CONAN_TC_SETUP = $(eval CFLAGS += $(CONAN_TC_CFLAGS)) ; \\
+                 $(eval CXXFLAGS += $(CONAN_TC_CXXFLAGS)) ; \\
+                 $(eval CPPFLAGS += $(CONAN_TC_CPPFLAGS)) ; \\
+                 $(eval LDFLAGS += $(CONAN_TC_LDFLAGS)) ;
 """)
 
 
-@unittest.skipUnless(platform.system() == "Linux", "Only for Linux")
 class MakeToolchainTest(unittest.TestCase):
     @parameterized.expand([
         ("Debug", "x86", "gcc", "9", "14", "libstdc++", False, False, EXPECTED_OUT_1),
@@ -266,7 +261,8 @@ class MakeToolchainTest(unittest.TestCase):
         ("Release", "x86_64", "clang", "8.0", "20", "libc++", True, True, EXPECTED_OUT_3),
         ("Release", "x86_64", "clang", "8.0", "20", "libstdc++11", True, True, EXPECTED_OUT_4),
     ])
-    def test_toolchain_linux(self, build_type, arch, compiler, compiler_ver, compiler_cppstd,
+    @unittest.skipUnless(platform.system() in ["Linux", "Macos"], "Requires make")
+    def test_toolchain_posix(self, build_type, arch, compiler, compiler_ver, compiler_cppstd,
                              compiler_libcxx, shared, fpic, expected):
 
         settings_mock = _MockSettings(build_type, arch, compiler, compiler_ver, compiler_cppstd,


### PR DESCRIPTION
Resolves https://github.com/conan-io/conan/issues/7813
- it nearly worked out of the box
- had to reformat `CONAN_BASIC_SETUP` macro because mingw32-make didn't support existing format
- update test accordingly
- add functional test for windows, assumes mingw32 is installed

Changelog: Feature : Add tests to support for using the maketoolchain in mingw
Docs: omit

#tags: slow

- [x] Refer to the issue that supports this Pull Request.
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [x] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 
