### PR TITLE
find_dependency following cmake_find_mode property

### DIFF
--- a/conan/tools/cmake/cmakedeps/templates/config.py
+++ b/conan/tools/cmake/cmakedeps/templates/config.py
@@ -63,11 +63,7 @@ class ConfigTemplate(CMakeDepsFileTemplate):
         foreach(_DEPENDENCY {{ '${' + pkg_name + '_FIND_DEPENDENCY_NAMES' + '}' }} )
             # Check that we have not already called a find_package with the transitive dependency
             if(NOT {{ '${_DEPENDENCY}' }}_FOUND)
-            {% if is_module %}
-                find_dependency({{ '${_DEPENDENCY}' }} REQUIRED MODULE)
-            {% else %}
-                find_dependency({{ '${_DEPENDENCY}' }} REQUIRED NO_MODULE)
-            {% endif %}
+                find_dependency({{ '${_DEPENDENCY}' }} REQUIRED ${${_DEPENDENCY}_FIND_MODE})
             endif()
         endforeach()
 

--- a/conan/tools/cmake/cmakedeps/templates/target_data.py
+++ b/conan/tools/cmake/cmakedeps/templates/target_data.py
@@ -41,6 +41,8 @@ class ConfigDataTemplate(CMakeDepsFileTemplate):
         # This is because in Conan 2.0 model, only the pure tools like CMake will be build_requires
         # for example a framework test won't be a build require but a "test/not public" require.
         dependency_filenames = self._get_dependency_filenames()
+        # Get the nodes that have the property cmake_find_mode=None (no files to generate)
+        dependency_find_modes = self._get_dependencies_find_modes()
         # package_folder might not be defined if Editable and layout()
         package_folder = self.conanfile.package_folder or ""
         package_folder = package_folder.replace('\\', '/').replace('$', '\\$').replace('"', '\\"')
@@ -52,7 +54,8 @@ class ConfigDataTemplate(CMakeDepsFileTemplate):
                 "config_suffix": self.config_suffix,
                 "components_names": components_names,
                 "components_cpp": components_cpp,
-                "dependency_filenames": " ".join(dependency_filenames)}
+                "dependency_filenames": " ".join(dependency_filenames),
+                "dependency_find_modes": dependency_find_modes}
 
     @property
     def template(self):
@@ -73,6 +76,9 @@ class ConfigDataTemplate(CMakeDepsFileTemplate):
               {% else %}
               set({{ pkg_name }}_FIND_DEPENDENCY_NAMES "")
               {% endif %}
+              {% for dep_name, mode in dependency_find_modes.items() %}
+              set({{ dep_name }}_FIND_MODE "{{ mode }}")
+              {% endfor %}
 
               ########### VARIABLES #######################################################################
               #############################################################################################
@@ -167,6 +173,22 @@ class ConfigDataTemplate(CMakeDepsFileTemplate):
         elif direct_host:
             ret = [get_file_name(r, self.find_module_mode) for r in direct_host.values()]
 
+        return ret
+
+    def _get_dependencies_find_modes(self):
+        ret = {}
+        if self.conanfile.is_build_context:
+            return ret
+        deps = self.conanfile.dependencies.filter({"build": False, "visible": True, "direct": True})
+        for dep in deps.values():
+            dep_file_name = get_file_name(dep, self.find_module_mode)
+            find_mode = dep.cpp_info.get_property("cmake_find_mode")
+            values = {"none": "",
+                      "config": "NO_MODULE",
+                      "module": "MODULE",
+                      "both": "NO_MODULE" if not self.find_module_mode else "MODULE"}
+            find_mode = find_mode or "both"
+            ret[dep_file_name] = values[find_mode.lower()]
         return ret
 
 

--- a/conans/test/functional/toolchains/android/test_using_cmake.py
+++ b/conans/test/functional/toolchains/android/test_using_cmake.py
@@ -1,71 +1,69 @@
 import textwrap
-import unittest
+import platform
 
+import pytest
 from conan.tools.cmake import CMakeToolchain
-from conans.client.tools import which
 from conans.test.utils.tools import TestClient
-from ._utils import create_library
+from conans.test.functional.toolchains.android._utils import create_library
 
 
-class AndroidToolchainTestCase(unittest.TestCase):
-    # This test assumes that 'CMake' and 'AndroidNDK' are available in the system
-    #
-    # Guidelines: https://developer.android.com/ndk/guides/cmake#command-line
+@pytest.fixture
+def client():
+    t = TestClient()
+    create_library(t)
+    t.save({
+        'conanfile.py': textwrap.dedent("""
+            from conans import ConanFile
+            from conan.tools.cmake import CMake, CMakeToolchain
 
-    @classmethod
-    def setUpClass(cls):
-        if not which('cmake'):
-            raise unittest.SkipTest("CMake expected in PATH")
-        if not which('ndk-build'):
-            raise unittest.SkipTest("ANDROID_NDK (ndk-build) expected in PATH")
+            class Library(ConanFile):
+                name = 'library'
+                settings = 'os', 'arch', 'compiler', 'build_type'
+                exports_sources = "CMakeLists.txt", "lib.h", "lib.cpp"
+                options = {'shared': [True, False]}
+                default_options = {'shared': False}
 
-    def setUp(self):
-        self.t = TestClient()
-        create_library(self.t)
-        self.t.save({
-            'conanfile.py': textwrap.dedent("""
-                from conans import ConanFile
-                from conan.tools.cmake import CMake, CMakeToolchain
+                def generate(self):
+                    tc = CMakeToolchain(self)
+                    tc.generate()
 
-                class Library(ConanFile):
-                    name = 'library'
-                    settings = 'os', 'arch', 'compiler', 'build_type'
-                    exports_sources = "CMakeLists.txt", "lib.h", "lib.cpp"
-                    options = {'shared': [True, False]}
-                    default_options = {'shared': False}
+                def build(self):
+                    cmake = CMake(self)
+                    cmake.configure()
+                    cmake.build()
 
-                    def generate(self):
-                        tc = CMakeToolchain(self)
-                        tc.generate()
+                def package(self):
+                    cmake = CMake(self)
+                    cmake.install()
+            """),
+        'profile_host': textwrap.dedent("""
+            [settings]
+            os=Android
+            os.api_level=23
+            arch=x86_64
+            compiler=clang
+            compiler.version=9
+            compiler.libcxx=c++_shared
+            build_type=Release
+            [conf]
+            tools.android:ndk_path=/usr/local/share/android-ndk
+        """)
+        # FIXME: The conf ndk_path is hardcoded, could be received from the conftest?
+    })
+    return t
 
-                    def build(self):
-                        cmake = CMake(self)
-                        cmake.configure()
 
-                    def package(self):
-                        cmake = CMake(self)
-                        cmake.install()
-                """),
-            'profile_host': textwrap.dedent("""
-                [settings]
-                os=Android
-                os.api_level=23
-                arch=x86_64
-                compiler=clang
-                compiler.version=9
-                compiler.libcxx=c++_shared
-                build_type=Release
-            """)
-        })
+@pytest.mark.tool_cmake
+@pytest.mark.tool_ndk
+@pytest.mark.skipif(platform.system() != "Darwin", reason="NDK only installed on MAC")
+def test_use_cmake_toolchain(client):
+    """ This is the naive approach, we follow instruction from CMake in its documentation
+        https://cmake.org/cmake/help/latest/manual/cmake-toolchains.7.html#cross-compiling-for-android
+    """
+    # Build in the cache
+    client.run('create . library/version@ --profile:host=profile_host --profile:build=default')
 
-    def test_use_cmake_toolchain(self):
-        """ This is the naive approach, we follow instruction from CMake in its documentation
-            https://cmake.org/cmake/help/latest/manual/cmake-toolchains.7.html#cross-compiling-for-android
-        """
-        # Build in the cache
-        self.t.run('create . library/version@ --profile:host=profile_host --profile:build=default')
-
-        # Build locally
-        self.t.run('install . library/version@ --profile:host=profile_host --profile:build=default')
-        self.t.run_command('cmake . -DCMAKE_TOOLCHAIN_FILE={}'.format(CMakeToolchain.filename))
-        self.t.run_command('cmake --build .')
+    # Build locally
+    client.run('install . library/version@ --profile:host=profile_host --profile:build=default')
+    client.run_command('cmake . -DCMAKE_TOOLCHAIN_FILE={}'.format(CMakeToolchain.filename))
+    client.run_command('cmake --build .')

--- a/conans/test/functional/toolchains/android/test_using_cmake.py
+++ b/conans/test/functional/toolchains/android/test_using_cmake.py
@@ -55,7 +55,7 @@ def client():
 
 
 @pytest.mark.tool_cmake
-@pytest.mark.tool_ndk
+@pytest.mark.tool_android_ndk
 @pytest.mark.skipif(platform.system() != "Darwin", reason="NDK only installed on MAC")
 def test_use_cmake_toolchain(client):
     """ This is the naive approach, we follow instruction from CMake in its documentation

--- a/conans/test/functional/toolchains/cmake/cmakedeps/test_cmakedeps.py
+++ b/conans/test/functional/toolchains/cmake/cmakedeps/test_cmakedeps.py
@@ -7,6 +7,7 @@ import pytest
 from conans.client.tools import replace_in_file
 from conans.test.assets.cmake import gen_cmakelists
 from conans.test.assets.genconanfile import GenConanfile
+from conans.test.assets.pkg_cmake import pkg_cmake
 from conans.test.assets.sources import gen_function_cpp, gen_function_h
 from conans.test.utils.tools import TestClient
 
@@ -61,8 +62,9 @@ def test_transitive_multi(client):
 
         # Test that we are using find_dependency with the NO_MODULE option
         # to skip finding first possible FindBye somewhere
-        assert "find_dependency(${_DEPENDENCY} REQUIRED NO_MODULE)" \
+        assert "find_dependency(${_DEPENDENCY} REQUIRED ${${_DEPENDENCY}_FIND_MODE})" \
                in client.load("libb-config.cmake")
+        assert 'set(liba_FIND_MODE "NO_MODULE")' in client.load("libb-release-x86_64-data.cmake")
 
         if platform.system() == "Windows":
             client.run_command('cmake .. -DCMAKE_TOOLCHAIN_FILE=conan_toolchain.cmake')
@@ -340,3 +342,39 @@ def test_private_transitive():
     assert "dep/0.1:5ab84d6acfe1f23c4fae0ab88f26e3a396351ac9 - Skip" in client.out
     data_cmake = client.load("pkg-release-x86_64-data.cmake")
     assert 'set(pkg_FIND_DEPENDENCY_NAMES "")' in data_cmake
+
+
+@pytest.mark.tool_cmake
+def test_system_dep():
+    """This test creates a zlib package and use the installation CMake FindZLIB.cmake to locate
+    the library of the package. That happens because:
+    - The package declares: self.cpp_info.set_property("cmake_find_mode", "none") so CMakeDeps does nothing
+    - The toolchain set the CMAKE_LIBRARY_PATH to the "lib" of the package, so the library file is found
+    """
+    client = TestClient()
+    files = pkg_cmake("zlib", "0.1")
+    files["conanfile.py"] += """
+    def package_info(self):
+        # This will use the FindZLIB from CMake but will find this library package
+        self.cpp_info.set_property("cmake_file_name", "ZLIB")
+        self.cpp_info.set_property("cmake_target_name", "ZLIB::ZLIB")
+        self.cpp_info.set_property("cmake_find_mode", "none")
+    """
+    client.save({os.path.join("zlib", name): content for name, content in files.items()})
+    files = pkg_cmake("mylib", "0.1", requires=["zlib/0.1"])
+    files["CMakeLists.txt"] = files["CMakeLists.txt"].replace("find_package(zlib)",
+                                                              "find_package(ZLIB)")
+    files["CMakeLists.txt"] = files["CMakeLists.txt"].replace("zlib::zlib","ZLIB::ZLIB")
+    client.save({os.path.join("mylib", name): content for name, content in files.items()})
+    files = pkg_cmake("consumer", "0.1", requires=["mylib/0.1"])
+    client.save({os.path.join("consumer", name): content for name, content in files.items()})
+    client.run("create zlib")
+    client.run("create mylib")
+    client.run("create consumer")
+    assert "Found ZLIB:" in client.out
+
+    client.run("install consumer")
+    if platform.system() != "Windows":
+        data = os.path.join("consumer/cmake-build-release/conan/mylib-release-x86_64-data.cmake")
+        contents = client.load(data)
+        assert 'set(ZLIB_FIND_MODE "")' in contents

--- a/conans/test/functional/toolchains/cmake/cmakedeps/test_cmakedeps_components.py
+++ b/conans/test/functional/toolchains/cmake/cmakedeps/test_cmakedeps_components.py
@@ -71,9 +71,6 @@ class PropagateSpecificComponents(unittest.TestCase):
         content = t.load('middle-release-x86_64-data.cmake')
         self.assertIn("list(APPEND middle_FIND_DEPENDENCY_NAMES top)", content)
 
-        content = t.load('middle-config.cmake')
-        self.assertIn("find_dependency(${_DEPENDENCY} REQUIRED NO_MODULE)", content)
-
         content = t.load('middle-Target-release.cmake')
         self.assertNotIn("top::top", content)
         self.assertNotIn("top::cmp2", content)

--- a/conans/test/integration/toolchains/cmake/cmakedeps/test_cmakedeps.py
+++ b/conans/test/integration/toolchains/cmake/cmakedeps/test_cmakedeps.py
@@ -33,11 +33,13 @@ def test_package_from_system():
         with_settings("os", "arch", "build_type", "compiler")
     client.save({"conanfile.py": consumer})
     client.run("install .")
+
     assert os.path.exists(os.path.join(client.current_folder, "dep1-config.cmake"))
     assert not os.path.exists(os.path.join(client.current_folder, "dep2-config.cmake"))
     assert not os.path.exists(os.path.join(client.current_folder, "custom_dep2-config.cmake"))
-    contents = client.load("dep1-release-x86_64-data.cmake")
-    assert 'list(APPEND dep1_FIND_DEPENDENCY_NAMES custom_dep2)' in contents
+    dep1_contents = client.load("dep1-release-x86_64-data.cmake")
+    assert 'list(APPEND dep1_FIND_DEPENDENCY_NAMES custom_dep2)' in dep1_contents
+    assert 'set(custom_dep2_FIND_MODE "")' in dep1_contents
 
 
 def test_test_package():


### PR DESCRIPTION
Changelog: BugFix: The `find_dependency` called internally in `CMakeDeps` generator to locate transitive dependencies now use the `MODULE/NO_MODULE` following the `cmake_find_mode` property when declared in the dependency.
Docs: 

Close #10591