### PR TITLE
--require-override in cli

### DIFF
--- a/conans/client/cmd/create.py
+++ b/conans/client/cmd/create.py
@@ -28,7 +28,7 @@ def _get_test_conanfile_path(tf, conanfile_path):
 
 def create(app, ref, graph_info, remotes, update, build_modes,
            manifest_folder, manifest_verify, manifest_interactive, keep_build, test_build_folder,
-           test_folder, conanfile_path, recorder, is_build_require=False):
+           test_folder, conanfile_path, recorder, is_build_require=False, require_overrides=None):
     assert isinstance(ref, ConanFileReference), "ref needed"
     test_conanfile_path = _get_test_conanfile_path(test_folder, conanfile_path)
 
@@ -76,7 +76,9 @@ def create(app, ref, graph_info, remotes, update, build_modes,
                                    manifest_interactive=manifest_interactive,
                                    keep_build=keep_build,
                                    test_build_folder=test_build_folder,
-                                   recorder=recorder)
+                                   recorder=recorder,
+                                   require_overrides=require_overrides
+                                   )
     else:
         deps_install(app=app,
                      ref_or_path=ref,
@@ -92,4 +94,5 @@ def create(app, ref, graph_info, remotes, update, build_modes,
                      update=update,
                      keep_build=keep_build,
                      recorder=recorder,
-                     is_build_require=is_build_require)
+                     is_build_require=is_build_require,
+                     require_overrides=require_overrides)

--- a/conans/client/cmd/test.py
+++ b/conans/client/cmd/test.py
@@ -11,7 +11,7 @@ from conans.util.files import rmdir
 def install_build_and_test(app, conanfile_abs_path, reference, graph_info,
                            remotes, update, build_modes=None, manifest_folder=None,
                            manifest_verify=False, manifest_interactive=False, keep_build=False,
-                           test_build_folder=None, recorder=None):
+                           test_build_folder=None, recorder=None, require_overrides=None):
     """
     Installs the reference (specified by the parameters or extracted from the test conanfile)
     and builds the test_package/conanfile.py running the test() method.
@@ -36,7 +36,8 @@ def install_build_and_test(app, conanfile_abs_path, reference, graph_info,
                      manifest_verify=manifest_verify,
                      manifest_interactive=manifest_interactive,
                      keep_build=keep_build,
-                     recorder=recorder)
+                     recorder=recorder,
+                     require_overrides=require_overrides)
         cmd_build(app, conanfile_abs_path, test_build_folder,
                   source_folder=base_folder, build_folder=test_build_folder,
                   package_folder=os.path.join(test_build_folder, "package"),

--- a/conans/client/command.py
+++ b/conans/client/command.py
@@ -347,6 +347,8 @@ class Command(object):
                                  ' revision and url even if there are uncommitted changes')
         parser.add_argument("--build-require", action='store_true', default=False,
                             help='The provided reference is a build-require')
+        parser.add_argument("--require-override", action="append",
+                            help="Define a requirement override")
 
         _add_manifests_arguments(parser)
         _add_common_install_arguments(parser, build_help=_help_build_policies.format("package name"))
@@ -392,7 +394,8 @@ class Command(object):
                                       lockfile_out=args.lockfile_out,
                                       ignore_dirty=args.ignore_dirty,
                                       profile_build=profile_build,
-                                      is_build_require=args.build_require)
+                                      is_build_require=args.build_require,
+                                      require_overrides=args.require_override)
         except ConanException as exc:
             info = exc.info
             raise
@@ -496,6 +499,8 @@ class Command(object):
         _add_common_install_arguments(parser, build_help=_help_build_policies.format("never"))
         parser.add_argument("--lockfile-node-id", action=OnceArgument,
                             help="NodeID of the referenced package in the lockfile")
+        parser.add_argument("--require-override", action="append",
+                            help="Define a requirement override")
 
         args = parser.parse_args(*args)
         self._check_lockfile_args(args)
@@ -529,7 +534,8 @@ class Command(object):
                                            no_imports=args.no_imports,
                                            install_folder=args.install_folder,
                                            lockfile=args.lockfile,
-                                           lockfile_out=args.lockfile_out)
+                                           lockfile_out=args.lockfile_out,
+                                           require_overrides=args.require_override)
             else:
                 if args.reference:
                     raise ConanException("A full reference was provided as first argument, second "
@@ -554,7 +560,8 @@ class Command(object):
                                                      lockfile=args.lockfile,
                                                      lockfile_out=args.lockfile_out,
                                                      lockfile_node_id=args.lockfile_node_id,
-                                                     is_build_require=args.build_require)
+                                                     is_build_require=args.build_require,
+                                                     require_overrides=args.require_override)
 
         except ConanException as exc:
             info = exc.info

--- a/conans/client/conan_api.py
+++ b/conans/client/conan_api.py
@@ -340,7 +340,7 @@ class ConanAPIV1(object):
                manifests=None, manifests_interactive=None,
                remote_name=None, update=False, cwd=None, test_build_folder=None,
                lockfile=None, lockfile_out=None, ignore_dirty=False, profile_build=None,
-               is_build_require=False, conf=None):
+               is_build_require=False, conf=None, require_overrides=None):
         """
         API method to create a conan package
 
@@ -386,7 +386,7 @@ class ConanAPIV1(object):
             create(self.app, ref, graph_info, remotes, update, build_modes,
                    manifest_folder, manifest_verify, manifest_interactive, keep_build,
                    test_build_folder, test_folder, conanfile_path, recorder=recorder,
-                   is_build_require=is_build_require)
+                   is_build_require=is_build_require, require_overrides=require_overrides)
 
             if lockfile_out:
                 lockfile_out = _make_abs_path(lockfile_out, cwd)
@@ -535,7 +535,8 @@ class ConanAPIV1(object):
                           manifests_interactive=None, build=None, profile_names=None,
                           update=False, generators=None, install_folder=None, cwd=None,
                           lockfile=None, lockfile_out=None, profile_build=None,
-                          lockfile_node_id=None, is_build_require=False, conf=None):
+                          lockfile_node_id=None, is_build_require=False, conf=None,
+                          require_overrides=None):
         profile_host = ProfileData(profiles=profile_names, settings=settings, options=options,
                                    env=env, conf=conf)
         recorder = ActionRecorder()
@@ -560,7 +561,8 @@ class ConanAPIV1(object):
                          generators=generators, recorder=recorder,
                          lockfile_node_id=lockfile_node_id,
                          is_build_require=is_build_require,
-                         add_txt_generator=False)
+                         add_txt_generator=False,
+                         require_overrides=require_overrides)
 
             if lockfile_out:
                 lockfile_out = _make_abs_path(lockfile_out, cwd)
@@ -579,7 +581,8 @@ class ConanAPIV1(object):
                 remote_name=None, verify=None, manifests=None,
                 manifests_interactive=None, build=None, profile_names=None,
                 update=False, generators=None, no_imports=False, install_folder=None, cwd=None,
-                lockfile=None, lockfile_out=None, profile_build=None, conf=None):
+                lockfile=None, lockfile_out=None, profile_build=None, conf=None,
+                require_overrides=None):
         profile_host = ProfileData(profiles=profile_names, settings=settings, options=options,
                                    env=env, conf=conf)
         recorder = ActionRecorder()
@@ -611,7 +614,8 @@ class ConanAPIV1(object):
                          manifest_interactive=manifest_interactive,
                          generators=generators,
                          no_imports=no_imports,
-                         recorder=recorder)
+                         recorder=recorder,
+                         require_overrides=require_overrides)
 
             if lockfile_out:
                 lockfile_out = _make_abs_path(lockfile_out, cwd)

--- a/conans/client/loader.py
+++ b/conans/client/loader.py
@@ -198,7 +198,7 @@ class ConanFileLoader(object):
         conanfile.conf = profile.conf.get_conanfile_conf(ref_str)
 
     def load_consumer(self, conanfile_path, profile_host, name=None, version=None, user=None,
-                      channel=None, lock_python_requires=None):
+                      channel=None, lock_python_requires=None, require_overrides=None):
         """ loads a conanfile.py in user space. Might have name/version or not
         """
         conanfile = self.load_named(conanfile_path, name, version, user, channel,
@@ -220,6 +220,11 @@ class ConanFileLoader(object):
             conanfile.options.initialize_upstream(profile_host.user_options,
                                                   name=conanfile.name)
             profile_host.user_options.clear_unscoped_options()
+
+            if require_overrides is not None:
+                for req_override in require_overrides:
+                    req_override = ConanFileReference.loads(req_override)
+                    conanfile.requires.override(req_override)
 
             return conanfile
         except ConanInvalidConfiguration:
@@ -298,7 +303,7 @@ class ConanFileLoader(object):
         return conanfile
 
     def load_virtual(self, references, profile_host, scope_options=True,
-                     build_requires_options=None, is_build_require=False):
+                     build_requires_options=None, is_build_require=False, require_overrides=None):
         # If user don't specify namespace in options, assume that it is
         # for the reference (keep compatibility)
         conanfile = ConanFile(self._output, self._runner, display_name="virtual")
@@ -312,6 +317,11 @@ class ConanFileLoader(object):
         else:
             for reference in references:
                 conanfile.requires.add_ref(reference)
+
+        if require_overrides is not None:
+            for req_override in require_overrides:
+                req_override = ConanFileReference.loads(req_override)
+                conanfile.requires.override(req_override)
 
         # Allows options without package namespace in conan install commands:
         #   conan install zlib/1.2.8@lasote/stable -o shared=True

--- a/conans/client/manager.py
+++ b/conans/client/manager.py
@@ -22,7 +22,7 @@ def deps_install(app, ref_or_path, install_folder, base_folder, graph_info, remo
                  build_modes=None, update=False, manifest_folder=None, manifest_verify=False,
                  manifest_interactive=False, generators=None, no_imports=False,
                  create_reference=None, keep_build=False, recorder=None, lockfile_node_id=None,
-                 is_build_require=False, add_txt_generator=True):
+                 is_build_require=False, add_txt_generator=True, require_overrides=None):
 
     """ Fetch and build all dependencies for the given reference
     @param app: The ConanApp instance with all collaborators
@@ -57,7 +57,8 @@ def deps_install(app, ref_or_path, install_folder, base_folder, graph_info, remo
     deps_graph = graph_manager.load_graph(ref_or_path, create_reference, graph_info, build_modes,
                                           False, update, remotes, recorder,
                                           lockfile_node_id=lockfile_node_id,
-                                          is_build_require=is_build_require)
+                                          is_build_require=is_build_require,
+                                          require_overrides=require_overrides)
     graph_lock = graph_info.graph_lock  # After the graph is loaded it is defined
     root_node = deps_graph.root
     conanfile = root_node.conanfile

--- a/conans/model/requires.py
+++ b/conans/model/requires.py
@@ -115,6 +115,14 @@ class Requirements(OrderedDict):
         else:
             self[name] = new_requirement
 
+    def override(self, ref):
+        name = ref.name
+        old_requirement = self.get(ref.name)
+        if old_requirement is not None:
+            self[name] = Requirement(ref, private=False, override=False)
+        else:
+            self[name] = Requirement(ref, private=False, override=True)
+
     def update(self, down_reqs, output, own_ref, down_ref):
         """ Compute actual requirement values when downstream values are defined
         param down_reqs: the current requirements as coming from downstream to override

--- a/conans/test/integration/command/install/install_test.py
+++ b/conans/test/integration/command/install/install_test.py
@@ -418,3 +418,32 @@ def test_install_error_never(client):
     assert "ERROR: --build=never not compatible with other options" in client.out
     client.run("install ./conanfile.py --build never --build outdated", assert_error=True)
     assert "ERROR: --build=never not compatible with other options" in client.out
+
+
+class TestCliOverride:
+
+    def test_install_cli_override(self, client):
+        client.save({"conanfile.py": GenConanfile()})
+        client.run("create . zlib/1.0@")
+        client.run("create . zlib/2.0@")
+        client.save({"conanfile.py": GenConanfile().with_requires("zlib/1.0")})
+        client.run("install . --require-override=zlib/2.0")
+        assert "zlib/2.0: Already installed" in client.out
+
+    def test_install_ref_cli_override(self, client):
+        client.save({"conanfile.py": GenConanfile()})
+        client.run("create . zlib/1.0@")
+        client.run("create . zlib/1.1@")
+        client.save({"conanfile.py": GenConanfile().with_requires("zlib/1.0")})
+        client.run("create . pkg/1.0@")
+        client.run("install pkg/1.0@ --require-override=zlib/1.1")
+        assert "zlib/1.1: Already installed" in client.out
+
+    def test_create_cli_override(self, client):
+        client.save({"conanfile.py": GenConanfile()})
+        client.run("create . zlib/1.0@")
+        client.run("create . zlib/2.0@")
+        client.save({"conanfile.py": GenConanfile().with_requires("zlib/1.0"),
+                     "test_package/conanfile.py": GenConanfile().with_test("pass")})
+        client.run("create . pkg/0.1@ --require-override=zlib/2.0")
+        assert "zlib/2.0: Already installed" in client.out


### PR DESCRIPTION
Changelog: Feature: Introduce the ``-require-override`` argument to define dependency overrides directly on command line.
Docs: https://github.com/conan-io/docs/pull/2170

Close https://github.com/conan-io/conan/issues/2140

Implementation note: It is a bit dirty that for implementing this kind of feature, 95% of the code is just passing around arguments that add to function calls that already contains +10 arguments, we need to revisit this architecture.


