### PR TITLE
[conf] Global flags management

### DIFF
--- a/conan/tools/cmake/toolchain/blocks.py
+++ b/conan/tools/cmake/toolchain/blocks.py
@@ -576,10 +576,10 @@ class CMakeFlagsInitBlock(Block):
         sharedlinkflags = self._conanfile.conf.get("tools.build:sharedlinkflags", default=[], check_type=list)
         exelinkflags = self._conanfile.conf.get("tools.build:exelinkflags", default=[], check_type=list)
         return {
-            "cxxflags": cxxflags,
-            "cflags": cflags,
-            "sharedlinkflags": sharedlinkflags,
-            "exelinkflags": exelinkflags,
+            "cxxflags": " ".join(cxxflags),
+            "cflags": " ".join(cflags),
+            "sharedlinkflags": " ".join(sharedlinkflags),
+            "exelinkflags": " ".join(exelinkflags),
         }
 
 

--- a/conan/tools/cmake/toolchain/blocks.py
+++ b/conan/tools/cmake/toolchain/blocks.py
@@ -582,7 +582,7 @@ class ExtraFlagsBlock(Block):
     """)
 
     def context(self):
-        # Now, it's time to add flags defined by the user
+        # Now, it's time to get all the flags defined by the user
         cxxflags = self._conanfile.conf.get("tools.build:cxxflags", default=[], check_type=list)
         cflags = self._conanfile.conf.get("tools.build:cflags", default=[], check_type=list)
         sharedlinkflags = self._conanfile.conf.get("tools.build:sharedlinkflags", default=[], check_type=list)

--- a/conan/tools/cmake/toolchain/blocks.py
+++ b/conan/tools/cmake/toolchain/blocks.py
@@ -516,17 +516,6 @@ class CMakeFlagsInitBlock(Block):
         self._conan_conf = Conf()
         self._process_conan_flags()
 
-    def _process_conan_flags(self):
-        mp_flag = self._get_parallel_jobs_flags()
-        arch_flag = self._get_arch_flag()
-        glib_flag = self._get_glib_flag()
-
-        # Defining all the flags
-        self._conan_conf.define("tools.build:cxxflags", [arch_flag, glib_flag, mp_flag])
-        self._conan_conf.define("tools.build:cflags", [arch_flag, mp_flag])
-        self._conan_conf.define("tools.build:sharedlinkflags", [arch_flag])
-        self._conan_conf.define("tools.build:exelinkflags", [arch_flag])
-
     def _get_parallel_jobs_flags(self):
         compiler = self._conanfile.settings.get_safe("compiler")
         if compiler not in ("Visual Studio", "msvc") or "Visual" not in self._toolchain.generator:
@@ -566,10 +555,21 @@ class CMakeFlagsInitBlock(Block):
                 glib_flag = "-library={}".format(glib_flag)
         return glib_flag
 
+    def _process_conan_flags(self):
+        """Calculating all the flags predefined by Conan"""
+        mp_flag = self._get_parallel_jobs_flags()
+        arch_flag = self._get_arch_flag()
+        glib_flag = self._get_glib_flag()
+
+        # Defining all the flags
+        self._conan_conf.define("tools.build:cxxflags", [arch_flag, glib_flag, mp_flag])
+        self._conan_conf.define("tools.build:cflags", [arch_flag, mp_flag])
+        self._conan_conf.define("tools.build:sharedlinkflags", [arch_flag])
+        self._conan_conf.define("tools.build:exelinkflags", [arch_flag])
+
     def context(self):
         # Now, it's time to update the predefined flags with [conf] ones injected by the user
         self._conan_conf.compose_conf(self._conanfile.conf)
-        # Getting all the flags from [conf]
         cxxflags = self._conan_conf.get("tools.build:cxxflags", default=[], check_type=list)
         cflags = self._conan_conf.get("tools.build:cflags", default=[], check_type=list)
         sharedlinkflags = self._conan_conf.get("tools.build:sharedlinkflags", default=[], check_type=list)

--- a/conan/tools/cmake/toolchain/blocks.py
+++ b/conan/tools/cmake/toolchain/blocks.py
@@ -575,7 +575,7 @@ class ExtraFlagsBlock(Block):
         {% if exelinkflags %}
         string(APPEND CONAN_EXE_LINKER_FLAGS
         {% for exelinkflag in exelinkflags %}
-        " {{ exelinkflags }}"
+        " {{ exelinkflag }}"
         {% endfor %}
         )
         {% endif %}

--- a/conan/tools/cmake/toolchain/blocks.py
+++ b/conan/tools/cmake/toolchain/blocks.py
@@ -552,32 +552,16 @@ class ExtraFlagsBlock(Block):
 
     template = textwrap.dedent("""
         {% if cxxflags %}
-        string(APPEND CONAN_CXX_FLAGS
-        {% for cxxflag in cxxflags %}
-        " {{ cxxflag }}"
-        {% endfor %}
-        )
+        string(APPEND CONAN_CXX_FLAGS "{% for cxxflag in cxxflags %} {{ cxxflag }}{% endfor %}")
         {% endif %}
         {% if cflags %}
-        string(APPEND CONAN_C_FLAGS
-        {% for cflag in cflags %}
-        " {{ cflag }}"
-        {% endfor %}
-        )
+        string(APPEND CONAN_C_FLAGS "{% for cflag in cflags %} {{ cflag }}{% endfor %}")
         {% endif %}
         {% if sharedlinkflags %}
-        string(APPEND CONAN_SHARED_LINKER_FLAGS
-        {% for sharedlinkflag in sharedlinkflags %}
-        " {{ sharedlinkflag }}"
-        {% endfor %}
-        )
+        string(APPEND CONAN_SHARED_LINKER_FLAGS "{% for sharedlinkflag in sharedlinkflags %} {{ sharedlinkflag }}{% endfor %}")
         {% endif %}
         {% if exelinkflags %}
-        string(APPEND CONAN_EXE_LINKER_FLAGS
-        {% for exelinkflag in exelinkflags %}
-        " {{ exelinkflag }}"
-        {% endfor %}
-        )
+        string(APPEND CONAN_EXE_LINKER_FLAGS "{% for exelinkflag in exelinkflags %} {{ exelinkflag }}{% endfor %}")
         {% endif %}
     """)
 

--- a/conan/tools/cmake/toolchain/blocks.py
+++ b/conan/tools/cmake/toolchain/blocks.py
@@ -8,13 +8,12 @@ from jinja2 import Template
 from conan.tools._compilers import architecture_flag
 from conan.tools.apple.apple import is_apple_os
 from conan.tools.build import build_jobs
-from conan.tools.build.cross_building import cross_building
 from conan.tools.cmake.toolchain import CONAN_TOOLCHAIN_FILENAME
 from conan.tools.cmake.utils import is_multi_configuration
+from conan.tools.build.cross_building import cross_building
 from conan.tools.intel import IntelCC
 from conan.tools.microsoft.visual import is_msvc, msvc_version_to_toolset_version
 from conans.errors import ConanException
-from conans.model.conf import Conf
 from conans.util.files import load
 
 
@@ -154,6 +153,9 @@ class FPicBlock(Block):
 
 class GLibCXXBlock(Block):
     template = textwrap.dedent("""
+        {% if set_libcxx %}
+        string(APPEND CONAN_CXX_FLAGS " {{ set_libcxx }}")
+        {% endif %}
         {% if glibcxx %}
         add_definitions(-D_GLIBCXX_USE_CXX11_ABI={{ glibcxx }})
         {% endif %}
@@ -164,14 +166,32 @@ class GLibCXXBlock(Block):
         if not libcxx:
             return None
         compiler = self._conanfile.settings.get_safe("compiler")
-        glib = None
+        lib = glib = None
+        if compiler == "apple-clang":
+            # In apple-clang 2 only values atm are "libc++" and "libstdc++"
+            lib = "-stdlib={}".format(libcxx)
+        elif compiler == "clang" or compiler == "intel-cc":
+            if libcxx == "libc++":
+                lib = "-stdlib=libc++"
+            elif libcxx == "libstdc++" or libcxx == "libstdc++11":
+                lib = "-stdlib=libstdc++"
+            # FIXME, something to do with the other values? Android c++_shared?
+        elif compiler == "sun-cc":
+            lib = {"libCstd": "Cstd",
+                   "libstdcxx": "stdcxx4",
+                   "libstlport": "stlport4",
+                   "libstdc++": "stdcpp"
+                   }.get(libcxx)
+            if lib:
+                lib = "-library={}".format(lib)
+
         if compiler in ['clang', 'apple-clang', 'gcc']:
             if libcxx == "libstdc++":
                 glib = "0"
             elif libcxx == "libstdc++11" and self._conanfile.conf.get("tools.gnu:define_libcxx11_abi",
                                                                       check_type=bool):
                 glib = "1"
-        return {"glibcxx": glib}
+        return {"set_libcxx": lib, "glibcxx": glib}
 
 
 class SkipRPath(Block):
@@ -188,6 +208,21 @@ class SkipRPath(Block):
 
     def context(self):
         return {"skip_rpath": self.skip_rpath}
+
+
+class ArchitectureBlock(Block):
+    template = textwrap.dedent("""
+        string(APPEND CONAN_CXX_FLAGS " {{ arch_flag }}")
+        string(APPEND CONAN_C_FLAGS " {{ arch_flag }}")
+        string(APPEND CONAN_SHARED_LINKER_FLAGS " {{ arch_flag }}")
+        string(APPEND CONAN_EXE_LINKER_FLAGS " {{ arch_flag }}")
+        """)
+
+    def context(self):
+        arch_flag = architecture_flag(self._conanfile.settings)
+        if not arch_flag:
+            return
+        return {"arch_flag": arch_flag}
 
 
 class CppStdBlock(Block):
@@ -224,6 +259,24 @@ class SharedLibBock(Block):
             return {"shared_libs": shared_libs}
         except ConanException:
             return None
+
+
+class ParallelBlock(Block):
+    template = textwrap.dedent("""
+        string(APPEND CONAN_CXX_FLAGS " /MP{{ parallel }}")
+        string(APPEND CONAN_C_FLAGS " /MP{{ parallel }}")
+        """)
+
+    def context(self):
+        # TODO: Check this conf
+
+        compiler = self._conanfile.settings.get_safe("compiler")
+        if compiler not in ("Visual Studio", "msvc") or "Visual" not in self._toolchain.generator:
+            return
+
+        jobs = build_jobs(self._conanfile)
+        if jobs:
+            return {"parallel": jobs}
 
 
 class AndroidSystemBlock(Block):
@@ -494,92 +547,69 @@ class UserToolchain(Block):
         return {"paths": [ut.replace("\\", "/") for ut in user_toolchain]}
 
 
-class CMakeFlagsInitBlock(Block):
+class ExtraFlagsBlock(Block):
+    """This block is adding flags directly from user [conf] section"""
+
     template = textwrap.dedent("""
         {% if cxxflags %}
-        string(APPEND CMAKE_CXX_FLAGS_INIT " {{ cxxflags }}")
+        string(APPEND CONAN_CXX_FLAGS
+        {% for cxxflag in cxxflags %}
+        " {{ cxxflag }}"
+        {% endfor %}
+        )
         {% endif %}
         {% if cflags %}
-        string(APPEND CMAKE_C_FLAGS_INIT " {{ cflags }}")
+        string(APPEND CONAN_C_FLAGS
+        {% for cflag in cflags %}
+        " {{ cflag }}"
+        {% endfor %}
+        )
         {% endif %}
         {% if sharedlinkflags %}
-        string(APPEND CMAKE_SHARED_LINKER_FLAGS_INIT " {{ sharedlinkflags }}")
+        string(APPEND CONAN_SHARED_LINKER_FLAGS
+        {% for sharedlinkflag in sharedlinkflags %}
+        " {{ sharedlinkflag }}"
+        {% endfor %}
+        )
         {% endif %}
         {% if exelinkflags %}
-        string(APPEND CMAKE_EXE_LINKER_FLAGS_INIT " {{ exelinkflags }}")
+        string(APPEND CONAN_EXE_LINKER_FLAGS
+        {% for exelinkflag in exelinkflags %}
+        " {{ exelinkflags }}"
+        {% endfor %}
+        )
         {% endif %}
     """)
 
-    def __init__(self, conanfile, toolchain):
-        super(CMakeFlagsInitBlock, self).__init__(conanfile, toolchain)
-        # Load all the predefined Conan C, CXX, etc. flags for CMakeToolchain
-        self._conan_conf = Conf()
-        self._process_conan_flags()
-
-    def _get_parallel_jobs_flags(self):
-        compiler = self._conanfile.settings.get_safe("compiler")
-        if compiler not in ("Visual Studio", "msvc") or "Visual" not in self._toolchain.generator:
-            return ""
-        jobs = build_jobs(self._conanfile)
-        if jobs:
-            return "/MP{}".format(jobs)
-
-    def _get_arch_flag(self):
-        arch_flag = architecture_flag(self._conanfile.settings)
-        if not arch_flag:
-            return ""
-        return arch_flag
-
-    def _get_glib_flag(self):
-        libcxx = self._conanfile.settings.get_safe("compiler.libcxx")
-        if not libcxx:
-            return ""
-
-        compiler = self._conanfile.settings.get_safe("compiler")
-        glib_flag = ""
-        if compiler == "apple-clang":
-            # In apple-clang 2 only values atm are "libc++" and "libstdc++"
-            glib_flag = "-stdlib={}".format(libcxx)
-        elif compiler == "clang" or compiler == "intel-cc":
-            if libcxx == "libc++":
-                glib_flag = "-stdlib=libc++"
-            elif libcxx == "libstdc++" or libcxx == "libstdc++11":
-                glib_flag = "-stdlib=libstdc++"
-            # FIXME, something to do with the other values? Android c++_shared?
-        elif compiler == "sun-cc":
-            glib_flag = {"libCstd": "Cstd",
-                         "libstdcxx": "stdcxx4",
-                         "libstlport": "stlport4",
-                         "libstdc++": "stdcpp"}.get(libcxx)
-            if glib_flag:
-                glib_flag = "-library={}".format(glib_flag)
-        return glib_flag
-
-    def _process_conan_flags(self):
-        """Calculating all the flags predefined by Conan"""
-        mp_flag = self._get_parallel_jobs_flags()
-        arch_flag = self._get_arch_flag()
-        glib_flag = self._get_glib_flag()
-
-        # Defining all the flags
-        self._conan_conf.define("tools.build:cxxflags", [arch_flag, glib_flag, mp_flag])
-        self._conan_conf.define("tools.build:cflags", [arch_flag, mp_flag])
-        self._conan_conf.define("tools.build:sharedlinkflags", [arch_flag])
-        self._conan_conf.define("tools.build:exelinkflags", [arch_flag])
-
     def context(self):
-        # Now, it's time to update the predefined flags with [conf] ones injected by the user
-        self._conan_conf.compose_conf(self._conanfile.conf)
-        cxxflags = self._conan_conf.get("tools.build:cxxflags", default=[], check_type=list)
-        cflags = self._conan_conf.get("tools.build:cflags", default=[], check_type=list)
-        sharedlinkflags = self._conan_conf.get("tools.build:sharedlinkflags", default=[], check_type=list)
-        exelinkflags = self._conan_conf.get("tools.build:exelinkflags", default=[], check_type=list)
+        # Now, it's time to add flags defined by the user
+        cxxflags = self._conanfile.conf.get("tools.build:cxxflags", default=[], check_type=list)
+        cflags = self._conanfile.conf.get("tools.build:cflags", default=[], check_type=list)
+        sharedlinkflags = self._conanfile.conf.get("tools.build:sharedlinkflags", default=[], check_type=list)
+        exelinkflags = self._conanfile.conf.get("tools.build:exelinkflags", default=[], check_type=list)
         return {
-            "cxxflags": " ".join(cxxflags),
-            "cflags": " ".join(cflags),
-            "sharedlinkflags": " ".join(sharedlinkflags),
-            "exelinkflags": " ".join(exelinkflags),
+            "cxxflags": cxxflags,
+            "cflags": cflags,
+            "sharedlinkflags": sharedlinkflags,
+            "exelinkflags": exelinkflags
         }
+
+
+class CMakeFlagsInitBlock(Block):
+    template = textwrap.dedent("""
+        if(DEFINED CONAN_CXX_FLAGS)
+          string(APPEND CMAKE_CXX_FLAGS_INIT " ${CONAN_CXX_FLAGS}")
+        endif()
+        if(DEFINED CONAN_C_FLAGS)
+          string(APPEND CMAKE_C_FLAGS_INIT " ${CONAN_C_FLAGS}")
+        endif()
+        if(DEFINED CONAN_SHARED_LINKER_FLAGS)
+          string(APPEND CMAKE_SHARED_LINKER_FLAGS_INIT " ${CONAN_SHARED_LINKER_FLAGS}")
+        endif()
+        if(DEFINED CONAN_EXE_LINKER_FLAGS)
+          string(APPEND CMAKE_EXE_LINKER_FLAGS_INIT " ${CONAN_EXE_LINKER_FLAGS}")
+        endif()
+        """)
 
 
 class TryCompileBlock(Block):

--- a/conan/tools/cmake/toolchain/toolchain.py
+++ b/conan/tools/cmake/toolchain/toolchain.py
@@ -133,7 +133,6 @@ class CMakeToolchain(object):
                                        ("shared", SharedLibBock),
                                        ("output_dirs", OutputDirsBlock)])
 
-
         check_using_build_profile(self._conanfile)
 
     def _context(self):

--- a/conan/tools/cmake/toolchain/toolchain.py
+++ b/conan/tools/cmake/toolchain/toolchain.py
@@ -8,9 +8,9 @@ from conan.tools._check_build_profile import check_using_build_profile
 from conan.tools._compilers import use_win_mingw
 from conan.tools.cmake.toolchain import CONAN_TOOLCHAIN_FILENAME
 from conan.tools.cmake.toolchain.blocks import ToolchainBlocks, UserToolchain, GenericSystemBlock, \
-    AndroidSystemBlock, AppleSystemBlock, FPicBlock, GLibCXXBlock, VSRuntimeBlock, \
-    CppStdBlock, CMakeFlagsInitBlock, TryCompileBlock, FindFiles, SkipRPath, \
-    SharedLibBock, OutputDirsBlock
+    AndroidSystemBlock, AppleSystemBlock, FPicBlock, ArchitectureBlock, GLibCXXBlock, VSRuntimeBlock, \
+    CppStdBlock, ParallelBlock, CMakeFlagsInitBlock, TryCompileBlock, FindFiles, SkipRPath, \
+    SharedLibBock, OutputDirsBlock, ExtraFlagsBlock
 from conan.tools.files.files import save_toolchain_args
 from conan.tools.intel import IntelCC
 from conan.tools.microsoft import VCVars
@@ -121,9 +121,12 @@ class CMakeToolchain(object):
                                        ("android_system", AndroidSystemBlock),
                                        ("apple_system", AppleSystemBlock),
                                        ("fpic", FPicBlock),
+                                       ("arch_flags", ArchitectureBlock),
                                        ("libcxx", GLibCXXBlock),
                                        ("vs_runtime", VSRuntimeBlock),
                                        ("cppstd", CppStdBlock),
+                                       ("parallel", ParallelBlock),
+                                       ("extra_flags", ExtraFlagsBlock),
                                        ("cmake_flags_init", CMakeFlagsInitBlock),
                                        ("try_compile", TryCompileBlock),
                                        ("find_paths", FindFiles),

--- a/conan/tools/cmake/toolchain/toolchain.py
+++ b/conan/tools/cmake/toolchain/toolchain.py
@@ -8,8 +8,8 @@ from conan.tools._check_build_profile import check_using_build_profile
 from conan.tools._compilers import use_win_mingw
 from conan.tools.cmake.toolchain import CONAN_TOOLCHAIN_FILENAME
 from conan.tools.cmake.toolchain.blocks import ToolchainBlocks, UserToolchain, GenericSystemBlock, \
-    AndroidSystemBlock, AppleSystemBlock, FPicBlock, ArchitectureBlock, GLibCXXBlock, VSRuntimeBlock, \
-    CppStdBlock, ParallelBlock, CMakeFlagsInitBlock, TryCompileBlock, FindFiles, SkipRPath, \
+    AndroidSystemBlock, AppleSystemBlock, FPicBlock, GLibCXXBlock, VSRuntimeBlock, \
+    CppStdBlock, CMakeFlagsInitBlock, TryCompileBlock, FindFiles, SkipRPath, \
     SharedLibBock, OutputDirsBlock
 from conan.tools.files.files import save_toolchain_args
 from conan.tools.intel import IntelCC
@@ -121,11 +121,9 @@ class CMakeToolchain(object):
                                        ("android_system", AndroidSystemBlock),
                                        ("apple_system", AppleSystemBlock),
                                        ("fpic", FPicBlock),
-                                       ("arch_flags", ArchitectureBlock),
                                        ("libcxx", GLibCXXBlock),
                                        ("vs_runtime", VSRuntimeBlock),
                                        ("cppstd", CppStdBlock),
-                                       ("parallel", ParallelBlock),
                                        ("cmake_flags_init", CMakeFlagsInitBlock),
                                        ("try_compile", TryCompileBlock),
                                        ("find_paths", FindFiles),

--- a/conan/tools/gnu/autotoolstoolchain.py
+++ b/conan/tools/gnu/autotoolstoolchain.py
@@ -125,7 +125,7 @@ class AutotoolsToolchain:
             return "-Y _%s" % str(libcxx)
 
     @staticmethod
-    def _filter_empty_list_fields(v):
+    def _filter_list_empty_fields(v):
         return list(filter(bool, v))
 
     def _get_extra_flags(self):
@@ -161,10 +161,10 @@ class AutotoolsToolchain:
             env.define("CXX", "cl")
             env.define("CC", "cl")
 
-        env.append("CPPFLAGS", ["-D{}".format(d) for d in self._filter_empty_list_fields(self.defines)])
-        env.append("CXXFLAGS", self._filter_empty_list_fields(self.cxxflags))
-        env.append("CFLAGS", self._filter_empty_list_fields(self.cflags))
-        env.append("LDFLAGS", self._filter_empty_list_fields(self.ldflags))
+        env.append("CPPFLAGS", ["-D{}".format(d) for d in self._filter_list_empty_fields(self.defines)])
+        env.append("CXXFLAGS", self._filter_list_empty_fields(self.cxxflags))
+        env.append("CFLAGS", self._filter_list_empty_fields(self.cflags))
+        env.append("LDFLAGS", self._filter_list_empty_fields(self.ldflags))
 
         return env
 

--- a/conan/tools/gnu/autotoolstoolchain.py
+++ b/conan/tools/gnu/autotoolstoolchain.py
@@ -26,7 +26,6 @@ class AutotoolsToolchain:
         self.ldflags = []
         self.defines = []
 
-        # TODO: compiler.runtime for Visual studio?
         # Defines
         self.gcc_cxx11_abi = self._get_cxx11_abi_define()
         self.ndebug = None

--- a/conan/tools/meson/meson.py
+++ b/conan/tools/meson/meson.py
@@ -3,6 +3,7 @@ import os
 from conan.tools.build import build_jobs
 from conan.tools.meson import MesonToolchain
 
+
 class Meson(object):
     def __init__(self, conanfile):
         self._conanfile = conanfile

--- a/conan/tools/meson/toolchain.py
+++ b/conan/tools/meson/toolchain.py
@@ -139,10 +139,10 @@ class MesonToolchain(object):
         self.as_ = build_env.get("AS")
         self.windres = build_env.get("WINDRES")
         self.pkgconfig = build_env.get("PKG_CONFIG")
-        self.c_args = build_env.get("CFLAGS", [])
-        self.c_link_args = build_env.get("LDFLAGS", [])
-        self.cpp_args = build_env.get("CXXFLAGS", [])
-        self.cpp_link_args = build_env.get("LDFLAGS", [])
+        self.c_args = self._get_env_list(build_env.get("CFLAGS", []))
+        self.c_link_args = self._get_env_list(build_env.get("LDFLAGS", []))
+        self.cpp_args = self._get_env_list(build_env.get("CXXFLAGS", []))
+        self.cpp_link_args = self._get_env_list(build_env.get("LDFLAGS", []))
 
         # Apple flags
         self.apple_arch_flag = []
@@ -183,6 +183,11 @@ class MesonToolchain(object):
             "cflags": cflags,
             "ldflags": ldflags
         }
+
+    @staticmethod
+    def _get_env_list(v):
+        # FIXME: Should Environment have the "check_type=None" keyword as Conf?
+        return v.strip().split() if not isinstance(v, list) else v
 
     @staticmethod
     def _filter_list_empty_fields(v):

--- a/conan/tools/meson/toolchain.py
+++ b/conan/tools/meson/toolchain.py
@@ -139,14 +139,19 @@ class MesonToolchain(object):
         self.as_ = build_env.get("AS")
         self.windres = build_env.get("WINDRES")
         self.pkgconfig = build_env.get("PKG_CONFIG")
-        self.c_args = build_env.get("CFLAGS", "")
-        self.c_link_args = build_env.get("LDFLAGS", "")
-        self.cpp_args = build_env.get("CXXFLAGS", "")
-        self.cpp_link_args = build_env.get("LDFLAGS", "")
+        self.c_args = build_env.get("CFLAGS", [])
+        self.c_link_args = build_env.get("LDFLAGS", [])
+        self.cpp_args = build_env.get("CXXFLAGS", [])
+        self.cpp_link_args = build_env.get("LDFLAGS", [])
 
-        self._add_apple_flags()
+        # Apple flags
+        self.apple_arch_flag = []
+        self.apple_isysroot_flag = []
+        self.apple_min_version_flag = []
 
-    def _add_apple_flags(self):
+        self._resolve_apple_flags()
+
+    def _resolve_apple_flags(self):
         conanfile = self._conanfile
         os_ = conanfile.settings.get_safe("os")
         if not is_apple_os(os_):
@@ -162,33 +167,36 @@ class MesonToolchain(object):
         if not os_sdk and os_ != "Macos":
             raise ConanException("Please, specify a suitable value for os.sdk.")
 
-        arch = to_apple_arch(conanfile.settings.get_safe("arch"))
         # Calculating the main Apple flags
-        deployment_target_flag = apple_min_version_flag(conanfile)
-        sysroot_flag = "-isysroot " + sdk_path if sdk_path else ""
-        arch_flag = "-arch " + arch if arch else ""
+        arch = to_apple_arch(conanfile.settings.get_safe("arch"))
+        self.apple_arch_flag = ["-arch", arch] if arch else []
+        self.apple_isysroot_flag = ["-isysroot", sdk_path] if sdk_path else []
+        self.apple_min_version_flag = [apple_min_version_flag(conanfile)]
 
-        apple_flags = {}
-        if deployment_target_flag:
-            flag_ = deployment_target_flag.split("=")[0]
-            apple_flags[flag_] = deployment_target_flag
-        if sysroot_flag:
-            apple_flags["-isysroot"] = sysroot_flag
-        if arch_flag:
-            apple_flags["-arch"] = arch_flag
+    def _get_extra_flags(self):
+        # Now, it's time to get all the flags defined by the user
+        cxxflags = self._conanfile.conf.get("tools.build:cxxflags", default=[], check_type=list)
+        cflags = self._conanfile.conf.get("tools.build:cflags", default=[], check_type=list)
+        ldflags = self._conanfile.conf.get("tools.build:ldflags", default=[], check_type=list)
+        return {
+            "cxxflags": cxxflags,
+            "cflags": cflags,
+            "ldflags": ldflags
+        }
 
-        for flag, arg_value in apple_flags.items():
-            v = " " + arg_value
-            if flag not in self.c_args:
-                self.c_args += v
-            if flag not in self.c_link_args:
-                self.c_link_args += v
-            if flag not in self.cpp_args:
-                self.cpp_args += v
-            if flag not in self.cpp_link_args:
-                self.cpp_link_args += v
+    @staticmethod
+    def _filter_list_empty_fields(v):
+        return list(filter(bool, v))
 
     def _context(self):
+        apple_flags = self.apple_isysroot_flag + self.apple_arch_flag + self.apple_min_version_flag
+        extra_flags = self._get_extra_flags()
+
+        self.c_args.extend(apple_flags + extra_flags["cflags"])
+        self.cpp_args.extend(apple_flags + extra_flags["cxxflags"])
+        self.c_link_args.extend(apple_flags + extra_flags["ldflags"])
+        self.cpp_link_args.extend(apple_flags + extra_flags["ldflags"])
+
         return {
             # https://mesonbuild.com/Machine-files.html#project-specific-options
             "project_options": {k: to_meson_value(v) for k, v in self.project_options.items()},
@@ -215,10 +223,10 @@ class MesonToolchain(object):
             "b_ndebug": to_meson_value(self._b_ndebug),  # boolean as string
             # https://mesonbuild.com/Builtin-options.html#compiler-options
             "cpp_std": self._cpp_std,
-            "c_args": to_meson_value(self.c_args.strip().split()),
-            "c_link_args": to_meson_value(self.c_link_args.strip().split()),
-            "cpp_args": to_meson_value(self.cpp_args.strip().split()),
-            "cpp_link_args": to_meson_value(self.cpp_link_args.strip().split()),
+            "c_args": to_meson_value(self._filter_list_empty_fields(self.c_args)),
+            "c_link_args": to_meson_value(self._filter_list_empty_fields(self.c_link_args)),
+            "cpp_args": to_meson_value(self._filter_list_empty_fields(self.cpp_args)),
+            "cpp_link_args": to_meson_value(self._filter_list_empty_fields(self.cpp_link_args)),
             "pkg_config_path": self.pkg_config_path,
             "preprocessor_definitions": self.preprocessor_definitions,
             "cross_build": self.cross_build

--- a/conans/model/conf.py
+++ b/conans/model/conf.py
@@ -235,6 +235,8 @@ class Conf:
                 return self._get_boolean_value(v)
             elif check_type is str and not isinstance(v, str):
                 return str(v)
+            elif v is None:  # value was unset
+                return default
             elif check_type is not None and not isinstance(v, check_type):
                 raise ConanException("[conf] {name} must be a {type}-like object. "
                                      "The value '{value}' introduced is a {vtype} "

--- a/conans/model/conf.py
+++ b/conans/model/conf.py
@@ -39,7 +39,13 @@ BUILT_IN_CONFS = {
     "tools.system.package_manager:mode": "Mode for package_manager tools: 'check' or 'install'",
     "tools.system.package_manager:sudo": "Use 'sudo' when invoking the package manager tools in Linux (False by default)",
     "tools.system.package_manager:sudo_askpass": "Use the '-A' argument if using sudo in Linux to invoke the system package manager (False by default)",
-    "tools.apple.xcodebuild:verbosity": "Verbosity level for xcodebuild: 'verbose' or 'quiet"
+    "tools.apple.xcodebuild:verbosity": "Verbosity level for xcodebuild: 'verbose' or 'quiet",
+    # Flags configuration
+    "tools.build:cxxflags": "TBD",
+    "tools.build:cflags": "TBD",
+    "tools.build:ldflags": "TBD",
+    "tools.build:sharedlinkflags": "TBD",
+    "tools.build:exelinkflags": "TBD",
 }
 
 

--- a/conans/model/conf.py
+++ b/conans/model/conf.py
@@ -41,12 +41,12 @@ BUILT_IN_CONFS = {
     "tools.system.package_manager:sudo_askpass": "Use the '-A' argument if using sudo in Linux to invoke the system package manager (False by default)",
     "tools.apple.xcodebuild:verbosity": "Verbosity level for xcodebuild: 'verbose' or 'quiet",
     # Flags configuration
-    "tools.build:cxxflags": "TBD",
-    "tools.build:cflags": "TBD",
-    "tools.build:cppflags": "TBD",
-    "tools.build:ldflags": "TBD",
-    "tools.build:sharedlinkflags": "TBD",
-    "tools.build:exelinkflags": "TBD",
+    "tools.build:cxxflags": "List of extra CXX flags used by different toolchains like CMakeToolchain, AutotoolsToolchain and MesonToolchain",
+    "tools.build:cflags": "List of extra C flags used by different toolchains like CMakeToolchain, AutotoolsToolchain and MesonToolchain",
+    "tools.build:cppflags": "List of extra CPP flags used by different toolchains like AutotoolsToolchain and MesonToolchain",
+    "tools.build:ldflags": "List of extra LD flags used by different toolchains like AutotoolsToolchain and MesonToolchain",
+    "tools.build:sharedlinkflags": "List of extra flags used by CMakeToolchain for CMAKE_SHARED_LINKER_FLAGS_INIT variable",
+    "tools.build:exelinkflags": "List of extra flags used by CMakeToolchain for CMAKE_EXE_LINKER_FLAGS_INIT variable",
 }
 
 

--- a/conans/model/conf.py
+++ b/conans/model/conf.py
@@ -43,6 +43,7 @@ BUILT_IN_CONFS = {
     # Flags configuration
     "tools.build:cxxflags": "TBD",
     "tools.build:cflags": "TBD",
+    "tools.build:cppflags": "TBD",
     "tools.build:ldflags": "TBD",
     "tools.build:sharedlinkflags": "TBD",
     "tools.build:exelinkflags": "TBD",

--- a/conans/test/integration/toolchains/cmake/test_cmaketoolchain.py
+++ b/conans/test/integration/toolchains/cmake/test_cmaketoolchain.py
@@ -229,3 +229,49 @@ def test_find_builddirs():
     with open(os.path.join(client.current_folder, "conan_toolchain.cmake")) as f:
         contents = f.read()
         assert "/path/to/builddir" in contents
+
+
+def test_extra_flags_via_conf():
+    profile = textwrap.dedent("""
+        [settings]
+        os=Linux
+        compiler=gcc
+        compiler.version=6
+        compiler.libcxx=libstdc++11
+        arch=armv8
+        build_type=Release
+
+        [conf]
+        tools.build:cxxflags=["--flag1", "--flag2"]
+        tools.build:cflags+=["--flag3", "--flag4"]
+        tools.build:sharedlinkflags=+["--flag5", "--flag6"]
+        tools.build:exelinkflags=["--flag7", "--flag8"]
+        """)
+
+    client = TestClient(path_with_spaces=False)
+
+    conanfile = GenConanfile().with_settings("os", "arch", "compiler", "build_type")\
+        .with_generator("CMakeToolchain")
+    client.save({"conanfile.py": conanfile,
+                "profile": profile})
+    client.run("install . --profile:build=profile --profile:host=profile")
+    toolchain = client.load("conan_toolchain.cmake")
+    expected = textwrap.dedent("""\
+        string(APPEND CONAN_CXX_FLAGS
+        " --flag1"
+        " --flag2"
+        )
+        string(APPEND CONAN_C_FLAGS
+        " --flag3"
+        " --flag4"
+        )
+        string(APPEND CONAN_SHARED_LINKER_FLAGS
+        " --flag5"
+        " --flag6"
+        )
+        string(APPEND CONAN_EXE_LINKER_FLAGS
+        " --flag7"
+        " --flag8"
+        )
+    """)
+    assert expected in toolchain

--- a/conans/test/integration/toolchains/cmake/test_cmaketoolchain.py
+++ b/conans/test/integration/toolchains/cmake/test_cmaketoolchain.py
@@ -256,22 +256,7 @@ def test_extra_flags_via_conf():
                 "profile": profile})
     client.run("install . --profile:build=profile --profile:host=profile")
     toolchain = client.load("conan_toolchain.cmake")
-    expected = textwrap.dedent("""\
-        string(APPEND CONAN_CXX_FLAGS
-        " --flag1"
-        " --flag2"
-        )
-        string(APPEND CONAN_C_FLAGS
-        " --flag3"
-        " --flag4"
-        )
-        string(APPEND CONAN_SHARED_LINKER_FLAGS
-        " --flag5"
-        " --flag6"
-        )
-        string(APPEND CONAN_EXE_LINKER_FLAGS
-        " --flag7"
-        " --flag8"
-        )
-    """)
-    assert expected in toolchain
+    assert 'string(APPEND CONAN_CXX_FLAGS " --flag1 --flag2")' in toolchain
+    assert 'string(APPEND CONAN_C_FLAGS " --flag3 --flag4")' in toolchain
+    assert 'string(APPEND CONAN_SHARED_LINKER_FLAGS " --flag5 --flag6")' in toolchain
+    assert 'string(APPEND CONAN_EXE_LINKER_FLAGS " --flag7 --flag8")' in toolchain

--- a/conans/test/integration/toolchains/gnu/test_autotoolstoolchain.py
+++ b/conans/test/integration/toolchains/gnu/test_autotoolstoolchain.py
@@ -1,0 +1,34 @@
+import platform
+import textwrap
+
+from conans.test.assets.genconanfile import GenConanfile
+from conans.test.utils.tools import TestClient
+
+
+def test_extra_flags_via_conf():
+    profile = textwrap.dedent("""
+        [settings]
+        os=Linux
+        compiler=gcc
+        compiler.version=6
+        compiler.libcxx=libstdc++11
+        arch=armv8
+        build_type=Release
+
+        [conf]
+        tools.build:cxxflags=["--flag1", "--flag2"]
+        tools.build:cflags+=["--flag3", "--flag4"]
+        tools.build:ldflags+=["--flag5", "--flag6"]
+        tools.build:cppflags+=["DEF1", "DEF2"]
+        """)
+    client = TestClient()
+    conanfile = GenConanfile().with_settings("os", "arch", "compiler", "build_type")\
+        .with_generator("AutotoolsToolchain")
+    client.save({"conanfile.py": conanfile,
+                "profile": profile})
+    client.run("install . --profile:build=profile --profile:host=profile")
+    toolchain = client.load("conanautotoolstoolchain{}".format('.sh' if platform.system() != "Windows" else '.bat'))
+    assert 'export CPPFLAGS="$CPPFLAGS -DNDEBUG -DDEF1 -DDEF2"' in toolchain
+    assert 'export CXXFLAGS="$CXXFLAGS -O3 -s --flag1 --flag2"' in toolchain
+    assert 'export CFLAGS="$CFLAGS -O3 -s --flag3 --flag4"' in toolchain
+    assert 'export LDFLAGS="$LDFLAGS --flag5 --flag6"' in toolchain

--- a/conans/test/integration/toolchains/meson/test_mesontoolchain.py
+++ b/conans/test/integration/toolchains/meson/test_mesontoolchain.py
@@ -7,54 +7,7 @@ from conan.tools.meson import MesonToolchain
 from conans.test.utils.tools import TestClient
 
 
-build_env_1 = textwrap.dedent("""
-CFLAGS=-mios-version-min=1 -isysroot ROOT1 -arch armv1
-CXXFLAGS=-mios-version-min=2 -isysroot ROOT2 -arch armv2
-LDFLAGS=-mios-version-min=3 -isysroot ROOT3 -arch armv3
-""")
-
-expected_args_1 = textwrap.dedent("""
-c_args = ['-mios-version-min=1', '-isysroot', 'ROOT1', '-arch', 'armv1'] + preprocessor_definitions
-c_link_args = ['-mios-version-min=3', '-isysroot', 'ROOT3', '-arch', 'armv3']
-cpp_args = ['-mios-version-min=2', '-isysroot', 'ROOT2', '-arch', 'armv2'] + preprocessor_definitions
-cpp_link_args = ['-mios-version-min=3', '-isysroot', 'ROOT3', '-arch', 'armv3']
-""")
-
-build_env_2 = textwrap.dedent("""
-CFLAGS=-isysroot ROOT1 -arch armv1
-CXXFLAGS=-mios-version-min=2 -arch armv2
-LDFLAGS=-mios-version-min=3 -isysroot ROOT3
-""")
-
-expected_args_2 = textwrap.dedent("""
-c_args = ['-isysroot', 'ROOT1', '-arch', 'armv1', '-mios-version-min=10.0'] + preprocessor_definitions
-c_link_args = ['-mios-version-min=3', '-isysroot', 'ROOT3', '-arch', 'arm64']
-cpp_args = ['-mios-version-min=2', '-arch', 'armv2', '-isysroot', '/my/sdk/path'] + preprocessor_definitions
-cpp_link_args = ['-mios-version-min=3', '-isysroot', 'ROOT3', '-arch', 'arm64']
-""")
-
-
-build_env_3 = textwrap.dedent("""
-CFLAGS=-flag1
-CXXFLAGS=-flag2
-LDFLAGS=-flag3
-""")
-
-expected_args_3 = textwrap.dedent("""
-c_args = ['-flag1', '-mios-version-min=10.0', '-isysroot', '/my/sdk/path', '-arch', 'arm64'] + preprocessor_definitions
-c_link_args = ['-flag3', '-mios-version-min=10.0', '-isysroot', '/my/sdk/path', '-arch', 'arm64']
-cpp_args = ['-flag2', '-mios-version-min=10.0', '-isysroot', '/my/sdk/path', '-arch', 'arm64'] + preprocessor_definitions
-cpp_link_args = ['-flag3', '-mios-version-min=10.0', '-isysroot', '/my/sdk/path', '-arch', 'arm64']
-""")
-
-
-@pytest.mark.skipif(sys.version_info.major == 2, reason="Meson not supported in Py2")
-@pytest.mark.parametrize("build_env,expected_args", [
-    (build_env_1, expected_args_1),
-    (build_env_2, expected_args_2),
-    (build_env_3, expected_args_3),
-])
-def test_apple_meson_keep_user_flags(build_env, expected_args):
+def test_apple_meson_keep_user_custom_flags():
     default = textwrap.dedent("""
     [settings]
     os=Macos
@@ -75,12 +28,9 @@ def test_apple_meson_keep_user_flags(build_env, expected_args):
     compiler.version = 12.0
     compiler.libcxx = libc++
 
-    [buildenv]
-    {build_env}
-
     [conf]
     tools.apple:sdk_path=/my/sdk/path
-    """.format(build_env=build_env))
+    """)
 
     _conanfile_py = textwrap.dedent("""
     from conan import ConanFile
@@ -91,6 +41,10 @@ def test_apple_meson_keep_user_flags(build_env, expected_args):
 
         def generate(self):
             tc = MesonToolchain(self)
+            # Customized apple flags
+            tc.apple_arch_flag = ['-arch', 'myarch']
+            tc.apple_isysroot_flag = ['-isysroot', '/other/sdk/path']
+            tc.apple_min_version_flag = ['-otherminversion=10.7']
             tc.generate()
     """)
 
@@ -101,7 +55,43 @@ def test_apple_meson_keep_user_flags(build_env, expected_args):
 
     t.run("install . -pr:h host_prof -pr:b build_prof")
     content = t.load(MesonToolchain.cross_filename)
-    assert expected_args in content
+    assert "c_args = ['-isysroot', '/other/sdk/path', '-arch', 'myarch', '-otherminversion=10.7']" in content
+    assert "c_link_args = ['-isysroot', '/other/sdk/path', '-arch', 'myarch', '-otherminversion=10.7']" in content
+    assert "cpp_args = ['-isysroot', '/other/sdk/path', '-arch', 'myarch', '-otherminversion=10.7']" in content
+    assert "cpp_link_args = ['-isysroot', '/other/sdk/path', '-arch', 'myarch', '-otherminversion=10.7']" in content
+
+
+def test_extra_flags_via_conf():
+    profile = textwrap.dedent("""
+        [settings]
+        os=Windows
+        arch=x86_64
+        compiler=gcc
+        compiler.version=9
+        compiler.cppstd=17
+        compiler.libcxx=libstdc++11
+        build_type=Release
+
+        [buildenv]
+        CFLAGS=-flag0 -other=val
+        CXXFLAGS=-flag0 -other=val
+        LDFLAGS=-flag0 -other=val
+
+        [conf]
+        tools.build:cxxflags=["-flag1", "-flag2"]
+        tools.build:cflags=["-flag3", "-flag4"]
+        tools.build:ldflags=["-flag5", "-flag6"]
+   """)
+    t = TestClient()
+    t.save({"conanfile.txt": "[generators]\nMesonToolchain",
+            "profile": profile})
+
+    t.run("install . -pr=profile")
+    content = t.load(MesonToolchain.native_filename)
+    assert "cpp_args = ['-flag0', '-other=val', '-flag1', '-flag2']" in content
+    assert "c_args = ['-flag0', '-other=val', '-flag3', '-flag4']" in content
+    assert "c_link_args = ['-flag0', '-other=val', '-flag5', '-flag6']" in content
+    assert "cpp_link_args = ['-flag0', '-other=val', '-flag5', '-flag6']" in content
 
 
 def test_correct_quotes():

--- a/conans/test/integration/toolchains/meson/test_mesontoolchain.py
+++ b/conans/test/integration/toolchains/meson/test_mesontoolchain.py
@@ -7,6 +7,7 @@ from conan.tools.meson import MesonToolchain
 from conans.test.utils.tools import TestClient
 
 
+@pytest.mark.skipif(sys.version_info.major == 2, reason="Meson not supported in Py2")
 def test_apple_meson_keep_user_custom_flags():
     default = textwrap.dedent("""
     [settings]
@@ -61,6 +62,7 @@ def test_apple_meson_keep_user_custom_flags():
     assert "cpp_link_args = ['-isysroot', '/other/sdk/path', '-arch', 'myarch', '-otherminversion=10.7']" in content
 
 
+@pytest.mark.skipif(sys.version_info.major == 2, reason="Meson not supported in Py2")
 def test_extra_flags_via_conf():
     profile = textwrap.dedent("""
         [settings]
@@ -94,6 +96,7 @@ def test_extra_flags_via_conf():
     assert "cpp_link_args = ['-flag0', '-other=val', '-flag5', '-flag6']" in content
 
 
+@pytest.mark.skipif(sys.version_info.major == 2, reason="Meson not supported in Py2")
 def test_correct_quotes():
     profile = textwrap.dedent("""
        [settings]

--- a/conans/test/unittests/client/toolchain/autotools/autotools_toolchain_test.py
+++ b/conans/test/unittests/client/toolchain/autotools/autotools_toolchain_test.py
@@ -258,7 +258,7 @@ def test_build_type_flag(compiler):
 
 def test_apple_arch_flag():
     conanfile = ConanFileMock()
-    conanfile.conf = {"tools.apple:sdk_path": "/path/to/sdk"}
+    conanfile.conf.define("tools.apple:sdk_path", "/path/to/sdk")
     conanfile.settings_build = MockSettings(
         {"build_type": "Debug",
          "os": "Macos",
@@ -290,7 +290,7 @@ def test_apple_arch_flag():
 def test_apple_min_os_flag():
     """Even when no cross building it is adjusted because it could target a Mac version"""
     conanfile = ConanFileMock()
-    conanfile.conf = {"tools.apple:sdk_path": "/path/to/sdk"}
+    conanfile.conf.define("tools.apple:sdk_path", "/path/to/sdk")
     conanfile.settings = MockSettings(
         {"build_type": "Debug",
          "os": "Macos",
@@ -308,7 +308,7 @@ def test_apple_min_os_flag():
 def test_apple_isysrootflag():
     """Even when no cross building it is adjusted because it could target a Mac version"""
     conanfile = ConanFileMock()
-    conanfile.conf = {"tools.apple:sdk_path": "/path/to/sdk"}
+    conanfile.conf.define("tools.apple:sdk_path", "/path/to/sdk")
     conanfile.settings_build = MockSettings(
         {"build_type": "Debug",
          "os": "Macos",
@@ -339,7 +339,7 @@ def test_apple_isysrootflag():
 
 def test_custom_defines():
     conanfile = ConanFileMock()
-    conanfile.conf = {"tools.apple:sdk_path": "/path/to/sdk"}
+    conanfile.conf.define("tools.apple:sdk_path", "/path/to/sdk")
     conanfile.settings = MockSettings(
         {"build_type": "RelWithDebInfo",
          "os": "iOS",
@@ -355,7 +355,7 @@ def test_custom_defines():
 
 def test_custom_cxxflags():
     conanfile = ConanFileMock()
-    conanfile.conf = {"tools.apple:sdk_path": "/path/to/sdk"}
+    conanfile.conf.define("tools.apple:sdk_path", "/path/to/sdk")
     conanfile.settings = MockSettings(
         {"build_type": "RelWithDebInfo",
          "os": "iOS",
@@ -374,7 +374,7 @@ def test_custom_cxxflags():
 
 def test_custom_cflags():
     conanfile = ConanFileMock()
-    conanfile.conf = {"tools.apple:sdk_path": "/path/to/sdk"}
+    conanfile.conf.define("tools.apple:sdk_path", "/path/to/sdk")
     conanfile.settings = MockSettings(
         {"build_type": "RelWithDebInfo",
          "os": "iOS",
@@ -393,7 +393,7 @@ def test_custom_cflags():
 
 def test_custom_ldflags():
     conanfile = ConanFileMock()
-    conanfile.conf = {"tools.apple:sdk_path": "/path/to/sdk"}
+    conanfile.conf.define("tools.apple:sdk_path", "/path/to/sdk")
     conanfile.settings = MockSettings(
         {"build_type": "RelWithDebInfo",
          "os": "iOS",

--- a/conans/test/unittests/client/toolchain/autotools/autotools_toolchain_test.py
+++ b/conans/test/unittests/client/toolchain/autotools/autotools_toolchain_test.py
@@ -408,3 +408,22 @@ def test_custom_ldflags():
 
     assert "MyFlag" not in env["CXXFLAGS"]
     assert "MyFlag" not in env["CFLAGS"]
+
+
+def test_extra_flags_via_conf():
+    conanfile = ConanFileMock()
+    conanfile.conf.define("tools.build:cxxflags", ["--flag1", "--flag2"])
+    conanfile.conf.define("tools.build:cflags", ["--flag3", "--flag4"])
+    conanfile.conf.define("tools.build:ldflags", ["--flag5", "--flag6"])
+    conanfile.conf.define("tools.build:cppflags", ["DEF1", "DEF2"])
+    conanfile.settings = MockSettings(
+        {"build_type": "RelWithDebInfo",
+         "os": "iOS",
+         "os.version": "14",
+         "arch": "armv8"})
+    be = AutotoolsToolchain(conanfile)
+    env = be.vars()
+    assert '-DNDEBUG -DDEF1 -DDEF2' in env["CPPFLAGS"]
+    assert '-mios-version-min=14 --flag1 --flag2' in env["CXXFLAGS"]
+    assert '-mios-version-min=14 --flag3 --flag4' in env["CFLAGS"]
+    assert '-mios-version-min=14 --flag5 --flag6' in env["LDFLAGS"]

--- a/conans/test/unittests/model/test_conf.py
+++ b/conans/test/unittests/model/test_conf.py
@@ -212,6 +212,8 @@ def test_conf_get_check_type_and_default():
     # Check type does not affect to default value
     assert c.get("non:existing:conf", default=0, check_type=dict) == 0
     assert c.get("zlib:user.company.check:shared") is None  # unset value
+    assert c.get("zlib:user.company.check:shared", default=[]) == []  # returning default
+    assert c.get("zlib:user.company.check:shared", default=[], check_type=list) == []  # not raising exception
     assert c.get("zlib:user.company.check:shared_str") == '"False"'
     assert c.get("zlib:user.company.check:shared_str", check_type=bool) is False  # smart conversion
     assert c.get("zlib:user.company.check:static_str") == "off"


### PR DESCRIPTION
Changelog: Feature: Added mechanism to inject extra flags via `[conf]` into several toolchains like `AutotoolsToolchain`, `MesonToolchain` and `CMakeToolchain`.

* `tools.build:cxxflags`
* `tools.build:cflags`
* ~`tools.build:cppflags`~ -> Changed to `tools.build:defines` (https://github.com/conan-io/conan/pull/10928)
* ~`tools.build:ldflags`~ -> Removed (https://github.com/conan-io/conan/pull/10928)
* `tools.build:sharedlinkflags`
* `tools.build:exelinkflags`

Changelog: Fix: `Conf.get()` always returns `default` value if internal `conf_value.value` is `None`, i.e., it was unset.

Docs: https://github.com/conan-io/docs/pull/2484
Closes: https://github.com/conan-io/conan/issues/10805 https://github.com/conan-io/conan/issues/10452 https://github.com/conan-io/conan/issues/10895