### PR TITLE
basic_layout and external_sources for cmake_layout, removed meson_layout

### DIFF
--- a/conan/tools/cmake/layout.py
+++ b/conan/tools/cmake/layout.py
@@ -3,7 +3,7 @@ import os
 from conans.errors import ConanException
 
 
-def cmake_layout(conanfile, generator=None, external_sources=False):
+def cmake_layout(conanfile, generator=None, src_folder="."):
     gen = conanfile.conf.get("tools.cmake.cmaketoolchain:generator", default=generator)
     if gen:
         multi = "Visual" in gen or "Xcode" in gen or "Multi-Config" in gen
@@ -14,12 +14,7 @@ def cmake_layout(conanfile, generator=None, external_sources=False):
         else:
             multi = False
 
-    if not external_sources:
-        # The CMakeLists.txt is typically in the root
-        conanfile.folders.source = "."
-    else:
-        # Cloned/unzipped in a subdirectory
-        conanfile.folders.source = "src"
+    conanfile.folders.source = src_folder
     try:
         build_type = str(conanfile.settings.build_type)
     except ConanException:
@@ -32,10 +27,12 @@ def cmake_layout(conanfile, generator=None, external_sources=False):
         conanfile.folders.build = "cmake-build-{}".format(build_type)
         conanfile.folders.generators = os.path.join(conanfile.folders.build, "conan")
 
-    if not external_sources:
+    if src_folder == ".":
+        # The CMakeLists.txt is in the root, the includes (and sources) typically don't
         conanfile.cpp.source.includedirs = ["src"]
     else:
         conanfile.cpp.source.includedirs = ["."]
+
     if multi:
         conanfile.cpp.build.libdirs = ["{}".format(build_type)]
         conanfile.cpp.build.bindirs = ["{}".format(build_type)]

--- a/conan/tools/cmake/layout.py
+++ b/conan/tools/cmake/layout.py
@@ -27,11 +27,7 @@ def cmake_layout(conanfile, generator=None, src_folder="."):
         conanfile.folders.build = "cmake-build-{}".format(build_type)
         conanfile.folders.generators = os.path.join(conanfile.folders.build, "conan")
 
-    if src_folder == ".":
-        # The CMakeLists.txt is in the root, the includes (and sources) typically don't
-        conanfile.cpp.source.includedirs = ["src"]
-    else:
-        conanfile.cpp.source.includedirs = ["."]
+    conanfile.cpp.source.includedirs = ["include"]
 
     if multi:
         conanfile.cpp.build.libdirs = ["{}".format(build_type)]

--- a/conan/tools/cmake/layout.py
+++ b/conan/tools/cmake/layout.py
@@ -3,7 +3,7 @@ import os
 from conans.errors import ConanException
 
 
-def cmake_layout(conanfile, generator=None):
+def cmake_layout(conanfile, generator=None, external_sources=False):
     gen = conanfile.conf.get("tools.cmake.cmaketoolchain:generator", default=generator)
     if gen:
         multi = "Visual" in gen or "Xcode" in gen or "Multi-Config" in gen
@@ -14,7 +14,12 @@ def cmake_layout(conanfile, generator=None):
         else:
             multi = False
 
-    conanfile.folders.source = "."
+    if not external_sources:
+        # The CMakeLists.txt is typically in the root
+        conanfile.folders.source = "."
+    else:
+        # Cloned/unzipped in a subdirectory
+        conanfile.folders.source = "src"
     try:
         build_type = str(conanfile.settings.build_type)
     except ConanException:
@@ -27,7 +32,10 @@ def cmake_layout(conanfile, generator=None):
         conanfile.folders.build = "cmake-build-{}".format(build_type)
         conanfile.folders.generators = os.path.join(conanfile.folders.build, "conan")
 
-    conanfile.cpp.source.includedirs = ["src"]
+    if not external_sources:
+        conanfile.cpp.source.includedirs = ["src"]
+    else:
+        conanfile.cpp.source.includedirs = ["."]
     if multi:
         conanfile.cpp.build.libdirs = ["{}".format(build_type)]
         conanfile.cpp.build.bindirs = ["{}".format(build_type)]

--- a/conan/tools/layout/__init__.py
+++ b/conan/tools/layout/__init__.py
@@ -4,12 +4,11 @@ from conan.tools.cmake import cmake_layout, clion_layout
 from conan.tools.microsoft import vs_layout
 
 
-def basic_layout(conanfile, external_sources=False):
+def basic_layout(conanfile, src_folder="."):
     conanfile.folders.build = "build"
     if conanfile.settings.get_safe("build_type"):
         conanfile.folders.build += "-{}".format(str(conanfile.settings.build_type).lower())
     conanfile.folders.generators = os.path.join(conanfile.folders.build, "conan")
     conanfile.cpp.build.bindirs = ["."]
     conanfile.cpp.build.libdirs = ["."]
-    if external_sources:
-        conanfile.folders.source = "src"
+    conanfile.folders.source = src_folder

--- a/conan/tools/layout/__init__.py
+++ b/conan/tools/layout/__init__.py
@@ -1,3 +1,15 @@
+import os
 # FIXME: Temporary fixes to avoid breaking 1.45, to be removed 2.0
 from conan.tools.cmake import cmake_layout, clion_layout
 from conan.tools.microsoft import vs_layout
+
+
+def basic_layout(conanfile, external_sources=False):
+    conanfile.folders.build = "build"
+    if conanfile.settings.get_safe("build_type"):
+        conanfile.folders.build += "-{}".format(str(conanfile.settings.build_type).lower())
+    conanfile.folders.generators = os.path.join(conanfile.folders.build, "conan")
+    conanfile.cpp.build.bindirs = ["."]
+    conanfile.cpp.build.libdirs = ["."]
+    if external_sources:
+        conanfile.folders.source = "src"

--- a/conan/tools/meson/__init__.py
+++ b/conan/tools/meson/__init__.py
@@ -1,3 +1,3 @@
 from conan.tools.meson.toolchain import MesonToolchain
 from conan.tools.meson.meson import Meson
-from conan.tools.meson.layout import meson_layout
+

--- a/conan/tools/meson/layout.py
+++ b/conan/tools/meson/layout.py
@@ -1,8 +1,0 @@
-import os
-
-
-def meson_layout(conanfile):
-    conanfile.folders.build = "build-{}".format(str(conanfile.settings.build_type).lower())
-    conanfile.folders.generators = os.path.join(conanfile.folders.build, "conan")
-    conanfile.cpp.build.bindirs = ["."]
-    conanfile.cpp.build.libdirs = ["."]

--- a/conans/assets/templates/new_v2_cmake.py
+++ b/conans/assets/templates/new_v2_cmake.py
@@ -19,7 +19,7 @@ class {package_name}Conan(ConanFile):
     default_options = {{"shared": False, "fPIC": True}}
 
     # Sources are located in the same place as this recipe, copy them to the recipe
-    exports_sources = "CMakeLists.txt", "src/*"
+    exports_sources = "CMakeLists.txt", "src/*", "include/*"
 
     def config_options(self):
         if self.settings.os == "Windows":
@@ -88,8 +88,9 @@ cmake_v2 = """cmake_minimum_required(VERSION 3.15)
 project({name} CXX)
 
 add_library({name} src/{name}.cpp)
+target_include_directories({name} PUBLIC include)
 
-set_target_properties({name} PROPERTIES PUBLIC_HEADER "src/{name}.h")
+set_target_properties({name} PROPERTIES PUBLIC_HEADER "include/{name}.h")
 install(TARGETS {name} DESTINATION "."
         PUBLIC_HEADER DESTINATION include
         RUNTIME DESTINATION bin
@@ -213,7 +214,7 @@ def get_cmake_lib_files(name, version, package_name="Pkg"):
     files = {"conanfile.py": conanfile_sources_v2.format(name=name, version=version,
                                                          package_name=package_name),
              "src/{}.cpp".format(name): source_cpp.format(name=name, version=version),
-             "src/{}.h".format(name): source_h.format(name=name, version=version),
+             "include/{}.h".format(name): source_h.format(name=name, version=version),
              "CMakeLists.txt": cmake_v2.format(name=name, version=version),
              "test_package/conanfile.py": test_conanfile_v2.format(name=name,
                                                                    version=version,
@@ -242,7 +243,7 @@ class {package_name}Conan(ConanFile):
     settings = "os", "compiler", "build_type", "arch"
 
     # Sources are located in the same place as this recipe, copy them to the recipe
-    exports_sources = "CMakeLists.txt", "src/*"
+    exports_sources = "CMakeLists.txt", "src/*", "include/*"
 
     def layout(self):
         cmake_layout(self)
@@ -265,6 +266,7 @@ cmake_exe_v2 = """cmake_minimum_required(VERSION 3.15)
 project({name} CXX)
 
 add_executable({name} src/{name}.cpp src/main.cpp)
+target_include_directories({name} PUBLIC include)
 
 install(TARGETS {name} DESTINATION "."
         RUNTIME DESTINATION bin
@@ -294,7 +296,7 @@ def get_cmake_exe_files(name, version, package_name="Pkg"):
     files = {"conanfile.py": conanfile_exe.format(name=name, version=version,
                                                   package_name=package_name),
              "src/{}.cpp".format(name): source_cpp.format(name=name, version=version),
-             "src/{}.h".format(name): source_h.format(name=name, version=version),
+             "include/{}.h".format(name): source_h.format(name=name, version=version),
              "src/main.cpp": test_main.format(name=name),
              "CMakeLists.txt": cmake_exe_v2.format(name=name, version=version),
              "test_package/conanfile.py": test_conanfile_exe_v2.format(name=name,

--- a/conans/assets/templates/new_v2_meson.py
+++ b/conans/assets/templates/new_v2_meson.py
@@ -2,7 +2,8 @@ from conans.assets.templates.new_v2_cmake import source_cpp, source_h, test_main
 
 conanfile_sources_v2 = """import os
 from conan import ConanFile
-from conan.tools.meson import MesonToolchain, Meson, meson_layout
+from conan.tools.meson import MesonToolchain, Meson
+from conan.tools.layout import basic_layout
 from conan.tools.files import copy
 
 class {package_name}Conan(ConanFile):
@@ -22,7 +23,7 @@ class {package_name}Conan(ConanFile):
             del self.options.fPIC
 
     def layout(self):
-        meson_layout(self)
+        basic_layout(self)
 
     def generate(self):
         tc = MesonToolchain(self)
@@ -50,7 +51,8 @@ class {package_name}Conan(ConanFile):
 test_conanfile_v2 = """import os
 from conan import ConanFile
 from conans import tools
-from conan.tools.meson import MesonToolchain, Meson, meson_layout
+from conan.tools.meson import MesonToolchain, Meson
+from conan.tools.layout import basic_layout
 
 
 class {package_name}TestConan(ConanFile):
@@ -66,7 +68,7 @@ class {package_name}TestConan(ConanFile):
         meson.build()
 
     def layout(self):
-        meson_layout(self)
+        basic_layout(self)
 
     def test(self):
         if not tools.cross_building(self):

--- a/conans/test/assets/cmake.py
+++ b/conans/test/assets/cmake.py
@@ -33,6 +33,7 @@ def gen_cmakelists(language="CXX", verify=True, project="project", libname="myli
 
         {% if libsources %}
         add_library({{libname}} {{libtype}} {% for s in libsources %} {{s}} {% endfor %})
+        target_include_directories({{libname}} PUBLIC "include")
         {% endif %}
 
         {% if libsources and find_package %}
@@ -49,6 +50,7 @@ def gen_cmakelists(language="CXX", verify=True, project="project", libname="myli
 
         {% if appsources %}
         add_executable({{appname}} {% for s in appsources %} {{s}} {% endfor %})
+        target_include_directories({{appname}} PUBLIC "include")
         {% endif %}
 
         {% if appsources and libsources %}

--- a/conans/test/assets/pkg_cmake.py
+++ b/conans/test/assets/pkg_cmake.py
@@ -17,7 +17,7 @@ def pkg_cmake(name, version, requires=None, exe=False):
         class Pkg(ConanFile):
             name = "{pkg_name}"
             version = "{version}"
-            exports_sources = "CMakeLists.txt", "src/*"
+            exports_sources = "CMakeLists.txt", "src/*", "include/*"
             {deps}
             settings = "os", "compiler", "arch", "build_type"
             options = {{"shared": [True, False]}}
@@ -33,7 +33,7 @@ def pkg_cmake(name, version, requires=None, exe=False):
                 cmake.build()
 
             def package(self):
-                self.copy("*.h", dst="include", src="src")
+                self.copy("*.h", dst="include", src="include")
                 self.copy("*.lib", dst="lib", keep_path=False)
                 self.copy("*.dll", dst="bin", keep_path=False)
                 self.copy("*.dylib*", dst="lib", keep_path=False)
@@ -53,7 +53,7 @@ def pkg_cmake(name, version, requires=None, exe=False):
     src = gen_function_cpp(name=name, includes=deps, calls=deps)
 
     deps = [r.name for r in refs]
-    files = {"src/{}.h".format(name): hdr,
+    files = {"include/{}.h".format(name): hdr,
              "src/{}.cpp".format(name): src,
              "conanfile.py": conanfile}
     if exe:

--- a/conans/test/functional/layout/test_build_system_layout_helpers.py
+++ b/conans/test/functional/layout/test_build_system_layout_helpers.py
@@ -161,7 +161,7 @@ def test_cmake_layout_external_sources():
             exports_sources = "exported.txt"
 
             def layout(self):
-                cmake_layout(self, external_sources=True)
+                cmake_layout(self, src_folder="src")
 
             def generate(self):
                 save(self, "generate.txt", "generate")
@@ -208,7 +208,7 @@ def test_basic_layout_external_sources(with_build_type):
                 exports_sources = "exported.txt"
 
                 def layout(self):
-                    basic_layout(self, external_sources=True)
+                    basic_layout(self, src_folder="src")
 
                 def generate(self):
                     save(self, "generate.txt", "generate")

--- a/conans/test/functional/layout/test_build_system_layout_helpers.py
+++ b/conans/test/functional/layout/test_build_system_layout_helpers.py
@@ -157,7 +157,7 @@ def test_cmake_layout_external_sources():
         from conan.tools.cmake import cmake_layout
         from conan.tools.files import save, copy, load
         class Pkg(ConanFile):
-            settings = "os", "compiler", "arch", "build_type"
+            settings = "os", "build_type"
             exports_sources = "exported.txt"
 
             def layout(self):
@@ -180,11 +180,11 @@ def test_cmake_layout_external_sources():
 
     client = TestClient()
     client.save({"conanfile.py": conanfile, "exported.txt": "exported_contents"})
-    client.run("create . foo/1.0@")
+    client.run("create . foo/1.0@ -s os=Linux")
     assert "Packaged 1 '.txt' file: build.txt" in client.out
 
     # Local flow
-    client.run("install . foo/1.0")
+    client.run("install . foo/1.0 -s os=Linux")
     assert os.path.exists(os.path.join(client.current_folder, "cmake-build-release", "conan", "generate.txt"))
     client.run("source .")
     assert os.path.exists(os.path.join(client.current_folder, "src", "source.txt"))
@@ -230,12 +230,12 @@ def test_basic_layout_external_sources(with_build_type):
         conanfile = conanfile.format("")
     client = TestClient()
     client.save({"conanfile.py": conanfile, "exported.txt": "exported_contents"})
-    client.run("create . foo/1.0@")
+    client.run("create . foo/1.0@ -s os=Linux")
     assert "Packaged 1 '.txt' file: build.txt" in client.out
 
     # Local flow
     build_folder = "build-release" if with_build_type else "build"
-    client.run("install . foo/1.0")
+    client.run("install . foo/1.0 -s os=Linux")
     assert os.path.exists(os.path.join(client.current_folder, build_folder, "conan", "generate.txt"))
     client.run("source .")
     assert os.path.exists(os.path.join(client.current_folder, "src", "source.txt"))
@@ -279,11 +279,11 @@ def test_basic_layout_no_external_sources(with_build_type):
 
     client = TestClient()
     client.save({"conanfile.py": conanfile, "exported.txt": "exported_contents"})
-    client.run("create . foo/1.0@")
+    client.run("create . foo/1.0@ -s os=Linux")
     assert "Packaged 1 '.txt' file: build.txt" in client.out
 
     # Local flow
-    client.run("install . foo/1.0")
+    client.run("install . foo/1.0 -s os=Linux")
 
     build_folder = "build-release" if with_build_type else "build"
     assert os.path.exists(os.path.join(client.current_folder, build_folder, "conan", "generate.txt"))

--- a/conans/test/functional/layout/test_build_system_layout_helpers.py
+++ b/conans/test/functional/layout/test_build_system_layout_helpers.py
@@ -3,6 +3,7 @@ import platform
 import textwrap
 
 import pytest
+import six
 
 from conans.model.ref import ConanFileReference
 from conans.test.assets.genconanfile import GenConanfile
@@ -148,6 +149,7 @@ def test_error_no_build_type():
     assert " 'build_type' setting not defined, it is necessary for cmake_layout()" in client.out
 
 
+@pytest.mark.skipif(six.PY2, reason="only Py3")
 def test_cmake_layout_external_sources():
     conanfile = textwrap.dedent("""
         import os
@@ -193,6 +195,7 @@ def test_cmake_layout_external_sources():
     assert "Packaged 1 '.txt' file: build.txt" in client.out
 
 
+@pytest.mark.skipif(six.PY2, reason="only Py3")
 @pytest.mark.parametrize("with_build_type", [True, False])
 def test_basic_layout_external_sources(with_build_type):
     conanfile = textwrap.dedent("""
@@ -243,6 +246,7 @@ def test_basic_layout_external_sources(with_build_type):
     assert "Packaged 1 '.txt' file: build.txt" in client.out
 
 
+@pytest.mark.skipif(six.PY2, reason="only Py3")
 @pytest.mark.parametrize("with_build_type", [True, False])
 def test_basic_layout_no_external_sources(with_build_type):
     conanfile = textwrap.dedent("""

--- a/conans/test/functional/layout/test_build_system_layout_helpers.py
+++ b/conans/test/functional/layout/test_build_system_layout_helpers.py
@@ -7,7 +7,7 @@ import pytest
 from conans.model.ref import ConanFileReference
 from conans.test.assets.genconanfile import GenConanfile
 from conans.test.utils.tools import TestClient, TurboTestClient
-from conans.util.files import save
+from conans.util.files import save, load
 
 
 @pytest.fixture
@@ -146,3 +146,146 @@ def test_error_no_build_type():
     client.save({"conanfile.py": conanfile})
     client.run('install .',  assert_error=True)
     assert " 'build_type' setting not defined, it is necessary for cmake_layout()" in client.out
+
+
+def test_cmake_layout_external_sources():
+    conanfile = textwrap.dedent("""
+        import os
+        from conans import ConanFile
+        from conan.tools.cmake import cmake_layout
+        from conan.tools.files import save, copy, load
+        class Pkg(ConanFile):
+            settings = "os", "compiler", "arch", "build_type"
+            exports_sources = "exported.txt"
+
+            def layout(self):
+                cmake_layout(self, external_sources=True)
+
+            def generate(self):
+                save(self, "generate.txt", "generate")
+
+            def source(self):
+                save(self, "source.txt", "foo")
+
+            def build(self):
+                c1 = load(self, os.path.join(self.source_folder, "source.txt"))
+                c2 = load(self, os.path.join(self.source_folder, "..", "exported.txt"))
+                save(self, "build.txt", c1 + c2)
+
+            def package(self):
+                copy(self, "build.txt", self.build_folder, os.path.join(self.package_folder, "res"))
+        """)
+
+    client = TestClient()
+    client.save({"conanfile.py": conanfile, "exported.txt": "exported_contents"})
+    client.run("create . foo/1.0@")
+    assert "Packaged 1 '.txt' file: build.txt" in client.out
+
+    # Local flow
+    client.run("install . foo/1.0")
+    assert os.path.exists(os.path.join(client.current_folder, "cmake-build-release", "conan", "generate.txt"))
+    client.run("source .")
+    assert os.path.exists(os.path.join(client.current_folder, "src", "source.txt"))
+    client.run("build .")
+    contents = load(os.path.join(client.current_folder, "cmake-build-release", "build.txt"))
+    assert contents == "fooexported_contents"
+    client.run("export-pkg . foo/1.0@ --force")
+    assert "Packaged 1 '.txt' file: build.txt" in client.out
+
+
+@pytest.mark.parametrize("with_build_type", [True, False])
+def test_basic_layout_external_sources(with_build_type):
+    conanfile = textwrap.dedent("""
+            import os
+            from conans import ConanFile
+            from conan.tools.layout import basic_layout
+            from conan.tools.files import save, load, copy
+            class Pkg(ConanFile):
+                settings = "os", "compiler", "arch"{}
+                exports_sources = "exported.txt"
+
+                def layout(self):
+                    basic_layout(self, external_sources=True)
+
+                def generate(self):
+                    save(self, "generate.txt", "generate")
+
+                def source(self):
+                    save(self, "source.txt", "foo")
+
+                def build(self):
+                    c1 = load(self, os.path.join(self.source_folder, "source.txt"))
+                    c2 = load(self, os.path.join(self.source_folder, "..", "exported.txt"))
+                    save(self, "build.txt", c1 + c2)
+
+                def package(self):
+                    copy(self, "build.txt", self.build_folder, os.path.join(self.package_folder, "res"))
+            """)
+    if with_build_type:
+        conanfile = conanfile.format(', "build_type"')
+    else:
+        conanfile = conanfile.format("")
+    client = TestClient()
+    client.save({"conanfile.py": conanfile, "exported.txt": "exported_contents"})
+    client.run("create . foo/1.0@")
+    assert "Packaged 1 '.txt' file: build.txt" in client.out
+
+    # Local flow
+    build_folder = "build-release" if with_build_type else "build"
+    client.run("install . foo/1.0")
+    assert os.path.exists(os.path.join(client.current_folder, build_folder, "conan", "generate.txt"))
+    client.run("source .")
+    assert os.path.exists(os.path.join(client.current_folder, "src", "source.txt"))
+    client.run("build .")
+    contents = load(os.path.join(client.current_folder, build_folder, "build.txt"))
+    assert contents == "fooexported_contents"
+    client.run("export-pkg . foo/1.0@ --force")
+    assert "Packaged 1 '.txt' file: build.txt" in client.out
+
+
+@pytest.mark.parametrize("with_build_type", [True, False])
+def test_basic_layout_no_external_sources(with_build_type):
+    conanfile = textwrap.dedent("""
+            import os
+            from conans import ConanFile
+            from conan.tools.layout import basic_layout
+            from conan.tools.files import save, load, copy
+            class Pkg(ConanFile):
+                settings = "os", "compiler", "arch"{}
+                exports_sources = "exported.txt"
+
+                def layout(self):
+                    basic_layout(self)
+
+                def generate(self):
+                    save(self, "generate.txt", "generate")
+
+                def build(self):
+                    contents = load(self, os.path.join(self.source_folder, "exported.txt"))
+                    save(self, "build.txt", contents)
+
+                def package(self):
+                    copy(self, "build.txt", self.build_folder, os.path.join(self.package_folder,
+                                                                            "res"))
+            """)
+    if with_build_type:
+        conanfile = conanfile.format(', "build_type"')
+    else:
+        conanfile = conanfile.format("")
+
+    client = TestClient()
+    client.save({"conanfile.py": conanfile, "exported.txt": "exported_contents"})
+    client.run("create . foo/1.0@")
+    assert "Packaged 1 '.txt' file: build.txt" in client.out
+
+    # Local flow
+    client.run("install . foo/1.0")
+
+    build_folder = "build-release" if with_build_type else "build"
+    assert os.path.exists(os.path.join(client.current_folder, build_folder, "conan", "generate.txt"))
+
+    client.run("build .")
+    contents = load(os.path.join(client.current_folder, build_folder, "build.txt"))
+    assert contents == "exported_contents"
+    client.run("export-pkg . foo/1.0@ --force")
+    assert "Packaged 1 '.txt' file: build.txt" in client.out

--- a/conans/test/functional/toolchains/cmake/cmakedeps/test_cmakedeps_and_linker_flags.py
+++ b/conans/test/functional/toolchains/cmake/cmakedeps/test_cmakedeps_and_linker_flags.py
@@ -26,7 +26,7 @@ def test_shared_link_flags():
         settings = "os", "compiler", "build_type", "arch"
         options = {"shared": [True, False]}
         default_options = {"shared": False}
-        exports_sources = "CMakeLists.txt", "src/*"
+        exports_sources = "CMakeLists.txt", "src/*", "include/*"
         generators = "CMakeDeps", "CMakeToolchain"
 
         def layout(self):

--- a/conans/test/functional/toolchains/cmake/cmakedeps/test_weird_library_names.py
+++ b/conans/test/functional/toolchains/cmake/cmakedeps/test_weird_library_names.py
@@ -73,7 +73,7 @@ def test_cmake_find_package(client_weird_lib_name):
         from conans import ConanFile, CMake
 
         class Pkg(ConanFile):
-            exports_sources = "CMakeLists.txt", "src/*"
+            exports_sources = "CMakeLists.txt", "src/*", "include/*"
             settings = "os", "compiler", "arch", "build_type"
             generators = "cmake_find_package"
             requires = "hello/0.1"
@@ -99,7 +99,7 @@ def test_cmake_find_package_multi(client_weird_lib_name):
         from conans import ConanFile, CMake
 
         class Pkg(ConanFile):
-            exports_sources = "CMakeLists.txt", "src/*"
+            exports_sources = "CMakeLists.txt", "src/*", "include/*"
             settings = "os", "compiler", "arch", "build_type"
             generators = "cmake_find_package_multi"
             requires = "hello/0.1"


### PR DESCRIPTION
Changelog: Feature: Added `basic_layout`, removed `meson_layout` and added argument `src_folder` to `cmake_layout`as a shortcut for adjusting `conanfile.folders.source`.
Docs: https://github.com/conan-io/docs/pull/2426

Close https://github.com/conan-io/conan/issues/10645
