### PR TITLE
Bugfix: conan profile {show, update, get, remove} did not work with new experimental [conf] section #9079

### DIFF
--- a/conans/client/cmd/profile.py
+++ b/conans/client/cmd/profile.py
@@ -68,7 +68,7 @@ def cmd_profile_update(profile_name, key, value, cache_profiles_path):
     elif first_key == "env":
         profile.env_values.update_replace(rest_key, value)
     elif first_key == "conf":
-        profile.conf.update_conf("{}={}".format(rest_key, value))
+        profile.conf.update_conf_line("{}={}".format(rest_key, value))
     elif first_key == "build_requires":
         raise ConanException("Edit the profile manually to change the build_requires")
 

--- a/conans/client/cmd/profile.py
+++ b/conans/client/cmd/profile.py
@@ -68,7 +68,7 @@ def cmd_profile_update(profile_name, key, value, cache_profiles_path):
     elif first_key == "env":
         profile.env_values.update_replace(rest_key, value)
     elif first_key == "conf":
-        profile.conf.update_conf_line("{}={}".format(rest_key, value))
+        profile.conf.update(rest_key, value)
     elif first_key == "build_requires":
         raise ConanException("Edit the profile manually to change the build_requires")
 

--- a/conans/client/cmd/profile.py
+++ b/conans/client/cmd/profile.py
@@ -68,7 +68,7 @@ def cmd_profile_update(profile_name, key, value, cache_profiles_path):
     elif first_key == "env":
         profile.env_values.update_replace(rest_key, value)
     elif first_key == "conf":
-        profile.conf.loads("{}={}".format(rest_key, value), reset=False)
+        profile.conf.update_conf("{}={}".format(rest_key, value))
     elif first_key == "build_requires":
         raise ConanException("Edit the profile manually to change the build_requires")
 

--- a/conans/client/cmd/profile.py
+++ b/conans/client/cmd/profile.py
@@ -13,7 +13,7 @@ def _get_profile_keys(key):
     tmp = key.split(".")
     first_key = tmp[0]
     rest_key = ".".join(tmp[1:]) if len(tmp) > 1 else None
-    if first_key not in ("build_requires", "settings", "options", "env"):
+    if first_key not in ("build_requires", "settings", "options", "env", "conf"):
         raise ConanException("Invalid specified key: %s" % key)
 
     return first_key, rest_key
@@ -67,6 +67,8 @@ def cmd_profile_update(profile_name, key, value, cache_profiles_path):
         profile.options.update(tmp)
     elif first_key == "env":
         profile.env_values.update_replace(rest_key, value)
+    elif first_key == "conf":
+        profile.conf.loads("{}={}".format(rest_key, value), reset=False)
     elif first_key == "build_requires":
         raise ConanException("Edit the profile manually to change the build_requires")
 
@@ -89,6 +91,8 @@ def cmd_profile_get(profile_name, key, cache_profiles_path):
             if ":" in rest_key:
                 package, var = rest_key.split(":")
             return profile.env_values.data[package][var]
+        elif first_key == "conf":
+            return profile.conf[rest_key]
         elif first_key == "build_requires":
             raise ConanException("List the profile manually to see the build_requires")
     except KeyError:
@@ -112,6 +116,8 @@ def cmd_profile_delete_key(profile_name, key, cache_profiles_path):
             profile.options.remove(name, package)
         elif first_key == "env":
             profile.env_values.remove(name, package)
+        elif first_key == "conf":
+            del profile.conf[rest_key]
         elif first_key == "build_requires":
             raise ConanException("Edit the profile manually to delete a build_require")
     except KeyError:

--- a/conans/client/printer.py
+++ b/conans/client/printer.py
@@ -215,6 +215,7 @@ class Printer(object):
         self._out.info("Configuration for profile %s:\n" % name)
         self._print_profile_section("settings", profile.settings.items(), separator="=")
         self._print_profile_section("options", profile.options.as_list(), separator="=")
+        self._print_profile_section("conf", profile.conf.as_list(), separator="=")
         self._print_profile_section("build_requires", [(key, ", ".join(str(val) for val in values))
                                                        for key, values in
                                                        profile.build_requires.items()])

--- a/conans/model/conf.py
+++ b/conans/model/conf.py
@@ -47,7 +47,7 @@ class Conf(object):
         self._values[name] = value
 
     def __delitem__(self, name):
-        return self._values.pop(name, None)
+        del self._values[name]
 
     def __repr__(self):
         return "Conf: " + repr(self._values)

--- a/conans/model/conf.py
+++ b/conans/model/conf.py
@@ -160,9 +160,9 @@ class ConfDefinition(object):
     def loads(self, text, profile=False):
         self._pattern_confs = {}
         for line in text.splitlines():
-            self.update_conf(line, profile=profile)
+            self.update_conf_line(line, profile=profile)
 
-    def update_conf(self, line, profile=False):
+    def update_conf_line(self, line, profile=False):
         """
         Validate the given [conf] line, extract the needed information and
         add/update the internal Conf() dictionary

--- a/conans/test/functional/command/profile_test.py
+++ b/conans/test/functional/command/profile_test.py
@@ -23,9 +23,11 @@ class ProfileTest(unittest.TestCase):
         client.run("profile new myprofile --detect")
         client.run("profile update options.Pkg:myoption=123 myprofile")
         client.run("profile update env.Pkg2:myenv=123 myprofile")
+        client.run("profile update conf.tools.ninja:jobs=10 myprofile")
         client.run("profile show myprofile")
         self.assertIn("Pkg:myoption=123", client.out)
         self.assertIn("Pkg2:myenv=123", client.out)
+        self.assertIn("tools.ninja:jobs=10", client.out)
         profile = str(client.out).splitlines()[2:]
         client.save({"conanfile.txt": "",
                      "mylocalprofile": "\n".join(profile)})
@@ -75,7 +77,8 @@ class ProfileTest(unittest.TestCase):
                        options=[("MyOption", "32")])
         create_profile(client.cache.profiles_path, "profile3",
                        env=[("package:VAR", "value"), ("CXX", "/path/tomy/g++_build"),
-                            ("CC", "/path/tomy/gcc_build")])
+                            ("CC", "/path/tomy/gcc_build")],
+                       conf=["tools.ninja:jobs=10", "tools.gnu.make:jobs=20"])
         client.run("profile show profile1")
         self.assertIn("[settings]\nos=Windows", client.out)
         self.assertIn("MyOption=32", client.out)
@@ -83,6 +86,8 @@ class ProfileTest(unittest.TestCase):
         self.assertIn("CC=/path/tomy/gcc_build", client.out)
         self.assertIn("CXX=/path/tomy/g++_build", client.out)
         self.assertIn("package:VAR=value", client.out)
+        self.assertIn("tools.ninja:jobs=10", client.out)
+        self.assertIn("tools.gnu.make:jobs=20", client.out)
 
     def test_profile_update_and_get(self):
         client = TestClient()
@@ -131,6 +136,18 @@ class ProfileTest(unittest.TestCase):
         client.run("profile get env.OneMyEnv ./MyProfile")
         self.assertEqual(client.out, "MYVALUe\n")
 
+        client.run("profile update conf.tools.ninja:jobs=10 ./MyProfile")
+        self.assertIn("Package:OtherOption=23", load(pr_path))
+
+        client.run("profile get conf.tools.ninja:jobs ./MyProfile")
+        self.assertEqual(client.out, "10\n")
+
+        client.run("profile update conf.tools.gnu.make:jobs=20 ./MyProfile")
+        self.assertIn("[env]\nOneMyEnv=MYVALUe", load(pr_path))
+
+        client.run("profile get conf.tools.gnu.make:jobs ./MyProfile")
+        self.assertEqual(client.out, "20\n")
+
         # Now try the remove
 
         client.run("profile remove settings.os ./MyProfile")
@@ -147,6 +164,10 @@ class ProfileTest(unittest.TestCase):
         self.assertNotIn("Package:MyOption", load(pr_path))
         self.assertIn("Package:OtherOption", load(pr_path))
 
+        client.run("profile remove conf.tools.gnu.make:jobs ./MyProfile")
+        self.assertNotIn("tools.gnu.make:jobs", load(pr_path))
+        self.assertIn("tools.ninja:jobs", load(pr_path))
+
         client.run("profile remove env.OneMyEnv ./MyProfile")
         self.assertNotIn("OneMyEnv", load(pr_path))
 
@@ -159,6 +180,9 @@ class ProfileTest(unittest.TestCase):
 
         client.run("profile remove env.foo ./MyProfile", assert_error=True)
         self.assertIn("Profile key 'env.foo' doesn't exist", client.out)
+
+        client.run("profile remove conf.MyConf ./MyProfile", assert_error=True)
+        self.assertIn("Profile key 'conf.MyConf' doesn't exist", client.out)
 
     def test_profile_update_env(self):
         client = TestClient()

--- a/conans/test/functional/command/profile_test.py
+++ b/conans/test/functional/command/profile_test.py
@@ -137,7 +137,7 @@ class ProfileTest(unittest.TestCase):
         self.assertEqual(client.out, "MYVALUe\n")
 
         client.run("profile update conf.tools.ninja:jobs=10 ./MyProfile")
-        self.assertIn("Package:OtherOption=23", load(pr_path))
+        self.assertIn("tools.ninja:jobs=10", load(pr_path))
 
         client.run("profile get conf.tools.ninja:jobs ./MyProfile")
         self.assertEqual(client.out, "10\n")

--- a/conans/test/functional/command/profile_test.py
+++ b/conans/test/functional/command/profile_test.py
@@ -137,13 +137,13 @@ class ProfileTest(unittest.TestCase):
         self.assertEqual(client.out, "MYVALUe\n")
 
         client.run("profile update conf.tools.ninja:jobs=10 ./MyProfile")
-        self.assertIn("tools.ninja:jobs=10", load(pr_path))
+        self.assertIn("[conf]\ntools.ninja:jobs=10", load(pr_path))
 
         client.run("profile get conf.tools.ninja:jobs ./MyProfile")
         self.assertEqual(client.out, "10\n")
 
         client.run("profile update conf.tools.gnu.make:jobs=20 ./MyProfile")
-        self.assertIn("[env]\nOneMyEnv=MYVALUe", load(pr_path))
+        self.assertIn("tools.gnu.make:jobs=20", load(pr_path))
 
         client.run("profile get conf.tools.gnu.make:jobs ./MyProfile")
         self.assertEqual(client.out, "20\n")

--- a/conans/test/integration/configuration/conf/test_conf_profile.py
+++ b/conans/test/integration/configuration/conf/test_conf_profile.py
@@ -104,7 +104,7 @@ def test_config_profile_forbidden(client):
     client.save({"myprofile": profile})
     client.run("install . pkg/0.1@ -pr=myprofile", assert_error=True)
     assert ("ERROR: Error reading 'myprofile' profile: [conf] "
-            "'cache:verbosity=Minimal' not allowed in profiles" in client.out)
+            "'cache:verbosity' not allowed in profiles" in client.out)
 
 
 def test_msbuild_config():

--- a/conans/test/unittests/model/test_conf.py
+++ b/conans/test/unittests/model/test_conf.py
@@ -64,7 +64,7 @@ def test_conf_error_per_package():
     text = "*:core:verbosity=minimal"
     c = ConfDefinition()
     with pytest.raises(ConanException,
-                       match=r"Conf '\*:core:verbosity=minimal' cannot have a package pattern"):
+                       match=r"Conf '\*:core:verbosity' cannot have a package pattern"):
         c.loads(text)
 
 

--- a/conans/test/utils/profiles.py
+++ b/conans/test/utils/profiles.py
@@ -6,7 +6,7 @@ from conans.util.files import save
 
 
 def create_profile(folder, name, settings=None, package_settings=None, env=None,
-                   package_env=None, options=None):
+                   package_env=None, options=None, conf=None):
 
     package_env = package_env or {}
 
@@ -18,6 +18,10 @@ def create_profile(folder, name, settings=None, package_settings=None, env=None,
 
     if options:
         profile.options = OptionsValues(options)
+
+    if conf:
+        _conf = "\n".join(conf) if isinstance(conf, list) else conf
+        profile.conf.loads(_conf)
 
     for package_name, envs in package_env.items():
         for var_name, value in envs:


### PR DESCRIPTION
Changelog: Bugfix: Now, `conan profile {show, update, get, remove}` is working fine with new experimental `[conf]` section.
Docs: omit

Closes: https://github.com/conan-io/conan/issues/9079

- [x] Refer to the issue that supports this Pull Request.
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 

<sup>**Note:** By default this PR will skip the slower tests and will use a limited set of python versions. Check [here](https://github.com/conan-io/conan/blob/develop/.github/PR_INCREASE_TESTING.md) how to increase the testing level by writing some tags in the current PR body text.</sup>
