### PR TITLE
Validate if settings.compiler is related to Visual Studio

### DIFF
--- a/conan/tools/microsoft/__init__.py
+++ b/conan/tools/microsoft/__init__.py
@@ -1,5 +1,5 @@
 from conan.tools.microsoft.toolchain import MSBuildToolchain
 from conan.tools.microsoft.msbuild import MSBuild
 from conan.tools.microsoft.msbuilddeps import MSBuildDeps
-from conan.tools.microsoft.visual import msvc_runtime_flag, VCVars
+from conan.tools.microsoft.visual import msvc_runtime_flag, VCVars, is_msvc
 from conan.tools.microsoft.subsystems import subsystem_path

--- a/conan/tools/microsoft/visual.py
+++ b/conan/tools/microsoft/visual.py
@@ -172,3 +172,15 @@ def _vcvars_vers(conanfile, compiler, vs_version):
         # The equivalent of compiler 192 is toolset 14.2
         vcvars_ver = "14.{}".format(compiler_version[-1])
     return vcvars_ver
+
+
+def is_msvc(conanfile):
+    """ Validate if current compiler is 'Visual Studio' or 'msvc'
+    :param conanfile: ConanFile instance
+    :return: True, if the host compiler is related to Visual Studio, otherwise, False.
+    """
+    settings = conanfile.settings
+    compiler = settings.get_safe("compiler")
+    if not compiler:
+        raise ConanException("settings.compiler is mandatory to check Visual Studio relation.")
+    return str(compiler) in ["Visual Studio", "msvc"]

--- a/conan/tools/microsoft/visual.py
+++ b/conan/tools/microsoft/visual.py
@@ -175,9 +175,9 @@ def _vcvars_vers(conanfile, compiler, vs_version):
 
 
 def is_msvc(conanfile):
-    """ Validate if current compiler is 'Visual Studio' or 'msvc'
+    """ Validate if current compiler in setttings is 'Visual Studio' or 'msvc'
     :param conanfile: ConanFile instance
     :return: True, if the host compiler is related to Visual Studio, otherwise, False.
     """
     settings = conanfile.settings
-    return str(settings.get_safe("compiler")) in ["Visual Studio", "msvc"]
+    return settings.get_safe("compiler") in ["Visual Studio", "msvc"]

--- a/conan/tools/microsoft/visual.py
+++ b/conan/tools/microsoft/visual.py
@@ -180,7 +180,4 @@ def is_msvc(conanfile):
     :return: True, if the host compiler is related to Visual Studio, otherwise, False.
     """
     settings = conanfile.settings
-    compiler = settings.get_safe("compiler")
-    if not compiler:
-        raise ConanException("settings.compiler is mandatory to check Visual Studio relation.")
-    return str(compiler) in ["Visual Studio", "msvc"]
+    return str(settings.get_safe("compiler")) in ["Visual Studio", "msvc"]


### PR DESCRIPTION
Add a new helper to simplify and avoid method copies in Conan Center Index

Changelog: Feature: Add `is_msvc` to validate if `settings.compiler` is `Visual Studio` and `msvc` compilers.
Docs: https://github.com/conan-io/docs/pull/2353

closes #10306

- [x] Refer to the issue that supports this Pull Request.
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [x] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 

<sup>**Note:** By default this PR will skip the slower tests and will use a limited set of python versions. Check [here](https://github.com/conan-io/conan/blob/develop/.github/PR_INCREASE_TESTING.md) how to increase the testing level by writing some tags in the current PR body text.</sup>
