### PR TITLE
Try to fix LNK1318  random failures in ci for windows nodes

### DIFF
--- a/conans/test/conftest.py
+++ b/conans/test/conftest.py
@@ -1,5 +1,6 @@
 import os
 import platform
+import uuid
 
 import pytest
 
@@ -136,8 +137,11 @@ def add_tool(request):
             tool_env = _get_tool_environment(tools_environments, tool_name, platform.system())
             if tool_env:
                 tools_env_vars.update(tool_env)
+        # To fix random failures in CI because of this: https://issues.jenkins.io/browse/JENKINS-9104
+        if "visual_studio" in mark.name:
+            tools_env_vars.update({'_MSPDBSRV_ENDPOINT_': str(uuid.uuid4())})
 
-    if tools_paths:
+    if tools_paths or tools_env_vars:
         tools_paths.append(os.environ["PATH"])
         temp_env = {'PATH': os.pathsep.join(tools_paths)}
         old_environ = dict(os.environ)


### PR DESCRIPTION
Changelog: omit
Docs: omit

We have been getting random `LNK1318` failures in the Windows nodes for Conan Jenkins ci. Looks like a [known issue](https://github.com/rust-lang/rust/issues/33145#issuecomment-214561730
) and seems like setting the undocumented `_MSPDBSRV_ENDPOINT_` variable to [an unique value for each parallel build could fix this](https://issues.jenkins.io/browse/JENKINS-9104).

First attempt was fixing in CI but as tests are also parallelised at pytest level we should fix this in Conan test suite.

#TAGS: slow