### PR TITLE
Fixed CMake toolchain for M1 crossbuilding and moved/completed test

### DIFF
--- a/conan/tools/cmake/toolchain.py
+++ b/conan/tools/cmake/toolchain.py
@@ -313,6 +313,8 @@ class AppleSystemBlock(Block):
         # for iOS a FAT library valid for simulator and device
         # can be generated if multiple archs are specified:
         # "-DCMAKE_OSX_ARCHITECTURES=armv7;armv7s;arm64;i386;x86_64"
+        if not host_context and not hasattr(self._conanfile, 'settings_build'):
+            return None
         arch = self._conanfile.settings.get_safe("arch") \
             if host_context else self._conanfile.settings_build.get_safe("arch")
         return {"x86": "i386",
@@ -342,7 +344,8 @@ class AppleSystemBlock(Block):
         host_architecture = self._get_architecture()
         # We could be cross building from Macos x64 to Macos armv8 (m1)
         build_architecture = self._get_architecture(host_context=False)
-        if os_ not in ('iOS', "watchOS", "tvOS") and host_architecture == build_architecture:
+        if os_ not in ('iOS', "watchOS", "tvOS") and \
+            (not build_architecture or host_architecture == build_architecture):
             return
 
         host_os = self._conanfile.settings.get_safe("os")

--- a/conan/tools/cmake/toolchain.py
+++ b/conan/tools/cmake/toolchain.py
@@ -292,7 +292,7 @@ class AndroidSystemBlock(Block):
         return ctxt_toolchain
 
 
-class IOSSystemBlock(Block):
+class AppleSystemBlock(Block):
     template = textwrap.dedent("""
         {% if CMAKE_SYSTEM_NAME is defined %}
         set(CMAKE_SYSTEM_NAME {{ CMAKE_SYSTEM_NAME }})
@@ -598,7 +598,7 @@ class CMakeToolchain(object):
                                           [("user_toolchain", UserToolchain),
                                            ("generic_system", GenericSystemBlock),
                                            ("android_system", AndroidSystemBlock),
-                                           ("ios_system", IOSSystemBlock)])
+                                           ("ios_system", AppleSystemBlock)])
 
         self.main_blocks = ToolchainBlocks(self._conanfile, self,
                                            [("find_paths", FindConfigFiles),

--- a/conan/tools/cmake/toolchain.py
+++ b/conan/tools/cmake/toolchain.py
@@ -294,8 +294,12 @@ class AndroidSystemBlock(Block):
 
 class IOSSystemBlock(Block):
     template = textwrap.dedent("""
+        {% if CMAKE_SYSTEM_NAME is defined %}
         set(CMAKE_SYSTEM_NAME {{ CMAKE_SYSTEM_NAME }})
+        {% endif %}
+        {% if CMAKE_SYSTEM_VERSION is defined %}
         set(CMAKE_SYSTEM_VERSION {{ CMAKE_SYSTEM_VERSION }})
+        {% endif %}
         set(DEPLOYMENT_TARGET ${CONAN_SETTINGS_HOST_MIN_OS_VERSION})
         # Set the architectures for which to build.
         set(CMAKE_OSX_ARCHITECTURES {{ CMAKE_OSX_ARCHITECTURES }} CACHE STRING "" FORCE)
@@ -304,12 +308,13 @@ class IOSSystemBlock(Block):
         set(CMAKE_OSX_SYSROOT {{ CMAKE_OSX_SYSROOT }} CACHE STRING "" FORCE)
         """)
 
-    def _get_architecture(self):
+    def _get_architecture(self, host_context=True):
         # check valid combinations of architecture - os ?
         # for iOS a FAT library valid for simulator and device
         # can be generated if multiple archs are specified:
         # "-DCMAKE_OSX_ARCHITECTURES=armv7;armv7s;arm64;i386;x86_64"
-        arch = self._conanfile.settings.get_safe("arch")
+        arch = self._conanfile.settings.get_safe("arch") \
+            if host_context else self._conanfile.settings_build.get_safe("arch")
         return {"x86": "i386",
                 "x86_64": "x86_64",
                 "armv8": "arm64",
@@ -334,9 +339,12 @@ class IOSSystemBlock(Block):
 
     def context(self):
         os_ = self._conanfile.settings.get_safe("os")
-        if os_ not in ('iOS', "watchOS", "tvOS"):
-            return
         host_architecture = self._get_architecture()
+        # We could be cross building from Macos x64 to Macos armv8 (m1)
+        build_architecture = self._get_architecture(host_context=False)
+        if os_ not in ('iOS', "watchOS", "tvOS") and host_architecture == build_architecture:
+            return
+
         host_os = self._conanfile.settings.get_safe("os")
         host_os_version = self._conanfile.settings.get_safe("os.version")
         host_sdk_name = self._apple_sdk_name()
@@ -346,10 +354,12 @@ class IOSSystemBlock(Block):
         #       default to os.version?
         ctxt_toolchain = {
             "CMAKE_OSX_ARCHITECTURES": host_architecture,
-            "CMAKE_SYSTEM_NAME": host_os,
-            "CMAKE_SYSTEM_VERSION": host_os_version,
             "CMAKE_OSX_SYSROOT": host_sdk_name
         }
+        if os_ in ('iOS', "watchOS", "tvOS"):
+            ctxt_toolchain["CMAKE_SYSTEM_NAME"] = host_os
+            ctxt_toolchain["CMAKE_SYSTEM_VERSION"] = host_os_version
+
         return ctxt_toolchain
 
 

--- a/conans/test/functional/toolchains/cmake/cmakedeps/test_apple_frameworks.py
+++ b/conans/test/functional/toolchains/cmake/cmakedeps/test_apple_frameworks.py
@@ -3,10 +3,8 @@ import textwrap
 
 import pytest
 
-from conans.client.tools import XCRun, to_apple_arch
 from conans.client.tools.env import environment_append
 from conans.model.ref import ConanFileReference
-from conans.test.assets.sources import gen_function_cpp
 from conans.test.utils.tools import TestClient
 
 
@@ -453,75 +451,3 @@ target_link_libraries(${PROJECT_NAME} hello::libhello)
             'test_package/CMakeLists.txt': test_cmakelists_txt,
             'test_package/test_package.cpp': test_test_package_cpp})
     t.run("create . hello/1.0@")
-
-
-@pytest.mark.skipif(platform.system() != "Darwin", reason="Only OSX")
-def test_m1():
-    xcrun = XCRun(None, sdk='iphoneos')
-    cflags = " -isysroot " + xcrun.sdk_path
-    cflags += " -arch " + to_apple_arch('armv8')
-    cxxflags = cflags
-    ldflags = cflags
-
-    profile = textwrap.dedent("""
-        include(default)
-        [settings]
-        os=iOS
-        os.version=12.0
-        arch=armv8
-        [env]
-        CC={cc}
-        CXX={cxx}
-        CFLAGS={cflags}
-        CXXFLAGS={cxxflags}
-        LDFLAGS={ldflags}
-    """).format(cc=xcrun.cc, cxx=xcrun.cxx, cflags=cflags, cxxflags=cxxflags, ldflags=ldflags)
-
-    client = TestClient(path_with_spaces=False)
-    client.save({"m1": profile}, clean_first=True)
-    client.run("new hello/0.1 --template=v2_cmake")
-    client.run("create . --profile:build=default --profile:host=m1 -tf None")
-
-    main = gen_function_cpp(name="main", includes=["hello"], calls=["hello"])
-    # FIXME: The crossbuild for iOS etc is failing with find_package because cmake ignore the
-    #        cmake_prefix_path to point only to the Frameworks of the system. The only fix found
-    #        would require to introduce something like "set (mylibrary_DIR "${CMAKE_BINARY_DIR}")"
-    #        at the toolchain (but it would require the toolchain to know about the deps)
-    #        https://stackoverflow.com/questions/65494246/cmakes-find-package-ignores-the-paths-option-when-building-for-ios#
-    cmakelists = textwrap.dedent("""
-    cmake_minimum_required(VERSION 3.15)
-    project(MyApp CXX)
-    set(hello_DIR "${CMAKE_BINARY_DIR}")
-    find_package(hello)
-    add_executable(main main.cpp)
-    target_link_libraries(main hello::hello)
-    """)
-
-    conanfile = textwrap.dedent("""
-        from conans import ConanFile
-        from conan.tools.cmake import CMake
-
-        class TestConan(ConanFile):
-            requires = "hello/0.1"
-            settings = "os", "compiler", "arch", "build_type"
-            exports_sources = "CMakeLists.txt", "main.cpp"
-            generators = "CMakeDeps", "CMakeToolchain"
-
-            def build(self):
-                cmake = CMake(self)
-                cmake.configure()
-                cmake.build()
-        """)
-
-    client.save({"conanfile.py": conanfile,
-                 "CMakeLists.txt": cmakelists,
-                 "main.cpp": main,
-                 "m1": profile}, clean_first=True)
-    client.run("install . --profile:build=default --profile:host=m1")
-    client.run("build .")
-    main_path = "./main.app/main"
-    client.run_command(main_path, assert_error=True)
-    assert "Bad CPU type in executable" in client.out
-    client.run_command("lipo -info {}".format(main_path))
-    assert "Non-fat file" in client.out
-    assert "is architecture: arm64" in client.out

--- a/conans/test/functional/toolchains/cmake/test_cmake_toolchain_m1.py
+++ b/conans/test/functional/toolchains/cmake/test_cmake_toolchain_m1.py
@@ -1,0 +1,65 @@
+import textwrap
+import platform
+
+
+import pytest
+
+from conans.test.assets.sources import gen_function_cpp
+from conans.test.utils.tools import TestClient
+
+
+@pytest.mark.skipif(platform.system() != "Darwin", reason="Only OSX")
+@pytest.mark.parametrize("op_system", ["Macos", "iOS"])
+def test_m1(op_system):
+    os_version = "os.version=12.0" if op_system == "iOS" else ""
+    profile = textwrap.dedent("""
+        include(default)
+        [settings]
+        os={}
+        {}
+        arch=armv8
+    """.format(op_system, os_version))
+
+    client = TestClient(path_with_spaces=False)
+    client.save({"m1": profile}, clean_first=True)
+    client.run("new hello/0.1 --template=v2_cmake")
+    client.run("create . --profile:build=default --profile:host=m1 -tf None")
+
+    main = gen_function_cpp(name="main", includes=["hello"], calls=["hello"])
+    cmakelists = textwrap.dedent("""
+    cmake_minimum_required(VERSION 3.15)
+    project(MyApp CXX)
+    set(hello_DIR "${CMAKE_BINARY_DIR}")
+    find_package(hello)
+    add_executable(main main.cpp)
+    target_link_libraries(main hello::hello)
+    """)
+
+    conanfile = textwrap.dedent("""
+        from conans import ConanFile
+        from conan.tools.cmake import CMake
+
+        class TestConan(ConanFile):
+            requires = "hello/0.1"
+            settings = "os", "compiler", "arch", "build_type"
+            exports_sources = "CMakeLists.txt", "main.cpp"
+            generators = "CMakeDeps", "CMakeToolchain"
+
+            def build(self):
+                cmake = CMake(self)
+                cmake.configure()
+                cmake.build()
+        """)
+
+    client.save({"conanfile.py": conanfile,
+                 "CMakeLists.txt": cmakelists,
+                 "main.cpp": main,
+                 "m1": profile}, clean_first=True)
+    client.run("install . --profile:build=default --profile:host=m1")
+    client.run("build .")
+    main_path = "./main.app/main" if op_system == "iOS" else "./main"
+    client.run_command(main_path, assert_error=True)
+    assert "Bad CPU type in executable" in client.out
+    client.run_command("lipo -info {}".format(main_path))
+    assert "Non-fat file" in client.out
+    assert "is architecture: arm64" in client.out

--- a/conans/test/functional/toolchains/cmake/test_cmake_toolchain_m1.py
+++ b/conans/test/functional/toolchains/cmake/test_cmake_toolchain_m1.py
@@ -4,6 +4,7 @@ import platform
 
 import pytest
 
+from conans.test.assets.cmake import gen_cmakelists
 from conans.test.assets.sources import gen_function_cpp
 from conans.test.utils.tools import TestClient
 
@@ -26,14 +27,9 @@ def test_m1(op_system):
     client.run("create . --profile:build=default --profile:host=m1 -tf None")
 
     main = gen_function_cpp(name="main", includes=["hello"], calls=["hello"])
-    cmakelists = textwrap.dedent("""
-    cmake_minimum_required(VERSION 3.15)
-    project(MyApp CXX)
-    set(hello_DIR "${CMAKE_BINARY_DIR}")
-    find_package(hello)
-    add_executable(main main.cpp)
-    target_link_libraries(main hello::hello)
-    """)
+    cmakelists = gen_cmakelists(find_package=["hello"], appname="main", appsources=["main.cpp"] )
+    # Cross building for iOS needs this trick to look outside the system frameworks dirs
+    cmakelists = 'set(hello_DIR "${CMAKE_BINARY_DIR}")\n' + cmakelists
 
     conanfile = textwrap.dedent("""
         from conans import ConanFile


### PR DESCRIPTION
Changelog: Fix: The `CMakeToolchain` now supports Apple M1 cross-building with a profile without environment declared pointing to the system toolchain.
Docs: omit


Moved test (was not testing frameworks) and refactored to test iOS armv8 and Macos armv8 without any trick in the profile.