### PR TITLE
Bugfix: Do not force new authentication when a token is expired, it might not be needed.

### DIFF
--- a/conans/client/rest/auth_manager.py
+++ b/conans/client/rest/auth_manager.py
@@ -62,7 +62,7 @@ class ConanApiAuthManager(object):
                 # (will be anonymous call but exporting who is calling)
                 logger.info("Token expired or not valid, cleaning the saved token and retrying")
                 self._clear_user_tokens_in_db(user, remote)
-                return self._retry_with_new_token(user, remote, method_name, *args, **kwargs)
+                return self.call_rest_api_method(remote, method_name, *args, **kwargs)
 
     def _retry_with_new_token(self, user, remote, method_name, *args, **kwargs):
         """Try LOGIN_RETRIES to obtain a password from user input for which

--- a/conans/test/integration/remote/auth_test.py
+++ b/conans/test/integration/remote/auth_test.py
@@ -1,4 +1,5 @@
 import os
+import textwrap
 import unittest
 
 from requests.models import Response
@@ -7,6 +8,8 @@ from conans.client import tools
 from conans.errors import AuthenticationException
 from conans.model.ref import ConanFileReference
 from conans.paths import CONANFILE
+from conans.test.assets.genconanfile import GenConanfile
+from conans.test.utils.test_files import temp_folder
 from conans.test.utils.tools import TestClient
 from conans.test.utils.tools import TestServer
 from conans.util.files import save
@@ -168,3 +171,40 @@ class AuthenticationTest(unittest.TestCase):
                       client.out)
         client.run("search pkg -r=default")
         self.assertIn("There are no packages matching the 'pkg' pattern", client.out)
+
+
+def test_token_expired():
+    server_folder = temp_folder()
+    server_conf = textwrap.dedent("""
+       [server]
+       jwt_expire_minutes: 1
+       authorize_timeout: 0
+       disk_authorize_timeout: 0
+       disk_storage_path: ./data
+       updown_secret: 12345
+       jwt_secret: mysecret
+       port: 12345
+       [read_permissions]
+       */*@*/*: *
+       [write_permissions]
+       */*@*/*: admin
+       """)
+    save(os.path.join(server_folder, ".conan_server", "server.conf"),
+         server_conf)
+    server = TestServer(base_path=server_folder, users={"admin": "password"})
+
+    c = TestClient(servers={"default": server}, users={"default": [("admin", "password")]})
+    c.save({"conanfile.py": GenConanfile()})
+    c.run("create . pkg/0.1@user/stable")
+    c.run("upload * -r=default --all -c")
+    print(c.out)
+    print(c.cache.localdb.get_login(server.fake_url))
+
+    import time
+    time.sleep(61)
+    c.users = {}
+    c.run("config set general.non_interactive=1")
+    c.run("remove * -f")
+    c.run("install pkg/0.1@user/stable")
+    print(c.out)
+    print(c.cache.localdb.get_login(server.fake_url))


### PR DESCRIPTION
Changelog: Bugfix: Do not force new authentication when a token is expired, it might not be needed.
Docs: Omit

This is exploratory at the moment, lets see what could break

#tags: slow
#revisions: 1

Close https://github.com/conan-io/conan/issues/9730