### PR TITLE
cmaketoolchain ninja support

### DIFF
--- a/conan/tools/cmake/cmake.py
+++ b/conan/tools/cmake/cmake.py
@@ -102,7 +102,8 @@ class CMake(object):
 
         self._conanfile.output.info("CMake command: %s" % command)
         with chdir(build_folder):
-            self._conanfile.run(command)
+            vcvars = os.path.join(self._conanfile.install_folder, "conanvcvars")
+            self._conanfile.run(command, env=["conanbuildenv", vcvars])
 
     def _build(self, build_type=None, target=None):
         bf = self._conanfile.build_folder
@@ -131,7 +132,8 @@ class CMake(object):
         arg_list = " ".join(filter(None, arg_list))
         command = "%s --build %s" % (self._cmake_program, arg_list)
         self._conanfile.output.info("CMake command: %s" % command)
-        self._conanfile.run(command)
+        vcvars = os.path.join(self._conanfile.install_folder, "conanvcvars")
+        self._conanfile.run(command, env=["conanbuildenv", vcvars])
 
     def build(self, build_type=None, target=None):
         if not self._conanfile.should_build:

--- a/conans/test/assets/cmake.py
+++ b/conans/test/assets/cmake.py
@@ -4,7 +4,8 @@ from jinja2 import Template
 
 
 def gen_cmakelists(language="CXX", verify=True, project="project", libname="mylibrary",
-                   libsources=None, appname="myapp", appsources=None, cmake_version="3.15"):
+                   libsources=None, appname="myapp", appsources=None, cmake_version="3.15",
+                   install=False):
     """
     language: C, C++, C/C++
     project: the project name
@@ -31,6 +32,10 @@ def gen_cmakelists(language="CXX", verify=True, project="project", libname="myli
         {% if appsources and libsources %}
         target_link_libraries({{appname}} {{libname}})
         {% endif %}
+
+        {% if install %}
+        install(TARGETS {{appname}} {{libname}} DESTINATION ".")
+        {% endif %}
         """)
 
     t = Template(cmake, trim_blocks=True, lstrip_blocks=True)
@@ -41,5 +46,6 @@ def gen_cmakelists(language="CXX", verify=True, project="project", libname="myli
                      "libsources": libsources,
                      "appname": appname,
                      "appsources": appsources,
-                     "cmake_version": cmake_version
+                     "cmake_version": cmake_version,
+                     "install": install
                      })

--- a/conans/test/integration/configuration/conf/test_conf_profile.py
+++ b/conans/test/integration/configuration/conf/test_conf_profile.py
@@ -17,7 +17,7 @@ def client():
             settings = "os", "arch", "compiler", "build_type"
             generators = "CMakeToolchain"
 
-            def run(self, cmd):  # INTERCEPTOR of running
+            def run(self, cmd, env):  # INTERCEPTOR of running
                 self.output.info("RECIPE-RUN: {}".format(cmd))
 
             def build(self):


### PR DESCRIPTION
Changelog: Feature: Add support to ``tools.cmake.CMake`` for Ninja toolchain defined with ``CMakeToolchain``.
Docs: Omit
