### PR TITLE
[conan.tools.cmake] Modernized `add_definitions`

### DIFF
--- a/conan/tools/cmake/toolchain/blocks.py
+++ b/conan/tools/cmake/toolchain/blocks.py
@@ -157,7 +157,7 @@ class GLibCXXBlock(Block):
         string(APPEND CONAN_CXX_FLAGS " {{ set_libcxx }}")
         {% endif %}
         {% if glibcxx %}
-        add_definitions(-D_GLIBCXX_USE_CXX11_ABI={{ glibcxx }})
+        add_compile_definitions(_GLIBCXX_USE_CXX11_ABI={{ glibcxx }})
         {% endif %}
         """)
 
@@ -545,7 +545,7 @@ class ExtraFlagsBlock(Block):
         string(APPEND CONAN_EXE_LINKER_FLAGS "{% for exelinkflag in exelinkflags %} {{ exelinkflag }}{% endfor %}")
         {% endif %}
         {% if defines %}
-        add_definitions({% for define in defines %} {{ define }}{% endfor %})
+        add_compile_definitions({% for define in defines %} {{ define }}{% endfor %})
         {% endif %}
     """)
 
@@ -561,7 +561,7 @@ class ExtraFlagsBlock(Block):
             "cflags": cflags,
             "sharedlinkflags": sharedlinkflags,
             "exelinkflags": exelinkflags,
-            "defines": ["-D{}".format(d) for d in defines]
+            "defines": defines
         }
 
 

--- a/conan/tools/cmake/toolchain/toolchain.py
+++ b/conan/tools/cmake/toolchain/toolchain.py
@@ -70,8 +70,8 @@ class CMakeToolchain(object):
                 {% if action=='set' %}
                 set({{ it }} {{ genexpr.str }} CACHE STRING
                     "Variable {{ it }} conan-toolchain defined")
-                {% elif action=='add_definitions' %}
-                add_definitions(-D{{ it }}={{ genexpr.str }})
+                {% elif action=='add_compile_definitions' %}
+                add_compile_definitions({{ it }}={{ genexpr.str }})
                 {% endif %}
             {% endfor %}
         {% endmacro %}
@@ -106,11 +106,10 @@ class CMakeToolchain(object):
 
         # Preprocessor definitions
         {% for it, value in preprocessor_definitions.items() %}
-        # add_compile_definitions only works in cmake >= 3.12
-        add_definitions(-D{{ it }}={{ value }})
+        add_compile_definitions({{ it }}={{ value }})
         {% endfor %}
         # Preprocessor definitions per configuration
-        {{ iterate_configs(preprocessor_definitions_config, action='add_definitions') }}
+        {{ iterate_configs(preprocessor_definitions_config, action='add_compile_definitions') }}
         """)
 
     def __init__(self, conanfile, generator=None):

--- a/conans/test/integration/toolchains/cmake/test_cmaketoolchain.py
+++ b/conans/test/integration/toolchains/cmake/test_cmaketoolchain.py
@@ -296,7 +296,7 @@ def test_apple_vars_overwrite_user_conf():
     assert "CMAKE_SYSTEM_PROCESSOR x86_64" in toolchain
     assert "CMAKE_SYSTEM_PROCESSOR armv8" not in toolchain
 
-    
+
 def test_extra_flags_via_conf():
     profile = textwrap.dedent("""
         [settings]
@@ -327,4 +327,4 @@ def test_extra_flags_via_conf():
     assert 'string(APPEND CONAN_C_FLAGS " --flag3 --flag4")' in toolchain
     assert 'string(APPEND CONAN_SHARED_LINKER_FLAGS " --flag5 --flag6")' in toolchain
     assert 'string(APPEND CONAN_EXE_LINKER_FLAGS " --flag7 --flag8")' in toolchain
-    assert 'add_definitions( -DD1 -DD2)' in toolchain
+    assert 'add_compile_definitions( D1 D2)' in toolchain

--- a/conans/test/unittests/tools/cmake/test_cmaketoolchain.py
+++ b/conans/test/unittests/tools/cmake/test_cmaketoolchain.py
@@ -386,7 +386,7 @@ def test_libcxx_abi_flag():
 
     toolchain = CMakeToolchain(c)
     content = toolchain.content
-    assert '-D_GLIBCXX_USE_CXX11_ABI=0' in content
+    assert '_GLIBCXX_USE_CXX11_ABI=0' in content
     c.settings.compiler.libcxx = "libstdc++11"
     toolchain = CMakeToolchain(c)
     content = toolchain.content
@@ -395,13 +395,13 @@ def test_libcxx_abi_flag():
     # recipe workaround for older distros
     toolchain.blocks["libcxx"].values["glibcxx"] = "1"
     content = toolchain.content
-    assert '-D_GLIBCXX_USE_CXX11_ABI=1' in content
+    assert '_GLIBCXX_USE_CXX11_ABI=1' in content
 
     # but maybe the conf is better
     c.conf["tools.gnu:define_libcxx11_abi"] = True
     toolchain = CMakeToolchain(c)
     content = toolchain.content
-    assert '-D_GLIBCXX_USE_CXX11_ABI=1' in content
+    assert '_GLIBCXX_USE_CXX11_ABI=1' in content
 
 
 @pytest.mark.parametrize("os,os_sdk,arch,expected_sdk", [


### PR DESCRIPTION
Changelog: Feature: Replaced `add_definitions` by `add_compile_definitions` in `conan.tools.cmake.*` package.
Docs: omit

Closes: https://github.com/conan-io/conan/issues/10929

Note: `conan.tools.cmake.*` is already using CMake >= 3.15 and `add_compile_definitions` requires >= 3.12.