### PR TITLE
fix: use package folder for Bazel dependency paths

### DIFF
--- a/conan/tools/google/bazeldeps.py
+++ b/conan/tools/google/bazeldeps.py
@@ -1,3 +1,4 @@
+import os
 import textwrap
 
 from jinja2 import Template
@@ -13,26 +14,27 @@ class BazelDeps(object):
 
     def generate(self):
         local_repositories = []
+        conandeps = os.path.join(self._conanfile.generators_folder, 'conandeps')
 
         for build_dependency in self._conanfile.dependencies.direct_build.values():
             content = self._get_build_dependency_buildfile_content(build_dependency)
-            filename = self._save_dependency_buildfile(build_dependency, content)
+            filename = self._save_dependency_buildfile(build_dependency, content, conandeps)
 
             local_repository = self._create_new_local_repository(build_dependency, filename)
             local_repositories.append(local_repository)
 
         for dependency in self._conanfile.dependencies.host.values():
             content = self._get_dependency_buildfile_content(dependency)
-            filename = self._save_dependency_buildfile(dependency, content)
+            filename = self._save_dependency_buildfile(dependency, content, conandeps)
 
             local_repository = self._create_new_local_repository(dependency, filename)
             local_repositories.append(local_repository)
 
         content = self._get_main_buildfile_content(local_repositories)
-        self._save_main_buildfiles(content)
+        self._save_main_buildfiles(content, conandeps)
 
-    def _save_dependency_buildfile(self, dependency, buildfile_content):
-        filename = 'conandeps/{}/BUILD.bazel'.format(dependency.ref.name)
+    def _save_dependency_buildfile(self, dependency, buildfile_content, conandeps):
+        filename = '{}/{}/BUILD.bazel'.format(conandeps, dependency.ref.name)
         save(filename, buildfile_content)
         return filename
 
@@ -153,9 +155,9 @@ class BazelDeps(object):
 
         return content
 
-    def _save_main_buildfiles(self, content):
+    def _save_main_buildfiles(self, content, conandeps):
         # A BUILD.bazel file must exist, even if it's empty, in order for Bazel
         # to detect it as a Bazel package and to allow to load the .bzl files
-        save("conandeps/BUILD.bazel", "")
+        save("{}/BUILD.bazel".format(conandeps), "")
 
-        save("conandeps/dependencies.bzl", content)
+        save("{}/dependencies.bzl".format(conandeps), content)

--- a/conan/tools/google/bazeldeps.py
+++ b/conan/tools/google/bazeldeps.py
@@ -16,14 +16,14 @@ class BazelDeps(object):
 
         for build_dependency in self._conanfile.dependencies.direct_build.values():
             content = self._get_build_dependency_buildfile_content(build_dependency)
-            filename = self._save_dependendy_buildfile(build_dependency, content)
+            filename = self._save_dependency_buildfile(build_dependency, content)
 
             local_repository = self._create_new_local_repository(build_dependency, filename)
             local_repositories.append(local_repository)
 
         for dependency in self._conanfile.dependencies.host.values():
             content = self._get_dependency_buildfile_content(dependency)
-            filename = self._save_dependendy_buildfile(dependency, content)
+            filename = self._save_dependency_buildfile(dependency, content)
 
             local_repository = self._create_new_local_repository(dependency, filename)
             local_repositories.append(local_repository)
@@ -31,8 +31,8 @@ class BazelDeps(object):
         content = self._get_main_buildfile_content(local_repositories)
         self._save_main_buildfiles(content)
 
-    def _save_dependendy_buildfile(self, dependency, buildfile_content):
-        filename = 'conandeps/{}/BUILD'.format(dependency.ref.name)
+    def _save_dependency_buildfile(self, dependency, buildfile_content):
+        filename = 'conandeps/{}/BUILD.bazel'.format(dependency.ref.name)
         save(filename, buildfile_content)
         return filename
 
@@ -154,8 +154,8 @@ class BazelDeps(object):
         return content
 
     def _save_main_buildfiles(self, content):
-        # A BUILD file must exist, even if it's empty, in order for bazel
-        # to detect it as a bazel package and allow to load the .bzl files
-        save("conandeps/BUILD", "")
+        # A BUILD.bazel file must exist, even if it's empty, in order for Bazel
+        # to detect it as a Bazel package and to allow to load the .bzl files
+        save("conandeps/BUILD.bazel", "")
 
         save("conandeps/dependencies.bzl", content)


### PR DESCRIPTION
Changelog: Feature: Use `.bazel` suffix for generated Bazel files.
Changelog: Fix: Use install folder for Bazel dependency paths.
Docs: https://github.com/conan-io/docs/pull/2381

Builds for subdirectories wouldn't work when `--install-folder` was set to anything besides the current directory without this.

- [ ] Refer to the issue that supports this Pull Request.
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one.
