### PR TITLE
fix editable search

### DIFF
--- a/conans/paths/package_layouts/package_editable_layout.py
+++ b/conans/paths/package_layouts/package_editable_layout.py
@@ -63,3 +63,6 @@ class PackageEditableLayout(object):
 
     def get_path(self, package_id=None, path=None):
         raise ConanException("Operation not allowed on a package installed as editable")
+
+    def package_ids(self):
+        raise ConanException("Package in editable mode cannot list binaries")

--- a/conans/test/integration/editable/editable_add_test.py
+++ b/conans/test/integration/editable/editable_add_test.py
@@ -3,6 +3,7 @@ import textwrap
 import unittest
 
 from conans.model.ref import ConanFileReference
+from conans.test.assets.genconanfile import GenConanfile
 from conans.test.utils.tools import TestClient
 
 
@@ -77,3 +78,11 @@ class CreateEditablePackageTest(unittest.TestCase):
         self.assertIn("Reference 'lib/version@user/name' in editable mode", t.out)
         t.run('install {}'.format(ref))
         self.assertIn("Installing package: {}".format(ref), t.out)
+
+    def test_search(self):
+        t = TestClient()
+        t.save({'conanfile.py': GenConanfile()})
+        t.run('editable add . "lib/0.1@"')
+        t.run('search lib/0.1@', assert_error=True)
+        assert "Package in editable mode cannot list binaries" in t.out
+


### PR DESCRIPTION
Changelog: Fix: Improve error message when ``conan search <ref>`` a package in editable mode.
Docs: Omit


Fix https://github.com/conan-io/conan/issues/9261