### PR TITLE
Rename QbsToolchain to QbsProfile

### DIFF
--- a/conan/tools/qbs/__init__.py
+++ b/conan/tools/qbs/__init__.py
@@ -1,2 +1,3 @@
-from conan.tools.qbs.qbstoolchain import QbsToolchain
+from conan.tools.qbs.qbsprofile import QbsProfile
+from conan.tools.qbs.qbsprofile import QbsProfile as QbsToolchain
 from conan.tools.qbs.qbs import Qbs

--- a/conan/tools/qbs/qbs.py
+++ b/conan/tools/qbs/qbs.py
@@ -21,7 +21,7 @@ def _configuration_dict_to_commandlist(name, config_dict):
 class Qbs(object):
     def __init__(self, conanfile, project_file=None):
         # hardcoded name, see qbs toolchain
-        self.use_profile = 'conan_toolchain_profile'
+        self.profile = 'conan_toolchain_profile'
         self._conanfile = conanfile
         self._set_project_file(project_file)
         self.jobs = tools.cpu_count()
@@ -52,8 +52,8 @@ class Qbs(object):
 
         args.extend(['--jobs', '%s' % self.jobs])
 
-        if self.use_profile:
-            args.append('profile:%s' % self.use_profile)
+        if self.profile:
+            args.append('profile:%s' % self.profile)
 
         for name in self._configuration:
             config = self._configuration[name]
@@ -72,8 +72,8 @@ class Qbs(object):
 
         args.extend(['--jobs', '%s' % self.jobs])
 
-        if self.use_profile:
-            args.append('profile:%s' % self.use_profile)
+        if self.profile:
+            args.append('profile:%s' % self.profile)
 
         for name in self._configuration:
             config = self._configuration[name]

--- a/conan/tools/qbs/qbs.py
+++ b/conan/tools/qbs/qbs.py
@@ -21,7 +21,7 @@ def _configuration_dict_to_commandlist(name, config_dict):
 class Qbs(object):
     def __init__(self, conanfile, project_file=None):
         # hardcoded name, see qbs toolchain
-        self.use_toolchain_profile = 'conan_toolchain_profile'
+        self.use_profile = 'conan_toolchain_profile'
         self._conanfile = conanfile
         self._set_project_file(project_file)
         self.jobs = tools.cpu_count()
@@ -52,8 +52,8 @@ class Qbs(object):
 
         args.extend(['--jobs', '%s' % self.jobs])
 
-        if self.use_toolchain_profile:
-            args.append('profile:%s' % self.use_toolchain_profile)
+        if self.use_profile:
+            args.append('profile:%s' % self.use_profile)
 
         for name in self._configuration:
             config = self._configuration[name]
@@ -72,8 +72,8 @@ class Qbs(object):
 
         args.extend(['--jobs', '%s' % self.jobs])
 
-        if self.use_toolchain_profile:
-            args.append('profile:%s' % self.use_toolchain_profile)
+        if self.use_profile:
+            args.append('profile:%s' % self.use_profile)
 
         for name in self._configuration:
             config = self._configuration[name]

--- a/conan/tools/qbs/qbsprofile.py
+++ b/conan/tools/qbs/qbsprofile.py
@@ -192,8 +192,9 @@ def _flags_from_env():
     return flags_from_env
 
 
-class QbsToolchain(object):
-    filename = 'conan_toolchain.qbs'
+class QbsProfile(object):
+    filename = 'conan_toolchain_profile.qbs'
+    old_filename = 'conan_toolchain.qbs'
 
     _template_toolchain = textwrap.dedent('''\
         import qbs
@@ -266,6 +267,7 @@ class QbsToolchain(object):
             conanfile.options.get_safe('fPIC'))
 
     def generate(self):
+        save(self.old_filename, self.content)
         save(self.filename, self.content)
 
     @property

--- a/conans/test/unittests/client/build/qbs_test.py
+++ b/conans/test/unittests/client/build/qbs_test.py
@@ -99,7 +99,7 @@ class QbsTest(unittest.TestCase):
             ('qbs build --no-install --build-directory %s '
              '--file %s --jobs %s profile:%s') % (
                 conanfile.build_folder, build_helper._project_file,
-                build_helper.jobs, build_helper.use_toolchain_profile))
+                build_helper.jobs, build_helper.use_profile))
 
         build_helper.build(products=['app1', 'app2', 'lib'])
         self.assertEqual(
@@ -107,7 +107,7 @@ class QbsTest(unittest.TestCase):
             ('qbs build --no-install --build-directory %s '
              '--file %s --products app1,app2,lib --jobs %s profile:%s') % (
                 conanfile.build_folder, build_helper._project_file,
-                build_helper.jobs, build_helper.use_toolchain_profile))
+                build_helper.jobs, build_helper.use_profile))
 
     def test_build_all(self):
         conanfile = MockConanfile(
@@ -123,7 +123,7 @@ class QbsTest(unittest.TestCase):
             ('qbs build --no-install --build-directory %s '
              '--file %s --all-products --jobs %s profile:%s') % (
                 conanfile.build_folder, build_helper._project_file,
-                build_helper.jobs, build_helper.use_toolchain_profile))
+                build_helper.jobs, build_helper.use_profile))
 
     @unittest.skipIf(six.PY2, "Order of qbs output is defined only for PY3")
     def test_build_with_custom_configuration(self):
@@ -148,7 +148,7 @@ class QbsTest(unittest.TestCase):
              '--file %s --jobs %s profile:%s '
              'config:%s %s:%s %s:%s %s:%s %s:%s') % (
                 conanfile.build_folder, build_helper._project_file,
-                build_helper.jobs, build_helper.use_toolchain_profile,
+                build_helper.jobs, build_helper.use_profile,
                 config_name,
                 'product.App.boolProperty',
                 'true',

--- a/conans/test/unittests/client/build/qbs_test.py
+++ b/conans/test/unittests/client/build/qbs_test.py
@@ -99,7 +99,7 @@ class QbsTest(unittest.TestCase):
             ('qbs build --no-install --build-directory %s '
              '--file %s --jobs %s profile:%s') % (
                 conanfile.build_folder, build_helper._project_file,
-                build_helper.jobs, build_helper.use_profile))
+                build_helper.jobs, build_helper.profile))
 
         build_helper.build(products=['app1', 'app2', 'lib'])
         self.assertEqual(
@@ -107,7 +107,7 @@ class QbsTest(unittest.TestCase):
             ('qbs build --no-install --build-directory %s '
              '--file %s --products app1,app2,lib --jobs %s profile:%s') % (
                 conanfile.build_folder, build_helper._project_file,
-                build_helper.jobs, build_helper.use_profile))
+                build_helper.jobs, build_helper.profile))
 
     def test_build_all(self):
         conanfile = MockConanfile(
@@ -123,7 +123,7 @@ class QbsTest(unittest.TestCase):
             ('qbs build --no-install --build-directory %s '
              '--file %s --all-products --jobs %s profile:%s') % (
                 conanfile.build_folder, build_helper._project_file,
-                build_helper.jobs, build_helper.use_profile))
+                build_helper.jobs, build_helper.profile))
 
     @unittest.skipIf(six.PY2, "Order of qbs output is defined only for PY3")
     def test_build_with_custom_configuration(self):
@@ -148,7 +148,7 @@ class QbsTest(unittest.TestCase):
              '--file %s --jobs %s profile:%s '
              'config:%s %s:%s %s:%s %s:%s %s:%s') % (
                 conanfile.build_folder, build_helper._project_file,
-                build_helper.jobs, build_helper.use_profile,
+                build_helper.jobs, build_helper.profile,
                 config_name,
                 'product.App.boolProperty',
                 'true',

--- a/conans/test/unittests/client/toolchain/test_qbs_profile.py
+++ b/conans/test/unittests/client/toolchain/test_qbs_profile.py
@@ -4,7 +4,7 @@ import textwrap
 
 import six
 
-import conan.tools.qbs.qbstoolchain as qbs
+import conan.tools.qbs.qbsprofile as qbs
 
 from conans import tools
 from conans.errors import ConanException
@@ -58,7 +58,7 @@ class QbsGenericTest(unittest.TestCase):
             'os': 'Linux',
             'compiler': 'gcc'}))
 
-        qbs_toolchain = qbs.QbsToolchain(conanfile)
+        qbs_toolchain = qbs.QbsProfile(conanfile)
         self.assertEqual(qbs_toolchain._build_variant, None)
 
         for build_type, build_variant in qbs._build_variant.items():
@@ -67,7 +67,7 @@ class QbsGenericTest(unittest.TestCase):
                 'compiler': 'gcc',
                 'build_type': build_type}))
 
-            qbs_toolchain = qbs.QbsToolchain(conanfile)
+            qbs_toolchain = qbs.QbsProfile(conanfile)
             self.assertEqual(qbs_toolchain._build_variant, build_variant)
 
     def test_convert_architecture(self):
@@ -75,7 +75,7 @@ class QbsGenericTest(unittest.TestCase):
             'os': 'Linux',
             'compiler': 'gcc'}))
 
-        qbs_toolchain = qbs.QbsToolchain(conanfile)
+        qbs_toolchain = qbs.QbsProfile(conanfile)
         self.assertEqual(qbs_toolchain._architecture, None)
 
         for arch, architecture in qbs._architecture.items():
@@ -84,7 +84,7 @@ class QbsGenericTest(unittest.TestCase):
                 'compiler': 'gcc',
                 'arch': arch}))
 
-            qbs_toolchain = qbs.QbsToolchain(conanfile)
+            qbs_toolchain = qbs.QbsProfile(conanfile)
             self.assertEqual(qbs_toolchain._architecture, architecture)
 
     def test_convert_optimization(self):
@@ -92,7 +92,7 @@ class QbsGenericTest(unittest.TestCase):
             'os': 'Linux',
             'compiler': 'gcc'}))
 
-        qbs_toolchain = qbs.QbsToolchain(conanfile)
+        qbs_toolchain = qbs.QbsProfile(conanfile)
         self.assertEqual(qbs_toolchain._optimization, None)
 
         for build_type, optimization in qbs._optimization.items():
@@ -101,7 +101,7 @@ class QbsGenericTest(unittest.TestCase):
                 'compiler': 'gcc',
                 'build_type': build_type}))
 
-            qbs_toolchain = qbs.QbsToolchain(conanfile)
+            qbs_toolchain = qbs.QbsProfile(conanfile)
             self.assertEqual(qbs_toolchain._optimization, optimization)
 
     def test_use_sysroot_from_env(self):
@@ -111,7 +111,7 @@ class QbsGenericTest(unittest.TestCase):
 
         sysroot = '/path/to/sysroot/foo/bar'
         with tools.environment_append({'SYSROOT': sysroot}):
-            qbs_toolchain = qbs.QbsToolchain(conanfile)
+            qbs_toolchain = qbs.QbsProfile(conanfile)
         self.assertEqual(qbs_toolchain._sysroot, sysroot)
 
     def test_detect_fpic_from_options(self):
@@ -130,7 +130,7 @@ class QbsGenericTest(unittest.TestCase):
                     'fPIC': option
                 }))
 
-            qbs_toolchain = qbs.QbsToolchain(conanfile)
+            qbs_toolchain = qbs.QbsProfile(conanfile)
             self.assertEqual(qbs_toolchain._position_independent_code, value)
 
     def test_convert_cxx_language_version(self):
@@ -138,14 +138,14 @@ class QbsGenericTest(unittest.TestCase):
             'os': 'Linux',
             'compiler': 'gcc'}))
 
-        qbs_toolchain = qbs.QbsToolchain(conanfile)
+        qbs_toolchain = qbs.QbsProfile(conanfile)
         self.assertEqual(qbs_toolchain._cxx_language_version, None)
         conanfile = MockConanfileWithFolders(MockSettings({
             'os': 'Linux',
             'compiler': 'gcc',
             'compiler.cppstd': 17}))
 
-        qbs_toolchain = qbs.QbsToolchain(conanfile)
+        qbs_toolchain = qbs.QbsProfile(conanfile)
         self.assertEqual(qbs_toolchain._cxx_language_version, 'c++17')
 
         for cppstd, cxx_language_version in qbs._cxx_language_version.items():
@@ -154,7 +154,7 @@ class QbsGenericTest(unittest.TestCase):
                 'compiler': 'gcc',
                 'compiler.cppstd': cppstd}))
 
-            qbs_toolchain = qbs.QbsToolchain(conanfile)
+            qbs_toolchain = qbs.QbsProfile(conanfile)
             self.assertEqual(qbs_toolchain._cxx_language_version,
                              cxx_language_version)
 
@@ -162,7 +162,7 @@ class QbsGenericTest(unittest.TestCase):
         conanfile = MockConanfileWithFolders(MockSettings({
             'compiler': 'gcc'}))
 
-        qbs_toolchain = qbs.QbsToolchain(conanfile)
+        qbs_toolchain = qbs.QbsProfile(conanfile)
         self.assertEqual(qbs_toolchain._target_platform, None)
 
         for os, target_platform in qbs._target_platform.items():
@@ -170,7 +170,7 @@ class QbsGenericTest(unittest.TestCase):
                 'os': os,
                 'compiler': 'gcc'}))
 
-            qbs_toolchain = qbs.QbsToolchain(conanfile)
+            qbs_toolchain = qbs.QbsProfile(conanfile)
             self.assertEqual(qbs_toolchain._target_platform,
                              target_platform)
 
@@ -408,6 +408,6 @@ class QbsGenericTest(unittest.TestCase):
                 ]))
 
         with tools.environment_append({'SYSROOT': '/foo/bar/path'}):
-            qbs_toolchain = qbs.QbsToolchain(conanfile)
+            qbs_toolchain = qbs.QbsProfile(conanfile)
 
         self.assertEqual(qbs_toolchain.content, expected_content)


### PR DESCRIPTION
This generator generates a qbs profile. Renaming the class from Toolchain
to Profile makes this more obvious.

Changelog: Fix: Renamed generator `QbsToolchain` to `QbsProfile`.
Changelog: Fix: Renamed default filename of _QbsProfile_ generated file to _conan_toolchain_profile_.qbs.
Changelog: Fix: Renamed Qbs attribute `use_toolchain_profile` to `profile`.
Docs: https://github.com/conan-io/docs/pull/2027

- [ ] Refer to the issue that supports this Pull Request.
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [x] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 

<sup>**Note:** By default this PR will skip the slower tests and will use a limited set of python versions. Check [here](https://github.com/conan-io/conan/blob/develop/.github/PR_INCREASE_TESTING.md) how to increase the testing level by writing some tags in the current PR body text.</sup>
