### PR TITLE
avoid exception for conan info --paths with editables

### DIFF
--- a/conans/client/conan_command_output.py
+++ b/conans/client/conan_command_output.py
@@ -8,6 +8,7 @@ from conans.client.graph.grapher import Grapher
 from conans.client.installer import build_id
 from conans.client.printer import Printer
 from conans.model.ref import ConanFileReference, PackageReference
+from conans.paths.package_layouts.package_editable_layout import PackageEditableLayout
 from conans.search.binary_html_table import html_binary_graph
 from conans.util.dates import iso8601_to_str
 from conans.util.files import save
@@ -147,14 +148,19 @@ class CommandOutputer(object):
             # Paths
             if isinstance(ref, ConanFileReference) and grab_paths:
                 package_layout = self._cache.package_layout(ref, conanfile.short_paths)
-                item_data["export_folder"] = package_layout.export()
-                item_data["source_folder"] = package_layout.source()
-                pref_build_id = build_id(conanfile) or package_id
-                pref = PackageReference(ref, pref_build_id)
-                item_data["build_folder"] = package_layout.build(pref)
-
-                pref = PackageReference(ref, package_id)
-                item_data["package_folder"] = package_layout.package(pref)
+                if isinstance(package_layout, PackageEditableLayout):  # Avoid raising exception
+                    item_data["export_folder"] = conanfile.recipe_folder
+                    item_data["source_folder"] = conanfile.source_folder  # This is None now
+                    item_data["build_folder"] = conanfile.build_folder  # This is None now
+                    item_data["package_folder"] = conanfile.package_folder  # This is None now
+                else:
+                    item_data["export_folder"] = package_layout.export()
+                    item_data["source_folder"] = package_layout.source()
+                    pref_build_id = build_id(conanfile) or package_id
+                    pref = PackageReference(ref, pref_build_id)
+                    item_data["build_folder"] = package_layout.build(pref)
+                    pref = PackageReference(ref, package_id)
+                    item_data["package_folder"] = package_layout.package(pref)
 
             try:
                 package_metadata = self._cache.package_layout(ref).load_metadata()

--- a/conans/test/integration/editable/commands/info_on_child_test.py
+++ b/conans/test/integration/editable/commands/info_on_child_test.py
@@ -72,10 +72,3 @@ class InfoCommandTest(unittest.TestCase):
                              sorted(["lib/version@user/name",
                                      "parent/version@user/name",
                                      str(project_name)]))
-
-    @parameterized.expand([(True,), (False,)])
-    def test_paths(self, use_local_path):
-        args = "." if use_local_path else self.ref_child
-        self.t.run('info {} --paths'.format(args), assert_error=True)
-        self.assertIn("ERROR: Operation not allowed on a package installed as editable", self.t.out)
-        # TODO: Cannot show paths for a linked/editable package... what to do here?

--- a/conans/test/integration/editable/commands/info_test.py
+++ b/conans/test/integration/editable/commands/info_test.py
@@ -85,3 +85,21 @@ class InfoCommandUsingReferenceTest(LinkedPackageAsProject):
         self.t.run('info {} --paths'.format(self.ref), assert_error=True)
         self.assertIn("Operation not allowed on a package installed as editable", self.t.out)
         # TODO: Cannot show paths for a linked/editable package... what to do here?
+
+
+def test_info_paths():
+    # https://github.com/conan-io/conan/issues/7054
+    c = TestClient()
+    conanfile = textwrap.dedent("""
+        from conans import ConanFile
+        class Pkg(ConanFile):
+            def layout(self):
+                self.folders.source = "."
+                self.folders.build = "."
+        """)
+    c.save({"pkg/conanfile.py": conanfile,
+            "consumer/conanfile.py": GenConanfile().with_require("pkg/0.1")})
+    c.run("editable add pkg pkg/0.1@")
+    c.run("info consumer --paths")
+    # TODO: Conan 2.0: see if it is possible to get the full actual values
+    assert "export_folder:" in c.out  # Important bit is it doesn't raise an error

--- a/conans/test/integration/editable/commands/info_test.py
+++ b/conans/test/integration/editable/commands/info_test.py
@@ -81,11 +81,6 @@ class InfoCommandUsingReferenceTest(LinkedPackageAsProject):
         self.assertListEqual(sorted(str(self.t.out).splitlines()),
                              sorted(["lib/version@user/name", "parent/version@user/name"]))
 
-    def test_paths(self):
-        self.t.run('info {} --paths'.format(self.ref), assert_error=True)
-        self.assertIn("Operation not allowed on a package installed as editable", self.t.out)
-        # TODO: Cannot show paths for a linked/editable package... what to do here?
-
 
 def test_info_paths():
     # https://github.com/conan-io/conan/issues/7054


### PR DESCRIPTION
Changelog: Fix: Avoid raising an exception for ``conan info --paths`` when there are editables in the graph. 
Docs: Omit

Partially improve https://github.com/conan-io/conan/issues/7054