### PR TITLE
[feature] Mandatory `os.sdk` for CMakeToolchain (only `AppleSystemBlock` block)

### DIFF
--- a/conan/tools/cmake/toolchain.py
+++ b/conan/tools/cmake/toolchain.py
@@ -350,25 +350,21 @@ class AppleSystemBlock(Block):
                 "armv8": "arm64",
                 "armv8_32": "arm64_32"}.get(arch, arch)
 
-    # TODO: refactor, comes from conans.client.tools.apple.py
     def _apple_sdk_name(self):
-        """returns proper SDK name suitable for OS and architecture
-        we're building for (considering simulators)"""
-        arch = self._conanfile.settings.get_safe('arch')
+        """
+        Returns the 'os.sdk' (SDK name) field value. Every user should specify it because
+        there could be several ones depending on the OS architecture.
+
+        Note: In case of MacOS it'll be the same for all the architectures.
+        """
         os_ = self._conanfile.settings.get_safe('os')
         os_sdk = self._conanfile.settings.get_safe('os.sdk')
         if os_sdk:
             return os_sdk
-        elif arch.startswith('x86'):
-            return {'Macos': 'macosx',
-                    'iOS': 'iphonesimulator',
-                    'watchOS': 'watchsimulator',
-                    'tvOS': 'appletvsimulator'}.get(os_)
+        elif os_ == "Macos":  # it has only a single value for all the architectures for now
+            return "macosx"
         else:
-            return {'Macos': 'macosx',
-                    'iOS': 'iphoneos',
-                    'watchOS': 'watchos',
-                    'tvOS': 'appletvos'}.get(os_)
+            raise ConanException("Please, specify a suitable value for os.sdk.")
 
     def context(self):
         os_ = self._conanfile.settings.get_safe("os")

--- a/conan/tools/cmake/toolchain.py
+++ b/conan/tools/cmake/toolchain.py
@@ -356,7 +356,10 @@ class AppleSystemBlock(Block):
         we're building for (considering simulators)"""
         arch = self._conanfile.settings.get_safe('arch')
         os_ = self._conanfile.settings.get_safe('os')
-        if arch.startswith('x86'):
+        os_sdk = self._conanfile.settings.get_safe('os.sdk')
+        if os_sdk:
+            return os_sdk
+        elif arch.startswith('x86'):
             return {'Macos': 'macosx',
                     'iOS': 'iphonesimulator',
                     'watchOS': 'watchsimulator',

--- a/conans/test/functional/toolchains/cmake/cmakedeps/test_apple_frameworks.py
+++ b/conans/test/functional/toolchains/cmake/cmakedeps/test_apple_frameworks.py
@@ -191,8 +191,8 @@ timer_cpp = textwrap.dedent("""
 @pytest.mark.skipif(platform.system() != "Darwin", reason="Only OSX")
 @pytest.mark.parametrize("settings",
                          [('',),
-                          ('-s os=iOS -s os.version=10.0 -s arch=armv8',),
-                          ("-s os=tvOS -s os.version=11.0 -s arch=armv8",)])
+                          ('-s os=iOS -s os.sdk=iphoneos -s os.version=10.0 -s arch=armv8',),
+                          ("-s os=tvOS -s os.sdk=appletvos -s os.version=11.0 -s arch=armv8",)])
 def test_apple_own_framework_cross_build(settings):
     client = TestClient()
 

--- a/conans/test/functional/toolchains/cmake/test_cmake_toolchain_m1.py
+++ b/conans/test/functional/toolchains/cmake/test_cmake_toolchain_m1.py
@@ -13,12 +13,12 @@ from conans.test.utils.tools import TestClient
 @pytest.mark.parametrize("op_system", ["Macos", "iOS"])
 def test_m1(op_system):
     os_version = "os.version=12.0" if op_system == "iOS" else ""
-    os_sdk = "macosx" if op_system == "Macos" else "iphoneos"
+    os_sdk = "" if op_system == "Macos" else "os.sdk=iphoneos"
     profile = textwrap.dedent("""
         include(default)
         [settings]
         os={}
-        os.sdk={}
+        {}
         {}
         arch=armv8
     """.format(op_system, os_sdk, os_version))

--- a/conans/test/functional/toolchains/cmake/test_cmake_toolchain_m1.py
+++ b/conans/test/functional/toolchains/cmake/test_cmake_toolchain_m1.py
@@ -13,13 +13,15 @@ from conans.test.utils.tools import TestClient
 @pytest.mark.parametrize("op_system", ["Macos", "iOS"])
 def test_m1(op_system):
     os_version = "os.version=12.0" if op_system == "iOS" else ""
+    os_sdk = "macosx" if op_system == "Macos" else "iphoneos"
     profile = textwrap.dedent("""
         include(default)
         [settings]
         os={}
+        os.sdk={}
         {}
         arch=armv8
-    """.format(op_system, os_version))
+    """.format(op_system, os_sdk, os_version))
 
     client = TestClient(path_with_spaces=False)
     client.save({"m1": profile}, clean_first=True)

--- a/conans/test/functional/toolchains/gnu/autotools/test_ios.py
+++ b/conans/test/functional/toolchains/gnu/autotools/test_ios.py
@@ -23,6 +23,7 @@ def test_ios():
         include(default)
         [settings]
         os=iOS
+        os.sdk=iphoneos
         os.version=12.0
         arch=armv8
         [env]

--- a/conans/test/functional/toolchains/ios/test_using_cmake.py
+++ b/conans/test/functional/toolchains/ios/test_using_cmake.py
@@ -46,6 +46,7 @@ class ToolchainiOSTestCase(unittest.TestCase):
             'ios_profile': textwrap.dedent("""
                 [settings]
                 os=iOS
+                os.sdk=iphoneos
                 os.version=12.0
                 arch=armv8
                 compiler=apple-clang


### PR DESCRIPTION
Changelog: Feature: `os.sdk` field is mandatory for CMakeToolchain and OS in `('Macos', 'iOS', 'watchOS', 'tvOS')`.
Docs: omit

Closes: https://github.com/conan-io/conan/issues/10275

- [x] Refer to the issue that supports this Pull Request.
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 

<sup>**Note:** By default this PR will skip the slower tests and will use a limited set of python versions. Check [here](https://github.com/conan-io/conan/blob/develop/.github/PR_INCREASE_TESTING.md) how to increase the testing level by writing some tags in the current PR body text.</sup>
