### PR TITLE
BugFix: Gnu Triplet for profiles with custom os are wrong/should be able to be overriden from profile

### DIFF
--- a/conans/client/build/autotools_environment.py
+++ b/conans/client/build/autotools_environment.py
@@ -152,6 +152,11 @@ class AutoToolsBuildEnvironment(object):
 
         triplet_args = []
 
+        if hasattr(self._conanfile, "conf"):
+            build = self._conanfile.conf["tools.autotoolsbuildenvironment"].build or build
+            host = self._conanfile.conf["tools.autotoolsbuildenvironment"].host or host
+            target = self._conanfile.conf["tools.autotoolsbuildenvironment"].target or target
+
         if build is not False:  # Skipped by user
             if build or self.build:  # User specified value or automatic
                 triplet_args.append("--build=%s" % (build or self.build))

--- a/conans/test/functional/build_helpers/autotools_conf_test.py
+++ b/conans/test/functional/build_helpers/autotools_conf_test.py
@@ -1,0 +1,57 @@
+import os
+import stat
+import textwrap
+import unittest
+
+from conans.test.utils.tools import TestClient
+
+
+@unittest.skipUnless(os.name == 'posix', "requires posix environment")
+class AutoToolsConfTest(unittest.TestCase):
+    def test_conf(self):
+
+        profile = textwrap.dedent("""
+            include(default)
+            [conf]
+            tools.autotoolsbuildenvironment:host=arm-linux-gnueabihf
+            tools.autotoolsbuildenvironment:build=i386-kfreebsd-gnu
+            tools.autotoolsbuildenvironment:target=aarch64-none-elf
+            """)
+
+        configure = textwrap.dedent("""
+            #/usr/bin/env bash
+            echo $@
+            """)
+
+        conanfile_py = textwrap.dedent("""
+            from conans import ConanFile, tools, AutoToolsBuildEnvironment
+
+
+            class App(ConanFile):
+                settings = "os", "arch", "compiler", "build_type"
+                options = {"shared": [True, False], "fPIC": [True, False]}
+                default_options = {"shared": False, "fPIC": True}
+
+                def config_options(self):
+                    if self.settings.os == "Windows":
+                        del self.options.fPIC
+
+                def build(self):
+                    env_build = AutoToolsBuildEnvironment(self)
+                    env_build.configure()
+            """)
+
+        self.t = TestClient()
+        self.t.save({"conanfile.py": conanfile_py,
+                     "configure": configure,
+                     "profile": profile})
+
+        filename = os.path.join(self.t.current_folder, "configure")
+        os.chmod(filename, os.stat(filename).st_mode | stat.S_IXUSR)
+
+        self.t.run("install . --profile:host=profile")
+        self.t.run("build .")
+
+        self.assertIn("--host=arm-linux-gnueabihf", self.t.out)
+        self.assertIn("--build=i386-kfreebsd-gnu", self.t.out)
+        self.assertIn("--target=aarch64-none-elf", self.t.out)


### PR DESCRIPTION
closes: #8290
based on: #8266

Changelog: BugFix: Gnu Triplet for profiles with custom os are wrong/should be able to be overriden from profile
Docs: omit

- [x] Refer to the issue that supports this Pull Request.
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 

<sup>**Note:** By default this PR will skip the slower tests and will use a limited set of python versions. Check [here](https://github.com/conan-io/conan/blob/develop/.github/PR_INCREASE_TESTING.md) how to increase the testing level by writing some tags in the current PR body text.</sup>
