### PR TITLE
Exclude meson tests from not mainstrem OSS

### DIFF
--- a/conans/test/functional/toolchains/meson/_base.py
+++ b/conans/test/functional/toolchains/meson/_base.py
@@ -9,6 +9,8 @@ from conans.test.utils.tools import TestClient
 
 @pytest.mark.tool_meson
 @pytest.mark.skipif(sys.version_info.major == 2, reason="Meson not supported in Py2")
+@pytest.mark.skipif(platform.system() not in ("Darwin", "Windows", "Linux"),
+                    reason="Not tested for not mainstream boring operating systems")
 class TestMesonBase(unittest.TestCase):
     def setUp(self):
         self.t = TestClient()


### PR DESCRIPTION
Changelog: omit
Docs: omit

The Meson tests are only ready to run in Mac, Windows, or Linux right now. So avoid other operating systems running Conan to run these tests.

Closes #9671