### PR TITLE
update message on create_settings when settings are constrained

### DIFF
--- a/conans/model/conan_file.py
+++ b/conans/model/conan_file.py
@@ -69,7 +69,7 @@ def create_settings(conanfile, settings):
         settings.constraint(current)
         return settings
     except Exception as e:
-        raise ConanInvalidConfiguration("Error while initializing settings. %s" % str(e))
+        raise ConanInvalidConfiguration("The recipe is contraining settings. %s" % str(e))
 
 
 @contextmanager

--- a/conans/test/conan_v2/settings_model/test_cppstd.py
+++ b/conans/test/conan_v2/settings_model/test_cppstd.py
@@ -30,7 +30,7 @@ class SettingsCppstdTestCase(ConanV2ModeTestCase):
         if use_settings_v1:
             self.assertIn("Conan v2 incompatible: Setting 'cppstd' is deprecated", t.out)
         else:
-            self.assertIn("ERROR: Error while initializing settings. 'settings.cppstd' doesn't exist", t.out)
+            self.assertIn("ERROR: The recipe is contraining settings. 'settings.cppstd' doesn't exist", t.out)
 
     @parameterized.expand([(True,), (False,)])
     def test_settings_model(self, use_settings_v1):


### PR DESCRIPTION
Changelog: Fix: displayed message when settings of the recipe are constrained.
Docs: https://github.com/conan-io/docs/pull/1890
Closes #6802
- [x] Refer to the issue that supports this Pull Request.
- [ ] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [x] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 

<sup>**Note:** By default this PR will skip the slower tests and will use a limited set of python versions. Check [here](https://github.com/conan-io/conan/blob/develop/.github/PR_INCREASE_TESTING.md) how to increase the testing level by writing some tags in the current PR body text.</sup>
