### PR TITLE
Fixes #5535 venv powershell infinite prompt

### DIFF
--- a/conans/client/envvars/environment.py
+++ b/conans/client/envvars/environment.py
@@ -70,7 +70,7 @@ bat_deactivate = textwrap.dedent("""\
 
 ps1_activate = textwrap.dedent("""\
     {%- for it in modified_vars %}
-    $env:CONAN_OLD_{{it}}=$env:{{it}}
+    $env:CONAN_OLD_{{venv_name}}_{{it}}=$env:{{it}}
     {%- endfor %}
 
     foreach ($line in Get-Content "{{ environment_file }}") {
@@ -79,20 +79,20 @@ ps1_activate = textwrap.dedent("""\
         Set-Item env:\\$var -Value "$value_expanded"
     }
 
-    function global:_old_conan_prompt {""}
-    $function:_old_conan_prompt = $function:prompt
+    function global:_old_conan_{{venv_name}}_prompt {""}
+    $function:_old_conan_{{venv_name}}_prompt = $function:prompt
     function global:prompt {
-        write-host "({{venv_name}}) " -nonewline; & $function:_old_conan_prompt
+        write-host "({{venv_name}}) " -nonewline; & $function:_old_conan_{{venv_name}}_prompt
     }
 """)
 
 ps1_deactivate = textwrap.dedent("""\
-    $function:prompt = $function:_old_conan_prompt
-    remove-item function:_old_conan_prompt
+    $function:prompt = $function:_old_conan_{{venv_name}}_prompt
+    remove-item function:_old_conan_{{venv_name}}_prompt
 
     {% for it in modified_vars %}
-    $env:{{it}}=$env:CONAN_OLD_{{it}}
-    Remove-Item env:CONAN_OLD_{{it}}
+    $env:{{it}}=$env:CONAN_OLD_{{venv_name}}_{{it}}
+    Remove-Item env:CONAN_OLD_{{venv_name}}_{{it}}
     {%- endfor %}
     {%- for it in new_vars %}
     Remove-Item env:{{it}}

--- a/conans/client/envvars/environment.py
+++ b/conans/client/envvars/environment.py
@@ -174,7 +174,8 @@ def _files(env_vars, vars_with_spaces, flavor, activate_tpl, deactivate_tpl, ven
     activate_content = activate_tpl.render(environment_file=env_filepath,
                                            modified_vars=modified_vars, new_vars=new_vars,
                                            venv_name=venv_name)
-    deactivate_content = deactivate_tpl.render(modified_vars=modified_vars, new_vars=new_vars)
+    deactivate_content = deactivate_tpl.render(modified_vars=modified_vars, new_vars=new_vars, 
+                                               venv_name=venv_name)
 
     environment_lines = ["{}={}".format(name, value) for name, value, _ in ret]
     # This blank line is important, otherwise the script doens't process last line


### PR DESCRIPTION
Changelog: Bugfix: Make prompt names unique when using multiple virtualenv scripts in Powershell.
Docs: Omit

Fixes #5535

- [x] Refer to the issue that supports this Pull Request.
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 

<sup>**Note:** By default this PR will skip the slower tests and will use a limited set of python versions. Check [here](https://github.com/conan-io/conan/blob/develop/.github/PR_INCREASE_TESTING.md) how to increase the testing level by writing some tags in the current PR body text.</sup>
