### PR TITLE
Pick the first free port to launch servers on tests

### DIFF
--- a/conans/test/functional/remote/rest_api_test.py
+++ b/conans/test/functional/remote/rest_api_test.py
@@ -27,6 +27,7 @@ from conans.test.utils.server_launcher import TestServerLauncher
 from conans.test.utils.test_files import temp_folder
 from conans.util.env_reader import get_env
 from conans.util.files import md5, save
+from conans.test.utils.tools import get_free_port
 
 
 class RestApiUnitTest(unittest.TestCase):
@@ -70,7 +71,7 @@ class RestApiTest(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         if not cls.server:
-            with environment_append({"CONAN_SERVER_PORT": str(9300+randrange(100))}):
+            with environment_append({"CONAN_SERVER_PORT": str(get_free_port())}):
                 cls.server = TestServerLauncher(server_capabilities=['ImCool', 'TooCool'])
                 cls.server.start()
 

--- a/conans/test/utils/tools.py
+++ b/conans/test/utils/tools.py
@@ -3,6 +3,7 @@ import os
 import random
 import shlex
 import shutil
+import socket
 import sys
 import textwrap
 import threading
@@ -876,6 +877,14 @@ class TurboTestClient(TestClient):
         return rev
 
 
+def get_free_port():
+    sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    sock.bind(('localhost', 0))
+    ret = sock.getsockname()[1]
+    sock.close()
+    return ret
+
+
 class StoppableThreadBottle(threading.Thread):
     """
     Real server to test download endpoints
@@ -883,8 +892,8 @@ class StoppableThreadBottle(threading.Thread):
 
     def __init__(self, host=None, port=None):
         self.host = host or "127.0.0.1"
-        self.port = port or random.randrange(48000, 49151)
         self.server = bottle.Bottle()
+        self.port = port or get_free_port()
         super(StoppableThreadBottle, self).__init__(target=self.server.run,
                                                     kwargs={"host": self.host, "port": self.port})
         self.daemon = True


### PR DESCRIPTION
Changelog: omit
Docs: omit

This is a little improvement over https://github.com/conan-io/conan/pull/8198
When tests launch servers sometimes the ports collide. It also could interfere with other project's tests in the same ci. This will reduce the probability of this to happen picking the first available port but will not completely solve the problem. It could happen that between the port is picked and it is passed to the server other process took this port but it should rarely happen.

#TAGS: slow

- [X] Refer to the issue that supports this Pull Request.
- [X] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [X] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [X] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 

<sup>**Note:** By default this PR will skip the slower tests and will use a limited set of python versions. Check [here](https://github.com/conan-io/conan/blob/develop/.github/PR_INCREASE_TESTING.md) how to increase the testing level by writing some tags in the current PR body text.</sup>
