### PR TITLE
tools.files.patch reads the patch files from the conanfile.source_folder

### DIFF
--- a/conan/tools/files/patches.py
+++ b/conan/tools/files/patches.py
@@ -50,13 +50,17 @@ def patch(conanfile, base_path=None, patch_file=None, patch_string=None, strip=0
     patchlog.addHandler(PatchLogHandler(conanfile, patch_file))
 
     if patch_file:
-        patchset = patch_ng.fromfile(patch_file)
+        # trick *1: patch_file path could be absolute (e.g. conanfile.build_folder), in that case
+        # the join does nothing and works.
+        patch_path = os.path.join(conanfile.source_folder, patch_file)
+        patchset = patch_ng.fromfile(patch_path)
     else:
         patchset = patch_ng.fromstring(patch_string.encode())
 
     if not patchset:
         raise ConanException("Failed to parse patch: %s" % (patch_file if patch_file else "string"))
 
+    # trick *1
     root = os.path.join(conanfile.source_folder, base_path) if base_path else conanfile.source_folder
     if not patchset.apply(strip=strip, root=root, fuzz=fuzz):
         raise ConanException("Failed to apply patch: %s" % patch_file)

--- a/conans/test/unittests/tools/files/test_patches.py
+++ b/conans/test/unittests/tools/files/test_patches.py
@@ -40,7 +40,7 @@ def test_single_patch_file(mock_patch_ng):
     conanfile.folders.set_base_source("/my_source")
     conanfile.display_name = 'mocked/ref'
     patch(conanfile, patch_file='patch-file')
-    assert mock_patch_ng.filename == '/my_source/patch-file'
+    assert mock_patch_ng.filename.replace("\\", "/") == '/my_source/patch-file'
     assert mock_patch_ng.string is None
     assert mock_patch_ng.apply_args == ("/my_source", 0, False)
     assert len(str(conanfile.output)) == 0
@@ -56,12 +56,13 @@ def test_single_patch_file_from_forced_build(mock_patch_ng):
     assert mock_patch_ng.apply_args == ("/my_source", 0, False)
     assert len(str(conanfile.output)) == 0
 
+
 def test_base_path(mock_patch_ng):
     conanfile = ConanFileMock()
     conanfile.folders.set_base_source("/my_source")
     conanfile.display_name = 'mocked/ref'
     patch(conanfile, patch_file='patch-file', base_path="subfolder")
-    assert mock_patch_ng.filename == '/my_source/patch-file'
+    assert mock_patch_ng.filename.replace("\\", "/") == '/my_source/patch-file'
     assert mock_patch_ng.string is None
     assert mock_patch_ng.apply_args == (os.path.join("/my_source", "subfolder"), 0, False)
     assert len(str(conanfile.output)) == 0
@@ -71,9 +72,11 @@ def test_apply_in_build_from_patch_in_source(mock_patch_ng):
     conanfile.folders.set_base_source("/my_source")
     conanfile.display_name = 'mocked/ref'
     patch(conanfile, patch_file='patch-file', base_path="/my_build/subfolder")
-    assert mock_patch_ng.filename == '/my_source/patch-file'
+    assert mock_patch_ng.filename.replace("\\", "/") == '/my_source/patch-file'
     assert mock_patch_ng.string is None
-    assert mock_patch_ng.apply_args == (os.path.join("/my_build", "subfolder"), 0, False)
+    assert mock_patch_ng.apply_args[0] == os.path.join("/my_build", "subfolder").replace("\\", "/")
+    assert mock_patch_ng.apply_args[1] == 0
+    assert mock_patch_ng.apply_args[2] is False
     assert len(str(conanfile.output)) == 0
 
 
@@ -93,7 +96,7 @@ def test_single_patch_arguments(mock_patch_ng):
     conanfile.display_name = 'mocked/ref'
     conanfile.folders.set_base_source("/path/to/sources")
     patch(conanfile, patch_file='patch-file', strip=23, fuzz=True)
-    assert mock_patch_ng.filename == '/path/to/sources/patch-file'
+    assert mock_patch_ng.filename.replace("\\", "/") == '/path/to/sources/patch-file'
     assert mock_patch_ng.apply_args == ("/path/to/sources", 23, True)
     assert len(str(conanfile.output)) == 0
 

--- a/conans/test/unittests/tools/files/test_patches.py
+++ b/conans/test/unittests/tools/files/test_patches.py
@@ -37,23 +37,43 @@ def mock_patch_ng(monkeypatch):
 
 def test_single_patch_file(mock_patch_ng):
     conanfile = ConanFileMock()
-    conanfile.folders.set_base_source("my_source")
+    conanfile.folders.set_base_source("/my_source")
     conanfile.display_name = 'mocked/ref'
     patch(conanfile, patch_file='patch-file')
-    assert mock_patch_ng.filename == 'patch-file'
+    assert mock_patch_ng.filename == '/my_source/patch-file'
     assert mock_patch_ng.string is None
-    assert mock_patch_ng.apply_args == ("my_source", 0, False)
+    assert mock_patch_ng.apply_args == ("/my_source", 0, False)
     assert len(str(conanfile.output)) == 0
 
 
+def test_single_patch_file_from_forced_build(mock_patch_ng):
+    conanfile = ConanFileMock()
+    conanfile.folders.set_base_source("/my_source")
+    conanfile.display_name = 'mocked/ref'
+    patch(conanfile, patch_file='/my_build/patch-file')
+    assert mock_patch_ng.filename == '/my_build/patch-file'
+    assert mock_patch_ng.string is None
+    assert mock_patch_ng.apply_args == ("/my_source", 0, False)
+    assert len(str(conanfile.output)) == 0
+
 def test_base_path(mock_patch_ng):
     conanfile = ConanFileMock()
-    conanfile.folders.set_base_source("my_source")
+    conanfile.folders.set_base_source("/my_source")
     conanfile.display_name = 'mocked/ref'
     patch(conanfile, patch_file='patch-file', base_path="subfolder")
-    assert mock_patch_ng.filename == 'patch-file'
+    assert mock_patch_ng.filename == '/my_source/patch-file'
     assert mock_patch_ng.string is None
-    assert mock_patch_ng.apply_args == (os.path.join("my_source", "subfolder"), 0, False)
+    assert mock_patch_ng.apply_args == (os.path.join("/my_source", "subfolder"), 0, False)
+    assert len(str(conanfile.output)) == 0
+
+def test_apply_in_build_from_patch_in_source(mock_patch_ng):
+    conanfile = ConanFileMock()
+    conanfile.folders.set_base_source("/my_source")
+    conanfile.display_name = 'mocked/ref'
+    patch(conanfile, patch_file='patch-file', base_path="/my_build/subfolder")
+    assert mock_patch_ng.filename == '/my_source/patch-file'
+    assert mock_patch_ng.string is None
+    assert mock_patch_ng.apply_args == (os.path.join("/my_build", "subfolder"), 0, False)
     assert len(str(conanfile.output)) == 0
 
 
@@ -73,7 +93,7 @@ def test_single_patch_arguments(mock_patch_ng):
     conanfile.display_name = 'mocked/ref'
     conanfile.folders.set_base_source("/path/to/sources")
     patch(conanfile, patch_file='patch-file', strip=23, fuzz=True)
-    assert mock_patch_ng.filename == 'patch-file'
+    assert mock_patch_ng.filename == '/path/to/sources/patch-file'
     assert mock_patch_ng.apply_args == ("/path/to/sources", 23, True)
     assert len(str(conanfile.output)) == 0
 


### PR DESCRIPTION
Changelog: Fix: The argument `patch_file` from `tools.files.patch` is now relative to `conanfile.source_folder`by default, unless an absolute path to another location is provided, for example, to a path in the `conanfile.build_folder`.
Docs: https://github.com/conan-io/docs/pull/2382

It will be ported to 2.0 to close #10374 at the alpha 3
