### PR TITLE
[conf] Global flags changes

### DIFF
--- a/conan/tools/cmake/toolchain/blocks.py
+++ b/conan/tools/cmake/toolchain/blocks.py
@@ -563,6 +563,9 @@ class ExtraFlagsBlock(Block):
         {% if exelinkflags %}
         string(APPEND CONAN_EXE_LINKER_FLAGS "{% for exelinkflag in exelinkflags %} {{ exelinkflag }}{% endfor %}")
         {% endif %}
+        {% if defines %}
+        add_definitions({% for define in defines %} {{ define }}{% endfor %})
+        {% endif %}
     """)
 
     def context(self):
@@ -571,11 +574,13 @@ class ExtraFlagsBlock(Block):
         cflags = self._conanfile.conf.get("tools.build:cflags", default=[], check_type=list)
         sharedlinkflags = self._conanfile.conf.get("tools.build:sharedlinkflags", default=[], check_type=list)
         exelinkflags = self._conanfile.conf.get("tools.build:exelinkflags", default=[], check_type=list)
+        defines = self._conanfile.conf.get("tools.build:defines", default=[], check_type=list)
         return {
             "cxxflags": cxxflags,
             "cflags": cflags,
             "sharedlinkflags": sharedlinkflags,
-            "exelinkflags": exelinkflags
+            "exelinkflags": exelinkflags,
+            "defines": ["-D{}".format(d) for d in defines]
         }
 
 

--- a/conan/tools/gnu/autotoolstoolchain.py
+++ b/conan/tools/gnu/autotoolstoolchain.py
@@ -119,13 +119,14 @@ class AutotoolsToolchain:
         # Now, it's time to get all the flags defined by the user
         cxxflags = self._conanfile.conf.get("tools.build:cxxflags", default=[], check_type=list)
         cflags = self._conanfile.conf.get("tools.build:cflags", default=[], check_type=list)
-        ldflags = self._conanfile.conf.get("tools.build:ldflags", default=[], check_type=list)
-        cppflags = self._conanfile.conf.get("tools.build:cppflags", default=[], check_type=list)
+        sharedlinkflags = self._conanfile.conf.get("tools.build:sharedlinkflags", default=[], check_type=list)
+        exelinkflags = self._conanfile.conf.get("tools.build:exelinkflags", default=[], check_type=list)
+        defines = self._conanfile.conf.get("tools.build:defines", default=[], check_type=list)
         return {
             "cxxflags": cxxflags,
             "cflags": cflags,
-            "cppflags": cppflags,
-            "ldflags": ldflags
+            "defines": defines,
+            "ldflags": sharedlinkflags + exelinkflags
         }
 
     def environment(self):
@@ -142,7 +143,7 @@ class AutotoolsToolchain:
                            + self.build_type_flags + apple_flags + extra_flags["cflags"])
         self.ldflags.extend([self.arch_flag] + self.build_type_link_flags
                             + apple_flags + extra_flags["ldflags"])
-        self.defines.extend([self.ndebug, self.gcc_cxx11_abi] + extra_flags["cppflags"])
+        self.defines.extend([self.ndebug, self.gcc_cxx11_abi] + extra_flags["defines"])
 
         if is_msvc(self._conanfile):
             env.define("CXX", "cl")

--- a/conan/tools/meson/toolchain.py
+++ b/conan/tools/meson/toolchain.py
@@ -208,11 +208,12 @@ class MesonToolchain(object):
         # Now, it's time to get all the flags defined by the user
         cxxflags = self._conanfile.conf.get("tools.build:cxxflags", default=[], check_type=list)
         cflags = self._conanfile.conf.get("tools.build:cflags", default=[], check_type=list)
-        ldflags = self._conanfile.conf.get("tools.build:ldflags", default=[], check_type=list)
+        sharedlinkflags = self._conanfile.conf.get("tools.build:sharedlinkflags", default=[], check_type=list)
+        exelinkflags = self._conanfile.conf.get("tools.build:exelinkflags", default=[], check_type=list)
         return {
             "cxxflags": cxxflags,
             "cflags": cflags,
-            "ldflags": ldflags
+            "ldflags": sharedlinkflags + exelinkflags
         }
 
     @staticmethod

--- a/conans/model/conf.py
+++ b/conans/model/conf.py
@@ -43,8 +43,7 @@ BUILT_IN_CONFS = {
     # Flags configuration
     "tools.build:cxxflags": "List of extra CXX flags used by different toolchains like CMakeToolchain, AutotoolsToolchain and MesonToolchain",
     "tools.build:cflags": "List of extra C flags used by different toolchains like CMakeToolchain, AutotoolsToolchain and MesonToolchain",
-    "tools.build:cppflags": "List of extra CPP flags used by different toolchains like AutotoolsToolchain and MesonToolchain",
-    "tools.build:ldflags": "List of extra LD flags used by different toolchains like AutotoolsToolchain and MesonToolchain",
+    "tools.build:defines": "List of extra definition flags used by different toolchains like AutotoolsToolchain and MesonToolchain",
     "tools.build:sharedlinkflags": "List of extra flags used by CMakeToolchain for CMAKE_SHARED_LINKER_FLAGS_INIT variable",
     "tools.build:exelinkflags": "List of extra flags used by CMakeToolchain for CMAKE_EXE_LINKER_FLAGS_INIT variable",
 }

--- a/conans/model/conf.py
+++ b/conans/model/conf.py
@@ -43,7 +43,7 @@ BUILT_IN_CONFS = {
     # Flags configuration
     "tools.build:cxxflags": "List of extra CXX flags used by different toolchains like CMakeToolchain, AutotoolsToolchain and MesonToolchain",
     "tools.build:cflags": "List of extra C flags used by different toolchains like CMakeToolchain, AutotoolsToolchain and MesonToolchain",
-    "tools.build:defines": "List of extra definition flags used by different toolchains like AutotoolsToolchain and MesonToolchain",
+    "tools.build:defines": "List of extra definition flags used by different toolchains like CMakeToolchain and AutotoolsToolchain",
     "tools.build:sharedlinkflags": "List of extra flags used by CMakeToolchain for CMAKE_SHARED_LINKER_FLAGS_INIT variable",
     "tools.build:exelinkflags": "List of extra flags used by CMakeToolchain for CMAKE_EXE_LINKER_FLAGS_INIT variable",
 }

--- a/conans/test/integration/toolchains/cmake/test_cmaketoolchain.py
+++ b/conans/test/integration/toolchains/cmake/test_cmaketoolchain.py
@@ -246,6 +246,7 @@ def test_extra_flags_via_conf():
         tools.build:cflags+=["--flag3", "--flag4"]
         tools.build:sharedlinkflags=+["--flag5", "--flag6"]
         tools.build:exelinkflags=["--flag7", "--flag8"]
+        tools.build:defines=["D1", "D2"]
         """)
 
     client = TestClient(path_with_spaces=False)
@@ -260,3 +261,4 @@ def test_extra_flags_via_conf():
     assert 'string(APPEND CONAN_C_FLAGS " --flag3 --flag4")' in toolchain
     assert 'string(APPEND CONAN_SHARED_LINKER_FLAGS " --flag5 --flag6")' in toolchain
     assert 'string(APPEND CONAN_EXE_LINKER_FLAGS " --flag7 --flag8")' in toolchain
+    assert 'add_definitions( -DD1 -DD2)' in toolchain

--- a/conans/test/integration/toolchains/gnu/test_autotoolstoolchain.py
+++ b/conans/test/integration/toolchains/gnu/test_autotoolstoolchain.py
@@ -21,8 +21,9 @@ def test_extra_flags_via_conf():
         [conf]
         tools.build:cxxflags=["--flag1", "--flag2"]
         tools.build:cflags+=["--flag3", "--flag4"]
-        tools.build:ldflags+=["--flag5", "--flag6"]
-        tools.build:cppflags+=["DEF1", "DEF2"]
+        tools.build:sharedlinkflags+=["--flag5"]
+        tools.build:exelinkflags+=["--flag6"]
+        tools.build:defines+=["DEF1", "DEF2"]
         """ % os_)
     client = TestClient()
     conanfile = GenConanfile().with_settings("os", "arch", "compiler", "build_type")\

--- a/conans/test/integration/toolchains/meson/test_mesontoolchain.py
+++ b/conans/test/integration/toolchains/meson/test_mesontoolchain.py
@@ -82,7 +82,8 @@ def test_extra_flags_via_conf():
         [conf]
         tools.build:cxxflags=["-flag1", "-flag2"]
         tools.build:cflags=["-flag3", "-flag4"]
-        tools.build:ldflags=["-flag5", "-flag6"]
+        tools.build:sharedlinkflags+=["-flag5"]
+        tools.build:exelinkflags+=["-flag6"]
    """)
     t = TestClient()
     t.save({"conanfile.txt": "[generators]\nMesonToolchain",

--- a/conans/test/unittests/client/toolchain/autotools/autotools_toolchain_test.py
+++ b/conans/test/unittests/client/toolchain/autotools/autotools_toolchain_test.py
@@ -414,8 +414,9 @@ def test_extra_flags_via_conf():
     conanfile = ConanFileMock()
     conanfile.conf.define("tools.build:cxxflags", ["--flag1", "--flag2"])
     conanfile.conf.define("tools.build:cflags", ["--flag3", "--flag4"])
-    conanfile.conf.define("tools.build:ldflags", ["--flag5", "--flag6"])
-    conanfile.conf.define("tools.build:cppflags", ["DEF1", "DEF2"])
+    conanfile.conf.define("tools.build:sharedlinkflags", ["--flag5"])
+    conanfile.conf.define("tools.build:exelinkflags", ["--flag6"])
+    conanfile.conf.define("tools.build:defines", ["DEF1", "DEF2"])
     conanfile.settings = MockSettings(
         {"build_type": "RelWithDebInfo",
          "os": "iOS",


### PR DESCRIPTION
Changelog: Feature: Renamed `tools.build:cppflags` to `tools.build:defines` and removed `tools.build:ldflags` (now it's the union between `tools.build:sharedlinkflags` and `tools.build:exelinkflags` in mostly all the cases).
Docs: https://github.com/conan-io/docs/pull/2484
Related to: https://github.com/conan-io/conan/pull/10800