### PR TITLE
conan_server own package

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -28,9 +28,11 @@ def get_requires(filename):
 project_requirements = get_requires("conans/requirements.txt")
 dev_requirements = get_requires("conans/requirements_dev.txt")
 # The tests utils are used by conan-package-tools
-exclude_test_packages = ["conans.test.{}*".format(d)
+excluded_test_packages = ["conans.test.{}*".format(d)
                          for d in os.listdir(os.path.join(here, "conans/test"))
                          if os.path.isdir(os.path.join(here, "conans/test", d)) and d != "utils"]
+excluded_server_packages = ["conans.server*"]
+exclude = excluded_test_packages + excluded_server_packages
 
 
 def load_version():
@@ -89,7 +91,7 @@ setup(
 
     # You can just specify the packages manually here if your project is
     # simple. Or you can use find_packages().
-    packages=find_packages(exclude=exclude_test_packages),
+    packages=find_packages(exclude=exclude),
 
     # Alternatively, if you want to distribute just a my_module.py, uncomment
     # this:

--- a/setup.py
+++ b/setup.py
@@ -4,16 +4,19 @@ https://packaging.python.org/en/latest/distributing.html
 https://github.com/pypa/sampleproject
 """
 
-import os
-import re
-# To use a consistent encoding
-from codecs import open
-from os import path
-
 # Always prefer setuptools over distutils
 from setuptools import find_packages, setup
 
+import os
+import re
+from os import path
+
+
+# The tests utils are used by conan-package-tools
 here = path.abspath(path.dirname(__file__))
+excluded_test_packages = ["conans.test.{}*".format(d)
+                         for d in os.listdir(os.path.join(here, "conans/test"))
+                         if os.path.isdir(os.path.join(here, "conans/test", d)) and d != "utils"]
 
 
 def get_requires(filename):
@@ -23,16 +26,6 @@ def get_requires(filename):
             if not line.strip().startswith("#"):
                 requirements.append(line)
     return requirements
-
-
-project_requirements = get_requires("conans/requirements.txt")
-dev_requirements = get_requires("conans/requirements_dev.txt")
-# The tests utils are used by conan-package-tools
-excluded_test_packages = ["conans.test.{}*".format(d)
-                         for d in os.listdir(os.path.join(here, "conans/test"))
-                         if os.path.isdir(os.path.join(here, "conans/test", d)) and d != "utils"]
-excluded_server_packages = ["conans.server*"]
-exclude = excluded_test_packages + excluded_server_packages
 
 
 def load_version():
@@ -50,6 +43,11 @@ def generate_long_description_file():
     with open(path.join(this_directory, 'README.rst'), encoding='utf-8') as f:
         long_description = f.read()
     return long_description
+
+project_requirements = get_requires("conans/requirements.txt")
+dev_requirements = get_requires("conans/requirements_dev.txt")
+excluded_server_packages = ["conans.server*"]
+exclude = excluded_test_packages + excluded_server_packages
 
 
 setup(

--- a/setup_server.py
+++ b/setup_server.py
@@ -22,7 +22,7 @@ dev_requirements = get_requires("conans/requirements_dev.txt")
 
 
 setup(
-    name='conan_server',
+    name='conan-server',
     # Versions should comply with PEP440.  For a discussion on single-sourcing
     # the version across setup.py and the project code, see
     # https://packaging.python.org/en/latest/single_source_version.html

--- a/setup_server.py
+++ b/setup_server.py
@@ -12,17 +12,14 @@ from os import path
 # Always prefer setuptools over distutils
 from setuptools import find_packages, setup
 
-from setup import load_version, generate_long_description_file, get_requires
+from setup import load_version, generate_long_description_file, get_requires, excluded_test_packages
 
 here = path.abspath(path.dirname(__file__))
 
 project_requirements = get_requires("conans/requirements.txt")
 project_requirements.extend(get_requires("conans/requirements_server.txt"))
 dev_requirements = get_requires("conans/requirements_dev.txt")
-# The tests utils are used by conan-package-tools
-exclude_test_packages = ["conans.test.{}*".format(d)
-                         for d in os.listdir(os.path.join(here, "conans/test"))
-                         if os.path.isdir(os.path.join(here, "conans/test", d)) and d != "utils"]
+
 
 setup(
     name='conan_server',
@@ -63,7 +60,7 @@ setup(
 
     # You can just specify the packages manually here if your project is
     # simple. Or you can use find_packages().
-    packages=find_packages(exclude=exclude_test_packages),
+    packages=find_packages(exclude=excluded_test_packages),
 
     # Alternatively, if you want to distribute just a my_module.py, uncomment
     # this:

--- a/setup_server.py
+++ b/setup_server.py
@@ -5,7 +5,6 @@ https://github.com/pypa/sampleproject
 """
 
 import os
-import re
 # To use a consistent encoding
 from codecs import open
 from os import path
@@ -13,51 +12,26 @@ from os import path
 # Always prefer setuptools over distutils
 from setuptools import find_packages, setup
 
+from setup import load_version, generate_long_description_file, get_requires
+
 here = path.abspath(path.dirname(__file__))
 
-
-def get_requires(filename):
-    requirements = []
-    with open(filename, "rt") as req_file:
-        for line in req_file.read().splitlines():
-            if not line.strip().startswith("#"):
-                requirements.append(line)
-    return requirements
-
-
 project_requirements = get_requires("conans/requirements.txt")
+project_requirements.extend(get_requires("conans/requirements_server.txt"))
 dev_requirements = get_requires("conans/requirements_dev.txt")
 # The tests utils are used by conan-package-tools
 exclude_test_packages = ["conans.test.{}*".format(d)
                          for d in os.listdir(os.path.join(here, "conans/test"))
                          if os.path.isdir(os.path.join(here, "conans/test", d)) and d != "utils"]
 
-
-def load_version():
-    """ Loads a file content """
-    filename = os.path.abspath(os.path.join(os.path.dirname(os.path.abspath(__file__)),
-                                            "conans", "__init__.py"))
-    with open(filename, "rt") as version_file:
-        conan_init = version_file.read()
-        version = re.search(r"__version__ = '([0-9a-z.-]+)'", conan_init).group(1)
-        return version
-
-
-def generate_long_description_file():
-    this_directory = path.abspath(path.dirname(__file__))
-    with open(path.join(this_directory, 'README.rst'), encoding='utf-8') as f:
-        long_description = f.read()
-    return long_description
-
-
 setup(
-    name='conan',
+    name='conan_server',
     # Versions should comply with PEP440.  For a discussion on single-sourcing
     # the version across setup.py and the project code, see
     # https://packaging.python.org/en/latest/single_source_version.html
     version=load_version(),  # + ".rc1",
 
-    description='Conan C/C++ package manager',
+    description='Conan Server of Conan C/C++ package manager',
     long_description=generate_long_description_file(),
     long_description_content_type='text/x-rst',
 
@@ -128,7 +102,7 @@ setup(
     # pip to create the appropriate form of executable for the target platform.
     entry_points={
         'console_scripts': [
-            'conan=conans.conan:run',
+            'conan_server=conans.conan_server:run'
         ],
     },
 )


### PR DESCRIPTION
- `pip install -e .` only installs conan (without conan_server requirements)
- ⚠️ To install `conan_server` tool in development we cannot (apparently) use `pip install -e` but we can do `python setup_server.py install`
- The deployment can be done the same way but split, something like:
  ```
   $ > rm -rf dist
   $ > python3 setup.py bdist_wheel 
   $ > twine upload dist/* 
   $ > rm -rf dist
   $ > python3 setup_server.py bdist_wheel 
   $ > twine upload dist/* 
   ```
   This has to be confirmed by the release manager @czoido (note that I'm not sure if we are using bdist_wheel or sdist, keep using the same)