### PR TITLE
[pylint_plugin] Added deprecated imports checker

### DIFF
--- a/conans/pylint_plugin.py
+++ b/conans/pylint_plugin.py
@@ -67,7 +67,7 @@ class ConanDeprecatedImportsChecker(BaseChecker):
     deprecated_imports_pattern = re.compile(r"(from|import)\s+conans[\.|\s].*")
     name = "conan_deprecated_imports"
     msgs = {
-        "W9000": (
+        "E9000": (
             "Using deprecated imports from 'conans'",
             "conan1.x-deprecated-imports",
             (

--- a/conans/pylint_plugin.py
+++ b/conans/pylint_plugin.py
@@ -1,15 +1,15 @@
 """Pylint plugin for ConanFile"""
+import re
+
 import astroid
 from astroid import MANAGER
+from pylint.checkers import BaseChecker
+from pylint.interfaces import IRawChecker
 
 
 def register(linter):
-    """Declare package as plugin
-
-    This function needs to be declared so astroid treats
-    current file as a plugin.
-    """
-    pass
+    """required method to auto register this checker"""
+    linter.register_checker(ConanImportsDeprecatedChecker(linter))
 
 
 def transform_conanfile(node):
@@ -55,3 +55,34 @@ def _python_requires_member():
 
 
 astroid.register_module_extender(astroid.MANAGER, "conans", _python_requires_member)
+
+
+class ConanImportsDeprecatedChecker(BaseChecker):
+    """
+    Check "from conans*" imports which disappears in Conan 2.x. Only "from conan*" is valid
+    """
+
+    __implements__ = IRawChecker
+
+    deprecated_imports_pattern = re.compile(r"(from|import)\s+conans[\.|\s].*")
+    name = "conan_imports"
+    msgs = {
+        "W9000": (
+            "Using deprecated imports from 'conans'",
+            "conan1.x-deprecated-imports",
+            (
+                "Use imports from 'conan' instead of 'conans'"
+                " because 'conan' will be the root package for Conan 2.x"
+            )
+        )
+    }
+    options = ()
+
+    def process_module(self, node):
+        """
+        Processing the module's content that is accessible via node.stream() function
+        """
+        with node.stream() as stream:
+            for (index, line) in enumerate(stream):
+                if self.deprecated_imports_pattern.match(line.decode('utf-8')):
+                    self.add_message("conan1.x-deprecated-imports", line=index)

--- a/conans/pylint_plugin.py
+++ b/conans/pylint_plugin.py
@@ -9,7 +9,7 @@ from pylint.interfaces import IRawChecker
 
 def register(linter):
     """required method to auto register this checker"""
-    linter.register_checker(ConanImportsDeprecatedChecker(linter))
+    linter.register_checker(ConanDeprecatedImportsChecker(linter))
 
 
 def transform_conanfile(node):
@@ -57,7 +57,7 @@ def _python_requires_member():
 astroid.register_module_extender(astroid.MANAGER, "conans", _python_requires_member)
 
 
-class ConanImportsDeprecatedChecker(BaseChecker):
+class ConanDeprecatedImportsChecker(BaseChecker):
     """
     Check "from conans*" imports which disappears in Conan 2.x. Only "from conan*" is valid
     """
@@ -65,7 +65,7 @@ class ConanImportsDeprecatedChecker(BaseChecker):
     __implements__ = IRawChecker
 
     deprecated_imports_pattern = re.compile(r"(from|import)\s+conans[\.|\s].*")
-    name = "conan_imports"
+    name = "conan_deprecated_imports"
     msgs = {
         "W9000": (
             "Using deprecated imports from 'conans'",


### PR DESCRIPTION
Changelog: Feature: Added a checker for Conan 2.x deprecated `from conans` imports in `pylint_plugin`.
Docs: https://github.com/conan-io/docs/pull/2475

- [ ] Refer to the issue that supports this Pull Request.
- [ ] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [ ] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [ ] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 

<sup>**Note:** By default this PR will skip the slower tests and will use a limited set of python versions. Check [here](https://github.com/conan-io/conan/blob/develop/.github/PR_INCREASE_TESTING.md) how to increase the testing level by writing some tags in the current PR body text.</sup>
