### PR TITLE
user_toolchain.cmake include quotes

### DIFF
--- a/conan/tools/cmake/toolchain.py
+++ b/conan/tools/cmake/toolchain.py
@@ -451,7 +451,7 @@ class FindConfigFiles(Block):
 class UserToolchain(Block):
     template = textwrap.dedent("""
         {% if user_toolchain %}
-        include({{user_toolchain}})
+        include("{{user_toolchain}}")
         {% endif %}
         """)
 
@@ -460,7 +460,10 @@ class UserToolchain(Block):
     def context(self):
         # This is global [conf] injection of extra toolchain files
         user_toolchain = self._conanfile.conf["tools.cmake.cmaketoolchain:user_toolchain"]
-        return {"user_toolchain": user_toolchain or self.user_toolchain}
+        user_toolchain = user_toolchain or self.user_toolchain
+        if user_toolchain:
+            user_toolchain = user_toolchain.replace("\\", "/")
+        return {"user_toolchain": user_toolchain}
 
 
 class CMakeFlagsInitBlock(Block):

--- a/conans/client/generators/__init__.py
+++ b/conans/client/generators/__init__.py
@@ -221,7 +221,7 @@ def _receive_conf(conanfile):
     # Conf only for first level build_requires
     for build_require in conanfile.dependencies.direct_build.values():
         if build_require.conf_info:
-            conanfile.conf.compose(build_require.conf_info)
+            conanfile.conf.compose_conf(build_require.conf_info)
 
 
 def write_toolchain(conanfile, path, output):

--- a/conans/model/conf.py
+++ b/conans/model/conf.py
@@ -81,7 +81,7 @@ class Conf(object):
         """
         self._values.update(other._values)
 
-    def compose(self, other):
+    def compose_conf(self, other):
         """
         :param other: other has less priority than current one
         :type other: Conf

--- a/conans/test/functional/toolchains/cmake/test_cmake_toolchain.py
+++ b/conans/test/functional/toolchains/cmake/test_cmake_toolchain.py
@@ -1,9 +1,11 @@
 import os
 import platform
+import textwrap
 
 import pytest
 
 from conan.tools.files import load_toolchain_args
+from conans.test.assets.cmake import gen_cmakelists
 from conans.test.assets.genconanfile import GenConanfile
 from conans.test.utils.tools import TestClient
 from conans.util.files import save
@@ -49,7 +51,7 @@ def test_cmake_toolchain_user_toolchain():
     client.save({"conanfile.py": conanfile})
     client.run("install .")
     toolchain = client.load("conan_toolchain.cmake")
-    assert "include(mytoolchain.cmake)" in toolchain
+    assert 'include("mytoolchain.cmake")' in toolchain
 
 
 def test_cmake_toolchain_custom_toolchain():
@@ -63,3 +65,39 @@ def test_cmake_toolchain_custom_toolchain():
     assert not os.path.exists(os.path.join(client.current_folder, "conan_toolchain.cmake"))
     build_content = load_toolchain_args(client.current_folder)
     assert "mytoolchain.cmake" == build_content["cmake_toolchain_file"]
+
+
+def test_cmake_toolchain_user_toolchain_from_dep():
+    client = TestClient()
+    conanfile = textwrap.dedent("""
+        import os
+        from conans import ConanFile
+        class Pkg(ConanFile):
+            exports_sources = "*"
+            def package(self):
+                self.copy("*")
+            def package_info(self):
+                f = os.path.join(self.package_folder, "mytoolchain.cmake")
+                self.conf_info["tools.cmake.cmaketoolchain:user_toolchain"] = f
+        """)
+    client.save({"conanfile.py": conanfile,
+                 "mytoolchain.cmake": 'message(STATUS "mytoolchain.cmake !!!running!!!")'})
+    client.run("create . toolchain/0.1@")
+
+    conanfile = textwrap.dedent("""
+        from conans import ConanFile
+        from conan.tools.cmake import CMake
+        class Pkg(ConanFile):
+            settings = "os", "compiler", "arch", "build_type"
+            exports_sources = "CMakeLists.txt"
+            build_requires = "toolchain/0.1"
+            generators = "CMakeToolchain"
+            def build(self):
+                cmake = CMake(self)
+                cmake.configure()
+        """)
+
+    client.save({"conanfile.py": conanfile,
+                 "CMakeLists.txt": gen_cmakelists()}, clean_first=True)
+    client.run("create . pkg/0.1@")
+    assert "mytoolchain.cmake !!!running!!!" in client.out

--- a/conans/test/integration/configuration/conf/test_conf_from_br.py
+++ b/conans/test/integration/configuration/conf/test_conf_from_br.py
@@ -95,7 +95,7 @@ def test_declared_generators_get_conf():
     client.save({"conanfile.py": consumer}, clean_first=True)
     client.run("install . -pr:b=default")
     toolchain = client.load("conan_toolchain.cmake")
-    assert "include(mytoolchain.cmake)" in toolchain
+    assert 'include("mytoolchain.cmake")' in toolchain
 
     consumer = textwrap.dedent("""
         from conans import ConanFile
@@ -111,4 +111,4 @@ def test_declared_generators_get_conf():
     client.save({"conanfile.py": consumer}, clean_first=True)
     client.run("install . -pr:b=default")
     toolchain = client.load("conan_toolchain.cmake")
-    assert "include(mytoolchain.cmake)" in toolchain
+    assert 'include("mytoolchain.cmake")' in toolchain

--- a/conans/test/unittests/tools/cmake/test_cmaketoolchain.py
+++ b/conans/test/unittests/tools/cmake/test_cmaketoolchain.py
@@ -136,11 +136,12 @@ def test_user_toolchain(conanfile):
     toolchain = CMakeToolchain(conanfile)
     toolchain.blocks["user_toolchain"].user_toolchain = "myowntoolchain.cmake"
     content = toolchain.content
-    assert 'include(myowntoolchain.cmake)' in content
+    assert 'include("myowntoolchain.cmake")' in content
 
     toolchain = CMakeToolchain(conanfile)
     content = toolchain.content
     assert 'include(' not in content
+
 
 @pytest.fixture
 def conanfile_apple():
@@ -161,6 +162,7 @@ def conanfile_apple():
     c._conan_node = Mock()
     c._conan_node.dependencies = []
     return c
+
 
 def test_osx_deployment_target(conanfile_apple):
     toolchain = CMakeToolchain(conanfile_apple)


### PR DESCRIPTION
Changelog: Bugfix: ``user_toolchain`` properly included and path quoted in ``CMakeToolchain``.
Docs: Omit

It also adds a full functional test to validate a toolchain can be defined from a build_require
