### PR TITLE
simple upgrade to jinja v3

### DIFF
--- a/conans/requirements.txt
+++ b/conans/requirements.txt
@@ -10,5 +10,5 @@ node-semver==0.6.1
 distro>=1.0.2, <=1.6.0
 pygments>=2.0, <3.0
 tqdm>=4.28.1, <5
-Jinja2>=2.9, <3
+Jinja2>=2.9, <4.0.0
 python-dateutil>=2.7.0, <3


### PR DESCRIPTION
Changelog: Feature: Upgrade Conan python jinja requirement to v3.x.
Docs: omit
Fixes #9907 

- [x] Refer to the issue that supports this Pull Request.
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 

#tags: slow

Makes conan more compatible with other libs requiring `jinja` in the same environment. The major version bump seems to e mostly stemming from dropping py2 & 3.5 support, didn't see any other breaking change.