### PR TITLE
remove corrupt cache files and retry download 3 times

### DIFF
--- a/conans/client/downloaders/cached_file_downloader.py
+++ b/conans/client/downloaders/cached_file_downloader.py
@@ -55,6 +55,7 @@ class CachedFileDownloader(object):
                     self._file_downloader.download(url=url, file_path=cached_path, md5=md5,
                                                 sha1=sha1, sha256=sha256, **kwargs)
                     clean_dirty(cached_path)
+                    break
                 else:
                     # specific check for corrupted cached files, will log an error
                     # and raise after the third failed download attempt

--- a/conans/client/downloaders/cached_file_downloader.py
+++ b/conans/client/downloaders/cached_file_downloader.py
@@ -48,28 +48,21 @@ class CachedFileDownloader(object):
                 if os.path.exists(cached_path):
                     os.remove(cached_path)
                 clean_dirty(cached_path)
-            
-            for attempt in range(3):
-                if not os.path.exists(cached_path):
-                    set_dirty(cached_path)
-                    self._file_downloader.download(url=url, file_path=cached_path, md5=md5,
-                                                sha1=sha1, sha256=sha256, **kwargs)
-                    clean_dirty(cached_path)
-                    break
-                else:
-                    # specific check for corrupted cached files, will log an error
-                    # and raise after the third failed download attempt
-                    try:
-                        check_checksum(cached_path, md5, sha1, sha256)
-                        break
-                    except ConanException as e:
-                        if attempt == 2:
-                            raise ConanException("%s\nCached downloaded file corrupted: %s"
-                                                % (str(e), cached_path))
-                        else:
-                            logger.error("Cached file corrupt, redownloading")
-                            remove(cached_path)
 
+            if os.path.exists(cached_path):
+                # If exists but it is corrupted, it is removed. Note that v2 downloads
+                # do not have checksums, this only works for user downloads
+                try:
+                    check_checksum(cached_path, md5, sha1, sha256)
+                except ConanException:
+                    logger.error("Cached file corrupt, redownloading")
+                    remove(cached_path)
+
+            if not os.path.exists(cached_path):
+                set_dirty(cached_path)
+                self._file_downloader.download(url=url, file_path=cached_path, md5=md5,
+                                               sha1=sha1, sha256=sha256, **kwargs)
+                clean_dirty(cached_path)
 
             if file_path is not None:
                 file_path = os.path.abspath(file_path)

--- a/conans/client/downloaders/cached_file_downloader.py
+++ b/conans/client/downloaders/cached_file_downloader.py
@@ -7,7 +7,8 @@ from six.moves.urllib_parse import urlsplit, urlunsplit
 
 from conans.client.downloaders.file_downloader import check_checksum
 from conans.errors import ConanException
-from conans.util.files import mkdir, set_dirty, clean_dirty, is_dirty
+from conans.util.log import logger
+from conans.util.files import mkdir, set_dirty, clean_dirty, is_dirty, remove
 from conans.util.locks import SimpleLock
 from conans.util.sha import sha256 as sha256_sum
 
@@ -47,19 +48,27 @@ class CachedFileDownloader(object):
                 if os.path.exists(cached_path):
                     os.remove(cached_path)
                 clean_dirty(cached_path)
-            if not os.path.exists(cached_path):
-                set_dirty(cached_path)
-                self._file_downloader.download(url=url, file_path=cached_path, md5=md5,
-                                               sha1=sha1, sha256=sha256, **kwargs)
-                clean_dirty(cached_path)
-            else:
-                # specific check for corrupted cached files, will raise, but do nothing more
-                # user can report it or "rm -rf cache_folder/path/to/file"
-                try:
-                    check_checksum(cached_path, md5, sha1, sha256)
-                except ConanException as e:
-                    raise ConanException("%s\nCached downloaded file corrupted: %s"
-                                         % (str(e), cached_path))
+            
+            for atempt in range(3):
+                if not os.path.exists(cached_path):
+                    set_dirty(cached_path)
+                    self._file_downloader.download(url=url, file_path=cached_path, md5=md5,
+                                                sha1=sha1, sha256=sha256, **kwargs)
+                    clean_dirty(cached_path)
+                else:
+                    # specific check for corrupted cached files, will log an error
+                    # and raise after the third failed download atempt
+                    try:
+                        check_checksum(cached_path, md5, sha1, sha256)
+                        break
+                    except ConanException as e:
+                        if atempt == 2:
+                            raise ConanException("%s\nCached downloaded file corrupted: %s"
+                                                % (str(e), cached_path))
+                        else:
+                            logger.error("Cached file corrupt, redownloading")
+                            remove(cached_path)
+
 
             if file_path is not None:
                 file_path = os.path.abspath(file_path)

--- a/conans/client/downloaders/cached_file_downloader.py
+++ b/conans/client/downloaders/cached_file_downloader.py
@@ -49,7 +49,7 @@ class CachedFileDownloader(object):
                     os.remove(cached_path)
                 clean_dirty(cached_path)
             
-            for atempt in range(3):
+            for attempt in range(3):
                 if not os.path.exists(cached_path):
                     set_dirty(cached_path)
                     self._file_downloader.download(url=url, file_path=cached_path, md5=md5,
@@ -57,12 +57,12 @@ class CachedFileDownloader(object):
                     clean_dirty(cached_path)
                 else:
                     # specific check for corrupted cached files, will log an error
-                    # and raise after the third failed download atempt
+                    # and raise after the third failed download attempt
                     try:
                         check_checksum(cached_path, md5, sha1, sha256)
                         break
                     except ConanException as e:
-                        if atempt == 2:
+                        if attempt == 2:
                             raise ConanException("%s\nCached downloaded file corrupted: %s"
                                                 % (str(e), cached_path))
                         else:

--- a/conans/test/integration/cache/download_cache_test.py
+++ b/conans/test/integration/cache/download_cache_test.py
@@ -93,9 +93,8 @@ class DownloadCacheTest(unittest.TestCase):
                 continue
             save(f, load(f) + "a")
         client.run("remove * -f")
-        client.run("install mypkg/0.1@user/testing", assert_error=True)
-        self.assertIn("ERROR: md5 signature failed", client.out)
-        self.assertIn("Cached downloaded file corrupted", client.out)
+        client.run("install mypkg/0.1@user/testing")
+        self.assertIn("mypkg/0.1@user/testing: Downloaded package", client.out)
 
     @pytest.mark.skipif(not get_env("TESTING_REVISIONS_ENABLED", False), reason="Only revisions")
     def test_dirty_download(self):


### PR DESCRIPTION
Changelog: Feature: Validate checksum and retry download for corrupted downloaded cache files.
Docs: omit

For testing, it would be cool if this feature could be switched on&off (default on), so the old test could remain with the feature switched off. Or mocking the Server to actually deliver corrupt files could also be an option to improve test coverage of the functionality.

I am also unsure about the logging, I have seen quite a multitude of ways to inform the user, from using the python `logging`, to `_out.warn` up to custom actions in a queue 🤔 

Issue: https://github.com/conan-io/conan/issues/8807

- [x] Refer to the issue that supports this Pull Request.
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 

<sup>**Note:** By default this PR will skip the slower tests and will use a limited set of python versions. Check [here](https://github.com/conan-io/conan/blob/develop/.github/PR_INCREASE_TESTING.md) how to increase the testing level by writing some tags in the current PR body text.</sup>
