### PR TITLE
json_generator with layout() method accessing dependency version field

### DIFF
--- a/conans/client/generators/json_generator.py
+++ b/conans/client/generators/json_generator.py
@@ -3,26 +3,6 @@ import json
 from conans.model import Generator
 
 
-def serialize_cpp_info(cpp_info):
-    keys = [
-        "version",
-        "description",
-        "rootpath",
-        "sysroot",
-        "include_paths", "lib_paths", "bin_paths", "build_paths", "res_paths",
-        "libs",
-        "system_libs",
-        "defines", "cflags", "cxxflags", "sharedlinkflags", "exelinkflags",
-        "frameworks", "framework_paths", "names", "filenames",
-        "build_modules", "build_modules_paths"
-    ]
-    res = {}
-    for key in keys:
-        res[key] = getattr(cpp_info, key)
-    res["cppflags"] = cpp_info.cxxflags  # Backwards compatibility
-    return res
-
-
 def serialize_user_info(user_info):
     res = {}
     for key, value in user_info.items():
@@ -51,10 +31,10 @@ class JsonGenerator(Generator):
     def get_dependencies_info(self):
         res = []
         for depname, cpp_info in self.deps_build_info.dependencies:
-            serialized_info = serialize_cpp_info(cpp_info)
-            serialized_info["name"] = depname
+            serialized_info = self.serialize_cpp_info(depname, cpp_info)
             for cfg, cfg_cpp_info in cpp_info.configs.items():
-                serialized_info.setdefault("configs", {})[cfg] = serialize_cpp_info(cfg_cpp_info)
+                serialized_info.setdefault("configs", {})[cfg] = self.serialize_cpp_info(depname,
+                                                                                         cfg_cpp_info)
             res.append(serialized_info)
         return res
 
@@ -71,3 +51,31 @@ class JsonGenerator(Generator):
             for key, value in self.conanfile.options[req].items():
                 options[req][key] = value
         return options
+
+    def serialize_cpp_info(self, depname, cpp_info):
+        keys = [
+            "version",
+            "description",
+            "rootpath",
+            "sysroot",
+            "include_paths", "lib_paths", "bin_paths", "build_paths", "res_paths",
+            "libs",
+            "system_libs",
+            "defines", "cflags", "cxxflags", "sharedlinkflags", "exelinkflags",
+            "frameworks", "framework_paths", "names", "filenames",
+            "build_modules", "build_modules_paths"
+        ]
+        res = {}
+        for key in keys:
+            res[key] = getattr(cpp_info, key)
+        res["cppflags"] = cpp_info.cxxflags  # Backwards compatibility
+        res["name"] = depname
+
+        # FIXME: trick for NewCppInfo objects when declared layout
+        if cpp_info.version is None:
+            try:
+                res["version"] = self.conanfile.dependencies.get(depname).ref.version
+            except Exception:
+                pass
+
+        return res

--- a/conans/client/generators/json_generator.py
+++ b/conans/client/generators/json_generator.py
@@ -72,10 +72,10 @@ class JsonGenerator(Generator):
         res["name"] = depname
 
         # FIXME: trick for NewCppInfo objects when declared layout
-        if cpp_info.version is None:
-            try:
+        try:
+            if cpp_info.version is None:
                 res["version"] = self.conanfile.dependencies.get(depname).ref.version
-            except Exception:
-                pass
+        except Exception:
+            pass
 
         return res

--- a/conans/test/integration/generators/json_test.py
+++ b/conans/test/integration/generators/json_test.py
@@ -13,6 +13,9 @@ class JsonTest(unittest.TestCase):
 
 class HelloConan(ConanFile):
     exports_sources = "*.h"
+    description = "foo"
+    def layout(self):
+        pass
     def package(self):
         self.copy("*.h", dst="include")
     def package_info(self):
@@ -26,7 +29,8 @@ class HelloConan(ConanFile):
         client.run("install Hello/0.1@lasote/testing -g json")
         conan_json = client.load("conanbuildinfo.json")
         data = json.loads(conan_json)
-
+        self.assertEqual(data["dependencies"][0]["version"], "0.1")
+        self.assertIsNone(data["dependencies"][0]["description"])
         self.assertEqual(data["deps_env_info"]["MY_ENV_VAR"], "foo")
         self.assertEqual(data["deps_user_info"]["Hello"]["my_var"], "my_value")
 
@@ -103,9 +107,6 @@ class HelloConan(ConanFile):
         self.assertEqual(deps_info_release["libs"], ["Hello"])
 
         # FIXME: There are _null_ nodes
-        self.assertEqual(deps_info_debug["version"], None)
-        self.assertEqual(deps_info_release["version"], None)
-
         self.assertEqual(deps_info_debug["description"], None)
         self.assertEqual(deps_info_release["description"], None)
 


### PR DESCRIPTION
Changelog: Bugfix: The `json` generator was showing "None" in the `version` field of the dependencies when the `layout()` method was used.
Docs: omit

Close #10956 

To discuss if we consider this should be fixed given that the "layout()" feature is a 2.0 feature and json generator doesn't exist anymore.
Pure refactor plus adding these dirty lines:

```
if cpp_info.version is None:
    try:
        res["version"] = self.conanfile.dependencies.get(depname).ref.version
    except Exception:
        pass
```