### PR TITLE
Fix compiler mark autodetection in pytest

### DIFF
--- a/conans/test/conftest.py
+++ b/conans/test/conftest.py
@@ -41,7 +41,7 @@ try:
 except ConanException:
     tools_available.remove("visual_studio")
 
-if not any([x for x in ("gcc", "clang", "visual_sudio") if x in tools_available]):
+if not any([x for x in ("gcc", "clang", "visual_studio") if x in tools_available]):
     tools_available.remove("compiler")
 
 if not which("xcodebuild"):

--- a/conans/test/functional/generators/components/pkg_config_test.py
+++ b/conans/test/functional/generators/components/pkg_config_test.py
@@ -11,6 +11,8 @@ from conans.test.utils.tools import TestClient
 
 
 @pytest.mark.tool_compiler
+@pytest.mark.tool_pkg_config
+@pytest.mark.skipif(platform.system() == "Windows", reason="Requires pkg-config")
 class PkgConfigGeneratorWithComponentsTest(unittest.TestCase):
 
     @staticmethod

--- a/conans/test/functional/generators/components/pkg_config_test.py
+++ b/conans/test/functional/generators/components/pkg_config_test.py
@@ -1,6 +1,7 @@
 import os
 import textwrap
 import unittest
+import platform
 
 import pytest
 

--- a/conans/test/functional/toolchains/cmake/test_cmake.py
+++ b/conans/test/functional/toolchains/cmake/test_cmake.py
@@ -261,6 +261,7 @@ class WinTest(Base):
 
     @parameterized.expand([("Debug", "libstdc++", "4.9", "98", "x86_64", True),
                            ("Release", "libstdc++", "4.9", "11", "x86_64", False)])
+    @pytest.mark.tool_mingw64
     def test_toolchain_mingw_win(self, build_type, libcxx, version, cppstd, arch, shared):
         # FIXME: The version and cppstd are wrong, toolchain doesn't enforce it
         settings = {"compiler": "gcc",

--- a/conans/test/functional/util/pkg_config_test.py
+++ b/conans/test/functional/util/pkg_config_test.py
@@ -29,18 +29,15 @@ Cflags: -I${includedir}/libastral -D_USE_LIBASTRAL
 
 
 @pytest.mark.unix
+@pytest.mark.skipif(platform.system() == "Windows", reason="Requires pkg-config")
 class PkgConfigTest(unittest.TestCase):
     def test_negative(self):
-        if platform.system() == "Windows":
-            return
         pc = PkgConfig('libsomething_that_does_not_exist_in_the_world')
         with self.assertRaises(ConanException):
             pc.libs()
 
     @pytest.mark.tool_pkg_config
     def test_pc(self):
-        if platform.system() == "Windows":
-            return
         tmp_dir = temp_folder()
         filename = os.path.join(tmp_dir, 'libastral.pc')
         with open(filename, 'w') as f:
@@ -64,8 +61,6 @@ class PkgConfigTest(unittest.TestCase):
 
     @pytest.mark.tool_pkg_config
     def test_define_prefix(self):
-        if platform.system() == "Windows":
-            return
         tmp_dir = temp_folder()
         filename = os.path.join(tmp_dir, 'libastral.pc')
         with open(filename, 'w') as f:
@@ -91,8 +86,6 @@ class PkgConfigTest(unittest.TestCase):
 
     @pytest.mark.tool_pkg_config
     def test_rpaths_libs(self):
-        if platform.system() == "Windows":
-            return
         pc_content = """prefix=/my_prefix/path
 libdir=/my_absoulte_path/fake/mylib/lib
 libdir3=${prefix}/lib2


### PR DESCRIPTION
Changelog: omit
Docs: omit
