### PR TITLE
allow -o &:option=value wildcard for consumer

### DIFF
--- a/conans/model/options.py
+++ b/conans/model/options.py
@@ -631,7 +631,8 @@ class Options(object):
             # This code is necessary to process patterns like *:shared=True
             # To apply to the current consumer, which might not have name
             for pattern, pkg_options in sorted(user_values._reqs_options.items()):
-                if fnmatch.fnmatch(name or "", pattern):
+                # pattern = & means the consumer, irrespective of name
+                if fnmatch.fnmatch(name or "", pattern) or pattern == "&":
                     self._package_options.initialize_patterns(pkg_options)
             # Then, the normal assignment of values, which could override patterns
             self._package_options.values = user_values._package_values

--- a/conans/test/functional/configuration/profile_test.py
+++ b/conans/test/functional/configuration/profile_test.py
@@ -742,9 +742,10 @@ def test_consumer_specific_settings():
     # Test that the generators take the setting
     if platform.system() != "Windows":  # Toolchain in windows is multiconfig
         # Now the consumer using &
-        client.run("install . -s &:build_type=Debug -o dep:shared=True -g CMakeToolchain")
+        client.run("install . -s &:build_type=Debug -g CMakeToolchain")
         assert "I'm dep and my build type is Release" in client.out
         # Verify the cmake toolchain takes Debug
+        assert "I'm dep and my shared is False" in client.out
         contents = client.load("conan_toolchain.cmake")
         assert 'set(CMAKE_BUILD_TYPE "Debug"' in contents
 

--- a/conans/test/functional/configuration/profile_test.py
+++ b/conans/test/functional/configuration/profile_test.py
@@ -685,18 +685,21 @@ def test_profile_from_temp_absolute_path():
 
 def test_consumer_specific_settings():
     client = TestClient()
-    dep = str(GenConanfile().with_settings("build_type"))
+    dep = str(GenConanfile().with_settings("build_type").with_option("shared", [True, False])
+              .with_default_option("shared", False))
     configure = """
     def configure(self):
         self.output.warn("I'm {} and my build type is {}".format(self.name,
                                                                  self.settings.build_type))
+        self.output.warn("I'm {} and my shared is {}".format(self.name, self.options.shared))
     """
     dep += configure
     client.save({"conanfile.py": dep})
     client.run("create . dep/1.0@")
-    client.run("create . dep/1.0@ -s build_type=Debug")
+    client.run("create . dep/1.0@ -s build_type=Debug -o dep:shared=True")
 
-    consumer = str(GenConanfile().with_settings("build_type").with_requires("dep/1.0"))
+    consumer = str(GenConanfile().with_settings("build_type").with_requires("dep/1.0")
+                   .with_option("shared", [True, False]).with_default_option("shared", False))
     consumer += configure
     client.save({"conanfile.py": consumer})
 
@@ -704,16 +707,22 @@ def test_consumer_specific_settings():
     client.run("install . -s build_type=Release")
     assert "I'm dep and my build type is Release" in client.out
     assert "I'm None and my build type is Release" in client.out
+    assert "I'm dep and my shared is False" in client.out
+    assert "I'm None and my shared is False" in client.out
 
     # Now the dependency by name
-    client.run("install . -s dep:build_type=Debug")
+    client.run("install . -s dep:build_type=Debug -o dep:shared=True")
     assert "I'm dep and my build type is Debug" in client.out
     assert "I'm None and my build type is Release" in client.out
+    assert "I'm dep and my shared is True" in client.out
+    assert "I'm None and my shared is False" in client.out
 
     # Now the consumer using &
-    client.run("install . -s &:build_type=Debug")
+    client.run("install . -s &:build_type=Debug -o &:shared=True")
     assert "I'm dep and my build type is Release" in client.out
     assert "I'm None and my build type is Debug" in client.out
+    assert "I'm dep and my shared is False" in client.out
+    assert "I'm None and my shared is True" in client.out
 
     # Now use a conanfile.txt
     client.save({"conanfile.txt": textwrap.dedent("""
@@ -726,13 +735,14 @@ def test_consumer_specific_settings():
     assert "I'm dep and my build type is Release" in client.out
 
     # Now the dependency by name
-    client.run("install . -s dep:build_type=Debug")
+    client.run("install . -s dep:build_type=Debug -o dep:shared=True")
     assert "I'm dep and my build type is Debug" in client.out
+    assert "I'm dep and my shared is True" in client.out
 
     # Test that the generators take the setting
     if platform.system() != "Windows":  # Toolchain in windows is multiconfig
         # Now the consumer using &
-        client.run("install . -s &:build_type=Debug  -g CMakeToolchain")
+        client.run("install . -s &:build_type=Debug -o dep:shared=True -g CMakeToolchain")
         assert "I'm dep and my build type is Release" in client.out
         # Verify the cmake toolchain takes Debug
         contents = client.load("conan_toolchain.cmake")


### PR DESCRIPTION
Changelog: Feature: Allow ``-o &:option=value`` wildcard for consumer, too, same it was done for settings in 1.39
Docs: https://github.com/conan-io/docs/pull/2214


