### PR TITLE
environment auto-use always

### DIFF
--- a/conans/client/generators/__init__.py
+++ b/conans/client/generators/__init__.py
@@ -185,12 +185,11 @@ def write_toolchain(conanfile, path, output):
             with conanfile_exception_formatter(str(conanfile), "generate"):
                 conanfile.generate()
 
-    # tools.env.virtualenv:auto_use will be always True in Conan 2.0
-    if conanfile.conf["tools.env.virtualenv:auto_use"] and conanfile.virtualenv:
+    if conanfile.virtualenv:
         mkdir(path)
         with chdir(path):
             from conan.tools.env.virtualbuildenv import VirtualBuildEnv
-            from conan.tools.env import VirtualRunEnv
+            from conan.tools.env.virtualrunenv import VirtualRunEnv
             env = VirtualBuildEnv(conanfile)
             env.generate()
 

--- a/conans/model/conf.py
+++ b/conans/model/conf.py
@@ -15,7 +15,6 @@ DEFAULT_CONFIGURATION = {
     "tools.ninja:jobs": "Argument for the --jobs parameter when running Ninja generator",
     "tools.gnu.make:jobs": "Argument for the -j parameter when running Make generator",
     "tools.gnu:make_program": "Indicate path to make program",
-    "tools.env.virtualenv:auto_use": "Automatically activate virtualenvs when changing into a directory",
     "tools.cmake.cmaketoolchain:generator": "User defined CMake generator to use instead of default",
     "tools.cmake.cmaketoolchain:msvc_parallel_compile": "Argument for the /MP when running msvc",
     "tools.cmake.cmaketoolchain:find_package_prefer_config": "Argument for the CMAKE_FIND_PACKAGE_PREFER_CONFIG",

--- a/conans/test/integration/environment/test_env.py
+++ b/conans/test/integration/environment/test_env.py
@@ -64,7 +64,6 @@ def client():
                 self.runenv_info.define("MYGTESTVAR", "MyGTestValue{}".format(self.settings.os))
             """)
     client = TestClient()
-    save(client.cache.new_config_path, "tools.env.virtualenv:auto_use=True")
     client.save({"cmake/conanfile.py": cmake,
                  "gtest/conanfile.py": gtest,
                  "openssl/conanfile.py": openssl})
@@ -169,7 +168,6 @@ def test_profile_included_multiple():
 
 def test_profile_buildenv():
     client = TestClient()
-    save(client.cache.new_config_path, "tools.env.virtualenv:auto_use=True")
     conanfile = textwrap.dedent("""\
         import os, platform
         from conans import ConanFile

--- a/conans/test/integration/toolchains/env/test_virtualenv_default_apply.py
+++ b/conans/test/integration/toolchains/env/test_virtualenv_default_apply.py
@@ -6,7 +6,6 @@ import pytest
 
 from conans.test.assets.genconanfile import GenConanfile
 from conans.test.utils.tools import TestClient
-from conans.tools import save
 
 
 @pytest.fixture
@@ -20,7 +19,6 @@ def client():
     """
     client.save({"conanfile.py": conanfile})
     client.run("create . foo/1.0@")
-    save(client.cache.new_config_path, "tools.env.virtualenv:auto_use=True")
     return client
 
 

--- a/conans/test/integration/toolchains/env/test_virtualenv_object_access.py
+++ b/conans/test/integration/toolchains/env/test_virtualenv_object_access.py
@@ -1,13 +1,10 @@
-import os
-import platform
 import textwrap
 
 import pytest
 
-from conans.client.tools.env import _environment_add
+
 from conans.test.assets.genconanfile import GenConanfile
 from conans.test.utils.tools import TestClient
-from conans.tools import save
 
 
 @pytest.fixture
@@ -22,7 +19,6 @@ def client():
     """
     client.save({"conanfile.py": conanfile})
     client.run("create . foo/1.0@")
-    save(client.cache.new_config_path, "tools.env.virtualenv:auto_use=True")
     return client
 
 


### PR DESCRIPTION
Changelog: Feature: ``VirtualBuildEnv`` and ``VirtualRunEnv`` are always defined by default to manage environment and create environment files. 
Docs: Omit
