### PR TITLE
Bump urllib3 version to 1.26.6

### DIFF
--- a/conans/requirements.txt
+++ b/conans/requirements.txt
@@ -1,6 +1,6 @@
 PyJWT>=1.4.0, <2.0.0
 requests>=2.8.1, <3.0.0
-urllib3>=1.25.8, <1.26
+urllib3>=1.26.6, <1.27
 colorama>=0.3.3, <0.5.0
 PyYAML>=3.11, <6.0
 patch-ng>=1.17.4, <1.18
@@ -14,4 +14,3 @@ deprecation>=2.0, <2.1
 tqdm>=4.28.1, <5
 Jinja2>=2.9, <3
 python-dateutil>=2.7.0, <3
-


### PR DESCRIPTION
Changelog: (Fix): Bump urllib3 version to 1.26.6 due to security issues with 1.25.x