### PR TITLE
tools.PkgConfig: honor PKG_CONFIG env var

### DIFF
--- a/conans/client/tools/pkg_config.py
+++ b/conans/client/tools/pkg_config.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-import subprocess
+import subprocess, os
 
 from conans.errors import ConanException
 from conans.util.runners import check_output_runner
@@ -12,7 +12,7 @@ class PkgConfig(object):
     def _cmd_output(command):
         return check_output_runner(command).strip()
 
-    def __init__(self, library, pkg_config_executable='pkg-config', static=False, msvc_syntax=False, variables=None,
+    def __init__(self, library, pkg_config_executable=None, static=False, msvc_syntax=False, variables=None,
                  print_errors=True):
         """
         :param library: library (package) name, such as libastral
@@ -23,7 +23,7 @@ class PkgConfig(object):
         :param print_errors: output error messages (adds --print-errors)
         """
         self.library = library
-        self.pkg_config_executable = pkg_config_executable
+        self.pkg_config_executable = pkg_config_executable or os.getenv('PKG_CONFIG', 'pkg-config')
         self.static = static
         self.msvc_syntax = msvc_syntax
         self.define_variables = variables


### PR DESCRIPTION
This environment variable is used at least by:

- cmake https://github.com/Kitware/CMake/blob/2a4a630f3acc83cd8eed95f940b54a851f9722d6/Modules/FindPkgConfig.cmake#L33
- meson https://github.com/mesonbuild/meson/blob/a9e9b7c7501a3c8a5984a93879d1f309bf8c72aa/docs/markdown/Release-notes-for-0.37.0.md#overriding-more-binaries-with-environment-variables
- autotools https://autotools.io/pkgconfig/pkg_check_modules.html#pkgconfig.pkg_check_modules.optional

Changelog: Feature: ``PkgConfig`` helper now honors `PKG_CONFIG` environment variable.
Docs: Omit

- [ ] Refer to the issue that supports this Pull Request.
- [ ] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [ ] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [ ] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 

<sup>**Note:** By default this PR will skip the slower tests and will use a limited set of python versions. Check [here](https://github.com/conan-io/conan/blob/develop/.github/PR_INCREASE_TESTING.md) how to increase the testing level by writing some tags in the current PR body text.</sup>
