### PR TITLE
rename ConanFileInterface.new_cpp_info

### DIFF
--- a/conan/tools/cmake/cmakedeps/cmakedeps.py
+++ b/conan/tools/cmake/cmakedeps/cmakedeps.py
@@ -81,7 +81,7 @@ class CMakeDeps(object):
             if dep.is_build_context and dep.ref.name not in self.build_context_activated:
                 continue
 
-            cmake_find_mode = dep.new_cpp_info.get_property("cmake_find_mode", "CMakeDeps")
+            cmake_find_mode = dep.cpp_info.get_property("cmake_find_mode", "CMakeDeps")
             cmake_find_mode = cmake_find_mode or FIND_MODE_CONFIG
             cmake_find_mode = cmake_find_mode.lower()
             # Skip from the requirement

--- a/conan/tools/cmake/cmakedeps/templates/__init__.py
+++ b/conan/tools/cmake/cmakedeps/templates/__init__.py
@@ -98,8 +98,6 @@ class CMakeDepsFileTemplate(object):
                 return ret
 
         ret = req.cpp_info.get_property("cmake_target_name", "CMakeDeps")
-        if not ret:
-            ret = req.cpp_info.get_name("cmake_find_package_multi", default_name=False)
         return ret or req.ref.name
 
     def get_component_alias(self, req, comp_name):
@@ -111,11 +109,8 @@ class CMakeDepsFileTemplate(object):
                                  "package requirement".format(name=req.ref.name, cname=comp_name))
         if self.find_module_mode:
             ret = req.cpp_info.components[comp_name].get_property("cmake_module_target_name",
-                                                                      "CMakeDeps")
+                                                                  "CMakeDeps")
             if ret:
                 return ret
         ret = req.cpp_info.components[comp_name].get_property("cmake_target_name", "CMakeDeps")
-        if not ret:
-            ret = req.cpp_info.components[comp_name].get_name("cmake_find_package_multi",
-                                                              default_name=False)
         return ret or comp_name

--- a/conan/tools/cmake/cmakedeps/templates/__init__.py
+++ b/conan/tools/cmake/cmakedeps/templates/__init__.py
@@ -84,37 +84,37 @@ class CMakeDepsFileTemplate(object):
 
     def get_target_namespace(self, req):
         if self.find_module_mode:
-            ret = req.new_cpp_info.get_property("cmake_module_target_namespace", "CMakeDeps")
+            ret = req.cpp_info.get_property("cmake_module_target_namespace", "CMakeDeps")
             if ret:
                 return ret
 
-        ret = req.new_cpp_info.get_property("cmake_target_namespace", "CMakeDeps")
+        ret = req.cpp_info.get_property("cmake_target_namespace", "CMakeDeps")
         return ret or self.get_global_target_name(req)
 
     def get_global_target_name(self, req):
         if self.find_module_mode:
-            ret = req.new_cpp_info.get_property("cmake_module_target_name", "CMakeDeps")
+            ret = req.cpp_info.get_property("cmake_module_target_name", "CMakeDeps")
             if ret:
                 return ret
 
-        ret = req.new_cpp_info.get_property("cmake_target_name", "CMakeDeps")
+        ret = req.cpp_info.get_property("cmake_target_name", "CMakeDeps")
         if not ret:
             ret = req.cpp_info.get_name("cmake_find_package_multi", default_name=False)
         return ret or req.ref.name
 
     def get_component_alias(self, req, comp_name):
-        if comp_name not in req.new_cpp_info.components:
+        if comp_name not in req.cpp_info.components:
             # foo::foo might be referencing the root cppinfo
             if req.ref.name == comp_name:
                 return self.get_target_namespace(req)
             raise ConanException("Component '{name}::{cname}' not found in '{name}' "
                                  "package requirement".format(name=req.ref.name, cname=comp_name))
         if self.find_module_mode:
-            ret = req.new_cpp_info.components[comp_name].get_property("cmake_module_target_name",
+            ret = req.cpp_info.components[comp_name].get_property("cmake_module_target_name",
                                                                       "CMakeDeps")
             if ret:
                 return ret
-        ret = req.new_cpp_info.components[comp_name].get_property("cmake_target_name", "CMakeDeps")
+        ret = req.cpp_info.components[comp_name].get_property("cmake_target_name", "CMakeDeps")
         if not ret:
             ret = req.cpp_info.components[comp_name].get_name("cmake_find_package_multi",
                                                               default_name=False)

--- a/conan/tools/cmake/cmakedeps/templates/target_configuration.py
+++ b/conan/tools/cmake/cmakedeps/templates/target_configuration.py
@@ -148,7 +148,7 @@ class TargetConfigurationTemplate(CMakeDepsFileTemplate):
     def get_required_components_names(self):
         """Returns a list of component_name"""
         ret = []
-        sorted_comps = self.conanfile.new_cpp_info.get_sorted_components()
+        sorted_comps = self.conanfile.cpp_info.get_sorted_components()
         for comp_name, comp in sorted_comps.items():
             ret.append(self.get_component_alias(self.conanfile, comp_name))
         ret.reverse()
@@ -164,8 +164,8 @@ class TargetConfigurationTemplate(CMakeDepsFileTemplate):
         # Declared cppinfo.requires or .components[].requires
         visible_host = self.conanfile.dependencies.filter({"build": False, "visible": True})
         visible_host_direct = visible_host.filter({"direct": True})
-        if self.conanfile.new_cpp_info.required_components:
-            for dep_name, component_name in self.conanfile.new_cpp_info.required_components:
+        if self.conanfile.cpp_info.required_components:
+            for dep_name, component_name in self.conanfile.cpp_info.required_components:
                 if not dep_name:
                     # Internal dep (no another component)
                     req = self.conanfile

--- a/conan/tools/cmake/cmakedeps/templates/target_data.py
+++ b/conan/tools/cmake/cmakedeps/templates/target_data.py
@@ -106,7 +106,7 @@ class ConfigDataTemplate(CMakeDepsFileTemplate):
         return ret
 
     def get_global_cpp_cmake(self):
-        global_cppinfo = self.conanfile.new_cpp_info.copy()
+        global_cppinfo = self.conanfile.cpp_info.copy()
         global_cppinfo.aggregate_components()
         pfolder_var_name = "{}_PACKAGE_FOLDER{}".format(self.pkg_name, self.config_suffix)
         return DepsCppCmake(global_cppinfo, pfolder_var_name)
@@ -114,7 +114,7 @@ class ConfigDataTemplate(CMakeDepsFileTemplate):
     def get_required_components_cpp(self):
         """Returns a list of (component_name, DepsCppCMake)"""
         ret = []
-        sorted_comps = self.conanfile.new_cpp_info.get_sorted_components()
+        sorted_comps = self.conanfile.cpp_info.get_sorted_components()
 
         direct_visible_host = self.conanfile.dependencies.filter({"build": False, "visible": True,
                                                                   "direct": True})
@@ -144,8 +144,8 @@ class ConfigDataTemplate(CMakeDepsFileTemplate):
         ret = []
         direct_host = self.conanfile.dependencies.filter({"build": False, "visible": True,
                                                           "direct": True})
-        if self.conanfile.new_cpp_info.required_components:
-            for dep_name, _ in self.conanfile.new_cpp_info.required_components:
+        if self.conanfile.cpp_info.required_components:
+            for dep_name, _ in self.conanfile.cpp_info.required_components:
                 if dep_name and dep_name not in ret:  # External dep
                     req = direct_host[dep_name]
                     ret.append(get_file_name(req, self.find_module_mode))

--- a/conan/tools/cmake/toolchain.py
+++ b/conan/tools/cmake/toolchain.py
@@ -430,7 +430,7 @@ class FindConfigFiles(Block):
         # Read the buildirs
         build_paths = []
         for req in host_req:
-            cppinfo = req.new_cpp_info.copy()
+            cppinfo = req.cpp_info.copy()
             cppinfo.aggregate_components()
             build_paths.extend([os.path.join(req.package_folder,
                                        p.replace('\\', '/').replace('$', '\\$').replace('"', '\\"'))

--- a/conan/tools/cmake/utils.py
+++ b/conan/tools/cmake/utils.py
@@ -13,7 +13,5 @@ def get_file_name(conanfile, find_module_mode=False):
         if ret:
             return ret
     ret = conanfile.cpp_info.get_property("cmake_file_name", "CMakeDeps")
-    if not ret:
-        ret = conanfile.cpp_info.get_filename("cmake_find_package_multi", default_name=False)
     return ret or conanfile.ref.name
 

--- a/conan/tools/cmake/utils.py
+++ b/conan/tools/cmake/utils.py
@@ -9,10 +9,10 @@ def get_file_name(conanfile, find_module_mode=False):
     # This is used by the CMakeToolchain to adjust the XXX_DIR variables and the CMakeDeps. Both
     # to know the file name that will have the XXX-config.cmake files.
     if find_module_mode:
-        ret = conanfile.new_cpp_info.get_property("cmake_module_file_name", "CMakeDeps")
+        ret = conanfile.cpp_info.get_property("cmake_module_file_name", "CMakeDeps")
         if ret:
             return ret
-    ret = conanfile.new_cpp_info.get_property("cmake_file_name", "CMakeDeps")
+    ret = conanfile.cpp_info.get_property("cmake_file_name", "CMakeDeps")
     if not ret:
         ret = conanfile.cpp_info.get_filename("cmake_find_package_multi", default_name=False)
     return ret or conanfile.ref.name

--- a/conan/tools/env/virtualbuildenv.py
+++ b/conan/tools/env/virtualbuildenv.py
@@ -54,9 +54,7 @@ class VirtualBuildEnv:
                 os_name = self._conanfile.settings_build.get_safe("os")
             else:
                 os_name = self._conanfile.settings.get_safe("os")
-            build_env.compose_env(runenv_from_cpp_info(self._conanfile,
-                                                       build_require.cpp_info,
-                                                       os_name))
+            build_env.compose_env(runenv_from_cpp_info(self._conanfile, build_require, os_name))
 
         # Requires in host context can also bring some direct buildenv_info
         host_requires = self._conanfile.dependencies.host.topological_sort

--- a/conan/tools/env/virtualrunenv.py
+++ b/conan/tools/env/virtualrunenv.py
@@ -1,22 +1,36 @@
+import os
+
 from conan.tools.env import Environment
 
 
-def runenv_from_cpp_info(conanfile, cpp_info, os_name):
+def runenv_from_cpp_info(conanfile, dep, os_name):
     """ return an Environment deducing the runtime information from a cpp_info
     """
+    cpp_info = dep.cpp_info
+    cpp_info.aggregate_components()
+    pkg_folder = dep.package_folder
     dyn_runenv = Environment(conanfile)
     if cpp_info is None:  # This happens when the dependency is a private one = BINARY_SKIP
         return dyn_runenv
-    if cpp_info.bin_paths:  # cpp_info.exes is not defined yet
-        dyn_runenv.prepend_path("PATH", cpp_info.bin_paths)
-    # If it is a build_require this will be the build-os, otherwise it will be the host-os
 
+    def _handle_paths(paths):
+        result = []
+        for p in paths:
+            abs_path = os.path.join(pkg_folder, p)
+            if os.path.exists(abs_path):
+                result.append(abs_path)
+        return result
+
+    if cpp_info.bindirs:  # cpp_info.exes is not defined yet
+        dyn_runenv.prepend_path("PATH", _handle_paths(cpp_info.bindirs))
+    # If it is a build_require this will be the build-os, otherwise it will be the host-os
     if os_name and not os_name.startswith("Windows"):
-        if cpp_info.lib_paths:
-            dyn_runenv.prepend_path("LD_LIBRARY_PATH", cpp_info.lib_paths)
-            dyn_runenv.prepend_path("DYLD_LIBRARY_PATH", cpp_info.lib_paths)
-        if cpp_info.framework_paths:
-            dyn_runenv.prepend_path("DYLD_FRAMEWORK_PATH", cpp_info.framework_paths)
+        if cpp_info.libdirs:
+            libdirs = _handle_paths(cpp_info.libdirs)
+            dyn_runenv.prepend_path("LD_LIBRARY_PATH", libdirs)
+            dyn_runenv.prepend_path("DYLD_LIBRARY_PATH", libdirs)
+        if cpp_info.frameworkdirs:
+            dyn_runenv.prepend_path("DYLD_FRAMEWORK_PATH", _handle_paths(cpp_info.frameworkdirs))
     return dyn_runenv
 
 
@@ -58,7 +72,8 @@ class VirtualRunEnv:
         for _, dep in list(host_req.items()) + list(test_req.items()):
             if dep.runenv_info:
                 runenv.compose_env(dep.runenv_info)
-            runenv.compose_env(runenv_from_cpp_info(self._conanfile, dep.cpp_info, self._conanfile.settings.get_safe("os")))
+            runenv.compose_env(runenv_from_cpp_info(self._conanfile, dep,
+                                                    self._conanfile.settings.get_safe("os")))
 
         return runenv
 

--- a/conan/tools/gnu/autotoolsdeps.py
+++ b/conan/tools/gnu/autotoolsdeps.py
@@ -13,7 +13,7 @@ class AutotoolsDeps:
     def _get_cpp_info(self):
         ret = NewCppInfo()
         for dep in self._conanfile.dependencies.host.values():
-            dep_cppinfo = dep.new_cpp_info.copy()
+            dep_cppinfo = dep.cpp_info.copy()
             dep_cppinfo.set_relative_base_folder(dep.package_folder)
             # In case we have components, aggregate them, we do not support isolated
             # "targets" with autotools

--- a/conan/tools/gnu/pkgconfigdeps.py
+++ b/conan/tools/gnu/pkgconfigdeps.py
@@ -28,18 +28,18 @@ def _concat_if_not_empty(groups):
 
 
 def get_target_namespace(req):
-    ret = req.new_cpp_info.get_property("pkg_config_name", "PkgConfigDeps")
+    ret = req.cpp_info.get_property("pkg_config_name", "PkgConfigDeps")
     return ret or req.ref.name
 
 
 def get_component_alias(req, comp_name):
-    if comp_name not in req.new_cpp_info.components:
+    if comp_name not in req.cpp_info.components:
         # foo::foo might be referencing the root cppinfo
         if req.ref.name == comp_name:
             return get_target_namespace(req)
         raise ConanException("Component '{name}::{cname}' not found in '{name}' "
                              "package requirement".format(name=req.ref.name, cname=comp_name))
-    ret = req.new_cpp_info.components[comp_name].get_property("pkg_config_name", "PkgConfigDeps")
+    ret = req.cpp_info.components[comp_name].get_property("pkg_config_name", "PkgConfigDeps")
     return ret or comp_name
 
 
@@ -63,7 +63,7 @@ class PkgConfigDeps(object):
 
     def _get_components(self, dep):
         ret = []
-        for comp_name, comp in dep.new_cpp_info.get_sorted_components().items():
+        for comp_name, comp in dep.cpp_info.get_sorted_components().items():
             comp_genname = get_component_alias(dep, comp_name)
             comp_requires_gennames = []
             for require in comp.requires:
@@ -74,7 +74,7 @@ class PkgConfigDeps(object):
     def _get_public_require_deps(self, dep):
         public_comp_deps = []
 
-        for require in dep.new_cpp_info.requires:
+        for require in dep.cpp_info.requires:
             if "::" in require:  # Points to a component of a different package
                 pkg, cmp_name = require.split("::")
                 req = dep.dependencies.direct_host[pkg]
@@ -92,7 +92,7 @@ class PkgConfigDeps(object):
         for require, dep in host_req.items():
             pkg_genname = get_target_namespace(dep)
 
-            if dep.new_cpp_info.has_components:
+            if dep.cpp_info.has_components:
                 components = self._get_components(dep)
                 # Adding one *.pc file per component, e.g., pkg-comp1.pc
                 for comp_genname, comp_cpp_info, comp_requires_gennames in components:
@@ -110,7 +110,7 @@ class PkgConfigDeps(object):
                                                                                dep,
                                                                                pkg_requires)
             else:
-                ret["%s.pc" % pkg_genname] = self._pc_file_content(pkg_genname, dep.new_cpp_info,
+                ret["%s.pc" % pkg_genname] = self._pc_file_content(pkg_genname, dep.cpp_info,
                                                                    self._get_public_require_deps(dep),
                                                                    dep.package_folder,
                                                                    dep.ref.version)

--- a/conan/tools/google/bazeldeps.py
+++ b/conan/tools/google/bazeldeps.py
@@ -65,15 +65,15 @@ class BazelDeps(object):
 
         """)
 
-        dependency.new_cpp_info.aggregate_components()
+        dependency.cpp_info.aggregate_components()
 
-        if not dependency.new_cpp_info.libs and not dependency.new_cpp_info.includedirs:
+        if not dependency.cpp_info.libs and not dependency.cpp_info.includedirs:
             return None
 
         headers = []
         includes = []
 
-        for path in dependency.new_cpp_info.includedirs:
+        for path in dependency.cpp_info.includedirs:
             headers.append('"{}/**"'.format(path))
             includes.append('"{}"'.format(path))
 
@@ -81,18 +81,18 @@ class BazelDeps(object):
         includes = ', '.join(includes)
 
         defines = ('"{}"'.format(define.replace('"', "'"))
-                   for define in dependency.new_cpp_info.defines)
+                   for define in dependency.cpp_info.defines)
         defines = ', '.join(defines)
 
         linkopts = []
-        for linkopt in dependency.new_cpp_info.system_libs:
+        for linkopt in dependency.cpp_info.system_libs:
             linkopts.append('"-l{}"'.format(linkopt))
         linkopts = ', '.join(linkopts)
 
         context = {
             "name": dependency.ref.name,
-            "libs": dependency.new_cpp_info.libs,
-            "libdir": dependency.new_cpp_info.libdirs[0],
+            "libs": dependency.cpp_info.libs,
+            "libdir": dependency.cpp_info.libdirs[0],
             "headers": headers,
             "includes": includes,
             "defines": defines,

--- a/conan/tools/microsoft/msbuilddeps.py
+++ b/conan/tools/microsoft/msbuilddeps.py
@@ -283,7 +283,7 @@ class MSBuildDeps(object):
         for dep in host_req + test_req:
             dep_name = dep.ref.name
             dep_name = dep_name.replace(".", "_")
-            cpp_info = dep.new_cpp_info.copy()
+            cpp_info = dep.cpp_info.copy()
             cpp_info.aggregate_components()
             public_deps = [d.ref.name.replace(".", "_")
                            for r, d in dep.dependencies.direct_host.items() if r.visible]
@@ -302,7 +302,7 @@ class MSBuildDeps(object):
         for dep in build_req:
             dep_name = dep.ref.name
             dep_name = dep_name.replace(".", "_") + "_build"
-            cpp_info = dep.new_cpp_info.copy()
+            cpp_info = dep.cpp_info.copy()
             cpp_info.aggregate_components()
             public_deps = [d.ref.name.replace(".", "_")
                            for r, d in dep.dependencies.direct_host.items() if r.visible]

--- a/conans/model/conanfile_interface.py
+++ b/conans/model/conanfile_interface.py
@@ -47,10 +47,6 @@ class ConanFileInterface:
 
     @property
     def cpp_info(self):
-        return self._conanfile.cpp_info
-
-    @property
-    def new_cpp_info(self):
         return self._conanfile.new_cpp_info
 
     @property

--- a/conans/test/unittests/tools/cmake/test_cmakedeps.py
+++ b/conans/test/unittests/tools/cmake/test_cmakedeps.py
@@ -1,5 +1,4 @@
 import mock
-import pytest
 from mock import Mock
 
 from conan.tools.cmake import CMakeDeps
@@ -11,8 +10,7 @@ from conans.model.env_info import EnvValues
 from conans.model.ref import ConanFileReference
 
 
-@pytest.mark.parametrize("using_properties", [True, False])
-def test_cpp_info_name_cmakedeps(using_properties):
+def test_cpp_info_name_cmakedeps():
     conanfile = ConanFile(Mock(), None)
     conanfile._conan_node = Mock()
     conanfile._conan_node.context = "host"
@@ -25,12 +23,8 @@ def test_cpp_info_name_cmakedeps(using_properties):
     conanfile.settings.arch = "x86"
 
     cpp_info = CppInfo("mypkg", "dummy_root_folder1")
-    if using_properties:
-        cpp_info.set_property("cmake_target_name", "MySuperPkg1")
-        cpp_info.set_property("cmake_file_name", "ComplexFileName1")
-    else:
-        cpp_info.names["cmake_find_package_multi"] = "MySuperPkg1"
-        cpp_info.filenames["cmake_find_package_multi"] = "ComplexFileName1"
+    cpp_info.set_property("cmake_target_name", "MySuperPkg1")
+    cpp_info.set_property("cmake_file_name", "ComplexFileName1")
 
     conanfile_dep = ConanFile(Mock(), None)
     conanfile_dep.cpp_info = cpp_info
@@ -51,8 +45,7 @@ def test_cpp_info_name_cmakedeps(using_properties):
                in files["ComplexFileName1-release-x86-data.cmake"]
 
 
-@pytest.mark.parametrize("using_properties", [True, False])
-def test_cpp_info_name_cmakedeps_components(using_properties):
+def test_cpp_info_name_cmakedeps_components():
     conanfile = ConanFile(Mock(), None)
     conanfile._conan_node = Mock()
     conanfile._conan_node.context = "host"
@@ -65,14 +58,9 @@ def test_cpp_info_name_cmakedeps_components(using_properties):
     conanfile.settings.arch = "x64"
 
     cpp_info = CppInfo("mypkg", "dummy_root_folder1")
-    if using_properties:
-        cpp_info.set_property("cmake_target_name", "GlobakPkgName1")
-        cpp_info.components["mycomp"].set_property("cmake_target_name", "MySuperPkg1")
-        cpp_info.set_property("cmake_file_name", "ComplexFileName1")
-    else:
-        cpp_info.names["cmake_find_package_multi"] = "GlobakPkgName1"
-        cpp_info.components["mycomp"].names["cmake_find_package_multi"] = "MySuperPkg1"
-        cpp_info.filenames["cmake_find_package_multi"] = "ComplexFileName1"
+    cpp_info.set_property("cmake_target_name", "GlobakPkgName1")
+    cpp_info.components["mycomp"].set_property("cmake_target_name", "MySuperPkg1")
+    cpp_info.set_property("cmake_file_name", "ComplexFileName1")
 
     conanfile_dep = ConanFile(Mock(), None)
     conanfile_dep.cpp_info = cpp_info


### PR DESCRIPTION
Changelog: Fix: Rename ``ConanFileInterface.new_cpp_info`` to ``ConanFileInterface.cpp_info`` (being it a ``NewCppInfo`` object). The `ConanFileInterface` object is only used when accessing `self.dependencies` in a conanfile, so we can make sure that the new develop generators use the final `cpp_info` name.
Docs: https://github.com/conan-io/docs/pull/2280

#tags: slow