### PR TITLE
Update pylint plugin after #8243

### DIFF
--- a/conans/pylint_plugin.py
+++ b/conans/pylint_plugin.py
@@ -28,10 +28,6 @@ def transform_conanfile(node):
         "conans.client.graph.python_requires").lookup("PyRequires")
 
     dynamic_fields = {
-        "source_folder": str_class,
-        "build_folder": str_class,
-        "package_folder": str_class,
-        "install_folder": str_class,
         "conan_data": str_class,
         "build_requires": build_requires_class,
         "info_build": info_class,


### PR DESCRIPTION
Changelog: Fix: Update pylint plugin, some fields are now available in the base `ConanFile`.
Docs: omit

After https://github.com/conan-io/conan/pull/8243 some fields are now available in `Conanfile`.