### PR TITLE
Add warning when downloading recipes from bintray

### DIFF
--- a/conans/client/graph/proxy.py
+++ b/conans/client/graph/proxy.py
@@ -13,6 +13,9 @@ from conans.paths.package_layouts.package_editable_layout import PackageEditable
 from conans.util.tracer import log_recipe_got_from_local_cache
 
 
+DEPRECATED_CONAN_CENTER_BINTRAY_URL = "https://conan.bintray.com"
+
+
 class ConanProxy(object):
     def __init__(self, cache, output, remote_manager):
         # collaborators
@@ -113,11 +116,12 @@ class ConanProxy(object):
         def _retrieve_from_remote(the_remote):
             output.info("Trying with '%s'..." % the_remote.name)
             # If incomplete, resolve the latest in server
-            if "https://conan.bintray.com" in the_remote.url:
+            if the_remote.url.startswith(DEPRECATED_CONAN_CENTER_BINTRAY_URL):
                 output.warn("Remote https://conan.bintray.com is deprecated and will be shut down "
                             "soon.")
-                output.warn("Please use the new 'conancenter' default remote "
-                           "(https://center.conan.io).")
+                output.warn("Please use the new 'conancenter' default remote.")
+                output.warn("Add it to your remotes with: conan remote add -i 0 conancenter "
+                            "https://center.conan.io")
             _ref = self._remote_manager.get_recipe(ref, the_remote)
             output.info("Downloaded recipe revision %s" % _ref.revision)
             recorder.recipe_downloaded(ref, the_remote.url)

--- a/conans/client/graph/proxy.py
+++ b/conans/client/graph/proxy.py
@@ -13,6 +13,7 @@ from conans.paths.package_layouts.package_editable_layout import PackageEditable
 from conans.util.tracer import log_recipe_got_from_local_cache
 
 
+# TODO: Remove warning message when this URL is no longer available
 DEPRECATED_CONAN_CENTER_BINTRAY_URL = "https://conan.bintray.com"
 
 

--- a/conans/client/graph/proxy.py
+++ b/conans/client/graph/proxy.py
@@ -113,6 +113,10 @@ class ConanProxy(object):
         def _retrieve_from_remote(the_remote):
             output.info("Trying with '%s'..." % the_remote.name)
             # If incomplete, resolve the latest in server
+            if "https://conan.bintray.com" in the_remote.url:
+                output.warn("Remote https://conan.bintray.com is deprecated and will be shut down "
+                            "soon. Please use the new 'conancenter' default remote "
+                            "(https://center.conan.io).")
             _ref = self._remote_manager.get_recipe(ref, the_remote)
             output.info("Downloaded recipe revision %s" % _ref.revision)
             recorder.recipe_downloaded(ref, the_remote.url)

--- a/conans/client/graph/proxy.py
+++ b/conans/client/graph/proxy.py
@@ -115,8 +115,9 @@ class ConanProxy(object):
             # If incomplete, resolve the latest in server
             if "https://conan.bintray.com" in the_remote.url:
                 output.warn("Remote https://conan.bintray.com is deprecated and will be shut down "
-                            "soon. Please use the new 'conancenter' default remote "
-                            "(https://center.conan.io).")
+                            "soon.")
+                output.warn("Please use the new 'conancenter' default remote "
+                           "(https://center.conan.io).")
             _ref = self._remote_manager.get_recipe(ref, the_remote)
             output.info("Downloaded recipe revision %s" % _ref.revision)
             recorder.recipe_downloaded(ref, the_remote.url)

--- a/conans/test/integration/command/install/install_test.py
+++ b/conans/test/integration/command/install/install_test.py
@@ -447,3 +447,18 @@ class TestCliOverride:
                      "test_package/conanfile.py": GenConanfile().with_test("pass")})
         client.run("create . pkg/0.1@ --require-override=zlib/2.0")
         assert "zlib/2.0: Already installed" in client.out
+
+
+def test_install_bintray_warning():
+    """
+    IMPORTANT: This test is actually using https://conan.bintray.com
+    Warning is only displayed when downloading a recipe from the remote
+    """
+    client = TestClient()
+    client.run("remote add whatever https://conan.bintray.com")
+    client.run("install zlib/1.2.8@conan/stable -r whatever")
+    assert "WARN: Remote https://conan.bintray.com is deprecated and will be shut down " \
+           "soon" in client.out
+    client.run("install zlib/1.2.8@conan/stable -r whatever -s build_type=Debug")
+    assert "WARN: Remote https://conan.bintray.com is deprecated and will be shut down " \
+           "soon" not in client.out

--- a/conans/test/integration/command/install/install_test.py
+++ b/conans/test/integration/command/install/install_test.py
@@ -455,10 +455,10 @@ def test_install_bintray_warning():
     Warning is only displayed when downloading a recipe from the remote
     """
     client = TestClient()
-    client.run("remote add whatever https://conan.bintray.com")
-    client.run("install zlib/1.2.8@conan/stable -r whatever")
+    client.run("remote add conan-center https://conan.bintray.com")
+    client.run("install zlib/1.2.8@conan/stable -r conan-center")
     assert "WARN: Remote https://conan.bintray.com is deprecated and will be shut down " \
            "soon" in client.out
-    client.run("install zlib/1.2.8@conan/stable -r whatever -s build_type=Debug")
+    client.run("install zlib/1.2.8@conan/stable -r conan-center -s build_type=Debug")
     assert "WARN: Remote https://conan.bintray.com is deprecated and will be shut down " \
            "soon" not in client.out


### PR DESCRIPTION
Changelog: omit
Docs: omit

- [x] Refer to the issue that supports this Pull Request: continuation of #9401 
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [x] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 

<sup>**Note:** By default this PR will skip the slower tests and will use a limited set of python versions. Check [here](https://github.com/conan-io/conan/blob/develop/.github/PR_INCREASE_TESTING.md) how to increase the testing level by writing some tags in the current PR body text.</sup>

Here you can check the output of an install command:

```
Configuration:
[settings]
arch=x86_64
arch_build=x86_64
build_type=Release
compiler=Visual Studio
compiler.runtime=MD
compiler.version=16
os=Windows
os_build=Windows
[options]
[build_requires]
[env]

zlib/1.2.8@conan/stable: Retrieving from server 'conan-center' 
zlib/1.2.8@conan/stable: Trying with 'conan-center'...
zlib/1.2.8@conan/stable: WARN: Remote https://conan.bintray.com is deprecated and will be shut down soon.
zlib/1.2.8@conan/stable: WARN: Please use the new 'conancenter' default remote.
zlib/1.2.8@conan/stable: WARN: Add it to your remotes with: conan remote add -i 0 conancenter https://center.conan.io
Downloading conanmanifest.txt
Downloading conanfile.py
Downloading conan_export.tgz
zlib/1.2.8@conan/stable: Downloaded recipe revision 0
Installing package: zlib/1.2.8@conan/stable
Requirements
    zlib/1.2.8@conan/stable from 'conan-center' - Downloaded
Packages
    zlib/1.2.8@conan/stable:3fb49604f9c2f729b85ba3115852006824e72cab - Download

Installing (downloading, building) binaries...
zlib/1.2.8@conan/stable: Retrieving package 3fb49604f9c2f729b85ba3115852006824e72cab from remote 'conan-center' 
Downloading conanmanifest.txt
Downloading conaninfo.txt
Downloading conan_package.tgz
zlib/1.2.8@conan/stable: Package installed 3fb49604f9c2f729b85ba3115852006824e72cab
zlib/1.2.8@conan/stable: Downloaded package revision 0
Aggregating env generators
```
