### PR TITLE
Fix self.folders.source

### DIFF
--- a/conans/__init__.py
+++ b/conans/__init__.py
@@ -20,4 +20,4 @@ OAUTH_TOKEN = "oauth_token"
 SERVER_CAPABILITIES = [COMPLEX_SEARCH_CAPABILITY, REVISIONS]  # Server is always with revisions
 DEFAULT_REVISION_V1 = "0"
 
-__version__ = '1.38.0-dev'
+__version__ = '1.37.1'

--- a/conans/__init__.py
+++ b/conans/__init__.py
@@ -20,4 +20,4 @@ OAUTH_TOKEN = "oauth_token"
 SERVER_CAPABILITIES = [COMPLEX_SEARCH_CAPABILITY, REVISIONS]  # Server is always with revisions
 DEFAULT_REVISION_V1 = "0"
 
-__version__ = '1.37.0-dev'
+__version__ = '1.38.0-dev'

--- a/conans/client/migrations_settings.py
+++ b/conans/client/migrations_settings.py
@@ -2302,5 +2302,5 @@ build_type: [None, Debug, Release, RelWithDebInfo, MinSizeRel]
 
 cppstd: [None, 98, gnu98, 11, gnu11, 14, gnu14, 17, gnu17, 20, gnu20, 23, gnu23]  # Deprecated, use compiler.cppstd
 """
-
-settings_1_38_0 = settings_1_37_0
+settings_1_37_1 = settings_1_37_0
+settings_1_38_0 = settings_1_37_1

--- a/conans/client/migrations_settings.py
+++ b/conans/client/migrations_settings.py
@@ -2303,4 +2303,3 @@ build_type: [None, Debug, Release, RelWithDebInfo, MinSizeRel]
 cppstd: [None, 98, gnu98, 11, gnu11, 14, gnu14, 17, gnu17, 20, gnu20, 23, gnu23]  # Deprecated, use compiler.cppstd
 """
 settings_1_37_1 = settings_1_37_0
-settings_1_38_0 = settings_1_37_1

--- a/conans/client/migrations_settings.py
+++ b/conans/client/migrations_settings.py
@@ -2302,3 +2302,5 @@ build_type: [None, Debug, Release, RelWithDebInfo, MinSizeRel]
 
 cppstd: [None, 98, gnu98, 11, gnu11, 14, gnu14, 17, gnu17, 20, gnu20, 23, gnu23]  # Deprecated, use compiler.cppstd
 """
+
+settings_1_38_0 = settings_1_37_0

--- a/conans/client/source.py
+++ b/conans/client/source.py
@@ -107,7 +107,7 @@ def config_source(export_folder, export_source_folder, scm_sources_folder, conan
                 # so self exported files have precedence over python_requires ones
                 merge_directories(export_folder, conanfile.source_folder)
                 # Now move the export-sources to the right location
-                merge_directories(export_source_folder, conanfile.source_folder)
+                merge_directories(export_source_folder, conanfile.folders.base_source)
 
             _run_source(conanfile, conanfile_path, hook_manager, reference, cache,
                         get_sources_from_exports=get_sources_from_exports)
@@ -183,9 +183,9 @@ def _run_cache_scm(conanfile, scm_sources_folder, output):
         return
 
     if scm_data.subfolder:
-        dest_dir = os.path.normpath(os.path.join(conanfile.source_folder, scm_data.subfolder))
+        dest_dir = os.path.normpath(os.path.join(conanfile.folders.base_source, scm_data.subfolder))
     else:
-        dest_dir = conanfile.source_folder
+        dest_dir = conanfile.folders.base_source
     if os.path.exists(scm_sources_folder):
         output.info("Copying previously cached scm sources")
         merge_directories(scm_sources_folder, dest_dir)

--- a/conans/test/assets/genconanfile.py
+++ b/conans/test/assets/genconanfile.py
@@ -42,6 +42,8 @@ class GenConanfile(object):
         self._short_paths = None
         self._exports_sources = None
         self._exports = None
+        self._cmake_build = False
+        self._class_attributes = None
 
     def with_short_paths(self, value):
         self._short_paths = value
@@ -191,6 +193,20 @@ class GenConanfile(object):
         self._test_lines.append(line)
         return self
 
+    def with_cmake_build(self):
+        self._imports.append("from conan.tools.cmake import CMake")
+        self._generators = self._generators or []
+        self._generators.append("CMakeDeps")
+        self._generators.append("CMakeToolchain")
+        self._cmake_build = True
+        return self
+
+    def with_class_attribute(self, attr):
+        """.with_class_attribute("no_copy_sources=True") """
+        self._class_attributes = self._class_attributes or []
+        self._class_attributes.append(attr)
+        return self
+
     @property
     def _name_render(self):
         return "name = '{}'".format(self._name)
@@ -314,10 +330,16 @@ class GenConanfile(object):
     """.format("\n".join(lines))
 
     @property
-    def _build_messages_render(self):
-        if not self._build_messages:
-            return ""
-        lines = ['        self.output.warn("{}")'.format(m) for m in self._build_messages]
+    def _build_render(self):
+        if not self._build_messages and not self._cmake_build:
+            return None
+        lines = []
+        if self._build_messages:
+            lines = ['        self.output.warn("{}")'.format(m) for m in self._build_messages]
+        if self._cmake_build:
+            lines.extend(['        cmake = CMake(self)',
+                          '        cmake.configure()',
+                          '        cmake.build()'])
         return """
     def build(self):
 {}
@@ -373,21 +395,31 @@ class GenConanfile(object):
         line = ", ".join('"{}"'.format(e) for e in self._exports)
         return "exports = {}".format(line)
 
+    @property
+    def _class_attributes_render(self):
+        self._class_attributes = self._class_attributes or []
+        return ["    {}".format(a) for a in self._class_attributes]
+
     def __repr__(self):
         ret = []
         ret.extend(self._imports)
         ret.append("class HelloConan(ConanFile):")
 
+        # FIXME: This is all a mess. Replace with Jinja2
         for member in ("name", "version", "provides", "deprecated", "short_paths", "exports_sources",
                        "exports", "generators", "requires", "build_requires", "requirements",
                        "build_requirements", "scm", "revision_mode", "settings", "options",
-                       "default_options", "build_messages", "package_method", "package_info",
+                       "default_options", "package_method", "package_info",
                        "package_id_lines", "test_lines"
                        ):
             v = getattr(self, "_{}".format(member), None)
             if v is not None:
                 ret.append("    {}".format(getattr(self, "_{}_render".format(member))))
 
+        ret.extend(self._class_attributes_render)
+        build = self._build_render
+        if build is not None:
+            ret.append("    {}".format(self._build_render))
         if ret[-1] == "class HelloConan(ConanFile):":
             ret.append("    pass")
         return "\n".join(ret)

--- a/conans/test/functional/layout/test_source_folder.py
+++ b/conans/test/functional/layout/test_source_folder.py
@@ -1,3 +1,6 @@
+import os
+import platform
+
 import pytest
 
 from conans.test.assets.cmake import gen_cmakelists
@@ -5,6 +8,8 @@ from conans.test.assets.genconanfile import GenConanfile
 from conans.test.assets.sources import gen_function_cpp
 from conans.test.utils.scm import create_local_git_repo
 from conans.test.utils.tools import TestClient
+
+app_name = "my_app.exe" if platform.system() == "Windows" else "my_app"
 
 
 @pytest.mark.parametrize("no_copy_source", ["False", "True"])
@@ -33,9 +38,9 @@ def test_exports_source_with_src_subfolder(no_copy_source):
                  "my_src/CMakeLists.txt": cmake})
     client.run("install . -if=install")
     client.run("build . -if=install")
-    assert "Built target my_app" in client.out
+    assert os.path.exists(os.path.join(client.current_folder, "Release", app_name))
     client.run("create . ")
-    assert "Built target my_app" in client.out
+    assert "Created package revision" in client.out
 
 
 def test_exports():
@@ -90,9 +95,9 @@ def test_exports_source_without_subfolder():
                  "CMakeLists.txt": cmake})
     client.run("install . -if=install")
     client.run("build . -if=install")
-    assert "Built target my_app" in client.out
+    assert os.path.exists(os.path.join(client.current_folder, "Release", app_name))
     client.run("create . ")
-    assert "Built target my_app" in client.out
+    assert "Created package revision" in client.out
 
 
 def test_scm_with_source_layout():
@@ -125,7 +130,6 @@ def test_scm_with_source_layout():
 
     client.run("install . -if=install")
     client.run("build . -if=install")
-    assert "Built target my_app" in client.out
-
+    assert os.path.exists(os.path.join(client.current_folder, "build_Release", app_name))
     client.run("create . ")
-    assert "Built target my_app" in client.out
+    assert "Created package revision" in client.out

--- a/conans/test/functional/layout/test_source_folder.py
+++ b/conans/test/functional/layout/test_source_folder.py
@@ -1,0 +1,131 @@
+import pytest
+
+from conans.test.assets.cmake import gen_cmakelists
+from conans.test.assets.genconanfile import GenConanfile
+from conans.test.assets.sources import gen_function_cpp
+from conans.test.utils.scm import create_local_git_repo
+from conans.test.utils.tools import TestClient
+
+
+@pytest.mark.parametrize("no_copy_source", ["False", "True"])
+def test_exports_source_with_src_subfolder(no_copy_source):
+    """If we have the sources in a subfolder, specifying it in the self.folders.source will
+    work both locally (conan build) or in the cache (exporting the sources)"""
+    conan_file = GenConanfile() \
+        .with_name("app").with_version("1.0") \
+        .with_settings("os", "arch", "build_type", "compiler") \
+        .with_exports_sources("my_src/*")\
+        .with_cmake_build()\
+        .with_class_attribute("no_copy_source={}".format(no_copy_source))
+
+    conan_file = str(conan_file)
+    conan_file += """
+    def layout(self):
+        self.folders.source = "my_src"
+        self.folders.build = str(self.settings.build_type)
+    """
+    cmake = gen_cmakelists(appname="my_app", appsources=["main.cpp"])
+    app = gen_function_cpp(name="main")
+
+    client = TestClient()
+    client.save({"conanfile.py": conan_file,
+                 "my_src/main.cpp": app,
+                 "my_src/CMakeLists.txt": cmake})
+    client.run("install . -if=install")
+    client.run("build . -if=install")
+    assert "Built target my_app" in client.out
+    client.run("create . ")
+    assert "Built target my_app" in client.out
+
+
+def test_exports():
+    """If we have some sources in the root (like the CMakeLists.txt)
+    we don't declare folders.source"""
+    conan_file = GenConanfile() \
+        .with_name("app").with_version("1.0") \
+        .with_settings("os", "arch", "build_type", "compiler") \
+        .with_exports("*.py") \
+        .with_import("from my_tools import FOO")
+
+    conan_file = str(conan_file)
+    conan_file += """
+    def layout(self):
+        self.folders.source = "my_src"
+    def build(self):
+        # This FOO comes from the my_tools.py
+        self.output.warn("FOO: {}".format(FOO))
+    """
+
+    client = TestClient()
+    client.save({"conanfile.py": conan_file,
+                 "my_tools.py": "FOO=1"})
+    client.run("install . -if=install")
+    client.run("build . -if=install")
+    assert "FOO: 1" in client.out
+
+    client.run("create . ")
+    assert "FOO: 1" in client.out
+
+
+def test_exports_source_without_subfolder():
+    """If we have some sources in the root (like the CMakeLists.txt)
+    we don't declare folders.source"""
+    conan_file = GenConanfile() \
+        .with_name("app").with_version("1.0") \
+        .with_settings("os", "arch", "build_type", "compiler") \
+        .with_exports_sources("CMakeLists.txt", "my_src/*")\
+        .with_cmake_build()
+
+    conan_file = str(conan_file)
+    conan_file += """
+    def layout(self):
+        self.folders.build = str(self.settings.build_type)
+    """
+    cmake = gen_cmakelists(appname="my_app", appsources=["my_src/main.cpp"])
+    app = gen_function_cpp(name="main")
+
+    client = TestClient()
+    client.save({"conanfile.py": conan_file,
+                 "my_src/main.cpp": app,
+                 "CMakeLists.txt": cmake})
+    client.run("install . -if=install")
+    client.run("build . -if=install")
+    assert "Built target my_app" in client.out
+    client.run("create . ")
+    assert "Built target my_app" in client.out
+
+
+def test_scm_with_source_layout():
+    """If we have the sources in git repository"""
+    conan_file = GenConanfile() \
+        .with_name("app").with_version("1.0") \
+        .with_settings("os", "arch", "build_type", "compiler") \
+        .with_scm({"type": "git", "revision": "auto", "url": "auto"})\
+        .with_cmake_build()
+
+    conan_file = str(conan_file)
+    conan_file += """
+    def layout(self):
+        self.folders.source = "my_src"
+        self.folders.build = "build_{}".format(self.settings.build_type)
+    """
+    cmake = gen_cmakelists(appname="my_app", appsources=["main.cpp"])
+    app = gen_function_cpp(name="main")
+
+    remote_path, _ = create_local_git_repo({"foo": "var"}, branch="my_release")
+
+    client = TestClient()
+
+    client.save({"conanfile.py": conan_file, "my_src/main.cpp": app,
+                 "my_src/CMakeLists.txt": cmake,
+                 ".gitignore": "build_*\n"})
+    client.init_git_repo()
+    client.run_command('git remote add origin "%s"' % remote_path.replace("\\", "/"))
+    client.run_command('git push origin master')
+
+    client.run("install . -if=install")
+    client.run("build . -if=install")
+    assert "Built target my_app" in client.out
+
+    client.run("create . ")
+    assert "Built target my_app" in client.out

--- a/conans/test/functional/layout/test_source_folder.py
+++ b/conans/test/functional/layout/test_source_folder.py
@@ -9,7 +9,7 @@ from conans.test.assets.sources import gen_function_cpp
 from conans.test.utils.scm import create_local_git_repo
 from conans.test.utils.tools import TestClient
 
-app_name = "my_app.exe" if platform.system() == "Windows" else "my_app"
+app_name = "Release/my_app.exe" if platform.system() == "Windows" else "my_app"
 
 
 @pytest.mark.parametrize("no_copy_source", ["False", "True"])

--- a/conans/test/functional/scm/source/test_run_scm.py
+++ b/conans/test/functional/scm/source/test_run_scm.py
@@ -29,7 +29,7 @@ class RunSCMTest(unittest.TestCase):
         # Mock the conanfile (return scm_data)
         conanfile = mock.MagicMock()
         conanfile.scm = {'type': 'git', 'url': 'auto', 'revision': 'auto'}
-        conanfile.source_folder = self.src_folder
+        conanfile.folders.base_source = self.src_folder
 
         # Mock functions called from inside _run_scm (tests will be here)
         def merge_directories(src, dst, excluded=None):
@@ -58,7 +58,7 @@ class RunSCMTest(unittest.TestCase):
         url = 'whatever'
         conanfile = mock.MagicMock()
         conanfile.scm = {'type': 'git', 'url': url, 'revision': 'auto', 'subfolder': subfolder}
-        conanfile.source_folder = self.src_folder
+        conanfile.folders.base_source = self.src_folder
 
         # Mock functions called from inside _run_scm (tests will be here)
         def clean_source_folder(folder):

--- a/conans/test/functional/toolchains/cmake/cmakedeps/test_build_context_protobuf.py
+++ b/conans/test/functional/toolchains/cmake/cmakedeps/test_build_context_protobuf.py
@@ -197,6 +197,7 @@ def test_build_modules_and_target_from_host_context(client):
         """)
 
     cmake_deps_conf = """
+        deps.build_context_activated = ["protobuf"]
         deps.build_context_build_modules = []
         deps.build_context_suffix = {"protobuf": "_BUILD"}
     """
@@ -206,6 +207,8 @@ def test_build_modules_and_target_from_host_context(client):
                  "main.cpp": main})
 
     client.run("create . app/1.0@ -pr:b default -pr:h default")
+    assert "Conan: Target declared 'protobuf::protobuf'" in client.out
+    assert "Conan: Target declared 'protobuf_BUILD::protobuf_BUILD'" in client.out
     assert "Library from host context!" in client.out
     assert "Generated code in host context!" in client.out
 


### PR DESCRIPTION
Changelog:  Fix: When using the new `self.folders.source` (at `layout(self)` method) the sources (from `export`, `export_sources` and `scm`) are copied to the base source folder and not to the `self.folders.source` that is intended to describe where the sources are after fetching them.
Docs: https://github.com/conan-io/docs/pull/2117
