### PR TITLE
Feature: allow arbitrary defines in conan new templates

### DIFF
--- a/conans/client/cmd/new.py
+++ b/conans/client/cmd/new.py
@@ -286,16 +286,17 @@ test_package/build
 """
 
 
-def _render_template(text, name, version, package_name):
+def _render_template(text, name, version, package_name, defines):
     context = {'name': name,
                'version': version,
                'package_name': package_name,
                'conan_version': client_version}
+    context.update(defines)
     t = Template(text, keep_trailing_newline=True)
     return t.render(**context)
 
 
-def _get_files_from_template_dir(template_dir, name, version, package_name):
+def _get_files_from_template_dir(template_dir, name, version, package_name, defines):
     files = []
     for d, _, fs in os.walk(template_dir):
         for f in fs:
@@ -306,9 +307,10 @@ def _get_files_from_template_dir(template_dir, name, version, package_name):
     out_files = dict()
     for f in files:
         f_path = os.path.join(template_dir, f)
-        rendered_path = _render_template(f, name=name, version=version, package_name=package_name)
+        rendered_path = _render_template(f, name=name, version=version, package_name=package_name,
+                                         defines=defines)
         rendered_file = _render_template(load(f_path), name=name, version=version,
-                                         package_name=package_name)
+                                         package_name=package_name, defines=defines)
         out_files[rendered_path] = rendered_file
 
     return out_files
@@ -319,7 +321,7 @@ def cmd_new(ref, header=False, pure_c=False, test=False, exports_sources=False, 
             osx_clang_versions=None, shared=None, upload_url=None, gitignore=None,
             gitlab_gcc_versions=None, gitlab_clang_versions=None,
             circleci_gcc_versions=None, circleci_clang_versions=None, circleci_osx_versions=None,
-            template=None, cache=None):
+            template=None, cache=None, defines=None):
     try:
         tokens = ref.split("@")
         name, version = tokens[0].split("/")
@@ -347,6 +349,8 @@ def cmd_new(ref, header=False, pure_c=False, test=False, exports_sources=False, 
         raise ConanException("'template' is incompatible with 'header', "
                              "'sources', 'pure-c' and 'bare'")
 
+    defines = defines or []
+    defines = dict((n, v) for n, v in (d.split('=') for d in defines))
     if header:
         files = {"conanfile.py": conanfile_header.format(name=name, version=version,
                                                          package_name=package_name)}
@@ -384,7 +388,8 @@ def cmd_new(ref, header=False, pure_c=False, test=False, exports_sources=False, 
             replaced = _render_template(load(template),
                                         name=name,
                                         version=version,
-                                        package_name=package_name)
+                                        package_name=package_name,
+                                        defines=defines)
             files = {"conanfile.py": replaced}
         elif template == "v2_cmake":
             from conans.assets.templates.new_v2_cmake import get_files
@@ -398,7 +403,8 @@ def cmd_new(ref, header=False, pure_c=False, test=False, exports_sources=False, 
             files = _get_files_from_template_dir(template_dir=template,
                                                  name=name,
                                                  version=version,
-                                                 package_name=package_name)
+                                                 package_name=package_name,
+                                                 defines=defines)
     else:
         files = {"conanfile.py": conanfile.format(name=name, version=version,
                                                   package_name=package_name)}

--- a/conans/client/cmd/new.py
+++ b/conans/client/cmd/new.py
@@ -349,8 +349,8 @@ def cmd_new(ref, header=False, pure_c=False, test=False, exports_sources=False, 
         raise ConanException("'template' is incompatible with 'header', "
                              "'sources', 'pure-c' and 'bare'")
 
-    defines = defines or []
-    defines = dict((n, v) for n, v in (d.split('=') for d in defines))
+    defines = defines or dict()
+
     if header:
         files = {"conanfile.py": conanfile_header.format(name=name, version=version,
                                                          package_name=package_name)}

--- a/conans/client/command.py
+++ b/conans/client/command.py
@@ -202,6 +202,10 @@ class Command(object):
         parser.add_argument('-d', '--define', action='append')
 
         args = parser.parse_args(*args)
+
+        defines = args.define or []
+        defines = dict((n, v) for n, v in (d.split('=') for d in defines))
+
         self._warn_python_version()
         self._conan.new(args.name, header=args.header, pure_c=args.pure_c, test=args.test,
                         exports_sources=args.sources, bare=args.bare,
@@ -217,7 +221,7 @@ class Command(object):
                         circleci_clang_versions=args.ci_circleci_clang,
                         circleci_osx_versions=args.ci_circleci_osx,
                         template=args.template,
-                        defines=args.define)
+                        defines=defines)
 
     def inspect(self, *args):
         """

--- a/conans/client/command.py
+++ b/conans/client/command.py
@@ -199,6 +199,7 @@ class Command(object):
                             help='Generate a .gitignore with the known patterns to excluded')
         parser.add_argument("-ciu", "--ci-upload-url",
                             help='Define URL of the repository to upload')
+        parser.add_argument('-d', '--define', action='append')
 
         args = parser.parse_args(*args)
         self._warn_python_version()
@@ -215,7 +216,8 @@ class Command(object):
                         circleci_gcc_versions=args.ci_circleci_gcc,
                         circleci_clang_versions=args.ci_circleci_clang,
                         circleci_osx_versions=args.ci_circleci_osx,
-                        template=args.template)
+                        template=args.template,
+                        defines=args.define)
 
     def inspect(self, *args):
         """

--- a/conans/client/conan_api.py
+++ b/conans/client/conan_api.py
@@ -250,7 +250,7 @@ class ConanAPIV1(object):
             osx_clang_versions=None, shared=None, upload_url=None, gitignore=None,
             gitlab_gcc_versions=None, gitlab_clang_versions=None,
             circleci_gcc_versions=None, circleci_clang_versions=None, circleci_osx_versions=None,
-            template=None):
+            template=None, defines=None):
         from conans.client.cmd.new import cmd_new
         cwd = os.path.abspath(cwd or os.getcwd())
         files = cmd_new(name, header=header, pure_c=pure_c, test=test,
@@ -265,7 +265,7 @@ class ConanAPIV1(object):
                         circleci_gcc_versions=circleci_gcc_versions,
                         circleci_clang_versions=circleci_clang_versions,
                         circleci_osx_versions=circleci_osx_versions,
-                        template=template, cache=self.app.cache)
+                        template=template, cache=self.app.cache, defines=defines)
 
         save_files(cwd, files)
         for f in sorted(files):

--- a/conans/test/integration/command/new_test.py
+++ b/conans/test/integration/command/new_test.py
@@ -29,6 +29,27 @@ class NewCommandTest(unittest.TestCase):
         self.assertIn('version = "0.1"', conanfile)
         self.assertIn('conan_version = "{}"'.format(client_version), conanfile)
 
+    def test_template_custom_definitions(self):
+        client = TestClient()
+        template1 = textwrap.dedent("""
+            class {{package_name}}Conan(ConanFile):
+                name = "{{name}}"
+                version = "{{version}}"
+                conan_version = "{{conan_version}}"
+                license = "{{license}}"
+                homepage = "{{homepage}}"
+        """)
+        save(os.path.join(client.cache_folder, "templates/mytemplate.py"), template1)
+        client.run("new hello/0.1 --template=mytemplate.py "
+                   "-d license=MIT -d homepage=http://example.com")
+        conanfile = client.load("conanfile.py")
+        self.assertIn("class HelloConan(ConanFile):", conanfile)
+        self.assertIn('name = "hello"', conanfile)
+        self.assertIn('version = "0.1"', conanfile)
+        self.assertIn('conan_version = "{}"'.format(client_version), conanfile)
+        self.assertIn('license = "MIT"', conanfile)
+        self.assertIn('homepage = "http://example.com"', conanfile)
+
     def test_template_dir(self):
         client = TestClient()
         template_dir = "templates/command/new/t_dir"


### PR DESCRIPTION
allow arbitrary defines in `conan new` templates

e.g. instead of running:
```
$ conan new zip/0.1.30 -m cci.cmake
```
I may run:
```
conan new zip/0.1.30 -m cci.cmake -d license=Unlicense
```
which allows further automation on top of `conan new`, for instance, some script may fetch license, description, topics, homepage, tarball URL and sha256 in order to pass em to the template.

Changelog: Feature: Allow arbitrary defines in `conan new` templates.
Docs: https://github.com/conan-io/docs/pull/2051
- [x] Refer to the issue that supports this Pull Request.
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 

<sup>**Note:** By default this PR will skip the slower tests and will use a limited set of python versions. Check [here](https://github.com/conan-io/conan/blob/develop/.github/PR_INCREASE_TESTING.md) how to increase the testing level by writing some tags in the current PR body text.</sup>
