### PR TITLE
AptTool: add repo key before running apt-add-repository (#8857)

### DIFF
--- a/conans/client/tools/system_pm.py
+++ b/conans/client/tools/system_pm.py
@@ -272,11 +272,11 @@ class NullTool(BaseTool):
 
 class AptTool(BaseTool):
     def add_repository(self, repository, repo_key=None):
-        _run(self._runner, "%sapt-add-repository %s" % (self._sudo_str, repository),
-             output=self._output)
         if repo_key:
             _run(self._runner, "wget -qO - %s | %sapt-key add -" % (repo_key, self._sudo_str),
                  output=self._output)
+        _run(self._runner, "%sapt-add-repository %s" % (self._sudo_str, repository),
+             output=self._output)
 
     def update(self):
         _run(self._runner, "%sapt-get update" % self._sudo_str, output=self._output)

--- a/conans/test/unittests/client/tools/system_pm_test.py
+++ b/conans/test/unittests/client/tools/system_pm_test.py
@@ -100,10 +100,10 @@ class SystemPackageToolTest(unittest.TestCase):
                 sudo_cmd = "sudo " if isatty else "sudo -A "
 
             runner = RunnerOrderedMock()
-            runner.commands.append(("{}apt-add-repository {}".format(sudo_cmd, repository), 0))
             if gpg_key:
                 runner.commands.append(
                     ("wget -qO - {} | {}apt-key add -".format(gpg_key, sudo_cmd), 0))
+            runner.commands.append(("{}apt-add-repository {}".format(sudo_cmd, repository), 0))
             if update:
                 runner.commands.append(("{}apt-get update".format(sudo_cmd), 0))
 


### PR DESCRIPTION
Changelog: Bugfix: AptTool: add repo key before running apt-add-repository.
Docs: omit

Closes #8857

In Ubuntu 20.04 (and maybe earlier), the behavior of

    apt-add-repository 'deb https://example.com/repo example main'

is to add the named repository to apt's sources *and* to update the
package index.  If the new repository's package key is not already in
apt's keyring, this will fail.

It is possible to change this behavior by running apt-add-repository -n,
but adding the key before running apt-add-repository also works, doesn't
require new command-line switches, and should be backwards-compatible
with apt-add-repository versions that might not behave as described
above.

- [X] Refer to the issue that supports this Pull Request.
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [X] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [X] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 

<sup>**Note:** By default this PR will skip the slower tests and will use a limited set of python versions. Check [here](https://github.com/conan-io/conan/blob/develop/.github/PR_INCREASE_TESTING.md) how to increase the testing level by writing some tags in the current PR body text.</sup>
