### PR TITLE
Use absolute paths in conanbuild.sh

### DIFF
--- a/conans/test/integration/environment/test_env.py
+++ b/conans/test/integration/environment/test_env.py
@@ -534,8 +534,8 @@ def test_deactivate_location():
     client.run("create pkg.py pkg/1.0@")
     client.run("install pkg/1.0@ -g VirtualBuildEnv --install-folder=myfolder -s build_type=Release -s arch=x86_64")
 
-    source_cmd, script_ext = ("", ".bat") if platform.system() == "Windows" else (". ./", ".sh")
-    cmd = "{}myfolder/conanbuild{}".format(source_cmd, script_ext)
+    source_cmd, script_ext = ("myfolder\\", ".bat") if platform.system() == "Windows" else (". ./myfolder/", ".sh")
+    cmd = "{}conanbuild{}".format(source_cmd, script_ext)
 
     subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, shell=True,
                      cwd=client.current_folder).communicate()

--- a/conans/test/integration/environment/test_env.py
+++ b/conans/test/integration/environment/test_env.py
@@ -533,16 +533,7 @@ def test_deactivate_location():
     client.save({"pkg.py": conanfile})
     client.run("create pkg.py pkg/1.0@")
 
-    conanfile_txt = textwrap.dedent(r"""
-            [requires]
-            pkg/1.0
-
-            [generators]
-            VirtualBuildEnv
-        """)
-    client.save({"conanfile.txt": conanfile_txt})
-    client.run("install conanfile.txt --install-folder=myfolder -s build_type=Release -s arch=x86_64")
-
+    client.run("install pkg/1.0@ -g VirtualBuildEnv --install-folder=myfolder -s build_type=Release -s arch=x86_64")
     if platform.system() == "Windows":
         cmd = "./myfolder/conanbuild.bat"
     else:

--- a/conans/test/integration/environment/test_env.py
+++ b/conans/test/integration/environment/test_env.py
@@ -534,8 +534,8 @@ def test_deactivate_location():
     client.run("create pkg.py pkg/1.0@")
     client.run("install pkg/1.0@ -g VirtualBuildEnv --install-folder=myfolder -s build_type=Release -s arch=x86_64")
 
-    source_cmd, script_ext = ("", ".bat") if platform.system() == "Windows" else (". ", ".sh")
-    cmd = "{}./myfolder/conanbuild{}".format(source_cmd, script_ext)
+    source_cmd, script_ext = ("", ".bat") if platform.system() == "Windows" else (". ./", ".sh")
+    cmd = "{}myfolder/conanbuild{}".format(source_cmd, script_ext)
 
     subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, shell=True,
                      cwd=client.current_folder).communicate()

--- a/conans/test/integration/environment/test_env.py
+++ b/conans/test/integration/environment/test_env.py
@@ -532,17 +532,16 @@ def test_deactivate_location():
     client = TestClient()
     client.save({"pkg.py": conanfile})
     client.run("create pkg.py pkg/1.0@")
-
     client.run("install pkg/1.0@ -g VirtualBuildEnv --install-folder=myfolder -s build_type=Release -s arch=x86_64")
-    if platform.system() == "Windows":
-        cmd = "./myfolder/conanbuild.bat"
-    else:
-        cmd = '. ./myfolder/conanbuild.sh'
+
+    source_cmd, script_ext = ("", ".bat") if platform.system() == "Windows" else (". ", ".sh")
+    cmd = "{}./myfolder/conanbuild{}".format(source_cmd, script_ext)
+
     subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, shell=True,
                      cwd=client.current_folder).communicate()
 
     assert not os.path.exists(os.path.join(client.current_folder,
-                                           "deactivate_conanbuildenv-release-x86_64.sh"))
+                                           "deactivate_conanbuildenv-release-x86_64{}".format(script_ext)))
 
     assert os.path.exists(os.path.join(client.current_folder, "myfolder",
-                                       "deactivate_conanbuildenv-release-x86_64.sh"))
+                                       "deactivate_conanbuildenv-release-x86_64{}".format(script_ext)))


### PR DESCRIPTION
Changelog: Fix: Fix creation path of deactivate scripts.
Docs: omit

doing a `conan install ... --install-folder=myfolder -g VirtualBuildEnv` for example
generates a `conanbuild.sh` that when you source: `source ./myfolder/conanbuild.sh`
creates a `deactivate_conanbuildenv-release-x86_64.sh` not in myfolder but in the folder we are in.

This PR adds absolute paths to those files.