### PR TITLE
Fix parallel package downloading

### DIFF
--- a/conans/client/installer.py
+++ b/conans/client/installer.py
@@ -393,11 +393,10 @@ class BinaryInstaller(object):
             download_nodes.append(node)
 
         def _download(n):
-            npref = n.pref
-            layout = self._cache.package_layout(npref.ref, n.conanfile.short_paths)
+            layout = self._cache.package_layout(n.pref.ref, n.conanfile.short_paths)
             # We cannot embed the package_lock inside the remote.get_package()
             # because the handle_node_cache has its own lock
-            with layout.package_lock(pref):
+            with layout.package_lock(n.pref):
                 self._download_pkg(layout, n)
 
         parallel = self._cache.config.parallel_download


### PR DESCRIPTION
Changelog: Bugfix: Fix parallel package downloading. While downloading conan locks incorrect package ref.
Docs: Omit

- [ ] Refer to the issue that supports this Pull Request.
- [ ] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [ ] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [ ] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 

<sup>**Note:** By default this PR will skip the slower tests and will use a limited set of python versions. Check [here](https://github.com/conan-io/conan/blob/develop/.github/PR_INCREASE_TESTING.md) how to increase the testing level by writing some tags in the current PR body text.</sup>
