### PR TITLE
Check Artifactory service context for conan_build_info --v2

### DIFF
--- a/conans/test/unittests/client/cmd/conan_build_info_test.py
+++ b/conans/test/unittests/client/cmd/conan_build_info_test.py
@@ -2,7 +2,8 @@ import json
 import os
 import textwrap
 import unittest
-from unittest.mock import Mock, patch
+
+from mock import patch, Mock
 
 from conans.build_info.build_info import update_build_info, publish_build_info
 from conans.test.utils.test_files import temp_folder


### PR DESCRIPTION
Changelog: Fix: Check if Artifactory url for publishing the build_info has `artifactory` string as the service context and remove from the API url if it doesn't.
Docs: omit

Closes: https://github.com/conan-io/conan/issues/8802

- [X] Refer to the issue that supports this Pull Request.
- [X] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [X] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [X] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 

<sup>**Note:** By default this PR will skip the slower tests and will use a limited set of python versions. Check [here](https://github.com/conan-io/conan/blob/develop/.github/PR_INCREASE_TESTING.md) how to increase the testing level by writing some tags in the current PR body text.</sup>
