### PR TITLE
CMakeDeps with custom namespace

### DIFF
--- a/conan/tools/cmake/cmakedeps/templates/__init__.py
+++ b/conan/tools/cmake/cmakedeps/templates/__init__.py
@@ -21,6 +21,10 @@ class CMakeDepsFileTemplate(object):
         return get_target_namespace(self.conanfile) + self.suffix
 
     @property
+    def global_target_name(self):
+        return get_global_target_name(self.conanfile) + self.suffix
+
+    @property
     def file_name(self):
         return get_file_name(self.conanfile) + self.suffix
 
@@ -82,6 +86,11 @@ class CMakeDepsFileTemplate(object):
 
 
 def get_target_namespace(req):
+    ret = req.new_cpp_info.get_property("cmake_target_namespace", "CMakeDeps")
+    return ret or get_global_target_name(req)
+
+
+def get_global_target_name(req):
     ret = req.new_cpp_info.get_property("cmake_target_name", "CMakeDeps")
     if not ret:
         ret = req.cpp_info.get_name("cmake_find_package_multi", default_name=False)

--- a/conan/tools/cmake/cmakedeps/templates/__init__.py
+++ b/conan/tools/cmake/cmakedeps/templates/__init__.py
@@ -83,6 +83,11 @@ class CMakeDepsFileTemplate(object):
         return get_file_name(self.conanfile, find_module_mode=self.find_module_mode)
 
     def get_target_namespace(self, req):
+        if self.find_module_mode:
+            ret = req.new_cpp_info.get_property("cmake_module_target_namespace", "CMakeDeps")
+            if ret:
+                return ret
+
         ret = req.new_cpp_info.get_property("cmake_target_namespace", "CMakeDeps")
         return ret or self.get_global_target_name(req)
 

--- a/conan/tools/cmake/cmakedeps/templates/target_configuration.py
+++ b/conan/tools/cmake/cmakedeps/templates/target_configuration.py
@@ -1,7 +1,7 @@
 import textwrap
 
 from conan.tools.cmake.cmakedeps.templates import CMakeDepsFileTemplate, get_component_alias, \
-    get_target_namespace
+    get_target_namespace, get_global_target_name
 
 """
 
@@ -23,6 +23,7 @@ class TargetConfigurationTemplate(CMakeDepsFileTemplate):
             if not self.conanfile.is_build_context else []
         return {"pkg_name": self.pkg_name,
                 "target_namespace": self.target_namespace,
+                "global_target_name": self.global_target_name,
                 "config_suffix": self.config_suffix,
                 "deps_targets_names": ";".join(deps_targets_names),
                 "components_names":  self.get_required_components_names(),
@@ -106,17 +107,17 @@ class TargetConfigurationTemplate(CMakeDepsFileTemplate):
 
 
         ########## GLOBAL TARGET PROPERTIES {{ configuration }} ########################################
-        set_property(TARGET {{target_namespace}}::{{target_namespace}}
+        set_property(TARGET {{target_namespace}}::{{global_target_name}}
                      PROPERTY INTERFACE_LINK_LIBRARIES
                      $<$<CONFIG:{{configuration}}>:${{'{'}}{{pkg_name}}_LIBRARIES_TARGETS{{config_suffix}}}
                                                    ${{'{'}}{{pkg_name}}_LINKER_FLAGS{{config_suffix}}}> APPEND)
-        set_property(TARGET {{target_namespace}}::{{target_namespace}}
+        set_property(TARGET {{target_namespace}}::{{global_target_name}}
                      PROPERTY INTERFACE_INCLUDE_DIRECTORIES
                      $<$<CONFIG:{{configuration}}>:${{'{'}}{{pkg_name}}_INCLUDE_DIRS{{config_suffix}}}> APPEND)
-        set_property(TARGET {{target_namespace}}::{{target_namespace}}
+        set_property(TARGET {{target_namespace}}::{{global_target_name}}
                      PROPERTY INTERFACE_COMPILE_DEFINITIONS
                      $<$<CONFIG:{{configuration}}>:${{'{'}}{{pkg_name}}_COMPILE_DEFINITIONS{{config_suffix}}}> APPEND)
-        set_property(TARGET {{target_namespace}}::{{target_namespace}}
+        set_property(TARGET {{target_namespace}}::{{global_target_name}}
                      PROPERTY INTERFACE_COMPILE_OPTIONS
                      $<$<CONFIG:{{configuration}}>:${{'{'}}{{pkg_name}}_COMPILE_OPTIONS{{config_suffix}}}> APPEND)
 
@@ -173,6 +174,6 @@ class TargetConfigurationTemplate(CMakeDepsFileTemplate):
                 ret.append("{}::{}".format(dep_name, component_name))
         elif self.conanfile.dependencies.direct_host:
             # Regular external "conanfile.requires" declared, not cpp_info requires
-            ret = ["{p}::{p}".format(p=get_target_namespace(r))
+            ret = ["{p}::{n}".format(p=get_target_namespace(r), n=get_global_target_name(r))
                    for r in self.conanfile.dependencies.direct_host.values()]
         return ret

--- a/conan/tools/cmake/cmakedeps/templates/targets.py
+++ b/conan/tools/cmake/cmakedeps/templates/targets.py
@@ -19,6 +19,7 @@ class TargetsTemplate(CMakeDepsFileTemplate):
     def context(self):
         ret = {"pkg_name": self.pkg_name,
                "target_namespace": self.target_namespace,
+               "global_target_name": self.global_target_name,
                "file_name": self.file_name}
         return ret
 
@@ -41,9 +42,9 @@ class TargetsTemplate(CMakeDepsFileTemplate):
             endif()
         endforeach()
 
-        if(NOT TARGET {{ target_namespace }}::{{ target_namespace }})
-            add_library({{ target_namespace }}::{{ target_namespace }} INTERFACE IMPORTED)
-            conan_message(STATUS "Conan: Target declared '{{ target_namespace }}::{{ target_namespace }}'")
+        if(NOT TARGET {{ target_namespace }}::{{ global_target_name }})
+            add_library({{ target_namespace }}::{{ global_target_name }} INTERFACE IMPORTED)
+            conan_message(STATUS "Conan: Target declared '{{ target_namespace }}::{{ global_target_name }}'")
         endif()
 
         # Load the debug and release library finders

--- a/conans/test/functional/toolchains/cmake/cmakedeps/test_cmakedeps_components_names.py
+++ b/conans/test/functional/toolchains/cmake/cmakedeps/test_cmakedeps_components_names.py
@@ -310,6 +310,47 @@ def test_custom_names(setup_client_with_greetings):
     create_chat(client, "custom", package_info, cmake_find, test_cmake_find)
 
 
+def test_different_namespace(setup_client_with_greetings):
+    client = setup_client_with_greetings
+
+    package_info = textwrap.dedent("""
+        self.cpp_info.set_property("cmake_target_namespace", "MyChat")
+        self.cpp_info.set_property("cmake_target_name", "MyGlobalChat")
+        self.cpp_info.set_property("cmake_file_name", "MyChat")
+
+        self.cpp_info.components["sayhello"].set_property("cmake_target_name", "MySay")
+
+        self.cpp_info.components["sayhello"].requires = ["greetings::hello"]
+        self.cpp_info.components["sayhello"].libs = ["sayhello"]
+        self.cpp_info.components["sayhellobye"].set_property("cmake_target_name", "MySayBye")
+
+        self.cpp_info.components["sayhellobye"].requires = ["sayhello", "greetings::bye"]
+        self.cpp_info.components["sayhellobye"].libs = ["sayhellobye"]
+        """)
+
+    cmake_find = textwrap.dedent("""
+        find_package(MYG COMPONENTS MyHello MyBye)
+
+        add_library(sayhello sayhello.cpp)
+        target_link_libraries(sayhello MyGreetings::MyHello)
+
+        add_library(sayhellobye sayhellobye.cpp)
+        target_link_libraries(sayhellobye sayhello MyGreetings::MyBye)
+        """)
+
+    test_cmake_find = textwrap.dedent("""
+        find_package(MyChat)
+
+        add_executable(example example.cpp)
+        target_link_libraries(example MyChat::MySayBye)
+
+        add_executable(example2 example.cpp)
+        target_link_libraries(example2 MyChat::MyGlobalChat)
+        """)
+    create_chat(client, "custom", package_info, cmake_find, test_cmake_find)
+
+
+
 def test_no_components(setup_client_with_greetings):
     client = setup_client_with_greetings
 

--- a/conans/test/functional/toolchains/cmake/cmakedeps/test_cmakedeps_find_module_and_config.py
+++ b/conans/test/functional/toolchains/cmake/cmakedeps/test_cmakedeps_find_module_and_config.py
@@ -48,6 +48,7 @@ def client():
 
                 self.cpp_info.set_property("cmake_module_file_name", "mi_dependencia")
                 self.cpp_info.set_property("cmake_module_target_name", "mi_dependencia_target")
+                self.cpp_info.set_property("cmake_module_target_namespace", "mi_dependencia_namespace")
 
                 self.cpp_info.components["crispin"].libs = ["mydep"]
                 self.cpp_info.components["crispin"].set_property("cmake_target_name", "MyCrispinTarget")
@@ -81,7 +82,7 @@ def test_reuse_with_modules_and_config(client):
 
     add_executable(myapp2 main.cpp)
     find_package(mi_dependencia) # This one will find the module
-    target_link_libraries(myapp2 mi_dependencia_target::mi_crispin_target)
+    target_link_libraries(myapp2 mi_dependencia_namespace::mi_crispin_target)
 
     """
     conanfile = GenConanfile().with_name("myapp")\


### PR DESCRIPTION
Changelog: Feature: Introduced a new cpp_info property `cmake_target_namespace` to declare the target namespace for the `CMakeDeps` generator. This feature allows declaring a global target with a different namespace like `Foo::Bar`.
Docs: https://github.com/conan-io/docs/pull/2209

Close https://github.com/conan-io/conan/issues/9511