### PR TITLE
Allow global build modules with components

### DIFF
--- a/conans/model/build_info.py
+++ b/conans/model/build_info.py
@@ -261,7 +261,6 @@ class CppInfo(_CppInfo):
              self.cxxflags or
              self.sharedlinkflags or
              self.exelinkflags or
-             self.build_modules or
              self.requires):
             raise ConanException("self.cpp_info.components cannot be used with self.cpp_info "
                                  "global values at the same time")

--- a/conans/test/functional/generators/cmake_find_package_test.py
+++ b/conans/test/functional/generators/cmake_find_package_test.py
@@ -486,7 +486,6 @@ message("Target libs: ${tmp}")
             """)
         client.save({"conanfile.py": consumer, "CMakeLists.txt": cmakelists})
         client.run("create .")
-        print(client.out)
         self.assertIn("Printing using a external module!", client.out)
 
     def test_cpp_info_name(self):


### PR DESCRIPTION
Changelog: Feature: Allow the usage of global scope build modules with components in `cpp_info`
Docs: omit

Note that build modules can still be used in components although they are always injected in the global scope.

- [x] Refer to the issue that supports this Pull Request.
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [x] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 

<sup>**Note:** By default this PR will skip the slower tests and will use a limited set of python versions. Check [here](https://github.com/conan-io/conan/blob/develop/.github/PR_INCREASE_TESTING.md) how to increase the testing level by writing some tags in the current PR body text.</sup>
