### PR TITLE
Fix OSX with special character on DYLD_LIBRARY_PATH

### DIFF
--- a/conans/test/functional/environment/run_environment_test.py
+++ b/conans/test/functional/environment/run_environment_test.py
@@ -202,21 +202,8 @@ class RunEnvironmentSharedTest(unittest.TestCase):
     def test_plus_char_dyld_path(self):
         client = TestClient(path_with_spaces=False)
         client.run("config set log.print_run_commands=1")
-        client.run("config set log.level=10")
-        client.run("new -s -t foo++/0.1")
-
-        tools.replace_in_file(os.path.join(client.current_folder, "conanfile.py"), "Foo++Conan", "FooConan")
-        tools.replace_in_file(os.path.join(client.current_folder, "test_package", "conanfile.py"), "Foo++TestConan",
-                              "FooTestConan")
-        tools.replace_in_file(os.path.join(client.current_folder, "src", "foo++.h"),
-                              "foo++",
-                              "foo")
-        tools.replace_in_file(os.path.join(client.current_folder, "src", "foo++.cpp"),
-                              "foo++(",
-                              "foo(")
-        tools.replace_in_file(os.path.join(client.current_folder, "test_package", "example.cpp"),
-                              "foo++(",
-                              "foo(")
+        client.run("new -s -t foo/0.1")
+        tools.replace_in_file(os.path.join(client.current_folder, "conanfile.py"), 'name = "foo"', 'name = "foo++"')
         tools.replace_in_file(os.path.join(client.current_folder, "test_package", "conanfile.py"),
                               "os.sep",
                               "os.sep, run_environment=True")

--- a/conans/test/functional/environment/run_environment_test.py
+++ b/conans/test/functional/environment/run_environment_test.py
@@ -198,7 +198,7 @@ class RunEnvironmentSharedTest(unittest.TestCase):
             output = check_output_runner(command)
             self.assertIn("Hello Tool!", output)
 
-    @pytest.mark.skipif(platform.system() == "Darwin", reason="Requires DYLD_LIBRARY_PATH")
+    @pytest.mark.skipif(platform.system() != "Darwin", reason="Requires DYLD_LIBRARY_PATH")
     def test_plus_char_dyld_path(self):
         client = TestClient(path_with_spaces=False)
         client.run("config set log.print_run_commands=1")

--- a/conans/test/functional/environment/run_environment_test.py
+++ b/conans/test/functional/environment/run_environment_test.py
@@ -222,4 +222,4 @@ class RunEnvironmentSharedTest(unittest.TestCase):
                               "os.sep, run_environment=True")
 
         client.run("create . -o foo++:shared=True")
-        self.assertIn("> DYLD_LIBRARY_PATH=asd", client.out)
+        self.assertNotIn('> DYLD_LIBRARY_PATH=""', client.out)


### PR DESCRIPTION
fixes #9421

Changelog: Fix: Recipe names using plus character are not propagate on DYLD_LIBRARY_PATH
Docs: Omit

- [ ] Refer to the issue that supports this Pull Request.
- [ ] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [ ] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [ ] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 

<sup>**Note:** By default this PR will skip the slower tests and will use a limited set of python versions. Check [here](https://github.com/conan-io/conan/blob/develop/.github/PR_INCREASE_TESTING.md) how to increase the testing level by writing some tags in the current PR body text.</sup>
