### PR TITLE
Add build_modules and build_modules_paths to JsonGenerator

### DIFF
--- a/conans/client/generators/json_generator.py
+++ b/conans/client/generators/json_generator.py
@@ -13,7 +13,8 @@ def serialize_cpp_info(cpp_info):
         "libs",
         "system_libs",
         "defines", "cflags", "cxxflags", "sharedlinkflags", "exelinkflags",
-        "frameworks", "framework_paths", "names", "filenames"
+        "frameworks", "framework_paths", "names", "filenames",
+        "build_modules", "build_modules_paths"
     ]
     res = {}
     for key in keys:

--- a/conans/test/unittests/client/generators/json_test.py
+++ b/conans/test/unittests/client/generators/json_test.py
@@ -1,4 +1,5 @@
 import json
+import os
 import unittest
 
 from mock import Mock
@@ -25,6 +26,7 @@ class JsonTest(unittest.TestCase):
         cpp_info.cflags.append("-Flag1=23")
         cpp_info.version = "1.3"
         cpp_info.description = "My cool description"
+        cpp_info.build_modules.append("cmake/module.cmake")
         conanfile.deps_cpp_info.add(ref.name, cpp_info)
 
         ref = ConanFileReference.loads("MyPkg2/0.1@lasote/stables")
@@ -65,6 +67,20 @@ class JsonTest(unittest.TestCase):
         self.assertEqual(my_pkg["name"], "MyPkg")
         self.assertEqual(my_pkg["description"], "My cool description")
         self.assertEqual(my_pkg["defines"], ["MYDEFINE1"])
+        self.assertListEqual(my_pkg["build_modules"]["cmake"], ["cmake/module.cmake"])
+        self.assertListEqual(my_pkg["build_modules"]["cmake_multi"], ["cmake/module.cmake"])
+        self.assertListEqual(my_pkg["build_modules"]["cmake_find_package"], ["cmake/module.cmake"])
+        self.assertListEqual(my_pkg["build_modules"]["cmake_find_package_multi"],
+                             ["cmake/module.cmake"])
+        self.assertListEqual(my_pkg["build_modules_paths"]["cmake"],
+                             [os.path.join("dummy_root_folder1", "cmake/module.cmake")])
+        self.assertListEqual(my_pkg["build_modules_paths"]["cmake_multi"],
+                             [os.path.join("dummy_root_folder1", "cmake/module.cmake")])
+        self.assertListEqual(my_pkg["build_modules_paths"]["cmake_find_package"],
+                             [os.path.join("dummy_root_folder1", "cmake/module.cmake")])
+        self.assertListEqual(my_pkg["build_modules_paths"]["cmake_find_package_multi"],
+                             [os.path.join("dummy_root_folder1", "cmake/module.cmake")])
+
 
         # Check env_info
         env_info = parsed["deps_env_info"]


### PR DESCRIPTION
Changelog: Feature: Add build_modules and build_modules_paths to JsonGenerator.
Fixes: #10202
Docs: https://github.com/conan-io/docs/pull/2329

- [X] Refer to the issue that supports this Pull Request.
- [X] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [X] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [X] I've followed the PEP8 style guides for Python code.
- [X] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 

<sup>**Note:** By default this PR will skip the slower tests and will use a limited set of python versions. Check [here](https://github.com/conan-io/conan/blob/develop/.github/PR_INCREASE_TESTING.md) how to increase the testing level by writing some tags in the current PR body text.</sup>
