### PR TITLE
Bugfix: add test to illustate failure when options differ between requires and build requires

### DIFF
--- a/conans/test/integration/build_requires/profile_build_requires_test.py
+++ b/conans/test/integration/build_requires/profile_build_requires_test.py
@@ -266,6 +266,29 @@ nonexistingpattern*: SomeTool/1.2@user/channel
         self.assertIn("MyLib/0.1@lasote/stable: Hello world from python tool!", client.out)
         self.assertNotIn("Project: Hello world from python tool!", client.out)
 
+    def test_build_requires_options_different(self):
+        client = TestClient()
+
+        conanfile_openssl_1_1_1 = GenConanfile("openssl", "1.1.1")
+        conanfile_openssl_3_0_0 = GenConanfile("openssl", "3.0.0")\
+            .with_option("no_fips", [True, False])\
+            .with_default_option("no_fips", True)
+        conanfile_cmake = GenConanfile("cmake", "0.1")\
+            .with_requires("openssl/1.1.1")
+        conanfile_consumer = GenConanfile("consumer", "0.1")\
+            .with_build_requires("cmake/0.1")\
+            .with_requires("openssl/3.0.0")
+
+        client.save({"conanfile_openssl_1_1_1.py": conanfile_openssl_1_1_1,
+                     "conanfile_openssl_3_0_0.py": conanfile_openssl_3_0_0,
+                     "conanfile_cmake.py": conanfile_cmake,
+                     "conanfile.py": conanfile_consumer})
+
+        client.run("create conanfile_openssl_1_1_1.py --profile:build=default --profile:host=default")
+        client.run("create conanfile_openssl_3_0_0.py --profile:build=default --profile:host=default")
+        client.run("create conanfile_cmake.py --profile:build=default --profile:host=default")
+        client.run("install conanfile.py --profile:build=default --profile:host=default")
+
     def test_build_requires_options(self):
         client = TestClient()
         client.save({CONANFILE: GenConanfile("MyTool", "0.1")})


### PR DESCRIPTION
we have found conan client may fail if options are different between requirements and build requirements:
https://github.com/conan-io/conan-center-index/pull/7747#issuecomment-947524266

I think the cause of the issue is: https://github.com/conan-io/conan/blob/6d7642d4d3bd911892eb0cf91161148f22968b32/conans/client/graph/graph_binaries.py#L311

Changelog: omit
Docs: omit

- [ ] Refer to the issue that supports this Pull Request.
- [ ] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [ ] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [ ] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 

<sup>**Note:** By default this PR will skip the slower tests and will use a limited set of python versions. Check [here](https://github.com/conan-io/conan/blob/develop/.github/PR_INCREASE_TESTING.md) how to increase the testing level by writing some tags in the current PR body text.</sup>
