### PR TITLE
Fix symlinked conan cache dir bug

### DIFF
--- a/conans/util/files.py
+++ b/conans/util/files.py
@@ -409,7 +409,7 @@ def merge_directories(src, dst, excluded=None):
             linkto = os.path.join(os.path.dirname(pointer_src), linkto)
 
         # Check if it is outside the sources
-        out_of_source = os.path.relpath(linkto, os.path.realpath(src)).startswith(".")
+        out_of_source = os.path.relpath(linkto, src).startswith(".")
         if out_of_source:
             # May warn about out of sources symlink
             return


### PR DESCRIPTION
Changelog: Bugfix: Fix symlinked conan cache directory bug
Docs: https://github.com/conan-io/docs/pull/9579

This PR fixes the situation when the conan cache dir (`~/.cache`) is a symlink and you attempt to create a package that also has internal symlinks in it. Previously, the symlinks were lost during the package creation process.