### PR TITLE
[bugfix] Legacy `cmake` not affected by `set_property`

### DIFF
--- a/conans/model/build_info.py
+++ b/conans/model/build_info.py
@@ -220,7 +220,8 @@ class _CppInfo(object):
         property_name = None
         if generator == "cmake_find_package" and self.get_property("cmake_module_target_name", generator):
             property_name = "cmake_module_target_name"
-        elif "cmake" in generator:
+        # set_property will have no effect on "cmake" legacy generator
+        elif "cmake" in generator and "cmake" != generator:
             property_name = "cmake_target_name"
         elif "pkg_config" in generator:
             property_name = "pkg_config_name"

--- a/conans/test/integration/generators/cpp_info_set_generator_properties_test.py
+++ b/conans/test/integration/generators/cpp_info_set_generator_properties_test.py
@@ -289,6 +289,38 @@ def test_cmake_find_package_new_properties():
     assert find_package_contents_old == find_package_contents
 
 
+def test_legacy_cmake_is_not_affected_by_set_property_usage():
+    """
+    "set_property" will have no effect on "cmake" legacy generator
+
+    Originally posted: https://github.com/conan-io/conan-center-index/issues/7925
+    """
+
+    client = TestClient()
+
+    greetings = textwrap.dedent("""
+        import os
+        from conans import ConanFile
+        class MyPkg(ConanFile):
+            settings = "build_type"
+            name = "greetings"
+            version = "1.0"
+
+            def package_info(self):
+                self.cpp_info.set_property("cmake_file_name", "MyChat")
+                self.cpp_info.set_property("cmake_target_name", "MyChat")
+                self.cpp_info.components["sayhello"].set_property("cmake_target_name", "MySay")
+        """)
+    client.save({"greetings.py": greetings})
+    client.run("create greetings.py greetings/1.0@")
+    client.run("install greetings/1.0@ -g cmake")
+    conanbuildinfo = client.load("conanbuildinfo.cmake")
+    # Let's check
+    assert "set_property(TARGET CONAN_PKG::greetings" in conanbuildinfo
+    assert "add_library(CONAN_PKG::greetings" in conanbuildinfo
+    assert "set(CONAN_TARGETS CONAN_PKG::greetings)" in conanbuildinfo
+
+
 def test_pkg_config_names(setup_client):
     client = setup_client
     mypkg = textwrap.dedent("""

--- a/conans/test/integration/generators/cpp_info_set_generator_properties_test.py
+++ b/conans/test/integration/generators/cpp_info_set_generator_properties_test.py
@@ -315,7 +315,7 @@ def test_legacy_cmake_is_not_affected_by_set_property_usage():
     client.run("create greetings.py greetings/1.0@")
     client.run("install greetings/1.0@ -g cmake")
     conanbuildinfo = client.load("conanbuildinfo.cmake")
-    # Let's check
+    # Let's check our final target is the pkg name instead of "MyChat"
     assert "set_property(TARGET CONAN_PKG::greetings" in conanbuildinfo
     assert "add_library(CONAN_PKG::greetings" in conanbuildinfo
     assert "set(CONAN_TARGETS CONAN_PKG::greetings)" in conanbuildinfo


### PR DESCRIPTION
Changelog: Bugfix: legacy `cmake` generator is not affected by `set_property`.
Docs: omit
Issue related: https://github.com/conan-io/conan-center-index/issues/7925

- [x] Refer to the issue that supports this Pull Request.
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 

<sup>**Note:** By default this PR will skip the slower tests and will use a limited set of python versions. Check [here](https://github.com/conan-io/conan/blob/develop/.github/PR_INCREASE_TESTING.md) how to increase the testing level by writing some tags in the current PR body text.</sup>
