### PR TITLE
Bump cryptography to >= 3.2

### DIFF
--- a/conans/requirements.txt
+++ b/conans/requirements.txt
@@ -15,6 +15,6 @@ tqdm>=4.28.1, <5
 Jinja2>=2.9, <3
 python-dateutil>=2.7.0, <3
 idna==2.6 ; sys_platform == "darwin" # Solving conflict, somehow is installing 2.7 when requests require 2.6
-cryptography>=1.3.4, <2.4.0 ; sys_platform == "darwin"
+cryptography>=3.2, <4 ; sys_platform == "darwin"
 pyOpenSSL>=16.0.0, <19.0.0 ; sys_platform == "darwin"
 


### PR DESCRIPTION
Changelog: Fix: Bump _cryptography_ dependency in MacOS to equal or later than 3.2.
Docs: omit

Close https://github.com/conan-io/conan/issues/6290

#TAGS: svn, slow
#REVISIONS: 1
