### PR TITLE
backport of compatibility() recipe method

### DIFF
--- a/conans/client/graph/compatibility.py
+++ b/conans/client/graph/compatibility.py
@@ -1,0 +1,32 @@
+from collections import OrderedDict
+
+from conans.errors import conanfile_exception_formatter
+
+
+class BinaryCompatibility:
+    def __init__(self, cache):
+        pass
+
+    def compatibles(self, conanfile):
+        compat_infos = []
+        if hasattr(conanfile, "compatibility") and callable(conanfile.compatibility):
+            with conanfile_exception_formatter(conanfile, "compatibility"):
+                recipe_compatibles = conanfile.compatibility()
+                compat_infos.extend(self._compatible_infos(conanfile, recipe_compatibles))
+
+        conanfile.compatible_packages.extend(compat_infos)
+
+    @staticmethod
+    def _compatible_infos(conanfile, compatibles):
+        result = []
+        if compatibles:
+            for elem in compatibles:
+                compat_info = conanfile.original_info.clone()
+                settings = elem.get("settings")
+                if settings:
+                    compat_info.settings.update_values(settings)
+                options = elem.get("options")
+                if options:
+                    compat_info.options.update(options_values=OrderedDict(options))
+                result.append(compat_info)
+        return result

--- a/conans/model/values.py
+++ b/conans/model/values.py
@@ -67,6 +67,18 @@ class Values(object):
             result.append((name.strip(), value.strip()))
         return cls.from_list(result)
 
+    def update_values(self, values):
+        """ receives a list of tuples (compiler.version, value)
+        Necessary for binary_compatibility.py
+        """
+        assert isinstance(values, (list, tuple)), values
+        for (name, value) in values:
+            list_settings = name.split(".")
+            attr = self
+            for setting in list_settings[:-1]:
+                attr = getattr(attr, setting)
+            setattr(attr, list_settings[-1], value)
+
     def as_list(self, list_all=True):
         result = []
         for field in self.fields:


### PR DESCRIPTION
Changelog: Feature: Backport of 2.0 compatibility() recipe method.
Docs: omit

Backport of https://github.com/conan-io/conan/pull/10241
I would probably wait 1 release to document or make this public, as the interface might still change