### PR TITLE
add GitHub URL for PyPi

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -65,7 +65,9 @@ setup(
     # The project's main homepage.
     url='https://conan.io',
     project_urls={
+        'Documentation': 'https://docs.conan.io',
         'Source': 'https://github.com/conan-io/conan',
+        'Tracker': 'https://github.com/conan-io/conan/issues',
     },
 
     # Author details

--- a/setup.py
+++ b/setup.py
@@ -64,6 +64,9 @@ setup(
 
     # The project's main homepage.
     url='https://conan.io',
+    project_urls={
+        'Source': 'https://github.com/conan-io/conan',
+    },
 
     # Author details
     author='JFrog LTD',


### PR DESCRIPTION
Warehouse now uses the project_urls provided to display links in the sidebar on [this screen](https://pypi.org/project/requests/), as well as including them in API responses to help automation tool find the source code for Requests.

[packaging.python.org/en/latest/guides/distributing-packages-using-setuptools/#project-urls](https://packaging.python.org/en/latest/guides/distributing-packages-using-setuptools/#project-urls)

Changelog: omit
Docs: omit

- [ ] Refer to the issue that supports this Pull Request.
- [ ] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [ ] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [ ] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 

<sup>**Note:** By default this PR will skip the slower tests and will use a limited set of python versions. Check [here](https://github.com/conan-io/conan/blob/develop/.github/PR_INCREASE_TESTING.md) how to increase the testing level by writing some tags in the current PR body text.</sup>
