### PR TITLE
Fixes #8166 by modifying reference to deprecated function FlagsForFile to Settings

### DIFF
--- a/conans/client/generators/ycm.py
+++ b/conans/client/generators/ycm.py
@@ -140,7 +140,7 @@ def GetCompilationInfoForFile( filename ):
   return database.GetCompilationInfoForFile( filename )
 
 
-def FlagsForFile( filename, **kwargs ):
+def Settings( filename, **kwargs ):
   relative_to = None
   compiler_flags = None
 


### PR DESCRIPTION
Changelog: Bugfix: Removed a reference to deprecated `FlagsForFile` function in place of current `Settings` function.
Docs: Omit.

Fixes: #8166

- [x] Refer to the issue that supports this Pull Request: Fixes #8166 
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [x] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one: Not applicable

<sup>**Note:** By default this PR will skip the slower tests and will use a limited set of python versions. Check [here](https://github.com/conan-io/conan/blob/develop/.github/PR_INCREASE_TESTING.md) how to increase the testing level by writing some tags in the current PR body text.</sup>
