### PR TITLE
Use absolute target names for cmake targets and new properties and deprecating namespace properties

### DIFF
--- a/conan/tools/cmake/cmakedeps/templates/__init__.py
+++ b/conan/tools/cmake/cmakedeps/templates/__init__.py
@@ -19,7 +19,7 @@ class CMakeDepsFileTemplate(object):
 
     @property
     def global_target_name(self):
-        return self.get_global_target_name(self.conanfile) + self.suffix
+        return self.get_global_target_name(self.conanfile, self.suffix)
 
     @property
     def file_name(self):
@@ -78,14 +78,14 @@ class CMakeDepsFileTemplate(object):
     def get_file_name(self):
         return get_file_name(self.conanfile, find_module_mode=self.find_module_mode)
 
-    def get_global_target_name(self, req):
+    def get_global_target_name(self, req, suffix=""):
         if self.find_module_mode:
             ret = req.cpp_info.get_property("cmake_module_target_name", "CMakeDeps")
             if ret:
                 return ret
 
         ret = req.cpp_info.get_property("cmake_target_name", "CMakeDeps")
-        return ret or "{}::{}".format(req.ref.name, req.ref.name)
+        return ret or "{name}{suffix}::{name}{suffix}".format(name=req.ref.name, suffix=suffix)
 
     def get_component_alias(self, req, comp_name):
         if comp_name not in req.cpp_info.components:

--- a/conan/tools/cmake/cmakedeps/templates/__init__.py
+++ b/conan/tools/cmake/cmakedeps/templates/__init__.py
@@ -22,6 +22,11 @@ class CMakeDepsFileTemplate(object):
         return self.get_global_target_name(self.conanfile, self.suffix)
 
     @property
+    def global_target_namespace(self):
+        gname = self.get_global_target_name(self.conanfile, self.suffix)
+        return gname if "::" not in gname else gname.split("::")[0]
+
+    @property
     def file_name(self):
         return get_file_name(self.conanfile, self.find_module_mode) + self.suffix
 

--- a/conan/tools/cmake/cmakedeps/templates/__init__.py
+++ b/conan/tools/cmake/cmakedeps/templates/__init__.py
@@ -89,11 +89,13 @@ class CMakeDepsFileTemplate(object):
 
     def get_component_alias(self, req, comp_name):
         if comp_name not in req.cpp_info.components:
+            # TODO: remove this
+            raise Exception("Can you get to this point?")
             # foo::foo might be referencing the root cppinfo
-            if req.ref.name == comp_name:
-                return self.get_target_namespace(req)
-            raise ConanException("Component '{name}::{cname}' not found in '{name}' "
-                                 "package requirement".format(name=req.ref.name, cname=comp_name))
+            # if req.ref.name == comp_name:
+            #     return self.get_target_namespace(req)
+            # raise ConanException("Component '{name}::{cname}' not found in '{name}' "
+            #                      "package requirement".format(name=req.ref.name, cname=comp_name))
         if self.find_module_mode:
             ret = req.cpp_info.components[comp_name].get_property("cmake_module_target_name",
                                                                   "CMakeDeps")

--- a/conan/tools/cmake/cmakedeps/templates/__init__.py
+++ b/conan/tools/cmake/cmakedeps/templates/__init__.py
@@ -89,13 +89,11 @@ class CMakeDepsFileTemplate(object):
 
     def get_component_alias(self, req, comp_name):
         if comp_name not in req.cpp_info.components:
-            # TODO: remove this
-            raise Exception("Can you get to this point?")
             # foo::foo might be referencing the root cppinfo
-            # if req.ref.name == comp_name:
-            #     return self.get_target_namespace(req)
-            # raise ConanException("Component '{name}::{cname}' not found in '{name}' "
-            #                      "package requirement".format(name=req.ref.name, cname=comp_name))
+            if req.ref.name == comp_name:
+                return self.get_global_target_name(req)
+            raise ConanException("Component '{name}::{cname}' not found in '{name}' "
+                                 "package requirement".format(name=req.ref.name, cname=comp_name))
         if self.find_module_mode:
             ret = req.cpp_info.components[comp_name].get_property("cmake_module_target_name",
                                                                   "CMakeDeps")

--- a/conan/tools/cmake/cmakedeps/templates/config.py
+++ b/conan/tools/cmake/cmakedeps/templates/config.py
@@ -30,8 +30,6 @@ class ConfigTemplate(CMakeDepsFileTemplate):
                 "version": self.conanfile.ref.version,
                 "file_name": self.file_name,
                 "pkg_name": self.pkg_name,
-                # TODO: maybe we should change this to file_name instead
-                #  using the namespace of the global target
                 "global_namespace": self.global_target_namespace,
                 "config_suffix": self.config_suffix,
                 "check_components_exist": self.cmakedeps.check_components_exist,

--- a/conan/tools/cmake/cmakedeps/templates/config.py
+++ b/conan/tools/cmake/cmakedeps/templates/config.py
@@ -31,7 +31,6 @@ class ConfigTemplate(CMakeDepsFileTemplate):
                 "file_name": self.file_name,
                 "pkg_name": self.pkg_name,
                 "config_suffix": self.config_suffix,
-                "target_namespace": self.target_namespace,
                 "check_components_exist": self.cmakedeps.check_components_exist,
                 "targets_include_file": targets_include}
 
@@ -76,9 +75,9 @@ class ConfigTemplate(CMakeDepsFileTemplate):
         {% if check_components_exist %}
         # Check that the specified components in the find_package(Foo COMPONENTS x y z) are there
         # This is the variable filled by CMake with the requested components in find_package
-        if({{ target_namespace }}_FIND_COMPONENTS)
-            foreach(_FIND_COMPONENT {{ '${'+target_namespace+'_FIND_COMPONENTS}' }})
-                if (TARGET {{ target_namespace }}::${_FIND_COMPONENT})
+        if({{ file_name }}_FIND_COMPONENTS)
+            foreach(_FIND_COMPONENT {{ '${'+file_name+'_FIND_COMPONENTS}' }})
+                if (TARGET ${_FIND_COMPONENT})
                     conan_message(STATUS "Conan: Component '${_FIND_COMPONENT}' found in package '{{ pkg_name }}'")
                 else()
                     conan_message(FATAL_ERROR "Conan: Component '${_FIND_COMPONENT}' NOT found in package '{{ pkg_name }}'")

--- a/conan/tools/cmake/cmakedeps/templates/config.py
+++ b/conan/tools/cmake/cmakedeps/templates/config.py
@@ -30,6 +30,9 @@ class ConfigTemplate(CMakeDepsFileTemplate):
                 "version": self.conanfile.ref.version,
                 "file_name": self.file_name,
                 "pkg_name": self.pkg_name,
+                # TODO: maybe we should change this to file_name instead
+                #  using the namespace of the global target
+                "global_namespace": self.global_target_namespace,
                 "config_suffix": self.config_suffix,
                 "check_components_exist": self.cmakedeps.check_components_exist,
                 "targets_include_file": targets_include}
@@ -77,7 +80,7 @@ class ConfigTemplate(CMakeDepsFileTemplate):
         # This is the variable filled by CMake with the requested components in find_package
         if({{ file_name }}_FIND_COMPONENTS)
             foreach(_FIND_COMPONENT {{ '${'+file_name+'_FIND_COMPONENTS}' }})
-                if (TARGET ${_FIND_COMPONENT})
+                if (TARGET {{ global_namespace }}::${_FIND_COMPONENT})
                     conan_message(STATUS "Conan: Component '${_FIND_COMPONENT}' found in package '{{ pkg_name }}'")
                 else()
                     conan_message(FATAL_ERROR "Conan: Component '${_FIND_COMPONENT}' NOT found in package '{{ pkg_name }}'")

--- a/conan/tools/cmake/cmakedeps/templates/target_configuration.py
+++ b/conan/tools/cmake/cmakedeps/templates/target_configuration.py
@@ -22,7 +22,6 @@ class TargetConfigurationTemplate(CMakeDepsFileTemplate):
         deps_targets_names = self.get_deps_targets_names() \
             if not self.conanfile.is_build_context else []
         return {"pkg_name": self.pkg_name,
-                "target_namespace": self.target_namespace,
                 "global_target_name": self.global_target_name,
                 "config_suffix": self.config_suffix,
                 "deps_targets_names": ";".join(deps_targets_names),
@@ -83,63 +82,63 @@ class TargetConfigurationTemplate(CMakeDepsFileTemplate):
         set(CMAKE_MODULE_PATH {{ '${' }}{{ pkg_name }}_BUILD_DIRS{{ config_suffix }}} {{ '${' }}CMAKE_MODULE_PATH})
         set(CMAKE_PREFIX_PATH {{ '${' }}{{ pkg_name }}_BUILD_DIRS{{ config_suffix }}} {{ '${' }}CMAKE_PREFIX_PATH})
 
-        {%- for comp_name in components_names %}
+        {%- for comp_target_name, comp_variable_name in components_names %}
 
-        ########## COMPONENT {{ comp_name }} FIND LIBRARIES & FRAMEWORKS / DYNAMIC VARS #############
+        ########## COMPONENT {{ comp_target_name }} FIND LIBRARIES & FRAMEWORKS / DYNAMIC VARS #############
 
-        set({{ pkg_name }}_{{ comp_name }}_FRAMEWORKS_FOUND{{ config_suffix }} "")
-        conan_find_apple_frameworks({{ pkg_name }}_{{ comp_name }}_FRAMEWORKS_FOUND{{ config_suffix }} "{{ '${'+pkg_name+'_'+comp_name+'_FRAMEWORKS'+config_suffix+'}' }}" "{{ '${'+pkg_name+'_'+comp_name+'_FRAMEWORK_DIRS'+config_suffix+'}' }}")
+        set({{ pkg_name }}_{{ comp_variable_name }}_FRAMEWORKS_FOUND{{ config_suffix }} "")
+        conan_find_apple_frameworks({{ pkg_name }}_{{ comp_variable_name }}_FRAMEWORKS_FOUND{{ config_suffix }} "{{ '${'+pkg_name+'_'+comp_variable_name+'_FRAMEWORKS'+config_suffix+'}' }}" "{{ '${'+pkg_name+'_'+comp_variable_name+'_FRAMEWORK_DIRS'+config_suffix+'}' }}")
 
-        set({{ pkg_name }}_{{ comp_name }}_LIB_TARGETS{{ config_suffix }} "")
-        set({{ pkg_name }}_{{ comp_name }}_NOT_USED{{ config_suffix }} "")
-        set({{ pkg_name }}_{{ comp_name }}_LIBS_FRAMEWORKS_DEPS{{ config_suffix }} {{ '${'+pkg_name+'_'+comp_name+'_FRAMEWORKS_FOUND'+config_suffix+'}' }} {{ '${'+pkg_name+'_'+comp_name+'_SYSTEM_LIBS'+config_suffix+'}' }} {{ '${'+pkg_name+'_'+comp_name+'_DEPENDENCIES'+config_suffix+'}' }})
-        conan_package_library_targets("{{ '${'+pkg_name+'_'+comp_name+'_LIBS'+config_suffix+'}' }}"
-                                      "{{ '${'+pkg_name+'_'+comp_name+'_LIB_DIRS'+config_suffix+'}' }}"
-                                      "{{ '${'+pkg_name+'_'+comp_name+'_LIBS_FRAMEWORKS_DEPS'+config_suffix+'}' }}"
-                                      {{ pkg_name }}_{{ comp_name }}_NOT_USED{{ config_suffix }}
-                                      {{ pkg_name }}_{{ comp_name }}_LIB_TARGETS{{ config_suffix }}
+        set({{ pkg_name }}_{{ comp_variable_name }}_LIB_TARGETS{{ config_suffix }} "")
+        set({{ pkg_name }}_{{ comp_variable_name }}_NOT_USED{{ config_suffix }} "")
+        set({{ pkg_name }}_{{ comp_variable_name }}_LIBS_FRAMEWORKS_DEPS{{ config_suffix }} {{ '${'+pkg_name+'_'+comp_variable_name+'_FRAMEWORKS_FOUND'+config_suffix+'}' }} {{ '${'+pkg_name+'_'+comp_variable_name+'_SYSTEM_LIBS'+config_suffix+'}' }} {{ '${'+pkg_name+'_'+comp_variable_name+'_DEPENDENCIES'+config_suffix+'}' }})
+        conan_package_library_targets("{{ '${'+pkg_name+'_'+comp_variable_name+'_LIBS'+config_suffix+'}' }}"
+                                      "{{ '${'+pkg_name+'_'+comp_variable_name+'_LIB_DIRS'+config_suffix+'}' }}"
+                                      "{{ '${'+pkg_name+'_'+comp_variable_name+'_LIBS_FRAMEWORKS_DEPS'+config_suffix+'}' }}"
+                                      {{ pkg_name }}_{{ comp_variable_name }}_NOT_USED{{ config_suffix }}
+                                      {{ pkg_name }}_{{ comp_variable_name }}_LIB_TARGETS{{ config_suffix }}
                                       "{{ config_suffix }}"
-                                      "{{ pkg_name }}_{{ comp_name }}")
+                                      "{{ pkg_name }}_{{ comp_variable_name }}")
 
-        set({{ pkg_name }}_{{ comp_name }}_LINK_LIBS{{ config_suffix }} {{ '${'+pkg_name+'_'+comp_name+'_LIB_TARGETS'+config_suffix+'}' }} {{ '${'+pkg_name+'_'+comp_name+'_LIBS_FRAMEWORKS_DEPS'+config_suffix+'}' }})
+        set({{ pkg_name }}_{{ comp_variable_name }}_LINK_LIBS{{ config_suffix }} {{ '${'+pkg_name+'_'+comp_variable_name+'_LIB_TARGETS'+config_suffix+'}' }} {{ '${'+pkg_name+'_'+comp_variable_name+'_LIBS_FRAMEWORKS_DEPS'+config_suffix+'}' }})
         {%- endfor %}
 
 
 
         ########## GLOBAL TARGET PROPERTIES {{ configuration }} ########################################
-        set_property(TARGET {{target_namespace}}::{{global_target_name}}
+        set_property(TARGET {{global_target_name}}
                      PROPERTY INTERFACE_LINK_LIBRARIES
                      $<$<CONFIG:{{configuration}}>:${{'{'}}{{pkg_name}}_LIBRARIES_TARGETS{{config_suffix}}}
                                                    ${{'{'}}{{pkg_name}}_LINKER_FLAGS{{config_suffix}}}
                                                    ${{'{'}}{{pkg_name}}_OBJECTS{{config_suffix}}}> APPEND)
-        set_property(TARGET {{target_namespace}}::{{global_target_name}}
+        set_property(TARGET {{global_target_name}}
                      PROPERTY INTERFACE_INCLUDE_DIRECTORIES
                      $<$<CONFIG:{{configuration}}>:${{'{'}}{{pkg_name}}_INCLUDE_DIRS{{config_suffix}}}> APPEND)
-        set_property(TARGET {{target_namespace}}::{{global_target_name}}
+        set_property(TARGET {{global_target_name}}
                      PROPERTY INTERFACE_COMPILE_DEFINITIONS
                      $<$<CONFIG:{{configuration}}>:${{'{'}}{{pkg_name}}_COMPILE_DEFINITIONS{{config_suffix}}}> APPEND)
-        set_property(TARGET {{target_namespace}}::{{global_target_name}}
+        set_property(TARGET {{global_target_name}}
                      PROPERTY INTERFACE_COMPILE_OPTIONS
                      $<$<CONFIG:{{configuration}}>:${{'{'}}{{pkg_name}}_COMPILE_OPTIONS{{config_suffix}}}> APPEND)
 
         ########## COMPONENTS TARGET PROPERTIES {{ configuration }} ########################################
 
-        {%- for comp_name in components_names %}
+        {%- for comp_target_name, comp_variable_name in components_names %}
 
-        ########## COMPONENT {{ comp_name }} TARGET PROPERTIES ######################################
-        set_property(TARGET {{ target_namespace }}::{{ comp_name }} PROPERTY INTERFACE_LINK_LIBRARIES
-                     $<$<CONFIG:{{ configuration }}>:{{tvalue(pkg_name, comp_name, 'LINK_LIBS', config_suffix)}}
-                     {{tvalue(pkg_name, comp_name, 'LINKER_FLAGS', config_suffix)}}
-                     {{tvalue(pkg_name, comp_name, 'OBJECTS', config_suffix)}}> APPEND)
-        set_property(TARGET {{ target_namespace }}::{{ comp_name }} PROPERTY INTERFACE_INCLUDE_DIRECTORIES
-                     $<$<CONFIG:{{ configuration }}>:{{tvalue(pkg_name, comp_name, 'INCLUDE_DIRS', config_suffix)}}> APPEND)
-        set_property(TARGET {{ target_namespace }}::{{ comp_name }} PROPERTY INTERFACE_COMPILE_DEFINITIONS
-                     $<$<CONFIG:{{ configuration }}>:{{tvalue(pkg_name, comp_name, 'COMPILE_DEFINITIONS', config_suffix)}}> APPEND)
-        set_property(TARGET {{ target_namespace }}::{{ comp_name }} PROPERTY INTERFACE_COMPILE_OPTIONS
+        ########## COMPONENT {{ comp_target_name }} TARGET PROPERTIES ######################################
+        set_property(TARGET {{ comp_target_name }} PROPERTY INTERFACE_LINK_LIBRARIES
+                     $<$<CONFIG:{{ configuration }}>:{{tvalue(pkg_name, comp_variable_name, 'LINK_LIBS', config_suffix)}}
+                     {{tvalue(pkg_name, comp_variable_name, 'LINKER_FLAGS', config_suffix)}}
+                     {{tvalue(pkg_name, comp_variable_name, 'OBJECTS', config_suffix)}}> APPEND)
+        set_property(TARGET {{ comp_target_name }} PROPERTY INTERFACE_INCLUDE_DIRECTORIES
+                     $<$<CONFIG:{{ configuration }}>:{{tvalue(pkg_name, comp_variable_name, 'INCLUDE_DIRS', config_suffix)}}> APPEND)
+        set_property(TARGET {{ comp_target_name }} PROPERTY INTERFACE_COMPILE_DEFINITIONS
+                     $<$<CONFIG:{{ configuration }}>:{{tvalue(pkg_name, comp_variable_name, 'COMPILE_DEFINITIONS', config_suffix)}}> APPEND)
+        set_property(TARGET {{ comp_target_name }} PROPERTY INTERFACE_COMPILE_OPTIONS
                      $<$<CONFIG:{{ configuration }}>:
-                     {{tvalue(pkg_name, comp_name, 'COMPILE_OPTIONS_C', config_suffix)}}
-                     {{tvalue(pkg_name, comp_name, 'COMPILE_OPTIONS_CXX', config_suffix)}}> APPEND)
-        set({{ pkg_name }}_{{ comp_name }}_TARGET_PROPERTIES TRUE)
+                     {{tvalue(pkg_name, comp_variable_name, 'COMPILE_OPTIONS_C', config_suffix)}}
+                     {{tvalue(pkg_name, comp_variable_name, 'COMPILE_OPTIONS_CXX', config_suffix)}}> APPEND)
+        set({{ pkg_name }}_{{ comp_variable_name }}_TARGET_PROPERTIES TRUE)
 
         {%- endfor %}
 
@@ -150,7 +149,9 @@ class TargetConfigurationTemplate(CMakeDepsFileTemplate):
         ret = []
         sorted_comps = self.conanfile.cpp_info.get_sorted_components()
         for comp_name, comp in sorted_comps.items():
-            ret.append(self.get_component_alias(self.conanfile, comp_name))
+            component_target_name = self.get_component_alias(self.conanfile, comp_name)
+            variable_name = component_target_name.replace("::", "_")
+            ret.append((component_target_name, variable_name))
         ret.reverse()
         return ret
 
@@ -172,11 +173,9 @@ class TargetConfigurationTemplate(CMakeDepsFileTemplate):
                 else:
                     req = visible_host[dep_name]
 
-                dep_name = self.get_target_namespace(req)
                 component_name = self.get_component_alias(req, component_name)
-                ret.append("{}::{}".format(dep_name, component_name))
+                ret.append(component_name)
         elif visible_host_direct:
             # Regular external "conanfile.requires" declared, not cpp_info requires
-            ret = ["{p}::{n}".format(p=self.get_target_namespace(r), n=self.get_global_target_name(r))
-                   for r in visible_host_direct.values()]
+            ret = [self.get_global_target_name(r) for r in visible_host_direct.values()]
         return ret

--- a/conan/tools/cmake/cmakedeps/templates/target_data.py
+++ b/conan/tools/cmake/cmakedeps/templates/target_data.py
@@ -126,12 +126,9 @@ class ConfigDataTemplate(CMakeDepsFileTemplate):
                 if "::" in require:  # Points to a component of a different package
                     pkg, cmp_name = require.split("::")
                     req = direct_visible_host[pkg]
-                    public_comp_deps.append("{}::{}".format(self.get_target_namespace(req),
-                                                            self.get_component_alias(req, cmp_name)))
+                    public_comp_deps.append(self.get_component_alias(req, cmp_name))
                 else:  # Points to a component of same package
-                    public_comp_deps.append("{}::{}".format(self.target_namespace,
-                                                            self.get_component_alias(self.conanfile,
-                                                                                     require)))
+                    public_comp_deps.append(self.get_component_alias(self.conanfile, require))
             deps_cpp_cmake.public_deps = " ".join(public_comp_deps)
             component_rename = self.get_component_alias(self.conanfile, comp_name)
             ret.append((component_rename, deps_cpp_cmake))

--- a/conan/tools/cmake/cmakedeps/templates/targets.py
+++ b/conan/tools/cmake/cmakedeps/templates/targets.py
@@ -28,7 +28,7 @@ class TargetsTemplate(CMakeDepsFileTemplate):
         cmake_target_aliases = self.conanfile.cpp_info.\
             get_property("cmake_target_aliases", "CMakeDeps") or dict()
 
-        target = "%s::%s" % (self.target_namespace, self.global_target_name)
+        target = self.global_target_name
         cmake_target_aliases = {alias: target for alias in cmake_target_aliases}
 
         cmake_component_target_aliases = dict()
@@ -37,12 +37,10 @@ class TargetsTemplate(CMakeDepsFileTemplate):
                 self.conanfile.cpp_info.components[comp_name].\
                 get_property("cmake_target_aliases", "CMakeDeps") or dict()
 
-            target = "%s::%s" % (self.target_namespace,
-                                 self.get_component_alias(self.conanfile, comp_name))
+            target = self.get_component_alias(self.conanfile, comp_name)
             cmake_component_target_aliases[comp_name] = {alias: target for alias in aliases}
 
         ret = {"pkg_name": self.pkg_name,
-               "target_namespace": self.target_namespace,
                "global_target_name": self.global_target_name,
                "file_name": self.file_name,
                "data_pattern": data_pattern,
@@ -65,15 +63,15 @@ class TargetsTemplate(CMakeDepsFileTemplate):
 
         # Create the targets for all the components
         foreach(_COMPONENT {{ '${' + pkg_name + '_COMPONENT_NAMES' + '}' }} )
-            if(NOT TARGET {{ target_namespace }}::${_COMPONENT})
-                add_library({{ target_namespace }}::${_COMPONENT} INTERFACE IMPORTED)
-                conan_message(STATUS "Conan: Component target declared '{{ target_namespace }}::${_COMPONENT}'")
+            if(NOT TARGET ${_COMPONENT})
+                add_library(${_COMPONENT} INTERFACE IMPORTED)
+                conan_message(STATUS "Conan: Component target declared '${_COMPONENT}'")
             endif()
         endforeach()
 
-        if(NOT TARGET {{ target_namespace }}::{{ global_target_name }})
-            add_library({{ target_namespace }}::{{ global_target_name }} INTERFACE IMPORTED)
-            conan_message(STATUS "Conan: Target declared '{{ target_namespace }}::{{ global_target_name }}'")
+        if(NOT TARGET {{ global_target_name }})
+            add_library({{ global_target_name }} INTERFACE IMPORTED)
+            conan_message(STATUS "Conan: Target declared '{{ global_target_name }}'")
         endif()
 
         {%- for alias, target in cmake_target_aliases.items() %}

--- a/conan/tools/cmake/cmakedeps/templates/targets.py
+++ b/conan/tools/cmake/cmakedeps/templates/targets.py
@@ -62,7 +62,7 @@ class TargetsTemplate(CMakeDepsFileTemplate):
         endforeach()
 
         # Create the targets for all the components
-        foreach(_COMPONENT {{ '${' + pkg_name + '_COMPONENT_NAMES' + '}' }} )
+        foreach(_COMPONENT {{ '${' + pkg_name + '_COMPONENT_TARGET_NAMES' + '}' }} )
             if(NOT TARGET ${_COMPONENT})
                 add_library(${_COMPONENT} INTERFACE IMPORTED)
                 conan_message(STATUS "Conan: Component target declared '${_COMPONENT}'")

--- a/conan/tools/files/cpp_package.py
+++ b/conan/tools/files/cpp_package.py
@@ -47,7 +47,11 @@ class CppPackage(object):
             conanfile.cpp_info.components[cname].libs = component.libs
             conanfile.cpp_info.components[cname].requires = component.requires
             for generator, gname in component.names.items():
-                conanfile.cpp_info.components[cname].set_property("cmake_target_name", gname, generator)
+                # TODO: probably we want to revisit all this stuff with the new absolute
+                #  target names via set_property
+                conanfile.cpp_info.components[cname].set_property("cmake_target_name",
+                                                                  "{}::{}".format(conanfile.cpp_info.name, gname),
+                                                                  generator)
 
     def add_component(self, name):
         """

--- a/conans/client/generators/cmake_find_package.py
+++ b/conans/client/generators/cmake_find_package.py
@@ -74,7 +74,7 @@ class CMakeFindPackageGenerator(GeneratorComponentsMixin, Generator):
 
         set({{ pkg_name }}_COMPONENTS {{ pkg_components }})
 
-        if({{ pkg_name }}_FIND_COMPONENTS)
+        if({{ pkg_filename }}_FIND_COMPONENTS)
             foreach(_FIND_COMPONENT {{ '${'+pkg_name+'_FIND_COMPONENTS}' }})
                 list(FIND {{ pkg_name }}_COMPONENTS "{{ namespace }}::${_FIND_COMPONENT}" _index)
                 if(${_index} EQUAL -1)
@@ -265,8 +265,7 @@ class CMakeFindPackageGenerator(GeneratorComponentsMixin, Generator):
         if cpp_info.components:
             components = self._get_components(pkg_name, cpp_info)
             # Note these are in reversed order, from more dependent to less dependent
-            pkg_components = " ".join(["{p}::{c}".format(p=pkg_namespace, c=comp_findname) for
-                                       comp_findname, _ in reversed(components)])
+            pkg_components = " ".join([comp_findname for comp_findname, _ in reversed(components)])
             pkg_info = DepsCppCmake(cpp_info, self.name)
             global_target_variables = target_template.format(name=pkg_findname, deps=pkg_info,
                                                              build_type_suffix="",

--- a/conans/client/generators/cmake_find_package.py
+++ b/conans/client/generators/cmake_find_package.py
@@ -75,7 +75,7 @@ class CMakeFindPackageGenerator(GeneratorComponentsMixin, Generator):
         set({{ pkg_name }}_COMPONENTS {{ pkg_components }})
 
         if({{ pkg_filename }}_FIND_COMPONENTS)
-            foreach(_FIND_COMPONENT {{ '${'+pkg_name+'_FIND_COMPONENTS}' }})
+            foreach(_FIND_COMPONENT {{ '${'+pkg_filename+'_FIND_COMPONENTS}' }})
                 list(FIND {{ pkg_name }}_COMPONENTS "{{ namespace }}::${_FIND_COMPONENT}" _index)
                 if(${_index} EQUAL -1)
                     conan_message(FATAL_ERROR "Conan: Component '${_FIND_COMPONENT}' NOT found in package '{{ pkg_name }}'")
@@ -265,7 +265,8 @@ class CMakeFindPackageGenerator(GeneratorComponentsMixin, Generator):
         if cpp_info.components:
             components = self._get_components(pkg_name, cpp_info)
             # Note these are in reversed order, from more dependent to less dependent
-            pkg_components = " ".join([comp_findname for comp_findname, _ in reversed(components)])
+            pkg_components = " ".join(["{p}::{c}".format(p=pkg_namespace, c=comp_findname) for
+                                       comp_findname, _ in reversed(components)])
             pkg_info = DepsCppCmake(cpp_info, self.name)
             global_target_variables = target_template.format(name=pkg_findname, deps=pkg_info,
                                                              build_type_suffix="",

--- a/conans/client/generators/cmake_find_package_multi.py
+++ b/conans/client/generators/cmake_find_package_multi.py
@@ -185,7 +185,7 @@ endforeach()
         endforeach()
 
         if({{ pkg_filename }}_FIND_COMPONENTS)
-            foreach(_FIND_COMPONENT {{ '${'+pkg_name+'_FIND_COMPONENTS}' }})
+            foreach(_FIND_COMPONENT {{ '${'+pkg_filename+'_FIND_COMPONENTS}' }})
                 list(FIND {{ pkg_name }}_COMPONENTS_{{ build_type }} "{{ namespace }}::${_FIND_COMPONENT}" _index)
                 if(${_index} EQUAL -1)
                     conan_message(FATAL_ERROR "Conan: Component '${_FIND_COMPONENT}' NOT found in package '{{ pkg_name }}'")
@@ -349,7 +349,8 @@ endforeach()
                 pkg_info = DepsCppCmake(cpp_info, self.name)
                 components = self._get_components(pkg_name, cpp_info)
                 # Note these are in reversed order, from more dependent to less dependent
-                pkg_components = " ".join([comp_findname for comp_findname, _ in reversed(components)])
+                pkg_components = " ".join(["{p}::{c}".format(p=pkg_namespace, c=comp_findname) for
+                                           comp_findname, _ in reversed(components)])
                 global_target_variables = target_template.format(name=pkg_findname, deps=pkg_info,
                                                                  build_type_suffix=build_type_suffix,
                                                                  deps_names=deps_names)

--- a/conans/client/generators/cmake_find_package_multi.py
+++ b/conans/client/generators/cmake_find_package_multi.py
@@ -184,7 +184,7 @@ endforeach()
             include(${f})
         endforeach()
 
-        if({{ pkg_name }}_FIND_COMPONENTS)
+        if({{ pkg_filename }}_FIND_COMPONENTS)
             foreach(_FIND_COMPONENT {{ '${'+pkg_name+'_FIND_COMPONENTS}' }})
                 list(FIND {{ pkg_name }}_COMPONENTS_{{ build_type }} "{{ namespace }}::${_FIND_COMPONENT}" _index)
                 if(${_index} EQUAL -1)
@@ -349,8 +349,7 @@ endforeach()
                 pkg_info = DepsCppCmake(cpp_info, self.name)
                 components = self._get_components(pkg_name, cpp_info)
                 # Note these are in reversed order, from more dependent to less dependent
-                pkg_components = " ".join(["{p}::{c}".format(p=pkg_namespace, c=comp_findname) for
-                                           comp_findname, _ in reversed(components)])
+                pkg_components = " ".join([comp_findname for comp_findname, _ in reversed(components)])
                 global_target_variables = target_template.format(name=pkg_findname, deps=pkg_info,
                                                                  build_type_suffix=build_type_suffix,
                                                                  deps_names=deps_names)

--- a/conans/client/installer.py
+++ b/conans/client/installer.py
@@ -674,7 +674,7 @@ class BinaryInstaller(object):
 
                     # this is necessary to check if the components declared for legacy generators
                     # have the same namespace as the root cpp_info
-                    conanfile.cpp_info._raise_incorrect_components_names(conanfile.name)
+                    conanfile.cpp_info._raise_incorrect_components_names()
 
                     if hasattr(conanfile, "layout") and is_editable:
                         # Adjust the folders of the layout to consolidate the rootfolder of the

--- a/conans/client/installer.py
+++ b/conans/client/installer.py
@@ -672,6 +672,10 @@ class BinaryInstaller(object):
 
                     conanfile.package_info()
 
+                    # this is necessary to check if the components declared for legacy generators
+                    # have the same namespace as the root cpp_info
+                    conanfile.cpp_info._raise_incorrect_components_names(conanfile.name)
+
                     if hasattr(conanfile, "layout") and is_editable:
                         # Adjust the folders of the layout to consolidate the rootfolder of the
                         # cppinfos inside

--- a/conans/model/build_info.py
+++ b/conans/model/build_info.py
@@ -219,6 +219,8 @@ class _CppInfo(object):
     #  Use get_property for 2.0
     def get_name(self, generator, default_name=True):
         property_name = None
+        if generator == "cmake_find_package" and self.get_property("cmake_module_target_name", generator):
+            property_name = "cmake_module_target_name"
         # set_property will have no effect on "cmake" legacy generator
         if "cmake" in generator and "cmake" != generator and "cmake_multi" != generator:
             property_name = "cmake_target_name"

--- a/conans/model/build_info.py
+++ b/conans/model/build_info.py
@@ -278,9 +278,10 @@ class _CppInfo(object):
         return self._build_modules
 
     def set_property(self, property_name, value, generator=None):
+        reg_exp = r"[a-zA-Z0-9_][a-zA-Z0-9_\+\.-]+{}[a-zA-Z0-9_][a-zA-Z0-9_\+\.-]+".format(COMPONENT_SCOPE)
         if property_name == "cmake_target_namespace" or property_name == "cmake_module_target_namespace":
             raise ConanException("Property '{}' has been deprecated.".format(property_name))
-        elif property_name == "cmake_target_name" and not re.match(r"\w+{}\w+".format(COMPONENT_SCOPE), value):
+        elif property_name == "cmake_target_name" and not re.match(reg_exp, value):
             raise ConanException("Target name: '{}' not valid. Property 'cmake_target_name' "
                                  "has to set an absolute target name with a namespace like "
                                  "'NAMESPACE::NAME'.".format(value))

--- a/conans/model/build_info.py
+++ b/conans/model/build_info.py
@@ -241,6 +241,7 @@ class _CppInfo(object):
         # this will try to extract the namespace from the absolute name to provide compatibility
         # with current build_info.names and also with CMakeDeps that specifies names with namespaces
         namespace = None
+        property_name = None
         if generator == "cmake_find_package" and self.get_property("cmake_module_target_name", generator):
             property_name = "cmake_module_target_name"
         elif "cmake" in generator and "cmake" != generator and "cmake_multi" != generator:

--- a/conans/model/build_info.py
+++ b/conans/model/build_info.py
@@ -222,7 +222,7 @@ class _CppInfo(object):
         if generator == "cmake_find_package" and self.get_property("cmake_module_target_name", generator):
             property_name = "cmake_module_target_name"
         # set_property will have no effect on "cmake" legacy generator
-        if "cmake" in generator and "cmake" != generator and "cmake_multi" != generator:
+        elif "cmake" in generator and "cmake" != generator and "cmake_multi" != generator:
             property_name = "cmake_target_name"
         elif "pkg_config" in generator:
             property_name = "pkg_config_name"
@@ -241,7 +241,7 @@ class _CppInfo(object):
         # this will try to extract the namespace from the absolute name to provide compatibility
         # with current build_info.names and also with CMakeDeps that specifies names with namespaces
         namespace = None
-        name = self.get_property("cmake_target_name", generator)
+        name = self.get_name(generator)
         if self._is_absolute_name(name):
             namespace = name.split(COMPONENT_SCOPE)[0]
         return namespace

--- a/conans/model/build_info.py
+++ b/conans/model/build_info.py
@@ -500,16 +500,19 @@ class CppInfo(_CppInfo):
         else:
             _check_components_requires_instersection(self.requires)
 
-    def _raise_incorrect_components_names(self, pkg_name):
+    def _raise_incorrect_components_names(self):
         if self.components:
-            # Raise on component name
-            pkg_namespace = self.get_namespace(generator=None)
-            for comp_name, comp in self.components.items():
-                cmp_namespace = comp.get_namespace(generator=None)
-                if cmp_namespace and cmp_namespace != pkg_namespace:
-                    raise ConanException("Component '{}' was defined with namespace '{}' but it "
-                                         "should be the same as the one defined for the root "
-                                         "cpp_info ('{}')".format(comp_name, cmp_namespace, pkg_namespace))
+            # Raise if component name does not contain the root cpp_info namespace
+            # for "cmake_find_package", "cmake_find_package_multi" generators
+            for generator in ["cmake_find_package", "cmake_find_package_multi"]:
+                pkg_name = self.get_name(generator)
+                pkg_namespace = self.get_namespace(generator) or pkg_name
+                for comp_name, comp in self.components.items():
+                    cmp_namespace = comp.get_namespace(generator=generator)
+                    if cmp_namespace and cmp_namespace != pkg_namespace:
+                        raise ConanException("Component '{}' was defined with namespace '{}' but it "
+                                             "should be the same as the one defined for the root "
+                                             "cpp_info ('{}')".format(comp_name, cmp_namespace, pkg_namespace))
 
 
 class _BaseDepsCppInfo(_CppInfo):

--- a/conans/model/build_info.py
+++ b/conans/model/build_info.py
@@ -1,4 +1,5 @@
 import os
+import re
 from collections import OrderedDict
 from copy import copy
 
@@ -281,7 +282,13 @@ class _CppInfo(object):
 
     def set_property(self, property_name, value, generator=None):
         if property_name == "cmake_target_namespace" or property_name == "cmake_module_target_namespace":
+            # TODO: add test
             raise ConanException("Property '{}' has been deprecated.".format(property_name))
+        elif property_name == "cmake_target_name" and not re.match(r"\w+{}\w+".format(COMPONENT_SCOPE), value):
+            # TODO: add test
+            raise ConanException("Target name: '{}' not valid. Property 'cmake_target_name' "
+                                 "has to set an absolute target name with a namespace like "
+                                 "'NAMESPACE::NAME'.".format(value))
         self._generator_properties.setdefault(generator, {})[property_name] = value
 
     @staticmethod

--- a/conans/model/build_info.py
+++ b/conans/model/build_info.py
@@ -241,7 +241,11 @@ class _CppInfo(object):
         # this will try to extract the namespace from the absolute name to provide compatibility
         # with current build_info.names and also with CMakeDeps that specifies names with namespaces
         namespace = None
-        name = self.get_name(generator)
+        if generator == "cmake_find_package" and self.get_property("cmake_module_target_name", generator):
+            property_name = "cmake_module_target_name"
+        elif "cmake" in generator and "cmake" != generator and "cmake_multi" != generator:
+            property_name = "cmake_target_name"
+        name = self.get_property(property_name, generator)
         if self._is_absolute_name(name):
             namespace = name.split(COMPONENT_SCOPE)[0]
         return namespace

--- a/conans/model/conan_generator.py
+++ b/conans/model/conan_generator.py
@@ -94,14 +94,6 @@ class GeneratorComponentsMixin(object):
         # by the property cmake_target_name
         pkg_namespace = self._get_namespace(pkg_build_info) or pkg_name
         if cmp in pkg_build_info.components:
-            if self.name == "cmake_find_package" or self.name == "cmake_find_package_multi":
-                # we are forcing for legacy generators to declare components with the same
-                # namespace as the root cpp_info
-                cmp_namespace = self._get_namespace(pkg_build_info.components[cmp])
-                if cmp_namespace and cmp_namespace != pkg_namespace:
-                    raise ConanException("Component '{}' was defined with namespace '{}' but it "
-                                         "should be the same as the one defined for the root "
-                                         "cpp_info ('{}')".format(req, cmp_namespace, pkg_namespace))
             cmp_name = self._get_name(pkg_build_info.components[cmp])
         else:
             cmp_name = pkg_name

--- a/conans/test/functional/generators/components/test_components_cmake_generators.py
+++ b/conans/test/functional/generators/components/test_components_cmake_generators.py
@@ -57,16 +57,10 @@ def setup_client_with_greetings():
                     self.cpp_info.filenames["cmake_find_package"] = "MYG"
                     self.cpp_info.set_property("cmake_file_name", "MYG")
 
-                    self.cpp_info.names["cmake_find_package_multi"] = "MyGreetings"
-                    self.cpp_info.names["cmake_find_package"] = "MyGreetings"
-                    self.cpp_info.set_property("cmake_target_name", "MyGreetings")
+                    self.cpp_info.set_property("cmake_target_name", "MyGreetings::MyGreetings")
 
-                    self.cpp_info.components["hello"].names["cmake_find_package_multi"] = "MyHello"
-                    self.cpp_info.components["bye"].names["cmake_find_package_multi"] = "MyBye"
-                    self.cpp_info.components["hello"].names["cmake_find_package"] = "MyHello"
-                    self.cpp_info.components["bye"].names["cmake_find_package"] = "MyBye"
-                    self.cpp_info.components["hello"].set_property("cmake_target_name", "MyHello")
-                    self.cpp_info.components["bye"].set_property("cmake_target_name", "MyBye")
+                    self.cpp_info.components["hello"].set_property("cmake_target_name", "MyGreetings::MyHello")
+                    self.cpp_info.components["bye"].set_property("cmake_target_name", "MyGreetings::MyBye")
 
                     self.cpp_info.components["hello"].libs = ["hello"]
                     self.cpp_info.components["bye"].libs = ["bye"]
@@ -306,21 +300,14 @@ def test_custom_names(setup_client_with_greetings, generator):
     client = setup_client_with_greetings
 
     package_info = textwrap.dedent("""
-        self.cpp_info.names["cmake_find_package_multi"] = "MyChat"
-        self.cpp_info.names["cmake_find_package"] = "MyChat"
-        # NOTE: For the new CMakeDeps only filenames mean filename, it is not using the "names" field
-        self.cpp_info.set_property("cmake_target_name", "MyChat")
+        self.cpp_info.set_property("cmake_target_name", "MyChat::MyChat")
         self.cpp_info.set_property("cmake_file_name", "MyChat")
 
-        self.cpp_info.components["sayhello"].names["cmake_find_package_multi"] = "MySay"
-        self.cpp_info.components["sayhello"].names["cmake_find_package"] = "MySay"
-        self.cpp_info.components["sayhello"].set_property("cmake_target_name", "MySay")
+        self.cpp_info.components["sayhello"].set_property("cmake_target_name", "MyChat::MySay")
 
         self.cpp_info.components["sayhello"].requires = ["greetings::hello"]
         self.cpp_info.components["sayhello"].libs = ["sayhello"]
-        self.cpp_info.components["sayhellobye"].names["cmake_find_package_multi"] ="MySayBye"
-        self.cpp_info.components["sayhellobye"].names["cmake_find_package"] ="MySayBye"
-        self.cpp_info.components["sayhellobye"].set_property("cmake_target_name", "MySayBye")
+        self.cpp_info.components["sayhellobye"].set_property("cmake_target_name", "MyChat::MySayBye")
 
         self.cpp_info.components["sayhellobye"].requires = ["sayhello", "greetings::bye"]
         self.cpp_info.components["sayhellobye"].libs = ["sayhellobye"]
@@ -586,14 +573,11 @@ class TestComponentsCMakeGenerators:
                     self.copy("*.a", dst="lib", keep_path=False)
 
                 def package_info(self):
-                    self.cpp_info.names["{generator}"] = "nonstd"
-                    self.cpp_info.filenames["{generator}"] = "{name}"
-                    self.cpp_info.set_property("cmake_target_name", "nonstd", "{generator}")
+                    self.cpp_info.set_property("cmake_target_name", "nonstd::nonstd", "{generator}")
                     self.cpp_info.set_property("cmake_file_name", "{name}", "{generator}")
 
-                    self.cpp_info.components["1"].names["{generator}"] = "{name}"
                     self.cpp_info.components["1"].set_property("cmake_target_name",
-                                                               "{name}", "{generator}")
+                                                               "nonstd::{name}", "{generator}")
                     self.cpp_info.components["1"].libs = ["{name}"]
             """)
         client = TestClient()

--- a/conans/test/functional/generators/components/test_components_cmake_generators.py
+++ b/conans/test/functional/generators/components/test_components_cmake_generators.py
@@ -56,9 +56,14 @@ def setup_client_with_greetings():
                     self.cpp_info.filenames["cmake_find_package_multi"] = "MYG"
                     self.cpp_info.filenames["cmake_find_package"] = "MYG"
                     self.cpp_info.set_property("cmake_file_name", "MYG")
-
+                    self.cpp_info.names["cmake_find_package_multi"] = "MyGreetings"
+                    self.cpp_info.names["cmake_find_package"] = "MyGreetings"
                     self.cpp_info.set_property("cmake_target_name", "MyGreetings::MyGreetings")
 
+                    self.cpp_info.components["hello"].names["cmake_find_package_multi"] = "MyHello"
+                    self.cpp_info.components["bye"].names["cmake_find_package_multi"] = "MyBye"
+                    self.cpp_info.components["hello"].names["cmake_find_package"] = "MyHello"
+                    self.cpp_info.components["bye"].names["cmake_find_package"] = "MyBye"
                     self.cpp_info.components["hello"].set_property("cmake_target_name", "MyGreetings::MyHello")
                     self.cpp_info.components["bye"].set_property("cmake_target_name", "MyGreetings::MyBye")
 
@@ -300,13 +305,20 @@ def test_custom_names(setup_client_with_greetings, generator):
     client = setup_client_with_greetings
 
     package_info = textwrap.dedent("""
+        self.cpp_info.names["cmake_find_package_multi"] = "MyChat"
+        self.cpp_info.names["cmake_find_package"] = "MyChat"
+        # NOTE: For the new CMakeDeps only filenames mean filename, it is not using the "names" field
         self.cpp_info.set_property("cmake_target_name", "MyChat::MyChat")
         self.cpp_info.set_property("cmake_file_name", "MyChat")
 
+        self.cpp_info.components["sayhello"].names["cmake_find_package_multi"] = "MySay"
+        self.cpp_info.components["sayhello"].names["cmake_find_package"] = "MySay"
         self.cpp_info.components["sayhello"].set_property("cmake_target_name", "MyChat::MySay")
 
         self.cpp_info.components["sayhello"].requires = ["greetings::hello"]
         self.cpp_info.components["sayhello"].libs = ["sayhello"]
+        self.cpp_info.components["sayhellobye"].names["cmake_find_package_multi"] ="MySayBye"
+        self.cpp_info.components["sayhellobye"].names["cmake_find_package"] ="MySayBye"
         self.cpp_info.components["sayhellobye"].set_property("cmake_target_name", "MyChat::MySayBye")
 
         self.cpp_info.components["sayhellobye"].requires = ["sayhello", "greetings::bye"]
@@ -573,9 +585,12 @@ class TestComponentsCMakeGenerators:
                     self.copy("*.a", dst="lib", keep_path=False)
 
                 def package_info(self):
+                    self.cpp_info.names["{generator}"] = "nonstd"
+                    self.cpp_info.filenames["{generator}"] = "{name}"
                     self.cpp_info.set_property("cmake_target_name", "nonstd::nonstd", "{generator}")
                     self.cpp_info.set_property("cmake_file_name", "{name}", "{generator}")
 
+                    self.cpp_info.components["1"].names["{generator}"] = "{name}"
                     self.cpp_info.components["1"].set_property("cmake_target_name",
                                                                "nonstd::{name}", "{generator}")
                     self.cpp_info.components["1"].libs = ["{name}"]

--- a/conans/test/functional/generators/components/test_components_cmake_generators.py
+++ b/conans/test/functional/generators/components/test_components_cmake_generators.py
@@ -499,15 +499,19 @@ class TestComponentsCMakeGenerators:
         assert ("Component 'greetings::non-existent' not found in 'greetings' "
                 "package requirement" in client.out)
 
-    @pytest.mark.parametrize("generator", ["cmake_find_package_multi", "cmake_find_package"])
-    def test_component_not_found_cmake(self, generator):
+    @pytest.mark.parametrize("generator, filename", [("cmake_find_package_multi", "greetings"),
+                                                     ("cmake_find_package_multi", "filegreetings"),
+                                                     ("cmake_find_package", "greetings"),
+                                                     ("cmake_find_package", "filegreetings")])
+    def test_component_not_found_cmake(self, generator, filename):
         conanfile = textwrap.dedent("""
             from conans import ConanFile
 
             class GreetingsConan(ConanFile):
                 def package_info(self):
                     self.cpp_info.components["hello"].libs = ["hello"]
-        """)
+                    self.cpp_info.filenames["{}"] = "{}"
+        """.format(generator, filename))
         client = TestClient()
         client.save({"conanfile.py": conanfile})
         client.run("create . greetings/0.0.1@")
@@ -530,9 +534,9 @@ class TestComponentsCMakeGenerators:
             cmake_minimum_required(VERSION 3.0)
             project(Consumer CXX)
 
-            find_package(greetings COMPONENTS hello)
-            find_package(greetings COMPONENTS non-existent)
-            """)
+            find_package({filename} COMPONENTS hello)
+            find_package({filename} COMPONENTS non-existent)
+            """.format(filename=filename))
         client.save({"conanfile.py": conanfile, "CMakeLists.txt": cmakelists})
         client.run("install .")
         client.run("build .", assert_error=True)

--- a/conans/test/functional/toolchains/cmake/cmakedeps/test_apple_frameworks.py
+++ b/conans/test/functional/toolchains/cmake/cmakedeps/test_apple_frameworks.py
@@ -344,6 +344,7 @@ def test_apple_own_framework_cmake_find_package_multi():
     client.run("create .")
     assert "Hello World Release!" in client.out
 
+
 @pytest.mark.skipif(platform.system() != "Darwin", reason="Only OSX")
 def test_component_uses_apple_framework():
     conanfile_py = textwrap.dedent("""
@@ -369,9 +370,7 @@ class HelloConan(ConanFile):
 
     def package_info(self):
         self.cpp_info.set_property("cmake_file_name", "HELLO")
-        self.cpp_info.components["libhello"].set_property("cmake_target_name", "libhello")
-        self.cpp_info.components["libhello"].set_property("cmake_target_name", "libhello")
-
+        self.cpp_info.components["libhello"].set_property("cmake_target_name", "hello::libhello")
         self.cpp_info.components["libhello"].libs = ["hello"]
         self.cpp_info.components["libhello"].frameworks.extend(["CoreFoundation"])
         """)

--- a/conans/test/functional/toolchains/cmake/cmakedeps/test_cmakedeps_aliases.py
+++ b/conans/test/functional/toolchains/cmake/cmakedeps/test_cmakedeps_aliases.py
@@ -99,8 +99,7 @@ def test_custom_name():
         settings = "os", "compiler", "build_type", "arch"
 
         def package_info(self):
-            self.cpp_info.set_property("cmake_target_namespace", "ola")
-            self.cpp_info.set_property("cmake_target_name", "comprar")
+            self.cpp_info.set_property("cmake_target_name", "ola::comprar")
             self.cpp_info.set_property("cmake_target_aliases", ["hello"])
     """)
 

--- a/conans/test/functional/toolchains/cmake/cmakedeps/test_cmakedeps_components_names.py
+++ b/conans/test/functional/toolchains/cmake/cmakedeps/test_cmakedeps_components_names.py
@@ -779,3 +779,65 @@ def test_targets_declared_in_build_modules(check_components_exist):
     assert "my_modules.cmake" in client.out
     assert bool(check_components_exist) == ("Conan: Component 'hello::invented' found in package 'hello'"
                                             in client.out)
+
+
+def test_set_absolute_target_names():
+    client = TestClient()
+    my_pkg = textwrap.dedent("""
+        from conans import ConanFile
+        class MyPkg(ConanFile):
+            name = "my_pkg"
+            version = "0.1"
+            settings = "os", "arch", "compiler", "build_type"
+            def package_info(self):
+                self.cpp_info.set_property("cmake_target_name", "MYPKG::MYPKG")
+                self.cpp_info.components["MYPKGCOMP"].set_property("cmake_target_name", "MYPKG::MYPKGCOMPNAME")
+        """)
+    client.save({"my_pkg/conanfile.py": my_pkg}, clean_first=True)
+    client.run("create my_pkg")
+
+    conanfile = textwrap.dedent("""
+        from conans import ConanFile
+        class LibcurlConan(ConanFile):
+            name = "libcurl"
+            version = "0.1"
+            requires = "my_pkg/0.1"
+            settings = "os", "arch", "compiler", "build_type"
+            def package_info(self):
+                self.cpp_info.set_property("cmake_target_name", "CURL::CURL")
+                self.cpp_info.set_property("cmake_file_name", "CURLFILENAME")
+                self.cpp_info.components["curl"].set_property("cmake_target_name", "CURL::libcurl")
+                self.cpp_info.components["curl2"].set_property("cmake_target_name", "CURL::libcurl2")
+                self.cpp_info.components["curl2"].requires.extend(["curl", "my_pkg::MYPKGCOMP"])
+        """)
+    client.save({"libcurl/conanfile.py": conanfile})
+    client.run("create libcurl")
+
+    conanfile = textwrap.dedent("""
+        from conans import ConanFile
+        from conan.tools.cmake import CMakeDeps, CMake, CMakeToolchain
+        class CONSUMER(ConanFile):
+            name = "consumer"
+            version = "0.1"
+            requires = "libcurl/0.1"
+            settings = "os", "arch", "compiler", "build_type"
+            exports_sources = "CMakeLists.txt"
+            def generate(self):
+                deps = CMakeDeps(self)
+                deps.check_components_exist=True
+                deps.generate()
+                tc = CMakeToolchain(self)
+                tc.generate()
+            def build(self):
+                cmake = CMake(self)
+                cmake.configure()
+                cmake.build()
+        """)
+
+    cmakelists = textwrap.dedent("""cmake_minimum_required(VERSION 3.15)
+        project(Consumer)
+        find_package(CURLFILENAME CONFIG REQUIRED COMPONENTS CURL::libcurl CURL::libcurl2)
+        """)
+
+    client.save({"consumer/conanfile.py": conanfile, "consumer/CMakeLists.txt": cmakelists})
+    client.run("create consumer")

--- a/conans/test/functional/toolchains/cmake/cmakedeps/test_cmakedeps_components_names.py
+++ b/conans/test/functional/toolchains/cmake/cmakedeps/test_cmakedeps_components_names.py
@@ -781,6 +781,7 @@ def test_targets_declared_in_build_modules(check_components_exist):
                                             in client.out)
 
 
+@pytest.mark.tool_cmake
 def test_set_absolute_target_names():
     client = TestClient()
     my_pkg = textwrap.dedent("""

--- a/conans/test/functional/toolchains/cmake/cmakedeps/test_cmakedeps_components_names.py
+++ b/conans/test/functional/toolchains/cmake/cmakedeps/test_cmakedeps_components_names.py
@@ -837,7 +837,7 @@ def test_set_absolute_target_names():
 
     cmakelists = textwrap.dedent("""cmake_minimum_required(VERSION 3.15)
         project(Consumer)
-        find_package(CURLFILENAME CONFIG REQUIRED COMPONENTS CURL::libcurl CURL::libcurl2)
+        find_package(CURLFILENAME CONFIG REQUIRED COMPONENTS libcurl libcurl2)
         """)
 
     client.save({"consumer/conanfile.py": conanfile, "consumer/CMakeLists.txt": cmakelists})

--- a/conans/test/functional/toolchains/cmake/cmakedeps/test_cmakedeps_components_names.py
+++ b/conans/test/functional/toolchains/cmake/cmakedeps/test_cmakedeps_components_names.py
@@ -50,10 +50,10 @@ def setup_client_with_greetings():
                     self.cpp_info.components["bye"].libs = ["bye"]
                 elif self.options.components == "custom":
                     self.cpp_info.set_property("cmake_file_name", "MYG")
-                    self.cpp_info.set_property("cmake_target_name", "MyGreetings")
+                    self.cpp_info.set_property("cmake_target_name", "MyGreetings::MyGreetings")
 
-                    self.cpp_info.components["hello"].set_property("cmake_target_name", "MyHello")
-                    self.cpp_info.components["bye"].set_property("cmake_target_name", "MyBye")
+                    self.cpp_info.components["hello"].set_property("cmake_target_name", "MyGreetings::MyHello")
+                    self.cpp_info.components["bye"].set_property("cmake_target_name", "MyGreetings::MyBye")
 
                     self.cpp_info.components["hello"].libs = ["hello"]
                     self.cpp_info.components["bye"].libs = ["bye"]
@@ -275,14 +275,14 @@ def test_custom_names(setup_client_with_greetings):
 
     package_info = textwrap.dedent("""
         # NOTE: For the new CMakeDeps only filenames mean filename, it is not using the "names" field
-        self.cpp_info.set_property("cmake_target_name", "MyChat")
+        self.cpp_info.set_property("cmake_target_name", "MyChat::MyChat")
         self.cpp_info.set_property("cmake_file_name", "MyChat")
 
-        self.cpp_info.components["sayhello"].set_property("cmake_target_name", "MySay")
+        self.cpp_info.components["sayhello"].set_property("cmake_target_name", "MyChat::MySay")
 
         self.cpp_info.components["sayhello"].requires = ["greetings::hello"]
         self.cpp_info.components["sayhello"].libs = ["sayhello"]
-        self.cpp_info.components["sayhellobye"].set_property("cmake_target_name", "MySayBye")
+        self.cpp_info.components["sayhellobye"].set_property("cmake_target_name", "MyChat::MySayBye")
 
         self.cpp_info.components["sayhellobye"].requires = ["sayhello", "greetings::bye"]
         self.cpp_info.components["sayhellobye"].libs = ["sayhellobye"]
@@ -314,15 +314,14 @@ def test_different_namespace(setup_client_with_greetings):
     client = setup_client_with_greetings
 
     package_info = textwrap.dedent("""
-        self.cpp_info.set_property("cmake_target_namespace", "MyChat")
-        self.cpp_info.set_property("cmake_target_name", "MyGlobalChat")
+        self.cpp_info.set_property("cmake_target_name", "MyChat::MyGlobalChat")
         self.cpp_info.set_property("cmake_file_name", "MyChat")
 
-        self.cpp_info.components["sayhello"].set_property("cmake_target_name", "MySay")
+        self.cpp_info.components["sayhello"].set_property("cmake_target_name", "MyChat::MySay")
 
         self.cpp_info.components["sayhello"].requires = ["greetings::hello"]
         self.cpp_info.components["sayhello"].libs = ["sayhello"]
-        self.cpp_info.components["sayhellobye"].set_property("cmake_target_name", "MySayBye")
+        self.cpp_info.components["sayhellobye"].set_property("cmake_target_name", "MyChat::MySayBye")
 
         self.cpp_info.components["sayhellobye"].requires = ["sayhello", "greetings::bye"]
         self.cpp_info.components["sayhellobye"].libs = ["sayhellobye"]
@@ -580,10 +579,10 @@ class TestComponentsCMakeGenerators:
                     self.copy("*.a", dst="lib", keep_path=False)
 
                 def package_info(self):
-                    self.cpp_info.set_property("cmake_target_name", "nonstd" )
+                    self.cpp_info.set_property("cmake_target_name", "nonstd::nonstd" )
                     self.cpp_info.set_property("cmake_file_name", "{name}")
 
-                    self.cpp_info.components["1"].set_property("cmake_target_name", "{name}")
+                    self.cpp_info.components["1"].set_property("cmake_target_name", "nonstd::{name}")
                     self.cpp_info.components["1"].libs = ["{name}"]
             """)
         basic_cmake = textwrap.dedent("""
@@ -766,7 +765,7 @@ def test_targets_declared_in_build_modules(check_components_exist):
         cmake_minimum_required(VERSION 3.15)
         project(project CXX)
 
-        find_package(hello COMPONENTS invented missing)
+        find_package(hello COMPONENTS hello::invented missing)
         add_executable(myapp main.cpp)
         target_link_libraries(myapp hello::invented)
     """)
@@ -778,5 +777,5 @@ def test_targets_declared_in_build_modules(check_components_exist):
 
     assert "Conan: Including build module" in client.out
     assert "my_modules.cmake" in client.out
-    assert bool(check_components_exist) == ("Conan: Component 'invented' found in package 'hello'"
+    assert bool(check_components_exist) == ("Conan: Component 'hello::invented' found in package 'hello'"
                                             in client.out)

--- a/conans/test/functional/toolchains/cmake/cmakedeps/test_cmakedeps_components_names.py
+++ b/conans/test/functional/toolchains/cmake/cmakedeps/test_cmakedeps_components_names.py
@@ -765,7 +765,7 @@ def test_targets_declared_in_build_modules(check_components_exist):
         cmake_minimum_required(VERSION 3.15)
         project(project CXX)
 
-        find_package(hello COMPONENTS hello::invented missing)
+        find_package(hello COMPONENTS invented missing)
         add_executable(myapp main.cpp)
         target_link_libraries(myapp hello::invented)
     """)
@@ -777,7 +777,7 @@ def test_targets_declared_in_build_modules(check_components_exist):
 
     assert "Conan: Including build module" in client.out
     assert "my_modules.cmake" in client.out
-    assert bool(check_components_exist) == ("Conan: Component 'hello::invented' found in package 'hello'"
+    assert bool(check_components_exist) == ("Conan: Component 'invented' found in package 'hello'"
                                             in client.out)
 
 

--- a/conans/test/functional/toolchains/cmake/cmakedeps/test_cmakedeps_find_module_and_config.py
+++ b/conans/test/functional/toolchains/cmake/cmakedeps/test_cmakedeps_find_module_and_config.py
@@ -44,18 +44,16 @@ def client():
                 self.cpp_info.set_property("cmake_find_mode", "both")
 
                 self.cpp_info.set_property("cmake_file_name", "MyDep")
-                self.cpp_info.set_property("cmake_target_name", "MyDepTarget")
+                self.cpp_info.set_property("cmake_target_name", "MyDepTarget::MyDepTarget")
 
                 self.cpp_info.set_property("cmake_module_file_name", "mi_dependencia")
-                self.cpp_info.set_property("cmake_module_target_name", "mi_dependencia_target")
-                self.cpp_info.set_property("cmake_module_target_namespace",
-                                           "mi_dependencia_namespace")
+                self.cpp_info.set_property("cmake_module_target_name", "mi_dependencia_namespace::mi_dependencia_target")
 
                 self.cpp_info.components["crispin"].libs = ["mydep"]
                 self.cpp_info.components["crispin"].set_property("cmake_target_name",
-                                                                 "MyCrispinTarget")
+                                                                 "MyDepTarget::MyCrispinTarget")
                 self.cpp_info.components["crispin"].set_property("cmake_module_target_name",
-                                                                 "mi_crispin_target")
+                                                                 "mi_dependencia_namespace::mi_crispin_target")
         """)
 
     t.save({"conanfile.py": conanfile,

--- a/conans/test/integration/generators/cpp_info_set_generator_properties_test.py
+++ b/conans/test/integration/generators/cpp_info_set_generator_properties_test.py
@@ -289,96 +289,6 @@ def test_cmake_find_package_new_properties():
     assert find_package_contents_old == find_package_contents
 
 
-@pytest.mark.xfail(reason="revisit later")
-@pytest.mark.parametrize("generator", ["cmake_find_package_multi", "cmake_find_package"])
-def test_cmake_find_package_target_namespace(generator):
-    # https://github.com/conan-io/conan/issues/9946
-    client = TestClient()
-    hello = textwrap.dedent("""
-        import os
-        from conans import ConanFile
-        class MyHello(ConanFile):
-            settings = "build_type"
-            name = "hello"
-            version = "1.0"
-            def package_info(self):
-                self.cpp_info.components["helloworld"].set_property("cmake_target_name", "hello::HelloWorld")
-                {}
-
-        """)
-
-    greetings = textwrap.dedent("""
-        import os
-        from conans import ConanFile
-        class MyPkg(ConanFile):
-            settings = "build_type"
-            name = "greetings"
-            version = "1.0"
-            requires = "hello/1.0"
-            def package_info(self):
-                self.cpp_info.components["greetingshello"].requires = ["hello::helloworld"]
-                {}
-        """)
-
-    client.save({"hello.py": hello.format('self.cpp_info.set_property("cmake_target_namespace", "hello_namespace")'),
-                 "greetings.py": greetings.format('self.cpp_info.set_property("cmake_target_namespace", "greetings_namespace")')})
-    client.run("create hello.py hello/1.0@")
-    client.run("create greetings.py greetings/1.0@")
-    client.run("install greetings/1.0@ -g {}".format(generator))
-    if generator == "cmake_find_package_multi":
-        hello_config = client.load("hello-config.cmake")
-        assert "set_property(TARGET hello_namespace::HelloWorld" in hello_config
-        hello_targets_release = client.load("helloTarget-release.cmake")
-        assert "set(hello_COMPONENTS_RELEASE hello_namespace::HelloWorld)" in hello_targets_release
-        hello_target = client.load("helloTargets.cmake")
-        assert "add_library(hello_namespace::HelloWorld" in hello_target
-        assert "add_library(hello_namespace::hello" in hello_target
-        greetings_config = client.load("greetings-config.cmake")
-        assert "set_property(TARGET greetings_namespace::greetings" in greetings_config
-        greetings_targets_release = client.load("greetingsTarget-release.cmake")
-        assert "set(greetings_COMPONENTS_RELEASE greetings_namespace::greetingshello)" in greetings_targets_release
-        greetings_target = client.load("greetingsTargets.cmake")
-        assert "add_library(greetings_namespace::greetingshello INTERFACE IMPORTED)" in greetings_target
-        assert "add_library(greetings_namespace::greetings INTERFACE IMPORTED)" in greetings_target
-    else:
-        hello_contents = client.load("Findhello.cmake")
-        assert "set(hello_COMPONENTS hello_namespace::HelloWorld)" in hello_contents
-        assert "add_library(hello_namespace::HelloWorld INTERFACE IMPORTED)" in hello_contents
-        assert "add_library(hello_namespace::hello INTERFACE IMPORTED)" in hello_contents
-        greetings_contents = client.load("Findgreetings.cmake")
-        assert "set(greetings_COMPONENTS greetings_namespace::greetingshello)" in greetings_contents
-        assert "add_library(greetings_namespace::greetingshello INTERFACE IMPORTED)" in greetings_contents
-        assert "add_library(greetings_namespace::greetings INTERFACE IMPORTED)" in greetings_contents
-
-    # check that the contents with the namespace that equals the default
-    # generates exactly the same files
-    client.save({"hello.py": hello.format('self.cpp_info.set_property("cmake_target_namespace", "hello")'),
-                 "greetings.py": greetings.format('self.cpp_info.set_property("cmake_target_namespace", "greetings")')},
-                clean_first=True)
-    client.run("create hello.py hello/1.0@")
-    client.run("create greetings.py greetings/1.0@")
-    client.run("install greetings/1.0@ -g {}".format(generator))
-
-    if generator == "cmake_find_package_multi":
-        files_to_compare = ["greetings-config.cmake", "greetingsTarget-release.cmake", "greetingsTargets.cmake",
-                            "hello-config.cmake", "helloTarget-release.cmake", "helloTargets.cmake"]
-    else:
-        files_to_compare = ["Findhello.cmake", "Findgreetings.cmake"]
-
-    files_namespace = [client.load(file) for file in files_to_compare]
-
-    client.save({"hello.py": hello.format(''),
-                 "greetings.py": greetings.format('')},
-                clean_first=True)
-    client.run("create hello.py hello/1.0@")
-    client.run("create greetings.py greetings/1.0@")
-    client.run("install greetings/1.0@ -g {}".format(generator))
-
-    files_no_namespace = [client.load(file) for file in files_to_compare]
-
-    assert files_namespace == files_no_namespace
-
-
 def test_legacy_cmake_is_not_affected_by_set_property_usage():
     """
     "set_property" will have no effect on "cmake" legacy generator
@@ -522,6 +432,52 @@ def test_set_absolute_target_names_legacy_generators():
                 self.cpp_info.components["curl2"].names["cmake_find_package"] = "libcurl2"
                 self.cpp_info.components["curl2"].names["cmake_find_package_multi"] = "libcurl2"
                 self.cpp_info.components["curl2"].requires.extend(["curl", "my_pkg::MYPKGCOMP"])
+    """)
+    client.save({"names/conanfile.py": conanfile})
+    client.run("create names")
+    client.run("install libcurl/0.1@ -g cmake_find_package_multi -g cmake_find_package "
+               "--install-folder=names")
+    files_with_names = []
+    for filename in check_files:
+        files_with_names.append(client.load(os.path.join("names", filename)))
+
+    assert files_with_properties == files_with_names
+
+
+def test_set_absolute_target_names_same_as_default():
+    # Test that using the new absolute names with names equaling the default result in the same
+    # that no adding any propeties
+    client = TestClient()
+    conanfile = textwrap.dedent("""
+        from conans import ConanFile
+        class LibcurlConan(ConanFile):
+            name = "libcurl"
+            version = "0.1"
+            settings = "os", "arch", "compiler", "build_type"
+            def package_info(self):
+                self.cpp_info.set_property("cmake_target_name", "libcurl::libcurl")
+                self.cpp_info.set_property("cmake_file_name", "libcurl")
+                self.cpp_info.components["curl"].set_property("cmake_target_name", "libcurl::curl")
+                self.cpp_info.components["curl"].libs = ["curl_lib"]
+    """)
+    client.save({"properties/conanfile.py": conanfile})
+    client.run("create properties")
+    client.run("install libcurl/0.1@ -g cmake_find_package_multi -g cmake_find_package "
+               "--install-folder=properties")
+    files_with_properties = []
+    check_files = ["Findlibcurl.cmake", "libcurl-config.cmake", "libcurlTargets.cmake", "libcurlTarget-release.cmake",
+                   "libcurl-config-version.cmake"]
+    for filename in check_files:
+        files_with_properties.append(client.load(os.path.join("properties", filename)))
+
+    conanfile = textwrap.dedent("""
+        from conans import ConanFile
+        class LibcurlConan(ConanFile):
+            name = "libcurl"
+            version = "0.1"
+            settings = "os", "arch", "compiler", "build_type"
+            def package_info(self):
+                self.cpp_info.components["curl"].libs = ["curl_lib"]
     """)
     client.save({"names/conanfile.py": conanfile})
     client.run("create names")

--- a/conans/test/integration/generators/cpp_info_set_generator_properties_test.py
+++ b/conans/test/integration/generators/cpp_info_set_generator_properties_test.py
@@ -240,7 +240,6 @@ def test_same_results_specific_generators(setup_client):
     assert new_approach_contents == old_approach_contents
 
 
-@pytest.mark.xfail(reason="revisit later")
 def test_cmake_find_package_new_properties():
     # test new properties support for cmake_find_package, necessary for migration in cci
     # cmake_target_name --> cmake_module_target_name
@@ -257,10 +256,10 @@ def test_cmake_find_package_new_properties():
             name = "greetings"
             version = "1.0"
             def package_info(self):
-                self.cpp_info.set_property("cmake_module_target_name", "MyChat")
+                self.cpp_info.set_property("cmake_module_target_name", "MyChat::MyChat")
                 self.cpp_info.set_property("cmake_module_file_name", "MyChat")
-                self.cpp_info.components["sayhello"].set_property("cmake_module_target_name", "MySay")
-                self.cpp_info.components["sayhellobye"].set_property("cmake_module_target_name", "MySayBye")
+                self.cpp_info.components["sayhello"].set_property("cmake_module_target_name", "MyChat::MySay")
+                self.cpp_info.components["sayhellobye"].set_property("cmake_module_target_name", "MyChat::MySayBye")
         """)
     client.save({"greetings.py": greetings})
     client.run("create greetings.py greetings/1.0@")
@@ -278,10 +277,10 @@ def test_cmake_find_package_new_properties():
             name = "greetings"
             version = "1.0"
             def package_info(self):
-                self.cpp_info.set_property("cmake_target_name", "MyChat")
+                self.cpp_info.set_property("cmake_target_name", "MyChat::MyChat")
                 self.cpp_info.set_property("cmake_file_name", "MyChat")
-                self.cpp_info.components["sayhello"].set_property("cmake_target_name", "MySay")
-                self.cpp_info.components["sayhellobye"].set_property("cmake_target_name", "MySayBye")
+                self.cpp_info.components["sayhello"].set_property("cmake_target_name", "MyChat::MySay")
+                self.cpp_info.components["sayhellobye"].set_property("cmake_target_name", "MyChat::MySayBye")
         """)
     client.save({"greetings.py": greetings})
     client.run("create greetings.py greetings/1.0@")

--- a/conans/test/integration/generators/cpp_info_set_generator_properties_test.py
+++ b/conans/test/integration/generators/cpp_info_set_generator_properties_test.py
@@ -464,9 +464,8 @@ def test_pkg_config_names(setup_client):
         assert "mypkg-config-name" in gen_file.read()
 
 
-def test_set_properties_simplified():
+def test_set_absolute_target_names_legacy_generators():
     client = TestClient()
-    client.current_folder = '/private/var/folders/6s/l9c3n5696gvg7qm3v7ms78lc0000gq/T/tmpb77ctm1lconans/path with spaces'
     my_pkg = textwrap.dedent("""
         from conans import ConanFile
         class MyPkg(ConanFile):
@@ -497,12 +496,12 @@ def test_set_properties_simplified():
                 self.cpp_info.components["curl2"].requires.extend(["curl", "my_pkg::MYPKGCOMP"])
 
     """)
-    client.save({"properties/conanfile.py": conanfile}, clean_first=True)
+    client.save({"properties/conanfile.py": conanfile})
     client.run("create properties")
-    client.run("install libcurl/0.1@ -g cmake_find_package_multi --install-folder=properties")
+    client.run("install libcurl/0.1@ -g cmake_find_package_multi -g cmake_find_package "
+               "--install-folder=properties")
     files_with_properties = []
-    # check_files = ["FindCURL.cmake"]
-    check_files = ["CURLConfig.cmake", "CURLTargets.cmake", "CURLTarget-release.cmake",
+    check_files = ["FindCURL.cmake", "CURLConfig.cmake", "CURLTargets.cmake", "CURLTarget-release.cmake",
                    "CURLConfigVersion.cmake"]
     for filename in check_files:
         files_with_properties.append(client.load(os.path.join("properties", filename)))
@@ -525,7 +524,8 @@ def test_set_properties_simplified():
     """)
     client.save({"names/conanfile.py": conanfile})
     client.run("create names")
-    client.run("install libcurl/0.1@ -g cmake_find_package_multi --install-folder=names")
+    client.run("install libcurl/0.1@ -g cmake_find_package_multi -g cmake_find_package "
+               "--install-folder=names")
     files_with_names = []
     for filename in check_files:
         files_with_names.append(client.load(os.path.join("names", filename)))

--- a/conans/test/integration/toolchains/cmake/cmakedeps/test_cmakedeps.py
+++ b/conans/test/integration/toolchains/cmake/cmakedeps/test_cmakedeps.py
@@ -103,8 +103,8 @@ def test_cpp_info_component_objects():
     with open(os.path.join(client.current_folder, "hello-Target-release.cmake")) as f:
         content = f.read()
         assert """set_property(TARGET hello::say PROPERTY INTERFACE_LINK_LIBRARIES
-             $<$<CONFIG:Release>:${hello_say_LINK_LIBS_RELEASE}
-             ${hello_say_OBJECTS_RELEASE}> APPEND)""" in content
+             $<$<CONFIG:Release>:${hello_hello_say_LINK_LIBS_RELEASE}
+             ${hello_hello_say_OBJECTS_RELEASE}> APPEND)""" in content
         assert """set_property(TARGET hello::hello
              PROPERTY INTERFACE_LINK_LIBRARIES
              $<$<CONFIG:Release>:${hello_LIBRARIES_TARGETS_RELEASE}
@@ -113,4 +113,5 @@ def test_cpp_info_component_objects():
     with open(os.path.join(client.current_folder, "hello-release-x86_64-data.cmake")) as f:
         content = f.read()
         assert 'set(hello_OBJECTS_RELEASE "${hello_PACKAGE_FOLDER_RELEASE}/mycomponent.o")' in content
-        assert 'set(hello_say_OBJECTS_RELEASE "${hello_PACKAGE_FOLDER_RELEASE}/mycomponent.o")' in content
+        assert 'set(hello_hello_say_OBJECTS_RELEASE "${hello_PACKAGE_FOLDER_RELEASE}/mycomponent.o")' in content
+    print("....")

--- a/conans/test/unittests/tools/cmake/test_cmakedeps.py
+++ b/conans/test/unittests/tools/cmake/test_cmakedeps.py
@@ -23,7 +23,7 @@ def test_cpp_info_name_cmakedeps():
     conanfile.settings.arch = "x86"
 
     cpp_info = CppInfo("mypkg", "dummy_root_folder1")
-    cpp_info.set_property("cmake_target_name", "MySuperPkg1")
+    cpp_info.set_property("cmake_target_name", "MySuperPkg1::MySuperPkg1")
     cpp_info.set_property("cmake_file_name", "ComplexFileName1")
 
     conanfile_dep = ConanFile(Mock(), None)
@@ -58,8 +58,8 @@ def test_cpp_info_name_cmakedeps_components():
     conanfile.settings.arch = "x64"
 
     cpp_info = CppInfo("mypkg", "dummy_root_folder1")
-    cpp_info.set_property("cmake_target_name", "GlobakPkgName1")
-    cpp_info.components["mycomp"].set_property("cmake_target_name", "MySuperPkg1")
+    cpp_info.set_property("cmake_target_name", "GlobakPkgName1::GlobakPkgName1")
+    cpp_info.components["mycomp"].set_property("cmake_target_name", "GlobakPkgName1::MySuperPkg1")
     cpp_info.set_property("cmake_file_name", "ComplexFileName1")
 
     conanfile_dep = ConanFile(Mock(), None)
@@ -79,7 +79,7 @@ def test_cpp_info_name_cmakedeps_components():
         assert 'set(OriginalDepName_INCLUDE_DIRS_DEBUG ' \
                '"${OriginalDepName_PACKAGE_FOLDER_DEBUG}/include")' \
                in files["ComplexFileName1-debug-x64-data.cmake"]
-        assert 'set(OriginalDepName_MySuperPkg1_INCLUDE_DIRS_DEBUG ' \
+        assert 'set(OriginalDepName_GlobakPkgName1_MySuperPkg1_INCLUDE_DIRS_DEBUG ' \
                '"${OriginalDepName_PACKAGE_FOLDER_DEBUG}/include")' \
                in files["ComplexFileName1-debug-x64-data.cmake"]
 
@@ -156,8 +156,8 @@ def test_component_name_same_package():
         cmakedeps = CMakeDeps(conanfile)
         files = cmakedeps.content
         target_cmake = files["mypkg-Target-release.cmake"]
-        assert "$<$<CONFIG:Release>:${mypkg_mypkg_INCLUDE_DIRS_RELEASE}> APPEND)" in target_cmake
+        assert "$<$<CONFIG:Release>:${mypkg_mypkg_mypkg_INCLUDE_DIRS_RELEASE}> APPEND)" in target_cmake
 
         data_cmake = files["mypkg-release-x86-data.cmake"]
-        assert 'set(mypkg_mypkg_INCLUDE_DIRS_RELEASE ' \
+        assert 'set(mypkg_mypkg_mypkg_INCLUDE_DIRS_RELEASE ' \
                '"${mypkg_PACKAGE_FOLDER_RELEASE}/includedirs1")' in data_cmake


### PR DESCRIPTION
Changelog: Feature: Force to use absolute target names with namespaces always via `cmake_target_name`.
Changelog: Feature: Add compatibility logic between legacy `cpp_info.names` and `cmake_target_name`.
Changelog: Feature: Restrict `cmake_target_name` for components to have the same namespace as the root cpp_info.
Changelog: Feature: Deprecate `cmake_target_namespace` and `cmake_module_target_namespace`.
Docs: TODO

This PR tries to make possible a transition from the old syntax for `cpp_info.names` and the new `cmake_target_name` property for `cmake_find_package[multi]` generators. `CMakeDeps` will also now use always absolute names via `set_property`.

There are some supposition when using `cmake_target_name` (maybe we can get rid of them for 2.0...):
- `cmake_target_name` is absolute in the form `NAMESPACE::NAME`, otherwise an exception raises.
- `cmake_target_name` for **components** has to specify a namespace that is always the same as the root cpp_info namespace, otherwise an expection raises.

~~Also, there's one more change, now when specifying components in find_package those have to be named with the full name: `find_package(hello COMPONENTS hello::say)` not `find_package(hello COMPONENTS say)`~~ --> This one is reverted 

#TAGS: slow

