### PR TITLE
"patch" tool directory where locate the patch files

### DIFF
--- a/conan/tools/files/patches.py
+++ b/conan/tools/files/patches.py
@@ -52,7 +52,7 @@ def patch(conanfile, base_path=None, patch_file=None, patch_string=None, strip=0
     if patch_file:
         # trick *1: patch_file path could be absolute (e.g. conanfile.build_folder), in that case
         # the join does nothing and works.
-        patch_path = os.path.join(conanfile.source_folder, patch_file)
+        patch_path = os.path.join(conanfile.base_source_folder, patch_file)
         patchset = patch_ng.fromfile(patch_path)
     else:
         patchset = patch_ng.fromstring(patch_string.encode())

--- a/conans/test/unittests/tools/files/test_patches.py
+++ b/conans/test/unittests/tools/files/test_patches.py
@@ -60,12 +60,14 @@ def test_single_patch_file_from_forced_build(mock_patch_ng):
 def test_base_path(mock_patch_ng):
     conanfile = ConanFileMock()
     conanfile.folders.set_base_source("/my_source")
+    conanfile.folders.source = "src"  # This not applies to find the patch file but for applying it
     conanfile.display_name = 'mocked/ref'
     patch(conanfile, patch_file='patch-file', base_path="subfolder")
     assert mock_patch_ng.filename.replace("\\", "/") == '/my_source/patch-file'
     assert mock_patch_ng.string is None
-    assert mock_patch_ng.apply_args == (os.path.join("/my_source", "subfolder"), 0, False)
+    assert mock_patch_ng.apply_args == (os.path.join("/my_source", "src", "subfolder"), 0, False)
     assert len(str(conanfile.output)) == 0
+
 
 def test_apply_in_build_from_patch_in_source(mock_patch_ng):
     conanfile = ConanFileMock()


### PR DESCRIPTION
Related but independent to: https://github.com/memsharded/conan/pull/43

Changelog: Fix: The "conan.tools.files.patch" will (by default) look for the patch files in the `self.base_source_folder` instead of `self.source_folder` but will apply them with `self.source_folder` as the base folder.
Docs: https://github.com/conan-io/docs/pull/2477

Close #10374