### PR TITLE
Fix typo where fPIC option is not templated, so it is always enabled

### DIFF
--- a/conan/tools/cmake/toolchain.py
+++ b/conan/tools/cmake/toolchain.py
@@ -153,7 +153,7 @@ class FPicBlock(Block):
             self._conanfile.output.warn("Toolchain: Ignoring fPIC option defined "
                                         "for a shared library")
             return None
-        return {"fpic": fpic}
+        return {"fpic": "ON" if fpic else "OFF"}
 
 
 class GLibCXXBlock(Block):

--- a/conan/tools/cmake/toolchain.py
+++ b/conan/tools/cmake/toolchain.py
@@ -134,8 +134,10 @@ class VSRuntimeBlock(Block):
 
 class FPicBlock(Block):
     template = textwrap.dedent("""
+        {% if fpic %}
         message(STATUS "Conan toolchain: Setting CMAKE_POSITION_INDEPENDENT_CODE={{ fpic }} (options.fPIC)")
         set(CMAKE_POSITION_INDEPENDENT_CODE {{ fpic }})
+        {% endif %}
         """)
 
     def context(self):

--- a/conan/tools/cmake/toolchain.py
+++ b/conan/tools/cmake/toolchain.py
@@ -134,7 +134,7 @@ class VSRuntimeBlock(Block):
 
 class FPicBlock(Block):
     template = textwrap.dedent("""
-        message(STATUS "Conan toolchain: Setting CMAKE_POSITION_INDEPENDENT_CODE=ON (options.fPIC)")
+        message(STATUS "Conan toolchain: Setting CMAKE_POSITION_INDEPENDENT_CODE={{ fpic }} (options.fPIC)")
         set(CMAKE_POSITION_INDEPENDENT_CODE {{ fpic }})
         """)
 

--- a/conan/tools/cmake/toolchain.py
+++ b/conan/tools/cmake/toolchain.py
@@ -135,7 +135,7 @@ class VSRuntimeBlock(Block):
 class FPicBlock(Block):
     template = textwrap.dedent("""
         message(STATUS "Conan toolchain: Setting CMAKE_POSITION_INDEPENDENT_CODE=ON (options.fPIC)")
-        set(CMAKE_POSITION_INDEPENDENT_CODE ON)
+        set(CMAKE_POSITION_INDEPENDENT_CODE {{ fpic }})
         """)
 
     def context(self):

--- a/conan/tools/cmake/toolchain.py
+++ b/conan/tools/cmake/toolchain.py
@@ -145,7 +145,7 @@ class FPicBlock(Block):
         if fpic is None:
             return None
         os_ = self._conanfile.settings.get_safe("os")
-        if os_ == "Windows":
+        if os_ and "Windows" in os_:
             self._conanfile.output.warn("Toolchain: Ignoring fPIC option defined for Windows")
             return None
         shared = self._conanfile.options.get_safe("shared")

--- a/conan/tools/cmake/toolchain.py
+++ b/conan/tools/cmake/toolchain.py
@@ -145,7 +145,7 @@ class FPicBlock(Block):
         if fpic is None:
             return None
         os_ = self._conanfile.settings.get_safe("os")
-        if os_ and "Windows" in os_:
+        if os_ == "Windows":
             self._conanfile.output.warn("Toolchain: Ignoring fPIC option defined for Windows")
             return None
         shared = self._conanfile.options.get_safe("shared")

--- a/conans/test/unittests/tools/cmake/test_cmaketoolchain.py
+++ b/conans/test/unittests/tools/cmake/test_cmaketoolchain.py
@@ -311,13 +311,13 @@ def conanfile_linux_fpic():
 
 def test_fpic_disabled(conanfile_linux_fpic):
     conanfile_linux_fpic.options.fPIC = False
-    toolchain = CMakeToolchain(conanfile_linux)
+    toolchain = CMakeToolchain(conanfile_linux_fpic)
     content = toolchain.content
     assert 'set(CMAKE_POSITION_INDEPENDENT_CODE OFF' in content
 
 
 def test_fpic_enabled(conanfile_linux_fpic):
     conanfile_linux_fpic.options.fPIC = True
-    toolchain = CMakeToolchain(conanfile_linux)
+    toolchain = CMakeToolchain(conanfile_linux_fpic)
     content = toolchain.content
     assert 'set(CMAKE_POSITION_INDEPENDENT_CODE ON' in content

--- a/conans/test/unittests/tools/cmake/test_cmaketoolchain.py
+++ b/conans/test/unittests/tools/cmake/test_cmaketoolchain.py
@@ -227,22 +227,74 @@ def test_no_fpic_when_not_an_option(conanfile_linux):
     assert 'set(CMAKE_POSITION_INDEPENDENT_CODE' not in content
 
 
-def test_no_fpic_when_shared(conanfile_linux):
-    conanfile_linux.options.shared = True
-    toolchain = CMakeToolchain(conanfile_linux)
+def conanfile_linux_shared():
+    c = ConanFile(Mock(), None)
+    c.settings = "os", "compiler", "build_type", "arch"
+    c.options.shared = [True, False]
+    c.default_options.shared = True
+    c.options.fPIC = [True, False]
+    c.default_options.fPIC = True
+    c.initialize(Settings({"os": ["Linux"],
+                           "compiler": {"gcc": {"version": ["11"], "cppstd": ["20"]}},
+                           "build_type": ["Release"],
+                           "arch": ["x86_64"]}), EnvValues())
+    c.settings.build_type = "Release"
+    c.settings.arch = "x86_64"
+    c.settings.compiler = "gcc"
+    c.settings.compiler.version = "11"
+    c.settings.compiler.cppstd = "20"
+    c.settings.os = "Linux"
+    c.conf = Conf()
+    c.folders.set_base_generators(".")
+    c._conan_node = Mock()
+    c._conan_node.dependencies = []
+    return c
+
+
+def test_no_fpic_when_shared(conanfile_linux_shared):
+    toolchain = CMakeToolchain(conanfile_linux_shared)
     content = toolchain.content
     assert 'set(CMAKE_POSITION_INDEPENDENT_CODE' not in content
 
 
-def test_fpic_disabled(conanfile_linux):
-    conanfile_linux.options.fPIC = False
+def test_fpic_when_not_shared(conanfile_linux_shared):
+    conanfile_linux_shared.options.shared = False
+    toolchain = CMakeToolchain(conanfile_linux_shared)
+    content = toolchain.content
+    assert 'set(CMAKE_POSITION_INDEPENDENT_CODE' in content
+
+
+def conanfile_linux_fpic():
+    c = ConanFile(Mock(), None)
+    c.settings = "os", "compiler", "build_type", "arch"
+    c.options.fPIC = [True, False]
+    c.default_options.fPIC = False
+    c.initialize(Settings({"os": ["Linux"],
+                           "compiler": {"gcc": {"version": ["11"], "cppstd": ["20"]}},
+                           "build_type": ["Release"],
+                           "arch": ["x86_64"]}), EnvValues())
+    c.settings.build_type = "Release"
+    c.settings.arch = "x86_64"
+    c.settings.compiler = "gcc"
+    c.settings.compiler.version = "11"
+    c.settings.compiler.cppstd = "20"
+    c.settings.os = "Linux"
+    c.conf = Conf()
+    c.folders.set_base_generators(".")
+    c._conan_node = Mock()
+    c._conan_node.dependencies = []
+    return c
+
+
+def test_fpic_disabled(conanfile_linux_fpic):
+    conanfile_linux_fpic.options.fPIC = False
     toolchain = CMakeToolchain(conanfile_linux)
     content = toolchain.content
     assert 'set(CMAKE_POSITION_INDEPENDENT_CODE OFF' in content
 
 
-def test_fpic_enabled(conanfile_linux):
-    conanfile_linux.options.fPIC = True
+def test_fpic_enabled(conanfile_linux_fpic):
+    conanfile_linux_fpic.options.fPIC = True
     toolchain = CMakeToolchain(conanfile_linux)
     content = toolchain.content
     assert 'set(CMAKE_POSITION_INDEPENDENT_CODE ON' in content

--- a/conans/test/unittests/tools/cmake/test_cmaketoolchain.py
+++ b/conans/test/unittests/tools/cmake/test_cmaketoolchain.py
@@ -246,6 +246,3 @@ def test_fpic_enabled(conanfile_linux):
     toolchain = CMakeToolchain(conanfile_linux)
     content = toolchain.content
     assert 'set(CMAKE_POSITION_INDEPENDENT_CODE ON' in content
-
-
-

--- a/conans/test/unittests/tools/cmake/test_cmaketoolchain.py
+++ b/conans/test/unittests/tools/cmake/test_cmaketoolchain.py
@@ -227,6 +227,7 @@ def test_no_fpic_when_not_an_option(conanfile_linux):
     assert 'set(CMAKE_POSITION_INDEPENDENT_CODE' not in content
 
 
+@pytest.fixture
 def conanfile_linux_shared():
     c = ConanFile(Mock(), None)
     c.settings = "os", "compiler", "build_type", "arch"
@@ -264,6 +265,7 @@ def test_fpic_when_not_shared(conanfile_linux_shared):
     assert 'set(CMAKE_POSITION_INDEPENDENT_CODE' in content
 
 
+@pytest.fixture
 def conanfile_linux_fpic():
     c = ConanFile(Mock(), None)
     c.settings = "os", "compiler", "build_type", "arch"

--- a/conans/test/unittests/tools/cmake/test_cmaketoolchain.py
+++ b/conans/test/unittests/tools/cmake/test_cmaketoolchain.py
@@ -228,21 +228,21 @@ def test_no_fpic_when_not_an_option(conanfile_linux):
 
 
 def test_no_fpic_when_shared(conanfile_linux):
-    conanfile.options.shared = True
+    conanfile_linux.options.shared = True
     toolchain = CMakeToolchain(conanfile_linux)
     content = toolchain.content
     assert 'set(CMAKE_POSITION_INDEPENDENT_CODE' not in content
 
 
 def test_fpic_disabled(conanfile_linux):
-    conanfile.options.fPIC = False
+    conanfile_linux.options.fPIC = False
     toolchain = CMakeToolchain(conanfile_linux)
     content = toolchain.content
     assert 'set(CMAKE_POSITION_INDEPENDENT_CODE OFF' in content
 
 
 def test_fpic_enabled(conanfile_linux):
-    conanfile.options.fPIC = True
+    conanfile_linux.options.fPIC = True
     toolchain = CMakeToolchain(conanfile_linux)
     content = toolchain.content
     assert 'set(CMAKE_POSITION_INDEPENDENT_CODE ON' in content

--- a/conans/test/unittests/tools/cmake/test_cmaketoolchain.py
+++ b/conans/test/unittests/tools/cmake/test_cmaketoolchain.py
@@ -22,6 +22,7 @@ def conanfile():
     c.settings.arch = "x86"
     c.settings.compiler = "gcc"
     c.settings.compiler.libcxx = "libstdc++"
+    c.settings.os = "Windows"
     c.conf = Conf()
     c.folders.set_base_generators(".")
     c._conan_node = Mock()
@@ -273,6 +274,7 @@ def conanfile_windows_fpic():
     c.settings.arch = "x86"
     c.settings.compiler = "gcc"
     c.settings.compiler.libcxx = "libstdc++"
+    c.settings.os = "Windows"
     c.conf = Conf()
     c.folders.set_base_generators(".")
     c._conan_node = Mock()

--- a/contributors.txt
+++ b/contributors.txt
@@ -24,3 +24,4 @@ Many thanks to all of them!
 - Ries, Uilian (uilianries@gmail.com, @uilianries)
 - Sechet, Olivier (osechet@gmail.com)
 - Sturm, Fabian (f@rtfs.org, @sturmf)
+- Williams, Jordan (jordan@jwillikers.com)


### PR DESCRIPTION
Changelog: Bugfix: The CMakeToolchain generator always sets fPIC enabled due to a typo where the actual parameter is not templated but instead hard-coded as `ON`.
Docs: Omit

- [X] Refer to the issue that supports this Pull Request.
- [X] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [X] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md). 
- [X] I've followed the PEP8 style guides for Python code.
- [X] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one.  (N/A)

<sup>**Note:** By default this PR will skip the slower tests and will use a limited set of python versions. Check [here](https://github.com/conan-io/conan/blob/develop/.github/PR_INCREASE_TESTING.md) how to increase the testing level by writing some tags in the current PR body text.</sup>

Fixes #9753