### PR TITLE
List required_conan_version on inspect command

### DIFF
--- a/conans/client/conan_api.py
+++ b/conans/client/conan_api.py
@@ -33,7 +33,7 @@ from conans.client.graph.range_resolver import RangeResolver
 from conans.client.hook_manager import HookManager
 from conans.client.importer import run_imports, undo_imports
 from conans.client.installer import BinaryInstaller
-from conans.client.loader import ConanFileLoader
+from conans.client.loader import ConanFileLoader, load_required_conan_version
 from conans.client.manager import deps_install
 from conans.client.migrations import ClientMigrator
 from conans.client.output import ConanOutput, colorama_initialize
@@ -292,6 +292,7 @@ class ConanAPIV1(object):
 
             result = self.app.proxy.get_recipe(ref, False, False, remotes, ActionRecorder())
             conanfile_path, _, _, ref = result
+
             conanfile = self.app.loader.load_basic(conanfile_path)
             conanfile.name = ref.name
             # FIXME: Conan 2.0, this should be a string, not a Version object
@@ -299,7 +300,7 @@ class ConanAPIV1(object):
 
         result = OrderedDict()
         if not attributes:
-            attributes = ['name', 'version', 'url', 'homepage', 'license', 'author',
+            attributes = ['required_conan_version', 'name', 'version', 'url', 'homepage', 'license', 'author',
                           'description', 'topics', 'generators', 'exports', 'exports_sources',
                           'short_paths', 'apply_env', 'build_policy', 'revision_mode', 'settings',
                           'options', 'default_options', 'deprecated']
@@ -311,6 +312,9 @@ class ConanAPIV1(object):
                 result[attribute] = attr
             except AttributeError:
                 result[attribute] = ''
+        if 'required_conan_version' in attributes:
+            version = load_required_conan_version(conanfile_path)
+            result['required_conan_version'] = version or "None"
         return result
 
     @api_method

--- a/conans/client/conan_api.py
+++ b/conans/client/conan_api.py
@@ -300,10 +300,10 @@ class ConanAPIV1(object):
 
         result = OrderedDict()
         if not attributes:
-            attributes = ['required_conan_version', 'name', 'version', 'url', 'homepage', 'license', 'author',
+            attributes = ['name', 'version', 'url', 'homepage', 'license', 'author',
                           'description', 'topics', 'generators', 'exports', 'exports_sources',
                           'short_paths', 'apply_env', 'build_policy', 'revision_mode', 'settings',
-                          'options', 'default_options', 'deprecated']
+                          'options', 'default_options', 'deprecated', 'required_conan_version']
         # TODO: Change this in Conan 2.0, cli stdout should display only fields with values,
         # json should contain all values for easy automation
         for attribute in attributes:

--- a/conans/client/loader.py
+++ b/conans/client/loader.py
@@ -457,3 +457,22 @@ def _parse_conanfile(conan_file_path):
         sys.path.pop(0)
 
     return loaded, module_id
+
+
+def load_required_conan_version(conanfile_path):
+    """
+        Load conanfile.py and read required_conan_version variable
+        :param conanfile_path: conanfile.py absolute path
+        :return: required_conan_version's value. Otherwise, None.
+    """
+    module_id = str(uuid.uuid1())
+    loaded = None
+    try:
+        from importlib.machinery import SourceFileLoader
+        loaded = SourceFileLoader(module_id, conanfile_path).load_module()
+    except ImportError:
+        old_dont_write_bytecode = sys.dont_write_bytecode
+        sys.dont_write_bytecode = True
+        loaded = imp.load_source(module_id, conanfile_path)
+        sys.dont_write_bytecode = old_dont_write_bytecode
+    return getattr(loaded, "required_conan_version", None)

--- a/conans/test/assets/genconanfile.py
+++ b/conans/test/assets/genconanfile.py
@@ -416,7 +416,8 @@ class GenConanfile(object):
     def __repr__(self):
         ret = []
         ret.extend(self._imports)
-        ret.append(self._required_conan_version_render)
+        if self._required_conan_version is not None:
+            ret.append(self._required_conan_version_render)
         ret.append("class HelloConan(ConanFile):")
 
         # FIXME: This is all a mess. Replace with Jinja2

--- a/conans/test/assets/genconanfile.py
+++ b/conans/test/assets/genconanfile.py
@@ -45,6 +45,7 @@ class GenConanfile(object):
         self._exports = None
         self._cmake_build = False
         self._class_attributes = None
+        self._required_conan_version = None
 
     def with_short_paths(self, value):
         self._short_paths = value
@@ -207,6 +208,10 @@ class GenConanfile(object):
         """.with_class_attribute("no_copy_sources=True") """
         self._class_attributes = self._class_attributes or []
         self._class_attributes.append(attr)
+        return self
+
+    def with_required_conan_version(self, version):
+        self._required_conan_version = version
         return self
 
     @property
@@ -402,9 +407,16 @@ class GenConanfile(object):
         self._class_attributes = self._class_attributes or []
         return ["    {}".format(a) for a in self._class_attributes]
 
+    @property
+    def _required_conan_version_render(self):
+        if self._required_conan_version is None:
+            return ""
+        return 'required_conan_version = "{}"'.format(self._required_conan_version)
+
     def __repr__(self):
         ret = []
         ret.extend(self._imports)
+        ret.append(self._required_conan_version_render)
         ret.append("class HelloConan(ConanFile):")
 
         # FIXME: This is all a mess. Replace with Jinja2

--- a/conans/test/integration/command/inspect_test.py
+++ b/conans/test/integration/command/inspect_test.py
@@ -242,6 +242,7 @@ settings: None
 options: None
 default_options: None
 deprecated: None
+required_conan_version: None
 """, client.out)
 
     def test_inspect_filled_attributes(self):
@@ -291,6 +292,7 @@ default_options:
     bar: False
     foo: True
 deprecated: suggestion
+required_conan_version: None
 """, client.out)
 
     def test_default_options_list(self):
@@ -338,6 +340,7 @@ deprecated: suggestion
                 no_asm: False
                 shared: False
             deprecated: None
+            required_conan_version: None
             """), client.out)
 
     def test_mixed_options_instances(self):
@@ -385,6 +388,7 @@ default_options:
     bar: True
     foo: True
 deprecated: None
+required_conan_version: None
 """, client.out)
 
         client.save({"conanfile.py": conanfile.replace("\"foo=True\", \"bar=True\"",
@@ -413,6 +417,7 @@ default_options:
     bar: True
     foo: True
 deprecated: None
+required_conan_version: None
 """, client.out)
 
 

--- a/conans/test/unittests/client/loader_test.py
+++ b/conans/test/unittests/client/loader_test.py
@@ -1,16 +1,18 @@
 import os
 import textwrap
 import unittest
+import pytest
 
-from conans import Settings
+from conans import Settings, tools
 from conans.client.graph.python_requires import ConanPythonRequire
-from conans.client.loader import ConanFileLoader
+from conans.client.loader import ConanFileLoader, load_required_conan_version
 from conans.model.env_info import EnvValues
 from conans.model.profile import Profile
 from conans.model.ref import ConanFileReference
 from conans.test.utils.test_files import temp_folder
 from conans.test.utils.mocks import TestBufferConanOutput
 from conans.util.files import save
+from conans.test.utils.tools import GenConanfile
 
 
 class LoadConanfileTxtTest(unittest.TestCase):
@@ -50,3 +52,20 @@ class LoadConanfileTxtTest(unittest.TestCase):
         ref = ConanFileReference("hello", "1.0", "user", "channel")
         conanfile = self.loader.load_conanfile(conanfile_path, self.profile, ref)
         self.assertEqual(conanfile.env, {"PREPEND_PATH": ["hello", "bye"], "VAR": ["var_value"]})
+
+
+@pytest.mark.parametrize("version", [None, ">=1.0.0"])
+def test_load_required_conan_version_with_variable(version):
+    """Must read the value present on required_conan_version and return it
+    """
+    conanfile_path = os.path.join(temp_folder(), "conanfile.py")
+    tools.save(conanfile_path, str(GenConanfile().with_required_conan_version(version)))
+    assert version == load_required_conan_version(conanfile_path)
+
+
+def test_load_required_conan_version_without_variable():
+    """Must return None when required_conan_version is not declared
+    """
+    conanfile_path = os.path.join(temp_folder(), "conanfile.py")
+    tools.save(conanfile_path, str(GenConanfile()))
+    assert load_required_conan_version(conanfile_path) is None


### PR DESCRIPTION
We have some ideas for C3i which require inspecting `required_conan_version`, also it's a variable which users can't check without reading the file.

This PR updates the command `inspect` only, but I'm intended to update `info` in a separated PR.

Changelog: Feature: Inspect required_conan_version value
Docs: https://github.com/conan-io/docs/pull/2371

Related to #10411

- [x] Refer to the issue that supports this Pull Request.
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 

<sup>**Note:** By default this PR will skip the slower tests and will use a limited set of python versions. Check [here](https://github.com/conan-io/conan/blob/develop/.github/PR_INCREASE_TESTING.md) how to increase the testing level by writing some tags in the current PR body text.</sup>
