### PR TITLE
post package-install in cache

### DIFF
--- a/conans/client/installer.py
+++ b/conans/client/installer.py
@@ -518,7 +518,7 @@ class BinaryInstaller(object):
                     pkg_layout.package_remove()
                     with pkg_layout.set_dirty_context_manager():
                         pref = self._build_package(node, output, remotes, pkg_layout)
-                    self._call_post_package(node, output, pkg_layout)
+                    self._call_post_package(node.conanfile, output, pkg_layout)
                     assert node.prev, "Node PREV shouldn't be empty"
                     assert node.pref.revision, "Node PREF revision shouldn't be empty"
                     assert pref.revision is not None, "PREV for %s to be built is None" % str(pref)
@@ -527,7 +527,7 @@ class BinaryInstaller(object):
                     # TODO: cache2.0. We can't pass the layout because we don't have the prev yet
                     #  move the layout inside the get... method
                     pkg_layout = self._download_pkg(node)
-                    self._call_post_package(node, output, pkg_layout)
+                    self._call_post_package(node.conanfile, output, pkg_layout)
                 elif node.binary == BINARY_CACHE:
                     assert node.prev, "PREV for %s is None" % str(pref)
                     output.success('Already installed!')
@@ -550,8 +550,7 @@ class BinaryInstaller(object):
             self._call_package_info(conanfile, package_folder, ref=pref.ref, is_editable=False)
             self._recorder.package_cpp_info(pref, conanfile.cpp_info)
 
-    def _call_post_package(self, node, output, pkg_layout):
-        conanfile = node.conanfile
+    def _call_post_package(self, conanfile, output, pkg_layout):
         # FIXME: better name? "install" might be confusing with the old install_folder mechanism
         # FIXME: Maybe it is better to remove first the install folder here in develop2
         # TODO: dirty?

--- a/conans/client/installer.py
+++ b/conans/client/installer.py
@@ -539,10 +539,9 @@ class BinaryInstaller(object):
             if pkg_layout.reference != pref:
                 self._cache.assign_prev(pkg_layout, ConanReference(pref))
 
-            package_install_folder = pkg_layout.post_package()
-            if os.path.exists(package_install_folder):
+            if os.path.exists(pkg_layout.post_package()):
                 output.info('Using package install folder')
-                package_folder = package_install_folder
+                package_folder = pkg_layout.post_package()
             else:
                 package_folder = pkg_layout.package()
             assert os.path.isdir(package_folder), ("Package '%s' folder must exist: %s\n"

--- a/conans/client/remote_manager.py
+++ b/conans/client/remote_manager.py
@@ -166,6 +166,7 @@ class RemoteManager(object):
         self._hook_manager.execute("post_download_package", conanfile_path=conanfile_path,
                                    reference=pref.ref, package_id=pref.id, remote=remote,
                                    conanfile=conanfile)
+        return pkg_layout
 
     def _get_package(self, layout, pref, remote, output, recorder, info):
         t1 = time.time()

--- a/conans/model/conan_file.py
+++ b/conans/model/conan_file.py
@@ -235,6 +235,10 @@ class ConanFile(object):
         self.folders.set_base_package(folder)
 
     @property
+    def post_package_folder(self):
+        return self.folders.base_post_package
+
+    @property
     def install_folder(self):
         # FIXME: Remove in 2.0, no self.install_folder
         return self.folders.base_install

--- a/conans/model/layout.py
+++ b/conans/model/layout.py
@@ -36,6 +36,7 @@ class Folders(object):
 
     def __init__(self):
         self._base_install = None
+        self._base_post_package = None
         self._base_source = None
         self._base_build = None
         self._base_package = None
@@ -88,6 +89,13 @@ class Folders(object):
 
     def set_base_install(self, folder):
         self._base_install = folder
+
+    @property
+    def base_post_package(self):
+        return self._base_post_package
+
+    def set_base_post_package(self, folder):
+        self._base_post_package = folder
 
     @property
     def base_package(self):

--- a/conans/test/integration/conanfile/post_package_method_test.py
+++ b/conans/test/integration/conanfile/post_package_method_test.py
@@ -1,0 +1,93 @@
+import os
+import textwrap
+
+from conans.model.ref import ConanFileReference
+from conans.test.utils.tools import TestClient
+
+
+def test_removed_folder():
+    client = TestClient()
+    conanfile = textwrap.dedent("""
+        import os
+        from conan.tools.files import save
+        from conans import ConanFile
+
+        class Recipe(ConanFile):
+            def post_package(self):
+                file_path = os.path.join(self.post_package_folder, "foo.txt")
+                save(self, file_path, "bar")
+        """)
+
+    client.save({"conanfile.py": conanfile})
+    client.run("create . foo/1.0@")
+    ref = ConanFileReference.loads("foo/1.0")
+    pref = client.get_latest_prev(ref)
+    layout = client.get_latest_pkg_layout(pref)
+    assert os.path.exists(os.path.join(layout.post_package(), "foo.txt"))
+    client.run("remove foo/1.0@ -f")
+    assert not os.path.exists(layout.post_package())
+
+    # Create again the pockage
+    client.run("create . foo/1.0@")
+
+    # remove the method and create again
+    conanfile = textwrap.dedent("""
+            import os
+            from conan.tools.files import save
+            from conans import ConanFile
+
+            class Recipe(ConanFile):
+                def package(self):
+                    file_path = os.path.join(self.package_folder, "foo_bar.txt")
+                    save(self, file_path, "bar")
+            """)
+    client.save({"conanfile.py": conanfile})
+    client.run("create . foo/1.0@")
+    pref = client.get_latest_prev(ref)
+    layout = client.get_latest_pkg_layout(pref)
+    assert not os.path.exists(layout.post_package())
+    assert os.path.exists(os.path.join(layout.package(), "foo_bar.txt")
+
+
+def test_post_package_method():
+    client = TestClient()
+    conanfile = textwrap.dedent("""
+    import os
+    from conan.tools.files import save
+    from conans import ConanFile
+
+    class Recipe(ConanFile):
+
+        def build(self):
+            save(self, "mylibrary.lib", "contents")
+
+        def package(self):
+            self.copy("mylibrary.lib", dst="lib")
+
+        def post_package(self):
+            file_path = os.path.join(self.post_package_folder, "lib", "mylibrary.lib")
+            assert os.path.exists(file_path)
+            with open(file_path, "w") as _f:
+                _f.write("modified contents")
+
+        def package_info(self):
+            self.cpp_info.libs = ["mylibrary.lib"]
+
+    """)
+
+    client.save({"conanfile.py": conanfile})
+    client.run("create . foo/1.0@")
+    client.run("install foo/1.0@ -g CMakeDeps")
+    asserted = False
+    with open(os.path.join(client.current_folder, "foo-release-x86_64-data.cmake")) as _f:
+        for _l in _f.readlines():
+            if _l.startswith("set(foo_PACKAGE_FOLDER_RELEASE "):
+                _tmp = _l.split('"')
+                folder = _tmp[1]
+                assert folder.endswith("install")
+                with open(os.path.join(folder, "lib", "mylibrary.lib")) as _lib:
+                    contents = _lib.read()
+                    asserted = True
+                    assert "modified contents" in contents
+
+    assert asserted

--- a/conans/test/integration/conanfile/post_package_method_test.py
+++ b/conans/test/integration/conanfile/post_package_method_test.py
@@ -46,7 +46,7 @@ def test_removed_folder():
     pref = client.get_latest_prev(ref)
     layout = client.get_latest_pkg_layout(pref)
     assert not os.path.exists(layout.post_package())
-    assert os.path.exists(os.path.join(layout.package(), "foo_bar.txt")
+    assert os.path.exists(os.path.join(layout.package(), "foo_bar.txt"))
 
 
 def test_post_package_method():


### PR DESCRIPTION
Changelog: Feature: New conanfile `post_package` method to patch packages after it is installed in the cache.
Docs: https://github.com/conan-io/docs/pull/XXXX

PENDING NAMING