### PR TITLE
Better UX error for migrations

### DIFF
--- a/conans/client/migrations.py
+++ b/conans/client/migrations.py
@@ -95,7 +95,7 @@ class ClientMigrator(Migrator):
             migrate_editables_use_conanfile_name(cache)
 
         if old_version < Version("1.31.0"):
-            migrate_tgz_location(self.cache, self.out)
+            migrate_tgz_location(cache, self.out)
 
 
 def _get_refs(cache):

--- a/conans/migrations.py
+++ b/conans/migrations.py
@@ -32,6 +32,8 @@ class Migrator(object):
     def _update_version_file(self):
         try:
             save(self.file_version_path, str(self.current_version))
+        except OSError as error:
+            raise ConanException(str(error))
         except Exception:
             raise ConanException("Can't write version file in %s" % self.file_version_path)
 

--- a/conans/migrations.py
+++ b/conans/migrations.py
@@ -32,10 +32,9 @@ class Migrator(object):
     def _update_version_file(self):
         try:
             save(self.file_version_path, str(self.current_version))
-        except OSError as error:
-            raise ConanException(str(error))
-        except Exception:
-            raise ConanException("Can't write version file in %s" % self.file_version_path)
+        except Exception as error:
+            raise ConanException("Can't write version file in '{}': {}"
+                                 .format(self.file_version_path, str(error)))
 
     def _load_old_version(self):
         try:

--- a/conans/test/unittests/client/migrations/test_migrator.py
+++ b/conans/test/unittests/client/migrations/test_migrator.py
@@ -1,0 +1,43 @@
+# coding=utf-8
+
+import unittest
+import os
+
+from conans.migrations import Migrator
+from conans.test.utils.mocks import TestBufferConanOutput
+from conans.test.utils.test_files import temp_folder
+from conans.errors import ConanMigrationError
+
+
+class FakeMigrator(Migrator):
+
+    def __init__(self, cache_folder, current_version, out):
+        self.cache_folder = cache_folder
+        super(FakeMigrator, self).__init__(cache_folder, current_version, out)
+
+    def _make_migrations(self, old_version):
+        pass
+
+
+class MigratorPermissionTest(unittest.TestCase):
+
+    def test_conf_dir_already_exist(self):
+        out = TestBufferConanOutput()
+        conf_path = temp_folder(False)
+        migrator = FakeMigrator(conf_path, "latest", out)
+        with self.assertRaises(ConanMigrationError) as error:
+            migrator.migrate()
+        self.assertEqual("Could not create the directory '{}/version.txt' because it already"
+                         " exists.".format(conf_path), str(error.exception))
+
+    def test_invalid_permission(self):
+        out = TestBufferConanOutput()
+        conf_path = temp_folder(False)
+        os.chmod(conf_path, 0o444)
+        conf_path = os.path.join(conf_path, "foo")
+        migrator = FakeMigrator(conf_path, "latest", out)
+        with self.assertRaises(ConanMigrationError) as error:
+            migrator.migrate()
+        self.assertEqual("Could not create the directory '{}/version.txt' due to lack of "
+                         "permission. Please, check your user write permission."
+                         .format(conf_path), str(error.exception))

--- a/conans/test/unittests/client/migrations/test_migrator.py
+++ b/conans/test/unittests/client/migrations/test_migrator.py
@@ -2,6 +2,7 @@
 
 import unittest
 import os
+import platform
 
 from conans.migrations import Migrator
 from conans.test.utils.mocks import TestBufferConanOutput
@@ -21,6 +22,7 @@ class FakeMigrator(Migrator):
 
 class MigratorPermissionTest(unittest.TestCase):
 
+    @unittest.skipIf(platform.system() == "Windows", "Can't apply chmod on Windows")
     def test_invalid_permission(self):
         out = TestBufferConanOutput()
         conf_path = temp_folder(False)

--- a/conans/test/unittests/client/migrations/test_migrator.py
+++ b/conans/test/unittests/client/migrations/test_migrator.py
@@ -29,6 +29,6 @@ class MigratorPermissionTest(unittest.TestCase):
         migrator = FakeMigrator(conf_path, "latest", out)
         with self.assertRaises(ConanMigrationError) as error:
             migrator.migrate()
-        self.assertEqual("Could not create the directory '{}' due to lack of "
-                         "permission. Please, check your user write permission."
-                         .format(conf_path), str(error.exception))
+        self.assertEqual("Can't write version file in '{0}/version.txt': The folder {0} does not "
+                         "exist and could not be created (Permission denied).".format(conf_path),
+                         str(error.exception))

--- a/conans/test/unittests/client/migrations/test_migrator.py
+++ b/conans/test/unittests/client/migrations/test_migrator.py
@@ -21,15 +21,6 @@ class FakeMigrator(Migrator):
 
 class MigratorPermissionTest(unittest.TestCase):
 
-    def test_conf_dir_already_exist(self):
-        out = TestBufferConanOutput()
-        conf_path = temp_folder(False)
-        migrator = FakeMigrator(conf_path, "latest", out)
-        with self.assertRaises(ConanMigrationError) as error:
-            migrator.migrate()
-        self.assertEqual("Could not create the directory '{}/version.txt' because it already"
-                         " exists.".format(conf_path), str(error.exception))
-
     def test_invalid_permission(self):
         out = TestBufferConanOutput()
         conf_path = temp_folder(False)

--- a/conans/test/unittests/client/migrations/test_migrator.py
+++ b/conans/test/unittests/client/migrations/test_migrator.py
@@ -29,6 +29,6 @@ class MigratorPermissionTest(unittest.TestCase):
         migrator = FakeMigrator(conf_path, "latest", out)
         with self.assertRaises(ConanMigrationError) as error:
             migrator.migrate()
-        self.assertEqual("Could not create the directory '{}/version.txt' due to lack of "
+        self.assertEqual("Could not create the directory '{}' due to lack of "
                          "permission. Please, check your user write permission."
                          .format(conf_path), str(error.exception))

--- a/conans/util/files.py
+++ b/conans/util/files.py
@@ -193,7 +193,8 @@ def save(path, content, only_if_modified=False, encoding="utf-8"):
         try:
             os.makedirs(os.path.dirname(path))
         except OSError as error:
-            raise OSError(errmsg.format(dir_path, error.strerror))
+            if "permission denied" in error.strerror.lower():
+                raise OSError(errmsg.format(dir_path, error.strerror))
         except Exception as error:
             raise OSError(errmsg.format(dir_path, str(error)))
 

--- a/conans/util/files.py
+++ b/conans/util/files.py
@@ -192,9 +192,6 @@ def save(path, content, only_if_modified=False, encoding="utf-8"):
         if error.errno == errno.EACCES:
             raise OSError("Could not create the directory '{}' due to lack of permission."
                           " Please, check your user write permission.".format(path))
-        elif error.errno == errno.EEXIST:
-            raise OSError("Could not create the directory '{}' because it already exists."
-                          .format(path))
     except Exception:
         pass
 

--- a/conans/util/files.py
+++ b/conans/util/files.py
@@ -188,6 +188,13 @@ def save(path, content, only_if_modified=False, encoding="utf-8"):
     """
     try:
         os.makedirs(os.path.dirname(path))
+    except OSError as error:
+        if error.errno == errno.EACCES:
+            raise OSError("Could not create the directory '{}' due to lack of permission."
+                          " Please, check your user write permission.".format(path))
+        elif error.errno == errno.EEXIST:
+            raise OSError("Could not create the directory '{}' because it already exists."
+                          .format(path))
     except Exception:
         pass
 

--- a/conans/util/files.py
+++ b/conans/util/files.py
@@ -189,14 +189,14 @@ def save(path, content, only_if_modified=False, encoding="utf-8"):
     """
     dir_path = os.path.dirname(path)
     if not os.path.isdir(dir_path):
-        errmsg = "The folder {} does not exist and could not be created ({})."
         try:
-            os.makedirs(os.path.dirname(path))
+            os.makedirs(dir_path)
         except OSError as error:
-            if "permission denied" in error.strerror.lower():
-                raise OSError(errmsg.format(dir_path, error.strerror))
-        except Exception as error:
-            raise OSError(errmsg.format(dir_path, str(error)))
+            if error.errno not in (errno.EEXIST, errno.ENOENT):
+                raise OSError("The folder {} does not exist and could not be created ({})."
+                              .format(dir_path, error.strerror))
+        except Exception:
+            raise
 
     new_content = to_file_bytes(content, encoding)
 

--- a/conans/util/files.py
+++ b/conans/util/files.py
@@ -191,7 +191,7 @@ def save(path, content, only_if_modified=False, encoding="utf-8"):
     except OSError as error:
         if error.errno == errno.EACCES:
             raise OSError("Could not create the directory '{}' due to lack of permission."
-                          " Please, check your user write permission.".format(path))
+                          " Please, check your user write permission.".format(os.path.dirname(path)))
     except Exception:
         pass
 

--- a/conans/util/files.py
+++ b/conans/util/files.py
@@ -187,14 +187,15 @@ def save(path, content, only_if_modified=False, encoding="utf-8"):
         only_if_modified: file won't be modified if the content hasn't changed
         encoding: target file text encoding
     """
-    try:
-        os.makedirs(os.path.dirname(path))
-    except OSError as error:
-        if error.errno == errno.EACCES:
-            raise OSError("Could not create the directory '{}' due to lack of permission."
-                          " Please, check your user write permission.".format(os.path.dirname(path)))
-    except Exception:
-        pass
+    dir_path = os.path.dirname(path)
+    if not os.path.isdir(dir_path):
+        errmsg = "The folder {} does not exist and could not be created ({})."
+        try:
+            os.makedirs(os.path.dirname(path))
+        except OSError as error:
+            raise OSError(errmsg.format(dir_path, error.strerror))
+        except Exception as error:
+            raise OSError(errmsg.format(dir_path, str(error)))
 
     new_content = to_file_bytes(content, encoding)
 


### PR DESCRIPTION
I didn't find specific test file only related to Migrator or ClientMigrator, so I created an unit test to validate the current error message.

This change should affect more tests, as now `save` raises an error. Let's see ...

Changelog: Fix: Improve permission error message when migrating cache folder.
Docs: Omit

Related to #7948

/cc @ngrodzitski @memsharded 

- [ ] Refer to the issue that supports this Pull Request.
- [ ] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [ ] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [ ] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 

<sup>**Note:** By default this PR will skip the slower tests and will use a limited set of python versions. Check [here](https://github.com/conan-io/conan/blob/develop/.github/PR_INCREASE_TESTING.md) how to increase the testing level by writing some tags in the current PR body text.</sup>
