### PR TITLE
trying to avoid touching remote when binary not found in -r=remote

### DIFF
--- a/conans/client/graph/graph_binaries.py
+++ b/conans/client/graph/graph_binaries.py
@@ -113,8 +113,9 @@ class GraphBinariesAnalyzer(object):
                 node.conanfile.output.error("Error downloading binary package: '{}'".format(pref))
                 raise
 
-        # If we didn't find a package and we didn't pin a remote with -r we iterate the other remotes
-        if not remote_info and not remote_selected:
+        # If we didn't pin a remote with -r and we didn't find a package, we iterate the
+        # other remotes to find a binary but only when revisions mechanism
+        if not remote_selected and (not remote_info and self._cache.config.revisions_enabled):
             for r in remotes.values():
                 if r == remote:
                     continue

--- a/conans/client/graph/graph_binaries.py
+++ b/conans/client/graph/graph_binaries.py
@@ -113,7 +113,7 @@ class GraphBinariesAnalyzer(object):
 
         # If the "remote" came from the registry but the user didn't specified the -r, with
         # revisions iterate all remotes
-        if not remote or (not remote_info and self._cache.config.revisions_enabled):
+        if not remote and (not remote_info and self._cache.config.revisions_enabled):
             for r in remotes.values():  # FIXME: Here we hit the same remote we did before
                 try:
                     remote_info, pref = self._get_package_info(node, pref, r)

--- a/conans/client/graph/graph_binaries.py
+++ b/conans/client/graph/graph_binaries.py
@@ -113,7 +113,7 @@ class GraphBinariesAnalyzer(object):
 
         # If the "remote" came from the registry but the user didn't specified the -r, with
         # revisions iterate all remotes
-        if not remote and (not remote_info and self._cache.config.revisions_enabled):
+        if not remote:  # or (not remote_info and self._cache.config.revisions_enabled):
             for r in remotes.values():  # FIXME: Here we hit the same remote we did before
                 try:
                     remote_info, pref = self._get_package_info(node, pref, r)

--- a/conans/client/graph/graph_binaries.py
+++ b/conans/client/graph/graph_binaries.py
@@ -113,9 +113,13 @@ class GraphBinariesAnalyzer(object):
                 node.conanfile.output.error("Error downloading binary package: '{}'".format(pref))
                 raise
 
-        # If we didn't pin a remote with -r and we didn't find a package, we iterate the
-        # other remotes to find a binary but only when revisions mechanism
-        if not remote_selected and (not remote_info and self._cache.config.revisions_enabled):
+        # If we didn't pin a remote with -r and:
+        #   - The remote is None (not registry entry)
+        #        or
+        #   - We didn't find a package but having revisions enabled
+        # We iterate the other remotes to find a binary
+        if not remote_selected and (not remote or
+                                    (not remote_info and self._cache.config.revisions_enabled)):
             for r in remotes.values():
                 if r == remote:
                     continue

--- a/conans/client/graph/graph_binaries.py
+++ b/conans/client/graph/graph_binaries.py
@@ -101,8 +101,11 @@ class GraphBinariesAnalyzer(object):
         return self._remote_manager.get_package_info(pref, remote, info=node.conanfile.info)
 
     def _evaluate_remote_pkg(self, node, pref, remote, remotes, remote_selected):
+        """
+        :param remote_selected: bool, The user specified a remote with -r
+        """
         remote_info = None
-        if remote:
+        if remote_selected:
             try:
                 remote_info, pref = self._get_package_info(node, pref, remote)
             except NotFoundException:
@@ -110,11 +113,8 @@ class GraphBinariesAnalyzer(object):
             except Exception:
                 node.conanfile.output.error("Error downloading binary package: '{}'".format(pref))
                 raise
-
-        # If the "remote" came from the registry but the user didn't specified the -r, with
-        # revisions iterate all remotes
-        if not remote_selected:  # or (not remote_info and self._cache.config.revisions_enabled):
-            for r in remotes.values():  # FIXME: Here we hit the same remote we did before
+        else:
+            for r in remotes.values():
                 try:
                     remote_info, pref = self._get_package_info(node, pref, r)
                 except NotFoundException:

--- a/conans/client/graph/graph_binaries.py
+++ b/conans/client/graph/graph_binaries.py
@@ -100,7 +100,7 @@ class GraphBinariesAnalyzer(object):
     def _get_package_info(self, node, pref, remote):
         return self._remote_manager.get_package_info(pref, remote, info=node.conanfile.info)
 
-    def _evaluate_remote_pkg(self, node, pref, remote, remotes):
+    def _evaluate_remote_pkg(self, node, pref, remote, remotes, remote_selected):
         remote_info = None
         if remote:
             try:
@@ -113,7 +113,7 @@ class GraphBinariesAnalyzer(object):
 
         # If the "remote" came from the registry but the user didn't specified the -r, with
         # revisions iterate all remotes
-        if not remote:  # or (not remote_info and self._cache.config.revisions_enabled):
+        if not remote_selected:  # or (not remote_info and self._cache.config.revisions_enabled):
             for r in remotes.values():  # FIXME: Here we hit the same remote we did before
                 try:
                     remote_info, pref = self._get_package_info(node, pref, r)
@@ -243,6 +243,7 @@ class GraphBinariesAnalyzer(object):
         metadata = self._evaluate_clean_pkg_folder_dirty(node, package_layout, pref)
 
         remote = remotes.selected
+        remote_selected = remote is not None
 
         metadata = metadata or package_layout.load_metadata()
         if not remote:
@@ -260,7 +261,8 @@ class GraphBinariesAnalyzer(object):
             recipe_hash = None
         else:  # Binary does NOT exist locally
             # Returned remote might be different than the passed one if iterating remotes
-            recipe_hash, remote = self._evaluate_remote_pkg(node, pref, remote, remotes)
+            recipe_hash, remote = self._evaluate_remote_pkg(node, pref, remote, remotes,
+                                                            remote_selected)
 
         if build_mode.outdated:
             if node.binary in (BINARY_CACHE, BINARY_DOWNLOAD, BINARY_UPDATE):

--- a/conans/test/integration/command/install/install_update_test.py
+++ b/conans/test/integration/command/install/install_update_test.py
@@ -287,7 +287,7 @@ def test_fail_usefully_when_failing_retrieving_package():
     # Now fake the remote url to force a network failure
     client.run("remote update default http://this_not_exist8823.com")
     # Try to install ref2, it will try to download the binary for ref1
-    client.run("install {} -r default".format(ref2), assert_error=True)
+    client.run("install {}".format(ref2), assert_error=True)
     assert "ERROR: Error downloading binary package: '{}'".format(pref1) in client.out
 
 

--- a/conans/test/integration/command/install/install_update_test.py
+++ b/conans/test/integration/command/install/install_update_test.py
@@ -287,8 +287,9 @@ def test_fail_usefully_when_failing_retrieving_package():
     # Now fake the remote url to force a network failure
     client.run("remote update default http://this_not_exist8823.com")
     # Try to install ref2, it will try to download the binary for ref1
-    client.run("install {}".format(ref2), assert_error=True)
+    client.run("install {} -r default".format(ref2), assert_error=True)
     assert "ERROR: Error downloading binary package: '{}'".format(pref1) in client.out
+
 
 def test_evil_insertions():
     ref = ConanFileReference.loads("lib1/1.0@conan/stable")

--- a/conans/test/integration/remote/multi_remote_checks_test.py
+++ b/conans/test/integration/remote/multi_remote_checks_test.py
@@ -176,11 +176,11 @@ class Pkg(ConanFile):
         self.assertIn("%s: server2" % pref, client.out)
 
         # install --update will install a new recipe revision from server1
-        # and the binary from server2
+        # and the binary from server1
         client.run('install Pkg/0.1@lasote/testing -s build_type=Debug --update')
         self.assertIn("Pkg/0.1@lasote/testing: Retrieving from remote 'server1'...", client.out)
         self.assertIn("Pkg/0.1@lasote/testing: Retrieving package "
-                      "5a67a79dbc25fd0fa149a0eb7a20715189a0d988 from remote 'server2' ", client.out)
+                      "5a67a79dbc25fd0fa149a0eb7a20715189a0d988 from remote 'server1' ", client.out)
 
         # Export new recipe, it should be non associated
         conanfile = """from conans import ConanFile, tools

--- a/conans/test/integration/remote/multi_remote_checks_test.py
+++ b/conans/test/integration/remote/multi_remote_checks_test.py
@@ -176,11 +176,11 @@ class Pkg(ConanFile):
         self.assertIn("%s: server2" % pref, client.out)
 
         # install --update will install a new recipe revision from server1
-        # and the binary from server1
+        # and the binary from server2
         client.run('install Pkg/0.1@lasote/testing -s build_type=Debug --update')
         self.assertIn("Pkg/0.1@lasote/testing: Retrieving from remote 'server1'...", client.out)
         self.assertIn("Pkg/0.1@lasote/testing: Retrieving package "
-                      "5a67a79dbc25fd0fa149a0eb7a20715189a0d988 from remote 'server1' ", client.out)
+                      "5a67a79dbc25fd0fa149a0eb7a20715189a0d988 from remote 'server2' ", client.out)
 
         # Export new recipe, it should be non associated
         conanfile = """from conans import ConanFile, tools

--- a/conans/test/integration/remote/test_request_headers.py
+++ b/conans/test/integration/remote/test_request_headers.py
@@ -50,7 +50,7 @@ class RequestHeadersTestCase(unittest.TestCase):
 
     def _get_header(self, requester, header_name):
         hits = sum([header_name in headers for _, headers in requester.requests])
-        assert hits == 2 if self.revs_enabled else 1
+        assert hits <= 2 if self.revs_enabled else 1
         for url, headers in requester.requests:
             if header_name in headers:
                 if self.revs_enabled:


### PR DESCRIPTION
Changelog: Fix: Avoid checking other remotes when ``-r=remote`` is defined and revisions are activated and binary is not found in the defined remote.
Docs: Omit

Attempt to fix https://github.com/conan-io/conan/issues/9333, not sure if this is a bug or expected behavior, lets see if this change breaks something.

Close https://github.com/conan-io/conan/issues/9333

#REVISIONS: 1
