### PR TITLE
Component with same name as package

### DIFF
--- a/conans/model/build_info.py
+++ b/conans/model/build_info.py
@@ -449,13 +449,6 @@ class CppInfo(_CppInfo):
                                          "but %s" % (comp_require, reason))
 
         if self.components:
-            # Raise on component name
-            for comp_name, comp in self.components.items():
-                if comp_name == package_name:
-                    raise ConanException(
-                        "Component name cannot be the same as the package name: '%s'"
-                        % comp_name)
-
             # check that requires are used in components and check that components exists in requires
             requires_from_components = set()
             for comp_name, comp in self.components.items():

--- a/conans/test/integration/generators/package_info/package_info_test.py
+++ b/conans/test/integration/generators/package_info/package_info_test.py
@@ -209,49 +209,6 @@ class HelloConan(ConanFile):
         self.assertIn("dep.defines: ['definedep1']", client.out)
         self.assertIn("dep.include_paths: ['include', 'includedep2']", client.out)
 
-    def test_package_info_raise_components(self):
-        conanfile = textwrap.dedent("""
-            from conans import ConanFile
-
-            class MyConan(ConanFile):
-
-                def package_info(self):
-                    self.cpp_info.defines.append("defint")
-                    self.cpp_info.components["int1"].libs.append("libint1")
-        """)
-        client = TestClient()
-        client.save({"conanfile.py": conanfile})
-        client.run("create conanfile.py dep/1.0@us/ch", assert_error=True)
-        self.assertIn("dep/1.0@us/ch package_info(): self.cpp_info.components cannot be used "
-                      "with self.cpp_info global values at the same time", client.out)
-
-        conanfile = textwrap.dedent("""
-            from conans import ConanFile
-
-            class MyConan(ConanFile):
-
-                def package_info(self):
-                    self.cpp_info.release.defines.append("defint")
-                    self.cpp_info.components["int1"].libs.append("libint1")
-        """)
-        client.save({"conanfile.py": conanfile})
-        client.run("create conanfile.py dep/1.0@us/ch", assert_error=True)
-        self.assertIn("dep/1.0@us/ch package_info(): self.cpp_info.components cannot be used "
-                      "with self.cpp_info configs (release/debug/...) at the same time", client.out)
-
-        conanfile = textwrap.dedent("""
-                    from conans import ConanFile
-
-                    class MyConan(ConanFile):
-
-                        def package_info(self):
-                            self.cpp_info.components["dep"].libs.append("libint1")
-                """)
-        client.save({"conanfile.py": conanfile})
-        client.run("create conanfile.py dep/1.0@us/ch", assert_error=True)
-        self.assertIn("dep/1.0@us/ch package_info(): Component name cannot be the same as the "
-                      "package name: 'dep'", client.out)
-
     def test_package_info_components_complete(self):
         dep = textwrap.dedent("""
             import os


### PR DESCRIPTION
Changelog: Feature: Let users define a new Component with the same name as the package.

Well, if you do that, Conan will raise this error:
```
ERROR:
	ConanException: pkg/0.1 package_info(): Component name cannot be the same as the package name: 'pkg'
```

This PR is aimed to solve this problem in relation to these comments:

* https://github.com/conan-io/conan/pull/9806#discussion_r733364484
* https://github.com/conan-io/conan/pull/9806#discussion_r734408718

Related PR: https://github.com/conan-io/conan/pull/9806
Docs: https://github.com/conan-io/docs/pull/XXXX

- [ ] Refer to the issue that supports this Pull Request.
- [ ] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [ ] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [ ] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 

<sup>**Note:** By default this PR will skip the slower tests and will use a limited set of python versions. Check [here](https://github.com/conan-io/conan/blob/develop/.github/PR_INCREASE_TESTING.md) how to increase the testing level by writing some tags in the current PR body text.</sup>
