### PR TITLE
Ported copy tool from develop2

### DIFF
--- a/conan/tools/files/__init__.py
+++ b/conan/tools/files/__init__.py
@@ -4,3 +4,4 @@ from conan.tools.files.patches import patch, apply_conandata_patches
 from conan.tools.files.cpp_package import CppPackage
 from conan.tools.files.packager import AutoPackager
 from conan.tools.files.symlinks import symlinks
+from conan.tools.files.copy_pattern import copy

--- a/conan/tools/files/copy_pattern.py
+++ b/conan/tools/files/copy_pattern.py
@@ -1,0 +1,226 @@
+import fnmatch
+import os
+import shutil
+from collections import defaultdict
+
+from conans.util.files import mkdir
+
+
+def copy(conanfile, pattern, src, dst, keep_path=True, excludes=None,
+         ignore_case=True, copy_symlink_folders=True):
+    #  FIXME: Simplify this removing the FileCopier class and moving to simple methods
+    file_copier = _FileCopier([src], dst)
+    copied = file_copier(pattern, keep_path=keep_path, excludes=excludes,
+                         ignore_case=ignore_case, copy_symlink_folders=copy_symlink_folders)
+    # FIXME: Not always passed conanfile
+    if conanfile:
+        report_copied_files(copied, conanfile.output)
+    return copied
+
+
+# FIXME: Transform to functions, without several origins
+class _FileCopier(object):
+    """ main responsible of copying files from place to place:
+    package: build folder -> package folder
+    export: user folder -> store "export" folder
+    """
+    def __init__(self, source_folders, root_destination_folder):
+        """
+        Takes the base folders to copy resources src -> dst. These folders names
+        will not be used in the relative names while copying
+        param source_folders: list of folders to copy things from, typically the
+                                  store build folder
+        param root_destination_folder: The base folder to copy things to, typically the
+                                       store package folder
+        """
+        assert isinstance(source_folders, list), "source folders must be a list"
+        self._src_folders = source_folders
+        self._dst_folder = root_destination_folder
+        self._copied = []
+
+    def report(self, scoped_output):
+        return report_copied_files(self._copied, scoped_output)
+
+    def __call__(self, pattern, dst="", src="", keep_path=True, excludes=None, ignore_case=True,
+                 copy_symlink_folders=True):
+        """
+        It will copy the files matching the pattern from the src folder to the dst, including the
+        symlinks to files. If a folder from "src" doesn't contain any file to be copied, it won't be
+        created empty at the "dst".
+        If in "src" there are symlinks to folders, they will be created at "dst" irrespective if
+        they (or the folder where points) have files to be copied or not, unless
+        "copy_symlink_folders=False" is specified.
+
+        param pattern: an fnmatch file pattern of the files that should be copied. Eg. *.dll
+        param dst: the destination local folder, wrt to current conanfile dir, to which
+                   the files will be copied. Eg: "bin"
+        param src: the source folder in which those files will be searched. This folder
+                   will be stripped from the dst name. Eg.: lib/Debug/x86
+        param keep_path: False if you want the relative paths to be maintained from
+                         src to dst folders, or just drop. False is useful if you want
+                         to collect e.g. many *.libs among many dirs into a single
+                         lib dir
+        param excludes: Single pattern or a tuple of patterns to be excluded from the copy
+        param ignore_case: will do a case-insensitive pattern matching when True
+        param copy_symlink_folders: Copy the symlink folders at the "dst" folder.
+
+        return: list of copied files
+        """
+
+        if os.path.isabs(src):
+            # Avoid repeatedly copying absolute paths
+            return self._copy(os.curdir, pattern, src, dst, ignore_case, excludes, keep_path,
+                              excluded_folders=[self._dst_folder],
+                              copy_symlink_folders=copy_symlink_folders)
+
+        files = []
+        for src_folder in self._src_folders:
+            excluded = [self._dst_folder]
+            excluded.extend([d for d in self._src_folders if d is not src_folder])
+            fs = self._copy(src_folder, pattern, src, dst, ignore_case, excludes, keep_path,
+                            excluded_folders=excluded, copy_symlink_folders=copy_symlink_folders)
+            files.extend(fs)
+
+        return files
+
+    def _copy(self, base_src, pattern, src, dst, ignore_case, excludes, keep_path,
+              excluded_folders, copy_symlink_folders):
+        # Check for ../ patterns and allow them
+        if pattern.startswith(".."):
+            rel_dir = os.path.abspath(os.path.join(base_src, pattern))
+            base_src = os.path.dirname(rel_dir)
+            pattern = os.path.basename(rel_dir)
+
+        src = os.path.join(base_src, src)
+        dst = os.path.join(self._dst_folder, dst)
+        if src == dst:
+            return []
+
+        files_to_copy, symlinked_folders = self._filter_files(src, pattern, excludes, ignore_case,
+                                                              excluded_folders)
+
+        copied_files = self._copy_files(files_to_copy, src, dst, keep_path)
+        if copy_symlink_folders:
+            self._create_symlinked_folders(src, dst, symlinked_folders)
+
+        self._copied.extend(files_to_copy)
+        return copied_files
+
+    @staticmethod
+    def _create_symlinked_folders(src, dst, symlinked_folders):
+        """If in the src folder there are folders that are symlinks, create them in the dst folder
+           pointing exactly to the same place."""
+        for folder in symlinked_folders:
+            relative_path = os.path.relpath(folder, src)
+            symlink_path = os.path.join(dst, relative_path)
+            # We create the same symlink in dst, no matter if it is absolute or relative
+            link_dst = os.readlink(folder)  # This could be perfectly broken
+
+            # Create the parent directory that will contain the symlink file
+            mkdir(os.path.dirname(symlink_path))
+            # If the symlink is already there, remove it (multiple copy(*.h) copy(*.dll))
+            if os.path.islink(symlink_path):
+                os.unlink(symlink_path)
+            os.symlink(link_dst, symlink_path)
+
+    @staticmethod
+    def _filter_files(src, pattern, excludes, ignore_case, excluded_folders):
+
+        """ return a list of the files matching the patterns
+        The list will be relative path names wrt to the root src folder
+        """
+        filenames = []
+        symlinked_folders = []
+
+        if excludes:
+            if not isinstance(excludes, (tuple, list)):
+                excludes = (excludes, )
+            if ignore_case:
+                excludes = [e.lower() for e in excludes]
+        else:
+            excludes = []
+
+        for root, subfolders, files in os.walk(src, followlinks=True):
+            if root in excluded_folders:
+                subfolders[:] = []
+                continue
+
+            if os.path.islink(root):
+                symlinked_folders.append(root)
+                # This is a symlink folder, the symlink will be copied, so stop iterating this folder
+                subfolders[:] = []
+                continue
+
+            relative_path = os.path.relpath(root, src)
+            compare_relative_path = relative_path.lower() if ignore_case else relative_path
+            for exclude in excludes:
+                if fnmatch.fnmatch(compare_relative_path, exclude):
+                    subfolders[:] = []
+                    files = []
+                    break
+            for f in files:
+                relative_name = os.path.normpath(os.path.join(relative_path, f))
+                filenames.append(relative_name)
+
+        if ignore_case:
+            pattern = pattern.lower()
+            files_to_copy = [n for n in filenames if fnmatch.fnmatch(os.path.normpath(n.lower()),
+                                                                     pattern)]
+        else:
+            files_to_copy = [n for n in filenames if fnmatch.fnmatchcase(os.path.normpath(n),
+                                                                         pattern)]
+
+        for exclude in excludes:
+            if ignore_case:
+                files_to_copy = [f for f in files_to_copy if not fnmatch.fnmatch(f.lower(), exclude)]
+            else:
+                files_to_copy = [f for f in files_to_copy if not fnmatch.fnmatchcase(f, exclude)]
+
+        return files_to_copy, symlinked_folders
+
+    @staticmethod
+    def _copy_files(files, src, dst, keep_path):
+        """ executes a multiple file copy from [(src_file, dst_file), (..)]
+        managing symlinks if necessary
+        """
+        copied_files = []
+        for filename in files:
+            abs_src_name = os.path.join(src, filename)
+            filename = filename if keep_path else os.path.basename(filename)
+            abs_dst_name = os.path.normpath(os.path.join(dst, filename))
+            try:
+                os.makedirs(os.path.dirname(abs_dst_name))
+            except Exception:
+                pass
+            if os.path.islink(abs_src_name):
+                linkto = os.readlink(abs_src_name)  # @UndefinedVariable
+                try:
+                    os.remove(abs_dst_name)
+                except OSError:
+                    pass
+                os.symlink(linkto, abs_dst_name)  # @UndefinedVariable
+            else:
+                shutil.copy2(abs_src_name, abs_dst_name)
+            copied_files.append(abs_dst_name)
+        return copied_files
+
+
+# FIXME: This doesn't belong here
+def report_copied_files(copied, scoped_output, message_suffix="Copied"):
+    ext_files = defaultdict(list)
+    for f in copied:
+        _, ext = os.path.splitext(f)
+        ext_files[ext].append(os.path.basename(f))
+
+    if not ext_files:
+        return False
+
+    for ext, files in ext_files.items():
+        files_str = (": " + ", ".join(files)) if len(files) < 5 else ""
+        file_or_files = "file" if len(files) == 1 else "files"
+        if not ext:
+            scoped_output.info("%s %d %s%s" % (message_suffix, len(files), file_or_files, files_str))
+        else:
+            scoped_output.info("%s %d '%s' %s%s"
+                               % (message_suffix, len(files), ext, file_or_files, files_str))
+    return True

--- a/conans/test/unittests/tools/files/test_tool_copy.py
+++ b/conans/test/unittests/tools/files/test_tool_copy.py
@@ -1,0 +1,263 @@
+import mock
+import os
+import platform
+import unittest
+
+import pytest
+
+from conan.tools.files import copy
+from conans.test.utils.test_files import temp_folder
+from conans.util.files import load, save
+
+
+class ToolCopyTest(unittest.TestCase):
+
+    def test_basic(self):
+        folder1 = temp_folder()
+        sub1 = os.path.join(folder1, "subdir1")
+        sub2 = os.path.join(folder1, "subdir2")
+        save(os.path.join(sub1, "file1.txt"), "hello1")
+        save(os.path.join(sub1, "file2.c"), "Hello2")
+        save(os.path.join(sub1, "sub1/file1.txt"), "Hello1 sub")
+        save(os.path.join(sub1, "sub1/file2.c"), "Hello2 sub")
+        save(os.path.join(sub2, "file1.txt"), "2 Hello1")
+        save(os.path.join(sub2, "file2.c"), "2 Hello2")
+
+        folder2 = temp_folder()
+        copy(None, "*.txt", folder1, os.path.join(folder2, "texts"))
+        self.assertEqual("hello1", load(os.path.join(folder2, "texts/subdir1/file1.txt")))
+        self.assertEqual("Hello1 sub", load(os.path.join(folder2, "texts/subdir1/sub1/file1.txt")))
+        self.assertEqual("2 Hello1", load(os.path.join(folder2, "texts/subdir2/file1.txt")))
+        self.assertEqual(['file1.txt'], os.listdir(os.path.join(folder2, "texts/subdir2")))
+
+        folder2 = temp_folder()
+        copy(None, "*.txt", os.path.join(folder1, "subdir1"), os.path.join(folder2, "texts"))
+        self.assertEqual("hello1", load(os.path.join(folder2, "texts/file1.txt")))
+        self.assertEqual("Hello1 sub", load(os.path.join(folder2, "texts/sub1/file1.txt")))
+        self.assertNotIn("subdir2", os.listdir(os.path.join(folder2, "texts")))
+
+    @pytest.mark.skipif(platform.system() == "Windows", reason="Requires Symlinks")
+    def test_basic_with_linked_dir(self):
+        folder1 = temp_folder()
+        sub1 = os.path.join(folder1, "subdir1")
+        sub2 = os.path.join(folder1, "subdir2")
+        os.makedirs(sub1)
+        os.symlink("subdir1", sub2)
+        save(os.path.join(sub1, "file1.txt"), "hello1")
+        save(os.path.join(sub1, "file2.c"), "Hello2")
+        save(os.path.join(sub1, "sub1/file1.txt"), "Hello1 sub")
+        folder2 = temp_folder()
+        copy(None, "*.txt", folder1, os.path.join(folder2, "texts"))
+        self.assertEqual(os.readlink(os.path.join(folder2, "texts/subdir2")), "subdir1")
+        self.assertEqual("hello1", load(os.path.join(folder2, "texts/subdir1/file1.txt")))
+        self.assertEqual("Hello1 sub", load(os.path.join(folder2,
+                                                         "texts/subdir1/sub1/file1.txt")))
+        self.assertEqual("hello1", load(os.path.join(folder2, "texts/subdir2/file1.txt")))
+        self.assertEqual(['file1.txt', 'sub1'].sort(),
+                         os.listdir(os.path.join(folder2, "texts/subdir2")).sort())
+
+        folder2 = temp_folder()
+        copy(None, "*.txt", os.path.join(folder1, "subdir1"), os.path.join(folder2, "texts"))
+        self.assertEqual("hello1", load(os.path.join(folder2, "texts/file1.txt")))
+        self.assertEqual("Hello1 sub", load(os.path.join(folder2, "texts/sub1/file1.txt")))
+        self.assertNotIn("subdir2", os.listdir(os.path.join(folder2, "texts")))
+
+    @pytest.mark.skipif(platform.system() == "Windows", reason="Requires Symlinks")
+    def test_linked_folder_missing_error(self):
+        folder1 = temp_folder()
+        sub1 = os.path.join(folder1, "subdir1")
+        sub2 = os.path.join(folder1, "subdir2")
+        os.makedirs(sub1)
+        os.symlink("subdir1", sub2)  # @UndefinedVariable
+        save(os.path.join(sub1, "file1.txt"), "hello1")
+        save(os.path.join(sub1, "file2.c"), "Hello2")
+        save(os.path.join(sub1, "sub1/file1.txt"), "Hello1 sub")
+
+        folder2 = temp_folder()
+        copy(None, "*.cpp", folder1, folder2)
+        # If we don't specify anything, the "subdir2" (symlinked folder) will be there even if it
+        # points to an empty folder
+        self.assertEqual(os.listdir(folder2), ["subdir2"])
+        sub2_abs = os.path.join(folder2, "subdir2")
+        assert os.path.islink(sub2_abs)
+        assert os.readlink(sub2_abs) == "subdir1"
+
+        # If we specify anything, the "subdir2" (symlinked folder) will be there even if it
+        # points to an empty folder
+        os.remove(sub2_abs)
+        copy(None, "*.cpp", folder1, folder2, copy_symlink_folders=False)
+        self.assertEqual(os.listdir(folder2), [])
+
+        copy(None, "*.txt", folder1, folder2)
+        self.assertEqual(sorted(os.listdir(folder2)), sorted(["subdir1", "subdir2"]))
+        self.assertEqual(os.readlink(os.path.join(folder2, "subdir2")), "subdir1")
+        self.assertEqual("hello1", load(os.path.join(folder2, "subdir1/file1.txt")))
+        self.assertEqual("hello1", load(os.path.join(folder2, "subdir2/file1.txt")))
+
+    @pytest.mark.skipif(platform.system() == "Windows", reason="Requires Symlinks")
+    def test_linked_relative(self):
+        folder1 = temp_folder()
+        sub1 = os.path.join(folder1, "foo/other/file")
+        save(os.path.join(sub1, "file.txt"), "Hello")
+        sub2 = os.path.join(folder1, "foo/symlink")
+        os.symlink("other/file", sub2)  # @UndefinedVariable
+
+        folder2 = temp_folder()
+        copy(None, "*", folder1, folder2)
+        symlink = os.path.join(folder2, "foo", "symlink")
+        self.assertTrue(os.path.islink(symlink))
+        self.assertTrue(load(os.path.join(symlink, "file.txt")), "Hello")
+
+    @pytest.mark.skipif(platform.system() == "Windows", reason="Requires Symlinks")
+    def test_linked_folder_nested(self):
+        # https://github.com/conan-io/conan/issues/2959
+        folder1 = temp_folder()
+        sub1 = os.path.join(folder1, "lib/icu/60.2")
+        sub2 = os.path.join(folder1, "lib/icu/current")
+        os.makedirs(sub1)
+        os.symlink("60.2", sub2)  # @UndefinedVariable
+
+        folder2 = temp_folder()
+        copied = copy(None, "*.cpp", folder1, folder2)
+        self.assertEqual(copied, [])
+
+    @pytest.mark.skipif(platform.system() == "Windows", reason="Requires Symlinks")
+    def test_linked_folder_copy_from_linked_folder(self):
+        # https://github.com/conan-io/conan/issues/5114
+        folder1 = temp_folder(path_with_spaces=False)
+        sub_src = os.path.join(folder1, "sub/src")
+
+        src = os.path.join(folder1, "src")
+        src_dir = os.path.join(folder1, "src/dir")
+        src_dir_link = os.path.join(folder1, "src/dir_link")
+        src_dir_file = os.path.join(src_dir, "file.txt")
+
+        dst = os.path.join(folder1, "dst")
+        dst_dir = os.path.join(folder1, "dst/dir")
+        dst_dir_link = os.path.join(folder1, "dst/dir_link")
+        dst_dir_file = os.path.join(dst_dir, "file.txt")
+
+        os.makedirs(dst)
+        os.makedirs(sub_src)
+        # input src folder should be a symlink
+        os.symlink(sub_src, src)
+        # folder, file and folder link to copy
+        os.mkdir(src_dir)
+        save(src_dir_file, "file")
+        os.symlink(src_dir, src_dir_link)
+
+        copied = copy(None, "*", src, dst)
+
+        self.assertEqual(copied, [dst_dir_file])
+        self.assertEqual(os.listdir(dst), os.listdir(src))
+        self.assertTrue(os.path.islink(dst_dir_link))
+
+    def test_excludes(self):
+        folder1 = temp_folder()
+        sub1 = os.path.join(folder1, "subdir1")
+        save(os.path.join(sub1, "file1.txt"), "hello1")
+        save(os.path.join(sub1, "file2.c"), "Hello2")
+
+        folder2 = temp_folder()
+        copy(None, "*.*", folder1, os.path.join(folder2, "texts"), excludes="*.c")
+        self.assertEqual(['file1.txt'], os.listdir(os.path.join(folder2, "texts/subdir1")))
+
+        folder1 = temp_folder()
+        save(os.path.join(folder1, "MyLib.txt"), "")
+        save(os.path.join(folder1, "MyLibImpl.txt"), "")
+        save(os.path.join(folder1, "MyLibTests.txt"), "")
+        folder2 = temp_folder()
+        copy(None, "*.txt", folder1, folder2, excludes="*Test*.txt")
+        self.assertEqual({'MyLib.txt', 'MyLibImpl.txt'}, set(os.listdir(folder2)))
+
+        folder2 = temp_folder()
+        copy(None, "*.txt", folder1, folder2, excludes=("*Test*.txt", "*Impl*"))
+        self.assertEqual(['MyLib.txt'], os.listdir(folder2))
+
+    def test_excludes_camelcase_folder(self):
+        # https://github.com/conan-io/conan/issues/8153
+        folder1 = temp_folder()
+        save(os.path.join(folder1, "UPPER.txt"), "")
+        save(os.path.join(folder1, "lower.txt"), "")
+        sub2 = os.path.join(folder1, "CamelCaseIgnore")
+        save(os.path.join(sub2, "file3.txt"), "")
+
+        folder2 = temp_folder()
+        copy(None, "*", folder1, folder2, excludes=["CamelCaseIgnore", "UPPER.txt"])
+        self.assertFalse(os.path.exists(os.path.join(folder2, "CamelCaseIgnore")))
+        self.assertFalse(os.path.exists(os.path.join(folder2, "UPPER.txt")))
+        self.assertTrue(os.path.exists(os.path.join(folder2, "lower.txt")))
+
+        folder2 = temp_folder()
+        copy(None, "*", folder1, folder2)
+        self.assertTrue(os.path.exists(os.path.join(folder2, "CamelCaseIgnore")))
+        self.assertTrue(os.path.exists(os.path.join(folder2, "UPPER.txt")))
+        self.assertTrue(os.path.exists(os.path.join(folder2, "lower.txt")))
+
+    def test_multifolder(self):
+        src_folder1 = temp_folder()
+        src_folder2 = temp_folder()
+        save(os.path.join(src_folder1, "file1.txt"), "hello1")
+        save(os.path.join(src_folder2, "file2.txt"), "Hello2")
+
+        dst_folder = temp_folder()
+        copy(None, "*", src_folder1, dst_folder)
+        copy(None, "*", src_folder2, dst_folder)
+        self.assertEqual(['file1.txt', 'file2.txt'],
+                         sorted(os.listdir(dst_folder)))
+
+    @mock.patch('shutil.copy2')
+    def test_avoid_repeat_copies(self, copy2_mock):
+        src_folders = [temp_folder() for _ in range(2)]
+        for index, src_folder in enumerate(src_folders):
+            save(os.path.join(src_folder, "sub", "file%d.txt" % index),
+                 "Hello%d" % index)
+
+        dst_folder = temp_folder()
+
+        for src_folder in src_folders:
+            copy(None, "*", os.path.join(src_folder, "sub"), dst_folder)
+
+        self.assertEqual(copy2_mock.call_count, len(src_folders))
+
+    def test_ignore_case(self):
+        src_folder = temp_folder()
+        save(os.path.join(src_folder, "FooBar.txt"), "Hello")
+
+        dst_folder = temp_folder()
+        copy(None, "foobar.txt", src_folder, dst_folder, ignore_case=False)
+        self.assertEqual([], os.listdir(dst_folder))
+
+        dst_folder = temp_folder()
+        copy(None, "FooBar.txt", src_folder, dst_folder, ignore_case=False)
+        self.assertEqual(["FooBar.txt"], os.listdir(dst_folder))
+
+        dst_folder = temp_folder()
+        copy(None, "foobar.txt", src_folder, dst_folder, ignore_case=True)
+        self.assertEqual(["FooBar.txt"], os.listdir(dst_folder))
+
+    def test_ignore_case_excludes(self):
+        src_folder = temp_folder()
+        save(os.path.join(src_folder, "file.h"), "")
+        save(os.path.join(src_folder, "AttributeStorage.h"), "")
+        save(os.path.join(src_folder, "sub/file.h"), "")
+        save(os.path.join(src_folder, "sub/AttributeStorage.h"), "")
+
+        dst_folder = temp_folder()
+        # Exclude pattern will match AttributeStorage
+        copy(None, "*.h", src_folder, os.path.join(dst_folder, "include"),
+             excludes="*Test*")
+        self.assertEqual(["include"], os.listdir(dst_folder))
+        self.assertEqual(sorted(["file.h", "sub"]),
+                         sorted(os.listdir(os.path.join(dst_folder, "include"))))
+        self.assertEqual(["file.h"], os.listdir(os.path.join(dst_folder, "include", "sub")))
+
+        dst_folder = temp_folder()
+        # Exclude pattern will not match AttributeStorage if ignore_case=False
+        copy(None, "*.h", src_folder, os.path.join(dst_folder, "include"), excludes="*Test*",
+             ignore_case=False)
+        self.assertEqual(["include"], os.listdir(dst_folder))
+        self.assertEqual(sorted(["AttributeStorage.h", "file.h", "sub"]),
+                         sorted(os.listdir(os.path.join(dst_folder, "include"))))
+        self.assertEqual(sorted(["AttributeStorage.h", "file.h"]),
+                         sorted(os.listdir(os.path.join(dst_folder, "include", "sub"))))


### PR DESCRIPTION
Changelog: Feature: New `copy` tool at `conan.tools.files` namespace that will replace the `self.copy` in Conan 2.0.
Docs: https://github.com/conan-io/docs/pull/2428
Document the migration plan of self.copy, no imports, no deploy.

Close https://github.com/conan-io/conan/issues/10529