### PR TITLE
Backport Make pkg_config generator listen to root cpp_info properties to 1.43

### DIFF
--- a/conans/model/build_info.py
+++ b/conans/model/build_info.py
@@ -328,9 +328,10 @@ class CppInfo(_CppInfo):
     def get_name(self, generator, default_name=True):
         name = super(CppInfo, self).get_name(generator, default_name=default_name)
 
-        # Legacy logic for pkg_config generator
+        # Legacy logic for pkg_config generator, do not enter this logic if the properties model
+        # is used: https://github.com/conan-io/conan/issues/10309
         from conans.client.generators.pkg_config import PkgConfigGenerator
-        if generator == PkgConfigGenerator.name:
+        if generator == PkgConfigGenerator.name and self.get_property("pkg_config_name") is None:
             fallback = self._name.lower() if self._name != self._ref_name else self._ref_name
             if PkgConfigGenerator.name not in self.names and self._name != self._name.lower():
                 conan_v2_error("Generated file and name for {gen} generator will change in"

--- a/conans/test/integration/generators/cpp_info_set_generator_properties_test.py
+++ b/conans/test/integration/generators/cpp_info_set_generator_properties_test.py
@@ -336,6 +336,7 @@ def test_pkg_config_names(setup_client):
             name = "mypkg"
             version = "1.0"
             def package_info(self):
+                self.cpp_info.set_property("pkg_config_name", "root-config-name")
                 self.cpp_info.components["mycomponent"].libs = ["mycomponent-lib"]
                 self.cpp_info.components["mycomponent"].set_property("pkg_config_name", "mypkg-config-name")
         """)
@@ -344,5 +345,8 @@ def test_pkg_config_names(setup_client):
     client.run("export mypkg.py")
     client.run("install consumer.py --build missing")
 
+    with open(os.path.join(client.current_folder, "root-config-name.pc")) as gen_file:
+        assert "Name: root-config-name" in gen_file.read()
+
     with open(os.path.join(client.current_folder, "mypkg-config-name.pc")) as gen_file:
-        assert "mypkg-config-name" in gen_file.read()
+        assert "Name: root-config-name-mypkg-config-name" in gen_file.read()


### PR DESCRIPTION
Changelog: Bugfix: Make `pkg_config` generator listen to root `cpp_info` properties.
Docs: omit

Backported from: https://github.com/conan-io/conan/pull/10312
