### PR TITLE
adding RootFolder to MSBuildDeps generator

### DIFF
--- a/conan/tools/microsoft/msbuilddeps.py
+++ b/conan/tools/microsoft/msbuilddeps.py
@@ -13,6 +13,7 @@ class MSBuildDeps(object):
         <?xml version="1.0" encoding="utf-8"?>
         <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
           <PropertyGroup Label="ConanVariables">
+            <Conan{name}RootFolder>{root_folder}</Conan{name}RootFolder>
             <Conan{name}CompilerFlags>{compiler_flags}</Conan{name}CompilerFlags>
             <Conan{name}LinkerFlags>{linker_flags}</Conan{name}LinkerFlags>
             <Conan{name}PreprocessorDefinitions>{definitions}</Conan{name}PreprocessorDefinitions>
@@ -151,6 +152,7 @@ class MSBuildDeps(object):
 
         fields = {
             'name': name,
+            'root_folder': cpp_info.rootpath,
             'bin_dirs': "".join("%s;" % p for p in cpp_info.bin_paths),
             'res_dirs': "".join("%s;" % p for p in cpp_info.res_paths),
             'include_dirs': "".join("%s;" % p for p in cpp_info.include_paths),

--- a/conans/test/functional/generators/msbuild_test.py
+++ b/conans/test/functional/generators/msbuild_test.py
@@ -1,3 +1,4 @@
+import os
 import platform
 import textwrap
 import unittest
@@ -453,6 +454,11 @@ class MSBuildGeneratorTest(unittest.TestCase):
         client.run("create . mypkg/0.1@")
         client.run("install mypkg/0.1@ -g MSBuildDeps")
         self.assertIn("Generator 'MSBuildDeps' calling 'generate()'", client.out)
+        # https://github.com/conan-io/conan/issues/8163
+        props = client.load("conan_mypkg_release_x64.props")  # default Release/x64
+        folder = props[props.find("<ConanmypkgRootFolder>")+len("<ConanmypkgRootFolder>")
+                       :props.find("</ConanmypkgRootFolder>")]
+        self.assertTrue(os.path.isfile(os.path.join(folder, "conaninfo.txt")))
 
     def test_install_reference_gcc(self):
         client = TestClient()


### PR DESCRIPTION
Changelog: Feature: Implement ``ConanXXXRootFolder`` in ``MSBuildDeps`` generator.
Docs: Omit

Close https://github.com/conan-io/conan/issues/8163
