### PR TITLE
adding context information to conan-info command

### DIFF
--- a/conans/client/conan_command_output.py
+++ b/conans/client/conan_command_output.py
@@ -137,6 +137,7 @@ class CommandOutputer(object):
             item_data["display_name"] = conanfile.display_name
             item_data["id"] = package_id
             item_data["build_id"] = build_id(conanfile)
+            item_data["context"] = conanfile.context
 
             # Paths
             if isinstance(ref, ConanFileReference) and grab_paths:

--- a/conans/client/printer.py
+++ b/conans/client/printer.py
@@ -74,6 +74,7 @@ class Printer(object):
             self._out.writeln(it["display_name"], Color.BRIGHT_CYAN)
             _print("id", name="ID")
             _print("build_id", name="BuildID")
+            _print("context", name="Context")
             if show_paths:
                 _print("export_folder")
                 _print("source_folder")

--- a/conans/test/integration/command/info/info_test.py
+++ b/conans/test/integration/command/info/info_test.py
@@ -4,10 +4,8 @@ import textwrap
 import unittest
 from datetime import datetime
 
-
 from conans import __version__ as client_version
-
-from conans.test.utils.tools import TestClient, GenConanfile
+from conans.test.utils.tools import TestClient, GenConanfile, NO_SETTINGS_PACKAGE_ID
 from conans.util.files import save, load
 
 
@@ -204,6 +202,7 @@ class InfoTest(unittest.TestCase):
             return "\n".join([line for line in str(output).splitlines()
                               if not line.strip().startswith("Creation date") and
                               not line.strip().startswith("ID") and
+                              not line.strip().startswith("Context") and
                               not line.strip().startswith("BuildID") and
                               not line.strip().startswith("export_folder") and
                               not line.strip().startswith("build_folder") and
@@ -657,3 +656,44 @@ def test_scm_info():
     info_json = json.loads(file_json)
     node = info_json[0]
     assert node["scm"] == {"type": "git", "url": "some-url/path", "revision": "some commit hash"}
+
+
+class TestInfoContext:
+    # https://github.com/conan-io/conan/issues/9121
+
+    def test_context_info(self):
+        client = TestClient()
+        client.save({"conanfile.py": GenConanfile()})
+
+        client.run("info .")
+        assert "Context: host" in client.out
+
+        client.run("info . --json=file.json")
+        info = json.loads(client.load("file.json"))
+        assert info[0]["context"] == "host"
+
+    def test_context_build(self):
+        client = TestClient()
+        client.save({"cmake/conanfile.py": GenConanfile(),
+                     "pkg/conanfile.py": GenConanfile().with_build_requires("cmake/1.0")})
+
+        client.run("create cmake cmake/1.0@")
+        client.run("export pkg pkg/1.0@")
+
+        client.run("info pkg/1.0@ -pr:b=default -pr:h=default --dry-build")
+        assert "cmake/1.0\n"\
+               "    ID: {}\n"\
+               "    BuildID: None\n"\
+               "    Context: build".format(NO_SETTINGS_PACKAGE_ID) in client.out
+
+        assert "pkg/1.0\n" \
+               "    ID: {}\n" \
+               "    BuildID: None\n" \
+               "    Context: host".format(NO_SETTINGS_PACKAGE_ID) in client.out
+
+        client.run("info pkg/1.0@ -pr:b=default -pr:h=default --dry-build --json=file.json")
+        info = json.loads(client.load("file.json"))
+        assert info[0]["reference"] == "cmake/1.0"
+        assert info[0]["context"] == "build"
+        assert info[1]["reference"] == "pkg/1.0"
+        assert info[1]["context"] == "host"

--- a/conans/test/integration/editable/commands/info_on_child_test.py
+++ b/conans/test/integration/editable/commands/info_on_child_test.py
@@ -50,6 +50,7 @@ class InfoCommandTest(unittest.TestCase):
         self.assertIn("lib/version@user/name\n"
                       "    ID: e94ed0d45e4166d2f946107eaa208d550bf3691e\n"
                       "    BuildID: None\n"
+                      "    Context: host\n"
                       "    Remote: None\n"
                       "    Provides: lib\n"
                       "    Recipe: Editable\n{}"

--- a/conans/test/integration/editable/commands/info_test.py
+++ b/conans/test/integration/editable/commands/info_test.py
@@ -37,6 +37,7 @@ class InfoCommandOnLocalWorkspaceTest(LinkedPackageAsProject):
         self.assertIn("conanfile.py\n"
                       "    ID: e94ed0d45e4166d2f946107eaa208d550bf3691e\n"
                       "    BuildID: None\n"
+                      "    Context: host\n"
                       "    Requires:\n"
                       "        parent/version@user/name\n", self.t.out)
 
@@ -50,6 +51,7 @@ class InfoCommandOnLocalWorkspaceTest(LinkedPackageAsProject):
         self.assertIn("conanfile.py\n"
                       "    ID: e94ed0d45e4166d2f946107eaa208d550bf3691e\n"
                       "    BuildID: None\n"
+                      "    Context: host\n"
                       "    Requires:\n"
                       "        parent/version@user/name\n", self.t.out)
 
@@ -64,6 +66,7 @@ class InfoCommandUsingReferenceTest(LinkedPackageAsProject):
         expected = "lib/version@user/name\n" \
                    "    ID: e94ed0d45e4166d2f946107eaa208d550bf3691e\n" \
                    "    BuildID: None\n" \
+                   "    Context: host\n" \
                    "    Remote: None\n" \
                    "    Provides: lib\n" \
                    "    Recipe: Editable\n{}" \


### PR DESCRIPTION
Changelog: Feature: Add ``context`` information to ``conan info`` output both to stdout and json outputs.
Docs: https://github.com/conan-io/docs/pull/2142


Close https://github.com/conan-io/conan/issues/9121