### PR TITLE
Fix excludes in FileCopier failures for case-insensitive in non-Windows

### DIFF
--- a/conans/client/file_copier.py
+++ b/conans/client/file_copier.py
@@ -143,8 +143,9 @@ class FileCopier(object):
                     pass
 
             relative_path = os.path.relpath(root, src)
+            compare_relative_path = relative_path.lower() if ignore_case else relative_path
             for exclude in excludes:
-                if fnmatch.fnmatch(relative_path, exclude):
+                if fnmatch.fnmatch(compare_relative_path, exclude):
                     subfolders[:] = []
                     files = []
                     break

--- a/conans/test/unittests/client/file_copier/file_copier_test.py
+++ b/conans/test/unittests/client/file_copier/file_copier_test.py
@@ -178,19 +178,24 @@ class FileCopierTest(unittest.TestCase):
     def test_excludes_camelcase_folder(self):
         # https://github.com/conan-io/conan/issues/8153
         folder1 = temp_folder()
-        sub1 = os.path.join(folder1, "subdir1")
-        save(os.path.join(sub1, "file1.txt"), "Hello1")
-        save(os.path.join(sub1, "file2.c"), "Hello2")
+        save(os.path.join(folder1, "UPPER.txt"), "")
+        save(os.path.join(folder1, "lower.txt"), "")
         sub2 = os.path.join(folder1, "CamelCaseIgnore")
-        save(os.path.join(sub2, "file3.txt"), "Hello3")
-        save(os.path.join(sub2, "file4.c"), "Hello4")
+        save(os.path.join(sub2, "file3.txt"), "")
 
         folder2 = temp_folder()
         copier = FileCopier([folder1], folder2)
-        copier("*", excludes=["somedll.dll", "CamelCaseIgnore"])
+        copier("*", excludes=["CamelCaseIgnore", "UPPER.txt"])
         self.assertFalse(os.path.exists(os.path.join(folder2, "CamelCaseIgnore")))
-        copier("*", excludes=["somedll.dll"])
+        self.assertFalse(os.path.exists(os.path.join(folder2, "UPPER.txt")))
+        self.assertTrue(os.path.exists(os.path.join(folder2, "lower.txt")))
+
+        folder2 = temp_folder()
+        copier = FileCopier([folder1], folder2)
+        copier("*")
         self.assertTrue(os.path.exists(os.path.join(folder2, "CamelCaseIgnore")))
+        self.assertTrue(os.path.exists(os.path.join(folder2, "UPPER.txt")))
+        self.assertTrue(os.path.exists(os.path.join(folder2, "lower.txt")))
 
     def test_multifolder(self):
         src_folder1 = temp_folder()

--- a/conans/test/unittests/client/file_copier/file_copier_test.py
+++ b/conans/test/unittests/client/file_copier/file_copier_test.py
@@ -175,6 +175,23 @@ class FileCopierTest(unittest.TestCase):
         copier("*.txt", excludes=("*Test*.txt", "*Impl*"))
         self.assertEqual(['MyLib.txt'], os.listdir(folder2))
 
+    def test_excludes_camelcase_folder(self):
+        # https://github.com/conan-io/conan/issues/8153
+        folder1 = temp_folder()
+        sub1 = os.path.join(folder1, "subdir1")
+        save(os.path.join(sub1, "file1.txt"), "Hello1")
+        save(os.path.join(sub1, "file2.c"), "Hello2")
+        sub2 = os.path.join(folder1, "CamelCaseIgnore")
+        save(os.path.join(sub2, "file3.txt"), "Hello3")
+        save(os.path.join(sub2, "file4.c"), "Hello4")
+
+        folder2 = temp_folder()
+        copier = FileCopier([folder1], folder2)
+        copier("*", excludes=["somedll.dll", "CamelCaseIgnore"])
+        self.assertFalse(os.path.exists(os.path.join(folder2, "CamelCaseIgnore")))
+        copier("*", excludes=["somedll.dll"])
+        self.assertTrue(os.path.exists(os.path.join(folder2, "CamelCaseIgnore")))
+
     def test_multifolder(self):
         src_folder1 = temp_folder()
         src_folder2 = temp_folder()


### PR DESCRIPTION
Changelog: Bugfix: Fix ``excludes`` pattern case-insensitive in non Windows platforms.
Docs: Omit

Close https://github.com/conan-io/conan/issues/8153