### PR TITLE
new update_conandata() helper

### DIFF
--- a/conan/tools/files/__init__.py
+++ b/conan/tools/files/__init__.py
@@ -6,3 +6,4 @@ from conan.tools.files.cpp_package import CppPackage
 from conan.tools.files.packager import AutoPackager
 from conan.tools.files.symlinks import symlinks
 from conan.tools.files.copy_pattern import copy
+from conan.tools.files.conandata import update_conandata

--- a/conan/tools/files/conandata.py
+++ b/conan/tools/files/conandata.py
@@ -1,0 +1,30 @@
+import os
+
+import yaml
+
+from conans.errors import ConanException
+from conans.util.files import load, save
+
+
+def update_conandata(conanfile, data):
+    """
+    this only works for updating the conandata on the export() method, it seems it would
+    be plain wrong to try to change it anywhere else
+    """
+    if not hasattr(conanfile, "export_folder") or conanfile.export_folder is None:
+        raise ConanException("The 'update_conandata()' can only be used in the 'export()' method")
+    path = os.path.join(conanfile.export_folder, "conandata.yml")
+    conandata = load(path)
+    conandata = yaml.safe_load(conandata)
+
+    def recursive_dict_update(d, u):
+        for k, v in u.items():
+            if isinstance(v, dict):
+                d[k] = recursive_dict_update(d.get(k, {}), v)
+            else:
+                d[k] = v
+        return d
+
+    recursive_dict_update(conandata, data)
+    new_content = yaml.safe_dump(conandata)
+    save(path, new_content)

--- a/conans/test/integration/conanfile/conan_data_test.py
+++ b/conans/test/integration/conanfile/conan_data_test.py
@@ -255,3 +255,59 @@ class Lib(ConanFile):
         self.assertIn("My URL: this url", client.out)
         client.run("export-pkg . name/version@ -sf tmp/source -if tmp/install -bf tmp/build")
         self.assertIn("My URL: this url", client.out)
+
+
+def test_conandata_update():
+    """ test the update_conandata() helper
+    """
+    c = TestClient()
+    conanfile = textwrap.dedent("""
+        from conan import ConanFile
+        from conan.tools.files import update_conandata
+        class Pkg(ConanFile):
+            name = "pkg"
+            version = "0.1"
+            def export(self):
+                update_conandata(self, {"sources": {"0.1": {"commit": 123, "type": "git"},
+                                                    "0.2": {"url": "new"}
+                                                   }
+                                       })
+
+            def source(self):
+                data = self.conan_data["sources"]
+                self.output.info("0.1-commit: {}!!".format(data["0.1"]["commit"]))
+                self.output.info("0.1-type: {}!!".format(data["0.1"]["type"]))
+                self.output.info("0.1-url: {}!!".format(data["0.1"]["url"]))
+                self.output.info("0.2-url: {}!!".format(data["0.2"]["url"]))
+        """)
+    conandata = textwrap.dedent("""\
+        sources:
+            "0.1":
+                url: myurl
+                commit: 234
+        """)
+    c.save({"conanfile.py": conanfile,
+            "conandata.yml": conandata})
+    c.run("create .")
+    assert "pkg/0.1: 0.1-commit: 123!!" in c.out
+    assert "pkg/0.1: 0.1-type: git!!" in c.out
+    assert "pkg/0.1: 0.1-url: myurl!!" in c.out
+    assert "pkg/0.1: 0.2-url: new!!" in c.out
+
+
+def test_conandata_update_error():
+    """ test the update_conandata() helper fails if used outside export()
+    """
+    c = TestClient()
+    conanfile = textwrap.dedent("""
+        from conan import ConanFile
+        from conan.tools.files import update_conandata
+        class Pkg(ConanFile):
+            name = "pkg"
+            version = "0.1"
+            def source(self):
+                update_conandata(self, {})
+                                       """)
+    c.save({"conanfile.py": conanfile})
+    c.run("create .", assert_error=True)
+    assert "The 'update_conandata()' can only be used in the 'export()' method" in c.out


### PR DESCRIPTION
Changelog: Feature: New ``from conan.tools.files import update_conandata()`` helper to add data to ``conandata.yml`` in the ``export()`` method.
Docs: https://github.com/conan-io/docs/pull/2422


