### PR TITLE
Fix help message in command remove --outdated

### DIFF
--- a/conans/client/command.py
+++ b/conans/client/command.py
@@ -1091,7 +1091,7 @@ class Command(object):
                             help="Remove locks")
         parser.add_argument("-o", "--outdated", default=False, action="store_true",
                             help="Remove only outdated from recipe packages. "
-                                 "This flag can only be used with a reference")
+                                 "This flag can only be used with a pattern or a reference")
         parser.add_argument('-p', '--packages', nargs="*", action=Extender,
                             help="Remove all packages of the specified reference if "
                                  "no specific package ID is provided")


### PR DESCRIPTION
Changelog: Fix: Fixed help message in command `conan remove --outdated` with reference or pattern
Docs: https://github.com/conan-io/docs/pull/1988

- [x] Refer to the issue that supports this Pull Request: closes #8349
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [x] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 

<sup>**Note:** By default this PR will skip the slower tests and will use a limited set of python versions. Check [here](https://github.com/conan-io/conan/blob/develop/.github/PR_INCREASE_TESTING.md) how to increase the testing level by writing some tags in the current PR body text.</sup>
