### PR TITLE
cmake_layout add bindirs

### DIFF
--- a/conan/tools/layout/__init__.py
+++ b/conan/tools/layout/__init__.py
@@ -26,8 +26,10 @@ def cmake_layout(conanfile, generator=None):
     conanfile.cpp.source.includedirs = ["."]
     if multi:
         conanfile.cpp.build.libdirs = ["{}".format(conanfile.settings.build_type)]
+        conanfile.cpp.build.bindirs = ["{}".format(conanfile.settings.build_type)]
     else:
         conanfile.cpp.build.libdirs = ["."]
+        conanfile.cpp.build.bindirs = ["."]
 
 
 def clion_layout(conanfile):

--- a/conans/test/functional/layout/test_editable_cmake.py
+++ b/conans/test/functional/layout/test_editable_cmake.py
@@ -3,8 +3,10 @@ import platform
 
 import pytest
 
+from conan.tools.env.environment import environment_wrap_command
 from conans.test.assets.pkg_cmake import pkg_cmake, pkg_cmake_app
 from conans.test.assets.sources import gen_function_cpp
+from conans.test.utils.mocks import ConanFileMock
 from conans.test.utils.tools import TestClient
 
 
@@ -19,12 +21,15 @@ def editable_cmake(generator):
     c.save(pkg_cmake_app("pkg", "0.1", requires=["dep/0.1"]),
            path=os.path.join(c.current_folder, "pkg"))
 
-    with c.chdir("dep"):
-        c.run("editable add . dep/0.1@")
+    def build_dep():
         c.run("install .")
         c.run("build .")
         c.run("install . -s build_type=Debug")
         c.run("build .")
+
+    with c.chdir("dep"):
+        c.run("editable add . dep/0.1@")
+        build_dep()
 
     def build_pkg(msg):
         c.run("build . -if=install_release")
@@ -46,10 +51,7 @@ def editable_cmake(generator):
     # Do a source change in the editable!
     with c.chdir("dep"):
         c.save({"src/dep.cpp": gen_function_cpp(name="dep", msg="SUPERDEP")})
-        c.run("install .")
-        c.run("build .")
-        c.run("install . -s build_type=Debug")
-        c.run("build .")
+        build_dep()
 
     with c.chdir("pkg"):
         build_pkg("SUPERDEP")
@@ -80,3 +82,69 @@ def test_editable_cmake_linux(generator):
 @pytest.mark.tool_cmake(version="3.19")
 def test_editable_cmake_osx(generator):
     editable_cmake(generator)
+
+
+def editable_cmake_exe(generator):
+    multi = (generator is None and platform.system() == "Windows") or \
+            generator in ("Ninja Multi-Config", "Xcode")
+    c = TestClient()
+    print(c.current_folder)
+    if generator is not None:
+        c.save({"global.conf": "tools.cmake.cmaketoolchain:generator={}".format(generator)},
+               path=os.path.join(c.cache.cache_folder))
+    c.save(pkg_cmake("dep", "0.1", exe=True), path=os.path.join(c.current_folder, "dep"))
+
+    def build_dep():
+        c.run("install . -o dep:shared=True")
+        c.run("build .")
+        c.run("install . -s build_type=Debug -o dep:shared=True")
+        c.run("build .")
+
+    with c.chdir("dep"):
+        c.run("editable add . dep/0.1@")
+        build_dep()
+
+    def run_pkg(msg):
+        # FIXME: This only works with ``--install-folder``, layout() will break this
+        cmd_release = environment_wrap_command(ConanFileMock(), "install_release/conanrunenv",
+                                               "dep_app", cwd=c.current_folder)
+        c.run_command(cmd_release)
+        assert "{}: Release!".format(msg) in c.out
+        cmd_release = environment_wrap_command(ConanFileMock(), "install_debug/conanrunenv",
+                                               "dep_app", cwd=c.current_folder)
+        c.run_command(cmd_release)
+        assert "{}: Debug!".format(msg) in c.out
+
+    with c.chdir("pkg"):
+        c.run("install dep/0.1@ -o dep:shared=True -if=install_release -g VirtualRunEnv")
+        c.run("install dep/0.1@ -o dep:shared=True -if=install_debug -s build_type=Debug "
+              "-g VirtualRunEnv")
+        run_pkg("dep")
+
+    # Do a source change in the editable!
+    with c.chdir("dep"):
+        c.save({"src/dep.cpp": gen_function_cpp(name="dep", msg="SUPERDEP")})
+        build_dep()
+
+    with c.chdir("pkg"):
+        run_pkg("SUPERDEP")
+
+
+@pytest.mark.skipif(platform.system() != "Windows", reason="Only windows")
+@pytest.mark.parametrize("generator", [None, "MinGW Makefiles"])
+@pytest.mark.tool_mingw64
+def test_editable_cmake_windows_exe(generator):
+    editable_cmake_exe(generator)
+
+
+@pytest.mark.skipif(platform.system() != "Linux", reason="Only linux")
+@pytest.mark.parametrize("generator", [None, "Ninja", "Ninja Multi-Config"])
+def test_editable_cmake_linux_exe(generator):
+    editable_cmake_exe(generator)
+
+
+@pytest.mark.skipif(platform.system() != "Darwin", reason="Requires Macos")
+@pytest.mark.parametrize("generator", [None, "Ninja", "Xcode"])
+@pytest.mark.tool_cmake(version="3.19")
+def test_editable_cmake_osx_exe(generator):
+    editable_cmake_exe(generator)

--- a/conans/test/functional/layout/test_editable_cmake.py
+++ b/conans/test/functional/layout/test_editable_cmake.py
@@ -85,10 +85,9 @@ def test_editable_cmake_osx(generator):
 
 
 def editable_cmake_exe(generator):
-    multi = (generator is None and platform.system() == "Windows") or \
-            generator in ("Ninja Multi-Config", "Xcode")
+    # This test works because it is not multi-config or single config, but explicit in
+    # --install folder
     c = TestClient()
-    print(c.current_folder)
     if generator is not None:
         c.save({"global.conf": "tools.cmake.cmaketoolchain:generator={}".format(generator)},
                path=os.path.join(c.cache.cache_folder))


### PR DESCRIPTION
Changelog: Fix: Add ``bindirs`` definition to ``cmake_layout()``.
Docs: Omit
