### PR TITLE
[develop2] Remove built-in attribute_checker hook

### DIFF
--- a/conans/client/conf/__init__.py
+++ b/conans/client/conf/__init__.py
@@ -213,10 +213,6 @@ _t_default_client_conf = Template(textwrap.dedent("""
     #   hostname.to.be.proxied.com = http://user:pass@10.10.1.10:3128
     # You can skip the proxy for the matching (fnmatch) urls (comma-separated)
     # no_proxy_match = *bintray.com*, https://myserver.*
-
-    [hooks]    # environment CONAN_HOOKS
-    attribute_checker
-
     """))
 
 

--- a/conans/client/hook_manager.py
+++ b/conans/client/hook_manager.py
@@ -10,16 +10,6 @@ from conans.client.tools.files import chdir
 from conans.errors import ConanException, NotFoundException
 from conans.util.files import save
 
-attribute_checker_hook = """
-def pre_export(output, conanfile, conanfile_path, reference, **kwargs):
-    # Check basic meta-data
-    for field in ["url", "license", "description"]:
-        field_value = getattr(conanfile, field, None)
-        if not field_value:
-            output.warn("Conanfile doesn't have '%s'. It is recommended to add it as attribute"
-                        % field)
-"""
-
 valid_hook_methods = ["pre_export", "post_export",
                       "pre_source", "post_source",
                       "pre_build", "post_build",
@@ -40,7 +30,6 @@ class HookManager(object):
         self._hook_names = hook_names
         self.hooks = defaultdict(list)
         self.output = output
-        self._attribute_checker_path = os.path.join(self._hooks_folder, "attribute_checker.py")
         self._mutex = Lock()
 
     def execute(self, method_name, **kwargs):
@@ -48,8 +37,6 @@ class HookManager(object):
         # concurrent (e.g. upload --parallel)
         self._mutex.acquire()
         try:
-            if not os.path.exists(self._attribute_checker_path):
-                save(self._attribute_checker_path, attribute_checker_hook)
             if not self.hooks:
                 self.load_hooks()
         finally:

--- a/conans/test/functional/command/config_install_test.py
+++ b/conans/test/functional/command/config_install_test.py
@@ -115,7 +115,6 @@ class ConfigInstallTest(unittest.TestCase):
         hooks = config.get_item("hooks")
         self.assertIn("foo", hooks)
         self.assertIn("custom/custom", hooks)
-        self.assertIn("attribute_checker", hooks)
         client.run('config install "%s"' % folder)
         self.assertIn("Processing conan.conf", client.out)
         content = load(client.cache.conan_conf_path)

--- a/conans/test/functional/command/export/export_test.py
+++ b/conans/test/functional/command/export/export_test.py
@@ -27,7 +27,6 @@ class ExportSettingsTest(unittest.TestCase):
             """)
         client.save({"conanfile.py": conanfile})
         client.run("export . lasote/stable")
-        self.assertIn("WARN: Conanfile doesn't have 'license'", client.out)
         client.run("install Hello/1.2@lasote/stable -s os=Windows", assert_error=True)
         self.assertIn("'Windows' is not a valid 'settings.os' value", client.out)
         self.assertIn("Possible values are ['Linux']", client.out)
@@ -80,7 +79,6 @@ class ExportSettingsTest(unittest.TestCase):
             save(os.path.join(export_path, "file1.txt"), "")
         with self.assertRaises(IOError):
             save(os.path.join(export_src_path, "file2.txt"), "")
-        self.assertIn("WARN: Conanfile doesn't have 'license'", client.out)
 
         os.chmod(os.path.join(client.current_folder, "file1.txt"), mode1 | stat.S_IWRITE)
         os.chmod(os.path.join(client.current_folder, "file2.txt"), mode2 | stat.S_IWRITE)

--- a/conans/test/functional/command/upload/upload_complete_test.py
+++ b/conans/test/functional/command/upload/upload_complete_test.py
@@ -307,7 +307,6 @@ class TestConan(ConanFile):
         files = {CONANFILE: conanfile}
         self.client.save(files)
         self.client.run("export . lasote/stable")
-        self.assertIn("WARN: Conanfile doesn't have 'license'", self.client.out)
         self.client.run("upload Hello/1.2@lasote/stable")
         self.assertIn("Uploading conanmanifest.txt", self.client.out)
 

--- a/conans/test/integration/hooks/hook_test.py
+++ b/conans/test/integration/hooks/hook_test.py
@@ -173,18 +173,6 @@ def pre_export(output, conanfile_path, reference, **kwargs):
 
 class HookTest(unittest.TestCase):
 
-    def test_default_hook(self):
-        client = TestClient()
-        self.assertTrue(client.cache.hooks_path.endswith("hooks"))
-        client.save({"conanfile.py": conanfile_basic})
-        client.run("export . danimtb/testing")
-        self.assertIn("[HOOK - attribute_checker.py] pre_export(): "
-                      "WARN: Conanfile doesn't have 'url'", client.out)
-        self.assertIn("[HOOK - attribute_checker.py] pre_export(): "
-                      "WARN: Conanfile doesn't have 'description'", client.out)
-        self.assertIn("[HOOK - attribute_checker.py] pre_export(): "
-                      "WARN: Conanfile doesn't have 'license'", client.out)
-
     def test_complete_hook(self):
         server = TestServer([], users={"danimtb": "pass"})
         client = TestClient(servers={"default": server}, users={"default": [("danimtb", "pass")]})


### PR DESCRIPTION
Changelog: Feature: Remove built-in attribute_checker hook
Docs: omit?

There is still some code related to the attribute_checker hook in migrations but I didn't remove it as I believe migrations will be completely removed in another PR

- [x] Refer to the issue that supports this Pull Request: closes #8444
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [x] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 

<sup>**Note:** By default this PR will skip the slower tests and will use a limited set of python versions. Check [here](https://github.com/conan-io/conan/blob/develop/.github/PR_INCREASE_TESTING.md) how to increase the testing level by writing some tags in the current PR body text.</sup>
