### PR TITLE
making Paths explicit in new Environment

### DIFF
--- a/conan/tools/env/environment.py
+++ b/conan/tools/env/environment.py
@@ -52,6 +52,9 @@ class _EnvValue:
         self._path = path
         self._sep = separator
 
+    def copy(self):
+        return _EnvValue(self._name, self._values, self._sep, self._path)
+
     @property
     def is_path(self):
         return self._path
@@ -236,7 +239,7 @@ class Environment:
         for k, v in other._values.items():
             existing = self._values.get(k)
             if existing is None:
-                self._values[k] = v
+                self._values[k] = v.copy()
             else:
                 existing.compose(v)
         return self

--- a/conans/test/integration/environment/test_buildenv_profile.py
+++ b/conans/test/integration/environment/test_buildenv_profile.py
@@ -12,7 +12,7 @@ def client():
        class Pkg(ConanFile):
            def generate(self):
                for var in (1, 2):
-                   v = self.buildenv.value("MyVar{}".format(var))
+                   v = self.buildenv.get("MyVar{}".format(var))
                    self.output.info("MyVar{}={}!!".format(var, v))
        """)
     profile1 = textwrap.dedent("""

--- a/conans/test/integration/environment/test_env.py
+++ b/conans/test/integration/environment/test_env.py
@@ -131,9 +131,9 @@ def test_profile_included_multiple():
         class Pkg(ConanFile):
             def generate(self):
                 buildenv = self.buildenv
-                self.output.info("MYVAR1: {}!!!".format(buildenv.value("MYVAR1")))
-                self.output.info("MYVAR2: {}!!!".format(buildenv.value("MYVAR2")))
-                self.output.info("MYVAR3: {}!!!".format(buildenv.value("MYVAR3")))
+                self.output.info("MYVAR1: {}!!!".format(buildenv.get("MYVAR1")))
+                self.output.info("MYVAR2: {}!!!".format(buildenv.get("MYVAR2")))
+                self.output.info("MYVAR3: {}!!!".format(buildenv.get("MYVAR3")))
         """)
 
     myprofile = textwrap.dedent("""
@@ -261,21 +261,21 @@ def test_transitive_order():
             def generate(self):
                 env = VirtualEnv(self)
                 buildenv = env.build_environment()
-                self.output.info("BUILDENV: {}!!!".format(buildenv.value("MYVAR")))
+                self.output.info("BUILDENV: {}!!!".format(buildenv.get("MYVAR")))
                 runenv = env.run_environment()
-                self.output.info("RUNENV: {}!!!".format(runenv.value("MYVAR")))
+                self.output.info("RUNENV: {}!!!".format(runenv.get("MYVAR")))
         """)
     client.save({"conanfile.py": consumer}, clean_first=True)
     client.run("install . -s:b os=Windows -s:h os=Linux --build")
-    assert "BUILDENV: MYVAR MyOpenSSLWindowsValue MyGCCValue "\
+    assert "BUILDENV: MyOpenSSLWindowsValue MyGCCValue "\
            "MyCMakeRunValue MyCMakeBuildValue!!!" in client.out
-    assert "RUNENV: MYVAR MyOpenSSLLinuxValue!!!" in client.out
+    assert "RUNENV: MyOpenSSLLinuxValue!!!" in client.out
 
     # Even if the generator is duplicated in command line (it used to fail due to bugs)
     client.run("install . -s:b os=Windows -s:h os=Linux --build -g VirtualEnv")
-    assert "BUILDENV: MYVAR MyOpenSSLWindowsValue MyGCCValue "\
+    assert "BUILDENV: MyOpenSSLWindowsValue MyGCCValue "\
            "MyCMakeRunValue MyCMakeBuildValue!!!" in client.out
-    assert "RUNENV: MYVAR MyOpenSSLLinuxValue!!!" in client.out
+    assert "RUNENV: MyOpenSSLLinuxValue!!!" in client.out
 
 
 def test_buildenv_from_requires():
@@ -310,13 +310,13 @@ def test_buildenv_from_requires():
             def generate(self):
                 env = VirtualEnv(self)
                 buildenv = env.build_environment()
-                self.output.info("BUILDENV POCO: {}!!!".format(buildenv.value("Poco_ROOT")))
-                self.output.info("BUILDENV OpenSSL: {}!!!".format(buildenv.value("OpenSSL_ROOT")))
+                self.output.info("BUILDENV POCO: {}!!!".format(buildenv.get("Poco_ROOT")))
+                self.output.info("BUILDENV OpenSSL: {}!!!".format(buildenv.get("OpenSSL_ROOT")))
         """)
     client.save({"conanfile.py": consumer}, clean_first=True)
     client.run("install . -s:b os=Windows -s:h os=Linux --build -g VirtualEnv")
-    assert "BUILDENV POCO: Poco_ROOT MyPocoLinuxValue!!!" in client.out
-    assert "BUILDENV OpenSSL: OpenSSL_ROOT MyOpenSSLLinuxValue!!!" in client.out
+    assert "BUILDENV POCO: MyPocoLinuxValue!!!" in client.out
+    assert "BUILDENV OpenSSL: MyOpenSSLLinuxValue!!!" in client.out
 
 
 def test_diamond_repeated():
@@ -367,10 +367,10 @@ def test_diamond_repeated():
            def generate(self):
                 env = VirtualEnv(self)
                 runenv = env.run_environment()
-                self.output.info("MYVAR1: {}!!!".format(runenv.value("MYVAR1")))
-                self.output.info("MYVAR2: {}!!!".format(runenv.value("MYVAR2")))
-                self.output.info("MYVAR3: {}!!!".format(runenv.value("MYVAR3")))
-                self.output.info("MYVAR4: {}!!!".format(runenv.value("MYVAR4")))
+                self.output.info("MYVAR1: {}!!!".format(runenv.get("MYVAR1")))
+                self.output.info("MYVAR2: {}!!!".format(runenv.get("MYVAR2")))
+                self.output.info("MYVAR3: {}!!!".format(runenv.get("MYVAR3")))
+                self.output.info("MYVAR4: {}!!!".format(runenv.get("MYVAR4")))
        """)
     client = TestClient()
     client.save({"pkga/conanfile.py": pkga,
@@ -386,6 +386,6 @@ def test_diamond_repeated():
 
     client.run("install pkge --build")
     assert "MYVAR1: PkgAValue1 PkgCValue1 PkgBValue1 PkgDValue1!!!" in client.out
-    assert "MYVAR2: MYVAR2 PkgAValue2 PkgCValue2 PkgBValue2 PkgDValue2!!!" in client.out
-    assert "MYVAR3: PkgDValue3 PkgBValue3 PkgCValue3 PkgAValue3 MYVAR3!!!" in client.out
+    assert "MYVAR2: PkgAValue2 PkgCValue2 PkgBValue2 PkgDValue2!!!" in client.out
+    assert "MYVAR3: PkgDValue3 PkgBValue3 PkgCValue3 PkgAValue3!!!" in client.out
     assert "MYVAR4: PkgDValue4!!!" in client.out

--- a/conans/test/integration/environment/test_env.py
+++ b/conans/test/integration/environment/test_env.py
@@ -266,8 +266,15 @@ def test_transitive_order():
                 self.output.info("RUNENV: {}!!!".format(runenv.value("MYVAR")))
         """)
     client.save({"conanfile.py": consumer}, clean_first=True)
+    client.run("install . -s:b os=Windows -s:h os=Linux --build")
+    assert "BUILDENV: MYVAR MyOpenSSLWindowsValue MyGCCValue "\
+           "MyCMakeRunValue MyCMakeBuildValue!!!" in client.out
+    assert "RUNENV: MYVAR MyOpenSSLLinuxValue!!!" in client.out
+
+    # Even if the generator is duplicated in command line (it used to fail due to bugs)
     client.run("install . -s:b os=Windows -s:h os=Linux --build -g VirtualEnv")
-    assert "BUILDENV: MYVAR MyOpenSSLWindowsValue MyGCCValue MyCMakeRunValue MyCMakeBuildValue!!!" in client.out
+    assert "BUILDENV: MYVAR MyOpenSSLWindowsValue MyGCCValue "\
+           "MyCMakeRunValue MyCMakeBuildValue!!!" in client.out
     assert "RUNENV: MYVAR MyOpenSSLLinuxValue!!!" in client.out
 
 

--- a/conans/test/unittests/client/toolchain/autotools/autotools_deps_test.py
+++ b/conans/test/unittests/client/toolchain/autotools/autotools_deps_test.py
@@ -73,7 +73,7 @@ def test_foo():
         deps = AutotoolsDeps(consumer)
         # deps.generate()
         env = deps.environment()
-        assert env["LDFLAGS"] == ' dep1_shared_link_flag dep2_shared_link_flag ' \
+        assert env["LDFLAGS"] == 'dep1_shared_link_flag dep2_shared_link_flag ' \
                                  'dep1_exe_link_flag dep2_exe_link_flag ' \
                                  '-framework dep1_oneframework -framework dep1_twoframework ' \
                                  '-framework dep2_oneframework -framework dep2_twoframework ' \
@@ -85,5 +85,5 @@ def test_foo():
                                  '-Wl,-rpath,"/path/to/folder_dep2/one/lib/path/dep2" ' \
                                  '--sysroot=/path/to/folder/dep1'
 
-        assert env["CXXFLAGS"] == ' dep1_a_cxx_flag dep2_a_cxx_flag --sysroot=/path/to/folder/dep1'
-        assert env["CFLAGS"] == ' dep1_a_c_flag dep2_a_c_flag --sysroot=/path/to/folder/dep1'
+        assert env["CXXFLAGS"] == 'dep1_a_cxx_flag dep2_a_cxx_flag --sysroot=/path/to/folder/dep1'
+        assert env["CFLAGS"] == 'dep1_a_c_flag dep2_a_c_flag --sysroot=/path/to/folder/dep1'

--- a/conans/test/unittests/tools/env/test_env.py
+++ b/conans/test/unittests/tools/env/test_env.py
@@ -35,6 +35,20 @@ def test_compose():
     assert env.value("MyVar5") == ''
 
 
+def test_define_append():
+    env = Environment()
+    env.define("MyVar", "MyValue")
+    env.append("MyVar", "MyValue1")
+    env.append("MyVar", ["MyValue2", "MyValue3"])
+    assert env.value("MyVar") == "MyValue MyValue1 MyValue2 MyValue3"
+
+    env = Environment()
+    env.append("MyVar", "MyValue")
+    env.append("MyVar", "MyValue1")
+    env.define("MyVar", "MyValue2")
+    assert env.value("MyVar") == "MyValue2"
+
+
 @pytest.mark.parametrize("op1, v1, s1, op2, v2, s2, result",
                          [("define", "Val1", " ", "define", "Val2", " ", "Val1"),
                           ("define", "Val1", " ", "append", "Val2", " ", "Val1"),
@@ -53,8 +67,8 @@ def test_compose():
                           ("unset", "", " ", "prepend", "Val2", " ", ""),
                           ("unset", "", " ", "unset", "", " ", ""),
                           # different separators
-                          ("append", "Val1", "+", "append", "Val2", "-", "MyVar-Val2+Val1"),
-                          ("append", "Val1", "+", "prepend", "Val2", "-", "Val2-MyVar+Val1"),
+                          ("append", "Val1", "+", "append", "Val2", "-", "MyVar+Val2+Val1"),
+                          ("append", "Val1", "+", "prepend", "Val2", "-", "Val2+MyVar+Val1"),
                           ("unset", "", " ", "append", "Val2", "+", ""),
                           ("unset", "", " ", "prepend", "Val2", "+", ""),
                           ])


### PR DESCRIPTION
Changelog: Omit
Docs: Omit

Making the different between a Path and other env-vars in the new ``Environment``.

The final extraction of values for the ``win_bash`` and others, would need some minor changes, like changing ``items()`` to return the new ``_EnvValue`` so the ``is_path`` property can be checked, but I haven't done it because better do it depending on the consumer use case.
