### PR TITLE
Feature/New CLI command "list package-ids"

### DIFF
--- a/conans/cli/commands/list.py
+++ b/conans/cli/commands/list.py
@@ -11,25 +11,25 @@ recipe_color = Color.BRIGHT_WHITE
 reference_color = Color.WHITE
 
 
-def _print_common_list_cli_output(results, ref_type):
-    if results.get("error"):
+def _print_common_list_cli_output(result, ref_type):
+    if result.get("error"):
         # TODO: Handle errors
         return
 
-    if results.get("remote"):
-        cli_out_write(f"{results['remote']}:", fg=remote_color)
+    if result.get("remote"):
+        cli_out_write(f"{result['remote']}:", fg=remote_color)
     else:
         cli_out_write("Local Cache:", remote_color)
 
-    if not results.get("results"):
+    if not result.get("results"):
         cli_out_write(f"There are no matching {ref_type}", indentation=2)
 
 
 def list_recipes_cli_formatter(results):
-    for remote_results in results:
-        _print_common_list_cli_output(remote_results, "recipes")
+    for result in results:
+        _print_common_list_cli_output(result, "recipes")
         current_recipe = None
-        for recipe in remote_results["results"]:
+        for recipe in result["results"]:
             if recipe["name"] != current_recipe:
                 current_recipe = recipe["name"]
                 cli_out_write(current_recipe, fg=recipe_color, indentation=2)
@@ -39,10 +39,10 @@ def list_recipes_cli_formatter(results):
 
 
 def _list_revisions_cli_formatter(results, ref_type):
-    for remote_results in results:
-        _print_common_list_cli_output(remote_results, ref_type)
-        reference = remote_results["reference"]
-        for revisions in remote_results["results"]:
+    for result in results:
+        _print_common_list_cli_output(result, ref_type)
+        reference = result["reference"]
+        for revisions in result["results"]:
             rev = revisions["revision"]
             date = iso8601_to_str(revisions["time"])
             cli_out_write(f"{reference}#{rev} ({date})", fg=recipe_color, indentation=2)
@@ -61,10 +61,10 @@ def list_package_ids_cli_formatter(results):
     requires_fields = ("requires", "full_requires")
     general_fields = ("options", "settings")
 
-    for remote_results in results:
-        _print_common_list_cli_output(remote_results, "references")
-        reference = remote_results["reference"]
-        for pkg_id, props in remote_results["results"].items():
+    for result in results:
+        _print_common_list_cli_output(result, "references")
+        reference = result["reference"]
+        for pkg_id, props in result["results"].items():
             cli_out_write(repr(PackageReference(reference, pkg_id)),
                           fg=reference_color, indentation=2)
             for prop_name, values in props.items():

--- a/conans/cli/commands/list.py
+++ b/conans/cli/commands/list.py
@@ -68,16 +68,16 @@ def list_package_ids_cli_formatter(results):
             cli_out_write(repr(PackageReference(reference, pkg_id)),
                           fg=reference_color, indentation=2)
             for prop_name, values in props.items():
-                if prop_name in requires_fields:
-                    if values:
-                        cli_out_write("requires:", fg=Color.BRIGHT_YELLOW, indentation=4)
-                        for req in values:
-                            cli_out_write(req, fg=Color.CYAN, indentation=6)
+                if not values:
+                    continue
+                elif prop_name in requires_fields:
+                    cli_out_write("requires:", fg=Color.BRIGHT_YELLOW, indentation=4)
+                    for req in values:
+                        cli_out_write(req, fg=Color.CYAN, indentation=6)
                 elif prop_name in general_fields:
-                    if values:
-                        cli_out_write(f"{prop_name}:", fg=Color.BRIGHT_YELLOW, indentation=4)
-                        for name, val in values.items():
-                            cli_out_write(f"{name}={val}", fg=Color.CYAN, indentation=6)
+                    cli_out_write(f"{prop_name}:", fg=Color.BRIGHT_YELLOW, indentation=4)
+                    for name, val in values.items():
+                        cli_out_write(f"{name}={val}", fg=Color.CYAN, indentation=6)
 
 
 # FIXME: it's a general formatter, perhaps we should look for another module
@@ -213,8 +213,9 @@ def list_package_revisions(conan_api, parser, subparser, *args):
 @conan_subcommand(formatters=list_package_ids_formatters)
 def list_package_ids(conan_api, parser, subparser, *args):
     """
-    List all the package IDs for a given recipe reference. If it doesn't include the revision,
-    the command will retrieve all the package IDs for the latest one by default.
+    List all the package IDs for a given recipe reference. If the reference doesn't
+    include the recipe revision, the command will retrieve all the package IDs for
+    the most recent revision.
     """
     _add_common_list_subcommands(subparser, "reference")
     args = parser.parse_args(*args)

--- a/conans/cli/commands/list.py
+++ b/conans/cli/commands/list.py
@@ -57,17 +57,7 @@ def list_package_revisions_cli_formatter(results):
 
 def list_package_ids_cli_formatter(results):
     for remote_results in results:
-        if remote_results.get("error"):
-            # TODO: Handle errors
-            return
-
-        if not remote_results.get("remote"):
-            cli_out_write("Local Cache:", fg=remote_color)
-        else:
-            cli_out_write(f"{remote_results['remote']}:", fg=remote_color)
-
-        if not remote_results.get("results"):
-            cli_out_write(f"There are no matching recipes", indentation=2)
+        _print_common_list_cli_output(remote_results, "references")
 
         reference = remote_results["package_reference" if ref_type == "packages" else "reference"]
         for revisions in remote_results["results"]:

--- a/conans/cli/commands/list.py
+++ b/conans/cli/commands/list.py
@@ -11,7 +11,7 @@ recipe_color = Color.BRIGHT_WHITE
 reference_color = Color.WHITE
 
 
-def _print_common_list_cli_output(result, ref_type):
+def _print_common_headers(result, ref_type):
     if result.get("error"):
         # TODO: Handle errors
         return
@@ -27,7 +27,7 @@ def _print_common_list_cli_output(result, ref_type):
 
 def list_recipes_cli_formatter(results):
     for result in results:
-        _print_common_list_cli_output(result, "recipes")
+        _print_common_headers(result, "recipes")
         current_recipe = None
         for recipe in result["results"]:
             if recipe["name"] != current_recipe:
@@ -40,7 +40,7 @@ def list_recipes_cli_formatter(results):
 
 def _list_revisions_cli_formatter(results, ref_type):
     for result in results:
-        _print_common_list_cli_output(result, ref_type)
+        _print_common_headers(result, ref_type)
         reference = result["reference"]
         for revisions in result["results"]:
             rev = revisions["revision"]
@@ -62,7 +62,7 @@ def list_package_ids_cli_formatter(results):
     general_fields = ("options", "settings")
 
     for result in results:
-        _print_common_list_cli_output(result, "references")
+        _print_common_headers(result, "references")
         reference = result["reference"]
         for pkg_id, props in result["results"].items():
             cli_out_write(repr(PackageReference(reference, pkg_id)),

--- a/conans/cli/commands/list.py
+++ b/conans/cli/commands/list.py
@@ -55,6 +55,27 @@ def list_package_revisions_cli_formatter(results):
     _list_revisions_cli_formatter(results, "packages")
 
 
+def list_package_ids_cli_formatter(results):
+    for remote_results in results:
+        if remote_results.get("error"):
+            # TODO: Handle errors
+            return
+
+        if not remote_results.get("remote"):
+            cli_out_write("Local Cache:", fg=remote_color)
+        else:
+            cli_out_write(f"{remote_results['remote']}:", fg=remote_color)
+
+        if not remote_results.get("results"):
+            cli_out_write(f"There are no matching recipes", indentation=2)
+
+        reference = remote_results["package_reference" if ref_type == "packages" else "reference"]
+        for revisions in remote_results["results"]:
+            rev = revisions["revision"]
+            date = iso8601_to_str(revisions["time"])
+            cli_out_write(f"{reference}#{rev} ({date})", fg=recipe_color, indentation=2)
+
+
 # FIXME: it's a general formatter, perhaps we should look for another module
 def json_formatter(info):
     myjson = json.dumps(info, indent=4)
@@ -74,7 +95,7 @@ list_package_revisions_formatters = {
     "json": json_formatter
 }
 list_package_ids_formatters = {
-    "cli": list_package_revisions_cli_formatter,
+    "cli": list_package_ids_cli_formatter,
     "json": json_formatter
 }
 
@@ -222,7 +243,7 @@ def list_package_ids(conan_api, parser, subparser, *args):
         result = {
             'remote': None,
             'reference': args.reference,
-            'results': conan_api.get_package_ids(args.package_reference)
+            'results': conan_api.get_package_ids(args.reference)
         }
         results.append(result)
 
@@ -230,7 +251,7 @@ def list_package_ids(conan_api, parser, subparser, *args):
         result = {
             'remote': remote.name,
             'reference': args.reference,
-            'results': conan_api.get_package_ids(args.package_reference, remote=remote)
+            'results': conan_api.get_package_ids(args.reference, remote=remote)
         }
         results.append(result)
 

--- a/conans/cli/commands/list.py
+++ b/conans/cli/commands/list.py
@@ -65,16 +65,19 @@ def list_package_ids_cli_formatter(results):
         _print_common_list_cli_output(remote_results, "references")
         reference = remote_results["reference"]
         for pkg_id, props in remote_results["results"].items():
-            cli_out_write(repr(PackageReference(reference, pkg_id)), fg=reference_color, indentation=2)
+            cli_out_write(repr(PackageReference(reference, pkg_id)),
+                          fg=reference_color, indentation=2)
             for prop_name, values in props.items():
                 if prop_name in requires_fields:
-                    cli_out_write("requires:", fg=Color.BRIGHT_YELLOW, indentation=4)
-                    for req in values:
-                        cli_out_write(req, fg=Color.CYAN, indentation=6)
+                    if values:
+                        cli_out_write("requires:", fg=Color.BRIGHT_YELLOW, indentation=4)
+                        for req in values:
+                            cli_out_write(req, fg=Color.CYAN, indentation=6)
                 elif prop_name in general_fields:
-                    cli_out_write(f"{prop_name}:", fg=Color.BRIGHT_YELLOW, indentation=4)
-                    for name, val in values.items():
-                        cli_out_write(f"{name}={val}", fg=Color.CYAN, indentation=6)
+                    if values:
+                        cli_out_write(f"{prop_name}:", fg=Color.BRIGHT_YELLOW, indentation=4)
+                        for name, val in values.items():
+                            cli_out_write(f"{name}={val}", fg=Color.CYAN, indentation=6)
 
 
 # FIXME: it's a general formatter, perhaps we should look for another module

--- a/conans/cli/commands/list.py
+++ b/conans/cli/commands/list.py
@@ -73,6 +73,10 @@ list_package_revisions_formatters = {
     "cli": list_package_revisions_cli_formatter,
     "json": json_formatter
 }
+list_package_ids_formatters = {
+    "cli": list_package_revisions_cli_formatter,
+    "json": json_formatter
+}
 
 
 @conan_subcommand(formatters=list_recipes_formatters)
@@ -193,6 +197,40 @@ def list_package_revisions(conan_api, parser, subparser, *args):
             'remote': remote.name,
             'package_reference': args.package_reference,
             'results': conan_api.get_package_revisions(args.package_reference, remote=remote)
+        }
+        results.append(result)
+
+    return results
+
+
+@conan_subcommand(formatters=list_package_ids_formatters)
+def list_package_ids(conan_api, parser, subparser, *args):
+    """
+    List all the package IDs for a given reference
+    """
+    _add_common_list_subcommands(subparser, "reference")
+    args = parser.parse_args(*args)
+
+    if not args.cache and not args.remote and not args.all_remotes:
+        # If neither remote nor cache are defined, show results only from cache
+        args.cache = True
+
+    remotes = _get_remotes(conan_api, args)
+
+    results = []
+    if args.cache:
+        result = {
+            'remote': None,
+            'reference': args.reference,
+            'results': conan_api.get_package_ids(args.package_reference)
+        }
+        results.append(result)
+
+    for remote in remotes:
+        result = {
+            'remote': remote.name,
+            'reference': args.reference,
+            'results': conan_api.get_package_ids(args.package_reference, remote=remote)
         }
         results.append(result)
 

--- a/conans/client/api/conan_api.py
+++ b/conans/client/api/conan_api.py
@@ -1,6 +1,5 @@
 import os
 import time
-from collections import OrderedDict
 
 from tqdm import tqdm
 

--- a/conans/client/api/conan_api.py
+++ b/conans/client/api/conan_api.py
@@ -350,7 +350,7 @@ class ConanAPIV2(object):
                 # but in the meantime we must handle it here
                 packages_props = {}
         else:
-            rrev = ref if ref.revision else self.app.cache.get_latest_rrev(remote, ref)
+            rrev = ref if ref.revision else self.app.cache.get_latest_rrev(ref)
             package_ids = self.app.cache.get_package_ids(rrev)
             package_layouts = []
             for pkg in package_ids:

--- a/conans/client/api/conan_api.py
+++ b/conans/client/api/conan_api.py
@@ -280,10 +280,17 @@ class ConanAPIV2(object):
         :param reference: `PackageReference` without the revision
         :param remote: `Remote` object
         :return: `dict` with all the results, e.g.,
-                 {"remote": "my_remote_name",  # or None
-                  "reference": "libyaml/0.2.5#80b7cbe095ac7f38844b6511e69e453a:ef93ea55bee154729e264db35ca6a16ecab77eb7",
-                  "results": [{"revision": "80b7cbe095ac7f38844b6511e69e453a",
-                               "time": "2021-07-20 00:56:25 UTC"}, ...]}
+                  {
+                    "remote": "my_remote_name",  # or None
+                    "reference": "libyaml/0.2.5#80b7cbe095ac7f38844b6511e69e453a:ef93ea55bee154729e264db35ca6a16ecab77eb7",
+                    "results": [
+                      {
+                        "revision": "80b7cbe095ac7f38844b6511e69e453a",
+                        "time": "2021-07-20 00:56:25 UTC"
+                      },
+                      ...
+                    ]
+                  }
         """
         ref = PackageReference.loads(reference)
         if ref.revision:
@@ -302,10 +309,17 @@ class ConanAPIV2(object):
         :param reference: `ConanFileReference` without the revision
         :param remote: `Remote` object
         :return: `dict` with all the results, e.g.,
-                 {"remote": "my_remote_name",  # or None
-                  "reference": "libyaml/0.2.5",
-                  "results": [{"revision": "80b7cbe095ac7f38844b6511e69e453a",
-                               "time": "2021-07-20 00:56:25 UTC"}, ...]}
+                  {
+                    "remote": "my_remote_name",  # or None
+                    "reference": "libyaml/0.2.5",
+                    "results": [
+                      {
+                        "revision": "80b7cbe095ac7f38844b6511e69e453a",
+                        "time": "2021-07-20 00:56:25 UTC"
+                      },
+                      ...
+                    ]
+                  }
         """
         ref = ConanFileReference.loads(reference)
         if ref.revision:
@@ -327,15 +341,17 @@ class ConanAPIV2(object):
         :param reference: `ConanFileReference` with/without revision
         :param remote: `Remote` object
         :return: `list` of `dict` with the `package-id` as keys, e.g.,
-                 {"remote": "my_remote_name",  # or None
-                  "reference": "libcurl/7.77.0#2a9c4fcc8d76d891e4db529efbe24242",
-                  "results": {"d5f16437dd4989cc688211b95c24525589acaafd": {
-                                    "settings": {"compiler": "apple-clang",...},
-                                    "options": {'options': {'shared': 'False',...}},
-                                    "requires": [
-                                        'mylib/1.0.8:3df6ebb8a308d309e882b21988fd9ea103560e16',...]}
-                            }
-                 }
+                  {
+                    "remote": "my_remote_name",  # or None
+                    "reference": "libcurl/7.77.0#2a9c4fcc8d76d891e4db529efbe24242",
+                    "results": {
+                        "d5f16437dd4989cc688211b95c24525589acaafd": {
+                            "settings": {"compiler": "apple-clang",...},
+                            "options": {'options': {'shared': 'False',...}},
+                            "requires": ['mylib/1.0.8:3df6ebb8a308d309e882b21988fd9ea103560e16',...]
+                        }
+                    }
+                  }
         """
         ref = ConanFileReference.loads(reference)
         if remote:

--- a/conans/client/api/conan_api.py
+++ b/conans/client/api/conan_api.py
@@ -252,13 +252,13 @@ class ConanAPIV2(object):
         # Let's get all the revisions from a remote server
         if remote:
             try:
-                return getattr(self.app.remote_manager, method_name)(ref, remote=remote)
+                results = getattr(self.app.remote_manager, method_name)(ref, remote=remote)
             except NotFoundException:
                 # This exception must be catched manually due to a server inconsistency:
                 # Artifactory API returns an empty result if the recipe doesn't exist, but
                 # Conan Server returns a 404. This probably should be fixed server side,
                 # but in the meantime we must handle it here
-                return []
+                results = []
         else:
             # Let's get the revisions from the local cache
             revs = getattr(self.app.cache, method_name)(ref)
@@ -270,7 +270,10 @@ class ConanAPIV2(object):
                     "time": from_timestamp_to_iso8601(timestamp)
                 }
                 results.append(result)
-            return results
+
+        return {"remote": remote.name if remote else None,
+                "reference": reference,
+                "results": results}
 
     @api_method
     def get_package_revisions(self, reference, remote=None):
@@ -279,9 +282,11 @@ class ConanAPIV2(object):
 
         :param reference: `PackageReference` without the revision
         :param remote: `Remote` object
-        :return: `list` of `dict`, e.g.,
-                 [{"revision": "73eef56f6e7c70ac852ef95a10c4473d",
-                   "time": "2021-07-20 00:56:25 UTC"}, ...]
+        :return: `dict` with all the results, e.g.,
+                 {"remote": "my_remote_name",  # or None
+                  "reference": "libyaml/0.2.5#80b7cbe095ac7f38844b6511e69e453a:ef93ea55bee154729e264db35ca6a16ecab77eb7",
+                  "results": [{"revision": "80b7cbe095ac7f38844b6511e69e453a",
+                               "time": "2021-07-20 00:56:25 UTC"}, ...]}
         """
         ref = PackageReference.loads(reference)
         if ref.revision:
@@ -296,9 +301,11 @@ class ConanAPIV2(object):
 
         :param reference: `ConanFileReference` without the revision
         :param remote: `Remote` object
-        :return: `list` of `dict`, e.g.,
-                 [{"revision": "73eef56f6e7c70ac852ef95a10c4473d",
-                   "time": "2021-07-20 00:56:25 UTC"}, ...]
+        :return: `dict` with all the results, e.g.,
+                 {"remote": "my_remote_name",  # or None
+                  "reference": "libyaml/0.2.5",
+                  "results": [{"revision": "80b7cbe095ac7f38844b6511e69e453a",
+                               "time": "2021-07-20 00:56:25 UTC"}, ...]}
         """
         ref = ConanFileReference.loads(reference)
         if ref.revision:
@@ -306,6 +313,7 @@ class ConanAPIV2(object):
 
         return self._get_revisions(ref, remote=remote)
 
+    @api_method
     def get_package_ids(self, reference, remote=None):
         """
         Get all the Package IDs given a recipe revision from cache or remote.
@@ -316,16 +324,21 @@ class ConanAPIV2(object):
         :param reference: `ConanFileReference` with/without revision
         :param remote: `Remote` object
         :return: `list` of `dict` with the `package-id` as keys, e.g.,
-                 {"d5f16437dd4989cc688211b95c24525589acaafd": {
-                        "settings": {"compiler": "apple-clang",...},
-                        "options": {'options': {'shared': 'False',...}},
-                        "requires": ['mylib/1.0.8:3df6ebb8a308d309e882b21988fd9ea103560e16',...]}
+                 {"remote": "my_remote_name",  # or None
+                  "reference": "libcurl/7.77.0#2a9c4fcc8d76d891e4db529efbe24242",
+                  "results": {"d5f16437dd4989cc688211b95c24525589acaafd": {
+                                    "settings": {"compiler": "apple-clang",...},
+                                    "options": {'options': {'shared': 'False',...}},
+                                    "requires": [
+                                        'mylib/1.0.8:3df6ebb8a308d309e882b21988fd9ea103560e16',...]}
+                            }
                  }
         """
         ref = ConanFileReference.loads(reference)
         if remote:
+            rrev = ref if ref.revision else self.app.remote_manager.get_latest_recipe_revision(ref,
+                                                                                               remote)
             try:
-                rrev = ref if ref.revision else self.app.remote_manager.get_latest_recipe_revision(ref, remote)
                 packages_props = self.app.remote_manager.search_packages(remote, rrev, None)
             except NotFoundException:
                 # This exception must be catched manually due to a server inconsistency:
@@ -342,7 +355,11 @@ class ConanAPIV2(object):
                 package_layouts.append(self.app.cache.pkg_layout(latest_prev))
             packages_props = search_packages(package_layouts, None)
 
-        return packages_props
+        return {
+            "remote": remote.name if remote else None,
+            "reference": rrev,
+            "results": packages_props
+        }
 
 
 Conan = ConanAPIV2

--- a/conans/client/api/conan_api.py
+++ b/conans/client/api/conan_api.py
@@ -286,5 +286,12 @@ class ConanAPIV2(object):
 
         return self._get_revisions(ref, remote=remote)
 
+    def get_package_ids(self, reference, remote=None):
+        ref = ConanFileReference.loads(reference)
+        if remote:
+            rrev = ref if ref.revision else self.app.remote_manager.search_packages(remote, ref, query)
+        else:
+            rrev = ref if ref.revision else self.app.cache.get_package_ids(ref)
+
 
 Conan = ConanAPIV2

--- a/conans/client/api/conan_api.py
+++ b/conans/client/api/conan_api.py
@@ -271,9 +271,7 @@ class ConanAPIV2(object):
                 }
                 results.append(result)
 
-        return {"remote": remote.name if remote else None,
-                "reference": reference,
-                "results": results}
+        return results
 
     @api_method
     def get_package_revisions(self, reference, remote=None):
@@ -292,7 +290,10 @@ class ConanAPIV2(object):
         if ref.revision:
             raise ConanException(f"Cannot list the revisions of a specific package revision")
 
-        return self._get_revisions(ref, remote=remote)
+        results = self._get_revisions(ref, remote=remote)
+        return {"remote": remote.name if remote else None,
+                "reference": reference,
+                "results": results}
 
     @api_method
     def get_recipe_revisions(self, reference, remote=None):
@@ -311,7 +312,10 @@ class ConanAPIV2(object):
         if ref.revision:
             raise ConanException(f"Cannot list the revisions of a specific recipe revision")
 
-        return self._get_revisions(ref, remote=remote)
+        results = self._get_revisions(ref, remote=remote)
+        return {"remote": remote.name if remote else None,
+                "reference": reference,
+                "results": results}
 
     @api_method
     def get_package_ids(self, reference, remote=None):

--- a/conans/test/integration/command_v2/list_package_ids_test.py
+++ b/conans/test/integration/command_v2/list_package_ids_test.py
@@ -158,6 +158,21 @@ class TestRemotes(TestListPackageIdsBase):
 
         assert bool(re.match(expected_output, str(self.client.out), re.MULTILINE))
 
+    def test_search_with_full_reference_but_package_has_no_properties(self):
+        remote_name = "remote1"
+        recipe_name = "test_recipe/1.0.0@user/channel"
+        self._add_remote(remote_name)
+        self._upload_recipe(remote_name, recipe_name)
+        rrev = self._get_lastest_recipe_ref("test_recipe/1.0.0@user/channel")
+        self.client.run(f"list package-ids -r remote1 {repr(rrev)}")
+
+        expected_output = textwrap.dedent("""\
+        remote1:
+          %s:.{40}
+        """ % repr(rrev))
+
+        assert bool(re.match(expected_output, str(self.client.out), re.MULTILINE))
+
     def test_search_with_full_reference_but_using_ref_without_revision(self):
         remote_name = "remote1"
         recipe_name = "test_recipe/1.0.0@user/channel"

--- a/conans/test/integration/command_v2/list_package_ids_test.py
+++ b/conans/test/integration/command_v2/list_package_ids_test.py
@@ -6,7 +6,7 @@ from conans.test.assets.genconanfile import GenConanfile
 from conans.test.utils.tools import TestClient, TestServer
 
 
-class TestListRecipeRevisionsBase:
+class TestListPackageIdsBase:
     @pytest.fixture(autouse=True)
     def _setup(self):
         self.client = TestClient()
@@ -26,40 +26,40 @@ class TestListRecipeRevisionsBase:
         self.client.run("upload --force -r {} {}".format(remote, reference))
 
 
-class TestParams(TestListRecipeRevisionsBase):
+class TestParams(TestListPackageIdsBase):
     def test_fail_if_reference_is_not_correct(self):
-        self.client.run("list recipe-revisions whatever", assert_error=True)
+        self.client.run("list package-ids whatever", assert_error=True)
         assert "ERROR: Specify the 'name' and the 'version'" in self.client.out
 
-        self.client.run("list recipe-revisions whatever/", assert_error=True)
+        self.client.run("list package-ids whatever/", assert_error=True)
         assert "ERROR: Specify the 'name' and the 'version'" in self.client.out
 
-        self.client.run("list recipe-revisions whatever/1", assert_error=True)
+        self.client.run("list package-ids whatever/1", assert_error=True)
         assert "ERROR: Value provided for package version, '1' (type Version), is too short" in self.client.out
 
     def test_query_param_is_required(self):
         self._add_remote("remote1")
 
-        self.client.run("list recipe-revisions", assert_error=True)
+        self.client.run("list package-ids", assert_error=True)
         assert "error: the following arguments are required: reference" in self.client.out
 
-        self.client.run("list recipe-revisions -c", assert_error=True)
+        self.client.run("list package-ids -c", assert_error=True)
         assert "error: the following arguments are required: reference" in self.client.out
 
-        self.client.run("list recipe-revisions --all-remotes", assert_error=True)
+        self.client.run("list package-ids --all-remotes", assert_error=True)
         assert "error: the following arguments are required: reference" in self.client.out
 
-        self.client.run("list recipe-revisions --remote remote1 --cache", assert_error=True)
+        self.client.run("list package-ids --remote remote1 --cache", assert_error=True)
         assert "error: the following arguments are required: reference" in self.client.out
 
     def test_remote_and_all_remotes_are_mutually_exclusive(self):
         self._add_remote("remote1")
 
-        self.client.run("list recipe-revisions --all-remotes --remote remote1 package/1.0", assert_error=True)
+        self.client.run("list package-ids --all-remotes --remote remote1 package/1.0", assert_error=True)
         assert "error: argument -r/--remote: not allowed with argument -a/--all-remotes" in self.client.out
 
 
-class TestListRecipesFromRemotes(TestListRecipeRevisionsBase):
+class TestListRecipesFromRemotes(TestListPackageIdsBase):
     def test_by_default_search_only_in_cache(self):
         self._add_remote("remote1")
         self._add_remote("remote2")
@@ -67,7 +67,7 @@ class TestListRecipesFromRemotes(TestListRecipeRevisionsBase):
         expected_output = ("Local Cache:\n"
                            "  There are no matching recipes\n")
 
-        self.client.run("list recipe-revisions whatever/1.0")
+        self.client.run("list package-ids whatever/1.0")
         assert expected_output == self.client.out
 
     def test_search_no_matching_recipes(self):
@@ -81,28 +81,28 @@ class TestListRecipesFromRemotes(TestListRecipeRevisionsBase):
                            "remote2:\n"
                            "  There are no matching recipes\n")
 
-        self.client.run("list recipe-revisions -c -a whatever/1.0")
+        self.client.run("list package-ids -c -a whatever/1.0")
         assert expected_output == self.client.out
 
     def test_fail_if_no_configured_remotes(self):
-        self.client.run("list recipe-revisions -a whatever/1.0", assert_error=True)
+        self.client.run("list package-ids -a whatever/1.0", assert_error=True)
         assert "ERROR: The remotes registry is empty" in self.client.out
 
     def test_search_disabled_remote(self):
         self._add_remote("remote1")
         self.client.run("remote disable remote1")
-        self.client.run("list recipe-revisions -r remote1 whatever/1.0", assert_error=True)
+        self.client.run("list package-ids -r remote1 whatever/1.0", assert_error=True)
         assert "ERROR: Remote 'remote1' is disabled" in self.client.out
 
 
-class TestRemotes(TestListRecipeRevisionsBase):
+class TestRemotes(TestListPackageIdsBase):
     def test_search_with_full_reference(self):
         remote_name = "remote1"
         recipe_name = "test_recipe/1.0.0@user/channel"
         self._add_remote(remote_name)
         self._upload_recipe(remote_name, recipe_name)
 
-        self.client.run("list recipe-revisions -r remote1 test_recipe/1.0.0@user/channel")
+        self.client.run("list package-ids -r remote1 test_recipe/1.0.0@user/channel")
 
         expected_output = (
             r"remote1:\n"
@@ -117,7 +117,7 @@ class TestRemotes(TestListRecipeRevisionsBase):
         self._add_remote(remote_name)
         self._upload_recipe(remote_name, recipe_name)
 
-        self.client.run("list recipe-revisions -r remote1 test_recipe/1.0.0")
+        self.client.run("list package-ids -r remote1 test_recipe/1.0.0")
 
         expected_output = (
             "remote1:\n"
@@ -147,7 +147,7 @@ class TestRemotes(TestListRecipeRevisionsBase):
         self._upload_recipe(remote2, "test_recipe/2.0.0@user/channel")
         self._upload_recipe(remote2, "test_recipe/2.1.0@user/channel")
 
-        self.client.run("list recipe-revisions -a -c test_recipe/1.0.0@user/channel")
+        self.client.run("list package-ids -a -c test_recipe/1.0.0@user/channel")
         output = str(self.client.out)
 
         assert bool(re.match(expected_output, output, re.MULTILINE))
@@ -164,7 +164,7 @@ class TestRemotes(TestListRecipeRevisionsBase):
         self._upload_recipe(remote1, remote1_recipe1)
         self._upload_recipe(remote1, remote1_recipe2)
 
-        self.client.run("list recipe-revisions -r wrong_remote test_recipe/1.0.0@user/channel", assert_error=True)
+        self.client.run("list package-ids -r wrong_remote test_recipe/1.0.0@user/channel", assert_error=True)
         assert expected_output in self.client.out
 
     def test_wildcard_not_accepted(self):
@@ -175,6 +175,6 @@ class TestRemotes(TestListRecipeRevisionsBase):
 
         self._add_remote(remote1)
         self._upload_recipe(remote1, remote1_recipe1)
-        self.client.run("list recipe-revisions -a -c test_*", assert_error=True)
+        self.client.run("list package-ids -a -c test_*", assert_error=True)
 
         assert expected_output in self.client.out

--- a/conans/test/integration/command_v2/list_package_ids_test.py
+++ b/conans/test/integration/command_v2/list_package_ids_test.py
@@ -140,7 +140,7 @@ class TestRemotes(TestListPackageIdsBase):
         recipe_name = "test_recipe/1.0.0@user/channel"
         self._add_remote(remote_name)
         self._upload_full_recipe(remote_name, recipe_name)
-        rrev = self._get_lastest_recipe_ref("test_recipe/1.0.0@user/channel")
+        rrev = self._get_lastest_recipe_ref(recipe_name)
         self.client.run(f"list package-ids -r remote1 {repr(rrev)}")
 
         expected_output = textwrap.dedent("""\
@@ -163,7 +163,7 @@ class TestRemotes(TestListPackageIdsBase):
         recipe_name = "test_recipe/1.0.0@user/channel"
         self._add_remote(remote_name)
         self._upload_recipe(remote_name, recipe_name)
-        rrev = self._get_lastest_recipe_ref("test_recipe/1.0.0@user/channel")
+        rrev = self._get_lastest_recipe_ref(recipe_name)
         self.client.run(f"list package-ids -r remote1 {repr(rrev)}")
 
         expected_output = textwrap.dedent("""\
@@ -175,14 +175,12 @@ class TestRemotes(TestListPackageIdsBase):
 
     def test_search_with_reference_without_revision_in_cache_and_remotes(self):
         remote_name = "remote1"
-        recipe_name = "test_recipe/1.0.0@user/channel"
-        self._add_remote(remote_name)
-        self._upload_full_recipe(remote_name, recipe_name)
         ref = "test_recipe/1.0.0@user/channel"
-        self.client.run(f"list package-ids -a -c {str(ref)}")
-
+        self._add_remote(remote_name)
+        self._upload_full_recipe(remote_name, ref)
+        self.client.run(f"list package-ids -a -c {ref}")
         # Now, let's check that we're using the latest one by default
-        rrev = self._get_lastest_recipe_ref("test_recipe/1.0.0@user/channel")
+        rrev = self._get_lastest_recipe_ref(ref)
         expected_output = textwrap.dedent("""\
         Local Cache:
           %(rrev)s:.{40}
@@ -248,7 +246,7 @@ class TestRemotes(TestListPackageIdsBase):
         remote2:
           There are no matching references
         """ % {"rrev": repr(rrev)})
-        assert bool(re.match(expected_output, str(self.client.out), re.MULTILINE))
+        assert bool(re.match(expected_output, output, re.MULTILINE))
 
     def test_search_in_missing_remote(self):
         remote1 = "remote1"

--- a/conans/test/integration/command_v2/list_package_ids_test.py
+++ b/conans/test/integration/command_v2/list_package_ids_test.py
@@ -121,6 +121,20 @@ class TestListPackagesFromRemotes(TestListPackageIdsBase):
 
 
 class TestRemotes(TestListPackageIdsBase):
+
+    def test_search_with_full_reference_but_no_packages_in_cache(self):
+        self.client.save({
+            "conanfile.py": GenConanfile("test_recipe", "1.0.0").with_package_file("file.h", "0.1")
+        })
+        self.client.run("export . user/channel")
+        rrev = self._get_lastest_recipe_ref("test_recipe/1.0.0@user/channel")
+        self.client.run(f"list package-ids {repr(rrev)}")
+        expected_output = textwrap.dedent(f"""\
+        Local Cache:
+          There are no matching references
+        """)
+        assert expected_output == str(self.client.out)
+
     def test_search_with_full_reference(self):
         remote_name = "remote1"
         recipe_name = "test_recipe/1.0.0@user/channel"

--- a/conans/test/integration/command_v2/list_package_ids_test.py
+++ b/conans/test/integration/command_v2/list_package_ids_test.py
@@ -143,9 +143,9 @@ class TestRemotes(TestListPackageIdsBase):
         rrev = self._get_lastest_recipe_ref("test_recipe/1.0.0@user/channel")
         self.client.run(f"list package-ids -r remote1 {repr(rrev)}")
 
-        expected_output = textwrap.dedent(f"""\
+        expected_output = textwrap.dedent("""\
         remote1:
-          {repr(rrev)}:.*
+          %s:.{40}
             settings:
               arch=.*
               build_type=.*
@@ -154,7 +154,7 @@ class TestRemotes(TestListPackageIdsBase):
               shared=False
             requires:
               pkg/0.1@user/channel:5ab84d6acfe1f23c4fae0ab88f26e3a396351ac9
-        """)
+        """ % repr(rrev))
 
         assert bool(re.match(expected_output, str(self.client.out), re.MULTILINE))
 
@@ -168,9 +168,9 @@ class TestRemotes(TestListPackageIdsBase):
 
         # Now, let's check that we're using the latest one by default
         rrev = self._get_lastest_recipe_ref("test_recipe/1.0.0@user/channel")
-        expected_output = textwrap.dedent(f"""\
+        expected_output = textwrap.dedent("""\
         remote1:
-          {repr(rrev)}:.*
+          %s:.{40}
             settings:
               arch=.*
               build_type=.*
@@ -179,7 +179,7 @@ class TestRemotes(TestListPackageIdsBase):
               shared=False
             requires:
               pkg/0.1@user/channel:5ab84d6acfe1f23c4fae0ab88f26e3a396351ac9
-        """)
+        """ % repr(rrev))
 
         assert bool(re.match(expected_output, str(self.client.out), re.MULTILINE))
 
@@ -199,9 +199,9 @@ class TestRemotes(TestListPackageIdsBase):
         rrev = self._get_lastest_recipe_ref("test_recipe/1.0.0@user/channel")
         self.client.run(f"list package-ids -a -c {repr(rrev)}")
         output = str(self.client.out)
-        expected_output = textwrap.dedent(f"""\
+        expected_output = textwrap.dedent("""\
         Local Cache:
-          {repr(rrev)}:.*
+          %(rrev)s:.{40}
             settings:
               arch=.*
               build_type=.*
@@ -211,7 +211,7 @@ class TestRemotes(TestListPackageIdsBase):
             requires:
               pkg/0.1@user/channel:5ab84d6acfe1f23c4fae0ab88f26e3a396351ac9
         remote1:
-          {repr(rrev)}:.*
+          %(rrev)s:.{40}
             settings:
               arch=.*
               build_type=.*
@@ -222,7 +222,7 @@ class TestRemotes(TestListPackageIdsBase):
               pkg/0.1@user/channel:5ab84d6acfe1f23c4fae0ab88f26e3a396351ac9
         remote2:
           There are no matching references
-        """)
+        """ % {"rrev": repr(rrev)})
         assert bool(re.match(expected_output, str(self.client.out), re.MULTILINE))
 
     def test_search_in_missing_remote(self):

--- a/conans/test/integration/command_v2/list_package_ids_test.py
+++ b/conans/test/integration/command_v2/list_package_ids_test.py
@@ -173,19 +173,19 @@ class TestRemotes(TestListPackageIdsBase):
 
         assert bool(re.match(expected_output, str(self.client.out), re.MULTILINE))
 
-    def test_search_with_full_reference_but_using_ref_without_revision(self):
+    def test_search_with_reference_without_revision_in_cache_and_remotes(self):
         remote_name = "remote1"
         recipe_name = "test_recipe/1.0.0@user/channel"
         self._add_remote(remote_name)
         self._upload_full_recipe(remote_name, recipe_name)
         ref = "test_recipe/1.0.0@user/channel"
-        self.client.run(f"list package-ids -r remote1 {repr(ref)}")
+        self.client.run(f"list package-ids -a -c {str(ref)}")
 
         # Now, let's check that we're using the latest one by default
         rrev = self._get_lastest_recipe_ref("test_recipe/1.0.0@user/channel")
         expected_output = textwrap.dedent("""\
-        remote1:
-          %s:.{40}
+        Local Cache:
+          %(rrev)s:.{40}
             settings:
               arch=.*
               build_type=.*
@@ -194,7 +194,17 @@ class TestRemotes(TestListPackageIdsBase):
               shared=False
             requires:
               pkg/0.1@user/channel:5ab84d6acfe1f23c4fae0ab88f26e3a396351ac9
-        """ % repr(rrev))
+        remote1:
+          %(rrev)s:.{40}
+            settings:
+              arch=.*
+              build_type=.*
+              os=.*
+            options:
+              shared=False
+            requires:
+              pkg/0.1@user/channel:5ab84d6acfe1f23c4fae0ab88f26e3a396351ac9
+        """ % {"rrev": repr(rrev)})
 
         assert bool(re.match(expected_output, str(self.client.out), re.MULTILINE))
 

--- a/conans/test/integration/command_v2/list_package_ids_test.py
+++ b/conans/test/integration/command_v2/list_package_ids_test.py
@@ -1,11 +1,10 @@
-import re
 import textwrap
 
 import pytest
 
-from conans.model.ref import ConanFileReference, PackageReference
+from conans.model.ref import ConanFileReference
 from conans.test.assets.genconanfile import GenConanfile
-from conans.test.utils.tools import TestClient, TestServer, NO_SETTINGS_PACKAGE_ID
+from conans.test.utils.tools import TestClient, TestServer
 
 
 class TestListPackageIdsBase:

--- a/conans/test/integration/command_v2/list_package_ids_test.py
+++ b/conans/test/integration/command_v2/list_package_ids_test.py
@@ -1,3 +1,4 @@
+import re
 import textwrap
 
 import pytest
@@ -29,8 +30,7 @@ class TestListPackageIdsBase:
         self.client.run("upload --force --all -r {} {}".format(remote, "pkg/0.1@user/channel"))
 
         self.client.save({'conanfile.py': GenConanfile().with_require("pkg/0.1@user/channel")
-                                                        .with_settings("os", "compiler",
-                                                                       "build_type", "arch")
+                                                        .with_settings("os", "build_type", "arch")
                                                         .with_option("shared", [True, False])
                                                         .with_default_option("shared", False)
                           })
@@ -131,21 +131,18 @@ class TestRemotes(TestListPackageIdsBase):
 
         expected_output = textwrap.dedent(f"""\
         remote1:
-          {repr(rrev)}:7b4cfcb069333452b5796da7757e7758bdaf0471
+          {repr(rrev)}:.*
             settings:
-              arch=x86_64
-              build_type=Release
-              compiler=apple-clang
-              compiler.libcxx=libc++
-              compiler.version=12.0
-              os=Macos
+              arch=.*
+              build_type=.*
+              os=.*
             options:
               shared=False
             requires:
               pkg/0.1@user/channel:5ab84d6acfe1f23c4fae0ab88f26e3a396351ac9
         """)
 
-        assert expected_output == str(self.client.out)
+        assert bool(re.match(expected_output, str(self.client.out), re.MULTILINE))
 
     def test_search_with_full_reference_but_using_ref_without_revision(self):
         remote_name = "remote1"
@@ -159,21 +156,18 @@ class TestRemotes(TestListPackageIdsBase):
         rrev = self._get_lastest_recipe_ref("test_recipe/1.0.0@user/channel")
         expected_output = textwrap.dedent(f"""\
         remote1:
-          {repr(rrev)}:7b4cfcb069333452b5796da7757e7758bdaf0471
+          {repr(rrev)}:.*
             settings:
-              arch=x86_64
-              build_type=Release
-              compiler=apple-clang
-              compiler.libcxx=libc++
-              compiler.version=12.0
-              os=Macos
+              arch=.*
+              build_type=.*
+              os=.*
             options:
               shared=False
             requires:
               pkg/0.1@user/channel:5ab84d6acfe1f23c4fae0ab88f26e3a396351ac9
         """)
 
-        assert expected_output == str(self.client.out)
+        assert bool(re.match(expected_output, str(self.client.out), re.MULTILINE))
 
     def test_search_in_all_remotes_and_cache(self):
         remote1 = "remote1"
@@ -193,27 +187,21 @@ class TestRemotes(TestListPackageIdsBase):
         output = str(self.client.out)
         expected_output = textwrap.dedent(f"""\
         Local Cache:
-          {repr(rrev)}:7b4cfcb069333452b5796da7757e7758bdaf0471
+          {repr(rrev)}:.*
             settings:
-              arch=x86_64
-              build_type=Release
-              compiler=apple-clang
-              compiler.libcxx=libc++
-              compiler.version=12.0
-              os=Macos
+              arch=.*
+              build_type=.*
+              os=.*
             options:
               shared=False
             requires:
               pkg/0.1@user/channel:5ab84d6acfe1f23c4fae0ab88f26e3a396351ac9
         remote1:
-          {repr(rrev)}:7b4cfcb069333452b5796da7757e7758bdaf0471
+          {repr(rrev)}:.*
             settings:
-              arch=x86_64
-              build_type=Release
-              compiler=apple-clang
-              compiler.libcxx=libc++
-              compiler.version=12.0
-              os=Macos
+              arch=.*
+              build_type=.*
+              os=.*
             options:
               shared=False
             requires:
@@ -221,7 +209,7 @@ class TestRemotes(TestListPackageIdsBase):
         remote2:
           There are no matching references
         """)
-        assert expected_output == output
+        assert bool(re.match(expected_output, str(self.client.out), re.MULTILINE))
 
     def test_search_in_missing_remote(self):
         remote1 = "remote1"

--- a/conans/test/integration/command_v2/list_package_ids_test.py
+++ b/conans/test/integration/command_v2/list_package_ids_test.py
@@ -1,0 +1,180 @@
+import re
+
+import pytest
+
+from conans.test.assets.genconanfile import GenConanfile
+from conans.test.utils.tools import TestClient, TestServer
+
+
+class TestListRecipeRevisionsBase:
+    @pytest.fixture(autouse=True)
+    def _setup(self):
+        self.client = TestClient()
+
+    def _add_remote(self, remote_name):
+        self.client.servers[remote_name] = TestServer(users={"username": "passwd"}, write_permissions=[("*/*@*/*", "*")])
+        self.client.update_servers()
+        self.client.run("user username -p passwd -r {}".format(remote_name))
+
+    def _create_recipe(self, reference):
+        self.client.save({'conanfile.py': GenConanfile()})
+        self.client.run("create . {}".format(reference))
+
+    def _upload_recipe(self, remote, reference):
+        self.client.save({'conanfile.py': GenConanfile()})
+        self.client.run("export . {}".format(reference))
+        self.client.run("upload --force -r {} {}".format(remote, reference))
+
+
+class TestParams(TestListRecipeRevisionsBase):
+    def test_fail_if_reference_is_not_correct(self):
+        self.client.run("list recipe-revisions whatever", assert_error=True)
+        assert "ERROR: Specify the 'name' and the 'version'" in self.client.out
+
+        self.client.run("list recipe-revisions whatever/", assert_error=True)
+        assert "ERROR: Specify the 'name' and the 'version'" in self.client.out
+
+        self.client.run("list recipe-revisions whatever/1", assert_error=True)
+        assert "ERROR: Value provided for package version, '1' (type Version), is too short" in self.client.out
+
+    def test_query_param_is_required(self):
+        self._add_remote("remote1")
+
+        self.client.run("list recipe-revisions", assert_error=True)
+        assert "error: the following arguments are required: reference" in self.client.out
+
+        self.client.run("list recipe-revisions -c", assert_error=True)
+        assert "error: the following arguments are required: reference" in self.client.out
+
+        self.client.run("list recipe-revisions --all-remotes", assert_error=True)
+        assert "error: the following arguments are required: reference" in self.client.out
+
+        self.client.run("list recipe-revisions --remote remote1 --cache", assert_error=True)
+        assert "error: the following arguments are required: reference" in self.client.out
+
+    def test_remote_and_all_remotes_are_mutually_exclusive(self):
+        self._add_remote("remote1")
+
+        self.client.run("list recipe-revisions --all-remotes --remote remote1 package/1.0", assert_error=True)
+        assert "error: argument -r/--remote: not allowed with argument -a/--all-remotes" in self.client.out
+
+
+class TestListRecipesFromRemotes(TestListRecipeRevisionsBase):
+    def test_by_default_search_only_in_cache(self):
+        self._add_remote("remote1")
+        self._add_remote("remote2")
+
+        expected_output = ("Local Cache:\n"
+                           "  There are no matching recipes\n")
+
+        self.client.run("list recipe-revisions whatever/1.0")
+        assert expected_output == self.client.out
+
+    def test_search_no_matching_recipes(self):
+        self._add_remote("remote1")
+        self._add_remote("remote2")
+
+        expected_output = ("Local Cache:\n"
+                           "  There are no matching recipes\n"
+                           "remote1:\n"
+                           "  There are no matching recipes\n"
+                           "remote2:\n"
+                           "  There are no matching recipes\n")
+
+        self.client.run("list recipe-revisions -c -a whatever/1.0")
+        assert expected_output == self.client.out
+
+    def test_fail_if_no_configured_remotes(self):
+        self.client.run("list recipe-revisions -a whatever/1.0", assert_error=True)
+        assert "ERROR: The remotes registry is empty" in self.client.out
+
+    def test_search_disabled_remote(self):
+        self._add_remote("remote1")
+        self.client.run("remote disable remote1")
+        self.client.run("list recipe-revisions -r remote1 whatever/1.0", assert_error=True)
+        assert "ERROR: Remote 'remote1' is disabled" in self.client.out
+
+
+class TestRemotes(TestListRecipeRevisionsBase):
+    def test_search_with_full_reference(self):
+        remote_name = "remote1"
+        recipe_name = "test_recipe/1.0.0@user/channel"
+        self._add_remote(remote_name)
+        self._upload_recipe(remote_name, recipe_name)
+
+        self.client.run("list recipe-revisions -r remote1 test_recipe/1.0.0@user/channel")
+
+        expected_output = (
+            r"remote1:\n"
+            r"  {}#.*\n".format(recipe_name)
+        )
+
+        assert bool(re.match(expected_output, str(self.client.out), re.MULTILINE))
+
+    def test_search_without_user_and_channel(self):
+        remote_name = "remote1"
+        recipe_name = "test_recipe/1.0.0@user/channel"
+        self._add_remote(remote_name)
+        self._upload_recipe(remote_name, recipe_name)
+
+        self.client.run("list recipe-revisions -r remote1 test_recipe/1.0.0")
+
+        expected_output = (
+            "remote1:\n"
+            "  There are no matching recipes\n"
+        )
+
+        assert expected_output in self.client.out
+
+    def test_search_in_all_remotes_and_cache(self):
+        expected_output = (
+            r"Local Cache:\n"
+            r"  test_recipe/1.0.0@user/channel#.*\n"
+            r"remote1:\n"
+            r"  test_recipe/1.0.0@user/channel#.*\n"
+            r"remote2:\n"
+            r"  There are no matching recipes\n"
+        )
+
+        remote1 = "remote1"
+        remote2 = "remote2"
+
+        self._add_remote(remote1)
+        self._upload_recipe(remote1, "test_recipe/1.0.0@user/channel")
+        self._upload_recipe(remote1, "test_recipe/1.1.0@user/channel")
+
+        self._add_remote(remote2)
+        self._upload_recipe(remote2, "test_recipe/2.0.0@user/channel")
+        self._upload_recipe(remote2, "test_recipe/2.1.0@user/channel")
+
+        self.client.run("list recipe-revisions -a -c test_recipe/1.0.0@user/channel")
+        output = str(self.client.out)
+
+        assert bool(re.match(expected_output, output, re.MULTILINE))
+
+    def test_search_in_missing_remote(self):
+        remote1 = "remote1"
+
+        remote1_recipe1 = "test_recipe/1.0.0@user/channel"
+        remote1_recipe2 = "test_recipe/1.1.0@user/channel"
+
+        expected_output = "No remote 'wrong_remote' defined in remotes"
+
+        self._add_remote(remote1)
+        self._upload_recipe(remote1, remote1_recipe1)
+        self._upload_recipe(remote1, remote1_recipe2)
+
+        self.client.run("list recipe-revisions -r wrong_remote test_recipe/1.0.0@user/channel", assert_error=True)
+        assert expected_output in self.client.out
+
+    def test_wildcard_not_accepted(self):
+        remote1 = "remote1"
+        remote1_recipe1 = "test_recipe/1.0.0@user/channel"
+
+        expected_output = "is an invalid name. Valid names MUST begin with a letter, number or underscore"
+
+        self._add_remote(remote1)
+        self._upload_recipe(remote1, remote1_recipe1)
+        self.client.run("list recipe-revisions -a -c test_*", assert_error=True)
+
+        assert expected_output in self.client.out


### PR DESCRIPTION
Changelog: omit
Docs: omit 

```
$ conan list package-ids -h
usage: conan list package-ids [-h] [-f {cli,json}] [-r REMOTE | -a] [-c] reference

positional arguments:
  reference

optional arguments:
  -h, --help            show this help message and exit
  -f {cli,json}, --format {cli,json}
                        Select the output format: cli, json. 'cli' is the default output.
  -r REMOTE, --remote REMOTE
                        Name of the remote to add
  -a, --all-remotes     Search in all the remotes
  -c, --cache           Search in the local cache
```
Docs: https://github.com/conan-io/docs/pull/XXXX

Depends on: https://github.com/conan-io/conan/pull/9288

- [x] Refer to the issue that supports this Pull Request.
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 

<sup>**Note:** By default this PR will skip the slower tests and will use a limited set of python versions. Check [here](https://github.com/conan-io/conan/blob/develop/.github/PR_INCREASE_TESTING.md) how to increase the testing level by writing some tags in the current PR body text.</sup>
