### PR TITLE
CMakeToolchain: Honor vc runtime from profile even if cmake_minimum_required() < 3.15 in CMakeLists

### DIFF
--- a/conan/tools/cmake/toolchain.py
+++ b/conan/tools/cmake/toolchain.py
@@ -99,9 +99,7 @@ class VSRuntimeBlock(Block):
             {% set genexpr.str = genexpr.str +
                                   '$<$<CONFIG:' + config + '>:' + value|string + '>' %}
         {% endfor %}
-        if(POLICY CMP0091)
-            cmake_policy(SET CMP0091 NEW)
-        endif()
+        set(CMAKE_POLICY_DEFAULT_CMP0091 NEW)
         set(CMAKE_MSVC_RUNTIME_LIBRARY "{{ genexpr.str }}")
         """)
 

--- a/conan/tools/cmake/toolchain.py
+++ b/conan/tools/cmake/toolchain.py
@@ -99,6 +99,9 @@ class VSRuntimeBlock(Block):
             {% set genexpr.str = genexpr.str +
                                   '$<$<CONFIG:' + config + '>:' + value|string + '>' %}
         {% endfor %}
+        if(POLICY CMP0091)
+            cmake_policy(SET CMP0091 NEW)
+        endif()
         set(CMAKE_MSVC_RUNTIME_LIBRARY "{{ genexpr.str }}")
         """)
 

--- a/conan/tools/cmake/toolchain.py
+++ b/conan/tools/cmake/toolchain.py
@@ -801,6 +801,10 @@ class CMakeToolchain(object):
             message("Using Conan toolchain: ${CMAKE_TOOLCHAIN_FILE}.")
         endif()
 
+        if(${CMAKE_VERSION} VERSION_LESS "3.15")
+            message(FATAL_ERROR "The 'CMakeToolchain' generator only works with CMake >= 3.15")
+        endif()
+
         {% for conan_block in conan_blocks %}
         {{ conan_block }}
         {% endfor %}


### PR DESCRIPTION
Changelog: Fix: Enforce `CMP0091` policy to NEW in `CMakeToolchain`.
Docs: omit

- [x] Refer to the issue that supports this Pull Request.
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 

closes https://github.com/conan-io/conan/issues/10239

<sup>**Note:** By default this PR will skip the slower tests and will use a limited set of python versions. Check [here](https://github.com/conan-io/conan/blob/develop/.github/PR_INCREASE_TESTING.md) how to increase the testing level by writing some tags in the current PR body text.</sup>
