### PR TITLE
avoid loading config when not running migrations

### DIFF
--- a/conans/migrations.py
+++ b/conans/migrations.py
@@ -9,9 +9,8 @@ CONAN_VERSION = "version.txt"
 
 class Migrator(object):
 
-    def __init__(self, conf_path, store_path, current_version, out):
+    def __init__(self, conf_path, current_version, out):
         self.conf_path = conf_path
-        self.store_path = store_path
 
         self.current_version = current_version
         self.file_version_path = os.path.join(self.conf_path, CONAN_VERSION)

--- a/conans/server/migrations.py
+++ b/conans/server/migrations.py
@@ -15,19 +15,11 @@ class ServerMigrator(Migrator):
 
     def __init__(self, conf_path, store_path, current_version, out, force_migrations):
         self.force_migrations = force_migrations
-        super(ServerMigrator, self).__init__(conf_path, store_path, current_version, out)
+        self.store_path = store_path
+        super(ServerMigrator, self).__init__(conf_path, current_version, out)
 
     def _make_migrations(self, old_version):
         # ############### FILL THIS METHOD WITH THE REQUIRED ACTIONS ##############
-
-        # VERSION 0.1
-        if old_version == Version("0.1"):
-            # Remove config, conans, all!
-            self.out.warn("Reseting configuration and storage files...")
-            if self.conf_path:
-                rmdir(self.conf_path)
-            if self.store_path:
-                rmdir(self.store_path)
 
         if old_version < Version("1.10.0"):
             if not os.path.exists(self.store_path) or not os.listdir(self.store_path):

--- a/conans/test/functional/command/config_test.py
+++ b/conans/test/functional/command/config_test.py
@@ -4,6 +4,7 @@ import unittest
 import six
 
 from conans.errors import ConanException
+from conans.test.utils.genconanfile import GenConanfile
 from conans.test.utils.tools import TestClient
 from conans.util.files import load, save_append
 from conans.test.utils.test_files import temp_folder
@@ -112,10 +113,19 @@ class ConfigTest(unittest.TestCase):
             client.run("config home --json home.json")
             self._assert_dict_subset({"home": cache_folder}, json.loads(client.load("home.json")))
 
+    def test_config_home_custom_install(self):
+        cache_folder = os.path.join(temp_folder(), "custom")
+        with environment_append({"CONAN_USER_HOME": cache_folder}):
+            client = TestClient(cache_folder=cache_folder, cache_autopopulate=False)
+            client.save({"conanfile.py": GenConanfile()})
+            client.run("install .")
+            self.assertIn("conanfile.py: Installing package", client.out)
+
     def test_config_home_short_home_dir(self):
         cache_folder = os.path.join(temp_folder(), "custom")
         with environment_append({"CONAN_USER_HOME_SHORT": cache_folder}):
-            with six.assertRaisesRegex(self, ConanException, "cannot be a subdirectory of the conan cache"):
+            with six.assertRaisesRegex(self, ConanException,
+                                       "cannot be a subdirectory of the conan cache"):
                 TestClient(cache_folder=cache_folder)
 
     def test_config_home_short_home_dir_contains_cache_dir(self):

--- a/conans/test/functional/test_migrations.py
+++ b/conans/test/functional/test_migrations.py
@@ -204,7 +204,7 @@ the old general
                                                         "layout": "anyfile"}}))
 
         cache = TestClient(cache_folder=tmp_folder).cache
-        migrate_editables_use_conanfile_name(cache, None)
+        migrate_editables_use_conanfile_name(cache)
 
         # Now we have same info and full paths
         with open(os.path.join(tmp_folder, EDITABLE_PACKAGES_FILE)) as f:


### PR DESCRIPTION
Changelog: Fix: Avoid unnecessary extra loading of *conan.conf* file in the version migrations check.
Docs: Omit

Discover this while investigating: https://github.com/conan-io/conan/issues/7948

We are loading the **conan.conf** too many times. One of them is for migrations, even if migration is not necessary, not executed, creating a ``ClientCache()`` object unnecessarily loads the config. Delayed it instantiation to avoid it.
