### PR TITLE
Fix migration settings comparison

### DIFF
--- a/conans/client/conf/__init__.py
+++ b/conans/client/conf/__init__.py
@@ -131,6 +131,7 @@ _t_default_settings_yml = Template(textwrap.dedent("""
 
 
     cppstd: [None, 98, gnu98, 11, gnu11, 14, gnu14, 17, gnu17, 20, gnu20, 23, gnu23]  # Deprecated, use compiler.cppstd
+
     """))
 
 

--- a/conans/client/migrations.py
+++ b/conans/client/migrations.py
@@ -47,7 +47,7 @@ class ClientMigrator(Migrator):
         self.out.warn("Migration: Updating settings.yml")
         if hasattr(migrations_settings, var_name):
             version_default_contents = getattr(migrations_settings, var_name)
-            if version_default_contents != get_default_settings_yml():
+            if version_default_contents.splitlines() != get_default_settings_yml().splitlines():
                 current_settings = load(cache.settings_path)
                 if current_settings != version_default_contents:
                     save_new()

--- a/conans/test/integration/test_migrations.py
+++ b/conans/test/integration/test_migrations.py
@@ -32,6 +32,7 @@ class TestMigrations(unittest.TestCase):
         self.assertTrue(hasattr(migrations_settings, var_name),
                         "Migrations var '{}' not found".format(var_name))
         migrations_settings_content = getattr(migrations_settings, var_name)
+        # this is the same comparison made in client/migrations.py
         self.assertListEqual(current_settings.splitlines(), migrations_settings_content.splitlines())
 
     def test_is_there_var_for_settings_previous_version(self):

--- a/conans/test/integration/test_migrations.py
+++ b/conans/test/integration/test_migrations.py
@@ -33,7 +33,7 @@ class TestMigrations(unittest.TestCase):
                         "Migrations var '{}' not found".format(var_name))
         migrations_settings_content = getattr(migrations_settings, var_name)
         # this is the same comparison made in client/migrations.py
-        self.assertListEqual(current_settings.splitlines(), migrations_settings_content.splitlines())
+        assert current_settings == migrations_settings_content
 
     def test_is_there_var_for_settings_previous_version(self):
         from conans import __version__ as current_version

--- a/conans/test/integration/test_migrations.py
+++ b/conans/test/integration/test_migrations.py
@@ -32,7 +32,6 @@ class TestMigrations(unittest.TestCase):
         self.assertTrue(hasattr(migrations_settings, var_name),
                         "Migrations var '{}' not found".format(var_name))
         migrations_settings_content = getattr(migrations_settings, var_name)
-        # this is the same comparison made in client/migrations.py
         assert current_settings == migrations_settings_content
 
     def test_is_there_var_for_settings_previous_version(self):


### PR DESCRIPTION
Changelog: Fix: Fix migrations settings comparison.
Docs: omit

There was a newline difference between default settings in __init__.py and the ones from migrations_settings.py, changing the literal string comparison to the same comparison that's tested in `test_migrations_matches_config`. 

Closes: https://github.com/conan-io/conan/issues/9614
