### PR TITLE
[bugfix] PkgConfigDeps and dependencies requires

### DIFF
--- a/conan/tools/gnu/pkgconfigdeps.py
+++ b/conan/tools/gnu/pkgconfigdeps.py
@@ -60,12 +60,22 @@ class PkgConfigDeps(object):
         Note: CppInfo could be coming from one Component object instead of the dependency
         """
         ret = []
-        for req in cpp_info.requires:
-            pkg_name, comp_name = req.split("::") if "::" in req else (name, req)
-            # FIXME: it could allow defining requires to not direct dependencies
-            req_conanfile = self._conanfile.dependencies.host[pkg_name]
-            comp_alias_name = get_component_name(req_conanfile, comp_name)
-            ret.append(self._get_pc_name(pkg_name, comp_alias_name))
+        if cpp_info.requires:
+            for req in cpp_info.requires:
+                pkg_name, comp_name = req.split("::") if "::" in req else (name, req)
+                # FIXME: it could allow defining requires to not direct dependencies
+                req_conanfile = self._conanfile.dependencies.host[pkg_name]
+                comp_alias_name = get_component_name(req_conanfile, comp_name)
+                ret.append(self._get_pc_name(pkg_name, comp_alias_name))
+        else:
+            # Let's try to get the transitive dependencies for the given package name
+            try:
+                dep_conanfile = self._conanfile.dependencies.host[name]
+            except KeyError:
+                pass
+            else:
+                ret = [get_package_name(req)
+                       for req in dep_conanfile.dependencies.direct_host.values()]
         return ret
 
     def get_components_files_and_content(self, dep):

--- a/conan/tools/gnu/pkgconfigdeps.py
+++ b/conan/tools/gnu/pkgconfigdeps.py
@@ -68,7 +68,7 @@ class PkgConfigDeps(object):
                 comp_alias_name = get_component_name(req_conanfile, comp_name)
                 ret.append(self._get_pc_name(pkg_name, comp_alias_name))
         else:
-            # Let's try to get the transitive dependencies for the given package name
+            # Let's try to get all the requires for the given package name
             try:
                 dep_conanfile = self._conanfile.dependencies.host[name]
             except KeyError:

--- a/conan/tools/gnu/pkgconfigdeps.py
+++ b/conan/tools/gnu/pkgconfigdeps.py
@@ -78,19 +78,11 @@ class PkgConfigDeps(object):
         # At first, let's check if we have defined some component requires, e.g., "pkg::cmp1"
         requires = self._get_component_requires_names(dep_name, dep.cpp_info)
         # If we have found some component requires it would be enough
-        if requires:
-            return requires
-        try:
-            # If no requires were found, let's try to get all the direct
-            # dependencies, e.g., requires = "other_pkg/1.0"
-            dep_conanfile = self._conanfile.dependencies.host[dep_name]
-        except KeyError:
-            # Don't raise any exception, returns default value
-            return []
-        else:
-            requires = [get_package_name(req)
-                        for req in dep_conanfile.dependencies.direct_host.values()]
-            return requires
+        if not requires:
+            # If no requires were found, let's try to get all the direct dependencies,
+            # e.g., requires = "other_pkg/1.0"
+            requires = [get_package_name(req) for req in dep.dependencies.direct_host.values()]
+        return requires
 
     def get_components_files_and_content(self, dep):
         """Get all the *.pc files content for the dependency and each of its components"""


### PR DESCRIPTION
Changelog: Bugfix: `PkgConfigDeps` was not adding correctly the `Requires` for all the package dependencies.
Closes: https://github.com/conan-io/conan/issues/9939
Docs: omit

- [x] Refer to the issue that supports this Pull Request.
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 

<sup>**Note:** By default this PR will skip the slower tests and will use a limited set of python versions. Check [here](https://github.com/conan-io/conan/blob/develop/.github/PR_INCREASE_TESTING.md) how to increase the testing level by writing some tags in the current PR body text.</sup>
