### PR TITLE
conan -v to stdout instead of stderr

### DIFF
--- a/conans/cli/cli.py
+++ b/conans/cli/cli.py
@@ -12,7 +12,7 @@ from conans.cli.api.conan_api import ConanAPIV2, ConanAPI
 from conans.cli.command import ConanSubCommand
 from conans.cli.exit_codes import SUCCESS, ERROR_MIGRATION, ERROR_GENERAL, USER_CTRL_C, \
     ERROR_SIGTERM, USER_CTRL_BREAK, ERROR_INVALID_CONFIGURATION
-from conans.cli.output import ConanOutput
+from conans.cli.output import ConanOutput, cli_out_write, Color
 from conans.client.command import Command
 from conans.client.conan_api import ConanAPIV1
 from conans.client.conf.config_installer import is_config_install_scheduled
@@ -112,7 +112,7 @@ class Cli(object):
                 command = self._commands[command_argument]
             except KeyError as exc:
                 if command_argument in ["-v", "--version"]:
-                    output.info("Conan version %s" % client_version)
+                    cli_out_write("Conan version %s" % client_version, fg=Color.BRIGHT_GREEN)
                     return SUCCESS
 
                 if command_argument in ["-h", "--help"]:


### PR DESCRIPTION
Changelog: Bugfix: `conan -v` goes to `stdout` instead of `stderr`
Closes: https://github.com/conan-io/conan/issues/10015
Docs: omit

- [ ] Refer to the issue that supports this Pull Request.
- [ ] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [ ] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [ ] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 

<sup>**Note:** By default this PR will skip the slower tests and will use a limited set of python versions. Check [here](https://github.com/conan-io/conan/blob/develop/.github/PR_INCREASE_TESTING.md) how to increase the testing level by writing some tags in the current PR body text.</sup>
