### PR TITLE
Reduce special cases in conan.tools patch handling

### DIFF
--- a/conan/tools/files/patches.py
+++ b/conan/tools/files/patches.py
@@ -99,13 +99,17 @@ def apply_conandata_patches(conanfile):
     if isinstance(patches, dict):
         assert conanfile.version, "Can only be applied if conanfile.version is already defined"
         entries = patches.get(conanfile.version, [])
-        for it in entries:
-            if not "patch_file" in it:
-                raise ConanException("The 'conandata.yml' file needs a 'patch_file' entry for every"
-                                     " patch to be applied")
+    elif isinstance(patches, Iterable):
+        entries = patches
+    else:
+        return
+    for it in entries:
+        if "patch_file" in it:
             # The patch files are located in the root src
             patch_file = os.path.join(conanfile.folders.base_source, it.pop("patch_file"))
             patch(conanfile, patch_file=patch_file, **it)
-    elif isinstance(patches, Iterable):
-        for it in patches:
+        elif "patch_string" in it:
             patch(conanfile, **it)
+        else:
+            raise ConanException("The 'conandata.yml' file needs a 'patch_file' entry for every"
+                                 " patch to be applied")

--- a/conan/tools/files/patches.py
+++ b/conan/tools/files/patches.py
@@ -111,5 +111,5 @@ def apply_conandata_patches(conanfile):
         elif "patch_string" in it:
             patch(conanfile, **it)
         else:
-            raise ConanException("The 'conandata.yml' file needs a 'patch_file' entry for every"
-                                 " patch to be applied")
+            raise ConanException("The 'conandata.yml' file needs a 'patch_file' or 'patch_string'"
+                                 " entry for every patch to be applied")

--- a/conans/test/functional/tools/test_files.py
+++ b/conans/test/functional/tools/test_files.py
@@ -221,8 +221,8 @@ def test_no_patch_file_entry():
                  'conandata.yml': conandata_yml})
     client.run('create .', assert_error=True)
 
-    assert "The 'conandata.yml' file needs a 'patch_file' entry for every patch to be applied" \
-           in str(client.out)
+    assert "The 'conandata.yml' file needs a 'patch_file' or 'patch_string' entry for every patch" \
+           " to be applied" in str(client.out)
 
 def test_patch_string_entry(mock_patch_ng):
     conanfile = textwrap.dedent("""


### PR DESCRIPTION
Changelog: Feature: Enabled `patch_string` when using `apply_conandata_patches`.
Changelog: Bugfix: The path to a patch file in a `conandata.yml` is also relative to the base source folder when the patches are not associated with a version (list of patches).
Docs: https://github.com/conan-io/docs/pull/2246

Closes #9739