### PR TITLE
do not convert to property legacy build_modules

### DIFF
--- a/conans/model/new_build_info.py
+++ b/conans/model/new_build_info.py
@@ -242,29 +242,6 @@ def from_old_cppinfo(old):
     ret = NewCppInfo()
     ret.merge(old)
     ret.clear_none()
-
-    def _copy_build_modules_to_property(origin, dest):
-        current_value = dest.get_property("cmake_build_modules") or []
-        if isinstance(origin.build_modules, list):
-            current_value.extend([v for v in origin.build_modules if v not in current_value])
-        else:
-            multi = origin.build_modules.get("cmake_find_package_multi")
-            no_multi = origin.build_modules.get("cmake_find_package")
-            if multi:
-                current_value.extend([v for v in multi if v not in current_value])
-            if no_multi:
-                current_value.extend([v for v in no_multi if v not in current_value])
-        dest.set_property("cmake_build_modules", current_value)
-
-    # Copy the build modules as the new recommended property
-    if old.build_modules:
-        _copy_build_modules_to_property(old, ret)
-
-    for cname, c in old.components.items():
-        if c.build_modules:
-            # The build modules properties are applied to the root cppinfo, not per component
-            # because it is something global that makes no sense to be set at a component
-            _copy_build_modules_to_property(c, ret)
     return ret
 
 

--- a/conans/test/unittests/conan_build_info/new_build_info_test.py
+++ b/conans/test/unittests/conan_build_info/new_build_info_test.py
@@ -184,8 +184,7 @@ def test_from_old_cppinfo_components():
     assert cppinfo.components["foo"].requires == ["my_req::my_component"]
     assert cppinfo.components["foo2"].get_property("cmake_build_modules") is None
 
-    assert cppinfo.get_property("cmake_build_modules") == \
-           ["foo_my_scripts.cmake", "foo.cmake", "foo2_my_scripts.cmake"]
+    assert cppinfo.get_property("cmake_build_modules") is None
 
 
 def test_from_old_cppinfo_no_components():
@@ -204,8 +203,7 @@ def test_from_old_cppinfo_no_components():
     for n in _DIRS_VAR_NAMES + _FIELD_VAR_NAMES:
         assert getattr(cppinfo, n) == ["var_{}_1".format(n), "var_{}_2".format(n)]
 
-    assert cppinfo.get_property("cmake_build_modules") == ["my_scripts.cmake",
-                                                           "foo2.cmake", "foo.cmake"]
+    assert cppinfo.get_property("cmake_build_modules") is None
     assert cppinfo.requires == ["my_req::my_component"]
 
 


### PR DESCRIPTION
Changelog: Fix: Do not convert to ``cmake_build_modules`` property the legacy ``cpp_info.build_modules``.
Docs: Omit

As per discussed for the migration, this shouldn't be done
