### PR TITLE
Remove sdk condition for xcodedeps

### DIFF
--- a/conan/tools/apple/xcodedeps.py
+++ b/conan/tools/apple/xcodedeps.py
@@ -31,15 +31,15 @@ class XcodeDeps(object):
         #include "{{vars_filename}}"
 
         // Compiler options for {{name}}
-        HEADER_SEARCH_PATHS_{{name}}_{{configuration}}[arch={{architecture}}][sdk={{sdk}}] = $(CONAN_{{name}}_INCLUDE_DIRECTORIES_{{configuration}})
-        GCC_PREPROCESSOR_DEFINITIONS_{{name}}_{{configuration}}[arch={{architecture}}][sdk={{sdk}}] = $(CONAN_{{name}}_PREPROCESSOR_DEFINITIONS_{{configuration}})
-        OTHER_CFLAGS_{{name}}_{{configuration}}[arch={{architecture}}][sdk={{sdk}}] = $(CONAN_{{name}}_C_COMPILER_FLAGS_{{configuration}})
-        OTHER_CPLUSPLUSFLAGS_{{name}}_{{configuration}}[arch={{architecture}}][sdk={{sdk}}] = $(CONAN_{{name}}_CXX_COMPILER_FLAGS_{{configuration}})
-        FRAMEWORK_SEARCH_PATHS_{{name}}_{{configuration}}[arch={{architecture}}][sdk={{sdk}}] = $(CONAN_{{name}}_FRAMEWORKS_DIRECTORIES_{{configuration}})
+        HEADER_SEARCH_PATHS_{{name}}_{{configuration}}[arch={{architecture}}] = $(CONAN_{{name}}_INCLUDE_DIRECTORIES_{{configuration}})
+        GCC_PREPROCESSOR_DEFINITIONS_{{name}}_{{configuration}}[arch={{architecture}}] = $(CONAN_{{name}}_PREPROCESSOR_DEFINITIONS_{{configuration}})
+        OTHER_CFLAGS_{{name}}_{{configuration}}[arch={{architecture}}] = $(CONAN_{{name}}_C_COMPILER_FLAGS_{{configuration}})
+        OTHER_CPLUSPLUSFLAGS_{{name}}_{{configuration}}[arch={{architecture}}] = $(CONAN_{{name}}_CXX_COMPILER_FLAGS_{{configuration}})
+        FRAMEWORK_SEARCH_PATHS_{{name}}_{{configuration}}[arch={{architecture}}] = $(CONAN_{{name}}_FRAMEWORKS_DIRECTORIES_{{configuration}})
 
         // Link options for {{name}}
-        LIBRARY_SEARCH_PATHS_{{name}}_{{configuration}}[arch={{architecture}}][sdk={{sdk}}] = $(CONAN_{{name}}_LIBRARY_DIRECTORIES_{{configuration}})
-        OTHER_LDFLAGS_{{name}}_{{configuration}}[arch={{architecture}}][sdk={{sdk}}] = $(CONAN_{{name}}_LINKER_FLAGS_{{configuration}}) $(CONAN_{{name}}_LIBRARIES_{{configuration}}) $(CONAN_{{name}}_SYSTEM_LIBS_{{configuration}}) $(CONAN_{{name}}_FRAMEWORKS_{{configuration}})
+        LIBRARY_SEARCH_PATHS_{{name}}_{{configuration}}[arch={{architecture}}] = $(CONAN_{{name}}_LIBRARY_DIRECTORIES_{{configuration}})
+        OTHER_LDFLAGS_{{name}}_{{configuration}}[arch={{architecture}}] = $(CONAN_{{name}}_LINKER_FLAGS_{{configuration}}) $(CONAN_{{name}}_LIBRARIES_{{configuration}}) $(CONAN_{{name}}_SYSTEM_LIBS_{{configuration}}) $(CONAN_{{name}}_FRAMEWORKS_{{configuration}})
         """)
 
     _dep_xconfig = textwrap.dedent("""\
@@ -74,12 +74,7 @@ class XcodeDeps(object):
         # TODO: check if it makes sense to add a subsetting for sdk version
         #  related to: https://github.com/conan-io/conan/issues/9608
         self.os_version = conanfile.settings.get_safe("os.version")
-        self.sdk = conanfile.settings.get_safe("os.sdk")
         check_using_build_profile(self._conanfile)
-
-    @property
-    def sdk_condition(self):
-        return "*" if not self.sdk else "{}".format(self.sdk)
 
     def generate(self):
         if self.configuration is None:
@@ -93,8 +88,7 @@ class XcodeDeps(object):
     def _config_filename(self):
         # Default name
         props = [("configuration", self.configuration),
-                 ("architecture", self.architecture),
-                 ("sdk", self.sdk)]
+                 ("architecture", self.architecture)]
         name = "".join("_{}".format(v) for _, v in props if v is not None)
         return name.lower()
 
@@ -130,13 +124,14 @@ class XcodeDeps(object):
         """
         content for conan_poco_x86_release.xcconfig, containing the activation
         """
-        # TODO: we are not taking into account the version for the sdk because we probably
+        # TODO: when it's more clear what to do with the sdk, add the condition for it and also
+        #  we are not taking into account the version for the sdk because we probably
         #  want to model also the sdk version decoupled of the compiler version
         #  for example XCode 13 is now using sdk=macosx11.3
         #  related to: https://github.com/conan-io/conan/issues/9608
         template = Template(self._conf_xconfig)
         content_multi = template.render(name=dep_name, vars_filename=vars_xconfig_name,
-                                        architecture=self.architecture, sdk=self.sdk_condition,
+                                        architecture=self.architecture,
                                         configuration=self.configuration)
         return content_multi
 

--- a/conans/test/functional/toolchains/apple/test_xcodedeps_build_configs.py
+++ b/conans/test/functional/toolchains/apple/test_xcodedeps_build_configs.py
@@ -332,11 +332,11 @@ def test_xcodedeps_build_configurations():
 
     for config in ["Release", "Debug"]:
         client.run(
-            "install . -s build_type={} -s arch=x86_64 -s os.sdk=macosx --build=missing -g XcodeDeps".format(config))
+            "install . -s build_type={} -s arch=x86_64 --build=missing -g XcodeDeps".format(config))
 
     for config in ["Release", "Debug"]:
         client.run_command("xcodebuild -project {}.xcodeproj -xcconfig conandeps.xcconfig "
-                           "-configuration {} -sdk macosx -arch x86_64".format(project_name, config))
+                           "-configuration {} -arch x86_64".format(project_name, config))
         client.run_command("./build/{}/{}".format(config, project_name))
         assert "App {}!".format(config) in client.out
         assert "hello/0.1: Hello World {}!".format(config).format(config) in client.out
@@ -368,6 +368,6 @@ def test_frameworks():
     client.run("install . -s build_type=Release -s arch=x86_64 --build=missing -g XcodeDeps")
 
     client.run_command("xcodebuild -project {}.xcodeproj -xcconfig conandeps.xcconfig "
-                       "-configuration Release -sdk macosx12.0 -arch x86_64".format(project_name))
+                       "-configuration Release -arch x86_64".format(project_name))
     client.run_command("./build/Release/{}".format(project_name))
     assert "Hello!" in client.out

--- a/conans/test/integration/toolchains/apple/test_xcodedeps.py
+++ b/conans/test/integration/toolchains/apple/test_xcodedeps.py
@@ -34,27 +34,26 @@ _expected_vars_xconfig = [
 
 _expected_conf_xconfig = [
     "#include \"{vars_name}\"",
-    "HEADER_SEARCH_PATHS_{name}_{configuration}[arch=x86_64][sdk={sdk}] = $(CONAN_{name}_INCLUDE_DIRECTORIES_{configuration})",
-    "GCC_PREPROCESSOR_DEFINITIONS_{name}_{configuration}[arch=x86_64][sdk={sdk}] = $(CONAN_{name}_PREPROCESSOR_DEFINITIONS_{configuration})",
-    "OTHER_CFLAGS_{name}_{configuration}[arch=x86_64][sdk={sdk}] = $(CONAN_{name}_C_COMPILER_FLAGS_{configuration})",
-    "OTHER_CPLUSPLUSFLAGS_{name}_{configuration}[arch=x86_64][sdk={sdk}] = $(CONAN_{name}_CXX_COMPILER_FLAGS_{configuration})",
-    "FRAMEWORK_SEARCH_PATHS_{name}_{configuration}[arch=x86_64][sdk={sdk}] = $(CONAN_{name}_FRAMEWORKS_DIRECTORIES_{configuration})",
-    "LIBRARY_SEARCH_PATHS_{name}_{configuration}[arch=x86_64][sdk={sdk}] = $(CONAN_{name}_LIBRARY_DIRECTORIES_{configuration})",
-    "OTHER_LDFLAGS_{name}_{configuration}[arch=x86_64][sdk={sdk}] = $(CONAN_{name}_LINKER_FLAGS_{configuration}) $(CONAN_{name}_LIBRARIES_{configuration}) $(CONAN_{name}_SYSTEM_LIBS_{configuration}) $(CONAN_{name}_FRAMEWORKS_{configuration})"
+    "HEADER_SEARCH_PATHS_{name}_{configuration}[arch=x86_64] = $(CONAN_{name}_INCLUDE_DIRECTORIES_{configuration})",
+    "GCC_PREPROCESSOR_DEFINITIONS_{name}_{configuration}[arch=x86_64] = $(CONAN_{name}_PREPROCESSOR_DEFINITIONS_{configuration})",
+    "OTHER_CFLAGS_{name}_{configuration}[arch=x86_64] = $(CONAN_{name}_C_COMPILER_FLAGS_{configuration})",
+    "OTHER_CPLUSPLUSFLAGS_{name}_{configuration}[arch=x86_64] = $(CONAN_{name}_CXX_COMPILER_FLAGS_{configuration})",
+    "FRAMEWORK_SEARCH_PATHS_{name}_{configuration}[arch=x86_64] = $(CONAN_{name}_FRAMEWORKS_DIRECTORIES_{configuration})",
+    "LIBRARY_SEARCH_PATHS_{name}_{configuration}[arch=x86_64] = $(CONAN_{name}_LIBRARY_DIRECTORIES_{configuration})",
+    "OTHER_LDFLAGS_{name}_{configuration}[arch=x86_64] = $(CONAN_{name}_LINKER_FLAGS_{configuration}) $(CONAN_{name}_LIBRARIES_{configuration}) $(CONAN_{name}_SYSTEM_LIBS_{configuration}) $(CONAN_{name}_FRAMEWORKS_{configuration})"
 ]
 
 
-def get_name(configuration, architecture, sdk):
+def get_name(configuration, architecture):
     props = [("configuration", configuration),
-             ("architecture", architecture),
-             ("sdk", sdk)]
+             ("architecture", architecture)]
     name = "".join("_{}".format(v) for _, v in props if v is not None)
     return name.lower()
 
 
-def expected_files(current_folder, configuration, architecture, sdk=None):
+def expected_files(current_folder, configuration, architecture):
     files = []
-    name = get_name(configuration, architecture, sdk)
+    name = get_name(configuration, architecture)
     deps = ["hello", "goodbye"]
     files.extend(
         [os.path.join(current_folder, "conan_{}{}.xcconfig".format(dep, name)) for dep in deps])
@@ -64,11 +63,11 @@ def expected_files(current_folder, configuration, architecture, sdk=None):
     return files
 
 
-def check_contents(client, deps, configuration, architecture, sdk=None):
+def check_contents(client, deps, configuration, architecture):
     for dep_name in deps:
         dep_xconfig = client.load("conan_{}.xcconfig".format(dep_name))
         conf_name = "conan_{}{}.xcconfig".format(dep_name,
-                                                 get_name(configuration, architecture, sdk))
+                                                 get_name(configuration, architecture))
 
         assert '#include "{}"'.format(conf_name) in dep_xconfig
         for var in _expected_dep_xconfig:
@@ -76,17 +75,15 @@ def check_contents(client, deps, configuration, architecture, sdk=None):
             assert line in dep_xconfig
 
         vars_name = "conan_{}_vars{}.xcconfig".format(dep_name,
-                                                      get_name(configuration, architecture, sdk))
+                                                      get_name(configuration, architecture))
         conan_vars = client.load(vars_name)
         for var in _expected_vars_xconfig:
             line = var.format(name=dep_name, configuration=configuration)
             assert line in conan_vars
 
         conan_conf = client.load(conf_name)
-        sdk_condition = "*" if not sdk else "{}".format(sdk)
         for var in _expected_conf_xconfig:
-            assert var.format(vars_name=vars_name, name=dep_name, sdk=sdk_condition,
-                              configuration=configuration) in conan_conf
+            assert var.format(vars_name=vars_name, name=dep_name, configuration=configuration) in conan_conf
 
 
 @pytest.mark.skipif(platform.system() != "Darwin", reason="Only for MacOS")
@@ -104,18 +101,15 @@ def test_generator_files():
     client.run("export goodbye.py goodbye/0.1@")
     client.save({"conanfile.txt": "[requires]\nhello/0.1\ngoodbye/0.1\n"}, clean_first=True)
 
-    for sdk in [None, "macosx"]:
-        for build_type in ["Release", "Debug"]:
+    for build_type in ["Release", "Debug"]:
 
-            sdk_setting = "-s os.sdk={}".format(sdk) if sdk else ""
-            client.run("install . -g XcodeDeps -s build_type={} -s arch=x86_64 {} --build missing".
-                       format(build_type, sdk_setting))
+        client.run("install . -g XcodeDeps -s build_type={} -s arch=x86_64 --build missing".format(build_type))
 
-            for config_file in expected_files(client.current_folder, build_type, "x86_64", sdk):
-                assert os.path.isfile(config_file)
+        for config_file in expected_files(client.current_folder, build_type, "x86_64"):
+            assert os.path.isfile(config_file)
 
-            conandeps = client.load("conandeps.xcconfig")
-            assert '#include "conan_hello.xcconfig"' in conandeps
-            assert '#include "conan_goodbye.xcconfig"' in conandeps
+        conandeps = client.load("conandeps.xcconfig")
+        assert '#include "conan_hello.xcconfig"' in conandeps
+        assert '#include "conan_goodbye.xcconfig"' in conandeps
 
-            check_contents(client, ["hello", "goodbye"], build_type, "x86_64", sdk)
+        check_contents(client, ["hello", "goodbye"], build_type, "x86_64")


### PR DESCRIPTION
Changelog: Feature: Remove `sdk` condition in _.xcconfig_ files generated by _XcodeDeps_.
Docs: omit

We have decided to remove the sdk conditions until we investigate further if we have to add a sdk_version setting and also at the same time we introduce XcodeToolchain and Xcode build helper.
