### PR TITLE
Default to install folder when no generators declared in the layout

### DIFF
--- a/conans/model/conan_file.py
+++ b/conans/model/conan_file.py
@@ -272,15 +272,18 @@ class ConanFile(object):
 
     @property
     def install_folder(self):
+        # FIXME: Remove in 2.0, no self.install_folder
         return self.folders.base_install
 
     @install_folder.setter
     def install_folder(self, folder):
+        # FIXME: Remove in 2.0, no self.install_folder
         self.folders.set_base_install(folder)
 
     @property
     def generators_folder(self):
-        return self.folders.generators_folder
+        # FIXME: Remove in 2.0, no self.install_folder
+        return self.folders.generators_folder if self.folders.generators else self.install_folder
 
     @property
     def imports_folder(self):

--- a/conans/test/functional/layout/test_local_commands.py
+++ b/conans/test/functional/layout/test_local_commands.py
@@ -87,8 +87,7 @@ def test_local_dynamic_generators_folder():
 
 def test_no_layout_generators_folder():
     """If we don't configure a generators folder in the layout, the generator files:
-      - all go to the install_folder, EXCEPT the new ones, that NEEDS the generator folder
-        or go to the BASE folder
+      - all go to the install_folder
     """
     client = TestClient()
     conan_file = str(GenConanfile().with_settings("build_type").
@@ -109,11 +108,11 @@ def test_no_layout_generators_folder():
     assert os.path.exists(conaninfo)
     assert os.path.exists(conanbuildinfo)
     assert os.path.exists(cmake_generator_path)
-    # Not in the install_folder
-    assert not os.path.exists(cmake_toolchain_generator_path)
+    # In the install_folder
+    assert os.path.exists(cmake_toolchain_generator_path)
 
-    # But in the base folder
-    assert os.path.exists(os.path.join(client.current_folder, "conan_toolchain.cmake"))
+    # But not in the base folder
+    assert not os.path.exists(os.path.join(client.current_folder, "conan_toolchain.cmake"))
 
 
 def test_local_build():


### PR DESCRIPTION
Changelog: Bugfix: The new generators like `CMakeDeps` and `CMakeToolchain`write the generated files defaulting to the `install folder` if no `self.folders.generators` is specified in the `layout()` method.
Docs: omit

Closes #9047 