### PR TITLE
Cmake complex strings

### DIFF
--- a/conan/tools/cmake/toolchain/blocks.py
+++ b/conan/tools/cmake/toolchain/blocks.py
@@ -532,6 +532,7 @@ class ExtraFlagsBlock(Block):
     """This block is adding flags directly from user [conf] section"""
 
     template = textwrap.dedent("""
+        # Extra c, cxx, linkflags and defines
         {% if cxxflags %}
         string(APPEND CONAN_CXX_FLAGS "{% for cxxflag in cxxflags %} {{ cxxflag }}{% endfor %}")
         {% endif %}
@@ -545,7 +546,7 @@ class ExtraFlagsBlock(Block):
         string(APPEND CONAN_EXE_LINKER_FLAGS "{% for exelinkflag in exelinkflags %} {{ exelinkflag }}{% endfor %}")
         {% endif %}
         {% if defines %}
-        add_compile_definitions({% for define in defines %} {{ define }}{% endfor %})
+        add_compile_definitions({% for define in defines %} "{{ define }}"{% endfor %})
         {% endif %}
     """)
 
@@ -561,7 +562,7 @@ class ExtraFlagsBlock(Block):
             "cflags": cflags,
             "sharedlinkflags": sharedlinkflags,
             "exelinkflags": exelinkflags,
-            "defines": defines
+            "defines": [define.replace('"', '\\"') for define in defines]
         }
 
 

--- a/conan/tools/cmake/toolchain/toolchain.py
+++ b/conan/tools/cmake/toolchain/toolchain.py
@@ -61,11 +61,11 @@ class CMakeToolchain(object):
             {% for it, values in var_config.items() %}
                 {% set genexpr = namespace(str='') %}
                 {% for conf, value in values -%}
-                set(CONAN_DEF_{{ it }} "{{ value }}")
+                set(CONAN_DEF_{{ conf }}{{ it }} "{{ value }}")
                 {% endfor %}
                 {% for conf, value in values -%}
                     {% set genexpr.str = genexpr.str +
-                                          '$<IF:$<CONFIG:' + conf + '>,${CONAN_DEF_' + it|string + '},' %}
+                                          '$<IF:$<CONFIG:' + conf + '>,${CONAN_DEF_' + conf|string + it|string + '},' %}
                     {% if loop.last %}{% set genexpr.str = genexpr.str + '""' -%}{%- endif -%}
                 {% endfor %}
                 {% for i in range(values|count) %}{% set genexpr.str = genexpr.str + '>' %}

--- a/conans/test/functional/toolchains/cmake/test_cmake.py
+++ b/conans/test/functional/toolchains/cmake/test_cmake.py
@@ -38,8 +38,8 @@ class Base(unittest.TestCase):
                 tc.variables.release["MYVAR2_CONFIG"] = "MYVAR2_RELEASE"
                 tc.preprocessor_definitions["MYDEFINE"] = "\"MYDEF_VALUE\""
                 tc.preprocessor_definitions["MYDEFINEINT"] = 42
-                tc.preprocessor_definitions.debug["MYDEFINE_CONFIG"] = "MYDEF_DEBUG"
-                tc.preprocessor_definitions.release["MYDEFINE_CONFIG"] = "MYDEF_RELEASE"
+                tc.preprocessor_definitions.debug["MYDEFINE_CONFIG"] = "\"MYDEF_DEBUG\""
+                tc.preprocessor_definitions.release["MYDEFINE_CONFIG"] = "\"MYDEF_RELEASE\""
                 tc.preprocessor_definitions.debug["MYDEFINEINT_CONFIG"] = 421
                 tc.preprocessor_definitions.release["MYDEFINEINT_CONFIG"] = 422
                 tc.generate()

--- a/conans/test/functional/toolchains/cmake/test_cmake.py
+++ b/conans/test/functional/toolchains/cmake/test_cmake.py
@@ -18,7 +18,7 @@ from conans.util.files import save
 @pytest.mark.tool_cmake
 class Base(unittest.TestCase):
 
-    conanfile = textwrap.dedent("""
+    conanfile = textwrap.dedent(r"""
         from conans import ConanFile
         from conan.tools.cmake import CMake, CMakeToolchain
         class App(ConanFile):
@@ -36,7 +36,7 @@ class Base(unittest.TestCase):
                 tc.variables.release["MYVAR_CONFIG"] = "MYVAR_RELEASE"
                 tc.variables.debug["MYVAR2_CONFIG"] = "MYVAR2_DEBUG"
                 tc.variables.release["MYVAR2_CONFIG"] = "MYVAR2_RELEASE"
-                tc.preprocessor_definitions["MYDEFINE"] = "MYDEF_VALUE"
+                tc.preprocessor_definitions["MYDEFINE"] = "\"MYDEF_VALUE\""
                 tc.preprocessor_definitions["MYDEFINEINT"] = 42
                 tc.preprocessor_definitions.debug["MYDEFINE_CONFIG"] = "MYDEF_DEBUG"
                 tc.preprocessor_definitions.release["MYDEFINE_CONFIG"] = "MYDEF_RELEASE"

--- a/conans/test/functional/toolchains/cmake/test_cmake_toolchain.py
+++ b/conans/test/functional/toolchains/cmake/test_cmake_toolchain.py
@@ -295,7 +295,7 @@ def test_cmake_toolchain_definitions_complex_strings():
                  "CMakeLists.txt": cmakelists}, clean_first=True)
     client.run("install . -pr=./profile -if=install")
     client.run("build . -if=install")
-    exe = "cmake-build-release/example" if platform.system() != "Windows" else "build/Release/example"
+    exe = "cmake-build-release/example" if platform.system() != "Windows" else r"build\MyRelease\example.exe"
     client.run_command(exe)
     assert 'escape=partially "escaped"' in client.out
     assert 'spaces=me you' in client.out

--- a/conans/test/functional/toolchains/cmake/test_cmake_toolchain.py
+++ b/conans/test/functional/toolchains/cmake/test_cmake_toolchain.py
@@ -233,16 +233,16 @@ def test_install_output_directories():
 def test_cmake_toolchain_definitions_complex_strings():
     # https://github.com/conan-io/conan/issues/11043
     client = TestClient(path_with_spaces=False)
-    profile = textwrap.dedent('''
+    profile = textwrap.dedent(r'''
         include(default)
         [conf]
-        tools.build:defines+=["escape=partially \\\"escaped\\\""]
+        tools.build:defines+=["escape=partially \"escaped\""]
         tools.build:defines+=["spaces=me you"]
         tools.build:defines+=["foobar=bazbuz"]
         tools.build:defines+=["answer=42"]
     ''')
 
-    conanfile = textwrap.dedent('''
+    conanfile = textwrap.dedent(r'''
         from conan import ConanFile
         from conan.tools.cmake import CMake, CMakeToolchain, cmake_layout
 
@@ -252,7 +252,7 @@ def test_cmake_toolchain_definitions_complex_strings():
 
             def generate(self):
                 tc = CMakeToolchain(self)
-                tc.preprocessor_definitions["escape2"] = "partially \\\"escaped\\\""
+                tc.preprocessor_definitions["escape2"] = "partially \"escaped\""
                 tc.preprocessor_definitions["spaces2"] = "me you"
                 tc.preprocessor_definitions["foobar2"] = "bazbuz"
                 tc.preprocessor_definitions["answer2"] = 42

--- a/conans/test/functional/toolchains/cmake/test_cmake_toolchain.py
+++ b/conans/test/functional/toolchains/cmake/test_cmake_toolchain.py
@@ -230,6 +230,7 @@ def test_install_output_directories():
     assert 'set(CMAKE_INSTALL_LIBDIR "mylibs")' in toolchain
 
 
+@pytest.mark.tool_cmake
 def test_cmake_toolchain_definitions_complex_strings():
     # https://github.com/conan-io/conan/issues/11043
     client = TestClient(path_with_spaces=False)

--- a/conans/test/functional/toolchains/cmake/test_cmake_toolchain.py
+++ b/conans/test/functional/toolchains/cmake/test_cmake_toolchain.py
@@ -256,6 +256,15 @@ def test_cmake_toolchain_definitions_complex_strings():
                 tc.preprocessor_definitions["spaces2"] = "me you"
                 tc.preprocessor_definitions["foobar2"] = "bazbuz"
                 tc.preprocessor_definitions["answer2"] = 42
+                tc.preprocessor_definitions.release["escape_release"] = "partially \"escaped\""
+                tc.preprocessor_definitions.release["spaces_release"] = "me you"
+                tc.preprocessor_definitions.release["foobar_release"] = "bazbuz"
+                tc.preprocessor_definitions.release["answer_release"] = 42
+
+                tc.preprocessor_definitions.debug["escape_debug"] = "partially \"escaped\""
+                tc.preprocessor_definitions.debug["spaces_debug"] = "me you"
+                tc.preprocessor_definitions.debug["foobar_debug"] = "bazbuz"
+                tc.preprocessor_definitions.debug["answer_debug"] = 42
                 tc.generate()
 
             def layout(self):
@@ -280,6 +289,17 @@ def test_cmake_toolchain_definitions_complex_strings():
             SHOW_DEFINE(spaces2);
             SHOW_DEFINE(foobar2);
             SHOW_DEFINE(answer2);
+            #ifdef NDEBUG
+            SHOW_DEFINE(escape_release);
+            SHOW_DEFINE(spaces_release);
+            SHOW_DEFINE(foobar_release);
+            SHOW_DEFINE(answer_release);
+            #else
+            SHOW_DEFINE(escape_debug);
+            SHOW_DEFINE(spaces_debug);
+            SHOW_DEFINE(foobar_debug);
+            SHOW_DEFINE(answer_debug);
+            #endif
             return 0;
         }
         """)
@@ -295,7 +315,7 @@ def test_cmake_toolchain_definitions_complex_strings():
                  "CMakeLists.txt": cmakelists}, clean_first=True)
     client.run("install . -pr=./profile -if=install")
     client.run("build . -if=install")
-    exe = "cmake-build-release/example" if platform.system() != "Windows" else r"build\MyRelease\example.exe"
+    exe = "cmake-build-release/example" if platform.system() != "Windows" else r"build\Release\example.exe"
     client.run_command(exe)
     assert 'escape=partially "escaped"' in client.out
     assert 'spaces=me you' in client.out
@@ -305,3 +325,16 @@ def test_cmake_toolchain_definitions_complex_strings():
     assert 'spaces2=me you' in client.out
     assert 'foobar2=bazbuz' in client.out
     assert 'answer2=42' in client.out
+    assert 'escape_release=partially "escaped"' in client.out
+    assert 'spaces_release=me you' in client.out
+    assert 'foobar_release=bazbuz' in client.out
+    assert 'answer_release=42' in client.out
+
+    client.run("install . -pr=./profile -if=install -s build_type=Debug")
+    client.run("build . -if=install -s build_type=Debug")
+    exe = "cmake-build-debug/example" if platform.system() != "Windows" else r"build\Debug\example.exe"
+    client.run_command(exe)
+    assert 'escape_debug=partially "escaped"' in client.out
+    assert 'spaces_debug=me you' in client.out
+    assert 'foobar_debug=bazbuz' in client.out
+    assert 'answer_debug=42' in client.out

--- a/conans/test/functional/toolchains/cmake/test_cmake_toolchain.py
+++ b/conans/test/functional/toolchains/cmake/test_cmake_toolchain.py
@@ -256,15 +256,15 @@ def test_cmake_toolchain_definitions_complex_strings():
                 tc.preprocessor_definitions["spaces2"] = "me you"
                 tc.preprocessor_definitions["foobar2"] = "bazbuz"
                 tc.preprocessor_definitions["answer2"] = 42
-                tc.preprocessor_definitions.release["escape_release"] = "partially \"escaped\""
-                tc.preprocessor_definitions.release["spaces_release"] = "me you"
-                tc.preprocessor_definitions.release["foobar_release"] = "bazbuz"
+                tc.preprocessor_definitions.release["escape_release"] = "release partially \"escaped\""
+                tc.preprocessor_definitions.release["spaces_release"] = "release me you"
+                tc.preprocessor_definitions.release["foobar_release"] = "release bazbuz"
                 tc.preprocessor_definitions.release["answer_release"] = 42
 
-                tc.preprocessor_definitions.debug["escape_debug"] = "partially \"escaped\""
-                tc.preprocessor_definitions.debug["spaces_debug"] = "me you"
-                tc.preprocessor_definitions.debug["foobar_debug"] = "bazbuz"
-                tc.preprocessor_definitions.debug["answer_debug"] = 42
+                tc.preprocessor_definitions.debug["escape_debug"] = "debug partially \"escaped\""
+                tc.preprocessor_definitions.debug["spaces_debug"] = "debug me you"
+                tc.preprocessor_definitions.debug["foobar_debug"] = "debug bazbuz"
+                tc.preprocessor_definitions.debug["answer_debug"] = 21
                 tc.generate()
 
             def layout(self):
@@ -325,16 +325,16 @@ def test_cmake_toolchain_definitions_complex_strings():
     assert 'spaces2=me you' in client.out
     assert 'foobar2=bazbuz' in client.out
     assert 'answer2=42' in client.out
-    assert 'escape_release=partially "escaped"' in client.out
-    assert 'spaces_release=me you' in client.out
-    assert 'foobar_release=bazbuz' in client.out
+    assert 'escape_release=release partially "escaped"' in client.out
+    assert 'spaces_release=release me you' in client.out
+    assert 'foobar_release=release bazbuz' in client.out
     assert 'answer_release=42' in client.out
 
     client.run("install . -pr=./profile -if=install -s build_type=Debug")
     client.run("build . -if=install -s build_type=Debug")
     exe = "cmake-build-debug/example" if platform.system() != "Windows" else r"build\Debug\example.exe"
     client.run_command(exe)
-    assert 'escape_debug=partially "escaped"' in client.out
-    assert 'spaces_debug=me you' in client.out
-    assert 'foobar_debug=bazbuz' in client.out
-    assert 'answer_debug=42' in client.out
+    assert 'escape_debug=debug partially "escaped"' in client.out
+    assert 'spaces_debug=debug me you' in client.out
+    assert 'foobar_debug=debug bazbuz' in client.out
+    assert 'answer_debug=21' in client.out

--- a/conans/test/functional/toolchains/cmake/test_cmake_toolchain.py
+++ b/conans/test/functional/toolchains/cmake/test_cmake_toolchain.py
@@ -295,7 +295,8 @@ def test_cmake_toolchain_definitions_complex_strings():
                  "CMakeLists.txt": cmakelists}, clean_first=True)
     client.run("install . -pr=./profile -if=install")
     client.run("build . -if=install")
-    client.run_command("cmake-build-release/example")
+    exe = "cmake-build-release/example" if platform.system() != "Windows" else "build/Release/example"
+    client.run_command(exe)
     assert 'escape=partially "escaped"' in client.out
     assert 'spaces=me you' in client.out
     assert 'foobar=bazbuz' in client.out

--- a/conans/test/functional/toolchains/cmake/test_cmake_toolchain.py
+++ b/conans/test/functional/toolchains/cmake/test_cmake_toolchain.py
@@ -233,7 +233,6 @@ def test_install_output_directories():
 def test_cmake_toolchain_definitions_complex_strings():
     # https://github.com/conan-io/conan/issues/11043
     client = TestClient(path_with_spaces=False)
-    client.current_folder = '/private/var/folders/hr/t3_1lzj9145g383b4zyj67d40000gn/T/tmp46iwlzxfconans/pathwithoutspaces'
     profile = textwrap.dedent('''
         include(default)
         [conf]

--- a/conans/test/integration/toolchains/cmake/test_cmaketoolchain.py
+++ b/conans/test/integration/toolchains/cmake/test_cmaketoolchain.py
@@ -327,4 +327,4 @@ def test_extra_flags_via_conf():
     assert 'string(APPEND CONAN_C_FLAGS " --flag3 --flag4")' in toolchain
     assert 'string(APPEND CONAN_SHARED_LINKER_FLAGS " --flag5 --flag6")' in toolchain
     assert 'string(APPEND CONAN_EXE_LINKER_FLAGS " --flag7 --flag8")' in toolchain
-    assert 'add_compile_definitions( D1 D2)' in toolchain
+    assert 'add_compile_definitions( "D1" "D2")' in toolchain


### PR DESCRIPTION
Changelog: Fix: Quote `add_compile_definitions` correctly in CMakeToolchain.
Changelog: Fix: Escape quotes in definitions in CMakeToochain.
Docs: omit

Closes: https://github.com/conan-io/conan/issues/11043

This PR does two things, first quoting the contents of add_compile_definitions following [these recommendations](https://crascit.com/2022/01/25/quoting-in-cmake/).
And also escapes the quotes in the defines so that when generating the toolchain the escaped quotes are correctly preserved.

Looks like CMakeDeps already handles this, so `ConanFile.cpp_info.defines` should not be a problem but I'll add tests and try to homogenize.

TODO: As this is becoming a common pattern in all the generators we should try to homogenize this across all the Conan codebase
