### PR TITLE
Remove default dummy value for iOS XCode signature

### DIFF
--- a/conan/tools/cmake/ios.py
+++ b/conan/tools/cmake/ios.py
@@ -17,9 +17,6 @@ class CMakeiOSToolchain(CMakeToolchainBase):
             # Setting CMAKE_OSX_SYSROOT SDK, when using Xcode generator the name is enough
             # but full path is necessary for others
             set(CMAKE_OSX_SYSROOT {{ CMAKE_OSX_SYSROOT }})
-            if(NOT DEFINED CMAKE_XCODE_ATTRIBUTE_DEVELOPMENT_TEAM)
-              set(CMAKE_XCODE_ATTRIBUTE_DEVELOPMENT_TEAM "123456789A" CACHE INTERNAL "")
-            endif()
         {% endblock %}
     """)
 


### PR DESCRIPTION
Changelog: Fix: Remove default dummy value for iOS XCode signature.
Docs: Omit
Fixes #8575
- [x] Refer to the issue that supports this Pull Request.
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 

For details please see #8575 

<sup>**Note:** By default this PR will skip the slower tests and will use a limited set of python versions. Check [here](https://github.com/conan-io/conan/blob/develop/.github/PR_INCREASE_TESTING.md) how to increase the testing level by writing some tags in the current PR body text.</sup>
