### PR TITLE
[Bugfix] Option `--require-override` is not working for `conanfile.txt`

### DIFF
--- a/conans/client/graph/graph_manager.py
+++ b/conans/client/graph/graph_manager.py
@@ -201,7 +201,8 @@ class GraphManager(object):
                                      ref.user, ref.channel, validate=False)
             root_node = Node(ref, conanfile, context=CONTEXT_HOST, recipe=RECIPE_CONSUMER, path=path)
         else:
-            conanfile = self._loader.load_conanfile_txt(path, profile, ref=ref)
+            conanfile = self._loader.load_conanfile_txt(path, profile, ref=ref,
+                                                        require_overrides=require_overrides)
             root_node = Node(None, conanfile, context=CONTEXT_HOST, recipe=RECIPE_CONSUMER,
                              path=path)
 

--- a/conans/client/loader.py
+++ b/conans/client/loader.py
@@ -261,7 +261,7 @@ class ConanFileLoader(object):
         except Exception as e:  # re-raise with file name
             raise ConanException("%s: %s" % (conanfile_path, str(e)))
 
-    def load_conanfile_txt(self, conan_txt_path, profile_host, ref=None):
+    def load_conanfile_txt(self, conan_txt_path, profile_host, ref=None, require_overrides=None):
         if not os.path.exists(conan_txt_path):
             raise NotFoundException("Conanfile not found!")
 
@@ -269,6 +269,12 @@ class ConanFileLoader(object):
         path, basename = os.path.split(conan_txt_path)
         display_name = "%s (%s)" % (basename, ref) if ref and ref.name else basename
         conanfile = self._parse_conan_txt(contents, path, display_name, profile_host)
+
+        if require_overrides is not None:
+            for req_override in require_overrides:
+                req_override = ConanFileReference.loads(req_override)
+                conanfile.requires.override(req_override)
+
         return conanfile
 
     def _parse_conan_txt(self, contents, path, display_name, profile):

--- a/conans/test/integration/command/install/install_test.py
+++ b/conans/test/integration/command/install/install_test.py
@@ -437,7 +437,7 @@ class TestCliOverride:
         client.save({"conanfile.txt": textwrap.dedent("""\
         [requires]
         zlib/1.0
-        """)})
+        """)}, clean_first=True)
         client.run("install . --require-override=zlib/2.0")
         assert "zlib/2.0: Already installed" in client.out
 

--- a/conans/test/integration/command/install/install_test.py
+++ b/conans/test/integration/command/install/install_test.py
@@ -430,6 +430,17 @@ class TestCliOverride:
         client.run("install . --require-override=zlib/2.0")
         assert "zlib/2.0: Already installed" in client.out
 
+    def test_install_cli_override_in_conanfile_txt(self, client):
+        client.save({"conanfile.py": GenConanfile()})
+        client.run("create . zlib/1.0@")
+        client.run("create . zlib/2.0@")
+        client.save({"conanfile.txt": textwrap.dedent("""\
+        [requires]
+        zlib/1.0
+        """)})
+        client.run("install . --require-override=zlib/2.0")
+        assert "zlib/2.0: Already installed" in client.out
+
     def test_install_ref_cli_override(self, client):
         client.save({"conanfile.py": GenConanfile()})
         client.run("create . zlib/1.0@")


### PR DESCRIPTION
Changelog: Bugfix: Option `--require-override` is not working for `conanfile.txt`.
Closes: https://github.com/conan-io/conan/issues/10010
Docs: omit

- [x] Refer to the issue that supports this Pull Request.
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 

<sup>**Note:** By default this PR will skip the slower tests and will use a limited set of python versions. Check [here](https://github.com/conan-io/conan/blob/develop/.github/PR_INCREASE_TESTING.md) how to increase the testing level by writing some tags in the current PR body text.</sup>
