### PR TITLE
[poc] try serializing the whole conaninfo.txt without parsing it

### DIFF
--- a/conans/client/remote_manager.py
+++ b/conans/client/remote_manager.py
@@ -1,4 +1,3 @@
-import base64
 import os
 import shutil
 import time

--- a/conans/client/remote_manager.py
+++ b/conans/client/remote_manager.py
@@ -227,9 +227,9 @@ class RemoteManager(object):
         return self._call_remote(remote, "search", pattern, ignorecase)
 
     def search_packages(self, remote, ref, query):
-        packages = self._call_remote(remote, "search_packages", ref, query)
+        packages = self._call_remote(remote, "search_packages", ref)
         # Avoid serializing conaninfo in server side
-        packages = {pid: ConanInfo.loads(base64.b64decode(data["content"].encode("utf-8")).decode("utf-8")).serialize_min()
+        packages = {pid: ConanInfo.loads(data["content"]).serialize_min()
                     if "content" in data else data
                     for pid, data in packages.items()}
         # Filter packages without recipe_hash, those are 1.X packages, the 2.0 are disregarded

--- a/conans/client/rest/client_routes.py
+++ b/conans/client/rest/client_routes.py
@@ -57,13 +57,11 @@ class ClientCommonRouter(object):
             query = "?%s" % urlencode(params)
         return self.base_url + "%s%s" % (self.routes.common_search, query)
 
-    def search_packages(self, ref, query=None):
+    def search_packages(self, ref):
         """URL search packages for a recipe"""
         route = self.routes.common_search_packages_revision \
             if ref.revision else self.routes.common_search_packages
         url = _format_ref(route, ref)
-        if query:
-            url += "?%s" % urlencode({"q": query})
         return self.base_url + url
 
     def oauth_authenticate(self):
@@ -92,9 +90,9 @@ class ClientV1Router(ClientCommonRouter):
             ret[filename] = url.replace("v1/files/", "v1/files{}/".format(self._matrix_params_str))
         return ret
 
-    def search_packages(self, ref, query=None):
+    def search_packages(self, ref):
         ref = ref.copy_clear_rev()
-        return super(ClientV1Router, self).search_packages(ref, query)
+        return super(ClientV1Router, self).search_packages(ref)
 
     def remove_recipe(self, ref):
         """Remove recipe"""

--- a/conans/client/rest/rest_client.py
+++ b/conans/client/rest/rest_client.py
@@ -137,11 +137,8 @@ class RestApiClient(object):
     def search(self, pattern=None, ignorecase=True):
         return self._get_api().search(pattern, ignorecase)
 
-    def search_packages(self, reference, query):
-        # Do not send the query to the server, as it will fail
-        # https://github.com/conan-io/conan/issues/4951
-        package_infos = self._get_api().search_packages(reference, query=None)
-        return filter_packages(query, package_infos)
+    def search_packages(self, reference):
+        return self._get_api().search_packages(reference)
 
     def remove_recipe(self, ref):
         return self._get_api().remove_conanfile(ref)

--- a/conans/client/rest/rest_client_common.py
+++ b/conans/client/rest/rest_client_common.py
@@ -244,8 +244,8 @@ class RestCommonMethods(object):
         response = self.get_json(url)["results"]
         return [ConanFileReference.loads(reference) for reference in response]
 
-    def search_packages(self, ref, query):
+    def search_packages(self, ref):
         """Client is filtering by the query"""
-        url = self.router.search_packages(ref, query)
+        url = self.router.search_packages(ref)
         package_infos = self.get_json(url)
         return package_infos

--- a/conans/client/rest/rest_client_v1.py
+++ b/conans/client/rest/rest_client_v1.py
@@ -312,7 +312,7 @@ class RestV1Methods(RestCommonMethods):
         if not package_ids and ret.status_code == 404:
             # Double check if it is a 404 because there are no packages
             try:
-                if not self.search_packages(ref, query=None):
+                if not self.search_packages(ref):
                     return namedtuple("_", ['status_code', 'content'])(200, b'')
             except Exception as e:
                 logger.warning("Unexpected error searching {} packages"

--- a/conans/server/service/common/search.py
+++ b/conans/server/service/common/search.py
@@ -33,9 +33,8 @@ def _get_local_infos_min(server_store, ref, look_in_all_rrevs):
                 info_path = os.path.join(server_store.package(pref), CONANINFO)
                 if not os.path.exists(info_path):
                     raise NotFoundException("")
-                conan_info_content = load(info_path)
-                encoded = base64.b64encode(conan_info_content.encode("utf-8")).decode("utf-8")
-                result[package_id] = {"content": encoded}
+                content = load(info_path)
+                result[package_id] = {"content": content}
             except Exception as exc:  # FIXME: Too wide
                 logger.error("Package %s has no ConanInfo file" % str(pref))
                 if str(exc):
@@ -61,7 +60,8 @@ def search_packages(server_store, ref, query, look_in_all_rrevs):
     if not os.path.exists(server_store.conan_revisions_root(ref.copy_clear_rev())):
         raise RecipeNotFoundException(ref)
     infos = _get_local_infos_min(server_store, ref, look_in_all_rrevs)
-    return filter_packages(query, infos)
+    assert query is None, "The server is not filtering packages remotely anymore"
+    return infos
 
 
 class SearchService(object):

--- a/conans/server/service/common/search.py
+++ b/conans/server/service/common/search.py
@@ -1,4 +1,3 @@
-import base64
 import os
 import re
 from fnmatch import translate

--- a/conans/server/service/common/search.py
+++ b/conans/server/service/common/search.py
@@ -1,10 +1,10 @@
+import base64
 import os
 import re
 from fnmatch import translate
 
 from conans import load
 from conans.errors import NotFoundException, ForbiddenException, RecipeNotFoundException
-from conans.model.info import ConanInfo
 from conans.model.ref import PackageReference, ConanFileReference
 from conans.paths import CONANINFO
 from conans.search.search import filter_packages, _partial_match
@@ -34,9 +34,8 @@ def _get_local_infos_min(server_store, ref, look_in_all_rrevs):
                 if not os.path.exists(info_path):
                     raise NotFoundException("")
                 conan_info_content = load(info_path)
-                info = ConanInfo.loads(conan_info_content)
-                conan_vars_info = info.serialize_min()
-                result[package_id] = conan_vars_info
+                encoded = base64.b64encode(conan_info_content.encode("utf-8")).decode("utf-8")
+                result[package_id] = {"content": encoded}
             except Exception as exc:  # FIXME: Too wide
                 logger.error("Package %s has no ConanInfo file" % str(pref))
                 if str(exc):

--- a/conans/test/functional/command/devflow_test.py
+++ b/conans/test/functional/command/devflow_test.py
@@ -232,6 +232,7 @@ class DevOutSourceFlowTest(unittest.TestCase):
                                             os.listdir(cache_package_folder)[0])
         self._assert_pkg(cache_package_folder)
 
+    @pytest.mark.tool_cmake
     def test_build_local_different_folders(self):
         # Real build, needed to ensure that the generator is put in the correct place and
         # cmake finds it, using an install_folder different from build_folder

--- a/conans/test/integration/remote/rest_api_test.py
+++ b/conans/test/integration/remote/rest_api_test.py
@@ -204,8 +204,9 @@ class RestApiTest(unittest.TestCase):
         self._upload_recipe(ref2)
 
         # Get the info about this ConanFileReference
-        info = self.api.search_packages(ref1, None)
-        self.assertEqual(ConanInfo.loads(conan_info).serialize_min(), info["1F23223EFDA"])
+        info = self.api.search_packages(ref1)
+        self.assertEqual(ConanInfo.loads(conan_info).serialize_min(),
+                         ConanInfo.loads(info["1F23223EFDA"]["content"]).serialize_min())
 
         # Search packages
         results = self.api.search("HelloOnly*", ignorecase=False)
@@ -239,7 +240,7 @@ class RestApiTest(unittest.TestCase):
             self.assertTrue(os.path.exists(folder))
             folders[sha] = folder
 
-        data = self.api.search_packages(ref, None)
+        data = self.api.search_packages(ref)
         self.assertEqual(len(data), 5)
 
         self.api.remove_packages(ref, ["1"])

--- a/conans/test/integration/remote/test_conaninfo_parsing.py
+++ b/conans/test/integration/remote/test_conaninfo_parsing.py
@@ -19,8 +19,8 @@ def test_conaninfo_special_chars():
     class Recipe(ConanFile):
         name = "weird_info"
         version = "1.0"
-        options = {"ññ¨¨&是": ['是"是', "是是是"]}
-        default_options = {"ññ¨¨&是": '是"是'}
+        options = {"ññ¨¨&是": ['是"是', '][{}"是是是']}
+        default_options = {"ññ¨¨&是": '][{}"是是是'}
 
     """)
 
@@ -29,4 +29,4 @@ def test_conaninfo_special_chars():
     t.run("upload * -c -r default --all")
 
     t.run('search weird_info/1.0@ -r default')
-    assert 'ññ¨¨&是: 是"是' in t.out
+    assert 'ññ¨¨&是: ][{}"是是是' in t.out

--- a/conans/test/integration/remote/test_conaninfo_parsing.py
+++ b/conans/test/integration/remote/test_conaninfo_parsing.py
@@ -1,0 +1,25 @@
+import textwrap
+
+from conans.test.utils.tools import TestClient
+
+
+def test_conaninfo_special_chars():
+
+    t = TestClient(default_server_user=True)
+    conanfile = textwrap.dedent("""
+    from conan import ConanFile
+
+    class Recipe(ConanFile):
+        name = "weird_info"
+        version = "1.0"
+        options = {"ññ¨¨&是": ['是"是', "是是是"]}
+        default_options = {"ññ¨¨&是": '是"是'}
+
+    """)
+
+    t.save({"conanfile.py": conanfile})
+    t.run("create . ")
+    t.run("upload * -c -r default --all")
+
+    t.run('search weird_info/1.0@ -r default')
+    assert 'ññ¨¨&是: 是"是' in t.out

--- a/conans/test/integration/remote/test_conaninfo_parsing.py
+++ b/conans/test/integration/remote/test_conaninfo_parsing.py
@@ -1,3 +1,5 @@
+# coding=utf-8
+
 import textwrap
 
 from conans.test.utils.tools import TestClient
@@ -7,6 +9,7 @@ def test_conaninfo_special_chars():
 
     t = TestClient(default_server_user=True)
     conanfile = textwrap.dedent("""
+    # coding=utf-8
     from conan import ConanFile
 
     class Recipe(ConanFile):

--- a/conans/test/integration/remote/test_conaninfo_parsing.py
+++ b/conans/test/integration/remote/test_conaninfo_parsing.py
@@ -2,9 +2,13 @@
 
 import textwrap
 
+import pytest
+import six
+
 from conans.test.utils.tools import TestClient
 
 
+@pytest.mark.skipif(six.PY2, reason="only Py3")
 def test_conaninfo_special_chars():
 
     t = TestClient(default_server_user=True)

--- a/conans/test/unittests/server/service/service_test.py
+++ b/conans/test/unittests/server/service/service_test.py
@@ -216,10 +216,20 @@ class ConanServiceTest(unittest.TestCase):
         self.assertEqual(info, [ref3.copy_clear_rev()])
 
         info = self.search_service.search_packages(ref2, None)
-        self.assertEqual(info, {'12345587754': {'content': '\n[options]\n    use_Qt=False\n'}})
+        self.assertEqual(info, {'12345587754': {'content': '\n[options]\n    use_Qt=False\n',
+                                                'full_requires': [],
+                                                'options': {'use_Qt': 'False'},
+                                                'recipe_hash': None,
+                                                'settings': {}
+                                                }})
 
         info = self.search_service.search_packages(ref3, None)
-        self.assertEqual(info, {'77777777777': {'content': '\n[options]\n    use_Qt=True\n'}})
+        self.assertEqual(info, {'77777777777': {'content': '\n[options]\n    use_Qt=True\n',
+                                                'full_requires': [],
+                                                'options': {'use_Qt': 'True'},
+                                                'recipe_hash': None,
+                                                'settings': {}}
+                                })
 
     def test_remove(self):
         ref2 = ConanFileReference("OpenCV", "3.0", "lasote", "stable", DEFAULT_REVISION_V1)

--- a/conans/test/unittests/server/service/service_test.py
+++ b/conans/test/unittests/server/service/service_test.py
@@ -216,16 +216,10 @@ class ConanServiceTest(unittest.TestCase):
         self.assertEqual(info, [ref3.copy_clear_rev()])
 
         info = self.search_service.search_packages(ref2, None)
-        self.assertEqual(info, {'12345587754': {'full_requires': [],
-                                                'options': {'use_Qt': 'False'},
-                                                'settings': {},
-                                                'recipe_hash': None}})
+        self.assertEqual(info, {'12345587754': {'content': '\n[options]\n    use_Qt=False\n'}})
 
         info = self.search_service.search_packages(ref3, None)
-        self.assertEqual(info, {'77777777777': {'full_requires': [],
-                                                'options': {'use_Qt': 'True'},
-                                                'settings': {},
-                                                'recipe_hash': None}})
+        self.assertEqual(info, {'77777777777': {'content': '\n[options]\n    use_Qt=True\n'}})
 
     def test_remove(self):
         ref2 = ConanFileReference("OpenCV", "3.0", "lasote", "stable", DEFAULT_REVISION_V1)


### PR DESCRIPTION
Changelog: omit
Docs: omit

This might help with the serialization issue of the ``conaninfo.txt`` that happens from server->client when doing a ``conan search <pkg-ref>`` to list binary configurations. In 2.0, the format changes, new fields might be added. The serialization is baked in servers like Artifactory and will break in 2.0 for this case.

Open questions:
- Robustness. Can something break? The payload of the Rest API is json.
