### PR TITLE
Remove not-export argument for conan crete

### DIFF
--- a/conans/client/cmd/export.py
+++ b/conans/client/cmd/export.py
@@ -52,7 +52,7 @@ def check_casing_conflict(cache, ref):
 
 
 def cmd_export(app, conanfile_path, name, version, user, channel, keep_source,
-               export=True, graph_lock=None, ignore_dirty=False):
+               graph_lock=None, ignore_dirty=False):
     """ Export the recipe
     param conanfile_path: the original source directory of the user containing a
                        conanfile.py
@@ -91,13 +91,6 @@ def cmd_export(app, conanfile_path, name, version, user, channel, keep_source,
 
     check_casing_conflict(cache=cache, ref=ref)
     package_layout = cache.package_layout(ref, short_paths=conanfile.short_paths)
-    if not export:
-        metadata = package_layout.load_metadata()
-        recipe_revision = metadata.recipe.revision
-        ref = ref.copy_with_rev(recipe_revision)
-        if graph_lock:
-            graph_lock.update_exported_ref(node_id, ref)
-        return ref
 
     _check_settings_for_warnings(conanfile, output)
 

--- a/conans/client/command.py
+++ b/conans/client/command.py
@@ -327,8 +327,6 @@ class Command(object):
                             help='Do not remove the build folder in local cache. '
                                  'Implies --keep-source. '
                                  'Use this for testing purposes only')
-        parser.add_argument("-ne", "--not-export", default=False, action='store_true',
-                            help='Do not export the conanfile.py')
         parser.add_argument("-tbf", "--test-build-folder", action=OnceArgument,
                             help='Working directory for the build of the test project.')
         parser.add_argument("-tf", "--test-folder", action=OnceArgument,
@@ -365,7 +363,7 @@ class Command(object):
 
             info = self._conan.create(args.path, name, version, user, channel,
                                       args.profile_host, args.settings_host, args.options_host,
-                                      args.env_host, args.test_folder, args.not_export,
+                                      args.env_host, args.test_folder,
                                       args.build, args.keep_source, args.keep_build,
                                       args.remote, args.update,
                                       test_build_folder=args.test_build_folder,

--- a/conans/client/conan_api.py
+++ b/conans/client/conan_api.py
@@ -330,7 +330,7 @@ class ConanAPIV1(object):
     @api_method
     def create(self, conanfile_path, name=None, version=None, user=None, channel=None,
                profile_names=None, settings=None,
-               options=None, env=None, test_folder=None, not_export=False,
+               options=None, env=None, test_folder=None,
                build_modes=None, keep_source=False, keep_build=False,
                remote_name=None, update=False, cwd=None, test_build_folder=None,
                lockfile=None, lockfile_out=None, ignore_dirty=False, profile_build=None):
@@ -360,7 +360,7 @@ class ConanAPIV1(object):
             # Make sure keep_source is set for keep_build
             keep_source = keep_source or keep_build
             new_ref = cmd_export(self.app, conanfile_path, name, version, user, channel, keep_source,
-                                 not not_export, graph_lock=graph_lock,
+                                 graph_lock=graph_lock,
                                  ignore_dirty=ignore_dirty)
 
             self.app.range_resolver.clear_output()  # invalidate version range output


### PR DESCRIPTION
Changelog: Remove: Remove `--not-export` argument for conan create.
Docs: omit
