### PR TITLE
Use dict.get instread of dict[]

### DIFF
--- a/conan/tools/qbs/qbsprofile.py
+++ b/conan/tools/qbs/qbsprofile.py
@@ -294,7 +294,8 @@ class QbsProfile(object):
             '_profile_values_from_setup': self._profile_values_from_setup,
             '_profile_values_from_env': self._profile_values_from_env,
             'build_variant': self._build_variant,
-            'architecture': self._architecture if not self._profile_values_from_setup["qbs.architecture"] else None,
+            'architecture': self._architecture if not
+                self._profile_values_from_setup.get("qbs.architecture") else None,
             'optimization': self._optimization,
             'sysroot': self._sysroot,
             'position_independent_code': self._position_independent_code,

--- a/conans/test/unittests/tools/qbs/test_qbs_profile.py
+++ b/conans/test/unittests/tools/qbs/test_qbs_profile.py
@@ -315,7 +315,6 @@ class QbsGenericTest(unittest.TestCase):
             'CXXFLAGS': cxx['env'],
             'LDFLAGS': '%s %s' % (wl['env'], ld['env'])
         }
-        print(env)
         with tools.environment_append(env):
             flags_from_env = qbs._flags_from_env()
 
@@ -329,108 +328,108 @@ class QbsGenericTest(unittest.TestCase):
         }
         self.assertEqual(flags_from_env, expected_flags)
 
-        @staticmethod
-        def _generate_qbs_config_output():
-            return textwrap.dedent('''\
-                profiles.conan.cpp.cCompilerName: "gcc"
-                profiles.conan.cpp.compilerName: "g++"
-                profiles.conan.cpp.cxxCompilerName: "g++"
-                profiles.conan.cpp.driverFlags: \
-                ["-march=armv7e-m", "-mtune=cortex-m4", "--specs=nosys.specs"]
-                profiles.conan.cpp.platformCommonCompilerFlags: undefined
-                profiles.conan.cpp.platformLinkerFlags: undefined
-                profiles.conan.cpp.toolchainInstallPath: "/usr/bin"
-                profiles.conan.cpp.toolchainPrefix: "arm-none-eabi-"
-                profiles.conan.qbs.someBoolProp: "true"
-                profiles.conan.qbs.someIntProp: "13"
-                profiles.conan.qbs.toolchain: ["gcc"]
-                ''')
+    @staticmethod
+    def _generate_qbs_config_output():
+        return textwrap.dedent('''\
+            profiles.conan.cpp.cCompilerName: "gcc"
+            profiles.conan.cpp.compilerName: "g++"
+            profiles.conan.cpp.cxxCompilerName: "g++"
+            profiles.conan.cpp.driverFlags: \
+            ["-march=armv7e-m", "-mtune=cortex-m4", "--specs=nosys.specs"]
+            profiles.conan.cpp.platformCommonCompilerFlags: undefined
+            profiles.conan.cpp.platformLinkerFlags: undefined
+            profiles.conan.cpp.toolchainInstallPath: "/usr/bin"
+            profiles.conan.cpp.toolchainPrefix: "arm-none-eabi-"
+            profiles.conan.qbs.someBoolProp: "true"
+            profiles.conan.qbs.someIntProp: "13"
+            profiles.conan.qbs.toolchain: ["gcc"]
+            ''')
 
-        def test_read_qbs_toolchain_from_qbs_config_output(self):
-            expected_config = {
-                'cpp.cCompilerName': '"gcc"',
-                'cpp.compilerName': '"g++"',
-                'cpp.cxxCompilerName': '"g++"',
-                'cpp.driverFlags': '["-march=armv7e-m", "-mtune=cortex-m4", "--specs=nosys.specs"]',
-                'cpp.platformCommonCompilerFlags': 'undefined',
-                'cpp.platformLinkerFlags': 'undefined',
-                'cpp.toolchainInstallPath': '"/usr/bin"',
-                'cpp.toolchainPrefix': '"arm-none-eabi-"',
-                'qbs.someBoolProp': 'true',
-                'qbs.someIntProp': '13',
-                'qbs.toolchain': '["gcc"]'
-            }
+    def test_read_qbs_toolchain_from_qbs_config_output(self):
+        expected_config = {
+            'cpp.cCompilerName': '"gcc"',
+            'cpp.compilerName': '"g++"',
+            'cpp.cxxCompilerName': '"g++"',
+            'cpp.driverFlags': '["-march=armv7e-m", "-mtune=cortex-m4", "--specs=nosys.specs"]',
+            'cpp.platformCommonCompilerFlags': 'undefined',
+            'cpp.platformLinkerFlags': 'undefined',
+            'cpp.toolchainInstallPath': '"/usr/bin"',
+            'cpp.toolchainPrefix': '"arm-none-eabi-"',
+            'qbs.someBoolProp': 'true',
+            'qbs.someIntProp': '13',
+            'qbs.toolchain': '["gcc"]'
+        }
 
-            conanfile = MockConanfileWithFolders(
-                MockSettings({}), runner=RunnerMock(
-                    expectations=[RunnerMock.Expectation(
-                        output=self._generate_qbs_config_output())]))
-            config = qbs._read_qbs_toolchain_from_config(conanfile)
-            self.assertEqual(len(conanfile.runner.command_called), 1)
-            self.assertEqual(conanfile.runner.command_called[0],
-                             'qbs-config --settings-dir "%s" --list' % (
-                                qbs._settings_dir(conanfile)))
-            self.assertEqual(config, expected_config)
+        conanfile = MockConanfileWithFolders(
+            MockSettings({}), runner=RunnerMock(
+                expectations=[RunnerMock.Expectation(
+                    output=self._generate_qbs_config_output())]))
+        config = qbs._read_qbs_toolchain_from_config(conanfile)
+        self.assertEqual(len(conanfile.runner.command_called), 1)
+        self.assertEqual(conanfile.runner.command_called[0],
+                         'qbs-config --settings-dir "%s" --list' % (
+                            qbs._settings_dir(conanfile)))
+        self.assertEqual(config, expected_config)
 
-        @unittest.skipIf(six.PY2, "Order of qbs output is defined only for PY3")
-        def test_toolchain_content(self):
-            expected_content = textwrap.dedent('''\
-                import qbs
+    @unittest.skipIf(six.PY2, "Order of qbs output is defined only for PY3")
+    def test_toolchain_content(self):
+        expected_content = textwrap.dedent('''\
+            import qbs
 
-                Project {
-                    Profile {
-                        name: "conan_toolchain_profile"
+            Project {
+                Profile {
+                    name: "conan_toolchain_profile"
 
-                        /* detected via qbs-setup-toolchains */
-                        cpp.cCompilerName: "gcc"
-                        cpp.compilerName: "g++"
-                        cpp.cxxCompilerName: "g++"
-                        cpp.driverFlags: ["-march=armv7e-m", "-mtune=cortex-m4", "--specs=nosys.specs"]
-                        cpp.platformCommonCompilerFlags: undefined
-                        cpp.platformLinkerFlags: undefined
-                        cpp.toolchainInstallPath: "/usr/bin"
-                        cpp.toolchainPrefix: "arm-none-eabi-"
-                        qbs.someBoolProp: true
-                        qbs.someIntProp: 13
-                        qbs.toolchain: ["gcc"]
+                    /* detected via qbs-setup-toolchains */
+                    cpp.cCompilerName: "gcc"
+                    cpp.compilerName: "g++"
+                    cpp.cxxCompilerName: "g++"
+                    cpp.driverFlags: ["-march=armv7e-m", "-mtune=cortex-m4", "--specs=nosys.specs"]
+                    cpp.platformCommonCompilerFlags: undefined
+                    cpp.platformLinkerFlags: undefined
+                    cpp.toolchainInstallPath: "/usr/bin"
+                    cpp.toolchainPrefix: "arm-none-eabi-"
+                    qbs.someBoolProp: true
+                    qbs.someIntProp: 13
+                    qbs.toolchain: ["gcc"]
 
-                        /* deduced from environment */
-                        qbs.sysroot: "/foo/bar/path"
+                    /* deduced from environment */
+                    qbs.sysroot: "/foo/bar/path"
 
-                        /* conan settings */
-                        qbs.buildVariant: "release"
-                        qbs.architecture: "x86_64"
-                        qbs.targetPlatform: "linux"
-                        qbs.optimization: "small"
-                        cpp.cxxLanguageVersion: "c++17"
+                    /* conan settings */
+                    qbs.buildVariant: "release"
+                    qbs.architecture: "x86_64"
+                    qbs.targetPlatform: "linux"
+                    qbs.optimization: "small"
+                    cpp.cxxLanguageVersion: "c++17"
 
-                        /* package options */
-                        cpp.positionIndependentCode: true
-                    }
-                }''')
+                    /* package options */
+                    cpp.positionIndependentCode: true
+                }
+            }''')
 
-            conanfile = MockConanfileWithFolders(
-                MockSettings({
-                    'compiler': 'gcc',
-                    'compiler.cppstd': 17,
-                    'os': 'Linux',
-                    'build_type': 'MinSizeRel',
-                    'arch': 'x86_64'
-                }),
-                options=MockOptions({
-                    'fPIC': True
-                }),
-                runner=RunnerMock(
-                    expectations=[
-                        RunnerMock.Expectation(),
-                        RunnerMock.Expectation(
-                            output=self._generate_qbs_config_output()),
-                    ]))
+        conanfile = MockConanfileWithFolders(
+            MockSettings({
+                'compiler': 'gcc',
+                'compiler.cppstd': 17,
+                'os': 'Linux',
+                'build_type': 'MinSizeRel',
+                'arch': 'x86_64'
+            }),
+            options=MockOptions({
+                'fPIC': True
+            }),
+            runner=RunnerMock(
+                expectations=[
+                    RunnerMock.Expectation(),
+                    RunnerMock.Expectation(
+                        output=self._generate_qbs_config_output()),
+                ]))
 
-            with tools.environment_append({'SYSROOT': '/foo/bar/path'}):
-                qbs_toolchain = qbs.QbsProfile(conanfile)
+        with tools.environment_append({'SYSROOT': '/foo/bar/path'}):
+            qbs_toolchain = qbs.QbsProfile(conanfile)
 
-            self.assertEqual(qbs_toolchain.content, expected_content)
+        self.assertEqual(qbs_toolchain.content, expected_content)
 
     @staticmethod
     def _generate_qbs_config_output_msvc():


### PR DESCRIPTION
Fix indentation in tests and remove `print` which was used for
debugging.

Changelog: Bugfix: Fix QbsProfile toolchain ``qbs.architecture`` KeyError.
Docs: Omit

Close #9188 

- [x] Refer to the issue that supports this Pull Request.
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 

<sup>**Note:** By default this PR will skip the slower tests and will use a limited set of python versions. Check [here](https://github.com/conan-io/conan/blob/develop/.github/PR_INCREASE_TESTING.md) how to increase the testing level by writing some tags in the current PR body text.</sup>
