### PR TITLE
Expand user-agent string to include OS info.

### DIFF
--- a/conans/client/rest/conan_requester.py
+++ b/conans/client/rest/conan_requester.py
@@ -105,8 +105,12 @@ class ConanRequester(object):
 
         # Only set User-Agent if none was provided
         if not kwargs["headers"].get("User-Agent"):
-            user_agent = "Conan/%s (Python %s) %s" % (client_version, platform.python_version(),
-                                                      requests.utils.default_user_agent())
+            platform_info = "; ".join([
+                " ".join([platform.system(), platform.release()]),
+                "Python "+platform.python_version(),
+                platform.machine()])
+            user_agent = "Conan/%s (%s) %s" % (client_version, platform_info,
+                                               requests.utils.default_user_agent())
             kwargs["headers"]["User-Agent"] = user_agent
 
         return kwargs


### PR DESCRIPTION
It's useful to have the operating system information in the user-agent of the client to provide better analytics. Such analytics can help in determining if some particular set of clients are having problems. This adds the operating system, version, and machine type. In a format similar to what regular browsers provide.

Changelog: Feature: Expand user-agent string to include OS info.
Docs: omit

- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
