### PR TITLE
Fix: Bazel builds generator in version 1.45

### DIFF
--- a/conan/tools/google/bazeldeps.py
+++ b/conan/tools/google/bazeldeps.py
@@ -99,9 +99,9 @@ class BazelDeps(object):
 
         def _relativize_path(p, base_path):
             # TODO: Very fragile, to test more
-            assert os.path.isabs(p), "{} is not absolute".format(p)
-            assert p.startswith(base_path)
-            return p[len(base_path):].replace("\\", "/").lstrip("/")
+            if p.startswith(base_path):
+                return p[len(base_path):].replace("\\", "/").lstrip("/")
+            return p.replace("\\", "/").lstrip("/")
 
         # TODO: This only wokrs for package_folder, but not editable
         package_folder = dependency.package_folder

--- a/conan/tools/google/bazeldeps.py
+++ b/conan/tools/google/bazeldeps.py
@@ -121,10 +121,15 @@ class BazelDeps(object):
             linkopts.append('"-l{}"'.format(linkopt))
         linkopts = ', '.join(linkopts)
 
+
+        lib_dir = 'lib'
+        if len(cpp_info.libdirs) != 0:
+            libd_dir = _relativize_path(lib_dir, package_folder)
+
         context = {
             "name": dependency.ref.name,
             "libs": cpp_info.libs,
-            "libdir": cpp_info.libdirs[0],
+            "libdir": lib_dir,
             "headers": headers,
             "includes": includes,
             "defines": defines,


### PR DESCRIPTION
Fix: Bazel builds generator in version 1.45

* BazelDeps was generating invalid bazel files cause the static_library paths were absolute and not relative
* BazelDeps was crashing when generating packages without libs cause the context was not checking the array size

I've tested this in my project using major libs like boost, qt, fmt etc. It works just fine with the latest commit

-  https://github.com/conan-io/conan/issues/10481
-  https://github.com/conan-io/conan/issues/10476

