### PR TITLE
fix unescaped double-quotes for defines

### DIFF
--- a/conans/client/generators/premake.py
+++ b/conans/client/generators/premake.py
@@ -13,7 +13,7 @@ class PremakeDeps(object):
                                     for p in deps_cpp_info.bin_paths)
         self.libs = ", ".join('"%s"' % p.replace('"', '\\"') for p in deps_cpp_info.libs)
         self.system_libs = ", ".join('"%s"' % p.replace('"', '\\"') for p in deps_cpp_info.system_libs)
-        self.defines = ", ".join('"%s"' % p for p in deps_cpp_info.defines)
+        self.defines = ", ".join('"%s"' % p.replace('"', '\\"') for p in deps_cpp_info.defines)
         self.cxxflags = ", ".join('"%s"' % p for p in deps_cpp_info.cxxflags)
         self.cflags = ", ".join('"%s"' % p for p in deps_cpp_info.cflags)
         self.sharedlinkflags = ", ".join('"%s"' % p.replace('"', '\\"') for p in deps_cpp_info.sharedlinkflags)


### PR DESCRIPTION
Changelog: Bugfix: Fix unescaped double-quotes for defines in ``Premake`` generator.
Docs: Omit

`boost/1.77.0` generates unescaped double-quotes:
```lua
conan_defines = {"BOOST_STACKTRACE_ADDR2LINE_LOCATION="/usr/bin/addr2line"",
```
the Premake generator didn't escape double-quotes for defines, so this PR fixes that.


- [ ] Refer to the issue that supports this Pull Request.
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 

<sup>**Note:** By default this PR will skip the slower tests and will use a limited set of python versions. Check [here](https://github.com/conan-io/conan/blob/develop/.github/PR_INCREASE_TESTING.md) how to increase the testing level by writing some tags in the current PR body text.</sup>