### PR TITLE
Do not remove sh from path in the new CMake helper

### DIFF
--- a/conan/tools/cmake/base.py
+++ b/conan/tools/cmake/base.py
@@ -95,7 +95,6 @@ class CMakeToolchainBase(object):
             # We are going to adjust automagically many things as requested by Conan
             #   these are the things done by 'conan_basic_setup()'
             set(CMAKE_EXPORT_NO_PACKAGE_REGISTRY ON)
-            set(CMAKE_SH "CMAKE_SH-NOTFOUND")
             # To support the cmake_find_package generators
             {% if cmake_module_path -%}
             set(CMAKE_MODULE_PATH {{ cmake_module_path }} ${CMAKE_MODULE_PATH})

--- a/conan/tools/cmake/base.py
+++ b/conan/tools/cmake/base.py
@@ -95,6 +95,7 @@ class CMakeToolchainBase(object):
             # We are going to adjust automagically many things as requested by Conan
             #   these are the things done by 'conan_basic_setup()'
             set(CMAKE_EXPORT_NO_PACKAGE_REGISTRY ON)
+            set(CMAKE_SH "CMAKE_SH-NOTFOUND")
             # To support the cmake_find_package generators
             {% if cmake_module_path -%}
             set(CMAKE_MODULE_PATH {{ cmake_module_path }} ${CMAKE_MODULE_PATH})

--- a/conan/tools/cmake/cmake.py
+++ b/conan/tools/cmake/cmake.py
@@ -85,11 +85,7 @@ class CMake(object):
         is_windows_mingw = platform.system() == "Windows" and self._generator == "MinGW Makefiles"
         self._conanfile.output.info("CMake command: %s" % command)
         with chdir(build_folder):
-            if is_windows_mingw:
-                with tools.remove_from_path("sh"):
-                    self._conanfile.run(command)
-            else:
-                self._conanfile.run(command)
+            self._conanfile.run(command)
 
     def _build(self, build_type=None, target=None):
         bf = self._conanfile.build_folder

--- a/conan/tools/cmake/cmake.py
+++ b/conan/tools/cmake/cmake.py
@@ -79,10 +79,12 @@ class CMake(object):
             self._conanfile.package_folder.replace("\\", "/"),
             source)
 
+        if platform.system() == "Windows" and self._generator == "MinGW Makefiles":
+            arg_list += ' -DCMAKE_SH="CMAKE_SH-NOTFOUND"'
+
         generator = '-G "{}" '.format(self._generator) if self._generator else ""
         command = "%s %s%s" % (self._cmake_program, generator, arg_list)
 
-        is_windows_mingw = platform.system() == "Windows" and self._generator == "MinGW Makefiles"
         self._conanfile.output.info("CMake command: %s" % command)
         with chdir(build_folder):
             self._conanfile.run(command)

--- a/conans/test/functional/toolchains/cmake/test_cmake.py
+++ b/conans/test/functional/toolchains/cmake/test_cmake.py
@@ -563,6 +563,6 @@ class TestMinGW:
         client.run_command("where cmake")
         print("CMAKE PATH: %s" % client.out)
         client.run_command("cmake --version")
-        assert "cmake version 3.16.9" in client.out
+        assert "cmake version 3.16" in client.out
         client.run("create . test/1.0@ --profile profile", assert_error=True)
         print(client.out)

--- a/conans/test/functional/toolchains/cmake/test_cmake.py
+++ b/conans/test/functional/toolchains/cmake/test_cmake.py
@@ -546,6 +546,7 @@ class TestMinGW:
     main_cpp = gen_function_cpp(name="main")
 
     @pytest.mark.tool_mingw64
+    @pytest.mark.tool_cmake(version="3.16")
     def test_mingw64(self):
         profile = textwrap.dedent("""
             [settings]

--- a/conans/test/functional/toolchains/cmake/test_cmake.py
+++ b/conans/test/functional/toolchains/cmake/test_cmake.py
@@ -272,6 +272,7 @@ class WinTest(Base):
     @parameterized.expand([("Debug", "libstdc++", "4.9", "98", "x86_64", True),
                            ("Release", "libstdc++", "4.9", "11", "x86_64", False)])
     @pytest.mark.tool_mingw64
+    @pytest.mark.tool_cmake(version="3.15")
     def test_toolchain_mingw_win(self, build_type, libcxx, version, cppstd, arch, shared):
         # FIXME: The version and cppstd are wrong, toolchain doesn't enforce it
         settings = {"compiler": "gcc",
@@ -287,6 +288,7 @@ class WinTest(Base):
         self.assertIn("The C compiler identification is GNU", self.client.out)
         self.assertIn('CMake command: cmake -G "MinGW Makefiles" '
                       '-DCMAKE_TOOLCHAIN_FILE="conan_toolchain.cmake"', self.client.out)
+        assert '-DCMAKE_SH="CMAKE_SH-NOTFOUND"' in self.client.out
 
         def _verify_out(marker=">>"):
             cmake_vars = {"CMAKE_GENERATOR_PLATFORM": "",
@@ -528,51 +530,3 @@ class CMakeOverrideCacheTest(unittest.TestCase):
         client.run("install .")
         client.run("build .")
         self.assertIn("VALUE OF CONFIG STRING: my new value", client.out)
-
-
-@pytest.mark.skipif(platform.system() != "Windows", reason="Tests Windows MinGW")
-class TestMinGW:
-    conanfile = textwrap.dedent("""
-            from conans import ConanFile
-            from conan.tools.cmake import CMake, CMakeToolchain
-            class App(ConanFile):
-                settings = "os", "arch", "compiler", "build_type"
-                generators = "cmake_find_package_multi"
-                exports_sources = "CMakeLists.txt", "main.cpp"
-
-                def generate(self):
-                    tc = CMakeToolchain(self)
-                    tc.generate()
-
-                def build(self):
-                    cmake = CMake(self)
-                    cmake.configure()
-                    cmake.build()
-            """)
-    cmakelists = textwrap.dedent("""
-        cmake_minimum_required(VERSION 2.8)
-        project(app)
-        add_executable(app main.cpp)
-        """)
-    main_cpp = gen_function_cpp(name="main")
-
-    @pytest.mark.tool_mingw64
-    @pytest.mark.tool_cmake(version="3.15")
-    def test_mingw64(self):
-        profile = textwrap.dedent("""
-            [settings]
-            os=Windows
-            arch=x86_64
-            build_type=Release
-            compiler=gcc
-            compiler.version=4.9
-            compiler.libcxx=libstdc++
-            compiler.cppstd=98
-            """)
-        client = TestClient()
-        client.save({"conanfile.py": self.conanfile, "CMakeLists.txt": self.cmakelists,
-                     "main.cpp": self.main_cpp, "profile": profile})
-        client.run_command("cmake --version")
-        assert "cmake version 3.15" in client.out
-        client.run_command('cmake . -G "MinGW Makefiles" -DCMAKE_SH=CMAKE_SH-NOTFOUND')
-        # client.run("create . test/1.0@ --profile profile")

--- a/conans/test/functional/toolchains/cmake/test_cmake.py
+++ b/conans/test/functional/toolchains/cmake/test_cmake.py
@@ -557,7 +557,6 @@ class TestMinGW:
     main_cpp = gen_function_cpp(name="main")
 
     @pytest.mark.tool_mingw64
-    @pytest.mark.tool_cmake(version="3.16")
     def test_mingw64(self):
         profile = textwrap.dedent("""
             [settings]

--- a/conans/test/functional/toolchains/cmake/test_cmake.py
+++ b/conans/test/functional/toolchains/cmake/test_cmake.py
@@ -563,6 +563,6 @@ class TestMinGW:
         client.run_command("where cmake")
         print("CMAKE PATH: %s" % client.out)
         client.run_command("cmake --version")
-        assert "cmake version 3.16" in client.out
+        assert "cmake version 3.15" in client.out
         client.run("create . test/1.0@ --profile profile", assert_error=True)
         print(client.out)

--- a/conans/test/functional/toolchains/cmake/test_cmake.py
+++ b/conans/test/functional/toolchains/cmake/test_cmake.py
@@ -560,5 +560,7 @@ class TestMinGW:
         client = TestClient()
         client.save({"conanfile.py": self.conanfile, "CMakeLists.txt": self.cmakelists,
                      "main.cpp": self.main_cpp, "profile": profile})
+        client.run_command("cmake --version")
+        assert "cmake version 3.16.9" in client.out
         client.run("create . test/1.0@ --profile profile", assert_error=True)
         print(client.out)

--- a/conans/test/functional/toolchains/cmake/test_cmake.py
+++ b/conans/test/functional/toolchains/cmake/test_cmake.py
@@ -560,6 +560,8 @@ class TestMinGW:
         client = TestClient()
         client.save({"conanfile.py": self.conanfile, "CMakeLists.txt": self.cmakelists,
                      "main.cpp": self.main_cpp, "profile": profile})
+        client.run_command("where cmake")
+        print("CMAKE PATH: %s" % client.out)
         client.run_command("cmake --version")
         assert "cmake version 3.16.9" in client.out
         client.run("create . test/1.0@ --profile profile", assert_error=True)

--- a/conans/test/functional/toolchains/cmake/test_cmake.py
+++ b/conans/test/functional/toolchains/cmake/test_cmake.py
@@ -557,6 +557,7 @@ class TestMinGW:
     main_cpp = gen_function_cpp(name="main")
 
     @pytest.mark.tool_mingw64
+    @pytest.mark.tool_cmake(version="3.15")
     def test_mingw64(self):
         profile = textwrap.dedent("""
             [settings]

--- a/conans/test/functional/toolchains/cmake/test_cmake.py
+++ b/conans/test/functional/toolchains/cmake/test_cmake.py
@@ -572,9 +572,7 @@ class TestMinGW:
         client = TestClient()
         client.save({"conanfile.py": self.conanfile, "CMakeLists.txt": self.cmakelists,
                      "main.cpp": self.main_cpp, "profile": profile})
-        client.run_command("where cmake")
-        print("CMAKE PATH: %s" % client.out)
         client.run_command("cmake --version")
         assert "cmake version 3.15" in client.out
-        client.run("create . test/1.0@ --profile profile", assert_error=True)
-        print(client.out)
+        client.run_command('cmake . -G "MinGW Makefiles" -DCMAKE_SH=CMAKE_SH-NOTFOUND')
+        # client.run("create . test/1.0@ --profile profile")


### PR DESCRIPTION
Changelog: Feature: Do not remove sh from the path in the new CMake helper.
Docs: https://github.com/conan-io/docs/pull/2055

#TAGS: slow

- [x] Refer to the issue that supports this Pull Request: closes #8597
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [x] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 

<sup>**Note:** By default this PR will skip the slower tests and will use a limited set of python versions. Check [here](https://github.com/conan-io/conan/blob/develop/.github/PR_INCREASE_TESTING.md) how to increase the testing level by writing some tags in the current PR body text.</sup>
