### PR TITLE
Fix pkgconfig tests for Windows

### DIFF
--- a/conans/test/conftest.py
+++ b/conans/test/conftest.py
@@ -84,12 +84,6 @@ tools_locations = {
         "exe": "mingw32-make",
         "system": {"path": {'Windows': "C:/msys64/mingw32/bin"}},
     },
-    'mingw32_g_plusplus': {
-        "platform": "Windows",
-        "default": "system",
-        "exe": "g++",
-        "system": {"path": {'Windows': "C:/msys64/mingw32/bin"}},
-    },
     'mingw64': {
         "platform": "Windows",
         "default": "system",

--- a/conans/test/conftest.py
+++ b/conans/test/conftest.py
@@ -39,11 +39,15 @@ tools_locations = {
                       "15": {},
                       "16": {"disabled": True},
                       "17": {"disabled": True}},
-    'pkg_config': {"exe": "pkg-config",
-                   "default": "system",
-                   # pacman -S pkg-config inside msys2-mingw64
-                   "system": {"path": {'Windows': "C:/msys64/usr/bin"}},
-                   },
+    'pkg_config': {
+        "exe": "pkg-config",
+        "default": "0.28",
+        "0.28": {
+            "path": {
+                # Using chocolatey in Windows -> choco install pkgconfiglite --version 0.28
+                'Windows': "C:/ProgramData/chocolatey/lib/pkgconfiglite/tools/pkg-config-lite-0.28-1/bin"
+            }
+        }},
     'autotools': {"exe": "autoconf"},
     'cmake': {
         "default": "3.15",

--- a/conans/test/conftest.py
+++ b/conans/test/conftest.py
@@ -84,6 +84,12 @@ tools_locations = {
         "exe": "mingw32-make",
         "system": {"path": {'Windows': "C:/msys64/mingw32/bin"}},
     },
+    'mingw32_g_plusplus': {
+        "platform": "Windows",
+        "default": "system",
+        "exe": "g++",
+        "system": {"path": {'Windows': "C:/msys64/mingw32/bin"}},
+    },
     'mingw64': {
         "platform": "Windows",
         "default": "system",

--- a/conans/test/functional/build_helpers/pkg_config_test.py
+++ b/conans/test/functional/build_helpers/pkg_config_test.py
@@ -68,7 +68,7 @@ Cflags: -I${includedir}
 
 
 @pytest.mark.tool_pkg_config
-@pytest.mark.tool_mingw32_g_plusplus
+@pytest.mark.tool_mingw32
 class PkgConfigTest(unittest.TestCase):
     """
     Test WITHOUT a build helper nor a generator, explicitly defining pkg-config in the

--- a/conans/test/functional/build_helpers/pkg_config_test.py
+++ b/conans/test/functional/build_helpers/pkg_config_test.py
@@ -67,8 +67,8 @@ Cflags: -I${includedir}
 """
 
 
-@pytest.mark.skipif(platform.system() == "Windows", reason=".pc files not in Win")
 @pytest.mark.tool_pkg_config
+@pytest.mark.tool_mingw32
 class PkgConfigTest(unittest.TestCase):
     """
     Test WITHOUT a build helper nor a generator, explicitly defining pkg-config in the
@@ -96,7 +96,10 @@ class PkgConfigTest(unittest.TestCase):
                     tools.replace_prefix_in_pc_file("libB.pc", lib_b_path)
 
                     with tools.environment_append({"PKG_CONFIG_PATH": os.getcwd()}):
-                       self.run('g++ main.cpp $(pkg-config libB --libs --cflags) -o main')
+                        # FIXME: windows is not able to catch the output, "$()" does not exist in cmd
+                        self.run("pkg-config libB --libs --cflags >> output.txt")
+                        with open("output.txt") as f:
+                            self.run('g++ main.cpp %s -o main' % f.readline().strip())
             """)
 
         self._run_reuse(libb_conanfile, liba_conanfile)
@@ -121,7 +124,10 @@ class PkgConfigTest(unittest.TestCase):
                             'PKG_CONFIG_PATH': "%s" % self.deps_cpp_info["libB"].rootpath}
 
                     with tools.environment_append(vars):
-                       self.run('g++ main.cpp $(pkg-config %s libB --libs --cflags) -o main' % args)
+                        # FIXME: windows is not able to catch the output, "$()" does not exist in cmd
+                        self.run("pkg-config %s libB --libs --cflags >> output.txt" % args)
+                        with open("output.txt") as f:
+                            self.run('g++ main.cpp %s -o main' % f.readline().strip())
 
             """)
         libb = libb_conanfile + """
@@ -142,5 +148,5 @@ class PkgConfigTest(unittest.TestCase):
 
         client.run("install .")
         client.run("build .")
-        client.run_command("./main")
+        client.run_command("main" if platform.system() == "Windows" else "./main")
         self.assertIn("Hello World!", client.out)

--- a/conans/test/functional/build_helpers/pkg_config_test.py
+++ b/conans/test/functional/build_helpers/pkg_config_test.py
@@ -96,8 +96,8 @@ class PkgConfigTest(unittest.TestCase):
                     tools.replace_prefix_in_pc_file("libB.pc", lib_b_path)
 
                     with tools.environment_append({"PKG_CONFIG_PATH": os.getcwd()}):
-                        # FIXME: windows is not able to catch the output, "$()" does not exist in cmd
-                        self.run("pkg-config libB --libs --cflags >> output.txt")
+                        # Windows is not able to catch the output, "$()" does not exist in cmd
+                        self.run("pkg-config libB --libs --cflags > output.txt")
                         with open("output.txt") as f:
                             self.run('g++ main.cpp %s -o main' % f.readline().strip())
             """)
@@ -124,8 +124,8 @@ class PkgConfigTest(unittest.TestCase):
                             'PKG_CONFIG_PATH': "%s" % self.deps_cpp_info["libB"].rootpath}
 
                     with tools.environment_append(vars):
-                        # FIXME: windows is not able to catch the output, "$()" does not exist in cmd
-                        self.run("pkg-config %s libB --libs --cflags >> output.txt" % args)
+                        # Windows is not able to catch the output, "$()" does not exist in cmd
+                        self.run("pkg-config %s libB --libs --cflags > output.txt" % args)
                         with open("output.txt") as f:
                             self.run('g++ main.cpp %s -o main' % f.readline().strip())
 

--- a/conans/test/functional/build_helpers/pkg_config_test.py
+++ b/conans/test/functional/build_helpers/pkg_config_test.py
@@ -68,7 +68,7 @@ Cflags: -I${includedir}
 
 
 @pytest.mark.tool_pkg_config
-@pytest.mark.tool_mingw32
+@pytest.mark.tool_mingw32_g_plusplus
 class PkgConfigTest(unittest.TestCase):
     """
     Test WITHOUT a build helper nor a generator, explicitly defining pkg-config in the

--- a/conans/test/functional/generators/components/pkg_config_test.py
+++ b/conans/test/functional/generators/components/pkg_config_test.py
@@ -1,7 +1,6 @@
 import os
 import textwrap
 import unittest
-import platform
 
 import pytest
 
@@ -12,7 +11,6 @@ from conans.test.utils.tools import TestClient
 
 
 @pytest.mark.tool_pkg_config
-@pytest.mark.skipif(platform.system() == "Windows", reason="Requires pkg-config")
 class PkgConfigGeneratorWithComponentsTest(unittest.TestCase):
 
     @staticmethod

--- a/conans/test/functional/toolchains/meson/test_pkg_config_reuse.py
+++ b/conans/test/functional/toolchains/meson/test_pkg_config_reuse.py
@@ -1,5 +1,4 @@
 import os
-import platform
 
 import pytest
 import textwrap
@@ -9,7 +8,6 @@ from conans.test.functional.toolchains.meson._base import TestMesonBase
 
 
 @pytest.mark.tool_pkg_config
-@pytest.mark.skipif(platform.system() == "Windows", reason="Doesn't work in Windows")
 class MesonPkgConfigTest(TestMesonBase):
     _conanfile_py = textwrap.dedent("""
     from conans import ConanFile, tools

--- a/conans/test/functional/toolchains/meson/test_test.py
+++ b/conans/test/functional/toolchains/meson/test_test.py
@@ -1,5 +1,4 @@
 import os
-import platform
 
 import pytest
 import textwrap
@@ -9,7 +8,6 @@ from conans.test.functional.toolchains.meson._base import TestMesonBase
 
 
 @pytest.mark.tool_pkg_config
-@pytest.mark.skipif(platform.system() == "Windows", reason="Doesn't work in Windows")
 class MesonTest(TestMesonBase):
     _test_package_meson_build = textwrap.dedent("""
         project('test_package', 'cpp')

--- a/conans/test/functional/util/pkg_config_test.py
+++ b/conans/test/functional/util/pkg_config_test.py
@@ -2,7 +2,6 @@
 # -*- coding: utf-8 -*-
 
 import os
-import platform
 import unittest
 
 import pytest
@@ -28,8 +27,6 @@ Cflags: -I${includedir}/libastral -D_USE_LIBASTRAL
 """
 
 
-@pytest.mark.unix
-@pytest.mark.skipif(platform.system() == "Windows", reason="Requires pkg-config")
 class PkgConfigTest(unittest.TestCase):
     def test_negative(self):
         pc = PkgConfig('libsomething_that_does_not_exist_in_the_world')


### PR DESCRIPTION
Changelog: Fix: Recovering `pkg-config` tests into Windows platform.
CI: Needs to be installed in Windows machine `pkg-config` tool through chocolatey: `choco install pkgconfiglite --version 0.28`
Closes: https://github.com/conan-io/conan/issues/9483
Docs: omit

- [x] Refer to the issue that supports this Pull Request.
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 

<sup>**Note:** By default this PR will skip the slower tests and will use a limited set of python versions. Check [here](https://github.com/conan-io/conan/blob/develop/.github/PR_INCREASE_TESTING.md) how to increase the testing level by writing some tags in the current PR body text.</sup>
