### PR TITLE
Add Conan version command

### DIFF
--- a/conans/client/command.py
+++ b/conans/client/command.py
@@ -1961,7 +1961,6 @@ class Command(object):
         else:
             self._out.success("Conan version %s" % client_version)
 
-
     def _show_help(self):
         """
         Prints a summary of all commands.

--- a/conans/client/command.py
+++ b/conans/client/command.py
@@ -1941,6 +1941,27 @@ class Command(object):
                                     lockfile=args.lockfile,
                                     lockfile_out=args.lockfile_out)
 
+    def version(self, *args):
+        """ Show Conan version
+        """
+        parser = argparse.ArgumentParser(description=self.version.__doc__,
+                                         prog="conan version",
+                                         formatter_class=SmartFormatter)
+        parser.add_argument("-j", "--json", default=None, action=OnceArgument,
+                            help='Path to a json file where the version information will be '
+                                 'written')
+
+        args = parser.parse_args(*args)
+        if args.json:
+            json_content = json.dumps({"version": client_version})
+            json_path = args.json
+            if not os.path.isabs(args.json):
+                json_path = os.path.join(get_cwd(), args.json)
+            save(json_path, json_content)
+        else:
+            self._out.success("Conan version %s" % client_version)
+
+
     def _show_help(self):
         """
         Prints a summary of all commands.

--- a/conans/test/functional/command/version_test.py
+++ b/conans/test/functional/command/version_test.py
@@ -1,0 +1,25 @@
+import json
+import unittest
+import os
+
+
+from conans import __version__
+from conans.test.utils.tools import TestClient
+from conans.util.files import load
+
+
+class VersionTest(unittest.TestCase):
+
+    def test_version_command(self):
+        client = TestClient()
+        client.run("version")
+        self.assertIn("Conan version %s" % __version__, client.out)
+
+    def test_version_json(self):
+        json_file = "version.json"
+        client = TestClient()
+        client.run("version --json={}".format(json_file))
+        self.assertTrue(os.path.isfile(os.path.join(client.current_folder, json_file)))
+        json_content = load(os.path.join(client.current_folder, json_file))
+        json_data = json.loads(json_content)
+        self.assertEqual(json_data["version"], __version__)

--- a/conans/test/functional/command/version_test.py
+++ b/conans/test/functional/command/version_test.py
@@ -15,6 +15,11 @@ class VersionTest(unittest.TestCase):
         client.run("version")
         self.assertIn("Conan version %s" % __version__, client.out)
 
+    def test_version_original_command(self):
+        client = TestClient()
+        client.run("--version")
+        self.assertIn("Conan version %s" % __version__, client.out)
+
     def test_version_json(self):
         json_file = "version.json"
         client = TestClient()


### PR DESCRIPTION
We could parse `--version --json`, but the problem that I see is giving a help about the json argument. If we don't use version as a command, --json would be a hidden feature on CLI.

Changelog: Feature: Output conan version as json file
Docs: TODO

closes https://github.com/conan-io/conan/issues/8162

- [ ] Refer to the issue that supports this Pull Request.
- [ ] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [ ] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [ ] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 

<sup>**Note:** By default this PR will skip the slower tests and will use a limited set of python versions. Check [here](https://github.com/conan-io/conan/blob/develop/.github/PR_INCREASE_TESTING.md) how to increase the testing level by writing some tags in the current PR body text.</sup>
