### PR TITLE
Adjust spaces around comments in settings.yml

### DIFF
--- a/conans/client/conf/__init__.py
+++ b/conans/client/conf/__init__.py
@@ -80,8 +80,8 @@ _t_default_settings_yml = Template(textwrap.dedent("""
                       "10", "10.1", "10.2", "10.3",
                       "11", "11.1", "11.2"]
             libcxx: [libstdc++, libstdc++11]
-            threads: [None, posix, win32] #  Windows MinGW
-            exception: [None, dwarf2, sjlj, seh] # Windows MinGW
+            threads: [None, posix, win32]  # Windows MinGW
+            exception: [None, dwarf2, sjlj, seh]  # Windows MinGW
             cppstd: [None, 98, gnu98, 11, gnu11, 14, gnu14, 17, gnu17, 20, gnu20, 23, gnu23]
         Visual Studio: &visual_studio
             runtime: [MD, MT, MTd, MDd]

--- a/conans/client/migrations_settings.py
+++ b/conans/client/migrations_settings.py
@@ -44,8 +44,8 @@ compiler:
                   "7", "7.1", "7.2", "7.3",
                   "8", "8.1", "8.2"]
         libcxx: [libstdc++, libstdc++11]
-        threads: [None, posix, win32]  # Windows MinGW
-        exception: [None, dwarf2, sjlj, seh]  # Windows MinGW
+        threads: [None, posix, win32] #  Windows MinGW
+        exception: [None, dwarf2, sjlj, seh] # Windows MinGW
     Visual Studio:
         runtime: [MD, MT, MTd, MDd]
         version: ["8", "9", "10", "11", "12", "14", "15"]
@@ -121,8 +121,8 @@ compiler:
                   "7", "7.1", "7.2", "7.3",
                   "8", "8.1", "8.2"]
         libcxx: [libstdc++, libstdc++11]
-        threads: [None, posix, win32]  # Windows MinGW
-        exception: [None, dwarf2, sjlj, seh]  # Windows MinGW
+        threads: [None, posix, win32] #  Windows MinGW
+        exception: [None, dwarf2, sjlj, seh] # Windows MinGW
     Visual Studio:
         runtime: [MD, MT, MTd, MDd]
         version: ["8", "9", "10", "11", "12", "14", "15"]
@@ -193,8 +193,8 @@ compiler:
                   "7", "7.1", "7.2", "7.3",
                   "8", "8.1", "8.2"]
         libcxx: [libstdc++, libstdc++11]
-        threads: [None, posix, win32]  # Windows MinGW
-        exception: [None, dwarf2, sjlj, seh]  # Windows MinGW
+        threads: [None, posix, win32] #  Windows MinGW
+        exception: [None, dwarf2, sjlj, seh] # Windows MinGW
     Visual Studio:
         runtime: [MD, MT, MTd, MDd]
         version: ["8", "9", "10", "11", "12", "14", "15", "16"]
@@ -265,8 +265,8 @@ compiler:
                   "7", "7.1", "7.2", "7.3",
                   "8", "8.1", "8.2"]
         libcxx: [libstdc++, libstdc++11]
-        threads: [None, posix, win32]  # Windows MinGW
-        exception: [None, dwarf2, sjlj, seh]  # Windows MinGW
+        threads: [None, posix, win32] #  Windows MinGW
+        exception: [None, dwarf2, sjlj, seh] # Windows MinGW
     Visual Studio:
         runtime: [MD, MT, MTd, MDd]
         version: ["8", "9", "10", "11", "12", "14", "15", "16"]
@@ -345,8 +345,8 @@ compiler:
                   "8", "8.1", "8.2",
                   "9"]
         libcxx: [libstdc++, libstdc++11]
-        threads: [None, posix, win32]  # Windows MinGW
-        exception: [None, dwarf2, sjlj, seh]  # Windows MinGW
+        threads: [None, posix, win32] #  Windows MinGW
+        exception: [None, dwarf2, sjlj, seh] # Windows MinGW
         cppstd: [None, 98, gnu98, 11, gnu11, 14, gnu14, 17, gnu17, 20, gnu20]
     Visual Studio:
         runtime: [MD, MT, MTd, MDd]
@@ -431,8 +431,8 @@ compiler:
                   "8", "8.1", "8.2", "8.3",
                   "9", "9.1"]
         libcxx: [libstdc++, libstdc++11]
-        threads: [None, posix, win32]  # Windows MinGW
-        exception: [None, dwarf2, sjlj, seh]  # Windows MinGW
+        threads: [None, posix, win32] #  Windows MinGW
+        exception: [None, dwarf2, sjlj, seh] # Windows MinGW
         cppstd: [None, 98, gnu98, 11, gnu11, 14, gnu14, 17, gnu17, 20, gnu20]
     Visual Studio:
         runtime: [MD, MT, MTd, MDd]
@@ -515,8 +515,8 @@ compiler:
                   "8", "8.1", "8.2", "8.3",
                   "9", "9.1"]
         libcxx: [libstdc++, libstdc++11]
-        threads: [None, posix, win32]  # Windows MinGW
-        exception: [None, dwarf2, sjlj, seh]  # Windows MinGW
+        threads: [None, posix, win32] #  Windows MinGW
+        exception: [None, dwarf2, sjlj, seh] # Windows MinGW
         cppstd: [None, 98, gnu98, 11, gnu11, 14, gnu14, 17, gnu17, 20, gnu20]
     Visual Studio:
         runtime: [MD, MT, MTd, MDd]
@@ -598,8 +598,8 @@ compiler:
                   "8", "8.1", "8.2", "8.3",
                   "9", "9.1"]
         libcxx: [libstdc++, libstdc++11]
-        threads: [None, posix, win32]  # Windows MinGW
-        exception: [None, dwarf2, sjlj, seh]  # Windows MinGW
+        threads: [None, posix, win32] #  Windows MinGW
+        exception: [None, dwarf2, sjlj, seh] # Windows MinGW
         cppstd: [None, 98, gnu98, 11, gnu11, 14, gnu14, 17, gnu17, 20, gnu20]
     Visual Studio:
         runtime: [MD, MT, MTd, MDd]
@@ -689,8 +689,8 @@ compiler:
                   "8", "8.1", "8.2", "8.3",
                   "9", "9.1", "9.2"]
         libcxx: [libstdc++, libstdc++11]
-        threads: [None, posix, win32]  # Windows MinGW
-        exception: [None, dwarf2, sjlj, seh]  # Windows MinGW
+        threads: [None, posix, win32] #  Windows MinGW
+        exception: [None, dwarf2, sjlj, seh] # Windows MinGW
         cppstd: [None, 98, gnu98, 11, gnu11, 14, gnu14, 17, gnu17, 20, gnu20]
     Visual Studio:
         runtime: [MD, MT, MTd, MDd]
@@ -775,8 +775,8 @@ compiler:
                   "8", "8.1", "8.2", "8.3",
                   "9", "9.1", "9.2"]
         libcxx: [libstdc++, libstdc++11]
-        threads: [None, posix, win32]  # Windows MinGW
-        exception: [None, dwarf2, sjlj, seh]  # Windows MinGW
+        threads: [None, posix, win32] #  Windows MinGW
+        exception: [None, dwarf2, sjlj, seh] # Windows MinGW
         cppstd: [None, 98, gnu98, 11, gnu11, 14, gnu14, 17, gnu17, 20, gnu20]
     Visual Studio:
         runtime: [MD, MT, MTd, MDd]
@@ -863,8 +863,8 @@ compiler:
                   "8", "8.1", "8.2", "8.3",
                   "9", "9.1", "9.2"]
         libcxx: [libstdc++, libstdc++11]
-        threads: [None, posix, win32]  # Windows MinGW
-        exception: [None, dwarf2, sjlj, seh]  # Windows MinGW
+        threads: [None, posix, win32] #  Windows MinGW
+        exception: [None, dwarf2, sjlj, seh] # Windows MinGW
         cppstd: [None, 98, gnu98, 11, gnu11, 14, gnu14, 17, gnu17, 20, gnu20]
     Visual Studio: &visual_studio
         runtime: [MD, MT, MTd, MDd]
@@ -964,8 +964,8 @@ compiler:
                   "8", "8.1", "8.2", "8.3",
                   "9", "9.1", "9.2"]
         libcxx: [libstdc++, libstdc++11]
-        threads: [None, posix, win32]  # Windows MinGW
-        exception: [None, dwarf2, sjlj, seh]  # Windows MinGW
+        threads: [None, posix, win32] #  Windows MinGW
+        exception: [None, dwarf2, sjlj, seh] # Windows MinGW
         cppstd: [None, 98, gnu98, 11, gnu11, 14, gnu14, 17, gnu17, 20, gnu20]
     Visual Studio: &visual_studio
         runtime: [MD, MT, MTd, MDd]
@@ -1058,8 +1058,8 @@ compiler:
                   "8", "8.1", "8.2", "8.3",
                   "9", "9.1", "9.2"]
         libcxx: [libstdc++, libstdc++11]
-        threads: [None, posix, win32]  # Windows MinGW
-        exception: [None, dwarf2, sjlj, seh]  # Windows MinGW
+        threads: [None, posix, win32] #  Windows MinGW
+        exception: [None, dwarf2, sjlj, seh] # Windows MinGW
         cppstd: [None, 98, gnu98, 11, gnu11, 14, gnu14, 17, gnu17, 20, gnu20]
     Visual Studio: &visual_studio
         runtime: [MD, MT, MTd, MDd]
@@ -1157,8 +1157,8 @@ compiler:
                   "9", "9.1", "9.2", "9.3",
                   "10"]
         libcxx: [libstdc++, libstdc++11]
-        threads: [None, posix, win32]  # Windows MinGW
-        exception: [None, dwarf2, sjlj, seh]  # Windows MinGW
+        threads: [None, posix, win32] #  Windows MinGW
+        exception: [None, dwarf2, sjlj, seh] # Windows MinGW
         cppstd: [None, 98, gnu98, 11, gnu11, 14, gnu14, 17, gnu17, 20, gnu20]
     Visual Studio: &visual_studio
         runtime: [MD, MT, MTd, MDd]
@@ -1254,8 +1254,8 @@ compiler:
                   "9", "9.1", "9.2", "9.3",
                   "10", "10.1"]
         libcxx: [libstdc++, libstdc++11]
-        threads: [None, posix, win32]  # Windows MinGW
-        exception: [None, dwarf2, sjlj, seh]  # Windows MinGW
+        threads: [None, posix, win32] #  Windows MinGW
+        exception: [None, dwarf2, sjlj, seh] # Windows MinGW
         cppstd: [None, 98, gnu98, 11, gnu11, 14, gnu14, 17, gnu17, 20, gnu20]
     Visual Studio: &visual_studio
         runtime: [MD, MT, MTd, MDd]
@@ -1359,8 +1359,8 @@ compiler:
                   "9", "9.1", "9.2", "9.3",
                   "10", "10.1"]
         libcxx: [libstdc++, libstdc++11]
-        threads: [None, posix, win32]  # Windows MinGW
-        exception: [None, dwarf2, sjlj, seh]  # Windows MinGW
+        threads: [None, posix, win32] #  Windows MinGW
+        exception: [None, dwarf2, sjlj, seh] # Windows MinGW
         cppstd: [None, 98, gnu98, 11, gnu11, 14, gnu14, 17, gnu17, 20, gnu20]
     Visual Studio: &visual_studio
         runtime: [MD, MT, MTd, MDd]
@@ -1462,8 +1462,8 @@ compiler:
                   "9", "9.1", "9.2", "9.3",
                   "10", "10.1"]
         libcxx: [libstdc++, libstdc++11]
-        threads: [None, posix, win32]  # Windows MinGW
-        exception: [None, dwarf2, sjlj, seh]  # Windows MinGW
+        threads: [None, posix, win32] #  Windows MinGW
+        exception: [None, dwarf2, sjlj, seh] # Windows MinGW
         cppstd: [None, 98, gnu98, 11, gnu11, 14, gnu14, 17, gnu17, 20, gnu20]
     Visual Studio: &visual_studio
         runtime: [MD, MT, MTd, MDd]
@@ -1564,8 +1564,8 @@ compiler:
                   "9", "9.1", "9.2", "9.3",
                   "10", "10.1"]
         libcxx: [libstdc++, libstdc++11]
-        threads: [None, posix, win32]  # Windows MinGW
-        exception: [None, dwarf2, sjlj, seh]  # Windows MinGW
+        threads: [None, posix, win32] #  Windows MinGW
+        exception: [None, dwarf2, sjlj, seh] # Windows MinGW
         cppstd: [None, 98, gnu98, 11, gnu11, 14, gnu14, 17, gnu17, 20, gnu20]
     Visual Studio: &visual_studio
         runtime: [MD, MT, MTd, MDd]
@@ -1664,8 +1664,8 @@ compiler:
                   "9", "9.1", "9.2", "9.3",
                   "10", "10.1"]
         libcxx: [libstdc++, libstdc++11]
-        threads: [None, posix, win32]  # Windows MinGW
-        exception: [None, dwarf2, sjlj, seh]  # Windows MinGW
+        threads: [None, posix, win32] #  Windows MinGW
+        exception: [None, dwarf2, sjlj, seh] # Windows MinGW
         cppstd: [None, 98, gnu98, 11, gnu11, 14, gnu14, 17, gnu17, 20, gnu20]
     Visual Studio: &visual_studio
         runtime: [MD, MT, MTd, MDd]
@@ -1766,8 +1766,8 @@ compiler:
                   "9", "9.1", "9.2", "9.3",
                   "10", "10.1"]
         libcxx: [libstdc++, libstdc++11]
-        threads: [None, posix, win32]  # Windows MinGW
-        exception: [None, dwarf2, sjlj, seh]  # Windows MinGW
+        threads: [None, posix, win32] #  Windows MinGW
+        exception: [None, dwarf2, sjlj, seh] # Windows MinGW
         cppstd: [None, 98, gnu98, 11, gnu11, 14, gnu14, 17, gnu17, 20, gnu20]
     Visual Studio: &visual_studio
         runtime: [MD, MT, MTd, MDd]
@@ -1879,8 +1879,8 @@ compiler:
                   "9", "9.1", "9.2", "9.3",
                   "10", "10.1"]
         libcxx: [libstdc++, libstdc++11]
-        threads: [None, posix, win32]  # Windows MinGW
-        exception: [None, dwarf2, sjlj, seh]  # Windows MinGW
+        threads: [None, posix, win32] #  Windows MinGW
+        exception: [None, dwarf2, sjlj, seh] # Windows MinGW
         cppstd: [None, 98, gnu98, 11, gnu11, 14, gnu14, 17, gnu17, 20, gnu20]
     Visual Studio: &visual_studio
         runtime: [MD, MT, MTd, MDd]
@@ -1998,8 +1998,8 @@ compiler:
                   "9", "9.1", "9.2", "9.3",
                   "10", "10.1"]
         libcxx: [libstdc++, libstdc++11]
-        threads: [None, posix, win32]  # Windows MinGW
-        exception: [None, dwarf2, sjlj, seh]  # Windows MinGW
+        threads: [None, posix, win32] #  Windows MinGW
+        exception: [None, dwarf2, sjlj, seh] # Windows MinGW
         cppstd: [None, 98, gnu98, 11, gnu11, 14, gnu14, 17, gnu17, 20, gnu20]
     Visual Studio: &visual_studio
         runtime: [MD, MT, MTd, MDd]
@@ -2124,8 +2124,8 @@ compiler:
                   "9", "9.1", "9.2", "9.3",
                   "10", "10.1"]
         libcxx: [libstdc++, libstdc++11]
-        threads: [None, posix, win32]  # Windows MinGW
-        exception: [None, dwarf2, sjlj, seh]  # Windows MinGW
+        threads: [None, posix, win32] #  Windows MinGW
+        exception: [None, dwarf2, sjlj, seh] # Windows MinGW
         cppstd: [None, 98, gnu98, 11, gnu11, 14, gnu14, 17, gnu17, 20, gnu20]
     Visual Studio: &visual_studio
         runtime: [MD, MT, MTd, MDd]
@@ -2244,8 +2244,8 @@ compiler:
                   "10", "10.1", "10.2", "10.3",
                   "11", "11.1"]
         libcxx: [libstdc++, libstdc++11]
-        threads: [None, posix, win32]  # Windows MinGW
-        exception: [None, dwarf2, sjlj, seh]  # Windows MinGW
+        threads: [None, posix, win32] #  Windows MinGW
+        exception: [None, dwarf2, sjlj, seh] # Windows MinGW
         cppstd: [None, 98, gnu98, 11, gnu11, 14, gnu14, 17, gnu17, 20, gnu20, 23, gnu23]
     Visual Studio: &visual_studio
         runtime: [MD, MT, MTd, MDd]
@@ -2371,8 +2371,8 @@ compiler:
                   "10", "10.1", "10.2", "10.3",
                   "11", "11.1"]
         libcxx: [libstdc++, libstdc++11]
-        threads: [None, posix, win32]  # Windows MinGW
-        exception: [None, dwarf2, sjlj, seh]  # Windows MinGW
+        threads: [None, posix, win32] #  Windows MinGW
+        exception: [None, dwarf2, sjlj, seh] # Windows MinGW
         cppstd: [None, 98, gnu98, 11, gnu11, 14, gnu14, 17, gnu17, 20, gnu20, 23, gnu23]
     Visual Studio: &visual_studio
         runtime: [MD, MT, MTd, MDd]
@@ -2495,8 +2495,8 @@ compiler:
                   "10", "10.1", "10.2", "10.3",
                   "11", "11.1"]
         libcxx: [libstdc++, libstdc++11]
-        threads: [None, posix, win32]  # Windows MinGW
-        exception: [None, dwarf2, sjlj, seh]  # Windows MinGW
+        threads: [None, posix, win32] #  Windows MinGW
+        exception: [None, dwarf2, sjlj, seh] # Windows MinGW
         cppstd: [None, 98, gnu98, 11, gnu11, 14, gnu14, 17, gnu17, 20, gnu20, 23, gnu23]
     Visual Studio: &visual_studio
         runtime: [MD, MT, MTd, MDd]
@@ -2619,8 +2619,8 @@ compiler:
                   "10", "10.1", "10.2", "10.3",
                   "11", "11.1"]
         libcxx: [libstdc++, libstdc++11]
-        threads: [None, posix, win32]  # Windows MinGW
-        exception: [None, dwarf2, sjlj, seh]  # Windows MinGW
+        threads: [None, posix, win32] #  Windows MinGW
+        exception: [None, dwarf2, sjlj, seh] # Windows MinGW
         cppstd: [None, 98, gnu98, 11, gnu11, 14, gnu14, 17, gnu17, 20, gnu20, 23, gnu23]
     Visual Studio: &visual_studio
         runtime: [MD, MT, MTd, MDd]
@@ -2755,8 +2755,8 @@ compiler:
                   "10", "10.1", "10.2", "10.3",
                   "11", "11.1"]
         libcxx: [libstdc++, libstdc++11]
-        threads: [None, posix, win32]  # Windows MinGW
-        exception: [None, dwarf2, sjlj, seh]  # Windows MinGW
+        threads: [None, posix, win32] #  Windows MinGW
+        exception: [None, dwarf2, sjlj, seh] # Windows MinGW
         cppstd: [None, 98, gnu98, 11, gnu11, 14, gnu14, 17, gnu17, 20, gnu20, 23, gnu23]
     Visual Studio: &visual_studio
         runtime: [MD, MT, MTd, MDd]
@@ -2895,8 +2895,8 @@ compiler:
                   "10", "10.1", "10.2", "10.3",
                   "11", "11.1", "11.2"]
         libcxx: [libstdc++, libstdc++11]
-        threads: [None, posix, win32]  # Windows MinGW
-        exception: [None, dwarf2, sjlj, seh]  # Windows MinGW
+        threads: [None, posix, win32] #  Windows MinGW
+        exception: [None, dwarf2, sjlj, seh] # Windows MinGW
         cppstd: [None, 98, gnu98, 11, gnu11, 14, gnu14, 17, gnu17, 20, gnu20, 23, gnu23]
     Visual Studio: &visual_studio
         runtime: [MD, MT, MTd, MDd]
@@ -2967,4 +2967,137 @@ settings_1_43_2 = settings_1_43_1
 
 settings_1_44_0 = settings_1_43_2
 
-settings_1_45_0 = settings_1_44_0
+settings_1_45_0 = """
+# Only for cross building, 'os_build/arch_build' is the system that runs Conan
+os_build: [Windows, WindowsStore, Linux, Macos, FreeBSD, SunOS, AIX]
+arch_build: [x86, x86_64, ppc32be, ppc32, ppc64le, ppc64, armv5el, armv5hf, armv6, armv7, armv7hf, armv7s, armv7k, armv8, armv8_32, armv8.3, sparc, sparcv9, mips, mips64, avr, s390, s390x, sh4le, e2k-v2, e2k-v3, e2k-v4, e2k-v5, e2k-v6, e2k-v7]
+
+# Only for building cross compilation tools, 'os_target/arch_target' is the system for
+# which the tools generate code
+os_target: [Windows, Linux, Macos, Android, iOS, watchOS, tvOS, FreeBSD, SunOS, AIX, Arduino, Neutrino]
+arch_target: [x86, x86_64, ppc32be, ppc32, ppc64le, ppc64, armv5el, armv5hf, armv6, armv7, armv7hf, armv7s, armv7k, armv8, armv8_32, armv8.3, sparc, sparcv9, mips, mips64, avr, s390, s390x, asm.js, wasm, sh4le, e2k-v2, e2k-v3, e2k-v4, e2k-v5, e2k-v6, e2k-v7, xtensalx6, xtensalx106]
+
+# Rest of the settings are "host" settings:
+# - For native building/cross building: Where the library/program will run.
+# - For building cross compilation tools: Where the cross compiler will run.
+os:
+    Windows:
+        subsystem: [None, cygwin, msys, msys2, wsl]
+    WindowsStore:
+        version: ["8.1", "10.0"]
+    WindowsCE:
+        platform: ANY
+        version: ["5.0", "6.0", "7.0", "8.0"]
+    Linux:
+    Macos:
+        version: [None, "10.6", "10.7", "10.8", "10.9", "10.10", "10.11", "10.12", "10.13", "10.14", "10.15", "11.0", "12.0", "13.0"]
+        sdk: [None, "macosx"]
+        subsystem: [None, catalyst]
+    Android:
+        api_level: ANY
+    iOS:
+        version: ["7.0", "7.1", "8.0", "8.1", "8.2", "8.3", "9.0", "9.1", "9.2", "9.3", "10.0", "10.1", "10.2", "10.3",
+                  "11.0", "11.1", "11.2", "11.3", "11.4", "12.0", "12.1", "12.2", "12.3", "12.4",
+                  "13.0", "13.1", "13.2", "13.3", "13.4", "13.5", "13.6", "13.7",
+                  "14.0", "14.1", "14.2", "14.3", "14.4", "14.5", "14.6", "14.7", "14.8", "15.0", "15.1"]
+        sdk: [None, "iphoneos", "iphonesimulator"]
+    watchOS:
+        version: ["4.0", "4.1", "4.2", "4.3", "5.0", "5.1", "5.2", "5.3", "6.0", "6.1", "6.2",
+                  "7.0", "7.1", "7.2", "7.3", "7.4", "7.5", "7.6", "8.0", "8.1"]
+        sdk: [None, "watchos", "watchsimulator"]
+    tvOS:
+        version: ["11.0", "11.1", "11.2", "11.3", "11.4", "12.0", "12.1", "12.2", "12.3", "12.4",
+                  "13.0", "13.2", "13.3", "13.4", "14.0", "14.2", "14.3", "14.4", "14.5", "14.6", "14.7",
+                  "15.0", "15.1"]
+        sdk: [None, "appletvos", "appletvsimulator"]
+    FreeBSD:
+    SunOS:
+    AIX:
+    Arduino:
+        board: ANY
+    Emscripten:
+    Neutrino:
+        version: ["6.4", "6.5", "6.6", "7.0", "7.1"]
+    baremetal:
+arch: [x86, x86_64, ppc32be, ppc32, ppc64le, ppc64, armv4, armv4i, armv5el, armv5hf, armv6, armv7, armv7hf, armv7s, armv7k, armv8, armv8_32, armv8.3, sparc, sparcv9, mips, mips64, avr, s390, s390x, asm.js, wasm, sh4le, e2k-v2, e2k-v3, e2k-v4, e2k-v5, e2k-v6, e2k-v7, xtensalx6, xtensalx106]
+compiler:
+    sun-cc:
+        version: ["5.10", "5.11", "5.12", "5.13", "5.14", "5.15"]
+        threads: [None, posix]
+        libcxx: [libCstd, libstdcxx, libstlport, libstdc++]
+    gcc: &gcc
+        version: ["4.1", "4.4", "4.5", "4.6", "4.7", "4.8", "4.9",
+                  "5", "5.1", "5.2", "5.3", "5.4", "5.5",
+                  "6", "6.1", "6.2", "6.3", "6.4", "6.5",
+                  "7", "7.1", "7.2", "7.3", "7.4", "7.5",
+                  "8", "8.1", "8.2", "8.3", "8.4",
+                  "9", "9.1", "9.2", "9.3",
+                  "10", "10.1", "10.2", "10.3",
+                  "11", "11.1", "11.2"]
+        libcxx: [libstdc++, libstdc++11]
+        threads: [None, posix, win32]  # Windows MinGW
+        exception: [None, dwarf2, sjlj, seh]  # Windows MinGW
+        cppstd: [None, 98, gnu98, 11, gnu11, 14, gnu14, 17, gnu17, 20, gnu20, 23, gnu23]
+    Visual Studio: &visual_studio
+        runtime: [MD, MT, MTd, MDd]
+        version: ["8", "9", "10", "11", "12", "14", "15", "16", "17"]
+        toolset: [None, v90, v100, v110, v110_xp, v120, v120_xp,
+                  v140, v140_xp, v140_clang_c2, LLVM-vs2012, LLVM-vs2012_xp,
+                  LLVM-vs2013, LLVM-vs2013_xp, LLVM-vs2014, LLVM-vs2014_xp,
+                  LLVM-vs2017, LLVM-vs2017_xp, v141, v141_xp, v141_clang_c2, v142,
+                  llvm, ClangCL, v143]
+        cppstd: [None, 14, 17, 20, 23]
+    msvc:
+        version: [190, 191, 192, 193]
+        update: [None, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
+        runtime: [static, dynamic]
+        runtime_type: [Debug, Release]
+        cppstd: [14, 17, 20, 23]
+    clang:
+        version: ["3.3", "3.4", "3.5", "3.6", "3.7", "3.8", "3.9", "4.0",
+                  "5.0", "6.0", "7.0", "7.1",
+                  "8", "9", "10", "11", "12", "13"]
+        libcxx: [None, libstdc++, libstdc++11, libc++, c++_shared, c++_static]
+        cppstd: [None, 98, gnu98, 11, gnu11, 14, gnu14, 17, gnu17, 20, gnu20, 23, gnu23]
+        runtime: [None, MD, MT, MTd, MDd]
+    apple-clang: &apple_clang
+        version: ["5.0", "5.1", "6.0", "6.1", "7.0", "7.3", "8.0", "8.1", "9.0", "9.1", "10.0", "11.0", "12.0", "13.0"]
+        libcxx: [libstdc++, libc++]
+        cppstd: [None, 98, gnu98, 11, gnu11, 14, gnu14, 17, gnu17, 20, gnu20]
+    intel:
+        version: ["11", "12", "13", "14", "15", "16", "17", "18", "19", "19.1"]
+        update: [None, ANY]
+        base:
+            gcc:
+                <<: *gcc
+                threads: [None]
+                exception: [None]
+            Visual Studio:
+                <<: *visual_studio
+            apple-clang:
+                <<: *apple_clang
+    intel-cc:
+        version: ["2021.1", "2021.2", "2021.3"]
+        update: [None, ANY]
+        mode: ["icx", "classic", "dpcpp"]
+        libcxx: [None, libstdc++, libstdc++11, libc++]
+        cppstd: [None, 98, gnu98, 03, gnu03, 11, gnu11, 14, gnu14, 17, gnu17, 20, gnu20, 23, gnu23]
+        runtime: [None, static, dynamic]
+        runtime_type: [None, Debug, Release]
+    qcc:
+        version: ["4.4", "5.4", "8.3"]
+        libcxx: [cxx, gpp, cpp, cpp-ne, accp, acpp-ne, ecpp, ecpp-ne]
+        cppstd: [None, 98, gnu98, 11, gnu11, 14, gnu14, 17, gnu17]
+    mcst-lcc:
+        version: ["1.19", "1.20", "1.21", "1.22", "1.23", "1.24", "1.25"]
+        base:
+            gcc:
+                <<: *gcc
+                threads: [None]
+                exceptions: [None]
+
+build_type: [None, Debug, Release, RelWithDebInfo, MinSizeRel]
+
+
+cppstd: [None, 98, gnu98, 11, gnu11, 14, gnu14, 17, gnu17, 20, gnu20, 23, gnu23]  # Deprecated, use compiler.cppstd
+"""

--- a/conans/client/migrations_settings.py
+++ b/conans/client/migrations_settings.py
@@ -44,8 +44,8 @@ compiler:
                   "7", "7.1", "7.2", "7.3",
                   "8", "8.1", "8.2"]
         libcxx: [libstdc++, libstdc++11]
-        threads: [None, posix, win32] #  Windows MinGW
-        exception: [None, dwarf2, sjlj, seh] # Windows MinGW
+        threads: [None, posix, win32]  # Windows MinGW
+        exception: [None, dwarf2, sjlj, seh]  # Windows MinGW
     Visual Studio:
         runtime: [MD, MT, MTd, MDd]
         version: ["8", "9", "10", "11", "12", "14", "15"]
@@ -121,8 +121,8 @@ compiler:
                   "7", "7.1", "7.2", "7.3",
                   "8", "8.1", "8.2"]
         libcxx: [libstdc++, libstdc++11]
-        threads: [None, posix, win32] #  Windows MinGW
-        exception: [None, dwarf2, sjlj, seh] # Windows MinGW
+        threads: [None, posix, win32]  # Windows MinGW
+        exception: [None, dwarf2, sjlj, seh]  # Windows MinGW
     Visual Studio:
         runtime: [MD, MT, MTd, MDd]
         version: ["8", "9", "10", "11", "12", "14", "15"]
@@ -193,8 +193,8 @@ compiler:
                   "7", "7.1", "7.2", "7.3",
                   "8", "8.1", "8.2"]
         libcxx: [libstdc++, libstdc++11]
-        threads: [None, posix, win32] #  Windows MinGW
-        exception: [None, dwarf2, sjlj, seh] # Windows MinGW
+        threads: [None, posix, win32]  # Windows MinGW
+        exception: [None, dwarf2, sjlj, seh]  # Windows MinGW
     Visual Studio:
         runtime: [MD, MT, MTd, MDd]
         version: ["8", "9", "10", "11", "12", "14", "15", "16"]
@@ -265,8 +265,8 @@ compiler:
                   "7", "7.1", "7.2", "7.3",
                   "8", "8.1", "8.2"]
         libcxx: [libstdc++, libstdc++11]
-        threads: [None, posix, win32] #  Windows MinGW
-        exception: [None, dwarf2, sjlj, seh] # Windows MinGW
+        threads: [None, posix, win32]  # Windows MinGW
+        exception: [None, dwarf2, sjlj, seh]  # Windows MinGW
     Visual Studio:
         runtime: [MD, MT, MTd, MDd]
         version: ["8", "9", "10", "11", "12", "14", "15", "16"]
@@ -345,8 +345,8 @@ compiler:
                   "8", "8.1", "8.2",
                   "9"]
         libcxx: [libstdc++, libstdc++11]
-        threads: [None, posix, win32] #  Windows MinGW
-        exception: [None, dwarf2, sjlj, seh] # Windows MinGW
+        threads: [None, posix, win32]  # Windows MinGW
+        exception: [None, dwarf2, sjlj, seh]  # Windows MinGW
         cppstd: [None, 98, gnu98, 11, gnu11, 14, gnu14, 17, gnu17, 20, gnu20]
     Visual Studio:
         runtime: [MD, MT, MTd, MDd]
@@ -431,8 +431,8 @@ compiler:
                   "8", "8.1", "8.2", "8.3",
                   "9", "9.1"]
         libcxx: [libstdc++, libstdc++11]
-        threads: [None, posix, win32] #  Windows MinGW
-        exception: [None, dwarf2, sjlj, seh] # Windows MinGW
+        threads: [None, posix, win32]  # Windows MinGW
+        exception: [None, dwarf2, sjlj, seh]  # Windows MinGW
         cppstd: [None, 98, gnu98, 11, gnu11, 14, gnu14, 17, gnu17, 20, gnu20]
     Visual Studio:
         runtime: [MD, MT, MTd, MDd]
@@ -515,8 +515,8 @@ compiler:
                   "8", "8.1", "8.2", "8.3",
                   "9", "9.1"]
         libcxx: [libstdc++, libstdc++11]
-        threads: [None, posix, win32] #  Windows MinGW
-        exception: [None, dwarf2, sjlj, seh] # Windows MinGW
+        threads: [None, posix, win32]  # Windows MinGW
+        exception: [None, dwarf2, sjlj, seh]  # Windows MinGW
         cppstd: [None, 98, gnu98, 11, gnu11, 14, gnu14, 17, gnu17, 20, gnu20]
     Visual Studio:
         runtime: [MD, MT, MTd, MDd]
@@ -598,8 +598,8 @@ compiler:
                   "8", "8.1", "8.2", "8.3",
                   "9", "9.1"]
         libcxx: [libstdc++, libstdc++11]
-        threads: [None, posix, win32] #  Windows MinGW
-        exception: [None, dwarf2, sjlj, seh] # Windows MinGW
+        threads: [None, posix, win32]  # Windows MinGW
+        exception: [None, dwarf2, sjlj, seh]  # Windows MinGW
         cppstd: [None, 98, gnu98, 11, gnu11, 14, gnu14, 17, gnu17, 20, gnu20]
     Visual Studio:
         runtime: [MD, MT, MTd, MDd]
@@ -689,8 +689,8 @@ compiler:
                   "8", "8.1", "8.2", "8.3",
                   "9", "9.1", "9.2"]
         libcxx: [libstdc++, libstdc++11]
-        threads: [None, posix, win32] #  Windows MinGW
-        exception: [None, dwarf2, sjlj, seh] # Windows MinGW
+        threads: [None, posix, win32]  # Windows MinGW
+        exception: [None, dwarf2, sjlj, seh]  # Windows MinGW
         cppstd: [None, 98, gnu98, 11, gnu11, 14, gnu14, 17, gnu17, 20, gnu20]
     Visual Studio:
         runtime: [MD, MT, MTd, MDd]
@@ -775,8 +775,8 @@ compiler:
                   "8", "8.1", "8.2", "8.3",
                   "9", "9.1", "9.2"]
         libcxx: [libstdc++, libstdc++11]
-        threads: [None, posix, win32] #  Windows MinGW
-        exception: [None, dwarf2, sjlj, seh] # Windows MinGW
+        threads: [None, posix, win32]  # Windows MinGW
+        exception: [None, dwarf2, sjlj, seh]  # Windows MinGW
         cppstd: [None, 98, gnu98, 11, gnu11, 14, gnu14, 17, gnu17, 20, gnu20]
     Visual Studio:
         runtime: [MD, MT, MTd, MDd]
@@ -863,8 +863,8 @@ compiler:
                   "8", "8.1", "8.2", "8.3",
                   "9", "9.1", "9.2"]
         libcxx: [libstdc++, libstdc++11]
-        threads: [None, posix, win32] #  Windows MinGW
-        exception: [None, dwarf2, sjlj, seh] # Windows MinGW
+        threads: [None, posix, win32]  # Windows MinGW
+        exception: [None, dwarf2, sjlj, seh]  # Windows MinGW
         cppstd: [None, 98, gnu98, 11, gnu11, 14, gnu14, 17, gnu17, 20, gnu20]
     Visual Studio: &visual_studio
         runtime: [MD, MT, MTd, MDd]
@@ -964,8 +964,8 @@ compiler:
                   "8", "8.1", "8.2", "8.3",
                   "9", "9.1", "9.2"]
         libcxx: [libstdc++, libstdc++11]
-        threads: [None, posix, win32] #  Windows MinGW
-        exception: [None, dwarf2, sjlj, seh] # Windows MinGW
+        threads: [None, posix, win32]  # Windows MinGW
+        exception: [None, dwarf2, sjlj, seh]  # Windows MinGW
         cppstd: [None, 98, gnu98, 11, gnu11, 14, gnu14, 17, gnu17, 20, gnu20]
     Visual Studio: &visual_studio
         runtime: [MD, MT, MTd, MDd]
@@ -1058,8 +1058,8 @@ compiler:
                   "8", "8.1", "8.2", "8.3",
                   "9", "9.1", "9.2"]
         libcxx: [libstdc++, libstdc++11]
-        threads: [None, posix, win32] #  Windows MinGW
-        exception: [None, dwarf2, sjlj, seh] # Windows MinGW
+        threads: [None, posix, win32]  # Windows MinGW
+        exception: [None, dwarf2, sjlj, seh]  # Windows MinGW
         cppstd: [None, 98, gnu98, 11, gnu11, 14, gnu14, 17, gnu17, 20, gnu20]
     Visual Studio: &visual_studio
         runtime: [MD, MT, MTd, MDd]
@@ -1157,8 +1157,8 @@ compiler:
                   "9", "9.1", "9.2", "9.3",
                   "10"]
         libcxx: [libstdc++, libstdc++11]
-        threads: [None, posix, win32] #  Windows MinGW
-        exception: [None, dwarf2, sjlj, seh] # Windows MinGW
+        threads: [None, posix, win32]  # Windows MinGW
+        exception: [None, dwarf2, sjlj, seh]  # Windows MinGW
         cppstd: [None, 98, gnu98, 11, gnu11, 14, gnu14, 17, gnu17, 20, gnu20]
     Visual Studio: &visual_studio
         runtime: [MD, MT, MTd, MDd]
@@ -1254,8 +1254,8 @@ compiler:
                   "9", "9.1", "9.2", "9.3",
                   "10", "10.1"]
         libcxx: [libstdc++, libstdc++11]
-        threads: [None, posix, win32] #  Windows MinGW
-        exception: [None, dwarf2, sjlj, seh] # Windows MinGW
+        threads: [None, posix, win32]  # Windows MinGW
+        exception: [None, dwarf2, sjlj, seh]  # Windows MinGW
         cppstd: [None, 98, gnu98, 11, gnu11, 14, gnu14, 17, gnu17, 20, gnu20]
     Visual Studio: &visual_studio
         runtime: [MD, MT, MTd, MDd]
@@ -1359,8 +1359,8 @@ compiler:
                   "9", "9.1", "9.2", "9.3",
                   "10", "10.1"]
         libcxx: [libstdc++, libstdc++11]
-        threads: [None, posix, win32] #  Windows MinGW
-        exception: [None, dwarf2, sjlj, seh] # Windows MinGW
+        threads: [None, posix, win32]  # Windows MinGW
+        exception: [None, dwarf2, sjlj, seh]  # Windows MinGW
         cppstd: [None, 98, gnu98, 11, gnu11, 14, gnu14, 17, gnu17, 20, gnu20]
     Visual Studio: &visual_studio
         runtime: [MD, MT, MTd, MDd]
@@ -1462,8 +1462,8 @@ compiler:
                   "9", "9.1", "9.2", "9.3",
                   "10", "10.1"]
         libcxx: [libstdc++, libstdc++11]
-        threads: [None, posix, win32] #  Windows MinGW
-        exception: [None, dwarf2, sjlj, seh] # Windows MinGW
+        threads: [None, posix, win32]  # Windows MinGW
+        exception: [None, dwarf2, sjlj, seh]  # Windows MinGW
         cppstd: [None, 98, gnu98, 11, gnu11, 14, gnu14, 17, gnu17, 20, gnu20]
     Visual Studio: &visual_studio
         runtime: [MD, MT, MTd, MDd]
@@ -1564,8 +1564,8 @@ compiler:
                   "9", "9.1", "9.2", "9.3",
                   "10", "10.1"]
         libcxx: [libstdc++, libstdc++11]
-        threads: [None, posix, win32] #  Windows MinGW
-        exception: [None, dwarf2, sjlj, seh] # Windows MinGW
+        threads: [None, posix, win32]  # Windows MinGW
+        exception: [None, dwarf2, sjlj, seh]  # Windows MinGW
         cppstd: [None, 98, gnu98, 11, gnu11, 14, gnu14, 17, gnu17, 20, gnu20]
     Visual Studio: &visual_studio
         runtime: [MD, MT, MTd, MDd]
@@ -1664,8 +1664,8 @@ compiler:
                   "9", "9.1", "9.2", "9.3",
                   "10", "10.1"]
         libcxx: [libstdc++, libstdc++11]
-        threads: [None, posix, win32] #  Windows MinGW
-        exception: [None, dwarf2, sjlj, seh] # Windows MinGW
+        threads: [None, posix, win32]  # Windows MinGW
+        exception: [None, dwarf2, sjlj, seh]  # Windows MinGW
         cppstd: [None, 98, gnu98, 11, gnu11, 14, gnu14, 17, gnu17, 20, gnu20]
     Visual Studio: &visual_studio
         runtime: [MD, MT, MTd, MDd]
@@ -1766,8 +1766,8 @@ compiler:
                   "9", "9.1", "9.2", "9.3",
                   "10", "10.1"]
         libcxx: [libstdc++, libstdc++11]
-        threads: [None, posix, win32] #  Windows MinGW
-        exception: [None, dwarf2, sjlj, seh] # Windows MinGW
+        threads: [None, posix, win32]  # Windows MinGW
+        exception: [None, dwarf2, sjlj, seh]  # Windows MinGW
         cppstd: [None, 98, gnu98, 11, gnu11, 14, gnu14, 17, gnu17, 20, gnu20]
     Visual Studio: &visual_studio
         runtime: [MD, MT, MTd, MDd]
@@ -1879,8 +1879,8 @@ compiler:
                   "9", "9.1", "9.2", "9.3",
                   "10", "10.1"]
         libcxx: [libstdc++, libstdc++11]
-        threads: [None, posix, win32] #  Windows MinGW
-        exception: [None, dwarf2, sjlj, seh] # Windows MinGW
+        threads: [None, posix, win32]  # Windows MinGW
+        exception: [None, dwarf2, sjlj, seh]  # Windows MinGW
         cppstd: [None, 98, gnu98, 11, gnu11, 14, gnu14, 17, gnu17, 20, gnu20]
     Visual Studio: &visual_studio
         runtime: [MD, MT, MTd, MDd]
@@ -1998,8 +1998,8 @@ compiler:
                   "9", "9.1", "9.2", "9.3",
                   "10", "10.1"]
         libcxx: [libstdc++, libstdc++11]
-        threads: [None, posix, win32] #  Windows MinGW
-        exception: [None, dwarf2, sjlj, seh] # Windows MinGW
+        threads: [None, posix, win32]  # Windows MinGW
+        exception: [None, dwarf2, sjlj, seh]  # Windows MinGW
         cppstd: [None, 98, gnu98, 11, gnu11, 14, gnu14, 17, gnu17, 20, gnu20]
     Visual Studio: &visual_studio
         runtime: [MD, MT, MTd, MDd]
@@ -2124,8 +2124,8 @@ compiler:
                   "9", "9.1", "9.2", "9.3",
                   "10", "10.1"]
         libcxx: [libstdc++, libstdc++11]
-        threads: [None, posix, win32] #  Windows MinGW
-        exception: [None, dwarf2, sjlj, seh] # Windows MinGW
+        threads: [None, posix, win32]  # Windows MinGW
+        exception: [None, dwarf2, sjlj, seh]  # Windows MinGW
         cppstd: [None, 98, gnu98, 11, gnu11, 14, gnu14, 17, gnu17, 20, gnu20]
     Visual Studio: &visual_studio
         runtime: [MD, MT, MTd, MDd]
@@ -2244,8 +2244,8 @@ compiler:
                   "10", "10.1", "10.2", "10.3",
                   "11", "11.1"]
         libcxx: [libstdc++, libstdc++11]
-        threads: [None, posix, win32] #  Windows MinGW
-        exception: [None, dwarf2, sjlj, seh] # Windows MinGW
+        threads: [None, posix, win32]  # Windows MinGW
+        exception: [None, dwarf2, sjlj, seh]  # Windows MinGW
         cppstd: [None, 98, gnu98, 11, gnu11, 14, gnu14, 17, gnu17, 20, gnu20, 23, gnu23]
     Visual Studio: &visual_studio
         runtime: [MD, MT, MTd, MDd]
@@ -2371,8 +2371,8 @@ compiler:
                   "10", "10.1", "10.2", "10.3",
                   "11", "11.1"]
         libcxx: [libstdc++, libstdc++11]
-        threads: [None, posix, win32] #  Windows MinGW
-        exception: [None, dwarf2, sjlj, seh] # Windows MinGW
+        threads: [None, posix, win32]  # Windows MinGW
+        exception: [None, dwarf2, sjlj, seh]  # Windows MinGW
         cppstd: [None, 98, gnu98, 11, gnu11, 14, gnu14, 17, gnu17, 20, gnu20, 23, gnu23]
     Visual Studio: &visual_studio
         runtime: [MD, MT, MTd, MDd]
@@ -2495,8 +2495,8 @@ compiler:
                   "10", "10.1", "10.2", "10.3",
                   "11", "11.1"]
         libcxx: [libstdc++, libstdc++11]
-        threads: [None, posix, win32] #  Windows MinGW
-        exception: [None, dwarf2, sjlj, seh] # Windows MinGW
+        threads: [None, posix, win32]  # Windows MinGW
+        exception: [None, dwarf2, sjlj, seh]  # Windows MinGW
         cppstd: [None, 98, gnu98, 11, gnu11, 14, gnu14, 17, gnu17, 20, gnu20, 23, gnu23]
     Visual Studio: &visual_studio
         runtime: [MD, MT, MTd, MDd]
@@ -2619,8 +2619,8 @@ compiler:
                   "10", "10.1", "10.2", "10.3",
                   "11", "11.1"]
         libcxx: [libstdc++, libstdc++11]
-        threads: [None, posix, win32] #  Windows MinGW
-        exception: [None, dwarf2, sjlj, seh] # Windows MinGW
+        threads: [None, posix, win32]  # Windows MinGW
+        exception: [None, dwarf2, sjlj, seh]  # Windows MinGW
         cppstd: [None, 98, gnu98, 11, gnu11, 14, gnu14, 17, gnu17, 20, gnu20, 23, gnu23]
     Visual Studio: &visual_studio
         runtime: [MD, MT, MTd, MDd]
@@ -2755,8 +2755,8 @@ compiler:
                   "10", "10.1", "10.2", "10.3",
                   "11", "11.1"]
         libcxx: [libstdc++, libstdc++11]
-        threads: [None, posix, win32] #  Windows MinGW
-        exception: [None, dwarf2, sjlj, seh] # Windows MinGW
+        threads: [None, posix, win32]  # Windows MinGW
+        exception: [None, dwarf2, sjlj, seh]  # Windows MinGW
         cppstd: [None, 98, gnu98, 11, gnu11, 14, gnu14, 17, gnu17, 20, gnu20, 23, gnu23]
     Visual Studio: &visual_studio
         runtime: [MD, MT, MTd, MDd]
@@ -2895,8 +2895,8 @@ compiler:
                   "10", "10.1", "10.2", "10.3",
                   "11", "11.1", "11.2"]
         libcxx: [libstdc++, libstdc++11]
-        threads: [None, posix, win32] #  Windows MinGW
-        exception: [None, dwarf2, sjlj, seh] # Windows MinGW
+        threads: [None, posix, win32]  # Windows MinGW
+        exception: [None, dwarf2, sjlj, seh]  # Windows MinGW
         cppstd: [None, 98, gnu98, 11, gnu11, 14, gnu14, 17, gnu17, 20, gnu20, 23, gnu23]
     Visual Studio: &visual_studio
         runtime: [MD, MT, MTd, MDd]


### PR DESCRIPTION
Prevents the YAML linter from complaining

Changelog: Fix: Fix spaces in settings.yml to prevent the YAML linter from complaining.
Docs: omit

- [ ] Refer to the issue that supports this Pull Request.
- [ ] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [ ] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [ ] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 

The equivalent docs change can be found in [this PR](https://github.com/conan-io/docs/pull/2334).

<sup>**Note:** By default this PR will skip the slower tests and will use a limited set of python versions. Check [here](https://github.com/conan-io/conan/blob/develop/.github/PR_INCREASE_TESTING.md) how to increase the testing level by writing some tags in the current PR body text.</sup>
