### PR TITLE
Escape quotes for XCodeDeps generator

### DIFF
--- a/conan/tools/apple/xcodedeps.py
+++ b/conan/tools/apple/xcodedeps.py
@@ -146,11 +146,11 @@ class XcodeDeps(object):
             'system_libs': " ".join("-l{}".format(sys_lib) for sys_lib in cpp_info.system_libs),
             'frameworksdirs': " ".join('"{}"'.format(p) for p in cpp_info.frameworkdirs),
             'frameworks': " ".join("-framework {}".format(framework) for framework in cpp_info.frameworks),
-            'definitions': " ".join(cpp_info.defines),
-            'c_compiler_flags': " ".join(cpp_info.cflags),
-            'cxx_compiler_flags': " ".join(cpp_info.cxxflags),
-            'linker_flags': " ".join(cpp_info.sharedlinkflags),
-            'exe_flags': " ".join(cpp_info.exelinkflags),
+            'definitions': " ".join('"{}"'.format(p.replace('"', '\\"')) for p in cpp_info.defines),
+            'c_compiler_flags': " ".join('"{}"'.format(p.replace('"', '\\"')) for p in cpp_info.cflags),
+            'cxx_compiler_flags': " ".join('"{}"'.format(p.replace('"', '\\"')) for p in cpp_info.cxxflags),
+            'linker_flags': " ".join('"{}"'.format(p.replace('"', '\\"')) for p in cpp_info.sharedlinkflags),
+            'exe_flags': " ".join('"{}"'.format(p.replace('"', '\\"')) for p in cpp_info.exelinkflags),
             'condition': _xcconfig_conditional(self._conanfile.settings)
         }
         formatted_template = Template(self._vars_xconfig).render(**fields)

--- a/conans/test/functional/toolchains/apple/test_xcodedeps_build_configs.py
+++ b/conans/test/functional/toolchains/apple/test_xcodedeps_build_configs.py
@@ -387,3 +387,36 @@ def test_xcodedeps_dashes_names_and_arch():
     assert os.path.exists(os.path.join(client.current_folder,
                                        "conan_hello_dashes_vars_release_arm64.xcconfig"))
     client.run_command("xcodebuild -project app.xcodeproj -xcconfig conandeps.xcconfig -arch arm64")
+
+
+@pytest.mark.skipif(platform.system() != "Darwin", reason="Only for MacOS")
+@pytest.mark.tool_xcodebuild
+def test_xcodedeps_definitions_escape():
+    client = TestClient(path_with_spaces=False)
+    conanfile = textwrap.dedent("""
+        from conans import ConanFile
+
+        class HelloLib(ConanFile):
+            def package_info(self):
+                self.cpp_info.defines.append('USER_CONFIG="user_config.h"')
+                self.cpp_info.defines.append('OTHER="other.h"')
+        """)
+    client.save({"conanfile.py": conanfile})
+    client.run("export . hello/1.0@")
+    client.save({"conanfile.txt": "[requires]\nhello/1.0\n"}, clean_first=True)
+    main = textwrap.dedent("""
+                                #include <stdio.h>
+                                #define STR(x)   #x
+                                #define SHOW_DEFINE(x) printf("%s=%s", #x, STR(x))
+                                int main(int argc, char *argv[]) {
+                                    SHOW_DEFINE(USER_CONFIG);
+                                    SHOW_DEFINE(OTHER);
+                                    return 0;
+                                }
+                                """)
+    create_xcode_project(client, "app", main)
+    client.run("install . --build=missing -g XcodeDeps")
+    client.run_command("xcodebuild -project app.xcodeproj -xcconfig conandeps.xcconfig")
+    client.run_command("build/Release/app")
+    assert 'USER_CONFIG="user_config.h"' in client.out
+    assert 'OTHER="other.h"' in client.out

--- a/conans/test/functional/toolchains/apple/test_xcodedeps_build_configs.py
+++ b/conans/test/functional/toolchains/apple/test_xcodedeps_build_configs.py
@@ -393,14 +393,14 @@ def test_xcodedeps_dashes_names_and_arch():
 @pytest.mark.tool_xcodebuild
 def test_xcodedeps_definitions_escape():
     client = TestClient(path_with_spaces=False)
-    conanfile = textwrap.dedent("""
+    conanfile = textwrap.dedent('''
         from conans import ConanFile
 
         class HelloLib(ConanFile):
             def package_info(self):
-                self.cpp_info.defines.append('USER_CONFIG="user_config.h"')
+                self.cpp_info.defines.append("USER_CONFIG=\\"user_config.h\\"")
                 self.cpp_info.defines.append('OTHER="other.h"')
-        """)
+        ''')
     client.save({"conanfile.py": conanfile})
     client.run("export . hello/1.0@")
     client.save({"conanfile.txt": "[requires]\nhello/1.0\n"}, clean_first=True)


### PR DESCRIPTION
Changelog: Fix: Escape quotes in XCodeDeps generator.
Docs: omit

Testing the [imgui recipe](https://github.com/conan-io/conan-center-index/blob/6a06d9628bba096497e77d93065715a672cea382/recipes/imgui/all/conanfile.py#L73) from Conan Center looks like XCode won't accept the defines generated in the xcconfig files because quote character is not properly escaped.

Related to: https://github.com/conan-io/conan/issues/11013
