### PR TITLE
Fix package-id-unknown issues with package_revision_mode and full_transitive_package_id

### DIFF
--- a/conans/client/graph/graph_binaries.py
+++ b/conans/client/graph/graph_binaries.py
@@ -315,6 +315,7 @@ class GraphBinariesAnalyzer(object):
         neighbors = node.neighbors()
 
         direct_reqs, indirect_reqs = self.package_id_transitive_reqs(node)
+        print("NODE ", node, "TRANSITIVE REQS ", [(r, r.revision) for r in direct_reqs], indirect_reqs)
 
         # FIXME: Conan v2.0 This is introducing a bug for backwards compatibility, it will add
         #   only the requirements available in the 'neighbour.info' object, not all the closure

--- a/conans/client/graph/graph_binaries.py
+++ b/conans/client/graph/graph_binaries.py
@@ -315,7 +315,6 @@ class GraphBinariesAnalyzer(object):
         neighbors = node.neighbors()
 
         direct_reqs, indirect_reqs = self.package_id_transitive_reqs(node)
-        print("NODE ", node, "TRANSITIVE REQS ", [(r, r.revision) for r in direct_reqs], indirect_reqs)
 
         # FIXME: Conan v2.0 This is introducing a bug for backwards compatibility, it will add
         #   only the requirements available in the 'neighbour.info' object, not all the closure

--- a/conans/client/installer.py
+++ b/conans/client/installer.py
@@ -511,6 +511,10 @@ class BinaryInstaller(object):
                     output.success('Already installed!')
                     log_package_got_from_local_cache(pref)
                     self._recorder.package_fetched_from_cache(pref)
+            else:
+
+                print("********************** ", node, " in processed, skipping its update")
+                print(pref.full_str(), [p.full_str() for p in processed_package_references])
 
             package_folder = layout.package(pref)
             assert os.path.isdir(package_folder), ("Package '%s' folder must exist: %s\n"

--- a/conans/test/integration/package_id/full_revision_mode_test.py
+++ b/conans/test/integration/package_id/full_revision_mode_test.py
@@ -326,14 +326,14 @@ def test_package_revision_mode_full_transitive_package_id():
     client = TestClient()
     client.run("config set general.default_package_id_mode=package_revision_mode")
     client.run("config set general.full_transitive_package_id=1")
-    client.save({"pkga/conanfile.py": GenConanfile(),
-                 "pkgb/conanfile.py": GenConanfile().with_require("pkga/0.1"),
-                 "pkgc/conanfile.py": GenConanfile().with_require("pkgb/0.1"),
-                 "pkgd/conanfile.py": GenConanfile().with_require("pkgc/0.1")})
+    client.save({"tool/conanfile.py": GenConanfile(),
+                 "pkga/conanfile.py": GenConanfile(),
+                 "pkgb/conanfile.py": GenConanfile().with_requires("tool/0.1", "pkga/0.1"),
+                 "profile": "[build_requires]\ntool/0.1"})
+    client.run("export tool tool/0.1@")
     client.run("export pkga pkga/0.1@")
-    client.run("export pkgb pkgb/0.1@")
-    client.run("export pkgc pkgc/0.1@")
-    client.run("create pkgd pkgd/0.1@ --build=missing")
+    client.run("create pkgb pkgb/0.1@ -pr=profile --build=missing")
+    print(client.out)
     assert "pkgc/0.1:Package_ID_unknown - Unknown" in client.out
     assert "pkgc/0.1: Unknown binary for pkgc/0.1, computing updated ID" in client.out
     assert "pkgc/0.1: Package '1d602da5278b24bf3aa0e19e6e199126cdfb7094' created" in client.out

--- a/conans/test/integration/package_id/full_revision_mode_test.py
+++ b/conans/test/integration/package_id/full_revision_mode_test.py
@@ -333,7 +333,6 @@ def test_package_revision_mode_full_transitive_package_id():
     client.run("export tool tool/0.1@")
     client.run("export pkga pkga/0.1@")
     client.run("create pkgb pkgb/0.1@ -pr=profile --build=missing")
-    print(client.out)
-    assert "pkgc/0.1:Package_ID_unknown - Unknown" in client.out
-    assert "pkgc/0.1: Unknown binary for pkgc/0.1, computing updated ID" in client.out
-    assert "pkgc/0.1: Package '1d602da5278b24bf3aa0e19e6e199126cdfb7094' created" in client.out
+    assert "pkgb/0.1:Package_ID_unknown - Unknown" in client.out
+    assert "pkgb/0.1: Unknown binary for pkgb/0.1, computing updated ID" in client.out
+    assert "pkgb/0.1: Package 'f524f1981a44932e1445e13ae4cf9e2ff8112027' created" in client.out


### PR DESCRIPTION
Changelog: Bugfix: Solved ``assert node.package_id != PACKAGE_ID_UNKNOWN`` assertion that happened when using ``build_requires`` that also exist in ``requires``, and using ``package_revision_mode`` and ``full_transitive_package_id=1``
Docs: Omit

Close https://github.com/conan-io/conan/issues/8310
