### PR TITLE
Use cmake 3.19 in ci for tests that use Xcode cmake generator

### DIFF
--- a/conans/test/functional/generators/cmake_apple_frameworks_test.py
+++ b/conans/test/functional/generators/cmake_apple_frameworks_test.py
@@ -80,6 +80,7 @@ class CMakeAppleFrameworksTestCase(unittest.TestCase):
         self.t.run("build .")
         self._check_frameworks_found(str(self.t.out))
 
+    @pytest.mark.tool_cmake(version="3.19")
     def test_apple_framework_cmake_multi_xcode(self):
         app_cmakelists = textwrap.dedent("""
             project(Testing CXX)
@@ -299,6 +300,7 @@ class CMakeAppleOwnFrameworksTestCase(unittest.TestCase):
         if not len(settings):
             self.assertIn("Hello World Release!", client.out)
 
+    @pytest.mark.tool_cmake(version="3.19")
     def test_apple_own_framework_cmake_multi(self):
         client = TestClient()
 

--- a/conans/test/functional/generators/cmake_find_package_multi_test.py
+++ b/conans/test/functional/generators/cmake_find_package_multi_test.py
@@ -549,6 +549,7 @@ class TestNoNamespaceTarget:
 
     @pytest.mark.skipif(platform.system() != "Darwin", reason="Requires Macos")
     @pytest.mark.tool_xcode
+    @pytest.mark.tool_cmake(version="3.19")
     def test_multi_generator_macos(self):
         t = self.t
         with t.chdir('multi_macos'):

--- a/conans/test/functional/generators/cmake_multi_test.py
+++ b/conans/test/functional/generators/cmake_multi_test.py
@@ -196,6 +196,7 @@ class HelloConan(ConanFile):
             self.assertIn("FIND HELLO MINSIZEREL!", client.out)
 
     @pytest.mark.skipif(platform.system() not in ["Windows", "Darwin"], reason="Exclude Linux")
+    @pytest.mark.tool_cmake(version="3.19")
     def test_cmake_multi(self):
         client = TestClient()
 

--- a/conans/test/functional/generators/link_order_test.py
+++ b/conans/test/functional/generators/link_order_test.py
@@ -268,26 +268,17 @@ class LinkOrderTest(unittest.TestCase):
     @staticmethod
     def _get_link_order_from_xcode(content):
         libs = []
-        for line in content.splitlines():
-            split_key = 'OTHER_LDFLAGS = " -Wl,-search_paths_first -Wl,-headerpad_max_install_names'
-            if split_key in line.strip():
-                _, links = line.split(split_key)
-                if links.strip() == '";':
-                    continue
-                for it_lib in links.strip().split():
-                    if it_lib.strip() == '";':
-                        continue
-                    if it_lib.startswith("-l"):
-                        libs.append(it_lib[2:].strip('";'))
-                    elif it_lib == "-framework":
-                        continue
-                    else:
-                        try:
-                            _, libname = it_lib.rsplit('/', 1)
-                        except ValueError:
-                            libname = it_lib
-                        finally:
-                            libs.append(libname.strip('";'))
+        start_key = 'OTHER_LDFLAGS = (" -Wl,-search_paths_first -Wl,-headerpad_max_install_names",'
+        end_key = '");'
+        libs_content = content.split(start_key, 1)[1].split(end_key, 1)[0]
+        libs_unstripped = libs_content.split(",")
+        for lib in libs_unstripped:
+            if ".a" in lib:
+                libs.append(lib.strip('"').rsplit('/', 1)[1])
+            elif "-l" in lib:
+                libs.append(lib.strip('"')[2:])
+            elif "-framework" in lib:
+                libs.append(lib.strip('"')[11:])
         return libs
 
     def _create_find_package_project(self, multi):

--- a/conans/test/functional/generators/link_order_test.py
+++ b/conans/test/functional/generators/link_order_test.py
@@ -11,7 +11,7 @@ from conans.model.ref import ConanFileReference
 from conans.test.utils.tools import TestClient
 
 
-@pytest.mark.tool_cmake
+@pytest.mark.tool_cmake(version="3.19")
 class LinkOrderTest(unittest.TestCase):
     """ Check that the link order of libraries is preserved when using CMake generators
         https://github.com/conan-io/conan/issues/6280


### PR DESCRIPTION
Changelog: omit
Docs: omit

CMake XCode generator does not work for latest XCode versions for [versions of CMake <3.19](https://cmake.org/cmake/help/latest/release/3.19.html).