### PR TITLE
Improve error message when a folder is not an SCM repo

### DIFF
--- a/conans/client/tools/scm.py
+++ b/conans/client/tools/scm.py
@@ -16,7 +16,7 @@ from conans.util.runners import check_output_runner, version_runner, muted_runne
 
 
 def _check_repo(cmd, folder):
-    msg = "Not a valid '{0}' repository or '{0}' not found.".format(cmd[0])
+    msg = "'{0}' is not a valid '{1}' repository or '{1}' not found.".format(folder, cmd[0])
     try:
         ret = muted_runner(cmd, folder=folder)
     except Exception:

--- a/conans/test/functional/scm/test_command_export.py
+++ b/conans/test/functional/scm/test_command_export.py
@@ -34,8 +34,9 @@ class ExportErrorCommandTestCase(unittest.TestCase):
                                                                 rev_value=rev_value)
                           })
         self.client.run("export . lib/version@user/channel", assert_error=True)
-        self.assertIn("ERROR: Not a valid '{}' repository".format(repo_type.lower()),
-                      self.client.out)
+        self.assertIn("ERROR: '{}' is not a valid '{}' repository".format(
+                      self.client.current_folder, repo_type.lower()), self.client.out)
+
 
 @pytest.mark.tool_git
 class ExportCommandTestCase(unittest.TestCase):

--- a/conans/test/functional/scm/tools/test_git.py
+++ b/conans/test/functional/scm/tools/test_git.py
@@ -1,5 +1,6 @@
 # coding=utf-8
 import os
+import re
 import subprocess
 import unittest
 
@@ -397,9 +398,11 @@ class GitToolsTests(unittest.TestCase):
 
     def test_get_tag_no_git_repo(self):
         # Try to get tag out of a git repo
-        git = Git(folder=temp_folder())
-        with six.assertRaisesRegex(self, ConanException,
-                                   "Not a valid 'git' repository or 'git' not found"):
+        tmp_folder = temp_folder()
+        git = Git(folder=tmp_folder)
+        pattern = "'{0}' is not a valid 'git' repository or 'git' not found".format(
+            re.escape(tmp_folder))
+        with six.assertRaisesRegex(self, ConanException, pattern):
             git.get_tag()
 
     def test_excluded_files(self):

--- a/conans/test/functional/scm/tools/test_svn.py
+++ b/conans/test/functional/scm/tools/test_svn.py
@@ -1,6 +1,7 @@
 # coding=utf-8
 
 import os
+import re
 import shutil
 import subprocess
 import unittest
@@ -56,7 +57,8 @@ compiled Apr  5 2019, 18:59:58 on x86_64-apple-darwin17.0.0"""
         project_url, _ = self.create_project(files={'myfile': "contents"})
         tmp_folder = self.gimme_tmp()
         svn = SVN(folder=tmp_folder)
-        with six.assertRaisesRegex(self, ConanException, "Not a valid 'svn' repository"):
+        pattern = "'{0}' is not a valid 'svn' repository".format(re.escape(tmp_folder))
+        with six.assertRaisesRegex(self, ConanException, pattern):
             svn.check_repo()
         svn.checkout(url=project_url)
         try:


### PR DESCRIPTION
Changelog: Fix: Improve error message when a directory doesn't contain a valid repository.
Docs: omit

Before you would get this:
ConanException: Not a valid 'svn' repository

Which doesn't help much, especially if you're using
"conan create" which may be off in a folder you didn't
create.

Add the path of the folder to the error message to instead
get:
ConanException: '/a/b/not_an_svn_repo' is not a valid 'svn' repository


