### PR TITLE
Remove ConanCommunity from tests

### DIFF
--- a/conans/test/functional/client/tools/scm/test_git.py
+++ b/conans/test/functional/client/tools/scm/test_git.py
@@ -163,7 +163,7 @@ class GitToolTest(unittest.TestCase):
         save(os.path.join(tmp, "file"), "dummy contents")
         git = Git(tmp)
         with six.assertRaisesRegex(self, ConanException, "specify a branch to checkout"):
-            git.clone("https://github.com/conan-community/conan-zlib.git")
+            git.clone("https://github.com/conan-io/hooks.git")
 
     def test_credentials(self):
         tmp = temp_folder()


### PR DESCRIPTION
As Conan Community will be closed soon, any test which points to a repository there will fail.

Here I replaced conan-community by hooks, because it's a small repository (I think our smaller).


Changelog: Omit
Docs: Omits


- [ ] Refer to the issue that supports this Pull Request.
- [ ] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [ ] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [ ] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 

<sup>**Note:** By default this PR will skip the slower tests and will use a limited set of python versions. Check [here](https://github.com/conan-io/conan/blob/develop/.github/PR_INCREASE_TESTING.md) how to increase the testing level by writing some tags in the current PR body text.</sup>
