### PR TITLE
if the build_require not activated shouldn't fail

### DIFF
--- a/conan/tools/cmake/cmakedeps/cmakedeps.py
+++ b/conan/tools/cmake/cmakedeps/cmakedeps.py
@@ -41,13 +41,16 @@ class CMakeDeps(object):
         build_req = self._conanfile.dependencies.build_requires_build_context
 
         # Check if the same package is at host and build and the same time
-        common = {r.ref.name for r in host_req}.intersection({r.ref.name for r in build_req})
-        for name in common:
-            if name not in self.build_context_suffix:
-                raise ConanException("The package '{}' exists both as 'require' and as "
-                                     "'build require'. You need to specify a suffix using the "
-                                     "'build_context_suffix' attribute at the CMakeDeps "
-                                     "generator.".format(name))
+        host_names = {r.ref.name for r in host_req}
+        for r in build_req:
+            req_name = r.ref.name
+            if req_name in self.build_context_activated and req_name in host_names:
+                suffix = self.build_context_suffix.get(req_name)
+                if not suffix:
+                    raise ConanException("The package '{}' exists both as 'require' and as "
+                                         "'build require'. You need to specify a suffix using the "
+                                         "'build_context_suffix' attribute at the CMakeDeps "
+                                         "generator.".format(req_name))
 
         # Iterate all the transitive requires
         for req in host_req + build_req:

--- a/conan/tools/cmake/cmakedeps/cmakedeps.py
+++ b/conan/tools/cmake/cmakedeps/cmakedeps.py
@@ -41,16 +41,15 @@ class CMakeDeps(object):
         build_req = self._conanfile.dependencies.build_requires_build_context
 
         # Check if the same package is at host and build and the same time
-        host_names = {r.ref.name for r in host_req}
-        for r in build_req:
-            req_name = r.ref.name
-            if req_name in self.build_context_activated and req_name in host_names:
-                suffix = self.build_context_suffix.get(req_name)
-                if not suffix:
-                    raise ConanException("The package '{}' exists both as 'require' and as "
-                                         "'build require'. You need to specify a suffix using the "
-                                         "'build_context_suffix' attribute at the CMakeDeps "
-                                         "generator.".format(req_name))
+        activated_br = {r.ref.name for r in build_req if r.ref.name in self.build_context_activated}
+        common_names = {r.ref.name for r in host_req}.intersection(activated_br)
+        for common_name in common_names:
+            suffix = self.build_context_suffix.get(common_name)
+            if not suffix:
+                raise ConanException("The package '{}' exists both as 'require' and as "
+                                     "'build require'. You need to specify a suffix using the "
+                                     "'build_context_suffix' attribute at the CMakeDeps "
+                                     "generator.".format(common_name))
 
         # Iterate all the transitive requires
         for req in host_req + build_req:

--- a/conans/test/functional/toolchains/cmake/cmakedeps/test_build_context_protobuf.py
+++ b/conans/test/functional/toolchains/cmake/cmakedeps/test_build_context_protobuf.py
@@ -69,31 +69,31 @@ main = textwrap.dedent("""
     """)
 
 consumer_conanfile = textwrap.dedent("""
-        import os
-        from conans import ConanFile
-        from conan.tools.cmake import CMake, CMakeToolchain, CMakeDeps
+    import os
+    from conans import ConanFile
+    from conan.tools.cmake import CMake, CMakeToolchain, CMakeDeps
 
-        class Consumer(ConanFile):
-            settings = "build_type", "os", "arch", "compiler"
-            exports_sources = "CMakeLists.txt", "main.cpp"
-            requires = "protobuf/1.0"
-            build_requires = "protobuf/1.0"
+    class Consumer(ConanFile):
+        settings = "build_type", "os", "arch", "compiler"
+        exports_sources = "CMakeLists.txt", "main.cpp"
+        requires = "protobuf/1.0"
+        build_requires = "protobuf/1.0"
 
-            def generate(self):
-                toolchain = CMakeToolchain(self)
-                toolchain.generate()
+        def generate(self):
+            toolchain = CMakeToolchain(self)
+            toolchain.generate()
 
-                deps = CMakeDeps(self)
-                {}
-                deps.generate()
+            deps = CMakeDeps(self)
+            {}
+            deps.generate()
 
-            def build(self):
-                cmake = CMake(self)
-                cmake.configure()
-                cmake.build()
-                folder = str(self.settings.build_type) if self.settings.os == "Windows" else "."
-                self.run(os.sep.join([folder, "app"]))
-        """)
+        def build(self):
+            cmake = CMake(self)
+            cmake.configure()
+            cmake.build()
+            folder = str(self.settings.build_type) if self.settings.os == "Windows" else "."
+            self.run(os.sep.join([folder, "app"]))
+    """)
 
 
 def test_build_modules_from_build_context(client):
@@ -117,7 +117,7 @@ def test_build_modules_from_build_context(client):
     """
 
     client.save({"conanfile.py": consumer_conanfile.format(cmake_deps_conf),
-                 "CMakeLists.txt": consumer_cmake.format(cmake_deps_conf),
+                 "CMakeLists.txt": consumer_cmake,
                  "main.cpp": main})
 
     client.run("create . app/1.0@ -pr:b default -pr:h default")
@@ -146,7 +146,7 @@ def test_build_modules_and_target_from_build_context(client):
     """
 
     client.save({"conanfile.py": consumer_conanfile.format(cmake_deps_conf),
-                 "CMakeLists.txt": consumer_cmake.format(cmake_deps_conf),
+                 "CMakeLists.txt": consumer_cmake,
                  "main.cpp": main})
 
     client.run("create . app/1.0@ -pr:b default -pr:h default")
@@ -174,7 +174,7 @@ def test_build_modules_from_host_and_target_from_build_context(client):
     """
 
     client.save({"conanfile.py": consumer_conanfile.format(cmake_deps_conf),
-                 "CMakeLists.txt": consumer_cmake.format(cmake_deps_conf),
+                 "CMakeLists.txt": consumer_cmake,
                  "main.cpp": main})
 
     client.run("create . app/1.0@ -pr:b default -pr:h default")
@@ -203,7 +203,7 @@ def test_build_modules_and_target_from_host_context(client):
     """
 
     client.save({"conanfile.py": consumer_conanfile.format(cmake_deps_conf),
-                 "CMakeLists.txt": consumer_cmake.format(cmake_deps_conf),
+                 "CMakeLists.txt": consumer_cmake,
                  "main.cpp": main})
 
     client.run("create . app/1.0@ -pr:b default -pr:h default")
@@ -214,6 +214,19 @@ def test_build_modules_and_target_from_host_context(client):
 
 
 def test_exception_when_not_prefix_specified(client):
+    cmake_deps_conf = """
+        deps.build_context_activated = ["protobuf"]
+    """
+    client.save({"conanfile.py": consumer_conanfile.format(cmake_deps_conf),
+                 "main.cpp": main})
+
+    client.run("create . app/1.0@ -pr:b default -pr:h default", assert_error=True)
+    assert "The package 'protobuf' exists both as 'require' and as 'build require'. " \
+           "You need to specify a suffix using the 'build_context_suffix' attribute at the " \
+           "CMakeDeps generator." in client.out
+
+
+def test_not_activated_not_fail(client):
     consumer_cmake = textwrap.dedent("""
         set(CMAKE_CXX_COMPILER_WORKS 1)
         set(CMAKE_CXX_ABI_COMPILED 1)
@@ -226,14 +239,11 @@ def test_exception_when_not_prefix_specified(client):
         target_link_libraries(app protobuf::protobuf)
         """)
 
-    cmake_deps_conf = """
-    """
-
-    client.save({"conanfile.py": consumer_conanfile.format(cmake_deps_conf),
-                 "CMakeLists.txt": consumer_cmake.format(cmake_deps_conf),
+    client.save({"conanfile.py": consumer_conanfile.format(""),
+                 "CMakeLists.txt": consumer_cmake,
                  "main.cpp": main})
 
-    client.run("create . app/1.0@ -pr:b default -pr:h default", assert_error=True)
-    assert "The package 'protobuf' exists both as 'require' and as 'build require'. " \
-           "You need to specify a suffix using the 'build_context_suffix' attribute at the " \
-           "CMakeDeps generator." in client.out
+    client.run("create . app/1.0@ -pr:b default -pr:h default")
+    assert "app/1.0: Created package" in client.out
+    assert "Library from host context!" in client.out
+    assert "Generated code in host context!" in client.out

--- a/conans/test/functional/toolchains/cmake/cmakedeps/test_build_context_transitive_build.py
+++ b/conans/test/functional/toolchains/cmake/cmakedeps/test_build_context_transitive_build.py
@@ -4,7 +4,6 @@ import textwrap
 import pytest
 
 from conans.test.assets.cmake import gen_cmakelists
-from conans.test.assets.genconanfile import GenConanfile
 from conans.test.assets.sources import gen_function_cpp
 from conans.test.utils.tools import TestClient
 

--- a/conans/test/functional/toolchains/cmake/cmakedeps/test_cmakedeps_components.py
+++ b/conans/test/functional/toolchains/cmake/cmakedeps/test_cmakedeps_components.py
@@ -82,8 +82,6 @@ class PropagateSpecificComponents(unittest.TestCase):
         self.assertIn("top::cmp1", content)
 
 
-
-
 @pytest.fixture
 def top_conanfile():
     return textwrap.dedent("""


### PR DESCRIPTION
Changelog: Fix: Do not fail in ``CMakeDeps`` when there are ``build_requires`` with same name as host requires, unless ``build_context_activated`` is enabled for those and a different suffix has not been defined.
Docs: Omit