### PR TITLE
Conan test assets is required for CPT

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ dev_requirements = get_requires("conans/requirements_dev.txt")
 # The tests utils are used by conan-package-tools
 exclude_test_packages = ["conans.test.{}*".format(d)
                          for d in os.listdir(os.path.join(here, "conans/test"))
-                         if os.path.isdir(os.path.join(here, "conans/test", d)) and d != "utils"]
+                         if os.path.isdir(os.path.join(here, "conans/test", d)) and d not in ("utils", "assets")]
 
 
 def load_version():

--- a/setup.py
+++ b/setup.py
@@ -29,10 +29,6 @@ def get_requires(filename):
 project_requirements = get_requires("conans/requirements.txt")
 project_requirements.extend(get_requires("conans/requirements_server.txt"))
 dev_requirements = get_requires("conans/requirements_dev.txt")
-# The tests utils are used by conan-package-tools
-exclude_test_packages = ["conans.test.{}*".format(d)
-                         for d in os.listdir(os.path.join(here, "conans/test"))
-                         if os.path.isdir(os.path.join(here, "conans/test", d)) and d not in ("utils", "assets")]
 
 
 def load_version():
@@ -91,7 +87,7 @@ setup(
 
     # You can just specify the packages manually here if your project is
     # simple. Or you can use find_packages().
-    packages=find_packages(exclude=exclude_test_packages),
+    packages=find_packages(exclude=("conans.test*")),
 
     # Alternatively, if you want to distribute just a my_module.py, uncomment
     # this:


### PR DESCRIPTION
Exclude conan.tests from Conan python package.

Changelog: Omit
Docs: Omit

Basically, it reverts https://github.com/conan-io/conan/pull/4750

CPT should copy and use what it needs.

- [ ] Refer to the issue that supports this Pull Request.
- [ ] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [ ] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [ ] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 

<sup>**Note:** By default this PR will skip the slower tests and will use a limited set of python versions. Check [here](https://github.com/conan-io/conan/blob/develop/.github/PR_INCREASE_TESTING.md) how to increase the testing level by writing some tags in the current PR body text.</sup>
