### PR TITLE
Legacy cmake_multi not affected by set_property

### DIFF
--- a/conans/model/build_info.py
+++ b/conans/model/build_info.py
@@ -221,7 +221,7 @@ class _CppInfo(object):
         if generator == "cmake_find_package" and self.get_property("cmake_module_target_name", generator):
             property_name = "cmake_module_target_name"
         # set_property will have no effect on "cmake" legacy generator
-        elif "cmake" in generator and "cmake" != generator:
+        elif "cmake" in generator and "cmake" != generator and "cmake_multi" != generator:
             property_name = "cmake_target_name"
         elif "pkg_config" in generator:
             property_name = "pkg_config_name"

--- a/conans/test/integration/generators/cpp_info_set_generator_properties_test.py
+++ b/conans/test/integration/generators/cpp_info_set_generator_properties_test.py
@@ -321,6 +321,38 @@ def test_legacy_cmake_is_not_affected_by_set_property_usage():
     assert "set(CONAN_TARGETS CONAN_PKG::greetings)" in conanbuildinfo
 
 
+def test_legacy_cmake_multi_is_not_affected_by_set_property_usage():
+    """
+    "set_property" will have no effect on "cmake_multi" legacy generator
+
+    Originally posted: https://github.com/conan-io/conan/issues/10061
+    """
+
+    client = TestClient()
+
+    greetings = textwrap.dedent("""
+        import os
+        from conans import ConanFile
+        class MyPkg(ConanFile):
+            settings = "build_type"
+            name = "greetings"
+            version = "1.0"
+
+            def package_info(self):
+                self.cpp_info.set_property("cmake_file_name", "MyChat")
+                self.cpp_info.set_property("cmake_target_name", "MyChat")
+                self.cpp_info.components["sayhello"].set_property("cmake_target_name", "MySay")
+        """)
+    client.save({"greetings.py": greetings})
+    client.run("create greetings.py greetings/1.0@")
+    client.run("install greetings/1.0@ -g cmake_multi")
+    conanbuildinfo = client.load("conanbuildinfo_multi.cmake")
+    # Let's check our final target is the pkg name instead of "MyChat"
+    assert "set_property(TARGET CONAN_PKG::greetings" in conanbuildinfo
+    assert "add_library(CONAN_PKG::greetings" in conanbuildinfo
+    assert "set(CONAN_TARGETS CONAN_PKG::greetings)" in conanbuildinfo
+
+
 def test_pkg_config_names(setup_client):
     client = setup_client
     mypkg = textwrap.dedent("""


### PR DESCRIPTION
Changelog: Bugfix: Legacy `cmake_multi` generator is not affected by `set_property`.
Docs: omit
Closes: https://github.com/conan-io/conan/issues/10061
