### PR TITLE
fix per-package settings exact match for packages without user/channel

### DIFF
--- a/conans/client/loader.py
+++ b/conans/client/loader.py
@@ -176,11 +176,16 @@ class ConanFileLoader(object):
         tmp_settings = profile.processed_settings.copy()
         package_settings_values = profile.package_settings_values
         if package_settings_values:
+            # First, try to get a match directly by name (without needing *)
+            # TODO: Conan 2.0: We probably want to remove this, and leave a pure fnmatch
             pkg_settings = package_settings_values.get(conanfile.name)
-            if pkg_settings is None:
-                # FIXME: This seems broken for packages without user/channel
-                ref = "%s/%s@%s/%s" % (conanfile.name, conanfile.version,
-                                       conanfile._conan_user, conanfile._conan_channel)
+            if pkg_settings is None:  # If there is not exact match by package name, do fnmatch
+                if conanfile._conan_user is not None:
+                    ref = "%s/%s@%s/%s" % (conanfile.name, conanfile.version,
+                                           conanfile._conan_user, conanfile._conan_channel)
+                else:
+                    ref = "%s/%s" % (conanfile.name, conanfile.version)
+
                 for pattern, settings in package_settings_values.items():
                     if fnmatch.fnmatchcase(ref, pattern):
                         pkg_settings = settings

--- a/conans/test/functional/configuration/profile_test.py
+++ b/conans/test/functional/configuration/profile_test.py
@@ -326,7 +326,8 @@ class ProfileTest(unittest.TestCase):
         profile = textwrap.dedent("""
             [settings]
             os=Windows
-            mypkg/0.1:os=Linux  # THIS FAILED BEFORE WITH NO MATCH
+            # THIS FAILED BEFORE WITH NO MATCH
+            mypkg/0.1:os=Linux
             mypkg/0.1@user/channel:os=FreeBSD
             """)
         client = TestClient()

--- a/conans/test/functional/configuration/profile_test.py
+++ b/conans/test/functional/configuration/profile_test.py
@@ -1,5 +1,6 @@
 import os
 import platform
+import textwrap
 import unittest
 from collections import OrderedDict
 from textwrap import dedent
@@ -313,6 +314,29 @@ class ProfileTest(unittest.TestCase):
         self.assertIn("compiler.version=12", info)
         self.assertNotIn("gcc", info)
         self.assertNotIn("libcxx", info)
+
+    def test_package_settings_no_user_channel(self):
+        conanfile = textwrap.dedent("""
+            from conans import ConanFile
+            class Pkg(ConanFile):
+                settings = "os"
+                def build(self):
+                    self.output.info("SETTINGS! os={}!!".format(self.settings.os))
+                """)
+        profile = textwrap.dedent("""
+            [settings]
+            os=Windows
+            mypkg/0.1:os=Linux  # THIS FAILED BEFORE WITH NO MATCH
+            mypkg/0.1@user/channel:os=FreeBSD
+            """)
+        client = TestClient()
+        client.save({"conanfile.py": conanfile,
+                     "profile": profile})
+
+        client.run("create . mypkg/0.1@user/channel -pr=profile")
+        assert "mypkg/0.1@user/channel: SETTINGS! os=FreeBSD!!" in client.out
+        client.run("create . mypkg/0.1@ -pr=profile")
+        assert "mypkg/0.1: SETTINGS! os=Linux!!" in client.out
 
     @pytest.mark.tool_compiler
     def test_install_profile_options(self):


### PR DESCRIPTION
Changelog: BugFix: Fix per-package settings exact match for packages without user/channel.
Docs: Omit


Could this be breaking in some way? Please review.