### PR TITLE
Fix: Change msg when not scoped options

### DIFF
--- a/conans/model/options.py
+++ b/conans/model/options.py
@@ -199,7 +199,7 @@ class Options:
                     if len(tokens) == 2:
                         package, option = tokens
                         if "/" not in package and "*" not in package:
-                            msg = "The usage of package names `{}` in 'default_options' is " \
+                            msg = "The usage of package names `{}` in options is " \
                                   "deprecated, use a pattern like `{}/*` or `{}*` " \
                                   "instead".format(k, package, package)
                             raise ConanException(msg)

--- a/conans/test/functional/toolchains/env/test_complete.py
+++ b/conans/test/functional/toolchains/env/test_complete.py
@@ -115,7 +115,7 @@ def test_complete():
                  "CMakeLists.txt": mycmake_cmakelists,
                  "main.cpp": mycmake_main}, clean_first=True)
     client.run("create . --name=mycmake --version=1.0", assert_error=True)
-    assert "The usage of package names `myopenssl:shared` in 'default_options' is deprecated, " \
+    assert "The usage of package names `myopenssl:shared` in options is deprecated, " \
            "use a pattern like `myopenssl/*` or `myopenssl*` instead" in client.out
 
     # Fix the default options and repeat the create


### PR DESCRIPTION
That error is also raised when specifying options in the command line, etc. So the msg should be more generic.