### PR TITLE
- BugFix: allow tested_reference_str to be None 

### DIFF
--- a/conans/client/graph/graph_manager.py
+++ b/conans/client/graph/graph_manager.py
@@ -31,6 +31,8 @@ class _RecipeBuildRequires(OrderedDict):
                 self.add(build_require, context=self._default_context)
 
     def add(self, build_require, context, force_host_context=False):
+        if build_require is None:
+            return
         if not isinstance(build_require, ConanFileReference):
             build_require = ConanFileReference.loads(build_require)
         build_require.force_host_context = force_host_context  # Dirty, but will be removed in 2.0

--- a/conans/model/conan_file.py
+++ b/conans/model/conan_file.py
@@ -141,6 +141,7 @@ class ConanFile(object):
 
     # Run in windows bash
     win_bash = None
+    tested_reference_str = None
 
     def __init__(self, output, runner, display_name="", user=None, channel=None):
         # an output stream (writeln, info, warn error)

--- a/conans/model/requires.py
+++ b/conans/model/requires.py
@@ -107,6 +107,8 @@ class Requirements(OrderedDict):
     def add(self, reference, private=False, override=False):
         """ to define requirements by the user in text, prior to any propagation
         """
+        if reference is None:
+            return
         assert isinstance(reference, six.string_types)
         ref = ConanFileReference.loads(reference)
         self.add_ref(ref, private, override)


### PR DESCRIPTION
closes: #10714

Changelog: Feature: Allow `tested_reference_str` to be `None`.
Docs: omit

- [ ] Refer to the issue that supports this Pull Request.
- [ ] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [ ] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [ ] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 

<sup>**Note:** By default this PR will skip the slower tests and will use a limited set of python versions. Check [here](https://github.com/conan-io/conan/blob/develop/.github/PR_INCREASE_TESTING.md) how to increase the testing level by writing some tags in the current PR body text.</sup>
