### PR TITLE
definition of custom VS version for msvc compiler in MSBuild

### DIFF
--- a/conan/tools/microsoft/__init__.py
+++ b/conan/tools/microsoft/__init__.py
@@ -1,17 +1,4 @@
-from .toolchain import MSBuildToolchain
-from .msbuild import MSBuild
-from .msbuilddeps import MSBuildDeps
-
-
-def msvc_runtime_flag(conanfile):
-    settings = conanfile.settings
-    compiler = settings.get_safe("compiler")
-    runtime = settings.get_safe("compiler.runtime")
-    if compiler == "Visual Studio":
-        return runtime
-    if compiler == "msvc":
-        runtime_type = settings.get_safe("compiler.runtime_type")
-        runtime = "MT" if runtime == "static" else "MD"
-        if runtime_type == "Debug":
-            runtime = "{}d".format(runtime)
-        return runtime
+from conan.tools.microsoft.toolchain import MSBuildToolchain
+from conan.tools.microsoft.msbuild import MSBuild
+from conan.tools.microsoft.msbuilddeps import MSBuildDeps
+from conan.tools.microsoft.visual import msvc_runtime_flag

--- a/conan/tools/microsoft/msbuild.py
+++ b/conan/tools/microsoft/msbuild.py
@@ -1,5 +1,3 @@
-from conan.tools.microsoft.visual import vcvars_arch, vcvars_command
-from conans.client.tools import intel_compilervars_command
 from conans.errors import ConanException
 
 
@@ -14,17 +12,6 @@ def msbuild_verbosity_cmd_line_arg(conanfile):
 class MSBuild(object):
     def __init__(self, conanfile):
         self._conanfile = conanfile
-        self.compiler = conanfile.settings.get_safe("compiler")
-        # This is assuming this is the Visual Studio IDE version, used for the vcvars
-        self.version = (conanfile.settings.get_safe("compiler.base.version") or
-                        conanfile.settings.get_safe("compiler.version"))
-        if self.compiler == "msvc":
-            version = self.version[:4]  # Remove the latest version number 19.1X if existing
-            _visuals = {'19.0': '14',  # TODO: This is common to CMake, refactor
-                        '19.1': '15',
-                        '19.2': '16'}
-            self.version = _visuals[version]
-        self.vcvars_arch = vcvars_arch(conanfile)
         self.build_type = conanfile.settings.get_safe("build_type")
         msvc_arch = {'x86': 'x86',
                      'x86_64': 'x64',
@@ -39,14 +26,9 @@ class MSBuild(object):
         self.platform = msvc_arch
 
     def command(self, sln):
-        if self.compiler == "intel":
-            cvars = intel_compilervars_command(self._conanfile)
-        else:
-            cvars = vcvars_command(self.version, architecture=self.vcvars_arch,
-                                   platform_type=None, winsdk_version=None,
-                                   vcvars_ver=None)
-        cmd = ('%s && msbuild "%s" /p:Configuration=%s /p:Platform=%s'
-               % (cvars, sln, self.build_type, self.platform))
+        install_folder = self._conanfile.install_folder
+        cmd = ('%s/conanvcvars.bat && msbuild "%s" /p:Configuration=%s /p:Platform=%s'
+               % (install_folder, sln, self.build_type, self.platform))
 
         verbosity = msbuild_verbosity_cmd_line_arg(self._conanfile)
         if verbosity:

--- a/conan/tools/microsoft/msbuilddeps.py
+++ b/conan/tools/microsoft/msbuilddeps.py
@@ -2,9 +2,11 @@ import os
 import textwrap
 from xml.dom import minidom
 
-from conans.client.tools import VALID_LIB_EXTENSIONS
+
 from conans.errors import ConanException
 from conans.util.files import load, save
+
+VALID_LIB_EXTENSIONS = (".so", ".lib", ".a", ".dylib", ".bc")
 
 
 class MSBuildDeps(object):
@@ -213,6 +215,7 @@ class MSBuildDeps(object):
         return content_multi
 
     def _content(self):
+        # We cannot use self._conanfile.warn(), because that fails for virtual conanfile
         print("*** The 'msbuild' generator is EXPERIMENTAL ***")
         if not self._conanfile.settings.get_safe("build_type"):
             raise ConanException("The 'msbuild' generator requires a 'build_type' setting value")

--- a/conan/tools/microsoft/visual.py
+++ b/conan/tools/microsoft/visual.py
@@ -4,6 +4,20 @@ from conans.client.tools.win import vs_installation_path
 from conans.errors import ConanException
 
 
+def msvc_runtime_flag(conanfile):
+    settings = conanfile.settings
+    compiler = settings.get_safe("compiler")
+    runtime = settings.get_safe("compiler.runtime")
+    if compiler == "Visual Studio":
+        return runtime
+    if compiler == "msvc":
+        runtime_type = settings.get_safe("compiler.runtime_type")
+        runtime = "MT" if runtime == "static" else "MD"
+        if runtime_type == "Debug":
+            runtime = "{}d".format(runtime)
+        return runtime
+
+
 def vcvars_command(version, architecture=None, platform_type=None, winsdk_version=None,
                    vcvars_ver=None, start_dir_cd=True):
     """ conan-agnostic construction of vcvars command

--- a/conans/test/functional/toolchains/test_basic.py
+++ b/conans/test/functional/toolchains/test_basic.py
@@ -1,4 +1,5 @@
 import os
+import platform
 import textwrap
 import unittest
 
@@ -34,8 +35,7 @@ class BasicTest(unittest.TestCase):
             from conans import ConanFile
             class Pkg(ConanFile):
                 settings = "os", "compiler", "arch", "build_type"
-                generators = ("CMakeToolchain", "CMakeDeps", "MesonToolchain", "MakeToolchain",
-                              "MSBuildToolchain")
+                generators = ("CMakeToolchain", "CMakeDeps", "MesonToolchain", "MakeToolchain")
             """)
         client = TestClient()
         client.save({"conanfile.py": conanfile})
@@ -44,16 +44,30 @@ class BasicTest(unittest.TestCase):
         self.assertIn("conanfile.py: Generator 'CMakeToolchain' calling 'generate()'", client.out)
         self.assertIn("conanfile.py: Generator 'MesonToolchain' calling 'generate()'", client.out)
         self.assertIn("conanfile.py: Generator 'MakeToolchain' calling 'generate()'", client.out)
-        self.assertIn("conanfile.py: Generator 'MSBuildToolchain' calling 'generate()'", client.out)
         self.assertIn("conanfile.py: Generator 'CMakeDeps' calling 'generate()'", client.out)
         toolchain = client.load("conan_toolchain.cmake")
         self.assertIn("Conan automatically generated toolchain file", toolchain)
-        toolchain = client.load("conantoolchain.props")
-        self.assertIn("<?xml version", toolchain)
         toolchain = client.load("conan_toolchain.mak")
         self.assertIn("# Conan generated toolchain file", toolchain)
         toolchain = client.load("conan_meson_native.ini")
         self.assertIn("[project options]", toolchain)
+
+    @pytest.mark.tool_visual_studio
+    @pytest.mark.skipif(platform.system() != "Windows", reason="Only for windows")
+    def test_declarative_msbuildtoolchain(self):
+        conanfile = textwrap.dedent("""
+            from conans import ConanFile
+            class Pkg(ConanFile):
+                settings = "os", "compiler", "arch", "build_type"
+                generators = ("MSBuildToolchain", )
+            """)
+        client = TestClient()
+        client.save({"conanfile.py": conanfile})
+        client.run("install .")
+
+        self.assertIn("conanfile.py: Generator 'MSBuildToolchain' calling 'generate()'", client.out)
+        toolchain = client.load("conantoolchain.props")
+        self.assertIn("<?xml version", toolchain)
 
     def test_error_missing_settings(self):
         conanfile = textwrap.dedent("""
@@ -121,6 +135,8 @@ class BasicTest(unittest.TestCase):
         client.run("install .", assert_error=True)
         self.assertIn("The 'toolchain' attribute or method has been deprecated", client.out)
 
+    @pytest.mark.tool_visual_studio
+    @pytest.mark.skipif(platform.system() != "Windows", reason="Only for windows")
     def test_toolchain_windows(self):
         client = TestClient()
         conanfile = textwrap.dedent("""

--- a/conans/test/functional/toolchains/test_txt_cmdline.py
+++ b/conans/test/functional/toolchains/test_txt_cmdline.py
@@ -1,3 +1,4 @@
+import platform
 import textwrap
 import unittest
 
@@ -15,7 +16,6 @@ class TestTxtCommandLine(unittest.TestCase):
             CMakeToolchain
             MesonToolchain
             MakeToolchain
-            MSBuildToolchain
             """)
         client = TestClient()
         client.save({"conanfile.txt": conanfile})
@@ -26,11 +26,8 @@ class TestTxtCommandLine(unittest.TestCase):
         self.assertIn("conanfile.txt: Generator 'CMakeToolchain' calling 'generate()'", client.out)
         self.assertIn("conanfile.txt: Generator 'MesonToolchain' calling 'generate()'", client.out)
         self.assertIn("conanfile.txt: Generator 'MakeToolchain' calling 'generate()'", client.out)
-        self.assertIn("conanfile.txt: Generator 'MSBuildToolchain' calling 'generate()'", client.out)
         toolchain = client.load("conan_toolchain.cmake")
         self.assertIn("Conan automatically generated toolchain file", toolchain)
-        toolchain = client.load("conantoolchain.props")
-        self.assertIn("<?xml version", toolchain)
         toolchain = client.load("conan_toolchain.mak")
         self.assertIn("# Conan generated toolchain file", toolchain)
         toolchain = client.load("conan_meson_native.ini")
@@ -40,5 +37,31 @@ class TestTxtCommandLine(unittest.TestCase):
         client = TestClient()
         client.save({"conanfile.txt": ""})
         client.run("install . -g CMakeToolchain -g MesonToolchain "
-                   "-g MakeToolchain -g MSBuildToolchain")
+                   "-g MakeToolchain")
+        self._check(client)
+
+
+@pytest.mark.tool_visual_studio
+@pytest.mark.skipif(platform.system() != "Windows", reason="Only for windows")
+class TestTxtCommandLineMSBuild(unittest.TestCase):
+
+    def test_declarative(self):
+        conanfile = textwrap.dedent("""
+            [generators]
+            MSBuildToolchain
+            """)
+        client = TestClient()
+        client.save({"conanfile.txt": conanfile})
+        client.run("install .")
+        self._check(client)
+
+    def _check(self, client):
+        self.assertIn("conanfile.txt: Generator 'MSBuildToolchain' calling 'generate()'", client.out)
+        toolchain = client.load("conantoolchain.props")
+        self.assertIn("<?xml version", toolchain)
+
+    def test_command_line(self):
+        client = TestClient()
+        client.save({"conanfile.txt": ""})
+        client.run("install . -g MSBuildToolchain")
         self._check(client)

--- a/conans/test/integration/configuration/conf/test_conf_profile.py
+++ b/conans/test/integration/configuration/conf/test_conf_profile.py
@@ -106,8 +106,6 @@ def test_config_profile_forbidden(client):
             "'cache:verbosity=Minimal' not allowed in profiles" in client.out)
 
 
-@pytest.mark.tool_visual_studio
-@pytest.mark.skipif(platform.system() != "Windows", reason="Only for windows")
 def test_msbuild_config():
     client = TestClient()
     conanfile = textwrap.dedent("""
@@ -137,6 +135,8 @@ def test_msbuild_config():
     assert "/verbosity:Minimal" in client.out
 
 
+@pytest.mark.tool_visual_studio
+@pytest.mark.skipif(platform.system() != "Windows", reason="Only for windows")
 def test_msbuild_compile_options():
     client = TestClient()
     conanfile = textwrap.dedent("""

--- a/conans/test/integration/toolchain/test_msbuild_toolchain.py
+++ b/conans/test/integration/toolchain/test_msbuild_toolchain.py
@@ -1,10 +1,14 @@
+import platform
 import textwrap
 
+import pytest
 from parameterized import parameterized
 
 from conans.test.utils.tools import TestClient
 
 
+@pytest.mark.tool_visual_studio
+@pytest.mark.skipif(platform.system() != "Windows", reason="Only for windows")
 @parameterized.expand([("msvc", "19.0", "dynamic"),
                        ("msvc", "19.1", "static")]
                       )


### PR DESCRIPTION
Changelog: Feature: Allow definition of custom Visual Studio version for ``msvc`` compiler in MSBuild helpers.
Changelog: Feature: ``MSBuildToolchain`` creates ``conanvcvars.bat`` containing vcvars command for command line building
Docs: https://github.com/conan-io/docs/pull/XXXX

#tags: slow