### PR TITLE
Use base_path as a relative folder from conanfile.source_folder

### DIFF
--- a/conan/tools/files/patches.py
+++ b/conan/tools/files/patches.py
@@ -25,9 +25,10 @@ class PatchLogHandler(logging.Handler):
             self._output.info("%s: %s" % (self.patchname, logstr))
 
 
-def patch(conanfile, patch_file=None, patch_string=None, strip=0, fuzz=False, **kwargs):
+def patch(conanfile, base_path=None, patch_file=None, patch_string=None, strip=0, fuzz=False, **kwargs):
     """ Applies a diff from file (patch_file)  or string (patch_string)
         in base_path directory or current dir if None
+    :param base_path: Base path where the patch should be applied.
     :param patch_file: Patch file that should be applied.
     :param patch_string: Patch string that should be applied.
     :param strip: Number of folders to be stripped from the path.
@@ -56,7 +57,8 @@ def patch(conanfile, patch_file=None, patch_string=None, strip=0, fuzz=False, **
     if not patchset:
         raise ConanException("Failed to parse patch: %s" % (patch_file if patch_file else "string"))
 
-    if not patchset.apply(root=conanfile.source_folder, strip=strip, fuzz=fuzz):
+    root = os.path.join(conanfile.source_folder, base_path) if base_path else conanfile.source_folder
+    if not patchset.apply(root, strip=strip, fuzz=fuzz):
         raise ConanException("Failed to apply patch: %s" % patch_file)
 
 
@@ -71,6 +73,7 @@ def apply_conandata_patches(conanfile):
     ```
     patches:
     - patch_file: "patches/0001-buildflatbuffers-cmake.patch"
+      base_path: "source_subfolder"
     - patch_file: "patches/0002-implicit-copy-constructor.patch"
       patch_type: backport
       patch_source: https://github.com/google/flatbuffers/pull/5650

--- a/conans/test/unittests/tools/files/test_patches.py
+++ b/conans/test/unittests/tools/files/test_patches.py
@@ -1,3 +1,5 @@
+import os
+
 import patch_ng
 import pytest
 
@@ -41,6 +43,17 @@ def test_single_patch_file(mock_patch_ng):
     assert mock_patch_ng.filename == 'patch-file'
     assert mock_patch_ng.string is None
     assert mock_patch_ng.apply_args == ("my_source", 0, False)
+    assert len(str(conanfile.output)) == 0
+
+
+def test_base_path(mock_patch_ng):
+    conanfile = ConanFileMock()
+    conanfile.folders.set_base_source("my_source")
+    conanfile.display_name = 'mocked/ref'
+    patch(conanfile, patch_file='patch-file', base_path="subfolder")
+    assert mock_patch_ng.filename == 'patch-file'
+    assert mock_patch_ng.string is None
+    assert mock_patch_ng.apply_args == (os.path.join("my_source", "subfolder"), 0, False)
     assert len(str(conanfile.output)) == 0
 
 


### PR DESCRIPTION
Changelog: Feature: Recovered `base_path` argument for `conan.tools.files.patch` and `conan.tools.files.apply_conandata_patches` to be able to specify a relative folder from the `conanfile.source_folder` directory (that follows the layout() method).
Docs: https://github.com/conan-io/docs/pull/2222

Closes #9587 
@sboehmann 