### PR TITLE
add system_libs to AutotoolsDeps

### DIFF
--- a/conan/tools/gnu/autotoolsdeps.py
+++ b/conan/tools/gnu/autotoolsdeps.py
@@ -37,6 +37,10 @@ class AutotoolsDeps:
             ldflags.extend(flags.framework_paths)
             ldflags.extend(flags.lib_paths)
 
+            # libs
+            libs = flags.libs
+            libs.extend(flags.system_libs)
+
             # cflags
             cflags = flags.cflags
             cxxflags = flags.cxxflags
@@ -49,7 +53,7 @@ class AutotoolsDeps:
 
             env = Environment()
             env.append("CPPFLAGS", cpp_flags)
-            env.append("LIBS", flags.libs)
+            env.append("LIBS", libs)
             env.append("LDFLAGS", ldflags)
             env.append("CXXFLAGS", cxxflags)
             env.append("CFLAGS", cflags)

--- a/conan/tools/gnu/gnudeps_flags.py
+++ b/conan/tools/gnu/gnudeps_flags.py
@@ -2,6 +2,7 @@
     This is a helper class which offers a lot of useful methods and attributes
 """
 # FIXME: only for tools.gnu? perhaps it should be a global module
+from conan.tools.microsoft import is_msvc
 from conan.tools.microsoft.subsystems import subsystem_path, deduce_subsystem
 
 
@@ -25,7 +26,7 @@ class GnuDepsFlags(object):
         self.cflags = cpp_info.cflags or []
         self.sharedlinkflags = cpp_info.sharedlinkflags or []
         self.exelinkflags = cpp_info.exelinkflags or []
-        self.system_libs = cpp_info.system_libs or []
+        self.system_libs = self._format_libraries(cpp_info.system_libs)
 
         # Not used?
         # self.bin_paths
@@ -47,8 +48,7 @@ class GnuDepsFlags(object):
             return []
         # FIXME: Missing support for subsystems
         compiler = self._conanfile.settings.get_safe("compiler")
-        compiler_base = self._conanfile.settings.get_safe("compiler.base")
-        if (str(compiler) not in self._GCC_LIKE) and (str(compiler_base) not in self._GCC_LIKE):
+        if str(compiler) not in self._GCC_LIKE:
             return []
         return ["-framework %s" % framework for framework in frameworks]
 
@@ -60,15 +60,13 @@ class GnuDepsFlags(object):
         if not framework_paths:
             return []
         compiler = self._conanfile.settings.get_safe("compiler")
-        compiler_base = self._conanfile.settings.get_safe("compiler.base")
-        if (str(compiler) not in self._GCC_LIKE) and (str(compiler_base) not in self._GCC_LIKE):
+        if str(compiler) not in self._GCC_LIKE:
             return []
-        return ["-F %s" % self._adjust_path(framework_path) for framework_path in
-                framework_paths]
+        return ["-F %s" % self._adjust_path(framework_path) for framework_path in framework_paths]
 
     def _sysroot_flag(self, sysroot):
         # FIXME: Missing support for subsystems
-        if self._base_compiler != 'Visual Studio' and sysroot:
+        if not is_msvc(self._conanfile) and sysroot:
             sysroot = self._adjust_path(sysroot)
             return '--sysroot=%s' % sysroot
         return ""
@@ -84,7 +82,7 @@ class GnuDepsFlags(object):
         if not library_paths:
             return []
         # FIXME: Missing support for subsystems
-        pattern = "-LIBPATH:%s" if self._base_compiler == 'Visual Studio' else "-L%s"
+        pattern = "-LIBPATH:%s" if is_msvc(self._conanfile) else "-L%s"
         return [pattern % self._adjust_path(library_path)
                 for library_path in library_paths if library_path]
 
@@ -93,10 +91,8 @@ class GnuDepsFlags(object):
             return []
 
         result = []
-        compiler = self._conanfile.settings.get_safe("compiler")
-        compiler_base = self._conanfile.settings.get_safe("compiler.base")
         for library in libraries:
-            if str(compiler) == 'Visual Studio' or str(compiler_base) == 'Visual Studio':
+            if is_msvc(self._conanfile):
                 if not library.endswith(".lib"):
                     library += ".lib"
                 result.append(library)
@@ -105,15 +101,10 @@ class GnuDepsFlags(object):
         return result
 
     def _adjust_path(self, path):
-        if self._base_compiler == 'Visual Studio':
+        if is_msvc(self._conanfile):
             path = path.replace('/', '\\')
         else:
             path = path.replace('\\', '/')
 
         path = subsystem_path(self._subsystem, path)
         return '"%s"' % path if ' ' in path else path
-
-    @property
-    def _base_compiler(self):
-        return str(self._conanfile.settings.get_safe("compiler.base") or
-                   self._conanfile.settings.get_safe("compiler"))

--- a/conans/test/unittests/client/toolchain/autotools/autotools_deps_test.py
+++ b/conans/test/unittests/client/toolchain/autotools/autotools_deps_test.py
@@ -95,6 +95,10 @@ def test_foo():
 
         assert env["CXXFLAGS"] == 'dep1_a_cxx_flag dep2_a_cxx_flag --sysroot=/path/to/folder/dep1'
         assert env["CFLAGS"] == 'dep1_a_c_flag dep2_a_c_flag --sysroot=/path/to/folder/dep1'
+        assert env["LIBS"] == "-ldep1_onelib -ldep1_twolib -ldep2_onelib -ldep2_twolib "\
+                              "-ldep1_onesystemlib -ldep1_twosystemlib "\
+                              "-ldep2_onesystemlib -ldep2_twosystemlib"
+
         folder = temp_folder()
         consumer.folders.set_base_install(folder)
         deps.generate()


### PR DESCRIPTION
Changelog: Bugfix: Add missing ``system_libs`` management in ``AutotoolsDeps``.
Docs: Omit

Close https://github.com/conan-io/conan/issues/10674

Also simplifying ``compiler.base`` management, this is new, and Conan 2.0 has already removed support for it, so can be dropped