### PR TITLE
msvc_runtime_flag should not break when expecting a string value

### DIFF
--- a/conan/tools/microsoft/visual.py
+++ b/conan/tools/microsoft/visual.py
@@ -80,6 +80,7 @@ def msvc_runtime_flag(conanfile):
         if runtime_type == "Debug":
             runtime = "{}d".format(runtime)
         return runtime
+    return ""
 
 
 def vcvars_command(version, architecture=None, platform_type=None, winsdk_version=None,

--- a/conans/test/functional/toolchains/microsoft/test_msbuild.py
+++ b/conans/test/functional/toolchains/microsoft/test_msbuild.py
@@ -605,3 +605,21 @@ class WinTest(unittest.TestCase):
             else:
                 self.assertNotIn("hello.dll", client.out)
             self.assertIn("KERNEL32.dll", client.out)
+
+
+def test_msvc_runtime_flag_common_usage():
+    """The msvc_runtime_flag must not break when expecting a string
+    """
+    client = TestClient()
+    conanfile = textwrap.dedent("""
+       from conans import ConanFile
+       from conan.tools.microsoft import msvc_runtime_flag
+       class App(ConanFile):
+           settings = "os", "arch", "compiler", "build_type"
+
+           def validate(self):
+               if "MT" in msvc_runtime_flag(self):
+                   pass
+        """)
+    client.save({"conanfile.py": conanfile})
+    client.run('info .')

--- a/conans/test/functional/toolchains/microsoft/test_msbuild.py
+++ b/conans/test/functional/toolchains/microsoft/test_msbuild.py
@@ -13,6 +13,7 @@ from conans.test.assets.sources import gen_function_cpp
 from conans.test.conftest import tools_locations
 from conans.test.functional.utils import check_vs_runtime, check_exe_run
 from conans.test.utils.tools import TestClient
+from conans.util.files import rmdir
 
 
 sln_file = r"""
@@ -551,8 +552,7 @@ class WinTest(unittest.TestCase):
             # Build the profile according to the settings provided
             # TODO: It is a bit ugly to remove manually
             build_test_folder = os.path.join(client.current_folder, "test_package", "build")
-            if os.path.exists(build_test_folder):
-                shutil.rmtree(build_test_folder)
+            rmdir(build_test_folder)
             runtime = "MT" if build_type == "Release" else "MTd"
             client.run("create . hello/0.1@ %s -s build_type=%s -s arch=%s -s compiler.runtime=%s "
                        " -o hello:shared=%s" % (settings, build_type, arch, runtime, shared))


### PR DESCRIPTION
Changelog: Fix: `msvc_runtime_flag` returns empty string instead of `None`.
Docs: https://github.com/conan-io/docs/pull/2363

The helper `msvc_runtime_flag` works fine when running on Windows, but it returns None when something is not expected, so the follow condition is fragile:

```python
    if "MT" in msvc_runtime_flag(self):
        pass
```

On Windows it can work, but for any other OS/compiler it will result:

```
if "MT" in msvc_runtime_flag(self):
TypeError: argument of type 'NoneType' is not iterable
```

The possible solution is an extra validation, but it makes the code more polluted and can result in prone error sometimes:

```python
    if self.settings.compiler in ["Visual Studio", "msvc"] and "MT" in msvc_runtime_flag(self):
        pass
```

If we return an empty string, it be avoided on Linux/Mac/other compiler.

- [ ] Refer to the issue that supports this Pull Request.
- [ ] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [ ] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [ ] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 

<sup>**Note:** By default this PR will skip the slower tests and will use a limited set of python versions. Check [here](https://github.com/conan-io/conan/blob/develop/.github/PR_INCREASE_TESTING.md) how to increase the testing level by writing some tags in the current PR body text.</sup>
