### PR TITLE
Allow defining settings for a downstream consumer

### DIFF
--- a/conans/client/graph/graph_builder.py
+++ b/conans/client/graph/graph_builder.py
@@ -368,7 +368,6 @@ class DepsGraphBuilder(object):
 
         locked_id = requirement.locked_id
         lock_py_requires = graph_lock.python_requires(locked_id) if locked_id is not None else None
-
         dep_conanfile = self._loader.load_conanfile(conanfile_path, profile, ref=requirement.ref,
                                                     lock_python_requires=lock_py_requires)
         if recipe_status == RECIPE_EDITABLE:

--- a/conans/client/graph/graph_builder.py
+++ b/conans/client/graph/graph_builder.py
@@ -368,6 +368,7 @@ class DepsGraphBuilder(object):
 
         locked_id = requirement.locked_id
         lock_py_requires = graph_lock.python_requires(locked_id) if locked_id is not None else None
+
         dep_conanfile = self._loader.load_conanfile(conanfile_path, profile, ref=requirement.ref,
                                                     lock_python_requires=lock_py_requires)
         if recipe_status == RECIPE_EDITABLE:

--- a/conans/client/loader.py
+++ b/conans/client/loader.py
@@ -172,7 +172,7 @@ class ConanFileLoader(object):
         return conanfile
 
     @staticmethod
-    def _initialize_conanfile(conanfile, profile, is_consumer):
+    def _initialize_conanfile(conanfile, profile):
         # Prepare the settings for the loaded conanfile
         # Mixing the global settings with the specified for that name if exist
         tmp_settings = profile.processed_settings.copy()
@@ -187,7 +187,7 @@ class ConanFileLoader(object):
             # TODO: Conan 2.0: We probably want to remove this, and leave a pure fnmatch
             pkg_settings = package_settings_values.get(conanfile.name)
 
-            if is_consumer and "$" in package_settings_values:
+            if conanfile.develop and "$" in package_settings_values:
                 # "$" overrides the "name" scoped settings.
                 pkg_settings = package_settings_values.get("$")
 
@@ -217,10 +217,10 @@ class ConanFileLoader(object):
         conanfile.output.scope = conanfile.display_name
         conanfile.in_local_cache = False
         try:
-            self._initialize_conanfile(conanfile, profile_host, is_consumer=True)
+            conanfile.develop = True
+            self._initialize_conanfile(conanfile, profile_host)
 
             # The consumer specific
-            conanfile.develop = True
             profile_host.user_options.descope_options(conanfile.name)
             conanfile.options.initialize_upstream(profile_host.user_options,
                                                   name=conanfile.name)
@@ -249,7 +249,7 @@ class ConanFileLoader(object):
         if profile.dev_reference and profile.dev_reference == ref:
             conanfile.develop = True
         try:
-            self._initialize_conanfile(conanfile, profile, is_consumer=False)
+            self._initialize_conanfile(conanfile, profile)
             return conanfile
         except ConanInvalidConfiguration:
             raise

--- a/conans/test/functional/configuration/profile_test.py
+++ b/conans/test/functional/configuration/profile_test.py
@@ -729,12 +729,14 @@ def test_consumer_specific_settings():
     client.run("install . -s dep:build_type=Debug")
     assert "I'm dep and my build type is Debug" in client.out
 
-    # Now the consumer using $
-    client.run("install . -s $:build_type=Debug  -g CMakeToolchain")
-    assert "I'm dep and my build type is Release" in client.out
-    # Verify the cmake toolchain takes Debug
-    contents = client.load("conan_toolchain.cmake")
-    assert 'set(CMAKE_BUILD_TYPE "Debug"' in contents
+    # Test that the generators take the setting
+    if platform.system() != "Windows":  # Toolchain in windows is multiconfig
+        # Now the consumer using $
+        client.run("install . -s $:build_type=Debug  -g CMakeToolchain")
+        assert "I'm dep and my build type is Release" in client.out
+        # Verify the cmake toolchain takes Debug
+        contents = client.load("conan_toolchain.cmake")
+        assert 'set(CMAKE_BUILD_TYPE "Debug"' in contents
 
 
 def test_consumer_specific_settings_from_profile():


### PR DESCRIPTION
Changelog: Feature: Now it is possible to define settings for a downstream consumer using `-s &:setting=value` or the same syntax in the profile even if the consumer is a `conanfile.txt` or a `conanfile.py` not declaring a name. e.g: Building a Debug application with Release dependencies: `-s build_type=Release -s &:build_type=Debug`
Docs: https://github.com/conan-io/docs/pull/2160

Close #9143