### PR TITLE
intel unittest were not being run, missing init.py

### DIFF
--- a/conans/client/tools/intel.py
+++ b/conans/client/tools/intel.py
@@ -63,7 +63,7 @@ def intel_compilervars_command(conanfile, arch=None, compiler_version=None, forc
     :return:
     """
     if "PSTLROOT" in os.environ and not force:
-        return "echo Conan:compilervars already set"
+        return "echo Conan:intel_compilervars already set"
     settings = conanfile.settings
     compiler_version = compiler_version or settings.get_safe("compiler.version")
     arch = arch or settings.get_safe("arch")

--- a/conans/test/unittests/client/tools/intel/compilervars_test.py
+++ b/conans/test/unittests/client/tools/intel/compilervars_test.py
@@ -40,19 +40,18 @@ class CompilerVarsTest(unittest.TestCase):
 
             settings.arch = "x86"
             cvars = intel_compilervars_command(MockConanfile(settings))
-            expected = '"%s" -arch ia32' % path
+            expected = 'call "%s" -arch ia32' % path
             self.assertEqual(expected, cvars)
 
             settings.compiler.base.version = "16"
             cvars = intel_compilervars_command(MockConanfile(settings))
-            expected = '"%s" -arch ia32 vs2019' % path
+            expected = 'call "%s" -arch ia32 vs2019' % path
             self.assertEqual(expected, cvars)
 
             settings.arch = "x86_64"
-            expected = '"%s" -arch intel64 vs2019' % path
+            expected = 'call "%s" -arch intel64 vs2019' % path
             cvars = intel_compilervars_command(MockConanfile(settings))
             self.assertEqual(expected, cvars)
-
 
     def test_linux(self):
         install_dir = "/opt/intel"


### PR DESCRIPTION
Changelog: omit
Docs: omit


Without the ``__init__.py`` nosetest do not discover the test, and didn't run it