### PR TITLE
Refactor/remote manager remove packages

### DIFF
--- a/conans/client/remote_manager.py
+++ b/conans/client/remote_manager.py
@@ -209,8 +209,8 @@ class RemoteManager(object):
     def remove_recipe(self, ref, remote):
         return self._call_remote(remote, "remove_recipe", ref)
 
-    def remove_packages(self, ref, remove_ids, remote):
-        return self._call_remote(remote, "remove_packages", ref, remove_ids)
+    def remove_packages(self, prefs, remote):
+        return self._call_remote(remote, "remove_packages", prefs)
 
     def get_recipe_file(self, ref, path, remote):
         return self._call_remote(remote, "get_recipe_file", ref, path)

--- a/conans/client/remote_manager.py
+++ b/conans/client/remote_manager.py
@@ -212,6 +212,9 @@ class RemoteManager(object):
     def remove_packages(self, prefs, remote):
         return self._call_remote(remote, "remove_packages", prefs)
 
+    def remove_all_packages(self, ref, remote):
+        return self._call_remote(remote, "remove_all_packages", ref)
+
     def get_recipe_file(self, ref, path, remote):
         return self._call_remote(remote, "get_recipe_file", ref, path)
 

--- a/conans/client/remover.py
+++ b/conans/client/remover.py
@@ -98,8 +98,17 @@ class ConanRemover(object):
             result = self._remote_manager.remove_recipe(ref, remote)
             return result
         else:
-            tmp = self._remote_manager.remove_packages(ref, package_ids, remote)
-            return tmp
+            if ref.revision is None:
+                refs = self._remote_manager.get_recipe_revisions_references(ref, remote)
+            else:
+                refs = [ref]
+
+            prefs = []
+            for _r in refs:
+                # pid can contain pid#prev
+                prefs.extend([PkgReference.loads("{}:{}".format(repr(_r), pid))
+                              for pid in package_ids])
+            return self._remote_manager.remove_packages(prefs, remote)
 
     @staticmethod
     def _message_removing_editable(ref):

--- a/conans/client/remover.py
+++ b/conans/client/remover.py
@@ -103,6 +103,12 @@ class ConanRemover(object):
             else:
                 refs = [ref]
 
+            if not package_ids:  # empty packages means all of them
+                ret = []
+                for _r in refs:
+                    ret.append(self._remote_manager.remove_all_packages(_r, remote))
+                return ret
+
             prefs = []
             for _r in refs:
                 # pid can contain pid#prev

--- a/conans/client/rest/rest_client.py
+++ b/conans/client/rest/rest_client.py
@@ -128,9 +128,8 @@ class RestApiClient(object):
     def remove_recipe(self, ref):
         return self._get_api().remove_recipe(ref)
 
-    def remove_packages(self, ref, package_ids=None):
-        # FIXME: This interface is a mess, the package_ids containing the revision.
-        return self._get_api().remove_packages(ref, package_ids)
+    def remove_packages(self, prefs):
+        return self._get_api().remove_packages(prefs)
 
     def server_capabilities(self):
         return self._get_api().server_capabilities()

--- a/conans/client/rest/rest_client.py
+++ b/conans/client/rest/rest_client.py
@@ -128,6 +128,9 @@ class RestApiClient(object):
     def remove_recipe(self, ref):
         return self._get_api().remove_recipe(ref)
 
+    def remove_all_packages(self, ref):
+        return self._get_api().remove_all_packages(ref)
+
     def remove_packages(self, prefs):
         return self._get_api().remove_packages(prefs)
 

--- a/conans/client/rest/rest_client_v2.py
+++ b/conans/client/rest/rest_client_v2.py
@@ -200,6 +200,28 @@ class RestV2Methods(RestCommonMethods):
         # V2 === revisions, do not remove files, it will create a new revision if the files changed
         return
 
+    def remove_all_packages(self, ref):
+        """ Remove all packages from the specified reference"""
+        self.check_credentials()
+        assert ref.revision is not None, "remove_packages needs RREV"
+
+        url = self.router.remove_all_packages(ref)
+        response = self.requester.delete(url, auth=self.auth, verify=self.verify_ssl,
+                                         headers=self.custom_headers)
+        if response.status_code == 404:
+            # Double check if it is a 404 because there are no packages
+            try:
+                package_search_url = self.router.search_packages(ref)
+                if not self.get_json(package_search_url):
+                    return
+            except Exception as e:
+                logger.warning("Unexpected error searching {} packages"
+                               " in remote {}: {}".format(ref, self.remote_url, e))
+        if response.status_code != 200:  # Error message is text
+            # To be able to access ret.text (ret.content are bytes)
+            response.charset = "utf-8"
+            raise get_exception_from_error(response.status_code)(response.text)
+
     def remove_packages(self, prefs):
         self.check_credentials()
         for pref in prefs:

--- a/conans/test/integration/command/remove_test.py
+++ b/conans/test/integration/command/remove_test.py
@@ -166,3 +166,22 @@ class RemovePackageRevisionsTest(unittest.TestCase):
                         .format(self.NO_SETTINGS_RREF, NO_SETTINGS_PACKAGE_ID))
         self.client.run("info foobar/0.1@user/testing")
         self.assertIn("Binary: Missing", self.client.out)
+
+    def test_remove_all_packages_but_the_recipe_at_remote(self):
+        """ Remove all the packages but not the recipe in a remote
+        """
+        self.client.save({"conanfile.py": GenConanfile().with_settings("arch")})
+        self.client.run("create . foobar/0.1@user/testing")
+        self.client.run("create . foobar/0.1@user/testing -s arch=x86")
+        self.client.run("upload foobar/0.1@user/testing -r default -c --all")
+        ref = self.client.cache.get_latest_recipe_reference(
+               RecipeReference.loads("foobar/0.1@user/testing"))
+        self.client.run("list packages foobar/0.1@user/testing#{} -r default".format(ref.revision))
+        self.assertIn("arch=x86_64", self.client.out)
+        self.assertIn("arch=x86", self.client.out)
+
+        self.client.run("remove -f foobar/0.1@user/testing -p -r default")
+        self.client.run("search foobar/0.1@user/testing -gr default")
+        self.assertNotIn("arch=x86_64", self.client.out)
+        self.assertNotIn("arch=x86", self.client.out)
+

--- a/conans/test/integration/command/remove_test.py
+++ b/conans/test/integration/command/remove_test.py
@@ -181,7 +181,7 @@ class RemovePackageRevisionsTest(unittest.TestCase):
         self.assertIn("arch=x86", self.client.out)
 
         self.client.run("remove -f foobar/0.1@user/testing -p -r default")
-        self.client.run("search foobar/0.1@user/testing -gr default")
+        self.client.run("search foobar/0.1@user/testing -r default")
         self.assertNotIn("arch=x86_64", self.client.out)
         self.assertNotIn("arch=x86", self.client.out)
 

--- a/conans/test/integration/remote/rest_api_test.py
+++ b/conans/test/integration/remote/rest_api_test.py
@@ -179,7 +179,7 @@ class RestApiTest(unittest.TestCase):
         data = self.api.search_packages(ref)
         self.assertEqual(len(data), 5)
 
-        self.api.remove_packages(ref, ["1"])
+        self.api.remove_packages([PkgReference(ref, "1")])
         self.assertTrue(os.path.exists(self.server.server_store.base_folder(ref)))
         self.assertFalse(os.path.exists(folders["1"]))
         self.assertTrue(os.path.exists(folders["2"]))
@@ -187,18 +187,13 @@ class RestApiTest(unittest.TestCase):
         self.assertTrue(os.path.exists(folders["4"]))
         self.assertTrue(os.path.exists(folders["5"]))
 
-        self.api.remove_packages(ref, ["2", "3"])
+        self.api.remove_packages([PkgReference(ref, "2"), PkgReference(ref, "3")])
         self.assertTrue(os.path.exists(self.server.server_store.base_folder(ref)))
         self.assertFalse(os.path.exists(folders["1"]))
         self.assertFalse(os.path.exists(folders["2"]))
         self.assertFalse(os.path.exists(folders["3"]))
         self.assertTrue(os.path.exists(folders["4"]))
         self.assertTrue(os.path.exists(folders["5"]))
-
-        self.api.remove_packages(ref, [])
-        self.assertTrue(os.path.exists(self.server.server_store.base_folder(ref)))
-        for sha in ["1", "2", "3", "4", "5"]:
-            self.assertFalse(os.path.exists(folders[sha]))
 
     def _upload_package(self, package_reference, base_files=None):
 

--- a/conans/test/integration/remote/rest_api_test.py
+++ b/conans/test/integration/remote/rest_api_test.py
@@ -195,6 +195,11 @@ class RestApiTest(unittest.TestCase):
         self.assertTrue(os.path.exists(folders["4"]))
         self.assertTrue(os.path.exists(folders["5"]))
 
+        self.api.remove_all_packages(ref)
+        self.assertTrue(os.path.exists(self.server.server_store.base_folder(ref)))
+        for sha in ["1", "2", "3", "4", "5"]:
+            self.assertFalse(os.path.exists(folders[sha]))
+
     def _upload_package(self, package_reference, base_files=None):
 
         files = {"conanfile.py": GenConanfile("3").with_requires("1", "12").with_exports("*"),


### PR DESCRIPTION
Pure refactor. Split **rest_client.remove_packages** into:
    - **remove_packages** accepting a list of prefs (formerly accepting ref + [pids] containing weird package revisions)
    - **remove_all_packages** to remove all the packages from a reference but not the recipe