### PR TITLE
Fix extra spaces and colons in flags and environment variables

### DIFF
--- a/conans/client/envvars/environment.py
+++ b/conans/client/envvars/environment.py
@@ -143,7 +143,10 @@ def _format_values(flavor, variables, append_with_spaces):
             placeholder = _variable_placeholder(flavor, name, append_space)
             if append_space:
                 # Variables joined with spaces look like: CPPFLAGS="one two three"
-                value = " ".join(value+[placeholder])
+                if flavor == SH_FLAVOR:
+                    value = " ".join(value) + placeholder
+                else:
+                    value = " ".join(value + [placeholder])
                 value = "\"%s\"" % value if quote_elements else value
             else:
                 # Quoted variables joined with pathset may look like:

--- a/conans/client/envvars/environment.py
+++ b/conans/client/envvars/environment.py
@@ -117,7 +117,7 @@ def _variable_placeholder(flavor, name, append_with_spaces):
     if flavor == PS1_FLAVOR:
         return "$env:%s" % name
     # flavor == sh
-    return "${%s+ $%s}" % (name, name) if append_with_spaces else "${%s+:$%s}" % (name,  name)
+    return "${%s:+ $%s}" % (name, name) if append_with_spaces else "${%s:+:$%s}" % (name,  name)
 
 
 def _format_values(flavor, variables, append_with_spaces):

--- a/conans/test/functional/configuration/profile_test.py
+++ b/conans/test/functional/configuration/profile_test.py
@@ -58,7 +58,7 @@ class ProfileTest(unittest.TestCase):
         self.client.run("install . -pr envs -g virtualenv")
         content = self.client.load("environment.sh.env")
         self.assertIn(":".join(["PREPEND_VAR=\"new_path\"", "\"other_path\""]) +
-                      "${PREPEND_VAR+:$PREPEND_VAR}", content)
+                      "${PREPEND_VAR:+:$PREPEND_VAR}", content)
         if platform.system() == "Windows":
             content = self.client.load("environment.bat.env")
             self.assertIn(";".join(["PREPEND_VAR=new_path", "other_path", "%PREPEND_VAR%"]),

--- a/conans/test/functional/environment/apply_environment_test.py
+++ b/conans/test/functional/environment/apply_environment_test.py
@@ -439,8 +439,8 @@ class HelloConan(ConanFile):
         if platform.system() == "Windows":
             self.assertIn('var2=value3;value2;%var2%', environment_contents)
         else:
-            self.assertIn('var2="value3":"value2"${var2+:$var2}', environment_contents)
-            self.assertIn('CPPFLAGS="OtherFlag=2 MYCPPFLAG=1 ${CPPFLAGS+ $CPPFLAGS}"',
+            self.assertIn('var2="value3":"value2"${var2:+:$var2}', environment_contents)
+            self.assertIn('CPPFLAGS="OtherFlag=2 MYCPPFLAG=1 ${CPPFLAGS:+ $CPPFLAGS}"',
                           environment_contents)
         self.assertIn("Another value", environment_contents)
         if platform.system() == "Windows":
@@ -675,7 +675,7 @@ PATH=["path_from_A"]
 PATH=["path_from_B"]""", info)
         if platform.system() != "Windows":
             activate = client.load("environment.sh.env")
-            self.assertIn('PATH="path_from_A":"path_from_B"${PATH+:$PATH}', activate)
+            self.assertIn('PATH="path_from_A":"path_from_B"${PATH:+:$PATH}', activate)
         else:
             activate = client.load("environment.bat.env")
             self.assertIn('PATH=path_from_A;path_from_B;%PATH%', activate)

--- a/conans/test/functional/environment/apply_environment_test.py
+++ b/conans/test/functional/environment/apply_environment_test.py
@@ -440,7 +440,7 @@ class HelloConan(ConanFile):
             self.assertIn('var2=value3;value2;%var2%', environment_contents)
         else:
             self.assertIn('var2="value3":"value2"${var2:+:$var2}', environment_contents)
-            self.assertIn('CPPFLAGS="OtherFlag=2 MYCPPFLAG=1 ${CPPFLAGS:+ $CPPFLAGS}"',
+            self.assertIn('CPPFLAGS="OtherFlag=2 MYCPPFLAG=1${CPPFLAGS:+ $CPPFLAGS}"',
                           environment_contents)
         self.assertIn("Another value", environment_contents)
         if platform.system() == "Windows":

--- a/conans/test/functional/generators/virtualenv_test.py
+++ b/conans/test/functional/generators/virtualenv_test.py
@@ -265,6 +265,10 @@ class VirtualEnvIntegrationTestCase(unittest.TestCase):
 
     @pytest.mark.tool_conan
     def test_empty_defined_list_variable(self):
+        if os_info.is_windows:
+            # Windows doesn't make distinction between empty and undefined
+            # environment variables.
+            return
         self.assertNotIn("WHATEVER", os.environ)
         try:
             os.environ["WHATEVER"] = ""

--- a/conans/test/functional/generators/virtualenv_test.py
+++ b/conans/test/functional/generators/virtualenv_test.py
@@ -278,10 +278,7 @@ class VirtualEnvIntegrationTestCase(unittest.TestCase):
 
             _, environment = self._run_virtualenv(generator)
 
-            # FIXME: extra separator in Windows
-            extra_separator = os.pathsep if platform.system() == "Windows" else ""
-            self.assertEqual(environment["WHATEVER"],
-                             "{}{}{}{}".format("list", os.pathsep, "other", extra_separator))
+            self.assertEqual(environment["WHATEVER"], "{}{}{}".format("list", os.pathsep, "other"))
         finally:
             del os.environ["WHATEVER"]
 

--- a/conans/test/functional/generators/virtualenv_test.py
+++ b/conans/test/functional/generators/virtualenv_test.py
@@ -221,14 +221,14 @@ class VirtualEnvIntegrationTestCase(unittest.TestCase):
 
         _, environment = self._run_virtualenv(generator)
 
-        self.assertEqual(environment["CFLAGS"], "-O2 ")  # FIXME: Trailing blank
-        self.assertEqual(environment["CL"], "-MD -DNDEBUG -O2 -Ob2 ")  # FIXME: Trailing blank
+        extra_blank = " " if platform.system() == "Windows" else ""  # FIXME: Extra blank under Windows
+        self.assertEqual(environment["CFLAGS"], "-O2" + extra_blank)
+        self.assertEqual(environment["CL"], "-MD -DNDEBUG -O2 -Ob2" + extra_blank)
 
         with environment_append({"CFLAGS": "cflags", "CL": "cl"}):
             _, environment = self._run_virtualenv(generator)
-            extra_blank = " " if platform.system() != "Windows" else ""  # FIXME: Extra blank
-            self.assertEqual(environment["CFLAGS"], "-O2 {}cflags".format(extra_blank))
-            self.assertEqual(environment["CL"], "-MD -DNDEBUG -O2 -Ob2 {}cl".format(extra_blank))
+            self.assertEqual(environment["CFLAGS"], "-O2 cflags")
+            self.assertEqual(environment["CL"], "-MD -DNDEBUG -O2 -Ob2 cl")
 
     @pytest.mark.tool_conan
     def test_list_variable(self):

--- a/conans/test/functional/generators/virtualenv_test.py
+++ b/conans/test/functional/generators/virtualenv_test.py
@@ -264,11 +264,9 @@ class VirtualEnvIntegrationTestCase(unittest.TestCase):
                          "{}{}{}{}".format("list", os.pathsep, "other", extra_separator))
 
     @pytest.mark.tool_conan
+    @pytest.mark.skipif(platform.system() == "Windows",
+                        reason="Windows doesn't make distinction between empty and undefined environment variables")
     def test_empty_defined_list_variable(self):
-        if os_info.is_windows:
-            # Windows doesn't make distinction between empty and undefined
-            # environment variables.
-            return
         self.assertNotIn("WHATEVER", os.environ)
         try:
             os.environ["WHATEVER"] = ""

--- a/conans/test/functional/generators/virtualenv_windows_bash_test.py
+++ b/conans/test/functional/generators/virtualenv_windows_bash_test.py
@@ -116,4 +116,4 @@ class VirtualenvWindowsBashTestCase(unittest.TestCase):
         self.assertEqual(environment["WHATEVER2"], "list:existing_value")
 
         # Variable: list with spaces
-        self.assertEqual(environment["CFLAGS"], "cflags1 cflags2  existing_value")  # FIXME: extra blank
+        self.assertEqual(environment["CFLAGS"], "cflags1 cflags2 existing_value")

--- a/conans/test/integration/generators/virtualenv_python_test.py
+++ b/conans/test/integration/generators/virtualenv_python_test.py
@@ -39,7 +39,7 @@ virtualenv
 
         if platform.system() != "Windows":
             contents = client.load("environment_run_python.sh.env")
-            self.assertIn('PYTHONPATH="/path/to/something"${PYTHONPATH+:$PYTHONPATH}', contents)
+            self.assertIn('PYTHONPATH="/path/to/something"${PYTHONPATH:+:$PYTHONPATH}', contents)
         else:
             contents = client.load("environment_run_python.bat.env")
             self.assertIn('PYTHONPATH=/path/to/something;%PYTHONPATH%', contents)
@@ -76,7 +76,7 @@ class BaseConan(ConanFile):
             if platform.system() != "Windows":
                 contents = client.load("environment_run_python.sh.env")
                 self.assertIn('PYTHONPATH="/path/to/something":"/otherpath"'
-                              '${PYTHONPATH+:$PYTHONPATH}', contents)
+                              '${PYTHONPATH:+:$PYTHONPATH}', contents)
             else:
                 contents = client.load("environment_run_python.bat.env")
                 self.assertIn('PYTHONPATH=/path/to/something;/otherpath;%PYTHONPATH%', contents)

--- a/conans/test/unittests/client/generators/virtualbuildenv_test.py
+++ b/conans/test/unittests/client/generators/virtualbuildenv_test.py
@@ -40,10 +40,10 @@ class VirtualBuildEnvGeneratorGCCTest(unittest.TestCase):
 
     def test_scripts(self):
         content = self.result["environment_build.sh.env"]
-        self.assertIn('CPPFLAGS="-DNDEBUG ${CPPFLAGS:+ $CPPFLAGS}"', content)
-        self.assertIn('CXXFLAGS="-O3 -s --sysroot=/path/to/sysroot ${CXXFLAGS:+ $CXXFLAGS}"', content)
-        self.assertIn('CFLAGS="-O3 -s --sysroot=/path/to/sysroot ${CFLAGS:+ $CFLAGS}"', content)
-        self.assertIn('LDFLAGS="--sysroot=/path/to/sysroot ${LDFLAGS:+ $LDFLAGS}"', content)
+        self.assertIn('CPPFLAGS="-DNDEBUG${CPPFLAGS:+ $CPPFLAGS}"', content)
+        self.assertIn('CXXFLAGS="-O3 -s --sysroot=/path/to/sysroot${CXXFLAGS:+ $CXXFLAGS}"', content)
+        self.assertIn('CFLAGS="-O3 -s --sysroot=/path/to/sysroot${CFLAGS:+ $CFLAGS}"', content)
+        self.assertIn('LDFLAGS="--sysroot=/path/to/sysroot${LDFLAGS:+ $LDFLAGS}"', content)
         self.assertIn('LIBS="${LIBS:+ $LIBS}"', content)
 
         content = self.result["environment_build.ps1.env"]

--- a/conans/test/unittests/client/generators/virtualbuildenv_test.py
+++ b/conans/test/unittests/client/generators/virtualbuildenv_test.py
@@ -40,11 +40,11 @@ class VirtualBuildEnvGeneratorGCCTest(unittest.TestCase):
 
     def test_scripts(self):
         content = self.result["environment_build.sh.env"]
-        self.assertIn('CPPFLAGS="-DNDEBUG ${CPPFLAGS+ $CPPFLAGS}"', content)
-        self.assertIn('CXXFLAGS="-O3 -s --sysroot=/path/to/sysroot ${CXXFLAGS+ $CXXFLAGS}"', content)
-        self.assertIn('CFLAGS="-O3 -s --sysroot=/path/to/sysroot ${CFLAGS+ $CFLAGS}"', content)
-        self.assertIn('LDFLAGS="--sysroot=/path/to/sysroot ${LDFLAGS+ $LDFLAGS}"', content)
-        self.assertIn('LIBS="${LIBS+ $LIBS}"', content)
+        self.assertIn('CPPFLAGS="-DNDEBUG ${CPPFLAGS:+ $CPPFLAGS}"', content)
+        self.assertIn('CXXFLAGS="-O3 -s --sysroot=/path/to/sysroot ${CXXFLAGS:+ $CXXFLAGS}"', content)
+        self.assertIn('CFLAGS="-O3 -s --sysroot=/path/to/sysroot ${CFLAGS:+ $CFLAGS}"', content)
+        self.assertIn('LDFLAGS="--sysroot=/path/to/sysroot ${LDFLAGS:+ $LDFLAGS}"', content)
+        self.assertIn('LIBS="${LIBS:+ $LIBS}"', content)
 
         content = self.result["environment_build.ps1.env"]
         self.assertIn('CPPFLAGS=-DNDEBUG $env:CPPFLAGS', content)

--- a/conans/test/unittests/client/generators/virtualenv_python_test.py
+++ b/conans/test/unittests/client/generators/virtualenv_python_test.py
@@ -22,6 +22,6 @@ class VirtualEnvPythonGeneratorTest(unittest.TestCase):
         gen.output_path = "not-used"
         content = gen.content
 
-        self.assertIn('PYTHONPATH="1":"2":"three":"DepAPath":"DepBPath"${PYTHONPATH+:$PYTHONPATH}',
+        self.assertIn('PYTHONPATH="1":"2":"three":"DepAPath":"DepBPath"${PYTHONPATH:+:$PYTHONPATH}',
                       content["environment_run_python.sh.env"])
 

--- a/conans/test/unittests/client/generators/virtualenv_test.py
+++ b/conans/test/unittests/client/generators/virtualenv_test.py
@@ -62,7 +62,7 @@ class VirtualEnvGeneratorTest(unittest.TestCase):
 
     def test_list_with_spaces(self):
         self.assertIn("CL", VirtualEnvGenerator.append_with_spaces)
-        self.assertIn("CL=\"cl1 cl2 ${CL:+ $CL}\"", self.result['environment.sh.env'])
+        self.assertIn("CL=\"cl1 cl2${CL:+ $CL}\"", self.result['environment.sh.env'])
         self.assertIn('CL=cl1 cl2 $env:CL', self.result["environment.ps1.env"])
 
         if platform.system() == "Windows":

--- a/conans/test/unittests/client/generators/virtualenv_test.py
+++ b/conans/test/unittests/client/generators/virtualenv_test.py
@@ -45,9 +45,9 @@ class VirtualEnvGeneratorTest(unittest.TestCase):
         self.assertIn("USER_FLAG=\"user_value\"", self.result['environment.sh.env'])
 
     def test_list_variable(self):
-        self.assertIn("PATH=\"another_path\"${PATH+:$PATH}", self.result['environment.sh.env'])
-        self.assertIn("PATH2=\"p1\":\"p2\"${PATH2+:$PATH2}", self.result['environment.sh.env'])
-        self.assertIn("PATH3=\"p1\":\"p2\":\"p3\":\"p4\"${PATH3+:$PATH3}",
+        self.assertIn("PATH=\"another_path\"${PATH:+:$PATH}", self.result['environment.sh.env'])
+        self.assertIn("PATH2=\"p1\":\"p2\"${PATH2:+:$PATH2}", self.result['environment.sh.env'])
+        self.assertIn("PATH3=\"p1\":\"p2\":\"p3\":\"p4\"${PATH3:+:$PATH3}",
                       self.result['environment.sh.env'])
 
         if platform.system() == "Windows":
@@ -62,7 +62,7 @@ class VirtualEnvGeneratorTest(unittest.TestCase):
 
     def test_list_with_spaces(self):
         self.assertIn("CL", VirtualEnvGenerator.append_with_spaces)
-        self.assertIn("CL=\"cl1 cl2 ${CL+ $CL}\"", self.result['environment.sh.env'])
+        self.assertIn("CL=\"cl1 cl2 ${CL:+ $CL}\"", self.result['environment.sh.env'])
         self.assertIn('CL=cl1 cl2 $env:CL', self.result["environment.ps1.env"])
 
         if platform.system() == "Windows":

--- a/conans/test/unittests/client/generators/virtualrunenv_test.py
+++ b/conans/test/unittests/client/generators/virtualrunenv_test.py
@@ -41,10 +41,10 @@ class VirtualRunEnvGeneratorTest(unittest.TestCase):
 
     def test_scripts(self):
         content = self.result[self.environment_sh_env]
-        self.assertIn('DYLD_LIBRARY_PATH="lib1":"lib2"${DYLD_LIBRARY_PATH+:$DYLD_LIBRARY_PATH}',
+        self.assertIn('DYLD_LIBRARY_PATH="lib1":"lib2"${DYLD_LIBRARY_PATH:+:$DYLD_LIBRARY_PATH}',
                       content)
-        self.assertIn('LD_LIBRARY_PATH="lib1":"lib2"${LD_LIBRARY_PATH+:$LD_LIBRARY_PATH}', content)
-        self.assertIn('PATH="bin1":"bin2"${PATH+:$PATH}', content)
+        self.assertIn('LD_LIBRARY_PATH="lib1":"lib2"${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}', content)
+        self.assertIn('PATH="bin1":"bin2"${PATH:+:$PATH}', content)
 
         if platform.system() == "Windows":
             content = self.result[self.environment_bat_env]


### PR DESCRIPTION
According to [Bash expansion](https://www.gnu.org/software/bash/manual/html_node/Shell-Parameter-Expansion.html):

    ${parameter:+word}

Correct form for PATH:

    ${PATH:+:$PATH}

Correct form for CFLAGS:

    ${CFLAGS:+ $CFLAGS}

Fixes #8495

Changelog: Fix: Remove extra spaces in flags and colons in path variables.
Docs: omit

- [x] Refer to the issue that supports this Pull Request.
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [x] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 
