### PR TITLE
Add configparser to requirements only for Python2

### DIFF
--- a/conans/requirements.txt
+++ b/conans/requirements.txt
@@ -12,3 +12,4 @@ pygments>=2.0, <3.0
 tqdm>=4.28.1, <5
 Jinja2>=2.9, <4.0.0
 python-dateutil>=2.7.0, <3
+configparser>=3.5;python_version<='2.7'


### PR DESCRIPTION
Changelog: omit
Docs: omit

After changes in 1.45 we are loading the MarkdownGenerator when conan is initialized, this makes that the `import configparser` from `conan.tools.files.files.py` is invoked so it crashes for Python2.

Why does it not fail in testing with Python2?

Because we use pytest for running the tests and after we install pytest, [configparser](https://pypi.org/project/configparser/) is installed as a requirement, this has a backport for python2, so it was loaded through the backport in the conan test suite and did not fail....

In Py2:

`pip install git+https://github.com/conan-io/conan.git@release/1.45 && conan --version` --> crashes
`pip install git+https://github.com/czoido/conan.git@add_configparser_to_requirements && conan --version` --> ok