### PR TITLE
Warning when overriding the reference being tested

### DIFF
--- a/conans/cli/commands/create.py
+++ b/conans/cli/commands/create.py
@@ -108,12 +108,9 @@ def _check_tested_reference_matches(deps_graph, tested_ref, out):
     but we specify the build require with a different version in the profile, it has priority,
     it is correct but weird and likely a mistake"""
     # https://github.com/conan-io/conan/issues/10453
-    levels = deps_graph.by_levels()
-    levels.reverse()
-    # The dependencies of the test package conanfile
-    level1_refs = [node.ref for node in levels[1]]
+    direct_refs = [n.conanfile.ref for n in deps_graph.root.neighbors()]
     # There is a reference with same name but different
-    missmatch = [ref for ref in level1_refs if ref.name == tested_ref.name and ref != tested_ref]
+    missmatch = [ref for ref in direct_refs if ref.name == tested_ref.name and ref != tested_ref]
     if missmatch:
         out.warning("The package created was '{}' but the reference being "
                     "tested is '{}'".format(missmatch[0], tested_ref))


### PR DESCRIPTION
Changelog: Feature: Added a warning when we are testing a build_require but the profile specifies a different reference of the same package name being tested.
Docs: omit

Close https://github.com/conan-io/conan/issues/10453