### PR TITLE
SystemPackageTool: fix mode=verify

### DIFF
--- a/conans/client/tools/system_pm.py
+++ b/conans/client/tools/system_pm.py
@@ -118,6 +118,7 @@ class SystemPackageTool(object):
                                    % "\n".join(packages))
                 raise ConanInvalidSystemRequirements("Aborted due to CONAN_SYSREQUIRES_MODE=%s. "
                                      "Some system packages need to be installed" % mode)
+            return
 
         if not force and self._installed(packages):
             return
@@ -169,11 +170,12 @@ class SystemPackageTool(object):
                                   % "\n".join(packages))
                 return
 
-            if mode == "verify" and not self._installed(packages):
+            if mode == "verify" and self._to_be_installed(packages):
                 self._output.error("The following packages need to be installed:\n %s"
                                    % "\n".join(packages))
                 raise ConanInvalidSystemRequirements("Aborted due to CONAN_SYSREQUIRES_MODE=%s. "
                                      "Some system packages need to be installed" % mode)
+            return
 
         packages = packages if force else self._to_be_installed(packages)
         if not force and not packages:


### PR DESCRIPTION
In this case, never install any package

fixes conan-io/conan#10592

Changelog: Bugfix: Fix ``SystemPackageTool`` when ``mode=verify``, it was still installing packages.
Docs: Omit

- [ ] Refer to the issue that supports this Pull Request.
- [ ] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [ ] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [ ] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 

<sup>**Note:** By default this PR will skip the slower tests and will use a limited set of python versions. Check [here](https://github.com/conan-io/conan/blob/develop/.github/PR_INCREASE_TESTING.md) how to increase the testing level by writing some tags in the current PR body text.</sup>
