### PR TITLE
remove detection of vs2022 as msvc

### DIFF
--- a/conans/client/conf/detect.py
+++ b/conans/client/conf/detect.py
@@ -226,13 +226,6 @@ def _detect_compiler_version(result, output, profile_path):
         output.info("No compiler was detected (one may not be needed)")
         return
 
-    # Visual Studio 2022 onwards, detect as a new compiler "msvc"
-    if compiler == "Visual Studio":
-        version = Version(version)
-        if version == "17":
-            compiler = "msvc"
-            version = "193"
-
     result.append(("compiler", compiler))
     result.append(("compiler.version", _get_profile_compiler_version(compiler, version, output)))
 

--- a/conans/test/unittests/util/detect_test.py
+++ b/conans/test/unittests/util/detect_test.py
@@ -100,8 +100,5 @@ class DetectTest(unittest.TestCase):
             result = detect_defaults_settings(output=Mock(),
                                               profile_path=DEFAULT_PROFILE_NAME)
             result = dict(result)
-            self.assertEqual('msvc', result['compiler'])
-            self.assertEqual('193', result['compiler.version'])
-            self.assertEqual('14', result['compiler.cppstd'])
-            self.assertEqual('dynamic', result['compiler.runtime'])
-            self.assertEqual('Release', result['compiler.runtime_type'])
+            self.assertEqual('Visual Studio', result['compiler'])
+            self.assertEqual('17', result['compiler.version'])


### PR DESCRIPTION
Changelog: Fix: Remove auto-detection of VS 2022 as ``msvc`` compiler, detect it as ``Visual Studio`` version ``17``. 
Docs: https://github.com/conan-io/docs/pull/2376

Close https://github.com/conan-io/conan/issues/10364
