### PR TITLE
Add support for "Ninja Multi-Config" CMake generator (#8813)

### DIFF
--- a/conan/tools/cmake/utils.py
+++ b/conan/tools/cmake/utils.py
@@ -7,7 +7,7 @@ from conans.errors import ConanException
 def is_multi_configuration(generator):
     if not generator:
         return False
-    return "Visual" in generator or "Xcode" in generator
+    return "Visual" in generator or "Xcode" in generator or "Multi-Config" in generator
 
 
 def get_generator(conanfile):

--- a/conans/client/build/cmake.py
+++ b/conans/client/build/cmake.py
@@ -226,13 +226,14 @@ class CMake(object):
         context = tools.no_op()
 
         if (is_msvc or is_clangcl) and platform.system() == "Windows":
-            if self.generator in ["Ninja", "NMake Makefiles", "NMake Makefiles JOM"]:
+            if self.generator in ["Ninja", "Ninja Multi-Config",
+                                  "NMake Makefiles", "NMake Makefiles JOM"]:
                 vcvars_dict = tools.vcvars_dict(self._settings, force=True, filter_known_paths=False,
                                                 output=self._conanfile.output)
                 context = _environment_add(vcvars_dict, post=self._append_vcvars)
         elif is_intel:
-            if self.generator in ["Ninja", "NMake Makefiles", "NMake Makefiles JOM",
-                                  "Unix Makefiles"]:
+            if self.generator in ["Ninja", "Ninja Multi-Config",
+                                  "NMake Makefiles", "NMake Makefiles JOM", "Unix Makefiles"]:
                 intel_compilervars_dict = tools.intel_compilervars_dict(self._conanfile, force=True)
                 context = _environment_add(intel_compilervars_dict, post=self._append_vcvars)
         with context:

--- a/conans/client/build/cmake_flags.py
+++ b/conans/client/build/cmake_flags.py
@@ -98,7 +98,7 @@ def get_generator_platform(settings, generator):
 def is_multi_configuration(generator):
     if not generator:
         return False
-    return "Visual" in generator or "Xcode" in generator
+    return "Visual" in generator or "Xcode" in generator or "Multi-Config" in generator
 
 
 def is_toolset_supported(generator):


### PR DESCRIPTION
The "Ninja Multi-Config" generator was added in CMake 3.17. Add
support for recognizing it as multi-config from
is_multi_configuration(), as well as inserting needed envvars as with
regular (single configuration) Ninja usage.

Signed-off-by: Joel Johnson <mrjoel@lixil.net>

Changelog: Fix: Recognize ``Ninja Multi-Config`` as a  CMake multi-configuration generator.
Docs: Omit

- [ ] Refer to the issue that supports this Pull Request.
- [ ] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [X] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [X] I've followed the PEP8 style guides for Python code.
- [X] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 
