### PR TITLE
BugFix: improve tools.unix_path for Cygwin

### DIFF
--- a/conans/client/tools/win.py
+++ b/conans/client/tools/win.py
@@ -614,18 +614,25 @@ def unix_path(path, path_flavor=None):
         path = get_cased_path(path)  # if the path doesn't exist (and abs) we cannot guess the casing
 
     path_flavor = path_flavor or OSInfo.detect_windows_subsystem() or MSYS2
+    if path.startswith('\\\\?\\'):
+        path = path[4:]
     path = path.replace(":/", ":\\")
+    append_prefix = re.match(r'[a-z]:\\', path, re.IGNORECASE)
     pattern = re.compile(r'([a-z]):\\', re.IGNORECASE)
     path = pattern.sub('/\\1/', path).replace('\\', '/')
-    if path_flavor in (MSYS, MSYS2):
-        return path.lower()
-    elif path_flavor == CYGWIN:
-        return '/cygdrive' + path.lower()
-    elif path_flavor == WSL:
-        return '/mnt' + path[0:2].lower() + path[2:]
-    elif path_flavor == SFU:
-        path = path.lower()
-        return '/dev/fs' + path[0] + path[1:].capitalize()
+
+    if append_prefix:
+        if path_flavor in (MSYS, MSYS2):
+            return path.lower()
+        elif path_flavor == CYGWIN:
+            return '/cygdrive' + path.lower()
+        elif path_flavor == WSL:
+            return '/mnt' + path[0:2].lower() + path[2:]
+        elif path_flavor == SFU:
+            path = path.lower()
+            return '/dev/fs' + path[0] + path[1:].capitalize()
+    else:
+        return path if path_flavor == WSL else path.lower()
     return None
 
 

--- a/conans/test/unittests/util/tools_test.py
+++ b/conans/test/unittests/util/tools_test.py
@@ -388,7 +388,7 @@ class HelloConan(ConanFile):
         with patch.object(OSInfo, "bash_path", return_value='bash'):
             tools.run_in_windows_bash(conanfile, "a_command.bat", subsystem="cygwin",
                                       env={"PATH": "/other/path", "MYVAR": "34"})
-            self.assertIn('^&^& PATH=\\^"/cygdrive/other/path:/cygdrive/path/to/somewhere:$PATH\\^" '
+            self.assertIn('^&^& PATH=\\^"/other/path:/path/to/somewhere:$PATH\\^" '
                           '^&^& MYVAR=34 ^&^& a_command.bat ^', conanfile._conan_runner.command)
 
     def test_download_retries_errors(self):

--- a/conans/test/unittests/util/unix_path_test.py
+++ b/conans/test/unittests/util/unix_path_test.py
@@ -1,6 +1,4 @@
-#!/usr/bin/env python
-# -*- coding: utf-8 -*-
-
+import mock
 import os
 import platform
 import unittest
@@ -46,27 +44,57 @@ class UnixPathTest(unittest.TestCase):
     def test_none(self):
         self.assertEqual(None, tools.unix_path(path=None))
 
-    @pytest.mark.skipif(platform.system() == "Windows", reason="All but Windows")
+    @mock.patch("platform.system", mock.MagicMock(return_value='Darwin'))
     def test_not_windows(self):
         path = 'C:\\Windows\\System32'
         self.assertEqual(path, tools.unix_path(path))
 
-    @pytest.mark.skipif(platform.system() != "Windows", reason="Only windows")
+    @mock.patch("platform.system", mock.MagicMock(return_value='Windows'))
     def test_msys_path(self):
         self.assertEqual('/c/windows/system32', tools.unix_path('C:\\Windows\\System32',
                                                                 path_flavor=tools.MSYS2))
 
-    @pytest.mark.skipif(platform.system() != "Windows", reason="Only windows")
+    @mock.patch("platform.system", mock.MagicMock(return_value='Windows'))
     def test_cygwin_path(self):
         self.assertEqual('/cygdrive/c/windows/system32', tools.unix_path('C:\\Windows\\System32',
                                                                          path_flavor=tools.CYGWIN))
 
-    @pytest.mark.skipif(platform.system() != "Windows", reason="Only windows")
+        # another drive
+        self.assertEqual('/cygdrive/d/work', tools.unix_path("D:\\work", path_flavor=tools.CYGWIN))
+
+        # path inside the cygwin
+        self.assertEqual('/home/.conan', tools.unix_path('/home/.conan', path_flavor=tools.CYGWIN))
+        self.assertEqual('/dev/null', tools.unix_path('/dev/null', path_flavor=tools.CYGWIN))
+
+        # relative paths
+        self.assertEqual('./configure', tools.unix_path('./configure', path_flavor=tools.CYGWIN))
+        self.assertEqual('../configure', tools.unix_path('../configure', path_flavor=tools.CYGWIN))
+        self.assertEqual('source_subfolder/configure',
+                         tools.unix_path('source_subfolder/configure', path_flavor=tools.CYGWIN))
+
+        self.assertEqual('./configure', tools.unix_path('.\\configure', path_flavor=tools.CYGWIN))
+        self.assertEqual('../configure', tools.unix_path('..\\configure', path_flavor=tools.CYGWIN))
+        self.assertEqual('source_subfolder/configure',
+                         tools.unix_path('source_subfolder\\configure', path_flavor=tools.CYGWIN))
+
+        # already with cygdrive
+        self.assertEqual('/cygdrive/c/conan',
+                         tools.unix_path('/cygdrive/c/conan', path_flavor=tools.CYGWIN))
+
+        # UNC (file share)
+        self.assertEqual('//server/share',
+                         tools.unix_path("\\\\SERVER\\Share", path_flavor=tools.CYGWIN))
+
+        # long path
+        self.assertEqual('/cygdrive/c/windows/system32',
+                         tools.unix_path('\\\\?\\C:\\Windows\\System32', path_flavor=tools.CYGWIN))
+
+    @mock.patch("platform.system", mock.MagicMock(return_value='Windows'))
     def test_wsl_path(self):
         self.assertEqual('/mnt/c/Windows/System32', tools.unix_path('C:\\Windows\\System32',
                                                                     path_flavor=tools.WSL))
 
-    @pytest.mark.skipif(platform.system() != "Windows", reason="Only windows")
+    @mock.patch("platform.system", mock.MagicMock(return_value='Windows'))
     def test_sfu_path(self):
         self.assertEqual('/dev/fs/C/windows/system32', tools.unix_path('C:\\Windows\\System32',
                                                                        path_flavor=tools.SFU))


### PR DESCRIPTION
a spin-off from #8506


Changelog: BugFix: Improve `tools.unix_path` for Cygwin.
Docs: omit

- [ ] Refer to the issue that supports this Pull Request.
- [ ] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [ ] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [ ] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 

<sup>**Note:** By default this PR will skip the slower tests and will use a limited set of python versions. Check [here](https://github.com/conan-io/conan/blob/develop/.github/PR_INCREASE_TESTING.md) how to increase the testing level by writing some tags in the current PR body text.</sup>
