### PR TITLE
[wip] Fix config install not working when .git* folder is in the path

### DIFF
--- a/conans/client/conf/config_installer.py
+++ b/conans/client/conf/config_installer.py
@@ -130,7 +130,7 @@ def _process_folder(config, folder, cache, output):
         folder = os.path.join(folder, config.source_folder)
     for root, dirs, files in walk(folder):
         dirs[:] = [d for d in dirs if d != ".git"]
-        if ".git" in root:
+        if os.path.join(".git", "") in root:
             continue
         for f in files:
             _process_file(root, f, config, cache, output, folder)

--- a/conans/client/conf/config_installer.py
+++ b/conans/client/conf/config_installer.py
@@ -130,8 +130,6 @@ def _process_folder(config, folder, cache, output):
         folder = os.path.join(folder, config.source_folder)
     for root, dirs, files in walk(folder):
         dirs[:] = [d for d in dirs if d != ".git"]
-        if os.path.join(".git", "") in root:
-            continue
         for f in files:
             _process_file(root, f, config, cache, output, folder)
 

--- a/conans/test/functional/command/config_install_test.py
+++ b/conans/test/functional/command/config_install_test.py
@@ -760,12 +760,12 @@ class ConfigInstallSchedTest(unittest.TestCase):
         assert os.path.basename(client.cache_folder) == ".conan"
         conf = load(client.cache.conan_conf_path)
         assert "config_install_interval = 5m" not in conf
-        with self.client.chdir(self.folder):
-            self.client.run_command('git init .')
-            self.client.run_command('git add .')
-            self.client.run_command('git config user.name myname')
-            self.client.run_command('git config user.email myname@mycompany.com')
-            self.client.run_command('git commit -m "mymsg"')
-        client.run("config install '%s'" % self.folder)
+        with client.chdir(self.folder):
+            client.run_command('git init .')
+            client.run_command('git add .')
+            client.run_command('git config user.name myname')
+            client.run_command('git config user.email myname@mycompany.com')
+            client.run_command('git commit -m "mymsg"')
+        client.run('config install "%s/.git" --type git' % self.folder)
         conf = load(client.cache.conan_conf_path)
         assert "config_install_interval = 5m" in conf

--- a/conans/test/functional/command/config_install_test.py
+++ b/conans/test/functional/command/config_install_test.py
@@ -9,7 +9,6 @@ import pytest
 import six
 from mock import patch
 
-from client.tools import environment_append
 from conans.client.cache.remote_registry import Remote
 from conans.client.conf import ConanClientConfigParser
 from conans.client.conf.config_installer import _hide_password, _ConfigOrigin

--- a/conans/test/functional/command/config_install_test.py
+++ b/conans/test/functional/command/config_install_test.py
@@ -759,6 +759,8 @@ class ConfigInstallSchedTest(unittest.TestCase):
         client = TestClient(cache_folder=folder)
         assert ".gitlab-conan" in client.cache_folder
         assert os.path.basename(client.cache_folder) == ".conan"
+        conf = load(client.cache.conan_conf_path)
+        assert "config_install_interval = 5m" not in conf
         with self.client.chdir(self.folder):
             self.client.run_command('git init .')
             self.client.run_command('git add .')

--- a/conans/test/functional/command/config_install_test.py
+++ b/conans/test/functional/command/config_install_test.py
@@ -754,18 +754,21 @@ class ConfigInstallSchedTest(unittest.TestCase):
             self.assertGreater(os.path.getmtime(self.client.cache.config_install_file), last_change)
 
     def test_config_fails_git_folder(self):
+        # https://github.com/conan-io/conan/issues/8594
         folder = os.path.join(temp_folder(), ".gitlab-conan", ".conan")
         client = TestClient(cache_folder=folder)
-        assert ".gitlab-conan" in client.cache_folder
-        assert os.path.basename(client.cache_folder) == ".conan"
-        conf = load(client.cache.conan_conf_path)
-        assert "config_install_interval = 5m" not in conf
         with client.chdir(self.folder):
             client.run_command('git init .')
             client.run_command('git add .')
             client.run_command('git config user.name myname')
             client.run_command('git config user.email myname@mycompany.com')
             client.run_command('git commit -m "mymsg"')
+        assert ".gitlab-conan" in client.cache_folder
+        assert os.path.basename(client.cache_folder) == ".conan"
+        conf = load(client.cache.conan_conf_path)
+        assert "config_install_interval = 5m" not in conf
         client.run('config install "%s/.git" --type git' % self.folder)
         conf = load(client.cache.conan_conf_path)
         assert "config_install_interval = 5m" in conf
+        dirs = os.listdir(client.cache.cache_folder)
+        assert ".git" not in dirs


### PR DESCRIPTION
Changelog: Bugfix: Fix config install not working when .git* folder is in the path.
Docs: omit

closes #8594