### PR TITLE
fix: support components with symbolic imports like @libdirs.

### DIFF
--- a/conans/client/importer.py
+++ b/conans/client/importer.py
@@ -169,6 +169,12 @@ class _FileImporter(object):
                     raise ConanException("Import from unknown package folder '@%s'"
                                          % symbolic_dir_name)
 
+                if cpp_info.components:
+                    for comp_name, comp in cpp_info.components.items():
+                        src_dir = getattr(comp, symbolic_dir_name)
+                        if isinstance(src_dirs, list):  # it can return a "config" CppInfo item!
+                            src_dirs += src_dir
+
             for src_dir in src_dirs:
                 files = file_copier(pattern, src=src_dir, links=True, ignore_case=ignore_case,
                                     excludes=excludes, keep_path=keep_path)


### PR DESCRIPTION
When copying from a dependency using `@libdirs` etc., not all directories from components of the dependency are traversed.

Signed-off-by: Joachim Kuebart <joachim.kuebart@tomtom.com>

Changelog: Bugfix: Support components with symbolic imports.
Docs: omit

- [ ] Refer to the issue that supports this Pull Request.
- [ ] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 

<sup>**Note:** By default this PR will skip the slower tests and will use a limited set of python versions. Check [here](https://github.com/conan-io/conan/blob/develop/.github/PR_INCREASE_TESTING.md) how to increase the testing level by writing some tags in the current PR body text.</sup>
