### PR TITLE
fix addition of CMAKE_SYSTEM_NAME for SunOS and AIX 64->32 bits builds

### DIFF
--- a/conans/client/build/cmake_flags.py
+++ b/conans/client/build/cmake_flags.py
@@ -202,7 +202,7 @@ class CMakeDefinitionsBuilder(object):
         if cmake_system_name is not True:  # String not empty
             definitions["CMAKE_SYSTEM_NAME"] = cmake_system_name
         else:  # detect if we are cross building and the system name and version
-            skip_x64_x86 = os_ in ['Windows', 'Linux']
+            skip_x64_x86 = os_ in ['Windows', 'Linux', 'SunOS', 'AIX']
             if cross_building(self._conanfile, skip_x64_x86=skip_x64_x86):  # We are cross building
                 apple_system_name = "Darwin" if cmake_version and Version(cmake_version) < Version(
                     "3.14") or not cmake_version else None

--- a/conans/client/tools/oss.py
+++ b/conans/client/tools/oss.py
@@ -459,7 +459,9 @@ def cross_building(conanfile=None, self_os=None, self_arch=None, skip_x64_x86=Fa
     build_os, build_arch, host_os, host_arch = ret
 
     if skip_x64_x86 and host_os is not None and (build_os == host_os) and \
-            host_arch is not None and (build_arch == "x86_64") and (host_arch == "x86"):
+            host_arch is not None and ((build_arch == "x86_64") and (host_arch == "x86") or
+                                       (build_arch == "sparcv9") and (host_arch == "sparc") or
+                                       (build_arch == "ppc64") and (host_arch == "ppc32")):
         return False
 
     if host_os is not None and (build_os != host_os):

--- a/conans/test/unittests/client/build/cmake_test.py
+++ b/conans/test/unittests/client/build/cmake_test.py
@@ -224,6 +224,27 @@ class CMakeTest(unittest.TestCase):
             self.assertNotIn('-G "Visual Studio 15 2017" -A "x64"', cmake.command_line)
             self.assertNotIn('-T "Intel C++ Compiler 19.0', cmake.command_line)
 
+    @parameterized.expand([("SunOS", "sparcv9", "sparc"),
+                           ("AIX", "ppc64", "ppc32"),
+                           ("SunOS", "x86_64", "x86")])
+    def test_cmake_not_cross_compile(self, os_build, arch_build, arch):
+        # https://github.com/conan-io/conan/issues/8052
+        settings = Settings.loads(get_default_settings_yml())
+        settings.os = os_build
+        settings.os_build = os_build
+        settings.compiler = "gcc"
+        settings.compiler.version = "9.2"
+        settings.compiler.libcxx = "libstdc++"
+        settings.arch = arch
+        settings.arch_build = arch_build
+
+        conanfile = ConanFileMock()
+        conanfile.settings = settings
+
+        cmake = CMake(conanfile)
+        self.assertNotIn('CMAKE_SYSTEM_NAME', cmake.command_line)
+        self.assertIn('-G "Unix Makefiles"', cmake.command_line)
+
     def test_cmake_generator_platform(self):
         conanfile = ConanFileMock()
         conanfile.settings = Settings()

--- a/conans/test/unittests/client/generators/cmake_test.py
+++ b/conans/test/unittests/client/generators/cmake_test.py
@@ -321,13 +321,12 @@ endmacro()""", macro)
         self.assertEqual(install_folder, definitions["CMAKE_MODULE_PATH"])
 
     def test_cmake_definitions_apple(self):
-        #https://github.com/conan-io/conan/issues/7875
+        # https://github.com/conan-io/conan/issues/7875
         settings_mock = _MockSettings(build_type="Release")
         settings_mock.os = "iOS"
         settings_mock.os_build = "Macos"
         conanfile = ConanFile(TestBufferConanOutput(), None)
-        install_folder = "/c/foo/testing"
-        setattr(conanfile, "install_folder", install_folder)
+        conanfile.install_folder = "/c/foo/testing"
         conanfile.initialize(settings_mock, EnvValues())
         definitions_builder = CMakeDefinitionsBuilder(conanfile)
         definitions = definitions_builder.get_definitions("3.13")


### PR DESCRIPTION
Changelog: Bugfix: Fix addition of CMAKE_SYSTEM_NAME for SunOS and AIX 64->32 bits builds
Docs: Omit

Close https://github.com/conan-io/conan/issues/8052
