### PR TITLE
let CMakeToolchain not crash if build_type not defined

### DIFF
--- a/conan/tools/cmake/toolchain.py
+++ b/conan/tools/cmake/toolchain.py
@@ -8,7 +8,7 @@ from jinja2 import Template
 
 from conan.tools._check_build_profile import check_using_build_profile
 from conan.tools._compilers import architecture_flag, use_win_mingw
-from conan.tools.cmake.utils import is_multi_configuration, get_file_name
+from conan.tools.cmake.utils import is_multi_configuration
 from conan.tools.files import save_toolchain_args
 from conan.tools.intel import IntelCC
 from conan.tools.microsoft import VCVars
@@ -117,6 +117,8 @@ class VSRuntimeBlock(Block):
                 config_dict = dict(matches)
 
         build_type = settings.get_safe("build_type")  # FIXME: change for configuration
+        if build_type is None:
+            return None
         runtime = settings.get_safe("compiler.runtime")
         if compiler == "Visual Studio":
             config_dict[build_type] = {"MT": "MultiThreaded",

--- a/conans/test/functional/toolchains/cmake/test_cmake_toolchain.py
+++ b/conans/test/functional/toolchains/cmake/test_cmake_toolchain.py
@@ -101,3 +101,17 @@ def test_cmake_toolchain_user_toolchain_from_dep():
                  "CMakeLists.txt": gen_cmakelists()}, clean_first=True)
     client.run("create . pkg/0.1@")
     assert "mytoolchain.cmake !!!running!!!" in client.out
+
+
+def test_cmake_toolchain_without_build_type():
+    # If "build_type" is not defined, toolchain will still be generated, it will not crash
+    # Main effect is CMAKE_MSVC_RUNTIME_LIBRARY not being defined
+    client = TestClient(path_with_spaces=False)
+    conanfile = GenConanfile().with_settings("os", "compiler", "arch").\
+        with_generator("CMakeToolchain")
+
+    client.save({"conanfile.py": conanfile})
+    client.run("install .")
+    toolchain = client.load("conan_toolchain.cmake")
+    assert "CMAKE_MSVC_RUNTIME_LIBRARY" not in toolchain
+    assert "CMAKE_BUILD_TYPE" not in toolchain


### PR DESCRIPTION
Changelog: Fix: CMakeToolchain will not crash if build_type not defined.
Docs: Omit

@KerstinKeller
