### PR TITLE
CMakeDeps build_requires full support

### DIFF
--- a/conan/tools/cmake/cmakedeps/cmakedeps.py
+++ b/conan/tools/cmake/cmakedeps/cmakedeps.py
@@ -35,7 +35,7 @@ class CMakeDeps(object):
         ret = {macros.filename: macros.render()}
 
         host_req = self._conanfile.dependencies.transitive_host_requires
-        build_req = self._conanfile.dependencies.build_requires
+        build_req = self._conanfile.dependencies.build_requires_build_context
 
         # Check if the same package is at host and build and the same time
         common = {r.ref.name for r in host_req}.intersection({r.ref.name for r in build_req})

--- a/conan/tools/cmake/cmakedeps/cmakedeps.py
+++ b/conan/tools/cmake/cmakedeps/cmakedeps.py
@@ -6,6 +6,7 @@ from conan.tools.cmake.cmakedeps.templates.macros import MacrosTemplate
 from conan.tools.cmake.cmakedeps.templates.target_configuration import TargetConfigurationTemplate
 from conan.tools.cmake.cmakedeps.templates.target_data import ConfigDataTemplate
 from conan.tools.cmake.cmakedeps.templates.targets import TargetsTemplate
+from conans.errors import ConanException
 from conans.util.files import save
 
 
@@ -16,6 +17,11 @@ class CMakeDeps(object):
         self.arch = self._conanfile.settings.get_safe("arch")
         self.configuration = str(self._conanfile.settings.build_type)
         self.configurations = [v for v in conanfile.settings.build_type.values_range if v != "None"]
+        # By default, the build modules are generated for host context only
+        self.build_context_build_modules = []
+        # If specified, the files/targets/variables for the build context will be renamed appeding
+        # a suffix. It is necessary in case of same require and build_require and will cause an error
+        self.build_context_suffix = {}
 
     def generate(self):
         # Current directory is the generators_folder
@@ -28,10 +34,21 @@ class CMakeDeps(object):
         macros = MacrosTemplate()
         ret = {macros.filename: macros.render()}
 
-        host_requires = {r.ref.name: r for r in
-                         self._conanfile.dependencies.transitive_host_requires}
+        host_req = self._conanfile.dependencies.transitive_host_requires
+        build_req = self._conanfile.dependencies.build_requires
+
+        # Check if the same package is at host and build and the same time
+        common = {r.ref.name for r in host_req}.intersection({r.ref.name for r in build_req})
+        for name in common:
+            if name not in self.build_context_suffix:
+                raise ConanException("The package '{}' exists both as 'require' and as "
+                                     "'build require'. You need to specify a suffix using the "
+                                     "'build_context_suffix' attribute at the CMakeDeps "
+                                     "generator.".format(name))
+
         # Iterate all the transitive requires
-        for req in host_requires.values():
+        requires = host_req + build_req
+        for req in requires:
 
             config_version = ConfigVersionTemplate(self, req)
             ret[config_version.filename] = config_version.render()

--- a/conan/tools/cmake/cmakedeps/cmakedeps.py
+++ b/conan/tools/cmake/cmakedeps/cmakedeps.py
@@ -47,8 +47,7 @@ class CMakeDeps(object):
                                      "generator.".format(name))
 
         # Iterate all the transitive requires
-        requires = host_req + build_req
-        for req in requires:
+        for req in host_req + build_req:
 
             config_version = ConfigVersionTemplate(self, req)
             ret[config_version.filename] = config_version.render()

--- a/conan/tools/cmake/cmakedeps/templates/__init__.py
+++ b/conan/tools/cmake/cmakedeps/templates/__init__.py
@@ -15,11 +15,6 @@ class CMakeDepsFileTemplate(object):
         return self.conanfile.ref.name + self.suffix
 
     @property
-    def package_folder(self):
-        return self.conanfile.package_folder.\
-            replace('\\', '/').replace('$', '\\$').replace('"', '\\"')
-
-    @property
     def target_namespace(self):
         return get_target_namespace(self.conanfile) + self.suffix
 

--- a/conan/tools/cmake/cmakedeps/templates/__init__.py
+++ b/conan/tools/cmake/cmakedeps/templates/__init__.py
@@ -8,13 +8,37 @@ class CMakeDepsFileTemplate(object):
 
     def __init__(self, cmakedeps, req):
         self.cmakedeps = cmakedeps
-        if req is not None:
-            self.conanfile = req
-            self.pkg_name = req.ref.name
-            self.package_folder = req.package_folder.\
-                replace('\\', '/').replace('$', '\\$').replace('"', '\\"')
-            self.target_namespace = get_target_namespace(self.conanfile)
-            self.file_name = get_file_name(self.conanfile)
+        self.conanfile = req
+
+    @property
+    def pkg_name(self):
+        return self.conanfile.ref.name + self.suffix
+
+    @property
+    def package_folder(self):
+        return self.conanfile.package_folder.\
+            replace('\\', '/').replace('$', '\\$').replace('"', '\\"')
+
+    @property
+    def target_namespace(self):
+        return get_target_namespace(self.conanfile) + self.suffix
+
+    @property
+    def file_name(self):
+        return get_file_name(self.conanfile) + self.suffix
+
+    @property
+    def suffix(self):
+        if not self.conanfile.is_build_context:
+            return ""
+        return self.cmakedeps.build_context_suffix.get(self.conanfile.ref.name, "")
+
+    @property
+    def build_modules_activated(self):
+        if self.conanfile.is_build_context:
+            return self.conanfile.ref.name in self.cmakedeps.build_context_build_modules
+        else:
+            return self.conanfile.ref.name not in self.cmakedeps.build_context_build_modules
 
     def render(self):
         context = self.context

--- a/conan/tools/cmake/cmakedeps/templates/target_configuration.py
+++ b/conan/tools/cmake/cmakedeps/templates/target_configuration.py
@@ -14,7 +14,8 @@ class TargetConfigurationTemplate(CMakeDepsFileTemplate):
 
     @property
     def filename(self):
-        return "{}Target-{}.cmake".format(self.file_name, self.cmakedeps.configuration.lower())
+        return "{}Target-{}.cmake".format(self.file_name,
+                                            self.cmakedeps.configuration.lower())
 
     @property
     def context(self):

--- a/conan/tools/cmake/cmakedeps/templates/target_data.py
+++ b/conan/tools/cmake/cmakedeps/templates/target_data.py
@@ -31,9 +31,11 @@ class ConfigDataTemplate(CMakeDepsFileTemplate):
         components_renames = " ".join([component_rename for component_rename, _ in
                                        reversed(components_cpp)])
         dependency_filenames = self.get_dependency_filenames()
+        package_folder = self.conanfile.package_folder.replace('\\', '/')\
+                                                      .replace('$', '\\$').replace('"', '\\"')
         return {"global_cpp": global_cpp,
                 "pkg_name": self.pkg_name,
-                "package_folder": self.package_folder,
+                "package_folder": package_folder,
                 "config_suffix": self.config_suffix,
                 "components_renames": components_renames,
                 "components_cpp": components_cpp,

--- a/conan/tools/cmake/cmakedeps/templates/target_data.py
+++ b/conan/tools/cmake/cmakedeps/templates/target_data.py
@@ -24,6 +24,9 @@ class ConfigDataTemplate(CMakeDepsFileTemplate):
     @property
     def context(self):
         global_cpp = self.get_global_cpp_cmake()
+        if not self.build_modules_activated:
+            global_cpp.build_modules_paths = ""
+
         components_cpp = self.get_required_components_cpp()
         components_renames = " ".join([component_rename for component_rename, _ in
                                        reversed(components_cpp)])

--- a/conans/client/graph/conanfile_dependencies.py
+++ b/conans/client/graph/conanfile_dependencies.py
@@ -26,6 +26,9 @@ class DependencyOrderedSet:
             raise ConanException("No dependency found")
         return result[0]
 
+    def __add__(self, other):
+        return DependencyOrderedSet(self._deps + other._deps)
+
 
 class ConanFileDependencies:
 

--- a/conans/client/graph/conanfile_dependencies.py
+++ b/conans/client/graph/conanfile_dependencies.py
@@ -1,4 +1,4 @@
-from conans.client.graph.graph import CONTEXT_HOST
+from conans.client.graph.graph import CONTEXT_HOST, CONTEXT_BUILD
 from conans.errors import ConanException
 from conans.model.conanfile_interface import ConanFileInterface
 
@@ -42,6 +42,18 @@ class ConanFileDependencies:
         """
         return DependencyOrderedSet([ConanFileInterface(edge.dst.conanfile)
                                      for edge in self._node.dependencies if edge.build_require])
+
+    @property
+    def build_requires_build_context(self):
+        """
+        :return: list of immediate direct build_requires, on build context.
+        FIXME: Why this method? To overcome the legacy use case without 2 profiles where everthing
+               is host, otherwise we can receive the same build require twice, one in
+               .transitive_host_requires and one in .build_requires
+        """
+        return DependencyOrderedSet([ConanFileInterface(edge.dst.conanfile)
+                                     for edge in self._node.dependencies if edge.build_require and
+                                     edge.dst.context == CONTEXT_BUILD])
 
     @property
     def requires(self):

--- a/conans/model/conanfile_interface.py
+++ b/conans/model/conanfile_interface.py
@@ -1,3 +1,4 @@
+from conans.client.graph.graph import CONTEXT_BUILD
 
 
 class ConanFileInterface:
@@ -60,3 +61,7 @@ class ConanFileInterface:
     @property
     def dependencies(self):
         return self._conanfile.dependencies
+
+    @property
+    def is_build_context(self):
+        return self._conanfile.context == CONTEXT_BUILD

--- a/conans/test/functional/toolchains/cmake/cmakedeps/test_build_context_protobuf.py
+++ b/conans/test/functional/toolchains/cmake/cmakedeps/test_build_context_protobuf.py
@@ -1,0 +1,232 @@
+import textwrap
+
+import pytest
+
+from conans.test.utils.tools import TestClient
+
+
+@pytest.fixture
+def client():
+    c = TestClient()
+    conanfile = textwrap.dedent('''
+    from conans import ConanFile
+    from conans.tools import save, chdir
+    import os
+
+    class Protobuf(ConanFile):
+        settings = "build_type", "os", "arch", "compiler"
+
+        def package(self):
+            my_cmake_module = """
+                  function(foo_generate)
+                     write_file(foo_generated.h "int from_context = %s;")
+                  endfunction()
+            """
+
+            with chdir(self.package_folder):
+                save("include_build/protobuff.h", "int protubuff_stuff(){ return 1; }")
+                save("include_host/protobuff.h", "int protubuff_stuff(){ return 2; }")
+                save("build/my_tools_build.cmake", my_cmake_module % "1")
+                save("build/my_tools_host.cmake", my_cmake_module % "2")
+
+        def package_info(self):
+            # This info depends on self.context !!
+            self.cpp_info.includedirs = ["include_{}".format(self.context)]
+            path_build_modules = os.path.join("build", "my_tools_{}.cmake".format(self.context))
+            self.cpp_info.set_property("cmake_build_modules", [path_build_modules])
+
+    ''')
+    c.save({"conanfile.py": conanfile})
+    c.run("create . protobuff/1.0@")
+    return c
+
+
+main = textwrap.dedent("""
+    #include <iostream>
+    #include "protobuff.h"
+    #include "foo_generated.h"
+
+
+    int main(){
+        int ret = protubuff_stuff();
+
+        if(ret == 1){
+            std::cout << " Library from build context!" << std::endl;
+        }
+        else if(ret == 2){
+            std::cout << " Library from host context!" << std::endl;
+        }
+
+        // Variable declared at the foo_generated
+        if(from_context == 1){
+            std::cout << " Generated code in build context!" << std::endl;
+        }
+        else if(from_context == 2){
+            std::cout << " Generated code in host context!" << std::endl;
+        }
+        return 0;
+    }
+    """)
+
+consumer_conanfile = textwrap.dedent("""
+        import os
+        from conans import ConanFile
+        from conan.tools.cmake import CMake, CMakeToolchain, CMakeDeps
+
+        class Consumer(ConanFile):
+            settings = "build_type", "os", "arch", "compiler"
+            exports_sources = "CMakeLists.txt", "main.cpp"
+            requires = "protobuff/1.0"
+            build_requires = "protobuff/1.0"
+
+            def generate(self):
+                toolchain = CMakeToolchain(self)
+                toolchain.generate()
+
+                deps = CMakeDeps(self)
+                {}
+                deps.generate()
+
+            def build(self):
+                cmake = CMake(self)
+                cmake.configure()
+                cmake.build()
+                self.run(os.sep.join([".", "app"]))
+        """)
+
+
+def test_build_modules_from_build_context(client):
+    consumer_cmake = textwrap.dedent("""
+        set(CMAKE_CXX_COMPILER_WORKS 1)
+        set(CMAKE_CXX_ABI_COMPILED 1)
+        cmake_minimum_required(VERSION 3.15)
+        project(MyApp CXX)
+
+        find_package(protobuff)
+        find_package(protobuff_KK)
+        add_executable(app main.cpp)
+        foo_generate()
+        target_link_libraries(app protobuff::protobuff)
+        """)
+
+    cmake_deps_conf = """
+        deps.build_context_build_modules = ["protobuff"]
+        deps.build_context_suffix = {"protobuff": "_KK"}
+    """
+
+    client.save({"conanfile.py": consumer_conanfile.format(cmake_deps_conf),
+                 "CMakeLists.txt": consumer_cmake.format(cmake_deps_conf),
+                 "main.cpp": main})
+
+    client.run("create . app/1.0@ -pr:b default -pr:h default")
+    assert "Library from host context!" in client.out
+    assert "Generated code in build context!" in client.out
+
+
+def test_build_modules_and_target_from_build_context(client):
+    consumer_cmake = textwrap.dedent("""
+        set(CMAKE_CXX_COMPILER_WORKS 1)
+        set(CMAKE_CXX_ABI_COMPILED 1)
+        cmake_minimum_required(VERSION 3.15)
+        project(MyApp CXX)
+
+        find_package(protobuff)
+        find_package(protobuff_KK)
+        add_executable(app main.cpp)
+        foo_generate()
+        target_link_libraries(app protobuff_KK::protobuff_KK)
+        """)
+
+    cmake_deps_conf = """
+        deps.build_context_build_modules = ["protobuff"]
+        deps.build_context_suffix = {"protobuff": "_KK"}
+    """
+
+    client.save({"conanfile.py": consumer_conanfile.format(cmake_deps_conf),
+                 "CMakeLists.txt": consumer_cmake.format(cmake_deps_conf),
+                 "main.cpp": main})
+
+    client.run("create . app/1.0@ -pr:b default -pr:h default")
+    assert "Library from build context!" in client.out
+    assert "Generated code in build context!" in client.out
+
+
+def test_build_modules_from_host_and_target_from_build_context(client):
+    consumer_cmake = textwrap.dedent("""
+        set(CMAKE_CXX_COMPILER_WORKS 1)
+        set(CMAKE_CXX_ABI_COMPILED 1)
+        cmake_minimum_required(VERSION 3.15)
+        project(MyApp CXX)
+
+        find_package(protobuff)
+        find_package(protobuff_KK)
+        add_executable(app main.cpp)
+        foo_generate()
+        target_link_libraries(app protobuff_KK::protobuff_KK)
+        """)
+
+    cmake_deps_conf = """
+        deps.build_context_suffix = {"protobuff": "_KK"}
+    """
+
+    client.save({"conanfile.py": consumer_conanfile.format(cmake_deps_conf),
+                 "CMakeLists.txt": consumer_cmake.format(cmake_deps_conf),
+                 "main.cpp": main})
+
+    client.run("create . app/1.0@ -pr:b default -pr:h default")
+    assert "Library from build context!" in client.out
+    assert "Generated code in host context!" in client.out
+
+
+def test_build_modules_and_target_from_host_context(client):
+    consumer_cmake = textwrap.dedent("""
+        set(CMAKE_CXX_COMPILER_WORKS 1)
+        set(CMAKE_CXX_ABI_COMPILED 1)
+        cmake_minimum_required(VERSION 3.15)
+        project(MyApp CXX)
+
+        find_package(protobuff)
+        find_package(protobuff_KK)
+        add_executable(app main.cpp)
+        foo_generate()
+        target_link_libraries(app protobuff::protobuff)
+        """)
+
+    cmake_deps_conf = """
+        deps.build_context_build_modules = []
+        deps.build_context_suffix = {"protobuff": "_KK"}
+    """
+
+    client.save({"conanfile.py": consumer_conanfile.format(cmake_deps_conf),
+                 "CMakeLists.txt": consumer_cmake.format(cmake_deps_conf),
+                 "main.cpp": main})
+
+    client.run("create . app/1.0@ -pr:b default -pr:h default")
+    assert "Library from host context!" in client.out
+    assert "Generated code in host context!" in client.out
+
+
+def test_exception_when_not_prefix_specified(client):
+    consumer_cmake = textwrap.dedent("""
+        set(CMAKE_CXX_COMPILER_WORKS 1)
+        set(CMAKE_CXX_ABI_COMPILED 1)
+        cmake_minimum_required(VERSION 3.15)
+        project(MyApp CXX)
+
+        find_package(protobuff)
+        add_executable(app main.cpp)
+        foo_generate()
+        target_link_libraries(app protobuff::protobuff)
+        """)
+
+    cmake_deps_conf = """
+    """
+
+    client.save({"conanfile.py": consumer_conanfile.format(cmake_deps_conf),
+                 "CMakeLists.txt": consumer_cmake.format(cmake_deps_conf),
+                 "main.cpp": main})
+
+    client.run("create . app/1.0@ -pr:b default -pr:h default", assert_error=True)
+    assert "The package 'protobuff' exists both as 'require' and as 'build require'. " \
+           "You need to specify a suffix using the 'build_context_suffix' attribute at the " \
+           "CMakeDeps generator." in client.out

--- a/conans/test/functional/toolchains/cmake/cmakedeps/test_build_context_protobuf.py
+++ b/conans/test/functional/toolchains/cmake/cmakedeps/test_build_context_protobuf.py
@@ -91,7 +91,8 @@ consumer_conanfile = textwrap.dedent("""
                 cmake = CMake(self)
                 cmake.configure()
                 cmake.build()
-                self.run(os.sep.join([".", "app"]))
+                folder = self.settings.build_require if self.settings.os == "Windows" else "."
+                self.run(os.sep.join([folder, "app"]))
         """)
 
 

--- a/conans/test/functional/toolchains/cmake/cmakedeps/test_build_context_protobuf.py
+++ b/conans/test/functional/toolchains/cmake/cmakedeps/test_build_context_protobuf.py
@@ -91,7 +91,7 @@ consumer_conanfile = textwrap.dedent("""
                 cmake = CMake(self)
                 cmake.configure()
                 cmake.build()
-                folder = self.settings.build_require if self.settings.os == "Windows" else "."
+                folder = str(self.settings.build_type) if self.settings.os == "Windows" else "."
                 self.run(os.sep.join([folder, "app"]))
         """)
 

--- a/conans/test/functional/toolchains/cmake/cmakedeps/test_build_context_protobuf.py
+++ b/conans/test/functional/toolchains/cmake/cmakedeps/test_build_context_protobuf.py
@@ -104,7 +104,7 @@ def test_build_modules_from_build_context(client):
         project(MyApp CXX)
 
         find_package(protobuff)
-        find_package(protobuff_KK)
+        find_package(protobuff_BUILD)
         add_executable(app main.cpp)
         foo_generate()
         target_link_libraries(app protobuff::protobuff)
@@ -112,7 +112,7 @@ def test_build_modules_from_build_context(client):
 
     cmake_deps_conf = """
         deps.build_context_build_modules = ["protobuff"]
-        deps.build_context_suffix = {"protobuff": "_KK"}
+        deps.build_context_suffix = {"protobuff": "_BUILD"}
     """
 
     client.save({"conanfile.py": consumer_conanfile.format(cmake_deps_conf),
@@ -132,15 +132,15 @@ def test_build_modules_and_target_from_build_context(client):
         project(MyApp CXX)
 
         find_package(protobuff)
-        find_package(protobuff_KK)
+        find_package(protobuff_BUILD)
         add_executable(app main.cpp)
         foo_generate()
-        target_link_libraries(app protobuff_KK::protobuff_KK)
+        target_link_libraries(app protobuff_BUILD::protobuff_BUILD)
         """)
 
     cmake_deps_conf = """
         deps.build_context_build_modules = ["protobuff"]
-        deps.build_context_suffix = {"protobuff": "_KK"}
+        deps.build_context_suffix = {"protobuff": "_BUILD"}
     """
 
     client.save({"conanfile.py": consumer_conanfile.format(cmake_deps_conf),
@@ -160,14 +160,14 @@ def test_build_modules_from_host_and_target_from_build_context(client):
         project(MyApp CXX)
 
         find_package(protobuff)
-        find_package(protobuff_KK)
+        find_package(protobuff_BUILD)
         add_executable(app main.cpp)
         foo_generate()
-        target_link_libraries(app protobuff_KK::protobuff_KK)
+        target_link_libraries(app protobuff_BUILD::protobuff_BUILD)
         """)
 
     cmake_deps_conf = """
-        deps.build_context_suffix = {"protobuff": "_KK"}
+        deps.build_context_suffix = {"protobuff": "_BUILD"}
     """
 
     client.save({"conanfile.py": consumer_conanfile.format(cmake_deps_conf),
@@ -187,7 +187,7 @@ def test_build_modules_and_target_from_host_context(client):
         project(MyApp CXX)
 
         find_package(protobuff)
-        find_package(protobuff_KK)
+        find_package(protobuff_BUILD)
         add_executable(app main.cpp)
         foo_generate()
         target_link_libraries(app protobuff::protobuff)
@@ -195,7 +195,7 @@ def test_build_modules_and_target_from_host_context(client):
 
     cmake_deps_conf = """
         deps.build_context_build_modules = []
-        deps.build_context_suffix = {"protobuff": "_KK"}
+        deps.build_context_suffix = {"protobuff": "_BUILD"}
     """
 
     client.save({"conanfile.py": consumer_conanfile.format(cmake_deps_conf),

--- a/conans/test/unittests/tools/cmake/test_cmakedeps.py
+++ b/conans/test/unittests/tools/cmake/test_cmakedeps.py
@@ -13,6 +13,8 @@ from conans.model.ref import ConanFileReference
 @pytest.mark.parametrize("using_properties", [True, False])
 def test_cpp_info_name_cmakedeps(using_properties):
     conanfile = ConanFile(Mock(), None)
+    conanfile._conan_node = Mock()
+    conanfile._conan_node.context = "host"
     conanfile.settings = "os", "compiler", "build_type", "arch"
     conanfile.initialize(Settings({"os": ["Windows"],
                                    "compiler": ["gcc"],
@@ -31,6 +33,8 @@ def test_cpp_info_name_cmakedeps(using_properties):
 
     conanfile_dep = ConanFile(Mock(), None)
     conanfile_dep.cpp_info = cpp_info
+    conanfile_dep._conan_node = Mock()
+    conanfile_dep._conan_node.context = "host"
 
     with mock.patch('conans.ConanFile.ref', new_callable=mock.PropertyMock) as mock_ref:
         with mock.patch('conans.ConanFile.dependencies', new_callable=mock.PropertyMock) as mock_deps:
@@ -40,6 +44,7 @@ def test_cpp_info_name_cmakedeps(using_properties):
             conanfile_dep.package_folder = "/path/to/folder_dep"
             conanfile.dependencies.transitive_host_requires = [ConanFileInterface(conanfile_dep)]
             conanfile.dependencies.host_requires = [ConanFileInterface(conanfile_dep)]
+            conanfile.dependencies.build_requires_build_context = []
 
             cmakedeps = CMakeDeps(conanfile)
             files = cmakedeps.content
@@ -52,6 +57,8 @@ def test_cpp_info_name_cmakedeps(using_properties):
 @pytest.mark.parametrize("using_properties", [True, False])
 def test_cpp_info_name_cmakedeps_components(using_properties):
     conanfile = ConanFile(Mock(), None)
+    conanfile._conan_node = Mock()
+    conanfile._conan_node.context = "host"
     conanfile.settings = "os", "compiler", "build_type", "arch"
     conanfile.initialize(Settings({"os": ["Windows"],
                                    "compiler": ["gcc"],
@@ -72,6 +79,8 @@ def test_cpp_info_name_cmakedeps_components(using_properties):
 
     conanfile_dep = ConanFile(Mock(), None)
     conanfile_dep.cpp_info = cpp_info
+    conanfile_dep._conan_node = Mock()
+    conanfile_dep._conan_node.context = "host"
 
     with mock.patch('conans.ConanFile.ref', new_callable=mock.PropertyMock) as mock_ref:
         with mock.patch('conans.ConanFile.dependencies', new_callable=mock.PropertyMock) as mock_deps:
@@ -81,6 +90,7 @@ def test_cpp_info_name_cmakedeps_components(using_properties):
             conanfile_dep.package_folder = "/path/to/folder_dep"
             conanfile.dependencies.transitive_host_requires = [ConanFileInterface(conanfile_dep)]
             conanfile.dependencies.host_requires = [ConanFileInterface(conanfile_dep)]
+            conanfile.dependencies.build_requires_build_context = []
 
             cmakedeps = CMakeDeps(conanfile)
             files = cmakedeps.content
@@ -96,6 +106,8 @@ def test_cpp_info_name_cmakedeps_components(using_properties):
 def test_cmake_deps_links_flags():
     # https://github.com/conan-io/conan/issues/8703
     conanfile = ConanFile(Mock(), None)
+    conanfile._conan_node = Mock()
+    conanfile._conan_node.context = "host"
     conanfile.settings = "os", "compiler", "build_type", "arch"
     conanfile.initialize(Settings({"os": ["Windows"],
                                    "compiler": ["gcc"],
@@ -110,6 +122,8 @@ def test_cmake_deps_links_flags():
     cpp_info.exelinkflags = ["-OPT:NOICF"]
     conanfile_dep = ConanFile(Mock(), None)
     conanfile_dep.cpp_info = cpp_info
+    conanfile_dep._conan_node = Mock()
+    conanfile_dep._conan_node.context = "host"
 
     with mock.patch('conans.ConanFile.ref', new_callable=mock.PropertyMock) as mock_ref:
         with mock.patch('conans.ConanFile.dependencies',
@@ -122,6 +136,7 @@ def test_cmake_deps_links_flags():
             conanfile_dep.package_folder = "/path/to/folder_dep"
             conanfile.dependencies.transitive_host_requires = [ConanFileInterface(conanfile_dep)]
             conanfile.dependencies.host_requires = [ConanFileInterface(conanfile_dep)]
+            conanfile.dependencies.build_requires_build_context = []
 
             cmakedeps = CMakeDeps(conanfile)
             files = cmakedeps.content


### PR DESCRIPTION
Changelog: Feature: Introduced new options for the `CMakeDeps` generator allowing to manage `build_requires` even declaring the same package as a `require` and `build_require` avoiding the collision of the `config` cmake files and enabling to specify which `build_modules` should be included (e.g protobuf issue)
Docs: https://github.com/conan-io/docs/pull/2104

Closes #8303
Closes #7719