### PR TITLE
Support other types of remote archives

### DIFF
--- a/conans/client/conf/config_installer.py
+++ b/conans/client/conf/config_installer.py
@@ -137,7 +137,7 @@ def _process_folder(config, folder, cache, output):
 def _process_download(config, cache, output, requester):
     with tmp_config_install_folder(cache) as tmp_folder:
         output.info("Trying to download  %s" % _hide_password(config.uri))
-        zippath = os.path.join(tmp_folder, "config.zip")
+        zippath = os.path.join(tmp_folder, os.path.basename(config.uri))
         try:
             tools.download(config.uri, zippath, out=output, verify=config.verify_ssl,
                            requester=requester)

--- a/conans/test/utils/test_files.py
+++ b/conans/test/utils/test_files.py
@@ -73,9 +73,9 @@ def scan_folder(folder):
     return sorted(scanned_files)
 
 
-def tgz_with_contents(files):
+def tgz_with_contents(files, output_path=None):
     folder = temp_folder()
-    file_path = os.path.join(folder, "myfile.tar.gz")
+    file_path = output_path or os.path.join(folder, "myfile.tar.gz")
 
     with open(file_path, "wb") as tgz_handle:
         tgz = gzopen_without_timestamps("myfile.tar.gz", mode="w", fileobj=tgz_handle)


### PR DESCRIPTION
Changelog: Feature: Support remote archives other than zip in ``conan config install``.
Docs: Omit
Fixes: #9382

When downloading the file, it used to be renamed to 'config.zip', which forced the file to be treated as a zip archive, disregarding its original name and extension. This change preserves the original name and extension, so the `unzip` call recognizes the type of the file (the `unzip` function already supports tar.gz and other types).

- [x] Refer to the issue that supports this Pull Request.
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 

<sup>**Note:** By default this PR will skip the slower tests and will use a limited set of python versions. Check [here](https://github.com/conan-io/conan/blob/develop/.github/PR_INCREASE_TESTING.md) how to increase the testing level by writing some tags in the current PR body text.</sup>
