### PR TITLE
Pass profile to conan_v2 integration tests to avoid profile auto-detection

### DIFF
--- a/conans/test/integration/conan_v2/build_helpers/test_autotools.py
+++ b/conans/test/integration/conan_v2/build_helpers/test_autotools.py
@@ -17,14 +17,24 @@ class AutotoolsBuildHelperTestCase(ConanV2ModeTestCase):
                 autotools.make()
     """)
 
+    profile = textwrap.dedent("""
+        [settings]
+        os = Linux
+        arch = x86_64
+        build_type = Release
+        compiler=gcc
+        compiler.version=4.9
+        compiler.libcxx=libstdc++
+        """)
+
     def test_no_build_type(self):
         t = self.get_client()
-        t.save({"conanfile.py": self.conanfile.format("compiler")})
-        t.run("create . pkg/0.1@user/testing", assert_error=True)
+        t.save({"conanfile.py": self.conanfile.format("compiler"), "myprofile": self.profile})
+        t.run("create . pkg/0.1@user/testing -pr myprofile", assert_error=True)
         self.assertIn("Conan v2 incompatible: build_type setting should be defined.", t.out)
 
     def test_no_compiler(self):
         t = self.get_client()
-        t.save({"conanfile.py": self.conanfile.format("build_type")})
-        t.run("create . pkg/0.1@user/testing", assert_error=True)
+        t.save({"conanfile.py": self.conanfile.format("build_type"), "myprofile": self.profile})
+        t.run("create . pkg/0.1@user/testing  -pr myprofile", assert_error=True)
         self.assertIn("Conan v2 incompatible: compiler setting should be defined.", t.out)

--- a/conans/test/integration/conan_v2/build_helpers/test_cmake.py
+++ b/conans/test/integration/conan_v2/build_helpers/test_cmake.py
@@ -4,6 +4,15 @@ from conans.test.utils.conan_v2_tests import ConanV2ModeTestCase
 
 
 class CMakeBuildHelperTestCase(ConanV2ModeTestCase):
+    profile = textwrap.dedent("""
+        [settings]
+        os = Linux
+        arch = x86_64
+        build_type = Release
+        compiler=gcc
+        compiler.version=4.9
+        compiler.libcxx=libstdc++
+        """)
 
     def test_no_build_type(self):
         t = self.get_client()
@@ -15,8 +24,8 @@ class CMakeBuildHelperTestCase(ConanV2ModeTestCase):
                     cmake = CMake(self)
                     cmake.build()
         """)
-        t.save({"conanfile.py": conanfile})
-        t.run("create . pkg/0.1@user/testing", assert_error=True)
+        t.save({"conanfile.py": conanfile, "myprofile": self.profile})
+        t.run("create . pkg/0.1@user/testing -pr myprofile", assert_error=True)
         self.assertIn("Conan v2 incompatible: build_type setting should be defined.", t.out)
 
     def test_no_compiler(self):
@@ -30,8 +39,8 @@ class CMakeBuildHelperTestCase(ConanV2ModeTestCase):
                     cmake = CMake(self)
                     cmake.build()
         """)
-        t.save({"conanfile.py": conanfile})
-        t.run("create . pkg/0.1@user/testing", assert_error=True)
+        t.save({"conanfile.py": conanfile, "myprofile": self.profile})
+        t.run("create . pkg/0.1@user/testing -pr myprofile", assert_error=True)
         self.assertIn("Conan v2 incompatible: compiler setting should be defined.", t.out)
 
     def test_toolchain_no_build_type(self):
@@ -40,11 +49,11 @@ class CMakeBuildHelperTestCase(ConanV2ModeTestCase):
             from conans import ConanFile, CMake
             class Pkg(ConanFile):
                 toolchain = "cmake"
-    
+
                 def build(self):
                     cmake = CMake(self)
                     cmake.build()
         """)
-        t.save({"conanfile.py": conanfile})
-        t.run("create . pkg/0.1@user/testing", assert_error=True)
+        t.save({"conanfile.py": conanfile, "myprofile": self.profile})
+        t.run("create . pkg/0.1@user/testing -pr myprofile", assert_error=True)
         self.assertIn("Conan v2 incompatible: build_type setting should be defined.", t.out)

--- a/conans/test/integration/conan_v2/build_helpers/test_meson.py
+++ b/conans/test/integration/conan_v2/build_helpers/test_meson.py
@@ -4,6 +4,15 @@ from conans.test.utils.conan_v2_tests import ConanV2ModeTestCase
 
 
 class MesonBuildHelperTestCase(ConanV2ModeTestCase):
+    profile = textwrap.dedent("""
+        [settings]
+        os = Linux
+        arch = x86_64
+        build_type = Release
+        compiler=gcc
+        compiler.version=4.9
+        compiler.libcxx=libstdc++
+        """)
 
     def test_no_build_type(self):
         t = self.get_client()
@@ -15,8 +24,8 @@ class MesonBuildHelperTestCase(ConanV2ModeTestCase):
                      meson = Meson(self)
                      meson.build()
         """)
-        t.save({"conanfile.py": conanfile})
-        t.run("create . pkg/0.1@user/testing", assert_error=True)
+        t.save({"conanfile.py": conanfile, "myprofile": self.profile})
+        t.run("create . pkg/0.1@user/testing -pr myprofile", assert_error=True)
         self.assertIn("Conan v2 incompatible: build_type setting should be defined.", t.out)
 
     def test_no_compiler(self):
@@ -30,6 +39,6 @@ class MesonBuildHelperTestCase(ConanV2ModeTestCase):
                      meson = Meson(self)
                      meson.build()
         """)
-        t.save({"conanfile.py": conanfile})
-        t.run("create . pkg/0.1@user/testing", assert_error=True)
+        t.save({"conanfile.py": conanfile, "myprofile": self.profile})
+        t.run("create . pkg/0.1@user/testing -pr myprofile", assert_error=True)
         self.assertIn("Conan v2 incompatible: compiler setting should be defined.", t.out)


### PR DESCRIPTION
Changelog: omit
Docs: omit

Tests won't really use the compiler but they need a profile to avoid auto-detection so they can remain as integration tests.
