### PR TITLE
Call conan_find_libraries_abs_path for CONAN_LIBS

### DIFF
--- a/conans/client/generators/cmake_common.py
+++ b/conans/client/generators/cmake_common.py
@@ -642,6 +642,8 @@ class CMakeCommonMacros:
 
             link_directories(${CONAN_LIB_DIRS})
 
+            conan_find_libraries_abs_path("${CONAN_LIBS}" "${CONAN_LIB_DIRS}"
+                                          CONAN_LIBS)
             conan_find_libraries_abs_path("${CONAN_LIBS_DEBUG}" "${CONAN_LIB_DIRS_DEBUG}"
                                           CONAN_LIBS_DEBUG)
             conan_find_libraries_abs_path("${CONAN_LIBS_RELEASE}" "${CONAN_LIB_DIRS_RELEASE}"


### PR DESCRIPTION
Changelog: Fix: Set `CONAN_LIBS` with absolute paths found instead of library names.
Docs: omit

When using the `cmake` generator using the global config (without targets) `CONAN_LIBS` takes the value for the library names and not the absolute path to the libraries, that absolute path is set if using `cmake_multi` generator. The absolute paths are also searched and set to the target if using targets.

Closes: https://github.com/conan-io/conan/issues/3162

- [X] Refer to the issue that supports this Pull Request.
- [X] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [X] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [X] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 

<sup>**Note:** By default this PR will skip the slower tests and will use a limited set of python versions. Check [here](https://github.com/conan-io/conan/blob/develop/.github/PR_INCREASE_TESTING.md) how to increase the testing level by writing some tags in the current PR body text.</sup>

#TAGS: slow
#REVISIONS: 1