### PR TITLE
`test_type` mechanism deprecation

### DIFF
--- a/conans/client/graph/graph_manager.py
+++ b/conans/client/graph/graph_manager.py
@@ -100,7 +100,7 @@ class GraphManager(object):
             if test:
                 conanfile.display_name = "%s (test package)" % str(test)
                 conanfile.output.scope = conanfile.display_name
-                conanfile.testing_reference = str(test)
+                conanfile.tested_reference_str = repr(test)
             run_configure_method(conanfile, down_options=None, down_ref=None, ref=None)
         else:
             conanfile = self._loader.load_conanfile_txt(conanfile_path, profile_host=profile_host)
@@ -248,7 +248,7 @@ class GraphManager(object):
                                                )
         conanfile.display_name = "%s (test package)" % str(test)
         conanfile.output.scope = conanfile.display_name
-        conanfile.testing_reference = str(create_reference)
+        conanfile.tested_reference_str = repr(create_reference)
 
         # Injection of the tested reference
         test_type = getattr(conanfile, "test_type", ("requires", ))

--- a/conans/client/graph/graph_manager.py
+++ b/conans/client/graph/graph_manager.py
@@ -100,7 +100,7 @@ class GraphManager(object):
             if test:
                 conanfile.display_name = "%s (test package)" % str(test)
                 conanfile.output.scope = conanfile.display_name
-                conanfile.testing_package_reference = str(test)
+                conanfile.testing_reference = str(test)
             run_configure_method(conanfile, down_options=None, down_ref=None, ref=None)
         else:
             conanfile = self._loader.load_conanfile_txt(conanfile_path, profile_host=profile_host)
@@ -248,7 +248,7 @@ class GraphManager(object):
                                                )
         conanfile.display_name = "%s (test package)" % str(test)
         conanfile.output.scope = conanfile.display_name
-        conanfile.testing_package_reference = str(create_reference)
+        conanfile.testing_reference = str(create_reference)
 
         # Injection of the tested reference
         test_type = getattr(conanfile, "test_type", ("requires", ))

--- a/conans/client/graph/graph_manager.py
+++ b/conans/client/graph/graph_manager.py
@@ -157,8 +157,9 @@ class GraphManager(object):
 
         path = reference  # The reference must be pointing to a user space conanfile
         if create_reference:  # Test_package -> tested reference
-            return self._load_root_test_package(path, create_reference, graph_lock, profile_host,
+            ret = self._load_root_test_package(path, create_reference, graph_lock, profile_host,
                                                 require_overrides)
+            return ret
 
         # It is a path to conanfile.py or conanfile.txt
         root_node = self._load_root_consumer(path, graph_lock, profile_host, root_ref,
@@ -246,6 +247,7 @@ class GraphManager(object):
                                                )
         conanfile.display_name = "%s (test package)" % str(test)
         conanfile.output.scope = conanfile.display_name
+        conanfile.testing_package_reference = create_reference
 
         # Injection of the tested reference
         test_type = getattr(conanfile, "test_type", ("requires", ))
@@ -266,6 +268,7 @@ class GraphManager(object):
                 require.ref = require.range_ref = create_reference
             else:
                 conanfile.requires.add_ref(create_reference)
+
         ref = ConanFileReference(conanfile.name, conanfile.version,
                                  create_reference.user, create_reference.channel, validate=False)
         root_node = Node(ref, conanfile, recipe=RECIPE_CONSUMER, context=CONTEXT_HOST, path=path)

--- a/conans/client/graph/graph_manager.py
+++ b/conans/client/graph/graph_manager.py
@@ -255,9 +255,7 @@ class GraphManager(object):
         if not isinstance(test_type, (list, tuple)):
             test_type = (test_type, )
 
-        if "explicit" in test_type:  # 2.0 mode, not automatically add the require, always explicit
-            pass
-        else:
+        if "explicit" not in test_type:  # 2.0 mode, not automatically add the require, always explicit
             if "build_requires" in test_type:
                 if getattr(conanfile, "build_requires", None):
                     # Injecting the tested reference

--- a/conans/client/graph/graph_manager.py
+++ b/conans/client/graph/graph_manager.py
@@ -100,6 +100,7 @@ class GraphManager(object):
             if test:
                 conanfile.display_name = "%s (test package)" % str(test)
                 conanfile.output.scope = conanfile.display_name
+                conanfile.testing_package_reference = str(test)
             run_configure_method(conanfile, down_options=None, down_ref=None, ref=None)
         else:
             conanfile = self._loader.load_conanfile_txt(conanfile_path, profile_host=profile_host)
@@ -247,27 +248,31 @@ class GraphManager(object):
                                                )
         conanfile.display_name = "%s (test package)" % str(test)
         conanfile.output.scope = conanfile.display_name
-        conanfile.testing_package_reference = create_reference
+        conanfile.testing_package_reference = str(create_reference)
 
         # Injection of the tested reference
         test_type = getattr(conanfile, "test_type", ("requires", ))
         if not isinstance(test_type, (list, tuple)):
             test_type = (test_type, )
-        if "build_requires" in test_type:
-            if getattr(conanfile, "build_requires", None):
-                # Injecting the tested reference
-                existing = conanfile.build_requires
-                if not isinstance(existing, (list, tuple)):
-                    existing = [existing]
-                conanfile.build_requires = list(existing) + [create_reference]
-            else:
-                conanfile.build_requires = str(create_reference)
-        if "requires" in test_type:
-            require = conanfile.requires.get(create_reference.name)
-            if require:
-                require.ref = require.range_ref = create_reference
-            else:
-                conanfile.requires.add_ref(create_reference)
+
+        if "explicit" in test_type:  # 2.0 mode, not automatically add the require, always explicit
+            pass
+        else:
+            if "build_requires" in test_type:
+                if getattr(conanfile, "build_requires", None):
+                    # Injecting the tested reference
+                    existing = conanfile.build_requires
+                    if not isinstance(existing, (list, tuple)):
+                        existing = [existing]
+                    conanfile.build_requires = list(existing) + [create_reference]
+                else:
+                    conanfile.build_requires = str(create_reference)
+            if "requires" in test_type:
+                require = conanfile.requires.get(create_reference.name)
+                if require:
+                    require.ref = require.range_ref = create_reference
+                else:
+                    conanfile.requires.add_ref(create_reference)
 
         ref = ConanFileReference(conanfile.name, conanfile.version,
                                  create_reference.user, create_reference.channel, validate=False)

--- a/conans/model/conan_file.py
+++ b/conans/model/conan_file.py
@@ -143,7 +143,7 @@ class ConanFile(object):
     win_bash = None
 
     # For test_package, reference being tested
-    testing_package_reference = None
+    testing_reference = None
 
     def __init__(self, output, runner, display_name="", user=None, channel=None):
         # an output stream (writeln, info, warn error)

--- a/conans/model/conan_file.py
+++ b/conans/model/conan_file.py
@@ -142,9 +142,6 @@ class ConanFile(object):
     # Run in windows bash
     win_bash = None
 
-    # For test_package, reference being tested
-    tested_reference_str = None
-
     def __init__(self, output, runner, display_name="", user=None, channel=None):
         # an output stream (writeln, info, warn error)
         self.output = ScopedOutput(display_name, output)

--- a/conans/model/conan_file.py
+++ b/conans/model/conan_file.py
@@ -142,6 +142,9 @@ class ConanFile(object):
     # Run in windows bash
     win_bash = None
 
+    # For test_package, reference being tested
+    testing_package_reference = None
+
     def __init__(self, output, runner, display_name="", user=None, channel=None):
         # an output stream (writeln, info, warn error)
         self.output = ScopedOutput(display_name, output)

--- a/conans/model/conan_file.py
+++ b/conans/model/conan_file.py
@@ -143,7 +143,7 @@ class ConanFile(object):
     win_bash = None
 
     # For test_package, reference being tested
-    testing_reference = None
+    tested_reference_str = None
 
     def __init__(self, output, runner, display_name="", user=None, channel=None):
         # an output stream (writeln, info, warn error)

--- a/conans/test/integration/command/test_package_test.py
+++ b/conans/test/integration/command/test_package_test.py
@@ -279,15 +279,15 @@ class HelloReuseConan(ConanFile):
                          load(os.path.join(client.cache.package_layout(pref.ref).package(pref), "FindXXX.cmake")))
 
 
-def test_testing_package_reference():
+def test_testing_reference():
     """
-    At the test_package/conanfile the variable `self.testing_package_reference` is injected with the
+    At the test_package/conanfile the variable `self.testing_reference` is injected with the
     str of the reference being tested. It is available in all the methods.
 
     Compatibility with Conan 2.0:
     If the 'test_type' is set to "explicit" the require won't be automatically injected and has to
     be the user the one injecting the require or the build require using the
-    `self.testing_package_reference`. This 'test_type' can be removed in 2.0 if we consider it has
+    `self.testing_reference`. This 'test_type' can be removed in 2.0 if we consider it has
     to be always explicit. The recipes will still work in Conan 2.0 because the 'test_type' will be
     ignored.
     """
@@ -301,19 +301,19 @@ def test_testing_package_reference():
         test_type = "explicit"
 
         def generate(self):
-            self.output.warn("At generate: {}".format(self.testing_package_reference))
+            self.output.warn("At generate: {}".format(self.testing_reference))
             assert len(self.dependencies.values()) == 1
             assert len(self.dependencies.build.values()) == 1
 
         def build(self):
-            self.output.warn("At build: {}".format(self.testing_package_reference))
+            self.output.warn("At build: {}".format(self.testing_reference))
 
         def build_requirements(self):
-            self.output.warn("At build_requirements: {}".format(self.testing_package_reference))
-            self.build_requires(self.testing_package_reference)
+            self.output.warn("At build_requirements: {}".format(self.testing_reference))
+            self.build_requires(self.testing_reference)
 
         def test(self):
-            self.output.warn("At test: {}".format(self.testing_package_reference))
+            self.output.warn("At test: {}".format(self.testing_reference))
     """)
 
     client.save({"conanfile.py": GenConanfile(), "test_package/conanfile.py": test_conanfile})
@@ -321,26 +321,3 @@ def test_testing_package_reference():
     for method in ("generate", "build", "build_requirements", "test"):
         assert "At {}: foo/1.0".format(method) in client.out
 
-
-def test_testing_package_reference2():
-    client = TestClient()
-    test_conanfile = textwrap.dedent("""
-    from conans import ConanFile, CMake
-    import os
-
-    class HelloReuseConan(ConanFile):
-
-        def build_requirements(self):
-            self.build_requires("foo/1.0")
-
-        def requirements(self):
-            self.requires("foo/1.0")
-
-        def test(self):
-            pass
-
-    """)
-
-    client.save({"conanfile.py": GenConanfile(), "test_package/conanfile.py": test_conanfile})
-    client.run("create . foo/1.0@ -pr:h=default -pr:b=default")
-    assert "kk" in client.out

--- a/conans/test/integration/command/test_package_test.py
+++ b/conans/test/integration/command/test_package_test.py
@@ -279,15 +279,15 @@ class HelloReuseConan(ConanFile):
                          load(os.path.join(client.cache.package_layout(pref.ref).package(pref), "FindXXX.cmake")))
 
 
-def test_testing_reference():
+def test_tested_reference_str():
     """
-    At the test_package/conanfile the variable `self.testing_reference` is injected with the
+    At the test_package/conanfile the variable `self.tested_reference_str` is injected with the
     str of the reference being tested. It is available in all the methods.
 
     Compatibility with Conan 2.0:
     If the 'test_type' is set to "explicit" the require won't be automatically injected and has to
     be the user the one injecting the require or the build require using the
-    `self.testing_reference`. This 'test_type' can be removed in 2.0 if we consider it has
+    `self.tested_reference_str`. This 'test_type' can be removed in 2.0 if we consider it has
     to be always explicit. The recipes will still work in Conan 2.0 because the 'test_type' will be
     ignored.
     """
@@ -301,19 +301,19 @@ def test_testing_reference():
         test_type = "explicit"
 
         def generate(self):
-            self.output.warn("At generate: {}".format(self.testing_reference))
+            self.output.warn("At generate: {}".format(self.tested_reference_str))
             assert len(self.dependencies.values()) == 1
             assert len(self.dependencies.build.values()) == 1
 
         def build(self):
-            self.output.warn("At build: {}".format(self.testing_reference))
+            self.output.warn("At build: {}".format(self.tested_reference_str))
 
         def build_requirements(self):
-            self.output.warn("At build_requirements: {}".format(self.testing_reference))
-            self.build_requires(self.testing_reference)
+            self.output.warn("At build_requirements: {}".format(self.tested_reference_str))
+            self.build_requires(self.tested_reference_str)
 
         def test(self):
-            self.output.warn("At test: {}".format(self.testing_reference))
+            self.output.warn("At test: {}".format(self.tested_reference_str))
     """)
 
     client.save({"conanfile.py": GenConanfile(), "test_package/conanfile.py": test_conanfile})


### PR DESCRIPTION
Changelog: Feature: In the conanfile.py of the test_package, the reference being tested is always available at `self.tested_reference_str`.
Changelog: Feature: Introduced a new `test_type` value `explicit` so a user can declare explicitly the `requires` or `build_requires` manually (using `self.tested_reference_str`), it won't be automatically injected as a require. In Conan 2.0 the `test_type` attribute will be ignored, the behavior will be always explicit, so declaring `test_type="explicit"` will make the test recipe compatible with Conan 2.0.
Docs: https://github.com/conan-io/docs/pull/2341

Close https://github.com/conan-io/conan/issues/10073
Close https://github.com/conan-io/conan/issues/9606
