### PR TITLE
temporary allow cmake_paths for CMakeToolchain

### DIFF
--- a/conan/tools/cmake/cmake.py
+++ b/conan/tools/cmake/cmake.py
@@ -14,7 +14,7 @@ from conans.util.files import mkdir
 
 
 def _validate_recipe(conanfile):
-    forbidden_generators = ["cmake", "cmake_multi", "cmake_paths"]
+    forbidden_generators = ["cmake", "cmake_multi"]
     if any(it in conanfile.generators for it in forbidden_generators):
         raise ConanException("Usage of toolchain is only supported with 'cmake_find_package'"
                              " or 'cmake_find_package_multi' generators")


### PR DESCRIPTION
Changelog: Fix: Temporarily allow ``cmake_paths`` generator for ``CMakeToolchain``, to allow start using the toolchain for users that depend on that generator.
Docs: Omit