### PR TITLE
qmake:  fix sharedlinkFlags and exelinkflags

### DIFF
--- a/conans/client/generators/qmake.py
+++ b/conans/client/generators/qmake.py
@@ -52,8 +52,8 @@ class QmakeGenerator(Generator):
                     'CONAN_DEFINES{dep_name}{build_type} += {deps.defines}\n'
                     'CONAN_QMAKE_CXXFLAGS{dep_name}{build_type} += {deps.cxxflags}\n'
                     'CONAN_QMAKE_CFLAGS{dep_name}{build_type} += {deps.cflags}\n'
-                    'CONAN_QMAKE_LFLAGS{dep_name}{build_type} += {deps.sharedlinkflags}\n'
-                    'CONAN_QMAKE_LFLAGS{dep_name}{build_type} += {deps.exelinkflags}\n')
+                    'CONAN_QMAKE_LFLAGS_SHLIB{dep_name}{build_type} += {deps.sharedlinkflags}\n'
+                    'CONAN_QMAKE_LFLAGS_APP{dep_name}{build_type} += {deps.exelinkflags}\n')
         sections = []
         template_all = template
         all_flags = template_all.format(dep_name="", deps=deps, build_type="")
@@ -116,13 +116,16 @@ class QmakeGenerator(Generator):
     }
     QMAKE_CXXFLAGS += $$CONAN_QMAKE_CXXFLAGS
     QMAKE_CFLAGS += $$CONAN_QMAKE_CFLAGS
-    QMAKE_LFLAGS += $$CONAN_QMAKE_LFLAGS
+    QMAKE_LFLAGS_SHLIB += $$CONAN_QMAKE_LFLAGS_SHLIB
+    QMAKE_LFLAGS_APP += $$CONAN_QMAKE_LFLAGS_APP
     QMAKE_CXXFLAGS_DEBUG += $$CONAN_QMAKE_CXXFLAGS_DEBUG
     QMAKE_CFLAGS_DEBUG += $$CONAN_QMAKE_CFLAGS_DEBUG
-    QMAKE_LFLAGS_DEBUG += $$CONAN_QMAKE_LFLAGS_DEBUG
+    QMAKE_LFLAGS_SHLIB_DEBUG += $$CONAN_QMAKE_LFLAGS_SHLIB_DEBUG
+    QMAKE_LFLAGS_APP_DEBUG += $$CONAN_QMAKE_LFLAGS_APP_DEBUG
     QMAKE_CXXFLAGS_RELEASE += $$CONAN_QMAKE_CXXFLAGS_RELEASE
     QMAKE_CFLAGS_RELEASE += $$CONAN_QMAKE_CFLAGS_RELEASE
-    QMAKE_LFLAGS_RELEASE += $$CONAN_QMAKE_LFLAGS_RELEASE
+    QMAKE_LFLAGS_SHLIB_RELEASE += $$CONAN_QMAKE_LFLAGS_SHLIB_RELEASE
+    QMAKE_LFLAGS_APP_RELEASE += $$CONAN_QMAKE_LFLAGS_APP_RELEASE
 }""")
 
         return output

--- a/conans/test/unittests/client/generators/qmake_test.py
+++ b/conans/test/unittests/client/generators/qmake_test.py
@@ -39,3 +39,28 @@ class QmakeGeneratorTest(unittest.TestCase):
         qmake_lines = content.splitlines()
         self.assertIn('CONAN_FRAMEWORKS += -framework HelloFramework', qmake_lines)
         self.assertIn('CONAN_FRAMEWORK_PATHS += -F%s' % framework_path, qmake_lines)
+        
+    def test_sharedlinkflags(self):
+        conanfile = ConanFile(Mock(), None)
+        conanfile.initialize(Settings({}), EnvValues())
+        framework_path = os.getcwd()  # must exist, otherwise filtered by framework_paths
+        cpp_info = CppInfo("MyPkg", "/rootpath")
+        cpp_info.sharedlinkflags = ["-llibrary_for_shared"]
+        conanfile.deps_cpp_info.add("MyPkg", DepCppInfo(cpp_info))
+        generator = QmakeGenerator(conanfile)
+        content = generator.content
+        qmake_lines = content.splitlines()
+        self.assertIn('CONAN_QMAKE_LFLAGS_SHLIB += -llibrary_for_shared', qmake_lines)
+        
+    def test_exelinkflags(self):
+        conanfile = ConanFile(Mock(), None)
+        conanfile.initialize(Settings({}), EnvValues())
+        framework_path = os.getcwd()  # must exist, otherwise filtered by framework_paths
+        cpp_info = CppInfo("MyPkg", "/rootpath")
+        cpp_info.exelinkflags = ["-llibrary_for_exe"]
+        conanfile.deps_cpp_info.add("MyPkg", DepCppInfo(cpp_info))
+        generator = QmakeGenerator(conanfile)
+        content = generator.content
+        qmake_lines = content.splitlines()
+        self.assertIn('CONAN_QMAKE_LFLAGS_APP += -llibrary_for_exe', qmake_lines)
+    


### PR DESCRIPTION
Changelog: Bugfix: The qmake generator now assigns `QMAKE_LFLAGS_SHLIB` and `QMAKE_LFLAGS_APP` variables instead of the incorrect `QMAKE_LFLAGS` following the official docs.
Docs: https://github.com/conan-io/docs/pull/2224

Link to qmake documentation: https://doc.qt.io/qt-5/qmake-variable-reference.html#qmake-lflags-shlib

related to conan-io/conan-center-index#7222