### PR TITLE
Add CMake include_guard() for cmake toolchain

### DIFF
--- a/conan/tools/cmake/base.py
+++ b/conan/tools/cmake/base.py
@@ -71,10 +71,15 @@ class CMakeToolchainBase(object):
 
         # Avoid including toolchain file several times (bad if appending to variables like
         #   CMAKE_CXX_FLAGS. See https://github.com/android/ndk/issues/323
-        if(CONAN_TOOLCHAIN_INCLUDED)
-          return()
+        if(${CMAKE_VERSION} VERSION_LESS "3.10")
+            if(CONAN_TOOLCHAIN_INCLUDED)
+                return()
+            endif()
+            set(CONAN_TOOLCHAIN_INCLUDED TRUE)
+        else()
+            include_guard()
         endif()
-        set(CONAN_TOOLCHAIN_INCLUDED TRUE)
+
 
         {% block before_try_compile %}
             {# build_type (Release, Debug, etc) is only defined for single-config generators #}

--- a/conan/tools/cmake/base.py
+++ b/conan/tools/cmake/base.py
@@ -71,14 +71,7 @@ class CMakeToolchainBase(object):
 
         # Avoid including toolchain file several times (bad if appending to variables like
         #   CMAKE_CXX_FLAGS. See https://github.com/android/ndk/issues/323
-        if(${CMAKE_VERSION} VERSION_LESS "3.10")
-            if(CONAN_TOOLCHAIN_INCLUDED)
-                return()
-            endif()
-            set(CONAN_TOOLCHAIN_INCLUDED TRUE)
-        else()
-            include_guard()
-        endif()
+        include_guard()
 
 
         {% block before_try_compile %}


### PR DESCRIPTION
Add [include_guard](https://cmake.org/cmake/help/latest/command/include_guard.html) support when CMake version is >= 3.10. Otherwise, use old sentinels approach.

Changelog: Feature: CMake toolchain supports include_guard() feature
Docs: Omit

closes #8639

- [x] Refer to the issue that supports this Pull Request.
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 

<sup>**Note:** By default this PR will skip the slower tests and will use a limited set of python versions. Check [here](https://github.com/conan-io/conan/blob/develop/.github/PR_INCREASE_TESTING.md) how to increase the testing level by writing some tags in the current PR body text.</sup>
