### PR TITLE
Fix export help typo

### DIFF
--- a/conans/client/command.py
+++ b/conans/client/command.py
@@ -1077,8 +1077,8 @@ class Command(object):
         Copies the recipe (conanfile.py & associated files) to your local cache.
 
         Use the 'reference' param to specify a user and channel where to export
-        it. Once the recipe is in the local cache it can be shared, reused and
-        to any remote with the 'conan upload' command.
+        it. Once the recipe is in the local cache it can be shared and reused
+        with any remote with the 'conan upload' command.
         """
         parser = argparse.ArgumentParser(description=self.export.__doc__,
                                          prog="conan export",


### PR DESCRIPTION
Coming from this issue https://github.com/conan-io/docs/pull/2187

Changelog: Fix: Fix `conan export` typo in help message.
Docs: https://github.com/conan-io/docs/pull/2187

- [x] Refer to the issue that supports this Pull Request: https://github.com/conan-io/docs/pull/2187
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [x] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 

<sup>**Note:** By default this PR will skip the slower tests and will use a limited set of python versions. Check [here](https://github.com/conan-io/conan/blob/develop/.github/PR_INCREASE_TESTING.md) how to increase the testing level by writing some tags in the current PR body text.</sup>
