### PR TITLE
remove virtual-envs auto-use

### DIFF
--- a/conans/assets/templates/new_v2_cmake.py
+++ b/conans/assets/templates/new_v2_cmake.py
@@ -56,9 +56,7 @@ from conan.tools.layout import cmake_layout
 
 class {package_name}TestConan(ConanFile):
     settings = "os", "compiler", "build_type", "arch"
-    # VirtualBuildEnv and VirtualRunEnv can be avoided if "tools.env.virtualenv:auto_use" is defined
-    # (it will be defined in Conan 2.0)
-    generators = "CMakeDeps", "CMakeToolchain", "VirtualBuildEnv", "VirtualRunEnv"
+    generators = "CMakeDeps", "CMakeToolchain"
 
     def build(self):
         cmake = CMake(self)
@@ -281,10 +279,6 @@ from conans import ConanFile, tools
 
 class {package_name}TestConan(ConanFile):
     settings = "os", "compiler", "build_type", "arch"
-    # VirtualRunEnv can be avoided if "tools.env.virtualenv:auto_use" is defined
-    # (it will be defined in Conan 2.0)
-    generators = "VirtualRunEnv"
-    apply_env = False
 
     def test(self):
         if not tools.cross_building(self):

--- a/conans/client/generators/__init__.py
+++ b/conans/client/generators/__init__.py
@@ -1,4 +1,5 @@
 import os
+import traceback
 
 from conan.tools.microsoft.subsystems import deduce_subsystem
 from conans.errors import ConanException, conanfile_exception_formatter
@@ -82,12 +83,14 @@ def write_generators(conanfile):
         if generator_class:
             try:
                 generator = generator_class(conanfile)
-                conanfile.output.highlight("Generator '{}' calling 'generate()'".format(generator_name))
+                conanfile.output.highlight(f"Generator '{generator_name}' calling 'generate()'")
                 mkdir(new_gen_folder)
                 with chdir(new_gen_folder):
                     generator.generate()
                 continue
             except Exception as e:
+                # When a generator fails, it is very useful to have the whole stacktrace
+                conanfile.output.error(traceback.format_exc())
                 raise ConanException("Error in generator '{}': {}".format(generator_name, str(e)))
 
     if hasattr(conanfile, "generate"):
@@ -97,18 +100,18 @@ def write_generators(conanfile):
             with conanfile_exception_formatter(str(conanfile), "generate"):
                 conanfile.generate()
 
-    if conanfile.virtualbuildenv or conanfile.virtualrunenv:
+    if conanfile.virtualbuildenv:
         mkdir(new_gen_folder)
         with chdir(new_gen_folder):
-
-            if conanfile.virtualbuildenv:
-                from conan.tools.env.virtualbuildenv import VirtualBuildEnv
-                env = VirtualBuildEnv(conanfile)
-                env.generate()
-            if conanfile.virtualrunenv:
-                from conan.tools.env import VirtualRunEnv
-                env = VirtualRunEnv(conanfile)
-                env.generate()
+            from conan.tools.env.virtualbuildenv import VirtualBuildEnv
+            env = VirtualBuildEnv(conanfile)
+            env.generate()
+    if conanfile.virtualrunenv:
+        mkdir(new_gen_folder)
+        with chdir(new_gen_folder):
+            from conan.tools.env import VirtualRunEnv
+            env = VirtualRunEnv(conanfile)
+            env.generate()
 
     conanfile.output.highlight("Aggregating env generators")
     _generate_aggregated_env(conanfile)

--- a/conans/model/conf.py
+++ b/conans/model/conf.py
@@ -19,7 +19,6 @@ DEFAULT_CONFIGURATION = {
     "tools.cmake.cmaketoolchain:system_name": "Define CMAKE_SYSTEM_NAME in CMakeToolchain",
     "tools.cmake.cmaketoolchain:system_version": "Define CMAKE_SYSTEM_VERSION in CMakeToolchain",
     "tools.cmake.cmaketoolchain:system_processor": "Define CMAKE_SYSTEM_PROCESSOR in CMakeToolchain",
-    "tools.env.virtualenv:auto_use": "Automatically activate virtualenv file generation",
     "tools.files.download:retry": "Number of retries in case of failure when downloading",
     "tools.files.download:retry_wait": "Seconds to wait between download attempts",
     "tools.gnu:make_program": "Indicate path to make program",

--- a/conans/test/functional/toolchains/cmake/test_cmake_toolchain_win_clang.py
+++ b/conans/test/functional/toolchains/cmake/test_cmake_toolchain_win_clang.py
@@ -12,7 +12,6 @@ from conans.util.files import save
 @pytest.fixture
 def client():
     c = TestClient()
-    save(c.cache.new_config_path, "tools.env.virtualenv:auto_use=True")
     clang_profile = textwrap.dedent("""
         [settings]
         os=Windows

--- a/conans/test/functional/toolchains/env/test_complete.py
+++ b/conans/test/functional/toolchains/env/test_complete.py
@@ -119,8 +119,7 @@ def test_complete():
             requires = "myopenssl/1.0"
             default_options = {"myopenssl:shared": True}
             exports_sources = "CMakeLists.txt", "main.cpp"
-            generators = "CMakeDeps", "CMakeToolchain", "VirtualBuildEnv", "VirtualRunEnv"
-            apply_env = False
+            generators = "CMakeDeps", "CMakeToolchain"
 
             def build(self):
                 cmake = CMake(self)

--- a/conans/test/integration/build_requires/build_requires_test.py
+++ b/conans/test/integration/build_requires/build_requires_test.py
@@ -71,7 +71,6 @@ def client():
             """)
     client = TestClient()
     save(client.cache.default_profile_path, "[settings]\nos=Windows")
-    save(client.cache.new_config_path, "tools.env.virtualenv:auto_use=True")
     client.save({"cmake/conanfile.py": cmake,
                  "gtest/conanfile.py": gtest,
                  "openssl/conanfile.py": openssl})
@@ -113,7 +112,6 @@ def test_complete(client):
         class Pkg(ConanFile):
             requires = "openssl/1.0"
             build_requires = "mycmake/1.0"
-            apply_env = False
 
             def build_requirements(self):
                 self.test_requires("mygtest/1.0")

--- a/conans/test/integration/build_requires/profile_build_requires_test.py
+++ b/conans/test/integration/build_requires/profile_build_requires_test.py
@@ -58,7 +58,6 @@ class BuildRequiresTest(unittest.TestCase):
 
     def test_profile_requires(self):
         client = TestClient()
-        save(client.cache.new_config_path, "tools.env.virtualenv:auto_use=True")
         self._create(client)
 
         client.save({CONANFILE: lib_conanfile,
@@ -74,7 +73,6 @@ class BuildRequiresTest(unittest.TestCase):
 
     def test_profile_open_requires(self):
         client = TestClient()
-        save(client.cache.new_config_path, "tools.env.virtualenv:auto_use=True")
         self._create(client)
 
         client.save({CONANFILE: lib_conanfile,
@@ -104,7 +102,6 @@ class BuildRequiresTest(unittest.TestCase):
 
     def test_profile_test_requires(self):
         client = TestClient()
-        save(client.cache.new_config_path, "tools.env.virtualenv:auto_use=True")
         self._create(client)
 
         test_conanfile = """
@@ -129,7 +126,6 @@ class TestMyLib(ConanFile):
 
     def test_consumer_patterns(self):
         client = TestClient()
-        save(client.cache.new_config_path, "tools.env.virtualenv:auto_use=True")
         self._create(client)
 
         test_conanfile = """

--- a/conans/test/integration/build_requires/test_install_test_build_require.py
+++ b/conans/test/integration/build_requires/test_install_test_build_require.py
@@ -45,7 +45,6 @@ def client():
             """)
 
     client = TestClient()
-    save(client.cache.new_config_path, "tools.env.virtualenv:auto_use=True")
     client.save({"tool/conanfile.py": GenConanfile(),
                  "cmake/conanfile.py": cmake,
                  "openssl/conanfile.py": openssl})


### PR DESCRIPTION
- Removed legacy "auto-use" conf
- Let failing generators print a whole exception, very necessary
