### PR TITLE
Add support for ``clang`` to ``msvc_runtime_flag()``.

### DIFF
--- a/conan/tools/gnu/autotoolstoolchain.py
+++ b/conan/tools/gnu/autotoolstoolchain.py
@@ -7,7 +7,7 @@ from conan.tools.build.cross_building import cross_building, get_cross_building_
 from conan.tools.env import Environment
 from conan.tools.files.files import save_toolchain_args
 from conan.tools.gnu.get_gnu_triplet import _get_gnu_triplet
-from conan.tools.microsoft import VCVars, is_msvc
+from conan.tools.microsoft import VCVars, is_msvc, msvc_runtime_flag
 from conans.tools import args_to_string
 
 
@@ -85,22 +85,10 @@ class AutotoolsToolchain:
                 return '_GLIBCXX_USE_CXX11_ABI=1'
 
     def _get_msvc_runtime_flag(self):
-        msvc_runtime_flag = None
-        if self._conanfile.settings.get_safe("compiler") == "msvc":
-            runtime_type = self._conanfile.settings.get_safe("compiler.runtime_type")
-            if runtime_type == "Release":
-                values = {"static": "MT", "dynamic": "MD"}
-            else:
-                values = {"static": "MTd", "dynamic": "MDd"}
-            runtime = values.get(self._conanfile.settings.get_safe("compiler.runtime"))
-            if runtime:
-                msvc_runtime_flag = "-{}".format(runtime)
-        elif self._conanfile.settings.get_safe("compiler") == "Visual Studio":
-            runtime = self._conanfile.settings.get_safe("compiler.runtime")
-            if runtime:
-                msvc_runtime_flag = "-{}".format(runtime)
-
-        return msvc_runtime_flag
+        flag = msvc_runtime_flag(self)
+        if flag:
+            flag = "-{}".format(flag)
+        return flag
 
     def _get_libcxx_flag(self):
         settings = self._conanfile.settings

--- a/conan/tools/gnu/autotoolstoolchain.py
+++ b/conan/tools/gnu/autotoolstoolchain.py
@@ -85,7 +85,7 @@ class AutotoolsToolchain:
                 return '_GLIBCXX_USE_CXX11_ABI=1'
 
     def _get_msvc_runtime_flag(self):
-        flag = msvc_runtime_flag(self)
+        flag = msvc_runtime_flag(self._conanfile)
         if flag:
             flag = "-{}".format(flag)
         return flag

--- a/conan/tools/microsoft/visual.py
+++ b/conan/tools/microsoft/visual.py
@@ -90,8 +90,13 @@ def msvc_runtime_flag(conanfile):
     if compiler == "Visual Studio":
         return runtime
     if runtime is not None:
+        if runtime == "static":
+            runtime = "MT"
+        elif runtime == "dynamic":
+            runtime = "MD"
+        else:
+            raise ConanException("compiler.runtime should be 'static' or 'dynamic'")
         runtime_type = settings.get_safe("compiler.runtime_type")
-        runtime = "MT" if runtime == "static" else "MD"
         if runtime_type == "Debug":
             runtime = "{}d".format(runtime)
         return runtime

--- a/conan/tools/microsoft/visual.py
+++ b/conan/tools/microsoft/visual.py
@@ -89,7 +89,7 @@ def msvc_runtime_flag(conanfile):
     runtime = settings.get_safe("compiler.runtime")
     if compiler == "Visual Studio":
         return runtime
-    if compiler == "msvc" or compiler == "intel-cc":
+    if runtime is not None:
         runtime_type = settings.get_safe("compiler.runtime_type")
         runtime = "MT" if runtime == "static" else "MD"
         if runtime_type == "Debug":

--- a/conans/client/conf/__init__.py
+++ b/conans/client/conf/__init__.py
@@ -121,7 +121,8 @@ _t_default_settings_yml = Template(textwrap.dedent("""
                       "8", "9", "10", "11", "12", "13", "14", "15"]
             libcxx: [None, libstdc++, libstdc++11, libc++, c++_shared, c++_static]
             cppstd: [None, 98, gnu98, 11, gnu11, 14, gnu14, 17, gnu17, 20, gnu20, 23, gnu23]
-            runtime: [None, MD, MT, MTd, MDd]
+            runtime: [None, MD, MT, MTd, MDd, static, dynamic]
+            runtime_type: [None, Debug, Release]
         apple-clang: &apple_clang
             version: ["5.0", "5.1", "6.0", "6.1", "7.0", "7.3", "8.0", "8.1", "9.0", "9.1", "10.0", "11.0", "12.0", "13", "13.0", "13.1"]
             libcxx: [libstdc++, libc++]

--- a/conans/client/migrations_settings.py
+++ b/conans/client/migrations_settings.py
@@ -3511,7 +3511,8 @@ compiler:
                   "8", "9", "10", "11", "12", "13", "14", "15"]
         libcxx: [None, libstdc++, libstdc++11, libc++, c++_shared, c++_static]
         cppstd: [None, 98, gnu98, 11, gnu11, 14, gnu14, 17, gnu17, 20, gnu20, 23, gnu23]
-        runtime: [None, MD, MT, MTd, MDd]
+        runtime: [None, MD, MT, MTd, MDd, static, dynamic]
+        runtime_type: [None, Debug, Release]
     apple-clang: &apple_clang
         version: ["5.0", "5.1", "6.0", "6.1", "7.0", "7.3", "8.0", "8.1", "9.0", "9.1", "10.0", "11.0", "12.0", "13", "13.0", "13.1"]
         libcxx: [libstdc++, libc++]


### PR DESCRIPTION
Changelog: Fix: Add support for ``clang`` to ``msvc_runtime_flag()``. It requires defining ``compiler.runtime = static/dynamic`` definition, same as modern ``msvc`` compiler setting.
Docs: https://github.com/conan-io/docs/pull/2485

Close https://github.com/conan-io/conan/issues/10892
