### PR TITLE
Skip when no arch is present

### DIFF
--- a/conan/tools/cmake/toolchain.py
+++ b/conan/tools/cmake/toolchain.py
@@ -344,6 +344,8 @@ class AppleSystemBlock(Block):
     def context(self):
         os_ = self._conanfile.settings.get_safe("os")
         host_architecture = self._get_architecture()
+        if host_architecture is None:
+            return
         # We could be cross building from Macos x64 to Macos armv8 (m1)
         build_architecture = self._get_architecture(host_context=False)
         if os_ not in ('iOS', "watchOS", "tvOS") and \

--- a/conan/tools/cmake/toolchain.py
+++ b/conan/tools/cmake/toolchain.py
@@ -310,15 +310,12 @@ class AppleSystemBlock(Block):
         set(CMAKE_OSX_SYSROOT {{ CMAKE_OSX_SYSROOT }} CACHE STRING "" FORCE)
         """)
 
-    def _get_architecture(self, host_context=True):
+    def _get_architecture(self):
         # check valid combinations of architecture - os ?
         # for iOS a FAT library valid for simulator and device
         # can be generated if multiple archs are specified:
         # "-DCMAKE_OSX_ARCHITECTURES=armv7;armv7s;arm64;i386;x86_64"
-        if not host_context and not hasattr(self._conanfile, 'settings_build'):
-            return None
-        arch = self._conanfile.settings.get_safe("arch") \
-            if host_context else self._conanfile.settings_build.get_safe("arch")
+        arch = self._conanfile.settings.get_safe("arch")
         return {"x86": "i386",
                 "x86_64": "x86_64",
                 "armv8": "arm64",
@@ -344,13 +341,6 @@ class AppleSystemBlock(Block):
     def context(self):
         os_ = self._conanfile.settings.get_safe("os")
         host_architecture = self._get_architecture()
-        if host_architecture is None:
-            return
-        # We could be cross building from Macos x64 to Macos armv8 (m1)
-        build_architecture = self._get_architecture(host_context=False)
-        if os_ not in ('iOS', "watchOS", "tvOS") and \
-            (not build_architecture or host_architecture == build_architecture):
-            return
 
         host_os = self._conanfile.settings.get_safe("os")
         host_os_version = self._conanfile.settings.get_safe("os.version")
@@ -359,10 +349,12 @@ class AppleSystemBlock(Block):
         # TODO: Discuss how to handle CMAKE_OSX_DEPLOYMENT_TARGET to set min-version
         #       add a setting? check an option and if not present set a default?
         #       default to os.version?
-        ctxt_toolchain = {
-            "CMAKE_OSX_ARCHITECTURES": host_architecture,
-            "CMAKE_OSX_SYSROOT": host_sdk_name
-        }
+        ctxt_toolchain = {}
+        if host_sdk_name:
+            ctxt_toolchain["CMAKE_OSX_SYSROOT"] = host_sdk_name
+        if host_architecture:
+            ctxt_toolchain["CMAKE_OSX_ARCHITECTURES"] = host_architecture
+
         if os_ in ('iOS', "watchOS", "tvOS"):
             ctxt_toolchain["CMAKE_SYSTEM_NAME"] = host_os
             ctxt_toolchain["CMAKE_SYSTEM_VERSION"] = host_os_version

--- a/conans/__init__.py
+++ b/conans/__init__.py
@@ -20,4 +20,4 @@ OAUTH_TOKEN = "oauth_token"
 SERVER_CAPABILITIES = [COMPLEX_SEARCH_CAPABILITY, REVISIONS]  # Server is always with revisions
 DEFAULT_REVISION_V1 = "0"
 
-__version__ = '1.37.0-dev'
+__version__ = '1.38.0-dev'

--- a/conans/client/migrations_settings.py
+++ b/conans/client/migrations_settings.py
@@ -2302,5 +2302,5 @@ build_type: [None, Debug, Release, RelWithDebInfo, MinSizeRel]
 
 cppstd: [None, 98, gnu98, 11, gnu11, 14, gnu14, 17, gnu17, 20, gnu20, 23, gnu23]  # Deprecated, use compiler.cppstd
 """
-
-settings_1_38_0 = settings_1_37_0
+settings_1_37_1 = settings_1_37_0
+settings_1_38_0 = settings_1_37_1

--- a/conans/client/migrations_settings.py
+++ b/conans/client/migrations_settings.py
@@ -2303,4 +2303,3 @@ build_type: [None, Debug, Release, RelWithDebInfo, MinSizeRel]
 cppstd: [None, 98, gnu98, 11, gnu11, 14, gnu14, 17, gnu17, 20, gnu20, 23, gnu23]  # Deprecated, use compiler.cppstd
 """
 settings_1_37_1 = settings_1_37_0
-settings_1_38_0 = settings_1_37_1

--- a/conans/client/migrations_settings.py
+++ b/conans/client/migrations_settings.py
@@ -2302,3 +2302,5 @@ build_type: [None, Debug, Release, RelWithDebInfo, MinSizeRel]
 
 cppstd: [None, 98, gnu98, 11, gnu11, 14, gnu14, 17, gnu17, 20, gnu20, 23, gnu23]  # Deprecated, use compiler.cppstd
 """
+
+settings_1_38_0 = settings_1_37_0

--- a/conans/test/functional/toolchains/cmake/cmakedeps/test_build_context_protobuf.py
+++ b/conans/test/functional/toolchains/cmake/cmakedeps/test_build_context_protobuf.py
@@ -197,6 +197,7 @@ def test_build_modules_and_target_from_host_context(client):
         """)
 
     cmake_deps_conf = """
+        deps.build_context_activated = ["protobuf"]
         deps.build_context_build_modules = []
         deps.build_context_suffix = {"protobuf": "_BUILD"}
     """
@@ -206,6 +207,8 @@ def test_build_modules_and_target_from_host_context(client):
                  "main.cpp": main})
 
     client.run("create . app/1.0@ -pr:b default -pr:h default")
+    assert "Conan: Target declared 'protobuf::protobuf'" in client.out
+    assert "Conan: Target declared 'protobuf_BUILD::protobuf_BUILD'" in client.out
     assert "Library from host context!" in client.out
     assert "Generated code in host context!" in client.out
 


### PR DESCRIPTION
Changelog: Bugfix: The `CMakeToolchain` generator now manages correctly a recipe without `arch` declared in an Apple system.
Docs: omit

