### PR TITLE
feature: Allow loading absolute paths in `.jinja` profiles

### DIFF
--- a/conans/client/profile_loader.py
+++ b/conans/client/profile_loader.py
@@ -129,7 +129,7 @@ def read_profile(profile_name, cwd, default_folder):
         class FullPathLoader(BaseLoader):
             """ Load absolute paths and relative paths to 'base_path'. """
             def __init__(self, base_path):
-                BaseLoader.__init__()
+                BaseLoader.__init__(self)
                 self.base_path = base_path
 
             def get_source(self, environment, template):

--- a/conans/client/profile_loader.py
+++ b/conans/client/profile_loader.py
@@ -2,7 +2,7 @@ import os
 import platform
 from collections import OrderedDict, defaultdict
 
-from jinja2 import Environment, BaseLoader
+from jinja2 import Environment, BaseLoader, TemplateNotFound
 
 from conan.tools.env.environment import ProfileEnvironment
 from conans.errors import ConanException, ConanV2Exception
@@ -135,6 +135,9 @@ def read_profile(profile_name, cwd, default_folder):
             def get_source(self, environment, template):
                 if not os.path.isabs(template):
                     template = os.path.join(self.base_path, template)
+
+                if os.path.exists(template):
+                    raise TemplateNotFound(template)
 
                 with open(template, "br") as f:
                     contents = f.read().decode('utf-8')

--- a/conans/client/profile_loader.py
+++ b/conans/client/profile_loader.py
@@ -136,7 +136,7 @@ def read_profile(profile_name, cwd, default_folder):
                 if not os.path.isabs(template):
                     template = os.path.join(self.base_path, template)
 
-                if os.path.exists(template):
+                if not os.path.exists(template):
                     raise TemplateNotFound(template)
 
                 with open(template, "br") as f:

--- a/conans/test/utils/mocks.py
+++ b/conans/test/utils/mocks.py
@@ -223,7 +223,7 @@ class TestBufferConanOutput(ConanOutput):
 
 class RedirectedTestOutput(StringIO):
     def __init__(self):
-        # Chage to super() for Py3
+        # TODO: Change to super() for Py3
         StringIO.__init__(self)
 
     def __repr__(self):


### PR DESCRIPTION
Changelog: Feature: Allow absolute and relative paths inside `.jinja` files.

This PR extends the `BaseLoader` sligthly by allowing to load full paths relative paths to `base_path`. Jinja2 does not allow this in its `FileSystemLoader` and its not aligned with the Conan text profile include statement `include(...)`.

Docs: https://github.com/conan-io/docs/pull/2466

- [x] Refer to the issue that supports this Pull Request.
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request:
  `.jinja` templates can be located anywhere (lets say inside subfolder of root-dir (where `conanfile.py` lies. Syntax as `{% extends os.path.join(profile_dir, "../../default.jinja" %}` does not work since jinja does not allow ".." inside paths and also does not load full paths. 
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [x] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 

<sup>**Note:** By default this PR will skip the slower tests and will use a limited set of python versions. Check [here](https://github.com/conan-io/conan/blob/develop/.github/PR_INCREASE_TESTING.md) how to increase the testing level by writing some tags in the current PR body text.</sup>
