### PR TITLE
msvc runtime to AutotoolsToolchain

### DIFF
--- a/conan/tools/gnu/autotoolstoolchain.py
+++ b/conan/tools/gnu/autotoolstoolchain.py
@@ -48,8 +48,19 @@ class AutotoolsToolchain:
         self._target = None
 
         self.apple_arch_flag = self.apple_isysroot_flag = None
-
         self.apple_min_version_flag = apple_min_version_flag(self._conanfile)
+
+        self.msvc_runtime_flag = None
+        if is_msvc(self._conanfile):
+            runtime_type = conanfile.settings.get_safe("compiler.runtime_type")
+            if runtime_type == "Release":
+                values = {"static": "MT", "dynamic": "MD"}
+            else:
+                values = {"static": "MTd", "dynamic": "MDd"}
+            runtime = values.get(conanfile.settings.get_safe("compiler.runtime"))
+            if runtime:
+                self.msvc_runtime_flag = "-{}".format(runtime)
+
         if cross_building(self._conanfile):
             os_build, arch_build, os_host, arch_host = get_cross_building_settings(self._conanfile)
             compiler = self._conanfile.settings.get_safe("compiler")

--- a/conan/tools/gnu/autotoolstoolchain.py
+++ b/conan/tools/gnu/autotoolstoolchain.py
@@ -154,6 +154,10 @@ class AutotoolsToolchain:
             self.cxxflags.append("-fPIC")
             self.cflags.append("-fPIC")
 
+        if self.msvc_runtime_flag:
+            self.cxxflags.append(self.msvc_runtime_flag)
+            self.cflags.append(self.msvc_runtime_flag)
+
         if is_msvc(self._conanfile):
             env.define("CXX", "cl")
             env.define("CC", "cl")

--- a/conans/test/unittests/tools/gnu/autotoolschain_test.py
+++ b/conans/test/unittests/tools/gnu/autotoolschain_test.py
@@ -29,7 +29,7 @@ def test_get_gnu_triplet_for_cross_building():
                           ("static", "Release", "MT"),
                           ("dynamic", "Debug", "MDd"),
                           ("dynamic", "Release", "MD")])
-def test_visual_runtime(runtime, runtime_type, expected):
+def test_msvc_runtime(runtime, runtime_type, expected):
     """
     Testing AutotoolsToolchain with the msvc compiler adjust the runtime
     """
@@ -45,6 +45,24 @@ def test_visual_runtime(runtime, runtime_type, expected):
     conanfile.settings_build = settings
     autotoolschain = AutotoolsToolchain(conanfile)
     assert autotoolschain.msvc_runtime_flag == "-{}".format(expected)
+
+
+@pytest.mark.parametrize("runtime", ["MTd", "MT", "MDd", "MD"])
+def test_visual_runtime(runtime):
+    """
+    Testing AutotoolsToolchain with the msvc compiler adjust the runtime
+    """
+    # Issue: https://github.com/conan-io/conan/issues/10139
+    settings = MockSettings({"build_type": "Release",
+                             "compiler": "Visual Studio",
+                             "compiler.runtime": runtime,
+                             "os": "Windows",
+                             "arch": "x86_64"})
+    conanfile = ConanFileMock()
+    conanfile.settings = settings
+    conanfile.settings_build = settings
+    autotoolschain = AutotoolsToolchain(conanfile)
+    assert autotoolschain.msvc_runtime_flag == "-{}".format(runtime)
 
 
 def test_get_gnu_triplet_for_cross_building_raise_error():

--- a/conans/test/unittests/tools/gnu/autotoolschain_test.py
+++ b/conans/test/unittests/tools/gnu/autotoolschain_test.py
@@ -44,7 +44,11 @@ def test_msvc_runtime(runtime, runtime_type, expected):
     conanfile.settings = settings
     conanfile.settings_build = settings
     autotoolschain = AutotoolsToolchain(conanfile)
-    assert autotoolschain.msvc_runtime_flag == "-{}".format(expected)
+    expected_flag = "-{}".format(expected)
+    assert autotoolschain.msvc_runtime_flag == expected_flag
+    env = autotoolschain.environment().vars(conanfile)
+    assert expected_flag in env["CFLAGS"]
+    assert expected_flag in env["CXXFLAGS"]
 
 
 @pytest.mark.parametrize("runtime", ["MTd", "MT", "MDd", "MD"])
@@ -62,7 +66,11 @@ def test_visual_runtime(runtime):
     conanfile.settings = settings
     conanfile.settings_build = settings
     autotoolschain = AutotoolsToolchain(conanfile)
-    assert autotoolschain.msvc_runtime_flag == "-{}".format(runtime)
+    expected_flag = "-{}".format(runtime)
+    assert autotoolschain.msvc_runtime_flag == expected_flag
+    env = autotoolschain.environment().vars(conanfile)
+    assert expected_flag in env["CFLAGS"]
+    assert expected_flag in env["CXXFLAGS"]
 
 
 def test_get_gnu_triplet_for_cross_building_raise_error():

--- a/conans/test/unittests/tools/gnu/autotoolschain_test.py
+++ b/conans/test/unittests/tools/gnu/autotoolschain_test.py
@@ -24,6 +24,29 @@ def test_get_gnu_triplet_for_cross_building():
     assert autotoolschain._build == "i686-solaris"
 
 
+@pytest.mark.parametrize("runtime, runtime_type, expected",
+                         [("static", "Debug", "MTd"),
+                          ("static", "Release", "MT"),
+                          ("dynamic", "Debug", "MDd"),
+                          ("dynamic", "Release", "MD")])
+def test_visual_runtime(runtime, runtime_type, expected):
+    """
+    Testing AutotoolsToolchain with the msvc compiler adjust the runtime
+    """
+    # Issue: https://github.com/conan-io/conan/issues/10139
+    settings = MockSettings({"build_type": "Release",
+                             "compiler": "msvc",
+                             "compiler.runtime": runtime,
+                             "compiler.runtime_type": runtime_type,
+                             "os": "Windows",
+                             "arch": "x86_64"})
+    conanfile = ConanFileMock()
+    conanfile.settings = settings
+    conanfile.settings_build = settings
+    autotoolschain = AutotoolsToolchain(conanfile)
+    assert autotoolschain.msvc_runtime_flag == "-{}".format(expected)
+
+
 def test_get_gnu_triplet_for_cross_building_raise_error():
     """
     Testing AutotoolsToolchain and _get_gnu_triplet() function raises an error in case of


### PR DESCRIPTION
Changelog: Fix: AutotoolsToolchain adjust the runtime flag of `msvc` (`MTd`, `MT`, `MDd` or `MD`) to `CFLAGS` and `CXXFLAGS` when using the `msvc` as `settings.compiler`.
Docs: https://github.com/conan-io/docs/pull/2478
