### PR TITLE
[fix] Respect order of declared directories when using components

### DIFF
--- a/conans/model/build_info.py
+++ b/conans/model/build_info.py
@@ -560,10 +560,13 @@ class DepCppInfo(object):
         values = getattr(self, "_%s" % item)
         if values is not None:
             return values
-        values = getattr(self._cpp_info, item)
         if self._cpp_info.components:
+            values = getattr(self._cpp_info, item)
+            values.clear()  # Get only the value type to be able to aggregate it
             for component in self._get_sorted_components().values():
                 values = agg_func(values, getattr(component, item))
+        else:
+            values = getattr(self._cpp_info, item)
         setattr(self, "_%s" % item, values)
         return values
 

--- a/conans/model/build_info.py
+++ b/conans/model/build_info.py
@@ -556,15 +556,27 @@ class DepCppInfo(object):
             attr = self._cpp_info.__getattr__(item)
         return attr
 
-    def _aggregated_values(self, item, agg_func=merge_lists):
+    def _aggregated_dict_values(self, item):
         values = getattr(self, "_%s" % item)
         if values is not None:
             return values
         if self._cpp_info.components:
-            values = getattr(self._cpp_info, item)
-            values.clear()  # Get only the value type to be able to aggregate it
+            values = {}
             for component in self._get_sorted_components().values():
-                values = agg_func(values, getattr(component, item))
+                values = merge_dicts(values, getattr(component, item))
+        else:
+            values = getattr(self._cpp_info, item)
+        setattr(self, "_%s" % item, values)
+        return values
+
+    def _aggregated_list_values(self, item):
+        values = getattr(self, "_%s" % item)
+        if values is not None:
+            return values
+        if self._cpp_info.components:
+            values = []
+            for component in self._get_sorted_components().values():
+                values = merge_lists(values, getattr(component, item))
         else:
             values = getattr(self._cpp_info, item)
         setattr(self, "_%s" % item, values)
@@ -617,71 +629,71 @@ class DepCppInfo(object):
 
     @property
     def build_modules_paths(self):
-        return self._aggregated_values("build_modules_paths", agg_func=merge_dicts)
+        return self._aggregated_dict_values("build_modules_paths")
 
     @property
     def include_paths(self):
-        return self._aggregated_values("include_paths")
+        return self._aggregated_list_values("include_paths")
 
     @property
     def lib_paths(self):
-        return self._aggregated_values("lib_paths")
+        return self._aggregated_list_values("lib_paths")
 
     @property
     def src_paths(self):
-        return self._aggregated_values("src_paths")
+        return self._aggregated_list_values("src_paths")
 
     @property
     def bin_paths(self):
-        return self._aggregated_values("bin_paths")
+        return self._aggregated_list_values("bin_paths")
 
     @property
     def build_paths(self):
-        return self._aggregated_values("build_paths")
+        return self._aggregated_list_values("build_paths")
 
     @property
     def res_paths(self):
-        return self._aggregated_values("res_paths")
+        return self._aggregated_list_values("res_paths")
 
     @property
     def framework_paths(self):
-        return self._aggregated_values("framework_paths")
+        return self._aggregated_list_values("framework_paths")
 
     @property
     def libs(self):
-        return self._aggregated_values("libs")
+        return self._aggregated_list_values("libs")
 
     @property
     def system_libs(self):
-        return self._aggregated_values("system_libs")
+        return self._aggregated_list_values("system_libs")
 
     @property
     def frameworks(self):
-        return self._aggregated_values("frameworks")
+        return self._aggregated_list_values("frameworks")
 
     @property
     def defines(self):
-        return self._aggregated_values("defines")
+        return self._aggregated_list_values("defines")
 
     @property
     def cxxflags(self):
-        return self._aggregated_values("cxxflags")
+        return self._aggregated_list_values("cxxflags")
 
     @property
     def cflags(self):
-        return self._aggregated_values("cflags")
+        return self._aggregated_list_values("cflags")
 
     @property
     def sharedlinkflags(self):
-        return self._aggregated_values("sharedlinkflags")
+        return self._aggregated_list_values("sharedlinkflags")
 
     @property
     def exelinkflags(self):
-        return self._aggregated_values("exelinkflags")
+        return self._aggregated_list_values("exelinkflags")
 
     @property
     def requires(self):
-        return self._aggregated_values("requires")
+        return self._aggregated_list_values("requires")
 
 
 class DepsCppInfo(_BaseDepsCppInfo):

--- a/conans/test/unittests/model/build_info/components_test.py
+++ b/conans/test/unittests/model/build_info/components_test.py
@@ -416,16 +416,12 @@ class CppInfoComponentsTest(unittest.TestCase):
                              list(deps_cpp_info["my_lib"].components["Component"].include_paths))
 
     def test_deps_cpp_info_components_includedirs(self):
-        folder = temp_folder()
-        info = CppInfo("my_lib", folder)
-        # Create files so paths are not cleared
-        save(os.path.join(folder, "lib", "kk.lib"), "")
-        save(os.path.join(folder, "include", "kk.h"), "")
-        info.components["component"].includedirs = ["lib", "include"]
+        info = CppInfo("my_lib", "root")
+        info.components["component"].includedirs = ["include1", "include2"]
+        info.components["component"].filter_empty = False
         dep_info = DepCppInfo(info)
-        expected = [os.path.join(folder, "lib"), os.path.join(folder, "include")]
+        expected = [os.path.join("root", "include1"), os.path.join("root", "include2")]
         self.assertListEqual(expected, list(dep_info.include_paths))
         deps_cpp_info = DepsCppInfo()
         deps_cpp_info.add("my_lib", dep_info)
-        expected = [os.path.join(folder, "lib"), os.path.join(folder, "include")]
         self.assertListEqual(expected, list(deps_cpp_info.includedirs))

--- a/conans/test/unittests/model/build_info/components_test.py
+++ b/conans/test/unittests/model/build_info/components_test.py
@@ -414,3 +414,18 @@ class CppInfoComponentsTest(unittest.TestCase):
         self.assertListEqual([os.path.join(folder, "include")], list(deps_cpp_info.include_paths))
         self.assertListEqual([os.path.join(folder, "include")],
                              list(deps_cpp_info["my_lib"].components["Component"].include_paths))
+
+    def test_deps_cpp_info_components_includedirs(self):
+        folder = temp_folder()
+        info = CppInfo("my_lib", folder)
+        # Create files so paths are not cleared
+        save(os.path.join(folder, "lib", "kk.lib"), "")
+        save(os.path.join(folder, "include", "kk.h"), "")
+        info.components["component"].includedirs = ["lib", "include"]
+        dep_info = DepCppInfo(info)
+        expected = [os.path.join(folder, "lib"), os.path.join(folder, "include")]
+        self.assertListEqual(expected, list(dep_info.include_paths))
+        deps_cpp_info = DepsCppInfo()
+        deps_cpp_info.add("my_lib", dep_info)
+        expected = [os.path.join(folder, "lib"), os.path.join(folder, "include")]
+        self.assertListEqual(expected, list(deps_cpp_info.includedirs))


### PR DESCRIPTION
Changelog: BugFix: Respect order of declared directories when using components.
Docs: omit

- [x] Refer to the issue that supports this Pull Request: close #8904
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [x] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 

<sup>**Note:** By default this PR will skip the slower tests and will use a limited set of python versions. Check [here](https://github.com/conan-io/conan/blob/develop/.github/PR_INCREASE_TESTING.md) how to increase the testing level by writing some tags in the current PR body text.</sup>
