### PR TITLE
avoid conflict of custom generators with new generators

### DIFF
--- a/conans/client/generators/__init__.py
+++ b/conans/client/generators/__init__.py
@@ -80,8 +80,13 @@ class GeneratorManager(object):
     def __getitem__(self, key):
         return self._generators[key]
 
-    def _new_generator(self, generator_name):
+    def _new_generator(self, generator_name, output):
         if generator_name not in self._new_generators:
+            return
+        if generator_name in self._generators:  # Avoid colisions with user custom generators
+            msg = ("******* Your custom generator name '{}' is colliding with a new experimental "
+                   "built-in one. It is recommended to rename it. *******".format(generator_name))
+            output.warn(msg)
             return
         if generator_name == "CMakeToolchain":
             from conan.tools.cmake import CMakeToolchain
@@ -106,7 +111,7 @@ class GeneratorManager(object):
         """ produces auxiliary files, required to build a project or a package.
         """
         for generator_name in set(conanfile.generators):
-            generator_class = self._new_generator(generator_name)
+            generator_class = self._new_generator(generator_name, output)
             if generator_class:
                 if generator_name == "msbuild":
                     msg = (

--- a/conans/test/functional/toolchain/test_basic.py
+++ b/conans/test/functional/toolchain/test_basic.py
@@ -1,4 +1,5 @@
 # coding=utf-8
+import os
 import platform
 import textwrap
 import unittest
@@ -8,6 +9,7 @@ import six
 from nose.plugins.attrib import attr
 
 from conans.test.utils.tools import TestClient
+from conans.util.files import save
 
 
 @attr("toolchain")
@@ -229,3 +231,32 @@ class BasicTest(unittest.TestCase):
         conan_toolchain_props = client.load("conantoolchain.props")
         self.assertIn("<ConanPackageName>Pkg</ConanPackageName>", conan_toolchain_props)
         self.assertIn("<ConanPackageVersion>0.1</ConanPackageVersion>", conan_toolchain_props)
+
+    def test_conflict_user_generator(self):
+        client = TestClient()
+        generator = textwrap.dedent("""
+            from conans import ConanFile
+            from conans.model import Generator
+            class CMakeToolchain(Generator):
+                @property
+                def filename(self):
+                    return "mygenerator.gen"
+                @property
+                def content(self):
+                    return "HelloWorld"
+                """)
+
+        save(os.path.join(client.cache.generators_path, "mygenerator.py"), generator)
+        conanfile = textwrap.dedent("""
+            from conans import ConanFile
+
+            class Pkg(ConanFile):
+                settings = "os", "compiler", "arch", "build_type"
+                generators = "CMakeToolchain"
+            """)
+
+        client.save({"conanfile.py": conanfile})
+        client.run("install .")
+        self.assertIn("Your custom generator name 'CMakeToolchain' is colliding", client.out)
+        gen = client.load("mygenerator.gen")
+        self.assertEqual("HelloWorld", gen)


### PR DESCRIPTION
Changelog: Bugfix: Avoid conflict of user custom generators names with new generators.
Docs: Omit

Fix https://github.com/conan-io/conan/issues/8182