### PR TITLE
small refactor to prefer config

### DIFF
--- a/conan/tools/cmake/base.py
+++ b/conan/tools/cmake/base.py
@@ -146,8 +146,6 @@ class CMakeToolchainBase(object):
         """)
 
     def __init__(self, conanfile, **kwargs):
-        import six
-
         self._conanfile = conanfile
         self.variables = Variables()
         self.preprocessor_definitions = Variables()
@@ -158,12 +156,11 @@ class CMakeToolchainBase(object):
 
         self.build_type = None
 
-        self.find_package_prefer_config = \
-            conanfile.conf["tools.cmake.cmaketoolchain"].find_package_prefer_config
-        if self.find_package_prefer_config is not None:
-            self.find_package_prefer_config = "OFF" if self.find_package_prefer_config.lower() in ("false", "0", "off") else "ON"
-        else:
-            self.find_package_prefer_config = "ON"  # assume ON by default if not specified in conf
+        self.find_package_prefer_config = "ON"  # assume ON by default if not specified in conf
+        prefer_config = conanfile.conf["tools.cmake.cmaketoolchain"].find_package_prefer_config
+        if prefer_config is not None and prefer_config.lower() in ("false", "0", "off"):
+            self.find_package_prefer_config = "OFF"
+
     def _get_templates(self):
         return {
             'toolchain_macros': self._toolchain_macros_tpl,


### PR DESCRIPTION
Changelog: Omit
Docs: Omit

Follow up from https://github.com/conan-io/conan/pull/8599:

- Removed unused ``import six``
- Reduced a bit the implementation, making more explicit and evident the default: ``self.find_package_prefer_config = "ON"``
- Make code pep8 compliant, like line lengths
- Make the test run faster, even if adding 1 more extra check (the default case when conf is not defined). Using a C project, reusing CMake cache, and avoiding compiler checks reduce test time from 14 seconds to just 3 in my machine, covering an extra case. When we are counting +3000 tests, it is important to keep test speed in mind.
- Remove ``unittest`` dependency and use bare ``assert`` checks as recommended by ``pytest``. Lets use this new pytest style for new tests when possible.