### PR TITLE
conf to default the usage of host and build profile

### DIFF
--- a/conans/client/conan_api.py
+++ b/conans/client/conan_api.py
@@ -1437,6 +1437,7 @@ class ConanAPIV1(object):
                     base=None, lockfile=None):
         # profile_host is mandatory
         profile_host = profile_host or ProfileData(None, None, None, None, None)
+        profile_build = profile_build or ProfileData(None, None, None, None, None)
         cwd = os.getcwd()
 
         if path and reference:
@@ -1467,11 +1468,11 @@ class ConanAPIV1(object):
                                       profile_host.options, profile_host.env, profile_host.conf,
                                       cwd, self.app.cache)
 
-        if profile_build and not pbuild:
+        if not pbuild:
             # Only work on the profile_build if something is provided
             pbuild = profile_from_args(profile_build.profiles, profile_build.settings,
                                        profile_build.options, profile_build.env, profile_build.conf,
-                                       cwd, self.app.cache)
+                                       cwd, self.app.cache, build_profile=True)
 
         root_ref = ConanFileReference(name, version, user, channel, validate=False)
         phost.process_settings(self.app.cache)
@@ -1557,14 +1558,14 @@ def get_graph_info(profile_host, profile_build, cwd, install_folder, cache, outp
         phost = profile_from_args(profile_host.profiles, profile_host.settings, profile_host.options,
                                   profile_host.env, profile_host.conf, cwd, cache)
         phost.process_settings(cache)
-        if profile_build:
-            # Only work on the profile_build if something is provided
-            pbuild = profile_from_args(profile_build.profiles, profile_build.settings,
-                                       profile_build.options, profile_build.env, profile_build.conf,
-                                       cwd, cache)
+
+        profile_build = profile_build or ProfileData(None, None, None, None, None)
+        # Only work on the profile_build if something is provided
+        pbuild = profile_from_args(profile_build.profiles, profile_build.settings,
+                                   profile_build.options, profile_build.env, profile_build.conf,
+                                   cwd, cache, build_profile=True)
+        if pbuild is not None:
             pbuild.process_settings(cache)
-        else:
-            pbuild = None
 
         root_ref = ConanFileReference(name, version, user, channel, validate=False)
         graph_info = GraphInfo(profile_host=phost, profile_build=pbuild, root_ref=root_ref)

--- a/conans/test/integration/configuration/default_profile_test.py
+++ b/conans/test/integration/configuration/default_profile_test.py
@@ -1,4 +1,5 @@
 import os
+import textwrap
 import unittest
 
 from conans.client import tools
@@ -179,4 +180,20 @@ class MyConanfile(ConanFile):
             self.assertIn("Environment variable 'CONAN_DEFAULT_PROFILE_PATH' must point to "
                           "an existing profile file.", client.out)
 
+
+def test_conf_default_two_profiles():
+    client = TestClient()
+    save(os.path.join(client.cache.profiles_path, "mydefault"), "[settings]\nos=FreeBSD")
+    save(os.path.join(client.cache.profiles_path, "mydefault_build"), "[settings]\nos=Android")
+    global_conf = textwrap.dedent("""
+        core:default_profile=mydefault
+        core:default_build_profile=mydefault_build
+        """)
+    save(client.cache.new_config_path, global_conf)
+    client.save({"conanfile.txt": ""})
+    client.run("install .")
+    assert "Configuration (profile_host):" in client.out
+    assert "os=FreeBSD" in client.out
+    assert "Configuration (profile_build):" in client.out
+    assert "os=Android" in client.out
 


### PR DESCRIPTION
Changelog: Feature: Provide new ``[conf]`` ``core:default_build_profile`` to enable the usage of the build profile as default, and to allow definition of the host profile default in new ``[conf]`` ``core:default_profile``.
Docs: https://github.com/conan-io/docs/pull/2213

Close https://github.com/conan-io/conan/issues/9336


This was way more difficult than expected, the implementation is ugly and confusing, but it is due to the current state of legacy 1.X, all this needs to be fixed for 2.0