### PR TITLE
Fix 9071

### DIFF
--- a/conan/tools/cmake/cmakedeps/templates/target_configuration.py
+++ b/conan/tools/cmake/cmakedeps/templates/target_configuration.py
@@ -33,11 +33,7 @@ class TargetConfigurationTemplate(CMakeDepsFileTemplate):
         return textwrap.dedent("""\
 
         {%- macro tvalue(pkg_name, comp_name, var, config_suffix) -%}
-            {%- if comp_name == pkg_name -%}
-                {{'${'+pkg_name+'_'+var+config_suffix+'}'}}
-            {%- else -%}
-                {{'${'+pkg_name+'_'+comp_name+'_'+var+config_suffix+'}'}}
-            {%- endif -%}
+            {{'${'+pkg_name+'_'+comp_name+'_'+var+config_suffix+'}'}}
         {%- endmacro -%}
 
         ########### VARIABLES #######################################################################


### PR DESCRIPTION
Changelog: Bugfix: The `CMakeDeps` generator variables were named wrongly when a component had the same name as the package.
Docs: omit

Closes #9071