### PR TITLE
Check for revisions already in cache for conan inspect in Conan 2.0

### DIFF
--- a/conans/client/cache/cache.py
+++ b/conans/client/cache/cache.py
@@ -112,6 +112,14 @@ class ClientCache(object):
         return [ConanFileReference.loads(f"{ref['reference']}#{ref['rrev']}", validate=False) for ref in
                 self._data_cache.list_references()]
 
+    def exists_rrev(self, ref):
+        matching_rrevs = self.get_recipe_revisions(ref)
+        return len(matching_rrevs) > 0
+
+    def exists_prev(self, ref):
+        matching_prevs = self.get_package_revisions(ref)
+        return len(matching_prevs) > 0
+
     def get_package_revisions(self, ref, only_latest_prev=False):
         return [
             PackageReference.loads(f'{pref["reference"]}#{pref["rrev"]}:{pref["pkgid"]}#{pref["prev"]}',

--- a/conans/client/conan_api.py
+++ b/conans/client/conan_api.py
@@ -273,7 +273,8 @@ class ConanAPIV1(object):
                 remotes = self.app.load_remotes()
                 remote = remotes.get_remote(remote_name)
                 try:  # get_recipe_manifest can fail, not in server
-                    _, ref = self.app.remote_manager.get_recipe_manifest(ref, remote)
+                    if not ref.revision:
+                        ref = self.app.remote_manager.get_latest_recipe_revision(ref, remote)
                 except NotFoundException:
                     raise RecipeNotFoundException(ref)
                 else:

--- a/conans/client/conan_api.py
+++ b/conans/client/conan_api.py
@@ -277,7 +277,9 @@ class ConanAPIV1(object):
                 except NotFoundException:
                     raise RecipeNotFoundException(ref)
                 else:
-                    ref = self.app.remote_manager.get_recipe(ref, remote)
+                    ref_in_cache = self.app.cache.get_recipe_revisions(ref)
+                    ref = self.app.remote_manager.get_recipe(ref, remote) if len(ref_in_cache) == 0 \
+                        else ref_in_cache[0]
 
             result = self.app.proxy.get_recipe(ref, False, False, remotes)
             conanfile_path, _, _, ref = result

--- a/conans/client/conan_api.py
+++ b/conans/client/conan_api.py
@@ -278,9 +278,8 @@ class ConanAPIV1(object):
                 except NotFoundException:
                     raise RecipeNotFoundException(ref)
                 else:
-                    ref_in_cache = self.app.cache.get_recipe_revisions(ref)
-                    ref = self.app.remote_manager.get_recipe(ref, remote) if len(ref_in_cache) == 0 \
-                        else ref_in_cache[0]
+                    if not self.app.cache.exists_rrev(ref):
+                        ref = self.app.remote_manager.get_recipe(ref, remote)
 
             result = self.app.proxy.get_recipe(ref, False, False, remotes)
             conanfile_path, _, _, ref = result

--- a/conans/test/integration/command/inspect_test.py
+++ b/conans/test/integration/command/inspect_test.py
@@ -59,8 +59,6 @@ class ConanInspectTest(unittest.TestCase):
         client.run("inspect pkg/0.1@user/channel -a settings")
         self.assertIn("settings: os", client.out)
 
-    @pytest.mark.xfail(reason="FIXME: cache2.0 inspect not checking if revision is in cache before "
-                              "download")
     def test_name_version(self):
         server = TestServer()
         client = TestClient(servers={"default": server}, users={"default": [("lasote", "mypass")]})

--- a/conans/test/integration/command/inspect_test.py
+++ b/conans/test/integration/command/inspect_test.py
@@ -26,7 +26,6 @@ class ConanInspectTest(unittest.TestCase):
         self.assertIn("ERROR: Unable to find 'non-existing/version@user/channel' in remotes",
                       client.out)
 
-    @pytest.mark.xfail(reason="cache2.0 check why this is failing with conan inspect")
     def test_inspect_remote(self):
         client = TestClient(default_server_user=True)
         client.save({"conanfile.py": GenConanfile("pkg", "0.1").with_settings("os")})
@@ -40,7 +39,9 @@ class ConanInspectTest(unittest.TestCase):
         client.run("inspect pkg/0.1@user/channel -r=default -a settings")
         self.assertIn("settings: os", client.out)
         client.run("inspect pkg/0.1@user/channel -a settings")
-        self.assertIn("settings: os", client.out)
+        # we got in cache the revision from the remote but still the latest
+        # revision in cache is the last we created
+        self.assertIn("settings: ('os', 'arch')", client.out)
         client.run("remove * -f")
         client.run("inspect pkg/0.1@user/channel -a settings")
         self.assertIn("settings: os", client.out)


### PR DESCRIPTION
Changelog: Feature: Conan inspect checks for already existing revision in cache when inspecting a recipe from a remote instead of trying to install the recipe without checking.
Docs: missing (2.0)
