### PR TITLE
Test different versions of tools

### DIFF
--- a/conans/test/conftest.py
+++ b/conans/test/conftest.py
@@ -75,7 +75,7 @@ if not which("conan"):
     tools_available.remove("conan")
 
 
-def _get_tool_location(locations, name, version, tool_platform):
+def _get_tool_path(locations, name, version, tool_platform):
     path = None
     try:
         path = locations[name][tool_platform][version]
@@ -103,7 +103,7 @@ def add_tool(request):
             version = mark.kwargs.get('version', 'default')
             tool_name = mark.name[5:]
             try:
-                tool_path = _get_tool_location(tool_locations, tool_name, version, platform.system())
+                tool_path = _get_tool_path(tool_locations, tool_name, version, platform.system())
                 if tool_path:
                     tools_paths.append(tool_path)
             except ConanException:

--- a/conans/test/conftest.py
+++ b/conans/test/conftest.py
@@ -14,7 +14,8 @@ tool_locations = {
     'cmake': {
         'Windows': {
             'default': 'C:/Program Files/Cmake/bin',
-            '3.16': 'C:/cmake/cmake-3.16.9-win64-x64/bin'
+            '3.16': 'C:/cmake/cmake-3.16.9-win64-x64/bin',
+            '3.17': 'C:/cmake/cmake-3.17.5-win64-x64/bin'
         }
     }
 }

--- a/conans/test/conftest.py
+++ b/conans/test/conftest.py
@@ -7,10 +7,10 @@ from conans.client.tools import vswhere, which
 from conans.errors import ConanException
 
 tool_locations = {
-    'msys2': {'Windows': {'default': os.getenv("CONAN_MSYS2_PATH", "C:/msys64/usr/bin")}},
-    'cygwin': {'Windows': {'default': os.getenv("CONAN_CYGWIN_PATH", "C:/cygwin64/bin")}},
-    'mingw32': {'Windows': {'default': os.getenv('CONAN_MINGW32_PATH', "C:/msys64/mingw32/bin")}},
-    'mingw64': {'Windows': {'default': os.getenv('CONAN_MINGW64_PATH', "C:/msys64/mingw64/bin")}},
+    'msys2': {'Windows': {'default': os.getenv('CONAN_MSYS2_PATH', 'C:/msys64/usr/bin')}},
+    'cygwin': {'Windows': {'default': os.getenv('CONAN_CYGWIN_PATH', 'C:/cygwin64/bin')}},
+    'mingw32': {'Windows': {'default': os.getenv('CONAN_MINGW32_PATH', 'C:/msys64/mingw32/bin')}},
+    'mingw64': {'Windows': {'default': os.getenv('CONAN_MINGW64_PATH', 'C:/msys64/mingw64/bin')}},
     'cmake': {
         'Windows': {
             'default': 'C:/Program Files/Cmake/bin',
@@ -75,32 +75,50 @@ if not which("conan"):
     tools_available.remove("conan")
 
 
+def _get_tool_location(locations, name, version, tool_platform):
+    path = None
+    try:
+        path = locations[name][tool_platform][version]
+    except KeyError as exc:
+        if version in str(exc):
+            raise ConanException(exc)
+    return path
+
+
+def _get_tool_environment(environments, name, tool_platform):
+    env = None
+    try:
+        env = environments[name][tool_platform]
+    except KeyError:
+        pass
+    return env
+
+
 @pytest.fixture(autouse=True)
 def add_tool(request):
-    add_tools = []
-    env_tools = dict()
+    tools_paths = []
+    tools_env_vars = dict()
     for mark in request.node.iter_markers():
         if mark.name.startswith("tool_"):
             version = mark.kwargs.get('version', 'default')
             tool_name = mark.name[5:]
-            if tool_name in tool_locations and tool_locations[tool_name].get(platform.system()):
-                tool_versions = tool_locations[tool_name].get(platform.system())
-                if version in tool_versions:
-                    add_tools.append(tool_versions[version])
-                else:
-                    pytest.fail("Required {} version: '{}' is not available".format(tool_name,
-                                                                                    version))
+            try:
+                tool_path = _get_tool_location(tool_locations, tool_name, version, platform.system())
+                if tool_path:
+                    tools_paths.append(tool_path)
+            except ConanException:
+                pytest.fail("Required {} version: '{}' is not available".format(tool_name, version))
 
-            if tool_name in tool_environments and tool_environments[tool_name].get(platform.system()):
-                tool_env = tool_environments[tool_name].get(platform.system())
-                env_tools.update(tool_env)
+            tool_env = _get_tool_environment(tool_environments, tool_name, platform.system())
+            if tool_env:
+                tools_env_vars.update(tool_env)
 
-    if add_tools:
-        add_tools.append(os.environ["PATH"])
-        temp_env = {'PATH': os.pathsep.join(add_tools)}
+    if tools_paths:
+        tools_paths.append(os.environ["PATH"])
+        temp_env = {'PATH': os.pathsep.join(tools_paths)}
         old_environ = dict(os.environ)
         os.environ.update(temp_env)
-        os.environ.update(env_tools)
+        os.environ.update(tools_env_vars)
         yield
         os.environ.clear()
         os.environ.update(old_environ)

--- a/conans/test/conftest.py
+++ b/conans/test/conftest.py
@@ -31,6 +31,12 @@ tools_locations = {
             '3.16': '/Users/jenkins/cmake/cmake-3.16.9/bin',
             '3.17': '/Users/jenkins/cmake/cmake-3.17.5/bin',
             '3.19': '/Users/jenkins/cmake/cmake-3.19.7/bin'
+        },
+        'Linux': {
+            '3.15': '/usr/share/cmake-3.15.7/bin',
+            '3.16': '/usr/share/cmake-3.16.9/bin',
+            '3.17': '/usr/share/cmake-3.17.5/bin',
+            '3.19': '/usr/share/cmake-3.19.7/bin'
         }
     }
 }

--- a/conans/test/conftest.py
+++ b/conans/test/conftest.py
@@ -7,7 +7,11 @@ from conans.client.tools import vswhere, which
 from conans.errors import ConanException
 
 tools_default_version = {
-    'cmake': '3.15'
+    'cmake': '3.15',
+    'msys2': 'default',
+    'cygwin': 'default',
+    'mingw32': 'default',
+    'mingw64': 'default'
 }
 
 tools_locations = {

--- a/conans/test/conftest.py
+++ b/conans/test/conftest.py
@@ -23,7 +23,14 @@ tools_locations = {
         'Windows': {
             '3.15': 'C:/cmake/cmake-3.15.7-win64-x64/bin',
             '3.16': 'C:/cmake/cmake-3.16.9-win64-x64/bin',
-            '3.17': 'C:/cmake/cmake-3.17.5-win64-x64/bin'
+            '3.17': 'C:/cmake/cmake-3.17.5-win64-x64/bin',
+            '3.19': 'C:/cmake/cmake-3.19.7-win64-x64/bin'
+        },
+        'Darwin': {
+            '3.15': '/Users/jenkins/cmake/cmake-3.15.7/bin',
+            '3.16': '/Users/jenkins/cmake/cmake-3.16.9/bin',
+            '3.17': '/Users/jenkins/cmake/cmake-3.17.5/bin',
+            '3.19': '/Users/jenkins/cmake/cmake-3.19.7/bin'
         }
     }
 }

--- a/conans/test/functional/subsystems_build_test.py
+++ b/conans/test/functional/subsystems_build_test.py
@@ -18,13 +18,6 @@ class TestSubsystems:
         client.run_command('uname')
         assert "MSYS" in client.out
 
-    @pytest.mark.tool_msys2
-    @pytest.mark.tool_cmake(version="3.16")
-    def test_custom_cmake_msys2(self):
-        client = TestClient()
-        client.run_command('cmake --version')
-        assert "cmake version 3.16" in client.out
-
     @pytest.mark.tool_cygwin
     def test_cygwin_available(self):
         client = TestClient()

--- a/conans/test/functional/subsystems_build_test.py
+++ b/conans/test/functional/subsystems_build_test.py
@@ -18,6 +18,13 @@ class TestSubsystems:
         client.run_command('uname')
         assert "MSYS" in client.out
 
+    @pytest.mark.tool_msys2
+    @pytest.mark.tool_cmake(version="3.16")
+    def test_custom_cmake_msys2(self):
+        client = TestClient()
+        client.run_command('cmake --version')
+        assert "cmake version 3.16" in client.out
+
     @pytest.mark.tool_cygwin
     def test_cygwin_available(self):
         client = TestClient()

--- a/conans/test/functional/tools_versions_test.py
+++ b/conans/test/functional/tools_versions_test.py
@@ -4,12 +4,11 @@ import textwrap
 import pytest
 
 from conans.test.assets.sources import gen_function_cpp
-from conans.test.utils.tools import TestClient
 from conans.test.conftest import tools_default_version
+from conans.test.utils.tools import TestClient
 
 
-# TODO: add versions for all platforms
-@pytest.mark.skipif(platform.system() != "Windows", reason="Only versions for Windows at the moment")
+@pytest.mark.skipif(platform.system() == "Linux", reason="Not in Linux yet")
 class TestToolsCustomVersions:
 
     @pytest.mark.tool_cmake
@@ -31,8 +30,16 @@ class TestToolsCustomVersions:
         client.run_command('cmake --version')
         assert "cmake version 3.17" in client.out
 
+    @pytest.mark.tool_cmake(version="3.19")
+    def test_custom_cmake_3_19(self):
+        client = TestClient()
+        client.run_command('cmake --version')
+        assert "cmake version 3.19" in client.out
+
     @pytest.mark.tool_mingw64
     @pytest.mark.tool_cmake(version="3.16")
+    @pytest.mark.skipif(platform.system() != "Windows",
+                        reason="Mingw test")
     def test_custom_cmake_mingw64(self):
         client = TestClient()
         client.run_command('cmake --version')

--- a/conans/test/functional/tools_versions_test.py
+++ b/conans/test/functional/tools_versions_test.py
@@ -1,8 +1,9 @@
 import platform
+import textwrap
 
 import pytest
 
-
+from conans.test.assets.sources import gen_function_cpp
 from conans.test.utils.tools import TestClient
 
 
@@ -28,3 +29,12 @@ class TestToolsCustomVersions:
         client = TestClient()
         client.run_command('cmake --version')
         assert "cmake version 3.16" in client.out
+        main = gen_function_cpp(name="main")
+        cmakelist = textwrap.dedent("""
+            cmake_minimum_required(VERSION 3.15)
+            project(App C CXX)
+            add_executable(app app.cpp)
+            """)
+        client.save({"CMakeLists.txt": cmakelist, "app.cpp": main})
+        client.run_command('cmake . -G "MinGW Makefiles"')
+        client.run_command("cmake --build .")

--- a/conans/test/functional/tools_versions_test.py
+++ b/conans/test/functional/tools_versions_test.py
@@ -5,11 +5,18 @@ import pytest
 
 from conans.test.assets.sources import gen_function_cpp
 from conans.test.utils.tools import TestClient
-
+from conans.test.conftest import tools_default_version
 
 # TODO: add versions for all platforms
 @pytest.mark.skipif(platform.system() != "Windows", reason="Only versions for Windows at the moment")
 class TestToolsCustomVersions:
+
+    @pytest.mark.tool_cmake
+    def test_default_cmake(self):
+        client = TestClient()
+        client.run_command('cmake --version')
+        default_cmake_version = tools_default_version.get("cmake")
+        assert "cmake version {}".format(default_cmake_version) in client.out
 
     @pytest.mark.tool_cmake(version="3.16")
     def test_custom_cmake_3_16(self):

--- a/conans/test/functional/tools_versions_test.py
+++ b/conans/test/functional/tools_versions_test.py
@@ -23,10 +23,9 @@ class TestToolsCustomVersions:
         client.run_command('cmake --version')
         assert "cmake version 3.17" in client.out
 
-    @pytest.mark.tool_msys2
     @pytest.mark.tool_mingw64
     @pytest.mark.tool_cmake(version="3.16")
-    def test_custom_cmake_msys2(self):
+    def test_custom_cmake_mingw64(self):
         client = TestClient()
         client.run_command('cmake --version')
         assert "cmake version 3.16" in client.out

--- a/conans/test/functional/tools_versions_test.py
+++ b/conans/test/functional/tools_versions_test.py
@@ -8,7 +8,6 @@ from conans.test.conftest import tools_default_version
 from conans.test.utils.tools import TestClient
 
 
-@pytest.mark.skipif(platform.system() == "Linux", reason="Not in Linux yet")
 class TestToolsCustomVersions:
 
     @pytest.mark.tool_cmake

--- a/conans/test/functional/tools_versions_test.py
+++ b/conans/test/functional/tools_versions_test.py
@@ -1,0 +1,30 @@
+import platform
+
+import pytest
+
+
+from conans.test.utils.tools import TestClient
+
+
+# TODO: add versions for all platforms
+@pytest.mark.skipif(platform.system() != "Windows", reason="Only versions for Windows at the moment")
+class TestToolsCustomVersions:
+
+    @pytest.mark.tool_cmake(version="3.16")
+    def test_custom_cmake_3_16(self):
+        client = TestClient()
+        client.run_command('cmake --version')
+        assert "cmake version 3.16" in client.out
+
+    @pytest.mark.tool_cmake(version="3.17")
+    def test_custom_cmake_3_17(self):
+        client = TestClient()
+        client.run_command('cmake --version')
+        assert "cmake version 3.17" in client.out
+
+    @pytest.mark.tool_msys2
+    @pytest.mark.tool_cmake(version="3.16")
+    def test_custom_cmake_msys2(self):
+        client = TestClient()
+        client.run_command('cmake --version')
+        assert "cmake version 3.16" in client.out

--- a/conans/test/functional/tools_versions_test.py
+++ b/conans/test/functional/tools_versions_test.py
@@ -7,6 +7,7 @@ from conans.test.assets.sources import gen_function_cpp
 from conans.test.utils.tools import TestClient
 from conans.test.conftest import tools_default_version
 
+
 # TODO: add versions for all platforms
 @pytest.mark.skipif(platform.system() != "Windows", reason="Only versions for Windows at the moment")
 class TestToolsCustomVersions:

--- a/conans/test/functional/tools_versions_test.py
+++ b/conans/test/functional/tools_versions_test.py
@@ -24,6 +24,7 @@ class TestToolsCustomVersions:
         assert "cmake version 3.17" in client.out
 
     @pytest.mark.tool_msys2
+    @pytest.mark.tool_mingw64
     @pytest.mark.tool_cmake(version="3.16")
     def test_custom_cmake_msys2(self):
         client = TestClient()


### PR DESCRIPTION
Changelog: Feature: Add support for testing with different tools versions.
Changelog: Feature: Add different CMake versions for testing.
Docs: omit

This is just to test if we can add some information to tests to select the version of the tools if it's installed in the CI.

#TAGS: slow