### PR TITLE
Test bazel just for one python version to avoid ci problems

### DIFF
--- a/conans/test/functional/toolchains/google/test_bazel.py
+++ b/conans/test/functional/toolchains/google/test_bazel.py
@@ -1,5 +1,6 @@
 import os
 import platform
+import sys
 import textwrap
 import time
 import unittest
@@ -162,6 +163,9 @@ class LinuxTest(Base):
 
 
 @pytest.mark.skipif(platform.system() != "Darwin", reason="Only for Apple")
+@pytest.mark.skipif(sys.version_info.major != 3 or sys.version_info.minor != 6,
+                    reason="We are running this test for just one python version, "
+                           "running this in parallel is very problematic")
 class AppleTest(Base):
 
     @parameterized.expand(["Debug",])


### PR DESCRIPTION
Changelog: omit
Docs: omit

The ci is failing because bazel tests interfere each other when launched in parallel (probably some server using the same port). Let's launch just for one python version (3.6) while we find other solution.