### PR TITLE
Fix: add MSYS2/MinGW32/MinGW64/Cygwin tests

### DIFF
--- a/conans/test/assets/sources.py
+++ b/conans/test/assets/sources.py
@@ -72,6 +72,24 @@ int {{name}}(){
     std::cout << "  {{ msg or name }} __apple_build_version__" << __apple_build_version__<< "\n";
     #endif
 
+    // SUBSYSTEMS
+
+    #if __MSYS__
+    std::cout << "  {{ msg or name }} __MSYS__" << __MSYS__<< "\n";
+    #endif
+
+    #if __MINGW32__
+    std::cout << "  {{ msg or name }} __MINGW32__" << __MINGW32__<< "\n";
+    #endif
+
+    #if __MINGW64__
+    std::cout << "  {{ msg or name }} __MINGW64__" << __MINGW64__<< "\n";
+    #endif
+
+    #if __CYGWIN__
+    std::cout << "  {{ msg or name }} __CYGWIN__" << __CYGWIN__<< "\n";
+    #endif
+
     {% for it in preprocessor -%}
     std::cout << "  {{msg}} {{it}}: " <<  {{it}} << "\n";
     {%- endfor %}

--- a/conans/test/conftest.py
+++ b/conans/test/conftest.py
@@ -7,13 +7,20 @@ from conans.errors import ConanException
 
 tool_locations = {
     'msys2': os.getenv("CONAN_MSYS2_PATH", "C:/msys64/usr/bin"),
-    'cygwin': os.getenv("CONAN_CYGWIN_PATH", "C:/cygwin64/bin")
+    'cygwin': os.getenv("CONAN_CYGWIN_PATH", "C:/cygwin64/bin"),
+    'mingw32': os.getenv('CONAN_MINGW32_PATH', "C:/msys64/mingw32/bin"),
+    'mingw64': os.getenv('CONAN_MINGW64_PATH', "C:/msys64/mingw64/bin"),
+}
+
+tool_environments = {
+    'mingw32': {'MSYSTEM': 'MINGW32'},
+    'mingw64': {'MSYSTEM': 'MINGW64'}
 }
 
 tools_available = [
     'cmake',
     'gcc', 'clang', 'visual_studio', 'mingw', 'xcode',
-    'msys2', 'cygwin',
+    'msys2', 'cygwin', 'mingw32', 'mingw64',
     'autotools', 'pkg_config', 'premake', 'meson',
     'file',
     'git', 'svn',
@@ -66,16 +73,20 @@ if not which("conan"):
 @pytest.fixture(autouse=True)
 def add_tool(request):
     add_tools = []
+    env_tools = dict()
     for mark in request.node.iter_markers():
         if mark.name.startswith("tool_"):
             tool_name = mark.name[5:]
             if tool_name in tool_locations:
                 add_tools.append(tool_locations[tool_name])
+            if tool_name in tool_environments:
+                env_tools.update(tool_environments[tool_name])
     if add_tools:
         add_tools.append(os.environ["PATH"])
         temp_env = {'PATH': os.pathsep.join(add_tools)}
         old_environ = dict(os.environ)
         os.environ.update(temp_env)
+        os.environ.update(env_tools)
         yield
         os.environ.clear()
         os.environ.update(old_environ)

--- a/conans/test/functional/subsystems_build_test.py
+++ b/conans/test/functional/subsystems_build_test.py
@@ -1,26 +1,124 @@
 import platform
 
 import pytest
+import textwrap
 
+from conans.test.assets.sources import gen_function_cpp
+from conans.test.functional.utils import check_exe_run
 from conans.test.utils.tools import TestClient
 
 
 @pytest.mark.skipif(platform.system() != "Windows", reason="Tests Windows Subsystems")
 class TestSubsystemsBuild:
 
+    @pytest.fixture
+    def client(self):
+        return TestClient()
+
     @pytest.mark.tool_msys2
-    def test_msys2_available(self):
-        client = TestClient()
+    def test_msys2_available(self, client):
         client.run_command('uname')
         assert "MSYS" in client.out
 
     @pytest.mark.tool_cygwin
-    def test_cygwin_available(self):
-        client = TestClient()
+    def test_cygwin_available(self, client):
         client.run_command('uname')
         assert "CYGWIN" in client.out
 
-    def test_tool_not_available(self):
-        client = TestClient()
+    @pytest.mark.tool_msys2
+    @pytest.mark.tool_mingw32
+    def test_mingw32_available(self, client):
+        client.run_command('uname')
+        assert "MINGW32_NT" in client.out
+
+    @pytest.mark.tool_msys2
+    @pytest.mark.tool_mingw64
+    def test_mingw64_available(self, client):
+        client.run_command('uname')
+        assert "MINGW64_NT" in client.out
+
+    def test_tool_not_available(self, client):
         client.run_command('uname', assert_error=True)
         assert "'uname' is not recognized as an internal or external command" in client.out
+
+    makefile = textwrap.dedent("""
+        .PHONY: all
+        all: app
+
+        app: main.o
+        	$(CXX) $(CFLAGS) -o app main.o
+
+        main.o: main.cpp
+        	$(CXX) $(CFLAGS) -c -o main.o main.cpp
+        """)
+
+    def _build(self, client):
+        main_cpp = gen_function_cpp(name="main")
+
+        client.save({"Makefile": self.makefile,
+                          "main.cpp": main_cpp})
+
+        client.run_command("make")
+
+        client.run_command("app")
+
+    @pytest.mark.tool_msys2
+    def test_msys(self, client):
+        """
+        native MSYS environment, binaries depend on MSYS runtime (msys-2.0.dll)
+        posix-compatible, intended to be run only in MSYS environment (not in pure Windows)
+        """
+        # pacman -S gcc
+        self._build(client)
+
+        check_exe_run(client.out, "main", "gcc", None, "Debug", "x86_64", None)
+
+        assert "__MINGW32__" not in client.out
+        assert "__MINGW64__" not in client.out
+        assert "__MSYS__" in client.out
+
+    @pytest.mark.tool_msys2
+    @pytest.mark.tool_mingw64
+    def test_mingw64(self, client):
+        """
+        64-bit GCC, binaries for generic Windows (no dependency on MSYS runtime)
+        """
+        # pacman -S mingw-w64-x86_64-gcc
+        self._build(client)
+
+        check_exe_run(client.out, "main", "gcc", None, "Debug", "x86_64", None)
+
+        assert "__MINGW64__" in client.out
+        assert "__CYGWIN__" not in client.out
+        assert "__MSYS__" not in client.out
+
+    @pytest.mark.tool_msys2
+    @pytest.mark.tool_mingw32
+    def test_mingw32(self, client):
+        """
+        32-bit GCC, binaries for generic Windows (no dependency on MSYS runtime)
+        """
+        # pacman -S mingw-w64-i686-gcc
+        self._build(client)
+
+        check_exe_run(client.out, "main", "gcc", None, "Debug", "x86", None)
+
+        assert "__MINGW32__" in client.out
+        assert "__CYGWIN__" not in client.out
+        assert "__MSYS__" not in client.out
+
+    @pytest.mark.tool_cygwin
+    def test_cygwin(self, client):
+        """
+        Cygwin environment, binaries depend on Cygwin runtime (cygwin1.dll)
+        posix-compatible, intended to be run only in Cygwin environment (not in pure Windows)
+        """
+        # install "gcc-c++" and "make" packages
+        self._build(client)
+
+        check_exe_run(client.out, "main", "gcc", None, "Debug", "x86_64", None)
+
+        assert "__CYGWIN__" in client.out
+        assert "__MINGW32__" not in client.out
+        assert "__MINGW64__" not in client.out
+        assert "__MSYS__" not in client.out


### PR DESCRIPTION
closes: #8458 

- builds simple hello-world app
- checks 32 and 64 architectures (MinGW32/MinGW64)
- assumes MSYS2 and MinGW32/MinGW64 are installed in the system
- doesn't use any build helpers, just g++ and make

Changelog: Fix: add MSYS2/MinGW32/MinGW64/Cygwin tests
Docs: https://github.com/conan-io/docs/pull/XXXX

- [ ] Refer to the issue that supports this Pull Request.
- [ ] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [ ] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [ ] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 

<sup>**Note:** By default this PR will skip the slower tests and will use a limited set of python versions. Check [here](https://github.com/conan-io/conan/blob/develop/.github/PR_INCREASE_TESTING.md) how to increase the testing level by writing some tags in the current PR body text.</sup>
