### PR TITLE
Rename conan.cfg to global.conf

### DIFF
--- a/conans/client/cache/cache.py
+++ b/conans/client/cache/cache.py
@@ -159,11 +159,11 @@ class ClientCache(object):
 
     @property
     def new_config_path(self):
-        return os.path.join(self.cache_folder, "conan.cfg")
+        return os.path.join(self.cache_folder, "global.conf")
 
     @property
     def new_config(self):
-        """ this is the new conan.cfgto replace the old conan.conf that contains
+        """ this is the new global.conf to replace the old conan.conf that contains
         configuration defined with the new syntax as in profiles, this config will be composed
         to the profile ones and passed to the conanfiles.conf, which can be passed to collaborators
         """

--- a/conans/model/conf.py
+++ b/conans/model/conf.py
@@ -122,7 +122,7 @@ class ConfDefinition(object):
 
     def rebase_conf_definition(self, other):
         """
-        for taking the new conan.cfg and composing with the profile [conf]
+        for taking the new global.conf and composing with the profile [conf]
         :type other: ConfDefinition
         """
         for k, v in other._pattern_confs.items():


### PR DESCRIPTION
Changelog: Fix: Rename _conan.cfg_ to _global.conf_.
Docs: https://github.com/conan-io/docs/pull/2008

Closes: https://github.com/conan-io/conan/issues/8400

Also opened a PR to the release post: https://github.com/conan-io/conan-io.github.io/pull/158

Naming of the new configuration file to _conan.cfg_ was a bit confusing. Better than changing the block section `[conf]` this PR renames the file from _conan.cfg_ to _global.conf_.

- [X] Refer to the issue that supports this Pull Request.
- [X] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [X] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [X] I've followed the PEP8 style guides for Python code.
- [x] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 

<sup>**Note:** By default this PR will skip the slower tests and will use a limited set of python versions. Check [here](https://github.com/conan-io/conan/blob/develop/.github/PR_INCREASE_TESTING.md) how to increase the testing level by writing some tags in the current PR body text.</sup>
