### PR TITLE
Feature: add forgotten msbuild & make to the mapping

### DIFF
--- a/conans/client/toolchain/base.py
+++ b/conans/client/toolchain/base.py
@@ -1,5 +1,7 @@
 from conans.client.toolchain.cmake import CMakeToolchain
+from conans.client.toolchain.make import MakeToolchain
 from conans.client.toolchain.meson import MesonToolchain
+from conans.client.toolchain.msbuild import MSBuildToolchain
 from conans.client.tools import chdir
 from conans.errors import conanfile_exception_formatter, ConanException
 
@@ -15,7 +17,9 @@ def write_toolchain(conanfile, path, output):
         else:
             try:
                 toolchain = {"cmake": CMakeToolchain,
-                             "meson": MesonToolchain}[conanfile.toolchain]
+                             "make": MakeToolchain,
+                             "meson": MesonToolchain,
+                             "msbuild": MSBuildToolchain}[conanfile.toolchain]
             except KeyError:
                 raise ConanException("Unknown toolchain '%s'" % conanfile.toolchain)
             tc = toolchain(conanfile)


### PR DESCRIPTION
Changelog: Feature: add forgotten msbuild & make to the mapping
Docs: omit

- [ ] Refer to the issue that supports this Pull Request.
- [ ] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [ ] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [ ] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 

<sup>**Note:** By default this PR will skip the slower tests and will use a limited set of python versions. Check [here](https://github.com/conan-io/conan/blob/develop/.github/PR_INCREASE_TESTING.md) how to increase the testing level by writing some tags in the current PR body text.</sup>
