### PR TITLE
Generator qbs deps

### DIFF
--- a/conan/tools/qbs/__init__.py
+++ b/conan/tools/qbs/__init__.py
@@ -1,3 +1,4 @@
 from conan.tools.qbs.qbsprofile import QbsProfile
 from conan.tools.qbs.qbsprofile import QbsProfile as QbsToolchain
 from conan.tools.qbs.qbs import Qbs
+from conan.tools.qbs.qbsdeps import QbsDeps

--- a/conan/tools/qbs/qbsconanmoduleproviderinfotemplate.py
+++ b/conan/tools/qbs/qbsconanmoduleproviderinfotemplate.py
@@ -43,6 +43,6 @@ class QbsConanModuleProviderInfoTemplate(object):
     def create_component(self, dep, component, comp_name):
         comp = {}
         comp["name"] = None if comp_name is None else utils.get_component_name(component, comp_name)
-        comp["bindirs"] = utils.prepent_package_folder(
+        comp["bindirs"] = utils.prepend_package_folder(
             component.bindirs, dep.package_folder)
         return comp

--- a/conan/tools/qbs/qbsconanmoduleproviderinfotemplate.py
+++ b/conan/tools/qbs/qbsconanmoduleproviderinfotemplate.py
@@ -1,0 +1,48 @@
+import json
+
+import conan.tools.qbs.utils as utils
+
+
+class QbsConanModuleProviderInfoTemplate(object):
+    def __init__(self, qbsdeps, requires, dependencies):
+        self.qbsdeps = qbsdeps
+        self.requires = requires
+        self.dependencies = dependencies
+
+    def render(self):
+        info = []
+
+        for dep in self.dependencies:
+            obj = {}
+            obj["name"] = utils.get_module_name(dep)
+
+            env = {}
+            env["build"] = {k: v for k, v in dep.buildenv_info.vars(
+                self.qbsdeps._conanfile).items()}
+            env["run"] = {k: v for k, v in dep.runenv_info.vars(self.qbsdeps._conanfile).items()}
+            env["deps"] = self.qbsdeps._conanfile.deps_env_info[dep.ref.name].vars
+            obj["env"] = env
+
+            components = []
+            if dep.cpp_info.has_components:
+                for comp_name in dep.cpp_info.component_names:
+                    components.append(self.create_component(
+                        dep, dep.cpp_info.components[comp_name], comp_name))
+            else:
+                components.append(self.create_component(
+                    dep, dep.cpp_info, None))
+            obj["components"] = components
+            info.append(obj)
+
+        return json.dumps(info, indent=2)
+
+    @ property
+    def filename(self):
+        return "qbs-conanmoduleprovider-info.json"
+
+    def create_component(self, dep, component, comp_name):
+        comp = {}
+        comp["name"] = None if comp_name is None else utils.get_component_name(component, comp_name)
+        comp["bindirs"] = utils.prepent_package_folder(
+            component.bindirs, dep.package_folder)
+        return comp

--- a/conan/tools/qbs/qbsdeps.py
+++ b/conan/tools/qbs/qbsdeps.py
@@ -1,0 +1,70 @@
+import os
+
+from conan.tools.qbs.qbsmoduletemplate import QbsModuleTemplate
+from conans.errors import ConanException
+from conans.util.files import save
+
+
+class QbsDeps(object):
+    def __init__(self, conanfile):
+        self._conanfile = conanfile
+        # Activate the build config files for the specified libraries
+        self.build_context_activated = []
+        # If specified, the files/targets/variables for the build context will be renamed appending
+        # a suffix. It is necessary in case of same require and build_require and will cause an error
+        self.build_context_suffix = {}
+
+    def generate(self):
+        generator_files = self.content
+        for generator_file, content in generator_files.items():
+            save(generator_file, content)
+
+    @property
+    def content(self):
+        ret = {}
+
+        host_req = self._conanfile.dependencies.host
+        build_req = self._conanfile.dependencies.direct_build
+        test_req = self._conanfile.dependencies.test
+
+        # Check if the same package is at host and build and the same time
+        activated_br = {r.ref.name for r in build_req.values()
+                        if r.ref.name in self.build_context_activated}
+        common_names = {r.ref.name for r in host_req.values()}.intersection(activated_br)
+        for common_name in common_names:
+            suffix = self.build_context_suffix.get(common_name)
+            if not suffix:
+                raise ConanException("The package '{}' exists both as 'require' and as "
+                                     "'build require'. You need to specify a suffix using the "
+                                     "'build_context_suffix' attribute at the QbsDeps "
+                                     "generator.".format(common_name))
+
+        def add_module(require, dep, comp_name):
+            print("## dependency {}".format(dep))
+            qbs_module_template = QbsModuleTemplate(self, require, dep, comp_name)
+            file_content = qbs_module_template.render()
+            # print("## added {} | content:\n{}".format(
+            #     qbs_module_template.filename, file_content))
+            ret["modules/{}/module.qbs".format(qbs_module_template.filename)] = file_content
+
+        for require, dep in list(host_req.items()) + list(build_req.items()) + list(test_req.items()):
+            # Require is not used at the moment, but its information could be used,
+            # and will be used in Conan 2.0
+            # Filter the build_requires not activated with qbsdeps.build_context_activated
+            if dep.is_build_context and dep.ref.name not in self.build_context_activated:
+                continue
+
+            if dep.cpp_info.get_property("skip_deps_file", "QbsDeps"):
+                # Skip the generation of config files for this node, it will be located externally
+                continue
+
+            if dep.cpp_info.has_components:
+                for comp_name in dep.cpp_info.component_names:
+                    print("## comp {} requires {}".format(
+                        comp_name, dep.cpp_info.components[comp_name].requires))
+                    add_module(require, dep, comp_name)
+            else:
+                add_module(require, dep, None)
+
+        # print("## ret {}".format(ret))
+        return ret

--- a/conan/tools/qbs/qbsdeps.py
+++ b/conan/tools/qbs/qbsdeps.py
@@ -1,6 +1,7 @@
 import os
 
 from conan.tools.qbs.qbsmoduletemplate import QbsModuleTemplate
+from conan.tools.qbs.qbsconanmoduleproviderinfotemplate import QbsConanModuleProviderInfoTemplate
 from conans.errors import ConanException
 from conans.util.files import save
 
@@ -44,6 +45,8 @@ class QbsDeps(object):
             file_content = qbs_module_template.render()
             ret["modules/{}/module.qbs".format(qbs_module_template.filename)] = file_content
 
+        requires = []
+        dependencies = []
         for require, dep in list(host_req.items()) + list(build_req.items()) + list(test_req.items()):
             # Require is not used at the moment, but its information could be used,
             # and will be used in Conan 2.0
@@ -55,10 +58,16 @@ class QbsDeps(object):
                 # Skip the generation of config files for this node, it will be located externally
                 continue
 
+            requires.append(require)
+            dependencies.append(dep)
+
             if dep.cpp_info.has_components:
                 for comp_name in dep.cpp_info.component_names:
                     add_module(require, dep, comp_name)
             else:
                 add_module(require, dep, None)
+        qbsConanModuleProviderInfoTemplate = QbsConanModuleProviderInfoTemplate(
+            self, requires, dependencies)
+        ret["qbs_conan-moduleprovider_info.json"] = qbsConanModuleProviderInfoTemplate.render()
 
         return ret

--- a/conan/tools/qbs/qbsdeps.py
+++ b/conan/tools/qbs/qbsdeps.py
@@ -65,9 +65,10 @@ class QbsDeps(object):
         return {"modules/{}/module.qbs".format(qbs_module_template.filename): file_content}
 
     def _get_conan_module_provider_info(self, requires, dependencies):
-        qbsConanModuleProviderInfoTemplate = self._create_module_provider_info_template(
+        qbs_conan_module_provider_info_template = self._create_module_provider_info_template(
             requires, dependencies)
-        return {"qbs_conan-moduleprovider_info.json": qbsConanModuleProviderInfoTemplate.render()}
+        return {"qbs_conan-moduleprovider_info.json":
+                qbs_conan_module_provider_info_template.render()}
 
     def _create_module_template(self, require, dep, comp_name):
         return QbsModuleTemplate(self, require, dep, comp_name)

--- a/conan/tools/qbs/qbsdeps.py
+++ b/conan/tools/qbs/qbsdeps.py
@@ -40,11 +40,8 @@ class QbsDeps(object):
                                      "generator.".format(common_name))
 
         def add_module(require, dep, comp_name):
-            print("## dependency {}".format(dep))
             qbs_module_template = QbsModuleTemplate(self, require, dep, comp_name)
             file_content = qbs_module_template.render()
-            # print("## added {} | content:\n{}".format(
-            #     qbs_module_template.filename, file_content))
             ret["modules/{}/module.qbs".format(qbs_module_template.filename)] = file_content
 
         for require, dep in list(host_req.items()) + list(build_req.items()) + list(test_req.items()):
@@ -60,11 +57,8 @@ class QbsDeps(object):
 
             if dep.cpp_info.has_components:
                 for comp_name in dep.cpp_info.component_names:
-                    print("## comp {} requires {}".format(
-                        comp_name, dep.cpp_info.components[comp_name].requires))
                     add_module(require, dep, comp_name)
             else:
                 add_module(require, dep, None)
 
-        # print("## ret {}".format(ret))
         return ret

--- a/conan/tools/qbs/qbsmoduletemplate.py
+++ b/conan/tools/qbs/qbsmoduletemplate.py
@@ -44,7 +44,7 @@ class QbsModuleTemplate(object):
         def create_module(conanfile, comp, comp_name):
             return {"{}.{}".format(utils.get_module_name(conanfile),
                                    utils.get_component_name(comp, comp_name)):
-                    self.conanfile.ref.version}
+                    conanfile.ref.version}
 
         cpp_info = self.conanfile.cpp_info.components[self.component_name]
         for req in cpp_info.requires:

--- a/conan/tools/qbs/qbsmoduletemplate.py
+++ b/conan/tools/qbs/qbsmoduletemplate.py
@@ -29,9 +29,7 @@ class QbsModuleTemplate(object):
             return self.conanfile.ref.name not in self.qbsdeps.build_context_build_modules
 
     def render(self):
-        print("### QbsModuleTemplate.render")
         context = self.context
-        print("#### context: {}".format(context))
         if context is None:
             return
         return Template(self.template, trim_blocks=True, lstrip_blocks=True,
@@ -39,15 +37,10 @@ class QbsModuleTemplate(object):
 
     @property
     def context(self):
-        print("### QbsModuleTemplate.context")
         pkg_version = self.conanfile.ref.version
         cpp = DepsCppQbs(
             self.conanfile.cpp_info.components[self.component_name], self.conanfile.package_folder)
         dependencies = self.get_direct_dependencies()
-
-        print("#### pkg_version: {}".format(pkg_version))
-        # print("#### cpp: {}".format(cpp))
-        print("#### dependencies: {}".format(dependencies))
 
         return {
             "pkg_version": pkg_version,
@@ -56,7 +49,6 @@ class QbsModuleTemplate(object):
         }
 
     def get_direct_dependencies(self):
-        print("### QbsModuleTemplate.get_direct_dependencies")
         ret = {}
 
         def create_module(conanfile, comp, comp_name):
@@ -71,13 +63,10 @@ class QbsModuleTemplate(object):
             if "::" not in req:
                 ret.update(create_module(self.conanfile, cpp_info, comp_name))
             else:
-                print("#### **** {} | {} {}".format(req, pkg_name, comp_name))
                 req_conanfile = self.conanfile.dependencies.direct_host[pkg_name]
                 if req_conanfile.cpp_info.has_components:
-                    print("#### append module {}.{}".format(pkg_name, comp_name))
                     ret.update(create_module(req_conanfile, req_conanfile.cpp_info, comp_name))
                 else:
-                    print("#### append module {}".format(pkg_name))
                     ret[self.get_module_name(req_conanfile)] = req_conanfile.ref.version
 
         return ret
@@ -155,12 +144,10 @@ class QbsModuleTemplate(object):
         return ret
 
     def get_module_name(self, dependency):
-        print("### get qbs_module_name from {}".format(dependency))
         return dependency.cpp_info.get_property("qbs_module_name", "QbsDeps") or \
             dependency.ref.name
 
     def get_component_name(self, component, default):
-        print("### get qbs_module_name from {}, default {}".format(component, default))
         return component.get_property("qbs_module_name", "QbsDeps") or \
             default
 
@@ -168,8 +155,6 @@ class QbsModuleTemplate(object):
 class DepsCppQbs(object):
     def __init__(self, cpp_info, package_folder):
         def prepent_package_folder(paths):
-            print("################# Yolo")
-            print("################# {}".format(package_folder))
             return [os.path.join(package_folder, path) for path in paths]
 
         self.includedirs = prepent_package_folder(cpp_info.includedirs)

--- a/conan/tools/qbs/qbsmoduletemplate.py
+++ b/conan/tools/qbs/qbsmoduletemplate.py
@@ -1,4 +1,3 @@
-import os
 import jinja2
 from jinja2 import Template
 import textwrap
@@ -18,13 +17,6 @@ class QbsModuleTemplate(object):
         if not self.conanfile.is_build_context:
             return ""
         return self.qbsdeps.build_context_suffix.get(self.conanfile.ref.name, "")
-
-    @property
-    def build_modules_activated(self):
-        if self.conanfile.is_build_context:
-            return self.conanfile.ref.name in self.qbsdeps.build_context_build_modules
-        else:
-            return self.conanfile.ref.name not in self.qbsdeps.build_context_build_modules
 
     def render(self):
         context = self.context
@@ -144,17 +136,30 @@ class QbsModuleTemplate(object):
 
 class DepsCppQbs(object):
     def __init__(self, cpp_info, package_folder):
-        def prepent_package_folder(paths):
-            return utils.prepent_package_folder(paths, package_folder)
+        def prepend_package_folder(paths):
+            return utils.prepend_package_folder(paths, package_folder)
 
-        self.includedirs = prepent_package_folder(cpp_info.includedirs)
-        self.libdirs = prepent_package_folder(cpp_info.libdirs)
+        self.includedirs = prepend_package_folder(cpp_info.includedirs)
+        self.libdirs = prepend_package_folder(cpp_info.libdirs)
         self.system_libs = cpp_info.system_libs
         self.libs = cpp_info.libs
-        self.frameworkdirs = prepent_package_folder(cpp_info.frameworkdirs)
+        self.frameworkdirs = prepend_package_folder(cpp_info.frameworkdirs)
         self.frameworks = cpp_info.frameworks
         self.defines = cpp_info.defines
         self.cflags = cpp_info.cflags
         self.cxxflags = cpp_info.cxxflags
         self.sharedlinkflags = cpp_info.sharedlinkflags
         self.exelinkflags = cpp_info.exelinkflags
+
+    def __eq__(self, other):
+        return self.includedirs == other.includedirs and \
+            self.libdirs == other.libdirs and \
+            self.system_libs == other.system_libs and \
+            self.libs == other.libs and \
+            self.frameworkdirs == other.frameworkdirs and \
+            self.frameworks == other.frameworks and \
+            self.defines == other.defines and \
+            self.cflags == other.cflags and \
+            self.cxxflags == other.cxxflags and \
+            self.sharedlinkflags == other.sharedlinkflags and \
+            self.exelinkflags == other.exelinkflags

--- a/conan/tools/qbs/qbsmoduletemplate.py
+++ b/conan/tools/qbs/qbsmoduletemplate.py
@@ -1,3 +1,4 @@
+import os
 import jinja2
 from jinja2 import Template
 import textwrap
@@ -40,7 +41,8 @@ class QbsModuleTemplate(object):
     def context(self):
         print("### QbsModuleTemplate.context")
         pkg_version = self.conanfile.ref.version
-        cpp = self.conanfile.cpp_info.components[self.component_name]
+        cpp = DepsCppQbs(
+            self.conanfile.cpp_info.components[self.component_name], self.conanfile.package_folder)
         dependencies = self.get_direct_dependencies()
 
         print("#### pkg_version: {}".format(pkg_version))
@@ -161,3 +163,23 @@ class QbsModuleTemplate(object):
         print("### get qbs_module_name from {}, default {}".format(component, default))
         return component.get_property("qbs_module_name", "QbsDeps") or \
             default
+
+
+class DepsCppQbs(object):
+    def __init__(self, cpp_info, package_folder):
+        def prepent_package_folder(paths):
+            print("################# Yolo")
+            print("################# {}".format(package_folder))
+            return [os.path.join(package_folder, path) for path in paths]
+
+        self.includedirs = prepent_package_folder(cpp_info.includedirs)
+        self.libdirs = prepent_package_folder(cpp_info.libdirs)
+        self.system_libs = cpp_info.system_libs
+        self.libs = cpp_info.libs
+        self.frameworkdirs = prepent_package_folder(cpp_info.frameworkdirs)
+        self.frameworks = cpp_info.frameworks
+        self.defines = cpp_info.defines
+        self.cflags = cpp_info.cflags
+        self.cxxflags = cpp_info.cxxflags
+        self.sharedlinkflags = cpp_info.sharedlinkflags
+        self.exelinkflags = cpp_info.exelinkflags

--- a/conan/tools/qbs/qbsmoduletemplate.py
+++ b/conan/tools/qbs/qbsmoduletemplate.py
@@ -3,9 +3,7 @@ import jinja2
 from jinja2 import Template
 import textwrap
 
-from conans.errors import ConanException
-from conans.model import dependencies
-from conans.model.conanfile_interface import ConanFileInterface
+import conan.tools.qbs.utils as utils
 
 
 class QbsModuleTemplate(object):
@@ -52,8 +50,8 @@ class QbsModuleTemplate(object):
         ret = {}
 
         def create_module(conanfile, comp, comp_name):
-            return {"{}.{}".format(self.get_module_name(conanfile),
-                                   self.get_component_name(comp, comp_name)):
+            return {"{}.{}".format(utils.get_module_name(conanfile),
+                                   utils.get_component_name(comp, comp_name)):
                     self.conanfile.ref.version}
 
         cpp_info = self.conanfile.cpp_info.components[self.component_name]
@@ -67,7 +65,7 @@ class QbsModuleTemplate(object):
                 if req_conanfile.cpp_info.has_components:
                     ret.update(create_module(req_conanfile, req_conanfile.cpp_info, comp_name))
                 else:
-                    ret[self.get_module_name(req_conanfile)] = req_conanfile.ref.version
+                    ret[utils.get_module_name(req_conanfile)] = req_conanfile.ref.version
 
         return ret
 
@@ -137,25 +135,17 @@ class QbsModuleTemplate(object):
 
     @ property
     def filename(self):
-        ret = self.get_module_name(self.conanfile) + self.suffix
+        ret = utils.get_module_name(self.conanfile) + self.suffix
         if self.conanfile.cpp_info.has_components:
             assert(self.component_name)
             ret = "{}/{}".format(ret, self.component_name)
         return ret
 
-    def get_module_name(self, dependency):
-        return dependency.cpp_info.get_property("qbs_module_name", "QbsDeps") or \
-            dependency.ref.name
-
-    def get_component_name(self, component, default):
-        return component.get_property("qbs_module_name", "QbsDeps") or \
-            default
-
 
 class DepsCppQbs(object):
     def __init__(self, cpp_info, package_folder):
         def prepent_package_folder(paths):
-            return [os.path.join(package_folder, path) for path in paths]
+            return utils.prepent_package_folder(paths, package_folder)
 
         self.includedirs = prepent_package_folder(cpp_info.includedirs)
         self.libdirs = prepent_package_folder(cpp_info.libdirs)

--- a/conan/tools/qbs/qbsmoduletemplate.py
+++ b/conan/tools/qbs/qbsmoduletemplate.py
@@ -1,0 +1,163 @@
+import jinja2
+from jinja2 import Template
+import textwrap
+
+from conans.errors import ConanException
+from conans.model import dependencies
+from conans.model.conanfile_interface import ConanFileInterface
+
+
+class QbsModuleTemplate(object):
+    def __init__(self, qbsdeps, require, conanfile, component):
+        self.qbsdeps = qbsdeps
+        self.require = require
+        self.conanfile = conanfile
+        self.component_name = component
+
+    @property
+    def suffix(self):
+        if not self.conanfile.is_build_context:
+            return ""
+        return self.qbsdeps.build_context_suffix.get(self.conanfile.ref.name, "")
+
+    @property
+    def build_modules_activated(self):
+        if self.conanfile.is_build_context:
+            return self.conanfile.ref.name in self.qbsdeps.build_context_build_modules
+        else:
+            return self.conanfile.ref.name not in self.qbsdeps.build_context_build_modules
+
+    def render(self):
+        print("### QbsModuleTemplate.render")
+        context = self.context
+        print("#### context: {}".format(context))
+        if context is None:
+            return
+        return Template(self.template, trim_blocks=True, lstrip_blocks=True,
+                        undefined=jinja2.StrictUndefined).render(context)
+
+    @property
+    def context(self):
+        print("### QbsModuleTemplate.context")
+        pkg_version = self.conanfile.ref.version
+        cpp = self.conanfile.cpp_info.components[self.component_name]
+        dependencies = self.get_direct_dependencies()
+
+        print("#### pkg_version: {}".format(pkg_version))
+        # print("#### cpp: {}".format(cpp))
+        print("#### dependencies: {}".format(dependencies))
+
+        return {
+            "pkg_version": pkg_version,
+            "cpp": cpp,
+            "dependencies": dependencies
+        }
+
+    def get_direct_dependencies(self):
+        print("### QbsModuleTemplate.get_direct_dependencies")
+        ret = {}
+
+        def create_module(conanfile, comp, comp_name):
+            return {"{}.{}".format(self.get_module_name(conanfile),
+                                   self.get_component_name(comp, comp_name)):
+                    self.conanfile.ref.version}
+
+        cpp_info = self.conanfile.cpp_info.components[self.component_name]
+        for req in cpp_info.requires:
+            pkg_name, comp_name = req.split("::") if "::" in req else (
+                self.conanfile.ref.name, req)
+            if "::" not in req:
+                ret.update(create_module(self.conanfile, cpp_info, comp_name))
+            else:
+                print("#### **** {} | {} {}".format(req, pkg_name, comp_name))
+                req_conanfile = self.conanfile.dependencies.direct_host[pkg_name]
+                if req_conanfile.cpp_info.has_components:
+                    print("#### append module {}.{}".format(pkg_name, comp_name))
+                    ret.update(create_module(req_conanfile, req_conanfile.cpp_info, comp_name))
+                else:
+                    print("#### append module {}".format(pkg_name))
+                    ret[self.get_module_name(req_conanfile)] = req_conanfile.ref.version
+
+        return ret
+
+    @ property
+    def template(self):
+        ret = textwrap.dedent("""\
+                Module {
+                    version: "{{ pkg_version }}"
+                    cpp.includePaths: [
+                        {% for include_path in cpp.includedirs %}
+                        "{{ include_path }}",
+                        {% endfor %}
+                    ]
+                    cpp.libraryPaths: [
+                        {% for library_path in cpp.libdirs %}
+                        "{{ library_path }}",
+                        {% endfor %}
+                    ]
+                    cpp.dynamicLibraries: [
+                        {% for library in cpp.system_libs %}
+                        "{{ library }}",
+                        {% endfor %}
+                        {% for library in cpp.libs %}
+                        "{{ library }}",
+                        {% endfor %}
+                    ]
+                    cpp.frameworkPaths: [
+                        {% for framework_path in cpp.frameworkdirs %}
+                        "{{ framework_path }}",
+                        {% endfor %}
+                    ]
+                    cpp.frameworks: [
+                        {% for framework in cpp.frameworks %}
+                        "{{ framework }}",
+                        {% endfor %}
+                    ]
+                    cpp.defines: [
+                        {% for define in cpp.defines %}
+                        '{{ define }}',
+                        {% endfor %}
+                    ]
+                    cpp.cFlags: [
+                        {% for c_flag in cpp.cflags %}
+                        "{{ c_flag }}",
+                        {% endfor %}
+                    ]
+                    cpp.cxxFlags: [
+                        {% for cxx_flag in cpp.cxxflags %}
+                        "{{ cxx_flag }}",
+                        {% endfor %}
+                    ]
+                    cpp.linkerFlags: [
+                        {% for linker_flag in cpp.sharedlinkflags %}
+                        "{{ linker_flag }}",
+                        {% endfor %}
+                        {% for linker_flag in cpp.exelinkflags %}
+                        "{{ linker_flag }}",
+                        {% endfor %}
+                    ]
+                    Depends { name: "cpp" }
+                    {% for name, version in dependencies.items() %}
+                    Depends { name: "{{ name }}"; version: "{{ version }}" }
+                    {% endfor %}
+                }
+            """)
+        return ret
+
+    @ property
+    def filename(self):
+        ret = self.get_module_name(self.conanfile) + self.suffix
+        if self.conanfile.cpp_info.has_components:
+            assert(self.component_name)
+            ret = "{}/{}".format(ret, self.component_name)
+        return ret
+
+    def get_module_name(self, dependency):
+        print("### get qbs_module_name from {}".format(dependency))
+        return dependency.cpp_info.get_property("qbs_module_name", "QbsDeps") or \
+            dependency.ref.name
+
+    def get_component_name(self, component, default):
+        print("### get qbs_module_name from {}, default {}".format(component, default))
+        return component.get_property("qbs_module_name", "QbsDeps") or \
+            default

--- a/conan/tools/qbs/utils.py
+++ b/conan/tools/qbs/utils.py
@@ -1,15 +1,14 @@
 import os
 
 
-def get_module_name(dependency):
-    return dependency.cpp_info.get_property("qbs_module_name", "QbsDeps") or \
-        dependency.ref.name
-
-
 def get_component_name(component, default):
     return component.get_property("qbs_module_name", "QbsDeps") or \
         default
 
 
-def prepent_package_folder(paths, package_folder):
+def get_module_name(dependency):
+    return get_component_name(dependency.cpp_info, dependency.ref.name)
+
+
+def prepend_package_folder(paths, package_folder):
     return [os.path.join(package_folder, path) for path in paths]

--- a/conan/tools/qbs/utils.py
+++ b/conan/tools/qbs/utils.py
@@ -1,0 +1,15 @@
+import os
+
+
+def get_module_name(dependency):
+    return dependency.cpp_info.get_property("qbs_module_name", "QbsDeps") or \
+        dependency.ref.name
+
+
+def get_component_name(component, default):
+    return component.get_property("qbs_module_name", "QbsDeps") or \
+        default
+
+
+def prepent_package_folder(paths, package_folder):
+    return [os.path.join(package_folder, path) for path in paths]

--- a/conans/client/generators/__init__.py
+++ b/conans/client/generators/__init__.py
@@ -72,7 +72,7 @@ class GeneratorManager(object):
                                 "MesonToolchain", "MSBuildDeps", "QbsToolchain", "msbuild",
                                 "VirtualRunEnv", "VirtualBuildEnv", "AutotoolsDeps",
                                 "AutotoolsToolchain", "BazelDeps", "BazelToolchain", "PkgConfigDeps",
-                                "VCVars", "IntelCC", "XcodeDeps"]
+                                "VCVars", "IntelCC", "XcodeDeps", "QbsDeps"]
 
     def add(self, name, generator_class, custom=False):
         if name not in self._generators or custom:
@@ -140,6 +140,9 @@ class GeneratorManager(object):
         elif generator_name == "XcodeDeps":
             from conan.tools.apple import XcodeDeps
             return XcodeDeps
+        elif generator_name == "QbsDeps":
+            from conan.tools.qbs import QbsDeps
+            return QbsDeps
         else:
             raise ConanException("Internal Conan error: Generator '{}' "
                                  "not commplete".format(generator_name))

--- a/conans/test/unittests/tools/qbs/test_qbs_deps.py
+++ b/conans/test/unittests/tools/qbs/test_qbs_deps.py
@@ -1,0 +1,82 @@
+from mock import Mock
+import unittest
+
+from mock.mock import MagicMock
+
+from conan.tools.qbs.qbsdeps import QbsDeps
+from conan.tools.qbs.qbsmoduletemplate import QbsModuleTemplate
+from conans import ConanFile
+from conans.model.dependencies import Requirement
+from conans.errors import ConanException
+
+
+class QbsDepsTest(unittest.TestCase):
+    @property
+    def requires(self):
+        requires = {
+            "foo": Requirement(ConanFile(Mock(), None)),
+            "bar": Requirement(ConanFile(Mock(), None)),
+            "foobar": Requirement(ConanFile(Mock(), None))
+        }
+        for k, v in requires.items():
+            v.ref.name = k
+        return requires
+
+    def test_activated_build_requires(self):
+        build_requires = self.requires
+
+        qbs_deps = QbsDeps(ConanFile(Mock(), None))
+
+        activated_br = qbs_deps._activated_build_requires(build_requires)
+        self.assertEqual(activated_br, set())
+
+        qbs_deps.build_context_activated.append("foo")
+        activated_br = qbs_deps._activated_build_requires(build_requires)
+        self.assertEqual(activated_br, {"foo"})
+
+        qbs_deps.build_context_activated.append("foobar")
+        activated_br = qbs_deps._activated_build_requires(build_requires)
+        self.assertEqual(activated_br, {"foo", "foobar"})
+
+    def test_check_if_build_require_suffix_is_missing(self):
+        qbs_deps = QbsDeps(ConanFile(Mock(), None))
+
+        qbs_deps._activated_build_requires = MagicMock(return_value={})
+        qbs_deps._check_if_build_require_suffix_is_missing(self.requires, dict())
+        qbs_deps._activated_build_requires.assert_called_once_with(dict())
+
+        qbs_deps._activated_build_requires = MagicMock(return_value={})
+        qbs_deps._check_if_build_require_suffix_is_missing(self.requires, self.requires)
+        qbs_deps._activated_build_requires.assert_called_once_with(self.requires)
+
+        qbs_deps._activated_build_requires = MagicMock(return_value={"foobar"})
+        with self.assertRaises(ConanException):
+            qbs_deps._check_if_build_require_suffix_is_missing(
+                self.requires, self.requires)
+        qbs_deps._activated_build_requires.assert_called_once_with(self.requires)
+
+        qbs_deps._activated_build_requires = MagicMock(return_value={"foobar"})
+        qbs_deps.build_context_suffix["foobar"] = "build-foobar"
+        qbs_deps._check_if_build_require_suffix_is_missing(self.requires, self.requires)
+        qbs_deps._activated_build_requires.assert_called_once_with(self.requires)
+
+    def test_get_module(self):
+        qbs_deps = QbsDeps(ConanFile(Mock(), None))
+        module_template = QbsModuleTemplate(None, None, None, None)
+
+        file_content = "this is file content"
+        file_name = "this is file name"
+        module_file_name = "modules/{}/module.qbs".format(file_name)
+
+        module_template.render = MagicMock(return_value=file_content)
+        module_template.filename = MagicMock(return_value=file_name)
+        qbs_deps._create_module_template = MagicMock(return_value=module_template)
+
+        require = 1
+        dep = 2
+        comp_name = 3
+
+        result = qbs_deps._get_module(require, dep, comp_name)
+        qbs_deps._create_module_template.assert_called_once_with(require, dep, comp_name)
+        module_template.render.assert_called_once()
+        module_template.filename.assert_called_once()

--- a/conans/test/unittests/tools/qbs/test_qbs_deps.py
+++ b/conans/test/unittests/tools/qbs/test_qbs_deps.py
@@ -1,10 +1,12 @@
 from mock import Mock
+import mock
 import unittest
 
-from mock.mock import MagicMock
+from mock.mock import MagicMock, PropertyMock
 
 from conan.tools.qbs.qbsdeps import QbsDeps
 from conan.tools.qbs.qbsmoduletemplate import QbsModuleTemplate
+from conan.tools.qbs.qbsconanmoduleproviderinfotemplate import QbsConanModuleProviderInfoTemplate
 from conans import ConanFile
 from conans.model.dependencies import Requirement
 from conans.errors import ConanException
@@ -60,23 +62,96 @@ class QbsDepsTest(unittest.TestCase):
         qbs_deps._check_if_build_require_suffix_is_missing(self.requires, self.requires)
         qbs_deps._activated_build_requires.assert_called_once_with(self.requires)
 
-    def test_get_module(self):
+    def test_get_conan_module_provider_info(self):
         qbs_deps = QbsDeps(ConanFile(Mock(), None))
-        module_template = QbsModuleTemplate(None, None, None, None)
+        module_provider_info_template_content = "Hello World"
+        module_provider_info_template = QbsConanModuleProviderInfoTemplate(None, None, None)
+        module_provider_info_template.render = MagicMock(
+            return_value=module_provider_info_template_content)
+        qbs_deps._create_module_provider_info_template = MagicMock(
+            return_value=module_provider_info_template)
+        result = qbs_deps._get_conan_module_provider_info(None, None)
+        self.assertEqual(
+            result, {"qbs_conan-moduleprovider_info.json": module_provider_info_template_content})
+        module_provider_info_template.render.assert_called_once_with()
 
+    def test_get_module(self):
         file_content = "this is file content"
         file_name = "this is file name"
         module_file_name = "modules/{}/module.qbs".format(file_name)
 
-        module_template.render = MagicMock(return_value=file_content)
-        module_template.filename = MagicMock(return_value=file_name)
-        qbs_deps._create_module_template = MagicMock(return_value=module_template)
+        qbs_deps = QbsDeps(ConanFile(Mock(), None))
+        with mock.patch.object(QbsModuleTemplate, 'filename',
+                               new_callable=PropertyMock) as mock_filename:
+            module_template = QbsModuleTemplate(None, None, None, None)
 
-        require = 1
-        dep = 2
-        comp_name = 3
+            module_template.render = MagicMock(return_value=file_content)
+            mock_filename.return_value = file_name
+            qbs_deps._create_module_template = MagicMock(return_value=module_template)
 
-        result = qbs_deps._get_module(require, dep, comp_name)
-        qbs_deps._create_module_template.assert_called_once_with(require, dep, comp_name)
-        module_template.render.assert_called_once()
-        module_template.filename.assert_called_once()
+            require = 1
+            dep = 2
+            comp_name = 3
+
+            result = qbs_deps._get_module(require, dep, comp_name)
+            self.assertEqual(result, {module_file_name: file_content})
+            qbs_deps._create_module_template.assert_called_once_with(require, dep, comp_name)
+            module_template.render.assert_called_once_with()
+            mock_filename.assert_called_once_with()
+
+    def test_content(self):
+        min_result = {"qbs_conan-moduleprovider_info.json": "module provider info"}
+        qbs_deps = QbsDeps(Mock())
+        qbs_deps.build_context_activated.append("foobar")
+        host_req = dict()
+        build_req = dict()
+        test_req = dict()
+
+        def setup_mocks():
+            qbs_deps._check_if_build_require_suffix_is_missing = MagicMock()
+            qbs_deps._get_module = MagicMock()
+            qbs_deps._get_conan_module_provider_info = MagicMock(return_value=min_result)
+            qbs_deps._conanfile.dependencies.host = host_req
+            qbs_deps._conanfile.dependencies.direct_build = build_req
+            qbs_deps._conanfile.dependencies.test = test_req
+
+        setup_mocks()
+        self.assertEqual(qbs_deps.content, min_result)
+        qbs_deps._check_if_build_require_suffix_is_missing.assert_called_once_with(
+            host_req, build_req)
+        qbs_deps._get_conan_module_provider_info.assert_called_once_with([], [])
+
+        def make_dep(name, version, build_context=False, skip=False, component_names=[]):
+            dep = Mock()
+            dep.ref.name = name
+            dep.ref.version = version
+            dep.is_build_context = build_context
+            dep.cpp_info.get_property = MagicMock(return_value=skip)
+            dep.cpp_info.has_components = component_names == []
+            dep.cpp_info.component_names = component_names
+            dep.skip = skip
+            return dep
+
+        def skip(dep):
+            return dep.skip or dep.is_build_context and dep.ref.name not in qbs_deps.build_context_activated
+
+        host_req = {1: make_dep("foo", "1.2.3"), 2: make_dep(
+            "bar", "9.8.7", skip=True), 3: make_dep("not_me", "0.0.0", build_context=True),
+            4: make_dep("foobar", "5.5.5", build_context=True),
+            5: make_dep("with_comp", "1.1.1", component_names=["comp1", "comp2"])}
+        content = min_result
+        content.update({"foo": "1.2.3", "bar": "9.8.7"})
+        setup_mocks()
+        self.assertEqual(qbs_deps.content, content)
+        qbs_deps._check_if_build_require_suffix_is_missing.assert_called_once_with(
+            host_req, build_req)
+        for r, d in host_req.items():
+            if not skip(d):
+                if d.cpp_info.has_components:
+                    for comp_name in d.cpp_info.component_names:
+                        qbs_deps._get_module.assert_any_call(r, d, comp_name)
+                else:
+                    qbs_deps._get_module.assert_any_call(r, d, None)
+        qbs_deps._get_conan_module_provider_info.assert_called_once_with(
+            [r for r, d in host_req.items() if not skip(d)],
+            [d for r, d in host_req.items() if not skip(d)])

--- a/conans/test/unittests/tools/qbs/test_qbs_deps.py
+++ b/conans/test/unittests/tools/qbs/test_qbs_deps.py
@@ -127,7 +127,7 @@ class QbsDepsTest(unittest.TestCase):
             dep.ref.version = version
             dep.is_build_context = build_context
             dep.cpp_info.get_property = MagicMock(return_value=skip)
-            dep.cpp_info.has_components = component_names == []
+            dep.cpp_info.has_components = component_names != []
             dep.cpp_info.component_names = component_names
             dep.skip = skip
             return dep

--- a/conans/test/unittests/tools/qbs/test_qbs_module_provider_info_template.py
+++ b/conans/test/unittests/tools/qbs/test_qbs_module_provider_info_template.py
@@ -1,0 +1,131 @@
+import json
+import mock
+import unittest
+
+from mock.mock import MagicMock, Mock
+from conan.tools.qbs.qbsconanmoduleproviderinfotemplate import QbsConanModuleProviderInfoTemplate
+
+import conan.tools.qbs.utils as utils
+
+
+class TestQbsModuleProviderInfoTemplate(unittest.TestCase):
+    def test_create_component(self):
+        with mock.patch.object(utils, 'get_component_name',
+                               new_callable=MagicMock) as mock_get_component_name:
+            with mock.patch.object(utils, 'prepend_package_folder',
+                                   new_callable=MagicMock) as mock_prepend_package_folder:
+                template = QbsConanModuleProviderInfoTemplate(None, None, None)
+
+                dep = Mock()
+                dep.package_folder = "package"
+                component = Mock()
+                component.bindirs = ["bin", "bin2", "hello"]
+                expected_bindirs = [
+                    "{}/{}".format(dep.package_folder, d) for d in component.bindirs]
+                mock_prepend_package_folder.return_value = expected_bindirs
+                comp = template.create_component(dep, component, None)
+                self.assertEqual(
+                    comp, {"name": None, "bindirs": mock_prepend_package_folder.return_value})
+                mock_prepend_package_folder.assert_called_once_with(
+                    component.bindirs, dep.package_folder)
+                mock_get_component_name.assert_not_called()
+                mock_prepend_package_folder.reset_mock()
+
+                comp_name = "comp"
+                mock_prepend_package_folder.return_value = expected_bindirs
+                expected_name = "some comp name"
+                mock_get_component_name.return_value = expected_name
+                comp = template.create_component(dep, component, comp_name)
+                self.assertEqual(comp, {"name": expected_name, "bindirs": expected_bindirs})
+                mock_get_component_name.assert_called_once_with(component, comp_name)
+                mock_prepend_package_folder.assert_called_once_with(
+                    component.bindirs, dep.package_folder)
+
+    def test_render(self):
+        def create_dep(name, build_env=dict(), run_env=dict(), component_names=[]):
+            dep = Mock()
+            dep.buildenv_info.vars = MagicMock(return_value=build_env)
+            dep.runenv_info.vars = MagicMock(return_value=run_env)
+            dep.ref.name = name
+            dep.cpp_info.has_components = component_names != []
+            dep.cpp_info.component_names = component_names
+            dep.cpp_info.components = {comp_name: None for comp_name in component_names}
+            return dep
+
+        def create_env(num, s):
+            return {"{}_{}_key_{}".format(num, s, i): "{}_value_{}".format(num, i) for i in range(0, 5)}
+
+        def create_component_names(num):
+            return ["{}_comp_{}".format(num, i) for i in range(0, 4)]
+
+        def side_effect_create_component(dep, component, comp_name):
+            del component
+            return "created_component-{}".format(comp_name
+                                                 if comp_name
+                                                 else dep.ref.name)
+
+        def create_deps_env_info(vars):
+            deps_env_info = Mock()
+            deps_env_info.vars = vars
+            return deps_env_info
+
+        def side_effect_get_module_name(dep):
+            return dep.ref.name
+
+        def side_effect_json_dumps(info, indent):
+            del indent
+            return info
+
+        with mock.patch.object(utils, 'get_module_name',
+                               new_callable=MagicMock) as mock_get_module_name:
+            mock_get_module_name.side_effect = side_effect_get_module_name
+            with mock.patch.object(json, 'dumps', new_callable=MagicMock) as mock_json_dump:
+                mock_json_dump.side_effect = side_effect_json_dumps
+
+                template = QbsConanModuleProviderInfoTemplate(Mock(), Mock(), Mock())
+                template.create_component = MagicMock()
+                template.create_component.side_effect = side_effect_create_component
+                template.qbsdeps._conanfile.deps_env_info = {
+                    "lib0": create_deps_env_info(create_env(0, 'd')),
+                    "lib1": create_deps_env_info(create_env(1, 'd')),
+                    "lib2": create_deps_env_info(create_env(2, 'd'))
+                }
+
+                template.dependencies = [create_dep("lib{}".format(i),
+                                                    create_env(i, 'b'),
+                                                    create_env(i, 'r'),
+                                                    create_component_names(i) if i % 2 else [])
+                                         for i in range(0, 3)]
+
+                expected_info = [
+                    {
+                        "name": "lib0",
+                        "env": {
+                            "build": create_env(0, 'b'),
+                            "run": create_env(0, 'r'),
+                            "deps": create_env(0, 'd')
+                        },
+                        "components": ["created_component-lib0"]
+                    },
+                    {
+                        "name": "lib1",
+                        "env": {
+                            "build": create_env(1, 'b'),
+                            "run": create_env(1, 'r'),
+                            "deps": create_env(1, 'd')
+                        },
+                        "components": ["created_component-{}".format(comp_name)
+                                       for comp_name in create_component_names(1)]
+                    },
+                    {
+                        "name": "lib2",
+                        "env": {
+                            "build": create_env(2, 'b'),
+                            "run": create_env(2, 'r'),
+                            "deps": create_env(2, 'd')
+                        },
+                        "components": ["created_component-lib2"]
+                    }
+                ]
+                info = template.render()
+                self.assertEqual(info, expected_info)

--- a/conans/test/unittests/tools/qbs/test_qbs_module_template.py
+++ b/conans/test/unittests/tools/qbs/test_qbs_module_template.py
@@ -1,0 +1,122 @@
+import mock
+from mock import Mock
+import unittest
+
+from mock.mock import MagicMock, PropertyMock
+from conan.tools import qbs
+from conan.tools.files.patches import patch
+
+from conan.tools.qbs.qbsmoduletemplate import QbsModuleTemplate, DepsCppQbs
+from conan.tools.qbs.qbsdeps import QbsDeps
+import conan.tools.qbs.utils as utils
+
+
+class StubCppInfo(object):
+    includedirs = []
+    libdirs = []
+    system_libs = []
+    libs = []
+    frameworkdirs = []
+    frameworks = []
+    defines = []
+    cflags = []
+    cxxflags = []
+    sharedlinkflags = []
+    exelinkflags = []
+
+
+class QbsModuleTemplateTest(unittest.TestCase):
+    def test_suffix(self):
+        qbs_deps = QbsDeps(None)
+        template = QbsModuleTemplate(qbs_deps, None, Mock(), None)
+
+        template.conanfile.is_build_context = False
+        self.assertEqual(template.suffix, "")
+
+        template.conanfile.is_build_context = True
+        self.assertEqual(template.suffix, "")
+
+        name = "foobar"
+        expected_suffix = "-build"
+        template.conanfile.ref.name = name
+        qbs_deps.build_context_suffix["foobar"] = expected_suffix
+        self.assertEqual(template.suffix, expected_suffix)
+
+    def test_context(self):
+        template = QbsModuleTemplate(None, None, Mock(), None)
+
+        expected_pkg_version = "1.2.3"
+        expected_cpp = DepsCppQbs(StubCppInfo(), "package")
+        expected_dependencies = 42
+
+        template.conanfile.ref.version = expected_pkg_version
+        template.component_name = "comp_name"
+        template.conanfile.cpp_info.components = {"comp_name": expected_cpp}
+        template.conanfile.package_folder = "package"
+        template.get_direct_dependencies = MagicMock(return_value=42)
+        result = template.context
+
+        self.assertEqual(result["pkg_version"], expected_pkg_version)
+        self.assertEqual(result["cpp"], expected_cpp)
+        self.assertEqual(result["dependencies"], expected_dependencies)
+
+    def test_filename(self):
+        expected_module_name = "module-name"
+        expected_component_name = "comp_name"
+        with mock.patch('conan.tools.qbs.qbsmoduletemplate.QbsModuleTemplate.suffix',
+                        new_callable=PropertyMock) as mock_suffix:
+            mock_suffix.return_value = "_build"
+            template = QbsModuleTemplate(None, None, Mock(), None)
+
+            utils.get_module_name = MagicMock(return_value=expected_module_name)
+            template.conanfile.cpp_info.has_components = False
+            self.assertEqual(template.filename, "{}{}".format(
+                expected_module_name, mock_suffix.return_value))
+
+            template.component_name = expected_component_name
+            template.conanfile.cpp_info.has_components = True
+            self.assertEqual(template.filename,
+                             "{}{}/{}".format(expected_module_name,
+                                              mock_suffix.return_value,
+                                              expected_component_name))
+
+    def test_render(self):
+        with mock.patch('conan.tools.qbs.qbsmoduletemplate.QbsModuleTemplate.context',
+                        new_callable=PropertyMock) as mock_context:
+            mock_context.return_value = None
+            template = QbsModuleTemplate(None, None, None, None)
+            template.render()
+
+
+class DepsCppQbsTest(unittest.TestCase):
+    def test_init(self):
+        package_folder = "package"
+
+        cpp_info = StubCppInfo()
+        cpp_info.includedirs = ["include", "include2"]
+        cpp_info.libdirs = ["lib", "lib2"]
+        cpp_info.system_libs = ["syslib", "syslib2"]
+        cpp_info.libs = ["lib", "lib2"]
+        cpp_info.frameworkdirs = ["frameworkdir", "frameworkdir2"]
+        cpp_info.frameworks = ["framework", "framework2"]
+        cpp_info.defines = ["define", "define2"]
+        cpp_info.cflags = ["cflag", "cflag2"]
+        cpp_info.cxxflags = ["cxxflag", "cxxflag2"]
+        cpp_info.sharedlinkflags = ["sharedlinkflag", "sharedlinkflag2"]
+        cpp_info.exelinkflags = ["exelinkflags", "exelinkflags2"]
+
+        cpp_info_qbs = DepsCppQbs(cpp_info, package_folder)
+        self.assertEqual(cpp_info_qbs.includedirs,
+                         utils.prepend_package_folder(cpp_info.includedirs, package_folder))
+        self.assertEqual(cpp_info_qbs.libdirs,
+                         utils.prepend_package_folder(cpp_info.libdirs, package_folder))
+        self.assertEqual(cpp_info_qbs.system_libs, cpp_info.system_libs)
+        self.assertEqual(cpp_info_qbs.libs, cpp_info.libs)
+        self.assertEqual(cpp_info_qbs.frameworkdirs,
+                         utils.prepend_package_folder(cpp_info.frameworkdirs, package_folder))
+        self.assertEqual(cpp_info_qbs.frameworks, cpp_info.frameworks)
+        self.assertEqual(cpp_info_qbs.defines, cpp_info.defines)
+        self.assertEqual(cpp_info_qbs.cflags, cpp_info.cflags)
+        self.assertEqual(cpp_info_qbs.cxxflags, cpp_info.cxxflags)
+        self.assertEqual(cpp_info_qbs.sharedlinkflags, cpp_info.sharedlinkflags)
+        self.assertEqual(cpp_info_qbs.exelinkflags, cpp_info.exelinkflags)

--- a/conans/test/unittests/tools/qbs/test_qbs_utils.py
+++ b/conans/test/unittests/tools/qbs/test_qbs_utils.py
@@ -1,0 +1,39 @@
+import mock
+import unittest
+
+from mock.mock import MagicMock
+import conan.tools.qbs.utils as utils
+
+
+class QbsUtilsTest(unittest.TestCase):
+    def test_get_component_name(self):
+        default = "default"
+        module_name = "module-name"
+
+        component = MagicMock()
+        component.get_property = MagicMock(return_value=None)
+
+        self.assertEqual(utils.get_component_name(component, default), default)
+        component.get_property.assert_called_once_with("qbs_module_name", "QbsDeps")
+
+        component.get_property = MagicMock(return_value=module_name)
+        self.assertEqual(utils.get_component_name(component, default), module_name)
+        component.get_property.assert_called_once_with("qbs_module_name", "QbsDeps")
+
+    def test_get_module_name(self):
+        dependency = MagicMock()
+        dependency.cpp_info.get_property = 1
+        dependency.ref.name = 2
+        expected_result = 3
+
+        utils.get_component_name = MagicMock(return_value=expected_result)
+        self.assertEqual(utils.get_module_name(dependency), expected_result)
+        utils.get_component_name.assert_called_once_with(dependency.cpp_info, dependency.ref.name)
+
+    def test_prepend_package_folder(self):
+        package_folder = "package"
+        paths = ["a", "b", "c"]
+        expected_paths = ["package/a", "package/b", "package/c"]
+
+        prepended_paths = utils.prepend_package_folder(paths, package_folder)
+        self.assertEqual(prepended_paths, expected_paths)


### PR DESCRIPTION
Changelog: (Feature): QbsDeps generator to generate Qbs modules
Docs: https://github.com/conan-io/docs/pull/XXXX

Part of #10033
Generates qbs [modules](https://doc.qt.io/qbs/qml-qbslanguageitems-module.html) which contain all required informations for linking. The directory with the modules could be passed to qbs via a projects [qbsSearchPaths](https://doc.qt.io/qbs/qml-qbslanguageitems-project.html#qbsSearchPaths-prop) property. Later a qbs [module provider](https://doc.qt.io/qbs/module-providers.html) should use (mostly copy) the generated files.

- [x] Refer to the issue that supports this Pull Request.
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one.

<sup>**Note:** By default this PR will skip the slower tests and will use a limited set of python versions. Check [here](https://github.com/conan-io/conan/blob/develop/.github/PR_INCREASE_TESTING.md) how to increase the testing level by writing some tags in the current PR body text.</sup>
