### PR TITLE
Remove trick in package_id_mode tests

### DIFF
--- a/conans/test/integration/package_id/package_id_requires_modes_test.py
+++ b/conans/test/integration/package_id/package_id_requires_modes_test.py
@@ -48,7 +48,6 @@ class Pkg(ConanFile):
                 conanfile = conanfile.with_require(ConanFileReference.loads(require))
 
         self.client.save({"conanfile.py": str(conanfile)}, clean_first=True)
-        revisions_enabled = self.client.cache.config.revisions_enabled
         self.client.run("export . %s" % (channel or "lasote/stable"))
 
     @property
@@ -203,8 +202,8 @@ class Pkg(ConanFile):
         self.client.save({"conanfile.txt": "[requires]\nHello2/2.3.8@lasote/stable"},
                          clean_first=True)
 
-        with self.assertRaises(Exception):
-            self.client.run("install .")
+        assert_error = True if self.client.cache.config.revisions_enabled else False
+        self.client.run("install .", assert_error=assert_error)
         self.assertIn("Hello2/2.3.8@lasote/stable:{}".format(pkg_id), self.client.out)
 
     def test_version_full_package_schema(self):


### PR DESCRIPTION
Changelog: omit
Docs: omit

I suspect that this trick of enabling and disabling revisions to leave the binaries of an already compiled library after an export was to test that the package_id's matched in test_version_full_recipe_schema and there was no need to compile again when revisions were active? 
If we check that the calculation of the package id is the same, should it be enough? 

#REVISIONS: 1
