### PR TITLE
Move 'CMAKE_INSTALL_PREFIX' to the command-line

### DIFF
--- a/conans/client/build/cmake_toolchain_build_helper.py
+++ b/conans/client/build/cmake_toolchain_build_helper.py
@@ -77,7 +77,7 @@ class CMakeToolchainBuildHelper(object):
         mkdir(build_folder)
         arg_list = '-DCMAKE_TOOLCHAIN_FILE="{}" -DCMAKE_INSTALL_PREFIX="{}" "{}"'.format(
             CMakeToolchainBase.filename,
-            self._conanfile.package_folder.package_folder.replace("\\", "/"),
+            self._conanfile.package_folder.replace("\\", "/"),
             source)
 
         generator = '-G "{}" '.format(self._generator) if self._generator else ""

--- a/conans/client/build/cmake_toolchain_build_helper.py
+++ b/conans/client/build/cmake_toolchain_build_helper.py
@@ -76,7 +76,9 @@ class CMakeToolchainBuildHelper(object):
 
         mkdir(build_folder)
         arg_list = '-DCMAKE_TOOLCHAIN_FILE="{}" -DCMAKE_INSTALL_PREFIX="{}" "{}"'.format(
-            CMakeToolchainBase.filename, self._conanfile.package_folder, source)
+            CMakeToolchainBase.filename,
+            self._conanfile.package_folder.package_folder.replace("\\", "/"),
+            source)
 
         generator = '-G "{}" '.format(self._generator) if self._generator else ""
         command = "%s %s%s" % (self._cmake_program, generator, arg_list)

--- a/conans/client/build/cmake_toolchain_build_helper.py
+++ b/conans/client/build/cmake_toolchain_build_helper.py
@@ -75,7 +75,8 @@ class CMakeToolchainBuildHelper(object):
             build_folder = os.path.join(self._conanfile.build_folder, self._build_folder)
 
         mkdir(build_folder)
-        arg_list = '-DCMAKE_TOOLCHAIN_FILE="%s" "%s"' % (CMakeToolchainBase.filename, source)
+        arg_list = '-DCMAKE_TOOLCHAIN_FILE="{}" -DCMAKE_INSTALL_PREFIX="{}" "{}"'.format(
+            CMakeToolchainBase.filename, self._conanfile.package_folder, source)
 
         generator = '-G "{}" '.format(self._generator) if self._generator else ""
         command = "%s %s%s" % (self._cmake_program, generator, arg_list)

--- a/conans/client/toolchain/cmake/base.py
+++ b/conans/client/toolchain/cmake/base.py
@@ -114,11 +114,6 @@ class CMakeToolchainBase(object):
             {%- endif %}
         {% endblock %}
 
-        # Install prefix
-        {% if install_prefix -%}
-        set(CMAKE_INSTALL_PREFIX "{{install_prefix}}" CACHE STRING "" FORCE)
-        {%- endif %}
-
         # Variables
         {% for it, value in variables.items() %}
         set({{ it }} "{{ value }}")
@@ -144,13 +139,6 @@ class CMakeToolchainBase(object):
         self.cmake_prefix_path = "${CMAKE_BINARY_DIR}"
         self.cmake_module_path = "${CMAKE_BINARY_DIR}"
 
-        try:
-            # This is only defined in the cache, not in the local flow
-            self.install_prefix = self._conanfile.package_folder.replace("\\", "/")
-        except AttributeError:
-            # FIXME: In the local flow, we don't know the package_folder
-            self.install_prefix = None
-
         self.build_type = None
 
     def _get_templates(self):
@@ -170,7 +158,6 @@ class CMakeToolchainBase(object):
             "preprocessor_definitions_config": self.preprocessor_definitions.configuration_types,
             "cmake_prefix_path": self.cmake_prefix_path,
             "cmake_module_path": self.cmake_module_path,
-            "install_prefix": self.install_prefix,
             "build_type": self.build_type,
         }
         return ctxt_toolchain, {}


### PR DESCRIPTION
Changelog: omit
Docs: omit

If the value for `CMAKE_INSTALL_PREFIX` is not known in the local-workflow, it makes no sense to add that value to the toolchain template. And the cache-workflow can use the command line to set the value.
