### PR TITLE
Feature: update conan new to latest guidelines

### DIFF
--- a/conans/client/cmd/new.py
+++ b/conans/client/cmd/new.py
@@ -186,7 +186,7 @@ class {package_name}TestConan(ConanFile):
             self.run(".%sexample" % os.sep)
 """
 
-test_cmake = """cmake_minimum_required(VERSION 2.8.12)
+test_cmake = """cmake_minimum_required(VERSION 3.1)
 project(PackageTest CXX)
 
 include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
@@ -202,7 +202,7 @@ target_link_libraries(example ${CONAN_LIBS})
 #          COMMAND example)
 """
 
-test_cmake_pure_c = """cmake_minimum_required(VERSION 2.8.12)
+test_cmake_pure_c = """cmake_minimum_required(VERSION 3.1)
 project(PackageTest C)
 
 include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
@@ -261,7 +261,7 @@ void {name}(){{
 }}
 """
 
-cmake_pure_c = """cmake_minimum_required(VERSION 2.8)
+cmake_pure_c = """cmake_minimum_required(VERSION 3.1)
 project({name} C)
 
 include(${{CMAKE_BINARY_DIR}}/conanbuildinfo.cmake)
@@ -270,7 +270,7 @@ conan_basic_setup()
 add_library({name} {name}.c)
 """
 
-cmake = """cmake_minimum_required(VERSION 2.8)
+cmake = """cmake_minimum_required(VERSION 3.1)
 project({name} CXX)
 
 include(${{CMAKE_BINARY_DIR}}/conanbuildinfo.cmake)

--- a/conans/client/cmd/new.py
+++ b/conans/client/cmd/new.py
@@ -22,9 +22,13 @@ class {package_name}Conan(ConanFile):
     description = "<Description of {package_name} here>"
     topics = ("<Put some tag here>", "<here>", "<and here>")
     settings = "os", "compiler", "build_type", "arch"
-    options = {{"shared": [True, False]}}
-    default_options = {{"shared": False}}
+    options = {{"shared": [True, False], "fPIC": [True, False]}}
+    default_options = {{"shared": False, "fPIC": True}}
     generators = "cmake"
+
+    def config_options(self):
+        if self.settings.os == "Windows":
+            del self.options.fPIC
 
     def source(self):
         self.run("git clone https://github.com/conan-io/hello.git")
@@ -91,11 +95,15 @@ class {package_name}Conan(ConanFile):
     description = "<Description of {package_name} here>"
     topics = ("<Put some tag here>", "<here>", "<and here>")
     settings = "os", "compiler", "build_type", "arch"
-    options = {{"shared": [True, False]}}
-    default_options = {{"shared": False}}
+    options = {{"shared": [True, False], "fPIC": [True, False]}}
+    default_options = {{"shared": False, "fPIC": True}}
     generators = "cmake"
     exports_sources = "src/*"
 {configure}
+    def config_options(self):
+        if self.settings.os == "Windows":
+            del self.options.fPIC
+
     def build(self):
         cmake = CMake(self)
         cmake.configure(source_folder="src")
@@ -145,6 +153,9 @@ class {package_name}Conan(ConanFile):
 
     def package(self):
         self.copy("*.h", "include")
+
+    def package_id(self):
+        self.info.header_only()
 """
 
 

--- a/conans/test/functional/generators/make_test.py
+++ b/conans/test/functional/generators/make_test.py
@@ -18,11 +18,6 @@ class MakeGeneratorTest(unittest.TestCase):
     def test_complete_creation_reuse(self):
         client = TestClient(path_with_spaces=False)
         client.run("new myhello/1.0.0 --sources")
-        conanfile_path = os.path.join(client.current_folder, "conanfile.py")
-        replace_in_file(conanfile_path, "{\"shared\": [True, False]}",
-                        "{\"shared\": [True, False], \"fPIC\": [True, False]}", output=client.out)
-        replace_in_file(conanfile_path, "{\"shared\": False}", "{\"shared\": False, \"fPIC\": True}",
-                        output=client.out)
         client.run("create . danimtb/testing")
         hellowrapper_include = """
 #pragma once


### PR DESCRIPTION
update several minor things in `conan new` command:
- add `fPIC` option handling
- ~~add `homepage` attribute~~
- add `header_only` to `package_id`
- update to `cmake_minimum_required(VERSION 3.1)`

this makes it easier to create package skeletons - fewer things need to be edited

Changelog: Feature: Update `conan new` to latest guidelines.
Docs: omit

#tags: slow
