### PR TITLE
Add new center remote

### DIFF
--- a/conans/client/cache/remote_registry.py
+++ b/conans/client/cache/remote_registry.py
@@ -11,6 +11,8 @@ from conans.util.files import load, save
 from conans.model.ref import PackageReference, ConanFileReference
 
 
+CONAN_CENTER_REMOTE_NAME = "conancenter"
+
 Remote = namedtuple("Remote", "name url verify_ssl disabled")
 
 
@@ -108,8 +110,8 @@ class Remotes(object):
     @classmethod
     def defaults(cls):
         result = Remotes()
-        result._remotes["ConanCenter"] = Remote("ConanCenter", "https://center.conan.io", True,
-                                                False)
+        result._remotes[CONAN_CENTER_REMOTE_NAME] = Remote(CONAN_CENTER_REMOTE_NAME,
+                                                           "https://center.conan.io", True, False)
         result._remotes["conan-center"] = Remote("conan-center", "https://conan.bintray.com", True,
                                                  False)
         return result

--- a/conans/client/cache/remote_registry.py
+++ b/conans/client/cache/remote_registry.py
@@ -108,6 +108,8 @@ class Remotes(object):
     @classmethod
     def defaults(cls):
         result = Remotes()
+        result._remotes["ConanCenter"] = Remote("ConanCenter", "https://center.conan.io", True,
+                                                False)
         result._remotes["conan-center"] = Remote("conan-center", "https://conan.bintray.com", True,
                                                  False)
         return result

--- a/conans/test/integration/configuration/registry_test.py
+++ b/conans/test/integration/configuration/registry_test.py
@@ -66,13 +66,13 @@ other/1.0@lasote/testing conan.io
         # Add
         registry.add("local", "http://localhost:9300")
         self.assertEqual(list(registry.load_remotes().values()),
-                         [("ConanCenter", "https://center.conan.io", True, False),
+                         [("conancenter", "https://center.conan.io", True, False),
                           ("conan-center", "https://conan.bintray.com", True, False),
                           ("local", "http://localhost:9300", True, False)])
         # Add
         registry.add("new", "new_url", False)
         self.assertEqual(list(registry.load_remotes().values()),
-                         [("ConanCenter", "https://center.conan.io", True, False),
+                         [("conancenter", "https://center.conan.io", True, False),
                           ("conan-center", "https://conan.bintray.com", True, False),
                           ("local", "http://localhost:9300", True, False),
                           ("new", "new_url", False, False)])
@@ -81,7 +81,7 @@ other/1.0@lasote/testing conan.io
         # Update
         registry.update("new", "other_url")
         self.assertEqual(list(registry.load_remotes().values()),
-                         [("ConanCenter", "https://center.conan.io", True, False),
+                         [("conancenter", "https://center.conan.io", True, False),
                           ("conan-center", "https://conan.bintray.com", True, False),
                           ("local", "http://localhost:9300", True, False),
                           ("new", "other_url", True, False)])
@@ -90,7 +90,7 @@ other/1.0@lasote/testing conan.io
 
         registry.update("new", "other_url", False)
         self.assertEqual(list(registry.load_remotes().values()),
-                         [("ConanCenter", "https://center.conan.io", True, False),
+                         [("conancenter", "https://center.conan.io", True, False),
                           ("conan-center", "https://conan.bintray.com", True, False),
                           ("local", "http://localhost:9300", True, False),
                           ("new", "other_url", False, False)])
@@ -98,7 +98,7 @@ other/1.0@lasote/testing conan.io
         # Remove
         registry.remove("local")
         self.assertEqual(list(registry.load_remotes().values()),
-                         [("ConanCenter", "https://center.conan.io", True, False),
+                         [("conancenter", "https://center.conan.io", True, False),
                           ("conan-center", "https://conan.bintray.com", True, False),
                           ("new", "other_url", False, False)])
         with self.assertRaises(ConanException):
@@ -144,7 +144,7 @@ other/1.0@lasote/testing conan.io
 
         registry.add("foobar", None)
         self.assertEqual(list(registry.load_remotes().values()),
-                         [("ConanCenter", "https://center.conan.io", True, False),
+                         [("conancenter", "https://center.conan.io", True, False),
                           ("conan-center", "https://conan.bintray.com", True, False),
                           ("foobar", None, True, False)])
         self.assertIn("WARN: The URL is empty. It must contain scheme and hostname.", cache._output)
@@ -152,7 +152,7 @@ other/1.0@lasote/testing conan.io
 
         registry.update("conan-center", None)
         self.assertEqual(list(registry.load_remotes().values()),
-                         [("ConanCenter", "https://center.conan.io", True, False),
+                         [("conancenter", "https://center.conan.io", True, False),
                           ("conan-center", None, True, False)])
         self.assertIn("WARN: The URL is empty. It must contain scheme and hostname.", cache._output)
 
@@ -165,26 +165,26 @@ other/1.0@lasote/testing conan.io
         registry.add("local", "http://localhost:9300")
         registry.set_disabled_state("local", True)
         self.assertEqual(list(registry.load_remotes().all_values()),
-                         [("ConanCenter", "https://center.conan.io", True, False),
+                         [("conancenter", "https://center.conan.io", True, False),
                           ("conan-center", "https://conan.bintray.com", True, False),
                           ("local", "http://localhost:9300", True, True)])
 
         self.assertEqual(list(registry.load_remotes().values()),
-                         [("ConanCenter", "https://center.conan.io", True, False),
+                         [("conancenter", "https://center.conan.io", True, False),
                           ("conan-center", "https://conan.bintray.com", True, False)])
 
         registry.set_disabled_state("conan-center", True)
         self.assertEqual(list(registry.load_remotes().all_values()),
-                         [("ConanCenter", "https://center.conan.io", True, False),
+                         [("conancenter", "https://center.conan.io", True, False),
                           ("conan-center", "https://conan.bintray.com", True, True),
                           ("local", "http://localhost:9300", True, True)])
 
         self.assertEqual(list(registry.load_remotes().values()),
-                         [("ConanCenter", "https://center.conan.io", True, False)])
+                         [("conancenter", "https://center.conan.io", True, False)])
 
         registry.set_disabled_state("*", False)
         self.assertEqual(list(registry.load_remotes().values()),
-                         [("ConanCenter", "https://center.conan.io", True, False),
+                         [("conancenter", "https://center.conan.io", True, False),
                           ("conan-center", "https://conan.bintray.com", True, False),
                           ("local", "http://localhost:9300", True, False)])
 

--- a/conans/test/integration/configuration/registry_test.py
+++ b/conans/test/integration/configuration/registry_test.py
@@ -66,12 +66,14 @@ other/1.0@lasote/testing conan.io
         # Add
         registry.add("local", "http://localhost:9300")
         self.assertEqual(list(registry.load_remotes().values()),
-                         [("conan-center", "https://conan.bintray.com", True, False),
+                         [("ConanCenter", "https://center.conan.io", True, False),
+                          ("conan-center", "https://conan.bintray.com", True, False),
                           ("local", "http://localhost:9300", True, False)])
         # Add
         registry.add("new", "new_url", False)
         self.assertEqual(list(registry.load_remotes().values()),
-                         [("conan-center", "https://conan.bintray.com", True, False),
+                         [("ConanCenter", "https://center.conan.io", True, False),
+                          ("conan-center", "https://conan.bintray.com", True, False),
                           ("local", "http://localhost:9300", True, False),
                           ("new", "new_url", False, False)])
         with self.assertRaises(ConanException):
@@ -79,7 +81,8 @@ other/1.0@lasote/testing conan.io
         # Update
         registry.update("new", "other_url")
         self.assertEqual(list(registry.load_remotes().values()),
-                         [("conan-center", "https://conan.bintray.com", True, False),
+                         [("ConanCenter", "https://center.conan.io", True, False),
+                          ("conan-center", "https://conan.bintray.com", True, False),
                           ("local", "http://localhost:9300", True, False),
                           ("new", "other_url", True, False)])
         with self.assertRaises(ConanException):
@@ -87,14 +90,16 @@ other/1.0@lasote/testing conan.io
 
         registry.update("new", "other_url", False)
         self.assertEqual(list(registry.load_remotes().values()),
-                         [("conan-center", "https://conan.bintray.com", True, False),
+                         [("ConanCenter", "https://center.conan.io", True, False),
+                          ("conan-center", "https://conan.bintray.com", True, False),
                           ("local", "http://localhost:9300", True, False),
                           ("new", "other_url", False, False)])
 
         # Remove
         registry.remove("local")
         self.assertEqual(list(registry.load_remotes().values()),
-                         [("conan-center", "https://conan.bintray.com", True, False),
+                         [("ConanCenter", "https://center.conan.io", True, False),
+                          ("conan-center", "https://conan.bintray.com", True, False),
                           ("new", "other_url", False, False)])
         with self.assertRaises(ConanException):
             registry.remove("new2")
@@ -139,14 +144,16 @@ other/1.0@lasote/testing conan.io
 
         registry.add("foobar", None)
         self.assertEqual(list(registry.load_remotes().values()),
-                         [("conan-center", "https://conan.bintray.com", True, False),
+                         [("ConanCenter", "https://center.conan.io", True, False),
+                          ("conan-center", "https://conan.bintray.com", True, False),
                           ("foobar", None, True, False)])
         self.assertIn("WARN: The URL is empty. It must contain scheme and hostname.", cache._output)
         registry.remove("foobar")
 
         registry.update("conan-center", None)
         self.assertEqual(list(registry.load_remotes().values()),
-                         [("conan-center", None, True, False)])
+                         [("ConanCenter", "https://center.conan.io", True, False),
+                          ("conan-center", None, True, False)])
         self.assertIn("WARN: The URL is empty. It must contain scheme and hostname.", cache._output)
 
     def test_enable_disable_remotes(self):
@@ -158,22 +165,27 @@ other/1.0@lasote/testing conan.io
         registry.add("local", "http://localhost:9300")
         registry.set_disabled_state("local", True)
         self.assertEqual(list(registry.load_remotes().all_values()),
-                         [("conan-center", "https://conan.bintray.com", True, False),
+                         [("ConanCenter", "https://center.conan.io", True, False),
+                          ("conan-center", "https://conan.bintray.com", True, False),
                           ("local", "http://localhost:9300", True, True)])
 
         self.assertEqual(list(registry.load_remotes().values()),
-                         [("conan-center", "https://conan.bintray.com", True, False)])
+                         [("ConanCenter", "https://center.conan.io", True, False),
+                          ("conan-center", "https://conan.bintray.com", True, False)])
 
         registry.set_disabled_state("conan-center", True)
         self.assertEqual(list(registry.load_remotes().all_values()),
-                         [("conan-center", "https://conan.bintray.com", True, True),
+                         [("ConanCenter", "https://center.conan.io", True, False),
+                          ("conan-center", "https://conan.bintray.com", True, True),
                           ("local", "http://localhost:9300", True, True)])
 
-        self.assertEqual(list(registry.load_remotes().values()), [])
+        self.assertEqual(list(registry.load_remotes().values()),
+                         [("ConanCenter", "https://center.conan.io", True, False)])
 
         registry.set_disabled_state("*", False)
         self.assertEqual(list(registry.load_remotes().values()),
-                         [("conan-center", "https://conan.bintray.com", True, False),
+                         [("ConanCenter", "https://center.conan.io", True, False),
+                          ("conan-center", "https://conan.bintray.com", True, False),
                           ("local", "http://localhost:9300", True, False)])
 
         registry.set_disabled_state("*", True)


### PR DESCRIPTION
Changelog: Feature: Add new default `conancenter` remote for `https://center.conan.io` as first in the list.
Docs: https://github.com/conan-io/docs/pull/2112

After Bintray shutdown and without a way to update _legacy_ packages (those **not** coming from conan-center-index), it makes sense to start introducing this new remote as default and with top priority in the list.

- [x] Refer to the issue that supports this Pull Request.
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [x] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 

<sup>**Note:** By default this PR will skip the slower tests and will use a limited set of python versions. Check [here](https://github.com/conan-io/conan/blob/develop/.github/PR_INCREASE_TESTING.md) how to increase the testing level by writing some tags in the current PR body text.</sup>
