### PR TITLE
upgraded to importlib

### DIFF
--- a/conans/client/loader.py
+++ b/conans/client/loader.py
@@ -1,4 +1,4 @@
-import imp
+from importlib import machinery, invalidate_caches
 import inspect
 import os
 import sys
@@ -9,8 +9,7 @@ import yaml
 from conans.client.conf.required_version import validate_conan_version
 from conans.client.loader_txt import ConanFileTextLoader
 from conans.client.tools.files import chdir
-from conans.errors import ConanException, NotFoundException, ConanInvalidConfiguration, \
-    conanfile_exception_formatter
+from conans.errors import ConanException, NotFoundException, conanfile_exception_formatter
 from conans.model.conan_file import ConanFile
 from conans.model.options import Options
 from conans.model.recipe_ref import RecipeReference
@@ -25,6 +24,7 @@ class ConanFileLoader:
         self._pyreq_loader = pyreq_loader
         self._cached_conanfile_classes = {}
         self._requester = requester
+        invalidate_caches()
 
     def load_basic(self, conanfile_path, graph_lock=None, display=""):
         """ loads a conanfile basic object without evaluating anything
@@ -317,7 +317,7 @@ def _parse_conanfile(conan_file_path):
         with chdir(current_dir):
             old_dont_write_bytecode = sys.dont_write_bytecode
             sys.dont_write_bytecode = True
-            loaded = imp.load_source(module_id, conan_file_path)
+            loaded = machinery.SourceFileLoader(module_id, conan_file_path).load_module()
             sys.dont_write_bytecode = old_dont_write_bytecode
 
         required_conan_version = getattr(loaded, "required_conan_version", None)

--- a/conans/client/loader.py
+++ b/conans/client/loader.py
@@ -1,4 +1,4 @@
-from importlib import machinery, invalidate_caches
+from importlib import invalidate_caches, util
 import inspect
 import os
 import sys
@@ -317,7 +317,9 @@ def load_python_file(conan_file_path):
         with chdir(current_dir):
             old_dont_write_bytecode = sys.dont_write_bytecode
             sys.dont_write_bytecode = True
-            loaded = machinery.SourceFileLoader(module_id, conan_file_path).load_module()
+            spec = util.spec_from_file_location(module_id, conan_file_path)
+            loaded = util.module_from_spec(spec)
+            spec.loader.exec_module(loaded)
             sys.dont_write_bytecode = old_dont_write_bytecode
 
         required_conan_version = getattr(loaded, "required_conan_version", None)

--- a/conans/client/loader.py
+++ b/conans/client/loader.py
@@ -1,4 +1,4 @@
-from importlib import invalidate_caches, util
+from importlib import invalidate_caches, util as imp_util
 import inspect
 import os
 import sys
@@ -317,8 +317,8 @@ def load_python_file(conan_file_path):
         with chdir(current_dir):
             old_dont_write_bytecode = sys.dont_write_bytecode
             sys.dont_write_bytecode = True
-            spec = util.spec_from_file_location(module_id, conan_file_path)
-            loaded = util.module_from_spec(spec)
+            spec = imp_util.spec_from_file_location(module_id, conan_file_path)
+            loaded = imp_util.module_from_spec(spec)
             spec.loader.exec_module(loaded)
             sys.dont_write_bytecode = old_dont_write_bytecode
 

--- a/conans/client/loader.py
+++ b/conans/client/loader.py
@@ -83,7 +83,7 @@ class ConanFileLoader:
             to the provided generator list
             @param conanfile_module: the module to be processed
             """
-        conanfile_module, module_id = _parse_conanfile(conanfile_path)
+        conanfile_module, module_id = load_python_file(conanfile_path)
         for name, attr in conanfile_module.__dict__.items():
             if (name.startswith("_") or not inspect.isclass(attr) or
                     attr.__dict__.get("__module__") != module_id):
@@ -294,7 +294,7 @@ def _parse_module(conanfile_module, module_id):
 
 
 def parse_conanfile(conanfile_path):
-    module, filename = _parse_conanfile(conanfile_path)
+    module, filename = load_python_file(conanfile_path)
     try:
         conanfile = _parse_module(module, filename)
         return module, conanfile
@@ -302,7 +302,7 @@ def parse_conanfile(conanfile_path):
         raise ConanException("%s: %s" % (conanfile_path, str(e)))
 
 
-def _parse_conanfile(conan_file_path):
+def load_python_file(conan_file_path):
     """ From a given path, obtain the in memory python import module
     """
 

--- a/conans/test/unittests/client/conanfile_loader_test.py
+++ b/conans/test/unittests/client/conanfile_loader_test.py
@@ -2,19 +2,15 @@ import os
 import sys
 import textwrap
 import unittest
-from collections import OrderedDict
 
 import pytest
 from mock import Mock, call
 from parameterized import parameterized
 
-from conans.client.loader import ConanFileLoader, ConanFileTextLoader, _parse_conanfile
+from conans.client.loader import ConanFileLoader, ConanFileTextLoader, load_python_file
 from conans.client.tools.files import chdir
 from conans.errors import ConanException
 from conans.model.options import Options
-from conans.model.profile import Profile
-from conans.model.requires import Requirements
-from conans.model.settings import Settings
 from conans.test.utils.test_files import temp_folder
 from conans.test.utils.tools import create_profile
 from conans.util.files import save
@@ -234,7 +230,7 @@ class ImportModuleLoaderTest(unittest.TestCase):
                 save("__init__.py", "")
                 save("{}/__init__.py".format(subdir_name), "")
 
-        loaded, module_id = _parse_conanfile(os.path.join(tmp, "conanfile.py"))
+        loaded, module_id = load_python_file(os.path.join(tmp, "conanfile.py"))
         return loaded, module_id, expected_return
 
     @parameterized.expand([(True, False), (False, True), (False, False)])
@@ -288,8 +284,8 @@ def append(data):
 
         try:
             sys.path.append(temp)
-            loaded1, _ = _parse_conanfile(os.path.join(temp1, "conanfile.py"))
-            loaded2, _ = _parse_conanfile(os.path.join(temp2, "conanfile.py"))
+            loaded1, _ = load_python_file(os.path.join(temp1, "conanfile.py"))
+            loaded2, _ = load_python_file(os.path.join(temp2, "conanfile.py"))
             self.assertIs(loaded1.myconanlogger, loaded2.myconanlogger)
             self.assertIs(loaded1.myconanlogger.value, loaded2.myconanlogger.value)
         finally:


### PR DESCRIPTION
Includes the ``invalidate_caches()`` call

Close https://github.com/conan-io/conan/issues/4687
Close https://github.com/conan-io/conan/issues/3441
Close https://github.com/conan-io/conan/pull/6633

@Minimonium this should address previous concerns about python loading, note ``invalidate_caches()`` is called in the constructor of ``ConanFileLoader()``, a new one will be created with each ``ConanApp()`` which is now explicitly created inside each ``api`` call, so I'd say we are ok now.