### PR TITLE
Change sources management

### DIFF
--- a/conans/client/source.py
+++ b/conans/client/source.py
@@ -125,7 +125,7 @@ def _run_source(conanfile, conanfile_path, hook_manager, reference, cache,
     """
 
 
-    src_folder = conanfile.source_folder
+    src_folder = conanfile.folders.base_source
     mkdir(src_folder)
 
     with tools.chdir(src_folder):

--- a/conans/test/functional/layout/test_in_cache.py
+++ b/conans/test/functional/layout/test_in_cache.py
@@ -24,7 +24,8 @@ def conanfile():
 
     def source(self):
         self.output.warn("Source folder: {}".format(self.source_folder))
-        tools.save("source.h", "foo")
+        # The layout describes where the sources are, not force them to be there
+        tools.save("my_sources/source.h", "foo")
 
     def build(self):
         self.output.warn("Build folder: {}".format(self.build_folder))

--- a/conans/test/functional/layout/test_layout_autopackage.py
+++ b/conans/test/functional/layout/test_layout_autopackage.py
@@ -14,19 +14,19 @@ def test_auto_package_no_components():
     conan_file += """
 
     def source(self):
-        tools.save("source_sources/source_stuff.cpp", "")
-        tools.save("source_includes/include1.hpp", "")
-        tools.save("source_includes/include2.hpp", "")
-        tools.save("source_includes2/include3.h", "")
-        tools.save("source_libs/slibone.a", "")
-        tools.save("source_libs/slibtwo.a", "")
-        tools.save("source_libs/bin_to_discard.exe", "")
-        tools.save("source_bins/source_bin.exe", "")
-        tools.save("source_frameworks/sframe1/include/include.h", "")
-        tools.save("source_frameworks/sframe2/include/include.h", "")
-        tools.save("source_frameworks/sframe1/lib/libframework.lib", "")
-        tools.save("source_frameworks/sframe2/lib/libframework.lib", "")
-        tools.save("source_frameworks/sframe2/foo/bar.txt", "")
+        tools.save("my_source/source_sources/source_stuff.cpp", "")
+        tools.save("my_source/source_includes/include1.hpp", "")
+        tools.save("my_source/source_includes/include2.hpp", "")
+        tools.save("my_source/source_includes2/include3.h", "")
+        tools.save("my_source/source_libs/slibone.a", "")
+        tools.save("my_source/source_libs/slibtwo.a", "")
+        tools.save("my_source/source_libs/bin_to_discard.exe", "")
+        tools.save("my_source/source_bins/source_bin.exe", "")
+        tools.save("my_source/source_frameworks/sframe1/include/include.h", "")
+        tools.save("my_source/source_frameworks/sframe2/include/include.h", "")
+        tools.save("my_source/source_frameworks/sframe1/lib/libframework.lib", "")
+        tools.save("my_source/source_frameworks/sframe2/lib/libframework.lib", "")
+        tools.save("my_source/source_frameworks/sframe2/foo/bar.txt", "")
 
     def build(self):
         tools.save("build_sources/build_stuff.cpp", "")

--- a/conans/test/functional/layout/test_local_commands.py
+++ b/conans/test/functional/layout/test_local_commands.py
@@ -162,7 +162,7 @@ def test_local_build_change_base():
 
 def test_local_source():
     """If we configure a source folder in the layout, the downloaded files in a "conan source ."
-    go to the specified folder: "my_source"
+    DON'T go to the specified folder: "my_source" but to the root source folder
     """
     client = TestClient()
     conan_file = str(GenConanfile().with_import("from conans import tools"))
@@ -171,7 +171,7 @@ def test_local_source():
         self.folders.source = "my_source"
 
     def source(self):
-        tools.save("downloaded.h", "bar")
+        tools.save("my_source/downloaded.h", "bar")
     """
     client.save({"conanfile.py": conan_file})
     client.run("install . -if=my_install")
@@ -182,8 +182,8 @@ def test_local_source():
 
 
 def test_local_source_change_base():
-    """If we configure a source folder in the layout, the souce files in a "conan source ."
-    go to the specified folder: "my_source under the modified base one "all_source"
+    """If we configure a source folder in the layout, the source files in a "conan source ."
+    DON'T go to the specified folder: "my_source under the modified base one "all_source"
     """
     client = TestClient()
     conan_file = str(GenConanfile().with_import("from conans import tools"))
@@ -192,7 +192,7 @@ def test_local_source_change_base():
         self.folders.source = "my_source"
 
     def source(self):
-        tools.save("downloaded.h", "bar")
+        tools.save("my_source/downloaded.h", "bar")
     """
     client.save({"conanfile.py": conan_file})
     client.run("install . -if=common")

--- a/conans/test/functional/layout/test_source_folder.py
+++ b/conans/test/functional/layout/test_source_folder.py
@@ -1,13 +1,15 @@
 import os
 import platform
+from shutil import copy
 
+import mock
 import pytest
 
 from conans.test.assets.cmake import gen_cmakelists
 from conans.test.assets.genconanfile import GenConanfile
 from conans.test.assets.sources import gen_function_cpp
 from conans.test.utils.scm import create_local_git_repo
-from conans.test.utils.tools import TestClient
+from conans.test.utils.tools import TestClient, zipdir
 
 app_name = "Release/my_app.exe" if platform.system() == "Windows" else "my_app"
 
@@ -133,3 +135,54 @@ def test_scm_with_source_layout():
     assert os.path.exists(os.path.join(client.current_folder, "build_Release", app_name))
     client.run("create . ")
     assert "Created package revision" in client.out
+
+
+@pytest.mark.parametrize("no_copy_source", ["False", "True"])
+def test_zip_download_with_subfolder(no_copy_source):
+    """If we have a zip with the sources in a subfolder, specifying it in the self.folders.source
+    will unzip in the base and will work both locally (conan build) or in the cache
+    (exporting the sources)"""
+
+    tmp = TestClient()  # Used only to save some files, sorry for the lazyness
+    cmake = gen_cmakelists(appname="my_app", appsources=["main.cpp"])
+    app = gen_function_cpp(name="main")
+    tmp.save({"subfolder/main.cpp": app,
+              "subfolder/CMakeLists.txt": cmake,
+              "ignored_subfolder/ignored.txt": ""})
+    zippath = os.path.join(tmp.current_folder, "my_sources.zip")
+    zipdir(tmp.current_folder, zippath)
+
+    conan_file = GenConanfile() \
+        .with_import("import os") \
+        .with_import("from conans import tools") \
+        .with_import("from conan.tools.cmake import CMake") \
+        .with_name("app").with_version("1.0") \
+        .with_settings("os", "arch", "build_type", "compiler") \
+        .with_generator("CMakeToolchain") \
+        .with_class_attribute("no_copy_source={}".format(no_copy_source))
+
+    conan_file = str(conan_file)
+    conan_file += """
+    def source(self):
+        tools.get("http://fake_url/my_sources.zip")
+
+    def layout(self):
+        self.folders.source = "subfolder"
+
+    def build(self):
+        assert os.path.exists(os.path.join(self.source_folder, "CMakeLists.txt"))
+        assert "subfolder" in self.source_folder
+        assert os.path.exists(os.path.join(self.source_folder, "..",
+                                           "ignored_subfolder", "ignored.txt"))
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+    """
+    client = TestClient()
+    client.save({"conanfile.py": conan_file})
+
+    with mock.patch("conans.client.tools.net.download") as mock_download:
+        def download_zip(*args, **kwargs):
+            copy(zippath, os.getcwd())
+        mock_download.side_effect = download_zip
+        client.run("create . ")


### PR DESCRIPTION
Changelog: Fix: Fixed behavior in the `self.folders` feature whereby the sources saved or downloaded inside the `source(self)` were saved at the `self.folders.source` folder. But `self.folders.source` is intended to describe where the sources are instead of forcing where the sources are saved.
Docs: https://github.com/conan-io/docs/pull/2127