### PR TITLE
cmake-toolchain: set CMAKE_SYSTEM_PROCESSOR in Apple block

### DIFF
--- a/conan/tools/cmake/toolchain.py
+++ b/conan/tools/cmake/toolchain.py
@@ -311,6 +311,9 @@ class AppleSystemBlock(Block):
         {% if CMAKE_SYSTEM_VERSION is defined %}
         set(CMAKE_SYSTEM_VERSION {{ CMAKE_SYSTEM_VERSION }})
         {% endif %}
+        {% if CMAKE_SYSTEM_PROCESSOR is defined %}
+        set(CMAKE_SYSTEM_PROCESSOR {{ CMAKE_SYSTEM_PROCESSOR }})
+        {% endif %}
         # Set the architectures for which to build.
         set(CMAKE_OSX_ARCHITECTURES {{ CMAKE_OSX_ARCHITECTURES }} CACHE STRING "" FORCE)
         # Setting CMAKE_OSX_SYSROOT SDK, when using Xcode generator the name is enough
@@ -340,6 +343,7 @@ class AppleSystemBlock(Block):
             ctxt_toolchain["CMAKE_OSX_SYSROOT"] = host_sdk_name
         if host_architecture:
             ctxt_toolchain["CMAKE_OSX_ARCHITECTURES"] = host_architecture
+            ctxt_toolchain["CMAKE_SYSTEM_PROCESSOR"] = host_architecture
 
         if os_ in ('iOS', "watchOS", "tvOS"):
             ctxt_toolchain["CMAKE_SYSTEM_NAME"] = os_


### PR DESCRIPTION
Hello,

`CMAKE_SYSTEM_PROCESSOR` is not set by `CMakeToolchain` when building on Apple, I'm not sure if this is the right place to set it.

It is mentioned in `GenericSystemBlock`, but after debugging a bit, the values returned by `self._get_cross_build()` are all `None`.

- [ ] Refer to the issue that supports this Pull Request.
- [ ] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [ ] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [ ] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 