### PR TITLE
Fix unsafe check of the compiler in the CMakeToolchain generator

### DIFF
--- a/conan/tools/cmake/toolchain.py
+++ b/conan/tools/cmake/toolchain.py
@@ -617,7 +617,7 @@ class GenericSystemBlock(Block):
         compiler = self._conanfile.settings.get_safe("compiler")
         # TODO: Check if really necessary now that conanvcvars is used
         if (generator is not None and "Ninja" in generator
-                and ("Visual" in compiler or compiler == "msvc")):
+                and (compiler is not None and "Visual" in compiler or compiler == "msvc")):
             compiler = "cl"
         else:
             compiler = None  # compiler defined by default


### PR DESCRIPTION
Changelog: Bugfix: Avoid crash in ``CMakeToolchain`` for custom generator when compiler is not defined.
Docs: Omit

The compiler variable here must not be a NoneType object to use `in`.
This will result in an error when attempting to package a header-only library.
This commit fixes this check.
It first verifies the compiler is not None before checking it.

- [X] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [X] I've followed the PEP8 style guides for Python code.

<sup>**Note:** By default this PR will skip the slower tests and will use a limited set of python versions. Check [here](https://github.com/conan-io/conan/blob/develop/.github/PR_INCREASE_TESTING.md) how to increase the testing level by writing some tags in the current PR body text.</sup>
