### PR TITLE
update jinja2>=3

### DIFF
--- a/conans/requirements.txt
+++ b/conans/requirements.txt
@@ -10,6 +10,6 @@ node-semver==0.6.1
 distro>=1.0.2, <=1.6.0; sys_platform == 'linux' or sys_platform == 'linux2'
 pygments>=2.0, <3.0
 tqdm>=4.28.1, <5
-Jinja2>=2.9, <4.0.0
+Jinja2>=3.0, <4.0.0
 python-dateutil>=2.7.0, <3
 configparser>=3.5;python_version<='2.7'


### PR DESCRIPTION
Changelog: Fix: Update ``jinja2>=3.0``, after the last Jinja2 breaking because of ```Markupsafe`` update, and maintainers saying it is no longer supported, and it can break again anytime.
Docs: Omit

TO DISCUSS: Or should we limit markupsafe<2.1, in the same way we did for the 1.43.4 patch release?