### PR TITLE
Old cmake check fixed

### DIFF
--- a/conans/client/generators/cmake_common.py
+++ b/conans/client/generators/cmake_common.py
@@ -528,7 +528,9 @@ class CMakeCommonMacros:
                 endif()
             elseif(CONAN_COMPILER STREQUAL "apple-clang" OR CONAN_COMPILER STREQUAL "sun-cc" OR CONAN_COMPILER STREQUAL "mcst-lcc")
                 conan_split_version(${CONAN_COMPILER_VERSION} CONAN_COMPILER_MAJOR CONAN_COMPILER_MINOR)
-                if(NOT ${VERSION_MAJOR}.${VERSION_MINOR} VERSION_EQUAL ${CONAN_COMPILER_MAJOR}.${CONAN_COMPILER_MINOR})
+                if(${CONAN_COMPILER_MAJOR} VERSION_GREATER_EQUAL "7" AND "${CONAN_COMPILER_MINOR}" STREQUAL "" AND ${CONAN_COMPILER_MAJOR} VERSION_EQUAL ${VERSION_MAJOR})
+                   # This is correct,  7.X is considered 7
+                elseif(NOT ${VERSION_MAJOR}.${VERSION_MINOR} VERSION_EQUAL ${CONAN_COMPILER_MAJOR}.${CONAN_COMPILER_MINOR})
                    conan_error_compiler_version()
                 endif()
             elseif(CONAN_COMPILER STREQUAL "intel")


### PR DESCRIPTION
Changelog: Bugfix: Specifying `compiler.version=7` for apple-clang raised a CMake error when using the old `cmake` generator.
Docs: omit
