### PR TITLE
Bugfix in MakeGenerator

### DIFF
--- a/conans/client/generators/make.py
+++ b/conans/client/generators/make.py
@@ -53,8 +53,8 @@ class MakeGenerator(Generator):
                      ("FRAMEWORKS", self.assignment_append, cpp_info.frameworks),
                      ("FRAMEWORK_PATHS", self.assignment_append, cpp_info.framework_paths)]
 
-        return [self._create_makefile_var(var_name, operator, info, pkg=pkg_name)
-                for var_name, operator, info in vars_info]
+        return [self._create_makefile_var(var_name, operator, values, pkg=pkg_name)
+                for var_name, operator, values in vars_info]
 
     def _create_combined_content(self):
         content = []

--- a/conans/client/generators/make.py
+++ b/conans/client/generators/make.py
@@ -25,9 +25,9 @@ class MakeGenerator(Generator):
 
         deps_content = []
         for pkg_name, cpp_info in self.deps_build_info.dependencies:
-            deps_content.extend(self.create_content_from_dep(pkg_name, cpp_info))
+            deps_content.extend(self._create_content_from_dep(pkg_name, cpp_info))
 
-        deps_content.extend(self.create_combined_content())
+        deps_content.extend(self._create_combined_content())
         for line_as_list in deps_content:
             content.append("".join(line_as_list))
 
@@ -35,7 +35,7 @@ class MakeGenerator(Generator):
         content.append(self.makefile_newline)
         return self.makefile_newline.join(content)
 
-    def create_content_from_dep(self, pkg_name, cpp_info):
+    def _create_content_from_dep(self, pkg_name, cpp_info):
         vars_info = [("ROOT", self.assignment_if_absent, [cpp_info.rootpath]),
                      ("SYSROOT", self.assignment_if_absent, [cpp_info.sysroot]),
                      ("INCLUDE_DIRS", self.assignment_append, cpp_info.include_paths),
@@ -53,20 +53,20 @@ class MakeGenerator(Generator):
                      ("FRAMEWORKS", self.assignment_append, cpp_info.frameworks),
                      ("FRAMEWORK_PATHS", self.assignment_append, cpp_info.framework_paths)]
 
-        return [self.create_makefile_var(var_name, operator, info, pkg=pkg_name)
+        return [self._create_makefile_var(var_name, operator, info, pkg=pkg_name)
                 for var_name, operator, info in vars_info]
 
-    def create_combined_content(self):
+    def _create_combined_content(self):
         content = []
         for var_name in ["root", "sysroot", "include_dirs", "lib_dirs", "bin_dirs", "build_dirs",
                          "res_dirs", "libs", "defines", "cflags", "cxxflags", "sharedlinkflags",
                          "exelinkflags", "frameworks", "framework_paths", "system_libs"]:
             values = ["$(CONAN_{var}_{pkg})".format(var=var_name.upper(), pkg=pkg.upper())
                       for pkg, _ in self.deps_build_info.dependencies]
-            content.append(self.create_makefile_var(var_name, self.assignment_append, values))
+            content.append(self._create_makefile_var(var_name, self.assignment_append, values))
         return content
 
-    def create_makefile_var(self, var_name, operator, values, pkg=None):
+    def _create_makefile_var(self, var_name, operator, values, pkg=None):
         pkg = "_{}".format(pkg.upper()) if pkg else ""
         make_var = ["CONAN_{var}{pkg}{op}".format(var=var_name.upper(), pkg=pkg, op=operator)]
         make_var.extend(value.replace("\\", "/") for value in values)

--- a/conans/client/generators/make.py
+++ b/conans/client/generators/make.py
@@ -16,7 +16,6 @@ class MakeGenerator(Generator):
 
     @property
     def content(self):
-
         content = [
             "#-------------------------------------------------------------------#",
             "#             Makefile variables from Conan Dependencies            #",
@@ -24,26 +23,19 @@ class MakeGenerator(Generator):
             "",
         ]
 
-        for line_as_list in self.create_deps_content():
+        deps_content = []
+        for pkg_name, cpp_info in self.deps_build_info.dependencies:
+            deps_content.extend(self.create_content_from_dep(pkg_name, cpp_info))
+
+        deps_content.extend(self.create_combined_content())
+        for line_as_list in deps_content:
             content.append("".join(line_as_list))
 
         content.append("#-------------------------------------------------------------------#")
         content.append(self.makefile_newline)
         return self.makefile_newline.join(content)
 
-    def create_deps_content(self):
-        deps_content = self.create_content_from_deps()
-        deps_content.extend(self.create_combined_content())
-        return deps_content
-
-    def create_content_from_deps(self):
-        content = []
-        for pkg_name, cpp_info in self.deps_build_info.dependencies:
-            content.extend(self.create_content_from_dep(pkg_name, cpp_info))
-        return content
-
     def create_content_from_dep(self, pkg_name, cpp_info):
-
         vars_info = [("ROOT", self.assignment_if_absent, [cpp_info.rootpath]),
                      ("SYSROOT", self.assignment_if_absent, [cpp_info.sysroot]),
                      ("INCLUDE_DIRS", self.assignment_append, cpp_info.include_paths),
@@ -61,36 +53,21 @@ class MakeGenerator(Generator):
                      ("FRAMEWORKS", self.assignment_append, cpp_info.frameworks),
                      ("FRAMEWORK_PATHS", self.assignment_append, cpp_info.framework_paths)]
 
-        return [self.create_makefile_var_pkg(var_name, pkg_name, operator, info)
+        return [self.create_makefile_var(var_name, operator, info, pkg=pkg_name)
                 for var_name, operator, info in vars_info]
 
     def create_combined_content(self):
         content = []
-        for var_name in ["rootpath", "sysroot", "include_dirs", "lib_dirs", "bin_dirs", "build_dirs",
+        for var_name in ["root", "sysroot", "include_dirs", "lib_dirs", "bin_dirs", "build_dirs",
                          "res_dirs", "libs", "defines", "cflags", "cxxflags", "sharedlinkflags",
                          "exelinkflags", "frameworks", "framework_paths", "system_libs"]:
-            content.append(self.create_makefile_var_global(var_name, self.assignment_append,
-                                                           self.create_combined_var_list(var_name)))
+            values = ["$(CONAN_{var}_{pkg})".format(var=var_name.upper(), pkg=pkg.upper())
+                      for pkg, _ in self.deps_build_info.dependencies]
+            content.append(self.create_makefile_var(var_name, self.assignment_append, values))
         return content
 
-    def create_combined_var_list(self, var_name):
-        make_vars = []
-        for pkg_name, _ in self.deps_build_info.dependencies:
-            pkg_var = "CONAN_{var}_{lib}".format(var=var_name, lib=pkg_name).upper()
-            make_vars.append("$({pkg_var})".format(pkg_var=pkg_var))
-        return make_vars
-
-    def create_makefile_var_global(self, var_name, operator, values):
-        make_var = ["CONAN_{var}".format(var=var_name).upper()]
-        make_var.extend(self.create_makefile_var_common(operator, values))
-        return make_var
-
-    def create_makefile_var_pkg(self, var_name, pkg_name, operator, values):
-        make_var = ["CONAN_{var}_{pkg}".format(var=var_name, pkg=pkg_name).upper()]
-        make_var.extend(self.create_makefile_var_common(operator, values))
-        return make_var
-
-    def create_makefile_var_common(self, operator, values):
-        formatted_values = [value.replace("\\", "/") for value in values]
-        formatted_values = self.makefile_line_continuation.join(formatted_values)
-        return [operator, self.makefile_line_continuation, formatted_values, self.makefile_newline]
+    def create_makefile_var(self, var_name, operator, values, pkg=None):
+        pkg = "_{}".format(pkg.upper()) if pkg else ""
+        make_var = ["CONAN_{var}{pkg}{op}".format(var=var_name.upper(), pkg=pkg, op=operator)]
+        make_var.extend(value.replace("\\", "/") for value in values)
+        return self.makefile_line_continuation.join(make_var) + self.makefile_newline

--- a/conans/paths/__init__.py
+++ b/conans/paths/__init__.py
@@ -34,7 +34,6 @@ BUILD_INFO_QBS = 'conanbuildinfo.qbs'
 BUILD_INFO_VISUAL_STUDIO = 'conanbuildinfo.props'
 BUILD_INFO_XCODE = 'conanbuildinfo.xcconfig'
 BUILD_INFO_PREMAKE = 'conanbuildinfo.premake.lua'
-BUILD_INFO_MAKE = 'conanbuildinfo.mak'
 BUILD_INFO_DEPLOY = 'deploy_manifest.txt'
 CONANINFO = "conaninfo.txt"
 CONANENV = "conanenv.txt"

--- a/conans/test/unittests/client/generators/make_test.py
+++ b/conans/test/unittests/client/generators/make_test.py
@@ -1,5 +1,4 @@
 import os
-import unittest
 
 from conans.client.generators import MakeGenerator
 from conans.model.build_info import CppInfo
@@ -12,55 +11,53 @@ from conans.test.utils.mocks import TestBufferConanOutput
 from conans.util.files import save
 
 
-class MakeGeneratorTest(unittest.TestCase):
+def test_make_generator():
+    tmp_folder1 = temp_folder()
+    tmp_folder2 = temp_folder()
+    save(os.path.join(tmp_folder1, "include1", "file.h"), "")
+    save(os.path.join(tmp_folder2, "include2", "file.h"), "")
+    save(os.path.join(tmp_folder1, "lib1", "file.a"), "")
+    save(os.path.join(tmp_folder2, "lib2", "file.a"), "")
+    save(os.path.join(tmp_folder1, "bin1", "file.bin"), "")
+    save(os.path.join(tmp_folder2, "bin2", "file.bin"), "")
+    save(os.path.join(tmp_folder1, "SystemFrameworks", "file.bin"), "")
 
-    def test_variables_setup(self):
-        tmp_folder1 = temp_folder()
-        tmp_folder2 = temp_folder()
-        save(os.path.join(tmp_folder1, "include1", "file.h"), "")
-        save(os.path.join(tmp_folder2, "include2", "file.h"), "")
-        save(os.path.join(tmp_folder1, "lib1", "file.a"), "")
-        save(os.path.join(tmp_folder2, "lib2", "file.a"), "")
-        save(os.path.join(tmp_folder1, "bin1", "file.bin"), "")
-        save(os.path.join(tmp_folder2, "bin2", "file.bin"), "")
-        save(os.path.join(tmp_folder1, "SystemFrameworks", "file.bin"), "")
+    conanfile = ConanFile(TestBufferConanOutput(), None)
+    conanfile.initialize(Settings({}), EnvValues())
+    ref = ConanFileReference.loads("MyPkg1/0.1@lasote/stables")
+    cpp_info = CppInfo(ref.name, tmp_folder1)
+    cpp_info.defines = ["MYDEFINE1"]
+    cpp_info.includedirs = ['include1']
+    cpp_info.libdirs = ['lib1']
+    cpp_info.libs = ['libfoo']
+    cpp_info.bindirs = ['bin1']
+    cpp_info.version = "0.1"
+    cpp_info.cflags = ['-fgimple']
+    cpp_info.cxxflags = ['-fdollars-in-identifiers']
+    cpp_info.sharedlinkflags = ['-framework Cocoa']
+    cpp_info.exelinkflags = ['-framework QuartzCore']
+    cpp_info.frameworks = ['AudioUnit']
+    cpp_info.frameworkdirs = ['SystemFrameworks']
+    cpp_info.system_libs = ["system_lib1"]
+    conanfile.deps_cpp_info.add(ref.name, cpp_info)
+    ref = ConanFileReference.loads("MyPkg2/3.2.3@lasote/stables")
+    cpp_info = CppInfo(ref.name, tmp_folder2)
+    cpp_info.defines = ["MYDEFINE2"]
+    cpp_info.includedirs = ['include2']
+    cpp_info.libdirs = ['lib2']
+    cpp_info.libs = ['libbar']
+    cpp_info.bindirs = ['bin2']
+    cpp_info.version = "3.2.3"
+    cpp_info.cflags = ['-fno-asm']
+    cpp_info.cxxflags = ['-pthread']
+    cpp_info.sharedlinkflags = ['-framework AudioFoundation']
+    cpp_info.exelinkflags = ['-framework VideoToolbox']
+    cpp_info.system_libs = ["system_lib2"]
+    conanfile.deps_cpp_info.add(ref.name, cpp_info)
+    generator = MakeGenerator(conanfile)
+    content = generator.content
 
-        conanfile = ConanFile(TestBufferConanOutput(), None)
-        conanfile.initialize(Settings({}), EnvValues())
-        ref = ConanFileReference.loads("MyPkg1/0.1@lasote/stables")
-        cpp_info = CppInfo(ref.name, tmp_folder1)
-        cpp_info.defines = ["MYDEFINE1"]
-        cpp_info.includedirs = ['include1']
-        cpp_info.libdirs = ['lib1']
-        cpp_info.libs = ['libfoo']
-        cpp_info.bindirs = ['bin1']
-        cpp_info.version = "0.1"
-        cpp_info.cflags = ['-fgimple']
-        cpp_info.cxxflags = ['-fdollars-in-identifiers']
-        cpp_info.sharedlinkflags = ['-framework Cocoa']
-        cpp_info.exelinkflags = ['-framework QuartzCore']
-        cpp_info.frameworks = ['AudioUnit']
-        cpp_info.frameworkdirs = ['SystemFrameworks']
-        cpp_info.system_libs = ["system_lib1"]
-        conanfile.deps_cpp_info.add(ref.name, cpp_info)
-        ref = ConanFileReference.loads("MyPkg2/3.2.3@lasote/stables")
-        cpp_info = CppInfo(ref.name, tmp_folder2)
-        cpp_info.defines = ["MYDEFINE2"]
-        cpp_info.includedirs = ['include2']
-        cpp_info.libdirs = ['lib2']
-        cpp_info.libs = ['libbar']
-        cpp_info.bindirs = ['bin2']
-        cpp_info.version = "3.2.3"
-        cpp_info.cflags = ['-fno-asm']
-        cpp_info.cxxflags = ['-pthread']
-        cpp_info.sharedlinkflags = ['-framework AudioFoundation']
-        cpp_info.exelinkflags = ['-framework VideoToolbox']
-        cpp_info.system_libs = ["system_lib2"]
-        conanfile.deps_cpp_info.add(ref.name, cpp_info)
-        generator = MakeGenerator(conanfile)
-        content = generator.content
-
-        content_template = """
+    content_template = """
 CONAN_ROOT_MYPKG1 ?=  \\
 {conan_root_mypkg1}
 
@@ -77,10 +74,9 @@ CONAN_BIN_DIRS_MYPKG1 +=  \\
 {conan_bin_dirs_mypkg1}
 
 CONAN_BUILD_DIRS_MYPKG1 +=  \\
-{conan_build_dirs_mypkg1}
+{conan_build_dirs_mypkg1}/
 
-CONAN_RES_DIRS_MYPKG1 +=  \\
-
+CONAN_RES_DIRS_MYPKG1 +=
 
 CONAN_LIBS_MYPKG1 +=  \\
 libfoo
@@ -107,7 +103,7 @@ CONAN_FRAMEWORKS_MYPKG1 +=  \\
 AudioUnit
 
 CONAN_FRAMEWORK_PATHS_MYPKG1 +=  \\
-{conan_framework_dirs_mypkg1}
+{conan_framework_dirs_mypkg1}/SystemFrameworks
 
 CONAN_ROOT_MYPKG2 ?=  \\
 {conan_root_mypkg2}
@@ -125,10 +121,9 @@ CONAN_BIN_DIRS_MYPKG2 +=  \\
 {conan_bin_dirs_mypkg2}
 
 CONAN_BUILD_DIRS_MYPKG2 +=  \\
-{conan_build_dirs_mypkg2}
+{conan_build_dirs_mypkg2}/
 
-CONAN_RES_DIRS_MYPKG2 +=  \\
-
+CONAN_RES_DIRS_MYPKG2 +=
 
 CONAN_LIBS_MYPKG2 +=  \\
 libbar
@@ -151,15 +146,13 @@ CONAN_SHAREDLINKFLAGS_MYPKG2 +=  \\
 CONAN_EXELINKFLAGS_MYPKG2 +=  \\
 -framework VideoToolbox
 
-CONAN_FRAMEWORKS_MYPKG2 +=  \\
+CONAN_FRAMEWORKS_MYPKG2 +=
 
+CONAN_FRAMEWORK_PATHS_MYPKG2 +=
 
-CONAN_FRAMEWORK_PATHS_MYPKG2 +=  \\
-
-
-CONAN_ROOTPATH +=  \\
-$(CONAN_ROOTPATH_MYPKG1) \\
-$(CONAN_ROOTPATH_MYPKG2)
+CONAN_ROOT +=  \\
+$(CONAN_ROOT_MYPKG1) \\
+$(CONAN_ROOT_MYPKG2)
 
 CONAN_SYSROOT +=  \\
 $(CONAN_SYSROOT_MYPKG1) \\
@@ -217,28 +210,29 @@ CONAN_FRAMEWORK_PATHS +=  \\
 $(CONAN_FRAMEWORK_PATHS_MYPKG1) \\
 $(CONAN_FRAMEWORK_PATHS_MYPKG2)
 """
-        root1 = tmp_folder1.replace('\\', '/')
-        root2 = tmp_folder2.replace('\\', '/')
+    root1 = tmp_folder1.replace('\\', '/')
+    root2 = tmp_folder2.replace('\\', '/')
 
-        inc1 = os.path.join(tmp_folder1, 'include1').replace('\\', '/')
-        inc2 = os.path.join(tmp_folder2, 'include2').replace('\\', '/')
+    inc1 = os.path.join(tmp_folder1, 'include1').replace('\\', '/')
+    inc2 = os.path.join(tmp_folder2, 'include2').replace('\\', '/')
 
-        lib1 = os.path.join(tmp_folder1, 'lib1').replace('\\', '/')
-        lib2 = os.path.join(tmp_folder2, 'lib2').replace('\\', '/')
+    lib1 = os.path.join(tmp_folder1, 'lib1').replace('\\', '/')
+    lib2 = os.path.join(tmp_folder2, 'lib2').replace('\\', '/')
 
-        bin1 = os.path.join(tmp_folder1, 'bin1').replace('\\', '/')
-        bin2 = os.path.join(tmp_folder2, 'bin2').replace('\\', '/')
+    bin1 = os.path.join(tmp_folder1, 'bin1').replace('\\', '/')
+    bin2 = os.path.join(tmp_folder2, 'bin2').replace('\\', '/')
 
-        expected_content = content_template.format(conan_root_mypkg1=root1,
-                                                   conan_include_dirs_mypkg1=inc1,
-                                                   conan_lib_dirs_mypkg1=lib1,
-                                                   conan_bin_dirs_mypkg1=bin1,
-                                                   conan_build_dirs_mypkg1=root1 + "/",
-                                                   conan_root_mypkg2=root2,
-                                                   conan_include_dirs_mypkg2=inc2,
-                                                   conan_lib_dirs_mypkg2=lib2,
-                                                   conan_bin_dirs_mypkg2=bin2,
-                                                   conan_build_dirs_mypkg2=root2 + "/",
-                                                   conan_framework_dirs_mypkg1=root1 + "/SystemFrameworks")
-        self.maxDiff = None
-        self.assertIn(expected_content, content)
+    expected_content = content_template.format(conan_root_mypkg1=root1,
+                                               conan_include_dirs_mypkg1=inc1,
+                                               conan_lib_dirs_mypkg1=lib1,
+                                               conan_bin_dirs_mypkg1=bin1,
+                                               conan_build_dirs_mypkg1=root1,
+                                               conan_root_mypkg2=root2,
+                                               conan_include_dirs_mypkg2=inc2,
+                                               conan_lib_dirs_mypkg2=lib2,
+                                               conan_bin_dirs_mypkg2=bin2,
+                                               conan_build_dirs_mypkg2=root2,
+                                               conan_framework_dirs_mypkg1=root1)
+
+    content = "\n".join(line.strip() for line in content.splitlines())  # Trailing spaces
+    assert expected_content in content


### PR DESCRIPTION
Changelog: Bugfix: Fix bug in definition of ``ROOT`` variables in ``MakeGenerator``.
Docs: Omit


MakeGenerator was using ``rootpath`` instead of ``root``.

I also did some refactors to simplify it a bit, reducing the number of methods, making them private, 
