### PR TITLE
Add revision information to build_info --v2 modules

### DIFF
--- a/conans/build_info/build_info.py
+++ b/conans/build_info/build_info.py
@@ -61,14 +61,15 @@ class BuildInfoCreator(object):
 
     def _get_reference(self, ref):
         r = self.parse_ref(ref)
-        if r.get("user") and r.get("channel"):
-            return "{name}/{version}@{user}/{channel}".format(**r)
-        else:
-            return "{name}/{version}".format(**r)
+        recipe_rev = self._get_recipe_rev(r)
+        user_channel = self._get_user_channel(r)
+        return "{name}/{version}{user_channel}{recipe_rev}".format(recipe_rev=recipe_rev,
+                                                                   user_channel=user_channel, **r)
 
-    def _get_package_reference(self, ref, pid):
-        r = self.parse_ref(ref)
-        return "{reference}:{pid}".format(reference=self._get_reference(ref), pid=pid)
+    def _get_package_reference(self, ref, pid, prev):
+        package_rev = "#{}".format(prev) if prev and prev != "0" else ""
+        return "{reference}:{pid}{package_rev}".format(reference=self._get_reference(ref), pid=pid,
+                                                       package_rev=package_rev)
 
     def _get_metadata_artifacts(self, metadata, request_path, use_id=False, name_format="{}",
                                 package_id=None):
@@ -107,41 +108,44 @@ class BuildInfoCreator(object):
                                                   "id": "conan_sources.tgz" if use_id else None}
         return set([Artifact(k, **v) for k, v in ret.items()])
 
+    def _get_recipe_rev(self, ref):
+        return "#{rrev}".format(ref.get("rrev")) if ref.get("rrev") and ref.get("rrev") != "0" else ""
+
+    def _get_user_channel(self, ref):
+        return "@{}/{}".format(ref.get("user"), ref.get("channel")) if ref.get("user") and \
+                                                                       ref.get("channel") else ""
+
     def _get_recipe_artifacts(self, ref, is_dependency):
         r = self.parse_ref(ref)
-        if r.get("user") and r.get("channel"):
-            ref = "{name}/{version}@{user}/{channel}#{rrev}".format(**r)
-        else:
-            ref = "{name}/{version}#{rrev}".format(**r)
+        user_channel = self._get_user_channel(r)
+        recipe_rev = self._get_recipe_rev(r)
+        ref = "{name}/{version}{user_channel}{recipe_rev}".format(user_channel=user_channel,
+                                                                  recipe_rev=recipe_rev, **r)
         reference = ConanFileReference.loads(ref)
         package_layout = self._conan_cache.package_layout(reference)
         metadata = package_layout.load_metadata()
         name_format = "{} :: {{}}".format(self._get_reference(ref)) if is_dependency else "{}"
-        if r.get("user") and r.get("channel"):
-            url = "{user}/{name}/{version}/{channel}/{rrev}/export".format(**r)
-        else:
-            url = "_/{name}/{version}/_/{rrev}/export".format(**r)
+        url = "{user}/{name}/{version}/{channel}/{rrev}/export".format(
+            **r) if user_channel else "_/{name}/{version}/_/{rrev}/export".format(**r)
 
         return self._get_metadata_artifacts(metadata, url, name_format=name_format,
                                             use_id=is_dependency)
 
     def _get_package_artifacts(self, ref, pid, prev, is_dependency):
         r = self.parse_ref(ref)
-        if r.get("user") and r.get("channel"):
-            ref = "{name}/{version}@{user}/{channel}#{rrev}".format(**r)
-        else:
-            ref = "{name}/{version}#{rrev}".format(**r)
+        user_channel = self._get_user_channel(r)
+        recipe_rev = self._get_recipe_rev(r)
+        ref = "{name}/{version}{user_channel}{recipe_rev}".format(user_channel=user_channel,
+                                                                  recipe_rev=recipe_rev, **r)
         reference = ConanFileReference.loads(ref)
         package_layout = self._conan_cache.package_layout(reference)
         metadata = package_layout.load_metadata()
         if is_dependency:
-            name_format = "{} :: {{}}".format(self._get_package_reference(ref, pid))
+            name_format = "{} :: {{}}".format(self._get_package_reference(ref, pid, prev))
         else:
             name_format = "{}"
-        if r.get("user") and r.get("channel"):
-            url = "{user}/{name}/{version}/{channel}/{rrev}/package/{pid}/{prev}"
-        else:
-            url = "_/{name}/{version}/_/{rrev}/package/{pid}/{prev}"
+        url = "{user}/{name}/{version}/{channel}/{rrev}/package/{pid}/{prev}" if user_channel else \
+              "_/{name}/{version}/_/{rrev}/package/{pid}/{prev}"
         url = url.format(pid=pid, prev=prev, **r)
         arts = self._get_metadata_artifacts(metadata, url, name_format=name_format,
                                             use_id=is_dependency, package_id=pid)
@@ -193,7 +197,7 @@ class BuildInfoCreator(object):
                 # TODO: be different per lockfile
 
                 # Create module for the package_id
-                package_key = self._get_package_reference(ref, pid)
+                package_key = self._get_package_reference(ref, pid, prev)
                 modules[package_key]["id"] = package_key
                 modules[package_key]["artifacts"].update(
                     self._get_package_artifacts(ref, pid, prev, is_dependency=False))

--- a/conans/build_info/build_info.py
+++ b/conans/build_info/build_info.py
@@ -109,7 +109,7 @@ class BuildInfoCreator(object):
         return set([Artifact(k, **v) for k, v in ret.items()])
 
     def _get_recipe_rev(self, ref):
-        return "#{rrev}".format(ref.get("rrev")) if ref.get("rrev") and ref.get("rrev") != "0" else ""
+        return "#{}".format(ref.get("rrev")) if ref.get("rrev") and ref.get("rrev") != "0" else ""
 
     def _get_user_channel(self, ref):
         return "@{}/{}".format(ref.get("user"), ref.get("channel")) if ref.get("user") and \

--- a/conans/test/functional/conan_build_info/test_build_info_creation.py
+++ b/conans/test/functional/conan_build_info/test_build_info_creation.py
@@ -121,7 +121,7 @@ class MyBuildInfoCreation(unittest.TestCase):
         self.assertEqual(buildinfo["name"], "MyBuildName")
         self.assertEqual(buildinfo["number"], "42")
         ids_list = [item["id"] for item in buildinfo["modules"]]
-        rrev_pkgd, rrev_pkgc, prev_pkgd_win, prev_pkgc_win, prev_pkgd_linux, prev_pkgc_linux = "", "" , "", "", "", ""
+        rrev_pkgd, rrev_pkgc, prev_pkgd_win, prev_pkgc_win, prev_pkgd_linux, prev_pkgc_linux = "", "", "", "", "", ""
         if client.cache.config.revisions_enabled:
             rrev_pkgd = "#4923df588db8c6e5867f8df8b8d4e79d" if user_channel else "#a4041e14960e937df21d431579e32e9c"
             rrev_pkgc = "#4fb6c2b0610701ceb5d3b5ccb7a93ecf" if user_channel else "#9d4a7842c95b2ab65b99e2a8834c58da"

--- a/conans/test/functional/conan_build_info/test_build_info_creation.py
+++ b/conans/test/functional/conan_build_info/test_build_info_creation.py
@@ -116,25 +116,33 @@ class MyBuildInfoCreation(unittest.TestCase):
                     os.path.join(client.current_folder, "Linux.lock")]
         run()
 
-        user_channel = "@" + user_channel if len(user_channel) > 2 else user_channel
+        user_channel = "@" + user_channel if user_channel else user_channel
         buildinfo = json.loads(client.load("buildinfowin.json"))
         self.assertEqual(buildinfo["name"], "MyBuildName")
         self.assertEqual(buildinfo["number"], "42")
         ids_list = [item["id"] for item in buildinfo["modules"]]
-        expected = ["PkgC/0.1{}".format(user_channel),
-                    "PkgD/0.1{}".format(user_channel),
-                    "PkgC/0.1{}:3374c4fa6b7e865cfc3a1903ae014cf77a6938ec".format(user_channel),
-                    "PkgD/0.1{}:6cd742f1b907e693abf6da9f767aab3ee7fde606".format(user_channel)]
+
+        rrev_pkgd = "4923df588db8c6e5867f8df8b8d4e79d" if user_channel else "a4041e14960e937df21d431579e32e9c"
+        rrev_pkgc = "4fb6c2b0610701ceb5d3b5ccb7a93ecf" if user_channel else "9d4a7842c95b2ab65b99e2a8834c58da"
+        prev_pkgd_win = "fae36f88c6cc61dafd2afe78687ab248" if user_channel else "5f50bfa7642cd8924c80b3d6be87b4c5"
+        prev_pkgc_win = "d0f5b7f73cb879dcc78b72ed3af8c85c" if user_channel else "861f0854c9135d1e753ca9ffe8587d4a"
+        prev_pkgd_linux = "ca5538e3a9abdfcc024ebd96837b7161" if user_channel else "e6adeb06f3b4296c63a751b5d68ed858"
+        prev_pkgc_linux = "472d19aea10fe10ddf081d13ca716404" if user_channel else "919776eb660a26575c327cceb2f046f8"
+
+        expected = ["PkgC/0.1{}#{}".format(user_channel, rrev_pkgc),
+                    "PkgD/0.1{}#{}".format(user_channel, rrev_pkgd),
+                    "PkgC/0.1{}#{}:3374c4fa6b7e865cfc3a1903ae014cf77a6938ec#{}".format(user_channel, rrev_pkgc, prev_pkgc_win),
+                    "PkgD/0.1{}#{}:6cd742f1b907e693abf6da9f767aab3ee7fde606#{}".format(user_channel, rrev_pkgd, prev_pkgd_win)]
         self.assertEqual(set(expected), set(ids_list))
 
         buildinfo = json.loads(client.load("buildinfolinux.json"))
         self.assertEqual(buildinfo["name"], "MyBuildName")
         self.assertEqual(buildinfo["number"], "42")
         ids_list = [item["id"] for item in buildinfo["modules"]]
-        expected = ["PkgC/0.1{}".format(user_channel),
-                    "PkgD/0.1{}".format(user_channel),
-                    "PkgC/0.1{}:a1e39343af463cef4284c5550fde03912afd9852".format(user_channel),
-                    "PkgD/0.1{}:39af3f48fdee2bbc5f84e7da3a67ebab2a297acb".format(user_channel)]
+        expected = ["PkgC/0.1{}#{}".format(user_channel, rrev_pkgc),
+                    "PkgD/0.1{}#{}".format(user_channel, rrev_pkgd),
+                    "PkgC/0.1{}#{}:a1e39343af463cef4284c5550fde03912afd9852#{}".format(user_channel, rrev_pkgc, prev_pkgc_linux),
+                    "PkgD/0.1{}#{}:39af3f48fdee2bbc5f84e7da3a67ebab2a297acb#{}".format(user_channel, rrev_pkgd, prev_pkgd_linux)]
         self.assertEqual(set(expected), set(ids_list))
 
         sys.argv = ["conan_build_info", "--v2", "update",
@@ -148,12 +156,12 @@ class MyBuildInfoCreation(unittest.TestCase):
         self.assertEqual(buildinfo["name"], "MyBuildName")
         self.assertEqual(buildinfo["number"], "42")
         ids_list = [item["id"] for item in buildinfo["modules"]]
-        expected = ["PkgC/0.1{}".format(user_channel),
-                    "PkgD/0.1{}".format(user_channel),
-                    "PkgC/0.1{}:3374c4fa6b7e865cfc3a1903ae014cf77a6938ec".format(user_channel),
-                    "PkgC/0.1{}:a1e39343af463cef4284c5550fde03912afd9852".format(user_channel),
-                    "PkgD/0.1{}:6cd742f1b907e693abf6da9f767aab3ee7fde606".format(user_channel),
-                    "PkgD/0.1{}:39af3f48fdee2bbc5f84e7da3a67ebab2a297acb".format(user_channel),
+        expected = ["PkgC/0.1{}#{}".format(user_channel, rrev_pkgc),
+                    "PkgD/0.1{}#{}".format(user_channel, rrev_pkgd),
+                    "PkgC/0.1{}#{}:3374c4fa6b7e865cfc3a1903ae014cf77a6938ec#{}".format(user_channel, rrev_pkgc, prev_pkgc_win),
+                    "PkgC/0.1{}#{}:a1e39343af463cef4284c5550fde03912afd9852#{}".format(user_channel, rrev_pkgc, prev_pkgc_linux),
+                    "PkgD/0.1{}#{}:6cd742f1b907e693abf6da9f767aab3ee7fde606#{}".format(user_channel, rrev_pkgd, prev_pkgd_win),
+                    "PkgD/0.1{}#{}:39af3f48fdee2bbc5f84e7da3a67ebab2a297acb#{}".format(user_channel, rrev_pkgd, prev_pkgd_linux)
                     ]
         self.assertEqual(set(expected), set(ids_list))
 
@@ -182,7 +190,7 @@ class MyBuildInfoCreation(unittest.TestCase):
 
         mock_cache.return_value = client.cache
         user_home_mock.return_value = base_folder
-        user_channels = ["", "user/channel"]
+        user_channels = ["user/channel", ""]
         for user_channel in user_channels:
             self._test_buildinfo(client, user_channel)
 

--- a/conans/test/functional/conan_build_info/test_build_info_creation.py
+++ b/conans/test/functional/conan_build_info/test_build_info_creation.py
@@ -121,28 +121,29 @@ class MyBuildInfoCreation(unittest.TestCase):
         self.assertEqual(buildinfo["name"], "MyBuildName")
         self.assertEqual(buildinfo["number"], "42")
         ids_list = [item["id"] for item in buildinfo["modules"]]
+        rrev_pkgd, rrev_pkgc, prev_pkgd_win, prev_pkgc_win, prev_pkgd_linux, prev_pkgc_linux = "", "" , "", "", "", ""
+        if client.cache.config.revisions_enabled:
+            rrev_pkgd = "#4923df588db8c6e5867f8df8b8d4e79d" if user_channel else "#a4041e14960e937df21d431579e32e9c"
+            rrev_pkgc = "#4fb6c2b0610701ceb5d3b5ccb7a93ecf" if user_channel else "#9d4a7842c95b2ab65b99e2a8834c58da"
+            prev_pkgd_win = "#fae36f88c6cc61dafd2afe78687ab248" if user_channel else "#5f50bfa7642cd8924c80b3d6be87b4c5"
+            prev_pkgc_win = "#d0f5b7f73cb879dcc78b72ed3af8c85c" if user_channel else "#861f0854c9135d1e753ca9ffe8587d4a"
+            prev_pkgd_linux = "#ca5538e3a9abdfcc024ebd96837b7161" if user_channel else "#e6adeb06f3b4296c63a751b5d68ed858"
+            prev_pkgc_linux = "#472d19aea10fe10ddf081d13ca716404" if user_channel else "#919776eb660a26575c327cceb2f046f8"
 
-        rrev_pkgd = "4923df588db8c6e5867f8df8b8d4e79d" if user_channel else "a4041e14960e937df21d431579e32e9c"
-        rrev_pkgc = "4fb6c2b0610701ceb5d3b5ccb7a93ecf" if user_channel else "9d4a7842c95b2ab65b99e2a8834c58da"
-        prev_pkgd_win = "fae36f88c6cc61dafd2afe78687ab248" if user_channel else "5f50bfa7642cd8924c80b3d6be87b4c5"
-        prev_pkgc_win = "d0f5b7f73cb879dcc78b72ed3af8c85c" if user_channel else "861f0854c9135d1e753ca9ffe8587d4a"
-        prev_pkgd_linux = "ca5538e3a9abdfcc024ebd96837b7161" if user_channel else "e6adeb06f3b4296c63a751b5d68ed858"
-        prev_pkgc_linux = "472d19aea10fe10ddf081d13ca716404" if user_channel else "919776eb660a26575c327cceb2f046f8"
-
-        expected = ["PkgC/0.1{}#{}".format(user_channel, rrev_pkgc),
-                    "PkgD/0.1{}#{}".format(user_channel, rrev_pkgd),
-                    "PkgC/0.1{}#{}:3374c4fa6b7e865cfc3a1903ae014cf77a6938ec#{}".format(user_channel, rrev_pkgc, prev_pkgc_win),
-                    "PkgD/0.1{}#{}:6cd742f1b907e693abf6da9f767aab3ee7fde606#{}".format(user_channel, rrev_pkgd, prev_pkgd_win)]
+        expected = ["PkgC/0.1{}{}".format(user_channel, rrev_pkgc),
+                    "PkgD/0.1{}{}".format(user_channel, rrev_pkgd),
+                    "PkgC/0.1{}{}:3374c4fa6b7e865cfc3a1903ae014cf77a6938ec{}".format(user_channel, rrev_pkgc, prev_pkgc_win),
+                    "PkgD/0.1{}{}:6cd742f1b907e693abf6da9f767aab3ee7fde606{}".format(user_channel, rrev_pkgd, prev_pkgd_win)]
         self.assertEqual(set(expected), set(ids_list))
 
         buildinfo = json.loads(client.load("buildinfolinux.json"))
         self.assertEqual(buildinfo["name"], "MyBuildName")
         self.assertEqual(buildinfo["number"], "42")
         ids_list = [item["id"] for item in buildinfo["modules"]]
-        expected = ["PkgC/0.1{}#{}".format(user_channel, rrev_pkgc),
-                    "PkgD/0.1{}#{}".format(user_channel, rrev_pkgd),
-                    "PkgC/0.1{}#{}:a1e39343af463cef4284c5550fde03912afd9852#{}".format(user_channel, rrev_pkgc, prev_pkgc_linux),
-                    "PkgD/0.1{}#{}:39af3f48fdee2bbc5f84e7da3a67ebab2a297acb#{}".format(user_channel, rrev_pkgd, prev_pkgd_linux)]
+        expected = ["PkgC/0.1{}{}".format(user_channel, rrev_pkgc),
+                    "PkgD/0.1{}{}".format(user_channel, rrev_pkgd),
+                    "PkgC/0.1{}{}:a1e39343af463cef4284c5550fde03912afd9852{}".format(user_channel, rrev_pkgc, prev_pkgc_linux),
+                    "PkgD/0.1{}{}:39af3f48fdee2bbc5f84e7da3a67ebab2a297acb{}".format(user_channel, rrev_pkgd, prev_pkgd_linux)]
         self.assertEqual(set(expected), set(ids_list))
 
         sys.argv = ["conan_build_info", "--v2", "update",
@@ -156,12 +157,12 @@ class MyBuildInfoCreation(unittest.TestCase):
         self.assertEqual(buildinfo["name"], "MyBuildName")
         self.assertEqual(buildinfo["number"], "42")
         ids_list = [item["id"] for item in buildinfo["modules"]]
-        expected = ["PkgC/0.1{}#{}".format(user_channel, rrev_pkgc),
-                    "PkgD/0.1{}#{}".format(user_channel, rrev_pkgd),
-                    "PkgC/0.1{}#{}:3374c4fa6b7e865cfc3a1903ae014cf77a6938ec#{}".format(user_channel, rrev_pkgc, prev_pkgc_win),
-                    "PkgC/0.1{}#{}:a1e39343af463cef4284c5550fde03912afd9852#{}".format(user_channel, rrev_pkgc, prev_pkgc_linux),
-                    "PkgD/0.1{}#{}:6cd742f1b907e693abf6da9f767aab3ee7fde606#{}".format(user_channel, rrev_pkgd, prev_pkgd_win),
-                    "PkgD/0.1{}#{}:39af3f48fdee2bbc5f84e7da3a67ebab2a297acb#{}".format(user_channel, rrev_pkgd, prev_pkgd_linux)
+        expected = ["PkgC/0.1{}{}".format(user_channel, rrev_pkgc),
+                    "PkgD/0.1{}{}".format(user_channel, rrev_pkgd),
+                    "PkgC/0.1{}{}:3374c4fa6b7e865cfc3a1903ae014cf77a6938ec{}".format(user_channel, rrev_pkgc, prev_pkgc_win),
+                    "PkgC/0.1{}{}:a1e39343af463cef4284c5550fde03912afd9852{}".format(user_channel, rrev_pkgc, prev_pkgc_linux),
+                    "PkgD/0.1{}{}:6cd742f1b907e693abf6da9f767aab3ee7fde606{}".format(user_channel, rrev_pkgd, prev_pkgd_win),
+                    "PkgD/0.1{}{}:39af3f48fdee2bbc5f84e7da3a67ebab2a297acb{}".format(user_channel, rrev_pkgd, prev_pkgd_linux)
                     ]
         self.assertEqual(set(expected), set(ids_list))
 


### PR DESCRIPTION
Changelog: Feature: Add recipe and package revision to show a complete Conan reference when generating the `build_info --v2` id fields.
Docs: omit

Now the id's in the build info generated with build_info --v2 will contain the complete reference with package and recipe revision. Changing the id's should not be a problem for Artifactory as it identifies the artifacts using the checksum and the id is just an arbitray label.

Closes: https://github.com/conan-io/conan/issues/7950

- [X] Refer to the issue that supports this Pull Request.
- [X] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [X] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [X] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 

<sup>**Note:** By default this PR will skip the slower tests and will use a limited set of python versions. Check [here](https://github.com/conan-io/conan/blob/develop/.github/PR_INCREASE_TESTING.md) how to increase the testing level by writing some tags in the current PR body text.</sup>
