### PR TITLE
Revert cpp.local but keep test_package simplified folder and AutoPackage

### DIFF
--- a/conan/tools/files/packager.py
+++ b/conan/tools/files/packager.py
@@ -16,7 +16,7 @@ class _PatternEntry(object):
         self.framework = []
 
 
-class Patterns(object):
+class _Patterns(object):
 
     def __init__(self):
         self.source = _PatternEntry()
@@ -27,7 +27,7 @@ class AutoPackager(object):
 
     def __init__(self, conanfile):
         self._conanfile = conanfile
-        self.patterns = Patterns()
+        self.patterns = _Patterns()
 
         self.patterns.source.include = ["*.h", "*.hpp", "*.hxx"]
         self.patterns.source.lib = []

--- a/conan/tools/files/packager.py
+++ b/conan/tools/files/packager.py
@@ -4,70 +4,92 @@ from conans.client.file_copier import FileCopier
 from conans.errors import ConanException
 
 
-class _AutoPackagerPatternEntry(object):
+class _PatternEntry(object):
 
     def __init__(self):
-        self.include = ["*.h", "*.hpp", "*.hxx"]
-        self.lib = ["*.so", "*.so.*", "*.a", "*.lib", "*.dylib"]
-        self.bin = ["*.exe", "*.dll"]
+        self.include = []
+        self.lib = []
+        self.bin = []
         self.src = []
         self.build = []
         self.res = []
         self.framework = []
 
 
+class Patterns(object):
+
+    def __init__(self):
+        self.source = _PatternEntry()
+        self.build = _PatternEntry()
+
+
 class AutoPackager(object):
 
     def __init__(self, conanfile):
         self._conanfile = conanfile
-        self.patterns = _AutoPackagerPatternEntry()
+        self.patterns = Patterns()
+
+        self.patterns.source.include = ["*.h", "*.hpp", "*.hxx"]
+        self.patterns.source.lib = []
+        self.patterns.source.bin = []
+
+        self.patterns.build.include = ["*.h", "*.hpp", "*.hxx"]
+        self.patterns.build.lib = ["*.so", "*.so.*", "*.a", "*.lib", "*.dylib"]
+        self.patterns.build.bin = ["*.exe", "*.dll"]
 
     def run(self):
         cf = self._conanfile
-
-        # Check that the components declared in  local are in package
-        cnames = set(cf.cpp.local.component_names)
+        # Check that the components declared in source/build are in package
+        cnames = set(cf.cpp.source.component_names)
+        cnames = cnames.union(set(cf.cpp.build.component_names))
         if cnames.difference(set(cf.cpp.package.component_names)):
             # TODO: Raise? Warning? Ignore?
-            raise ConanException("There are components declared in cpp.local.components"
-                                 " that are not declared in cpp.package.components")
-
+            raise ConanException("There are components declared in cpp.source.components"
+                                 " or in cpp.build.components that are not declared in"
+                                 " cpp.package.components")
         if cnames:
             for cname in cnames:
-                if cname in cf.cpp.local.components:
-                    self._package_cppinfo(cf.cpp.local.components[cname],
+                if cname in cf.cpp.source.components:
+                    self._package_cppinfo("source", cf.cpp.source.components[cname],
                                           cf.cpp.package.components[cname])
-
+                if cname in cf.cpp.build.components:
+                    self._package_cppinfo("build", cf.cpp.build.components[cname],
+                                          cf.cpp.package.components[cname])
         else:  # No components declared
-            self._package_cppinfo(cf.cpp.local, cf.cpp.package)
+           self._package_cppinfo("source", cf.cpp.source, cf.cpp.package)
+           self._package_cppinfo("build", cf.cpp.build, cf.cpp.package)
 
-    def _package_cppinfo(self, origin_cppinfo, dest_cppinfo):
+
+    def _package_cppinfo(self, origin_name, origin_cppinfo, dest_cppinfo):
         """
         @param origin_name: one from ["source", "build"]
         @param origin_cppinfo: cpp_info object of an origin (can be a component cppinfo too)
         @param dest_cppinfo: cpp_info object of the package or a component from package
         """
+
+        patterns_var = getattr(self.patterns, origin_name)
+        base_folder = getattr(self._conanfile, "{}_folder".format(origin_name))
+
         for var in ["include", "lib", "bin", "framework", "src", "build", "res"]:
             dirs_var_name = "{}dirs".format(var)
             origin_paths = getattr(origin_cppinfo, dirs_var_name)
             if not origin_paths:
                 continue
-            patterns = getattr(self.patterns, var)
+            patterns = getattr(patterns_var, var)
             destinations = getattr(dest_cppinfo, dirs_var_name)
+
             if not destinations:  # For example: Not declared "includedirs" in package.cpp_info
                 continue
+
             if len(destinations) > 1:
                 # Check if there is only one possible destination at package, otherwise the
                 # copy would need to be done manually
                 err_msg = "The package has more than 1 cpp_info.{}, cannot package automatically"
                 raise ConanException(err_msg.format(dirs_var_name))
 
-            # We cannot know if the declared folder lives in source or build... so we copy everything
-            paths = [os.path.join(self._conanfile.folders.base_source, f) for f in origin_paths]
-            if self._conanfile.folders.base_build != self._conanfile.folders.base_source:
-                paths.extend([os.path.join(self._conanfile.folders.base_build, f)
-                              for f in origin_paths])
+            for d in origin_paths:
+                copier = FileCopier([os.path.join(base_folder, d)],
+                                    self._conanfile.folders.base_package)
+                for pattern in patterns:
+                    copier(pattern, dst=destinations[0])
 
-            copier = FileCopier(paths, self._conanfile.folders.base_package)
-            for pattern in patterns:
-                copier(pattern, dst=destinations[0])

--- a/conan/tools/layout/__init__.py
+++ b/conan/tools/layout/__init__.py
@@ -22,14 +22,13 @@ def cmake_layout(conanfile, generator=None):
         conanfile.folders.build = "cmake-build-{}".format(build_type)
         conanfile.folders.generators = os.path.join(conanfile.folders.build, "conan")
 
-    conanfile.cpp.local.includedirs = ["src"]
+    conanfile.cpp.source.includedirs = ["src"]
     if multi:
-        _dir = os.path.join(conanfile.folders.build, str(conanfile.settings.build_type))
-        conanfile.cpp.local.libdirs = [_dir]
-        conanfile.cpp.local.bindirs = [_dir]
+        conanfile.cpp.build.libdirs = ["{}".format(conanfile.settings.build_type)]
+        conanfile.cpp.build.bindirs = ["{}".format(conanfile.settings.build_type)]
     else:
-        conanfile.cpp.local.libdirs = [conanfile.folders.build]
-        conanfile.cpp.local.bindirs = [conanfile.folders.build]
+        conanfile.cpp.build.libdirs = ["."]
+        conanfile.cpp.build.bindirs = ["."]
 
 
 def clion_layout(conanfile):
@@ -37,10 +36,10 @@ def clion_layout(conanfile):
         raise ConanException("The 'clion_layout' requires the 'build_type' setting")
     base = "cmake-build-{}".format(str(conanfile.settings.build_type).lower())
     conanfile.folders.build = base
-    conanfile.cpp.local.libdirs = [conanfile.folders.build]
+    conanfile.cpp.build.libdirs = ["."]
     conanfile.folders.generators = os.path.join(base, "generators")
     conanfile.folders.source = "."
-    conanfile.cpp.local.includedirs = [conanfile.folders.source]
+    conanfile.cpp.source.includedirs = ["."]
 
 
 def vs_layout(conanfile):
@@ -59,7 +58,7 @@ def vs_layout(conanfile):
         base = str(conanfile.settings.build_type)
 
     conanfile.folders.build = base
-    conanfile.cpp.local.libdirs = [conanfile.folders.build]
+    conanfile.cpp.build.libdirs = ["."]
     conanfile.folders.generators = os.path.join(base, "generators")
     conanfile.folders.source = "."
-    conanfile.cpp.local.includedirs = [conanfile.folders.source]
+    conanfile.cpp.source.includedirs = ["."]

--- a/conans/assets/templates/new_v2_cmake.py
+++ b/conans/assets/templates/new_v2_cmake.py
@@ -71,7 +71,7 @@ class {package_name}TestConan(ConanFile):
 
     def test(self):
         if not tools.cross_building(self):
-            cmd = os.path.join(self.cpp.local.bindirs[0], "example")
+            cmd = os.path.join(self.cpp.build.bindirs[0], "example")
             self.run(cmd, env="conanrun")
 """
 

--- a/conans/client/cmd/build.py
+++ b/conans/client/cmd/build.py
@@ -64,9 +64,7 @@ def cmd_build(app, conanfile_path, base_path, source_folder, build_folder, packa
             with get_env_context_manager(conan_file):
                 conan_file.output.highlight("Running test()")
                 with conanfile_exception_formatter(str(conan_file), "test"):
-                    test_curdir = conanfile_folder \
-                        if hasattr(conan_file, "layout") else conan_file.build_folder
-                    with chdir(test_curdir):
+                    with chdir(conan_file.build_folder):
                         conan_file.test()
 
     except ConanException:

--- a/conans/client/installer.py
+++ b/conans/client/installer.py
@@ -682,9 +682,20 @@ class BinaryInstaller(object):
                         conanfile.folders.set_base_source(package_folder)
                         conanfile.folders.set_base_generators(package_folder)
 
+                        # convert directory entries to be relative to the declared folders.build
+                        build_cppinfo = conanfile.cpp.build.copy()
+                        build_cppinfo.set_relative_base_folder(conanfile.folders.build)
+
+                        # convert directory entries to be relative to the declared folders.source
+                        source_cppinfo = conanfile.cpp.source.copy()
+                        source_cppinfo.set_relative_base_folder(conanfile.folders.source)
+
+                        full_editable_cppinfo = NewCppInfo()
+                        full_editable_cppinfo.merge(source_cppinfo)
+                        full_editable_cppinfo.merge(build_cppinfo)
                         # Paste the editable cpp_info but prioritizing it, only if a
-                        # variable is not declared at cpp.local, the package will keep the value
-                        fill_old_cppinfo(conanfile.cpp.local, conanfile.cpp_info)
+                        # variable is not declared at build/source, the package will keep the value
+                        fill_old_cppinfo(full_editable_cppinfo, conanfile.cpp_info)
 
                     if conanfile._conan_dep_cpp_info is None:
                         try:

--- a/conans/model/layout.py
+++ b/conans/model/layout.py
@@ -6,7 +6,8 @@ from conans.model.new_build_info import NewCppInfo
 class Infos(object):
 
     def __init__(self):
-        self.local = NewCppInfo()
+        self.source = NewCppInfo()
+        self.build = NewCppInfo()
         self.package = NewCppInfo()
 
 

--- a/conans/test/assets/pkg_cmake.py
+++ b/conans/test/assets/pkg_cmake.py
@@ -88,7 +88,7 @@ def pkg_cmake_test(require_name):
                 cmake.build()
 
             def test(self):
-                cmd = os.path.join(self.cpp.local.bindirs[0], "test")
+                cmd = os.path.join(self.cpp.build.bindirs[0], "test")
                 self.run(cmd, env="conanrun")
         """)
 

--- a/conans/test/functional/layout/test_editables_layout.py
+++ b/conans/test/functional/layout/test_editables_layout.py
@@ -8,19 +8,20 @@ def test_cpp_info_editable():
 
     client = TestClient()
 
-    conan_hello = str(GenConanfile().with_import("import os"))
+    conan_hello = str(GenConanfile())
     conan_hello += """
     def layout(self):
         self.folders.source = "my_sources"
         self.folders.build = "my_build"
 
-        self.cpp.local.includedirs = [os.path.join(self.folders.source, "my_include_source"),
-                                      os.path.join(self.folders.build, "my_include")]
-        self.cpp.local.libdirs = [os.path.join(self.folders.build, "my_libdir")]
-        self.cpp.local.libs = ["hello"]
-        self.cpp.local.frameworkdirs = []  # Empty list is also explicit priority declaration
-        self.cpp.local.cxxflags = ["my_cxx_flag"]
-        self.cpp.local.builddirs = [os.path.join(self.folders.source, "my_builddir_source")]
+        self.cpp.build.includedirs = ["my_include"]
+        self.cpp.build.libdirs = ["my_libdir"]
+        self.cpp.build.libs = ["hello"]
+        self.cpp.build.frameworkdirs = []  # Empty list is also explicit priority declaration
+
+        self.cpp.source.cxxflags = ["my_cxx_flag"]
+        self.cpp.source.includedirs = ["my_include_source"]
+        self.cpp.source.builddirs = ["my_builddir_source"]
 
         self.cpp.package.libs = ["lib_when_package"]
 
@@ -101,20 +102,21 @@ def test_cpp_info_components_editable():
         self.folders.source = "my_sources"
         self.folders.build = "my_build"
 
-        self.cpp.local.components["foo"].includedirs = ["my_sources/my_include_source_foo",
-                                                        "my_build/my_include_foo"]
-        self.cpp.local.components["foo"].libdirs = ["my_build/my_libdir_foo"]
-        self.cpp.local.components["foo"].libs = ["hello_foo"]
-        self.cpp.local.components["foo"].cxxflags = ["my_cxx_flag_foo"]
-        self.cpp.local.components["foo"].builddirs = ["my_sources/my_builddir_source_foo"]
+        self.cpp.build.components["foo"].includedirs = ["my_include_foo"]
+        self.cpp.build.components["foo"].libdirs = ["my_libdir_foo"]
+        self.cpp.build.components["foo"].libs = ["hello_foo"]
 
+        self.cpp.build.components["var"].includedirs = ["my_include_var"]
+        self.cpp.build.components["var"].libdirs = ["my_libdir_var"]
+        self.cpp.build.components["var"].libs = ["hello_var"]
 
-        self.cpp.local.components["var"].includedirs = ["my_sources/my_include_source_var",
-                                                        "my_build/my_include_var"]
-        self.cpp.local.components["var"].libdirs = ["my_build/my_libdir_var"]
-        self.cpp.local.components["var"].libs = ["hello_var"]
-        self.cpp.local.components["var"].cxxflags = ["my_cxx_flag_var"]
-        self.cpp.local.components["var"].builddirs = ["my_sources/my_builddir_source_var"]
+        self.cpp.source.components["foo"].cxxflags = ["my_cxx_flag_foo"]
+        self.cpp.source.components["foo"].includedirs = ["my_include_source_foo"]
+        self.cpp.source.components["foo"].builddirs = ["my_builddir_source_foo"]
+
+        self.cpp.source.components["var"].cxxflags = ["my_cxx_flag_var"]
+        self.cpp.source.components["var"].includedirs = ["my_include_source_var"]
+        self.cpp.source.components["var"].builddirs = ["my_builddir_source_var"]
 
         self.cpp.package.components["foo"].libs = ["lib_when_package_foo"]
         self.cpp.package.components["var"].libs = ["lib_when_package_var"]

--- a/conans/test/functional/layout/test_layout_autopackage.py
+++ b/conans/test/functional/layout/test_layout_autopackage.py
@@ -46,7 +46,7 @@ def test_auto_package_no_components():
         self.folders.build = "my_build"
         self.folders.generators = "my_build/generators"
 
-        # Package locati
+        # Package locations
         self.cpp.package.includedirs = ["my_includes"]
         self.cpp.package.srcdirs = ["my_sources"]
         self.cpp.package.bindirs = ["my_bins"]
@@ -54,24 +54,33 @@ def test_auto_package_no_components():
         self.cpp.package.frameworkdirs = ["my_frameworks"]
 
         # Source CPP INFO
-        self.cpp.local.srcdirs = ["my_source/source_sources",
-                                  "my_build/build_sources",
-                                  "my_build/build_sources/subdir/othersubdir"]
-        self.cpp.local.includedirs = ["my_source/source_includes",
-                                      "my_source/source_includes2",
-                                      "my_build/build_includes"]
-        self.cpp.local.libdirs = ["my_source/source_libs", "my_build/build_libs"]
-        self.cpp.local.bindirs = ["my_source/source_bins", "my_build/build_bins"]
-        self.cpp.local.frameworkdirs = ["my_source/source_frameworks", "my_build/build_frameworks"]
+        self.cpp.source.srcdirs = ["source_sources"]
+        self.cpp.source.includedirs = ["source_includes", "source_includes2"]
+        self.cpp.source.libdirs = ["source_libs"]
+        self.cpp.source.bindirs = ["source_bins"]
+        self.cpp.source.frameworkdirs = ["source_frameworks"]
+
+        # Build CPP INFO
+        self.cpp.build.srcdirs = ["build_sources",
+                                              "build_sources/subdir/othersubdir"]
+        self.cpp.build.includedirs = ["build_includes"]
+        self.cpp.build.libdirs = ["build_libs"]
+        self.cpp.build.bindirs = ["build_bins"]
+        self.cpp.build.frameworkdirs = ["build_frameworks"]
 
     def package(self):
         # Discard include3.h from source
         packager = AutoPackager(self)
-        packager.patterns.include = ["*.hpp", "*.h", "include3.h"]
-        packager.patterns.lib = ["*.a"]
-        packager.patterns.bin = ["*.exe"]
-        packager.patterns.src = ["*.cpp"]
-        packager.patterns.framework = ["sframe*", "bframe*"]
+        packager.patterns.build.include = ["*.hpp", "*.h", "include3.h"]
+        packager.patterns.build.lib = ["*.a"]
+        packager.patterns.build.bin = ["*.exe"]
+        packager.patterns.build.src = ["*.cpp"]
+        packager.patterns.build.framework = ["sframe*", "bframe*"]
+        packager.patterns.source.include = ["*.hpp"] # Discard include3.h from source
+        packager.patterns.source.lib = ["*.a"]
+        packager.patterns.source.bin = ["*.exe"]
+        packager.patterns.source.src = ["*.cpp"]
+        packager.patterns.source.framework = ["sframe*"]
         packager.run()
     """
     client.save({"conanfile.py": conan_file})
@@ -111,7 +120,10 @@ def test_auto_package_no_components():
 
     # Check files build
     assert os.path.exists(p_path("my_sources/build_stuff.cpp"))
+    # note: as the "selective_stuff.cpp" is included in another my_sources dir, is copied twice
+    #       it would need manual adjustement of the copy to avoid it
     assert os.path.exists(p_path("my_sources/selective_stuff.cpp"))
+    assert os.path.exists(p_path("my_sources/subdir/othersubdir/selective_stuff.cpp"))
 
     assert os.path.exists(p_path("my_includes/include3.h"))
     assert not os.path.exists(p_path("my_includes/include4.h"))
@@ -145,12 +157,11 @@ def test_auto_package_with_components():
 
     def layout(self):
         # Build and source infos
-        self.cpp.local.components["component1"].includedirs = ["includes1"]
-        self.cpp.local.components["component1"].libdirs = ["build_libs"]
-
-        self.cpp.local.components["component2"].libdirs = ["build_libs"]
-        self.cpp.local.components["component2"].includedirs = ["includes2"]
-        self.cpp.local.components["component3"].bindirs = ["build_bins"]
+        self.cpp.source.components["component1"].includedirs = ["includes1"]
+        self.cpp.source.components["component2"].includedirs = ["includes2"]
+        self.cpp.build.components["component1"].libdirs = ["build_libs"]
+        self.cpp.build.components["component2"].libdirs = ["build_libs"]
+        self.cpp.build.components["component3"].bindirs = ["build_bins"]
 
         # Package infos
         self.cpp.package.components["component1"].includedirs = ["include"]
@@ -202,11 +213,11 @@ def test_auto_package_with_components_declared_badly():
 
     def layout(self):
         # Build and source infos
-        self.cpp.local.components["component1"].includedirs = ["includes1"]
-        self.cpp.local.components["component2"].includedirs = ["includes2"]
-        self.cpp.local.components["component1"].libdirs = ["build_libs"]
-        self.cpp.local.components["component2"].libdirs = ["build_libs"]
-        self.cpp.local.components["component3"].bindirs = ["build_bins"]
+        self.cpp.source.components["component1"].includedirs = ["includes1"]
+        self.cpp.source.components["component2"].includedirs = ["includes2"]
+        self.cpp.build.components["component1"].libdirs = ["build_libs"]
+        self.cpp.build.components["component2"].libdirs = ["build_libs"]
+        self.cpp.build.components["component3"].bindirs = ["build_bins"]
 
         # Package infos BUT NOT DECLARING component2
         self.cpp.package.components["component1"].includedirs = ["include"]
@@ -219,7 +230,8 @@ def test_auto_package_with_components_declared_badly():
 
     client.save({"conanfile.py": conan_file})
     client.run("create . lib/1.0@", assert_error=True)
-    assert "There are components declared in cpp.local.components that are not declared in " \
+    assert "There are components declared in cpp.source.components or in " \
+           "cpp.build.components that are not declared in " \
            "cpp.package.components" in client.out
 
 
@@ -252,9 +264,9 @@ def test_auto_package_default_patterns():
         tools.save("ugly_build/mylib.janderclander", "")
 
     def layout(self):
-        self.cpp.local.includedirs = ["myincludes"]
-        self.cpp.local.libdirs = ["ugly_build"]
-        self.cpp.local.bindirs = ["ugly_build"]
+        self.cpp.source.includedirs = ["myincludes"]
+        self.cpp.build.libdirs = ["ugly_build"]
+        self.cpp.build.bindirs = ["ugly_build"]
 
     def package(self):
         AutoPackager(self).run()
@@ -282,13 +294,13 @@ def test_auto_package_default_folders_with_components():
                      .with_import("from conan.tools.files import AutoPackager"))
     conan_file += """
     def layout(self):
-
-        assert self.cpp.local.components["foo"].includedirs is None
-        assert self.cpp.local.components["foo"].libdirs is None
-        assert self.cpp.local.components["foo"].bindirs is None
-        assert self.cpp.local.components["foo"].frameworkdirs is None
-        assert self.cpp.local.components["foo"].srcdirs is None
-        assert self.cpp.local.components["foo"].resdirs is None
+        for el in [self.cpp.source, self.cpp.build]:
+            assert el.components["foo"].includedirs is None
+            assert el.components["foo"].libdirs is None
+            assert el.components["foo"].bindirs is None
+            assert el.components["foo"].frameworkdirs is None
+            assert el.components["foo"].srcdirs is None
+            assert el.components["foo"].resdirs is None
 
         assert self.cpp.package.components["foo"].includedirs is None
         assert self.cpp.package.components["foo"].libdirs is None
@@ -320,13 +332,13 @@ def test_auto_package_with_custom_package_too():
         tools.save("ugly_build/mylib.a", "")
 
     def layout(self):
-        self.cpp.local.includedirs = ["myincludes"]
-        self.cpp.local.libdirs = ["ugly_build"]
+        self.cpp.source.includedirs = ["myincludes"]
+        self.cpp.build.libdirs = ["ugly_build"]
 
     def package(self):
         packager = AutoPackager(self)
-        packager.patterns.include = ["*.header"]
-        packager.patterns.lib = ["*.a"]
+        packager.patterns.source.include = ["*.header"]
+        packager.patterns.build.lib = ["*.a"]
         packager.run()
         assert os.path.exists(os.path.join(self.package_folder, "include", "mylib.header"))
         assert os.path.exists(os.path.join(self.package_folder, "lib", "mylib.a"))
@@ -354,19 +366,20 @@ def test_auto_package_only_one_destination():
        tools.save("ugly_build/mylib.a", "")
 
     def layout(self):
-       self.cpp.local.includedirs = ["myincludes"]
-       self.cpp.local.libdirs = ["ugly_build"]
-       self.cpp.local.bindirs = ["ugly_build"]
-       self.cpp.local.frameworkdirs = ["ugly_build"]
-       self.cpp.local.srcdirs = ["ugly_build"]
-       self.cpp.local.builddirs = ["ugly_build"]
-       self.cpp.local.resdirs = ["ugly_build"]
+       self.cpp.source.includedirs = ["myincludes"]
+       self.cpp.build.libdirs = ["ugly_build"]
+       self.cpp.build.bindirs = ["ugly_build"]
+       self.cpp.build.frameworkdirs = ["ugly_build"]
+       self.cpp.build.srcdirs = ["ugly_build"]
+       self.cpp.build.builddirs = ["ugly_build"]
+       self.cpp.build.resdirs = ["ugly_build"]
+
        self.cpp.package.{} = ["folder1", "folder2"]
 
     def package(self):
         packager = AutoPackager(self)
-        packager.patterns.include = ["*.header"]
-        packager.patterns.lib = ["*.a"]
+        packager.patterns.source.include = ["*.header"]
+        packager.patterns.build.lib = ["*.a"]
         packager.run()
 
     """

--- a/conans/test/functional/toolchains/cmake/cmakedeps/test_apple_frameworks.py
+++ b/conans/test/functional/toolchains/cmake/cmakedeps/test_apple_frameworks.py
@@ -258,7 +258,6 @@ def test_apple_own_framework_cmake_deps():
         import os
         from conans import ConanFile
         from conan.tools.cmake import CMake
-        from conan.tools.layout import cmake_layout
 
         class TestPkg(ConanFile):
             generators = "CMakeDeps", "CMakeToolchain"
@@ -269,7 +268,7 @@ def test_apple_own_framework_cmake_deps():
             settings = "build_type",
 
             def layout(self):
-                cmake_layout(self)
+                self.folders.build = str(self.settings.build_type)
 
             def build(self):
                 cmake = CMake(self)
@@ -277,7 +276,7 @@ def test_apple_own_framework_cmake_deps():
                 cmake.build()
 
             def test(self):
-                self.run(os.path.join(self.cpp.local.bindirs[0], "timer"), run_environment=True)
+                self.run(os.path.join(str(self.settings.build_type), "timer"), run_environment=True)
         """)
     client.save({'conanfile.py': conanfile,
                  "src/CMakeLists.txt": cmake,

--- a/conans/test/functional/toolchains/cmake/cmakedeps/test_cmakedeps_components_names.py
+++ b/conans/test/functional/toolchains/cmake/cmakedeps/test_cmakedeps_components_names.py
@@ -663,8 +663,7 @@ class TestComponentsCMakeGenerators:
                     cmake = CMake(self)
                     cmake.configure(build_script_folder="src")
                     cmake.build()
-                    local_path = os.path.relpath(self.cpp.local.bindirs[0], self.folders.build)
-                    cmd = os.path.join(local_path, "main")
+                    cmd = os.path.join(self.cpp.build.bindirs[0], "main")
                     self.run(cmd, env="conanrun")
             """)
         cmakelists = textwrap.dedent("""

--- a/conans/test/functional/toolchains/cmake/test_cmake_toolchain_win_clang.py
+++ b/conans/test/functional/toolchains/cmake/test_cmake_toolchain_win_clang.py
@@ -43,8 +43,7 @@ def client():
                 cmake = CMake(self)
                 cmake.configure()
                 cmake.build()
-                local_path = os.path.relpath(self.cpp.local.bindirs[0], self.folders.build)
-                cmd = os.path.join(local_path, "my_app")
+                cmd = os.path.join(self.cpp.build.bindirs[0], "my_app")
                 self.run(cmd, env=["conanrunenv"])
         """)
     c.save({"conanfile.py": conanfile,


### PR DESCRIPTION
Changelog: Fix: Moved experimental LayoutPackager to a `conan.tools.files.AutoPackager` with a new interface. Removed also the `conanfile.patterns` attribute that now is configured directly in the AutoPackager.
Changelog: Fix: When the `layout()` method is declared inside the conanfile.py of a `test-package`, Conan won't generate temporary folders at build/_HASH_ anymore. The build folder will follow the structure declared at the layout() method.
Docs: https://github.com/conan-io/docs/pull/2278

