### PR TITLE
Add return code 7 (Invalid system requirements)

### DIFF
--- a/conans/cli/exit_codes.py
+++ b/conans/cli/exit_codes.py
@@ -1,8 +1,9 @@
 # Exit codes for conan command:
-SUCCESS = 0                         # 0: Success (done)
-ERROR_GENERAL = 1                   # 1: General ConanException error (done)
-ERROR_MIGRATION = 2                 # 2: Migration error
-USER_CTRL_C = 3                     # 3: Ctrl+C
-USER_CTRL_BREAK = 4                 # 4: Ctrl+Break
-ERROR_SIGTERM = 5                   # 5: SIGTERM
-ERROR_INVALID_CONFIGURATION = 6     # 6: Invalid configuration (done)
+SUCCESS = 0                             # 0: Success (done)
+ERROR_GENERAL = 1                       # 1: General ConanException error (done)
+ERROR_MIGRATION = 2                     # 2: Migration error
+USER_CTRL_C = 3                         # 3: Ctrl+C
+USER_CTRL_BREAK = 4                     # 4: Ctrl+Break
+ERROR_SIGTERM = 5                       # 5: SIGTERM
+ERROR_INVALID_CONFIGURATION = 6         # 6: Invalid configuration (done)
+ERROR_INVALID_SYSTEM_REQUIREMENTS = 7   # 7: Invalid system requirements

--- a/conans/client/command.py
+++ b/conans/client/command.py
@@ -19,7 +19,7 @@ from conans.client.conan_command_output import CommandOutputer
 from conans.client.output import Color
 from conans.client.printer import Printer
 from conans.errors import ConanException, ConanInvalidConfiguration, NoRemoteAvailable, \
-    ConanMigrationError
+    ConanMigrationError, ConanInvalidSystemRequirements
 from conans.model.ref import ConanFileReference, PackageReference, get_reference_fields, \
     check_valid_ref
 from conans.model.conf import DEFAULT_CONFIGURATION
@@ -29,7 +29,7 @@ from conans.util.files import save
 from conans.util.log import logger
 from conans.assets import templates
 from conans.cli.exit_codes import SUCCESS, ERROR_MIGRATION, ERROR_GENERAL, USER_CTRL_C, \
-    ERROR_SIGTERM, USER_CTRL_BREAK, ERROR_INVALID_CONFIGURATION
+    ERROR_SIGTERM, USER_CTRL_BREAK, ERROR_INVALID_CONFIGURATION, ERROR_INVALID_SYSTEM_REQUIREMENTS
 
 
 class Extender(argparse.Action):
@@ -2240,6 +2240,9 @@ class Command(object):
             ret_code = exc.code
         except ConanInvalidConfiguration as exc:
             ret_code = ERROR_INVALID_CONFIGURATION
+            self._out.error(exc)
+        except ConanInvalidSystemRequirements as exc:
+            ret_code = ERROR_INVALID_SYSTEM_REQUIREMENTS
             self._out.error(exc)
         except ConanException as exc:
             ret_code = ERROR_GENERAL

--- a/conans/client/tools/system_pm.py
+++ b/conans/client/tools/system_pm.py
@@ -5,7 +5,7 @@ import six
 from conans.client.runner import ConanRunner
 from conans.client.tools.oss import OSInfo, cross_building, get_cross_building_settings
 from conans.client.tools.files import which
-from conans.errors import ConanException, ConanInvalidConfiguration
+from conans.errors import ConanException, ConanInvalidSystemRequirements
 from conans.util.env_reader import get_env
 from conans.util.fallbacks import default_output
 
@@ -116,7 +116,7 @@ class SystemPackageTool(object):
             if mode == "verify" and not self._installed(packages):
                 self._output.error("The following packages need to be installed:\n %s"
                                    % "\n".join(packages))
-                raise ConanInvalidConfiguration("Aborted due to CONAN_SYSREQUIRES_MODE=%s. "
+                raise ConanInvalidSystemRequirements("Aborted due to CONAN_SYSREQUIRES_MODE=%s. "
                                      "Some system packages need to be installed" % mode)
 
         if not force and self._installed(packages):
@@ -172,7 +172,7 @@ class SystemPackageTool(object):
             if mode == "verify" and not self._installed(packages):
                 self._output.error("The following packages need to be installed:\n %s"
                                    % "\n".join(packages))
-                raise ConanInvalidConfiguration("Aborted due to CONAN_SYSREQUIRES_MODE=%s. "
+                raise ConanInvalidSystemRequirements("Aborted due to CONAN_SYSREQUIRES_MODE=%s. "
                                      "Some system packages need to be installed" % mode)
 
         packages = packages if force else self._to_be_installed(packages)

--- a/conans/client/tools/system_pm.py
+++ b/conans/client/tools/system_pm.py
@@ -5,7 +5,7 @@ import six
 from conans.client.runner import ConanRunner
 from conans.client.tools.oss import OSInfo, cross_building, get_cross_building_settings
 from conans.client.tools.files import which
-from conans.errors import ConanException
+from conans.errors import ConanException, ConanInvalidConfiguration
 from conans.util.env_reader import get_env
 from conans.util.fallbacks import default_output
 
@@ -116,7 +116,7 @@ class SystemPackageTool(object):
             if mode == "verify" and not self._installed(packages):
                 self._output.error("The following packages need to be installed:\n %s"
                                    % "\n".join(packages))
-                raise ConanException("Aborted due to CONAN_SYSREQUIRES_MODE=%s. "
+                raise ConanInvalidConfiguration("Aborted due to CONAN_SYSREQUIRES_MODE=%s. "
                                      "Some system packages need to be installed" % mode)
 
         if not force and self._installed(packages):
@@ -172,7 +172,7 @@ class SystemPackageTool(object):
             if mode == "verify" and not self._installed(packages):
                 self._output.error("The following packages need to be installed:\n %s"
                                    % "\n".join(packages))
-                raise ConanException("Aborted due to CONAN_SYSREQUIRES_MODE=%s. "
+                raise ConanInvalidConfiguration("Aborted due to CONAN_SYSREQUIRES_MODE=%s. "
                                      "Some system packages need to be installed" % mode)
 
         packages = packages if force else self._to_be_installed(packages)

--- a/conans/errors.py
+++ b/conans/errors.py
@@ -32,8 +32,12 @@ def conanfile_exception_formatter(conanfile_name, func_name):
     """
     try:
         yield
+    # TODO: Move ConanInvalidSystemRequirements, ConanInvalidConfiguration from here?
+    except ConanInvalidSystemRequirements as exc:
+        msg = "{}: Invalid system requirements: {}".format(conanfile_name, exc)
+        raise ConanInvalidSystemRequirements(msg)
     except ConanInvalidConfiguration as exc:
-        msg = "{}: Invalid configuration: {}".format(conanfile_name, exc)  # TODO: Move from here?
+        msg = "{}: Invalid configuration: {}".format(conanfile_name, exc)
         raise ConanInvalidConfiguration(msg)
     except Exception as exc:
         msg = _format_conanfile_exception(conanfile_name, func_name, exc)

--- a/conans/errors.py
+++ b/conans/errors.py
@@ -144,6 +144,10 @@ class ConanExceptionInUserConanfileMethod(ConanException):
     pass
 
 
+class ConanInvalidSystemRequirements(ConanException):
+    pass
+
+
 class ConanInvalidConfiguration(ConanExceptionInUserConanfileMethod):
     pass
 

--- a/conans/test/integration/conanfile/invalid_system_requirements_test.py
+++ b/conans/test/integration/conanfile/invalid_system_requirements_test.py
@@ -1,0 +1,5 @@
+import unittest
+
+
+class InvalidSystemRequirementsTest(unittest.TestCase):
+    pass

--- a/conans/test/integration/conanfile/invalid_system_requirements_test.py
+++ b/conans/test/integration/conanfile/invalid_system_requirements_test.py
@@ -1,5 +1,24 @@
 import unittest
+from conans.client.command import ERROR_INVALID_SYSTEM_REQUIREMENTS
+from conans.test.utils.tools import TestClient
 
 
 class InvalidSystemRequirementsTest(unittest.TestCase):
-    pass
+    def test_create_method(self):
+        self.client = TestClient()
+        self.client.save({"conanfile.py": """
+from conans import ConanFile
+from conans.errors import ConanInvalidSystemRequirements
+
+class MyPkg(ConanFile):
+    settings = "os", "compiler", "build_type", "arch"
+
+    def build_requirements(self):
+        raise ConanInvalidSystemRequirements("Some package missed")
+
+"""})
+
+        error = self.client.run("create . name/ver@jgsogo/test", assert_error=True)
+        self.assertEqual(error, ERROR_INVALID_SYSTEM_REQUIREMENTS)
+        self.assertIn("Invalid system requirements: Some package missed", self.client.out)
+

--- a/conans/test/unittests/client/tools/system_pm_test.py
+++ b/conans/test/unittests/client/tools/system_pm_test.py
@@ -9,7 +9,7 @@ from conans.client.output import ConanOutput
 from conans.client.tools.files import which
 from conans.client.tools.oss import OSInfo
 from conans.client.tools.system_pm import ChocolateyTool, SystemPackageTool, AptTool
-from conans.errors import ConanException
+from conans.errors import ConanException, ConanInvalidConfiguration
 from conans.test.unittests.util.tools_test import RunnerMock
 from conans.test.utils.mocks import MockSettings, MockConanfile, TestBufferConanOutput
 
@@ -427,7 +427,7 @@ class SystemPackageToolTest(unittest.TestCase):
             packages = ["verify_package", "verify_another_package", "verify_yet_another_package"]
             runner = RunnerMultipleMock(["sudo -A apt-get update"])
             spt = SystemPackageTool(runner=runner, tool=AptTool(output=self.out), output=self.out)
-            with self.assertRaises(ConanException) as exc:
+            with self.assertRaises(ConanInvalidConfiguration) as exc:
                 spt.install(packages)
             self.assertIn("Aborted due to CONAN_SYSREQUIRES_MODE=", str(exc.exception))
             self.assertIn('\n'.join(packages), self.out)
@@ -469,7 +469,7 @@ class SystemPackageToolTest(unittest.TestCase):
             runner = RunnerMultipleMock(["sudo -A apt-get update"])
             spt = SystemPackageTool(runner=runner, tool=AptTool(output=self.out), output=self.out,
                                     default_mode="verify")
-            with self.assertRaises(ConanException) as exc:
+            with self.assertRaises(ConanInvalidConfiguration) as exc:
                 spt.install(packages)
             self.assertIn("Aborted due to CONAN_SYSREQUIRES_MODE=", str(exc.exception))
             self.assertIn('\n'.join(packages), self.out)

--- a/conans/test/unittests/client/tools/system_pm_test.py
+++ b/conans/test/unittests/client/tools/system_pm_test.py
@@ -9,7 +9,7 @@ from conans.client.output import ConanOutput
 from conans.client.tools.files import which
 from conans.client.tools.oss import OSInfo
 from conans.client.tools.system_pm import ChocolateyTool, SystemPackageTool, AptTool
-from conans.errors import ConanException, ConanInvalidConfiguration
+from conans.errors import ConanException, ConanInvalidSystemRequirements
 from conans.test.unittests.util.tools_test import RunnerMock
 from conans.test.utils.mocks import MockSettings, MockConanfile, TestBufferConanOutput
 
@@ -427,7 +427,7 @@ class SystemPackageToolTest(unittest.TestCase):
             packages = ["verify_package", "verify_another_package", "verify_yet_another_package"]
             runner = RunnerMultipleMock(["sudo -A apt-get update"])
             spt = SystemPackageTool(runner=runner, tool=AptTool(output=self.out), output=self.out)
-            with self.assertRaises(ConanInvalidConfiguration) as exc:
+            with self.assertRaises(ConanInvalidSystemRequirements) as exc:
                 spt.install(packages)
             self.assertIn("Aborted due to CONAN_SYSREQUIRES_MODE=", str(exc.exception))
             self.assertIn('\n'.join(packages), self.out)
@@ -469,7 +469,7 @@ class SystemPackageToolTest(unittest.TestCase):
             runner = RunnerMultipleMock(["sudo -A apt-get update"])
             spt = SystemPackageTool(runner=runner, tool=AptTool(output=self.out), output=self.out,
                                     default_mode="verify")
-            with self.assertRaises(ConanInvalidConfiguration) as exc:
+            with self.assertRaises(ConanInvalidSystemRequirements) as exc:
                 spt.install(packages)
             self.assertIn("Aborted due to CONAN_SYSREQUIRES_MODE=", str(exc.exception))
             self.assertIn('\n'.join(packages), self.out)


### PR DESCRIPTION
Changelog: Fix: Respect error code 6 in some situations.
Docs: omit

- [ ] Refer to the issue that supports this Pull Request.
- [ ] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [ ] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 


In my case, i want to filter builds (with incorrect environment) which return code is 6. Based on https://github.com/conan-io/conan/issues/5163, I think that it can be merged.
