### PR TITLE
CMakeToolchain: proper support of find_*() & include() commands

### DIFF
--- a/conan/tools/cmake/toolchain.py
+++ b/conan/tools/cmake/toolchain.py
@@ -428,18 +428,10 @@ class FindFiles(Block):
         {% endif %}
 
         # To support cross building
-        if(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM STREQUAL "ONLY")
-            set(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM "BOTH")
-        endif()
-        if(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY STREQUAL "ONLY")
-            set(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY "BOTH")
-        endif()
-        if(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE STREQUAL "ONLY")
-            set(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE "BOTH")
-        endif()
-        if(CMAKE_FIND_ROOT_PATH_MODE_PACKAGE STREQUAL "ONLY")
-            set(CMAKE_FIND_ROOT_PATH_MODE_PACKAGE "BOTH")
-        endif()
+        set(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM "BOTH")
+        set(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY "BOTH")
+        set(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE "BOTH")
+        set(CMAKE_FIND_ROOT_PATH_MODE_PACKAGE "BOTH")
         """)
 
     def context(self):

--- a/conan/tools/cmake/toolchain.py
+++ b/conan/tools/cmake/toolchain.py
@@ -447,42 +447,42 @@ class FindFiles(Block):
 
         # Read information from host context
         host_req = self._conanfile.dependencies.host.values()
-        module_host_paths = []
-        prefix_paths = []
-        bin_host_paths = []
-        lib_paths = []
-        framework_paths = []
-        include_paths = []
+        host_module_paths = []
+        host_prefix_paths = []
+        host_bin_paths = []
+        host_lib_paths = []
+        host_framework_paths = []
+        host_include_paths = []
         for req in host_req:
             cppinfo = req.cpp_info.copy()
             cppinfo.aggregate_components()
-            module_host_paths.extend([os.path.join(req.package_folder, p) for p in cppinfo.builddirs if p != ""])
-            prefix_paths.extend([os.path.join(req.package_folder, p) for p in cppinfo.builddirs if p != ""])
+            host_module_paths.extend([os.path.join(req.package_folder, p) for p in cppinfo.builddirs if p != ""])
+            host_prefix_paths.extend([os.path.join(req.package_folder, p) for p in cppinfo.builddirs if p != ""])
             if not cross_building(self._conanfile):
-                bin_host_paths.extend([os.path.join(req.package_folder, p) for p in cppinfo.bindirs])
-            lib_paths.extend([os.path.join(req.package_folder, p) for p in cppinfo.libdirs])
-            framework_paths.extend([os.path.join(req.package_folder, p) for p in cppinfo.frameworkdirs])
-            include_paths.extend([os.path.join(req.package_folder, p) for p in cppinfo.includedirs])
+                host_bin_paths.extend([os.path.join(req.package_folder, p) for p in cppinfo.bindirs])
+            host_lib_paths.extend([os.path.join(req.package_folder, p) for p in cppinfo.libdirs])
+            host_framework_paths.extend([os.path.join(req.package_folder, p) for p in cppinfo.frameworkdirs])
+            host_include_paths.extend([os.path.join(req.package_folder, p) for p in cppinfo.includedirs])
 
         # Read information from build context
         build_req = self._conanfile.dependencies.build.values()
-        module_build_paths = []
-        bin_build_paths = []
+        build_module_paths = []
+        build_bin_paths = []
         for req in build_req:
             cppinfo = req.cpp_info.copy()
             cppinfo.aggregate_components()
-            module_build_paths.extend([os.path.join(req.package_folder, p) for p in cppinfo.builddirs if p != ""])
-            bin_build_paths.extend([os.path.join(req.package_folder, p) for p in cppinfo.bindirs])
+            build_module_paths.extend([os.path.join(req.package_folder, p) for p in cppinfo.builddirs if p != ""])
+            build_bin_paths.extend([os.path.join(req.package_folder, p) for p in cppinfo.bindirs])
 
         return {
             "find_package_prefer_config": find_package_prefer_config,
             "generators_folder": "${CMAKE_CURRENT_LIST_DIR}",
-            "cmake_module_path": self._join_paths(module_host_paths + module_build_paths),
-            "cmake_prefix_path": self._join_paths(prefix_paths),
-            "cmake_program_path": self._join_paths(bin_build_paths + bin_host_paths),
-            "cmake_library_path": self._join_paths(lib_paths),
-            "cmake_framework_path": self._join_paths(framework_paths),
-            "cmake_include_path": self._join_paths(include_paths),
+            "cmake_module_path": self._join_paths(host_module_paths + build_module_paths),
+            "cmake_prefix_path": self._join_paths(host_prefix_paths),
+            "cmake_program_path": self._join_paths(build_bin_paths + host_bin_paths),
+            "cmake_library_path": self._join_paths(host_lib_paths),
+            "cmake_framework_path": self._join_paths(host_framework_paths),
+            "cmake_include_path": self._join_paths(host_include_paths),
         }
 
 

--- a/conan/tools/cmake/toolchain.py
+++ b/conan/tools/cmake/toolchain.py
@@ -431,6 +431,12 @@ class FindFiles(Block):
         {% endif %}
         """)
 
+    @staticmethod
+    def _join_paths(paths):
+        return " ".join(['"{}"'.format(p.replace('\\', '/')
+                                        .replace('$', '\\$')
+                                        .replace('"', '\\"')) for p in paths])
+
     def context(self):
         # To find the generated cmake_find_package finders
         # TODO: Change this for parameterized output location of CMakeDeps
@@ -468,34 +474,15 @@ class FindFiles(Block):
             module_build_paths.extend([os.path.join(req.package_folder, p) for p in cppinfo.builddirs if p != ""])
             bin_build_paths.extend([os.path.join(req.package_folder, p) for p in cppinfo.bindirs])
 
-        module_paths = " ".join(['"{}"'.format(b.replace('\\', '/')
-                                                .replace('$', '\\$')
-                                                .replace('"', '\\"')) for b in module_host_paths + module_build_paths])
-        prefix_paths = " ".join(['"{}"'.format(b.replace('\\', '/')
-                                                .replace('$', '\\$')
-                                                .replace('"', '\\"')) for b in prefix_paths])
-        bin_paths = " ".join(['"{}"'.format(b.replace('\\', '/')
-                                             .replace('$', '\\$')
-                                             .replace('"', '\\"')) for b in bin_build_paths + bin_host_paths])
-        lib_paths = " ".join(['"{}"'.format(b.replace('\\', '/')
-                                             .replace('$', '\\$')
-                                             .replace('"', '\\"')) for b in lib_paths])
-        framework_paths = " ".join(['"{}"'.format(b.replace('\\', '/')
-                                                   .replace('$', '\\$')
-                                                   .replace('"', '\\"')) for b in framework_paths])
-        include_paths = " ".join(['"{}"'.format(b.replace('\\', '/')
-                                                 .replace('$', '\\$')
-                                                 .replace('"', '\\"')) for b in include_paths])
-
         return {
             "find_package_prefer_config": find_package_prefer_config,
             "generators_folder": "${CMAKE_CURRENT_LIST_DIR}",
-            "cmake_module_path": module_paths,
-            "cmake_prefix_path": prefix_paths,
-            "cmake_program_path": bin_paths,
-            "cmake_library_path": lib_paths,
-            "cmake_framework_path": framework_paths,
-            "cmake_include_path": include_paths,
+            "cmake_module_path": self._join_paths(module_host_paths + module_build_paths),
+            "cmake_prefix_path": self._join_paths(prefix_paths),
+            "cmake_program_path": self._join_paths(bin_build_paths + bin_host_paths),
+            "cmake_library_path": self._join_paths(lib_paths),
+            "cmake_framework_path": self._join_paths(framework_paths),
+            "cmake_include_path": self._join_paths(include_paths),
         }
 
 

--- a/conan/tools/cmake/toolchain.py
+++ b/conan/tools/cmake/toolchain.py
@@ -423,9 +423,6 @@ class FindFiles(Block):
         # To support find_file() and file_path() of headers from host context
         set(CMAKE_INCLUDE_PATH {{ cmake_include_path }} ${CMAKE_INCLUDE_PATH})
         {% endif %}
-        {% if android_prefix_path %}
-        set(CMAKE_FIND_ROOT_PATH {{ android_prefix_path }} ${CMAKE_FIND_ROOT_PATH})
-        {% endif %}
 
         # To support cross building
         set(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM "BOTH")
@@ -441,9 +438,6 @@ class FindFiles(Block):
         prefer_config = self._conanfile.conf["tools.cmake.cmaketoolchain:find_package_prefer_config"]
         if prefer_config is not None and prefer_config.lower() in ("false", "0", "off"):
             find_package_prefer_config = "OFF"
-
-        os_ = self._conanfile.settings.get_safe("os")
-        android_prefix = "${CMAKE_CURRENT_LIST_DIR}" if os_ == "Android" else None
 
         module_paths = []
 
@@ -499,7 +493,6 @@ class FindFiles(Block):
             "cmake_library_path": lib_paths,
             "cmake_framework_path": framework_paths,
             "cmake_include_path": include_paths,
-            "android_prefix_path": android_prefix,
         }
 
 

--- a/conan/tools/cmake/toolchain.py
+++ b/conan/tools/cmake/toolchain.py
@@ -439,10 +439,9 @@ class FindFiles(Block):
         if prefer_config is not None and prefer_config.lower() in ("false", "0", "off"):
             find_package_prefer_config = "OFF"
 
-        module_paths = []
-
         # Read information from host context
         host_req = self._conanfile.dependencies.host.values()
+        module_host_paths = []
         prefix_paths = []
         bin_host_paths = []
         lib_paths = []
@@ -451,7 +450,7 @@ class FindFiles(Block):
         for req in host_req:
             cppinfo = req.cpp_info.copy()
             cppinfo.aggregate_components()
-            module_paths.extend([os.path.join(req.package_folder, p) for p in cppinfo.builddirs if p != ""])
+            module_host_paths.extend([os.path.join(req.package_folder, p) for p in cppinfo.builddirs if p != ""])
             prefix_paths.extend([os.path.join(req.package_folder, p) for p in cppinfo.builddirs if p != ""])
             if not cross_building(self._conanfile):
                 bin_host_paths.extend([os.path.join(req.package_folder, p) for p in cppinfo.bindirs])
@@ -461,16 +460,17 @@ class FindFiles(Block):
 
         # Read information from build context
         build_req = self._conanfile.dependencies.build.values()
+        module_build_paths = []
         bin_build_paths = []
         for req in build_req:
             cppinfo = req.cpp_info.copy()
             cppinfo.aggregate_components()
-            module_paths.extend([os.path.join(req.package_folder, p) for p in cppinfo.builddirs if p != ""])
+            module_build_paths.extend([os.path.join(req.package_folder, p) for p in cppinfo.builddirs if p != ""])
             bin_build_paths.extend([os.path.join(req.package_folder, p) for p in cppinfo.bindirs])
 
         module_paths = " ".join(['"{}"'.format(b.replace('\\', '/')
                                                 .replace('$', '\\$')
-                                                .replace('"', '\\"')) for b in module_paths])
+                                                .replace('"', '\\"')) for b in module_host_paths + module_build_paths])
         prefix_paths = " ".join(['"{}"'.format(b.replace('\\', '/')
                                                 .replace('$', '\\$')
                                                 .replace('"', '\\"')) for b in prefix_paths])

--- a/conan/tools/cmake/toolchain.py
+++ b/conan/tools/cmake/toolchain.py
@@ -802,9 +802,6 @@ class CMakeToolchain(object):
                                        ("rpath", SkipRPath),
                                        ("shared", SharedLibBock)])
 
-        # Set the CMAKE_MODULE_PATH and CMAKE_PREFIX_PATH to the deps .builddirs
-        self.find_builddirs = True
-
         check_using_build_profile(self._conanfile)
 
     def _context(self):

--- a/conan/tools/cmake/toolchain.py
+++ b/conan/tools/cmake/toolchain.py
@@ -405,30 +405,29 @@ class FindFiles(Block):
         {% endif %}
         {% if generators_folder or cmake_prefix_path %}
         # To support find_package() of CMake config Files from host context
+        set(CMAKE_FIND_ROOT_PATH_MODE_PACKAGE "BOTH")
         set(CMAKE_PREFIX_PATH {{ generators_folder }} {{ cmake_prefix_path }} ${CMAKE_PREFIX_PATH})
         {% endif %}
         {% if cmake_program_path %}
         # To support find_program() of executables from build context
+        set(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM "BOTH")
         set(CMAKE_PROGRAM_PATH {{ cmake_program_path }} ${CMAKE_PROGRAM_PATH})
         {% endif %}
+        {% if cmake_library_path or cmake_framework_path %}
+        # To support find_library() of libraries/frameworks from host context
+        set(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY "BOTH")
         {% if cmake_library_path %}
-        # To support find_library() of libraries from host context
         set(CMAKE_LIBRARY_PATH {{ cmake_library_path }} ${CMAKE_LIBRARY_PATH})
         {% endif %}
         {% if cmake_framework_path %}
-        # To support find_framework() of frameworks from host context
         set(CMAKE_FRAMEWORK_PATH {{ cmake_framework_path }} ${CMAKE_FRAMEWORK_PATH})
+        {% endif %}
         {% endif %}
         {% if cmake_include_path %}
         # To support find_file() and file_path() of headers from host context
+        set(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE "BOTH")
         set(CMAKE_INCLUDE_PATH {{ cmake_include_path }} ${CMAKE_INCLUDE_PATH})
         {% endif %}
-
-        # To support cross building
-        set(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM "BOTH")
-        set(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY "BOTH")
-        set(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE "BOTH")
-        set(CMAKE_FIND_ROOT_PATH_MODE_PACKAGE "BOTH")
         """)
 
     def context(self):

--- a/conan/tools/cmake/toolchain.py
+++ b/conan/tools/cmake/toolchain.py
@@ -420,50 +420,22 @@ class FindFiles(Block):
         {% endif %}
 
         {% if cross_building %}
-        if(NOT DEFINED CMAKE_FIND_ROOT_PATH_MODE_PACKAGE)
+        if(NOT DEFINED CMAKE_FIND_ROOT_PATH_MODE_PACKAGE OR CMAKE_FIND_ROOT_PATH_MODE_PACKAGE STREQUAL "ONLY")
             set(CMAKE_FIND_ROOT_PATH_MODE_PACKAGE "BOTH")
         endif()
-        if(NOT DEFINED CMAKE_FIND_ROOT_PATH_MODE_PROGRAM)
+        if(NOT DEFINED CMAKE_FIND_ROOT_PATH_MODE_PROGRAM OR CMAKE_FIND_ROOT_PATH_MODE_PROGRAM STREQUAL "ONLY")
             set(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM "BOTH")
         endif()
-        if(NOT DEFINED CMAKE_FIND_ROOT_PATH_MODE_LIBRARY)
+        if(NOT DEFINED CMAKE_FIND_ROOT_PATH_MODE_LIBRARY OR CMAKE_FIND_ROOT_PATH_MODE_LIBRARY STREQUAL "ONLY")
             set(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY "BOTH")
         endif()
         {% if is_apple %}
-        if(NOT DEFINED CMAKE_FIND_ROOT_PATH_MODE_FRAMEWORK)
+        if(NOT DEFINED CMAKE_FIND_ROOT_PATH_MODE_FRAMEWORK OR CMAKE_FIND_ROOT_PATH_MODE_FRAMEWORK STREQUAL "ONLY")
             set(CMAKE_FIND_ROOT_PATH_MODE_FRAMEWORK "BOTH")
         endif()
         {% endif %}
-        if(NOT DEFINED CMAKE_FIND_ROOT_PATH_MODE_INCLUDE)
+        if(NOT DEFINED CMAKE_FIND_ROOT_PATH_MODE_INCLUDE OR CMAKE_FIND_ROOT_PATH_MODE_INCLUDE STREQUAL "ONLY")
             set(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE "BOTH")
-        endif()
-
-        if(CMAKE_FIND_ROOT_PATH_MODE_PACKAGE STREQUAL "ONLY")
-            set(CMAKE_FIND_ROOT_PATH ${CMAKE_FIND_ROOT_PATH} {{ generators_folder }} {{ host_build_paths_noroot }})
-        endif()
-        if(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM STREQUAL "NEVER")
-            if(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY STREQUAL "ONLY" OR
-        {% if is_apple %}
-               CMAKE_FIND_ROOT_PATH_MODE_FRAMEWORK STREQUAL "ONLY" OR
-        {% endif %}
-               CMAKE_FIND_ROOT_PATH_MODE_INCLUDE STREQUAL "ONLY")
-                set(CMAKE_FIND_ROOT_PATH ${CMAKE_FIND_ROOT_PATH} {{ host_build_paths_root }})
-            endif()
-        else()
-            if(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM STREQUAL "ONLY")
-                set(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM "BOTH")
-            endif()
-            if(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY STREQUAL "ONLY")
-                set(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY "BOTH")
-            endif()
-        {% if is_apple %}
-            if(CMAKE_FIND_ROOT_PATH_MODE_FRAMEWORK STREQUAL "ONLY")
-                set(CMAKE_FIND_ROOT_PATH_MODE_FRAMEWORK "BOTH")
-            endif()
-        {% endif %}
-            if(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE STREQUAL "ONLY")
-                set(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE "BOTH")
-            endif()
         endif()
         {% endif %}
     """)

--- a/conan/tools/cmake/toolchain.py
+++ b/conan/tools/cmake/toolchain.py
@@ -401,7 +401,6 @@ class FindFiles(Block):
         set(CMAKE_FIND_PACKAGE_PREFER_CONFIG {{ find_package_prefer_config }})
         {% endif %}
         {% if generators_folder or cmake_module_path %}
-        # To support find_package() of CMake Find files (host context), and include() of CMake modules (host & build context)
         set(CMAKE_MODULE_PATH {{ generators_folder }} {{ cmake_module_path }} ${CMAKE_MODULE_PATH})
         {% endif %}
         {% if generators_folder or cmake_prefix_path %}
@@ -410,12 +409,10 @@ class FindFiles(Block):
         set(CMAKE_PREFIX_PATH {{ generators_folder }} {{ cmake_prefix_path }} ${CMAKE_PREFIX_PATH})
         {% endif %}
         {% if cmake_program_path %}
-        # To support find_program() of executables from build context (and host context if not cross-building)
         set(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM "BOTH")
         set(CMAKE_PROGRAM_PATH {{ cmake_program_path }} ${CMAKE_PROGRAM_PATH})
         {% endif %}
         {% if cmake_library_path or cmake_framework_path %}
-        # To support find_library() of libraries/frameworks from host context
         set(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY "BOTH")
         {% if cmake_library_path %}
         set(CMAKE_LIBRARY_PATH {{ cmake_library_path }} ${CMAKE_LIBRARY_PATH})
@@ -425,9 +422,11 @@ class FindFiles(Block):
         {% endif %}
         {% endif %}
         {% if cmake_include_path %}
-        # To support find_file() and file_path() of headers from host context
         set(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE "BOTH")
         set(CMAKE_INCLUDE_PATH {{ cmake_include_path }} ${CMAKE_INCLUDE_PATH})
+        {% endif %}
+        {% if cmake_ignore_path %}
+        set(CMAKE_IGNORE_PATH {{ cmake_ignore_path }} ${CMAKE_IGNORE_PATH})
         {% endif %}
         """)
 
@@ -456,9 +455,8 @@ class FindFiles(Block):
         for req in host_req:
             cppinfo = req.cpp_info.aggregated_components()
             host_module_paths.extend([os.path.join(req.package_folder, p) for p in cppinfo.builddirs])
-            host_prefix_paths.extend([os.path.join(req.package_folder, p) for p in cppinfo.builddirs if p != ""])
-            if not cross_building(self._conanfile):
-                host_bin_paths.extend([os.path.join(req.package_folder, p) for p in cppinfo.bindirs])
+            host_prefix_paths.extend([os.path.join(req.package_folder, p) for p in cppinfo.builddirs])
+            host_bin_paths.extend([os.path.join(req.package_folder, p) for p in cppinfo.bindirs])
             host_lib_paths.extend([os.path.join(req.package_folder, p) for p in cppinfo.libdirs])
             host_framework_paths.extend([os.path.join(req.package_folder, p) for p in cppinfo.frameworkdirs])
             host_include_paths.extend([os.path.join(req.package_folder, p) for p in cppinfo.includedirs])
@@ -466,21 +464,33 @@ class FindFiles(Block):
         # Read information from build context
         build_req = self._conanfile.dependencies.build.values()
         build_module_paths = []
+        build_prefix_paths = []
         build_bin_paths = []
+        build_lib_paths = []
+        build_framework_paths = []
+        build_include_paths = []
         for req in build_req:
             cppinfo = req.cpp_info.aggregated_components()
             build_module_paths.extend([os.path.join(req.package_folder, p) for p in cppinfo.builddirs])
+            build_prefix_paths.extend([os.path.join(req.package_folder, p) for p in cppinfo.builddirs])
             build_bin_paths.extend([os.path.join(req.package_folder, p) for p in cppinfo.bindirs])
+            build_lib_paths.extend([os.path.join(req.package_folder, p) for p in cppinfo.libdirs])
+            build_framework_paths.extend([os.path.join(req.package_folder, p) for p in cppinfo.frameworkdirs])
+            build_include_paths.extend([os.path.join(req.package_folder, p) for p in cppinfo.includedirs])
 
         return {
             "find_package_prefer_config": find_package_prefer_config,
             "generators_folder": "${CMAKE_CURRENT_LIST_DIR}",
             "cmake_module_path": self._join_paths(host_module_paths + build_module_paths),
-            "cmake_prefix_path": self._join_paths(host_prefix_paths),
-            "cmake_program_path": self._join_paths(build_bin_paths + host_bin_paths),
+            "cmake_prefix_path": self._join_paths(host_prefix_paths + build_prefix_paths),
+            "cmake_program_path": self._join_paths(build_bin_paths),
             "cmake_library_path": self._join_paths(host_lib_paths),
             "cmake_framework_path": self._join_paths(host_framework_paths),
             "cmake_include_path": self._join_paths(host_include_paths),
+            "cmake_ignore_path": self._join_paths(
+                host_bin_paths + build_lib_paths +
+                build_framework_paths + build_include_paths
+            ),
         }
 
 

--- a/conan/tools/cmake/toolchain.py
+++ b/conan/tools/cmake/toolchain.py
@@ -401,6 +401,7 @@ class FindFiles(Block):
         set(CMAKE_FIND_PACKAGE_PREFER_CONFIG {{ find_package_prefer_config }})
         {% endif %}
         {% if generators_folder or cmake_module_path %}
+        # To support find_package() of CMake Find files (host context), and include() of CMake modules (host & build context)
         set(CMAKE_MODULE_PATH {{ generators_folder }} {{ cmake_module_path }} ${CMAKE_MODULE_PATH})
         {% endif %}
         {% if generators_folder or cmake_prefix_path %}
@@ -409,10 +410,12 @@ class FindFiles(Block):
         set(CMAKE_PREFIX_PATH {{ generators_folder }} {{ cmake_prefix_path }} ${CMAKE_PREFIX_PATH})
         {% endif %}
         {% if cmake_program_path %}
+        # To support find_program() of executables from build context (and host context if not cross-building)
         set(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM "BOTH")
         set(CMAKE_PROGRAM_PATH {{ cmake_program_path }} ${CMAKE_PROGRAM_PATH})
         {% endif %}
         {% if cmake_library_path or cmake_framework_path %}
+        # To support find_library() of libraries/frameworks from host context
         set(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY "BOTH")
         {% if cmake_library_path %}
         set(CMAKE_LIBRARY_PATH {{ cmake_library_path }} ${CMAKE_LIBRARY_PATH})
@@ -422,11 +425,9 @@ class FindFiles(Block):
         {% endif %}
         {% endif %}
         {% if cmake_include_path %}
+        # To support find_file() and file_path() of headers from host context
         set(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE "BOTH")
         set(CMAKE_INCLUDE_PATH {{ cmake_include_path }} ${CMAKE_INCLUDE_PATH})
-        {% endif %}
-        {% if cmake_ignore_path %}
-        set(CMAKE_IGNORE_PATH {{ cmake_ignore_path }} ${CMAKE_IGNORE_PATH})
         {% endif %}
         """)
 
@@ -455,8 +456,9 @@ class FindFiles(Block):
         for req in host_req:
             cppinfo = req.cpp_info.aggregated_components()
             host_module_paths.extend([os.path.join(req.package_folder, p) for p in cppinfo.builddirs])
-            host_prefix_paths.extend([os.path.join(req.package_folder, p) for p in cppinfo.builddirs])
-            host_bin_paths.extend([os.path.join(req.package_folder, p) for p in cppinfo.bindirs])
+            host_prefix_paths.extend([os.path.join(req.package_folder, p) for p in cppinfo.builddirs if p != ""])
+            if not cross_building(self._conanfile):
+                host_bin_paths.extend([os.path.join(req.package_folder, p) for p in cppinfo.bindirs])
             host_lib_paths.extend([os.path.join(req.package_folder, p) for p in cppinfo.libdirs])
             host_framework_paths.extend([os.path.join(req.package_folder, p) for p in cppinfo.frameworkdirs])
             host_include_paths.extend([os.path.join(req.package_folder, p) for p in cppinfo.includedirs])
@@ -464,33 +466,21 @@ class FindFiles(Block):
         # Read information from build context
         build_req = self._conanfile.dependencies.build.values()
         build_module_paths = []
-        build_prefix_paths = []
         build_bin_paths = []
-        build_lib_paths = []
-        build_framework_paths = []
-        build_include_paths = []
         for req in build_req:
             cppinfo = req.cpp_info.aggregated_components()
             build_module_paths.extend([os.path.join(req.package_folder, p) for p in cppinfo.builddirs])
-            build_prefix_paths.extend([os.path.join(req.package_folder, p) for p in cppinfo.builddirs])
             build_bin_paths.extend([os.path.join(req.package_folder, p) for p in cppinfo.bindirs])
-            build_lib_paths.extend([os.path.join(req.package_folder, p) for p in cppinfo.libdirs])
-            build_framework_paths.extend([os.path.join(req.package_folder, p) for p in cppinfo.frameworkdirs])
-            build_include_paths.extend([os.path.join(req.package_folder, p) for p in cppinfo.includedirs])
 
         return {
             "find_package_prefer_config": find_package_prefer_config,
             "generators_folder": "${CMAKE_CURRENT_LIST_DIR}",
             "cmake_module_path": self._join_paths(host_module_paths + build_module_paths),
-            "cmake_prefix_path": self._join_paths(host_prefix_paths + build_prefix_paths),
-            "cmake_program_path": self._join_paths(build_bin_paths),
+            "cmake_prefix_path": self._join_paths(host_prefix_paths),
+            "cmake_program_path": self._join_paths(build_bin_paths + host_bin_paths),
             "cmake_library_path": self._join_paths(host_lib_paths),
             "cmake_framework_path": self._join_paths(host_framework_paths),
             "cmake_include_path": self._join_paths(host_include_paths),
-            "cmake_ignore_path": self._join_paths(
-                host_bin_paths + build_lib_paths +
-                build_framework_paths + build_include_paths
-            ),
         }
 
 

--- a/conan/tools/cmake/toolchain.py
+++ b/conan/tools/cmake/toolchain.py
@@ -1,4 +1,3 @@
-import json
 import os
 import re
 import textwrap

--- a/conan/tools/cmake/toolchain.py
+++ b/conan/tools/cmake/toolchain.py
@@ -456,7 +456,7 @@ class FindFiles(Block):
         for req in host_req:
             cppinfo = req.cpp_info.copy()
             cppinfo.aggregate_components()
-            host_module_paths.extend([os.path.join(req.package_folder, p) for p in cppinfo.builddirs if p != ""])
+            host_module_paths.extend([os.path.join(req.package_folder, p) for p in cppinfo.builddirs])
             host_prefix_paths.extend([os.path.join(req.package_folder, p) for p in cppinfo.builddirs if p != ""])
             if not cross_building(self._conanfile):
                 host_bin_paths.extend([os.path.join(req.package_folder, p) for p in cppinfo.bindirs])
@@ -471,7 +471,7 @@ class FindFiles(Block):
         for req in build_req:
             cppinfo = req.cpp_info.copy()
             cppinfo.aggregate_components()
-            build_module_paths.extend([os.path.join(req.package_folder, p) for p in cppinfo.builddirs if p != ""])
+            build_module_paths.extend([os.path.join(req.package_folder, p) for p in cppinfo.builddirs])
             build_bin_paths.extend([os.path.join(req.package_folder, p) for p in cppinfo.bindirs])
 
         return {

--- a/conans/test/functional/toolchains/cmake/cmakedeps/test_apple_frameworks.py
+++ b/conans/test/functional/toolchains/cmake/cmakedeps/test_apple_frameworks.py
@@ -191,8 +191,8 @@ timer_cpp = textwrap.dedent("""
 @pytest.mark.skipif(platform.system() != "Darwin", reason="Only OSX")
 @pytest.mark.parametrize("settings",
                          [('',),
-                          ('-s os=iOS -s os.version=10.0 -s arch=armv8',),
-                          ("-s os=tvOS -s os.version=11.0 -s arch=armv8",)])
+                          ('-pr:b default -s os=iOS -s os.version=10.0 -s arch=armv8',),
+                          ("-pr:b default -s os=tvOS -s os.version=11.0 -s arch=armv8",)])
 def test_apple_own_framework_cross_build(settings):
     client = TestClient()
 

--- a/conans/test/functional/toolchains/cmake/test_cmaketoolchain_paths.py
+++ b/conans/test/functional/toolchains/cmake/test_cmaketoolchain_paths.py
@@ -6,7 +6,8 @@ import pytest
 from conans.test.utils.tools import TestClient
 
 
-ios10_armv8_settings = "-s os=iOS -s os.version=10.0 -s arch=armv8"
+ios10_armv8_settings = "-s os=iOS -s os.sdk=iphoneos -s os.version=10.0 -s arch=armv8"
+
 
 class _FindRootPathModes(object):
     def __init__(self, package=None, library=None, framework=None, include=None, program=None):
@@ -16,6 +17,7 @@ class _FindRootPathModes(object):
         self.include = include
         self.program = program
 
+
 find_root_path_modes_default = _FindRootPathModes()
 find_root_path_modes_cross_build = _FindRootPathModes(
     package="ONLY",
@@ -24,6 +26,7 @@ find_root_path_modes_cross_build = _FindRootPathModes(
     include="ONLY",
     program="NEVER",
 )
+
 
 def _cmake_command_toolchain(find_root_path_modes):
     cmake_command = "cmake .. -DCMAKE_TOOLCHAIN_FILE=../conan_toolchain.cmake"

--- a/conans/test/functional/toolchains/cmake/test_cmaketoolchain_paths.py
+++ b/conans/test/functional/toolchains/cmake/test_cmaketoolchain_paths.py
@@ -13,7 +13,8 @@ def test_cmaketoolchain_path_find(package, find_package):
     """Test with user "Hello" and also ZLIB one, to check that package ZLIB
     has priority over the CMake system one
 
-    Also, that user cmake files in builddirs -except root- are accessible via CMake include() or find_package()
+    Also, that user cmake files in builddirs are accessible via CMake include() or find_package()
+    CMake config files at root package folder are not accessible
     """
     client = TestClient()
     conanfile = textwrap.dedent("""

--- a/conans/test/functional/toolchains/cmake/test_cmaketoolchain_paths.py
+++ b/conans/test/functional/toolchains/cmake/test_cmaketoolchain_paths.py
@@ -108,6 +108,149 @@ def test_cmaketoolchain_path_include_cmake_modules(require_type):
 
 
 @pytest.mark.tool_cmake
+def test_cmaketoolchain_path_find_file_find_path():
+    """Test that headers in includedirs of requires can be found with
+    find_file() and find_path() in consumer CMakeLists
+    """
+    client = TestClient()
+
+    conanfile = textwrap.dedent("""
+        from conans import ConanFile
+        class TestConan(ConanFile):
+            settings = "os", "arch", "compiler", "build_type"
+            exports = "*"
+            def layout(self):
+                pass
+            def package(self):
+                self.copy(pattern="*.h", dst="include")
+    """)
+    client.save({"conanfile.py": conanfile, "hello.h": ""})
+    client.run("create . hello/0.1@")
+
+    consumer = textwrap.dedent("""
+        cmake_minimum_required(VERSION 3.15)
+        project(MyHello)
+        find_file(HELLOFILE hello.h)
+        if(HELLOFILE)
+            message("Found file hello.h")
+        endif()
+        find_path(HELLODIR hello.h)
+        if(HELLODIR)
+            message("Found path of hello.h")
+        endif()
+    """)
+    client.save({"CMakeLists.txt": consumer}, clean_first=True)
+    client.run("install hello/0.1@ -g CMakeToolchain")
+    with client.chdir("build"):
+        client.run_command("cmake .. -DCMAKE_TOOLCHAIN_FILE=../conan_toolchain.cmake")
+    assert "Found file hello.h" in client.out
+    assert "Found path of hello.h" in client.out
+
+
+@pytest.mark.tool_cmake
+def test_cmaketoolchain_path_find_library():
+    """Test that libraries in libdirs of requires can be found with
+    find_library() in consumer CMakeLists
+    """
+    client = TestClient()
+
+    conanfile = textwrap.dedent("""
+        from conans import ConanFile
+        class TestConan(ConanFile):
+            settings = "os", "arch", "compiler", "build_type"
+            exports = "*"
+            def layout(self):
+                pass
+            def package(self):
+                self.copy(pattern="*", dst="lib")
+    """)
+    client.save({"conanfile.py": conanfile, "libhello.a": "", "hello.lib": ""})
+    client.run("create . hello/0.1@")
+
+    consumer = textwrap.dedent("""
+        cmake_minimum_required(VERSION 3.15)
+        project(MyHello)
+        find_library(HELLOLIB hello)
+        if(HELLOLIB)
+            message("Found hello lib")
+        endif()
+    """)
+    client.save({"CMakeLists.txt": consumer}, clean_first=True)
+    client.run("install hello/0.1@ -g CMakeToolchain")
+    with client.chdir("build"):
+        client.run_command("cmake .. -DCMAKE_TOOLCHAIN_FILE=../conan_toolchain.cmake")
+    assert "Found hello lib" in client.out
+
+
+@pytest.mark.tool_cmake
+def test_cmaketoolchain_path_find_program():
+    """Test that executables in bindirs of build_requires can be found with
+    find_program() in consumer CMakeLists.
+    Moreover, they must be found before any other executable of requires.
+    """
+    client = TestClient()
+
+    conanfile = textwrap.dedent("""
+        import os
+        from conans import ConanFile
+        class TestConan(ConanFile):
+            settings = "os", "arch", "compiler", "build_type"
+            exports = "*"
+            def layout(self):
+                pass
+            def package(self):
+                self.copy(pattern="*", dst="bin")
+            def package_info(self):
+                self.cpp_info.bindirs = [os.path.join("bin", "require_host")]
+    """)
+    client.save({"conanfile.py": conanfile,
+                 "require_host/hello": "", "require_host/hello.exe": ""})
+    client.run("create . hello_host/0.1@")
+
+    conanfile = textwrap.dedent("""
+        import os
+        from conans import ConanFile
+        class TestConan(ConanFile):
+            settings = "os", "arch", "compiler", "build_type"
+            exports = "*"
+            def layout(self):
+                pass
+            def package(self):
+                self.copy(pattern="*", dst="bin")
+            def package_info(self):
+                self.cpp_info.bindirs = [os.path.join("bin", "require_build")]
+    """)
+    client.save({"conanfile.py": conanfile,
+                 "require_build/hello": "", "require_build/hello.exe": ""},
+                clean_first=True)
+    client.run("create . hello_build/0.1@")
+
+    conanfile = textwrap.dedent("""
+        from conans import ConanFile
+        class TestConan(ConanFile):
+            settings = "os", "arch", "compiler", "build_type"
+            requires = "hello_host/0.1"
+            build_requires = "hello_build/0.1"
+    """)
+    consumer = textwrap.dedent("""
+        cmake_minimum_required(VERSION 3.15)
+        project(MyHello)
+        find_program(HELLOPROG hello)
+        if(HELLOPROG)
+            message("Found hello prog: ${HELLOPROG}")
+        endif()
+    """)
+    client.save({"conanfile.py": conanfile, "CMakeLists.txt": consumer},
+                clean_first=True)
+    client.run("install . pkg/0.1@ -g CMakeToolchain")
+    with client.chdir("build"):
+        client.run_command("cmake .. -DCMAKE_TOOLCHAIN_FILE=../conan_toolchain.cmake")
+    assert "Found hello prog" in client.out
+    assert os.path.join("require_host", "hello") not in client.out
+    assert os.path.join("require_build", "hello") in client.out
+
+
+@pytest.mark.tool_cmake
 def test_cmaketoolchain_path_find_real_config():
     client = TestClient()
     conanfile = textwrap.dedent("""

--- a/conans/test/functional/toolchains/cmake/test_cmaketoolchain_paths.py
+++ b/conans/test/functional/toolchains/cmake/test_cmaketoolchain_paths.py
@@ -21,7 +21,9 @@ def test_cmaketoolchain_path_find_package(package, find_package):
             def layout(self):
                 pass
             def package(self):
-                self.copy(pattern="*", keep_path=False)
+                self.copy(pattern="*")
+            def package_info(self):
+                self.cpp_info.builddirs.append("cmake")
         """)
     find = textwrap.dedent("""
         SET({package}_FOUND 1)
@@ -30,10 +32,14 @@ def test_cmaketoolchain_path_find_package(package, find_package):
 
     filename = "{}Config.cmake" if find_package == "config" else "Find{}.cmake"
     filename = filename.format(package)
-    client.save({"conanfile.py": conanfile, "{}".format(filename): find})
+    client.save({"conanfile.py": conanfile})
+    client.save({"{}".format(filename): find},
+                os.path.join(client.current_folder, "cmake"))
     client.run("create . {}/0.1@".format(package))
 
     consumer = textwrap.dedent("""
+        set(CMAKE_CXX_COMPILER_WORKS 1)
+        set(CMAKE_CXX_ABI_COMPILED 1)
         cmake_minimum_required(VERSION 3.15)
         project(MyHello CXX)
         find_package({package} REQUIRED)
@@ -71,11 +77,15 @@ def test_cmaketoolchain_path_include_cmake_modules(require_type):
                 pass
             def package(self):
                 self.copy(pattern="*")
+            def package_info(self):
+                self.cpp_info.builddirs.append("cmake")
     """)
     myowncmake = textwrap.dedent("""
         MESSAGE("MYOWNCMAKE FROM hello!")
     """)
-    client.save({"conanfile.py": conanfile, "myowncmake.cmake": myowncmake})
+    client.save({"conanfile.py": conanfile})
+    client.save({"myowncmake.cmake": myowncmake},
+                os.path.join(client.current_folder, "cmake"))
     client.run("create . hello/0.1@")
 
     conanfile = textwrap.dedent("""
@@ -176,6 +186,7 @@ def test_cmaketoolchain_path_find_library():
 def test_cmaketoolchain_path_find_program():
     """Test that executables in bindirs of build_requires can be found with
     find_program() in consumer CMakeLists.
+    Moreover, they must be found before any other executable of requires.
     """
     client = TestClient()
 
@@ -190,11 +201,10 @@ def test_cmaketoolchain_path_find_program():
             def package(self):
                 self.copy(pattern="*", dst="bin")
             def package_info(self):
-                self.cpp_info.bindirs = [os.path.join("bin", "require_host", "bin")]
-                self.cpp_info.builddirs.append(os.path.join("bin", "require_host"))
+                self.cpp_info.bindirs = [os.path.join("bin", "require_host")]
     """)
     client.save({"conanfile.py": conanfile,
-                 "require_host/bin/hello": "", "require_host/bin/hello.exe": ""})
+                 "require_host/hello": "", "require_host/hello.exe": ""})
     client.run("create . hello_host/0.1@")
 
     conanfile = textwrap.dedent("""
@@ -208,11 +218,10 @@ def test_cmaketoolchain_path_find_program():
             def package(self):
                 self.copy(pattern="*", dst="bin")
             def package_info(self):
-                self.cpp_info.bindirs = [os.path.join("bin", "require_build", "bin")]
-                self.cpp_info.builddirs.append(os.path.join("bin", "require_build"))
+                self.cpp_info.bindirs = [os.path.join("bin", "require_build")]
     """)
     client.save({"conanfile.py": conanfile,
-                 "require_build/bin/hello": "", "require_build/bin/hello.exe": ""},
+                 "require_build/hello": "", "require_build/hello.exe": ""},
                 clean_first=True)
     client.run("create . hello_build/0.1@")
 
@@ -237,8 +246,8 @@ def test_cmaketoolchain_path_find_program():
     with client.chdir("build"):
         client.run_command("cmake .. -DCMAKE_TOOLCHAIN_FILE=../conan_toolchain.cmake")
     assert "Found hello prog" in client.out
-    assert "require_host/bin/hello" not in client.out
-    assert "require_build/bin/hello" in client.out
+    assert "require_host/hello" not in client.out
+    assert "require_build/hello" in client.out
 
 
 @pytest.mark.tool_cmake
@@ -247,6 +256,7 @@ def test_cmaketoolchain_path_find_real_config():
     conanfile = textwrap.dedent("""
         from conans import ConanFile
         from conan.tools.cmake import CMake
+        import os
         class TestConan(ConanFile):
             settings = "os", "compiler", "build_type", "arch"
             exports = "*"
@@ -262,6 +272,9 @@ def test_cmaketoolchain_path_find_real_config():
             def package(self):
                 cmake = CMake(self)
                 cmake.install()
+
+            def package_info(self):
+                self.cpp_info.builddirs.append(os.path.join("hello", "cmake"))
         """)
     cmake = textwrap.dedent("""
         cmake_minimum_required(VERSION 3.15)

--- a/conans/test/functional/toolchains/cmake/test_cmaketoolchain_paths.py
+++ b/conans/test/functional/toolchains/cmake/test_cmaketoolchain_paths.py
@@ -200,11 +200,8 @@ def test_cmaketoolchain_path_find_program():
                 pass
             def package(self):
                 self.copy(pattern="*", dst="bin")
-            def package_info(self):
-                self.cpp_info.bindirs = [os.path.join("bin", "require_host")]
     """)
-    client.save({"conanfile.py": conanfile,
-                 "require_host/hello": "", "require_host/hello.exe": ""})
+    client.save({"conanfile.py": conanfile, "hello": "", "hello.exe": ""})
     client.run("create . hello_host/0.1@")
 
     conanfile = textwrap.dedent("""
@@ -217,11 +214,8 @@ def test_cmaketoolchain_path_find_program():
                 pass
             def package(self):
                 self.copy(pattern="*", dst="bin")
-            def package_info(self):
-                self.cpp_info.bindirs = [os.path.join("bin", "require_build")]
     """)
-    client.save({"conanfile.py": conanfile,
-                 "require_build/hello": "", "require_build/hello.exe": ""},
+    client.save({"conanfile.py": conanfile, "hello": "", "hello.exe": ""},
                 clean_first=True)
     client.run("create . hello_build/0.1@")
 
@@ -246,8 +240,8 @@ def test_cmaketoolchain_path_find_program():
     with client.chdir("build"):
         client.run_command("cmake .. -DCMAKE_TOOLCHAIN_FILE=../conan_toolchain.cmake")
     assert "Found hello prog" in client.out
-    assert "require_host/hello" not in client.out
-    assert "require_build/hello" in client.out
+    assert "hello_host/0.1/" not in client.out
+    assert "hello_build/0.1/" in client.out
 
 
 @pytest.mark.tool_cmake

--- a/conans/test/functional/toolchains/cmake/test_cmaketoolchain_paths.py
+++ b/conans/test/functional/toolchains/cmake/test_cmaketoolchain_paths.py
@@ -1,4 +1,3 @@
-import os
 import textwrap
 
 import pytest
@@ -32,9 +31,7 @@ def test_cmaketoolchain_path_find_package(package, find_package):
 
     filename = "{}Config.cmake" if find_package == "config" else "Find{}.cmake"
     filename = filename.format(package)
-    client.save({"conanfile.py": conanfile})
-    client.save({"{}".format(filename): find},
-                os.path.join(client.current_folder, "cmake"))
+    client.save({"conanfile.py": conanfile, "cmake/{}".format(filename): find})
     client.run("create . {}/0.1@".format(package))
 
     consumer = textwrap.dedent("""
@@ -80,12 +77,8 @@ def test_cmaketoolchain_path_include_cmake_modules(require_type):
             def package_info(self):
                 self.cpp_info.builddirs.append("cmake")
     """)
-    myowncmake = textwrap.dedent("""
-        MESSAGE("MYOWNCMAKE FROM hello!")
-    """)
-    client.save({"conanfile.py": conanfile})
-    client.save({"myowncmake.cmake": myowncmake},
-                os.path.join(client.current_folder, "cmake"))
+    myowncmake = 'MESSAGE("MYOWNCMAKE FROM hello!")'
+    client.save({"conanfile.py": conanfile, "cmake/myowncmake.cmake": myowncmake})
     client.run("create . hello/0.1@")
 
     conanfile = textwrap.dedent("""
@@ -99,8 +92,7 @@ def test_cmaketoolchain_path_include_cmake_modules(require_type):
         project(MyHello)
         include(myowncmake)
     """)
-    client.save({"conanfile.py": conanfile,
-                 "CMakeLists.txt": consumer}, clean_first=True)
+    client.save({"conanfile.py": conanfile, "CMakeLists.txt": consumer}, clean_first=True)
     client.run("install . pkg/0.1@ -g CMakeToolchain")
     with client.chdir("build"):
         client.run_command("cmake .. -DCMAKE_TOOLCHAIN_FILE=../conan_toolchain.cmake")
@@ -303,4 +295,3 @@ def test_cmaketoolchain_path_find_real_config():
     with client.chdir("build2"):  # A clean folder, not the previous one, CMake cache doesnt affect
         client.run_command("cmake .. -DCMAKE_TOOLCHAIN_FILE=../conan_toolchain.cmake")
     assert "Conan: Target declared 'hello::hello'" in client.out
-

--- a/conans/test/functional/toolchains/cmake/test_cmaketoolchain_paths.py
+++ b/conans/test/functional/toolchains/cmake/test_cmaketoolchain_paths.py
@@ -13,16 +13,16 @@ ios10_armv8_settings = "-s os=iOS -s os.version=10.0 -s arch=armv8"
 @pytest.mark.parametrize("package", ["hello", "ZLIB"])
 @pytest.mark.parametrize("find_package", ["module", "config"])
 @pytest.mark.parametrize(
-    ("build_profile", "settings"),
+    "settings",
     [
-        ("default", ""),
+        "",
         pytest.param(
-            "default", ios10_armv8_settings,
+            ios10_armv8_settings,
             marks=pytest.mark.skipif(platform.system() != "Darwin", reason="OSX only"),
         ),
     ],
 )
-def test_cmaketoolchain_path_find_package(package, find_package, build_profile, settings):
+def test_cmaketoolchain_path_find_package(package, find_package, settings):
     """Test with user "Hello" and also ZLIB one, to check that package ZLIB
     has priority over the CMake system one
     """
@@ -47,7 +47,7 @@ def test_cmaketoolchain_path_find_package(package, find_package, build_profile, 
     filename = "{}Config.cmake" if find_package == "config" else "Find{}.cmake"
     filename = filename.format(package)
     client.save({"conanfile.py": conanfile, "cmake/{}".format(filename): find})
-    client.run("create . {}/0.1@ -pr:b {} {}".format(package, build_profile, settings))
+    client.run("create . {}/0.1@ -pr:b default {}".format(package, settings))
 
     consumer = textwrap.dedent("""
         cmake_minimum_required(VERSION 3.15)
@@ -56,15 +56,15 @@ def test_cmaketoolchain_path_find_package(package, find_package, build_profile, 
         """).format(package=package)
 
     client.save({"CMakeLists.txt": consumer}, clean_first=True)
-    client.run("install {}/0.1@ -g CMakeToolchain -pr:b {} {}".format(package, build_profile, settings))
+    client.run("install {}/0.1@ -g CMakeToolchain -pr:b default {}".format(package, settings))
     with client.chdir("build"):
         client.run_command("cmake .. -DCMAKE_TOOLCHAIN_FILE=../conan_toolchain.cmake")
     assert "Conan: Target declared" not in client.out
     assert "HELLO FROM THE {package} FIND PACKAGE!".format(package=package) in client.out
 
     # If using the CMakeDeps generator, the in-package .cmake will be ignored
-    client.run("install {}/0.1@ -g CMakeToolchain -g CMakeDeps -pr:b {} {}".format(
-        package, build_profile, settings
+    client.run("install {}/0.1@ -g CMakeToolchain -g CMakeDeps -pr:b default {}".format(
+        package, settings,
     ))
     with client.chdir("build2"):  # A clean folder, not the previous one, CMake cache doesnt affect
         client.run_command("cmake .. -DCMAKE_TOOLCHAIN_FILE=../conan_toolchain.cmake")
@@ -74,16 +74,16 @@ def test_cmaketoolchain_path_find_package(package, find_package, build_profile, 
 
 @pytest.mark.tool_cmake
 @pytest.mark.parametrize(
-    ("build_profile", "settings"),
+    "settings",
     [
-        ("default", ""),
+        "",
         pytest.param(
-            "default", ios10_armv8_settings,
+            ios10_armv8_settings,
             marks=pytest.mark.skipif(platform.system() != "Darwin", reason="OSX only"),
         ),
     ],
 )
-def test_cmaketoolchain_path_find_package_real_config(build_profile, settings):
+def test_cmaketoolchain_path_find_package_real_config(settings):
     client = TestClient()
 
     conanfile = textwrap.dedent("""
@@ -125,7 +125,7 @@ def test_cmaketoolchain_path_find_package_real_config(build_profile, settings):
         )
         """)
     client.save({"conanfile.py": conanfile, "CMakeLists.txt": cmake})
-    client.run("create . hello/0.1@ -pr:b {} {}".format(build_profile, settings))
+    client.run("create . hello/0.1@ -pr:b default {}".format(settings))
 
     consumer = textwrap.dedent("""
         project(MyHello NONE)
@@ -135,14 +135,14 @@ def test_cmaketoolchain_path_find_package_real_config(build_profile, settings):
         """)
 
     client.save({"CMakeLists.txt": consumer}, clean_first=True)
-    client.run("install hello/0.1@ -g CMakeToolchain -pr:b {} {}".format(build_profile, settings))
+    client.run("install hello/0.1@ -g CMakeToolchain -pr:b default {}".format(settings))
     with client.chdir("build"):
         client.run_command("cmake .. -DCMAKE_TOOLCHAIN_FILE=../conan_toolchain.cmake")
     # If it didn't fail, it found the helloConfig.cmake
     assert "Conan: Target declared" not in client.out
 
     # If using the CMakeDeps generator, the in-package .cmake will be ignored
-    client.run("install hello/0.1@ -g CMakeToolchain -g CMakeDeps -pr:b {} {}".format(build_profile, settings))
+    client.run("install hello/0.1@ -g CMakeToolchain -g CMakeDeps -pr:b default {}".format(settings))
     with client.chdir("build2"):  # A clean folder, not the previous one, CMake cache doesnt affect
         client.run_command("cmake .. -DCMAKE_TOOLCHAIN_FILE=../conan_toolchain.cmake")
     assert "Conan: Target declared 'hello::hello'" in client.out
@@ -151,16 +151,16 @@ def test_cmaketoolchain_path_find_package_real_config(build_profile, settings):
 @pytest.mark.tool_cmake
 @pytest.mark.parametrize("require_type", ["requires", "build_requires"])
 @pytest.mark.parametrize(
-    ("build_profile", "settings"),
+    "settings",
     [
-        ("default", ""),
+        "",
         pytest.param(
-            "default", ios10_armv8_settings,
+            ios10_armv8_settings,
             marks=pytest.mark.skipif(platform.system() != "Darwin", reason="OSX only"),
         ),
     ],
 )
-def test_cmaketoolchain_path_include_cmake_modules(require_type, build_profile, settings):
+def test_cmaketoolchain_path_include_cmake_modules(require_type, settings):
     """Test that cmake module files in builddirs of requires and build_requires
     are accessible with include() in consumer CMakeLists
     """
@@ -180,10 +180,9 @@ def test_cmaketoolchain_path_include_cmake_modules(require_type, build_profile, 
     """)
     myowncmake = 'MESSAGE("MYOWNCMAKE FROM hello!")'
     client.save({"conanfile.py": conanfile, "cmake/myowncmake.cmake": myowncmake})
-    if require_type == "requires":
-        client.run("create . hello/0.1@ -pr:b {} {}".format(build_profile, settings))
-    else:
-        client.run("create . hello/0.1@ -pr {}".format(build_profile))
+    client.run("create . hello/0.1@{}".format(
+        " -pr:b default {}".format(settings) if require_type == "requires" else "",
+    ))
 
     conanfile = textwrap.dedent("""
         from conans import ConanFile
@@ -197,7 +196,7 @@ def test_cmaketoolchain_path_include_cmake_modules(require_type, build_profile, 
         include(myowncmake)
     """)
     client.save({"conanfile.py": conanfile, "CMakeLists.txt": consumer}, clean_first=True)
-    client.run("install . pkg/0.1@ -g CMakeToolchain -pr:b {} {}".format(build_profile, settings))
+    client.run("install . pkg/0.1@ -g CMakeToolchain -pr:b default {}".format(settings))
     with client.chdir("build"):
         client.run_command("cmake .. -DCMAKE_TOOLCHAIN_FILE=../conan_toolchain.cmake")
     assert "MYOWNCMAKE FROM hello!" in client.out
@@ -205,16 +204,16 @@ def test_cmaketoolchain_path_include_cmake_modules(require_type, build_profile, 
 
 @pytest.mark.tool_cmake
 @pytest.mark.parametrize(
-    ("build_profile", "settings"),
+    "settings",
     [
-        ("default", ""),
+        "",
         pytest.param(
-            "default", ios10_armv8_settings,
+            ios10_armv8_settings,
             marks=pytest.mark.skipif(platform.system() != "Darwin", reason="OSX only"),
         ),
     ],
 )
-def test_cmaketoolchain_path_find_file_find_path(build_profile, settings):
+def test_cmaketoolchain_path_find_file_find_path(settings):
     """Test that headers in includedirs of requires can be found with
     find_file() and find_path() in consumer CMakeLists
     """
@@ -231,7 +230,7 @@ def test_cmaketoolchain_path_find_file_find_path(build_profile, settings):
                 self.copy(pattern="*.h", dst="include")
     """)
     client.save({"conanfile.py": conanfile, "hello.h": ""})
-    client.run("create . hello/0.1@ -pr:b {} {}".format(build_profile, settings))
+    client.run("create . hello/0.1@ -pr:b default {}".format(settings))
 
     consumer = textwrap.dedent("""
         cmake_minimum_required(VERSION 3.15)
@@ -246,7 +245,7 @@ def test_cmaketoolchain_path_find_file_find_path(build_profile, settings):
         endif()
     """)
     client.save({"CMakeLists.txt": consumer}, clean_first=True)
-    client.run("install hello/0.1@ -g CMakeToolchain -pr:b {} {}".format(build_profile, settings))
+    client.run("install hello/0.1@ -g CMakeToolchain -pr:b default {}".format(settings))
     with client.chdir("build"):
         client.run_command("cmake .. -DCMAKE_TOOLCHAIN_FILE=../conan_toolchain.cmake")
     assert "Found file hello.h" in client.out
@@ -255,16 +254,16 @@ def test_cmaketoolchain_path_find_file_find_path(build_profile, settings):
 
 @pytest.mark.tool_cmake
 @pytest.mark.parametrize(
-    ("build_profile", "settings"),
+    "settings",
     [
-        ("default", ""),
+        "",
         pytest.param(
-            "default", ios10_armv8_settings,
+            ios10_armv8_settings,
             marks=pytest.mark.skipif(platform.system() != "Darwin", reason="OSX only"),
         ),
     ],
 )
-def test_cmaketoolchain_path_find_library(build_profile, settings):
+def test_cmaketoolchain_path_find_library(settings):
     """Test that libraries in libdirs of requires can be found with
     find_library() in consumer CMakeLists
     """
@@ -281,8 +280,8 @@ def test_cmaketoolchain_path_find_library(build_profile, settings):
                 self.copy(pattern="*", dst="lib")
     """)
     client.save({"conanfile.py": conanfile, "libhello.a": "", "hello.lib": ""})
-    client.run("create . hello_host/0.1@ -pr:b {} {}".format(build_profile, settings))
-    client.run("create . hello_build/0.1@ -pr {}".format(build_profile))
+    client.run("create . hello_host/0.1@ -pr:b default {}".format(settings))
+    client.run("create . hello_build/0.1@")
 
     conanfile = textwrap.dedent("""
         from conans import ConanFile
@@ -300,7 +299,7 @@ def test_cmaketoolchain_path_find_library(build_profile, settings):
         endif()
     """)
     client.save({"conanfile.py": conanfile, "CMakeLists.txt": consumer}, clean_first=True)
-    client.run("install . pkg/0.1@ -g CMakeToolchain -pr:b {} {}".format(build_profile, settings))
+    client.run("install . pkg/0.1@ -g CMakeToolchain -pr:b default {}".format(settings))
     with client.chdir("build"):
         client.run_command("cmake .. -DCMAKE_TOOLCHAIN_FILE=../conan_toolchain.cmake")
     assert "Found hello lib" in client.out
@@ -310,16 +309,16 @@ def test_cmaketoolchain_path_find_library(build_profile, settings):
 
 @pytest.mark.tool_cmake
 @pytest.mark.parametrize(
-    ("build_profile", "settings"),
+    "settings",
     [
-        ("default", ""),
+        "",
         pytest.param(
-            "default", ios10_armv8_settings,
+            ios10_armv8_settings,
             marks=pytest.mark.skipif(platform.system() != "Darwin", reason="OSX only"),
         ),
     ],
 )
-def test_cmaketoolchain_path_find_program(build_profile, settings):
+def test_cmaketoolchain_path_find_program(settings):
     """Test that executables in bindirs of build_requires can be found with
     find_program() in consumer CMakeLists.
     """
@@ -336,8 +335,8 @@ def test_cmaketoolchain_path_find_program(build_profile, settings):
                 self.copy(pattern="*", dst="bin")
     """)
     client.save({"conanfile.py": conanfile, "hello": "", "hello.exe": ""})
-    client.run("create . hello_host/0.1@ -pr:b {} {}".format(build_profile, settings))
-    client.run("create . hello_build/0.1@ -pr {}".format(build_profile))
+    client.run("create . hello_host/0.1@ -pr:b default {}".format(settings))
+    client.run("create . hello_build/0.1@")
 
     conanfile = textwrap.dedent("""
         from conans import ConanFile
@@ -355,7 +354,7 @@ def test_cmaketoolchain_path_find_program(build_profile, settings):
         endif()
     """)
     client.save({"conanfile.py": conanfile, "CMakeLists.txt": consumer}, clean_first=True)
-    client.run("install . pkg/0.1@ -g CMakeToolchain -pr:b {} {}".format(build_profile, settings))
+    client.run("install . pkg/0.1@ -g CMakeToolchain -pr:b default {}".format(settings))
     with client.chdir("build"):
         client.run_command("cmake .. -DCMAKE_TOOLCHAIN_FILE=../conan_toolchain.cmake")
     assert "Found hello prog" in client.out

--- a/conans/test/functional/toolchains/cmake/test_cmaketoolchain_paths.py
+++ b/conans/test/functional/toolchains/cmake/test_cmaketoolchain_paths.py
@@ -246,8 +246,8 @@ def test_cmaketoolchain_path_find_program():
     with client.chdir("build"):
         client.run_command("cmake .. -DCMAKE_TOOLCHAIN_FILE=../conan_toolchain.cmake")
     assert "Found hello prog" in client.out
-    assert os.path.join("require_host", "hello") not in client.out
-    assert os.path.join("require_build", "hello") in client.out
+    assert "require_host/hello" not in client.out
+    assert "require_build/hello" in client.out
 
 
 @pytest.mark.tool_cmake

--- a/conans/test/functional/toolchains/cmake/test_cmaketoolchain_paths.py
+++ b/conans/test/functional/toolchains/cmake/test_cmaketoolchain_paths.py
@@ -35,8 +35,6 @@ def test_cmaketoolchain_path_find_package(package, find_package):
     client.run("create . {}/0.1@".format(package))
 
     consumer = textwrap.dedent("""
-        set(CMAKE_CXX_COMPILER_WORKS 1)
-        set(CMAKE_CXX_ABI_COMPILED 1)
         cmake_minimum_required(VERSION 3.15)
         project(MyHello CXX)
         find_package({package} REQUIRED)
@@ -83,7 +81,7 @@ def test_cmaketoolchain_path_include_cmake_modules(require_type):
 
     conanfile = textwrap.dedent("""
         from conans import ConanFile
-        class Pkg(ConanFile):
+        class PkgConan(ConanFile):
             settings = "os", "compiler", "arch", "build_type"
             {require_type} = "hello/0.1"
     """.format(require_type=require_type))
@@ -162,7 +160,7 @@ def test_cmaketoolchain_path_find_library():
 
     conanfile = textwrap.dedent("""
         from conans import ConanFile
-        class TestConan(ConanFile):
+        class PkgConan(ConanFile):
             settings = "os", "arch", "compiler", "build_type"
             requires = "hello_host/0.1"
             build_requires = "hello_build/0.1"
@@ -192,7 +190,6 @@ def test_cmaketoolchain_path_find_program():
     client = TestClient()
 
     conanfile = textwrap.dedent("""
-        import os
         from conans import ConanFile
         class TestConan(ConanFile):
             settings = "os", "arch", "compiler", "build_type"
@@ -208,7 +205,7 @@ def test_cmaketoolchain_path_find_program():
 
     conanfile = textwrap.dedent("""
         from conans import ConanFile
-        class TestConan(ConanFile):
+        class PkgConan(ConanFile):
             settings = "os", "arch", "compiler", "build_type"
             requires = "hello_host/0.1"
             build_requires = "hello_build/0.1"

--- a/conans/test/functional/toolchains/cmake/test_cmaketoolchain_paths.py
+++ b/conans/test/functional/toolchains/cmake/test_cmaketoolchain_paths.py
@@ -92,6 +92,103 @@ def test_cmaketoolchain_path_find_package(package, find_package, host):
 
 
 @pytest.mark.tool_cmake
+@pytest.mark.parametrize(
+    "host",
+    [
+        "native",
+        pytest.param(
+            "cross_build_iOS", marks=pytest.mark.skipif(
+                platform.system() != "Darwin", reason="OSX only",
+            ),
+        ),
+    ],
+)
+def test_cmaketoolchain_path_find_package_real_config(host):
+    client = TestClient()
+
+    cross_build = "cross_build" in host
+    if cross_build:
+        host_profile = "ios12.0-armv8"
+        profile_content = textwrap.dedent("""
+            include(default)
+            [settings]
+            os=iOS
+            os.version=12.0
+            arch=armv8
+        """)
+        client.save({host_profile: profile_content})
+
+    conanfile = textwrap.dedent("""
+        from conans import ConanFile
+        from conan.tools.cmake import CMake
+        import os
+        class TestConan(ConanFile):
+            settings = "os", "compiler", "build_type", "arch"
+            exports = "*"
+            generators = "CMakeToolchain"
+
+            def layout(self):
+                pass
+
+            def build(self):
+                cmake = CMake(self)
+                cmake.configure()
+
+            def package(self):
+                cmake = CMake(self)
+                cmake.install()
+
+            def package_info(self):
+                self.cpp_info.builddirs.append(os.path.join("hello", "cmake"))
+        """)
+    cmake = textwrap.dedent("""
+        cmake_minimum_required(VERSION 3.15)
+        project(MyHello NONE)
+
+        add_library(hello INTERFACE)
+        install(TARGETS hello EXPORT helloConfig)
+        export(TARGETS hello
+            NAMESPACE hello::
+            FILE "${CMAKE_CURRENT_BINARY_DIR}/helloConfig.cmake"
+        )
+        install(EXPORT helloConfig
+            DESTINATION "${CMAKE_INSTALL_PREFIX}/hello/cmake"
+            NAMESPACE hello::
+        )
+        """)
+    client.save({"conanfile.py": conanfile, "CMakeLists.txt": cmake})
+    client.run("create . hello/0.1@{}".format(
+        " -pr:b default -pr:h {}".format(host_profile) if cross_build else "",
+    ))
+
+    consumer = textwrap.dedent("""
+        project(MyHello NONE)
+        cmake_minimum_required(VERSION 3.15)
+
+        find_package(hello REQUIRED)
+        """)
+
+    client.save({"CMakeLists.txt": consumer}, clean_first=True)
+    if cross_build:
+        client.save({host_profile: profile_content})
+    client.run("install hello/0.1@ -g CMakeToolchain{}".format(
+        " -pr:b default -pr:h {}".format(host_profile) if cross_build else "",
+    ))
+    with client.chdir("build"):
+        client.run_command("cmake .. -DCMAKE_TOOLCHAIN_FILE=../conan_toolchain.cmake")
+    # If it didn't fail, it found the helloConfig.cmake
+    assert "Conan: Target declared" not in client.out
+
+    # If using the CMakeDeps generator, the in-package .cmake will be ignored
+    client.run("install hello/0.1@ -g CMakeToolchain -g CMakeDeps{}".format(
+        " -pr:b default -pr:h {}".format(host_profile) if cross_build else "",
+    ))
+    with client.chdir("build2"):  # A clean folder, not the previous one, CMake cache doesnt affect
+        client.run_command("cmake .. -DCMAKE_TOOLCHAIN_FILE=../conan_toolchain.cmake")
+    assert "Conan: Target declared 'hello::hello'" in client.out
+
+
+@pytest.mark.tool_cmake
 @pytest.mark.parametrize("require_type", ["requires", "build_requires"])
 def test_cmaketoolchain_path_include_cmake_modules(require_type):
     """Test that cmake module files in builddirs of requires and build_requires
@@ -348,70 +445,3 @@ def test_cmaketoolchain_path_find_program(host):
     assert "Found hello prog" in client.out
     assert "hello_host/0.1/" not in client.out
     assert "hello_build/0.1/" in client.out
-
-
-@pytest.mark.tool_cmake
-def test_cmaketoolchain_path_find_real_config():
-    client = TestClient()
-    conanfile = textwrap.dedent("""
-        from conans import ConanFile
-        from conan.tools.cmake import CMake
-        import os
-        class TestConan(ConanFile):
-            settings = "os", "compiler", "build_type", "arch"
-            exports = "*"
-            generators = "CMakeToolchain"
-
-            def layout(self):
-                pass
-
-            def build(self):
-                cmake = CMake(self)
-                cmake.configure()
-
-            def package(self):
-                cmake = CMake(self)
-                cmake.install()
-
-            def package_info(self):
-                self.cpp_info.builddirs.append(os.path.join("hello", "cmake"))
-        """)
-    cmake = textwrap.dedent("""
-        cmake_minimum_required(VERSION 3.15)
-        project(MyHello NONE)
-
-        add_library(hello INTERFACE)
-        install(TARGETS hello EXPORT helloConfig)
-        export(TARGETS hello
-            NAMESPACE hello::
-            FILE "${CMAKE_CURRENT_BINARY_DIR}/helloConfig.cmake"
-        )
-        install(EXPORT helloConfig
-            DESTINATION "${CMAKE_INSTALL_PREFIX}/hello/cmake"
-            NAMESPACE hello::
-        )
-        """)
-    client.save({"conanfile.py": conanfile,
-                 "CMakeLists.txt": cmake})
-    client.run("create . hello/0.1@")
-
-    consumer = textwrap.dedent("""
-        project(MyHello NONE)
-        cmake_minimum_required(VERSION 3.15)
-
-        find_package(hello REQUIRED)
-        """)
-
-    client.save({"CMakeLists.txt": consumer}, clean_first=True)
-    client.run("install hello/0.1@ -g CMakeToolchain")
-    with client.chdir("build"):
-        client.run_command("cmake .. -DCMAKE_TOOLCHAIN_FILE=../conan_toolchain.cmake")
-    # If it didn't fail, it found the helloConfig.cmake
-    assert "Conan: Target declared" not in client.out
-
-    # If using the CMakeDeps generator, the in-package .cmake will be ignored
-    # But it is still possible to include(owncmake)
-    client.run("install hello/0.1@ -g CMakeToolchain -g CMakeDeps")
-    with client.chdir("build2"):  # A clean folder, not the previous one, CMake cache doesnt affect
-        client.run_command("cmake .. -DCMAKE_TOOLCHAIN_FILE=../conan_toolchain.cmake")
-    assert "Conan: Target declared 'hello::hello'" in client.out

--- a/conans/test/integration/toolchains/cmake/test_cmaketoolchain.py
+++ b/conans/test/integration/toolchains/cmake/test_cmaketoolchain.py
@@ -193,8 +193,7 @@ def test_cross_build_conf():
     assert "set(CMAKE_SYSTEM_PROCESSOR myarm)" in toolchain
 
 
-@pytest.mark.parametrize("find_builddir", [True, False, None])
-def test_find_builddirs(find_builddir):
+def test_find_builddirs():
     client = TestClient()
     conanfile = textwrap.dedent("""
             import os
@@ -227,14 +226,8 @@ def test_find_builddirs(find_builddir):
                     cmake.generate()
             """)
 
-    if find_builddir is not None:
-        conanfile = conanfile.format('cmake.find_builddirs = {}'.format(str(find_builddir)))
-
     client.save({"conanfile.py": conanfile})
     client.run("install . ")
     with open(os.path.join(client.current_folder, "conan_toolchain.cmake")) as f:
         contents = f.read()
-        if find_builddir is True or find_builddir is None:
-            assert "/path/to/builddir" in contents
-        else:
-            assert "/path/to/builddir" not in contents
+        assert "/path/to/builddir" in contents

--- a/conans/test/unittests/tools/cmake/test_cmaketoolchain.py
+++ b/conans/test/unittests/tools/cmake/test_cmaketoolchain.py
@@ -138,10 +138,6 @@ def test_user_toolchain(conanfile):
     content = toolchain.content
     assert 'include("myowntoolchain.cmake")' in content
 
-    toolchain = CMakeToolchain(conanfile)
-    content = toolchain.content
-    assert 'include(' not in content
-
 
 @pytest.fixture
 def conanfile_apple():


### PR DESCRIPTION
Changelog: Fix: Improved CMakeToolchain robustness regarding ``find_file``, ``find_path`` and ``find_program`` commands allowing better cross-build scenarios and better differentiation of the right context where to get, for example,  executables (build vs host).
Docs: https://github.com/conan-io/docs/pull/2383

- In `find_program()`, avoid to find executables of host context before executables of build context.
- support all cross-build scenario (hopefully).
- support `include()` of CMake modules coming from build context.
- remove `CMakeToolchain.find_builddirs` (doesn't make sense anymore).


- [x] Refer to the issue that supports this Pull Request.
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [ ] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 

<sup>**Note:** By default this PR will skip the slower tests and will use a limited set of python versions. Check [here](https://github.com/conan-io/conan/blob/develop/.github/PR_INCREASE_TESTING.md) how to increase the testing level by writing some tags in the current PR body text.</sup>

closes https://github.com/conan-io/conan/issues/9427
closes https://github.com/conan-io/conan/issues/9735
closes https://github.com/conan-io/conan/issues/10167
