### PR TITLE
Bugfix: missing framework for xcode generator with no compiler setting

### DIFF
--- a/conans/client/generators/xcode.py
+++ b/conans/client/generators/xcode.py
@@ -29,7 +29,8 @@ FRAMEWORK_SEARCH_PATHS = $(inherited) {rootpaths} {framework_paths}
         self.cxx_compiler_flags = " ".join(deps_cpp_info.cxxflags)
         self.linker_flags = " ".join(deps_cpp_info.sharedlinkflags)
         self.rootpaths = " ".join('"%s"' % d.replace("\\", "/") for d in deps_cpp_info.rootpaths)
-        self.frameworks = " ".join(format_frameworks(deps_cpp_info.frameworks, self.conanfile.settings))
+        self.frameworks = " ".join(["-framework %s" % framework
+                                    for framework in deps_cpp_info.frameworks])
         self.framework_paths = " ".join(deps_cpp_info.framework_paths)
         self.system_libs = " ".join(['-l%s' % lib for lib in deps_cpp_info.system_libs])
 


### PR DESCRIPTION
closes: #9878 

Changelog: Bugfix: Missing framework for Xcode generator with no compiler setting.
Docs: omit

- [x] Refer to the issue that supports this Pull Request.
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 

<sup>**Note:** By default this PR will skip the slower tests and will use a limited set of python versions. Check [here](https://github.com/conan-io/conan/blob/develop/.github/PR_INCREASE_TESTING.md) how to increase the testing level by writing some tags in the current PR body text.</sup>
