### PR TITLE
POC generic remotes

### DIFF
--- a/conans/cli/api/model.py
+++ b/conans/cli/api/model.py
@@ -1,10 +1,14 @@
 class Remote:
 
-    def __init__(self, name, url, verify_ssl=True, disabled=False):
+    def __init__(self, name, url, verify_ssl=True, disabled=False, generic=False, username=None,
+                 password=None):
         self._name = name  # Read only, is the key
         self.url = url
         self.verify_ssl = verify_ssl
         self.disabled = disabled
+        self.generic = generic
+        self.username = username
+        self.password = password
 
     @property
     def name(self):
@@ -16,11 +20,17 @@ class Remote:
         return self.name == other.name and \
                self.url == other.url and \
                self.verify_ssl == other.verify_ssl and \
-               self.disabled == other.disabled
+               self.disabled == other.disabled and \
+               self.generic == other.generic
 
     def __str__(self):
-        return "{}: {} [Verify SSL: {}, Enabled: {}]".format(self.name, self.url, self.verify_ssl,
-                                                             not self.disabled)
+        ret = ""
+        the_type = "generic" if self.generic else "conan"
+        ret += "{}: {} [Verify SSL: {}, Enabled: {}, Type: {}]".format(self.name, self.url,
+                                                                       self.verify_ssl,
+                                                                       not self.disabled,
+                                                                       the_type)
+        return ret
 
 
 class PackageConfiguration:

--- a/conans/cli/command.py
+++ b/conans/cli/command.py
@@ -183,9 +183,10 @@ def get_remote_selection(conan_api, remote_patterns):
     """
     ret_remotes = []
     for pattern in remote_patterns:
-        tmp = conan_api.remotes.list(pattern=pattern, only_active=True)
+        tmp = conan_api.remotes.list(pattern=pattern)
+        tmp = [r for r in tmp if not r.disabled and not r.generic]
         if not tmp:
-            raise ConanException("Remotes for pattern '{}' can't be found or are "
+            raise ConanException("Remotes for pattern '{}' can't be found, are generic, or are "
                                  "disabled".format(pattern))
         ret_remotes.extend(tmp)
     return ret_remotes

--- a/conans/cli/commands/remote.py
+++ b/conans/cli/commands/remote.py
@@ -13,7 +13,8 @@ from conans.errors import ConanException
 
 
 def output_remote_list_json(remotes):
-    info = [{"name": r.name, "url": r.url, "verify_ssl": r.verify_ssl, "enabled": not r.disabled}
+    info = [{"name": r.name, "url": r.url, "verify_ssl": r.verify_ssl, "enabled": not r.disabled,
+             "type": "generic" if r.generic else "conan"}
             for r in remotes]
     myjson = json.dumps(info, indent=4)
     cli_out_write(myjson)
@@ -74,10 +75,14 @@ def remote_add(conan_api, parser, subparser, *args):
                            help="Allow insecure server connections when using SSL")
     subparser.add_argument("--index", action=OnceArgument, type=int,
                            help="Insert the remote at a specific position in the remote list")
+    subparser.add_argument("--generic", action='store_true',
+                           help="Add a generic repository used to store generic credentials to be "
+                                "used in recipes on download(), get() etc.")
     subparser.set_defaults(secure=True)
     args = parser.parse_args(*args)
     index = _check_index_argument(args.index)
-    r = Remote(args.name, args.url, args.secure, disabled=False)
+    generic = args.generic
+    r = Remote(args.name, args.url, args.secure, disabled=False, generic=generic)
     conan_api.remotes.add(r)
     if index is not None:
         conan_api.remotes.move(r, index)

--- a/conans/cli/conan_app.py
+++ b/conans/cli/conan_app.py
@@ -52,7 +52,8 @@ class ConanApp(object):
         self.range_resolver = RangeResolver(self)
 
         self.pyreq_loader = PyRequireLoader(self.proxy, self.range_resolver)
-        self.loader = ConanFileLoader(self.runner, self.pyreq_loader, self.requester)
+        self.loader = ConanFileLoader(self.cache.remotes_registry, self.runner, self.pyreq_loader,
+                                      self.requester)
         self.binaries_analyzer = GraphBinariesAnalyzer(self)
         self.graph_manager = GraphManager(self)
 

--- a/conans/cli/conan_app.py
+++ b/conans/cli/conan_app.py
@@ -52,8 +52,8 @@ class ConanApp(object):
         self.range_resolver = RangeResolver(self)
 
         self.pyreq_loader = PyRequireLoader(self.proxy, self.range_resolver)
-        self.loader = ConanFileLoader(self.cache.remotes_registry, self.runner, self.pyreq_loader,
-                                      self.requester)
+        self.loader = ConanFileLoader(self.runner, self.pyreq_loader,
+                                      self.requester, remotes_registry=self.cache.remotes_registry)
         self.binaries_analyzer = GraphBinariesAnalyzer(self)
         self.graph_manager = GraphManager(self)
 

--- a/conans/client/cache/remote_registry.py
+++ b/conans/client/cache/remote_registry.py
@@ -157,7 +157,11 @@ class RemoteRegistry(object):
         data = json.loads(content)
         for r in data.get("remotes", []):
             disabled = r.get("disabled", False)
-            remote = Remote(r["name"], r["url"], r["verify_ssl"], disabled)
+            generic = r.get("generic", False)
+            username = r.get("username", None)
+            password = r.get("password", None)
+            remote = Remote(r["name"], r["url"], r["verify_ssl"], disabled,
+                            generic, username, password)
             result._remotes.append(remote)
         return result
 
@@ -165,7 +169,10 @@ class RemoteRegistry(object):
     def _dumps_json(remotes):
         ret = {"remotes": []}
         for r in remotes.items():
-            remote = {"name": r.name, "url": r.url, "verify_ssl": r.verify_ssl}
+            remote = {"name": r.name, "url": r.url, "verify_ssl": r.verify_ssl, "generic": r.generic}
+            if r.generic:
+                remote["username"] = r.username
+                remote["password"] = r.password
             if r.disabled:
                 remote["disabled"] = True
             ret["remotes"].append(remote)

--- a/conans/client/cmd/user.py
+++ b/conans/client/cmd/user.py
@@ -16,11 +16,6 @@ def users_list(localdb, remotes):
     return remotes_info
 
 
-def token_present(localdb, remote, user):
-    current_user, token, _ = localdb.get_login(remote.url)
-    return token is not None and (user is None or user == current_user)
-
-
 def users_clean(localdb, remote_url=None):
     localdb.clean(remote_url=remote_url)
 

--- a/conans/client/loader.py
+++ b/conans/client/loader.py
@@ -23,7 +23,8 @@ from conans.util.files import load
 
 class ConanFileLoader(object):
 
-    def __init__(self, remotes_registry, runner,  pyreq_loader=None, requester=None):
+    def __init__(self, runner,  pyreq_loader=None, requester=None, remotes_registry=None):
+        # FIXME: If kept after POC, make remotes_registry positional
         self._remotes_registry = remotes_registry
         self._runner = runner
 
@@ -200,7 +201,8 @@ class ConanFileLoader(object):
         conanfile.conf = profile.conf.get_conanfile_conf(ref_str)
 
         # Initialize the generic remotes
-        conanfile.generic_remotes = [r for r in self._remotes_registry.list() if r.generic]
+        if self._remotes_registry:
+            conanfile.generic_remotes = [r for r in self._remotes_registry.list() if r.generic]
 
     def load_consumer(self, conanfile_path, profile_host, name=None, version=None, user=None,
                       channel=None, graph_lock=None, require_overrides=None):
@@ -218,7 +220,7 @@ class ConanFileLoader(object):
         conanfile.in_local_cache = False
         try:
             conanfile.develop = True
-            self._initialize_conanfile(self, conanfile, profile_host)
+            self._initialize_conanfile(conanfile, profile_host)
 
             if require_overrides is not None:
                 for req_override in require_overrides:

--- a/conans/client/rest/rest_client.py
+++ b/conans/client/rest/rest_client.py
@@ -2,7 +2,6 @@ from conans import CHECKSUM_DEPLOY, REVISIONS, OAUTH_TOKEN, MATRIX_PARAMS
 from conans.client.rest.rest_client_v1 import RestV1Methods
 from conans.client.rest.rest_client_v2 import RestV2Methods
 from conans.errors import AuthenticationException, ConanException
-from conans.search.search import filter_packages
 from conans.util.log import logger
 
 

--- a/conans/test/functional/command/config_install_test.py
+++ b/conans/test/functional/command/config_install_test.py
@@ -132,9 +132,9 @@ class ConfigInstallTest(unittest.TestCase):
         save(client.cache.conan_conf_path, conf)
         client.run('config install "%s"' % folder)
         client.run("remote list")
-        self.assertIn("myrepo1: https://myrepourl.net [Verify SSL: False, Enabled: True]",
+        self.assertIn("myrepo1: https://myrepourl.net [Verify SSL: False, Enabled: True",
                       client.out)
-        self.assertIn("my-repo-2: https://myrepo2.com [Verify SSL: True, Enabled: True]", client.out)
+        self.assertIn("my-repo-2: https://myrepo2.com [Verify SSL: True, Enabled: True", client.out)
 
     def _create_zip(self, zippath=None):
         folder = self._create_profile_folder()

--- a/conans/test/integration/command_v2/list_package_ids_test.py
+++ b/conans/test/integration/command_v2/list_package_ids_test.py
@@ -116,7 +116,7 @@ class TestListPackagesFromRemotes(TestListPackageIdsBase):
 
     def test_fail_if_no_configured_remotes(self):
         self.client.run('list packages -r="*" whatever/1.0', assert_error=True)
-        assert "Remotes for pattern '*' can't be found or are disabled" in self.client.out
+        assert "Remotes for pattern '*' can't be found" in self.client.out
 
     def test_search_disabled_remote(self):
         self._add_remote("remote1")
@@ -125,7 +125,7 @@ class TestListPackagesFromRemotes(TestListPackageIdsBase):
         # He have to put both remotes instead of using "-a" because of the
         # disbaled remote won't appear
         self.client.run("list packages whatever/1.0 -r remote1 -r remote2", assert_error=True)
-        assert "Remotes for pattern 'remote1' can't be found or are disabled" in self.client.out
+        assert "Remotes for pattern 'remote1' can't be found" in self.client.out
 
     @pytest.mark.parametrize("exc,output", [
         (ConanConnectionError("Review your network!"),

--- a/conans/test/integration/command_v2/list_package_revisions_test.py
+++ b/conans/test/integration/command_v2/list_package_revisions_test.py
@@ -112,7 +112,7 @@ class TestListPackagesFromRemotes(TestListPackageRevisionsBase):
     def test_fail_if_no_configured_remotes(self):
         pref = self._get_fake_package_refence('whatever/0.1')
         self.client.run(f'list package-revisions -r="*" {pref}', assert_error=True)
-        assert "ERROR: Remotes for pattern '*' can't be found or are disabled" in self.client.out
+        assert "ERROR: Remotes for pattern '*' can't be found" in self.client.out
 
     def test_search_disabled_remote(self):
         self._add_remote("remote1")
@@ -122,7 +122,7 @@ class TestListPackagesFromRemotes(TestListPackageRevisionsBase):
         # disbaled remote won't appear
         pref = self._get_fake_package_refence('whatever/0.1')
         self.client.run(f"list package-revisions {pref} -r remote1 -r remote2", assert_error=True)
-        assert "Remotes for pattern 'remote1' can't be found or are disabled" in self.client.out
+        assert "Remotes for pattern 'remote1' can't be found" in self.client.out
 
     @pytest.mark.parametrize("exc,output", [
         (ConanConnectionError("Review your network!"),

--- a/conans/test/integration/command_v2/list_recipe_revisions_test.py
+++ b/conans/test/integration/command_v2/list_recipe_revisions_test.py
@@ -89,7 +89,7 @@ class TestListRecipesFromRemotes(TestListRecipeRevisionsBase):
 
     def test_fail_if_no_configured_remotes(self):
         self.client.run('list recipe-revisions -r="*" whatever/1.0', assert_error=True)
-        assert "ERROR: Remotes for pattern '*' can't be found or are disabled" in self.client.out
+        assert "ERROR: Remotes for pattern '*' can't be found" in self.client.out
 
     def test_search_disabled_remote(self):
         self._add_remote("remote1")
@@ -99,7 +99,7 @@ class TestListRecipesFromRemotes(TestListRecipeRevisionsBase):
         # disbaled remote won't appear
         self.client.run("list recipe-revisions whatever/1.0 -r remote1 -r remote2",
                         assert_error=True)
-        assert "Remotes for pattern 'remote1' can't be found or are disabled" in self.client.out
+        assert "Remotes for pattern 'remote1' can't be found" in self.client.out
 
     @pytest.mark.parametrize("exc,output", [
         (ConanConnectionError("Review your network!"),

--- a/conans/test/integration/command_v2/list_recipes_test.py
+++ b/conans/test/integration/command_v2/list_recipes_test.py
@@ -78,7 +78,7 @@ class TestListRecipesFromRemotes(TestListRecipesBase):
 
     def test_fail_if_no_configured_remotes(self):
         self.client.run('list recipes -r="*" whatever', assert_error=True)
-        assert "Remotes for pattern '*' can't be found or are disabled" in self.client.out
+        assert "Remotes for pattern '*' can't be found" in self.client.out
 
     def test_search_disabled_remote(self):
         self._add_remote("remote1")
@@ -87,7 +87,7 @@ class TestListRecipesFromRemotes(TestListRecipesBase):
         # He have to put both remotes instead of using "-a" because of the
         # disbaled remote won't appear
         self.client.run("list recipes whatever -r remote1 -r remote2", assert_error=True)
-        assert "Remotes for pattern 'remote1' can't be found or are disabled" in self.client.out
+        assert "Remotes for pattern 'remote1' can't be found" in self.client.out
 
     @pytest.mark.parametrize("exc,output", [
         (ConanConnectionError("Review your network!"),

--- a/conans/test/integration/command_v2/search_test.py
+++ b/conans/test/integration/command_v2/search_test.py
@@ -39,12 +39,12 @@ class TestSearch:
         self.client = TestClient(servers=self.servers)
 
         self.client.run("search whatever", assert_error=True)
-        assert "ERROR: Remotes for pattern '*' can't be found or are disabled" in self.client.out
+        assert "ERROR: Remotes for pattern '*' can't be found" in self.client.out
 
     def test_search_disabled_remote(self, remotes):
         self.client.run("remote disable remote1")
         self.client.run("search whatever -r remote1", assert_error=True)
-        expected_output = "ERROR: Remotes for pattern 'remote1' can't be found or are disabled"
+        expected_output = "ERROR: Remotes for pattern 'remote1' can't be found"
         assert expected_output in self.client.out
 
 
@@ -92,7 +92,7 @@ class TestRemotes:
 
     def test_no_remotes(self):
         self.client.run("search something", assert_error=True)
-        expected_output = "Remotes for pattern '*' can't be found or are disabled"
+        expected_output = "Remotes for pattern '*' can't be found"
         assert expected_output in self.client.out
 
     def test_search_by_name(self):

--- a/conans/test/integration/remote/generic_remote_test.py
+++ b/conans/test/integration/remote/generic_remote_test.py
@@ -1,0 +1,50 @@
+import textwrap
+
+import mock
+from requests import Response
+
+from conans.test.utils.tools import TestClient, TestRequester
+
+
+def test_remote_generic_user_operations():
+    client = TestClient()
+    client.run("remote add foo http://foo.com --generic")
+    client.run("remote login foo my_user -p my_pass")
+    assert "Changed user of remote 'foo' from 'None' (anonymous) to " \
+           "'my_user' (authenticated)" in client.out
+    client.run("remote list")
+    assert "foo: http://foo.com [Verify SSL: True, Enabled: True, Type: generic]" in client.out
+    client.run("remote list-users")
+    assert "foo:\n  Username: my_user\n  authenticated: True\n" in client.out
+    client.run("remote logout foo")
+    assert "Changed user of remote 'foo' from 'my_user' (authenticated) to " \
+           "'None' (anonymous)" in client.out
+    client.run("remote list-users")
+    assert "foo:\n  No user\n" in client.out
+
+
+def test_remote_generic_download():
+    class MyHttpRequester(TestRequester):
+
+        def get(self, url, **kwargs):
+            assert url == 'http://foo.com/relative/path/file.txt'
+            assert kwargs["auth"] == ("my_user", "my_pass")
+            ret = Response()
+            ret.status_code = 200
+            ret._content = b''
+            return ret
+
+    client = TestClient(requester_class=MyHttpRequester)
+    client.run("remote add foo http://foo.com --generic")
+    client.run("remote login foo my_user -p my_pass")
+    conanfile = textwrap.dedent("""
+                from conans import ConanFile
+                from conan.tools.files import download
+
+                class Pkg(ConanFile):
+                    def source(self):
+                        download(self, "/relative/path/file.txt", "file.txt", remote="foo")
+                """)
+
+    client.save({"conanfile.py": conanfile})
+    client.run("create . boo/1.0@")


### PR DESCRIPTION
- A remote can be added with the same "conan remote add" command but with a `--generic` argument.
- As the `tools.download` (only supported yet) needs access to the remotes I gave access in the recipe to a list at `self.generic_remotes`. <= `discuss`, could be private, could be the cache, could be the remote registry,...
- You can call the download like this: `download(self, "/relative/path/file.txt", "file.txt", remote="foo")`. The URL should be relative to the remote one.
- It is obvious looking now at the remotes API that the "dual" storage of credentials is a mess. Maybe we could store them all just in the plain `json` or all in the database. <= `discuss`. Anyway, I think it is a good approach that should be generalized in any case to have the `username` and `password/token` at the `Remote` model from the API because it simplifies the code and the API.
- My opinion about this POC: If we are going to unify the credentials storage, it is ok, not complex, not very invasive, otherwise I don't think we should introduce this, or we will regret it later because of the mess.

Closes https://github.com/conan-io/conan/issues/4702