### PR TITLE
Add failing test when removing options that already have a value

### DIFF
--- a/conans/model/options.py
+++ b/conans/model/options.py
@@ -1,4 +1,3 @@
-from conans.cli.output import ConanOutput
 from conans.errors import ConanException
 from conans.model.recipe_ref import RecipeReference, ref_matches
 
@@ -138,10 +137,9 @@ class _PackageOptions:
     def __delattr__(self, field):
         assert field[0] != "_", "ERROR %s" % field
         current_value = self._data.get(field)
-        if self._freeze and current_value.value is not None:
-            raise ConanException(f"Incorrect attempt to remove option '{field}' "
-                                 f"with current value '{current_value}'")
-
+        # It is always possible to remove an option, even if it is frozen (freeze=True),
+        # and it got a value, because it is the only way an option could be removed
+        # conditionally to other option value (like fPIC if shared)
         self._ensure_exists(field)
         del self._data[field]
 

--- a/conans/test/integration/options/options_test.py
+++ b/conans/test/integration/options/options_test.py
@@ -291,6 +291,10 @@ equal/1.0.0@user/testing:opt=a=b
         assert "pkg/0.1: with_stacktrace_backtrace: True" in c.out
 
     def test_del_options_configure(self):
+        """
+        this test was failing because Options was protecting against removal of options with
+        already assigned values. This has been relaxed, to make possible this case
+        """
         c = TestClient()
         conanfile = textwrap.dedent("""
             from conan import ConanFile
@@ -312,3 +316,4 @@ equal/1.0.0@user/testing:opt=a=b
         c.save({"conanfile.py": GenConanfile("consumer", "1.0").with_requirement("pkg/0.1")},
                clean_first=True)
         c.run("install . -o pkg*:shared=True --build=missing")
+        assert "pkg/0.1" in c.out  # Real test is the above doesn't crash

--- a/conans/test/integration/options/options_test.py
+++ b/conans/test/integration/options/options_test.py
@@ -289,3 +289,26 @@ equal/1.0.0@user/testing:opt=a=b
         c.run("create . --name=pkg --version=0.1 -o pkg*:without_stacktrace=False")
         assert "pkg/0.1: without_stacktrace: False" in c.out
         assert "pkg/0.1: with_stacktrace_backtrace: True" in c.out
+
+    def test_del_options_configure(self):
+        c = TestClient()
+        conanfile = textwrap.dedent("""
+            from conan import ConanFile
+            class Pkg(ConanFile):
+                options = {
+                    "shared": [True, False],
+                    "fPIC": [True, False],
+                }
+                default_options = {
+                    "shared": False,
+                    "fPIC": True,
+                }
+                def configure(self):
+                    if self.options.shared:
+                        del self.options.fPIC
+            """)
+        c.save({"conanfile.py": conanfile})
+        c.run("create . --name=pkg --version=0.1")
+        c.save({"conanfile.py": GenConanfile("consumer", "1.0").with_requirement("pkg/0.1")},
+               clean_first=True)
+        c.run("install . -o pkg*:shared=True --build=missing")

--- a/conans/test/unittests/model/options_test.py
+++ b/conans/test/unittests/model/options_test.py
@@ -92,11 +92,9 @@ class TestOptions:
         assert "Incorrect attempt to modify option 'static'" in str(e.value)
         assert "static=True" in self.sut.dumps()
 
-        # Removal of options with values should rais
-        with pytest.raises(ConanException) as e:
-            del self.sut.static
-        assert "Incorrect attempt to remove option 'static'" in str(e.value)
-        assert "static" in self.sut.dumps()
+        # Removal of options with values doesn't raise anymore
+        del self.sut.static
+        assert "static" not in self.sut.dumps()
 
         # Test None is possible to change
         sut2 = Options({"static": [True, False],


### PR DESCRIPTION
`conan install . -o pkg*:shared=True --build=missing`
over a package that defines something like:
```
def configure(self):
    if self.options.shared:
        del self.options.fPIC
```
fails with:
`ConanException: Incorrect attempt to remove option 'fPIC' with current value 'True' `