### PR TITLE
Bugfix: Fix file copying with .. patterns and keep_path=True

### DIFF
--- a/conans/client/file_copier.py
+++ b/conans/client/file_copier.py
@@ -90,10 +90,9 @@ class FileCopier(object):
     def _copy(self, base_src, pattern, src, dst, symlinks, ignore_case, excludes, keep_path,
               excluded_folders):
         # Check for ../ patterns and allow them
-        if pattern.startswith(".."):
-            rel_dir = os.path.abspath(os.path.join(base_src, pattern))
-            base_src = os.path.dirname(rel_dir)
-            pattern = os.path.basename(rel_dir)
+        while pattern.startswith(".."):
+            base_src = os.path.abspath(os.path.join(base_src, ".."))
+            pattern = pattern[3:]
 
         src = os.path.join(base_src, src)
         dst = os.path.join(self._dst_folder, dst)

--- a/conans/test/functional/command/export/export_test.py
+++ b/conans/test/functional/command/export/export_test.py
@@ -142,7 +142,7 @@ class TestConan(ConanFile):
         client.run("export . lasote/stable")
         ref = ConanFileReference("Hello", "1.2", "lasote", "stable")
         export_path = client.cache.package_layout(ref).export()
-        content = load(os.path.join(export_path, "file.txt"))
+        content = load(os.path.join(export_path, "sibling/file.txt"))
         self.assertEqual("Hello World!", content)
 
     def test_code_several_sibling(self):
@@ -163,8 +163,12 @@ class TestConan(ConanFile):
         client.run("export . lasote/stable")
         ref = ConanFileReference("Hello", "1.2", "lasote", "stable")
         export_path = client.cache.package_layout(ref).export_sources()
-        self.assertEqual(sorted(['file.txt', 'file.cpp', 'file.h']),
+        self.assertEqual(sorted(['test', 'cpp', 'include']),
                          sorted(os.listdir(export_path)))
+        self.assertEqual(['src'], os.listdir(os.path.join(export_path, 'test')))
+        self.assertEqual(['file.txt'], os.listdir(os.path.join(export_path, 'test', 'src')))
+        self.assertEqual(['file.cpp'], os.listdir(os.path.join(export_path, 'cpp')))
+        self.assertEqual(['file.h'], os.listdir(os.path.join(export_path, 'include')))
 
     @parameterized.expand([("myconanfile.py", ), ("Conanfile.py", )])
     def test_filename(self, filename):

--- a/conans/test/unittests/client/file_copier/file_copier_test.py
+++ b/conans/test/unittests/client/file_copier/file_copier_test.py
@@ -270,3 +270,17 @@ class FileCopierTest(unittest.TestCase):
                          sorted(os.listdir(os.path.join(dst_folder, "include"))))
         self.assertEqual(sorted(["AttributeStorage.h", "file.h"]),
                          sorted(os.listdir(os.path.join(dst_folder, "include", "sub"))))
+
+    def test_dotdot_with_keep_path(self):
+        src_folder = temp_folder()
+        save(os.path.join(src_folder, "libfoo/file.c"), "")
+
+        sub_folder = os.path.join(src_folder, "build")
+
+        dst_folder = temp_folder()
+        copier = FileCopier([sub_folder], dst_folder)
+        copier("../libfoo/*.c", keep_path=True)
+
+        # Ensure that directories are preserved by the copy.
+        self.assertEqual(["libfoo"], os.listdir(dst_folder))
+        self.assertEqual(["file.c"], os.listdir(os.path.join(dst_folder, "libfoo")))


### PR DESCRIPTION
Changelog: Bugfix: Fix file copying with .. patterns and keep_path=True
Docs: N/A

- [ ] Refer to the issue that supports this Pull Request.
- [X] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [X] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [X] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 

When copying files using a pattern such as `"../libfoo/*.c"`, the expected outcome in the destination directory is:

libfoo/
└── file.c

Instead, all files matched by the pattern are currently flattened into the destination directory. This PR fixes that.

<sup>**Note:** By default this PR will skip the slower tests and will use a limited set of python versions. Check [here](https://github.com/conan-io/conan/blob/develop/.github/PR_INCREASE_TESTING.md) how to increase the testing level by writing some tags in the current PR body text.</sup>
