### PR TITLE
Fix cppstd info message

### DIFF
--- a/conan/tools/cmake/toolchain.py
+++ b/conan/tools/cmake/toolchain.py
@@ -230,7 +230,7 @@ class ArchitectureBlock(Block):
 
 class CppStdBlock(Block):
     template = textwrap.dedent("""
-        message(STATUS "Conan toolchain: C++ Standard {{ cppstd }} with extensions {{ cppstd_extensions }}}")
+        message(STATUS "Conan toolchain: C++ Standard {{ cppstd }} with extensions {{ cppstd_extensions }}")
         set(CMAKE_CXX_STANDARD {{ cppstd }})
         set(CMAKE_CXX_EXTENSIONS {{ cppstd_extensions }})
         set(CMAKE_CXX_STANDARD_REQUIRED ON)


### PR DESCRIPTION
Changelog: Fix: Fix extra `}` characters in cppstd info message.
Docs: omit

The message that indicates the c++ standard was modified has one too many '}' characters giving the text 

```sh
-- Conan toolchain: C++ Standard 17 with extensions OFF}
```


No related issue that I saw.
Related PR: #9670
