### PR TITLE
Bazel build files have an extra ] if there are no depenedencies

### DIFF
--- a/conan/tools/google/bazeldeps.py
+++ b/conan/tools/google/bazeldeps.py
@@ -59,8 +59,8 @@ class BazelDeps(object):
                 {% for lib in libs %}
                 ":{{ lib }}_precompiled",
                 {% endfor %}
-                {% endif %}
                 ],
+                {% endif %}
             )
 
         """)

--- a/conans/test/unittests/tools/google/test_bazeldeps.py
+++ b/conans/test/unittests/tools/google/test_bazeldeps.py
@@ -1,5 +1,6 @@
 import mock
 from mock import Mock
+import re
 
 from conan.tools.google import BazelDeps
 from conans import ConanFile
@@ -36,6 +37,25 @@ def test_bazeldeps_dependency_buildfiles():
             assert 'linkopts = ["-lsystem_lib1"],' in dependency_content
             assert 'deps = [\n    \n    ":lib1_precompiled",' in dependency_content
 
+def test_bazeldeps_interface_buildfiles():
+    conanfile = ConanFile(Mock(), None)
+
+    cpp_info = CppInfo("mypkg", "dummy_root_folder2")
+
+    conanfile_dep = ConanFile(Mock(), None)
+    conanfile_dep.cpp_info = cpp_info
+    conanfile_dep._conan_node = Mock()
+    conanfile_dep._conan_node.ref = ConanFileReference.loads("OriginalDepName/2.0")
+
+    with mock.patch('conans.ConanFile.dependencies', new_callable=mock.PropertyMock) as mock_deps:
+        req = Requirement(ConanFileReference.loads("OriginalDepName/1.0"))
+        mock_deps.return_value = ConanFileDependencies({req: ConanFileInterface(conanfile_dep)})
+
+        bazeldeps = BazelDeps(conanfile)
+
+        dependency = next(iter(bazeldeps._conanfile.dependencies.host.values()))
+        dependency_content = re.sub(r"\s", "", bazeldeps._get_dependency_buildfile_content(dependency))
+        assert(dependency_content == 'load("@rules_cc//cc:defs.bzl","cc_import","cc_library")cc_library(name="OriginalDepName",hdrs=glob(["include/**"]),includes=["include"],visibility=["//visibility:public"],)')
 
 def test_bazeldeps_main_buildfile():
     expected_content = [


### PR DESCRIPTION
Changelog: Bugfix: Bazel build files have an extra `]` if there are no dependencies.
Docs: omit

- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [skipped] Refer to the issue that supports this Pull Request.
- [skipped] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 
