### PR TITLE
Fixed iOS cross building for old generators

### DIFF
--- a/conans/client/build/cmake.py
+++ b/conans/client/build/cmake.py
@@ -5,7 +5,6 @@ from itertools import chain
 
 from six import StringIO  # Python 2 and 3 compatible
 
-
 from conans.client import tools
 from conans.client.build import defs_to_string, join_arguments
 from conans.client.build.cmake_flags import CMakeDefinitionsBuilder, \
@@ -77,6 +76,14 @@ class CMake(object):
             self.definitions = builder.get_definitions(None)
 
         self.definitions["CONAN_EXPORTED"] = "1"
+
+        if hasattr(self._conanfile, 'settings_build'):
+            # https://github.com/conan-io/conan/issues/9202
+            if self._conanfile.settings_build.get_safe("os") == "Macos" and \
+               self._conanfile.settings.get_safe("os") == "iOS":
+                self.definitions["CMAKE_FIND_ROOT_PATH_MODE_INCLUDE"] = "BOTH"
+                self.definitions["CMAKE_FIND_ROOT_PATH_MODE_LIBRARY"] = "BOTH"
+                self.definitions["CMAKE_FIND_ROOT_PATH_MODE_PACKAGE"] = "BOTH"
 
         self.toolset = toolset or get_toolset(self._settings, self.generator)
         self.build_dir = None

--- a/conans/test/functional/build_helpers/cmake_ios_cross_build_test.py
+++ b/conans/test/functional/build_helpers/cmake_ios_cross_build_test.py
@@ -1,0 +1,73 @@
+import platform
+import textwrap
+
+import pytest
+
+from conans.test.utils.tools import TestClient
+
+
+@pytest.mark.skipif(platform.system() != "Darwin", reason="Only for Apple")
+@pytest.mark.tool_cmake
+def test_cross_build_test_package():
+    # https://github.com/conan-io/conan/issues/9202
+    profile_build = textwrap.dedent("""
+        [settings]
+        os=Macos
+        arch=x86_64
+        compiler=apple-clang
+        compiler.version=12.0
+        compiler.libcxx=libc++
+        build_type=Release
+        [options]
+        [build_requires]
+        [env]
+    """)
+
+    profile_host = textwrap.dedent("""
+        [settings]
+        os=iOS
+        os.version=12.0
+        arch=x86_64
+        compiler=apple-clang
+        compiler.version=12.0
+        compiler.libcxx=libc++
+        build_type=Release
+        [options]
+        [build_requires]
+        [env]
+    """)
+
+    test_cmakelist = textwrap.dedent("""
+        cmake_minimum_required(VERSION 3.1)
+        project(PackageTest CXX)
+        include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
+        conan_basic_setup(TARGETS)
+        find_package(hello REQUIRED CONFIG)
+        add_executable(example example.cpp)
+        target_link_libraries(example hello::hello)
+        set_property(TARGET example PROPERTY CXX_STANDARD 11)
+    """)
+
+    test_conanfile = textwrap.dedent("""
+        import os
+        from conans import ConanFile, CMake, tools
+        class HelloTestConan(ConanFile):
+            settings = "os", "compiler", "build_type", "arch"
+            generators = "cmake", "cmake_find_package_multi"
+            def build(self):
+                cmake = CMake(self)
+                cmake.configure()
+                cmake.build()
+            def test(self):
+                if not tools.cross_building(self):
+                    os.chdir("bin")
+                    self.run(".%sexample" % os.sep)
+    """)
+
+    client = TestClient()
+    client.run("new hello/0.1 -t")
+    client.save({"profile_build": profile_build,
+                 "profile_host": profile_host,
+                 "./test_package/conanfile.py": test_conanfile,
+                 "./test_package/CMakeLists.txt": test_cmakelist})
+    client.run("create . -pr:b profile_build -pr:h profile_host")


### PR DESCRIPTION
Changelog:  Fix: Fixed old CMake build helper to cross-build to iOS when two profiles are specified.
Docs: omit

Close #9202

@memsharded  This is limited only to the usage of two profiles, only when `build` is `Macos` and `host` is `iOS`. Do you think this could still be risky?