### PR TITLE
aggregate conf from build_requires earlier for declarative generators

### DIFF
--- a/conans/client/generators/__init__.py
+++ b/conans/client/generators/__init__.py
@@ -141,6 +141,8 @@ class GeneratorManager(object):
     def write_generators(self, conanfile, old_gen_folder, new_gen_folder, output):
         """ produces auxiliary files, required to build a project or a package.
         """
+        _receive_conf(conanfile)
+
         for generator_name in set(conanfile.generators):
             generator_class = self._new_generator(generator_name, output)
             if generator_class:
@@ -226,8 +228,6 @@ def write_toolchain(conanfile, path, output):
                "********************************************************************\n")
         raise ConanException(msg)
 
-    _receive_conf(conanfile)
-
     if hasattr(conanfile, "generate"):
         output.highlight("Calling generate()")
         mkdir(path)
@@ -270,4 +270,3 @@ def _generate_aggregated_env(conanfile):
                         {}
                         """.format(lines))
         save(os.path.join(conanfile.generators_folder, "conanenv.bat"), bat_content)
-

--- a/conans/test/integration/configuration/conf/test_conf_from_br.py
+++ b/conans/test/integration/configuration/conf/test_conf_from_br.py
@@ -70,3 +70,45 @@ def test_basic_conf_through_cli():
                '-c:h=tools.android:ndk_path="MY-SYSTEM-NDK!!!"')
     assert "android_ndk/1.0: NDK build: MY-NDK!!!" in client.out
     assert "conanfile.py: NDK host: MY-SYSTEM-NDK!!!" in client.out
+
+
+def test_declared_generators_get_conf():
+    # https://github.com/conan-io/conan/issues/9571
+    client = TestClient()
+    conanfile = textwrap.dedent("""
+        from conans import ConanFile
+        class Pkg(ConanFile):
+            def package_info(self):
+                self.conf_info["tools.cmake.cmaketoolchain:user_toolchain"] = "mytoolchain.cmake"
+        """)
+    client.save({"conanfile.py": conanfile})
+    client.run("create . mytool/1.0@")
+
+    consumer = textwrap.dedent("""
+        from conans import ConanFile
+
+        class Pkg(ConanFile):
+            settings = "os", "compiler", "build_type", "arch"
+            generators = "CMakeToolchain"
+            build_requires = "mytool/1.0"
+        """)
+    client.save({"conanfile.py": consumer}, clean_first=True)
+    client.run("install . -pr:b=default")
+    toolchain = client.load("conan_toolchain.cmake")
+    assert "include(mytoolchain.cmake)" in toolchain
+
+    consumer = textwrap.dedent("""
+        from conans import ConanFile
+        from conan.tools.cmake import CMakeToolchain
+
+        class Pkg(ConanFile):
+            settings = "os", "compiler", "build_type", "arch"
+            build_requires = "mytool/1.0"
+
+            def generate(self):
+                CMakeToolchain(self).generate()
+        """)
+    client.save({"conanfile.py": consumer}, clean_first=True)
+    client.run("install . -pr:b=default")
+    toolchain = client.load("conan_toolchain.cmake")
+    assert "include(mytoolchain.cmake)" in toolchain


### PR DESCRIPTION
Changelog: Bugfix: Aggregate `[conf]` from `build_requires` earlier so it is available for generators declared as `generators`. attribute. Close https://github.com/conan-io/conan/issues/9571
Docs: Omit

