### PR TITLE
Feature/list package revisions

### DIFF
--- a/conans/cli/commands/list.py
+++ b/conans/cli/commands/list.py
@@ -1,7 +1,7 @@
 import json
 
-from conans.cli.output import cli_out_write
 from conans.cli.command import conan_command, conan_subcommand, Extender, COMMAND_GROUPS
+from conans.cli.output import cli_out_write
 from conans.client.output import Color
 from conans.util.dates import iso8601_to_str
 

--- a/conans/cli/commands/list.py
+++ b/conans/cli/commands/list.py
@@ -31,7 +31,7 @@ def list_recipes_cli_formatter(results):
                 cli_out_write(current_recipe, fg=recipe_color, indentation=2)
 
             reference = recipe["id"]
-            cli_out_write(reference, fg=reference_color, indentation=2)
+            cli_out_write(reference, fg=reference_color, indentation=4)
 
 
 def _list_revisions_cli_formatter(results, is_package=False):

--- a/conans/cli/commands/list.py
+++ b/conans/cli/commands/list.py
@@ -5,7 +5,6 @@ from conans.cli.output import cli_out_write
 from conans.client.output import Color
 from conans.util.dates import iso8601_to_str
 
-indentation = 2
 remote_color = Color.BRIGHT_BLUE
 recipe_color = Color.BRIGHT_WHITE
 reference_color = Color.WHITE
@@ -20,19 +19,19 @@ def list_recipes_cli_formatter(results):
         if not remote_results.get("remote"):
             cli_out_write("Local Cache:", remote_color)
         else:
-            cli_out_write("{}:".format(remote_results["remote"]), remote_color)
+            cli_out_write(f"{remote_results['remote']}:", fg=remote_color)
 
         if not remote_results.get("results"):
-            cli_out_write("{}There are no matching recipes".format(" " * indentation))
+            cli_out_write("There are no matching recipes", indentation=2)
 
         current_recipe = None
         for recipe in remote_results["results"]:
             if recipe["name"] != current_recipe:
                 current_recipe = recipe["name"]
-                cli_out_write("{}{}".format(" " * indentation, current_recipe), recipe_color)
+                cli_out_write(current_recipe, fg=recipe_color, indentation=2)
 
             reference = recipe["id"]
-            cli_out_write("{}{}".format(" " * (indentation * 2), reference), reference_color)
+            cli_out_write(reference, fg=reference_color, indentation=2)
 
 
 def _list_revisions_cli_formatter(results, is_package=False):
@@ -42,20 +41,19 @@ def _list_revisions_cli_formatter(results, is_package=False):
             return
 
         if not remote_results.get("remote"):
-            cli_out_write("Local Cache:", remote_color)
+            cli_out_write("Local Cache:", fg=remote_color)
         else:
-            cli_out_write("{}:".format(remote_results["remote"]), remote_color)
+            cli_out_write(f"{remote_results['remote']}:", fg=remote_color)
 
-        tab_space = " " * indentation
         if not remote_results.get("results"):
             ref_type = "packages" if is_package else "recipes"
-            cli_out_write(f"{tab_space}There are no matching {ref_type}")
+            cli_out_write(f"There are no matching {ref_type}", indentation=2)
 
         reference = remote_results["package_reference" if is_package else "reference"]
         for revisions in remote_results["results"]:
             rev = revisions["revision"]
             date = iso8601_to_str(revisions["time"])
-            cli_out_write(f"{tab_space}{reference}#{rev} ({date})", recipe_color)
+            cli_out_write(f"{reference}#{rev} ({date})", fg=recipe_color, indentation=2)
 
 
 def list_recipe_revisions_cli_formatter(results):
@@ -161,7 +159,7 @@ def list_recipe_revisions(conan_api, parser, subparser, *args):
         result = {
             'remote': None,
             'reference': args.reference,
-            'results': conan_api.get_revisions(args.reference)
+            'results': conan_api.get_recipe_revisions(args.reference)
         }
         results.append(result)
 
@@ -169,7 +167,7 @@ def list_recipe_revisions(conan_api, parser, subparser, *args):
         result = {
             'remote': remote.name,
             'reference': args.reference,
-            'results': conan_api.get_revisions(args.reference, remote=remote)
+            'results': conan_api.get_recipe_revisions(args.reference, remote=remote)
         }
         results.append(result)
 
@@ -195,7 +193,7 @@ def list_package_revisions(conan_api, parser, subparser, *args):
         result = {
             'remote': None,
             'package_reference': args.package_reference,
-            'results': conan_api.get_revisions(args.package_reference, is_package=True)
+            'results': conan_api.get_package_revisions(args.package_reference)
         }
         results.append(result)
 
@@ -203,7 +201,7 @@ def list_package_revisions(conan_api, parser, subparser, *args):
         result = {
             'remote': remote.name,
             'package_reference': args.package_reference,
-            'results': conan_api.get_revisions(args.package_reference, is_package=True, remote=remote)
+            'results': conan_api.get_package_revisions(args.package_reference, remote=remote)
         }
         results.append(result)
 

--- a/conans/cli/commands/list.py
+++ b/conans/cli/commands/list.py
@@ -35,7 +35,7 @@ def list_recipes_cli_formatter(results):
             cli_out_write("{}{}".format(" " * (indentation * 2), reference), reference_color)
 
 
-def _list_revisions_cli_formatter(results, ref_type="recipes"):
+def _list_revisions_cli_formatter(results, is_package=False):
     for remote_results in results:
         if remote_results.get("error"):
             # TODO: Handle errors
@@ -48,9 +48,10 @@ def _list_revisions_cli_formatter(results, ref_type="recipes"):
 
         tab_space = " " * indentation
         if not remote_results.get("results"):
+            ref_type = "packages" if is_package else "recipes"
             cli_out_write(f"{tab_space}There are no matching {ref_type}")
 
-        reference = remote_results["package_reference"]
+        reference = remote_results["package_reference" if is_package else "reference"]
         for revisions in remote_results["results"]:
             rev = revisions["revision"]
             date = iso8601_to_str(revisions["time"])
@@ -62,7 +63,7 @@ def list_recipe_revisions_cli_formatter(results):
 
 
 def list_package_revisions_cli_formatter(results):
-    _list_revisions_cli_formatter(results, ref_type="packages")
+    _list_revisions_cli_formatter(results, is_package=True)
 
 
 # FIXME: it's a general formatter, perhaps we should look for another module
@@ -160,7 +161,7 @@ def list_recipe_revisions(conan_api, parser, subparser, *args):
         result = {
             'remote': None,
             'reference': args.reference,
-            'results': conan_api.get_local_recipe_revisions(args.reference)
+            'results': conan_api.get_revisions(args.reference)
         }
         results.append(result)
 
@@ -168,7 +169,7 @@ def list_recipe_revisions(conan_api, parser, subparser, *args):
         result = {
             'remote': remote.name,
             'reference': args.reference,
-            'results': conan_api.get_remote_recipe_revisions(args.reference, remote=remote)
+            'results': conan_api.get_revisions(args.reference, remote=remote)
         }
         results.append(result)
 
@@ -194,7 +195,7 @@ def list_package_revisions(conan_api, parser, subparser, *args):
         result = {
             'remote': None,
             'package_reference': args.package_reference,
-            'results': conan_api.get_local_package_revisions(args.package_reference)
+            'results': conan_api.get_revisions(args.package_reference, is_package=True)
         }
         results.append(result)
 
@@ -202,8 +203,7 @@ def list_package_revisions(conan_api, parser, subparser, *args):
         result = {
             'remote': remote.name,
             'package_reference': args.package_reference,
-            'results': conan_api.get_remote_package_revisions(args.package_reference,
-                                                              remote=remote)
+            'results': conan_api.get_revisions(args.package_reference, is_package=True, remote=remote)
         }
         results.append(result)
 

--- a/conans/cli/commands/list.py
+++ b/conans/cli/commands/list.py
@@ -34,7 +34,7 @@ def list_recipes_cli_formatter(results):
             cli_out_write(reference, fg=reference_color, indentation=4)
 
 
-def _list_revisions_cli_formatter(results, is_package=False):
+def _list_revisions_cli_formatter(results, ref_type):
     for remote_results in results:
         if remote_results.get("error"):
             # TODO: Handle errors
@@ -46,10 +46,9 @@ def _list_revisions_cli_formatter(results, is_package=False):
             cli_out_write(f"{remote_results['remote']}:", fg=remote_color)
 
         if not remote_results.get("results"):
-            ref_type = "packages" if is_package else "recipes"
             cli_out_write(f"There are no matching {ref_type}", indentation=2)
 
-        reference = remote_results["package_reference" if is_package else "reference"]
+        reference = remote_results["package_reference" if ref_type == "packages" else "reference"]
         for revisions in remote_results["results"]:
             rev = revisions["revision"]
             date = iso8601_to_str(revisions["time"])
@@ -57,11 +56,11 @@ def _list_revisions_cli_formatter(results, is_package=False):
 
 
 def list_recipe_revisions_cli_formatter(results):
-    _list_revisions_cli_formatter(results)
+    _list_revisions_cli_formatter(results, "recipes")
 
 
 def list_package_revisions_cli_formatter(results):
-    _list_revisions_cli_formatter(results, is_package=True)
+    _list_revisions_cli_formatter(results, "packages")
 
 
 # FIXME: it's a general formatter, perhaps we should look for another module

--- a/conans/cli/commands/list.py
+++ b/conans/cli/commands/list.py
@@ -10,20 +10,23 @@ recipe_color = Color.BRIGHT_WHITE
 reference_color = Color.WHITE
 
 
+def _print_common_list_cli_output(results, ref_type):
+    if results.get("error"):
+        # TODO: Handle errors
+        return
+
+    if results.get("remote"):
+        cli_out_write(f"{results['remote']}:", fg=remote_color)
+    else:
+        cli_out_write("Local Cache:", remote_color)
+
+    if not results.get("results"):
+        cli_out_write(f"There are no matching {ref_type}", indentation=2)
+
+
 def list_recipes_cli_formatter(results):
     for remote_results in results:
-        if remote_results.get("error"):
-            # TODO: Handle errors
-            return
-
-        if not remote_results.get("remote"):
-            cli_out_write("Local Cache:", remote_color)
-        else:
-            cli_out_write(f"{remote_results['remote']}:", fg=remote_color)
-
-        if not remote_results.get("results"):
-            cli_out_write("There are no matching recipes", indentation=2)
-
+        _print_common_list_cli_output(remote_results, "recipes")
         current_recipe = None
         for recipe in remote_results["results"]:
             if recipe["name"] != current_recipe:
@@ -36,18 +39,7 @@ def list_recipes_cli_formatter(results):
 
 def _list_revisions_cli_formatter(results, ref_type):
     for remote_results in results:
-        if remote_results.get("error"):
-            # TODO: Handle errors
-            return
-
-        if not remote_results.get("remote"):
-            cli_out_write("Local Cache:", fg=remote_color)
-        else:
-            cli_out_write(f"{remote_results['remote']}:", fg=remote_color)
-
-        if not remote_results.get("results"):
-            cli_out_write(f"There are no matching {ref_type}", indentation=2)
-
+        _print_common_list_cli_output(remote_results, ref_type)
         reference = remote_results["package_reference" if ref_type == "packages" else "reference"]
         for revisions in remote_results["results"]:
             rev = revisions["revision"]

--- a/conans/cli/commands/list.py
+++ b/conans/cli/commands/list.py
@@ -62,6 +62,33 @@ def list_recipe_revisions_cli_formatter(results):
             )
 
 
+def list_package_revisions_cli_formatter(results):
+    for remote_results in results:
+        if remote_results.get("error"):
+            # TODO: Handle errors
+            return
+
+        if not remote_results.get("remote"):
+            cli_out_write("Local Cache:", remote_color)
+        else:
+            cli_out_write("{}:".format(remote_results["remote"]), remote_color)
+
+        if not remote_results.get("results"):
+            cli_out_write("{}There are no matching recipes".format(" " * indentation))
+
+        reference = remote_results["package_reference"]
+        for revisions in remote_results["results"]:
+            cli_out_write(
+                "{}{}#{} ({})".format(
+                    " " * indentation,
+                    reference,
+                    revisions["revision"],
+                    iso8601_to_str(revisions["time"])
+                ),
+                recipe_color
+            )
+
+
 def json_formatter(info):
     myjson = json.dumps(info, indent=4)
     cli_out_write(myjson)
@@ -73,6 +100,10 @@ list_recipes_formatters = {
 }
 list_recipe_revisions_formatters = {
     "cli": list_recipe_revisions_cli_formatter,
+    "json": json_formatter
+}
+list_package_revisions_formatters = {
+    "cli": list_package_revisions_cli_formatter,
     "json": json_formatter
 }
 
@@ -114,18 +145,22 @@ def list_recipes(conan_api, parser, subparser, *args):
     return results
 
 
+def _add_common_list_subcommands(subparser, positional_arg_name):
+    subparser.add_argument(positional_arg_name)
+    remotes_group = subparser.add_mutually_exclusive_group()
+    remotes_group.add_argument("-r", "--remote", default=None, action=Extender,
+                               help="Name of the remote to add")
+    remotes_group.add_argument("-a", "--all-remotes", action='store_true',
+                               help="Search in all the remotes")
+    subparser.add_argument("-c", "--cache", action='store_true', help="Search in the local cache")
+
+
 @conan_subcommand(formatters=list_recipe_revisions_formatters)
 def list_recipe_revisions(conan_api, parser, subparser, *args):
     """
     List all the revisions of a recipe
     """
-    subparser.add_argument("reference")
-    remotes_group = subparser.add_mutually_exclusive_group()
-    remotes_group.add_argument("-r", "--remote", default=None, action=Extender,
-                           help="Name of the remote to add")
-    remotes_group.add_argument("-a", "--all-remotes", action='store_true',
-                           help="Search in all the remotes")
-    subparser.add_argument("-c", "--cache", action='store_true', help="Search in the local cache")
+    _add_common_list_subcommands(subparser, "reference")
     args = parser.parse_args(*args)
 
     if not args.cache and not args.remote and not args.all_remotes:
@@ -152,6 +187,45 @@ def list_recipe_revisions(conan_api, parser, subparser, *args):
                 'remote': remote.name,
                 'reference': args.reference,
                 'results': conan_api.get_remote_recipe_revisions(args.reference, remote=remote)
+            }
+            results.append(result)
+
+    return results
+
+
+@conan_subcommand(formatters=list_package_revisions_formatters)
+def list_package_revisions(conan_api, parser, subparser, *args):
+    """
+    List all the revisions of a package ID
+    """
+    _add_common_list_subcommands(subparser, "package_reference")
+    args = parser.parse_args(*args)
+
+    if not args.cache and not args.remote and not args.all_remotes:
+        # If neither remote nor cache are defined, show results only from cache
+        args.cache = True
+
+    remotes = None
+    if args.all_remotes:
+        remotes = conan_api.get_active_remotes(None)
+    elif args.remote:
+        remotes = conan_api.get_active_remotes(args.remote)
+
+    results = []
+    if args.cache:
+        result = {
+            'remote': None,
+            'package_reference': args.package_reference,
+            'results': conan_api.get_local_package_revisions(args.package_reference)
+        }
+        results.append(result)
+    if remotes:
+        for remote in remotes:
+            result = {
+                'remote': remote.name,
+                'package_reference': args.package_reference,
+                'results': conan_api.get_remote_package_revisions(args.package_reference,
+                                                                  remote=remote)
             }
             results.append(result)
 

--- a/conans/cli/output.py
+++ b/conans/cli/output.py
@@ -155,6 +155,8 @@ class ConanOutput(object):
             return True
 
 
-def cli_out_write(data, fg=None, bg=None, endline="\n"):
-    data = "{}{}{}{}{}".format(fg or '', bg or '', data, Style.RESET_ALL, endline)
+def cli_out_write(data, fg=None, bg=None, endline="\n", indentation=0):
+    fg_ = fg or ''
+    bg_ = bg or ''
+    data = f"{' ' * indentation}{fg_}{bg_}{data}{Style.RESET_ALL}{endline}"
     sys.stdout.write(data)

--- a/conans/client/api/conan_api.py
+++ b/conans/client/api/conan_api.py
@@ -4,7 +4,6 @@ import time
 from tqdm import tqdm
 
 import conans
-from conan.cache.conan_reference import ConanReference
 from conans import __version__ as client_version
 from conans.cli.output import ConanOutput
 from conans.client.api.helpers.search import Search

--- a/conans/client/api/conan_api.py
+++ b/conans/client/api/conan_api.py
@@ -239,16 +239,13 @@ class ConanAPIV2(object):
         data["results"] = results
         return data
 
-    def _get_revisions(self, reference, ref_type, remote=None):
-        if ref_type == "package":
-            ref = PackageReference.loads(reference)
+    def _get_revisions(self, ref, remote=None):
+        if isinstance(ref, PackageReference):
+            method_name = 'get_package_revisions'
+        elif isinstance(ref, ConanFileReference):
+            method_name = 'get_recipe_revisions'
         else:
-            ref = ConanFileReference.loads(reference)
-
-        # Class method name to get the specific revisions
-        method_name = f"get_{ref_type}_revisions"
-        if ref.revision:
-            raise ConanException(f"Cannot list the revisions of a specific {ref_type} revision")
+            raise ConanException(f"Unknown reference type: {ref}")
 
         # Let's get all the revisions from a remote server
         if remote:
@@ -275,11 +272,19 @@ class ConanAPIV2(object):
 
     @api_method
     def get_package_revisions(self, reference, remote=None):
-        return self._get_revisions(reference, 'package', remote=remote)
+        ref = PackageReference.loads(reference)
+        if ref.revision:
+            raise ConanException(f"Cannot list the revisions of a specific package revision")
+
+        return self._get_revisions(ref, remote=remote)
 
     @api_method
     def get_recipe_revisions(self, reference, remote=None):
-        return self._get_revisions(reference, 'recipe', remote=remote)
+        ref = ConanFileReference.loads(reference)
+        if ref.revision:
+            raise ConanException(f"Cannot list the revisions of a specific recipe revision")
+
+        return self._get_revisions(ref, remote=remote)
 
 
 Conan = ConanAPIV2

--- a/conans/client/api/conan_api.py
+++ b/conans/client/api/conan_api.py
@@ -239,14 +239,11 @@ class ConanAPIV2(object):
         data["results"] = results
         return data
 
-    @api_method
-    def get_revisions(self, reference, is_package=False, remote=None):
-        if is_package:
+    def _get_revisions(self, reference, ref_type, remote=None):
+        if ref_type == "package":
             ref = PackageReference.loads(reference)
-            ref_type = "package"
         else:
             ref = ConanFileReference.loads(reference)
-            ref_type = "recipe"
 
         # Class method name to get the specific revisions
         method_name = f"get_{ref_type}_revisions"
@@ -275,6 +272,14 @@ class ConanAPIV2(object):
                 }
                 results.append(result)
             return results
+
+    @api_method
+    def get_package_revisions(self, reference, remote=None):
+        return self._get_revisions(reference, 'package', remote=remote)
+
+    @api_method
+    def get_recipe_revisions(self, reference, remote=None):
+        return self._get_revisions(reference, 'recipe', remote=remote)
 
 
 Conan = ConanAPIV2

--- a/conans/test/integration/command_v2/list_package_revisions_test.py
+++ b/conans/test/integration/command_v2/list_package_revisions_test.py
@@ -85,7 +85,7 @@ class TestListRecipesFromRemotes(TestListRecipeRevisionsBase):
 
         expected_output = textwrap.dedent("""\
         Local Cache:
-          There are no matching recipes
+          There are no matching packages
         """)
 
         self.client.run(f"list package-revisions {self._get_fake_package_refence('whatever/0.1')}")
@@ -97,11 +97,11 @@ class TestListRecipesFromRemotes(TestListRecipeRevisionsBase):
 
         expected_output = textwrap.dedent("""\
         Local Cache:
-          There are no matching recipes
+          There are no matching packages
         remote1:
-          There are no matching recipes
+          There are no matching packages
         remote2:
-          There are no matching recipes
+          There are no matching packages
         """)
 
         pref = self._get_fake_package_refence('whatever/0.1')
@@ -156,7 +156,7 @@ class TestRemotes(TestListRecipeRevisionsBase):
         remote1:
           {repr(pref)}#.*
         remote2:
-          There are no matching recipes""")
+          There are no matching packages""")
         assert bool(re.match(expected_output, output, re.MULTILINE))
 
     def test_search_in_missing_remote(self):

--- a/conans/test/integration/command_v2/list_package_revisions_test.py
+++ b/conans/test/integration/command_v2/list_package_revisions_test.py
@@ -1,0 +1,186 @@
+import re
+
+import pytest
+
+from conans.test.assets.genconanfile import GenConanfile
+from conans.test.utils.tools import TestClient, TestServer
+
+
+class TestListRecipeRevisionsBase:
+    @pytest.fixture(autouse=True)
+    def _setup(self):
+        self.users = {}
+        self.client = TestClient()
+
+    def _add_remote(self, remote_name):
+        self.client.servers[remote_name] = TestServer(users={"username": "passwd"},
+                                                      write_permissions=[("*/*@*/*", "*")])
+        self.client.update_servers()
+        self.client.run("user username -p passwd -r {}".format(remote_name))
+
+    def _create_recipe(self, reference):
+        self.client.save({'conanfile.py': GenConanfile()})
+        self.client.run("create . {}".format(reference))
+
+    def _upload_recipe(self, remote, reference):
+        self.client.save({'conanfile.py': GenConanfile()})
+        self.client.run("export . {}".format(reference))
+        self.client.run("upload --force -r {} {}".format(remote, reference))
+
+    @staticmethod
+    def _get_package_refence(recipe_name):
+        return f"{recipe_name}#fca0383e6a43348f7989f11ab8f0a92d:3fb49604f9c2f729b85ba3115852006824e72cab"
+
+
+class TestParams(TestListRecipeRevisionsBase):
+    def test_fail_if_reference_is_not_correct(self):
+        self.client.run("list package-revisions whatever", assert_error=True)
+        assert "ERROR: Specify the 'name' and the 'version'" in self.client.out
+
+        self.client.run("list package-revisions whatever/", assert_error=True)
+        assert "ERROR: Specify the 'name' and the 'version'" in self.client.out
+
+        self.client.run("list package-revisions whatever/1", assert_error=True)
+        assert "ERROR: Value provided for package version, '1' (type Version), is too short" in self.client.out
+
+    def test_query_param_is_required(self):
+        self._add_remote("remote1")
+
+        self.client.run("list package-revisions", assert_error=True)
+        assert "error: the following arguments are required: package_reference" in self.client.out
+
+        self.client.run("list package-revisions -c", assert_error=True)
+        assert "error: the following arguments are required: package_reference" in self.client.out
+
+        self.client.run("list package-revisions --all-remotes", assert_error=True)
+        assert "error: the following arguments are required: package_reference" in self.client.out
+
+        self.client.run("list package-revisions --remote remote1 --cache", assert_error=True)
+        assert "error: the following arguments are required: package_reference" in self.client.out
+
+    def test_remote_and_all_remotes_are_mutually_exclusive(self):
+        self._add_remote("remote1")
+
+        self.client.run("list package-revisions --all-remotes --remote remote1 package/1.0", assert_error=True)
+        assert "error: argument -r/--remote: not allowed with argument -a/--all-remotes" in self.client.out
+
+
+class TestListRecipesFromRemotes(TestListRecipeRevisionsBase):
+    def test_by_default_search_only_in_cache(self):
+        self._add_remote("remote1")
+        self._add_remote("remote2")
+
+        expected_output = ("Local Cache:\n"
+                           "  There are no matching recipes\n")
+
+        self.client.run(f"list package-revisions {self._get_package_refence('whatever/0.1')}")
+        assert expected_output == self.client.out
+
+    def test_search_no_matching_recipes(self):
+        self._add_remote("remote1")
+        self._add_remote("remote2")
+
+        expected_output = ("Local Cache:\n"
+                           "  There are no matching recipes\n"
+                           "remote1:\n"
+                           "  There are no matching recipes\n"
+                           "remote2:\n"
+                           "  There are no matching recipes\n")
+
+        self.client.run(f"list package-revisions -c -a {self._get_package_refence('whatever/0.1')}")
+        assert expected_output == self.client.out
+
+    def test_fail_if_no_configured_remotes(self):
+        self.client.run("list package-revisions -a whatever/1.0", assert_error=True)
+        assert "ERROR: The remotes registry is empty" in self.client.out
+
+    def test_search_disabled_remote(self):
+        self._add_remote("remote1")
+        self.client.run("remote disable remote1")
+        self.client.run(f"list package-revisions -r remote1 {self._get_package_refence('whatever/0.1')}", assert_error=True)
+        assert "ERROR: Remote 'remote1' is disabled" in self.client.out
+
+
+class TestRemotes(TestListRecipeRevisionsBase):
+    def test_search_with_full_reference(self):
+        remote_name = "remote1"
+        recipe_name = "test_recipe/1.0.0@user/channel"
+        self._add_remote(remote_name)
+        self._upload_recipe(remote_name, recipe_name)
+
+        self.client.run(f"list package-revisions -r remote1 {self._get_package_refence(recipe_name)}")
+
+        expected_output = (
+            r"remote1:\n"
+            r"  {}#.*\n".format(recipe_name)
+        )
+
+        assert bool(re.match(expected_output, str(self.client.out), re.MULTILINE))
+
+    def test_search_without_user_and_channel(self):
+        remote_name = "remote1"
+        recipe_name = "test_recipe/1.0.0@user/channel"
+        self._add_remote(remote_name)
+        self._upload_recipe(remote_name, recipe_name)
+
+        self.client.run(f"list package-revisions -r remote1 {self._get_package_refence(recipe_name)}")
+
+        expected_output = (
+            "remote1:\n"
+            "  There are no matching recipes\n"
+        )
+
+        assert expected_output in self.client.out
+
+    def test_search_in_all_remotes_and_cache(self):
+        expected_output = (
+            r"Local Cache:\n"
+            r"  test_recipe/1.0.0@user/channel#.*\n"
+            r"remote1:\n"
+            r"  test_recipe/1.0.0@user/channel#.*\n"
+            r"remote2:\n"
+            r"  There are no matching recipes\n"
+        )
+
+        remote1 = "remote1"
+        remote2 = "remote2"
+
+        self._add_remote(remote1)
+        self._upload_recipe(remote1, "test_recipe/1.0.0@user/channel")
+        self._upload_recipe(remote1, "test_recipe/1.1.0@user/channel")
+
+        self._add_remote(remote2)
+        self._upload_recipe(remote2, "test_recipe/2.0.0@user/channel")
+        self._upload_recipe(remote2, "test_recipe/2.1.0@user/channel")
+
+        self.client.run(f"list package-revisions -a -c {self._get_package_refence('test_recipe/1.0.0@user/channel')}")
+        output = str(self.client.out)
+
+        assert bool(re.match(expected_output, output, re.MULTILINE))
+
+    def test_search_in_missing_remote(self):
+        remote1 = "remote1"
+
+        remote1_recipe1 = "test_recipe/1.0.0@user/channel"
+        remote1_recipe2 = "test_recipe/1.1.0@user/channel"
+
+        expected_output = "No remote 'wrong_remote' defined in remotes"
+
+        self._add_remote(remote1)
+        self._upload_recipe(remote1, remote1_recipe1)
+        self._upload_recipe(remote1, remote1_recipe2)
+
+        self.client.run(f"list package-revisions -r wrong_remote  {self._get_package_refence(remote1_recipe1)}", assert_error=True)
+        assert expected_output in self.client.out
+
+    def test_wildcard_not_accepted(self):
+        remote1 = "remote1"
+        remote1_recipe1 = "test_recipe/1.0.0@user/channel"
+
+        expected_output = "is an invalid name. Valid names MUST begin with a letter, number or underscore"
+
+        self._add_remote(remote1)
+        self._upload_recipe(remote1, remote1_recipe1)
+        self.client.run("list package-revisions -a -c test_*", assert_error=True)
+
+        assert expected_output in self.client.out

--- a/conans/test/integration/command_v2/list_package_revisions_test.py
+++ b/conans/test/integration/command_v2/list_package_revisions_test.py
@@ -8,7 +8,7 @@ from conans.test.assets.genconanfile import GenConanfile
 from conans.test.utils.tools import TestClient, TestServer, NO_SETTINGS_PACKAGE_ID
 
 
-class TestListRecipeRevisionsBase:
+class TestListPackageRevisionsBase:
     @pytest.fixture(autouse=True)
     def _setup(self):
         self.users = {}
@@ -19,10 +19,6 @@ class TestListRecipeRevisionsBase:
                                                       write_permissions=[("*/*@*/*", "*")])
         self.client.update_servers()
         self.client.run("user username -p passwd -r {}".format(remote_name))
-
-    def _create_recipe(self, reference):
-        self.client.save({'conanfile.py': GenConanfile()})
-        self.client.run("create . {}".format(reference))
 
     def _upload_recipe(self, remote, reference):
         self.client.save({'conanfile.py': GenConanfile()})
@@ -40,7 +36,7 @@ class TestListRecipeRevisionsBase:
         return pref
 
 
-class TestParams(TestListRecipeRevisionsBase):
+class TestParams(TestListPackageRevisionsBase):
     def test_fail_if_reference_is_not_correct(self):
         self.client.run("list package-revisions whatever", assert_error=True)
         assert "ERROR: Specify the 'name' and the 'version'" in self.client.out
@@ -78,7 +74,7 @@ class TestParams(TestListRecipeRevisionsBase):
         assert "error: argument -r/--remote: not allowed with argument -a/--all-remotes" in self.client.out
 
 
-class TestListRecipesFromRemotes(TestListRecipeRevisionsBase):
+class TestListPackagesFromRemotes(TestListPackageRevisionsBase):
     def test_by_default_search_only_in_cache(self):
         self._add_remote("remote1")
         self._add_remote("remote2")
@@ -120,7 +116,7 @@ class TestListRecipesFromRemotes(TestListRecipeRevisionsBase):
         assert "ERROR: Remote 'remote1' is disabled" in self.client.out
 
 
-class TestRemotes(TestListRecipeRevisionsBase):
+class TestRemotes(TestListPackageRevisionsBase):
     def test_search_with_full_reference(self):
         remote_name = "remote1"
         recipe_name = "test_recipe/1.0.0@user/channel"


### PR DESCRIPTION
Changelog: (Feature 2.0): Added new `list` subcommand:

```
conan list package-revisions -h
usage: conan list package-revisions [-h] [-f {cli,json}] [-r REMOTE | -a] [-c] package_reference

positional arguments:
  package_reference

optional arguments:
  -h, --help            show this help message and exit
  -f {cli,json}, --format {cli,json}
                        Select the output format: cli, json. 'cli' is the default output.
  -r REMOTE, --remote REMOTE
                        Name of the remote to add
  -a, --all-remotes     Search in all the remotes
  -c, --cache           Search in the local cache
```

Docs: https://github.com/conan-io/docs/pull/XXXX

Depends on: https://github.com/conan-io/conan/pull/9272

- [x] Refer to the issue that supports this Pull Request.
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 

<sup>**Note:** By default this PR will skip the slower tests and will use a limited set of python versions. Check [here](https://github.com/conan-io/conan/blob/develop/.github/PR_INCREASE_TESTING.md) how to increase the testing level by writing some tags in the current PR body text.</sup>
