### PR TITLE
Feature/default skip rpaths

### DIFF
--- a/conan/tools/cmake/toolchain.py
+++ b/conan/tools/cmake/toolchain.py
@@ -175,16 +175,18 @@ class GLibCXXBlock(Block):
 
 class SkipRPath(Block):
     template = textwrap.dedent("""
+        {% if skip_rpath %}
         set(CMAKE_SKIP_RPATH 1 CACHE BOOL "rpaths" FORCE)
         # Policy CMP0068
         # We want the old behavior, in CMake >= 3.9 CMAKE_SKIP_RPATH won't affect install_name in OSX
         set(CMAKE_INSTALL_NAME_DIR "")
+        {% endif %}
         """)
 
+    skip_rpath = False
+
     def context(self):
-        if self._conanfile.settings.get_safe("os") != "Macos":
-            return
-        return {"skip_rpath": True}
+        return {"skip_rpath": self.skip_rpath}
 
 
 class ArchitectureBlock(Block):

--- a/conans/test/assets/pkg_cmake.py
+++ b/conans/test/assets/pkg_cmake.py
@@ -18,6 +18,8 @@ def pkg_cmake(name, version, requires=None):
             exports = "*"
             {deps}
             settings = "os", "compiler", "arch", "build_type"
+            options = {{"shared": [True, False]}}
+            default_options = {{"shared": False}}
             generators = "CMakeToolchain", "CMakeDeps"
 
             def build(self):
@@ -72,8 +74,8 @@ def pkg_cmake_app(name, version, requires=None):
                 cmake.build()
 
             def package(self):
-                self.copy("*.exe", dst="bin", keep_path=False)
-                self.copy("app", dst="bin", keep_path=False)
+                self.copy("*/app.exe", dst="bin", keep_path=False)
+                self.copy("*app", dst="bin", keep_path=False)
 
         """)
     deps = "requires = " + ", ".join('"{}"'.format(r) for r in requires) if requires else ""

--- a/conans/test/assets/pkg_cmake.py
+++ b/conans/test/assets/pkg_cmake.py
@@ -49,3 +49,41 @@ def pkg_cmake(name, version, requires=None):
             "src/{}.cpp".format(name): src,
             "src/CMakeLists.txt": cmake,
             "conanfile.py": conanfile}
+
+
+def pkg_cmake_app(name, version, requires=None):
+    refs = [ConanFileReference.loads(r) for r in requires or []]
+    pkg_name = name
+    name = name.replace(".", "_")
+    conanfile = textwrap.dedent("""\
+        from conans import ConanFile
+        from conan.tools.cmake import CMake
+        class Pkg(ConanFile):
+            name = "{pkg_name}"
+            version = "{version}"
+            exports = "*"
+            {deps}
+            settings = "os", "compiler", "arch", "build_type"
+            generators = "CMakeToolchain", "CMakeDeps"
+
+            def build(self):
+                cmake = CMake(self)
+                cmake.configure(source_folder="src")
+                cmake.build()
+
+            def package(self):
+                self.copy("*.exe", dst="bin", keep_path=False)
+                self.copy("app", dst="bin", keep_path=False)
+
+        """)
+    deps = "requires = " + ", ".join('"{}"'.format(r) for r in requires) if requires else ""
+    conanfile = conanfile.format(pkg_name=pkg_name, name=name, version=version, deps=deps)
+
+    deps = [r.name.replace(".", "_") for r in refs]
+    src = gen_function_cpp(name="main", includes=deps, calls=deps)
+    deps = [r.name for r in refs]
+    cmake = gen_cmakelists(appname=name, appsources=["{}.cpp".format(name)], find_package=deps)
+
+    return {"src/{}.cpp".format(name): src,
+            "src/CMakeLists.txt": cmake,
+            "conanfile.py": conanfile}

--- a/conans/test/functional/toolchains/cmake/test_cmake.py
+++ b/conans/test/functional/toolchains/cmake/test_cmake.py
@@ -422,7 +422,6 @@ class AppleTest(Base):
                 "CMAKE_C_FLAGS_RELEASE": "-O3 -DNDEBUG",
                 "CMAKE_SHARED_LINKER_FLAGS": "-m64",
                 "CMAKE_EXE_LINKER_FLAGS": "-m64",
-                "CMAKE_SKIP_RPATH": "1",
                 "CMAKE_INSTALL_NAME_DIR": ""
                 }
 

--- a/conans/test/functional/toolchains/cmake/test_shared_cmake.py
+++ b/conans/test/functional/toolchains/cmake/test_shared_cmake.py
@@ -1,0 +1,19 @@
+from conans.test.assets.pkg_cmake import pkg_cmake
+from conans.test.utils.tools import TestClient
+
+
+def test_shared_cmake_toolchain():
+    client = TestClient(default_server_user=True)
+    client.save(pkg_cmake("hello", "0.1"))
+    client.run("create . -o hello:shared=True")
+    client.save(pkg_cmake("chat", "0.1", requires=["hello/0.1"]))
+    client.run("create . -o chat:shared=True -o hello:shared=True")
+
+    client.save(pkg_cmake("app", "0.1", requires=["chat/0.1"]))
+    client.run("create . -o chat:shared=True -o hello:shared=True")
+
+    client.run("install app/0.1@ -g VirtualEnv")
+    client.run_command("app")
+
+
+

--- a/conans/test/functional/toolchains/cmake/test_shared_cmake.py
+++ b/conans/test/functional/toolchains/cmake/test_shared_cmake.py
@@ -1,19 +1,24 @@
-from conans.test.assets.pkg_cmake import pkg_cmake
+from conan.tools.env.environment import environment_wrap_command
+from conans.test.assets.pkg_cmake import pkg_cmake, pkg_cmake_app
 from conans.test.utils.tools import TestClient
 
 
 def test_shared_cmake_toolchain():
     client = TestClient(default_server_user=True)
+
     client.save(pkg_cmake("hello", "0.1"))
     client.run("create . -o hello:shared=True")
-    client.save(pkg_cmake("chat", "0.1", requires=["hello/0.1"]))
+    client.save(pkg_cmake("chat", "0.1", requires=["hello/0.1"]), clean_first=True)
     client.run("create . -o chat:shared=True -o hello:shared=True")
-
-    client.save(pkg_cmake("app", "0.1", requires=["chat/0.1"]))
+    client.save(pkg_cmake_app("app", "0.1", requires=["chat/0.1"]), clean_first=True)
     client.run("create . -o chat:shared=True -o hello:shared=True")
+    client.run("upload * --all -c")
+    client.run("remove * -f")
 
-    client.run("install app/0.1@ -g VirtualEnv")
-    client.run_command("app")
-
-
-
+    client = TestClient(servers=client.servers, users=client.users)
+    client.run("install app/0.1@ -o chat:shared=True -o hello:shared=True -g VirtualEnv")
+    command = environment_wrap_command("conanrunenv", "app", cwd=client.current_folder)
+    client.run_command(command)
+    assert "main: Release!" in client.out
+    assert "chat: Release!" in client.out
+    assert "hello: Release!" in client.out


### PR DESCRIPTION
Changelog: Feature: Remove ``CMAKE_SKIP_RPATHS`` by default to True in ``CMakeToolchain``, it is not necessary by default, users can opt-in, and new test validates shared libs will work with ``VirtualEnv`` generator ``conanrunenv``.
Docs: https://github.com/conan-io/docs/pull/2105

#tags: slow

Close https://github.com/conan-io/conan/issues/9007