### PR TITLE
Add toolchain support for qbs.targetPlatform property

### DIFF
--- a/conan/tools/qbs/qbstoolchain.py
+++ b/conan/tools/qbs/qbstoolchain.py
@@ -62,12 +62,26 @@ _cxx_language_version = {
     '20': 'c++20',
     'gnu20': 'c++20'
 }
-
+_target_platform = {
+    'Windows': 'windows',
+    'WindowsStore': 'windows',
+    'WindowsCE': 'windows',
+    'Linux': 'linux',
+    'Macos': 'macos',
+    'Android': 'android',
+    'iOS': 'ios',
+    'watchOS': 'watchos',
+    'tvOS': 'tvos',
+    'FreeBSD': 'freebsd',
+    'SunOS': 'solaris',
+    'AIX': 'aix',
+    'Emscripten': None,
+    'Arduino': 'none',
+    'Neutrino': 'qnx',
+}
 
 def _bool(b):
-    if b is None:
-        return None
-    return str(b).lower()
+    return None if b is None else str(b).lower()
 
 
 def _env_var_to_list(var):
@@ -208,6 +222,11 @@ class QbsToolchain(object):
                 {%- if architecture %}
                 qbs.architecture: "{{ architecture }}"
                 {%- endif %}
+                {%- if target_platform %}
+                qbs.targetPlatform: "{{ target_platform }}"
+                {%- else %}
+                qbs.targetPlatform: undefined
+                {%- endif %}
                 {%- if optimization %}
                 qbs.optimization: "{{ optimization }}"
                 {%- endif %}
@@ -240,6 +259,8 @@ class QbsToolchain(object):
             conanfile.settings.get_safe('build_type'))
         self._cxx_language_version = _cxx_language_version.get(
             str(conanfile.settings.get_safe('compiler.cppstd')))
+        self._target_platform = _target_platform.get(
+            conanfile.settings.get_safe('os'))
         self._sysroot = tools.get_env('SYSROOT')
         self._position_independent_code = _bool(
             conanfile.options.get_safe('fPIC'))
@@ -257,7 +278,8 @@ class QbsToolchain(object):
             'optimization': self._optimization,
             'sysroot': self._sysroot,
             'position_independent_code': self._position_independent_code,
-            'cxx_language_version': self._cxx_language_version
+            'cxx_language_version': self._cxx_language_version,
+            'target_platform': self._target_platform
         }
         t = Template(self._template_toolchain)
         content = t.render(**context)

--- a/conans/test/unittests/client/toolchain/test_qbs_generic.py
+++ b/conans/test/unittests/client/toolchain/test_qbs_generic.py
@@ -158,6 +158,22 @@ class QbsGenericTest(unittest.TestCase):
             self.assertEqual(qbs_toolchain._cxx_language_version,
                              cxx_language_version)
 
+    def test_convert_target_platform(self):
+        conanfile = MockConanfileWithFolders(MockSettings({
+            'compiler': 'gcc'}))
+
+        qbs_toolchain = qbs.QbsToolchain(conanfile)
+        self.assertEqual(qbs_toolchain._target_platform, None)
+
+        for os, target_platform in qbs._target_platform.items():
+            conanfile = MockConanfileWithFolders(MockSettings({
+                'os': os,
+                'compiler': 'gcc'}))
+
+            qbs_toolchain = qbs.QbsToolchain(conanfile)
+            self.assertEqual(qbs_toolchain._target_platform,
+                             target_platform)
+
     def test_split_env_var_into_list(self):
         env_var_list = ['-p1', '-p2', '-p3_with_value=13',
                         '-p_with_space1="hello world"',
@@ -305,7 +321,6 @@ class QbsGenericTest(unittest.TestCase):
             profiles.conan.cpp.platformLinkerFlags: undefined
             profiles.conan.cpp.toolchainInstallPath: "/usr/bin"
             profiles.conan.cpp.toolchainPrefix: "arm-none-eabi-"
-            profiles.conan.qbs.targetPlatform: ""
             profiles.conan.qbs.someBoolProp: "true"
             profiles.conan.qbs.someIntProp: "13"
             profiles.conan.qbs.toolchain: ["gcc"]
@@ -321,7 +336,6 @@ class QbsGenericTest(unittest.TestCase):
             'cpp.platformLinkerFlags': 'undefined',
             'cpp.toolchainInstallPath': '"/usr/bin"',
             'cpp.toolchainPrefix': '"arm-none-eabi-"',
-            'qbs.targetPlatform': '""',
             'qbs.someBoolProp': 'true',
             'qbs.someIntProp': '13',
             'qbs.toolchain': '["gcc"]'
@@ -356,7 +370,6 @@ class QbsGenericTest(unittest.TestCase):
                     cpp.platformLinkerFlags: undefined
                     cpp.toolchainInstallPath: "/usr/bin"
                     cpp.toolchainPrefix: "arm-none-eabi-"
-                    qbs.targetPlatform: ""
                     qbs.someBoolProp: true
                     qbs.someIntProp: 13
                     qbs.toolchain: ["gcc"]
@@ -367,6 +380,7 @@ class QbsGenericTest(unittest.TestCase):
                     /* conan settings */
                     qbs.buildVariant: "release"
                     qbs.architecture: "x86_64"
+                    qbs.targetPlatform: "linux"
                     qbs.optimization: "small"
                     cpp.cxxLanguageVersion: "c++17"
 


### PR DESCRIPTION
The Qbs property `qbs.targetPlatform` defines the os of the build target
(or "none" for bare-metal devices). When implementing the Qbs toolchain I wrongly assumed 
that it would be outputted by `qbs-setup-toolchains`. With this PR the QbsToolchain class will
set the `qbs.targetPlatform` property based on the value in `settings.os`.

Changelog: Fix: Set `qbs.targetPlatform` with qbs toolchain.
Docs: Omit

- [ ] Refer to the issue that supports this Pull Request.
- [ ] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 

<sup>**Note:** By default this PR will skip the slower tests and will use a limited set of python versions. Check [here](https://github.com/conan-io/conan/blob/develop/.github/PR_INCREASE_TESTING.md) how to increase the testing level by writing some tags in the current PR body text.</sup>
