### PR TITLE
possible fix for lock of compatible packages

### DIFF
--- a/conans/client/graph/graph_binaries.py
+++ b/conans/client/graph/graph_binaries.py
@@ -166,15 +166,18 @@ class GraphBinariesAnalyzer(object):
                 locked.unlock_prev()
 
             if node.package_id != locked.package_id:  # It was a compatible package
-                node._package_id = locked.package_id  # FIXME: Ugly definition of private
                 # https://github.com/conan-io/conan/issues/9002
                 # We need to iterate to search the compatible combination
                 for compatible_package in node.conanfile.compatible_packages:
                     comp_package_id = compatible_package.package_id()
                     if comp_package_id == locked.package_id:
+                        node._package_id = locked.package_id  # FIXME: Ugly definition of private
                         node.conanfile.settings.values = compatible_package.settings
                         node.conanfile.options.values = compatible_package.options
                         break
+                else:
+                    raise ConanException("'%s' package-id '%s' doesn't match the locked one '%s'"
+                                         % (repr(locked.ref), node.package_id, locked.package_id))
         else:
             assert node.prev is None, "Non locked node shouldn't have PREV in evaluate_node"
             assert node.binary is None, "Node.binary should be None if not locked"

--- a/conans/client/graph/graph_binaries.py
+++ b/conans/client/graph/graph_binaries.py
@@ -157,18 +157,24 @@ class GraphBinariesAnalyzer(object):
 
         # If it has lock
         locked = node.graph_lock_node
-        if locked and locked.package_id:  # if package_id = None, nothing to lock here
-            # First we update the package_id, just in case there are differences or something
-            if locked.package_id != node.package_id and locked.package_id != PACKAGE_ID_UNKNOWN:
-                raise ConanException("'%s' package-id '%s' doesn't match the locked one '%s'"
-                                     % (repr(locked.ref), node.package_id, locked.package_id))
-            locked.package_id = node.package_id  # necessary for PACKAGE_ID_UNKNOWN
+        if locked and locked.package_id and locked.package_id != PACKAGE_ID_UNKNOWN:
             pref = PackageReference(locked.ref, locked.package_id, locked.prev)  # Keep locked PREV
             self._process_node(node, pref, build_mode, update, remotes)
             if node.binary == BINARY_MISSING and build_mode.allowed(node.conanfile):
                 node.binary = BINARY_BUILD
             if node.binary == BINARY_BUILD:
                 locked.unlock_prev()
+
+            if node.package_id != locked.package_id:  # It was a compatible package
+                node._package_id = locked.package_id  # FIXME: Ugly definition of private
+                # https://github.com/conan-io/conan/issues/9002
+                # We need to iterate to search the compatible combination
+                for compatible_package in node.conanfile.compatible_packages:
+                    comp_package_id = compatible_package.package_id()
+                    if comp_package_id == locked.package_id:
+                        node.conanfile.settings.values = compatible_package.settings
+                        node.conanfile.options.values = compatible_package.options
+                        break
         else:
             assert node.prev is None, "Non locked node shouldn't have PREV in evaluate_node"
             assert node.binary is None, "Node.binary should be None if not locked"

--- a/conans/test/integration/package_id/compatible_test.py
+++ b/conans/test/integration/package_id/compatible_test.py
@@ -511,7 +511,6 @@ class CompatibleIDsTest(unittest.TestCase):
             """)
 
         client.save({"conanfile.py": conanfile})
-        # Create package with gcc 4.8
         client.run("create . pkg/0.1@user/stable -s os=Linux")
         self.assertIn("pkg/0.1@user/stable: PackageInfo!: OS: Linux!", client.out)
         self.assertIn("pkg/0.1@user/stable: Package 'cb054d0b3e1ca595dc66bc2339d40f1f8f04ab31'"

--- a/conans/test/integration/package_id/compatible_test.py
+++ b/conans/test/integration/package_id/compatible_test.py
@@ -494,6 +494,37 @@ class CompatibleIDsTest(unittest.TestCase):
                       client.out)
         self.assertIn("pkg/0.1@user/testing: Already installed!", client.out)
 
+    def test_compatible_lockfile(self):
+        # https://github.com/conan-io/conan/issues/9002
+        client = TestClient()
+        conanfile = textwrap.dedent("""
+            from conans import ConanFile
+            class Pkg(ConanFile):
+                settings = "os"
+                def package_id(self):
+                    if self.settings.os == "Windows":
+                        compatible_pkg = self.info.clone()
+                        compatible_pkg.settings.os = "Linux"
+                        self.compatible_packages.append(compatible_pkg)
+                def package_info(self):
+                    self.output.info("PackageInfo!: OS: %s!" % self.settings.os)
+            """)
+
+        client.save({"conanfile.py": conanfile})
+        # Create package with gcc 4.8
+        client.run("create . pkg/0.1@user/stable -s os=Linux")
+        self.assertIn("pkg/0.1@user/stable: PackageInfo!: OS: Linux!", client.out)
+        self.assertIn("pkg/0.1@user/stable: Package 'cb054d0b3e1ca595dc66bc2339d40f1f8f04ab31'"
+                      " created", client.out)
+
+        # package can be used with a profile gcc 4.9 falling back to 4.8 binary
+        client.save({"conanfile.py": GenConanfile().with_require("pkg/0.1@user/stable")})
+        client.run("lock create conanfile.py -s os=Windows --lockfile-out=deps.lock")
+        client.run("install conanfile.py --lockfile=deps.lock")
+        self.assertIn("pkg/0.1@user/stable: PackageInfo!: OS: Linux!", client.out)
+        self.assertIn("pkg/0.1@user/stable:cb054d0b3e1ca595dc66bc2339d40f1f8f04ab31", client.out)
+        self.assertIn("pkg/0.1@user/stable: Already installed!", client.out)
+
 
 def test_msvc_visual_incompatible():
     conanfile = GenConanfile().with_settings("os", "compiler", "build_type", "arch")

--- a/conans/test/integration/package_id/compatible_test.py
+++ b/conans/test/integration/package_id/compatible_test.py
@@ -516,7 +516,6 @@ class CompatibleIDsTest(unittest.TestCase):
         self.assertIn("pkg/0.1@user/stable: Package 'cb054d0b3e1ca595dc66bc2339d40f1f8f04ab31'"
                       " created", client.out)
 
-        # package can be used with a profile gcc 4.9 falling back to 4.8 binary
         client.save({"conanfile.py": GenConanfile().with_require("pkg/0.1@user/stable")})
         client.run("lock create conanfile.py -s os=Windows --lockfile-out=deps.lock")
         client.run("install conanfile.py --lockfile=deps.lock")


### PR DESCRIPTION
Changelog: Bugfix: Avoid errors because of ``package_id`` mismatch in lockfiles when using ``compatible_packages`` feature.
Docs: Omit


Fix https://github.com/conan-io/conan/issues/9002