### PR TITLE
CMakeDeps reading name from cmake_find_package_multi too 

### DIFF
--- a/conan/tools/cmake/cmakedeps.py
+++ b/conan/tools/cmake/cmakedeps.py
@@ -552,17 +552,11 @@ endforeach()
     def get_name(self, req):
         ret = req.new_cpp_info.get_property("cmake_target_name", self.name)
         if not ret:
-            # The old cpp info
-            ret = req.cpp_info.get_name(self.name, default_name=False)
-        if not ret:
             ret = req.cpp_info.get_name("cmake_find_package_multi", default_name=False)
         return ret or req.ref.name
 
     def get_filename(self, req):
         ret = req.new_cpp_info.get_property("cmake_file_name", self.name)
-        if not ret:
-            # The old cpp info
-            ret = req.cpp_info.get_filename(self.name, default_name=False)
         if not ret:
             ret = req.cpp_info.get_filename("cmake_find_package_multi", default_name=False)
         return ret or req.ref.name
@@ -574,12 +568,8 @@ endforeach()
             raise KeyError(comp_name)
         ret = req.new_cpp_info.components[comp_name].get_property("cmake_target_name", self.name)
         if not ret:
-            # The old cpp info
-            ret = req.cpp_info.components[comp_name].get_name(self.name, default_name=False)
-        if not ret:
             ret = req.cpp_info.components[comp_name].get_name("cmake_find_package_multi",
                                                               default_name=False)
-
         return ret or comp_name
 
     @property

--- a/conan/tools/cmake/cmakedeps.py
+++ b/conan/tools/cmake/cmakedeps.py
@@ -454,7 +454,7 @@ endforeach()
         {%- for comp_name, comp in components %}
 
         ########## COMPONENT {{ comp_name }} TARGET PROPERTIES ######################################
-
+        conan_message(STATUS "Target declared: '{{ pkg_name }}::{{ comp_name }}'")
         set_property(TARGET {{ pkg_name }}::{{ comp_name }} PROPERTY INTERFACE_LINK_LIBRARIES
                      {%- for config in configs %}
                      $<$<CONFIG:{{config}}>:{{tvalue(pkg_name, comp_name, 'LINK_LIBS', config)}}
@@ -481,6 +481,7 @@ endforeach()
         ########## GLOBAL TARGET PROPERTIES #########################################################
 
         if(NOT {{ pkg_name }}_{{ pkg_name }}_TARGET_PROPERTIES)
+            conan_message(STATUS "Target declared: '{{ pkg_name }}::{{ pkg_name }}'")
             set_property(TARGET {{ pkg_name }}::{{ pkg_name }} APPEND PROPERTY INTERFACE_LINK_LIBRARIES
                          {%- for config in configs %}
                          $<$<CONFIG:{{config}}>:{{ '${'+pkg_name+'_COMPONENTS_'+config.upper()+'}'}}>
@@ -552,14 +553,18 @@ endforeach()
         ret = req.new_cpp_info.get_property("cmake_target_name", self.name)
         if not ret:
             # The old cpp info
-            ret = req.cpp_info.get_name(self.name)
+            ret = req.cpp_info.get_name(self.name, default_name=False)
+        if not ret:
+            ret = req.cpp_info.get_name("cmake_find_package_multi", default_name=False)
         return ret or req.ref.name
 
     def get_filename(self, req):
         ret = req.new_cpp_info.get_property("cmake_file_name", self.name)
         if not ret:
             # The old cpp info
-            ret = req.cpp_info.get_filename(self.name)
+            ret = req.cpp_info.get_filename(self.name, default_name=False)
+        if not ret:
+            ret = req.cpp_info.get_filename("cmake_find_package_multi", default_name=False)
         return ret or req.ref.name
 
     def get_component_name(self, req, comp_name):
@@ -567,11 +572,13 @@ endforeach()
             if req.ref.name == comp_name:  # foo::foo might be referencing the root cppinfo
                 return self.get_name(req)
             raise KeyError(comp_name)
-        ret = req.new_cpp_info.components[comp_name].get_property("cmake_target_name",
-                                                                  self.name)
+        ret = req.new_cpp_info.components[comp_name].get_property("cmake_target_name", self.name)
         if not ret:
             # The old cpp info
-            ret = req.cpp_info.components[comp_name].get_name(self.name)
+            ret = req.cpp_info.components[comp_name].get_name(self.name, default_name=False)
+        if not ret:
+            ret = req.cpp_info.components[comp_name].get_name("cmake_find_package_multi",
+                                                              default_name=False)
 
         return ret or comp_name
 

--- a/conans/model/build_info.py
+++ b/conans/model/build_info.py
@@ -215,20 +215,21 @@ class _CppInfo(object):
 
     # TODO: Deprecate for 2.0. Only cmake and pkg_config generators should access this.
     #  Use get_property for 2.0
-    def get_name(self, generator):
+    def get_name(self, generator, default_name=True):
         property_name = None
         if "cmake" in generator:
             property_name = "cmake_target_name"
         elif "pkg_config" in generator:
             property_name = "pkg_config_name"
-        return self.get_property(property_name, generator) or self.names.get(generator, self._name)
+        return self.get_property(property_name, generator) \
+               or self.names.get(generator, self._name if default_name else None)
 
     # TODO: Deprecate for 2.0. Only cmake generators should access this. Use get_property for 2.0
-    def get_filename(self, generator):
+    def get_filename(self, generator, default_name=True):
         result = self.get_property("cmake_file_name", generator) or self.filenames.get(generator)
         if result:
             return result
-        return self.get_name(generator)
+        return self.get_name(generator, default_name=default_name)
 
     # TODO: Deprecate for 2.0. Use get_property for 2.0
     def get_build_modules(self):
@@ -346,8 +347,8 @@ class CppInfo(_CppInfo):
     def __str__(self):
         return self._ref_name
 
-    def get_name(self, generator):
-        name = super(CppInfo, self).get_name(generator)
+    def get_name(self, generator, default_name=True):
+        name = super(CppInfo, self).get_name(generator, default_name=default_name)
 
         # Legacy logic for pkg_config generator
         from conans.client.generators.pkg_config import PkgConfigGenerator

--- a/conans/test/unittests/tools/cmake/test_cmakedeps.py
+++ b/conans/test/unittests/tools/cmake/test_cmakedeps.py
@@ -26,8 +26,8 @@ def test_cpp_info_name_cmakedeps(using_properties):
         cpp_info.set_property("cmake_target_name", "MySuperPkg1")
         cpp_info.set_property("cmake_file_name", "ComplexFileName1")
     else:
-        cpp_info.names["CMakeDeps"] = "MySuperPkg1"
-        cpp_info.filenames["CMakeDeps"] = "ComplexFileName1"
+        cpp_info.names["cmake_find_package_multi"] = "MySuperPkg1"
+        cpp_info.filenames["cmake_find_package_multi"] = "ComplexFileName1"
 
     conanfile_dep = ConanFile(Mock(), None)
     conanfile_dep.cpp_info = cpp_info
@@ -65,9 +65,9 @@ def test_cpp_info_name_cmakedeps_components(using_properties):
         cpp_info.components["mycomp"].set_property("cmake_target_name", "MySuperPkg1")
         cpp_info.set_property("cmake_file_name", "ComplexFileName1")
     else:
-        cpp_info.names["CMakeDeps"] = "GlobakPkgName1"
-        cpp_info.components["mycomp"].names["CMakeDeps"] = "MySuperPkg1"
-        cpp_info.filenames["CMakeDeps"] = "ComplexFileName1"
+        cpp_info.names["cmake_find_package_multi"] = "GlobakPkgName1"
+        cpp_info.components["mycomp"].names["cmake_find_package_multi"] = "MySuperPkg1"
+        cpp_info.filenames["cmake_find_package_multi"] = "ComplexFileName1"
 
     conanfile_dep = ConanFile(Mock(), None)
     conanfile_dep.cpp_info = cpp_info


### PR DESCRIPTION
Changelog: Feature: The `CMakeDeps` generator will print CMake traces with the declared targets. e.g: `Target declared: 'OpenSSL::Crypto'`.
Docs: omit

ALSO A MINI FEATURE FOR PRINTING THE FOUND (GENERATED) TARGETS FOR THE CONSUMER.