### PR TITLE
self.run(env="conanbuild") instead of "None"

### DIFF
--- a/conans/client/subsystems.py
+++ b/conans/client/subsystems.py
@@ -18,7 +18,7 @@ def run_in_windows_bash(conanfile, command, cwd=None, env=None):
     from conan.tools.env import Environment
     from conan.tools.env.environment import environment_wrap_command
     """ Will run a unix command inside a bash terminal It requires to have MSYS2, CYGWIN, or WSL"""
-    if env:
+    if env and env != ["conanbuild"]:
         # Passing env invalidates the conanfile.environment_scripts
         env_win = [env] if not isinstance(env, list) else env
         env_shell = []

--- a/conans/client/subsystems.py
+++ b/conans/client/subsystems.py
@@ -18,7 +18,7 @@ def run_in_windows_bash(conanfile, command, cwd=None, env=None):
     from conan.tools.env import Environment
     from conan.tools.env.environment import environment_wrap_command
     """ Will run a unix command inside a bash terminal It requires to have MSYS2, CYGWIN, or WSL"""
-    if env and env != ["conanbuild"]:
+    if env and env != "conanbuild":
         # Passing env invalidates the conanfile.environment_scripts
         env_win = [env] if not isinstance(env, list) else env
         env_shell = []

--- a/conans/model/conan_file.py
+++ b/conans/model/conan_file.py
@@ -215,7 +215,7 @@ class ConanFile:
         """ define cpp_build_info, flags, etc
         """
 
-    def run(self, command, stdout=None, cwd=None, ignore_errors=False, env=None, quiet=False,
+    def run(self, command, stdout=None, cwd=None, ignore_errors=False, env="conanbuild", quiet=False,
             shell=True):
         # NOTE: "self.win_bash" is the new parameter "win_bash" for Conan 2.0
         command = self._conan_helpers.cmd_wrapper.wrap(command)
@@ -223,10 +223,11 @@ class ConanFile:
             if self.win_bash:  # New, Conan 2.0
                 from conans.client.subsystems import run_in_windows_bash
                 return run_in_windows_bash(self, command=command, cwd=cwd, env=env)
-        if env is None:
-            env = "conanbuild"
         from conan.tools.env.environment import environment_wrap_command
-        wrapped_cmd = environment_wrap_command(env, command, cwd=self.generators_folder)
+        if env:
+            wrapped_cmd = environment_wrap_command(env, command, cwd=self.generators_folder)
+        else:
+            wrapped_cmd = command
         from conans.util.runners import conan_run
         ConanOutput().writeln(f"{self.display_name}: RUN: {command if not quiet else '*hidden*'}")
         retcode = conan_run(wrapped_cmd, cwd=cwd, stdout=stdout, shell=shell)

--- a/conans/test/integration/environment/test_env.py
+++ b/conans/test/integration/environment/test_env.py
@@ -572,3 +572,44 @@ def test_deactivate_location():
 
     assert os.path.exists(os.path.join(client.current_folder, "myfolder",
                                        "deactivate_conanbuildenv-release-x86_64{}".format(script_ext)))
+
+
+@pytest.mark.skipif(platform.system() == "Windows", reason="Requires sh")
+def test_skip_virtualbuildenv_run():
+    # Build require
+    conanfile = textwrap.dedent(r"""
+           from conan import ConanFile
+           from conan.tools.env import Environment
+           class Pkg(ConanFile):
+               def package_info(self):
+                   self.buildenv_info.define("FOO", "BAR")
+           """)
+    client = TestClient()
+    client.save({"pkg.py": conanfile})
+    client.run("create pkg.py --name pkg --version 1.0")
+
+    # consumer
+    conanfile = textwrap.dedent(r"""
+               import os
+               from conan import ConanFile
+               from conan.tools.env import Environment
+               class Consumer(ConanFile):
+                   tool_requires = "pkg/1.0"
+                   exports_sources = "my_script.sh"
+                   def build(self):
+                       path = os.path.join(self.source_folder, "my_script.sh")
+                       os.chmod(path, 0o777)
+                       self.run("'{}'".format(path))
+               """)
+    my_script = 'echo FOO is $FOO'
+    client.save({"conanfile.py": conanfile, "my_script.sh": my_script})
+    client.run("create . --name consumer --version 1.0")
+    assert "FOO is BAR" in client.out
+
+    # If we pass env=None no "conanbuild" is applied
+    # self.run("'{}'".format(path), env=None)
+    conanfile = conanfile.replace(".format(path))",
+                                  ".format(path), env=None)")
+    client.save({"conanfile.py": conanfile})
+    client.run("create . --name consumer --version 1.0")
+    assert "FOO is BAR" not in client.out

--- a/conans/test/integration/environment/test_env.py
+++ b/conans/test/integration/environment/test_env.py
@@ -579,7 +579,6 @@ def test_skip_virtualbuildenv_run():
     # Build require
     conanfile = textwrap.dedent(r"""
            from conan import ConanFile
-           from conan.tools.env import Environment
            class Pkg(ConanFile):
                def package_info(self):
                    self.buildenv_info.define("FOO", "BAR")
@@ -592,7 +591,6 @@ def test_skip_virtualbuildenv_run():
     conanfile = textwrap.dedent(r"""
                import os
                from conan import ConanFile
-               from conan.tools.env import Environment
                class Consumer(ConanFile):
                    tool_requires = "pkg/1.0"
                    exports_sources = "my_script.sh"


### PR DESCRIPTION
Changelog: omit
Docs: https://github.com/conan-io/docs/pull/XXXX

Related #11009
If we would like to skip the "conanbuild" for any reason to be applied at some `self.run` execution (sounds legit use case) we don't have a way to override the default to not apply `conanbuild`. Look at the test.
**FIXME**: I made this in develop2 but it should be done in "develop" I guess.