### PR TITLE
BugFix: prevent evil insertions into metadata.json resulted in corrupted package and inability to install

### DIFF
--- a/conans/client/graph/graph_binaries.py
+++ b/conans/client/graph/graph_binaries.py
@@ -231,14 +231,19 @@ class GraphBinariesAnalyzer(object):
         metadata = self._evaluate_clean_pkg_folder_dirty(node, package_layout, pref)
 
         remote = remotes.selected
+
+        metadata = metadata or package_layout.load_metadata()
         if not remote:
             # If the remote_name is not given, follow the binary remote, or the recipe remote
             # If it is defined it won't iterate (might change in conan2.0)
-            metadata = metadata or package_layout.load_metadata()
-            remote_name = metadata.packages[pref.id].remote or metadata.recipe.remote
+            if pref.id in metadata.packages:
+                remote_name = metadata.packages[pref.id].remote or metadata.recipe.remote
+            else:
+                remote_name = metadata.recipe.remote
             remote = remotes.get(remote_name)
 
-        if package_layout.package_id_exists(pref.id):  # Binary already in cache, check for updates
+        if package_layout.package_id_exists(pref.id) and pref.id in metadata.packages:
+            # Binary already in cache, check for updates
             self._evaluate_cache_pkg(node, package_layout, pref, metadata, remote, remotes, update)
             recipe_hash = None
         else:  # Binary does NOT exist locally

--- a/conans/test/integration/command/install/install_update_test.py
+++ b/conans/test/integration/command/install/install_update_test.py
@@ -289,3 +289,23 @@ def test_fail_usefully_when_failing_retrieving_package():
     # Try to install ref2, it will try to download the binary for ref1
     client.run("install {}".format(ref2), assert_error=True)
     assert "ERROR: Error downloading binary package: '{}'".format(pref1) in client.out
+
+def test_evil_insertions():
+    ref = ConanFileReference.loads("lib1/1.0@conan/stable")
+    ref2 = ConanFileReference.loads("lib2/1.0@conan/stable")
+
+    client = TurboTestClient(servers={"default": TestServer()})
+    pref1 = client.create(ref)
+    client.upload_all(ref)
+
+    client.create(ref2, conanfile=GenConanfile().with_requirement(ref))
+    client.upload_all(ref2)
+
+    client.run("remove {} -p {} -f".format(pref1.ref, pref1.id))
+
+    # Even if we create the package folder artificially, the folder will be discarded and installed again.
+    os.makedirs(os.path.join(client.cache_folder, "data", ref.dir_repr(), "package", pref1.id))
+
+    client.run("install {}".format(ref2))
+
+    assert "AssertionError: PREV" not in client.out


### PR DESCRIPTION
#TAGS: slow

see #8519

Changelog: BugFix: Prevent evil insertions into metadata.json resulted in corrupted package and inability to install.
Docs: omit

- [ ] Refer to the issue that supports this Pull Request.
- [ ] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [ ] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [ ] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 

<sup>**Note:** By default this PR will skip the slower tests and will use a limited set of python versions. Check [here](https://github.com/conan-io/conan/blob/develop/.github/PR_INCREASE_TESTING.md) how to increase the testing level by writing some tags in the current PR body text.</sup>
