### PR TITLE
fix VCvars defining -vcvars for 2015)

### DIFF
--- a/conans/test/integration/toolchains/microsoft/vcvars_test.py
+++ b/conans/test/integration/toolchains/microsoft/vcvars_test.py
@@ -51,3 +51,22 @@ def test_vcvars_generator_string():
                '-s compiler.cppstd=14 -s compiler.runtime=static')
 
     assert os.path.exists(os.path.join(client.current_folder, "conanvcvars.bat"))
+
+
+@pytest.mark.skipif(platform.system() != "Windows", reason="Requires Windows")
+def test_vcvars_2015_error():
+    # https://github.com/conan-io/conan/issues/9888
+    client = TestClient(path_with_spaces=False)
+
+    conanfile = textwrap.dedent("""
+        from conans import ConanFile
+        class TestConan(ConanFile):
+            generators = "VCVars"
+            settings = "os", "compiler", "arch", "build_type"
+    """)
+    client.save({"conanfile.py": conanfile})
+    client.run('install . -s os=Windows -s compiler="msvc" -s compiler.version=19.0 '
+               '-s compiler.cppstd=14 -s compiler.runtime=static')
+
+    vcvars = client.load("conanvcvars.bat")
+    assert "-vcvars_ver" not in vcvars

--- a/conans/test/unittests/tools/cmake/test_cmaketoolchain.py
+++ b/conans/test/unittests/tools/cmake/test_cmaketoolchain.py
@@ -167,6 +167,7 @@ def test_osx_deployment_target(conanfile_apple):
     content = toolchain.content
     assert 'set(CMAKE_OSX_DEPLOYMENT_TARGET "10.15" CACHE STRING "")' in content
 
+
 @pytest.fixture
 def conanfile_msvc():
     c = ConanFile(Mock(), None)
@@ -186,6 +187,7 @@ def conanfile_msvc():
     c._conan_node = Mock()
     c._conan_node.dependencies = []
     return c
+
 
 def test_toolset(conanfile_msvc):
     toolchain = CMakeToolchain(conanfile_msvc)


### PR DESCRIPTION
Changelog: Bugfix: Avoid VCVars defining ``-vcvars`` argument for VS<=2015. Close https://github.com/conan-io/conan/issues/9888
Docs: Omit


