### PR TITLE
Make tests fail if tools are not available

### DIFF
--- a/conans/test/conftest.py
+++ b/conans/test/conftest.py
@@ -97,7 +97,7 @@ def add_tool(request):
 def tool_check(mark):
     tool_name = mark.name[5:]
     if tool_name not in tools_available:
-        pytest.fail("required tool: '{}' is not available".format(tool_name))
+        pytest.fail("Required tool: '{}' is not available".format(tool_name))
 
 
 def pytest_runtest_setup(item):

--- a/conans/test/conftest.py
+++ b/conans/test/conftest.py
@@ -97,7 +97,7 @@ def add_tool(request):
 def tool_check(mark):
     tool_name = mark.name[5:]
     if tool_name not in tools_available:
-        pytest.skip("required {} not satisfied".format(tool_name))
+        pytest.fail("required tool: '{}' is not available".format(tool_name))
 
 
 def pytest_runtest_setup(item):

--- a/conans/test/functional/toolchains/intel/test_using_cmake.py
+++ b/conans/test/functional/toolchains/intel/test_using_cmake.py
@@ -64,7 +64,7 @@ conanfile_py = textwrap.dedent("""
 @pytest.mark.toolchain
 @pytest.mark.tool_cmake
 @pytest.mark.tool_icc
-@pytest.mark.xfail("Intel compiler not installed yet on CI")
+@pytest.mark.xfail(reason="Intel compiler not installed yet on CI")
 @pytest.mark.skipif(platform.system() != "Windows", reason="Only for windows")
 class CMakeIntelTestCase(BaseIntelTestCase):
 

--- a/conans/test/functional/toolchains/intel/test_using_cmake.py
+++ b/conans/test/functional/toolchains/intel/test_using_cmake.py
@@ -64,6 +64,7 @@ conanfile_py = textwrap.dedent("""
 @pytest.mark.toolchain
 @pytest.mark.tool_cmake
 @pytest.mark.tool_icc
+@pytest.mark.xfail("Intel compiler not installed yet on CI")
 @pytest.mark.skipif(platform.system() != "Windows", reason="Only for windows")
 class CMakeIntelTestCase(BaseIntelTestCase):
 

--- a/conans/test/functional/toolchains/intel/test_using_cmake.py
+++ b/conans/test/functional/toolchains/intel/test_using_cmake.py
@@ -1,4 +1,6 @@
 import os
+import platform
+
 import pytest
 import textwrap
 
@@ -62,6 +64,7 @@ conanfile_py = textwrap.dedent("""
 @pytest.mark.toolchain
 @pytest.mark.tool_cmake
 @pytest.mark.tool_icc
+@pytest.mark.skipif(platform.system() != "Windows", reason="Only for windows")
 class CMakeIntelTestCase(BaseIntelTestCase):
 
     def test_use_cmake_toolchain(self):

--- a/conans/test/functional/toolchains/intel/test_using_msbuild.py
+++ b/conans/test/functional/toolchains/intel/test_using_msbuild.py
@@ -34,6 +34,7 @@ conanfile_py = textwrap.dedent("""
 @pytest.mark.tool_cmake
 @pytest.mark.tool_msbuild
 @pytest.mark.tool_icc
+@pytest.mark.xfail("Intel compiler not installed yet on CI")
 @pytest.mark.skipif(platform.system() != "Windows", reason="msbuild requires Windows")
 class MSBuildIntelTestCase(BaseIntelTestCase):
     def test_use_msbuild_toolchain(self):

--- a/conans/test/functional/toolchains/intel/test_using_msbuild.py
+++ b/conans/test/functional/toolchains/intel/test_using_msbuild.py
@@ -34,7 +34,7 @@ conanfile_py = textwrap.dedent("""
 @pytest.mark.tool_cmake
 @pytest.mark.tool_msbuild
 @pytest.mark.tool_icc
-@pytest.mark.xfail("Intel compiler not installed yet on CI")
+@pytest.mark.xfail(reason="Intel compiler not installed yet on CI")
 @pytest.mark.skipif(platform.system() != "Windows", reason="msbuild requires Windows")
 class MSBuildIntelTestCase(BaseIntelTestCase):
     def test_use_msbuild_toolchain(self):

--- a/conans/test/functional/toolchains/test_msbuild.py
+++ b/conans/test/functional/toolchains/test_msbuild.py
@@ -307,6 +307,7 @@ myapp_vcxproj = r"""<?xml version="1.0" encoding="utf-8"?>
 
 
 @pytest.mark.tool_visual_studio
+@pytest.mark.skipif(platform.system() != "Windows", reason="Only for windows")
 def test_msvc_runtime_flag():
     client = TestClient()
     conanfile = textwrap.dedent("""

--- a/conans/test/integration/configuration/conf/test_conf_profile.py
+++ b/conans/test/integration/configuration/conf/test_conf_profile.py
@@ -1,3 +1,4 @@
+import platform
 import textwrap
 
 import pytest
@@ -106,6 +107,7 @@ def test_config_profile_forbidden(client):
 
 
 @pytest.mark.tool_visual_studio
+@pytest.mark.skipif(platform.system() != "Windows", reason="Only for windows")
 def test_msbuild_config():
     client = TestClient()
     conanfile = textwrap.dedent("""


### PR DESCRIPTION
Changelog: omit
Docs: omit

Default testing behaviour with tools marks is that if the tools are not found the test is skipped, but this can make that for any reason like for example a ci node was not configured properly we skip tests that we would like to run. This PR alters that behaviour to fail if tools are not found.