### PR TITLE
Fix typo in error message (contraining -> constraining).

### DIFF
--- a/conans/model/conan_file.py
+++ b/conans/model/conan_file.py
@@ -69,7 +69,7 @@ def create_settings(conanfile, settings):
         settings.constraint(current)
         return settings
     except Exception as e:
-        raise ConanInvalidConfiguration("The recipe is contraining settings. %s" % str(e))
+        raise ConanInvalidConfiguration("The recipe is constraining settings. %s" % str(e))
 
 
 @contextmanager

--- a/conans/test/conan_v2/settings_model/test_cppstd.py
+++ b/conans/test/conan_v2/settings_model/test_cppstd.py
@@ -30,7 +30,7 @@ class SettingsCppstdTestCase(ConanV2ModeTestCase):
         if use_settings_v1:
             self.assertIn("Conan v2 incompatible: Setting 'cppstd' is deprecated", t.out)
         else:
-            self.assertIn("ERROR: The recipe is contraining settings. 'settings.cppstd' doesn't exist", t.out)
+            self.assertIn("ERROR: The recipe is constraining settings. 'settings.cppstd' doesn't exist", t.out)
 
     @parameterized.expand([(True,), (False,)])
     def test_settings_model(self, use_settings_v1):


### PR DESCRIPTION
Changelog: Omit
Docs: Omit

Fixes https://github.com/conan-io/conan/issues/8271
