### PR TITLE
[develop2] Simplify settings constraints

### DIFF
--- a/conans/client/loader.py
+++ b/conans/client/loader.py
@@ -272,12 +272,9 @@ class ConanFileLoader(object):
             pkg_settings = package_settings_values.get("&")
             if pkg_settings:
                 tmp_settings.update_values(pkg_settings)
-        conanfile.initialize(Settings(), profile.buildenv)
+        tmp_settings._unconstrained = True
+        conanfile.initialize(tmp_settings, profile.buildenv)
         conanfile.conf = profile.conf.get_conanfile_conf(None)
-        # It is necessary to copy the settings, because the above is only a constraint of
-        # conanfile settings, and a txt doesn't define settings. Necessary for generators,
-        # as cmake_multi, that check build_type.
-        conanfile.settings = tmp_settings.copy_values()
 
         try:
             parser = ConanFileTextLoader(contents)
@@ -306,9 +303,10 @@ class ConanFileLoader(object):
         # If user don't specify namespace in options, assume that it is
         # for the reference (keep compatibility)
         conanfile = ConanFile(self._runner, display_name="virtual")
-        conanfile.initialize(profile_host.processed_settings.copy(), profile_host.buildenv)
+        tmp_settings = profile_host.processed_settings.copy()
+        tmp_settings._unconstrained = True
+        conanfile.initialize(tmp_settings, profile_host.buildenv)
         conanfile.conf = profile_host.conf.get_conanfile_conf(None)
-        conanfile.settings = profile_host.processed_settings.copy_values()
 
         if is_build_require:
             for reference in references:

--- a/conans/model/conan_file.py
+++ b/conans/model/conan_file.py
@@ -139,7 +139,7 @@ class ConanFile:
         self.options = Options(self.options or {}, self.default_options)
         self._conan_buildenv = buildenv
         try:
-            settings.constraint(self.settings or [])
+            settings.constrained(self.settings)
         except Exception as e:
             raise ConanInvalidConfiguration("The recipe %s is constraining settings. %s" % (
                 self.display_name, str(e)))

--- a/conans/model/settings.py
+++ b/conans/model/settings.py
@@ -84,10 +84,9 @@ class SettingsItem(object):
         """ This is necessary to remove libcxx subsetting from compiler in config()
            del self.settings.compiler.stdlib
         """
-        try:
-            self._get_child(self._value).remove(item)
-        except Exception:
-            pass
+        child_setting = self._get_child(self._value)
+        delattr(child_setting, item)
+
 
     def _get_child(self, item):
         if not isinstance(self._definition, dict):

--- a/conans/test/integration/command/export/export_test.py
+++ b/conans/test/integration/command/export/export_test.py
@@ -16,21 +16,6 @@ from conans.util.files import load, save
 
 class ExportSettingsTest(unittest.TestCase):
 
-    def test_basic(self):
-        client = TestClient()
-        conanfile = textwrap.dedent("""
-            from conans import ConanFile
-            class TestConan(ConanFile):
-                name = "Hello"
-                version = "1.2"
-                settings = "os"
-            """)
-        client.save({"conanfile.py": conanfile})
-        client.run("export . lasote/stable")
-        client.run("install Hello/1.2@lasote/stable -s os=Windows", assert_error=True)
-        self.assertIn("'Windows' is not a valid 'settings.os' value", client.out)
-        self.assertIn("Possible values are ['Linux']", client.out)
-
     def test_export_without_full_reference(self):
         client = TestClient()
         client.save({"conanfile.py": GenConanfile()})

--- a/conans/test/integration/command/export/export_test.py
+++ b/conans/test/integration/command/export/export_test.py
@@ -23,7 +23,7 @@ class ExportSettingsTest(unittest.TestCase):
             class TestConan(ConanFile):
                 name = "Hello"
                 version = "1.2"
-                settings = {"os": ["Linux"]}
+                settings = "os"
             """)
         client.save({"conanfile.py": conanfile})
         client.run("export . lasote/stable")

--- a/conans/test/integration/command/upload/upload_complete_test.py
+++ b/conans/test/integration/command/upload/upload_complete_test.py
@@ -315,7 +315,7 @@ class UploadTest(unittest.TestCase):
             class TestConan(ConanFile):
                 name = "Hello"
                 version = "1.2"
-                settings = {"os": ["Windows"]}
+                settings = "os"
             """)
         self.client.save({CONANFILE: conanfile})
         self.client.run("export . lasote/stable")

--- a/conans/test/unittests/model/other_settings_test.py
+++ b/conans/test/unittests/model/other_settings_test.py
@@ -190,51 +190,20 @@ class SayConan(ConanFile):
         self.assertEqual(conan_info.settings.os,  "Windows")
         self.assertEqual(conan_info.settings.fields, ["arch", "os"])
 
-    def test_invalid_settings2(self):
-        # MISSING A DEFAULT VALUE BECAUSE ITS RESTRICTED TO OTHER, SO ITS REQUIRED
-        content = """
-from conans import ConanFile
-
-class SayConan(ConanFile):
-    name = "Say"
-    version = "0.1"
-    settings = {"os": "compiler"}
-"""
-        client = TestClient()
-        client.save({CONANFILE: content})
-        client.run("install . -s compiler=gcc -s compiler.version=4.8 --build missing",
-                   assert_error=True)
-        self.assertIn(bad_value_msg("settings.compiler", "gcc", ["Visual Studio"]),
-                      str(client.out))
-
     def test_invalid_settings3(self):
-        # dict without options
-        content = """
-from conans import ConanFile
-
-class SayConan(ConanFile):
-    name = "Say"
-    version = "0.1"
-    settings = {"os", "compiler"}
-"""
         client = TestClient()
-        client.save({CONANFILE: content})
-        client.run("install . -s compiler=gcc -s compiler.version=4.8 --build missing",
-                   assert_error=True)
-        self.assertIn(bad_value_msg("settings.compiler", "gcc", ["Visual Studio"]),
-                      str(client.out))
 
         # Test wrong settings in conanfile
         content = textwrap.dedent("""
             from conans import ConanFile
 
             class SayConan(ConanFile):
-                settings = invalid
+                settings = "invalid"
             """)
 
         client.save({CONANFILE: content})
         client.run("install . --build missing", assert_error=True)
-        self.assertIn("invalid' is not defined", client.out)
+        self.assertIn("'settings.invalid' doesn't exist", client.out)
 
         # Test wrong values in conanfile
     def test_invalid_settings4(self):

--- a/conans/test/unittests/model/other_settings_test.py
+++ b/conans/test/unittests/model/other_settings_test.py
@@ -124,7 +124,7 @@ cppstd=11""", client.out)
         # https://github.com/conan-io/conan/issues/3022
         conanfile = """from conans import ConanFile
 class Test(ConanFile):
-    settings = {"os": "Linux"}
+    settings = "os"
     def build(self):
         self.output.info("OS!!: %s" % self.settings.os)
     """
@@ -181,7 +181,7 @@ from conans import ConanFile
 class SayConan(ConanFile):
     name = "Say"
     version = "0.1"
-    settings = {"os": ["Windows"], "arch": ["x86", "x86_64", "sparc", "sparcv9"]}
+    settings = {"os", "arch"}
 """
         client = TestClient()
         client.save({CONANFILE: content})
@@ -198,8 +198,7 @@ from conans import ConanFile
 class SayConan(ConanFile):
     name = "Say"
     version = "0.1"
-    settings = {"os": ["Windows", "Linux", "Macos", "FreeBSD", "SunOS"],
-                "compiler": ["Visual Studio"]}
+    settings = {"os": "compiler"}
 """
         client = TestClient()
         client.save({CONANFILE: content})
@@ -216,7 +215,7 @@ from conans import ConanFile
 class SayConan(ConanFile):
     name = "Say"
     version = "0.1"
-    settings = {"os": None, "compiler": ["Visual Studio"]}
+    settings = {"os", "compiler"}
 """
         client = TestClient()
         client.save({CONANFILE: content})

--- a/conans/test/unittests/model/settings_test.py
+++ b/conans/test/unittests/model/settings_test.py
@@ -48,41 +48,6 @@ class SettingsLoadsTest(unittest.TestCase):
         self.assertTrue(settings.os == "Windows")
         self.assertEqual("os=Windows", settings.values.dumps())
 
-    def test_windows_linux_remove(self):
-        yml = "os: [Windows, Linux]"
-        settings = Settings.loads(yml)
-        settings.os = "Windows"
-        settings.os.remove("Linux")
-        # removing a definition which is not contained shall not raise an exception
-        settings.os.remove("invalid")
-        settings.os.remove("ANY")
-        with self.assertRaisesRegex(ConanException, "Invalid setting 'Windows'"):
-            settings.os.remove("Windows")
-
-    def test_none_any_remove(self):
-        yml = "os: [None, ANY]"
-        settings = Settings.loads(yml)
-        settings.os = "Windows"
-        # removing a definition which is not contained shall not raise an exception
-        settings.os.remove("invalid")
-        with self.assertRaisesRegex(ConanException, "Invalid setting 'Windows'"):
-            settings.os.remove("ANY")
-
-        settings = Settings.loads(yml)
-        settings.os = "None"
-        settings.os.remove("ANY")  # "None" is still valid
-        with self.assertRaisesRegex(ConanException, "Invalid setting 'None'"):
-            settings.os.remove("None")  # "None" is not valid anymore
-
-    def test_any_remove(self):
-        yml = "os: ANY"
-        settings = Settings.loads(yml)
-        settings.os = "Windows"
-        # removing a definition which is not contained shall not raise an exception
-        settings.os.remove("invalid")
-        with self.assertRaisesRegex(ConanException, "Invalid setting 'Windows'"):
-            settings.os.remove("ANY")
-
     def test_getattr_none(self):
         yml = "os: [None, Windows]"
         settings = Settings.loads(yml)
@@ -197,36 +162,10 @@ class SettingsTest(unittest.TestCase):
         self.assertTrue(settings.os.codename == "Yosemite")
 
     def test_remove(self):
-        self.sut.remove("compiler")
+        del self.sut.compiler
         self.sut.os = "Windows"
         self.sut.validate()
         self.assertEqual(self.sut.values.dumps(), "os=Windows")
-
-    def test_remove_compiler(self):
-        self.sut.compiler.remove("Visual Studio")
-        with self.assertRaises(ConanException) as cm:
-            self.sut.compiler = "Visual Studio"
-        self.assertEqual(str(cm.exception),
-                         bad_value_msg("settings.compiler", "Visual Studio", ["gcc"]))
-
-    def test_remove_version(self):
-        self.sut.compiler["Visual Studio"].version.remove("12")
-        self.sut.compiler = "Visual Studio"
-        with self.assertRaises(ConanException) as cm:
-            self.sut.compiler.version = "12"
-        self.assertEqual(str(cm.exception),
-                         bad_value_msg("settings.compiler.version", "12", ["10", "11"]))
-        self.sut.compiler.version = 11
-        self.assertEqual(self.sut.compiler.version, "11")
-
-    def test_remove_os(self):
-        self.sut.os.remove("Windows")
-        with self.assertRaises(ConanException) as cm:
-            self.sut.os = "Windows"
-        self.assertEqual(str(cm.exception),
-                         bad_value_msg("settings.os", "Windows", ["Linux"]))
-        self.sut.os = "Linux"
-        self.assertEqual(self.sut.os, "Linux")
 
     def test_loads_default(self):
         settings = Settings.loads("""os: [Windows, Linux, Macos, Android, FreeBSD, SunOS]
@@ -389,7 +328,7 @@ os: [Windows, Linux]
         with self.assertRaises(ConanException) as cm:
             self.sut.compiler = "kk"
         self.assertEqual(str(cm.exception),
-                         bad_value_msg("settings.compiler", "kk", "['Visual Studio', 'gcc']"))
+                         bad_value_msg("settings.compiler", "kk", ['Visual Studio', 'gcc']))
 
     def test_my(self):
         self.assertEqual(self.sut.compiler, None)
@@ -397,7 +336,7 @@ os: [Windows, Linux]
         with self.assertRaises(ConanException) as cm:
             self.sut.compiler = "kk"
         self.assertEqual(str(cm.exception),
-                         bad_value_msg("settings.compiler", "kk", "['Visual Studio', 'gcc']"))
+                         bad_value_msg("settings.compiler", "kk", ['Visual Studio', 'gcc']))
 
         self.sut.compiler = "Visual Studio"
         self.assertEqual(str(self.sut.compiler), "Visual Studio")
@@ -406,7 +345,7 @@ os: [Windows, Linux]
         with self.assertRaises(ConanException) as cm:
             self.sut.compiler.kk
         self.assertEqual(str(cm.exception),
-                         str(undefined_field("settings.compiler", "kk", "['runtime', 'version']",
+                         str(undefined_field("settings.compiler", "kk", ['runtime', 'version'],
                                              "Visual Studio")))
 
         self.assertEqual(self.sut.compiler.version, None)
@@ -423,7 +362,7 @@ os: [Windows, Linux]
         with self.assertRaises(ConanException) as cm:
             assert self.sut.compiler == "kk"
         self.assertEqual(str(cm.exception),
-                         bad_value_msg("settings.compiler", "kk", "['Visual Studio', 'gcc']"))
+                         bad_value_msg("settings.compiler", "kk", ['Visual Studio', 'gcc']))
 
         self.assertFalse(self.sut.compiler == "gcc")
         self.assertTrue(self.sut.compiler == "Visual Studio")

--- a/conans/test/unittests/model/settings_test.py
+++ b/conans/test/unittests/model/settings_test.py
@@ -305,8 +305,8 @@ os: [Windows, Linux]
         self.assertEqual(self.sut.compiler.arch.speed, "A")
 
     def test_constraint(self):
-        s2 = {"os": None}
-        self.sut.constraint(s2)
+        s2 = ["os"]
+        self.sut.constrained(s2)
         with self.assertRaises(ConanException) as cm:
             self.sut.compiler
         self.assertEqual(str(cm.exception), str(undefined_field("settings", "compiler", ["os"])))
@@ -314,66 +314,23 @@ os: [Windows, Linux]
         self.sut.os = "Linux"
 
     def test_constraint2(self):
-        s2 = {"os2": None}
+        s2 = ["os2"]
         with self.assertRaises(ConanException) as cm:
-            self.sut.constraint(s2)
+            self.sut.constrained(s2)
         self.assertEqual(str(cm.exception),
                          str(undefined_field("settings", "os2", ["compiler", "os"])))
 
-    def test_constraint3(self):
-        s2 = {"os": ["Win"]}
-        with self.assertRaises(ConanException) as cm:
-            self.sut.constraint(s2)
-        self.assertEqual(str(cm.exception),
-                         bad_value_msg("os", "Win", ["Windows", "Linux"]))
-
-    def test_constraint4(self):
-        s2 = {"os": ["Windows"]}
-        self.sut.constraint(s2)
-        with self.assertRaises(ConanException) as cm:
-            self.sut.os = "Linux"
-        self.assertEqual(str(cm.exception), bad_value_msg("settings.os", "Linux", ["Windows"]))
-
-        self.sut.os = "Windows"
-
-    def test_constraint5(self):
-        s2 = {"os": None,
-              "compiler": {"Visual Studio": {"version2": None}}}
-
-        with self.assertRaises(ConanException) as cm:
-            self.sut.constraint(s2)
-        self.assertEqual(str(cm.exception), str(undefined_field("settings.compiler", "version2",
-                                                                ['runtime', 'version'])))
-        self.sut.os = "Windows"
-
     def test_constraint6(self):
-        s2 = {"os": None,
-              "compiler": {"Visual Studio": {"version": None}}}
-        self.sut.constraint(s2)
+        s2 = {"os", "compiler"}
+        self.sut.constrained(s2)
         self.sut.compiler = "Visual Studio"
         with self.assertRaises(ConanException) as cm:
             self.sut.compiler.arch
         self.assertEqual(str(cm.exception), str(undefined_field("settings.compiler", "arch",
-                                                                ['version'], "Visual Studio")))
+                                                                ['runtime', 'version'], "Visual Studio")))
         self.sut.os = "Windows"
         self.sut.compiler.version = "11"
         self.sut.compiler.version = "12"
-
-    def test_constraint7(self):
-        s2 = {"os": None,
-              "compiler": {"Visual Studio": {"version": ("11", "10")},
-                           "gcc": None}}
-
-        self.sut.constraint(s2)
-        self.sut.compiler = "Visual Studio"
-        with self.assertRaises(ConanException) as cm:
-            self.sut.compiler.version = "12"
-        self.assertEqual(str(cm.exception),
-                         bad_value_msg("settings.compiler.version", "12", ["10", "11"]))
-        self.sut.compiler.version = "10"
-        self.sut.compiler.version = "11"
-        self.sut.os = "Windows"
-        self.sut.compiler = "gcc"
 
     def test_validate(self):
         with self.assertRaisesRegex(ConanException, str(undefined_value("settings.compiler"))):


### PR DESCRIPTION
- Removed the multi-level constraints in recipes. Now recipes can only define first level ``settings = "os", ...``, but not dicts. Alternative: raise in ``validate()``
- Removed dirty ``self.settings.compiler["Visual Studio"].remove("xxxx")``. Alternative: raise in ``validate()``
- Removed ``copy_values()`` interface, used only to prune non assigned values to ``conanfile.txt`` and ``virtual`` conanfiles, that cannot declare a ``settings`` list. Let the whole settings apply, if some don't have value, the error message will be more evident than not having the setting defined at all.