### PR TITLE
respect env var CONAN_DOWNLOAD_CACHE to overwrite storage.download_cache

### DIFF
--- a/conans/client/conf/__init__.py
+++ b/conans/client/conf/__init__.py
@@ -231,6 +231,7 @@ _t_default_client_conf = Template(textwrap.dedent("""
     # path beginning with "~" (if the environment var CONAN_USER_HOME is specified, this directory, even
     # with "~/", will be relative to the conan user home, not to the system user home)
     path = ./data
+    # download_cache = /tmp/conan         # environment CONAN_DOWNLOAD_CACHE
 
     [proxies]
     # Empty (or missing) section will try to use system proxies.
@@ -481,7 +482,9 @@ class ConanClientConfigParser(ConfigParser, object):
     @property
     def download_cache(self):
         try:
-            download_cache = self.get_item("storage.download_cache")
+            download_cache = get_env("CONAN_DOWNLOAD_CACHE")
+            if download_cache is None:
+                download_cache = self.get_item("storage.download_cache")
             return download_cache
         except ConanException:
             return None


### PR DESCRIPTION
closes: #7165

Changelog: Feature: respect the environment variable CONAN_DOWNLOAD_CACHE in order to overwrite conan.conf value of storage.download_cache
Docs: https://github.com/conan-io/docs/pull/2452

- [x] Refer to the issue that supports this Pull Request.
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [x] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 

<sup>**Note:** By default this PR will skip the slower tests and will use a limited set of python versions. Check [here](https://github.com/conan-io/conan/blob/develop/.github/PR_INCREASE_TESTING.md) how to increase the testing level by writing some tags in the current PR body text.</sup>
