### PR TITLE
removing warn of remotes file

### DIFF
--- a/conans/client/cache/remote_registry.py
+++ b/conans/client/cache/remote_registry.py
@@ -137,8 +137,6 @@ class RemoteRegistry(object):
 
     def initialize_remotes(self):
         if not os.path.exists(self._filename):
-            self._output.warning("Remotes registry file missing, "
-                                 "creating default one in %s" % self._filename)
             remotes = _Remotes()
             remote = Remote(CONAN_CENTER_REMOTE_NAME, "https://center.conan.io", True, False)
             remotes.add(remote)

--- a/conans/test/integration/command/search_test.py
+++ b/conans/test/integration/command/search_test.py
@@ -690,7 +690,6 @@ helloTest/1.4.10@myuser/stable""".format(remote)
         client = TestClient()
         os.remove(client.cache.remotes_path)
         client.run("search nonexist/1.0@lasote/stable -r=myremote", assert_error=True)
-        self.assertIn("WARN: Remotes registry file missing, creating default one", client.out)
         self.assertIn("ERROR: No remote 'myremote' defined in remotes", client.out)
 
     def test_search_json(self):
@@ -1099,7 +1098,6 @@ helloTest/1.4.10@myuser/stable""".format(remote)
         client = TestClient()
         os.remove(client.cache.remotes_path)
         client.run("search my_pkg")
-        self.assertIn("WARN: Remotes registry file missing, creating default one", client.out)
         self.assertIn("There are no packages matching the 'my_pkg' pattern", client.out)
 
 


### PR DESCRIPTION
This warning message is not very clear, not helpful, removing it. Was there some use case for this message?
