### PR TITLE
markupsafe pinning

### DIFF
--- a/conans/requirements.txt
+++ b/conans/requirements.txt
@@ -11,7 +11,7 @@ distro>=1.0.2, <=1.6.0; sys_platform == 'linux' or sys_platform == 'linux2'
 pygments>=2.0, <3.0
 tqdm>=4.28.1, <5
 Jinja2>=2.9, <3.0.0;python_version<='2.7'
-MarkupSafe==2.0.1;python_version<='2.7'
+MarkupSafe<=2.0.1;python_version<='2.7'
 Jinja2>=3.0, <4.0.0;python_version>='3'
 python-dateutil>=2.7.0, <3
 configparser>=3.5;python_version<='2.7'

--- a/conans/requirements.txt
+++ b/conans/requirements.txt
@@ -10,6 +10,8 @@ node-semver==0.6.1
 distro>=1.0.2, <=1.6.0; sys_platform == 'linux' or sys_platform == 'linux2'
 pygments>=2.0, <3.0
 tqdm>=4.28.1, <5
-Jinja2>=2.9, <4.0.0
+Jinja2>=2.9, <3.0.0;python_version<='2.7'
+MarkupSafe==2.0.1;python_version<='2.7'
+Jinja2>=3.0, <4.0.0;python_version>='3'
 python-dateutil>=2.7.0, <3
 configparser>=3.5;python_version<='2.7'


### PR DESCRIPTION
Changelog: Fix: Pin Markupsafe==2.0.1 for py27 and upgrade Jinja2>3 for py3, after Markupsafe latest 2.1 release broke Jinja2 2.11.
Docs: Omit