### PR TITLE
keep python files in packaging .pyc, .pyo, etc

### DIFF
--- a/conans/client/conf/__init__.py
+++ b/conans/client/conf/__init__.py
@@ -264,6 +264,7 @@ class ConanClientConfigParser(ConfigParser, object):
             ("CONAN_MSBUILD_VERBOSITY", "msbuild_verbosity", None),
             ("CONAN_CACERT_PATH", "cacert_path", None),
             ("CONAN_DEFAULT_PACKAGE_ID_MODE", "default_package_id_mode", None),
+            ("CONAN_KEEP_PYTHON_FILES", "keep_python_files", False),
             # ("CONAN_DEFAULT_PROFILE_PATH", "default_profile", DEFAULT_PROFILE_NAME),
         ],
         "hooks": [

--- a/conans/paths/package_layouts/package_cache_layout.py
+++ b/conans/paths/package_layouts/package_cache_layout.py
@@ -17,6 +17,7 @@ from conans.model.ref import ConanFileReference
 from conans.model.ref import PackageReference
 from conans.paths import CONANFILE, SYSTEM_REQS, EXPORT_FOLDER, EXPORT_SRC_FOLDER, SRC_FOLDER, \
     BUILD_FOLDER, PACKAGES_FOLDER, SYSTEM_REQS_FOLDER, PACKAGE_METADATA, SCM_SRC_FOLDER, rm_conandir
+from conans.util.env_reader import get_env
 from conans.util.files import load, save, rmdir, set_dirty, clean_dirty, is_dirty
 from conans.util.locks import Lock, NoLock, ReadLock, SimpleLock, WriteLock
 from conans.util.log import logger
@@ -294,6 +295,8 @@ class PackageCacheLayout(object):
         if not os.path.exists(abs_path):
             raise NotFoundException("The specified path doesn't exist")
         if os.path.isdir(abs_path):
-            return sorted([path for path in os.listdir(abs_path) if not discarded_file(path)])
+            keep_python = get_env("CONAN_KEEP_PYTHON_FILES", False)
+            return sorted([path for path in os.listdir(abs_path) if not discarded_file(path,
+                                                                                       keep_python)])
         else:
             return load(abs_path)

--- a/conans/test/test_package_python_files.py
+++ b/conans/test/test_package_python_files.py
@@ -61,9 +61,3 @@ class TestPackagePythonFiles(unittest.TestCase):
         self.assertIn("myfile.pyc", manifest)
         self.assertIn("myfile.pyo", manifest)
         self.assertNotIn(".DS_Store", manifest)
-
-
-
-
-
-

--- a/conans/test/test_package_python_files.py
+++ b/conans/test/test_package_python_files.py
@@ -1,0 +1,69 @@
+import os
+import textwrap
+import unittest
+
+from conans.util.files import load
+from conans.model.ref import ConanFileReference, PackageReference
+from conans.test.utils.tools import TestClient, NO_SETTINGS_PACKAGE_ID
+
+
+class TestPackagePythonFiles(unittest.TestCase):
+    def test_package_python_files(self):
+        client = TestClient(default_server_user=True)
+        client.run("config set general.keep_python_files=True")
+        conanfile = textwrap.dedent("""
+            from conans import ConanFile
+            class Pkg(ConanFile):
+                exports_sources = "*"
+                def package(self):
+                    self.copy("*")
+            """)
+        client.save({"conanfile.py": conanfile,
+                     "myfile.pyc": "",
+                     "myfile.pyo": "",
+                     ".DS_Store": ""})
+        client.run("create . pkg/0.1@")
+        ref = ConanFileReference.loads("pkg/0.1")
+        layout = client.cache.package_layout(ref)
+        export = layout.export()
+        export_sources = layout.export_sources()
+        self.assertTrue(os.path.isfile(os.path.join(export_sources, "myfile.pyc")))
+        self.assertTrue(os.path.isfile(os.path.join(export_sources, "myfile.pyo")))
+        self.assertTrue(os.path.isfile(os.path.join(export_sources, ".DS_Store")))
+        manifest = load(os.path.join(export, "conanmanifest.txt"))
+        self.assertIn("myfile.pyc", manifest)
+        self.assertIn("myfile.pyo", manifest)
+        self.assertNotIn(".DS_Store", manifest)
+        pkg_folder = layout.package(PackageReference(ref, NO_SETTINGS_PACKAGE_ID))
+        self.assertTrue(os.path.isfile(os.path.join(pkg_folder, "myfile.pyc")))
+        self.assertTrue(os.path.isfile(os.path.join(pkg_folder, "myfile.pyo")))
+        self.assertTrue(os.path.isfile(os.path.join(pkg_folder, ".DS_Store")))
+        manifest = load(os.path.join(pkg_folder, "conanmanifest.txt"))
+        self.assertIn("myfile.pyc", manifest)
+        self.assertIn("myfile.pyo", manifest)
+        self.assertNotIn(".DS_Store", manifest)
+
+        client.run("upload * --all -r=default --confirm")
+        client.run("remove * -f")
+        client.run("download pkg/0.1@")
+
+        self.assertTrue(os.path.isfile(os.path.join(export_sources, "myfile.pyc")))
+        self.assertTrue(os.path.isfile(os.path.join(export_sources, "myfile.pyo")))
+        self.assertFalse(os.path.isfile(os.path.join(export_sources, ".DS_Store")))
+        manifest = load(os.path.join(export, "conanmanifest.txt"))
+        self.assertIn("myfile.pyc", manifest)
+        self.assertIn("myfile.pyo", manifest)
+        self.assertNotIn(".DS_Store", manifest)
+        self.assertTrue(os.path.isfile(os.path.join(pkg_folder, "myfile.pyc")))
+        self.assertTrue(os.path.isfile(os.path.join(pkg_folder, "myfile.pyo")))
+        self.assertFalse(os.path.isfile(os.path.join(pkg_folder, ".DS_Store")))
+        manifest = load(os.path.join(pkg_folder, "conanmanifest.txt"))
+        self.assertIn("myfile.pyc", manifest)
+        self.assertIn("myfile.pyo", manifest)
+        self.assertNotIn(".DS_Store", manifest)
+
+
+
+
+
+


### PR DESCRIPTION
Changelog: Feature: Introduce configuration ``general.keep_python_files`` to allow packaging of Python .pyc files.
Docs: https://github.com/conan-io/docs/pull/1942

Close https://github.com/conan-io/conan/issues/4961


