### PR TITLE
[bugfix] `AutotoolsToolchain` was not passing the `compiler` to `get_gnu_triplet`

### DIFF
--- a/conan/tools/gnu/autotoolstoolchain.py
+++ b/conan/tools/gnu/autotoolstoolchain.py
@@ -49,8 +49,9 @@ class AutotoolsToolchain:
         self.apple_min_version_flag = apple_min_version_flag(self._conanfile)
         if cross_building(self._conanfile):
             os_build, arch_build, os_host, arch_host = get_cross_building_settings(self._conanfile)
-            self._host = _get_gnu_triplet(os_host, arch_host)
-            self._build = _get_gnu_triplet(os_build, arch_build)
+            compiler = self._conanfile.settings.get_safe("compiler")
+            self._host = _get_gnu_triplet(os_host, arch_host, compiler=compiler)
+            self._build = _get_gnu_triplet(os_build, arch_build, compiler=compiler)
 
             # Apple Stuff
             if os_build == "Macos":

--- a/conans/test/unittests/tools/gnu/autotools_test.py
+++ b/conans/test/unittests/tools/gnu/autotools_test.py
@@ -1,5 +1,4 @@
 import os
-import textwrap
 
 from conan.tools.files import save_toolchain_args
 from conan.tools.gnu import Autotools

--- a/conans/test/unittests/tools/gnu/autotoolschain_test.py
+++ b/conans/test/unittests/tools/gnu/autotoolschain_test.py
@@ -1,0 +1,43 @@
+import pytest
+
+from conan.tools.gnu import AutotoolsToolchain
+from conans.errors import ConanException
+from conans.test.utils.mocks import ConanFileMock, MockSettings
+
+
+def test_get_gnu_triplet_for_cross_building():
+    """
+    Testing AutotoolsToolchain and _get_gnu_triplet() function in case of
+    having os=Windows and cross compiling
+    """
+    # Issue: https://github.com/conan-io/conan/issues/10139
+    settings = MockSettings({"build_type": "Release",
+                             "compiler": "gcc",
+                             "compiler.version": "10.2",
+                             "os": "Windows",
+                             "arch": "x86_64"})
+    conanfile = ConanFileMock()
+    conanfile.settings = settings
+    conanfile.settings_build = MockSettings({"os": "Solaris", "arch": "x86"})
+    autotoolschain = AutotoolsToolchain(conanfile)
+    assert autotoolschain._host == "x86_64-w64-mingw32"
+    assert autotoolschain._build == "i686-solaris"
+
+
+def test_get_gnu_triplet_for_cross_building_raise_error():
+    """
+    Testing AutotoolsToolchain and _get_gnu_triplet() function raises an error in case of
+    having os=Windows, cross compiling and not defined any compiler
+    """
+    # Issue: https://github.com/conan-io/conan/issues/10139
+    settings = MockSettings({"build_type": "Release",
+                             "os": "Windows",
+                             "arch": "x86_64"})
+    conanfile = ConanFileMock()
+    conanfile.settings = settings
+    conanfile.settings_build = MockSettings({"os": "Solaris", "arch": "x86"})
+    with pytest.raises(ConanException) as conan_error:
+        AutotoolsToolchain(conanfile)
+        msg = "'compiler' parameter for 'get_gnu_triplet()' is not specified and " \
+              "needed for os=Windows"
+        assert msg == str(conan_error.value)


### PR DESCRIPTION
Changelog: Bugfix: `AutotoolsToolchain` was not passing the `compiler` to `get_gnu_triplet` function.
Docs: omit

Closes: https://github.com/conan-io/conan/issues/10139

- [x] Refer to the issue that supports this Pull Request.
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 

<sup>**Note:** By default this PR will skip the slower tests and will use a limited set of python versions. Check [here](https://github.com/conan-io/conan/blob/develop/.github/PR_INCREASE_TESTING.md) how to increase the testing level by writing some tags in the current PR body text.</sup>
