### PR TITLE
Hotfix/short paths info paths

### DIFF
--- a/conans/client/conan_command_output.py
+++ b/conans/client/conan_command_output.py
@@ -8,15 +8,12 @@ from conans.client.graph.grapher import Grapher
 from conans.client.installer import build_id
 from conans.client.printer import Printer
 from conans.model.ref import ConanFileReference, PackageReference
-from conans.paths import CONANINFO
 from conans.search.binary_html_table import html_binary_graph
 from conans.unicode import get_cwd
 from conans.util.dates import iso8601_to_str
-from conans.util.env_reader import get_env
 from conans.util.files import save
 from conans import __version__ as client_version
 from conans.util.misc import make_tuple
-from conans.util.windows import CONAN_REAL_PATH
 
 
 class CommandOutputer(object):
@@ -152,12 +149,7 @@ class CommandOutputer(object):
                 item_data["build_folder"] = package_layout.build(pref)
 
                 pref = PackageReference(ref, package_id)
-                package_folder = package_layout.package(pref)
-                # If the package folder exist, but doesn't contain package, it was short-folder new
-                if (os.path.isdir(package_folder)
-                        and not os.path.exists(os.path.join(package_folder, CONANINFO))):
-                    package_layout.package_remove(pref)
-                item_data["package_folder"] = package_folder
+                item_data["package_folder"] = package_layout.package(pref)
 
             try:
                 package_metadata = self._cache.package_layout(ref).load_metadata()

--- a/conans/client/conan_command_output.py
+++ b/conans/client/conan_command_output.py
@@ -8,6 +8,7 @@ from conans.client.graph.grapher import Grapher
 from conans.client.installer import build_id
 from conans.client.printer import Printer
 from conans.model.ref import ConanFileReference, PackageReference
+from conans.paths import CONANINFO
 from conans.search.binary_html_table import html_binary_graph
 from conans.unicode import get_cwd
 from conans.util.dates import iso8601_to_str
@@ -15,6 +16,7 @@ from conans.util.env_reader import get_env
 from conans.util.files import save
 from conans import __version__ as client_version
 from conans.util.misc import make_tuple
+from conans.util.windows import CONAN_REAL_PATH
 
 
 class CommandOutputer(object):
@@ -150,7 +152,12 @@ class CommandOutputer(object):
                 item_data["build_folder"] = package_layout.build(pref)
 
                 pref = PackageReference(ref, package_id)
-                item_data["package_folder"] = package_layout.package(pref)
+                package_folder = package_layout.package(pref)
+                # If the package folder exist, but doesn't contain package, it was short-folder new
+                if (os.path.isdir(package_folder)
+                        and not os.path.exists(os.path.join(package_folder, CONANINFO))):
+                    package_layout.package_remove(pref)
+                item_data["package_folder"] = package_folder
 
             try:
                 package_metadata = self._cache.package_layout(ref).load_metadata()

--- a/conans/client/installer.py
+++ b/conans/client/installer.py
@@ -510,10 +510,8 @@ class BinaryInstaller(object):
                     self._recorder.package_fetched_from_cache(pref)
 
             package_folder = layout.package(pref)
-            if not os.path.isdir(package_folder):
-                raise ConanException("Package '%s' corrupted. Package folder must exist: %s\n"
-                                     "Try removing the package with 'conan remove'"
-                                     % (str(pref), package_folder))
+            assert os.path.isdir(package_folder), ("Package '%s' folder must exist: %s\n"
+                                                   % (str(pref), package_folder))
             # Call the info method
             self._call_package_info(conanfile, package_folder, ref=pref.ref)
             self._recorder.package_cpp_info(pref, conanfile.cpp_info)

--- a/conans/paths/package_layouts/package_cache_layout.py
+++ b/conans/paths/package_layouts/package_cache_layout.py
@@ -129,8 +129,8 @@ class PackageCacheLayout(object):
         return is_dirty(pkg_folder)
 
     def package_id_exists(self, package_id):
-        # This is NOT the short paths, but the standard cache one
-        pkg_folder = os.path.join(self._base_folder, PACKAGES_FOLDER, package_id)
+        # The package exists if the folder exists, also for short_paths case
+        pkg_folder = self.package(PackageReference(self._ref, package_id))
         return os.path.isdir(pkg_folder)
 
     def package_remove(self, pref):

--- a/conans/test/functional/cache/short_paths_test.py
+++ b/conans/test/functional/cache/short_paths_test.py
@@ -113,31 +113,6 @@ class TestConan(ConanFile):
         self.assertIn("conaninfo.txt", client.out)
         self.assertIn("conanmanifest.txt", client.out)
 
-    def test_package_folder_removed(self):
-        conanfile = textwrap.dedent("""
-            from conans import ConanFile
-
-            class TestConan(ConanFile):
-                short_paths = True
-            """)
-        client = TestClient()
-        client.save({"conanfile.py": conanfile})
-        client.run("create . test/1.0@")
-        self.assertIn("test/1.0: Package '%s' created" % NO_SETTINGS_PACKAGE_ID, client.out)
-        ref = ConanFileReference.loads("test/1.0")
-        pref = PackageReference(ref, NO_SETTINGS_PACKAGE_ID)
-        pkg_folder = client.cache.package_layout(ref).package(pref)
-
-        shutil.rmtree(pkg_folder)
-
-        client.run("install test/1.0@", assert_error=True)
-        self.assertIn("ERROR: Package 'test/1.0:5ab84d6acfe1f23c4fae0ab88f26e3a396351ac9' corrupted."
-                      " Package folder must exist:", client.out)
-        client.run("remove test/1.0@ -p -f")
-        client.run("install test/1.0@", assert_error=True)
-        self.assertIn("ERROR: Missing binary: test/1.0:5ab84d6acfe1f23c4fae0ab88f26e3a396351ac9",
-                      client.out)
-
     @parameterized.expand([(True,), (False,)])
     def test_leaking_folders(self, use_always_short_paths):
         # https://github.com/conan-io/conan/issues/7983

--- a/conans/test/functional/cache/short_paths_test.py
+++ b/conans/test/functional/cache/short_paths_test.py
@@ -162,3 +162,12 @@ class TestConan(ConanFile):
             self.assertEqual(5, len(os.listdir(short_folder)))
             client.run("install dep/1.0@ --build")
             self.assertEqual(5, len(os.listdir(short_folder)))
+
+    def test_info_paths(self):
+        # https://github.com/conan-io/conan/issues/8172
+        client = TestClient()
+        client.save({"conanfile.py": GenConanfile().with_short_paths(True)})
+        client.run("export . test/1.0@")
+        client.run("info test/1.0@ --paths")
+        print(client.out)
+        client.run("info test/1.0@ --paths")

--- a/conans/test/functional/cache/short_paths_test.py
+++ b/conans/test/functional/cache/short_paths_test.py
@@ -169,5 +169,4 @@ class TestConan(ConanFile):
         client.save({"conanfile.py": GenConanfile().with_short_paths(True)})
         client.run("export . test/1.0@")
         client.run("info test/1.0@ --paths")
-        print(client.out)
         client.run("info test/1.0@ --paths")


### PR DESCRIPTION
Changelog: Bugfix: Fix errors when using ``conan info --paths`` and ``short_paths=True`` in Windows, due to creation of empty folders in the short-paths storage.
Docs: Omit

Fix https://github.com/conan-io/conan/issues/8172