### PR TITLE
make CMakeDeps available declarative

### DIFF
--- a/conans/client/generators/__init__.py
+++ b/conans/client/generators/__init__.py
@@ -67,7 +67,7 @@ class GeneratorManager(object):
                             "make": MakeGenerator,
                             "deploy": DeployGenerator,
                             "markdown": MarkdownGenerator}
-        self._new_generators = ["CMakeToolchain", "MakeToolchain", "MSBuildToolchain",
+        self._new_generators = ["CMakeToolchain", "CMakeDeps", "MakeToolchain", "MSBuildToolchain",
                                 "MesonToolchain", "MSBuildDeps", "QbsToolchain", "msbuild"]
 
     def add(self, name, generator_class, custom=False):
@@ -91,6 +91,9 @@ class GeneratorManager(object):
         if generator_name == "CMakeToolchain":
             from conan.tools.cmake import CMakeToolchain
             return CMakeToolchain
+        if generator_name == "CMakeDeps":
+            from conan.tools.cmake import CMakeDeps
+            return CMakeDeps
         elif generator_name == "MakeToolchain":
             from conan.tools.gnu import MakeToolchain
             return MakeToolchain

--- a/conans/test/functional/toolchains/test_basic.py
+++ b/conans/test/functional/toolchains/test_basic.py
@@ -37,7 +37,8 @@ class BasicTest(unittest.TestCase):
             from conans import ConanFile
             class Pkg(ConanFile):
                 settings = "os", "compiler", "arch", "build_type"
-                generators = "CMakeToolchain", "MesonToolchain", "MakeToolchain", "MSBuildToolchain"
+                generators = ("CMakeToolchain", "CMakeDeps", "MesonToolchain", "MakeToolchain",
+                              "MSBuildToolchain")
             """)
         client = TestClient()
         client.save({"conanfile.py": conanfile})
@@ -47,6 +48,7 @@ class BasicTest(unittest.TestCase):
         self.assertIn("conanfile.py: Generator 'MesonToolchain' calling 'generate()'", client.out)
         self.assertIn("conanfile.py: Generator 'MakeToolchain' calling 'generate()'", client.out)
         self.assertIn("conanfile.py: Generator 'MSBuildToolchain' calling 'generate()'", client.out)
+        self.assertIn("conanfile.py: Generator 'CMakeDeps' calling 'generate()'", client.out)
         toolchain = client.load("conan_toolchain.cmake")
         self.assertIn("Conan automatically generated toolchain file", toolchain)
         toolchain = client.load("conantoolchain.props")


### PR DESCRIPTION
Changelog: Fix: Make CMakeDeps generator available in declarative mode ``generators = "CMakeDeps"``
Docs: Omit