### PR TITLE
remove local scm checkout, should be source()

### DIFF
--- a/conans/client/cmd/export.py
+++ b/conans/client/cmd/export.py
@@ -119,7 +119,7 @@ def _capture_scm_auto_fields(conanfile, conanfile_dir, recipe_layout, ignore_dir
     captured = scm_data.capture_origin or scm_data.capture_revision
 
     if not captured:
-        # We replace not only "auto" values, also evaluated functions (e.g from a python_require)
+        
         _add_scmdata_to_conandata_yml(recipe_layout, scm_data)
         return scm_data, None
 

--- a/conans/client/cmd/export.py
+++ b/conans/client/cmd/export.py
@@ -120,7 +120,7 @@ def _capture_scm_auto_fields(conanfile, conanfile_dir, recipe_layout, ignore_dir
 
     if not captured:
         # We replace not only "auto" values, also evaluated functions (e.g from a python_require)
-        _replace_scm_data_in_recipe(recipe_layout, scm_data)
+        _add_scmdata_to_conandata_yml(recipe_layout, scm_data)
         return scm_data, None
 
     if not scm.is_pristine() and not ignore_dirty:
@@ -153,15 +153,16 @@ def _capture_scm_auto_fields(conanfile, conanfile_dir, recipe_layout, ignore_dir
         conanfile.output.success("Revision deduced by 'auto': %s" % scm_data.revision)
 
     local_src_path = scm.get_local_path_to_url(scm_data.url)
-    _replace_scm_data_in_recipe(recipe_layout, scm_data)
+    _add_scmdata_to_conandata_yml(recipe_layout, scm_data)
 
     return scm_data, local_src_path
 
 
-def _replace_scm_data_in_recipe(recipe_layout, scm_data):
+def _add_scmdata_to_conandata_yml(recipe_layout, scm_data):
     conandata_path = os.path.join(recipe_layout.export(), DATA_YML)
     conandata_yml = {}
     if os.path.exists(conandata_path):
+
         conandata_yml = yaml.safe_load(load(conandata_path))
         conandata_yml = conandata_yml or {}  # In case the conandata is a blank file
         if '.conan' in conandata_yml:

--- a/conans/client/loader.py
+++ b/conans/client/loader.py
@@ -50,18 +50,23 @@ class ConanFileLoader:
 
             conanfile.recipe_folder = os.path.dirname(conanfile_path)
 
-            # If the scm is inherited, create my own instance
-            if hasattr(conanfile, "scm") and "scm" not in conanfile.__class__.__dict__:
-                assert isinstance(conanfile.scm, dict), "'scm' attribute must be a dictionary"
-                conanfile.scm = conanfile.scm.copy()
-
             # Load and populate dynamic fields from the data file
             conan_data = self._load_data(conanfile_path)
             conanfile.conan_data = conan_data
-            if conan_data and '.conan' in conan_data:
-                scm_data = conan_data['.conan'].get('scm')
-                if scm_data:
-                    conanfile.scm.update(scm_data)
+
+            if hasattr(conanfile, "scm"):
+                if "scm" not in conanfile.__class__.__dict__:
+                    # If the scm is inherited, create my own instance
+                    conanfile.scm = conanfile.scm.copy()
+
+                if conanfile.scm.get("revision", "auto") != "auto":
+                    raise ConanException("'scm' can only be used for 'auto'. For fixed revisions use"
+                                         " the 'source()' method (and maybe conandata.yml file)")
+
+                if conan_data and '.conan' in conan_data:
+                    scm_data = conan_data['.conan'].get('scm')
+                    if scm_data:
+                        conanfile.scm.update(scm_data)
 
             self._cached_conanfile_classes[conanfile_path] = (conanfile, module)
             result = conanfile(display)

--- a/conans/client/source.py
+++ b/conans/client/source.py
@@ -65,7 +65,6 @@ def config_source_local(conanfile, conanfile_path, hook_manager):
     def get_sources_from_exports():
         src_folder = conanfile.source_folder
         if conanfile_folder != src_folder:
-            _run_local_scm(conanfile, conanfile_folder, src_folder)
             conanfile.output.info("Executing exports to: %s" % src_folder)
             export_recipe(conanfile, src_folder)
             export_source(conanfile, src_folder)
@@ -207,35 +206,3 @@ def _run_cache_scm(conanfile, scm_sources_folder):
         # Maybe check conan 2.0
         # TODO: Why removing in the cache? There is no danger.
         _clean_source_folder(dest_dir)
-
-
-def _run_local_scm(conanfile, conanfile_folder, src_folder):
-    """
-    Only called when 'conan source' in user space
-    :param conanfile: recipe
-    :param src_folder: specified src_folder
-    :param conanfile_folder: Folder containing the local conanfile
-    :param output: Output
-    :return:
-    """
-
-    scm_data = get_scm_data(conanfile)
-    if not scm_data:
-        return
-    dest_dir = os.path.normpath(os.path.join(src_folder, scm_data.subfolder or ""))
-    # In user space, if revision="auto", then copy
-    if scm_data.capture_origin or scm_data.capture_revision:  # FIXME: or clause?
-        scm = SCM(scm_data, conanfile_folder, conanfile.output)
-        scm_url = scm_data.url if scm_data.url != "auto" else \
-            scm.get_qualified_remote_url(remove_credentials=True)
-
-        src_path = scm.get_local_path_to_url(url=scm_url)
-        if src_path and src_path != dest_dir:
-            excluded = SCM(scm_data, src_path, conanfile.output).excluded_files
-            conanfile.output.info("SCM: Getting sources from folder: %s" % src_path)
-            merge_directories(src_path, dest_dir, excluded=excluded)
-            return
-
-    conanfile.output.info("SCM: Getting sources from url: '%s'" % scm_data.url)
-    scm = SCM(scm_data, dest_dir, conanfile.output)
-    scm.checkout()

--- a/conans/model/scm.py
+++ b/conans/model/scm.py
@@ -14,14 +14,13 @@ def get_scm_data(conanfile):
         return None
 
 
-def _get_dict_value(data, key, expected_type, default=None, disallowed_type=None):
+def _get_dict_value(data, key, expected_type, default=None):
     if key in data:
         r = data.get(key)
         if r is None:  # None is always a valid value
             return r
-        if not isinstance(r, expected_type) or (disallowed_type and isinstance(r, disallowed_type)):
-            type_str = "' or '".join([it.__name__ for it in expected_type]) \
-                if isinstance(expected_type, tuple) else expected_type.__name__
+        if not isinstance(r, expected_type):
+            type_str = expected_type.__name__
             raise ConanException("SCM value for '{}' must be of type '{}'"
                                  " (found '{}')".format(key, type_str, type(r).__name__))
         return r
@@ -36,8 +35,7 @@ class SCMData(object):
         data = getattr(conanfile, "scm")
         self.type = _get_dict_value(data, "type", str)
         self.url = _get_dict_value(data, "url", str)
-        self.revision = _get_dict_value(data, "revision", (str, int),
-                                        disallowed_type=bool)  # bool is subclass of integer
+        self.revision = _get_dict_value(data, "revision", str)
         self.verify_ssl = _get_dict_value(data, "verify_ssl", bool, SCMData.VERIFY_SSL_DEFAULT)
         self.username = _get_dict_value(data, "username", str)
         self.password = _get_dict_value(data, "password", str)

--- a/conans/test/functional/scm/export/test_capture_export_scm_data.py
+++ b/conans/test/functional/scm/export/test_capture_export_scm_data.py
@@ -20,7 +20,7 @@ from conans.util.files import save
 
 
 @pytest.mark.tool("git")
-@mock.patch("conans.client.cmd.export._replace_scm_data_in_recipe", return_value=None)
+@mock.patch("conans.client.cmd.export._add_scmdata_to_conandata_yml", return_value=None)
 class CaptureExportSCMDataTest(unittest.TestCase):
 
     def setUp(self):

--- a/conans/test/functional/scm/scm_test.py
+++ b/conans/test/functional/scm/scm_test.py
@@ -70,46 +70,6 @@ class GitSCMTest(unittest.TestCase):
         self.client.run_command("git add .")
         self.client.run_command('git commit -m  "commiting"')
 
-    def test_scm_other_type_ignored(self):
-        conanfile = '''
-from conan import ConanFile
-
-class ConanLib(ConanFile):
-    name = "lib"
-    version = "0.1"
-    scm = ["Other stuff"]
-'''
-        self.client.save({"conanfile.py": conanfile})
-        # nothing breaks
-        self.client.run("create . --user=user --channel=channel", assert_error=True)
-        self.assertIn("'scm' attribute must be a dictionary", self.client.out)
-
-    def test_repeat_clone_changing_subfolder(self):
-        tmp = '''
-from conan import ConanFile
-
-class ConanLib(ConanFile):
-    name = "lib"
-    version = "0.1"
-    scm = {{
-        "type": "git",
-        "url": "{url}",
-        "revision": "{revision}",
-        "subfolder": "onesubfolder"
-    }}
-'''
-        path, commit = create_local_git_repo({"myfile": "contents"}, branch="my_release")
-        conanfile = tmp.format(url=path, revision=commit)
-        self.client.save({"conanfile.py": conanfile,
-                          "myfile.txt": "My file is copied"})
-        self.client.run("create . --user=user --channel=channel")
-        conanfile = conanfile.replace('"onesubfolder"', '"othersubfolder"')
-        self.client.save({"conanfile.py": conanfile})
-        self.client.run("create . --user=user --channel=channel")
-        folder = self.client.get_latest_ref_layout(self.ref).source()
-        self.assertIn("othersubfolder", os.listdir(folder))
-        self.assertTrue(os.path.exists(os.path.join(folder, "othersubfolder", "myfile")))
-
     @pytest.mark.xfail(reason="Remove source folders not implemented yet")
     def test_auto_filesystem_remote_git(self):
         # https://github.com/conan-io/conan/issues/3109
@@ -145,17 +105,6 @@ class ConanLib(ConanFile):
         self.assertIn("Repo origin deduced by 'auto': https://myrepo.com.git", self.client.out)
         self.assertIn("Revision deduced by 'auto'", self.client.out)
         self.assertIn("SCM: Getting sources from folder: %s" % curdir, self.client.out)
-        self.assertIn("My file is copied", self.client.out)
-
-        # Export again but now with absolute reference, so no sources are copied from the local dir
-        git = Git(curdir)
-        self.client.save({"conanfile.py": base_git.format(url=_quoted(curdir),
-                                                          revision=git.get_revision())})
-        self.client.run("create . --user=user --channel=channel")
-        self.assertNotIn("Repo origin deduced by 'auto'", self.client.out)
-        self.assertNotIn("Revision deduced by 'auto'", self.client.out)
-        self.assertNotIn("Getting sources from folder: %s" % curdir, self.client.out)
-        self.assertIn("SCM: Getting sources from url: '%s'" % curdir, self.client.out)
         self.assertIn("My file is copied", self.client.out)
 
     def test_auto_subfolder(self):
@@ -278,6 +227,9 @@ class ConanLib(ConanFile):
         self.assertFalse(os.path.exists(os.path.join(bf, "other_folder", "excluded_subfolder")))
 
     def test_local_source(self):
+        """ the --source-folder argument for a in-source recipe is useless and unnecessary
+        Nothing is copied to the --source-folder=source
+        """
         curdir = self.client.current_folder.replace("\\", "/")
         conanfile = base_git.format(url=_quoted("auto"), revision="auto")
         conanfile += """
@@ -289,33 +241,15 @@ class ConanLib(ConanFile):
         self.client.save({"aditional_file.txt": "contents"})
 
         self.client.run("source . --source-folder=./source")
-        self.assertTrue(os.path.exists(os.path.join(curdir, "source", "myfile.txt")))
         self.assertIn("SOURCE METHOD CALLED", self.client.out)
-        # Even the not commited files are copied
-        self.assertTrue(os.path.exists(os.path.join(curdir, "source", "aditional_file.txt")))
-        self.assertIn("SCM: Getting sources from folder: %s" % curdir,
-                      str(self.client.out).replace("\\", "/"))
-
-        # Export again but now with absolute reference, so no pointer file is created nor kept
-        git = Git(curdir.replace("\\", "/"))
-        conanfile = base_git.format(url=_quoted(curdir.replace("\\", "/")),
-                                    revision=git.get_revision())
-        conanfile += """
-    def source(self):
-        self.output.warning("SOURCE METHOD CALLED")
-"""
-        self.client.save({"conanfile.py": conanfile,
-                          "myfile2.txt": "My file is copied"})
-        self.client.init_git_repo()
-        self.client.run("source . --source-folder=./source2")
-        # myfile2 is no in the specified commit
-        self.assertFalse(os.path.exists(os.path.join(curdir, "source2", "myfile2.txt")))
-        self.assertTrue(os.path.exists(os.path.join(curdir, "source2", "myfile.txt")))
-        self.assertIn("SCM: Getting sources from url: '%s'" % curdir.replace("\\", "/"),
-                      self.client.out)
-        self.assertIn("SOURCE METHOD CALLED", self.client.out)
+        # Files are NOT copied
+        assert not os.path.exists(os.path.join(curdir, "source", "myfile.txt"))
+        assert not os.path.exists(os.path.join(curdir, "source", "aditional_file.txt"))
 
     def test_local_source_subfolder(self):
+        """ the --source-folder argument for a in-source recipe is useless and unnecessary
+        Nothing is copied to the --source-folder=source
+        """
         curdir = self.client.current_folder
         conanfile = base_git.replace('"revision": "{revision}"',
                                      '"revision": "{revision}",\n        '
@@ -329,41 +263,9 @@ class ConanLib(ConanFile):
         self.client.init_git_repo()
 
         self.client.run("source . --source-folder=./source")
-        self.assertFalse(os.path.exists(os.path.join(curdir, "source", "myfile.txt")))
-        self.assertTrue(os.path.exists(os.path.join(curdir, "source", "mysub", "myfile.txt")))
+        assert not os.path.exists(os.path.join(curdir, "source", "myfile.txt"))
+        assert not os.path.exists(os.path.join(curdir, "source", "mysub", "myfile.txt"))
         self.assertIn("SOURCE METHOD CALLED", self.client.out)
-
-    @parameterized.expand([
-        ("local", "v1.0", True),
-        ("local", None, False),
-        ("https://github.com/conan-io/conan.git", "0.22.1", True),
-        ("https://github.com/conan-io/conan.git", "c6cc15fa2f4b576bd70c9df11942e61e5cc7d746", False)])
-    def test_shallow_clone_remote(self, remote, revision, is_tag):
-        # https://github.com/conan-io/conan/issues/5570
-        self.client = TestClient()
-
-        # "remote" git
-        if remote == "local":
-            remote, rev = create_local_git_repo(tags=[revision] if is_tag else None,
-                                                files={"conans/model/username.py": "foo"})
-            if revision is None:  # Get the generated commit
-                revision = rev
-
-        # Use explicit URL to avoid local optimization (scm_folder.txt)
-        conanfile = '''
-import os
-from conan import ConanFile
-
-class ConanLib(ConanFile):
-    name = "lib"
-    version = "0.1"
-    scm = {"type": "git", "url": "%s", "revision": "%s"}
-
-    def build(self):
-        assert os.path.exists(os.path.join(self.build_folder, "conans", "model", "username.py"))
-''' % (remote, revision)
-        self.client.save({"conanfile.py": conanfile})
-        self.client.run("create . --user=user --channel=channel")
 
     def test_install_checked_out(self):
         test_server = TestServer()
@@ -409,85 +311,6 @@ class ConanLib(ConanFile):
         self.client.run("create . --name=lib --version=1.0 --user=user --channel=channel")
         self.assertIn("Contents: Contents 2", self.client.out)
 
-    def test_submodule(self):
-        subsubmodule, _ = create_local_git_repo({"subsubmodule": "contents"})
-        submodule, _ = create_local_git_repo({"submodule": "contents"}, submodules=[subsubmodule])
-        path, commit = create_local_git_repo({"myfile": "contents"}, branch="my_release",
-                                             submodules=[submodule])
-
-        def _relative_paths(folder_):
-            sub_path = os.path.join(folder_, os.path.basename(os.path.normpath(submodule)))
-            subsub_path = os.path.join(sub_path, os.path.basename(os.path.normpath(subsubmodule)))
-            return sub_path, subsub_path
-
-        # Check old (default) behaviour
-        tmp = '''
-from conan import ConanFile
-
-class ConanLib(ConanFile):
-    name = "lib"
-    version = "0.1"
-    scm = {{
-        "type": "git",
-        "url": "{url}",
-        "revision": "{revision}"
-    }}
-'''
-        conanfile = tmp.format(url=path, revision=commit)
-        self.client.save({"conanfile.py": conanfile})
-        self.client.run("create . --user=user --channel=channel")
-
-        ref = RecipeReference.loads("lib/0.1@user/channel")
-        folder = self.client.get_latest_ref_layout(ref).source()
-        submodule_path, _ = _relative_paths(folder)
-        self.assertTrue(os.path.exists(os.path.join(folder, "myfile")))
-        self.assertFalse(os.path.exists(os.path.join(submodule_path, "submodule")))
-
-        # Check invalid value
-        tmp = '''
-from conan import ConanFile
-
-class ConanLib(ConanFile):
-    name = "lib"
-    version = "0.1"
-    scm = {{
-        "type": "git",
-        "url": "{url}",
-        "revision": "{revision}",
-        "submodule": "{submodule}"
-    }}
-'''
-        conanfile = tmp.format(url=path, revision=commit, submodule="invalid")
-        self.client.save({"conanfile.py": conanfile})
-
-        self.client.run("create . --user=user --channel=channel", assert_error=True)
-        self.assertIn("Invalid 'submodule' attribute value in the 'scm'.",
-                      self.client.out)
-
-        # Check shallow
-        conanfile = tmp.format(url=path, revision=commit, submodule="shallow")
-        self.client.save({"conanfile.py": conanfile})
-        self.client.run("create . --user=user --channel=channel")
-
-        ref = RecipeReference.loads("lib/0.1@user/channel")
-        folder = self.client.get_latest_ref_layout(ref).source()
-        submodule_path, subsubmodule_path = _relative_paths(folder)
-        self.assertTrue(os.path.exists(os.path.join(folder, "myfile")))
-        self.assertTrue(os.path.exists(os.path.join(submodule_path, "submodule")))
-        self.assertFalse(os.path.exists(os.path.join(subsubmodule_path, "subsubmodule")))
-
-        # Check recursive
-        conanfile = tmp.format(url=path, revision=commit, submodule="recursive")
-        self.client.save({"conanfile.py": conanfile})
-        self.client.run("create . --user=user --channel=channel")
-
-        ref = RecipeReference.loads("lib/0.1@user/channel")
-        folder = self.client.get_latest_ref_layout(ref).source()
-        submodule_path, subsubmodule_path = _relative_paths(folder)
-        self.assertTrue(os.path.exists(os.path.join(folder, "myfile")))
-        self.assertTrue(os.path.exists(os.path.join(submodule_path, "submodule")))
-        self.assertTrue(os.path.exists(os.path.join(subsubmodule_path, "subsubmodule")))
-
     def test_scm_bad_filename(self):
         # Fixes: #3500
         badfilename = "\xE3\x81\x82badfile.txt"
@@ -515,41 +338,6 @@ class ConanLib(ConanFile):
         self.client.save({"conanfile.py": conanfile})
         self.client.run("create . --user=user --channel=channel")
 
-    def test_source_method_export_sources_and_scm_mixed(self):
-        path, _ = create_local_git_repo({"myfile": "contents"}, branch="my_release")
-
-        conanfile = '''
-import os
-from conan import ConanFile
-from conan.tools.files import save
-
-class ConanLib(ConanFile):
-    name = "lib"
-    version = "0.1"
-    exports_sources = "file.txt"
-    scm = {
-        "type": "git",
-        "url": "%s",
-        "revision": "my_release",
-        "subfolder": "src/nested"
-    }
-
-    def source(self):
-        self.output.warning("SOURCE METHOD CALLED")
-        assert(os.path.exists("file.txt"))
-        assert(os.path.exists(os.path.join("src", "nested", "myfile")))
-        save(self, "cosa.txt", "contents")
-
-    def build(self):
-        assert(os.path.exists("file.txt"))
-        assert(os.path.exists("cosa.txt"))
-        self.output.warning("BUILD METHOD CALLED")
-''' % path
-        self.client.save({"conanfile.py": conanfile, "file.txt": "My file is copied"})
-        self.client.run("create . --user=user --channel=channel")
-        self.assertIn("SOURCE METHOD CALLED", self.client.out)
-        self.assertIn("BUILD METHOD CALLED", self.client.out)
-
     def test_scm_serialization(self):
         data = {"url": "myurl", "revision": "myrevision", "username": "myusername",
                 "password": "mypassword", "type": "git", "verify_ssl": True,
@@ -561,35 +349,6 @@ class ConanLib(ConanFile):
                           ' "subfolder": "mysubfolder", "type": "git", "url": "myurl",' \
                           ' "username": "myusername"}'
         self.assertEqual(str(scm_data), expected_output)
-
-    def test_git_delegated_function(self):
-        conanfile = textwrap.dedent("""
-            import os
-            from conan import ConanFile
-            from conans.client.tools.scm import Git
-
-            def get_revision():
-                here = os.path.dirname(__file__)
-                git = Git(here)
-                return git.get_commit()
-
-            def get_url():
-                def nested_url():
-                    here = os.path.dirname(__file__)
-                    git = Git(here)
-                    return git.get_remote_url()
-                return nested_url()
-
-            class MyLib(ConanFile):
-                name = "issue"
-                version = "3831"
-                scm = {'type': 'git', 'url': get_url(), 'revision': get_revision()}
-            """)
-        commit = self.client.init_git_repo({"conanfile.py": conanfile})
-
-        self.client.run("export . --user=user --channel=channel")
-        scm_info = self.client.scm_info_cache("issue/3831@user/channel")
-        self.assertEqual(commit, scm_info.revision)
 
     def test_git_version(self):
         git = Git()
@@ -738,31 +497,10 @@ class ConanLib(ConanFile):
         self.client.save({"aditional_file.txt": "contents"})
 
         self.client.run("source . --source-folder=./source")
-        self.assertTrue(os.path.exists(os.path.join(curdir, "source", "myfile.txt")))
         self.assertIn("SOURCE METHOD CALLED", self.client.out)
-        # Even the not commited files are copied
-        self.assertTrue(os.path.exists(os.path.join(curdir, "source", "aditional_file.txt")))
-        self.assertIn("SCM: Getting sources from folder: %s" % curdir, self.client.out)
-
-        # Export again but now with absolute reference, so no pointer file is created nor kept
-        svn = SVN(curdir)
-        conanfile = base_svn.format(url=_quoted(svn.get_remote_url()), revision=svn.get_revision())
-        conanfile += """
-    def source(self):
-        self.output.warning("SOURCE METHOD CALLED")
-"""
-        self.client.save({"conanfile.py": conanfile,
-                          "myfile2.txt": "My file is copied"})
-        self.client.run_command("svn add myfile2.txt")
-        self.client.run_command('svn commit -m  "commiting"')
-
-        self.client.run("source . --source-folder=./source2")
-        # myfile2 is no in the specified commit
-        self.assertFalse(os.path.exists(os.path.join(curdir, "source2", "myfile2.txt")))
-        self.assertTrue(os.path.exists(os.path.join(curdir, "source2", "myfile.txt")))
-        self.assertIn("SCM: Getting sources from url: '{}'".format(project_url).lower(),
-                      str(self.client.out).lower())
-        self.assertIn("SOURCE METHOD CALLED", self.client.out)
+        # Files are NOT copied
+        assert not os.path.exists(os.path.join(curdir, "source", "myfile.txt"))
+        assert not os.path.exists(os.path.join(curdir, "source", "aditional_file.txt"))
 
     def test_local_source_subfolder(self):
         curdir = self.client.current_folder
@@ -781,8 +519,8 @@ class ConanLib(ConanFile):
                                                                  path=self.client.current_folder))
 
         self.client.run("source . --source-folder=./source")
-        self.assertFalse(os.path.exists(os.path.join(curdir, "source", "myfile.txt")))
-        self.assertTrue(os.path.exists(os.path.join(curdir, "source", "mysub", "myfile.txt")))
+        assert not os.path.exists(os.path.join(curdir, "source", "myfile.txt"))
+        assert not os.path.exists(os.path.join(curdir, "source", "mysub", "myfile.txt"))
         self.assertIn("SOURCE METHOD CALLED", self.client.out)
 
     def test_install_checked_out(self):
@@ -978,37 +716,6 @@ class SCMBlockUploadTest(unittest.TestCase):
         # The upload with --force should work
         client.run("upload lib/0.1@user/channel -r default --force")
         self.assertIn("Uploading lib/0.1@user/channel", client.out)
-
-    def test_export_blocking_type_none(self):
-        client = TestClient(default_server_user=True)
-        conanfile = textwrap.dedent("""
-            from conan import ConanFile
-            class ConanLib(ConanFile):
-                scm = {
-                    "type": None,
-                    "url": "some url",
-                    "revision": "some_rev",
-                }
-            """)
-        client.save({"conanfile.py": conanfile})
-        client.run("export . --name=pkg --version=0.1 --user=user --channel=channel", assert_error=True)
-        self.assertIn("ERROR: SCM not supported: None", client.out)
-
-    def test_create_blocking_url_none(self):
-        # If URL is None, it cannot create locally, as it will try to clone it
-        client = TestClient()
-        conanfile = textwrap.dedent("""
-            from conan import ConanFile
-            class ConanLib(ConanFile):
-                scm = {
-                    "type": "git",
-                    "url": None,
-                    "revision": "some_rev",
-                }
-            """)
-        client.save({"conanfile.py": conanfile})
-        client.run("create . --name=pkg --version=0.1 --user=user --channel=channel", assert_error=True)
-        self.assertIn("Couldn't checkout SCM:", client.out)
 
     def test_upload_blocking_url_none_revision_auto(self):
         # if the revision is auto and the url is None, it can be created locally, but not uploaded

--- a/conans/test/functional/scm/source/test_run_scm.py
+++ b/conans/test/functional/scm/source/test_run_scm.py
@@ -7,7 +7,7 @@ import mock
 import pytest
 
 from conans.cli.output import ConanOutput
-from conans.client.source import _run_cache_scm, _run_local_scm
+from conans.client.source import _run_cache_scm
 from conans.client.tools.scm import Git
 from conans.model.scm import SCM
 from conans.test.utils.mocks import RedirectedTestOutput
@@ -77,32 +77,3 @@ class RunSCMTest(unittest.TestCase):
                                    scm_sources_folder="/not/existing/path")
 
         self.assertIn("SCM: Getting sources from url: '{}'".format(url), output)
-
-    def test_user_space_with_local_sources(self):
-        output = RedirectedTestOutput()
-        with redirect_output(output):
-            # Need a real repo to get a working SCM object
-            local_sources_path = os.path.join(self.tmp_dir, 'git_repo').replace('\\', '/')
-            create_local_git_repo(files={'file1': "content"}, folder=local_sources_path)
-            git = Git(local_sources_path)
-            url = "https://remote.url"
-            git.run("remote add origin \"{}\"".format(url))
-
-            # Mock the conanfile (return scm_data)
-            conanfile = mock.MagicMock()
-            conanfile.output = ConanOutput()
-            conanfile.scm = {'type': 'git', 'url': 'auto', 'revision': 'auto'}
-
-            # Mock functions called from inside _run_scm (tests will be here)
-            def merge_directories(src, dst, excluded=None):
-                src = os.path.normpath(src)
-                dst = os.path.normpath(dst)
-                self.assertEqual(src.replace('\\', '/'), local_sources_path)
-                self.assertEqual(dst, self.src_folder)
-
-            with mock.patch("conans.client.source.merge_directories", side_effect=merge_directories):
-                _run_local_scm(conanfile, conanfile_folder=local_sources_path,
-                               src_folder=self.src_folder)
-
-            self.assertIn("getting sources from folder: {}".format(local_sources_path).lower(),
-                          str(output).lower())

--- a/conans/test/functional/scm/test_command_export.py
+++ b/conans/test/functional/scm/test_command_export.py
@@ -22,11 +22,10 @@ class ExportErrorCommandTestCase(unittest.TestCase):
                     "revision": "{rev_value}"}}
     """)
 
-    @parameterized.expand(itertools.product(["SVN", "git"], [(True, False), (False, True)]))
-    def test_no_repo(self, repo_type, autos):
-        auto_url, auto_rev = autos
-        url_value = "auto" if auto_url else "http://this.url"
-        rev_value = "auto" if auto_rev else "123"
+    @parameterized.expand(itertools.product(["SVN", "git"],))
+    def test_no_repo(self, repo_type):
+        url_value = "auto"
+        rev_value = "auto"
 
         self.client = TestClient()
         self.client.save({"conanfile.py": self.conanfile.format(repo_type=repo_type.lower(),

--- a/conans/test/functional/scm/test_command_export.py
+++ b/conans/test/functional/scm/test_command_export.py
@@ -49,10 +49,9 @@ class ExportCommandTestCase(unittest.TestCase):
                     "revision": "{rev_value}"}}
     """)
 
-    @parameterized.expand([(True, False), (False, True)])
-    def test_non_existing_remote(self, auto_url, auto_rev):
-        url_value = "auto" if auto_url else "http://this.url"
-        rev_value = "auto" if auto_rev else "123"
+    def test_non_existing_remote(self):
+        url_value = "auto"
+        rev_value = "auto"
 
         self.path, _ = create_local_git_repo({"conanfile.py":
                                               self.conanfile.format(repo_type="git",
@@ -61,6 +60,6 @@ class ExportCommandTestCase(unittest.TestCase):
         self.client = TestClient()
         self.client.current_folder = self.path
         self.client.run("export . --name=lib --version=version --user=user --channel=channel")
-        if auto_url:
-            self.assertIn("WARN: Repo origin cannot be deduced, 'auto' fields won't be replaced.",
-                          self.client.out)
+
+        self.assertIn("WARN: Repo origin cannot be deduced, 'auto' fields won't be replaced.",
+                      self.client.out)

--- a/conans/test/functional/scm/test_git_shallow.py
+++ b/conans/test/functional/scm/test_git_shallow.py
@@ -2,7 +2,6 @@ import textwrap
 import unittest
 
 import pytest
-from parameterized import parameterized
 from parameterized.parameterized import parameterized_class
 
 from conans.model.recipe_ref import RecipeReference
@@ -18,7 +17,7 @@ def test_shallow_none_string():
 
         class Recipe(ConanFile):
             scm = {"type": "git", "url": "https://github.com/repo/library.git",
-                    "revision": "123456", "shallow": 'None' }
+                    "revision": "auto", "shallow": 'None' }
     """)})
 
     client.run('export . --name=name --version=version', assert_error=True)
@@ -71,25 +70,3 @@ class GitShallowTestCase(unittest.TestCase):
             self.assertIn('shallow: null', content)
         else:
             self.assertIn('shallow: false', content)
-
-    # FIXME : https://github.com/conan-io/conan/issues/8449
-    # scm_to_conandata=1 changes behavior for shallow=None
-    @pytest.mark.xfail
-    @parameterized.expand([("c6cc15fa2f4b576bd", False), ("0.22.1", True)])
-    def test_remote_build(self, revision, shallow_works):
-        # Shallow works only with branches or tags
-        # xfail doesn't work (don't know why), just skip manually
-        if self.shallow is "None" and revision == "0.22.1":
-            return
-        client = TestClient()
-        client.save({'conanfile.py':
-                         self.conanfile.format(shallow_attrib=self._shallow_attrib_str(),
-                                               url="https://github.com/conan-io/conan.git",
-                                               rev=revision)})
-
-        client.run(f"create . --name={self.ref.name} --version={self.ref.version} --user={self.ref.user} --channel={self.ref.channel}")
-
-        if self.shallow in [None, True] and shallow_works:
-            self.assertIn(">>> describe-fails", client.out)
-        else:
-            self.assertIn(">>> tags: 0.22.1", client.out)

--- a/conans/test/functional/scm/test_scm_to_conandata.py
+++ b/conans/test/functional/scm/test_scm_to_conandata.py
@@ -18,54 +18,18 @@ from conans.util.files import save_files
 class SCMDataToConanDataTestCase(unittest.TestCase):
     ref = RecipeReference.loads("name/version@")
 
-    def test_plain_recipe(self):
-        conanfile = textwrap.dedent("""
-            import os
-            from conan import ConanFile
-
-            class Recipe(ConanFile):
-                scm = {"type": "git", "url": "myurl", "revision": "myrev",
-                       "username": "myuser", "password": os.environ.get("SECRET", None),
-                       "verify_ssl": False, "shallow": False}
-
-                def init(self):
-                    self.output.info("name: {}".format(self.scm["username"]))
-                    self.output.info("password: {}".format(self.scm["password"]))
-        """)
-        t = TestClient()
-        t.save({'conanfile.py': conanfile})
-        t.run("export . --name=name --version=version")
-
-        # Check exported files
-        ref_layout = t.get_latest_ref_layout(self.ref)
-        exported_conanfile = load(ref_layout.conanfile())
-        self.assertEqual(exported_conanfile, conanfile)
-        exported_conandata = load(ref_layout.conandata())
-        conan_data = yaml.safe_load(exported_conandata)
-        self.assertDictEqual(conan_data['.conan']['scm'],
-                             {"type": "git", "url": "myurl", "revision": "myrev",
-                              "verify_ssl": False, "shallow": False})
-
-        # Check the recipe gets the proper values
-        t.run("install --reference=name/version@", assert_error=True)
-        assert "name/version: name: myuser" in t.out
-        assert "name/version: password: None" in t.out
-        with environment_update({"SECRET": "42"}):
-            t.run("install --reference=name/version@", assert_error=True)
-            assert "name/version: name: myuser" in t.out
-            assert "name/version: password: 42" in t.out
-
     def test_save_special_chars(self):
         conanfile = textwrap.dedent("""
             import os
             from conan import ConanFile
 
             class Recipe(ConanFile):
-                scm = {"type": "git", "url": 'weir"d', "revision": 123,
+                scm = {"type": "git", "url": 'weir"d', "revision": "auto",
                        "subfolder": "weir\\"d", "submodule": "don't"}
         """)
         t = TestClient()
         t.save({'conanfile.py': conanfile})
+        commit = t.init_git_repo()
         t.run("export . --name=name --version=version")
 
         # Check exported files
@@ -75,7 +39,8 @@ class SCMDataToConanDataTestCase(unittest.TestCase):
         exported_conandata = load(ref_layout.conandata())
         conan_data = yaml.safe_load(exported_conandata)
         self.assertDictEqual(conan_data['.conan']['scm'], {"type": "git", "url": 'weir"d',
-                                                           "revision": 123, "subfolder": "weir\"d",
+                                                           "revision": commit,
+                                                           "subfolder": "weir\"d",
                                                            "submodule": "don't"})
 
     @pytest.mark.tool("git")
@@ -107,12 +72,13 @@ class SCMDataToConanDataTestCase(unittest.TestCase):
             from conan import ConanFile
 
             class Recipe(ConanFile):
-                scm = {"type": "git", "url": "myurl", "revision": "myrev",
+                scm = {"type": "git", "url": "myurl", "revision": "auto",
                        "username": "myuser", "password": os.environ.get("SECRET", None),}
         """)
         t = TestClient()
         t.save({'conanfile.py': conanfile,
                 DATA_YML: yaml.safe_dump({'.conan': {'scm_data': {}}}, default_flow_style=False)})
+        t.init_git_repo()
 
         # It fails with it activated
         t.run("export . --name=name --version=version", assert_error=True)
@@ -178,45 +144,29 @@ def test_auto_can_be_automated():
     conanfile = textwrap.dedent("""
         import os
         from conan import ConanFile
+        from conan.tools.files import load, save
 
         class Recipe(ConanFile):
-            scm = {"type": "git",
-                   "url": os.getenv("USER_EXTERNAL_URL", "auto"),
-                   "revision": os.getenv("USER_EXTERNAL_COMMIT", "auto")}
+
+            def export(self):
+                self.output.info("executing export")
+                revision = os.getenv("USER_EXTERNAL_COMMIT")
+                if revision is not None:
+                    path = os.path.join(self.export_folder, "conandata.yml")
+                    conandata = load(self, path)
+                    conandata = conandata.replace("123", revision)
+                    save(self, path, conandata)
+
+            def source(self):
+                self.output.info("USING COMMIT: {}".format(self.conan_data["commit"]))
     """)
     t = TestClient()
-    commit = t.init_git_repo({'conanfile.py': conanfile,
-                              'conandata.yml': ""})
-    t.run_command('git remote add origin https://myrepo.com.git')
-    t.run("export . --name=pkg --version=1.0")
+    t.save({'conanfile.py': conanfile,
+            "conandata.yml": "commit: 123"})
+    t.run("create . --name=pkg --version=1.0")
+    assert "pkg/1.0: USING COMMIT: 123" in t.out
 
-    def _check(client):
-        # Check exported files
-        ref = RecipeReference.loads("pkg/1.0")
-        ref_layout = client.get_latest_ref_layout(ref)
-        assert load(ref_layout.conanfile()) == conanfile
-        exported_conandata = load(ref_layout.conandata())
-        conan_data = yaml.safe_load(exported_conandata)
-        assert conan_data['.conan']['scm'] == {"type": "git",
-                                               "url": 'https://myrepo.com.git',
-                                               "revision": commit}
+    with environment_update({"USER_EXTERNAL_COMMIT": "456"}):
+        t.run("create . --name=pkg --version=1.0")
+        assert "pkg/1.0: USING COMMIT: 456" in t.out
 
-    _check(t)
-
-    # Now try from another folder, doing a copy and using the env-vars
-    t = TestClient(default_server_user=True)
-    t.save({"conanfile.py": conanfile})
-    with environment_update({"USER_EXTERNAL_URL": "https://myrepo.com.git",
-                             "USER_EXTERNAL_COMMIT": commit}):
-        t.run("export . --name=pkg --version=1.0")
-    _check(t)
-
-    t.run("upload * -c -r default --only-recipe")
-    t.run("remove * -f")
-    t.run("install --reference=pkg/1.0@ --build", assert_error=True)
-    assert "pkg/1.0: SCM: Getting sources from url: 'https://myrepo.com.git'" in t.out
-
-    with environment_update({"USER_EXTERNAL_URL": "https://other.different.url",
-                             "USER_EXTERNAL_COMMIT": "invalid commit"}):
-        t.run("install --reference=pkg/1.0@ --build", assert_error=True)
-        assert "pkg/1.0: SCM: Getting sources from url: 'https://myrepo.com.git'" in t.out

--- a/conans/test/functional/scm/test_verify_ssl.py
+++ b/conans/test/functional/scm/test_verify_ssl.py
@@ -17,7 +17,7 @@ def test_verify_ssl_none_string():
 
         class Recipe(ConanFile):
             scm = {"type": "git", "url": "https://github.com/repo/library.git",
-                    "revision": "123456", "verify_ssl": 'None' }
+                    "revision": "auto", "verify_ssl": 'None' }
     """)})
 
     client.run('export . --name=name --version=version', assert_error=True)

--- a/conans/test/functional/scm/workflows/test_conanfile_in_repo_root.py
+++ b/conans/test/functional/scm/workflows/test_conanfile_in_repo_root.py
@@ -48,11 +48,6 @@ class SVNConanfileInRepoRootTest(ConanfileInRepoRoot, SVNLocalRepoTestCase):
         t.run_command("svn co {}/lib1 .".format(self.url))
         self._run_local_test(t, t.current_folder, self.path_to_conanfile)
 
-    def test_local_monorepo(self):
-        t = TestClient(path_with_spaces=False)
-        t.run_command("svn co {} .".format(self.url))
-        self._run_local_test(t, t.current_folder, os.path.join("lib1", self.path_to_conanfile))
-
     def test_local_monorepo_chdir(self):
         t = TestClient(path_with_spaces=False)
         t.run_command("svn co {} .".format(self.url))

--- a/conans/test/functional/scm/workflows/test_conanfile_in_subfolder.py
+++ b/conans/test/functional/scm/workflows/test_conanfile_in_subfolder.py
@@ -51,11 +51,6 @@ class SVNConanfileInSubfolderTest(ConanfileInSubfolder, SVNLocalRepoTestCase):
         t.run_command("svn co {}/lib1 .".format(self.url))
         self._run_local_test(t, t.current_folder, self.path_to_conanfile)
 
-    def test_local_monorepo(self):
-        t = TestClient(path_with_spaces=False)
-        t.run_command("svn co {} .".format(self.url))
-        self._run_local_test(t, t.current_folder, os.path.join("lib1", self.path_to_conanfile))
-
     def test_local_monorepo_chdir(self):
         t = TestClient(path_with_spaces=False)
         t.run_command("svn co {} .".format(self.url))

--- a/conans/test/functional/scm/workflows/test_scm_subfolder.py
+++ b/conans/test/functional/scm/workflows/test_scm_subfolder.py
@@ -60,12 +60,6 @@ class SVNConanfileInRepoRootTest(SCMSubfolder, SVNLocalRepoTestCase):
         files = self.get_files(subfolder='lib1', conanfile=self.conanfile, lib_ref=self.lib1_ref)
         self.url, _ = self.create_project(files=files)
 
-    # Local workflow
-    def test_local_root_folder(self):
-        t = TestClient(path_with_spaces=False)
-        t.run_command("svn co {}/lib1 .".format(self.url))
-        self._run_local_test(t, t.current_folder, self.path_to_conanfile)
-
     def test_remote_monorepo(self):
         t = TestClient(path_with_spaces=False)
         t.run_command("svn co {} .".format(self.url))

--- a/conans/test/functional/scm/workflows/test_scm_subfolder.py
+++ b/conans/test/functional/scm/workflows/test_scm_subfolder.py
@@ -66,22 +66,6 @@ class SVNConanfileInRepoRootTest(SCMSubfolder, SVNLocalRepoTestCase):
         t.run_command("svn co {}/lib1 .".format(self.url))
         self._run_local_test(t, t.current_folder, self.path_to_conanfile)
 
-    def test_local_monorepo(self):
-        t = TestClient(path_with_spaces=False)
-        t.run_command("svn co {} .".format(self.url))
-        self._run_local_test(t, t.current_folder, os.path.join("lib1", self.path_to_conanfile))
-
-    def test_local_monorepo_chdir(self):
-        t = TestClient(path_with_spaces=False)
-        t.run_command("svn co {} .".format(self.url))
-        self._run_local_test(t, os.path.join(t.current_folder, "lib1"), self.path_to_conanfile)
-
-    # Cache workflow
-    def test_remote_root_folder(self):
-        t = TestClient(path_with_spaces=False)
-        t.run_command("svn co {}/lib1 .".format(self.url))
-        self._run_remote_test(t, t.current_folder, self.path_to_conanfile)
-
     def test_remote_monorepo(self):
         t = TestClient(path_with_spaces=False)
         t.run_command("svn co {} .".format(self.url))
@@ -105,12 +89,6 @@ class GitConanfileInRepoRootTest(SCMSubfolder, unittest.TestCase):
         self.lib1_ref = "lib1/version@user/channel"
         files = self.get_files(subfolder=".", conanfile=self.conanfile, lib_ref=self.lib1_ref)
         self.url, _ = create_local_git_repo(files=files)
-
-    # Local workflow
-    def test_local_root_folder(self):
-        t = TestClient(path_with_spaces=False)
-        t.run_command('git clone "{}" .'.format(self.url))
-        self._run_local_test(t, t.current_folder, self.path_to_conanfile)
 
     # Cache workflow
     def test_remote_root_folder(self):

--- a/conans/test/integration/command/info/info_test.py
+++ b/conans/test/integration/command/info/info_test.py
@@ -108,18 +108,19 @@ class TestAdvancedCliOutput:
             class pkg(ConanFile):
                 scm = {"type": "git",
                        "url": "some-url/path",
-                       "revision": "some commit hash"}
+                       "revision": "auto"}
             """)
         client = TestClient()
         client.save({"conanfile.py": conanfile})
+        commit = client.init_git_repo()
 
         client.run("graph info .")
-        assert "revision: some commit hash" in client.out
+        assert "revision: auto" in client.out
         assert "url: some-url/path" in client.out
 
         client.run("export . --name=pkg --version=0.1")
         client.run("graph info --reference=pkg/0.1@")
-        assert "revision: some commit hash" in client.out
+        assert f"revision: {commit}" in client.out
         assert "url: some-url/path" in client.out
 
         client.run("graph info . --format=json")

--- a/conans/test/integration/command/info/info_test.py
+++ b/conans/test/integration/command/info/info_test.py
@@ -1,6 +1,8 @@
 import json
 import textwrap
 
+import pytest
+
 from conans.model.recipe_ref import RecipeReference
 from conans.test.utils.tools import TestClient, GenConanfile, TurboTestClient
 
@@ -101,6 +103,7 @@ class TestJsonOutput:
 class TestAdvancedCliOutput:
     """ Testing more advanced fields output, like SCM or PYTHON-REQUIRES
     """
+    @pytest.mark.tool("git")
     def test_scm_info(self):
         # https://github.com/conan-io/conan/issues/8377
         conanfile = textwrap.dedent("""

--- a/conans/test/integration/command/info/info_test.py
+++ b/conans/test/integration/command/info/info_test.py
@@ -103,7 +103,6 @@ class TestJsonOutput:
 class TestAdvancedCliOutput:
     """ Testing more advanced fields output, like SCM or PYTHON-REQUIRES
     """
-    @pytest.mark.tool("git")
     def test_scm_info(self):
         # https://github.com/conan-io/conan/issues/8377
         conanfile = textwrap.dedent("""
@@ -115,15 +114,9 @@ class TestAdvancedCliOutput:
             """)
         client = TestClient()
         client.save({"conanfile.py": conanfile})
-        commit = client.init_git_repo()
 
         client.run("graph info .")
         assert "revision: auto" in client.out
-        assert "url: some-url/path" in client.out
-
-        client.run("export . --name=pkg --version=0.1")
-        client.run("graph info --reference=pkg/0.1@")
-        assert f"revision: {commit}" in client.out
         assert "url: some-url/path" in client.out
 
         client.run("graph info . --format=json")

--- a/conans/test/integration/scm/test_fields_validation.py
+++ b/conans/test/integration/scm/test_fields_validation.py
@@ -1,5 +1,3 @@
-# coding=utf-8
-
 import textwrap
 import unittest
 
@@ -13,12 +11,13 @@ class SCMDataFieldsValdation(unittest.TestCase):
             from conan import ConanFile
 
             class Lib(ConanFile):
-                scm = {"type": "git", "revision": "123", "username": True}
+                scm = {"type": "git", "revision": "auto", "username": True}
         """)
 
         client = TestClient()
         client.save({'conanfile.py': conanfile})
-        client.run("export . --name=name --version=version --user=user --channel=channel", assert_error=True)
+        client.run("export . --name=name --version=version --user=user --channel=channel",
+                   assert_error=True)
 
         self.assertIn("ERROR: SCM value for 'username' must be of"
                       " type 'str' (found 'bool')", client.out)
@@ -33,34 +32,23 @@ class SCMDataFieldsValdation(unittest.TestCase):
 
         client = TestClient()
         client.save({'conanfile.py': conanfile})
-        client.run("export . --name=name --version=version --user=user --channel=channel", assert_error=True)
+        client.run("export . --name=name --version=version --user=user --channel=channel",
+                   assert_error=True)
 
-        self.assertIn("ERROR: SCM value for 'revision' must be of type"
-                      " 'str' or 'int' (found 'bool')", client.out)
+        self.assertIn("'scm' can only be used for 'auto'", client.out)
 
     def test_fail_boolean(self):
         conanfile = textwrap.dedent("""
             from conan import ConanFile
 
             class Lib(ConanFile):
-                scm = {"type": "git", "revision": "123", "verify_ssl": "True"}
+                scm = {"type": "git", "revision": "auto", "verify_ssl": "True"}
         """)
 
         client = TestClient()
         client.save({'conanfile.py': conanfile})
-        client.run("export . --name=name --version=version --user=user --channel=channel", assert_error=True)
+        client.run("export . --name=name --version=version --user=user --channel=channel",
+                   assert_error=True)
 
         self.assertIn("ERROR: SCM value for 'verify_ssl' must be of type 'bool' (found 'str')",
                       client.out)
-
-    def test_ok_none(self):
-        conanfile = textwrap.dedent("""
-            from conan import ConanFile
-
-            class Lib(ConanFile):
-                scm = {"type": "git", "revision": None, "shallow": False}
-        """)
-
-        client = TestClient()
-        client.save({'conanfile.py': conanfile})
-        client.run("export . --name=name --version=version --user=user --channel=channel")

--- a/conans/test/integration/scm/workflows/common.py
+++ b/conans/test/integration/scm/workflows/common.py
@@ -57,7 +57,7 @@ class TestWorkflow(object):
             path_to_conanfile = path_to_conanfile.replace('\\', '/')
             t.current_folder = working_dir
             t.run("install {}".format(path_to_conanfile))
-            t.run("source {} -sf src".format(path_to_conanfile))
+            t.run("source {}".format(path_to_conanfile))
             self.assertIn(">>>> I'm None/None@user/channel".format(self.lib1_ref), t.out)
             self.assertIn(">>>> content: {}".format(self.lib1_ref), t.out)
         finally:

--- a/conans/test/unittests/model/scm/scm_data_test.py
+++ b/conans/test/unittests/model/scm/scm_data_test.py
@@ -46,7 +46,7 @@ class GetDictValueTestCase(unittest.TestCase):
 
 class SCMDataToStringTestCase(unittest.TestCase):
     data = {"url": "http://my.url",
-            "revision": 123,
+            "revision": "123",
             "shallow": False,
             "username": 'weir"d',
             "type": "weir\"d",


### PR DESCRIPTION
As we have discussed, the local scm checkout doesn't make sense:

- scm is for "auto" capture only, and later retrieval
- otherwise use the ``source()`` method with some conandata.yml data.
Related https://github.com/conan-io/conan/issues/10503