### PR TITLE
Fix clang gcc-toolchain

### DIFF
--- a/conans/client/conf/detect.py
+++ b/conans/client/conf/detect.py
@@ -107,14 +107,14 @@ def _get_default_compiler(output):
             if compiler:
                 return compiler
         else:
+            if "clang" in command.lower():
+                return _clang_compiler(output, command)
             if "gcc" in command:
                 gcc = _gcc_compiler(output, command)
                 if platform.system() == "Darwin" and gcc is None:
                     output.error("%s detected as a frontend using apple-clang. "
                                  "Compiler not supported" % command)
                 return gcc
-            if "clang" in command.lower():
-                return _clang_compiler(output, command)
             if platform.system() == "SunOS" and command.lower() == "cc":
                 return _sun_cc_compiler(output, command)
         # I am not able to find its version

--- a/conans/test/unittests/util/detect_test.py
+++ b/conans/test/unittests/util/detect_test.py
@@ -86,3 +86,10 @@ class DetectTest(unittest.TestCase):
             result = dict(result)
             self.assertEqual(expected_arch, result['arch'])
             self.assertEqual(expected_arch, result['arch_build'])
+
+    @mock.patch("conans.client.conf.detect._clang_compiler", return_value=("clang", "9"))
+    def test_detect_clang_gcc_toolchain(self, _):
+        output = TestBufferConanOutput()
+        with tools.environment_append({"CC": "clang-9 --gcc-toolchain=/usr/lib/gcc/x86_64-linux-gnu/9"}):
+            detect_defaults_settings(output, profile_path="./MyProfile")
+            self.assertIn("CC and CXX: clang-9 --gcc-toolchain", output)


### PR DESCRIPTION
Changelog: Fix: `CC=clang` `--gcc-toolchain` is now identified as _clang_.
Docs: Omit

Clang allows gcc toolchain by `--gcc-toolchain` options, but gcc has no any clang option, so inverting the detect order should not break anything because we are reading CC and CXX here. 

fixes #7150

- [ ] Refer to the issue that supports this Pull Request.
- [ ] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [ ] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [ ] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 

<sup>**Note:** By default this PR will skip the slower tests and will use a limited set of python versions. Check [here](https://github.com/conan-io/conan/blob/develop/.github/PR_INCREASE_TESTING.md) how to increase the testing level by writing some tags in the current PR body text.</sup>
