### PR TITLE
Fix bug 9885: config install 

### DIFF
--- a/conans/client/conf/config_installer.py
+++ b/conans/client/conf/config_installer.py
@@ -82,8 +82,12 @@ def _filecopy(src, filename, dst):
     # copying with permissions that later cause bugs
     src = os.path.join(src, filename)
     dst = os.path.join(dst, filename)
+    # Clear the destination file
     if os.path.exists(dst):
-        remove(dst)
+        if os.path.isdir(dst):  # dst was a directory and now src is a file
+            rmdir(dst)
+        else:
+            remove(dst)
     shutil.copyfile(src, dst)
 
 
@@ -119,6 +123,11 @@ def _process_file(directory, filename, config, cache, output, folder):
                                              relpath)
             else:
                 target_folder = os.path.join(cache.cache_folder, relpath)
+
+            if os.path.exists(target_folder):
+                if os.path.isfile(target_folder):  # Existed as a file and now should be a folder
+                    remove(target_folder)
+
             mkdir(target_folder)
             output.info("Copying file %s to %s" % (filename, target_folder))
             _filecopy(directory, filename, target_folder)

--- a/conans/test/functional/command/config_install_test.py
+++ b/conans/test/functional/command/config_install_test.py
@@ -804,3 +804,30 @@ class ConfigInstallSchedTest(unittest.TestCase):
         assert "config_install_interval = 5m" in conf
         dirs = os.listdir(client.cache.cache_folder)
         assert ".git" not in dirs
+
+    def test_config_install_reestructuring_source(self):
+        """  https://github.com/conan-io/conan/issues/9885 """
+
+        folder = temp_folder()
+        client = TestClient()
+        with client.chdir(folder):
+            client.save({"profiles/debug/address-sanitizer": ""})
+            client.run("config install .")
+
+        debug_cache_folder = os.path.join(client.cache_folder, "profiles", "debug")
+        assert os.path.isdir(debug_cache_folder)
+
+        # Now reestructure the files, what it was already a directory in the cache now we want
+        # it to be a file
+        folder = temp_folder()
+        with client.chdir(folder):
+            client.save({"profiles/debug": ""})
+            client.run("config install .")
+        assert os.path.isfile(debug_cache_folder)
+
+        # And now is a directory again
+        folder = temp_folder()
+        with client.chdir(folder):
+            client.save({"profiles/debug/address-sanitizer": ""})
+            client.run("config install .")
+        assert os.path.isdir(debug_cache_folder)


### PR DESCRIPTION
Changelog:  Bugfix: Solved an issue with the `conan config install` whereby a cryptic error was raised when a user tried to install a directory that previously was a file and vice-versa.
Docs: omit



Close #9885
