### PR TITLE
improving vcvars install_path and removed legacy intel support in VCVars

### DIFF
--- a/conan/tools/microsoft/visual.py
+++ b/conan/tools/microsoft/visual.py
@@ -44,7 +44,7 @@ class VCVars:
             minor = version_components[1]
             # The equivalent of compiler 19.26 is toolset 14.26
             vcvars_ver = "14.{}".format(minor)
-        vs_install_path = conanfile.conf["tools.microsoft.msbuild:install_path"]
+        vs_install_path = conanfile.conf["tools.microsoft.msbuild:installation_path"]
         vcvars = vcvars_command(vs_version, architecture=vcvarsarch, platform_type=None,
                                 winsdk_version=None, vcvars_ver=vcvars_ver,
                                 vs_install_path=vs_install_path)

--- a/conans/model/conf.py
+++ b/conans/model/conf.py
@@ -30,7 +30,7 @@ DEFAULT_CONFIGURATION = {
                                          "'Quiet', 'Minimal', 'Normal', 'Detailed', 'Diagnostic'",
     "tools.microsoft.msbuild:max_cpu_count": "Argument for the /m (/maxCpuCount) when running MSBuild",
     "tools.microsoft.msbuild:vs_version": "Defines the IDE version when using the new msvc compiler",
-    "tools.microsoft.msbuild:installation_path": "VS install path, to avoid auto-detect via vswhere, like C:\Program Files (x86)\Microsoft Visual Studio\2019\Community",
+    "tools.microsoft.msbuild:installation_path": "VS install path, to avoid auto-detect via vswhere, like C:/Program Files (x86)/Microsoft Visual Studio/2019/Community",
     "tools.microsoft.msbuilddeps:exclude_code_analysis": "Suppress MSBuild code analysis for patterns",
     "tools.microsoft.msbuildtoolchain:compile_options": "Dictionary with MSBuild compiler options",
     "tools.ninja:jobs": "Argument for the --jobs parameter when running Ninja generator",

--- a/conans/model/conf.py
+++ b/conans/model/conf.py
@@ -30,7 +30,7 @@ DEFAULT_CONFIGURATION = {
                                          "'Quiet', 'Minimal', 'Normal', 'Detailed', 'Diagnostic'",
     "tools.microsoft.msbuild:max_cpu_count": "Argument for the /m (/maxCpuCount) when running MSBuild",
     "tools.microsoft.msbuild:vs_version": "Defines the IDE version when using the new msvc compiler",
-    "tools.microsoft.msbuild:install_path": "VS install path, to avoid auto-detect via vswhere",
+    "tools.microsoft.msbuild:installation_path": "VS install path, to avoid auto-detect via vswhere",
     "tools.microsoft.msbuilddeps:exclude_code_analysis": "Suppress MSBuild code analysis for patterns",
     "tools.microsoft.msbuildtoolchain:compile_options": "Dictionary with MSBuild compiler options",
     "tools.ninja:jobs": "Argument for the --jobs parameter when running Ninja generator",

--- a/conans/model/conf.py
+++ b/conans/model/conf.py
@@ -30,6 +30,7 @@ DEFAULT_CONFIGURATION = {
                                          "'Quiet', 'Minimal', 'Normal', 'Detailed', 'Diagnostic'",
     "tools.microsoft.msbuild:max_cpu_count": "Argument for the /m (/maxCpuCount) when running MSBuild",
     "tools.microsoft.msbuild:vs_version": "Defines the IDE version when using the new msvc compiler",
+    "tools.microsoft.msbuild:install_path": "VS install path, to avoid auto-detect via vswhere",
     "tools.microsoft.msbuilddeps:exclude_code_analysis": "Suppress MSBuild code analysis for patterns",
     "tools.microsoft.msbuildtoolchain:compile_options": "Dictionary with MSBuild compiler options",
     "tools.ninja:jobs": "Argument for the --jobs parameter when running Ninja generator",

--- a/conans/test/unittests/tools/microsoft/test_msbuild.py
+++ b/conans/test/unittests/tools/microsoft/test_msbuild.py
@@ -115,7 +115,8 @@ def test_resource_compile():
     conanfile = ConanFile(Mock(), None)
     conanfile.folders.set_base_generators(test_folder)
     conanfile.install_folder = test_folder
-    conanfile.conf = ConfDefinition()
+    conanfile.conf = Conf()
+    conanfile.conf["tools.microsoft.msbuild:installation_path"] = "."
     conanfile.settings = "os", "compiler", "build_type", "arch"
     conanfile.settings_build = settings
     conanfile.initialize(settings, EnvValues())
@@ -129,8 +130,7 @@ def test_resource_compile():
     msbuild = MSBuildToolchain(conanfile)
     msbuild.preprocessor_definitions["MYTEST"] = "MYVALUE"
     props_file = os.path.join(test_folder, 'conantoolchain_release_x64.props')
-    with mock.patch("conan.tools.microsoft.visual.vcvars_path", mock.MagicMock(return_value=".")):
-        msbuild.generate()
+    msbuild.generate()
     expected = """
         <ResourceCompile>
           <PreprocessorDefinitions>


### PR DESCRIPTION
Changelog: Feature: Define new ``conf["tools.microsoft.msbuild:install_path"]`` for the MSBuild toolchain and remove generation of intel_vars files by ``VCVars``.
Docs: https://github.com/conan-io/docs/pull/2281
