### PR TITLE
Fix more evil insertions

### DIFF
--- a/conans/client/graph/graph_binaries.py
+++ b/conans/client/graph/graph_binaries.py
@@ -61,7 +61,10 @@ class GraphBinariesAnalyzer(object):
 
             if self._cache.config.revisions_enabled:
                 metadata = package_layout.load_metadata()
-                rec_rev = metadata.packages[pref.id].recipe_revision
+
+                rec_rev = metadata.packages[
+                    pref.id].recipe_revision if pref.id in metadata.packages else None
+
                 if rec_rev and rec_rev != node.ref.revision:
                     node.conanfile.output.warn("The package {} doesn't belong to the installed "
                                                "recipe revision, removing folder".format(pref))


### PR DESCRIPTION
Changelog: Bugfix: Prevent unintended evil insertions into metadata.json resulted in corrupted package and inability to install.
Docs: omit

Related to: https://github.com/conan-io/conan/pull/8532

There were some evil insertions left with revisions, it was not caught because this only happened with revisions enabled and test suite was run without the revisions tag.

#REVISIONS: 1
