### PR TITLE
New version ranges resolution logic for conan 2.0 with --update

### DIFF
--- a/conans/client/graph/range_resolver.py
+++ b/conans/client/graph/range_resolver.py
@@ -1,5 +1,4 @@
 import re
-from collections import defaultdict
 
 from conans.errors import ConanException
 from conans.model.ref import ConanFileReference

--- a/conans/client/graph/range_resolver.py
+++ b/conans/client/graph/range_resolver.py
@@ -118,16 +118,11 @@ class RangeResolver(object):
         # The search pattern must be a string
         search_ref = ConanFileReference(ref.name, "*", ref.user, ref.channel)
 
-        if update:
-            resolved_ref, remote_name = self._resolve_remote(search_ref, version_range, remotes)
-            if not resolved_ref:
-                remote_name = None
-                resolved_ref = self._resolve_local(search_ref, version_range)
-        else:
-            remote_name = None
-            resolved_ref = self._resolve_local(search_ref, version_range)
-            if not resolved_ref:
-                resolved_ref, remote_name = self._resolve_remote(search_ref, version_range, remotes)
+        remote_name = None
+        resolved_ref = self._resolve_local(search_ref, version_range)
+        if not resolved_ref or update:
+            resolved_ref, remote_name = self._resolve_remote(search_ref, version_range, remotes,
+                                                             check_all_remotes=update)
 
         origin = ("remote '%s'" % remote_name) if remote_name else "local cache"
         if resolved_ref:
@@ -147,24 +142,36 @@ class RangeResolver(object):
         if local_found:
             return self._resolve_version(version_range, local_found)
 
-    def _search_remotes(self, search_ref, version_range, remotes):
+    def _search_remotes(self, search_ref, version_range, remotes, check_all_remotes):
         pattern = str(search_ref)
+        results = []
         for remote in remotes.values():
             if not remotes.selected or remote == remotes.selected:
                 remote_results = self._remote_manager.search_recipes(remote, pattern, ignorecase=False)
                 remote_results = [ref for ref in remote_results
                                   if ref.user == search_ref.user and ref.channel == search_ref.channel]
                 resolved_version = self._resolve_version(version_range, remote_results)
-                if resolved_version:
+                if resolved_version and not check_all_remotes:
                     return resolved_version, remote.name
-        return None, None
+                elif resolved_version:
+                    results.append({"remote": remote.name,
+                                    "version": resolved_version})
+        if len(results) > 0:
+            resolved_version = self._resolve_version(version_range,
+                                                     [result.get("version") for result in results])
+            for result in results:
+                if result.get("version") == resolved_version:
+                    return result.get("version"), result.get("remote")
+        else:
+            return None, None
 
-    def _resolve_remote(self, search_ref, version_range, remotes):
+    def _resolve_remote(self, search_ref, version_range, remotes, check_all_remotes):
         # We should use ignorecase=False, we want the exact case!
         found_refs, remote_name = self._cached_remote_found.get(search_ref, (None, None))
         if found_refs is None:
             # Searching for just the name is much faster in remotes like Artifactory
-            found_refs, remote_name = self._search_remotes(search_ref, version_range, remotes)
+            found_refs, remote_name = self._search_remotes(search_ref, version_range, remotes,
+                                                           check_all_remotes)
             if found_refs:
                 self._result.append("%s versions found in '%s' remote" % (search_ref, remote_name))
             else:

--- a/conans/client/graph/range_resolver.py
+++ b/conans/client/graph/range_resolver.py
@@ -177,7 +177,7 @@ class RangeResolver(object):
             if not remotes.selected or remote == remotes.selected:
                 cached_search = self._cached_remote_found.get(search_ref)
                 if cached_search:
-                    cached_refs = cached_search.get(remote.name) or []
+                    cached_refs = cached_search.get(remote.name, [])
                     all_refs = [resolved_ref].extend(cached_refs) if resolved_ref else cached_refs
                     resolved_ref = self._resolve_version(version_range, all_refs)
                     if resolved_ref in cached_refs:

--- a/conans/client/graph/range_resolver.py
+++ b/conans/client/graph/range_resolver.py
@@ -1,4 +1,5 @@
 import re
+from collections import defaultdict
 
 from conans.errors import ConanException
 from conans.model.ref import ConanFileReference
@@ -86,7 +87,7 @@ class RangeResolver(object):
     def __init__(self, cache, remote_manager):
         self._cache = cache
         self._remote_manager = remote_manager
-        self._cached_remote_found = {}
+        self._cached_remote_found = defaultdict(dict)
         self._result = []
 
     @property
@@ -152,7 +153,7 @@ class RangeResolver(object):
             if not remotes.selected or remote == remotes.selected:
                 remote_results = self._remote_manager.search_recipes(remote, pattern, ignorecase=False)
                 if remote_results:
-                    self._cached_remote_found.update({search_ref: {remote.name: remote_results}})
+                    self._cached_remote_found[search_ref].update({remote.name: remote_results})
                 remote_results = [ref for ref in remote_results
                                   if ref.user == search_ref.user and ref.channel == search_ref.channel]
                 resolved_version = self._resolve_version(version_range, remote_results)

--- a/conans/client/graph/range_resolver.py
+++ b/conans/client/graph/range_resolver.py
@@ -147,15 +147,16 @@ class RangeResolver(object):
         if local_found:
             return self._resolve_version(version_range, local_found)
 
-    def _search_remotes(self, search_ref, remotes):
+    def _search_remotes(self, search_ref, version_range, remotes):
         pattern = str(search_ref)
         for remote in remotes.values():
             if not remotes.selected or remote == remotes.selected:
-                result = self._remote_manager.search_recipes(remote, pattern, ignorecase=False)
-                result = [ref for ref in result
-                          if ref.user == search_ref.user and ref.channel == search_ref.channel]
-                if result:
-                    return result, remote.name
+                remote_results = self._remote_manager.search_recipes(remote, pattern, ignorecase=False)
+                remote_results = [ref for ref in remote_results
+                                  if ref.user == search_ref.user and ref.channel == search_ref.channel]
+                resolved_version = self._resolve_version(version_range, remote_results)
+                if resolved_version:
+                    return resolved_version, remote.name
         return None, None
 
     def _resolve_remote(self, search_ref, version_range, remotes):
@@ -163,19 +164,18 @@ class RangeResolver(object):
         found_refs, remote_name = self._cached_remote_found.get(search_ref, (None, None))
         if found_refs is None:
             # Searching for just the name is much faster in remotes like Artifactory
-            found_refs, remote_name = self._search_remotes(search_ref, remotes)
+            found_refs, remote_name = self._search_remotes(search_ref, version_range, remotes)
             if found_refs:
                 self._result.append("%s versions found in '%s' remote" % (search_ref, remote_name))
             else:
                 self._result.append("%s versions not found in remotes")
             # We don't want here to resolve the revision that should be done in the proxy
             # as any other regular flow
-            found_refs = [ref.copy_clear_rev() for ref in found_refs or []]
+            # FIXME: refactor all this and update for 2.0
+            found_refs = found_refs.copy_clear_rev() if found_refs else None
             # Empty list, just in case it returns None
             self._cached_remote_found[search_ref] = found_refs, remote_name
-        if found_refs:
-            return self._resolve_version(version_range, found_refs), remote_name
-        return None, None
+        return (found_refs, remote_name) if found_refs else (None, None)
 
     def _resolve_version(self, version_range, refs_found):
         versions = {ref.version: ref for ref in refs_found}

--- a/conans/test/integration/graph/version_ranges/version_ranges_cached_test.py
+++ b/conans/test/integration/graph/version_ranges/version_ranges_cached_test.py
@@ -63,8 +63,7 @@ class TestVersionRangesCache:
         # should call only once to server0
         self.counters["server0"] = 0
         self.counters["server1"] = 0
-        with patch.object(RemoteManager, "search_recipes",
-                          new=self._mocked_search_recipes) as mocked_search_recipes:
+        with patch.object(RemoteManager, "search_recipes", new=self._mocked_search_recipes):
             client.run("create . --update")
             assert self.counters["server0"] == 1
             assert self.counters["server1"] == 1

--- a/conans/test/integration/graph/version_ranges/version_ranges_cached_test.py
+++ b/conans/test/integration/graph/version_ranges/version_ranges_cached_test.py
@@ -1,0 +1,70 @@
+from collections import OrderedDict
+
+import pytest
+from mock import patch
+
+from conans.client.remote_manager import RemoteManager
+from conans.model.ref import ConanFileReference
+from conans.test.assets.genconanfile import GenConanfile
+from conans.test.utils.tools import TestClient, TestServer
+
+
+class TestVersionRangesCache:
+
+    @pytest.fixture(autouse=True)
+    def _setup(self):
+        self.counters = {"server0": 0, "server1": 0}
+
+    def _mocked_search_recipes(self, remote, pattern, ignorecase=True):
+        packages = {
+            "server0": [ConanFileReference.loads("liba/1.0.0"),
+                        ConanFileReference.loads("liba/1.1.0")],
+            "server1": [ConanFileReference.loads("liba/2.0.0"),
+                        ConanFileReference.loads("liba/2.1.0")]
+        }
+        self.counters[remote.name] = self.counters[remote.name] + 1
+        return packages[remote.name]
+
+    def test_version_ranges_cached(self):
+        servers = OrderedDict()
+        for index in range(2):
+            servers[f"server{index}"] = TestServer([("*/*@*/*", "*")], [("*/*@*/*", "*")],
+                                                   users={"user": "password"})
+
+        users = {"server0": [("user", "password")],
+                 "server1": [("user", "password")]}
+
+        client = TestClient(servers=servers, users=users)
+
+        # server0 does not satisfy range
+        # server1 does
+
+        for minor in range(2):
+            client.save({"conanfile.py": GenConanfile("liba", f"1.{minor}.0")})
+            client.run("create .")
+            client.run(f"upload liba/1.{minor}.0 -r server0 --all -c")
+
+        for minor in range(2):
+            client.save({"conanfile.py": GenConanfile("liba", f"2.{minor}.0")})
+            client.run("create .")
+            client.run(f"upload liba/2.{minor}.0 -r server1 --all -c")
+
+        client.run("remove * -f")
+
+        client.save({"conanfile.py": GenConanfile("libb", "1.0").with_require("liba/[>=2.0]")})
+        client.run("create .")
+
+        client.save({"conanfile.py": GenConanfile("libc", "1.0").with_require("liba/[>=2.0]")})
+        client.run("create .")
+
+        client.save({"conanfile.py": GenConanfile("consumer", "1.0")
+                    .with_requires("libb/1.0", "libc/1.0")})
+
+        # should call only once to server0
+        self.counters["server0"] = 0
+        self.counters["server1"] = 0
+        with patch.object(RemoteManager, "search_recipes",
+                          new=self._mocked_search_recipes) as mocked_search_recipes:
+            client.run("create . --update")
+            assert self.counters["server0"] == 1
+            assert self.counters["server1"] == 1

--- a/conans/test/integration/graph/version_ranges/version_ranges_diamond_test.py
+++ b/conans/test/integration/graph/version_ranges/version_ranges_diamond_test.py
@@ -276,7 +276,6 @@ class HelloReuseConan(ConanFile):
                       "RequirementOne/[=1.2.3]@lasote/stable"], upload=True)
 
         self.client.run("remove '*' -f")
-        self.client.run("search '*' -r default")
         self.client.run("install Project/1.0.0@lasote/stable --build missing", assert_error=True)
         self.assertIn("Conflict in RequirementOne/1.2.3@lasote/stable:\n"
             "    'RequirementOne/1.2.3@lasote/stable' requires "

--- a/conans/test/integration/graph/version_ranges/version_ranges_diamond_test.py
+++ b/conans/test/integration/graph/version_ranges/version_ranges_diamond_test.py
@@ -6,6 +6,7 @@ import pytest
 from parameterized import parameterized
 
 from conans.paths import CONANFILE
+from conans.test.assets.genconanfile import GenConanfile
 from conans.test.utils.tools import NO_SETTINGS_PACKAGE_ID, TestClient, TestServer, \
     inc_package_manifest_timestamp, inc_recipe_manifest_timestamp
 
@@ -52,35 +53,35 @@ class VersionRangesUpdatingTest(unittest.TestCase):
     def test_update(self):
         client = TestClient(servers={"default": TestServer()},
                             users={"default": [("lasote", "mypass")]})
-        conanfile = """from conans import ConanFile
-class HelloReuseConan(ConanFile):
-    pass
-"""
-        client.save({"conanfile.py": conanfile})
-        client.run("create . Pkg/1.1@lasote/testing")
-        client.run("create . Pkg/1.2@lasote/testing")
+
+        client.save({"pkg.py": GenConanfile()})
+        client.run("create pkg.py Pkg/1.1@lasote/testing")
+        client.run("create pkg.py Pkg/1.2@lasote/testing")
         client.run("upload Pkg* -r=default --all --confirm")
         client.run("remove Pkg/1.2@lasote/testing -f")
-        conanfile = """from conans import ConanFile
-class HelloReuseConan(ConanFile):
-    requires = "Pkg/[~1]@lasote/testing"
-"""
-        client.save({"conanfile.py": conanfile})
-        client.run("install .")
+
+        client.save({"consumer.py": GenConanfile().with_requirement("Pkg/[~1]@lasote/testing")})
+        client.run("install consumer.py")
         # Resolves to local package
         self.assertIn("Pkg/1.1@lasote/testing: Already installed!", client.out)
-        client.run("install . --update")
+        client.run("install consumer.py --update")
         # Resolves to remote package
         self.assertIn("Pkg/1.2@lasote/testing: Package installed", client.out)
         self.assertNotIn("Pkg/1.1", client.out)
 
+        # newer in cache that in remotes and updating, should resolve the cache one
+        client.run("create pkg.py Pkg/1.3@lasote/testing")
+        client.run("install consumer.py --update")
+        self.assertIn("Pkg/1.3@lasote/testing: Already installed!", client.out)
+        client.run("remove Pkg/1.3@lasote/testing -f")
+
         # removes remote
         client.run("remove Pkg* -r=default --f")
         # Resolves to local package
-        client.run("install .")
+        client.run("install consumer.py")
         self.assertIn("Pkg/1.2@lasote/testing: Already installed!", client.out)
         # Update also resolves to local package
-        client.run("install . --update")
+        client.run("install consumer.py --update")
         self.assertIn("Pkg/1.2@lasote/testing: Already installed!", client.out)
         self.assertNotIn("Pkg/1.1", client.out)
 
@@ -275,8 +276,8 @@ class HelloReuseConan(ConanFile):
                       "RequirementOne/[=1.2.3]@lasote/stable"], upload=True)
 
         self.client.run("remove '*' -f")
+        self.client.run("search '*' -r default")
         self.client.run("install Project/1.0.0@lasote/stable --build missing", assert_error=True)
-
         self.assertIn("Conflict in RequirementOne/1.2.3@lasote/stable:\n"
             "    'RequirementOne/1.2.3@lasote/stable' requires "
             "'ProblemRequirement/1.0.0@lasote/stable' while 'RequirementTwo/4.5.6@lasote/stable'"


### PR DESCRIPTION
Changelog: Feature: New version ranges resolution logic for conan 2.0.
Docs: TODO (2.0 docs)

Extracted version ranges part from: https://github.com/conan-io/conan/pull/9191

This PR fixes some not clear behaviours when using version ranges and also using the --update argument. The logic should be exactly the same than [the one used with revisions](https://github.com/conan-io/conan/pull/9191#issuecomment-882256402) but translated to version ranges.

Version ranges are always resolved before revisions. So for example requiring a range [>1.0.0] with --update will check all the remotes and take the latest version that satisfies the range, for example 1.3, then if that version is in several remotes it will take the latest from all of them in the proxy. TODO: optimize all this flow to make as few API calls as we can.