### PR TITLE
Feature: retry http requests with 5xx responses

### DIFF
--- a/conans/client/rest/conan_requester.py
+++ b/conans/client/rest/conan_requester.py
@@ -26,7 +26,7 @@ class ConanRequester(object):
             self._http_requester = http_requester
         else:
             self._http_requester = requests.Session()
-            adapter = HTTPAdapter(max_retries=self._get_retries(config.retry, config.retry_wait))
+            adapter = HTTPAdapter(max_retries=self._get_retries(config.retry))
 
             self._http_requester.mount("http://", adapter)
             self._http_requester.mount("https://", adapter)
@@ -63,7 +63,7 @@ class ConanRequester(object):
             else:
                 self._client_certificates = self._client_cert_path
 
-    def _get_retries(self, retry, retry_wait):
+    def _get_retries(self, retry):
         retry = retry if retry is not None else 2
         if retry == 0:
             return 0
@@ -78,6 +78,7 @@ class ConanRequester(object):
         }
         return urllib3.Retry(
             total=retry,
+            backoff_factor = 0.05,
             status_forcelist=retry_status_code_set
         )
 

--- a/conans/client/rest/conan_requester.py
+++ b/conans/client/rest/conan_requester.py
@@ -65,7 +65,6 @@ class ConanRequester(object):
 
     def _get_retries(self, retry, retry_wait):
         retry = retry if retry is not None else 2
-        retry_wait = retry_wait if retry_wait is not None else 5
         if retry == 0:
             return 0
         retry_status_code_set = {
@@ -79,7 +78,6 @@ class ConanRequester(object):
         }
         return urllib3.Retry(
             total=retry,
-            backoff_factor=(retry * retry_wait) / (2**(retry-1)),
             status_forcelist=retry_status_code_set
         )
 

--- a/conans/client/rest/conan_requester.py
+++ b/conans/client/rest/conan_requester.py
@@ -5,7 +5,6 @@ import platform
 import time
 import warnings
 
-import http
 import urllib3
 import requests
 from requests.adapters import HTTPAdapter
@@ -69,11 +68,15 @@ class ConanRequester(object):
         retry_wait = retry_wait if retry_wait is not None else 5
         if retry == 0:
             return 0
-        retry_status_code_set = set()
-        for status in http.HTTPStatus:
-            code = int(status)
-            if code // 100 == 5:
-                retry_status_code_set.add(code)
+        retry_status_code_set = {
+            requests.codes.internal_server_error,
+            requests.codes.bad_gateway,
+            requests.codes.service_unavailable,
+            requests.codes.gateway_timeout,
+            requests.codes.variant_also_negotiates,
+            requests.codes.insufficient_storage,
+            requests.codes.bandwidth_limit_exceeded
+        }
         return urllib3.Retry(
             total=retry,
             backoff_factor=(retry * retry_wait) / (2**(retry-1)),

--- a/conans/client/rest/conan_requester.py
+++ b/conans/client/rest/conan_requester.py
@@ -67,6 +67,8 @@ class ConanRequester(object):
     def _get_retries(self, retry, retry_wait):
         retry = retry if retry is not None else 2
         retry_wait = retry_wait if retry_wait is not None else 5
+        if retry == 0:
+            return 0
         retry_status_code_set = set()
         for status in http.HTTPStatus:
             code = int(status)


### PR DESCRIPTION
Changelog: Feature: Use built-in retries in requests lib to retry http requests with _5xx_ response code.
Closes: https://github.com/conan-io/conan/issues/8330
Docs: Omit

#tags: slow




- [x] Refer to the issue that supports this Pull Request.
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 

<sup>**Note:** By default this PR will skip the slower tests and will use a limited set of python versions. Check [here](https://github.com/conan-io/conan/blob/develop/.github/PR_INCREASE_TESTING.md) how to increase the testing level by writing some tags in the current PR body text.</sup>
