### PR TITLE
Remove cryptography, pyopenssl and idna from requirements

### DIFF
--- a/conans/requirements.txt
+++ b/conans/requirements.txt
@@ -14,7 +14,4 @@ deprecation>=2.0, <2.1
 tqdm>=4.28.1, <5
 Jinja2>=2.9, <3
 python-dateutil>=2.7.0, <3
-idna==2.6 ; sys_platform == "darwin" # Solving conflict, somehow is installing 2.7 when requests require 2.6
-cryptography>=3.2, <4 ; sys_platform == "darwin"
-pyOpenSSL>=16.0.0, <19.0.0 ; sys_platform == "darwin"
 


### PR DESCRIPTION
Changelog: Fix: Remove cryptography, pyopenssl and idna from OSX requirements in Python.
Docs: omit

Closes: https://github.com/conan-io/conan/issues/8061
Close: https://github.com/conan-io/conan/issues/7286

As summarised in [this comment](https://github.com/conan-io/conan/issues/8061#issuecomment-728904100), looks like it would be safe to remove these 3 Python dependencies:

- `idna` was introduced because installing via requests was installing an incorrect version but looks like the issue is not happening any more so it should be safe to remove.
- `pyopenssl` and `cryptography` were introduced just for OSX here: memsharded@10d69ff because of #309

The only cases that might fail is for Python<2.7.9 and a very old openssl version in the host platform. In that case this could be solved by doing [python -m pip install pyopenssl cryptography idna](https://urllib3.readthedocs.io/en/latest/reference/contrib/pyopenssl.html) so it looks relatively safe to remove this dependencies.

- [X] Refer to the issue that supports this Pull Request.
- [X] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [X] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [X] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 

<sup>**Note:** By default this PR will skip the slower tests and will use a limited set of python versions. Check [here](https://github.com/conan-io/conan/blob/develop/.github/PR_INCREASE_TESTING.md) how to increase the testing level by writing some tags in the current PR body text.</sup>

#TAGS: svn, slow
#REVISIONS: 1