### PR TITLE
Fix Bazel build string defines

### DIFF
--- a/conan/tools/google/bazeldeps.py
+++ b/conan/tools/google/bazeldeps.py
@@ -68,7 +68,8 @@ class BazelDeps(object):
         headers = ', '.join(headers)
         includes = ', '.join(includes)
 
-        defines = ('"{}"'.format(define) for define in dependency.new_cpp_info.defines)
+        defines = ('"{}"'.format(define.replace('"', "'"))
+                   for define in dependency.new_cpp_info.defines)
         defines = ', '.join(defines)
 
         context = {

--- a/conans/test/unittests/tools/google/test_bazeldeps.py
+++ b/conans/test/unittests/tools/google/test_bazeldeps.py
@@ -13,6 +13,7 @@ def test_bazeldeps_dependency_buildfiles():
     conanfile = ConanFile(Mock(), None)
 
     cpp_info = CppInfo("mypkg", "dummy_root_folder1")
+    cpp_info.defines = ["DUMMY_DEFINE=\"string/value\""]
 
     conanfile_dep = ConanFile(Mock(), None)
     conanfile_dep.cpp_info = cpp_info
@@ -29,6 +30,7 @@ def test_bazeldeps_dependency_buildfiles():
         for dependency in bazeldeps._conanfile.dependencies.host.values():
             dependency_content = bazeldeps._get_dependency_buildfile_content(dependency)
             assert 'cc_library(\n    name = "OriginalDepName",' in dependency_content
+            assert 'defines = ["DUMMY_DEFINE=\'string/value\'"],' in dependency_content
 
 
 def test_bazeldeps_main_buildfile():


### PR DESCRIPTION
Changelog: Fix: Fix Bazel build string defines.
Docs: omit

Closes: #9138 

- [x] Refer to the issue that supports this Pull Request.
- [ ] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 

<sup>**Note:** By default this PR will skip the slower tests and will use a limited set of python versions. Check [here](https://github.com/conan-io/conan/blob/develop/.github/PR_INCREASE_TESTING.md) how to increase the testing level by writing some tags in the current PR body text.</sup>
