### PR TITLE
proof of concept of build_policy=never for export-pkg

### DIFF
--- a/conans/client/graph/build_mode.py
+++ b/conans/client/graph/build_mode.py
@@ -66,6 +66,9 @@ class BuildMode(object):
                 conan_file.output.info("Excluded build from source")
                 return False
 
+        if conan_file.build_policy == "never":  # this package has been export-pkg
+            return False
+
         if self.never:
             return False
         if self.all:

--- a/conans/test/integration/command/export_pkg_test.py
+++ b/conans/test/integration/command/export_pkg_test.py
@@ -639,3 +639,23 @@ class TestConan(ConanFile):
                        assert_error=True)
             self.assertIn("ERROR: The {} folder '{}' does not exist."
                           .format(folder, os.path.join(client.current_folder, folder)), client.out)
+
+
+def test_build_policy_never():
+    client = TestClient()
+    conanfile = textwrap.dedent("""
+        from conans import ConanFile
+        class TestConan(ConanFile):
+            build_policy = "never"
+
+            def package(self):
+                self.copy("*.h", src="src", dst="include")
+        """)
+    client.save({CONANFILE: conanfile,
+                 "src/header.h": "contents"})
+    client.run("export-pkg . pkg/1.0@")
+    assert "pkg/1.0 package(): Packaged 1 '.h' file: header.h" in client.out
+
+    client.run("install pkg/1.0@ --build")
+    assert "pkg/1.0:5ab84d6acfe1f23c4fae0ab88f26e3a396351ac9 - Cache" in client.out
+    assert "pkg/1.0: Calling build()" not in client.out


### PR DESCRIPTION
Changelog: Feature: Implement ``build_policy=never`` for ``conan export-pkg`` packages that cannot be rebuilt with ``--build=xxx``.
Docs: https://github.com/conan-io/docs/pull/2106

Close https://github.com/conan-io/conan/issues/8898