### PR TITLE
added import for custom Blocks in CMakeToolchain

### DIFF
--- a/conan/tools/cmake/__init__.py
+++ b/conan/tools/cmake/__init__.py
@@ -1,4 +1,5 @@
 from conan.tools.cmake.toolchain import CMakeToolchain
+from conan.tools.cmake.toolchain import Block as CMakeToolchainBlock
 from conan.tools.cmake.cmake import CMake
 from conan.tools.cmake.cmakedeps.cmakedeps import CMakeDeps
 from conan.tools.cmake.file_api import CMakeFileAPI

--- a/conans/test/integration/toolchains/cmake/test_cmaketoolchain_blocks.py
+++ b/conans/test/integration/toolchains/cmake/test_cmaketoolchain_blocks.py
@@ -1,0 +1,27 @@
+import textwrap
+
+from conans.test.utils.tools import TestClient
+
+
+def test_custom_block():
+    # https://github.com/conan-io/conan/issues/9998
+    c = TestClient()
+    conanfile = textwrap.dedent("""
+        from conans import ConanFile
+        from conan.tools.cmake import CMakeToolchain, CMakeToolchainBlock
+        class Pkg(ConanFile):
+            def generate(self):
+                toolchain = CMakeToolchain(self)
+
+                class MyBlock(CMakeToolchainBlock):
+                    template = "Hello {{myvar}}!!!"
+
+                    def context(self):
+                        return {"myvar": "World"}
+
+                toolchain.blocks["mynewblock"] = MyBlock
+                toolchain.generate()
+        """)
+    c.save({"conanfile.py": conanfile})
+    c.run("install .")
+    assert "Hello World!!!" in c.load("conan_toolchain.cmake")


### PR DESCRIPTION
Changelog: Bugfix: Add import for ``CMakeToolchainBlock`` custom Blocks in ``CMakeToolchain``.
Docs: https://github.com/conan-io/docs/pull/2312

Close https://github.com/conan-io/conan/issues/9998
