### PR TITLE
[Bugfix] `GnuDepsFlags` Apple flags

### DIFF
--- a/conans/test/unittests/client/toolchain/autotools/autotools_deps_test.py
+++ b/conans/test/unittests/client/toolchain/autotools/autotools_deps_test.py
@@ -69,6 +69,7 @@ def test_foo():
         consumer.settings = MockSettings(
             {"build_type": "Release",
              "arch": "x86",
+             "os": "Macos",
              "compiler": "gcc",
              "compiler.libcxx": "libstdc++11",
              "compiler.version": "7.1",

--- a/conans/test/unittests/tools/gnu/gnudepsflags_test.py
+++ b/conans/test/unittests/tools/gnu/gnudepsflags_test.py
@@ -1,0 +1,33 @@
+import pytest
+from mock import MagicMock
+
+from conan.tools.apple.apple import is_apple_os
+from conan.tools.gnu.gnudeps_flags import GnuDepsFlags
+from conans.test.utils.mocks import ConanFileMock, MockSettings
+
+
+@pytest.mark.parametrize("os_", ["Macos", "Windows", "Linux"])
+def test_framework_flags_only_for_apple_os(os_):
+    """
+    Testing GnuDepsFlags attributes exclusively for Apple OS, frameworks and framework_paths
+    """
+    # Issue: https://github.com/conan-io/conan/issues/10651
+    # Issue: https://github.com/conan-io/conan/issues/10640
+    settings = MockSettings({"build_type": "Release",
+                             "compiler": "gcc",
+                             "compiler.version": "10.2",
+                             "os": os_,
+                             "arch": "x86_64"})
+    conanfile = ConanFileMock()
+    conanfile.settings = settings
+    cpp_info = MagicMock()
+    cpp_info.frameworks = ["Foundation"]
+    cpp_info.frameworkdirs = ["Framework"]
+    gnudepsflags = GnuDepsFlags(conanfile, cpp_info)
+    expected_framework = []
+    expected_framework_path = []
+    if is_apple_os(os_):
+        expected_framework = ["-framework Foundation"]
+        expected_framework_path = ["-F Framework"]
+    assert gnudepsflags.frameworks == expected_framework
+    assert gnudepsflags.framework_paths == expected_framework_path


### PR DESCRIPTION
Changelog: Bugfix: `GnuDepsFlags` attributes like `frameworks` and `frameworkdirs` are only available for Apple OS.
Closes: https://github.com/conan-io/conan/issues/10640
Closes: https://github.com/conan-io/conan/issues/10651
Docs: omit

- [x] Refer to the issue that supports this Pull Request.
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 

<sup>**Note:** By default this PR will skip the slower tests and will use a limited set of python versions. Check [here](https://github.com/conan-io/conan/blob/develop/.github/PR_INCREASE_TESTING.md) how to increase the testing level by writing some tags in the current PR body text.</sup>
