### PR TITLE
[develop2] Infinite value for requester

### DIFF
--- a/conans/client/rest/conan_requester.py
+++ b/conans/client/rest/conan_requester.py
@@ -18,6 +18,7 @@ logging.captureWarnings(True)
 
 
 DEFAULT_TIMEOUT = (30, 60)  # connect, read timeouts
+INFINITE_TIMEOUT = -1
 
 
 class ConanRequester(object):
@@ -78,7 +79,7 @@ class ConanRequester(object):
         if self._proxies:
             if not self._should_skip_proxy(url):
                 kwargs["proxies"] = self._proxies
-        if self._timeout:
+        if self._timeout and self._timeout != INFINITE_TIMEOUT:
             kwargs["timeout"] = self._timeout
         if not kwargs.get("headers"):
             kwargs["headers"] = {}

--- a/conans/test/integration/remote/requester_test.py
+++ b/conans/test/integration/remote/requester_test.py
@@ -50,10 +50,17 @@ class TestRequester:
             client.run("install --requires=Lib/1.0@conan/stable")
         assert "Conf 'core.net.http:timeout' value 'invalid' must be" in str(e.value)
 
-    def test_no_request_timeout(self):
+    def test_request_infinite_timeout(self):
         # Test that not having timeout works
         client = TestClient(requester_class=MyRequester)
         client.save({"global.conf": "core.net.http:timeout=-1"}, path=client.cache.cache_folder)
         client.save({"conanfile.py": conanfile})
         client.run("create . --name=foo --version=1.0")
         assert "TIMEOUT: NOT SPECIFIED" in client.out
+
+    def test_unset_request_timeout_use_default_one(self):
+        client = TestClient(requester_class=MyRequester)
+        client.save({"global.conf": "core.net.http:timeout=!"}, path=client.cache.cache_folder)
+        client.save({"conanfile.py": conanfile})
+        client.run("create . --name=foo --version=1.0")
+        assert "TIMEOUT: (30, 60)" in client.out

--- a/conans/test/integration/remote/requester_test.py
+++ b/conans/test/integration/remote/requester_test.py
@@ -53,7 +53,7 @@ class TestRequester:
     def test_no_request_timeout(self):
         # Test that not having timeout works
         client = TestClient(requester_class=MyRequester)
-        client.save({"global.conf": "core.net.http:timeout=None"}, path=client.cache.cache_folder)
+        client.save({"global.conf": "core.net.http:timeout=-1"}, path=client.cache.cache_folder)
         client.save({"conanfile.py": conanfile})
         client.run("create . --name=foo --version=1.0")
         assert "TIMEOUT: NOT SPECIFIED" in client.out


### PR DESCRIPTION
Changelog: Feature: Defined a new `conan_requester.INFINITE_TIMEOUT = -1` variable to manage infinte timeouts via `[conf]`.