### PR TITLE
modern tools.gnu.PkgConfig

### DIFF
--- a/conan/tools/gnu/pkgconfig.py
+++ b/conan/tools/gnu/pkgconfig.py
@@ -1,0 +1,83 @@
+import subprocess
+
+from conan.tools.env import Environment
+from conans.errors import ConanException
+from conans.util.runners import check_output_runner
+
+
+class PkgConfig:
+
+    def __init__(self, conanfile, package, pkg_config_path=None):
+        """
+        :param package: library (package) name, such as libastral
+        """
+        self._conanfile = conanfile
+        self._package = package
+        self._info = dict()
+        self._pkg_config_path = pkg_config_path
+
+    def _parse_output(self, option):
+        executable = self._conanfile.conf["tools.gnu:pkg_config"] or "pkg-config"
+        command = [executable, '--' + option, self._package, '--print-errors']
+        try:
+            env = Environment()
+            if self._pkg_config_path:
+                env.prepend_path("PKG_CONFIG_PATH", self._pkg_config_path)
+            with env.vars(self._conanfile).apply():
+                return check_output_runner(command).strip()
+        except subprocess.CalledProcessError as e:
+            raise ConanException('pkg-config command %s failed with error: %s' % (command, e))
+
+    def _get_option(self, option):
+        if option not in self._info:
+            self._info[option] = self._parse_output(option)
+        return self._info[option]
+
+    @property
+    def includedirs(self):
+        return [include[2:] for include in self._get_option('cflags-only-I').split()]
+
+    @property
+    def cflags(self):
+        return [flag for flag in self._get_option('cflags-only-other').split()
+                if not flag.startswith("-D")]
+
+    @property
+    def defines(self):
+        return [flag for flag in self._get_option('cflags-only-other').split()
+                if flag.startswith("-D")]
+
+    @property
+    def libdirs(self):
+        return [lib[2:] for lib in self._get_option('libs-only-L').split()]
+
+    @property
+    def libs(self):
+        return [lib[2:] for lib in self._get_option('libs-only-l').split()]
+
+    @property
+    def linkflags(self):
+        return self._get_option('libs-only-other').split()
+
+    @property
+    def provides(self):
+        return self._get_option('print-provides')
+
+    @property
+    def version(self):
+        return self._get_option('modversion')
+
+    def cpp_info(self, cpp_info, is_system=True):
+        if not self.provides:
+            raise ConanException("PkgConfig error, '{}' files not available".format(self._package))
+        if is_system:
+            cpp_info.system_libs = self.libs
+        else:
+            cpp_info.libs = self.libs
+        cpp_info.libdirs = self.libdirs
+        cpp_info.sharedlinkflags = self.linkflags
+        cpp_info.exelinkflags = self.linkflags
+        cpp_info.defines = self.defines
+        cpp_info.includedirs = self.includedirs
+        cpp_info.cflags = self.cflags
+        cpp_info.cxxflags = self.cflags

--- a/conan/tools/gnu/pkgconfig.py
+++ b/conan/tools/gnu/pkgconfig.py
@@ -77,13 +77,15 @@ class PkgConfig:
                 self._variables[name] = self._parse_output('variable=%s' % name)
         return self._variables
 
-    def cpp_info(self, cpp_info, is_system=True):
+    def fill_cpp_info(self, cpp_info, is_system=True, system_libs=None):
         if not self.provides:
             raise ConanException("PkgConfig error, '{}' files not available".format(self._package))
         if is_system:
             cpp_info.system_libs = self.libs
         else:
-            cpp_info.libs = self.libs
+            system_libs = system_libs or []
+            cpp_info.libs = [lib for lib in self.libs if lib not in system_libs]
+            cpp_info.system_libs = [lib for lib in self.libs if lib in system_libs]
         cpp_info.libdirs = self.libdirs
         cpp_info.sharedlinkflags = self.linkflags
         cpp_info.exelinkflags = self.linkflags

--- a/conan/tools/gnu/pkgconfig.py
+++ b/conan/tools/gnu/pkgconfig.py
@@ -13,8 +13,9 @@ class PkgConfig:
         """
         self._conanfile = conanfile
         self._package = package
-        self._info = dict()
+        self._info = {}
         self._pkg_config_path = pkg_config_path
+        self._variables = {}
 
     def _parse_output(self, option):
         executable = self._conanfile.conf["tools.gnu:pkg_config"] or "pkg-config"
@@ -66,6 +67,15 @@ class PkgConfig:
     @property
     def version(self):
         return self._get_option('modversion')
+
+    @property
+    def variables(self):
+        if self._variables is None:
+            variable_names = self._parse_output('print-variables').split()
+            self._variables = {}
+            for name in variable_names:
+                self._variables[name] = self._parse_output('variable=%s' % name)
+        return self._variables
 
     def cpp_info(self, cpp_info, is_system=True):
         if not self.provides:

--- a/conan/tools/gnu/pkgconfig.py
+++ b/conan/tools/gnu/pkgconfig.py
@@ -45,7 +45,7 @@ class PkgConfig:
 
     @property
     def defines(self):
-        return [flag for flag in self._get_option('cflags-only-other').split()
+        return [flag[2:] for flag in self._get_option('cflags-only-other').split()
                 if flag.startswith("-D")]
 
     @property

--- a/conan/tools/gnu/pkgconfig.py
+++ b/conan/tools/gnu/pkgconfig.py
@@ -15,7 +15,7 @@ class PkgConfig:
         self._package = package
         self._info = {}
         self._pkg_config_path = pkg_config_path
-        self._variables = {}
+        self._variables = None
 
     def _parse_output(self, option):
         executable = self._conanfile.conf["tools.gnu:pkg_config"] or "pkg-config"

--- a/conan/tools/gnu/pkgconfig.py
+++ b/conan/tools/gnu/pkgconfig.py
@@ -7,19 +7,19 @@ from conans.util.runners import check_output_runner
 
 class PkgConfig:
 
-    def __init__(self, conanfile, package, pkg_config_path=None):
+    def __init__(self, conanfile, library, pkg_config_path=None):
         """
-        :param package: library (package) name, such as libastral
+        :param library: library (package) name, such as libastral
         """
         self._conanfile = conanfile
-        self._package = package
+        self._library = library
         self._info = {}
         self._pkg_config_path = pkg_config_path
         self._variables = None
 
     def _parse_output(self, option):
         executable = self._conanfile.conf["tools.gnu:pkg_config"] or "pkg-config"
-        command = [executable, '--' + option, self._package, '--print-errors']
+        command = [executable, '--' + option, self._library, '--print-errors']
         try:
             env = Environment()
             if self._pkg_config_path:
@@ -79,7 +79,7 @@ class PkgConfig:
 
     def fill_cpp_info(self, cpp_info, is_system=True, system_libs=None):
         if not self.provides:
-            raise ConanException("PkgConfig error, '{}' files not available".format(self._package))
+            raise ConanException("PkgConfig error, '{}' files not available".format(self._library))
         if is_system:
             cpp_info.system_libs = self.libs
         else:

--- a/conans/test/functional/tools/test_pkg_config.py
+++ b/conans/test/functional/tools/test_pkg_config.py
@@ -20,7 +20,7 @@ includedir=${prefix}/include
 Name: libastral
 Description: Interface library for Astral data flows
 Version: 6.6.6
-Libs: -L${libdir}/libastral -lastral -Wl,--whole-archive
+Libs: -L${libdir}/libastral -lastral -lm -Wl,--whole-archive
 Cflags: -I${includedir}/libastral -D_USE_LIBASTRAL
 """
 
@@ -45,17 +45,17 @@ class TestPkgConfig:
         assert pkg_config.version == "6.6.6"
         assert pkg_config.includedirs == ['/usr/local/include/libastral']
         assert pkg_config.defines == ['-D_USE_LIBASTRAL']
-        assert pkg_config.libs == ['astral']
+        assert pkg_config.libs == ['astral', 'm']
         assert pkg_config.libdirs == ['/usr/local/lib/libastral']
         assert pkg_config.linkflags == ['-Wl,--whole-archive']
         assert pkg_config.variables['prefix'] == '/usr/local'
 
         cpp_info = NewCppInfo()
-        pkg_config.cpp_info(cpp_info)
+        pkg_config.fill_cpp_info(cpp_info, is_system=False, system_libs=["m"])
 
         assert cpp_info.includedirs == ['/usr/local/include/libastral']
         assert cpp_info.defines == ['-D_USE_LIBASTRAL']
-        assert cpp_info.system_libs == ['astral']
+        assert cpp_info.libs == ['astral']
+        assert cpp_info.system_libs == ['m']
         assert cpp_info.libdirs == ['/usr/local/lib/libastral']
         assert cpp_info.sharedlinkflags == ['-Wl,--whole-archive']
-

--- a/conans/test/functional/tools/test_pkg_config.py
+++ b/conans/test/functional/tools/test_pkg_config.py
@@ -54,7 +54,7 @@ class TestPkgConfig:
         pkg_config.fill_cpp_info(cpp_info, is_system=False, system_libs=["m"])
 
         assert cpp_info.includedirs == ['/usr/local/include/libastral']
-        assert cpp_info.defines == ['-D_USE_LIBASTRAL']
+        assert cpp_info.defines == ['_USE_LIBASTRAL']
         assert cpp_info.libs == ['astral']
         assert cpp_info.system_libs == ['m']
         assert cpp_info.libdirs == ['/usr/local/lib/libastral']

--- a/conans/test/functional/tools/test_pkg_config.py
+++ b/conans/test/functional/tools/test_pkg_config.py
@@ -44,7 +44,7 @@ class TestPkgConfig:
         assert pkg_config.provides == "libastral = 6.6.6"
         assert pkg_config.version == "6.6.6"
         assert pkg_config.includedirs == ['/usr/local/include/libastral']
-        assert pkg_config.defines == ['-D_USE_LIBASTRAL']
+        assert pkg_config.defines == ['_USE_LIBASTRAL']
         assert pkg_config.libs == ['astral', 'm']
         assert pkg_config.libdirs == ['/usr/local/lib/libastral']
         assert pkg_config.linkflags == ['-Wl,--whole-archive']

--- a/conans/test/functional/tools/test_pkg_config.py
+++ b/conans/test/functional/tools/test_pkg_config.py
@@ -48,6 +48,7 @@ class TestPkgConfig:
         assert pkg_config.libs == ['astral']
         assert pkg_config.libdirs == ['/usr/local/lib/libastral']
         assert pkg_config.linkflags == ['-Wl,--whole-archive']
+        assert pkg_config.variables['prefix'] == '/usr/local'
 
         cpp_info = NewCppInfo()
         pkg_config.cpp_info(cpp_info)

--- a/conans/test/functional/tools/test_pkg_config.py
+++ b/conans/test/functional/tools/test_pkg_config.py
@@ -1,0 +1,60 @@
+import os
+
+import pytest
+
+from conan.tools.gnu.pkgconfig import PkgConfig
+from conans.errors import ConanException
+from conans.model.new_build_info import NewCppInfo
+from conans.test.utils.mocks import ConanFileMock
+from conans.test.utils.test_files import temp_folder
+from conans.util.files import save
+
+libastral_pc = """
+PC FILE EXAMPLE:
+
+prefix=/usr/local
+exec_prefix=${prefix}
+libdir=${exec_prefix}/lib
+includedir=${prefix}/include
+
+Name: libastral
+Description: Interface library for Astral data flows
+Version: 6.6.6
+Libs: -L${libdir}/libastral -lastral -Wl,--whole-archive
+Cflags: -I${includedir}/libastral -D_USE_LIBASTRAL
+"""
+
+
+@pytest.mark.tool_pkg_config
+class TestPkgConfig:
+    def test_negative(self):
+        conanfile = ConanFileMock()
+        pkg_config = PkgConfig(conanfile, 'libsomething_that_does_not_exist_in_the_world')
+        with pytest.raises(ConanException):
+            pkg_config.libs()
+
+    def test_pc(self):
+        tmp_dir = temp_folder()
+        filename = os.path.join(tmp_dir, 'libastral.pc')
+        save(filename, libastral_pc)
+
+        conanfile = ConanFileMock()
+        pkg_config = PkgConfig(conanfile, "libastral", pkg_config_path=tmp_dir)
+
+        assert pkg_config.provides == "libastral = 6.6.6"
+        assert pkg_config.version == "6.6.6"
+        assert pkg_config.includedirs == ['/usr/local/include/libastral']
+        assert pkg_config.defines == ['-D_USE_LIBASTRAL']
+        assert pkg_config.libs == ['astral']
+        assert pkg_config.libdirs == ['/usr/local/lib/libastral']
+        assert pkg_config.linkflags == ['-Wl,--whole-archive']
+
+        cpp_info = NewCppInfo()
+        pkg_config.cpp_info(cpp_info)
+
+        assert cpp_info.includedirs == ['/usr/local/include/libastral']
+        assert cpp_info.defines == ['-D_USE_LIBASTRAL']
+        assert cpp_info.system_libs == ['astral']
+        assert cpp_info.libdirs == ['/usr/local/lib/libastral']
+        assert cpp_info.sharedlinkflags == ['-Wl,--whole-archive']
+


### PR DESCRIPTION
Changelog: Feature: Modern ``tools.gnu.PkgConfig`` to supersede legacy ``tools.PkgConfig``. Includes management of `PKG_CONFIG_PATH` and mapping to a ``cpp_info`` structure
Docs: https://github.com/conan-io/docs/pull/2310

I am dropping unused or untested options, abstracting the model, and providing a ``cpp_info`` mapping that seems will be useful in ConanCenter recipes cc/ @madebr @spaceim