### PR TITLE
further improving GraphAPI and InstallAPI

### DIFF
--- a/conans/cli/api/subapi/graph.py
+++ b/conans/cli/api/subapi/graph.py
@@ -13,13 +13,17 @@ class GraphAPI:
     @api_method
     def load_root_node(self, reference, path, profile_host, profile_build, lockfile, root_ref,
                        create_reference=None, is_build_require=False,
-                       require_overrides=None):
+                       require_overrides=None, remote=None, update=None):
 
         if path and reference:
             raise ConanException("Both path and reference arguments were provided. Please provide "
                                  "only one of them")
 
         app = ConanApp(self.conan_api.cache_folder)
+        # necessary for correct resolution and update of remote python_requires
+        remote = [remote] if remote is not None else None
+        app.load_remotes(remote, update=update)
+
         graph_manager, cache = app.graph_manager, app.cache
         reference = reference or path
         root_node = graph_manager._load_root_node(reference, create_reference, profile_host,

--- a/conans/cli/api/subapi/graph.py
+++ b/conans/cli/api/subapi/graph.py
@@ -1,6 +1,7 @@
 from conans.cli.api.subapi import api_method
 from conans.cli.conan_app import ConanApp
 from conans.cli.output import ConanOutput
+from conans.client.graph.graph_builder import DepsGraphBuilder
 from conans.errors import ConanException
 
 
@@ -9,29 +10,29 @@ class GraphAPI:
     def __init__(self, conan_api):
         self.conan_api = conan_api
 
-    # Maybe we don't want to pass Profile objects to the API?
     @api_method
-    def load_graph(self, reference, path, profile_host, profile_build, lockfile, root_ref,
-                   build_modes=None, create_reference=None, is_build_require=False,
-                   require_overrides=None, remote=None, update=False):
-        """ Calculate graph and fetch needed recipes
-        @param reference: Conan reference to build the graph for
-        @param path: Path to the conanfile.py or conanfile.txt to build the graph
-        @param profile_host: Profile for the host context
-        @param profile_build: Profile for the build context
-        @param lockfile: Locked graph to use to build the graph
-        @param root_ref: RecipeReference with fields (name, version, user, channel) that may be missing in the conanfile provided as argument
-        @param build_modes:
-        @param create_reference:
-        @param is_build_require:
-        @param require_overrides:
-        @param remote:
-        @param update:
-        """
+    def load_root_node(self, reference, path, profile_host, profile_build, lockfile, root_ref,
+                       create_reference=None, is_build_require=False,
+                       require_overrides=None):
+
         if path and reference:
             raise ConanException("Both path and reference arguments were provided. Please provide "
                                  "only one of them")
 
+        app = ConanApp(self.conan_api.cache_folder)
+        graph_manager, cache = app.graph_manager, app.cache
+        reference = reference or path
+        root_node = graph_manager._load_root_node(reference, create_reference, profile_host,
+                                                  lockfile, root_ref, is_build_require,
+                                                  require_overrides)
+        return root_node
+
+    # Maybe we don't want to pass Profile objects to the API?
+    @api_method
+    def load_graph(self, root_node, profile_host, profile_build, lockfile,
+                   remote=None, update=False):
+        """ Calculate graph and fetch needed recipes
+        """
         app = ConanApp(self.conan_api.cache_folder)
 
         remote = [remote] if remote is not None else None
@@ -40,28 +41,28 @@ class GraphAPI:
         assert profile_host is not None
         assert profile_build is not None
 
-        if path and reference:
-            raise ConanException("Both path and reference arguments were provided. Please provide "
-                                 "only one of them")
-
-        graph_manager, cache = app.graph_manager, app.cache
-
         out = ConanOutput()
-        out.info("Configuration (profile_host):")
-        out.info(profile_host.dumps())
-        out.info("Configuration (profile_build):")
-        out.info(profile_build.dumps())
 
-        ref_or_path = reference or path
-        deps_graph = graph_manager.load_graph(ref_or_path, create_reference, profile_host,
-                                              profile_build,
-                                              lockfile, root_ref, build_modes,
-                                              is_build_require=is_build_require,
-                                              require_overrides=require_overrides)
-
-        deps_graph.report_graph_error()
+        builder = DepsGraphBuilder(app.proxy, app.loader, app.range_resolver)
+        deps_graph = builder.load_graph(root_node, profile_host, profile_build, lockfile)
+        # FIXME: this ugly ouput doesn't belong here
+        version_ranges_output = app.range_resolver.output
+        if version_ranges_output:
+            out.success("Version ranges solved")
+            for msg in version_ranges_output:
+                out.info("    %s" % msg)
+            out.writeln("")
+            app.range_resolver.clear_output()
 
         if lockfile:
             lockfile.update_lock(deps_graph)
 
         return deps_graph
+
+    @api_method
+    def analyze_binaries(self, deps_graph, build_mode=None, remote=None, update=None):
+        conan_app = ConanApp(self.conan_api.cache_folder)
+        remote = [remote] if remote is not None else None
+        conan_app.load_remotes(remote, update=update)
+        deps_graph.report_graph_error()
+        conan_app.binaries_analyzer.evaluate_graph(deps_graph, build_mode)

--- a/conans/cli/api/subapi/graph.py
+++ b/conans/cli/api/subapi/graph.py
@@ -14,7 +14,12 @@ class GraphAPI:
     def load_root_node(self, reference, path, profile_host, profile_build, lockfile, root_ref,
                        create_reference=None, is_build_require=False,
                        require_overrides=None, remote=None, update=None):
-
+        """ creates the first, root node of the graph, loading or creating a conanfile
+        and initializing it (settings, options) as necessary. Also locking with lockfile
+        information, necessary if it has python_requires to be locked, or override-requires
+        """
+        # TODO: This API is probably not final, but we want it split based on the different things
+        #   curently done inside GraphManager. To discuss
         if path and reference:
             raise ConanException("Both path and reference arguments were provided. Please provide "
                                  "only one of them")
@@ -26,16 +31,29 @@ class GraphAPI:
 
         graph_manager, cache = app.graph_manager, app.cache
         reference = reference or path
+        # TODO: Improve this interface, not making it public yet, because better to be splitted
         root_node = graph_manager._load_root_node(reference, create_reference, profile_host,
                                                   lockfile, root_ref, is_build_require,
                                                   require_overrides)
         return root_node
 
-    # Maybe we don't want to pass Profile objects to the API?
     @api_method
-    def load_graph(self, root_node, profile_host, profile_build, lockfile,
-                   remote=None, update=False):
-        """ Calculate graph and fetch needed recipes
+    def load_graph(self, root_node, profile_host, profile_build, lockfile=None, remote=None,
+                   update=False):
+        """ Compute the dependency graph, starting from a root package, evaluation the graph with
+        the provided configuration in profile_build, and profile_host. The resulting graph is a
+        graph of recipes, but packages are not computed yet (package_ids) will be empty in the
+        result.
+        The result might have errors, like version or configuration conflicts, but it is still
+        possible to inspect it. Only trying to install such graph will fail
+        :param root_node: the starting point, an already initialized Node structure, as returned
+                          by the "load_root_node" api
+        :param profile_host: The host profile
+        :param profile_build: The build profile
+        :param lockfile: A valid lockfile (None by default, means no locked)
+        :param remote: TODO: Not clear, cannot be more than 1 now?
+        :param update: (False by default), if Conan should look for newer versions or revisions for
+                       already existing recipes in the Conan cache
         """
         app = ConanApp(self.conan_api.cache_folder)
 
@@ -64,9 +82,18 @@ class GraphAPI:
         return deps_graph
 
     @api_method
-    def analyze_binaries(self, deps_graph, build_mode=None, remote=None, update=None):
+    def analyze_binaries(self, graph, build_mode=None, remote=None, update=None):
+        """ Given a dependency graph, will compute the package_ids of all recipes in the graph, and
+        evaluate if they should be built from sources, downloaded from a remote server, of if the
+        packages are already in the local Conan cache
+        :param graph: a Conan dependency graph, as returned by "load_graph()"
+        :param build_mode: TODO: Discuss if this should be a BuildMode object or list of arguments
+        :param remote: TODO: Same as above
+        :param update: (False by default), if Conan should look for newer versions or revisions for
+                       already existing recipes in the Conan cache
+        """
         conan_app = ConanApp(self.conan_api.cache_folder)
         remote = [remote] if remote is not None else None
         conan_app.load_remotes(remote, update=update)
-        deps_graph.report_graph_error()
-        conan_app.binaries_analyzer.evaluate_graph(deps_graph, build_mode)
+        graph.report_graph_error()
+        conan_app.binaries_analyzer.evaluate_graph(graph, build_mode)

--- a/conans/cli/api/subapi/install.py
+++ b/conans/cli/api/subapi/install.py
@@ -33,6 +33,10 @@ class InstallAPI:
     def install_consumer(deps_graph, install_folder, base_folder, conanfile_folder,
                          generators=None, reference=None, no_imports=False, create_reference=None,
                          test=None):
+        """ Once a dependency graph has been installed, there are things to be done, like invoking
+        generators for the root consumer, or calling imports()/deploy() to copy things to user space.
+        This is necessary for example for conanfile.txt/py, or for "conan install <ref> -g
+        """
         root_node = deps_graph.root
         conanfile = root_node.conanfile
 

--- a/conans/cli/api/subapi/install.py
+++ b/conans/cli/api/subapi/install.py
@@ -1,19 +1,10 @@
-import os
-
 from conans import ConanFile
 from conans.cli.api.subapi import api_method
-from conans.cli.common import get_lockfile
 from conans.cli.conan_app import ConanApp
-from conans.cli.output import ConanOutput
-from conans.client.conan_api import _make_abs_path
 from conans.client.generators import write_generators
 from conans.client.graph.build_mode import BuildMode
-from conans.client.graph.graph import RECIPE_VIRTUAL
-from conans.client.graph.printer import print_graph
 from conans.client.importer import run_imports, run_deploy
 from conans.client.installer import BinaryInstaller, call_system_requirements
-from conans.errors import ConanException
-from conans.model.recipe_ref import RecipeReference
 
 
 class InstallAPI:

--- a/conans/cli/commands/install.py
+++ b/conans/cli/commands/install.py
@@ -124,7 +124,9 @@ def install(conan_api, parser, *args, **kwargs):
                                                lockfile, root_ref,
                                                create_reference=None,
                                                is_build_require=args.build_require,
-                                               require_overrides=args.require_override)
+                                               require_overrides=args.require_override,
+                                               remote=remote,
+                                               update=args.update)
     deps_graph = conan_api.graph.load_graph(root_node, profile_host=profile_host,
                                             profile_build=profile_build,
                                             lockfile=lockfile,

--- a/conans/cli/commands/install.py
+++ b/conans/cli/commands/install.py
@@ -3,6 +3,7 @@ import os
 from conans.cli.command import conan_command, Extender, COMMAND_GROUPS, OnceArgument
 from conans.cli.common import _add_common_install_arguments, _help_build_policies, \
     get_profiles_from_args, get_lockfile
+from conans.cli.output import ConanOutput
 from conans.client.conan_api import _make_abs_path
 from conans.client.graph.printer import print_graph
 from conans.errors import ConanException
@@ -111,18 +112,25 @@ def install(conan_api, parser, *args, **kwargs):
     root_ref = RecipeReference(name=args.name, version=args.version,
                                user=args.user, channel=args.channel)
 
-    # TODO: Discuss: This could be further split into graph + binary-analyzer
-    deps_graph = conan_api.graph.load_graph(reference=reference,
-                                            path=path,
-                                            profile_host=profile_host,
+    out = ConanOutput()
+    out.info("Configuration (profile_host):")
+    out.info(profile_host.dumps())
+    out.info("Configuration (profile_build):")
+    out.info(profile_build.dumps())
+
+    # decoupling the most complex part, which is loading the root_node, this is the point where
+    # the difference between "reference", "path", etc
+    root_node = conan_api.graph.load_root_node(reference, path, profile_host, profile_build,
+                                               lockfile, root_ref,
+                                               create_reference=None,
+                                               is_build_require=args.build_require,
+                                               require_overrides=args.require_override)
+    deps_graph = conan_api.graph.load_graph(root_node, profile_host=profile_host,
                                             profile_build=profile_build,
                                             lockfile=lockfile,
-                                            root_ref=root_ref,
-                                            build_modes=args.build,
-                                            is_build_require=args.build_require,
-                                            require_overrides=args.require_override,
                                             remote=remote,
                                             update=args.update)
+    conan_api.graph.analyze_binaries(deps_graph, args.build, remote=remote, update=args.update)
     print_graph(deps_graph)
     conan_api.install.install_binaries(deps_graph=deps_graph, build_modes=args.build,
                                        remote=remote, update=args.update)

--- a/conans/client/graph/graph_manager.py
+++ b/conans/client/graph/graph_manager.py
@@ -77,10 +77,7 @@ class GraphManager(object):
 
     def _load_root_node(self, reference, create_reference, profile_host, graph_lock, root_ref,
                         is_build_require, require_overrides):
-        """ creates the first, root node of the graph, loading or creating a conanfile
-        and initializing it (settings, options) as necessary. Also locking with lockfile
-        information
-        """
+
         profile_host.dev_reference = create_reference  # Make sure the created one has develop=True
 
         # create (without test_package), install|info|graph|export-pkg <ref>


### PR DESCRIPTION
Splitting:

- The ``load_root_node`` which is the ugliest part of computing the graph, better isolate it (maybe further split in the feature for the different cases (``reference``, ``path``, etc)
- The ``binary_analyzing``