### PR TITLE
autotools: apply unix_path to CONAN_MAKE_PROGRAM

### DIFF
--- a/conans/client/build/autotools_environment.py
+++ b/conans/client/build/autotools_environment.py
@@ -234,7 +234,10 @@ class AutoToolsBuildEnvironment(object):
         if not self._conanfile.should_build:
             return
         conan_v2_error("build_type setting should be defined.", not self._build_type)
-        make_program = os.getenv("CONAN_MAKE_PROGRAM") or make_program or "make"
+        conan_make_program = os.getenv("CONAN_MAKE_PROGRAM")
+        if conan_make_program and self._win_bash:
+            conan_make_program = tools.unix_path(conan_make_program, subsystem)
+        make_program = conan_make_program or make_program or "make"
         with environment_append(vars or self.vars):
             str_args = args_to_string(args)
             cpu_count_option = (("-j%s" % cpu_count(output=self._conanfile.output))

--- a/conans/client/build/autotools_environment.py
+++ b/conans/client/build/autotools_environment.py
@@ -236,7 +236,7 @@ class AutoToolsBuildEnvironment(object):
         conan_v2_error("build_type setting should be defined.", not self._build_type)
         conan_make_program = os.getenv("CONAN_MAKE_PROGRAM")
         if conan_make_program and self._win_bash:
-            conan_make_program = tools.unix_path(conan_make_program, subsystem)
+            conan_make_program = tools.unix_path(conan_make_program, path_flavor=self.subsystem)
         make_program = conan_make_program or make_program or "make"
         with environment_append(vars or self.vars):
             str_args = args_to_string(args)


### PR DESCRIPTION
Changelog: Bugfix: enable use of `make/*` recipe in msys environment

this intends to fix the use of `make/*` recipe in msys environment. [Currently, the error is](https://ci.appveyor.com/project/SpaceIm/conan-libiconv/builds/38884285/job/lrjjsifc5m39chyo#L772):
```
libiconv/1.16@SpaceIm/testing: run_in_windows_bash: "C:\Program Files\Git\usr\bin\bash.exe" --login -c ^"cd \^"/c/users/appveyor/.conan/data/libiconv/1.16/spaceim/testing/build/dbc97e02589c20e3ca37b15d05c8e5853fae244f/source_subfolder\^" ^&^& PATH=\^"/c/users/appveyor/.conan/data/mingw_installer/1.0/conan/stable/package/4b8f5a096ecfd6aabff608521169f167b01837ec/bin:$PATH\^" ^&^& C:\Users\appveyor\.conan\data\make\4.2.1\_\_\package\0a420ff5c47119e668867cdb51baff0eca1fdb68\bin\gnumake.exe -j2 ^"
/usr/bin/bash: C:Usersappveyor.conandatamake4.2.1__package0a420ff5c47119e668867cdb51baff0eca1fdb68bingnumake.exe: command not found
```

- [ ] Refer to the issue that supports this Pull Request.
- [ ] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [X] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [X] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 

<sup>**Note:** By default this PR will skip the slower tests and will use a limited set of python versions. Check [here](https://github.com/conan-io/conan/blob/develop/.github/PR_INCREASE_TESTING.md) how to increase the testing level by writing some tags in the current PR body text.</sup>

CC @SpaceIm