### PR TITLE
[2.0 alpha3] Remove default builddirs + simplified CMakeToolchain

### DIFF
--- a/conan/tools/cmake/toolchain.py
+++ b/conan/tools/cmake/toolchain.py
@@ -383,17 +383,8 @@ class FindFiles(Block):
         {% endif %}
 
         # Definition of CMAKE_MODULE_PATH
-        {% if build_build_paths %}
-        # Explicitly defined "buildirs" of "build" context dependencies
-        list(PREPEND CMAKE_MODULE_PATH {{ build_build_paths }})
-        {% endif %}
-        {% if host_build_paths_noroot %}
-        # Explicitly defined "builddirs" of "host" dependencies
-        list(PREPEND CMAKE_MODULE_PATH {{ host_build_paths_noroot }})
-        {% endif %}
-        {% if host_build_paths_root %}
-        # The root (which is the default builddirs) path of dependencies in the host context
-        list(PREPEND CMAKE_MODULE_PATH {{ host_build_paths_root }})
+        {% if build_paths %}
+        list(PREPEND CMAKE_MODULE_PATH {{ build_paths }})
         {% endif %}
         {% if generators_folder %}
         # the generators folder (where conan generates files, like this toolchain)
@@ -401,9 +392,9 @@ class FindFiles(Block):
         {% endif %}
 
         # Definition of CMAKE_PREFIX_PATH, CMAKE_XXXXX_PATH
-        {% if host_build_paths_noroot %}
+        {% if build_paths %}
         # The explicitly defined "builddirs" of "host" context dependencies must be in PREFIX_PATH
-        list(PREPEND CMAKE_PREFIX_PATH {{ host_build_paths_noroot }})
+        list(PREPEND CMAKE_PREFIX_PATH {{ build_paths }})
         {% endif %}
         {% if generators_folder %}
         # The Conan local "generators" folder, where this toolchain is saved.
@@ -462,17 +453,13 @@ class FindFiles(Block):
 
         # Read information from host context
         host_req = self._conanfile.dependencies.host.values()
-        host_build_paths_root = []
-        host_build_paths_noroot = []
+        build_paths = []
         host_lib_paths = []
         host_framework_paths = []
         host_include_paths = []
         for req in host_req:
             cppinfo = req.cpp_info.aggregated_components()
-            # If the builddir is the package_folder, then it is the default "root" one
-            nf = os.path.normpath(req.package_folder)
-            host_build_paths_root.extend(p for p in cppinfo.builddirs if os.path.normpath(p) == nf)
-            host_build_paths_noroot.extend(p for p in cppinfo.builddirs if os.path.normpath(p) != nf)
+            build_paths.extend(cppinfo.builddirs)
             host_lib_paths.extend(cppinfo.libdirs)
             if is_apple_:
                 host_framework_paths.extend(cppinfo.frameworkdirs)
@@ -480,19 +467,16 @@ class FindFiles(Block):
 
         # Read information from build context
         build_req = self._conanfile.dependencies.build.values()
-        build_build_paths = []
         build_bin_paths = []
         for req in build_req:
             cppinfo = req.cpp_info.aggregated_components()
-            build_build_paths.extend(cppinfo.builddirs)
+            build_paths.extend(cppinfo.builddirs)
             build_bin_paths.extend(cppinfo.bindirs)
 
         return {
             "find_package_prefer_config": find_package_prefer_config,
             "generators_folder": "${CMAKE_CURRENT_LIST_DIR}",
-            "host_build_paths_root": self._join_paths(host_build_paths_root),
-            "host_build_paths_noroot": self._join_paths(host_build_paths_noroot),
-            "build_build_paths": self._join_paths(build_build_paths),
+            "build_paths": self._join_paths(build_paths),
             "cmake_program_path": self._join_paths(build_bin_paths),
             "cmake_library_path": self._join_paths(host_lib_paths),
             "cmake_framework_path": self._join_paths(host_framework_paths),

--- a/conans/model/build_info.py
+++ b/conans/model/build_info.py
@@ -276,7 +276,7 @@ class CppInfo(object):
             self.libdirs = ["lib"]
             self.resdirs = ["res"]
             self.bindirs = ["bin"]
-            self.builddirs = [""]
+            self.builddirs = []
             self.frameworkdirs = ["Frameworks"]
 
         self._aggregated = None  # A _NewComponent object with all the components aggregated

--- a/conans/test/functional/layout/test_editables_layout.py
+++ b/conans/test/functional/layout/test_editables_layout.py
@@ -86,7 +86,7 @@ def test_cpp_info_editable():
     out = str(client2.out).replace(r"\\", "/").replace(package_folder, "")
     assert "**includedirs:['package_include']**" in out
     assert "**libdirs:['lib']**" in out
-    assert "**builddirs:['']**" in out
+    assert "**builddirs:[]**" in out
     assert "**frameworkdirs:['Frameworks', 'package_frameworks_path']**" in out
     assert "**libs:['lib_when_package', 'lib_when_package2']**" in out
     assert "**objects:['myobject.o']**" in out


### PR DESCRIPTION
~~I'll open a PR~~ https://github.com/conan-io/docs/pull/2365 in the doc to complete the migration guide regarding the builddirs.
We will document at the 2.0 docs that the inclusion of [''] at the builddirs is discouraged. (e.g. once the root dir is added to CMAKE_PREFIX_PATH, cmake will find executables from host context instead of build context)

Closes https://github.com/conan-io/conan/issues/10362