### PR TITLE
using CMAKE_CURRENT_LIST_DIR in CMakeToolchain to locate CMakeDeps config files

### DIFF
--- a/conan/tools/cmake/toolchain.py
+++ b/conan/tools/cmake/toolchain.py
@@ -382,21 +382,22 @@ class FindConfigFiles(Block):
         set(CMAKE_PREFIX_PATH {{ cmake_prefix_path }} ${CMAKE_PREFIX_PATH})
         {% endif %}
         {% if android_prefix_path %}
-        set(CMAKE_FIND_ROOT_PATH ${CMAKE_BINARY_DIR} ${CMAKE_FIND_ROOT_PATH})
+        set(CMAKE_FIND_ROOT_PATH {{ android_prefix_path }} ${CMAKE_FIND_ROOT_PATH})
         {% endif %}
         """)
 
     def context(self):
         # To find the generated cmake_find_package finders
         # TODO: Change this for parameterized output location of CMakeDeps
-        cmake_prefix_path = "${CMAKE_BINARY_DIR}"
-        cmake_module_path = "${CMAKE_BINARY_DIR}"
+        cmake_prefix_path = "${CMAKE_CURRENT_LIST_DIR}"
+        cmake_module_path = "${CMAKE_CURRENT_LIST_DIR}"
         find_package_prefer_config = "ON"  # assume ON by default if not specified in conf
         prefer_config = self._conanfile.conf["tools.cmake.cmaketoolchain"].find_package_prefer_config
         if prefer_config is not None and prefer_config.lower() in ("false", "0", "off"):
             find_package_prefer_config = "OFF"
 
-        android_prefix = True if self._conanfile.settings.get_safe("os") == "Android" else False
+        os_ = self._conanfile.settings.get_safe("os")
+        android_prefix = "${CMAKE_CURRENT_LIST_DIR}" if os_ == "Android" else None
         return {"find_package_prefer_config": find_package_prefer_config,
                 "cmake_prefix_path": cmake_prefix_path,
                 "cmake_module_path": cmake_module_path,

--- a/conans/test/integration/toolchain/test_cmake_toolchain.py
+++ b/conans/test/integration/toolchain/test_cmake_toolchain.py
@@ -37,4 +37,3 @@ def test_toolchain_win(compiler, version, runtime):
         assert line.format(minor) in toolchain
     else:
         assert "CMAKE_GENERATOR_TOOLSET" not in toolchain
-


### PR DESCRIPTION
Changelog: Fix: using `CMAKE_CURRENT_LIST_DIR` in `CMakeToolchain` to locate `CMakeDeps` config files.
Docs: Omit

Close https://github.com/conan-io/conan/issues/8808