### PR TITLE
fix the caching of ConanFile.dependencies at validate() time

### DIFF
--- a/conans/client/graph/graph_binaries.py
+++ b/conans/client/graph/graph_binaries.py
@@ -387,6 +387,8 @@ class GraphBinariesAnalyzer(object):
             with conanfile_exception_formatter(str(conanfile), "validate"):
                 try:
                     conanfile.validate()
+                    # FIXME: this shouldn't be necessary in Conan 2.0
+                    conanfile._conan_dependencies = None
                 except ConanInvalidConfiguration as e:
                     conanfile.info.invalid = str(e)
 


### PR DESCRIPTION
Changelog: Bugfix: Fix the caching of `ConanFile.dependencies` at `validate()` time. 
Docs: Omit

Close https://github.com/conan-io/conan/issues/10304
