### PR TITLE
adding preprocessor defintiions to MSBuildTolchain ResourceCompile

### DIFF
--- a/conan/tools/microsoft/toolchain.py
+++ b/conan/tools/microsoft/toolchain.py
@@ -131,6 +131,11 @@ class MSBuildToolchain(object):
                   <RuntimeLibrary>{}</RuntimeLibrary>
                   <LanguageStandard>{}</LanguageStandard>{}
                 </ClCompile>
+                <ResourceCompile>
+                  <PreprocessorDefinitions>
+                     {};%(PreprocessorDefinitions)
+                  </PreprocessorDefinitions>
+                </ResourceCompile>
               </ItemDefinitionGroup>
               <PropertyGroup Label="Configuration">
                 <PlatformToolset>{}</PlatformToolset>
@@ -150,7 +155,7 @@ class MSBuildToolchain(object):
         compile_options = "".join("\n      <{k}>{v}</{k}>".format(k=k, v=v)
                                   for k, v in self.compile_options.items())
         config_props = toolchain_file.format(preprocessor_definitions, runtime_library, cppstd,
-                                             compile_options, toolset)
+                                             compile_options, preprocessor_definitions, toolset)
         config_filepath = os.path.join(self._conanfile.generators_folder, config_filename)
         self._conanfile.output.info("MSBuildToolchain created %s" % config_filename)
         save(config_filepath, config_props)


### PR DESCRIPTION
Changelog: Feature: adding preprocessor definitions to ``MSBuildTolchain`` ResourceCompile.
Docs: Omit

Close https://github.com/conan-io/conan/issues/9828
