### PR TITLE
Add quotes around `conan_message` output variable so it is not modified

### DIFF
--- a/conan/tools/cmake/cmakedeps/templates/macros.py
+++ b/conan/tools/cmake/cmakedeps/templates/macros.py
@@ -28,7 +28,7 @@ class MacrosTemplate(CMakeDepsFileTemplate):
         return textwrap.dedent("""
         function(conan_message MESSAGE_TYPE MESSAGE_CONTENT)
             if(NOT CONAN_CMAKE_SILENT_OUTPUT)
-                message(${MESSAGE_TYPE} ${MESSAGE_CONTENT})
+                message(${MESSAGE_TYPE} "${MESSAGE_CONTENT}")
             endif()
         endfunction()
 
@@ -39,9 +39,9 @@ class MacrosTemplate(CMakeDepsFileTemplate):
                    find_library(CONAN_FRAMEWORK_${_FRAMEWORK}_FOUND NAMES ${_FRAMEWORK} PATHS ${FRAMEWORKS_DIRS} CMAKE_FIND_ROOT_PATH_BOTH)
                    if(CONAN_FRAMEWORK_${_FRAMEWORK}_FOUND)
                        list(APPEND ${FRAMEWORKS_FOUND} ${CONAN_FRAMEWORK_${_FRAMEWORK}_FOUND})
-                       message("Framework found! ${FRAMEWORKS_FOUND}")
+                       conan_message(DEBUG "Framework found! ${FRAMEWORKS_FOUND}")
                    else()
-                       message(FATAL_ERROR "Framework library ${_FRAMEWORK} not found in paths: ${FRAMEWORKS_DIRS}")
+                       conan_message(FATAL_ERROR "Framework library ${_FRAMEWORK} not found in paths: ${FRAMEWORKS_DIRS}")
                    endif()
                endforeach()
            endif()

--- a/conan/tools/cmake/cmakedeps/templates/target_data.py
+++ b/conan/tools/cmake/cmakedeps/templates/target_data.py
@@ -212,7 +212,6 @@ class _TargetDataContext(object):
             return '"%s"' % ";".join(p.replace('\\', '/').replace('$', '\\$') for p in values)
 
         self.include_paths = join_paths(cpp_info.includedirs)
-        self.include_path = join_paths_single_var(cpp_info.includedirs)
         self.lib_paths = join_paths(cpp_info.libdirs)
         self.res_paths = join_paths(cpp_info.resdirs)
         self.bin_paths = join_paths(cpp_info.bindirs)


### PR DESCRIPTION
Changelog: Fix: Add quotes around `conan_message` output variable so it is not modified.
Docs: omit

