### PR TITLE
Automatically handle CONAN_RUN_TESTS environment variable

### DIFF
--- a/conan/tools/cmake/cmake.py
+++ b/conan/tools/cmake/cmake.py
@@ -11,6 +11,7 @@ from conans.client.tools.oss import cpu_count, args_to_string
 from conans.errors import ConanException
 from conans.model.version import Version
 from conans.util.conan_v2_mode import conan_v2_error
+from conans.util.env_reader import get_env
 from conans.util.files import mkdir
 
 
@@ -133,7 +134,7 @@ class CMake(object):
         self._build(build_type=build_type, target="install")
 
     def test(self, build_type=None, target=None, output_on_failure=False):
-        if not self._conanfile.should_test:
+        if not self._conanfile.should_test or not get_env("CONAN_RUN_TESTS", True):
             return
         if not target:
             target = "RUN_TESTS" if self._is_multiconfiguration else "test"

--- a/conan/tools/cmake/cmake.py
+++ b/conan/tools/cmake/cmake.py
@@ -134,7 +134,7 @@ class CMake(object):
         self._build(build_type=build_type, target="install")
 
     def test(self, build_type=None, target=None, output_on_failure=False):
-        if not self._conanfile.should_test or not get_env("CONAN_RUN_TESTS", True):
+        if not self._conanfile.should_test:
             return
         if not target:
             target = "RUN_TESTS" if self._is_multiconfiguration else "test"

--- a/conans/client/build/cmake.py
+++ b/conans/client/build/cmake.py
@@ -20,6 +20,7 @@ from conans.errors import ConanException
 from conans.model.version import Version
 from conans.util.conan_v2_mode import conan_v2_error
 from conans.util.config_parser import get_bool_from_text
+from conans.util.env_reader import get_env
 from conans.util.files import mkdir, get_abs_path, walk, decode_text
 from conans.util.runners import version_runner
 
@@ -330,7 +331,7 @@ class CMake(object):
         self._build(args=args, build_dir=build_dir, target="install")
 
     def test(self, args=None, build_dir=None, target=None, output_on_failure=False):
-        if not self._conanfile.should_test:
+        if not self._conanfile.should_test or not get_env("CONAN_RUN_TESTS", True):
             return
         if not target:
             target = "RUN_TESTS" if self.is_multi_configuration else "test"

--- a/conans/client/build/meson.py
+++ b/conans/client/build/meson.py
@@ -12,6 +12,7 @@ from conans.errors import ConanException
 from conans.model.build_info import DEFAULT_BIN, DEFAULT_INCLUDE, DEFAULT_LIB
 from conans.model.version import Version
 from conans.util.conan_v2_mode import conan_v2_error
+from conans.util.env_reader import get_env
 from conans.util.files import decode_text, get_abs_path, mkdir
 from conans.util.runners import version_runner
 
@@ -225,7 +226,7 @@ class Meson(object):
         self._run_ninja_targets(args=args, build_dir=build_dir, targets=["install"])
 
     def test(self, args=None, build_dir=None, targets=None):
-        if not self._conanfile.should_test:
+        if not self._conanfile.should_test or not get_env("CONAN_RUN_TESTS", True):
             return
         if not targets:
             targets = ["test"]
@@ -237,7 +238,7 @@ class Meson(object):
         self._run_meson_command(subcommand='install', args=args, build_dir=build_dir)
 
     def meson_test(self, args=None, build_dir=None):
-        if not self._conanfile.should_test:
+        if not self._conanfile.should_test or not get_env("CONAN_RUN_TESTS", True):
             return
         self._run_meson_command(subcommand='test', args=args, build_dir=build_dir)
 

--- a/conans/test/unittests/client/build/cmake_test.py
+++ b/conans/test/unittests/client/build/cmake_test.py
@@ -184,6 +184,15 @@ class CMakeTest(unittest.TestCase):
                          CMakeTest.scape(". --target test -- -j%i" %
                                          cpu_count(output=conanfile.output)), conanfile.command)
 
+    def test_conan_run_tests(self):
+        conanfile = ConanFileMock()
+        conanfile.settings = Settings()
+        conanfile.should_test = True
+        cmake = CMake(conanfile, generator="Unix Makefiles")
+        with tools.environment_append({"CONAN_RUN_TESTS": "0"}):
+            cmake.test()
+            self.assertIsNone(conanfile.command)
+
     def test_cmake_generator(self):
         conanfile = ConanFileMock()
         conanfile.settings = Settings()

--- a/conans/test/unittests/client/build/meson_test.py
+++ b/conans/test/unittests/client/build/meson_test.py
@@ -8,7 +8,7 @@ import six
 from conans.client.build import defs_to_string
 from conans.client.build.meson import Meson
 from conans.client.conf import get_default_settings_yml
-from conans.client.tools import args_to_string
+from conans.client.tools import args_to_string, environment_append
 from conans.errors import ConanException
 from conans.model.settings import Settings
 from conans.test.utils.mocks import MockDepsCppInfo, ConanFileMock
@@ -50,6 +50,15 @@ class MesonTest(unittest.TestCase):
         self.assertIsNone(conan_file.command)
         meson.meson_install()
         self.assertIsNone(conan_file.command)
+
+    def test_conan_run_tests(self):
+        conan_file = ConanFileMock()
+        conan_file.settings = Settings()
+        conan_file.should_test = True
+        meson = Meson(conan_file)
+        with environment_append({"CONAN_RUN_TESTS": "0"}):
+            meson.test()
+            self.assertIsNone(conan_file.command)
 
     def test_folders(self):
         settings = Settings.loads(get_default_settings_yml())


### PR DESCRIPTION
Helps to avoid boilerplate in conanfiles:

    if tools.get_env("CONAN_RUN_TESTS", True):
        self._cmake.test()

Implements https://github.com/conan-io/conan/issues/7965

Changelog: Feature: Automatically handle `CONAN_RUN_TESTS` to avoid extra boilerplate.
Docs: https://github.com/conan-io/docs/pull/2056

- [x] Refer to the issue that supports this Pull Request.
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [x] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 

<sup>**Note:** By default this PR will skip the slower tests and will use a limited set of python versions. Check [here](https://github.com/conan-io/conan/blob/develop/.github/PR_INCREASE_TESTING.md) how to increase the testing level by writing some tags in the current PR body text.</sup>
