### PR TITLE
Fix conf True and False handling in system package_manager helpers

### DIFF
--- a/conan/tools/system/package_manager.py
+++ b/conan/tools/system/package_manager.py
@@ -15,8 +15,8 @@ class _SystemPackageManagerTool(object):
     def __init__(self, conanfile):
         self._conanfile = conanfile
         self._active_tool = self._conanfile.conf["tools.system.package_manager:tool"] or self.get_default_tool()
-        self._sudo = self._conanfile.conf["tools.system.package_manager:sudo"]
-        self._sudo_askpass = self._conanfile.conf["tools.system.package_manager:sudo_askpass"]
+        self._sudo = True if self._conanfile.conf["tools.system.package_manager:sudo"] == "True" else False
+        self._sudo_askpass = True if self._conanfile.conf["tools.system.package_manager:sudo_askpass"] == "True" else False
         self._mode = self._conanfile.conf["tools.system.package_manager:mode"] or self.mode_check
         self._arch = self._conanfile.settings_build.get_safe('arch') \
             if self._conanfile.context == CONTEXT_BUILD else self._conanfile.settings.get_safe('arch')

--- a/conans/test/integration/tools/system/package_manager_test.py
+++ b/conans/test/integration/tools/system/package_manager_test.py
@@ -65,10 +65,10 @@ def test_package_manager_distro(distro, tool):
 
 
 @pytest.mark.parametrize("sudo, sudo_askpass, expected_str", [
-    (True, True, "sudo -A "),
-    (True, False, "sudo "),
-    (False, True, ""),
-    (False, False, ""),
+    ("True", "True", "sudo -A "),
+    ("True", "False", "sudo "),
+    ("False", "True", ""),
+    ("False", "False", ""),
 ])
 def test_sudo_str(sudo, sudo_askpass, expected_str):
     conanfile = ConanFileMock()


### PR DESCRIPTION
Changelog: Fix: Fix conf `True` and `False` handling in `tools.system.package_manage` helpers.
Docs: omit
