### PR TITLE
Feature/cache short second attempt

### DIFF
--- a/conan/cache/cache.py
+++ b/conan/cache/cache.py
@@ -1,4 +1,4 @@
-import base64
+import hashlib
 import hashlib
 import os
 import shutil
@@ -6,15 +6,16 @@ import time
 import uuid
 from io import StringIO
 
+from conan.cache.conan_reference import ConanReference
+from conan.cache.conan_reference_layout import RecipeLayout, PackageLayout
 # TODO: Random folders are no longer accessible, how to get rid of them asap?
 # TODO: Add timestamp for LRU
 # TODO: We need the workflow to remove existing references.
 from conan.cache.db.cache_database import CacheDatabase
-from conan.cache.conan_reference import ConanReference
-from conan.cache.conan_reference_layout import RecipeLayout, PackageLayout
-from conans.errors import ConanException, ConanReferenceAlreadyExistsInDB, ConanReferenceDoesNotExistInDB
+from conans.errors import ConanException, ConanReferenceAlreadyExistsInDB, \
+    ConanReferenceDoesNotExistInDB
 from conans.model.info import RREV_UNKNOWN, PREV_UNKNOWN
-from conans.util.files import md5, rmdir
+from conans.util.files import rmdir
 
 
 class DataCache:
@@ -55,11 +56,8 @@ class DataCache:
         hash = hash.encode("utf-8")
         md = hashlib.sha256()
         md.update(hash)
-        sha_bytes = md.digest()
-        tmp = base64.b64encode(sha_bytes)  # Trick to reduce the len from 64 to 44
-        # 9 is the default len of the shorted git commit, as this is base64 => 6
-        # FIXME: This "/" replace is a bit dirty
-        return tmp.decode("ascii")[0:6].replace("/", "_")  # '/' is a base64 valid char, replace it
+        sha_bytes = md.hexdigest()
+        return sha_bytes[0:9]
 
     @staticmethod
     def _get_tmp_path():

--- a/conan/cache/cache.py
+++ b/conan/cache/cache.py
@@ -58,7 +58,8 @@ class DataCache:
         sha_bytes = md.digest()
         tmp = base64.b64encode(sha_bytes)  # Trick to reduce the len from 64 to 44
         # 9 is the default len of the shorted git commit, as this is base64 => 6
-        return tmp.decode("ascii")[0:6]
+        # FIXME: This "/" replace is a bit dirty
+        return tmp.decode("ascii")[0:6].replace("/", "_")  # '/' is a base64 valid char, replace it
 
     @staticmethod
     def _get_tmp_path():

--- a/conan/cache/cache.py
+++ b/conan/cache/cache.py
@@ -56,7 +56,7 @@ class DataCache:
     def _get_path(ref: ConanReference):
         value = ref.full_reference.encode("utf-8")
         sha = sha256(value)
-        return sha[0:7]  # 7 is the default len of the shorted git commit
+        return sha[0:8]  # 9 is the default len of the shorted git commit
 
     def create_tmp_reference_layout(self, ref: ConanReference):
         assert not ref.rrev, "Recipe revision should be unknown"

--- a/conan/cache/cache.py
+++ b/conan/cache/cache.py
@@ -10,6 +10,7 @@ from io import StringIO
 from conan.cache.db.cache_database import CacheDatabase
 from conan.cache.conan_reference import ConanReference
 from conan.cache.conan_reference_layout import RecipeLayout, PackageLayout
+from conan.tools.sha import sha256
 from conans.errors import ConanException, ConanReferenceAlreadyExistsInDB, ConanReferenceDoesNotExistInDB
 from conans.model.info import RREV_UNKNOWN, PREV_UNKNOWN
 from conans.util.files import md5, rmdir
@@ -53,7 +54,9 @@ class DataCache:
 
     @staticmethod
     def _get_path(ref: ConanReference):
-        return md5(ref.full_reference)
+        value = ref.full_reference.encode("utf-8")
+        sha = sha256(value)
+        return sha[0:7]  # 7 is the default len of the shorted git commit
 
     def create_tmp_reference_layout(self, ref: ConanReference):
         assert not ref.rrev, "Recipe revision should be unknown"

--- a/conan/cache/cache.py
+++ b/conan/cache/cache.py
@@ -57,7 +57,8 @@ class DataCache:
         md = hashlib.sha256()
         md.update(hash)
         sha_bytes = md.hexdigest()
-        return sha_bytes[0:9]
+        # len based on: https://github.com/conan-io/conan/pull/9595#issuecomment-918976451
+        return sha_bytes[0:16]
 
     @staticmethod
     def _get_tmp_path():

--- a/conan/cache/cache.py
+++ b/conan/cache/cache.py
@@ -50,18 +50,25 @@ class DataCache:
         return self._base_folder
 
     @staticmethod
-    def _get_tmp_path():
-        return os.path.join("tmp", str(uuid.uuid4()))
-
-    @staticmethod
-    def _get_path(ref: ConanReference):
-        value = ref.full_reference.encode("utf-8")
+    def _short_hash_path(hash):
+        """:param hash: Unicode text to reduce"""
+        hash = hash.encode("utf-8")
         md = hashlib.sha256()
-        md.update(value)
+        md.update(hash)
         sha_bytes = md.digest()
         tmp = base64.b64encode(sha_bytes)  # Trick to reduce the len from 64 to 44
         # 9 is the default len of the shorted git commit, as this is base64 => 6
         return tmp.decode("ascii")[0:6]
+
+    @staticmethod
+    def _get_tmp_path():
+        hash = DataCache._short_hash_path(str(uuid.uuid4()))
+        return os.path.join("tmp", hash)
+
+    @staticmethod
+    def _get_path(ref: ConanReference):
+        value = ref.full_reference
+        return DataCache._short_hash_path(value)
 
     def create_tmp_reference_layout(self, ref: ConanReference):
         assert not ref.rrev, "Recipe revision should be unknown"

--- a/conan/cache/conan_reference_layout.py
+++ b/conan/cache/conan_reference_layout.py
@@ -9,12 +9,14 @@ from conans.util.files import set_dirty, clean_dirty, is_dirty, rmdir
 
 
 # To be able to change them later to something shorter
-SRC_FOLDER = "source"
-BUILD_FOLDER = "build"
-PACKAGES_FOLDER = "package"
-EXPORT_SRC_FOLDER = "export_source"
-SYSTEM_REQS_FOLDER = "system_reqs"
-SCM_SRC_FOLDER = "scm_source"
+SRC_FOLDER = "s"
+BUILD_FOLDER = "b"
+PACKAGES_FOLDER = "p"
+EXPORT_FOLDER = "e"
+EXPORT_SRC_FOLDER = "es"
+DOWNLOAD_EXPORT_FOLDER = "d"
+SYSTEM_REQS_FOLDER = "se"
+SCM_SRC_FOLDER = "sc"
 SYSTEM_REQS = "system_reqs.txt"
 
 
@@ -50,13 +52,13 @@ class RecipeLayout(LayoutBase):
         yield
 
     def export(self):
-        return os.path.join(self.base_folder, 'export')
+        return os.path.join(self.base_folder, EXPORT_FOLDER)
 
     def export_sources(self):
-        return os.path.join(self.base_folder, 'export_sources')
+        return os.path.join(self.base_folder, EXPORT_SRC_FOLDER)
 
     def download_export(self):
-        return os.path.join(self.base_folder, "dl")
+        return os.path.join(self.base_folder, DOWNLOAD_EXPORT_FOLDER)
 
     def source(self):
         return os.path.join(self.base_folder, SRC_FOLDER)

--- a/conan/tools/sha.py
+++ b/conan/tools/sha.py
@@ -1,0 +1,9 @@
+import hashlib
+
+
+def sha256(value):
+    if value is None:
+        return None
+    md = hashlib.sha256()
+    md.update(value)
+    return md.hexdigest()

--- a/conan/tools/sha.py
+++ b/conan/tools/sha.py
@@ -1,9 +1,0 @@
-import hashlib
-
-
-def sha256(value):
-    if value is None:
-        return None
-    md = hashlib.sha256()
-    md.update(value)
-    return md.hexdigest()

--- a/conans/client/installer.py
+++ b/conans/client/installer.py
@@ -482,19 +482,13 @@ class BinaryInstaller(object):
         pref = node.pref
         assert pref.id, "Package-ID without value"
         assert pref.id != PACKAGE_ID_UNKNOWN, "Package-ID error: %s" % str(pref)
+        assert pkg_layout, "The pkg_layout should be declared here"
         conanfile = node.conanfile
         output = conanfile.output
 
         bare_pref = PackageReference(pref.ref, pref.id)
         processed_prev = processed_package_references.get(bare_pref)
-        if processed_prev is None:  # This package-id has not been processed before
-            if not pkg_layout:
-                if pref.revision:
-                    raise ConanException("should this happen?")
-                    pkg_layout = self._cache.pkg_layout(pref)
-                else:
-                    pkg_layout = self._cache.create_temp_pkg_layout(pref)
-        else:
+        if processed_prev is not None:  # This package-id has not been processed before
             # We need to update the PREV of this node, as its processing has been skipped,
             # but it could be that another node with same PREF was built and obtained a new PREV
             node.prev = processed_prev


### PR DESCRIPTION
Changelog:  omit
Docs: omit

- To discuss the length we want. 
- This alleviates the PATH env variables limit and windows users are forced to use the user home folder instead of `C:/`
- Introduced assert and simplified apparently dead code