### PR TITLE
Feature: detect VS2022 as msvc

### DIFF
--- a/conans/client/conf/detect.py
+++ b/conans/client/conf/detect.py
@@ -163,7 +163,7 @@ def _get_profile_compiler_version(compiler, version, output):
     elif compiler == "msvc":
         # by default, drop the last digit of the minor (19.30 -> 19.3)
         if len(minor) == 2:
-            version = version[:len(version) - 1]
+            version = version[:-1]
     return version
 
 

--- a/conans/client/conf/detect.py
+++ b/conans/client/conf/detect.py
@@ -160,6 +160,10 @@ def _get_profile_compiler_version(compiler, version, output):
         return major
     elif compiler == "intel" and (int(major) < 19 or (int(major) == 19 and int(minor) == 0)):
         return major
+    elif compiler == "msvc":
+        # by default, drop the last digit of the minor (19.30 -> 19.3)
+        if len(minor) == 2:
+            version = version[:len(version) - 1]
     return version
 
 
@@ -223,6 +227,13 @@ def _detect_compiler_version(result, output, profile_path):
     if not compiler or not version:
         output.error("Unable to find a working compiler")
         return
+
+    # Visual Studio 2022 onwards, detect as a new compiler "msvc"
+    if compiler == "Visual Studio":
+        version = Version(version)
+        if version == "17":
+            compiler = "msvc"
+            version = "19.3"
 
     result.append(("compiler", compiler))
     result.append(("compiler.version", _get_profile_compiler_version(compiler, version, output)))

--- a/conans/test/unittests/client/build/compiler_id_test.py
+++ b/conans/test/unittests/client/build/compiler_id_test.py
@@ -2,7 +2,7 @@ import unittest
 from parameterized import parameterized
 
 from conans.client.conf.compiler_id import detect_compiler_id, CompilerId, UNKNOWN_COMPILER, \
-    GCC, LLVM_GCC, CLANG, APPLE_CLANG, SUNCC, MSVC, INTEL, QCC, MCST_LCC
+    GCC, LLVM_GCC, CLANG, APPLE_CLANG, SUNCC, VISUAL_STUDIO, MSVC, INTEL, QCC, MCST_LCC
 from conans.test.unittests.util.tools_test import RunnerMock
 
 
@@ -105,13 +105,18 @@ class CompilerIdTest(unittest.TestCase):
                            ("MSC_CMD_FLAGS=-D_MSC_VER=1928 -D_MSC_FULL_VER=192829500", 16, 9, 0),
                            ("MSC_CMD_FLAGS=-D_MSC_VER=1929", 16, 10, 0),
                            ("MSC_CMD_FLAGS=-D_MSC_VER=1929 -D_MSC_FULL_VER=192930100", 16, 11, 0),
-                           ("MSC_CMD_FLAGS=-D_MSC_VER=1930", 17, 0, 0),
                            ])
-    def test_msvc(self, line, major, minor, patch):
+    def test_visual_studio(self, line, major, minor, patch):
         runner = RunnerMock()
         runner.output = line
         compiler_id = detect_compiler_id("cl", runner=runner)
-        self.assertEqual(CompilerId(MSVC, major, minor, patch), compiler_id)
+        self.assertEqual(CompilerId(VISUAL_STUDIO, major, minor, patch), compiler_id)
+
+    def test_msvc(self):
+        runner = RunnerMock()
+        runner.output = "MSC_CMD_FLAGS=-D_MSC_VER=1930"
+        compiler_id = detect_compiler_id("cl", runner=runner)
+        self.assertEqual(CompilerId(MSVC, 19, 30, 0), compiler_id)
 
     def test_intel(self):
         runner = RunnerMock()

--- a/conans/test/unittests/util/detect_test.py
+++ b/conans/test/unittests/util/detect_test.py
@@ -93,3 +93,12 @@ class DetectTest(unittest.TestCase):
         with tools.environment_append({"CC": "clang-9 --gcc-toolchain=/usr/lib/gcc/x86_64-linux-gnu/9"}):
             detect_defaults_settings(output, profile_path="./MyProfile")
             self.assertIn("CC and CXX: clang-9 --gcc-toolchain", output)
+
+    def test_vs2022(self):
+        with mock.patch("conans.client.conf.detect._get_default_compiler",
+                        mock.MagicMock(return_value=("Visual Studio", "17"))):
+            result = detect_defaults_settings(output=Mock(),
+                                              profile_path=DEFAULT_PROFILE_NAME)
+            result = dict(result)
+            self.assertEqual('msvc', result['compiler'])
+            self.assertEqual('19.3', result['compiler.version'])


### PR DESCRIPTION
closes: #9501 

Changelog: Feature: Detect Visual Studio 2022 as `msvc`.
Docs: omit

- [ ] Refer to the issue that supports this Pull Request.
- [ ] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [ ] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [ ] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 

<sup>**Note:** By default this PR will skip the slower tests and will use a limited set of python versions. Check [here](https://github.com/conan-io/conan/blob/develop/.github/PR_INCREASE_TESTING.md) how to increase the testing level by writing some tags in the current PR body text.</sup>
