### PR TITLE
BugFix: conan new accepts short reference with address sign

### DIFF
--- a/conans/client/cmd/new.py
+++ b/conans/client/cmd/new.py
@@ -6,7 +6,7 @@ from jinja2 import Template
 from conans import __version__ as client_version
 from conans.client.cmd.new_ci import ci_get_files
 from conans.errors import ConanException
-from conans.model.ref import ConanFileReference
+from conans.model.ref import ConanFileReference, get_reference_fields
 from conans.util.files import load
 
 
@@ -323,12 +323,8 @@ def cmd_new(ref, header=False, pure_c=False, test=False, exports_sources=False, 
             circleci_gcc_versions=None, circleci_clang_versions=None, circleci_osx_versions=None,
             template=None, cache=None, defines=None):
     try:
-        tokens = ref.split("@")
-        name, version = tokens[0].split("/")
-        if len(tokens) == 2:
-            user, channel = tokens[1].split("/")
-        else:
-            user, channel = "user", "channel"
+        name, version, user, channel, revision = get_reference_fields(ref, user_channel_input=False)
+        # convert "package_name" -> "PackageName"
         package_name = re.sub(r"(?:^|[\W_])(\w)", lambda x: x.group(1).upper(), name)
     except ValueError:
         raise ConanException("Bad parameter, please use full package name,"

--- a/conans/test/integration/command/new_test.py
+++ b/conans/test/integration/command/new_test.py
@@ -386,3 +386,21 @@ class NewCommandTest(unittest.TestCase):
         self.assertIn("CMakeToolchain", conanfile)
         cmake = client.load("test_package/CMakeLists.txt")
         self.assertIn("find_package", cmake)
+
+    def test_new_reference(self):
+        client = TestClient()
+        # full reference
+        client.run("new MyPackage/1.3@myuser/testing --template=v2_cmake")
+        conanfile = client.load("conanfile.py")
+        self.assertIn('name = "MyPackage"', conanfile)
+        self.assertIn('version = "1.3"', conanfile)
+        # no username, no channel (with @)
+        client.run("new MyPackage/1.3@ --template=v2_cmake")
+        conanfile = client.load("conanfile.py")
+        self.assertIn('version = "1.3"', conanfile)
+        self.assertIn('name = "MyPackage"', conanfile)
+        # no username, no channel (without @)
+        client.run("new MyPackage/1.3 --template=v2_cmake")
+        conanfile = client.load("conanfile.py")
+        self.assertIn('name = "MyPackage"', conanfile)
+        self.assertIn('version = "1.3"', conanfile)


### PR DESCRIPTION
closes: #8720 

Changelog: BugFix: Command `conan new` accepts short reference with address sign.
Docs: omit

- [x] Refer to the issue that supports this Pull Request.
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 

<sup>**Note:** By default this PR will skip the slower tests and will use a limited set of python versions. Check [here](https://github.com/conan-io/conan/blob/develop/.github/PR_INCREASE_TESTING.md) how to increase the testing level by writing some tags in the current PR body text.</sup>
