### PR TITLE
BugFix: allow `run_in_windows_bash` in MSYS/Cygwin

### DIFF
--- a/conans/client/tools/win.py
+++ b/conans/client/tools/win.py
@@ -635,7 +635,7 @@ def run_in_windows_bash(conanfile, bashcmd, cwd=None, subsystem=None, msys_mingw
         It requires to have MSYS2, CYGWIN, or WSL
     """
     env = env or {}
-    if platform.system() != "Windows":
+    if not OSInfo().is_windows:
         raise ConanException("Command only for Windows operating system")
     subsystem = subsystem or OSInfo.detect_windows_subsystem()
 
@@ -693,7 +693,11 @@ def run_in_windows_bash(conanfile, bashcmd, cwd=None, subsystem=None, msys_mingw
         bash_path = OSInfo.bash_path()
         bash_path = '"%s"' % bash_path if " " in bash_path else bash_path
         login = "--login" if with_login else ""
-        wincmd = '%s %s -c %s' % (bash_path, login, escape_windows_cmd(to_run))
+        if platform.system() == "Windows":
+            # cmd.exe shell
+            wincmd = '%s %s -c %s' % (bash_path, login, escape_windows_cmd(to_run))
+        else:
+            wincmd = '%s %s -c %s' % (bash_path, login, to_run)
         conanfile.output.info('run_in_windows_bash: %s' % wincmd)
 
         # If is there any other env var that we know it contains paths, convert it to unix_path


### PR DESCRIPTION
related to #8476

running `AutoToolsBuildEnvironment(self, win_bash=True)` in MSYS2 results in an error:
```
ERROR: apr/1.7.0: Error in build() method, line 92
        autotools = self._configure_autotools()
while calling '_configure_autotools', line 76
        self._autotools.configure(args=conf_args, configure_dir=self._source_subfolder)
        ConanException: Command only for Windows operating system
```
the fix allows `run_in_windows_bash` to work in sub-systems as well.

Changelog: BugFix: Allow `run_in_windows_bash` in MSYS/Cygwin.
Docs: omit

- [ ] Refer to the issue that supports this Pull Request.
- [ ] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [ ] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [ ] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 

<sup>**Note:** By default this PR will skip the slower tests and will use a limited set of python versions. Check [here](https://github.com/conan-io/conan/blob/develop/.github/PR_INCREASE_TESTING.md) how to increase the testing level by writing some tags in the current PR body text.</sup>
