### PR TITLE
Fix test_config_rm test causing concurren ci failures

### DIFF
--- a/conans/test/integration/conan_api/config_test.py
+++ b/conans/test/integration/conan_api/config_test.py
@@ -1,12 +1,23 @@
+import os
 import unittest
 
+from conans import tools
 from conans.client import conan_api
+from conans.client.cache.cache import CONAN_CONF
+from conans.client.conf import get_default_client_conf
+from conans.test.utils.test_files import temp_folder
+from conans.tools import save
 
 
 class ConfigTest(unittest.TestCase):
 
     def setUp(self):
-        self.api, _, _ = conan_api.ConanAPIV1.factory()
+        tmp = temp_folder()
+        conf = get_default_client_conf()
+        os.mkdir(os.path.join(tmp, ".conan"))
+        save(os.path.join(tmp, ".conan", CONAN_CONF), conf)
+        with tools.environment_append({"CONAN_USER_HOME": tmp}):
+            self.api, _, _ = conan_api.ConanAPIV1.factory()
 
     def test_config_rm(self):
         self.api.config_set("proxies.https", "http://10.10.1.10:1080")


### PR DESCRIPTION
Changelog: omit
Docs: omit

`test_config_rm` was not running on a temporary folder, but directly on the regular conan cache causing [frequent failures](https://ci.conan.io/blue/organizations/jenkins/ConanTestSuite/detail/develop/232/pipeline/) when tests were executed in parallel. Setting a temporary directory to run the test.
