### PR TITLE
duplicate and isolate cmake utilities

### DIFF
--- a/conan/tools/cmake/__init__.py
+++ b/conan/tools/cmake/__init__.py
@@ -1,4 +1,4 @@
 # noinspection PyUnresolvedReferences
 
-from .toolchain import CMakeToolchain
-from .cmake import CMake
+from conan.tools.cmake.toolchain import CMakeToolchain
+from conan.tools.cmake.cmake import CMake

--- a/conan/tools/cmake/android.py
+++ b/conan/tools/cmake/android.py
@@ -3,7 +3,7 @@ import textwrap
 
 from conans.client.tools.files import which
 from conans.errors import ConanException
-from .base import CMakeToolchainBase
+from conan.tools.cmake.base import CMakeToolchainBase
 
 
 class CMakeAndroidToolchain(CMakeToolchainBase):

--- a/conan/tools/cmake/cmake.py
+++ b/conan/tools/cmake/cmake.py
@@ -1,10 +1,10 @@
 import os
 import platform
 
+from conan.tools.cmake.utils import get_generator, is_multi_configuration
+from conan.tools.cmake.base import CMakeToolchainBase
 from conans.client import tools
 from conans.client.build import join_arguments
-from conans.client.build.cmake_flags import is_multi_configuration, get_generator
-from conan.tools.cmake.base import CMakeToolchainBase
 from conans.client.tools.files import chdir
 from conans.client.tools.oss import cpu_count, args_to_string
 from conans.errors import ConanException

--- a/conan/tools/cmake/generic.py
+++ b/conan/tools/cmake/generic.py
@@ -1,16 +1,52 @@
+import os
 import textwrap
 
-from conans.client.build.cmake_flags import get_generator, get_generator_platform, get_toolset, \
-    is_multi_configuration
-from conans.client.build.compiler_flags import architecture_flag
 from conans.client.tools import cpu_count
 from conans.errors import ConanException
-from .base import CMakeToolchainBase
+from conan.tools.cmake.base import CMakeToolchainBase
+from conan.tools.cmake.utils import get_generator, is_multi_configuration, architecture_flag
 
 
 # https://stackoverflow.com/questions/30503631/cmake-in-which-order-are-files-parsed-cache-toolchain-etc
 # https://cmake.org/cmake/help/v3.6/manual/cmake-toolchains.7.html
 # https://github.com/microsoft/vcpkg/tree/master/scripts/buildsystems
+
+
+def get_toolset(settings, generator):
+    compiler = settings.get_safe("compiler")
+    compiler_base = settings.get_safe("compiler.base")
+    if compiler == "Visual Studio":
+        subs_toolset = settings.get_safe("compiler.toolset")
+        if subs_toolset:
+            return subs_toolset
+    elif compiler == "intel" and compiler_base == "Visual Studio" and "Visual" in generator:
+        compiler_version = settings.get_safe("compiler.version")
+        if compiler_version:
+            compiler_version = compiler_version if "." in compiler_version else \
+                "%s.0" % compiler_version
+            return "Intel C++ Compiler " + compiler_version
+    return None
+
+
+def get_generator_platform(settings, generator):
+    # Returns the generator platform to be used by CMake
+    if "CONAN_CMAKE_GENERATOR_PLATFORM" in os.environ:
+        return os.environ["CONAN_CMAKE_GENERATOR_PLATFORM"]
+
+    compiler = settings.get_safe("compiler")
+    compiler_base = settings.get_safe("compiler.base")
+    arch = settings.get_safe("arch")
+
+    if settings.get_safe("os") == "WindowsCE":
+        return settings.get_safe("os.platform")
+
+    if (compiler == "Visual Studio" or compiler_base == "Visual Studio") and \
+            generator and "Visual" in generator:
+        return {"x86": "Win32",
+                "x86_64": "x64",
+                "armv7": "ARM",
+                "armv8": "ARM64"}.get(arch)
+    return None
 
 
 class CMakeGenericToolchain(CMakeToolchainBase):

--- a/conan/tools/cmake/ios.py
+++ b/conan/tools/cmake/ios.py
@@ -1,6 +1,6 @@
 import textwrap
 
-from .base import CMakeToolchainBase
+from conan.tools.cmake.base import CMakeToolchainBase
 
 
 class CMakeiOSToolchain(CMakeToolchainBase):

--- a/conan/tools/cmake/toolchain.py
+++ b/conan/tools/cmake/toolchain.py
@@ -1,6 +1,6 @@
-from .android import CMakeAndroidToolchain
-from .ios import CMakeiOSToolchain
-from .generic import CMakeGenericToolchain
+from conan.tools.cmake.android import CMakeAndroidToolchain
+from conan.tools.cmake.ios import CMakeiOSToolchain
+from conan.tools.cmake.generic import CMakeGenericToolchain
 
 
 def CMakeToolchain(conanfile, **kwargs):

--- a/conan/tools/cmake/utils.py
+++ b/conan/tools/cmake/utils.py
@@ -1,0 +1,82 @@
+import os
+
+from conans.util.log import logger
+
+
+def is_multi_configuration(generator):
+    if not generator:
+        return False
+    return "Visual" in generator or "Xcode" in generator
+
+
+def architecture_flag(settings):
+    """
+    returns flags specific to the target architecture and compiler
+    """
+    compiler = settings.get_safe("compiler")
+    compiler_base = settings.get_safe("compiler.base")
+    arch = settings.get_safe("arch")
+    the_os = settings.get_safe("os")
+    if not compiler or not arch:
+        return ""
+
+    if str(compiler) in ['gcc', 'apple-clang', 'clang', 'sun-cc']:
+        if str(arch) in ['x86_64', 'sparcv9', 's390x']:
+            return '-m64'
+        elif str(arch) in ['x86', 'sparc']:
+            return '-m32'
+        elif str(arch) in ['s390']:
+            return '-m31'
+        elif str(the_os) == 'AIX':
+            if str(arch) in ['ppc32']:
+                return '-maix32'
+            elif str(arch) in ['ppc64']:
+                return '-maix64'
+    elif str(compiler) == "intel":
+        # https://software.intel.com/en-us/cpp-compiler-developer-guide-and-reference-m32-m64-qm32-qm64
+        if str(arch) == "x86":
+            return "/Qm32" if str(compiler_base) == "Visual Studio" else "-m32"
+        elif str(arch) == "x86_64":
+            return "/Qm64" if str(compiler_base) == "Visual Studio" else "-m64"
+    return ""
+
+
+def get_generator(conanfile):
+    # Returns the name of the generator to be used by CMake
+    if "CONAN_CMAKE_GENERATOR" in os.environ:
+        return os.environ["CONAN_CMAKE_GENERATOR"]
+
+    compiler = conanfile.settings.get_safe("compiler")
+    compiler_base = conanfile.settings.get_safe("compiler.base")
+    arch = conanfile.settings.get_safe("arch")
+    compiler_version = conanfile.settings.get_safe("compiler.version")
+    compiler_base_version = conanfile.settings.get_safe("compiler.base.version")
+    if hasattr(conanfile, 'settings_build'):
+        os_build = conanfile.settings_build.get_safe('os')
+    else:
+        os_build = conanfile.settings.get_safe('os_build')
+
+    if not compiler or not compiler_version or not arch:
+        if os_build == "Windows":
+            logger.warning("CMake generator could not be deduced from settings")
+            return None
+        return "Unix Makefiles"
+
+    if compiler == "Visual Studio" or compiler_base == "Visual Studio":
+        version = compiler_base_version or compiler_version
+        _visuals = {'8': '8 2005',
+                    '9': '9 2008',
+                    '10': '10 2010',
+                    '11': '11 2012',
+                    '12': '12 2013',
+                    '14': '14 2015',
+                    '15': '15 2017',
+                    '16': '16 2019'}.get(version, "UnknownVersion %s" % version)
+        base = "Visual Studio %s" % _visuals
+        return base
+
+    # The generator depends on the build machine, not the target
+    if os_build == "Windows" and compiler != "qcc":
+        return "MinGW Makefiles"  # it is valid only under Windows
+
+    return "Unix Makefiles"

--- a/conan/tools/cmake/utils.py
+++ b/conan/tools/cmake/utils.py
@@ -55,6 +55,8 @@ def get_generator(conanfile):
         os_build = conanfile.settings_build.get_safe('os')
     else:
         os_build = conanfile.settings.get_safe('os_build')
+    if os_build is None:  # Assume is the same specified in host settings, not cross-building
+        os_build = conanfile.settings.get_safe("os")
 
     if not compiler or not compiler_version or not arch:
         if os_build == "Windows":


### PR DESCRIPTION
Changelog: Omit
Docs: Omit

Put a copy of some cmake helpers into ``conan.tools.cmake`` because changes will be needed to adapt to:

- build-profiles
- new settings.compiler=msvc
- using config instead of env-vars

Too risky to do it in the code used by old helpers.

Close https://github.com/conan-io/conan/issues/7485

#tags: slow
