### PR TITLE
adding python-requires to info output

### DIFF
--- a/conans/client/conan_command_output.py
+++ b/conans/client/conan_command_output.py
@@ -139,6 +139,11 @@ class CommandOutputer(object):
             item_data["build_id"] = build_id(conanfile)
             item_data["context"] = conanfile.context
 
+            python_requires = getattr(conanfile, "python_requires", None)
+            if python_requires and not isinstance(python_requires, dict):  # no old python requires
+                item_data["python_requires"] = [repr(r)
+                                                for r in conanfile.python_requires.all_refs()]
+
             # Paths
             if isinstance(ref, ConanFileReference) and grab_paths:
                 package_layout = self._cache.package_layout(ref, conanfile.short_paths)

--- a/conans/client/printer.py
+++ b/conans/client/printer.py
@@ -124,6 +124,11 @@ class Printer(object):
 
             _print("scm", show_field="scm", name="scm")
 
+            if show("python_requires") and "python_requires" in it:
+                self._out.writeln("    Python-requires:", Color.BRIGHT_GREEN)
+                for d in it["python_requires"]:
+                    self._out.writeln("        %s" % d, Color.BRIGHT_YELLOW)
+
             if show("required") and "required_by" in it:
                 self._out.writeln("    Required by:", Color.BRIGHT_GREEN)
                 for d in it["required_by"]:


### PR DESCRIPTION
Changelog: Feature: Display ``python_requires`` information in the ``conan info`` output.
Docs: Omit

Close https://github.com/conan-io/conan/issues/9277