### PR TITLE
removing warnings for toolchain imports

### DIFF
--- a/conan/tools/cmake/base.py
+++ b/conan/tools/cmake/base.py
@@ -1,5 +1,4 @@
 import textwrap
-import warnings
 from collections import OrderedDict, defaultdict
 
 from jinja2 import DictLoader, Environment
@@ -163,21 +162,6 @@ class CMakeToolchainBase(object):
             "build_type": self.build_type,
         }
         return ctxt_toolchain
-
-    def write_toolchain_files(self):
-        # Warning
-        msg = ("\n*****************************************************************\n"
-               "******************************************************************\n"
-               "'write_toolchain_files()' has been deprecated and moved.\n"
-               "It will be removed in next Conan release.\n"
-               "Use 'generate()' method instead.\n"
-               "********************************************************************\n"
-               "********************************************************************\n")
-        from conans.client.output import Color, ConanOutput
-        ConanOutput(self._conanfile.output._stream,
-                    color=self._conanfile.output._color).writeln(msg, front=Color.BRIGHT_RED)
-        warnings.warn(msg)
-        self.generate()
 
     def generate(self):
         # Prepare templates to be loaded

--- a/conan/tools/gnu/make.py
+++ b/conan/tools/gnu/make.py
@@ -1,8 +1,5 @@
-# coding=utf-8
-
 import platform
 import textwrap
-import warnings
 from collections import OrderedDict
 
 from jinja2 import Template
@@ -61,21 +58,6 @@ class MakeToolchain(object):
             os_build = detected_os() or platform.system()
             arch_build = detected_architecture() or platform.machine()
         return arch_build, os_build
-
-    def write_toolchain_files(self):
-        # Warning
-        msg = ("\n*****************************************************************\n"
-               "******************************************************************\n"
-               "'write_toolchain_files()' has been deprecated and moved.\n"
-               "It will be removed in next Conan release.\n"
-               "Use 'generate()' method instead.\n"
-               "********************************************************************\n"
-               "********************************************************************\n")
-        from conans.client.output import Color, ConanOutput
-        ConanOutput(self._conanfile.output._stream,
-                    color=self._conanfile.output._color).writeln(msg, front=Color.BRIGHT_RED)
-        warnings.warn(msg)
-        self.generate()
 
     def generate(self):
         save(self.filename, self.content)

--- a/conan/tools/microsoft/toolchain.py
+++ b/conan/tools/microsoft/toolchain.py
@@ -1,6 +1,5 @@
 import os
 import textwrap
-import warnings
 from xml.dom import minidom
 
 from conans.errors import ConanException
@@ -29,21 +28,6 @@ class MSBuildToolchain(object):
         name = "".join("_%s" % v for _, v in props if v is not None)
         condition = " And ".join("'$(%s)' == '%s'" % (k, v) for k, v in props if v is not None)
         return name.lower(), condition
-
-    def write_toolchain_files(self):
-        # Warning
-        msg = ("\n*****************************************************************\n"
-               "******************************************************************\n"
-               "'write_toolchain_files()' has been deprecated and moved.\n"
-               "It will be removed in next Conan release.\n"
-               "Use 'generate()' method instead.\n"
-               "********************************************************************\n"
-               "********************************************************************\n")
-        from conans.client.output import Color, ConanOutput
-        ConanOutput(self._conanfile.output._stream,
-                    color=self._conanfile.output._color).writeln(msg, front=Color.BRIGHT_RED)
-        warnings.warn(msg)
-        self.generate()
 
     def generate(self):
         name, condition = self._name_condition(self._conanfile.settings)
@@ -100,8 +84,8 @@ class MSBuildToolchain(object):
 
     def _write_config_toolchain(self, config_filename):
 
-        def format_macro(k, value):
-            return '%s="%s"' % (k, value) if value is not None else k
+        def format_macro(key, value):
+            return '%s="%s"' % (key, value) if value is not None else key
 
         toolchain_file = textwrap.dedent("""\
             <?xml version="1.0" encoding="utf-8"?>

--- a/conans/__init__.py
+++ b/conans/__init__.py
@@ -1,7 +1,3 @@
-# Allow conans to import ConanFile from here
-# to allow refactors
-import warnings
-
 from conans.client.build.autotools_environment import AutoToolsBuildEnvironment
 from conans.client.build.cmake import CMake
 from conans.client.build.meson import Meson
@@ -12,70 +8,6 @@ from conans.model.conan_file import ConanFile
 from conans.model.options import Options
 from conans.model.settings import Settings
 from conans.util.files import load
-
-
-try:
-    from conan.tools.gnu import MakeToolchain as _MakeToolchain
-    from conans.client.output import Color, ConanOutput
-    class MakeToolchain(_MakeToolchain):
-        def __init__(self, conanfile, *args, **kwargs):
-            msg = ("\n*****************************************************************\n"
-                   "*****************************************************************\n"
-                   "'from conans import MakeToolchain' has been deprecated and moved.\n"
-                   "It will be removed in next Conan release.\n"
-                   "Use 'from conan.tools.gnu import MakeToolchain' instead.\n"
-                   "*****************************************************************\n"
-                   "*****************************************************************\n")
-            ConanOutput(conanfile.output._stream,
-                        color=conanfile.output._color).writeln(msg, front=Color.BRIGHT_RED)
-            warnings.warn(msg)
-            super(MakeToolchain, self).__init__(conanfile, *args, **kwargs)
-except ImportError:
-    class MakeToolchain(object):
-        def __init__(self, conanfile, *args, **kwargs):
-            raise Exception("Python 2.7 is no longer supported for MakeToolchain")
-
-
-try:
-    from conan.tools.microsoft import MSBuildToolchain as _MSBuildToolchain
-    from conans.client.output import Color, ConanOutput
-    class MSBuildToolchain(_MSBuildToolchain):
-        def __init__(self, conanfile, *args, **kwargs):
-            msg = ("\n*****************************************************************\n"
-                   "*****************************************************************\n"
-                   "'from conans import MSBuildToolchain' has been deprecated and moved.\n"
-                   "It will be removed in next Conan release.\n"
-                   "Use 'from conan.tools.microsoft import MSBuildToolchain' instead.\n"
-                   "*****************************************************************\n"
-                   "*****************************************************************\n")
-            ConanOutput(conanfile.output._stream,
-                        color=conanfile.output._color).writeln(msg, front=Color.BRIGHT_RED)
-            warnings.warn(msg)
-            super(MSBuildToolchain, self).__init__(conanfile, *args, **kwargs)
-except ImportError:
-    class MSBuildToolchain(object):
-        def __init__(self, conanfile, *args, **kwargs):
-            raise Exception("Python 2.7 is no longer supported for MSBuildToolchain")
-
-
-def CMakeToolchain(conanfile, **kwargs):
-    # Warning
-    msg = ("\n*****************************************************************\n"
-           "*****************************************************************\n"
-           "'from conans import CMakeToolchain' has been deprecated and moved.\n"
-           "It will be removed in next Conan release.\n"
-           "Use 'from conan.tools.cmake import CMakeToolchain' instead.\n"
-           "*****************************************************************\n"
-           "*****************************************************************\n")
-    from conans.client.output import Color, ConanOutput
-    ConanOutput(conanfile.output._stream,
-                color=conanfile.output._color).writeln(msg, front=Color.BRIGHT_RED)
-    warnings.warn(msg)
-    try:
-        from conan.tools.cmake import CMakeToolchain as _CMakeToolchain
-        return _CMakeToolchain(conanfile, **kwargs)
-    except ImportError:
-        raise Exception("Python 2.7 is no longer supported for CMakeToolchain")
 
 
 # complex_search: With ORs and not filtering by not restricted settings

--- a/conans/client/generators/__init__.py
+++ b/conans/client/generators/__init__.py
@@ -1,8 +1,6 @@
 import traceback
-import warnings
 from os.path import join
 
-from conan.tools.cmake import CMakeToolchain
 from conans.client.generators.cmake_find_package import CMakeFindPackageGenerator
 from conans.client.generators.cmake_find_package_multi import CMakeFindPackageMultiGenerator
 from conans.client.generators.compiler_args import CompilerArgsGenerator
@@ -180,29 +178,11 @@ def write_toolchain(conanfile, path, output):
     if hasattr(conanfile, "toolchain"):
         msg = ("\n*****************************************************************\n"
                "******************************************************************\n"
-               "The 'toolchain' attribute or method has been deprecated.\n"
-               "It will be removed in next Conan release.\n"
+               "The 'toolchain' attribute or method has been deprecated and removed\n"
                "Use 'generators = \"ClassName\"' or 'generate()' method instead.\n"
                "********************************************************************\n"
                "********************************************************************\n")
-        output.warn(msg)
-        warnings.warn(msg)
-        output.highlight("Generating toolchain files")
-        if callable(conanfile.toolchain):
-            # This is the toolchain
-            with chdir(path):
-                with conanfile_exception_formatter(str(conanfile), "toolchain"):
-                    conanfile.toolchain()
-        else:
-            try:
-                toolchain = {"cmake": CMakeToolchain}[conanfile.toolchain]
-            except KeyError:
-                raise ConanException("Unknown toolchain '%s'" % conanfile.toolchain)
-            tc = toolchain(conanfile)
-            with chdir(path):
-                tc.generate()
-
-        # TODO: Lets discuss what to do with the environment
+        raise ConanException(msg)
 
     if hasattr(conanfile, "generate"):
         output.highlight("Calling generate()")

--- a/conans/test/functional/build_helpers/cmake_test.py
+++ b/conans/test/functional/build_helpers/cmake_test.py
@@ -28,7 +28,6 @@ class CMakeBuildHelper(unittest.TestCase):
         conanfile = textwrap.dedent("""
         from conans import ConanFile, CMake
         class Pkg(ConanFile):
-            toolchain = "cmake"
 
             def build(self):
                 self.output.info("CMAKE_VERSION: %s" % CMake.get_version())
@@ -37,46 +36,5 @@ class CMakeBuildHelper(unittest.TestCase):
         """)
         client.save({"conanfile.py": conanfile})
         client.run("create . pkg/0.1@user/testing")
-        self.assertIn("CMAKE_VERSION: 3", client.out)
-        self.assertIn("CMAKE_VERSION (obj): 3", client.out)
-
-    def test_inheriting_cmake_build_helper_no_toolchain(self):
-        # https://github.com/conan-io/conan/issues/7196
-        base = textwrap.dedent("""
-            import conans
-            class CMake(conans.CMake):
-                pass
-            class BaseConanFile(conans.ConanFile):
-                def build(self):
-                    self.output.info("CMAKE_VERSION: %s" % conans.CMake.get_version())
-                    cmake = CMake(self)
-                    self.output.info("CMAKE_VERSION (obj): %s" % cmake.get_version())
-        """)
-
-        client = TestClient()
-        client.save({"conanfile.py": base})
-        client.run("create . pkg/0.1@")
-        self.assertIn("pkg/0.1: Exported revision", client.out)
-        self.assertIn("CMAKE_VERSION: 3", client.out)
-        self.assertIn("CMAKE_VERSION (obj): 3", client.out)
-
-    def test_inheriting_cmake_build_helper_toolchain(self):
-        # https://github.com/conan-io/conan/issues/7196
-        base = textwrap.dedent("""
-            import conans
-            class CMake(conans.CMake):
-                pass
-            class BaseConanFile(conans.ConanFile):
-                toolchain = "cmake"
-                def build(self):
-                    self.output.info("CMAKE_VERSION: %s" % conans.CMake.get_version())
-                    cmake = CMake(self)
-                    self.output.info("CMAKE_VERSION (obj): %s" % cmake.get_version())
-        """)
-
-        client = TestClient()
-        client.save({"conanfile.py": base})
-        client.run("create . pkg/0.1@")
-        self.assertIn("pkg/0.1: Exported revision", client.out)
         self.assertIn("CMAKE_VERSION: 3", client.out)
         self.assertIn("CMAKE_VERSION (obj): 3", client.out)

--- a/conans/test/functional/toolchains/test_basic.py
+++ b/conans/test/functional/toolchains/test_basic.py
@@ -1,11 +1,8 @@
-# coding=utf-8
 import os
-import platform
 import textwrap
 import unittest
 
 import pytest
-import six
 
 from conans.test.utils.tools import TestClient
 from conans.util.files import save
@@ -99,92 +96,6 @@ class BasicTest(unittest.TestCase):
         self.assertIn('-DCMAKE_TOOLCHAIN_FILE="conan_toolchain.cmake"',  client.out)
         self.assertIn("ERROR: conanfile.py: Error in build() method", client.out)
 
-    @pytest.mark.skipif(six.PY2, reason="The import to sibling fails in Python2")
-    def test_old_cmake_tools_imports(self):
-        conanfile = textwrap.dedent("""
-           from conans import ConanFile, CMakeToolchain, CMake
-           class Pkg(ConanFile):
-               def generate(self):
-                   tc = CMakeToolchain(self)
-                   tc.generate()
-               def build(self):
-                   cmake = CMake(self)
-                   cmake.configure()
-           """)
-        client = TestClient()
-        client.save({"conanfile.py": conanfile})
-        client.run("install .")
-        self.assertIn("'from conans import CMakeToolchain' has been deprecated and moved",
-                      client.out)
-        client.run("build .", assert_error=True)  # No CMakeLists.txt
-        self.assertIn("This 'CMake' build helper has been deprecated and moved.", client.out)
-        self.assertIn('-DCMAKE_TOOLCHAIN_FILE="conan_toolchain.cmake"', client.out)
-        self.assertIn("ERROR: conanfile.py: Error in build() method", client.out)
-
-    @pytest.mark.skipif(six.PY2, reason="The import to sibling fails in Python2")
-    @pytest.mark.skipif(platform.system() != "Windows", reason="msbuild requires Windows")
-    def test_old_msbuild_tools_imports(self):
-        conanfile = textwrap.dedent("""
-            from conans import ConanFile, MSBuildToolchain, MSBuild
-            class Pkg(ConanFile):
-                settings = "os", "compiler", "arch", "build_type"
-                def generate(self):
-                   tc = MSBuildToolchain(self)
-                   tc.generate()
-                def build(self):
-                   msbuild = MSBuild(self)
-                   msbuild.build("Project.sln")
-            """)
-        client = TestClient()
-        client.save({"conanfile.py": conanfile})
-        client.run("install .")
-        self.assertIn("'from conans import MSBuildToolchain' has been deprecated and moved",
-                      client.out)
-        client.run("build .", assert_error=True)  # No CMakeLists.txt
-        self.assertIn("This 'MSBuild' build helper has been deprecated and moved.", client.out)
-        self.assertIn("ERROR: conanfile.py: Error in build() method", client.out)
-
-    @pytest.mark.tool_compiler
-    @pytest.mark.skipif(six.PY2, reason="The import to sibling fails in Python2")
-    def test_old_gnu_tools_imports(self):
-        conanfile = textwrap.dedent("""
-            from conans import ConanFile, MakeToolchain
-            class Pkg(ConanFile):
-                settings = "os", "compiler", "arch", "build_type"
-                def generate(self):
-                   tc = MakeToolchain(self)
-                   tc.generate()
-            """)
-        client = TestClient()
-        client.save({"conanfile.py": conanfile})
-        client.run("install .")
-        self.assertIn("'from conans import MakeToolchain' has been deprecated and moved",
-                      client.out)
-
-    @pytest.mark.tool_compiler
-    @pytest.mark.skipif(six.PY2, reason="The import to sibling fails in Python2")
-    def test_old_write_toolchain_files(self):
-        conanfile = textwrap.dedent("""
-               from conans import ConanFile
-               from conan.tools.gnu import MakeToolchain
-               from conan.tools.cmake import CMakeToolchain
-               from conan.tools.microsoft import MSBuildToolchain
-               class Pkg(ConanFile):
-                   settings = "os", "compiler", "arch", "build_type"
-                   def generate(self):
-                      tc = MakeToolchain(self)
-                      tc.write_toolchain_files()
-                      tc = CMakeToolchain(self)
-                      tc.write_toolchain_files()
-                      tc = MSBuildToolchain(self)
-                      tc.write_toolchain_files()
-               """)
-        client = TestClient()
-        client.save({"conanfile.py": conanfile})
-        client.run("install .")
-        self.assertEqual(3, str(client.out).count("'write_toolchain_files()' "
-                                                  "has been deprecated and moved"))
-
     def test_old_toolchain(self):
         conanfile = textwrap.dedent("""
             from conans import ConanFile
@@ -193,7 +104,7 @@ class BasicTest(unittest.TestCase):
             """)
         client = TestClient()
         client.save({"conanfile.py": conanfile})
-        client.run("install .")
+        client.run("install .", assert_error=True)
         self.assertIn("The 'toolchain' attribute or method has been deprecated", client.out)
 
     def test_old_toolchain_method(self):
@@ -205,7 +116,7 @@ class BasicTest(unittest.TestCase):
             """)
         client = TestClient()
         client.save({"conanfile.py": conanfile})
-        client.run("install .")
+        client.run("install .", assert_error=True)
         self.assertIn("The 'toolchain' attribute or method has been deprecated", client.out)
 
     def test_toolchain_windows(self):

--- a/conans/test/integration/conan_v2/build_helpers/test_cmake.py
+++ b/conans/test/integration/conan_v2/build_helpers/test_cmake.py
@@ -32,7 +32,7 @@ class CMakeBuildHelperTestCase(ConanV2ModeTestCase):
         t = self.get_client()
         conanfile = textwrap.dedent("""
             from conans import ConanFile, CMake
-            
+
             class Pkg(ConanFile):
                 settings = "os", "arch", "build_type"
                 def build(self):
@@ -48,7 +48,7 @@ class CMakeBuildHelperTestCase(ConanV2ModeTestCase):
         conanfile = textwrap.dedent("""
             from conans import ConanFile, CMake
             class Pkg(ConanFile):
-                toolchain = "cmake"
+                generators = "cmake"
 
                 def build(self):
                     cmake = CMake(self)


### PR DESCRIPTION
Changelog: Fix: Remove warnings for old toolchains imports and ``generate_toolchain_files()`` calls (use new imports and ``generate()`` calls.
Docs: Omit