### PR TITLE
remove 'conan info --build-order', superseded by lockfiles

### DIFF
--- a/conans/client/command.py
+++ b/conans/client/command.py
@@ -645,10 +645,6 @@ class Command(object):
         parser.add_argument("--channel", action=OnceArgument, help='Provide a channel')
         parser.add_argument("--paths", action='store_true', default=False,
                             help='Show package paths in local cache')
-        parser.add_argument("-bo", "--build-order",
-                            help="given a modified reference, return an ordered list to build (CI)."
-                                 " [DEPRECATED: use 'conan lock build-order ...' instead]",
-                            nargs=1, action=Extender)
         parser.add_argument("-g", "--graph", action=OnceArgument,
                             help='Creates file with project dependencies graph. It will generate '
                             'a DOT or HTML file depending on the filename extension')
@@ -677,32 +673,8 @@ class Command(object):
         profile_build = ProfileData(profiles=args.profile_build, settings=args.settings_build,
                                     options=args.options_build, env=args.env_build)
 
-        if args.build_order:
-            self._out.warn("Usage of `--build-order` argument is deprecated and can return"
-                           " wrong results. Use `conan lock build-order ...` instead.")
-
-        if args.build_order and args.graph:
-            raise ArgumentError(None, "--build-order cannot be used together with --graph")
-
-        # BUILD ORDER ONLY
-        if args.build_order:
-            ret = self._conan.info_build_order(args.path_or_reference,
-                                               settings=args.settings_host,
-                                               options=args.options_host,
-                                               env=args.env_host,
-                                               profile_names=args.profile_host,
-                                               profile_build=profile_build,
-                                               remote_name=args.remote,
-                                               build_order=args.build_order,
-                                               check_updates=args.update)
-            if args.json:
-                json_arg = True if args.json == "1" else args.json
-                self._outputer.json_build_order(ret, json_arg, os.getcwd())
-            else:
-                self._outputer.build_order(ret)
-
         # INSTALL SIMULATION, NODES TO INSTALL
-        elif args.build is not None:
+        if args.build is not None:
             nodes, _ = self._conan.info_nodes_to_build(args.path_or_reference,
                                                        build_modes=args.build,
                                                        settings=args.settings_host,
@@ -717,7 +689,6 @@ class Command(object):
                 self._outputer.json_nodes_to_build(nodes, json_arg, os.getcwd())
             else:
                 self._outputer.nodes_to_build(nodes)
-
         # INFO ABOUT DEPS OF CURRENT PROJECT OR REFERENCE
         else:
             data = self._conan.info(args.path_or_reference,

--- a/conans/client/conan_api.py
+++ b/conans/client/conan_api.py
@@ -688,23 +688,6 @@ class ConanAPIV1(object):
         return ref, profile_host, profile_build, graph_lock, root_ref
 
     @api_method
-    def info_build_order(self, reference, settings=None, options=None, env=None,
-                         profile_names=None, remote_name=None, build_order=None, check_updates=None,
-                         profile_build=None,name=None, version=None, user=None, channel=None):
-        profile_host = ProfileData(profiles=profile_names, settings=settings, options=options,
-                                   env=env)
-        reference, profile_host, profile_build, graph_lock, root_ref = \
-            self._info_args(reference, profile_host, profile_build, name=name,
-                            version=version, user=user, channel=channel)
-        recorder = ActionRecorder()
-        remotes = self.app.load_remotes(remote_name=remote_name, check_updates=check_updates)
-        deps_graph = self.app.graph_manager.load_graph(reference, None, profile_host,
-                                                       profile_build, graph_lock,
-                                                       root_ref, ["missing"],
-                                                       check_updates, False, remotes, recorder)
-        return deps_graph.build_order(build_order)
-
-    @api_method
     def info_nodes_to_build(self, reference, build_modes, settings=None, options=None, env=None,
                             profile_names=None, remote_name=None, check_updates=None,
                             profile_build=None, name=None, version=None, user=None, channel=None):

--- a/conans/client/conan_command_output.py
+++ b/conans/client/conan_command_output.py
@@ -51,22 +51,6 @@ class CommandOutputer(object):
             pref = PackageReference.loads(package_reference)
             self._output.info("%s: %s" % (pref.full_str(), remote_name))
 
-    def build_order(self, info):
-        groups = [[ref.copy_clear_rev() for ref in group] for group in info]
-        msg = ", ".join(str(s) for s in groups)
-        self._output.info(msg)
-
-    def json_build_order(self, info, json_output, cwd):
-        data = {"groups": [[repr(ref.copy_clear_rev()) for ref in group] for group in info]}
-        json_str = json.dumps(data)
-        if json_output is True:  # To the output
-            self._output.write(json_str)
-        else:  # Path to a file
-            cwd = os.path.abspath(cwd or os.getcwd())
-            if not os.path.isabs(json_output):
-                json_output = os.path.join(cwd, json_output)
-            save(json_output, json_str)
-
     def json_output(self, info, json_output, cwd):
         cwd = os.path.abspath(cwd or os.getcwd())
         if not os.path.isabs(json_output):

--- a/conans/client/graph/graph.py
+++ b/conans/client/graph/graph.py
@@ -261,20 +261,6 @@ class DepsGraph(object):
             for node in level:
                 yield node
 
-    def _inverse_closure(self, references):
-        closure = set()
-        current = [n for n in self.nodes if str(n.ref) in references or "ALL" in references]
-        closure.update(current)
-        while current:
-            new_current = set()
-            for n in current:
-                closure.add(n)
-                new_neighs = n.inverse_neighbors()
-                to_add = set(new_neighs).difference(current)
-                new_current.update(to_add)
-            current = new_current
-        return closure
-
     def nodes_to_build(self):
         ret = []
         for node in self.ordered_iterate():

--- a/conans/client/graph/graph.py
+++ b/conans/client/graph/graph.py
@@ -133,16 +133,6 @@ class Node(object):
     def ancestors(self):
         return self._ancestors
 
-    def partial_copy(self):
-        # Used for collapse_graph
-        result = Node(self.ref, self.conanfile, self.context, self.recipe, self.path)
-        result.dependants = set()
-        result.dependencies = []
-        result.binary = self.binary
-        result.remote = self.remote
-        result.binary_remote = self.binary_remote
-        return result
-
     def add_edge(self, edge):
         if edge.src == self:
             if edge not in self.dependencies:
@@ -284,54 +274,6 @@ class DepsGraph(object):
                 new_current.update(to_add)
             current = new_current
         return closure
-
-    def collapse_graph(self):
-        """Computes and return a new graph, that doesn't have duplicated nodes with the same
-        PackageReference. This is the case for build_requires and private requirements
-        """
-        result = DepsGraph()
-        result.add_node(self.root.partial_copy())
-        unique_nodes = {}  # {PackageReference: Node (result, unique)}
-        nodes_map = {self.root: result.root}  # {Origin Node: Result Node}
-        # Add the nodes, without repetition. THe "node.partial_copy()" copies the nodes
-        # without Edges
-        for node in self.nodes:
-            if node.recipe in (RECIPE_CONSUMER, RECIPE_VIRTUAL):
-                continue
-            pref = PackageReference(node.ref, node.package_id)
-            if pref not in unique_nodes:
-                result_node = node.partial_copy()
-                result.add_node(result_node)
-                unique_nodes[pref] = result_node
-            else:
-                result_node = unique_nodes[pref]
-            nodes_map[node] = result_node
-
-        # Compute the new edges of the graph
-        for node in self.nodes:
-            result_node = nodes_map[node]
-            for dep in node.dependencies:
-                src = result_node
-                dst = nodes_map[dep.dst]
-                result.add_edge(src, dst, dep.require)
-            for dep in node.dependants:
-                src = nodes_map[dep.src]
-                dst = result_node
-                result.add_edge(src, dst, dep.require)
-
-        return result
-
-    def build_order(self, references):
-        new_graph = self.collapse_graph()
-        levels = new_graph.inverse_levels()
-        closure = new_graph._inverse_closure(references)
-        result = []
-        for level in reversed(levels):
-            new_level = [n.ref for n in level
-                         if (n in closure and n.recipe not in (RECIPE_CONSUMER, RECIPE_VIRTUAL))]
-            if new_level:
-                result.append(new_level)
-        return result
 
     def nodes_to_build(self):
         ret = []

--- a/conans/test/functional/configuration/profile_test.py
+++ b/conans/test/functional/configuration/profile_test.py
@@ -571,18 +571,12 @@ class ProfileAggregationTest(unittest.TestCase):
         self.assertIn("arch: x86", self.client.out)
 
     def test_info(self):
-
         # The latest declared profile has priority
         self.client.run("create . lib/1.0@user/channel --profile profile1 -pr profile2")
 
         self.client.save({CONANFILE: self.consumer})
         self.client.run("info . --profile profile1 --profile profile2")
         self.assertIn("b786e9ece960c3a76378ca4d5b0d0e922f4cedc1", self.client.out)
-
-        # Build order
-        self.client.run("info . --profile profile1 --profile profile2 "
-                        "--build-order lib/1.0@user/channel")
-        self.assertIn("[lib/1.0@user/channel]", self.client.out)
 
     def test_install(self):
         self.client.run("export . lib/1.0@user/channel")

--- a/conans/test/integration/package_id/full_revision_mode_test.py
+++ b/conans/test/integration/package_id/full_revision_mode_test.py
@@ -52,14 +52,10 @@ class FullRevisionModeTest(unittest.TestCase):
         clientc.run("install . user/testing", assert_error=True)
         self.assertIn("ERROR: Missing prebuilt package for 'libb/0.1@user/testing'", clientc.out)
         clientc.run("install . user/testing --build=libb")
-        clientc.run("info . --build-order=ALL")
 
         clienta.run("create . liba/0.1@user/testing")
         clientc.run("install . user/testing", assert_error=True)
         self.assertIn("ERROR: Missing prebuilt package for 'libb/0.1@user/testing'", clientc.out)
-
-        clienta.run("create . liba/0.1@user/testing")
-        clientc.run("info . --build-order=ALL")
 
     def test_binary_id_recomputation_after_build(self):
         clienta = TestClient()


### PR DESCRIPTION
Changelog: Remove: remove 'conan info --build-order', superseded by lockfiles
Docs: Omit

#tags: slow