### PR TITLE
Toolchain declare DIR find package variables

### DIFF
--- a/conan/tools/cmake/cmakedeps/templates/__init__.py
+++ b/conan/tools/cmake/cmakedeps/templates/__init__.py
@@ -1,6 +1,7 @@
 import jinja2
 from jinja2 import Template
 
+from conan.tools.cmake.utils import get_file_name
 from conans.errors import ConanException
 
 
@@ -83,13 +84,6 @@ def get_target_namespace(req):
     ret = req.new_cpp_info.get_property("cmake_target_name", "CMakeDeps")
     if not ret:
         ret = req.cpp_info.get_name("cmake_find_package_multi", default_name=False)
-    return ret or req.ref.name
-
-
-def get_file_name(req):
-    ret = req.new_cpp_info.get_property("cmake_file_name", "CMakeDeps")
-    if not ret:
-        ret = req.cpp_info.get_filename("cmake_find_package_multi", default_name=False)
     return ret or req.ref.name
 
 

--- a/conan/tools/cmake/cmakedeps/templates/target_data.py
+++ b/conan/tools/cmake/cmakedeps/templates/target_data.py
@@ -2,7 +2,8 @@ import os
 import textwrap
 
 from conan.tools.cmake.cmakedeps.templates import CMakeDepsFileTemplate, get_component_alias, \
-    get_file_name, get_target_namespace
+    get_target_namespace
+from conan.tools.cmake.utils import get_file_name
 
 """
 

--- a/conan/tools/cmake/utils.py
+++ b/conan/tools/cmake/utils.py
@@ -6,6 +6,8 @@ def is_multi_configuration(generator):
 
 def get_file_name(conanfile):
     """Get the name of the file for the find_package(XXX)"""
+    # This is used by the CMakeToolchain to adjust the XXX_DIR variables and the CMakeDeps. Both
+    # to know the file name that will have the XXX-config.cmake files.
     ret = conanfile.new_cpp_info.get_property("cmake_file_name", "CMakeDeps")
     if not ret:
         ret = conanfile.cpp_info.get_filename("cmake_find_package_multi", default_name=False)

--- a/conan/tools/cmake/utils.py
+++ b/conan/tools/cmake/utils.py
@@ -2,3 +2,12 @@ def is_multi_configuration(generator):
     if not generator:
         return False
     return "Visual" in generator or "Xcode" in generator or "Multi-Config" in generator
+
+
+def get_file_name(conanfile):
+    """Get the name of the file for the find_package(XXX)"""
+    ret = conanfile.new_cpp_info.get_property("cmake_file_name", "CMakeDeps")
+    if not ret:
+        ret = conanfile.cpp_info.get_filename("cmake_find_package_multi", default_name=False)
+    return ret or conanfile.ref.name
+

--- a/conans/test/functional/toolchains/cmake/cmakedeps/test_apple_frameworks.py
+++ b/conans/test/functional/toolchains/cmake/cmakedeps/test_apple_frameworks.py
@@ -193,17 +193,10 @@ timer_cpp = textwrap.dedent("""
 def test_apple_own_framework_cross_build(settings):
     client = TestClient()
 
-    # FIXME: The crossbuild for iOS etc is failing with find_package because cmake ignore the
-    #        cmake_prefix_path to point only to the Frameworks of the system. The only fix found
-    #        would require to introduce something like "set (mylibrary_DIR "${CMAKE_BINARY_DIR}")"
-    #        at the toolchain (but it would require the toolchain to know about the deps)
-    #        https://stackoverflow.com/questions/65494246/cmakes-find-package-ignores-the-paths-option-when-building-for-ios#
     test_cmake = textwrap.dedent("""
         cmake_minimum_required(VERSION 3.15)
         project(Testing CXX)
-        # set(CMAKE_FIND_DEBUG_MODE TRUE)
 
-        set (mylibrary_DIR "${CMAKE_BINARY_DIR}")
         find_package(mylibrary REQUIRED)
 
         add_executable(timer timer.cpp)

--- a/conans/test/unittests/tools/cmake/test_cmaketoolchain.py
+++ b/conans/test/unittests/tools/cmake/test_cmaketoolchain.py
@@ -24,6 +24,8 @@ def conanfile():
     c.settings.compiler.libcxx = "libstdc++"
     c.conf = Conf()
     c.folders.set_base_generators(".")
+    c._conan_node = Mock()
+    c._conan_node.dependencies = []
     return c
 
 


### PR DESCRIPTION
Changelog: Feature: The `conan_toolchain.cmake` now includes `xxx_DIR` variables for the dependencies to ease the `find_package` mechanism to locate them. The declaration of these directories is a must when cross-building in OSX where CMake ignores `CMAKE_PREFIX_PATH` and `CMAKE_MODULE_PATH` to look only at the system framework directories.
Docs: https://github.com/conan-io/docs/pull/2108
