### PR TITLE
Minor fix for argument formatting consistancy

### DIFF
--- a/conans/client/command.py
+++ b/conans/client/command.py
@@ -594,9 +594,9 @@ class Command(object):
 
         install_subparser.add_argument("--verify-ssl", nargs="?", default="True",
                                        help='Verify SSL connection when downloading file')
-        install_subparser.add_argument("--type", "-t", choices=["git", "dir", "file", "url"],
+        install_subparser.add_argument("-t", "--type", choices=["git", "dir", "file", "url"],
                                        help='Type of remote config')
-        install_subparser.add_argument("--args", "-a",
+        install_subparser.add_argument("-a", "--args",
                                        help='String with extra arguments for "git clone"')
         install_subparser.add_argument("-sf", "--source-folder",
                                        help='Install files only from a source subfolder from the '


### PR DESCRIPTION
When looking at the help output, I spotted a little inconsistency in argument position and ran a little regex to find out that it is really consistent except for the 2 that are in conan config install -h, I haven't opened an issue for this little amount of changes, but I can open one if necessary.
If you think this is necessary, you can just close this PR.

Changelog: Fix: Consistently put short arguments (-a) before long ones (--args).
Docs: omit

- [ ] Refer to the issue that supports this Pull Request.
- [ ] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 

<sup>**Note:** By default this PR will skip the slower tests and will use a limited set of python versions. Check [here](https://github.com/conan-io/conan/blob/develop/.github/PR_INCREASE_TESTING.md) how to increase the testing level by writing some tags in the current PR body text.</sup>
