### PR TITLE
removing --require-override, now is in lockfiles

### DIFF
--- a/conans/cli/api/subapi/graph.py
+++ b/conans/cli/api/subapi/graph.py
@@ -18,8 +18,7 @@ class GraphAPI:
     @api_method
     def load_root_consumer_conanfile(self, path, profile_host, profile_build,
                                      name=None, version=None, user=None, channel=None,
-                                     update=None, remotes=None, require_overrides=None,
-                                     lockfile=None):
+                                     update=None, remotes=None, lockfile=None):
         app = ConanApp(self.conan_api.cache_folder)
         # necessary for correct resolution and update of remote python_requires
         app.load_remotes(remotes, update=update)
@@ -30,8 +29,7 @@ class GraphAPI:
                                                  version=version,
                                                  user=user,
                                                  channel=channel,
-                                                 graph_lock=lockfile,
-                                                 require_overrides=require_overrides)
+                                                 graph_lock=lockfile)
             ref = RecipeReference(conanfile.name, conanfile.version,
                                   conanfile.user, conanfile.channel)
             initialize_conanfile_profile(conanfile, profile_build, profile_host, CONTEXT_HOST,
@@ -40,7 +38,7 @@ class GraphAPI:
                 profile_host.options.scope(ref)
             root_node = Node(ref, conanfile, context=CONTEXT_HOST, recipe=RECIPE_CONSUMER, path=path)
         else:
-            conanfile = app.loader.load_conanfile_txt(path, require_overrides=require_overrides)
+            conanfile = app.loader.load_conanfile_txt(path)
             consumer_definer(conanfile, profile_host)
             root_node = Node(None, conanfile, context=CONTEXT_HOST, recipe=RECIPE_CONSUMER,
                              path=path)
@@ -48,7 +46,7 @@ class GraphAPI:
 
     @api_method
     def load_root_test_conanfile(self, path, tested_reference, profile_host, profile_build,
-                                 update=None, remotes=None, require_overrides=None, lockfile=None):
+                                 update=None, remotes=None, lockfile=None):
         """
         create and initialize a root node from a test_package/conanfile.py consumer
         @param lockfile: Might be good to lock python-requires, build-requires
@@ -58,7 +56,6 @@ class GraphAPI:
         @param profile_build:
         @param update:
         @param remotes:
-        @param require_overrides:
         @return: a graph Node, recipe=RECIPE_CONSUMER
         """
 
@@ -72,7 +69,6 @@ class GraphAPI:
         # do not try apply lock_python_requires for test_package/conanfile.py consumer
         conanfile = loader.load_consumer(path, user=tested_reference.user,
                                          channel=tested_reference.channel,
-                                         require_overrides=require_overrides,
                                          graph_lock=lockfile)
         initialize_conanfile_profile(conanfile, profile_build, profile_host, CONTEXT_HOST, False)
         conanfile.display_name = "%s (test package)" % str(tested_reference)
@@ -85,13 +81,11 @@ class GraphAPI:
         return root_node
 
     @api_method
-    def load_root_virtual_conanfile(self, profile_host, requires=None, tool_requires=None,
-                                    require_overrides=None):
+    def load_root_virtual_conanfile(self, profile_host, requires=None, tool_requires=None):
         if not requires and not tool_requires:
             raise ConanException("Provide requires or tool_requires")
         app = ConanApp(self.conan_api.cache_folder)
-        conanfile = app.loader.load_virtual(requires=requires,  tool_requires=tool_requires,
-                                            require_overrides=require_overrides)
+        conanfile = app.loader.load_virtual(requires=requires,  tool_requires=tool_requires)
         consumer_definer(conanfile, profile_host)
         root_node = Node(ref=None, conanfile=conanfile, context=CONTEXT_HOST, recipe=RECIPE_VIRTUAL)
         return root_node

--- a/conans/cli/commands/create.py
+++ b/conans/cli/commands/create.py
@@ -25,8 +25,6 @@ def create(conan_api, parser, *args):
     _add_common_install_arguments(parser, build_help=_help_build_policies.format("never"))
     parser.add_argument("--build-require", action='store_true', default=False,
                         help='The provided reference is a build-require')
-    parser.add_argument("--require-override", action="append",
-                        help="Define a requirement override")
     parser.add_argument("-tbf", "--test-build-folder", action=OnceArgument,
                         help='Working directory for the build of the test project.')
     parser.add_argument("-tf", "--test-folder", action=OnceArgument,
@@ -63,19 +61,16 @@ def create(conan_api, parser, *args):
             raise ConanException("--build-require should not be specified, test_package does it")
         root_node = conan_api.graph.load_root_test_conanfile(test_conanfile_path, ref,
                                                              profile_host, profile_build,
-                                                             require_overrides=args.require_override,
                                                              remotes=remotes,
                                                              update=args.update,
                                                              lockfile=lockfile)
     else:
-        req_override = args.require_override
         requires = [ref] if not args.build_require else None
         tool_requires = [ref] if args.build_require else None
         scope_options(profile_host, requires=requires, tool_requires=tool_requires)
         root_node = conan_api.graph.load_root_virtual_conanfile(requires=requires,
                                                                 tool_requires=tool_requires,
-                                                                profile_host=profile_host,
-                                                                require_overrides=req_override)
+                                                                profile_host=profile_host)
 
     out.highlight("-------- Computing dependency graph ----------")
     check_updates = args.check_updates if "check_updates" in args else False

--- a/conans/cli/commands/install.py
+++ b/conans/cli/commands/install.py
@@ -1,6 +1,6 @@
 import os
 
-from conans.cli.command import conan_command, Extender, COMMAND_GROUPS, OnceArgument
+from conans.cli.command import conan_command, Extender, COMMAND_GROUPS
 from conans.cli.commands import make_abs_path
 from conans.cli.common import _add_common_install_arguments, _help_build_policies, \
     get_profiles_from_args, get_lockfile, get_multiple_remotes, add_lockfile_args, \
@@ -70,9 +70,6 @@ def graph_compute(args, conan_api, strict=False):
     out.info("Profile build:")
     out.info(profile_build.dumps())
 
-    # FIXME: Not used?
-    build_require = args.build_require if "build_require" in args else None
-    require_override = args.require_override if "require_override" in args else None
     if path is not None:
         root_node = conan_api.graph.load_root_consumer_conanfile(path, profile_host, profile_build,
                                                                  name=args.name,
@@ -80,15 +77,13 @@ def graph_compute(args, conan_api, strict=False):
                                                                  user=args.user,
                                                                  channel=args.channel,
                                                                  lockfile=lockfile,
-                                                                 require_overrides=require_override,
                                                                  remotes=remotes,
                                                                  update=args.update)
     else:
         scope_options(profile_host, requires=requires, tool_requires=tool_requires)
         root_node = conan_api.graph.load_root_virtual_conanfile(requires=requires,
                                                                 tool_requires=tool_requires,
-                                                                profile_host=profile_host,
-                                                                require_overrides=require_override)
+                                                                profile_host=profile_host)
 
     out.highlight("-------- Computing dependency graph ----------")
     check_updates = args.check_updates if "check_updates" in args else False
@@ -119,9 +114,6 @@ def common_graph_args(subparser):
                            help='Directly provide tool-requires instead of a conanfile')
     _add_common_install_arguments(subparser, build_help=_help_build_policies.format("never"))
     add_lockfile_args(subparser)
-
-    subparser.add_argument("--require-override", action="append",
-                           help="Define a requirement override")
 
 
 @conan_command(group=COMMAND_GROUPS['consumer'])

--- a/conans/cli/commands/test.py
+++ b/conans/cli/commands/test.py
@@ -25,8 +25,6 @@ def test(conan_api, parser, *args):
                         help='Provide a package reference to test')
     _add_common_install_arguments(parser, build_help=False)  # Package must exist
     add_lockfile_args(parser)
-    parser.add_argument("--require-override", action="append",
-                        help="Define a requirement override")
     args = parser.parse_args(*args)
 
     cwd = os.getcwd()
@@ -46,7 +44,6 @@ def test(conan_api, parser, *args):
 
     root_node = conan_api.graph.load_root_test_conanfile(path, ref,
                                                          profile_host, profile_build,
-                                                         require_overrides=args.require_override,
                                                          remotes=remotes,
                                                          update=args.update,
                                                          lockfile=lockfile)

--- a/conans/client/loader.py
+++ b/conans/client/loader.py
@@ -135,7 +135,7 @@ class ConanFileLoader:
         return conanfile
 
     def load_consumer(self, conanfile_path, name=None, version=None, user=None,
-                      channel=None, graph_lock=None, require_overrides=None):
+                      channel=None, graph_lock=None):
         """ loads a conanfile.py in user space. Might have name/version or not
         """
         conanfile = self.load_named(conanfile_path, name, version, user, channel, graph_lock)
@@ -147,11 +147,6 @@ class ConanFileLoader:
             conanfile.display_name = os.path.basename(conanfile_path)
         conanfile.output.scope = conanfile.display_name
         try:
-            if require_overrides is not None:
-                for req_override in require_overrides:
-                    req_override = RecipeReference.loads(req_override)
-                    conanfile.requires.override(req_override)
-
             conanfile._conan_is_consumer = True
             return conanfile
         except Exception as e:  # re-raise with file name
@@ -172,7 +167,7 @@ class ConanFileLoader:
         conanfile.channel = ref.channel
         return conanfile
 
-    def load_conanfile_txt(self, conan_txt_path, require_overrides=None):
+    def load_conanfile_txt(self, conan_txt_path):
         if not os.path.exists(conan_txt_path):
             raise NotFoundException("Conanfile not found!")
 
@@ -180,12 +175,6 @@ class ConanFileLoader:
         path, basename = os.path.split(conan_txt_path)
         display_name = basename
         conanfile = self._parse_conan_txt(contents, path, display_name)
-
-        if require_overrides is not None:
-            for req_override in require_overrides:
-                req_override = RecipeReference.loads(req_override)
-                conanfile.requires.override(req_override)
-
         conanfile._conan_is_consumer = True
         return conanfile
 
@@ -212,7 +201,7 @@ class ConanFileLoader:
 
         return conanfile
 
-    def load_virtual(self, requires=None, tool_requires=None, require_overrides=None):
+    def load_virtual(self, requires=None, tool_requires=None):
         # If user don't specify namespace in options, assume that it is
         # for the reference (keep compatibility)
         conanfile = ConanFile(display_name="virtual")
@@ -223,11 +212,6 @@ class ConanFileLoader:
         if requires:
             for reference in requires:
                 conanfile.requires(repr(reference))
-
-        if require_overrides is not None:
-            for req_override in require_overrides:
-                req_override = RecipeReference.loads(req_override)
-                conanfile.requires.override(req_override)
 
         conanfile._conan_is_consumer = True
         conanfile.generators = []  # remove the default txt generator

--- a/conans/test/integration/command/install/install_test.py
+++ b/conans/test/integration/command/install/install_test.py
@@ -336,46 +336,6 @@ def test_install_error_never(client):
     assert "ERROR: --build=never not compatible with other options" in client.out
 
 
-class TestCliOverride:
-
-    def test_install_cli_override(self, client):
-        client.save({"conanfile.py": GenConanfile()})
-        client.run("create . --name=zlib --version=1.0")
-        client.run("create . --name=zlib --version=2.0")
-        client.save({"conanfile.py": GenConanfile().with_requires("zlib/1.0")})
-        client.run("install . --require-override=zlib/2.0")
-        assert "zlib/2.0: Already installed" in client.out
-
-    def test_install_cli_override_in_conanfile_txt(self, client):
-        client.save({"conanfile.py": GenConanfile()})
-        client.run("create . --name=zlib --version=1.0")
-        client.run("create . --name=zlib --version=2.0")
-        client.save({"conanfile.txt": textwrap.dedent("""\
-        [requires]
-        zlib/1.0
-        """)}, clean_first=True)
-        client.run("install . --require-override=zlib/2.0")
-        assert "zlib/2.0: Already installed" in client.out
-
-    def test_install_ref_cli_override(self, client):
-        client.save({"conanfile.py": GenConanfile()})
-        client.run("create . --name=zlib --version=1.0")
-        client.run("create . --name=zlib --version=1.1")
-        client.save({"conanfile.py": GenConanfile().with_requires("zlib/1.0")})
-        client.run("create . --name=pkg --version=1.0")
-        client.run("install --requires=pkg/1.0@ --require-override=zlib/1.1")
-        assert "zlib/1.1: Already installed" in client.out
-
-    def test_create_cli_override(self, client):
-        client.save({"conanfile.py": GenConanfile()})
-        client.run("create . --name=zlib --version=1.0")
-        client.run("create . --name=zlib --version=2.0")
-        client.save({"conanfile.py": GenConanfile().with_requires("zlib/1.0"),
-                     "test_package/conanfile.py": GenConanfile().with_test("pass")})
-        client.run("create . --name=pkg --version=0.1 --require-override=zlib/2.0")
-        assert "zlib/2.0: Already installed" in client.out
-
-
 def test_package_folder_available_consumer():
     """
     The package folder is not available when doing a consumer conan install "."

--- a/conans/test/integration/lockfile/test_lock_requires.py
+++ b/conans/test/integration/lockfile/test_lock_requires.py
@@ -285,27 +285,6 @@ def test_conditional_compatible_range(requires):
     assert "dep/0.3" not in client.out
 
 
-def test_locking_require_override_version_ranges():
-    """
-    conanfile.txt locking it dependencies (with version ranges) and using a ``--require-override``
-    can work, because the locked version fits in the consumer range
-    """
-    client = TestClient()
-    client.save({"pkg/conanfile.py": GenConanfile(),
-                 "consumer/conanfile.txt": f"[requires]\npkg/[*]"})
-    client.run("create pkg --name=pkg --version=0.1")
-    client.run("create pkg --name=pkg --version=0.2")
-    client.run("lock create consumer/conanfile.txt  --lockfile-out=conan.lock "
-               "--require-override=pkg/0.1")
-    assert "pkg/0.1" in client.out
-    assert "pkg/0.2" not in client.out
-
-    # This work without override, it matches the range
-    client.run("install consumer/conanfile.txt --lockfile=conan.lock")
-    assert "pkg/0.1" in client.out
-    assert "pkg/0.2" not in client.out
-
-
 def test_partial_lockfile():
     """
     make sure that a partial lockfile can be applied anywhere downstream without issues,


### PR DESCRIPTION
After https://github.com/conan-io/conan/pull/10713, the ``--require-override`` cli arg doesn't make sense anymore, removing
