### PR TITLE
[hotfix] Remove package by its reference

### DIFF
--- a/conans/client/command.py
+++ b/conans/client/command.py
@@ -1182,8 +1182,20 @@ class Command(object):
             if not args.pattern_or_reference:
                 raise ConanException('Please specify a pattern to be removed ("*" for all)')
 
-        return self._conan.remove(pattern=args.pattern_or_reference, query=args.query,
-                                  packages=args.packages, builds=args.builds, src=args.src,
+        try:
+            pref = PackageReference.loads(args.pattern_or_reference, validate=True)
+            packages = [pref.id]
+            pattern_or_reference = repr(pref.ref)
+        except ConanException:
+            pref = None
+            pattern_or_reference = args.pattern_or_reference
+            packages = args.packages
+
+        if pref and args.packages:
+            raise ConanException("Use package ID only as -p argument or reference, not both")
+
+        return self._conan.remove(pattern=pattern_or_reference, query=args.query,
+                                  packages=packages, builds=args.builds, src=args.src,
                                   force=args.force, remote_name=args.remote, outdated=args.outdated)
 
     def copy(self, *args):

--- a/conans/test/integration/command/remove_test.py
+++ b/conans/test/integration/command/remove_test.py
@@ -519,3 +519,55 @@ class RemoveWithoutUserChannel(unittest.TestCase):
         self.client.run("remove lib/1.0 -f -r default")
         self.client.run("install lib/1.0@", assert_error=True)
         self.assertIn("ERROR: Unable to find 'lib/1.0' in remotes", self.client.out)
+
+
+class RemovePackageRevisionsTest(unittest.TestCase):
+
+    NO_SETTINGS_RREF = "f3367e0e7d170aa12abccb175fee5f97"
+
+    def setUp(self):
+        self.test_server = TestServer(users={"user": "password"},
+                                      write_permissions=[("foobar/0.1@*/*", "user")])
+        servers = {"default": self.test_server}
+        self.client = TestClient(servers=servers, users={"default": [("user", "password")]})
+        self.client.run("config set general.revisions_enabled=1")
+
+    def test_remove_local_package_id_argument(self):
+        """ Remove package ID based on recipe revision. The package must be deleted, but
+            the recipe must be preserved
+            Package ID is a separated argument: <package>#<rref> -p <pkgid>
+        """
+
+        self.client.save({"conanfile.py": GenConanfile()})
+        self.client.run("create . foobar/0.1@user/testing")
+        self.client.run("info foobar/0.1@user/testing")
+        self.assertIn("Binary: Cache", self.client.out)
+        self.assertIn("Revision: f3367e0e7d170aa12abccb175fee5f97", self.client.out)
+        self.assertIn("Package revision: 83c38d3b4e5f1b8450434436eec31b00", self.client.out)
+
+        self.client.run("remove -f foobar/0.1@user/testing#{} -p {}"
+                        .format(self.NO_SETTINGS_RREF, NO_SETTINGS_PACKAGE_ID))
+        self.client.run("info foobar/0.1@user/testing")
+        self.assertIn("Binary: Missing", self.client.out)
+        self.assertIn("Revision: f3367e0e7d170aa12abccb175fee5f97", self.client.out)
+        self.assertIn("Package revision: None", self.client.out)
+
+    def test_remove_local_package_id_reference(self):
+        """ Remove package ID based on recipe revision. The package must be deleted, but
+            the recipe must be preserved.
+            Package ID is part of package reference: <package>#<rref>:<pkgid>
+        """
+
+        self.client.save({"conanfile.py": GenConanfile()})
+        self.client.run("create . foobar/0.1@user/testing")
+        self.client.run("info foobar/0.1@user/testing")
+        self.assertIn("Binary: Cache", self.client.out)
+        self.assertIn("Revision: f3367e0e7d170aa12abccb175fee5f97", self.client.out)
+        self.assertIn("Package revision: 83c38d3b4e5f1b8450434436eec31b00", self.client.out)
+
+        self.client.run("remove -f foobar/0.1@user/testing#{}:{}"
+                        .format(self.NO_SETTINGS_RREF, NO_SETTINGS_PACKAGE_ID))
+        self.client.run("info foobar/0.1@user/testing")
+        self.assertIn("Binary: Missing", self.client.out)
+        self.assertIn("Revision: f3367e0e7d170aa12abccb175fee5f97", self.client.out)
+        self.assertIn("Package revision: None", self.client.out)


### PR DESCRIPTION
Now it's possible to remove a packages based on its package reference, for example:

    conan remove foobar/0.1@user/testing#f3367e0e7d170aa12abccb175fee5f97:5ab84d6acfe1f23c4fae0ab88f26e3a396351ac9

As we can't break our current behavior, [-p|--package] is still valid but when both package reference and -p have a package ID, it will be considered an error, resulting in a `ConanException`

I didn't use pytest, because the entire file is python unittest and I don't want to mix the things. Let's update in a next PR as enhancement.

Changelog: Fix: Make `conan remove` accept package reference syntax.
Docs: https://github.com/conan-io/docs/pull/2198

Fixes: #6545

/cc @danimtb 

- [x] Refer to the issue that supports this Pull Request.
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [x] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 

<sup>**Note:** By default this PR will skip the slower tests and will use a limited set of python versions. Check [here](https://github.com/conan-io/conan/blob/develop/.github/PR_INCREASE_TESTING.md) how to increase the testing level by writing some tags in the current PR body text.</sup>
