### PR TITLE
Support PKG_CONFIG env var to define the pkg-config executbale used by tools.PkgConfig

### DIFF
--- a/conans/client/tools/pkg_config.py
+++ b/conans/client/tools/pkg_config.py
@@ -6,7 +6,6 @@ import subprocess
 
 from conans.errors import ConanException
 from conans.util.runners import check_output_runner
-from util.env_reader import get_env
 
 
 class PkgConfig(object):

--- a/conans/client/tools/pkg_config.py
+++ b/conans/client/tools/pkg_config.py
@@ -1,10 +1,12 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
+import os
 import subprocess
 
 from conans.errors import ConanException
 from conans.util.runners import check_output_runner
+from util.env_reader import get_env
 
 
 class PkgConfig(object):
@@ -12,8 +14,8 @@ class PkgConfig(object):
     def _cmd_output(command):
         return check_output_runner(command).strip()
 
-    def __init__(self, library, pkg_config_executable='pkg-config', static=False, msvc_syntax=False, variables=None,
-                 print_errors=True):
+    def __init__(self, library, pkg_config_executable="pkg-config", static=False, msvc_syntax=False,
+                 variables=None, print_errors=True):
         """
         :param library: library (package) name, such as libastral
         :param pkg_config_executable: specify custom pkg-config executable (e.g. for cross-compilation)
@@ -23,7 +25,8 @@ class PkgConfig(object):
         :param print_errors: output error messages (adds --print-errors)
         """
         self.library = library
-        self.pkg_config_executable = pkg_config_executable
+        pkg_config_env = os.environ.get("PKG_CONFIG", None)
+        self.pkg_config_executable = pkg_config_env or pkg_config_executable
         self.static = static
         self.msvc_syntax = msvc_syntax
         self.define_variables = variables

--- a/conans/test/functional/util/pkg_config_test.py
+++ b/conans/test/functional/util/pkg_config_test.py
@@ -114,3 +114,12 @@ Cflags: -I${includedir}"""
                         "-Wl,-rpath=/my_prefix/path/lib2")
             pkg_config = PkgConfig("MyLib")
             self.assertIn(expected, " ".join(lib for lib in pkg_config.libs))
+
+    def test_override_pkg_config_executable(self):
+        assert PkgConfig("MyLib").pkg_config_executable == "pkg-config"
+        assert PkgConfig("MyLib", pkg_config_executable="my_pkg_config").pkg_config_executable == \
+               "my_pkg_config"
+        with environment_append({"PKG_CONFIG": "env_pkg_config"}):
+            assert PkgConfig("MyLib", pkg_config_executable="my_pkg_config").pkg_config_executable == \
+                   "env_pkg_config"
+            assert PkgConfig("MyLib").pkg_config_executable == "env_pkg_config"


### PR DESCRIPTION
Changelog: Feature: Support `PKG_CONFIG` env var to define the pkg-config executbale used by `tools.PkgConfig`
Docs: https://github.com/conan-io/docs/pull/XXXX

- [x] Refer to the issue that supports this Pull Request: closes #8591
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [x] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 

<sup>**Note:** By default this PR will skip the slower tests and will use a limited set of python versions. Check [here](https://github.com/conan-io/conan/blob/develop/.github/PR_INCREASE_TESTING.md) how to increase the testing level by writing some tags in the current PR body text.</sup>
