### PR TITLE
Feature/develop2 relax options freeze

### DIFF
--- a/conans/model/options.py
+++ b/conans/model/options.py
@@ -87,8 +87,6 @@ class _PackageOptions:
 
     def clear(self):
         # for header_only() clearing
-        if self._freeze:
-            raise ConanException(f"Incorrect attempt to modify options.clear()")
         self._data.clear()
 
     def freeze(self):
@@ -128,8 +126,6 @@ class _PackageOptions:
 
     def __delattr__(self, field):
         assert field[0] != "_", "ERROR %s" % field
-        if self._freeze:
-            raise ConanException(f"Incorrect attempt to modify options '{field}'")
         self._ensure_exists(field)
         del self._data[field]
 
@@ -143,8 +139,10 @@ class _PackageOptions:
 
     def _set(self, item, value):
         # programmatic way to define values, for Conan codebase
-        if self._freeze:
-            raise ConanException(f"Incorrect attempt to modify options '{item}'")
+        current_value = self._data.get(item)
+        if self._freeze and current_value.value is not None and current_value != value:
+            raise ConanException(f"Incorrect attempt to modify option '{item}' "
+                                 f"from '{current_value}' to '{value}'")
         self._ensure_exists(item)
         self._data.setdefault(item, _PackageOption(item, None)).value = value
 

--- a/conans/model/options.py
+++ b/conans/model/options.py
@@ -126,6 +126,11 @@ class _PackageOptions:
 
     def __delattr__(self, field):
         assert field[0] != "_", "ERROR %s" % field
+        current_value = self._data.get(field)
+        if self._freeze and current_value.value is not None:
+            raise ConanException(f"Incorrect attempt to remove option '{field}' "
+                                 f"with current value '{current_value}'")
+
         self._ensure_exists(field)
         del self._data[field]
 
@@ -247,10 +252,7 @@ class Options:
         return setattr(self._package_options, attr, value)
 
     def __delattr__(self, field):
-        try:
-            self._package_options.__delattr__(field)
-        except ConanException:
-            pass
+        self._package_options.__delattr__(field)
 
     def __getitem__(self, item):
         # To access dependencies options like ``options["mydep"]``. This will no longer be

--- a/conans/test/unittests/model/options_test.py
+++ b/conans/test/unittests/model/options_test.py
@@ -92,12 +92,15 @@ class TestOptions:
         assert "Incorrect attempt to modify option 'static'" in str(e.value)
         assert "static=True" in self.sut.dumps()
 
-        # Removal of options might still be possible
-        del self.sut.static
-        assert "static" not in self.sut.dumps()
+        # Removal of options with values should rais
+        with pytest.raises(ConanException) as e:
+            del self.sut.static
+        assert "Incorrect attempt to remove option 'static'" in str(e.value)
+        assert "static" in self.sut.dumps()
 
         # Test None is possible to change
-        sut2 = Options({"static": [True, False]})
+        sut2 = Options({"static": [True, False],
+                        "other": [True, False]})
         sut2.freeze()
         sut2.static = True
         assert "static=True" in sut2.dumps()
@@ -105,6 +108,11 @@ class TestOptions:
         with pytest.raises(ConanException) as e:
             sut2.static = False
         assert "Incorrect attempt to modify option 'static'" in str(e.value)
+        assert "static=True" in sut2.dumps()
+
+        # can remove other, not assigned yet
+        del sut2.other
+        assert "other" not in sut2.dumps()
 
 
 class TestOptionsLoad:

--- a/conans/test/unittests/model/options_test.py
+++ b/conans/test/unittests/model/options_test.py
@@ -78,6 +78,34 @@ class TestOptions:
             static=True""")
         assert text == expected
 
+    def test_freeze(self):
+        assert self.sut.static
+
+        self.sut.freeze()
+        # Should be freezed now
+        # same value should not raise
+        self.sut.static = True
+
+        # Different value should raise
+        with pytest.raises(ConanException) as e:
+            self.sut.static = False
+        assert "Incorrect attempt to modify option 'static'" in str(e.value)
+        assert "static=True" in self.sut.dumps()
+
+        # Removal of options might still be possible
+        del self.sut.static
+        assert "static" not in self.sut.dumps()
+
+        # Test None is possible to change
+        sut2 = Options({"static": [True, False]})
+        sut2.freeze()
+        sut2.static = True
+        assert "static=True" in sut2.dumps()
+        # But not twice
+        with pytest.raises(ConanException) as e:
+            sut2.static = False
+        assert "Incorrect attempt to modify option 'static'" in str(e.value)
+
 
 class TestOptionsLoad:
     def test_load(self):
@@ -117,7 +145,7 @@ class TestOptionsPropagate:
         # Should be freezed now
         with pytest.raises(ConanException) as e:
             sut.static = True
-        assert "Incorrect attempt to modify options 'static'" in str(e.value)
+        assert "Incorrect attempt to modify option 'static'" in str(e.value)
 
         self_options, up_options = sut.get_upstream_options(down_options, ref)
         assert up_options.dumps() == "zlib:other=1"


### PR DESCRIPTION
Solve https://github.com/conan-io/conan/issues/10104#issuecomment-983499654

The current code in 2.0 seems to be too strict on the freezing on options values. The final goal is to make sure the values defined in the profiles always have priority over the ones defined in recipes. It is very bad that I declare ``boost:static=False`` in my profile and for some reason some recipe can decide to change it to ``boost:static=True``, without erroring. This is what is possible with Conan 1.X and we are trying to avoid here.

However, the current ``freeze`` seems to strict, and I am relaxing here to allow:
- Removing options that have not been assigned a value yet (``None`` value)
- Assigning values to options that have not been defined yet (``None`` value)
- 
This is an exploratory PR to discuss, lets see what makes sense