### PR TITLE
BugFix: add some sanity check to avoid a vague error for custom architectures

### DIFF
--- a/conans/client/build/autotools_environment.py
+++ b/conans/client/build/autotools_environment.py
@@ -357,10 +357,13 @@ class AutoToolsBuildEnvironment(object):
                                                                                 self._os_subsystem,
                                                                                 self._arch))
             if "-isysroot" not in concat and platform.system() == "Darwin":
-                tmp_compilation_flags.extend(["-isysroot",
-                                              tools.XCRun(self._conanfile.settings).sdk_path])
+                isysroot = tools.XCRun(self._conanfile.settings).sdk_path
+                if isysroot:
+                    tmp_compilation_flags.extend(["-isysroot", isysroot])
             if "-arch" not in concat and self._arch:
-                tmp_compilation_flags.extend(["-arch", tools.to_apple_arch(self._arch)])
+                apple_arch = tools.to_apple_arch(self._arch)
+                if apple_arch:
+                    tmp_compilation_flags.extend(["-arch", apple_arch])
 
         cxx_flags = append(tmp_compilation_flags, self.cxx_flags, self.cppstd_flag)
         c_flags = tmp_compilation_flags


### PR DESCRIPTION
closes: #8500 

Changelog: BugFix: Add some sanity check to avoid a vague error for custom architectures.
Docs: omit

- [ ] Refer to the issue that supports this Pull Request.
- [ ] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [ ] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [ ] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 

<sup>**Note:** By default this PR will skip the slower tests and will use a limited set of python versions. Check [here](https://github.com/conan-io/conan/blob/develop/.github/PR_INCREASE_TESTING.md) how to increase the testing level by writing some tags in the current PR body text.</sup>
