### PR TITLE
Bugfix: consider /usr/bin/cc and usr/bin/c++ for auto-detection

### DIFF
--- a/conans/client/conf/detect.py
+++ b/conans/client/conf/detect.py
@@ -99,11 +99,9 @@ def _get_compiler_exe(exe):
     return compiler
 
 
-def _choose_compiler_by_platform_priority(vs, cc, gcc, clang, sun_cc):
+def _choose_compiler_by_platform_priority(cc, gcc, clang, sun_cc):
     # historically, the compiler priority used to be different for platforms in conan
-    if detected_os() == "Windows":
-        return vs or cc or gcc or clang
-    elif platform.system() == "Darwin":
+    if platform.system() == "Darwin":
         return clang or cc or gcc
     elif platform.system() == "SunOS":
         return sun_cc or cc or gcc or clang
@@ -134,7 +132,7 @@ def _get_compiler_from_command(output, command):
 
     # the compiler command doesn't contain an obvious name hint like "gcc" or "clang", so brute-force
     gcc, clang, sun_cc = _get_gcc_clang_suncc(output, command)
-    return _choose_compiler_by_platform_priority(None, None, gcc, clang, sun_cc)
+    return _choose_compiler_by_platform_priority(None, gcc, clang, sun_cc)
 
 
 def _get_default_compiler(output):
@@ -164,10 +162,12 @@ def _get_default_compiler(output):
         output.error("Not able to automatically detect '%s' version" % command)
         return None
 
-    vs = sun_cc = None
+    sun_cc = None
     if detected_os() == "Windows":
         version = latest_visual_studio_version_installed(output)
         vs = ('Visual Studio', version) if version else None
+        if vs:
+            return vs
 
     if v2_mode:
         cc = _get_compiler_and_version(output, "cc")
@@ -185,7 +185,7 @@ def _get_default_compiler(output):
         cc = None
         gcc, clang, sun_cc = _get_gcc_clang_suncc(output, command=None)
 
-    return _choose_compiler_by_platform_priority(vs, cc, gcc, clang, sun_cc)
+    return _choose_compiler_by_platform_priority(cc, gcc, clang, sun_cc)
 
 
 def _get_profile_compiler_version(compiler, version, output):

--- a/conans/client/conf/detect.py
+++ b/conans/client/conf/detect.py
@@ -6,7 +6,7 @@ import textwrap
 
 from conans.client.conf.compiler_id import UNKNOWN_COMPILER, LLVM_GCC, detect_compiler_id
 from conans.client.output import Color
-from conans.client.tools import detected_os, OSInfo
+from conans.client.tools import detected_os, OSInfo, which
 from conans.client.tools.win import latest_visual_studio_version_installed
 from conans.model.version import Version
 from conans.util.conan_v2_mode import CONAN_V2_MODE_ENVVAR
@@ -85,6 +85,58 @@ def _sun_cc_compiler(output, compiler_exe="cc"):
         return None
 
 
+def _get_compiler_exe(exe):
+    # get real compiler executable from the alias like /usr/bin/cc (/usr/bin/c++)
+    compiler = which(exe)
+    if not compiler:
+        return None
+    # careful: avoid broken links and don't call readlink on Windows
+    if os.path.islink(compiler) and os.path.exists(compiler) and os.name == 'posix':
+        try:
+            compiler = os.readlink(compiler)
+        except IOError:
+            return None  # can't read link (e.g. due to the permissions)
+    return compiler
+
+
+def _choose_compiler_by_platform_priority(vs, cc, gcc, clang, sun_cc):
+    # historically, the compiler priority used to be different for platforms in conan
+    if detected_os() == "Windows":
+        return vs or cc or gcc or clang
+    elif platform.system() == "Darwin":
+        return clang or cc or gcc
+    elif platform.system() == "SunOS":
+        return sun_cc or cc or gcc or clang
+    else:
+        return cc or gcc or clang
+
+
+def _get_gcc_clang_suncc(output, command):
+    gcc = _gcc_compiler(output, command)
+    clang = _clang_compiler(output, command)
+    sun_cc = None
+    if platform.system() == "SunOS":
+        sun_cc = _sun_cc_compiler(output, command)
+    return gcc, clang, sun_cc
+
+
+def _get_compiler_from_command(output, command):
+    if "gcc" in command.lower() or ("g++" in command.lower() and not "clang" in command.lower()):
+        gcc = _gcc_compiler(output, command)
+        if platform.system() == "Darwin" and gcc is None:
+            output.error("%s detected as a frontend using apple-clang. "
+                         "Compiler not supported" % command)
+        return gcc
+    if "clang" in command.lower():
+        return _clang_compiler(output, command)
+    if platform.system() == "SunOS" and command.lower() == "cc":
+        return _sun_cc_compiler(output, command)
+
+    # the compiler command doesn't contain an obvious name hint like "gcc" or "clang", so brute-force
+    gcc, clang, sun_cc = _get_gcc_clang_suncc(output, command)
+    return _choose_compiler_by_platform_priority(None, None, gcc, clang, sun_cc)
+
+
 def _get_default_compiler(output):
     """
     find the default compiler on the build machine
@@ -104,24 +156,15 @@ def _get_default_compiler(output):
         command = cc or cxx
         if v2_mode:
             compiler = _get_compiler_and_version(output, command)
-            if compiler:
-                return compiler
         else:
-            if "gcc" in command:
-                gcc = _gcc_compiler(output, command)
-                if platform.system() == "Darwin" and gcc is None:
-                    output.error("%s detected as a frontend using apple-clang. "
-                                 "Compiler not supported" % command)
-                return gcc
-            if "clang" in command.lower():
-                return _clang_compiler(output, command)
-            if platform.system() == "SunOS" and command.lower() == "cc":
-                return _sun_cc_compiler(output, command)
+            compiler = _get_compiler_from_command(output, command)
+        if compiler:
+            return compiler
         # I am not able to find its version
         output.error("Not able to automatically detect '%s' version" % command)
         return None
 
-    vs = cc = sun_cc = None
+    vs = sun_cc = None
     if detected_os() == "Windows":
         version = latest_visual_studio_version_installed(output)
         vs = ('Visual Studio', version) if version else None
@@ -131,19 +174,18 @@ def _get_default_compiler(output):
         gcc = _get_compiler_and_version(output, "gcc")
         clang = _get_compiler_and_version(output, "clang")
     else:
-        gcc = _gcc_compiler(output)
-        clang = _clang_compiler(output)
-        if platform.system() == "SunOS":
-            sun_cc = _sun_cc_compiler(output)
+        cc = _get_compiler_exe("cc")
+        cxx = _get_compiler_exe("c++")
+        if cc or cxx:
+            output.info("cc and cxx: %s, %s " % (cc or "None", cxx or "None"))
+            command = cxx or cxx
+            compiler = _get_compiler_from_command(output, command)
+            if compiler:
+                return compiler
+        cc = None
+        gcc, clang, sun_cc = _get_gcc_clang_suncc(output, command=None)
 
-    if detected_os() == "Windows":
-        return vs or cc or gcc or clang
-    elif platform.system() == "Darwin":
-        return clang or cc or gcc
-    elif platform.system() == "SunOS":
-        return sun_cc or cc or gcc or clang
-    else:
-        return cc or gcc or clang
+    return _choose_compiler_by_platform_priority(vs, cc, gcc, clang, sun_cc)
 
 
 def _get_profile_compiler_version(compiler, version, output):


### PR DESCRIPTION
#TAGS: svn, slow
#REVISIONS: 1

closes: #4322
NOTE: this is the same changes as #7586 (changes were reverted in #7638).
**plus** it ensures Visual Studio always has priority over `/usr/bin/cc` or `/usr/bin/c++`.

Changelog: Bugfix: consider /usr/bin/cc and usr/bin/c++ for auto-detection
Docs: omit

- [x] Refer to the issue that supports this Pull Request.
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 

<sup>**Note:** By default this PR will skip the slower tests and will use a limited set of python versions. Check [here](https://github.com/conan-io/conan/blob/develop/.github/PR_INCREASE_TESTING.md) how to increase the testing level by writing some tags in the current PR body text.</sup>
