### PR TITLE
Fix SCM by making user and password url-encoded

### DIFF
--- a/conans/client/tools/scm.py
+++ b/conans/client/tools/scm.py
@@ -77,20 +77,25 @@ class SCMBase(object):
             return "{scheme}://{url}".format(scheme=scheme, url=url)
         elif scheme == "ssh" and self._password:
             self._output.warn("SCM password cannot be set for ssh url, ignoring parameter")
+        elif password and self._password:
+            self._output.warn("SCM password got from URL, ignoring 'password' parameter")
 
         if user and self._username:
             self._output.warn("SCM username got from URL, ignoring 'username' parameter")
-        if password and self._password:
-            self._output.warn("SCM password got from URL, ignoring 'password' parameter")
 
-        the_user = quote_plus(user or self._username)
-        the_password = quote_plus(password or self._password)
+        the_user = user or self._username
+        the_password = password or self._password
 
         if the_password and the_user and scheme != "ssh":
-            return "{scheme}://{user}:{password}@{url}".format(scheme=scheme, user=the_user,
-                                                               password=the_password, url=url)
+            return "{scheme}://{user}:{password}@{url}".format(scheme=scheme,
+                                                               user=quote_plus(the_user),
+                                                               password=quote_plus(the_password),
+                                                               url=url)
         elif the_user:
-            return "{scheme}://{user}@{url}".format(scheme=scheme, user=the_user, url=url)
+            if scheme == "ssh" and password:
+                self._output.warn("Password in URL cannot be set for 'ssh' SCM type, removing it")
+            return "{scheme}://{user}@{url}".format(scheme=scheme, user=quote_plus(the_user),
+                                                    url=url)
         else:
             return "{scheme}://{url}".format(scheme=scheme, url=url)
 
@@ -99,8 +104,8 @@ class SCMBase(object):
             return url
 
         scp_regex = re.compile("^(?P<user>[a-zA-Z0-9_]+)@(?P<domain>[a-zA-Z0-9._-]+):(?P<url>.*)$")
-        url_user_pass_regex = re.compile("^(?P<scheme>file|http|https|git):\/\/(?P<user>\S+):(?P<password>\S+)@(?P<url>.*)$")
-        url_user_regex = re.compile("^(?P<scheme>file|http|https|git|ssh):\/\/(?P<user>\S+)@(?P<url>.*)$")
+        url_user_pass_regex = re.compile("^(?P<scheme>file|http|https|git|ssh):\/\/(?P<user>\w+):(?P<password>\w+)@(?P<url>.*)$")
+        url_user_regex = re.compile("^(?P<scheme>file|http|https|git|ssh):\/\/(?P<user>\w+)@(?P<url>.*)$")
         url_basic_regex = re.compile("^(?P<scheme>file|http|https|git|ssh):\/\/(?P<url>.*)$")
 
         url_patterns = [

--- a/conans/client/tools/scm.py
+++ b/conans/client/tools/scm.py
@@ -69,11 +69,16 @@ class SCMBase(object):
         return "{user}@{domain}:{url}".format(user=user, domain=domain, url=url)
 
     def _handle_url_pattern(self, scheme, url, user=None, password=None):
-        if scheme == "file":
+        if scheme in ["file", "git"]:
             if self._username:
-                self._output.warn("SCM username cannot be set for file url, ignoring parameter")
+                self._output.warn("SCM username cannot be set for {} url, ignoring "
+                                  "parameter".format(scheme))
             if self._password:
-                self._output.warn("SCM password cannot be set for file url, ignoring parameter")
+                self._output.warn("SCM password cannot be set for {} url, ignoring "
+                                  "parameter".format(scheme))
+            if user or password:
+                self._output.warn("Username/Password in URL cannot be set for '{}' SCM type, "
+                                  "removing it".format(scheme))
             return "{scheme}://{url}".format(scheme=scheme, url=url)
         elif scheme == "ssh" and self._password:
             self._output.warn("SCM password cannot be set for ssh url, ignoring parameter")

--- a/conans/client/tools/scm.py
+++ b/conans/client/tools/scm.py
@@ -83,8 +83,9 @@ class SCMBase(object):
         if password and self._password:
             self._output.warn("SCM password got from URL, ignoring 'password' parameter")
 
-        the_user = user or self._username
-        the_password = password or self._password
+        the_user = quote_plus(user or self._username)
+        the_password = quote_plus(password or self._password)
+
         if the_password and the_user and scheme != "ssh":
             return "{scheme}://{user}:{password}@{url}".format(scheme=scheme, user=the_user,
                                                                password=the_password, url=url)

--- a/conans/test/unittests/client/tools/scm/test_scm_base.py
+++ b/conans/test/unittests/client/tools/scm/test_scm_base.py
@@ -102,6 +102,11 @@ class GetUrlWithCredentialsTest(unittest.TestCase):
         self.assertEqual('https://user:pass@github.com/conan-io/conan.git',
                          scm.get_url_with_credentials("https://github.com/conan-io/conan.git"))
 
+    def test_url_with_user_password_characters_param(self):
+        scm = SCMBase(username="el niño", password="la contra%seña")
+        self.assertEqual('https://el+ni%C3%B1o:la+contra%25se%C3%B1a@github.com/conan-io/conan.git',
+                         scm.get_url_with_credentials("https://github.com/conan-io/conan.git"))
+
     def test_url_user_with_user_param(self):
         output = OutputMock()
         scm = SCMBase(username="user", output=output)

--- a/conans/test/unittests/client/tools/scm/test_scm_base.py
+++ b/conans/test/unittests/client/tools/scm/test_scm_base.py
@@ -286,3 +286,42 @@ class GetUrlWithCredentialsTest(unittest.TestCase):
                       output.out)
         self.assertIn("WARN: SCM password cannot be set for file url, ignoring parameter",
                       output.out)
+
+    def test_git(self):
+        scm = SCMBase()
+        self.assertEqual('git://github.com/conan-io/conan.git',
+                         scm.get_url_with_credentials("git://github.com/conan-io/conan.git"))
+
+    def test_git_only_password(self):
+        output = OutputMock()
+        scm = SCMBase(password="pass", output=output)
+        self.assertEqual("git://github.com/conan-io/conan.git",
+                         scm.get_url_with_credentials("git://github.com/conan-io/conan.git"))
+        self.assertIn("WARN: SCM password cannot be set for git url, ignoring parameter", output.out)
+
+    def test_git_only_username(self):
+        output = OutputMock()
+        scm = SCMBase(username="dani", output=output)
+        self.assertEqual("git://github.com/conan-io/conan.git",
+                         scm.get_url_with_credentials("git://github.com/conan-io/conan.git"))
+        self.assertIn("WARN: SCM username cannot be set for git url, ignoring parameter", output.out)
+
+    def test_git_username_password(self):
+        output = OutputMock()
+        scm = SCMBase(password="pass", username="dani", output=output)
+        self.assertEqual("git://github.com/conan-io/conan.git",
+                         scm.get_url_with_credentials("git://github.com/conan-io/conan.git"))
+        self.assertEqual(2, len(output.out))
+        self.assertIn("WARN: SCM password cannot be set for git url, ignoring parameter", output.out)
+        self.assertIn("WARN: SCM password cannot be set for git url, ignoring parameter", output.out)
+
+    def test_git_url_username_password(self):
+        output = OutputMock()
+        scm = SCMBase(password="pass", output=output)
+        self.assertEqual("git://github.com/conan-io/conan.git",
+                         scm.get_url_with_credentials(
+                             "git://user:pass@github.com/conan-io/conan.git"))
+        self.assertEqual(2, len(output.out))
+        self.assertIn("WARN: SCM password cannot be set for git url, ignoring parameter", output.out)
+        self.assertIn("WARN: Username/Password in URL cannot be set for 'git' SCM type, removing it",
+                      output.out)

--- a/conans/test/unittests/client/tools/scm/test_scm_base.py
+++ b/conans/test/unittests/client/tools/scm/test_scm_base.py
@@ -209,28 +209,33 @@ class GetUrlWithCredentialsTest(unittest.TestCase):
     def test_ssh_url_with_username_password_and_only_password(self):
         output = OutputMock()
         scm = SCMBase(password="password", output=output)
-        self.assertEqual('ssh://git:pass@github.com/conan-io/conan.git',
+        self.assertEqual('ssh://git@github.com/conan-io/conan.git',
                          scm.get_url_with_credentials("ssh://git:pass@github.com/conan-io/conan.git"))
-        self.assertEqual(1, len(output.out))
+        self.assertEqual(2, len(output.out))
         self.assertIn("WARN: SCM password cannot be set for ssh url, ignoring parameter", output.out)
+        self.assertIn("WARN: Password in URL cannot be set for 'ssh' SCM type, removing it",
+                      output.out)
 
     def test_ssh_url_with_username_password_and_only_username(self):
         output = OutputMock()
         scm = SCMBase(username="dani", output=output)
-        self.assertEqual('ssh://git:pass@github.com/conan-io/conan.git',
+        self.assertEqual('ssh://git@github.com/conan-io/conan.git',
                          scm.get_url_with_credentials("ssh://git:pass@github.com/conan-io/conan.git"))
-        self.assertEqual(1, len(output.out))
-        self.assertIn("WARN: SCM username got from URL, ignoring 'username' parameter",
+        self.assertEqual(2, len(output.out))
+        self.assertIn("WARN: SCM username got from URL, ignoring 'username' parameter", output.out)
+        self.assertIn("WARN: Password in URL cannot be set for 'ssh' SCM type, removing it",
                       output.out)
 
     def test_ssh_url_with_username_password_and_username_password(self):
         output = OutputMock()
         scm = SCMBase(password="password", username="dani", output=output)
-        self.assertEqual("ssh://git:pass@github.com/conan-io/conan.git",
+        self.assertEqual("ssh://git@github.com/conan-io/conan.git",
                          scm.get_url_with_credentials("ssh://git:pass@github.com/conan-io/conan.git"))
-        self.assertEqual(2, len(output.out))
+        self.assertEqual(3, len(output.out))
         self.assertIn("WARN: SCM password cannot be set for ssh url, ignoring parameter", output.out)
         self.assertIn("WARN: SCM username got from URL, ignoring 'username' parameter", output.out)
+        self.assertIn("WARN: Password in URL cannot be set for 'ssh' SCM type, removing it",
+                      output.out)
 
     def test_scp(self):
         scm = SCMBase()


### PR DESCRIPTION
Changelog: BugFix: Fix SCM user and password by making them url-encoded
Docs: omit

- [x] Refer to the issue that supports this Pull Request: closes #8224
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [x] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 

<sup>**Note:** By default this PR will skip the slower tests and will use a limited set of python versions. Check [here](https://github.com/conan-io/conan/blob/develop/.github/PR_INCREASE_TESTING.md) how to increase the testing level by writing some tags in the current PR body text.</sup>
