### PR TITLE
Fix: conan_v2_error if scm_to_conandata is not enabled

### DIFF
--- a/conans/client/cmd/export.py
+++ b/conans/client/cmd/export.py
@@ -16,6 +16,7 @@ from conans.model.ref import ConanFileReference
 from conans.model.scm import SCM, get_scm_data
 from conans.paths import CONANFILE, DATA_YML
 from conans.search.search import search_recipes, search_packages
+from conans.util.conan_v2_mode import conan_v2_error
 from conans.util.files import is_dirty, load, rmdir, save, set_dirty, remove, mkdir, \
     merge_directories, clean_dirty
 from conans.util.log import logger
@@ -298,6 +299,7 @@ def _replace_scm_data_in_recipe(package_layout, scm_data, scm_to_conandata):
 
         save(conandata_path, yaml.safe_dump(conandata_yml, default_flow_style=False))
     else:
+        conan_v2_error("general.scm_to_conandata should be set to 1")
         _replace_scm_data_in_conanfile(package_layout.conanfile(), scm_data)
 
 


### PR DESCRIPTION
#5777 

Changelog: Fix: `conan_v2_error` if `scm_to_conandata` is not enabled.
Docs: omit

- [ ] Refer to the issue that supports this Pull Request.
- [ ] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [ ] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [ ] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 

<sup>**Note:** By default this PR will skip the slower tests and will use a limited set of python versions. Check [here](https://github.com/conan-io/conan/blob/develop/.github/PR_INCREASE_TESTING.md) how to increase the testing level by writing some tags in the current PR body text.</sup>
