### PR TITLE
new test for package_id_unknown download case

### DIFF
--- a/conans/client/graph/graph_binaries.py
+++ b/conans/client/graph/graph_binaries.py
@@ -381,5 +381,3 @@ class GraphBinariesAnalyzer(object):
         output.info("Binary for updated ID from: %s" % node.binary)
         if node.binary == BINARY_BUILD:
             output.info("Binary for the updated ID has to be built")
-        else:
-            output.info("Binary for the updated ID from: %s" % node.binary)

--- a/conans/test/functional/package_id/package_id_requires_modes_test.py
+++ b/conans/test/functional/package_id/package_id_requires_modes_test.py
@@ -55,7 +55,7 @@ class Pkg(ConanFile):
 
     @property
     def conaninfo(self):
-        return load(os.path.join(self.client.current_folder, CONANINFO))
+        return self.client.load(CONANINFO)
 
     def test_version_semver_schema(self):
         self._export("Hello", "1.2.0")
@@ -321,11 +321,11 @@ class Pkg(ConanFile):
                             ' -s arch_build="x86"'
                             ' --build missing')
 
-            ref = ConanFileReference.loads("Hello/1.2.0@user/testing")
-            pkg = os.listdir(self.client.cache.package_layout(ref).packages())
-            pref = PackageReference(ref, pkg[0])
-            pkg_folder = self.client.cache.package_layout(pref.ref).package(pref)
-            return ConanInfo.loads(load(os.path.join(pkg_folder, CONANINFO)))
+            hello_ref = ConanFileReference.loads("Hello/1.2.0@user/testing")
+            layout = self.client.cache.package_layout(hello_ref)
+            pkg_ids = layout.package_ids()
+            hello_pref = PackageReference(hello_ref, pkg_ids[0])
+            return ConanInfo.loads(load(os.path.join(layout.package(hello_pref), CONANINFO)))
 
         info = install_and_get_info(None)  # Default
 
@@ -470,15 +470,18 @@ class Pkg(ConanFile):
         self.client.run("config set general.default_package_id_mode=patch_mode")
         self._export("liba", "0.1.0", channel=channel, package_id_text=None, requires=None)
         self.client.run("create . liba/0.1.0@user/testing")
-        self._export("libb", "0.1.0", channel=channel, package_id_text=None, requires=["liba/0.1.0@user/testing"])
+        self._export("libb", "0.1.0", channel=channel, package_id_text=None,
+                     requires=["liba/0.1.0@user/testing"])
         self.client.run("create . libb/0.1.0@user/testing")
         self._export("libbar", "0.1.0", channel=channel, package_id_text=None, requires=None)
         self.client.run("create . libbar/0.1.0@user/testing")
-        self._export("libfoo", "0.1.0", channel=channel, package_id_text=None, requires=["libbar/0.1.0@user/testing"])
+        self._export("libfoo", "0.1.0", channel=channel, package_id_text=None,
+                     requires=["libbar/0.1.0@user/testing"])
         self.client.run("create . libfoo/0.1.0@user/testing")
         self._export("libc", "0.1.0", channel=channel, package_id_text=None,
                      requires=["libb/0.1.0@user/testing", "libfoo/0.1.0@user/testing"])
-        self._export("libd", "0.1.0", channel=channel, package_id_text=None, requires=["libc/0.1.0@user/testing"])
+        self._export("libd", "0.1.0", channel=channel, package_id_text=None,
+                     requires=["libc/0.1.0@user/testing"])
         self.client.run("create . libd/0.1.0@user/testing", assert_error=True)
         self.assertIn("""ERROR: Missing binary: libc/0.1.0@user/testing:e12c9d31fa508340bb8d0c4f9dd4c98a5d0ac082
 
@@ -624,3 +627,33 @@ class PackageRevisionModeTestCase(unittest.TestCase):
         self.assertIn("pkg3/1.0:Package_ID_unknown - Unknown", t.out)
         self.assertIn("pkg3/1.0: Updated ID: 283642385cc7b64ec7b5903f6895107e0848d238", t.out)
         self.assertIn("pkg3/1.0: Package '283642385cc7b64ec7b5903f6895107e0848d238' created", t.out)
+
+    @unittest.skipUnless(get_env("TESTING_REVISIONS_ENABLED", False), "Only revisions")
+    def test_package_revision_mode_download(self):
+        t = TestClient(default_server_user=True)
+        t.save({
+            'package1.py': GenConanfile("pkg1"),
+            'package2.py':  textwrap.dedent("""
+                from conans import ConanFile
+                class Recipe(ConanFile):
+                    requires = "pkg1/1.0"
+                    def package_id(self):
+                        self.info.requires["pkg1"].package_revision_mode()
+                """),
+            'package3.py': GenConanfile("pkg3").with_require("pkg2/1.0")
+        })
+        t.run("create package1.py pkg1/1.0@")
+        t.run("create package2.py pkg2/1.0@")
+        t.run("create package3.py pkg3/1.0@")
+        t.run("upload * --all -c")
+        t.run("remove * -f")
+
+        # If we build pkg1, we need a new packageID for pkg2
+        t.run("install pkg3/1.0@ --build=pkg1")
+        self.assertIn("pkg2/1.0:Package_ID_unknown - Unknown", t.out)
+        self.assertIn("pkg3/1.0:3ea4b5f291451dab54b09abbf324d99d1f4f8cd7 - Download", t.out)
+        self.assertIn("pkg2/1.0: Unknown binary for pkg2/1.0, computing updated ID", t.out)
+        self.assertIn("pkg2/1.0: Updated ID: d3afcd43f39697e7529bcc7d1ec5b31c947de74c", t.out)
+        self.assertIn("pkg2/1.0: Binary for updated ID from: Download", t.out)
+        self.assertIn("pkg2/1.0: Retrieving package d3afcd43f39697e7529bcc7d1ec5b31c947de74c "
+                      "from remote 'default'", t.out)


### PR DESCRIPTION
Changelog: omit
Docs: omit

The case of ``Package_ID_Unknown`` that finally resolved to something that exists in the server and is downloaded instead of built from sources was not covered.