### PR TITLE
remove legacy conan info --dry-build

### DIFF
--- a/conans/client/command.py
+++ b/conans/client/command.py
@@ -676,12 +676,8 @@ class Command(object):
         parser.add_argument("--package-filter", nargs='?',
                             help='Print information only for packages that match the filter pattern'
                                  ' e.g., MyPackage/1.2@user/channel or MyPackage*')
-        dry_build_help = ("Apply the --build argument to output the information, "
-                          "as it would be done by the install command")
-        parser.add_argument("-db", "--dry-build", action=Extender, nargs="?", help=dry_build_help)
         build_help = ("Given a build policy, return an ordered list of packages that would be built"
                       " from sources during the install command")
-
         update_help = "Will check if updates of the dependencies exist in the remotes " \
                       "(a new version that satisfies a version range, a new revision or a newer " \
                       "recipe if not using revisions)."
@@ -694,70 +690,52 @@ class Command(object):
                                     conf=args.conf_build)
         # TODO: 2.0 create profile_host object here to avoid passing a lot of arguments to the API
 
-        # INSTALL SIMULATION, NODES TO INSTALL
-        if args.build is not None:
-            nodes, _ = self._conan.info_nodes_to_build(args.path_or_reference,
-                                                       build_modes=args.build,
-                                                       settings=args.settings_host,
-                                                       options=args.options_host,
-                                                       env=args.env_host,
-                                                       profile_names=args.profile_host,
-                                                       conf=args.conf_host,
-                                                       profile_build=profile_build,
-                                                       remote_name=args.remote,
-                                                       check_updates=args.update)
-            if args.json:
-                json_arg = True if args.json == "1" else args.json
-                self._outputer.json_nodes_to_build(nodes, json_arg, os.getcwd())
-            else:
-                self._outputer.nodes_to_build(nodes)
         # INFO ABOUT DEPS OF CURRENT PROJECT OR REFERENCE
-        else:
-            data = self._conan.info(args.path_or_reference,
-                                    remote_name=args.remote,
-                                    settings=args.settings_host,
-                                    options=args.options_host,
-                                    env=args.env_host,
-                                    profile_names=args.profile_host,
-                                    conf=args.conf_host,
-                                    profile_build=profile_build,
-                                    update=args.update,
-                                    build=args.dry_build,
-                                    lockfile=args.lockfile,
-                                    name=args.name,
-                                    version=args.version,
-                                    user=args.user,
-                                    channel=args.channel)
-            deps_graph, _ = data
-            only = args.only
-            if args.only == ["None"]:
-                only = []
-            if only and args.paths and (set(only) - set(path_only_options)):
-                raise ConanException("Invalid --only value '%s' with --path specified, allowed "
-                                     "values: [%s]." % (only, str_path_only_options))
-            elif only and not args.paths and (set(only) - set(info_only_options)):
-                raise ConanException("Invalid --only value '%s', allowed values: [%s].\n"
-                                     "Use --only=None to show only the references."
-                                     % (only, str_only_options))
+        data = self._conan.info(args.path_or_reference,
+                                remote_name=args.remote,
+                                settings=args.settings_host,
+                                options=args.options_host,
+                                env=args.env_host,
+                                profile_names=args.profile_host,
+                                conf=args.conf_host,
+                                profile_build=profile_build,
+                                update=args.update,
+                                build=args.build,
+                                lockfile=args.lockfile,
+                                name=args.name,
+                                version=args.version,
+                                user=args.user,
+                                channel=args.channel)
+        deps_graph, _ = data
+        only = args.only
+        if args.only == ["None"]:
+            only = []
+        if only and args.paths and (set(only) - set(path_only_options)):
+            raise ConanException("Invalid --only value '%s' with --path specified, allowed "
+                                 "values: [%s]." % (only, str_path_only_options))
+        elif only and not args.paths and (set(only) - set(info_only_options)):
+            raise ConanException("Invalid --only value '%s', allowed values: [%s].\n"
+                                 "Use --only=None to show only the references."
+                                 % (only, str_only_options))
 
-            if args.graph:
-                if args.graph.endswith(".html"):
-                    template = self._conan.app.cache.get_template(templates.INFO_GRAPH_HTML,
-                                                                  user_overrides=True)
-                else:
-                    template = self._conan.app.cache.get_template(templates.INFO_GRAPH_DOT,
-                                                                  user_overrides=True)
-                self._outputer.info_graph(args.graph, deps_graph, os.getcwd(), template=template)
-            if args.json:
-                json_arg = True if args.json == "1" else args.json
-                self._outputer.json_info(deps_graph, json_arg, os.getcwd(), show_paths=args.paths)
+        if args.graph:
+            if args.graph.endswith(".html"):
+                template = self._conan.app.cache.get_template(templates.INFO_GRAPH_HTML,
+                                                              user_overrides=True)
+            else:
+                template = self._conan.app.cache.get_template(templates.INFO_GRAPH_DOT,
+                                                              user_overrides=True)
+            self._outputer.info_graph(args.graph, deps_graph, os.getcwd(), template=template)
+        if args.json:
+            json_arg = True if args.json == "1" else args.json
+            self._outputer.json_info(deps_graph, json_arg, os.getcwd(), show_paths=args.paths)
 
-            if not args.graph and not args.json:
-                self._outputer.info(deps_graph, only, args.package_filter, args.paths)
+        if not args.graph and not args.json:
+            self._outputer.info(deps_graph, only, args.package_filter, args.paths)
 
-            # TODO: Check this UX or flow
-            if deps_graph.error:
-                raise deps_graph.error
+        # TODO: Check this UX or flow
+        if deps_graph.error:
+            raise deps_graph.error
 
     def source(self, *args):
         """

--- a/conans/client/conan_api.py
+++ b/conans/client/conan_api.py
@@ -640,26 +640,6 @@ class ConanAPIV1(object):
         return ref, profile_host, profile_build, graph_lock, root_ref
 
     @api_method
-    def info_nodes_to_build(self, reference, build_modes, settings=None, options=None, env=None,
-                            profile_names=None, remote_name=None, check_updates=None,
-                            profile_build=None, name=None, version=None, user=None, channel=None,
-                            conf=None):
-        profile_host = ProfileData(profiles=profile_names, settings=settings, options=options,
-                                   env=env, conf=conf)
-        reference, profile_host, profile_build, graph_lock, root_ref = \
-            self._info_args(reference, profile_host, profile_build, name=name,
-                            version=version, user=user, channel=channel)
-
-        recorder = ActionRecorder()
-        remotes = self.app.load_remotes(remote_name=remote_name, check_updates=check_updates)
-        deps_graph = self.app.graph_manager.load_graph(reference, None, profile_host,
-                                                       profile_build, graph_lock,
-                                                       root_ref, build_modes, check_updates,
-                                                       False, remotes, recorder)
-        nodes_to_build = deps_graph.nodes_to_build()
-        return nodes_to_build, deps_graph.root.conanfile
-
-    @api_method
     def info(self, reference_or_path, remote_name=None, settings=None, options=None, env=None,
              profile_names=None, update=False, build=None, lockfile=None,
              profile_build=None, name=None, version=None, user=None, channel=None, conf=None):

--- a/conans/client/conan_command_output.py
+++ b/conans/client/conan_command_output.py
@@ -75,9 +75,6 @@ class CommandOutputer(object):
                 ret[ref] = manifest.time_str
         return ret
 
-    def nodes_to_build(self, nodes_to_build):
-        self._output.info(", ".join(str(n) for n in nodes_to_build))
-
     def _handle_json_output(self, data, json_output, cwd):
         json_str = json.dumps(data)
 
@@ -89,10 +86,6 @@ class CommandOutputer(object):
             save(json_output, json.dumps(data))
             self._output.writeln("")
             self._output.info("JSON file created at '%s'" % json_output)
-
-    def json_nodes_to_build(self, nodes_to_build, json_output, cwd):
-        data = [str(n) for n in nodes_to_build]
-        self._handle_json_output(data, json_output, cwd)
 
     def _grab_info_data(self, deps_graph, grab_paths):
         """ Convert 'deps_graph' into consumible information for json and cli """

--- a/conans/client/graph/graph.py
+++ b/conans/client/graph/graph.py
@@ -226,14 +226,6 @@ class DepsGraph(object):
             for node in level:
                 yield node
 
-    def nodes_to_build(self):
-        ret = []
-        for node in self.ordered_iterate():
-            if node.binary == BINARY_BUILD:
-                if node.ref.copy_clear_rev() not in ret:
-                    ret.append(node.ref.copy_clear_rev())
-        return ret
-
     def by_levels(self, nodes_subset=None):
         return self._order_levels(True, nodes_subset)
 

--- a/conans/test/integration/command/info/info_test.py
+++ b/conans/test/integration/command/info/info_test.py
@@ -342,13 +342,13 @@ class InfoTest2(unittest.TestCase):
         client.run("export . Pkg2/0.1@user/channel")
         client.save({"conanfile.txt": "[requires]\nPkg/0.1@user/channel\nPkg2/0.1@user/channel",
                      "myprofile": "[build_requires]\ntool/0.1@user/channel"}, clean_first=True)
-        client.run("info . -pr=myprofile --dry-build=missing")
+        client.run("info . -pr=myprofile --build=missing")
         print(client.out)
         # Check that there is only 1 output for tool, not repeated many times
         pkgs = [line for line in str(client.out).splitlines() if line.startswith("tool")]
         self.assertEqual(len(pkgs), 1)
 
-        client.run("info . -pr=myprofile --dry-build=missing --graph=file.html")
+        client.run("info . -pr=myprofile --build=missing --graph=file.html")
         html = client.load("file.html")
         self.assertIn("html", html)
         # To check that this node is not duplicated
@@ -537,7 +537,7 @@ class TestInfoContext:
         client.run("create cmake cmake/1.0@")
         client.run("export pkg pkg/1.0@")
 
-        client.run("info pkg/1.0@ -pr:b=default -pr:h=default --dry-build")
+        client.run("info pkg/1.0@ -pr:b=default -pr:h=default --build")
         assert "cmake/1.0\n"\
                "    ID: {}\n"\
                "    BuildID: None\n"\
@@ -548,7 +548,7 @@ class TestInfoContext:
                "    BuildID: None\n" \
                "    Context: host".format(NO_SETTINGS_PACKAGE_ID) in client.out
 
-        client.run("info pkg/1.0@ -pr:b=default -pr:h=default --dry-build --json=file.json")
+        client.run("info pkg/1.0@ -pr:b=default -pr:h=default --build --json=file.json")
         info = json.loads(client.load("file.json"))
         assert info[0]["reference"] == "cmake/1.0"
         assert info[0]["context"] == "build"

--- a/conans/test/integration/command/upload/upload_test.py
+++ b/conans/test/integration/command/upload/upload_test.py
@@ -502,7 +502,7 @@ class MyPkg(ConanFile):
 
     @pytest.mark.xfail(reason="Tests using the Search command are temporarely disabled")
     def test_skip_upload(self):
-        """ Check that the option --dry does not upload anything
+        """ Check that the option --skip does not upload anything
         """
         client = TestClient(default_server_user=True)
 


### PR DESCRIPTION
Changelog: Remove: Removed ``conan info --dry-build``, replaced with ``conan info --build``. Old ``--build`` behavior removed.
Docs: Omit