### PR TITLE
Fix cmake build helper get_definitions when failed CMake get version

### DIFF
--- a/conans/client/build/cmake.py
+++ b/conans/client/build/cmake.py
@@ -98,7 +98,12 @@ class CMakeBuildHelper(object):
         # FIXME CONAN 2.0: CMake() interface should be always the constructor and self.definitions.
         # FIXME CONAN 2.0: Avoid properties and attributes to make the user interface more clear
 
-        self.definitions = builder.get_definitions(self.get_version())
+        try:
+            cmake_version = self.get_version()
+            self.definitions = builder.get_definitions(cmake_version)
+        except ConanException:
+            self.definitions = builder.get_definitions(None)
+
         self.definitions["CONAN_EXPORTED"] = "1"
 
         self.toolset = toolset or get_toolset(self._settings, self.generator)

--- a/conans/client/build/cmake_flags.py
+++ b/conans/client/build/cmake_flags.py
@@ -204,7 +204,8 @@ class CMakeDefinitionsBuilder(object):
         else:  # detect if we are cross building and the system name and version
             skip_x64_x86 = os_ in ['Windows', 'Linux']
             if cross_building(self._conanfile, skip_x64_x86=skip_x64_x86):  # We are cross building
-                apple_system_name = "Darwin" if Version(cmake_version) < Version("3.14") else None
+                apple_system_name = "Darwin" if cmake_version and Version(cmake_version) < Version(
+                    "3.14") or not cmake_version else None
                 cmake_system_name_map = {"Macos": "Darwin",
                                          "iOS": apple_system_name or "iOS",
                                          "tvOS": apple_system_name or "tvOS",

--- a/conans/test/unittests/client/generators/cmake_test.py
+++ b/conans/test/unittests/client/generators/cmake_test.py
@@ -334,6 +334,8 @@ endmacro()""", macro)
         self.assertEqual("Darwin", definitions["CMAKE_SYSTEM_NAME"])
         definitions = definitions_builder.get_definitions("3.14")
         self.assertEqual("iOS", definitions["CMAKE_SYSTEM_NAME"])
+        definitions = definitions_builder.get_definitions(None)
+        self.assertEqual("Darwin", definitions["CMAKE_SYSTEM_NAME"])
 
     def test_cmake_definitions_cmake_not_in_path(self):
         def raise_get_version():

--- a/conans/test/unittests/client/generators/cmake_test.py
+++ b/conans/test/unittests/client/generators/cmake_test.py
@@ -3,7 +3,10 @@ import re
 import unittest
 
 import six
+from mock import patch
 
+import conans
+from conans.client.build.cmake import CMakeBuildHelper
 from conans.client.build.cmake_flags import CMakeDefinitionsBuilder
 from conans.client.conf import get_default_settings_yml
 from conans.client.generators import CMakeFindPackageGenerator, CMakeFindPackageMultiGenerator
@@ -331,6 +334,19 @@ endmacro()""", macro)
         self.assertEqual("Darwin", definitions["CMAKE_SYSTEM_NAME"])
         definitions = definitions_builder.get_definitions("3.14")
         self.assertEqual("iOS", definitions["CMAKE_SYSTEM_NAME"])
+
+    def test_cmake_definitions_cmake_not_in_path(self):
+        def raise_get_version():
+            raise ConanException('Error retrieving CMake version')
+
+        with patch.object(conans.client.build.cmake.CMakeBuildHelper, "get_version",
+                          side_effect=raise_get_version):
+            settings_mock = _MockSettings(build_type="Release")
+            conanfile = ConanFile(TestBufferConanOutput(), None)
+            install_folder = "/c/foo/testing"
+            setattr(conanfile, "install_folder", install_folder)
+            conanfile.initialize(settings_mock, EnvValues())
+            assert CMakeBuildHelper(conanfile)
 
     def test_apple_frameworks(self):
         settings = Settings.loads(get_default_settings_yml())


### PR DESCRIPTION
Changelog: omit
Docs: omit

Develop CI broken at: https://github.com/conan-io/conan/pull/7924

Just to test if it fixes develop after: https://conan-ci.jfrog.info/blue/organizations/jenkins/ConanTestSuite/detail/develop/695/pipeline/414

#TAGS: slow
