### PR TITLE
Feature/develop2 avoid temp pkg db

### DIFF
--- a/conan/cache/conan_reference.py
+++ b/conan/cache/conan_reference.py
@@ -86,10 +86,12 @@ class ConanReference:
 
     @property
     def full_reference(self):
-        if self.prev:
-            return f'{self.reference}#{self.rrev}:{self.pkgid}#{self.prev}'
-        else:
-            return f'{self.reference}#{self.rrev}'
+        result = f'{self.reference}#{self.rrev}'
+        if self.pkgid:
+            result += f":{self.pkgid}"
+            if self.prev:
+                result += f'#{self.prev}'
+        return result
 
     @property
     def recipe_reference(self):

--- a/conan/cache/conan_reference_layout.py
+++ b/conan/cache/conan_reference_layout.py
@@ -103,6 +103,11 @@ class RecipeLayout(LayoutBase):
 
 
 class PackageLayout(LayoutBase):
+
+    def __init__(self, ref, base_folder):
+        super().__init__(ref, base_folder)
+        self.build_id = None
+
     @property
     def reference(self):
         return self._ref.as_package_reference()

--- a/conan/cache/db/cache_database.py
+++ b/conan/cache/db/cache_database.py
@@ -22,9 +22,8 @@ class CacheDatabase:
     def update_recipe_timestamp(self, ref: ConanReference, new_timestamp=None):
         self._recipes.update_timestamp(ref, new_timestamp)
 
-    def update_package(self, ref: ConanReference,
-                       new_path=None, new_timestamp=None, new_build_id=None):
-        self._packages.update(ref, new_path, new_timestamp, new_build_id)
+    def update_package_timestamp(self, ref: ConanReference, new_timestamp=None):
+        self._packages.update_timestamp(ref,  new_timestamp)
 
     def remove_recipe(self, ref: ConanReference):
         # Removing the recipe must remove all the package binaries too from DB
@@ -48,8 +47,8 @@ class CacheDatabase:
     def create_recipe(self, path, ref: ConanReference):
         self._recipes.create(path, ref, timestamp=time.time())
 
-    def create_package(self, path, ref: ConanReference):
-        self._packages.create(path, ref, timestamp=time.time())
+    def create_package(self, path, ref: ConanReference, build_id):
+        self._packages.create(path, ref, timestamp=time.time(), build_id=build_id)
 
     def list_references(self, only_latest_rrev):
         for it in self._recipes.all_references(only_latest_rrev):

--- a/conan/cache/db/cache_database.py
+++ b/conan/cache/db/cache_database.py
@@ -1,6 +1,5 @@
 import sqlite3
 import time
-from io import StringIO
 
 from conan.cache.conan_reference import ConanReference
 from conan.cache.db.packages_table import PackagesDBTable
@@ -23,12 +22,9 @@ class CacheDatabase:
     def update_recipe_timestamp(self, ref: ConanReference, new_timestamp=None):
         self._recipes.update_timestamp(ref, new_timestamp)
 
-    def update_package(self, old_ref: ConanReference, new_ref: ConanReference = None,
+    def update_package(self, ref: ConanReference,
                        new_path=None, new_timestamp=None, new_build_id=None):
-        self._packages.update(old_ref, new_ref, new_path, new_timestamp, new_build_id)
-
-    def delete_package_by_path(self, path):
-        self._packages.delete_by_path(path)
+        self._packages.update(ref, new_path, new_timestamp, new_build_id)
 
     def remove_recipe(self, ref: ConanReference):
         # Removing the recipe must remove all the package binaries too from DB
@@ -49,14 +45,11 @@ class CacheDatabase:
         ref_data = self._packages.get(ref)
         return ref_data
 
-    def create_tmp_package(self, path, ref: ConanReference):
-        self._packages.save(path, ref, timestamp=0)
-
     def create_recipe(self, path, ref: ConanReference):
         self._recipes.create(path, ref, timestamp=time.time())
 
     def create_package(self, path, ref: ConanReference):
-        self._packages.save(path, ref, timestamp=time.time())
+        self._packages.create(path, ref, timestamp=time.time())
 
     def list_references(self, only_latest_rrev):
         for it in self._recipes.all_references(only_latest_rrev):

--- a/conan/cache/db/packages_table.py
+++ b/conan/cache/db/packages_table.py
@@ -63,23 +63,24 @@ class PackagesDBTable(BaseDbTable):
             raise ConanReferenceDoesNotExistInDB(f"No entry for package '{ref.full_reference}'")
         return self._as_dict(self.row_type(*row))
 
-    def save(self, path, ref: ConanReference, timestamp):
+    def create(self, path, ref: ConanReference, timestamp):
         # we set the timestamp to 0 until they get a complete reference, here they
         # are saved with the temporary uuid one, we don't want to consider these
         # not yet built packages for search and so on
         placeholders = ', '.join(['?' for _ in range(len(self.columns))])
-        r = self._conn.execute(f'INSERT INTO {self.table_name} '
-                         f'VALUES ({placeholders})',
-                         [ref.reference, ref.rrev, ref.pkgid, ref.prev, path, timestamp,
-                          None])
+        try:
+            r = self._conn.execute(f'INSERT INTO {self.table_name} '
+                                   f'VALUES ({placeholders})',
+                                   [ref.reference, ref.rrev, ref.pkgid, ref.prev, path, timestamp,
+                                    None])
+        except sqlite3.IntegrityError:
+            raise ConanReferenceAlreadyExistsInDB(f"Reference '{ref.full_reference}' already exists")
+
         return r.lastrowid
 
-    def update(self, old_ref: ConanReference, new_ref: ConanReference = None, new_path=None,
-               new_timestamp=None, new_build_id=None):
-        if not new_ref:
-            new_ref = old_ref
-        where_clause = self._where_clause(old_ref)
-        set_clause = self._set_clause(new_ref, path=new_path, timestamp=new_timestamp,
+    def update(self, ref: ConanReference, new_path=None, new_timestamp=None, new_build_id=None):
+        where_clause = self._where_clause(ref)
+        set_clause = self._set_clause(ref, path=new_path, timestamp=new_timestamp,
                                       build_id=new_build_id)
         query = f"UPDATE {self.table_name} " \
                 f"SET {set_clause} " \
@@ -87,13 +88,7 @@ class PackagesDBTable(BaseDbTable):
         try:
             r = self._conn.execute(query)
         except sqlite3.IntegrityError:
-            raise ConanReferenceAlreadyExistsInDB(f"Reference '{new_ref.full_reference}' already exists")
-        return r.lastrowid
-
-    def delete_by_path(self, path):
-        query = f"DELETE FROM {self.table_name} " \
-                f"WHERE path = ?;"
-        r = self._conn.execute(query, (path,))
+            raise ConanReferenceAlreadyExistsInDB(f"Reference '{ref.full_reference}' already exists")
         return r.lastrowid
 
     def remove(self, ref: ConanReference):
@@ -102,26 +97,6 @@ class PackagesDBTable(BaseDbTable):
                 f"WHERE {where_clause};"
         r = self._conn.execute(query)
         return r.lastrowid
-
-    # returns all different conan references (name/version@user/channel)
-    def all_references(self, only_latest_rrev=False):
-        if only_latest_rrev:
-            query = f'SELECT DISTINCT {self.columns.reference}, ' \
-                    f'{self.columns.rrev}, ' \
-                    f'{self.columns.pkgid}, ' \
-                    f'{self.columns.prev}, ' \
-                    f'{self.columns.path}, ' \
-                    f'{self.columns.build_id} ' \
-                    f'FROM {self.table_name} ' \
-                    f'WHERE {self.columns.prev} IS NULL ' \
-                    f'ORDER BY {self.columns.timestamp} DESC'
-        else:
-            query = f'SELECT * FROM {self.table_name} ' \
-                    f'WHERE {self.columns.prev} IS NULL ' \
-                    f'ORDER BY {self.columns.timestamp} DESC;'
-        r = self._conn.execute(query)
-        for row in r.fetchall():
-            yield self._as_dict(self.row_type(*row))
 
     def get_package_revisions(self, ref: ConanReference, only_latest_prev=False):
         assert ref.rrev, "To search for package revisions you must provide a recipe revision."
@@ -170,34 +145,6 @@ class PackagesDBTable(BaseDbTable):
                 f'AND {self.columns.pkgid} IS NOT NULL ' \
                 f'GROUP BY {self.columns.pkgid} ' \
                 f'ORDER BY {self.columns.timestamp} DESC'
-        r = self._conn.execute(query)
-        for row in r.fetchall():
-            yield self._as_dict(self.row_type(*row))
-
-    def get_recipe_revisions(self, ref: ConanReference, only_latest_rrev=False):
-        check_rrev = f'AND {self.columns.rrev} = "{ref.rrev}" ' if ref.rrev else ''
-        if only_latest_rrev:
-            query = f'SELECT {self.columns.reference}, ' \
-                    f'{self.columns.rrev}, ' \
-                    f'{self.columns.pkgid}, ' \
-                    f'{self.columns.prev}, ' \
-                    f'{self.columns.path}, ' \
-                    f'MAX({self.columns.timestamp}), ' \
-                    f'{self.columns.build_id} ' \
-                    f'FROM {self.table_name} ' \
-                    f'WHERE {self.columns.reference} = "{ref.reference}" ' \
-                    f'AND {self.columns.prev} IS NULL ' \
-                    f'AND {self.columns.pkgid} IS NULL ' \
-                    f'{check_rrev} ' \
-                    f'GROUP BY {self.columns.pkgid} '
-        else:
-            query = f'SELECT * FROM {self.table_name} ' \
-                    f'WHERE {self.columns.reference} = "{ref.reference}" ' \
-                    f'AND {self.columns.prev} IS NULL ' \
-                    f'{check_rrev} ' \
-                    f'AND {self.columns.pkgid} IS NULL ' \
-                    f'ORDER BY {self.columns.timestamp} DESC'
-
         r = self._conn.execute(query)
         for row in r.fetchall():
             yield self._as_dict(self.row_type(*row))

--- a/conans/client/cache/cache.py
+++ b/conans/client/cache/cache.py
@@ -72,8 +72,8 @@ class ClientCache(object):
     def assign_rrev(self, layout: RecipeLayout):
         return self._data_cache.assign_rrev(layout)
 
-    def assign_prev(self, layout: PackageLayout, ref: ConanReference):
-        return self._data_cache.assign_prev(layout, ref)
+    def assign_prev(self, layout: PackageLayout):
+        return self._data_cache.assign_prev(layout)
 
     def ref_layout(self, ref):
         # It must exists

--- a/conans/client/cache/cache.py
+++ b/conans/client/cache/cache.py
@@ -58,12 +58,6 @@ class ClientCache(object):
     def closedb(self):
         self._data_cache.closedb()
 
-    def update_package(self, old_ref: ConanReference, new_ref: ConanReference = None,
-                       new_path=None, new_timestamp=None, new_build_id=None):
-        new_ref = ConanReference(new_ref) if new_ref else None
-        return self._data_cache.update_package(ConanReference(old_ref), new_ref, new_path,
-                                               new_timestamp, new_build_id)
-
     def dump(self):
         out = StringIO()
         self._data_cache.dump(out)
@@ -113,7 +107,7 @@ class ClientCache(object):
         return self._data_cache.update_recipe_timestamp(ConanReference(ref), new_timestamp=timestamp)
 
     def set_package_timestamp(self, ref, timestamp):
-        return self._data_cache.update_package(ConanReference(ref), new_timestamp=timestamp)
+        return self._data_cache.update_package_timestamp(ConanReference(ref), new_timestamp=timestamp)
 
     def all_refs(self, only_latest_rrev=False):
         # TODO: cache2.0 we are not validating the reference here because it can be a uuid, check

--- a/conans/client/cmd/export_pkg.py
+++ b/conans/client/cmd/export_pkg.py
@@ -73,6 +73,7 @@ def export_pkg(app, ref, source_folder, build_folder, package_folder,
             prev = run_package_method(conanfile, package_id, hook_manager, conan_file_path, ref)
 
     pref = PkgReference(pref.ref, pref.package_id, prev)
-    cache.assign_prev(pkg_layout, ConanReference(pref))
+    pkg_layout.reference = ConanReference(pref)
+    cache.assign_prev(pkg_layout)
     # Make sure folder is updated
     conanfile.folders.set_base_package(pkg_layout.package())

--- a/conans/client/installer.py
+++ b/conans/client/installer.py
@@ -60,7 +60,8 @@ class _PackageBuilder(object):
         build_folder = package_layout.build()
         recipe_build_id = build_id(conanfile)
         pref = package_layout.reference
-        if pref.package_id != recipe_build_id and hasattr(conanfile, "build_id"):
+        if recipe_build_id is not None and pref.package_id != recipe_build_id:
+            package_layout.build_id = recipe_build_id
             # check if we already have a package with the calculated build_id
             recipe_ref = ConanFileReference.loads(ConanReference(pref).recipe_reference)
             package_refs = self._cache.get_package_references(recipe_ref)
@@ -81,8 +82,6 @@ class _PackageBuilder(object):
                 other_pkg_layout = self._cache.pkg_layout(build_prev)
                 build_folder = other_pkg_layout.build()
                 skip_build = True
-            elif build_prev == pref:
-                self._cache.update_package(build_prev, new_build_id=recipe_build_id)
 
         if is_dirty(build_folder):
             self._scoped_output.warning("Build folder is dirty, removing it: %s" % build_folder)

--- a/conans/client/installer.py
+++ b/conans/client/installer.py
@@ -443,13 +443,13 @@ class BinaryInstaller(object):
             assert node.pref.revision, "Node PREF revision shouldn't be empty"
             assert pref.revision is not None, "PREV for %s to be built is None" % str(pref)
             # at this point the package reference should be complete
-            if pkg_layout.reference != pref:
-                self._cache.assign_prev(pkg_layout, ConanReference(pref))
-                # Make sure the current conanfile.folders is updated (it is later in package_info(),
-                # but better make sure here, and be able to report the actual folder in case
-                # something fails)
-                node.conanfile.folders.set_base_package(pkg_layout.package())
-                self._out.info("Package folder %s" % node.conanfile.package_folder)
+            pkg_layout.reference = ConanReference(pref)
+            self._cache.assign_prev(pkg_layout)
+            # Make sure the current conanfile.folders is updated (it is later in package_info(),
+            # but better make sure here, and be able to report the actual folder in case
+            # something fails)
+            node.conanfile.folders.set_base_package(pkg_layout.package())
+            self._out.info("Package folder %s" % node.conanfile.package_folder)
 
     def _build_package(self, node, pkg_layout):
         builder = _PackageBuilder(self._app, node.conanfile.output)

--- a/conans/client/remover.py
+++ b/conans/client/remover.py
@@ -160,8 +160,6 @@ class ConanRemover(object):
             for package in prev_remove_build:
                 package_layout = self._cache.pkg_layout(package)
                 package_layout.build_remove()
-                # also remove the build_id from the db if any
-                self._cache.update_package(package, new_build_id="")
 
         if not src and remove_recipe:
             ref_layout = self._cache.ref_layout(ref)

--- a/conans/model/package_ref.py
+++ b/conans/model/package_ref.py
@@ -1,5 +1,3 @@
-import traceback
-
 from conans.errors import ConanException
 from conans.model.recipe_ref import RecipeReference
 
@@ -77,7 +75,6 @@ class PkgReference:
 
             return PkgReference(ref, package_id, revision, timestamp)
         except Exception:
-            print(traceback.format_exc())
             raise ConanException(
                 f"{text} is not a valid package reference, provide a reference"
                 f" in the form name/version[@user/channel:package_id]")

--- a/conans/model/package_ref.py
+++ b/conans/model/package_ref.py
@@ -1,3 +1,5 @@
+import traceback
+
 from conans.errors import ConanException
 from conans.model.recipe_ref import RecipeReference
 
@@ -75,6 +77,7 @@ class PkgReference:
 
             return PkgReference(ref, package_id, revision, timestamp)
         except Exception:
+            print(traceback.format_exc())
             raise ConanException(
                 f"{text} is not a valid package reference, provide a reference"
                 f" in the form name/version[@user/channel:package_id]")

--- a/conans/test/integration/command/create_test.py
+++ b/conans/test/integration/command/create_test.py
@@ -293,15 +293,14 @@ class MyPkg(ConanFile):
             class MyPkg(ConanFile):
 
                 def build(self):
-                    raise ConanException("Build error")
+                    raise Exception("Build error")
             """)
         client.save({"conanfile.py": conanfile})
         ref = ConanFileReference("pkg", "0.1", "danimtb", "testing")
         client.run("create . %s" % ref.full_str(), assert_error=True)
-        pref = client.get_latest_prev(ref, NO_SETTINGS_PACKAGE_ID)
         self.assertIn("Build error", client.out)
-        package_folder = client.get_latest_pkg_layout(pref).package()
-        self.assertFalse(os.path.exists(package_folder))
+        pref = client.get_latest_prev(ref, NO_SETTINGS_PACKAGE_ID)
+        assert pref is None
 
     def test_create_with_name_and_version(self):
         client = TestClient()


### PR DESCRIPTION
Same that was done for ``export``, now for ``package``: avoid putting temporary stuff in the DB, only enter data when revisions are fully computed and final
