### PR TITLE
Fix/xcodedeps pkg name and arm64

### DIFF
--- a/conan/tools/apple/xcodedeps.py
+++ b/conan/tools/apple/xcodedeps.py
@@ -70,6 +70,10 @@ class XcodeDeps(object):
         self._conanfile = conanfile
         self.configuration = conanfile.settings.get_safe("build_type")
         self.architecture = conanfile.settings.get_safe("arch")
+
+        if self.architecture == "armv8":
+            self.architecture = "arm64" # Xcode uses arm64 instead of armv8
+
         # TODO: check if it makes sense to add a subsetting for sdk version
         #  related to: https://github.com/conan-io/conan/issues/9608
         self.os_version = conanfile.settings.get_safe("os.version")

--- a/conan/tools/apple/xcodedeps.py
+++ b/conan/tools/apple/xcodedeps.py
@@ -158,7 +158,7 @@ class XcodeDeps(object):
         content_multi = self._all_xconfig
 
         for req, dep in deps.items():
-            dep_name = dep.ref.name.replace(".", "_")
+            dep_name = dep.ref.name.replace(".", "_").replace("-", "_")
             content_multi = content_multi + '\n#include "conan_{}.xcconfig"\n'.format(dep_name)
         return content_multi
 
@@ -169,10 +169,10 @@ class XcodeDeps(object):
 
         for dep in self._conanfile.dependencies.host.values():
             dep_name = dep.ref.name
-            dep_name = dep_name.replace(".", "_")
+            dep_name = dep_name.replace(".", "_").replace("-", "_")
             cpp_info = dep.cpp_info.copy()
             cpp_info.aggregate_components()
-            public_deps = [d.ref.name.replace(".", "_")
+            public_deps = [d.ref.name.replace(".", "_").replace("-", "_")
                            for r, d in dep.dependencies.direct_host.items() if r.visible]
 
             # One file per configuration, with just the variables


### PR DESCRIPTION
Changelog: (Bugfix): Fixes XcodeDeps bad xcconfig generation when using either dash-case-named packages or `armv8` arch.

Here is the link to the open issue: #9949 