### PR TITLE
[pkg_config][PkgConfigDeps] Checking PC files creation order

### DIFF
--- a/conan/tools/gnu/pkgconfigdeps/pc_files_creator.py
+++ b/conan/tools/gnu/pkgconfigdeps/pc_files_creator.py
@@ -61,9 +61,16 @@ def _get_components_pc_files_and_content(conanfile, dep, components_info):
 
 def _get_package_with_components_pc_files_and_content(conanfile, dep, package_info, components_info):
     """
-    Get the PC files and content for dependencies with components
+    Get the PC files and content for dependencies with components.
+    The PC files will be saved in this order:
+        1- Package components.
+        2- Root component.
+
+    Note: If the root-package PC name matches with any other of the components one, the first one
+    is not going to be created. Components have more priority than root package.
     """
     pc_files = {}
+    # First, let's load all the components PC files
     pc_files.update(_get_components_pc_files_and_content(conanfile, dep, components_info))
     description = "Conan package: %s" % package_info.name
     pc_name, pc_content = get_alias_pc_filename_and_content(
@@ -72,6 +79,9 @@ def _get_package_with_components_pc_files_and_content(conanfile, dep, package_in
         package_info.requires,
         description
     )
+    # Second, let's load the root package's PC file ONLY
+    # if it does not already exist in components one
+    # Issue related: https://github.com/conan-io/conan/issues/10341
     if pc_name in pc_files:
         conanfile.output.warn("[%s] The PC package name %s already exists and it matches with "
                               "another component one. Please, review all the "

--- a/conans/client/generators/pkg_config.py
+++ b/conans/client/generators/pkg_config.py
@@ -59,6 +59,9 @@ class PkgConfigGenerator(GeneratorComponentsMixin, Generator):
                         comp,
                         comp_requires_gennames)
                 comp_gennames = [comp_genname for comp_genname, _, _ in components]
+                # Mechanism to avoid overwriting the component PC file in case of being
+                # the same as the root package one.
+                # Issue related: https://github.com/conan-io/conan/issues/10341
                 if pkg_genname not in comp_gennames:
                     ret["%s.pc" % pkg_genname] = self.global_pc_file_contents(pkg_genname, cpp_info,
                                                                               comp_gennames)

--- a/conans/test/functional/toolchains/gnu/test_pkgconfigdeps.py
+++ b/conans/test/functional/toolchains/gnu/test_pkgconfigdeps.py
@@ -469,7 +469,7 @@ def test_duplicated_names_warnings():
     """
     Testing some WARN messages if there are duplicated pkg_config_name/pkg_config_aliases defined
 
-    Scenario: consumer -> pkgA/1.0 -> pkgB/1.0
+    Scenario: consumer -> pkga/1.0 -> pkgb/1.0
     Expected WARN cases:
         - Duplicated aliases.
         - Duplicated names, alias and component name
@@ -492,18 +492,18 @@ def test_duplicated_names_warnings():
                 self.cpp_info.components["cmp3"].set_property("pkg_config_name", "libpkg")
     """)
     client.save({"conanfile.py": conanfile})
-    client.run("create . pkgB/1.0@")
+    client.run("create . pkgb/1.0@")
 
     conanfile = textwrap.dedent("""
         from conans import ConanFile
 
         class PkgConfigConan(ConanFile):
-            requires = "pkgB/1.0"
+            requires = "pkgb/1.0"
 
             def package_info(self):
-                # Duplicated name as pkgB
+                # Duplicated name as pkgb
                 self.cpp_info.set_property("pkg_config_name", "libpkg")
-                self.cpp_info.components["cmp1"].requires.append("pkgB::cmp1")
+                self.cpp_info.components["cmp1"].requires.append("pkgb::cmp1")
                 self.cpp_info.components["cmp1"].set_property("pkg_config_name", "component1")
                 # Duplicated aliases
                 self.cpp_info.components["cmp2"].set_property("pkg_config_aliases", ["alias1"])
@@ -513,11 +513,11 @@ def test_duplicated_names_warnings():
                 self.cpp_info.components["cmp4"].set_property("pkg_config_aliases", ["libcmp"])
         """)
     client.save({"conanfile.py": conanfile}, clean_first=True)
-    client.run("create . pkgA/1.0@")
+    client.run("create . pkga/1.0@")
 
     conanfile = textwrap.dedent("""
         [requires]
-        pkgA/1.0
+        pkga/1.0
 
         [generators]
         PkgConfigDeps
@@ -525,25 +525,81 @@ def test_duplicated_names_warnings():
     client.save({"conanfile.txt": conanfile}, clean_first=True)
     client.run("install .")
     output = client.out
-    # Duplicated aliases from pkgA
-    assert "WARN: [pkgA/1.0] The PC alias name alias1.pc already exists and it matches with " \
+    # Duplicated aliases from pkga
+    assert "WARN: [pkga/1.0] The PC alias name alias1.pc already exists and it matches with " \
            "another alias one" in output
-    # Duplicated names, alias and component name from pkgA
-    assert "WARN: [pkgA/1.0] The PC alias name libcmp.pc already exists and it matches with " \
+    # Duplicated names, alias and component name from pkga
+    # Issue related: https://github.com/conan-io/conan/issues/10341
+    assert "WARN: [pkga/1.0] The PC alias name libcmp.pc already exists and it matches with " \
            "another package/component one" in output
-    # Duplicated components from pkgB
-    assert "WARN: [pkgB/1.0] The PC component name component1.pc already exists and it matches " \
+    # Duplicated components from pkgb
+    assert "WARN: [pkgb/1.0] The PC component name component1.pc already exists and it matches " \
            "with another component one" in output
-    # Duplicated package and component name from pkgB
-    assert "WARN: [pkgB/1.0] The PC package name libpkg.pc already exists and it matches with " \
+    # Duplicated package and component name from pkgb
+    assert "WARN: [pkgb/1.0] The PC package name libpkg.pc already exists and it matches with " \
            "another component one" in output
-    # Duplicated names between pkgB and pkgA
-    assert "WARN: [pkgB/1.0] The PC file name component1.pc already exists and it matches with " \
-           "another name/alias declared in pkgA/1.0 package" in output
-    assert "WARN: [pkgB/1.0] The PC file name libpkg.pc already exists and it matches with " \
-           "another name/alias declared in pkgA/1.0 package" in output
+    # Duplicated names between pkgb and pkga
+    assert "WARN: [pkgb/1.0] The PC file name component1.pc already exists and it matches with " \
+           "another name/alias declared in pkga/1.0 package" in output
+    assert "WARN: [pkgb/1.0] The PC file name libpkg.pc already exists and it matches with " \
+           "another name/alias declared in pkga/1.0 package" in output
     pc_files = [os.path.basename(i) for i in glob.glob(os.path.join(client.current_folder, '*.pc'))]
     pc_files.sort()
     # Let's check all the PC file names created just in case
     assert pc_files == ['alias1.pc', 'component1.pc', 'libcmp.pc', 'libpkg-cmp3.pc',
                         'libpkg-cmp4.pc', 'libpkg.pc']
+
+
+def test_components_and_package_pc_creation_order():
+    """
+    Testing if the root package PC file name matches with any of the components one, the first one
+    is not going to be created. Components have more priority than root package.
+
+    Issue related: https://github.com/conan-io/conan/issues/10341
+    """
+    client = TestClient()
+    conanfile = textwrap.dedent("""
+        from conans import ConanFile
+
+        class PkgConfigConan(ConanFile):
+
+            def package_info(self):
+                self.cpp_info.set_property("pkg_config_name", "OpenCL")
+                self.cpp_info.components["_opencl-headers"].set_property("pkg_config_name", "OpenCL")
+                self.cpp_info.components["_opencl-other"].set_property("pkg_config_name", "OtherCL")
+        """)
+    client.save({"conanfile.py": conanfile})
+    client.run("create . opencl/1.0@")
+
+    conanfile = textwrap.dedent("""
+        from conans import ConanFile
+
+        class PkgConfigConan(ConanFile):
+            requires = "opencl/1.0"
+
+            def package_info(self):
+                self.cpp_info.components["comp"].set_property("pkg_config_name", "pkgb")
+                self.cpp_info.components["comp"].requires.append("opencl::_opencl-headers")
+        """)
+    client.save({"conanfile.py": conanfile}, clean_first=True)
+    client.run("create . pkgb/1.0@")
+
+    conanfile = textwrap.dedent("""
+        [requires]
+        pkgb/1.0
+
+        [generators]
+        PkgConfigDeps
+        """)
+    client.save({"conanfile.txt": conanfile}, clean_first=True)
+    client.run("install .")
+    pc_files = [os.path.basename(i) for i in glob.glob(os.path.join(client.current_folder, '*.pc'))]
+    pc_files.sort()
+    # Let's check all the PC file names created just in case
+    assert pc_files == ['OpenCL.pc', 'OtherCL.pc', 'pkgb.pc']
+    pc_content = client.load("OpenCL.pc")
+    assert "Name: OpenCL" in pc_content
+    assert "Description: Conan component: OpenCL" in pc_content
+    assert "Requires:" not in pc_content
+    pc_content = client.load("pkgb.pc")
+    assert "Requires: OpenCL" in get_requires_from_content(pc_content)


### PR DESCRIPTION
Changelog: Feature: Testing the expected PC files created when the component name matches with the root package one using either `pkg_config` or `PkgConfigDeps` generators.
Closes: https://github.com/conan-io/conan/issues/10341
Docs: https://github.com/conan-io/docs/pull/2378

- [x] Refer to the issue that supports this Pull Request.
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 

<sup>**Note:** By default this PR will skip the slower tests and will use a limited set of python versions. Check [here](https://github.com/conan-io/conan/blob/develop/.github/PR_INCREASE_TESTING.md) how to increase the testing level by writing some tags in the current PR body text.</sup>
