### PR TITLE
Fix some typos in the code

### DIFF
--- a/conans/client/conf/__init__.py
+++ b/conans/client/conf/__init__.py
@@ -571,7 +571,7 @@ class ConanClientConfigParser(ConfigParser, object):
             # For explicit cacert files, the file should already exist
             if not os.path.exists(cacert_path):
                 raise ConanException("Configured file for 'cacert_path'"
-                                     " doesn't exists: '{}'".format(cacert_path))
+                                     " doesn't exist: '{}'".format(cacert_path))
         return cacert_path
 
     @property
@@ -586,7 +586,7 @@ class ConanClientConfigParser(ConfigParser, object):
             path = os.path.join(cache_folder, path)
             if not os.path.exists(path):
                 raise ConanException("Configured file for 'client_cert_path'"
-                                     " doesn't exists: '{}'".format(path))
+                                     " doesn't exist: '{}'".format(path))
         return os.path.normpath(path)
 
     @property
@@ -601,7 +601,7 @@ class ConanClientConfigParser(ConfigParser, object):
             path = os.path.join(cache_folder, path)
             if not os.path.exists(path):
                 raise ConanException("Configured file for 'client_cert_key_path'"
-                                     " doesn't exists: '{}'".format(path))
+                                     " doesn't exist: '{}'".format(path))
         return os.path.normpath(path)
 
     @property

--- a/conans/test/functional/tools/old/vcvars/vcvars_arch_test.py
+++ b/conans/test/functional/tools/old/vcvars/vcvars_arch_test.py
@@ -24,7 +24,7 @@ class VCVarsArchTest(unittest.TestCase):
         command = tools.vcvars_command(settings, output=output, **kwargs)
         command = command.replace('"', '').replace("'", "")
         self.assertTrue(command.endswith('vcvarsall.bat %s' % expected),
-                        msg="'{}' doesn't ends with 'vcvarsall.bat {}'".format(command, expected))
+                        msg="'{}' doesn't end with 'vcvarsall.bat {}'".format(command, expected))
 
     def test_arch(self):
         settings = Settings.loads(get_default_settings_yml())

--- a/conans/test/unittests/client/conanfile_loader_test.py
+++ b/conans/test/unittests/client/conanfile_loader_test.py
@@ -323,7 +323,7 @@ class ImportModuleLoaderTest(unittest.TestCase):
         with six.assertRaisesRegex(self, ConanException, "Unable to load conanfile in"):
             self._create_and_load(myfunc1, value1, "requests", add_subdir_init)
 
-        # File does not exists in already existing module
+        # File does not exist in already existing module
         with six.assertRaisesRegex(self, ConanException, "Unable to load conanfile in"):
             self._create_and_load(myfunc1, value1, "conans", add_subdir_init)
 


### PR DESCRIPTION
We use scripts which act based on some errors returned by Conan and while catching error messages I discovered some typos that I thought are worth fixing :)
I didn't create an issue for such a small change but if you think it is necessary please let me know.

----

Changelog: Fix: Fix some typos in the code.
Docs: omit

- [ ] Refer to the issue that supports this Pull Request.
- [ ] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 

<sup>**Note:** By default this PR will skip the slower tests and will use a limited set of python versions. Check [here](https://github.com/conan-io/conan/blob/develop/.github/PR_INCREASE_TESTING.md) how to increase the testing level by writing some tags in the current PR body text.</sup>
