### PR TITLE
BugFix: M1 detection

### DIFF
--- a/conans/client/tools/oss.py
+++ b/conans/client/tools/oss.py
@@ -111,6 +111,8 @@ def detected_architecture():
         return "s390x"
     elif "s390" in machine:
         return "s390"
+    elif "sun4v" in machine:
+        return "sparc"
     elif "e2k" in machine:
         return OSInfo.get_e2k_architecture()
 

--- a/conans/test/unittests/util/detect_test.py
+++ b/conans/test/unittests/util/detect_test.py
@@ -68,3 +68,20 @@ class DetectTest(unittest.TestCase):
             self.assertEqual("AIX", result['os_build'])
             self.assertEqual(expected_arch, result['arch'])
             self.assertEqual(expected_arch, result['arch_build'])
+
+    @parameterized.expand([
+        ['arm64', 'armv8'],
+        ['i386', 'x86'],
+        ['i686', 'x86'],
+        ['i86pc', 'x86'],
+        ['amd64', 'x86_64'],
+        ['aarch64', 'armv8'],
+        ['sun4v', 'sparc']
+    ])
+    def test_detect_arch(self, machine, expected_arch):
+        with mock.patch("platform.machine", mock.MagicMock(return_value=machine)):
+            result = detect_defaults_settings(output=TestBufferConanOutput(),
+                                              profile_path=DEFAULT_PROFILE_NAME)
+            result = dict(result)
+            self.assertEqual(expected_arch, result['arch'])
+            self.assertEqual(expected_arch, result['arch_build'])


### PR DESCRIPTION
closes: #8499
continues story in #8113
it turns out the function `_detect_os_arch` (part of the `detect_defaults_settings`) didn't use `detected_architecture` and used its own mapping.
I guess it's better to have changes unified, done within a single place, so it's harder to forget to update both functions (like in the case of M1).

another confusing thing was:
```
ERROR: Your ARM 'arm64' architecture is probably not defined in settings.yml
Please check your conan.conf and settings.yml files
```
which emitted the error event after `arm64` was added to the settings.yml. I also corrected that, so the function always loads the settings. (to be honest, I am not even sure the error message is needed at all, as it doesn't play nice with custom settings).

Changelog: BugFix: Fix Apple M1 detection.
Docs: omit

- [ ] Refer to the issue that supports this Pull Request.
- [ ] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [ ] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [ ] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 

<sup>**Note:** By default this PR will skip the slower tests and will use a limited set of python versions. Check [here](https://github.com/conan-io/conan/blob/develop/.github/PR_INCREASE_TESTING.md) how to increase the testing level by writing some tags in the current PR body text.</sup>
