### PR TITLE
[develop2] exports are not sources

### DIFF
--- a/conans/client/source.py
+++ b/conans/client/source.py
@@ -2,7 +2,7 @@ import os
 import shutil
 
 from conans.client import tools
-from conans.client.cmd.export import export_recipe, export_source
+from conans.client.cmd.export import export_source
 from conans.errors import ConanException, ConanExceptionInUserConanfileMethod, \
     conanfile_exception_formatter, NotFoundException
 from conans.model.scm import SCM, get_scm_data
@@ -66,7 +66,6 @@ def config_source_local(conanfile, conanfile_path, hook_manager):
         src_folder = conanfile.source_folder
         if conanfile_folder != src_folder:
             conanfile.output.info("Executing exports to: %s" % src_folder)
-            export_recipe(conanfile, src_folder)
             export_source(conanfile, src_folder)
 
     _run_source(conanfile, conanfile_path, hook_manager, reference=None, cache=None,
@@ -109,8 +108,6 @@ def config_source(export_folder, export_source_folder, scm_sources_folder, conan
             def get_sources_from_exports():
                 # First of all get the exported scm sources (if auto) or clone (if fixed)
                 _run_cache_scm(conanfile, scm_sources_folder)
-                # so self exported files have precedence over python_requires ones
-                merge_directories(export_folder, conanfile.folders.base_source)
                 # Now move the export-sources to the right location
                 merge_directories(export_source_folder, conanfile.folders.base_source)
 

--- a/conans/test/functional/layout/test_in_cache.py
+++ b/conans/test/functional/layout/test_in_cache.py
@@ -230,7 +230,7 @@ def test_git_clone_with_source_layout():
            import os
            from conan import ConanFile
            class Pkg(ConanFile):
-               exports = "*.txt"
+               exports_sources = "*.txt"
 
                def layout(self):
                    self.folders.source = "src"

--- a/conans/test/functional/toolchains/cmake/test_cmaketoolchain_paths.py
+++ b/conans/test/functional/toolchains/cmake/test_cmaketoolchain_paths.py
@@ -69,7 +69,7 @@ def test_cmaketoolchain_path_find_package(package, find_package, settings, find_
         from conan import ConanFile
         from conan.tools.files import copy
         class TestConan(ConanFile):
-            exports = "*"
+            exports_sources = "*"
             def layout(self):
                 pass
             def package(self):
@@ -133,7 +133,7 @@ def test_cmaketoolchain_path_find_package_real_config(settings, find_root_path_m
         import os
         class TestConan(ConanFile):
             settings = "os", "compiler", "build_type", "arch"
-            exports = "*"
+            exports_sources = "*"
             generators = "CMakeToolchain"
 
             def layout(self):
@@ -219,7 +219,7 @@ def test_cmaketoolchain_path_include_cmake_modules(require_type, settings, find_
         from conan.tools.files import copy
         class TestConan(ConanFile):
             settings = "os", "compiler", "arch", "build_type"
-            exports = "*"
+            exports_sources = "*"
             def layout(self):
                 pass
             def package(self):
@@ -276,7 +276,7 @@ def test_cmaketoolchain_path_find_file_find_path(settings, find_root_path_modes)
         from conan.tools.files import copy
         class TestConan(ConanFile):
             settings = "os", "arch", "compiler", "build_type"
-            exports = "*"
+            exports_sources = "*"
             def layout(self):
                 pass
             def package(self):
@@ -331,7 +331,7 @@ def test_cmaketoolchain_path_find_library(settings, find_root_path_modes):
         from conan.tools.files import copy
         class TestConan(ConanFile):
             settings = "os", "arch", "compiler", "build_type"
-            exports = "*"
+            exports_sources = "*"
             def layout(self):
                 pass
             def package(self):
@@ -397,7 +397,7 @@ def test_cmaketoolchain_path_find_program(settings, find_root_path_modes):
         from conan import ConanFile
         class TestConan(ConanFile):
             settings = "os", "arch", "compiler", "build_type"
-            exports = "*"
+            exports_sources = "*"
             def layout(self):
                 pass
             def package(self):

--- a/conans/test/functional/toolchains/env/test_complete.py
+++ b/conans/test/functional/toolchains/env/test_complete.py
@@ -86,7 +86,7 @@ def test_complete():
             requires = "myopenssl/1.0"
             default_options = {"myopenssl:shared": True}
             generators = "CMakeDeps", "CMakeToolchain", "VirtualBuildEnv"
-            exports = "*"
+            exports_sources = "*"
 
             def build(self):
                 cmake = CMake(self)

--- a/conans/test/functional/toolchains/microsoft/test_msbuilddeps.py
+++ b/conans/test/functional/toolchains/microsoft/test_msbuilddeps.py
@@ -728,7 +728,7 @@ def check_build_vs_project_with_a(vs_version):
         from conan.tools.files import copy
         class HelloConan(ConanFile):
             settings = "os", "build_type", "compiler", "arch"
-            exports = '*'
+            exports_sources = '*'
             requires = "updep.pkg.team/0.1@"
             generators = "CMakeToolchain"
 
@@ -872,7 +872,7 @@ def test_build_requires():
     client = TestClient()
     package = "copy(self, '*', os.path.join(self.build_folder, str(self.settings.arch))," \
               " os.path.join(self.package_folder, 'bin'))"
-    dep = GenConanfile().with_exports("*").with_settings("arch").with_package(package)\
+    dep = GenConanfile().with_exports_sources("*").with_settings("arch").with_package(package)\
         .with_import("import os").with_import("from conan.tools.files import copy")
     consumer = textwrap.dedent("""
         from conan import ConanFile

--- a/conans/test/integration/cache/download_cache_test.py
+++ b/conans/test/integration/cache/download_cache_test.py
@@ -157,7 +157,7 @@ class DownloadCacheTest(unittest.TestCase):
             from conan import ConanFile
             from conan.tools.files import copy, load
             class Pkg(ConanFile):
-                exports = "*"
+                exports_sources = "*"
                 def package(self):
                     copy(self, "*", self.source_folder, self.package_folder)
                 def package_info(self):

--- a/conans/test/integration/command/install/install_update_test.py
+++ b/conans/test/integration/command/install/install_update_test.py
@@ -115,7 +115,7 @@ def test_update_not_date():
 def test_reuse():
     client = TestClient(default_server_user=True)
     conanfile = GenConanfile("hello0", "1.0")\
-        .with_exports("*")\
+        .with_exports_sources("*")\
         .with_import("from conan.tools.files import copy")\
         .with_package("copy(self, '*', self.source_folder, self.package_folder)")
     client.save({"conanfile.py": conanfile,

--- a/conans/test/integration/command/source_test.py
+++ b/conans/test/integration/command/source_test.py
@@ -15,6 +15,9 @@ class SourceTest(unittest.TestCase):
 from conan.tools.files import save, load
 import os
 class TestexportConan(ConanFile):
+    name = "test"
+    version = "0.1"
+
     exports = "mypython.py"
     exports_sources = "patch.patch"
 
@@ -24,7 +27,7 @@ class TestexportConan(ConanFile):
         self.output.info("PATCH: %s" % load(self, patch))
         header = os.path.join(self.source_folder, "hello/hello.h")
         self.output.info("HEADER: %s" % load(self, header))
-        python = os.path.join(self.source_folder, "mypython.py")
+        python = os.path.join(self.recipe_folder, "mypython.py")
         self.output.info("PYTHON: %s" % load(self, python))
 """
         client = TestClient()
@@ -32,20 +35,22 @@ class TestexportConan(ConanFile):
                      "patch.patch": "mypatch",
                      "mypython.py": "mypython"})
         client.run("source .")
-        self.assertIn("conanfile.py: PATCH: mypatch", client.out)
-        self.assertIn("conanfile.py: HEADER: my hello header!", client.out)
-        self.assertIn("conanfile.py: PYTHON: mypython", client.out)
+        self.assertIn("conanfile.py (test/0.1): PATCH: mypatch", client.out)
+        self.assertIn("conanfile.py (test/0.1): HEADER: my hello header!", client.out)
+        self.assertIn("conanfile.py (test/0.1): PYTHON: mypython", client.out)
         client.run("source . -sf=mysrc")
-        self.assertIn("conanfile.py: Executing exports to", client.out)
-        self.assertIn("conanfile.py: PATCH: mypatch", client.out)
-        self.assertIn("conanfile.py: HEADER: my hello header!", client.out)
-        self.assertIn("conanfile.py: PYTHON: mypython", client.out)
+        self.assertIn("conanfile.py (test/0.1): Executing exports to", client.out)
+        self.assertIn("conanfile.py (test/0.1): PATCH: mypatch", client.out)
+        self.assertIn("conanfile.py (test/0.1): HEADER: my hello header!", client.out)
+        self.assertIn("conanfile.py (test/0.1): PYTHON: mypython", client.out)
         self.assertTrue(os.path.exists(os.path.join(client.current_folder,
                                                     "mysrc", "patch.patch")))
         self.assertTrue(os.path.exists(os.path.join(client.current_folder,
-                                                    "mysrc", "mypython.py")))
-        self.assertTrue(os.path.exists(os.path.join(client.current_folder,
                                                     "mysrc", "hello/hello.h")))
+        client.run("create . ")
+        self.assertIn("test/0.1: PATCH: mypatch", client.out)
+        self.assertIn("test/0.1: HEADER: my hello header!", client.out)
+        self.assertIn("test/0.1: PYTHON: mypython", client.out)
 
     def test_apply_patch(self):
         # https://github.com/conan-io/conan/issues/2327

--- a/conans/test/integration/command/test_package_test.py
+++ b/conans/test/integration/command/test_package_test.py
@@ -236,7 +236,7 @@ from conan.tools.files import copy
 class HelloConan(ConanFile):
     name = "hello"
     version = "0.1"
-    exports = "*"
+    exports_sources = "*"
 
     def package(self):
         copy(self, "*", self.source_folder, self.package_folder)

--- a/conans/test/integration/editable/test_editable_import.py
+++ b/conans/test/integration/editable/test_editable_import.py
@@ -21,7 +21,7 @@ class TestEditableImport:
             from conan import ConanFile
             from conan.tools.files import copy
             class Pkg(ConanFile):
-                exports = "*"
+                exports_sources = "*"
                 def layout(self):
                     self.folders.source = "src"
                     self.cpp.source.resdirs = ["res"]

--- a/conans/test/integration/export_sources_test.py
+++ b/conans/test/integration/export_sources_test.py
@@ -1,346 +1,68 @@
-import copy
 import os
 import platform
-import time
-import unittest
-from collections import OrderedDict
+import textwrap
 
 import pytest
-from mock import patch
-from parameterized.parameterized import parameterized
 
-from conans.model.package_ref import PkgReference
 from conans.model.recipe_ref import RecipeReference
-from conans.paths import EXPORT_SOURCES_TGZ_NAME, EXPORT_TGZ_NAME
-from conans.server.revision_list import RevisionList
 from conans.test.assets.genconanfile import GenConanfile
-from conans.test.utils.test_files import scan_folder, temp_folder
-from conans.test.utils.tools import NO_SETTINGS_PACKAGE_ID, TestClient, TestServer, TurboTestClient
+from conans.test.utils.test_files import temp_folder
+from conans.test.utils.tools import TestClient, TurboTestClient
 from conans.util.files import load, rmdir
 
-conanfile_py = """
-import os
-from conan import ConanFile
-from conan.tools.files import copy
 
-class HelloConan(ConanFile):
-    name = "hello"
-    version = "0.1"
-    exports = "*.h", "*.cpp", "*.lic"
-    def package(self):
-        copy(self, "*.h", self.source_folder, os.path.join(self.package_folder, "include"))
-"""
+def test_exports():
+    """ Check that exported files go to the right folder
+    """
+    conanfile = textwrap.dedent("""
+        from conan import ConanFile
 
+        class HelloConan(ConanFile):
+            name = "hello"
+            version = "0.1"
+            exports = "*.h"
+        """)
+    c = TestClient()
+    c.save({"conanfile.py": conanfile,
+            "hello.h": "hello",
+            "data.txt": "data"})
+    c.run("create .")
+    ref = RecipeReference.loads("hello/0.1")
+    ref_layout = c.get_latest_ref_layout(ref)
 
-combined_conanfile = """
-import os
-from conan import ConanFile
-from conan.tools.files import copy
+    def assert_files(folder, files):
+        assert sorted(os.listdir(folder)) == sorted(files)
 
-class HelloConan(ConanFile):
-    name = "hello"
-    version = "0.1"
-    exports_sources = "*.h", "*.cpp"
-    exports = "*.txt", "*.lic"
-    def package(self):
-        copy(self, "*.h", self.source_folder, os.path.join(self.package_folder, "include"))
-        copy(self, "data.txt", self.source_folder, os.path.join(self.package_folder, "docs"))
-"""
+    assert_files(ref_layout.source(), [])
+    assert_files(ref_layout.export(), ['conanfile.py', 'conanmanifest.txt', 'hello.h'])
+    assert_files(ref_layout.export_sources(), [])
 
 
-nested_conanfile = """
-import os
-from conan import ConanFile
-from conan.tools.files import copy
-
-class HelloConan(ConanFile):
-    name = "hello"
-    version = "0.1"
-    exports_sources = "src/*.h", "src/*.cpp"
-    exports = "src/*.txt", "src/*.lic"
-    def package(self):
-        copy(self, "*.h", self.source_folder, os.path.join(self.package_folder, "include"))
-        copy(self, "*data.txt", self.source_folder, os.path.join(self.package_folder, "docs"))
-"""
-
-
-overlap_conanfile = """
-import os
-from conan import ConanFile
-from conan.tools.files import copy
-
-class HelloConan(ConanFile):
-    name = "hello"
-    version = "0.1"
-    exports_sources = "src/*.h", "*.txt"
-    exports = "src/*.txt", "*.h", "src/*.lic"
-    def package(self):
-        copy(self, "*.h", self.source_folder, os.path.join(self.package_folder, "include"))
-        copy(self, "*data.txt", self.source_folder, os.path.join(self.package_folder, "docs"))
-"""
-
-
-class ExportsSourcesTest(unittest.TestCase):
-
-    def setUp(self):
-        self.server = TestServer()
-        self.other_server = TestServer()
-        servers = OrderedDict([("default", self.server),
-                               ("other", self.other_server)])
-        client = TestClient(servers=servers, inputs=2*["admin", "password"])
-        self.client = client
-        self.ref = RecipeReference.loads("hello/0.1@lasote/testing")
-        self.pref = PkgReference(self.ref, NO_SETTINGS_PACKAGE_ID)
-
-    def _get_folders(self):
-        latest_rrev = self.client.cache.get_latest_recipe_reference(self.ref)
-        ref_layout = self.client.cache.ref_layout(latest_rrev)
-        self.source_folder = ref_layout.source()
-        self.export_folder = ref_layout.export()
-        self.export_sources_folder = ref_layout.export_sources()
-
-        latest_prev = self.client.cache.get_latest_package_reference(PkgReference(latest_rrev,
-                                                                     NO_SETTINGS_PACKAGE_ID))
-        if latest_prev:
-            pkg_layout = self.client.cache.pkg_layout(latest_prev)
-            self.package_folder = pkg_layout.package()
-
-    def _check_source_folder(self, mode):
-        """ Source folder MUST be always the same
+def test_exports_sources():
+    """ Check that exported-sources files go to the right folder AND to the source folder
         """
-        expected_sources = ["hello.h"]
-        if mode == "both":
-            expected_sources.append("data.txt")
-        if mode == "nested" or mode == "overlap":
-            expected_sources = ["src/hello.h", "src/data.txt"]
-        expected_sources = sorted(expected_sources)
-        self.assertEqual(scan_folder(self.source_folder), expected_sources)
+    conanfile = textwrap.dedent("""
+        from conan import ConanFile
 
-    def _check_package_folder(self, mode):
-        """ Package folder must be always the same (might have tgz after upload)
-        """
-        if mode in ["exports", "exports_sources"]:
-            expected_package = ["conaninfo.txt", "conanmanifest.txt", "include/hello.h"]
-        if mode == "both":
-            expected_package = ["conaninfo.txt", "conanmanifest.txt", "include/hello.h",
-                                "docs/data.txt"]
-        if mode == "nested" or mode == "overlap":
-            expected_package = ["conaninfo.txt", "conanmanifest.txt", "include/src/hello.h",
-                                "docs/src/data.txt"]
+        class HelloConan(ConanFile):
+            name = "hello"
+            version = "0.1"
+            exports_sources = "*.h"
+        """)
+    c = TestClient()
+    c.save({"conanfile.py": conanfile,
+            "hello.h": "hello",
+            "data.txt": "data"})
+    c.run("create .")
+    ref = RecipeReference.loads("hello/0.1")
+    ref_layout = c.get_latest_ref_layout(ref)
 
-        self.assertEqual(scan_folder(self.package_folder), sorted(expected_package))
+    def assert_files(folder, files):
+        assert sorted(os.listdir(folder)) == sorted(files)
 
-    def _check_server_folder(self, mode, server=None):
-        if mode == "exports_sources":
-            expected_server = [EXPORT_SOURCES_TGZ_NAME, 'conanfile.py', 'conanmanifest.txt']
-        if mode == "exports":
-            expected_server = [EXPORT_TGZ_NAME, 'conanfile.py', 'conanmanifest.txt']
-        if mode == "both" or mode == "nested" or mode == "overlap":
-            expected_server = [EXPORT_TGZ_NAME, EXPORT_SOURCES_TGZ_NAME, 'conanfile.py',
-                               'conanmanifest.txt']
-
-        server = server or self.server
-        rev, _ = server.server_store.get_last_revision(self.ref)
-        ref = copy.copy(self.ref)
-        ref.revision = rev
-        self.assertEqual(scan_folder(server.server_store.export(ref)), expected_server)
-
-    def _check_export_folder(self, mode, export_folder=None, export_src_folder=None):
-        if mode == "exports_sources":
-            expected_src_exports = ["hello.h"]
-            expected_exports = ['conanfile.py', 'conanmanifest.txt']
-        if mode == "exports":
-            expected_src_exports = []
-            expected_exports = ["hello.h", 'conanfile.py', 'conanmanifest.txt']
-        if mode == "both":
-            expected_src_exports = ["hello.h"]
-            expected_exports = ['conanfile.py', 'conanmanifest.txt', "data.txt"]
-        if mode == "nested":
-            expected_src_exports = ["src/hello.h"]
-            expected_exports = ["src/data.txt", 'conanfile.py', 'conanmanifest.txt']
-        if mode == "overlap":
-            expected_src_exports = ["src/hello.h", "src/data.txt"]
-            expected_exports = ["src/data.txt", "src/hello.h", 'conanfile.py', 'conanmanifest.txt']
-
-        self.assertEqual(scan_folder(export_folder or self.export_folder),
-                         sorted(expected_exports))
-        self.assertEqual(scan_folder(export_src_folder or self.export_sources_folder),
-                         sorted(expected_src_exports))
-
-    def _check_export_installed_folder(self, mode, updated=False):
-        """ Just installed, no EXPORT_SOURCES_DIR is present
-        """
-        if mode == "exports_sources":
-            expected_exports = ['conanfile.py', 'conanmanifest.txt']
-        if mode == "both":
-            expected_exports = ['conanfile.py', 'conanmanifest.txt', "data.txt"]
-        if mode == "exports":
-            expected_exports = ['conanfile.py', 'conanmanifest.txt', "hello.h"]
-        if mode == "nested":
-            expected_exports = ['conanfile.py', 'conanmanifest.txt', "src/data.txt"]
-        if mode == "overlap":
-            expected_exports = ['conanfile.py', 'conanmanifest.txt', "src/data.txt", "src/hello.h"]
-        if updated and mode not in ["exports_sources", "nested", "overlap"]:
-            expected_exports.append("license.lic")
-
-        self.assertEqual(scan_folder(self.export_folder), sorted(expected_exports))
-        if mode == "exports":
-            self.assertFalse(os.path.exists(self.export_sources_folder))
-
-    def _check_export_uploaded_folder(self, mode, export_folder=None, export_src_folder=None):
-        if mode == "exports_sources":
-            expected_src_exports = ["hello.h"]
-            expected_exports = ['conanfile.py', 'conanmanifest.txt']
-        if mode == "exports":
-            expected_src_exports = []
-            expected_exports = ["hello.h", 'conanfile.py', 'conanmanifest.txt']
-        if mode == "both":
-            expected_src_exports = ["hello.h"]
-            expected_exports = ['conanfile.py', 'conanmanifest.txt', "data.txt"]
-        if mode == "nested":
-            expected_src_exports = ["src/hello.h"]
-            expected_exports = ["src/data.txt", 'conanfile.py', 'conanmanifest.txt']
-
-        if mode == "overlap":
-            expected_src_exports = ["src/hello.h", "src/data.txt"]
-            expected_exports = ["src/data.txt", "src/hello.h", 'conanfile.py', 'conanmanifest.txt']
-
-        export_folder = export_folder or self.export_folder
-        self.assertEqual(scan_folder(export_folder), sorted(expected_exports))
-        self.assertEqual(scan_folder(export_src_folder or self.export_sources_folder),
-                         sorted(expected_src_exports))
-
-    def _create_code(self, mode):
-        if mode == "exports":
-            conanfile = conanfile_py
-        elif mode == "exports_sources":
-            conanfile = conanfile_py.replace("exports", "exports_sources")
-        elif mode == "both":
-            conanfile = combined_conanfile
-        elif mode == "nested":
-            conanfile = nested_conanfile
-        elif mode == "overlap":
-            conanfile = overlap_conanfile
-
-        if mode in ["nested", "overlap"]:
-            self.client.save({"conanfile.py": conanfile,
-                              "src/hello.h": "hello",
-                              "src/data.txt": "data"})
-        else:
-            self.client.save({"conanfile.py": conanfile,
-                              "hello.h": "hello",
-                              "data.txt": "data"})
-
-    @parameterized.expand([("exports", ), ("exports_sources", ), ("both", ), ("nested", ),
-                           ("overlap", )])
-    def test_export(self, mode):
-        self._create_code(mode)
-
-        self.client.run("export . --user=lasote --channel=testing")
-        self._get_folders()
-        self._check_export_folder(mode)
-
-        # now build package
-        self.client.run("install --reference=hello/0.1@lasote/testing --build=missing")
-        # Source folder and package should be exatly the same
-        self._get_folders()
-        self._check_export_folder(mode)
-        self._check_source_folder(mode)
-        self._check_package_folder(mode)
-
-        # upload to remote
-        self.client.run("upload hello/0.1@lasote/testing -r default")
-        self._check_export_uploaded_folder(mode)
-        self._check_server_folder(mode)
-
-        # remove local
-        self.client.run('remove hello/0.1@lasote/testing -f')
-        self.assertFalse(os.path.exists(self.export_folder))
-
-        # install from remote
-        self.client.run("install --reference=hello/0.1@lasote/testing")
-        self.assertFalse(os.path.exists(self.source_folder))
-        self._check_export_installed_folder(mode)
-        self._check_package_folder(mode)
-
-    @parameterized.expand([("exports", ), ("exports_sources", ), ("both", ), ("nested", ),
-                           ("overlap", )])
-    def test_export_upload(self, mode):
-        self._create_code(mode)
-
-        self.client.run("export . --user=lasote --channel=testing")
-        self._get_folders()
-
-        self.client.run("upload hello/0.1@lasote/testing -r default --only-recipe")
-        self.assertFalse(os.path.exists(self.source_folder))
-        self._check_export_uploaded_folder(mode)
-        self._check_server_folder(mode)
-
-        # remove local
-        self.client.run('remove hello/0.1@lasote/testing -f')
-        self.assertFalse(os.path.exists(self.export_folder))
-
-        # install from remote
-        self.client.run("install --reference=hello/0.1@lasote/testing --build")
-        self._get_folders()
-        self._check_export_folder(mode)
-        self._check_source_folder(mode)
-        self._check_package_folder(mode)
-
-    @parameterized.expand([("exports", ), ("exports_sources", ), ("both", ), ("nested", ),
-                           ("overlap", )])
-    def test_reupload(self, mode):
-        """ try to reupload to same and other remote
-        """
-        self._create_code(mode)
-
-        self.client.run("export . --user=lasote --channel=testing")
-        self.client.run("install --reference=hello/0.1@lasote/testing --build=missing")
-        self.client.run("upload hello/0.1@lasote/testing -r default")
-        self.client.run('remove hello/0.1@lasote/testing -f')
-        self.client.run("install --reference=hello/0.1@lasote/testing")
-        self._get_folders()
-
-        # upload to remote again, the folder remains as installed
-        self.client.run("upload hello/0.1@lasote/testing -r default")
-        self._check_export_installed_folder(mode)
-        self._check_server_folder(mode)
-
-        self.client.run("upload hello/0.1@lasote/testing -r=other")
-        self._check_export_uploaded_folder(mode)
-        self._check_server_folder(mode, self.other_server)
-
-    @parameterized.expand([("exports", ), ("exports_sources", ), ("both", ), ("nested", ),
-                           ("overlap", )])
-    def test_update(self, mode):
-        self._create_code(mode)
-
-        self.client.run("export . --user=lasote --channel=testing")
-        self.client.run("install --reference=hello/0.1@lasote/testing --build=missing")
-        self.client.run("upload hello/0.1@lasote/testing -r default")
-        self.client.run('remove hello/0.1@lasote/testing -f')
-        self.client.run("install --reference=hello/0.1@lasote/testing")
-
-        # upload to remote again, the folder remains as installed
-        self.client.run("install --reference=hello/0.1@lasote/testing --update")
-        self.assertIn("hello/0.1@lasote/testing: Already installed!", self.client.out)
-        self._get_folders()
-        self._check_export_installed_folder(mode)
-
-        self.client.save({f"license.lic": "mylicense"})
-        self.client.run("create . --user=lasote --channel=testing")
-
-        the_time = time.time() + 10
-        with patch.object(RevisionList, '_now', return_value=the_time):
-            self.client.run("upload hello/0.1@lasote/testing#latest -r default")
-
-        ref = RecipeReference.loads('hello/0.1@lasote/testing')
-        self.client.run(f"remove hello/0.1@lasote/testing"
-                        f"#{self.client.cache.get_latest_recipe_reference(ref).revision} -f")
-
-        self.client.run("install --reference=hello/0.1@lasote/testing --update")
-        self._get_folders()
-        self._check_export_installed_folder(mode, updated=True)
+    assert_files(ref_layout.source(), ['hello.h'])
+    assert_files(ref_layout.export(), ['conanfile.py', 'conanmanifest.txt', ])
+    assert_files(ref_layout.export_sources(), ['hello.h'])
 
 
 def test_test_package_copied():
@@ -348,25 +70,25 @@ def test_test_package_copied():
     exported"""
 
     client = TestClient()
-    client.save({"conanfile.py":
-                     GenConanfile().with_exports("*").with_exports_sources("*"),
+    conanfile = GenConanfile().with_exports("*").with_exports_sources("*")
+    client.save({"conanfile.py": conanfile,
                  "test_package/foo.txt": "bar"})
     client.run("export . --name foo --version 1.0")
     assert "Copied 1 '.txt' file" in client.out
 
 
-def absolute_existing_folder():
-    tmp = temp_folder()
-    with open(os.path.join(tmp, "source.cpp"), "a") as _f:
-        _f.write("foo")
-    return tmp
-
-
 @pytest.mark.skipif(platform.system() == "Windows", reason="Symlinks not in Windows")
 def test_exports_does_not_follow_symlink():
+    def absolute_existing_folder():
+        tmp = temp_folder()
+        with open(os.path.join(tmp, "source.cpp"), "a") as _f:
+            _f.write("foo")
+        return tmp
+
     linked_abs_folder = absolute_existing_folder()
     client = TurboTestClient(default_server_user=True)
-    conanfile = GenConanfile().with_package('copy(self, "*", self.source_folder, self.package_folder)')\
+    conanfile = GenConanfile()\
+        .with_package('copy(self, "*", self.source_folder, self.package_folder)')\
         .with_exports_sources("*")\
         .with_import("from conan.tools.files import copy")
     client.save({"conanfile.py": conanfile, "foo.txt": "bar"})
@@ -397,5 +119,3 @@ def test_exports_does_not_follow_symlink():
     assert not os.path.exists(os.path.join(exports_sources_folder, "linked_folder", "source.cpp"))
     assert not os.path.exists(os.path.join(build_folder, "linked_folder", "source.cpp"))
     assert not os.path.exists(os.path.join(package_folder, "linked_folder", "source.cpp"))
-
-


### PR DESCRIPTION
Another small step in cleaning the source process:

- The ``exports`` files are exclusively for the recipe, but those are not sources. They will not be copied to source folder.
- Not in local flow, not in cache.

Removed ``ExportsSourcesTest`` very dirty test, replaced with some much simpler ones.