### PR TITLE
Fix: meson : add target and jobs arguments

### DIFF
--- a/conan/tools/meson/meson.py
+++ b/conan/tools/meson/meson.py
@@ -2,7 +2,7 @@ import os
 
 from conan.tools.meson import MesonToolchain
 from conan.tools.microsoft.visual import vcvars_command, vcvars_arch
-from conans.client.tools.oss import cross_building
+from conans.client.tools.oss import cross_building, cpu_count
 
 
 class Meson(object):
@@ -39,8 +39,10 @@ class Meson(object):
             cmd += ' -Dprefix="{}"'.format(self._conanfile.package_folder)
         self._run(cmd)
 
-    def build(self):
-        cmd = 'meson compile -C "{}"'.format(self._build_dir)
+    def build(self, target=None):
+        cmd = 'meson compile -C "{}" -j {}'.format(self._build_dir, cpu_count())
+        if target:
+            cmd += " {}".format(target)
         self._run(cmd)
 
     def install(self):

--- a/conans/test/functional/toolchains/meson/test_meson.py
+++ b/conans/test/functional/toolchains/meson/test_meson.py
@@ -32,7 +32,8 @@ class MesonToolchainTest(TestMesonBase):
         def build(self):
             meson = Meson(self)
             meson.configure()
-            meson.build()
+            meson.build(target='hello')
+            meson.build(target='demo')
     """)
 
     _meson_options_txt = textwrap.dedent("""


### PR DESCRIPTION
add two missing arguments to new Meson build helper

Changelog: Fix: meson : Add target and jobs arguments.
Docs: https://github.com/conan-io/docs/pull/2011

- [x] Refer to the issue that supports this Pull Request.
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 

<sup>**Note:** By default this PR will skip the slower tests and will use a limited set of python versions. Check [here](https://github.com/conan-io/conan/blob/develop/.github/PR_INCREASE_TESTING.md) how to increase the testing level by writing some tags in the current PR body text.</sup>
