### PR TITLE
better printing of lockfile/computed option mismatch

### DIFF
--- a/conans/client/graph/graph_binaries.py
+++ b/conans/client/graph/graph_binaries.py
@@ -399,11 +399,24 @@ class GraphBinariesAnalyzer(object):
             if (node.graph_lock_node is not None and
                     node.graph_lock_node.options is not None and
                     node.conanfile.options.values != node.graph_lock_node.options):
+
+                toset = lambda a: set(str(a).split())
+
+                computed = toset(node.graph_lock_node.options)
+                locked = toset(node.conanfile.options.values)
+
+                difference = computed ^ locked
+
+                incomputed = difference & computed
+                inlocked = difference & locked
+
                 raise ConanException("{}: Locked options do not match computed options\n"
-                                     "Locked options:\n{}\n"
-                                     "Computed options:\n{}".format(node.ref,
-                                                                    node.graph_lock_node.options,
-                                                                    node.conanfile.options.values))
+                                     "difference:\n{}\n"
+                                     "in Locked options:\n{}\n"
+                                     "in Computed options:\n{}".format(node.ref,
+                                                                    difference,
+                                                                    inlocked,
+                                                                    incomputed))
 
             self._compute_package_id(node, default_package_id_mode, default_python_requires_id_mode)
             if node.recipe in (RECIPE_CONSUMER, RECIPE_VIRTUAL):


### PR DESCRIPTION
As it stands, if the lockfile locked options dont meet the computed ones, both option configurations are just dumped to stderr in the exception. It makes it hard to parse with your eyeballs in the case where there are a ton of options. With this change, only the difference in options is printed, along with for which configurations the differences are present. So, you just see what was different, and where it was different. 

For example if the lockfile has foo:shared=true and bar:thing=18, and the computed options are foo:shared=true and bar:baz=20, you will see the differences of bar:thing=18 and bar:baz=20 printed first. Then bar:thing=18 since it was the part of the difference in the lockfile. then bar:baz=20 since it was the part of the difference in the computed options. 

This is my first contribution so I really don't know what I'm doing, but I didn't make an issue for it because seems like the PR just does a better job of describing it, and also its small. Also I didn't open a docs issue because I didn't figure anything would need to be documented for this. 


Changelog: (Feature | Fix | Bugfix): Describe here your pull request
Docs: https://github.com/conan-io/docs/pull/XXXX

- [ ] Refer to the issue that supports this Pull Request.
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 

<sup>**Note:** By default this PR will skip the slower tests and will use a limited set of python versions. Check [here](https://github.com/conan-io/conan/blob/develop/.github/PR_INCREASE_TESTING.md) how to increase the testing level by writing some tags in the current PR body text.</sup>
