### PR TITLE
Added unrelated_mode to python requires

### DIFF
--- a/conans/model/info.py
+++ b/conans/model/info.py
@@ -349,6 +349,9 @@ class PythonRequireInfo(object):
         self._channel = self._ref.channel
         self._revision = self._ref.revision
 
+    def unrelated_mode(self):
+        self._name = self._version = self._user = self._channel = self._revision = None
+
 
 class PythonRequiresInfo(object):
 

--- a/conans/test/integration/package_id/python_requires_package_id_test.py
+++ b/conans/test/integration/package_id/python_requires_package_id_test.py
@@ -50,6 +50,19 @@ class PythonRequiresPackageIDTest(unittest.TestCase):
         self.assertIn("tool/1.1.2", self.client2.out)
         self.assertIn("pkg/0.1:387c1c797a011d426ecb25a1e01b28251e443ec8 - Build", self.client2.out)
 
+    def test_unrelated_conf(self):
+        # change the policy in conan.conf
+        self.client2.run("config set general.default_python_requires_id_mode=unrelated_mode")
+        self.client2.run("create . pkg/0.1@")
+        self.assertIn("tool/1.1.1", self.client2.out)
+        self.assertIn("pkg/0.1:c941ae50e2daf4a118c393591cfef6a55cd1cfad - Build", self.client2.out)
+
+        # with any change the package id doesn't change
+        self.client.run("export . tool/1.1.2@")
+        self.client2.run("create . pkg/0.1@ --build missing")
+        self.assertIn("tool/1.1.2", self.client2.out)
+        self.assertIn("pkg/0.1:c941ae50e2daf4a118c393591cfef6a55cd1cfad - Cache", self.client2.out)
+
     def test_change_mode_package_id(self):
         # change the policy in package_id
         conanfile = textwrap.dedent("""


### PR DESCRIPTION
Changelog: Bugfix: The config `default_python_requires_id_mode=unrelated_mode` raised an error, it has been fixed.
Docs: omit

Close #10954