### PR TITLE
Add transitive dependencies to generated Bazel BUILD files

### DIFF
--- a/conan/tools/google/bazeldeps.py
+++ b/conan/tools/google/bazeldeps.py
@@ -83,6 +83,9 @@ class BazelDeps(object):
                 {% for lib in libs %}
                 ":{{ lib }}_precompiled",
                 {% endfor %}
+                {% for dep in dependencies %}
+                "@{{ dep }}",
+                {% endfor %}
                 ],
                 {% endif %}
             )
@@ -126,6 +129,10 @@ class BazelDeps(object):
         if len(cpp_info.libdirs) != 0:
             lib_dir = _relativize_path(cpp_info.libdirs[0], package_folder)
 
+        dependencies = []
+        for req, dep in dependency.dependencies.items():
+            dependencies.append(dep.ref.name)
+
         shared_library = dependency.options.get_safe("shared") if dependency.options else False
         context = {
             "name": dependency.ref.name,
@@ -136,7 +143,8 @@ class BazelDeps(object):
             "defines": defines,
             "linkopts": linkopts,
             "library_type": "shared_library" if shared_library else "static_library",
-            "extension": "so" if shared_library else "a"
+            "extension": "so" if shared_library else "a",
+            "dependencies": dependencies,
         }
         content = Template(template).render(**context)
         return content

--- a/conans/test/unittests/tools/google/test_bazeldeps.py
+++ b/conans/test/unittests/tools/google/test_bazeldeps.py
@@ -39,6 +39,56 @@ def test_bazeldeps_dependency_buildfiles():
             assert 'deps = [\n    \n    ":lib1_precompiled",' in dependency_content
 
 
+def test_bazeldeps_dependency_transitive():
+    # Create main ConanFile
+    conanfile = ConanFile(Mock(), None)
+
+    cpp_info = CppInfo("mypkg", "dummy_root_folder1")
+    cpp_info.defines = ["DUMMY_DEFINE=\"string/value\""]
+    cpp_info.system_libs = ["system_lib1"]
+    cpp_info.libs = ["lib1"]
+
+    # Create a ConanFile for a direct dependency
+    conanfile_dep = ConanFile(Mock(), None)
+    conanfile_dep.cpp_info = cpp_info
+    conanfile_dep._conan_node = Mock()
+    conanfile_dep._conan_node.ref = ConanFileReference.loads("OriginalDepName/1.0")
+    conanfile_dep.folders.set_base_package("/path/to/folder_dep")
+
+    # Add dependency on the direct dependency
+    req = Requirement(ConanFileReference.loads("OriginalDepName/1.0"))
+    conanfile._conan_dependencies = ConanFileDependencies({req: ConanFileInterface(conanfile_dep)})
+
+    cpp_info_transitive = CppInfo("mypkg_t", "dummy_root_folder1")
+    cpp_info_transitive.defines = ["DUMMY_DEFINE=\"string/value\""]
+    cpp_info_transitive.system_libs = ["system_lib1"]
+    cpp_info_transitive.libs = ["lib_t1"]
+
+    # Create a ConanFile for a transitive dependency
+    conanfile_dep_transitive = ConanFile(Mock(), None)
+    conanfile_dep_transitive.cpp_info = cpp_info_transitive
+    conanfile_dep_transitive._conan_node = Mock()
+    conanfile_dep_transitive._conan_node.ref = ConanFileReference.loads("TransitiveDepName/1.0")
+    conanfile_dep_transitive.folders.set_base_package("/path/to/folder_dep_t")
+
+    # Add dependency from the direct dependency to the transitive dependency
+    req = Requirement(ConanFileReference.loads("TransitiveDepName/1.0"))
+    conanfile_dep._conan_dependencies = ConanFileDependencies(
+        {req: ConanFileInterface(conanfile_dep_transitive)})
+
+    bazeldeps = BazelDeps(conanfile)
+
+    for dependency in bazeldeps._conanfile.dependencies.host.values():
+        dependency_content = bazeldeps._get_dependency_buildfile_content(dependency)
+        assert 'cc_library(\n    name = "OriginalDepName",' in dependency_content
+        assert 'defines = ["DUMMY_DEFINE=\'string/value\'"],' in dependency_content
+        assert 'linkopts = ["-lsystem_lib1"],' in dependency_content
+        # Ensure that transitive dependency is referenced by the 'deps' attribute of the direct
+        # dependency
+        assert re.search(r'deps =\s*\[\s*":lib1_precompiled",\s*"@TransitiveDepName"',
+                         dependency_content)
+
+
 def test_bazeldeps_interface_buildfiles():
     conanfile = ConanFile(Mock(), None)
 


### PR DESCRIPTION
Changelog: Bugfix: Add transitive dependencies to generated Bazel BUILD files.
Docs: omit

Fixes #10685

Previously the Bazel generator wasn't adding transitive dependencies to the `deps` field of the BUILD file for each dependency. This results in Bazel's build graph being incorrect and causing issues with things like linking order. This change fixes #10685 by inserting these dependencies.