### PR TITLE
support custom name in virtualbuildenv and virtualbuildenv

### DIFF
--- a/conan/tools/env/virtualbuildenv.py
+++ b/conan/tools/env/virtualbuildenv.py
@@ -40,7 +40,7 @@ class VirtualBuildEnv:
 
         return build_env
 
-    def generate(self, auto_activate=True):
+    def generate(self, auto_activate=True, name="conanbuildenv"):
         build_env = self.environment()
         if build_env:  # Only if there is something defined
-            build_env.save_script("conanbuildenv", auto_activate=auto_activate)
+            build_env.save_script(name, auto_activate=auto_activate)

--- a/conan/tools/env/virtualrunenv.py
+++ b/conan/tools/env/virtualrunenv.py
@@ -43,7 +43,7 @@ class VirtualRunEnv:
 
         return runenv
 
-    def generate(self, auto_activate=False):
+    def generate(self, auto_activate=False, name="conanrunenv"):
         run_env = self.environment()
         if run_env:
-            run_env.save_script("conanrunenv", auto_activate=auto_activate)
+            run_env.save_script(name, auto_activate=auto_activate)


### PR DESCRIPTION
Changelog: Feature : support using a custom name in virtualbuildenv and virtualbuildenv.
This is useful for example when using multi config ide like visual studio. In this this case: we want to have two scripts:
* conanrunenv_release.bat
* conanrunenv_debug.bat 

Currently `conanrunenv.bat` for release overrides `conanrunenv.bat` for debug.

Docs: https://github.com/conan-io/docs/pull/2199

- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [x] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 

<sup>**Note:** By default this PR will skip the slower tests and will use a limited set of python versions. Check [here](https://github.com/conan-io/conan/blob/develop/.github/PR_INCREASE_TESTING.md) how to increase the testing level by writing some tags in the current PR body text.</sup>
