### PR TITLE
Pass conanfile to download_package hooks

### DIFF
--- a/conans/client/cmd/download.py
+++ b/conans/client/cmd/download.py
@@ -51,7 +51,7 @@ def _download_binaries(conanfile, ref, package_ids, cache, remote_manager, remot
         layout = cache.package_layout(pref.ref, short_paths=short_paths)
         if output and not output.is_terminal:
             output.info("Downloading %s" % str(pref))
-        remote_manager.get_package(pref, layout, remote, output, recorder)
+        remote_manager.get_package(conanfile, pref, layout, remote, output, recorder)
 
     if parallel is not None:
         output.info("Downloading binary packages in %s parallel threads" % parallel)

--- a/conans/client/installer.py
+++ b/conans/client/installer.py
@@ -383,7 +383,7 @@ class BinaryInstaller(object):
             # We cannot embed the package_lock inside the remote.get_package()
             # because the handle_node_cache has its own lock
             with layout.package_lock(pref):
-                self._download_pkg(layout, npref, n)
+                self._download_pkg(layout, n)
 
         parallel = self._cache.config.parallel_download
         if parallel is not None:
@@ -396,8 +396,8 @@ class BinaryInstaller(object):
             for node in download_nodes:
                 _download(node)
 
-    def _download_pkg(self, layout, pref, node):
-        self._remote_manager.get_package(pref, layout, node.binary_remote,
+    def _download_pkg(self, layout, node):
+        self._remote_manager.get_package(node.conanfile, node.pref, layout, node.binary_remote,
                                          node.conanfile.output, self._recorder)
 
     def _build(self, nodes_by_level, keep_build, root_node, graph_info, remotes, build_mode, update):
@@ -495,7 +495,7 @@ class BinaryInstaller(object):
                     assert pref.revision is not None, "PREV for %s to be built is None" % str(pref)
                 elif node.binary in (BINARY_UPDATE, BINARY_DOWNLOAD):
                     # this can happen after a re-evaluation of packageID with Package_ID_unknown
-                    self._download_pkg(layout, node.pref, node)
+                    self._download_pkg(layout, node)
                 elif node.binary == BINARY_CACHE:
                     assert node.prev, "PREV for %s is None" % str(pref)
                     output.success('Already installed!')

--- a/conans/client/remote_manager.py
+++ b/conans/client/remote_manager.py
@@ -130,10 +130,11 @@ class RemoteManager(object):
         uncompress_file(tgz_file, export_sources_folder, output=self._output)
         touch_folder(export_sources_folder)
 
-    def get_package(self, pref, layout, remote, output, recorder):
+    def get_package(self, conanfile, pref, layout, remote, output, recorder):
         conanfile_path = layout.conanfile()
         self._hook_manager.execute("pre_download_package", conanfile_path=conanfile_path,
-                                   reference=pref.ref, package_id=pref.id, remote=remote)
+                                   reference=pref.ref, package_id=pref.id, remote=remote,
+                                   conanfile=conanfile)
 
         output.info("Retrieving package %s from remote '%s' " % (pref.id, remote.name))
         layout.package_remove(pref)  # Remove first the destination folder
@@ -141,7 +142,8 @@ class RemoteManager(object):
             self._get_package(layout, pref, remote, output, recorder)
 
         self._hook_manager.execute("post_download_package", conanfile_path=conanfile_path,
-                                   reference=pref.ref, package_id=pref.id, remote=remote)
+                                   reference=pref.ref, package_id=pref.id, remote=remote,
+                                   conanfile=conanfile)
 
     def _get_package(self, layout, pref, remote, output, recorder):
         t1 = time.time()


### PR DESCRIPTION
Changelog: Feature: Add argument `conanfile` to `pre_download_package` and `post_download_package` hook functions.
Docs: https://github.com/conan-io/docs/pull/1905

closes https://github.com/conan-io/conan/issues/7544

It was already documented for the `post_download_hook`, but it is easy to add it to the `pre_xxx` one.