### PR TITLE
Fix broken custom output in self.run()

### DIFF
--- a/conans/client/runner.py
+++ b/conans/client/runner.py
@@ -76,7 +76,7 @@ class ConanRunner(object):
             # if the other fills the pip. So piping stdout, and redirecting stderr to stdout,
             # so both are merged and use just a single get_stream_lines() call
             capture_output = log_handler or not self._log_run_to_output or user_output \
-                             or isinstance(stream_output._stream, six.StringIO)
+                             or (stream_output and isinstance(stream_output._stream, six.StringIO))
             if capture_output:
                 proc = Popen(command, shell=isinstance(command, six.string_types), stdout=PIPE,
                              stderr=STDOUT, cwd=cwd)

--- a/conans/client/runner.py
+++ b/conans/client/runner.py
@@ -1,5 +1,4 @@
 import io
-import os
 import subprocess
 import sys
 from subprocess import PIPE, Popen, STDOUT
@@ -7,7 +6,6 @@ from subprocess import PIPE, Popen, STDOUT
 import six
 
 from conans.errors import ConanException
-from conans.unicode import get_cwd
 from conans.util.files import decode_text
 from conans.util.runners import pyinstaller_bundle_env_cleaned
 
@@ -77,7 +75,8 @@ class ConanRunner(object):
             # piping both stdout, stderr and then later only reading one will hang the process
             # if the other fills the pip. So piping stdout, and redirecting stderr to stdout,
             # so both are merged and use just a single get_stream_lines() call
-            capture_output = log_handler or not self._log_run_to_output or user_output
+            capture_output = log_handler or not self._log_run_to_output or user_output \
+                             or isinstance(stream_output._stream, six.StringIO)
             if capture_output:
                 proc = Popen(command, shell=isinstance(command, six.string_types), stdout=PIPE,
                              stderr=STDOUT, cwd=cwd)

--- a/conans/client/runner.py
+++ b/conans/client/runner.py
@@ -76,8 +76,7 @@ class ConanRunner(object):
             # piping both stdout, stderr and then later only reading one will hang the process
             # if the other fills the pip. So piping stdout, and redirecting stderr to stdout,
             # so both are merged and use just a single get_stream_lines() call
-            capture_output = log_handler or not self._log_run_to_output or (
-                    stream_output and isinstance(stream_output._stream, six.StringIO))
+            capture_output = log_handler or not self._log_run_to_output or stream_output
             if capture_output:
                 proc = Popen(command, shell=isinstance(command, six.string_types), stdout=PIPE,
                              stderr=STDOUT, cwd=cwd)

--- a/conans/client/runner.py
+++ b/conans/client/runner.py
@@ -42,7 +42,8 @@ class ConanRunner(object):
             print("*** WARN: Invalid output parameter of type io.StringIO(), "
                   "use six.StringIO() instead ***")
 
-        stream_output = output if output and hasattr(output, "write") else self._output or sys.stdout
+        user_output = output if output and hasattr(output, "write") else None
+        stream_output = user_output or self._output or sys.stdout
         if hasattr(stream_output, "flush"):
             # We do not want output from different streams to get mixed (sys.stdout, os.system)
             stream_output = _UnbufferedWrite(stream_output)
@@ -66,17 +67,17 @@ class ConanRunner(object):
                 with open(log_filepath, "a+") as log_handler:
                     if self._print_commands_to_output:
                         log_handler.write(call_message)
-                    return self._pipe_os_call(command, stream_output, log_handler, cwd)
+                    return self._pipe_os_call(command, stream_output, log_handler, cwd, user_output)
             else:
-                return self._pipe_os_call(command, stream_output, None, cwd)
+                return self._pipe_os_call(command, stream_output, None, cwd, user_output)
 
-    def _pipe_os_call(self, command, stream_output, log_handler, cwd):
+    def _pipe_os_call(self, command, stream_output, log_handler, cwd, user_output):
 
         try:
             # piping both stdout, stderr and then later only reading one will hang the process
             # if the other fills the pip. So piping stdout, and redirecting stderr to stdout,
             # so both are merged and use just a single get_stream_lines() call
-            capture_output = log_handler or not self._log_run_to_output or stream_output
+            capture_output = log_handler or not self._log_run_to_output or user_output
             if capture_output:
                 proc = Popen(command, shell=isinstance(command, six.string_types), stdout=PIPE,
                              stderr=STDOUT, cwd=cwd)
@@ -112,17 +113,9 @@ class ConanRunner(object):
         ret = proc.returncode
         return ret
 
-    def _simple_os_call(self, command, cwd):
-        if not cwd:
-            return subprocess.call(command, shell=isinstance(command, six.string_types))
-        else:
-            try:
-                old_dir = get_cwd()
-                os.chdir(cwd)
-                result = subprocess.call(command, shell=isinstance(command, six.string_types))
-            except Exception as e:
-                raise ConanException("Error while executing"
-                                     " '%s'\n\t%s" % (command, str(e)))
-            finally:
-                os.chdir(old_dir)
-            return result
+    @staticmethod
+    def _simple_os_call(command, cwd):
+        try:
+            return subprocess.call(command, cwd=cwd, shell=isinstance(command, six.string_types))
+        except Exception as e:
+            raise ConanException("Error while executing '%s'\n\t%s" % (command, str(e)))


### PR DESCRIPTION
Changelog: Bugfix: Fix regression in self.run(output=xxxx) that have a write() method but do not wrap a stream.
Docs: Omit

Fix #7888

https://github.com/conan-io/conan/pull/7893 with minimal changes.

- [X] Refer to the issue that supports this Pull Request.
- [X] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [X] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [X] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 

<sup>**Note:** By default this PR will skip the slower tests and will use a limited set of python versions. Check [here](https://github.com/conan-io/conan/blob/develop/.github/PR_INCREASE_TESTING.md) how to increase the testing level by writing some tags in the current PR body text.</sup>
