### PR TITLE
meson 0.60 broke preprocessor defs

### DIFF
--- a/conan/tools/meson/toolchain.py
+++ b/conan/tools/meson/toolchain.py
@@ -15,6 +15,10 @@ class MesonToolchain(object):
     cross_filename = "conan_meson_cross.ini"
 
     _native_file_template = textwrap.dedent("""
+    [constants]
+    preprocessor_definitions = [{% for it, value in preprocessor_definitions.items() -%}
+    '-D{{ it }}="{{ value}}"'{%- if not loop.last %}, {% endif %}{% endfor %}]
+
     [project options]
     {{project_options}}
 
@@ -30,8 +34,6 @@ class MesonToolchain(object):
     {% if pkgconfig %}pkgconfig = {{pkgconfig}}{% endif %}
 
     [built-in options]
-    preprocessor_definitions = [{% for it, value in preprocessor_definitions.items() -%}
-    '-D{{ it }}="{{ value}}"'{%- if not loop.last %}, {% endif %}{% endfor %}]
     {% if buildtype %}buildtype = {{buildtype}}{% endif %}
     {% if debug %}debug = {{debug}}{% endif %}
     {% if default_library %}default_library = {{default_library}}{% endif %}


### PR DESCRIPTION
Changelog: Fix: Change ``MesonToolchain`` to define ``preprocessor_definitions`` as ``[constant]``, because Meson 0.60 now raises errors on it defined in ``[built-in options]``.
Docs: Omit

