### PR TITLE
info with scm data

### DIFF
--- a/conans/client/conan_command_output.py
+++ b/conans/client/conan_command_output.py
@@ -176,6 +176,7 @@ class CommandOutputer(object):
             _add_if_exists("topics", as_list=True)
             _add_if_exists("deprecated")
             _add_if_exists("provides", as_list=True)
+            _add_if_exists("scm")
 
             if isinstance(ref, ConanFileReference):
                 item_data["recipe"] = node.recipe

--- a/conans/client/printer.py
+++ b/conans/client/printer.py
@@ -122,6 +122,8 @@ class Printer(object):
 
             _print("creation_date", show_field="date", name="Creation date")
 
+            _print("scm", show_field="scm", name="scm")
+
             if show("required") and "required_by" in it:
                 self._out.writeln("    Required by:", Color.BRIGHT_GREEN)
                 for d in it["required_by"]:


### PR DESCRIPTION
Changelog: Feature: Add ``scm`` output in ``conan info`` command.
Docs: Omit

Close https://github.com/conan-io/conan/issues/8377