### PR TITLE
solve build_policy=never bug when export-pkg --force

### DIFF
--- a/conans/client/cmd/export_pkg.py
+++ b/conans/client/cmd/export_pkg.py
@@ -78,6 +78,8 @@ def export_pkg(app, recorder, full_ref, source_folder, build_folder, package_fol
     packager.update_package_metadata(prev, layout, package_id, full_ref.revision)
     pref = PackageReference(pref.ref, pref.id, prev)
     if pkg_node.graph_lock_node:
+        pkg_node.graph_lock_node.relax()
+        pkg_node.graph_lock_node.unlock_prev()
         # after the package has been created we need to update the node PREV
         pkg_node.prev = pref.revision
         pkg_node.graph_lock_node.prev = pref.revision

--- a/conans/test/integration/command/export_pkg_test.py
+++ b/conans/test/integration/command/export_pkg_test.py
@@ -659,6 +659,10 @@ def test_build_policy_never():
     client.run("export-pkg . pkg/1.0@")
     assert "pkg/1.0 package(): Packaged 1 '.h' file: header.h" in client.out
 
+    # check for https://github.com/conan-io/conan/issues/10736
+    client.run("export-pkg . pkg/1.0@ --force")
+    assert "pkg/1.0 package(): Packaged 1 '.h' file: header.h" in client.out
+
     client.run("install pkg/1.0@ --build")
     assert "pkg/1.0:{} - Cache".format(NO_SETTINGS_PACKAGE_ID) in client.out
     assert "pkg/1.0: Calling build()" not in client.out


### PR DESCRIPTION
Changelog: Bugfix: solve ``build_policy=never`` bug when ``conan export-pkg --force`` and there already exists a package in the cache.
Docs: Omit

Fix https://github.com/conan-io/conan/issues/10736
