### PR TITLE
CMakePresets instead of config file

### DIFF
--- a/conan/tools/cmake/cmake.py
+++ b/conan/tools/cmake/cmake.py
@@ -87,9 +87,9 @@ class CMake(object):
 
         if not variables:
             variables = {}
-        variables.update(self._cacheVariables)
+        self._cacheVariables.update(variables)
 
-        arg_list.extend(["-D{}={}".format(k, v) for k, v in variables.items()])
+        arg_list.extend(['-D{}="{}"'.format(k, v) for k, v in self._cacheVariables.items()])
         arg_list.append('"{}"'.format(cmakelist_folder))
 
         command = " ".join(arg_list)

--- a/conan/tools/cmake/cmake.py
+++ b/conan/tools/cmake/cmake.py
@@ -2,6 +2,7 @@ import os
 import platform
 
 from conan.tools.build import build_jobs
+from conan.tools.cmake.presets import load_cmake_presets
 from conan.tools.cmake.utils import is_multi_configuration
 from conan.tools.files import chdir, mkdir
 from conan.tools.files.files import load_toolchain_args
@@ -54,9 +55,10 @@ class CMake(object):
         self._conanfile = conanfile
         self._namespace = namespace
 
-        toolchain_file_content = load_toolchain_args(self._conanfile.generators_folder, namespace=self._namespace)
-        self._generator = toolchain_file_content.get("cmake_generator")
-        self._toolchain_file = toolchain_file_content.get("cmake_toolchain_file")
+        cmake_presets = load_cmake_presets(conanfile.generators_folder)
+        self._generator = cmake_presets["configurePresets"][0]["generator"]
+        self._toolchain_file = cmake_presets["configurePresets"][0]["toolchainFile"]
+        self._cacheVariables = cmake_presets["configurePresets"][0]["cacheVariables"]
 
         self._cmake_program = "cmake"  # Path to CMake should be handled by environment
 
@@ -82,16 +84,12 @@ class CMake(object):
         if self._conanfile.package_folder:
             pkg_folder = self._conanfile.package_folder.replace("\\", "/")
             arg_list.append('-DCMAKE_INSTALL_PREFIX="{}"'.format(pkg_folder))
-        if platform.system() == "Windows" and self._generator == "MinGW Makefiles":
-            # It seems these don't work in the toolchain file, they need to be here in command line
-            arg_list.append('-DCMAKE_SH="CMAKE_SH-NOTFOUND"')
-            cmake_make_program = self._conanfile.conf.get("tools.gnu:make_program", default=None)
-            if cmake_make_program:
-                cmake_make_program = cmake_make_program.replace("\\", "/")
-                arg_list.append('-DCMAKE_MAKE_PROGRAM="{}"'.format(cmake_make_program))
 
-        if variables:
-            arg_list.extend(["-D{}={}".format(k, v) for k, v in variables.items()])
+        if not variables:
+            variables = {}
+        variables.update(self._cacheVariables)
+
+        arg_list.extend(["-D{}={}".format(k, v) for k, v in variables.items()])
         arg_list.append('"{}"'.format(cmakelist_folder))
 
         command = " ".join(arg_list)

--- a/conan/tools/cmake/cmake.py
+++ b/conan/tools/cmake/cmake.py
@@ -58,7 +58,7 @@ class CMake(object):
         cmake_presets = load_cmake_presets(conanfile.generators_folder)
         self._generator = cmake_presets["configurePresets"][0]["generator"]
         self._toolchain_file = cmake_presets["configurePresets"][0]["toolchainFile"]
-        self._cacheVariables = cmake_presets["configurePresets"][0]["cacheVariables"]
+        self._cache_variables = cmake_presets["configurePresets"][0]["cacheVariables"]
 
         self._cmake_program = "cmake"  # Path to CMake should be handled by environment
 
@@ -87,9 +87,9 @@ class CMake(object):
 
         if not variables:
             variables = {}
-        self._cacheVariables.update(variables)
+        self._cache_variables.update(variables)
 
-        arg_list.extend(['-D{}="{}"'.format(k, v) for k, v in self._cacheVariables.items()])
+        arg_list.extend(['-D{}="{}"'.format(k, v) for k, v in self._cache_variables.items()])
         arg_list.append('"{}"'.format(cmakelist_folder))
 
         command = " ".join(arg_list)

--- a/conan/tools/cmake/presets.py
+++ b/conan/tools/cmake/presets.py
@@ -33,7 +33,9 @@ def write_cmake_presets(conanfile, toolchain_file, generator):
     if platform.system() == "Windows" and generator == "MinGW Makefiles":
         cache_variables["CMAKE_SH"] = "CMAKE_SH-NOTFOUND"
         cmake_make_program = conanfile.conf.get("tools.gnu:make_program", default=None)
-        cache_variables["CMAKE_MAKE_PROGRAM"] = cmake_make_program
+        if cmake_make_program:
+            cmake_make_program = cmake_make_program.replace("\\", "/")
+            cache_variables["CMAKE_MAKE_PROGRAM"] = cmake_make_program
 
     tmp = _contents(conanfile, toolchain_file, cache_variables, generator)
     tmp = json.dumps(tmp, indent=4)

--- a/conan/tools/cmake/presets.py
+++ b/conan/tools/cmake/presets.py
@@ -1,12 +1,11 @@
 import json
 import os
 import platform
-from typing import Dict
 
 from conans.util.files import save, load
 
 
-def _contents(conanfile, toolchain_file, cache_variables: Dict, generator):
+def _contents(conanfile, toolchain_file, cache_variables, generator):
     return {"version": 3,
             "cmakeMinimumRequired": {"major": 3, "minor": 15, "patch": 0},
             "configurePresets": [{

--- a/conan/tools/cmake/presets.py
+++ b/conan/tools/cmake/presets.py
@@ -1,0 +1,46 @@
+import json
+import os
+import platform
+from typing import Dict
+
+from conans.util.files import save, load
+
+
+def _contents(conanfile, toolchain_file, cache_variables: Dict, generator):
+    return {"version": 3,
+            "cmakeMinimumRequired": {"major": 3, "minor": 15, "patch": 0},
+            "configurePresets": [{
+                "name": "default",
+                "displayName": "Default Config",
+                "description": "Default configure using '{}' generator".format(generator),
+                "generator": generator,
+                "cacheVariables": cache_variables,
+                "toolchainFile": toolchain_file,
+                "binaryDir": conanfile.build_folder
+            }],
+            "buildPresets": [{
+              "name": "default",
+              "configurePreset": "default"
+            }],
+            "testPresets": [{
+              "name": "default",
+              "configurePreset": "default"
+            }]
+            }
+
+
+def write_cmake_presets(conanfile, toolchain_file, generator):
+    cache_variables = {}
+    if platform.system() == "Windows" and generator == "MinGW Makefiles":
+        cache_variables["CMAKE_SH"] = "CMAKE_SH-NOTFOUND"
+        cmake_make_program = conanfile.conf.get("tools.gnu:make_program", default=None)
+        cache_variables["CMAKE_MAKE_PROGRAM"] = cmake_make_program
+
+    tmp = _contents(conanfile, toolchain_file, cache_variables, generator)
+    tmp = json.dumps(tmp, indent=4)
+    save(os.path.join(conanfile.generators_folder, "CMakePresets.json"), tmp)
+
+
+def load_cmake_presets(folder):
+    tmp = load(os.path.join(folder, "CMakePresets.json"))
+    return json.loads(tmp)

--- a/conan/tools/cmake/toolchain/toolchain.py
+++ b/conan/tools/cmake/toolchain/toolchain.py
@@ -1,3 +1,4 @@
+import os
 import textwrap
 import six
 from collections import OrderedDict
@@ -6,12 +7,12 @@ from jinja2 import Template
 
 from conan.tools._check_build_profile import check_using_build_profile
 from conan.tools._compilers import use_win_mingw
+from conan.tools.cmake.presets import write_cmake_presets
 from conan.tools.cmake.toolchain import CONAN_TOOLCHAIN_FILENAME
 from conan.tools.cmake.toolchain.blocks import ToolchainBlocks, UserToolchain, GenericSystemBlock, \
     AndroidSystemBlock, AppleSystemBlock, FPicBlock, ArchitectureBlock, GLibCXXBlock, VSRuntimeBlock, \
     CppStdBlock, ParallelBlock, CMakeFlagsInitBlock, TryCompileBlock, FindFiles, SkipRPath, \
     SharedLibBock, OutputDirsBlock, ExtraFlagsBlock
-from conan.tools.files.files import save_toolchain_args
 from conan.tools.intel import IntelCC
 from conan.tools.microsoft import VCVars
 from conan.tools.microsoft.visual import vs_ide_version
@@ -167,18 +168,8 @@ class CMakeToolchain(object):
         # Generators like Ninja or NMake requires an active vcvars
         elif self.generator is not None and "Visual" not in self.generator:
             VCVars(self._conanfile).generate()
-        self._writebuild(toolchain_file)
-
-    def _writebuild(self, toolchain_file):
-        result = {}
-        # TODO: Lets do it compatible with presets soon
-        if self.generator is not None:
-            result["cmake_generator"] = self.generator
-
-        result["cmake_toolchain_file"] = toolchain_file or self.filename
-
-        if result:
-            save_toolchain_args(result, namespace=self._namespace)
+        toolchain = os.path.join(self._conanfile.generators_folder, toolchain_file or self.filename)
+        write_cmake_presets(self._conanfile,toolchain , self.generator)
 
     def _get_generator(self, recipe_generator):
         # Returns the name of the generator to be used by CMake

--- a/conans/test/functional/toolchains/cmake/test_cmake_toolchain.py
+++ b/conans/test/functional/toolchains/cmake/test_cmake_toolchain.py
@@ -4,6 +4,7 @@ import textwrap
 
 import pytest
 
+from conan.tools.cmake.presets import load_cmake_presets
 from conan.tools.files.files import load_toolchain_args
 from conans.model.ref import ConanFileReference
 from conans.test.assets.cmake import gen_cmakelists
@@ -64,8 +65,8 @@ def test_cmake_toolchain_custom_toolchain():
     client.save({"conanfile.py": conanfile})
     client.run("install .")
     assert not os.path.exists(os.path.join(client.current_folder, "conan_toolchain.cmake"))
-    build_content = load_toolchain_args(client.current_folder)
-    assert "mytoolchain.cmake" == build_content["cmake_toolchain_file"]
+    presets = load_cmake_presets(client.current_folder)
+    assert "mytoolchain.cmake" in presets["configurePresets"][0]["toolchainFile"]
 
 
 def test_cmake_toolchain_user_toolchain_from_dep():

--- a/conans/test/functional/toolchains/cmake/test_ninja.py
+++ b/conans/test/functional/toolchains/cmake/test_ninja.py
@@ -4,6 +4,7 @@ import platform
 import pytest
 
 from conan.tools.cmake import CMakeToolchain
+from conan.tools.cmake.presets import load_cmake_presets
 from conan.tools.files.files import load_toolchain_args
 from conans.test.assets.cmake import gen_cmakelists
 from conans.test.assets.genconanfile import GenConanfile
@@ -215,8 +216,10 @@ def test_ninja_conf():
     client.save({"conanfile.py": conanfile,
                  "profile": profile})
     client.run("install . -pr=profile")
-    conanbuild = load_toolchain_args(client.current_folder)
-    assert conanbuild["cmake_generator"] == "Ninja"
+    presets = load_cmake_presets(client.current_folder)
+    generator = presets["configurePresets"][0]["generator"]
+
+    assert generator == "Ninja"
     vcvars = client.load("conanvcvars.bat")
     assert "2017" in vcvars
 

--- a/conans/test/integration/toolchains/cmake/test_cmake.py
+++ b/conans/test/integration/toolchains/cmake/test_cmake.py
@@ -27,7 +27,7 @@ def test_configure_args():
     client.run("create . ")
     # TODO: This check is ugly, because the command line is so different in each platform,
     #  and args_to_string() is doing crazy stuff
-    assert '-DMYVAR=MYVALUE' in client.out
+    assert '-DMYVAR="MYVALUE"' in client.out
     assert "--verbosebuild" in client.out
     assert "-something" in client.out
     assert "--testverbose" in client.out

--- a/conans/test/integration/toolchains/test_toolchain_namespaces.py
+++ b/conans/test/integration/toolchains/test_toolchain_namespaces.py
@@ -2,6 +2,7 @@ import os
 import textwrap
 
 from conan.tools import CONAN_TOOLCHAIN_ARGS_FILE
+from conan.tools.cmake.presets import load_cmake_presets
 from conan.tools.files.files import load_toolchain_args
 from conans.test.utils.tools import TestClient
 
@@ -26,11 +27,9 @@ def test_cmake_namespace():
 
     client.save({"conanfile.py": conanfile})
     client.run("install . ")
-    assert os.path.isfile(os.path.join(client.current_folder,
-                                       "{}_{}".format(namespace, CONAN_TOOLCHAIN_ARGS_FILE)))
-    content = load_toolchain_args(generators_folder=client.current_folder, namespace=namespace)
-    generator = content.get("cmake_generator")
-    toolchain_file = content.get("cmake_toolchain_file")
+    presets = load_cmake_presets(client.current_folder)
+    toolchain_file = presets["configurePresets"][0]["toolchainFile"]
+    generator = presets["configurePresets"][0]["generator"]
     client.run("build . ")
     assert generator in client.out
     assert toolchain_file in client.out
@@ -110,12 +109,11 @@ def test_autotools_namespace():
 def test_multiple_toolchains_one_recipe():
     # https://github.com/conan-io/conan/issues/9376
     client = TestClient()
-    namespaces = ["autotools", "bazel", "cmake"]
+    namespaces = ["autotools", "bazel"]
     conanfile = textwrap.dedent("""
             from conans import ConanFile
             from conan.tools.gnu import AutotoolsToolchain, Autotools
             from conan.tools.google import BazelToolchain, Bazel
-            from conan.tools.cmake import CMakeToolchain, CMake
 
             class Conan(ConanFile):
                 settings = "os", "arch", "compiler", "build_type"
@@ -126,8 +124,6 @@ def test_multiple_toolchains_one_recipe():
                     autotools.generate()
                     bazel = BazelToolchain(self, namespace='{1}')
                     bazel.generate()
-                    cmake = CMakeToolchain(self, namespace='{2}')
-                    cmake.generate()
 
                 def build(self):
                     autotools = Autotools(self, namespace='{0}')
@@ -136,9 +132,6 @@ def test_multiple_toolchains_one_recipe():
                     bazel = Bazel(self, namespace='{1}')
                     self.output.info(bazel._bazel_config)
                     self.output.info(bazel._bazelrc_path)
-                    cmake = CMake(self, namespace='{2}')
-                    self.output.info(cmake._generator)
-                    self.output.info(cmake._toolchain_file)
             """.format(*namespaces))
 
     client.save({"conanfile.py": conanfile})
@@ -156,7 +149,6 @@ def test_multiple_toolchains_one_recipe():
     check_args = {
         "autotools": ["configure_args", "make_args"],
         "bazel": ["bazel_configs", "bazelrc_path"],
-        "cmake": ["cmake_generator", "cmake_toolchain_file"]
     }
     checks = []
     for namespace in namespaces:

--- a/conans/test/unittests/tools/cmake/test_cmake_presets_definitions.py
+++ b/conans/test/unittests/tools/cmake/test_cmake_presets_definitions.py
@@ -34,7 +34,7 @@ def conanfile():
 
 def test_cmake_make_program(conanfile):
     def run(command):
-        assert '-DCMAKE_MAKE_PROGRAM=C:/mymake.exe' in command
+        assert '-DCMAKE_MAKE_PROGRAM="C:/mymake.exe"' in command
 
     conanfile.run = run
     conanfile.conf.define("tools.gnu:make_program", "C:\\mymake.exe")

--- a/conans/test/unittests/tools/cmake/test_cmake_presets_definitions.py
+++ b/conans/test/unittests/tools/cmake/test_cmake_presets_definitions.py
@@ -3,6 +3,7 @@ from mock import mock
 from mock.mock import Mock
 
 from conan.tools.cmake import CMake
+from conan.tools.cmake.presets import write_cmake_presets
 from conan.tools.files.files import save_toolchain_args
 from conans import ConanFile, Settings
 from conans.model.conf import Conf
@@ -32,14 +33,15 @@ def conanfile():
 
 
 def test_cmake_make_program(conanfile):
-    save_toolchain_args({"cmake_generator": "MinGW Makefiles"},
-                        generators_folder=conanfile.folders.generators_folder)
-
     def run(command):
-        assert '-DCMAKE_MAKE_PROGRAM="C:/mymake.exe"' in command
+        assert '-DCMAKE_MAKE_PROGRAM=C:\\mymake.exe' in command
 
     conanfile.run = run
     conanfile.conf.define("tools.gnu:make_program", "C:\\mymake.exe")
+
     with mock.patch("platform.system", mock.MagicMock(return_value='Windows')):
-        cmake = CMake(conanfile)
-        cmake.configure()
+        write_cmake_presets(conanfile, "the_toolchain.cmake", "MinGW Makefiles")
+
+    cmake = CMake(conanfile)
+    cmake.configure()
+

--- a/conans/test/unittests/tools/cmake/test_cmake_presets_definitions.py
+++ b/conans/test/unittests/tools/cmake/test_cmake_presets_definitions.py
@@ -34,7 +34,7 @@ def conanfile():
 
 def test_cmake_make_program(conanfile):
     def run(command):
-        assert '-DCMAKE_MAKE_PROGRAM=C:\\mymake.exe' in command
+        assert '-DCMAKE_MAKE_PROGRAM=C:/mymake.exe' in command
 
     conanfile.run = run
     conanfile.conf.define("tools.gnu:make_program", "C:\\mymake.exe")


### PR DESCRIPTION
Changelog: Feature: Preliminar support for CMakePresets.json.
Docs: https://github.com/conan-io/docs/pull/2476

- There is a limitation, the `CMakePresets.json` has to be in the same folder as the `CMakeLists.txt` file to be located by `cmake --preset XXX` and the IDEs. But, for the end-user to leverage it,  it can be copied or symlinked and works fine (tested in Visual Studio Code).
- The limitation doesn't exist or interfere with Conan, because Conan is able to locate the file and read the contents previously stored at (conanbuild.conf). 
- This is a legit use of `CMakePresets.json`, it is not needed to call `cmake` with `--preset XXX`, this file is intended to be readable by IDE's (and Conan) to call "cmake" properly passing the right arguments. Because of that, there is no limitation to CMake 3.19.
- Notice that the entry `binaryDir` is indicating the IDEs to use that "build folder" so it could make every IDE follow the Conan build layout (and not the opposite).
- Pending: Look into multi config completing the same CMakePresets.json with different configurations?

Related https://github.com/conan-io/conan/issues/10101