### PR TITLE
Fix failing import for configparser in python 2

### DIFF
--- a/conan/tools/files/files.py
+++ b/conan/tools/files/files.py
@@ -1,9 +1,10 @@
-import configparser
 import errno
 import os
 import platform
 import subprocess
 from contextlib import contextmanager
+
+from six.moves import configparser
 
 from conan.tools import CONAN_TOOLCHAIN_ARGS_FILE, CONAN_TOOLCHAIN_ARGS_SECTION
 from conans.client.downloaders.download import run_downloader

--- a/conan/tools/files/files.py
+++ b/conan/tools/files/files.py
@@ -230,7 +230,11 @@ def save_toolchain_args(content, generators_folder=None, namespace=None):
     args_file = os.path.join(generators_folder, namespace_name) if generators_folder \
         else namespace_name
     toolchain_config = configparser.ConfigParser()
-    toolchain_config[CONAN_TOOLCHAIN_ARGS_SECTION] = content_
+    # FIXME: Python2 compatibility replace this in Conan 2.0 with:
+    #  toolchain_config[CONAN_TOOLCHAIN_ARGS_SECTION] = content_
+    toolchain_config.add_section(CONAN_TOOLCHAIN_ARGS_SECTION)
+    for key, values in content_.items():
+        toolchain_config.set(CONAN_TOOLCHAIN_ARGS_SECTION, key, values)
     with open(args_file, "w") as f:
         toolchain_config.write(f)
 


### PR DESCRIPTION
Changelog: omit
Docs: omit

Using Python 2:

`pip install git+https://github.com/conan-io/conan.git@release/1.45 && conan --version` --> fails

`pip install git+https://github.com/czoido/conan.git@fix_configparser_import && conan --version` --> ok
