### PR TITLE
Let conan download preserve tarfiles in the cache

### DIFF
--- a/conans/client/generators/deploy.py
+++ b/conans/client/generators/deploy.py
@@ -9,7 +9,7 @@ from conans.paths import BUILD_INFO_DEPLOY
 from conans.util.files import mkdir, md5sum
 
 
-FILTERED_FILES = ["conaninfo.txt", "conanmanifest.txt", "conan_package.tgz"]
+FILTERED_FILES = ["conaninfo.txt", "conanmanifest.txt"]
 
 
 class DeployGenerator(Generator):

--- a/conans/client/generators/deploy.py
+++ b/conans/client/generators/deploy.py
@@ -9,7 +9,7 @@ from conans.paths import BUILD_INFO_DEPLOY
 from conans.util.files import mkdir, md5sum
 
 
-FILTERED_FILES = ["conaninfo.txt", "conanmanifest.txt"]
+FILTERED_FILES = ["conaninfo.txt", "conanmanifest.txt", "conan_package.tgz"]
 
 
 class DeployGenerator(Generator):

--- a/conans/client/remote_manager.py
+++ b/conans/client/remote_manager.py
@@ -279,9 +279,8 @@ def unzip_and_get_files(files, destination_dir, tgz_name, output):
     check_compressed_files(tgz_name, files)
     if tgz_file:
         uncompress_file(tgz_file, destination_dir, output=output)
-        file_name = os.path.basename(tgz_file)
         # https://github.com/conan-io/conan/issues/7869
-        if file_name != "conan_package.tgz":
+        if os.path.basename(tgz_file) != "conan_package.tgz":
             os.remove(tgz_file)
 
 

--- a/conans/client/remote_manager.py
+++ b/conans/client/remote_manager.py
@@ -279,6 +279,10 @@ def unzip_and_get_files(files, destination_dir, tgz_name, output):
     check_compressed_files(tgz_name, files)
     if tgz_file:
         uncompress_file(tgz_file, destination_dir, output=output)
+        file_name = os.path.basename(tgz_file)
+        # https://github.com/conan-io/conan/issues/7869
+        if file_name != "conan_package.tgz":
+            os.remove(tgz_file)
 
 
 def uncompress_file(src_path, dest_folder, output):

--- a/conans/client/remote_manager.py
+++ b/conans/client/remote_manager.py
@@ -279,7 +279,6 @@ def unzip_and_get_files(files, destination_dir, tgz_name, output):
     check_compressed_files(tgz_name, files)
     if tgz_file:
         uncompress_file(tgz_file, destination_dir, output=output)
-        os.remove(tgz_file)
 
 
 def uncompress_file(src_path, dest_folder, output):

--- a/conans/test/functional/cache/path_limit_test.py
+++ b/conans/test/functional/cache/path_limit_test.py
@@ -111,7 +111,7 @@ class PathLengthLimitTest(unittest.TestCase):
             files = os.listdir(package_folder)
             self.assertIn("myfile.txt", files)
             self.assertIn("myfile2.txt", files)
-            self.assertNotIn("conan_package.tgz", files)
+            self.assertIn("conan_package.tgz", files)
 
     def export_source_test(self):
         client = TestClient()

--- a/conans/test/functional/command/download/download_test.py
+++ b/conans/test/functional/command/download/download_test.py
@@ -3,6 +3,7 @@ import unittest
 from collections import OrderedDict
 
 from conans.model.ref import ConanFileReference
+from conans.paths import PACKAGE_TGZ_NAME
 from conans.test.utils.tools import (TestClient, TestServer, NO_SETTINGS_PACKAGE_ID, TurboTestClient,
                                      GenConanfile)
 from conans.util.files import load
@@ -180,6 +181,9 @@ class Pkg(ConanFile):
         self.assertTrue(os.path.exists(package_layout.conanfile()))
         # Check package folder created
         self.assertTrue(os.path.exists(package_folder))
+        # https://github.com/conan-io/conan/issues/7869
+        # Check conan_package.tgz has been downloaded
+        self.assertTrue(os.path.exists(os.path.join(package_folder, PACKAGE_TGZ_NAME)))
 
     def download_not_found_reference_test(self):
         server = TestServer()

--- a/conans/test/integration/export_sources_test.py
+++ b/conans/test/integration/export_sources_test.py
@@ -7,7 +7,8 @@ from parameterized.parameterized import parameterized
 from conans.client import tools
 from conans.model.manifest import FileTreeManifest
 from conans.model.ref import ConanFileReference, PackageReference
-from conans.paths import EXPORT_SOURCES_TGZ_NAME, EXPORT_SRC_FOLDER, EXPORT_TGZ_NAME
+from conans.paths import EXPORT_SOURCES_TGZ_NAME, EXPORT_SRC_FOLDER, EXPORT_TGZ_NAME, \
+    PACKAGE_TGZ_NAME
 from conans.test.utils.test_files import scan_folder
 from conans.test.utils.tools import NO_SETTINGS_PACKAGE_ID, TestClient, TestServer
 from conans.util.files import load, md5sum, save
@@ -94,7 +95,7 @@ class ExportsSourcesTest(unittest.TestCase):
         expected_sources = sorted(expected_sources)
         self.assertEqual(scan_folder(self.source_folder), expected_sources)
 
-    def _check_package_folder(self, mode):
+    def _check_package_folder(self, mode, conanpackage=False):
         """ Package folder must be always the same (might have tgz after upload)
         """
         if mode in ["exports", "exports_sources"]:
@@ -105,6 +106,8 @@ class ExportsSourcesTest(unittest.TestCase):
         if mode == "nested" or mode == "overlap":
             expected_package = ["conaninfo.txt", "conanmanifest.txt", "include/src/hello.h",
                                 "docs/src/data.txt"]
+        if conanpackage:
+            expected_package.append(PACKAGE_TGZ_NAME)
 
         self.assertEqual(scan_folder(self.package_folder), sorted(expected_package))
 
@@ -302,14 +305,14 @@ class ExportsSourcesTest(unittest.TestCase):
         self.client.run("install Hello/0.1@lasote/testing")
         self.assertFalse(os.path.exists(self.source_folder))
         self._check_export_installed_folder(mode)
-        self._check_package_folder(mode)
+        self._check_package_folder(mode, conanpackage=True)
 
         # Manifests must work too!
         self.client.run("install Hello/0.1@lasote/testing --manifests")
         self.assertFalse(os.path.exists(self.source_folder))
         # The manifests retrieve the normal state, as it retrieves sources
         self._check_export_folder(mode)
-        self._check_package_folder(mode)
+        self._check_package_folder(mode, conanpackage=True)
         self._check_manifest(mode)
 
         # lets try to verify
@@ -319,7 +322,7 @@ class ExportsSourcesTest(unittest.TestCase):
         self.assertFalse(os.path.exists(self.source_folder))
         # The manifests retrieve the normal state, as it retrieves sources
         self._check_export_folder(mode)
-        self._check_package_folder(mode)
+        self._check_package_folder(mode, conanpackage=True)
         self._check_manifest(mode)
 
     @parameterized.expand([("exports", ), ("exports_sources", ), ("both", ), ("nested", ),


### PR DESCRIPTION
Changelog: Feature: Do not delete the downloaded `conan_package.tgz` when doing a conan download.
Docs: TODO?

The intention of this PR is to make possible a flow like doing conan download and conan upload without repackaging the conan_package.tgz each time Conan performs these operations. Besides the optimizations if will also enable the workaround commented here: https://github.com/conan-io/conan/issues/7863#issuecomment-707198363

Closes: https://github.com/conan-io/conan/issues/7869

#TAGS: slow
#REVISIONS: 1

- [X] Refer to the issue that supports this Pull Request.
- [X] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [X] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [X] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 

<sup>**Note:** By default this PR will skip the slower tests and will use a limited set of python versions. Check [here](https://github.com/conan-io/conan/blob/develop/.github/PR_INCREASE_TESTING.md) how to increase the testing level by writing some tags in the current PR body text.</sup>
