### PR TITLE
[test] Remove '__init__.py' from the root of the repository

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -91,7 +91,7 @@ setup(
 
     # You can just specify the packages manually here if your project is
     # simple. Or you can use find_packages().
-    packages=find_packages(exclude=exclude_test_packages),
+    packages=['conans', 'conan'],  # find_packages(exclude=exclude_test_packages),
 
     # Alternatively, if you want to distribute just a my_module.py, uncomment
     # this:

--- a/setup.py
+++ b/setup.py
@@ -91,7 +91,7 @@ setup(
 
     # You can just specify the packages manually here if your project is
     # simple. Or you can use find_packages().
-    packages=['conans', 'conan'],  # find_packages(exclude=exclude_test_packages),
+    packages=find_packages(exclude=exclude_test_packages),
 
     # Alternatively, if you want to distribute just a my_module.py, uncomment
     # this:


### PR DESCRIPTION
Changelog: Fix: Remove ``__init__.py`` in the root of the repo, which was useless, without a purpose, but caused issues with other projects importing Conan Python code.
Docs: Omit


The file `~/__init__.py` is causing _all_ the problems with the new `conan` module, from the Python perspective there is a `conan` module  (root of the repo when it is cloned into `conan` folder) and a `conan.conan` one (the good one). This also happens when the project is installed as editable because the egg-name is `conan` too.

I've been exploring different alternatives to bypass the problem we have right now: https://github.com/jgsogo/conan-center-index-graph/pulls, as you can see in those PR it works when Conan is just install `pip install <conan>` but it fails when editable (`pip install -e <conan>`) unless:
 1. we change the name of the egg
 1. we remove the `__init__.py` (TBH, I don't know which is the purpose it serves)

I'm opening this PR to see if something fails (not expected), but it will probably requires further testing in our own computers. 

- [x] Conan usage with `python -m conans.conan ...` still works.

- [x] This file is not packaged for Pypi, so it cannot break anything in that direction

- [ ] what about pyinstaller?