### PR TITLE
Limit markupsafe<2.1

### DIFF
--- a/conans/__init__.py
+++ b/conans/__init__.py
@@ -20,4 +20,4 @@ OAUTH_TOKEN = "oauth_token"
 SERVER_CAPABILITIES = [COMPLEX_SEARCH_CAPABILITY, REVISIONS]  # Server is always with revisions
 DEFAULT_REVISION_V1 = "0"
 
-__version__ = '1.43.3'
+__version__ = '1.43.4'

--- a/conans/client/migrations_settings.py
+++ b/conans/client/migrations_settings.py
@@ -2965,3 +2965,4 @@ cppstd: [None, 98, gnu98, 11, gnu11, 14, gnu14, 17, gnu17, 20, gnu20, 23, gnu23]
 settings_1_43_1 = settings_1_43_0
 settings_1_43_2 = settings_1_43_1
 settings_1_43_3 = settings_1_43_2
+settings_1_43_4 = settings_1_43_3

--- a/conans/requirements.txt
+++ b/conans/requirements.txt
@@ -12,3 +12,4 @@ pygments>=2.0, <3.0
 tqdm>=4.28.1, <5
 Jinja2>=2.9, <3
 python-dateutil>=2.7.0, <3
+markupsafe<2.1


### PR DESCRIPTION
Changelog:Fix: Limit markupsafe python dependency to <2.1
Docs: omit

Backporting because of: https://github.com/conan-io/conan/issues/10611
See: https://github.com/pallets/jinja/issues/1587