### PR TITLE
Extending loop checking beyond visibility to avoid infinite loops

### DIFF
--- a/conans/client/graph/graph.py
+++ b/conans/client/graph/graph.py
@@ -151,6 +151,16 @@ class Node(object):
         source_node = dependant.src
         return source_node.check_downstream_exists(down_require)
 
+    def check_loops(self, new_node):
+        if self.ref == new_node.ref:
+            return self
+        if not self.dependants:
+            return
+        assert len(self.dependants) == 1
+        dependant = self.dependants[0]
+        source_node = dependant.src
+        return source_node.check_loops(new_node)
+
     @property
     def package_id(self):
         return self._package_id

--- a/conans/client/graph/graph_builder.py
+++ b/conans/client/graph/graph_builder.py
@@ -273,6 +273,10 @@ class DepsGraphBuilder(object):
         if node.propagate_downstream(require, new_node):
             raise GraphError.runtime(node, new_node)
 
+        ancestor = node.check_loops(new_node)
+        if ancestor is not None:
+            raise GraphError.loop(new_node, require, ancestor)
+
         return new_node
 
     @staticmethod

--- a/conans/model/requires.py
+++ b/conans/model/requires.py
@@ -391,7 +391,7 @@ class Requirements:
         self._requires[req] = req
 
     def build_require(self, ref, raise_if_duplicated=True, package_id_mode=None, visible=False,
-                      run=None,options=None):
+                      run=None, options=None):
         """
              Represent a generic build require, could be a tool, like "cmake" or a bundle of build
              scripts.
@@ -412,7 +412,6 @@ class Requirements:
         self._requires[req] = req
 
     def override(self, ref):
-        name = ref.name
         req = Requirement(ref)
         old_requirement = self._requires.get(req)
         if old_requirement is not None:


### PR DESCRIPTION
While working on https://github.com/conan-io/conan/issues/10193, realized that it is easy that build_requires go into infinite loops in 2.0 dependency resolution. This PR aims to improve this.