### PR TITLE
add CMAKE_GENERATOR_PLATFORM and CMAKE_GENERATOR_TOOLSET conditionall…

### DIFF
--- a/conan/tools/cmake/generic.py
+++ b/conan/tools/cmake/generic.py
@@ -57,8 +57,12 @@ class CMakeGenericToolchain(CMakeToolchainBase):
 
         {% block before_try_compile %}
             {{ super() }}
-            {% if generator_platform %}set(CMAKE_GENERATOR_PLATFORM "{{ generator_platform }}" CACHE STRING "" FORCE){% endif %}
-            {% if toolset %}set(CMAKE_GENERATOR_TOOLSET "{{ toolset }}" CACHE STRING "" FORCE){% endif %}
+            if(CMAKE_GENERATOR MATCHES "Visual Studio")
+                # TODO: This IF might be a temporary solution, as the toolchain should be aware of
+                # which generator is going to be used and define this accordingly
+                {% if generator_platform %}set(CMAKE_GENERATOR_PLATFORM "{{ generator_platform }}" CACHE STRING "" FORCE){% endif %}
+                {% if toolset %}set(CMAKE_GENERATOR_TOOLSET "{{ toolset }}" CACHE STRING "" FORCE){% endif %}
+            endif()
             {% if compiler %}
             set(CMAKE_C_COMPILER {{ compiler }})
             set(CMAKE_CXX_COMPILER {{ compiler }})


### PR DESCRIPTION
…y to Visual Studio only in CMakeToolchain

Changelog: Fix: Do not define CMAKE_GENERATOR_PLATFORM and CMAKE_GENERATOR_TOOLSET in the ``CMakeToolchain`` file unless the CMake generator is "Visual Studio". Fix https://github.com/conan-io/conan/issues/7485
Docs: Omit

This might be a temporary measure, as the generator needs to become more explicit at some point (via configuration or some other way), so the ``CMakeToolchain`` might decide to completely skip those definitions if they don't apply.
