### PR TITLE
Feature/get safe options test package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -87,6 +87,10 @@ conan.conf
 #VScode folder
 .vscode
 
+#Python env
+env/
+test/
+
 #Generated certificate file
 cacert.pem
 

--- a/conans/model/options.py
+++ b/conans/model/options.py
@@ -156,6 +156,9 @@ class PackageOptionValues(object):
     def serialize(self):
         return self.items()
 
+    def get_safe(self, field, default=None):
+        return self._dict.get(field, default)
+
     @property
     def sha(self):
         result = []

--- a/conans/test/unittests/model/options_test.py
+++ b/conans/test/unittests/model/options_test.py
@@ -240,6 +240,24 @@ Poco:deps_bundled=True""")
         self.assertEqual("None", self.sut.get_safe("path", True))
         self.assertEqual(True, self.sut.get_safe("unknown", True))
 
+    def test_get_safe_package_options(self):
+        boost_values = PackageOptionValues()
+        boost_values.add_option("static", True)
+        boost_values.add_option("optimized", 3)
+        boost_values.add_option("path", "NOTDEF")
+
+        self.assertEqual(True, boost_values.get_safe("static"))
+        self.assertEqual(3, boost_values.get_safe("optimized"))
+        self.assertEqual("NOTDEF", boost_values.get_safe("path"))
+        self.assertEqual(None, boost_values.get_safe("unknown"))
+        boost_values.static = False
+        boost_values.path = "None"
+        self.assertEqual(False, boost_values.get_safe("static"))
+        self.assertEqual("None", boost_values.get_safe("path"))
+        self.assertEqual(False, boost_values.get_safe("static", True))
+        self.assertEqual("None", boost_values.get_safe("path", True))
+        self.assertEqual(True, boost_values.get_safe("unknown", True))
+
 
 class OptionsValuesPropagationUpstreamNone(unittest.TestCase):
 


### PR DESCRIPTION
Changelog: Bugfix: Adding `get_safe` to `self.options` object
Docs: skip

closes #7548

- [x] Refer to the issue that supports this Pull Request.
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.

<sup>**Note:** By default this PR will skip the slower tests and will use a limited set of python versions. Check [here](https://github.com/conan-io/conan/blob/develop/.github/PR_INCREASE_TESTING.md) how to increase the testing level by writing some tags in the current PR body text.</sup>
