### PR TITLE
Avoid concurrency issues with load_metadata function

### DIFF
--- a/conans/paths/package_layouts/package_cache_layout.py
+++ b/conans/paths/package_layouts/package_cache_layout.py
@@ -238,6 +238,10 @@ class PackageCacheLayout(object):
 
     # Metadata
     def load_metadata(self):
+        with self.update_metadata() as metadata:
+            return metadata
+
+    def _load_metadata(self):
         try:
             text = load(self.package_metadata())
         except IOError:
@@ -256,7 +260,7 @@ class PackageCacheLayout(object):
             thread_lock.acquire()
             try:
                 try:
-                    metadata = self.load_metadata()
+                    metadata = self._load_metadata()
                 except RecipeNotFoundException:
                     metadata = PackageMetadata()
                 yield metadata


### PR DESCRIPTION
Changelog: omit
Docs: omit

Use the locking mechanism to read the metadata file, not only with the contextmanager when you are going to modify it.

---

I'm trying to figure out which could be the worst scenario that leads to the `assert` failure:

```
assert node.prev, "PREV for %s is None: %s" % (str(pref), metadata.dumps())
```

