### PR TITLE
Fix qbs install

### DIFF
--- a/conan/tools/qbs/qbs.py
+++ b/conan/tools/qbs/qbs.py
@@ -85,8 +85,7 @@ class Qbs(object):
     def install(self):
         args = [
             '--no-build',
-            '--clean-install-root',
-            '--install-root', self._conanfile.install_folder,
+            '--install-root', self._conanfile.package_folder,
             '--file', self._project_file
         ]
 

--- a/conans/test/unittests/client/build/qbs_test.py
+++ b/conans/test/unittests/client/build/qbs_test.py
@@ -158,3 +158,42 @@ class QbsTest(unittest.TestCase):
                 config_values['product.App.stringProperty'],
                 'product.App.stringListProperty',
                 config_values['product.App.stringListProperty']))
+
+    def test_install(self):
+        conanfile = MockConanfile(
+            MockSettings({'os': 'Linux', 'compiler': 'gcc'}),
+            runner=RunnerMock())
+        conanfile.source_folder = '.'
+        conanfile.package_folder = 'pkg'
+        build_helper = qbs.Qbs(conanfile)
+
+        build_helper.install()
+        self.assertEqual(
+            conanfile.runner.command_called,
+            ('qbs install --no-build --install-root %s '
+             '--file %s') % (
+                conanfile.package_folder, build_helper._project_file))
+
+    def test_install_with_custom_configuration(self):
+        conanfile = MockConanfile(
+            MockSettings({'os': 'Linux', 'compiler': 'gcc'}),
+            runner=RunnerMock())
+        conanfile.source_folder = '.'
+        conanfile.package_folder = 'pkg'
+        build_helper = qbs.Qbs(conanfile)
+        config_name = 'debug'
+        config_values = {
+            'product.App.boolProperty': True,
+            'product.App.intProperty': 1337,
+            'product.App.stringProperty': 'Hello World',
+            'product.App.stringListProperty': ['Hello', 'World']
+        }
+        build_helper.add_configuration(config_name, config_values)
+
+        build_helper.install()
+        self.assertEqual(
+            conanfile.runner.command_called,
+            ('qbs install --no-build --install-root %s '
+             '--file %s config:%s') % (
+                conanfile.package_folder, build_helper._project_file,
+                config_name))


### PR DESCRIPTION
Currently the qbs build helper installed its files into `conanfile.install_folder`. With this PR the files are installed directly in the `conanfile.package_folder` like cmake does.

Changelog: Fix: Build helper qbs install now installs directly into package_folder.
Docs: omit

- [ ] Refer to the issue that supports this Pull Request.
- [ ] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 

<sup>**Note:** By default this PR will skip the slower tests and will use a limited set of python versions. Check [here](https://github.com/conan-io/conan/blob/develop/.github/PR_INCREASE_TESTING.md) how to increase the testing level by writing some tags in the current PR body text.</sup>
