### PR TITLE
Feature/conf cli support #9038

### DIFF
--- a/conans/client/command.py
+++ b/conans/client/command.py
@@ -724,7 +724,7 @@ class Command(object):
         if args.install_folder and (args.profile_host or args.settings_host
                                     or args.options_host or args.env_host or args.conf_host):
             raise ArgumentError(None, "--install-folder cannot be used together with a"
-                                      " host profile (-s, -o, -e or -pr)")
+                                      " host profile (-s, -o, -e, -pr or -c)")
 
         if args.build_order and args.graph:
             raise ArgumentError(None, "--build-order cannot be used together with --graph")
@@ -2125,12 +2125,12 @@ class Command(object):
     @staticmethod
     def _check_lockfile_args(args):
         if args.lockfile and (args.profile_build or args.settings_build or args.options_build or
-                              args.env_build):
-            raise ConanException("Cannot use profile, settings, options or env 'build' when "
+                              args.env_build or args.conf_build):
+            raise ConanException("Cannot use profile, settings, options, env or conf 'build' when "
                                  "using lockfile")
         if args.lockfile and (args.profile_host or args.settings_host or args.options_host or
                               args.env_host or args.conf_host):
-            raise ConanException("Cannot use profile, settings, options or env 'host' when "
+            raise ConanException("Cannot use profile, settings, options, env or conf 'host' when "
                                  "using lockfile")
         if args.lockfile_out and not args.lockfile:
             raise ConanException("lockfile_out cannot be specified if lockfile is not defined")

--- a/conans/client/command.py
+++ b/conans/client/command.py
@@ -299,12 +299,14 @@ class Command(object):
         self._check_lockfile_args(args)
 
         profile_build = ProfileData(profiles=args.profile_build, settings=args.settings_build,
-                                    options=args.options_build, env=args.env_build)
+                                    options=args.options_build, env=args.env_build,
+                                    conf=args.conf_build)
 
         return self._conan.test(args.path, args.reference,
                                 args.profile_host, args.settings_host, args.options_host,
-                                args.env_host, remote_name=args.remote, update=args.update,
-                                build_modes=args.build, test_build_folder=args.test_build_folder,
+                                args.env_host, conf=args.conf_host, remote_name=args.remote,
+                                update=args.update, build_modes=args.build,
+                                test_build_folder=args.test_build_folder,
                                 lockfile=args.lockfile, profile_build=profile_build)
 
     def create(self, *args):
@@ -369,14 +371,19 @@ class Command(object):
         info = None
         try:
             profile_build = ProfileData(profiles=args.profile_build, settings=args.settings_build,
-                                        options=args.options_build, env=args.env_build)
+                                        options=args.options_build, env=args.env_build,
+                                        conf=args.conf_build)
 
-            info = self._conan.create(args.path, name, version, user, channel,
-                                      args.profile_host, args.settings_host, args.options_host,
-                                      args.env_host, args.test_folder, args.not_export,
-                                      args.build, args.keep_source, args.keep_build, args.verify,
-                                      args.manifests, args.manifests_interactive,
-                                      args.remote, args.update,
+            info = self._conan.create(args.path, name=name, version=version, user=user,
+                                      channel=channel, profile_names=args.profile_host,
+                                      settings=args.settings_host, conf=args.conf_host,
+                                      options=args.options_host, env=args.env_host,
+                                      test_folder=args.test_folder, not_export=args.not_export,
+                                      build_modes=args.build, keep_source=args.keep_source,
+                                      keep_build=args.keep_build, verify=args.verify,
+                                      manifests=args.manifests,
+                                      manifests_interactive=args.manifests_interactive,
+                                      remote_name=args.remote, update=args.update,
                                       test_build_folder=args.test_build_folder,
                                       lockfile=args.lockfile,
                                       lockfile_out=args.lockfile_out,
@@ -491,7 +498,9 @@ class Command(object):
         self._check_lockfile_args(args)
 
         profile_build = ProfileData(profiles=args.profile_build, settings=args.settings_build,
-                                    options=args.options_build, env=args.env_build)
+                                    options=args.options_build, env=args.env_build,
+                                    conf=args.conf_build)
+        # TODO: 2.0 create profile_host object here to avoid passing a lot of arguments to the API
 
         cwd = os.getcwd()
 
@@ -507,6 +516,7 @@ class Command(object):
                                            name=name, version=version, user=user, channel=channel,
                                            settings=args.settings_host, options=args.options_host,
                                            env=args.env_host, profile_names=args.profile_host,
+                                           conf=args.conf_host,
                                            profile_build=profile_build,
                                            remote_name=args.remote,
                                            verify=args.verify, manifests=args.manifests,
@@ -528,6 +538,7 @@ class Command(object):
                                                      settings=args.settings_host,
                                                      options=args.options_host,
                                                      env=args.env_host,
+                                                     conf=args.conf_host,
                                                      profile_names=args.profile_host,
                                                      profile_build=profile_build,
                                                      remote_name=args.remote,
@@ -699,14 +710,15 @@ class Command(object):
         self._check_lockfile_args(args)
 
         profile_build = ProfileData(profiles=args.profile_build, settings=args.settings_build,
-                                    options=args.options_build, env=args.env_build)
+                                    options=args.options_build, env=args.env_build,
+                                    conf=args.conf_build)
 
         if args.build_order:
             self._out.warn("Usage of `--build-order` argument is deprecated and can return"
                            " wrong results. Use `conan lock build-order ...` instead.")
 
         if args.install_folder and (args.profile_host or args.settings_host
-                                    or args.options_host or args.env_host):
+                                    or args.options_host or args.env_host or args.conf_host):
             raise ArgumentError(None, "--install-folder cannot be used together with a"
                                       " host profile (-s, -o, -e or -pr)")
 
@@ -720,6 +732,7 @@ class Command(object):
                                                options=args.options_host,
                                                env=args.env_host,
                                                profile_names=args.profile_host,
+                                               conf=args.conf_host,
                                                profile_build=profile_build,
                                                remote_name=args.remote,
                                                build_order=args.build_order,
@@ -739,6 +752,7 @@ class Command(object):
                                                        options=args.options_host,
                                                        env=args.env_host,
                                                        profile_names=args.profile_host,
+                                                       conf=args.conf_host,
                                                        profile_build=profile_build,
                                                        remote_name=args.remote,
                                                        check_updates=args.update,
@@ -757,6 +771,7 @@ class Command(object):
                                     options=args.options_host,
                                     env=args.env_host,
                                     profile_names=args.profile_host,
+                                    conf=args.conf_host,
                                     profile_build=profile_build,
                                     update=args.update,
                                     install_folder=args.install_folder,
@@ -1015,7 +1030,8 @@ class Command(object):
 
         try:
             profile_build = ProfileData(profiles=args.profile_build, settings=args.settings_build,
-                                        options=args.options_build, env=args.env_build)
+                                        options=args.options_build, env=args.env_build,
+                                        conf=args.conf_build)
 
             info = self._conan.export_pkg(conanfile_path=args.path,
                                           name=name,
@@ -1028,6 +1044,7 @@ class Command(object):
                                           env=args.env_host,
                                           settings=args.settings_host,
                                           options=args.options_host,
+                                          conf=args.conf_host,
                                           profile_build=profile_build,
                                           force=args.force,
                                           user=user,
@@ -1812,12 +1829,19 @@ class Command(object):
             raise ConanException("lockfile_out cannot be specified if lockfile is not defined")
 
         profile_build = ProfileData(profiles=args.profile_build, settings=args.settings_build,
-                                    options=args.options_build, env=args.env_build)
+                                    options=args.options_build, env=args.env_build,
+                                    conf=args.conf_build)
 
         if args.subcommand == "install":
-            self._conan.workspace_install(args.path, args.settings_host, args.options_host,
-                                          args.env_host, args.remote, args.build,
-                                          args.profile_host, args.update,
+            self._conan.workspace_install(args.path,
+                                          settings=args.settings_host,
+                                          options=args.options_host,
+                                          env=args.env_host,
+                                          profile_name=args.profile_host,
+                                          conf=args.conf_host,
+                                          remote_name=args.remote,
+                                          build=args.build,
+                                          update=args.update,
                                           profile_build=profile_build,
                                           install_folder=args.install_folder)
 
@@ -1987,9 +2011,11 @@ class Command(object):
             self._conan.lock_clean_modified(args.lockfile)
         elif args.subcommand == "create":
             profile_build = ProfileData(profiles=args.profile_build, settings=args.settings_build,
-                                        options=args.options_build, env=args.env_build)
+                                        options=args.options_build, env=args.env_build,
+                                        conf=args.conf_build)
             profile_host = ProfileData(profiles=args.profile_host, settings=args.settings_host,
-                                       options=args.options_host, env=args.env_host)
+                                       options=args.options_host, env=args.env_host,
+                                       conf=args.conf_host)
 
             self._conan.lock_create(path=args.path,
                                     reference=args.reference,
@@ -2096,7 +2122,7 @@ class Command(object):
             raise ConanException("Cannot use profile, settings, options or env 'build' when "
                                  "using lockfile")
         if args.lockfile and (args.profile_host or args.settings_host or args.options_host or
-                              args.env_host):
+                              args.env_host or args.conf_host):
             raise ConanException("Cannot use profile, settings, options or env 'host' when "
                                  "using lockfile")
         if args.lockfile_out and not args.lockfile:
@@ -2277,7 +2303,17 @@ def _add_profile_arguments(parser):
                                  ' ({} machine). e.g.: -s{} compiler=gcc'.format(machine,
                                                                                  short_suffix))
 
-    for item_fn in [environment_args, options_args, profile_args, settings_args]:
+    def conf_args(machine, short_suffix="", long_suffix=""):
+        parser.add_argument("-c{}".format(short_suffix),
+                            "--conf{}".format(long_suffix),
+                            nargs=1, action=Extender,
+                            dest='conf_{}'.format(machine),
+                            help='Configuration to build the package, overwriting the defaults'
+                                 ' ({} machine). e.g.: -c{} '
+                                 'tools.cmake.cmaketoolchain:generator=Xcode'.format(machine,
+                                                                                     short_suffix))
+
+    for item_fn in [environment_args, options_args, profile_args, settings_args, conf_args]:
         item_fn("host", "", "")  # By default it is the HOST, the one we are building binaries for
         item_fn("build", ":b", ":build")
         item_fn("host", ":h", ":host")

--- a/conans/client/command.py
+++ b/conans/client/command.py
@@ -301,6 +301,7 @@ class Command(object):
         profile_build = ProfileData(profiles=args.profile_build, settings=args.settings_build,
                                     options=args.options_build, env=args.env_build,
                                     conf=args.conf_build)
+        # TODO: 2.0 create profile_host object here to avoid passing a lot of arguments to the API
 
         return self._conan.test(args.path, args.reference,
                                 args.profile_host, args.settings_host, args.options_host,
@@ -373,6 +374,8 @@ class Command(object):
             profile_build = ProfileData(profiles=args.profile_build, settings=args.settings_build,
                                         options=args.options_build, env=args.env_build,
                                         conf=args.conf_build)
+            # TODO: 2.0 create profile_host object here to avoid passing a lot of arguments
+            #       to the API
 
             info = self._conan.create(args.path, name=name, version=version, user=user,
                                       channel=channel, profile_names=args.profile_host,
@@ -712,6 +715,7 @@ class Command(object):
         profile_build = ProfileData(profiles=args.profile_build, settings=args.settings_build,
                                     options=args.options_build, env=args.env_build,
                                     conf=args.conf_build)
+        # TODO: 2.0 create profile_host object here to avoid passing a lot of arguments to the API
 
         if args.build_order:
             self._out.warn("Usage of `--build-order` argument is deprecated and can return"
@@ -1032,6 +1036,8 @@ class Command(object):
             profile_build = ProfileData(profiles=args.profile_build, settings=args.settings_build,
                                         options=args.options_build, env=args.env_build,
                                         conf=args.conf_build)
+            # TODO: 2.0 create profile_host object here to avoid passing a lot of arguments
+            #       to the API
 
             info = self._conan.export_pkg(conanfile_path=args.path,
                                           name=name,
@@ -1831,6 +1837,7 @@ class Command(object):
         profile_build = ProfileData(profiles=args.profile_build, settings=args.settings_build,
                                     options=args.options_build, env=args.env_build,
                                     conf=args.conf_build)
+        # TODO: 2.0 create profile_host object here to avoid passing a lot of arguments to the API
 
         if args.subcommand == "install":
             self._conan.workspace_install(args.path,

--- a/conans/client/conan_api.py
+++ b/conans/client/conan_api.py
@@ -1464,7 +1464,7 @@ class ConanAPIV1(object):
         if profile_build and not pbuild:
             # Only work on the profile_build if something is provided
             pbuild = profile_from_args(profile_build.profiles, profile_build.settings,
-                                       profile_build.options, profile_build.env, profile_host.conf,
+                                       profile_build.options, profile_build.env, profile_build.conf,
                                        cwd, self.app.cache)
 
         root_ref = ConanFileReference(name, version, user, channel, validate=False)
@@ -1554,7 +1554,7 @@ def get_graph_info(profile_host, profile_build, cwd, install_folder, cache, outp
         if profile_build:
             # Only work on the profile_build if something is provided
             pbuild = profile_from_args(profile_build.profiles, profile_build.settings,
-                                       profile_build.options, profile_build.env, profile_host.conf,
+                                       profile_build.options, profile_build.env, profile_build.conf,
                                        cwd, cache)
             pbuild.process_settings(cache)
         else:

--- a/conans/client/conan_api.py
+++ b/conans/client/conan_api.py
@@ -1458,12 +1458,14 @@ class ConanAPIV1(object):
 
         if not phost:
             phost = profile_from_args(profile_host.profiles, profile_host.settings,
-                                      profile_host.options, profile_host.env, cwd, self.app.cache)
+                                      profile_host.options, profile_host.env, profile_host.conf,
+                                      cwd, self.app.cache)
 
         if profile_build and not pbuild:
             # Only work on the profile_build if something is provided
             pbuild = profile_from_args(profile_build.profiles, profile_build.settings,
-                                       profile_build.options, profile_build.env, cwd, self.app.cache)
+                                       profile_build.options, profile_build.env, profile_host.conf,
+                                       cwd, self.app.cache)
 
         root_ref = ConanFileReference(name, version, user, channel, validate=False)
         phost.process_settings(self.app.cache)
@@ -1547,12 +1549,13 @@ def get_graph_info(profile_host, profile_build, cwd, install_folder, cache, outp
                         % install_folder)
 
         phost = profile_from_args(profile_host.profiles, profile_host.settings, profile_host.options,
-                                  profile_host.env, cwd, cache)
+                                  profile_host.env, profile_host.conf, cwd, cache)
         phost.process_settings(cache)
         if profile_build:
             # Only work on the profile_build if something is provided
             pbuild = profile_from_args(profile_build.profiles, profile_build.settings,
-                                       profile_build.options, profile_build.env, cwd, cache)
+                                       profile_build.options, profile_build.env, profile_host.conf,
+                                       cwd, cache)
             pbuild.process_settings(cache)
         else:
             pbuild = None

--- a/conans/client/conan_api.py
+++ b/conans/client/conan_api.py
@@ -71,9 +71,9 @@ from conans.util.tracer import log_command, log_exception
 default_manifest_folder = '.conan_manifests'
 
 
-class ProfileData(namedtuple("ProfileData", ["profiles", "settings", "options", "env"])):
+class ProfileData(namedtuple("ProfileData", ["profiles", "settings", "options", "env", "conf"])):
     def __bool__(self):
-        return bool(self.profiles or self.settings or self.options or self.env)
+        return bool(self.profiles or self.settings or self.options or self.env or self.conf)
     __nonzero__ = __bool__
 
 
@@ -314,10 +314,10 @@ class ConanAPIV1(object):
     @api_method
     def test(self, path, reference, profile_names=None, settings=None, options=None, env=None,
              remote_name=None, update=False, build_modes=None, cwd=None, test_build_folder=None,
-             lockfile=None, profile_build=None):
+             lockfile=None, profile_build=None, conf=None):
 
         profile_host = ProfileData(profiles=profile_names, settings=settings, options=options,
-                                   env=env)
+                                   env=env, conf=conf)
 
         remotes = self.app.load_remotes(remote_name=remote_name, update=update)
         conanfile_path = _get_conanfile_path(path, cwd, py=True)
@@ -340,7 +340,7 @@ class ConanAPIV1(object):
                manifests=None, manifests_interactive=None,
                remote_name=None, update=False, cwd=None, test_build_folder=None,
                lockfile=None, lockfile_out=None, ignore_dirty=False, profile_build=None,
-               is_build_require=False):
+               is_build_require=False, conf=None):
         """
         API method to create a conan package
 
@@ -350,7 +350,7 @@ class ConanAPIV1(object):
         """
 
         profile_host = ProfileData(profiles=profile_names, settings=settings, options=options,
-                                   env=env)
+                                   env=env, conf=conf)
         cwd = cwd or os.getcwd()
         recorder = ActionRecorder()
         try:
@@ -404,9 +404,10 @@ class ConanAPIV1(object):
     def export_pkg(self, conanfile_path, name, channel, source_folder=None, build_folder=None,
                    package_folder=None, install_folder=None, profile_names=None, settings=None,
                    options=None, env=None, force=False, user=None, version=None, cwd=None,
-                   lockfile=None, lockfile_out=None, ignore_dirty=False, profile_build=None):
+                   lockfile=None, lockfile_out=None, ignore_dirty=False, profile_build=None,
+                   conf=None):
         profile_host = ProfileData(profiles=profile_names, settings=settings, options=options,
-                                   env=env)
+                                   env=env, conf=conf)
         remotes = self.app.load_remotes()
         cwd = cwd or os.getcwd()
 
@@ -487,9 +488,10 @@ class ConanAPIV1(object):
     @api_method
     def workspace_install(self, path, settings=None, options=None, env=None,
                           remote_name=None, build=None, profile_name=None,
-                          update=False, cwd=None, install_folder=None, profile_build=None):
+                          update=False, cwd=None, install_folder=None, profile_build=None,
+                          conf=None):
         profile_host = ProfileData(profiles=profile_name, settings=settings, options=options,
-                                   env=env)
+                                   env=env, conf=conf)
         cwd = cwd or os.getcwd()
         abs_path = os.path.normpath(os.path.join(cwd, path))
 
@@ -533,9 +535,9 @@ class ConanAPIV1(object):
                           manifests_interactive=None, build=None, profile_names=None,
                           update=False, generators=None, install_folder=None, cwd=None,
                           lockfile=None, lockfile_out=None, profile_build=None,
-                          lockfile_node_id=None, is_build_require=False):
+                          lockfile_node_id=None, is_build_require=False, conf=None):
         profile_host = ProfileData(profiles=profile_names, settings=settings, options=options,
-                                   env=env)
+                                   env=env, conf=conf)
         recorder = ActionRecorder()
         cwd = cwd or os.getcwd()
         try:
@@ -577,9 +579,9 @@ class ConanAPIV1(object):
                 remote_name=None, verify=None, manifests=None,
                 manifests_interactive=None, build=None, profile_names=None,
                 update=False, generators=None, no_imports=False, install_folder=None, cwd=None,
-                lockfile=None, lockfile_out=None, profile_build=None):
+                lockfile=None, lockfile_out=None, profile_build=None, conf=None):
         profile_host = ProfileData(profiles=profile_names, settings=settings, options=options,
-                                   env=env)
+                                   env=env, conf=conf)
         recorder = ActionRecorder()
         cwd = cwd or os.getcwd()
         try:
@@ -703,9 +705,9 @@ class ConanAPIV1(object):
     @api_method
     def info_build_order(self, reference, settings=None, options=None, env=None,
                          profile_names=None, remote_name=None, build_order=None, check_updates=None,
-                         install_folder=None, profile_build=None):
+                         install_folder=None, profile_build=None, conf=None):
         profile_host = ProfileData(profiles=profile_names, settings=settings, options=options,
-                                   env=env)
+                                   env=env, conf=conf)
         reference, graph_info = self._info_args(reference, install_folder, profile_host,
                                                 profile_build)
         recorder = ActionRecorder()
@@ -717,9 +719,9 @@ class ConanAPIV1(object):
     @api_method
     def info_nodes_to_build(self, reference, build_modes, settings=None, options=None, env=None,
                             profile_names=None, remote_name=None, check_updates=None,
-                            install_folder=None, profile_build=None):
+                            install_folder=None, profile_build=None, conf=None):
         profile_host = ProfileData(profiles=profile_names, settings=settings, options=options,
-                                   env=env)
+                                   env=env, conf=conf)
         reference, graph_info = self._info_args(reference, install_folder, profile_host,
                                                 profile_build)
         recorder = ActionRecorder()
@@ -732,9 +734,9 @@ class ConanAPIV1(object):
     @api_method
     def info(self, reference_or_path, remote_name=None, settings=None, options=None, env=None,
              profile_names=None, update=False, install_folder=None, build=None, lockfile=None,
-             profile_build=None):
+             profile_build=None, conf=None):
         profile_host = ProfileData(profiles=profile_names, settings=settings, options=options,
-                                   env=env)
+                                   env=env, conf=conf)
         reference, graph_info = self._info_args(reference_or_path, install_folder, profile_host,
                                                 profile_build,
                                                 lockfile=lockfile)
@@ -1428,7 +1430,7 @@ class ConanAPIV1(object):
                     profile_host=None, profile_build=None, remote_name=None, update=None, build=None,
                     base=None, lockfile=None):
         # profile_host is mandatory
-        profile_host = profile_host or ProfileData(None, None, None, None)
+        profile_host = profile_host or ProfileData(None, None, None, None, None)
         cwd = os.getcwd()
 
         if path and reference:

--- a/conans/client/profile_loader.py
+++ b/conans/client/profile_loader.py
@@ -236,7 +236,6 @@ def profile_from_args(profiles, settings, options, env, conf, cwd, cache):
     file and the args command-line arguments
     """
     default_profile = cache.default_profile  # Ensures a default profile creating
-
     if profiles is None:
         result = default_profile
     else:
@@ -294,14 +293,20 @@ def _profile_parse_args(settings, options, envs, conf):
                 _env_values.add(name, EnvValues.load_value(value), package)
         return _env_values
 
-    result = Profile()
     options = _get_tuples_list_from_extender_arg(options)
-    result.options = OptionsValues(options)
     env, package_env = _get_simple_and_package_tuples(envs)
     env_values = _get_env_values(env, package_env)
-    result.env_values = env_values
     settings, package_settings = _get_simple_and_package_tuples(settings)
+
+    result = Profile()
+    result.options = OptionsValues(options)
+    result.env_values = env_values
     result.settings = OrderedDict(settings)
+    if conf:
+        result.conf = ConfDefinition()
+        result.conf.loads("\n".join(conf))
+
     for pkg, values in package_settings.items():
         result.package_settings[pkg] = OrderedDict(values)
+
     return result

--- a/conans/client/profile_loader.py
+++ b/conans/client/profile_loader.py
@@ -231,7 +231,7 @@ def _apply_inner_profile(doc, base_profile):
         base_profile.buildenv.compose(buildenv)
 
 
-def profile_from_args(profiles, settings, options, env, cwd, cache):
+def profile_from_args(profiles, settings, options, env, conf, cwd, cache):
     """ Return a Profile object, as the result of merging a potentially existing Profile
     file and the args command-line arguments
     """
@@ -245,7 +245,7 @@ def profile_from_args(profiles, settings, options, env, cwd, cache):
             tmp, _ = read_profile(p, cwd, cache.profiles_path)
             result.compose(tmp)
 
-    args_profile = _profile_parse_args(settings, options, env)
+    args_profile = _profile_parse_args(settings, options, env, conf)
 
     if result:
         result.compose(args_profile)
@@ -254,7 +254,7 @@ def profile_from_args(profiles, settings, options, env, cwd, cache):
     return result
 
 
-def _profile_parse_args(settings, options, envs):
+def _profile_parse_args(settings, options, envs, conf):
     """ return a Profile object result of parsing raw data
     """
     def _get_tuples_list_from_extender_arg(items):

--- a/conans/test/integration/command/info/info_test.py
+++ b/conans/test/integration/command/info/info_test.py
@@ -404,7 +404,7 @@ class InfoTest2(unittest.TestCase):
                    assert_error=True)  # Re-uses debug from MyInstall folder
 
         self.assertIn("--install-folder cannot be used together with a"
-                      " host profile (-s, -o, -e or -pr)", client.out)
+                      " host profile (-s, -o, -e, -pr or -c)", client.out)
 
     def test_graph_html_embedded_visj(self):
         client = TestClient()

--- a/conans/test/integration/configuration/conf/test_conf.py
+++ b/conans/test/integration/configuration/conf/test_conf.py
@@ -133,3 +133,32 @@ def test_new_config_file_required_version():
         client.run("install .")
     assert ("Current Conan version (1.26.0) does not satisfy the defined one (>=2.0)"
             in str(excinfo.value))
+
+
+def test_new_conf_lines_via_cli(client):
+    profile = textwrap.dedent("""\
+        [conf]
+        """)
+    client.save({"profile": profile})
+    client.run("install . -pr=profile -c tools.microsoft.msbuild:verbosity=Minimal "
+               "-c tools.microsoft.msbuild:robustness=High")
+    assert "tools.microsoft.msbuild:verbosity$Minimal" in client.out
+    assert "tools.microsoft.msbuild:robustness$High" in client.out
+
+
+def test_composition_conan_conf_and_cli(client):
+    conf = textwrap.dedent("""\
+        tools.microsoft.msbuild:verbosity=Quiet
+        tools.microsoft.msbuild:performance=Slow
+        """)
+    save(client.cache.new_config_path, conf)
+    profile = textwrap.dedent("""\
+        [conf]
+        tools.microsoft.msbuild:verbosity=Minimal
+        tools.microsoft.msbuild:robustness=High
+        """)
+    client.save({"profile": profile})
+    client.run("install . -pr=profile -c tools.microsoft.msbuild:verbosity=Detailed")
+    assert "tools.microsoft.msbuild:verbosity$Detailed" in client.out
+    assert "tools.microsoft.msbuild:performance$Slow" in client.out
+    assert "tools.microsoft.msbuild:robustness$High" in client.out

--- a/conans/test/integration/configuration/conf/test_conf.py
+++ b/conans/test/integration/configuration/conf/test_conf.py
@@ -135,7 +135,7 @@ def test_new_config_file_required_version():
             in str(excinfo.value))
 
 
-def test_composition_conan_conf_and_cli(client):
+def test_composition_conan_conf_overwritten_by_cli_arg(client):
     conf = textwrap.dedent("""\
         tools.microsoft.msbuild:verbosity=Quiet
         tools.microsoft.msbuild:performance=Slow

--- a/conans/test/integration/configuration/conf/test_conf.py
+++ b/conans/test/integration/configuration/conf/test_conf.py
@@ -135,17 +135,6 @@ def test_new_config_file_required_version():
             in str(excinfo.value))
 
 
-def test_new_conf_lines_via_cli(client):
-    profile = textwrap.dedent("""\
-        [conf]
-        """)
-    client.save({"profile": profile})
-    client.run("install . -pr=profile -c tools.microsoft.msbuild:verbosity=Minimal "
-               "-c tools.microsoft.msbuild:robustness=High")
-    assert "tools.microsoft.msbuild:verbosity$Minimal" in client.out
-    assert "tools.microsoft.msbuild:robustness$High" in client.out
-
-
 def test_composition_conan_conf_and_cli(client):
     conf = textwrap.dedent("""\
         tools.microsoft.msbuild:verbosity=Quiet
@@ -158,7 +147,9 @@ def test_composition_conan_conf_and_cli(client):
         tools.microsoft.msbuild:robustness=High
         """)
     client.save({"profile": profile})
-    client.run("install . -pr=profile -c tools.microsoft.msbuild:verbosity=Detailed")
+    client.run("install . -pr=profile -c tools.microsoft.msbuild:verbosity=Detailed "
+               "-c tools.meson.meson:verbosity=Super")
     assert "tools.microsoft.msbuild:verbosity$Detailed" in client.out
     assert "tools.microsoft.msbuild:performance$Slow" in client.out
     assert "tools.microsoft.msbuild:robustness$High" in client.out
+    assert "tools.meson.meson:verbosity$Super" in client.out

--- a/conans/test/integration/configuration/conf/test_conf_from_br.py
+++ b/conans/test/integration/configuration/conf/test_conf_from_br.py
@@ -39,3 +39,34 @@ def test_basic():
 
     client.run("install . -pr:b=default -pr:h=android")
     assert "conanfile.py: NDK: MY-SYSTEM-NDK!!!" in client.out
+
+
+def test_basic_conf_through_cli():
+    client = TestClient()
+    conanfile = textwrap.dedent("""
+        from conans import ConanFile
+
+        class Pkg(ConanFile):
+
+            def package_info(self):
+                self.output.info("NDK build: %s" % self.conf["tools.android:ndk_path"])
+        """)
+    client.save({"conanfile.py": conanfile})
+    client.run("create . android_ndk/1.0@")
+
+    consumer = textwrap.dedent("""
+        from conans import ConanFile
+
+        class Pkg(ConanFile):
+            settings = "os", "compiler", "build_type", "arch"
+            generators = "CMakeToolchain"
+            build_requires = "android_ndk/1.0"
+
+            def generate(self):
+                self.output.info("NDK host: %s" % self.conf["tools.android:ndk_path"])
+        """)
+    client.save({"conanfile.py": consumer}, clean_first=True)
+    client.run('install . -c:b=tools.android:ndk_path="MY-NDK!!!" '
+               '-c:h=tools.android:ndk_path="MY-SYSTEM-NDK!!!"')
+    assert "android_ndk/1.0: NDK build: MY-NDK!!!" in client.out
+    assert "conanfile.py: NDK host: MY-SYSTEM-NDK!!!" in client.out

--- a/conans/test/integration/configuration/conf/test_conf_package_id.py
+++ b/conans/test/integration/configuration/conf/test_conf_package_id.py
@@ -32,3 +32,5 @@ def test_package_id(client):
     assert "pkg/0.1:b85ef030da903577bd87d1c92c0524c9c96212b5 - Build" in client.out
     client.run("create . pkg/0.1@ -pr=profile2")
     assert "pkg/0.1:7d2f1590113db99bcd08a4ebd4c841cc0a2e7020 - Build" in client.out
+    client.run("create . pkg/0.1@ -c tools.microsoft.msbuild:verbosity=Detailed")
+    assert "pkg/0.1:a2e8034244a388f79b31ebec1ddb991bd7b91f48 - Build" in client.out

--- a/conans/test/integration/graph_lock/graph_lock_test.py
+++ b/conans/test/integration/graph_lock/graph_lock_test.py
@@ -32,22 +32,26 @@ class GraphLockErrorsTest(unittest.TestCase):
         client.save({"conanfile.py": GenConanfile("PkgA", "0.1")})
         client.run("lock create conanfile.py --lockfile-out=conan.lock")
         client.run("install . --lockfile=conan.lock -s os=Windows", assert_error=True)
-        self.assertIn("ERROR: Cannot use profile, settings, options or env 'host' "
+        self.assertIn("ERROR: Cannot use profile, settings, options, env or conf 'host' "
                       "when using lockfile", client.out)
         client.run("install . --lockfile=conan.lock -pr=default", assert_error=True)
-        self.assertIn("ERROR: Cannot use profile, settings, options or env 'host' "
+        self.assertIn("ERROR: Cannot use profile, settings, options, env or conf 'host' "
                       "when using lockfile", client.out)
         client.run("install . --lockfile=conan.lock -o myoption=default", assert_error=True)
-        self.assertIn("ERROR: Cannot use profile, settings, options or env 'host' "
+        self.assertIn("ERROR: Cannot use profile, settings, options, env or conf 'host' "
                       "when using lockfile", client.out)
         client.run("install . --lockfile=conan.lock -s:b os=Windows", assert_error=True)
-        self.assertIn("ERROR: Cannot use profile, settings, options or env 'build' "
+        self.assertIn("ERROR: Cannot use profile, settings, options, env or conf 'build' "
                       "when using lockfile", client.out)
         client.run("install . --lockfile=conan.lock --profile:build=default", assert_error=True)
-        self.assertIn("ERROR: Cannot use profile, settings, options or env 'build' "
+        self.assertIn("ERROR: Cannot use profile, settings, options, env or conf 'build' "
                       "when using lockfile", client.out)
         client.run("install . --lockfile=conan.lock -o:b myoption=default", assert_error=True)
-        self.assertIn("ERROR: Cannot use profile, settings, options or env 'build' "
+        self.assertIn("ERROR: Cannot use profile, settings, options, env or conf 'build' "
+                      "when using lockfile", client.out)
+        client.run("install . --lockfile=conan.lock -c:b core:required_conan_version=>=1.36",
+                   assert_error=True)
+        self.assertIn("ERROR: Cannot use profile, settings, options, env or conf 'build' "
                       "when using lockfile", client.out)
 
     def test_error_old_format(self):

--- a/conans/test/unittests/client/command/parse_arguments_test.py
+++ b/conans/test/unittests/client/command/parse_arguments_test.py
@@ -11,7 +11,9 @@ from conans.client.command import _add_profile_arguments
 @parameterized_class([{"argument": ["env", "-e", "--env"]},
                       {"argument": ["options", "-o", "--options"]},
                       {"argument": ["profile", "-pr", "--profile"]},
-                      {"argument": ["settings", "-s", "--settings"]}])
+                      {"argument": ["settings", "-s", "--settings"]},
+                      {"argument": ["conf", "-c", "--conf"]}]
+                     )
 class ArgsParseProfileTest(unittest.TestCase):
     """ Check argparse for profile arguments """
 

--- a/conans/test/unittests/client/profile_loader/compiler_cppstd_test.py
+++ b/conans/test/unittests/client/profile_loader/compiler_cppstd_test.py
@@ -53,7 +53,7 @@ class SettingsCppStdTests(unittest.TestCase):
             """)
         save(self.cache.settings_path, settings_1_14_0)
         save(fullpath, t)
-        r = profile_from_args(["default", ], [], [], [], cwd=self.tmp_folder, cache=self.cache)
+        r = profile_from_args(["default", ], [], [], [], [], cwd=self.tmp_folder, cache=self.cache)
         with six.assertRaisesRegex(self, ConanException,
                                    "'settings.compiler.cppstd' doesn't exist for 'apple-clang'"):
             r.process_settings(self.cache)
@@ -61,7 +61,7 @@ class SettingsCppStdTests(unittest.TestCase):
     def test_no_value(self):
         self._save_profile()
 
-        r = profile_from_args(["default", ], [], [], [], cwd=self.tmp_folder, cache=self.cache)
+        r = profile_from_args(["default", ], [], [], [], [], cwd=self.tmp_folder, cache=self.cache)
         r.process_settings(self.cache)
         self.assertNotIn("compiler.cppstd", r.settings)
         self.assertNotIn("cppstd", r.settings)
@@ -69,7 +69,7 @@ class SettingsCppStdTests(unittest.TestCase):
     def test_value_none(self):
         self._save_profile(compiler_cppstd="None")
 
-        r = profile_from_args(["default", ], [], [], [], cwd=self.tmp_folder, cache=self.cache)
+        r = profile_from_args(["default", ], [], [], [], [], cwd=self.tmp_folder, cache=self.cache)
         r.process_settings(self.cache)
         self.assertEqual(r.settings["compiler.cppstd"], "None")
         self.assertNotIn("cppstd", r.settings)
@@ -77,7 +77,7 @@ class SettingsCppStdTests(unittest.TestCase):
     def test_value_valid(self):
         self._save_profile(compiler_cppstd="11")
 
-        r = profile_from_args(["default", ], [], [], [], cwd=self.tmp_folder, cache=self.cache)
+        r = profile_from_args(["default", ], [], [], [], [], cwd=self.tmp_folder, cache=self.cache)
         r.process_settings(self.cache)
         self.assertEqual(r.settings["compiler.cppstd"], "11")
         self.assertNotIn("cppstd", r.settings)
@@ -85,7 +85,7 @@ class SettingsCppStdTests(unittest.TestCase):
     def test_value_invalid(self):
         self._save_profile(compiler_cppstd="13")
 
-        r = profile_from_args(["default", ], [], [], [], cwd=self.tmp_folder, cache=self.cache)
+        r = profile_from_args(["default", ], [], [], [], [], cwd=self.tmp_folder, cache=self.cache)
         with six.assertRaisesRegex(self, ConanException, "Invalid setting '13' is not a valid "
                                                          "'settings.compiler.cppstd' value"):
             r.process_settings(self.cache)
@@ -94,7 +94,7 @@ class SettingsCppStdTests(unittest.TestCase):
     def test_value_duplicated_None(self):
         self._save_profile(compiler_cppstd="None", cppstd="None")
 
-        r = profile_from_args(["default", ], [], [], [], cwd=self.tmp_folder, cache=self.cache)
+        r = profile_from_args(["default", ], [], [], [], [], cwd=self.tmp_folder, cache=self.cache)
         r.process_settings(self.cache)
         self.assertEqual(r.settings["compiler.cppstd"], "None")
         self.assertEqual(r.settings["cppstd"], "None")
@@ -102,7 +102,7 @@ class SettingsCppStdTests(unittest.TestCase):
     def test_value_duplicated(self):
         self._save_profile(compiler_cppstd="11", cppstd="11")
 
-        r = profile_from_args(["default", ], [], [], [], cwd=self.tmp_folder, cache=self.cache)
+        r = profile_from_args(["default", ], [], [], [], [], cwd=self.tmp_folder, cache=self.cache)
         with six.assertRaisesRegex(self, ConanException, "Do not use settings 'compiler.cppstd'"
                                                          " together with 'cppstd'. Use only the"
                                                          " former one."):
@@ -113,7 +113,7 @@ class SettingsCppStdTests(unittest.TestCase):
     def test_value_different(self):
         self._save_profile(cppstd="14", compiler_cppstd="11")
 
-        r = profile_from_args(["default", ], [], [], [], cwd=self.tmp_folder, cache=self.cache)
+        r = profile_from_args(["default", ], [], [], [], [], cwd=self.tmp_folder, cache=self.cache)
         with six.assertRaisesRegex(self, ConanException, "Do not use settings 'compiler.cppstd'"
                                                          " together with 'cppstd'. Use only the"
                                                          " former one"):
@@ -122,7 +122,7 @@ class SettingsCppStdTests(unittest.TestCase):
     def test_value_from_cppstd(self):
         self._save_profile(cppstd="11")
 
-        r = profile_from_args(["default", ], [], [], [], cwd=self.tmp_folder, cache=self.cache)
+        r = profile_from_args(["default", ], [], [], [], [], cwd=self.tmp_folder, cache=self.cache)
         r.process_settings(self.cache)
         self.assertNotIn('compiler.cppstd', r.settings)
         self.assertEqual(r.settings["cppstd"], "11")


### PR DESCRIPTION
Changelog: Feature: Provide `[conf]` command line support.
Docs: https://github.com/conan-io/docs/pull/2124
Closes: #9038

Added new parameter `-c, --conf` to provide inline configuration

```
  -c CONF_HOST, --conf CONF_HOST
                        Configuration to build the package, overwriting the defaults (host machine). e.g.: -c
                        tools.cmake.cmaketoolchain:generator=Xcode
  -c:b CONF_BUILD, --conf:build CONF_BUILD
                        Configuration to build the package, overwriting the defaults (build machine). e.g.: -c:b
                        tools.cmake.cmaketoolchain:generator=Xcode
  -c:h CONF_HOST, --conf:host CONF_HOST
                        Configuration to build the package, overwriting the defaults (host machine). e.g.: -c:h
                        tools.cmake.cmaketoolchain:generator=Xcode
```

You can use these options for the following commands: `export_pkg`, `test`, `create`, `install`, `info`, `workspace install` and `lock create`

- [x] Refer to the issue that supports this Pull Request.
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [x] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 

<sup>**Note:** By default this PR will skip the slower tests and will use a limited set of python versions. Check [here](https://github.com/conan-io/conan/blob/develop/.github/PR_INCREASE_TESTING.md) how to increase the testing level by writing some tags in the current PR body text.</sup>
