### PR TITLE
Feature: add property "cmake_target_aliases" to create some CMake alias targets (CMakeDeps)

### DIFF
--- a/conan/tools/cmake/cmakedeps/templates/targets.py
+++ b/conan/tools/cmake/cmakedeps/templates/targets.py
@@ -28,20 +28,18 @@ class TargetsTemplate(CMakeDepsFileTemplate):
         cmake_target_aliases = self.conanfile.cpp_info.\
             get_property("cmake_target_aliases", "CMakeDeps") or dict()
 
-        if isinstance(cmake_target_aliases, (list, tuple)):
-            target = "%s::%s" % (self.target_namespace, self.global_target_name)
-            cmake_target_aliases = {alias: target for alias in cmake_target_aliases}
+        target = "%s::%s" % (self.target_namespace, self.global_target_name)
+        cmake_target_aliases = {alias: target for alias in cmake_target_aliases}
 
         cmake_component_target_aliases = dict()
         for comp_name in self.conanfile.cpp_info.components:
             aliases = \
                 self.conanfile.cpp_info.components[comp_name].\
                 get_property("cmake_target_aliases", "CMakeDeps") or dict()
-            if isinstance(aliases, (list, tuple)):
-                target = "%s::%s" % (self.target_namespace,
-                                     self.get_component_alias(self.conanfile, comp_name))
-                aliases = {alias: target for alias in aliases}
-            cmake_component_target_aliases[comp_name] = aliases
+
+            target = "%s::%s" % (self.target_namespace,
+                                 self.get_component_alias(self.conanfile, comp_name))
+            cmake_component_target_aliases[comp_name] = {alias: target for alias in aliases}
 
         ret = {"pkg_name": self.pkg_name,
                "target_namespace": self.target_namespace,

--- a/conan/tools/cmake/cmakedeps/templates/targets.py
+++ b/conan/tools/cmake/cmakedeps/templates/targets.py
@@ -81,6 +81,8 @@ class TargetsTemplate(CMakeDepsFileTemplate):
         if(NOT TARGET {{alias}})
             add_library({{alias}} INTERFACE IMPORTED)
             set_property(TARGET {{ alias }} PROPERTY INTERFACE_LINK_LIBRARIES {{target}})
+        else()
+            message(WARNING "target '{{alias}}' already exists, alias for target '{{target}}' won't be created!")
         endif()
 
         {%- endfor %}
@@ -92,6 +94,8 @@ class TargetsTemplate(CMakeDepsFileTemplate):
         if(NOT TARGET {{alias}})
             add_library({{alias}} INTERFACE IMPORTED)
             set_property(TARGET {{ alias }} PROPERTY INTERFACE_LINK_LIBRARIES {{target}})
+        else()
+            message(WARNING "target '{{alias}}' already exists, alias for target '{{target}}' won't be created!")
         endif()
 
             {%- endfor %}

--- a/conan/tools/cmake/cmakedeps/templates/targets.py
+++ b/conan/tools/cmake/cmakedeps/templates/targets.py
@@ -28,11 +28,20 @@ class TargetsTemplate(CMakeDepsFileTemplate):
         cmake_target_aliases = self.conanfile.new_cpp_info.\
             get_property("cmake_target_aliases", "CMakeDeps") or dict()
 
+        if isinstance(cmake_target_aliases, (list, tuple)):
+            target = "%s::%s" % (self.target_namespace, self.global_target_name)
+            cmake_target_aliases = {alias: target for alias in cmake_target_aliases}
+
         cmake_component_target_aliases = dict()
         for comp_name in self.conanfile.new_cpp_info.components:
-            cmake_component_target_aliases[comp_name] = \
+            aliases = \
                 self.conanfile.new_cpp_info.components[comp_name].\
                 get_property("cmake_target_aliases", "CMakeDeps") or dict()
+            if isinstance(aliases, (list, tuple)):
+                target = "%s::%s" % (self.target_namespace,
+                                     self.get_component_alias(self.conanfile, comp_name))
+                aliases = {alias: target for alias in aliases}
+            cmake_component_target_aliases[comp_name] = aliases
 
         ret = {"pkg_name": self.pkg_name,
                "target_namespace": self.target_namespace,

--- a/conan/tools/cmake/cmakedeps/templates/targets.py
+++ b/conan/tools/cmake/cmakedeps/templates/targets.py
@@ -25,12 +25,23 @@ class TargetsTemplate(CMakeDepsFileTemplate):
         target_pattern = "" if not self.find_module_mode else "module-"
         target_pattern += "{}-Target-*.cmake".format(self.file_name)
 
+        cmake_target_aliases = self.conanfile.new_cpp_info.\
+            get_property("cmake_target_aliases", "CMakeDeps") or dict()
+
+        cmake_component_target_aliases = dict()
+        for comp_name in self.conanfile.new_cpp_info.components:
+            cmake_component_target_aliases[comp_name] = \
+                self.conanfile.new_cpp_info.components[comp_name].\
+                get_property("cmake_target_aliases", "CMakeDeps") or dict()
+
         ret = {"pkg_name": self.pkg_name,
                "target_namespace": self.target_namespace,
                "global_target_name": self.global_target_name,
                "file_name": self.file_name,
                "data_pattern": data_pattern,
-               "target_pattern": target_pattern}
+               "target_pattern": target_pattern,
+               "cmake_target_aliases": cmake_target_aliases,
+               "cmake_component_target_aliases": cmake_component_target_aliases}
 
         return ret
 
@@ -57,6 +68,28 @@ class TargetsTemplate(CMakeDepsFileTemplate):
             add_library({{ target_namespace }}::{{ global_target_name }} INTERFACE IMPORTED)
             conan_message(STATUS "Conan: Target declared '{{ target_namespace }}::{{ global_target_name }}'")
         endif()
+
+        {%- for alias, target in cmake_target_aliases.items() %}
+
+        if(NOT TARGET {{alias}})
+            add_library({{alias}} INTERFACE IMPORTED)
+            set_property(TARGET {{ alias }} PROPERTY INTERFACE_LINK_LIBRARIES {{target}})
+        endif()
+
+        {%- endfor %}
+
+        {%- for comp_name, component_aliases in cmake_component_target_aliases.items() %}
+
+            {%- for alias, target in component_aliases.items() %}
+
+        if(NOT TARGET {{alias}})
+            add_library({{alias}} INTERFACE IMPORTED)
+            set_property(TARGET {{ alias }} PROPERTY INTERFACE_LINK_LIBRARIES {{target}})
+        endif()
+
+            {%- endfor %}
+
+        {%- endfor %}
 
         # Load the debug and release library finders
         get_filename_component(_DIR "${CMAKE_CURRENT_LIST_FILE}" PATH)

--- a/conan/tools/cmake/cmakedeps/templates/targets.py
+++ b/conan/tools/cmake/cmakedeps/templates/targets.py
@@ -25,7 +25,7 @@ class TargetsTemplate(CMakeDepsFileTemplate):
         target_pattern = "" if not self.find_module_mode else "module-"
         target_pattern += "{}-Target-*.cmake".format(self.file_name)
 
-        cmake_target_aliases = self.conanfile.new_cpp_info.\
+        cmake_target_aliases = self.conanfile.cpp_info.\
             get_property("cmake_target_aliases", "CMakeDeps") or dict()
 
         if isinstance(cmake_target_aliases, (list, tuple)):
@@ -33,9 +33,9 @@ class TargetsTemplate(CMakeDepsFileTemplate):
             cmake_target_aliases = {alias: target for alias in cmake_target_aliases}
 
         cmake_component_target_aliases = dict()
-        for comp_name in self.conanfile.new_cpp_info.components:
+        for comp_name in self.conanfile.cpp_info.components:
             aliases = \
-                self.conanfile.new_cpp_info.components[comp_name].\
+                self.conanfile.cpp_info.components[comp_name].\
                 get_property("cmake_target_aliases", "CMakeDeps") or dict()
             if isinstance(aliases, (list, tuple)):
                 target = "%s::%s" % (self.target_namespace,

--- a/conans/test/functional/toolchains/cmake/cmakedeps/test_cmakedeps_aliases.py
+++ b/conans/test/functional/toolchains/cmake/cmakedeps/test_cmakedeps_aliases.py
@@ -33,7 +33,7 @@ def test_global_alias():
         settings = "os", "compiler", "build_type", "arch"
 
         def package_info(self):
-            self.cpp_info.set_property("cmake_target_aliases", {"hello": "hello::hello"}, "CMakeDeps")
+            self.cpp_info.set_property("cmake_target_aliases", ["hello"], "CMakeDeps")
     """)
 
     cmakelists = textwrap.dedent("""
@@ -66,7 +66,7 @@ def test_component_alias():
 
         def package_info(self):
             self.cpp_info.components["buy"].set_property("cmake_target_aliases",
-                {"hola::adios": "hello::buy"}, "CMakeDeps")
+                ["hola::adios"], "CMakeDeps")
     """)
 
     cmakelists = textwrap.dedent("""

--- a/conans/test/functional/toolchains/cmake/cmakedeps/test_cmakedeps_aliases.py
+++ b/conans/test/functional/toolchains/cmake/cmakedeps/test_cmakedeps_aliases.py
@@ -66,7 +66,7 @@ def test_component_alias():
 
         def package_info(self):
             self.cpp_info.components["buy"].set_property("cmake_target_aliases",
-                ["hola::adios"], "CMakeDeps")
+                ["hola::adios"])
     """)
 
     cmakelists = textwrap.dedent("""

--- a/conans/test/functional/toolchains/cmake/cmakedeps/test_cmakedeps_aliases.py
+++ b/conans/test/functional/toolchains/cmake/cmakedeps/test_cmakedeps_aliases.py
@@ -1,0 +1,87 @@
+import textwrap
+import pytest
+
+from conans.test.utils.tools import TestClient
+
+consumer = textwrap.dedent("""
+from conans import ConanFile
+from conan.tools.cmake import CMake
+
+class Consumer(ConanFile):
+    name = "consumer"
+    version = "1.0"
+    settings = "os", "compiler", "build_type", "arch"
+    generators = "CMakeDeps", "CMakeToolchain"
+    exports_sources = ["CMakeLists.txt"]
+    requires = "hello/1.0"
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+""")
+
+
+@pytest.mark.tool_cmake
+def test_global_alias():
+    conanfile = textwrap.dedent("""
+    from conans import ConanFile
+
+    class Hello(ConanFile):
+        name = "hello"
+        version = "1.0"
+        settings = "os", "compiler", "build_type", "arch"
+
+        def package_info(self):
+            self.cpp_info.set_property("cmake_target_aliases", {"hello": "hello::hello"}, "CMakeDeps")
+    """)
+
+    cmakelists = textwrap.dedent("""
+    cmake_minimum_required(VERSION 2.8)
+
+    find_package(hello REQUIRED)
+    get_target_property(link_libraries hello INTERFACE_LINK_LIBRARIES)
+    message("hello link libraries: ${link_libraries}")
+    """)
+
+    client = TestClient()
+    client.save({"conanfile.py": conanfile})
+    client.run("create .")
+
+    client.save({"conanfile.py": consumer, "CMakeLists.txt": cmakelists})
+    client.run("create .")
+
+    assert "hello link libraries: hello::hello" in client.out
+
+
+@pytest.mark.tool_cmake
+def test_component_alias():
+    conanfile = textwrap.dedent("""
+    from conans import ConanFile
+
+    class Hello(ConanFile):
+        name = "hello"
+        version = "1.0"
+        settings = "os", "compiler", "build_type", "arch"
+
+        def package_info(self):
+            self.cpp_info.components["buy"].set_property("cmake_target_aliases",
+                {"hola::adios": "hello::buy"}, "CMakeDeps")
+    """)
+
+    cmakelists = textwrap.dedent("""
+    cmake_minimum_required(VERSION 2.8)
+
+    find_package(hello REQUIRED)
+    get_target_property(link_libraries hola::adios INTERFACE_LINK_LIBRARIES)
+    message("hola::adios link libraries: ${link_libraries}")
+    """)
+
+    client = TestClient()
+    client.save({"conanfile.py": conanfile})
+    client.run("create .")
+
+    client.save({"conanfile.py": consumer, "CMakeLists.txt": cmakelists})
+    client.run("create .")
+
+    assert "hola::adios link libraries: hello::buy" in client.out

--- a/conans/test/functional/toolchains/cmake/cmakedeps/test_cmakedeps_aliases.py
+++ b/conans/test/functional/toolchains/cmake/cmakedeps/test_cmakedeps_aliases.py
@@ -33,7 +33,7 @@ def test_global_alias():
         settings = "os", "compiler", "build_type", "arch"
 
         def package_info(self):
-            self.cpp_info.set_property("cmake_target_aliases", ["hello"], "CMakeDeps")
+            self.cpp_info.set_property("cmake_target_aliases", ["hello"])
     """)
 
     cmakelists = textwrap.dedent("""

--- a/conans/test/functional/toolchains/cmake/cmakedeps/test_cmakedeps_aliases.py
+++ b/conans/test/functional/toolchains/cmake/cmakedeps/test_cmakedeps_aliases.py
@@ -33,6 +33,7 @@ def test_global_alias():
         settings = "os", "compiler", "build_type", "arch"
 
         def package_info(self):
+            # the default global target is "hello::hello"
             self.cpp_info.set_property("cmake_target_aliases", ["hello"])
     """)
 


### PR DESCRIPTION
Changelog: Feature: Add property "cmake_target_aliases" to create some CMake alias targets using CMakeDeps.
Docs: omit

closes: #8360

- [ ] Refer to the issue that supports this Pull Request.
- [ ] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [ ] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [ ] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 

<sup>**Note:** By default this PR will skip the slower tests and will use a limited set of python versions. Check [here](https://github.com/conan-io/conan/blob/develop/.github/PR_INCREASE_TESTING.md) how to increase the testing level by writing some tags in the current PR body text.</sup>
