### PR TITLE
Add repository and path properties to conan_build_info --v2

### DIFF
--- a/conans/build_info/build_info.py
+++ b/conans/build_info/build_info.py
@@ -203,10 +203,11 @@ class BuildInfoCreator(object):
             if node.get("modified"):  # Work only on generated nodes
                 # Create module for the recipe reference
                 recipe_key = self._get_reference(ref)
+                repository = self._get_repo(ref)
                 modules[recipe_key]["id"] = recipe_key
                 modules[recipe_key]["artifacts"].update(
                     self._get_recipe_artifacts(ref, is_dependency=False))
-                modules[recipe_key]["repository"] = self._get_repo(ref)
+                modules[recipe_key]["repository"] = repository
 
                 # TODO: what about `python_requires`?
                 # TODO: can we associate any properties to the recipe? Profile/options may
@@ -217,7 +218,7 @@ class BuildInfoCreator(object):
                 modules[package_key]["id"] = package_key
                 modules[package_key]["artifacts"].update(
                     self._get_package_artifacts(ref, pid, prev, is_dependency=False))
-                modules[package_key]["repository"] = self._get_repo(ref)
+                modules[package_key]["repository"] = repository
 
                 # Recurse requires
                 node_ids = node.get("requires", []) + node.get("build_requires", [])

--- a/conans/build_info/build_info.py
+++ b/conans/build_info/build_info.py
@@ -14,6 +14,7 @@ from conans.model.ref import ConanFileReference
 from conans.paths import ARTIFACTS_PROPERTIES_PUT_PREFIX
 from conans.paths import get_conan_user_home
 from conans.util.files import save
+from conans import __version__
 
 
 class Artifact(namedtuple('Artifact', ["sha1", "md5", "name", "id"])):
@@ -223,7 +224,7 @@ class BuildInfoCreator(object):
                "number": properties[ARTIFACTS_PROPERTIES_PUT_PREFIX + "build.number"],
                "type": "GENERIC",
                "started": datetime.datetime.utcnow().isoformat().split(".")[0] + ".000Z",
-               "buildAgent": {"name": "Conan Client", "version": "1.X"},
+               "buildAgent": {"name": "conan", "version": "{}".format(__version__)},
                "modules": list(modules.values())}
 
         def dump_custom_types(obj):

--- a/conans/build_info/build_info.py
+++ b/conans/build_info/build_info.py
@@ -153,7 +153,10 @@ class BuildInfoCreator(object):
         return arts
 
     def process_lockfile(self):
-        modules = defaultdict(lambda: {"id": None, "artifacts": set(), "dependencies": set()})
+        modules = defaultdict(lambda: {"type": "conan",
+                                       "id": None,
+                                       "artifacts": set(),
+                                       "dependencies": set()})
 
         def _gather_transitive_recipes(nid, contents):
             n = contents["graph_lock"]["nodes"][nid]

--- a/conans/build_info/build_info.py
+++ b/conans/build_info/build_info.py
@@ -336,6 +336,11 @@ def merge_buildinfo(lhs, rhs):
                                                   cmp_key="name")
         lhs_module["dependencies"] = merge_artifacts(lhs_module, rhs_module, key="dependencies",
                                                      cmp_key="id")
+        if not lhs_module.get("type", None):
+            lhs_module["type"] = rhs_module["type"]
+        if not lhs_module.get("repository", None):
+            lhs_module["repository"] = rhs_module["repository"]
+
     return lhs
 
 

--- a/conans/test/unittests/client/cmd/conan_build_info_test.py
+++ b/conans/test/unittests/client/cmd/conan_build_info_test.py
@@ -559,4 +559,6 @@ class BuildInfoTest(unittest.TestCase):
             mergedinfo = json.load(json_data)
             res_json = json.loads(self.result)
 
+        mergedinfo["started"] = ""
+        res_json["started"] = ""
         self.assertDictEqual(mergedinfo, res_json)

--- a/conans/test/unittests/client/cmd/conan_build_info_test.py
+++ b/conans/test/unittests/client/cmd/conan_build_info_test.py
@@ -24,120 +24,136 @@ class BuildInfoTest(unittest.TestCase):
         "modules": [
             {{
                 "type": "conan",
-                "id": "PkgB/0.1@user/channel",
+                "repository": "develop",
+                "id": "PkgB/0.1@user/channel#59ba6f9d5109a2692330b3c6b961313b",
                 "artifacts": [
                     {{
                         "sha1": "aba8527a2c4fc142cf5262298824d3680ecb057f",
                         "md5": "aad124317706ef90df47686329be8e2b",
-                        "name": "conan_sources.tgz"
+                        "name": "conan_sources.tgz",
+                        "path": "user/PkgB/0.1/channel/59ba6f9d5109a2692330b3c6b961313b/export"
                     }},
                     {{
                         "sha1": "a058b1a9366a361d71ea5d67997009f7200de6e1",
                         "md5": "a73be4ec0c7301d2ea2dacc873df5483",
-                        "name": "conanfile.py"
+                        "name": "conanfile.py",
+                        "path": "user/PkgB/0.1/channel/59ba6f9d5109a2692330b3c6b961313b/export"
                     }},
                     {{
                         "sha1": "6cbda4a7286d9bb37eb3a6c97b150ed4939f4095",
                         "md5": "67abd07526f4abdf24f88f443c907f78",
-                        "name": "conanmanifest.txt"
+                        "name": "conanmanifest.txt",
+                        "path": "user/PkgB/0.1/channel/59ba6f9d5109a2692330b3c6b961313b/export"
                     }}
                 ],
                 "dependencies": [
                     {{
                         "sha1": "def7797033b5b46ca063aaaf21dc7a9c1b93a35a",
                         "md5": "89b684b95f6f5c7a8e2fda664be22c5a",
-                        "id": "PkgA/0.2@user/channel :: conan_sources.tgz"
+                        "id": "PkgA/0.2@user/channel#26386415fb6f92bb9413d60903e5181e :: conan_sources.tgz"
                     }},
                     {{
                         "sha1": "7bd4da1c70ca29637b159a0131a8b886cfaeeb27",
                         "md5": "00dbccdd251aa5652df8886cf153d2d6",
-                        "id": "PkgA/0.2@user/channel :: conanfile.py"
+                        "id": "PkgA/0.2@user/channel#26386415fb6f92bb9413d60903e5181e :: conanfile.py"
                     }},
                     {{
                         "sha1": "7ca1713befc9eabcfaaa244133e3e173307705f4",
                         "md5": "d723dfc35eb5a121e401818fdb43b210",
-                        "id": "PkgA/0.2@user/channel :: conanmanifest.txt"
+                        "id": "PkgA/0.2@user/channel#26386415fb6f92bb9413d60903e5181e :: conanmanifest.txt"
                     }}
                 ]
             }},
             {{
                 "type": "conan",
-                "id": "PkgB/0.1@user/channel:09f152eb7b3e0a6e15a2a3f464245864ae8f8644",
+                "repository": "develop",
+                "id": "PkgB/0.1@user/channel#59ba6f9d5109a2692330b3c6b961313b:451532304ef8fa47e00fa54ca3f94d06c6e0e57f#692a3a14fb5860c377c1dff609bc90cb",
                 "artifacts": [
                     {{
                         "sha1": "45f961804e3bcc5267a2f6d130b4dcc16e2379ee",
                         "md5": "d4f703971717722bd84c24eccf50b9fd",
-                        "name": "conan_package.tgz"
+                        "name": "conan_package.tgz",
+                        "path": "user/PkgB/0.1/channel/59ba6f9d5109a2692330b3c6b961313b/package/451532304ef8fa47e00fa54ca3f94d06c6e0e57f/692a3a14fb5860c377c1dff609bc90cb"
                     }},
                     {{
                         "sha1": "9525339890e3b484d5e7d8f351957b6c2a28147f",
                         "md5": "fd6b4a992aa1254fa5a404888ed8c7ce",
-                        "name": "conaninfo.txt"
+                        "name": "conaninfo.txt",
+                        "path": "user/PkgB/0.1/channel/59ba6f9d5109a2692330b3c6b961313b/package/451532304ef8fa47e00fa54ca3f94d06c6e0e57f/692a3a14fb5860c377c1dff609bc90cb"
                     }},
                     {{
                         "sha1": "f8f2795005c8fbfbcddae7224888d66a8f47f533",
                         "md5": "c18ffa171f4df3ab4af24dc443320a5a",
-                        "name": "conanmanifest.txt"
+                        "name": "conanmanifest.txt",
+                        "path": "user/PkgB/0.1/channel/59ba6f9d5109a2692330b3c6b961313b/package/451532304ef8fa47e00fa54ca3f94d06c6e0e57f/692a3a14fb5860c377c1dff609bc90cb"
                     }}
                 ],
                 "dependencies": [
                     {{
                         "sha1": "a96d326d2449a103a4f9e6d81018ffd411b3f4a1",
                         "md5": "43c402f3ad0cc9dfa89c5be37bf9b7e5",
-                        "id": "PkgA/0.2@user/channel:5ab84d6acfe1f23c4fae0ab88f26e3a396351ac9 :: conan_package.tgz"
+                        "id": "PkgA/0.2@user/channel#26386415fb6f92bb9413d60903e5181e:9db1d964f4a0e5590a43a0c634a3196a8a3eca3b#2d0052a59a49a706c057ebeb107292e6 :: conan_package.tgz"
                     }},
                     {{
                         "sha1": "2f452380f6ec5db0baab369d0bc4286793710ca3",
                         "md5": "95adc888e92d1a888454fae2093c0862",
-                        "id": "PkgA/0.2@user/channel:5ab84d6acfe1f23c4fae0ab88f26e3a396351ac9 :: conaninfo.txt"
+                        "id": "PkgA/0.2@user/channel#26386415fb6f92bb9413d60903e5181e:9db1d964f4a0e5590a43a0c634a3196a8a3eca3b#2d0052a59a49a706c057ebeb107292e6 :: conaninfo.txt"
                     }},
                     {{
                         "sha1": "fe0b6d9343648ae2b60d5c6c4ce765291cc278fb",
                         "md5": "2702b1656a7318c01112b90cca875867",
-                        "id": "PkgA/0.2@user/channel:5ab84d6acfe1f23c4fae0ab88f26e3a396351ac9 :: conanmanifest.txt"
+                        "id": "PkgA/0.2@user/channel#26386415fb6f92bb9413d60903e5181e:9db1d964f4a0e5590a43a0c634a3196a8a3eca3b#2d0052a59a49a706c057ebeb107292e6 :: conanmanifest.txt"
                     }}
                 ]
             }},
             {{
                 "type": "conan",
-                "id": "PkgA/0.2@user/channel",
+                "repository": "develop",
+                "id": "PkgA/0.2@user/channel#26386415fb6f92bb9413d60903e5181e",
                 "artifacts": [
                     {{
                         "sha1": "def7797033b5b46ca063aaaf21dc7a9c1b93a35a",
                         "md5": "89b684b95f6f5c7a8e2fda664be22c5a",
-                        "name": "conan_sources.tgz"
+                        "name": "conan_sources.tgz",
+                        "path": "user/PkgA/0.2/channel/26386415fb6f92bb9413d60903e5181e/export"
                     }},
                     {{
                         "sha1": "7bd4da1c70ca29637b159a0131a8b886cfaeeb27",
                         "md5": "00dbccdd251aa5652df8886cf153d2d6",
-                        "name": "conanfile.py"
+                        "name": "conanfile.py",
+                        "path": "user/PkgA/0.2/channel/26386415fb6f92bb9413d60903e5181e/export"
                     }},
                     {{
                         "sha1": "7ca1713befc9eabcfaaa244133e3e173307705f4",
                         "md5": "d723dfc35eb5a121e401818fdb43b210",
-                        "name": "conanmanifest.txt"
+                        "name": "conanmanifest.txt",
+                        "path": "user/PkgA/0.2/channel/26386415fb6f92bb9413d60903e5181e/export"
                     }}
                 ],
                 "dependencies": []
             }},
             {{
                 "type": "conan",
-                "id": "PkgA/0.2@user/channel:5ab84d6acfe1f23c4fae0ab88f26e3a396351ac9",
+                "repository": "develop",
+                "id": "PkgA/0.2@user/channel#26386415fb6f92bb9413d60903e5181e:9db1d964f4a0e5590a43a0c634a3196a8a3eca3b#2d0052a59a49a706c057ebeb107292e6",
                 "artifacts": [
                     {{
                         "sha1": "a96d326d2449a103a4f9e6d81018ffd411b3f4a1",
                         "md5": "43c402f3ad0cc9dfa89c5be37bf9b7e5",
-                        "name": "conan_package.tgz"
+                        "name": "conan_package.tgz",
+                        "path": "user/PkgA/0.2/channel/26386415fb6f92bb9413d60903e5181e/package/9db1d964f4a0e5590a43a0c634a3196a8a3eca3b/2d0052a59a49a706c057ebeb107292e6"
                     }},
                     {{
                         "sha1": "2f452380f6ec5db0baab369d0bc4286793710ca3",
                         "md5": "95adc888e92d1a888454fae2093c0862",
-                        "name": "conaninfo.txt"
+                        "name": "conaninfo.txt",
+                        "path": "user/PkgA/0.2/channel/26386415fb6f92bb9413d60903e5181e/package/9db1d964f4a0e5590a43a0c634a3196a8a3eca3b/2d0052a59a49a706c057ebeb107292e6"
                     }},
                     {{
                         "sha1": "fe0b6d9343648ae2b60d5c6c4ce765291cc278fb",
                         "md5": "2702b1656a7318c01112b90cca875867",
-                        "name": "conanmanifest.txt"
+                        "name": "conanmanifest.txt",
+                        "path": "user/PkgA/0.2/channel/26386415fb6f92bb9413d60903e5181e/package/9db1d964f4a0e5590a43a0c634a3196a8a3eca3b/2d0052a59a49a706c057ebeb107292e6"
                     }}
                 ],
                 "dependencies": []
@@ -159,120 +175,136 @@ class BuildInfoTest(unittest.TestCase):
         "modules": [
             {{
                 "type": "conan",
-                "id": "PkgC/0.1@user/channel",
+                "repository": "develop",
+                "id": "PkgC/0.1@user/channel#0b1a78f5925f62480ed2d97002e926fa",
                 "artifacts": [
                     {{
                         "sha1": "410b7df1fd1483a5a7b4c47e67822fc1e3dd533b",
                         "md5": "461fbd5d7e66ce86b8e56fb2524970dc",
-                        "name": "conan_sources.tgz"
+                        "name": "conan_sources.tgz",
+                        "path": "user/PkgC/0.1/channel/0b1a78f5925f62480ed2d97002e926fa/export"
                     }},
                     {{
                         "sha1": "a058b1a9366a361d71ea5d67997009f7200de6e1",
                         "md5": "a73be4ec0c7301d2ea2dacc873df5483",
-                        "name": "conanfile.py"
+                        "name": "conanfile.py",
+                        "path": "user/PkgC/0.1/channel/0b1a78f5925f62480ed2d97002e926fa/export"
                     }},
                     {{
                         "sha1": "594ff68dadb4cbeb36ff724286032698098b41e7",
                         "md5": "19052f117ce1513c3a815f41fd704c24",
-                        "name": "conanmanifest.txt"
+                        "name": "conanmanifest.txt",
+                        "path": "user/PkgC/0.1/channel/0b1a78f5925f62480ed2d97002e926fa/export"
                     }}
                 ],
                 "dependencies": [
                     {{
                         "sha1": "def7797033b5b46ca063aaaf21dc7a9c1b93a35a",
                         "md5": "89b684b95f6f5c7a8e2fda664be22c5a",
-                        "id": "PkgA/0.2@user/channel :: conan_sources.tgz"
+                        "id": "PkgA/0.2@user/channel#26386415fb6f92bb9413d60903e5181e :: conan_sources.tgz"
                     }},
                     {{
                         "sha1": "7bd4da1c70ca29637b159a0131a8b886cfaeeb27",
                         "md5": "00dbccdd251aa5652df8886cf153d2d6",
-                        "id": "PkgA/0.2@user/channel :: conanfile.py"
+                        "id": "PkgA/0.2@user/channel#26386415fb6f92bb9413d60903e5181e :: conanfile.py"
                     }},
                     {{
                         "sha1": "7ca1713befc9eabcfaaa244133e3e173307705f4",
                         "md5": "d723dfc35eb5a121e401818fdb43b210",
-                        "id": "PkgA/0.2@user/channel :: conanmanifest.txt"
+                        "id": "PkgA/0.2@user/channel#26386415fb6f92bb9413d60903e5181e :: conanmanifest.txt"
                     }}
                 ]
             }},
             {{
                 "type": "conan",
-                "id": "PkgC/0.1@user/channel:09f152eb7b3e0a6e15a2a3f464245864ae8f8644",
+                "repository": "develop",
+                "id": "PkgC/0.1@user/channel#0b1a78f5925f62480ed2d97002e926fa:6a83d7f783e7ee89a83cf2fe72b5f5f67538e2a6#28fb6fe2b23c481d38b88d1521374f3e",
                 "artifacts": [
                     {{
                         "sha1": "0b6a6755369820f66d6a858d3b44775fb1b38f54",
                         "md5": "c1f3a9ff4ee80ab5e5492c1c381dff56",
-                        "name": "conan_package.tgz"
+                        "name": "conan_package.tgz",
+                        "path": "user/PkgC/0.1/channel/0b1a78f5925f62480ed2d97002e926fa/package/6a83d7f783e7ee89a83cf2fe72b5f5f67538e2a6/28fb6fe2b23c481d38b88d1521374f3e"
                     }},
                     {{
                         "sha1": "6bce988c0cfc1d17588c0fddac573066afd8d26d",
                         "md5": "bde279efd0a24162425017d937fe8484",
-                        "name": "conaninfo.txt"
+                        "name": "conaninfo.txt",
+                        "path": "user/PkgC/0.1/channel/0b1a78f5925f62480ed2d97002e926fa/package/6a83d7f783e7ee89a83cf2fe72b5f5f67538e2a6/28fb6fe2b23c481d38b88d1521374f3e"
                     }},
                     {{
                         "sha1": "6a85f6893f316433cd935abad31c4daf80d09884",
                         "md5": "5996a968f13f4e4722d24d9d98ed0923",
-                        "name": "conanmanifest.txt"
+                        "name": "conanmanifest.txt",
+                        "path": "user/PkgC/0.1/channel/0b1a78f5925f62480ed2d97002e926fa/package/6a83d7f783e7ee89a83cf2fe72b5f5f67538e2a6/28fb6fe2b23c481d38b88d1521374f3e"
                     }}
                 ],
                 "dependencies": [
                     {{
                         "sha1": "a96d326d2449a103a4f9e6d81018ffd411b3f4a1",
                         "md5": "43c402f3ad0cc9dfa89c5be37bf9b7e5",
-                        "id": "PkgA/0.2@user/channel:5ab84d6acfe1f23c4fae0ab88f26e3a396351ac9 :: conan_package.tgz"
+                        "id": "PkgA/0.2@user/channel#26386415fb6f92bb9413d60903e5181e:9db1d964f4a0e5590a43a0c634a3196a8a3eca3b#2d0052a59a49a706c057ebeb107292e6 :: conan_package.tgz"
                     }},
                     {{
                         "sha1": "2f452380f6ec5db0baab369d0bc4286793710ca3",
                         "md5": "95adc888e92d1a888454fae2093c0862",
-                        "id": "PkgA/0.2@user/channel:5ab84d6acfe1f23c4fae0ab88f26e3a396351ac9 :: conaninfo.txt"
+                        "id": "PkgA/0.2@user/channel#26386415fb6f92bb9413d60903e5181e:9db1d964f4a0e5590a43a0c634a3196a8a3eca3b#2d0052a59a49a706c057ebeb107292e6 :: conaninfo.txt"
                     }},
                     {{
                         "sha1": "fe0b6d9343648ae2b60d5c6c4ce765291cc278fb",
                         "md5": "2702b1656a7318c01112b90cca875867",
-                        "id": "PkgA/0.2@user/channel:5ab84d6acfe1f23c4fae0ab88f26e3a396351ac9 :: conanmanifest.txt"
+                        "id": "PkgA/0.2@user/channel#26386415fb6f92bb9413d60903e5181e:9db1d964f4a0e5590a43a0c634a3196a8a3eca3b#2d0052a59a49a706c057ebeb107292e6 :: conanmanifest.txt"
                     }}
                 ]
             }},
             {{
                 "type": "conan",
-                "id": "PkgA/0.2@user/channel",
+                "repository": "develop",
+                "id": "PkgA/0.2@user/channel#26386415fb6f92bb9413d60903e5181e",
                 "artifacts": [
                     {{
                         "sha1": "def7797033b5b46ca063aaaf21dc7a9c1b93a35a",
                         "md5": "89b684b95f6f5c7a8e2fda664be22c5a",
-                        "name": "conan_sources.tgz"
+                        "name": "conan_sources.tgz",
+                        "path": "user/PkgA/0.2/channel/26386415fb6f92bb9413d60903e5181e/export"
                     }},
                     {{
                         "sha1": "7bd4da1c70ca29637b159a0131a8b886cfaeeb27",
                         "md5": "00dbccdd251aa5652df8886cf153d2d6",
-                        "name": "conanfile.py"
+                        "name": "conanfile.py",
+                        "path": "user/PkgA/0.2/channel/26386415fb6f92bb9413d60903e5181e/export"
                     }},
                     {{
                         "sha1": "7ca1713befc9eabcfaaa244133e3e173307705f4",
                         "md5": "d723dfc35eb5a121e401818fdb43b210",
-                        "name": "conanmanifest.txt"
+                        "name": "conanmanifest.txt",
+                        "path": "user/PkgA/0.2/channel/26386415fb6f92bb9413d60903e5181e/export"
                     }}
                 ],
                 "dependencies": []
             }},
             {{
                 "type": "conan",
-                "id": "PkgA/0.2@user/channel:5ab84d6acfe1f23c4fae0ab88f26e3a396351ac9",
+                "repository": "develop",
+                "id": "PkgA/0.2@user/channel#26386415fb6f92bb9413d60903e5181e:9db1d964f4a0e5590a43a0c634a3196a8a3eca3b#2d0052a59a49a706c057ebeb107292e6",
                 "artifacts": [
                     {{
                         "sha1": "a96d326d2449a103a4f9e6d81018ffd411b3f4a1",
                         "md5": "43c402f3ad0cc9dfa89c5be37bf9b7e5",
-                        "name": "conan_package.tgz"
+                        "name": "conan_package.tgz",
+                        "path": "user/PkgA/0.2/channel/26386415fb6f92bb9413d60903e5181e/package/9db1d964f4a0e5590a43a0c634a3196a8a3eca3b/2d0052a59a49a706c057ebeb107292e6"
                     }},
                     {{
                         "sha1": "2f452380f6ec5db0baab369d0bc4286793710ca3",
                         "md5": "95adc888e92d1a888454fae2093c0862",
-                        "name": "conaninfo.txt"
+                        "name": "conaninfo.txt",
+                        "path": "user/PkgA/0.2/channel/26386415fb6f92bb9413d60903e5181e/package/9db1d964f4a0e5590a43a0c634a3196a8a3eca3b/2d0052a59a49a706c057ebeb107292e6"
                     }},
                     {{
                         "sha1": "fe0b6d9343648ae2b60d5c6c4ce765291cc278fb",
                         "md5": "2702b1656a7318c01112b90cca875867",
-                        "name": "conanmanifest.txt"
+                        "name": "conanmanifest.txt",
+                        "path": "user/PkgA/0.2/channel/26386415fb6f92bb9413d60903e5181e/package/9db1d964f4a0e5590a43a0c634a3196a8a3eca3b/2d0052a59a49a706c057ebeb107292e6"
                     }}
                 ],
                 "dependencies": []
@@ -294,197 +326,221 @@ class BuildInfoTest(unittest.TestCase):
         "modules": [
             {{
                 "type": "conan",
-                "id": "PkgB/0.1@user/channel",
+                "repository": "develop",
+                "id": "PkgB/0.1@user/channel#59ba6f9d5109a2692330b3c6b961313b",
                 "artifacts": [
                     {{
                         "sha1": "aba8527a2c4fc142cf5262298824d3680ecb057f",
                         "md5": "aad124317706ef90df47686329be8e2b",
-                        "name": "conan_sources.tgz"
+                        "name": "conan_sources.tgz",
+                        "path": "user/PkgB/0.1/channel/59ba6f9d5109a2692330b3c6b961313b/export"
                     }},
                     {{
                         "sha1": "a058b1a9366a361d71ea5d67997009f7200de6e1",
                         "md5": "a73be4ec0c7301d2ea2dacc873df5483",
-                        "name": "conanfile.py"
+                        "name": "conanfile.py",
+                        "path": "user/PkgB/0.1/channel/59ba6f9d5109a2692330b3c6b961313b/export"
                     }},
                     {{
                         "sha1": "6cbda4a7286d9bb37eb3a6c97b150ed4939f4095",
                         "md5": "67abd07526f4abdf24f88f443c907f78",
-                        "name": "conanmanifest.txt"
+                        "name": "conanmanifest.txt",
+                        "path": "user/PkgB/0.1/channel/59ba6f9d5109a2692330b3c6b961313b/export"
                     }}
                 ],
                 "dependencies": [
                     {{
                         "sha1": "def7797033b5b46ca063aaaf21dc7a9c1b93a35a",
                         "md5": "89b684b95f6f5c7a8e2fda664be22c5a",
-                        "id": "PkgA/0.2@user/channel :: conan_sources.tgz"
+                        "id": "PkgA/0.2@user/channel#26386415fb6f92bb9413d60903e5181e :: conan_sources.tgz"
                     }},
                     {{
                         "sha1": "7bd4da1c70ca29637b159a0131a8b886cfaeeb27",
                         "md5": "00dbccdd251aa5652df8886cf153d2d6",
-                        "id": "PkgA/0.2@user/channel :: conanfile.py"
+                        "id": "PkgA/0.2@user/channel#26386415fb6f92bb9413d60903e5181e :: conanfile.py"
                     }},
                     {{
                         "sha1": "7ca1713befc9eabcfaaa244133e3e173307705f4",
                         "md5": "d723dfc35eb5a121e401818fdb43b210",
-                        "id": "PkgA/0.2@user/channel :: conanmanifest.txt"
+                        "id": "PkgA/0.2@user/channel#26386415fb6f92bb9413d60903e5181e :: conanmanifest.txt"
                     }}
                 ]
             }},
             {{
                 "type": "conan",
-                "id": "PkgB/0.1@user/channel:09f152eb7b3e0a6e15a2a3f464245864ae8f8644",
+                "repository": "develop",
+                "id": "PkgB/0.1@user/channel#59ba6f9d5109a2692330b3c6b961313b:451532304ef8fa47e00fa54ca3f94d06c6e0e57f#692a3a14fb5860c377c1dff609bc90cb",
                 "artifacts": [
                     {{
                         "sha1": "45f961804e3bcc5267a2f6d130b4dcc16e2379ee",
                         "md5": "d4f703971717722bd84c24eccf50b9fd",
-                        "name": "conan_package.tgz"
+                        "name": "conan_package.tgz",
+                        "path": "user/PkgB/0.1/channel/59ba6f9d5109a2692330b3c6b961313b/package/451532304ef8fa47e00fa54ca3f94d06c6e0e57f/692a3a14fb5860c377c1dff609bc90cb"
                     }},
                     {{
                         "sha1": "9525339890e3b484d5e7d8f351957b6c2a28147f",
                         "md5": "fd6b4a992aa1254fa5a404888ed8c7ce",
-                        "name": "conaninfo.txt"
+                        "name": "conaninfo.txt",
+                        "path": "user/PkgB/0.1/channel/59ba6f9d5109a2692330b3c6b961313b/package/451532304ef8fa47e00fa54ca3f94d06c6e0e57f/692a3a14fb5860c377c1dff609bc90cb"
                     }},
                     {{
                         "sha1": "f8f2795005c8fbfbcddae7224888d66a8f47f533",
                         "md5": "c18ffa171f4df3ab4af24dc443320a5a",
-                        "name": "conanmanifest.txt"
+                        "name": "conanmanifest.txt",
+                        "path": "user/PkgB/0.1/channel/59ba6f9d5109a2692330b3c6b961313b/package/451532304ef8fa47e00fa54ca3f94d06c6e0e57f/692a3a14fb5860c377c1dff609bc90cb"
                     }}
                 ],
                 "dependencies": [
                     {{
                         "sha1": "a96d326d2449a103a4f9e6d81018ffd411b3f4a1",
                         "md5": "43c402f3ad0cc9dfa89c5be37bf9b7e5",
-                        "id": "PkgA/0.2@user/channel:5ab84d6acfe1f23c4fae0ab88f26e3a396351ac9 :: conan_package.tgz"
+                        "id": "PkgA/0.2@user/channel#26386415fb6f92bb9413d60903e5181e:9db1d964f4a0e5590a43a0c634a3196a8a3eca3b#2d0052a59a49a706c057ebeb107292e6 :: conan_package.tgz"
                     }},
                     {{
                         "sha1": "2f452380f6ec5db0baab369d0bc4286793710ca3",
                         "md5": "95adc888e92d1a888454fae2093c0862",
-                        "id": "PkgA/0.2@user/channel:5ab84d6acfe1f23c4fae0ab88f26e3a396351ac9 :: conaninfo.txt"
+                        "id": "PkgA/0.2@user/channel#26386415fb6f92bb9413d60903e5181e:9db1d964f4a0e5590a43a0c634a3196a8a3eca3b#2d0052a59a49a706c057ebeb107292e6 :: conaninfo.txt"
                     }},
                     {{
                         "sha1": "fe0b6d9343648ae2b60d5c6c4ce765291cc278fb",
                         "md5": "2702b1656a7318c01112b90cca875867",
-                        "id": "PkgA/0.2@user/channel:5ab84d6acfe1f23c4fae0ab88f26e3a396351ac9 :: conanmanifest.txt"
+                        "id": "PkgA/0.2@user/channel#26386415fb6f92bb9413d60903e5181e:9db1d964f4a0e5590a43a0c634a3196a8a3eca3b#2d0052a59a49a706c057ebeb107292e6 :: conanmanifest.txt"
                     }}
                 ]
             }},
             {{
                 "type": "conan",
-                "id": "PkgA/0.2@user/channel",
+                "repository": "develop",
+                "id": "PkgA/0.2@user/channel#26386415fb6f92bb9413d60903e5181e",
                 "artifacts": [
                     {{
                         "sha1": "def7797033b5b46ca063aaaf21dc7a9c1b93a35a",
                         "md5": "89b684b95f6f5c7a8e2fda664be22c5a",
-                        "name": "conan_sources.tgz"
+                        "name": "conan_sources.tgz",
+                        "path": "user/PkgA/0.2/channel/26386415fb6f92bb9413d60903e5181e/export"
                     }},
                     {{
                         "sha1": "7bd4da1c70ca29637b159a0131a8b886cfaeeb27",
                         "md5": "00dbccdd251aa5652df8886cf153d2d6",
-                        "name": "conanfile.py"
+                        "name": "conanfile.py",
+                        "path": "user/PkgA/0.2/channel/26386415fb6f92bb9413d60903e5181e/export"
                     }},
                     {{
                         "sha1": "7ca1713befc9eabcfaaa244133e3e173307705f4",
                         "md5": "d723dfc35eb5a121e401818fdb43b210",
-                        "name": "conanmanifest.txt"
+                        "name": "conanmanifest.txt",
+                        "path": "user/PkgA/0.2/channel/26386415fb6f92bb9413d60903e5181e/export"
                     }}
                 ],
                 "dependencies": []
             }},
             {{
                 "type": "conan",
-                "id": "PkgA/0.2@user/channel:5ab84d6acfe1f23c4fae0ab88f26e3a396351ac9",
+                "repository": "develop",
+                "id": "PkgA/0.2@user/channel#26386415fb6f92bb9413d60903e5181e:9db1d964f4a0e5590a43a0c634a3196a8a3eca3b#2d0052a59a49a706c057ebeb107292e6",
                 "artifacts": [
                     {{
                         "sha1": "a96d326d2449a103a4f9e6d81018ffd411b3f4a1",
                         "md5": "43c402f3ad0cc9dfa89c5be37bf9b7e5",
-                        "name": "conan_package.tgz"
+                        "name": "conan_package.tgz",
+                        "path": "user/PkgA/0.2/channel/26386415fb6f92bb9413d60903e5181e/package/9db1d964f4a0e5590a43a0c634a3196a8a3eca3b/2d0052a59a49a706c057ebeb107292e6"
                     }},
                     {{
                         "sha1": "2f452380f6ec5db0baab369d0bc4286793710ca3",
                         "md5": "95adc888e92d1a888454fae2093c0862",
-                        "name": "conaninfo.txt"
+                        "name": "conaninfo.txt",
+                        "path": "user/PkgA/0.2/channel/26386415fb6f92bb9413d60903e5181e/package/9db1d964f4a0e5590a43a0c634a3196a8a3eca3b/2d0052a59a49a706c057ebeb107292e6"
                     }},
                     {{
                         "sha1": "fe0b6d9343648ae2b60d5c6c4ce765291cc278fb",
                         "md5": "2702b1656a7318c01112b90cca875867",
-                        "name": "conanmanifest.txt"
+                        "name": "conanmanifest.txt",
+                        "path": "user/PkgA/0.2/channel/26386415fb6f92bb9413d60903e5181e/package/9db1d964f4a0e5590a43a0c634a3196a8a3eca3b/2d0052a59a49a706c057ebeb107292e6"
                     }}
                 ],
                 "dependencies": []
             }},
             {{
                 "type": "conan",
-                "id": "PkgC/0.1@user/channel",
+                "repository": "develop",
+                "id": "PkgC/0.1@user/channel#0b1a78f5925f62480ed2d97002e926fa",
                 "artifacts": [
                     {{
                         "sha1": "410b7df1fd1483a5a7b4c47e67822fc1e3dd533b",
                         "md5": "461fbd5d7e66ce86b8e56fb2524970dc",
-                        "name": "conan_sources.tgz"
+                        "name": "conan_sources.tgz",
+                        "path": "user/PkgC/0.1/channel/0b1a78f5925f62480ed2d97002e926fa/export"
                     }},
                     {{
                         "sha1": "a058b1a9366a361d71ea5d67997009f7200de6e1",
                         "md5": "a73be4ec0c7301d2ea2dacc873df5483",
-                        "name": "conanfile.py"
+                        "name": "conanfile.py",
+                        "path": "user/PkgC/0.1/channel/0b1a78f5925f62480ed2d97002e926fa/export"
                     }},
                     {{
                         "sha1": "594ff68dadb4cbeb36ff724286032698098b41e7",
                         "md5": "19052f117ce1513c3a815f41fd704c24",
-                        "name": "conanmanifest.txt"
+                        "name": "conanmanifest.txt",
+                        "path": "user/PkgC/0.1/channel/0b1a78f5925f62480ed2d97002e926fa/export"
                     }}
                 ],
                 "dependencies": [
                     {{
                         "sha1": "def7797033b5b46ca063aaaf21dc7a9c1b93a35a",
                         "md5": "89b684b95f6f5c7a8e2fda664be22c5a",
-                        "id": "PkgA/0.2@user/channel :: conan_sources.tgz"
+                        "id": "PkgA/0.2@user/channel#26386415fb6f92bb9413d60903e5181e :: conan_sources.tgz"
                     }},
                     {{
                         "sha1": "7bd4da1c70ca29637b159a0131a8b886cfaeeb27",
                         "md5": "00dbccdd251aa5652df8886cf153d2d6",
-                        "id": "PkgA/0.2@user/channel :: conanfile.py"
+                        "id": "PkgA/0.2@user/channel#26386415fb6f92bb9413d60903e5181e :: conanfile.py"
                     }},
                     {{
                         "sha1": "7ca1713befc9eabcfaaa244133e3e173307705f4",
                         "md5": "d723dfc35eb5a121e401818fdb43b210",
-                        "id": "PkgA/0.2@user/channel :: conanmanifest.txt"
+                        "id": "PkgA/0.2@user/channel#26386415fb6f92bb9413d60903e5181e :: conanmanifest.txt"
                     }}
                 ]
             }},
             {{
                 "type": "conan",
-                "id": "PkgC/0.1@user/channel:09f152eb7b3e0a6e15a2a3f464245864ae8f8644",
+                "repository": "develop",
+                "id": "PkgC/0.1@user/channel#0b1a78f5925f62480ed2d97002e926fa:6a83d7f783e7ee89a83cf2fe72b5f5f67538e2a6#28fb6fe2b23c481d38b88d1521374f3e",
                 "artifacts": [
                     {{
                         "sha1": "0b6a6755369820f66d6a858d3b44775fb1b38f54",
                         "md5": "c1f3a9ff4ee80ab5e5492c1c381dff56",
-                        "name": "conan_package.tgz"
+                        "name": "conan_package.tgz",
+                        "path": "user/PkgC/0.1/channel/0b1a78f5925f62480ed2d97002e926fa/package/6a83d7f783e7ee89a83cf2fe72b5f5f67538e2a6/28fb6fe2b23c481d38b88d1521374f3e"
                     }},
                     {{
                         "sha1": "6bce988c0cfc1d17588c0fddac573066afd8d26d",
                         "md5": "bde279efd0a24162425017d937fe8484",
-                        "name": "conaninfo.txt"
+                        "name": "conaninfo.txt",
+                        "path": "user/PkgC/0.1/channel/0b1a78f5925f62480ed2d97002e926fa/package/6a83d7f783e7ee89a83cf2fe72b5f5f67538e2a6/28fb6fe2b23c481d38b88d1521374f3e"
                     }},
                     {{
                         "sha1": "6a85f6893f316433cd935abad31c4daf80d09884",
                         "md5": "5996a968f13f4e4722d24d9d98ed0923",
-                        "name": "conanmanifest.txt"
+                        "name": "conanmanifest.txt",
+                        "path": "user/PkgC/0.1/channel/0b1a78f5925f62480ed2d97002e926fa/package/6a83d7f783e7ee89a83cf2fe72b5f5f67538e2a6/28fb6fe2b23c481d38b88d1521374f3e"
                     }}
                 ],
                 "dependencies": [
                     {{
                         "sha1": "a96d326d2449a103a4f9e6d81018ffd411b3f4a1",
                         "md5": "43c402f3ad0cc9dfa89c5be37bf9b7e5",
-                        "id": "PkgA/0.2@user/channel:5ab84d6acfe1f23c4fae0ab88f26e3a396351ac9 :: conan_package.tgz"
+                        "id": "PkgA/0.2@user/channel#26386415fb6f92bb9413d60903e5181e:9db1d964f4a0e5590a43a0c634a3196a8a3eca3b#2d0052a59a49a706c057ebeb107292e6 :: conan_package.tgz"
                     }},
                     {{
                         "sha1": "2f452380f6ec5db0baab369d0bc4286793710ca3",
                         "md5": "95adc888e92d1a888454fae2093c0862",
-                        "id": "PkgA/0.2@user/channel:5ab84d6acfe1f23c4fae0ab88f26e3a396351ac9 :: conaninfo.txt"
+                        "id": "PkgA/0.2@user/channel#26386415fb6f92bb9413d60903e5181e:9db1d964f4a0e5590a43a0c634a3196a8a3eca3b#2d0052a59a49a706c057ebeb107292e6 :: conaninfo.txt"
                     }},
                     {{
                         "sha1": "fe0b6d9343648ae2b60d5c6c4ce765291cc278fb",
                         "md5": "2702b1656a7318c01112b90cca875867",
-                        "id": "PkgA/0.2@user/channel:5ab84d6acfe1f23c4fae0ab88f26e3a396351ac9 :: conanmanifest.txt"
+                        "id": "PkgA/0.2@user/channel#26386415fb6f92bb9413d60903e5181e:9db1d964f4a0e5590a43a0c634a3196a8a3eca3b#2d0052a59a49a706c057ebeb107292e6 :: conanmanifest.txt"
                     }}
                 ]
             }}
@@ -503,14 +559,4 @@ class BuildInfoTest(unittest.TestCase):
             mergedinfo = json.load(json_data)
             res_json = json.loads(self.result)
 
-        self.assertEqual(mergedinfo["version"], res_json["version"])
-        self.assertEqual(mergedinfo["name"], res_json["name"])
-        self.assertEqual(mergedinfo["number"], res_json["number"])
-        self.assertEqual(mergedinfo["type"], res_json["type"])
-        self.assertEqual(mergedinfo["started"], res_json["started"])
-        self.assertDictEqual(mergedinfo["buildAgent"], res_json["buildAgent"])
-        for index in range(2):
-            self.assertEqual(mergedinfo["modules"][index]["id"],
-                             res_json["modules"][index]["id"])
-            self.assertEqual(mergedinfo["modules"][index]["type"],
-                             res_json["modules"][index]["type"])
+        self.assertDictEqual(mergedinfo, res_json)

--- a/conans/test/unittests/client/cmd/conan_build_info_test.py
+++ b/conans/test/unittests/client/cmd/conan_build_info_test.py
@@ -559,6 +559,16 @@ class BuildInfoTest(unittest.TestCase):
             mergedinfo = json.load(json_data)
             res_json = json.loads(self.result)
 
-        mergedinfo["started"] = ""
-        res_json["started"] = ""
-        self.assertDictEqual(mergedinfo, res_json)
+        self.assertEqual(mergedinfo["version"], res_json["version"])
+        self.assertEqual(mergedinfo["name"], res_json["name"])
+        self.assertEqual(mergedinfo["number"], res_json["number"])
+        self.assertEqual(mergedinfo["type"], res_json["type"])
+        self.assertDictEqual(mergedinfo["buildAgent"], res_json["buildAgent"])
+
+        for index in range(len(mergedinfo["modules"])):
+            self.assertEqual(mergedinfo["modules"][index]["id"],
+                             res_json["modules"][index]["id"])
+            self.assertEqual(mergedinfo["modules"][index]["type"],
+                             res_json["modules"][index]["type"])
+            self.assertEqual(mergedinfo["modules"][index]["repository"],
+                             res_json["modules"][index]["repository"])

--- a/conans/test/unittests/client/cmd/conan_build_info_test.py
+++ b/conans/test/unittests/client/cmd/conan_build_info_test.py
@@ -6,475 +6,476 @@ import unittest
 from conans.build_info.build_info import update_build_info
 from conans.test.utils.test_files import temp_folder
 from conans.tools import save
+from conans import __version__
 
 
 class BuildInfoTest(unittest.TestCase):
     buildinfo1 = textwrap.dedent("""
-    {
+    {{
         "version": "1.0.1",
         "name": "MyBuildName",
         "number": "42",
         "type": "GENERIC",
         "started": "2019-10-29T10:41:25.000Z",
-        "buildAgent": {
-            "name": "Conan Client",
-            "version": "1.X"
-        },
+        "buildAgent": {{
+            "name": "conan",
+            "version": "{}"
+        }},
         "modules": [
-            {
+            {{
                 "id": "PkgB/0.1@user/channel",
                 "artifacts": [
-                    {
+                    {{
                         "sha1": "aba8527a2c4fc142cf5262298824d3680ecb057f",
                         "md5": "aad124317706ef90df47686329be8e2b",
                         "name": "conan_sources.tgz"
-                    },
-                    {
+                    }},
+                    {{
                         "sha1": "a058b1a9366a361d71ea5d67997009f7200de6e1",
                         "md5": "a73be4ec0c7301d2ea2dacc873df5483",
                         "name": "conanfile.py"
-                    },
-                    {
+                    }},
+                    {{
                         "sha1": "6cbda4a7286d9bb37eb3a6c97b150ed4939f4095",
                         "md5": "67abd07526f4abdf24f88f443c907f78",
                         "name": "conanmanifest.txt"
-                    }
+                    }}
                 ],
                 "dependencies": [
-                    {
+                    {{
                         "sha1": "def7797033b5b46ca063aaaf21dc7a9c1b93a35a",
                         "md5": "89b684b95f6f5c7a8e2fda664be22c5a",
                         "id": "PkgA/0.2@user/channel :: conan_sources.tgz"
-                    },
-                    {
+                    }},
+                    {{
                         "sha1": "7bd4da1c70ca29637b159a0131a8b886cfaeeb27",
                         "md5": "00dbccdd251aa5652df8886cf153d2d6",
                         "id": "PkgA/0.2@user/channel :: conanfile.py"
-                    },
-                    {
+                    }},
+                    {{
                         "sha1": "7ca1713befc9eabcfaaa244133e3e173307705f4",
                         "md5": "d723dfc35eb5a121e401818fdb43b210",
                         "id": "PkgA/0.2@user/channel :: conanmanifest.txt"
-                    }
+                    }}
                 ]
-            },
-            {
+            }},
+            {{
                 "id": "PkgB/0.1@user/channel:09f152eb7b3e0a6e15a2a3f464245864ae8f8644",
                 "artifacts": [
-                    {
+                    {{
                         "sha1": "45f961804e3bcc5267a2f6d130b4dcc16e2379ee",
                         "md5": "d4f703971717722bd84c24eccf50b9fd",
                         "name": "conan_package.tgz"
-                    },
-                    {
+                    }},
+                    {{
                         "sha1": "9525339890e3b484d5e7d8f351957b6c2a28147f",
                         "md5": "fd6b4a992aa1254fa5a404888ed8c7ce",
                         "name": "conaninfo.txt"
-                    },
-                    {
+                    }},
+                    {{
                         "sha1": "f8f2795005c8fbfbcddae7224888d66a8f47f533",
                         "md5": "c18ffa171f4df3ab4af24dc443320a5a",
                         "name": "conanmanifest.txt"
-                    }
+                    }}
                 ],
                 "dependencies": [
-                    {
+                    {{
                         "sha1": "a96d326d2449a103a4f9e6d81018ffd411b3f4a1",
                         "md5": "43c402f3ad0cc9dfa89c5be37bf9b7e5",
                         "id": "PkgA/0.2@user/channel:5ab84d6acfe1f23c4fae0ab88f26e3a396351ac9 :: conan_package.tgz"
-                    },
-                    {
+                    }},
+                    {{
                         "sha1": "2f452380f6ec5db0baab369d0bc4286793710ca3",
                         "md5": "95adc888e92d1a888454fae2093c0862",
                         "id": "PkgA/0.2@user/channel:5ab84d6acfe1f23c4fae0ab88f26e3a396351ac9 :: conaninfo.txt"
-                    },
-                    {
+                    }},
+                    {{
                         "sha1": "fe0b6d9343648ae2b60d5c6c4ce765291cc278fb",
                         "md5": "2702b1656a7318c01112b90cca875867",
                         "id": "PkgA/0.2@user/channel:5ab84d6acfe1f23c4fae0ab88f26e3a396351ac9 :: conanmanifest.txt"
-                    }
+                    }}
                 ]
-            },
-            {
+            }},
+            {{
                 "id": "PkgA/0.2@user/channel",
                 "artifacts": [
-                    {
+                    {{
                         "sha1": "def7797033b5b46ca063aaaf21dc7a9c1b93a35a",
                         "md5": "89b684b95f6f5c7a8e2fda664be22c5a",
                         "name": "conan_sources.tgz"
-                    },
-                    {
+                    }},
+                    {{
                         "sha1": "7bd4da1c70ca29637b159a0131a8b886cfaeeb27",
                         "md5": "00dbccdd251aa5652df8886cf153d2d6",
                         "name": "conanfile.py"
-                    },
-                    {
+                    }},
+                    {{
                         "sha1": "7ca1713befc9eabcfaaa244133e3e173307705f4",
                         "md5": "d723dfc35eb5a121e401818fdb43b210",
                         "name": "conanmanifest.txt"
-                    }
+                    }}
                 ],
                 "dependencies": []
-            },
-            {
+            }},
+            {{
                 "id": "PkgA/0.2@user/channel:5ab84d6acfe1f23c4fae0ab88f26e3a396351ac9",
                 "artifacts": [
-                    {
+                    {{
                         "sha1": "a96d326d2449a103a4f9e6d81018ffd411b3f4a1",
                         "md5": "43c402f3ad0cc9dfa89c5be37bf9b7e5",
                         "name": "conan_package.tgz"
-                    },
-                    {
+                    }},
+                    {{
                         "sha1": "2f452380f6ec5db0baab369d0bc4286793710ca3",
                         "md5": "95adc888e92d1a888454fae2093c0862",
                         "name": "conaninfo.txt"
-                    },
-                    {
+                    }},
+                    {{
                         "sha1": "fe0b6d9343648ae2b60d5c6c4ce765291cc278fb",
                         "md5": "2702b1656a7318c01112b90cca875867",
                         "name": "conanmanifest.txt"
-                    }
+                    }}
                 ],
                 "dependencies": []
-            }
+            }}
         ]
-    }""")
+    }}""".format(__version__))
 
     buildinfo2 = textwrap.dedent("""
-    {
+    {{
         "version": "1.0.1",
         "name": "MyBuildName",
         "number": "42",
         "type": "GENERIC",
         "started": "2019-10-29T10:41:25.000Z",
-        "buildAgent": {
-            "name": "Conan Client",
-            "version": "1.X"
-        },
+        "buildAgent": {{
+            "name": "conan",
+            "version": "{}"
+        }},
         "modules": [
-            {
+            {{
                 "id": "PkgC/0.1@user/channel",
                 "artifacts": [
-                    {
+                    {{
                         "sha1": "410b7df1fd1483a5a7b4c47e67822fc1e3dd533b",
                         "md5": "461fbd5d7e66ce86b8e56fb2524970dc",
                         "name": "conan_sources.tgz"
-                    },
-                    {
+                    }},
+                    {{
                         "sha1": "a058b1a9366a361d71ea5d67997009f7200de6e1",
                         "md5": "a73be4ec0c7301d2ea2dacc873df5483",
                         "name": "conanfile.py"
-                    },
-                    {
+                    }},
+                    {{
                         "sha1": "594ff68dadb4cbeb36ff724286032698098b41e7",
                         "md5": "19052f117ce1513c3a815f41fd704c24",
                         "name": "conanmanifest.txt"
-                    }
+                    }}
                 ],
                 "dependencies": [
-                    {
+                    {{
                         "sha1": "def7797033b5b46ca063aaaf21dc7a9c1b93a35a",
                         "md5": "89b684b95f6f5c7a8e2fda664be22c5a",
                         "id": "PkgA/0.2@user/channel :: conan_sources.tgz"
-                    },
-                    {
+                    }},
+                    {{
                         "sha1": "7bd4da1c70ca29637b159a0131a8b886cfaeeb27",
                         "md5": "00dbccdd251aa5652df8886cf153d2d6",
                         "id": "PkgA/0.2@user/channel :: conanfile.py"
-                    },
-                    {
+                    }},
+                    {{
                         "sha1": "7ca1713befc9eabcfaaa244133e3e173307705f4",
                         "md5": "d723dfc35eb5a121e401818fdb43b210",
                         "id": "PkgA/0.2@user/channel :: conanmanifest.txt"
-                    }
+                    }}
                 ]
-            },
-            {
+            }},
+            {{
                 "id": "PkgC/0.1@user/channel:09f152eb7b3e0a6e15a2a3f464245864ae8f8644",
                 "artifacts": [
-                    {
+                    {{
                         "sha1": "0b6a6755369820f66d6a858d3b44775fb1b38f54",
                         "md5": "c1f3a9ff4ee80ab5e5492c1c381dff56",
                         "name": "conan_package.tgz"
-                    },
-                    {
+                    }},
+                    {{
                         "sha1": "6bce988c0cfc1d17588c0fddac573066afd8d26d",
                         "md5": "bde279efd0a24162425017d937fe8484",
                         "name": "conaninfo.txt"
-                    },
-                    {
+                    }},
+                    {{
                         "sha1": "6a85f6893f316433cd935abad31c4daf80d09884",
                         "md5": "5996a968f13f4e4722d24d9d98ed0923",
                         "name": "conanmanifest.txt"
-                    }
+                    }}
                 ],
                 "dependencies": [
-                    {
+                    {{
                         "sha1": "a96d326d2449a103a4f9e6d81018ffd411b3f4a1",
                         "md5": "43c402f3ad0cc9dfa89c5be37bf9b7e5",
                         "id": "PkgA/0.2@user/channel:5ab84d6acfe1f23c4fae0ab88f26e3a396351ac9 :: conan_package.tgz"
-                    },
-                    {
+                    }},
+                    {{
                         "sha1": "2f452380f6ec5db0baab369d0bc4286793710ca3",
                         "md5": "95adc888e92d1a888454fae2093c0862",
                         "id": "PkgA/0.2@user/channel:5ab84d6acfe1f23c4fae0ab88f26e3a396351ac9 :: conaninfo.txt"
-                    },
-                    {
+                    }},
+                    {{
                         "sha1": "fe0b6d9343648ae2b60d5c6c4ce765291cc278fb",
                         "md5": "2702b1656a7318c01112b90cca875867",
                         "id": "PkgA/0.2@user/channel:5ab84d6acfe1f23c4fae0ab88f26e3a396351ac9 :: conanmanifest.txt"
-                    }
+                    }}
                 ]
-            },
-            {
+            }},
+            {{
                 "id": "PkgA/0.2@user/channel",
                 "artifacts": [
-                    {
+                    {{
                         "sha1": "def7797033b5b46ca063aaaf21dc7a9c1b93a35a",
                         "md5": "89b684b95f6f5c7a8e2fda664be22c5a",
                         "name": "conan_sources.tgz"
-                    },
-                    {
+                    }},
+                    {{
                         "sha1": "7bd4da1c70ca29637b159a0131a8b886cfaeeb27",
                         "md5": "00dbccdd251aa5652df8886cf153d2d6",
                         "name": "conanfile.py"
-                    },
-                    {
+                    }},
+                    {{
                         "sha1": "7ca1713befc9eabcfaaa244133e3e173307705f4",
                         "md5": "d723dfc35eb5a121e401818fdb43b210",
                         "name": "conanmanifest.txt"
-                    }
+                    }}
                 ],
                 "dependencies": []
-            },
-            {
+            }},
+            {{
                 "id": "PkgA/0.2@user/channel:5ab84d6acfe1f23c4fae0ab88f26e3a396351ac9",
                 "artifacts": [
-                    {
+                    {{
                         "sha1": "a96d326d2449a103a4f9e6d81018ffd411b3f4a1",
                         "md5": "43c402f3ad0cc9dfa89c5be37bf9b7e5",
                         "name": "conan_package.tgz"
-                    },
-                    {
+                    }},
+                    {{
                         "sha1": "2f452380f6ec5db0baab369d0bc4286793710ca3",
                         "md5": "95adc888e92d1a888454fae2093c0862",
                         "name": "conaninfo.txt"
-                    },
-                    {
+                    }},
+                    {{
                         "sha1": "fe0b6d9343648ae2b60d5c6c4ce765291cc278fb",
                         "md5": "2702b1656a7318c01112b90cca875867",
                         "name": "conanmanifest.txt"
-                    }
+                    }}
                 ],
                 "dependencies": []
-            }
+            }}
         ]
-    }""")
+    }}""".format(__version__))
 
     result = textwrap.dedent("""
-    {
+    {{
         "version": "1.0.1",
         "name": "MyBuildName",
         "number": "42",
         "type": "GENERIC",
         "started": "2019-10-29T10:41:25.000Z",
-        "buildAgent": {
-            "name": "Conan Client",
-            "version": "1.X"
-        },
+        "buildAgent": {{
+            "name": "conan",
+            "version": "{}"
+        }},
         "modules": [
-            {
+            {{
                 "id": "PkgB/0.1@user/channel",
                 "artifacts": [
-                    {
+                    {{
                         "sha1": "aba8527a2c4fc142cf5262298824d3680ecb057f",
                         "md5": "aad124317706ef90df47686329be8e2b",
                         "name": "conan_sources.tgz"
-                    },
-                    {
+                    }},
+                    {{
                         "sha1": "a058b1a9366a361d71ea5d67997009f7200de6e1",
                         "md5": "a73be4ec0c7301d2ea2dacc873df5483",
                         "name": "conanfile.py"
-                    },
-                    {
+                    }},
+                    {{
                         "sha1": "6cbda4a7286d9bb37eb3a6c97b150ed4939f4095",
                         "md5": "67abd07526f4abdf24f88f443c907f78",
                         "name": "conanmanifest.txt"
-                    }
+                    }}
                 ],
                 "dependencies": [
-                    {
+                    {{
                         "sha1": "def7797033b5b46ca063aaaf21dc7a9c1b93a35a",
                         "md5": "89b684b95f6f5c7a8e2fda664be22c5a",
                         "id": "PkgA/0.2@user/channel :: conan_sources.tgz"
-                    },
-                    {
+                    }},
+                    {{
                         "sha1": "7bd4da1c70ca29637b159a0131a8b886cfaeeb27",
                         "md5": "00dbccdd251aa5652df8886cf153d2d6",
                         "id": "PkgA/0.2@user/channel :: conanfile.py"
-                    },
-                    {
+                    }},
+                    {{
                         "sha1": "7ca1713befc9eabcfaaa244133e3e173307705f4",
                         "md5": "d723dfc35eb5a121e401818fdb43b210",
                         "id": "PkgA/0.2@user/channel :: conanmanifest.txt"
-                    }
+                    }}
                 ]
-            },
-            {
+            }},
+            {{
                 "id": "PkgB/0.1@user/channel:09f152eb7b3e0a6e15a2a3f464245864ae8f8644",
                 "artifacts": [
-                    {
+                    {{
                         "sha1": "45f961804e3bcc5267a2f6d130b4dcc16e2379ee",
                         "md5": "d4f703971717722bd84c24eccf50b9fd",
                         "name": "conan_package.tgz"
-                    },
-                    {
+                    }},
+                    {{
                         "sha1": "9525339890e3b484d5e7d8f351957b6c2a28147f",
                         "md5": "fd6b4a992aa1254fa5a404888ed8c7ce",
                         "name": "conaninfo.txt"
-                    },
-                    {
+                    }},
+                    {{
                         "sha1": "f8f2795005c8fbfbcddae7224888d66a8f47f533",
                         "md5": "c18ffa171f4df3ab4af24dc443320a5a",
                         "name": "conanmanifest.txt"
-                    }
+                    }}
                 ],
                 "dependencies": [
-                    {
+                    {{
                         "sha1": "a96d326d2449a103a4f9e6d81018ffd411b3f4a1",
                         "md5": "43c402f3ad0cc9dfa89c5be37bf9b7e5",
                         "id": "PkgA/0.2@user/channel:5ab84d6acfe1f23c4fae0ab88f26e3a396351ac9 :: conan_package.tgz"
-                    },
-                    {
+                    }},
+                    {{
                         "sha1": "2f452380f6ec5db0baab369d0bc4286793710ca3",
                         "md5": "95adc888e92d1a888454fae2093c0862",
                         "id": "PkgA/0.2@user/channel:5ab84d6acfe1f23c4fae0ab88f26e3a396351ac9 :: conaninfo.txt"
-                    },
-                    {
+                    }},
+                    {{
                         "sha1": "fe0b6d9343648ae2b60d5c6c4ce765291cc278fb",
                         "md5": "2702b1656a7318c01112b90cca875867",
                         "id": "PkgA/0.2@user/channel:5ab84d6acfe1f23c4fae0ab88f26e3a396351ac9 :: conanmanifest.txt"
-                    }
+                    }}
                 ]
-            },
-            {
+            }},
+            {{
                 "id": "PkgA/0.2@user/channel",
                 "artifacts": [
-                    {
+                    {{
                         "sha1": "def7797033b5b46ca063aaaf21dc7a9c1b93a35a",
                         "md5": "89b684b95f6f5c7a8e2fda664be22c5a",
                         "name": "conan_sources.tgz"
-                    },
-                    {
+                    }},
+                    {{
                         "sha1": "7bd4da1c70ca29637b159a0131a8b886cfaeeb27",
                         "md5": "00dbccdd251aa5652df8886cf153d2d6",
                         "name": "conanfile.py"
-                    },
-                    {
+                    }},
+                    {{
                         "sha1": "7ca1713befc9eabcfaaa244133e3e173307705f4",
                         "md5": "d723dfc35eb5a121e401818fdb43b210",
                         "name": "conanmanifest.txt"
-                    }
+                    }}
                 ],
                 "dependencies": []
-            },
-            {
+            }},
+            {{
                 "id": "PkgA/0.2@user/channel:5ab84d6acfe1f23c4fae0ab88f26e3a396351ac9",
                 "artifacts": [
-                    {
+                    {{
                         "sha1": "a96d326d2449a103a4f9e6d81018ffd411b3f4a1",
                         "md5": "43c402f3ad0cc9dfa89c5be37bf9b7e5",
                         "name": "conan_package.tgz"
-                    },
-                    {
+                    }},
+                    {{
                         "sha1": "2f452380f6ec5db0baab369d0bc4286793710ca3",
                         "md5": "95adc888e92d1a888454fae2093c0862",
                         "name": "conaninfo.txt"
-                    },
-                    {
+                    }},
+                    {{
                         "sha1": "fe0b6d9343648ae2b60d5c6c4ce765291cc278fb",
                         "md5": "2702b1656a7318c01112b90cca875867",
                         "name": "conanmanifest.txt"
-                    }
+                    }}
                 ],
                 "dependencies": []
-            },
-            {
+            }},
+            {{
                 "id": "PkgC/0.1@user/channel",
                 "artifacts": [
-                    {
+                    {{
                         "sha1": "410b7df1fd1483a5a7b4c47e67822fc1e3dd533b",
                         "md5": "461fbd5d7e66ce86b8e56fb2524970dc",
                         "name": "conan_sources.tgz"
-                    },
-                    {
+                    }},
+                    {{
                         "sha1": "a058b1a9366a361d71ea5d67997009f7200de6e1",
                         "md5": "a73be4ec0c7301d2ea2dacc873df5483",
                         "name": "conanfile.py"
-                    },
-                    {
+                    }},
+                    {{
                         "sha1": "594ff68dadb4cbeb36ff724286032698098b41e7",
                         "md5": "19052f117ce1513c3a815f41fd704c24",
                         "name": "conanmanifest.txt"
-                    }
+                    }}
                 ],
                 "dependencies": [
-                    {
+                    {{
                         "sha1": "def7797033b5b46ca063aaaf21dc7a9c1b93a35a",
                         "md5": "89b684b95f6f5c7a8e2fda664be22c5a",
                         "id": "PkgA/0.2@user/channel :: conan_sources.tgz"
-                    },
-                    {
+                    }},
+                    {{
                         "sha1": "7bd4da1c70ca29637b159a0131a8b886cfaeeb27",
                         "md5": "00dbccdd251aa5652df8886cf153d2d6",
                         "id": "PkgA/0.2@user/channel :: conanfile.py"
-                    },
-                    {
+                    }},
+                    {{
                         "sha1": "7ca1713befc9eabcfaaa244133e3e173307705f4",
                         "md5": "d723dfc35eb5a121e401818fdb43b210",
                         "id": "PkgA/0.2@user/channel :: conanmanifest.txt"
-                    }
+                    }}
                 ]
-            },
-            {
+            }},
+            {{
                 "id": "PkgC/0.1@user/channel:09f152eb7b3e0a6e15a2a3f464245864ae8f8644",
                 "artifacts": [
-                    {
+                    {{
                         "sha1": "0b6a6755369820f66d6a858d3b44775fb1b38f54",
                         "md5": "c1f3a9ff4ee80ab5e5492c1c381dff56",
                         "name": "conan_package.tgz"
-                    },
-                    {
+                    }},
+                    {{
                         "sha1": "6bce988c0cfc1d17588c0fddac573066afd8d26d",
                         "md5": "bde279efd0a24162425017d937fe8484",
                         "name": "conaninfo.txt"
-                    },
-                    {
+                    }},
+                    {{
                         "sha1": "6a85f6893f316433cd935abad31c4daf80d09884",
                         "md5": "5996a968f13f4e4722d24d9d98ed0923",
                         "name": "conanmanifest.txt"
-                    }
+                    }}
                 ],
                 "dependencies": [
-                    {
+                    {{
                         "sha1": "a96d326d2449a103a4f9e6d81018ffd411b3f4a1",
                         "md5": "43c402f3ad0cc9dfa89c5be37bf9b7e5",
                         "id": "PkgA/0.2@user/channel:5ab84d6acfe1f23c4fae0ab88f26e3a396351ac9 :: conan_package.tgz"
-                    },
-                    {
+                    }},
+                    {{
                         "sha1": "2f452380f6ec5db0baab369d0bc4286793710ca3",
                         "md5": "95adc888e92d1a888454fae2093c0862",
                         "id": "PkgA/0.2@user/channel:5ab84d6acfe1f23c4fae0ab88f26e3a396351ac9 :: conaninfo.txt"
-                    },
-                    {
+                    }},
+                    {{
                         "sha1": "fe0b6d9343648ae2b60d5c6c4ce765291cc278fb",
                         "md5": "2702b1656a7318c01112b90cca875867",
                         "id": "PkgA/0.2@user/channel:5ab84d6acfe1f23c4fae0ab88f26e3a396351ac9 :: conanmanifest.txt"
-                    }
+                    }}
                 ]
-            }
+            }}
         ]
-    }""")
+    }}""".format(__version__))
 
     def test_update_build_info(self):
         tmp_dir = temp_folder()

--- a/conans/test/unittests/client/cmd/conan_build_info_test.py
+++ b/conans/test/unittests/client/cmd/conan_build_info_test.py
@@ -23,6 +23,7 @@ class BuildInfoTest(unittest.TestCase):
         }},
         "modules": [
             {{
+                "type": "conan",
                 "id": "PkgB/0.1@user/channel",
                 "artifacts": [
                     {{
@@ -60,6 +61,7 @@ class BuildInfoTest(unittest.TestCase):
                 ]
             }},
             {{
+                "type": "conan",
                 "id": "PkgB/0.1@user/channel:09f152eb7b3e0a6e15a2a3f464245864ae8f8644",
                 "artifacts": [
                     {{
@@ -97,6 +99,7 @@ class BuildInfoTest(unittest.TestCase):
                 ]
             }},
             {{
+                "type": "conan",
                 "id": "PkgA/0.2@user/channel",
                 "artifacts": [
                     {{
@@ -118,6 +121,7 @@ class BuildInfoTest(unittest.TestCase):
                 "dependencies": []
             }},
             {{
+                "type": "conan",
                 "id": "PkgA/0.2@user/channel:5ab84d6acfe1f23c4fae0ab88f26e3a396351ac9",
                 "artifacts": [
                     {{
@@ -154,6 +158,7 @@ class BuildInfoTest(unittest.TestCase):
         }},
         "modules": [
             {{
+                "type": "conan",
                 "id": "PkgC/0.1@user/channel",
                 "artifacts": [
                     {{
@@ -191,6 +196,7 @@ class BuildInfoTest(unittest.TestCase):
                 ]
             }},
             {{
+                "type": "conan",
                 "id": "PkgC/0.1@user/channel:09f152eb7b3e0a6e15a2a3f464245864ae8f8644",
                 "artifacts": [
                     {{
@@ -228,6 +234,7 @@ class BuildInfoTest(unittest.TestCase):
                 ]
             }},
             {{
+                "type": "conan",
                 "id": "PkgA/0.2@user/channel",
                 "artifacts": [
                     {{
@@ -249,6 +256,7 @@ class BuildInfoTest(unittest.TestCase):
                 "dependencies": []
             }},
             {{
+                "type": "conan",
                 "id": "PkgA/0.2@user/channel:5ab84d6acfe1f23c4fae0ab88f26e3a396351ac9",
                 "artifacts": [
                     {{
@@ -285,6 +293,7 @@ class BuildInfoTest(unittest.TestCase):
         }},
         "modules": [
             {{
+                "type": "conan",
                 "id": "PkgB/0.1@user/channel",
                 "artifacts": [
                     {{
@@ -322,6 +331,7 @@ class BuildInfoTest(unittest.TestCase):
                 ]
             }},
             {{
+                "type": "conan",
                 "id": "PkgB/0.1@user/channel:09f152eb7b3e0a6e15a2a3f464245864ae8f8644",
                 "artifacts": [
                     {{
@@ -359,6 +369,7 @@ class BuildInfoTest(unittest.TestCase):
                 ]
             }},
             {{
+                "type": "conan",
                 "id": "PkgA/0.2@user/channel",
                 "artifacts": [
                     {{
@@ -380,6 +391,7 @@ class BuildInfoTest(unittest.TestCase):
                 "dependencies": []
             }},
             {{
+                "type": "conan",
                 "id": "PkgA/0.2@user/channel:5ab84d6acfe1f23c4fae0ab88f26e3a396351ac9",
                 "artifacts": [
                     {{
@@ -401,6 +413,7 @@ class BuildInfoTest(unittest.TestCase):
                 "dependencies": []
             }},
             {{
+                "type": "conan",
                 "id": "PkgC/0.1@user/channel",
                 "artifacts": [
                     {{
@@ -438,6 +451,7 @@ class BuildInfoTest(unittest.TestCase):
                 ]
             }},
             {{
+                "type": "conan",
                 "id": "PkgC/0.1@user/channel:09f152eb7b3e0a6e15a2a3f464245864ae8f8644",
                 "artifacts": [
                     {{
@@ -498,3 +512,5 @@ class BuildInfoTest(unittest.TestCase):
         for index in range(2):
             self.assertEqual(mergedinfo["modules"][index]["id"],
                              res_json["modules"][index]["id"])
+            self.assertEqual(mergedinfo["modules"][index]["type"],
+                             res_json["modules"][index]["type"])


### PR DESCRIPTION
Changelog: Feature: Add `path` and `repository` properties to _conan_build_info --v2_.
Docs: omit

Update on Conan BuildInfo properties:

- `repository` and `type` property at module level available from Artifactory 7.15
- `path` property will be supported in the future

On top of: https://github.com/conan-io/conan/pull/8433

- [X] Refer to the issue that supports this Pull Request.
- [X] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [X] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [X] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 

<sup>**Note:** By default this PR will skip the slower tests and will use a limited set of python versions. Check [here](https://github.com/conan-io/conan/blob/develop/.github/PR_INCREASE_TESTING.md) how to increase the testing level by writing some tags in the current PR body text.</sup>
