### PR TITLE
[poc][wip] Cache in local Artifactory everything that is downloaded by Conan

### DIFF
--- a/conans/client/conf/__init__.py
+++ b/conans/client/conf/__init__.py
@@ -446,10 +446,10 @@ class ConanClientConfigParser(ConfigParser, object):
             return None
 
     @property
-    def artifactory_cache(self):
+    def sources_backup(self):
         try:
-            artifactory_cache = self.get_item("storage.artifactory_cache")
-            return artifactory_cache
+            sources_backup = self.get_item("storage.sources_backup")
+            return sources_backup
         except ConanException:
             return None
 

--- a/conans/client/conf/__init__.py
+++ b/conans/client/conf/__init__.py
@@ -446,6 +446,14 @@ class ConanClientConfigParser(ConfigParser, object):
             return None
 
     @property
+    def artifactory_cache(self):
+        try:
+            artifactory_cache = self.get_item("storage.artifactory_cache")
+            return artifactory_cache
+        except ConanException:
+            return None
+
+    @property
     def scm_to_conandata(self):
         try:
             scm_to_conandata = get_env("CONAN_SCM_TO_CONANDATA")

--- a/conans/client/rest/artifactory_cache.py
+++ b/conans/client/rest/artifactory_cache.py
@@ -47,6 +47,7 @@ class ArtifactoryCacheDownloader(object):
         if checksum is not None:
             url += checksum
         h = sha256_sum(url.encode())
+        h = "{}/{}/{}".format(h[:2], h[2:4], h[4:])  # This will help Artifactory UI
         return h
 
     def download(self, url, file_path, md5=None, sha1=None, sha256=None, *args, **kwargs):

--- a/conans/client/rest/artifactory_cache.py
+++ b/conans/client/rest/artifactory_cache.py
@@ -1,0 +1,46 @@
+from urllib.parse import urlsplit, urlunsplit
+from conans.util.sha import sha256 as sha256_sum
+
+
+class ArtifactoryCacheDownloader(object):
+
+    def __init__(self, rt_base_url, file_downloader, requester, user_download=False):
+        self._rt_base_url = rt_base_url  # TBD: expected full url with credentials
+        self._file_downloader = file_downloader
+        self._user_download = user_download
+        self._requester = requester
+
+    def _put(self, rt_path, file_path, **props):
+        """ Put the 'local_filepath' to remote and assign given properties """
+        pass
+
+    def _try_get(self, rt_path, file_path):
+        """ Try to get remote file, return None if file is not found """
+        try:
+            url = self._rt_base_url + "/" + rt_path
+            response = self._requester.get(url, stream=True, verify=False)
+
+        except Exception as exc:
+
+
+    def _rt_path(self, url, checksum=None):
+        # TODO: Chain classes, use same implementation as 'file_downloader'
+        urltokens = urlsplit(url)
+        # append empty query and fragment before unsplit
+        if not self._user_download:  # removes ?signature=xxx
+            url = urlunsplit(urltokens[0:3] + ("", ""))
+        if checksum is not None:
+            url += checksum
+        h = sha256_sum(url.encode())
+        return h
+
+    def download(self, url, file_path, md5=None, sha1=None, sha256=None, *args, **kwargs):
+        """ Intercept download call """
+        # TODO: We don't want to intercept every call, like 'conan_sources.tgz' or
+        #  'conan_package.tgz', they are already under our control. Argument from outside or
+        #  something to check names here?
+        checksum = sha256 or sha1 or md5
+        rt_path = self._rt_path(url, checksum)
+        if not self._try_get(rt_path, file_path=file_path):
+            self._file_downloader.download(url=url, file_path=file_path, *args, **kwargs)
+            self._put(rt_path, file_path=file_path, url=url)

--- a/conans/client/rest/download_cache.py
+++ b/conans/client/rest/download_cache.py
@@ -46,8 +46,10 @@ class CachedFileDownloader(object):
             try:
                 if not os.path.exists(cached_path):
                     try:
-                        self._file_downloader.download(url, cached_path, auth, retry, retry_wait,
-                                                       overwrite, headers)
+                        self._file_downloader.download(url, file_path=cached_path, auth=auth,
+                                                       retry=retry, retry_wait=retry_wait,
+                                                       overwrite=overwrite, headers=headers,
+                                                       md5=md5, sha1=sha1, sha256=sha256)
                         self._check_checksum(cached_path, md5, sha1, sha256)
                     except Exception:
                         if os.path.exists(cached_path):

--- a/conans/client/rest/file_downloader.py
+++ b/conans/client/rest/file_downloader.py
@@ -54,7 +54,7 @@ class FileDownloader(object):
             range_start = 0
 
         try:
-            response = self._requester.get(url, stream=True, verify=self._verify_ssl, auth=auth,
+            response = self._requester.get(url, stream=True, verify=False, auth=auth,
                                            headers=headers)
         except Exception as exc:
             raise ConanException("Error downloading file %s: '%s'" % (url, exc))

--- a/conans/client/rest/rest_client_v1.py
+++ b/conans/client/rest/rest_client_v1.py
@@ -48,7 +48,8 @@ class RestV1Methods(RestCommonMethods):
         downloader = FileDownloader(self.requester, None, self.verify_ssl, self._config)
         artifactory_cache = self._config.artifactory_cache
         if artifactory_cache:
-            downloader = ArtifactoryCacheDownloader(artifactory_cache, downloader)
+            downloader = ArtifactoryCacheDownloader(artifactory_cache, downloader, self.requester,
+                                                    None, self.verify_ssl, self._config)
         download_cache = self._config.download_cache
         if download_cache:
             assert snapshot_md5 is not None, "if download_cache is set, we need the file checksums"
@@ -195,7 +196,8 @@ class RestV1Methods(RestCommonMethods):
         downloader = FileDownloader(self.requester, self._output, self.verify_ssl, self._config)
         artifactory_cache = self._config.artifactory_cache
         if artifactory_cache:
-            downloader = ArtifactoryCacheDownloader(artifactory_cache, downloader)
+            downloader = ArtifactoryCacheDownloader(artifactory_cache, downloader, self.requester,
+                                                    self._output, self.verify_ssl, self._config)
         download_cache = self._config.download_cache
         if download_cache:
             assert snapshot_md5 is not None, "if download_cache is set, we need the file checksums"

--- a/conans/client/rest/rest_client_v1.py
+++ b/conans/client/rest/rest_client_v1.py
@@ -46,9 +46,9 @@ class RestV1Methods(RestCommonMethods):
         Its a generator, so it yields elements for memory performance
         """
         downloader = FileDownloader(self.requester, None, self.verify_ssl, self._config)
-        artifactory_cache = self._config.artifactory_cache
-        if artifactory_cache:
-            downloader = ArtifactoryCacheDownloader(artifactory_cache, downloader, self.requester,
+        sources_backup = self._config.sources_backup
+        if sources_backup:
+            downloader = ArtifactoryCacheDownloader(sources_backup, downloader, self.requester,
                                                     None, self.verify_ssl, self._config)
         download_cache = self._config.download_cache
         if download_cache:
@@ -194,9 +194,9 @@ class RestV1Methods(RestCommonMethods):
         It writes downloaded files to disk (appending to file, only keeps chunks in memory)
         """
         downloader = FileDownloader(self.requester, self._output, self.verify_ssl, self._config)
-        artifactory_cache = self._config.artifactory_cache
-        if artifactory_cache:
-            downloader = ArtifactoryCacheDownloader(artifactory_cache, downloader, self.requester,
+        sources_backup = self._config.sources_backup
+        if sources_backup:
+            downloader = ArtifactoryCacheDownloader(sources_backup, downloader, self.requester,
                                                     self._output, self.verify_ssl, self._config)
         download_cache = self._config.download_cache
         if download_cache:

--- a/conans/client/rest/rest_client_v1.py
+++ b/conans/client/rest/rest_client_v1.py
@@ -6,6 +6,7 @@ from collections import namedtuple
 from six.moves.urllib.parse import parse_qs, urljoin, urlparse, urlsplit
 
 from conans.client.remote_manager import check_compressed_files
+from conans.client.rest.artifactory_cache import ArtifactoryCacheDownloader
 from conans.client.rest.client_routes import ClientV1Router
 from conans.client.rest.download_cache import CachedFileDownloader
 from conans.client.rest.file_uploader import FileUploader
@@ -45,6 +46,9 @@ class RestV1Methods(RestCommonMethods):
         Its a generator, so it yields elements for memory performance
         """
         downloader = FileDownloader(self.requester, None, self.verify_ssl, self._config)
+        artifactory_cache = self._config.artifactory_cache
+        if artifactory_cache:
+            downloader = ArtifactoryCacheDownloader(artifactory_cache, downloader)
         download_cache = self._config.download_cache
         if download_cache:
             assert snapshot_md5 is not None, "if download_cache is set, we need the file checksums"
@@ -189,6 +193,9 @@ class RestV1Methods(RestCommonMethods):
         It writes downloaded files to disk (appending to file, only keeps chunks in memory)
         """
         downloader = FileDownloader(self.requester, self._output, self.verify_ssl, self._config)
+        artifactory_cache = self._config.artifactory_cache
+        if artifactory_cache:
+            downloader = ArtifactoryCacheDownloader(artifactory_cache, downloader)
         download_cache = self._config.download_cache
         if download_cache:
             assert snapshot_md5 is not None, "if download_cache is set, we need the file checksums"

--- a/conans/client/rest/rest_client_v2.py
+++ b/conans/client/rest/rest_client_v2.py
@@ -4,6 +4,7 @@ import traceback
 
 from conans import DEFAULT_REVISION_V1
 from conans.client.remote_manager import check_compressed_files
+from conans.client.rest.artifactory_cache import ArtifactoryCacheDownloader
 from conans.client.rest.client_routes import ClientV2Router
 from conans.client.rest.download_cache import CachedFileDownloader
 from conans.client.rest.file_uploader import FileUploader
@@ -42,6 +43,9 @@ class RestV2Methods(RestCommonMethods):
     def _get_remote_file_contents(self, url, use_cache, headers=None):
         # We don't want traces in output of these downloads, they are ugly in output
         downloader = FileDownloader(self.requester, None, self.verify_ssl, self._config)
+        artifactory_cache = self._config.artifactory_cache
+        if artifactory_cache:
+            downloader = ArtifactoryCacheDownloader(artifactory_cache, downloader)
         if use_cache and self._config.download_cache:
             downloader = CachedFileDownloader(self._config.download_cache, downloader)
         contents = downloader.download(url, auth=self.auth, headers=headers)
@@ -217,6 +221,9 @@ class RestV2Methods(RestCommonMethods):
 
     def _download_and_save_files(self, urls, dest_folder, files, use_cache):
         downloader = FileDownloader(self.requester, self._output, self.verify_ssl, self._config)
+        artifactory_cache = self._config.artifactory_cache
+        if artifactory_cache:
+            downloader = ArtifactoryCacheDownloader(artifactory_cache, downloader)
         if use_cache and self._config.download_cache:
             downloader = CachedFileDownloader(self._config.download_cache, downloader)
         # Take advantage of filenames ordering, so that conan_package.tgz and conan_export.tgz

--- a/conans/client/rest/rest_client_v2.py
+++ b/conans/client/rest/rest_client_v2.py
@@ -43,9 +43,9 @@ class RestV2Methods(RestCommonMethods):
     def _get_remote_file_contents(self, url, use_cache, headers=None):
         # We don't want traces in output of these downloads, they are ugly in output
         downloader = FileDownloader(self.requester, None, self.verify_ssl, self._config)
-        artifactory_cache = self._config.artifactory_cache
-        if artifactory_cache:
-            downloader = ArtifactoryCacheDownloader(artifactory_cache, downloader, self.requester,
+        sources_backup = self._config.sources_backup
+        if sources_backup:
+            downloader = ArtifactoryCacheDownloader(sources_backup, downloader, self.requester,
                                                     None, self.verify_ssl, self._config)
         if use_cache and self._config.download_cache:
             downloader = CachedFileDownloader(self._config.download_cache, downloader)
@@ -222,9 +222,9 @@ class RestV2Methods(RestCommonMethods):
 
     def _download_and_save_files(self, urls, dest_folder, files, use_cache):
         downloader = FileDownloader(self.requester, self._output, self.verify_ssl, self._config)
-        artifactory_cache = self._config.artifactory_cache
-        if artifactory_cache:
-            downloader = ArtifactoryCacheDownloader(artifactory_cache, downloader, self.requester,
+        sources_backup = self._config.sources_backup
+        if sources_backup:
+            downloader = ArtifactoryCacheDownloader(sources_backup, downloader, self.requester,
                                                     self._output, self.verify_ssl, self._config)
         if use_cache and self._config.download_cache:
             downloader = CachedFileDownloader(self._config.download_cache, downloader)

--- a/conans/client/rest/rest_client_v2.py
+++ b/conans/client/rest/rest_client_v2.py
@@ -45,7 +45,8 @@ class RestV2Methods(RestCommonMethods):
         downloader = FileDownloader(self.requester, None, self.verify_ssl, self._config)
         artifactory_cache = self._config.artifactory_cache
         if artifactory_cache:
-            downloader = ArtifactoryCacheDownloader(artifactory_cache, downloader)
+            downloader = ArtifactoryCacheDownloader(artifactory_cache, downloader, self.requester,
+                                                    None, self.verify_ssl, self._config)
         if use_cache and self._config.download_cache:
             downloader = CachedFileDownloader(self._config.download_cache, downloader)
         contents = downloader.download(url, auth=self.auth, headers=headers)
@@ -223,7 +224,8 @@ class RestV2Methods(RestCommonMethods):
         downloader = FileDownloader(self.requester, self._output, self.verify_ssl, self._config)
         artifactory_cache = self._config.artifactory_cache
         if artifactory_cache:
-            downloader = ArtifactoryCacheDownloader(artifactory_cache, downloader)
+            downloader = ArtifactoryCacheDownloader(artifactory_cache, downloader, self.requester,
+                                                    self._output, self.verify_ssl, self._config)
         if use_cache and self._config.download_cache:
             downloader = CachedFileDownloader(self._config.download_cache, downloader)
         # Take advantage of filenames ordering, so that conan_package.tgz and conan_export.tgz

--- a/conans/client/tools/net.py
+++ b/conans/client/tools/net.py
@@ -93,7 +93,9 @@ def download(url, filename, verify=True, out=None, retry=None, retry_wait=None, 
     downloader = FileDownloader(requester=requester, output=out, verify=verify, config=config)
     artifactory_cache = config.artifactory_cache
     if artifactory_cache:
-        downloader = ArtifactoryCacheDownloader(artifactory_cache, downloader)
+        downloader = ArtifactoryCacheDownloader(artifactory_cache, downloader, requester=requester,
+                                                output=out, verify=verify, config=config,
+                                                user_download=True)
     if config and config.download_cache and checksum:
         downloader = CachedFileDownloader(config.download_cache, downloader, user_download=True)
 

--- a/conans/client/tools/net.py
+++ b/conans/client/tools/net.py
@@ -91,9 +91,9 @@ def download(url, filename, verify=True, out=None, retry=None, retry_wait=None, 
     checksum = sha256 or sha1 or md5
 
     downloader = FileDownloader(requester=requester, output=out, verify=verify, config=config)
-    artifactory_cache = config.artifactory_cache
-    if artifactory_cache:
-        downloader = ArtifactoryCacheDownloader(artifactory_cache, downloader, requester=requester,
+    sources_backup = config.sources_backup
+    if sources_backup:
+        downloader = ArtifactoryCacheDownloader(sources_backup, downloader, requester=requester,
                                                 output=out, verify=verify, config=config,
                                                 user_download=True)
     if config and config.download_cache and checksum:

--- a/conans/test/functional/cache/test_artifactory_cache.py
+++ b/conans/test/functional/cache/test_artifactory_cache.py
@@ -1,4 +1,3 @@
-import textwrap
 import unittest
 
 from conans.test.utils.test_files import temp_folder
@@ -11,7 +10,8 @@ class ArtifactoryCacheTestCase(unittest.TestCase):
         cache_folder = temp_folder()
         client.run('remote add conan-center https://conan.bintray.com')
         client.run('config set storage.download_cache="%s"' % cache_folder)
-        client.run('config set storage.artifactory_cache="http://admin:password@0.0.0.0:8082/artifactory/conan-sources"')
+        client.run(
+            'config set storage.sources_backup="http://admin:password@0.0.0.0:8082/artifactory/conan-sources"')
 
         client.run('install zlib/1.2.8@ -r conan-center --build=zlib')
         print(client.out)

--- a/conans/test/functional/cache/test_artifactory_cache.py
+++ b/conans/test/functional/cache/test_artifactory_cache.py
@@ -1,0 +1,21 @@
+import textwrap
+import unittest
+
+from conans.test.utils.test_files import temp_folder
+from conans.test.utils.tools import TestClient
+
+
+class ArtifactoryCacheTestCase(unittest.TestCase):
+    def test_rt_cache(self):
+        client = TestClient(default_server_user=True)
+        cache_folder = temp_folder()
+        client.run('remote add conan-center https://conan.bintray.com')
+        client.run('config set storage.download_cache="%s"' % cache_folder)
+        client.run('config set storage.artifactory_cache="http://admin:password@0.0.0.0:8082/artifactory/conan-sources"')
+
+        client.run('install zlib/1.2.8@ -r conan-center --build=zlib')
+        print(client.out)
+        self.fail("AAA")
+
+    def test_download_cache(self):
+        pass


### PR DESCRIPTION
Changelog: (Feature | Fix | Bugfix): Describe here your pull request
Docs: https://github.com/conan-io/docs/pull/XXXX

**This is just to start talking about it and realize about different needs**
 + What do we want to cache? Everything like the _DownloadCache_ does or just the things used by the recipe?
    The DownloadCache caches every file, the `conanfile.py`, `conanmanifest.txt`,... Here we probably want to cache **only 3rdparty files**:
    - can we filter them using the URLs in the `remote.json` (maybe only v2)? 
    - activate some flag before running certain methods to enable/disable this cache?
 + Do we want to provide some organization inside the generic repo or everything inside one folder? 
 + Credentials: use JFrog CLI under the hood and forget about credentials?
    - use-case: the user can try-get artifacts, but cannot upload them.

Refactor before? Chain download classes?


