### PR TITLE
trying to understand layouts 2

### DIFF
--- a/conans/client/graph/proxy.py
+++ b/conans/client/graph/proxy.py
@@ -51,7 +51,7 @@ class ConanProxy(object):
         # NOT in disk, must be retrieved from remotes
         if not ref:
             remote, new_ref = self._download_recipe(reference, output, remotes, remotes.selected)
-            recipe_layout = self._cache.ref_layout(new_ref)
+            recipe_layout = self._cache.get_ref_layout(new_ref)
             status = RECIPE_DOWNLOADED
             conanfile_path = recipe_layout.conanfile()
             return conanfile_path, status, remote, new_ref

--- a/conans/client/installer.py
+++ b/conans/client/installer.py
@@ -189,7 +189,7 @@ class _PackageBuilder(object):
         pref = node.pref
 
         # TODO: cache2.0 fix this
-        recipe_layout = self._cache.ref_layout(pref.ref)
+        recipe_layout = self._cache.get_ref_layout(pref.ref)
 
         base_source = recipe_layout.source()
         conanfile_path = recipe_layout.conanfile()

--- a/conans/client/remote_manager.py
+++ b/conans/client/remote_manager.py
@@ -150,7 +150,7 @@ class RemoteManager(object):
         touch_folder(export_sources_folder)
 
     def get_package(self, conanfile, pref, remote, output, recorder):
-        ref_layout = self._cache.ref_layout(pref.ref)
+        ref_layout = self._cache.get_ref_layout(pref.ref)
         conanfile_path = ref_layout.conanfile()
         self._hook_manager.execute("pre_download_package", conanfile_path=conanfile_path,
                                    reference=pref.ref, package_id=pref.id, remote=remote,


### PR DESCRIPTION
Changelog: Omit
Docs: Omit

Experimenting with the cache 2.0 and layouts:

It is necessary to clear express intention ``cache.ref_layout`` and ``cache.get_ref_layout`` are confusing. Lets go with something a bit more explicit, maybe something like: 
- ``cache.temp_ref_layout()`` For rrev=None, exporting with a temporary rrev
- ``cache.create_ref_layout()`` For rrev!=None, downloading or installing something to the cache, that is not there yet, but we should already know the rrev from the server.
- ``cache.ref_layout()``: It must exist already in the cache and rrev!=None

Let me know if this makes sense, or what problems could it have.


