### PR TITLE
fixing definition of CXX11_ABI for gcc-like

### DIFF
--- a/conan/tools/cmake/toolchain.py
+++ b/conan/tools/cmake/toolchain.py
@@ -187,11 +187,9 @@ class GLibCXXBlock(Block):
                    }.get(libcxx)
             if lib:
                 lib = "-library={}".format(lib)
-        elif compiler == "gcc":
-            # we might want to remove this "1", it is the default in most distros
-            if libcxx == "libstdc++11":
-                glib = "1"
-            elif libcxx == "libstdc++":
+
+        if compiler in ['clang', 'apple-clang', 'gcc']:
+            if libcxx == "libstdc++":
                 glib = "0"
         return {"set_libcxx": lib, "glibcxx": glib}
 

--- a/conan/tools/cmake/toolchain.py
+++ b/conan/tools/cmake/toolchain.py
@@ -191,6 +191,8 @@ class GLibCXXBlock(Block):
         if compiler in ['clang', 'apple-clang', 'gcc']:
             if libcxx == "libstdc++":
                 glib = "0"
+            elif libcxx == "libstdc++11" and self._conanfile.conf["tools.gnu:define_libcxx11_abi"]:
+                glib = "1"
         return {"set_libcxx": lib, "glibcxx": glib}
 
 

--- a/conan/tools/gnu/autotoolstoolchain.py
+++ b/conan/tools/gnu/autotoolstoolchain.py
@@ -75,6 +75,8 @@ class AutotoolsToolchain:
         if compiler in ['clang', 'apple-clang', 'gcc']:
             if libcxx == 'libstdc++':
                 return '_GLIBCXX_USE_CXX11_ABI=0'
+            elif libcxx == "libstdc++11" and self._conanfile.conf["tools.gnu:define_libcxx11_abi"]:
+                return '_GLIBCXX_USE_CXX11_ABI=1'
 
     def _libcxx(self):
         settings = self._conanfile.settings

--- a/conan/tools/gnu/autotoolstoolchain.py
+++ b/conan/tools/gnu/autotoolstoolchain.py
@@ -72,7 +72,7 @@ class AutotoolsToolchain:
             return
 
         compiler = settings.get_safe("compiler.base") or settings.get_safe("compiler")
-        if compiler == "gcc":
+        if compiler in ['clang', 'apple-clang', 'gcc']:
             if libcxx == 'libstdc++':
                 return '_GLIBCXX_USE_CXX11_ABI=0'
 

--- a/conans/model/conf.py
+++ b/conans/model/conf.py
@@ -22,6 +22,7 @@ DEFAULT_CONFIGURATION = {
     "tools.files.download:retry": "Number of retries in case of failure when downloading",
     "tools.files.download:retry_wait": "Seconds to wait between download attempts",
     "tools.gnu:make_program": "Indicate path to make program",
+    "tools.gnu:define_libcxx11_abi": "Force definition of GLIBCXX_USE_CXX11_ABI=1 for libstdc++11",
     "tools.google.bazel:config": "Define Bazel config file",
     "tools.google.bazel:bazelrc_path": "Defines Bazel rc-path",
     "tools.microsoft.msbuild:verbosity": "Verbosity level for MSBuild: "

--- a/conans/test/functional/toolchains/cmake/test_cmake.py
+++ b/conans/test/functional/toolchains/cmake/test_cmake.py
@@ -352,8 +352,8 @@ class LinuxTest(Base):
 
         extensions_str = "ON" if "gnu" in cppstd else "OFF"
         arch_str = "-m32" if arch == "x86" else "-m64"
-        cxx11_abi_str = "1" if libcxx == "libstdc++11" else "0"
-        defines = '_GLIBCXX_USE_CXX11_ABI=%s;MYDEFINE="MYDEF_VALUE";MYDEFINEINT=42;'\
+        cxx11_abi_str = "_GLIBCXX_USE_CXX11_ABI=0;" if libcxx == "libstdc++" else ""
+        defines = '%sMYDEFINE="MYDEF_VALUE";MYDEFINEINT=42;'\
                   'MYDEFINE_CONFIG=$<IF:$<CONFIG:debug>,"MYDEF_DEBUG",$<IF:$<CONFIG:release>,'\
                   '"MYDEF_RELEASE","">>;MYDEFINEINT_CONFIG=$<IF:$<CONFIG:debug>,421,'\
                   '$<IF:$<CONFIG:release>,422,"">>' % cxx11_abi_str

--- a/conans/test/unittests/client/toolchain/autotools/autotools_toolchain_test.py
+++ b/conans/test/unittests/client/toolchain/autotools/autotools_toolchain_test.py
@@ -203,12 +203,23 @@ def test_cxx11_abi_define():
     be = AutotoolsToolchain(conanfile)
     env = be.vars()
     assert be.gcc_cxx11_abi is None
-    assert "-D_GLIBCXX_USE_CXX11_ABI=0" not in env["CPPFLAGS"]
+    assert "GLIBCXX_USE_CXX11_ABI" not in env["CPPFLAGS"]
+
+    # Force the GLIBCXX_USE_CXX11_ABI=1 for old distros is direct def f ``gcc_cxx11_abi``
+    be.gcc_cxx11_abi = "_GLIBCXX_USE_CXX11_ABI=1"
+    env = be.vars()
+    assert "-D_GLIBCXX_USE_CXX11_ABI=1" in env["CPPFLAGS"]
+
+    # Also conf is possible
+    conanfile.conf["tools.gnu:define_libcxx11_abi"] = True
+    be = AutotoolsToolchain(conanfile)
+    env = be.vars()
+    assert "-D_GLIBCXX_USE_CXX11_ABI=1" in env["CPPFLAGS"]
 
 
 @pytest.mark.parametrize("config", [
     ('x86_64', "-m64"),
-    ('x86', "-m32"),])
+    ('x86', "-m32")])
 def test_architecture_flag(config):
     """Architecture flag is set in CXXFLAGS, CFLAGS and LDFLAGS"""
     arch, expected = config


### PR DESCRIPTION
Changelog: Bugfix: Fix the definition of D_GLIBCXX_USE_CXX11_ABI in gcc-like compilers for ``CMakeToolchain`` and ``AutotoolsToolchain``. Define it only to ``D_GLIBCXX_USE_CXX11_ABI=0`` for new compilers, assuming that the default is alread 1.
Docs: Omit

Address https://github.com/conan-io/conan-center-index/pull/8389

Lets see if something breaks, need to add tests.


