### PR TITLE
Fix call to undefined function for markdown generator when components add `system_libs`

### DIFF
--- a/conans/client/generators/markdown.py
+++ b/conans/client/generators/markdown.py
@@ -73,7 +73,7 @@ macros = textwrap.dedent("""
     * Links to libraries: {{ join_list_bold(cpp_info.libs) }}
     {%- endif %}
     {%- if cpp_info.system_libs %}
-    * Systems libs: {{ join_list_sources(cpp_info.system_libs) }}
+    * Systems libs: {{ join_list_bold(cpp_info.system_libs) }}
     {%- endif %}
     {%- if cpp_info.defines %}
     * Preprocessor definitions: {{ join_list_code(cpp_info.defines) }}

--- a/conans/test/integration/generators/markdown_test.py
+++ b/conans/test/integration/generators/markdown_test.py
@@ -145,3 +145,18 @@ class MarkDownGeneratorTest(unittest.TestCase):
         content = client.load("bar.md")
         self.assertIn("main.c", content)
         self.assertIn("project(bar_project C)", content)
+
+    def test_with_sys_requirements(self):
+        conanfile = textwrap.dedent("""
+                    import os
+                    from conans import ConanFile
+
+                    class HelloConan(ConanFile):
+                        def package_info(self):
+                            self.cpp_info.components["component1"].system_libs = ["system_lib"]
+                    """)
+        client = TestClient()
+        client.save({"conanfile.py": conanfile})
+        client.run("create . bar/0.1.0@user/testing")
+        client.run("install bar/0.1.0@user/testing -g markdown")
+        assert "ERROR: 'join_list_sources' is undefined" not in client.out

--- a/conans/test/integration/generators/markdown_test.py
+++ b/conans/test/integration/generators/markdown_test.py
@@ -159,4 +159,4 @@ class MarkDownGeneratorTest(unittest.TestCase):
         client.save({"conanfile.py": conanfile})
         client.run("create . bar/0.1.0@user/testing")
         client.run("install bar/0.1.0@user/testing -g markdown")
-        assert "ERROR: 'join_list_sources' is undefined" not in client.out
+        assert "Generator markdown created bar.md" in client.out


### PR DESCRIPTION
Changelog: Bugfix: Fix call to undefined function for markdown generator when components add `system_libs`.
Docs: omit

Closes: https://github.com/conan-io/conan/issues/10780
