### PR TITLE
Add pytest.ini file with norecursedirs and testpaths

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+norecursedirs = '.*', 'dist', 'CVS', '_darcs', '{arch}', '*.egg', 'venv', 'assets'
+testpaths = 'conans/test'


### PR DESCRIPTION
Changelog: omit
Docs: omit

Add the default ignore folders for pytest but the build one and adding assets.
Also addding location of testpaths in conans/test.