### PR TITLE
Recovered test for CMakeDeps

### DIFF
--- a/conans/test/conftest.py
+++ b/conans/test/conftest.py
@@ -18,6 +18,7 @@ To override these locations with your own in your dev machine:
 tools_locations = {
     'svn': {"disabled": True},
     'cmake': {
+        "default": "3.19",
         "3.15": {},
         "3.16": {"disabled": True},
         "3.17": {"disabled": True},
@@ -26,6 +27,7 @@ tools_locations = {
     'ninja': {
         "1.10.2": {}
     },
+    'meson': {"disabled": True},
     'bazel':  {
         "system": {"path": {'Windows': 'C:/ws/bazel/4.2.0'}},
     }

--- a/conans/test/functional/toolchains/cmake/cmakedeps/test_cmakedeps_components_names.py
+++ b/conans/test/functional/toolchains/cmake/cmakedeps/test_cmakedeps_components_names.py
@@ -556,7 +556,6 @@ class TestComponentsCMakeGenerators:
         assert "Component 'mypkg::zlib' not found in 'mypkg' package requirement" in client.out
 
     @pytest.mark.slow
-    @pytest.mark.xfail(reason="This test is failing in Py27, waiting for CMakeDeps improvements")
     def test_same_name_global_target_collision(self):
         # https://github.com/conan-io/conan/issues/7889
         conanfile_tpl = textwrap.dedent("""
@@ -616,7 +615,8 @@ class TestComponentsCMakeGenerators:
         middle_cpp = gen_function_cpp(name="middle", includes=["middle", "expected", "variant"],
                                       calls=["expected", "variant"])
         middle_conanfile = textwrap.dedent("""
-            from conans import ConanFile, CMake
+            from conans import ConanFile
+            from conan.tools.cmake import CMake
 
             class Conan(ConanFile):
                 name = "middle"


### PR DESCRIPTION
Recover test Overriding with a component "rename" the global scope.
Also completing the "Help template" of the conftest to include a default cmake version and avoid unexpected results when using `contest_user.py`

Changelog: omit
Docs: omit