### PR TITLE
minor refactor genconanfile

### DIFF
--- a/conans/test/assets/genconanfile.py
+++ b/conans/test/assets/genconanfile.py
@@ -282,12 +282,14 @@ class GenConanfile(object):
 
     @property
     def _package_method(self):
-        return self._package_files or self._package_files_env or self._package_files_link
+        return (self._package_lines or self._package_files or self._package_files_env or
+                self._package_files_link)
 
     @property
     def _package_method_render(self):
         lines = []
-        lines.extend("        {}".format(line) for line in self._package_lines)
+        if self._package_lines:
+            lines.extend("        {}".format(line) for line in self._package_lines)
         if self._package_files:
             lines = ['        tools.save(os.path.join(self.package_folder, "{}"), "{}")'
                      ''.format(key, value)
@@ -359,17 +361,17 @@ class GenConanfile(object):
 
     @property
     def _short_paths_render(self):
-        return "    short_paths = {}".format(str(self._short_path))
+        return "short_paths = {}".format(str(self._short_path))
 
     @property
     def _exports_sources_render(self):
         line = ", ".join('"{}"'.format(e) for e in self._exports_sources)
-        return "    exports_sources = {}".format(line)
+        return "exports_sources = {}".format(line)
 
     @property
     def _exports_render(self):
         line = ", ".join('"{}"'.format(e) for e in self._exports)
-        return "    exports = {}".format(line)
+        return "exports = {}".format(line)
 
     def __repr__(self):
         ret = []

--- a/conans/test/assets/genconanfile.py
+++ b/conans/test/assets/genconanfile.py
@@ -39,12 +39,12 @@ class GenConanfile(object):
         self._package_info = None
         self._package_id_lines = None
         self._test_lines = None
-        self._short_path = None
+        self._short_paths = None
         self._exports_sources = None
         self._exports = None
 
     def with_short_paths(self, value):
-        self._short_path = value
+        self._short_paths = value
         return self
 
     def with_name(self, name):
@@ -361,7 +361,7 @@ class GenConanfile(object):
 
     @property
     def _short_paths_render(self):
-        return "short_paths = {}".format(str(self._short_path))
+        return "short_paths = {}".format(str(self._short_paths))
 
     @property
     def _exports_sources_render(self):

--- a/conans/test/assets/genconanfile.py
+++ b/conans/test/assets/genconanfile.py
@@ -19,29 +19,29 @@ class GenConanfile(object):
         self._imports = ["from conans import ConanFile"]
         self._name = name
         self._version = version
-        self._settings = []
-        self._options = {}
-        self._generators = []
-        self._default_options = {}
-        self._provides = []
+        self._settings = None
+        self._options = None
+        self._generators = None
+        self._default_options = None
+        self._provides = None
         self._deprecated = None
-        self._package_lines = []
-        self._package_files = {}
-        self._package_files_env = {}
-        self._package_files_link = {}
-        self._build_messages = []
-        self._scm = {}
-        self._requires = []
-        self._requirements = []
-        self._build_requires = []
-        self._build_requirements = []
+        self._package_lines = None
+        self._package_files = None
+        self._package_files_env = None
+        self._package_files_link = None
+        self._build_messages = None
+        self._scm = None
+        self._requires = None
+        self._requirements = None
+        self._build_requires = None
+        self._build_requirements = None
         self._revision_mode = None
-        self._package_info = {}
-        self._package_id_lines = []
-        self._test_lines = []
+        self._package_info = None
+        self._package_id_lines = None
+        self._test_lines = None
         self._short_path = None
-        self._exports_sources = []
-        self._exports = []
+        self._exports_sources = None
+        self._exports = None
 
     def with_short_paths(self, value):
         self._short_path = value
@@ -56,6 +56,7 @@ class GenConanfile(object):
         return self
 
     def with_provides(self, provides):
+        self._provides = self._provides or []
         self._provides.append(provides)
         return self
 
@@ -72,20 +73,24 @@ class GenConanfile(object):
         return self
 
     def with_generator(self, generator):
+        self._generators = self._generators or []
         self._generators.append(generator)
         return self
 
     def with_exports_sources(self, *exports):
+        self._exports_sources = self._exports_sources or []
         for export in exports:
             self._exports_sources.append(export)
         return self
 
     def with_exports(self, *exports):
+        self._exports = self._exports or []
         for export in exports:
             self._exports.append(export)
         return self
 
     def with_require(self, ref, private=False, override=False):
+        self._requires = self._requires or []
         ref_str = ref.full_str() if isinstance(ref, ConanFileReference) else ref
         self._requires.append((ref_str, private, override))
         return self
@@ -96,17 +101,20 @@ class GenConanfile(object):
         return self
 
     def with_requirement(self, ref, private=False, override=False):
+        self._requirements = self._requirements or []
         ref_str = ref.full_str() if isinstance(ref, ConanFileReference) else ref
         self._requirements.append((ref_str, private, override))
         return self
 
     def with_build_requires(self, *refs):
+        self._build_requires = self._build_requires or []
         for ref in refs:
             ref_str = ref.full_str() if isinstance(ref, ConanFileReference) else ref
             self._build_requires.append(ref_str)
         return self
 
     def with_build_requirement(self, ref, force_host_context=False):
+        self._build_requirements = self._build_requirements or []
         ref_str = ref.full_str() if isinstance(ref, ConanFileReference) else ref
         self._build_requirements.append((ref_str, force_host_context))
         return self
@@ -117,24 +125,31 @@ class GenConanfile(object):
         return self
 
     def with_setting(self, setting):
+        self._settings = self._settings or []
         self._settings.append(setting)
         return self
 
     def with_settings(self, *settings):
+        self._settings = self._settings or []
         self._settings.extend(settings)
         return self
 
     def with_option(self, option_name, values):
+        self._options = self._options or {}
         self._options[option_name] = values
         return self
 
     def with_default_option(self, option_name, value):
+        self._default_options = self._default_options or {}
         self._default_options[option_name] = value
         return self
 
     def with_package_file(self, file_name, contents=None, env_var=None, link=None):
         if not contents and not env_var:
             raise Exception("Specify contents or env_var")
+        self._package_files = self._package_files or {}
+        self._package_files_link = self._package_files_link or {}
+        self._package_files_env = self._package_files_env or {}
         self.with_import("import os")
         self.with_import("from conans import tools")
         if contents:
@@ -146,17 +161,20 @@ class GenConanfile(object):
         return self
 
     def with_package(self, *lines):
+        self._package_lines = self._package_lines or []
         for line in lines:
             self._package_lines.append(line)
         return self
 
     def with_build_msg(self, msg):
+        self._build_messages = self._build_messages or []
         self._build_messages.append(msg)
         return self
 
     def with_package_info(self, cpp_info=None, env_info=None):
         assert isinstance(cpp_info, dict), "cpp_info ({}) expects dict".format(type(cpp_info))
         assert isinstance(env_info, dict), "env_info ({}) expects dict".format(type(env_info))
+        self._package_info = self._package_info or {}
         if cpp_info:
             self._package_info["cpp_info"] = cpp_info
         if env_info:
@@ -164,87 +182,66 @@ class GenConanfile(object):
         return self
 
     def with_package_id(self, line):
+        self._package_id_lines = self._package_id_lines or []
         self._package_id_lines.append(line)
         return self
 
     def with_test(self, line):
+        self._test_lines = self._test_lines or []
         self._test_lines.append(line)
         return self
 
     @property
-    def _name_line(self):
-        if not self._name:
-            return ""
+    def _name_render(self):
         return "name = '{}'".format(self._name)
 
     @property
-    def _version_line(self):
-        if not self._version:
-            return ""
+    def _version_render(self):
         return "version = '{}'".format(self._version)
 
     @property
-    def _provides_line(self):
-        if not self._provides:
-            return ""
+    def _provides_render(self):
         line = ", ".join('"{}"'.format(provide) for provide in self._provides)
         return "provides = {}".format(line)
 
     @property
-    def _deprecated_line(self):
-        if not self._deprecated:
-            return ""
+    def _deprecated_render(self):
         return "deprecated = {}".format(self._deprecated)
 
     @property
-    def _scm_line(self):
-        if not self._scm:
-            return ""
+    def _scm_render(self):
         line = ", ".join('"%s": "%s"' % (k, v) for k, v in self._scm.items())
         return "scm = {%s}" % line
 
     @property
-    def _generators_line(self):
-        if not self._generators:
-            return ""
+    def _generators_render(self):
         line = ", ".join('"{}"'.format(generator) for generator in self._generators)
         return "generators = {}".format(line)
 
     @property
-    def _revision_mode_line(self):
-        if not self._revision_mode:
-            return ""
+    def _revision_mode_render(self):
         line = "revision_mode=\"{}\"".format(self._revision_mode)
         return line
 
     @property
-    def _settings_line(self):
-        if not self._settings:
-            return ""
+    def _settings_render(self):
         line = ", ".join('"%s"' % s for s in self._settings)
         return "settings = {}".format(line)
 
     @property
-    def _options_line(self):
-        if not self._options:
-            return ""
+    def _options_render(self):
         line = ", ".join('"%s": %s' % (k, v) for k, v in self._options.items())
         tmp = "options = {%s}" % line
         return tmp
 
     @property
-    def _default_options_line(self):
-        if not self._default_options:
-            return ""
+    def _default_options_render(self):
         line = ", ".join('"%s": %s' % (k, v) for k, v in self._default_options.items())
         tmp = "default_options = {%s}" % line
         return tmp
 
     @property
-    def _build_requirements_method(self):
-        if not self._build_requirements:
-            return ""
-
+    def _build_requirements_render(self):
         lines = []
         for ref, force_host_context in self._build_requirements:
             force_host = ", force_host_context=True" if force_host_context else ""
@@ -252,17 +249,13 @@ class GenConanfile(object):
         return "def build_requirements(self):\n{}\n".format("\n".join(lines))
 
     @property
-    def _build_requires_line(self):
-        if not self._build_requires:
-            return ""
+    def _build_requires_render(self):
         line = ", ".join(['"{}"'.format(r) for r in self._build_requires])
         tmp = "build_requires = %s" % line
         return tmp
 
     @property
-    def _requires_line(self):
-        if not self._requires:
-            return ""
+    def _requires_render(self):
         items = []
         for ref, private, override in self._requires:
             if private or override:
@@ -275,10 +268,7 @@ class GenConanfile(object):
         return tmp
 
     @property
-    def _requirements_method(self):
-        if not self._requirements:
-            return ""
-
+    def _requirements_render(self):
         lines = []
         for ref, private, override in self._requirements:
             private_str = ", private=True" if private else ""
@@ -292,6 +282,10 @@ class GenConanfile(object):
 
     @property
     def _package_method(self):
+        return self._package_files or self._package_files_env or self._package_files_link
+
+    @property
+    def _package_method_render(self):
         lines = []
         lines.extend("        {}".format(line) for line in self._package_lines)
         if self._package_files:
@@ -318,7 +312,7 @@ class GenConanfile(object):
     """.format("\n".join(lines))
 
     @property
-    def _build_method(self):
+    def _build_messages_render(self):
         if not self._build_messages:
             return ""
         lines = ['        self.output.warn("{}")'.format(m) for m in self._build_messages]
@@ -328,9 +322,7 @@ class GenConanfile(object):
     """.format("\n".join(lines))
 
     @property
-    def _package_info_method(self):
-        if not self._package_info:
-            return ""
+    def _package_info_render(self):
         lines = []
         if "cpp_info" in self._package_info:
             for k, v in self._package_info["cpp_info"].items():
@@ -351,9 +343,7 @@ class GenConanfile(object):
         """.format("\n".join(lines))
 
     @property
-    def _package_id_method(self):
-        if not self._package_id_lines:
-            return ""
+    def _package_id_lines_render(self):
         lines = ['        {}'.format(line) for line in self._package_id_lines]
         return """
     def package_id(self):
@@ -361,62 +351,41 @@ class GenConanfile(object):
         """.format("\n".join(lines))
 
     @property
-    def _test_method(self):
+    def _test_lines_render(self):
         if not self._test_lines:
             return ""
         lines = ['', '    def test(self):'] + ['        %s' % m for m in self._test_lines]
         return "\n".join(lines)
 
+    @property
+    def _short_paths_render(self):
+        return "    short_paths = {}".format(str(self._short_path))
+
+    @property
+    def _exports_sources_render(self):
+        line = ", ".join('"{}"'.format(e) for e in self._exports_sources)
+        return "    exports_sources = {}".format(line)
+
+    @property
+    def _exports_render(self):
+        line = ", ".join('"{}"'.format(e) for e in self._exports)
+        return "    exports = {}".format(line)
+
     def __repr__(self):
         ret = []
         ret.extend(self._imports)
         ret.append("class HelloConan(ConanFile):")
-        if self._name_line:
-            ret.append("    {}".format(self._name_line))
-        if self._version_line:
-            ret.append("    {}".format(self._version_line))
-        if self._provides_line:
-            ret.append("    {}".format(self._provides_line))
-        if self._deprecated_line:
-            ret.append("    {}".format(self._deprecated_line))
-        if self._short_path is not None:
-            ret.append("    short_paths = {}".format(str(self._short_path)))
-        if self._exports_sources:
-            line = ", ".join('"{}"'.format(e) for e in self._exports_sources)
-            ret.append("    exports_sources = {}".format(line))
-        if self._exports:
-            line = ", ".join('"{}"'.format(e) for e in self._exports)
-            ret.append("    exports = {}".format(line))
-        if self._generators_line:
-            ret.append("    {}".format(self._generators_line))
-        if self._requires_line:
-            ret.append("    {}".format(self._requires_line))
-        if self._build_requires_line:
-            ret.append("    {}".format(self._build_requires_line))
-        if self._requirements_method:
-            ret.append("    {}".format(self._requirements_method))
-        if self._build_requirements_method:
-            ret.append("    {}".format(self._build_requirements_method))
-        if self._scm:
-            ret.append("    {}".format(self._scm_line))
-        if self._revision_mode_line:
-            ret.append("    {}".format(self._revision_mode_line))
-        if self._settings_line:
-            ret.append("    {}".format(self._settings_line))
-        if self._options_line:
-            ret.append("    {}".format(self._options_line))
-        if self._default_options_line:
-            ret.append("    {}".format(self._default_options_line))
-        if self._build_method:
-            ret.append("    {}".format(self._build_method))
-        if self._package_method:
-            ret.append("    {}".format(self._package_method))
-        if self._package_info_method:
-            ret.append("    {}".format(self._package_info_method))
-        if self._package_id_lines:
-            ret.append("    {}".format(self._package_id_method))
-        if self._test_method:
-            ret.append("    {}".format(self._test_method))
+
+        for member in ("name", "version", "provides", "deprecated", "short_paths", "exports_sources",
+                       "exports", "generators", "requires", "build_requires", "requirements",
+                       "build_requirements", "scm", "revision_mode", "settings", "options",
+                       "default_options", "build_messages", "package_method", "package_info",
+                       "package_id_lines", "test_lines"
+                       ):
+            v = getattr(self, "_{}".format(member), None)
+            if v is not None:
+                ret.append("    {}".format(getattr(self, "_{}_render".format(member))))
+
         if ret[-1] == "class HelloConan(ConanFile):":
             ret.append("    pass")
         return "\n".join(ret)

--- a/conans/test/integration/cache/path_limit_test.py
+++ b/conans/test/integration/cache/path_limit_test.py
@@ -197,6 +197,7 @@ class PathLengthLimitTest(unittest.TestCase):
     def test_basic_disabled(self):
         client = TestClient()
         conanfile = GenConanfile().with_short_paths(True)
+        print(conanfile)
         client.save({"conanfile.py": conanfile})
 
         client.run("create . lib/0.1@user/channel")

--- a/conans/test/integration/cache/path_limit_test.py
+++ b/conans/test/integration/cache/path_limit_test.py
@@ -197,7 +197,6 @@ class PathLengthLimitTest(unittest.TestCase):
     def test_basic_disabled(self):
         client = TestClient()
         conanfile = GenConanfile().with_short_paths(True)
-        print(conanfile)
         client.save({"conanfile.py": conanfile})
 
         client.run("create . lib/0.1@user/channel")

--- a/conans/test/integration/deprecated/test_deprecated.py
+++ b/conans/test/integration/deprecated/test_deprecated.py
@@ -6,7 +6,7 @@ from conans.test.utils.tools import TestClient, GenConanfile
 class DeprecatedTestCase(unittest.TestCase):
     def test_no_deprecated(self):
         t = TestClient()
-        t.save({'taskflow.py': GenConanfile("cpp-taskflow", "1.0").with_deprecated("")})
+        t.save({'taskflow.py': GenConanfile("cpp-taskflow", "1.0").with_deprecated("''")})
         t.run("create taskflow.py")
 
         self.assertNotIn("Please, consider changing your requirements.", t.out)


### PR DESCRIPTION
Changelog: Omit
Docs: Omit

Just a small refactor of GenConanfile, to normalize the namings of the variables, there was a bit of confusion with "line", "method", and what everything meant.