### PR TITLE
fixing url filename in config install

### DIFF
--- a/conans/client/conf/config_installer.py
+++ b/conans/client/conf/config_installer.py
@@ -3,12 +3,9 @@ import os
 import shutil
 
 from datetime import datetime
-from urllib.parse import urlsplit
-
 from dateutil.tz import gettz
-
 from contextlib import contextmanager
-from six.moves.urllib.parse import urlparse
+from six.moves.urllib.parse import urlparse, urlsplit
 
 from conans import load
 from conans.client import tools

--- a/conans/client/conf/config_installer.py
+++ b/conans/client/conf/config_installer.py
@@ -3,6 +3,8 @@ import os
 import shutil
 
 from datetime import datetime
+from urllib.parse import urlsplit
+
 from dateutil.tz import gettz
 
 from contextlib import contextmanager
@@ -147,7 +149,9 @@ def _process_folder(config, folder, cache, output):
 def _process_download(config, cache, output, requester):
     with tmp_config_install_folder(cache) as tmp_folder:
         output.info("Trying to download  %s" % _hide_password(config.uri))
-        zippath = os.path.join(tmp_folder, os.path.basename(config.uri))
+        path = urlsplit(config.uri).path
+        filename = os.path.basename(path)
+        zippath = os.path.join(tmp_folder, filename)
         try:
             downloader = FileDownloader(requester=requester, output=output, verify=config.verify_ssl,
                                         config_retry=None, config_retry_wait=None)

--- a/conans/test/functional/command/config_install_test.py
+++ b/conans/test/functional/command/config_install_test.py
@@ -366,6 +366,18 @@ class Pkg(ConanFile):
                 self.client.run("config install http://myfakeurl.com/myconf.zip %s" % origin)
                 self._check("url, http://myfakeurl.com/myconf.zip, True, None")
 
+    def test_install_url_query(self):
+        """ should install from a URL
+        """
+
+        def my_download(obj, url, file_path, **kwargs):  # @UnusedVariable
+            self._create_zip(file_path)
+
+        with patch.object(FileDownloader, 'download', new=my_download):
+            # repeat the process to check it works with ?args
+            self.client.run("config install http://myfakeurl.com/myconf.zip?sha=1")
+            self._check("url, http://myfakeurl.com/myconf.zip?sha=1, True, None")
+
     def test_install_change_only_verify_ssl(self):
         def my_download(obj, url, file_path, **kwargs):  # @UnusedVariable
             self._create_zip(file_path)


### PR DESCRIPTION
Changelog: Fix: Parsing a url with query args in ``conan config install`` results in a bad filename that could fail. 
Docs: Omit
Close https://github.com/conan-io/conan/issues/10421