### PR TITLE
Unify "extensions" folder in the cache.

### DIFF
--- a/conan/cache/cache.py
+++ b/conan/cache/cache.py
@@ -1,5 +1,4 @@
 import hashlib
-import hashlib
 import os
 import shutil
 import uuid

--- a/conan/cache/cache.py
+++ b/conan/cache/cache.py
@@ -1,4 +1,4 @@
-import copy
+import hashlib
 import hashlib
 import os
 import shutil

--- a/conans/cli/api/subapi/install.py
+++ b/conans/cli/api/subapi/install.py
@@ -2,7 +2,7 @@ import os
 
 from conans.cli.api.subapi import api_method
 from conans.cli.conan_app import ConanApp
-from conans.client.cache.cache import EXTENSIONS_FOLDER, DEPLOYERS_EXTENSION_FOLDER, ClientCache
+from conans.client.cache.cache import ClientCache
 from conans.client.generators import write_generators
 from conans.client.installer import BinaryInstaller, call_system_requirements
 from conans.client.loader import load_python_file

--- a/conans/cli/api/subapi/install.py
+++ b/conans/cli/api/subapi/install.py
@@ -2,6 +2,7 @@ import os
 
 from conans.cli.api.subapi import api_method
 from conans.cli.conan_app import ConanApp
+from conans.client.cache.cache import EXTENSIONS_FOLDER, DEPLOYERS_EXTENSION_FOLDER, ClientCache
 from conans.client.generators import write_generators
 from conans.client.installer import BinaryInstaller, call_system_requirements
 from conans.client.loader import load_python_file
@@ -78,9 +79,9 @@ def _find_deployer(d, cache_deploy_folder):
 
 def _do_deploys(conan_api, graph, deploy, output_folder):
     # Handle the deploys
-    cache_deploy_folder = os.path.join(conan_api.cache_folder, "extensions", "deploy")
+    cache = ClientCache(conan_api.cache_folder)
     for d in deploy or []:
-        deployer = _find_deployer(d, cache_deploy_folder)
+        deployer = _find_deployer(d, cache.deployers_path)
         # IMPORTANT: Use always kwargs to not break if it changes in the future
         conanfile = graph.root.conanfile
         deployer(conanfile=conanfile, output_folder=output_folder)

--- a/conans/cli/cli.py
+++ b/conans/cli/cli.py
@@ -14,6 +14,7 @@ from conans.cli.command import ConanSubCommand
 from conans.cli.exit_codes import SUCCESS, ERROR_MIGRATION, ERROR_GENERAL, USER_CTRL_C, \
     ERROR_SIGTERM, USER_CTRL_BREAK, ERROR_INVALID_CONFIGURATION, ERROR_INVALID_SYSTEM_REQUIREMENTS
 from conans.cli.output import ConanOutput, cli_out_write, Color
+from conans.client.cache.cache import ClientCache
 from conans.errors import ConanInvalidSystemRequirements
 from conans.errors import ConanException, ConanInvalidConfiguration, ConanMigrationError
 from conans.util.files import exception_message_safe
@@ -36,9 +37,9 @@ class Cli:
         for module in pkgutil.iter_modules([conan_commands_path]):
             module_name = module[1]
             self._add_command("conans.cli.commands.{}".format(module_name), module_name)
-        user_commands_path = os.path.join(self._conan_api.cache_folder, "commands")
-        sys.path.append(user_commands_path)
-        for module in pkgutil.iter_modules([user_commands_path]):
+        custom_commands_path = ClientCache(conan_api.cache_folder).custom_commands_path
+        sys.path.append(custom_commands_path)
+        for module in pkgutil.iter_modules([custom_commands_path]):
             module_name = module[1]
             if module_name.startswith("cmd_"):
                 self._add_command(module_name, module_name.replace("cmd_", ""))

--- a/conans/client/cache/cache.py
+++ b/conans/client/cache/cache.py
@@ -29,6 +29,7 @@ EXTENSIONS_FOLDER = "extensions"
 HOOKS_EXTENSION_FOLDER = "hooks"
 GENERATORS_EXTENSION_FOLDER = "generators"
 DEPLOYERS_EXTENSION_FOLDER = "deploy"
+CUSTOM_COMMANDS_FOLDER = "commands"
 
 
 # TODO: Rename this to ClientHome
@@ -223,6 +224,10 @@ class ClientCache(object):
     @property
     def generators_path(self):
         return os.path.join(self.cache_folder, EXTENSIONS_FOLDER, GENERATORS_EXTENSION_FOLDER)
+
+    @property
+    def custom_commands_path(self):
+        return os.path.join(self.cache_folder, EXTENSIONS_FOLDER, CUSTOM_COMMANDS_FOLDER)
 
     @property
     def default_profile_path(self):

--- a/conans/client/cache/cache.py
+++ b/conans/client/cache/cache.py
@@ -25,9 +25,10 @@ CONAN_SETTINGS = "settings.yml"
 LOCALDB = ".conan.db"
 REMOTES = "remotes.json"
 PROFILES_FOLDER = "profiles"
-HOOKS_FOLDER = "hooks"
-TEMPLATES_FOLDER = "templates"
-GENERATORS_FOLDER = "generators"
+EXTENSIONS_FOLDER = "extensions"
+HOOKS_EXTENSION_FOLDER = "hooks"
+GENERATORS_EXTENSION_FOLDER = "generators"
+DEPLOYERS_EXTENSION_FOLDER = "deploy"
 
 
 # TODO: Rename this to ClientHome
@@ -221,7 +222,7 @@ class ClientCache(object):
 
     @property
     def generators_path(self):
-        return os.path.join(self.cache_folder, GENERATORS_FOLDER)
+        return os.path.join(self.cache_folder, EXTENSIONS_FOLDER, GENERATORS_EXTENSION_FOLDER)
 
     @property
     def default_profile_path(self):
@@ -233,7 +234,11 @@ class ClientCache(object):
         """
         :return: Hooks folder in client cache
         """
-        return os.path.join(self.cache_folder, HOOKS_FOLDER)
+        return os.path.join(self.cache_folder, EXTENSIONS_FOLDER, HOOKS_EXTENSION_FOLDER)
+
+    @property
+    def deployers_path(self):
+        return os.path.join(self.cache_folder, EXTENSIONS_FOLDER, DEPLOYERS_EXTENSION_FOLDER)
 
     @property
     def settings(self):

--- a/conans/test/functional/command/config_install_test.py
+++ b/conans/test/functional/command/config_install_test.py
@@ -478,7 +478,7 @@ class ConfigInstallTest(unittest.TestCase):
             self.client.run_command('git config user.email myname@mycompany.com')
             self.client.run_command('git commit -m "mymsg"')
             self.client.run_command('git checkout -b other_branch')
-            save(os.path.join(folder, "hooks", "cust", "cust.py"), "")
+            save(os.path.join(folder, "extensions", "hooks", "cust", "cust.py"), "")
             self.client.run_command('git add .')
             self.client.run_command('git commit -m "my file"')
 
@@ -490,7 +490,7 @@ class ConfigInstallTest(unittest.TestCase):
 
         # Add changes to that branch and update
         with self.client.chdir(folder):
-            save(os.path.join(folder, "hooks", "cust", "cust.py"), "new content")
+            save(os.path.join(folder, "extensions", "hooks", "cust", "cust.py"), "new content")
             self.client.run_command('git add .')
             self.client.run_command('git commit -m "my other file"')
             self.client.run_command('git checkout master')

--- a/conans/test/functional/toolchains/apple/test_xcodetoolchain.py
+++ b/conans/test/functional/toolchains/apple/test_xcodetoolchain.py
@@ -333,7 +333,7 @@ test = textwrap.dedent("""
 
 
 @pytest.mark.skipif(platform.system() != "Darwin", reason="Only for MacOS")
-@pytest.mark.tool_xcodebuild
+@pytest.mark.tool("xcodebuild")
 @pytest.mark.parametrize("cppstd, cppstd_output, min_version", [
     ("gnu14", "__cplusplus201402", "11.0"),
     ("gnu17", "__cplusplus201703", "11.0"),

--- a/conans/test/integration/command_v2/custom_commands_test.py
+++ b/conans/test/integration/command_v2/custom_commands_test.py
@@ -31,7 +31,8 @@ class TestCustomCommands:
             """)
 
         client = TestClient()
-        command_file_path = os.path.join(client.cache_folder, 'commands', 'cmd_mycommand.py')
+        command_file_path = os.path.join(client.cache_folder, 'extensions',
+                                         'commands', 'cmd_mycommand.py')
         client.save({f"{command_file_path}": mycommand})
         client.run("mycommand -f cli")
         foldername = os.path.basename(client.cache_folder)
@@ -70,7 +71,8 @@ class TestCustomCommands:
             """)
 
         client = TestClient()
-        command_file_path = os.path.join(client.cache_folder, 'commands', 'cmd_complex.py')
+        command_file_path = os.path.join(client.cache_folder, 'extensions',
+                                         'commands', 'cmd_complex.py')
         client.save({f"{command_file_path}": complex_command})
         client.run("complex sub1 myargument -f=cli")
         assert "myargument" in client.out


### PR DESCRIPTION
Unify extensions to "extensions/" folder at the cache.
Should we put a warning or error if "cache/hooks" is installed to prevent errors?
PENDING: Migration guide of the "conan config install" about the hooks. 