### PR TITLE
Fix test_token_expired

### DIFF
--- a/conans/test/integration/remote/auth_test.py
+++ b/conans/test/integration/remote/auth_test.py
@@ -177,7 +177,7 @@ def test_token_expired():
     server_folder = temp_folder()
     server_conf = textwrap.dedent("""
        [server]
-       jwt_expire_minutes: 0.001
+       jwt_expire_minutes: 0.01
        authorize_timeout: 0
        disk_authorize_timeout: 0
        disk_storage_path: ./data
@@ -201,7 +201,7 @@ def test_token_expired():
     assert token is not None
 
     import time
-    time.sleep(1)
+    time.sleep(2)
     c.users = {}
     c.run("config set general.non_interactive=1")
     c.run("remove * -f")

--- a/conans/test/integration/remote/auth_test.py
+++ b/conans/test/integration/remote/auth_test.py
@@ -177,7 +177,7 @@ def test_token_expired():
     server_folder = temp_folder()
     server_conf = textwrap.dedent("""
        [server]
-       jwt_expire_minutes: 0.01
+       jwt_expire_minutes: 0.001
        authorize_timeout: 0
        disk_authorize_timeout: 0
        disk_storage_path: ./data


### PR DESCRIPTION
Changelog: omit
Docs: omit

Looks like this test was failing randomly maybe because sometimes it did not expire the token, let's see if this fixes that.
