### PR TITLE
Fix mingw marks

### DIFF
--- a/conans/test/conftest.py
+++ b/conans/test/conftest.py
@@ -19,7 +19,7 @@ tool_environments = {
 
 tools_available = [
     'cmake',
-    'gcc', 'clang', 'visual_studio', 'mingw', 'xcode',
+    'gcc', 'clang', 'visual_studio', 'xcode',
     'msys2', 'cygwin', 'mingw32', 'mingw64',
     'autotools', 'pkg_config', 'premake', 'meson',
     'file',
@@ -45,7 +45,10 @@ if not any([x for x in ("gcc", "clang", "visual_sudio") if x in tools_available]
     tools_available.remove("compiler")
 
 if not which("mingw32-make"):
-    tools_available.remove("mingw")
+    tools_available.remove("mingw32")
+
+if not which("mingw64-make"):
+    tools_available.remove("mingw64")
 
 if not which("xcodebuild"):
     tools_available.remove("xcode")

--- a/conans/test/conftest.py
+++ b/conans/test/conftest.py
@@ -44,12 +44,6 @@ except ConanException:
 if not any([x for x in ("gcc", "clang", "visual_sudio") if x in tools_available]):
     tools_available.remove("compiler")
 
-if not which("mingw32-make"):
-    tools_available.remove("mingw32")
-
-if not which("mingw64-make"):
-    tools_available.remove("mingw64")
-
 if not which("xcodebuild"):
     tools_available.remove("xcode")
 

--- a/conans/test/functional/generators/cmake_multi_test.py
+++ b/conans/test/functional/generators/cmake_multi_test.py
@@ -136,7 +136,7 @@ int main(){{
 @pytest.mark.tool_cmake
 class CMakeMultiTest(unittest.TestCase):
 
-    @pytest.mark.tool_mingw
+    @pytest.mark.tool_mingw32
     @pytest.mark.tool_gcc
     def test_cmake_multi_find(self):
         if platform.system() not in ["Windows", "Linux"]:

--- a/conans/test/functional/generators/cmake_multi_test.py
+++ b/conans/test/functional/generators/cmake_multi_test.py
@@ -136,6 +136,7 @@ int main(){{
 @pytest.mark.tool_cmake
 class CMakeMultiTest(unittest.TestCase):
 
+    @pytest.mark.skipif(platform.system() != "Windows", reason="Requires mingw32-make")
     @pytest.mark.tool_mingw32
     @pytest.mark.tool_gcc
     def test_cmake_multi_find(self):

--- a/conans/test/functional/toolchains/test_make.py
+++ b/conans/test/functional/toolchains/test_make.py
@@ -107,7 +107,7 @@ class MakeToolchainTest(unittest.TestCase):
 
     @pytest.mark.skipif(platform.system() != "Windows", reason="Requires mingw32-make")
     @pytest.mark.skipif(which("mingw32-make") is None, reason="Needs mingw32-make")
-    @pytest.mark.tool_mingw
+    @pytest.mark.tool_mingw32
     def test_toolchain_windows(self):
         client = TestClient(path_with_spaces=False)
 

--- a/conans/test/functional/toolchains/test_make.py
+++ b/conans/test/functional/toolchains/test_make.py
@@ -106,7 +106,6 @@ class MakeToolchainTest(unittest.TestCase):
         self.assertIn("hello()", client.out)
 
     @pytest.mark.skipif(platform.system() != "Windows", reason="Requires mingw32-make")
-    @pytest.mark.skipif(which("mingw32-make") is None, reason="Needs mingw32-make")
     @pytest.mark.tool_mingw32
     def test_toolchain_windows(self):
         client = TestClient(path_with_spaces=False)


### PR DESCRIPTION
Changelog: Fix: Change mingw mark to mingw32 or mingw64
Docs: omit

Using the new mingw mechanism to add the tool to path, some tests were skipped because the tool was not found. Removing mingw mark, now the test must be marked as mingw64 or mingw32.

#TAGS: slow
