### PR TITLE
allow integers as CMakeToolchain.preprocessor_definitions

### DIFF
--- a/conan/tools/cmake/base.py
+++ b/conan/tools/cmake/base.py
@@ -1,5 +1,5 @@
 import textwrap
-from collections import OrderedDict, defaultdict
+from collections import OrderedDict
 
 import six
 from jinja2 import DictLoader, Environment
@@ -18,15 +18,15 @@ class Variables(OrderedDict):
         try:
             return super(Variables, self).__getattribute__(config)
         except AttributeError:
-            return self._configuration_types.setdefault(config, dict())
+            return self._configuration_types.setdefault(config, OrderedDict())
 
     @property
     def configuration_types(self):
         # Reverse index for the configuration_types variables
-        ret = defaultdict(list)
+        ret = OrderedDict()
         for conf, definitions in self._configuration_types.items():
             for k, v in definitions.items():
-                ret[k].append((conf, v))
+                ret.setdefault(k, []).append((conf, v))
         return ret
 
     def quote_preprocessor_strings(self):

--- a/conans/test/functional/toolchains/cmake/test_cmake.py
+++ b/conans/test/functional/toolchains/cmake/test_cmake.py
@@ -346,7 +346,10 @@ class LinuxTest(Base):
         pic_str = "" if shared else "ON"
         arch_str = "-m32" if arch == "x86" else "-m64"
         cxx11_abi_str = "1" if libcxx == "libstdc++11" else "0"
-        defines = '_GLIBCXX_USE_CXX11_ABI=%s;MYDEFINE="MYDEF_VALUE";MYDEFINEINT=42;' % cxx11_abi_str
+        defines = '_GLIBCXX_USE_CXX11_ABI=%s;MYDEFINE="MYDEF_VALUE";MYDEFINEINT=42;'\
+                  'MYDEFINEINT_CONFIG=$<IF:$<CONFIG:debug>,421,$<IF:$<CONFIG:release>,422,"">>;'\
+                  'MYDEFINE_CONFIG=$<IF:$<CONFIG:debug>,"MYDEF_DEBUG",'\
+                  '$<IF:$<CONFIG:release>,"MYDEF_RELEASE","">>' % cxx11_abi_str
         vals = {"CMAKE_CXX_STANDARD": "14",
                 "CMAKE_CXX_EXTENSIONS": extensions_str,
                 "CMAKE_BUILD_TYPE": build_type,

--- a/conans/test/functional/toolchains/cmake/test_cmake.py
+++ b/conans/test/functional/toolchains/cmake/test_cmake.py
@@ -346,9 +346,7 @@ class LinuxTest(Base):
         pic_str = "" if shared else "ON"
         arch_str = "-m32" if arch == "x86" else "-m64"
         cxx11_abi_str = "1" if libcxx == "libstdc++11" else "0"
-        defines = '_GLIBCXX_USE_CXX11_ABI=%s;MYDEFINE="MYDEF_VALUE";'\
-                  'MYDEFINE_CONFIG=$<IF:$<CONFIG:debug>,"MYDEF_DEBUG",'\
-                  '$<IF:$<CONFIG:release>,"MYDEF_RELEASE","">>' % cxx11_abi_str
+        defines = '_GLIBCXX_USE_CXX11_ABI=%s;MYDEFINE="MYDEF_VALUE";MYDEFINEINT=42;' % cxx11_abi_str
         vals = {"CMAKE_CXX_STANDARD": "14",
                 "CMAKE_CXX_EXTENSIONS": extensions_str,
                 "CMAKE_BUILD_TYPE": build_type,

--- a/conans/test/functional/toolchains/cmake/test_cmake.py
+++ b/conans/test/functional/toolchains/cmake/test_cmake.py
@@ -347,9 +347,9 @@ class LinuxTest(Base):
         arch_str = "-m32" if arch == "x86" else "-m64"
         cxx11_abi_str = "1" if libcxx == "libstdc++11" else "0"
         defines = '_GLIBCXX_USE_CXX11_ABI=%s;MYDEFINE="MYDEF_VALUE";MYDEFINEINT=42;'\
-                  'MYDEFINEINT_CONFIG=$<IF:$<CONFIG:debug>,421,$<IF:$<CONFIG:release>,422,"">>;'\
-                  'MYDEFINE_CONFIG=$<IF:$<CONFIG:debug>,"MYDEF_DEBUG",'\
-                  '$<IF:$<CONFIG:release>,"MYDEF_RELEASE","">>' % cxx11_abi_str
+                  'MYDEFINE_CONFIG=$<IF:$<CONFIG:debug>,"MYDEF_DEBUG",$<IF:$<CONFIG:release>,'\
+                  '"MYDEF_RELEASE","">>;MYDEFINEINT_CONFIG=$<IF:$<CONFIG:debug>,421,'\
+                  '$<IF:$<CONFIG:release>,422,"">>' % cxx11_abi_str
         vals = {"CMAKE_CXX_STANDARD": "14",
                 "CMAKE_CXX_EXTENSIONS": extensions_str,
                 "CMAKE_BUILD_TYPE": build_type,

--- a/conans/test/functional/toolchains/cmake/test_cmake.py
+++ b/conans/test/functional/toolchains/cmake/test_cmake.py
@@ -36,8 +36,11 @@ class Base(unittest.TestCase):
                 tc.variables.debug["MYVAR2_CONFIG"] = "MYVAR2_DEBUG"
                 tc.variables.release["MYVAR2_CONFIG"] = "MYVAR2_RELEASE"
                 tc.preprocessor_definitions["MYDEFINE"] = "MYDEF_VALUE"
+                tc.preprocessor_definitions["MYDEFINEINT"] = 42
                 tc.preprocessor_definitions.debug["MYDEFINE_CONFIG"] = "MYDEF_DEBUG"
                 tc.preprocessor_definitions.release["MYDEFINE_CONFIG"] = "MYDEF_RELEASE"
+                tc.preprocessor_definitions.debug["MYDEFINEINT_CONFIG"] = 421
+                tc.preprocessor_definitions.release["MYDEFINEINT_CONFIG"] = 422
                 tc.generate()
 
             def build(self):
@@ -48,7 +51,8 @@ class Base(unittest.TestCase):
 
     lib_h = gen_function_h(name="app")
     lib_cpp = gen_function_cpp(name="app", msg="App", includes=["hello"], calls=["hello"],
-                               preprocessor=["MYVAR", "MYVAR_CONFIG", "MYDEFINE", "MYDEFINE_CONFIG"])
+                               preprocessor=["MYVAR", "MYVAR_CONFIG", "MYDEFINE", "MYDEFINE_CONFIG",
+                                             "MYDEFINEINT", "MYDEFINEINT_CONFIG"])
     main = gen_function_cpp(name="main", includes=["app"], calls=["app"])
 
     cmakelist = textwrap.dedent("""
@@ -83,7 +87,7 @@ class Base(unittest.TestCase):
         add_library(app_lib app_lib.cpp)
         target_link_libraries(app_lib PRIVATE hello::hello)
         target_compile_definitions(app_lib PRIVATE MYVAR="${MYVAR}")
-        target_compile_definitions(app_lib PRIVATE MYVAR_CONFIG=${MYVAR_CONFIG})
+        target_compile_definitions(app_lib PRIVATE MYVAR_CONFIG="${MYVAR_CONFIG}")
         add_executable(app app.cpp)
         target_link_libraries(app PRIVATE app_lib)
         """)
@@ -130,7 +134,9 @@ class Base(unittest.TestCase):
     def _modify_code(self):
         lib_cpp = gen_function_cpp(name="app", msg="AppImproved", includes=["hello"],
                                    calls=["hello"], preprocessor=["MYVAR", "MYVAR_CONFIG",
-                                                                  "MYDEFINE", "MYDEFINE_CONFIG"])
+                                                                  "MYDEFINE", "MYDEFINE_CONFIG",
+                                                                  "MYDEFINEINT",
+                                                                  "MYDEFINEINT_CONFIG"])
         self.client.save({"app_lib.cpp": lib_cpp})
 
         content = self.client.load("CMakeLists.txt")
@@ -158,6 +164,9 @@ class Base(unittest.TestCase):
         self.assertIn("MYVAR_CONFIG: MYVAR_%s" % build_type.upper(), self.client.out)
         self.assertIn("MYDEFINE: MYDEF_VALUE", self.client.out)
         self.assertIn("MYDEFINE_CONFIG: MYDEF_%s" % build_type.upper(), self.client.out)
+        self.assertIn("MYDEFINEINT: 42", self.client.out)
+        self.assertIn("MYDEFINEINT_CONFIG: {}".format(421 if build_type == "Debug" else 422),
+                      self.client.out)
 
 
 @pytest.mark.skipif(platform.system() != "Windows", reason="Only for windows")
@@ -236,6 +245,7 @@ class WinTest(Base):
                        "MYVAR_CONFIG": "MYVAR_RELEASE",
                        "MYDEFINE": "MYDEF_VALUE",
                        "MYDEFINE_CONFIG": "MYDEF_RELEASE"
+
                        })
         self._run_app("Debug", bin_folder=True)
         check_exe_run(self.client.out, "main", "msvc", visual_version, "Debug", arch, cppstd,


### PR DESCRIPTION
Changelog: Feature: Allow integers as ``preprocessor_definitions`` in ``CMakeToolchain``.
Docs: Omit

Close https://github.com/conan-io/conan/issues/8632