### PR TITLE
some minor fixes to premakedeps

### DIFF
--- a/conan/tools/premake/premake.py
+++ b/conan/tools/premake/premake.py
@@ -4,7 +4,7 @@ class Premake(object):
 
     # automatically chooses premake action based on used compiler
     def configure(self):
-        if "Visual Studio" in self.settings.compiler:
+        if "Visual Studio" in self._conanfile.settings.compiler:
             _visuals = {'8': '2005',
                         '9': '2008',
                         '10': '2010',
@@ -13,9 +13,9 @@ class Premake(object):
                         '14': '2015',
                         '15': '2017',
                         '16': '2019'}
-            premake_command = "premake5 vs%s" % _visuals.get(str(self.settings.compiler.version), "UnknownVersion %s" % str(self.settings.compiler.version))
-            self.run(premake_command)
-        elif "msvc" in self.settings.compiler:
+            premake_command = "premake5 vs%s" % _visuals.get(str(self._conanfile.settings.compiler.version))
+            self._conanfile.run(premake_command)
+        elif "msvc" in self._conanfile.settings.compiler:
             _visuals = {'14.0': '2005',
                         '15.0': '2008',
                         '16.0': '2010',
@@ -33,7 +33,7 @@ class Premake(object):
             for i in range(0,10):
                 ver = '19.2' + str(i)
                 _visuals[ver] = '2019'
-            premake_command = "premake5 vs%s" % _visuals.get(str(self.settings.compiler.version), "UnknownVersion %s" % str(self.settings.compiler.version))
-            self.run(premake_command)
+            premake_command = "premake5 vs%s" % _visuals.get(str(self._conanfile.settings.compiler.version))
+            self._conanfile.run(premake_command)
         else:
-            self.run("premake5 gmake2")
+            self._conanfile.run("premake5 gmake2")

--- a/conans/test/integration/toolchains/premake/test_premakedeps.py
+++ b/conans/test/integration/toolchains/premake/test_premakedeps.py
@@ -1,4 +1,3 @@
-import os
 import textwrap
 
 from conans.test.utils.tools import TestClient
@@ -13,6 +12,5 @@ def test_premakedeps():
     client.save({"conanfile.txt": conanfile}, clean_first=True)
     client.run("install .")
 
-    assert os.path.exists(os.path.join(client.current_folder, "conanbuildinfo.premake.lua"))
-    contents = client.load("conanbuildinfo.premake.lua")
+    contents = client.load("conandeps.premake.lua")
     assert 'function conan_basic_setup()' in contents


### PR DESCRIPTION
Changelog: Omit
Docs: Omit

Follow up of https://github.com/conan-io/conan/pull/10090

Hi @Enhex 

I have seen some minor things in the contributed code, that I think deserves a bit more work:

- The ``Premake`` helper is mostly broken, needs to get some functional testing
- The ``PremakeDeps`` was doing some legacy things, like trying to define build_type or architecture. That is not the responsibility of "xxxDeps" anymore.
- I have added a couple of "fixmes" it seems the generation of file per dependency is missing things (for example, components are not being aggregated).
- Modernized the name to ``conandeps.premake.lua``
- Done some minor Pep8 cleanings (recall that we are also using a width of 100 chars)

Overall, this is a good first step, but this integration still needs some work to take it to production level, including some good functional testing, so it is necessary to keep pushing it. I recommended not to document it, until it is matured a little bit more.