### PR TITLE
fixing preprocessor_definitions in MSBuildToolchain

### DIFF
--- a/conan/tools/microsoft/toolchain.py
+++ b/conan/tools/microsoft/toolchain.py
@@ -135,7 +135,7 @@ class MSBuildToolchain(object):
     def _write_config_toolchain(self, config_filename):
 
         def format_macro(key, value):
-            return '%s="%s"' % (key, value) if value is not None else key
+            return '%s=%s' % (key, value) if value is not None else key
 
         toolchain_file = textwrap.dedent("""\
             <?xml version="1.0" encoding="utf-8"?>

--- a/conans/test/functional/toolchains/microsoft/test_msbuild.py
+++ b/conans/test/functional/toolchains/microsoft/test_msbuild.py
@@ -353,11 +353,16 @@ class WinTest(unittest.TestCase):
                     tc.configuration = "ReleaseShared"
                     gen.configuration = "ReleaseShared"
 
-                tc.preprocessor_definitions["DEFINITIONS_BOTH"] = "True"
+                tc.preprocessor_definitions["DEFINITIONS_BOTH"] = '"True"'
+                tc.preprocessor_definitions["DEFINITIONS_BOTH2"] = 'DEFINITIONS_BOTH'
+                tc.preprocessor_definitions["DEFINITIONS_BOTH_INT"] = 123
                 if self.settings.build_type == "Debug":
-                    tc.preprocessor_definitions["DEFINITIONS_CONFIG"] = "Debug"
+                    tc.preprocessor_definitions["DEFINITIONS_CONFIG"] = '"Debug"'
+                    tc.preprocessor_definitions["DEFINITIONS_CONFIG_INT"] = 234
                 else:
-                    tc.preprocessor_definitions["DEFINITIONS_CONFIG"] = "Release"
+                    tc.preprocessor_definitions["DEFINITIONS_CONFIG"] = '"Release"'
+                    tc.preprocessor_definitions["DEFINITIONS_CONFIG_INT"] = 456
+                tc.preprocessor_definitions["DEFINITIONS_CONFIG2"] = 'DEFINITIONS_CONFIG'
 
                 tc.generate()
                 gen.generate()
@@ -376,7 +381,9 @@ class WinTest(unittest.TestCase):
                 msbuild.build("MyProject.sln")
         """)
     app = gen_function_cpp(name="main", includes=["hello"], calls=["hello"],
-                           preprocessor=["DEFINITIONS_BOTH", "DEFINITIONS_CONFIG"])
+                           preprocessor=["DEFINITIONS_BOTH", "DEFINITIONS_BOTH2",
+                                         "DEFINITIONS_BOTH_INT", "DEFINITIONS_CONFIG",
+                                         "DEFINITIONS_CONFIG2", "DEFINITIONS_CONFIG_INT"])
 
     @staticmethod
     def _run_app(client, arch, build_type, shared=None):
@@ -444,8 +451,12 @@ class WinTest(unittest.TestCase):
         self.assertIn("Hello World Release", client.out)
         compiler_version = version if compiler == "msvc" else "19.1"
         check_exe_run(client.out, "main", "msvc", compiler_version, "Release", "x86", cppstd,
-                      {"DEFINITIONS_BOTH": "True",
-                       "DEFINITIONS_CONFIG": "Release"})
+                      {"DEFINITIONS_BOTH": 'True',
+                       "DEFINITIONS_BOTH2": "True",
+                       "DEFINITIONS_BOTH_INT": "123",
+                       "DEFINITIONS_CONFIG": 'Release',
+                       "DEFINITIONS_CONFIG2": 'Release',
+                       "DEFINITIONS_CONFIG_INT": "456"})
         static_runtime = True if runtime == "static" or "MT" in runtime else False
         check_vs_runtime("Release/MyApp.exe", client, "15", build_type="Release",
                          static_runtime=static_runtime)
@@ -483,8 +494,12 @@ class WinTest(unittest.TestCase):
         self._run_app(client, "x64", "Debug")
         self.assertIn("Hello World Debug", client.out)
         check_exe_run(client.out, "main", "msvc", "19.0", "Debug", "x86_64", "14",
-                      {"DEFINITIONS_BOTH": "True",
-                       "DEFINITIONS_CONFIG": "Debug"})
+                      {"DEFINITIONS_BOTH": 'True',
+                       "DEFINITIONS_BOTH2": "True",
+                       "DEFINITIONS_BOTH_INT": "123",
+                       "DEFINITIONS_CONFIG": 'Debug',
+                       "DEFINITIONS_CONFIG2": 'Debug',
+                       "DEFINITIONS_CONFIG_INT": "234"})
         check_vs_runtime("x64/Debug/MyApp.exe", client, "15", build_type="Debug")
 
     @pytest.mark.tool_cmake


### PR DESCRIPTION
Changelog: BugFix: Do not quote all values and allow integer and macro referencing in ``MSBuildToolchain.preprocessor_definitions``
Docs: Omit

This might be breaking for other users, but better fix it soon or it will be impossible to fix later.