### PR TITLE
Add system.package_manager tools to conan config list

### DIFF
--- a/conans/model/conf.py
+++ b/conans/model/conf.py
@@ -33,7 +33,11 @@ DEFAULT_CONFIGURATION = {
     "tools.microsoft.msbuilddeps:exclude_code_analysis": "Suppress MSBuild code analysis for patterns",
     "tools.microsoft.msbuildtoolchain:compile_options": "Dictionary with MSBuild compiler options",
     "tools.intel:installation_path": "Defines the Intel oneAPI installation root path",
-    "tools.intel:setvars_args": "Custom arguments to be passed onto the setvars.sh|bat script from Intel oneAPI"
+    "tools.intel:setvars_args": "Custom arguments to be passed onto the setvars.sh|bat script from Intel oneAPI",
+    "tools.system.package_manager:tool": "Default package manager tool: 'apt-get', 'yum', 'dnf', 'brew', 'pacman', 'choco', 'zypper', 'pkg' or 'pkgutil'",
+    "tools.system.package_manager:mode": "Mode for package_manager tools: 'check' or 'install'",
+    "tools.system.package_manager:sudo": "Use 'sudo' when invoking the package manager tools in Linux (False by default)",
+    "tools.system.package_manager:sudo_askpass": "Use the '-A' argument if using sudo in Linux to invoke the system package manager (False by default)",
 }
 
 


### PR DESCRIPTION
Changelog: Feature: Add system.package_manager tools to `conan config list`.
Docs: https://github.com/conan-io/docs/pull/2379
