### PR TITLE
Return 'deprecated' attribute in 'conan inspect' command

### DIFF
--- a/conans/client/conan_api.py
+++ b/conans/client/conan_api.py
@@ -302,7 +302,7 @@ class ConanAPIV1(object):
             attributes = ['name', 'version', 'url', 'homepage', 'license', 'author',
                           'description', 'topics', 'generators', 'exports', 'exports_sources',
                           'short_paths', 'apply_env', 'build_policy', 'revision_mode', 'settings',
-                          'options', 'default_options']
+                          'options', 'default_options', 'deprecated']
         for attribute in attributes:
             try:
                 attr = getattr(conanfile, attribute)

--- a/conans/test/integration/command/inspect_test.py
+++ b/conans/test/integration/command/inspect_test.py
@@ -240,6 +240,7 @@ revision_mode: hash
 settings: None
 options: None
 default_options: None
+deprecated: None
 """, client.out)
 
     def test_inspect_filled_attributes(self):
@@ -335,6 +336,7 @@ deprecated: suggestion
                 386: False
                 no_asm: False
                 shared: False
+            deprecated: None
             """), client.out)
 
     def test_mixed_options_instances(self):
@@ -381,6 +383,7 @@ options:
 default_options:
     bar: True
     foo: True
+deprecated: None
 """, client.out)
 
         client.save({"conanfile.py": conanfile.replace("\"foo=True\", \"bar=True\"",
@@ -408,6 +411,7 @@ options:
 default_options:
     bar: True
     foo: True
+deprecated: None
 """, client.out)
 
 

--- a/conans/test/integration/command/inspect_test.py
+++ b/conans/test/integration/command/inspect_test.py
@@ -260,6 +260,7 @@ class Pkg(ConanFile):
     default_options = {"foo": True, "bar": False}
     _private = "Nothing"
     revision_mode = "scm"
+    deprecated = "suggestion"
     def build(self):
         pass
 """
@@ -287,6 +288,7 @@ options:
 default_options:
     bar: False
     foo: True
+deprecated: suggestion
 """, client.out)
 
     def test_default_options_list(self):


### PR DESCRIPTION
Changelog: Fix: Return `deprecated` attribute in `conan inspect` command.
Docs: omit

Required/Expected here: https://github.com/conan-io/c3i_jenkins/issues/257

The deprecated attribute doesn't depend on profile/configuration, if one recipe is marked as deprecated, it is for all configurations. It is safe (and expected IMO) to return this value from `conan inspect` command.