### PR TITLE
Fix to allow migration to 2.0: reference patterns

### DIFF
--- a/conans/model/options.py
+++ b/conans/model/options.py
@@ -194,6 +194,10 @@ class OptionsValues(object):
             tokens = k.split(":")
             if len(tokens) == 2:
                 package, option = tokens
+                if package.endswith("/*"):
+                    # Compatibility with 2.0, only allowed /*, at Conan 2.0 a version or any
+                    # pattern would be allowed
+                    package = package[:-2]
                 package_values = self._reqs_options.setdefault(package.strip(),
                                                                PackageOptionValues())
                 package_values.add_option(option, v)

--- a/conans/test/functional/generators/components/test_components_cmake_generators.py
+++ b/conans/test/functional/generators/components/test_components_cmake_generators.py
@@ -161,7 +161,7 @@ def create_chat(client, generator, components, package_info, cmake_find, test_cm
             generators = "{}", "cmake"
             exports_sources = "src/*"
             requires = "greetings/0.0.1"
-            default_options = {{"greetings:components": "{}"}}
+            default_options = {{"greetings/*:components": "{}"}}
 
             def build(self):
                 cmake = CMake(self)


### PR DESCRIPTION
Changelog: Feature: Allow specifying `default_options = {"pkg/*:option": "value"}` or `default_options = {"pkg*:option": "value"}`   instead of `default_options = {"pkg:option": "value"}` to make compatible recipes with 2.0.
Docs: https://github.com/conan-io/docs/pull/2468

Related: https://github.com/conan-io/conan/pull/10587