### PR TITLE
raise error in export-pkg if package_id is Invalid

### DIFF
--- a/conans/client/cmd/export_pkg.py
+++ b/conans/client/cmd/export_pkg.py
@@ -2,10 +2,10 @@ import os
 
 from conans.client import packager
 from conans.client.conanfile.package import run_package_method
-from conans.client.graph.graph import BINARY_SKIP
+from conans.client.graph.graph import BINARY_SKIP, BINARY_INVALID
 from conans.client.graph.graph_manager import load_deps_info
 from conans.client.installer import add_env_conaninfo
-from conans.errors import ConanException
+from conans.errors import ConanException, ConanInvalidConfiguration
 from conans.model.ref import PackageReference
 
 
@@ -29,6 +29,9 @@ def export_pkg(app, recorder, full_ref, source_folder, build_folder, package_fol
     # which is the exported pkg
     nodes = deps_graph.root.neighbors()
     pkg_node = nodes[0]
+    if pkg_node.binary == BINARY_INVALID:
+        msg = "{}: Invalid ID: {}".format(ref, pkg_node.conanfile.info.invalid)
+        raise ConanInvalidConfiguration(msg)
     conanfile = pkg_node.conanfile
 
     def _init_conanfile_infos():

--- a/conans/test/integration/package_id/test_validate.py
+++ b/conans/test/integration/package_id/test_validate.py
@@ -247,3 +247,18 @@ class TestValidate(unittest.TestCase):
                       "exist for this configuration):", client.out)
         self.assertIn("dep/0.1: Invalid ID: Windows not supported", client.out)
         self.assertIn("pkg/0.1: Invalid ID: Invalid transitive dependencies", client.out)
+
+    def test_validate_export(self):
+        # https://github.com/conan-io/conan/issues/9797
+        c = TestClient()
+        conanfile = textwrap.dedent("""
+            from conans import ConanFile
+            from conans.errors import ConanInvalidConfiguration
+
+            class TestConan(ConanFile):
+                def validate(self):
+                    raise ConanInvalidConfiguration("never ever")
+            """)
+        c.save({"conanfile.py": conanfile})
+        c.run("export-pkg . test/1.0@", assert_error=True)
+        assert "Invalid ID: never ever" in c.out


### PR DESCRIPTION
Changelog: Bugfix: ``conan export-pkg`` now raises an error (ConanInvalidConfiguration exception) if the ``validate()`` method raise that error and results in an invalid `package_id`.
Docs: Omit

Close https://github.com/conan-io/conan/issues/9797