### PR TITLE
Fix Test System

### DIFF
--- a/conans/test/conftest.py
+++ b/conans/test/conftest.py
@@ -244,39 +244,53 @@ def _get_tool(name, version):
     return cached
 
 
-@pytest.fixture(autouse=True)
-def add_tool(request):
+def pytest_configure(config):
+    # register an additional marker
+    config.addinivalue_line(
+        "markers", "tool(name, version): mark test to require a tool by name"
+    )
+
+
+def pytest_runtest_teardown(item):
+    if hasattr(item, "old_environ"):
+        os.environ.clear()
+        os.environ.update(item.old_environ)
+
+
+def pytest_runtest_setup(item):
     tools_paths = []
     tools_env_vars = dict()
-    for mark in request.node.iter_markers():
-        if mark.name.startswith("tool_"):
-            tool_name = mark.name[5:]
-            tool_version = mark.kwargs.get('version')
-            result = _get_tool(tool_name, tool_version)
-            if result is True:
-                version_msg = "Any" if tool_version is None else tool_version
-                pytest.fail("Required '{}' tool version '{}' is not available".format(tool_name,
-                                                                                      version_msg))
-            if result is False:
-                version_msg = "Any" if tool_version is None else tool_version
-                pytest.skip("Required '{}' tool version '{}' is not available".format(tool_name,
-                                                                                      version_msg))
 
-            tool_path, tool_env = result
-            if tool_path:
-                tools_paths.append(tool_path)
-            if tool_env:
-                tools_env_vars.update(tool_env)
-            # Fix random failures CI because of this: https://issues.jenkins.io/browse/JENKINS-9104
-            if tool_name == "visual_studio":
-                tools_env_vars['_MSPDBSRV_ENDPOINT_'] = str(uuid.uuid4())
+    tools_params = [mark.args for mark in item.iter_markers(name="tool")]
+    for tool_params in tools_params:
+        if len(tool_params) == 1:
+            tool_name = tool_params[0]
+            tool_version = None
+        elif len(tool_params) == 2:
+            tool_name, tool_version = tool_params
+        else:
+            raise Exception("Invalid arguments for mark.tool: {}".format(tool_params))
+
+        result = _get_tool(tool_name, tool_version)
+        if result is True:
+            version_msg = "Any" if tool_version is None else tool_version
+            pytest.fail("Required '{}' tool version '{}' is not available".format(tool_name,
+                                                                                  version_msg))
+        if result is False:
+            version_msg = "Any" if tool_version is None else tool_version
+            pytest.skip("Required '{}' tool version '{}' is not available".format(tool_name,
+                                                                                  version_msg))
+
+        tool_path, tool_env = result
+        if tool_path:
+            tools_paths.append(tool_path)
+        if tool_env:
+            tools_env_vars.update(tool_env)
+        # Fix random failures CI because of this: https://issues.jenkins.io/browse/JENKINS-9104
+        if tool_name == "visual_studio":
+            tools_env_vars['_MSPDBSRV_ENDPOINT_'] = str(uuid.uuid4())
 
     if tools_paths or tools_env_vars:
-        old_environ = dict(os.environ)
+        item.old_environ = dict(os.environ)
         tools_env_vars['PATH'] = os.pathsep.join(tools_paths + [os.environ["PATH"]])
         os.environ.update(tools_env_vars)
-        yield
-        os.environ.clear()
-        os.environ.update(old_environ)
-    else:
-        yield

--- a/conans/test/functional/build_helpers/cmake_ios_cross_build_test.py
+++ b/conans/test/functional/build_helpers/cmake_ios_cross_build_test.py
@@ -9,7 +9,7 @@ from conans.test.utils.tools import TestClient
 @pytest.mark.xfail(reason="This was using legacy cmake_find_package generator, need to be tested "
                    "with modern, probably move it to elsewhere")
 @pytest.mark.skipif(platform.system() != "Darwin", reason="Only for Apple")
-@pytest.mark.tool_cmake
+@pytest.mark.tool("cmake")
 def test_cross_build_test_package():
     # https://github.com/conan-io/conan/issues/9202
     profile_build = textwrap.dedent("""

--- a/conans/test/functional/build_helpers/pkg_config_test.py
+++ b/conans/test/functional/build_helpers/pkg_config_test.py
@@ -66,9 +66,8 @@ Cflags: -I${includedir}
 
 """
 
-
-@pytest.mark.tool_pkg_config
-@pytest.mark.tool_mingw32
+@pytest.mark.tool("pkg_config")
+@pytest.mark.tool("mingw32")
 class PkgConfigTest(unittest.TestCase):
     """
     Test WITHOUT a build helper nor a generator, explicitly defining pkg-config in the

--- a/conans/test/functional/command/config_install_test.py
+++ b/conans/test/functional/command/config_install_test.py
@@ -322,7 +322,7 @@ class ConfigInstallTest(unittest.TestCase):
         self.assertIn("ERROR: Failed conan config install: "
                       "Error while installing config from httpnonexisting", self.client.out)
 
-    @pytest.mark.tool_git
+    @pytest.mark.tool("git")
     def test_install_repo(self):
         """ should install from a git repo
         """
@@ -339,7 +339,7 @@ class ConfigInstallTest(unittest.TestCase):
         check_path = os.path.join(folder, ".git")
         self._check("git, %s, True, None" % check_path)
 
-    @pytest.mark.tool_git
+    @pytest.mark.tool("git")
     def test_install_repo_relative(self):
         relative_folder = "./config"
         absolute_folder = os.path.join(self.client.current_folder, "config")
@@ -355,7 +355,7 @@ class ConfigInstallTest(unittest.TestCase):
         self.client.run('config install "%s/.git"' % relative_folder)
         self._check("git, %s, True, None" % os.path.join("%s" % folder, ".git"))
 
-    @pytest.mark.tool_git
+    @pytest.mark.tool("git")
     def test_install_custom_args(self):
         """ should install from a git repo
         """
@@ -462,7 +462,7 @@ class ConfigInstallTest(unittest.TestCase):
         with patch.object(FileDownloader, 'download', new=download_verify_true):
             self.client.run("config install %s --verify-ssl=True" % fake_url)
 
-    @pytest.mark.tool_git
+    @pytest.mark.tool("git")
     def test_git_checkout_is_possible(self):
         folder = self._create_profile_folder()
         with self.client.chdir(folder):
@@ -547,7 +547,7 @@ class ConfigInstallSchedTest(unittest.TestCase):
         self.client.run('config install "%s"' % self.folder)
         self.assertIn("Copying file global.conf", self.client.out)
 
-    @pytest.mark.tool_git
+    @pytest.mark.tool("git")
     def test_config_install_remove_git_repo(self):
         """ config_install_interval must break when remote git has been removed
         """

--- a/conans/test/functional/command/export_test.py
+++ b/conans/test/functional/command/export_test.py
@@ -17,7 +17,7 @@ class ExportMetadataTest(unittest.TestCase):
 
     summary_hash = "bfe8b4a6a2a74966c0c4e0b34705004a"
 
-    @pytest.mark.tool_git
+    @pytest.mark.tool("git")
     def test_revision_mode_scm(self):
         t = TestClient()
         commit = t.init_git_repo({'conanfile.py': self.conanfile.format(revision_mode="scm")})

--- a/conans/test/functional/command/profile_test.py
+++ b/conans/test/functional/command/profile_test.py
@@ -95,7 +95,7 @@ class DetectCompilersTest(unittest.TestCase):
         if platform_compiler is not None:
             self.assertEqual(result.get("compiler", None), platform_compiler)
 
-    @pytest.mark.tool_gcc
+    @pytest.mark.tool("gcc")
     @pytest.mark.skipif(platform.system() != "Darwin", reason="only OSX test")
     def test_detect_default_in_mac_os_using_gcc_as_default(self):
         """

--- a/conans/test/functional/command/source_test.py
+++ b/conans/test/functional/command/source_test.py
@@ -8,7 +8,7 @@ from conans.test.utils.tools import TestClient
 
 class SourceTest(unittest.TestCase):
 
-    @pytest.mark.tool_git
+    @pytest.mark.tool("git")
     def test_conanfile_removed(self):
         # https://github.com/conan-io/conan/issues/4013
         conanfile = """from conan import ConanFile

--- a/conans/test/functional/command/test_command_test.py
+++ b/conans/test/functional/command/test_command_test.py
@@ -10,7 +10,7 @@ from conans.test.utils.tools import TestClient
 @pytest.mark.slow
 class ConanTestTest(unittest.TestCase):
 
-    @pytest.mark.tool_cmake
+    @pytest.mark.tool("cmake")
     def test_conan_test(self):
         client = TestClient()
         client.run("new cmake_lib -d name=hello -d version=0.1")

--- a/conans/test/functional/editable/consume_header_only_test.py
+++ b/conans/test/functional/editable/consume_header_only_test.py
@@ -13,7 +13,7 @@ from conans.test.utils.test_files import temp_folder
 
 
 @pytest.mark.xfail(reason="Editable packages to be superseded by new layout")
-@pytest.mark.tool_cmake
+@pytest.mark.tool("cmake")
 class HeaderOnlyLibTestClient(TestClient):
     header = textwrap.dedent("""\
         #include <iostream>
@@ -66,7 +66,7 @@ class HeaderOnlyLibTestClient(TestClient):
                                                                      origin='local')})
 
 
-@pytest.mark.tool_cmake
+@pytest.mark.tool("cmake")
 @pytest.mark.xfail(reason="cache2.0 editables not considered yet")
 class EditableReferenceTest(unittest.TestCase):
 

--- a/conans/test/functional/editable/consume_settings_and_options_test.py
+++ b/conans/test/functional/editable/consume_settings_and_options_test.py
@@ -65,7 +65,7 @@ class Pkg(ConanFile):
 
 
 @pytest.mark.xfail(reason="Editable packages to be superseded by new layout")
-@pytest.mark.tool_cmake
+@pytest.mark.tool("cmake")
 @pytest.mark.xfail(reason="cache2.0 editables not considered yet")
 class SettingsAndOptionsTest(unittest.TestCase):
 

--- a/conans/test/functional/generators/cmake_apple_frameworks_test.py
+++ b/conans/test/functional/generators/cmake_apple_frameworks_test.py
@@ -12,7 +12,7 @@ from conans.test.utils.tools import TestClient
 
 @pytest.mark.xfail(reason="cmake old generator will be removed")
 @pytest.mark.skipif(platform.system() != "Darwin", reason="Only for MacOS")
-@pytest.mark.tool_cmake
+@pytest.mark.tool("cmake")
 class CMakeAppleFrameworksTestCase(unittest.TestCase):
     lib_ref = RecipeReference.loads("lib/version")
     lib_conanfile = textwrap.dedent("""

--- a/conans/test/functional/generators/premake_test.py
+++ b/conans/test/functional/generators/premake_test.py
@@ -7,7 +7,7 @@ from conans.client.tools import which
 from conans.test.utils.tools import TestClient
 
 
-@pytest.mark.tool_premake
+@pytest.mark.tool("premake")
 @pytest.mark.skipif(which("premake5") is None, reason="Needs premake5")
 class PremakeGeneratorTest(unittest.TestCase):
 

--- a/conans/test/functional/layout/test_editable_cmake.py
+++ b/conans/test/functional/layout/test_editable_cmake.py
@@ -68,11 +68,12 @@ def editable_cmake(generator, build_folder=None):
 
 @pytest.mark.skipif(platform.system() != "Windows", reason="Only windows")
 @pytest.mark.parametrize("generator", [None, "MinGW Makefiles"])
-@pytest.mark.tool_mingw64
+@pytest.mark.tool("mingw64")
 def test_editable_cmake_windows(generator):
     editable_cmake(generator)
 
 
+@pytest.mark.tool("cmake")
 def test_editable_cmake_windows_folders():
     build_folder = temp_folder()
     editable_cmake(generator=None, build_folder=build_folder)
@@ -80,14 +81,14 @@ def test_editable_cmake_windows_folders():
 
 @pytest.mark.skipif(platform.system() != "Linux", reason="Only linux")
 @pytest.mark.parametrize("generator", [None, "Ninja", "Ninja Multi-Config"])
-@pytest.mark.tool_cmake(version="3.17")
+@pytest.mark.toolcmake(version="3.17")
 def test_editable_cmake_linux(generator):
     editable_cmake(generator)
 
 
 @pytest.mark.skipif(platform.system() != "Darwin", reason="Requires Macos")
 @pytest.mark.parametrize("generator", [None, "Ninja", "Xcode"])
-@pytest.mark.tool_cmake(version="3.19")
+@pytest.mark.tool("cmake", "3.19")
 def test_editable_cmake_osx(generator):
     editable_cmake(generator)
 
@@ -136,20 +137,20 @@ def editable_cmake_exe(generator):
 
 @pytest.mark.skipif(platform.system() != "Windows", reason="Only windows")
 @pytest.mark.parametrize("generator", [None, "MinGW Makefiles"])
-@pytest.mark.tool_mingw64
+@pytest.mark.tool("mingw64")
 def test_editable_cmake_windows_exe(generator):
     editable_cmake_exe(generator)
 
 
 @pytest.mark.skipif(platform.system() != "Linux", reason="Only linux")
 @pytest.mark.parametrize("generator", [None, "Ninja", "Ninja Multi-Config"])
-@pytest.mark.tool_cmake(version="3.17")
+@pytest.mark.tool("cmake", "3.17")
 def test_editable_cmake_linux_exe(generator):
     editable_cmake_exe(generator)
 
 
 @pytest.mark.skipif(platform.system() != "Darwin", reason="Requires Macos")
 @pytest.mark.parametrize("generator", [None, "Ninja", "Xcode"])
-@pytest.mark.tool_cmake(version="3.19")
+@pytest.mark.tool("cmake", "3.19")
 def test_editable_cmake_osx_exe(generator):
     editable_cmake_exe(generator)

--- a/conans/test/functional/layout/test_editable_cmake.py
+++ b/conans/test/functional/layout/test_editable_cmake.py
@@ -81,7 +81,7 @@ def test_editable_cmake_windows_folders():
 
 @pytest.mark.skipif(platform.system() != "Linux", reason="Only linux")
 @pytest.mark.parametrize("generator", [None, "Ninja", "Ninja Multi-Config"])
-@pytest.mark.toolcmake(version="3.17")
+@pytest.mark.tool("cmake", "3.17")
 def test_editable_cmake_linux(generator):
     editable_cmake(generator)
 

--- a/conans/test/functional/layout/test_source_folder.py
+++ b/conans/test/functional/layout/test_source_folder.py
@@ -14,6 +14,7 @@ from conans.test.utils.tools import TestClient, zipdir
 app_name = "Release/my_app.exe" if platform.system() == "Windows" else "my_app"
 
 
+@pytest.mark.tool("cmake")
 @pytest.mark.parametrize("no_copy_source", ["False", "True"])
 def test_exports_source_with_src_subfolder(no_copy_source):
     """If we have the sources in a subfolder, specifying it in the self.folders.source will
@@ -74,6 +75,7 @@ def test_exports():
     assert "FOO: 1" in client.out
 
 
+@pytest.mark.tool("cmake")
 def test_exports_source_without_subfolder():
     """If we have some sources in the root (like the CMakeLists.txt)
     we don't declare folders.source"""
@@ -102,6 +104,7 @@ def test_exports_source_without_subfolder():
     assert "Created package revision" in client.out
 
 
+@pytest.mark.tool("cmake")
 def test_scm_with_source_layout():
     """If we have the sources in git repository"""
     conan_file = GenConanfile() \
@@ -137,6 +140,7 @@ def test_scm_with_source_layout():
     assert "Created package revision" in client.out
 
 
+@pytest.mark.tool("cmake")
 @pytest.mark.parametrize("no_copy_source", ["False", "True"])
 def test_zip_download_with_subfolder_new_tools(no_copy_source):
     """If we have a zip with the sources in a subfolder, specifying it in the self.folders.source

--- a/conans/test/functional/py_requires/python_requires_test.py
+++ b/conans/test/functional/py_requires/python_requires_test.py
@@ -8,7 +8,7 @@ from conans.test.utils.tools import TestClient
 
 class PyRequiresExtendTest(unittest.TestCase):
 
-    @pytest.mark.tool_git
+    @pytest.mark.tool("git")
     def test_reuse_scm(self):
         client = TestClient()
         conanfile = textwrap.dedent("""
@@ -41,7 +41,7 @@ class PyRequiresExtendTest(unittest.TestCase):
         assert "pkg/0.1@user/testing: Type: git!!!!" in client.out
         assert "pkg/0.1@user/testing: Commit: True!!!!" in client.out
 
-    @pytest.mark.tool_git
+    @pytest.mark.tool("git")
     def test_reuse_customize_scm(self):
         client = TestClient()
         conanfile = textwrap.dedent("""
@@ -79,7 +79,7 @@ class PyRequiresExtendTest(unittest.TestCase):
         assert "pkg/0.1@user/testing: Type: git!!!!" in client.out
         assert "pkg/0.1@user/testing: Commit: True!!!!" in client.out
 
-    @pytest.mark.tool_git
+    @pytest.mark.tool("git")
     def test_reuse_scm_multiple_conandata(self):
         # https://github.com/conan-io/conan/issues/7236
         # This only works when using conandata.yml, conanfile.py replace is broken

--- a/conans/test/functional/revisions_test.py
+++ b/conans/test/functional/revisions_test.py
@@ -834,7 +834,7 @@ class SCMRevisions(unittest.TestCase):
                       "'{f}': Unable to get git commit from '{f}'".format(f=client.current_folder),
                       client.out)
 
-    @pytest.mark.tool_svn
+    @pytest.mark.tool("svn")
     def test_auto_revision_even_without_scm_svn(self):
         """Even without using the scm feature, the revision is detected from repo.
          Also while we continue working in local, the revision doesn't change, so the packages

--- a/conans/test/functional/scm/export/test_capture_export_scm_data.py
+++ b/conans/test/functional/scm/export/test_capture_export_scm_data.py
@@ -19,7 +19,7 @@ from conans.test.utils.tools import redirect_output
 from conans.util.files import save
 
 
-@pytest.mark.tool_git
+@pytest.mark.tool("git")
 @mock.patch("conans.client.cmd.export._replace_scm_data_in_recipe", return_value=None)
 class CaptureExportSCMDataTest(unittest.TestCase):
 

--- a/conans/test/functional/scm/issues/test_svn_tag.py
+++ b/conans/test/functional/scm/issues/test_svn_tag.py
@@ -8,7 +8,7 @@ from conans.test.utils.scm import SVNLocalRepoTestCase
 from conans.test.utils.tools import TestClient
 
 
-@pytest.mark.tool_svn
+@pytest.mark.tool("svn")
 class SVNTaggedComponentTest(SVNLocalRepoTestCase):
     # Reproducing https://github.com/conan-io/conan/issues/5017
 

--- a/conans/test/functional/scm/scm_test.py
+++ b/conans/test/functional/scm/scm_test.py
@@ -56,7 +56,7 @@ def _quoted(item):
     return '"{}"'.format(item)
 
 
-@pytest.mark.tool_git
+@pytest.mark.tool("git")
 class GitSCMTest(unittest.TestCase):
 
     def setUp(self):
@@ -596,7 +596,7 @@ class ConanLib(ConanFile):
         self.assertNotIn("Error retrieving git", str(git.version))
 
 
-@pytest.mark.tool_svn
+@pytest.mark.tool("svn")
 class SVNSCMTest(SVNLocalRepoTestCase):
 
     def setUp(self):
@@ -933,7 +933,7 @@ class ConanLib(ConanFile):
         self.assertIn("Bla? bla2 bla2", self.client.out)
 
 
-@pytest.mark.tool_svn
+@pytest.mark.tool("svn")
 class SCMSVNWithLockedFilesTest(SVNLocalRepoTestCase):
 
     def test_propset_own(self):
@@ -956,7 +956,7 @@ class SCMSVNWithLockedFilesTest(SVNLocalRepoTestCase):
         client.run("export . --user=user --channel=channel")
 
 
-@pytest.mark.tool_git
+@pytest.mark.tool("git")
 class SCMBlockUploadTest(unittest.TestCase):
 
     def test_upload_blocking_auto(self):
@@ -1033,7 +1033,7 @@ class SCMBlockUploadTest(unittest.TestCase):
 
 class SCMUpload(unittest.TestCase):
 
-    @pytest.mark.tool_git
+    @pytest.mark.tool("git")
     def test_scm_sources(self):
         """ Test conan_sources.tgz is deleted in server when removing 'exports_sources' and using
         'scm'"""

--- a/conans/test/functional/scm/source/test_run_scm.py
+++ b/conans/test/functional/scm/source/test_run_scm.py
@@ -16,7 +16,7 @@ from conans.test.utils.test_files import temp_folder
 from conans.test.utils.tools import redirect_output
 
 
-@pytest.mark.tool_git
+@pytest.mark.tool("git")
 class RunSCMTest(unittest.TestCase):
 
     def setUp(self):

--- a/conans/test/functional/scm/test_command_export.py
+++ b/conans/test/functional/scm/test_command_export.py
@@ -11,7 +11,7 @@ from conans.test.utils.scm import create_local_git_repo
 from conans.test.utils.tools import TestClient
 
 
-@pytest.mark.tool_svn
+@pytest.mark.tool("svn")
 class ExportErrorCommandTestCase(unittest.TestCase):
     conanfile = textwrap.dedent("""\
         from conan import ConanFile
@@ -38,7 +38,7 @@ class ExportErrorCommandTestCase(unittest.TestCase):
                       self.client.current_folder, repo_type.lower()), self.client.out)
 
 
-@pytest.mark.tool_git
+@pytest.mark.tool("git")
 class ExportCommandTestCase(unittest.TestCase):
     conanfile = textwrap.dedent("""\
         from conan import ConanFile

--- a/conans/test/functional/scm/test_git_shallow.py
+++ b/conans/test/functional/scm/test_git_shallow.py
@@ -25,7 +25,7 @@ def test_shallow_none_string():
     assert "ERROR: SCM value for 'shallow' must be of type 'bool' (found 'str')" in str(client.out)
 
 
-@pytest.mark.tool_git
+@pytest.mark.tool("git")
 @parameterized_class([{"shallow": True}, {"shallow": False},
                       {"shallow": None},  # No value written in the recipe
                       {"shallow": 'None'}])  # Explicit 'None' written in the recipe

--- a/conans/test/functional/scm/test_local_modified.py
+++ b/conans/test/functional/scm/test_local_modified.py
@@ -10,7 +10,7 @@ from conans.test.utils.tools import TestClient
 from conans.test.utils.scm import create_local_git_repo
 
 
-@pytest.mark.tool_git
+@pytest.mark.tool("git")
 class SCMFolderObsoleteTest(unittest.TestCase):
     conanfile = textwrap.dedent("""\
         from conan import ConanFile

--- a/conans/test/functional/scm/test_scm_to_conandata.py
+++ b/conans/test/functional/scm/test_scm_to_conandata.py
@@ -78,7 +78,7 @@ class SCMDataToConanDataTestCase(unittest.TestCase):
                                                            "revision": 123, "subfolder": "weir\"d",
                                                            "submodule": "don't"})
 
-    @pytest.mark.tool_git
+    @pytest.mark.tool("git")
     def test_auto_is_replaced(self):
         conanfile = textwrap.dedent("""
             import os
@@ -119,7 +119,7 @@ class SCMDataToConanDataTestCase(unittest.TestCase):
         self.assertIn("ERROR: Field '.conan' inside 'conandata.yml' file is"
                       " reserved to Conan usage.", t.out)
 
-    @pytest.mark.tool_git
+    @pytest.mark.tool("git")
     def test_empty_conandata(self):
         # https://github.com/conan-io/conan/issues/8209
         conanfile = textwrap.dedent("""
@@ -172,7 +172,7 @@ class ParseSCMFromConanDataTestCase(unittest.TestCase):
         self.assertDictEqual(conanfile.scm, conan_data['.conan']['scm'])
 
 
-@pytest.mark.tool_git
+@pytest.mark.tool("git")
 def test_auto_can_be_automated():
     # https://github.com/conan-io/conan/issues/8881
     conanfile = textwrap.dedent("""

--- a/conans/test/functional/scm/test_url_auto.py
+++ b/conans/test/functional/scm/test_url_auto.py
@@ -27,7 +27,7 @@ class RemoveCredentials(unittest.TestCase):
         self.client.current_folder = self.path
         self.client.run_command("git remote add origin https://url.to.be.sustituted")
 
-    @pytest.mark.tool_git
+    @pytest.mark.tool("git")
     def test_https(self):
         expected_url = 'https://myrepo.com.git'
         origin_url = 'https://username:password@myrepo.com.git'

--- a/conans/test/functional/scm/test_verify_ssl.py
+++ b/conans/test/functional/scm/test_verify_ssl.py
@@ -25,7 +25,7 @@ def test_verify_ssl_none_string():
            "'bool' (found 'str')" in str(client.out)
 
 
-@pytest.mark.tool_git
+@pytest.mark.tool("git")
 @parameterized_class([{"verify_ssl": True}, {"verify_ssl": False},
                       {"verify_ssl": None},  # No value written in the recipe
                       {"verify_ssl": 'None'}])  # Explicit 'None' written in the recipe

--- a/conans/test/functional/scm/tools/test_git.py
+++ b/conans/test/functional/scm/tools/test_git.py
@@ -17,7 +17,7 @@ from conans.util.env import environment_update
 from conans.util.files import save
 
 
-@pytest.mark.tool_git
+@pytest.mark.tool("git")
 class GitRemoteUrlTest(unittest.TestCase):
 
     def test_remove_credentials(self):
@@ -33,7 +33,7 @@ class GitRemoteUrlTest(unittest.TestCase):
         self.assertEqual(git.get_remote_url(remove_credentials=True), expected_url)
 
 
-@pytest.mark.tool_git
+@pytest.mark.tool("git")
 class GitToolTest(unittest.TestCase):
 
     @patch('subprocess.Popen')
@@ -367,7 +367,7 @@ class HelloConan(ConanFile):
         self.assertEqual("first commit", git.get_commit_message())
 
 
-@pytest.mark.tool_git
+@pytest.mark.tool("git")
 class GitToolsTests(unittest.TestCase):
 
     def setUp(self):

--- a/conans/test/functional/scm/tools/test_svn.py
+++ b/conans/test/functional/scm/tools/test_svn.py
@@ -35,7 +35,7 @@ class SVNRemoteUrlTest(unittest.TestCase):
 
 
 @pytest.mark.slow
-@pytest.mark.tool_svn
+@pytest.mark.tool("svn")
 class SVNToolTestsBasic(SVNLocalRepoTestCase):
 
     @patch('subprocess.Popen')
@@ -308,7 +308,7 @@ compiled Apr  5 2019, 18:59:58 on x86_64-apple-darwin17.0.0"""
 
 
 @pytest.mark.slow
-@pytest.mark.tool_svn
+@pytest.mark.tool("svn")
 class SVNToolTestsBasicOldVersion(SVNToolTestsBasic):
     def run(self, *args, **kwargs):
         try:
@@ -324,7 +324,7 @@ class SVNToolTestsBasicOldVersion(SVNToolTestsBasic):
 
 
 @pytest.mark.slow
-@pytest.mark.tool_svn
+@pytest.mark.tool("svn")
 class SVNToolTestsPristine(SVNLocalRepoTestCase):
 
     def setUp(self):
@@ -426,7 +426,7 @@ class SVNToolTestsPristine(SVNLocalRepoTestCase):
         self.assertFalse(svn.is_pristine())
 
 
-@pytest.mark.tool_svn
+@pytest.mark.tool("svn")
 class SVNToolTestsPristineWithExternalFile(SVNLocalRepoTestCase):
 
     def _propset_cmd(self, relpath, rev, url):
@@ -449,7 +449,7 @@ class SVNToolTestsPristineWithExternalFile(SVNLocalRepoTestCase):
         self.assertFalse(self.svn.is_pristine())
 
 
-@pytest.mark.tool_svn
+@pytest.mark.tool("svn")
 class SVNToolTestsPristineWithExternalsNotFixed(SVNLocalRepoTestCase):
 
     def _propset_cmd(self, relpath, url):
@@ -481,7 +481,7 @@ class SVNToolTestsPristineWithExternalsNotFixed(SVNLocalRepoTestCase):
         self.assertFalse(self.svn.is_pristine())
 
 
-@pytest.mark.tool_svn
+@pytest.mark.tool("svn")
 class SVNToolTestsPristineWithExternalsFixed(SVNLocalRepoTestCase):
 
     def _propset_cmd(self, relpath, rev, url):
@@ -548,7 +548,7 @@ class SVNToolTestsPristineWithExternalsFixed(SVNLocalRepoTestCase):
 
 
 @pytest.mark.slow
-@pytest.mark.tool_svn
+@pytest.mark.tool("svn")
 class SVNToolsTestsRecipe(SVNLocalRepoTestCase):
 
     conanfile = """

--- a/conans/test/functional/scm/workflows/test_conanfile_in_repo_root.py
+++ b/conans/test/functional/scm/workflows/test_conanfile_in_repo_root.py
@@ -17,7 +17,7 @@ class ConanfileInRepoRoot(TestWorkflow):
     path_from_conanfile_to_root = "."
 
 
-@pytest.mark.tool_svn
+@pytest.mark.tool("svn")
 class SVNConanfileInRepoRootTest(ConanfileInRepoRoot, SVNLocalRepoTestCase):
     """ Test SCM url='auto' with SVN, it can only work if conanfile is in the root of the repo
 
@@ -78,7 +78,7 @@ class SVNConanfileInRepoRootTest(ConanfileInRepoRoot, SVNLocalRepoTestCase):
         self.assertIn("Repo origin deduced by 'auto':", t.out)
 
 
-@pytest.mark.tool_git
+@pytest.mark.tool("git")
 class GitConanfileInRepoRootTest(ConanfileInRepoRoot, unittest.TestCase):
 
     conanfile = ConanfileInRepoRoot.conanfile_base.format(extra_header="",

--- a/conans/test/functional/scm/workflows/test_conanfile_in_subfolder.py
+++ b/conans/test/functional/scm/workflows/test_conanfile_in_subfolder.py
@@ -18,7 +18,7 @@ class ConanfileInSubfolder(TestWorkflow):
     path_from_conanfile_to_root = ".."
 
 
-@pytest.mark.tool_svn
+@pytest.mark.tool("svn")
 class SVNConanfileInSubfolderTest(ConanfileInSubfolder, SVNLocalRepoTestCase):
 
     extra_header = textwrap.dedent("""\
@@ -78,7 +78,7 @@ class SVNConanfileInSubfolderTest(ConanfileInSubfolder, SVNLocalRepoTestCase):
         self._run_remote_test(t, os.path.join(t.current_folder, "lib1"), self.path_to_conanfile)
 
 
-@pytest.mark.tool_git
+@pytest.mark.tool("git")
 class GitConanfileInSubfolderTest(ConanfileInSubfolder, unittest.TestCase):
 
     conanfile = ConanfileInSubfolder.conanfile_base.format(extra_header="",

--- a/conans/test/functional/scm/workflows/test_scm_subfolder.py
+++ b/conans/test/functional/scm/workflows/test_scm_subfolder.py
@@ -21,7 +21,7 @@ class SCMSubfolder(TestWorkflow):
     scm_subfolder = "scm_subfolder"
 
 
-@pytest.mark.tool_svn
+@pytest.mark.tool("svn")
 class SVNConanfileInRepoRootTest(SCMSubfolder, SVNLocalRepoTestCase):
     """ Test SCM url='auto' with SVN, it can only work if conanfile is in the root of the repo
 
@@ -93,7 +93,7 @@ class SVNConanfileInRepoRootTest(SCMSubfolder, SVNLocalRepoTestCase):
         self._run_remote_test(t, os.path.join(t.current_folder, "lib1"), self.path_to_conanfile)
 
 
-@pytest.mark.tool_git
+@pytest.mark.tool("git")
 class GitConanfileInRepoRootTest(SCMSubfolder, unittest.TestCase):
 
     conanfile = SCMSubfolder.conanfile_base.format(extra_header="",

--- a/conans/test/functional/settings/libcxx_setting_test.py
+++ b/conans/test/functional/settings/libcxx_setting_test.py
@@ -11,7 +11,7 @@ from conans.test.utils.tools import TestClient
 class LibcxxSettingTest(unittest.TestCase):
 
     @pytest.mark.skipif(platform.system() == "Windows", reason="Not in Windows")
-    @pytest.mark.tool_cmake
+    @pytest.mark.tool("cmake")
     def test_declared_stdlib_and_passed(self):
         file_content = textwrap.dedent('''
             from conan import ConanFile, CMake

--- a/conans/test/functional/subsystems_build_test.py
+++ b/conans/test/functional/subsystems_build_test.py
@@ -12,27 +12,27 @@ from conans.test.utils.tools import TestClient
 @pytest.mark.skipif(platform.system() != "Windows", reason="Tests Windows Subsystems")
 class TestSubsystems:
 
-    @pytest.mark.tool_msys2
+    @pytest.mark.tool("msys2")
     def test_msys2_available(self):
         client = TestClient()
         client.run_command('uname')
         assert "MSYS" in client.out
 
-    @pytest.mark.tool_cygwin
+    @pytest.mark.tool("cygwin")
     def test_cygwin_available(self):
         client = TestClient()
         client.run_command('uname')
         assert "CYGWIN" in client.out
 
-    @pytest.mark.tool_msys2
-    @pytest.mark.tool_mingw32
+    @pytest.mark.tool("msys2")
+    @pytest.mark.tool("mingw32")
     def test_mingw32_available(self):
         client = TestClient()
         client.run_command('uname')
         assert "MINGW32_NT" in client.out
 
-    @pytest.mark.tool_msys2
-    @pytest.mark.tool_mingw64
+    @pytest.mark.tool("msys2")
+    @pytest.mark.tool("mingw32")
     def test_mingw64_available(self):
         client = TestClient()
         client.run_command('uname')
@@ -56,7 +56,7 @@ class TestSubsystemsBuild:
         client.run_command("make")
         client.run_command("app")
 
-    @pytest.mark.tool_msys2
+    @pytest.mark.tool("msys2")
     def test_msys(self):
         """
         native MSYS environment, binaries depend on MSYS runtime (msys-2.0.dll)
@@ -72,8 +72,8 @@ class TestSubsystemsBuild:
         assert "__MINGW64__" not in client.out
         assert "__MSYS__" in client.out
 
-    @pytest.mark.tool_msys2
-    @pytest.mark.tool_mingw64
+    @pytest.mark.tool("msys2")
+    @pytest.mark.tool("mingw32")
     def test_mingw64(self):
         """
         64-bit GCC, binaries for generic Windows (no dependency on MSYS runtime)
@@ -88,8 +88,8 @@ class TestSubsystemsBuild:
         assert "__CYGWIN__" not in client.out
         assert "__MSYS__" not in client.out
 
-    @pytest.mark.tool_msys2
-    @pytest.mark.tool_mingw32
+    @pytest.mark.tool("msys2")
+    @pytest.mark.tool("mingw32")
     def test_mingw32(self):
         """
         32-bit GCC, binaries for generic Windows (no dependency on MSYS runtime)
@@ -104,7 +104,7 @@ class TestSubsystemsBuild:
         assert "__CYGWIN__" not in client.out
         assert "__MSYS__" not in client.out
 
-    @pytest.mark.tool_cygwin
+    @pytest.mark.tool("cygwin")
     def test_cygwin(self):
         """
         Cygwin environment, binaries depend on Cygwin runtime (cygwin1.dll)
@@ -148,7 +148,7 @@ class TestSubsystemsAutotoolsBuild:
         client.run_command("make")
         client.run_command("app")
 
-    @pytest.mark.tool_msys2
+    @pytest.mark.tool("msys2")
     def test_msys(self):
         """
         native MSYS environment, binaries depend on MSYS runtime (msys-2.0.dll)
@@ -164,8 +164,8 @@ class TestSubsystemsAutotoolsBuild:
         assert "__MINGW64__" not in client.out
         assert "__MSYS__" in client.out
 
-    @pytest.mark.tool_msys2
-    @pytest.mark.tool_mingw64
+    @pytest.mark.tool("msys2")
+    @pytest.mark.tool("mingw32")
     def test_mingw64(self):
         """
         64-bit GCC, binaries for generic Windows (no dependency on MSYS runtime)
@@ -180,8 +180,8 @@ class TestSubsystemsAutotoolsBuild:
         assert "__CYGWIN__" not in client.out
         assert "__MSYS__" not in client.out
 
-    @pytest.mark.tool_msys2
-    @pytest.mark.tool_mingw32
+    @pytest.mark.tool("msys2")
+    @pytest.mark.tool("mingw32")
     def test_mingw32(self):
         """
         32-bit GCC, binaries for generic Windows (no dependency on MSYS runtime)
@@ -196,7 +196,7 @@ class TestSubsystemsAutotoolsBuild:
         assert "__CYGWIN__" not in client.out
         assert "__MSYS__" not in client.out
 
-    @pytest.mark.tool_cygwin
+    @pytest.mark.tool("cygwin")
     def test_cygwin(self):
         """
         Cygwin environment, binaries depend on Cygwin runtime (cygwin1.dll)
@@ -233,7 +233,7 @@ class TestSubsystemsCMakeBuild:
         client.run_command("cmake --build .")
         client.run_command("app")
 
-    @pytest.mark.tool_msys2
+    @pytest.mark.tool("msys2")
     def test_msys(self):
         """
         native MSYS environment, binaries depend on MSYS runtime (msys-2.0.dll)
@@ -249,8 +249,8 @@ class TestSubsystemsCMakeBuild:
         assert "__MINGW64__" not in client.out
         assert "__MSYS__" in client.out
 
-    @pytest.mark.tool_msys2
-    @pytest.mark.tool_mingw64
+    @pytest.mark.tool("msys2")
+    @pytest.mark.tool("mingw32")
     def test_mingw64(self):
         """
         64-bit GCC, binaries for generic Windows (no dependency on MSYS runtime)
@@ -265,8 +265,8 @@ class TestSubsystemsCMakeBuild:
         assert "__CYGWIN__" not in client.out
         assert "__MSYS__" not in client.out
 
-    @pytest.mark.tool_msys2
-    @pytest.mark.tool_mingw32
+    @pytest.mark.tool("msys2")
+    @pytest.mark.tool("mingw32")
     def test_mingw32(self):
         """
         32-bit GCC, binaries for generic Windows (no dependency on MSYS runtime)
@@ -281,7 +281,7 @@ class TestSubsystemsCMakeBuild:
         assert "__CYGWIN__" not in client.out
         assert "__MSYS__" not in client.out
 
-    @pytest.mark.tool_cygwin
+    @pytest.mark.tool("cygwin")
     def test_cygwin(self):
         """
         Cygwin environment, binaries depend on Cygwin runtime (cygwin1.dll)

--- a/conans/test/functional/subsystems_build_test.py
+++ b/conans/test/functional/subsystems_build_test.py
@@ -32,7 +32,7 @@ class TestSubsystems:
         assert "MINGW32_NT" in client.out
 
     @pytest.mark.tool("msys2")
-    @pytest.mark.tool("mingw32")
+    @pytest.mark.tool("mingw64")
     def test_mingw64_available(self):
         client = TestClient()
         client.run_command('uname')
@@ -73,7 +73,7 @@ class TestSubsystemsBuild:
         assert "__MSYS__" in client.out
 
     @pytest.mark.tool("msys2")
-    @pytest.mark.tool("mingw32")
+    @pytest.mark.tool("mingw64")
     def test_mingw64(self):
         """
         64-bit GCC, binaries for generic Windows (no dependency on MSYS runtime)
@@ -165,7 +165,7 @@ class TestSubsystemsAutotoolsBuild:
         assert "__MSYS__" in client.out
 
     @pytest.mark.tool("msys2")
-    @pytest.mark.tool("mingw32")
+    @pytest.mark.tool("mingw64")
     def test_mingw64(self):
         """
         64-bit GCC, binaries for generic Windows (no dependency on MSYS runtime)
@@ -250,7 +250,7 @@ class TestSubsystemsCMakeBuild:
         assert "__MSYS__" in client.out
 
     @pytest.mark.tool("msys2")
-    @pytest.mark.tool("mingw32")
+    @pytest.mark.tool("mingw64")
     def test_mingw64(self):
         """
         64-bit GCC, binaries for generic Windows (no dependency on MSYS runtime)

--- a/conans/test/functional/toolchains/apple/test_xcodedeps_build_configs.py
+++ b/conans/test/functional/toolchains/apple/test_xcodedeps_build_configs.py
@@ -300,7 +300,7 @@ def create_xcode_project(client, project_name, source):
 
 
 @pytest.mark.skipif(platform.system() != "Darwin", reason="Only for MacOS")
-@pytest.mark.tool_cmake()
+@pytest.mark.tool("cmake")
 def test_xcodedeps_build_configurations():
     client = TestClient(path_with_spaces=False)
 
@@ -342,7 +342,7 @@ def test_xcodedeps_build_configurations():
 
 
 @pytest.mark.skipif(platform.system() != "Darwin", reason="Only for MacOS")
-@pytest.mark.tool_cmake()
+@pytest.mark.tool("cmake")
 def test_frameworks():
     client = TestClient(path_with_spaces=False)
 

--- a/conans/test/functional/toolchains/cmake/cmakedeps/test_apple_frameworks.py
+++ b/conans/test/functional/toolchains/cmake/cmakedeps/test_apple_frameworks.py
@@ -44,7 +44,7 @@ app_conanfile = textwrap.dedent("""
 
 
 @pytest.mark.skipif(platform.system() != "Darwin", reason="Only OSX")
-@pytest.mark.tool_cmake(version="3.19")
+@pytest.mark.tool("cmake", "3.19")
 def test_apple_framework_xcode(client):
     app_cmakelists = textwrap.dedent("""
         cmake_minimum_required(VERSION 3.15)
@@ -192,6 +192,7 @@ timer_cpp = textwrap.dedent("""
     """)
 
 
+@pytest.mark.tool("cmake")
 @pytest.mark.skipif(platform.system() != "Darwin", reason="Only OSX")
 @pytest.mark.parametrize("settings",
          [('',),
@@ -260,7 +261,7 @@ def test_apple_own_framework_cross_build(settings):
 
 @pytest.mark.xfail(reason="run_environment=True no longer works")
 @pytest.mark.skipif(platform.system() != "Darwin", reason="Only OSX")
-@pytest.mark.tool_cmake(version="3.19")
+@pytest.mark.tool("cmake", "3.19")
 def test_apple_own_framework_cmake_deps():
     client = TestClient()
 
@@ -335,6 +336,7 @@ def test_apple_own_framework_cmake_deps():
     assert "Hello World Debug!" in client.out
 
 
+@pytest.mark.tool("cmake")
 @pytest.mark.skipif(platform.system() != "Darwin", reason="Only OSX")
 def test_apple_own_framework_cmake_find_package_multi():
     client = TestClient()
@@ -380,7 +382,7 @@ def test_apple_own_framework_cmake_find_package_multi():
     assert "Hello World Release!" in client.out
 
 
-@pytest.mark.tool_cmake(version="3.19")
+@pytest.mark.tool("cmake", "3.19")
 @pytest.mark.skipif(platform.system() != "Darwin", reason="Only OSX")
 def test_component_uses_apple_framework():
     conanfile_py = textwrap.dedent("""
@@ -502,6 +504,7 @@ target_link_libraries(${PROJECT_NAME} hello::libhello)
     t.run("create . --name=hello --version=1.0")
 
 
+@pytest.mark.tool("cmake")
 @pytest.mark.skipif(platform.system() != "Darwin", reason="Only OSX")
 def test_m1():
     xcrun = XCRun(None, sdk='iphoneos')

--- a/conans/test/functional/toolchains/cmake/cmakedeps/test_build_context_protobuf.py
+++ b/conans/test/functional/toolchains/cmake/cmakedeps/test_build_context_protobuf.py
@@ -96,6 +96,7 @@ consumer_conanfile = textwrap.dedent("""
     """)
 
 
+@pytest.mark.tool("cmake")
 def test_build_modules_from_build_context(client):
     consumer_cmake = textwrap.dedent("""
         set(CMAKE_CXX_COMPILER_WORKS 1)
@@ -184,6 +185,7 @@ def test_build_modules_from_host_and_target_from_build_context(client):
     assert "Generated code in host context!" in client.out
 
 
+@pytest.mark.tool("cmake")
 def test_build_modules_and_target_from_host_context(client):
     consumer_cmake = textwrap.dedent("""
         set(CMAKE_CXX_COMPILER_WORKS 1)
@@ -228,6 +230,7 @@ def test_exception_when_not_prefix_specified(client):
            "CMakeDeps generator." in client.out
 
 
+@pytest.mark.tool("cmake")
 def test_not_activated_not_fail(client):
     consumer_cmake = textwrap.dedent("""
         set(CMAKE_CXX_COMPILER_WORKS 1)

--- a/conans/test/functional/toolchains/cmake/cmakedeps/test_build_context_transitive_build.py
+++ b/conans/test/functional/toolchains/cmake/cmakedeps/test_build_context_transitive_build.py
@@ -48,6 +48,7 @@ def client():
     return c
 
 
+@pytest.mark.tool("cmake")
 def test_zlib_not_included(client):
 
     main = gen_function_cpp(name="main", include="doxygen.h")

--- a/conans/test/functional/toolchains/cmake/cmakedeps/test_cmakedeps.py
+++ b/conans/test/functional/toolchains/cmake/cmakedeps/test_cmakedeps.py
@@ -36,7 +36,7 @@ def client():
     return c
 
 
-@pytest.mark.tool_cmake
+@pytest.mark.tool("cmake")
 def test_transitive_multi(client):
     # TODO: Make a full linking example, with correct header transitivity
 
@@ -94,7 +94,7 @@ def test_transitive_multi(client):
                 assert "MYVARlibb: {}".format(bt) in client.out
 
 
-@pytest.mark.tool_cmake
+@pytest.mark.tool("cmake")
 def test_system_libs():
     conanfile = textwrap.dedent("""
         from conan import ConanFile
@@ -161,7 +161,7 @@ def test_system_libs():
         assert "Target libs: %s" % target_libs in client.out
 
 
-@pytest.mark.tool_cmake
+@pytest.mark.tool("cmake")
 def test_do_not_mix_cflags_cxxflags():
     # TODO: Verify with components too
     client = TestClient()
@@ -241,6 +241,7 @@ def test_custom_configuration(client):
            open(os.path.join(curdir, data_name_context_host)).read()
 
 
+@pytest.mark.tool("cmake")
 def test_buildirs_working():
     """  If a recipe declares cppinfo.buildirs those dirs will be exposed to be consumer
     to allow a cmake "include" function call after a find_package"""
@@ -274,7 +275,7 @@ def test_buildirs_working():
     assert "MYVAR=>Like a Rolling Stone" in c.out
 
 
-@pytest.mark.tool_cmake
+@pytest.mark.tool("cmake")
 def test_cpp_info_link_objects():
     client = TestClient()
     obj_ext = "obj" if platform.system() == "Windows" else "o"

--- a/conans/test/functional/toolchains/cmake/cmakedeps/test_cmakedeps_aliases.py
+++ b/conans/test/functional/toolchains/cmake/cmakedeps/test_cmakedeps_aliases.py
@@ -22,7 +22,7 @@ class Consumer(ConanFile):
 """)
 
 
-@pytest.mark.tool_cmake
+@pytest.mark.tool("cmake")
 def test_global_alias():
     conanfile = textwrap.dedent("""
     from conan import ConanFile
@@ -55,7 +55,7 @@ def test_global_alias():
     assert "hello link libraries: hello::hello" in client.out
 
 
-@pytest.mark.tool_cmake
+@pytest.mark.tool("cmake")
 def test_component_alias():
     conanfile = textwrap.dedent("""
     from conan import ConanFile
@@ -88,7 +88,7 @@ def test_component_alias():
     assert "hola::adios link libraries: hello::buy" in client.out
 
 
-@pytest.mark.tool_cmake
+@pytest.mark.tool("cmake")
 def test_custom_name():
     conanfile = textwrap.dedent("""
     from conan import ConanFile
@@ -121,7 +121,7 @@ def test_custom_name():
     assert "hello link libraries: ola::comprar" in client.out
 
 
-@pytest.mark.tool_cmake
+@pytest.mark.tool("cmake")
 def test_collide_global_alias():
     conanfile = textwrap.dedent("""
     from conan import ConanFile
@@ -151,7 +151,7 @@ def test_collide_global_alias():
     assert "Target name 'hello::hello' already exists." in client.out
 
 
-@pytest.mark.tool_cmake
+@pytest.mark.tool("cmake")
 def test_collide_component_alias():
     conanfile = textwrap.dedent("""
     from conan import ConanFile

--- a/conans/test/functional/toolchains/cmake/cmakedeps/test_cmakedeps_and_linker_flags.py
+++ b/conans/test/functional/toolchains/cmake/cmakedeps/test_cmakedeps_and_linker_flags.py
@@ -8,7 +8,7 @@ from conans.test.utils.tools import TestClient
 
 
 @pytest.mark.skipif(platform.system() != "Linux", reason="Only Linux")
-@pytest.mark.tool_cmake
+@pytest.mark.tool("cmake")
 def test_shared_link_flags():
     """
     Testing CMakeDeps and linker flags injection

--- a/conans/test/functional/toolchains/cmake/cmakedeps/test_cmakedeps_build_modules.py
+++ b/conans/test/functional/toolchains/cmake/cmakedeps/test_cmakedeps_build_modules.py
@@ -5,7 +5,7 @@ import pytest
 from conans.test.utils.tools import TestClient
 
 
-@pytest.mark.tool_cmake
+@pytest.mark.tool("cmake")
 @pytest.mark.parametrize("use_components", [False, True])
 def test_build_modules_alias_target(use_components):
     client = TestClient()
@@ -73,7 +73,7 @@ def test_build_modules_alias_target(use_components):
         assert "otherhello link libraries: hello::hello" in client.out
 
 
-@pytest.mark.tool_cmake
+@pytest.mark.tool("cmake")
 def test_build_modules_components_selection_is_not_possible():
     """
     If openssl declares different cmake_build_modules on ssl and crypto, in the consumer both
@@ -164,7 +164,7 @@ def test_build_modules_components_selection_is_not_possible():
     assert "ROOT MESSAGE:hello!" in client.out
 
 
-@pytest.mark.tool_cmake
+@pytest.mark.tool("cmake")
 def test_build_modules_components_selection_is_not_possible2():
     """
     If openssl declares different cmake_build_modules on ssl and crypto, in the consumer both

--- a/conans/test/functional/toolchains/cmake/cmakedeps/test_cmakedeps_components.py
+++ b/conans/test/functional/toolchains/cmake/cmakedeps/test_cmakedeps_components.py
@@ -161,7 +161,7 @@ def test_wrong_requirement(top_conanfile):
            "components requires but not defined as a recipe requirement" in t.out
 
 
-@pytest.mark.tool_cmake
+@pytest.mark.tool("cmake")
 def test_components_system_libs():
     conanfile = textwrap.dedent("""
         from conan import ConanFile
@@ -218,7 +218,7 @@ def test_components_system_libs():
     #       <CONFIG:Debug>
 
 
-@pytest.mark.tool_cmake
+@pytest.mark.tool("cmake")
 def test_components_exelinkflags():
     conanfile = textwrap.dedent("""
         from conan import ConanFile
@@ -272,7 +272,7 @@ def test_components_exelinkflags():
     #       <CONFIG:Debug>
 
 
-@pytest.mark.tool_cmake
+@pytest.mark.tool("cmake")
 def test_components_sharedlinkflags():
     conanfile = textwrap.dedent("""
         from conan import ConanFile

--- a/conans/test/functional/toolchains/cmake/cmakedeps/test_cmakedeps_components_names.py
+++ b/conans/test/functional/toolchains/cmake/cmakedeps/test_cmakedeps_components_names.py
@@ -12,7 +12,7 @@ from conans.test.utils.tools import TestClient
 
 
 @pytest.mark.slow
-@pytest.mark.tool_cmake
+@pytest.mark.tool("cmake")
 @pytest.fixture(scope="module")
 def setup_client_with_greetings():
     """
@@ -236,6 +236,7 @@ def create_chat(client, components, package_info, cmake_find, test_cmake_find):
     assert "bye: Debug!" in client.out
 
 
+@pytest.mark.tool("cmake")
 def test_standard_names(setup_client_with_greetings):
     client = setup_client_with_greetings
 
@@ -292,6 +293,7 @@ def test_standard_names(setup_client_with_greetings):
             assert "bye: Release!" in client.out
 
 
+@pytest.mark.tool("cmake")
 def test_custom_names(setup_client_with_greetings):
     client = setup_client_with_greetings
 
@@ -338,6 +340,7 @@ def test_custom_names(setup_client_with_greetings):
     create_chat(client, "custom", package_info, cmake_find, test_cmake_find)
 
 
+@pytest.mark.tool("cmake")
 def test_different_namespace(setup_client_with_greetings):
     client = setup_client_with_greetings
 
@@ -382,6 +385,7 @@ def test_different_namespace(setup_client_with_greetings):
     create_chat(client, "custom", package_info, cmake_find, test_cmake_find)
 
 
+@pytest.mark.tool("cmake")
 def test_no_components(setup_client_with_greetings):
     client = setup_client_with_greetings
 
@@ -420,7 +424,7 @@ def test_no_components(setup_client_with_greetings):
 
 
 @pytest.mark.slow
-@pytest.mark.tool_cmake
+@pytest.mark.tool("cmake")
 def test_same_names():
     client = TestClient()
     conanfile_greetings = textwrap.dedent("""
@@ -506,7 +510,7 @@ def test_same_names():
     assert "hello: Release!" in client.out
 
 
-@pytest.mark.tool_cmake
+@pytest.mark.tool("cmake")
 class TestComponentsCMakeGenerators:
 
     def test_component_not_found(self):
@@ -742,6 +746,7 @@ class TestComponentsCMakeGenerators:
         assert 'variant/1.0: Hello World Release!' in client.out
 
 
+@pytest.mark.tool("cmake")
 @pytest.mark.parametrize("check_components_exist", [False, True, None])
 def test_targets_declared_in_build_modules(check_components_exist):
     """If a require is declaring the component targets in a build_module, CMakeDeps is
@@ -832,7 +837,7 @@ def test_targets_declared_in_build_modules(check_components_exist):
                                             in client.out)
 
 
-@pytest.mark.tool_cmake
+@pytest.mark.tool("cmake")
 def test_cmakedeps_targets_no_namespace():
     """
     This test is checking that when we add targets with no namespace for the root cpp_info

--- a/conans/test/functional/toolchains/cmake/cmakedeps/test_cmakedeps_custom_configs.py
+++ b/conans/test/functional/toolchains/cmake/cmakedeps/test_cmakedeps_custom_configs.py
@@ -13,7 +13,7 @@ from conans.test.utils.tools import TestClient
 from conans.util.files import save
 
 
-@pytest.mark.tool_cmake
+@pytest.mark.tool("cmake")
 @pytest.mark.skipif(platform.system() != "Windows", reason="Only for windows")
 class CustomConfigurationTest(unittest.TestCase):
     conanfile = textwrap.dedent("""
@@ -99,7 +99,7 @@ class CustomConfigurationTest(unittest.TestCase):
             self.assertIn("main: Release!", self.client.out)
 
 
-@pytest.mark.tool_cmake
+@pytest.mark.tool("cmake")
 @pytest.mark.skipif(platform.system() != "Windows", reason="Only for windows")
 class CustomSettingsTest(unittest.TestCase):
     conanfile = textwrap.dedent("""
@@ -190,7 +190,7 @@ class CustomSettingsTest(unittest.TestCase):
             self.assertIn("main: Release!", self.client.out)
 
 
-@pytest.mark.tool_cmake
+@pytest.mark.tool("cmake")
 def test_changing_build_type():
     client = TestClient(path_with_spaces=False)
     dep_conanfile = textwrap.dedent(r"""

--- a/conans/test/functional/toolchains/cmake/cmakedeps/test_cmakedeps_find_module_and_config.py
+++ b/conans/test/functional/toolchains/cmake/cmakedeps/test_cmakedeps_find_module_and_config.py
@@ -67,7 +67,7 @@ def client():
     return t
 
 
-@pytest.mark.tool_cmake
+@pytest.mark.tool("cmake")
 def test_reuse_with_modules_and_config(client):
     cpp = gen_function_cpp(name="main")
 
@@ -115,6 +115,7 @@ def test_reuse_with_modules_and_config(client):
     client.run("build . -if=install")
 
 
+@pytest.mark.tool("cmake")
 @pytest.mark.parametrize("find_mode", ["both", "config", "module"])
 def test_transitive_modules_found(find_mode):
     """

--- a/conans/test/functional/toolchains/cmake/cmakedeps/test_cmakedeps_transitivity.py
+++ b/conans/test/functional/toolchains/cmake/cmakedeps/test_cmakedeps_transitivity.py
@@ -11,7 +11,7 @@ from conans.test.utils.tools import TestClient
 
 
 @pytest.mark.skipif(platform.system() != "Windows", reason="Requires MSBuild")
-@pytest.mark.tool_cmake
+@pytest.mark.tool("cmake")
 def test_transitive_headers_not_public():
     c = TestClient()
 
@@ -56,7 +56,7 @@ def test_transitive_headers_not_public():
 
 
 @pytest.mark.skipif(platform.system() != "Windows", reason="Requires MSBuild")
-@pytest.mark.tool_cmake
+@pytest.mark.tool("cmake")
 def test_shared_requires_static():
     c = TestClient()
 
@@ -96,7 +96,7 @@ def test_shared_requires_static():
 
 
 @pytest.mark.skipif(platform.system() != "Windows", reason="Requires MSBuild")
-@pytest.mark.tool_cmake
+@pytest.mark.tool("cmake")
 def test_transitive_binary_skipped():
     c = TestClient()
 

--- a/conans/test/functional/toolchains/cmake/cmakedeps/test_cmakedeps_versions.py
+++ b/conans/test/functional/toolchains/cmake/cmakedeps/test_cmakedeps_versions.py
@@ -34,6 +34,7 @@ def hello_client():
     ("hello", "0.1", "REQUIRED", True, False),
     ("hello", "2.0", "REQUIRED", True, False)
 ])
+@pytest.mark.tool("cmake")
 def test_version(hello_client, name, version, params, cmake_fails, package_found):
     client = hello_client
     cmakelists = textwrap.dedent("""
@@ -68,6 +69,7 @@ def test_version(hello_client, name, version, params, cmake_fails, package_found
         assert "hello found: 0" in client.out
 
 
+@pytest.mark.tool("cmake")
 def test_no_version_file(hello_client):
     client = hello_client
 

--- a/conans/test/functional/toolchains/cmake/cmakedeps/test_link_order.py
+++ b/conans/test/functional/toolchains/cmake/cmakedeps/test_link_order.py
@@ -314,7 +314,7 @@ def _run_and_get_lib_order(t, generator):
 
 
 @pytest.mark.parametrize("generator", [None, "Xcode"])
-@pytest.mark.tool_cmake(version="3.19")
+@pytest.mark.tool("cmake", "3.19")
 def test_cmake_deps(client, generator):
     if generator == "Xcode" and platform.system() != "Darwin":
         pytest.skip("Xcode is needed")

--- a/conans/test/functional/toolchains/cmake/cmakedeps/test_weird_library_names.py
+++ b/conans/test/functional/toolchains/cmake/cmakedeps/test_weird_library_names.py
@@ -55,7 +55,7 @@ def client_weird_lib_name():
     return c
 
 
-@pytest.mark.tool_cmake
+@pytest.mark.tool("cmake")
 def test_cmakedeps(client_weird_lib_name):
     c = client_weird_lib_name
     c.save(pkg_cmake("chat", "0.1", requires=["hello/0.1"]), clean_first=True)

--- a/conans/test/functional/toolchains/cmake/test_cmake.py
+++ b/conans/test/functional/toolchains/cmake/test_cmake.py
@@ -273,7 +273,7 @@ class WinTest(Base):
 
     @parameterized.expand([("Debug", "libstdc++", "4.9", "98", "x86_64", True),
                            ("Release", "libstdc++", "4.9", "11", "x86_64", False)])
-    @pytest.mark.tool("mingw32")
+    @pytest.mark.tool("mingw64")
     @pytest.mark.tool("cmake", "3.15")
     def test_toolchain_mingw_win(self, build_type, libcxx, version, cppstd, arch, shared):
         # FIXME: The version and cppstd are wrong, toolchain doesn't enforce it

--- a/conans/test/functional/toolchains/cmake/test_cmake.py
+++ b/conans/test/functional/toolchains/cmake/test_cmake.py
@@ -15,7 +15,7 @@ from conans.test.utils.tools import TestClient
 from conans.util.files import save
 
 
-@pytest.mark.tool_cmake
+@pytest.mark.tool("cmake")
 class Base(unittest.TestCase):
 
     conanfile = textwrap.dedent("""
@@ -273,8 +273,8 @@ class WinTest(Base):
 
     @parameterized.expand([("Debug", "libstdc++", "4.9", "98", "x86_64", True),
                            ("Release", "libstdc++", "4.9", "11", "x86_64", False)])
-    @pytest.mark.tool_mingw64
-    @pytest.mark.tool_cmake(version="3.15")
+    @pytest.mark.tool("mingw32")
+    @pytest.mark.tool("cmake", "3.15")
     def test_toolchain_mingw_win(self, build_type, libcxx, version, cppstd, arch, shared):
         # FIXME: The version and cppstd are wrong, toolchain doesn't enforce it
         settings = {"compiler": "gcc",
@@ -488,7 +488,7 @@ def test_msvc_vs_versiontoolset(version, vs_version):
     check_exe_run(client.out, "main", "msvc", version, "Release", "x86_64", "14")
 
 
-@pytest.mark.tool_cmake
+@pytest.mark.tool("cmake")
 class CMakeInstallTest(unittest.TestCase):
 
     def test_install(self):
@@ -543,7 +543,7 @@ class CMakeInstallTest(unittest.TestCase):
         self.assertTrue(os.path.exists(os.path.join(package_folder, "include", "header.h")))
 
 
-@pytest.mark.tool_cmake
+@pytest.mark.tool("cmake")
 class CMakeOverrideCacheTest(unittest.TestCase):
 
     def test_cmake_cache_variables(self):
@@ -576,7 +576,7 @@ class CMakeOverrideCacheTest(unittest.TestCase):
         self.assertIn("VALUE OF CONFIG STRING: my new value", client.out)
 
 
-@pytest.mark.tool_cmake
+@pytest.mark.tool("cmake")
 class TestCMakeFindPackagePreferConfig:
 
     def test_prefer_config(self):

--- a/conans/test/functional/toolchains/cmake/test_cmake_and_no_soname_flag.py
+++ b/conans/test/functional/toolchains/cmake/test_cmake_and_no_soname_flag.py
@@ -8,7 +8,7 @@ from conans.test.utils.tools import TestClient
 
 
 @pytest.mark.skipif(platform.system() != "Linux", reason="Only Linux")
-@pytest.mark.tool_cmake
+@pytest.mark.tool("cmake")
 def test_no_soname_flag():
     """ This test case is testing this graph structure:
             *   'LibNoSoname' -> 'OtherLib' -> 'Executable'

--- a/conans/test/functional/toolchains/cmake/test_cmake_toolchain.py
+++ b/conans/test/functional/toolchains/cmake/test_cmake_toolchain.py
@@ -67,6 +67,7 @@ def test_cmake_toolchain_custom_toolchain():
     assert "mytoolchain.cmake" == build_content["cmake_toolchain_file"]
 
 
+@pytest.mark.tool("cmake")
 def test_cmake_toolchain_user_toolchain_from_dep():
     client = TestClient()
     conanfile = textwrap.dedent("""
@@ -117,6 +118,7 @@ def test_cmake_toolchain_without_build_type():
     assert "CMAKE_BUILD_TYPE" not in toolchain
 
 
+@pytest.mark.tool("cmake")
 def test_cmake_toolchain_multiple_user_toolchain():
     """ A consumer consuming two packages that declare:
             self.conf_info["tools.cmake.cmaketoolchain:user_toolchain"]
@@ -179,7 +181,7 @@ def test_cmake_toolchain_multiple_user_toolchain():
     assert "mytoolchain2.cmake !!!running!!!" in client.out
 
 
-@pytest.mark.tool_cmake
+@pytest.mark.tool("cmake")
 def test_cmaketoolchain_no_warnings():
     """Make sure unitialized variables do not cause any warnings, passing -Werror=dev
     and --wanr-unitialized, calling "cmake" with conan_toolchain.cmake used to fail

--- a/conans/test/functional/toolchains/cmake/test_cmake_toolchain_m1.py
+++ b/conans/test/functional/toolchains/cmake/test_cmake_toolchain_m1.py
@@ -11,6 +11,7 @@ from conans.test.utils.tools import TestClient
 
 @pytest.mark.skipif(platform.system() != "Darwin", reason="Only OSX")
 @pytest.mark.parametrize("op_system", ["Macos", "iOS"])
+@pytest.mark.tool("cmake")
 def test_m1(op_system):
     os_version = "os.version=12.0" if op_system == "iOS" else ""
     os_sdk = "" if op_system == "Macos" else "os.sdk=iphoneos"

--- a/conans/test/functional/toolchains/cmake/test_cmake_toolchain_vxworks_clang.py
+++ b/conans/test/functional/toolchains/cmake/test_cmake_toolchain_vxworks_clang.py
@@ -120,8 +120,8 @@ def client():
     return c
 
 
-@pytest.mark.tool_cmake
-@pytest.mark.tool_clang(version="12")
+@pytest.mark.tool("cmake")
+@pytest.mark.tool("clang", "12")
 def test_clang_cmake_ninja(client):
     client.run("create . pkg/0.1@ -pr=clang -c tools.cmake.cmaketoolchain:generator=Ninja -c tools.cmake.cmaketoolchain:toolchain_file=../../toolchain-vxworks.cmake")
     assert 'cmake -G "Ninja"' in client.out

--- a/conans/test/functional/toolchains/cmake/test_cmake_toolchain_win_clang.py
+++ b/conans/test/functional/toolchains/cmake/test_cmake_toolchain_win_clang.py
@@ -48,7 +48,7 @@ def client():
 
 
 @pytest.mark.tool("cmake")
-@pytest.mark.tool("mingw32")
+@pytest.mark.tool("mingw64")
 @pytest.mark.tool("clang", "12")
 @pytest.mark.skipif(platform.system() != "Windows", reason="requires Win")
 def test_clang(client):

--- a/conans/test/functional/toolchains/cmake/test_cmake_toolchain_win_clang.py
+++ b/conans/test/functional/toolchains/cmake/test_cmake_toolchain_win_clang.py
@@ -47,9 +47,9 @@ def client():
     return c
 
 
-@pytest.mark.tool_cmake
-@pytest.mark.tool_mingw64
-@pytest.mark.tool_clang(version="12")
+@pytest.mark.tool("cmake")
+@pytest.mark.tool("mingw32")
+@pytest.mark.tool("clang", "12")
 @pytest.mark.skipif(platform.system() != "Windows", reason="requires Win")
 def test_clang(client):
     client.run("create . --name=pkg --version=0.1 -pr=clang")
@@ -61,8 +61,8 @@ def test_clang(client):
     assert "main _MSVC_LANG2014" in client.out
 
 
-@pytest.mark.tool_cmake
-@pytest.mark.tool_clang(version="12")
+@pytest.mark.tool("cmake")
+@pytest.mark.tool("clang", "12")
 @pytest.mark.skipif(platform.system() != "Windows", reason="requires Win")
 def test_clang_cmake_ninja(client):
     client.run("create . --name=pkg --version=0.1 -pr=clang -c tools.cmake.cmaketoolchain:generator=Ninja")
@@ -73,8 +73,8 @@ def test_clang_cmake_ninja(client):
     assert "main _MSVC_LANG2014" in client.out
 
 
-@pytest.mark.tool_cmake
-@pytest.mark.tool_clang(version="12")
+@pytest.mark.tool("cmake")
+@pytest.mark.tool("clang", "12")
 @pytest.mark.skipif(platform.system() != "Windows", reason="requires Win")
 def test_clang_cmake_ninja_custom_cxx(client):
     with environment_update({"CXX": "/no/exist/clang++"}):
@@ -100,8 +100,8 @@ def test_clang_cmake_ninja_custom_cxx(client):
     assert '/no/exist/clang++' in client.out
 
 
-@pytest.mark.tool_cmake
-@pytest.mark.tool_visual_studio(version="16")  # With Clang distributed in VS!
+@pytest.mark.tool("cmake")
+@pytest.mark.tool("visual_studio", "16")  # With Clang distributed in VS!
 @pytest.mark.skipif(platform.system() != "Windows", reason="requires Win")
 def test_clang_cmake_visual(client):
     clang_profile = textwrap.dedent("""

--- a/conans/test/functional/toolchains/cmake/test_cmaketoolchain_paths.py
+++ b/conans/test/functional/toolchains/cmake/test_cmaketoolchain_paths.py
@@ -43,7 +43,7 @@ def _cmake_command_toolchain(find_root_path_modes):
     return cmake_command
 
 
-@pytest.mark.tool_cmake
+@pytest.mark.tool("cmake")
 @pytest.mark.parametrize("package", ["hello", "zlib"])
 @pytest.mark.parametrize("find_package", ["module", "config"])
 @pytest.mark.parametrize(
@@ -109,7 +109,7 @@ def test_cmaketoolchain_path_find_package(package, find_package, settings, find_
     assert "HELLO FROM THE {package} FIND PACKAGE!".format(package=package) not in client.out
 
 
-@pytest.mark.tool_cmake
+@pytest.mark.tool("cmake")
 @pytest.mark.parametrize(
     "settings",
     [
@@ -192,7 +192,7 @@ def test_cmaketoolchain_path_find_package_real_config(settings, find_root_path_m
     assert "Conan: Target declared 'hello::hello'" in client.out
 
 
-@pytest.mark.tool_cmake
+@pytest.mark.tool("cmake")
 @pytest.mark.parametrize("require_type", ["requires", "tool_requires"])
 @pytest.mark.parametrize(
     "settings",
@@ -248,7 +248,7 @@ def test_cmaketoolchain_path_include_cmake_modules(require_type, settings, find_
     assert "MYOWNCMAKE FROM hello!" in client.out
 
 
-@pytest.mark.tool_cmake
+@pytest.mark.tool("cmake")
 @pytest.mark.parametrize(
     "settings",
     [
@@ -301,7 +301,7 @@ def test_cmaketoolchain_path_find_file_find_path(settings, find_root_path_modes)
     assert "Found path of hello.h" in client.out
 
 
-@pytest.mark.tool_cmake
+@pytest.mark.tool("cmake")
 @pytest.mark.parametrize(
     "settings",
     [
@@ -365,7 +365,7 @@ def test_cmaketoolchain_path_find_library(settings, find_root_path_modes):
     assert build_folder_hash not in client.out
 
 
-@pytest.mark.tool_cmake
+@pytest.mark.tool("cmake")
 @pytest.mark.parametrize(
     "settings",
     [

--- a/conans/test/functional/toolchains/cmake/test_file_api.py
+++ b/conans/test/functional/toolchains/cmake/test_file_api.py
@@ -9,7 +9,7 @@ from conans.test.utils.tools import TestClient
 
 
 @pytest.mark.xfail(reason="NewCppInfo: xfail until it adds default folders for the components")
-@pytest.mark.tool_cmake
+@pytest.mark.tool("cmake")
 def test_file_api():
     """
     simple library providing 3 targets:

--- a/conans/test/functional/toolchains/cmake/test_ninja.py
+++ b/conans/test/functional/toolchains/cmake/test_ninja.py
@@ -56,7 +56,7 @@ def client():
 
 @pytest.mark.skipif(platform.system() != "Linux", reason="Only Linux")
 @pytest.mark.parametrize("build_type,shared", [("Release", False), ("Debug", True)])
-@pytest.mark.tool_ninja
+@pytest.mark.tool("ninja")
 def test_locally_build_linux(build_type, shared, client):
     settings = "-s os=Linux -s arch=x86_64 -s build_type={} -o hello:shared={}".format(build_type,
                                                                                        shared)
@@ -85,7 +85,7 @@ def test_locally_build_linux(build_type, shared, client):
 
 @pytest.mark.skipif(platform.system() != "Windows", reason="Only windows")
 @pytest.mark.parametrize("build_type,shared", [("Release", False), ("Debug", True)])
-@pytest.mark.tool_ninja
+@pytest.mark.tool("ninja")
 def test_locally_build_msvc(build_type, shared, client):
     msvc_version = "15"
     settings = "-s build_type={} -o hello:shared={}".format(build_type, shared)
@@ -116,7 +116,7 @@ def test_locally_build_msvc(build_type, shared, client):
 
 
 @pytest.mark.skipif(platform.system() != "Windows", reason="Only windows")
-@pytest.mark.tool_ninja
+@pytest.mark.tool("ninja")
 def test_locally_build_msvc_toolset(client):
     msvc_version = "15"
     profile = textwrap.dedent("""
@@ -151,8 +151,8 @@ def test_locally_build_msvc_toolset(client):
 
 @pytest.mark.skipif(platform.system() != "Windows", reason="Only windows")
 @pytest.mark.parametrize("build_type,shared", [("Release", False), ("Debug", True)])
-@pytest.mark.tool_mingw64
-@pytest.mark.tool_ninja
+@pytest.mark.tool("mingw32")
+@pytest.mark.tool("ninja")
 def test_locally_build_gcc(build_type, shared, client):
     # FIXME: Note the gcc version is still incorrect
     gcc = ("-s os=Windows -s compiler=gcc -s compiler.version=4.9 -s compiler.libcxx=libstdc++ "
@@ -175,7 +175,7 @@ def test_locally_build_gcc(build_type, shared, client):
 
 @pytest.mark.skipif(platform.system() != "Darwin", reason="Requires apple-clang")
 @pytest.mark.parametrize("build_type,shared", [("Release", False), ("Debug", True)])
-@pytest.mark.tool_ninja
+@pytest.mark.tool("ninja")
 def test_locally_build_macos(build_type, shared, client):
     client.run('install . -s os=Macos -s arch=x86_64 -s build_type={} -o hello:shared={}'
                .format(build_type, shared))
@@ -195,7 +195,7 @@ def test_locally_build_macos(build_type, shared, client):
 
 
 @pytest.mark.skipif(platform.system() != "Windows", reason="Only windows")
-@pytest.mark.tool_visual_studio
+@pytest.mark.tool("visual_studio")
 def test_ninja_conf():
     conanfile = GenConanfile().with_generator("CMakeToolchain").with_settings("os", "compiler",
                                                                               "build_type", "arch")

--- a/conans/test/functional/toolchains/cmake/test_ninja.py
+++ b/conans/test/functional/toolchains/cmake/test_ninja.py
@@ -151,7 +151,7 @@ def test_locally_build_msvc_toolset(client):
 
 @pytest.mark.skipif(platform.system() != "Windows", reason="Only windows")
 @pytest.mark.parametrize("build_type,shared", [("Release", False), ("Debug", True)])
-@pytest.mark.tool("mingw32")
+@pytest.mark.tool("mingw64")
 @pytest.mark.tool("ninja")
 def test_locally_build_gcc(build_type, shared, client):
     # FIXME: Note the gcc version is still incorrect

--- a/conans/test/functional/toolchains/cmake/test_shared_cmake.py
+++ b/conans/test/functional/toolchains/cmake/test_shared_cmake.py
@@ -1,9 +1,12 @@
+import pytest
+
 from conan.tools.env.environment import environment_wrap_command
 from conans.test.assets.pkg_cmake import pkg_cmake, pkg_cmake_app, pkg_cmake_test
 from conans.test.utils.mocks import ConanFileMock
 from conans.test.utils.tools import TestClient
 
 
+@pytest.mark.tool("cmake")
 def test_shared_cmake_toolchain():
     client = TestClient(default_server_user=True)
 
@@ -28,6 +31,7 @@ def test_shared_cmake_toolchain():
     assert "hello: Release!" in client.out
 
 
+@pytest.mark.tool("cmake")
 def test_shared_cmake_toolchain_test_package():
     client = TestClient()
     files = pkg_cmake("hello", "0.1")

--- a/conans/test/functional/toolchains/cmake/test_v2_cmake_template.py
+++ b/conans/test/functional/toolchains/cmake/test_v2_cmake_template.py
@@ -1,11 +1,14 @@
 import os
 import re
 
+import pytest
+
 from conans.model.package_ref import PkgReference
 from conans.model.recipe_ref import RecipeReference
 from conans.test.utils.tools import TestClient
 
 
+@pytest.mark.tool("cmake")
 def test_cmake_lib_template():
     client = TestClient(path_with_spaces=False)
     client.run("new cmake_lib -d name=hello -d version=0.1")
@@ -34,6 +37,7 @@ def test_cmake_lib_template():
     assert "hello/0.1: Hello World Release!" in client.out
 
 
+@pytest.mark.tool("cmake")
 def test_cmake_exe_template():
     client = TestClient(path_with_spaces=False)
     client.run("new cmake_exe -d name=greet -d version=0.1")

--- a/conans/test/functional/toolchains/env/test_complete.py
+++ b/conans/test/functional/toolchains/env/test_complete.py
@@ -1,9 +1,12 @@
 import textwrap
 
+import pytest
+
 from conans.test.assets.sources import gen_function_cpp
 from conans.test.utils.tools import TestClient
 
 
+@pytest.mark.tool("cmake")
 def test_cmake_virtualenv():
     client = TestClient()
     client.run("new cmake_lib -d name=hello -d version=0.1")
@@ -64,6 +67,7 @@ def test_cmake_virtualenv():
     assert "consumer/0.1: Created package" in client.out
 
 
+@pytest.mark.tool("cmake")
 def test_complete():
     client = TestClient()
     client.run("new cmake_lib -d name=myopenssl -d version=1.0")

--- a/conans/test/functional/toolchains/gnu/autotools/test_basic.py
+++ b/conans/test/functional/toolchains/gnu/autotools/test_basic.py
@@ -9,13 +9,12 @@ from conan.tools.env.environment import environment_wrap_command
 from conans.test.assets.autotools import gen_makefile_am, gen_configure_ac, gen_makefile
 from conans.test.assets.sources import gen_function_cpp
 from conans.test.functional.utils import check_exe_run
-from conans.test.utils.mocks import ConanFileMock
 from conans.test.utils.tools import TestClient
 from conans.util.files import touch
 
 
 @pytest.mark.skipif(platform.system() not in ["Linux", "Darwin"], reason="Requires Autotools")
-@pytest.mark.tool_autotools()
+@pytest.mark.tool("autotools")
 def test_autotools():
     client = TestClient(path_with_spaces=False)
     client.run("new cmake_lib -d name=hello -d version=0.1")
@@ -115,7 +114,7 @@ def build_windows_subsystem(profile, make_program):
     return client.out
 
 
-@pytest.mark.tool_cygwin
+@pytest.mark.tool("cygwin")
 @pytest.mark.skipif(platform.system() != "Windows", reason="Needs windows")
 def test_autotoolsdeps_cygwin():
     gcc = textwrap.dedent("""
@@ -134,7 +133,7 @@ def test_autotoolsdeps_cygwin():
     assert "main2 __CYGWIN__1" in out
 
 
-@pytest.mark.tool_mingw64
+@pytest.mark.tool("mingw32")
 @pytest.mark.skipif(platform.system() != "Windows", reason="Needs windows")
 def test_autotoolsdeps_mingw_msys():
     gcc = textwrap.dedent("""
@@ -151,7 +150,7 @@ def test_autotoolsdeps_mingw_msys():
     assert "main2 __MINGW64__1" in out
 
 
-@pytest.mark.tool_msys2
+@pytest.mark.tool("msys2")
 @pytest.mark.skipif(platform.system() != "Windows", reason="Needs windows")
 def test_autotoolsdeps_msys():
     gcc = textwrap.dedent("""

--- a/conans/test/functional/toolchains/gnu/autotools/test_basic.py
+++ b/conans/test/functional/toolchains/gnu/autotools/test_basic.py
@@ -133,7 +133,7 @@ def test_autotoolsdeps_cygwin():
     assert "main2 __CYGWIN__1" in out
 
 
-@pytest.mark.tool("mingw32")
+@pytest.mark.tool("mingw64")
 @pytest.mark.skipif(platform.system() != "Windows", reason="Needs windows")
 def test_autotoolsdeps_mingw_msys():
     gcc = textwrap.dedent("""

--- a/conans/test/functional/toolchains/gnu/autotools/test_ios.py
+++ b/conans/test/functional/toolchains/gnu/autotools/test_ios.py
@@ -11,6 +11,8 @@ from conans.test.utils.tools import TestClient
 
 
 @pytest.mark.skipif(platform.system() != "Darwin", reason="Requires Xcode")
+@pytest.mark.tool("cmake")
+@pytest.mark.tool("autotools")
 def test_ios():
     xcrun = XCRun(None, sdk='iphoneos')
     sdk_path = xcrun.sdk_path

--- a/conans/test/functional/toolchains/gnu/autotools/test_win_bash.py
+++ b/conans/test/functional/toolchains/gnu/autotools/test_win_bash.py
@@ -13,7 +13,7 @@ from conans.util.files import save
 
 @pytest.mark.xfail(reason="Winbash is broken for multi-profile. Ongoing https://github.com/conan-io/conan/pull/9755")
 @pytest.mark.skipif(platform.system() != "Windows", reason="Requires Windows")
-@pytest.mark.tool_msys2
+@pytest.mark.tool("msys2")
 def test_autotools_bash_complete():
     client = TestClient(path_with_spaces=False)
     bash_path = tools_locations["msys2"]["system"]["path"]["Windows"] + "/bash.exe"

--- a/conans/test/functional/toolchains/google/test_bazel.py
+++ b/conans/test/functional/toolchains/google/test_bazel.py
@@ -10,7 +10,7 @@ from conans.test.assets.sources import gen_function_cpp, gen_function_h
 from conans.test.utils.tools import TestClient
 
 
-@pytest.mark.tool_bazel
+@pytest.mark.tool("bazel")
 class Base(unittest.TestCase):
 
     conanfile = textwrap.dedent("""

--- a/conans/test/functional/toolchains/intel/test_intel_cc.py
+++ b/conans/test/functional/toolchains/intel/test_intel_cc.py
@@ -6,8 +6,8 @@ from conans.test.assets.pkg_cmake import pkg_cmake
 from conans.test.utils.tools import TestClient
 
 
-@pytest.mark.tool_cmake
-@pytest.mark.tool_intel_oneapi
+@pytest.mark.tool("cmake")
+@pytest.mark.tool("intel_oneapi")
 @pytest.mark.xfail(reason="Intel oneAPI Toolkit is not installed on CI yet")
 @pytest.mark.skipif(platform.system() != "Linux", reason="Only for Linux")
 class TestIntelCC:

--- a/conans/test/functional/toolchains/intel/test_using_msbuild.py
+++ b/conans/test/functional/toolchains/intel/test_using_msbuild.py
@@ -25,9 +25,9 @@ conanfile_py = textwrap.dedent("""
 """)
 
 
-@pytest.mark.tool_cmake
-@pytest.mark.tool_msbuild
-@pytest.mark.tool_icc
+@pytest.mark.tool("cmake")
+@pytest.mark.tool("msbuild")
+@pytest.mark.tool("icc")
 @pytest.mark.xfail(reason="Intel compiler not installed yet on CI")
 @pytest.mark.skipif(platform.system() != "Windows", reason="msbuild requires Windows")
 class MSBuildIntelTestCase:

--- a/conans/test/functional/toolchains/ios/test_using_cmake.py
+++ b/conans/test/functional/toolchains/ios/test_using_cmake.py
@@ -56,7 +56,7 @@ class ToolchainiOSTestCase(unittest.TestCase):
             """)
         })
 
-    @pytest.mark.tool_cmake(version="3.19")
+    @pytest.mark.tool("cmake", "3.19")
     def test_xcode_generator(self):
         """ Simplest approach:
             https://cmake.org/cmake/help/latest/manual/cmake-toolchains.7.html#cross-compiling-for-ios-tvos-or-watchos

--- a/conans/test/functional/toolchains/meson/_base.py
+++ b/conans/test/functional/toolchains/meson/_base.py
@@ -7,7 +7,7 @@ import pytest
 from conans.test.utils.tools import TestClient
 
 
-@pytest.mark.tool_meson
+@pytest.mark.tool("meson")
 @pytest.mark.skipif(sys.version_info.major == 2, reason="Meson not supported in Py2")
 @pytest.mark.skipif(platform.system() not in ("Darwin", "Windows", "Linux"),
                     reason="Not tested for not mainstream boring operating systems")

--- a/conans/test/functional/toolchains/meson/test_backend.py
+++ b/conans/test/functional/toolchains/meson/test_backend.py
@@ -9,7 +9,7 @@ from conans.test.assets.sources import gen_function_cpp
 from conans.test.utils.tools import TestClient
 
 
-@pytest.mark.tool_meson
+@pytest.mark.tool("meson")
 @pytest.mark.skipif(sys.version_info.major == 2, reason="Meson not supported in Py2")
 @pytest.mark.skipif(platform.system() != "Windows", reason="requires Windows")
 def test_cross_x86():

--- a/conans/test/functional/toolchains/meson/test_cross_compilation.py
+++ b/conans/test/functional/toolchains/meson/test_cross_compilation.py
@@ -52,7 +52,7 @@ option('STRING_DEFINITION', type : 'string', description : 'a string option')
 """)
 
 
-@pytest.mark.tool_meson
+@pytest.mark.tool("meson")
 @pytest.mark.skipif(sys.version_info.major == 2, reason="Meson not supported in Py2")
 @pytest.mark.skipif(platform.system() != "Darwin", reason="requires Xcode")
 @pytest.mark.parametrize("arch, os_, os_version, os_sdk", [
@@ -118,7 +118,7 @@ def test_apple_meson_toolchain_cross_compiling(arch, os_, os_version, os_sdk):
     assert "architecture: %s" % to_apple_arch(arch) in t.out
 
 
-@pytest.mark.tool_meson
+@pytest.mark.tool("meson")
 # for Linux, build for x86 will require a multilib compiler
 # for macOS, build for x86 is no longer supported by modern Xcode
 @pytest.mark.skipif(platform.system() != "Windows", reason="requires Windows")
@@ -147,7 +147,7 @@ def test_windows_cross_compiling_x86():
     assert "main _MSVC_LANG2014" in client.out
 
 
-@pytest.mark.tool_meson
+@pytest.mark.tool("meson")
 class AndroidMesonToolchainCrossTestCase(unittest.TestCase):
 
     def setUp(self):

--- a/conans/test/functional/toolchains/meson/test_install.py
+++ b/conans/test/functional/toolchains/meson/test_install.py
@@ -94,7 +94,7 @@ class MesonInstall(TestMesonBase):
         target_link_libraries(${PROJECT_NAME} hello::hello)
         """)
 
-    @pytest.mark.tool_meson
+    @pytest.mark.tool("meson")
     def test_install(self):
         hello_cpp = gen_function_cpp(name="hello")
         hello_h = gen_function_h(name="hello")

--- a/conans/test/functional/toolchains/meson/test_pkg_config_reuse.py
+++ b/conans/test/functional/toolchains/meson/test_pkg_config_reuse.py
@@ -7,7 +7,7 @@ from conans.test.assets.sources import gen_function_cpp
 from conans.test.functional.toolchains.meson._base import TestMesonBase
 
 
-@pytest.mark.tool_pkg_config
+@pytest.mark.tool("pkg_config")
 class MesonPkgConfigTest(TestMesonBase):
     _conanfile_py = textwrap.dedent("""
     from conan import ConanFile

--- a/conans/test/functional/toolchains/meson/test_test.py
+++ b/conans/test/functional/toolchains/meson/test_test.py
@@ -7,7 +7,7 @@ from conans.test.assets.sources import gen_function_cpp
 from conans.test.functional.toolchains.meson._base import TestMesonBase
 
 
-@pytest.mark.tool_pkg_config
+@pytest.mark.tool("pkg_config")
 class MesonTest(TestMesonBase):
     _test_package_meson_build = textwrap.dedent("""
         project('test_package', 'cpp')

--- a/conans/test/functional/toolchains/meson/test_v2_meson_template.py
+++ b/conans/test/functional/toolchains/meson/test_v2_meson_template.py
@@ -7,9 +7,9 @@ from conans.model.recipe_ref import RecipeReference
 from conans.test.utils.tools import TestClient
 
 
-@pytest.mark.tool_meson
+@pytest.mark.tool("meson")
 @pytest.mark.skipif(sys.version_info.major == 2, reason="Meson not supported in Py2")
-@pytest.mark.tool_pkg_config
+@pytest.mark.tool("pkg_config")
 def test_meson_lib_template():
     # Identical to def test_cmake_lib_template(), but for Meson
     client = TestClient(path_with_spaces=False)
@@ -36,7 +36,7 @@ def test_meson_lib_template():
     assert "hello/0.1: Hello World Release!" in client.out
 
 
-@pytest.mark.tool_meson
+@pytest.mark.tool("meson")
 @pytest.mark.skipif(sys.version_info.major == 2, reason="Meson not supported in Py2")
 def test_meson_exe_template():
     client = TestClient(path_with_spaces=False)

--- a/conans/test/functional/toolchains/microsoft/test_msbuild.py
+++ b/conans/test/functional/toolchains/microsoft/test_msbuild.py
@@ -305,13 +305,13 @@ myapp_vcxproj = r"""<?xml version="1.0" encoding="utf-8"?>
 """
 
 
-@pytest.mark.tool_visual_studio(version='15')
+@pytest.mark.tool("visual_studio", "15")
 @pytest.mark.skipif(platform.system() != "Windows", reason="Only for windows")
 def test_msvc_runtime_flag_vs2017():
     check_msvc_runtime_flag("15", "191")
 
 
-@pytest.mark.tool_visual_studio(version='17')
+@pytest.mark.tool("visual_studio", "17")
 @pytest.mark.skipif(platform.system() != "Windows", reason="Only for windows")
 def test_msvc_runtime_flag_vs2022():
     check_msvc_runtime_flag("17", "193")
@@ -351,7 +351,7 @@ if "17" in tools_locations['visual_studio'] and not tools_locations['visual_stud
 
 @parameterized_class(vs_versions)
 @pytest.mark.skipif(platform.system() != "Windows", reason="Only for windows")
-@pytest.mark.tool_visual_studio
+@pytest.mark.tool("visual_studio")
 class WinTest(unittest.TestCase):
 
     conanfile = textwrap.dedent("""
@@ -428,7 +428,7 @@ class WinTest(unittest.TestCase):
                            ("msvc", "191", "static", "17"),
                            ("msvc", "190", "static", "14")]
                           )
-    @pytest.mark.tool_cmake
+    @pytest.mark.tool("cmake")
     def test_toolchain_win_vs2017(self, compiler, version, runtime, cppstd):
         if self.vs_version != "15":
             pytest.skip("test for Visual Studio 2017")
@@ -497,7 +497,7 @@ class WinTest(unittest.TestCase):
         check_vs_runtime("Release/MyApp.exe", client, self.vs_version, build_type="Release",
                          static_runtime=static_runtime)
 
-    @pytest.mark.tool_cmake
+    @pytest.mark.tool("cmake")
     def test_toolchain_win_debug(self):
         client = TestClient(path_with_spaces=False)
         settings = [("compiler",  "Visual Studio"),
@@ -537,7 +537,7 @@ class WinTest(unittest.TestCase):
                        "DEFINITIONS_CONFIG_INT": "234"})
         check_vs_runtime("x64/Debug/MyApp.exe", client, self.vs_version, build_type="Debug")
 
-    @pytest.mark.tool_cmake
+    @pytest.mark.tool("cmake")
     def test_toolchain_win_multi(self):
         client = TestClient(path_with_spaces=False)
 

--- a/conans/test/functional/toolchains/microsoft/test_msbuilddeps.py
+++ b/conans/test/functional/toolchains/microsoft/test_msbuilddeps.py
@@ -405,12 +405,12 @@ if "17" in tools_locations['visual_studio'] and not tools_locations['visual_stud
 
 
 @parameterized_class(vs_versions)
-@pytest.mark.tool_visual_studio
+@pytest.mark.tool("visual_studio")
 @pytest.mark.skipif(platform.system() != "Windows", reason="Requires MSBuild")
 class MSBuildGeneratorTest(unittest.TestCase):
 
     @pytest.mark.slow
-    @pytest.mark.tool_cmake
+    @pytest.mark.tool("cmake")
     def test_msbuild_generator(self):
         client = TestClient()
         client.save(pkg_cmake("hello0", "1.0"))
@@ -703,15 +703,15 @@ def test_exclude_code_analysis(pattern, exclude_a, exclude_b):
         assert "CAExcludePath" not in depb
 
 
-@pytest.mark.tool_visual_studio(version="15")
-@pytest.mark.tool_cmake
+@pytest.mark.tool("visual_studio", "15")
+@pytest.mark.tool("cmake")
 @pytest.mark.skipif(platform.system() != "Windows", reason="Requires MSBuild")
 def test_build_vs_project_with_a_vs2017():
     check_build_vs_project_with_a("15")
 
 
-@pytest.mark.tool_visual_studio(version="17")
-@pytest.mark.tool_cmake
+@pytest.mark.tool("visual_studio", "17")
+@pytest.mark.tool("cmake")
 @pytest.mark.skipif(platform.system() != "Windows", reason="Requires MSBuild")
 def test_build_vs_project_with_a_vs2022():
     check_build_vs_project_with_a("17")
@@ -790,15 +790,15 @@ def check_build_vs_project_with_a(vs_version):
     # assert "main: Release!" in client.out
 
 
-@pytest.mark.tool_visual_studio(version="15")
-@pytest.mark.tool_cmake
+@pytest.mark.tool("visual_studio", "15")
+@pytest.mark.tool("cmake")
 @pytest.mark.skipif(platform.system() != "Windows", reason="Requires MSBuild")
 def test_build_vs_project_with_test_requires_vs2017():
     check_build_vs_project_with_test_requires("15")
 
 
-@pytest.mark.tool_visual_studio(version="17")
-@pytest.mark.tool_cmake
+@pytest.mark.tool("visual_studio", "17")
+@pytest.mark.tool("cmake")
 @pytest.mark.skipif(platform.system() != "Windows", reason="Requires MSBuild")
 def test_build_vs_project_with_test_requires_vs2022():
     check_build_vs_project_with_test_requires("17")

--- a/conans/test/functional/toolchains/test_basic.py
+++ b/conans/test/functional/toolchains/test_basic.py
@@ -47,7 +47,7 @@ class BasicTest(unittest.TestCase):
         toolchain = client.load("conan_meson_native.ini")
         self.assertIn("[project options]", toolchain)
 
-    @pytest.mark.tool_visual_studio
+    @pytest.mark.tool("visual_studio")
     @pytest.mark.skipif(platform.system() != "Windows", reason="Only for windows")
     def test_declarative_msbuildtoolchain(self):
         conanfile = textwrap.dedent("""
@@ -108,7 +108,7 @@ class BasicTest(unittest.TestCase):
         self.assertIn('-DCMAKE_TOOLCHAIN_FILE="{}"'.format(toolchain_path),  client.out)
         self.assertIn("ERROR: conanfile.py: Error in build() method", client.out)
 
-    @pytest.mark.tool_visual_studio
+    @pytest.mark.tool("visual_studio")
     @pytest.mark.skipif(platform.system() != "Windows", reason="Only for windows")
     def test_toolchain_windows(self):
         client = TestClient()

--- a/conans/test/functional/toolchains/test_msbuild_toolchain.py
+++ b/conans/test/functional/toolchains/test_msbuild_toolchain.py
@@ -10,7 +10,7 @@ from conans.test.utils.tools import TestClient
 @parameterized.expand([("msvc", "190", "dynamic"),
                        ("msvc", "191", "static")]
                       )
-@pytest.mark.tool_visual_studio
+@pytest.mark.tool("visual_studio")
 @pytest.mark.skipif(platform.system() != "Windows", reason="Only for windows")
 def test_toolchain_win(compiler, version, runtime):
     client = TestClient(path_with_spaces=False)

--- a/conans/test/functional/toolchains/test_txt_cmdline.py
+++ b/conans/test/functional/toolchains/test_txt_cmdline.py
@@ -35,7 +35,7 @@ class TestTxtCommandLine(unittest.TestCase):
         self._check(client)
 
 
-@pytest.mark.tool_visual_studio
+@pytest.mark.tool("visual_studio")
 @pytest.mark.skipif(platform.system() != "Windows", reason="Only for windows")
 class TestTxtCommandLineMSBuild(unittest.TestCase):
 

--- a/conans/test/functional/tools/system/package_manager_test.py
+++ b/conans/test/functional/tools/system/package_manager_test.py
@@ -6,7 +6,7 @@ import pytest
 from conans.test.utils.tools import TestClient
 
 
-@pytest.mark.tool_apt_get
+@pytest.mark.tool("apt_get")
 @pytest.mark.skipif(platform.system() != "Linux", reason="Requires apt")
 def test_apt_check():
     client = TestClient()
@@ -27,7 +27,7 @@ def test_apt_check():
     assert "missing: ['non-existing1', 'non-existing2']" in client.out
 
 
-@pytest.mark.tool_apt_get
+@pytest.mark.tool("apt_get")
 @pytest.mark.skipif(platform.system() != "Linux", reason="Requires apt")
 def test_build_require():
     client = TestClient()
@@ -56,7 +56,7 @@ def test_build_require():
     assert "missing: ['non-existing1', 'non-existing2']" in client.out
 
 
-@pytest.mark.tool_brew
+@pytest.mark.tool("brew")
 @pytest.mark.skipif(platform.system() != "Darwin", reason="Requires brew")
 def test_brew_check():
     client = TestClient()
@@ -75,7 +75,7 @@ def test_brew_check():
     assert "missing: ['non-existing1', 'non-existing2']" in client.out
 
 
-@pytest.mark.tool_brew
+@pytest.mark.tool("brew")
 @pytest.mark.skipif(platform.system() != "Darwin", reason="Requires brew")
 @pytest.mark.skip(reason="brew update takes a lot of time")
 def test_brew_install_check_mode():
@@ -96,7 +96,7 @@ def test_brew_install_check_mode():
            "can't install because tools.system.package_manager:mode is 'check'" in client.out
 
 
-@pytest.mark.tool_brew
+@pytest.mark.tool("brew")
 @pytest.mark.skipif(platform.system() != "Darwin", reason="Requires brew")
 @pytest.mark.skip(reason="brew update takes a lot of time")
 def test_brew_install_install_mode():

--- a/conans/test/functional/tools/test_pkg_config.py
+++ b/conans/test/functional/tools/test_pkg_config.py
@@ -25,7 +25,7 @@ Cflags: -I${includedir}/libastral -D_USE_LIBASTRAL
 """
 
 
-@pytest.mark.tool_pkg_config
+@pytest.mark.tool("pkg_config")
 class TestPkgConfig:
     def test_negative(self):
         conanfile = ConanFileMock()

--- a/conans/test/functional/tools_versions_test.py
+++ b/conans/test/functional/tools_versions_test.py
@@ -35,7 +35,7 @@ class TestToolsCustomVersions:
         client.run_command('cmake --version')
         assert "cmake version 3.19" in client.out
 
-    @pytest.mark.tool("mingw32")
+    @pytest.mark.tool("mingw64")
     @pytest.mark.tool("cmake", "3.16")
     @pytest.mark.skipif(platform.system() != "Windows",
                         reason="Mingw test")

--- a/conans/test/functional/tools_versions_test.py
+++ b/conans/test/functional/tools_versions_test.py
@@ -10,33 +10,33 @@ from conans.test.utils.tools import TestClient
 
 class TestToolsCustomVersions:
 
-    @pytest.mark.tool_cmake
+    @pytest.mark.tool("cmake")
     def test_default_cmake(self):
         client = TestClient()
         client.run_command('cmake --version')
         default_cmake_version = tools_locations["cmake"]["default"]
         assert "cmake version {}".format(default_cmake_version) in client.out
 
-    @pytest.mark.tool_cmake(version="3.16")
+    @pytest.mark.tool("cmake", "3.16")
     def test_custom_cmake_3_16(self):
         client = TestClient()
         client.run_command('cmake --version')
         assert "cmake version 3.16" in client.out
 
-    @pytest.mark.tool_cmake(version="3.17")
+    @pytest.mark.tool("cmake", "3.17")
     def test_custom_cmake_3_17(self):
         client = TestClient()
         client.run_command('cmake --version')
         assert "cmake version 3.17" in client.out
 
-    @pytest.mark.tool_cmake(version="3.19")
+    @pytest.mark.tool("cmake", "3.19")
     def test_custom_cmake_3_19(self):
         client = TestClient()
         client.run_command('cmake --version')
         assert "cmake version 3.19" in client.out
 
-    @pytest.mark.tool_mingw64
-    @pytest.mark.tool_cmake(version="3.16")
+    @pytest.mark.tool("mingw32")
+    @pytest.mark.tool("cmake", "3.16")
     @pytest.mark.skipif(platform.system() != "Windows",
                         reason="Mingw test")
     def test_custom_cmake_mingw64(self):

--- a/conans/test/functional/util/tools_test.py
+++ b/conans/test/functional/util/tools_test.py
@@ -12,7 +12,7 @@ from conans.util.env import get_env, environment_update
 
 
 @pytest.mark.skipif(platform.system() != "Windows", reason="Requires Visual Studio")
-@pytest.mark.tool_visual_studio
+@pytest.mark.tool("visual_studio")
 class VisualStudioToolsTest(unittest.TestCase):
 
     def test_vswhere_path(self):

--- a/conans/test/integration/configuration/conf/test_conf_profile.py
+++ b/conans/test/integration/configuration/conf/test_conf_profile.py
@@ -136,7 +136,7 @@ def test_msbuild_config():
     assert "/verbosity:Minimal" in client.out
 
 
-@pytest.mark.tool_visual_studio
+@pytest.mark.tool("visual_studio")
 @pytest.mark.skipif(platform.system() != "Windows", reason="Only for windows")
 def test_msbuild_compile_options():
     client = TestClient()


### PR DESCRIPTION
- The `pytest.mark.tool_XXX` was not working correctly when declared a fixture in the `scope="module"` because our `tool_XXX` mechanism was using an `autouse` fixture that was not applied when living in a different scope.
- Replaced with `pytest_runtest_setup` + `pytest_runtest_teardown` at `conftest.py`
- A huge amount of tests were not adding the `tool_XXX` needed.
- New syntax of tools `@pytest.mark.tool("cmake", "3.7")` with the version as the second argument being optional.

All this has been unveiled because my pycharm stopped adding the `/usr/local/bin` to the PATH so all the brew tools where only located when correctly tagged and when no `scope="module"`.
