### PR TITLE
Release conan 1.40.4 to fix generation of deb packages for Ubuntu

### DIFF
--- a/conans/__init__.py
+++ b/conans/__init__.py
@@ -20,4 +20,4 @@ OAUTH_TOKEN = "oauth_token"
 SERVER_CAPABILITIES = [COMPLEX_SEARCH_CAPABILITY, REVISIONS]  # Server is always with revisions
 DEFAULT_REVISION_V1 = "0"
 
-__version__ = '1.40.3'
+__version__ = '1.40.4'

--- a/conans/client/migrations_settings.py
+++ b/conans/client/migrations_settings.py
@@ -2555,3 +2555,4 @@ cppstd: [None, 98, gnu98, 11, gnu11, 14, gnu14, 17, gnu17, 20, gnu20, 23, gnu23]
 """
 
 settings_1_40_3 = settings_1_40_2
+settings_1_40_4 = settings_1_40_3


### PR DESCRIPTION
Changelog: Fix: Update Conan debian package to fix ssl certificates problem.
Docs: omit

Adding this PR to generate the changelog correctly, although we are changing the way in how we generate the deb package in the release pipeline but not changing the conan codebase more than updating the version.

Closes: https://github.com/conan-io/conan/issues/9714