### PR TITLE
printing only 1 ref at missing binary message

### DIFF
--- a/conans/client/installer.py
+++ b/conans/client/installer.py
@@ -373,7 +373,7 @@ class BinaryInstaller(object):
             Or try to build locally from sources with '%s'
 
             More Info at 'https://docs.conan.io/en/latest/faq/troubleshooting.html#error-missing-prebuilt-package'
-            ''' % (missing_pkgs, missing_pkgs, build_str)))
+            ''' % (missing_pkgs, ref, build_str)))
 
     def _download(self, downloads, processed_package_refs):
         """ executes the download of packages (both download and update), only once for a given

--- a/conans/test/functional/only_source_test.py
+++ b/conans/test/functional/only_source_test.py
@@ -27,6 +27,8 @@ class OnlySourceTest(unittest.TestCase):
         # Will Fail because Hello0/0.0 and Hello1/1.1 has not built packages
         # and by default no packages are built
         client.run("create . lasote/stable", assert_error=True)
+        # Only 1 reference!
+        assert "Use 'conan search Hello0/0.0@lasote/stable --table=table.html" in client.out
         self.assertIn("Or try to build locally from sources with '--build=Hello0 --build=Hello1'", client.out)
 
         # We generate the package for Hello0/0.0


### PR DESCRIPTION
Changelog: Omit
Docs: Omit

Changes in https://github.com/conan-io/conan/pull/10089 can be confusing when more than 1 binary is missing. This should fix it.

Please review @abrousseau001 
