### PR TITLE
Fix: Allow modification of system/cpu_family/cpu/endian in generated MesonToolchain toolchain file

### DIFF
--- a/conans/test/functional/toolchains/meson/test_conf.py
+++ b/conans/test/functional/toolchains/meson/test_conf.py
@@ -1,0 +1,93 @@
+import os
+import textwrap
+
+from conans.test.assets.sources import gen_function_cpp, gen_function_h
+from conans.test.functional.toolchains.meson._base import TestMesonBase
+
+
+class MesonConfTest(TestMesonBase):
+    _conanfile_py = textwrap.dedent("""
+    from conans import ConanFile, tools
+    from conan.tools.meson import Meson, MesonToolchain
+
+
+    class App(ConanFile):
+        settings = "os", "arch", "compiler", "build_type"
+        options = {"shared": [True, False], "fPIC": [True, False]}
+        default_options = {"shared": False, "fPIC": True}
+
+        def config_options(self):
+            if self.settings.os == "Windows":
+                del self.options.fPIC
+
+        def generate(self):
+            tc = MesonToolchain(self)
+            tc.generate()
+
+        def build(self):
+            meson = Meson(self)
+            meson.configure()
+            meson.build()
+    """)
+
+    _meson_build = textwrap.dedent("""
+    project('tutorial', 'cpp')
+    hello = library('hello', 'hello.cpp')
+    executable('demo', 'main.cpp', link_with: hello)
+    """)
+
+    def test_build(self):
+        hello_h = gen_function_h(name="hello")
+        hello_cpp = gen_function_cpp(name="hello")
+        app = gen_function_cpp(name="main", includes=["hello"], calls=["hello"])
+
+        profile_host = textwrap.dedent("""
+    include(default)
+    [settings]
+    arch=armv8
+    os=FreeBSD
+    [conf]
+    tools.meson.mesontoolchain.host_machine:system=nes
+    tools.meson.mesontoolchain.host_machine:cpu_family=MOS
+    tools.meson.mesontoolchain.host_machine:cpu=6502
+    tools.meson.mesontoolchain.host_machine:endian=big
+    
+    tools.meson.mesontoolchain.build_machine:system=smd
+    tools.meson.mesontoolchain.build_machine:cpu_family=Motorola
+    tools.meson.mesontoolchain.build_machine:cpu=68K
+    tools.meson.mesontoolchain.build_machine:endian=big
+    
+    tools.meson.mesontoolchain.target_machine:system=spectrum
+    tools.meson.mesontoolchain.target_machine:cpu_family=Zilog
+    tools.meson.mesontoolchain.target_machine:cpu=Z80
+    tools.meson.mesontoolchain.target_machine:endian=big
+    """)
+
+        self.t.save({"conanfile.py": self._conanfile_py,
+                     "meson.build": self._meson_build,
+                     "hello.h": hello_h,
+                     "hello.cpp": hello_cpp,
+                     "main.cpp": app,
+                     "profile_host": profile_host})
+
+        self.t.run("install . %s -pr:b=default -pr:h=profile_host" % self._settings_str)
+
+        content = self.t.load("conan_meson_cross.ini")
+
+        self.assertIn("[host_machine]\n\n"
+                      "system = 'nes'\n"
+                      "cpu_family = 'MOS'\n"
+                      "cpu = '6502'\n"
+                      "endian = 'big", content)
+
+        self.assertIn("[build_machine]\n\n"
+                      "system = 'smd'\n"
+                      "cpu_family = 'Motorola'\n"
+                      "cpu = '68K'\n"
+                      "endian = 'big", content)
+
+        self.assertIn("[target_machine]\n\n"
+                      "system = 'spectrum'\n"
+                      "cpu_family = 'Zilog'\n"
+                      "cpu = 'Z80'\n"
+                      "endian = 'big", content)

--- a/conans/test/functional/toolchains/meson/test_conf.py
+++ b/conans/test/functional/toolchains/meson/test_conf.py
@@ -42,25 +42,25 @@ class MesonConfTest(TestMesonBase):
         app = gen_function_cpp(name="main", includes=["hello"], calls=["hello"])
 
         profile_host = textwrap.dedent("""
-    include(default)
-    [settings]
-    arch=armv8
-    os=FreeBSD
-    [conf]
-    tools.meson.mesontoolchain.host_machine:system=nes
-    tools.meson.mesontoolchain.host_machine:cpu_family=MOS
-    tools.meson.mesontoolchain.host_machine:cpu=6502
-    tools.meson.mesontoolchain.host_machine:endian=big
-    
-    tools.meson.mesontoolchain.build_machine:system=smd
-    tools.meson.mesontoolchain.build_machine:cpu_family=Motorola
-    tools.meson.mesontoolchain.build_machine:cpu=68K
-    tools.meson.mesontoolchain.build_machine:endian=big
-    
-    tools.meson.mesontoolchain.target_machine:system=spectrum
-    tools.meson.mesontoolchain.target_machine:cpu_family=Zilog
-    tools.meson.mesontoolchain.target_machine:cpu=Z80
-    tools.meson.mesontoolchain.target_machine:endian=big
+            include(default)
+            [settings]
+            arch=armv8
+            os=FreeBSD
+            [conf]
+            tools.meson.mesontoolchain.host_machine:system=nes
+            tools.meson.mesontoolchain.host_machine:cpu_family=MOS
+            tools.meson.mesontoolchain.host_machine:cpu=6502
+            tools.meson.mesontoolchain.host_machine:endian=big
+
+            tools.meson.mesontoolchain.build_machine:system=smd
+            tools.meson.mesontoolchain.build_machine:cpu_family=Motorola
+            tools.meson.mesontoolchain.build_machine:cpu=68K
+            tools.meson.mesontoolchain.build_machine:endian=big
+
+            tools.meson.mesontoolchain.target_machine:system=spectrum
+            tools.meson.mesontoolchain.target_machine:cpu_family=Zilog
+            tools.meson.mesontoolchain.target_machine:cpu=Z80
+            tools.meson.mesontoolchain.target_machine:endian=big
     """)
 
         self.t.save({"conanfile.py": self._conanfile_py,


### PR DESCRIPTION
closes: #8312

based on #8266

Changelog: Fix: Allow modification of system/cpu_family/cpu/endian in generated MesonToolchain toolchain file
Docs: omit

- [x] Refer to the issue that supports this Pull Request.
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 

<sup>**Note:** By default this PR will skip the slower tests and will use a limited set of python versions. Check [here](https://github.com/conan-io/conan/blob/develop/.github/PR_INCREASE_TESTING.md) how to increase the testing level by writing some tags in the current PR body text.</sup>
