### PR TITLE
Set default storage folder to $CONAN_USER_HOME/.conan/data

### DIFF
--- a/conans/client/cache/cache.py
+++ b/conans/client/cache/cache.py
@@ -76,7 +76,7 @@ class ClientCache(object):
         self._config = None
         self.editable_packages = EditablePackages(self.cache_folder)
         # paths
-        self._store_folder = self.config.storage_path or self.cache_folder
+        self._store_folder = self.config.storage_path or os.path.join(self.cache_folder, "data")
         # Just call it to make it raise in case of short_paths misconfiguration
         _ = self.config.short_paths_home
 


### PR DESCRIPTION
Changelog: Bugfix: Set default storage_folder to .conan/data in case if storage_path entry fails to be defined by conan.conf.
Docs: Omit

Set default storage_folder to .conan/data in case if storage/path entry is missing from the conan.conf. Usage of .conan for storage root seems to be a mistake and leads to failures in case of various operations, like conan config install <some_relatively_deep_git_repo>


We've noticed that sometimes when doing conan install from a git repo, we're getting an error like:
```
conan config install <sample-repo>
Trying to clone repo: <sample-repo>
Repo cloned!
Defining remotes from remotes.txt
ERROR: Failed conan config install: Value provided for package version, '.git' (type Version), is an invalid name. Valid names MUST begin with a letter, number or underscore, have between 2-51 chars, including letters, numbers, underscore, dot and dash
```

It turned out that, if [storage] / path entry in conan.conf is missing, the default storage path would be set to $CONAN_USER_HOME/.conan ; which looks to be incorrect. Default per [here](https://github.com/conan-io/conan/blob/develop/conans/client/conf/__init__.py#L189) seems to be $CONAN_USER_HOME/.conan/data . 
Later during conan config install command execution, conan tries to traverse all packages to fix the remotes, but given that it clones the config repo to the temporary directory within .conan dir, it tries to read packages in the temporarily cloned repo and fails with the error above.
Adding "data" at the end of the path fixes the error.

- [ ] Refer to the issue that supports this Pull Request.
- [ ] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 

<sup>**Note:** By default this PR will skip the slower tests and will use a limited set of python versions. Check [here](https://github.com/conan-io/conan/blob/develop/.github/PR_INCREASE_TESTING.md) how to increase the testing level by writing some tags in the current PR body text.</sup>
