### PR TITLE
Fix: Manage spaces in ``[buildenv]`` profile definition

### DIFF
--- a/conan/tools/env/environment.py
+++ b/conan/tools/env/environment.py
@@ -450,12 +450,17 @@ class ProfileEnvironment:
                 else:
                     pattern, name = None, pattern_name[0]
 
+                # strip whitespaces before/after =
+                # values are not strip() unless they are a path, to preserve potential whitespaces
+                name = name.strip()
+
                 # When loading from profile file, latest line has priority
                 env = Environment()
                 if method == "unset":
                     env.unset(name)
                 else:
-                    if value.startswith("(path)"):
+                    if value.strip().startswith("(path)"):
+                        value = value.strip()
                         value = value[6:]
                         method = method + "_path"
                     getattr(env, method)(name, value)

--- a/conans/test/unittests/tools/env/test_env.py
+++ b/conans/test/unittests/tools/env/test_env.py
@@ -338,7 +338,7 @@ class TestProfileEnvRoundTrip:
         myprofile = textwrap.dedent("""
             # define
             MyVar1=MyValue1
-            MyPath1 =(path)/my/path1
+            MyPath1 = (path)/my/path1
             """)
 
         env = ProfileEnvironment.loads(myprofile)

--- a/conans/test/unittests/tools/env/test_env.py
+++ b/conans/test/unittests/tools/env/test_env.py
@@ -130,7 +130,7 @@ def test_compose_path_combinations(op1, v1, op2, v2, result):
 def test_profile():
     myprofile = textwrap.dedent("""
         # define
-        MyVar1=MyValue1
+        MyVar1 =MyValue1
         #  append
         MyVar2+=MyValue2
         #  multiple append works
@@ -195,7 +195,7 @@ def env():
 
 def check_command_output(cmd, prevenv):
     result, _ = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE,
-                            env=prevenv, shell=True).communicate()
+                                 env=prevenv, shell=True).communicate()
     out = result.decode()
 
     assert "MyVar=MyValueB!!" in out
@@ -338,7 +338,7 @@ class TestProfileEnvRoundTrip:
         myprofile = textwrap.dedent("""
             # define
             MyVar1=MyValue1
-            MyPath1=(path)/my/path1
+            MyPath1 =(path)/my/path1
             """)
 
         env = ProfileEnvironment.loads(myprofile)
@@ -352,7 +352,7 @@ class TestProfileEnvRoundTrip:
         myprofile = textwrap.dedent("""
             # define
             MyVar1+=MyValue1
-            MyPath1+=(path)/my/path1
+            MyPath1 +=(path)/my/path1
             """)
 
         env = ProfileEnvironment.loads(myprofile)


### PR DESCRIPTION
Changelog: Fix: Manage spaces in ``[buildenv]`` profile definition.
Docs: Omit

Close https://github.com/conan-io/conan/issues/10334
