### PR TITLE
change source folder

### DIFF
--- a/conans/client/source.py
+++ b/conans/client/source.py
@@ -124,8 +124,8 @@ def _run_source(conanfile, conanfile_path, hook_manager, reference, cache,
         - Calling post_source hook
     """
 
-
-    src_folder = conanfile.folders.base_source
+    src_folder = conanfile.source_folder if hasattr(conanfile, "layout") \
+        else conanfile.folders.base_source
     mkdir(src_folder)
 
     with tools.chdir(src_folder):

--- a/conans/test/functional/layout/test_in_cache.py
+++ b/conans/test/functional/layout/test_in_cache.py
@@ -26,7 +26,7 @@ def conanfile():
     def source(self):
         self.output.warn("Source folder: {}".format(self.source_folder))
         # The layout describes where the sources are, not force them to be there
-        tools.save("my_sources/source.h", "foo")
+        tools.save("source.h", "foo")
 
     def build(self):
         self.output.warn("Build folder: {}".format(self.build_folder))
@@ -288,7 +288,7 @@ def test_git_clone_with_source_layout():
                    self.folders.source = "src"
 
                def source(self):
-                   self.run('git clone "{}" src')
+                   self.run('git clone "{}" .')
        """).format(repo.replace("\\", "/"))
 
     client.save({"conanfile.py": conanfile,
@@ -301,7 +301,7 @@ def test_git_clone_with_source_layout():
     sf = client.cache.package_layout(ConanFileReference.loads("hello/1.0@")).source()
     assert os.path.exists(os.path.join(sf, "myfile.txt"))
     # The conanfile is cleared from the root before cloning
-    assert not os.path.exists(os.path.join(sf, "conanfile.py"))
+    assert os.path.exists(os.path.join(sf, "conanfile.py"))
     assert not os.path.exists(os.path.join(sf, "cloned.txt"))
 
     assert os.path.exists(os.path.join(sf, "src", "cloned.txt"))

--- a/conans/test/functional/layout/test_layout_autopackage.py
+++ b/conans/test/functional/layout/test_layout_autopackage.py
@@ -14,19 +14,19 @@ def test_auto_package_no_components():
     conan_file += """
 
     def source(self):
-        tools.save("my_source/source_sources/source_stuff.cpp", "")
-        tools.save("my_source/source_includes/include1.hpp", "")
-        tools.save("my_source/source_includes/include2.hpp", "")
-        tools.save("my_source/source_includes2/include3.h", "")
-        tools.save("my_source/source_libs/slibone.a", "")
-        tools.save("my_source/source_libs/slibtwo.a", "")
-        tools.save("my_source/source_libs/bin_to_discard.exe", "")
-        tools.save("my_source/source_bins/source_bin.exe", "")
-        tools.save("my_source/source_frameworks/sframe1/include/include.h", "")
-        tools.save("my_source/source_frameworks/sframe2/include/include.h", "")
-        tools.save("my_source/source_frameworks/sframe1/lib/libframework.lib", "")
-        tools.save("my_source/source_frameworks/sframe2/lib/libframework.lib", "")
-        tools.save("my_source/source_frameworks/sframe2/foo/bar.txt", "")
+        tools.save("source_sources/source_stuff.cpp", "")
+        tools.save("source_includes/include1.hpp", "")
+        tools.save("source_includes/include2.hpp", "")
+        tools.save("source_includes2/include3.h", "")
+        tools.save("source_libs/slibone.a", "")
+        tools.save("source_libs/slibtwo.a", "")
+        tools.save("source_libs/bin_to_discard.exe", "")
+        tools.save("source_bins/source_bin.exe", "")
+        tools.save("source_frameworks/sframe1/include/include.h", "")
+        tools.save("source_frameworks/sframe2/include/include.h", "")
+        tools.save("source_frameworks/sframe1/lib/libframework.lib", "")
+        tools.save("source_frameworks/sframe2/lib/libframework.lib", "")
+        tools.save("source_frameworks/sframe2/foo/bar.txt", "")
 
     def build(self):
         tools.save("build_sources/build_stuff.cpp", "")

--- a/conans/test/functional/layout/test_local_commands.py
+++ b/conans/test/functional/layout/test_local_commands.py
@@ -176,7 +176,7 @@ def test_local_source():
         self.folders.source = "my_source"
 
     def source(self):
-        tools.save("my_source/downloaded.h", "bar")
+        tools.save("downloaded.h", "bar")
     """
     client.save({"conanfile.py": conan_file})
     client.run("install . -if=my_install")
@@ -197,7 +197,7 @@ def test_local_source_change_base():
         self.folders.source = "my_source"
 
     def source(self):
-        tools.save("my_source/downloaded.h", "bar")
+        tools.save("downloaded.h", "bar")
     """
     client.save({"conanfile.py": conan_file})
     client.run("install . -if=common")

--- a/conans/test/functional/layout/test_source_folder.py
+++ b/conans/test/functional/layout/test_source_folder.py
@@ -167,15 +167,14 @@ def test_zip_download_with_subfolder(no_copy_source):
         tools.get("http://fake_url/my_sources.zip")
 
     def layout(self):
-        self.folders.source = "subfolder"
+        self.folders.source = "src"
 
     def build(self):
-        assert os.path.exists(os.path.join(self.source_folder, "CMakeLists.txt"))
-        assert "subfolder" in self.source_folder
-        assert os.path.exists(os.path.join(self.source_folder, "..",
+        assert os.path.exists(os.path.join(self.source_folder, "subfolder", "CMakeLists.txt"))
+        assert os.path.exists(os.path.join(self.source_folder,
                                            "ignored_subfolder", "ignored.txt"))
         cmake = CMake(self)
-        cmake.configure()
+        cmake.configure(build_script_folder="subfolder")
         cmake.build()
     """
     client = TestClient()
@@ -218,15 +217,14 @@ def test_zip_download_with_subfolder_new_tools(no_copy_source):
         get(self, "http://fake_url/my_sources.zip")
 
     def layout(self):
-        self.folders.source = "subfolder"
+        self.folders.source = "src"
 
     def build(self):
-        assert os.path.exists(os.path.join(self.source_folder, "CMakeLists.txt"))
-        assert "subfolder" in self.source_folder
-        assert os.path.exists(os.path.join(self.source_folder, "..",
+        assert os.path.exists(os.path.join(self.source_folder, "subfolder", "CMakeLists.txt"))
+        assert os.path.exists(os.path.join(self.source_folder,
                                            "ignored_subfolder", "ignored.txt"))
         cmake = CMake(self)
-        cmake.configure()
+        cmake.configure(build_script_folder="subfolder")
         cmake.build()
     """
     client = TestClient()


### PR DESCRIPTION
Changelog: Fix: Make the ``source()`` method run inside the ``self.source_folder``, in the same way ``build()`` runs in ``self.build_folder``. But only for recipes that define the ``layout()`` method, to not break unless using ``layout()``.
Docs: https://github.com/conan-io/docs/pull/2418

This is my second try to change the source-folder of the ``source()`` method. Please have a look at the tests for more details.