### PR TITLE
refactor to prepare for better compatible_packages

### DIFF
--- a/conans/cli/api/subapi/list.py
+++ b/conans/cli/api/subapi/list.py
@@ -56,6 +56,8 @@ class ListAPI:
             refs = app.cache.get_package_revisions_references(pref, only_latest_prev=False)
             results = []
             for ref in refs:
+                # TODO: Why another call, and why get_package_revisions_references doesn't return
+                #  already the timestamps?
                 timestamp = app.cache.get_package_timestamp(ref)
                 ref.timestamp = timestamp
                 results.append(ref)

--- a/conans/client/graph/graph.py
+++ b/conans/client/graph/graph.py
@@ -188,9 +188,6 @@ class Node(object):
     def neighbors(self):
         return [edge.dst for edge in self.dependencies]
 
-    def private_neighbors(self):
-        return [edge.dst for edge in self.dependencies if edge.private]
-
     def inverse_neighbors(self):
         return [edge.src for edge in self.dependants]
 

--- a/conans/client/graph/graph_binaries.py
+++ b/conans/client/graph/graph_binaries.py
@@ -191,7 +191,6 @@ class GraphBinariesAnalyzer(object):
 
     def _evaluate_in_cache(self, cache_latest_prev, node):
         assert cache_latest_prev.revision
-        pref = node.pref
         if self._app.update:
             output = node.conanfile.output
             try:
@@ -205,7 +204,7 @@ class GraphBinariesAnalyzer(object):
                 # cache_time = self._cache.get_package_timestamp(cache_latest_prev)
                 cache_time = cache_latest_prev.timestamp
                 # TODO: cache 2.0 should we update the date if the prev is the same?
-                if cache_time < node.pref_timestamp and cache_latest_prev != pref:
+                if cache_time < node.pref_timestamp and cache_latest_prev != node.pref:
                     node.binary = BINARY_UPDATE
                     output.info("Current package revision is older than the remote one")
                 else:
@@ -219,7 +218,7 @@ class GraphBinariesAnalyzer(object):
             node.binary = BINARY_CACHE
             node.binary_remote = None
             node.prev = cache_latest_prev.revision
-            assert node.prev, "PREV for %s is None" % str(pref)
+            assert node.prev, "PREV for %s is None" % str(node.pref)
 
     def _evaluate_package_id(self, node):
         compute_package_id(node, self._cache.new_config)  # TODO: revise compute_package_id()

--- a/conans/test/integration/export_sources_test.py
+++ b/conans/test/integration/export_sources_test.py
@@ -210,37 +210,6 @@ class ExportsSourcesTest(unittest.TestCase):
         self.assertEqual(scan_folder(export_src_folder or self.export_sources_folder),
                          sorted(expected_src_exports))
 
-    def _check_manifest(self, mode):
-        manifest = load(os.path.join(self.client.current_folder,
-                                     ".conan_manifests/hello/0.1/lasote/testing/export/"
-                                     "conanmanifest.txt"))
-
-        if mode == "exports_sources":
-            self.assertIn("%s/hello.h: 5d41402abc4b2a76b9719d911017c592" % EXPORT_SRC_FOLDER,
-                          manifest.splitlines())
-        elif mode == "exports":
-            self.assertIn("hello.h: 5d41402abc4b2a76b9719d911017c592",
-                          manifest.splitlines())
-        elif mode == "both":
-            self.assertIn("data.txt: 8d777f385d3dfec8815d20f7496026dc", manifest.splitlines())
-            self.assertIn("%s/hello.h: 5d41402abc4b2a76b9719d911017c592" % EXPORT_SRC_FOLDER,
-                          manifest.splitlines())
-        elif mode == "nested":
-            self.assertIn("src/data.txt: 8d777f385d3dfec8815d20f7496026dc",
-                          manifest.splitlines())
-            self.assertIn("%s/src/hello.h: 5d41402abc4b2a76b9719d911017c592" % EXPORT_SRC_FOLDER,
-                          manifest.splitlines())
-        else:
-            assert mode == "overlap"
-            self.assertIn("src/data.txt: 8d777f385d3dfec8815d20f7496026dc",
-                          manifest.splitlines())
-            self.assertIn("src/hello.h: 5d41402abc4b2a76b9719d911017c592",
-                          manifest.splitlines())
-            self.assertIn("%s/src/hello.h: 5d41402abc4b2a76b9719d911017c592" % EXPORT_SRC_FOLDER,
-                          manifest.splitlines())
-            self.assertIn("%s/src/data.txt: 8d777f385d3dfec8815d20f7496026dc" % EXPORT_SRC_FOLDER,
-                          manifest.splitlines())
-
     def _create_code(self, mode):
         if mode == "exports":
             conanfile = conanfile_py

--- a/conans/test/integration/package_id/test_validate.py
+++ b/conans/test/integration/package_id/test_validate.py
@@ -68,7 +68,6 @@ class TestValidate(unittest.TestCase):
 
         client.run("create . --name=pkg --version=0.1 -s os=Windows", assert_error=True)
         self.assertIn("pkg/0.1: Invalid: Windows not supported", client.out)
-        print(client.out)
         client.assert_listed_binary({"pkg/0.1": ("cf2e4ff978548fafd099ad838f9ecb8858bf25cb",
                                                  "Invalid")})
         client.run("graph info --reference=pkg/0.1@ -s os=Windows")


### PR DESCRIPTION
It should be a pure refactor of ``GraphBinariesAnalyzer``, trying to clarify the different binary package resolution, and isolating a bit better the ``compatible_packages`` code, in order to improve it a little bit (for invalid packages, and external compatibility definition)