### PR TITLE
Add multi-architecture generator for Xcode

### DIFF
--- a/conans/client/generators/__init__.py
+++ b/conans/client/generators/__init__.py
@@ -34,6 +34,7 @@ from .visualstudio import VisualStudioGenerator
 from .visualstudio_multi import VisualStudioMultiGenerator
 from .visualstudiolegacy import VisualStudioLegacyGenerator
 from .xcode import XCodeGenerator
+from .xcode_multi import XCodeMultiGenerator
 from .ycm import YouCompleteMeGenerator
 from ..tools import chdir
 
@@ -55,6 +56,7 @@ class GeneratorManager(object):
                             "visual_studio_multi": VisualStudioMultiGenerator,
                             "visual_studio_legacy": VisualStudioLegacyGenerator,
                             "xcode": XCodeGenerator,
+                            "xcode_multi": XCodeMultiGenerator,
                             "ycm": YouCompleteMeGenerator,
                             "virtualenv": VirtualEnvGenerator,
                             "virtualenv_python": VirtualEnvPythonGenerator,
@@ -87,7 +89,7 @@ class GeneratorManager(object):
     def _new_generator(self, generator_name, output):
         if generator_name not in self._new_generators:
             return
-        if generator_name in self._generators:  # Avoid colisions with user custom generators
+        if generator_name in self._generators:  # Avoid collisions with user custom generators
             msg = ("******* Your custom generator name '{}' is colliding with a new experimental "
                    "built-in one. It is recommended to rename it. *******".format(generator_name))
             output.warn(msg)
@@ -136,7 +138,7 @@ class GeneratorManager(object):
             return BazelToolchain
         else:
             raise ConanException("Internal Conan error: Generator '{}' "
-                                 "not commplete".format(generator_name))
+                                 "not complete".format(generator_name))
 
     def write_generators(self, conanfile, old_gen_folder, new_gen_folder, output):
         """ produces auxiliary files, required to build a project or a package.

--- a/conans/client/generators/xcode_multi.py
+++ b/conans/client/generators/xcode_multi.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 from conans.model import Generator
 from conans.client.generators import XCodeGenerator
 from conans import tools

--- a/conans/client/generators/xcode_multi.py
+++ b/conans/client/generators/xcode_multi.py
@@ -1,0 +1,40 @@
+from conans.model import Generator
+from conans.client.generators import XCodeGenerator
+from conans import tools
+from conans.util.files import load
+import os
+
+
+class XCodeMultiGenerator(Generator):
+    multi_file_name = "conanbuildinfo_multi.xcconfig"
+
+    @property
+    def content(self):
+        arch = self.conanfile.settings.arch
+        apple_arch = tools.to_apple_arch(arch)
+        return {"conanbuildinfo_%s.xcconfig" % apple_arch: self._content_arch(apple_arch),
+                self.multi_file_name: self._content_multi(apple_arch)}
+
+    @property
+    def filename(self):
+        pass
+
+    def _content_arch(self, apple_arch):
+        xcode_gen = XCodeGenerator(self.conanfile)
+        return xcode_gen.content.replace(" = ", "[arch=%s] = " % apple_arch)
+
+    def _read_old_multi_content(self):
+        multi_path = os.path.join(self.output_path, self.multi_file_name)
+        content_multi = ""
+        if os.path.isfile(multi_path):
+            content_multi = load(multi_path)
+
+        return content_multi
+
+    def _content_multi(self, apple_arch):
+        content = self._read_old_multi_content()
+        additional_line = '#include "conanbuildinfo_%s.xcconfig"' % apple_arch
+        if content.find(additional_line) == -1:
+            content = content + "\n" + additional_line
+
+        return content


### PR DESCRIPTION
Changelog: Feature: Provide an `Xcode_multi` generator that handles multiple architectures.

Docs: https://github.com/conan-io/docs/pull/2234

Uses code provided by @kdonev example linked to conan-io/conan#8403

My use case for this is supporting `x86_64` and `arm64 (M1)` conan packages without resorting to converting the conan library into a universal2 library

Relates to conan-io/conan-extensions#59
Closes conan-io/conan#8403

NOTE: This seems like a good place to add `sdk=` attributes as well. I see people need this for `iphoneos` vs. `iphonesimulator` etc, but that is not the problem I am trying to solve at the moment

- [x] Refer to the issue that supports this Pull Request.
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [x] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 

