### PR TITLE
CMakeDeps improvements

### DIFF
--- a/conan/tools/cmake/cmakedeps/cmakedeps.py
+++ b/conan/tools/cmake/cmakedeps/cmakedeps.py
@@ -16,17 +16,13 @@ class CMakeDeps(object):
         self._conanfile = conanfile
         self.arch = self._conanfile.settings.get_safe("arch")
         self.configuration = str(self._conanfile.settings.build_type)
-        if hasattr(self._conanfile, "settings_build"):
-            self.configuration_build = str(self._conanfile.settings_build.get_safe("build_type"))
-            self.arch_build = str(self._conanfile.settings_build.get_safe("arch"))
-        else:
-            self.configuration_build = self.configuration
-            self.arch_build = self.arch
 
         self.configurations = [v for v in conanfile.settings.build_type.values_range if v != "None"]
+        # Activate the build config files for the specified libraries
+        self.build_context_activated = []
         # By default, the build modules are generated for host context only
         self.build_context_build_modules = []
-        # If specified, the files/targets/variables for the build context will be renamed appeding
+        # If specified, the files/targets/variables for the build context will be renamed appending
         # a suffix. It is necessary in case of same require and build_require and will cause an error
         self.build_context_suffix = {}
 
@@ -55,6 +51,10 @@ class CMakeDeps(object):
 
         # Iterate all the transitive requires
         for req in host_req + build_req:
+
+            # Filter the build_requires not activated with cmakedeps.build_context_activated
+            if req.is_build_context and req.ref.name not in self.build_context_activated:
+                continue
 
             config_version = ConfigVersionTemplate(self, req)
             ret[config_version.filename] = config_version.render()

--- a/conan/tools/cmake/cmakedeps/templates/__init__.py
+++ b/conan/tools/cmake/cmakedeps/templates/__init__.py
@@ -59,15 +59,14 @@ class CMakeDepsFileTemplate(object):
             return self.cmakedeps.configuration \
                 if self.cmakedeps.configuration else None
         else:
-            return self.cmakedeps.configuration_build\
-                if self.cmakedeps.configuration_build else None
+            return str(self.conanfile.settings_build.get_safe("build_type"))
 
     @property
     def arch(self):
         if not self.conanfile.is_build_context:
             return self.cmakedeps.arch if self.cmakedeps.arch else None
         else:
-            return self.cmakedeps.arch_build if self.cmakedeps.arch_build else None
+            return str(self.conanfile.settings_build.get_safe("arch"))
 
     @property
     def config_suffix(self):

--- a/conan/tools/cmake/cmakedeps/templates/__init__.py
+++ b/conan/tools/cmake/cmakedeps/templates/__init__.py
@@ -83,7 +83,7 @@ def get_component_alias(req, comp_name):
     if comp_name not in req.new_cpp_info.components:
         # foo::foo might be referencing the root cppinfo
         if req.ref.name == comp_name:
-            return comp_name
+            return get_target_namespace(req)
         raise ConanException("Component '{name}::{cname}' not found in '{name}' "
                              "package requirement".format(name=req.ref.name, cname=comp_name))
     ret = req.new_cpp_info.components[comp_name].get_property("cmake_target_name", "CMakeDeps")

--- a/conan/tools/cmake/cmakedeps/templates/__init__.py
+++ b/conan/tools/cmake/cmakedeps/templates/__init__.py
@@ -59,14 +59,14 @@ class CMakeDepsFileTemplate(object):
             return self.cmakedeps.configuration \
                 if self.cmakedeps.configuration else None
         else:
-            return str(self.conanfile.settings_build.get_safe("build_type"))
+            return self.conanfile.settings_build.get_safe("build_type")
 
     @property
     def arch(self):
         if not self.conanfile.is_build_context:
             return self.cmakedeps.arch if self.cmakedeps.arch else None
         else:
-            return str(self.conanfile.settings_build.get_safe("arch"))
+            return self.conanfile.settings_build.get_safe("arch")
 
     @property
     def config_suffix(self):

--- a/conan/tools/cmake/cmakedeps/templates/config.py
+++ b/conan/tools/cmake/cmakedeps/templates/config.py
@@ -47,6 +47,7 @@ class ConfigTemplate(CMakeDepsFileTemplate):
 
         # Only the first installed configuration is included to avoid the collission
         foreach(_BUILD_MODULE {{ '${' + pkg_name + '_BUILD_MODULES_PATHS' + config_suffix + '}' }} )
+            conan_message(STATUS "Conan: Including build module from '${_BUILD_MODULE}'")
             include({{ '${_BUILD_MODULE}' }})
         endforeach()
 

--- a/conan/tools/cmake/cmakedeps/templates/target_data.py
+++ b/conan/tools/cmake/cmakedeps/templates/target_data.py
@@ -30,7 +30,10 @@ class ConfigDataTemplate(CMakeDepsFileTemplate):
         components_cpp = self.get_required_components_cpp()
         components_renames = " ".join([component_rename for component_rename, _ in
                                        reversed(components_cpp)])
-        dependency_filenames = self.get_dependency_filenames()
+        # For the build requires, we don't care about the transitive (only runtime for the br)
+        # so as the xxx-conf.cmake files won't be generated, don't include them as find_dependency
+        dependency_filenames = self.get_dependency_filenames() \
+            if not self.conanfile.is_build_context else []
         package_folder = self.conanfile.package_folder.replace('\\', '/')\
                                                       .replace('$', '\\$').replace('"', '\\"')
         return {"global_cpp": global_cpp,

--- a/conan/tools/cmake/cmakedeps/templates/target_data.py
+++ b/conan/tools/cmake/cmakedeps/templates/target_data.py
@@ -15,7 +15,7 @@ class ConfigDataTemplate(CMakeDepsFileTemplate):
 
     @property
     def filename(self):
-        data_fname = "{}-{}".format(self.file_name, self.configuration)
+        data_fname = "{}-{}".format(self.file_name, self.configuration.lower())
         if self.arch:
             data_fname += "-{}".format(self.arch)
         data_fname += "-data.cmake"

--- a/conan/tools/cmake/cmakedeps/templates/target_data.py
+++ b/conan/tools/cmake/cmakedeps/templates/target_data.py
@@ -32,6 +32,8 @@ class ConfigDataTemplate(CMakeDepsFileTemplate):
                                        reversed(components_cpp)])
         # For the build requires, we don't care about the transitive (only runtime for the br)
         # so as the xxx-conf.cmake files won't be generated, don't include them as find_dependency
+        # This is because in Conan 2.0 model, only the pure tools like CMake will be build_requires
+        # for example a framework test won't be a build require but a "test/not public" require.
         dependency_filenames = self.get_dependency_filenames() \
             if not self.conanfile.is_build_context else []
         package_folder = self.conanfile.package_folder.replace('\\', '/')\

--- a/conan/tools/cmake/toolchain.py
+++ b/conan/tools/cmake/toolchain.py
@@ -294,8 +294,12 @@ class AndroidSystemBlock(Block):
 
 class IOSSystemBlock(Block):
     template = textwrap.dedent("""
+        {% if CMAKE_SYSTEM_NAME is defined %}
         set(CMAKE_SYSTEM_NAME {{ CMAKE_SYSTEM_NAME }})
+        {% endif %}
+        {% if CMAKE_SYSTEM_VERSION is defined %}
         set(CMAKE_SYSTEM_VERSION {{ CMAKE_SYSTEM_VERSION }})
+        {% endif %}
         set(DEPLOYMENT_TARGET ${CONAN_SETTINGS_HOST_MIN_OS_VERSION})
         # Set the architectures for which to build.
         set(CMAKE_OSX_ARCHITECTURES {{ CMAKE_OSX_ARCHITECTURES }} CACHE STRING "" FORCE)
@@ -304,12 +308,13 @@ class IOSSystemBlock(Block):
         set(CMAKE_OSX_SYSROOT {{ CMAKE_OSX_SYSROOT }} CACHE STRING "" FORCE)
         """)
 
-    def _get_architecture(self):
+    def _get_architecture(self, host_context=True):
         # check valid combinations of architecture - os ?
         # for iOS a FAT library valid for simulator and device
         # can be generated if multiple archs are specified:
         # "-DCMAKE_OSX_ARCHITECTURES=armv7;armv7s;arm64;i386;x86_64"
-        arch = self._conanfile.settings.get_safe("arch")
+        arch = self._conanfile.settings.get_safe("arch") \
+            if host_context else self._conanfile.settings_build.get_safe("arch")
         return {"x86": "i386",
                 "x86_64": "x86_64",
                 "armv8": "arm64",
@@ -334,9 +339,12 @@ class IOSSystemBlock(Block):
 
     def context(self):
         os_ = self._conanfile.settings.get_safe("os")
-        if os_ not in ('iOS', "watchOS", "tvOS"):
-            return
         host_architecture = self._get_architecture()
+        build_architecture = self._get_architecture(host_context=False)
+
+        if os_ not in ('iOS', "watchOS", "tvOS") and host_architecture == build_architecture:
+            return
+
         host_os = self._conanfile.settings.get_safe("os")
         host_os_version = self._conanfile.settings.get_safe("os.version")
         host_sdk_name = self._apple_sdk_name()
@@ -346,10 +354,12 @@ class IOSSystemBlock(Block):
         #       default to os.version?
         ctxt_toolchain = {
             "CMAKE_OSX_ARCHITECTURES": host_architecture,
-            "CMAKE_SYSTEM_NAME": host_os,
-            "CMAKE_SYSTEM_VERSION": host_os_version,
             "CMAKE_OSX_SYSROOT": host_sdk_name
         }
+        if os_ in ('iOS', "watchOS", "tvOS"):
+            ctxt_toolchain["CMAKE_SYSTEM_NAME"] = host_os
+            ctxt_toolchain["CMAKE_SYSTEM_VERSION"] = host_os_version
+
         return ctxt_toolchain
 
 

--- a/conans/model/conanfile_interface.py
+++ b/conans/model/conanfile_interface.py
@@ -55,6 +55,10 @@ class ConanFileInterface:
         return self._conanfile.settings
 
     @property
+    def settings_build(self):
+        return self._conanfile.settings_build
+
+    @property
     def context(self):
         return self._conanfile.context
 

--- a/conans/model/new_build_info.py
+++ b/conans/model/new_build_info.py
@@ -174,7 +174,6 @@ class NewCppInfo(object):
             for n in _DIRS_VAR_NAMES + _FIELD_VAR_NAMES:
                 setattr(self.components[None], n, [])
 
-            self.components[None]._generator_properties = {}
             for name in cnames:
                 component = components[name]
                 for n in _DIRS_VAR_NAMES + _FIELD_VAR_NAMES:

--- a/conans/model/new_build_info.py
+++ b/conans/model/new_build_info.py
@@ -174,6 +174,7 @@ class NewCppInfo(object):
             for n in _DIRS_VAR_NAMES + _FIELD_VAR_NAMES:
                 setattr(self.components[None], n, [])
 
+            self.components[None]._generator_properties = {}
             for name in cnames:
                 component = components[name]
                 for n in _DIRS_VAR_NAMES + _FIELD_VAR_NAMES:
@@ -185,17 +186,14 @@ class NewCppInfo(object):
 
                 # NOTE: The properties are not aggregated because they might refer only to the
                 # component like "cmake_target_name" describing the target name FOR THE component
-                # not the namespace. The build_modules should be declared in the global one.
+                # not the namespace.
                 # We only aggregate manually the "cmake_build_modules" that is the one replacing
                 # the old cpp_info.components["foo"].build_modules
                 if component._generator_properties:
                     for gen_name, props in component._generator_properties.items():
-                        if props["cmake_build_modules"]:
+                        if props.get("cmake_build_modules"):
                             dest = self.components[None]._generator_properties
-                            if dest.get(gen_name) is None:
-                                dest[gen_name] = {}
-                            if dest[gen_name].get("cmake_build_modules") is None:
-                                dest[gen_name]["cmake_build_modules"] = []
+                            dest.setdefault(gen_name, {}).setdefault("cmake_build_modules", [])
                             for new_value in props["cmake_build_modules"]:
                                 if new_value not in dest[gen_name]["cmake_build_modules"]:
                                     dest[gen_name]["cmake_build_modules"].append(new_value)

--- a/conans/model/new_build_info.py
+++ b/conans/model/new_build_info.py
@@ -186,6 +186,19 @@ class NewCppInfo(object):
                 # NOTE: The properties are not aggregated because they might refer only to the
                 # component like "cmake_target_name" describing the target name FOR THE component
                 # not the namespace. The build_modules should be declared in the global one.
+                # We only aggregate manually the "cmake_build_modules" that is the one replacing
+                # the old cpp_info.components["foo"].build_modules
+                if component._generator_properties:
+                    for gen_name, props in component._generator_properties.items():
+                        if props["cmake_build_modules"]:
+                            dest = self.components[None]._generator_properties
+                            if dest.get(gen_name) is None:
+                                dest[gen_name] = {}
+                            if dest[gen_name].get("cmake_build_modules") is None:
+                                dest[gen_name]["cmake_build_modules"] = []
+                            for new_value in props["cmake_build_modules"]:
+                                if new_value not in dest[gen_name]["cmake_build_modules"]:
+                                    dest[gen_name]["cmake_build_modules"].append(new_value)
 
                 if component.requires:
                     if self.components[None].requires is None:

--- a/conans/model/new_build_info.py
+++ b/conans/model/new_build_info.py
@@ -187,16 +187,6 @@ class NewCppInfo(object):
                 # NOTE: The properties are not aggregated because they might refer only to the
                 # component like "cmake_target_name" describing the target name FOR THE component
                 # not the namespace.
-                # We only aggregate manually the "cmake_build_modules" that is the one replacing
-                # the old cpp_info.components["foo"].build_modules
-                if component._generator_properties:
-                    for gen_name, props in component._generator_properties.items():
-                        if props.get("cmake_build_modules"):
-                            dest = self.components[None]._generator_properties
-                            dest.setdefault(gen_name, {}).setdefault("cmake_build_modules", [])
-                            for new_value in props["cmake_build_modules"]:
-                                if new_value not in dest[gen_name]["cmake_build_modules"]:
-                                    dest[gen_name]["cmake_build_modules"].append(new_value)
 
                 if component.requires:
                     if self.components[None].requires is None:
@@ -276,7 +266,9 @@ def from_old_cppinfo(old):
 
     for cname, c in old.components.items():
         if c.build_modules:
-            _copy_build_modules_to_property(c, ret.components[cname])
+            # The build modules properties are applied to the root cppinfo, not per component
+            # because it is something global that makes no sense to be set at a component
+            _copy_build_modules_to_property(c, ret)
     return ret
 
 

--- a/conans/test/functional/toolchains/cmake/cmakedeps/test_build_context_protobuf.py
+++ b/conans/test/functional/toolchains/cmake/cmakedeps/test_build_context_protobuf.py
@@ -24,8 +24,8 @@ def client():
             """
 
             with chdir(self.package_folder):
-                save("include_build/protobuff.h", "int protubuff_stuff(){ return 1; }")
-                save("include_host/protobuff.h", "int protubuff_stuff(){ return 2; }")
+                save("include_build/protobuf.h", "int protubuff_stuff(){ return 1; }")
+                save("include_host/protobuf.h", "int protubuff_stuff(){ return 2; }")
                 save("build/my_tools_build.cmake", my_cmake_module % "1")
                 save("build/my_tools_host.cmake", my_cmake_module % "2")
 
@@ -37,13 +37,13 @@ def client():
 
     ''')
     c.save({"conanfile.py": conanfile})
-    c.run("create . protobuff/1.0@")
+    c.run("create . protobuf/1.0@")
     return c
 
 
 main = textwrap.dedent("""
     #include <iostream>
-    #include "protobuff.h"
+    #include "protobuf.h"
     #include "foo_generated.h"
 
 
@@ -76,8 +76,8 @@ consumer_conanfile = textwrap.dedent("""
         class Consumer(ConanFile):
             settings = "build_type", "os", "arch", "compiler"
             exports_sources = "CMakeLists.txt", "main.cpp"
-            requires = "protobuff/1.0"
-            build_requires = "protobuff/1.0"
+            requires = "protobuf/1.0"
+            build_requires = "protobuf/1.0"
 
             def generate(self):
                 toolchain = CMakeToolchain(self)
@@ -103,16 +103,17 @@ def test_build_modules_from_build_context(client):
         cmake_minimum_required(VERSION 3.15)
         project(MyApp CXX)
 
-        find_package(protobuff)
-        find_package(protobuff_BUILD)
+        find_package(protobuf)
+        find_package(protobuf_BUILD)
         add_executable(app main.cpp)
         foo_generate()
-        target_link_libraries(app protobuff::protobuff)
+        target_link_libraries(app protobuf::protobuf)
         """)
 
     cmake_deps_conf = """
-        deps.build_context_build_modules = ["protobuff"]
-        deps.build_context_suffix = {"protobuff": "_BUILD"}
+        deps.build_context_activated = ["protobuf"]
+        deps.build_context_build_modules = ["protobuf"]
+        deps.build_context_suffix = {"protobuf": "_BUILD"}
     """
 
     client.save({"conanfile.py": consumer_conanfile.format(cmake_deps_conf),
@@ -131,16 +132,17 @@ def test_build_modules_and_target_from_build_context(client):
         cmake_minimum_required(VERSION 3.15)
         project(MyApp CXX)
 
-        find_package(protobuff)
-        find_package(protobuff_BUILD)
+        find_package(protobuf)
+        find_package(protobuf_BUILD)
         add_executable(app main.cpp)
         foo_generate()
-        target_link_libraries(app protobuff_BUILD::protobuff_BUILD)
+        target_link_libraries(app protobuf_BUILD::protobuf_BUILD)
         """)
 
     cmake_deps_conf = """
-        deps.build_context_build_modules = ["protobuff"]
-        deps.build_context_suffix = {"protobuff": "_BUILD"}
+        deps.build_context_activated = ["protobuf"]
+        deps.build_context_build_modules = ["protobuf"]
+        deps.build_context_suffix = {"protobuf": "_BUILD"}
     """
 
     client.save({"conanfile.py": consumer_conanfile.format(cmake_deps_conf),
@@ -159,15 +161,16 @@ def test_build_modules_from_host_and_target_from_build_context(client):
         cmake_minimum_required(VERSION 3.15)
         project(MyApp CXX)
 
-        find_package(protobuff)
-        find_package(protobuff_BUILD)
+        find_package(protobuf)
+        find_package(protobuf_BUILD)
         add_executable(app main.cpp)
         foo_generate()
-        target_link_libraries(app protobuff_BUILD::protobuff_BUILD)
+        target_link_libraries(app protobuf_BUILD::protobuf_BUILD)
         """)
 
     cmake_deps_conf = """
-        deps.build_context_suffix = {"protobuff": "_BUILD"}
+        deps.build_context_activated = ["protobuf"]
+        deps.build_context_suffix = {"protobuf": "_BUILD"}
     """
 
     client.save({"conanfile.py": consumer_conanfile.format(cmake_deps_conf),
@@ -186,16 +189,16 @@ def test_build_modules_and_target_from_host_context(client):
         cmake_minimum_required(VERSION 3.15)
         project(MyApp CXX)
 
-        find_package(protobuff)
-        find_package(protobuff_BUILD)
+        find_package(protobuf)
+        find_package(protobuf_BUILD)
         add_executable(app main.cpp)
         foo_generate()
-        target_link_libraries(app protobuff::protobuff)
+        target_link_libraries(app protobuf::protobuf)
         """)
 
     cmake_deps_conf = """
         deps.build_context_build_modules = []
-        deps.build_context_suffix = {"protobuff": "_BUILD"}
+        deps.build_context_suffix = {"protobuf": "_BUILD"}
     """
 
     client.save({"conanfile.py": consumer_conanfile.format(cmake_deps_conf),
@@ -214,10 +217,10 @@ def test_exception_when_not_prefix_specified(client):
         cmake_minimum_required(VERSION 3.15)
         project(MyApp CXX)
 
-        find_package(protobuff)
+        find_package(protobuf)
         add_executable(app main.cpp)
         foo_generate()
-        target_link_libraries(app protobuff::protobuff)
+        target_link_libraries(app protobuf::protobuf)
         """)
 
     cmake_deps_conf = """
@@ -228,6 +231,6 @@ def test_exception_when_not_prefix_specified(client):
                  "main.cpp": main})
 
     client.run("create . app/1.0@ -pr:b default -pr:h default", assert_error=True)
-    assert "The package 'protobuff' exists both as 'require' and as 'build require'. " \
+    assert "The package 'protobuf' exists both as 'require' and as 'build require'. " \
            "You need to specify a suffix using the 'build_context_suffix' attribute at the " \
            "CMakeDeps generator." in client.out

--- a/conans/test/functional/toolchains/cmake/cmakedeps/test_build_context_transitive_build.py
+++ b/conans/test/functional/toolchains/cmake/cmakedeps/test_build_context_transitive_build.py
@@ -1,0 +1,90 @@
+import os
+import textwrap
+
+import pytest
+
+from conans.test.utils.tools import TestClient
+
+"""
+If we have a BR with transitive requires we won't generate 'xxx-config.cmake' files for them
+but neither will be included as find_dependencies()
+"""
+
+@pytest.fixture
+def client():
+    c = TestClient()
+    zlib_conanfile = textwrap.dedent('''
+    from conans import ConanFile
+
+    class Zlib(ConanFile):
+        name = "zlib"
+        version = "1.2.11"
+
+        def package_info(self):
+            self.cpp_info.includedirs = []
+            self.cpp_info.cxxflags = ["foo"]
+    ''')
+    c.save({"conanfile.py": zlib_conanfile})
+    c.run("create . ")
+
+    doxygen_conanfile = textwrap.dedent('''
+    from conans import ConanFile
+    from conans.tools import save, chdir
+    import os
+
+    class Doxygen(ConanFile):
+        settings = "build_type", "os", "arch", "compiler"
+        requires = "zlib/1.2.11"
+
+        def package(self):
+            with chdir(self.package_folder):
+                save("include/doxygen.h", "int foo=1;")
+    ''')
+    c.save({"conanfile.py": doxygen_conanfile})
+    c.run("create . doxygen/1.0@")
+    return c
+
+
+def test_zlib_not_included(client):
+
+    main = textwrap.dedent("""
+    #include "doxygen.h"
+    int main(){
+        return foo;
+    }
+    """)
+    cmake = textwrap.dedent("""
+    cmake_minimum_required(VERSION 3.15)
+    project(foo)
+    set(CMAKE_CXX_COMPILER_WORKS 1)
+    set(CMAKE_CXX_ABI_COMPILED 1)
+    find_package(doxygen)
+    add_executable(main main.cpp)
+    """)
+
+    conanfile_consumer = textwrap.dedent('''
+    from conans import ConanFile
+    from conans.tools import save, chdir
+    import os
+
+    class Consumer(ConanFile):
+        settings = "build_type", "os", "arch", "compiler"
+        build_requires = "doxygen/1.0"
+        generators = "CMakeDeps", "CMakeToolchain"
+
+    ''')
+    client.save({"main.cpp": main, "CMakeLists.txt": cmake, "conanfile.py": conanfile_consumer},
+                clean_first=True)
+    client.run("install . -pr:h=default -pr:b=default")
+    # The compilation works, so it finds the doxygen without transitive failures
+    client.run_command("cmake . -DCMAKE_TOOLCHAIN_FILE=conan_toolchain.cmake")
+
+    # Assert there is no zlib target
+    assert "Target declared 'zlib::zlib'" not in client.out
+
+    # Of course we find the doxygen-config.cmake
+    assert os.path.exists(os.path.join(client.current_folder, "doxygen-config.cmake"))
+
+    # The -config files for zlib are not there
+    assert not os.path.exists(os.path.join(client.current_folder, "zlib-config.cmake"))
+

--- a/conans/test/functional/toolchains/cmake/cmakedeps/test_cmakedeps.py
+++ b/conans/test/functional/toolchains/cmake/cmakedeps/test_cmakedeps.py
@@ -232,8 +232,8 @@ def test_custom_configuration(client):
     client.run("install . -pr:h default -s:h build_type=Debug"
                " -pr:b default -s:b arch=x86 --build missing")
     curdir = client.current_folder
-    data_name_context_build = "liba_build-RelWithDebInfo-x86-data.cmake"
-    data_name_context_host = "liba-Debug-x86_64-data.cmake"
+    data_name_context_build = "liba_build-relwithdebinfo-x86-data.cmake"
+    data_name_context_host = "liba-debug-x86_64-data.cmake"
     assert os.path.exists(os.path.join(curdir, data_name_context_build))
     assert os.path.exists(os.path.join(curdir, data_name_context_host))
 

--- a/conans/test/functional/toolchains/cmake/cmakedeps/test_cmakedeps.py
+++ b/conans/test/functional/toolchains/cmake/cmakedeps/test_cmakedeps.py
@@ -223,13 +223,14 @@ def test_custom_configuration(client):
 
            def generate(self):
                cmake = CMakeDeps(self)
-               cmake.configuration_build = "RelWithDebInfo"
+               cmake.configuration = "Debug"
+               cmake.build_context_activated = ["liba"]
                cmake.build_context_suffix["liba"] = "_build"
                cmake.generate()
        """)
 
     client.save({"conanfile.py": conanfile})
-    client.run("install . -pr:h default -s:h build_type=Debug"
+    client.run("install . -pr:h default -s:b build_type=RelWithDebInfo"
                " -pr:b default -s:b arch=x86 --build missing")
     curdir = client.current_folder
     data_name_context_build = "liba_build-relwithdebinfo-x86-data.cmake"

--- a/conans/test/unittests/conan_build_info/new_build_info_test.py
+++ b/conans/test/unittests/conan_build_info/new_build_info_test.py
@@ -61,7 +61,6 @@ def test_component_aggregation():
     cppinfo.components["c1"].defines = ["defines_c1"]
     cppinfo.components["c1"].set_property("my_foo", "jander")
     cppinfo.components["c1"].set_property("my_foo2", "bar2", "other_gen")
-    cppinfo.components["c1"].set_property("cmake_build_modules", ["build_module_c1"])
 
 
     ret = cppinfo.copy()
@@ -80,8 +79,7 @@ def test_component_aggregation():
     # for example, cannot be aggregated. But "cmake_build_modules" is aggregated.
     assert ret.get_property("my_foo") is None
     assert ret.get_property("my_foo2", "other_gen") is None
-    assert ret.get_property("cmake_build_modules") == ["build_module_c1", "build_module_c2",
-                                                       "build_module_c22"]
+    assert ret.get_property("cmake_build_modules") == None
 
     # If we change the internal graph the order is different
     cppinfo.components["c1"].requires = []
@@ -165,11 +163,14 @@ def test_from_old_cppinfo_components():
         assert getattr(cppinfo.components["foo2"], n) == ["var2_{}_1".format(n),
                                                           "var2_{}_2".format(n)]
 
-    assert cppinfo.components["foo"].get_property("cmake_build_modules") == \
-           ["foo_my_scripts.cmake", "foo.cmake"]
+    # The .build_modules are assigned to the root cppinfo because it is something
+    # global that make no sense to set as a component property
+    assert cppinfo.components["foo"].get_property("cmake_build_modules") is None
     assert cppinfo.components["foo"].requires == ["my_req::my_component"]
-    assert cppinfo.components["foo2"].get_property("cmake_build_modules") == \
-           ["foo2_my_scripts.cmake"]
+    assert cppinfo.components["foo2"].get_property("cmake_build_modules") is None
+
+    assert cppinfo.get_property("cmake_build_modules") == \
+           ["foo_my_scripts.cmake", "foo.cmake", "foo2_my_scripts.cmake"]
 
 
 def test_from_old_cppinfo_no_components():

--- a/conans/test/unittests/conan_build_info/new_build_info_test.py
+++ b/conans/test/unittests/conan_build_info/new_build_info_test.py
@@ -47,6 +47,8 @@ def test_component_aggregation():
     cppinfo.components["c2"].cxxflags = ["cxxflags_c2"]
     cppinfo.components["c2"].defines = ["defines_c2"]
     cppinfo.components["c2"].set_property("my_foo", ["bar", "bar2"])
+    cppinfo.components["c2"].set_property("cmake_build_modules", ["build_module_c2",
+                                                                  "build_module_c22"])
 
     cppinfo.components["c1"].requires = ["c2", "LIB_A::C1"]
     cppinfo.components["c1"].includedirs = ["includedir_c1"]
@@ -59,6 +61,8 @@ def test_component_aggregation():
     cppinfo.components["c1"].defines = ["defines_c1"]
     cppinfo.components["c1"].set_property("my_foo", "jander")
     cppinfo.components["c1"].set_property("my_foo2", "bar2", "other_gen")
+    cppinfo.components["c1"].set_property("cmake_build_modules", ["build_module_c1"])
+
 
     ret = cppinfo.copy()
     ret.aggregate_components()
@@ -73,9 +77,11 @@ def test_component_aggregation():
     assert ret.defines == ["defines_c1", "defines_c2"]
     # The properties are not aggregated because we cannot generalize the meaning of a property
     # that belongs to a component, it could make sense to aggregate it or not, "cmake_target_name"
-    # for example, cannot be aggregated
+    # for example, cannot be aggregated. But "cmake_build_modules" is aggregated.
     assert ret.get_property("my_foo") is None
     assert ret.get_property("my_foo2", "other_gen") is None
+    assert ret.get_property("cmake_build_modules") == ["build_module_c1", "build_module_c2",
+                                                       "build_module_c22"]
 
     # If we change the internal graph the order is different
     cppinfo.components["c1"].requires = []


### PR DESCRIPTION
Changelog:  Fix: **CMakeDeps** generator: The transitive requirements for a build_require are not included in the `xxx-config.cmake` files generated.
Docs: omit

