### PR TITLE
Fix conan create when lockfile-out is specified but not lockfile

### DIFF
--- a/conans/cli/commands/create.py
+++ b/conans/cli/commands/create.py
@@ -38,7 +38,7 @@ def create(conan_api, parser, *args):
     lockfile_path = make_abs_path(args.lockfile, cwd)
     lockfile = get_lockfile(lockfile=lockfile_path, strict=args.lockfile_strict)
     if not lockfile and args.lockfile_out:
-        raise argparse.ArgumentError(lockfile, "Specify --lockfile with a valid --lockfile "
+        raise argparse.ArgumentError(lockfile, "Specify --lockfile with a valid file "
                                                "if you use --lockfile-out or use 'conan lock create'"
                                                " to create a new lockfile")
     remotes = get_multiple_remotes(conan_api, args.remote)

--- a/conans/cli/commands/create.py
+++ b/conans/cli/commands/create.py
@@ -1,3 +1,4 @@
+import argparse
 import os
 import shutil
 
@@ -36,6 +37,10 @@ def create(conan_api, parser, *args):
     path = _get_conanfile_path(args.path, cwd, py=True)
     lockfile_path = make_abs_path(args.lockfile, cwd)
     lockfile = get_lockfile(lockfile=lockfile_path, strict=args.lockfile_strict)
+    if not lockfile and args.lockfile_out:
+        raise argparse.ArgumentError(lockfile, "Specify --lockfile with a valid --lockfile "
+                                               "if you use --lockfile-out or use 'conan lock create'"
+                                               " to create a new lockfile")
     remotes = get_multiple_remotes(conan_api, args.remote)
     profile_host, profile_build = get_profiles_from_args(conan_api, args)
 

--- a/conans/test/integration/command/create_test.py
+++ b/conans/test/integration/command/create_test.py
@@ -387,7 +387,7 @@ def test_lockfile_input_not_specified():
     client.save({"conanfile.py": GenConanfile().with_name("foo").with_version("1.0")})
     client.run("lock create . --lockfile-out locks/conan.lock")
     client.run("create . --lockfile-out locks/conan.lock", assert_error=True)
-    assert "Specify --lockfile with a valid --lockfile if you use --lockfile-out or use " \
+    assert "Specify --lockfile with a valid file if you use --lockfile-out or use " \
            "'conan lock create' to create a new lockfile" in client.out
     client.run("create . --lockfile locks/conan.lock --lockfile-out locks/conan.lock")
     assert "Saving lockfile:" in client.out

--- a/conans/test/integration/command/create_test.py
+++ b/conans/test/integration/command/create_test.py
@@ -380,3 +380,14 @@ class MyPkg(ConanFile):
         self.assertNotIn("requires", cpp_info_data["components"]["pkg1"])
         self.assertIn("libpkg2", cpp_info_data["components"]["pkg2"]["libs"])
         self.assertListEqual(["pkg1"], cpp_info_data["components"]["pkg2"]["requires"])
+
+
+def test_lockfile_input_not_specified():
+    client = TestClient()
+    client.save({"conanfile.py": GenConanfile().with_name("foo").with_version("1.0")})
+    client.run("lock create . --lockfile-out locks/conan.lock")
+    client.run("create . --lockfile-out locks/conan.lock", assert_error=True)
+    assert "Specify --lockfile with a valid --lockfile if you use --lockfile-out or use " \
+           "'conan lock create' to create a new lockfile" in client.out
+    client.run("create . --lockfile locks/conan.lock --lockfile-out locks/conan.lock")
+    assert "Saving lockfile:" in client.out


### PR DESCRIPTION
Changelog: Bugfix:  "conan create" command raised an exception when `--lockfile-out` was specified but not `--lockfile`.
Docs: omit

Close #10966