### PR TITLE
enabling set_name, set_version for lockfile root_node finding

### DIFF
--- a/conans/client/graph/graph_manager.py
+++ b/conans/client/graph/graph_manager.py
@@ -162,7 +162,9 @@ class GraphManager(object):
                 if ref.name is None:
                     # If the graph_info information is not there, better get what we can from
                     # the conanfile
-                    conanfile = self._loader.load_basic(path)
+                    # Using load_named() to run set_name() set_version() and get them
+                    # so it can be found by name in the lockfile
+                    conanfile = self._loader.load_named(path, None, None, None, None)
                     ref = ConanFileReference(ref.name or conanfile.name,
                                              ref.version or conanfile.version,
                                              ref.user, ref.channel, validate=False)

--- a/conans/test/functional/graph_lock/graph_lock_test.py
+++ b/conans/test/functional/graph_lock/graph_lock_test.py
@@ -528,4 +528,4 @@ class AddressRootNodetest(unittest.TestCase):
         client.save({"conanfile.py": conanfile})
         client.run("lock create conanfile.py --lockfile-out=conan.lock")
         client.run("install . --lockfile=conan.lock")
-        self.assertIn("conanfile.py (pkg/0.1): Installing package, client.out")
+        self.assertIn("conanfile.py (pkg/0.1): Installing package", client.out)

--- a/conans/test/functional/graph_lock/graph_lock_test.py
+++ b/conans/test/functional/graph_lock/graph_lock_test.py
@@ -509,3 +509,23 @@ class BuildLockedTest(unittest.TestCase):
         self.assertEqual(flac["ref"], ref)
         self.assertEqual(flac["package_id"], "5ab84d6acfe1f23c4fae0ab88f26e3a396351ac9")
         self.assertEqual(flac["prev"], prev)
+
+
+class AddressRootNodetest(unittest.TestCase):
+    def test_find_root_node(self):
+        client = TestClient()
+        conanfile = textwrap.dedent("""
+            from conans import ConanFile
+            from conans.errors import ConanInvalidConfiguration
+
+            class Pkg(ConanFile):
+                def set_name(self):
+                    self.name = "pkg"
+
+                def set_version(self):
+                    self.version = "0.1"
+            """)
+        client.save({"conanfile.py": conanfile})
+        client.run("lock create conanfile.py --lockfile-out=conan.lock")
+        client.run("install . --lockfile=conan.lock")
+        self.assertIn("conanfile.py (pkg/0.1): Installing package, client.out")


### PR DESCRIPTION
Changelog: Bugfix: Enabling set_name, set_version for lockfile roo not location.
Docs: Omit

cc/ @jasal82 