### PR TITLE
Test agains Clang for ClangCL toolset

### DIFF
--- a/conans/client/generators/cmake_common.py
+++ b/conans/client/generators/cmake_common.py
@@ -583,7 +583,8 @@ class CMakeCommonMacros:
             # If using VS, verify toolset
             if (CONAN_COMPILER STREQUAL "Visual Studio")
                 if (CONAN_SETTINGS_COMPILER_TOOLSET MATCHES "LLVM" OR
-                    CONAN_SETTINGS_COMPILER_TOOLSET MATCHES "clang")
+                    CONAN_SETTINGS_COMPILER_TOOLSET MATCHES "clang" OR
+                    CONAN_SETTINGS_COMPILER_TOOLSET MATCHES "ClangCL")
                     set(EXPECTED_CMAKE_CXX_COMPILER_ID "Clang")
                 elseif (CONAN_SETTINGS_COMPILER_TOOLSET MATCHES "Intel")
                     set(EXPECTED_CMAKE_CXX_COMPILER_ID "Intel")

--- a/conans/client/generators/cmake_common.py
+++ b/conans/client/generators/cmake_common.py
@@ -583,8 +583,9 @@ class CMakeCommonMacros:
             # If using VS, verify toolset
             if (CONAN_COMPILER STREQUAL "Visual Studio")
                 if (CONAN_SETTINGS_COMPILER_TOOLSET MATCHES "LLVM" OR
+                    CONAN_SETTINGS_COMPILER_TOOLSET MATCHES "llvm" OR
                     CONAN_SETTINGS_COMPILER_TOOLSET MATCHES "clang" OR
-                    CONAN_SETTINGS_COMPILER_TOOLSET MATCHES "ClangCL")
+                    CONAN_SETTINGS_COMPILER_TOOLSET MATCHES "Clang")
                     set(EXPECTED_CMAKE_CXX_COMPILER_ID "Clang")
                 elseif (CONAN_SETTINGS_COMPILER_TOOLSET MATCHES "Intel")
                     set(EXPECTED_CMAKE_CXX_COMPILER_ID "Intel")


### PR DESCRIPTION
Changelog: Fix: Let CMake generator generate code for checking against "ClangCL" msvc toolset.
Docs: Omit

Without that fix the generated `conanbuildinfo.cmake` would check for compiler and just fail because cmake detected clang but the code would compare with "MSVC".

Fixes #5896
May also fix the #1839 for Visual Studio 2019

- [x] Refer to the issue that supports this Pull Request.
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 

<sup>**Note:** By default this PR will skip the slower tests and will use a limited set of python versions. Check [here](https://github.com/conan-io/conan/blob/develop/.github/PR_INCREASE_TESTING.md) how to increase the testing level by writing some tags in the current PR body text.</sup>
