### PR TITLE
Feature/cmakedeps files

### DIFF
--- a/conan/tools/cmake/cmakedeps.py
+++ b/conan/tools/cmake/cmakedeps.py
@@ -96,8 +96,8 @@ set({name}_COMPILE_DEFINITIONS{build_type_suffix} {deps.compile_definitions})
 set({name}_COMPILE_OPTIONS{build_type_suffix}_LIST "{deps.cxxflags_list}" "{deps.cflags_list}")
 set({name}_COMPILE_OPTIONS_C{build_type_suffix} "{deps.cflags_list}")
 set({name}_COMPILE_OPTIONS_CXX{build_type_suffix} "{deps.cxxflags_list}")
-set({name}_LIB_DIRS{build_type_suffix} {deps.lib_paths})
-set({name}_LIBS{build_type_suffix} {deps.libs})
+set({name}_LIBRARY_DIRS{build_type_suffix} {deps.lib_paths})
+set({name}_LIBRARIES{build_type_suffix} {deps.libs})
 set({name}_SYSTEM_LIBS{build_type_suffix} {deps.system_libs})
 set({name}_FRAMEWORK_DIRS{build_type_suffix} {deps.framework_paths})
 set({name}_FRAMEWORKS{build_type_suffix} {deps.frameworks})
@@ -115,7 +115,7 @@ set(_{name}_DEPENDENCIES{build_type_suffix} "${{{name}_FRAMEWORKS_FOUND{build_ty
 set({name}_LIBRARIES_TARGETS{build_type_suffix} "") # Will be filled later, if CMake 3
 set({name}_LIBRARIES{build_type_suffix} "") # Will be filled later
 conan_package_library_targets("${{{name}_LIBS{build_type_suffix}}}"           # libraries
-                              "${{{name}_LIB_DIRS{build_type_suffix}}}"       # package_libdir
+                              "${{{name}_LIBRARY_DIRS{build_type_suffix}}}"   # package_libdir
                               "${{_{name}_DEPENDENCIES{build_type_suffix}}}"  # deps
                               {name}_LIBRARIES{build_type_suffix}             # out_libraries
                               {name}_LIBRARIES_TARGETS{build_type_suffix}     # out_libraries_targets
@@ -358,13 +358,13 @@ endforeach()
         ########### COMPONENT {{ comp_name }} VARIABLES #############################################
 
         set({{ pkg_name }}_{{ comp_name }}_INCLUDE_DIRS_{{ build_type }} {{ comp.include_paths }})
-        set({{ pkg_name }}_{{ comp_name }}_LIB_DIRS_{{ build_type }} {{ comp.lib_paths }})
+        set({{ pkg_name }}_{{ comp_name }}_LIBRARY_DIRS_{{ build_type }} {{ comp.lib_paths }})
         set({{ pkg_name }}_{{ comp_name }}_RES_DIRS_{{ build_type }} {{ comp.res_paths }})
         set({{ pkg_name }}_{{ comp_name }}_DEFINITIONS_{{ build_type }} {{ comp.defines }})
         set({{ pkg_name }}_{{ comp_name }}_COMPILE_DEFINITIONS_{{ build_type }} {{ comp.compile_definitions }})
         set({{ pkg_name }}_{{ comp_name }}_COMPILE_OPTIONS_C_{{ build_type }} "{{ comp.cflags_list }}")
         set({{ pkg_name }}_{{ comp_name }}_COMPILE_OPTIONS_CXX_{{ build_type }} "{{ comp.cxxflags_list }}")
-        set({{ pkg_name }}_{{ comp_name }}_LIBS_{{ build_type }} {{ comp.libs }})
+        set({{ pkg_name }}_{{ comp_name }}_LIBRARIES_{{ build_type }} {{ comp.libs }})
         set({{ pkg_name }}_{{ comp_name }}_SYSTEM_LIBS_{{ build_type }} {{ comp.system_libs }})
         set({{ pkg_name }}_{{ comp_name }}_FRAMEWORK_DIRS_{{ build_type }} {{ comp.framework_paths }})
         set({{ pkg_name }}_{{ comp_name }}_FRAMEWORKS_{{ build_type }} {{ comp.frameworks }})
@@ -398,8 +398,8 @@ endforeach()
         set({{ pkg_name }}_{{ comp_name }}_LIB_TARGETS_{{ build_type }} "")
         set({{ pkg_name }}_{{ comp_name }}_NOT_USED_{{ build_type }} "")
         set({{ pkg_name }}_{{ comp_name }}_LIBS_FRAMEWORKS_DEPS_{{ build_type }} {{ '${'+pkg_name+'_'+comp_name+'_FRAMEWORKS_FOUND_'+build_type+'}' }} {{ '${'+pkg_name+'_'+comp_name+'_SYSTEM_LIBS_'+build_type+'}' }} {{ '${'+pkg_name+'_'+comp_name+'_DEPENDENCIES_'+build_type+'}' }})
-        conan_package_library_targets("{{ '${'+pkg_name+'_'+comp_name+'_LIBS_'+build_type+'}' }}"
-                                      "{{ '${'+pkg_name+'_'+comp_name+'_LIB_DIRS_'+build_type+'}' }}"
+        conan_package_library_targets("{{ '${'+pkg_name+'_'+comp_name+'_LIBRARIES_'+build_type+'}' }}"
+                                      "{{ '${'+pkg_name+'_'+comp_name+'_LIBRARY_DIRS_'+build_type+'}' }}"
                                       "{{ '${'+pkg_name+'_'+comp_name+'_LIBS_FRAMEWORKS_DEPS_'+build_type+'}' }}"
                                       {{ pkg_name }}_{{ comp_name }}_NOT_USED_{{ build_type }}
                                       {{ pkg_name }}_{{ comp_name }}_LIB_TARGETS_{{ build_type }}

--- a/conan/tools/cmake/cmakedeps.py
+++ b/conan/tools/cmake/cmakedeps.py
@@ -105,7 +105,7 @@ set({name}_BUILD_MODULES_PATHS{build_type_suffix} {deps.build_modules_paths})
 """
 
 
-preprocess_variables_template = """
+dynamic_variables_template = """
 set({name}_FRAMEWORKS_FOUND{build_type_suffix} "") # Will be filled later
 conan_find_apple_frameworks({name}_FRAMEWORKS_FOUND{build_type_suffix} "${{{name}_FRAMEWORKS{build_type_suffix}}}" "${{{name}_FRAMEWORK_DIRS{build_type_suffix}}}")
 
@@ -663,14 +663,14 @@ endforeach()
                     variables_template.format(name=pkg_findname, deps=deps,
                                               build_type_suffix=build_type_suffix)
                              }
-                preprocess_variables = {
+                dynamic_variables = {
                     "{}Target-{}.cmake".format(pkg_filename, self.configuration.lower()):
-                    preprocess_variables_template.format(name=pkg_findname, deps=deps,
-                                                         build_type_suffix=build_type_suffix,
-                                                         deps_names=deps_names)
+                    dynamic_variables_template.format(name=pkg_findname, deps=deps,
+                                                      build_type_suffix=build_type_suffix,
+                                                      deps_names=deps_names)
                 }
                 ret.update(variables)
-                ret.update(preprocess_variables)
+                ret.update(dynamic_variables)
                 ret[self._config_filename(pkg_filename)] = self._config(
                     filename=pkg_filename,
                     name=pkg_findname,

--- a/conan/tools/cmake/cmakedeps.py
+++ b/conan/tools/cmake/cmakedeps.py
@@ -83,10 +83,8 @@ conan_package_library_targets = textwrap.dedent("""
    """)
 
 
-target_template = """
+variables_template = """
 set({name}_INCLUDE_DIRS{build_type_suffix} {deps.include_paths})
-set({name}_INCLUDE_DIR{build_type_suffix} {deps.include_path})
-set({name}_INCLUDES{build_type_suffix} {deps.include_paths})
 set({name}_RES_DIRS{build_type_suffix} {deps.res_paths})
 set({name}_DEFINITIONS{build_type_suffix} {deps.defines})
 set({name}_LINKER_FLAGS{build_type_suffix}_LIST
@@ -98,44 +96,31 @@ set({name}_COMPILE_DEFINITIONS{build_type_suffix} {deps.compile_definitions})
 set({name}_COMPILE_OPTIONS{build_type_suffix}_LIST "{deps.cxxflags_list}" "{deps.cflags_list}")
 set({name}_COMPILE_OPTIONS_C{build_type_suffix} "{deps.cflags_list}")
 set({name}_COMPILE_OPTIONS_CXX{build_type_suffix} "{deps.cxxflags_list}")
-set({name}_LIBRARIES_TARGETS{build_type_suffix} "") # Will be filled later, if CMake 3
-set({name}_LIBRARIES{build_type_suffix} "") # Will be filled later
-set({name}_LIBS{build_type_suffix} "") # Same as {name}_LIBRARIES
+set({name}_LIB_DIRS{build_type_suffix} {deps.lib_paths})
+set({name}_LIBS{build_type_suffix} {deps.libs})
 set({name}_SYSTEM_LIBS{build_type_suffix} {deps.system_libs})
 set({name}_FRAMEWORK_DIRS{build_type_suffix} {deps.framework_paths})
 set({name}_FRAMEWORKS{build_type_suffix} {deps.frameworks})
-set({name}_FRAMEWORKS_FOUND{build_type_suffix} "") # Will be filled later
 set({name}_BUILD_MODULES_PATHS{build_type_suffix} {deps.build_modules_paths})
+"""
 
+
+preprocess_variables_template = """
+set({name}_FRAMEWORKS_FOUND{build_type_suffix} "") # Will be filled later
 conan_find_apple_frameworks({name}_FRAMEWORKS_FOUND{build_type_suffix} "${{{name}_FRAMEWORKS{build_type_suffix}}}" "${{{name}_FRAMEWORK_DIRS{build_type_suffix}}}")
-
-mark_as_advanced({name}_INCLUDE_DIRS{build_type_suffix}
-                 {name}_INCLUDE_DIR{build_type_suffix}
-                 {name}_INCLUDES{build_type_suffix}
-                 {name}_DEFINITIONS{build_type_suffix}
-                 {name}_LINKER_FLAGS{build_type_suffix}_LIST
-                 {name}_COMPILE_DEFINITIONS{build_type_suffix}
-                 {name}_COMPILE_OPTIONS{build_type_suffix}_LIST
-                 {name}_LIBRARIES{build_type_suffix}
-                 {name}_LIBS{build_type_suffix}
-                 {name}_LIBRARIES_TARGETS{build_type_suffix})
-
-# Find the real .lib/.a and add them to {name}_LIBS and {name}_LIBRARY_LIST
-set({name}_LIBRARY_LIST{build_type_suffix} {deps.libs})
-set({name}_LIB_DIRS{build_type_suffix} {deps.lib_paths})
 
 # Gather all the libraries that should be linked to the targets (do not touch existing variables):
 set(_{name}_DEPENDENCIES{build_type_suffix} "${{{name}_FRAMEWORKS_FOUND{build_type_suffix}}} ${{{name}_SYSTEM_LIBS{build_type_suffix}}} {deps_names}")
 
-conan_package_library_targets("${{{name}_LIBRARY_LIST{build_type_suffix}}}"  # libraries
-                              "${{{name}_LIB_DIRS{build_type_suffix}}}"      # package_libdir
+set({name}_LIBRARIES_TARGETS{build_type_suffix} "") # Will be filled later, if CMake 3
+set({name}_LIBRARIES{build_type_suffix} "") # Will be filled later
+conan_package_library_targets("${{{name}_LIBS{build_type_suffix}}}"           # libraries
+                              "${{{name}_LIB_DIRS{build_type_suffix}}}"       # package_libdir
                               "${{_{name}_DEPENDENCIES{build_type_suffix}}}"  # deps
-                              {name}_LIBRARIES{build_type_suffix}            # out_libraries
-                              {name}_LIBRARIES_TARGETS{build_type_suffix}    # out_libraries_targets
-                              "{build_type_suffix}"                          # build_type
-                              "{name}")                                      # package_name
-
-set({name}_LIBS{build_type_suffix} ${{{name}_LIBRARIES{build_type_suffix}}})
+                              {name}_LIBRARIES{build_type_suffix}             # out_libraries
+                              {name}_LIBRARIES_TARGETS{build_type_suffix}     # out_libraries_targets
+                              "{build_type_suffix}"                           # build_type
+                              "{name}")                                       # package_name
 
 foreach(_FRAMEWORK ${{{name}_FRAMEWORKS_FOUND{build_type_suffix}}})
     list(APPEND {name}_LIBRARIES_TARGETS{build_type_suffix} ${{_FRAMEWORK}})
@@ -289,8 +274,13 @@ class CMakeDeps(object):
 
         # Load the debug and release library finders
         get_filename_component(_DIR "${{CMAKE_CURRENT_LIST_FILE}}" PATH)
-        file(GLOB CONFIG_FILES "${{_DIR}}/{filename}Target-*.cmake")
+        file(GLOB DATA_FILES "${{_DIR}}/{filename}-*-*-data.cmake")
 
+        foreach(f ${{DATA_FILES}})
+            include(${{f}})
+        endforeach()
+
+        file(GLOB CONFIG_FILES "${{_DIR}}/{filename}Target-*.cmake")
         foreach(f ${{CONFIG_FILES}})
             include(${{f}})
         endforeach()
@@ -536,7 +526,7 @@ endforeach()
 
     def __init__(self, conanfile):
         self._conanfile = conanfile
-
+        self.arch = str(self._conanfile.settings.arch)
         self.configuration = str(self._conanfile.settings.build_type)
         self.configurations = [v for v in conanfile.settings.build_type.values_range if v != "None"]
         # FIXME: Ugly way to define the output path
@@ -663,22 +653,30 @@ endforeach()
             config_version = self.config_version_template.format(version=pkg_version)
             ret[self._config_version_filename(pkg_filename)] = config_version
             if not cpp_info.components:
+                # If any config matches the build_type one, add it to the cpp_info
+                dep_cpp_info = extend(cpp_info, build_type.lower())
+                deps = DepsCppCmake(dep_cpp_info, self.name)
+                variables = {
+                    "{name}-{build_type}-{arch}-data.cmake".format(name=pkg_filename,
+                                                                   build_type=self.configuration.lower(),
+                                                                   arch=self.arch):
+                    variables_template.format(name=pkg_findname, deps=deps,
+                                              build_type_suffix=build_type_suffix)
+                             }
+                preprocess_variables = {
+                    "{}Target-{}.cmake".format(pkg_filename, self.configuration.lower()):
+                    preprocess_variables_template.format(name=pkg_findname, deps=deps,
+                                                         build_type_suffix=build_type_suffix,
+                                                         deps_names=deps_names)
+                }
+                ret.update(variables)
+                ret.update(preprocess_variables)
                 ret[self._config_filename(pkg_filename)] = self._config(
                     filename=pkg_filename,
                     name=pkg_findname,
                     version=cpp_info.version,
                     public_deps_names=pkg_public_deps_filenames
                 )
-                ret["{}Targets.cmake".format(pkg_filename)] = self.targets_template.format(
-                    filename=pkg_filename, name=pkg_findname)
-
-                # If any config matches the build_type one, add it to the cpp_info
-                dep_cpp_info = extend(cpp_info, build_type.lower())
-                deps = DepsCppCmake(dep_cpp_info, self.name)
-                find_lib = target_template.format(name=pkg_findname, deps=deps,
-                                                  build_type_suffix=build_type_suffix,
-                                                  deps_names=deps_names)
-                ret["{}Target-{}.cmake".format(pkg_filename, self.configuration.lower())] = find_lib
             else:
                 cpp_info = extend(cpp_info, build_type.lower())
                 pkg_info = DepsCppCmake(cpp_info, self.name)

--- a/conan/tools/cmake/cmakedeps.py
+++ b/conan/tools/cmake/cmakedeps.py
@@ -693,6 +693,8 @@ endforeach()
                     version=cpp_info.version,
                     public_deps_names=pkg_public_deps_filenames
                 )
+                ret["{}Targets.cmake".format(pkg_filename)] = self.targets_template.format(
+                    filename=pkg_filename, name=pkg_findname)
             else:
                 cpp_info = extend(cpp_info, build_type.lower())
                 pkg_info = DepsCppCmake(cpp_info, self.name)

--- a/conan/tools/cmake/cmakedeps.py
+++ b/conan/tools/cmake/cmakedeps.py
@@ -96,8 +96,8 @@ set({name}_COMPILE_DEFINITIONS{build_type_suffix} {deps.compile_definitions})
 set({name}_COMPILE_OPTIONS{build_type_suffix}_LIST "{deps.cxxflags_list}" "{deps.cflags_list}")
 set({name}_COMPILE_OPTIONS_C{build_type_suffix} "{deps.cflags_list}")
 set({name}_COMPILE_OPTIONS_CXX{build_type_suffix} "{deps.cxxflags_list}")
-set({name}_LIBRARY_DIRS{build_type_suffix} {deps.lib_paths})
-set({name}_LIBRARIES{build_type_suffix} {deps.libs})
+set({name}_LIB_DIRS{build_type_suffix} {deps.lib_paths})
+set({name}_LIBS{build_type_suffix} {deps.libs})
 set({name}_SYSTEM_LIBS{build_type_suffix} {deps.system_libs})
 set({name}_FRAMEWORK_DIRS{build_type_suffix} {deps.framework_paths})
 set({name}_FRAMEWORKS{build_type_suffix} {deps.frameworks})
@@ -115,7 +115,7 @@ set(_{name}_DEPENDENCIES{build_type_suffix} "${{{name}_FRAMEWORKS_FOUND{build_ty
 set({name}_LIBRARIES_TARGETS{build_type_suffix} "") # Will be filled later, if CMake 3
 set({name}_LIBRARIES{build_type_suffix} "") # Will be filled later
 conan_package_library_targets("${{{name}_LIBS{build_type_suffix}}}"           # libraries
-                              "${{{name}_LIBRARY_DIRS{build_type_suffix}}}"   # package_libdir
+                              "${{{name}_LIB_DIRS{build_type_suffix}}}"       # package_libdir
                               "${{_{name}_DEPENDENCIES{build_type_suffix}}}"  # deps
                               {name}_LIBRARIES{build_type_suffix}             # out_libraries
                               {name}_LIBRARIES_TARGETS{build_type_suffix}     # out_libraries_targets
@@ -358,13 +358,13 @@ endforeach()
         ########### COMPONENT {{ comp_name }} VARIABLES #############################################
 
         set({{ pkg_name }}_{{ comp_name }}_INCLUDE_DIRS_{{ build_type }} {{ comp.include_paths }})
-        set({{ pkg_name }}_{{ comp_name }}_LIBRARY_DIRS_{{ build_type }} {{ comp.lib_paths }})
+        set({{ pkg_name }}_{{ comp_name }}_LIB_DIRS_{{ build_type }} {{ comp.lib_paths }})
         set({{ pkg_name }}_{{ comp_name }}_RES_DIRS_{{ build_type }} {{ comp.res_paths }})
         set({{ pkg_name }}_{{ comp_name }}_DEFINITIONS_{{ build_type }} {{ comp.defines }})
         set({{ pkg_name }}_{{ comp_name }}_COMPILE_DEFINITIONS_{{ build_type }} {{ comp.compile_definitions }})
         set({{ pkg_name }}_{{ comp_name }}_COMPILE_OPTIONS_C_{{ build_type }} "{{ comp.cflags_list }}")
         set({{ pkg_name }}_{{ comp_name }}_COMPILE_OPTIONS_CXX_{{ build_type }} "{{ comp.cxxflags_list }}")
-        set({{ pkg_name }}_{{ comp_name }}_LIBRARIES_{{ build_type }} {{ comp.libs }})
+        set({{ pkg_name }}_{{ comp_name }}_LIBS_{{ build_type }} {{ comp.libs }})
         set({{ pkg_name }}_{{ comp_name }}_SYSTEM_LIBS_{{ build_type }} {{ comp.system_libs }})
         set({{ pkg_name }}_{{ comp_name }}_FRAMEWORK_DIRS_{{ build_type }} {{ comp.framework_paths }})
         set({{ pkg_name }}_{{ comp_name }}_FRAMEWORKS_{{ build_type }} {{ comp.frameworks }})
@@ -398,8 +398,8 @@ endforeach()
         set({{ pkg_name }}_{{ comp_name }}_LIB_TARGETS_{{ build_type }} "")
         set({{ pkg_name }}_{{ comp_name }}_NOT_USED_{{ build_type }} "")
         set({{ pkg_name }}_{{ comp_name }}_LIBS_FRAMEWORKS_DEPS_{{ build_type }} {{ '${'+pkg_name+'_'+comp_name+'_FRAMEWORKS_FOUND_'+build_type+'}' }} {{ '${'+pkg_name+'_'+comp_name+'_SYSTEM_LIBS_'+build_type+'}' }} {{ '${'+pkg_name+'_'+comp_name+'_DEPENDENCIES_'+build_type+'}' }})
-        conan_package_library_targets("{{ '${'+pkg_name+'_'+comp_name+'_LIBRARIES_'+build_type+'}' }}"
-                                      "{{ '${'+pkg_name+'_'+comp_name+'_LIBRARY_DIRS_'+build_type+'}' }}"
+        conan_package_library_targets("{{ '${'+pkg_name+'_'+comp_name+'_LIBS_'+build_type+'}' }}"
+                                      "{{ '${'+pkg_name+'_'+comp_name+'_LIB_DIRS_'+build_type+'}' }}"
                                       "{{ '${'+pkg_name+'_'+comp_name+'_LIBS_FRAMEWORKS_DEPS_'+build_type+'}' }}"
                                       {{ pkg_name }}_{{ comp_name }}_NOT_USED_{{ build_type }}
                                       {{ pkg_name }}_{{ comp_name }}_LIB_TARGETS_{{ build_type }}

--- a/conans/test/unittests/tools/cmake/test_cmakedeps.py
+++ b/conans/test/unittests/tools/cmake/test_cmakedeps.py
@@ -51,6 +51,8 @@ def test_cpp_info_name_cmakedeps_components():
     cmakedeps = CMakeDeps(conanfile)
     files = cmakedeps.content
     assert "TARGET GlobakPkgName1::MySuperPkg1" in files["ComplexFileName1Config.cmake"]
+    assert "set(GlobakPkgName1_INCLUDE_DIRS_NONE )" in files["ComplexFileName1-none-None-data.cmake"]
+    assert "set(GlobakPkgName1_MySuperPkg1_INCLUDE_DIRS_NONE )" in files["ComplexFileName1-none-None-data.cmake"]
 
     with pytest.raises(ConanException,
                        match="'mypkg' defines information for 'cmake_find_package_multi'"):

--- a/conans/test/unittests/tools/cmake/test_cmakedeps.py
+++ b/conans/test/unittests/tools/cmake/test_cmakedeps.py
@@ -17,6 +17,8 @@ def test_cpp_info_name_cmakedeps():
                                    "compiler": ["gcc"],
                                    "build_type": ["Release"],
                                    "arch": ["x86"]}), EnvValues())
+    conanfile.settings.build_type = "Release"
+    conanfile.settings.arch = "x86"
 
     cpp_info = CppInfo("mypkg", "dummy_root_folder1")
     cpp_info.names["cmake_find_package_multi"] = "MySuperPkg1"
@@ -26,7 +28,7 @@ def test_cpp_info_name_cmakedeps():
     cmakedeps = CMakeDeps(conanfile)
     files = cmakedeps.content
     assert "TARGET MySuperPkg1::MySuperPkg1" in files["ComplexFileName1Config.cmake"]
-    assert "set(MySuperPkg1_INCLUDE_DIRS_NONE )" in files["ComplexFileName1-none-None-data.cmake"]
+    assert "set(MySuperPkg1_INCLUDE_DIRS_RELEASE )" in files["ComplexFileName1-release-x86-data.cmake"]
 
     with pytest.raises(ConanException,
                        match="'mypkg' defines information for 'cmake_find_package_multi'"):
@@ -39,8 +41,10 @@ def test_cpp_info_name_cmakedeps_components():
     conanfile.settings = "os", "compiler", "build_type", "arch"
     conanfile.initialize(Settings({"os": ["Windows"],
                                    "compiler": ["gcc"],
-                                   "build_type": ["Release"],
-                                   "arch": ["x86"]}), EnvValues())
+                                   "build_type": ["Release", "Debug"],
+                                   "arch": ["x86", "x64"]}), EnvValues())
+    conanfile.settings.build_type = "Debug"
+    conanfile.settings.arch = "x64"
 
     cpp_info = CppInfo("mypkg", "dummy_root_folder1")
     cpp_info.names["cmake_find_package_multi"] = "GlobakPkgName1"
@@ -51,8 +55,8 @@ def test_cpp_info_name_cmakedeps_components():
     cmakedeps = CMakeDeps(conanfile)
     files = cmakedeps.content
     assert "TARGET GlobakPkgName1::MySuperPkg1" in files["ComplexFileName1Config.cmake"]
-    assert "set(GlobakPkgName1_INCLUDE_DIRS_NONE )" in files["ComplexFileName1-none-None-data.cmake"]
-    assert "set(GlobakPkgName1_MySuperPkg1_INCLUDE_DIRS_NONE )" in files["ComplexFileName1-none-None-data.cmake"]
+    assert "set(GlobakPkgName1_INCLUDE_DIRS_DEBUG )" in files["ComplexFileName1-debug-x64-data.cmake"]
+    assert "set(GlobakPkgName1_MySuperPkg1_INCLUDE_DIRS_DEBUG )" in files["ComplexFileName1-debug-x64-data.cmake"]
 
     with pytest.raises(ConanException,
                        match="'mypkg' defines information for 'cmake_find_package_multi'"):

--- a/conans/test/unittests/tools/cmake/test_cmakedeps.py
+++ b/conans/test/unittests/tools/cmake/test_cmakedeps.py
@@ -26,6 +26,7 @@ def test_cpp_info_name_cmakedeps():
     cmakedeps = CMakeDeps(conanfile)
     files = cmakedeps.content
     assert "TARGET MySuperPkg1::MySuperPkg1" in files["ComplexFileName1Config.cmake"]
+    assert "set(MySuperPkg1_INCLUDE_DIRS_NONE )" in files["ComplexFileName1-none-None-data.cmake"]
 
     with pytest.raises(ConanException,
                        match="'mypkg' defines information for 'cmake_find_package_multi'"):


### PR DESCRIPTION
Changelog: Feature: Move the definition of CMakeDeps variables to its own file
Docs: https://github.com/conan-io/docs/pull/2055

CMakeDeps generator now creates a new *mypkg-release-x86-data.cmake* file per configuration where the information of the `cpp_info` is added without getting dynamic values from any other CMake functionality or macro.

This new file(s) is included in the config cmake files as well as the old *<pkg-name>Target-<build_type>.cmake* where the "dynamic" variables are defined (variables that have values assignated after calling macros or cmake functionality)

The implementation is done for recipes defining components and for recipes that do not have components.

As per #8636:
- Duplicated variables that have been removed: `*_INCLUDE_DIR`, `*_INCLUDES`

------------------------------------------------------------------
- [x] Refer to the issue that supports this Pull Request: closes #8593, closes #8636
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [x] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 

<sup>**Note:** By default this PR will skip the slower tests and will use a limited set of python versions. Check [here](https://github.com/conan-io/conan/blob/develop/.github/PR_INCREASE_TESTING.md) how to increase the testing level by writing some tags in the current PR body text.</sup>
