### PR TITLE
Autotools adds apple deployement target flag

### DIFF
--- a/conans/client/build/autotools_environment.py
+++ b/conans/client/build/autotools_environment.py
@@ -11,6 +11,7 @@ from conans.client.build.compiler_flags import (architecture_flag, build_type_de
                                                 format_frameworks, format_framework_paths)
 from conans.client.build.cppstd_flags import cppstd_from_settings, \
     cppstd_flag_new as cppstd_flag
+from conans.client import tools
 from conans.client.tools.env import environment_append
 from conans.client.tools.oss import OSInfo, args_to_string, cpu_count, cross_building, \
     detected_architecture, detected_os, get_gnu_triplet, get_target_os_arch, get_build_os_arch
@@ -39,6 +40,7 @@ class AutoToolsBuildEnvironment(object):
         self.subsystem = OSInfo().detect_windows_subsystem() if self._win_bash else None
         self._deps_cpp_info = conanfile.deps_cpp_info
         self._os = conanfile.settings.get_safe("os")
+        self._os_version = conanfile.settings.get_safe("os.version")
         self._arch = conanfile.settings.get_safe("arch")
         self._os_target, self._arch_target = get_target_os_arch(conanfile)
 
@@ -339,6 +341,10 @@ class AutoToolsBuildEnvironment(object):
         tmp_compilation_flags = copy.copy(self.flags)
         if self.fpic:
             tmp_compilation_flags.append(pic_flag(self._conanfile.settings))
+        if tools.is_apple_os(self._os) and self._os_version:
+            flag = tools.apple_deployment_target_flag(self._os,
+                                                      self._os_version)
+            tmp_compilation_flags.append(flag)
 
         cxx_flags = append(tmp_compilation_flags, self.cxx_flags, self.cppstd_flag)
         c_flags = tmp_compilation_flags

--- a/conans/client/build/autotools_environment.py
+++ b/conans/client/build/autotools_environment.py
@@ -343,6 +343,8 @@ class AutoToolsBuildEnvironment(object):
             tmp_compilation_flags.append(pic_flag(self._conanfile.settings))
         if tools.is_apple_os(self._os):
             concat = " ".join(tmp_compilation_flags)
+            if os.environ.get("CFLAGS", None):
+                concat += " " + os.environ.get("CFLAGS", None)
             if self._os_version and "-version-min" not in concat and "-target" not in concat:
                 tmp_compilation_flags.append(tools.apple_deployment_target_flag(self._os,
                                                                                 self._os_version))

--- a/conans/client/build/autotools_environment.py
+++ b/conans/client/build/autotools_environment.py
@@ -345,6 +345,8 @@ class AutoToolsBuildEnvironment(object):
             concat = " ".join(tmp_compilation_flags)
             if os.environ.get("CFLAGS", None):
                 concat += " " + os.environ.get("CFLAGS", None)
+            if os.environ.get("CXXFLAGS", None):
+                concat += " " + os.environ.get("CXXFLAGS", None)
             if self._os_version and "-version-min" not in concat and "-target" not in concat:
                 tmp_compilation_flags.append(tools.apple_deployment_target_flag(self._os,
                                                                                 self._os_version))

--- a/conans/client/build/autotools_environment.py
+++ b/conans/client/build/autotools_environment.py
@@ -341,10 +341,11 @@ class AutoToolsBuildEnvironment(object):
         tmp_compilation_flags = copy.copy(self.flags)
         if self.fpic:
             tmp_compilation_flags.append(pic_flag(self._conanfile.settings))
-        if tools.is_apple_os(self._os) and self._os_version:
-            flag = tools.apple_deployment_target_flag(self._os,
-                                                      self._os_version)
-            tmp_compilation_flags.append(flag)
+        if tools.is_apple_os(self._os):
+            concat = " ".join(tmp_compilation_flags)
+            if self._os_version and "-version-min" not in concat and "-target" not in concat:
+                tmp_compilation_flags.append(tools.apple_deployment_target_flag(self._os,
+                                                                                self._os_version))
 
         cxx_flags = append(tmp_compilation_flags, self.cxx_flags, self.cppstd_flag)
         c_flags = tmp_compilation_flags

--- a/conans/test/unittests/client/build/autotools_environment_test.py
+++ b/conans/test/unittests/client/build/autotools_environment_test.py
@@ -688,8 +688,8 @@ class AutoToolsConfigureTest(unittest.TestCase):
         expected = be.vars["CXXFLAGS"]
         self.assertIn("10.13", expected)
 
-        with tools.environment_append({"CXXFLAGS": "-mmacosx-version-min=10.9"}):
+        with tools.environment_append({"CFLAGS": "-mmacosx-version-min=10.9"}):
             be = AutoToolsBuildEnvironment(conanfile)
-            expected = be.vars["CXXFLAGS"]
+            expected = be.vars["CFLAGS"]
             self.assertIn("10.9", expected)
             self.assertNotIn("10.13", expected)

--- a/conans/test/unittests/client/build/autotools_environment_test.py
+++ b/conans/test/unittests/client/build/autotools_environment_test.py
@@ -671,3 +671,19 @@ class AutoToolsConfigureTest(unittest.TestCase):
         self.assertFalse(ab.fpic)
         ab.fpic = True
         self.assertIn("-fPIC", ab.vars["CXXFLAGS"])
+
+    def mac_version_min_test(self):
+        options = MockOptions({})
+        settings = MockSettings({"os": "Macos"})
+        conanfile = MockConanfile(settings, options)
+        be = AutoToolsBuildEnvironment(conanfile)
+        expected = be.vars["CXXFLAGS"]
+        self.assertEqual("", expected)
+
+        settings = MockSettings({"os": "Macos",
+                                 "os.version": "10.13",
+                                 "compiler.version": "12.0"})
+        conanfile = MockConanfile(settings, options)
+        be = AutoToolsBuildEnvironment(conanfile)
+        expected = be.vars["CXXFLAGS"]
+        self.assertIn("10.13", expected)

--- a/conans/test/unittests/client/build/autotools_environment_test.py
+++ b/conans/test/unittests/client/build/autotools_environment_test.py
@@ -687,3 +687,9 @@ class AutoToolsConfigureTest(unittest.TestCase):
         be = AutoToolsBuildEnvironment(conanfile)
         expected = be.vars["CXXFLAGS"]
         self.assertIn("10.13", expected)
+
+        with tools.environment_append({"CXXFLAGS": "-mmacosx-version-min=10.9"}):
+            be = AutoToolsBuildEnvironment(conanfile)
+            expected = be.vars["CXXFLAGS"]
+            self.assertIn("10.9", expected)
+            self.assertNotIn("10.13", expected)

--- a/conans/test/unittests/client/build/autotools_environment_test.py
+++ b/conans/test/unittests/client/build/autotools_environment_test.py
@@ -693,3 +693,8 @@ class AutoToolsConfigureTest(unittest.TestCase):
             expected = be.vars["CFLAGS"]
             self.assertIn("10.9", expected)
             self.assertNotIn("10.13", expected)
+
+        with tools.environment_append({"CXXFLAGS": "-mmacosx-version-min=10.9"}):
+            be = AutoToolsBuildEnvironment(conanfile)
+            expected = be.vars["CFLAGS"]
+            self.assertNotIn("10.13", expected)


### PR DESCRIPTION
Changelog: Fix: Automatically add OSX deployment flags in ``AutootoolsBuildEnvironment`` with the value of ``os_version``, unless the values are already defined in environment variables `CFLAGS` or `CXXFLAGS`.
Docs: Omit

- [ ] Refer to the issue that supports this Pull Request.
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 

After submitting [this pull request on CCI](https://github.com/conan-io/conan-center-index/pull/3170) I realized that maybe that was something that `AutoToolsBuildEnvironment` could do automatically since 4 recipes are using the same kind of code: [zlib](https://github.com/conan-io/conan-center-index/blob/f16b9ee7771b73d46662b38a50df00d147df937e/recipes/zlib/1.2.11/conanfile.py#L69), [icu](https://github.com/conan-io/conan-center-index/blob/f696331f762027cfb4c43ac0c01145d682e30163/recipes/icu/all/conanfile.py#L110), [libcurl](https://github.com/conan-io/conan-center-index/blob/27c119a06fc0303efa89c2d8cbbace35f32db1b6/recipes/libcurl/all/conanfile.py#L398), [openssl](https://github.com/conan-io/conan-center-index/blob/27c119a06fc0303efa89c2d8cbbace35f32db1b6/recipes/libcurl/all/conanfile.py#L398)