### PR TITLE
Feature: follow up for intel toolchain

### DIFF
--- a/conans/client/toolchain/msbuild.py
+++ b/conans/client/toolchain/msbuild.py
@@ -29,15 +29,16 @@ class MSBuildCmd(object):
         self.platform = msvc_arch
 
     def command(self, sln):
-        vcvars = vcvars_command(self.version, architecture=self.vcvars_arch,
-                                platform_type=None, winsdk_version=None,
-                                vcvars_ver=None)
+        if self.compiler == "intel":
+            cvars = intel_compilervars_command(self._conanfile)
+        else:
+            cvars = vcvars_command(self.version, architecture=self.vcvars_arch,
+                                    platform_type=None, winsdk_version=None,
+                                    vcvars_ver=None)
         cmd = ('%s && msbuild "%s" /p:Configuration=%s /p:Platform=%s '
-               % (vcvars, sln, self.build_type, self.platform))
+               % (cvars, sln, self.build_type, self.platform))
 
         if self.compiler == 'intel':
-            cvars = intel_compilervars_command(self._conanfile)
-            cmd = '%s && %s' % (cvars, cmd)
             cmd += '/p:PlatformToolset="%s"' % msvs_toolset(self._conanfile)
 
         return cmd

--- a/conans/client/toolchain/msbuild.py
+++ b/conans/client/toolchain/msbuild.py
@@ -38,9 +38,6 @@ class MSBuildCmd(object):
         cmd = ('%s && msbuild "%s" /p:Configuration=%s /p:Platform=%s '
                % (cvars, sln, self.build_type, self.platform))
 
-        if self.compiler == 'intel':
-            cmd += '/p:PlatformToolset="%s"' % msvs_toolset(self._conanfile)
-
         return cmd
 
     def build(self, sln):

--- a/conans/client/toolchain/msbuild.py
+++ b/conans/client/toolchain/msbuild.py
@@ -58,8 +58,6 @@ class MSBuildToolchain(object):
         self._conanfile = conanfile
         self.preprocessor_definitions = {}
 
-    filename = "conan_toolchain.props"
-
     @staticmethod
     def _name_condition(settings):
         props = [("Configuration", settings.build_type),


### PR DESCRIPTION
Changelog: omit
Docs: omit
small follow up for #8062:
- vcvars are redundant if intel compiler vars were set
- don't pass toolset on command line
- remove duplicated `MSBuildToolchain.filename`


- [x] Refer to the issue that supports this Pull Request.
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 

<sup>**Note:** By default this PR will skip the slower tests and will use a limited set of python versions. Check [here](https://github.com/conan-io/conan/blob/develop/.github/PR_INCREASE_TESTING.md) how to increase the testing level by writing some tags in the current PR body text.</sup>
