### PR TITLE
Fix/export case insensitive

### DIFF
--- a/conans/client/cmd/export.py
+++ b/conans/client/cmd/export.py
@@ -461,7 +461,7 @@ def export_source(conanfile, origin_folder, destination_source_folder):
     included_sources, excluded_sources = _classify_patterns(conanfile.exports_sources)
     copier = FileCopier([origin_folder], destination_source_folder)
     for pattern in included_sources:
-        copier(pattern, links=True, excludes=excluded_sources, ignore_case=False)
+        copier(pattern, links=True, excludes=excluded_sources)
     output = conanfile.output
     package_output = ScopedOutput("%s exports_sources" % output.scope, output)
     copier.report(package_output)
@@ -494,7 +494,7 @@ def export_recipe(conanfile, origin_folder, destination_folder):
 
     copier = FileCopier([origin_folder], destination_folder)
     for pattern in included_exports:
-        copier(pattern, links=True, excludes=excluded_exports, ignore_case=False)
+        copier(pattern, links=True, excludes=excluded_exports)
     copier.report(package_output)
 
     _run_method(conanfile, "export", origin_folder, destination_folder, output)

--- a/conans/client/cmd/export.py
+++ b/conans/client/cmd/export.py
@@ -461,7 +461,7 @@ def export_source(conanfile, origin_folder, destination_source_folder):
     included_sources, excluded_sources = _classify_patterns(conanfile.exports_sources)
     copier = FileCopier([origin_folder], destination_source_folder)
     for pattern in included_sources:
-        copier(pattern, links=True, excludes=excluded_sources)
+        copier(pattern, links=True, excludes=excluded_sources, ignore_case=False)
     output = conanfile.output
     package_output = ScopedOutput("%s exports_sources" % output.scope, output)
     copier.report(package_output)
@@ -494,7 +494,7 @@ def export_recipe(conanfile, origin_folder, destination_folder):
 
     copier = FileCopier([origin_folder], destination_folder)
     for pattern in included_exports:
-        copier(pattern, links=True, excludes=excluded_exports)
+        copier(pattern, links=True, excludes=excluded_exports, ignore_case=False)
     copier.report(package_output)
 
     _run_method(conanfile, "export", origin_folder, destination_folder, output)

--- a/conans/client/file_copier.py
+++ b/conans/client/file_copier.py
@@ -145,8 +145,6 @@ class FileCopier(object):
             relative_path = os.path.relpath(root, src)
             compare_relative_path = relative_path.lower() if ignore_case else relative_path
             for exclude in excludes:
-                if ignore_case:
-                    exclude = exclude.lower()
                 if fnmatch.fnmatch(compare_relative_path, exclude):
                     subfolders[:] = []
                     files = []

--- a/conans/client/file_copier.py
+++ b/conans/client/file_copier.py
@@ -163,7 +163,6 @@ class FileCopier(object):
 
         for exclude in excludes:
             if ignore_case:
-                exclude = exclude.lower()
                 files_to_copy = [f for f in files_to_copy if not fnmatch.fnmatch(f.lower(), exclude)]
             else:
                 files_to_copy = [f for f in files_to_copy if not fnmatch.fnmatchcase(f, exclude)]

--- a/conans/client/file_copier.py
+++ b/conans/client/file_copier.py
@@ -145,6 +145,8 @@ class FileCopier(object):
             relative_path = os.path.relpath(root, src)
             compare_relative_path = relative_path.lower() if ignore_case else relative_path
             for exclude in excludes:
+                if ignore_case:
+                    exclude = exclude.lower()
                 if fnmatch.fnmatch(compare_relative_path, exclude):
                     subfolders[:] = []
                     files = []
@@ -163,7 +165,8 @@ class FileCopier(object):
 
         for exclude in excludes:
             if ignore_case:
-                files_to_copy = [f for f in files_to_copy if not fnmatch.fnmatch(f, exclude)]
+                exclude = exclude.lower()
+                files_to_copy = [f for f in files_to_copy if not fnmatch.fnmatch(f.lower(), exclude)]
             else:
                 files_to_copy = [f for f in files_to_copy if not fnmatch.fnmatchcase(f, exclude)]
 

--- a/conans/client/file_copier.py
+++ b/conans/client/file_copier.py
@@ -154,20 +154,18 @@ class FileCopier(object):
                 filenames.append(relative_name)
 
         if ignore_case:
-            filenames = {f.lower(): f for f in filenames}
             pattern = pattern.lower()
-            files_to_copy = fnmatch.filter(filenames, pattern)
+            files_to_copy = [n for n in filenames if fnmatch.fnmatch(os.path.normpath(n.lower()),
+                                                                     pattern)]
         else:
             files_to_copy = [n for n in filenames if fnmatch.fnmatchcase(os.path.normpath(n),
                                                                          pattern)]
+
         for exclude in excludes:
             if ignore_case:
                 files_to_copy = [f for f in files_to_copy if not fnmatch.fnmatch(f, exclude)]
             else:
                 files_to_copy = [f for f in files_to_copy if not fnmatch.fnmatchcase(f, exclude)]
-
-        if ignore_case:
-            files_to_copy = [filenames[f] for f in files_to_copy]
 
         return files_to_copy, linked_folders
 

--- a/conans/test/functional/command/export/export_test.py
+++ b/conans/test/functional/command/export/export_test.py
@@ -472,15 +472,24 @@ def test_export_casing():
     conanfile = textwrap.dedent("""
         from conans import ConanFile
         class Pkg(ConanFile):
+            exports = "file1", "FILE1"
             exports_sources = "test", "TEST"
         """)
     client.save({"conanfile.py": conanfile,
                  "test": "some lowercase",
-                 "TEST": "some UPPERCASE"})
+                 "TEST": "some UPPERCASE",
+                 "file1": "file1 lowercase",
+                 "FILE1": "file1 UPPERCASE"
+                 })
     assert client.load("test") == "some lowercase"
     assert client.load("TEST") == "some UPPERCASE"
+    assert client.load("file1") == "file1 lowercase"
+    assert client.load("FILE1") == "file1 UPPERCASE"
     client.run("export . pkg/0.1@")
     ref = ConanFileReference.loads("pkg/0.1@")
     export_src_folder = client.cache.package_layout(ref).export_sources()
     assert load(os.path.join(export_src_folder, "test")) == "some lowercase"
     assert load(os.path.join(export_src_folder, "TEST")) == "some UPPERCASE"
+    exports_folder = client.cache.package_layout(ref).export()
+    assert load(os.path.join(exports_folder, "file1")) == "file1 lowercase"
+    assert load(os.path.join(exports_folder, "FILE1")) == "file1 UPPERCASE"

--- a/conans/test/functional/command/export/export_test.py
+++ b/conans/test/functional/command/export/export_test.py
@@ -1,4 +1,5 @@
 import os
+import platform
 import stat
 import textwrap
 import unittest
@@ -462,3 +463,24 @@ class ExportMetadataTest(unittest.TestCase):
         self.assertIn("pkg/0.1: A new conanfile.py version was exported", client.out)
         client.run('export . Pkg/0.1@', assert_error=True)
         self.assertIn("ERROR: Cannot export package with same name but different case", client.out)
+
+
+@pytest.mark.skipif(platform.system() != "Linux", reason="Needs case-sensitive filesystem")
+def test_export_casing():
+    # https://github.com/conan-io/conan/issues/8583
+    client = TestClient()
+    conanfile = textwrap.dedent("""
+        from conans import ConanFile
+        class Pkg(ConanFile):
+            exports_sources = "test", "TEST"
+        """)
+    client.save({"conanfile.py": conanfile,
+                 "test": "some lowercase",
+                 "TEST": "some UPPERCASE"})
+    assert client.load("test") == "some lowercase"
+    assert client.load("TEST") == "some UPPERCASE"
+    client.run("export . pkg/0.1@")
+    ref = ConanFileReference.loads("pkg/0.1@")
+    export_src_folder = client.cache.package_layout(ref).export_sources()
+    assert load(os.path.join(export_src_folder, "test")) == "some lowercase"
+    assert load(os.path.join(export_src_folder, "TEST")) == "some UPPERCASE"


### PR DESCRIPTION
Changelog: Fix: Restoring the behavior that `exports` and `exports_sources` were case sensitive by default.
Docs: Omit

Close https://github.com/conan-io/conan/issues/8583

It is possible that this might be breaking, lets see.
#tags: slow
