### PR TITLE
Fix help consistancy

### DIFF
--- a/conans/client/command.py
+++ b/conans/client/command.py
@@ -1676,7 +1676,7 @@ class Command(object):
         parser = argparse.ArgumentParser(description=self.profile.__doc__,
                                          prog="conan profile",
                                          formatter_class=SmartFormatter)
-        subparsers = parser.add_subparsers(dest='subcommand')
+        subparsers = parser.add_subparsers(dest='subcommand', help='sub-command help')
         subparsers.required = True
 
         # create the parser for the "profile" command


### PR DESCRIPTION
Follow up of #9199
When looking at the help output (well, actually I am parsing it), I've spotted a little inconsistency in the conan profile sub-command help.
Apart from this little inconsistency, I have successfully parsed the entire conan help output, so it should be really consistent now.
If you think this is unnecessary, you can just close this PR.

Changelog: Fix: Consistent help message for conan profile (sub-command part).
Docs: https://github.com/conan-io/docs/pull/2171

- [ ] Refer to the issue that supports this Pull Request.
- [ ] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 

<sup>**Note:** By default this PR will skip the slower tests and will use a limited set of python versions. Check [here](https://github.com/conan-io/conan/blob/develop/.github/PR_INCREASE_TESTING.md) how to increase the testing level by writing some tags in the current PR body text.</sup>
