### PR TITLE
refactoring settings definition out of loader into graph_manager

### DIFF
--- a/conans/cli/api/subapi/graph.py
+++ b/conans/cli/api/subapi/graph.py
@@ -32,8 +32,8 @@ class GraphAPI:
         graph_manager, cache = app.graph_manager, app.cache
         reference = reference or path
         # TODO: Improve this interface, not making it public yet, because better to be splitted
-        root_node = graph_manager._load_root_node(reference, create_reference, profile_host,
-                                                  lockfile, root_ref, is_build_require,
+        root_node = graph_manager._load_root_node(reference, create_reference, profile_build,
+                                                  profile_host, lockfile, root_ref, is_build_require,
                                                   require_overrides)
         return root_node
 

--- a/conans/cli/api/subapi/install.py
+++ b/conans/cli/api/subapi/install.py
@@ -50,11 +50,8 @@ class InstallAPI:
             conanfile.folders.set_base_generators(base_folder)
 
         if install_folder:
-            # Write generators
-            tmp = list(conanfile.generators)  # Add the command line specified generators
-            generators = set(generators) if generators else set()
-            tmp.extend([g for g in generators if g not in tmp])
-            conanfile.generators = tmp
+            # Add cli -g generators
+            conanfile.generators = list(set(conanfile.generators).union(generators or []))
             write_generators(conanfile)
 
             if not no_imports:
@@ -68,5 +65,3 @@ class InstallAPI:
                 deploy_conanfile = neighbours[0].conanfile
                 if hasattr(deploy_conanfile, "deploy") and callable(deploy_conanfile.deploy):
                     run_deploy(deploy_conanfile, install_folder)
-
-        return deps_graph

--- a/conans/client/graph/graph_manager.py
+++ b/conans/client/graph/graph_manager.py
@@ -1,14 +1,15 @@
-
 import os
-import traceback
 
 from conans.cli.output import ConanOutput
 from conans.client.conanfile.configure import run_configure_method
 from conans.client.graph.graph import Node, CONTEXT_HOST
 from conans.client.graph.graph_binaries import RECIPE_CONSUMER, RECIPE_VIRTUAL
 from conans.client.graph.graph_builder import DepsGraphBuilder
+from conans.client.graph.profile_node_definer import txt_definer, virtual_definer, \
+    initialize_conanfile_profile
 from conans.client.profile_loader import ProfileLoader
 from conans.model.options import Options
+from conans.model.profile import Profile
 from conans.model.recipe_ref import RecipeReference
 
 
@@ -36,16 +37,18 @@ class GraphManager(object):
             # The global.conf is necessary for download_cache definition
             profile_host.conf.rebase_conf_definition(self._cache.new_config)
             conanfile = self._loader.load_consumer(conanfile_path,
-                                                   profile_host=profile_host,
                                                    name=name, version=version,
                                                    user=user, channel=channel,
                                                    graph_lock=None)
 
+            initialize_conanfile_profile(conanfile, profile_host, profile_host, CONTEXT_HOST,
+                                         False)
+
             run_configure_method(conanfile, down_options=Options(),
                                  profile_options=profile_host.options,  ref=None)
         else:
-            conanfile = self._loader.load_conanfile_txt(conanfile_path, profile_host=profile_host)
-
+            conanfile = self._loader.load_conanfile_txt(conanfile_path)
+            txt_definer(conanfile, profile_host)
         return conanfile
 
     def load_graph(self, reference, create_reference, profile_host, profile_build, graph_lock,
@@ -55,9 +58,11 @@ class GraphManager(object):
         assert profile_host is not None
         assert profile_build is not None
 
-        root_node = self._load_root_node(reference, create_reference, profile_host, graph_lock,
+        root_node = self._load_root_node(reference, create_reference, profile_build, profile_host,
+                                         graph_lock,
                                          root_ref, is_build_require,
                                          require_overrides)
+
         profile_host_build_requires = profile_host.build_requires
         builder = DepsGraphBuilder(self._proxy, self._loader, self._range_resolver)
         deps_graph = builder.load_graph(root_node, profile_host, profile_build, graph_lock)
@@ -75,7 +80,8 @@ class GraphManager(object):
 
         return deps_graph
 
-    def _load_root_node(self, reference, create_reference, profile_host, graph_lock, root_ref,
+    def _load_root_node(self, reference, create_reference, profile_build, profile_host,
+                        graph_lock, root_ref,
                         is_build_require, require_overrides):
         """ creates the first, root node of the graph, loading or creating a conanfile
         and initializing it (settings, options) as necessary. Also locking with lockfile
@@ -88,22 +94,23 @@ class GraphManager(object):
             # options without scope like ``-o shared=True`` refer to this reference
             profile_host.options.scope(reference.name)
             # FIXME: Might need here the profile_build
-            return self._load_root_direct_reference(reference, profile_host,
+            return self._load_root_direct_reference(reference, profile_build, profile_host,
                                                     is_build_require,
                                                     require_overrides)
 
         path = reference  # The reference must be pointing to a user space conanfile
         if create_reference:  # Test_package -> tested reference
             profile_host.options.scope(create_reference.name)
-            return self._load_root_test_package(path, create_reference, graph_lock, profile_host,
-                                                require_overrides)
+            return self._load_root_test_package(path, profile_build, profile_host,
+                                                create_reference, require_overrides)
 
         # It is a path to conanfile.py or conanfile.txt
-        root_node = self._load_root_consumer(path, graph_lock, profile_host, root_ref,
-                                             require_overrides)
+        root_node = self._load_root_consumer(path, graph_lock, profile_build, profile_host,
+                                             root_ref, require_overrides)
         return root_node
 
-    def _load_root_consumer(self, path, graph_lock, profile, ref, require_overrides):
+    def _load_root_consumer(self, path, graph_lock, profile_build, profile_host, ref,
+                            require_overrides):
         """ load a CONSUMER node from a user space conanfile.py or conanfile.txt
         install|info|create|graph <path>
         :path full path to a conanfile
@@ -113,7 +120,7 @@ class GraphManager(object):
               the lockfile, or to initialize
         """
         if path.endswith(".py"):
-            conanfile = self._loader.load_consumer(path, profile,
+            conanfile = self._loader.load_consumer(path,
                                                    name=ref.name,
                                                    version=ref.version,
                                                    user=ref.user,
@@ -121,31 +128,36 @@ class GraphManager(object):
                                                    graph_lock=graph_lock,
                                                    require_overrides=require_overrides)
 
+            initialize_conanfile_profile(conanfile, profile_build, profile_host, CONTEXT_HOST,
+                                         False, ref)
+
             ref = RecipeReference(conanfile.name, conanfile.version, ref.user, ref.channel)
             if ref.name:
-                profile.options.scope(ref.name)
+                profile_host.options.scope(ref.name)
             root_node = Node(ref, conanfile, context=CONTEXT_HOST, recipe=RECIPE_CONSUMER, path=path)
         else:
-            conanfile = self._loader.load_conanfile_txt(path, profile, ref=ref,
+            conanfile = self._loader.load_conanfile_txt(path, ref=ref,
                                                         require_overrides=require_overrides)
+            txt_definer(conanfile, profile_host)
             root_node = Node(None, conanfile, context=CONTEXT_HOST, recipe=RECIPE_CONSUMER,
                              path=path)
 
         return root_node
 
-    def _load_root_direct_reference(self, reference, profile,
+    def _load_root_direct_reference(self, reference, profile_build, profile_host,
                                     is_build_require, require_overrides):
         """ When a full reference is provided:
         install|info|graph <ref> or export-pkg .
         :return a VIRTUAL root_node with a conanfile that requires the reference
         """
-        conanfile = self._loader.load_virtual([reference], profile,
+        conanfile = self._loader.load_virtual([reference],
                                               is_build_require=is_build_require,
                                               require_overrides=require_overrides)
+        virtual_definer(conanfile, profile_host)
         root_node = Node(ref=None, conanfile=conanfile, context=CONTEXT_HOST, recipe=RECIPE_VIRTUAL)
         return root_node
 
-    def _load_root_test_package(self, path, create_reference, graph_lock, profile,
+    def _load_root_test_package(self, path, profile_build, profile_host, create_reference,
                                 require_overrides):
         """ when a test_package/conanfile.py is provided, together with the reference that is
         being created and need to be tested
@@ -154,10 +166,12 @@ class GraphManager(object):
         """
         test = str(create_reference)
         # do not try apply lock_python_requires for test_package/conanfile.py consumer
-        conanfile = self._loader.load_consumer(path, profile, user=create_reference.user,
+        conanfile = self._loader.load_consumer(path, user=create_reference.user,
                                                channel=create_reference.channel,
                                                require_overrides=require_overrides
                                                )
+        initialize_conanfile_profile(conanfile, profile_build, profile_host, CONTEXT_HOST,
+                                     False)
         conanfile.display_name = "%s (test package)" % str(test)
         conanfile.output.scope = conanfile.display_name
 

--- a/conans/client/graph/profile_node_definer.py
+++ b/conans/client/graph/profile_node_definer.py
@@ -1,7 +1,7 @@
 import fnmatch
 
 from conans.client import settings_preprocessor
-from conans.client.graph.graph import CONTEXT_HOST
+from conans.client.graph.graph import CONTEXT_HOST, CONTEXT_BUILD
 from conans.errors import ConanException
 
 
@@ -60,7 +60,7 @@ def initialize_conanfile_profile(conanfile, profile_build, profile_host, base_co
     # build(gcc) -(r)-> build(openssl/zlib) => settings_host=profile_build, settings_target=None
     # build(gcc) -(br)-> build(gcc) => settings_host=profile_build, settings_target=profile_build
     # profile host
-    profile = profile_build if build_require else profile_host
+    profile = profile_build if build_require or base_context == CONTEXT_BUILD else profile_host
     _initialize_conanfile(conanfile, profile, ref)
     # profile build
     conanfile.settings_build = profile_build.processed_settings.copy()

--- a/conans/client/graph/profile_node_definer.py
+++ b/conans/client/graph/profile_node_definer.py
@@ -5,6 +5,39 @@ from conans.client.graph.graph import CONTEXT_HOST, CONTEXT_BUILD
 from conans.errors import ConanException
 
 
+def initialize_conanfile_profile(conanfile, profile_build, profile_host, base_context,
+                                 is_build_require, ref=None):
+    """ this function fills conanfile information with the profile informaiton
+    It is called for:
+        - computing the root_node
+           - GraphManager.load_consumer_conanfile, for "conan source" command
+           - GraphManager._load_root_consumer for "conan install <path to conanfile>
+           - GraphManager._load_root_test_package for "conan create ." with test_package folder
+        - computing each graph node:
+            GraphBuilder->create_new_node
+    """
+    # NOTE: Need the context, as conanfile.context NOT defined yet
+
+    # settings_build=profile_build ALWAYS
+    # host -(r)-> host => settings_host=profile_host, settings_target=None
+    # host -(br)-> build => settings_host=profile_build, settings_target=profile_host
+    # build(gcc) -(r)-> build(openssl/zlib) => settings_host=profile_build, settings_target=None
+    # build(gcc) -(br)-> build(gcc) => settings_host=profile_build, settings_target=profile_build
+    # profile host
+    profile = profile_build if is_build_require or base_context == CONTEXT_BUILD else profile_host
+    _initialize_conanfile(conanfile, profile, ref)
+    # profile build
+    conanfile.settings_build = profile_build.processed_settings.copy()
+    # profile target
+    conanfile.settings_target = None
+    if base_context == CONTEXT_HOST:
+        if is_build_require:
+            conanfile.settings_target = profile_host.processed_settings.copy()
+    else:
+        if not is_build_require:
+            conanfile.settings_target = profile_build.processed_settings.copy()
+
+
 def _initialize_conanfile(conanfile, profile, ref):
     # Prepare the settings for the loaded conanfile
     # Mixing the global settings with the specified for that name if exist
@@ -45,52 +78,31 @@ def _initialize_conanfile(conanfile, profile, ref):
             conanfile.display_name, str(e)))
     conanfile.settings = tmp_settings
     conanfile._conan_buildenv = profile.buildenv
-    conanfile.conf = profile.conf.get_conanfile_conf(ref_str)
-
-
-
-def initialize_conanfile_profile(conanfile, profile_build, profile_host, base_context,
-                                 build_require, ref=None):
-    # NOTE: Need the context, as conanfile.context NOT defined yet
-    # graph_builder _create_new_node
-    # If there is a context_switch, it is because it is a BR-build
-    # Assign the profiles depending on the context
-    #
-    # settings_build=profile_build ALWAYS
-    # host -(r)-> host => settings_host=profile_host, settings_target=None
-    # host -(br)-> build => settings_host=profile_build, settings_target=profile_host
-    # build(gcc) -(r)-> build(openssl/zlib) => settings_host=profile_build, settings_target=None
-    # build(gcc) -(br)-> build(gcc) => settings_host=profile_build, settings_target=profile_build
-    # profile host
-    profile = profile_build if build_require or base_context == CONTEXT_BUILD else profile_host
-    _initialize_conanfile(conanfile, profile, ref)
-    # profile build
-    conanfile.settings_build = profile_build.processed_settings.copy()
-    # profile target
-    conanfile.settings_target = None
-    if base_context == CONTEXT_HOST:
-        if build_require:
-            conanfile.settings_target = profile_host.processed_settings.copy()
-    else:
-        if not build_require:
-            conanfile.settings_target = profile_build.processed_settings.copy()
+    conanfile.conf = profile.conf.get_conanfile_conf(ref_str)  # Maybe this can be done lazy too
 
 
 def txt_definer(conanfile, profile_host):
+    """ conanfile.txt does not declare settings, but it assumes it uses all the profile settings
+    These settings are very necessary for helpers like generators to produce the right output
+    """
     tmp_settings = profile_host.processed_settings.copy()
     package_settings_values = profile_host.package_settings_values
+    # TODO: The pattern-matching for pkg, buildenv and conf needs to be extracted too
     if "&" in package_settings_values:
         pkg_settings = package_settings_values.get("&")
         if pkg_settings:
             tmp_settings.update_values(pkg_settings)
-    tmp_settings._unconstrained = True  # TODO: Remove unconstrained, probably not necesary anymore
     conanfile.settings = tmp_settings
     conanfile._conan_buildenv = profile_host.buildenv
     conanfile.conf = profile_host.conf.get_conanfile_conf(None)
 
 
 def virtual_definer(conanfile, profile_host):
+    """ virtual does not declare settings, but it assumes it uses all the profile settings
+    These settings are very necessary for helpers like generators to produce the right output
+    """
     tmp_settings = profile_host.processed_settings.copy()
+    # TODO: Maybe "if "&" in package_settings_values": is necessary here too?
     conanfile.settings = tmp_settings
     conanfile._conan_buildenv = profile_host.buildenv
     conanfile.conf = profile_host.conf.get_conanfile_conf(None)

--- a/conans/client/graph/profile_node_definer.py
+++ b/conans/client/graph/profile_node_definer.py
@@ -8,6 +8,9 @@ from conans.errors import ConanException
 def _initialize_conanfile(conanfile, profile, ref):
     # Prepare the settings for the loaded conanfile
     # Mixing the global settings with the specified for that name if exist
+    if profile.dev_reference and profile.dev_reference == ref:
+        conanfile.develop = True
+
     tmp_settings = profile.processed_settings.copy()
     package_settings_values = profile.package_settings_values
     if conanfile.user is not None:
@@ -43,8 +46,7 @@ def _initialize_conanfile(conanfile, profile, ref):
     conanfile.settings = tmp_settings
     conanfile._conan_buildenv = profile.buildenv
     conanfile.conf = profile.conf.get_conanfile_conf(ref_str)
-    if profile.dev_reference and profile.dev_reference == ref:
-        conanfile.develop = True
+
 
 
 def initialize_conanfile_profile(conanfile, profile_build, profile_host, base_context,

--- a/conans/client/graph/profile_node_definer.py
+++ b/conans/client/graph/profile_node_definer.py
@@ -1,0 +1,94 @@
+import fnmatch
+
+from conans.client import settings_preprocessor
+from conans.client.graph.graph import CONTEXT_HOST
+from conans.errors import ConanException
+
+
+def _initialize_conanfile(conanfile, profile, ref):
+    # Prepare the settings for the loaded conanfile
+    # Mixing the global settings with the specified for that name if exist
+    tmp_settings = profile.processed_settings.copy()
+    package_settings_values = profile.package_settings_values
+    if conanfile.user is not None:
+        ref_str = "%s/%s@%s/%s" % (conanfile.name, conanfile.version,
+                                   conanfile.user, conanfile.channel)
+    else:
+        ref_str = "%s/%s" % (conanfile.name, conanfile.version)
+    if package_settings_values:
+        # First, try to get a match directly by name (without needing *)
+        # TODO: Conan 2.0: We probably want to remove this, and leave a pure fnmatch
+        pkg_settings = package_settings_values.get(conanfile.name)
+
+        if conanfile.develop and "&" in package_settings_values:
+            # "&" overrides the "name" scoped settings.
+            pkg_settings = package_settings_values.get("&")
+
+        if pkg_settings is None:  # If there is not exact match by package name, do fnmatch
+            for pattern, settings in package_settings_values.items():
+                if fnmatch.fnmatchcase(ref_str, pattern):
+                    pkg_settings = settings
+                    # TODO: Conan 2.0 won't stop at first match
+                    break
+        if pkg_settings:
+            tmp_settings.update_values(pkg_settings)
+            # if the global settings are composed with per-package settings, need to preprocess
+            settings_preprocessor.preprocess(tmp_settings)
+
+    try:
+        tmp_settings.constrained(conanfile.settings)
+    except Exception as e:
+        raise ConanException("The recipe %s is constraining settings. %s" % (
+            conanfile.display_name, str(e)))
+    conanfile.settings = tmp_settings
+    conanfile._conan_buildenv = profile.buildenv
+    conanfile.conf = profile.conf.get_conanfile_conf(ref_str)
+    if profile.dev_reference and profile.dev_reference == ref:
+        conanfile.develop = True
+
+
+def initialize_conanfile_profile(conanfile, profile_build, profile_host, base_context,
+                                 build_require, ref=None):
+    # NOTE: Need the context, as conanfile.context NOT defined yet
+    # graph_builder _create_new_node
+    # If there is a context_switch, it is because it is a BR-build
+    # Assign the profiles depending on the context
+    #
+    # settings_build=profile_build ALWAYS
+    # host -(r)-> host => settings_host=profile_host, settings_target=None
+    # host -(br)-> build => settings_host=profile_build, settings_target=profile_host
+    # build(gcc) -(r)-> build(openssl/zlib) => settings_host=profile_build, settings_target=None
+    # build(gcc) -(br)-> build(gcc) => settings_host=profile_build, settings_target=profile_build
+    # profile host
+    profile = profile_build if build_require else profile_host
+    _initialize_conanfile(conanfile, profile, ref)
+    # profile build
+    conanfile.settings_build = profile_build.processed_settings.copy()
+    # profile target
+    conanfile.settings_target = None
+    if base_context == CONTEXT_HOST:
+        if build_require:
+            conanfile.settings_target = profile_host.processed_settings.copy()
+    else:
+        if not build_require:
+            conanfile.settings_target = profile_build.processed_settings.copy()
+
+
+def txt_definer(conanfile, profile_host):
+    tmp_settings = profile_host.processed_settings.copy()
+    package_settings_values = profile_host.package_settings_values
+    if "&" in package_settings_values:
+        pkg_settings = package_settings_values.get("&")
+        if pkg_settings:
+            tmp_settings.update_values(pkg_settings)
+    tmp_settings._unconstrained = True  # TODO: Remove unconstrained, probably not necesary anymore
+    conanfile.settings = tmp_settings
+    conanfile._conan_buildenv = profile_host.buildenv
+    conanfile.conf = profile_host.conf.get_conanfile_conf(None)
+
+
+def virtual_definer(conanfile, profile_host):
+    tmp_settings = profile_host.processed_settings.copy()
+    conanfile.settings = tmp_settings
+    conanfile._conan_buildenv = profile_host.buildenv
+    conanfile.conf = profile_host.conf.get_conanfile_conf(None)

--- a/conans/client/installer.py
+++ b/conans/client/installer.py
@@ -282,6 +282,8 @@ class BinaryInstaller(object):
             app.loader.load_generators(generator_path)
 
     def install(self, deps_graph, build_mode):
+        # build_mode is needed exclusively because the package_revision_mode requiring
+        # re-evaluating binaries
         assert not deps_graph.error, "This graph cannot be installed: {}".format(deps_graph)
 
         self._out.info("\nInstalling (downloading, building) binaries...")

--- a/conans/client/loader.py
+++ b/conans/client/loader.py
@@ -18,11 +18,10 @@ from conans.paths import DATA_YML
 from conans.util.files import load
 
 
-class ConanFileLoader(object):
+class ConanFileLoader:
 
-    def __init__(self, runner,  pyreq_loader=None, requester=None):
+    def __init__(self, runner, pyreq_loader=None, requester=None):
         self._runner = runner
-
         self._pyreq_loader = pyreq_loader
         self._cached_conanfile_classes = {}
         self._requester = requester
@@ -47,7 +46,6 @@ class ConanFileLoader(object):
         try:
             module, conanfile = parse_conanfile(conanfile_path)
 
-            # This is the new py_requires feature, to supersede the old python_requires
             if self._pyreq_loader:
                 self._pyreq_loader.load_py_requires(conanfile, self, graph_lock)
 
@@ -150,8 +148,7 @@ class ConanFileLoader(object):
     def load_export(self, conanfile_path, name, version, user, channel, graph_lock=None):
         """ loads the conanfile and evaluates its name, version, and enforce its existence
         """
-        conanfile = self.load_named(conanfile_path, name, version, user, channel,
-                                    graph_lock)
+        conanfile = self.load_named(conanfile_path, name, version, user, channel, graph_lock)
         if not conanfile.name:
             raise ConanException("conanfile didn't specify name")
         if not conanfile.version:
@@ -166,8 +163,7 @@ class ConanFileLoader(object):
                       channel=None, graph_lock=None, require_overrides=None):
         """ loads a conanfile.py in user space. Might have name/version or not
         """
-        conanfile = self.load_named(conanfile_path, name, version, user, channel,
-                                    graph_lock)
+        conanfile = self.load_named(conanfile_path, name, version, user, channel, graph_lock)
 
         ref = RecipeReference(conanfile.name, conanfile.version, user, channel)
         if str(ref):
@@ -186,8 +182,6 @@ class ConanFileLoader(object):
                     conanfile.requires.override(req_override)
 
             return conanfile
-        except ConanInvalidConfiguration:
-            raise
         except Exception as e:  # re-raise with file name
             raise ConanException("%s: %s" % (conanfile_path, str(e)))
 
@@ -209,8 +203,6 @@ class ConanFileLoader(object):
         try:
             conanfile.initialize()
             return conanfile
-        except ConanInvalidConfiguration:
-            raise
         except Exception as e:  # re-raise with file name
             raise ConanException("%s: %s" % (conanfile_path, str(e)))
 

--- a/conans/client/loader.py
+++ b/conans/client/loader.py
@@ -228,8 +228,6 @@ class ConanFileLoader(object):
                 req_override = RecipeReference.loads(req_override)
                 conanfile.requires.override(req_override)
 
-        conanfile.initialize()
-
         return conanfile
 
     def _parse_conan_txt(self, contents, path, display_name):

--- a/conans/model/conan_file.py
+++ b/conans/model/conan_file.py
@@ -4,7 +4,7 @@ import platform
 from conan.tools.env import Environment
 from conan.tools.env.environment import environment_wrap_command
 from conans.cli.output import ConanOutput, ScopedOutput
-from conans.errors import ConanException, ConanInvalidConfiguration
+from conans.errors import ConanException
 from conans.model.conf import Conf
 from conans.model.dependencies import ConanFileDependencies
 from conans.model.layout import Folders, Infos
@@ -133,17 +133,10 @@ class ConanFile:
             self._conan_buildenv = self._conan_buildenv.get_profile_env(ref_str)
         return self._conan_buildenv
 
-    def initialize(self, settings, buildenv=None):
+    def initialize(self):
         # If we move this to constructor, the python_require inheritance in init fails
         # and "conan inspect" also breaks
         self.options = Options(self.options or {}, self.default_options)
-        self._conan_buildenv = buildenv
-        try:
-            settings.constrained(self.settings)
-        except Exception as e:
-            raise ConanInvalidConfiguration("The recipe %s is constraining settings. %s" % (
-                self.display_name, str(e)))
-        self.settings = settings
 
     @property
     def cpp_info(self):

--- a/conans/model/settings.py
+++ b/conans/model/settings.py
@@ -153,7 +153,6 @@ class Settings(object):
         self._parent_value = parent_value  # gcc, x86
         self._data = {str(k): SettingsItem(v, "%s.%s" % (name, k))
                       for k, v in definition.items()}
-        self._unconstrained = False
 
     def get_safe(self, name, default=None):
         try:
@@ -255,9 +254,6 @@ class Settings(object):
            No additions allowed
         2. If the other defines {"compiler": None} means to keep the full specification
         """
-        if self._unconstrained:
-            return
-
         constraint_def = constraint_def or []
         if not isinstance(constraint_def, (list, tuple, set)):
             raise ConanException("Please defines settings as a list or tuple")

--- a/conans/test/unittests/client/conanfile_loader_test.py
+++ b/conans/test/unittests/client/conanfile_loader_test.py
@@ -40,43 +40,8 @@ class BasePackage(ConanFile):
         conan_file = loader.load_basic(conanfile_path)
         self.assertEqual(conan_file.short_paths, True)
 
-        result = loader.load_consumer(conanfile_path, profile_host=create_profile())
+        result = loader.load_consumer(conanfile_path)
         self.assertEqual(result.short_paths, True)
-
-    def test_package_settings(self):
-        # CREATE A CONANFILE TO LOAD
-        tmp_dir = temp_folder()
-        conanfile_path = os.path.join(tmp_dir, "conanfile.py")
-        conanfile = """from conans import ConanFile
-class MyTest(ConanFile):
-    requires = {}
-    name = "MyPackage"
-    version = "1.0"
-    settings = "os"
-"""
-        save(conanfile_path, conanfile)
-
-        # Apply windows for MyPackage
-        profile = Profile()
-        profile.processed_settings = Settings({"os": ["Windows", "Linux"]})
-        profile.package_settings = {"MyPackage": OrderedDict([("os", "Windows")])}
-        loader = ConanFileLoader(None)
-        recipe = loader.load_consumer(conanfile_path, profile)
-        self.assertEqual(recipe.settings.os, "Windows")
-
-        # Apply Linux for MyPackage
-        profile = Profile()
-        profile.processed_settings = Settings({"os": ["Windows", "Linux"]})
-        profile.package_settings = {"MyPackage": OrderedDict([("os", "Linux")])}
-        recipe = loader.load_consumer(conanfile_path, profile)
-        self.assertEqual(recipe.settings.os, "Linux")
-
-        # If the package name is different from the conanfile one, it wont apply
-        profile = Profile()
-        profile.processed_settings = Settings({"os": ["Windows", "Linux"]})
-        profile.package_settings = {"OtherPACKAGE": OrderedDict([("os", "Linux")])}
-        recipe = loader.load_consumer(conanfile_path, profile)
-        self.assertIsNone(recipe.settings.os.value)
 
 
 class ConanLoaderTxtTest(unittest.TestCase):
@@ -206,7 +171,7 @@ licenses, * -> ./licenses @ root_package=Pkg, folder=True, ignore_case=False, ex
         file_path = os.path.join(tmp_dir, "file.txt")
         save(file_path, file_content)
         loader = ConanFileLoader(None, None)
-        ret = loader.load_conanfile_txt(file_path, create_profile())
+        ret = loader.load_conanfile_txt(file_path)
 
         ret.copy = Mock()
         ret.imports()
@@ -230,7 +195,7 @@ licenses, * -> ./licenses @ root_package=Pkg, folder=True, ignore_case=False, ex
         with self.assertRaisesRegex(ConanException,
                                    r"Error while parsing \[options\] in conanfile\n"
                                    "Options should be specified as 'pkg:option=value'"):
-            loader.load_conanfile_txt(file_path, create_profile())
+            loader.load_conanfile_txt(file_path)
 
 
 class ImportModuleLoaderTest(unittest.TestCase):

--- a/conans/test/unittests/model/conanfile_test.py
+++ b/conans/test/unittests/model/conanfile_test.py
@@ -12,7 +12,7 @@ class ConanFileTest(unittest.TestCase):
                 self.assertTrue(member.startswith('_conan'))
 
         conanfile = ConanFile(None)
-        conanfile.initialize(Settings())
+        conanfile.initialize()
 
         for member in vars(conanfile):
             if member.startswith('_') and not member.startswith("__"):

--- a/conans/test/unittests/tools/cmake/test_cmakedeps.py
+++ b/conans/test/unittests/tools/cmake/test_cmakedeps.py
@@ -15,10 +15,11 @@ def test_cpp_info_name_cmakedeps():
     conanfile._conan_node = Mock()
     conanfile._conan_node.context = "host"
     conanfile.settings = "os", "compiler", "build_type", "arch"
-    conanfile.initialize(Settings({"os": ["Windows"],
+    conanfile.initialize()
+    conanfile.settings = Settings({"os": ["Windows"],
                                    "compiler": ["gcc"],
                                    "build_type": ["Release"],
-                                   "arch": ["x86"]}))
+                                   "arch": ["x86"]})
     conanfile.settings.build_type = "Release"
     conanfile.settings.arch = "x86"
 
@@ -50,10 +51,11 @@ def test_cpp_info_name_cmakedeps_components():
     conanfile._conan_node = Mock()
     conanfile._conan_node.context = "host"
     conanfile.settings = "os", "compiler", "build_type", "arch"
-    conanfile.initialize(Settings({"os": ["Windows"],
+    conanfile.initialize()
+    conanfile.settings = Settings({"os": ["Windows"],
                                    "compiler": ["gcc"],
                                    "build_type": ["Release", "Debug"],
-                                   "arch": ["x86", "x64"]}))
+                                   "arch": ["x86", "x64"]})
     conanfile.settings.build_type = "Debug"
     conanfile.settings.arch = "x64"
 
@@ -91,10 +93,11 @@ def test_cmake_deps_links_flags():
     conanfile._conan_node = Mock()
     conanfile._conan_node.context = "host"
     conanfile.settings = "os", "compiler", "build_type", "arch"
-    conanfile.initialize(Settings({"os": ["Windows"],
+    conanfile.initialize()
+    conanfile.settings = Settings({"os": ["Windows"],
                                    "compiler": ["gcc"],
                                    "build_type": ["Release"],
-                                   "arch": ["x86"]}))
+                                   "arch": ["x86"]})
     conanfile.settings.build_type = "Release"
     conanfile.settings.arch = "x86"
 
@@ -131,10 +134,11 @@ def test_component_name_same_package():
     conanfile._conan_node = Mock()
     conanfile._conan_node.context = "host"
     conanfile.settings = "os", "compiler", "build_type", "arch"
-    conanfile.initialize(Settings({"os": ["Windows"],
+    conanfile.initialize()
+    conanfile.settings = Settings({"os": ["Windows"],
                                    "compiler": ["gcc"],
                                    "build_type": ["Release"],
-                                   "arch": ["x86"]}))
+                                   "arch": ["x86"]})
     conanfile.settings.build_type = "Release"
     conanfile.settings.arch = "x86"
 

--- a/conans/test/unittests/tools/cmake/test_cmaketoolchain.py
+++ b/conans/test/unittests/tools/cmake/test_cmaketoolchain.py
@@ -15,10 +15,12 @@ from conans.model.settings import Settings
 def conanfile():
     c = ConanFile(None)
     c.settings = "os", "compiler", "build_type", "arch"
-    c.initialize(Settings({"os": ["Windows"],
+    c.initialize()
+    settings = Settings({"os": ["Windows"],
                            "compiler": {"gcc": {"libcxx": ["libstdc++"]}},
                            "build_type": ["Release"],
-                           "arch": ["x86"]}))
+                           "arch": ["x86"]})
+    c.settings = settings
     c.settings.build_type = "Release"
     c.settings.arch = "x86"
     c.settings.compiler = "gcc"
@@ -149,10 +151,11 @@ def test_user_toolchain(conanfile):
 def conanfile_apple():
     c = ConanFile(None)
     c.settings = "os", "compiler", "build_type", "arch"
-    c.initialize(Settings({"os": {"Macos": {"version": ["10.15"]}},
+    c.initialize()
+    c.settings = Settings({"os": {"Macos": {"version": ["10.15"]}},
                            "compiler": {"apple-clang": {"libcxx": ["libc++"]}},
                            "build_type": ["Release"],
-                           "arch": ["x86"]}))
+                           "arch": ["x86"]})
     c.settings.build_type = "Release"
     c.settings.arch = "x86"
     c.settings.compiler = "apple-clang"
@@ -178,10 +181,11 @@ def test_osx_deployment_target(conanfile_apple):
 def conanfile_msvc():
     c = ConanFile(None)
     c.settings = "os", "compiler", "build_type", "arch"
-    c.initialize(Settings({"os": ["Windows"],
+    c.initialize()
+    c.settings = Settings({"os": ["Windows"],
                            "compiler": {"msvc": {"version": ["19.3X"], "cppstd": ["20"]}},
                            "build_type": ["Release"],
-                           "arch": ["x86"]}))
+                           "arch": ["x86"]})
     c.settings.build_type = "Release"
     c.settings.arch = "x86"
     c.settings.compiler = "msvc"
@@ -207,10 +211,11 @@ def test_toolset(conanfile_msvc):
 def conanfile_linux():
     c = ConanFile(Mock(), None)
     c.settings = "os", "compiler", "build_type", "arch"
-    c.initialize(Settings({"os": ["Linux"],
+    c.initialize()
+    c.settings = Settings({"os": ["Linux"],
                            "compiler": {"gcc": {"version": ["11"], "cppstd": ["20"]}},
                            "build_type": ["Release"],
-                           "arch": ["x86_64"]}))
+                           "arch": ["x86_64"]})
     c.settings.build_type = "Release"
     c.settings.arch = "x86_64"
     c.settings.compiler = "gcc"
@@ -241,10 +246,11 @@ def conanfile_linux_shared():
         "shared": [True, False],
     }
     c.default_options = {"fPIC": False, "shared": True, }
-    c.initialize(Settings({"os": ["Linux"],
+    c.initialize()
+    c.settings = Settings({"os": ["Linux"],
                            "compiler": {"gcc": {"version": ["11"], "cppstd": ["20"]}},
                            "build_type": ["Release"],
-                           "arch": ["x86_64"]}))
+                           "arch": ["x86_64"]})
     c.settings.build_type = "Release"
     c.settings.arch = "x86_64"
     c.settings.compiler = "gcc"
@@ -282,10 +288,11 @@ def conanfile_windows_fpic():
     c.settings = "os", "compiler", "build_type", "arch"
     c.options = {"fPIC": [True, False], }
     c.default_options = {"fPIC": True, }
-    c.initialize(Settings({"os": ["Windows"],
+    c.initialize()
+    c.settings = Settings({"os": ["Windows"],
                            "compiler": {"gcc": {"libcxx": ["libstdc++"]}},
                            "build_type": ["Release"],
-                           "arch": ["x86"]}))
+                           "arch": ["x86"]})
     c.settings.build_type = "Release"
     c.settings.arch = "x86"
     c.settings.compiler = "gcc"
@@ -312,10 +319,11 @@ def conanfile_linux_fpic():
     c.settings = "os", "compiler", "build_type", "arch"
     c.options = {"fPIC": [True, False], }
     c.default_options = {"fPIC": False, }
-    c.initialize(Settings({"os": ["Linux"],
+    c.initialize()
+    c.settings = Settings({"os": ["Linux"],
                            "compiler": {"gcc": {"version": ["11"], "cppstd": ["20"]}},
                            "build_type": ["Release"],
-                           "arch": ["x86_64"]}))
+                           "arch": ["x86_64"]})
     c.settings.build_type = "Release"
     c.settings.arch = "x86_64"
     c.settings.compiler = "gcc"

--- a/conans/test/unittests/tools/files_patch_test.py
+++ b/conans/test/unittests/tools/files_patch_test.py
@@ -270,7 +270,7 @@ Just the wind that smells fresh before the storm."""), foo_content)
 
     def _build_and_check(self, tmp_dir, file_path, text_file, msg):
         loader = ConanFileLoader(None)
-        ret = loader.load_consumer(file_path, create_profile())
+        ret = loader.load_consumer(file_path)
         curdir = os.path.abspath(os.curdir)
         os.chdir(tmp_dir)
         try:

--- a/conans/test/unittests/tools/microsoft/test_msbuild.py
+++ b/conans/test/unittests/tools/microsoft/test_msbuild.py
@@ -42,7 +42,8 @@ def test_msbuild_toolset():
                          "arch": ["x86_64"]})
     conanfile = ConanFile(None)
     conanfile.settings = "os", "compiler", "build_type", "arch"
-    conanfile.initialize(settings)
+    conanfile.initialize()
+    conanfile.settings = settings
     conanfile.settings.build_type = "Release"
     conanfile.settings.compiler = "msvc"
     conanfile.settings.compiler.version = "19.3"
@@ -59,14 +60,14 @@ def test_msbuild_toolset():
     ("classic", "Intel C++ Compiler 19.2")
 ])
 def test_msbuild_toolset_for_intel_cc(mode, expected_toolset):
-    settings = Settings({"build_type": ["Release"],
+    conanfile = ConanFile(Mock(), None)
+    conanfile.settings = "os", "compiler", "build_type", "arch"
+    conanfile.initialize()
+    conanfile.settings = Settings({"build_type": ["Release"],
                          "compiler": {"intel-cc": {"version": ["2021.3"], "mode": [mode]},
                                       "msvc": {"version": ["19.3"], "cppstd": ["20"]}},
                          "os": ["Windows"],
                          "arch": ["x86_64"]})
-    conanfile = ConanFile(Mock(), None)
-    conanfile.settings = "os", "compiler", "build_type", "arch"
-    conanfile.initialize(settings)
     conanfile.settings.build_type = "Release"
     conanfile.settings.compiler = "intel-cc"
     conanfile.settings.compiler.version = "2021.3"
@@ -80,19 +81,18 @@ def test_msbuild_toolset_for_intel_cc(mode, expected_toolset):
 
 def test_msbuild_standard():
     test_folder = temp_folder()
-
-    settings = Settings({"build_type": ["Release"],
-                         "compiler": {"msvc": {"version": ["19.3"], "cppstd": ["20"]}},
-                         "os": ["Windows"],
-                         "arch": ["x86_64"]})
     conanfile = ConanFile(Mock(), None)
     conanfile.folders.set_base_generators(test_folder)
     conanfile.install_folder = test_folder
     conanfile.conf = Conf()
     conanfile.conf["tools.microsoft.msbuild:installation_path"] = "."
     conanfile.settings = "os", "compiler", "build_type", "arch"
-    conanfile.settings_build = settings
-    conanfile.initialize(settings)
+    conanfile.initialize()
+    conanfile.settings = Settings({"build_type": ["Release"],
+                         "compiler": {"msvc": {"version": ["19.3"], "cppstd": ["20"]}},
+                         "os": ["Windows"],
+                         "arch": ["x86_64"]})
+    conanfile.settings_build = conanfile.settings
     conanfile.settings.build_type = "Release"
     conanfile.settings.compiler = "msvc"
     conanfile.settings.compiler.version = "19.3"
@@ -119,8 +119,9 @@ def test_resource_compile():
     conanfile.conf = Conf()
     conanfile.conf["tools.microsoft.msbuild:installation_path"] = "."
     conanfile.settings = "os", "compiler", "build_type", "arch"
+    conanfile.settings = settings
     conanfile.settings_build = settings
-    conanfile.initialize(settings)
+    conanfile.initialize()
     conanfile.settings.build_type = "Release"
     conanfile.settings.compiler = "msvc"
     conanfile.settings.compiler.version = "19.3"
@@ -162,7 +163,8 @@ def test_msbuild_and_intel_cc_props(mode, expected_toolset):
     conanfile.conf["tools.intel:installation_path"] = "my/intel/oneapi/path"
     conanfile.conf["tools.microsoft.msbuild:installation_path"] = "."
     conanfile.settings = "os", "compiler", "build_type", "arch"
-    conanfile.initialize(settings)
+    conanfile.initialize()
+    conanfile.settings = settings
     conanfile.settings.build_type = "Release"
     conanfile.settings.compiler = "intel-cc"
     conanfile.settings.compiler.version = "2021.3"


### PR DESCRIPTION
Should be pure refactor. Only some unittests changed because of internal interfaces changing.

The assignment of settings is done too inside the ``ConanFileLoader`` (when we only had 1 profile), but also in other places, making it very spread distributed and difficult to track. The pattern-matching of package-settings, and other profile => conanfile assignment is being centralized in one place.