### PR TITLE
[MSBuildToolchain][conf] Adding extra flags to `MSBuildToolchain`

### DIFF
--- a/conan/tools/microsoft/msbuilddeps.py
+++ b/conan/tools/microsoft/msbuilddeps.py
@@ -184,8 +184,7 @@ class MSBuildDeps(object):
             'system_libs': "".join([add_valid_ext(sys_dep) for sys_dep in cpp_info.system_libs]),
             'definitions': "".join("%s;" % d for d in cpp_info.defines),
             'compiler_flags': " ".join(cpp_info.cxxflags + cpp_info.cflags),
-            'linker_flags': " ".join(cpp_info.sharedlinkflags),
-            'exe_flags': " ".join(cpp_info.exelinkflags),
+            'linker_flags': " ".join(cpp_info.sharedlinkflags + cpp_info.exelinkflags),
             'dependencies': ";".join(deps) if not build else "",
             'host_context': not build
         }

--- a/conan/tools/microsoft/toolchain.py
+++ b/conan/tools/microsoft/toolchain.py
@@ -130,13 +130,13 @@ class MSBuildToolchain(object):
         def format_macro(key, value):
             return '%s=%s' % (key, value) if value is not None else key
 
-        extra_flags = self._get_extra_flags()
+        cxxflags, cflags, defines, sharedlinkflags, exelinkflags = self._get_extra_flags()
         preprocessor_definitions = "".join(["%s;" % format_macro(k, v)
                                             for k, v in self.preprocessor_definitions.items()])
-        defines = preprocessor_definitions + "".join("%s;" % d for d in extra_flags["defines"])
-        self.cxxflags.extend(extra_flags["cxxflags"])
-        self.cflags.extend(extra_flags["cflags"])
-        self.ldflags.extend(extra_flags["sharedlinkflags"] + extra_flags["exelinkflags"])
+        defines = preprocessor_definitions + "".join("%s;" % d for d in defines)
+        self.cxxflags.extend(cxxflags)
+        self.cflags.extend(cflags)
+        self.ldflags.extend(sharedlinkflags + exelinkflags)
 
         cppstd = "stdcpp%s" % self.cppstd if self.cppstd else ""
         runtime_library = self.runtime_library
@@ -220,10 +220,4 @@ class MSBuildToolchain(object):
         sharedlinkflags = self._conanfile.conf.get("tools.build:sharedlinkflags", default=[], check_type=list)
         exelinkflags = self._conanfile.conf.get("tools.build:exelinkflags", default=[], check_type=list)
         defines = self._conanfile.conf.get("tools.build:defines", default=[], check_type=list)
-        return {
-            "cxxflags": cxxflags,
-            "cflags": cflags,
-            "defines": defines,
-            "sharedlinkflags": sharedlinkflags,
-            "exelinkflags": exelinkflags
-        }
+        return cxxflags, cflags, defines, sharedlinkflags, exelinkflags

--- a/conan/tools/microsoft/toolchain.py
+++ b/conan/tools/microsoft/toolchain.py
@@ -2,6 +2,8 @@ import os
 import textwrap
 from xml.dom import minidom
 
+from jinja2 import Template
+
 from conan.tools._check_build_profile import check_using_build_profile
 from conan.tools.build import build_jobs
 from conan.tools.intel.intel_cc import IntelCC
@@ -14,8 +16,34 @@ class MSBuildToolchain(object):
 
     filename = "conantoolchain.props"
 
+    _config_toolchain_props = textwrap.dedent("""\
+        <?xml version="1.0" encoding="utf-8"?>
+        <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+          <ItemDefinitionGroup>
+            <ClCompile>
+              <PreprocessorDefinitions>{{ defines }}%(PreprocessorDefinitions)</PreprocessorDefinitions>
+              <AdditionalOptions>{{ compiler_flags }} %(AdditionalOptions)</AdditionalOptions>
+              <RuntimeLibrary>{{ runtime_library }}</RuntimeLibrary>
+              <LanguageStandard>{{ cppstd }}</LanguageStandard>{{ parallel }}{{ compile_options }}
+            </ClCompile>
+            <Link>
+              <AdditionalOptions>{{ linker_flags }} %(AdditionalOptions)</AdditionalOptions>
+            </Link>
+            <ResourceCompile>
+              <PreprocessorDefinitions>{{ defines }}%(PreprocessorDefinitions)</PreprocessorDefinitions>
+              <AdditionalOptions>{{ compiler_flags }} %(AdditionalOptions)</AdditionalOptions>
+            </ResourceCompile>
+          </ItemDefinitionGroup>
+          <PropertyGroup Label="Configuration">
+            <PlatformToolset>{{ toolset }}</PlatformToolset>
+          </PropertyGroup>
+        </Project>
+    """)
+
     def __init__(self, conanfile):
         self._conanfile = conanfile
+        self.compiler_flags = []
+        self.linker_flags = []
         self.preprocessor_definitions = {}
         self.compile_options = {}
         self.configuration = conanfile.settings.build_type
@@ -94,36 +122,17 @@ class MSBuildToolchain(object):
                                "MDd": "MultiThreadedDebugDLL"}.get(runtime, "")
         return runtime_library
 
-    def _write_config_toolchain(self, config_filename):
-
+    @property
+    def context_config_toolchain(self):
         def format_macro(key, value):
             return '%s=%s' % (key, value) if value is not None else key
 
-        toolchain_file = textwrap.dedent("""\
-            <?xml version="1.0" encoding="utf-8"?>
-            <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-              <ItemDefinitionGroup>
-                <ClCompile>
-                  <PreprocessorDefinitions>
-                     {};%(PreprocessorDefinitions)
-                  </PreprocessorDefinitions>
-                  <RuntimeLibrary>{}</RuntimeLibrary>
-                  <LanguageStandard>{}</LanguageStandard>{}{}
-                </ClCompile>
-                <ResourceCompile>
-                  <PreprocessorDefinitions>
-                     {};%(PreprocessorDefinitions)
-                  </PreprocessorDefinitions>
-                </ResourceCompile>
-              </ItemDefinitionGroup>
-              <PropertyGroup Label="Configuration">
-                <PlatformToolset>{}</PlatformToolset>
-              </PropertyGroup>
-            </Project>
-            """)
-        preprocessor_definitions = ";".join([format_macro(k, v)
-                                             for k, v in self.preprocessor_definitions.items()])
-
+        preprocessor_definitions = "".join(["%s;" % format_macro(k, v)
+                                            for k, v in self.preprocessor_definitions.items()])
+        extra_flags = self._get_extra_flags()
+        defines = preprocessor_definitions + "".join("%s;" % d for d in extra_flags["defines"])
+        compiler_flags = self.compiler_flags + extra_flags["compiler_flags"]
+        linker_flags = self.linker_flags + extra_flags["linker_flags"]
         cppstd = "stdcpp%s" % self.cppstd if self.cppstd else ""
         runtime_library = self.runtime_library
         toolset = self.toolset
@@ -138,10 +147,21 @@ class MSBuildToolchain(object):
                  "\n      <ProcessorNumber>{}</ProcessorNumber>".format(njobs)])
         compile_options = "".join("\n      <{k}>{v}</{k}>".format(k=k, v=v)
                                   for k, v in self.compile_options.items())
-        config_props = toolchain_file.format(preprocessor_definitions, runtime_library, cppstd,
-                                             parallel, compile_options, preprocessor_definitions,
-                                             toolset)
+        return {
+            'defines': defines,
+            'compiler_flags': " ".join(compiler_flags),
+            'linker_flags': " ".join(linker_flags),
+            "cppstd": cppstd,
+            "runtime_library": runtime_library,
+            "toolset": toolset,
+            "compile_options": compile_options,
+            "parallel": parallel
+        }
+
+    def _write_config_toolchain(self, config_filename):
         config_filepath = os.path.join(self._conanfile.generators_folder, config_filename)
+        config_props = Template(self._config_toolchain_props, trim_blocks=True,
+                                lstrip_blocks=True).render(**self.context_config_toolchain)
         self._conanfile.output.info("MSBuildToolchain created %s" % config_filename)
         save(config_filepath, config_props)
 
@@ -187,3 +207,16 @@ class MSBuildToolchain(object):
         conan_toolchain = "\n".join(line for line in conan_toolchain.splitlines() if line.strip())
         self._conanfile.output.info("MSBuildToolchain writing {}".format(self.filename))
         save(main_toolchain_path, conan_toolchain)
+
+    def _get_extra_flags(self):
+        # Now, it's time to get all the flags defined by the user
+        cxxflags = self._conanfile.conf.get("tools.build:cxxflags", default=[], check_type=list)
+        cflags = self._conanfile.conf.get("tools.build:cflags", default=[], check_type=list)
+        sharedlinkflags = self._conanfile.conf.get("tools.build:sharedlinkflags", default=[], check_type=list)
+        exelinkflags = self._conanfile.conf.get("tools.build:exelinkflags", default=[], check_type=list)
+        defines = self._conanfile.conf.get("tools.build:defines", default=[], check_type=list)
+        return {
+            "compiler_flags": cflags + cxxflags,
+            "defines": defines,
+            "linker_flags": sharedlinkflags + exelinkflags,
+        }

--- a/conans/test/functional/toolchains/microsoft/test_msbuildtoolchain.py
+++ b/conans/test/functional/toolchains/microsoft/test_msbuildtoolchain.py
@@ -44,7 +44,7 @@ def test_msbuildtoolchain_props_with_extra_flags():
     replace_in_file(MagicMock(), os.path.join(client.current_folder, "hello.vcxproj"),
                     r'  <ImportGroup Label="PropertySheets">', toolchain_props)
     client.run("create . -pr myprofile -tf None")
-    assert "/analyze:quiet /doc src/hell.cpp" in client.out
-    assert r"/VERBOSE:UNUSEDLIBS /PDB:mypdbfile x64\Release\hell.obj" in client.out
+    assert "/analyze:quiet /doc src/hello.cpp" in client.out
+    assert r"/VERBOSE:UNUSEDLIBS /PDB:mypdbfile x64\Release\hello.obj" in client.out
     assert "/D DEF1 /D DEF2" in client.out
     assert "Build succeeded." in client.out

--- a/conans/test/functional/toolchains/microsoft/test_msbuildtoolchain.py
+++ b/conans/test/functional/toolchains/microsoft/test_msbuildtoolchain.py
@@ -40,6 +40,7 @@ def test_msbuildtoolchain_props_with_extra_flags():
     client.save({
         "myprofile": profile
     })
+    # Let's import manually the created conantoolchain_release_x64.props
     replace_in_file(MagicMock(), os.path.join(client.current_folder, "hello.vcxproj"),
                     r'  <ImportGroup Label="PropertySheets">', toolchain_props)
     client.run("create . -pr myprofile -tf None")

--- a/conans/test/functional/toolchains/microsoft/test_msbuildtoolchain.py
+++ b/conans/test/functional/toolchains/microsoft/test_msbuildtoolchain.py
@@ -1,0 +1,49 @@
+import platform
+import textwrap
+import os
+
+import pytest
+try:
+    from unittest.mock import MagicMock
+except:
+    from mock import MagicMock
+
+from conan.tools.files import replace_in_file
+from conans.test.utils.tools import TestClient
+
+toolchain_props = """
+  <ImportGroup Label="PropertySheets">
+      <Import Project="conan\\conantoolchain_release_x64.props" />
+"""
+
+
+@pytest.mark.skipif(platform.system() not in ["Windows"], reason="Requires Windows")
+def test_msbuildtoolchain_props_with_extra_flags():
+    """
+    Real test which is injecting some compiler/linker options and other dummy defines and
+    checking that they are being processed somehow.
+
+    Expected result: everything was built successfully.
+    """
+    profile = textwrap.dedent("""\
+    include(default)
+
+    [conf]
+    tools.build:cxxflags=["/analyze:quiet"]
+    tools.build:cflags+=["/doc"]
+    tools.build:sharedlinkflags+=["/VERBOSE:UNUSEDLIBS"]
+    tools.build:exelinkflags+=["/PDB:mypdbfile"]
+    tools.build:defines+=["DEF1", "DEF2"]
+    """)
+    client = TestClient(path_with_spaces=False)
+    client.run("new hello/0.1 --template=msbuild_exe")
+    client.save({
+        "myprofile": profile
+    })
+    replace_in_file(MagicMock(), os.path.join(client.current_folder, "hello.vcxproj"),
+                    r'  <ImportGroup Label="PropertySheets">', toolchain_props)
+    client.run("create . -pr myprofile -tf None")
+    assert "/analyze:quiet /doc src/hell.cpp" in client.out
+    assert r"/VERBOSE:UNUSEDLIBS /PDB:mypdbfile x64\Release\hell.obj" in client.out
+    assert "/D DEF1 /D DEF2" in client.out
+    assert "Build succeeded." in client.out

--- a/conans/test/integration/toolchains/microsoft/test_msbuildtoolchain.py
+++ b/conans/test/integration/toolchains/microsoft/test_msbuildtoolchain.py
@@ -1,0 +1,44 @@
+import os
+import textwrap
+
+from conans.test.utils.tools import TestClient
+
+
+def test_msbuildtoolchain_props_with_extra_flags():
+    """
+    Simple test checking that conantoolchain_release_x64.props is adding all the expected
+    flags and preprocessor definitions
+    """
+    profile = textwrap.dedent("""\
+    include(default)
+    [conf]
+    tools.build:cxxflags=["--flag1", "--flag2"]
+    tools.build:cflags+=["--flag3", "--flag4"]
+    tools.build:sharedlinkflags+=["--flag5"]
+    tools.build:exelinkflags+=["--flag6"]
+    tools.build:defines+=["DEF1", "DEF2"]
+    """)
+    client = TestClient(path_with_spaces=False)
+    client.run("new hello/0.1 --template=msbuild_lib")
+    client.save({
+        "myprofile": profile
+    })
+    # Local flow works
+    client.run("install . -pr myprofile -if=install")
+    toolchain = client.load(os.path.join("conan", "conantoolchain_release_x64.props"))
+    expected_cl_compile = """
+    <ClCompile>
+      <PreprocessorDefinitions>DEF1;DEF2;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalOptions>--flag1 --flag2 --flag3 --flag4 %(AdditionalOptions)</AdditionalOptions>"""
+    expected_link = """
+    <Link>
+      <AdditionalOptions>--flag5 --flag6 %(AdditionalOptions)</AdditionalOptions>
+    </Link>"""
+    expected_resource_compile = """
+    <ResourceCompile>
+      <PreprocessorDefinitions>DEF1;DEF2;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalOptions>--flag1 --flag2 --flag3 --flag4 %(AdditionalOptions)</AdditionalOptions>
+    </ResourceCompile>"""
+    assert expected_cl_compile in toolchain
+    assert expected_link in toolchain
+    assert expected_resource_compile in toolchain

--- a/conans/test/unittests/tools/microsoft/test_msbuild.py
+++ b/conans/test/unittests/tools/microsoft/test_msbuild.py
@@ -139,7 +139,9 @@ def test_resource_compile():
           <PreprocessorDefinitions>
              MYTEST=MYVALUE;%(PreprocessorDefinitions)
           </PreprocessorDefinitions>
+          <AdditionalOptions> %(AdditionalOptions)</AdditionalOptions>
         </ResourceCompile>"""
+
     props_file = load(props_file)  # Remove all blanks and CR to compare
     props_file = "".join(s.strip() for s in props_file.splitlines())
     assert "".join(s.strip() for s in expected.splitlines()) in props_file

--- a/conans/test/unittests/tools/microsoft/test_msbuild.py
+++ b/conans/test/unittests/tools/microsoft/test_msbuild.py
@@ -215,3 +215,50 @@ def test_is_msvc_static_runtime(compiler, shared, runtime, build_type, expected)
                              "cppstd": "17"})
     conanfile = MockConanfile(settings, options)
     assert is_msvc_static_runtime(conanfile) == expected
+
+
+def test_msbuildtoolchain_changing_flags_via_attributes():
+    test_folder = temp_folder()
+
+    settings = Settings({"build_type": ["Release"],
+                         "compiler": {"msvc": {"version": ["193"], "cppstd": ["20"]}},
+                         "os": ["Windows"],
+                         "arch": ["x86_64"]})
+    conanfile = ConanFile(Mock(), None)
+    conanfile.folders.set_base_generators(test_folder)
+    conanfile.folders.set_base_install(test_folder)
+    conanfile.conf = Conf()
+    conanfile.conf["tools.microsoft.msbuild:installation_path"] = "."
+    conanfile.settings = "os", "compiler", "build_type", "arch"
+    conanfile.settings_build = settings
+    conanfile.initialize(settings, EnvValues())
+    conanfile.settings.build_type = "Release"
+    conanfile.settings.compiler = "msvc"
+    conanfile.settings.compiler.version = "193"
+    conanfile.settings.compiler.cppstd = "20"
+    conanfile.settings.os = "Windows"
+    conanfile.settings.arch = "x86_64"
+
+    msbuild = MSBuildToolchain(conanfile)
+    msbuild.cxxflags.append("/flag1")
+    msbuild.cflags.append("/flag2")
+    msbuild.ldflags.append("/link1")
+    msbuild.generate()
+    toolchain = load(os.path.join(test_folder, "conantoolchain_release_x64.props"))
+
+    expected_cl_compile = """
+    <ClCompile>
+      <PreprocessorDefinitions>%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalOptions>/flag1 /flag2 %(AdditionalOptions)</AdditionalOptions>"""
+    expected_link = """
+    <Link>
+      <AdditionalOptions>/link1 %(AdditionalOptions)</AdditionalOptions>
+    </Link>"""
+    expected_resource_compile = """
+    <ResourceCompile>
+      <PreprocessorDefinitions>%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalOptions>/flag1 /flag2 %(AdditionalOptions)</AdditionalOptions>
+    </ResourceCompile>"""
+    assert expected_cl_compile in toolchain
+    assert expected_link in toolchain
+    assert expected_resource_compile in toolchain


### PR DESCRIPTION
Changelog: Feature: Added `cxxflags`, `cflags`, and `ldflags` attributes to `MSBuildToolchain`.
Changelog: Feature: Added mechanism to inject extra flags to `MSBuildToolchain` via `[conf]`.
Closes: https://github.com/conan-io/conan/issues/10885
Docs: https://github.com/conan-io/docs/pull/2507

