### PR TITLE
Improve error message

### DIFF
--- a/conans/client/graph/graph_builder.py
+++ b/conans/client/graph/graph_builder.py
@@ -288,7 +288,7 @@ class DepsGraphBuilder(object):
                 # Maybe it was an ALIAS, so we can check conflict again
                 conflict = self._conflicting_references(previous, require.ref, node.ref)
                 if conflict:
-                    raise ConanException(conflict)
+                    raise ConanException("Unresolvable conflict between {} and {}".format(previous, require.ref))
 
             # Add current ancestors to the previous node and upstream deps
             for n in previous.public_closure:

--- a/conans/client/graph/graph_builder.py
+++ b/conans/client/graph/graph_builder.py
@@ -288,7 +288,7 @@ class DepsGraphBuilder(object):
                 # Maybe it was an ALIAS, so we can check conflict again
                 conflict = self._conflicting_references(previous, require.ref, node.ref)
                 if conflict:
-                    raise ConanException("Unresolvable conflict between {} and {}".format(previous, require.ref))
+                    raise ConanException(conflict)
 
             # Add current ancestors to the previous node and upstream deps
             for n in previous.public_closure:
@@ -328,7 +328,8 @@ class DepsGraphBuilder(object):
                         "in your root package."
                         % (consumer_ref, consumer_ref, new_ref, next(iter(previous.dependants)).src,
                            previous.ref, new_ref.name))
-            return True
+            return "Unresolvable conflict between {} and {}".format(previous.ref, new_ref)
+
         # Computed node, if is Editable, has revision=None
         # If new_ref.revision is None we cannot assume any conflict, the user hasn't specified
         # a revision, so it's ok any previous_ref

--- a/conans/test/integration/graph/conflict_diamond_test.py
+++ b/conans/test/integration/graph/conflict_diamond_test.py
@@ -4,6 +4,7 @@ import unittest
 
 from conans.client.tools import environment_append
 from conans.paths import CONANFILE
+from conans.test.assets.genconanfile import GenConanfile
 from conans.test.utils.tools import TestClient, load
 import json
 
@@ -97,3 +98,18 @@ class ConflictDiamondTest(unittest.TestCase):
             self.assertEqual(hello0["reference"], "Hello0/0.1@lasote/stable")
             self.assertListEqual(sorted(hello0["required_by"]),
                                  sorted(["Hello2/0.1@lasote/stable", "Hello1/0.1@lasote/stable"]))
+
+
+def test_conflict_msg():
+    c = TestClient()
+    c.save({"lib/conanfile.py": GenConanfile(),
+            "conanfile.txt":  textwrap.dedent("""
+                                [requires]
+                                libdeflate/1.7
+                                [build_requires]
+                                libdeflate/1.8
+                                """)})
+    c.run("export lib libdeflate/1.7@")
+    c.run("export lib libdeflate/1.8@")
+    c.run("install .", assert_error=True)
+    assert "ERROR: Unresolvable conflict between libdeflate/1.7 and libdeflate/1.8" in c.out


### PR DESCRIPTION
Fixes #9626, which contains a reproducer. While working with a project that had two conflicting version overrides for a dependency in build_requires and requires I got the unhelpful message:

```
ERROR: True
```

This tries to improve upon that message.
For closer inspection: I found `node.ref` to be `None`, which skips the outputs inside `self._conflicting_references`.

Changelog: Fix:  Don't just print  "ERROR: True" on unresolvable conflict.
Docs: Omit

- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.

<sup>**Note:** By default this PR will skip the slower tests and will use a limited set of python versions. Check [here](https://github.com/conan-io/conan/blob/develop/.github/PR_INCREASE_TESTING.md) how to increase the testing level by writing some tags in the current PR body text.</sup>

Close #9626