### PR TITLE
Custom CMakeToolchain blocks without subclass

### DIFF
--- a/conan/tools/cmake/__init__.py
+++ b/conan/tools/cmake/__init__.py
@@ -1,5 +1,4 @@
 from conan.tools.cmake.toolchain import CMakeToolchain
-from conan.tools.cmake.toolchain import Block as CMakeToolchainBlock
 from conan.tools.cmake.cmake import CMake
 from conan.tools.cmake.cmakedeps.cmakedeps import CMakeDeps
 from conan.tools.cmake.file_api import CMakeFileAPI

--- a/conan/tools/cmake/toolchain.py
+++ b/conan/tools/cmake/toolchain.py
@@ -654,7 +654,7 @@ class ToolchainBlocks:
         del self._blocks[name]
 
     def __setitem__(self, name, block_type):
-        if Block not in block_type.__mro__:  # tuple of classes that are considered base classes.
+        if not issubclass(block_type, Block):
             # Create a new class inheriting Block with the elements of the provided one
             block_type = type('proxyUserBlock', (Block,), dict(block_type.__dict__))
 

--- a/conan/tools/cmake/toolchain.py
+++ b/conan/tools/cmake/toolchain.py
@@ -654,10 +654,8 @@ class ToolchainBlocks:
         del self._blocks[name]
 
     def __setitem__(self, name, block_type):
-        if not issubclass(block_type, Block):
-            # Create a new class inheriting Block with the elements of the provided one
-            block_type = type('proxyUserBlock', (Block,), dict(block_type.__dict__))
-
+        # Create a new class inheriting Block with the elements of the provided one
+        block_type = type('proxyUserBlock', (Block,), dict(block_type.__dict__))
         self._blocks[name] = block_type(self._conanfile, self._toolchain)
 
     def __getitem__(self, name):

--- a/conan/tools/cmake/toolchain.py
+++ b/conan/tools/cmake/toolchain.py
@@ -654,7 +654,9 @@ class ToolchainBlocks:
         del self._blocks[name]
 
     def __setitem__(self, name, block_type):
-        self._blocks[name] = block_type(self._conanfile, self._toolchain)
+        # Create a new class inheriting Block with the elements of the provided one
+        new_class = type('proxyUserBlock', (Block,), dict(block_type.__dict__))
+        self._blocks[name] = new_class(self._conanfile, self._toolchain)
 
     def __getitem__(self, name):
         return self._blocks[name]

--- a/conan/tools/cmake/toolchain.py
+++ b/conan/tools/cmake/toolchain.py
@@ -654,9 +654,11 @@ class ToolchainBlocks:
         del self._blocks[name]
 
     def __setitem__(self, name, block_type):
-        # Create a new class inheriting Block with the elements of the provided one
-        new_class = type('proxyUserBlock', (Block,), dict(block_type.__dict__))
-        self._blocks[name] = new_class(self._conanfile, self._toolchain)
+        if Block not in block_type.__mro__:  # tuple of classes that are considered base classes.
+            # Create a new class inheriting Block with the elements of the provided one
+            block_type = type('proxyUserBlock', (Block,), dict(block_type.__dict__))
+
+        self._blocks[name] = block_type(self._conanfile, self._toolchain)
 
     def __getitem__(self, name):
         return self._blocks[name]

--- a/conans/test/integration/toolchains/cmake/test_cmaketoolchain_blocks.py
+++ b/conans/test/integration/toolchains/cmake/test_cmaketoolchain_blocks.py
@@ -8,12 +8,12 @@ def test_custom_block():
     c = TestClient()
     conanfile = textwrap.dedent("""
         from conans import ConanFile
-        from conan.tools.cmake import CMakeToolchain, CMakeToolchainBlock
+        from conan.tools.cmake import CMakeToolchain
         class Pkg(ConanFile):
             def generate(self):
                 toolchain = CMakeToolchain(self)
 
-                class MyBlock(CMakeToolchainBlock):
+                class MyBlock:
                     template = "Hello {{myvar}}!!!"
 
                     def context(self):

--- a/conans/test/unittests/tools/cmake/test_cmaketoolchain.py
+++ b/conans/test/unittests/tools/cmake/test_cmaketoolchain.py
@@ -115,23 +115,6 @@ def test_add_new_block(conanfile):
     assert 'CMAKE_BUILD_TYPE' in content
 
 
-def test_extend_block(conanfile):
-    toolchain = CMakeToolchain(conanfile)
-
-    class MyBlock(GenericSystemBlock):
-        template = "Hello {{build_type}}!!"
-
-        def context(self):
-            c = super(MyBlock, self).context()
-            c["build_type"] = c["build_type"] + "Super"
-            return c
-
-    toolchain.blocks["generic_system"] = MyBlock
-    content = toolchain.content
-    assert 'Hello ReleaseSuper!!' in content
-    assert 'CMAKE_BUILD_TYPE' not in content
-
-
 def test_user_toolchain(conanfile):
     toolchain = CMakeToolchain(conanfile)
     toolchain.blocks["user_toolchain"].user_toolchain = "myowntoolchain.cmake"


### PR DESCRIPTION
Changelog: Feature: Adding a new Block to the CMakeToolchain now doesn't require inheriting `CMakeToolchainBlock`. 
Docs: https://github.com/conan-io/docs/pull/2337
Closes #10118