### PR TITLE
[bugfix] msvc in legacy cmake generators

### DIFF
--- a/conans/client/build/cmake_flags.py
+++ b/conans/client/build/cmake_flags.py
@@ -2,6 +2,7 @@ import os
 import platform
 from collections import OrderedDict
 
+from conan.tools.microsoft.visual import vs_ide_version
 from conans.client import tools
 from conans.client.build.compiler_flags import architecture_flag, parallel_compiler_cl_flag
 from conans.client.build.cppstd_flags import cppstd_from_settings, cppstd_flag_new as cppstd_flag
@@ -53,18 +54,26 @@ def get_generator(conanfile):
             return None
         return "Unix Makefiles"
 
+    cmake_years = {'8': '8 2005',
+                   '9': '9 2008',
+                   '10': '10 2010',
+                   '11': '11 2012',
+                   '12': '12 2013',
+                   '14': '14 2015',
+                   '15': '15 2017',
+                   '16': '16 2019',
+                   '17': '17 2022'}
+
+    if compiler == "msvc":
+        if compiler_version is None:
+            raise ConanException("compiler.version must be defined")
+        vs_version = vs_ide_version(conanfile)
+        return "Visual Studio %s" % cmake_years[vs_version]
+
     if compiler == "Visual Studio" or compiler_base == "Visual Studio":
         version = compiler_base_version or compiler_version
         major_version = version.split('.', 1)[0]
-        _visuals = {'8': '8 2005',
-                    '9': '9 2008',
-                    '10': '10 2010',
-                    '11': '11 2012',
-                    '12': '12 2013',
-                    '14': '14 2015',
-                    '15': '15 2017',
-                    '16': '16 2019',
-                    '17': '17 2022'}.get(major_version, "UnknownVersion %s" % version)
+        _visuals = cmake_years.get(major_version, "UnknownVersion %s" % version)
         base = "Visual Studio %s" % _visuals
         return base
 

--- a/conans/test/unittests/client/build/test_cmake_flags.py
+++ b/conans/test/unittests/client/build/test_cmake_flags.py
@@ -1,16 +1,19 @@
+import pytest
+
 from conans.client.build.cmake_flags import get_generator
 from conans.test.utils.mocks import ConanFileMock, MockSettings
 
 
-class TestGetGenerator(object):
+@pytest.mark.parametrize("compiler,version,expected", [
+    ("Visual Studio", "15", "Visual Studio 15 2017"),
+    ("Visual Studio", "15.9", "Visual Studio 15 2017"),
+    ("msvc", "193", "Visual Studio 17 2022"),
+    ("msvc", "192", "Visual Studio 16 2019")
+])
+def test_vs_generator(compiler, version, expected):
+    settings = MockSettings({"os": "Windows", "arch": "x86_64", "compiler": compiler})
+    conanfile = ConanFileMock()
+    conanfile.settings = settings
 
-    def test_vs_generator(self):
-        settings = MockSettings({"os": "Windows", "arch": "x86_64", "compiler": "Visual Studio"})
-        conanfile = ConanFileMock()
-        conanfile.settings = settings
-
-        settings.values['compiler.version'] = '15'
-        assert get_generator(conanfile) == 'Visual Studio 15 2017'
-
-        settings.values['compiler.version'] = '15.9'
-        assert get_generator(conanfile) == 'Visual Studio 15 2017'
+    settings.values['compiler.version'] = version
+    assert get_generator(conanfile) == expected


### PR DESCRIPTION
Changelog: Bugfix: Compiler `msvc` was not working for CMake legacy generators.
Docs: omit

Closes: #10185

- [x] Refer to the issue that supports this Pull Request.
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 

<sup>**Note:** By default this PR will skip the slower tests and will use a limited set of python versions. Check [here](https://github.com/conan-io/conan/blob/develop/.github/PR_INCREASE_TESTING.md) how to increase the testing level by writing some tags in the current PR body text.</sup>
