### PR TITLE
[fix] use only the major version in CMake get_generator

### DIFF
--- a/conan/tools/cmake/utils.py
+++ b/conan/tools/cmake/utils.py
@@ -67,6 +67,7 @@ def get_generator(conanfile):
 
     if compiler == "Visual Studio" or compiler_base == "Visual Studio":
         version = compiler_base_version or compiler_version
+        major_version = version.split('.', 1)[0]
         _visuals = {'8': '8 2005',
                     '9': '9 2008',
                     '10': '10 2010',
@@ -74,7 +75,7 @@ def get_generator(conanfile):
                     '12': '12 2013',
                     '14': '14 2015',
                     '15': '15 2017',
-                    '16': '16 2019'}.get(version, "UnknownVersion %s" % version)
+                    '16': '16 2019'}.get(major_version, "UnknownVersion %s" % version)
         base = "Visual Studio %s" % _visuals
         return base
 

--- a/conans/client/build/cmake_flags.py
+++ b/conans/client/build/cmake_flags.py
@@ -55,6 +55,7 @@ def get_generator(conanfile):
 
     if compiler == "Visual Studio" or compiler_base == "Visual Studio":
         version = compiler_base_version or compiler_version
+        major_version = version.split('.', 1)[0]
         _visuals = {'8': '8 2005',
                     '9': '9 2008',
                     '10': '10 2010',
@@ -62,7 +63,7 @@ def get_generator(conanfile):
                     '12': '12 2013',
                     '14': '14 2015',
                     '15': '15 2017',
-                    '16': '16 2019'}.get(version, "UnknownVersion %s" % version)
+                    '16': '16 2019'}.get(major_version, "UnknownVersion %s" % version)
         base = "Visual Studio %s" % _visuals
         return base
 

--- a/conans/test/unittests/client/build/test_cmake_flags.py
+++ b/conans/test/unittests/client/build/test_cmake_flags.py
@@ -1,0 +1,16 @@
+from conans.client.build.cmake_flags import get_generator
+from conans.test.utils.mocks import ConanFileMock, MockSettings
+
+
+class TestGetGenerator(object):
+
+    def test_vs_generator(self):
+        settings = MockSettings({"os": "Windows", "arch": "x86_64", "compiler": "Visual Studio"})
+        conanfile = ConanFileMock()
+        conanfile.settings = settings
+
+        settings.values['compiler.version'] = '15'
+        assert get_generator(conanfile) == 'Visual Studio 15 2017'
+
+        settings.values['compiler.version'] = '15.9'
+        assert get_generator(conanfile) == 'Visual Studio 15 2017'

--- a/conans/test/unittests/tools/cmake/test_utils.py
+++ b/conans/test/unittests/tools/cmake/test_utils.py
@@ -1,0 +1,16 @@
+from conan.tools.cmake.utils import get_generator
+from conans.test.utils.mocks import ConanFileMock, MockSettings
+
+
+class TestGetGenerator(object):
+
+    def test_vs_generator(self):
+        settings = MockSettings({"os": "Windows", "arch": "x86_64", "compiler": "Visual Studio"})
+        conanfile = ConanFileMock()
+        conanfile.settings = settings
+
+        settings.values['compiler.version'] = '15'
+        assert get_generator(conanfile) == 'Visual Studio 15 2017'
+
+        settings.values['compiler.version'] = '15.9'
+        assert get_generator(conanfile) == 'Visual Studio 15 2017'


### PR DESCRIPTION
Changelog: Fix: CMake's generator name for Visual Studio compiler uses only the major version.
Docs: omit


Issue found in stackoverflow (comments): https://stackoverflow.com/questions/64694269/getting-uwebsockets-for-visual-2017-via-conan