### PR TITLE
[bug] Do not try to encode 'None' value when storing tokens in the database

### DIFF
--- a/conans/client/store/localdb.py
+++ b/conans/client/store/localdb.py
@@ -16,12 +16,12 @@ class LocalDB(object):
         self.encryption_key = encryption_key
 
     def _encode(self, value):
-        if self.encryption_key:
+        if value and self.encryption_key:
             return encrypt.encode(value, self.encryption_key)
         return value
 
     def _decode(self, value):
-        if self.encryption_key:
+        if value and self.encryption_key:
             return encrypt.decode(value, self.encryption_key)
         return value
 

--- a/conans/test/unittests/util/local_db_test.py
+++ b/conans/test/unittests/util/local_db_test.py
@@ -40,6 +40,18 @@ class LocalStoreTest(unittest.TestCase):
         self.assertEqual("token", token)
         self.assertEqual("access_token", access_token)
 
+    def test_token_encryption_none(self):
+        tmp_dir = temp_folder()
+        db_file = os.path.join(tmp_dir, "dbfile")
+        encryption_key = str(uuid.uuid4())
+        localdb = LocalDB.create(db_file, encryption_key=encryption_key)
+
+        localdb.store("pepe", "token", None, "myurl1")
+        user, token, access_token = localdb.get_login("myurl1")
+        self.assertEqual("pepe", user)
+        self.assertEqual("token", token)
+        self.assertEqual(None, access_token)
+
     @unittest.skipIf(six.PY2, "Python2 sqlite3 converts to str")
     def test_token_encryption_unicode(self):
         tmp_dir = temp_folder()


### PR DESCRIPTION
Changelog: Bugfix: Do not try to encrypt a `None` value when using `CONAN_LOGIN_ENCRYPTION_KEY` environment variable.
Docs: omit
