### PR TITLE
2.0 Fix subsystems run + test

### DIFF
--- a/conans/client/subsystems.py
+++ b/conans/client/subsystems.py
@@ -4,6 +4,7 @@ import re
 import subprocess
 
 from conans.errors import ConanException
+from conans.util.runners import conan_run
 
 WINDOWS = "windows"
 MSYS2 = 'msys2'
@@ -71,7 +72,7 @@ def run_in_windows_bash(conanfile, command, cwd=None, env=None):
         wrapped_shell=wrapped_shell,
         inside_command=inside_command)
     conanfile.output.info('Running in windows bash: %s' % final_command)
-    return conanfile._conan_runner(final_command, output=conanfile.output, subprocess=True)
+    return conan_run(final_command)
 
 
 def escape_windows_cmd(command):

--- a/conans/client/subsystems.py
+++ b/conans/client/subsystems.py
@@ -27,14 +27,15 @@ def run_in_windows_bash(conanfile, command, cwd=None, env=None):
         env_win = ["conanbuild.bat"]
 
     subsystem = conanfile.conf.get("tools.microsoft.bash:subsystem")
-    shell_path = conanfile.conf.get("tools.microsoft.bash:path")
+    shell_path = conanfile.conf.get("tools.microsoft.bash:path", default="bash")
 
     if not platform.system() == "Windows":
         raise ConanException("Command only for Windows operating system")
 
     if not subsystem or not shell_path:
-        raise ConanException("The config 'tools.microsoft.bash:subsystem' and 'tools.microsoft.bash:path' are "
-                             "needed to run commands in a Windows subsystem")
+        raise ConanException("The config 'tools.microsoft.bash:subsystem' and "
+                             "'tools.microsoft.bash:path' are needed to run commands in a "
+                             "Windows subsystem")
     if subsystem == MSYS2:
         # Configure MSYS2 to inherith the PATH
         msys2_mode_env = Environment()

--- a/conans/test/functional/subsystems_build_test.py
+++ b/conans/test/functional/subsystems_build_test.py
@@ -134,8 +134,6 @@ class TestSubsystemsBuild:
         include(default)
         [conf]
         tools.microsoft.bash:subsystem=msys2
-        tools.microsoft.bash:path=bash.exe
-        tools.gnu:make_program=mingw32-make.exe
         """)
         client.save({"conanfile.py": conanfile,
                      "Makefile": makefile,

--- a/conans/test/functional/subsystems_build_test.py
+++ b/conans/test/functional/subsystems_build_test.py
@@ -4,6 +4,7 @@ import pytest
 import textwrap
 
 from conans.test.assets.autotools import gen_makefile
+from conans.test.assets.genconanfile import GenConanfile
 from conans.test.assets.sources import gen_function_cpp
 from conans.test.functional.utils import check_exe_run
 from conans.test.utils.tools import TestClient
@@ -44,7 +45,7 @@ class TestSubsystems:
         assert "'uname' is not recognized as an internal or external command" in client.out
 
 
-@pytest.mark.skipif(platform.system() != "Windows", reason="Tests Windows Subsystems")
+#@pytest.mark.skipif(platform.system() != "Windows", reason="Tests Windows Subsystems")
 class TestSubsystemsBuild:
 
     @staticmethod
@@ -87,6 +88,53 @@ class TestSubsystemsBuild:
         assert "__MINGW64__" in client.out
         assert "__CYGWIN__" not in client.out
         assert "__MSYS__" not in client.out
+
+    @pytest.mark.tool("msys2")
+    @pytest.mark.tool("mingw64")
+    def test_mingw64_recipe(self):
+        """
+        64-bit GCC, binaries for generic Windows (no dependency on MSYS runtime)
+        """
+        client = TestClient()
+        makefile = gen_makefile(apps=["app"])
+        main_cpp = gen_function_cpp(name="main")
+        conanfile = textwrap.dedent("""
+        import os
+        from conan import ConanFile
+        from conan.tools.gnu import Autotools
+        from conan.tools.layout import basic_layout
+        from conan.tools.files import copy
+        class HelloConan(ConanFile):
+            exports_sources = "*.cpp", "Makefile"
+            generators = "AutotoolsToolchain"
+            win_bash = True
+
+            def build(self):
+                self.output.warning(self.build_folder)
+                auto = Autotools(self)
+                auto.make()
+
+            def package(self):
+                copy(self, "app*", self.build_folder, os.path.join(self.package_folder, "bin"))
+
+        """)
+        test_conanfile = textwrap.dedent("""
+                import os
+                from conan import ConanFile
+                class TestConan(ConanFile):
+
+                    def requirements(self):
+                        self.tool_requires(self.tested_reference_str)
+
+                    def test(self):
+                        self.run("app")
+                """)
+        client.save({"conanfile.py": conanfile,
+                     "Makefile": makefile,
+                     "app.cpp": main_cpp,
+                     "test_package/conanfile.py": test_conanfile})
+
+        client.run("create . --name foo --version 1.0")
 
     @pytest.mark.tool("msys2")
     @pytest.mark.tool("mingw32")


### PR DESCRIPTION
Changelog: Bugfix: Fixed crash when running commands inside a windows subsystem (`self.win_bash=True`).
Docs: omit