### PR TITLE
Bugfix/make 'conan new' templates work for special chars in package name

### DIFF
--- a/conans/cli/api/helpers/new/cmake_exe.py
+++ b/conans/cli/api/helpers/new/cmake_exe.py
@@ -13,7 +13,7 @@ class {{class_name or name}}Recipe(ConanFile):
     license = "<Put the package license here>"
     author = "<Put your name here> <And your email here>"
     url = "<Package recipe repository url here, for issues about the package>"
-    description = "<Description of {package_name} here>"
+    description = "<Description of {{ name }} package here>"
     topics = ("<Put some tag here>", "<here>", "<and here>")
 
     # Binary configuration
@@ -56,7 +56,7 @@ from conan import ConanFile
 from conan.tools.build import cross_building
 
 
-class {{package_name}}TestConan(ConanFile):
+class {{class_name}}TestConan(ConanFile):
     settings = "os", "compiler", "build_type", "arch"
 
     def requirements(self):

--- a/conans/cli/api/helpers/new/cmake_exe.py
+++ b/conans/cli/api/helpers/new/cmake_exe.py
@@ -4,7 +4,7 @@ conanfile_exe = '''from conan import ConanFile
 from conan.tools.cmake import CMakeToolchain, CMake, cmake_layout
 
 
-class {{class_name or name}}Recipe(ConanFile):
+class {{class_name or name.replace("-", "_").replace("+", "_").replace(".", "_")}}Recipe(ConanFile):
     name = "{{name}}"
     version = "{{version}}"
     package_type = "application"
@@ -56,7 +56,7 @@ from conan import ConanFile
 from conan.tools.build import cross_building
 
 
-class {{class_name}}TestConan(ConanFile):
+class {{class_name or name.replace("-", "_").replace("+", "_").replace(".", "_")}}TestConan(ConanFile):
     settings = "os", "compiler", "build_type", "arch"
 
     def requirements(self):

--- a/conans/cli/api/helpers/new/cmake_lib.py
+++ b/conans/cli/api/helpers/new/cmake_lib.py
@@ -168,7 +168,7 @@ from conan.tools.layout import cmake_layout
 from conan.tools.build import cross_building
 
 
-class {{package_name}}TestConan(ConanFile):
+class {{class_name}}TestConan(ConanFile):
     settings = "os", "compiler", "build_type", "arch"
     generators = "CMakeDeps", "CMakeToolchain"
 

--- a/conans/cli/api/helpers/new/cmake_lib.py
+++ b/conans/cli/api/helpers/new/cmake_lib.py
@@ -2,7 +2,7 @@ conanfile_sources_v2 = '''from conan import ConanFile
 from conan.tools.cmake import CMakeToolchain, CMake, cmake_layout
 
 
-class {{class_name or name}}Recipe(ConanFile):
+class {{class_name or name.replace("-", "_").replace("+", "_").replace(".", "_")}}Recipe(ConanFile):
     name = "{{name}}"
     version = "{{version}}"
 
@@ -60,20 +60,20 @@ install(TARGETS {{name}} DESTINATION "."
 """
 
 source_h = """#pragma once
-
+{% set define_name = name.replace("-", "_").replace("+", "_").replace(".", "_").upper() %}
 #ifdef WIN32
-  #define {{name}}_EXPORT __declspec(dllexport)
+  #define {{define_name}}_EXPORT __declspec(dllexport)
 #else
-  #define {{name}}_EXPORT
+  #define {{define_name}}_EXPORT
 #endif
 
-{{name}}_EXPORT void {{name}}();
+{{define_name}}_EXPORT void {{name.replace("-", "_").replace("+", "_").replace(".", "_")}}();
 """
 
 source_cpp = r"""#include <iostream>
 #include "{{name}}.h"
 
-void {{name}}(){
+void {{name.replace("-", "_").replace("+", "_").replace(".", "_")}}(){
     #ifdef NDEBUG
     std::cout << "{{name}}/{{version}}: Hello World Release!\n";
     #else
@@ -168,7 +168,7 @@ from conan.tools.layout import cmake_layout
 from conan.tools.build import cross_building
 
 
-class {{class_name}}TestConan(ConanFile):
+class {{class_name or name.replace("-", "_").replace("+", "_").replace(".", "_")}}TestConan(ConanFile):
     settings = "os", "compiler", "build_type", "arch"
     generators = "CMakeDeps", "CMakeToolchain"
 
@@ -202,7 +202,7 @@ target_link_libraries(example {{name}}::{{name}})
 test_main = """#include "{{name}}.h"
 
 int main() {
-    {{name}}();
+    {{name.replace("-", "_").replace("+", "_").replace(".", "_")}}();
 }
 """
 


### PR DESCRIPTION
Changelog: Bugfix: Avoid issues of ``conan new`` templates with packages containing special characters like ``-.+``
Docs: Omit

- Replace leftovers of 'package_name' in templates (Conan 1.x) with 'class_name', defaulting to patched 'name')
- Make 'conan new' templates work for special chars in package name ("+-._" are allowed)


- [ ] Refer to the issue that supports this Pull Request.
- [ ] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 

This is targeting develop2 and I didn't find corresponding docs, so I omitted them. Closed the former docs PR targeting develop

<sup>**Note:** By default this PR will skip the slower tests and will use a limited set of python versions. Check [here](https://github.com/conan-io/conan/blob/develop/.github/PR_INCREASE_TESTING.md) how to increase the testing level by writing some tags in the current PR body text.</sup>
