### PR TITLE
fix: AttributeError: 'PackageEditableLayout' object has no attribute …

### DIFF
--- a/conans/client/installer.py
+++ b/conans/client/installer.py
@@ -434,19 +434,19 @@ class BinaryInstaller(object):
                 output = conan_file.output
 
                 self._propagate_info(node, using_build_profile)
-                if node.binary == BINARY_EDITABLE:
-                    self._handle_node_editable(node, profile_host, profile_build, graph_lock)
-                    # Need a temporary package revision for package_revision_mode
-                    # Cannot be PREV_UNKNOWN otherwise the consumers can't compute their packageID
-                    node.prev = "editable"
-                else:
-                    if node.binary == BINARY_SKIP:  # Privates not necessary
+                if node.binary == BINARY_SKIP:  # Privates not necessary
                         continue
                     assert ref.revision is not None, "Installer should receive RREV always"
                     if node.binary == BINARY_UNKNOWN:
                         self._binaries_analyzer.reevaluate_node(node, remotes, build_mode, update)
                         if node.binary == BINARY_MISSING:
                             self._raise_missing([node])
+                if node.binary == BINARY_EDITABLE:
+                    self._handle_node_editable(node, profile_host, profile_build, graph_lock)
+                    # Need a temporary package revision for package_revision_mode
+                    # Cannot be PREV_UNKNOWN otherwise the consumers can't compute their packageID
+                    node.prev = "editable"
+                else:
                     _handle_system_requirements(conan_file, node.pref, self._cache, output)
                     self._handle_node_cache(node, keep_build, processed_package_refs, remotes)
 

--- a/conans/client/installer.py
+++ b/conans/client/installer.py
@@ -434,21 +434,27 @@ class BinaryInstaller(object):
                 output = conan_file.output
 
                 self._propagate_info(node, using_build_profile)
-                if node.binary == BINARY_SKIP:  # Privates not necessary
-                        continue
-                    assert ref.revision is not None, "Installer should receive RREV always"
-                    if node.binary == BINARY_UNKNOWN:
-                        self._binaries_analyzer.reevaluate_node(node, remotes, build_mode, update)
-                        if node.binary == BINARY_MISSING:
-                            self._raise_missing([node])
                 if node.binary == BINARY_EDITABLE:
                     self._handle_node_editable(node, profile_host, profile_build, graph_lock)
                     # Need a temporary package revision for package_revision_mode
                     # Cannot be PREV_UNKNOWN otherwise the consumers can't compute their packageID
                     node.prev = "editable"
                 else:
-                    _handle_system_requirements(conan_file, node.pref, self._cache, output)
-                    self._handle_node_cache(node, keep_build, processed_package_refs, remotes)
+                    if node.binary == BINARY_SKIP:  # Privates not necessary
+                        continue
+                    assert ref.revision is not None, "Installer should receive RREV always"
+                    if node.binary == BINARY_UNKNOWN:
+                        self._binaries_analyzer.reevaluate_node(node, remotes, build_mode, update)
+                        if node.binary == BINARY_MISSING:
+                            self._raise_missing([node])
+                    if node.binary == BINARY_EDITABLE:
+                        self._handle_node_editable(node, profile_host, profile_build, graph_lock)
+                        # Need a temporary package revision for package_revision_mode
+                        # Cannot be PREV_UNKNOWN otherwise the consumers can't compute their packageID
+                        node.prev = "editable"
+                    else:
+                        _handle_system_requirements(conan_file, node.pref, self._cache, output)
+                        self._handle_node_cache(node, keep_build, processed_package_refs, remotes)
 
         # Finally, propagate information to root node (ref=None)
         self._propagate_info(root_node, using_build_profile)


### PR DESCRIPTION
…'package_lock'. Correct node.binary handling in editable mode with package_revision_mode.

Changelog: Bugfix: Fix ``AttributeError: 'PackageEditableLayout' object has no attribute 'package_lock'`` that happened when sing ``package_revision_mode`` with ``editable`` packages (and lockfiles). 
Docs: Omit

Close #10410

**Describe here your pull request**


- [x] Refer to the issue that supports this Pull Request.
- [ ] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 

<sup>**Note:** By default this PR will skip the slower tests and will use a limited set of python versions. Check [here](https://github.com/conan-io/conan/blob/develop/.github/PR_INCREASE_TESTING.md) how to increase the testing level by writing some tags in the current PR body text.</sup>
