### PR TITLE
toos.OsInfo: properly detect amazon linux 2

### DIFF
--- a/conans/client/tools/oss.py
+++ b/conans/client/tools/oss.py
@@ -204,7 +204,7 @@ class OSInfo(object):
     def with_yum(self):
         return self.is_linux and self.linux_distro in ("pidora", "fedora", "scientific", "centos",
                                                        "redhat", "rhel", "xenserver", "amazon",
-                                                       "oracle")
+                                                       "oracle", "amzn")
 
     @property
     def with_dnf(self):


### PR DESCRIPTION
This should fix https://github.com/turtlebrowser/turtlebrowser/issues/58
`/etc/os-release` has the following content:
```
NAME="Amazon Linux"
VERSION="2"
ID="amzn"
ID_LIKE="centos rhel fedora"
VERSION_ID="2"
PRETTY_NAME="Amazon Linux 2"
ANSI_COLOR="0;33"
CPE_NAME="cpe:2.3:o:amazon:amazon_linux:2"
HOME_URL="https://amazonlinux.com/"
```

Changelog: Bugfix: Properly detect Amazon Linux 2 distro.
Docs: omit

- [ ] Refer to the issue that supports this Pull Request.
- [X] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [X] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [X] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 

<sup>**Note:** By default this PR will skip the slower tests and will use a limited set of python versions. Check [here](https://github.com/conan-io/conan/blob/develop/.github/PR_INCREASE_TESTING.md) how to increase the testing level by writing some tags in the current PR body text.</sup>