### PR TITLE
Export to base src and test with git clone

### DIFF
--- a/conans/client/source.py
+++ b/conans/client/source.py
@@ -105,7 +105,7 @@ def config_source(export_folder, export_source_folder, scm_sources_folder, conan
                 # First of all get the exported scm sources (if auto) or clone (if fixed)
                 _run_cache_scm(conanfile, scm_sources_folder, output)
                 # so self exported files have precedence over python_requires ones
-                merge_directories(export_folder, conanfile.source_folder)
+                merge_directories(export_folder, conanfile.folders.base_source)
                 # Now move the export-sources to the right location
                 merge_directories(export_source_folder, conanfile.folders.base_source)
 
@@ -139,7 +139,8 @@ def _run_source(conanfile, conanfile_path, hook_manager, reference, cache,
                 get_sources_from_exports()
 
                 if cache:
-                    _clean_source_folder(src_folder)  # TODO: Why is it needed in cache?
+                    # Clear the conanfile.py to avoid errors cloning git repositories.
+                    _clean_source_folder(src_folder)
                 with conanfile_exception_formatter(conanfile.display_name, "source"):
 
                     with conan_v2_property(conanfile, 'settings',

--- a/conans/test/functional/layout/test_in_cache.py
+++ b/conans/test/functional/layout/test_in_cache.py
@@ -7,6 +7,7 @@ import pytest
 from conans import load
 from conans.model.ref import ConanFileReference, PackageReference
 from conans.test.assets.genconanfile import GenConanfile
+from conans.test.utils.test_files import temp_folder
 from conans.test.utils.tools import TestClient
 
 
@@ -270,3 +271,40 @@ def test_cpp_package():
     assert 'set(hello_INCLUDE_DIRS_RELEASE "${hello_PACKAGE_FOLDER_RELEASE}/foo/include")' in cmake
     assert 'set(hello_LIB_DIRS_RELEASE "${hello_PACKAGE_FOLDER_RELEASE}/foo/libs")' in cmake
     assert 'set(hello_LIBS_RELEASE foo)' in cmake
+
+
+def test_git_clone_with_source_layout():
+    client = TestClient()
+    repo = temp_folder()
+    conanfile = textwrap.dedent("""
+           import os
+           from conans import ConanFile
+           class Pkg(ConanFile):
+               exports = "*.txt"
+
+               def layout(self):
+                   self.folders.source = "src"
+
+               def source(self):
+                   self.run('git clone "{}" src')
+       """).format(repo)
+
+    client.save({"conanfile.py": conanfile,
+                 "myfile.txt": "My file is copied"})
+    with client.chdir(repo):
+        client.save({"cloned.txt": "foo"}, repo)
+        client.run_command("git init .")
+        client.run_command('git config user.email "you@example.com"')
+        client.run_command('git config user.name "Your Name"')
+        client.run_command("git add .")
+        client.run_command('git commit -m  "commiting"')
+
+    client.run("create . hello/1.0@")
+    sf = client.cache.package_layout(ConanFileReference.loads("hello/1.0@")).source()
+    assert os.path.exists(os.path.join(sf, "myfile.txt"))
+    # The conanfile is cleared from the root before cloning
+    assert not os.path.exists(os.path.join(sf, "conanfile.py"))
+    assert not os.path.exists(os.path.join(sf, "cloned.txt"))
+
+    assert os.path.exists(os.path.join(sf, "src", "cloned.txt"))
+    assert not os.path.exists(os.path.join(sf, "src", "myfile.txt"))

--- a/conans/test/functional/layout/test_in_cache.py
+++ b/conans/test/functional/layout/test_in_cache.py
@@ -287,7 +287,7 @@ def test_git_clone_with_source_layout():
 
                def source(self):
                    self.run('git clone "{}" src')
-       """).format(repo)
+       """).format(repo.replace("\\", "/"))
 
     client.save({"conanfile.py": conanfile,
                  "myfile.txt": "My file is copied"})

--- a/conans/test/functional/layout/test_in_cache.py
+++ b/conans/test/functional/layout/test_in_cache.py
@@ -293,11 +293,7 @@ def test_git_clone_with_source_layout():
                  "myfile.txt": "My file is copied"})
     with client.chdir(repo):
         client.save({"cloned.txt": "foo"}, repo)
-        client.run_command("git init .")
-        client.run_command('git config user.email "you@example.com"')
-        client.run_command('git config user.name "Your Name"')
-        client.run_command("git add .")
-        client.run_command('git commit -m  "commiting"')
+        client.init_git_repo()
 
     client.run("create . hello/1.0@")
     sf = client.cache.package_layout(ConanFileReference.loads("hello/1.0@")).source()


### PR DESCRIPTION
Changelog: BugFix: Fixed a bug where using the new `layout()` the `exports` went to the `conanfile.source_folder` instead of the base source folder in the cache and only the `exports_sources` should go there.
Docs: omit

Closes #9532
