### PR TITLE
fix new environment files with spaces in path

### DIFF
--- a/conan/tools/env/environment.py
+++ b/conan/tools/env/environment.py
@@ -33,7 +33,7 @@ def environment_wrap_command(filename, cmd, cwd=None):
         raise ConanException("Cannot wrap command with different envs, {} - {}".format(bats, shs))
 
     if bats:
-        command = " && ".join(bats)
+        command = " && ".join('"{}"'.format(b) for b in bats)
         return "{} && {}".format(command, cmd)
     elif shs:
         command = " && ".join(". ./{}".format(f) for f in shs)


### PR DESCRIPTION
Changelog: Fix: Allow spaces in the path for new environment files and ``conancvvars.bat`` Visual toolchain file.
Docs: omit