### PR TITLE
Subfolder for the configure script

### DIFF
--- a/conan/tools/cmake/cmake.py
+++ b/conan/tools/cmake/cmake.py
@@ -73,14 +73,14 @@ class CMake(object):
 
         self._cmake_program = "cmake"  # Path to CMake should be handled by environment
 
-    def configure(self, source_folder=None):
+    def configure(self, build_script_folder=None):
         # TODO: environment?
         if not self._conanfile.should_configure:
             return
 
         source = self._conanfile.source_folder
-        if source_folder:
-            source = os.path.join(self._conanfile.source_folder, source_folder)
+        if build_script_folder:
+            source = os.path.join(self._conanfile.source_folder, build_script_folder)
 
         build_folder = self._conanfile.build_folder
         generator_folder = self._conanfile.generators_folder

--- a/conan/tools/cmake/cmake.py
+++ b/conan/tools/cmake/cmake.py
@@ -78,9 +78,9 @@ class CMake(object):
         if not self._conanfile.should_configure:
             return
 
-        source = self._conanfile.source_folder
+        cmakelist_folder = self._conanfile.source_folder
         if build_script_folder:
-            source = os.path.join(self._conanfile.source_folder, build_script_folder)
+            cmakelist_folder = os.path.join(self._conanfile.source_folder, build_script_folder)
 
         build_folder = self._conanfile.build_folder
         generator_folder = self._conanfile.generators_folder
@@ -101,7 +101,7 @@ class CMake(object):
             arg_list.append('-DCMAKE_INSTALL_PREFIX="{}"'.format(pkg_folder))
         if platform.system() == "Windows" and self._generator == "MinGW Makefiles":
             arg_list.append('-DCMAKE_SH="CMAKE_SH-NOTFOUND"')
-        arg_list.append('"{}"'.format(source))
+        arg_list.append('"{}"'.format(cmakelist_folder))
 
         command = " ".join(arg_list)
         self._conanfile.output.info("CMake command: %s" % command)

--- a/conan/tools/gnu/autotools.py
+++ b/conan/tools/gnu/autotools.py
@@ -14,7 +14,7 @@ class Autotools(object):
         self._configure_args = toolchain_file_content.get("configure_args")
         self._make_args = toolchain_file_content.get("make_args")
 
-    def configure(self, source_folder=None):
+    def configure(self, build_script_folder=None):
         """
         http://jingfenghanmax.blogspot.com.es/2010/09/configure-with-host-target-and-build.html
         https://gcc.gnu.org/onlinedocs/gccint/Configure-Terms.html
@@ -24,8 +24,8 @@ class Autotools(object):
             return
 
         source = self._conanfile.source_folder
-        if source_folder:
-            source = os.path.join(self._conanfile.source_folder, source_folder)
+        if build_script_folder:
+            source = os.path.join(self._conanfile.source_folder, build_script_folder)
 
         configure_cmd = "{}/configure".format(source)
         configure_cmd = unix_path(self._conanfile, configure_cmd)

--- a/conan/tools/gnu/autotools.py
+++ b/conan/tools/gnu/autotools.py
@@ -1,3 +1,4 @@
+import os
 from conan.tools.files import load_toolchain_args
 from conan.tools.gnu.make import make_jobs_cmd_line_arg
 from conan.tools.microsoft import unix_path
@@ -13,7 +14,7 @@ class Autotools(object):
         self._configure_args = toolchain_file_content.get("configure_args")
         self._make_args = toolchain_file_content.get("make_args")
 
-    def configure(self):
+    def configure(self, source_folder=None):
         """
         http://jingfenghanmax.blogspot.com.es/2010/09/configure-with-host-target-and-build.html
         https://gcc.gnu.org/onlinedocs/gccint/Configure-Terms.html
@@ -22,7 +23,11 @@ class Autotools(object):
         if not self._conanfile.should_configure:
             return
 
-        configure_cmd = "{}/configure".format(self._conanfile.source_folder)
+        source = self._conanfile.source_folder
+        if source_folder:
+            source = os.path.join(self._conanfile.source_folder, source_folder)
+
+        configure_cmd = "{}/configure".format(source)
         configure_cmd = unix_path(self._conanfile, configure_cmd)
         cmd = "{} {}".format(configure_cmd, self._configure_args)
         self._conanfile.output.info("Calling:\n > %s" % cmd)

--- a/conans/test/functional/toolchains/cmake/cmakedeps/test_apple_frameworks.py
+++ b/conans/test/functional/toolchains/cmake/cmakedeps/test_apple_frameworks.py
@@ -72,9 +72,12 @@ conanfile = textwrap.dedent("""
                 name = "mylibrary"
                 version = "1.0"
 
+                def layout(self):
+                    self.folders.source = "src"
+
                 def build(self):
                     cmake = CMake(self)
-                    cmake.configure(build_script_folder="src")
+                    cmake.configure()
                     cmake.build()
                     cmake.install()
                     self.run("otool -L '%s/hello.framework/hello'" % self.build_folder)

--- a/conans/test/functional/toolchains/cmake/cmakedeps/test_apple_frameworks.py
+++ b/conans/test/functional/toolchains/cmake/cmakedeps/test_apple_frameworks.py
@@ -74,7 +74,7 @@ conanfile = textwrap.dedent("""
 
                 def build(self):
                     cmake = CMake(self)
-                    cmake.configure(source_folder="src")
+                    cmake.configure(build_script_folder="src")
                     cmake.build()
                     cmake.install()
                     self.run("otool -L '%s/hello.framework/hello'" % self.build_folder)

--- a/conans/test/functional/toolchains/cmake/cmakedeps/test_cmakedeps_build_modules.py
+++ b/conans/test/functional/toolchains/cmake/cmakedeps/test_cmakedeps_build_modules.py
@@ -173,9 +173,12 @@ class TestNoNamespaceTarget:
             exports_sources = ["src/*", "build-module.cmake"]
             generators = "cmake"
 
+            def layout(self):
+                self.folders.source = "src"
+
             def build(self):
                 cmake = CMake(self)
-                cmake.configure(build_script_folder="src")
+                cmake.configure()
                 cmake.build()
 
             def package(self):

--- a/conans/test/functional/toolchains/cmake/cmakedeps/test_cmakedeps_build_modules.py
+++ b/conans/test/functional/toolchains/cmake/cmakedeps/test_cmakedeps_build_modules.py
@@ -175,7 +175,7 @@ class TestNoNamespaceTarget:
 
             def build(self):
                 cmake = CMake(self)
-                cmake.configure(source_folder="src")
+                cmake.configure(build_script_folder="src")
                 cmake.build()
 
             def package(self):

--- a/conans/test/functional/toolchains/cmake/cmakedeps/test_cmakedeps_components_names.py
+++ b/conans/test/functional/toolchains/cmake/cmakedeps/test_cmakedeps_components_names.py
@@ -36,7 +36,7 @@ def setup_client_with_greetings():
 
             def build(self):
                 cmake = CMake(self)
-                cmake.configure(source_folder="src")
+                cmake.configure(build_script_folder="src")
                 cmake.build()
 
             def package(self):
@@ -143,7 +143,7 @@ def create_chat(client, components, package_info, cmake_find, test_cmake_find):
 
             def build(self):
                 cmake = CMake(self)
-                cmake.configure(source_folder="src")
+                cmake.configure(build_script_folder="src")
                 cmake.build()
 
             def package(self):
@@ -359,7 +359,7 @@ def test_same_names():
 
             def build(self):
                 cmake = CMake(self)
-                cmake.configure(source_folder="src")
+                cmake.configure(build_script_folder="src")
                 cmake.build()
 
             def package(self):
@@ -531,7 +531,7 @@ class TestComponentsCMakeGenerators:
 
                 def build(self):
                     cmake = CMake(self)
-                    cmake.configure(source_folder="src")
+                    cmake.configure(build_script_folder="src")
                     cmake.build()
 
                 def package(self):
@@ -587,7 +587,7 @@ class TestComponentsCMakeGenerators:
 
                 def build(self):
                     cmake = CMake(self)
-                    cmake.configure(source_folder="src")
+                    cmake.configure(build_script_folder="src")
                     cmake.build()
 
                 def package(self):
@@ -616,7 +616,7 @@ class TestComponentsCMakeGenerators:
 
                 def build(self):
                     cmake = CMake(self)
-                    cmake.configure(source_folder="src")
+                    cmake.configure(build_script_folder="src")
                     cmake.build()
                     self.run(".%smain" % os.sep)
             """.format("CMakeDeps"))

--- a/conans/test/unittests/tools/gnu/autotools_test.py
+++ b/conans/test/unittests/tools/gnu/autotools_test.py
@@ -1,0 +1,26 @@
+import os
+import textwrap
+
+from conan.tools.files import save_toolchain_args
+from conan.tools.gnu import Autotools
+from conans.test.utils.mocks import ConanFileMock
+from conans.test.utils.test_files import temp_folder
+
+
+def test_source_folder_works():
+    folder = temp_folder()
+    os.chdir(folder)
+    save_toolchain_args({
+        "configure_args": "-foo bar",
+        "make_args": ""}
+    )
+    conanfile = ConanFileMock()
+    conanfile.folders.set_base_install(folder)
+    sources = "/path/to/sources"
+    conanfile.folders.set_base_source(sources)
+    autotools = Autotools(conanfile)
+    autotools.configure(source_folder="subfolder")
+    assert conanfile.command == "/path/to/sources/subfolder/configure -foo bar"
+
+    autotools.configure()
+    assert conanfile.command == "/path/to/sources/configure -foo bar"

--- a/conans/test/unittests/tools/gnu/autotools_test.py
+++ b/conans/test/unittests/tools/gnu/autotools_test.py
@@ -20,7 +20,7 @@ def test_source_folder_works():
     conanfile.folders.set_base_source(sources)
     autotools = Autotools(conanfile)
     autotools.configure(source_folder="subfolder")
-    assert conanfile.command == "/path/to/sources/subfolder/configure -foo bar"
+    assert conanfile.command.replace("\\", "/") == "/path/to/sources/subfolder/configure -foo bar"
 
     autotools.configure()
-    assert conanfile.command == "/path/to/sources/configure -foo bar"
+    assert conanfile.command.replace("\\", "/") == "/path/to/sources/configure -foo bar"

--- a/conans/test/unittests/tools/gnu/autotools_test.py
+++ b/conans/test/unittests/tools/gnu/autotools_test.py
@@ -19,7 +19,7 @@ def test_source_folder_works():
     sources = "/path/to/sources"
     conanfile.folders.set_base_source(sources)
     autotools = Autotools(conanfile)
-    autotools.configure(source_folder="subfolder")
+    autotools.configure(build_script_folder="subfolder")
     assert conanfile.command.replace("\\", "/") == "/path/to/sources/subfolder/configure -foo bar"
 
     autotools.configure()


### PR DESCRIPTION
Changelog: Fix: The new `Autotools` build helper accepts a `build_script_folder ` argument in the `configure()` method to specify are subfolder where the configure script is.
Docs: https://github.com/conan-io/docs/pull/2208

Closes #9375 