### PR TITLE
Add meson properties field, and specificy needs_exe_wrapper depending…

### DIFF
--- a/conans/test/functional/toolchains/meson/test_cross_compilation.py
+++ b/conans/test/functional/toolchains/meson/test_cross_compilation.py
@@ -116,6 +116,11 @@ def test_apple_meson_toolchain_cross_compiling(arch, os_, os_version, sdk):
     t.run_command('"%s" -info "%s"' % (lipo, demo))
     assert "architecture: %s" % to_apple_arch(arch) in t.out
 
+    # only check for iOS because one of the macos build variants is usually native
+    if os_ == "iOS":
+        content = t.load("conan_meson_cross.ini")
+        assert "needs_exe_wrapper = true" in content
+
 
 @pytest.mark.tool_meson
 @pytest.mark.skipif(sys.version_info.major == 2, reason="Meson not supported in Py2")
@@ -264,3 +269,7 @@ class AndroidMesonToolchainCrossTestCase(unittest.TestCase):
         self.assertIn("Class:                             %s" % expected_class, self.t.out)
         self.assertIn("OS/ABI:                            UNIX - System V", self.t.out)
         self.assertIn("Machine:                           %s" % expected_machine, self.t.out)
+
+        content = self.t.load(os.path.join("build", "gen_folder", "conan_meson_cross.ini"))
+        self.assertIn("[project options]", content)
+        self.assertIn("needs_exe_wrapper = true")

--- a/conans/test/functional/toolchains/meson/test_meson.py
+++ b/conans/test/functional/toolchains/meson/test_meson.py
@@ -90,4 +90,7 @@ class MesonToolchainTest(TestMesonBase):
         self.assertIn("hello: Release!", self.t.out)
         self.assertIn("STRING_DEFINITION: Text", self.t.out)
 
+        self.assertIn("[properties]", content)
+        self.assertNotIn("needs_exe_wrapper", content)
+
         self._check_binary()


### PR DESCRIPTION
… on cross conditions.

Changelog: Feature: Add detection in meson toolchain for cross conditions and requirement of needs_exe_wrapper. Users may specify the exe wrapper in their meson.build now.
Docs: omit

Issue: https://github.com/conan-io/conan/issues/10796

Not sure if docs are required, as this is probably expected behavior of the generator for someone who understands what meson is looking for. Happy to write some docs, though.


- [x] Refer to the issue that supports this Pull Request.
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [x] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 

<sup>**Note:** By default this PR will skip the slower tests and will use a limited set of python versions. Check [here](https://github.com/conan-io/conan/blob/develop/.github/PR_INCREASE_TESTING.md) how to increase the testing level by writing some tags in the current PR body text.</sup>
