### PR TITLE
Feature: Use CMAKE_OSX_DEPLOYMENT_TARGET to get -version-min set in CMakeToolchain

### DIFF
--- a/conan/tools/cmake/toolchain.py
+++ b/conan/tools/cmake/toolchain.py
@@ -313,12 +313,14 @@ class AppleSystemBlock(Block):
         {% if CMAKE_SYSTEM_VERSION is defined %}
         set(CMAKE_SYSTEM_VERSION {{ CMAKE_SYSTEM_VERSION }})
         {% endif %}
-        set(DEPLOYMENT_TARGET ${CONAN_SETTINGS_HOST_MIN_OS_VERSION})
         # Set the architectures for which to build.
         set(CMAKE_OSX_ARCHITECTURES {{ CMAKE_OSX_ARCHITECTURES }} CACHE STRING "" FORCE)
         # Setting CMAKE_OSX_SYSROOT SDK, when using Xcode generator the name is enough
         # but full path is necessary for others
         set(CMAKE_OSX_SYSROOT {{ CMAKE_OSX_SYSROOT }} CACHE STRING "" FORCE)
+        {% if CMAKE_OSX_DEPLOYMENT_TARGET is defined %}
+        set(CMAKE_OSX_DEPLOYMENT_TARGET {{ CMAKE_OSX_DEPLOYMENT_TARGET }})
+        {% endif %}
         """)
 
     def _get_architecture(self):
@@ -358,9 +360,6 @@ class AppleSystemBlock(Block):
         host_os_version = self._conanfile.settings.get_safe("os.version")
         host_sdk_name = self._apple_sdk_name()
 
-        # TODO: Discuss how to handle CMAKE_OSX_DEPLOYMENT_TARGET to set min-version
-        #       add a setting? check an option and if not present set a default?
-        #       default to os.version?
         ctxt_toolchain = {}
         if host_sdk_name:
             ctxt_toolchain["CMAKE_OSX_SYSROOT"] = host_sdk_name
@@ -370,6 +369,12 @@ class AppleSystemBlock(Block):
         if os_ in ('iOS', "watchOS", "tvOS"):
             ctxt_toolchain["CMAKE_SYSTEM_NAME"] = os_
             ctxt_toolchain["CMAKE_SYSTEM_VERSION"] = host_os_version
+
+        if host_os_version:
+            # https://cmake.org/cmake/help/latest/variable/CMAKE_OSX_DEPLOYMENT_TARGET.html
+            # Despite the OSX part in the variable name(s) they apply also to other SDKs than
+            # macOS like iOS, tvOS, or watchOS.
+            ctxt_toolchain["CMAKE_OSX_DEPLOYMENT_TARGET"] = host_os_version
 
         return ctxt_toolchain
 

--- a/conans/test/unittests/tools/cmake/test_cmaketoolchain.py
+++ b/conans/test/unittests/tools/cmake/test_cmaketoolchain.py
@@ -140,3 +140,28 @@ def test_user_toolchain(conanfile):
     toolchain = CMakeToolchain(conanfile)
     content = toolchain.content
     assert 'include(' not in content
+
+@pytest.fixture
+def conanfile_apple():
+    c = ConanFile(Mock(), None)
+    c.settings = "os", "compiler", "build_type", "arch"
+    c.initialize(Settings({"os": {"Macos": {"version": ["10.15"]}},
+                           "compiler": {"apple-clang": {"libcxx": ["libc++"]}},
+                           "build_type": ["Release"],
+                           "arch": ["x86"]}), EnvValues())
+    c.settings.build_type = "Release"
+    c.settings.arch = "x86"
+    c.settings.compiler = "apple-clang"
+    c.settings.compiler.libcxx = "libc++"
+    c.settings.os = "Macos"
+    c.settings.os.version = "10.15"
+    c.conf = Conf()
+    c.folders.set_base_generators(".")
+    c._conan_node = Mock()
+    c._conan_node.dependencies = []
+    return c
+
+def test_osx_deployment_target(conanfile_apple):
+    toolchain = CMakeToolchain(conanfile_apple)
+    content = toolchain.content
+    assert 'set(CMAKE_OSX_DEPLOYMENT_TARGET 10.15)' in content


### PR DESCRIPTION
/cc @ssrobins 
closes: #9282
set [CMAKE_OSX_DEPLOYMENT_TARGET](https://cmake.org/cmake/help/latest/variable/CMAKE_OSX_DEPLOYMENT_TARGET.html) to the `os.version` value for macOS, iOS, watchOS, tvOS
also, remove the leftover variable [DEPLOYMENT_TARGET](https://github.com/conan-io/conan/commit/5861e3835baef44429a517b831ee0382ed6a7d55#diff-a9d80c0c1c5562fe43298a71c13ddd118d2c6f346c029c7d6ddfe7281761b108R330) which doesn't seem to be used/needed

Changelog: Feature: Use `CMAKE_OSX_DEPLOYMENT_TARGET` to get `-version-min` set in _CMakeToolchain_.
Docs: omit

- [ ] Refer to the issue that supports this Pull Request.
- [ ] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [ ] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [ ] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 

<sup>**Note:** By default this PR will skip the slower tests and will use a limited set of python versions. Check [here](https://github.com/conan-io/conan/blob/develop/.github/PR_INCREASE_TESTING.md) how to increase the testing level by writing some tags in the current PR body text.</sup>
