### PR TITLE
Fix/lock create error msg

### DIFF
--- a/conans/client/command.py
+++ b/conans/client/command.py
@@ -1886,7 +1886,8 @@ class Command(object):
 
         create_cmd = subparsers.add_parser('create',
                                            help='Create a lockfile from a conanfile or a reference')
-        create_cmd.add_argument("path", nargs="?", help="Path to a conanfile")
+        create_cmd.add_argument("path", nargs="?", help="Path to a conanfile, including filename, "
+                                                        "like 'path/conanfile.py'")
         create_cmd.add_argument("--name", action=OnceArgument,
                                 help='Provide a package name if not specified in conanfile')
         create_cmd.add_argument("--version", action=OnceArgument,

--- a/conans/client/conan_api.py
+++ b/conans/client/conan_api.py
@@ -1380,6 +1380,9 @@ class ConanAPIV1(object):
 
         if path:
             ref_or_path = _make_abs_path(path, cwd)
+            if os.path.isdir(ref_or_path):
+                raise ConanException("Path argument must include filename "
+                                     "like 'conanfile.py' or 'path/conanfile.py'")
             if not os.path.isfile(ref_or_path):
                 raise ConanException("Conanfile does not exist in %s" % ref_or_path)
         else:  # reference

--- a/conans/test/integration/graph_lock/graph_lock_test.py
+++ b/conans/test/integration/graph_lock/graph_lock_test.py
@@ -72,6 +72,14 @@ class GraphLockErrorsTest(unittest.TestCase):
         client.run("install consumer.py name/version@ --lockfile=output.lock")
         self.assertIn("consumer.py (name/version): Generated graphinfo", client.out)
 
+    @staticmethod
+    def test_error_no_filename():
+        # https://github.com/conan-io/conan/issues/8675
+        client = TestClient()
+        client.save({"consumer.txt": ""})
+        client.run("lock create .", assert_error=True)
+        assert "RROR: Path argument must include filename like 'conanfile.py'" in client.out
+
     def test_commands_cannot_create_lockfile(self):
         client = TestClient()
         client.save({"conanfile.py": GenConanfile("PkgA", "0.1")})


### PR DESCRIPTION
Changelog: Fix: Improve error message for ``lock create`` providing a path instead of full path with filename.
Docs: Omit

Close https://github.com/conan-io/conan/issues/8675