### PR TITLE
Fix #8328 - remove spurious '-find' argument to XCodes xcrun tool whi…

### DIFF
--- a/conans/client/tools/apple.py
+++ b/conans/client/tools/apple.py
@@ -74,7 +74,7 @@ class XCRun(object):
         def cmd_output(cmd):
             return check_output_runner(cmd).strip()
 
-        command = ['xcrun', '-find']
+        command = ['xcrun']
         if self.sdk:
             command.extend(['-sdk', self.sdk])
         command.extend(args)


### PR DESCRIPTION
…ch fails on osxcross'es clone

Changelog: Fix: Remove spurious '-find' argument to XCodes xcrun tool. 
Docs: Omit

Fixes: #8328

- [x] Refer to the issue that supports this Pull Request.
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 

<sup>**Note:** By default this PR will skip the slower tests and will use a limited set of python versions. Check [here](https://github.com/conan-io/conan/blob/develop/.github/PR_INCREASE_TESTING.md) how to increase the testing level by writing some tags in the current PR body text.</sup>
