### PR TITLE
check if distro pypi package can be upgraded to 1.6.0

### DIFF
--- a/conans/requirements.txt
+++ b/conans/requirements.txt
@@ -7,7 +7,7 @@ patch-ng>=1.17.4, <1.18
 fasteners>=0.14.1
 six>=1.10.0,<=1.16.0
 node-semver==0.6.1
-distro>=1.0.2, <=1.5.0
+distro>=1.0.2, <=1.6.0
 future>=0.16.0, <0.19.0
 pygments>=2.0, <3.0
 deprecation>=2.0, <2.1


### PR DESCRIPTION
Changelog: Fix: Upgrade ``distro`` dependency to allow 1.6.0
Docs: Omit

Close #9452
Maybe helps with https://github.com/conan-io/conan/issues/9460

Release notes https://github.com/python-distro/distro/releases/tag/v1.6.0 doesnt show any concerning change.