### PR TITLE
Set CMAKE_POSITION_INDEPENDENT_CODE in CMakeToolchain even if shared=True

### DIFF
--- a/conan/tools/cmake/toolchain.py
+++ b/conan/tools/cmake/toolchain.py
@@ -148,11 +148,6 @@ class FPicBlock(Block):
         if os_ and "Windows" in os_:
             self._conanfile.output.warn("Toolchain: Ignoring fPIC option defined for Windows")
             return None
-        shared = self._conanfile.options.get_safe("shared")
-        if shared:
-            self._conanfile.output.warn("Toolchain: Ignoring fPIC option defined "
-                                        "for a shared library")
-            return None
         return {"fpic": "ON" if fpic else "OFF"}
 
 

--- a/conans/test/functional/toolchains/cmake/test_cmake.py
+++ b/conans/test/functional/toolchains/cmake/test_cmake.py
@@ -352,7 +352,6 @@ class LinuxTest(Base):
                       '-DCMAKE_TOOLCHAIN_FILE="{}"'.format(toolchain_path), self.client.out)
 
         extensions_str = "ON" if "gnu" in cppstd else "OFF"
-        pic_str = "" if shared else "ON"
         arch_str = "-m32" if arch == "x86" else "-m64"
         cxx11_abi_str = "1" if libcxx == "libstdc++11" else "0"
         defines = '_GLIBCXX_USE_CXX11_ABI=%s;MYDEFINE="MYDEF_VALUE";MYDEFINEINT=42;'\
@@ -371,7 +370,7 @@ class LinuxTest(Base):
                 "CMAKE_SHARED_LINKER_FLAGS": arch_str,
                 "CMAKE_EXE_LINKER_FLAGS": arch_str,
                 "COMPILE_DEFINITIONS": defines,
-                "CMAKE_POSITION_INDEPENDENT_CODE": pic_str
+                "CMAKE_POSITION_INDEPENDENT_CODE": "ON"
                 }
 
         def _verify_out(marker=">>"):

--- a/conans/test/unittests/tools/cmake/test_cmaketoolchain.py
+++ b/conans/test/unittests/tools/cmake/test_cmaketoolchain.py
@@ -248,7 +248,7 @@ def conanfile_linux_shared():
 
 
 @pytest.mark.parametrize("fPIC", [True, False])
-def test_fpic_when_shared_and_false(conanfile_linux_shared, fPIC):
+def test_fpic_when_shared_true(conanfile_linux_shared, fPIC):
     conanfile_linux_shared.options.fPIC = fPIC
     toolchain = CMakeToolchain(conanfile_linux_shared)
     cmake_value = 'ON' if fPIC else 'OFF'

--- a/conans/test/unittests/tools/cmake/test_cmaketoolchain.py
+++ b/conans/test/unittests/tools/cmake/test_cmaketoolchain.py
@@ -247,10 +247,13 @@ def conanfile_linux_shared():
     return c
 
 
-def test_no_fpic_when_shared(conanfile_linux_shared):
+@pytest.mark.parametrize("fPIC", [True, False])
+def test_fpic_when_shared_and_false(conanfile_linux_shared, fPIC):
+    conanfile_linux_shared.options.fPIC = fPIC
     toolchain = CMakeToolchain(conanfile_linux_shared)
+    cmake_value = 'ON' if fPIC else 'OFF'
     content = toolchain.content
-    assert 'set(CMAKE_POSITION_INDEPENDENT_CODE' not in content
+    assert 'set(CMAKE_POSITION_INDEPENDENT_CODE {})'.format(cmake_value) in content
 
 
 def test_fpic_when_not_shared(conanfile_linux_shared):


### PR DESCRIPTION
Changelog: Feature: Add `CMAKE_POSITION_INDEPENDENT_CODE` in `CMakeToolchain` if it's set in the conanfile independently from the value of the shared option.
Docs: omit

Closes: https://github.com/conan-io/conan/issues/9810
