### PR TITLE
fix linker flags in cmake (find_package based) generators

### DIFF
--- a/conan/tools/cmake/cmakedeps.py
+++ b/conan/tools/cmake/cmakedeps.py
@@ -217,7 +217,15 @@ class DepsCppCmake(object):
             return '"%s"' % ";".join(p.replace('\\', '/').replace('$', '\\$') for p in values)
 
         def format_link_flags(link_flags):
-            return [(f if f.startswith("-") else"-{}".format(f)) for f in link_flags]
+            result = []
+            for f in link_flags:
+                if f.startswith("-"):
+                    result.append(f)
+                else:
+                    if f.startswith("/"):  # msvc link flag
+                        f = f[1:]  # Remove the initial / and use only "-"
+                    result.append("-{}".format(f))
+            return result
 
         self.include_paths = join_paths(cpp_info.include_paths)
         self.include_path = join_paths_single_var(cpp_info.include_paths)

--- a/conan/tools/cmake/cmakedeps.py
+++ b/conan/tools/cmake/cmakedeps.py
@@ -235,8 +235,9 @@ class DepsCppCmake(object):
         # Issue: #1251
         self.cxxflags_list = join_flags(";", cpp_info.cxxflags)
         self.cflags_list = join_flags(";", cpp_info.cflags)
-        self.sharedlinkflags_list = join_flags(";", cpp_info.sharedlinkflags)
-        self.exelinkflags_list = join_flags(";", cpp_info.exelinkflags)
+        self.sharedlinkflags_list = join_flags(";", ["-{}".format(f)
+                                                     for f in cpp_info.sharedlinkflags])
+        self.exelinkflags_list = join_flags(";", ["-{}".format(f) for f in cpp_info.exelinkflags])
 
         self.rootpath = join_paths([cpp_info.rootpath])
         self.build_modules_paths = join_paths(cpp_info.build_modules_paths.get(generator_name, []))

--- a/conan/tools/cmake/cmakedeps.py
+++ b/conan/tools/cmake/cmakedeps.py
@@ -216,6 +216,9 @@ class DepsCppCmake(object):
             """
             return '"%s"' % ";".join(p.replace('\\', '/').replace('$', '\\$') for p in values)
 
+        def format_link_flags(link_flags):
+            return [(f if f.startswith("-") else"-{}".format(f)) for f in link_flags]
+
         self.include_paths = join_paths(cpp_info.include_paths)
         self.include_path = join_paths_single_var(cpp_info.include_paths)
         self.lib_paths = join_paths(cpp_info.lib_paths)
@@ -235,9 +238,8 @@ class DepsCppCmake(object):
         # Issue: #1251
         self.cxxflags_list = join_flags(";", cpp_info.cxxflags)
         self.cflags_list = join_flags(";", cpp_info.cflags)
-        self.sharedlinkflags_list = join_flags(";", ["-{}".format(f)
-                                                     for f in cpp_info.sharedlinkflags])
-        self.exelinkflags_list = join_flags(";", ["-{}".format(f) for f in cpp_info.exelinkflags])
+        self.sharedlinkflags_list = join_flags(";", format_link_flags(cpp_info.sharedlinkflags))
+        self.exelinkflags_list = join_flags(";", format_link_flags(cpp_info.exelinkflags))
 
         self.rootpath = join_paths([cpp_info.rootpath])
         self.build_modules_paths = join_paths(cpp_info.build_modules_paths.get(generator_name, []))

--- a/conans/client/generators/cmake.py
+++ b/conans/client/generators/cmake.py
@@ -34,6 +34,9 @@ class DepsCppCmake(object):
             """
             return '"%s"' % ";".join(p.replace('\\', '/').replace('$', '\\$') for p in values)
 
+        def format_link_flags(link_flags):
+            return [(f if f.startswith("-") else"-{}".format(f)) for f in link_flags]
+
         self.include_paths = join_paths(cpp_info.include_paths)
         self.include_path = join_paths_single_var(cpp_info.include_paths)
         self.lib_paths = join_paths(cpp_info.lib_paths)
@@ -58,9 +61,8 @@ class DepsCppCmake(object):
         # Issue: #1251
         self.cxxflags_list = join_flags(";", cpp_info.cxxflags)
         self.cflags_list = join_flags(";", cpp_info.cflags)
-        self.sharedlinkflags_list = join_flags(";", ["-{}".format(f)
-                                                     for f in cpp_info.sharedlinkflags])
-        self.exelinkflags_list = join_flags(";", ["-{}".format(f) for f in cpp_info.exelinkflags])
+        self.sharedlinkflags_list = join_flags(";", format_link_flags(cpp_info.sharedlinkflags))
+        self.exelinkflags_list = join_flags(";", format_link_flags(cpp_info.exelinkflags))
 
         self.rootpath = join_paths([cpp_info.rootpath])
         self.build_modules_paths = join_paths(cpp_info.build_modules_paths.get(generator_name, []))

--- a/conans/client/generators/cmake.py
+++ b/conans/client/generators/cmake.py
@@ -58,8 +58,9 @@ class DepsCppCmake(object):
         # Issue: #1251
         self.cxxflags_list = join_flags(";", cpp_info.cxxflags)
         self.cflags_list = join_flags(";", cpp_info.cflags)
-        self.sharedlinkflags_list = join_flags(";", cpp_info.sharedlinkflags)
-        self.exelinkflags_list = join_flags(";", cpp_info.exelinkflags)
+        self.sharedlinkflags_list = join_flags(";", ["-{}".format(f)
+                                                     for f in cpp_info.sharedlinkflags])
+        self.exelinkflags_list = join_flags(";", ["-{}".format(f) for f in cpp_info.exelinkflags])
 
         self.rootpath = join_paths([cpp_info.rootpath])
         self.build_modules_paths = join_paths(cpp_info.build_modules_paths.get(generator_name, []))

--- a/conans/client/generators/cmake.py
+++ b/conans/client/generators/cmake.py
@@ -35,7 +35,15 @@ class DepsCppCmake(object):
             return '"%s"' % ";".join(p.replace('\\', '/').replace('$', '\\$') for p in values)
 
         def format_link_flags(link_flags):
-            return [(f if f.startswith("-") else"-{}".format(f)) for f in link_flags]
+            result = []
+            for f in link_flags:
+                if f.startswith("-"):
+                    result.append(f)
+                else:
+                    if f.startswith("/"):  # msvc link flag
+                        f = f[1:]  # Remove the initial / and use only "-"
+                    result.append("-{}".format(f))
+            return result
 
         self.include_paths = join_paths(cpp_info.include_paths)
         self.include_path = join_paths_single_var(cpp_info.include_paths)

--- a/conans/test/functional/generators/cmake_find_package_test.py
+++ b/conans/test/functional/generators/cmake_find_package_test.py
@@ -73,8 +73,10 @@ class TestCMakeFindPackageGenerator:
                     cmake.configure()
             """)
         cmakelists = textwrap.dedent("""
+            set(CMAKE_CXX_COMPILER_WORKS 1)
+            set(CMAKE_CXX_ABI_COMPILED 1)
             cmake_minimum_required(VERSION 3.0)
-            project(test)
+            project(test CXX)
             find_package(hello)
             get_target_property(tmp otherhello INTERFACE_LINK_LIBRARIES)
             message("otherhello link libraries: ${tmp}")
@@ -119,10 +121,11 @@ class Consumer(ConanFile):
     def build(self):
         cmake = CMake(self)
         cmake.configure()
-
     """
         cmakelists = """
-project(consumer)
+set(CMAKE_CXX_COMPILER_WORKS 1)
+set(CMAKE_CXX_ABI_COMPILED 1)
+project(consumer CXX)
 cmake_minimum_required(VERSION 3.1)
 find_package(Test)
 message("Libraries to Link: ${Test_LIBS}")
@@ -140,8 +143,8 @@ message("Compile options: ${tmp}")
         self.assertIn("Libraries to Link: fake_lib", client.out)
         self.assertIn("Version: 0.1", client.out)
         self.assertIn("Target libs: fake_lib;;"
-                      "$<$<STREQUAL:$<TARGET_PROPERTY:TYPE>,SHARED_LIBRARY>:shared_link_flag>;"
-                      "$<$<STREQUAL:$<TARGET_PROPERTY:TYPE>,MODULE_LIBRARY>:shared_link_flag>;"
+                      "$<$<STREQUAL:$<TARGET_PROPERTY:TYPE>,SHARED_LIBRARY>:-shared_link_flag>;"
+                      "$<$<STREQUAL:$<TARGET_PROPERTY:TYPE>,MODULE_LIBRARY>:-shared_link_flag>;"
                       "$<$<STREQUAL:$<TARGET_PROPERTY:TYPE>,EXECUTABLE>:>", client.out)
         self.assertIn("Compile options: a_cxx_flag;a_flag", client.out)
 
@@ -198,12 +201,13 @@ message("Target libs: ${tmp}")
                 def build(self):
                     cmake = CMake(self)
                     cmake.configure()
-
         """)
 
         cmakelists = textwrap.dedent("""
+            set(CMAKE_CXX_COMPILER_WORKS 1)
+            set(CMAKE_CXX_ABI_COMPILED 1)
             cmake_minimum_required(VERSION 3.0)
-            project(app)
+            project(app CXX)
             find_package(PkgC)
         """)
 
@@ -294,7 +298,6 @@ include_directories(${Hello0_INCLUDE_DIRS})
 target_link_libraries(helloHello1 PUBLIC ${Hello0_LIBS})
 add_executable(say_hello main.cpp)
 target_link_libraries(say_hello helloHello1)
-
 """
         client.save(files, clean_first=True)
         client.run("create . user/channel -s build_type=Release")
@@ -359,8 +362,10 @@ target_link_libraries(say_hello helloHello2)
                     cmake.configure()
         """)
         cmakelists = textwrap.dedent("""
+            set(CMAKE_CXX_COMPILER_WORKS 1)
+            set(CMAKE_CXX_ABI_COMPILED 1)
             cmake_minimum_required(VERSION 3.1)
-            project(consumer)
+            project(consumer CXX)
             find_package(Test)
             message("Package libs: ${Test_LIBS}")
             message("Package version: ${Test_VERSION}")
@@ -402,10 +407,11 @@ class Consumer(ConanFile):
     def build(self):
         cmake = CMake(self)
         cmake.configure()
-
     """
         cmakelists = """
-project(consumer)
+set(CMAKE_CXX_COMPILER_WORKS 1)
+set(CMAKE_CXX_ABI_COMPILED 1)
+project(consumer CXX)
 cmake_minimum_required(VERSION 3.1)
 find_package(Test)
 message("Libraries to link: ${Test_LIBS}")
@@ -493,8 +499,10 @@ message("Target libs: ${tmp}")
                     cmake.build()
             """)
         cmakelists = textwrap.dedent("""
+            set(CMAKE_CXX_COMPILER_WORKS 1)
+            set(CMAKE_CXX_ABI_COMPILED 1)
             cmake_minimum_required(VERSION 3.0)
-            project(test)
+            project(test CXX)
             find_package(test)
             custom_message("Printing using a external module!")
             """)
@@ -521,6 +529,7 @@ message("Target libs: ${tmp}")
                         output=client.out)
         client.run("create .")
         cmakelists = textwrap.dedent("""
+            set(CMAKE_CXX_ABI_COMPILED 1)
             set(CMAKE_CXX_COMPILER_WORKS 1)
             project(consumer CXX)
             cmake_minimum_required(VERSION 3.1)
@@ -599,6 +608,7 @@ message("Target libs: ${tmp}")
         client.run("create .")
 
         cmakelists = textwrap.dedent("""
+            set(CMAKE_CXX_ABI_COMPILED 1)
             set(CMAKE_CXX_COMPILER_WORKS 1)
             project(consumer CXX)
             cmake_minimum_required(VERSION 3.1)
@@ -708,7 +718,9 @@ message("Target libs: ${tmp}")
         """)
 
         cmakelists = textwrap.dedent("""
-            project(consumer)
+            set(CMAKE_CXX_COMPILER_WORKS 1)
+            set(CMAKE_CXX_ABI_COMPILED 1)
+            project(consumer CXX)
             cmake_minimum_required(VERSION 3.1)
             find_package(requirement)
             get_target_property(tmp requirement::component INTERFACE_LINK_LIBRARIES)

--- a/conans/test/unittests/client/generators/cmake_find_package_multi_test.py
+++ b/conans/test/unittests/client/generators/cmake_find_package_multi_test.py
@@ -2,6 +2,7 @@ import unittest
 
 from mock import Mock
 
+from conans import Settings
 from conans.client.generators import CMakeFindPackageMultiGenerator
 from conans.model.build_info import CppInfo
 from conans.model.conan_file import ConanFile
@@ -27,3 +28,27 @@ class CMakeFindPackageMultiTest(unittest.TestCase):
         content = generator.content
         config_version = content["my_pkg-config-version.cmake"]
         self.assertIn('set(PACKAGE_VERSION "0.1")', config_version)
+
+
+def test_cmake_find_package_multi_links_flags():
+    # https://github.com/conan-io/conan/issues/8703
+    conanfile = ConanFile(Mock(), None)
+    conanfile.settings = "os", "compiler", "build_type", "arch"
+    conanfile.initialize(Settings({"os": ["Windows"],
+                                   "compiler": ["gcc"],
+                                   "build_type": ["Release"],
+                                   "arch": ["x86"]}), EnvValues())
+    conanfile.settings.build_type = "Release"
+    conanfile.settings.arch = "x86"
+
+    cpp_info = CppInfo("mypkg", "dummy_root_folder1")
+    cpp_info.sharedlinkflags = ["/NODEFAULTLIB", "/OTHERFLAG"]
+    cpp_info.exelinkflags = ["/OPT:NOICF"]
+    conanfile.deps_cpp_info.add("mypkg", cpp_info)
+
+    gen = CMakeFindPackageMultiGenerator(conanfile)
+    files = gen.content
+    d = files["mypkgTarget-release.cmake"]
+    assert "$<$<STREQUAL:$<TARGET_PROPERTY:TYPE>,EXECUTABLE>:-/OPT:NOICF>" in d
+    assert "$<$<STREQUAL:$<TARGET_PROPERTY:TYPE>,MODULE_LIBRARY>:-/NODEFAULTLIB;-/OTHERFLAG>" in d
+    assert "$<$<STREQUAL:$<TARGET_PROPERTY:TYPE>,SHARED_LIBRARY>:-/NODEFAULTLIB;-/OTHERFLAG>" in d

--- a/conans/test/unittests/client/generators/cmake_find_package_multi_test.py
+++ b/conans/test/unittests/client/generators/cmake_find_package_multi_test.py
@@ -49,6 +49,6 @@ def test_cmake_find_package_multi_links_flags():
     gen = CMakeFindPackageMultiGenerator(conanfile)
     files = gen.content
     d = files["mypkgTarget-release.cmake"]
-    assert "$<$<STREQUAL:$<TARGET_PROPERTY:TYPE>,EXECUTABLE>:-/OPT:NOICF>" in d
-    assert "$<$<STREQUAL:$<TARGET_PROPERTY:TYPE>,MODULE_LIBRARY>:-/NODEFAULTLIB;-/OTHERFLAG>" in d
-    assert "$<$<STREQUAL:$<TARGET_PROPERTY:TYPE>,SHARED_LIBRARY>:-/NODEFAULTLIB;-/OTHERFLAG>" in d
+    assert "$<$<STREQUAL:$<TARGET_PROPERTY:TYPE>,EXECUTABLE>:-OPT:NOICF>" in d
+    assert "$<$<STREQUAL:$<TARGET_PROPERTY:TYPE>,MODULE_LIBRARY>:-NODEFAULTLIB;-OTHERFLAG>" in d
+    assert "$<$<STREQUAL:$<TARGET_PROPERTY:TYPE>,SHARED_LIBRARY>:-NODEFAULTLIB;-OTHERFLAG>" in d

--- a/conans/test/unittests/tools/cmake/test_cmakedeps.py
+++ b/conans/test/unittests/tools/cmake/test_cmakedeps.py
@@ -83,5 +83,5 @@ def test_cmake_deps_links_flags():
     cmakedeps = CMakeDeps(conanfile)
     files = cmakedeps.content
     data_cmake = files["mypkg-release-x86-data.cmake"]
-    assert "set(mypkg_SHARED_LINK_FLAGS_RELEASE -/NODEFAULTLIB;-/OTHERFLAG)" in data_cmake
-    assert "set(mypkg_EXE_LINK_FLAGS_RELEASE -/OPT:NOICF)" in data_cmake
+    assert "set(mypkg_SHARED_LINK_FLAGS_RELEASE -NODEFAULTLIB;-OTHERFLAG)" in data_cmake
+    assert "set(mypkg_EXE_LINK_FLAGS_RELEASE -OPT:NOICF)" in data_cmake

--- a/conans/test/unittests/tools/cmake/test_cmakedeps.py
+++ b/conans/test/unittests/tools/cmake/test_cmakedeps.py
@@ -62,3 +62,26 @@ def test_cpp_info_name_cmakedeps_components():
                        match="'mypkg' defines information for 'cmake_find_package_multi'"):
         with environment_append({CONAN_V2_MODE_ENVVAR: "1"}):
             _ = cmakedeps.content
+
+
+def test_cmake_deps_links_flags():
+    # https://github.com/conan-io/conan/issues/8703
+    conanfile = ConanFile(Mock(), None)
+    conanfile.settings = "os", "compiler", "build_type", "arch"
+    conanfile.initialize(Settings({"os": ["Windows"],
+                                   "compiler": ["gcc"],
+                                   "build_type": ["Release"],
+                                   "arch": ["x86"]}), EnvValues())
+    conanfile.settings.build_type = "Release"
+    conanfile.settings.arch = "x86"
+
+    cpp_info = CppInfo("mypkg", "dummy_root_folder1")
+    cpp_info.sharedlinkflags = ["/NODEFAULTLIB", "/OTHERFLAG"]
+    cpp_info.exelinkflags = ["/OPT:NOICF"]
+    conanfile.deps_cpp_info.add("mypkg", cpp_info)
+
+    cmakedeps = CMakeDeps(conanfile)
+    files = cmakedeps.content
+    data_cmake = files["mypkg-release-x86-data.cmake"]
+    assert "set(mypkg_SHARED_LINK_FLAGS_RELEASE -/NODEFAULTLIB;-/OTHERFLAG)" in data_cmake
+    assert "set(mypkg_EXE_LINK_FLAGS_RELEASE -/OPT:NOICF)" in data_cmake


### PR DESCRIPTION
Changelog: Bugfix: Fix linker flags in cmake (find_package based) generators.
Docs: Omit

Fix: https://github.com/conan-io/conan/issues/8703

#tags: slow
