### PR TITLE
package_folder available when "conan install" consumer

### DIFF
--- a/conans/client/conan_api.py
+++ b/conans/client/conan_api.py
@@ -601,7 +601,8 @@ class ConanAPIV1(object):
                                         lockfile=lockfile)
 
             install_folder = _make_abs_path(install_folder, cwd)
-            output_folder = _make_abs_path(output_folder, cwd)
+            if output_folder:
+                output_folder = _make_abs_path(output_folder, cwd)
             conanfile_path = _get_conanfile_path(path, cwd, py=None)
 
             remotes = self.app.load_remotes(remote_name=remote_name, update=update)

--- a/conans/client/conan_api.py
+++ b/conans/client/conan_api.py
@@ -601,6 +601,7 @@ class ConanAPIV1(object):
                                         lockfile=lockfile)
 
             install_folder = _make_abs_path(install_folder, cwd)
+            output_folder = _make_abs_path(output_folder, cwd)
             conanfile_path = _get_conanfile_path(path, cwd, py=None)
 
             remotes = self.app.load_remotes(remote_name=remote_name, update=update)

--- a/conans/client/manager.py
+++ b/conans/client/manager.py
@@ -101,6 +101,7 @@ def deps_install(app, ref_or_path, install_folder, base_folder, graph_info, remo
         conanfile.folders.set_base_install(output_folder or conanfile_path)
         conanfile.folders.set_base_imports(output_folder or conanfile_path)
         conanfile.folders.set_base_generators(output_folder or conanfile_path)
+        conanfile.folders.set_base_package(output_folder or conanfile_path)
     else:
         conanfile.folders.set_base_install(install_folder)
         conanfile.folders.set_base_imports(install_folder)

--- a/conans/test/integration/command/install/install_test.py
+++ b/conans/test/integration/command/install/install_test.py
@@ -476,3 +476,34 @@ def test_install_bintray_warning():
     client.run("install zlib/1.0@lasote/testing -r conan-center -s build_type=Debug")
     assert "WARN: Remote https://conan.bintray.com is deprecated and will be shut down " \
            "soon" not in client.out
+
+
+def test_package_folder_available_consumer():
+    client = TestClient()
+    conanfile = textwrap.dedent("""
+    from conans import ConanFile
+    from conan.tools.cmake import cmake_layout
+    class HelloConan(ConanFile):
+
+        settings = "os", "arch", "build_type"
+
+        def layout(self):
+            cmake_layout(self)
+
+        def generate(self):
+            self.output.warn("Package folder is None? {}".format(self.package_folder is None))
+            self.output.warn("Package folder: {}".format(self.package_folder))
+    """)
+    client.save({"conanfile.py": conanfile})
+
+    # Installing it with "install ." with output folder
+    client.run("install . -of=my_build")
+    assert "WARN: Package folder is None? False" in client.out
+    build_folder = os.path.join(client.current_folder, "my_build")
+    assert "WARN: Package folder: {}".format(build_folder) in str(client.out).replace("\\", "/")
+
+    # Installing it with "install ." without output folder
+    client.run("install .")
+    assert "WARN: Package folder is None? False" in client.out
+    build_folder = client.current_folder
+    assert "WARN: Package folder: {}".format(build_folder) in str(client.out).replace("\\", "/")

--- a/conans/test/integration/command/install/install_test.py
+++ b/conans/test/integration/command/install/install_test.py
@@ -499,11 +499,11 @@ def test_package_folder_available_consumer():
     # Installing it with "install ." with output folder
     client.run("install . -of=my_build")
     assert "WARN: Package folder is None? False" in client.out
-    build_folder = os.path.join(client.current_folder, "my_build")
+    build_folder = os.path.join(client.current_folder, "my_build").replace("\\", "/")
     assert "WARN: Package folder: {}".format(build_folder) in str(client.out).replace("\\", "/")
 
     # Installing it with "install ." without output folder
     client.run("install .")
     assert "WARN: Package folder is None? False" in client.out
-    build_folder = client.current_folder
+    build_folder = client.current_folder.replace("\\", "/")
     assert "WARN: Package folder: {}".format(build_folder) in str(client.out).replace("\\", "/")


### PR DESCRIPTION
Changelog: Fix: When the `layout()` method is declared, the `self.package_folder` in the recipe is now available even when doing a `conan install . `, pointing to the specified output folder (`-of` ) or the path of the conanfile if not specified.
Docs: omit

Address #10652 in Conan 1.X, pending fix at Conan 2.X