### PR TITLE
gcc 5 support of std c++17

### DIFF
--- a/conan/tools/_compilers.py
+++ b/conan/tools/_compilers.py
@@ -302,7 +302,7 @@ def _cppstd_gcc(gcc_version, cppstd):
         v14 = "c++1y"
         vgnu14 = "gnu++1y"
 
-    if Version(gcc_version) == "5" or Version(gcc_version) >= "5.1":
+    if Version(gcc_version) >= "5":
         v17 = "c++1z"
         vgnu17 = "gnu++1z"
 

--- a/conan/tools/_compilers.py
+++ b/conan/tools/_compilers.py
@@ -302,7 +302,7 @@ def _cppstd_gcc(gcc_version, cppstd):
         v14 = "c++1y"
         vgnu14 = "gnu++1y"
 
-    if Version(gcc_version) >= "5.1":
+    if Version(gcc_version) == "5" or Version(gcc_version) >= "5.1":
         v17 = "c++1z"
         vgnu17 = "gnu++1z"
 

--- a/conans/client/build/cppstd_flags.py
+++ b/conans/client/build/cppstd_flags.py
@@ -253,7 +253,7 @@ def _cppstd_gcc(gcc_version, cppstd):
         v14 = "c++1y"
         vgnu14 = "gnu++1y"
 
-    if Version(gcc_version) == "5" or Version(gcc_version) >= "5.1":
+    if Version(gcc_version) >= "5":
         v17 = "c++1z"
         vgnu17 = "gnu++1z"
 

--- a/conans/client/build/cppstd_flags.py
+++ b/conans/client/build/cppstd_flags.py
@@ -253,7 +253,7 @@ def _cppstd_gcc(gcc_version, cppstd):
         v14 = "c++1y"
         vgnu14 = "gnu++1y"
 
-    if Version(gcc_version) >= "5.1":
+    if Version(gcc_version) == "5" or Version(gcc_version) >= "5.1":
         v17 = "c++1z"
         vgnu17 = "gnu++1z"
 

--- a/conans/test/unittests/client/build/cpp_std_flags_test.py
+++ b/conans/test/unittests/client/build/cpp_std_flags_test.py
@@ -52,7 +52,8 @@ class CompilerFlagsTest(unittest.TestCase):
         self.assertEqual(_make_cppstd_flag("gcc", "5", "11"), '-std=c++11')
         self.assertEqual(_make_cppstd_flag("gcc", "5", "14"), '-std=c++14')
         self.assertEqual(_make_cppstd_flag("gcc", "5", "gnu14"), '-std=gnu++14')
-        self.assertEqual(_make_cppstd_flag("gcc", "5", "17"), None)
+        self.assertEqual(_make_cppstd_flag("gcc", "5", "17"), '-std=c++1z')
+        self.assertEqual(_make_cppstd_flag("gcc", "5", "gnu17"), '-std=gnu++1z')
 
         self.assertEqual(_make_cppstd_flag("gcc", "5.1", "11"), '-std=c++11')
         self.assertEqual(_make_cppstd_flag("gcc", "5.1", "14"), '-std=c++14')


### PR DESCRIPTION
Changelog: Bugfix: Fixed bug whereby Conan failed when using `compiler=gcc` with `compiler.version=5` (without specifying a minor version) and `compiler.cppstd=17`.
Docs: omit

Closes #9417