### PR TITLE
fix cpp_info.names and cpp_info.filenames in the local flow

### DIFF
--- a/conans/client/generators/text.py
+++ b/conans/client/generators/text.py
@@ -43,6 +43,8 @@ class DepCppTXT(RootCppTXT):
         self.version = cpp_info.version
         self.name = cpp_info.get_name(TXTGenerator.name)
         self.rootpath = "%s" % cpp_info.rootpath.replace("\\", "/")
+        self.generatornames = "\n".join("%s:%s" % (k, v) for k, v in cpp_info.names.items())
+        self.generatorfilenames = "\n".join("%s:%s" % (k, v) for k, v in cpp_info.filenames.items())
 
 
 class TXTGenerator(Generator):
@@ -165,6 +167,14 @@ class TXTGenerator(Generator):
                 dep_cpp_info = CppInfo(dep, rootpath)
                 dep_cpp_info.filter_empty = filter_empty
                 dep_cpp_info.names[TXTGenerator.name] = no_config_data.pop('name')[0]
+                generatornames = no_config_data.pop("generatornames")
+                for n in generatornames:
+                    gen, value = n.split(":")
+                    dep_cpp_info.names[gen] = value
+                generatorfilenames = no_config_data.pop("generatorfilenames")
+                for n in generatorfilenames:
+                    gen, value = n.split(":")
+                    dep_cpp_info.filenames[gen] = value
                 dep_cpp_info.sysroot = no_config_data.pop('sysroot', [""])[0]
                 _populate_cpp_info(dep_cpp_info, no_config_data, rootpath)
 
@@ -216,7 +226,9 @@ class TXTGenerator(Generator):
         # Makes no sense to have an accumulated rootpath
         template_deps = (template + '[rootpath{dep}]\n{deps.rootpath}\n\n' +
                          '[name{dep}]\n{deps.name}\n\n' +
-                         '[version{dep}]\n{deps.version}\n\n')
+                         '[version{dep}]\n{deps.version}\n\n' +
+                         '[generatornames{dep}]\n{deps.generatornames}\n\n' +
+                         '[generatorfilenames{dep}]\n{deps.generatorfilenames}\n\n')
 
         for dep_name, dep_cpp_info in self.deps_build_info.dependencies:
             dep = "_" + dep_name

--- a/conans/client/generators/text.py
+++ b/conans/client/generators/text.py
@@ -43,8 +43,8 @@ class DepCppTXT(RootCppTXT):
         self.version = cpp_info.version
         self.name = cpp_info.get_name(TXTGenerator.name)
         self.rootpath = "%s" % cpp_info.rootpath.replace("\\", "/")
-        self.generatornames = "\n".join("%s:%s" % (k, v) for k, v in cpp_info.names.items())
-        self.generatorfilenames = "\n".join("%s:%s" % (k, v) for k, v in cpp_info.filenames.items())
+        self.generatornames = "\n".join("%s=%s" % (k, v) for k, v in cpp_info.names.items())
+        self.generatorfilenames = "\n".join("%s=%s" % (k, v) for k, v in cpp_info.filenames.items())
 
 
 class TXTGenerator(Generator):
@@ -171,11 +171,11 @@ class TXTGenerator(Generator):
                 dep_cpp_info.version = version
                 generatornames = no_config_data.pop("generatornames", [])  # can be empty
                 for n in generatornames:
-                    gen, value = n.split(":")
+                    gen, value = n.split("=", 1)
                     dep_cpp_info.names[gen] = value
                 generatorfilenames = no_config_data.pop("generatorfilenames", [])  # can be empty
                 for n in generatorfilenames:
-                    gen, value = n.split(":")
+                    gen, value = n.split("=", 1)
                     dep_cpp_info.filenames[gen] = value
                 dep_cpp_info.sysroot = no_config_data.pop('sysroot', [""])[0]
                 _populate_cpp_info(dep_cpp_info, no_config_data, rootpath)

--- a/conans/client/generators/text.py
+++ b/conans/client/generators/text.py
@@ -150,11 +150,11 @@ class TXTGenerator(Generator):
                     return p
 
             def _populate_cpp_info(_cpp_info, _data, _rootpath):
-                for key, value in _data.items():
+                for key, v in _data.items():
                     if key.endswith('dirs'):
-                        value = [_relativize_path(it, _rootpath) for it in value]
-                        value = ['' if it == '.' else it for it in value]
-                    setattr(_cpp_info, key, value)
+                        v = [_relativize_path(it, _rootpath) for it in v]
+                        v = ['' if it == '.' else it for it in v]
+                    setattr(_cpp_info, key, v)
 
             if None in data:
                 del data[None]
@@ -167,11 +167,11 @@ class TXTGenerator(Generator):
                 dep_cpp_info = CppInfo(dep, rootpath)
                 dep_cpp_info.filter_empty = filter_empty
                 dep_cpp_info.names[TXTGenerator.name] = no_config_data.pop('name')[0]
-                generatornames = no_config_data.pop("generatornames")
+                generatornames = no_config_data.pop("generatornames", [])  # can be empty
                 for n in generatornames:
                     gen, value = n.split(":")
                     dep_cpp_info.names[gen] = value
-                generatorfilenames = no_config_data.pop("generatorfilenames")
+                generatorfilenames = no_config_data.pop("generatorfilenames", [])  # can be empty
                 for n in generatorfilenames:
                     gen, value = n.split(":")
                     dep_cpp_info.filenames[gen] = value

--- a/conans/client/generators/text.py
+++ b/conans/client/generators/text.py
@@ -166,7 +166,9 @@ class TXTGenerator(Generator):
                 rootpath = no_config_data.pop('rootpath')[0]
                 dep_cpp_info = CppInfo(dep, rootpath)
                 dep_cpp_info.filter_empty = filter_empty
-                dep_cpp_info.names[TXTGenerator.name] = no_config_data.pop('name')[0]
+                _ = no_config_data.pop('name')[0]
+                version = no_config_data.pop('version', [""])[0]
+                dep_cpp_info.version = version
                 generatornames = no_config_data.pop("generatornames", [])  # can be empty
                 for n in generatornames:
                     gen, value = n.split(":")
@@ -184,8 +186,6 @@ class TXTGenerator(Generator):
                     _populate_cpp_info(cpp_info_config, config_data, rootpath)
 
                 # Add to the dependecy list
-                version = no_config_data.pop('version', [""])[0]
-                dep_cpp_info.version = version
                 deps_cpp_info.add(dep, DepCppInfo(dep_cpp_info))
 
             return deps_cpp_info

--- a/conans/test/unittests/client/generators/txt/test_dump_load.py
+++ b/conans/test/unittests/client/generators/txt/test_dump_load.py
@@ -17,7 +17,7 @@ class DumpLoadTestCase(unittest.TestCase):
         cpp_info = CppInfo("pkg_name", "root")
         cpp_info.name = "name"
         cpp_info.names["txt"] = "txt_name"
-        cpp_info.names["cmake_find_package"] = "cmake_find_package"
+        cpp_info.names["cmake_find_package"] = "SpecialName"
         conanfile = ConanFile(TestBufferConanOutput(), None)
         conanfile.initialize(Settings({}), EnvValues())
         conanfile.deps_cpp_info.add("pkg_name", DepCppInfo(cpp_info))
@@ -25,9 +25,8 @@ class DumpLoadTestCase(unittest.TestCase):
         parsed_deps_cpp_info, _, _, _ = TXTGenerator.loads(content, filter_empty=False)
 
         parsed_cpp_info = parsed_deps_cpp_info["pkg_name"]
-        # FIXME: Conan v2: Remove 'txt' generator or serialize all the names
         self.assertEqual(parsed_cpp_info.get_name("txt"), "txt_name")
-        self.assertEqual(parsed_cpp_info.get_name("cmake_find_package"), "pkg_name")
+        self.assertEqual(parsed_cpp_info.get_name("cmake_find_package"), "SpecialName")
         self.assertEqual(parsed_cpp_info.get_name("pkg_config"), "pkg_name")
 
     def test_idempotent(self):

--- a/conans/test/unittests/client/generators/txt/test_dump_load.py
+++ b/conans/test/unittests/client/generators/txt/test_dump_load.py
@@ -18,6 +18,7 @@ class DumpLoadTestCase(unittest.TestCase):
         cpp_info.name = "name"
         cpp_info.names["txt"] = "txt_name"
         cpp_info.names["cmake_find_package"] = "SpecialName"
+        cpp_info.filenames["cmake_find_package"] = "SpecialFileName"
         conanfile = ConanFile(TestBufferConanOutput(), None)
         conanfile.initialize(Settings({}), EnvValues())
         conanfile.deps_cpp_info.add("pkg_name", DepCppInfo(cpp_info))
@@ -27,6 +28,7 @@ class DumpLoadTestCase(unittest.TestCase):
         parsed_cpp_info = parsed_deps_cpp_info["pkg_name"]
         self.assertEqual(parsed_cpp_info.get_name("txt"), "txt_name")
         self.assertEqual(parsed_cpp_info.get_name("cmake_find_package"), "SpecialName")
+        self.assertEqual(parsed_cpp_info.get_filename("cmake_find_package"), "SpecialFileName")
         self.assertEqual(parsed_cpp_info.get_name("pkg_config"), "pkg_name")
 
     def test_idempotent(self):

--- a/conans/test/unittests/model/build_info_test.py
+++ b/conans/test/unittests/model/build_info_test.py
@@ -3,7 +3,7 @@ import unittest
 from collections import defaultdict, namedtuple
 
 from conans.client.generators import TXTGenerator
-from conans.model.build_info import CppInfo, DepsCppInfo
+from conans.model.build_info import DepsCppInfo
 from conans.model.env_info import DepsEnvInfo, EnvInfo
 from conans.model.user_info import DepsUserInfo
 from conans.test.utils.test_files import temp_folder


### PR DESCRIPTION
Changelog: Bugfix: Fix local flow (conan install + build) support for ``cpp_info.names`` and ``cpp_info.filenames``.
Docs: Omit

Close https://github.com/conan-io/conan/issues/7854

