### PR TITLE
Prefer <pkgname>-config.cmake files in cmake_find_package_multi generator

### DIFF
--- a/conans/client/generators/cmake_find_package_multi.py
+++ b/conans/client/generators/cmake_find_package_multi.py
@@ -278,9 +278,9 @@ set_property(TARGET {{name}}::{{name}}
             pkg_public_deps_filenames = [self._get_filename(self.deps_build_info[it[0]]) for it in
                                          public_deps]
             config_version = self.config_version_template.format(version=pkg_version)
-            ret["{}ConfigVersion.cmake".format(pkg_filename)] = config_version
+            ret[self._config_version_filename(pkg_filename)] = config_version
             if not cpp_info.components:
-                ret["{}Config.cmake".format(pkg_filename)] = self._config(
+                ret[self._config_filename(pkg_filename)] = self._config(
                     filename=pkg_filename,
                     name=pkg_findname,
                     version=cpp_info.version,
@@ -331,8 +331,20 @@ set_property(TARGET {{name}}::{{name}}
                     conan_message=CMakeFindPackageCommonMacros.conan_message,
                     configs=self._configurations
                 )
-                ret["{}Config.cmake".format(pkg_filename)] = target_config
+                ret[self._config_filename(pkg_filename)] = target_config
         return ret
+
+    def _config_filename(self, pkg_filename):
+        if pkg_filename == pkg_filename.lower():
+            return "{}-config.cmake".format(pkg_filename)
+        else:
+            return "{}Config.cmake".format(pkg_filename)
+
+    def _config_version_filename(self, pkg_filename):
+        if pkg_filename == pkg_filename.lower():
+            return "{}-config-version.cmake".format(pkg_filename)
+        else:
+            return "{}ConfigVersion.cmake".format(pkg_filename)
 
     def _config(self, filename, name, version, public_deps_names):
         # Builds the XXXConfig.cmake file for one package

--- a/conans/test/functional/generators/components/propagate_specific_components_test.py
+++ b/conans/test/functional/generators/components/propagate_specific_components_test.py
@@ -56,7 +56,7 @@ class PropagateSpecificComponents(unittest.TestCase):
     def test_cmake_find_package_multi(self):
         t = TestClient(cache_folder=self.cache_folder)
         t.run('install middle/version@ -g cmake_find_package_multi')
-        content = t.load('middleConfig.cmake')
+        content = t.load('middle-config.cmake')
         self.assertIn("find_dependency(top REQUIRED NO_MODULE)", content)
         self.assertIn("find_package(top REQUIRED NO_MODULE)", content)
 

--- a/conans/test/unittests/client/generators/cmake_find_package_multi_test.py
+++ b/conans/test/unittests/client/generators/cmake_find_package_multi_test.py
@@ -24,5 +24,5 @@ class CMakeFindPackageMultiTest(unittest.TestCase):
 
         generator = CMakeFindPackageMultiGenerator(conanfile)
         content = generator.content
-        config_version = content["my_pkgConfigVersion.cmake"]
+        config_version = content["my_pkg-config-version.cmake"]
         self.assertIn('set(PACKAGE_VERSION "0.1")', config_version)


### PR DESCRIPTION
Changelog: Feature: Generate `<pkgname>-config.cmake` files for lowercase packages to improve case compatibility.
Docs: https://github.com/conan-io/docs/pull/1945

According to https://cmake.org/cmake/help/latest/command/find_package.html, `<pkgname>-config.cmake` are more compatible regarding casing. This is just an improvement for consumers of a package.


- [x] Refer to the issue that supports this Pull Request: closes #8048
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [x] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 

<sup>**Note:** By default this PR will skip the slower tests and will use a limited set of python versions. Check [here](https://github.com/conan-io/conan/blob/develop/.github/PR_INCREASE_TESTING.md) how to increase the testing level by writing some tags in the current PR body text.</sup>
