### PR TITLE
Fix 9331 (usage of layout + components)

### DIFF
--- a/conans/client/installer.py
+++ b/conans/client/installer.py
@@ -699,9 +699,14 @@ class BinaryInstaller(object):
 
                     if conanfile._conan_dep_cpp_info is None:
                         try:
-                            if not is_editable:
+                            if not is_editable and not hasattr(conanfile, "layout"):
                                 # FIXME: The default for the cppinfo from build are not the same
                                 #        so this check fails when editable
+                                # FIXME: Remove when new cppinfo model. If using the layout method
+                                #        the cppinfo object is filled from self.cpp.package new
+                                #        model and we cannot check if the defaults have been modified
+                                #        because it doesn't exist in the new model where the defaults
+                                #        for the components are always empty
                                 conanfile.cpp_info._raise_incorrect_components_definition(
                                     conanfile.name, conanfile.requires)
                         except ConanException as e:

--- a/conans/test/integration/toolchains/cmake/cmakedeps/test_cmakedeps.py
+++ b/conans/test/integration/toolchains/cmake/cmakedeps/test_cmakedeps.py
@@ -62,3 +62,26 @@ def test_test_package():
     client.run("install . -s:b os=Windows -s:h os=Linux --build=missing")
     cmake_data = client.load("pkg-release-x86_64-data.cmake")
     assert "gtest" not in cmake_data
+
+
+def test_components_error():
+    # https://github.com/conan-io/conan/issues/9331
+    client = TestClient()
+
+    conan_hello = textwrap.dedent("""
+        import os
+        from conans import ConanFile
+
+        from conan.tools.files import save
+        class Pkg(ConanFile):
+            settings = "os", "arch", "compiler", "build_type"
+
+            def layout(self):
+                pass
+
+            def package_info(self):
+                self.cpp_info.components["say"].includedirs = ["include"]
+            """)
+
+    client.save({"conanfile.py": conan_hello})
+    client.run("create . hello/1.0@")


### PR DESCRIPTION
Changelog: Bugfix: Fixed bug whereby using new `layout()` method together with `cppinfo.components` in the `package_info` method caused an exception.
Docs: omit

close #9331 
