### PR TITLE
poc of new alias

### DIFF
--- a/conans/client/graph/graph.py
+++ b/conans/client/graph/graph.py
@@ -249,6 +249,7 @@ class DepsGraph(object):
         self.nodes = set()
         self.root = None
         self.aliased = {}
+        self.new_aliased = {}
         self._node_counter = initial_node_id if initial_node_id is not None else -1
 
     def add_node(self, node):

--- a/conans/client/graph/graph_builder.py
+++ b/conans/client/graph/graph_builder.py
@@ -94,6 +94,8 @@ class DepsGraphBuilder(object):
             # TODO: Add info about context?
             graph_lock.lock_node(node, build_requires, build_requires=True)
 
+        for require in build_requires:
+            self._resolve_alias(node, require, graph, update, update, remotes)
         self._resolve_ranges(graph, build_requires, scope, update, remotes)
 
         for br in build_requires:
@@ -145,6 +147,43 @@ class DepsGraphBuilder(object):
                 if alias:
                     require.ref = alias
 
+    def _resolve_alias(self, node, require, graph, check_updates, update, remotes):
+        alias = require.alias
+        if alias is None:
+            return
+
+        # First try cached
+        cached = graph.new_aliased.get(alias)
+        if cached is not None:
+            while True:
+                new_cached = graph.new_aliased.get(cached)
+                if new_cached is None:
+                    break
+                else:
+                    cached = new_cached
+            require.ref = cached
+            return
+
+        while alias is not None:
+            # if not cached, then resolve
+            try:
+                result = self._proxy.get_recipe(alias, check_updates, update, remotes, self._recorder)
+                conanfile_path, recipe_status, remote, new_ref = result
+            except ConanException as e:
+                raise e
+
+            dep_conanfile = self._loader.load_basic(conanfile_path)
+            try:
+                pointed_ref = ConanFileReference.loads(dep_conanfile.alias)
+            except Exception as e:
+                raise ConanException(f"Alias definition error in {alias}: {str(e)}")
+
+            # UPDATE THE REQUIREMENT!
+            require.ref = require.range_ref = pointed_ref
+            graph.new_aliased[alias] = pointed_ref  # Caching the alias
+            new_req = Requirement(pointed_ref)  # FIXME: Ugly temp creation just for alias check
+            alias = new_req.alias
+
     def _get_node_requirements(self, node, graph, down_ref, down_options, down_reqs, graph_lock,
                                update, remotes):
         """ compute the requirements of a node, evaluating requirements(), propagating
@@ -154,6 +193,8 @@ class DepsGraphBuilder(object):
         if graph_lock:
             graph_lock.pre_lock_node(node)
         new_options = self._config_node(node, down_ref, down_options)
+        for require in node.conanfile.requires.values():
+            self._resolve_alias(node, require, graph, update, update, remotes)
         # Alias that are cached should be replaced here, bc next requires.update() will warn if not
         self._resolve_cached_alias(node.conanfile.requires.values(), graph)
 

--- a/conans/client/graph/graph_builder.py
+++ b/conans/client/graph/graph_builder.py
@@ -176,7 +176,7 @@ class DepsGraphBuilder(object):
             try:
                 pointed_ref = ConanFileReference.loads(dep_conanfile.alias)
             except Exception as e:
-                raise ConanException(f"Alias definition error in {alias}: {str(e)}")
+                raise ConanException("Alias definition error in {}: {}".format(alias, str(e)))
 
             # UPDATE THE REQUIREMENT!
             require.ref = require.range_ref = pointed_ref

--- a/conans/client/graph/python_requires.py
+++ b/conans/client/graph/python_requires.py
@@ -127,9 +127,13 @@ class PyRequireLoader(object):
             ref = locked
         else:
             requirement = Requirement(ref)
-            self._range_resolver.resolve(requirement, "py_require", update=self._update,
-                                         remotes=self._remotes)
-            ref = requirement.ref
+            alias = requirement.alias
+            if alias is not None:
+                ref = alias
+            else:
+                self._range_resolver.resolve(requirement, "py_require", update=self._update,
+                                             remotes=self._remotes)
+                ref = requirement.ref
         return ref
 
     def _load_pyreq_conanfile(self, loader, lock_python_requires, ref):
@@ -144,6 +148,10 @@ class PyRequireLoader(object):
 
         if getattr(conanfile, "alias", None):
             ref = ConanFileReference.loads(conanfile.alias)
+            requirement = Requirement(ref)
+            alias = requirement.alias
+            if alias is not None:
+                ref = alias
             conanfile, module, new_ref, path = self._load_pyreq_conanfile(loader,
                                                                           lock_python_requires,
                                                                           ref)

--- a/conans/model/ref.py
+++ b/conans/model/ref.py
@@ -135,7 +135,8 @@ class ConanName(object):
         if name == "*":
             return
         if ConanName._validation_pattern.match(name) is None:
-            if version and name.startswith("[") and name.endswith("]"):
+            if version and ((name.startswith("[") and name.endswith("]")) or
+                            (name.startswith("(") and name.endswith(")"))):
                 return
             ConanName.invalid_name_message(name, reference_token=reference_token)
 

--- a/conans/model/requires.py
+++ b/conans/model/requires.py
@@ -45,6 +45,13 @@ class Requirement(object):
             return version[1:-1]
 
     @property
+    def alias(self):
+        version = self.ref.version
+        if version.startswith("(") and version.endswith(")"):
+            return ConanFileReference(self.ref.name, version[1:-1], self.ref.user, self.ref.channel,
+                                      self.ref.revision, validate=False)
+
+    @property
     def is_resolved(self):
         """ returns True if the version_range reference has been already resolved to a
         concrete reference

--- a/conans/test/integration/graph/core/graph_manager_base.py
+++ b/conans/test/integration/graph/core/graph_manager_base.py
@@ -12,7 +12,7 @@ from conans.client.graph.build_mode import BuildMode
 from conans.client.graph.graph_binaries import GraphBinariesAnalyzer
 from conans.client.graph.graph_manager import GraphManager
 from conans.client.graph.proxy import ConanProxy
-from conans.client.graph.python_requires import ConanPythonRequire
+from conans.client.graph.python_requires import ConanPythonRequire, PyRequireLoader
 from conans.client.graph.range_resolver import RangeResolver
 from conans.client.installer import BinaryInstaller
 from conans.client.loader import ConanFileLoader
@@ -42,7 +42,10 @@ class GraphManagerTest(unittest.TestCase):
         cache = self.cache
         self.resolver = RangeResolver(self.cache, self.remote_manager)
         proxy = ConanProxy(cache, self.output, self.remote_manager)
-        self.loader = ConanFileLoader(None, self.output, ConanPythonRequire(None, None))
+        pyreq_loader = PyRequireLoader(proxy, self.resolver)
+        pyreq_loader.enable_remotes(remotes=Remotes())
+        self.loader = ConanFileLoader(None, self.output, ConanPythonRequire(None, None),
+                                      pyreq_loader=pyreq_loader)
         binaries = GraphBinariesAnalyzer(cache, self.output, self.remote_manager)
         self.manager = GraphManager(self.output, cache, self.remote_manager, self.loader, proxy,
                                     self.resolver, binaries)

--- a/conans/test/integration/graph/core/test_new_alias.py
+++ b/conans/test/integration/graph/core/test_new_alias.py
@@ -1,0 +1,184 @@
+import pytest
+
+from conans.test.assets.genconanfile import GenConanfile
+from conans.test.integration.graph.core.graph_manager_base import GraphManagerTest
+from conans.test.utils.tools import TestClient
+
+
+class TestAlias(GraphManagerTest):
+
+    def test_basic(self):
+        # app -> liba/latest -(alias)-> liba/0.1
+        self.recipe_cache("liba/0.1")
+        self.alias_cache("liba/latest", "liba/0.1")
+
+        consumer = self.recipe_consumer("app/0.1", ["liba/(latest)"])
+        deps_graph = self.build_consumer(consumer)
+
+        self.assertEqual(2, len(deps_graph.nodes))
+        app = deps_graph.root
+        liba = app.dependencies[0].dst
+
+        self._check_node(liba, "liba/0.1#123", dependents=[app])
+        self._check_node(app, "app/0.1", deps=[liba], closure=[liba])
+
+    def test_alias_diamond(self):
+        # app -> ----------------------------------> liba/0.1
+        #   \ -> libb/0.1 -> liba/latest -(alias) ----->/
+        self.recipe_cache("liba/0.1")
+        self.alias_cache("liba/latest", "liba/0.1")
+        self.recipe_cache("libb/0.1", requires=["liba/(latest)"])
+        consumer = self.recipe_consumer("app/0.1", ["liba/0.1", "libb/0.1"])
+        deps_graph = self.build_consumer(consumer)
+
+        self.assertEqual(3, len(deps_graph.nodes))
+        app = deps_graph.root
+        liba = app.dependencies[0].dst
+        libb = app.dependencies[1].dst
+
+        self._check_node(liba, "liba/0.1#123", dependents=[app, libb])
+        self._check_node(libb, "libb/0.1#123", deps=[liba], dependents=[app], closure=[liba])
+        self._check_node(app, "app/0.1", deps=[liba, libb], closure=[libb, liba])
+
+    def test_two_alias_diamond(self):
+        # https://github.com/conan-io/conan/issues/3353
+        # app -> liba/latest -(alias) --------------------------------------> liba/0.1
+        #   \ -> libb/latest -(alias) -> libb/0.1 -> liba/latest -(alias) ----->/
+
+        self.recipe_cache("liba/0.1")
+        self.alias_cache("liba/latest", "liba/0.1")
+        self.recipe_cache("libb/0.1", requires=["liba/(latest)"])
+        self.alias_cache("libb/latest", "libb/0.1")
+
+        consumer = self.recipe_consumer("app/0.1", ["liba/(latest)", "libb/(latest)"])
+        deps_graph = self.build_consumer(consumer)
+
+        self.assertEqual(3, len(deps_graph.nodes))
+        app = deps_graph.root
+        liba = app.dependencies[0].dst
+        libb = app.dependencies[1].dst
+
+        self._check_node(liba, "liba/0.1#123", dependents=[app, libb])
+        self._check_node(libb, "libb/0.1#123", deps=[liba], dependents=[app], closure=[liba])
+        self._check_node(app, "app/0.1", deps=[liba, libb], closure=[libb, liba])
+
+    def test_full_two_branches_diamond(self):
+        # https://github.com/conan-io/conan/issues/3353
+        # app -> libb/latest -(alias) -> libb/0.1 -> liba/latest -(alias) ----> liba/0.1
+        #   \ -> libc/latest -(alias) -> libc/0.1 -> liba/latest -(alias) ----->/
+
+        self.recipe_cache("liba/0.1")
+        self.alias_cache("liba/latest", "liba/0.1")
+        self.recipe_cache("libb/0.1", requires=["liba/(latest)"])
+        self.recipe_cache("libc/0.1", requires=["liba/(latest)"])
+        self.alias_cache("libb/latest", "libb/0.1")
+        self.alias_cache("libc/latest", "libc/0.1")
+
+        consumer = self.recipe_consumer("app/0.1", ["libb/(latest)", "libc/(latest)"])
+        deps_graph = self.build_consumer(consumer)
+
+        self.assertEqual(4, len(deps_graph.nodes))
+        app = deps_graph.root
+        libb = app.dependencies[0].dst
+        libc = app.dependencies[1].dst
+        liba = libb.dependencies[0].dst
+
+        self._check_node(liba, "liba/0.1#123", dependents=[libb, libc])
+        self._check_node(libb, "libb/0.1#123", deps=[liba], dependents=[app], closure=[liba])
+        self._check_node(libc, "libc/0.1#123", deps=[liba], dependents=[app], closure=[liba])
+        self._check_node(app, "app/0.1", deps=[libb, libc], closure=[libb, libc, liba])
+
+    def test_alias_bug(self):
+        # https://github.com/conan-io/conan/issues/2252
+        # app -> libb/0.1 -> liba/latest -(alias)->liba/0.1
+        #   \ -> libc/0.1 ----/
+        self.recipe_cache("liba/0.1")
+        self.alias_cache("liba/latest", "liba/0.1")
+        self.recipe_cache("libb/0.1", requires=["liba/(latest)"])
+        self.recipe_cache("libc/0.1", requires=["liba/(latest)"])
+
+        consumer = self.recipe_consumer("app/0.1", ["libb/0.1", "libc/0.1"])
+        deps_graph = self.build_consumer(consumer)
+
+        self.assertEqual(4, len(deps_graph.nodes))
+        app = deps_graph.root
+        libb = app.dependencies[0].dst
+        libc = app.dependencies[1].dst
+        liba = libb.dependencies[0].dst
+
+        self._check_node(liba, "liba/0.1#123", dependents=[libb, libc])
+        self._check_node(libb, "libb/0.1#123", deps=[liba], dependents=[app], closure=[liba])
+        self._check_node(libc, "libc/0.1#123", deps=[liba], dependents=[app], closure=[liba])
+        self._check_node(app, "app/0.1", deps=[libb, libc], closure=[libb, libc, liba])
+
+    def test_alias_tansitive(self):
+        # app -> liba/giga -(alias)->-> liba/mega -(alias)-> liba/latest -(alias)->liba/0.1
+
+        self.recipe_cache("liba/0.1")
+        self.alias_cache("liba/latest", "liba/0.1")
+        self.alias_cache("liba/mega", "liba/(latest)")
+        self.alias_cache("liba/giga", "liba/(mega)")
+
+        consumer = self.recipe_consumer("app/0.1", ["liba/(giga)"])
+        deps_graph = self.build_consumer(consumer)
+
+        self.assertEqual(2, len(deps_graph.nodes))
+        app = deps_graph.root
+        liba = app.dependencies[0].dst
+
+        self._check_node(liba, "liba/0.1#123", dependents=[app])
+        self._check_node(app, "app/0.1", deps=[liba], closure=[liba])
+
+
+class AliasBuildRequiresTest(GraphManagerTest):
+
+    @pytest.mark.xfail(reason="This onely works with the build context")
+    def test_non_conflicting_alias(self):
+        # https://github.com/conan-io/conan/issues/5468
+        # libc ----> libb -------------------> liba/0.1
+        #   \-(build)-> liba/latest -(alias)-> liba/0.2
+        self.recipe_cache("liba/0.1")
+        self.recipe_cache("liba/0.2")
+        self.alias_cache("liba/latest", "liba/0.2")
+        self.recipe_cache("libb/0.1", ["liba/0.1"])
+        consumer = self.recipe_consumer("app/0.1", ["libb/0.1"], build_requires=["liba/(latest)"])
+
+        deps_graph = self.build_consumer(consumer)
+
+        self.assertEqual(4, len(deps_graph.nodes))
+        app = deps_graph.root
+        libb = app.dependencies[0].dst
+        liba_build = app.dependencies[1].dst
+        liba = libb.dependencies[0].dst
+
+        self._check_node(liba, "liba/0.1#123", dependents=[libb])
+        self._check_node(liba_build, "liba/0.2#123", dependents=[app])
+        self._check_node(libb, "libb/0.1#123", deps=[liba], dependents=[app])
+        self._check_node(app, "app/0.1", deps=[libb, liba_build])
+
+
+def test_mixing_aliases_and_fix_versions():
+    # cd/1.0 -----------------------------> cb/latest -(alias)-> cb/1.0 -> ca/1.0
+    #   \-----> cc/latest -(alias)-> cc/1.0 ->/                             /
+    #                                    \------ ca/latest -(alias)------->/
+    client = TestClient()
+
+    client.save({"conanfile.py": GenConanfile("ca", "1.0")})
+    client.run("create . ")
+    client.run("alias ca/latest@ ca/1.0@")
+
+    client.save({"conanfile.py": GenConanfile("cb", "1.0")
+                .with_requirement("ca/1.0@")})
+    client.run("create . cb/1.0@")
+    client.run("alias cb/latest@ cb/1.0@")
+
+    client.save({"conanfile.py": GenConanfile("cc", "1.0")
+                .with_requirement("cb/(latest)")
+                .with_requirement("ca/(latest)")})
+    client.run("create . ")
+    client.run("alias cc/latest@ cc/1.0@")
+
+    client.save({"conanfile.py": GenConanfile("cd", "1.0")
+                .with_requirement("cb/(latest)")
+                .with_requirement("cc/(latest)")})
+    client.run("create . ")

--- a/conans/test/integration/graph/core/test_new_alias.py
+++ b/conans/test/integration/graph/core/test_new_alias.py
@@ -1,3 +1,5 @@
+import textwrap
+
 import pytest
 
 from conans.test.assets.genconanfile import GenConanfile
@@ -155,6 +157,27 @@ class AliasBuildRequiresTest(GraphManagerTest):
         self._check_node(liba_build, "liba/0.2#123", dependents=[app])
         self._check_node(libb, "libb/0.1#123", deps=[liba], dependents=[app])
         self._check_node(app, "app/0.1", deps=[libb, liba_build])
+
+
+class AliasPythonRequiresTest(GraphManagerTest):
+
+    def test_python_requires(self):
+        # app ----(python-requires)---> tool/(latest) -> tool/0.1
+        self.recipe_cache("tool/0.1")
+        self.recipe_cache("tool/0.2")
+        self.alias_cache("tool/latest", "tool/0.1")
+        consumer = textwrap.dedent("""
+            from conans import ConanFile
+            class Pkg(ConanFile):
+                name = "app"
+                version = "0.1"
+                python_requires = "tool/(latest)"
+            """)
+        deps_graph = self.build_graph(consumer)
+
+        self.assertEqual(1, len(deps_graph.nodes))
+        app = deps_graph.root
+        self._check_node(app, "app/0.1", deps=[])
 
 
 def test_mixing_aliases_and_fix_versions():


### PR DESCRIPTION
Changelog: Feature: Implement a new ``requires = "pkg/(alias)"`` syntax to be able to dissambiguate alias requirements and resolve them earlier in the flow, solving some limitations of the previous alias definition. This approach is intended to be the one in Conan 2.0 (issue backported from https://github.com/conan-io/tribe/pull/25).
Docs: https://github.com/conan-io/docs/pull/2169

Close https://github.com/conan-io/conan/issues/8966

From https://github.com/conan-io/conan/pull/9039, trying a proof of concept, if the new ``pkg/(alias)`` syntax could help addressing problems and help to transition smoothly to Conan 2.0
