### PR TITLE
Use `frameworks` in Premake generator

### DIFF
--- a/conans/client/generators/premake.py
+++ b/conans/client/generators/premake.py
@@ -18,6 +18,7 @@ class PremakeDeps(object):
         self.cflags = ", ".join('"%s"' % p for p in deps_cpp_info.cflags)
         self.sharedlinkflags = ", ".join('"%s"' % p.replace('"', '\\"') for p in deps_cpp_info.sharedlinkflags)
         self.exelinkflags = ", ".join('"%s"' % p.replace('"', '\\"') for p in deps_cpp_info.exelinkflags)
+        self.frameworks = ", ".join('"%s.framework"' % p.replace('"', '\\"') for p in deps_cpp_info.frameworks)
 
         self.rootpath = "%s" % deps_cpp_info.rootpath.replace("\\", "/")
 
@@ -40,7 +41,8 @@ class PremakeGenerator(Generator):
                     'conan_cxxflags{dep} = {{{deps.cxxflags}}}\n'
                     'conan_cflags{dep} = {{{deps.cflags}}}\n'
                     'conan_sharedlinkflags{dep} = {{{deps.sharedlinkflags}}}\n'
-                    'conan_exelinkflags{dep} = {{{deps.exelinkflags}}}\n')
+                    'conan_exelinkflags{dep} = {{{deps.exelinkflags}}}\n'
+                    'conan_frameworks{dep} = {{{deps.frameworks}}}\n')
 
         sections = ["#!lua"]
 
@@ -68,6 +70,7 @@ class PremakeGenerator(Generator):
             "    libdirs{conan_libdirs}\n"
             "    links{conan_libs}\n"
             "    links{conan_system_libs}\n"
+            "    links{conan_frameworks}\n"
             "    defines{conan_defines}\n"
             "    bindirs{conan_bindirs}\n"
             "end\n")

--- a/conans/test/unittests/client/generators/premake_test.py
+++ b/conans/test/unittests/client/generators/premake_test.py
@@ -33,6 +33,7 @@ class PremakeGeneratorTest(unittest.TestCase):
     conan_cflags = {{"-mtune=native", "-fPIC"}}
     conan_sharedlinkflags = {{"-framework AudioFoundation", "-framework \\\"Some Spaced Framework\\\"", "-framework Cocoa"}}
     conan_exelinkflags = {{"-framework VideoToolbox", "-framework \\\"Other Spaced Framework\\\"", "-framework QuartzCore"}}
+    conan_frameworks = {{"AudioUnit.framework"}}
 
     conan_includedirs_MyPkg1 = {{"{include1}"}}
     conan_libdirs_MyPkg1 = {{"{lib1}"}}
@@ -44,6 +45,7 @@ class PremakeGeneratorTest(unittest.TestCase):
     conan_cflags_MyPkg1 = {{"-fPIC"}}
     conan_sharedlinkflags_MyPkg1 = {{"-framework Cocoa"}}
     conan_exelinkflags_MyPkg1 = {{"-framework QuartzCore"}}
+    conan_frameworks_MyPkg1 = {{"AudioUnit.framework"}}
     conan_rootpath_MyPkg1 = "{root1}"
 
     conan_includedirs_MyPkg2 = {{"{include2}"}}
@@ -56,6 +58,7 @@ class PremakeGeneratorTest(unittest.TestCase):
     conan_cflags_MyPkg2 = {{"-mtune=native"}}
     conan_sharedlinkflags_MyPkg2 = {{"-framework AudioFoundation", "-framework \\\"Some Spaced Framework\\\""}}
     conan_exelinkflags_MyPkg2 = {{"-framework VideoToolbox", "-framework \\\"Other Spaced Framework\\\""}}
+    conan_frameworks_MyPkg2 = {{}}
     conan_rootpath_MyPkg2 = "{root2}"
 
     function conan_basic_setup()
@@ -65,6 +68,7 @@ class PremakeGeneratorTest(unittest.TestCase):
         libdirs{{conan_libdirs}}
         links{{conan_libs}}
         links{{conan_system_libs}}
+        links{{conan_frameworks}}
         defines{{conan_defines}}
         bindirs{{conan_bindirs}}
     end
@@ -95,6 +99,7 @@ class PremakeGeneratorTest(unittest.TestCase):
         cpp_info.cxxflags = ['-fPIE']
         cpp_info.sharedlinkflags = ['-framework Cocoa']
         cpp_info.exelinkflags = ['-framework QuartzCore']
+        cpp_info.frameworks = ['AudioUnit']
         self.conanfile.deps_cpp_info.add(ref.name, cpp_info)
         ref = ConanFileReference.loads("MyPkg2/3.2.3@lasote/stables")
         cpp_info = CppInfo(ref.name, self.tmp_folder2)


### PR DESCRIPTION
Fixes #9367 

Changelog: Fix: Use `frameworks` in Premake generator.
Docs: https://github.com/conan-io/docs/pull/2210

This PR allows the system frameworks in a package like SDL2 to now be associated with Premake. There is still the issue with how to use `frameworkdirs`. It seems like Premake5 does support a `framworkdirs` property itself but it's only used for the Xcode generator. There is a PR (https://github.com/premake/premake-core/pull/1661) to add this to the `gmake` generator, however.

Although after looking at the `make` generator I'm a bit confused about `frameworkdirs`. The `conanbuildinfo.txt` has `framework_dirs` but the `make` generator (and unit tests) seem to use `framework_paths`. Are they the same thing? 

<sup>**Note:** By default this PR will skip the slower tests and will use a limited set of python versions. Check [here](https://github.com/conan-io/conan/blob/develop/.github/PR_INCREASE_TESTING.md) how to increase the testing level by writing some tags in the current PR body text.</sup>
