### PR TITLE
Remove conan-center default remote

### DIFF
--- a/conans/client/cache/remote_registry.py
+++ b/conans/client/cache/remote_registry.py
@@ -112,8 +112,6 @@ class Remotes(object):
         result = Remotes()
         result._remotes[CONAN_CENTER_REMOTE_NAME] = Remote(CONAN_CENTER_REMOTE_NAME,
                                                            "https://center.conan.io", True, False)
-        result._remotes["conan-center"] = Remote("conan-center", "https://conan.bintray.com", True,
-                                                 False)
         return result
 
     def select(self, remote_name):

--- a/conans/test/integration/configuration/registry_test.py
+++ b/conans/test/integration/configuration/registry_test.py
@@ -67,13 +67,11 @@ other/1.0@lasote/testing conan.io
         registry.add("local", "http://localhost:9300")
         self.assertEqual(list(registry.load_remotes().values()),
                          [("conancenter", "https://center.conan.io", True, False),
-                          ("conan-center", "https://conan.bintray.com", True, False),
                           ("local", "http://localhost:9300", True, False)])
         # Add
         registry.add("new", "new_url", False)
         self.assertEqual(list(registry.load_remotes().values()),
                          [("conancenter", "https://center.conan.io", True, False),
-                          ("conan-center", "https://conan.bintray.com", True, False),
                           ("local", "http://localhost:9300", True, False),
                           ("new", "new_url", False, False)])
         with self.assertRaises(ConanException):
@@ -82,7 +80,6 @@ other/1.0@lasote/testing conan.io
         registry.update("new", "other_url")
         self.assertEqual(list(registry.load_remotes().values()),
                          [("conancenter", "https://center.conan.io", True, False),
-                          ("conan-center", "https://conan.bintray.com", True, False),
                           ("local", "http://localhost:9300", True, False),
                           ("new", "other_url", True, False)])
         with self.assertRaises(ConanException):
@@ -91,7 +88,6 @@ other/1.0@lasote/testing conan.io
         registry.update("new", "other_url", False)
         self.assertEqual(list(registry.load_remotes().values()),
                          [("conancenter", "https://center.conan.io", True, False),
-                          ("conan-center", "https://conan.bintray.com", True, False),
                           ("local", "http://localhost:9300", True, False),
                           ("new", "other_url", False, False)])
 
@@ -99,7 +95,6 @@ other/1.0@lasote/testing conan.io
         registry.remove("local")
         self.assertEqual(list(registry.load_remotes().values()),
                          [("conancenter", "https://center.conan.io", True, False),
-                          ("conan-center", "https://conan.bintray.com", True, False),
                           ("new", "other_url", False, False)])
         with self.assertRaises(ConanException):
             registry.remove("new2")
@@ -145,15 +140,13 @@ other/1.0@lasote/testing conan.io
         registry.add("foobar", None)
         self.assertEqual(list(registry.load_remotes().values()),
                          [("conancenter", "https://center.conan.io", True, False),
-                          ("conan-center", "https://conan.bintray.com", True, False),
                           ("foobar", None, True, False)])
         self.assertIn("WARN: The URL is empty. It must contain scheme and hostname.", cache._output)
         registry.remove("foobar")
 
-        registry.update("conan-center", None)
+        registry.update("conancenter", None)
         self.assertEqual(list(registry.load_remotes().values()),
-                         [("conancenter", "https://center.conan.io", True, False),
-                          ("conan-center", None, True, False)])
+                         [("conancenter", None, True, False)])
         self.assertIn("WARN: The URL is empty. It must contain scheme and hostname.", cache._output)
 
     def test_enable_disable_remotes(self):
@@ -166,26 +159,21 @@ other/1.0@lasote/testing conan.io
         registry.set_disabled_state("local", True)
         self.assertEqual(list(registry.load_remotes().all_values()),
                          [("conancenter", "https://center.conan.io", True, False),
-                          ("conan-center", "https://conan.bintray.com", True, False),
-                          ("local", "http://localhost:9300", True, True)])
-
-        self.assertEqual(list(registry.load_remotes().values()),
-                         [("conancenter", "https://center.conan.io", True, False),
-                          ("conan-center", "https://conan.bintray.com", True, False)])
-
-        registry.set_disabled_state("conan-center", True)
-        self.assertEqual(list(registry.load_remotes().all_values()),
-                         [("conancenter", "https://center.conan.io", True, False),
-                          ("conan-center", "https://conan.bintray.com", True, True),
                           ("local", "http://localhost:9300", True, True)])
 
         self.assertEqual(list(registry.load_remotes().values()),
                          [("conancenter", "https://center.conan.io", True, False)])
 
+        registry.set_disabled_state("conancenter", True)
+        self.assertEqual(list(registry.load_remotes().all_values()),
+                         [("conancenter", "https://center.conan.io", True, True),
+                          ("local", "http://localhost:9300", True, True)])
+
+        self.assertEqual(list(registry.load_remotes().values()), [])
+
         registry.set_disabled_state("*", False)
         self.assertEqual(list(registry.load_remotes().values()),
                          [("conancenter", "https://center.conan.io", True, False),
-                          ("conan-center", "https://conan.bintray.com", True, False),
                           ("local", "http://localhost:9300", True, False)])
 
         registry.set_disabled_state("*", True)


### PR DESCRIPTION
Changelog: Feature: Remove `conan-center` (https://conan.bintray.com) default remote.
Docs: https://github.com/conan-io/docs/pull/2212

As `conancenter` is already working fine, there is no need to keep `conan-center` remote by default in the client, so we can remove it and start fading out the usage of this old repo.

- [x] Refer to the issue that supports this Pull Request.
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [x] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 

<sup>**Note:** By default this PR will skip the slower tests and will use a limited set of python versions. Check [here](https://github.com/conan-io/conan/blob/develop/.github/PR_INCREASE_TESTING.md) how to increase the testing level by writing some tags in the current PR body text.</sup>
