### PR TITLE
fix regression in imports due to incorrect pattern matching of backslash in Win

### DIFF
--- a/conans/client/importer.py
+++ b/conans/client/importer.py
@@ -137,7 +137,7 @@ class _FileImporter(object):
         self.copied_files = set()
 
     def __call__(self, pattern, dst="", src="", root_package=None, folder=False,
-                 ignore_case=False, excludes=None, keep_path=True):
+                 ignore_case=True, excludes=None, keep_path=True):
         """
         param pattern: an fnmatch file pattern of the files that should be copied. Eg. *.dll
         param dst: the destination local folder, wrt to current conanfile dir, to which

--- a/conans/test/functional/conanfile/imports_tests.py
+++ b/conans/test/functional/conanfile/imports_tests.py
@@ -214,12 +214,16 @@ bin, *.dll ->  @ excludes=Foo/*.dll Baz/*.dll
         client.run("create . pkg/0.1@")
         consumer_conanfile = textwrap.dedent("""
             from conans import ConanFile
+            import platform
 
             class TestConan(ConanFile):
                 requires = "pkg/0.1"
 
                 def imports(self):
-                    self.copy("licenses\\LICENSE", dst="deps_licenses", root_package="pkg")
+                    if platform.system() == "Windows":
+                        self.copy("licenses\\LICENSE", dst="deps_licenses", root_package="pkg")
+                    else:
+                        self.copy("licenses/LICENSE", dst="deps_licenses", root_package="pkg")
                     self.copy("licenses/README", dst="deps_licenses", root_package="pkg")
             """)
         client.save({"conanfile.py": consumer_conanfile})

--- a/conans/test/functional/conanfile/imports_tests.py
+++ b/conans/test/functional/conanfile/imports_tests.py
@@ -1,4 +1,5 @@
 import os
+import textwrap
 import unittest
 
 from conans.model.ref import ConanFileReference, PackageReference
@@ -195,3 +196,35 @@ bin, *.dll ->  @ excludes=Foo/*.dll Baz/*.dll
         client.run("install . --build=missing")
         self.assertTrue(os.path.exists(os.path.join(client.current_folder, "licenses")))
         self.assertTrue(os.path.exists(os.path.join(client.current_folder, "licenses/license.txt")))
+
+    def test_wrong_path_sep(self):
+        # https://github.com/conan-io/conan/issues/7856
+        pkg_conanfile = textwrap.dedent("""
+            from conans import ConanFile
+            from conans.tools import save
+            import os
+
+            class TestConan(ConanFile):
+                def package(self):
+                    save(os.path.join(self.package_folder, "licenses/LICENSE"), "mylicense in file")
+                    save(os.path.join(self.package_folder, "licenses/README"), "myreadme in file")
+            """)
+        client = TestClient()
+        client.save({"conanfile.py": pkg_conanfile})
+        client.run("create . pkg/0.1@")
+        consumer_conanfile = textwrap.dedent("""
+            from conans import ConanFile
+
+            class TestConan(ConanFile):
+                requires = "pkg/0.1"
+
+                def imports(self):
+                    self.copy("licenses\\LICENSE", dst="deps_licenses", root_package="pkg")
+                    self.copy("licenses/README", dst="deps_licenses", root_package="pkg")
+            """)
+        client.save({"conanfile.py": consumer_conanfile})
+        client.run("install .")
+        pkg_license = client.load("deps_licenses/licenses/LICENSE")
+        self.assertEqual(pkg_license, "mylicense in file")
+        readme_license = client.load("deps_licenses/licenses/README")
+        self.assertEqual(readme_license, "myreadme in file")


### PR DESCRIPTION
Changelog: Bugfix: Fix regression https://github.com/conan-io/conan/issues/7856, ``imports`` failing to match subfolders in Windows due to backslash differences.
Docs: Omit

Close https://github.com/conan-io/conan/issues/7856
