### PR TITLE
Fix/lockfile options base

### DIFF
--- a/conans/model/graph_lock.py
+++ b/conans/model/graph_lock.py
@@ -228,7 +228,8 @@ class GraphLockNode(object):
         if python_requires:
             python_requires = [ConanFileReference.loads(py_req, validate=False)
                                for py_req in python_requires]
-        options = OptionsValues.loads(data.get("options", ""))
+        options = data.get("options")
+        options = OptionsValues.loads(options) if options else None
         modified = data.get("modified")
         context = data.get("context")
         requires = data.get("requires", [])
@@ -491,8 +492,8 @@ class GraphLock(object):
                                      % (node.ref, node.id))
         else:
             node.graph_lock_node = locked_node
-            node.conanfile.options.values = locked_node.options
-            if locked_node.package_id is not None:  # This was not a "base" one, but a partial one
+            if locked_node.options is not None:  # This was a "partial" one, not a "base" one
+                node.conanfile.options.values = locked_node.options
                 node.conanfile.options.freeze()
 
     def lock_node(self, node, requires, build_requires=False):

--- a/conans/model/graph_lock.py
+++ b/conans/model/graph_lock.py
@@ -492,7 +492,8 @@ class GraphLock(object):
         else:
             node.graph_lock_node = locked_node
             node.conanfile.options.values = locked_node.options
-            node.conanfile.options.freeze()
+            if locked_node.package_id is not None:  # This was not a "base" one, but a partial one
+                node.conanfile.options.freeze()
 
     def lock_node(self, node, requires, build_requires=False):
         """ apply options and constraints on requirements of a node, given the information from

--- a/conans/test/functional/graph_lock/graph_lock_test.py
+++ b/conans/test/functional/graph_lock/graph_lock_test.py
@@ -372,6 +372,21 @@ class LockFileOptionsTest(unittest.TestCase):
         client.run("create ffmepg ffmpeg/1.0@ --build --lockfile=conan.lock")
         self.assertIn("ffmpeg/1.0: Requirements: Variation nano!!", client.out)
 
+    def test_base_options(self):
+        client = TestClient()
+        client.save({"conanfile.py": GenConanfile().with_option("shared", [True, False])
+                                                   .with_default_option("shared", False)})
+        client.run("create . pkg/0.1@")
+        client.run("lock create --reference=pkg/0.1 --base --lockfile-out=pkg_base.lock")
+        client.run("lock create --reference=pkg/0.1 --lockfile=pkg_base.lock "
+                   "--lockfile-out=pkg.lock -o pkg:shared=True")
+        pkg_lock = client.load("pkg.lock")
+        self.assertIn('"options": "shared=True"', pkg_lock)
+        client.run("lock create --reference=pkg/0.1 --lockfile=pkg_base.lock "
+                   "--lockfile-out=pkg.lock -o pkg:shared=False")
+        pkg_lock = client.load("pkg.lock")
+        self.assertIn('"options": "shared=False"', pkg_lock)
+
 
 class GraphInstallArgumentsUpdated(unittest.TestCase):
 


### PR DESCRIPTION
Changelog: Bugfix: Allow defining new options values when creating a new lockfile from an existing base lockfile.
Docs: Omit
