### PR TITLE
Feature - Add version method for git scm per #9396

### DIFF
--- a/conans/client/tools/scm.py
+++ b/conans/client/tools/scm.py
@@ -148,6 +148,13 @@ class Git(SCMBase):
     def _configure_ssl_verify(self):
         return "-c http.sslVerify=%s " % ("true" if self._verify_ssl else "false")
 
+    @property
+    def version(self):
+        if not hasattr(self, '_version'):
+            version = Git.get_version()
+            setattr(self, '_version', version)
+        return getattr(self, '_version')
+
     def run(self, command):
         command = self._configure_ssl_verify + command
         return super(Git, self).run(command)

--- a/conans/test/functional/scm/scm_test.py
+++ b/conans/test/functional/scm/scm_test.py
@@ -627,6 +627,10 @@ class ConanLib(ConanFile):
         content = load(exported_conanfile)
         self.assertIn(commit, content)
 
+    def test_git_version(self):
+        git = Git()
+        self.assertNotIn("Error retrieving git", git.version)
+
 
 @pytest.mark.tool_svn
 class SVNSCMTest(SVNLocalRepoTestCase):


### PR DESCRIPTION
Changelog: Feature: Add ``Git.version`` property to check the current git version, aligned with ``SVN.version``.
Docs: https://github.com/conan-io/docs/pull/2338

Implements feature request #9396 

This was left as just the entire return string instead of the major.minor.patch as was suggested by feature request to conform with what was already being done with the SVN side of things.

A simple test to check if the return of the version is not the ConanException error indicating the executable was missing from the path



- [x] Refer to the issue that supports this Pull Request.
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.

<sup>**Note:** By default this PR will skip the slower tests and will use a limited set of python versions. Check [here](https://github.com/conan-io/conan/blob/develop/.github/PR_INCREASE_TESTING.md) how to increase the testing level by writing some tags in the current PR body text.</sup>
