### PR TITLE
Fix apple-clang v13 compatibility

### DIFF
--- a/conans/client/conf/__init__.py
+++ b/conans/client/conf/__init__.py
@@ -118,7 +118,7 @@ _t_default_settings_yml = Template(textwrap.dedent("""
             cppstd: [None, 98, gnu98, 11, gnu11, 14, gnu14, 17, gnu17, 20, gnu20, 23, gnu23]
             runtime: [None, MD, MT, MTd, MDd]
         apple-clang: &apple_clang
-            version: ["5.0", "5.1", "6.0", "6.1", "7.0", "7.3", "8.0", "8.1", "9.0", "9.1", "10.0", "11.0", "12.0", "13.0", "13.1"]
+            version: ["5.0", "5.1", "6.0", "6.1", "7.0", "7.3", "8.0", "8.1", "9.0", "9.1", "10.0", "11.0", "12.0", "13", "13.0", "13.1"]
             libcxx: [libstdc++, libc++]
             cppstd: [None, 98, gnu98, 11, gnu11, 14, gnu14, 17, gnu17, 20, gnu20]
         intel:

--- a/conans/client/conf/detect.py
+++ b/conans/client/conf/detect.py
@@ -156,6 +156,9 @@ def _get_profile_compiler_version(compiler, version, output):
     elif compiler == "gcc" and int(major) >= 5:
         output.info("gcc>=5, using the major as version")
         return major
+    elif compiler == "apple-clang" and int(major) >= 13:
+        output.info("aple-clang>=13, using the major as version")
+        return major
     elif compiler == "Visual Studio":
         return major
     elif compiler == "intel" and (int(major) < 19 or (int(major) == 19 and int(minor) == 0)):

--- a/conans/client/graph/graph_binaries.py
+++ b/conans/client/graph/graph_binaries.py
@@ -377,6 +377,10 @@ class GraphBinariesAnalyzer(object):
             if msvc_compatible:
                 conanfile.compatible_packages.append(msvc_compatible)
 
+        apple_clang_compatible = conanfile.info.apple_clang_compatible()
+        if apple_clang_compatible:
+            conanfile.compatible_packages.append(apple_clang_compatible)
+
         # Once we are done, call package_id() to narrow and change possible values
         with conanfile_exception_formatter(str(conanfile), "package_id"):
             with conan_v2_property(conanfile, 'cpp_info',

--- a/conans/client/migrations_settings.py
+++ b/conans/client/migrations_settings.py
@@ -3359,7 +3359,7 @@ compiler:
         cppstd: [None, 98, gnu98, 11, gnu11, 14, gnu14, 17, gnu17, 20, gnu20, 23, gnu23]
         runtime: [None, MD, MT, MTd, MDd]
     apple-clang: &apple_clang
-        version: ["5.0", "5.1", "6.0", "6.1", "7.0", "7.3", "8.0", "8.1", "9.0", "9.1", "10.0", "11.0", "12.0", "13.0", "13.1"]
+        version: ["5.0", "5.1", "6.0", "6.1", "7.0", "7.3", "8.0", "8.1", "9.0", "9.1", "10.0", "11.0", "12.0", "13", "13.0", "13.1"]
         libcxx: [libstdc++, libc++]
         cppstd: [None, 98, gnu98, 11, gnu11, 14, gnu14, 17, gnu17, 20, gnu20]
     intel:

--- a/conans/model/info.py
+++ b/conans/model/info.py
@@ -591,9 +591,19 @@ class ConanInfo(object):
         visual_version = msvc_version_to_vs_ide_version(version)
         compatible.settings.compiler.version = visual_version
         runtime = "MT" if runtime == "static" else "MD"
-        if  runtime_type == "Debug":
+        if runtime_type == "Debug":
             runtime = "{}d".format(runtime)
         compatible.settings.compiler.runtime = runtime
+        return compatible
+
+    def apple_clang_compatible(self):
+        # https://github.com/conan-io/conan/pull/10797
+        # apple-clang compiler version 13 will be compatible with 13.0
+        if self.settings.compiler != "apple-clang" and self.settings.compiler.version != "13":
+            return
+
+        compatible = self.clone()
+        compatible.settings.compiler.version = "13.0"
         return compatible
 
     def vs_toolset_compatible(self):

--- a/conans/model/info.py
+++ b/conans/model/info.py
@@ -599,7 +599,8 @@ class ConanInfo(object):
     def apple_clang_compatible(self):
         # https://github.com/conan-io/conan/pull/10797
         # apple-clang compiler version 13 will be compatible with 13.0
-        if self.settings.compiler != "apple-clang" and self.settings.compiler.version != "13":
+        if not self.settings.compiler or \
+           (self.settings.compiler != "apple-clang" and self.settings.compiler.version != "13"):
             return
 
         compatible = self.clone()

--- a/conans/test/integration/package_id/compatible_test.py
+++ b/conans/test/integration/package_id/compatible_test.py
@@ -576,3 +576,27 @@ def test_msvc_visual_incompatible():
     save(client.cache.new_config_path, new_config)
     client.run("install pkg/0.1@ -pr=profile", assert_error=True)
     assert "ERROR: Missing prebuilt package for 'pkg/0.1'" in client.out
+
+
+def test_apple_clang_compatible():
+    """
+    From apple-clang version 13 we detect apple-clang version as 13 and we make
+    this compiler version compatible with 13.0
+    """
+    conanfile = GenConanfile().with_settings("os", "compiler", "build_type", "arch")
+    client = TestClient()
+    profile = textwrap.dedent("""
+        [settings]
+        os=Macos
+        arch=x86_64
+        compiler=apple-clang
+        compiler.version=13
+        compiler.libcxx=libc++
+        build_type=Release
+        """)
+    client.save({"conanfile.py": conanfile,
+                 "profile": profile})
+    client.run('create . pkg/0.1@ -s os=Macos -s compiler="apple-clang" -s compiler.version=13.0 '
+               '-s build_type=Release -s arch=x86_64')
+    client.run("install pkg/0.1@ -pr=profile")
+    assert "Using compatible package" in client.out


### PR DESCRIPTION
Changelog: Feature: Add apple-clang 13 major version to settings.
Changelog: Feature: Make apple-clang 13 version package-id compatible with 13.0.
Changelog: Feature: Autodetect only major version for apple-clang profile starting in version 13.
Docs: TODO

Related with: https://github.com/conan-io/conan/pull/10797

#TAGS: slow
