### PR TITLE
fix: use  `Folders.package` in `Folders.package_folder`

### DIFF
--- a/conans/client/cmd/export_pkg.py
+++ b/conans/client/cmd/export_pkg.py
@@ -61,6 +61,7 @@ def export_pkg(app, recorder, full_ref, source_folder, build_folder, package_fol
         conanfile_folder = os.path.dirname(source_conanfile_path)
         conanfile.folders.set_base_folders(conanfile_folder, output_folder=None)
         conanfile.folders.set_base_package(dest_package_folder)
+        conanfile.folders.package = None
     else:
         conanfile.folders.set_base_build(build_folder)
         conanfile.folders.set_base_source(source_folder)

--- a/conans/client/installer.py
+++ b/conans/client/installer.py
@@ -570,6 +570,7 @@ class BinaryInstaller(object):
                                                    % (str(pref), package_folder))
             # Call the info method
             conanfile.folders.set_base_package(package_folder)
+            conanfile.folders.package = None
             conanfile.folders.set_base_source(None)
             conanfile.folders.set_base_build(None)
             conanfile.folders.set_base_install(None)

--- a/conans/model/conan_file.py
+++ b/conans/model/conan_file.py
@@ -271,7 +271,7 @@ class ConanFile(object):
 
     @property
     def package_folder(self):
-        return self.folders.base_package
+        return self.folders.package_folder
 
     @property
     def install_folder(self):

--- a/conans/model/layout.py
+++ b/conans/model/layout.py
@@ -102,8 +102,11 @@ class Folders(object):
 
     @property
     def package_folder(self):
-        """For the cache, the package folder is only the base"""
-        return self._base_package
+        if self._base_package is None:
+            return None
+        if not self.package:
+            return self._base_package
+        return os.path.join(self._base_package, self.package)
 
     @property
     def generators_folder(self):


### PR DESCRIPTION
Currently, installing directly from a configured build tool uses `folders._base_package`, which is often the root folder. Relevant cache cases should set `folders.package = None` before getting `folders.package_folder` or otherwise find a way to only use `folders._base_package`.

Changelog:
* Feat: Use `Folders.package_folder` in `ConanFile.package_folder`
* Fix: Respect `Folders.package` in `Folders.package_folder`

- [ ] Refer to the issue that supports this Pull Request.
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one.