### PR TITLE
fix conan new -t includes

### DIFF
--- a/conans/client/cmd/new.py
+++ b/conans/client/cmd/new.py
@@ -409,10 +409,11 @@ def cmd_new(ref, header=False, pure_c=False, test=False, exports_sources=False, 
                                                                    user=user, channel=channel,
                                                                    package_name=package_name)
         if pure_c:
-            files["test_package/example.c"] = test_main.format(name=name, version=version)
+            files["test_package/example.c"] = test_main.format(name=name)
             files["test_package/CMakeLists.txt"] = test_cmake_pure_c
         else:
-            files["test_package/example.cpp"] = test_main.format(name=name, version=version)
+            include_name = name if exports_sources else "hello"
+            files["test_package/example.cpp"] = test_main.format(name=include_name)
             files["test_package/CMakeLists.txt"] = test_cmake
 
     if gitignore:

--- a/conans/test/functional/command/new_test.py
+++ b/conans/test/functional/command/new_test.py
@@ -347,3 +347,11 @@ class NewCommandTest(unittest.TestCase):
         self.assertFalse(os.path.exists(os.path.join(root, ".travis/install.sh")))
         self.assertFalse(os.path.exists(os.path.join(root, ".travis/run.sh")))
         self.assertFalse(os.path.exists(os.path.join(root, "appveyor.yml")))
+
+    def test_new_test_package_custom_name(self):
+        # https://github.com/conan-io/conan/issues/8164
+        client = TestClient()
+        client.run("new mypackage/0.1 -t")
+        source = client.load("test_package/example.cpp")
+        self.assertIn('#include "hello.h"', source)
+        self.assertIn("hello();", source)


### PR DESCRIPTION
Changelog: Bugfix: ``conan new <pkg-name>/version -t`` wrong include when not using ``-s`` (using the hardcoded git repo).
Docs: Omit

Fix https://github.com/conan-io/conan/issues/8164