### PR TITLE
feat: make pkg-config tooling more accessible

### DIFF
--- a/conan/tools/gnu/__init__.py
+++ b/conan/tools/gnu/__init__.py
@@ -1,4 +1,5 @@
+from conan.tools.gnu.autotools import Autotools
 from conan.tools.gnu.autotoolstoolchain import AutotoolsToolchain
 from conan.tools.gnu.autotoolsdeps import AutotoolsDeps
-from conan.tools.gnu.autotools import Autotools
-from conan.tools.gnu.pkgconfigdeps.pkgconfigdeps import PkgConfigDeps
+from conan.tools.gnu.pkgconfig import PkgConfig
+from conan.tools.gnu.pkgconfigdeps import PkgConfigDeps

--- a/conan/tools/gnu/pkgconfigdeps/__init__.py
+++ b/conan/tools/gnu/pkgconfigdeps/__init__.py
@@ -1,0 +1,1 @@
+from conan.tools.gnu.pkgconfigdeps.pkgconfigdeps import PkgConfigDeps


### PR DESCRIPTION
This is how other tooling under `conan.tools` is expected to be accessed.

Changelog: Feature: Make `pkg-config` tooling accessible under `conan.tools.gnu.PkgConfig` and `conan.tools.gnu.PkgConfigDeps`.
Docs: Omit

- [x] Not applicable: Refer to the issue that supports this Pull Request.
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [x] Not applicable: I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one.