### PR TITLE
some new Version improvements for build and pre-releases

### DIFF
--- a/conans/model/recipe_ref.py
+++ b/conans/model/recipe_ref.py
@@ -1,4 +1,3 @@
-import re
 from functools import total_ordering
 
 from conans.errors import ConanException
@@ -12,13 +11,44 @@ class Version:
     This is NOT an implementation of semver, as users may use any pattern in their versions.
     It is just a helper to parse "." or "-" and compare taking into account integers when possible
     """
-    # FIXME: parse also +
-    version_pattern = re.compile('[.-]')
-
     def __init__(self, value):
         assert isinstance(value, str)
         self._value = value
         self._items = None  # elements of the version
+        self._pre = None
+        self._build = None
+
+    @property
+    def pre(self):
+        if self._items is None:  # the indicator parse is needed is empty items
+            self._parse()
+        return self._pre
+
+    @property
+    def build(self):
+        if self._items is None:  # the indicator parse is needed is empty items
+            self._parse()
+        return self._build
+
+    @property
+    def main(self):
+        if self._items is None:
+            self._parse()
+        return self._items
+
+    @property
+    def major(self):
+        try:
+            return self.main[0]
+        except IndexError:
+            return None
+
+    @property
+    def minor(self):
+        try:
+            return self.main[1]
+        except IndexError:
+            return None
 
     def __str__(self):
         return self._value
@@ -34,15 +64,40 @@ class Version:
     def __lt__(self, other):
         if not isinstance(other, Version):
             other = Version(other)
-        # FIXME: this comparison is not enough
-        return self._tokens() < other._tokens()
+        if self.pre:
+            if other.pre:  # both are pre-releases
+                return (self.main, self.pre, self.build) < (other.main, other.pre, other.build)
+            else:  # Left hand is pre-release, right side is regular
+                if self.main == other.main:  # Problem only happens if both are equal
+                    return True
+                else:
+                    return self.main < other.main
+        else:
+            if other.pre:  # Left hand is regular, right side is pre-release
+                if self.main == other.main:  # Problem only happens if both are equal
+                    return False
+                else:
+                    return self.main < other.main
+            else:  # None of them is pre-release
+                return (self.main, self.build) < (other.main, other.build)
 
-    def _tokens(self):
-        if self._items is None:
-            items = self.version_pattern.split(self._value)
-            items = [int(item) if item.isdigit() else item for item in items]
-            self._items = items
-        return self._items
+    def _parse(self):
+        items = self._value.rsplit("+", 1)  # split for build
+        if len(items) == 2:
+            value, build = items
+            self._build = Version(build)  # This is a nested version by itself
+        else:
+            value = items[0]
+
+        items = value.rsplit("-", 1)  # split for pre-release
+        if len(items) == 2:
+            value, pre = items
+            self._pre = Version(pre)  # This is a nested version by itself
+        else:
+            value = items[0]
+        items = value.split(".")
+        items = [int(item) if item.isdigit() else item for item in items]
+        self._items = items
 
 
 @total_ordering

--- a/conans/test/unittests/model/version/test_version_comparison.py
+++ b/conans/test/unittests/model/version/test_version_comparison.py
@@ -1,0 +1,42 @@
+import pytest
+
+from conans.model.recipe_ref import Version
+
+v = [("1", "2"),
+     ("1.0", "1.1"),
+     ("1.1", "1.1.0"),  # generic 1.1 is earlier than 1.1.0
+     ("1.0.2", "1.1.0"),
+     ("1.3", "1.22"),
+     ("1.1.3", "1.1.22"),
+     ("1.1.1.3", "1.1.1.22"),
+     ("1.1.1.1.3", "1.1.1.1.22"),
+     # Different lengths
+     ("1.0", "2"),
+     ("1.2", "1.3.1"),
+     ("1.0.2", "1.1"),
+     # Now with letters
+     ("1.1.a", "1.1.b"),
+     ("1.1.1.abc", "1.1.1.abz"),
+     ("a.b.c", "b.c"),
+     # build is easy
+     ("1.1+b1", "1.1+b2"),
+     ("1.1+b.3", "1.1+b.22"),
+     # pre-release is challenging
+     ("1.1-pre1", "1.1-pre2"),
+     ("1.1-alpha.3", "1.1-alpha.22"),
+     ("1.1-alpha.3+b1", "1.1-alpha.3+b2"),
+     ("1.1-alpha.1", "1.1"),
+     ("1.1", "1.2-alpha1"),
+     ("1.1-alpha.1", "1.1.0"),  # pre to the generic 1.1 is earlier than 1.1.0
+     ]
+
+
+@pytest.mark.parametrize("v1, v2", v)
+def test_comparison(v1, v2):
+    v1 = Version(v1)
+    v2 = Version(v2)
+    assert v1 < v2
+    assert v2 > v1
+    assert v1 != v2
+    assert v1 <= v2
+    assert v2 >= v1


### PR DESCRIPTION
New ``RecipeReference`` is using a new ``Version`` class:

- The legacy ``Version`` class we have is quite dirty
- The new ``Version`` that was added to ``tools.Version`` for recipes usage and comparison is based on the dependency pip "node-semver" which seems to be entering maintenance mode, not much activity (17 stars in Github)
- Users seems to be demanding more flexibility on versions, having more than 3 main digits.


So I am evaluating the effort to maintain our own ``Version`` class for everything. I have fully read ``node-semver`` code. So far seems quite doable.
