### PR TITLE
Alow "foo/1.0@" to indicate a reference without user and channel 

### DIFF
--- a/conan/api/subapi/search.py
+++ b/conan/api/subapi/search.py
@@ -58,16 +58,16 @@ class SearchAPI:
             if not ref.revision and "#" in expression:
                 # Something like "foo/var#" without specifying revision
                 raise ConanException("Specify a recipe revision")
+
+            # First resolve any * in the regular reference, doing a search
+            if any(["*" in field for field in (ref.name, str(ref.version),
+                                               ref.user or "", ref.channel or "")]):
+                query = str(ref)
+                if expression.endswith("@"):
+                    query += "@"
+                refs = self.recipes(query, remote)
             else:
-                # First resolve any * in the regular reference, doing a search
-                if any(["*" in field for field in (ref.name, str(ref.version),
-                                                   ref.user or "", ref.channel or "")]):
-                    query = str(ref)
-                    if expression.endswith("@"):
-                        query += "@"
-                    refs = self.recipes(query, remote)
-                else:
-                    refs = [ref]
+                refs = [ref]
 
         # Second, for the got references, check revisions matching.
         ret = []

--- a/conans/test/integration/command/remove_test.py
+++ b/conans/test/integration/command/remove_test.py
@@ -240,10 +240,10 @@ def populated_client():
     {"remove": "*/*#*:*", "recipes": ['bar/1.1', 'foo/1.0@user/channel', 'foo/1.0', 'fbar/1.1']},
     {"remove": "foo/1.0@user/channel -p", "recipes": ['bar/1.1', 'foo/1.0@user/channel', 'foo/1.0',
                                                       'fbar/1.1']},
+    {"remove": "foo/*@", "recipes": ['foo/1.0@user/channel', 'bar/1.1', 'fbar/1.1']},
     # These are errors
     {"remove": "foo", "error": True,
      "error_msg": 'ERROR: Invalid expression, specify a version or a wildcard. e.g: foo*\n'},
-    {"remove": "*/*@", "error": True},
     {"remove": "*#", "error": True},
     {"remove": "*/*#", "error": True},
 ])

--- a/conans/test/integration/conan_api/list_test.py
+++ b/conans/test/integration/conan_api/list_test.py
@@ -1,11 +1,10 @@
 import copy
 
-import pytest
 
 from conan.api.conan_api import ConanAPIV2
 from conans.model.recipe_ref import RecipeReference
 from conans.test.assets.genconanfile import GenConanfile
-from conans.test.utils.tools import TurboTestClient
+from conans.test.utils.tools import TurboTestClient, TestClient
 
 
 def _pref_gen():
@@ -71,3 +70,13 @@ def test_get_package_revisions():
     with client.mocked_servers():
         sot = api.list.package_revisions(_pref, api.remotes.get("default"))
         assert sot == [pref3, pref2, pref1]
+
+
+def test_search_recipes_no_user_channel_only():
+    client = TestClient()
+    client.save({"conanfile.py": GenConanfile()})
+    client.run("create . --name foo --version 1.0 --user user --channel channel")
+    client.run("create . --name foo --version 1.0")
+    client.run("list recipes foo/1.0@")
+    assert "foo/1.0@user/channel" not in client.out
+    assert "foo/1.0" in client.out


### PR DESCRIPTION
Changelog: Feature: Enabled patterns ending with `@` to search recipes without user and channel only. e.g: `foo/1.0@`. It affects several commands like `conan list`, `conan remove` and `conan upload`. 
Docs: https://github.com/conan-io/docs/pull/XXXX

Close https://github.com/conan-io/conan/issues/10579