### PR TITLE
Restore folder write permissions after testing

### DIFF
--- a/conans/test/integration/system_reqs_test.py
+++ b/conans/test/integration/system_reqs_test.py
@@ -250,6 +250,9 @@ class SystemReqsTest(unittest.TestCase):
             client.run("remove --system-reqs Test/0.1@user/channel")
         self.assertTrue(os.path.exists(system_reqs_path))
 
+        # restore write permission so the temporal folder can be deleted later
+        os.chmod(system_reqs_path, current | stat.S_IWRITE)
+
     def test_duplicate_remove_system_reqs(self):
         ref = ConanFileReference.loads("Test/0.1@user/channel")
         client = TestClient()


### PR DESCRIPTION
Changelog: omit
Docs: omit

The ci was [failing](https://ci.conan.io/blue/organizations/jenkins/ConanTestSuite/detail/PR-8299/4/pipeline/) trying to delete some temporal files because `test_permission_denied_remove_system_reqs` was changing the permissions to read only and not restoring them back. 
