### PR TITLE
remove definition of sysroot from CONAN_CMAKE_FIND_ROOT_PATH

### DIFF
--- a/conans/client/build/cmake_flags.py
+++ b/conans/client/build/cmake_flags.py
@@ -237,13 +237,11 @@ class CMakeDefinitionsBuilder(object):
 
             if self._conanfile and self._conanfile.deps_cpp_info.sysroot:
                 sysroot_path = self._conanfile.deps_cpp_info.sysroot
-            else:
-                sysroot_path = os.getenv("CONAN_CMAKE_FIND_ROOT_PATH", None)
 
-            if sysroot_path:
-                # Needs to be set here, can't be managed in the cmake generator, CMake needs
-                # to know about the sysroot before any other thing
-                definitions["CMAKE_SYSROOT"] = sysroot_path.replace("\\", "/")
+                if sysroot_path:
+                    # Needs to be set here, can't be managed in the cmake generator, CMake needs
+                    # to know about the sysroot before any other thing
+                    definitions["CMAKE_SYSROOT"] = sysroot_path.replace("\\", "/")
 
             # Adjust Android stuff
             if str(os_) == "Android" and definitions["CMAKE_SYSTEM_NAME"] == "Android":

--- a/conans/client/build/cmake_flags.py
+++ b/conans/client/build/cmake_flags.py
@@ -243,6 +243,10 @@ class CMakeDefinitionsBuilder(object):
                     # to know about the sysroot before any other thing
                     definitions["CMAKE_SYSROOT"] = sysroot_path.replace("\\", "/")
 
+            cmake_sysroot = os.getenv("CONAN_CMAKE_SYSROOT")
+            if cmake_sysroot is not None:
+                definitions["CMAKE_SYSROOT"] = cmake_sysroot.replace("\\", "/")
+
             # Adjust Android stuff
             if str(os_) == "Android" and definitions["CMAKE_SYSTEM_NAME"] == "Android":
                 arch_abi_settings = tools.to_android_abi(arch)

--- a/conans/test/unittests/client/build/cmake_test.py
+++ b/conans/test/unittests/client/build/cmake_test.py
@@ -875,7 +875,6 @@ build_type: [ Release]
         settings.compiler = "Visual Studio"
         settings.compiler.version = "12"
         settings.arch = "x86"
-        settings.os = "Windows"
         if platform.system() == "Windows":
             cmake = CMake(conanfile)
             self.assertNotIn("-DCMAKE_SYSROOT=", cmake.flags)
@@ -886,6 +885,22 @@ build_type: [ Release]
             cmake = CMake(conanfile)
             self.assertEqual(cmake.definitions["CMAKE_SYSROOT"], "/path/to/sysroot")
             self.assertEqual(cmake.definitions["CMAKE_SYSTEM_PROCESSOR"], "somevalue")
+
+    def test_sysroot_envvar(self):
+        settings = Settings.loads(get_default_settings_yml())
+        conanfile = ConanFileMock()
+        conanfile.settings = settings
+        settings.os = "Linux"
+        settings.os_build = "Windows"
+        settings.compiler = "gcc"
+        settings.compiler.version = "5"
+        settings.arch_build = "x86_64"
+        settings.arch = "armv7"
+
+        # Now activate cross build and check sysroot and system processor
+        with(tools.environment_append({"CONAN_CMAKE_SYSROOT": "/path/to/var/sysroot"})):
+            cmake = CMake(conanfile)
+            self.assertEqual(cmake.definitions["CMAKE_SYSROOT"], "/path/to/var/sysroot")
 
     def test_deprecated_behaviour(self):
         """"Remove when deprecate the old settings parameter to CMake and


### PR DESCRIPTION
Changelog: Bugfix: remove definition of sysroot from `CONAN_CMAKE_FIND_ROOT_PATH`.
Changelog: Feature: Add new `CONAN_CMAKE_SYSROOT` environment variable to enable the definition of sysroot from environment, without abusing `CONAN_CMAKE_FIND_ROOT_PATH`.
Docs: https://github.com/conan-io/docs/pull/1926

Maybe helps with https://github.com/conan-io/conan/issues/8081, lets see what happens in CI tests.

#tags: slow
