### PR TITLE
[CMakeToolchain] Adding Xcode flags

### DIFF
--- a/conan/tools/apple/apple.py
+++ b/conan/tools/apple/apple.py
@@ -4,13 +4,6 @@
 from conans.util.runners import check_output_runner
 
 
-def is_apple_cross_building(conanfile):
-    os_host = conanfile.settings.get_safe("os")
-    arch_host = conanfile.settings.get_safe("arch")
-    arch_build = conanfile.settings_build.get_safe("arch")
-    return os_host in ('iOS', 'watchOS', 'tvOS') or (os_host == 'Macos' and arch_host != arch_build)
-
-
 def is_apple_os(os_):
     """returns True if OS is Apple one (Macos, iOS, watchOS or tvOS"""
     return str(os_) in ['Macos', 'iOS', 'watchOS', 'tvOS']

--- a/conan/tools/apple/apple.py
+++ b/conan/tools/apple/apple.py
@@ -1,8 +1,14 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-import os
 
 from conans.util.runners import check_output_runner
+
+
+def is_apple_cross_building(conanfile):
+    os_host = conanfile.settings.get_safe("os")
+    arch_host = conanfile.settings.get_safe("arch")
+    arch_build = conanfile.settings_build.get_safe("arch")
+    return os_host in ('iOS', 'watchOS', 'tvOS') or (os_host == 'Macos' and arch_host != arch_build)
 
 
 def is_apple_os(os_):

--- a/conan/tools/cmake/toolchain/blocks.py
+++ b/conan/tools/cmake/toolchain/blocks.py
@@ -6,7 +6,7 @@ from collections import OrderedDict
 from jinja2 import Template
 
 from conan.tools._compilers import architecture_flag
-from conan.tools.apple.apple import is_apple_os, to_apple_arch
+from conan.tools.apple.apple import is_apple_os, to_apple_arch, is_apple_cross_building
 from conan.tools.build import build_jobs
 from conan.tools.build.cross_building import cross_building
 from conan.tools.cmake.toolchain import CONAN_TOOLCHAIN_FILENAME
@@ -328,7 +328,63 @@ class AppleSystemBlock(Block):
         # Setting CMAKE_OSX_DEPLOYMENT_TARGET if "os.version" is defined by the used conan profile
         set(CMAKE_OSX_DEPLOYMENT_TARGET "{{ cmake_osx_deployment_target }}" CACHE STRING "")
         {% endif %}
+        {% if enable_bitcode is defined and enable_bitcode is sameas true %}
+        # Bitcode
+        set(CMAKE_XCODE_ATTRIBUTE_ENABLE_BITCODE YES)
+        set(CMAKE_XCODE_ATTRIBUTE_BITCODE_GENERATION_MODE bitcode)
+        {% endif %}
+        {% if enable_arc is defined and enable_arc is sameas true %}
+        # ARC
+        set(CMAKE_XCODE_ATTRIBUTE_CLANG_ENABLE_OBJC_ARC YES)
+        {% elif enable_arc is defined and enable_arc is sameas false %}
+        # ARC
+        set(CMAKE_XCODE_ATTRIBUTE_CLANG_ENABLE_OBJC_ARC NO)
+        {% endif %}
+        {% if enable_visibility is defined and enable_visibility is sameas true %}
+        # Visibility
+        set(CMAKE_XCODE_ATTRIBUTE_GCC_SYMBOLS_PRIVATE_EXTERN YES)
+        {% elif enable_visibility is defined and enable_visibility is sameas false %}
+        # Visibility
+        set(CMAKE_XCODE_ATTRIBUTE_GCC_SYMBOLS_PRIVATE_EXTERN NO)
+        {% endif %}
+        {% if common_flags|length > 0 %}
+        string(APPEND CONAN_CXX_FLAGS "{% for flag in common_flags %} {{ flag }}{% endfor %}")
+        string(APPEND CONAN_C_FLAGS "{% for flag in common_flags %} {{ flag }}{% endfor %}")
+        string(APPEND CONAN_SHARED_LINKER_FLAGS "{% for flag in common_flags %} {{ flag }}{% endfor %}")
+        string(APPEND CONAN_EXE_LINKER_FLAGS "{% for flag in common_flags %} {{ flag }}{% endfor %}")
+        {% endif %}
         """)
+
+    def _get_xcode_common_flags(self):
+        """
+        Adding Xcode flags if enabled Bitcode, ARC or Visibility via conf.
+
+        :return: `dict` with common flags and boolean values if enabled bitcode, arc or visibility.
+        """
+        # Issue related: https://github.com/conan-io/conan/issues/9448
+        enable_bitcode = self._conanfile.conf.get("tools.apple:enable_bitcode",
+                                                  default=self._conanfile.settings.get_safe('os') in ["watchOS", "tvOS"],
+                                                  check_type=bool)
+        enable_arc = self._conanfile.conf.get("tools.apple:enable_arc", check_type=bool)
+        enable_visibility = self._conanfile.conf.get("tools.apple:enable_visibility", check_type=bool)
+        common_flags = []
+        if enable_bitcode:
+            if self._conanfile.settings.get_safe('build_type') == "Debug":
+                common_flags.append("-fembed-bitcode-marker")
+            else:
+                common_flags.append("-fembed-bitcode")
+        if enable_arc:
+            common_flags.append("-fobjc-arc")
+        elif enable_arc is False:
+            common_flags.append("-fno-objc-arc")
+        if enable_visibility is False:
+            common_flags.append("-fvisibility=hidden")
+        return {
+            "common_flags": common_flags,
+            "enable_bitcode": enable_bitcode,
+            "enable_arc": enable_arc,
+            "enable_visibility": enable_visibility
+        }
 
     def _apple_sdk_name(self):
         """
@@ -357,7 +413,7 @@ class AppleSystemBlock(Block):
 
     def context(self):
         os_ = self._conanfile.settings.get_safe("os")
-        if os_ not in ['Macos', 'iOS', 'watchOS', 'tvOS']:
+        if not is_apple_os(os_):
             return None
 
         arch = self._conanfile.settings.get_safe("arch")
@@ -378,6 +434,7 @@ class AppleSystemBlock(Block):
             # macOS like iOS, tvOS, or watchOS.
             ctxt_toolchain["cmake_osx_deployment_target"] = host_os_version
 
+        ctxt_toolchain.update(self._get_xcode_common_flags())
         return ctxt_toolchain
 
 
@@ -719,12 +776,6 @@ class GenericSystemBlock(Block):
                     (arch_build == "ppc64") and (arch_host == "ppc32")):
                 return cmake_system_name_map.get(os_host, os_host)
 
-    def _is_apple_cross_building(self):
-        os_host = self._conanfile.settings.get_safe("os")
-        arch_host = self._conanfile.settings.get_safe("arch")
-        arch_build = self._conanfile.settings_build.get_safe("arch")
-        return os_host in ('iOS', 'watchOS', 'tvOS') or (os_host == 'Macos' and arch_host != arch_build)
-
     def _get_cross_build(self):
         user_toolchain = self._conanfile.conf.get("tools.cmake.cmaketoolchain:user_toolchain")
         if user_toolchain is not None:
@@ -740,7 +791,7 @@ class GenericSystemBlock(Block):
             if system_name is None:  # Try to deduce
                 _system_version = None
                 _system_processor = None
-                if self._is_apple_cross_building():
+                if is_apple_cross_building(self._conanfile):
                     # cross-build in Macos also for M1
                     system_name = {'Macos': 'Darwin'}.get(os_host, os_host)
                     #  CMAKE_SYSTEM_VERSION for Apple sets the sdk version, not the os version

--- a/conan/tools/cmake/toolchain/blocks.py
+++ b/conan/tools/cmake/toolchain/blocks.py
@@ -328,6 +328,9 @@ class AppleSystemBlock(Block):
         # Setting CMAKE_OSX_DEPLOYMENT_TARGET if "os.version" is defined by the used conan profile
         set(CMAKE_OSX_DEPLOYMENT_TARGET "{{ cmake_osx_deployment_target }}" CACHE STRING "")
         {% endif %}
+        set(BITCODE "")
+        set(FOBJC_ARC "")
+        set(VISIBILITY "")
         {% if enable_bitcode is defined and enable_bitcode is sameas true %}
         # Bitcode ON
         set(CMAKE_XCODE_ATTRIBUTE_ENABLE_BITCODE "YES")
@@ -339,7 +342,6 @@ class AppleSystemBlock(Block):
         {% endif %}
         {% elif enable_bitcode is defined and enable_bitcode is sameas false %}
         # Bitcode OFF
-        set(BITCODE "")
         set(CMAKE_XCODE_ATTRIBUTE_ENABLE_BITCODE "NO")
         {% endif %}
         {% if enable_arc is defined and enable_arc is sameas true %}

--- a/conan/tools/cmake/toolchain/blocks.py
+++ b/conan/tools/cmake/toolchain/blocks.py
@@ -362,8 +362,13 @@ class AppleSystemBlock(Block):
         set(VISIBILITY "-fvisibility=hidden -fvisibility-inlines-hidden")
         set(CMAKE_XCODE_ATTRIBUTE_GCC_SYMBOLS_PRIVATE_EXTERN "YES")
         {% endif %}
-        string(APPEND CONAN_C_FLAGS " ${BITCODE} ${FOBJC_ARC}")
-        string(APPEND CONAN_CXX_FLAGS " ${BITCODE} ${VISIBILITY} ${FOBJC_ARC}")
+        #Check if Xcode generator is used, since that will handle these flags automagically
+        if(CMAKE_GENERATOR MATCHES "Xcode")
+          message(DEBUG "Not setting any manual command-line buildflags, since Xcode is selected as generator.")
+        else()
+            string(APPEND CONAN_C_FLAGS " ${BITCODE} ${FOBJC_ARC}")
+            string(APPEND CONAN_CXX_FLAGS " ${BITCODE} ${VISIBILITY} ${FOBJC_ARC}")
+        endif()
         """)
 
     def _apple_sdk_name(self):
@@ -405,9 +410,7 @@ class AppleSystemBlock(Block):
         # Reading some configurations to enable or disable some Xcode toolchain flags and variables
         # Issue related: https://github.com/conan-io/conan/issues/9448
         # Based on https://github.com/leetal/ios-cmake repository
-        enable_bitcode = self._conanfile.conf.get("tools.apple:enable_bitcode",
-                                                  default=self._conanfile.settings.get_safe('os') in ["watchOS", "tvOS"],
-                                                  check_type=bool)
+        enable_bitcode = self._conanfile.conf.get("tools.apple:enable_bitcode", check_type=bool)
         enable_arc = self._conanfile.conf.get("tools.apple:enable_arc", check_type=bool)
         enable_visibility = self._conanfile.conf.get("tools.apple:enable_visibility", check_type=bool)
 

--- a/conan/tools/cmake/toolchain/blocks.py
+++ b/conan/tools/cmake/toolchain/blocks.py
@@ -331,33 +331,33 @@ class AppleSystemBlock(Block):
         set(BITCODE "")
         set(FOBJC_ARC "")
         set(VISIBILITY "")
-        {% if enable_bitcode is defined and enable_bitcode is sameas true %}
+        {% if enable_bitcode %}
         # Bitcode ON
         set(CMAKE_XCODE_ATTRIBUTE_ENABLE_BITCODE "YES")
         set(CMAKE_XCODE_ATTRIBUTE_BITCODE_GENERATION_MODE "bitcode")
-        {% if enable_bitcode_marker is sameas true %}
+        {% if enable_bitcode_marker %}
         set(BITCODE "-fembed-bitcode-marker")
         {% else %}
         set(BITCODE "-fembed-bitcode")
         {% endif %}
-        {% elif enable_bitcode is defined and enable_bitcode is sameas false %}
+        {% elif enable_bitcode is not none %}
         # Bitcode OFF
         set(CMAKE_XCODE_ATTRIBUTE_ENABLE_BITCODE "NO")
         {% endif %}
-        {% if enable_arc is defined and enable_arc is sameas true %}
+        {% if enable_arc %}
         # ARC ON
         set(FOBJC_ARC "-fobjc-arc")
         set(CMAKE_XCODE_ATTRIBUTE_CLANG_ENABLE_OBJC_ARC "YES")
-        {% elif enable_arc is defined and enable_arc is sameas false %}
+        {% elif enable_arc is not none %}
         # ARC OFF
         set(FOBJC_ARC "-fno-objc-arc")
         set(CMAKE_XCODE_ATTRIBUTE_CLANG_ENABLE_OBJC_ARC "NO")
         {% endif %}
-        {% if enable_visibility is defined and enable_visibility is sameas true %}
+        {% if enable_visibility %}
         # Visibility ON
         set(CMAKE_XCODE_ATTRIBUTE_GCC_SYMBOLS_PRIVATE_EXTERN "NO")
         set(VISIBILITY "-fvisibility=default")
-        {% elif enable_visibility is defined and enable_visibility is sameas false %}
+        {% elif enable_visibility is not none %}
         # Visibility OFF
         set(VISIBILITY "-fvisibility=hidden -fvisibility-inlines-hidden")
         set(CMAKE_XCODE_ATTRIBUTE_GCC_SYMBOLS_PRIVATE_EXTERN "YES")

--- a/conans/model/conf.py
+++ b/conans/model/conf.py
@@ -40,6 +40,9 @@ BUILT_IN_CONFS = {
     "tools.system.package_manager:sudo": "Use 'sudo' when invoking the package manager tools in Linux (False by default)",
     "tools.system.package_manager:sudo_askpass": "Use the '-A' argument if using sudo in Linux to invoke the system package manager (False by default)",
     "tools.apple.xcodebuild:verbosity": "Verbosity level for xcodebuild: 'verbose' or 'quiet",
+    "tools.apple:enable_bitcode": "(boolean) Enable/Disable Bitcode Xcode flags",
+    "tools.apple:enable_arc": "(boolean) Enable/Disable ARC Xcode flags",
+    "tools.apple:enable_visibility": "(boolean) Enable/Disable Visibility Xcode flags",
     # Flags configuration
     "tools.build:cxxflags": "List of extra CXX flags used by different toolchains like CMakeToolchain, AutotoolsToolchain and MesonToolchain",
     "tools.build:cflags": "List of extra C flags used by different toolchains like CMakeToolchain, AutotoolsToolchain and MesonToolchain",

--- a/conans/model/conf.py
+++ b/conans/model/conf.py
@@ -40,9 +40,9 @@ BUILT_IN_CONFS = {
     "tools.system.package_manager:sudo": "Use 'sudo' when invoking the package manager tools in Linux (False by default)",
     "tools.system.package_manager:sudo_askpass": "Use the '-A' argument if using sudo in Linux to invoke the system package manager (False by default)",
     "tools.apple.xcodebuild:verbosity": "Verbosity level for xcodebuild: 'verbose' or 'quiet",
-    "tools.apple:enable_bitcode": "(boolean) Enable/Disable Bitcode Xcode flags",
-    "tools.apple:enable_arc": "(boolean) Enable/Disable ARC Xcode flags",
-    "tools.apple:enable_visibility": "(boolean) Enable/Disable Visibility Xcode flags",
+    "tools.apple:enable_bitcode": "(boolean) Enable/Disable Bitcode Apple Clang flags",
+    "tools.apple:enable_arc": "(boolean) Enable/Disable ARC Apple Clang flags",
+    "tools.apple:enable_visibility": "(boolean) Enable/Disable Visibility Apple Clang flags",
     # Flags configuration
     "tools.build:cxxflags": "List of extra CXX flags used by different toolchains like CMakeToolchain, AutotoolsToolchain and MesonToolchain",
     "tools.build:cflags": "List of extra C flags used by different toolchains like CMakeToolchain, AutotoolsToolchain and MesonToolchain",

--- a/conans/test/functional/toolchains/cmake/test_cmake_toolchain_xcode_flags.py
+++ b/conans/test/functional/toolchains/cmake/test_cmake_toolchain_xcode_flags.py
@@ -7,12 +7,19 @@ import pytest
 from conans.test.utils.tools import TestClient
 
 
+def _add_message_status_flags(client):
+    cmakelists_path = os.path.join(client.current_folder, "CMakeLists.txt")
+    with open(cmakelists_path, "a") as cmakelists_file:
+        cmakelists_file.write('message(STATUS "CONAN_C_FLAGS: ${CONAN_C_FLAGS}")\n')
+        cmakelists_file.write('message(STATUS "CONAN_CXX_FLAGS: ${CONAN_CXX_FLAGS}")\n')
+
+
 @pytest.mark.skipif(platform.system() != "Darwin", reason="Only OSX")
 @pytest.mark.parametrize("op_system,os_version,sdk,arch", [
     ("watchOS", "8.1", "watchos", "armv7k"),
     ("tvOS", "13.2", "appletvos", "armv8")
 ])
-def test_xcode_bitcode_arc_and_visibility_flags_enabled(op_system, os_version, sdk, arch):
+def test_cmake_apple_bitcode_arc_and_visibility_flags_enabled(op_system, os_version, sdk, arch):
     profile = textwrap.dedent("""
         include(default)
         [settings]
@@ -29,6 +36,7 @@ def test_xcode_bitcode_arc_and_visibility_flags_enabled(op_system, os_version, s
     client = TestClient(path_with_spaces=False)
     client.save({"host": profile}, clean_first=True)
     client.run("new hello/0.1 --template=cmake_lib")
+    _add_message_status_flags(client)
     client.run("install . --profile:build=default --profile:host=host")
     toolchain = client.load(os.path.join("cmake-build-release", "conan", "conan_toolchain.cmake"))
     # bitcode
@@ -41,11 +49,11 @@ def test_xcode_bitcode_arc_and_visibility_flags_enabled(op_system, os_version, s
     # visibility
     assert 'set(CMAKE_XCODE_ATTRIBUTE_GCC_SYMBOLS_PRIVATE_EXTERN "NO")' in toolchain
     assert 'set(VISIBILITY "-fvisibility=default")' in toolchain
-    # flags
-    assert 'string(APPEND CONAN_C_FLAGS " ${BITCODE} ${FOBJC_ARC}")' in toolchain
-    assert 'string(APPEND CONAN_CXX_FLAGS " ${BITCODE} ${VISIBILITY} ${FOBJC_ARC}")' in toolchain
 
     client.run("create . --profile:build=default --profile:host=host -tf None")
+    # flags
+    assert "-- CONAN_C_FLAGS:  -fembed-bitcode -fobjc-arc" in client.out
+    assert "-- CONAN_CXX_FLAGS:  -fembed-bitcode -fvisibility=default -fobjc-arc" in client.out
     assert "[100%] Built target hello" in client.out
 
 
@@ -54,7 +62,46 @@ def test_xcode_bitcode_arc_and_visibility_flags_enabled(op_system, os_version, s
     ("watchOS", "8.1", "watchos", "armv7k"),
     ("tvOS", "13.2", "appletvos", "armv8")
 ])
-def test_xcode_bitcode_arc_and_visibility_flags_disabled(op_system, os_version, sdk, arch):
+def test_cmake_apple_bitcode_arc_and_visibility_flags_enabled_and_xcode_generator(op_system, os_version, sdk, arch):
+    """
+    Testing what happens when any of the Bitcode, ARC or Visibility configurations are not defined.
+
+    Note: If cross-compiling to watchOS or tvOS, bitcode will be enabled by default.
+    """
+    profile = textwrap.dedent("""
+        include(default)
+        [settings]
+        os={}
+        os.version={}
+        os.sdk={}
+        arch={}
+        [conf]
+        tools.apple:enable_bitcode=True
+        tools.apple:enable_arc=True
+        tools.apple:enable_visibility=True
+    """.format(op_system, os_version, sdk, arch))
+
+    client = TestClient(path_with_spaces=False)
+    client.save({"host": profile}, clean_first=True)
+    client.run("new hello/0.1 --template=cmake_lib")
+    _add_message_status_flags(client)
+    client.run("create . --profile:build=default --profile:host=host -tf None -c tools.cmake.cmaketoolchain:generator=Xcode")
+    assert "** BUILD SUCCEEDED **" in client.out
+    # flags
+    for line in str(client.out).splitlines():
+        if "CONAN_C_FLAGS:" in line:
+            assert "-- CONAN_C_FLAGS:" == line.strip()
+        if "CONAN_CXX_FLAGS:" in line:
+            assert "-- CONAN_CXX_FLAGS:  -stdlib=libc++" == line.strip()
+            break
+
+
+@pytest.mark.skipif(platform.system() != "Darwin", reason="Only OSX")
+@pytest.mark.parametrize("op_system,os_version,sdk,arch", [
+    ("watchOS", "8.1", "watchos", "armv7k"),
+    ("tvOS", "13.2", "appletvos", "armv8")
+])
+def test_cmake_apple_bitcode_arc_and_visibility_flags_disabled(op_system, os_version, sdk, arch):
     profile = textwrap.dedent("""
         include(default)
         [settings]
@@ -71,6 +118,7 @@ def test_xcode_bitcode_arc_and_visibility_flags_disabled(op_system, os_version, 
     client = TestClient(path_with_spaces=False)
     client.save({"host": profile}, clean_first=True)
     client.run("new hello/0.1 --template=cmake_lib")
+    _add_message_status_flags(client)
     client.run("install . --profile:build=default --profile:host=host")
     toolchain = client.load(os.path.join("cmake-build-release", "conan", "conan_toolchain.cmake"))
     # bitcode
@@ -83,11 +131,11 @@ def test_xcode_bitcode_arc_and_visibility_flags_disabled(op_system, os_version, 
     # visibility
     assert 'set(CMAKE_XCODE_ATTRIBUTE_GCC_SYMBOLS_PRIVATE_EXTERN "YES")' in toolchain
     assert 'set(VISIBILITY "-fvisibility=hidden -fvisibility-inlines-hidden")' in toolchain
-    # flags
-    assert 'string(APPEND CONAN_C_FLAGS " ${BITCODE} ${FOBJC_ARC}")' in toolchain
-    assert 'string(APPEND CONAN_CXX_FLAGS " ${BITCODE} ${VISIBILITY} ${FOBJC_ARC}")' in toolchain
 
     client.run("create . --profile:build=default --profile:host=host -tf None")
+    # flags
+    assert "-- CONAN_C_FLAGS:   -fno-objc-arc" in client.out
+    assert "-- CONAN_CXX_FLAGS:   -fvisibility=hidden -fvisibility-inlines-hidden -fno-objc-arc" in client.out
     assert "[100%] Built target hello" in client.out
 
 
@@ -96,7 +144,7 @@ def test_xcode_bitcode_arc_and_visibility_flags_disabled(op_system, os_version, 
     ("watchOS", "8.1", "watchos", "armv7k"),
     ("tvOS", "13.2", "appletvos", "armv8")
 ])
-def test_xcode_bitcode_arc_and_visibility_flags_are_none(op_system, os_version, sdk, arch):
+def test_cmake_apple_bitcode_arc_and_visibility_flags_are_none(op_system, os_version, sdk, arch):
     """
     Testing what happens when any of the Bitcode, ARC or Visibility configurations are not defined.
 
@@ -114,21 +162,22 @@ def test_xcode_bitcode_arc_and_visibility_flags_are_none(op_system, os_version, 
     client = TestClient(path_with_spaces=False)
     client.save({"host": profile}, clean_first=True)
     client.run("new hello/0.1 --template=cmake_lib")
+    _add_message_status_flags(client)
     client.run("install . --profile:build=default --profile:host=host")
     toolchain = client.load(os.path.join("cmake-build-release", "conan", "conan_toolchain.cmake"))
-    # bitcode is enabled by default
-    assert 'set(CMAKE_XCODE_ATTRIBUTE_ENABLE_BITCODE "YES")' in toolchain
-    assert 'set(CMAKE_XCODE_ATTRIBUTE_BITCODE_GENERATION_MODE "bitcode")' in toolchain
-    assert 'set(BITCODE "-fembed-bitcode")' in toolchain
+    # bitcode
+    assert 'set(CMAKE_XCODE_ATTRIBUTE_ENABLE_BITCODE "NO")' not in toolchain
+    assert 'set(CMAKE_XCODE_ATTRIBUTE_BITCODE_GENERATION_MODE "bitcode")' not in toolchain
+    assert 'set(BITCODE "-fembed-bitcode")' not in toolchain
     # arc
     assert 'set(FOBJC_ARC "-' not in toolchain
     assert 'set(CMAKE_XCODE_ATTRIBUTE_CLANG_ENABLE_OBJC_ARC' not in toolchain
     # visibility
     assert 'set(CMAKE_XCODE_ATTRIBUTE_GCC_SYMBOLS_PRIVATE_EXTERN' not in toolchain
     assert 'set(VISIBILITY "-' not in toolchain
-    # flags
-    assert 'string(APPEND CONAN_C_FLAGS " ${BITCODE} ${FOBJC_ARC}")' in toolchain
-    assert 'string(APPEND CONAN_CXX_FLAGS " ${BITCODE} ${VISIBILITY} ${FOBJC_ARC}")' in toolchain
 
     client.run("create . --profile:build=default --profile:host=host -tf None")
+    # flags
+    for flag in ["-fembed-bitcode", "-fno-objc-arc", "-fobjc-arc", "-fvisibility"]:
+        assert flag not in client.out
     assert "[100%] Built target hello" in client.out

--- a/conans/test/functional/toolchains/cmake/test_cmake_toolchain_xcode_flags.py
+++ b/conans/test/functional/toolchains/cmake/test_cmake_toolchain_xcode_flags.py
@@ -1,0 +1,49 @@
+import textwrap
+import platform
+import os
+
+import pytest
+
+from conans.test.utils.tools import TestClient
+
+
+@pytest.mark.skipif(platform.system() != "Darwin", reason="Only OSX")
+@pytest.mark.parametrize("op_system,os_version,sdk,arch", [
+    ("watchOS", "8.1", "watchos", "armv7k"),
+    ("tvOS", "13.2", "appletvos", "armv8")
+])
+def test_xcode_bitcode_arc_and_visibility_flags(op_system, os_version, sdk, arch):
+    profile = textwrap.dedent("""
+        include(default)
+        [settings]
+        os={}
+        os.version={}
+        os.sdk={}
+        arch={}
+        [conf]
+        tools.apple:enable_bitcode=True
+        tools.apple:enable_arc=True
+        tools.apple:enable_visibility=False
+    """.format(op_system, os_version, sdk, arch))
+
+    client = TestClient(path_with_spaces=False)
+    client.save({"host": profile}, clean_first=True)
+    client.run("new hello/0.1 --template=cmake_lib")
+    client.run("install . --profile:build=default --profile:host=host")
+    toolchain = client.load(os.path.join("cmake-build-release", "conan", "conan_toolchain.cmake"))
+    # bitcode
+    assert 'set(CMAKE_XCODE_ATTRIBUTE_ENABLE_BITCODE "YES")' in toolchain
+    assert 'set(CMAKE_XCODE_ATTRIBUTE_BITCODE_GENERATION_MODE "bitcode")' in toolchain
+    assert 'set(BITCODE "-fembed-bitcode")' in toolchain
+    # arc
+    assert 'set(FOBJC_ARC "-fobjc-arc")' in toolchain
+    assert 'set(CMAKE_XCODE_ATTRIBUTE_CLANG_ENABLE_OBJC_ARC "YES")' in toolchain
+    # visibility
+    assert 'set(CMAKE_XCODE_ATTRIBUTE_GCC_SYMBOLS_PRIVATE_EXTERN "YES")' in toolchain
+    assert 'set(VISIBILITY "-fvisibility=hidden -fvisibility-inlines-hidden")' in toolchain
+    # flags
+    assert 'string(APPEND CONAN_C_FLAGS " ${BITCODE} ${FOBJC_ARC}")' in toolchain
+    assert 'string(APPEND CONAN_CXX_FLAGS " ${BITCODE} ${VISIBILITY} ${FOBJC_ARC}")' in toolchain
+
+    client.run("create . --profile:build=default --profile:host=host -tf None")
+    assert "[100%] Built target hello" in client.out

--- a/conans/test/functional/toolchains/cmake/test_cmake_toolchain_xcode_flags.py
+++ b/conans/test/functional/toolchains/cmake/test_cmake_toolchain_xcode_flags.py
@@ -89,3 +89,46 @@ def test_xcode_bitcode_arc_and_visibility_flags_disabled(op_system, os_version, 
 
     client.run("create . --profile:build=default --profile:host=host -tf None")
     assert "[100%] Built target hello" in client.out
+
+
+@pytest.mark.skipif(platform.system() != "Darwin", reason="Only OSX")
+@pytest.mark.parametrize("op_system,os_version,sdk,arch", [
+    ("watchOS", "8.1", "watchos", "armv7k"),
+    ("tvOS", "13.2", "appletvos", "armv8")
+])
+def test_xcode_bitcode_arc_and_visibility_flags_are_none(op_system, os_version, sdk, arch):
+    """
+    Testing what happens when any of the Bitcode, ARC or Visibility configurations are not defined.
+
+    Note: If cross-compiling to watchOS or tvOS, bitcode will be enabled by default.
+    """
+    profile = textwrap.dedent("""
+        include(default)
+        [settings]
+        os={}
+        os.version={}
+        os.sdk={}
+        arch={}
+    """.format(op_system, os_version, sdk, arch))
+
+    client = TestClient(path_with_spaces=False)
+    client.save({"host": profile}, clean_first=True)
+    client.run("new hello/0.1 --template=cmake_lib")
+    client.run("install . --profile:build=default --profile:host=host")
+    toolchain = client.load(os.path.join("cmake-build-release", "conan", "conan_toolchain.cmake"))
+    # bitcode is enabled by default
+    assert 'set(CMAKE_XCODE_ATTRIBUTE_ENABLE_BITCODE "YES")' in toolchain
+    assert 'set(CMAKE_XCODE_ATTRIBUTE_BITCODE_GENERATION_MODE "bitcode")' in toolchain
+    assert 'set(BITCODE "-fembed-bitcode")' in toolchain
+    # arc
+    assert 'set(FOBJC_ARC "-' not in toolchain
+    assert 'set(CMAKE_XCODE_ATTRIBUTE_CLANG_ENABLE_OBJC_ARC' not in toolchain
+    # visibility
+    assert 'set(CMAKE_XCODE_ATTRIBUTE_GCC_SYMBOLS_PRIVATE_EXTERN' not in toolchain
+    assert 'set(VISIBILITY "-' not in toolchain
+    # flags
+    assert 'string(APPEND CONAN_C_FLAGS " ${BITCODE} ${FOBJC_ARC}")' in toolchain
+    assert 'string(APPEND CONAN_CXX_FLAGS " ${BITCODE} ${VISIBILITY} ${FOBJC_ARC}")' in toolchain
+
+    client.run("create . --profile:build=default --profile:host=host -tf None")
+    assert "[100%] Built target hello" in client.out

--- a/conans/test/functional/toolchains/cmake/test_cmake_toolchain_xcode_flags.py
+++ b/conans/test/functional/toolchains/cmake/test_cmake_toolchain_xcode_flags.py
@@ -12,7 +12,7 @@ from conans.test.utils.tools import TestClient
     ("watchOS", "8.1", "watchos", "armv7k"),
     ("tvOS", "13.2", "appletvos", "armv8")
 ])
-def test_xcode_bitcode_arc_and_visibility_flags(op_system, os_version, sdk, arch):
+def test_xcode_bitcode_arc_and_visibility_flags_enabled(op_system, os_version, sdk, arch):
     profile = textwrap.dedent("""
         include(default)
         [settings]
@@ -23,7 +23,7 @@ def test_xcode_bitcode_arc_and_visibility_flags(op_system, os_version, sdk, arch
         [conf]
         tools.apple:enable_bitcode=True
         tools.apple:enable_arc=True
-        tools.apple:enable_visibility=False
+        tools.apple:enable_visibility=True
     """.format(op_system, os_version, sdk, arch))
 
     client = TestClient(path_with_spaces=False)
@@ -38,6 +38,48 @@ def test_xcode_bitcode_arc_and_visibility_flags(op_system, os_version, sdk, arch
     # arc
     assert 'set(FOBJC_ARC "-fobjc-arc")' in toolchain
     assert 'set(CMAKE_XCODE_ATTRIBUTE_CLANG_ENABLE_OBJC_ARC "YES")' in toolchain
+    # visibility
+    assert 'set(CMAKE_XCODE_ATTRIBUTE_GCC_SYMBOLS_PRIVATE_EXTERN "NO")' in toolchain
+    assert 'set(VISIBILITY "-fvisibility=default")' in toolchain
+    # flags
+    assert 'string(APPEND CONAN_C_FLAGS " ${BITCODE} ${FOBJC_ARC}")' in toolchain
+    assert 'string(APPEND CONAN_CXX_FLAGS " ${BITCODE} ${VISIBILITY} ${FOBJC_ARC}")' in toolchain
+
+    client.run("create . --profile:build=default --profile:host=host -tf None")
+    assert "[100%] Built target hello" in client.out
+
+
+@pytest.mark.skipif(platform.system() != "Darwin", reason="Only OSX")
+@pytest.mark.parametrize("op_system,os_version,sdk,arch", [
+    ("watchOS", "8.1", "watchos", "armv7k"),
+    ("tvOS", "13.2", "appletvos", "armv8")
+])
+def test_xcode_bitcode_arc_and_visibility_flags_disabled(op_system, os_version, sdk, arch):
+    profile = textwrap.dedent("""
+        include(default)
+        [settings]
+        os={}
+        os.version={}
+        os.sdk={}
+        arch={}
+        [conf]
+        tools.apple:enable_bitcode=False
+        tools.apple:enable_arc=False
+        tools.apple:enable_visibility=False
+    """.format(op_system, os_version, sdk, arch))
+
+    client = TestClient(path_with_spaces=False)
+    client.save({"host": profile}, clean_first=True)
+    client.run("new hello/0.1 --template=cmake_lib")
+    client.run("install . --profile:build=default --profile:host=host")
+    toolchain = client.load(os.path.join("cmake-build-release", "conan", "conan_toolchain.cmake"))
+    # bitcode
+    assert 'set(CMAKE_XCODE_ATTRIBUTE_ENABLE_BITCODE "NO")' in toolchain
+    assert 'set(CMAKE_XCODE_ATTRIBUTE_BITCODE_GENERATION_MODE "bitcode")' not in toolchain
+    assert 'set(BITCODE "-fembed-bitcode")' not in toolchain
+    # arc
+    assert 'set(FOBJC_ARC "-fno-objc-arc")' in toolchain
+    assert 'set(CMAKE_XCODE_ATTRIBUTE_CLANG_ENABLE_OBJC_ARC "NO")' in toolchain
     # visibility
     assert 'set(CMAKE_XCODE_ATTRIBUTE_GCC_SYMBOLS_PRIVATE_EXTERN "YES")' in toolchain
     assert 'set(VISIBILITY "-fvisibility=hidden -fvisibility-inlines-hidden")' in toolchain

--- a/conans/test/functional/toolchains/cmake/test_cmake_toolchain_xcode_flags.py
+++ b/conans/test/functional/toolchains/cmake/test_cmake_toolchain_xcode_flags.py
@@ -64,9 +64,9 @@ def test_cmake_apple_bitcode_arc_and_visibility_flags_enabled(op_system, os_vers
 ])
 def test_cmake_apple_bitcode_arc_and_visibility_flags_enabled_and_xcode_generator(op_system, os_version, sdk, arch):
     """
-    Testing what happens when any of the Bitcode, ARC or Visibility configurations are not defined.
+    Testing when all the Bitcode, ARC and Visibility are enabled, and Xcode as generator.
 
-    Note: If cross-compiling to watchOS or tvOS, bitcode will be enabled by default.
+    Note: When using CMake and Xcode as generator, the C/CXX flags do not need to be appended.
     """
     profile = textwrap.dedent("""
         include(default)
@@ -85,9 +85,10 @@ def test_cmake_apple_bitcode_arc_and_visibility_flags_enabled_and_xcode_generato
     client.save({"host": profile}, clean_first=True)
     client.run("new hello/0.1 --template=cmake_lib")
     _add_message_status_flags(client)
-    client.run("create . --profile:build=default --profile:host=host -tf None -c tools.cmake.cmaketoolchain:generator=Xcode")
+    client.run("create . --profile:build=default --profile:host=host -tf None "
+               "-c tools.cmake.cmaketoolchain:generator=Xcode")
     assert "** BUILD SUCCEEDED **" in client.out
-    # flags
+    # flags are not appended when Xcode generator is used
     for line in str(client.out).splitlines():
         if "CONAN_C_FLAGS:" in line:
             assert "-- CONAN_C_FLAGS:" == line.strip()
@@ -147,8 +148,6 @@ def test_cmake_apple_bitcode_arc_and_visibility_flags_disabled(op_system, os_ver
 def test_cmake_apple_bitcode_arc_and_visibility_flags_are_none(op_system, os_version, sdk, arch):
     """
     Testing what happens when any of the Bitcode, ARC or Visibility configurations are not defined.
-
-    Note: If cross-compiling to watchOS or tvOS, bitcode will be enabled by default.
     """
     profile = textwrap.dedent("""
         include(default)
@@ -177,7 +176,7 @@ def test_cmake_apple_bitcode_arc_and_visibility_flags_are_none(op_system, os_ver
     assert 'set(VISIBILITY "-' not in toolchain
 
     client.run("create . --profile:build=default --profile:host=host -tf None")
-    # flags
+    # flags are not appended
     for flag in ["-fembed-bitcode", "-fno-objc-arc", "-fobjc-arc", "-fvisibility"]:
         assert flag not in client.out
     assert "[100%] Built target hello" in client.out


### PR DESCRIPTION
Changelog: Feature: Added new configuration fields: `tools.apple:enable_bitcode`, `tools.apple:enable_arc` and `tools.apple:enable_visibility`.
Changelog: Feature: Added new mechanism to inject common Xcode flags in `CMakeToolchain` generator if enabled Bitcode, ARC, or Visibility configurations.
Closes: https://github.com/conan-io/conan/issues/9448
Docs: https://github.com/conan-io/docs/pull/2506
