### PR TITLE
Fix/develop2 remove profile autodetect

### DIFF
--- a/conans/client/cmd/profile.py
+++ b/conans/client/cmd/profile.py
@@ -43,7 +43,7 @@ def cmd_profile_create(profile_name, cache, detect=False, force=False):
 
     profile = Profile()
     if detect:
-        settings = detect_defaults_settings(profile_path)
+        settings = detect_defaults_settings()
         for name, value in settings:
             profile.settings[name] = value
 

--- a/conans/client/conf/detect.py
+++ b/conans/client/conf/detect.py
@@ -7,12 +7,11 @@ import textwrap
 from conans.client.conf.compiler_id import UNKNOWN_COMPILER, LLVM_GCC, detect_compiler_id
 from conans.cli.output import Color, ConanOutput
 from conans.client.conf.detect_vs import latest_visual_studio_version_installed
-from conans.client.tools import detected_architecture
 from conans.model.version import Version
 from conans.util.conan_v2_mode import CONAN_V2_MODE_ENVVAR
 from conans.util.env_reader import get_env
 from conans.util.files import save
-from conans.util.runners import detect_runner
+from conans.util.runners import detect_runner, check_output_runner
 
 
 def _get_compiler_and_version(compiler_exe):
@@ -171,12 +170,39 @@ def _get_profile_compiler_version(compiler, version):
 
 
 def _detect_gcc_libcxx(version):
-    # Lets keep it very simple, will not be guaranteed to be stable or correct, not hidden now
+    output = ConanOutput()
+    # Assumes a working g++ executable
     new_abi_available = Version(version) >= Version("5.1")
     if not new_abi_available:
         return "libstdc++"
-    # This assumption will be wrong in gcc>=5 in older distros. User responsibility
-    return "libstdc++11"
+
+    main = textwrap.dedent("""
+        #include <string>
+
+        using namespace std;
+        static_assert(sizeof(std::string) != sizeof(void*), "using libstdc++");
+        int main(){}
+        """)
+    t = tempfile.mkdtemp()
+    filename = os.path.join(t, "main.cpp")
+    save(filename, main)
+    old_path = os.getcwd()
+    os.chdir(t)
+    try:
+        executable = "g++"
+        error, out_str = detect_runner("%s main.cpp -std=c++11" % executable)
+        if error:
+            if "using libstdc++" in out_str:
+                output.info("gcc C++ standard library: libstdc++")
+                return "libstdc++"
+            # Other error, but can't know, lets keep libstdc++11
+            output.warning("compiler.libcxx check error: %s" % out_str)
+            output.warning("Couldn't deduce compiler.libcxx for gcc>=5.1, assuming libstdc++11")
+        else:
+            output.info("gcc C++ standard library: libstdc++11")
+        return "libstdc++11"
+    finally:
+        os.chdir(old_path)
 
 
 def _detect_compiler_version(result):
@@ -228,6 +254,105 @@ def _detect_compiler_version(result):
             result.append(("compiler.base.version", "4.4"))
 
 
+def _get_solaris_architecture():
+    # under intel solaris, platform.machine()=='i86pc' so we need to handle
+    # it early to suport 64-bit
+    processor = platform.processor()
+    kernel_bitness, elf = platform.architecture()
+    if "sparc" in processor:
+        return "sparcv9" if kernel_bitness == "64bit" else "sparc"
+    elif "i386" in processor:
+        return "x86_64" if kernel_bitness == "64bit" else "x86"
+
+
+def _get_aix_conf(options=None):
+    options = " %s" % options if options else ""
+    try:
+        ret = check_output_runner("getconf%s" % options).strip()
+        return ret
+    except Exception:
+        return None
+
+
+def _get_aix_architecture():
+    processor = platform.processor()
+    if "powerpc" in processor:
+        kernel_bitness = _get_aix_conf("KERNEL_BITMODE")
+        if kernel_bitness:
+            return "ppc64" if kernel_bitness == "64" else "ppc32"
+    elif "rs6000" in processor:
+        return "ppc32"
+
+
+def _get_e2k_architecture():
+    return {
+        "E1C+": "e2k-v4",  # Elbrus 1C+ and Elbrus 1CK
+        "E2C+": "e2k-v2",  # Elbrus 2CM
+        "E2C+DSP": "e2k-v2",  # Elbrus 2C+
+        "E2C3": "e2k-v6",  # Elbrus 2C3
+        "E2S": "e2k-v3",  # Elbrus 2S (aka Elbrus 4C)
+        "E8C": "e2k-v4",  # Elbrus 8C and Elbrus 8C1
+        "E8C2": "e2k-v5",  # Elbrus 8C2 (aka Elbrus 8CB)
+        "E12C": "e2k-v6",  # Elbrus 12C
+        "E16C": "e2k-v6",  # Elbrus 16C
+        "E32C": "e2k-v7",  # Elbrus 32C
+    }.get(platform.processor())
+
+
+def _detected_architecture():
+    # FIXME: Very weak check but not very common to run conan in other architectures
+    machine = platform.machine()
+    arch = None
+    system = platform.system()
+
+    # special detectors
+    if system == "SunOS":
+        arch = _get_solaris_architecture()
+    elif system == "AIX":
+        arch = _get_aix_architecture()
+    if arch:
+        return arch
+
+    if "ppc64le" in machine:
+        return "ppc64le"
+    elif "ppc64" in machine:
+        return "ppc64"
+    elif "ppc" in machine:
+        return "ppc32"
+    elif "mips64" in machine:
+        return "mips64"
+    elif "mips" in machine:
+        return "mips"
+    elif "sparc64" in machine:
+        return "sparcv9"
+    elif "sparc" in machine:
+        return "sparc"
+    elif "aarch64" in machine:
+        return "armv8"
+    elif "arm64" in machine:
+        return "armv8"
+    elif "64" in machine:
+        return "x86_64"
+    elif "86" in machine:
+        return "x86"
+    elif "armv8" in machine:
+        return "armv8"
+    elif "armv7" in machine:
+        return "armv7"
+    elif "arm" in machine:
+        return "armv6"
+    elif "s390x" in machine:
+        return "s390x"
+    elif "s390" in machine:
+        return "s390"
+    elif "sun4v" in machine:
+        return "sparc"
+    elif "e2k" in machine:
+        return _get_e2k_architecture()
+
+    return None
+
+
 def _detect_os_arch(result):
     from conans.client.conf import get_default_settings_yml
     from conans.model.settings import Settings
@@ -237,7 +362,7 @@ def _detect_os_arch(result):
         the_os = "Macos"
     result.append(("os", the_os))
 
-    arch = detected_architecture()
+    arch = _detected_architecture()
 
     if arch:
         if arch.startswith('arm'):

--- a/conans/client/tools/oss.py
+++ b/conans/client/tools/oss.py
@@ -57,59 +57,6 @@ def cpu_count(output=None):
     return 1  # Safe guess
 
 
-def detected_architecture():
-    # FIXME: Very weak check but not very common to run conan in other architectures
-    machine = platform.machine()
-    os_info = OSInfo()
-    arch = None
-
-    if os_info.is_solaris:
-        arch = OSInfo.get_solaris_architecture()
-    elif os_info.is_aix:
-        arch = OSInfo.get_aix_architecture()
-
-    if arch:
-        return arch
-
-    if "ppc64le" in machine:
-        return "ppc64le"
-    elif "ppc64" in machine:
-        return "ppc64"
-    elif "ppc" in machine:
-        return "ppc32"
-    elif "mips64" in machine:
-        return "mips64"
-    elif "mips" in machine:
-        return "mips"
-    elif "sparc64" in machine:
-        return "sparcv9"
-    elif "sparc" in machine:
-        return "sparc"
-    elif "aarch64" in machine:
-        return "armv8"
-    elif "arm64" in machine:
-        return "armv8"
-    elif "64" in machine:
-        return "x86_64"
-    elif "86" in machine:
-        return "x86"
-    elif "armv8" in machine:
-        return "armv8"
-    elif "armv7" in machine:
-        return "armv7"
-    elif "arm" in machine:
-        return "armv6"
-    elif "s390x" in machine:
-        return "s390x"
-    elif "s390" in machine:
-        return "s390"
-    elif "sun4v" in machine:
-        return "sparc"
-    elif "e2k" in machine:
-        return OSInfo.get_e2k_architecture()
-
-    return None
-
 # DETECT OS, VERSION AND DISTRIBUTIONS
 
 
@@ -324,42 +271,6 @@ class OSInfo(object):
             return "Cheetha"
 
     @staticmethod
-    def get_aix_architecture():
-        processor = platform.processor()
-        if "powerpc" in processor:
-            kernel_bitness = OSInfo().get_aix_conf("KERNEL_BITMODE")
-            if kernel_bitness:
-                return "ppc64" if kernel_bitness == "64" else "ppc32"
-        elif "rs6000" in processor:
-            return "ppc32"
-
-    @staticmethod
-    def get_solaris_architecture():
-        # under intel solaris, platform.machine()=='i86pc' so we need to handle
-        # it early to suport 64-bit
-        processor = platform.processor()
-        kernel_bitness, elf = platform.architecture()
-        if "sparc" in processor:
-            return "sparcv9" if kernel_bitness == "64bit" else "sparc"
-        elif "i386" in processor:
-            return "x86_64" if kernel_bitness == "64bit" else "x86"
-
-    @staticmethod
-    def get_e2k_architecture():
-        return {
-            "E1C+": "e2k-v4",  # Elbrus 1C+ and Elbrus 1CK
-            "E2C+": "e2k-v2",  # Elbrus 2CM
-            "E2C+DSP": "e2k-v2",  # Elbrus 2C+
-            "E2C3": "e2k-v6",  # Elbrus 2C3
-            "E2S": "e2k-v3",  # Elbrus 2S (aka Elbrus 4C)
-            "E8C": "e2k-v4",  # Elbrus 8C and Elbrus 8C1
-            "E8C2": "e2k-v5",  # Elbrus 8C2 (aka Elbrus 8CB)
-            "E12C": "e2k-v6",  # Elbrus 12C
-            "E16C": "e2k-v6",  # Elbrus 16C
-            "E32C": "e2k-v7",  # Elbrus 32C
-        }.get(platform.processor())
-
-    @staticmethod
     def get_freebsd_version():
         return platform.release().split("-")[0]
 
@@ -379,18 +290,6 @@ class OSInfo(object):
             return Version(ret)
         except Exception:
             return Version("%s.%s" % (platform.version(), platform.release()))
-
-    @staticmethod
-    def get_aix_conf(options=None):
-        options = " %s" % options if options else ""
-        if not OSInfo().is_aix:
-            raise ConanException("Command only for AIX operating system")
-
-        try:
-            ret = check_output_runner("getconf%s" % options).strip()
-            return ret
-        except Exception:
-            return None
 
 
 def cross_building(conanfile, self_os=None, self_arch=None, skip_x64_x86=False):

--- a/conans/test/functional/command/profile_test.py
+++ b/conans/test/functional/command/profile_test.py
@@ -8,7 +8,6 @@ import pytest
 
 from conans.client import tools
 from conans.client.conf.detect import detect_defaults_settings
-from conans.paths import DEFAULT_PROFILE_NAME
 from conans.test.utils.mocks import RedirectedTestOutput
 from conans.test.utils.profiles import create_profile
 from conans.test.utils.tools import TestClient, redirect_output
@@ -269,7 +268,7 @@ class DetectCompilersTest(unittest.TestCase):
             "Windows": "Visual Studio"
         }
 
-        result = detect_defaults_settings(profile_path=DEFAULT_PROFILE_NAME)
+        result = detect_defaults_settings()
         # result is a list of tuples (name, value) so converting it to dict
         result = dict(result)
         platform_compiler = platform_default_compilers.get(platform.system(), None)
@@ -293,7 +292,7 @@ class DetectCompilersTest(unittest.TestCase):
         output = RedirectedTestOutput()  # Initialize each command
         with redirect_output(output):
             with tools.environment_append({"CC": "gcc"}):
-                result = detect_defaults_settings(profile_path=DEFAULT_PROFILE_NAME)
+                result = detect_defaults_settings()
         # result is a list of tuples (name, value) so converting it to dict
         result = dict(result)
         # No compiler should be detected

--- a/conans/test/unittests/util/detect_test.py
+++ b/conans/test/unittests/util/detect_test.py
@@ -1,13 +1,10 @@
 import mock
 import unittest
 
-from mock import Mock
 from parameterized import parameterized
 
 from conans.client import tools
 from conans.client.conf.detect import detect_defaults_settings
-from conans.cli.output import ConanOutput
-from conans.paths import DEFAULT_PROFILE_NAME
 from conans.test.utils.mocks import RedirectedTestOutput
 from conans.test.utils.tools import redirect_output
 
@@ -15,45 +12,9 @@ from conans.test.utils.tools import redirect_output
 class DetectTest(unittest.TestCase):
     @mock.patch("platform.machine", return_value="")
     def test_detect_empty_arch(self, _):
-        result = detect_defaults_settings(profile_path=DEFAULT_PROFILE_NAME)
+        result = detect_defaults_settings()
         result = dict(result)
         self.assertTrue("arch" not in result)
-
-    @mock.patch("conans.client.conf.detect._gcc_compiler", return_value=("gcc", "8"))
-    def test_detect_custom_profile(self, _):
-        output = RedirectedTestOutput()
-        with redirect_output(output):
-            with tools.environment_append({"CC": "gcc"}):
-                detect_defaults_settings(profile_path="~/.conan/profiles/mycustomprofile")
-                self.assertIn("conan profile update settings.compiler.libcxx=libstdc++11 "
-                              "mycustomprofile", output)
-
-    @mock.patch("conans.client.conf.detect._gcc_compiler", return_value=("gcc", "8"))
-    def test_detect_default_profile(self, _):
-        output = RedirectedTestOutput()
-        with redirect_output(output):
-            with tools.environment_append({"CC": "gcc"}):
-                detect_defaults_settings(profile_path="~/.conan/profiles/default")
-                self.assertIn("conan profile update settings.compiler.libcxx=libstdc++11 default",
-                              output)
-
-    @mock.patch("conans.client.conf.detect._gcc_compiler", return_value=("gcc", "8"))
-    def test_detect_file_profile(self, _):
-        output = RedirectedTestOutput()
-        with redirect_output(output):
-            with tools.environment_append({"CC": "gcc"}):
-                detect_defaults_settings(profile_path="./MyProfile")
-                self.assertIn("conan profile update settings.compiler.libcxx=libstdc++11 MyProfile",
-                              output)
-
-    @mock.patch("conans.client.conf.detect._gcc_compiler", return_value=("gcc", "8"))
-    def test_detect_abs_file_profile(self, _):
-        output = RedirectedTestOutput()
-        with redirect_output(output):
-            with tools.environment_append({"CC": "gcc"}):
-                detect_defaults_settings(profile_path="/foo/bar/quz/custom-profile")
-                self.assertIn("conan profile update settings.compiler.libcxx=libstdc++11 "
-                              "custom-profile", output)
 
     @parameterized.expand([
         ['powerpc', '64', '7.1.0.0', 'ppc64'],
@@ -66,7 +27,7 @@ class DetectTest(unittest.TestCase):
                 mock.patch("platform.system", mock.MagicMock(return_value='AIX')), \
                 mock.patch("conans.client.tools.oss.OSInfo.get_aix_conf", mock.MagicMock(return_value=bitness)), \
                 mock.patch('subprocess.check_output', mock.MagicMock(return_value=version)):
-            result = detect_defaults_settings(profile_path=DEFAULT_PROFILE_NAME)
+            result = detect_defaults_settings()
             result = dict(result)
             self.assertEqual("AIX", result['os'])
             self.assertEqual(expected_arch, result['arch'])
@@ -82,7 +43,7 @@ class DetectTest(unittest.TestCase):
     ])
     def test_detect_arch(self, machine, expected_arch):
         with mock.patch("platform.machine", mock.MagicMock(return_value=machine)):
-            result = detect_defaults_settings(profile_path=DEFAULT_PROFILE_NAME)
+            result = detect_defaults_settings()
             result = dict(result)
             self.assertEqual(expected_arch, result['arch'])
 
@@ -91,13 +52,13 @@ class DetectTest(unittest.TestCase):
         output = RedirectedTestOutput()
         with redirect_output(output):
             with tools.environment_append({"CC": "clang-9 --gcc-toolchain=/usr/lib/gcc/x86_64-linux-gnu/9"}):
-                detect_defaults_settings(profile_path="./MyProfile")
+                detect_defaults_settings()
                 self.assertIn("CC and CXX: clang-9 --gcc-toolchain", output)
 
     def test_vs2022(self):
         with mock.patch("conans.client.conf.detect._get_default_compiler",
                         mock.MagicMock(return_value=("Visual Studio", "17"))):
-            result = detect_defaults_settings(profile_path=DEFAULT_PROFILE_NAME)
+            result = detect_defaults_settings()
             result = dict(result)
             self.assertEqual('msvc', result['compiler'])
             self.assertEqual('19.3', result['compiler.version'])

--- a/conans/test/unittests/util/detect_test.py
+++ b/conans/test/unittests/util/detect_test.py
@@ -25,7 +25,7 @@ class DetectTest(unittest.TestCase):
         with mock.patch("platform.machine", mock.MagicMock(return_value='XXXXXXXXXXXX')), \
                 mock.patch("platform.processor", mock.MagicMock(return_value=processor)), \
                 mock.patch("platform.system", mock.MagicMock(return_value='AIX')), \
-                mock.patch("conans.client.tools.oss.OSInfo.get_aix_conf", mock.MagicMock(return_value=bitness)), \
+                mock.patch("conans.client.conf.detect._get_aix_conf", mock.MagicMock(return_value=bitness)), \
                 mock.patch('subprocess.check_output', mock.MagicMock(return_value=version)):
             result = detect_defaults_settings()
             result = dict(result)

--- a/conans/test/unittests/util/detected_architecture_test.py
+++ b/conans/test/unittests/util/detected_architecture_test.py
@@ -8,7 +8,7 @@ import unittest
 
 from parameterized import parameterized
 
-from conans.client.tools.oss import detected_architecture
+from conans.client.conf.detect import _detected_architecture
 
 
 class DetectedArchitectureTest(unittest.TestCase):
@@ -36,22 +36,22 @@ class DetectedArchitectureTest(unittest.TestCase):
     def test_various(self, mocked_machine, expected_arch):
 
         with mock.patch("platform.machine", mock.MagicMock(return_value=mocked_machine)):
-            self.assertEqual(expected_arch, detected_architecture(), "given '%s' expected '%s'" % (mocked_machine, expected_arch))
+            self.assertEqual(expected_arch, _detected_architecture(), "given '%s' expected '%s'" % (mocked_machine, expected_arch))
 
     def test_aix(self):
         with mock.patch("platform.machine", mock.MagicMock(return_value='00FB91F44C00')),\
                 mock.patch("platform.processor", mock.MagicMock(return_value='powerpc')),\
                 mock.patch("platform.system", mock.MagicMock(return_value='AIX')),\
-                mock.patch("conans.client.tools.oss.OSInfo.get_aix_conf", mock.MagicMock(return_value='32')),\
+                mock.patch("conans.client.conf.detect._get_aix_conf", mock.MagicMock(return_value='32')),\
                 mock.patch('subprocess.check_output', mock.MagicMock(return_value='7.1.0.0')):
-            self.assertEqual('ppc32', detected_architecture())
+            self.assertEqual('ppc32', _detected_architecture())
 
         with mock.patch("platform.machine", mock.MagicMock(return_value='00FB91F44C00')),\
                 mock.patch("platform.processor", mock.MagicMock(return_value='powerpc')),\
                 mock.patch("platform.system", mock.MagicMock(return_value='AIX')),\
-                mock.patch("conans.client.tools.oss.OSInfo.get_aix_conf", mock.MagicMock(return_value='64')),\
+                mock.patch("conans.client.conf.detect._get_aix_conf", mock.MagicMock(return_value='64')),\
                 mock.patch('subprocess.check_output', mock.MagicMock(return_value='7.1.0.0')):
-            self.assertEqual('ppc64', detected_architecture())
+            self.assertEqual('ppc64', _detected_architecture())
 
     def test_solaris(self):
         with mock.patch("platform.machine", mock.MagicMock(return_value='sun4v')),\
@@ -59,14 +59,14 @@ class DetectedArchitectureTest(unittest.TestCase):
                 mock.patch("platform.system", mock.MagicMock(return_value='SunOS')),\
                 mock.patch("platform.architecture", mock.MagicMock(return_value=('64bit', 'ELF'))),\
                 mock.patch("platform.release", mock.MagicMock(return_value='5.11')):
-            self.assertEqual('sparcv9', detected_architecture())
+            self.assertEqual('sparcv9', _detected_architecture())
 
         with mock.patch("platform.machine", mock.MagicMock(return_value='i86pc')),\
                 mock.patch("platform.processor", mock.MagicMock(return_value='i386')),\
                 mock.patch("platform.system", mock.MagicMock(return_value='SunOS')),\
                 mock.patch("platform.architecture", mock.MagicMock(return_value=('64bit', 'ELF'))),\
                 mock.patch("platform.release", mock.MagicMock(return_value='5.11')):
-            self.assertEqual('x86_64', detected_architecture())
+            self.assertEqual('x86_64', _detected_architecture())
 
     @parameterized.expand([
         ["E1C+", "e2k-v4"],
@@ -83,4 +83,4 @@ class DetectedArchitectureTest(unittest.TestCase):
     def test_e2k(self, processor, expected_arch):
         with mock.patch("platform.machine", mock.MagicMock(return_value='e2k')), \
                 mock.patch("platform.processor", mock.MagicMock(return_value=processor)):
-            self.assertEqual(expected_arch, detected_architecture())
+            self.assertEqual(expected_arch, _detected_architecture())


### PR DESCRIPTION
- Move stuff from OSInfo to **private** detect.
- Remove legacy warning about libstdc++11, rely on correct compilation detection
