### PR TITLE
exports are not sources, not copied if layout()

### DIFF
--- a/conans/client/source.py
+++ b/conans/client/source.py
@@ -59,7 +59,8 @@ def config_source_local(conanfile, conanfile_path, hook_manager):
         if conanfile_folder != src_folder:
             _run_local_scm(conanfile, conanfile_folder, src_folder, output=conanfile.output)
             conanfile.output.info("Executing exports to: %s" % src_folder)
-            export_recipe(conanfile, conanfile_folder, src_folder)
+            if not hasattr(conanfile, "layout"):
+                export_recipe(conanfile, conanfile_folder, src_folder)
             export_source(conanfile, conanfile_folder, src_folder)
 
     _run_source(conanfile, conanfile_path, hook_manager, reference=None, cache=None,
@@ -104,8 +105,9 @@ def config_source(export_folder, export_source_folder, scm_sources_folder, conan
             def get_sources_from_exports():
                 # First of all get the exported scm sources (if auto) or clone (if fixed)
                 _run_cache_scm(conanfile, scm_sources_folder, output)
-                # so self exported files have precedence over python_requires ones
-                merge_directories(export_folder, conanfile.folders.base_source)
+                if not hasattr(conanfile, "layout"):
+                    # so self exported files have precedence over python_requires ones
+                    merge_directories(export_folder, conanfile.folders.base_source)
                 # Now move the export-sources to the right location
                 merge_directories(export_source_folder, conanfile.folders.base_source)
 

--- a/conans/test/functional/layout/test_in_cache.py
+++ b/conans/test/functional/layout/test_in_cache.py
@@ -282,7 +282,7 @@ def test_git_clone_with_source_layout():
            import os
            from conans import ConanFile
            class Pkg(ConanFile):
-               exports = "*.txt"
+               exports_sources = "*.txt"
 
                def layout(self):
                    self.folders.source = "src"
@@ -301,7 +301,7 @@ def test_git_clone_with_source_layout():
     sf = client.cache.package_layout(ConanFileReference.loads("hello/1.0@")).source()
     assert os.path.exists(os.path.join(sf, "myfile.txt"))
     # The conanfile is cleared from the root before cloning
-    assert os.path.exists(os.path.join(sf, "conanfile.py"))
+    assert not os.path.exists(os.path.join(sf, "conanfile.py"))
     assert not os.path.exists(os.path.join(sf, "cloned.txt"))
 
     assert os.path.exists(os.path.join(sf, "src", "cloned.txt"))

--- a/conans/test/functional/toolchains/cmake/test_cmaketoolchain_paths.py
+++ b/conans/test/functional/toolchains/cmake/test_cmaketoolchain_paths.py
@@ -68,7 +68,7 @@ def test_cmaketoolchain_path_find_package(package, find_package, settings, find_
     conanfile = textwrap.dedent("""
         from conans import ConanFile
         class TestConan(ConanFile):
-            exports = "*"
+            exports_sources = "*"
             def layout(self):
                 pass
             def package(self):
@@ -132,7 +132,7 @@ def test_cmaketoolchain_path_find_package_real_config(settings, find_root_path_m
         import os
         class TestConan(ConanFile):
             settings = "os", "compiler", "build_type", "arch"
-            exports = "*"
+            exports_sources = "*"
             generators = "CMakeToolchain"
 
             def layout(self):
@@ -213,7 +213,7 @@ def test_cmaketoolchain_path_include_cmake_modules(require_type, settings, find_
         from conans import ConanFile
         class TestConan(ConanFile):
             settings = "os", "compiler", "arch", "build_type"
-            exports = "*"
+            exports_sources = "*"
             def layout(self):
                 pass
             def package(self):
@@ -269,7 +269,7 @@ def test_cmaketoolchain_path_find_file_find_path(settings, find_root_path_modes)
         from conans import ConanFile
         class TestConan(ConanFile):
             settings = "os", "arch", "compiler", "build_type"
-            exports = "*"
+            exports_sources = "*"
             def layout(self):
                 pass
             def package(self):
@@ -322,7 +322,7 @@ def test_cmaketoolchain_path_find_library(settings, find_root_path_modes):
         from conans import ConanFile
         class TestConan(ConanFile):
             settings = "os", "arch", "compiler", "build_type"
-            exports = "*"
+            exports_sources = "*"
             def layout(self):
                 pass
             def package(self):
@@ -380,7 +380,7 @@ def test_cmaketoolchain_path_find_program(settings, find_root_path_modes):
         from conans import ConanFile
         class TestConan(ConanFile):
             settings = "os", "arch", "compiler", "build_type"
-            exports = "*"
+            exports_sources = "*"
             def layout(self):
                 pass
             def package(self):


### PR DESCRIPTION
Changelog: Fix: When ``layout()`` is defined, the ``exports`` will not be considered sources anymore, but only the ``exports_sources``. The ``exports`` are used exclusively by the recipe, but not as package source.
Docs: Omit

Continuation of https://github.com/conan-io/conan/pull/10612
Preparation for https://github.com/conan-io/conan/pull/10594
