### PR TITLE
No verbose traceback for `layout()` method

### DIFF
--- a/conans/client/conanfile/configure.py
+++ b/conans/client/conanfile/configure.py
@@ -41,4 +41,5 @@ def run_configure_method(conanfile, down_options, down_ref, ref):
 
         # Once the node is configured call the layout()
         if hasattr(conanfile, "layout"):
-            conanfile.layout()
+            with conanfile_exception_formatter(str(conanfile), "layout"):
+                conanfile.layout()

--- a/conans/test/integration/conanfile/test_exception_printing.py
+++ b/conans/test/integration/conanfile/test_exception_printing.py
@@ -31,7 +31,8 @@ def test_all_methods(direct):
     else:
         throw = "self._aux_method()"
     for method in ["source", "build", "package", "package_info", "configure", "build_id",
-                   "package_id", "requirements", "config_options", "layout", "generate"]:
+                   "package_id", "requirements", "config_options", "layout", "generate", "export",
+                   "export_sources"]:
         client.save({CONANFILE: conanfile.format(method=method, method_contents=throw)})
         client.run("create . ", assert_error=True)
         assert "exceptions/0.1: Error in %s() method, line 12" % method in client.out

--- a/conans/test/integration/conanfile/test_exception_printing.py
+++ b/conans/test/integration/conanfile/test_exception_printing.py
@@ -31,7 +31,7 @@ def test_all_methods(direct):
     else:
         throw = "self._aux_method()"
     for method in ["source", "build", "package", "package_info", "configure", "build_id",
-                   "package_id", "requirements", "config_options", "layout"]:
+                   "package_id", "requirements", "config_options", "layout", "generate"]:
         client.save({CONANFILE: conanfile.format(method=method, method_contents=throw)})
         client.run("create . ", assert_error=True)
         assert "exceptions/0.1: Error in %s() method, line 12" % method in client.out

--- a/conans/test/integration/conanfile/test_exception_printing.py
+++ b/conans/test/integration/conanfile/test_exception_printing.py
@@ -31,7 +31,7 @@ def test_all_methods(direct):
     else:
         throw = "self._aux_method()"
     for method in ["source", "build", "package", "package_info", "configure", "build_id",
-                   "package_id", "requirements", "config_options"]:
+                   "package_id", "requirements", "config_options", "layout"]:
         client.save({CONANFILE: conanfile.format(method=method, method_contents=throw)})
         client.run("create . ", assert_error=True)
         assert "exceptions/0.1: Error in %s() method, line 12" % method in client.out


### PR DESCRIPTION
Changelog: Bugfix: No verbose traceback was been printed for `conanfile.layout()` method.
Closes: https://github.com/conan-io/conan/issues/9378
Docs: omit

- [x] Refer to the issue that supports this Pull Request.
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 

<sup>**Note:** By default this PR will skip the slower tests and will use a limited set of python versions. Check [here](https://github.com/conan-io/conan/blob/develop/.github/PR_INCREASE_TESTING.md) how to increase the testing level by writing some tags in the current PR body text.</sup>
