### PR TITLE
fixing error in deduce package_id_mode

### DIFF
--- a/conans/client/graph/compute_pid.py
+++ b/conans/client/graph/compute_pid.py
@@ -26,6 +26,8 @@ def compute_package_id(node, new_config):
     for require, transitive in node.transitive_deps.items():
         dep_package_id = require.package_id_mode
         dep_node = transitive.node
+        require.deduce_package_id_mode(node.conanfile.package_type,
+                                       dep_node.conanfile.package_type)
         if require.build:
             if dep_package_id:
                 req_info = RequirementInfo(dep_node.pref, dep_package_id)

--- a/conans/model/requires.py
+++ b/conans/model/requires.py
@@ -296,27 +296,25 @@ class Requirement:
             downstream_require.test = True
 
         downstream_require.direct = False
-
-        # If the requirement doesn't declare package_id, try to guess it with the types
-        package_id_mode = require.package_id_mode
-        if package_id_mode is None:
-            if require.headers or require.libs:  # linked
-                if pkg_type in (PackageType.SHARED, PackageType.APP):
-                    if dep_pkg_type is PackageType.SHARED:
-                        package_id_mode = "minor_mode"
-                    else:
-                        package_id_mode = "recipe_revision_mode"
-                elif pkg_type is PackageType.STATIC:
-                    if dep_pkg_type is PackageType.HEADER:
-                        package_id_mode = "recipe_revision_mode"
-                    else:
-                        package_id_mode = "minor_mode"
-                elif pkg_type is PackageType.HEADER:
-                    package_id_mode = "unrelated_mode"
-
-        downstream_require.package_id_mode = package_id_mode
-
         return downstream_require
+
+    def deduce_package_id_mode(self, pkg_type, dep_pkg_type):
+        # If the requirement doesn't declare package_id, try to guess it with the types
+        if self.package_id_mode is not None:
+            return
+
+        if self.headers or self.libs:  # only if linked
+            if pkg_type in (PackageType.SHARED, PackageType.APP):
+                if dep_pkg_type is PackageType.SHARED:
+                    self.package_id_mode = "minor_mode"
+                else:
+                    self.package_id_mode = "recipe_revision_mode"
+            elif pkg_type is PackageType.STATIC:
+                if dep_pkg_type is PackageType.HEADER:
+                    self.package_id_mode = "recipe_revision_mode"
+                else:
+                    self.package_id_mode = "minor_mode"
+            # HEADER-ONLY is automatically cleared in compute_package_id()
 
 
 class BuildRequirements:

--- a/conans/test/integration/graph/core/graph_manager_test.py
+++ b/conans/test/integration/graph/core/graph_manager_test.py
@@ -115,6 +115,9 @@ class TestLinear(GraphManagerTest):
         libb = app.dependencies[0].dst
         liba = libb.dependencies[0].dst
 
+        for r, t in libb.transitive_deps.items():
+            assert r.package_id_mode == "minor_mode"
+
         self._check_node(app, "app/0.1", deps=[libb])
         self._check_node(libb, "libb/0.1#123", deps=[liba], dependents=[app])
         self._check_node(liba, "liba/0.1#123", dependents=[libb])


### PR DESCRIPTION
The movement of the deduction of package_id_mode from ``compute_package_id()`` to graph builder step was broken, as it was not computing the relation for direct dependencies, only for propagated dependencies.

I have moved it back to the ``BinariesAnalyzer`` stage, as I couldn't find an intuitive place to do it while building the graph
