### PR TITLE
Make the vs environment take effect when generating the configuration…

### DIFF
--- a/conans/client/build/meson.py
+++ b/conans/client/build/meson.py
@@ -164,7 +164,11 @@ class Meson(object):
             build_type
         ])
         command = 'meson "%s" "%s" %s' % (source_dir, self.build_dir, arg_list)
-        with environment_append({"PKG_CONFIG_PATH": pc_paths}):
+        envs = {"PKG_CONFIG_PATH": pc_paths}
+        if self._append_vcvars and self.backend.startswith("vs"):
+            vcvars_dict = tools.vcvars_dict(self._settings, output=self._conanfile.output)
+            envs.update(vcvars_dict)
+        with environment_append(envs):
             self._run(command)
 
     @property

--- a/conans/test/functional/build_helpers/meson_test.py
+++ b/conans/test/functional/build_helpers/meson_test.py
@@ -30,4 +30,5 @@ class MesonTest(unittest.TestCase):
 
         client.save({"conanfile.py": conanfile_vcvars})
         client.run('create . pkg/1.0@ -e PATH="MyCustomPath"')
-        self.assertIn("pkg/1.0: PATH ENV VAR: MyCustomPath;", client.out)
+        self.assertIn("pkg/1.0: PATH ENV VAR: ", client.out)
+        self.assertIn("MyCustomPath;", client.out)


### PR DESCRIPTION
When meson generates the configuration, append_vcvars does not work. This pr submission is to make this parameter work.

The benefits are as follows:
- [x] A 32-bit program can be generated when vs is backend, which was not possible before
- [x] In the old version of meson, this allows meson to find vs

Signed-off-by: deadash <dead.ash@hotmail.com>

Changelog: (Feature): Describe here your pull request
Docs: https://github.com/conan-io/docs/pull/XXXX

- [x] Refer to the issue that supports this Pull Request.
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [x] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 

<sup>**Note:** By default this PR will skip the slower tests and will use a limited set of python versions. Check [here](https://github.com/conan-io/conan/blob/develop/.github/PR_INCREASE_TESTING.md) how to increase the testing level by writing some tags in the current PR body text.</sup>
