### PR TITLE
fix CONAN_USER_HOME/.conan env-var

### DIFF
--- a/conans/cli/api/conan_api.py
+++ b/conans/cli/api/conan_api.py
@@ -60,7 +60,7 @@ class ConanAPIV2(object):
     def __init__(self, cache_folder=None):
 
         self.out = ConanOutput()
-        self.cache_folder = cache_folder or os.path.join(get_conan_user_home(), ".conan")
+        self.cache_folder = cache_folder or get_conan_user_home()
 
         # Migration system
         migrator = ClientMigrator(self.cache_folder, Version(client_version))

--- a/conans/client/cache/cache.py
+++ b/conans/client/cache/cache.py
@@ -48,7 +48,7 @@ class ClientCache(object):
         self._new_config = None
         self.editable_packages = EditablePackages(self.cache_folder)
         # paths
-        self._store_folder = self.config.storage_path or os.path.join(self.cache_folder, "data")
+        self._store_folder = os.path.join(self.cache_folder, "p")
 
         mkdir(self._store_folder)
         db_filename = os.path.join(self._store_folder, 'cache.sqlite3')

--- a/conans/client/conan_api.py
+++ b/conans/client/conan_api.py
@@ -97,7 +97,7 @@ def _get_conanfile_path(path, cwd, py):
 class ConanAPIV1(object):
 
     def __init__(self, cache_folder=None):
-        self.cache_folder = cache_folder or os.path.join(get_conan_user_home(), ".conan")
+        self.cache_folder = cache_folder or get_conan_user_home()
         # Migration system
         migrator = ClientMigrator(self.cache_folder, Version(client_version))
         migrator.migrate()

--- a/conans/client/conf/__init__.py
+++ b/conans/client/conf/__init__.py
@@ -431,33 +431,6 @@ class ConanClientConfigParser(ConfigParser, object):
         return default_package_id_mode
 
     @property
-    def storage_path(self):
-        # Try with CONAN_STORAGE_PATH
-        result = get_env('CONAN_STORAGE_PATH', None)
-        if not result:
-            # Try with conan.conf "path"
-            try:
-                # TODO: Fix this mess for Conan 2.0
-                env_conan_user_home = os.getenv("CONAN_USER_HOME")
-                current_dir = os.path.dirname(self.filename)
-                # if env var is declared, any specified path will be relative to CONAN_USER_HOME
-                # even with the ~/
-                result = dict(self._get_conf("storage"))["path"]
-                if result.startswith("."):
-                    result = os.path.abspath(os.path.join(current_dir, result))
-                elif result[:2] == "~/":
-                    if env_conan_user_home:
-                        result = os.path.join(env_conan_user_home, result[2:])
-            except (KeyError, ConanException):  # If storage not defined, to return None
-                pass
-
-        if result:
-            result = conan_expand_user(result)
-            if not os.path.isabs(result):
-                raise ConanException("Conan storage path has to be an absolute path")
-        return result
-
-    @property
     def proxies(self):
         try:  # optional field, might not exist
             proxies = self._get_conf("proxies")

--- a/conans/paths/__init__.py
+++ b/conans/paths/__init__.py
@@ -10,13 +10,17 @@ else:
 
 
 def get_conan_user_home():
-    user_home = os.getenv("CONAN_USER_HOME", "~")
-    tmp = conan_expand_user(user_home)
-    if not os.path.isabs(tmp):
+    user_home = os.getenv("CONAN_USER_HOME")
+    if user_home is None:
+        # the default, in the user home
+        user_home = os.path.join(conan_expand_user("~"), ".conan")
+    else:  # Do an expansion, just in case the user is using ~/something/here
+        user_home = conan_expand_user(user_home)
+    if not os.path.isabs(user_home):
         raise Exception("Invalid CONAN_USER_HOME value '%s', "
                         "please specify an absolute or path starting with ~/ "
-                        "(relative to user home)" % tmp)
-    return os.path.abspath(tmp)
+                        "(relative to user home)" % user_home)
+    return user_home
 
 
 # Files

--- a/conans/test/unittests/util/tools_test.py
+++ b/conans/test/unittests/util/tools_test.py
@@ -18,7 +18,6 @@ from conans.client.conf import get_default_client_conf
 from conans.cli.output import ConanOutput
 from conans.client.tools import chdir
 from conans.client.tools.files import replace_in_file
-from conans.client.tools.oss import OSInfo
 from conans.client.tools.win import vswhere
 from conans.errors import ConanException, AuthenticationException
 from conans.model.build_info import CppInfo
@@ -254,8 +253,7 @@ class HelloConan(ConanFile):
         # Not test the real commmand get_command if it's setting the module global vars
         tmp = temp_folder()
         conf = get_default_client_conf().replace("\n[proxies]", "\n[proxies]\nhttp = http://myproxy.com")
-        os.mkdir(os.path.join(tmp, ".conan"))
-        save(os.path.join(tmp, ".conan", CONAN_CONF), conf)
+        save(os.path.join(tmp, CONAN_CONF), conf)
         with tools.environment_append({"CONAN_USER_HOME": tmp}):
             conan_api = ConanAPIV1()
         conan_api.remote_list()


### PR DESCRIPTION
Changelog: Fix: Avoid creating always an extra ``.conan`` subfolder in the cache, if the usre defines CONAN_USER_HOME, that can be directly be the cache folder. Use it only for the default ``<userhome>/.conan``
Docs: Omit

Close https://github.com/conan-io/conan/issues/5295