### PR TITLE
Fix/xcodedeps pkg name and arch names

### DIFF
--- a/conan/tools/apple/xcodedeps.py
+++ b/conan/tools/apple/xcodedeps.py
@@ -158,7 +158,7 @@ class XcodeDeps(object):
         content_multi = self._all_xconfig
 
         for req, dep in deps.items():
-            dep_name = dep.ref.name.replace(".", "_")
+            dep_name = dep.ref.name.replace(".", "_").replace("-", "_")
             content_multi = content_multi + '\n#include "conan_{}.xcconfig"\n'.format(dep_name)
         return content_multi
 
@@ -169,10 +169,10 @@ class XcodeDeps(object):
 
         for dep in self._conanfile.dependencies.host.values():
             dep_name = dep.ref.name
-            dep_name = dep_name.replace(".", "_")
+            dep_name = dep_name.replace(".", "_").replace("-", "_")
             cpp_info = dep.cpp_info.copy()
             cpp_info.aggregate_components()
-            public_deps = [d.ref.name.replace(".", "_")
+            public_deps = [d.ref.name.replace(".", "_").replace("-", "_")
                            for r, d in dep.dependencies.direct_host.items() if r.visible]
 
             # One file per configuration, with just the variables

--- a/conan/tools/apple/xcodedeps.py
+++ b/conan/tools/apple/xcodedeps.py
@@ -6,6 +6,7 @@ from jinja2 import Template
 from conan.tools._check_build_profile import check_using_build_profile
 from conans.errors import ConanException
 from conans.util.files import load, save
+from conan.tools.apple.apple import to_apple_arch
 
 
 class XcodeDeps(object):
@@ -69,7 +70,10 @@ class XcodeDeps(object):
     def __init__(self, conanfile):
         self._conanfile = conanfile
         self.configuration = conanfile.settings.get_safe("build_type")
-        self.architecture = conanfile.settings.get_safe("arch")
+
+        arch = conanfile.settings.get_safe("arch")
+        self.architecture = to_apple_arch(arch) or arch
+
         # TODO: check if it makes sense to add a subsetting for sdk version
         #  related to: https://github.com/conan-io/conan/issues/9608
         self.os_version = conanfile.settings.get_safe("os.version")

--- a/conans/test/functional/toolchains/apple/test_xcodedeps_build_configs.py
+++ b/conans/test/functional/toolchains/apple/test_xcodedeps_build_configs.py
@@ -375,15 +375,12 @@ def test_frameworks():
 
 
 @pytest.mark.skipif(platform.system() != "Darwin", reason="Only for MacOS")
-def test_xcodedeps_dashes_names():
+def test_xcodedeps_dashes_names_and_arch():
+    # https://github.com/conan-io/conan/issues/9949
     client = TestClient(path_with_spaces=False)
     client.save({"conanfile.py": GenConanfile().with_name("hello-dashes").with_version("0.1")})
     client.run("export .")
-    main = textwrap.dedent("""
-        #include <iostream>
-        int main(int argc, char *argv[]) {
-        }
-        """)
+    main = "int main(int argc, char *argv[]) { return 0; }"
     project_name = "app"
     client.save({"conanfile.txt": "[requires]\nhello-dashes/0.1\n"}, clean_first=True)
     create_xcode_project(client, project_name, main)

--- a/conans/test/functional/toolchains/apple/test_xcodedeps_build_configs.py
+++ b/conans/test/functional/toolchains/apple/test_xcodedeps_build_configs.py
@@ -375,6 +375,8 @@ def test_frameworks():
 
 
 @pytest.mark.skipif(platform.system() != "Darwin", reason="Only for MacOS")
+@pytest.mark.xfail(reason="The xcconfig syntax needs at leats Xcode 13 because of "
+                          "support for macros in overriding parameters with condition sets")
 def test_xcodedeps_dashes_names_and_arch():
     # https://github.com/conan-io/conan/issues/9949
     client = TestClient(path_with_spaces=False)

--- a/conans/test/functional/toolchains/apple/test_xcodedeps_build_configs.py
+++ b/conans/test/functional/toolchains/apple/test_xcodedeps_build_configs.py
@@ -300,8 +300,6 @@ def create_xcode_project(client, project_name, source):
 
 
 @pytest.mark.skipif(platform.system() != "Darwin", reason="Only for MacOS")
-@pytest.mark.xfail(reason="The xcconfig syntax needs at leats Xcode 13 because of "
-                          "support for macros in overriding parameters with condition sets")
 @pytest.mark.tool_cmake()
 def test_xcodedeps_build_configurations():
     client = TestClient(path_with_spaces=False)
@@ -344,8 +342,6 @@ def test_xcodedeps_build_configurations():
 
 
 @pytest.mark.skipif(platform.system() != "Darwin", reason="Only for MacOS")
-@pytest.mark.xfail(reason="The xcconfig syntax needs at leats Xcode 13 because of "
-                          "support for macros in overriding parameters with condition sets")
 @pytest.mark.tool_cmake()
 def test_frameworks():
     client = TestClient(path_with_spaces=False)
@@ -375,8 +371,6 @@ def test_frameworks():
 
 
 @pytest.mark.skipif(platform.system() != "Darwin", reason="Only for MacOS")
-@pytest.mark.xfail(reason="The xcconfig syntax needs at leats Xcode 13 because of "
-                          "support for macros in overriding parameters with condition sets")
 def test_xcodedeps_dashes_names_and_arch():
     # https://github.com/conan-io/conan/issues/9949
     client = TestClient(path_with_spaces=False)

--- a/conans/test/functional/toolchains/apple/test_xcodedeps_build_configs.py
+++ b/conans/test/functional/toolchains/apple/test_xcodedeps_build_configs.py
@@ -380,10 +380,9 @@ def test_xcodedeps_dashes_names_and_arch():
     client = TestClient(path_with_spaces=False)
     client.save({"conanfile.py": GenConanfile().with_name("hello-dashes").with_version("0.1")})
     client.run("export .")
-    main = "int main(int argc, char *argv[]) { return 0; }"
-    project_name = "app"
     client.save({"conanfile.txt": "[requires]\nhello-dashes/0.1\n"}, clean_first=True)
-    create_xcode_project(client, project_name, main)
+    main = "int main(int argc, char *argv[]) { return 0; }"
+    create_xcode_project(client, "app", main)
     client.run("install . -s arch=armv8 --build=missing -g XcodeDeps")
     assert os.path.exists(os.path.join(client.current_folder, "conan_hello_dashes_vars_release_arm64.xcconfig"))
     client.run_command("xcodebuild -project app.xcodeproj -xcconfig conandeps.xcconfig -arch arm64")


### PR DESCRIPTION
Changelog: Bugfix: Fix XcodeDeps bad xcconfig generation when using dash-case-named packages
Changelog: Fix: Fix XcodeDeps architecture name translation from Conan to Apple identifiers.
Docs: omit

See PR #9950 for more context.
Closes: #9949 