### PR TITLE
Don't run bazel toolchain test in Darwin and also simplify test code

### DIFF
--- a/conans/test/functional/toolchains/google/test_bazel.py
+++ b/conans/test/functional/toolchains/google/test_bazel.py
@@ -111,7 +111,7 @@ class Base(unittest.TestCase):
 
 
 @pytest.mark.skipif(platform.system() == "Darwin", reason="Test failing randomly in macOS")
-class LinuxTest(Base):
+class BazelToolchainTest(Base):
     @parameterized.expand(["Debug",])
     def test_toolchain(self, build_type):
         self._run_build()

--- a/conans/test/functional/toolchains/google/test_bazel.py
+++ b/conans/test/functional/toolchains/google/test_bazel.py
@@ -110,66 +110,10 @@ class Base(unittest.TestCase):
         self.client.run_command(command_str)
 
 
-@pytest.mark.skipif(platform.system() != "Windows", reason="Only for windows")
-class WinTest(Base):
-    @parameterized.expand(["Debug"])
-    def test_toolchain_win(self, build_type):
-        self._run_build()
-
-        self.assertIn("INFO: Build completed successfully", self.client.out)
-
-        self._run_app()
-        self.assertIn("%s: %s!" % ("Hello", build_type), self.client.out)
-
-        self._modify_code()
-        time.sleep(1)
-        self._incremental_build()
-        rebuild_info = self.client.load("output.txt")
-
-        if build_type == 'Debug':
-            text_to_find = "'Compiling app/hello.cpp': One of the files has changed."
-        elif build_type == 'Release':
-            text_to_find = "'Compiling app/hello.cpp': Effective client environment has changed"
-        self.assertIn(text_to_find, rebuild_info)
-
-        self._run_app()
-        self.assertIn("%s: %s!" % ("HelloImproved", build_type), self.client.out)
-
-
-@pytest.mark.skipif(platform.system() != "Linux", reason="Only for Linux")
+@pytest.mark.skipif(platform.system() == "Darwin", reason="Test failing randomly in macOS")
 class LinuxTest(Base):
     @parameterized.expand(["Debug",])
-    def test_toolchain_linux(self, build_type):
-        self._run_build()
-
-        self.assertIn("INFO: Build completed successfully", self.client.out)
-
-        self._run_app()
-        self.assertIn("%s: %s!" % ("Hello", build_type), self.client.out)
-
-        self._modify_code()
-        time.sleep(1)
-        self._incremental_build()
-        rebuild_info = self.client.load("output.txt")
-
-        if build_type == 'Debug':
-            text_to_find = "'Compiling app/hello.cpp': One of the files has changed."
-        elif build_type == 'Release':
-            text_to_find = "'Compiling app/hello.cpp': Effective client environment has changed"
-        self.assertIn(text_to_find, rebuild_info)
-
-        self._run_app()
-        self.assertIn("%s: %s!" % ("HelloImproved", build_type), self.client.out)
-
-
-@pytest.mark.skipif(platform.system() != "Darwin", reason="Only for Apple")
-@pytest.mark.skipif(sys.version_info.major != 3 or sys.version_info.minor != 6,
-                    reason="We are running this test for just one python version, "
-                           "running this in parallel is very problematic")
-class AppleTest(Base):
-
-    @parameterized.expand(["Debug",])
-    def test_toolchain_apple(self, build_type):
+    def test_toolchain(self, build_type):
         self._run_build()
 
         self.assertIn("INFO: Build completed successfully", self.client.out)


### PR DESCRIPTION
Changelog: omit
Docs: omit

- Don't run toolchain bazel test any more
- Also, simplify tests, there were three identical tests for different platforms?
