### PR TITLE
Fix exit code for conan_build_info

### DIFF
--- a/conans/build_info/command.py
+++ b/conans/build_info/command.py
@@ -121,10 +121,9 @@ def runv2():
             check_credential_arguments()
             publish_build_info(args.buildinfo, args.url, args.user, args.password,
                                args.apikey)
-    except ConanException as exc:
-        output.error(exc)
     except Exception as exc:
         output.error(exc)
+        exit(1)
 
 
 if __name__ == "__main__":

--- a/conans/build_info/command.py
+++ b/conans/build_info/command.py
@@ -34,10 +34,10 @@ def runv1():
 
         if not os.path.exists(args.trace_path):
             output.error("Conan trace log not found! '%s'" % args.trace_path)
-            exit(1)
+            sys.exit(1)
         if args.output and not os.path.exists(os.path.dirname(args.output)):
             output.error("Output file directory not found! '%s'" % args.trace_path)
-            exit(1)
+            sys.exit(1)
 
         info = get_build_info(args.trace_path)
         the_json = json.dumps(info.serialize())
@@ -47,7 +47,7 @@ def runv1():
             output.write(the_json)
     except Exception as exc:
         output.error(exc)
-        exit(1)
+        sys.exit(1)
     except SystemExit:
         output.writeln("")
         output.warn("Use 'conan_build_info --v2' to see the usage of the new recommended way to "
@@ -123,7 +123,7 @@ def runv2():
                                args.apikey)
     except Exception as exc:
         output.error(exc)
-        exit(1)
+        sys.exit(1)
 
 
 if __name__ == "__main__":

--- a/conans/test/functional/conan_build_info/test_build_info_creation.py
+++ b/conans/test/functional/conan_build_info/test_build_info_creation.py
@@ -52,7 +52,7 @@ class MyBuildInfoCreation(unittest.TestCase):
                 kwargs["headers"]["X-JFrog-Art-Api"] != "apikey"):
             mock_resp.status_code = 401
         buildinfo = json.load(data)
-        if not buildinfo["name"] == "MyBuildInfo" or not buildinfo["number"] == "42":
+        if not buildinfo["name"] == "MyBuildName" or not buildinfo["number"] == "42":
             mock_resp.status_code = 400
         mock_resp.content = None
         return mock_resp
@@ -271,6 +271,7 @@ class MyBuildInfoCreation(unittest.TestCase):
             result = StringIO()
             sys.stderr = result
             run()
+        except SystemExit:
             result = result.getvalue()
             self.assertIn("This lockfile was created with an incompatible version of Conan", result)
         finally:


### PR DESCRIPTION
Changelog: Bugfix: Fix exit code for `conan_build_info`.
Docs: omit

Fixes: https://github.com/conan-io/conan/issues/8395

- [X] Refer to the issue that supports this Pull Request.
- [X] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [X] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [X] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 

<sup>**Note:** By default this PR will skip the slower tests and will use a limited set of python versions. Check [here](https://github.com/conan-io/conan/blob/develop/.github/PR_INCREASE_TESTING.md) how to increase the testing level by writing some tags in the current PR body text.</sup>
