### PR TITLE
[Bugfix] Added mandatory fields when VS 2022 auto-detection

### DIFF
--- a/conans/client/conf/detect.py
+++ b/conans/client/conf/detect.py
@@ -268,7 +268,7 @@ def _detect_compiler_version(result, output, profile_path):
     elif compiler == "msvc":
         # Add default mandatory fields for MSVC compiler
         result.append(("compiler.cppstd", "14"))
-        result.append(("compiler.runtime", "static"))
+        result.append(("compiler.runtime", "dynamic"))
         result.append(("compiler.runtime_type", "Release"))
 
 

--- a/conans/client/conf/detect.py
+++ b/conans/client/conf/detect.py
@@ -265,6 +265,11 @@ def _detect_compiler_version(result, output, profile_path):
             result.append(("compiler.base.version", "4.8"))
         else:
             result.append(("compiler.base.version", "4.4"))
+    elif compiler == "msvc":
+        # Add default mandatory fields for MSVC compiler
+        result.append(("compiler.cppstd", "14"))
+        result.append(("compiler.runtime", "static"))
+        result.append(("compiler.runtime_type", "Release"))
 
 
 def _detect_os_arch(result, output):

--- a/conans/test/unittests/util/detect_test.py
+++ b/conans/test/unittests/util/detect_test.py
@@ -103,5 +103,5 @@ class DetectTest(unittest.TestCase):
             self.assertEqual('msvc', result['compiler'])
             self.assertEqual('193', result['compiler.version'])
             self.assertEqual('14', result['compiler.cppstd'])
-            self.assertEqual('static', result['compiler.runtime'])
+            self.assertEqual('dynamic', result['compiler.runtime'])
             self.assertEqual('Release', result['compiler.runtime_type'])

--- a/conans/test/unittests/util/detect_test.py
+++ b/conans/test/unittests/util/detect_test.py
@@ -102,3 +102,6 @@ class DetectTest(unittest.TestCase):
             result = dict(result)
             self.assertEqual('msvc', result['compiler'])
             self.assertEqual('193', result['compiler.version'])
+            self.assertEqual('14', result['compiler.cppstd'])
+            self.assertEqual('static', result['compiler.runtime'])
+            self.assertEqual('Release', result['compiler.runtime_type'])


### PR DESCRIPTION
Changelog: Bugfix: Visual Studio 2022 auto-detected profile was incomplete.
Docs: omit

Closes: https://github.com/conan-io/conan/issues/10302

- [x] Refer to the issue that supports this Pull Request.
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 

<sup>**Note:** By default this PR will skip the slower tests and will use a limited set of python versions. Check [here](https://github.com/conan-io/conan/blob/develop/.github/PR_INCREASE_TESTING.md) how to increase the testing level by writing some tags in the current PR body text.</sup>
