### PR TITLE
add build_requires to conandeps.props file in MSBuildDeps

### DIFF
--- a/conan/tools/microsoft/msbuilddeps.py
+++ b/conan/tools/microsoft/msbuilddeps.py
@@ -221,7 +221,10 @@ class MSBuildDeps(object):
         conf_name = self._config_filename()
         condition = self._condition()
         # Include all direct build_requires for both build & host context. This might change
-        build_requires_names = [name for name, _ in self._conanfile.build_requires.keys()]
+        if hasattr(self._conanfile, "build_requires"):
+            build_requires_names = [name for name, _ in self._conanfile.build_requires.keys()]
+        else:
+            build_requires_names = []
         public_deps = list(self._conanfile.requires.keys()) + build_requires_names
         result[general_name] = self._deps_props(general_name, public_deps)
         for dep_name, cpp_info in self._conanfile.deps_cpp_info.dependencies:

--- a/conan/tools/microsoft/msbuilddeps.py
+++ b/conan/tools/microsoft/msbuilddeps.py
@@ -220,8 +220,8 @@ class MSBuildDeps(object):
         general_name = "conandeps.props"
         conf_name = self._config_filename()
         condition = self._condition()
-        # Include all direct build_requires for both build & host context. This might change
-        direct_deps = self._conanfile.deps_cpp_info.direct_deps
+        # Include all direct build_requires for host context. This might change
+        direct_deps = self._conanfile.deps_cpp_info.direct_host_deps
         result[general_name] = self._deps_props(general_name, direct_deps)
         for dep_name, cpp_info in self._conanfile.deps_cpp_info.dependencies:
             # One file per configuration, with just the variables

--- a/conan/tools/microsoft/msbuilddeps.py
+++ b/conan/tools/microsoft/msbuilddeps.py
@@ -221,12 +221,8 @@ class MSBuildDeps(object):
         conf_name = self._config_filename()
         condition = self._condition()
         # Include all direct build_requires for both build & host context. This might change
-        if hasattr(self._conanfile, "build_requires"):
-            build_requires_names = [name for name, _ in self._conanfile.build_requires.keys()]
-        else:
-            build_requires_names = []
-        public_deps = list(self._conanfile.requires.keys()) + build_requires_names
-        result[general_name] = self._deps_props(general_name, public_deps)
+        direct_deps = self._conanfile.deps_cpp_info.direct_deps
+        result[general_name] = self._deps_props(general_name, direct_deps)
         for dep_name, cpp_info in self._conanfile.deps_cpp_info.dependencies:
             # One file per configuration, with just the variables
             vars_props_name = "conan_%s%s.props" % (dep_name, conf_name)

--- a/conan/tools/microsoft/msbuilddeps.py
+++ b/conan/tools/microsoft/msbuilddeps.py
@@ -217,10 +217,12 @@ class MSBuildDeps(object):
         if not self._conanfile.settings.get_safe("build_type"):
             raise ConanException("The 'msbuild' generator requires a 'build_type' setting value")
         result = {}
-        general_name = "conan_deps.props"
+        general_name = "conandeps.props"
         conf_name = self._config_filename()
         condition = self._condition()
-        public_deps = self._conanfile.requires.keys()
+        # Include all direct build_requires for both build & host context. This might change
+        build_requires_names = [name for name, _ in self._conanfile.build_requires.keys()]
+        public_deps = list(self._conanfile.requires.keys()) + build_requires_names
         result[general_name] = self._deps_props(general_name, public_deps)
         for dep_name, cpp_info in self._conanfile.deps_cpp_info.dependencies:
             # One file per configuration, with just the variables

--- a/conans/client/installer.py
+++ b/conans/client/installer.py
@@ -588,7 +588,8 @@ class BinaryInstaller(object):
                     env_info.PATH.extend(dep_cpp_info.bin_paths)
                     conan_file.deps_env_info.update(env_info, n.ref.name)
 
-        conan_file.deps_cpp_info.direct_deps = [n.name for n in node.neighbors()]
+        conan_file.deps_cpp_info.direct_host_deps = [n.name for n in node.neighbors()
+                                                     if n.context == CONTEXT_HOST]
         # Update the info but filtering the package values that not apply to the subtree
         # of this current node and its dependencies.
         subtree_libnames = [node.ref.name for node in node_order]

--- a/conans/client/installer.py
+++ b/conans/client/installer.py
@@ -588,6 +588,7 @@ class BinaryInstaller(object):
                     env_info.PATH.extend(dep_cpp_info.bin_paths)
                     conan_file.deps_env_info.update(env_info, n.ref.name)
 
+        conan_file.deps_cpp_info.direct_deps = [n.name for n in node.neighbors()]
         # Update the info but filtering the package values that not apply to the subtree
         # of this current node and its dependencies.
         subtree_libnames = [node.ref.name for node in node_order]

--- a/conans/test/functional/generators/msbuild_test.py
+++ b/conans/test/functional/generators/msbuild_test.py
@@ -609,4 +609,3 @@ class MSBuildGeneratorTest(unittest.TestCase):
         self.assertIn("conan_tool.props", deps)
         client.run("create . pkg/0.1@")
         self.assertIn("Conan_tools.props in deps", client.out)
-


### PR DESCRIPTION
Changelog: Fix: Include ``build_requires`` in the global ``conandeps.props`` file generated by MSBuildDeps.
Changelog: Fix: Change `MSBuildDeps` file ``conan_deps.props`` to ``conandeps.props`` to avoid collision with a package named "deps".
Docs: Omit

Close https://github.com/conan-io/conan/issues/8170