### PR TITLE
Filename PKG-NAME_COMP-NAME.pc for PkgConfigDeps

### DIFF
--- a/conan/tools/gnu/pkgconfigdeps.py
+++ b/conan/tools/gnu/pkgconfigdeps.py
@@ -87,9 +87,11 @@ class PkgConfigDeps(object):
             if dep.new_cpp_info.has_components:
                 components = self._get_components(dep.ref.name, dep)
                 for comp_genname, comp_cpp_info, comp_requires_gennames in components:
-                    ret["%s.pc" % comp_genname] = self._pc_file_content(
-                        "%s-%s" % (pkg_genname, comp_genname),
-                        comp_cpp_info, comp_requires_gennames, dep.package_folder, dep.ref.version)
+                    pkg_comp_genname = "%s-%s" % (pkg_genname, comp_genname)
+                    ret["%s.pc" % pkg_comp_genname] = self._pc_file_content(
+                        pkg_comp_genname, comp_cpp_info,
+                        comp_requires_gennames, dep.package_folder,
+                        dep.ref.version)
                 comp_gennames = [comp_genname for comp_genname, _, _ in components]
                 if pkg_genname not in comp_gennames:
                     ret["%s.pc" % pkg_genname] = self._global_pc_file_contents(pkg_genname,

--- a/conan/tools/gnu/pkgconfigdeps.py
+++ b/conan/tools/gnu/pkgconfigdeps.py
@@ -87,7 +87,7 @@ class PkgConfigDeps(object):
             if dep.new_cpp_info.has_components:
                 components = self._get_components(dep.ref.name, dep)
                 for comp_genname, comp_cpp_info, comp_requires_gennames in components:
-                    pkg_comp_genname = "%s_%s" % (pkg_genname, comp_genname)
+                    pkg_comp_genname = "%s-%s" % (pkg_genname, comp_genname)
                     ret["%s.pc" % pkg_comp_genname] = self._pc_file_content(
                         pkg_comp_genname, comp_cpp_info,
                         comp_requires_gennames, dep.package_folder,

--- a/conan/tools/gnu/pkgconfigdeps.py
+++ b/conan/tools/gnu/pkgconfigdeps.py
@@ -87,7 +87,7 @@ class PkgConfigDeps(object):
             if dep.new_cpp_info.has_components:
                 components = self._get_components(dep.ref.name, dep)
                 for comp_genname, comp_cpp_info, comp_requires_gennames in components:
-                    pkg_comp_genname = "%s-%s" % (pkg_genname, comp_genname)
+                    pkg_comp_genname = "%s_%s" % (pkg_genname, comp_genname)
                     ret["%s.pc" % pkg_comp_genname] = self._pc_file_content(
                         pkg_comp_genname, comp_cpp_info,
                         comp_requires_gennames, dep.package_folder,

--- a/conans/test/functional/toolchains/gnu/test_pkgconfigdeps.py
+++ b/conans/test/functional/toolchains/gnu/test_pkgconfigdeps.py
@@ -252,5 +252,5 @@ def test_custom_content_components():
     client.run("create . pkg/0.1@")
     client.run("install pkg/0.1@ -g PkgConfigDeps")
 
-    pc_content = client.load("pkg_mycomponent.pc")
+    pc_content = client.load("pkg-mycomponent.pc")
     assert "componentdir=${prefix}/mydir" in pc_content

--- a/conans/test/functional/toolchains/gnu/test_pkgconfigdeps.py
+++ b/conans/test/functional/toolchains/gnu/test_pkgconfigdeps.py
@@ -252,5 +252,5 @@ def test_custom_content_components():
     client.run("create . pkg/0.1@")
     client.run("install pkg/0.1@ -g PkgConfigDeps")
 
-    pc_content = client.load("mycomponent.pc")
+    pc_content = client.load("pkg-mycomponent.pc")
     assert "componentdir=${prefix}/mydir" in pc_content

--- a/conans/test/functional/toolchains/gnu/test_pkgconfigdeps.py
+++ b/conans/test/functional/toolchains/gnu/test_pkgconfigdeps.py
@@ -252,5 +252,5 @@ def test_custom_content_components():
     client.run("create . pkg/0.1@")
     client.run("install pkg/0.1@ -g PkgConfigDeps")
 
-    pc_content = client.load("pkg-mycomponent.pc")
+    pc_content = client.load("pkg_mycomponent.pc")
     assert "componentdir=${prefix}/mydir" in pc_content


### PR DESCRIPTION
Changelog: Fix: Use filename `[PKG-NAME]-[COMP-NAME]` for `PkgConfigDeps`.
Docs: https://github.com/conan-io/docs/pull/2148
Closes https://github.com/conan-io/conan/issues/9185

Now, we don't have any conflict for components of different packages.
* `<COMP-NAME>.pc` -> `<PKG-NAME_COMP-NAME>.pc`

- [x] Refer to the issue that supports this Pull Request.
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [x] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 

<sup>**Note:** By default this PR will skip the slower tests and will use a limited set of python versions. Check [here](https://github.com/conan-io/conan/blob/develop/.github/PR_INCREASE_TESTING.md) how to increase the testing level by writing some tags in the current PR body text.</sup>
