### PR TITLE
Extract profiles from lockfiles

### DIFF
--- a/conans/client/command.py
+++ b/conans/client/command.py
@@ -1988,6 +1988,13 @@ class Command(object):
                                                                  help='Clean modified flag')
         clean_modified_bundle_cmd.add_argument('bundle', help='Path to lockfile bundle')
 
+        profile_cmd = subparsers.add_parser('extract-profiles',
+                                            help='Extract host and build profiles from a lockfile')
+        profile_cmd.add_argument('host_profile_name', help='Path to host profile to be extracted')
+        profile_cmd.add_argument('build_profile_name', help='Path to build profile to be extracted')
+        profile_cmd.add_argument('-l', '--lockfile', action=OnceArgument,
+                                 help='Path to lockfile to be used as a base')
+
         args = parser.parse_args(*args)
         self._warn_python_version()
 
@@ -2038,6 +2045,9 @@ class Command(object):
                                     base=args.base,
                                     lockfile=args.lockfile,
                                     lockfile_out=args.lockfile_out)
+        elif args.subcommand == "extract-profiles":
+            self._conan.lock_extract_profiles(args.host_profile_name, args.build_profile_name,
+                                              args.lockfile)
 
     def _show_help(self):
         """

--- a/conans/client/conan_api.py
+++ b/conans/client/conan_api.py
@@ -1495,6 +1495,22 @@ class ConanAPIV1(object):
         graph_lock_file.save(lockfile_out)
         self.app.out.info("Generated lockfile: %s" % lockfile_out)
 
+    @api_method
+    def lock_extract_profiles(self, host_profile_name, build_profile_name, lockfile=None, cwd=None):
+        cwd = cwd or os.getcwd()
+        lockfile = lockfile or LOCKFILE
+        lockfile_path = _make_abs_path(lockfile, cwd)
+        host_profile_path = _make_abs_path(host_profile_name, cwd)
+        build_profile_path = _make_abs_path(build_profile_name, cwd)
+        revisions_enabled = self.app.config.revisions_enabled
+        lockfile_handle = GraphLockFile.load(lockfile_path, revisions_enabled)
+        if lockfile_handle.profile_host:
+            save(host_profile_path, lockfile_handle.profile_host.dumps())
+            self.app.out.info("Generated host profile: {}".format(host_profile_path))
+        if lockfile_handle.profile_build:
+            save(build_profile_path, lockfile_handle.profile_build.dumps())
+            self.app.out.info("Generated build profile: {}".format(build_profile_path))
+
 
 Conan = ConanAPIV1
 

--- a/conans/client/conan_api.py
+++ b/conans/client/conan_api.py
@@ -1497,6 +1497,13 @@ class ConanAPIV1(object):
 
     @api_method
     def lock_extract_profiles(self, host_profile_name, build_profile_name, lockfile=None, cwd=None):
+        """ Extract host and build profile from a conan lockfile
+            :param host_profile_name: File name to be used to store the host profile content
+            :param build_profile_name: File name to be used to store the build profile content
+            :param lockfile: Lockfile path to be read. When None, then is conan.lock
+            :param cwd: Current folder to locale the default lockfile. When None, then is getcwd()
+            :return: None
+        """
         cwd = cwd or os.getcwd()
         lockfile = lockfile or LOCKFILE
         lockfile_path = _make_abs_path(lockfile, cwd)


### PR DESCRIPTION
Hello!

Add the new subcommand for `lock`: `extract-profile`

    conan lock extract-profiles <host_profile> <build_profile> --lockfile=<conan.lock>

This new command read a lockfile, by default it reads `./conan.lock`, but also accepts any file path by `--lockfile` argument;

The profiles extracted are written to both file paths passed as argument. When build profile is not listed in conan.lock, the build profile file is not generated.

Changelog: Feature: Extract host and build profiles from conan.lock
Docs: TODO

closes #8684

- [x] Refer to the issue that supports this Pull Request.
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 

<sup>**Note:** By default this PR will skip the slower tests and will use a limited set of python versions. Check [here](https://github.com/conan-io/conan/blob/develop/.github/PR_INCREASE_TESTING.md) how to increase the testing level by writing some tags in the current PR body text.</sup>
