### PR TITLE
Better error than 'ERROR: True' when conflicts

### DIFF
--- a/conans/client/graph/graph_builder.py
+++ b/conans/client/graph/graph_builder.py
@@ -288,7 +288,8 @@ class DepsGraphBuilder(object):
                 # Maybe it was an ALIAS, so we can check conflict again
                 conflict = self._conflicting_references(previous, require.ref, node.ref)
                 if conflict:
-                    raise ConanException(conflict)
+                    raise ConanException("Conflicting references: {} => {}".format(previous,
+                                                                                   require.ref))
 
             # Add current ancestors to the previous node and upstream deps
             for n in previous.public_closure:


### PR DESCRIPTION
Changelog: Bugfix: Fixed bug whereby when a conflict of requirements happens, in some special situations, just a message `ERROR: True` was printed in the terminal, making it hard to guess what was going on.
Docs: omit

Closes #9633