### PR TITLE
Add 'provides' and 'deprecated' fields to 'conan info' output

### DIFF
--- a/conans/client/command.py
+++ b/conans/client/command.py
@@ -629,7 +629,8 @@ class Command(object):
         """
 
         info_only_options = ["id", "build_id", "remote", "url", "license", "requires", "update",
-                             "required", "date", "author", "description", "None"]
+                             "required", "date", "author", "description", "provides", "deprecated",
+                             "None"]
         path_only_options = ["export_folder", "build_folder", "package_folder", "source_folder"]
         str_path_only_options = ", ".join(['"%s"' % field for field in path_only_options])
         str_only_options = ", ".join(['"%s"' % field for field in info_only_options])

--- a/conans/client/conan_command_output.py
+++ b/conans/client/conan_command_output.py
@@ -14,6 +14,7 @@ from conans.util.dates import iso8601_to_str
 from conans.util.env_reader import get_env
 from conans.util.files import save
 from conans import __version__ as client_version
+from conans.util.misc import make_tuple
 
 
 class CommandOutputer(object):
@@ -166,8 +167,7 @@ class CommandOutputer(object):
                     if not as_list:
                         item_data[attrib] = value
                     else:
-                        item_data[attrib] = list(value) if isinstance(value, (list, tuple, set)) \
-                            else [value, ]
+                        item_data[attrib] = make_tuple(value)
 
             _add_if_exists("url")
             _add_if_exists("homepage")
@@ -175,6 +175,8 @@ class CommandOutputer(object):
             _add_if_exists("author")
             _add_if_exists("description")
             _add_if_exists("topics", as_list=True)
+            _add_if_exists("deprecated")
+            _add_if_exists("provides", as_list=True)
 
             if isinstance(ref, ConanFileReference):
                 item_data["recipe"] = node.recipe

--- a/conans/client/printer.py
+++ b/conans/client/printer.py
@@ -103,6 +103,11 @@ class Printer(object):
             if show("topics") and "topics" in it:
                 self._out.writeln("    Topics: %s" % ", ".join(it["topics"]), Color.BRIGHT_GREEN)
 
+            if show("provides") and "provides" in it:
+                self._out.writeln("    Provides: %s" % ", ".join(it["provides"]), Color.BRIGHT_GREEN)
+
+            _print("deprecated", name="Deprecated")
+
             _print("recipe", name="Recipe", color=None)
             if show_revisions:
                 _print("revision", name="Revision", color=None)

--- a/conans/test/functional/command/info/info_test.py
+++ b/conans/test/functional/command/info/info_test.py
@@ -15,7 +15,7 @@ from conans.util.files import save
 
 class InfoTest(unittest.TestCase):
 
-    def not_found_package_dirty_cache_test(self):
+    def test_not_found_package_dirty_cache(self):
         # Conan does a lock on the cache, and even if the package doesn't exist
         # left a trailing folder with the filelocks. This test checks
         # it will be cleared
@@ -26,7 +26,7 @@ class InfoTest(unittest.TestCase):
         client.save({"conanfile.py": GenConanfile().with_name("Nothing").with_version("0.1")})
         client.run("export . user/testing")
 
-    def failed_info_test(self):
+    def test_failed_info(self):
         client = TestClient()
         client.save({"conanfile.py": GenConanfile().with_require("Pkg/1.0.x@user/testing")})
         client.run("info .", assert_error=True)
@@ -74,7 +74,7 @@ class InfoTest(unittest.TestCase):
             self.client.run("export . lasote/stable")
             self.assertNotIn("WARN: Conanfile doesn't have 'url'", self.client.out)
 
-    def install_folder_test(self):
+    def test_install_folder(self):
         conanfile = GenConanfile("Pkg", "0.1").with_setting("build_type")
         client = TestClient()
         client.save({"conanfile.py": conanfile})
@@ -106,7 +106,7 @@ class InfoTest(unittest.TestCase):
         self.assertIn("--install-folder cannot be used together with a"
                       " host profile (-s, -o, -e or -pr)", client.out)
 
-    def graph_test(self):
+    def test_graph(self):
         self.client = TestClient()
 
         test_deps = {
@@ -175,7 +175,7 @@ class InfoTest(unittest.TestCase):
         dot_file = os.path.join(self.client.current_folder, arg_filename)
         check_file(dot_file)
 
-    def graph_html_test(self):
+    def test_graph_html(self):
         self.client = TestClient()
 
         test_deps = {
@@ -205,7 +205,7 @@ class InfoTest(unittest.TestCase):
                       " JFrog LTD. <a>https://conan.io</a>"
                       .format(client_version, datetime.today().year), html)
 
-    def graph_html_embedded_visj_test(self):
+    def test_graph_html_embedded_visj(self):
         client = TestClient()
         visjs_path = os.path.join(client.cache_folder, "vis.min.js")
         viscss_path = os.path.join(client.cache_folder, "vis.min.css")
@@ -219,7 +219,7 @@ class InfoTest(unittest.TestCase):
         self.assertIn(visjs_path, html)
         self.assertIn(viscss_path, html)
 
-    def info_build_requires_test(self):
+    def test_info_build_requires(self):
         client = TestClient()
         client.save({"conanfile.py": GenConanfile()})
         client.run("create . tool/0.1@user/channel")
@@ -250,7 +250,7 @@ class InfoTest(unittest.TestCase):
                       "shape: 'ellipse',\n                        "
                       "color: { background: 'SkyBlue'},", html)
 
-    def only_names_test(self):
+    def test_only_names(self):
         self.client = TestClient()
         self._create("Hello0", "0.1")
         self._create("Hello1", "0.1", ["Hello0/0.1@lasote/stable"])
@@ -288,7 +288,7 @@ class InfoTest(unittest.TestCase):
         path = os.path.join(client.current_folder, "jsonfile.txt")
         self.assertTrue(os.path.exists(path))
 
-    def info_virtual_test(self):
+    def test_info_virtual(self):
         # Checking that "Required by: virtual" doesnt appear in the output
         self.client = TestClient()
         self._create("Hello", "0.1")
@@ -308,13 +308,13 @@ class InfoTest(unittest.TestCase):
         self.assertIn("ID: ", self.client.out)
         self.assertIn("BuildID: ", self.client.out)
 
-        expected_output = textwrap.dedent(
-            """\
+        expected_output = textwrap.dedent("""\
             Hello0/0.1@lasote/stable
                 Remote: None
                 URL: myurl
                 License: MIT
                 Description: blah
+                Provides: Hello0
                 Recipe: No remote%s
                 Binary: Missing
                 Binary remote: None
@@ -325,6 +325,7 @@ class InfoTest(unittest.TestCase):
                 URL: myurl
                 License: MIT
                 Description: blah
+                Provides: Hello1
                 Recipe: No remote%s
                 Binary: Missing
                 Binary remote: None
@@ -338,6 +339,7 @@ class InfoTest(unittest.TestCase):
                 Description: Yo no creo en brujas,
                              pero que las hay,
                              las hay
+                Provides: Hello2
                 Requires:
                     Hello1/0.1@lasote/stable""")
 
@@ -362,8 +364,7 @@ class InfoTest(unittest.TestCase):
         self.assertIn(expected_output, clean_output(self.client.out))
 
         self.client.run("info . -u --only=url")
-        expected_output = textwrap.dedent(
-            """\
+        expected_output = textwrap.dedent("""\
             Hello0/0.1@lasote/stable
                 URL: myurl
             Hello1/0.1@lasote/stable
@@ -373,8 +374,7 @@ class InfoTest(unittest.TestCase):
 
         self.assertIn(expected_output, clean_output(self.client.out))
         self.client.run("info . -u --only=url --only=license")
-        expected_output = textwrap.dedent(
-            """\
+        expected_output = textwrap.dedent("""\
             Hello0/0.1@lasote/stable
                 URL: myurl
                 License: MIT
@@ -388,8 +388,7 @@ class InfoTest(unittest.TestCase):
         self.assertIn(expected_output, clean_output(self.client.out))
 
         self.client.run("info . -u --only=url --only=license --only=description")
-        expected_output = textwrap.dedent(
-            """\
+        expected_output = textwrap.dedent("""\
             Hello0/0.1@lasote/stable
                 URL: myurl
                 License: MIT
@@ -430,7 +429,7 @@ class InfoTest(unittest.TestCase):
         self.assertEqual(content[1]["url"], "myurl")
         self.assertEqual(content[1]["required_by"][0], "conanfile.py (LibD/0.1)")
 
-    def build_order_test(self):
+    def test_build_order(self):
         self.client = TestClient()
         self._create("Hello0", "0.1")
         self._create("Hello1", "0.1", ["Hello0/0.1@lasote/stable"])
@@ -463,7 +462,7 @@ class InfoTest(unittest.TestCase):
                         "--graph=index.html", assert_error=True)
         self.assertIn("--build-order cannot be used together with --graph", self.client.out)
 
-    def build_order_build_requires_test(self):
+    def test_build_order_build_requires(self):
         # https://github.com/conan-io/conan/issues/3267
         client = TestClient()
         conanfile = str(GenConanfile())
@@ -480,7 +479,7 @@ class InfoTest(unittest.TestCase):
         self.assertIn("[tool/0.1@user/channel], [Pkg/0.1@user/channel, Pkg2/0.1@user/channel]",
                       client.out)
 
-    def build_order_privates_test(self):
+    def test_build_order_privates(self):
         # https://github.com/conan-io/conan/issues/3267
         client = TestClient()
         client.save({"conanfile.py": GenConanfile()})
@@ -498,7 +497,7 @@ class InfoTest(unittest.TestCase):
                       "[Pkg/0.1@user/channel, Pkg2/0.1@user/channel]",
                       client.out)
 
-    def diamond_build_order_test(self):
+    def test_diamond_build_order(self):
         self.client = TestClient()
         self._create("LibA", "0.1")
         self._create("LibE", "0.1")
@@ -539,7 +538,7 @@ class InfoTest(unittest.TestCase):
                       "LibF/0.1@lasote/stable], [LibB/0.1@lasote/stable, LibC/0.1@lasote/stable]",
                       self.client.out)
 
-    def wrong_path_parameter_test(self):
+    def test_wrong_path_parameter(self):
         self.client = TestClient()
 
         self.client.run("info", assert_error=True)
@@ -584,7 +583,7 @@ class InfoTest(unittest.TestCase):
                 topics = ("foo", "bar", "qux")
                 provides = ("libjpeg", "libjpg")
                 deprecated = "other-pkg"
-            """)
+        """)
 
         client.save({"subfolder/conanfile.py": conanfile})
         client.run("export ./subfolder lasote/testing")
@@ -610,15 +609,16 @@ class InfoTest(unittest.TestCase):
         self.assertListEqual(output['provides'], ['libjpeg', 'libjpg'])
         self.assertEquals(output['deprecated'], 'other-pkg')
 
-    def topics_graph_test(self):
+    def test_topics_graph(self):
 
-        conanfile = """from conans import ConanFile
+        conanfile = textwrap.dedent("""
+            from conans import ConanFile
 
-class MyTest(ConanFile):
-    name = "Pkg"
-    version = "0.2"
-    topics = ("foo", "bar", "qux")
-        """
+            class MyTest(ConanFile):
+                name = "Pkg"
+                version = "0.2"
+                topics = ("foo", "bar", "qux")
+        """)
 
         client = TestClient()
         client.save({"conanfile.py": conanfile})
@@ -639,7 +639,7 @@ class MyTest(ConanFile):
         self.assertIn("<h3>Pkg/0.2@lasote/testing</h3>", html_content)
         self.assertIn("<li><b>topics</b>: foo", html_content)
 
-    def wrong_graph_info_test(self):
+    def test_wrong_graph_info(self):
         # https://github.com/conan-io/conan/issues/4443
         conanfile = GenConanfile().with_name("Hello").with_version("0.1")
         client = TestClient()
@@ -656,7 +656,7 @@ class MyTest(ConanFile):
         client.run("info .", assert_error=True)
         self.assertIn("ERROR: Error parsing GraphInfo from file", client.out)
 
-    def previous_lockfile_error_test(self):
+    def test_previous_lockfile_error(self):
         # https://github.com/conan-io/conan/issues/5479
         client = TestClient()
         client.save({"conanfile.py": GenConanfile().with_name("pkg").with_version("0.1")})

--- a/conans/test/functional/editable/commands/info_on_child_test.py
+++ b/conans/test/functional/editable/commands/info_on_child_test.py
@@ -62,6 +62,7 @@ class InfoCommandTest(unittest.TestCase):
                       "    ID: e94ed0d45e4166d2f946107eaa208d550bf3691e\n"
                       "    BuildID: None\n"
                       "    Remote: None\n"
+                      "    Provides: lib\n"
                       "    Recipe: Editable\n{}"
                       "    Binary: Editable\n"
                       "    Binary remote: None\n"

--- a/conans/test/functional/editable/commands/info_test.py
+++ b/conans/test/functional/editable/commands/info_test.py
@@ -30,9 +30,9 @@ class LinkedPackageAsProject(unittest.TestCase):
         self.t.run('create . {}'.format(self.ref_parent))
 
         self.t.save(files={'conanfile.py':
-                           self.conanfile_base.format(
-                               body='requires = "{}"'.format(self.ref_parent)),
-                           "mylayout": self.conan_package_layout, })
+            self.conanfile_base.format(
+                body='requires = "{}"'.format(self.ref_parent)),
+            "mylayout": self.conan_package_layout, })
         self.t.run('editable add . {}'.format(self.ref))
         self.assertTrue(self.t.cache.installed_as_editable(self.ref))
 
@@ -76,6 +76,7 @@ class InfoCommandUsingReferenceTest(LinkedPackageAsProject):
                    "    ID: e94ed0d45e4166d2f946107eaa208d550bf3691e\n" \
                    "    BuildID: None\n" \
                    "    Remote: None\n" \
+                   "    Provides: lib\n" \
                    "    Recipe: Editable\n{}" \
                    "    Binary: Editable\n" \
                    "    Binary remote: None\n" \


### PR DESCRIPTION
Changelog: Feature: Add `provides` and `deprecated` fields to `conan info` output
Docs: omit

Changes:
 * Add `provides` and `deprecated` fields to `conan info` output
 * Minor format changes:
   + test names to match _standard_ names expected by `pytest`
   + some `textwrap.dedent`