### PR TITLE
adding hidden-imports to pyinstaller

### DIFF
--- a/pyinstaller.py
+++ b/pyinstaller.py
@@ -89,7 +89,13 @@ def pyinstall(source_folder):
     conan_build_info_path = os.path.join(source_folder, "conans/build_info/command.py")
     hidden = ("--hidden-import=glob --hidden-import=conan.tools.microsoft "
               "--hidden-import=conan.tools.gnu --hidden-import=conan.tools.cmake "
-              "--hidden-import=conan.tools.meson")
+              "--hidden-import=conan.tools.meson --hidden-import=conan.tools.apple "
+              "--hidden-import=conan.tools.build --hidden-import=conan.tools.env "
+              "--hidden-import=conan.tools.files --hidden-import=conan.tools.gnu "
+              "--hidden-import=conan.tools.google --hidden-import=conan.tools.intel "
+              "--hidden-import=conan.tools.layout --hidden-import=conan.tools.premake "
+              "--hidden-import=conan.tools.qbs")
+    hidden += " --hidden-import=distutils.dir_util"
     if platform.system() != "Windows":
         hidden += " --hidden-import=setuptools.msvc"
         win_ver = ""


### PR DESCRIPTION
Changelog: Bugfix: Adding missing hidden-imports to pyinstaller. Close https://github.com/conan-io/conan/issues/10318 Close https://github.com/conan-io/conan/issues/10260
Docs: Omit

I have tested manually, seems it solves the issue. 
The root cause seems an upgrade in latest virtualenv, which might be used in the release pyinstaller process. I hope hardcoding the hidden imports in the script will fix it in release process.