### PR TITLE
remove cpp_info properties per-generator

### DIFF
--- a/conan/tools/cmake/cmakedeps/cmakedeps.py
+++ b/conan/tools/cmake/cmakedeps/cmakedeps.py
@@ -80,7 +80,7 @@ class CMakeDeps(object):
             if dep.is_build_context and dep.ref.name not in self.build_context_activated:
                 continue
 
-            cmake_find_mode = dep.cpp_info.get_property("cmake_find_mode", "CMakeDeps")
+            cmake_find_mode = dep.cpp_info.get_property("cmake_find_mode")
             cmake_find_mode = cmake_find_mode or FIND_MODE_CONFIG
             cmake_find_mode = cmake_find_mode.lower()
             # Skip from the requirement

--- a/conan/tools/cmake/cmakedeps/templates/__init__.py
+++ b/conan/tools/cmake/cmakedeps/templates/__init__.py
@@ -85,10 +85,10 @@ class CMakeDepsFileTemplate(object):
 
     def get_root_target_name(self, req, suffix=""):
         if self.find_module_mode:
-            ret = req.cpp_info.get_property("cmake_module_target_name", "CMakeDeps")
+            ret = req.cpp_info.get_property("cmake_module_target_name")
             if ret:
                 return ret
-        ret = req.cpp_info.get_property("cmake_target_name", "CMakeDeps")
+        ret = req.cpp_info.get_property("cmake_target_name")
         return ret or self._get_target_default_name(req, suffix=suffix)
 
     def get_component_alias(self, req, comp_name):
@@ -99,10 +99,10 @@ class CMakeDepsFileTemplate(object):
             raise ConanException("Component '{name}::{cname}' not found in '{name}' "
                                  "package requirement".format(name=req.ref.name, cname=comp_name))
         if self.find_module_mode:
-            ret = req.cpp_info.components[comp_name].get_property("cmake_module_target_name", "CMakeDeps")
+            ret = req.cpp_info.components[comp_name].get_property("cmake_module_target_name")
             if ret:
                 return ret
-        ret = req.cpp_info.components[comp_name].get_property("cmake_target_name", "CMakeDeps")
+        ret = req.cpp_info.components[comp_name].get_property("cmake_target_name")
         # If we don't specify the `cmake_target_name` property for the component it will
         # fallback to the pkg_name::comp_name, it wont use the root cpp_info cmake_target_name
         # property because that is also an absolute name (Greetings::Greetings), it is not a namespace

--- a/conan/tools/cmake/cmakedeps/templates/target_data.py
+++ b/conan/tools/cmake/cmakedeps/templates/target_data.py
@@ -224,5 +224,5 @@ class _TargetDataContext(object):
 
         self.objects_list = join_paths(cpp_info.objects)
 
-        build_modules = cpp_info.get_property("cmake_build_modules", "CMakeDeps") or []
+        build_modules = cpp_info.get_property("cmake_build_modules") or []
         self.build_modules_paths = join_paths(build_modules)

--- a/conan/tools/cmake/cmakedeps/templates/targets.py
+++ b/conan/tools/cmake/cmakedeps/templates/targets.py
@@ -26,7 +26,7 @@ class TargetsTemplate(CMakeDepsFileTemplate):
         target_pattern += "{}-Target-*.cmake".format(self.file_name)
 
         cmake_target_aliases = self.conanfile.cpp_info.\
-            get_property("cmake_target_aliases", "CMakeDeps") or dict()
+            get_property("cmake_target_aliases") or dict()
 
         target = self.root_target_name
         cmake_target_aliases = {alias: target for alias in cmake_target_aliases}
@@ -36,7 +36,7 @@ class TargetsTemplate(CMakeDepsFileTemplate):
             if comp_name is not None:
                 aliases = \
                     self.conanfile.cpp_info.components[comp_name].\
-                    get_property("cmake_target_aliases", "CMakeDeps") or dict()
+                    get_property("cmake_target_aliases") or dict()
 
                 target = self.get_component_alias(self.conanfile, comp_name)
                 cmake_component_target_aliases[comp_name] = {alias: target for alias in aliases}

--- a/conan/tools/cmake/utils.py
+++ b/conan/tools/cmake/utils.py
@@ -9,9 +9,9 @@ def get_file_name(conanfile, find_module_mode=False):
     # This is used by the CMakeToolchain to adjust the XXX_DIR variables and the CMakeDeps. Both
     # to know the file name that will have the XXX-config.cmake files.
     if find_module_mode:
-        ret = conanfile.cpp_info.get_property("cmake_module_file_name", "CMakeDeps")
+        ret = conanfile.cpp_info.get_property("cmake_module_file_name")
         if ret:
             return ret
-    ret = conanfile.cpp_info.get_property("cmake_file_name", "CMakeDeps")
+    ret = conanfile.cpp_info.get_property("cmake_file_name")
     return ret or conanfile.ref.name
 

--- a/conan/tools/files/cpp_package.py
+++ b/conan/tools/files/cpp_package.py
@@ -51,7 +51,7 @@ class CppPackage(object):
                 #  target names via set_property
                 conanfile.cpp_info.components[cname].set_property("cmake_target_name",
                                                                   "{}::{}".format(conanfile.ref.name,
-                                                                                  gname), generator)
+                                                                                  gname))
 
     def add_component(self, name):
         """

--- a/conan/tools/gnu/pkgconfigdeps/pc_files_templates.py
+++ b/conan/tools/gnu/pkgconfigdeps/pc_files_templates.py
@@ -100,7 +100,7 @@ def get_pc_filename_and_content(conanfile, dep, name, requires, description, cpp
     prefix_path = package_folder.replace("\\", "/")
     libdirs = _get_formatted_dirs(cpp_info.libdirs, prefix_path)
     includedirs = _get_formatted_dirs(cpp_info.includedirs, prefix_path)
-    custom_content = cpp_info.get_property("pkg_config_custom_content", "PkgConfigDeps")
+    custom_content = cpp_info.get_property("pkg_config_custom_content")
 
     context = {
         "prefix_path": prefix_path,

--- a/conan/tools/gnu/pkgconfigdeps/pc_info_loader.py
+++ b/conan/tools/gnu/pkgconfigdeps/pc_info_loader.py
@@ -20,7 +20,7 @@ def _get_package_reference_name(dep):
 
 
 def _get_package_aliases(dep):
-    pkg_aliases = dep.cpp_info.get_property("pkg_config_aliases", "PkgConfigDeps")
+    pkg_aliases = dep.cpp_info.get_property("pkg_config_aliases")
     return pkg_aliases or []
 
 
@@ -32,13 +32,12 @@ def _get_component_aliases(dep, comp_name):
         raise ConanException("Component '{name}::{cname}' not found in '{name}' "
                              "package requirement".format(name=_get_package_reference_name(dep),
                                                           cname=comp_name))
-    comp_aliases = dep.cpp_info.components[comp_name].get_property("pkg_config_aliases",
-                                                                   "PkgConfigDeps")
+    comp_aliases = dep.cpp_info.components[comp_name].get_property("pkg_config_aliases")
     return comp_aliases or []
 
 
 def _get_package_name(dep):
-    pkg_name = dep.cpp_info.get_property("pkg_config_name", "PkgConfigDeps")
+    pkg_name = dep.cpp_info.get_property("pkg_config_name")
     return pkg_name or _get_package_reference_name(dep)
 
 
@@ -50,7 +49,7 @@ def _get_component_name(dep, comp_name):
         raise ConanException("Component '{name}::{cname}' not found in '{name}' "
                              "package requirement".format(name=_get_package_reference_name(dep),
                                                           cname=comp_name))
-    comp_name = dep.cpp_info.components[comp_name].get_property("pkg_config_name", "PkgConfigDeps")
+    comp_name = dep.cpp_info.components[comp_name].get_property("pkg_config_name")
     return comp_name
 
 

--- a/conans/client/generators/pkg_config.py
+++ b/conans/client/generators/pkg_config.py
@@ -81,7 +81,7 @@ class PkgConfigGenerator(GeneratorComponentsMixin, Generator):
             includedir_vars = varnames
             lines.extend(dir_lines)
 
-        pkg_config_custom_content = cpp_info.get_property("pkg_config_custom_content", self.name)
+        pkg_config_custom_content = cpp_info.get_property("pkg_config_custom_content")
         if pkg_config_custom_content:
             lines.append(pkg_config_custom_content)
 

--- a/conans/model/build_info.py
+++ b/conans/model/build_info.py
@@ -220,7 +220,7 @@ class _CppInfo(object):
         property_name = None
         if "pkg_config" in generator:
             property_name = "pkg_config_name"
-        return self.get_property(property_name, generator) \
+        return self.get_property(property_name) \
                or self.names.get(generator, self._name if default_name else None)
 
     # TODO: Deprecate for 2.0. Only cmake generators should access this. Use get_property for 2.0

--- a/conans/model/build_info.py
+++ b/conans/model/build_info.py
@@ -234,17 +234,12 @@ class _CppInfo(object):
             self._build_modules = self.build_modules
         return self._build_modules
 
-    def set_property(self, property_name, value, generator=None):
-        self._generator_properties.setdefault(generator, {})[property_name] = value
+    def set_property(self, property_name, value):
+        self._generator_properties[property_name] = value
 
-    def get_property(self, property_name, generator=None):
-        if generator:
-            try:
-                return self._generator_properties[generator][property_name]
-            except KeyError:
-                pass
+    def get_property(self, property_name):
         try:
-            return self._generator_properties[None][property_name]
+            return self._generator_properties[property_name]
         except KeyError:
             pass
 

--- a/conans/model/new_build_info.py
+++ b/conans/model/new_build_info.py
@@ -47,21 +47,16 @@ class _NewComponent(object):
             return []
         return [r for r in self.requires if "::" not in r]
 
-    def set_property(self, property_name, value, generator=None):
+    def set_property(self, property_name, value):
         if self._generator_properties is None:
             self._generator_properties = {}
-        self._generator_properties.setdefault(generator, {})[property_name] = value
+        self._generator_properties[property_name] = value
 
-    def get_property(self, property_name, generator=None):
+    def get_property(self, property_name):
         if self._generator_properties is None:
             return None
-        if generator:
-            try:
-                return self._generator_properties[generator][property_name]
-            except KeyError:
-                pass
-        try:  # generator = None is the dict for all generators
-            return self._generator_properties[None][property_name]
+        try:
+            return self._generator_properties[property_name]
         except KeyError:
             pass
 

--- a/conans/test/integration/generators/cpp_info_set_generator_properties_test.py
+++ b/conans/test/integration/generators/cpp_info_set_generator_properties_test.py
@@ -26,7 +26,7 @@ def setup_client():
             def _get_components_custom_names(self, cpp_info):
                 ret = []
                 for comp_name, comp in self.sorted_components(cpp_info).items():
-                    comp_genname = comp.get_property("custom_name", generator=self.name)
+                    comp_genname = comp.get_property("custom_name")
                     ret.append("{}:{}".format(comp.name, comp_genname))
                 return ret
 
@@ -34,7 +34,7 @@ def setup_client():
             def content(self):
                 info = []
                 for pkg_name, cpp_info in self.deps_build_info.dependencies:
-                    info.append("{}:{}".format(pkg_name, cpp_info.get_property("custom_name", self.name)))
+                    info.append("{}:{}".format(pkg_name, cpp_info.get_property("custom_name")))
                     info.extend(self._get_components_custom_names(cpp_info))
                 return os.linesep.join(info)
         """)

--- a/conans/test/integration/generators/cpp_info_set_generator_properties_test.py
+++ b/conans/test/integration/generators/cpp_info_set_generator_properties_test.py
@@ -79,7 +79,7 @@ def test_properties_dont_affect_legacy_cmake_with_components(setup_client):
                 self.cpp_info.set_property("cmake_file_name", "AnotherFileName")
                 self.cpp_info.components["mycomponent"].set_property("cmake_target_name", "mycomponent-name-but-different")
                 self.cpp_info.components["mycomponent"].set_property("cmake_build_modules", [os.path.join("lib", "non-existing.cmake")])
-                self.cpp_info.components["mycomponent"].set_property("custom_name", "mycomponent-name", "custom_generator")
+                self.cpp_info.components["mycomponent"].set_property("custom_name", "mycomponent-name")
 
                 self.cpp_info.components["mycomponent"].libs = ["mycomponent-lib"]
                 self.cpp_info.filenames["cmake_find_package"] = "MyFileName"
@@ -145,7 +145,7 @@ def test_properties_dont_affect_legacy_cmake_without_components(setup_client):
                 self.cpp_info.set_property("cmake_target_name", "other-mypkg-name")
                 self.cpp_info.set_property("cmake_build_modules",[os.path.join("lib",
                                                                  "other-mypkg_bm.cmake")])
-                self.cpp_info.set_property("custom_name", "mypkg-name", "custom_generator")
+                self.cpp_info.set_property("custom_name", "mypkg-name")
 
                 self.cpp_info.filenames["cmake_find_package"] = "MyFileName"
                 self.cpp_info.filenames["cmake_find_package_multi"] = "MyFileName"
@@ -208,14 +208,14 @@ def test_properties_dont_affect_legacy_cmake_specific_generators(setup_client):
                 self.copy("mypkg_bm.cmake", dst="lib")
                 self.copy("mypkg_anootherbm.cmake", dst="lib")
             def package_info(self):
-                self.cpp_info.set_property("cmake_file_name", "OtherMyFileName", "cmake_find_package")
-                self.cpp_info.set_property("cmake_file_name", "OtherMyFileNameMulti", "cmake_find_package_multi")
-                self.cpp_info.set_property("cmake_target_name", "other-mypkg-name", "cmake_find_package")
-                self.cpp_info.set_property("cmake_target_name", "other-mypkg-name-multi", "cmake_find_package_multi")
+                self.cpp_info.set_property("cmake_file_name", "OtherMyFileName")
+                self.cpp_info.set_property("cmake_file_name", "OtherMyFileNameMulti")
+                self.cpp_info.set_property("cmake_target_name", "other-mypkg-name")
+                self.cpp_info.set_property("cmake_target_name", "other-mypkg-name-multi")
                 self.cpp_info.set_property("cmake_build_modules",[os.path.join("lib",
-                                                                 "mypkg_bm.cmake")], "other-cmake_find_package")
+                                                                 "mypkg_bm.cmake")],)
                 self.cpp_info.set_property("cmake_build_modules",[os.path.join("lib",
-                                                                 "mypkg_anootherbm.cmake")], "other-cmake_find_package_multi")
+                                                                 "mypkg_anootherbm.cmake")])
 
                 self.cpp_info.filenames["cmake_find_package"] = "MyFileName"
                 self.cpp_info.filenames["cmake_find_package_multi"] = "MyFileNameMulti"

--- a/conans/test/unittests/conan_build_info/new_build_info_test.py
+++ b/conans/test/unittests/conan_build_info/new_build_info_test.py
@@ -17,15 +17,13 @@ def test_components_order():
 
 def test_generator_properties_copy():
     cppinfo = NewCppInfo()
-    cppinfo.set_property("foo", "foo_value", "generator1")
-    cppinfo.set_property("foo", "var_value", "generator2")
-    cppinfo.set_property("foo2", "foo2_value", "generator1")
+    cppinfo.set_property("foo", "foo_value")
+    cppinfo.set_property("foo2", "foo2_value")
 
     copied = cppinfo.copy()
 
-    assert copied.get_property("foo") is None
-    assert copied.get_property("foo", "generator1") == "foo_value"
-    assert copied.get_property("foo", "generator2") == "var_value"
+    assert copied.get_property("foo") == "foo_value"
+    assert copied.get_property("foo2") == "foo2_value"
 
 
 def test_component_aggregation():
@@ -60,7 +58,7 @@ def test_component_aggregation():
     cppinfo.components["c1"].cxxflags = ["cxxflags_c1"]
     cppinfo.components["c1"].defines = ["defines_c1"]
     cppinfo.components["c1"].set_property("my_foo", "jander")
-    cppinfo.components["c1"].set_property("my_foo2", "bar2", "other_gen")
+    cppinfo.components["c1"].set_property("my_foo2", "bar2")
 
     ret = cppinfo.aggregated_components()
 
@@ -76,7 +74,7 @@ def test_component_aggregation():
     # that belongs to a component, it could make sense to aggregate it or not, "cmake_target_name"
     # for example, cannot be aggregated. But "cmake_build_modules" is aggregated.
     assert ret.get_property("my_foo") is None
-    assert ret.get_property("my_foo2", "other_gen") is None
+    assert ret.get_property("my_foo2") is None
     assert ret.get_property("cmake_build_modules") == None
 
     # If we change the internal graph the order is different
@@ -235,7 +233,7 @@ def test_fill_old_cppinfo():
     assert old_cpp.cxxflags == ["source_cxxflags"]
     assert old_cpp.cflags == ["package_cflags"]
     assert old_cpp.frameworkdirs == []
-    assert old_cpp.get_property("cmake_build_modules", "my_cmake.cmake")
+    assert old_cpp.get_property("cmake_build_modules")
     assert old_cpp.builddirs == ["my_build"]
 
 

--- a/conans/test/unittests/model/build_info/generic_properties_test.py
+++ b/conans/test/unittests/model/build_info/generic_properties_test.py
@@ -14,5 +14,4 @@ def test_set_get_properties():
     cpp_info.set_property("my_property", "pkg_config_value")
     assert cpp_info.get_property("my_property") == "pkg_config_value"
     cpp_info.set_property("other_property", "other_pkg_config_value")
-    assert not cpp_info.get_property("other_property")
     assert cpp_info.get_property("other_property") == "other_pkg_config_value"

--- a/conans/test/unittests/model/build_info/generic_properties_test.py
+++ b/conans/test/unittests/model/build_info/generic_properties_test.py
@@ -5,16 +5,14 @@ def test_set_get_properties():
     cpp_info = _CppInfo()
 
     assert not cpp_info.get_property("my_property")
-    assert not cpp_info.get_property("my_property", "some_generator")
 
     cpp_info.set_property("my_property", "default_value")
     assert cpp_info.get_property("my_property") == "default_value"
     # can you do a get_property for just a family without generator?
-    assert cpp_info.get_property("my_property", generator="cmake_multi") == "default_value"
-    assert cpp_info.get_property("my_property", generator="pkg_config") == "default_value"
+    assert cpp_info.get_property("my_property") == "default_value"
 
-    cpp_info.set_property("my_property", "pkg_config_value", generator="pkg_config")
-    assert cpp_info.get_property("my_property", generator="pkg_config") == "pkg_config_value"
-    cpp_info.set_property("other_property", "other_pkg_config_value", generator="pkg_config")
+    cpp_info.set_property("my_property", "pkg_config_value")
+    assert cpp_info.get_property("my_property") == "pkg_config_value"
+    cpp_info.set_property("other_property", "other_pkg_config_value")
     assert not cpp_info.get_property("other_property")
-    assert cpp_info.get_property("other_property", generator="pkg_config") == "other_pkg_config_value"
+    assert cpp_info.get_property("other_property") == "other_pkg_config_value"


### PR DESCRIPTION
Changelog: Fix: Remove ``generator`` argument from ``cpp_info.set_property()`` method.
Docs: https://github.com/conan-io/docs/pull/2331
