### PR TITLE
[develop2] improvements in package_id

### DIFF
--- a/conans/client/graph/compute_pid.py
+++ b/conans/client/graph/compute_pid.py
@@ -13,9 +13,9 @@ def compute_package_id(node, new_config):
     conanfile = node.conanfile
 
     unknown_mode = new_config.get("core.package_id:default_unknown_mode", default="semver_mode")
-    lib_mode = new_config.get("core.package_id:default_lib_mode", default="minor_mode")
+    non_embed_mode = new_config.get("core.package_id:default_non_embed_mode", default="minor_mode")
     # recipe_revision_mode already takes into account the package_id
-    bin_mode = new_config.get("core.package_id:default_bin_mode", default="recipe_revision_mode")
+    embed_mode = new_config.get("core.package_id:default_embed_mode", default="full_mode")
     python_mode = new_config.get("core.package_id:default_python_mode", default="minor_mode")
     build_mode = new_config.get("core.package_id:default_build_mode", default=None)
 
@@ -28,7 +28,7 @@ def compute_package_id(node, new_config):
     for require, transitive in node.transitive_deps.items():
         dep_node = transitive.node
         require.deduce_package_id_mode(conanfile.package_type, dep_node.conanfile.package_type,
-                                       lib_mode, bin_mode, build_mode, unknown_mode)
+                                       non_embed_mode, embed_mode, build_mode, unknown_mode)
         if require.package_id_mode is not None:
             req_info = RequirementInfo(dep_node.pref, require.package_id_mode)
             if require.build:

--- a/conans/client/graph/compute_pid.py
+++ b/conans/client/graph/compute_pid.py
@@ -14,7 +14,7 @@ def compute_package_id(node, new_config):
 
     unknown_mode = new_config.get("core.package_id:default_unknown_mode", default="semver_mode")
     lib_mode = new_config.get("core.package_id:default_lib_mode", default="minor_mode")
-    # TODO: Change it to "full_mode" including package_id
+    # recipe_revision_mode already takes into account the package_id
     bin_mode = new_config.get("core.package_id:default_bin_mode", default="recipe_revision_mode")
     python_mode = new_config.get("core.package_id:default_python_mode", default="minor_mode")
     build_mode = new_config.get("core.package_id:default_build_mode", default=None)

--- a/conans/model/info.py
+++ b/conans/model/info.py
@@ -145,13 +145,15 @@ class RequirementInfo:
         self.package_id = self._pref.package_id
         self.recipe_revision = None
 
-    def recipe_revision_mode(self):
+    def full_mode(self):
         self.name = self._pref.ref.name
         self.version = self._pref.ref.version
         self.user = self._pref.ref.user
         self.channel = self._pref.ref.channel
         self.package_id = self._pref.package_id
         self.recipe_revision = self._pref.ref.revision
+
+    recipe_revision_mode = full_mode  # to not break everything and help in upgrade
 
 
 class RequirementsInfo(UserRequirementsDict):

--- a/conans/model/requires.py
+++ b/conans/model/requires.py
@@ -252,7 +252,7 @@ class Requirement:
             elif pkg_type is PackageType.APP:
                 downstream_require = Requirement(require.ref, headers=False, libs=False, run=True)
             else:
-                assert pkg_type is PackageType.UNKNOWN
+                assert pkg_type in (PackageType.UNKNOWN, PackageType.HEADER)
                 # TODO: This is undertested, changing it did not break tests
                 downstream_require = require.copy_requirement()
         elif dep_pkg_type is PackageType.STATIC:
@@ -263,7 +263,7 @@ class Requirement:
             elif pkg_type is PackageType.APP:
                 downstream_require = Requirement(require.ref, headers=False, libs=False, run=False)
             else:
-                assert pkg_type is PackageType.UNKNOWN
+                assert pkg_type in (PackageType.UNKNOWN, PackageType.HEADER)
                 # TODO: This is undertested, changing it did not break tests
                 downstream_require = require.copy_requirement()
         elif dep_pkg_type is PackageType.HEADER:
@@ -317,6 +317,10 @@ class Requirement:
                 self.package_id_mode = build_mode
             return  # At the moment no defaults
 
+        if pkg_type is PackageType.HEADER:
+            self.package_id_mode = "unrelated_mode"
+            return
+
         if self.headers or self.libs:  # only if linked
             if pkg_type in (PackageType.SHARED, PackageType.APP):
                 if dep_pkg_type is PackageType.SHARED:
@@ -329,9 +333,11 @@ class Requirement:
                 else:
                     self.package_id_mode = lib_mode
 
-            # HEADER-ONLY is automatically cleared in compute_package_id()
-        if self.package_id_mode is None:
-            self.package_id_mode = unknown_mode
+            if self.package_id_mode is None:
+                self.package_id_mode = unknown_mode
+
+        # For cases like Application->Application, without headers or libs, package_id_mode=None
+        # It will be independent by default
 
 
 class BuildRequirements:

--- a/conans/model/requires.py
+++ b/conans/model/requires.py
@@ -305,7 +305,7 @@ class Requirement:
         downstream_require.direct = False
         return downstream_require
 
-    def deduce_package_id_mode(self, pkg_type, dep_pkg_type, lib_mode, bin_mode, build_mode,
+    def deduce_package_id_mode(self, pkg_type, dep_pkg_type, non_embed_mode, embed_mode, build_mode,
                                unknown_mode):
         # If defined by the ``require(package_id_mode=xxx)`` trait, that is higher priority
         # The "conf" values are defaults, no hard overrides
@@ -324,14 +324,14 @@ class Requirement:
         if self.headers or self.libs:  # only if linked
             if pkg_type in (PackageType.SHARED, PackageType.APP):
                 if dep_pkg_type is PackageType.SHARED:
-                    self.package_id_mode = lib_mode
+                    self.package_id_mode = non_embed_mode
                 else:
-                    self.package_id_mode = bin_mode
+                    self.package_id_mode = embed_mode
             elif pkg_type is PackageType.STATIC:
                 if dep_pkg_type is PackageType.HEADER:
-                    self.package_id_mode = bin_mode
+                    self.package_id_mode = embed_mode
                 else:
-                    self.package_id_mode = lib_mode
+                    self.package_id_mode = non_embed_mode
 
             if self.package_id_mode is None:
                 self.package_id_mode = unknown_mode

--- a/conans/test/integration/package_id/test_default_package_id.py
+++ b/conans/test/integration/package_id/test_default_package_id.py
@@ -1,0 +1,80 @@
+import pytest
+
+from conans.test.assets.genconanfile import GenConanfile
+from conans.test.utils.tools import TestClient
+
+
+@pytest.mark.parametrize("typedep, typeconsumer, different_id",
+                         [("header-library", "application", True),
+                          ("header-library", "shared-library", True),
+                          ("header-library", "static-library", True),
+                          ("static-library", "application", True),
+                          ("static-library", "shared-library", True),
+                          ("static-library", "header-library", False),
+                          ("static-library", "static-library", False),
+                          ("shared-library", "header-library", False),
+                          ("shared-library", "static-library", False),
+                          ("shared-library", "shared-library", False),
+                          ("shared-library", "application", False)
+                          ])
+def test_default_package_id_options(typedep, typeconsumer, different_id):
+    """ test that some consumer package ids are changed when the dependency change one of its
+    options
+    """
+    c = TestClient()
+    dep = GenConanfile("dep", "0.1").with_option("myopt", [True, False]) \
+        .with_package_type(typedep)
+    consumer = GenConanfile("consumer", "0.1").with_requires("dep/0.1")\
+        .with_package_type(typeconsumer)
+
+    c.save({"dep/conanfile.py": dep,
+            "consumer/conanfile.py": consumer})
+    c.run("create dep -o dep/*:myopt=True")
+    pid1 = c.created_package_id("dep/0.1")
+    c.run("create dep -o dep/*:myopt=False")
+    pid2 = c.created_package_id("dep/0.1")
+    assert pid1 != pid2
+
+    c.run("create consumer -o dep/*:myopt=True")
+    pid1 = c.created_package_id("consumer/0.1")
+    c.run("create consumer -o dep/*:myopt=False")
+    pid2 = c.created_package_id("consumer/0.1")
+    if different_id:
+        assert pid1 != pid2
+    else:
+        assert pid1 == pid2
+
+
+@pytest.mark.parametrize("typedep, versiondep, typeconsumer, different_id",
+                         [("static-library", "1.1", "header-library", False),
+                          ("static-library", "1.0.1", "static-library", False),
+                          ("static-library", "1.1", "static-library", True),
+                          ("shared-library", "1.1", "header-library", False),
+                          ("shared-library", "1.0.1", "static-library", False),
+                          ("shared-library", "1.1", "static-library", True),
+                          ("shared-library", "1.0.1", "shared-library", False),
+                          ("shared-library", "1.1", "shared-library", True),
+                          ("shared-library", "1.0.1", "application", False),
+                          ("shared-library", "1.1", "application", True),
+                          ("application", "2.1", "application", False),
+                          ])
+def test_default_package_id_versions(typedep, versiondep, typeconsumer, different_id):
+    """ test that some consumer package ids are changed when the dependency changes its version
+    """
+    c = TestClient()
+    dep = GenConanfile("dep").with_package_type(typedep)
+    consumer = GenConanfile("consumer", "0.1").with_requires("dep/[>0.0]") \
+        .with_package_type(typeconsumer)
+    c.save({"dep/conanfile.py": dep,
+            "consumer/conanfile.py": consumer})
+    c.run("create dep --version=1.0")
+    c.run("create consumer")
+    pid1 = c.created_package_id("consumer/0.1")
+
+    c.run(f"create dep --version={versiondep}")
+    c.run("create consumer")
+    pid2 = c.created_package_id("consumer/0.1")
+    if different_id:
+        assert pid1 != pid2
+    else:
+        assert pid1 == pid2


### PR DESCRIPTION
- New tests, a bit more exhaustive
- Fixed a bug in header->library
- Remove deducing package_id_mode=unknown(semver), for non-library, non-package-type known cases