### PR TITLE
[PkgConfigDeps] Added new property `component_version`

### DIFF
--- a/conan/tools/gnu/pkgconfigdeps/pc_files_creator.py
+++ b/conan/tools/gnu/pkgconfigdeps/pc_files_creator.py
@@ -33,7 +33,7 @@ def _get_aliases_pc_files_and_content(conanfile, dep, aliases_info, root_pc_file
     return pc_files
 
 
-def _get_components_pc_files_and_content(conanfile, dep, components_info):
+def _get_components_pc_files_and_content(conanfile, dep, package_info, components_info):
     """
     Get the PC files and content for dependency's components
     """
@@ -41,7 +41,7 @@ def _get_components_pc_files_and_content(conanfile, dep, components_info):
     # Loop through all the package's components
     for pc_info_component in components_info:
         # Get the *.pc file content for each component
-        description = "Conan component: %s" % pc_info_component.name
+        description = "Conan component: %s-%s" % (package_info.name, pc_info_component.name)
         pc_name, pc_content = get_pc_filename_and_content(
             conanfile,
             dep,
@@ -71,7 +71,7 @@ def _get_package_with_components_pc_files_and_content(conanfile, dep, package_in
     """
     pc_files = {}
     # First, let's load all the components PC files
-    pc_files.update(_get_components_pc_files_and_content(conanfile, dep, components_info))
+    pc_files.update(_get_components_pc_files_and_content(conanfile, dep, package_info, components_info))
     description = "Conan package: %s" % package_info.name
     pc_name, pc_content = get_alias_pc_filename_and_content(
         dep,

--- a/conan/tools/gnu/pkgconfigdeps/pc_files_templates.py
+++ b/conan/tools/gnu/pkgconfigdeps/pc_files_templates.py
@@ -88,8 +88,8 @@ def _get_formatted_dirs(folders, prefix_path_):
 
 def get_pc_filename_and_content(conanfile, dep, name, requires, description, cpp_info=None):
     package_folder = dep.package_folder
-    version = dep.ref.version
     cpp_info = cpp_info or dep.cpp_info
+    version = cpp_info.get_property("pkg_config_version") or dep.ref.version
 
     prefix_path = package_folder.replace("\\", "/")
     libdirs = _get_formatted_dirs(cpp_info.libdirs, prefix_path)

--- a/conan/tools/gnu/pkgconfigdeps/pc_files_templates.py
+++ b/conan/tools/gnu/pkgconfigdeps/pc_files_templates.py
@@ -89,7 +89,7 @@ def _get_formatted_dirs(folders, prefix_path_):
 def get_pc_filename_and_content(conanfile, dep, name, requires, description, cpp_info=None):
     package_folder = dep.package_folder
     cpp_info = cpp_info or dep.cpp_info
-    version = cpp_info.get_property("pkg_config_version") or dep.ref.version
+    version = cpp_info.get_property("component_version") or dep.ref.version
 
     prefix_path = package_folder.replace("\\", "/")
     libdirs = _get_formatted_dirs(cpp_info.libdirs, prefix_path)

--- a/conans/client/generators/pkg_config.py
+++ b/conans/client/generators/pkg_config.py
@@ -68,6 +68,7 @@ class PkgConfigGenerator(GeneratorComponentsMixin, Generator):
         return ret
 
     def _pc_file_content(self, name, cpp_info, requires_gennames):
+        version = cpp_info.get_property("component_version") or cpp_info.version
         prefix_path = cpp_info.rootpath.replace("\\", "/")
         lines = ['prefix=%s' % prefix_path]
 
@@ -92,7 +93,7 @@ class PkgConfigGenerator(GeneratorComponentsMixin, Generator):
         lines.append("Name: %s" % name)
         description = cpp_info.description or "Conan package: %s" % name
         lines.append("Description: %s" % description)
-        lines.append("Version: %s" % cpp_info.version)
+        lines.append("Version: %s" % version)
         libdirs_flags = ['-L"${%s}"' % name for name in libdir_vars]
         libnames_flags = ["-l%s " % name for name in (cpp_info.libs + cpp_info.system_libs)]
         shared_flags = cpp_info.sharedlinkflags + cpp_info.exelinkflags

--- a/conans/test/functional/generators/pkg_config_test.py
+++ b/conans/test/functional/generators/pkg_config_test.py
@@ -254,6 +254,8 @@ class PkgConfigConan(ConanFile):
                 def package_info(self):
                     self.cpp_info.components["mycomponent"].set_property("pkg_config_custom_content",
                                                                          "componentdir=${prefix}/mydir")
+                    self.cpp_info.components["mycomponent"].set_property("component_version",
+                                                                         "19.8.199")
             """)
         client = TestClient()
         client.save({"conanfile.py": conanfile})
@@ -262,6 +264,7 @@ class PkgConfigConan(ConanFile):
 
         pc_content = client.load("mycomponent.pc")
         self.assertIn("componentdir=${prefix}/mydir", pc_content)
+        self.assertIn("Version: 19.8.199", pc_content)
 
 
 def test_components_and_package_pc_creation_order():

--- a/conans/test/functional/toolchains/gnu/test_pkgconfigdeps.py
+++ b/conans/test/functional/toolchains/gnu/test_pkgconfigdeps.py
@@ -192,7 +192,7 @@ def test_custom_content():
     assert "Name: pkg" in pc_content
 
 
-def test_custom_content_components():
+def test_custom_content_and_version_components():
     conanfile = textwrap.dedent("""
         from conans import ConanFile
         from conans.tools import save
@@ -204,6 +204,8 @@ def test_custom_content_components():
             def package_info(self):
                 self.cpp_info.components["mycomponent"].set_property("pkg_config_custom_content",
                                                                      "componentdir=${prefix}/mydir")
+                self.cpp_info.components["mycomponent"].set_property("pkg_config_version",
+                                                                     "19.8.199")
         """)
     client = TestClient()
     client.save({"conanfile.py": conanfile})
@@ -211,6 +213,7 @@ def test_custom_content_components():
     client.run("install pkg/0.1@ -g PkgConfigDeps")
     pc_content = client.load("pkg-mycomponent.pc")
     assert "componentdir=${prefix}/mydir" in pc_content
+    assert "Version: 19.8.199" in pc_content
 
 
 def test_pkg_with_public_deps_and_component_requires():
@@ -419,7 +422,7 @@ def test_pkg_config_name_full_aliases():
     client.run("install .")
 
     pc_content = client.load("compo1.pc")
-    assert "Description: Conan component: compo1" in pc_content
+    assert "Description: Conan component: pkg_other_name-compo1" in pc_content
     assert "Requires" not in pc_content
 
     pc_content = client.load("compo1_alias.pc")

--- a/conans/test/functional/toolchains/gnu/test_pkgconfigdeps.py
+++ b/conans/test/functional/toolchains/gnu/test_pkgconfigdeps.py
@@ -204,7 +204,7 @@ def test_custom_content_and_version_components():
             def package_info(self):
                 self.cpp_info.components["mycomponent"].set_property("pkg_config_custom_content",
                                                                      "componentdir=${prefix}/mydir")
-                self.cpp_info.components["mycomponent"].set_property("pkg_config_version",
+                self.cpp_info.components["mycomponent"].set_property("component_version",
                                                                      "19.8.199")
         """)
     client = TestClient()


### PR DESCRIPTION
Changelog: Feature: Added new property `component_version` for `PkgConfigDeps` and legacy `PkgConfig`.
Changelog: Feature: Changed `.pc` file description field for components in `PkgConfigDeps`.
Closes: https://github.com/conan-io/conan/issues/10629
Docs: https://github.com/conan-io/docs/pull/2433

- [x] Refer to the issue that supports this Pull Request.
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 

<sup>**Note:** By default this PR will skip the slower tests and will use a limited set of python versions. Check [here](https://github.com/conan-io/conan/blob/develop/.github/PR_INCREASE_TESTING.md) how to increase the testing level by writing some tags in the current PR body text.</sup>
