### PR TITLE
CMakeToolchain bool variables

### DIFF
--- a/conan/tools/cmake/toolchain/blocks.py
+++ b/conan/tools/cmake/toolchain/blocks.py
@@ -8,9 +8,9 @@ from jinja2 import Template
 from conan.tools._compilers import architecture_flag
 from conan.tools.apple.apple import is_apple_os, to_apple_arch
 from conan.tools.build import build_jobs
+from conan.tools.build.cross_building import cross_building
 from conan.tools.cmake.toolchain import CONAN_TOOLCHAIN_FILENAME
 from conan.tools.cmake.utils import is_multi_configuration
-from conan.tools.build.cross_building import cross_building
 from conan.tools.intel import IntelCC
 from conan.tools.microsoft.visual import is_msvc, msvc_version_to_toolset_version
 from conans.errors import ConanException

--- a/conan/tools/cmake/toolchain/toolchain.py
+++ b/conan/tools/cmake/toolchain/toolchain.py
@@ -1,8 +1,8 @@
 import os
 import textwrap
-import six
 from collections import OrderedDict
 
+import six
 from jinja2 import Template
 
 from conan.tools._check_build_profile import check_using_build_profile
@@ -95,7 +95,11 @@ class CMakeToolchain(object):
 
         # Variables
         {% for it, value in variables.items() %}
+        {% if value is boolean %}
+        set({{ it }} {{ value|cmake_value }} CACHE BOOL "Variable {{ it }} conan-toolchain defined")
+        {% else %}
         set({{ it }} {{ value|cmake_value }} CACHE STRING "Variable {{ it }} conan-toolchain defined")
+        {% endif %}
         {% endfor %}
         # Variables  per configuration
         {{ iterate_configs(variables_config, action='set') }}
@@ -161,7 +165,7 @@ class CMakeToolchain(object):
     def generate(self):
         toolchain_file = self._conanfile.conf.get("tools.cmake.cmaketoolchain:toolchain_file")
         if toolchain_file is None:  # The main toolchain file generated only if user dont define
-            save(self.filename, self.content)
+            save(os.path.join(self._conanfile.generators_folder, self.filename), self.content)
         # If we're using Intel oneAPI, we need to generate the environment file and run it
         if self._conanfile.settings.get_safe("compiler") == "intel-cc":
             IntelCC(self._conanfile).generate()

--- a/conans/test/unittests/tools/cmake/test_cmaketoolchain.py
+++ b/conans/test/unittests/tools/cmake/test_cmaketoolchain.py
@@ -1,3 +1,4 @@
+import os
 import types
 
 import pytest
@@ -10,6 +11,8 @@ from conans.client.conf import get_default_settings_yml
 from conans.errors import ConanException
 from conans.model.conf import Conf
 from conans.model.env_info import EnvValues
+from conans.test.utils.test_files import temp_folder
+from conans.util.files import load
 
 
 @pytest.fixture
@@ -462,3 +465,17 @@ def test_apple_cmake_osx_sysroot_sdk_mandatory(os, os_sdk, arch, expected_sdk):
     with pytest.raises(ConanException) as excinfo:
         CMakeToolchain(c).content()
         assert "Please, specify a suitable value for os.sdk." % expected_sdk in str(excinfo.value)
+
+
+def test_variables_types(conanfile):
+    generator_folder = temp_folder()
+    conanfile.folders.set_base_generators(generator_folder)
+    # This is a trick for 1.X to use base_generator and not install folder
+    conanfile.folders.generators = "here"
+
+    toolchain = CMakeToolchain(conanfile)
+    toolchain.variables["FOO"] = True
+    toolchain.generate()
+
+    contents = load(os.path.join(conanfile.generators_folder, "conan_toolchain.cmake"))
+    assert 'set(FOO ON CACHE BOOL "Variable FOO conan-toolchain defined")' in contents


### PR DESCRIPTION
Changelog: Bugfix: The CMakeToolchain now declares `CACHE BOOL` variables when a bool is stored in a variable: `toolchain.variables["FOO"] = True`.
Docs: omit

Close #10936 