### PR TITLE
fix use of CMAKE_GENERATOR_TOOLSET for Ninja and use vcvars_ver

### DIFF
--- a/conan/tools/cmake/toolchain.py
+++ b/conan/tools/cmake/toolchain.py
@@ -483,6 +483,8 @@ class GenericSystemBlock(Block):
         """)
 
     def _get_toolset(self, generator):
+        if generator is None or ("Visual" not in generator and "Xcode" not in generator):
+            return None
         settings = self._conanfile.settings
         compiler = settings.get_safe("compiler")
         compiler_base = settings.get_safe("compiler.base")

--- a/conan/tools/microsoft/toolchain.py
+++ b/conan/tools/microsoft/toolchain.py
@@ -26,8 +26,23 @@ def write_conanvcvars(conanfile):
     elif compiler == "Visual Studio" or compiler == "msvc":
         vs_version = vs_ide_version(conanfile)
         vcvarsarch = vcvars_arch(conanfile)
+        vcvars_ver = None
+        if compiler == "Visual Studio":
+            toolset = conanfile.settings.get_safe("compiler.toolset")
+            if toolset is not None:
+                vcvars_ver = {"v140": "14.0",
+                              "v141": "14.1",
+                              "v142": "14.2"}.get(toolset)
+        else:
+            # Code similar to CMakeToolchain toolset one
+            compiler_version = str(conanfile.settings.compiler.version)
+            version_components = compiler_version.split(".")
+            assert len(version_components) >= 2  # there is a 19.XX
+            minor = version_components[1]
+            # The equivalent of compiler 19.26 is toolset 14.26
+            vcvars_ver = "14.{}".format(minor)
         cvars = vcvars_command(vs_version, architecture=vcvarsarch, platform_type=None,
-                               winsdk_version=None, vcvars_ver=None)
+                               winsdk_version=None, vcvars_ver=vcvars_ver)
     if cvars:
         content = textwrap.dedent("""\
             @echo off

--- a/conans/test/functional/toolchains/cmake/test_ninja.py
+++ b/conans/test/functional/toolchains/cmake/test_ninja.py
@@ -117,6 +117,41 @@ def test_locally_build_msvc(build_type, shared, client):
 
 
 @pytest.mark.skipif(platform.system() != "Windows", reason="Only windows")
+@pytest.mark.tool_compiler
+@pytest.mark.tool_ninja
+def test_locally_build_msvc_toolset(client):
+    msvc_version = "15"
+    profile = textwrap.dedent("""
+        [settings]
+        os=Windows
+        compiler=msvc
+        compiler.version=19.0
+        compiler.runtime=dynamic
+        compiler.cppstd=14
+        build_type=Release
+        arch=x86_64
+        [conf]
+        tools.cmake.cmaketoolchain:generator=Ninja
+        tools.microsoft.msbuild:vs_version = 15
+        """)
+    client.save({"profile": profile})
+    client.run("install . -pr=profile")
+
+    client.run_command('conanvcvars.bat && cmake . -G "Ninja" '
+                       '-DCMAKE_TOOLCHAIN_FILE=conan_toolchain.cmake '
+                       '-DCMAKE_BUILD_TYPE=Release')
+
+    client.run_command("conanvcvars.bat && ninja")
+
+    client.run_command("myapp.exe")
+
+    # Checking that compiler is indeed version 19.0, not 19.1-default of VS15
+    check_exe_run(client.out, ["main", "hello"], "msvc", "19.0", "Release", "x86_64", cppstd="14")
+    check_vs_runtime("myapp.exe", client, msvc_version, "Release", architecture="amd64")
+    check_vs_runtime("mylibrary.lib", client, msvc_version, "Release", architecture="amd64")
+
+
+@pytest.mark.skipif(platform.system() != "Windows", reason="Only windows")
 @pytest.mark.parametrize("build_type,shared", [("Release", False), ("Debug", True)])
 @pytest.mark.tool_mingw64
 @pytest.mark.tool_compiler
@@ -186,6 +221,9 @@ def test_ninja_conf():
     client.run("install . -pr=profile")
     conanbuild = client.load("conanbuild.json")
     assert '"cmake_generator": "Ninja"' in conanbuild
-    if platform.system() == "Windows":
-        vcvars = client.load("conanvcvars.bat")
-        assert "2017" in vcvars
+    vcvars = client.load("conanvcvars.bat")
+    assert "2017" in vcvars
+
+    # toolchain cannot define the CMAKE_GENERATOR_TOOLSET for Ninja
+    cmake = client.load("conan_toolchain.cmake")
+    assert "CMAKE_GENERATOR_TOOLSET" not in cmake


### PR DESCRIPTION
Changelog: Bugfix: Do not define CMAKE_GENERATOR_TOOLSET  in CMakeToolchain for Ninja generator, and define it in ``vcvars_ver`` instead.
Docs: Omit


Fix: https://github.com/conan-io/conan/issues/9178
