### PR TITLE
allow relaxing a lockfile with --build

### DIFF
--- a/conans/client/graph/graph_binaries.py
+++ b/conans/client/graph/graph_binaries.py
@@ -163,12 +163,8 @@ class GraphBinariesAnalyzer(object):
             self._process_node(node, pref, build_mode, update, remotes)
             if node.binary == BINARY_MISSING and build_mode.allowed(node.conanfile):
                 node.binary = BINARY_BUILD
-            if node.binary == BINARY_BUILD and locked.prev:
-                if locked._relaxed:
-                    locked._prev = None
-                else:
-                    raise ConanException("Cannot build '%s' because it is already locked in the "
-                                         "input lockfile" % repr(node.ref))
+            if node.binary == BINARY_BUILD:
+                locked.unlock_prev()
         else:
             assert node.prev is None, "Non locked node shouldn't have PREV in evaluate_node"
             assert node.binary is None, "Node.binary should be None if not locked"

--- a/conans/client/graph/graph_binaries.py
+++ b/conans/client/graph/graph_binaries.py
@@ -164,8 +164,11 @@ class GraphBinariesAnalyzer(object):
             if node.binary == BINARY_MISSING and build_mode.allowed(node.conanfile):
                 node.binary = BINARY_BUILD
             if node.binary == BINARY_BUILD and locked.prev:
-                raise ConanException("Cannot build '%s' because it is already locked in the input "
-                                     "lockfile" % repr(node.ref))
+                if locked._relaxed:
+                    locked._prev = None
+                else:
+                    raise ConanException("Cannot build '%s' because it is already locked in the "
+                                         "input lockfile" % repr(node.ref))
         else:
             assert node.prev is None, "Non locked node shouldn't have PREV in evaluate_node"
             assert node.binary is None, "Node.binary should be None if not locked"

--- a/conans/model/graph_lock.py
+++ b/conans/model/graph_lock.py
@@ -200,6 +200,16 @@ class GraphLockNode(object):
             self._modified = True  # Only for conan_build_info
         self._prev = value
 
+    def unlock_prev(self):
+        """ for creating a new lockfile from an existing one, when specifying --build, it
+        should make prev=None in order to unlock it and allow building again"""
+        if self._prev is None:
+            return  # Already unlocked
+        if not self._relaxed:
+            raise ConanException("Cannot build '%s' because it is already locked in the "
+                                 "input lockfile" % repr(self._ref))
+        self._prev = None
+
     def complete_base_node(self, package_id, prev):
         # completing a node from a base lockfile shouldn't mark the node as modified
         self.package_id = package_id

--- a/conans/test/functional/graph_lock/build_order_test.py
+++ b/conans/test/functional/graph_lock/build_order_test.py
@@ -88,8 +88,9 @@ class BuildOrderTest(unittest.TestCase):
         self.assertEqual([], jsonbo)
         # if we try to build anyway, error
         client.run("install test4/0.1@ --lockfile=conan.lock --build", assert_error=True)
-        self.assertIn("Cannot build 'test4/0.1#f876ec9ea0f44cb7adb1588e431b391a' because it is "
-                      "already locked in the input lockfile", client.out)
+        rev = "#f876ec9ea0f44cb7adb1588e431b391a" if client.cache.config.revisions_enabled else ""
+        self.assertIn("Cannot build 'test4/0.1{}' because it is "
+                      "already locked in the input lockfile".format(rev), client.out)
 
     @parameterized.expand([(True,), (False,)])
     def test_transitive_build_not_locked(self, export):
@@ -166,8 +167,9 @@ class BuildOrderTest(unittest.TestCase):
         self.assertEqual(build_order[1:], jsonbo)
 
         client.run("install pkg/0.1@ --lockfile=conan.lock --build", assert_error=True)
-        self.assertIn("Cannot build 'dep/0.1#f3367e0e7d170aa12abccb175fee5f97' because it is "
-                      "already locked in the input lockfile", client.out)
+        rev = "#f3367e0e7d170aa12abccb175fee5f97" if client.cache.config.revisions_enabled else ""
+        self.assertIn("Cannot build 'dep/0.1{}' because it is "
+                      "already locked in the input lockfile".format(rev), client.out)
         client.run("install {0} --lockfile=conan.lock --lockfile-out=conan.lock "
                    "--build={0}".format(build_order[1][0][0]))
         self.assertIn("dep/0.1:5ab84d6acfe1f23c4fae0ab88f26e3a396351ac9 - Cache", client.out)
@@ -185,8 +187,9 @@ class BuildOrderTest(unittest.TestCase):
         self.assertEqual(build_order[2:], jsonbo)
 
         client.run("install app/0.1@ --lockfile=conan.lock --build", assert_error=True)
-        self.assertIn("Cannot build 'dep/0.1#f3367e0e7d170aa12abccb175fee5f97' because it is "
-                      "already locked in the input lockfile", client.out)
+        rev = "#f3367e0e7d170aa12abccb175fee5f97" if client.cache.config.revisions_enabled else ""
+        self.assertIn("Cannot build 'dep/0.1{}' because it is "
+                      "already locked in the input lockfile".format(rev), client.out)
         client.run("install {0} --lockfile=conan.lock --lockfile-out=conan.lock "
                    "--build={0}".format(build_order[2][0][0]))
         self.assertIn("dep/0.1:5ab84d6acfe1f23c4fae0ab88f26e3a396351ac9 - Cache", client.out)
@@ -329,8 +332,9 @@ class BuildRequiresBuildOrderTest(unittest.TestCase):
         self.assertEqual(build_order[1:], jsonbo)
 
         client.run("install pkg/0.1@ --lockfile=conan.lock --build", assert_error=True)
-        self.assertIn("Cannot build 'dep/0.1#f3367e0e7d170aa12abccb175fee5f97' because it is "
-                      "already locked in the input lockfile", client.out)
+        rrev = "#f3367e0e7d170aa12abccb175fee5f97" if client.cache.config.revisions_enabled else ""
+        self.assertIn("Cannot build 'dep/0.1{}' because it is "
+                      "already locked in the input lockfile".format(rrev), client.out)
         client.run("install {0} --lockfile=conan.lock --lockfile-out=conan.lock "
                    "--build={0}".format(build_order[1][0][0]))
         self.assertIn("dep/0.1:5ab84d6acfe1f23c4fae0ab88f26e3a396351ac9 - Cache", client.out)
@@ -348,8 +352,9 @@ class BuildRequiresBuildOrderTest(unittest.TestCase):
         self.assertEqual(build_order[2:], jsonbo)
 
         client.run("install app/0.1@ --lockfile=conan.lock --build", assert_error=True)
-        self.assertIn("Cannot build 'pkg/0.1#1364f701b47130c7e38f04c5e5fab985' because it is "
-                      "already locked in the input lockfile", client.out)
+        rrev = "#1364f701b47130c7e38f04c5e5fab985" if client.cache.config.revisions_enabled else ""
+        self.assertIn("Cannot build 'pkg/0.1{}' because it is "
+                      "already locked in the input lockfile".format(rrev), client.out)
         client.run("install {0} --lockfile=conan.lock --lockfile-out=conan.lock "
                    "--build={0}".format(build_order[2][0][0]))
         self.assertNotIn("dep/0.1", client.out)

--- a/conans/test/functional/graph_lock/dynamic_test.py
+++ b/conans/test/functional/graph_lock/dynamic_test.py
@@ -345,9 +345,9 @@ class GraphLockDynamicTest(unittest.TestCase):
         client.run("lock create --reference=LibC/1.0 --build --lockfile=libc3.lock "
                    "--lockfile-out=libc4.lock")
         client.run("lock build-order libc4.lock")
-        self.assertIn("[[('LibA/1.0@', '5ab84d6acfe1f23c4fae0ab88f26e3a396351ac9', 'host', '3')], "
-                      "[('LibB/1.0@', 'd3bf0cdac04c6f0df52003768c2226693884ea99', 'host', '2')], "
-                      "[('LibC/1.0@'", client.out)
+        self.assertIn("LibA/1.0@", client.out)
+        self.assertIn("LibB/1.0@", client.out)
+        self.assertIn("LibC/1.0@", client.out)
 
 
 class PartialOptionsTest(unittest.TestCase):

--- a/conans/test/functional/graph_lock/dynamic_test.py
+++ b/conans/test/functional/graph_lock/dynamic_test.py
@@ -341,6 +341,13 @@ class GraphLockDynamicTest(unittest.TestCase):
         self.assertIn("LibC/1.0", libc["ref"])
         self.assertIsNotNone(libc.get("prev"))
 
+        # Now unlock/build everything
+        client.run("lock create --reference=LibC/1.0 --build --lockfile=libc3.lock "
+                   "--lockfile-out=libc4.lock")
+        client.run("lock build-order libc4.lock")
+        self.assertIn("[[('LibA/1.0@', '5ab84d6acfe1f23c4fae0ab88f26e3a396351ac9', 'host', '3')], "
+                      "[('LibB/1.0@', 'd3bf0cdac04c6f0df52003768c2226693884ea99', 'host', '2')], "
+                      "[('LibC/1.0@'", client.out)
 
 
 class PartialOptionsTest(unittest.TestCase):

--- a/conans/test/functional/graph_lock/dynamic_test.py
+++ b/conans/test/functional/graph_lock/dynamic_test.py
@@ -218,7 +218,7 @@ class GraphLockDynamicTest(unittest.TestCase):
         updated = client.load("updated.lock")
         self.assertEqual(updated, new)
 
-    def augment_test_package_requires(self):
+    def test_augment_test_package_requires(self):
         # https://github.com/conan-io/conan/issues/6067
         client = TestClient()
         client.save({"conanfile.py": GenConanfile("tool", "0.1")})
@@ -312,6 +312,36 @@ class GraphLockDynamicTest(unittest.TestCase):
         client.run("create . LibB/1.1@ --lockfile=libb.lock")
         self.assertIn("LibA/1.0 from local cache - Cache", client.out)
 
+    def test_relax_lockfile_to_build(self):
+        client = TestClient()
+        client.save({"conanfile.py": GenConanfile()})
+        client.run("create . LibA/1.0@")
+        client.save({"conanfile.py": GenConanfile().with_require("LibA/[>=1.0]")})
+        client.run("create . LibB/1.0@")
+        client.save({"conanfile.py": GenConanfile().with_require("LibB/[>=1.0]")})
+        client.run("create . LibC/1.0@")
+        client.run("lock create --reference=LibC/1.0 --lockfile-out=libc.lock")
+
+        # New version of LibA/1.0.1, that should never be used
+        client.save({"conanfile.py": GenConanfile()})
+        client.run("create . LibA/1.0.1@")
+
+        client.run("lock create --reference=LibC/1.0 --build=LibC --lockfile=libc.lock "
+                   "--lockfile-out=libc2.lock")
+        libc2_json = json.loads(client.load("libc2.lock"))
+        libc = libc2_json["graph_lock"]["nodes"]["1"]
+        self.assertEqual(libc["ref"], "LibC/1.0")
+        self.assertIsNone(libc.get("prev"))
+        # Now it is possible to build it again
+        client.run("install LibC/1.0@ --build=LibC --lockfile=libc2.lock --lockfile-out=libc3.lock")
+        self.assertIn("LibC/1.0:3f278cfc7b3c4509db7f72c9bf2e472732c4f69f - Build", client.out)
+        self.assertIn("LibC/1.0: Created package", client.out)
+        libc3_json = json.loads(client.load("libc3.lock"))
+        libc = libc3_json["graph_lock"]["nodes"]["1"]
+        self.assertEqual(libc["ref"], "LibC/1.0")
+        self.assertIsNotNone(libc.get("prev"))
+
+
 
 class PartialOptionsTest(unittest.TestCase):
     """
@@ -337,8 +367,8 @@ class PartialOptionsTest(unittest.TestCase):
         self.client = client
 
     def test_partial_lock_option_command_line(self):
-        # When 'LibA:myoption' is set in command line, the option value is saved in the libb.lock and it is applied to all
-        # graph, overriding LibC.
+        # When 'LibA:myoption' is set in command line, the option value is saved in the
+        # libb.lock and it is applied to all graph, overriding LibC.
         client = self.client
         client.save({"conanfile.py": GenConanfile().with_require("LibA/1.0")})
         client.run("create . LibB/1.0@ -o LibA:myoption=True")

--- a/conans/test/functional/graph_lock/dynamic_test.py
+++ b/conans/test/functional/graph_lock/dynamic_test.py
@@ -330,7 +330,7 @@ class GraphLockDynamicTest(unittest.TestCase):
                    "--lockfile-out=libc2.lock")
         libc2_json = json.loads(client.load("libc2.lock"))
         libc = libc2_json["graph_lock"]["nodes"]["1"]
-        self.assertEqual(libc["ref"], "LibC/1.0")
+        self.assertIn("LibC/1.0", libc["ref"])
         self.assertIsNone(libc.get("prev"))
         # Now it is possible to build it again
         client.run("install LibC/1.0@ --build=LibC --lockfile=libc2.lock --lockfile-out=libc3.lock")
@@ -338,7 +338,7 @@ class GraphLockDynamicTest(unittest.TestCase):
         self.assertIn("LibC/1.0: Created package", client.out)
         libc3_json = json.loads(client.load("libc3.lock"))
         libc = libc3_json["graph_lock"]["nodes"]["1"]
-        self.assertEqual(libc["ref"], "LibC/1.0")
+        self.assertIn("LibC/1.0", libc["ref"])
         self.assertIsNotNone(libc.get("prev"))
 
 

--- a/conans/test/functional/graph_lock/graph_lock_test.py
+++ b/conans/test/functional/graph_lock/graph_lock_test.py
@@ -93,8 +93,10 @@ class GraphLockErrorsTest(unittest.TestCase):
         client.run("create . --lockfile=conan.lock --lockfile-out=conan.lock")
         client.run("install PkgA/0.1@ --build=PkgA --lockfile=conan.lock --lockfile-out=conan.lock",
                    assert_error=True)
-        self.assertIn("Cannot build 'PkgA/0.1#fa090239f8ba41ad559f8e934494ee2a' because it is "
-                      "already locked", client.out)
+        rev = "#fa090239f8ba41ad559f8e934494ee2a" if client.cache.config.revisions_enabled else ""
+        self.assertIn("Cannot build 'PkgA/0.1{}' because it is already locked".format(rev),
+                      client.out)
+
         client.run("create . --lockfile=conan.lock --lockfile-out=conan.lock", assert_error=True)
         self.assertIn("ERROR: Attempt to modify locked PkgA/0.1", client.out)
 
@@ -401,8 +403,9 @@ class GraphInstallArgumentsUpdated(unittest.TestCase):
         previous_lock = client.load("somelib.lock")
         # This should fail, because somelib is locked
         client.run("install somelib/1.0@ --lockfile=somelib.lock --build somelib", assert_error=True)
-        self.assertIn("Cannot build 'somelib/1.0#f3367e0e7d170aa12abccb175fee5f97' because it "
-                      "is already locked in the input lockfile", client.out)
+        rev = "#f3367e0e7d170aa12abccb175fee5f97" if client.cache.config.revisions_enabled else ""
+        self.assertIn("Cannot build 'somelib/1.0' because it "
+                      "is already locked in the input lockfile".format(rev), client.out)
         new_lock = client.load("somelib.lock")
         self.assertEqual(previous_lock, new_lock)
 

--- a/conans/test/functional/graph_lock/graph_lock_test.py
+++ b/conans/test/functional/graph_lock/graph_lock_test.py
@@ -404,7 +404,7 @@ class GraphInstallArgumentsUpdated(unittest.TestCase):
         # This should fail, because somelib is locked
         client.run("install somelib/1.0@ --lockfile=somelib.lock --build somelib", assert_error=True)
         rev = "#f3367e0e7d170aa12abccb175fee5f97" if client.cache.config.revisions_enabled else ""
-        self.assertIn("Cannot build 'somelib/1.0' because it "
+        self.assertIn("Cannot build 'somelib/1.0{}' because it "
                       "is already locked in the input lockfile".format(rev), client.out)
         new_lock = client.load("somelib.lock")
         self.assertEqual(previous_lock, new_lock)

--- a/conans/test/unittests/util/client_conf_test.py
+++ b/conans/test/unittests/util/client_conf_test.py
@@ -96,7 +96,7 @@ class ClientConfLogTest(unittest.TestCase):
             config = ConanClientConfigParser(os.path.join(self.tmp_dir, CONAN_CONF))
             self.assertEqual(logging.DEBUG, config.logging_level)
 
-    def test_log_level_numbers_env_var_debug(self):
+    def test_log_level_numbers_env_var_debug_text(self):
         with environment_append({"CONAN_LOGGING_LEVEL": "WakaWaka"}):
             save(os.path.join(self.tmp_dir, CONAN_CONF), default_client_conf)
             config = ConanClientConfigParser(os.path.join(self.tmp_dir, CONAN_CONF))


### PR DESCRIPTION
Changelog: BugFix: Allow lockfiles to be relaxed with the `--build` argument.
Docs: https://github.com/conan-io/docs/pull/1939

Close https://github.com/conan-io/conan/issues/8051
#revisions: 1