### PR TITLE
Check old cacert.pem before deleting when updating Conan

### DIFF
--- a/conans/client/migrations.py
+++ b/conans/client/migrations.py
@@ -1,6 +1,8 @@
 import os
 import shutil
 
+import six
+
 from conans import DEFAULT_REVISION_V1
 from conans.client import migrations_settings
 from conans.client.cache.cache import ClientCache
@@ -119,7 +121,7 @@ def remove_buggy_cacert(cache, out):
     Needed migration because otherwise the cacert is kept in the cache even upgrading conan"""
     cacert_path = os.path.join(cache.cache_folder, CACERT_FILE)
     if os.path.exists(cacert_path):
-        current_cacert = load(cacert_path)
+        current_cacert = load(cacert_path).encode('utf-8') if six.PY2 else load(cacert_path)
         if current_cacert == cacert_default:
             out.info("Removing the 'cacert.pem' file...")
             os.unlink(cacert_path)

--- a/conans/client/migrations.py
+++ b/conans/client/migrations.py
@@ -6,6 +6,7 @@ from conans.client import migrations_settings
 from conans.client.cache.cache import ClientCache
 from conans.client.cache.remote_registry import migrate_registry_file
 from conans.client.conf.config_installer import _ConfigOrigin, _save_configs
+from conans.client.rest.cacert import cacert_default, cacert
 from conans.client.tools import replace_in_file
 from conans.errors import ConanException
 from conans.migrations import Migrator
@@ -118,8 +119,19 @@ def remove_buggy_cacert(cache, out):
     Needed migration because otherwise the cacert is kept in the cache even upgrading conan"""
     cacert_path = os.path.join(cache.cache_folder, CACERT_FILE)
     if os.path.exists(cacert_path):
-        out.info("Removing the 'cacert.pem' file...")
-        os.unlink(cacert_path)
+        current_cacert = load(cacert_path)
+        if current_cacert == cacert_default:
+            out.info("Removing the 'cacert.pem' file...")
+            os.unlink(cacert_path)
+        elif current_cacert != cacert:  # locally modified by user
+            new_path = cacert_path + ".new"
+            save(new_path, cacert)
+            out.warn("*" * 40)
+            out.warn("'cacert.pem' is locally modified, can't be updated")
+            out.warn("The new 'cacert.pem' has been stored in: %s" % new_path)
+            out.warn("*" * 40)
+        else:
+            out.info("Conan 'cacert.pem' is up to date...")
 
 
 def migrate_tgz_location(cache, out):

--- a/conans/client/rest/cacert.py
+++ b/conans/client/rest/cacert.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-cacert = """
+cacert_default = """
 # Issuer: O=Equifax OU=Equifax Secure Certificate Authority
 # Subject: O=Equifax OU=Equifax Secure Certificate Authority
 # Label: "Equifax Secure CA"
@@ -5701,6 +5701,10 @@ j4rBYKEMrltDR5FL1ZoXX/nUh8HCjLfn4g8wGTeGrODcQgPmlKidrv0PJFGUzpII
 lBlGGSW4gNfL1IYoakRwJiNiqZ+Gb7+6kHDSVneFeO/qJakXzlByjAA6quPbYzSf
 +AZxAeKCINT+b72x
 -----END CERTIFICATE-----
+"""
+
+# Added block: https://github.com/conan-io/conan/pull/9696
+cacert_1_40_3 = """
 -----BEGIN CERTIFICATE-----
 MIIFazCCA1OgAwIBAgIRAIIQz7DSQONZRGPgu2OCiwAwDQYJKoZIhvcNAQELBQAw
 TzELMAkGA1UEBhMCVVMxKTAnBgNVBAoTIEludGVybmV0IFNlY3VyaXR5IFJlc2Vh
@@ -5733,3 +5737,5 @@ mRGunUHBcnWEvgJBQl9nJEiU0Zsnvgc/ubhPgXRR4Xq37Z0j4r7g1SgEEzwxA57d
 emyPxgcYxn/eR44/KJ4EBs+lVDR3veyJm+kXQ99b21/+jh5Xos1AnX5iItreGCc=
 -----END CERTIFICATE-----
 """
+
+cacert = cacert_default + cacert_1_40_3

--- a/conans/test/integration/test_migrations.py
+++ b/conans/test/integration/test_migrations.py
@@ -8,12 +8,14 @@ from six import StringIO
 from conans import __version__
 from conans.client.cache.editable import EDITABLE_PACKAGES_FILE
 from conans.client.migrations import migrate_plugins_to_hooks, migrate_to_default_profile, \
-    migrate_editables_use_conanfile_name
+    migrate_editables_use_conanfile_name, remove_buggy_cacert
 from conans.client.output import ConanOutput
+from conans.client.rest.cacert import cacert_default
 from conans.client.tools.version import Version
 from conans.migrations import CONAN_VERSION
 from conans.model.ref import ConanFileReference, PackageReference
-from conans.paths import EXPORT_TGZ_NAME, EXPORT_SOURCES_TGZ_NAME, PACKAGE_TGZ_NAME
+from conans.paths import EXPORT_TGZ_NAME, EXPORT_SOURCES_TGZ_NAME, PACKAGE_TGZ_NAME, CACERT_FILE
+from conans.test.utils.mocks import TestBufferConanOutput
 from conans.test.utils.test_files import temp_folder
 from conans.test.utils.tools import TestClient, GenConanfile, NO_SETTINGS_PACKAGE_ID
 from conans.util.files import load, save
@@ -250,3 +252,24 @@ the old general
         self.assertFalse(os.path.isfile(export_tgz))
         self.assertFalse(os.path.isfile(export_src_tgz))
         self.assertFalse(os.path.isfile(pkg_tgz))
+
+    def test_cacert_migration(self):
+        client = TestClient()
+        client.run("search foo")
+        cacert_path = os.path.join(client.cache_folder, CACERT_FILE)
+        out = TestBufferConanOutput()
+        remove_buggy_cacert(client.cache, out)
+        assert "Conan 'cacert.pem' is up to date..." in out
+
+        modified_cacert_content = load(cacert_path) + "other_info"
+        save(cacert_path, modified_cacert_content)
+        remove_buggy_cacert(client.cache, out)
+        assert "'cacert.pem' is locally modified, can't be updated" in out
+        new_path = cacert_path + ".new"
+        assert os.path.exists(new_path)
+
+        old_cacert = cacert_default
+        save(cacert_path, old_cacert)
+        remove_buggy_cacert(client.cache, out)
+        assert "Removing the 'cacert.pem' file..." in out
+        assert not os.path.exists(cacert_path)


### PR DESCRIPTION
Changelog: Fix: Check current _cacert.pem_ file when updating Conan and only migrate if the user has not modified the file. If  the local file is modified then create a new cacert file but don't overwrite current.
Docs: omit

Closes: https://github.com/conan-io/conan/issues/9731