### PR TITLE
define layout folders for package and export-pkg commands

### DIFF
--- a/conan/tools/cmake/cmake.py
+++ b/conan/tools/cmake/cmake.py
@@ -147,8 +147,9 @@ class CMake(object):
         is_multi = is_multi_configuration(self._generator)
         build_config = "--config {}".format(bt) if bt and is_multi else ""
 
-        pkg_folder = self._conanfile.package_folder.replace("\\", "/")
-        arg_list = ["--install", self._conanfile.build_folder, build_config, "--prefix", pkg_folder]
+        pkg_folder = args_to_string([self._conanfile.package_folder.replace("\\", "/")])
+        build_folder = args_to_string([self._conanfile.build_folder])
+        arg_list = ["--install", build_folder, build_config, "--prefix", pkg_folder]
         arg_list = " ".join(filter(None, arg_list))
         command = "%s %s" % (self._cmake_program, arg_list)
         self._conanfile.output.info("CMake command: %s" % command)

--- a/conans/client/cmd/export_pkg.py
+++ b/conans/client/cmd/export_pkg.py
@@ -10,7 +10,7 @@ from conans.model.ref import PackageReference
 
 
 def export_pkg(app, recorder, full_ref, source_folder, build_folder, package_folder, install_folder,
-               graph_info, force, remotes):
+               graph_info, force, remotes, source_conanfile_path):
     ref = full_ref.copy_clear_rev()
     cache, output, hook_manager = app.cache, app.out, app.hook_manager
     graph_manager = app.graph_manager
@@ -54,13 +54,22 @@ def export_pkg(app, recorder, full_ref, source_folder, build_folder, package_fol
     recipe_hash = layout.recipe_manifest().summary_hash
     conanfile.info.recipe_hash = recipe_hash
     conanfile.develop = True
-    conanfile.folders.set_base_build(build_folder)
-    conanfile.folders.set_base_source(source_folder)
-    conanfile.folders.set_base_package(dest_package_folder)
-    conanfile.folders.set_base_install(install_folder)
+    if hasattr(conanfile, "layout"):
+        conanfile_folder = os.path.dirname(source_conanfile_path)
+        conanfile.folders.set_base_build(conanfile_folder)
+        conanfile.folders.set_base_source(conanfile_folder)
+        conanfile.folders.set_base_package(dest_package_folder)
+        conanfile.folders.set_base_install(conanfile_folder)
+        conanfile.folders.set_base_generators(conanfile_folder)
+    else:
+        conanfile.folders.set_base_build(build_folder)
+        conanfile.folders.set_base_source(source_folder)
+        conanfile.folders.set_base_package(dest_package_folder)
+        conanfile.folders.set_base_install(install_folder)
 
     with layout.set_dirty_context_manager(pref):
         if package_folder:
+            # FIXME: To be removed in 2.0
             prev = packager.export_pkg(conanfile, package_id, package_folder, hook_manager,
                                        conan_file_path, ref)
         else:

--- a/conans/client/conan_api.py
+++ b/conans/client/conan_api.py
@@ -784,6 +784,7 @@ class ConanAPIV1(object):
 
         cwd = cwd or os.getcwd()
         conanfile_path = _get_conanfile_path(path, cwd, py=True)
+        conanfile_dir = os.path.dirname(conanfile_path)
         build_folder = _make_abs_path(build_folder, cwd)
         install_folder = _make_abs_path(install_folder, cwd, default=build_folder)
         source_folder = _make_abs_path(source_folder, cwd, default=os.path.dirname(conanfile_path))
@@ -800,6 +801,7 @@ class ConanAPIV1(object):
         conanfile.folders.set_base_source(source_folder)
         conanfile.folders.set_base_package(package_folder)
         conanfile.folders.set_base_install(install_folder)
+        conanfile.folders.set_base_generators(conanfile_dir)
 
         # Use the complete package layout for the local method
         if conanfile.folders.package:

--- a/conans/client/conan_api.py
+++ b/conans/client/conan_api.py
@@ -453,7 +453,7 @@ class ConanAPIV1(object):
             export_pkg(self.app, recorder, new_ref, source_folder=source_folder,
                        build_folder=build_folder, package_folder=package_folder,
                        install_folder=install_folder, graph_info=graph_info, force=force,
-                       remotes=remotes)
+                       remotes=remotes, source_conanfile_path=conanfile_path)
             if lockfile_out:
                 lockfile_out = _make_abs_path(lockfile_out, cwd)
                 graph_lock_file = GraphLockFile(graph_info.profile_host, graph_info.profile_build,

--- a/conans/test/functional/toolchains/cmake/test_v2_cmake_template.py
+++ b/conans/test/functional/toolchains/cmake/test_v2_cmake_template.py
@@ -1,3 +1,5 @@
+import os
+
 from conans.test.utils.tools import TestClient
 
 
@@ -7,6 +9,11 @@ def test_cmake_lib_template():
     # Local flow works
     client.run("install . -if=install")
     client.run("build . -if=install")
+    client.run("package . -if=install")
+    assert os.path.exists(os.path.join(client.current_folder, "package", "include", "hello.h"))
+
+    # This doesn't work yet, because the layout definition is ignored here
+    # client.run("export-pkg . hello/0.1@ -if=install")
 
     # Create works
     client.run("create .")

--- a/conans/test/functional/toolchains/cmake/test_v2_cmake_template.py
+++ b/conans/test/functional/toolchains/cmake/test_v2_cmake_template.py
@@ -1,5 +1,7 @@
 import os
+import re
 
+from conans.model.ref import ConanFileReference, PackageReference
 from conans.test.utils.tools import TestClient
 
 
@@ -12,8 +14,11 @@ def test_cmake_lib_template():
     client.run("package . -if=install")
     assert os.path.exists(os.path.join(client.current_folder, "package", "include", "hello.h"))
 
-    # This doesn't work yet, because the layout definition is ignored here
-    # client.run("export-pkg . hello/0.1@ -if=install")
+    client.run("export-pkg . hello/0.1@ -if=install")
+    package_id = re.search(r"Packaging to (\S+)", str(client.out)).group(1)
+    pref = PackageReference(ConanFileReference.loads("hello/0.1"), package_id)
+    package_folder = client.cache.package_layout(pref.ref).package(pref)
+    assert os.path.exists(os.path.join(package_folder, "include", "hello.h"))
 
     # Create works
     client.run("create .")


### PR DESCRIPTION
Changelog: Fix: Command ``conan package`` now works for new ``layout()`` with generators folder.
Docs: Omit

- ``conan export-pkg`` is still broken
- It is possible that we need to discuss plans for 2.0 regarding ``package``, ``export-pkg`` flows.