### PR TITLE
making the filename property independent

### DIFF
--- a/conan/tools/gnu/autotoolsdeps.py
+++ b/conan/tools/gnu/autotoolsdeps.py
@@ -23,6 +23,7 @@ class AutotoolsDeps:
 
     @property
     def environment(self):
+        # TODO: Seems we want to make this uniform, equal to other generators
         if self._environment is None:
             flags = GnuDepsFlags(self._conanfile, self._get_cpp_info())
 

--- a/conans/client/generators/__init__.py
+++ b/conans/client/generators/__init__.py
@@ -260,6 +260,7 @@ def _generate_aggregated_env(conanfile):
     from conan.tools.microsoft.subsystems import subsystem_path
 
     def deactivates(filenames):
+        # FIXME: Probably the order needs to be reversed
         result = []
         for s in filenames:
             folder, f = os.path.split(s)

--- a/conans/model/build_info.py
+++ b/conans/model/build_info.py
@@ -236,7 +236,8 @@ class _CppInfo(object):
         result = self.get_property(property_name, generator) or self.filenames.get(generator)
         if result:
             return result
-        return self.get_name(generator, default_name=default_name)
+        # Default to the legacy "names", but not using the other properties like "cmake_target_name"
+        return self.names.get(generator, self._name if default_name else None)
 
     # TODO: Deprecate for 2.0. Use get_property for 2.0
     def get_build_modules(self):


### PR DESCRIPTION
Changelog: Fix: Do not fall back for the property "filename" to target properties, only to legacy "names" definition.
Docs: omit

#tags: slow