### PR TITLE
[fix] build_modules were failing for markdown generator

### DIFF
--- a/conans/client/generators/markdown.py
+++ b/conans/client/generators/markdown.py
@@ -228,7 +228,10 @@ class MarkdownGenerator(Generator):
         template = env.get_template('package.md')
 
         def read_pkg_file(filename):
-            return open(filename, 'r').read()
+            try:
+                return open(filename, 'r').read()
+            except IOError:
+                return '# Error reading file content. Please report.'
 
         env.filters['read_pkg_file'] = read_pkg_file
 

--- a/conans/test/integration/generators/markdown_test.py
+++ b/conans/test/integration/generators/markdown_test.py
@@ -25,3 +25,31 @@ class MarkDownGeneratorTest(unittest.TestCase):
 
         self.assertIn("Generates the file FindFooBar.cmake", content)
         self.assertIn("find_package(FooBar)", content)
+
+    def test_with_build_modules(self):
+        conanfile = textwrap.dedent("""
+                    import os
+                    from conans import ConanFile
+
+                    class HelloConan(ConanFile):
+                        exports_sources = 'bm.cmake'
+                        def package(self):
+                            self.copy('bm.cmake', dst='lib/cmake')
+
+                        def package_info(self):
+                            self.cpp_info.filenames['cmake_find_package'] = 'FooBar'
+                            self.cpp_info.names['cmake_find_package'] = 'foobar'
+                            self.cpp_info.names['cmake_find_package_multi'] = 'foobar_multi'
+                            self.cpp_info.names['pkg_config'] = 'foobar_cfg'
+                            self.cpp_info.build_modules['cmake_find_package'] = ['lib/cmake/bm.cmake']
+                    """)
+        client = TestClient()
+        client.save({"conanfile.py": conanfile,
+                     "bm.cmake": "Content of build_module" })
+        client.run("create . bar/0.1.0@user/testing")
+        client.run("install bar/0.1.0@user/testing -g markdown")
+        content = client.load("bar.md")
+
+        self.assertIn("Generates the file FindFooBar.cmake", content)
+        self.assertIn("* `lib/cmake/bm.cmake`", content)
+        self.assertIn("Content of build_module", content)


### PR DESCRIPTION
Changelog: Fix: The `build_modules` defined per generator in `cpp_info` now are rendered properly using the `markdown` generator. 
Docs: omit