### PR TITLE
CMakeDeps/CMakeToolchain: Several improvements for open issues

### DIFF
--- a/conan/tools/cmake/cmakedeps/cmakedeps.py
+++ b/conan/tools/cmake/cmakedeps/cmakedeps.py
@@ -92,22 +92,22 @@ class CMakeDeps(object):
             generate_find_module = dep.new_cpp_info.get_property("cmake_module_file_name",
                                                                  "CMakeDeps") is not None
 
-            for find_modules_mode in ([False, True] if generate_find_module else [False]):
-                if not find_modules_mode:
+            for find_module_mode in ([False, True] if generate_find_module else [False]):
+                if not find_module_mode:
                     config_version = ConfigVersionTemplate(self, require, dep)
                     ret[config_version.filename] = config_version.render()
 
-                data_target = ConfigDataTemplate(self, require, dep, find_modules_mode)
+                data_target = ConfigDataTemplate(self, require, dep, find_module_mode)
                 ret[data_target.filename] = data_target.render()
 
                 target_configuration = TargetConfigurationTemplate(self, require, dep,
-                                                                   find_modules_mode)
+                                                                   find_module_mode)
                 ret[target_configuration.filename] = target_configuration.render()
 
-                targets = TargetsTemplate(self, require, dep, find_modules_mode)
+                targets = TargetsTemplate(self, require, dep, find_module_mode)
                 ret[targets.filename] = targets.render()
 
-                config = ConfigTemplate(self, require, dep, find_modules_mode)
+                config = ConfigTemplate(self, require, dep, find_module_mode)
                 # Check if the XXConfig.cmake exists to keep the first generated configuration
                 # to only include the build_modules from the first conan install. The rest of the
                 # file is common for the different configurations.

--- a/conan/tools/cmake/cmakedeps/cmakedeps.py
+++ b/conan/tools/cmake/cmakedeps/cmakedeps.py
@@ -12,6 +12,11 @@ from conans.errors import ConanException
 from conans.util.files import save
 
 
+FIND_MODE_MODULE = "module"
+FIND_MODE_CONFIG = "config"
+FIND_MODE_NONE = "none"
+FIND_MODE_BOTH = "both"
+
 class CMakeDeps(object):
 
     def __init__(self, conanfile):
@@ -84,34 +89,38 @@ class CMakeDeps(object):
                 self._conanfile.output.info("CMakeDeps: Skipped '{}'".format(dep.ref))
                 continue
 
+            cmake_find_mode = dep.new_cpp_info.get_property("cmake_find_mode", "CMakeDeps") or FIND_MODE_CONFIG
+            cmake_find_mode = cmake_find_mode.lower()
             # Skip from the requirement
-            if dep.new_cpp_info.get_property("skip_deps_file", "CMakeDeps"):
+            if cmake_find_mode == FIND_MODE_NONE:
                 # Skip the generation of config files for this node, it will be located externally
                 continue
 
-            generate_find_module = dep.new_cpp_info.get_property("cmake_module_file_name",
-                                                                 "CMakeDeps") is not None
+            if cmake_find_mode in (FIND_MODE_CONFIG, FIND_MODE_BOTH):
+                self._generate_files(require, dep, ret, find_module_mode=False)
 
-            for find_module_mode in ([False, True] if generate_find_module else [False]):
-                if not find_module_mode:
-                    config_version = ConfigVersionTemplate(self, require, dep)
-                    ret[config_version.filename] = config_version.render()
-
-                data_target = ConfigDataTemplate(self, require, dep, find_module_mode)
-                ret[data_target.filename] = data_target.render()
-
-                target_configuration = TargetConfigurationTemplate(self, require, dep,
-                                                                   find_module_mode)
-                ret[target_configuration.filename] = target_configuration.render()
-
-                targets = TargetsTemplate(self, require, dep, find_module_mode)
-                ret[targets.filename] = targets.render()
-
-                config = ConfigTemplate(self, require, dep, find_module_mode)
-                # Check if the XXConfig.cmake exists to keep the first generated configuration
-                # to only include the build_modules from the first conan install. The rest of the
-                # file is common for the different configurations.
-                if not os.path.exists(config.filename):
-                    ret[config.filename] = config.render()
+            if cmake_find_mode in (FIND_MODE_MODULE, FIND_MODE_BOTH):
+                self._generate_files(require, dep, ret, find_module_mode=True)
 
         return ret
+
+    def _generate_files(self, require, dep, ret, find_module_mode):
+        if not find_module_mode:
+            config_version = ConfigVersionTemplate(self, require, dep)
+            ret[config_version.filename] = config_version.render()
+
+        data_target = ConfigDataTemplate(self, require, dep, find_module_mode)
+        ret[data_target.filename] = data_target.render()
+
+        target_configuration = TargetConfigurationTemplate(self, require, dep, find_module_mode)
+        ret[target_configuration.filename] = target_configuration.render()
+
+        targets = TargetsTemplate(self, require, dep, find_module_mode)
+        ret[targets.filename] = targets.render()
+
+        config = ConfigTemplate(self, require, dep, find_module_mode)
+        # Check if the XXConfig.cmake exists to keep the first generated configuration
+        # to only include the build_modules from the first conan install. The rest of the
+        # file is common for the different configurations.
+        if not os.path.exists(config.filename):
+            ret[config.filename] = config.render()

--- a/conan/tools/cmake/cmakedeps/cmakedeps.py
+++ b/conan/tools/cmake/cmakedeps/cmakedeps.py
@@ -33,9 +33,6 @@ class CMakeDeps(object):
         # a suffix. It is necessary in case of same require and build_require and will cause an error
         self.build_context_suffix = {}
 
-        # Patterns to be excluded
-        self.excluded_requirement_patterns = []
-
         check_using_build_profile(self._conanfile)
 
         # Enable/Disable checking if a component target exists or not
@@ -82,11 +79,6 @@ class CMakeDeps(object):
             # and will be used in Conan 2.0
             # Filter the build_requires not activated with cmakedeps.build_context_activated
             if dep.is_build_context and dep.ref.name not in self.build_context_activated:
-                continue
-
-            # Skip from the consumer
-            if any(fnmatch(str(dep.ref), pattern) for pattern in self.excluded_requirement_patterns):
-                self._conanfile.output.info("CMakeDeps: Skipped '{}'".format(dep.ref))
                 continue
 
             cmake_find_mode = dep.new_cpp_info.get_property("cmake_find_mode", "CMakeDeps") or FIND_MODE_CONFIG

--- a/conan/tools/cmake/cmakedeps/templates/__init__.py
+++ b/conan/tools/cmake/cmakedeps/templates/__init__.py
@@ -7,11 +7,11 @@ from conans.errors import ConanException
 
 class CMakeDepsFileTemplate(object):
 
-    def __init__(self, cmakedeps, require, conanfile, find_modules_mode=False):
+    def __init__(self, cmakedeps, require, conanfile, find_module_mode=False):
         self.cmakedeps = cmakedeps
         self.require = require
         self.conanfile = conanfile
-        self.find_modules_mode = find_modules_mode
+        self.find_module_mode = find_module_mode
 
     @property
     def pkg_name(self):
@@ -23,7 +23,7 @@ class CMakeDepsFileTemplate(object):
 
     @property
     def file_name(self):
-        return get_file_name(self.conanfile, self.find_modules_mode) + self.suffix
+        return get_file_name(self.conanfile, self.find_module_mode) + self.suffix
 
     @property
     def suffix(self):
@@ -76,10 +76,10 @@ class CMakeDepsFileTemplate(object):
         return "_{}".format(self.configuration.upper()) if self.configuration else ""
 
     def get_file_name(self):
-        return get_file_name(self.conanfile, find_module_mode=self.find_modules_mode)
+        return get_file_name(self.conanfile, find_module_mode=self.find_module_mode)
 
     def get_target_namespace(self, req):
-        if self.find_modules_mode:
+        if self.find_module_mode:
             ret = req.new_cpp_info.get_property("cmake_module_target_name", "CMakeDeps")
             if ret:
                 return ret
@@ -96,7 +96,7 @@ class CMakeDepsFileTemplate(object):
                 return self.get_target_namespace(req)
             raise ConanException("Component '{name}::{cname}' not found in '{name}' "
                                  "package requirement".format(name=req.ref.name, cname=comp_name))
-        if self.find_modules_mode:
+        if self.find_module_mode:
             ret = req.new_cpp_info.components[comp_name].get_property("cmake_module_target_name",
                                                                       "CMakeDeps")
             if ret:

--- a/conan/tools/cmake/cmakedeps/templates/__init__.py
+++ b/conan/tools/cmake/cmakedeps/templates/__init__.py
@@ -7,10 +7,11 @@ from conans.errors import ConanException
 
 class CMakeDepsFileTemplate(object):
 
-    def __init__(self, cmakedeps, require, conanfile):
+    def __init__(self, cmakedeps, require, conanfile, find_modules_mode=False):
         self.cmakedeps = cmakedeps
         self.require = require
         self.conanfile = conanfile
+        self.find_modules_mode = find_modules_mode
 
     @property
     def pkg_name(self):
@@ -18,11 +19,11 @@ class CMakeDepsFileTemplate(object):
 
     @property
     def target_namespace(self):
-        return get_target_namespace(self.conanfile) + self.suffix
+        return self.get_target_namespace(self.conanfile) + self.suffix
 
     @property
     def file_name(self):
-        return get_file_name(self.conanfile) + self.suffix
+        return get_file_name(self.conanfile, self.find_modules_mode) + self.suffix
 
     @property
     def suffix(self):
@@ -74,29 +75,34 @@ class CMakeDepsFileTemplate(object):
     def config_suffix(self):
         return "_{}".format(self.configuration.upper()) if self.configuration else ""
 
-    def get_target_namespace(self):
-        return get_target_namespace(self.conanfile)
-
     def get_file_name(self):
-        return get_file_name(self.conanfile)
+        return get_file_name(self.conanfile, find_module_mode=self.find_modules_mode)
 
+    def get_target_namespace(self, req):
+        if self.find_modules_mode:
+            ret = req.new_cpp_info.get_property("cmake_module_target_name", "CMakeDeps")
+            if ret:
+                return ret
 
-def get_target_namespace(req):
-    ret = req.new_cpp_info.get_property("cmake_target_name", "CMakeDeps")
-    if not ret:
-        ret = req.cpp_info.get_name("cmake_find_package_multi", default_name=False)
-    return ret or req.ref.name
+        ret = req.new_cpp_info.get_property("cmake_target_name", "CMakeDeps")
+        if not ret:
+            ret = req.cpp_info.get_name("cmake_find_package_multi", default_name=False)
+        return ret or req.ref.name
 
-
-def get_component_alias(req, comp_name):
-    if comp_name not in req.new_cpp_info.components:
-        # foo::foo might be referencing the root cppinfo
-        if req.ref.name == comp_name:
-            return get_target_namespace(req)
-        raise ConanException("Component '{name}::{cname}' not found in '{name}' "
-                             "package requirement".format(name=req.ref.name, cname=comp_name))
-    ret = req.new_cpp_info.components[comp_name].get_property("cmake_target_name", "CMakeDeps")
-    if not ret:
-        ret = req.cpp_info.components[comp_name].get_name("cmake_find_package_multi",
-                                                          default_name=False)
-    return ret or comp_name
+    def get_component_alias(self, req, comp_name):
+        if comp_name not in req.new_cpp_info.components:
+            # foo::foo might be referencing the root cppinfo
+            if req.ref.name == comp_name:
+                return self.get_target_namespace(req)
+            raise ConanException("Component '{name}::{cname}' not found in '{name}' "
+                                 "package requirement".format(name=req.ref.name, cname=comp_name))
+        if self.find_modules_mode:
+            ret = req.new_cpp_info.components[comp_name].get_property("cmake_module_target_name",
+                                                                      "CMakeDeps")
+            if ret:
+                return ret
+        ret = req.new_cpp_info.components[comp_name].get_property("cmake_target_name", "CMakeDeps")
+        if not ret:
+            ret = req.cpp_info.components[comp_name].get_name("cmake_find_package_multi",
+                                                              default_name=False)
+        return ret or comp_name

--- a/conan/tools/cmake/cmakedeps/templates/config.py
+++ b/conan/tools/cmake/cmakedeps/templates/config.py
@@ -14,7 +14,7 @@ class ConfigTemplate(CMakeDepsFileTemplate):
 
     @property
     def filename(self):
-        if self.find_modules_mode:
+        if self.find_module_mode:
             return "Find{}.cmake".format(self.file_name)
         else:
             if self.file_name == self.file_name.lower():
@@ -24,7 +24,7 @@ class ConfigTemplate(CMakeDepsFileTemplate):
 
     @property
     def context(self):
-        targets_include = "" if not self.find_modules_mode else "modules-"
+        targets_include = "" if not self.find_module_mode else "module-"
         targets_include += "{}Targets.cmake".format(self.file_name)
         return {"file_name": self.file_name,
                 "pkg_name": self.pkg_name,

--- a/conan/tools/cmake/cmakedeps/templates/config.py
+++ b/conan/tools/cmake/cmakedeps/templates/config.py
@@ -14,18 +14,24 @@ class ConfigTemplate(CMakeDepsFileTemplate):
 
     @property
     def filename(self):
-        if self.file_name == self.file_name.lower():
-            return "{}-config.cmake".format(self.file_name)
+        if self.find_modules_mode:
+            return "Find{}.cmake".format(self.file_name)
         else:
-            return "{}Config.cmake".format(self.file_name)
+            if self.file_name == self.file_name.lower():
+                return "{}-config.cmake".format(self.file_name)
+            else:
+                return "{}Config.cmake".format(self.file_name)
 
     @property
     def context(self):
+        targets_include = "" if not self.find_modules_mode else "modules-"
+        targets_include += "{}Targets.cmake".format(self.file_name)
         return {"file_name": self.file_name,
                 "pkg_name": self.pkg_name,
                 "config_suffix": self.config_suffix,
                 "target_namespace": self.target_namespace,
-                "check_components_exist": self.cmakedeps.check_components_exist}
+                "check_components_exist": self.cmakedeps.check_components_exist,
+                "targets_include_file": targets_include}
 
     @property
     def template(self):
@@ -38,7 +44,7 @@ class ConfigTemplate(CMakeDepsFileTemplate):
         endif()
 
         include(${CMAKE_CURRENT_LIST_DIR}/cmakedeps_macros.cmake)
-        include(${CMAKE_CURRENT_LIST_DIR}/{{ file_name }}Targets.cmake)
+        include(${CMAKE_CURRENT_LIST_DIR}/{{ targets_include_file }})
         include(CMakeFindDependencyMacro)
 
         foreach(_DEPENDENCY {{ '${' + pkg_name + '_FIND_DEPENDENCY_NAMES' + '}' }} )

--- a/conan/tools/cmake/cmakedeps/templates/target_configuration.py
+++ b/conan/tools/cmake/cmakedeps/templates/target_configuration.py
@@ -13,7 +13,7 @@ class TargetConfigurationTemplate(CMakeDepsFileTemplate):
 
     @property
     def filename(self):
-        name = "" if not self.find_modules_mode else "modules-"
+        name = "" if not self.find_module_mode else "module-"
         name += "{}-Target-{}.cmake".format(self.file_name, self.cmakedeps.configuration.lower())
         return name
 

--- a/conan/tools/cmake/cmakedeps/templates/target_configuration.py
+++ b/conan/tools/cmake/cmakedeps/templates/target_configuration.py
@@ -14,7 +14,7 @@ class TargetConfigurationTemplate(CMakeDepsFileTemplate):
     @property
     def filename(self):
         name = "" if not self.find_modules_mode else "modules-"
-        name += "{}Target-{}.cmake".format(self.file_name, self.cmakedeps.configuration.lower())
+        name += "{}-Target-{}.cmake".format(self.file_name, self.cmakedeps.configuration.lower())
         return name
 
     @property

--- a/conan/tools/cmake/cmakedeps/templates/target_data.py
+++ b/conan/tools/cmake/cmakedeps/templates/target_data.py
@@ -15,7 +15,7 @@ class ConfigDataTemplate(CMakeDepsFileTemplate):
 
     @property
     def filename(self):
-        data_fname = "" if not self.find_modules_mode else "modules-"
+        data_fname = "" if not self.find_module_mode else "module-"
         data_fname += "{}-{}".format(self.file_name, self.configuration.lower())
         if self.arch:
             data_fname += "-{}".format(self.arch)
@@ -143,9 +143,9 @@ class ConfigDataTemplate(CMakeDepsFileTemplate):
             for dep_name, _ in self.conanfile.new_cpp_info.required_components:
                 if dep_name and dep_name not in ret:  # External dep
                     req = direct_host[dep_name]
-                    ret.append(get_file_name(req, self.find_modules_mode))
+                    ret.append(get_file_name(req, self.find_module_mode))
         elif direct_host:
-            ret = [get_file_name(r, self.find_modules_mode) for r in direct_host.values()]
+            ret = [get_file_name(r, self.find_module_mode) for r in direct_host.values()]
 
         return ret
 

--- a/conan/tools/cmake/cmakedeps/templates/targets.py
+++ b/conan/tools/cmake/cmakedeps/templates/targets.py
@@ -19,7 +19,7 @@ class TargetsTemplate(CMakeDepsFileTemplate):
 
     @property
     def context(self):
-        data_pattern = "${_DIR}/" if not self.find_modules_mode else  "${_DIR}/modules-"
+        data_pattern = "${_DIR}/" if not self.find_modules_mode else "${_DIR}/modules-"
         data_pattern += "{}-*-data.cmake".format(self.file_name)
 
         target_pattern = "" if not self.find_modules_mode else "modules-"

--- a/conan/tools/cmake/cmakedeps/templates/targets.py
+++ b/conan/tools/cmake/cmakedeps/templates/targets.py
@@ -13,16 +13,16 @@ class TargetsTemplate(CMakeDepsFileTemplate):
 
     @property
     def filename(self):
-        name = "" if not self.find_modules_mode else "modules-"
+        name = "" if not self.find_module_mode else "module-"
         name += self.file_name + "Targets.cmake"
         return name
 
     @property
     def context(self):
-        data_pattern = "${_DIR}/" if not self.find_modules_mode else "${_DIR}/modules-"
+        data_pattern = "${_DIR}/" if not self.find_module_mode else "${_DIR}/module-"
         data_pattern += "{}-*-data.cmake".format(self.file_name)
 
-        target_pattern = "" if not self.find_modules_mode else "modules-"
+        target_pattern = "" if not self.find_module_mode else "module-"
         target_pattern += "{}-Target-*.cmake".format(self.file_name)
 
         ret = {"pkg_name": self.pkg_name,

--- a/conan/tools/cmake/cmakedeps/templates/targets.py
+++ b/conan/tools/cmake/cmakedeps/templates/targets.py
@@ -13,13 +13,22 @@ class TargetsTemplate(CMakeDepsFileTemplate):
 
     @property
     def filename(self):
-        return "{}Targets.cmake".format(self.file_name)
+        name = "" if not self.find_modules_mode else "modules-"
+        name += self.file_name + "Targets.cmake"
+        return name
 
     @property
     def context(self):
+        data_pattern = "${_DIR}/" if not self.find_modules_mode else  "${_DIR}/modules-"
+        data_pattern += "{}-*-data.cmake".format(self.file_name)
+
+        target_pattern = "" if not self.find_modules_mode else "modules-"
+        target_pattern += "{}-Target-*.cmake".format(self.file_name)
+
         ret = {"pkg_name": self.pkg_name,
                "target_namespace": self.target_namespace,
-               "file_name": self.file_name}
+               "data_pattern": data_pattern,
+               "target_pattern": target_pattern}
         return ret
 
     @property
@@ -27,7 +36,7 @@ class TargetsTemplate(CMakeDepsFileTemplate):
         return textwrap.dedent("""\
         # Load the debug and release variables
         get_filename_component(_DIR "${CMAKE_CURRENT_LIST_FILE}" PATH)
-        file(GLOB DATA_FILES "${_DIR}/{{ file_name }}-*-data.cmake")
+        file(GLOB DATA_FILES "{{data_pattern}}")
 
         foreach(f ${DATA_FILES})
             include(${f})
@@ -48,7 +57,7 @@ class TargetsTemplate(CMakeDepsFileTemplate):
 
         # Load the debug and release library finders
         get_filename_component(_DIR "${CMAKE_CURRENT_LIST_FILE}" PATH)
-        file(GLOB CONFIG_FILES "${_DIR}/{{ file_name }}Target-*.cmake")
+        file(GLOB CONFIG_FILES "${_DIR}/{{ target_pattern }}")
 
         foreach(f ${CONFIG_FILES})
             include(${f})

--- a/conan/tools/cmake/toolchain.py
+++ b/conan/tools/cmake/toolchain.py
@@ -436,9 +436,12 @@ class FindConfigFiles(Block):
                                        p.replace('\\', '/').replace('$', '\\$').replace('"', '\\"'))
                                  for p in cppinfo.builddirs])
 
-        build_paths = " ".join(['"{}"'.format(b.replace('\\', '/')
-                                               .replace('$', '\\$')
-                                               .replace('"', '\\"')) for b in build_paths])
+        if self._toolchain.find_builddirs:
+            build_paths = " ".join(['"{}"'.format(b.replace('\\', '/')
+                                                   .replace('$', '\\$')
+                                                   .replace('"', '\\"')) for b in build_paths])
+        else:
+            build_paths = ""
 
         return {"find_package_prefer_config": find_package_prefer_config,
                 "cmake_prefix_path": "${CMAKE_CURRENT_LIST_DIR} " + build_paths,
@@ -727,6 +730,9 @@ class CMakeToolchain(object):
                                        ("rpath", SkipRPath),
                                        ("shared", SharedLibBock)])
 
+        # Set the CMAKE_MODULE_PATH and CMAKE_PREFIX_PATH to the deps .builddirs
+        self.find_builddirs = False
+
         check_using_build_profile(self._conanfile)
 
     def _context(self):
@@ -739,7 +745,7 @@ class CMakeToolchain(object):
             "variables_config": self.variables.configuration_types,
             "preprocessor_definitions": self.preprocessor_definitions,
             "preprocessor_definitions_config": self.preprocessor_definitions.configuration_types,
-            "conan_blocks": blocks,
+            "conan_blocks": blocks
         }
 
         return ctxt_toolchain

--- a/conan/tools/cmake/toolchain.py
+++ b/conan/tools/cmake/toolchain.py
@@ -68,7 +68,16 @@ class Block(object):
         context = self.values
         if context is None:
             return
-        return Template(self.template, trim_blocks=True, lstrip_blocks=True).render(**context)
+
+        def cmake_value(value):
+            if isinstance(value, bool):
+                return "ON" if value else "OFF"
+            else:
+                return '"{}"'.format(value)
+
+        template = Template(self.template, trim_blocks=True, lstrip_blocks=True)
+        template.environment.filters["cmake_value"] = cmake_value
+        return template.render(**context)
 
     def context(self):
         return {}
@@ -386,10 +395,10 @@ class FindConfigFiles(Block):
         {% endif %}
         # To support the generators based on find_package()
         {% if cmake_module_path %}
-        set(CMAKE_MODULE_PATH "{{ cmake_module_path }}" ${CMAKE_MODULE_PATH})
+        set(CMAKE_MODULE_PATH {{ cmake_module_path }} ${CMAKE_MODULE_PATH})
         {% endif %}
         {% if cmake_prefix_path %}
-        set(CMAKE_PREFIX_PATH "{{ cmake_prefix_path }}" ${CMAKE_PREFIX_PATH})
+        set(CMAKE_PREFIX_PATH {{ cmake_prefix_path }} ${CMAKE_PREFIX_PATH})
         {% endif %}
         {% if android_prefix_path %}
         set(CMAKE_FIND_ROOT_PATH {{ android_prefix_path }} ${CMAKE_FIND_ROOT_PATH})
@@ -415,11 +424,23 @@ class FindConfigFiles(Block):
 
         host_req = self._conanfile.dependencies.host.values()
         find_names_needed = os_ in ('iOS', "watchOS", "tvOS")
-        find_names = [get_file_name(req) for req in host_req] if find_names_needed else []
+        find_names = [get_file_name(req)
+                      for req in host_req] if find_names_needed else []
+
+        # Read the buildirs
+        build_paths = []
+        for req in host_req:
+            cppinfo = req.new_cpp_info.copy()
+            cppinfo.aggregate_components()
+            build_paths.extend([os.path.join(req.package_folder,
+                                       p.replace('\\', '/').replace('$', '\\$').replace('"', '\\"'))
+                                 for p in cppinfo.builddirs])
+
+        build_paths = " ".join(['"{}"'.format(b) for b in build_paths])
 
         return {"find_package_prefer_config": find_package_prefer_config,
-                "cmake_prefix_path": "${CMAKE_CURRENT_LIST_DIR}",
-                "cmake_module_path": "${CMAKE_CURRENT_LIST_DIR}",
+                "cmake_prefix_path": "${CMAKE_CURRENT_LIST_DIR} " + build_paths,
+                "cmake_module_path": "${CMAKE_CURRENT_LIST_DIR} " + build_paths,
                 "android_prefix_path": android_prefix,
                 "find_names": find_names,
                 "generators_folder": "${CMAKE_CURRENT_LIST_DIR}"}
@@ -667,7 +688,7 @@ class CMakeToolchain(object):
 
         # Variables
         {% for it, value in variables.items() %}
-        set({{ it }} "{{ value }}" CACHE STRING "Variable {{ it }} conan-toolchain defined")
+        set({{ it }} {{ value|cmake_value }} CACHE STRING "Variable {{ it }} conan-toolchain defined")
         {% endfor %}
         # Variables  per configuration
         {{ iterate_configs(variables_config, action='set') }}

--- a/conan/tools/cmake/toolchain.py
+++ b/conan/tools/cmake/toolchain.py
@@ -731,7 +731,7 @@ class CMakeToolchain(object):
                                        ("shared", SharedLibBock)])
 
         # Set the CMAKE_MODULE_PATH and CMAKE_PREFIX_PATH to the deps .builddirs
-        self.find_builddirs = False
+        self.find_builddirs = True
 
         check_using_build_profile(self._conanfile)
 

--- a/conan/tools/cmake/toolchain.py
+++ b/conan/tools/cmake/toolchain.py
@@ -436,7 +436,9 @@ class FindConfigFiles(Block):
                                        p.replace('\\', '/').replace('$', '\\$').replace('"', '\\"'))
                                  for p in cppinfo.builddirs])
 
-        build_paths = " ".join(['"{}"'.format(b) for b in build_paths])
+        build_paths = " ".join(['"{}"'.format(b.replace('\\', '/')
+                                               .replace('$', '\\$')
+                                               .replace('"', '\\"')) for b in build_paths])
 
         return {"find_package_prefer_config": find_package_prefer_config,
                 "cmake_prefix_path": "${CMAKE_CURRENT_LIST_DIR} " + build_paths,

--- a/conan/tools/cmake/utils.py
+++ b/conan/tools/cmake/utils.py
@@ -4,10 +4,14 @@ def is_multi_configuration(generator):
     return "Visual" in generator or "Xcode" in generator or "Multi-Config" in generator
 
 
-def get_file_name(conanfile):
+def get_file_name(conanfile, find_module_mode=False):
     """Get the name of the file for the find_package(XXX)"""
     # This is used by the CMakeToolchain to adjust the XXX_DIR variables and the CMakeDeps. Both
     # to know the file name that will have the XXX-config.cmake files.
+    if find_module_mode:
+        ret = conanfile.new_cpp_info.get_property("cmake_module_file_name", "CMakeDeps")
+        if ret:
+            return ret
     ret = conanfile.new_cpp_info.get_property("cmake_file_name", "CMakeDeps")
     if not ret:
         ret = conanfile.cpp_info.get_filename("cmake_find_package_multi", default_name=False)

--- a/conans/test/functional/toolchains/cmake/cmakedeps/test_cmakedeps_components.py
+++ b/conans/test/functional/toolchains/cmake/cmakedeps/test_cmakedeps_components.py
@@ -61,7 +61,7 @@ class PropagateSpecificComponents(unittest.TestCase):
         t = TestClient(cache_folder=self.cache_folder)
         t.save({'conanfile.py': self.app})
         t.run("install .  -g CMakeDeps")
-        config = t.load("middleTarget-release.cmake")
+        config = t.load("middle-Target-release.cmake")
         self.assertIn('top::cmp1', config)
         self.assertNotIn("top::top", config)
 
@@ -76,7 +76,7 @@ class PropagateSpecificComponents(unittest.TestCase):
         content = t.load('middle-config.cmake')
         self.assertIn("find_dependency(${_DEPENDENCY} REQUIRED NO_MODULE)", content)
 
-        content = t.load('middleTarget-release.cmake')
+        content = t.load('middle-Target-release.cmake')
         self.assertNotIn("top::top", content)
         self.assertNotIn("top::cmp2", content)
         self.assertIn("top::cmp1", content)

--- a/conans/test/functional/toolchains/cmake/cmakedeps/test_cmakedeps_find_module_and_config.py
+++ b/conans/test/functional/toolchains/cmake/cmakedeps/test_cmakedeps_find_module_and_config.py
@@ -1,0 +1,91 @@
+import textwrap
+
+import pytest
+
+from conans.test.assets.cmake import gen_cmakelists
+from conans.test.assets.genconanfile import GenConanfile
+from conans.test.assets.sources import gen_function_cpp, gen_function_h
+from conans.test.utils.tools import TestClient
+
+
+@pytest.fixture(scope="module")
+def client():
+    t = TestClient()
+    cpp = gen_function_cpp(name="mydep")
+    h = gen_function_h(name="mydep")
+    cmake = gen_cmakelists(libname="mydep", libsources=["mydep.cpp"])
+    conanfile = textwrap.dedent("""
+        import os
+        from conans import ConanFile
+        from conan.tools.cmake import CMake
+
+        class Conan(ConanFile):
+            name = "mydep"
+            version = "1.0"
+            settings = "os", "arch", "compiler", "build_type"
+            exports_sources = "*.cpp", "*.h", "CMakeLists.txt"
+            generators = "CMakeToolchain"
+
+            def build(self):
+                cmake = CMake(self)
+                cmake.configure()
+                cmake.build()
+
+            def package(self):
+                self.copy("*.h", dst="include")
+                self.copy("*.lib", dst="lib", keep_path=False)
+                self.copy("*.dll", dst="bin", keep_path=False)
+                self.copy("*.dylib*", dst="lib", keep_path=False)
+                self.copy("*.so", dst="lib", keep_path=False)
+                self.copy("*.a", dst="lib", keep_path=False)
+
+            def package_info(self):
+                self.cpp_info.set_property("cmake_file_name", "MyDep")
+                self.cpp_info.set_property("cmake_target_name", "MyDepTarget")
+
+                self.cpp_info.set_property("cmake_module_file_name", "mi_dependencia")
+                self.cpp_info.set_property("cmake_module_target_name", "mi_dependencia_target")
+
+                self.cpp_info.components["crispin"].libs = ["mydep"]
+                self.cpp_info.components["crispin"].set_property("cmake_target_name", "MyCrispinTarget")
+                self.cpp_info.components["crispin"].set_property("cmake_module_target_name", "mi_crispin_target")
+        """)
+
+    t.save({"conanfile.py": conanfile,
+            "mydep.cpp": cpp,
+            "mydep.h": h,
+            "CMakeLists.txt": cmake})
+
+    t.run("create .")
+    return t
+
+
+@pytest.mark.tool_cmake
+def test_reuse_with_modules_and_config(client):
+    cpp = gen_function_cpp(name="main")
+    cmake = """
+    set(CMAKE_CXX_COMPILER_WORKS 1)
+    set(CMAKE_CXX_ABI_COMPILED 1)
+    set(CMAKE_C_COMPILER_WORKS 1)
+    set(CMAKE_C_ABI_COMPILED 1)
+
+    cmake_minimum_required(VERSION 3.15)
+    project(project CXX)
+
+    add_executable(myapp main.cpp)
+    find_package(MyDep) # This one will find the config
+    target_link_libraries(myapp MyDepTarget::MyCrispinTarget)
+
+    add_executable(myapp2 main.cpp)
+    find_package(mi_dependencia) # This one will find the module
+    target_link_libraries(myapp2 mi_dependencia_target::mi_crispin_target)
+
+    """
+    conanfile = GenConanfile().with_name("myapp")\
+        .with_cmake_build().with_exports_sources("*.cpp", "*.txt").with_require("mydep/1.0")
+    client.save({"conanfile.py": conanfile,
+                 "main.cpp": cpp,
+                 "CMakeLists.txt": cmake})
+
+    client.run("install . -if=install")
+    client.run("build . -if=install")

--- a/conans/test/functional/toolchains/cmake/cmakedeps/test_cmakedeps_find_module_and_config.py
+++ b/conans/test/functional/toolchains/cmake/cmakedeps/test_cmakedeps_find_module_and_config.py
@@ -40,6 +40,9 @@ def client():
                 self.copy("*.a", dst="lib", keep_path=False)
 
             def package_info(self):
+
+                self.cpp_info.set_property("cmake_find_mode", "both")
+
                 self.cpp_info.set_property("cmake_file_name", "MyDep")
                 self.cpp_info.set_property("cmake_target_name", "MyDepTarget")
 

--- a/conans/test/functional/toolchains/cmake/test_cmakedeps_custom_configs.py
+++ b/conans/test/functional/toolchains/cmake/test_cmakedeps_custom_configs.py
@@ -84,9 +84,9 @@ class CustomConfigurationTest(unittest.TestCase):
             self.client.run("install .. %s -o hello:shared=True" % settings)
             self.client.run("install .. %s -o hello:shared=False" % settings)
             self.assertTrue(os.path.isfile(os.path.join(self.client.current_folder,
-                                                        "helloTarget-releaseshared.cmake")))
+                                                        "hello-Target-releaseshared.cmake")))
             self.assertTrue(os.path.isfile(os.path.join(self.client.current_folder,
-                                                        "helloTarget-release.cmake")))
+                                                        "hello-Target-release.cmake")))
 
             self.client.run_command('cmake .. -G "Visual Studio 15 Win64"')
             self.client.run_command('cmake --build . --config Release')
@@ -177,7 +177,7 @@ class CustomSettingsTest(unittest.TestCase):
         with self.client.chdir(build_directory):
             self.client.run("install .. %s" % settings)
             self.assertTrue(os.path.isfile(os.path.join(self.client.current_folder,
-                                                        "helloTarget-myrelease.cmake")))
+                                                        "hello-Target-myrelease.cmake")))
 
             self.client.run_command('cmake .. -G "Visual Studio 15 Win64"')
             self.client.run_command('cmake --build . --config MyRelease')

--- a/conans/test/integration/toolchains/cmake/cmakedeps/test_cmakedeps.py
+++ b/conans/test/integration/toolchains/cmake/cmakedeps/test_cmakedeps.py
@@ -16,7 +16,7 @@ def test_package_from_system():
                .with_settings("os", "arch", "build_type", "compiler"))
     dep2 += """
     def package_info(self):
-        self.cpp_info.set_property("skip_deps_file", True)
+        self.cpp_info.set_property("cmake_find_mode", "None")
         self.cpp_info.set_property("cmake_file_name", "custom_dep2")
 
     """

--- a/conans/test/integration/toolchains/cmake/cmakedeps/test_cmakedeps_find_module_and_config.py
+++ b/conans/test/integration/toolchains/cmake/cmakedeps/test_cmakedeps_find_module_and_config.py
@@ -1,0 +1,63 @@
+import os
+import textwrap
+
+import pytest
+
+from conan.tools.cmake.cmakedeps.cmakedeps import FIND_MODE_CONFIG, FIND_MODE_MODULE, FIND_MODE_BOTH, \
+    FIND_MODE_NONE
+from conans.test.assets.genconanfile import GenConanfile
+from conans.test.utils.tools import TestClient
+
+
+@pytest.mark.parametrize("cmake_find_mode", [FIND_MODE_CONFIG, FIND_MODE_MODULE,
+                                             FIND_MODE_BOTH, FIND_MODE_NONE, None])
+def test_reuse_with_modules_and_config(cmake_find_mode):
+    t = TestClient()
+    conanfile = textwrap.dedent("""
+            import os
+            from conans import ConanFile
+
+            class Conan(ConanFile):
+                name = "mydep"
+                version = "1.0"
+                settings = "os", "arch", "compiler", "build_type"
+
+                def package_info(self):
+                    {}
+
+            """)
+
+    if cmake_find_mode is not None:
+        s = 'self.cpp_info.set_property("cmake_find_mode", "{}")'.format(cmake_find_mode)
+        conanfile = conanfile.format(s)
+    t.save({"conanfile.py": conanfile})
+    t.run("create .")
+
+    conanfile = GenConanfile().with_name("myapp").with_require("mydep/1.0")\
+                                                 .with_generator("CMakeDeps")\
+                                                 .with_settings("build_type", "os", "arch", "compiler")
+    t.save({"conanfile.py": conanfile})
+
+    t.run("install . -if=install")
+
+    ifolder = os.path.join(t.current_folder, "install")
+
+    def exists_config(ifolder):
+        return os.path.exists(os.path.join(ifolder, "mydep-config.cmake"))
+
+    def exists_module(ifolder):
+        return os.path.exists(os.path.join(ifolder, "Findmydep.cmake"))
+
+    if cmake_find_mode == FIND_MODE_CONFIG or cmake_find_mode is None:
+        # None is default "config"
+        assert exists_config(ifolder)
+        assert not exists_module(ifolder)
+    elif cmake_find_mode == FIND_MODE_MODULE:
+        assert not exists_config(ifolder)
+        assert exists_module(ifolder)
+    elif cmake_find_mode == FIND_MODE_BOTH:
+        assert exists_config(ifolder)
+        assert exists_module(ifolder)
+    elif cmake_find_mode == FIND_MODE_NONE:
+        assert not exists_config(ifolder)
+        assert not exists_module(ifolder)

--- a/conans/test/unittests/tools/cmake/test_cmakedeps.py
+++ b/conans/test/unittests/tools/cmake/test_cmakedeps.py
@@ -45,7 +45,7 @@ def test_cpp_info_name_cmakedeps(using_properties):
 
         cmakedeps = CMakeDeps(conanfile)
         files = cmakedeps.content
-        assert "TARGET MySuperPkg1::MySuperPkg1" in files["ComplexFileName1Target-release.cmake"]
+        assert "TARGET MySuperPkg1::MySuperPkg1" in files["ComplexFileName1-Target-release.cmake"]
         assert 'set(OriginalDepName_INCLUDE_DIRS_RELEASE ' \
                '"${OriginalDepName_PACKAGE_FOLDER_RELEASE}/include")' \
                in files["ComplexFileName1-release-x86-data.cmake"]
@@ -87,7 +87,7 @@ def test_cpp_info_name_cmakedeps_components(using_properties):
 
         cmakedeps = CMakeDeps(conanfile)
         files = cmakedeps.content
-        assert "TARGET GlobakPkgName1::MySuperPkg1" in files["ComplexFileName1Target-debug.cmake"]
+        assert "TARGET GlobakPkgName1::MySuperPkg1" in files["ComplexFileName1-Target-debug.cmake"]
         assert 'set(OriginalDepName_INCLUDE_DIRS_DEBUG ' \
                '"${OriginalDepName_PACKAGE_FOLDER_DEBUG}/include")' \
                in files["ComplexFileName1-debug-x64-data.cmake"]
@@ -165,7 +165,7 @@ def test_component_name_same_package():
 
         cmakedeps = CMakeDeps(conanfile)
         files = cmakedeps.content
-        target_cmake = files["mypkgTarget-release.cmake"]
+        target_cmake = files["mypkg-Target-release.cmake"]
         assert "$<$<CONFIG:Release>:${mypkg_mypkg_INCLUDE_DIRS_RELEASE}> APPEND)" in target_cmake
 
         data_cmake = files["mypkg-release-x86-data.cmake"]


### PR DESCRIPTION
Changelog: Feature: **CMakeToolchain** new member `find_builddirs` defaulted to `True` to add the `cpp_info.builddirs` from the requirements to the `CMAKE_PREFIX_PATH/CMAKE_MODULE_PATH`. That would allow finding the config files packaged and to be able to `include()` them from the consumer `CMakeLists.txt`.
Changelog: Bugfix: **CMakeToolchain**. Fixed a bugfix whereby a variable declared at the `.variables` containing a boolean ended at CMake with a quoted `"True"` or `"False"` values, instead of `ON` / `OFF`
Changelog: Feature: **CMakeDeps**. Added a new property `cmake_find_mode` with possible values to `config`(default), `module`, `both` or `none` to control the files to be generated from a package itself. The `none` replaces the current `skip_deps_file` property.
Changelog: Feature: **CMakeDeps**: Added two new properties `cmake_module_file_name` and `cmake_module_target_name`, analog to `cmake_file_name` and `cmake_target_name`, but to configure the name of `FindXXX.cmake` file and the target declared inside. 
    
Docs: https://github.com/conan-io/docs/pull/2209