### PR TITLE
[refact] rename 'tools.microsoft:msbuild_verbosity' to 'tools.microsoft.msbuild:verbosity'

### DIFF
--- a/conan/tools/microsoft/msbuild.py
+++ b/conan/tools/microsoft/msbuild.py
@@ -2,7 +2,7 @@ from conans.errors import ConanException
 
 
 def msbuild_verbosity_cmd_line_arg(conanfile):
-    verbosity = conanfile.conf["tools.microsoft"].msbuild_verbosity
+    verbosity = conanfile.conf["tools.microsoft.msbuild"].verbosity
     if verbosity:
         if verbosity not in ("Quiet", "Minimal", "Normal", "Detailed", "Diagnostic"):
             raise ConanException("Unknown msbuild verbosity: {}".format(verbosity))

--- a/conans/test/integration/configuration/conf/test_conf_package_id.py
+++ b/conans/test/integration/configuration/conf/test_conf_package_id.py
@@ -22,13 +22,13 @@ def client():
 def test_package_id(client):
     profile1 = textwrap.dedent("""\
         [conf]
-        tools.microsoft:msbuild_verbosity=Quiet""")
+        tools.microsoft.msbuild:verbosity=Quiet""")
     profile2 = textwrap.dedent("""\
         [conf]
-        tools.microsoft:msbuild_verbosity=Minimal""")
+        tools.microsoft.msbuild:verbosity=Minimal""")
     client.save({"profile1": profile1,
                  "profile2": profile2})
     client.run("create . pkg/0.1@ -pr=profile1")
-    assert "pkg/0.1:b40df771e875672867408f9edf54bec0c2c361a7 - Build" in client.out
+    assert "pkg/0.1:b85ef030da903577bd87d1c92c0524c9c96212b5 - Build" in client.out
     client.run("create . pkg/0.1@ -pr=profile2")
-    assert "pkg/0.1:017c055fc7833bf6a7836211a26727533237071d - Build" in client.out
+    assert "pkg/0.1:7d2f1590113db99bcd08a4ebd4c841cc0a2e7020 - Build" in client.out

--- a/conans/test/integration/configuration/conf/test_conf_profile.py
+++ b/conans/test/integration/configuration/conf/test_conf_profile.py
@@ -52,7 +52,7 @@ def test_cmake_config(client):
         compiler.runtime=MD
         build_type=Release
         [conf]
-        tools.microsoft:msbuild_verbosity=Minimal
+        tools.microsoft.msbuild:verbosity=Minimal
         """)
     client.save({"myprofile": profile})
     client.run("create . pkg/0.1@ -pr=myprofile")
@@ -69,7 +69,7 @@ def test_cmake_config_error(client):
         compiler.runtime=MD
         build_type=Release
         [conf]
-        tools.microsoft:msbuild_verbosity=non-existing
+        tools.microsoft.msbuild:verbosity=non-existing
         """)
     client.save({"myprofile": profile})
     client.run("create . pkg/0.1@ -pr=myprofile", assert_error=True)
@@ -86,7 +86,7 @@ def test_cmake_config_package(client):
         compiler.runtime=MD
         build_type=Release
         [conf]
-        dep*:tools.microsoft:msbuild_verbosity=Minimal
+        dep*:tools.microsoft.msbuild:verbosity=Minimal
         """)
     client.save({"myprofile": profile})
     client.run("create . pkg/0.1@ -pr=myprofile")
@@ -128,7 +128,7 @@ def test_msbuild_config():
         compiler.runtime=MD
         build_type=Release
         [conf]
-        tools.microsoft:msbuild_verbosity=Minimal
+        tools.microsoft.msbuild:verbosity=Minimal
         """)
     client.save({"myprofile": profile})
     client.run("create . pkg/0.1@ -pr=myprofile")


### PR DESCRIPTION
Changelog: Fix: Rename `tools.microsoft:msbuild_verbosity` to `tools.microsoft.msbuild:verbosity`
Docs: https://github.com/conan-io/docs/pull/2059

Taken from: https://github.com/conan-io/conan/pull/8665
