### PR TITLE
changing CMakeToolchain message to Verbose

### DIFF
--- a/conan/tools/cmake/toolchain.py
+++ b/conan/tools/cmake/toolchain.py
@@ -795,7 +795,7 @@ class CMakeToolchain(object):
         #   CMAKE_CXX_FLAGS. See https://github.com/android/ndk/issues/323
         include_guard()
 
-        message(VERBOSE "Using Conan toolchain: ${CMAKE_CURRENT_LIST_FILE}")
+        message(STATUS "Using Conan toolchain: ${CMAKE_CURRENT_LIST_FILE}")
 
         if(${CMAKE_VERSION} VERSION_LESS "3.15")
             message(FATAL_ERROR "The 'CMakeToolchain' generator only works with CMake >= 3.15")

--- a/conan/tools/cmake/toolchain.py
+++ b/conan/tools/cmake/toolchain.py
@@ -795,9 +795,7 @@ class CMakeToolchain(object):
         #   CMAKE_CXX_FLAGS. See https://github.com/android/ndk/issues/323
         include_guard()
 
-        if(CMAKE_TOOLCHAIN_FILE)
-            message("Using Conan toolchain: ${CMAKE_TOOLCHAIN_FILE}.")
-        endif()
+        message(VERBOSE "Using Conan toolchain: ${CMAKE_CURRENT_LIST_FILE}")
 
         if(${CMAKE_VERSION} VERSION_LESS "3.15")
             message(FATAL_ERROR "The 'CMakeToolchain' generator only works with CMake >= 3.15")


### PR DESCRIPTION
Changelog: Fix: Change the ``CMakeToolchain`` message to use ``CMAKE_CURRENT_LIST_FILE``. 
Docs: Omit
Close https://github.com/conan-io/conan/issues/10550
