### PR TITLE
possible fix to cmake.install() failing in test_package

### DIFF
--- a/conans/client/cmd/test.py
+++ b/conans/client/cmd/test.py
@@ -37,9 +37,7 @@ def install_build_and_test(app, conanfile_abs_path, reference, graph_info,
                      keep_build=keep_build,
                      recorder=recorder)
         cmd_build(app, conanfile_abs_path, base_folder, test_build_folder,
-                  # FIXME: Probably we need a better (or user-defined) layout definition
-                  #package_folder=os.path.join(test_build_folder, "package"),
-                  package_folder=None,
+                  package_folder=os.path.join(test_build_folder, "package"),
                   install_folder=test_build_folder, test=reference)
     finally:
         if delete_after_build:

--- a/conans/client/cmd/test.py
+++ b/conans/client/cmd/test.py
@@ -37,7 +37,9 @@ def install_build_and_test(app, conanfile_abs_path, reference, graph_info,
                      keep_build=keep_build,
                      recorder=recorder)
         cmd_build(app, conanfile_abs_path, base_folder, test_build_folder,
-                  package_folder=test_build_folder,
+                  # FIXME: Probably we need a better (or user-defined) layout definition
+                  #package_folder=os.path.join(test_build_folder, "package"),
+                  package_folder=None,
                   install_folder=test_build_folder, test=reference)
     finally:
         if delete_after_build:

--- a/conans/client/cmd/test.py
+++ b/conans/client/cmd/test.py
@@ -36,7 +36,8 @@ def install_build_and_test(app, conanfile_abs_path, reference, graph_info,
                      manifest_interactive=manifest_interactive,
                      keep_build=keep_build,
                      recorder=recorder)
-        cmd_build(app, conanfile_abs_path, base_folder, test_build_folder, package_folder=None,
+        cmd_build(app, conanfile_abs_path, base_folder, test_build_folder,
+                  package_folder=test_build_folder,
                   install_folder=test_build_folder, test=reference)
     finally:
         if delete_after_build:

--- a/conans/test/functional/build_helpers/cmake_install_package_test.py
+++ b/conans/test/functional/build_helpers/cmake_install_package_test.py
@@ -105,11 +105,12 @@ cmake_minimum_required(VERSION 2.8.12)
             from conans import ConanFile, CMake, load
             class TestConan(ConanFile):
                 def build(self):
+                    self.package_folder = "package"
                     cmake = CMake(self)
                     cmake.configure()
                     cmake.install()
                 def test(self):
-                    self.output.info("Content: %s" % load("include/header.h"))
+                    self.output.info("Content: %s" % load("package/include/header.h"))
             """)
         cmake = textwrap.dedent("""set(CMAKE_CXX_COMPILER_WORKS 1)
             project(Chat NONE)

--- a/conans/test/functional/build_helpers/cmake_install_package_test.py
+++ b/conans/test/functional/build_helpers/cmake_install_package_test.py
@@ -105,7 +105,6 @@ cmake_minimum_required(VERSION 2.8.12)
             from conans import ConanFile, CMake, load
             class TestConan(ConanFile):
                 def build(self):
-                    self.package_folder = "package"
                     cmake = CMake(self)
                     cmake.configure()
                     cmake.install()

--- a/conans/test/functional/build_helpers/cmake_install_package_test.py
+++ b/conans/test/functional/build_helpers/cmake_install_package_test.py
@@ -1,7 +1,9 @@
+import textwrap
 import unittest
 
 import pytest
 
+from conans.test.assets.genconanfile import GenConanfile
 from conans.test.utils.tools import TestClient
 
 
@@ -94,5 +96,31 @@ cmake_minimum_required(VERSION 2.8.12)
 
         client.run("remove * --force")
         client.run("create . user/channel")
-        self.assertIn("Test/0.1@user/channel (test package): Content: my header h!!",
-                      client.out)
+        self.assertIn("Test/0.1@user/channel (test package): Content: my header h!!", client.out)
+
+    @pytest.mark.tool_cmake
+    def test_cmake_install_test_package(self):
+        client = TestClient()
+        test_conanfile = textwrap.dedent("""
+            from conans import ConanFile, CMake, load
+            class TestConan(ConanFile):
+                def build(self):
+                    cmake = CMake(self)
+                    cmake.configure()
+                    cmake.install()
+                def test(self):
+                    self.output.info("Content: %s" % load("include/header.h"))
+            """)
+        cmake = textwrap.dedent("""set(CMAKE_CXX_COMPILER_WORKS 1)
+            project(Chat NONE)
+            cmake_minimum_required(VERSION 2.8.12)
+            install(FILES header.h DESTINATION include)
+            """)
+        client.save({"conanfile.py": GenConanfile(),
+                     "test/conanfile.py": test_conanfile,
+                     "test/CMakeLists.txt": cmake,
+                     "test/header.h": "my header h!!"})
+
+        client.run("create . pkg/0.1@")
+        self.assertIn("pkg/0.1 (test package): Running test()", client.out)
+        self.assertIn("pkg/0.1 (test package): Content: my header h!!", client.out)


### PR DESCRIPTION
Changelog: Fix: Define ``package_folder`` in the ``test_package`` folder (defaulting to "package"), so the test recipe can execute ``cmake.install()`` in its ``build()`` method.
Docs: Omit

Close https://github.com/conan-io/conan/issues/8080