### PR TITLE
CMakeDeps: Do not report warning for duplicated component names

### DIFF
--- a/conan/tools/cmake/cmakedeps/templates/targets.py
+++ b/conan/tools/cmake/cmakedeps/templates/targets.py
@@ -67,8 +67,6 @@ class TargetsTemplate(CMakeDepsFileTemplate):
             if(NOT TARGET ${_COMPONENT})
                 add_library(${_COMPONENT} INTERFACE IMPORTED)
                 conan_message(STATUS "Conan: Component target declared '${_COMPONENT}'")
-            else()
-                message(WARNING "Component target name '${_COMPONENT}' already exists.")
             endif()
         endforeach()
 


### PR DESCRIPTION
Changelog: Fix: Do not report warning for duplicated component names in CMakeDeps.
Docs: omit

This is a follow-up for https://github.com/conan-io/conan/pull/10150 which removed warnings for duplicated target names however for components warnings were still reported. 

- [x] Refer to the issue that supports this Pull Request.
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 
