### PR TITLE
avoid conflict of filenames with generator

### DIFF
--- a/conans/client/toolchain/msbuild.py
+++ b/conans/client/toolchain/msbuild.py
@@ -46,6 +46,8 @@ class MSBuildCmd(object):
 
 class MSBuildToolchain(object):
 
+    filename = "conantoolchain.props"
+
     def __init__(self, conanfile):
         self._conanfile = conanfile
         self.preprocessor_definitions = {}
@@ -63,7 +65,7 @@ class MSBuildToolchain(object):
 
     def write_toolchain_files(self):
         name, condition = self._name_condition(self._conanfile.settings)
-        config_filename = "conan_toolchain{}.props".format(name)
+        config_filename = "conantoolchain{}.props".format(name)
         self._write_config_toolchain(config_filename)
         self._write_main_toolchain(config_filename, condition)
 
@@ -108,7 +110,7 @@ class MSBuildToolchain(object):
         save(config_filepath, config_props)
 
     def _write_main_toolchain(self, config_filename, condition):
-        main_toolchain_path = os.path.abspath("conan_toolchain.props")
+        main_toolchain_path = os.path.abspath(self.filename)
         if os.path.isfile(main_toolchain_path):
             content = load(main_toolchain_path)
         else:
@@ -125,7 +127,7 @@ class MSBuildToolchain(object):
         try:
             import_group = dom.getElementsByTagName('ImportGroup')[0]
         except Exception:
-            raise ConanException("Broken conan_toolchain.props. Remove the file and try again")
+            raise ConanException("Broken {}. Remove the file and try again".format(self.filename))
         children = import_group.getElementsByTagName("Import")
         for node in children:
             if (config_filename == node.getAttribute("Project") and
@@ -139,5 +141,5 @@ class MSBuildToolchain(object):
 
         conan_toolchain = dom.toprettyxml()
         conan_toolchain = "\n".join(line for line in conan_toolchain.splitlines() if line.strip())
-        self._conanfile.output.info("MSBuildToolchain writing %s" % "conan_toolchain.props")
+        self._conanfile.output.info("MSBuildToolchain writing {}".format(self.filename))
         save(main_toolchain_path, conan_toolchain)

--- a/conans/test/integration/toolchains/test_msbuild.py
+++ b/conans/test/integration/toolchains/test_msbuild.py
@@ -104,7 +104,7 @@ myapp_vcxproj = r"""<?xml version="1.0" encoding="utf-8"?>
   If it goes after, the Toolset definition is ignored -->
   <ImportGroup Label="PropertySheets">
     <Import Project="..\conan\conan_Hello.props" />
-    <Import Project="..\conan\conan_toolchain.props" />
+    <Import Project="..\conan\conantoolchain.props" />
   </ImportGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ImportGroup Label="ExtensionSettings">
@@ -289,7 +289,7 @@ class WinTest(unittest.TestCase):
 
         # Run the configure corresponding to this test case
         client.run("install . %s -if=conan" % (settings, ))
-        self.assertIn("conanfile.py: MSBuildToolchain created conan_toolchain_release_win32.props",
+        self.assertIn("conanfile.py: MSBuildToolchain created conantoolchain_release_win32.props",
                       client.out)
         client.run("build . -if=conan")
 
@@ -333,7 +333,7 @@ class WinTest(unittest.TestCase):
 
         # Run the configure corresponding to this test case
         client.run("install . %s -if=conan" % (settings, ))
-        self.assertIn("conanfile.py: MSBuildToolchain created conan_toolchain_debug_x64.props",
+        self.assertIn("conanfile.py: MSBuildToolchain created conantoolchain_debug_x64.props",
                       client.out)
         client.run("build . -if=conan")
         self.assertIn("Visual Studio 2017", client.out)


### PR DESCRIPTION
Changelog: Fix: Rename the generated file of ``MSBuildToolchain`` to ``conantoolchain.props`` so it doesn't collide with a potential ``toolchain`` package name and the ``msbuild`` generator.
Docs: https://github.com/conan-io/docs/pull/1941

From https://github.com/conan-io/conan/pull/7645