### PR TITLE
Removing tool_compiler mark for testing

### DIFF
--- a/conans/test/conftest.py
+++ b/conans/test/conftest.py
@@ -188,14 +188,6 @@ def _get_tool(name, version):
     return cached
 
 
-def _tool_name_mapping(tool_name):
-    if tool_name == "compiler":
-        tool_name = {"Windows": "visual_studio",
-                     "Linux": "gcc",
-                     "Darwin": "clang"}.get(platform.system())
-    return tool_name
-
-
 @pytest.fixture(autouse=True)
 def add_tool(request):
     tools_paths = []
@@ -203,7 +195,6 @@ def add_tool(request):
     for mark in request.node.iter_markers():
         if mark.name.startswith("tool_"):
             tool_name = mark.name[5:]
-            tool_name = _tool_name_mapping(tool_name)
             tool_version = mark.kwargs.get('version')
             result = _get_tool(tool_name, tool_version)
             if result is True:

--- a/conans/test/functional/basic_build_test.py
+++ b/conans/test/functional/basic_build_test.py
@@ -21,7 +21,6 @@ class BasicBuildTest(unittest.TestCase):
                                            False, False)]:
             build(self, cmd, static, pure_c, use_cmake=True, lang=lang)
 
-    @pytest.mark.tool_compiler
     def test_build_default(self):
         """ build default (gcc in nix, VS in win) """
         if platform.system() == "SunOS":

--- a/conans/test/functional/build_helpers/cmake_install_package_test.py
+++ b/conans/test/functional/build_helpers/cmake_install_package_test.py
@@ -9,7 +9,6 @@ from conans.test.utils.tools import TestClient
 
 class CMakeInstallPackageTest(unittest.TestCase):
 
-    @pytest.mark.tool_compiler
     def test_patch_config(self):
         client = TestClient()
         conanfile = """from conans import ConanFile, CMake

--- a/conans/test/functional/case_sensitive_test.py
+++ b/conans/test/functional/case_sensitive_test.py
@@ -23,7 +23,6 @@ conanfile = textwrap.dedent('''
 @pytest.mark.skipif(platform.system() == 'Linux', reason="Only for case insensitive OS")
 class CaseSensitiveTest(unittest.TestCase):
 
-    @pytest.mark.tool_compiler
     def test_install(self):
         test_server = TestServer()
         servers = {"default": test_server}

--- a/conans/test/functional/command/devflow_test.py
+++ b/conans/test/functional/command/devflow_test.py
@@ -232,7 +232,6 @@ class DevOutSourceFlowTest(unittest.TestCase):
                                             os.listdir(cache_package_folder)[0])
         self._assert_pkg(cache_package_folder)
 
-    @pytest.mark.tool_compiler
     def test_build_local_different_folders(self):
         # Real build, needed to ensure that the generator is put in the correct place and
         # cmake finds it, using an install_folder different from build_folder

--- a/conans/test/functional/command/install/install_outdated_test.py
+++ b/conans/test/functional/command/install/install_outdated_test.py
@@ -11,7 +11,6 @@ from conans.util.env_reader import get_env
 from conans.util.files import rmdir
 
 
-@pytest.mark.tool_compiler
 class InstallOutdatedPackagesTest(unittest.TestCase):
 
     def setUp(self):

--- a/conans/test/functional/command/profile_test.py
+++ b/conans/test/functional/command/profile_test.py
@@ -262,7 +262,6 @@ class ProfileTest(unittest.TestCase):
 
 
 class DetectCompilersTest(unittest.TestCase):
-    @pytest.mark.tool_compiler
     def test_detect_default_compilers(self):
         platform_default_compilers = {
             "Linux": "gcc",

--- a/conans/test/functional/conan_build_info/test_build_info_extraction.py
+++ b/conans/test/functional/conan_build_info/test_build_info_extraction.py
@@ -15,7 +15,6 @@ from conans.test.utils.tools import TestClient, TestServer
 from conans.util.files import load, save
 
 
-@pytest.mark.tool_compiler  # Needed only because it assume that a settings.compiler is detected
 class MyBuildInfo(unittest.TestCase):
 
     def setUp(self):

--- a/conans/test/functional/configuration/profile_test.py
+++ b/conans/test/functional/configuration/profile_test.py
@@ -72,7 +72,6 @@ class ProfileTest(unittest.TestCase):
         self.client.run("install .. -pr=sub/profile")
         self.assertIn("conanfile.txt: Installing package", self.client.out)
 
-    @pytest.mark.tool_compiler
     def test_base_profile_generated(self):
         """we are testing that the default profile is created (when not existing, fresh install)
          even when you run a create with a profile"""
@@ -80,7 +79,6 @@ class ProfileTest(unittest.TestCase):
                           "myprofile": "include(default)\n[settings]\nbuild_type=Debug"})
         self.client.run("create . conan/testing --profile myprofile")
 
-    @pytest.mark.tool_compiler
     def test_bad_syntax(self):
         self.client.save({CONANFILE: conanfile_scope_env})
         self.client.run("export . lasote/stable")
@@ -166,7 +164,6 @@ class ProfileTest(unittest.TestCase):
         self.assertIn("ERROR: Profile not found:", self.client.out)
         self.assertIn("scopes_env", self.client.out)
 
-    @pytest.mark.tool_compiler
     def test_install_profile_env(self):
         create_profile(self.client.cache.profiles_path, "envs", settings={},
                        env=[("A_VAR", "A_VALUE"),
@@ -333,7 +330,6 @@ class ProfileTest(unittest.TestCase):
         client.run("create . mypkg/0.1@ -pr=profile")
         assert "mypkg/0.1: SETTINGS! os=Linux!!" in client.out
 
-    @pytest.mark.tool_compiler
     def test_install_profile_options(self):
         create_profile(self.client.cache.profiles_path, "vs_12_86",
                        options=[("Hello0:language", 1),
@@ -346,7 +342,6 @@ class ProfileTest(unittest.TestCase):
         self.assertIn("language=1", info)
         self.assertIn("static=False", info)
 
-    @pytest.mark.tool_compiler
     def test_scopes_env(self):
         # Create a profile and use it
         create_profile(self.client.cache.profiles_path, "scopes_env", settings={},
@@ -362,7 +357,6 @@ class ProfileTest(unittest.TestCase):
         self.assertFalse(os.environ.get("CC", None) == "/path/tomy/gcc")
         self.assertFalse(os.environ.get("CXX", None) == "/path/tomy/g++")
 
-    @pytest.mark.tool_compiler
     def test_default_including_another_profile(self):
         p1 = "include(p2)\n[env]\nA_VAR=1"
         p2 = "include(default)\n[env]\nA_VAR=2"
@@ -379,7 +373,6 @@ class ProfileTest(unittest.TestCase):
         self.client.run("create . user/testing")
         self._assert_env_variable_printed("A_VAR", "1")
 
-    @pytest.mark.tool_compiler
     def test_test_package(self):
         test_conanfile = '''from conans.model.conan_file import ConanFile
 from conans import CMake
@@ -439,7 +432,6 @@ class DefaultNameConan(ConanFile):
     def _assert_env_variable_printed(self, name, value):
         self.assertIn("%s=%s" % (name, value), self.client.out)
 
-    @pytest.mark.tool_compiler
     def test_info_with_profiles(self):
 
         self.client.run("remove '*' -f")

--- a/conans/test/functional/environment/build_environment_test.py
+++ b/conans/test/functional/environment/build_environment_test.py
@@ -104,7 +104,6 @@ class BuildEnvironmenTest(unittest.TestCase):
         self.assertIn("15", client.out)
 
     @pytest.mark.skipif(platform.system() != "Windows", reason="Requires windows")
-    @pytest.mark.tool_compiler
     def test_use_build_virtualenv_windows(self):
         files = cpp_hello_conan_files("hello", "0.1",  use_cmake=False, with_exe=False)
         client = TestClient(path_with_spaces=False)

--- a/conans/test/functional/generators/cmake_find_package_multi_test.py
+++ b/conans/test/functional/generators/cmake_find_package_multi_test.py
@@ -521,7 +521,6 @@ class TestNoNamespaceTarget:
         # Prepare project to consume the targets
         t.save({'CMakeLists.txt': cls.consumer, 'main.cpp': cls.main}, clean_first=True)
 
-    @pytest.mark.tool_compiler
     def test_non_multi_generator(self):
         t = self.t
         with t.chdir('not_multi'):

--- a/conans/test/functional/generators/components/pkg_config_test.py
+++ b/conans/test/functional/generators/components/pkg_config_test.py
@@ -11,7 +11,6 @@ from conans.test.assets.genconanfile import GenConanfile
 from conans.test.utils.tools import TestClient
 
 
-@pytest.mark.tool_compiler
 @pytest.mark.tool_pkg_config
 @pytest.mark.skipif(platform.system() == "Windows", reason="Requires pkg-config")
 class PkgConfigGeneratorWithComponentsTest(unittest.TestCase):

--- a/conans/test/functional/generators/components/propagate_specific_components_test.py
+++ b/conans/test/functional/generators/components/propagate_specific_components_test.py
@@ -65,7 +65,6 @@ class PropagateSpecificComponents(unittest.TestCase):
         self.assertNotIn("top::cmp2", content)
         self.assertIn("top::cmp1", content)
 
-    @pytest.mark.tool_compiler
     def test_cmake_find_package_app(self):
         t = TestClient(cache_folder=self.cache_folder)
         t.save({'conanfile.py': self.app})

--- a/conans/test/functional/generators/custom_generator_test.py
+++ b/conans/test/functional/generators/custom_generator_test.py
@@ -73,7 +73,6 @@ class CustomGeneratorTest(unittest.TestCase):
         test_server = TestServer()
         self.servers = {"default": test_server}
 
-    @pytest.mark.tool_compiler  # Needed only because it assume that a settings.compiler is detected
     def test_reuse(self):
         ref = ConanFileReference.loads("Hello0/0.1@lasote/stable")
 

--- a/conans/test/functional/generators/pkg_config_test.py
+++ b/conans/test/functional/generators/pkg_config_test.py
@@ -13,7 +13,6 @@ from conans.util.files import load
 class PkgGeneratorTest(unittest.TestCase):
 
     # Without compiler, def rpath_flags(settings, os_build, lib_paths): doesn't append the -Wl...etc
-    @pytest.mark.tool_compiler
     def test_pkg_config_dirs(self):
         # https://github.com/conan-io/conan/issues/2756
         conanfile = """

--- a/conans/test/functional/generators/qbs_test.py
+++ b/conans/test/functional/generators/qbs_test.py
@@ -6,7 +6,6 @@ from conans.test.assets.genconanfile import GenConanfile
 from conans.test.utils.tools import TestClient
 
 
-@pytest.mark.tool_compiler
 class QbsGeneratorTest(unittest.TestCase):
 
     def test(self):

--- a/conans/test/functional/generators/virtualbuildenv_test.py
+++ b/conans/test/functional/generators/virtualbuildenv_test.py
@@ -27,7 +27,6 @@ class TestConan(ConanFile):
         self.assertIn("UseEnv=True", bat)
         self.assertIn('CL=-MD -DNDEBUG -O2 -Ob2 %CL%', bat)
 
-    @pytest.mark.tool_compiler  # Needed only because it assume that a settings.compiler is detected
     def test_environment_deactivate(self):
         if platform.system() == "Windows":
             """ This test fails. The deactivation script takes the value of some envvars set by

--- a/conans/test/functional/generators/visual_studio_test.py
+++ b/conans/test/functional/generators/visual_studio_test.py
@@ -94,7 +94,6 @@ class VisualStudioTest(unittest.TestCase):
         client.run_command(r"x64\Release\MyProject.exe")
         self.assertIn("Hello world!!!", client.out)
 
-    @pytest.mark.tool_compiler
     def test_system_libs(self):
         mylib = textwrap.dedent("""
             import os

--- a/conans/test/functional/graph/diamond_test.py
+++ b/conans/test/functional/graph/diamond_test.py
@@ -12,7 +12,6 @@ from conans.util.files import load
 
 
 @pytest.mark.slow
-@pytest.mark.tool_compiler
 class DiamondTest(unittest.TestCase):
 
     def setUp(self):

--- a/conans/test/functional/settings/conan_settings_preprocessor_test.py
+++ b/conans/test/functional/settings/conan_settings_preprocessor_test.py
@@ -7,7 +7,6 @@ from conans.test.utils.tools import TestClient
 from conans.util.files import load, save
 
 
-@pytest.mark.tool_compiler
 class ConanSettingsPreprocessorTest(unittest.TestCase):
 
     def setUp(self):

--- a/conans/test/functional/settings/cppstd/compiler_cppstd_test.py
+++ b/conans/test/functional/settings/cppstd/compiler_cppstd_test.py
@@ -110,7 +110,6 @@ class SettingsCppStdScopedPackageTests(unittest.TestCase):
                       " 'compiler.cppstd' together with 'cppstd'", t.out)
 
 
-@pytest.mark.tool_compiler
 class UseCompilerCppStdSettingTests(unittest.TestCase):
 
     conanfile = textwrap.dedent("""

--- a/conans/test/functional/shared_chain_test.py
+++ b/conans/test/functional/shared_chain_test.py
@@ -28,7 +28,6 @@ class SharedChainTest(unittest.TestCase):
         rmdir(conan.current_folder)
         shutil.rmtree(conan.cache.store, ignore_errors=True)
 
-    @pytest.mark.tool_compiler
     def test_uploaded_chain(self):
         self._export_upload("Hello0", "0.1")
         self._export_upload("Hello1", "0.1", ["Hello0/0.1@lasote/stable"])

--- a/conans/test/functional/symlinks/symlink_package_test.py
+++ b/conans/test/functional/symlinks/symlink_package_test.py
@@ -9,7 +9,6 @@ from conans.test.utils.tools import TestClient
 class SymlinkPackageTest(unittest.TestCase):
 
     @pytest.mark.skipif(platform.system() not in ("Linux", "Darwin"), reason="Requires Symlinks")
-    @pytest.mark.tool_compiler
     def test_symlink_created(self):
         conanfile = """from conans import ConanFile
 import os

--- a/conans/test/functional/toolchains/cmake/cmakedeps/test_cmakedeps_components.py
+++ b/conans/test/functional/toolchains/cmake/cmakedeps/test_cmakedeps_components.py
@@ -56,7 +56,6 @@ class PropagateSpecificComponents(unittest.TestCase):
         client.run('create middle.py middle/version@')
         self.cache_folder = client.cache_folder
 
-    @pytest.mark.tool_compiler
     def test_cmakedeps_app(self):
         t = TestClient(cache_folder=self.cache_folder)
         t.save({'conanfile.py': self.app})

--- a/conans/test/functional/toolchains/cmake/test_ninja.py
+++ b/conans/test/functional/toolchains/cmake/test_ninja.py
@@ -56,7 +56,6 @@ def client():
 
 @pytest.mark.skipif(platform.system() != "Linux", reason="Only Linux")
 @pytest.mark.parametrize("build_type,shared", [("Release", False), ("Debug", True)])
-@pytest.mark.tool_compiler
 @pytest.mark.tool_ninja
 def test_locally_build_linux(build_type, shared, client):
     settings = "-s os=Linux -s arch=x86_64 -s build_type={} -o hello:shared={}".format(build_type,
@@ -86,7 +85,6 @@ def test_locally_build_linux(build_type, shared, client):
 
 @pytest.mark.skipif(platform.system() != "Windows", reason="Only windows")
 @pytest.mark.parametrize("build_type,shared", [("Release", False), ("Debug", True)])
-@pytest.mark.tool_compiler
 @pytest.mark.tool_ninja
 def test_locally_build_msvc(build_type, shared, client):
     msvc_version = "15"
@@ -118,7 +116,6 @@ def test_locally_build_msvc(build_type, shared, client):
 
 
 @pytest.mark.skipif(platform.system() != "Windows", reason="Only windows")
-@pytest.mark.tool_compiler
 @pytest.mark.tool_ninja
 def test_locally_build_msvc_toolset(client):
     msvc_version = "15"
@@ -178,7 +175,6 @@ def test_locally_build_gcc(build_type, shared, client):
 
 @pytest.mark.skipif(platform.system() != "Darwin", reason="Requires apple-clang")
 @pytest.mark.parametrize("build_type,shared", [("Release", False), ("Debug", True)])
-@pytest.mark.tool_compiler
 @pytest.mark.tool_ninja
 def test_locally_build_macos(build_type, shared, client):
     client.run('install . -s os=Macos -s arch=x86_64 -s build_type={} -o hello:shared={}'

--- a/conans/test/functional/toolchains/gnu/test_pkgconfigdeps.py
+++ b/conans/test/functional/toolchains/gnu/test_pkgconfigdeps.py
@@ -11,7 +11,6 @@ from conans.util.files import load
 
 
 # Without compiler, def rpath_flags(settings, os_build, lib_paths): doesn't append the -Wl...etc
-@pytest.mark.tool_compiler
 def test_pkg_config_dirs():
     # https://github.com/conan-io/conan/issues/2756
     conanfile = textwrap.dedent("""

--- a/conans/test/functional/toolchains/test_basic.py
+++ b/conans/test/functional/toolchains/test_basic.py
@@ -28,7 +28,6 @@ class BasicTest(unittest.TestCase):
         toolchain = client.load("conan_toolchain.cmake")
         self.assertIn("Conan automatically generated toolchain file", toolchain)
 
-    @pytest.mark.tool_compiler
     def test_declarative(self):
         conanfile = textwrap.dedent("""
             from conans import ConanFile
@@ -160,7 +159,6 @@ class BasicTest(unittest.TestCase):
         self.assertIn("<ConanPackageName>Pkg</ConanPackageName>", conan_toolchain_props)
         self.assertIn("<ConanPackageVersion>0.1</ConanPackageVersion>", conan_toolchain_props)
 
-    @pytest.mark.tool_compiler
     def test_conflict_user_generator(self):
         client = TestClient()
         generator = textwrap.dedent("""

--- a/conans/test/functional/tools/old/vcvars/vcvars_test.py
+++ b/conans/test/functional/tools/old/vcvars/vcvars_test.py
@@ -172,7 +172,6 @@ compiler:
                 # Not raising
                 tools.vcvars_command(settings, force=True, output=output)
 
-    @pytest.mark.tool_compiler
     def test_vcvars_context_manager(self):
         conanfile = """
 from conans import ConanFile, tools

--- a/conans/test/functional/workspace/workspace_test.py
+++ b/conans/test/functional/workspace/workspace_test.py
@@ -156,7 +156,6 @@ class WorkspaceTest(unittest.TestCase):
                                    "does not define path"):
             Workspace(path, None)
 
-    @pytest.mark.tool_compiler
     def test_simple(self):
         client = TestClient()
 
@@ -246,7 +245,6 @@ class WorkspaceTest(unittest.TestCase):
         b_cmake = client.load(os.path.join("B", "conanbuildinfo.cmake"))
         self.assertIn("set(CONAN_LIBS helloD ${CONAN_LIBS})", b_cmake)
 
-    @pytest.mark.tool_compiler
     def test_transitivity(self):
         # https://github.com/conan-io/conan/issues/4720
         client = TestClient()
@@ -810,7 +808,6 @@ class Pkg(ConanFile):
         conanbuildinfo = client.load(os.path.join("A", "build", "conanbuildinfo.cmake"))
         self.assertIn("set(CONAN_LIBS_TOOL MyToolLib)", conanbuildinfo)
 
-    @pytest.mark.tool_compiler
     def test_per_package_layout(self):
         client = TestClient()
 
@@ -855,7 +852,6 @@ class Pkg(ConanFile):
         self.assertIn("myincludeC", conanbuildcmake)
         self.assertIn("myincludeB", conanbuildcmake)
 
-    @pytest.mark.tool_compiler
     def test_generators(self):
         client = TestClient()
 

--- a/conans/test/integration/remote/multi_remote_test.py
+++ b/conans/test/integration/remote/multi_remote_test.py
@@ -179,7 +179,6 @@ class MultiRemotesTest(unittest.TestCase):
         self.assertIn("Hello0/0.0@lasote/stable from 'local' - Updated", client.out)
 
 
-@pytest.mark.tool_compiler  # Needed only because it assume that a settings.compiler is detected
 class MultiRemoteTest(unittest.TestCase):
 
     def setUp(self):

--- a/conans/test/integration/ui/json_output_test.py
+++ b/conans/test/integration/ui/json_output_test.py
@@ -78,7 +78,6 @@ class JsonOutputTest(unittest.TestCase):
         self.assertFalse(my_json["installed"][0]["packages"][0]["downloaded"])
         self.assertTrue(my_json["installed"][0]["packages"][0]["cpp_info"])
 
-    @pytest.mark.tool_compiler
     def test_errors(self):
 
         # Missing recipe


### PR DESCRIPTION
Changelog: omit
Docs: omit

Remove `tool_compiler` mark for testing. It was making that all the `tool_compiler` tests for Macos were skipped and also is a bit redundant.
