### PR TITLE
Add Clang 11 in settings.yml

### DIFF
--- a/conans/client/conf/__init__.py
+++ b/conans/client/conf/__init__.py
@@ -84,7 +84,7 @@ _t_default_settings_yml = Template(textwrap.dedent("""
         clang:
             version: ["3.3", "3.4", "3.5", "3.6", "3.7", "3.8", "3.9", "4.0",
                       "5.0", "6.0", "7.0", "7.1",
-                      "8", "9", "10"]
+                      "8", "9", "10", "11"]
             libcxx: [None, libstdc++, libstdc++11, libc++, c++_shared, c++_static]
             cppstd: [None, 98, gnu98, 11, gnu11, 14, gnu14, 17, gnu17, 20, gnu20]
             runtime: [None, MD, MT, MTd, MDd]

--- a/conans/client/migrations_settings.py
+++ b/conans/client/migrations_settings.py
@@ -1679,7 +1679,7 @@ compiler:
     clang:
         version: ["3.3", "3.4", "3.5", "3.6", "3.7", "3.8", "3.9", "4.0",
                   "5.0", "6.0", "7.0", "7.1",
-                  "8", "9", "10"]
+                  "8", "9", "10", "11"]
         libcxx: [None, libstdc++, libstdc++11, libc++, c++_shared, c++_static]
         cppstd: [None, 98, gnu98, 11, gnu11, 14, gnu14, 17, gnu17, 20, gnu20]
         runtime: [None, MD, MT, MTd, MDd]

--- a/conans/client/migrations_settings.py
+++ b/conans/client/migrations_settings.py
@@ -1679,7 +1679,7 @@ compiler:
     clang:
         version: ["3.3", "3.4", "3.5", "3.6", "3.7", "3.8", "3.9", "4.0",
                   "5.0", "6.0", "7.0", "7.1",
-                  "8", "9", "10", "11"]
+                  "8", "9", "10"]
         libcxx: [None, libstdc++, libstdc++11, libc++, c++_shared, c++_static]
         cppstd: [None, 98, gnu98, 11, gnu11, 14, gnu14, 17, gnu17, 20, gnu20]
         runtime: [None, MD, MT, MTd, MDd]
@@ -1710,4 +1710,102 @@ cppstd: [None, 98, gnu98, 11, gnu11, 14, gnu14, 17, gnu17, 20, gnu20]  # Depreca
 """
 
 settings_1_30_1 = settings_1_30_0
-settings_1_30_2 = settings_1_30_1
+settings_1_30_2 = """
+# Only for cross building, 'os_build/arch_build' is the system that runs Conan
+os_build: [Windows, WindowsStore, Linux, Macos, FreeBSD, SunOS, AIX]
+arch_build: [x86, x86_64, ppc32be, ppc32, ppc64le, ppc64, armv5el, armv5hf, armv6, armv7, armv7hf, armv7s, armv7k, armv8, armv8_32, armv8.3, sparc, sparcv9, mips, mips64, avr, s390, s390x, sh4le]
+
+# Only for building cross compilation tools, 'os_target/arch_target' is the system for
+# which the tools generate code
+os_target: [Windows, Linux, Macos, Android, iOS, watchOS, tvOS, FreeBSD, SunOS, AIX, Arduino, Neutrino]
+arch_target: [x86, x86_64, ppc32be, ppc32, ppc64le, ppc64, armv5el, armv5hf, armv6, armv7, armv7hf, armv7s, armv7k, armv8, armv8_32, armv8.3, sparc, sparcv9, mips, mips64, avr, s390, s390x, asm.js, wasm, sh4le]
+
+# Rest of the settings are "host" settings:
+# - For native building/cross building: Where the library/program will run.
+# - For building cross compilation tools: Where the cross compiler will run.
+os:
+    Windows:
+        subsystem: [None, cygwin, msys, msys2, wsl]
+    WindowsStore:
+        version: ["8.1", "10.0"]
+    WindowsCE:
+        platform: ANY
+        version: ["5.0", "6.0", "7.0", "8.0"]
+    Linux:
+    Macos:
+        version: [None, "10.6", "10.7", "10.8", "10.9", "10.10", "10.11", "10.12", "10.13", "10.14", "10.15", "11.0"]
+    Android:
+        api_level: ANY
+    iOS:
+        version: ["7.0", "7.1", "8.0", "8.1", "8.2", "8.3", "9.0", "9.1", "9.2", "9.3", "10.0", "10.1", "10.2", "10.3", "11.0", "11.1", "11.2", "11.3", "11.4", "12.0", "12.1", "12.2", "12.3", "12.4", "13.0", "13.1", "13.2", "13.3", "13.4", "13.5", "13.6"]
+    watchOS:
+        version: ["4.0", "4.1", "4.2", "4.3", "5.0", "5.1", "5.2", "5.3", "6.0", "6.1"]
+    tvOS:
+        version: ["11.0", "11.1", "11.2", "11.3", "11.4", "12.0", "12.1", "12.2", "12.3", "12.4", "13.0"]
+    FreeBSD:
+    SunOS:
+    AIX:
+    Arduino:
+        board: ANY
+    Emscripten:
+    Neutrino:
+        version: ["6.4", "6.5", "6.6", "7.0", "7.1"]
+arch: [x86, x86_64, ppc32be, ppc32, ppc64le, ppc64, armv4, armv4i, armv5el, armv5hf, armv6, armv7, armv7hf, armv7s, armv7k, armv8, armv8_32, armv8.3, sparc, sparcv9, mips, mips64, avr, s390, s390x, asm.js, wasm, sh4le]
+compiler:
+    sun-cc:
+        version: ["5.10", "5.11", "5.12", "5.13", "5.14", "5.15"]
+        threads: [None, posix]
+        libcxx: [libCstd, libstdcxx, libstlport, libstdc++]
+    gcc: &gcc
+        version: ["4.1", "4.4", "4.5", "4.6", "4.7", "4.8", "4.9",
+                  "5", "5.1", "5.2", "5.3", "5.4", "5.5",
+                  "6", "6.1", "6.2", "6.3", "6.4", "6.5",
+                  "7", "7.1", "7.2", "7.3", "7.4", "7.5",
+                  "8", "8.1", "8.2", "8.3", "8.4",
+                  "9", "9.1", "9.2", "9.3",
+                  "10", "10.1"]
+        libcxx: [libstdc++, libstdc++11]
+        threads: [None, posix, win32] #  Windows MinGW
+        exception: [None, dwarf2, sjlj, seh] # Windows MinGW
+        cppstd: [None, 98, gnu98, 11, gnu11, 14, gnu14, 17, gnu17, 20, gnu20]
+    Visual Studio: &visual_studio
+        runtime: [MD, MT, MTd, MDd]
+        version: ["8", "9", "10", "11", "12", "14", "15", "16"]
+        toolset: [None, v90, v100, v110, v110_xp, v120, v120_xp,
+                  v140, v140_xp, v140_clang_c2, LLVM-vs2012, LLVM-vs2012_xp,
+                  LLVM-vs2013, LLVM-vs2013_xp, LLVM-vs2014, LLVM-vs2014_xp,
+                  LLVM-vs2017, LLVM-vs2017_xp, v141, v141_xp, v141_clang_c2, v142,
+                  llvm, ClangCL]
+        cppstd: [None, 14, 17, 20]
+    clang:
+        version: ["3.3", "3.4", "3.5", "3.6", "3.7", "3.8", "3.9", "4.0",
+                  "5.0", "6.0", "7.0", "7.1",
+                  "8", "9", "10", "11"]
+        libcxx: [None, libstdc++, libstdc++11, libc++, c++_shared, c++_static]
+        cppstd: [None, 98, gnu98, 11, gnu11, 14, gnu14, 17, gnu17, 20, gnu20]
+        runtime: [None, MD, MT, MTd, MDd]
+    apple-clang: &apple_clang
+        version: ["5.0", "5.1", "6.0", "6.1", "7.0", "7.3", "8.0", "8.1", "9.0", "9.1", "10.0", "11.0", "12.0"]
+        libcxx: [libstdc++, libc++]
+        cppstd: [None, 98, gnu98, 11, gnu11, 14, gnu14, 17, gnu17, 20, gnu20]
+    intel:
+        version: ["11", "12", "13", "14", "15", "16", "17", "18", "19", "19.1"]
+        base:
+            gcc:
+                <<: *gcc
+                threads: [None]
+                exception: [None]
+            Visual Studio:
+                <<: *visual_studio
+            apple-clang:
+                <<: *apple_clang
+    qcc:
+        version: ["4.4", "5.4", "8.3"]
+        libcxx: [cxx, gpp, cpp, cpp-ne, accp, acpp-ne, ecpp, ecpp-ne]
+        cppstd: [None, 98, gnu98, 11, gnu11, 14, gnu14, 17, gnu17]
+
+build_type: [None, Debug, Release, RelWithDebInfo, MinSizeRel]
+
+
+cppstd: [None, 98, gnu98, 11, gnu11, 14, gnu14, 17, gnu17, 20, gnu20]  # Deprecated, use compiler.cppstd
+"""

--- a/conans/test/unittests/client/build/cpp_std_flags_test.py
+++ b/conans/test/unittests/client/build/cpp_std_flags_test.py
@@ -109,20 +109,11 @@ class CompilerFlagsTest(unittest.TestCase):
         self.assertEqual(_make_cppstd_flag("clang", "5.1", "14"), '-std=c++14')
         self.assertEqual(_make_cppstd_flag("clang", "5.1", "17"), '-std=c++17')
 
-        self.assertEqual(_make_cppstd_flag("clang", "6", "11"), '-std=c++11')
-        self.assertEqual(_make_cppstd_flag("clang", "6", "14"), '-std=c++14')
-        self.assertEqual(_make_cppstd_flag("clang", "6", "17"), '-std=c++17')
-        self.assertEqual(_make_cppstd_flag("clang", "6", "20"), '-std=c++2a')
-
-        self.assertEqual(_make_cppstd_flag("clang", "7", "11"), '-std=c++11')
-        self.assertEqual(_make_cppstd_flag("clang", "7", "14"), '-std=c++14')
-        self.assertEqual(_make_cppstd_flag("clang", "7", "17"), '-std=c++17')
-        self.assertEqual(_make_cppstd_flag("clang", "7", "20"), '-std=c++2a')
-
-        self.assertEqual(_make_cppstd_flag("clang", "8", "11"), '-std=c++11')
-        self.assertEqual(_make_cppstd_flag("clang", "8", "14"), '-std=c++14')
-        self.assertEqual(_make_cppstd_flag("clang", "8", "17"), '-std=c++17')
-        self.assertEqual(_make_cppstd_flag("clang", "8", "20"), '-std=c++2a')
+        for version in ["6", "7", "8", "9", "10"]:
+            self.assertEqual(_make_cppstd_flag("clang", version, "11"), '-std=c++11')
+            self.assertEqual(_make_cppstd_flag("clang", version, "14"), '-std=c++14')
+            self.assertEqual(_make_cppstd_flag("clang", version, "17"), '-std=c++17')
+            self.assertEqual(_make_cppstd_flag("clang", version, "20"), '-std=c++2a')
 
     def test_clang_cppstd_defaults(self):
         self.assertEqual(_make_cppstd_default("clang", "2"), "gnu98")
@@ -135,6 +126,9 @@ class CompilerFlagsTest(unittest.TestCase):
         self.assertEqual(_make_cppstd_default("clang", "5.1"), "gnu98")
         self.assertEqual(_make_cppstd_default("clang", "6"), "gnu14")
         self.assertEqual(_make_cppstd_default("clang", "7"), "gnu14")
+        self.assertEqual(_make_cppstd_default("clang", "8"), "gnu14")
+        self.assertEqual(_make_cppstd_default("clang", "9"), "gnu14")
+        self.assertEqual(_make_cppstd_default("clang", "10"), "gnu14")
 
     def test_apple_clang_cppstd_flags(self):
         self.assertEqual(_make_cppstd_flag("apple-clang", "3.9", "98"), None)

--- a/conans/test/unittests/client/build/cpp_std_flags_test.py
+++ b/conans/test/unittests/client/build/cpp_std_flags_test.py
@@ -109,7 +109,7 @@ class CompilerFlagsTest(unittest.TestCase):
         self.assertEqual(_make_cppstd_flag("clang", "5.1", "14"), '-std=c++14')
         self.assertEqual(_make_cppstd_flag("clang", "5.1", "17"), '-std=c++17')
 
-        for version in ["6", "7", "8", "9", "10"]:
+        for version in ["6", "7", "8", "9", "10", "11"]:
             self.assertEqual(_make_cppstd_flag("clang", version, "11"), '-std=c++11')
             self.assertEqual(_make_cppstd_flag("clang", version, "14"), '-std=c++14')
             self.assertEqual(_make_cppstd_flag("clang", version, "17"), '-std=c++17')
@@ -129,6 +129,7 @@ class CompilerFlagsTest(unittest.TestCase):
         self.assertEqual(_make_cppstd_default("clang", "8"), "gnu14")
         self.assertEqual(_make_cppstd_default("clang", "9"), "gnu14")
         self.assertEqual(_make_cppstd_default("clang", "10"), "gnu14")
+        self.assertEqual(_make_cppstd_default("clang", "11"), "gnu14")
 
     def test_apple_clang_cppstd_flags(self):
         self.assertEqual(_make_cppstd_flag("apple-clang", "3.9", "98"), None)


### PR DESCRIPTION
Changelog: Feature: Supports Clang 11.
Docs: https://github.com/conan-io/docs/pull/1883

closes #7223

Clang 10 still uses C++14 by default and same flag for c++20 (c++2a). Thus, `_cppstd_clang` is totally fine.

https://releases.llvm.org/10.0.0/tools/clang/docs/ReleaseNotes.html
https://releases.llvm.org/10.0.0/tools/clang/docs/index.html


- [x] Refer to the issue that supports this Pull Request.
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [x] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 

<sup>**Note:** By default this PR will skip the slower tests and will use a limited set of python versions. Check [here](https://github.com/conan-io/conan/blob/develop/.github/PR_INCREASE_TESTING.md) how to increase the testing level by writing some tags in the current PR body text.</sup>
