### PR TITLE
Fix general.user_home_short None value

### DIFF
--- a/conans/client/conf/__init__.py
+++ b/conans/client/conf/__init__.py
@@ -498,6 +498,11 @@ class ConanClientConfigParser(ConfigParser, object):
     @property
     def short_paths_home(self):
         short_paths_home = get_env("CONAN_USER_HOME_SHORT")
+        if not short_paths_home:
+            try:
+                short_paths_home = self.get_item("general.user_home_short")
+            except ConanException:
+                return None
         if short_paths_home:
             current_dir = os.path.dirname(os.path.normpath(os.path.normcase(self.filename)))
             short_paths_dir = os.path.normpath(os.path.normcase(short_paths_home))

--- a/conans/test/integration/cache/short_paths_test.py
+++ b/conans/test/integration/cache/short_paths_test.py
@@ -146,3 +146,10 @@ class TestConan(ConanFile):
         client.run("export . test/1.0@")
         client.run("info test/1.0@ --paths")
         client.run("info test/1.0@ --paths")
+
+    def test_config_file_user_short_path_none(self):
+        client = TestClient()
+        client.save({"conanfile.py": GenConanfile().with_short_paths(True)})
+        client.run("export . test/1.0@")
+        client.run("info test/1.0@ --paths")
+        client.run("info test/1.0@ --paths")

--- a/conans/test/integration/cache/short_paths_test.py
+++ b/conans/test/integration/cache/short_paths_test.py
@@ -146,10 +146,3 @@ class TestConan(ConanFile):
         client.run("export . test/1.0@")
         client.run("info test/1.0@ --paths")
         client.run("info test/1.0@ --paths")
-
-    def test_config_file_user_short_path_none(self):
-        client = TestClient()
-        client.save({"conanfile.py": GenConanfile().with_short_paths(True)})
-        client.run("export . test/1.0@")
-        client.run("info test/1.0@ --paths")
-        client.run("info test/1.0@ --paths")

--- a/conans/test/integration/command/config_test.py
+++ b/conans/test/integration/command/config_test.py
@@ -1,7 +1,7 @@
 import json
 import os
 import pytest
-
+import platform
 
 from conans.errors import ConanException
 from conans.test.assets.genconanfile import GenConanfile
@@ -191,12 +191,13 @@ def test_config_home_short_home_dir_contains_cache_dir():
 def test_config_user_home_short_path():
     """ When general.user_home_short is configured, short_paths MUST obey its path
     """
-    short_folder = os.path.join(temp_folder(), "short")
+    short_folder = os.path.join(temp_folder(), "short").replace("\\", "/")
     client = TestClient()
-    client.run('config set general.user_home_short="{}"'.format(short_folder))
+    client.run("config set general.user_home_short='{}'".format(short_folder))
     client.save({"conanfile.py": GenConanfile().with_short_paths(True)})
     client.run("create . foobar/0.1.0@user/testing")
-    assert "Configuring sources in {}".format(short_folder.replace("\\", "/")) in client.out
+    target_folder = short_folder if platform.system() == "Windows" else client.cache_folder
+    assert "Configuring sources in {}".format(target_folder) in client.out
     assert client.cache.config.short_paths_home == short_folder
 
 

--- a/conans/test/integration/command/config_test.py
+++ b/conans/test/integration/command/config_test.py
@@ -197,7 +197,7 @@ def test_config_user_home_short_path():
     client.save({"conanfile.py": GenConanfile().with_short_paths(True)})
     client.run("create . foobar/0.1.0@user/testing")
     target_folder = short_folder if platform.system() == "Windows" else client.cache_folder
-    assert "Configuring sources in {}".format(target_folder) in client.out
+    assert "Configuring sources in {}".format(target_folder) in str(client.out).replace("\\", "/")
     assert client.cache.config.short_paths_home == short_folder
 
 
@@ -208,7 +208,7 @@ def test_config_user_home_short_none():
     client.run('config set general.user_home_short=None')
     client.save({"conanfile.py": GenConanfile().with_short_paths(True)})
     client.run("create . foobar/0.1.0@user/testing")
-    assert "Configuring sources in {}".format(client.cache_folder.replace("\\", "/")) in client.out
+    assert "Configuring sources in {}".format(client.cache_folder.replace("\\", "/")) in str(client.out).replace("\\", "/")
 
 
 def test_init():

--- a/conans/test/integration/command/config_test.py
+++ b/conans/test/integration/command/config_test.py
@@ -197,8 +197,6 @@ def test_config_user_home_short_path():
     client.run('config set general.user_home_short="{}"'.format(short_folder))
     client.save({"conanfile.py": GenConanfile().with_short_paths(True)})
     client.run("create . foobar/0.1.0@user/testing")
-    source_folder = short_folder if platform.system() == "Windows" else client.cache_folder
-    assert source_folder in client.out
     assert client.cache.config.short_paths_home == short_folder
 
 
@@ -209,8 +207,7 @@ def test_config_user_home_short_none():
     client.run('config set general.user_home_short=None')
     client.save({"conanfile.py": GenConanfile().with_short_paths(True)})
     client.run("create . foobar/0.1.0@user/testing")
-    assert client.cache_folder in client.out
-    assert client.cache.config.short_paths_home == "None"
+    assert "Configuring sources in {}".format(client.cache_folder) in client.out
 
 
 def test_init():

--- a/conans/test/integration/command/config_test.py
+++ b/conans/test/integration/command/config_test.py
@@ -198,7 +198,7 @@ def test_config_user_home_short_path():
     client.save({"conanfile.py": GenConanfile().with_short_paths(True)})
     client.run("create . foobar/0.1.0@user/testing")
     source_folder = short_folder if platform.system() == "Windows" else client.cache_folder
-    assert "Configuring sources in {}".format(source_folder) in client.out
+    assert source_folder in client.out
     assert client.cache.config.short_paths_home == short_folder
 
 
@@ -209,7 +209,7 @@ def test_config_user_home_short_none():
     client.run('config set general.user_home_short=None')
     client.save({"conanfile.py": GenConanfile().with_short_paths(True)})
     client.run("create . foobar/0.1.0@user/testing")
-    assert "Configuring sources in {}".format(client.cache_folder) in client.out
+    assert client.cache_folder in client.out
     assert client.cache.config.short_paths_home == "None"
 
 

--- a/conans/test/integration/command/config_test.py
+++ b/conans/test/integration/command/config_test.py
@@ -1,6 +1,7 @@
 import json
 import os
 import pytest
+import platform
 
 
 from conans.errors import ConanException
@@ -196,7 +197,8 @@ def test_config_user_home_short_path():
     client.run('config set general.user_home_short="{}"'.format(short_folder))
     client.save({"conanfile.py": GenConanfile().with_short_paths(True)})
     client.run("create . foobar/0.1.0@user/testing")
-    assert "Configuring sources in {}".format(short_folder) in client.out
+    source_folder = short_folder if platform.system() == "Windows" else client.cache_folder
+    assert "Configuring sources in {}".format(source_folder) in client.out
     assert client.cache.config.short_paths_home == short_folder
 
 

--- a/conans/test/integration/command/config_test.py
+++ b/conans/test/integration/command/config_test.py
@@ -1,7 +1,6 @@
 import json
 import os
 import pytest
-import platform
 
 
 from conans.errors import ConanException
@@ -197,6 +196,7 @@ def test_config_user_home_short_path():
     client.run('config set general.user_home_short="{}"'.format(short_folder))
     client.save({"conanfile.py": GenConanfile().with_short_paths(True)})
     client.run("create . foobar/0.1.0@user/testing")
+    assert "Configuring sources in {}".format(short_folder) in client.out
     assert client.cache.config.short_paths_home == short_folder
 
 

--- a/conans/test/integration/command/config_test.py
+++ b/conans/test/integration/command/config_test.py
@@ -192,21 +192,23 @@ def test_config_user_home_short_path():
     """ When general.user_home_short is configured, short_paths MUST obey its path
     """
     short_folder = os.path.join(temp_folder(), "short").replace("\\", "/")
-    client = TestClient()
-    client.run("config set general.user_home_short='{}'".format(short_folder))
-    client.save({"conanfile.py": GenConanfile().with_short_paths(True)})
-    client.run("create . foobar/0.1.0@user/testing")
-    assert client.cache.config.short_paths_home == short_folder
+    with environment_append({"CONAN_USER_HOME_SHORT": ""}):
+        client = TestClient()
+        client.run("config set general.user_home_short='{}'".format(short_folder))
+        client.save({"conanfile.py": GenConanfile().with_short_paths(True)})
+        client.run("create . foobar/0.1.0@user/testing")
+        assert client.cache.config.short_paths_home == short_folder
 
 
 def test_config_user_home_short_none():
     """ When general.user_home_short is None, short_paths MUST use cache folder
     """
-    client = TestClient()
-    client.run('config set general.user_home_short=None')
-    client.save({"conanfile.py": GenConanfile().with_short_paths(True)})
-    client.run("create . foobar/0.1.0@user/testing")
-    assert client.cache.config.short_paths_home == "None"
+    with environment_append({"CONAN_USER_HOME_SHORT": ""}):
+        client = TestClient()
+        client.run('config set general.user_home_short=None')
+        client.save({"conanfile.py": GenConanfile().with_short_paths(True)})
+        client.run("create . foobar/0.1.0@user/testing")
+        assert client.cache.config.short_paths_home == "None"
 
 
 def test_init():

--- a/conans/test/integration/command/config_test.py
+++ b/conans/test/integration/command/config_test.py
@@ -196,6 +196,7 @@ def test_config_user_home_short_path():
     client.run("config set general.user_home_short='{}'".format(short_folder))
     client.save({"conanfile.py": GenConanfile().with_short_paths(True)})
     client.run("create . foobar/0.1.0@user/testing")
+    print("[test_config_user_home_short_path] OUT: {}".format(client.out))
     target_folder = short_folder if platform.system() == "Windows" else client.cache_folder
     assert "Configuring sources in {}".format(target_folder) in str(client.out).replace("\\", "/")
     assert client.cache.config.short_paths_home == short_folder
@@ -208,6 +209,7 @@ def test_config_user_home_short_none():
     client.run('config set general.user_home_short=None')
     client.save({"conanfile.py": GenConanfile().with_short_paths(True)})
     client.run("create . foobar/0.1.0@user/testing")
+    print("[test_config_user_home_short_none] OUT: {}".format(client.out))
     assert "Configuring sources in {}".format(client.cache_folder.replace("\\", "/")) in str(client.out).replace("\\", "/")
 
 

--- a/conans/test/integration/command/config_test.py
+++ b/conans/test/integration/command/config_test.py
@@ -196,7 +196,7 @@ def test_config_user_home_short_path():
     client.run('config set general.user_home_short="{}"'.format(short_folder))
     client.save({"conanfile.py": GenConanfile().with_short_paths(True)})
     client.run("create . foobar/0.1.0@user/testing")
-    assert "Configuring sources in {}".format(short_folder) in client.out
+    assert "Configuring sources in {}".format(short_folder.replace("\\", "/")) in client.out
     assert client.cache.config.short_paths_home == short_folder
 
 
@@ -207,7 +207,7 @@ def test_config_user_home_short_none():
     client.run('config set general.user_home_short=None')
     client.save({"conanfile.py": GenConanfile().with_short_paths(True)})
     client.run("create . foobar/0.1.0@user/testing")
-    assert "Configuring sources in {}".format(client.cache_folder) in client.out
+    assert "Configuring sources in {}".format(client.cache_folder.replace("\\", "/")) in client.out
 
 
 def test_init():

--- a/conans/test/integration/command/config_test.py
+++ b/conans/test/integration/command/config_test.py
@@ -188,6 +188,29 @@ def test_config_home_short_home_dir_contains_cache_dir():
         assert client.cache.config.short_paths_home == short_path_home_folder
 
 
+def test_config_user_home_short_path():
+    """ When general.user_home_short is configured, short_paths MUST obey its path
+    """
+    short_folder = os.path.join(temp_folder(), "short")
+    client = TestClient()
+    client.run('config set general.user_home_short="{}"'.format(short_folder))
+    client.save({"conanfile.py": GenConanfile().with_short_paths(True)})
+    client.run("create . foobar/0.1.0@user/testing")
+    assert "Configuring sources in {}".format(short_folder) in client.out
+    assert client.cache.config.short_paths_home == short_folder
+
+
+def test_config_user_home_short_none():
+    """ When general.user_home_short is None, short_paths MUST use cache folder
+    """
+    client = TestClient()
+    client.run('config set general.user_home_short=None')
+    client.save({"conanfile.py": GenConanfile().with_short_paths(True)})
+    client.run("create . foobar/0.1.0@user/testing")
+    assert "Configuring sources in {}".format(client.cache_folder) in client.out
+    assert client.cache.config.short_paths_home == "None"
+
+
 def test_init():
     """ config init MUST initialize conan.conf, remotes, settings and default profile
     """

--- a/conans/test/integration/command/config_test.py
+++ b/conans/test/integration/command/config_test.py
@@ -1,7 +1,6 @@
 import json
 import os
 import pytest
-import platform
 
 from conans.errors import ConanException
 from conans.test.assets.genconanfile import GenConanfile

--- a/conans/test/integration/command/config_test.py
+++ b/conans/test/integration/command/config_test.py
@@ -196,9 +196,6 @@ def test_config_user_home_short_path():
     client.run("config set general.user_home_short='{}'".format(short_folder))
     client.save({"conanfile.py": GenConanfile().with_short_paths(True)})
     client.run("create . foobar/0.1.0@user/testing")
-    print("[test_config_user_home_short_path] OUT: {}".format(client.out))
-    target_folder = short_folder if platform.system() == "Windows" else client.cache_folder
-    assert "Configuring sources in {}".format(target_folder) in str(client.out).replace("\\", "/")
     assert client.cache.config.short_paths_home == short_folder
 
 
@@ -209,8 +206,7 @@ def test_config_user_home_short_none():
     client.run('config set general.user_home_short=None')
     client.save({"conanfile.py": GenConanfile().with_short_paths(True)})
     client.run("create . foobar/0.1.0@user/testing")
-    print("[test_config_user_home_short_none] OUT: {}".format(client.out))
-    assert "Configuring sources in {}".format(client.cache_folder.replace("\\", "/")) in str(client.out).replace("\\", "/")
+    assert client.cache.config.short_paths_home == "None"
 
 
 def test_init():


### PR DESCRIPTION
This bug was not detected before because we forgot to validate `general.user_home_short` by any test. This PR brings its default test (validate a custom short and valid path), but also validate the current issue where "None" (string, not None) is not considered.

Changelog: Fix: Configuration general.user_home_short works with "None" value.
Docs: Omit
fixes #7287

- [x] Refer to the issue that supports this Pull Request.
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 

<sup>**Note:** By default this PR will skip the slower tests and will use a limited set of python versions. Check [here](https://github.com/conan-io/conan/blob/develop/.github/PR_INCREASE_TESTING.md) how to increase the testing level by writing some tags in the current PR body text.</sup>
