### PR TITLE
Bugfix/pkconfigdeps

### DIFF
--- a/conan/tools/gnu/pkgconfigdeps.py
+++ b/conan/tools/gnu/pkgconfigdeps.py
@@ -49,7 +49,8 @@ class PkgConfigDeps(object):
         self._conanfile = conanfile
 
     def _get_require_comp_name(self, dep, req):
-        pkg_name = dep.ref.name
+        # FIXME: this str() is only needed for python2.7 (unicode values). Remove it for Conan 2.0
+        pkg_name = str(dep.ref.name)
         pkg, comp_name = req.split("::") if "::" in req else (pkg_name, req)
         # FIXME: it could allow defining requires to not direct dependencies
         req = self._conanfile.dependencies.host[pkg]

--- a/conan/tools/gnu/pkgconfigdeps.py
+++ b/conan/tools/gnu/pkgconfigdeps.py
@@ -51,7 +51,8 @@ class PkgConfigDeps(object):
     def _get_require_comp_name(self, dep, req):
         pkg_name = dep.ref.name
         pkg, comp_name = req.split("::") if "::" in req else (pkg_name, req)
-        req = dep.dependencies.direct_host[pkg]
+        # FIXME: it could allow defining requires to not direct dependencies
+        req = self._conanfile.dependencies.host[pkg]
         cmp_name = get_component_alias(req, comp_name)
         return cmp_name
 

--- a/conans/test/functional/toolchains/gnu/test_pkgconfigdeps.py
+++ b/conans/test/functional/toolchains/gnu/test_pkgconfigdeps.py
@@ -299,6 +299,8 @@ def test_pkg_getting_public_requires():
             def package_info(self):
                 self.cpp_info.components["cmp1"].libs = ["other_cmp1"]
                 self.cpp_info.components["cmp2"].libs = ["other_cmp2"]
+                self.cpp_info.components["cmp3"].requires.append("cmp1")
+
     """)
     client.save({"conanfile.py": conanfile})
     client.run("create . other/1.0@")
@@ -329,3 +331,5 @@ def test_pkg_getting_public_requires():
     assert "Requires: cmp1" in pc_content
     assert client2.load("other-cmp1.pc")
     assert client2.load("other-cmp2.pc")
+    pc_content = client2.load("other-cmp3.pc")
+    assert "Requires: cmp1" in pc_content

--- a/conans/test/functional/toolchains/gnu/test_pkgconfigdeps.py
+++ b/conans/test/functional/toolchains/gnu/test_pkgconfigdeps.py
@@ -252,12 +252,11 @@ def test_custom_content_components():
     client.save({"conanfile.py": conanfile})
     client.run("create . pkg/0.1@")
     client.run("install pkg/0.1@ -g PkgConfigDeps")
-
     pc_content = client.load("pkg-mycomponent.pc")
     assert "componentdir=${prefix}/mydir" in pc_content
 
 
-def test_components_with_requires():
+def test_pkg_with_component_requires():
     client = TestClient()
     client.save({"conanfile.py": GenConanfile("other", "0.1").with_package_file("file.h", "0.1")})
     client.run("create . user/channel")
@@ -270,6 +269,7 @@ def test_components_with_requires():
 
             def package_info(self):
                 self.cpp_info.components["mycomponent"].requires.append("other::other")
+                self.cpp_info.components["myothercomp"].requires.append("mycomponent")
 
         """)
     client.save({"conanfile.py": conanfile})
@@ -285,3 +285,47 @@ def test_components_with_requires():
         """)
     client2.save({"conanfile.txt": conanfile})
     client2.run("install .")
+    pc_content = client2.load("pkg-mycomponent.pc")
+    assert "Requires: other" in pc_content
+
+
+def test_pkg_getting_public_requires():
+    client = TestClient()
+    conanfile = textwrap.dedent("""
+        from conans import ConanFile
+
+        class Recipe(ConanFile):
+
+            def package_info(self):
+                self.cpp_info.components["cmp1"].libs = ["other_cmp1"]
+                self.cpp_info.components["cmp2"].libs = ["other_cmp2"]
+    """)
+    client.save({"conanfile.py": conanfile})
+    client.run("create . other/1.0@")
+
+    conanfile = textwrap.dedent("""
+        from conans import ConanFile
+
+        class PkgConfigConan(ConanFile):
+            requires = "other/1.0"
+
+            def package_info(self):
+                self.cpp_info.requires = ["other::cmp1"]
+        """)
+    client.save({"conanfile.py": conanfile})
+    client.run("create . pkg/0.1@")
+
+    client2 = TestClient(cache_folder=client.cache_folder)
+    conanfile = textwrap.dedent("""
+        [requires]
+        pkg/0.1
+
+        [generators]
+        PkgConfigDeps
+        """)
+    client2.save({"conanfile.txt": conanfile})
+    client2.run("install .")
+    pc_content = client2.load("pkg.pc")
+    assert "Requires: cmp1" in pc_content
+    assert client2.load("other-cmp1.pc")
+    assert client2.load("other-cmp2.pc")


### PR DESCRIPTION
Changelog: Bugfix: Fix `PkgConfigDeps` that was failing in the case of components with requirements. 
Docs: omit

`PkgConfigDeps` was failing in the case of components with requirements.  It was showing an error like the following one:
```
ERROR: Error in generator 'PkgConfigDeps': {'ref': pkg/unknown@unknown/unknown, 'build': False, 'direct': True, 'test': False}
```


Closes: https://github.com/conan-io/conan/issues/9292
Close: https://github.com/conan-io/conan/issues/9496

- [x] Refer to the issue that supports this Pull Request.
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 

<sup>**Note:** By default this PR will skip the slower tests and will use a limited set of python versions. Check [here](https://github.com/conan-io/conan/blob/develop/.github/PR_INCREASE_TESTING.md) how to increase the testing level by writing some tags in the current PR body text.</sup>
