### PR TITLE
[test] Add test creating a target without namespaces (CMake)

### DIFF
--- a/conans/model/build_info.py
+++ b/conans/model/build_info.py
@@ -2,8 +2,6 @@ import os
 from collections import OrderedDict
 from copy import copy
 
-import six
-
 from conans.errors import ConanException
 from conans.util.conan_v2_mode import conan_v2_behavior
 
@@ -84,7 +82,6 @@ def dict_to_abs_paths(the_dict, rootpath):
 def merge_dicts(d1, d2):
     def merge_lists(seq1, seq2):
         return [s for s in seq1 if s not in seq2] + seq2
-
     result = d1.copy()
     for k, v in d2.items():
         if k not in d1.keys():
@@ -148,12 +145,7 @@ class _CppInfo(object):
     @property
     def build_modules_paths(self):
         if self._build_modules_paths is None:
-            # FIXME: This should be just a plain dict
-            if isinstance(self.build_modules, six.string_types):
-                conan_v2_behavior("Use 'self.cpp_info.build_modules[\"<generator>\"] = "
-                                  "{the_list}' instead".format(the_list=[self.build_modules, ]))
-                self.build_modules = BuildModulesDict.from_list([self.build_modules, ])
-            if isinstance(self.build_modules, list):
+            if isinstance(self.build_modules, list):  # FIXME: This should be just a plain dict
                 conan_v2_behavior("Use 'self.cpp_info.build_modules[\"<generator>\"] = "
                                   "{the_list}' instead".format(the_list=self.build_modules))
                 self.build_modules = BuildModulesDict.from_list(self.build_modules)
@@ -354,8 +346,7 @@ class CppInfo(_CppInfo):
                 reason = None
                 if comp_require not in pkg_requires:
                     reason = "not defined as a recipe requirement"
-                elif package_requires[comp_require].private and package_requires[
-                    comp_require].override:
+                elif package_requires[comp_require].private and package_requires[comp_require].override:
                     reason = "it was defined as an overridden private recipe requirement"
                 elif package_requires[comp_require].private:
                     reason = "it was defined as a private recipe requirement"
@@ -389,6 +380,7 @@ class _BaseDepsCppInfo(_CppInfo):
         super(_BaseDepsCppInfo, self).__init__()
 
     def update(self, dep_cpp_info):
+
         def merge_lists(seq1, seq2):
             return [s for s in seq1 if s not in seq2] + seq2
 

--- a/conans/test/functional/generators/cmake_find_package_multi_test.py
+++ b/conans/test/functional/generators/cmake_find_package_multi_test.py
@@ -539,7 +539,7 @@ class TestNoNamespaceTarget:
         from conans import ConanFile, CMake
 
         class Recipe(ConanFile):
-            settings = "os", "compiler", "arch"
+            settings = "os", "compiler", "arch", "build_type"
             exports_sources = ["src/*", "build-module.cmake"]
             generators = "cmake"
 
@@ -606,7 +606,8 @@ class TestNoNamespaceTarget:
         t.run('new library/version -s')
         t.save({'conanfile.py': cls.conanfile,
                 'build-module.cmake': cls.build_module})
-        t.run('create conanfile.py library/version@')
+        t.run('create conanfile.py library/version@ -s build_type=Debug')
+        t.run('create conanfile.py library/version@ -s build_type=Release')
         # Prepare project to consume the targets
         t.save({'CMakeLists.txt': cls.consumer, 'main.cpp': cls.main}, clean_first=True)
 
@@ -627,7 +628,7 @@ class TestNoNamespaceTarget:
         with t.chdir('multi_windows'):
             t.run('install library/version@ -g cmake_find_package_multi -s build_type=Release')
             t.run('install library/version@ -g cmake_find_package_multi -s build_type=Debug')
-            generator = '-G "Visual Studio 15 2017" -A "x64"'
+            generator = '-G "Visual Studio 15 Win64"'
             t.run_command(
                 'cmake .. {} -DCMAKE_PREFIX_PATH:PATH="{}"'.format(generator, t.current_folder))
             assert str(t.out).count('>> Build-module is included') == 2  # FIXME: Known bug

--- a/conans/test/functional/generators/cmake_find_package_multi_test.py
+++ b/conans/test/functional/generators/cmake_find_package_multi_test.py
@@ -601,7 +601,6 @@ class TestNoNamespaceTarget:
     @classmethod
     def setup_class(cls):
         cls.t = t = TestClient()
-        t.current_folder = '/private/var/folders/fc/6mvcrc952dqcjfhl4c7c11ph0000gn/T/tmpiq_fqfmfconans/path with spaces'
         # Create a library providing a build-module
         t.run('new library/version -s')
         t.save({'conanfile.py': cls.conanfile,

--- a/conans/test/functional/generators/cmake_find_package_multi_test.py
+++ b/conans/test/functional/generators/cmake_find_package_multi_test.py
@@ -560,7 +560,8 @@ class TestNoNamespaceTarget:
             def package_info(self):
                 self.cpp_info.libs = ["library"]
                 module = os.path.join("share", "cmake", "build-module.cmake")
-                self.cpp_info.build_modules = module
+                self.cpp_info.build_modules['cmake_find_package'] = [module, ]
+                self.cpp_info.build_modules['cmake_find_package_multi'] = [module, ]
     """)
 
     build_module = textwrap.dedent("""

--- a/conans/test/functional/generators/cmake_find_package_multi_test.py
+++ b/conans/test/functional/generators/cmake_find_package_multi_test.py
@@ -615,20 +615,21 @@ class TestNoNamespaceTarget:
         t = self.t
         with t.chdir('not_multi'):
             t.run('install library/version@ -g cmake_find_package -s build_type=Release')
-            t.run_command('cmake .. -DCMAKE_MODULE_PATH="{}"'.format(t.current_folder))
+            t.run_command('cmake .. -DCMAKE_MODULE_PATH:PATH="{}"'.format(t.current_folder))
             assert str(t.out).count('>> Build-module is included') == 1
             assert '>> nonamespace libs: library::library' in t.out
-            t.run_command('cmake --build .') # Compiles and links.
+            t.run_command('cmake --build .')  # Compiles and links.
 
     @pytest.mark.skipif(platform.system() != "Windows", reason="Only windows")
     @pytest.mark.tool_visual_studio
     def test_multi_generator_windows(self):
         t = self.t
-        with t.chdir('multi_macos'):
+        with t.chdir('multi_windows'):
             t.run('install library/version@ -g cmake_find_package_multi -s build_type=Release')
             t.run('install library/version@ -g cmake_find_package_multi -s build_type=Debug')
             generator = '-G "Visual Studio 15 2017" -A "x64"'
-            t.run_command('cmake .. {} -DCMAKE_PREFIX_PATH="{}"'.format(generator, t.current_folder))
+            t.run_command(
+                'cmake .. {} -DCMAKE_PREFIX_PATH:PATH="{}"'.format(generator, t.current_folder))
             assert str(t.out).count('>> Build-module is included') == 2  # FIXME: Known bug
             assert '>> nonamespace libs: library::library' in t.out
             t.run_command('cmake --build . --config Release')  # Compiles and links.
@@ -640,7 +641,7 @@ class TestNoNamespaceTarget:
         with t.chdir('multi_macos'):
             t.run('install library/version@ -g cmake_find_package_multi -s build_type=Release')
             t.run('install library/version@ -g cmake_find_package_multi -s build_type=Debug')
-            t.run_command('cmake .. -G Xcode -DCMAKE_PREFIX_PATH="{}"'.format(t.current_folder))
+            t.run_command('cmake .. -G Xcode -DCMAKE_PREFIX_PATH:PATH="{}"'.format(t.current_folder))
             assert str(t.out).count('>> Build-module is included') == 2  # FIXME: Known bug
             assert '>> nonamespace libs: library::library' in t.out
             t.run_command('cmake --build . --config Release')  # Compiles and links.

--- a/conans/test/functional/generators/cmake_find_package_multi_test.py
+++ b/conans/test/functional/generators/cmake_find_package_multi_test.py
@@ -587,7 +587,7 @@ class TestNoNamespaceTarget:
         message(">> nonamespace libs: ${LIBS2}")
 
         add_executable(consumer main.cpp)
-        target_link_libraries(consumer library::library)
+        target_link_libraries(consumer nonamespace)
     """)
 
     main = textwrap.dedent("""

--- a/conans/test/functional/generators/cmake_find_package_multi_test.py
+++ b/conans/test/functional/generators/cmake_find_package_multi_test.py
@@ -610,6 +610,7 @@ class TestNoNamespaceTarget:
         # Prepare project to consume the targets
         t.save({'CMakeLists.txt': cls.consumer, 'main.cpp': cls.main}, clean_first=True)
 
+    @pytest.mark.tool_compiler
     def test_non_multi_generator(self):
         t = self.t
         with t.chdir('not_multi'):
@@ -620,6 +621,7 @@ class TestNoNamespaceTarget:
             t.run_command('cmake --build .') # Compiles and links.
 
     @pytest.mark.skipif(platform.system() != "Windows", reason="Only windows")
+    @pytest.mark.tool_visual_studio
     def test_multi_generator_windows(self):
         t = self.t
         with t.chdir('multi_macos'):
@@ -632,6 +634,7 @@ class TestNoNamespaceTarget:
             t.run_command('cmake --build . --config Release')  # Compiles and links.
 
     @pytest.mark.skipif(platform.system() != "Darwin", reason="Requires Macos")
+    @pytest.mark.tool_xcode
     def test_multi_generator_macos(self):
         t = self.t
         with t.chdir('multi_macos'):

--- a/conans/test/functional/generators/cmake_find_package_multi_test.py
+++ b/conans/test/functional/generators/cmake_find_package_multi_test.py
@@ -616,7 +616,9 @@ class TestNoNamespaceTarget:
         t = self.t
         with t.chdir('not_multi'):
             t.run('install library/version@ -g cmake_find_package -s build_type=Release')
-            t.run_command('cmake .. -DCMAKE_MODULE_PATH:PATH="{}"'.format(t.current_folder))
+            generator = '-G "Visual Studio 15 Win64"' if platform.system() == "Windows" else ''
+            t.run_command(
+                'cmake .. {} -DCMAKE_MODULE_PATH:PATH="{}"'.format(generator, t.current_folder))
             assert str(t.out).count('>> Build-module is included') == 1
             assert '>> nonamespace libs: library::library' in t.out
             t.run_command('cmake --build .')  # Compiles and links.


### PR DESCRIPTION
Changelog: omit
Docs: omit

Adds a test using `build_modules` to create a target without namespace. This target consumes the targets provided by Conan.

closes https://github.com/conan-io/conan/issues/7615 - At this moment we are not implementing anything else in the model to create targets without namespaces (it is very CMake specific and `cpp_info` should have some level of abstraction over different build-systems). ping @madebr @SpaceIm