### PR TITLE
More pytest marks for windows

### DIFF
--- a/conans/test/conftest.py
+++ b/conans/test/conftest.py
@@ -6,10 +6,11 @@ from conans.client.tools import vswhere, which
 tools_available = [
     'cmake',
     'gcc', 'clang', 'visual_studio',
-    'autotools', 'pkg_config', 'premake',
+    'autotools', 'pkg_config', 'premake', 'meson',
     'file',
     'git', 'svn',
-    'compiler'
+    'compiler',
+    'conan',  # Search the tool_conan test that needs conan itself
 ]
 
 if not which("cmake"):
@@ -20,7 +21,8 @@ if not which("gcc"):
 if not which("clang"):
     tools_available.remove("clang")
 try:
-    vswhere()
+    if not vswhere():
+       tools_available.remove("visual_studio")
 except ConanException:
     tools_available.remove("visual_studio")
 
@@ -38,10 +40,14 @@ if not which("svn"):
 
 if not which("autoconf") or not which("automake"):
     tools_available.remove("autotools")
+if not which("meson"):
+    tools_available.remove("meson")
 if not which("pkg-config"):
     tools_available.remove("pkg_config")
 if not which("premake"):
     tools_available.remove("premake")
+if not which("conan"):
+    tools_available.remove("conan")
 
 
 def tool_check(mark):

--- a/conans/test/conftest.py
+++ b/conans/test/conftest.py
@@ -54,4 +54,4 @@ def pytest_runtest_setup(item):
     # Every mark is a required tool, some specify a version
     for mark in item.iter_markers():
         if mark.name.startswith("tool_"):
-            return tool_check(mark)
+            tool_check(mark)

--- a/conans/test/functional/build_helpers/meson_test.py
+++ b/conans/test/functional/build_helpers/meson_test.py
@@ -1,6 +1,7 @@
 import platform
 import textwrap
 import unittest
+import pytest
 
 from conans.test.utils.tools import TestClient
 
@@ -8,18 +9,20 @@ from conans.test.utils.tools import TestClient
 class MesonTest(unittest.TestCase):
 
     @unittest.skipIf(platform.system() != "Windows", "Needs windows for vcvars")
+    @pytest.mark.tool_compiler
+    @pytest.mark.tool_meson
     def test_vcvars_priority(self):
         # https://github.com/conan-io/conan/issues/5999
         client = TestClient()
         conanfile_vcvars = textwrap.dedent("""
             import os
             from conans import ConanFile, Meson
-    
+
             class HelloConan(ConanFile):
                 settings = "os", "compiler", "arch", "build_type"
                 def build(self):
-                    cmake = Meson(self, append_vcvars=True)
-                    cmake.configure()
+                    meson = Meson(self, append_vcvars=True)
+                    meson.configure()
 
                 # CAPTURING THE RUN METHOD
                 def run(self, cmd):

--- a/conans/test/functional/build_helpers/msbuild_test.py
+++ b/conans/test/functional/build_helpers/msbuild_test.py
@@ -21,6 +21,7 @@ class MSBuildTest(unittest.TestCase):
 
     @attr('slow')
     @pytest.mark.slow
+    @pytest.mark.tool_visual_studio
     @unittest.skipUnless(platform.system() == "Windows" and six.PY3, "Requires MSBuild")
     def test_build_vs_project(self):
         conan_build_vs = """
@@ -104,6 +105,7 @@ class HelloConan(ConanFile):
 
     @attr('slow')
     @pytest.mark.slow
+    @pytest.mark.tool_visual_studio
     @unittest.skipUnless(platform.system() == "Windows", "Requires MSBuild")
     def test_user_properties_file(self):
         conan_build_vs = textwrap.dedent("""
@@ -157,6 +159,7 @@ class HelloConan(ConanFile):
 
     @attr('slow')
     @pytest.mark.slow
+    @pytest.mark.tool_visual_studio
     @unittest.skipUnless(platform.system() == "Windows", "Requires MSBuild")
     def test_user_properties_multifile(self):
         conan_build_vs = textwrap.dedent("""
@@ -223,6 +226,7 @@ class HelloConan(ConanFile):
         content = load(conan_props)
         self.assertIn("<RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>", content)
 
+    @pytest.mark.tool_visual_studio
     @unittest.skipUnless(platform.system() == "Windows", "Requires MSBuild")
     def test_reuse_msbuild_object(self):
         # https://github.com/conan-io/conan/issues/2865
@@ -253,6 +257,7 @@ class HelloConan(ConanFile):
         client.run("create . danimtb/testing")
         self.assertIn("build() completed", client.out)
 
+    @pytest.mark.tool_visual_studio
     @parameterized.expand([("True",), ("'my_log.binlog'",)])
     @unittest.skipUnless(platform.system() == "Windows", "Requires MSBuild")
     def test_binary_log_build(self, value):

--- a/conans/test/functional/build_helpers/msbuild_test.py
+++ b/conans/test/functional/build_helpers/msbuild_test.py
@@ -257,9 +257,9 @@ class HelloConan(ConanFile):
         client.run("create . danimtb/testing")
         self.assertIn("build() completed", client.out)
 
-    @pytest.mark.tool_visual_studio
     @parameterized.expand([("True",), ("'my_log.binlog'",)])
     @unittest.skipUnless(platform.system() == "Windows", "Requires MSBuild")
+    @pytest.mark.tool_visual_studio
     def test_binary_log_build(self, value):
         conan_build_vs = """
 from conans import ConanFile, MSBuild

--- a/conans/test/functional/command/export/export_dirty_test.py
+++ b/conans/test/functional/command/export/export_dirty_test.py
@@ -2,6 +2,8 @@ import os
 import platform
 import unittest
 
+import pytest
+
 from conans.model.ref import ConanFileReference
 from conans.paths import CONANFILE
 from conans.test.assets.cpp_test_files import cpp_hello_conan_files
@@ -69,6 +71,7 @@ class ExportDirtyTest(unittest.TestCase):
         self.client.run("install Hello0/0.1@lasote/stable --build", assert_error=True)
         self.assertIn("ERROR: Unable to remove source folder", self.client.out)
 
+    @pytest.mark.tool_compiler
     def test_export_remove(self):
         # export is able to remove dirty source folders
         self.f.close()
@@ -77,6 +80,7 @@ class ExportDirtyTest(unittest.TestCase):
         self.client.run("install Hello0/0.1@lasote/stable --build")
         self.assertNotIn("WARN: Trying to remove corrupted source folder", self.client.out)
 
+    @pytest.mark.tool_compiler
     def test_install_remove(self):
         # install is also able to remove dirty source folders
         # Now, release the handle to the file

--- a/conans/test/functional/environment/build_environment_test.py
+++ b/conans/test/functional/environment/build_environment_test.py
@@ -115,6 +115,7 @@ class ConanReuseLib(ConanFile):
         self.assertIn("15", client.out)
 
     @unittest.skipUnless(platform.system() == "Windows", "Requires windows")
+    @pytest.mark.tool_compiler
     def test_use_build_virtualenv_windows(self):
         files = cpp_hello_conan_files("hello", "0.1",  use_cmake=False, with_exe=False)
         client = TestClient(path_with_spaces=False)

--- a/conans/test/functional/generators/cmake_test.py
+++ b/conans/test/functional/generators/cmake_test.py
@@ -75,6 +75,7 @@ class CMakeGeneratorTest(unittest.TestCase):
 
     @attr("slow")
     @pytest.mark.slow
+    @pytest.mark.tool_visual_studio
     @unittest.skipUnless(platform.system() == "Windows", "Requires MSBuild")
     def test_skip_check_if_toolset(self):
         file_content = textwrap.dedent("""

--- a/conans/test/functional/generators/msbuild_test.py
+++ b/conans/test/functional/generators/msbuild_test.py
@@ -410,12 +410,13 @@ int main(){
 }
 """
 
-
+@pytest.mark.tool_visual_studio
 @unittest.skipUnless(platform.system() == "Windows", "Requires MSBuild")
 class MSBuildGeneratorTest(unittest.TestCase):
 
     @attr('slow')
     @pytest.mark.slow
+    @pytest.mark.tool_cmake
     def test_msbuild_generator(self):
         client = TestClient()
         # Upload to alternative server Hello0 but Hello1 to the default

--- a/conans/test/functional/generators/virtualbuildenv_test.py
+++ b/conans/test/functional/generators/virtualbuildenv_test.py
@@ -12,6 +12,7 @@ from conans.util.runners import check_output_runner
 class VirtualBuildEnvTest(unittest.TestCase):
 
     @unittest.skipUnless(platform.system() == "Windows", "needs Windows")
+    @pytest.mark.tool_visual_studio  # 15
     def test_delimiter_error(self):
         # https://github.com/conan-io/conan/issues/3080
         conanfile = """from conans import ConanFile

--- a/conans/test/functional/generators/virtualenv_test.py
+++ b/conans/test/functional/generators/virtualenv_test.py
@@ -5,6 +5,7 @@ import textwrap
 import unittest
 from collections import OrderedDict
 
+import pytest
 import six
 from parameterized.parameterized import parameterized_class
 
@@ -193,6 +194,7 @@ class VirtualEnvIntegrationTestCase(unittest.TestCase):
         self.assertDictEqual(env_before, env_after)  # Environment restored correctly
         return stdout, _load_env_file(os.path.join(self.test_folder, self.env_activated))
 
+    @pytest.mark.tool_conan
     def test_basic_variable(self):
         generator = VirtualEnvGenerator(ConanFileMock())
         generator.env = {"USER_VAR": r"some value with space and \ (backslash)",
@@ -209,6 +211,7 @@ class VirtualEnvIntegrationTestCase(unittest.TestCase):
             self.assertEqual(environment["USER_VAR"], r"some value with space and \ (backslash)")
             self.assertEqual(environment["ANOTHER"], "data")
 
+    @pytest.mark.tool_conan
     def test_list_with_spaces(self):
         generator = VirtualEnvGenerator(ConanFileMock())
         self.assertIn("CFLAGS", VirtualEnvGenerator.append_with_spaces)
@@ -227,6 +230,7 @@ class VirtualEnvIntegrationTestCase(unittest.TestCase):
             self.assertEqual(environment["CFLAGS"], "-O2 {}cflags".format(extra_blank))
             self.assertEqual(environment["CL"], "-MD -DNDEBUG -O2 -Ob2 {}cl".format(extra_blank))
 
+    @pytest.mark.tool_conan
     def test_list_variable(self):
         self.assertNotIn("WHATEVER", os.environ)
         self.assertIn("PATH", os.environ)
@@ -251,6 +255,7 @@ class VirtualEnvIntegrationTestCase(unittest.TestCase):
         self.assertEqual(environment["WHATEVER"],
                          "{}{}{}{}".format("list", os.pathsep, "other", extra_separator))
 
+    @pytest.mark.tool_conan
     def test_find_program(self):
         # If we add the path, we should found the env/executable instead of ori/executable
         # Watch out! 'cmd' returns all the paths where the executable is found, so we need to

--- a/conans/test/functional/generators/virtualenv_windows_bash_test.py
+++ b/conans/test/functional/generators/virtualenv_windows_bash_test.py
@@ -4,6 +4,8 @@ import subprocess
 import textwrap
 import unittest
 
+import pytest
+
 from conans.test.functional.generators.virtualenv_test import _load_env_file
 from conans.test.utils.test_files import temp_folder
 from conans.test.utils.tools import TestClient
@@ -21,7 +23,7 @@ class VirtualenvWindowsBashTestCase(unittest.TestCase):
     conanfile = textwrap.dedent("""
         import os
         from conans import ConanFile, tools
-        
+
         class Recipe(ConanFile):
             def build(self):
                 tools.save("executable.exe", "echo EXECUTABLE IN PACKAGE!!")
@@ -33,19 +35,20 @@ class VirtualenvWindowsBashTestCase(unittest.TestCase):
                 # Basic variable
                 self.env_info.USER_VAR = r"some value with space and \\ (backslash)"
                 self.env_info.ANOTHER = "data"
-                
+
                 # List variable
                 self.env_info.WHATEVER = ["list", "other"]
                 self.env_info.WHATEVER2.append("list")
-                
+
                 # List with spaces
                 self.env_info.CFLAGS = ["cflags1", "cflags2"]
-                
+
                 # Add something to the path
                 self.env_info.PATH.append(os.path.join(self.package_folder, "bin"))
-                
+
     """)
 
+    @pytest.mark.tool_conan
     def test_git_shell(self):
         test_folder = temp_folder(path_with_spaces=False)
 
@@ -68,11 +71,11 @@ class VirtualenvWindowsBashTestCase(unittest.TestCase):
             export WHATEVER=existing_value
             export WHATEVER2=existing_value
             export CFLAGS=existing_value
-            
+
             export PATH={conan_path}:$PATH
             export CONAN_USER_HOME={conan_user_home}
             conan install name/version@ -g virtualenv -g virtualrunenv
-            
+
             env > env_before.txt
             echo 'Start to find executable'
             echo __exec_pre_path__=$(which executable)

--- a/conans/test/functional/generators/visual_studio_multi_test.py
+++ b/conans/test/functional/generators/visual_studio_multi_test.py
@@ -60,6 +60,7 @@ void hello(){
 
 @attr('slow')
 @pytest.mark.slow
+@pytest.mark.tool_visual_studio
 @unittest.skipUnless(platform.system() == "Windows", "Requires MSBuild")
 class VisualStudioMultiTest(unittest.TestCase):
 

--- a/conans/test/functional/generators/visual_studio_test.py
+++ b/conans/test/functional/generators/visual_studio_test.py
@@ -28,6 +28,8 @@ class VisualStudioTest(unittest.TestCase):
 
     @attr('slow')
     @pytest.mark.slow
+    @pytest.mark.tool_cmake
+    @pytest.mark.tool_visual_studio
     @unittest.skipUnless(platform.system() == "Windows", "Requires MSBuild")
     def test_build_vs_project_with_a(self):
         client = TestClient()

--- a/conans/test/functional/workspace/workspace_test.py
+++ b/conans/test/functional/workspace/workspace_test.py
@@ -591,6 +591,7 @@ class WorkspaceTest(unittest.TestCase):
         self.assertNotIn("Release", client.out)
 
     @unittest.skipUnless(platform.system() == "Windows", "only windows")
+    @pytest.mark.tool_cmake
     def test_complete_multi_conf_build(self):
         client = TestClient()
 

--- a/conans/test/integration/toolchains/test_msbuild.py
+++ b/conans/test/integration/toolchains/test_msbuild.py
@@ -4,6 +4,8 @@ import re
 import textwrap
 import unittest
 
+import pytest
+
 from conans.client.toolchain.visual import vcvars_command
 from conans.client.tools import vs_installation_path
 from conans.test.assets.sources import gen_function_cpp
@@ -219,6 +221,7 @@ myapp_vcxproj = r"""<?xml version="1.0" encoding="utf-8"?>
 
 
 @unittest.skipUnless(platform.system() == "Windows", "Only for windows")
+@pytest.mark.tool_visual_studio
 class WinTest(unittest.TestCase):
 
     conanfile = textwrap.dedent("""
@@ -261,6 +264,7 @@ class WinTest(unittest.TestCase):
         self.assertIn("DEFINITIONS_BOTH: True", client.out)
         self.assertIn("DEFINITIONS_CONFIG: %s" % build_type, client.out)
 
+    @pytest.mark.tool_cmake
     def test_toolchain_win(self):
         client = TestClient(path_with_spaces=False)
         settings = {"compiler": "Visual Studio",
@@ -304,6 +308,7 @@ class WinTest(unittest.TestCase):
         self.assertIn("KERNEL32.dll", client.out)
         self.assertEqual(1, str(client.out).count(".dll"))
 
+    @pytest.mark.tool_cmake
     def test_toolchain_win_debug(self):
         client = TestClient(path_with_spaces=False)
         settings = {"compiler": "Visual Studio",
@@ -343,6 +348,7 @@ class WinTest(unittest.TestCase):
         self.assertIn("MSVCP140D.dll", client.out)
         self.assertIn("VCRUNTIME140D.dll", client.out)
 
+    @pytest.mark.tool_cmake
     def test_toolchain_win_multi(self):
         client = TestClient(path_with_spaces=False)
         settings = {"compiler": "Visual Studio",

--- a/conans/test/unittests/client/build/msbuild_test.py
+++ b/conans/test/unittests/client/build/msbuild_test.py
@@ -4,6 +4,7 @@ import re
 import unittest
 
 import mock
+import pytest
 import six
 from parameterized import parameterized
 
@@ -72,6 +73,7 @@ class MSBuildTest(unittest.TestCase):
         self.assertIn('/p:MyProp2="MyValue2"', command)
 
     @unittest.skipUnless(platform.system() == "Windows", "Requires MSBuild")
+    @pytest.mark.tool_visual_studio
     def test_binary_logging_on(self):
         settings = MockSettings({"build_type": "Debug",
                                  "compiler": "Visual Studio",
@@ -83,6 +85,7 @@ class MSBuildTest(unittest.TestCase):
         command = msbuild.get_command("dummy.sln", output_binary_log=True)
         self.assertIn("/bl", command)
 
+    @pytest.mark.tool_visual_studio
     @unittest.skipUnless(platform.system() == "Windows", "Requires MSBuild")
     def test_binary_logging_on_with_filename(self):
         bl_filename = "a_special_log.log"
@@ -119,6 +122,7 @@ class MSBuildTest(unittest.TestCase):
         command = msbuild.get_command("dummy.sln")
         self.assertNotIn("/bl", command)
 
+    @pytest.mark.tool_visual_studio
     @unittest.skipUnless(platform.system() == "Windows", "Requires MSBuild")
     @mock.patch("conans.client.build.msbuild.MSBuildHelper.get_version")
     def test_binary_logging_not_supported(self, mock_get_version):
@@ -143,6 +147,7 @@ class MSBuildTest(unittest.TestCase):
         with self.assertRaises(TypeError):
             msbuild.get_command("dummy.sln", targets="sometarget")
 
+    @pytest.mark.tool_visual_studio
     @unittest.skipUnless(platform.system() == "Windows", "Requires MSBuild")
     def test_get_version(self):
         settings = MockSettings({"build_type": "Debug",
@@ -172,6 +177,7 @@ class MSBuildTest(unittest.TestCase):
         command = msbuild.get_command("project_should_flags_test_file.sln")
         self.assertIn('/p:PlatformToolset="%s"' % expected_toolset, command)
 
+    @pytest.mark.tool_visual_studio
     @unittest.skipUnless(platform.system() == "Windows", "Requires MSBuild")
     def test_skip_toolset(self):
         settings = MockSettings({"build_type": "Debug",

--- a/conans/test/unittests/client/tools/win/vcvars_test.py
+++ b/conans/test/unittests/client/tools/win/vcvars_test.py
@@ -19,6 +19,7 @@ from conans.test.utils.tools import TestClient
 from conans.test.utils.mocks import TestBufferConanOutput
 
 
+@pytest.mark.tool_visual_studio
 class VCVarsTest(unittest.TestCase):
     def setUp(self):
         self.output = TestBufferConanOutput()

--- a/conans/test/unittests/util/tools_test.py
+++ b/conans/test/unittests/util/tools_test.py
@@ -291,6 +291,7 @@ class HelloConan(ConanFile):
         self.assertEqual(os.getenv("Z", None), None)
 
     @unittest.skipUnless(platform.system() == "Windows", "Requires vswhere")
+    @pytest.mark.tool_visual_studio
     def test_msvc_build_command(self):
         settings = Settings.loads(get_default_settings_yml())
         settings.os = "Windows"
@@ -400,6 +401,7 @@ class HelloConan(ConanFile):
             self.assertNotIn("descripton", json)
 
     @unittest.skipUnless(platform.system() == "Windows", "Requires vswhere")
+    @pytest.mark.tool_visual_studio
     def test_vswhere_path(self):
         """
         Locate vswhere in PATH or in ProgramFiles
@@ -633,7 +635,7 @@ class HelloConan(ConanFile):
             tools.get_gnu_triplet("Windows", "x86")
 
     def test_detect_windows_subsystem(self):
-        # Dont raise test
+        # Don't raise test
         result = OSInfo.detect_windows_subsystem()
         if not OSInfo.bash_path() or platform.system() != "Windows":
             self.assertEqual(None, result)


### PR DESCRIPTION
Changelog: omit
Docs: omit

Used a Windows machine with nothing installed to verify the pytest marks are complete.
Added one more tool for meson and for "conan" itself (used in several tests). 
Fixed the `tool_check` function to check every tool mark applied to a test.
