### PR TITLE
Fix Bazel cc_library's deps and linkopts

### DIFF
--- a/conan/tools/google/bazeldeps.py
+++ b/conan/tools/google/bazeldeps.py
@@ -48,7 +48,17 @@ class BazelDeps(object):
                 {% if defines %}
                 defines = [{{ defines }}],
                 {% endif %}
-                visibility = ["//visibility:public"]
+                {% if linkopts %}
+                linkopts = [{{ linkopts }}],
+                {% endif %}
+                visibility = ["//visibility:public"],
+                {% if libs %}
+                deps = [
+                {% for lib in libs %}
+                ":{{ lib }}_precompiled",
+                {% endfor %}
+                {% endif %}
+                ],
             )
 
         """)
@@ -72,13 +82,19 @@ class BazelDeps(object):
                    for define in dependency.new_cpp_info.defines)
         defines = ', '.join(defines)
 
+        linkopts = []
+        for linkopt in dependency.new_cpp_info.system_libs:
+            linkopts.append('"-l{}"'.format(linkopt))
+        linkopts = ', '.join(linkopts)
+
         context = {
             "name": dependency.ref.name,
             "libs": dependency.new_cpp_info.libs,
             "libdir": dependency.new_cpp_info.libdirs[0],
             "headers": headers,
             "includes": includes,
-            "defines": defines
+            "defines": defines,
+            "linkopts": linkopts
         }
 
         content = Template(template).render(**context)

--- a/conans/test/unittests/tools/google/test_bazeldeps.py
+++ b/conans/test/unittests/tools/google/test_bazeldeps.py
@@ -14,6 +14,8 @@ def test_bazeldeps_dependency_buildfiles():
 
     cpp_info = CppInfo("mypkg", "dummy_root_folder1")
     cpp_info.defines = ["DUMMY_DEFINE=\"string/value\""]
+    cpp_info.system_libs = ["system_lib1"]
+    cpp_info.libs = ["lib1"]
 
     conanfile_dep = ConanFile(Mock(), None)
     conanfile_dep.cpp_info = cpp_info
@@ -31,6 +33,8 @@ def test_bazeldeps_dependency_buildfiles():
             dependency_content = bazeldeps._get_dependency_buildfile_content(dependency)
             assert 'cc_library(\n    name = "OriginalDepName",' in dependency_content
             assert 'defines = ["DUMMY_DEFINE=\'string/value\'"],' in dependency_content
+            assert 'linkopts = ["-lsystem_lib1"],' in dependency_content
+            assert 'deps = [\n    \n    ":lib1_precompiled",' in dependency_content
 
 
 def test_bazeldeps_main_buildfile():


### PR DESCRIPTION
Changelog: Bugfix: Fix Bazel `cc_library`: `deps` and `linkopts`.
Docs: omit

Closes: #9379 #9380

- [x] Refer to the issue that supports this Pull Request.
- [ ] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 

<sup>**Note:** By default this PR will skip the slower tests and will use a limited set of python versions. Check [here](https://github.com/conan-io/conan/blob/develop/.github/PR_INCREASE_TESTING.md) how to increase the testing level by writing some tags in the current PR body text.</sup>
