### PR TITLE
fixing test_requires in host context transitivity

### DIFF
--- a/conan/tools/cmake/cmakedeps/cmakedeps.py
+++ b/conan/tools/cmake/cmakedeps/cmakedeps.py
@@ -39,6 +39,7 @@ class CMakeDeps(object):
 
         host_req = self._conanfile.dependencies.host
         build_req = self._conanfile.dependencies.direct_build
+        test_req = self._conanfile.dependencies.test
 
         # Check if the same package is at host and build and the same time
         activated_br = {r.ref.name for r in build_req.values()
@@ -53,7 +54,7 @@ class CMakeDeps(object):
                                      "generator.".format(common_name))
 
         # Iterate all the transitive requires
-        for require, dep in list(host_req.items()) + list(build_req.items()):
+        for require, dep in list(host_req.items()) + list(build_req.items()) + list(test_req.items()):
             # Require is not used at the moment, but its information could be used,
             # and will be used in Conan 2.0
             # Filter the build_requires not activated with cmakedeps.build_context_activated

--- a/conan/tools/cmake/cmakedeps/templates/target_data.py
+++ b/conan/tools/cmake/cmakedeps/templates/target_data.py
@@ -35,8 +35,7 @@ class ConfigDataTemplate(CMakeDepsFileTemplate):
         # so as the xxx-conf.cmake files won't be generated, don't include them as find_dependency
         # This is because in Conan 2.0 model, only the pure tools like CMake will be build_requires
         # for example a framework test won't be a build require but a "test/not public" require.
-        dependency_filenames = self.get_dependency_filenames() \
-            if not self.conanfile.is_build_context else []
+        dependency_filenames = self._get_dependency_filenames()
         package_folder = self.conanfile.package_folder.replace('\\', '/')\
                                                       .replace('$', '\\$').replace('"', '\\"')
         return {"global_cpp": global_cpp,
@@ -135,15 +134,19 @@ class ConfigDataTemplate(CMakeDepsFileTemplate):
         ret.reverse()
         return ret
 
-    def get_dependency_filenames(self):
+    def _get_dependency_filenames(self):
+        if self.conanfile.is_build_context:
+            return []
         ret = []
+        direct_host = self.conanfile.dependencies.direct_host
         if self.conanfile.new_cpp_info.required_components:
             for dep_name, _ in self.conanfile.new_cpp_info.required_components:
                 if dep_name and dep_name not in ret:  # External dep
-                    req = self.conanfile.dependencies.direct_host[dep_name]
+                    req = direct_host[dep_name]
                     ret.append(get_file_name(req))
-        elif self.conanfile.dependencies.direct_host:
-            ret = [get_file_name(r) for r in self.conanfile.dependencies.direct_host.values()]
+        elif direct_host:
+            ret = [get_file_name(r) for r in direct_host.values()]
+
         return ret
 
 

--- a/conan/tools/env/virtualenv.py
+++ b/conan/tools/env/virtualenv.py
@@ -65,8 +65,10 @@ class VirtualEnv:
         # FIXME: Missing profile info
         # FIXME: Cache value?
 
-        # Visitor, breadth-first
-        for require in self._conanfile.dependencies.host.values():
+        host = self._conanfile.dependencies.host
+        test = self._conanfile.dependencies.test
+
+        for require in list(host.values()) + list(test.values()):
             if require.runenv_info:
                 runenv.compose(require.runenv_info)
             runenv.compose(self._runenv_from_cpp_info(require.cpp_info))

--- a/conan/tools/microsoft/msbuilddeps.py
+++ b/conan/tools/microsoft/msbuilddeps.py
@@ -259,9 +259,12 @@ class MSBuildDeps(object):
         conf_name = self._config_filename()
         condition = self._condition()
         # Include all direct build_requires for host context. This might change
-        direct_deps = self._conanfile.dependencies.direct_host.values()
-        result[general_name] = self._all_props_file(general_name, direct_deps)
-        for dep in self._conanfile.dependencies.host.values():
+        direct_deps = self._conanfile.dependencies.filter({"direct": True, "build": False})
+        host_req = list(self._conanfile.dependencies.host.values())
+        test_req = list(self._conanfile.dependencies.test.values())
+
+        result[general_name] = self._all_props_file(general_name, direct_deps.values())
+        for dep in host_req + test_req:
             dep_name = dep.ref.name
             dep_name = dep_name.replace(".", "_")
             cpp_info = DepCppInfo(dep.cpp_info)  # To account for automatic component aggregation

--- a/conans/client/graph/graph_builder.py
+++ b/conans/client/graph/graph_builder.py
@@ -86,6 +86,7 @@ class DepsGraphBuilder(object):
             r = Requirement(ref)
             r.build_require = True
             r.build_require_context = context
+            r.force_host_context = getattr(ref, "force_host_context", False)
             build_requires.append(r)
 
         if graph_lock:

--- a/conans/client/graph/graph_manager.py
+++ b/conans/client/graph/graph_manager.py
@@ -35,6 +35,7 @@ class _RecipeBuildRequires(OrderedDict):
 
     def __call__(self, build_require, force_host_context=False):
         context = CONTEXT_HOST if force_host_context else self._default_context
+        build_require.force_host_context = force_host_context  # Dirty, but will be removed in 2.0
         self.add(build_require, context)
 
     def __str__(self):

--- a/conans/client/graph/graph_manager.py
+++ b/conans/client/graph/graph_manager.py
@@ -28,15 +28,15 @@ class _RecipeBuildRequires(OrderedDict):
         for build_require in build_requires:
             self.add(build_require, context=self._default_context)
 
-    def add(self, build_require, context):
+    def add(self, build_require, context, force_host_context=False):
         if not isinstance(build_require, ConanFileReference):
             build_require = ConanFileReference.loads(build_require)
+        build_require.force_host_context = force_host_context  # Dirty, but will be removed in 2.0
         self[(build_require.name, context)] = build_require
 
     def __call__(self, build_require, force_host_context=False):
         context = CONTEXT_HOST if force_host_context else self._default_context
-        build_require.force_host_context = force_host_context  # Dirty, but will be removed in 2.0
-        self.add(build_require, context)
+        self.add(build_require, context, force_host_context)
 
     def __str__(self):
         items = ["{} ({})".format(br, ctxt) for (_, ctxt), br in self.items()]

--- a/conans/model/dependencies.py
+++ b/conans/model/dependencies.py
@@ -87,7 +87,7 @@ class ConanFileDependencies(UserRequirementsDict):
         build, test, host = [], [], []
         for edge in node.dependencies:
             if edge.build_require:
-                if edge.require.build_require_context == CONTEXT_BUILD:
+                if not edge.require.force_host_context:
                     build.append(edge.dst)
                 else:
                     test.append(edge.dst)

--- a/conans/model/dependencies.py
+++ b/conans/model/dependencies.py
@@ -79,7 +79,7 @@ class ConanFileDependencies(UserRequirementsDict):
         build, test, host = [], [], []
         for edge in node.dependencies:
             if edge.build_require:
-                if edge.dst.context == CONTEXT_BUILD:
+                if edge.require.build_require_context == CONTEXT_BUILD:
                     build.append(edge.dst)
                 else:
                     test.append(edge.dst)

--- a/conans/model/requires.py
+++ b/conans/model/requires.py
@@ -22,6 +22,7 @@ class Requirement(object):
         self.private = private
         self.build_require = False
         self.build_require_context = None
+        self.force_host_context = False
         self._locked_id = None
 
     def lock(self, locked_ref, locked_id):

--- a/conans/test/functional/toolchains/microsoft/test_msbuilddeps.py
+++ b/conans/test/functional/toolchains/microsoft/test_msbuilddeps.py
@@ -596,15 +596,15 @@ class MSBuildGeneratorTest(unittest.TestCase):
                 generators = "MSBuildDeps"
                 def build(self):
                     deps = load("conandeps.props")
-                    assert "conan_tool.props" in deps
-                    self.output.info("Conan_tools.props in deps")
+                    assert "conan_tool.props" not in deps
+                    self.output.info("Conan_tools.props not in deps")
             """)
         client.save({"conanfile.py": conanfile})
         client.run("install .")
         deps = client.load("conandeps.props")
-        self.assertIn("conan_tool.props", deps)
+        self.assertNotIn("conan_tool.props", deps)
         client.run("create . pkg/0.1@")
-        self.assertIn("Conan_tools.props in deps", client.out)
+        self.assertIn("Conan_tools.props not in deps", client.out)
 
     def test_install_transitive_build_requires(self):
         # https://github.com/conan-io/conan/issues/8170
@@ -624,7 +624,7 @@ class MSBuildGeneratorTest(unittest.TestCase):
         client.run("install . -g MSBuildDeps -pr:b=default -pr:h=default --build=missing")
         pkg = client.load("conan_pkg_release_x64.props")
         assert "conan_dep.props" in pkg
-        assert "tool_test" in pkg  # test requires are there
+        assert "tool_test" not in pkg  # test requires are not there
         assert "tool_build" not in pkg
 
 

--- a/conans/test/integration/toolchains/cmake/cmakedeps/test_cmakedeps.py
+++ b/conans/test/integration/toolchains/cmake/cmakedeps/test_cmakedeps.py
@@ -1,4 +1,5 @@
 import os
+import textwrap
 
 from conans.test.assets.genconanfile import GenConanfile
 from conans.test.utils.tools import TestClient
@@ -37,3 +38,27 @@ def test_package_from_system():
     assert not os.path.exists(os.path.join(client.current_folder, "custom_dep2-config.cmake"))
     contents = client.load("dep1-release-x86_64-data.cmake")
     assert 'set(dep1_FIND_DEPENDENCY_NAMES ${dep1_FIND_DEPENDENCY_NAMES} custom_dep2)' in contents
+
+
+def test_test_package():
+    client = TestClient()
+    client.save({"conanfile.py": GenConanfile()})
+    client.run("create . gtest/1.0@")
+    client.run("create . cmake/1.0@")
+
+    client.save({"conanfile.py": GenConanfile().with_build_requires("cmake/1.0").
+                with_build_requirement("gtest/1.0", force_host_context=True)})
+
+    client.run("export . pkg/1.0@")
+
+    consumer = textwrap.dedent(r"""
+        from conans import ConanFile
+        class Pkg(ConanFile):
+            settings = "os", "compiler", "build_type", "arch"
+            generators = "CMakeDeps"
+            requires = "pkg/1.0"
+        """)
+    client.save({"conanfile.py": consumer})
+    client.run("install . -s:b os=Windows -s:h os=Linux --build=missing")
+    cmake_data = client.load("pkg-release-x86_64-data.cmake")
+    assert "gtest" not in cmake_data


### PR DESCRIPTION
Changelog: BugFix: ``build_requires`` in host context, like gtest, are being propagated downstream by generators in the ``dependencies`` model.
Docs: https://github.com/conan-io/docs/pull/2172


