### PR TITLE
Port changes in tests for new ci Mac node to release branch

### DIFF
--- a/conans/test/functional/build_helpers/cmake_ios_cross_build_test.py
+++ b/conans/test/functional/build_helpers/cmake_ios_cross_build_test.py
@@ -15,7 +15,7 @@ def test_cross_build_test_package():
         os=Macos
         arch=x86_64
         compiler=apple-clang
-        compiler.version=12.0
+        compiler.version=13.0
         compiler.libcxx=libc++
         build_type=Release
         [options]
@@ -26,10 +26,10 @@ def test_cross_build_test_package():
     profile_host = textwrap.dedent("""
         [settings]
         os=iOS
-        os.version=12.0
+        os.version=13.0
         arch=x86_64
         compiler=apple-clang
-        compiler.version=12.0
+        compiler.version=13.0
         compiler.libcxx=libc++
         build_type=Release
         [options]

--- a/conans/test/functional/toolchains/meson/_base.py
+++ b/conans/test/functional/toolchains/meson/_base.py
@@ -19,7 +19,7 @@ class TestMesonBase(unittest.TestCase):
     def _settings(self):
         settings_macosx = {"compiler": "apple-clang",
                            "compiler.libcxx": "libc++",
-                           "compiler.version": "12.0",
+                           "compiler.version": "13.0",
                            "arch": "x86_64",
                            "build_type": "Release"}
 
@@ -47,7 +47,7 @@ class TestMesonBase(unittest.TestCase):
         if platform.system() == "Darwin":
             self.assertIn("main __x86_64__ defined", self.t.out)
             self.assertIn("main __apple_build_version__", self.t.out)
-            self.assertIn("main __clang_major__12", self.t.out)
+            self.assertIn("main __clang_major__13", self.t.out)
             # TODO: check why __clang_minor__ seems to be not defined in XCode 12
             # commented while migrating to XCode12 CI
             # self.assertIn("main __clang_minor__0", self.t.out)


### PR DESCRIPTION
Porting changes in tests to pass with new Macos node.
Port https://github.com/conan-io/conan/pull/9909 to release/1.42
Changelog: omit
Docs: omit