### PR TITLE
revert cmake linkflags handling

### DIFF
--- a/conan/tools/cmake/cmakedeps.py
+++ b/conan/tools/cmake/cmakedeps.py
@@ -217,15 +217,8 @@ class DepsCppCmake(object):
             return '"%s"' % ";".join(p.replace('\\', '/').replace('$', '\\$') for p in values)
 
         def format_link_flags(link_flags):
-            result = []
-            for f in link_flags:
-                if f.startswith("-"):
-                    result.append(f)
-                else:
-                    if f.startswith("/"):  # msvc link flag
-                        f = f[1:]  # Remove the initial / and use only "-"
-                    result.append("-{}".format(f))
-            return result
+            # Trying to mess with - and / => https://github.com/conan-io/conan/issues/8811
+            return link_flags
 
         self.include_paths = join_paths(cpp_info.include_paths)
         self.include_path = join_paths_single_var(cpp_info.include_paths)

--- a/conans/client/generators/cmake.py
+++ b/conans/client/generators/cmake.py
@@ -35,15 +35,8 @@ class DepsCppCmake(object):
             return '"%s"' % ";".join(p.replace('\\', '/').replace('$', '\\$') for p in values)
 
         def format_link_flags(link_flags):
-            result = []
-            for f in link_flags:
-                if f.startswith("-"):
-                    result.append(f)
-                else:
-                    if f.startswith("/"):  # msvc link flag
-                        f = f[1:]  # Remove the initial / and use only "-"
-                    result.append("-{}".format(f))
-            return result
+            # Trying to mess with - and / => https://github.com/conan-io/conan/issues/8811
+            return link_flags
 
         self.include_paths = join_paths(cpp_info.include_paths)
         self.include_path = join_paths_single_var(cpp_info.include_paths)

--- a/conans/test/functional/generators/cmake_find_package_test.py
+++ b/conans/test/functional/generators/cmake_find_package_test.py
@@ -103,7 +103,7 @@ class Test(ConanFile):
         self.cpp_info.libs.append("fake_lib")
         self.cpp_info.cflags.append("a_flag")
         self.cpp_info.cxxflags.append("a_cxx_flag")
-        self.cpp_info.sharedlinkflags.append("shared_link_flag")
+        self.cpp_info.sharedlinkflags.append("-shared_link_flag")
     """
         client = TestClient()
         client.save({"conanfile.py": conanfile})

--- a/conans/test/unittests/client/generators/cmake_find_package_multi_test.py
+++ b/conans/test/unittests/client/generators/cmake_find_package_multi_test.py
@@ -42,8 +42,9 @@ def test_cmake_find_package_multi_links_flags():
     conanfile.settings.arch = "x86"
 
     cpp_info = CppInfo("mypkg", "dummy_root_folder1")
-    cpp_info.sharedlinkflags = ["/NODEFAULTLIB", "/OTHERFLAG"]
-    cpp_info.exelinkflags = ["/OPT:NOICF"]
+    # https://github.com/conan-io/conan/issues/8811 regression, fix with explicit - instead of /
+    cpp_info.sharedlinkflags = ["-NODEFAULTLIB", "-OTHERFLAG"]
+    cpp_info.exelinkflags = ["-OPT:NOICF"]
     conanfile.deps_cpp_info.add("mypkg", cpp_info)
 
     gen = CMakeFindPackageMultiGenerator(conanfile)

--- a/conans/test/unittests/tools/cmake/test_cmakedeps.py
+++ b/conans/test/unittests/tools/cmake/test_cmakedeps.py
@@ -76,8 +76,9 @@ def test_cmake_deps_links_flags():
     conanfile.settings.arch = "x86"
 
     cpp_info = CppInfo("mypkg", "dummy_root_folder1")
-    cpp_info.sharedlinkflags = ["/NODEFAULTLIB", "/OTHERFLAG"]
-    cpp_info.exelinkflags = ["/OPT:NOICF"]
+    # https://github.com/conan-io/conan/issues/8811 regression, fix with explicit - instead of /
+    cpp_info.sharedlinkflags = ["-NODEFAULTLIB", "-OTHERFLAG"]
+    cpp_info.exelinkflags = ["-OPT:NOICF"]
     conanfile.deps_cpp_info.add("mypkg", cpp_info)
 
     cmakedeps = CMakeDeps(conanfile)


### PR DESCRIPTION
Changelog: Bugfix: Revert regression that replaces first ``/`` by ``-`` in ``cpp_info.xxxxlinkflags`` in _CMake_ generators because it can break passing objects and other paths that start with ``/``.
Docs: Omit

Fix https://github.com/conan-io/conan/issues/8811