### PR TITLE
Feature: premake_multi generator

### DIFF
--- a/conan/tools/premake/__init__.py
+++ b/conan/tools/premake/__init__.py
@@ -1,0 +1,2 @@
+
+from conan.tools.premake.premakedeps import PremakeDeps

--- a/conan/tools/premake/__init__.py
+++ b/conan/tools/premake/__init__.py
@@ -1,2 +1,1 @@
-
 from conan.tools.premake.premakedeps import PremakeDeps

--- a/conan/tools/premake/premakedeps.py
+++ b/conan/tools/premake/premakedeps.py
@@ -1,0 +1,109 @@
+import os
+import textwrap
+
+from conans.errors import ConanException
+from conans.model.build_info import DepCppInfo
+from conans.util.files import load, save
+
+VALID_LIB_EXTENSIONS = (".so", ".lib", ".a", ".dylib", ".bc")
+
+
+class PremakeDeps(object):
+    
+    _vars_conf_props = textwrap.dedent("""\
+       {lua_module}.conan_includedirs{name} = {{{include_dirs}}}
+       {lua_module}.conan_libdirs{name} = {{{lib_dirs}}}
+       {lua_module}.conan_bindirs{name} = {{{bin_dirs}}}
+       {lua_module}.conan_libs{name} = {{{libs}}}
+       {lua_module}.conan_system_libs{name} = {{{system_libs}}}
+       {lua_module}.conan_defines{name} = {{{definitions}}}
+       {lua_module}.conan_cxxflags{name} = {{{compiler_flags}}}
+       {lua_module}.conan_cflags{name} = {{{compiler_flags}}}
+       {lua_module}.conan_sharedlinkflags{name} = {{{linker_flags}}}
+       {lua_module}.conan_exelinkflags{name} = {{{linker_flags}}}
+       """)
+
+    _vars_luafile = textwrap.dedent("""\
+        local {lua_module} = {{}}
+
+        {lua_module}.conan_build_type = "{build_type}"
+        {lua_module}.conan_arch = "{arch}"
+
+        {deps}
+
+        function {lua_module}.conan_basic_setup()
+            configurations{{{lua_module}.conan_build_type}}
+            architecture({lua_module}.conan_arch)
+            includedirs{{{lua_module}.conan_includedirs}}
+            libdirs{{{lua_module}.conan_libdirs}}
+            links{{{lua_module}.conan_libs}}
+            links{{{lua_module}.conan_system_libs}}
+            defines{{{lua_module}.conan_defines}}
+            bindirs{{{lua_module}.conan_bindirs}}
+        end
+        
+        return {lua_module}
+        """)
+
+    def __init__(self, conanfile):
+        self._conanfile = conanfile
+        self.configuration = conanfile.settings.build_type
+        self.arch = conanfile.settings.arch
+        self.output_path = os.getcwd()
+
+    def generate(self):
+        if self.configuration is None:
+            raise ConanException("PremakeDeps.configuration is None, it should have a value")
+
+        self._lua_module = "conan_{config}".format(config=str(self.configuration).lower())
+
+        generator_files = self._content()
+        for generator_file, content in generator_files.items():
+            generator_file = os.path.join(self.output_path, generator_file)
+            save(generator_file, content)
+
+    def _pkg_props(self, name, cpp_info):
+        def add_valid_ext(libname):
+            (base, ext) = os.path.splitext(libname)
+            return libname if ext == 'framework' else base
+
+        fields = {
+            'name': name,
+            'lua_module': self._lua_module,
+            'root_folder': cpp_info.rootpath,
+            'bin_dirs': ";".join('"%s"' % p for p in cpp_info.bin_paths),
+            #'res_dirs': ";".join('"%s"' % p for p in cpp_info.res_paths),
+            'include_dirs': ";".join('"%s"' % p for p in cpp_info.include_paths),
+            'lib_dirs': ";".join('"%s"' % p for p in cpp_info.lib_paths),
+            'libs': ";".join('"%s"' % add_valid_ext(lib) for lib in cpp_info.libs),
+            'system_libs': ";".join('"%s"' % add_valid_ext(sys_dep) for sys_dep in cpp_info.system_libs),
+            'definitions': ";".join('"%s"' % d for d in cpp_info.defines),
+            'compiler_flags': " ".join(cpp_info.cxxflags + cpp_info.cflags),
+            'linker_flags': " ".join(cpp_info.sharedlinkflags),
+            'exe_flags': " ".join(cpp_info.exelinkflags),
+        }
+        formatted_template = self._vars_conf_props.format(**fields)
+        return formatted_template
+
+    def _content(self):
+        
+        deps = []
+        deps.append(self._pkg_props("", self._conanfile.deps_cpp_info))
+
+        for dep in self._conanfile.dependencies.host_requires:
+            cpp_info = DepCppInfo(dep.cpp_info)
+            deps.append(self._pkg_props("_{}".format(dep.name), cpp_info))
+
+        fields = {
+            'lua_module': self._lua_module,
+            'build_type': self.configuration,
+            'arch': self.arch,
+            'deps': "\n".join(deps),
+        }
+
+        filename = str(self.configuration).lower()
+        formatted_template = self._vars_luafile.format(**fields)
+        
+        return {
+            "conanbuildinfo_{}.premake.lua".format(filename): formatted_template
+        }

--- a/conans/client/generators/__init__.py
+++ b/conans/client/generators/__init__.py
@@ -67,7 +67,8 @@ class GeneratorManager(object):
                             "markdown": MarkdownGenerator}
         self._new_generators = ["CMakeToolchain", "CMakeDeps", "MakeToolchain", "MSBuildToolchain",
                                 "MesonToolchain", "MSBuildDeps", "QbsToolchain", "msbuild",
-                                "VirtualEnv", "AutotoolsDeps", "AutotoolsToolchain", "AutotoolsGen"]
+                                "VirtualEnv", "AutotoolsDeps", "AutotoolsToolchain", "AutotoolsGen",
+                                "PremakeDeps"]
 
     def add(self, name, generator_class, custom=False):
         if name not in self._generators or custom:
@@ -123,6 +124,9 @@ class GeneratorManager(object):
         elif generator_name == "VirtualEnv":
             from conan.tools.env.virtualenv import VirtualEnv
             return VirtualEnv
+        elif generator_name == "PremakeDeps":
+            from conan.tools.premake import PremakeDeps
+            return PremakeDeps
         else:
             raise ConanException("Internal Conan error: Generator '{}' "
                                  "not commplete".format(generator_name))

--- a/conans/test/functional/toolchains/premake/test_premakedeps.py
+++ b/conans/test/functional/toolchains/premake/test_premakedeps.py
@@ -1,0 +1,76 @@
+import pytest
+import textwrap
+import unittest
+
+from conans.test.assets.cpp_test_files import cpp_hello_conan_files
+from conans.test.assets.genconanfile import GenConanfile
+from conans.test.assets.sources import gen_function_cpp
+from conans.test.utils.tools import TestClient
+
+premake_file = r"""
+workspace("ConanPremakeDemo")
+
+    configurations { "Debug", "Release" }
+
+    project "ConanPremakeDemo"
+        kind "ConsoleApp"
+        language "C++"
+        targetdir "bin/%{cfg.buildcfg}"
+
+        linkoptions { conan_exelinkflags }
+
+        files { "**.h", "**.cpp" }
+
+        --filter "configurations:Debug"
+        --    require('conanbuildinfo_debug.premake').conan_basic_setup()
+        --    defines { "DEBUG" }
+        --    symbols "On"
+        filter "configurations:Release"
+            require('conanbuildinfo_release.premake').conan_basic_setup()
+            defines { "NDEBUG" }
+            optimize "On"
+"""
+
+@pytest.mark.tool_premake
+class PremakeGeneratorTest(unittest.TestCase):
+
+    def test_premake_generator(self):
+        client = TestClient()
+        files = cpp_hello_conan_files("Hello0", "1.0")
+        client.save(files)
+        client.run("create . ")
+        files = cpp_hello_conan_files("Hello3", "1.0")
+        client.save(files, clean_first=True)
+        client.run("create . ")
+        files = cpp_hello_conan_files("Hello1", "1.0", deps=["Hello0/1.0"])
+        client.save(files, clean_first=True)
+        client.run("create . ")
+
+        conanfile = textwrap.dedent("""
+            from conans import ConanFile, MSBuild
+            class HelloConan(ConanFile):
+                settings = "os", "build_type", "compiler", "arch"
+                requires = "Hello1/1.0", "Hello3/1.0"
+                generators = "PremakeDeps"
+                def build(self):
+                    self.run('premake gmake2')
+                    self.run('make config=release')
+            """)
+
+        myproject_cpp = gen_function_cpp(name="main", msg="MyProject", includes=["helloHello3"],
+                                         calls=["helloHello3"])
+
+        files = {"premake5.lua": premake_file,
+                 "MyProject.cpp": myproject_cpp,
+                 "conanfile.py": conanfile}
+
+        client.save(files, clean_first=True)
+        client.run("install .")
+        client.run("build .")
+        client.run_command(r"bin/Release/ConanPremakeDemo")
+        self.assertIn("MyProject: Release!", client.out)
+        self.assertIn("Hello Hello3", client.out)
+        #client.run_command(r"x64\Release\MyApp.exe")
+        #self.assertIn("MyApp: Release!", client.out)
+        #self.assertIn("Hello Hello1", client.out)
+        #self.assertIn("Hello Hello0", client.out)

--- a/conans/test/functional/toolchains/premake/test_premakedeps.py
+++ b/conans/test/functional/toolchains/premake/test_premakedeps.py
@@ -3,7 +3,6 @@ import textwrap
 import unittest
 
 from conans.test.assets.cpp_test_files import cpp_hello_conan_files
-from conans.test.assets.genconanfile import GenConanfile
 from conans.test.assets.sources import gen_function_cpp
 from conans.test.utils.tools import TestClient
 
@@ -31,11 +30,13 @@ workspace("ConanPremakeDemo")
             optimize "On"
 """
 
+
 @pytest.mark.tool_premake
 class PremakeGeneratorTest(unittest.TestCase):
 
     def test_premake_generator(self):
         client = TestClient()
+        # TODO: replace with more modern GenConanfile and others
         files = cpp_hello_conan_files("Hello0", "1.0")
         client.save(files)
         client.run("create . ")


### PR DESCRIPTION
Changelog: (Feature | Fix | Bugfix): experimental premake_multi generator
Docs: https://github.com/conan-io/docs/pull/XXXX

Closes #6634. I changed the existing premake generator to generate real Lua modules instead of include files. It's just some experimental code. I'm not a Lua/premake expert so this may be solved more elegantly. And I'm not sure if I have enough time to add tests/documentation. But maybe the PR can help somebody else.

It can be used like this:

```
$ conan install . -s build_type=RelWithDebInfo
$ conan install . -s build_type=Debug
```
This creates two files: conanbuildinfo_debug.premake.lua and connabuildinfo_relwithdebinfo.premake.lua.

The modules can then be used in the premake script like this:

```
conan_dbg = require("conanbuildinfo_debug.premake")
conan_rel = require("conanbuildinfo_relwithdebinfo.premake")

solution("Program")
  -- ...
  filter "Debug"
    conan_dbg.conan_basic_setup()
  filter "Release"
    conan_rel.conan_basic_setup()
```
or directly:
```
solution("Program")
  -- ...
  filter "Debug"
    require("conanbuildinfo_debug.premake").conan_basic_setup()
  filter "Release"
    require("conanbuildinfo_relwithdebinfo.premake").conan_basic_setup()
```
I.e. the ``conan_basic_setup()`` functions are now clearly separated into different modules.

- [x] Refer to the issue that supports this Pull Request.
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 

<sup>**Note:** By default this PR will skip the slower tests and will use a limited set of python versions. Check [here](https://github.com/conan-io/conan/blob/develop/.github/PR_INCREASE_TESTING.md) how to increase the testing level by writing some tags in the current PR body text.</sup>
