### PR TITLE
Identify when using static runtime

### DIFF
--- a/conan/tools/microsoft/__init__.py
+++ b/conan/tools/microsoft/__init__.py
@@ -1,6 +1,6 @@
 from conan.tools.microsoft.toolchain import MSBuildToolchain
 from conan.tools.microsoft.msbuild import MSBuild
 from conan.tools.microsoft.msbuilddeps import MSBuildDeps
-from conan.tools.microsoft.visual import msvc_runtime_flag, VCVars, is_msvc
+from conan.tools.microsoft.visual import msvc_runtime_flag, VCVars, is_msvc, is_msvc_static_runtime
 from conan.tools.microsoft.subsystems import subsystem_path
 from conan.tools.microsoft.layout import vs_layout

--- a/conan/tools/microsoft/visual.py
+++ b/conan/tools/microsoft/visual.py
@@ -181,3 +181,15 @@ def is_msvc(conanfile):
     """
     settings = conanfile.settings
     return settings.get_safe("compiler") in ["Visual Studio", "msvc"]
+
+
+def is_msvc_static_runtime(conanfile):
+    """ Validate when building with Visual Studio or msvc, and self.option.shared and MT on runtime
+    :param conanfile: ConanFile instance
+    :return: True, if msvc + shared option + runtime MT. Otherwise, False
+    """
+    shared = conanfile.options.get_safe("shared")
+    msvc = is_msvc(conanfile)
+    runtime = msvc_runtime_flag(conanfile)
+    result = msvc and shared and "MT" in runtime
+    return result

--- a/conan/tools/microsoft/visual.py
+++ b/conan/tools/microsoft/visual.py
@@ -184,12 +184,8 @@ def is_msvc(conanfile):
 
 
 def is_msvc_static_runtime(conanfile):
-    """ Validate when building with Visual Studio or msvc, and self.option.shared and MT on runtime
+    """ Validate when building with Visual Studio or msvc and MT on runtime
     :param conanfile: ConanFile instance
-    :return: True, if msvc + shared option + runtime MT. Otherwise, False
+    :return: True, if msvc + runtime MT. Otherwise, False
     """
-    shared = conanfile.options.get_safe("shared")
-    msvc = is_msvc(conanfile)
-    runtime = msvc_runtime_flag(conanfile)
-    result = msvc and shared and "MT" in runtime
-    return result
+    return is_msvc(conanfile) and "MT" in msvc_runtime_flag(conanfile)

--- a/conans/test/unittests/tools/microsoft/test_msbuild.py
+++ b/conans/test/unittests/tools/microsoft/test_msbuild.py
@@ -4,10 +4,10 @@ import textwrap
 import pytest
 from mock import Mock
 
-from conan.tools.microsoft import MSBuild, MSBuildToolchain, is_msvc
+from conan.tools.microsoft import MSBuild, MSBuildToolchain, is_msvc, is_msvc_static_runtime
 from conans.model.conf import ConfDefinition, Conf
 from conans.model.env_info import EnvValues
-from conans.test.utils.mocks import ConanFileMock, MockSettings
+from conans.test.utils.mocks import ConanFileMock, MockSettings, MockOptions, MockConanfile
 from conans.test.utils.test_files import temp_folder
 from conans.tools import load
 from conans import ConanFile, Settings
@@ -189,3 +189,23 @@ def test_is_msvc(compiler, expected):
     conanfile.initialize(settings, EnvValues())
     conanfile.settings.compiler = compiler
     assert is_msvc(conanfile) == expected
+
+
+@pytest.mark.parametrize("compiler,shared,runtime,build_type,expected", [
+    ("Visual Studio", True, "MT", "Release", True),
+    ("msvc", True, "static", "Release", True),
+    ("Visual Studio", False, "MT", "Release", False),
+    ("Visual Studio", True, "MD", "Release", False),
+    ("msvc", True, "static", "Debug", True),
+    ("clang", True, None, "Debug", False),
+])
+def test_is_msvc_static_runtime(compiler, shared, runtime, build_type, expected):
+    options = MockOptions({"shared": shared})
+    settings = MockSettings({"build_type": "Release",
+                             "arch": "x86_64",
+                             "compiler": compiler,
+                             "compiler.runtime": runtime,
+                             "compiler.version": "17",
+                             "cppstd": "17"})
+    conanfile = MockConanfile(settings, options)
+    assert is_msvc_static_runtime(conanfile) == expected

--- a/conans/test/unittests/tools/microsoft/test_msbuild.py
+++ b/conans/test/unittests/tools/microsoft/test_msbuild.py
@@ -201,7 +201,7 @@ def test_is_msvc(compiler, expected):
 ])
 def test_is_msvc_static_runtime(compiler, shared, runtime, build_type, expected):
     options = MockOptions({"shared": shared})
-    settings = MockSettings({"build_type": "Release",
+    settings = MockSettings({"build_type": build_type,
                              "arch": "x86_64",
                              "compiler": compiler,
                              "compiler.runtime": runtime,

--- a/conans/test/unittests/tools/microsoft/test_msbuild.py
+++ b/conans/test/unittests/tools/microsoft/test_msbuild.py
@@ -194,7 +194,7 @@ def test_is_msvc(compiler, expected):
 @pytest.mark.parametrize("compiler,shared,runtime,build_type,expected", [
     ("Visual Studio", True, "MT", "Release", True),
     ("msvc", True, "static", "Release", True),
-    ("Visual Studio", False, "MT", "Release", False),
+    ("Visual Studio", False, "MT", "Release", True),
     ("Visual Studio", True, "MD", "Release", False),
     ("msvc", True, "static", "Debug", True),
     ("clang", True, None, "Debug", False),


### PR DESCRIPTION
Changelog: Feature: Add `is_msvc_static_runtime` method to `conan.tools.microsoft.visual` to identify when using `msvc` with static runtime.
Docs: https://github.com/conan-io/docs/pull/2372

Related to discussion https://github.com/conan-io/conan/pull/10424#issuecomment-1021567713

The idea here helping static runtime identification and simplifying conditions in recipes, where can result in a prone error. Example:

```python
def validate(self):
    if is_msvc_static_runtime(self) and self.options.shared:
        raise ConanInvalidConfiguration("Shared option is not well supported with static runtime on Windows")
```



- [ ] Refer to the issue that supports this Pull Request.
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [x] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 

<sup>**Note:** By default this PR will skip the slower tests and will use a limited set of python versions. Check [here](https://github.com/conan-io/conan/blob/develop/.github/PR_INCREASE_TESTING.md) how to increase the testing level by writing some tags in the current PR body text.</sup>
