### PR TITLE
ninja + visual testing

### DIFF
--- a/conans/client/toolchain/cmake/generic.py
+++ b/conans/client/toolchain/cmake/generic.py
@@ -129,7 +129,8 @@ class CMakeGenericToolchain(CMakeToolchainBase):
                                    get_generator_platform(self._conanfile.settings,
                                                           self.generator))
         self.toolset = toolset or get_toolset(self._conanfile.settings, self.generator)
-        if "Ninja" in self.generator and "Visual" in self._conanfile.settings.compiler:
+        if (self.generator is not None and "Ninja" in self.generator
+                and "Visual" in self._conanfile.settings.compiler):
             self.compiler = "cl"
         else:
             self.compiler = None  # compiler defined by default

--- a/conans/client/toolchain/cmake/generic.py
+++ b/conans/client/toolchain/cmake/generic.py
@@ -21,6 +21,10 @@ class CMakeGenericToolchain(CMakeToolchainBase):
             {{ super() }}
             {% if generator_platform %}set(CMAKE_GENERATOR_PLATFORM "{{ generator_platform }}" CACHE STRING "" FORCE){% endif %}
             {% if toolset %}set(CMAKE_GENERATOR_TOOLSET "{{ toolset }}" CACHE STRING "" FORCE){% endif %}
+            {% if compiler %}
+            set(CMAKE_C_COMPILER {{ compiler }})
+            set(CMAKE_CXX_COMPILER {{ compiler }})
+            {%- endif %}
         {% endblock %}
 
         {% block main %}
@@ -125,6 +129,10 @@ class CMakeGenericToolchain(CMakeToolchainBase):
                                    get_generator_platform(self._conanfile.settings,
                                                           self.generator))
         self.toolset = toolset or get_toolset(self._conanfile.settings, self.generator)
+        if "Ninja" in self.generator and "Visual" in self._conanfile.settings.compiler:
+            self.compiler = "cl"
+        else:
+            self.compiler = None  # compiler defined by default
 
         try:
             self._build_shared_libs = "ON" if self._conanfile.options.shared else "OFF"
@@ -237,7 +245,8 @@ class CMakeGenericToolchain(CMakeToolchainBase):
             "cppstd": self.cppstd,
             "cppstd_extensions": self.cppstd_extensions,
             "shared_libs": self._build_shared_libs,
-            "architecture": self.architecture
+            "architecture": self.architecture,
+            "compiler": self.compiler
         })
         ctxt_project_include.update({'vs_static_runtime': self.vs_static_runtime})
         return ctxt_toolchain, ctxt_project_include

--- a/conans/test/integration/toolchains/cmake/test_ninja.py
+++ b/conans/test/integration/toolchains/cmake/test_ninja.py
@@ -111,7 +111,7 @@ class CMakeNinjaTestCase(unittest.TestCase):
 
     @unittest.skipIf(platform.system() != "Windows", "Only windows")
     def test_locally_build_windows_debug(self):
-        """ Ninja build must proceed using default profile and cmake build (Windows)
+        """ Ninja build must proceed using default profile and cmake build (Windows Debug)
         """
         client = TestClient(path_with_spaces=False)
         client.save({"conanfile.py": self.conanfile,

--- a/conans/test/integration/toolchains/cmake/test_ninja.py
+++ b/conans/test/integration/toolchains/cmake/test_ninja.py
@@ -1,70 +1,37 @@
 import textwrap
 import unittest
-import os
 import platform
 
+from conans.client.toolchain.visual import vcvars_command
+from conans.test.assets.sources import gen_function_cpp
 from conans.test.utils.tools import TestClient
-from conans.test.utils.test_files import temp_folder
-from conans.client.tools import environment_append, which
-from conans.client.toolchain.cmake.base import CMakeToolchainBase
+from conans.client.tools import which
 
 
-class CppProject(object):
-
-    header = textwrap.dedent("""
-        #include <string>
-        int bar(const std::string& str);
-    """)
-
-    source = textwrap.dedent("""
-        #include "foobar.hpp"
-        #include <iostream>
-        int bar(const std::string& str) {
-            std::cout << "(BAR): " << str << std::endl;
-            return 0;
-        }
-    """)
-
-    cmakefile = textwrap.dedent("""
-        cmake_minimum_required(VERSION 2.8.12)
-        project(foobar CXX)
-        set(CMAKE_VERBOSE_MAKEFILE ON)
-        add_library(${CMAKE_PROJECT_NAME} foobar.hpp foobar.cpp)
-        set_target_properties(${CMAKE_PROJECT_NAME} PROPERTIES
-                              PUBLIC_HEADER foobar.hpp
-                              DEBUG_POSTFIX "d")
-        install(TARGETS ${CMAKE_PROJECT_NAME}
-            RUNTIME DESTINATION bin
-            LIBRARY DESTINATION lib
-            ARCHIVE DESTINATION lib
-            PUBLIC_HEADER DESTINATION include
-        )
-    """)
-
-    def create_project(self, testclient):
-        testclient.save({
-            "foobar.hpp": CppProject.header,
-            "foobar.cpp": CppProject.source,
-            "CMakeLists.txt": CppProject.cmakefile
-        })
-
-
-@unittest.skip("Ninja tests still not working")
 class CMakeNinjaTestCase(unittest.TestCase):
     # This test assumes that 'CMake' and 'Ninja' are available in the system
 
+    main_cpp = gen_function_cpp(name="main")
+    cmake = textwrap.dedent("""
+        cmake_minimum_required(VERSION 2.8.12)
+        project(App CXX)
+        if(CMAKE_VERSION VERSION_LESS "3.15")
+            include(${CMAKE_BINARY_DIR}/conan_project_include.cmake)
+        endif()
+        set(CMAKE_VERBOSE_MAKEFILE ON)
+        add_executable(App main.cpp)
+        install(TARGETS App RUNTIME DESTINATION bin)
+        """)
     conanfile = textwrap.dedent("""
         from conans import ConanFile, CMake, CMakeToolchain
 
         class Foobar(ConanFile):
             name = "foobar"
             settings = "os", "arch", "compiler", "build_type"
-            exports_sources = "CMakeLists.txt", "foobar.hpp", "foobar.cpp"
-            options = {"shared": [True, False]}
-            default_options = {"shared": False}
+            exports_sources = "CMakeLists.txt", "main.cpp"
 
             def toolchain(self):
-                tc = CMakeToolchain(self)
+                tc = CMakeToolchain(self, generator="Ninja")
                 tc.write_toolchain_files()
 
             def build(self):
@@ -74,63 +41,28 @@ class CMakeNinjaTestCase(unittest.TestCase):
 
             def package(self):
                 cmake = CMake(self)
-
                 cmake.configure()
                 cmake.install()
-    """)
+        """)
 
     @classmethod
     def setUpClass(cls):
         if not which("ninja"):
             raise unittest.SkipTest("Ninja expected in PATH")
 
-    def setUp(self):
-        folder = temp_folder(False)
-        cpp_project = CppProject()
-        self.client = TestClient(current_folder=folder)
-        cpp_project.create_project(self.client)
-        self.client.save({
-            "conanfile.py": CMakeNinjaTestCase.conanfile,
-        })
-
-    def test_local_cache_build(self):
-        """ Ninja build must proceed using default profile and conan create
-        """
-        with environment_append({"CONAN_CMAKE_GENERATOR": "Ninja"}):
-            self.client.run("create . foobar/0.1.0@ --profile:build=default --profile:host=default")
-            self.assertIn('CMake command: cmake -G "Ninja" '
-                          '-DCMAKE_TOOLCHAIN_FILE="conan_toolchain.cmake"', self.client.out)
-
-        conanfile = CMakeNinjaTestCase.conanfile.replace("(self)", "(self, generator='Ninja')")
-        self.client.save({
-            "conanfile.py": conanfile,
-        })
-        self.client.run("create . foobar/0.1.0@ --profile:build=default --profile:host=default")
-        self.assertIn('CMake command: cmake -G "Ninja" '
-                      '-DCMAKE_TOOLCHAIN_FILE="conan_toolchain.cmake"', self.client.out)
-
-    def _build_locally(self, profile="default", build_type="Release", shared=False):
-        self.client.run("export . foobar/0.1.0@")
-        self.client.run("install . -o foobar:shared={} -s build_type={} -pr:h={} -pr:b=default"
-                        .format(shared, build_type, profile))
-        self.client.run_command('cmake . -G "Ninja" -DCMAKE_TOOLCHAIN_FILE={}'
-                                .format(CMakeToolchainBase.filename))
-        self.client.run_command("cmake --build . --config {}".format(build_type))
-
-    @unittest.skipIf(platform.system() != "Linux", "Only linux")
+    @unittest.skip("Not tested yet")
     def test_locally_build_linux(self):
         """ Ninja build must proceed using default profile and cmake build (Linux)
         """
         self.client.save({"linux_host": textwrap.dedent("""
-                      [settings]
-                      os=Linux
-                      arch=x86_64
-                      compiler=gcc
-                      compiler.version=10
-                      compiler.libcxx=libstdc++11
-                      build_type=Release
-                      [env]
-                      CONAN_CMAKE_GENERATOR=Ninja""")})
+            [settings]
+            os=Linux
+            arch=x86_64
+            compiler=gcc
+            compiler.version=10
+            compiler.libcxx=libstdc++11
+            build_type=Release
+            """)})
         self._build_locally("linux_host")
         self.client.run_command("objdump -f libfoobar.a")
         self.assertIn("architecture: i386:x86-64", self.client.out)
@@ -143,55 +75,72 @@ class CMakeNinjaTestCase(unittest.TestCase):
         # FIXME: Broken assert
         #  self.assertIn("with debug_info", self.client.out)
 
-    def test_locally_build_Windows(self):
+    @unittest.skipIf(platform.system() != "Windows", "Only windows")
+    def test_locally_build_windows(self):
         """ Ninja build must proceed using default profile and cmake build (Windows)
         """
-        win_host = textwrap.dedent("""[settings]
-                                 os=Windows
-                                 arch=x86_64
-                                 compiler=Visual Studio
-                                 compiler.version=16
-                                 compiler.runtime=MD
-                                 build_type=Release
-                                 [env]
-                                 CONAN_CMAKE_GENERATOR=Ninja""")
-        self.client.save({"win_host": win_host})
-        self._build_locally("win_host")
-        self.client.run_command("DUMPBIN /NOLOGO /DIRECTIVES foobar.lib")
-        self.assertIn("RuntimeLibrary=MD_Dynamic", self.client.out)
-        self.client.run_command("DUMPBIN /NOLOGO /HEADERS foobar.lib")
-        self.assertIn("machine (x64)", self.client.out)
+        client = TestClient(path_with_spaces=False)
+        client.save({"conanfile.py": self.conanfile,
+                     "main.cpp": self.main_cpp,
+                     "CMakeLists.txt": self.cmake})
+        win_host = textwrap.dedent("""
+            [settings]
+            os=Windows
+            arch=x86_64
+            compiler=Visual Studio
+            compiler.version=15
+            compiler.runtime=MD
+            build_type=Release
+             """)
+        client.save({"win": win_host})
+        client.run("install . -pr=win")
+        # Ninja is single-configuration
+        vcvars = vcvars_command("15", architecture="amd64")
+        client.run_command('{} && cmake . -G "Ninja" -DCMAKE_TOOLCHAIN_FILE=conan_toolchain.cmake '
+                           .format(vcvars))
+        client.run_command("{} && cmake --build .".format(vcvars))
+        client.run_command("App")
+        self.assertIn("main: Release!", client.out)
+        self.assertIn("main _M_X64 defined", client.out)
+        self.assertIn("main _MSC_VER19", client.out)
+        self.assertIn("main _MSVC_LANG2014", client.out)
 
-        win_host.replace("MD", "MDd")
-        self.client.save({"win_host": win_host})
-        self._build_locally("win_host", "Debug", False)
-        self.client.run_command("DUMPBIN /NOLOGO /DIRECTIVES foobard.lib")
-        self.assertIn("RuntimeLibrary=MDd_DynamicDebug", self.client.out)
-        self.client.run_command("DUMPBIN /NOLOGO /HEADERS foobard.lib")
-        self.assertIn("machine (x64)", self.client.out)
+        client.run_command('{} && dumpbin /dependents /summary /directives "App.exe"'.format(vcvars))
+        self.assertIn("MSVCP140.dll", client.out)
+        self.assertIn("VCRUNTIME140.dll", client.out)
 
-        win_host.replace("MD", "MDd")
-        self.client.save({"win_host": win_host})
-        self._build_locally("win_host", "Debug", True)
-        self.client.run_command("DUMPBIN /NOLOGO /HEADERS foobard.dll")
-        self.assertIn("machine (x64)", self.client.out)
-        # TODO - How to detect Runtime library from a DLL (command line)?
-        # self.client.run_command("DUMPBIN /NOLOGO /DIRECTIVES foobard.dll")
-        # self.assertIn("RuntimeLibrary=MDd_DynamicDebug", self.client.out)
-
-    def test_devflow_build(self):
-        """ Ninja build must proceed using default profile and conan development flow
+    @unittest.skipIf(platform.system() != "Windows", "Only windows")
+    def test_locally_build_windows_debug(self):
+        """ Ninja build must proceed using default profile and cmake build (Windows)
         """
-        conanfile = CMakeNinjaTestCase.conanfile.replace("(self)", "(self, generator='Ninja')")
-        self.client.save({
-            "conanfile.py": conanfile,
-        })
+        client = TestClient(path_with_spaces=False)
+        client.save({"conanfile.py": self.conanfile,
+                     "main.cpp": self.main_cpp,
+                     "CMakeLists.txt": self.cmake})
+        win_host = textwrap.dedent("""
+            [settings]
+            os=Windows
+            arch=x86
+            compiler=Visual Studio
+            compiler.version=15
+            compiler.runtime=MTd
+            build_type=Debug
+             """)
+        client.save({"win": win_host})
+        client.run("install . -pr=win")
+        # Ninja is single-configuration
+        # It is necessary to set architecture=x86 here, otherwise final architecture is wrong
+        vcvars = vcvars_command("15", architecture="x86")
+        client.run("install . -pr=win")
+        client.run_command('{} && cmake . -G "Ninja" -DCMAKE_TOOLCHAIN_FILE=conan_toolchain.cmake '
+                           .format(vcvars))
+        client.run_command("{} && cmake --build .".format(vcvars))
+        client.run_command("App")
+        self.assertIn("main: Debug!", client.out)
+        self.assertIn("main _M_IX86 defined", client.out)
+        self.assertIn("main _MSC_VER19", client.out)
+        self.assertIn("main _MSVC_LANG2014", client.out)
 
-        build_folder = os.path.join(self.client.current_folder, "build")
-        package_folder = os.path.join(self.client.current_folder, "pkg")
-        with environment_append({"CONAN_PRINT_RUN_COMMANDS": "1"}):
-            self.client.run("export . foobar/0.1.0@")
-            self.client.run("install . --install-folder={}".format(build_folder))
-            self.client.run("build . --build-folder={}".format(build_folder))
-            self.assertIn('CMake command: cmake -G "Ninja" '
-                          '-DCMAKE_TOOLCHAIN_FILE="conan_toolchain.cmake"', self.client.out)
+        client.run_command('{} && dumpbin /dependents /summary /directives "App.exe"'.format(vcvars))
+        self.assertIn("KERNEL32.dll", client.out)
+        self.assertEqual(1, str(client.out).count(".dll"))

--- a/conans/test/integration/toolchains/cmake/test_ninja.py
+++ b/conans/test/integration/toolchains/cmake/test_ninja.py
@@ -77,7 +77,7 @@ class CMakeNinjaTestCase(unittest.TestCase):
 
     @unittest.skipIf(platform.system() != "Windows", "Only windows")
     def test_locally_build_windows(self):
-        """ Ninja build must proceed using default profile and cmake build (Windows)
+        """ Ninja build must proceed using default profile and cmake build (Windows Release)
         """
         client = TestClient(path_with_spaces=False)
         client.save({"conanfile.py": self.conanfile,


### PR DESCRIPTION
Changelog: Feature: Preliminary experimental support for toolchains with CMake + Visual + Ninja.
Docs: Omit

CMakeToolchain with Ninja for VS doesn't work, it was using the gcc compiler. 

#tags: slow


