### PR TITLE
BazelDeps build requires support

### DIFF
--- a/conan/tools/google/bazeldeps.py
+++ b/conan/tools/google/bazeldeps.py
@@ -13,7 +13,8 @@ class BazelDeps(object):
 
     def generate(self):
         local_repositories = []
-        for build_dependency in self._conanfile.dependencies.build.values():
+
+        for build_dependency in self._conanfile.dependencies.direct_build.values():
             content = self._get_build_dependency_buildfile_content(build_dependency)
             filename = self._save_dependendy_buildfile(build_dependency, content)
 

--- a/conan/tools/google/bazeldeps.py
+++ b/conan/tools/google/bazeldeps.py
@@ -13,6 +13,13 @@ class BazelDeps(object):
 
     def generate(self):
         local_repositories = []
+        for build_dependency in self._conanfile.dependencies.build.values():
+            content = self._get_build_dependency_buildfile_content(build_dependency)
+            filename = self._save_dependendy_buildfile(build_dependency, content)
+
+            local_repository = self._create_new_local_repository(build_dependency, filename)
+            local_repositories.append(local_repository)
+
         for dependency in self._conanfile.dependencies.host.values():
             content = self._get_dependency_buildfile_content(dependency)
             filename = self._save_dependendy_buildfile(dependency, content)
@@ -27,6 +34,18 @@ class BazelDeps(object):
         filename = 'conandeps/{}/BUILD'.format(dependency.ref.name)
         save(filename, buildfile_content)
         return filename
+
+    def _get_build_dependency_buildfile_content(self, dependency):
+        filegroup = textwrap.dedent("""
+            filegroup(
+                name = "{}_binaries",
+                data = glob(["**"]),
+                visibility = ["//visibility:public"],
+            )
+
+        """).format(dependency.ref.name)
+
+        return filegroup
 
     def _get_dependency_buildfile_content(self, dependency):
         template = textwrap.dedent("""

--- a/conans/test/unittests/tools/google/test_bazeldeps.py
+++ b/conans/test/unittests/tools/google/test_bazeldeps.py
@@ -22,7 +22,7 @@ def test_bazeldeps_dependency_buildfiles():
     conanfile_dep.cpp_info = cpp_info
     conanfile_dep._conan_node = Mock()
     conanfile_dep._conan_node.ref = ConanFileReference.loads("OriginalDepName/1.0")
-    conanfile_dep.package_folder = "/path/to/folder_dep"
+    conanfile_dep.folders.set_base_package("/path/to/folder_dep")
 
     with mock.patch('conans.ConanFile.dependencies', new_callable=mock.PropertyMock) as mock_deps:
         req = Requirement(ConanFileReference.loads("OriginalDepName/1.0"))
@@ -74,7 +74,7 @@ def test_bazeldeps_main_buildfile():
     conanfile_dep.cpp_info = cpp_info
     conanfile_dep._conan_node = Mock()
     conanfile_dep._conan_node.ref = ConanFileReference.loads("OriginalDepName/1.0")
-    conanfile_dep.package_folder = "/path/to/folder_dep"
+    conanfile_dep.folders.set_base_package("/path/to/folder_dep")
 
     with mock.patch('conans.ConanFile.dependencies', new_callable=mock.PropertyMock) as mock_deps:
         req = Requirement(ConanFileReference.loads("OriginalDepName/1.0"))
@@ -99,7 +99,7 @@ def test_bazeldeps_build_dependency_buildfiles():
     conanfile_dep = ConanFile(Mock(), None)
     conanfile_dep._conan_node = Mock()
     conanfile_dep._conan_node.ref = ConanFileReference.loads("OriginalDepName/1.0")
-    conanfile_dep.package_folder = "/path/to/folder_dep"
+    conanfile_dep.folders.set_base_package("/path/to/folder_dep")
 
     with mock.patch('conans.ConanFile.dependencies', new_callable=mock.PropertyMock) as mock_deps:
         req = Requirement(ConanFileReference.loads("OriginalDepName/1.0"), build=True)

--- a/conans/test/unittests/tools/google/test_bazeldeps.py
+++ b/conans/test/unittests/tools/google/test_bazeldeps.py
@@ -92,3 +92,22 @@ def test_bazeldeps_main_buildfile():
 
         for line in expected_content:
             assert line in content
+
+def test_bazeldeps_build_dependency_buildfiles():
+    conanfile = ConanFile(Mock(), None)
+
+    conanfile_dep = ConanFile(Mock(), None)
+    conanfile_dep._conan_node = Mock()
+    conanfile_dep._conan_node.ref = ConanFileReference.loads("OriginalDepName/1.0")
+    conanfile_dep.package_folder = "/path/to/folder_dep"
+
+    with mock.patch('conans.ConanFile.dependencies', new_callable=mock.PropertyMock) as mock_deps:
+        req = Requirement(ConanFileReference.loads("OriginalDepName/1.0"), build=True)
+        mock_deps.return_value = ConanFileDependencies({req: ConanFileInterface(conanfile_dep)})
+
+        bazeldeps = BazelDeps(conanfile)
+
+        for build_dependency in bazeldeps._conanfile.dependencies.build.values():
+            dependency_content = bazeldeps._get_build_dependency_buildfile_content(build_dependency)
+            assert 'filegroup(\n    name = "OriginalDepName_binaries",' in dependency_content
+            assert 'data = glob(["**"]),' in dependency_content

--- a/conans/test/unittests/tools/google/test_bazeldeps.py
+++ b/conans/test/unittests/tools/google/test_bazeldeps.py
@@ -107,7 +107,7 @@ def test_bazeldeps_build_dependency_buildfiles():
 
         bazeldeps = BazelDeps(conanfile)
 
-        for build_dependency in bazeldeps._conanfile.dependencies.build.values():
+        for build_dependency in bazeldeps._conanfile.dependencies.direct_build.values():
             dependency_content = bazeldeps._get_build_dependency_buildfile_content(build_dependency)
             assert 'filegroup(\n    name = "OriginalDepName_binaries",' in dependency_content
             assert 'data = glob(["**"]),' in dependency_content


### PR DESCRIPTION
Changelog: Feature: Add build_requires support in BazelDeps generators.
Docs: omit

Closes: #9875 

- [x] Refer to the issue that supports this Pull Request.
- [ ] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 

<sup>**Note:** By default this PR will skip the slower tests and will use a limited set of python versions. Check [here](https://github.com/conan-io/conan/blob/develop/.github/PR_INCREASE_TESTING.md) how to increase the testing level by writing some tags in the current PR body text.</sup>
