### PR TITLE
pylint: add recipe_folder member

### DIFF
--- a/conans/pylint_plugin.py
+++ b/conans/pylint_plugin.py
@@ -35,6 +35,7 @@ def transform_conanfile(node):
         "copy": file_copier_class,
         "copy_deps": file_importer_class,
         "python_requires": [str_class, python_requires_class],
+        "recipe_folder": str_class,
     }
 
     for f, t in dynamic_fields.items():


### PR DESCRIPTION
it is created dynamically in conans/client/loader.py#L71

Changelog: Feature: Add ``recipe_folder`` to pylint plugin.
Docs: Omit

- [ ] Refer to the issue that supports this Pull Request.
- [ ] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 

<sup>**Note:** By default this PR will skip the slower tests and will use a limited set of python versions. Check [here](https://github.com/conan-io/conan/blob/develop/.github/PR_INCREASE_TESTING.md) how to increase the testing level by writing some tags in the current PR body text.</sup>
