### PR TITLE
[develop2] minor refactor to Settings, ANY

### DIFF
--- a/conans/client/conf/__init__.py
+++ b/conans/client/conf/__init__.py
@@ -40,12 +40,12 @@ os:
             catalyst:
                 ios_version: *ios_version
     Android:
-        api_level: ANY
+        api_level: [ANY]
     FreeBSD:
     SunOS:
     AIX:
     Arduino:
-        board: ANY
+        board: [ANY]
     Emscripten:
     Neutrino:
         version: ["6.4", "6.5", "6.6", "7.0", "7.1"]

--- a/conans/client/graph/compute_pid.py
+++ b/conans/client/graph/compute_pid.py
@@ -47,10 +47,6 @@ def compute_package_id(node, new_config):
                                       default_python_requires_id_mode=python_mode)
     conanfile.original_info = conanfile.info.clone()
 
-    apple_clang_compatible = conanfile.info.apple_clang_compatible()
-    if apple_clang_compatible:
-        conanfile.compatible_packages.append(apple_clang_compatible)
-
     run_validate_package_id(conanfile)
 
     info = conanfile.info

--- a/conans/client/graph/install_graph.py
+++ b/conans/client/graph/install_graph.py
@@ -247,7 +247,7 @@ def raise_missing(missing, out):
     ref, conanfile = node.ref, node.conanfile
     dependencies = [str(dep.dst) for dep in node.dependencies]
 
-    settings_text = ", ".join(conanfile.info.full_settings.dumps().splitlines())
+    settings_text = ", ".join(conanfile.info.settings.dumps().splitlines())
     options_text = ", ".join(conanfile.info.options.dumps().splitlines())
     dependencies_text = ', '.join(dependencies)
     requires_text = ", ".join(conanfile.info.requires.dumps().splitlines())

--- a/conans/model/values.py
+++ b/conans/model/values.py
@@ -5,7 +5,6 @@ class Values(object):
     def __init__(self, value="values"):
         self._value = str(value)
         self._dict = {}  # {key: Values()}
-        self._modified = {}  # {"compiler.version.arch": (old_value, old_reference)}
 
     def __getattr__(self, attr):
         if attr not in self._dict:

--- a/conans/test/integration/command/install/test_install_transitive.py
+++ b/conans/test/integration/command/install/test_install_transitive.py
@@ -7,7 +7,7 @@ from conans.model.package_ref import PkgReference
 from conans.model.recipe_ref import RecipeReference
 from conans.paths import CONANFILE_TXT, CONANINFO
 from conans.test.utils.tools import TestClient,  GenConanfile
-from conans.util.files import save
+from conans.util.files import save, load
 
 
 @pytest.fixture()
@@ -68,13 +68,13 @@ def test_reuse(client):
 
         hello0 = client.get_latest_pkg_layout(PkgReference(ref, id0)).package()
         hello0_info = os.path.join(hello0, CONANINFO)
-        hello0_conan_info = ConanInfo.load_file(hello0_info)
+        hello0_conan_info = ConanInfo.loads(load(hello0_info))
         assert lang == hello0_conan_info.options.language
 
         pref1 = PkgReference(RecipeReference.loads("hello1/0.1@lasote/stable"), id1)
         hello1 = client.get_latest_pkg_layout(pref1).package()
         hello1_info = os.path.join(hello1, CONANINFO)
-        hello1_conan_info = ConanInfo.load_file(hello1_info)
+        hello1_conan_info = ConanInfo.loads(load(hello1_info))
         assert lang == hello1_conan_info.options.language
 
 
@@ -88,13 +88,13 @@ def test_upper_option(client):
     hello0 = client.get_latest_pkg_layout(pref).package()
 
     hello0_info = os.path.join(hello0, CONANINFO)
-    hello0_conan_info = ConanInfo.load_file(hello0_info)
+    hello0_conan_info = ConanInfo.loads(load(hello0_info))
     assert 1 == hello0_conan_info.options.language
 
     pref1 = client.get_latest_package_reference(RecipeReference.loads("hello1/0.1@lasote/stable"), package_id2)
     hello1 = client.get_latest_pkg_layout(pref1).package()
     hello1_info = os.path.join(hello1, CONANINFO)
-    hello1_conan_info = ConanInfo.load_file(hello1_info)
+    hello1_conan_info = ConanInfo.loads(load(hello1_info))
     assert 0 == hello1_conan_info.options.language
 
 
@@ -107,13 +107,13 @@ def test_inverse_upper_option(client):
     hello0 = client.get_latest_pkg_layout(pref).package()
 
     hello0_info = os.path.join(hello0, CONANINFO)
-    hello0_conan_info = ConanInfo.load_file(hello0_info)
+    hello0_conan_info = ConanInfo.loads(load(hello0_info))
     assert "language=0" == hello0_conan_info.options.dumps()
 
     pref1 = client.get_latest_package_reference(RecipeReference.loads("hello1/0.1@lasote/stable"), package_id2)
     hello1 = client.get_latest_pkg_layout(pref1).package()
     hello1_info = os.path.join(hello1, CONANINFO)
-    hello1_conan_info = ConanInfo.load_file(hello1_info)
+    hello1_conan_info = ConanInfo.loads(load(hello1_info))
     assert "language=1" == hello1_conan_info.options.dumps()
 
 
@@ -134,11 +134,11 @@ def test_upper_option_txt(client):
     pref = client.get_latest_package_reference(ref, package_id)
     hello0 = client.get_latest_pkg_layout(pref).package()
     hello0_info = os.path.join(hello0, CONANINFO)
-    hello0_conan_info = ConanInfo.load_file(hello0_info)
+    hello0_conan_info = ConanInfo.loads(load(hello0_info))
     assert 1 == hello0_conan_info.options.language
 
     pref1 = client.get_latest_package_reference(RecipeReference.loads("hello1/0.1@lasote/stable"), package_id2)
     hello1 = client.get_latest_pkg_layout(pref1).package()
     hello1_info = os.path.join(hello1, CONANINFO)
-    hello1_conan_info = ConanInfo.load_file(hello1_info)
+    hello1_conan_info = ConanInfo.loads(load(hello1_info))
     assert 0 == hello1_conan_info.options.language

--- a/conans/test/integration/remote/test_request_headers.py
+++ b/conans/test/integration/remote/test_request_headers.py
@@ -3,7 +3,6 @@ import unittest
 
 import pytest
 
-from conans.client.remote_manager import CONAN_REQUEST_HEADER_SETTINGS, CONAN_REQUEST_HEADER_OPTIONS
 from conans.test.assets.genconanfile import GenConanfile
 from conans.test.utils.tools import TestClient, TestServer, TestRequester
 

--- a/conans/test/unittests/model/settings_test.py
+++ b/conans/test/unittests/model/settings_test.py
@@ -24,7 +24,7 @@ class SettingsLoadsTest(unittest.TestCase):
         self.assertEqual("os=Windows", settings.values.dumps())
 
     def test_any(self):
-        yml = "os: ANY"
+        yml = "os: [ANY]"
         settings = Settings.loads(yml)
         with self.assertRaisesRegex(ConanException, "'settings.os' value not defined"):
             settings.validate()  # Raise exception if unset
@@ -135,7 +135,7 @@ class SettingsTest(unittest.TestCase):
         self.assertEqual(settings.values.sha, other_settings.values.sha)
 
     def test_any(self):
-        data = {"target": "ANY"}
+        data = {"target": ["ANY"]}
         sut = Settings(data)
         sut.target = "native"
         self.assertTrue(sut.target == "native")


### PR DESCRIPTION
- The "ANY" needs to be a list element, not unique value
- Removed dead ``_headers_for_info``, that send settings header to server. We might want to recover this, but atm it is dead code.
- Remove ``apple_clang_compatible`` legacy from 1.X
- Remove unused ``load_from_package()`` method