### PR TITLE
adding os=baremetal to settings

### DIFF
--- a/conans/client/conf/__init__.py
+++ b/conans/client/conf/__init__.py
@@ -63,6 +63,7 @@ _t_default_settings_yml = Template(textwrap.dedent("""
         Emscripten:
         Neutrino:
             version: ["6.4", "6.5", "6.6", "7.0", "7.1"]
+        baremetal:
     arch: [x86, x86_64, ppc32be, ppc32, ppc64le, ppc64, armv4, armv4i, armv5el, armv5hf, armv6, armv7, armv7hf, armv7s, armv7k, armv8, armv8_32, armv8.3, sparc, sparcv9, mips, mips64, avr, s390, s390x, asm.js, wasm, sh4le, e2k-v2, e2k-v3, e2k-v4, e2k-v5, e2k-v6, e2k-v7, xtensalx6, xtensalx106]
     compiler:
         sun-cc:

--- a/conans/client/migrations_settings.py
+++ b/conans/client/migrations_settings.py
@@ -2878,6 +2878,7 @@ os:
     Emscripten:
     Neutrino:
         version: ["6.4", "6.5", "6.6", "7.0", "7.1"]
+    baremetal:
 arch: [x86, x86_64, ppc32be, ppc32, ppc64le, ppc64, armv4, armv4i, armv5el, armv5hf, armv6, armv7, armv7hf, armv7s, armv7k, armv8, armv8_32, armv8.3, sparc, sparcv9, mips, mips64, avr, s390, s390x, asm.js, wasm, sh4le, e2k-v2, e2k-v3, e2k-v4, e2k-v5, e2k-v6, e2k-v7, xtensalx6, xtensalx106]
 compiler:
     sun-cc:

--- a/conans/test/unittests/model/other_settings_test.py
+++ b/conans/test/unittests/model/other_settings_test.py
@@ -318,7 +318,7 @@ class SayConan(ConanFile):
         client.run("install . -s os=ChromeOS --build missing", assert_error=True)
         self.assertIn(bad_value_msg("settings.os", "ChromeOS",
                                     ['AIX', 'Android', 'Arduino', 'Emscripten', 'FreeBSD', 'Linux', 'Macos', 'Neutrino',
-                                     'SunOS', 'Windows', 'WindowsCE', 'WindowsStore', 'iOS', 'tvOS', 'watchOS']),
+                                     'SunOS', 'Windows', 'WindowsCE', 'WindowsStore', 'baremetal', 'iOS', 'tvOS', 'watchOS']),
                       client.out)
 
         # Now add new settings to config and try again

--- a/conans/test/unittests/model/transitive_reqs_test.py
+++ b/conans/test/unittests/model/transitive_reqs_test.py
@@ -1737,7 +1737,7 @@ class SayConan(ConanFile):
         self.assertIn(bad_value_msg("settings.os", "Linux",
                                     ['AIX', 'Android', 'Arduino', 'Emscripten', 'FreeBSD', 'Macos',
                                      'Neutrino', 'SunOS', 'Windows', 'WindowsCE', 'WindowsStore',
-                                     'iOS', 'tvOS', 'watchOS']),
+                                     'baremetal', 'iOS', 'tvOS', 'watchOS']),
                       str(cm.exception))
 
     def test_config_remove2(self):


### PR DESCRIPTION
Changelog: Feature: Define ``os=baremetal`` in ``settings.yml`` to represent platforms without OS "bare metal". 
Docs: https://github.com/conan-io/docs/pull/2309

Close https://github.com/conan-io/conan/issues/4216

