### PR TITLE
BugFix: fix detected_architecture() for Apple M1

### DIFF
--- a/conans/client/tools/oss.py
+++ b/conans/client/tools/oss.py
@@ -95,6 +95,8 @@ def detected_architecture():
         return "sparc"
     elif "aarch64" in machine:
         return "armv8"
+    elif "arm64" in machine:
+        return "armv8"
     elif "64" in machine:
         return "x86_64"
     elif "86" in machine:

--- a/conans/test/unittests/util/detected_architecture_test.py
+++ b/conans/test/unittests/util/detected_architecture_test.py
@@ -10,6 +10,7 @@ from parameterized import parameterized
 
 from conans.client.tools.oss import detected_architecture
 
+
 class DetectedArchitectureTest(unittest.TestCase):
 
     @parameterized.expand([
@@ -29,13 +30,13 @@ class DetectedArchitectureTest(unittest.TestCase):
         ['sparc', 'sparc'],
         ['sparc64', 'sparcv9'],
         ['s390', 's390'],
-        ['s390x', 's390x']
+        ['s390x', 's390x'],
+        ['arm64', "armv8"]
     ])
     def test_various(self, mocked_machine, expected_arch):
 
         with mock.patch("platform.machine", mock.MagicMock(return_value=mocked_machine)):
             self.assertEqual(expected_arch, detected_architecture(), "given '%s' expected '%s'" % (mocked_machine, expected_arch))
-
 
     def test_aix(self):
         with mock.patch("platform.machine", mock.MagicMock(return_value='00FB91F44C00')),\
@@ -51,7 +52,6 @@ class DetectedArchitectureTest(unittest.TestCase):
                 mock.patch("conans.client.tools.oss.OSInfo.get_aix_conf", mock.MagicMock(return_value='64')),\
                 mock.patch('subprocess.check_output', mock.MagicMock(return_value='7.1.0.0')):
             self.assertEqual('ppc64', detected_architecture())
-
 
     def test_solaris(self):
         with mock.patch("platform.machine", mock.MagicMock(return_value='sun4v')),\


### PR DESCRIPTION
related: #8113 

`uname -m` returns `arm64` on Apple M1 https://stackoverflow.com/questions/65259300/detect-apple-silicon-from-command-line
/cc @theodelrieu 

Changelog: BugFix: Fix detected_architecture() for Apple M1, mapping to ``armv8`` (from returned ``arm64``).
Docs: omit

- [x] Refer to the issue that supports this Pull Request.
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 

<sup>**Note:** By default this PR will skip the slower tests and will use a limited set of python versions. Check [here](https://github.com/conan-io/conan/blob/develop/.github/PR_INCREASE_TESTING.md) how to increase the testing level by writing some tags in the current PR body text.</sup>
