### PR TITLE
fix conan_manifest.txt parse error

### DIFF
--- a/conans/model/manifest.py
+++ b/conans/model/manifest.py
@@ -71,8 +71,7 @@ class FileTreeManifest(object):
 
     @staticmethod
     def loads(text):
-        """ parses a string representation, generated with __repr__ of a
-        ConanDigest
+        """ parses a string representation, generated with __repr__
         """
         tokens = text.split("\n")
         the_time = int(tokens[0])
@@ -80,7 +79,7 @@ class FileTreeManifest(object):
         keep_python = get_env("CONAN_KEEP_PYTHON_FILES", False)
         for md5line in tokens[1:]:
             if md5line:
-                filename, file_md5 = md5line.split(": ")
+                filename, file_md5 = md5line.rsplit(": ", 1)
                 # FIXME: This is weird, it should never happen, maybe remove?
                 if not discarded_file(filename, keep_python):
                     file_sums[filename] = file_md5

--- a/conans/test/unittests/model/manifest_test.py
+++ b/conans/test/unittests/model/manifest_test.py
@@ -1,12 +1,12 @@
 import os
-import unittest
+
 
 from conans.model.manifest import FileTreeManifest
 from conans.test.utils.test_files import temp_folder
 from conans.util.files import load, md5, save
 
 
-class ManifestTest(unittest.TestCase):
+class TestManifest:
 
     def test_tree_manifest(self):
         tmp_dir = temp_folder()
@@ -24,15 +24,14 @@ class ManifestTest(unittest.TestCase):
         manifest.save(tmp_dir)
         readed_manifest = FileTreeManifest.load(tmp_dir)
 
-        self.assertEqual(readed_manifest.time, manifest.time)
-        self.assertEqual(readed_manifest, manifest)
+        assert readed_manifest.time == manifest.time
+        assert readed_manifest == manifest
         # Not included the pycs or pyo
-        self.assertEqual(set(manifest.file_sums.keys()),
-                          set(["one.ext", "path/to/two.txt", "two.txt"]))
+        assert set(manifest.file_sums.keys()) == {"one.ext", "path/to/two.txt", "two.txt"}
 
         for filepath, md5readed in manifest.file_sums.items():
             content = files[filepath]
-            self.assertEqual(md5(content), md5readed)
+            assert md5(content) == md5readed
 
     def test_already_pyc_in_manifest(self):
         tmp_dir = temp_folder()
@@ -43,5 +42,10 @@ class ManifestTest(unittest.TestCase):
 
         read_manifest = FileTreeManifest.loads(load(os.path.join(tmp_dir, "man.txt")))
         # Not included the pycs or pyo
-        self.assertEqual(set(read_manifest.file_sums.keys()),
-                          set(["conanfile.py"]))
+        assert set(read_manifest.file_sums.keys()) == {"conanfile.py"}
+
+    def test_special_chars(self):
+        tmp_dir = temp_folder()
+        save(os.path.join(tmp_dir, "conanmanifest.txt"), "1478122267\nsome: file.py: 123\n")
+        read_manifest = FileTreeManifest.load(tmp_dir)
+        assert read_manifest.file_sums["some: file.py"] == "123"


### PR DESCRIPTION
Changelog: Bugfix: Fix conan_manifest.txt parse error when the filename has ":" in it. 
Docs: Omit
Close https://github.com/conan-io/conan/issues/10475
