### PR TITLE
Fix profile repeated build requires

### DIFF
--- a/conans/client/profile_loader.py
+++ b/conans/client/profile_loader.py
@@ -137,7 +137,7 @@ def _load_profile(text, profile_path, default_folder):
         for include in profile_parser.get_includes():
             # Recursion !!
             profile, included_vars = read_profile(include, cwd, default_folder)
-            inherited_profile.update(profile)
+            inherited_profile.update_profile(profile)
             profile_parser.update_vars(included_vars)
 
         # Apply the automatic PROFILE_DIR variable

--- a/conans/client/profile_loader.py
+++ b/conans/client/profile_loader.py
@@ -137,7 +137,7 @@ def _load_profile(text, profile_path, default_folder):
         for include in profile_parser.get_includes():
             # Recursion !!
             profile, included_vars = read_profile(include, cwd, default_folder)
-            inherited_profile.update_profile(profile)
+            inherited_profile.compose(profile)
             profile_parser.update_vars(included_vars)
 
         # Apply the automatic PROFILE_DIR variable
@@ -237,12 +237,12 @@ def profile_from_args(profiles, settings, options, env, cwd, cache):
         result = Profile()
         for p in profiles:
             tmp, _ = read_profile(p, cwd, cache.profiles_path)
-            result.update_profile(tmp)
+            result.compose(tmp)
 
     args_profile = _profile_parse_args(settings, options, env)
 
     if result:
-        result.update_profile(args_profile)
+        result.compose(args_profile)
     else:
         result = args_profile
     return result

--- a/conans/client/profile_loader.py
+++ b/conans/client/profile_loader.py
@@ -237,12 +237,12 @@ def profile_from_args(profiles, settings, options, env, cwd, cache):
         result = Profile()
         for p in profiles:
             tmp, _ = read_profile(p, cwd, cache.profiles_path)
-            result.update(tmp)
+            result.update_profile(tmp)
 
     args_profile = _profile_parse_args(settings, options, env)
 
     if result:
-        result.update(args_profile)
+        result.update_profile(args_profile)
     else:
         result = args_profile
     return result

--- a/conans/model/profile.py
+++ b/conans/model/profile.py
@@ -103,6 +103,7 @@ class Profile(object):
             existing = OrderedDict()
             if existing_build_requires is not None:
                 for br in existing_build_requires:
+                    # TODO: Understand why sometimes they are str and other are ConanFileReference
                     r = ConanFileReference.loads(br) \
                          if not isinstance(br, ConanFileReference) else br
                     existing[r.name] = br

--- a/conans/model/profile.py
+++ b/conans/model/profile.py
@@ -90,7 +90,7 @@ class Profile(object):
 
         return "\n".join(result).replace("\n\n", "\n")
 
-    def update(self, other):
+    def update_profile(self, other):
         self.update_settings(other.settings)
         self.update_package_settings(other.package_settings)
         # this is the opposite
@@ -103,12 +103,14 @@ class Profile(object):
             existing = OrderedDict()
             if existing_build_requires is not None:
                 for br in existing_build_requires:
-                    r = ConanFileReference.loads(br)
-                    existing[r.name] = r
+                    r = (ConanFileReference.loads(br)
+                         if not isinstance(br, ConanFileReference) else br)
+                    existing[r.name] = br
             for req in req_list:
-                r = ConanFileReference.loads(req)
-                existing[r.name] = r
-            self.build_requires[pattern] = [repr(r) for r in existing.values()]
+                r = (ConanFileReference.loads(req)
+                     if not isinstance(req, ConanFileReference) else req)
+                existing[r.name] = req
+            self.build_requires[pattern] = list(existing.values())
 
         self.conf.update_conf_definition(other.conf)
 

--- a/conans/model/profile.py
+++ b/conans/model/profile.py
@@ -107,8 +107,8 @@ class Profile(object):
                          if not isinstance(br, ConanFileReference) else br
                     existing[r.name] = br
             for req in req_list:
-                r = (ConanFileReference.loads(req)
-                     if not isinstance(req, ConanFileReference) else req)
+                r = ConanFileReference.loads(req) \
+                     if not isinstance(req, ConanFileReference) else req
                 existing[r.name] = req
             self.build_requires[pattern] = list(existing.values())
 

--- a/conans/model/profile.py
+++ b/conans/model/profile.py
@@ -103,8 +103,8 @@ class Profile(object):
             existing = OrderedDict()
             if existing_build_requires is not None:
                 for br in existing_build_requires:
-                    r = (ConanFileReference.loads(br)
-                         if not isinstance(br, ConanFileReference) else br)
+                    r = ConanFileReference.loads(br) \
+                         if not isinstance(br, ConanFileReference) else br
                     existing[r.name] = br
             for req in req_list:
                 r = (ConanFileReference.loads(req)

--- a/conans/model/profile.py
+++ b/conans/model/profile.py
@@ -90,7 +90,7 @@ class Profile(object):
 
         return "\n".join(result).replace("\n\n", "\n")
 
-    def update_profile(self, other):
+    def compose(self, other):
         self.update_settings(other.settings)
         self.update_package_settings(other.package_settings)
         # this is the opposite

--- a/conans/test/unittests/client/profile_loader/profile_loader_test.py
+++ b/conans/test/unittests/client/profile_loader/profile_loader_test.py
@@ -312,9 +312,9 @@ one/1.5@lasote/stable
         self.assertEqual("1", profile.env_values.data["package1"]["ENVY"])
         self.assertEqual(profile.settings, {"os": "1"})
         self.assertEqual(profile.options.as_list(), [('zlib:aoption', '1'), ('zlib:otheroption', '12')])
-        self.assertEqual(profile.build_requires, {"*": [ConanFileReference.loads("one/1.0@lasote/stable"),
-                                                         ConanFileReference.loads("two/1.2@lasote/stable"),
-                                                         ConanFileReference.loads("one/1.5@lasote/stable")]})
+        self.assertEqual(profile.build_requires, {"*": [ConanFileReference.loads("one/1.5@lasote/stable"),
+                                                        ConanFileReference.loads("two/1.2@lasote/stable"),
+                                                        ]})
 
     def test_profile_dir(self):
         tmp = temp_folder()

--- a/conans/test/unittests/model/profile_test.py
+++ b/conans/test/unittests/model/profile_test.py
@@ -119,17 +119,17 @@ def test_update_build_requires():
     profile2 = Profile()
     profile2.build_requires["*"] = ["zlib/1.2.8"]
 
-    profile.update(profile2)
+    profile.update_profile(profile2)
     assert profile.build_requires["*"] == ["zlib/1.2.8"]
 
     profile3 = Profile()
     profile3.build_requires["*"] = ["zlib/1.2.11"]
 
-    profile.update(profile3)
+    profile.update_profile(profile3)
     assert profile.build_requires["*"] == ["zlib/1.2.11"]
 
     profile4 = Profile()
     profile4.build_requires["*"] = ["cmake/2.7"]
 
-    profile.update(profile4)
+    profile.update_profile(profile4)
     assert profile.build_requires["*"] == ["zlib/1.2.11", "cmake/2.7"]

--- a/conans/test/unittests/model/profile_test.py
+++ b/conans/test/unittests/model/profile_test.py
@@ -127,3 +127,9 @@ def test_update_build_requires():
 
     profile.update(profile3)
     assert profile.build_requires["*"] == ["zlib/1.2.11"]
+
+    profile4 = Profile()
+    profile4.build_requires["*"] = ["cmake/2.7"]
+
+    profile.update(profile4)
+    assert profile.build_requires["*"] == ["zlib/1.2.11", "cmake/2.7"]

--- a/conans/test/unittests/model/profile_test.py
+++ b/conans/test/unittests/model/profile_test.py
@@ -119,17 +119,17 @@ def test_update_build_requires():
     profile2 = Profile()
     profile2.build_requires["*"] = ["zlib/1.2.8"]
 
-    profile.update_profile(profile2)
+    profile.compose(profile2)
     assert profile.build_requires["*"] == ["zlib/1.2.8"]
 
     profile3 = Profile()
     profile3.build_requires["*"] = ["zlib/1.2.11"]
 
-    profile.update_profile(profile3)
+    profile.compose(profile3)
     assert profile.build_requires["*"] == ["zlib/1.2.11"]
 
     profile4 = Profile()
     profile4.build_requires["*"] = ["cmake/2.7"]
 
-    profile.update_profile(profile4)
+    profile.compose(profile4)
     assert profile.build_requires["*"] == ["zlib/1.2.11", "cmake/2.7"]

--- a/conans/test/unittests/model/profile_test.py
+++ b/conans/test/unittests/model/profile_test.py
@@ -21,8 +21,8 @@ os=Windows
 
         new_profile.update_settings(OrderedDict([("compiler", "2"), ("compiler.version", "3")]))
         self.assertEqual(new_profile.settings,
-                          OrderedDict([("os", "Windows"), ("OTHER", "2"),
-                                       ("compiler", "2"), ("compiler.version", "3")]))
+                         OrderedDict([("os", "Windows"), ("OTHER", "2"),
+                                      ("compiler", "2"), ("compiler.version", "3")]))
 
     def test_env_vars_inheritance(self):
         tmp_dir = temp_folder()
@@ -109,3 +109,21 @@ zlib/*: aaaa/1.2.3@lasote/testing, bb/1.2@lasote/testing
                          '[build_requires]\n'
                          '[env]\nCC=path/to/my/compiler/gcc\nCXX=path/to/my/compiler/g++',
                          profile.dumps())
+
+
+def test_update_build_requires():
+    # https://github.com/conan-io/conan/issues/8205#issuecomment-775032229
+    profile = Profile()
+    profile.build_requires["*"] = ["zlib/1.2.8"]
+
+    profile2 = Profile()
+    profile2.build_requires["*"] = ["zlib/1.2.8"]
+
+    profile.update(profile2)
+    assert profile.build_requires["*"] == ["zlib/1.2.8"]
+
+    profile3 = Profile()
+    profile3.build_requires["*"] = ["zlib/1.2.11"]
+
+    profile.update(profile3)
+    assert profile.build_requires["*"] == ["zlib/1.2.11"]


### PR DESCRIPTION
Changelog: Bugfix: Fix repeated ``build_requires``, including conflicting versions in profile composition or inclusion that repeats ``[build_requires]`` values.
Docs: Omit


Comes from https://github.com/conan-io/conan/issues/8205#issuecomment-775032229