### PR TITLE
Removed folders.package

### DIFF
--- a/conans/client/conan_api.py
+++ b/conans/client/conan_api.py
@@ -791,33 +791,20 @@ class ConanAPIV1(object):
 
         conanfile = self.app.graph_manager.load_consumer_conanfile(conanfile_path, install_folder,
                                                                    deps_info_required=True)
-        if not conanfile.folders.package:
-            default_pkg_folder = os.path.join(build_folder, "package")
-            package_folder = _make_abs_path(package_folder, cwd, default=default_pkg_folder)
-        else:
-            package_folder = _make_abs_path(package_folder, cwd, default=build_folder)
+        default_pkg_folder = os.path.join(build_folder, "package")
+        package_folder = _make_abs_path(package_folder, cwd, default=default_pkg_folder)
 
         if hasattr(conanfile, "layout"):
-            dir_path = os.path.dirname(conanfile_path)
-            conanfile.folders.set_base_generators(dir_path)
-            conanfile.folders.set_base_build(dir_path)
-            conanfile.folders.set_base_source(dir_path)
-            # FIXME: this is bad, but conanfile.folders.package=xxx is broken atm, cant be used
-            # The "conan package" will create "include", "lib" subfolders directly at the root folder
-            # level, which pollutes the source repo itself. It is not possible to change this via
-            # self.folders.package="package" in layout(), because that breaks packaging and create
-            conanfile.folders.set_base_package(os.path.join(dir_path, "package"))
-            conanfile.folders.set_base_install(install_folder)
+            raise ConanException("The usage of the 'conan package' local method is disabled when "
+                                 "using layout(). Use 'export-pkg' to test if the recipe is "
+                                 "packaging the files correctly or use the cpp.info.local object "
+                                 "if you are going to use this package as editable package.")
         else:
             conanfile.folders.set_base_build(build_folder)
             conanfile.folders.set_base_source(source_folder)
             conanfile.folders.set_base_package(package_folder)
             conanfile.folders.set_base_install(install_folder)
 
-        # Use the complete package layout for the local method
-        if conanfile.folders.package:
-            pf = os.path.join(package_folder, conanfile.folders.package)
-            conanfile.folders.set_base_package(pf)
         run_package_method(conanfile, None, self.app.hook_manager, conanfile_path, None,
                            copy_info=True)
 

--- a/conans/client/installer.py
+++ b/conans/client/installer.py
@@ -666,8 +666,6 @@ class BinaryInstaller(object):
                         conanfile.cpp_info = CppInfo(conanfile.name, package_folder,
                                                      default_values=CppInfoDefaultValues())
                         if not is_editable:
-                            package_cppinfo = conanfile.cpp.package.copy()
-                            package_cppinfo.set_relative_base_folder(conanfile.folders.package)
                             # Copy the infos.package into the old cppinfo
                             fill_old_cppinfo(conanfile.cpp.package, conanfile.cpp_info)
                         else:

--- a/conans/model/conan_file.py
+++ b/conans/model/conan_file.py
@@ -267,7 +267,7 @@ class ConanFile(object):
 
     @property
     def package_folder(self):
-        return self.folders.package_folder
+        return self.folders.base_package
 
     @package_folder.setter
     def package_folder(self, folder):

--- a/conans/test/functional/layout/test_build_system_layout_helpers.py
+++ b/conans/test/functional/layout/test_build_system_layout_helpers.py
@@ -24,7 +24,6 @@ def conanfile():
 
     def layout(self):
         {ly}(self)
-        self.folders.package = "my_package"
 
     def package(self):
         AutoPackager(self).run()
@@ -95,6 +94,7 @@ def test_layout_with_local_methods(conanfile, layout_helper_name, build_type, ar
         assert os.path.exists(path)
 
     # Check the package
-    client.run("package .")
-    assert os.path.exists(os.path.join(client.current_folder, "my_package", "lib", "mylib.lib"))
+    client.run("package .", assert_error=True)
+    assert "The usage of the 'conan package' local method is disabled when using layout()" \
+           "" in client.out
 

--- a/conans/test/functional/layout/test_in_cache.py
+++ b/conans/test/functional/layout/test_in_cache.py
@@ -173,11 +173,9 @@ def test_same_conanfile_local(conanfile):
     assert "Build folder: {}".format(build_folder) in client.out
     assert os.path.exists(os.path.join(build_folder, "build.lib"))
 
-    client.run("package .  -if=install")
-    # By default, the "package" folder is still used (not breaking)
-    pf = os.path.join(client.current_folder, "package")
-    assert "Package folder: {}".format(pf) in client.out
-    assert os.path.exists(os.path.join(pf, "LICENSE"))
+    client.run("package .  -if=install", assert_error=True)
+    assert "The usage of the 'conan package' local method is disabled when using " \
+           "layout()" in client.out
 
 
 def test_imports():

--- a/conans/test/functional/layout/test_local_commands.py
+++ b/conans/test/functional/layout/test_local_commands.py
@@ -3,6 +3,8 @@ import platform
 import re
 import textwrap
 
+import pytest
+
 from conans.model.ref import ConanFileReference, PackageReference
 from conans.test.assets.genconanfile import GenConanfile
 from conans.test.assets.pkg_cmake import pkg_cmake
@@ -252,6 +254,8 @@ def test_export_pkg():
     assert os.path.exists(os.path.join(pf, "library.lib"))
 
 
+@pytest.mark.xfail(reason="We cannot test the export-pkg from a local package folder when we cannot "
+                          "run the package method")
 def test_export_pkg_local():
     """The export-pkg, without calling "package" method, with local package, follows the layout"""
     client = TestClient()

--- a/conans/test/functional/toolchains/cmake/test_v2_cmake_template.py
+++ b/conans/test/functional/toolchains/cmake/test_v2_cmake_template.py
@@ -11,8 +11,6 @@ def test_cmake_lib_template():
     # Local flow works
     client.run("install . -if=install")
     client.run("build . -if=install")
-    client.run("package . -if=install")
-    assert os.path.exists(os.path.join(client.current_folder, "package", "include", "hello.h"))
 
     client.run("export-pkg . hello/0.1@ -if=install")
     package_id = re.search(r"Packaging to (\S+)", str(client.out)).group(1)


### PR DESCRIPTION
Changelog: Fix: Removed the new layout `folders.package` property as it was not clear the value/usage.
Changelog: Fix: The "conan package" method now raises an exception when declaring the layout() method. This is part of the migration to Conan 2.0 where the local method "conan package" is removed.
Docs: https://github.com/conan-io/docs/pull/2278

Closes: https://github.com/conan-io/conan/issues/9725
