### PR TITLE
Bugfix: PkgConfigDeps generator creates bad `Requires` references

### DIFF
--- a/conan/tools/gnu/pkgconfigdeps.py
+++ b/conan/tools/gnu/pkgconfigdeps.py
@@ -48,7 +48,8 @@ class PkgConfigDeps(object):
     def __init__(self, conanfile):
         self._conanfile = conanfile
 
-    def _get_composed_require_name(self, pkg_name, comp_name):
+    @staticmethod
+    def _get_composed_require_name(pkg_name, comp_name):
         return "%s-%s" % (pkg_name, comp_name)
 
     def _get_require_comp_name(self, dep, req):

--- a/conans/test/functional/toolchains/gnu/test_pkgconfigdeps.py
+++ b/conans/test/functional/toolchains/gnu/test_pkgconfigdeps.py
@@ -285,8 +285,12 @@ def test_pkg_with_component_requires():
         """)
     client2.save({"conanfile.txt": conanfile})
     client2.run("install .")
+    pc_content = client2.load("pkg.pc")
+    assert "Requires: pkg-mycomponent" in pc_content
     pc_content = client2.load("pkg-mycomponent.pc")
     assert "Requires: other" in pc_content
+    pc_content = client2.load("pkg-myothercomp.pc")
+    assert "Requires: pkg-mycomponent" in pc_content
 
 
 def test_pkg_getting_public_requires():
@@ -328,8 +332,10 @@ def test_pkg_getting_public_requires():
     client2.save({"conanfile.txt": conanfile})
     client2.run("install .")
     pc_content = client2.load("pkg.pc")
-    assert "Requires: cmp1" in pc_content
+    assert "Requires: other-cmp1" in pc_content
+    pc_content = client2.load("other.pc")
+    assert "Requires: other-cmp1 other-cmp2 other-cmp3" in pc_content
     assert client2.load("other-cmp1.pc")
     assert client2.load("other-cmp2.pc")
     pc_content = client2.load("other-cmp3.pc")
-    assert "Requires: cmp1" in pc_content
+    assert "Requires: other-cmp1" in pc_content


### PR DESCRIPTION
Changelog: Bugfix: Fixed bad `Requires` declaration in `*.pc` files.
Closes: #9631 
Docs: omit

- [x] Refer to the issue that supports this Pull Request.
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 

<sup>**Note:** By default this PR will skip the slower tests and will use a limited set of python versions. Check [here](https://github.com/conan-io/conan/blob/develop/.github/PR_INCREASE_TESTING.md) how to increase the testing level by writing some tags in the current PR body text.</sup>
