### PR TITLE
Remove invalid config_install_interval

### DIFF
--- a/conans/client/conf/__init__.py
+++ b/conans/client/conf/__init__.py
@@ -716,16 +716,19 @@ class ConanClientConfigParser(ConfigParser, object):
 
     @property
     def config_install_interval(self):
+        item = "general.config_install_interval"
         try:
-            interval = self.get_item("general.config_install_interval")
+            interval = self.get_item(item)
         except ConanException:
             return None
 
         try:
             return timedelta_from_text(interval)
         except Exception:
-            raise ConanException("Incorrect definition of general.config_install_interval: %s"
-                                 % interval)
+            self.rm_item(item)
+            raise ConanException("Incorrect definition of general.config_install_interval: {}. "
+                                 "Removing it from conan.conf to avoid possible loop error."
+                                 .format(interval))
 
     @property
     def required_conan_version(self):

--- a/conans/test/functional/command/config_install_test.py
+++ b/conans/test/functional/command/config_install_test.py
@@ -8,6 +8,7 @@ import unittest
 import pytest
 import six
 from mock import patch
+from parameterized import parameterized
 
 from conans.client.cache.remote_registry import Remote
 from conans.client.conf import ConanClientConfigParser
@@ -637,6 +638,7 @@ class ConfigInstallSchedTest(unittest.TestCase):
         self.folder = temp_folder(path_with_spaces=False)
         save_files(self.folder, {"conan.conf": conanconf_interval})
         self.client = TestClient()
+        self.client.save({"conanfile.txt": ""})
 
     def test_config_install_sched_file(self):
         """ Config install can be executed without restriction
@@ -685,14 +687,17 @@ class ConfigInstallSchedTest(unittest.TestCase):
         self.client.run('config get general.config_install_interval', assert_error=True)
         self.assertIn("config_install_interval defined, but no config_install file", self.client.out)
 
-    def test_invalid_time_interval(self):
-        """ config_install_interval only accepts minutes, hours or days
+    @parameterized.expand([("1y",), ("2015t",), ("42",)])
+    def test_invalid_time_interval(self, internal):
+        """ config_install_interval only accepts seconds, minutes, hours, days and weeks.
         """
-        self.client.run('config set general.config_install_interval=1s')
+        self.client.run('config set general.config_install_interval={}'.format(internal))
         # Any conan invocation will fire the configuration error
         self.client.run('install .', assert_error=True)
-        self.assertIn("ERROR: Incorrect definition of general.config_install_interval: 1s",
+        self.assertIn("ERROR: Incorrect definition of general.config_install_interval: {}. "
+                      "Removing it from conan.conf to avoid possible loop error.".format(internal),
                       self.client.out)
+        self.client.run('install .')
 
     @pytest.mark.tool_git
     def test_config_install_remove_git_repo(self):

--- a/conans/util/dates.py
+++ b/conans/util/dates.py
@@ -34,15 +34,11 @@ def timedelta_from_text(interval):
     match = re.search(r"(\d+)([smhdw])", interval)
     try:
         value, unit = match.group(1), match.group(2)
-        if unit == 's':
-            return datetime.timedelta(seconds=float(value))
-        elif unit == 'm':
-            return datetime.timedelta(minutes=float(value))
-        elif unit == 'h':
-            return datetime.timedelta(hours=float(value))
-        elif unit == 'd':
-            return datetime.timedelta(days=float(value))
-        elif unit == 'w':
-            return datetime.timedelta(weeks=float(value))
+        name = {'s': 'seconds',
+                'm': 'minutes',
+                'h': 'hours',
+                'd': 'days',
+                'w': 'weeks'}[unit]
+        return datetime.timedelta(**{name: float(value)})
     except Exception:
         raise ConanException("Incorrect time interval definition: %s" % interval)

--- a/conans/util/dates.py
+++ b/conans/util/dates.py
@@ -31,14 +31,18 @@ def timestamp_to_str(timestamp):
 
 
 def timedelta_from_text(interval):
-    match = re.search(r"(\d+)([mhd])", interval)
+    match = re.search(r"(\d+)([smhdw])", interval)
     try:
         value, unit = match.group(1), match.group(2)
-        if unit == 'm':
+        if unit == 's':
+            return datetime.timedelta(seconds=float(value))
+        elif unit == 'm':
             return datetime.timedelta(minutes=float(value))
         elif unit == 'h':
             return datetime.timedelta(hours=float(value))
-        else:
+        elif unit == 'd':
             return datetime.timedelta(days=float(value))
+        elif unit == 'w':
+            return datetime.timedelta(weeks=float(value))
     except Exception:
         raise ConanException("Incorrect time interval definition: %s" % interval)


### PR DESCRIPTION
Hello there.

I've added new units for `seconds` and `weeks`. Now when loading `conan.conf`, if `config_install_interval` is invalid, it will be removed.

I did another change that may break users, but I think necessary. Before this PR, if `config_install_interval` value had no value (e.g. config_install_interval=1), it would be considered **days**, implicitly. Now, an unit is mandatory (explicit is better than implicit).

I need to update docs, because those units are not clear there, but first I would like some review.



fixes #8713

Changelog: Fix: `config_install_interval` no longer enter in loop when invalid.
Docs: https://github.com/conan-io/docs/pull/2067

- [x] Refer to the issue that supports this Pull Request.
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [x] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 

<sup>**Note:** By default this PR will skip the slower tests and will use a limited set of python versions. Check [here](https://github.com/conan-io/conan/blob/develop/.github/PR_INCREASE_TESTING.md) how to increase the testing level by writing some tags in the current PR body text.</sup>
