### PR TITLE
Better isolation for jinja rendering of global.conf

### DIFF
--- a/conans/client/cache/cache.py
+++ b/conans/client/cache/cache.py
@@ -3,7 +3,7 @@ import platform
 import shutil
 from collections import OrderedDict
 
-from jinja2 import Environment, select_autoescape, FileSystemLoader, ChoiceLoader
+from jinja2 import Environment, select_autoescape, FileSystemLoader, ChoiceLoader, Template
 
 from conans.assets.templates import dict_loader
 from conans.client.cache.editable import EditablePackages
@@ -169,7 +169,9 @@ class ClientCache(object):
         if self._new_config is None:
             self._new_config = ConfDefinition()
             if os.path.exists(self.new_config_path):
-                self._new_config.loads(load(self.new_config_path))
+                text = load(self.new_config_path)
+                content = Template(text).render({"platform": platform, "os": os})
+                self._new_config.loads(content)
         return self._new_config
 
     @property

--- a/conans/model/conf.py
+++ b/conans/model/conf.py
@@ -1,13 +1,9 @@
 import fnmatch
-import os
-import platform
 from collections import OrderedDict
 
 import six
-from jinja2 import Template
 
 from conans.errors import ConanException
-
 
 BUILT_IN_CONFS = {
     "core:required_conan_version": "Raise if current version does not match the defined range.",
@@ -474,7 +470,6 @@ class ConfDefinition:
         return parsed_value
 
     def loads(self, text, profile=False):
-        text = Template(text).render({"platform": platform, "os": os})
         self._pattern_confs = {}
 
         for line in text.splitlines():


### PR DESCRIPTION
Changelog: omit
Docs: omit

Same as https://github.com/conan-io/conan/pull/10687