### PR TITLE
self.run(env="conanbuild") instead of "None"

### DIFF
--- a/conans/client/subsystems.py
+++ b/conans/client/subsystems.py
@@ -17,7 +17,7 @@ def run_in_windows_bash(conanfile, command, cwd=None, env=None):
     from conan.tools.env import Environment
     from conan.tools.env.environment import environment_wrap_command
     """ Will run a unix command inside a bash terminal It requires to have MSYS2, CYGWIN, or WSL"""
-    if env:
+    if env and env != "conanbuild":
         # Passing env invalidates the conanfile.environment_scripts
         env_win = [env] if not isinstance(env, list) else env
         env_shell = []

--- a/conans/client/subsystems.py
+++ b/conans/client/subsystems.py
@@ -13,17 +13,20 @@ WSL = 'wsl'  # Windows Subsystem for Linux
 SFU = 'sfu'  # Windows Services for UNIX
 
 
-def run_in_windows_bash(conanfile, command, cwd=None, env=None):
+def run_in_windows_bash(conanfile, command, cwd=None, env="conanbuild"):
     from conan.tools.env import Environment
     from conan.tools.env.environment import environment_wrap_command
     """ Will run a unix command inside a bash terminal It requires to have MSYS2, CYGWIN, or WSL"""
-    if env and env != "conanbuild":
-        # Passing env invalidates the conanfile.environment_scripts
-        env_win = [env] if not isinstance(env, list) else env
-        env_shell = []
-    else:
-        env_shell = ["conanbuild.sh"]
-        env_win = ["conanbuild.bat"]
+    env_win = []
+    env_shell = []
+    if env:
+        if env == "conanbuild":
+            env_shell = ["conanbuild.sh"]
+            env_win = ["conanbuild.bat"]
+        else:
+            # Passing env invalidates the conanfile.environment_scripts
+            env_win = [env] if not isinstance(env, list) else env
+            env_shell = []
 
     subsystem = conanfile.conf.get("tools.microsoft.bash:subsystem")
     shell_path = conanfile.conf.get("tools.microsoft.bash:path")

--- a/conans/model/conan_file.py
+++ b/conans/model/conan_file.py
@@ -376,7 +376,7 @@ class ConanFile(object):
         """
 
     def run(self, command, output=True, cwd=None, win_bash=False, subsystem=None, msys_mingw=True,
-            ignore_errors=False, run_environment=False, with_login=True, env=None):
+            ignore_errors=False, run_environment=False, with_login=True, env="conanbuild"):
         # NOTE: "self.win_bash" is the new parameter "win_bash" for Conan 2.0
 
         def _run(cmd, _env):
@@ -388,10 +388,11 @@ class ConanFile(object):
                 elif self.win_bash:  # New, Conan 2.0
                     from conans.client.subsystems import run_in_windows_bash
                     return run_in_windows_bash(self, command=cmd, cwd=cwd, env=_env)
-            if _env is None:
-                _env = "conanbuild"
             from conan.tools.env.environment import environment_wrap_command
-            wrapped_cmd = environment_wrap_command(_env, cmd, cwd=self.generators_folder)
+            if env:
+                wrapped_cmd = environment_wrap_command(_env, cmd, cwd=self.generators_folder)
+            else:
+                wrapped_cmd = cmd
             return self._conan_runner(wrapped_cmd, output, os.path.abspath(RUN_LOG_NAME), cwd)
 
         if run_environment:


### PR DESCRIPTION
Changelog: omit
Docs: https://github.com/conan-io/docs/pull/2516

SAME AS https://github.com/conan-io/conan/pull/11011 BUT IN DEVELOP BRANCH

Related https://github.com/conan-io/conan/issues/11009
If we would like to skip the "conanbuild" for any reason to be applied at some self.run execution (sounds legit use case) we don't have a way to override the default to not apply conanbuild. Look at the test.

