### PR TITLE
Fix remotes not loaded for conan alias command

### DIFF
--- a/conans/client/conan_api.py
+++ b/conans/client/conan_api.py
@@ -1166,6 +1166,8 @@ class ConanAPIV1(object):
 
     @api_method
     def export_alias(self, reference, target_reference):
+        self.app.load_remotes()
+
         ref = ConanFileReference.loads(reference)
         target_ref = ConanFileReference.loads(target_reference)
 

--- a/conans/test/integration/command/alias_test.py
+++ b/conans/test/integration/command/alias_test.py
@@ -398,6 +398,19 @@ class Pkg(ConanFile):
         client.run("alias Hello/0.X@lasote/channel Hello/0.2@lasote/channel")
         client.run("alias Hello/0.X@lasote/channel Hello/0.3@lasote/channel")
 
+    def test_existing_python_requires(self):
+        # https://github.com/conan-io/conan/issues/8702
+        client = TestClient()
+        client.save({"conanfile.py": GenConanfile()})
+        client.run("create . test-python-requires/0.1@user/testing")
+        client.save({"conanfile.py": """from conans import ConanFile
+class Pkg(ConanFile):
+    python_requires = 'test-python-requires/0.1@user/testing'"""})
+        client.run("create . Pkg/0.1@user/testing")
+        client.run("alias Pkg/0.1@user/testing Pkg/0.2@user/testing", assert_error=True)
+        self.assertIn("ERROR: Reference 'Pkg/0.1@user/testing' is already a package",
+                      client.out)
+
     def test_basic(self):
         test_server = TestServer()
         servers = {"default": test_server}


### PR DESCRIPTION
Changelog: Fix: remotes not being loaded for the `conan alias` command, which was preventing `conan alias` from working if python_requires is used.
Docs: Omit

Fixes #8702 
Fix remotes not being loaded for the `conan alias` command, which was ~preventing `conan alias` from working if python_requires is used.~ causing a stack trace to be printed instead of the actual error message

- [x] Refer to the issue that supports this Pull Request.
- [ ] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 
