### PR TITLE
Add VxWorks to os in default settings.yml. (#10313)

### DIFF
--- a/conans/client/conf/__init__.py
+++ b/conans/client/conf/__init__.py
@@ -14,7 +14,7 @@ from conans.util.files import load
 
 _t_default_settings_yml = Template(textwrap.dedent("""
     # Only for cross building, 'os_build/arch_build' is the system that runs Conan
-    os_build: [Windows, WindowsStore, Linux, Macos, FreeBSD, SunOS, AIX]
+    os_build: [Windows, WindowsStore, Linux, Macos, FreeBSD, SunOS, AIX, VxWorks]
     arch_build: [x86, x86_64, ppc32be, ppc32, ppc64le, ppc64, armv5el, armv5hf, armv6, armv7, armv7hf, armv7s, armv7k, armv8, armv8_32, armv8.3, sparc, sparcv9, mips, mips64, avr, s390, s390x, sh4le, e2k-v2, e2k-v3, e2k-v4, e2k-v5, e2k-v6, e2k-v7]
 
     # Only for building cross compilation tools, 'os_target/arch_target' is the system for
@@ -64,6 +64,8 @@ _t_default_settings_yml = Template(textwrap.dedent("""
         Neutrino:
             version: ["6.4", "6.5", "6.6", "7.0", "7.1"]
         baremetal:
+        VxWorks:
+            version: ["7"]
     arch: [x86, x86_64, ppc32be, ppc32, ppc64le, ppc64, armv4, armv4i, armv5el, armv5hf, armv6, armv7, armv7hf, armv7s, armv7k, armv8, armv8_32, armv8.3, sparc, sparcv9, mips, mips64, avr, s390, s390x, asm.js, wasm, sh4le, e2k-v2, e2k-v3, e2k-v4, e2k-v5, e2k-v6, e2k-v7, xtensalx6, xtensalx106]
     compiler:
         sun-cc:

--- a/conans/client/migrations_settings.py
+++ b/conans/client/migrations_settings.py
@@ -2969,7 +2969,7 @@ settings_1_44_0 = settings_1_43_2
 
 settings_1_45_0 = """
 # Only for cross building, 'os_build/arch_build' is the system that runs Conan
-os_build: [Windows, WindowsStore, Linux, Macos, FreeBSD, SunOS, AIX]
+os_build: [Windows, WindowsStore, Linux, Macos, FreeBSD, SunOS, AIX, VxWorks]
 arch_build: [x86, x86_64, ppc32be, ppc32, ppc64le, ppc64, armv5el, armv5hf, armv6, armv7, armv7hf, armv7s, armv7k, armv8, armv8_32, armv8.3, sparc, sparcv9, mips, mips64, avr, s390, s390x, sh4le, e2k-v2, e2k-v3, e2k-v4, e2k-v5, e2k-v6, e2k-v7]
 
 # Only for building cross compilation tools, 'os_target/arch_target' is the system for
@@ -3019,6 +3019,8 @@ os:
     Neutrino:
         version: ["6.4", "6.5", "6.6", "7.0", "7.1"]
     baremetal:
+    VxWorks:
+        version: ["7"]
 arch: [x86, x86_64, ppc32be, ppc32, ppc64le, ppc64, armv4, armv4i, armv5el, armv5hf, armv6, armv7, armv7hf, armv7s, armv7k, armv8, armv8_32, armv8.3, sparc, sparcv9, mips, mips64, avr, s390, s390x, asm.js, wasm, sh4le, e2k-v2, e2k-v3, e2k-v4, e2k-v5, e2k-v6, e2k-v7, xtensalx6, xtensalx106]
 compiler:
     sun-cc:

--- a/conans/test/functional/toolchains/cmake/test_cmake_toolchain_vxworks_clang.py
+++ b/conans/test/functional/toolchains/cmake/test_cmake_toolchain_vxworks_clang.py
@@ -1,0 +1,62 @@
+import platform
+import textwrap
+
+import pytest
+
+from conans.test.assets.cmake import gen_cmakelists
+from conans.test.assets.sources import gen_function_cpp
+from conans.test.utils.tools import TestClient
+from conans.util.files import save
+
+
+@pytest.fixture
+def client():
+    c = TestClient()
+    save(c.cache.new_config_path, "tools.env.virtualenv:auto_use=True")
+    clang_profile = textwrap.dedent("""
+        [settings]
+        arch=armv7
+        build_type=RelWithDebInfo
+        compiler=clang
+        compiler.libcxx=libstdc++11
+        compiler.version=12
+        os=VxWorks
+        os.version=7
+
+        [buildenv]
+        CC=clang
+        CXX=clang++
+        """)
+    conanfile = textwrap.dedent("""
+        import os
+        from conans import ConanFile
+        from conan.tools.cmake import CMake
+        from conan.tools.layout import cmake_layout
+        class Pkg(ConanFile):
+            settings = "os", "compiler", "build_type", "arch"
+            exports_sources = "*"
+            generators = "CMakeToolchain"
+
+            def layout(self):
+                cmake_layout(self)
+
+            def build(self):
+                cmake = CMake(self)
+                cmake.configure()
+                cmake.build()
+                cmd = os.path.join(self.cpp.build.bindirs[0], "my_app")
+                self.run(cmd, env=["conanrunenv"])
+        """)
+    c.save({"conanfile.py": conanfile,
+            "clang": clang_profile,
+            "CMakeLists.txt": gen_cmakelists(appname="my_app", appsources=["src/main.cpp"]),
+            "src/main.cpp": gen_function_cpp(name="main")})
+    return c
+
+
+@pytest.mark.tool_cmake
+@pytest.mark.tool_clang(version="12")
+def test_clang_cmake_ninja(client):
+    client.run("create . pkg/0.1@ -pr=clang -c tools.cmake.cmaketoolchain:generator=Ninja")
+    assert 'cmake -G "Ninja"' in client.out
+    assert "main __clang_major__12" in client.out

--- a/conans/test/functional/toolchains/cmake/test_cmake_toolchain_vxworks_clang.py
+++ b/conans/test/functional/toolchains/cmake/test_cmake_toolchain_vxworks_clang.py
@@ -45,10 +45,76 @@ def client():
                 cmake.configure()
                 cmake.build()
                 cmd = os.path.join(self.cpp.build.bindirs[0], "my_app")
-                self.run(cmd, env=["conanrunenv"])
+                self.run('readelf -s ' + cmd, env=["conanrunenv"])
+        """)
+    toolchain_file = textwrap.dedent("""
+            set(vsb "/vsb") # location of VxWorks Source Build (vsb)
+            set(CMAKE_LINKER "ldarm")
+            set(CMAKE_CXX_LINK_EXECUTABLE "<CMAKE_LINKER> <CMAKE_CXX_LINK_FLAGS> <LINK_FLAGS> <OBJECTS> -o <TARGET> <LINK_LIBRARIES>" CACHE STRING "Workaround for clang, use GNU linker not clang/lld" FORCE)
+            set(CMAKE_CXX_STANDARD_INCLUDE_DIRECTORIES
+                ${vsb}/usr/h
+                ${vsb}/usr/h/public
+                ${vsb}/h/config
+                ${vsb}/share/h/public
+            )
+            add_compile_definitions(
+                ARMEL
+                CPU=_VX_ARMARCH7
+                _REENTRANT
+                INET
+                _VSB_CONFIG_FILE="${vsb}/h/config/vsbConfig.h"
+            )
+            add_compile_options(
+                -fno-builtin
+                -pipe
+            )
+            add_compile_definitions(
+                _C99
+                _HAS_C9X
+                _VX_CPU=_VX_ARMARCH7
+                __RTP__
+                TOOL=llvm
+                TOOL_FAMILY=llvm
+                CPU_FAMILY=ARM
+                __ELF__
+                __vxworks
+                __VXWORKS__
+                _USE_INIT_ARRAY
+            )
+            add_compile_options(
+                -fasm
+                -fomit-frame-pointer
+                -ffunction-sections
+                -fdata-sections
+                --target=arm-eabi
+                -mabi=aapcs
+                -mcpu=cortex-a9
+                -mfloat-abi=hard
+                -mfpu=vfpv3
+                -mlittle-endian
+                -mno-implicit-float
+                -nostdinc++
+                -nostdlibinc
+                -march=armv7
+                -gdwarf-3
+                -mllvm
+                -two-entry-phi-node-folding-threshold=2
+            )
+            add_link_options(
+                --target2=rel
+            )
+            link_directories(
+                ${vsb}/usr/lib/common
+            )
+
+            set(CMAKE_CXX_STANDARD 14)
+            set(CMAKE_C_STANDARD_LIBRARIES "--start-group --as-needed -lllvm -lc -lc_internal --end-group")
+            set(CMAKE_CXX_STANDARD_LIBRARIES "-lnet --start-group --as-needed -lc -lc_internal -lllvm -lcplusplus -lllvmcplus -ldl --end-group")
+            set(CMAKE_EXE_LINKER_FLAGS "--defsym __wrs_rtp_base=0x80000000 -u __wr_need_frame_add -u __tls__ -T${vsb}/usr/ldscripts/rtp.ld -static -EL ${vsb}/usr/lib/common/crt0.o" CACHE STRING "" FORCE)
         """)
     c.save({"conanfile.py": conanfile,
             "clang": clang_profile,
+            "toolchain-vxworks.cmake": toolchain_file,
             "CMakeLists.txt": gen_cmakelists(appname="my_app", appsources=["src/main.cpp"]),
             "src/main.cpp": gen_function_cpp(name="main")})
     return c
@@ -57,6 +123,6 @@ def client():
 @pytest.mark.tool_cmake
 @pytest.mark.tool_clang(version="12")
 def test_clang_cmake_ninja(client):
-    client.run("create . pkg/0.1@ -pr=clang -c tools.cmake.cmaketoolchain:generator=Ninja")
+    client.run("create . pkg/0.1@ -pr=clang -c tools.cmake.cmaketoolchain:generator=Ninja -c tools.cmake.cmaketoolchain:toolchain_file=../../toolchain-vxworks.cmake")
     assert 'cmake -G "Ninja"' in client.out
-    assert "main __clang_major__12" in client.out
+    assert "__wrs_rtp_" in client.out

--- a/conans/test/unittests/client/tools/oss/get_cross_building_settings_test.py
+++ b/conans/test/unittests/client/tools/oss/get_cross_building_settings_test.py
@@ -105,3 +105,11 @@ class GetCrossBuildSettingsTest(unittest.TestCase):
             build_os, build_arch, _, _ = get_cross_building_settings(conanfile)
             self.assertEqual("AIX", build_os)
             self.assertEqual("x86_64", build_arch)
+
+    def test_vxworks(self):
+        with mock.patch("platform.system", mock.MagicMock(return_value='VxWorks')), \
+             mock.patch("platform.machine", mock.MagicMock(return_value="armv7")):
+            conanfile = MockConanfile(MockSettings({}))
+            build_os, build_arch, _, _ = get_cross_building_settings(conanfile)
+            self.assertEqual("VxWorks", build_os)
+            self.assertEqual("armv7", build_arch)

--- a/conans/test/unittests/model/other_settings_test.py
+++ b/conans/test/unittests/model/other_settings_test.py
@@ -318,7 +318,8 @@ class SayConan(ConanFile):
         client.run("install . -s os=ChromeOS --build missing", assert_error=True)
         self.assertIn(bad_value_msg("settings.os", "ChromeOS",
                                     ['AIX', 'Android', 'Arduino', 'Emscripten', 'FreeBSD', 'Linux', 'Macos', 'Neutrino',
-                                     'SunOS', 'Windows', 'WindowsCE', 'WindowsStore', 'baremetal', 'iOS', 'tvOS', 'watchOS']),
+                                     'SunOS', 'VxWorks', 'Windows', 'WindowsCE', 'WindowsStore', 'baremetal', 'iOS', 'tvOS',
+                                     'watchOS']),
                       client.out)
 
         # Now add new settings to config and try again

--- a/conans/test/unittests/model/transitive_reqs_test.py
+++ b/conans/test/unittests/model/transitive_reqs_test.py
@@ -1736,8 +1736,8 @@ class SayConan(ConanFile):
             self.build_graph(content, options="arch_independent=True", settings="os=Linux")
         self.assertIn(bad_value_msg("settings.os", "Linux",
                                     ['AIX', 'Android', 'Arduino', 'Emscripten', 'FreeBSD', 'Macos',
-                                     'Neutrino', 'SunOS', 'Windows', 'WindowsCE', 'WindowsStore',
-                                     'baremetal', 'iOS', 'tvOS', 'watchOS']),
+                                     'Neutrino', 'SunOS', 'VxWorks', 'Windows', 'WindowsCE',
+                                     'WindowsStore', 'baremetal', 'iOS', 'tvOS', 'watchOS']),
                       str(cm.exception))
 
     def test_config_remove2(self):


### PR DESCRIPTION
Closes https://github.com/conan-io/conan/issues/10313

Changelog: Feature: Add VxWorks to OSs in default settings.yml.
Docs: https://github.com/conan-io/docs/pull/2355

- [x] Refer to the issue that supports this Pull Request.
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [x] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 

<sup>**Note:** By default this PR will skip the slower tests and will use a limited set of python versions. Check [here](https://github.com/conan-io/conan/blob/develop/.github/PR_INCREASE_TESTING.md) how to increase the testing level by writing some tags in the current PR body text.</sup>
