### PR TITLE
removing env propagation for conaninfo.txt

### DIFF
--- a/conans/client/cmd/export_pkg.py
+++ b/conans/client/cmd/export_pkg.py
@@ -2,8 +2,6 @@ import os
 
 from conans.client import packager
 from conans.client.conanfile.package import run_package_method
-from conans.client.graph.graph import BINARY_SKIP
-from conans.client.installer import add_env_conaninfo
 from conans.errors import ConanException
 from conans.model.ref import PackageReference
 
@@ -30,13 +28,6 @@ def export_pkg(app, recorder, full_ref, source_folder, build_folder, package_fol
     nodes = deps_graph.root.neighbors()
     pkg_node = nodes[0]
     conanfile = pkg_node.conanfile
-
-    def _init_conanfile_infos():
-        node_order = [n for n in pkg_node.public_closure if n.binary != BINARY_SKIP]
-        subtree_libnames = [node.ref.name for node in node_order]
-        add_env_conaninfo(conanfile, subtree_libnames)
-
-    _init_conanfile_infos()
 
     package_id = pkg_node.package_id
     output.info("Packaging to %s" % package_id)

--- a/conans/client/installer.py
+++ b/conans/client/installer.py
@@ -47,14 +47,6 @@ def build_id(conan_file):
     return None
 
 
-def add_env_conaninfo(conan_file, subtree_libnames):
-    for package_name, env_vars in conan_file._conan_env_values.data.items():
-        for name, value in env_vars.items():
-            if not package_name or package_name in subtree_libnames or \
-                    package_name == conan_file.name:
-                conan_file.info.env_values.add(name, value, package_name)
-
-
 class _PackageBuilder(object):
     def __init__(self, cache, output, hook_manager, remote_manager, generators):
         self._cache = cache
@@ -592,11 +584,6 @@ class BinaryInstaller(object):
                 env_info.LD_LIBRARY_PATH.extend(dep_cpp_info.lib_paths)
                 env_info.PATH.extend(dep_cpp_info.bin_paths)
                 conan_file.deps_env_info.update(env_info, n.ref.name)
-
-        # Update the info but filtering the package values that not apply to the subtree
-        # of this current node and its dependencies.
-        subtree_libnames = [node.ref.name for node in node_order]
-        add_env_conaninfo(conan_file, subtree_libnames)
 
     def _call_package_info(self, conanfile, package_folder, ref, is_editable):
         conanfile.cpp_info = CppInfo(conanfile.name, package_folder)

--- a/conans/test/integration/command/export_pkg_test.py
+++ b/conans/test/integration/command/export_pkg_test.py
@@ -167,23 +167,6 @@ class HelloPythonConan(ConanFile):
         client.run("export-pkg . Hello/0.1@lasote/stable -pr=myprofile")
         self.assertIn("Hello/0.1@lasote/stable: ENV-VALUE: MYCUSTOMVALUE!!!", client.out)
 
-    def test_profile_environment_conaninfo(self):
-        # https://github.com/conan-io/conan/issues/6603
-        profile = dedent("""
-            [env]
-            MYCUSTOMVAR=MYCUSTOMVALUE
-            """)
-        client = TestClient()
-        client.save({"conanfile.py": GenConanfile().with_name("Hello").with_version("0.1"),
-                     "myprofile": profile})
-        client.run("export-pkg . Hello/0.1@lasote/stable -pr=myprofile")
-        ref = ConanFileReference.loads("Hello/0.1@lasote/stable")
-        pkg_folder = client.cache.package_layout(ref).packages()
-        folders = os.listdir(pkg_folder)
-        pkg_folder = os.path.join(pkg_folder, folders[0])
-        conaninfo = load(os.path.join(pkg_folder, "conaninfo.txt"))
-        self.assertIn("MYCUSTOMVAR=MYCUSTOMVALUE", conaninfo)
-
     def _consume(self, client, install_args):
         consumer = """
 from conans import ConanFile


### PR DESCRIPTION
Changelog: Remove: ``conaninfo.txt`` no longer gets ``[env]`` information from dependencies.
Docs: Omit