### PR TITLE
Feature add an option to only copy files if they are different

### DIFF
--- a/conans/client/file_copier.py
+++ b/conans/client/file_copier.py
@@ -66,7 +66,7 @@ class FileCopier(object):
         param links: True to activate symlink copying
         param excludes: Single pattern or a tuple of patterns to be excluded from the copy
         param ignore_case: will do a case-insensitive pattern matching when True
-        param if_different: only copy file if destination is different from the source
+        param if_different: only copy file if source is different from the destination
         return: list of copied files
         """
         # TODO: Remove the old "links" arg for Conan 2.0

--- a/conans/client/file_copier.py
+++ b/conans/client/file_copier.py
@@ -84,7 +84,7 @@ class FileCopier(object):
             excluded = [self._dst_folder]
             excluded.extend([d for d in self._src_folders if d is not src_folder])
             fs = self._copy(src_folder, pattern, src, dst, links, ignore_case, excludes,
-                            keep_path, excluded_folders=excluded)
+                            keep_path, excluded_folders=excluded, if_different=if_different)
             files.extend(fs)
 
         return files

--- a/conans/client/file_copier.py
+++ b/conans/client/file_copier.py
@@ -52,7 +52,7 @@ class FileCopier(object):
         return report_copied_files(self._copied, output)
 
     def __call__(self, pattern, dst="", src="", keep_path=True, links=False, symlinks=None,
-                 excludes=None, ignore_case=True, if_different=True):
+                 excludes=None, ignore_case=True, if_different=False):
         """
         param pattern: an fnmatch file pattern of the files that should be copied. Eg. *.dll
         param dst: the destination local folder, wrt to current conanfile dir, to which
@@ -66,7 +66,7 @@ class FileCopier(object):
         param links: True to activate symlink copying
         param excludes: Single pattern or a tuple of patterns to be excluded from the copy
         param ignore_case: will do a case-insensitive pattern matching when True
-        param if_different: only copy file if source is different from the destination
+        param if_different: only copy file if source is different from the destination (specially useful for imports)
         return: list of copied files
         """
         # TODO: Remove the old "links" arg for Conan 2.0

--- a/conans/client/importer.py
+++ b/conans/client/importer.py
@@ -136,7 +136,7 @@ class _FileImporter(object):
         self.copied_files = set()
 
     def __call__(self, pattern, dst="", src="", root_package=None, folder=False,
-                 ignore_case=True, excludes=None, keep_path=True, if_different=False):
+                 ignore_case=True, excludes=None, keep_path=True, if_different=True):
         """
         param pattern: an fnmatch file pattern of the files that should be copied. Eg. *.dll
         param dst: the destination local folder, wrt to current conanfile dir, to which

--- a/conans/client/importer.py
+++ b/conans/client/importer.py
@@ -136,7 +136,7 @@ class _FileImporter(object):
         self.copied_files = set()
 
     def __call__(self, pattern, dst="", src="", root_package=None, folder=False,
-                 ignore_case=True, excludes=None, keep_path=True):
+                 ignore_case=True, excludes=None, keep_path=True, if_different=False):
         """
         param pattern: an fnmatch file pattern of the files that should be copied. Eg. *.dll
         param dst: the destination local folder, wrt to current conanfile dir, to which
@@ -171,5 +171,5 @@ class _FileImporter(object):
 
             for src_dir in src_dirs:
                 files = file_copier(pattern, src=src_dir, links=True, ignore_case=ignore_case,
-                                    excludes=excludes, keep_path=keep_path)
+                                    excludes=excludes, keep_path=keep_path, if_different=if_different)
                 self.copied_files.update(files)


### PR DESCRIPTION
Changelog: added new param to self.copy function to only copy files if they are different. Similar to the cmake function `copy_if_different`
Mainly for performance purpose to speedup imports when reusing the same build directory.

Docs: https://github.com/conan-io/docs/pull/2186

- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [x] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 

<sup>**Note:** By default this PR will skip the slower tests and will use a limited set of python versions. Check [here](https://github.com/conan-io/conan/blob/develop/.github/PR_INCREASE_TESTING.md) how to increase the testing level by writing some tags in the current PR body text.</sup>
