### PR TITLE
Allow meson wrapper to use backends other than ninja

### DIFF
--- a/conans/client/build/meson.py
+++ b/conans/client/build/meson.py
@@ -185,6 +185,17 @@ class Meson(object):
         else:
             _build()
 
+    def _run_meson_targets(self, args=None, build_dir=None, targets=None):
+        args = args or []
+        build_dir = build_dir or self.build_dir or self._conanfile.build_folder
+
+        arg_list = join_arguments([
+            '-C "%s"' % build_dir,
+            args_to_string(args),
+            args_to_string(targets)
+        ])
+        self._run("meson compile %s" % arg_list)
+
     def _run_ninja_targets(self, args=None, build_dir=None, targets=None):
         if self.backend != "ninja":
             raise ConanException("Build only supported with 'ninja' backend")
@@ -214,7 +225,11 @@ class Meson(object):
         if not self._conanfile.should_build:
             return
         conan_v2_error("build_type setting should be defined.", not self._build_type)
-        self._run_ninja_targets(args=args, build_dir=build_dir, targets=targets)
+        if self.backend == "ninja":
+            self._run_ninja_targets(args=args, build_dir=build_dir, targets=targets)
+        else:
+            self._run_meson_targets(args=args, build_dir=build_dir, targets=targets)
+
 
     def install(self, args=None, build_dir=None):
         if not self._conanfile.should_install:

--- a/conans/test/unittests/client/build/meson_test.py
+++ b/conans/test/unittests/client/build/meson_test.py
@@ -183,6 +183,21 @@ class MesonTest(unittest.TestCase):
         self.assertEqual("meson install -C \"%s\"" % build_expected,
                          conan_file.command)
 
+    def test_other_backend(self):
+        conan_file = ConanFileMock()
+        conan_file.deps_cpp_info = MockDepsCppInfo()
+        conan_file.settings = Settings()
+        conan_file.folders.set_base_package(os.getcwd())
+        meson = Meson(conan_file, backend="vs")
+        meson.configure()
+        self.assertIn("--backend=vs", conan_file.command)
+        meson.build()
+        self.assertIn("meson compile -C", conan_file.command)
+        meson.install()
+        self.assertIn("meson compile -C", conan_file.command)
+        meson.test()
+        self.assertIn("meson compile -C", conan_file.command)
+
     def test_prefix(self):
         conan_file = ConanFileMock()
         conan_file.deps_cpp_info = MockDepsCppInfo()


### PR DESCRIPTION
Changelog: Fix: Let legacy `Meson` build helper use other backends apart from `ninja`.
Docs: omit

- [x] Refer to the issue that supports this Pull Request.
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 

Issue: https://github.com/conan-io/conan/issues/10440

<sup>**Note:** By default this PR will skip the slower tests and will use a limited set of python versions. Check [here](https://github.com/conan-io/conan/blob/develop/.github/PR_INCREASE_TESTING.md) how to increase the testing level by writing some tags in the current PR body text.</sup>
