### PR TITLE
toolchain work with paths with spaces

### DIFF
--- a/conans/client/build/cmake_toolchain_build_helper.py
+++ b/conans/client/build/cmake_toolchain_build_helper.py
@@ -75,7 +75,7 @@ class CMakeToolchainBuildHelper(object):
             build_folder = os.path.join(self._conanfile.build_folder, self._build_folder)
 
         mkdir(build_folder)
-        arg_list = '-DCMAKE_TOOLCHAIN_FILE="%s" %s' % (CMakeToolchainBase.filename, source)
+        arg_list = '-DCMAKE_TOOLCHAIN_FILE="%s" "%s"' % (CMakeToolchainBase.filename, source)
 
         generator = '-G "{}" '.format(self._generator) if self._generator else ""
         command = "%s %s%s" % (self._cmake_program, generator, arg_list)

--- a/conans/test/functional/toolchain/test_cmake.py
+++ b/conans/test/functional/toolchain/test_cmake.py
@@ -117,7 +117,7 @@ class Base(unittest.TestCase):
         """)
 
     def setUp(self):
-        self.client = TestClient(path_with_spaces=False)
+        self.client = TestClient(path_with_spaces=True)
         conanfile = textwrap.dedent("""
             from conans import ConanFile
             from conans.tools import save


### PR DESCRIPTION
Changelog: Omit
Docs: Omit

Toolchains did not work in paths with spaces after changes in https://github.com/conan-io/conan/pull/7913
