### PR TITLE
AutotoolsDeps: Allow modifying the environment before generate()

### DIFF
--- a/conan/tools/env/environment.py
+++ b/conan/tools/env/environment.py
@@ -67,6 +67,9 @@ class _EnvValue:
     def is_path(self):
         return self._path
 
+    def remove(self, value):
+        self._values.remove(value)
+
     def append(self, value, separator=None):
         if separator is not None:
             self._sep = separator
@@ -161,6 +164,9 @@ class Environment:
 
     def prepend_path(self, name, value):
         self._values.setdefault(name, _EnvValue(name, path=True)).prepend(value)
+
+    def remove(self, name, value):
+        self._values[name].remove(value)
 
     def save_bat(self, filename, generate_deactivate=False, pathsep=os.pathsep):
         deactivate = textwrap.dedent("""\
@@ -282,14 +288,8 @@ class Environment:
         return v.get_value(self._conanfile)
 
     def items(self):
+        """returns {str: str} (varname: value)"""
         return {k: v.get_value(self._conanfile) for k, v in self._values.items()}.items()
-
-    def var(self, name):
-        return self._values[name]
-
-    def var_items(self):
-        # Access to the dict items, so users can do what they want with the underlying env-var
-        return self._values.items()
 
     def __eq__(self, other):
         """

--- a/conan/tools/gnu/autotoolsdeps.py
+++ b/conan/tools/gnu/autotoolsdeps.py
@@ -6,60 +6,58 @@ from conans.model.new_build_info import NewCppInfo
 
 class AutotoolsDeps:
     def __init__(self, conanfile):
-        # Set the generic objects before mapping to env vars to let the user
-        # alter some value
         self._conanfile = conanfile
-        self._cpp_info = None
+        self._environment = None
         check_using_build_profile(self._conanfile)
 
+    def _get_cpp_info(self):
+        ret = NewCppInfo()
+        for dep in self._conanfile.dependencies.host.values():
+            dep_cppinfo = dep.new_cpp_info.copy()
+            dep_cppinfo.set_relative_base_folder(dep.package_folder)
+            # In case we have components, aggregate them, we do not support isolated
+            # "targets" with autotools
+            dep_cppinfo.aggregate_components()
+            ret.merge(dep_cppinfo)
+        return ret
+
     @property
-    def cpp_info(self):
-        if self._cpp_info is None:
-            self._cpp_info = NewCppInfo()
-            for dep in self._conanfile.dependencies.host.values():
-                dep_cppinfo = dep.new_cpp_info.copy()
-                dep_cppinfo.set_relative_base_folder(dep.package_folder)
-                # In case we have components, aggregate them, we do not support isolated
-                # "targets" with autotools
-                dep_cppinfo.aggregate_components()
-                self._cpp_info.merge(dep_cppinfo)
-        return self._cpp_info
-
     def environment(self):
-        flags = GnuDepsFlags(self._conanfile, self.cpp_info)
+        if self._environment is None:
+            flags = GnuDepsFlags(self._conanfile, self._get_cpp_info())
 
-        # cpp_flags
-        cpp_flags = []
-        cpp_flags.extend(flags.include_paths)
-        cpp_flags.extend(flags.defines)
+            # cpp_flags
+            cpp_flags = []
+            cpp_flags.extend(flags.include_paths)
+            cpp_flags.extend(flags.defines)
 
-        # Ldflags
-        ldflags = flags.sharedlinkflags
-        ldflags.extend(flags.exelinkflags)
-        ldflags.extend(flags.frameworks)
-        ldflags.extend(flags.framework_paths)
-        ldflags.extend(flags.lib_paths)
-        # FIXME: Previously we had an argument "include_rpath_flags" defaulted to False
-        ldflags.extend(flags.rpath_flags)
+            # Ldflags
+            ldflags = flags.sharedlinkflags
+            ldflags.extend(flags.exelinkflags)
+            ldflags.extend(flags.frameworks)
+            ldflags.extend(flags.framework_paths)
+            ldflags.extend(flags.lib_paths)
+            # FIXME: Previously we had an argument "include_rpath_flags" defaulted to False
+            ldflags.extend(flags.rpath_flags)
 
-        # cflags
-        cflags = flags.cflags
-        cxxflags = flags.cxxflags
+            # cflags
+            cflags = flags.cflags
+            cxxflags = flags.cxxflags
 
-        srf = flags.sysroot
-        if srf:
-            cflags.append(srf)
-            cxxflags.append(srf)
-            ldflags.append(srf)
+            srf = flags.sysroot
+            if srf:
+                cflags.append(srf)
+                cxxflags.append(srf)
+                ldflags.append(srf)
 
-        env = Environment(self._conanfile)
-        env.append("CPPFLAGS", cpp_flags)
-        env.append("LIBS", flags.libs)
-        env.append("LDFLAGS", ldflags)
-        env.append("CXXFLAGS", cxxflags)
-        env.append("CFLAGS", cflags)
-        return env
+            env = Environment(self._conanfile)
+            env.append("CPPFLAGS", cpp_flags)
+            env.append("LIBS", flags.libs)
+            env.append("LDFLAGS", ldflags)
+            env.append("CXXFLAGS", cxxflags)
+            env.append("CFLAGS", cflags)
+            self._environment = env
+        return self._environment
 
-    def generate(self, env=None, auto_activate=True):
-        env = env or self.environment()
-        env.save_script("conanautotoolsdeps", auto_activate=auto_activate)
+    def generate(self,  auto_activate=True):
+        self.environment.save_script("conanautotoolsdeps", auto_activate=auto_activate)


### PR DESCRIPTION
Changelog: Feature: The `AutotoolsDeps` allows to alter the generated environment corresponding to the information read from the dependencies before calling the `generate()` method.
Changelog: Feature: new `remove` and `items` methods for the `Environment` objects.
Docs: https://github.com/conan-io/docs/pull/2155

Close #9181
Close #9176