### PR TITLE
[MesonToolchain] Added option `wrap_mode=nofallback`

### DIFF
--- a/conan/tools/meson/toolchain.py
+++ b/conan/tools/meson/toolchain.py
@@ -96,6 +96,8 @@ class MesonToolchain(object):
         else:
             self._b_vscrt = None
 
+        # default option
+        self.wrap_mode = "nofallback"
         self.project_options = {}
         self.preprocessor_definitions = {}
         self.pkg_config_path = self._conanfile.generators_folder
@@ -189,6 +191,7 @@ class MesonToolchain(object):
                 self.cpp_link_args += v
 
     def _context(self):
+        self.project_options.setdefault("wrap_mode", self.wrap_mode)
         return {
             # https://mesonbuild.com/Machine-files.html#project-specific-options
             "project_options": {k: to_meson_value(v) for k, v in self.project_options.items()},

--- a/conan/tools/meson/toolchain.py
+++ b/conan/tools/meson/toolchain.py
@@ -96,9 +96,9 @@ class MesonToolchain(object):
         else:
             self._b_vscrt = None
 
-        # default option
-        self.wrap_mode = "nofallback"
-        self.project_options = {}
+        self.project_options = {
+            "wrap_mode": "nofallback"  # https://github.com/conan-io/conan/issues/10671
+        }
         self.preprocessor_definitions = {}
         self.pkg_config_path = self._conanfile.generators_folder
 
@@ -191,7 +191,6 @@ class MesonToolchain(object):
                 self.cpp_link_args += v
 
     def _context(self):
-        self.project_options.setdefault("wrap_mode", self.wrap_mode)
         return {
             # https://mesonbuild.com/Machine-files.html#project-specific-options
             "project_options": {k: to_meson_value(v) for k, v in self.project_options.items()},


### PR DESCRIPTION
Changelog: Feature: Added `wrap_mode=nofallback` project-option into `MesonToolchain` as default value.
Closes: https://github.com/conan-io/conan/issues/10671
Docs: omit

- [x] Refer to the issue that supports this Pull Request.
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 

<sup>**Note:** By default this PR will skip the slower tests and will use a limited set of python versions. Check [here](https://github.com/conan-io/conan/blob/develop/.github/PR_INCREASE_TESTING.md) how to increase the testing level by writing some tags in the current PR body text.</sup>
