### PR TITLE
check if not necessary to sort settings lists

### DIFF
--- a/conans/model/settings.py
+++ b/conans/model/settings.py
@@ -45,7 +45,7 @@ class SettingsItem(object):
             self._definition = "ANY"
         else:
             # list or tuple of possible values
-            self._definition = sorted(str(v) for v in definition)
+            self._definition = [str(v) for v in definition]
 
     def __contains__(self, value):
         return value in (self._value or "")

--- a/conans/test/functional/generators/cmake_test.py
+++ b/conans/test/functional/generators/cmake_test.py
@@ -429,9 +429,9 @@ class CMakeGeneratorTest(unittest.TestCase):
                         self.assertIn("comp compile options: one;two;three;four", client.out)
                     else:
                         self.assertIn("$<$<CONFIG:Debug>:;>;"
-                                      "$<$<CONFIG:Release>:;one;two;three;four>"
+                                      "$<$<CONFIG:Release>:;one;two;three;four>;"
                                       "$<$<CONFIG:RelWithDebInfo>:;>;"
-                                      "$<$<CONFIG:MinSizeRel>:;>;"
+                                      "$<$<CONFIG:MinSizeRel>:;>"
                                       , client.out)
             else:
                 generate_files({"cflags": ["one", "two"], "cxxflags": ["three", "four"]},

--- a/conans/test/functional/generators/cmake_test.py
+++ b/conans/test/functional/generators/cmake_test.py
@@ -429,9 +429,9 @@ class CMakeGeneratorTest(unittest.TestCase):
                         self.assertIn("comp compile options: one;two;three;four", client.out)
                     else:
                         self.assertIn("$<$<CONFIG:Debug>:;>;"
-                                      "$<$<CONFIG:MinSizeRel>:;>;"
-                                      "$<$<CONFIG:RelWithDebInfo>:;>;"
                                       "$<$<CONFIG:Release>:;one;two;three;four>"
+                                      "$<$<CONFIG:RelWithDebInfo>:;>;"
+                                      "$<$<CONFIG:MinSizeRel>:;>;"
                                       , client.out)
             else:
                 generate_files({"cflags": ["one", "two"], "cxxflags": ["three", "four"]},

--- a/conans/test/integration/settings/cppstd_test.py
+++ b/conans/test/integration/settings/cppstd_test.py
@@ -23,7 +23,7 @@ class TestConan(ConanFile):
                    '-s compiler.version="4.6" -s cppstd=17', assert_error=True)
 
         self.assertIn("The specified 'cppstd=17' is not available for 'gcc 4.6'", client.out)
-        self.assertIn("Possible values are ['11', '98', 'gnu11', 'gnu98']", client.out)
+        self.assertIn("Possible values are ['98', 'gnu98', '11', 'gnu11']", client.out)
 
         client.run('create . user/testing -s compiler="gcc" -s compiler.libcxx="libstdc++11" '
                    '-s compiler.version="6.3" -s cppstd=17')

--- a/conans/test/unittests/model/settings_test.py
+++ b/conans/test/unittests/model/settings_test.py
@@ -327,7 +327,7 @@ os: [Windows, Linux]
         with self.assertRaises(ConanException) as cm:
             self.sut.constraint(s2)
         self.assertEqual(str(cm.exception),
-                         bad_value_msg("os", "Win", ["Linux", "Windows"]))
+                         bad_value_msg("os", "Win", ["Windows", "Linux"]))
 
     def test_constraint4(self):
         s2 = {"os": ["Windows"]}


### PR DESCRIPTION
Changelog: Fix: Do not order Settings lists, so error messages are in declared order.
Docs: Omit

Lets see if this doesn't break anything...

Close https://github.com/conan-io/conan/issues/8571