### PR TITLE
making aggregate_components non-destructive, very dangerous

### DIFF
--- a/conan/tools/apple/xcodedeps.py
+++ b/conan/tools/apple/xcodedeps.py
@@ -174,8 +174,7 @@ class XcodeDeps(object):
         for dep in self._conanfile.dependencies.host.values():
             dep_name = dep.ref.name
             dep_name = dep_name.replace(".", "_").replace("-", "_")
-            cpp_info = dep.cpp_info.copy()
-            cpp_info.aggregate_components()
+            cpp_info = dep.cpp_info.aggregated_components()
             public_deps = [d.ref.name.replace(".", "_").replace("-", "_")
                            for r, d in dep.dependencies.direct_host.items() if r.visible]
 

--- a/conan/tools/cmake/toolchain.py
+++ b/conan/tools/cmake/toolchain.py
@@ -434,8 +434,7 @@ class FindConfigFiles(Block):
         # Read the buildirs
         build_paths = []
         for req in host_req:
-            cppinfo = req.cpp_info.copy()
-            cppinfo.aggregate_components()
+            cppinfo = req.cpp_info.aggregated_components()
             build_paths.extend([os.path.join(req.package_folder,
                                        p.replace('\\', '/').replace('$', '\\$').replace('"', '\\"'))
                                 for p in cppinfo.builddirs])

--- a/conan/tools/env/virtualrunenv.py
+++ b/conan/tools/env/virtualrunenv.py
@@ -9,9 +9,9 @@ def runenv_from_cpp_info(conanfile, dep, os_name):
     # FIXME: Remove conanfile arg
     dyn_runenv = Environment()
 
-    cpp_info = dep.cpp_info
-    cpp_info.aggregate_components()
+    cpp_info = dep.cpp_info.aggregated_components()
     pkg_folder = dep.package_folder
+    # FIXME: This code is dead, cpp_info cannot be None
     if cpp_info is None:  # This happens when the dependency is a private one = BINARY_SKIP
         return dyn_runenv
 

--- a/conan/tools/gnu/autotoolsdeps.py
+++ b/conan/tools/gnu/autotoolsdeps.py
@@ -13,11 +13,10 @@ class AutotoolsDeps:
     def _get_cpp_info(self):
         ret = NewCppInfo()
         for dep in self._conanfile.dependencies.host.values():
-            dep_cppinfo = dep.cpp_info.copy()
+            dep_cppinfo = dep.cpp_info.aggregated_components()
             dep_cppinfo.set_relative_base_folder(dep.package_folder)
             # In case we have components, aggregate them, we do not support isolated
             # "targets" with autotools
-            dep_cppinfo.aggregate_components()
             ret.merge(dep_cppinfo)
         return ret
 

--- a/conan/tools/google/bazeldeps.py
+++ b/conan/tools/google/bazeldeps.py
@@ -65,15 +65,15 @@ class BazelDeps(object):
 
         """)
 
-        dependency.cpp_info.aggregate_components()
+        cpp_info = dependency.cpp_info.aggregated_components()
 
-        if not dependency.cpp_info.libs and not dependency.cpp_info.includedirs:
+        if not cpp_info.libs and not cpp_info.includedirs:
             return None
 
         headers = []
         includes = []
 
-        for path in dependency.cpp_info.includedirs:
+        for path in cpp_info.includedirs:
             headers.append('"{}/**"'.format(path))
             includes.append('"{}"'.format(path))
 
@@ -81,18 +81,18 @@ class BazelDeps(object):
         includes = ', '.join(includes)
 
         defines = ('"{}"'.format(define.replace('"', "'"))
-                   for define in dependency.cpp_info.defines)
+                   for define in cpp_info.defines)
         defines = ', '.join(defines)
 
         linkopts = []
-        for linkopt in dependency.cpp_info.system_libs:
+        for linkopt in cpp_info.system_libs:
             linkopts.append('"-l{}"'.format(linkopt))
         linkopts = ', '.join(linkopts)
 
         context = {
             "name": dependency.ref.name,
-            "libs": dependency.cpp_info.libs,
-            "libdir": dependency.cpp_info.libdirs[0],
+            "libs": cpp_info.libs,
+            "libdir": cpp_info.libdirs[0],
             "headers": headers,
             "includes": includes,
             "defines": defines,

--- a/conan/tools/microsoft/msbuilddeps.py
+++ b/conan/tools/microsoft/msbuilddeps.py
@@ -283,8 +283,7 @@ class MSBuildDeps(object):
         for dep in host_req + test_req:
             dep_name = dep.ref.name
             dep_name = dep_name.replace(".", "_")
-            cpp_info = dep.cpp_info.copy()
-            cpp_info.aggregate_components()
+            cpp_info = dep.cpp_info.aggregated_components()
             public_deps = [d.ref.name.replace(".", "_")
                            for r, d in dep.dependencies.direct_host.items() if r.visible]
             # One file per configuration, with just the variables
@@ -302,8 +301,7 @@ class MSBuildDeps(object):
         for dep in build_req:
             dep_name = dep.ref.name
             dep_name = dep_name.replace(".", "_") + "_build"
-            cpp_info = dep.cpp_info.copy()
-            cpp_info.aggregate_components()
+            cpp_info = dep.cpp_info.aggregated_components()
             public_deps = [d.ref.name.replace(".", "_")
                            for r, d in dep.dependencies.direct_host.items() if r.visible]
             # One file per configuration, with just the variables

--- a/conans/client/command.py
+++ b/conans/client/command.py
@@ -2245,6 +2245,8 @@ class Command(object):
             ret_code = ERROR_INVALID_SYSTEM_REQUIREMENTS
             self._out.error(exc)
         except ConanException as exc:
+            import traceback
+            print(traceback.format_exc())
             ret_code = ERROR_GENERAL
             self._out.error(exc)
         except Exception as exc:

--- a/conans/client/command.py
+++ b/conans/client/command.py
@@ -2245,8 +2245,6 @@ class Command(object):
             ret_code = ERROR_INVALID_SYSTEM_REQUIREMENTS
             self._out.error(exc)
         except ConanException as exc:
-            import traceback
-            print(traceback.format_exc())
             ret_code = ERROR_GENERAL
             self._out.error(exc)
         except Exception as exc:

--- a/conans/test/integration/toolchains/cmake/cmakedeps/test_cmakedeps.py
+++ b/conans/test/integration/toolchains/cmake/cmakedeps/test_cmakedeps.py
@@ -114,3 +114,42 @@ def test_cpp_info_component_objects():
         content = f.read()
         assert 'set(hello_OBJECTS_RELEASE "${hello_PACKAGE_FOLDER_RELEASE}/mycomponent.o")' in content
         assert 'set(hello_hello_say_OBJECTS_RELEASE "${hello_PACKAGE_FOLDER_RELEASE}/mycomponent.o")' in content
+
+
+def test_cpp_info_component_error_aggregate():
+    # https://github.com/conan-io/conan/issues/10176
+    # This test was consistently failing because "VirtualRunEnv" was not doing a "copy()"
+    # of cpp_info before calling "aggregate_components()", and it was destructive, removing
+    # components data
+    client = TestClient()
+    conan_hello = textwrap.dedent("""
+        from conan import ConanFile
+        class Pkg(ConanFile):
+            def package_info(self):
+                self.cpp_info.components["say"].includedirs = ["include"]
+            """)
+    consumer = textwrap.dedent("""
+        from conans import ConanFile
+        class Pkg(ConanFile):
+            settings = "os", "compiler", "arch", "build_type"
+            requires = "hello/1.0"
+            generators = "VirtualRunEnv", "CMakeDeps"
+            def package_info(self):
+                self.cpp_info.components["chat"].requires = ["hello::say"]
+        """)
+    test_package = textwrap.dedent("""
+        from conans import ConanFile
+        class Pkg(ConanFile):
+            settings = "os", "compiler", "arch", "build_type"
+            generators = "VirtualRunEnv", "CMakeDeps"
+
+            def test(self):
+                pass
+        """)
+
+    client.save({"hello/conanfile.py": conan_hello,
+                 "consumer/conanfile.py": consumer,
+                 "consumer/test_package/conanfile.py": test_package})
+    client.run("create hello hello/1.0@")
+    client.run("create consumer consumer/1.0@")
+    assert "consumer/1.0 (test package): Running test()" in client.out

--- a/conans/test/unittests/conan_build_info/new_build_info_test.py
+++ b/conans/test/unittests/conan_build_info/new_build_info_test.py
@@ -62,9 +62,7 @@ def test_component_aggregation():
     cppinfo.components["c1"].set_property("my_foo", "jander")
     cppinfo.components["c1"].set_property("my_foo2", "bar2", "other_gen")
 
-
-    ret = cppinfo.copy()
-    ret.aggregate_components()
+    ret = cppinfo.aggregated_components()
 
     assert ret.includedirs == ["includedir_c1", "includedir_c2"]
     assert ret.libdirs == ["libdir_c1", "libdir_c2"]
@@ -85,8 +83,8 @@ def test_component_aggregation():
     cppinfo.components["c1"].requires = []
     cppinfo.components["c2"].requires = ["c1"]
 
-    ret = cppinfo.copy()
-    ret.aggregate_components()
+    cppinfo._aggregated = None  # Dirty, just to force recomputation
+    ret = cppinfo.aggregated_components()
 
     assert ret.includedirs == ["includedir_c2", "includedir_c1"]
     assert ret.libdirs == ["libdir_c2", "libdir_c1"]
@@ -130,8 +128,8 @@ def test_cpp_info_merge_aggregating_components_first(aggregate_first):
     other.components["boo"].requires = ["boo2"]  # Deterministic order
 
     if aggregate_first:
-        cppinfo.aggregate_components()
-        other.aggregate_components()
+        cppinfo = cppinfo.aggregated_components()
+        other = other.aggregated_components()
 
     cppinfo.merge(other)
 


### PR DESCRIPTION
Changelog: Bugfix: Making aggregate_components non-destructive, which was causing errors in generators with components. 
Docs: Omit

Fix: https://github.com/conan-io/conan/issues/10176

I have removed the requirement to do a ``copy()`` before an ``aggregate_components()`` because forgetting to do that was causing a super-challenging to debug and understand behavior. Now ``aggregated_components()`` return a copy (cached) of the aggregated information, but never destroys the current one. Take into account that users building their own ``generate()`` logic or their own generators will very often need to aggregate the components information (for example MSBuildDeps and AutoToolsDeps already need to do it), and missing to do the ``copy()`` results in this very problematic bug.

Fix: https://github.com/conan-io/conan/issues/10176

