### PR TITLE
Adjust INTERFACE_LINK_DIRECTORIES in CMakeDeps

### DIFF
--- a/conan/tools/cmake/cmakedeps/cmakedeps.py
+++ b/conan/tools/cmake/cmakedeps/cmakedeps.py
@@ -13,7 +13,6 @@ from conans.errors import ConanException
 from conans.util.files import save
 
 
-
 class CMakeDeps(object):
 
     def __init__(self, conanfile):

--- a/conan/tools/cmake/cmakedeps/cmakedeps.py
+++ b/conan/tools/cmake/cmakedeps/cmakedeps.py
@@ -19,7 +19,6 @@ class CMakeDeps(object):
         self._conanfile = conanfile
         self.arch = self._conanfile.settings.get_safe("arch")
         self.configuration = str(self._conanfile.settings.build_type)
-        self.set_interface_link_directories = False
 
         # Activate the build config files for the specified libraries
         self.build_context_activated = []

--- a/conan/tools/cmake/cmakedeps/cmakedeps.py
+++ b/conan/tools/cmake/cmakedeps/cmakedeps.py
@@ -19,6 +19,7 @@ class CMakeDeps(object):
         self._conanfile = conanfile
         self.arch = self._conanfile.settings.get_safe("arch")
         self.configuration = str(self._conanfile.settings.build_type)
+        self.set_interface_link_directories = False
 
         # Activate the build config files for the specified libraries
         self.build_context_activated = []

--- a/conan/tools/cmake/cmakedeps/templates/target_configuration.py
+++ b/conan/tools/cmake/cmakedeps/templates/target_configuration.py
@@ -26,16 +26,15 @@ class TargetConfigurationTemplate(CMakeDepsFileTemplate):
         components_names = [(components_target_name.replace("::", "_"), components_target_name)
                             for components_target_name in components_targets_names]
 
-        is_win = hasattr(self.conanfile, "settings_build") and \
-            self.conanfile.settings_build.get_safe("os") == "Windows"
+        is_win = self.conanfile.settings.get_safe("os") == "Windows"
+        auto_link = self.conanfile.cpp_info.get_property("cmake_set_interface_link_directories")
         return {"pkg_name": self.pkg_name,
                 "root_target_name": self.root_target_name,
                 "config_suffix": self.config_suffix,
                 "deps_targets_names": ";".join(deps_targets_names),
                 "components_names": components_names,
                 "configuration": self.cmakedeps.configuration,
-                "set_interface_link_directories":
-                    self.cmakedeps.set_interface_link_directories and is_win}
+                "set_interface_link_directories": auto_link and is_win}
 
     @property
     def template(self):

--- a/conan/tools/cmake/cmakedeps/templates/target_configuration.py
+++ b/conan/tools/cmake/cmakedeps/templates/target_configuration.py
@@ -115,6 +115,7 @@ class TargetConfigurationTemplate(CMakeDepsFileTemplate):
                      PROPERTY INTERFACE_LINK_LIBRARIES
                      $<$<CONFIG:{{configuration}}>:${{'{'}}{{pkg_name}}_LIBRARIES_TARGETS{{config_suffix}}}
                                                    ${{'{'}}{{pkg_name}}_OBJECTS{{config_suffix}}}> APPEND)
+
         set_property(TARGET {{root_target_name}}
                      PROPERTY INTERFACE_LINK_OPTIONS
                      $<$<CONFIG:{{configuration}}>:${{'{'}}{{pkg_name}}_LINKER_FLAGS{{config_suffix}}}> APPEND)
@@ -127,6 +128,11 @@ class TargetConfigurationTemplate(CMakeDepsFileTemplate):
         set_property(TARGET {{root_target_name}}
                      PROPERTY INTERFACE_COMPILE_OPTIONS
                      $<$<CONFIG:{{configuration}}>:${{'{'}}{{pkg_name}}_COMPILE_OPTIONS{{config_suffix}}}> APPEND)
+
+        # This is only used for '#pragma comment(lib, "foo")' (automatic link)
+        set_property(TARGET {{root_target_name}}
+                     PROPERTY INTERFACE_LINK_DIRECTORIES
+                     $<$<CONFIG:{{configuration}}>:${{'{'}}{{pkg_name}}_LIB_DIRS{{config_suffix}}}> APPEND)
 
         ########## COMPONENTS TARGET PROPERTIES {{ configuration }} ########################################
 
@@ -147,6 +153,10 @@ class TargetConfigurationTemplate(CMakeDepsFileTemplate):
                      {{tvalue(pkg_name, comp_variable_name, 'COMPILE_OPTIONS_C', config_suffix)}}
                      {{tvalue(pkg_name, comp_variable_name, 'COMPILE_OPTIONS_CXX', config_suffix)}}> APPEND)
         set({{ pkg_name }}_{{ comp_variable_name }}_TARGET_PROPERTIES TRUE)
+
+        # This is only used for '#pragma comment(lib, "foo")' (automatic link)
+        set_property(TARGET {{ comp_target_name }} PROPERTY INTERFACE_LINK_DIRECTORIES
+                     $<$<CONFIG:{{ configuration }}>:{{tvalue(pkg_name, comp_variable_name, 'LIB_DIRS', config_suffix)}}> APPEND)
 
         {%- endfor %}
 

--- a/conans/test/functional/toolchains/cmake/cmakedeps/test_link_order.py
+++ b/conans/test/functional/toolchains/cmake/cmakedeps/test_link_order.py
@@ -226,7 +226,9 @@ def _get_link_order_from_cmake(content):
         if 'main.cpp.o -o example' in line:
             _, links = line.split("main.cpp.o -o example")
             for it_lib in links.split():
-                if it_lib.startswith("-l"):
+                if it_lib.startswith("-L") or it_lib.startswith("-Wl,"):
+                    continue
+                elif it_lib.startswith("-l"):
                     libs.append(it_lib[2:])
                 elif it_lib == "-framework":
                     continue
@@ -258,6 +260,9 @@ def _get_link_order_from_xcode(content):
     start_key = '-headerpad_max_install_names",'
     end_key = ');'
     libs_content = content.split(start_key, 1)[1].split(end_key, 1)[0]
+    if libs_content == '"$(inherited)"':
+        # FIXME: Dirty hack, sometimes the library list is not at the 1 but at 2
+        libs_content = content.split(start_key, 1)[2].split(end_key, 1)[0]
     libs_unstripped = libs_content.split(",")
     for lib in libs_unstripped:
         if ".a" in lib:

--- a/conans/test/functional/toolchains/cmake/cmakedeps/test_link_order.py
+++ b/conans/test/functional/toolchains/cmake/cmakedeps/test_link_order.py
@@ -226,7 +226,7 @@ def _get_link_order_from_cmake(content):
         if 'main.cpp.o -o example' in line:
             _, links = line.split("main.cpp.o -o example")
             for it_lib in links.split():
-                if it_lib.startswith("-L") or it_lib.startswith("-Wl,"):
+                if it_lib.startswith("-L") or it_lib.startswith("-Wl,-rpath"):
                     continue
                 elif it_lib.startswith("-l"):
                     libs.append(it_lib[2:])

--- a/conans/test/functional/toolchains/cmake/test_cmake_toolchain.py
+++ b/conans/test/functional/toolchains/cmake/test_cmake_toolchain.py
@@ -271,7 +271,11 @@ class TestAutoLinkPragma:
     @pytest.mark.skipif(platform.system() != "Windows", reason="Requires Visual Studio")
     @pytest.mark.tool_cmake
     def test_autolink_pragma_components(self):
-        """https://github.com/conan-io/conan/issues/10837"""
+        """https://github.com/conan-io/conan/issues/10837
+
+        NOTE: At the moment the property cmake_set_interface_link_directories is only read at the
+        global cppinfo, not in the components"""
+
         client = TestClient()
         client.run("new hello/1.0 --template cmake_lib")
         cf = client.load("conanfile.py")
@@ -279,6 +283,7 @@ class TestAutoLinkPragma:
             self.cpp_info.components['my_component'].includedirs.append('include')
             self.cpp_info.components['my_component'].libdirs.append('lib')
             self.cpp_info.components['my_component'].libs = []
+            self.cpp_info.set_property("cmake_set_interface_link_directories", True)
         """)
         hello_h = client.load("include/hello.h")
         hello_h = hello_h.replace("#define hello_EXPORT __declspec(dllexport)",
@@ -307,6 +312,7 @@ class TestAutoLinkPragma:
             self.cpp_info.includedirs.append('include')
             self.cpp_info.libdirs.append('lib')
             self.cpp_info.libs = []
+            self.cpp_info.set_property("cmake_set_interface_link_directories", True)
         """)
         hello_h = client.load("include/hello.h")
         hello_h = hello_h.replace("#define hello_EXPORT __declspec(dllexport)",

--- a/conans/test/unittests/tools/cmake/test_cmakedeps.py
+++ b/conans/test/unittests/tools/cmake/test_cmakedeps.py
@@ -31,6 +31,7 @@ def test_cpp_info_name_cmakedeps():
     conanfile_dep._conan_node = Mock()
     conanfile_dep._conan_node.ref = ConanFileReference.loads("OriginalDepName/1.0")
     conanfile_dep._conan_node.context = "host"
+    conanfile_dep.settings = conanfile.settings
     conanfile_dep.folders.set_base_package("/path/to/folder_dep")
 
     with mock.patch('conans.ConanFile.dependencies', new_callable=mock.PropertyMock) as mock_deps:
@@ -64,6 +65,7 @@ def test_cpp_info_name_cmakedeps_components():
 
     conanfile_dep = ConanFile(Mock(), None)
     conanfile_dep.cpp_info = cpp_info
+    conanfile_dep.settings = conanfile.settings
     conanfile_dep._conan_node = Mock()
     conanfile_dep._conan_node.ref = ConanFileReference.loads("OriginalDepName/1.0")
     conanfile_dep._conan_node.context = "host"
@@ -104,6 +106,7 @@ def test_cmake_deps_links_flags():
     cpp_info.objects = ["myobject.o"]
     conanfile_dep = ConanFile(Mock(), None)
     conanfile_dep.cpp_info = cpp_info
+    conanfile_dep.settings = conanfile.settings
     conanfile_dep._conan_node = Mock()
     conanfile_dep._conan_node.ref = ConanFileReference.loads("mypkg/1.0")
     conanfile_dep._conan_node.context = "host"
@@ -145,6 +148,7 @@ def test_component_name_same_package():
 
     conanfile_dep = ConanFile(Mock(), None)
     conanfile_dep.cpp_info = cpp_info
+    conanfile_dep.settings = conanfile.settings
     conanfile_dep._conan_node = Mock()
     conanfile_dep._conan_node.context = "host"
     conanfile_dep._conan_node.ref = ConanFileReference.loads("mypkg/1.0")


### PR DESCRIPTION
Changelog: Fix: The `CMakeDeps` generator now set `INTERFACE_LINK_DIRECTORIES` necessary when using auto link `'#pragma comment(lib, "foo")' ` when the required library sets the property `cmake_set_interface_link_directories`.
Docs: https://github.com/conan-io/docs/pull/2510

!!  For the documentation -> Property `cmake_set_interface_link_directories` only supported at the root cppinfo, components not supported (could be done later).

Close #10837 