### PR TITLE
avoid breaking users calling forbidden private api conanfile.__init__

### DIFF
--- a/conans/client/loader.py
+++ b/conans/client/loader.py
@@ -47,8 +47,8 @@ class ConanFileLoader(object):
         """
         cached = self._cached_conanfile_classes.get(conanfile_path)
         if cached and cached[1] == lock_python_requires:
-            conanfile = cached[0](self._output, self._runner, display, user, channel,
-                                  self._requester)
+            conanfile = cached[0](self._output, self._runner, display, user, channel)
+            conanfile._conan_requires = self._requester
             if hasattr(conanfile, "init") and callable(conanfile.init):
                 with conanfile_exception_formatter(str(conanfile), "init"):
                     conanfile.init()
@@ -85,7 +85,8 @@ class ConanFileLoader(object):
 
             self._cached_conanfile_classes[conanfile_path] = (conanfile, lock_python_requires,
                                                               module)
-            result = conanfile(self._output, self._runner, display, user, channel, self._requester)
+            result = conanfile(self._output, self._runner, display, user, channel)
+            result._conan_requester = self._requester
             if hasattr(result, "init") and callable(result.init):
                 with conanfile_exception_formatter(str(result), "init"):
                     result.init()

--- a/conans/client/loader.py
+++ b/conans/client/loader.py
@@ -48,7 +48,7 @@ class ConanFileLoader(object):
         cached = self._cached_conanfile_classes.get(conanfile_path)
         if cached and cached[1] == lock_python_requires:
             conanfile = cached[0](self._output, self._runner, display, user, channel)
-            conanfile._conan_requires = self._requester
+            conanfile._conan_requester = self._requester
             if hasattr(conanfile, "init") and callable(conanfile.init):
                 with conanfile_exception_formatter(str(conanfile), "init"):
                     conanfile.init()

--- a/conans/model/conan_file.py
+++ b/conans/model/conan_file.py
@@ -136,7 +136,7 @@ class ConanFile(object):
     # layout
     layout = None
 
-    def __init__(self, output, runner, display_name="", user=None, channel=None, requester=None):
+    def __init__(self, output, runner, display_name="", user=None, channel=None):
         # an output stream (writeln, info, warn error)
         self.output = ScopedOutput(display_name, output)
         self.display_name = display_name
@@ -147,7 +147,7 @@ class ConanFile(object):
 
         self.compatible_packages = []
         self._conan_using_build_profile = False
-        self._conan_requester = requester
+        self._conan_requester = None
 
         self.layout = Layout()
         self.buildenv_info = Environment()


### PR DESCRIPTION
Changelog: Fix: Avoid breaking users calling forbidden private api ``conanfile.__init__``.
Docs: Omit

Close https://github.com/conan-io/conan/issues/8741

#tags: slow
