### PR TITLE
 Fix: Bazel builds generator

### DIFF
--- a/conan/tools/google/bazeldeps.py
+++ b/conan/tools/google/bazeldeps.py
@@ -126,7 +126,7 @@ class BazelDeps(object):
         if len(cpp_info.libdirs) != 0:
             lib_dir = _relativize_path(cpp_info.libdirs[0], package_folder)
 
-        shared_library = dependency.options.get_safe("shared")
+        shared_library = dependency.options.get_safe("shared") if dependency.options else False
         context = {
             "name": dependency.ref.name,
             "libs": cpp_info.libs,

--- a/conan/tools/google/bazeldeps.py
+++ b/conan/tools/google/bazeldeps.py
@@ -99,9 +99,9 @@ class BazelDeps(object):
 
         def _relativize_path(p, base_path):
             # TODO: Very fragile, to test more
-            assert os.path.isabs(p), "{} is not absolute".format(p)
-            assert p.startswith(base_path)
-            return p[len(base_path):].replace("\\", "/").lstrip("/")
+            if p.startswith(base_path):
+                return p[len(base_path):].replace("\\", "/").lstrip("/")
+            return p.replace("\\", "/").lstrip("/")
 
         # TODO: This only wokrs for package_folder, but not editable
         package_folder = dependency.package_folder

--- a/conan/tools/google/bazeldeps.py
+++ b/conan/tools/google/bazeldeps.py
@@ -59,7 +59,7 @@ class BazelDeps(object):
             {% for lib in libs %}
             cc_import(
                 name = "{{ lib }}_precompiled",
-                static_library = "{{ libdir }}/lib{{ lib }}.a"
+                {{ library_type }} = "{{ libdir }}/lib{{ lib }}.{{extension}}"
             )
             {% endfor %}
 
@@ -126,6 +126,7 @@ class BazelDeps(object):
         if len(cpp_info.libdirs) != 0:
             lib_dir = _relativize_path(cpp_info.libdirs[0], package_folder)
 
+        shared_library = dependency.options.get_safe("shared")
         context = {
             "name": dependency.ref.name,
             "libs": cpp_info.libs,
@@ -133,9 +134,10 @@ class BazelDeps(object):
             "headers": headers,
             "includes": includes,
             "defines": defines,
-            "linkopts": linkopts
+            "linkopts": linkopts,
+            "library_type": "shared_library" if shared_library else "static_library",
+            "extension": "so" if shared_library else "a"
         }
-
         content = Template(template).render(**context)
         return content
 

--- a/conan/tools/google/bazeldeps.py
+++ b/conan/tools/google/bazeldeps.py
@@ -121,10 +121,15 @@ class BazelDeps(object):
             linkopts.append('"-l{}"'.format(linkopt))
         linkopts = ', '.join(linkopts)
 
+
+        lib_dir = 'lib'
+        if len(cpp_info.libdirs) != 0:
+            libd_dir = _relativize_path(lib_dir, package_folder)
+
         context = {
             "name": dependency.ref.name,
             "libs": cpp_info.libs,
-            "libdir": cpp_info.libdirs[0],
+            "libdir": lib_dir,
             "headers": headers,
             "includes": includes,
             "defines": defines,

--- a/conan/tools/google/bazeldeps.py
+++ b/conan/tools/google/bazeldeps.py
@@ -124,7 +124,7 @@ class BazelDeps(object):
 
         lib_dir = 'lib'
         if len(cpp_info.libdirs) != 0:
-            libd_dir = _relativize_path(lib_dir, package_folder)
+            lib_dir = _relativize_path(cpp_info.libdirs[0], package_folder)
 
         context = {
             "name": dependency.ref.name,


### PR DESCRIPTION
Changelog: Fix: BazelDeps was generating invalid bazel files cause the static_library paths were absolute and not relative.
Changelog: Fix: BazelDeps was crashing when generating packages without libs cause the context was not checking the array size.
Docs: Omit

* BazelDeps was generating invalid bazel files cause the static_library paths were absolute and not relative
* BazelDeps was crashing when generating packages without libs cause the context was not checking the array size

I've tested this in my project using major libs like boost, qt, fmt etc. It works just fine with the latest commit

-  https://github.com/conan-io/conan/issues/10481
-  https://github.com/conan-io/conan/issues/10476

