### PR TITLE
add --no-remote to list references without remote

### DIFF
--- a/conans/client/command.py
+++ b/conans/client/command.py
@@ -1531,8 +1531,10 @@ class Command(object):
         parser_rename.add_argument('remote', help='The old remote name')
         parser_rename.add_argument('new_remote', help='The new remote name')
 
-        subparsers.add_parser('list_ref',
-                              help='List the package recipes and its associated remotes')
+        parser_list_ref = subparsers.add_parser('list_ref', help='List the package recipes '
+                                                                 'and its associated remotes')
+        parser_list_ref.add_argument("--no-remote", action='store_true', default=False,
+                                     help='List the ones without remote')
         parser_padd = subparsers.add_parser('add_ref',
                                             help="Associate a recipe's reference to a remote")
         parser_padd.add_argument('reference', help='Package recipe reference')
@@ -1548,6 +1550,8 @@ class Command(object):
         list_pref = subparsers.add_parser('list_pref', help='List the package binaries and '
                                                             'its associated remotes')
         list_pref.add_argument('reference', help='Package recipe reference')
+        list_pref.add_argument("--no-remote", action='store_true', default=False,
+                               help='List the ones without remote')
 
         add_pref = subparsers.add_parser('add_pref',
                                          help="Associate a package reference to a remote")
@@ -1594,7 +1598,7 @@ class Command(object):
         elif args.subcommand == "update":
             return self._conan.remote_update(remote_name, url, verify_ssl, args.insert)
         elif args.subcommand == "list_ref":
-            refs = self._conan.remote_list_ref()
+            refs = self._conan.remote_list_ref(args.no_remote)
             self._outputer.remote_ref_list(refs)
         elif args.subcommand == "add_ref":
             return self._conan.remote_add_ref(reference, remote_name)
@@ -1603,7 +1607,7 @@ class Command(object):
         elif args.subcommand == "update_ref":
             return self._conan.remote_update_ref(reference, remote_name)
         elif args.subcommand == "list_pref":
-            refs = self._conan.remote_list_pref(reference)
+            refs = self._conan.remote_list_pref(reference, args.no_remote)
             self._outputer.remote_pref_list(refs)
         elif args.subcommand == "add_pref":
             return self._conan.remote_add_pref(package_reference, remote_name)

--- a/conans/client/conan_api.py
+++ b/conans/client/conan_api.py
@@ -48,7 +48,6 @@ from conans.client.rest.conan_requester import ConanRequester
 from conans.client.rest.rest_client import RestApiClientFactory
 from conans.client.runner import ConanRunner
 from conans.client.source import config_source_local
-from conans.client.store.localdb import LocalDB
 from conans.client.tools.env import environment_append
 from conans.client.userio import UserIO
 from conans.errors import (ConanException, RecipeNotFoundException,
@@ -1007,9 +1006,18 @@ class ConanAPIV1(object):
         return self.app.cache.registry.rename(remote_name, new_new_remote)
 
     @api_method
-    def remote_list_ref(self):
-        return {str(r): remote_name for r, remote_name in self.app.cache.registry.refs_list.items()
-                if remote_name}
+    def remote_list_ref(self, no_remote=False):
+        if no_remote:
+            result = {}
+            for ref in self.app.cache.all_refs():
+                metadata = self.app.cache.package_layout(ref).load_metadata()
+                if not metadata.recipe.remote:
+                    result[str(ref)] = None
+            return result
+        else:
+            return {str(r): remote_name for r, remote_name in
+                    self.app.cache.registry.refs_list.items()
+                    if remote_name}
 
     @api_method
     def remote_add_ref(self, reference, remote_name):
@@ -1032,14 +1040,23 @@ class ConanAPIV1(object):
             metadata.recipe.remote = remote.name
 
     @api_method
-    def remote_list_pref(self, reference):
+    def remote_list_pref(self, reference, no_remote=False):
         ref = ConanFileReference.loads(reference, validate=True)
-        ret = {}
-        tmp = self.app.cache.registry.prefs_list
-        for pref, remote in tmp.items():
-            if pref.ref == ref and remote:
-                ret[repr(pref)] = remote
-        return ret
+        if no_remote:
+            result = {}
+            metadata = self.app.cache.package_layout(ref).load_metadata()
+            for pid, pkg_metadata in metadata.packages.items():
+                if not pkg_metadata.remote:
+                    pref = PackageReference(ref, pid)
+                    result[repr(pref)] = None
+            return result
+        else:
+            ret = {}
+            tmp = self.app.cache.registry.prefs_list
+            for pref, remote in tmp.items():
+                if pref.ref == ref and remote:
+                    ret[repr(pref)] = remote
+            return ret
 
     @api_method
     def remote_add_pref(self, package_reference, remote_name):


### PR DESCRIPTION
Changelog: Feature: Add ``conan remote list_ref --no-remote`` to list recipes without a remote defined.
Changelog: Feature: Add ``conan remote list_pref --no-remote`` to list packages without a remote defined.
Docs: https://github.com/conan-io/docs/pull/1936

Close https://github.com/conan-io/conan/issues/8092