### PR TITLE
[pylint_plugin] Added deprecated imports checker (#10746)

### DIFF
--- a/conans/pylint_plugin.py
+++ b/conans/pylint_plugin.py
@@ -1,15 +1,15 @@
 """Pylint plugin for ConanFile"""
+import re
+
 import astroid
 from astroid import MANAGER
+from pylint.checkers import BaseChecker
+from pylint.interfaces import IRawChecker
 
 
 def register(linter):
-    """Declare package as plugin
-
-    This function needs to be declared so astroid treats
-    current file as a plugin.
-    """
-    pass
+    """required method to auto register this checker"""
+    linter.register_checker(ConanDeprecatedImportsChecker(linter))
 
 
 def transform_conanfile(node):
@@ -55,3 +55,34 @@ def _python_requires_member():
 
 
 astroid.register_module_extender(astroid.MANAGER, "conans", _python_requires_member)
+
+
+class ConanDeprecatedImportsChecker(BaseChecker):
+    """
+    Check "from conans*" imports which disappears in Conan 2.x. Only "from conan*" is valid
+    """
+
+    __implements__ = IRawChecker
+
+    deprecated_imports_pattern = re.compile(r"(from|import)\s+conans[\.|\s].*")
+    name = "conan_deprecated_imports"
+    msgs = {
+        "E9000": (
+            "Using deprecated imports from 'conans'",
+            "conan1.x-deprecated-imports",
+            (
+                "Use imports from 'conan' instead of 'conans'"
+                " because 'conan' will be the root package for Conan 2.x"
+            )
+        )
+    }
+    options = ()
+
+    def process_module(self, node):
+        """
+        Processing the module's content that is accessible via node.stream() function
+        """
+        with node.stream() as stream:
+            for (index, line) in enumerate(stream):
+                if self.deprecated_imports_pattern.match(line.decode('utf-8')):
+                    self.add_message("conan1.x-deprecated-imports", line=index)


### PR DESCRIPTION
Port https://github.com/conan-io/conan/pull/10746 to 1.46.1

Changelog: Feature: Added a checker for Conan 2.x deprecated from conans imports in pylint_plugin.
Docs: omit