### PR TITLE
opensuse SystemPackageTools incorrectly using apt-get when zypper-aptitude

### DIFF
--- a/conans/client/tools/oss.py
+++ b/conans/client/tools/oss.py
@@ -187,6 +187,10 @@ class OSInfo(object):
         if not self.is_linux:
             return False
 
+        # https://github.com/conan-io/conan/issues/8737 zypper-aptitude can fake it
+        if "opensuse" in self.linux_distro or "sles" in self.linux_distro:
+            return False
+
         apt_location = which('apt-get')
         if apt_location:
             # Check if we actually have the official apt package.
@@ -196,9 +200,6 @@ class OSInfo(object):
                 return False
             else:
                 # Yes, we have mooed today. :-) MOOOOOOOO.
-                # https://github.com/conan-io/conan/issues/8737 zypper-aptitude can fake it
-                if "zypper" in output:
-                    return False
                 return True
         else:
             return False

--- a/conans/client/tools/oss.py
+++ b/conans/client/tools/oss.py
@@ -187,6 +187,11 @@ class OSInfo(object):
         if not self.is_linux:
             return False
 
+        # https://github.com/conan-io/conan/issues/8737 zypper-aptitude can fake it
+        # FIXME: This needs a better approach
+        if "opensuse" in self.linux_distro or "sles" in self.linux_distro:
+            return False
+
         apt_location = which('apt-get')
         if apt_location:
             # Check if we actually have the official apt package.

--- a/conans/client/tools/oss.py
+++ b/conans/client/tools/oss.py
@@ -187,11 +187,6 @@ class OSInfo(object):
         if not self.is_linux:
             return False
 
-        # https://github.com/conan-io/conan/issues/8737 zypper-aptitude can fake it
-        # FIXME: This needs a better approach
-        if "opensuse" in self.linux_distro or "sles" in self.linux_distro:
-            return False
-
         apt_location = which('apt-get')
         if apt_location:
             # Check if we actually have the official apt package.
@@ -201,6 +196,9 @@ class OSInfo(object):
                 return False
             else:
                 # Yes, we have mooed today. :-) MOOOOOOOO.
+                # https://github.com/conan-io/conan/issues/8737 zypper-aptitude can fake it
+                if "zypper" in output:
+                    return False
                 return True
         else:
             return False

--- a/conans/test/unittests/client/tools/system_pm_test.py
+++ b/conans/test/unittests/client/tools/system_pm_test.py
@@ -371,7 +371,7 @@ class SystemPackageToolTest(unittest.TestCase):
         os_info.distro = "opensuse"
         runner = RunnerMock()
         with mock.patch("conans.client.tools.oss.which", return_value=True):
-            with mock.patch("conans.client.tools.oss.check_output_runner", return_value="Linux"):
+            with mock.patch("conans.client.tools.oss.check_output_runner", return_value="zypper"):
                 with tools.environment_append({"CONAN_SYSREQUIRES_SUDO": "False"}):
                     os_info.linux_distro = "opensuse"
                     spt = SystemPackageTool(runner=runner, os_info=os_info, output=self.out)

--- a/conans/test/unittests/client/tools/system_pm_test.py
+++ b/conans/test/unittests/client/tools/system_pm_test.py
@@ -368,15 +368,13 @@ class SystemPackageToolTest(unittest.TestCase):
         os_info.is_solaris = False
         os_info.is_macos = False
         os_info.is_windows = False
-        os_info.distro = "opensuse"
+        os_info.linux_distro = "opensuse"
         runner = RunnerMock()
-        with mock.patch("conans.client.tools.oss.which", return_value=True):
-            with mock.patch("conans.client.tools.oss.check_output_runner", return_value="zypper"):
-                with tools.environment_append({"CONAN_SYSREQUIRES_SUDO": "False"}):
-                    os_info.linux_distro = "opensuse"
-                    spt = SystemPackageTool(runner=runner, os_info=os_info, output=self.out)
-                    spt.update()
-                    self.assertEqual(runner.command_called, "zypper --non-interactive ref")
+
+        with tools.environment_append({"CONAN_SYSREQUIRES_SUDO": "False"}):
+            spt = SystemPackageTool(runner=runner, os_info=os_info, output=self.out)
+            spt.update()
+            self.assertEqual(runner.command_called, "zypper --non-interactive ref")
 
     def test_system_package_tool_try_multiple(self):
         packages = ["a_package", "another_package", "yet_another_package"]

--- a/conans/test/unittests/client/tools/system_pm_test.py
+++ b/conans/test/unittests/client/tools/system_pm_test.py
@@ -365,6 +365,9 @@ class SystemPackageToolTest(unittest.TestCase):
         # https://github.com/conan-io/conan/issues/8737
         os_info = OSInfo()
         os_info.is_linux = True
+        os_info.is_solaris = False
+        os_info.is_macos = False
+        os_info.is_windows = False
         os_info.distro = "opensuse"
         runner = RunnerMock()
         with mock.patch("conans.client.tools.oss.which", return_value=True):

--- a/conans/test/unittests/client/tools/system_pm_test.py
+++ b/conans/test/unittests/client/tools/system_pm_test.py
@@ -369,10 +369,11 @@ class SystemPackageToolTest(unittest.TestCase):
         runner = RunnerMock()
         with mock.patch("conans.client.tools.oss.which", return_value=True):
             with mock.patch("conans.client.tools.oss.check_output_runner", return_value="Linux"):
-                os_info.linux_distro = "opensuse"
-                spt = SystemPackageTool(runner=runner, os_info=os_info, output=self.out)
-                spt.update()
-                self.assertEqual(runner.command_called, "zypper --non-interactive ref")
+                with tools.environment_append({"CONAN_SYSREQUIRES_SUDO": "False"}):
+                    os_info.linux_distro = "opensuse"
+                    spt = SystemPackageTool(runner=runner, os_info=os_info, output=self.out)
+                    spt.update()
+                    self.assertEqual(runner.command_called, "zypper --non-interactive ref")
 
     def test_system_package_tool_try_multiple(self):
         packages = ["a_package", "another_package", "yet_another_package"]

--- a/conans/test/unittests/client/tools/system_pm_test.py
+++ b/conans/test/unittests/client/tools/system_pm_test.py
@@ -361,6 +361,19 @@ class SystemPackageToolTest(unittest.TestCase):
                                  'choco search --local-only --exact a_package | '
                                  'findstr /c:"1 packages installed."')
 
+    def test_opensuse_zypper_aptitude(self):
+        # https://github.com/conan-io/conan/issues/8737
+        os_info = OSInfo()
+        os_info.is_linux = True
+        os_info.distro = "opensuse"
+        runner = RunnerMock()
+        with mock.patch("conans.client.tools.oss.which", return_value=True):
+            with mock.patch("conans.client.tools.oss.check_output_runner", return_value="Linux"):
+                os_info.linux_distro = "opensuse"
+                spt = SystemPackageTool(runner=runner, os_info=os_info, output=self.out)
+                spt.update()
+                self.assertEqual(runner.command_called, "zypper --non-interactive ref")
+
     def test_system_package_tool_try_multiple(self):
         packages = ["a_package", "another_package", "yet_another_package"]
         with tools.environment_append({"CONAN_SYSREQUIRES_SUDO": "True"}):


### PR DESCRIPTION
Changelog: Bugfix: Fix opensuse SystemPackageTools incorrectly using apt-get when zypper-aptitude.
Docs: Omit

Fix https://github.com/conan-io/conan/issues/8737