### PR TITLE
Use python patch instead of custom dependency injection for tests (stdin)

### DIFF
--- a/conans/test/integration/command/help_test.py
+++ b/conans/test/integration/command/help_test.py
@@ -1,8 +1,5 @@
-import sys
 import unittest
 import textwrap
-
-from six import StringIO
 
 from conans import __version__
 from conans.test.utils.tools import TestClient
@@ -69,29 +66,14 @@ class BasicClientTest(unittest.TestCase):
 
     def test_help_cmd(self):
         client = TestClient()
-        try:
-            old_stdout = sys.stdout
-            result = StringIO()
-            sys.stdout = result
-            client.run("help new")
-        finally:
-            sys.stdout = old_stdout
-        self.assertIn("Creates a new package recipe template with a 'conanfile.py'",
-                      result.getvalue())
+        client.run("help new")
+        self.assertIn("Creates a new package recipe template with a 'conanfile.py'", client.out)
 
-        try:
-            old_stdout = sys.stdout
-            result = StringIO()
-            sys.stdout = result
-            client.run("help build")
-        finally:
-            sys.stdout = old_stdout
-        self.assertIn("Calls your local conanfile.py 'build()' method",
-                      result.getvalue())
+        client.run("help build")
+        self.assertIn("Calls your local conanfile.py 'build()' method", client.out)
 
         client.run("help")
-        self.assertIn("Creator commands",
-                      client.out)
+        self.assertIn("Creator commands", client.out)
 
     def test_help_cmd_error(self):
         client = TestClient()

--- a/conans/test/integration/command/remove_test.py
+++ b/conans/test/integration/command/remove_test.py
@@ -15,8 +15,7 @@ from conans.paths import BUILD_FOLDER, CONANFILE, CONANINFO, CONAN_MANIFEST, EXP
 from conans.server.store.server_store import ServerStore
 from conans.test.assets.cpp_test_files import cpp_hello_conan_files
 from conans.test.utils.test_files import temp_folder
-from conans.test.utils.tools import NO_SETTINGS_PACKAGE_ID, TestClient, \
-    TestServer, GenConanfile
+from conans.test.utils.tools import NO_SETTINGS_PACKAGE_ID, TestClient, TestServer, GenConanfile
 from conans.util.env_reader import get_env
 from conans.util.files import load
 

--- a/conans/test/integration/command/remove_test.py
+++ b/conans/test/integration/command/remove_test.py
@@ -1,12 +1,12 @@
 import os
+import sys
 import unittest
 
 import six
-from mock import Mock
+from mock import patch
 import pytest
 
 from conans import DEFAULT_REVISION_V1
-from conans.client.userio import UserIO
 from conans.model.manifest import FileTreeManifest
 from conans.model.package_metadata import PackageMetadata
 from conans.model.ref import ConanFileReference, PackageReference
@@ -14,7 +14,6 @@ from conans.paths import BUILD_FOLDER, CONANFILE, CONANINFO, CONAN_MANIFEST, EXP
     PACKAGES_FOLDER, SRC_FOLDER
 from conans.server.store.server_store import ServerStore
 from conans.test.assets.cpp_test_files import cpp_hello_conan_files
-from conans.test.utils.mocks import TestBufferConanOutput
 from conans.test.utils.test_files import temp_folder
 from conans.test.utils.tools import NO_SETTINGS_PACKAGE_ID, TestClient, \
     TestServer, GenConanfile
@@ -277,9 +276,8 @@ class RemoveTest(unittest.TestCase):
         six.assertCountEqual(self, ["Other", "Bye"], folders)
 
     def test_basic_mocked(self):
-        mocked_user_io = UserIO(out=TestBufferConanOutput())
-        mocked_user_io.request_boolean = Mock(return_value=True)
-        self.client.run("remove hello/*", user_io=mocked_user_io)
+        with patch.object(sys.stdin, "readline", return_value="y"):
+            self.client.run("remove hello/*")
         self.assert_folders(local_folders={"H1": None, "H2": None, "B": [1, 2], "O": [1, 2]},
                             remote_folders={"H1": [1, 2], "H2": [1, 2], "B": [1, 2], "O": [1, 2]},
                             build_folders={"H1": None, "H2": None, "B": [1, 2], "O": [1, 2]},
@@ -341,9 +339,8 @@ class RemoveTest(unittest.TestCase):
         self._validate_remove_hello_1_4_10()
 
     def test_builds(self):
-        mocked_user_io = UserIO(out=TestBufferConanOutput())
-        mocked_user_io.request_boolean = Mock(return_value=True)
-        self.client.run("remove hello/* -b", user_io=mocked_user_io)
+        with patch.object(sys.stdin, "readline", return_value="y"):
+            self.client.run("remove hello/* -b")
         self.assert_folders(local_folders={"H1": [1, 2], "H2": [1, 2], "B": [1, 2], "O": [1, 2]},
                             remote_folders={"H1": [1, 2], "H2": [1, 2], "B": [1, 2], "O": [1, 2]},
                             build_folders={"H1": [], "H2": [], "B": [1, 2], "O": [1, 2]},
@@ -360,9 +357,8 @@ class RemoveTest(unittest.TestCase):
                                                      "Hello/2.4.11/myuser/testing")))
 
     def test_src(self):
-        mocked_user_io = UserIO(out=TestBufferConanOutput())
-        mocked_user_io.request_boolean = Mock(return_value=True)
-        self.client.run("remove hello/* -s", user_io=mocked_user_io)
+        with patch.object(sys.stdin, "readline", return_value="y"):
+            self.client.run("remove hello/* -s")
         self.assert_folders(local_folders={"H1": [1, 2], "H2": [1, 2], "B": [1, 2], "O": [1, 2]},
                             remote_folders={"H1": [1, 2], "H2": [1, 2], "B": [1, 2], "O": [1, 2]},
                             build_folders={"H1": [1, 2], "H2": [1, 2], "B": [1, 2], "O": [1, 2]},
@@ -379,9 +375,8 @@ class RemoveTest(unittest.TestCase):
                                                      "Hello/2.4.11/myuser/testing")))
 
     def test_reject_removal(self):
-        mocked_user_io = UserIO(out=TestBufferConanOutput())
-        mocked_user_io.request_boolean = Mock(return_value=False)
-        self.client.run("remove hello/* -s -b -p", user_io=mocked_user_io)
+        with patch.object(sys.stdin, "readline", return_value="n"):
+            self.client.run("remove hello/* -s -b -p")
         self.assert_folders(local_folders={"H1": [1, 2], "H2": [1, 2], "B": [1, 2], "O": [1, 2]},
                             remote_folders={"H1": [1, 2], "H2": [1, 2], "B": [1, 2], "O": [1, 2]},
                             build_folders={"H1": [1, 2], "H2": [1, 2], "B": [1, 2], "O": [1, 2]},

--- a/conans/test/integration/test_migrations.py
+++ b/conans/test/integration/test_migrations.py
@@ -241,15 +241,12 @@ the old general
         self.assertTrue(os.path.isfile(export_tgz))
         self.assertTrue(os.path.isfile(export_src_tgz))
         self.assertTrue(os.path.isfile(pkg_tgz))
-        save(os.path.join(client.cache_folder, "version.txt"), "1.30.0")
+
         client2 = TestClient(client.cache_folder)
-        if client2.cache.config.revisions_enabled:
-            self.assertIn("Removing temporary .tgz files, they are stored in a different "
-                          "location now", client2.out)
-        else:
-            client2.run("-h")
-            self.assertIn("Removing temporary .tgz files, they are stored in a different "
-                          "location now", client2.out)
+        save(os.path.join(client.cache_folder, "version.txt"), "1.30.0")
+        client2.run("search")
+        self.assertIn("Removing temporary .tgz files, they are stored in a different location now",
+                      client2.out)
         self.assertFalse(os.path.isfile(export_tgz))
         self.assertFalse(os.path.isfile(export_src_tgz))
         self.assertFalse(os.path.isfile(pkg_tgz))

--- a/conans/test/utils/mocks.py
+++ b/conans/test/utils/mocks.py
@@ -139,7 +139,6 @@ class MockConanfile(ConanFile):
 
         self.package_folder = None
 
-
     def run(self, *args, **kwargs):
         if self.runner:
             kwargs["output"] = None

--- a/conans/test/utils/mocks.py
+++ b/conans/test/utils/mocks.py
@@ -219,7 +219,8 @@ class TestBufferConanOutput(ConanOutput):
 # cli2.0
 class RedirectedTestOutput(StringIO):
     def __init__(self):
-        super(RedirectedTestOutput, self).__init__()
+        # Chage to super() for Py3
+        StringIO.__init__(self)
 
     def __repr__(self):
         return self.getvalue()

--- a/conans/test/utils/tools.py
+++ b/conans/test/utils/tools.py
@@ -1,6 +1,5 @@
 import json
 import os
-import random
 import shlex
 import shutil
 import socket
@@ -39,7 +38,7 @@ from conans.model.settings import Settings
 from conans.server.revision_list import _RevisionEntry
 from conans.test.assets import copy_assets
 from conans.test.assets.genconanfile import GenConanfile
-from conans.test.utils.mocks import MockedUserIO, TestBufferConanOutput
+from conans.test.utils.mocks import MockedUserIO, TestBufferConanOutput, RedirectedTestOutput
 from conans.test.utils.scm import create_local_git_repo, create_local_svn_checkout, \
     create_remote_svn_repo
 from conans.test.utils.server_launcher import (TESTING_REMOTE_PRIVATE_PASS,
@@ -553,7 +552,6 @@ class TestClient(object):
         mkdir(self.current_folder)
         self.tune_conan_conf(cache_folder, cpu_count, revisions_enabled)
 
-        from conans.test.utils.mocks import RedirectedTestOutput
         self.out = RedirectedTestOutput()
 
     def load(self, filename):


### PR DESCRIPTION
Changelog: Omit
Docs: Omit

Use python patch instead of custom dependency injection for tests (stdin)

#tags: slow
#revisions: 1
