### PR TITLE
Fix module CMakeDeps vars and call find_dependency for transitive modules

### DIFF
--- a/conan/tools/cmake/cmakedeps/templates/config.py
+++ b/conan/tools/cmake/cmakedeps/templates/config.py
@@ -63,15 +63,14 @@ class ConfigTemplate(CMakeDepsFileTemplate):
             find_dependency({{ '${_DEPENDENCY}' }} REQUIRED MODULE)
         endforeach()
 
-        {% endif %}
+        {% else %}
 
         foreach(_DEPENDENCY {{ '${' + file_name + '_FIND_DEPENDENCY_NAMES' + '}' }} )
-            # if we did not set the <dependency>_FOUND var in a Find<Package>.cmake MODULE
-            # let's try to find the CONFIG files
-            if(NOT {{ '${_DEPENDENCY}' }}_FOUND)
-                find_dependency({{ '${_DEPENDENCY}' }} REQUIRED NO_MODULE)
-            endif()
+            find_dependency({{ '${_DEPENDENCY}' }} REQUIRED NO_MODULE)
         endforeach()
+
+        {% endif %}
+
 
         # Only the first installed configuration is included to avoid the collision
         foreach(_BUILD_MODULE {{ '${' + pkg_name + '_BUILD_MODULES_PATHS' + config_suffix + '}' }} )

--- a/conan/tools/cmake/cmakedeps/templates/config.py
+++ b/conan/tools/cmake/cmakedeps/templates/config.py
@@ -71,6 +71,9 @@ class ConfigTemplate(CMakeDepsFileTemplate):
             endif()
         endforeach()
 
+        set({{ file_name }}_INCLUDE_DIRS {{ '${' + pkg_name + '_INCLUDE_DIRS' + config_suffix + '}' }} )
+        set({{ file_name }}_LIBRARIES {{ '${' + pkg_name + '_LIBRARIES' + config_suffix + '}' }} )
+
         # Only the first installed configuration is included to avoid the collision
         foreach(_BUILD_MODULE {{ '${' + pkg_name + '_BUILD_MODULES_PATHS' + config_suffix + '}' }} )
             conan_message(STATUS "Conan: Including build module from '${_BUILD_MODULE}'")

--- a/conan/tools/cmake/cmakedeps/templates/config.py
+++ b/conan/tools/cmake/cmakedeps/templates/config.py
@@ -71,8 +71,11 @@ class ConfigTemplate(CMakeDepsFileTemplate):
             endif()
         endforeach()
 
+        set({{ file_name }}_VERSION_STRING "{{ version }}")
         set({{ file_name }}_INCLUDE_DIRS {{ '${' + pkg_name + '_INCLUDE_DIRS' + config_suffix + '}' }} )
+        set({{ file_name }}_INCLUDE_DIR {{ '${' + pkg_name + '_INCLUDE_DIRS' + config_suffix + '}' }} )
         set({{ file_name }}_LIBRARIES {{ '${' + pkg_name + '_LIBRARIES' + config_suffix + '}' }} )
+        set({{ file_name }}_DEFINITIONS {{ '${' + pkg_name + '_DEFINITIONS' + config_suffix + '}' }} )
 
         # Only the first installed configuration is included to avoid the collision
         foreach(_BUILD_MODULE {{ '${' + pkg_name + '_BUILD_MODULES_PATHS' + config_suffix + '}' }} )

--- a/conan/tools/cmake/cmakedeps/templates/config.py
+++ b/conan/tools/cmake/cmakedeps/templates/config.py
@@ -60,7 +60,7 @@ class ConfigTemplate(CMakeDepsFileTemplate):
         include(${CMAKE_CURRENT_LIST_DIR}/{{ targets_include_file }})
         include(CMakeFindDependencyMacro)
 
-        foreach(_DEPENDENCY {{ '${' + file_name + '_FIND_DEPENDENCY_NAMES' + '}' }} )
+        foreach(_DEPENDENCY {{ '${' + pkg_name + '_FIND_DEPENDENCY_NAMES' + '}' }} )
             # Check that we have not already called a find_package with the transitive dependency
             if(NOT {{ '${_DEPENDENCY}' }}_FOUND)
             {% if is_module %}

--- a/conan/tools/cmake/cmakedeps/templates/config.py
+++ b/conan/tools/cmake/cmakedeps/templates/config.py
@@ -45,22 +45,29 @@ class ConfigTemplate(CMakeDepsFileTemplate):
             message(FATAL_ERROR "The 'CMakeDeps' generator only works with CMake >= 3.15")
         endif()
 
-        {% if is_module %}
-        include(FindPackageHandleStandardArgs)
-        set({{ pkg_name }}_FOUND 1)
-        set({{ pkg_name }}_VERSION "{{ version }}")
-
-        find_package_handle_standard_args({{ pkg_name }}
-                                          REQUIRED_VARS {{ pkg_name }}_VERSION
-                                          VERSION_VAR {{ pkg_name }}_VERSION)
-        mark_as_advanced({{ pkg_name }}_FOUND {{ pkg_name }}_VERSION)
-        {% endif %}
-
         include(${CMAKE_CURRENT_LIST_DIR}/cmakedeps_macros.cmake)
         include(${CMAKE_CURRENT_LIST_DIR}/{{ targets_include_file }})
         include(CMakeFindDependencyMacro)
 
-        foreach(_DEPENDENCY {{ '${' + pkg_name + '_FIND_DEPENDENCY_NAMES' + '}' }} )
+        {% if is_module %}
+        include(FindPackageHandleStandardArgs)
+        set({{ file_name }}_FOUND 1)
+        set({{ file_name }}_VERSION "{{ version }}")
+
+        find_package_handle_standard_args({{ file_name }}
+                                          REQUIRED_VARS {{ file_name }}_VERSION
+                                          VERSION_VAR {{ file_name }}_VERSION)
+        mark_as_advanced({{ file_name }}_FOUND {{ file_name }}_VERSION)
+
+        foreach(_DEPENDENCY {{ '${' + file_name + '_FIND_DEPENDENCY_NAMES' + '}' }} )
+            find_dependency({{ '${_DEPENDENCY}' }} REQUIRED MODULE)
+        endforeach()
+
+        {% endif %}
+
+        foreach(_DEPENDENCY {{ '${' + file_name + '_FIND_DEPENDENCY_NAMES' + '}' }} )
+            # if we did not set the <dependency>_FOUND var in a Find<Package>.cmake MODULE
+            # let's try to find the CONFIG files
             if(NOT {{ '${_DEPENDENCY}' }}_FOUND)
                 find_dependency({{ '${_DEPENDENCY}' }} REQUIRED NO_MODULE)
             endif()

--- a/conan/tools/cmake/cmakedeps/templates/target_data.py
+++ b/conan/tools/cmake/cmakedeps/templates/target_data.py
@@ -45,6 +45,7 @@ class ConfigDataTemplate(CMakeDepsFileTemplate):
                                                       .replace('$', '\\$').replace('"', '\\"')
         return {"global_cpp": global_cpp,
                 "pkg_name": self.pkg_name,
+                "file_name": self.file_name,
                 "package_folder": package_folder,
                 "config_suffix": self.config_suffix,
                 "components_names": components_names,
@@ -60,8 +61,8 @@ class ConfigDataTemplate(CMakeDepsFileTemplate):
 
               set({{ pkg_name }}_COMPONENT_NAMES {{ '${'+ pkg_name }}_COMPONENT_NAMES} {{ components_names }})
               list(REMOVE_DUPLICATES {{ pkg_name }}_COMPONENT_NAMES)
-              set({{ pkg_name }}_FIND_DEPENDENCY_NAMES {{ '${'+ pkg_name }}_FIND_DEPENDENCY_NAMES} {{ dependency_filenames }})
-              list(REMOVE_DUPLICATES {{ pkg_name }}_FIND_DEPENDENCY_NAMES)
+              set({{ file_name }}_FIND_DEPENDENCY_NAMES {{ '${'+ file_name }}_FIND_DEPENDENCY_NAMES} {{ dependency_filenames }})
+              list(REMOVE_DUPLICATES {{ file_name }}_FIND_DEPENDENCY_NAMES)
 
               ########### VARIABLES #######################################################################
               #############################################################################################

--- a/conan/tools/cmake/cmakedeps/templates/target_data.py
+++ b/conan/tools/cmake/cmakedeps/templates/target_data.py
@@ -61,8 +61,8 @@ class ConfigDataTemplate(CMakeDepsFileTemplate):
 
               set({{ pkg_name }}_COMPONENT_NAMES {{ '${'+ pkg_name }}_COMPONENT_NAMES} {{ components_names }})
               list(REMOVE_DUPLICATES {{ pkg_name }}_COMPONENT_NAMES)
-              set({{ file_name }}_FIND_DEPENDENCY_NAMES {{ '${'+ file_name }}_FIND_DEPENDENCY_NAMES} {{ dependency_filenames }})
-              list(REMOVE_DUPLICATES {{ file_name }}_FIND_DEPENDENCY_NAMES)
+              set({{ pkg_name }}_FIND_DEPENDENCY_NAMES {{ '${'+ pkg_name }}_FIND_DEPENDENCY_NAMES} {{ dependency_filenames }})
+              list(REMOVE_DUPLICATES {{ pkg_name }}_FIND_DEPENDENCY_NAMES)
 
               ########### VARIABLES #######################################################################
               #############################################################################################

--- a/conans/test/functional/toolchains/cmake/cmakedeps/test_cmakedeps_find_module_and_config.py
+++ b/conans/test/functional/toolchains/cmake/cmakedeps/test_cmakedeps_find_module_and_config.py
@@ -111,3 +111,53 @@ def test_reuse_with_modules_and_config(client):
 
     client.run("install . -if=install")
     client.run("build . -if=install")
+
+
+@pytest.mark.parametrize("find_mode", ["both", "config", "module"])
+def test_transitive_modules_found(find_mode):
+    """
+    related to https://github.com/conan-io/conan/issues/10224
+    modules files variables were set with the pkg_name_FOUND or pkg_name_VERSION
+    instead of using filename_*, also there was missing doing a find_dependency of the
+    requires packages to find_package transitive dependencies
+    """
+    client = TestClient()
+    conan_pkg = textwrap.dedent("""
+        from conan import ConanFile
+        class Pkg(ConanFile):
+            {requires}
+            def package_info(self):
+                self.cpp_info.set_property("cmake_find_mode", "{mode}")
+                self.cpp_info.set_property("cmake_file_name", "{filename}")
+            """)
+
+    consumer = textwrap.dedent("""
+        from conan import ConanFile
+        from conan.tools.cmake import CMake
+        class Consumer(ConanFile):
+            settings = "os", "compiler", "arch", "build_type"
+            requires = "pkgb/1.0"
+            generators = "CMakeDeps", "CMakeToolchain"
+            exports_sources = "CMakeLists.txt"
+            def build(self):
+                cmake = CMake(self)
+                cmake.configure()
+                cmake.build()
+        """)
+
+    cmakelist = textwrap.dedent("""
+        cmake_minimum_required(VERSION 3.1)
+        project(test_package CXX)
+        find_package(MYPKGB REQUIRED)
+        """)
+
+    client.save({"pkgb.py": conan_pkg.format(requires='requires="pkga/1.0"', filename='MYPKGB', mode=find_mode),
+                 "pkga.py": conan_pkg.format(requires='', filename='MYPKGA', mode=find_mode),
+                 "consumer.py": consumer,
+                 "CMakeLists.txt": cmakelist})
+    client.run("create pkga.py pkga/1.0@")
+    client.run("create pkgb.py pkgb/1.0@")
+    client.run("create consumer.py consumer/1.0@")
+    assert "Conan: Target declared 'pkga::pkga'"
+    if find_mode == "module":
+        assert 'Found MYPKGA: 1.0 (found version "1.0")' in client.out

--- a/conans/test/integration/toolchains/cmake/cmakedeps/test_cmakedeps_find_module_and_config.py
+++ b/conans/test/integration/toolchains/cmake/cmakedeps/test_cmakedeps_find_module_and_config.py
@@ -61,28 +61,3 @@ def test_reuse_with_modules_and_config(cmake_find_mode):
     elif cmake_find_mode == FIND_MODE_NONE:
         assert not exists_config(ifolder)
         assert not exists_module(ifolder)
-
-
-def test_module_defined_vars():
-    t = TestClient()
-    conanfile = textwrap.dedent("""
-            import os
-            from conans import ConanFile
-
-            class Conan(ConanFile):
-                name = "mydep"
-                version = "1.0"
-                settings = "os", "arch", "compiler", "build_type"
-
-            def package_info(self):
-                self.cpp_info.set_property("cmake_file_name", "MYDEP")
-                self.cpp_info.set_property("cmake_find_mode", "module")
-
-            """)
-
-    t.save({"conanfile.py": conanfile})
-    t.run("create .")
-    t.run("install mydep/1.0@")
-    with open(os.path.join(t.current_folder, "Findmydep.cmake")) as f:
-        content = f.read()
-        self.assertIn(filename, content)

--- a/conans/test/integration/toolchains/cmake/cmakedeps/test_cmakedeps_find_module_and_config.py
+++ b/conans/test/integration/toolchains/cmake/cmakedeps/test_cmakedeps_find_module_and_config.py
@@ -61,3 +61,28 @@ def test_reuse_with_modules_and_config(cmake_find_mode):
     elif cmake_find_mode == FIND_MODE_NONE:
         assert not exists_config(ifolder)
         assert not exists_module(ifolder)
+
+
+def test_module_defined_vars():
+    t = TestClient()
+    conanfile = textwrap.dedent("""
+            import os
+            from conans import ConanFile
+
+            class Conan(ConanFile):
+                name = "mydep"
+                version = "1.0"
+                settings = "os", "arch", "compiler", "build_type"
+
+            def package_info(self):
+                self.cpp_info.set_property("cmake_file_name", "MYDEP")
+                self.cpp_info.set_property("cmake_find_mode", "module")
+
+            """)
+
+    t.save({"conanfile.py": conanfile})
+    t.run("create .")
+    t.run("install mydep/1.0@")
+    with open(os.path.join(t.current_folder, "Findmydep.cmake")) as f:
+        content = f.read()
+        self.assertIn(filename, content)


### PR DESCRIPTION
Changelog: Fix: Fix variable names set by `CMakeDeps` modules.
Changelog: Fix: Call to `find_dependency` in module mode to find transitive dependencies.
Changelog: Feature: Add `<PackageName>_LIBRARIES`, `<PackageName>_INCLUDE_DIRS`, `<PackageName>_INCLUDE_DIR`, `<PackageName>_DEFINITIONS` and `<PackageName>_VERSION_STRING` variables in CMakeDeps.
Docs: omit

Closes: https://github.com/conan-io/conan/issues/10224

When only `cmake_find_mode == "module"` was used in CMakeDeps, transitive dependencies were not correctly found. Also, related with that variable names were not generated correctly.
