### PR TITLE
[develop2] adding package_id: package_revision to lockfiles

### DIFF
--- a/conans/cli/api/subapi/graph.py
+++ b/conans/cli/api/subapi/graph.py
@@ -128,10 +128,11 @@ class GraphAPI:
         return deps_graph
 
     @api_method
-    def analyze_binaries(self, graph, build_mode=None, remotes=None, update=None):
+    def analyze_binaries(self, graph, build_mode=None, remotes=None, update=None, lockfile=None):
         """ Given a dependency graph, will compute the package_ids of all recipes in the graph, and
         evaluate if they should be built from sources, downloaded from a remote server, of if the
         packages are already in the local Conan cache
+        :param lockfile:
         :param graph: a Conan dependency graph, as returned by "load_graph()"
         :param build_mode: TODO: Discuss if this should be a BuildMode object or list of arguments
         :param remotes: list of remotes
@@ -142,4 +143,4 @@ class GraphAPI:
         conan_app.load_remotes(remotes, update=update)
         graph.report_graph_error()
         binaries_analyzer = GraphBinariesAnalyzer(conan_app)
-        binaries_analyzer.evaluate_graph(graph, build_mode)
+        binaries_analyzer.evaluate_graph(graph, build_mode, lockfile)

--- a/conans/cli/commands/create.py
+++ b/conans/cli/commands/create.py
@@ -87,7 +87,8 @@ def create(conan_api, parser, *args):
         build_modes = [ref.name]
     else:
         build_modes = args.build
-    conan_api.graph.analyze_binaries(deps_graph, build_modes, remotes=remotes, update=args.update)
+    conan_api.graph.analyze_binaries(deps_graph, build_modes, remotes=remotes, update=args.update,
+                                     lockfile=lockfile)
     print_graph_packages(deps_graph)
 
     out.highlight("\n-------- Installing packages ----------")

--- a/conans/cli/commands/export_pkg.py
+++ b/conans/cli/commands/export_pkg.py
@@ -38,7 +38,7 @@ def export_pkg(conan_api, parser, *args, **kwargs):
                                             lockfile=lockfile,
                                             remotes=None,
                                             update=None)
-    conan_api.graph.analyze_binaries(deps_graph, build_mode=[ref.name])
+    conan_api.graph.analyze_binaries(deps_graph, build_mode=[ref.name], lockfile=lockfile)
     deps_graph.report_graph_error()
 
     conan_api.export.export_pkg(deps_graph, path)

--- a/conans/cli/commands/install.py
+++ b/conans/cli/commands/install.py
@@ -92,7 +92,8 @@ def graph_compute(args, conan_api, strict=False):
                                             check_update=check_updates)
     print_graph_basic(deps_graph)
     out.highlight("\n-------- Computing necessary packages ----------")
-    conan_api.graph.analyze_binaries(deps_graph, args.build, remotes=remotes, update=args.update)
+    conan_api.graph.analyze_binaries(deps_graph, args.build, remotes=remotes, update=args.update,
+                                     lockfile=lockfile)
     print_graph_packages(deps_graph)
 
     return deps_graph, lockfile

--- a/conans/cli/commands/lock.py
+++ b/conans/cli/commands/lock.py
@@ -32,9 +32,9 @@ def lock_create(conan_api, parser, subparser, *args):
     deps_graph, lockfile = graph_compute(args, conan_api, strict=False)
 
     if lockfile is None or args.clean:
-        lockfile = Lockfile(deps_graph)
+        lockfile = Lockfile(deps_graph, args.lockfile_packages)
     else:
-        lockfile.update_lock(deps_graph)
+        lockfile.update_lock(deps_graph, args.lockfile_packages)
 
     lockfile_out = make_abs_path(args.lockfile_out or "conan.lock")
     lockfile.save(lockfile_out)

--- a/conans/cli/commands/test.py
+++ b/conans/cli/commands/test.py
@@ -61,7 +61,8 @@ def test(conan_api, parser, *args):
                                             check_update=check_updates)
     print_graph_basic(deps_graph)
     out.highlight("\n-------- Computing necessary packages ----------")
-    conan_api.graph.analyze_binaries(deps_graph, remotes=remotes, update=args.update)
+    conan_api.graph.analyze_binaries(deps_graph, remotes=remotes, update=args.update,
+                                     lockfile=lockfile)
     print_graph_packages(deps_graph)
 
     out.highlight("\n-------- Installing packages ----------")

--- a/conans/cli/common.py
+++ b/conans/cli/common.py
@@ -105,6 +105,8 @@ def add_lockfile_args(parser):
                         help="Raise an error if some dependency is not found in lockfile")
     parser.add_argument("--lockfile-out", action=OnceArgument,
                         help="Filename of the updated lockfile")
+    parser.add_argument("--lockfile-packages", action="store_true",
+                        help="Lock package-id and package-revision information")
 
 
 def get_profiles_from_args(conan_api, args):

--- a/conans/model/graph_lock.py
+++ b/conans/model/graph_lock.py
@@ -26,6 +26,9 @@ class _LockRequires:
     def refs(self):
         return self._requires.keys()
 
+    def get(self, item):
+        return self._requires.get(item)
+
     def serialize(self):
         result = []
         for k, v in self._requires.items():
@@ -49,7 +52,7 @@ class _LockRequires:
         if package_ids is not None:
             self._requires.setdefault(ref, {}).update(package_ids)
         else:
-            self._requires[ref] = None
+            self._requires.setdefault(ref, None)  # To keep previous packgae_id: prev if exists
 
     def insert(self, ref):
         self._requires[ref] = None
@@ -167,6 +170,14 @@ class Lockfile(object):
         else:
             locked_refs = self._requires.refs()
         self._resolve(require, locked_refs)
+
+    def resolve_prev(self, node):
+        if node.context == CONTEXT_BUILD:
+            prevs = self._build_requires.get(node.ref)
+        else:
+            prevs = self._requires.get(node.ref)
+        if prevs:
+            return prevs.get(node.package_id)
 
     def _resolve(self, require, locked_refs):
         ref = require.ref

--- a/conans/model/graph_lock.py
+++ b/conans/model/graph_lock.py
@@ -1,5 +1,6 @@
 import json
 import os
+from collections import OrderedDict
 
 from conans.client.graph.graph import RECIPE_VIRTUAL, RECIPE_CONSUMER, CONTEXT_BUILD
 from conans.errors import ConanException
@@ -10,41 +11,101 @@ LOCKFILE = "conan.lock"
 LOCKFILE_VERSION = "0.5"
 
 
+class _LockRequires:
+    """
+    This is an ordered set of locked references.
+    It is implemented this way to allow adding package_id:prev information later,
+    otherwise it could be a bare list
+    """
+    def __init__(self):
+        self._requires = OrderedDict()  # {require: package_ids}
+
+    def __contains__(self, item):
+        return item in self._requires
+
+    def refs(self):
+        return self._requires.keys()
+
+    def serialize(self):
+        result = []
+        for k, v in self._requires.items():
+            if v is None:
+                result.append(repr(k))
+            else:
+                result.append((repr(k), v))
+        return result
+
+    @staticmethod
+    def deserialize(data):
+        result = _LockRequires()
+        for d in data:
+            if isinstance(d, str):
+                result._requires[RecipeReference.loads(d)] = None
+            else:
+                result._requires[RecipeReference.loads(d[0])] = d[1]
+        return result
+
+    def add(self, ref, package_ids=None):
+        if package_ids is not None:
+            self._requires.setdefault(ref, {}).update(package_ids)
+        else:
+            self._requires[ref] = None
+
+    def insert(self, ref):
+        self._requires[ref] = None
+        self._requires.move_to_end(ref, last=False)
+
+    def sort(self):
+        self._requires = OrderedDict(reversed(sorted(self._requires.items())))
+
+    def merge(self, other):
+        """
+        :type other: _LockRequires
+        """
+        for k, v in other._requires.items():
+            if k in self._requires:
+                if v is not None:
+                    self._requires.setdefault(k, {}).update(v)
+            else:
+                self._requires[k] = v
+        self.sort()
+
+
 class Lockfile(object):
 
-    def __init__(self, deps_graph=None):
-        self.requires = []
-        self.python_requires = []
-        self.build_requires = []
-        self.alias = {}
+    def __init__(self, deps_graph=None, lock_packages=False):
+        self._requires = _LockRequires()
+        self._python_requires = _LockRequires()
+        self._build_requires = _LockRequires()
+        self.alias = {}  # TODO: Alias locking needs to be tested more
         self.strict = False
 
         if deps_graph is None:
             return
 
-        requires = set()
-        python_requires = set()
-        build_requires = set()
+        self.update_lock(deps_graph, lock_packages)
+        self.alias = deps_graph.aliased
+
+    def update_lock(self, deps_graph, lock_packages=False):
         for graph_node in deps_graph.nodes:
             try:
-                python_requires.update(graph_node.conanfile.python_requires.all_refs())
+                for r in graph_node.conanfile.python_requires.all_refs():
+                    self._python_requires.add(r)
             except AttributeError:
                 pass
             if graph_node.recipe in (RECIPE_VIRTUAL, RECIPE_CONSUMER) or graph_node.ref is None:
                 continue
             assert graph_node.conanfile is not None
 
+            pids = {graph_node.package_id: graph_node.prev} if lock_packages else None
             if graph_node.context == CONTEXT_BUILD:
-                build_requires.add(graph_node.ref)
+                self._build_requires.add(graph_node.ref, pids)
             else:
-                requires.add(graph_node.ref)
+                self._requires.add(graph_node.ref, pids)
 
-        # Sorted, newer versions first, so first found is valid for version ranges
-        # TODO: Need to impmlement same ordering for revisions, based on revision time
-        self.requires = list(reversed(sorted(requires)))
-        self.python_requires = list(reversed(sorted(python_requires)))
-        self.build_requires = list(reversed(sorted(build_requires)))
-        self.alias = deps_graph.aliased
+        self._requires.sort()
+        self._build_requires.sort()
+        self._python_requires.sort()
 
     @staticmethod
     def load(path):
@@ -54,53 +115,40 @@ class Lockfile(object):
             raise ConanException("Missing lockfile in: %s" % path)
         content = load(path)
         try:
-            return Lockfile.deserialize(json.loads(content))
+            return Lockfile.loads(content)
         except Exception as e:
             raise ConanException("Error parsing lockfile '{}': {}".format(path, e))
 
+    @staticmethod
+    def loads(content):
+        return Lockfile.deserialize(json.loads(content))
+
+    def dumps(self):
+        return json.dumps(self.serialize(), indent=4)
+
     def save(self, path):
-        save(path, json.dumps(self.serialize(), indent=True))
-
-    def update_lock(self, deps_graph):
-        """ add new things at the beginning, to give more priority
-        """
-        requires = set()
-        build_requires = set()
-        for graph_node in deps_graph.nodes:
-            if graph_node.recipe in (RECIPE_VIRTUAL, RECIPE_CONSUMER) or graph_node.ref is None:
-                continue
-            assert graph_node.conanfile is not None
-
-            if graph_node.context == CONTEXT_BUILD:
-                build_requires.add(graph_node.ref)
-            else:
-                requires.add(graph_node.ref)
-
-        requires.update(self.requires)
-        self.requires = list(reversed(sorted(requires)))
-        build_requires.update(self.build_requires)
-        self.build_requires = list(reversed(sorted(build_requires)))
-        # TODO other members
+        save(path, self.dumps())
 
     def merge(self, other):
-        self.requires = list(reversed(sorted(set(other.requires + self.requires))))
-        self.build_requires = list(reversed(sorted(set(other.build_requires + self.build_requires))))
+        """
+        :type other: Lockfile
+        """
+        self._requires.merge(other._requires)
+        self._build_requires.merge(other._build_requires)
+        self._python_requires.merge(other._python_requires)
 
     @staticmethod
     def deserialize(data):
         """ constructs a GraphLock from a json like dict
         """
-        graph_lock = Lockfile(deps_graph=None)
+        graph_lock = Lockfile()
         version = data.get("version")
         if version and version != LOCKFILE_VERSION:
             raise ConanException("This lockfile was created with an incompatible "
                                  "version. Please regenerate the lockfile")
-        for r in data["requires"]:
-            graph_lock.requires.append(RecipeReference.loads(r))
-        for r in data["python_requires"]:
-            graph_lock.python_requires.append(RecipeReference.loads(r))
-        for r in data["build_requires"]:
-            graph_lock.build_requires.append(RecipeReference.loads(r))
+        graph_lock._requires = _LockRequires.deserialize(data["requires"])
+        graph_lock._build_requires = _LockRequires.deserialize(data["build_requires"])
+        graph_lock._python_requires = _LockRequires.deserialize(data["python_requires"])
         return graph_lock
 
     def serialize(self):
@@ -108,15 +156,16 @@ class Lockfile(object):
         that can be converted to json
         """
         return {"version": LOCKFILE_VERSION,
-                "requires": [repr(r) for r in self.requires],
-                "python_requires": [repr(r) for r in self.python_requires],
-                "build_requires": [repr(r) for r in self.build_requires]}
+                "requires": self._requires.serialize(),
+                "build_requires": self._build_requires.serialize(),
+                "python_requires": self._python_requires.serialize()
+                }
 
     def resolve_locked(self, node, require):
         if require.build or node.context == CONTEXT_BUILD:
-            locked_refs = self.build_requires
+            locked_refs = self._build_requires.refs()
         else:
-            locked_refs = self.requires
+            locked_refs = self._requires.refs()
         self._resolve(require, locked_refs)
 
     def _resolve(self, require, locked_refs):
@@ -151,7 +200,7 @@ class Lockfile(object):
                     raise ConanException(f"Requirement '{repr(ref)}' not in lockfile")
 
     def resolve_locked_pyrequires(self, require):
-        locked_refs = self.python_requires  # CHANGE
+        locked_refs = self._python_requires.refs()  # CHANGE
         self._resolve(require, locked_refs)
 
     def update_lock_export_ref(self, ref):
@@ -159,7 +208,7 @@ class Lockfile(object):
         match the existing RREV
         """
         # Filter existing matching
-        if ref not in self.requires:
+        if ref not in self._requires:
             # It is inserted in the first position, because that will result in prioritization
             # That includes testing previous versions in a version range
-            self.requires.insert(0, ref)
+            self._requires.insert(ref)

--- a/conans/test/integration/lockfile/test_lock_packages.py
+++ b/conans/test/integration/lockfile/test_lock_packages.py
@@ -2,29 +2,37 @@ import pytest
 
 from conans.test.assets.genconanfile import GenConanfile
 from conans.test.utils.tools import TestClient, NO_SETTINGS_PACKAGE_ID
+from conans.util.env import environment_update
 
 
 @pytest.mark.parametrize("requires", ["requires", "tool_requires"])
-def test_conanfile_txt_deps_ranges(requires):
+def test_lock_packages(requires):
     """
     Check that package revisions can be locked too
     NOTE: They are still not used! only to check that it is possible to store them
           And that the lockfile is still usable
     """
     client = TestClient()
-    client.save({"pkg/conanfile.py": GenConanfile(),
+    client.save({"pkg/conanfile.py": GenConanfile().with_package_file("file.txt", env_var="MYVAR"),
                  "consumer/conanfile.txt": f"[{requires}]\npkg/[>0.0]"})
-    client.run("create pkg --name=pkg --version=0.1 ")
+    with environment_update({"MYVAR": "MYVALUE"}):
+        client.run("create pkg --name=pkg --version=0.1")
+    prev = client.created_package_revision("pkg/0.1")
+
     client.run("lock create consumer/conanfile.txt  --lockfile-out=conan.lock --lockfile-packages")
     assert "pkg/0.1#" in client.out
     lock = client.load("conan.lock")
     assert NO_SETTINGS_PACKAGE_ID in lock
 
-    client.run("create pkg --name=pkg --version=0.2 ")
+    with environment_update({"MYVAR": "MYVALUE2"}):
+        client.run("create pkg --name=pkg --version=0.1")
+    prev2 = client.created_package_revision("pkg/0.1")
+    assert prev2 != prev
 
     client.run("install consumer/conanfile.txt --lockfile=conan.lock")
-    assert "pkg/0.1#" in client.out
-    assert "pkg/0.2" not in client.out
+    assert prev in client.out
+    assert prev2 not in client.out
+
     client.run("install consumer/conanfile.txt")
-    assert "pkg/0.2#" in client.out
-    assert "pkg/0.1" not in client.out
+    assert prev2 in client.out
+    assert prev not in client.out

--- a/conans/test/integration/lockfile/test_lock_packages.py
+++ b/conans/test/integration/lockfile/test_lock_packages.py
@@ -1,0 +1,30 @@
+import pytest
+
+from conans.test.assets.genconanfile import GenConanfile
+from conans.test.utils.tools import TestClient, NO_SETTINGS_PACKAGE_ID
+
+
+@pytest.mark.parametrize("requires", ["requires", "tool_requires"])
+def test_conanfile_txt_deps_ranges(requires):
+    """
+    Check that package revisions can be locked too
+    NOTE: They are still not used! only to check that it is possible to store them
+          And that the lockfile is still usable
+    """
+    client = TestClient()
+    client.save({"pkg/conanfile.py": GenConanfile(),
+                 "consumer/conanfile.txt": f"[{requires}]\npkg/[>0.0]"})
+    client.run("create pkg --name=pkg --version=0.1 ")
+    client.run("lock create consumer/conanfile.txt  --lockfile-out=conan.lock --lockfile-packages")
+    assert "pkg/0.1#" in client.out
+    lock = client.load("conan.lock")
+    assert NO_SETTINGS_PACKAGE_ID in lock
+
+    client.run("create pkg --name=pkg --version=0.2 ")
+
+    client.run("install consumer/conanfile.txt --lockfile=conan.lock")
+    assert "pkg/0.1#" in client.out
+    assert "pkg/0.2" not in client.out
+    client.run("install consumer/conanfile.txt")
+    assert "pkg/0.2#" in client.out
+    assert "pkg/0.1" not in client.out

--- a/conans/test/utils/tools.py
+++ b/conans/test/utils/tools.py
@@ -732,7 +732,13 @@ class TestClient(object):
                 raise AssertionError(f"Cant find {r}-{kind} in {reqs}")
 
     def created_package_id(self, ref):
-        package_id = re.search(r"{}: Package '(\S+)' created".format(str(ref)), str(self.out)).group(1)
+        package_id = re.search(r"{}: Package '(\S+)' created".format(str(ref)),
+                               str(self.out)).group(1)
+        return package_id
+
+    def created_package_revision(self, ref):
+        package_id = re.search(r"{}: Created package revision (\S+)".format(str(ref)),
+                               str(self.out)).group(1)
         return package_id
 
     def exported_recipe_revision(self):


### PR DESCRIPTION
Main purpose of this PR is to validate that the new proposed lockfiles are also good to store package-id and package revision without disrupting the whole idea of the lockfile

To discuss:
- Using ``--lockfile-packages`` as an opt-in to this feature
- Using by default recipe-only lockfiles

Missing:
- Really use the locked package-revision in the binary resolution