### PR TITLE
removing the --source-folder new argument

### DIFF
--- a/conans/client/cache/cache.py
+++ b/conans/client/cache/cache.py
@@ -106,8 +106,7 @@ class ClientCache(object):
             conanfile_path = edited_ref["path"]
             layout_file = edited_ref["layout"]
             return PackageEditableLayout(os.path.dirname(conanfile_path), layout_file, ref,
-                                         conanfile_path, edited_ref.get("source_folder"),
-                                         edited_ref.get("output_folder"))
+                                         conanfile_path, edited_ref.get("output_folder"))
         else:
             _check_ref_case(ref, self.store)
             base_folder = os.path.normpath(os.path.join(self.store, ref.dir_repr()))

--- a/conans/client/cache/editable.py
+++ b/conans/client/cache/editable.py
@@ -34,11 +34,10 @@ class EditablePackages(object):
         ref = ref.copy_clear_rev()
         return self._edited_refs.get(ref)
 
-    def add(self, ref, path, layout, source_folder=None, output_folder=None):
+    def add(self, ref, path, layout, output_folder=None):
         assert isinstance(ref, ConanFileReference)
         ref = ref.copy_clear_rev()
-        self._edited_refs[ref] = {"path": path, "layout": layout, "source_folder": source_folder,
-                                  "output_folder": output_folder}
+        self._edited_refs[ref] = {"path": path, "layout": layout, "output_folder": output_folder}
         self.save()
 
     def remove(self, ref):

--- a/conans/client/command.py
+++ b/conans/client/command.py
@@ -488,7 +488,6 @@ class Command(object):
                                  'files. e.g., conaninfo/conanbuildinfo.txt')
         parser.add_argument("-of", "--output-folder",
                             help='The root output folder for generated and build files')
-        parser.add_argument("-sf", "--source-folder", help='The root source folder')
         _add_manifests_arguments(parser)
 
         parser.add_argument("--no-imports", action='store_true', default=False,
@@ -536,7 +535,6 @@ class Command(object):
                                            update=args.update, generators=args.generator,
                                            no_imports=args.no_imports,
                                            install_folder=args.install_folder,
-                                           source_folder=args.source_folder,
                                            output_folder=args.output_folder,
                                            lockfile=args.lockfile,
                                            lockfile_out=args.lockfile_out,
@@ -1899,7 +1897,6 @@ class Command(object):
                                 'then to local cache "layouts" folder')
         add_parser.add_argument("-of", "--output-folder",
                                 help='The root output folder for generated and build files')
-        add_parser.add_argument("-sf", "--source-folder", help='The root source folder')
 
         remove_parser = subparsers.add_parser('remove', help='Disable editable mode for a package')
         remove_parser.add_argument('reference',
@@ -1911,8 +1908,8 @@ class Command(object):
         self._warn_python_version()
 
         if args.subcommand == "add":
-            self._conan.editable_add(args.path, args.reference, args.layout, args.source_folder,
-                                     args.output_folder, cwd=os.getcwd())
+            self._conan.editable_add(args.path, args.reference, args.layout, args.output_folder,
+                                     cwd=os.getcwd())
             self._out.success("Reference '{}' in editable mode".format(args.reference))
         elif args.subcommand == "remove":
             ret = self._conan.editable_remove(args.reference)

--- a/conans/client/conan_api.py
+++ b/conans/client/conan_api.py
@@ -583,7 +583,7 @@ class ConanAPIV1(object):
                 remote_name=None, verify=None, manifests=None,
                 manifests_interactive=None, build=None, profile_names=None,
                 update=False, generators=None, no_imports=False, install_folder=None,
-                source_folder=None, output_folder=None, cwd=None,
+                output_folder=None, cwd=None,
                 lockfile=None, lockfile_out=None, profile_build=None, conf=None,
                 require_overrides=None):
         profile_host = ProfileData(profiles=profile_names, settings=settings, options=options,
@@ -607,7 +607,6 @@ class ConanAPIV1(object):
             deps_install(app=self.app,
                          ref_or_path=conanfile_path,
                          install_folder=install_folder,
-                         source_folder=source_folder,
                          output_folder=output_folder,
                          base_folder=cwd,
                          remotes=remotes,
@@ -1300,7 +1299,7 @@ class ConanAPIV1(object):
             return self.app.remote_manager.get_package_revisions(pref, remote=remote)
 
     @api_method
-    def editable_add(self, path, reference, layout, source_folder, output_folder, cwd):
+    def editable_add(self, path, reference, layout, output_folder, cwd):
         # Retrieve conanfile.py from target_path
         target_path = _get_conanfile_path(path=path, cwd=cwd, py=True)
 
@@ -1319,13 +1318,10 @@ class ConanAPIV1(object):
         if layout_abs_path:
             self.app.out.success("Using layout file: %s" % layout_abs_path)
 
-        if source_folder is not None:
-            source_folder = _make_abs_path(source_folder)
         if output_folder is not None:
             build_folder = _make_abs_path(output_folder)
 
-        self.app.cache.editable_packages.add(ref, target_path, layout_abs_path, source_folder,
-                                             output_folder)
+        self.app.cache.editable_packages.add(ref, target_path, layout_abs_path, output_folder)
 
     @api_method
     def editable_remove(self, reference):

--- a/conans/client/installer.py
+++ b/conans/client/installer.py
@@ -468,7 +468,7 @@ class BinaryInstaller(object):
 
         if hasattr(conanfile, "layout"):
             conanfile.folders.set_base_package(package_layout.output_folder or base_path)
-            conanfile.folders.set_base_source(package_layout.source_folder or base_path)
+            conanfile.folders.set_base_source(base_path)
             conanfile.folders.set_base_build(package_layout.output_folder or base_path)
             conanfile.folders.set_base_generators(package_layout.output_folder or base_path)
             conanfile.folders.set_base_install(base_path)

--- a/conans/client/manager.py
+++ b/conans/client/manager.py
@@ -23,7 +23,7 @@ def deps_install(app, ref_or_path, install_folder, base_folder, graph_info, remo
                  manifest_interactive=False, generators=None, no_imports=False,
                  create_reference=None, keep_build=False, recorder=None, lockfile_node_id=None,
                  is_build_require=False, add_txt_generator=True, require_overrides=None,
-                 conanfile_path=None, test=None, source_folder=None, output_folder=None):
+                 conanfile_path=None, test=None, output_folder=None):
 
     """ Fetch and build all dependencies for the given reference
     @param app: The ConanApp instance with all collaborators
@@ -96,7 +96,7 @@ def deps_install(app, ref_or_path, install_folder, base_folder, graph_info, remo
         manifest_manager.print_log()
 
     if hasattr(conanfile, "layout") and not test:
-        conanfile.folders.set_base_source(source_folder or conanfile_path)
+        conanfile.folders.set_base_source(conanfile_path)
         conanfile.folders.set_base_build(output_folder or conanfile_path)
         conanfile.folders.set_base_install(output_folder or conanfile_path)
         conanfile.folders.set_base_imports(output_folder or conanfile_path)

--- a/conans/paths/package_layouts/package_editable_layout.py
+++ b/conans/paths/package_layouts/package_editable_layout.py
@@ -10,13 +10,12 @@ from conans.model.ref import PackageReference
 
 class PackageEditableLayout(object):
 
-    def __init__(self, base_folder, layout_file, ref, conanfile_path, source_folder, output_folder):
+    def __init__(self, base_folder, layout_file, ref, conanfile_path, output_folder):
         assert isinstance(ref, ConanFileReference)
         self._ref = ref
         self._base_folder = base_folder
         self._layout_file = layout_file
         self._conanfile_path = conanfile_path
-        self.source_folder = source_folder
         self.output_folder = output_folder
 
     @property


### PR DESCRIPTION
Changelog: Fix: Remove the ``--source-folder`` new argument to ``install`` and ``editable``, not necessary at the moment.
Docs: https://github.com/conan-io/docs/pull/2420

