### PR TITLE
#5415: removed a seemingly spurious deletion of conanfile.py during t…

### DIFF
--- a/conans/client/source.py
+++ b/conans/client/source.py
@@ -159,7 +159,7 @@ def _run_source(conanfile, conanfile_path, hook_manager, reference, cache,
 
 def _clean_source_folder(folder):
     for f in (EXPORT_TGZ_NAME, EXPORT_SOURCES_TGZ_NAME, CONANFILE+"c",
-              CONANFILE+"o", CONANFILE, CONAN_MANIFEST):
+              CONANFILE+"o", CONAN_MANIFEST):
         try:
             os.remove(os.path.join(folder, f))
         except OSError:


### PR DESCRIPTION
#5415: removed a seemingly spurious deletion of conanfile.py during the source method.  This prevented projects using cmake-conan and conan_cmake_install(PATH_OR_REFERENCE conanfile.py) as it deleted the project's conanfile.py before cmake-conan could used it.

Changelog: (Feature | Fix | Bugfix): Bugfix
Docs: https://github.com/conan-io/docs/pull/5415

- [x] Refer to the issue that supports this Pull Request.
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 

<sup>**Note:** By default this PR will skip the slower tests and will use a limited set of python versions. Check [here](https://github.com/conan-io/conan/blob/develop/.github/PR_INCREASE_TESTING.md) how to increase the testing level by writing some tags in the current PR body text.</sup>
