### PR TITLE
Fail if we are about to save a package without revision to 'metadata.json'

### DIFF
--- a/conans/client/conan_api.py
+++ b/conans/client/conan_api.py
@@ -1068,6 +1068,7 @@ class ConanAPIV1(object):
             m = metadata.packages.get(pref.id)
             if m and m.remote:
                 raise ConanException("%s already exists. Use update" % str(pref))
+            # Create the package entry although we know nothing else about it
             metadata.packages[pref.id].remote = remote.name
 
     @api_method

--- a/conans/model/package_metadata.py
+++ b/conans/model/package_metadata.py
@@ -56,9 +56,12 @@ class _BinaryPackageMetadata(object):
         self._recipe_revision = DEFAULT_REVISION_V1 if r is None else r
 
     def to_dict(self):
-        # It is totally unexpected to save 'metadata.json' file without package-revsion, when
-        # even with revisions deactivated, it takes the value DEFAULT_REVISION_V1.
-        assert self._revision is not None, 'Trying to save to metadata packages without revision!'
+        # It is totally unexpected to save 'metadata.json' file without package-revision,
+        # even if revisions are deactivated, it takes the value DEFAULT_REVISION_V1.
+        # EXCEPT, for a requested feature to be able to asign the remote for a package-id before
+        # installing it to the cache.
+        if self.remote is None:
+            assert self._revision is not None, 'Trying to save to metadata without package revision!'
 
         ret = {"revision": self.revision,
                "recipe_revision": self.recipe_revision,

--- a/conans/model/package_metadata.py
+++ b/conans/model/package_metadata.py
@@ -56,6 +56,11 @@ class _BinaryPackageMetadata(object):
         self._recipe_revision = DEFAULT_REVISION_V1 if r is None else r
 
     def to_dict(self):
+        if not self.revision:
+            # It is totally unexpected to save 'metadata.json' file without package-revsion, when
+            # even with revisions deactivated, it takes the value DEFAULT_REVISION_V1.
+            assert False, 'Trying to save to metadata packages without revision!'
+
         ret = {"revision": self.revision,
                "recipe_revision": self.recipe_revision,
                "remote": self.remote,

--- a/conans/model/package_metadata.py
+++ b/conans/model/package_metadata.py
@@ -56,10 +56,9 @@ class _BinaryPackageMetadata(object):
         self._recipe_revision = DEFAULT_REVISION_V1 if r is None else r
 
     def to_dict(self):
-        if not self.revision:
-            # It is totally unexpected to save 'metadata.json' file without package-revsion, when
-            # even with revisions deactivated, it takes the value DEFAULT_REVISION_V1.
-            assert False, 'Trying to save to metadata packages without revision!'
+        # It is totally unexpected to save 'metadata.json' file without package-revsion, when
+        # even with revisions deactivated, it takes the value DEFAULT_REVISION_V1.
+        assert self._revision is not None, 'Trying to save to metadata packages without revision!'
 
         ret = {"revision": self.revision,
                "recipe_revision": self.recipe_revision,

--- a/conans/test/functional/command/remote_test.py
+++ b/conans/test/functional/command/remote_test.py
@@ -415,11 +415,10 @@ class RemoteTest(unittest.TestCase):
         self.assertIn("Hello1/0.1@user/testing: remote2", self.client.out)
 
     def test_package_refs(self):
-
         self.client.run("remote add_pref Hello/0.1@user/testing:555 remote0")
         self.client.run("remote list_pref Hello/0.1@user/testing")
         self.assertIn("Hello/0.1@user/testing:555: remote0", self.client.out)
-
+        
         self.client.run("remote add_pref Hello1/0.1@user/testing:555 remote1")
         self.client.run("remote list_pref Hello1/0.1@user/testing")
         self.assertIn("Hello1/0.1@user/testing:555: remote1", self.client.out)


### PR DESCRIPTION
Changelog: omit
Docs: omit

Fail if we are saving a package without a revision. I think this can be the easiest way to figure out what is happening here https://github.com/conan-io/conan-center-index/issues/4599. 

There are places in the codebase where we are using `metadata.packages['pkgID'].member` which will create an empty `_BinaryPackageMetadata` and return `None`. No exception, no error, just an empty item is added to the dictionary. We should use `.get('pkgID')` instead... but ATM, this `assert` will be enough to check if/where we are saving a package without `revision` to `metadata.json` file.

Blocked by https://github.com/conan-io/conan/pull/8520