### PR TITLE
fix when conandata.yml is empty and scm_to_conandata

### DIFF
--- a/conans/client/cmd/export.py
+++ b/conans/client/cmd/export.py
@@ -287,6 +287,7 @@ def _replace_scm_data_in_recipe(package_layout, scm_data, scm_to_conandata):
         conandata_yml = {}
         if os.path.exists(conandata_path):
             conandata_yml = yaml.safe_load(load(conandata_path))
+            conandata_yml = conandata_yml or {}  # In case the conandata is a blank file
             if '.conan' in conandata_yml:
                 raise ConanException("Field '.conan' inside '{}' file is reserved to "
                                      "Conan usage.".format(DATA_YML))


### PR DESCRIPTION
Changelog: Bugfix: Fix when _conandata.yml_ is empty and `scm_to_conandata` is enabled
Docs: Omit

Fix https://github.com/conan-io/conan/issues/8209
