### PR TITLE
[Bugfix] Setting CMAKE_OSX_DEPLOYMENT_TARGET as cache entry

### DIFF
--- a/conan/tools/cmake/toolchain.py
+++ b/conan/tools/cmake/toolchain.py
@@ -319,7 +319,8 @@ class AppleSystemBlock(Block):
         # but full path is necessary for others
         set(CMAKE_OSX_SYSROOT {{ CMAKE_OSX_SYSROOT }} CACHE STRING "" FORCE)
         {% if CMAKE_OSX_DEPLOYMENT_TARGET is defined %}
-        set(CMAKE_OSX_DEPLOYMENT_TARGET {{ CMAKE_OSX_DEPLOYMENT_TARGET }})
+        # Setting CMAKE_OSX_DEPLOYMENT_TARGET if "os.version" is defined by the used conan profile
+        set(CMAKE_OSX_DEPLOYMENT_TARGET "{{ CMAKE_OSX_DEPLOYMENT_TARGET }}" CACHE STRING "")
         {% endif %}
         """)
 

--- a/conans/test/unittests/tools/cmake/test_cmaketoolchain.py
+++ b/conans/test/unittests/tools/cmake/test_cmaketoolchain.py
@@ -164,4 +164,4 @@ def conanfile_apple():
 def test_osx_deployment_target(conanfile_apple):
     toolchain = CMakeToolchain(conanfile_apple)
     content = toolchain.content
-    assert 'set(CMAKE_OSX_DEPLOYMENT_TARGET 10.15)' in content
+    assert 'set(CMAKE_OSX_DEPLOYMENT_TARGET "10.15" CACHE STRING "")' in content


### PR DESCRIPTION
Changelog: Bugfix: Setting the `CMAKE_OSX_DEPLOYMENT_TARGET` variable as a cache entry.
Docs: omit
Closes: https://github.com/conan-io/conan/issues/9349

- [x] Refer to the issue that supports this Pull Request.
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 

<sup>**Note:** By default this PR will skip the slower tests and will use a limited set of python versions. Check [here](https://github.com/conan-io/conan/blob/develop/.github/PR_INCREASE_TESTING.md) how to increase the testing level by writing some tags in the current PR body text.</sup>
