### PR TITLE
Remove duplicate entries while modifying PATH-like environment variables

### DIFF
--- a/conans/client/envvars/environment.py
+++ b/conans/client/envvars/environment.py
@@ -1,6 +1,7 @@
 import os
 import platform
 import textwrap
+from collections import OrderedDict
 
 from jinja2 import Template
 
@@ -137,6 +138,7 @@ def _format_values(flavor, variables, append_with_spaces):
     for name, value in variables:
         # activate values
         if isinstance(value, list):
+            value = list(OrderedDict.fromkeys(value)) # Avoid repeated entries, while keeping order
             append_space = name in append_with_spaces
             placeholder = _variable_placeholder(flavor, name, append_space)
             if append_space:

--- a/conans/client/tools/env.py
+++ b/conans/client/tools/env.py
@@ -1,6 +1,7 @@
 import os
 import platform
 import sys
+from collections import OrderedDict
 from contextlib import contextmanager
 
 from conans.client.run_environment import RunEnvironment
@@ -65,6 +66,9 @@ def _environment_add(env_vars, post=False):
                     apply_vars[name] = old + os.pathsep + apply_vars[name]
                 else:
                     apply_vars[name] += os.pathsep + old
+            # Remove possible duplicates, keeping the order of the remaining paths
+            items = apply_vars[name].split(os.pathsep)
+            apply_vars[name] = os.pathsep.join(OrderedDict.fromkeys(items))
         else:
             apply_vars[name] = value
 

--- a/conans/test/unittests/client/generators/virtualenv_test.py
+++ b/conans/test/unittests/client/generators/virtualenv_test.py
@@ -25,6 +25,7 @@ class VirtualEnvGeneratorTest(unittest.TestCase):
         env.add("CL", ["cl1", "cl2"])
         env.add("PATH", ["another_path", ])
         env.add("PATH2", ["p1", "p2"])
+        env.add("PATH3", ["p1", "p2", "p1", "p3", "p4", "p2"])
         conanfile = ConanFile(TestBufferConanOutput(), None)
         conanfile.initialize(Settings({}), env)
 
@@ -46,6 +47,8 @@ class VirtualEnvGeneratorTest(unittest.TestCase):
     def test_list_variable(self):
         self.assertIn("PATH=\"another_path\"${PATH+:$PATH}", self.result['environment.sh.env'])
         self.assertIn("PATH2=\"p1\":\"p2\"${PATH2+:$PATH2}", self.result['environment.sh.env'])
+        self.assertIn("PATH3=\"p1\":\"p2\":\"p3\":\"p4\"${PATH3+:$PATH3}",
+                      self.result['environment.sh.env'])
 
         if platform.system() == "Windows":
             self.assertIn("PATH=another_path;%PATH%", self.result["environment.bat.env"])
@@ -61,6 +64,6 @@ class VirtualEnvGeneratorTest(unittest.TestCase):
         self.assertIn("CL", VirtualEnvGenerator.append_with_spaces)
         self.assertIn("CL=\"cl1 cl2 ${CL+ $CL}\"", self.result['environment.sh.env'])
         self.assertIn('CL=cl1 cl2 $env:CL', self.result["environment.ps1.env"])
-        
+
         if platform.system() == "Windows":
             self.assertIn("CL=cl1 cl2 %CL%", self.result["environment.bat.env"])

--- a/conans/test/unittests/client/tools/test_env.py
+++ b/conans/test/unittests/client/tools/test_env.py
@@ -9,46 +9,47 @@ from conans.client.tools import env
 
 class ToolsEnvTest(unittest.TestCase):
     def test_environment_append_variables(self):
-        with mock.patch.dict('os.environ', {}),\
-             env.environment_append({'env_var1': 'value',
-                                     'env_var2': 'value2'}):
-                self.assertEqual(os.environ['env_var1'], 'value')
-                self.assertEqual(os.environ['env_var2'], 'value2')
+        with mock.patch.dict('os.environ', {}), env.environment_append({'env_var1': 'value',
+                                                                        'env_var2': 'value2'}):
+            self.assertEqual(os.environ['env_var1'], 'value')
+            self.assertEqual(os.environ['env_var2'], 'value2')
 
     def test_environment_append_variables_without_values(self):
-        with mock.patch.dict('os.environ',
-                             {'env_var1': 'value',
-                              'env_var2': 'value2'}),\
-             env.environment_append({}):
-                self.assertEqual(os.environ['env_var1'], 'value')
-                self.assertEqual(os.environ['env_var2'], 'value2')
+        with mock.patch.dict('os.environ', {'env_var1': 'value',
+                                            'env_var2': 'value2'}), env.environment_append({}):
+            self.assertEqual(os.environ['env_var1'], 'value')
+            self.assertEqual(os.environ['env_var2'], 'value2')
 
     def test_environment_append_overwriting(self):
         with mock.patch.dict('os.environ', {'env_var1': 'value'}),\
              env.environment_append({'env_var1': 'new_value'}):
-                self.assertEqual(os.environ['env_var1'], 'new_value')
+            self.assertEqual(os.environ['env_var1'], 'new_value')
 
     def test_environment_append_list(self):
         with mock.patch.dict('os.environ', {}),\
              env.environment_append({'env_var1': ['value1', 'value2']}):
-                self.assertEqual(os.environ['env_var1'], 'value1' +
-                                 os.pathsep + 'value2')
+            self.assertEqual(os.environ['env_var1'], 'value1' + os.pathsep + 'value2')
+
+    def test_environment_repeated_list(self):
+        with mock.patch.dict('os.environ', {}),\
+             env.environment_append({'env_var1': ['value1', 'value2', 'value1']}):
+            self.assertEqual(os.environ['env_var1'], 'value1' + os.pathsep + 'value2')
 
     def test_environment_append_unsetting_some_variables(self):
         with mock.patch.dict('os.environ', {'env_var1': 'value'}),\
              env.environment_append({'env_var1': None, 'env_var2': 'value2'}):
-                self.assertNotIn('env_var1', os.environ)
-                self.assertEqual(os.environ['env_var2'], 'value2')
+            self.assertNotIn('env_var1', os.environ)
+            self.assertEqual(os.environ['env_var2'], 'value2')
 
     def test_environment_append_unsetting_all_variables(self):
         with mock.patch.dict('os.environ',
                              {'env_var1': 'value',
                               'env_var2': 'value2'}),\
              env.environment_append({'env_var1': None}):
-                self.assertNotIn('env_var1', os.environ)
+            self.assertNotIn('env_var1', os.environ)
 
     def test_environment_append_unsetting_non_existing_variables(self):
         with mock.patch.dict('os.environ',
                              {'env_var2': 'value2'}),\
              env.environment_append({'env_var1': None}):
-                self.assertNotIn('env_var1', os.environ)
+            self.assertNotIn('env_var1', os.environ)


### PR DESCRIPTION
Changelog: Fix: Remove duplicate entries while modifying PATH-like environment variables internally. Especially important for Windows where system PATH size is limited by 8192 charachers (when using cmd.exe).
Docs: omit

- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.

Partially solves https://github.com/conan-io/conan/issues/7587, especially when `conan` is launched from MSVC develper command prompt.
