### PR TITLE
Fix strip root from zip

### DIFF
--- a/conans/client/tools/files.py
+++ b/conans/client/tools/files.py
@@ -115,7 +115,9 @@ def unzip(filename, destination=".", keep_permissions=False, pattern=None, outpu
                 raise ConanException("The zip file contains more than 1 folder in the root")
             if len(names) == 1 and len(names[0].split("/", 1)) == 1:
                 raise ConanException("The zip file contains a file in the root")
-
+            # Remove the directory entry if present
+            # Note: The "zip" format contains the "/" at the end if it is a directory
+            zip_info = [m for m in zip_info if m.filename != (common_folder + "/")]
             for member in zip_info:
                 name = member.filename.replace("\\", "/")
                 member.filename = name.split("/", 1)[1]
@@ -167,7 +169,8 @@ def untargz(filename, destination=".", pattern=None, strip_root=False):
                     raise ConanException("The tgz file contains more than 1 folder in the root")
                 if len(names) == 1 and len(names[0].split("/", 1)) == 1:
                     raise ConanException("The tgz file contains a file in the root")
-
+                # Remove the directory entry if present
+                members = [m for m in members if m.name != common_folder]
                 for member in members:
                     name = member.name.replace("\\", "/")
                     member.name = name.split("/", 1)[1]


### PR DESCRIPTION
Changelog: omit
Docs: omit

FIX FOR A FEATURE NOT RELEASED YET
https://github.com/conan-io/conan/pull/8208/files

Playing with the feature with real tgz and zip files I faced issues because in the compressed files is likely to have an entry not only for the files but also for the directories. If the root directory (the one to strip) had an entry, it failed because of a `split("/")[1]` in case of the TGZ files and causing an "invalid zip" while extracting, in case of the ZIP format