### PR TITLE
adding conf for activate powershell env scripts

### DIFF
--- a/conans/client/generators/__init__.py
+++ b/conans/client/generators/__init__.py
@@ -277,12 +277,15 @@ def _generate_aggregated_env(conanfile):
         subsystem = deduce_subsystem(conanfile, group)
         bats = []
         shs = []
+        ps1s = []
         for env_script in env_scripts:
             path = os.path.join(conanfile.generators_folder, env_script)
             if env_script.endswith(".bat"):
                 bats.append(path)
             elif env_script.endswith(".sh"):
                 shs.append(subsystem_path(subsystem, path))
+            elif env_script.endswith(".ps1"):
+                ps1s.append(path)
         if shs:
             def sh_content(files):
                 return ". " + " && . ".join('"{}"'.format(s) for s in files)
@@ -297,3 +300,10 @@ def _generate_aggregated_env(conanfile):
             save(os.path.join(conanfile.generators_folder, filename), bat_content(bats))
             save(os.path.join(conanfile.generators_folder, "deactivate_{}".format(filename)),
                  bat_content(deactivates(bats)))
+        if ps1s:
+            def ps1_content(files):
+                return "\r\n".join(['& "{}"'.format(b) for b in files])
+            filename = "conan{}.ps1".format(group)
+            save(os.path.join(conanfile.generators_folder, filename), ps1_content(ps1s))
+            save(os.path.join(conanfile.generators_folder, "deactivate_{}".format(filename)),
+                 ps1_content(deactivates(ps1s)))

--- a/conans/test/integration/toolchains/env/test_virtualenv_powershell.py
+++ b/conans/test/integration/toolchains/env/test_virtualenv_powershell.py
@@ -1,0 +1,63 @@
+import os
+import platform
+import textwrap
+
+import pytest
+
+from conans.test.assets.genconanfile import GenConanfile
+from conans.test.utils.tools import TestClient
+from conans.tools import save
+
+
+@pytest.fixture
+def client():
+    client = TestClient(path_with_spaces=False)
+    conanfile = str(GenConanfile("pkg", "0.1"))
+    conanfile += """
+
+    def package_info(self):
+        self.buildenv_info.define_path("MYPATH1", "c:/path/to/ar")
+        self.runenv_info.define("MYVAR1", 'some nice content\" with quotes')
+    """
+    client.save({"conanfile.py": conanfile})
+    client.run("create .")
+    save(client.cache.new_config_path, "tools.env.virtualenv:powershell=True\n"
+                                       "tools.env.virtualenv:auto_use=True\n")
+    return client
+
+
+@pytest.mark.skipif(platform.system() != "Windows", reason="Requires Windows powershell")
+def test_virtualenv(client):
+    conanfile = textwrap.dedent("""
+        import os
+        from conan import ConanFile
+
+        class ConanFileToolsTest(ConanFile):
+            name = "app"
+            version = "0.1"
+            requires = "pkg/0.1"
+
+            def build(self):
+                self.output.info("----------BUILD----------------")
+                self.run("set")
+                self.output.info("----------RUN----------------")
+                self.run("set", env="conanrun")
+        """)
+    client.save({"conanfile.py": conanfile})
+    client.run("install . -s:b os=Windows -s:h os=Windows")
+
+    assert not os.path.exists(os.path.join(client.current_folder, "conanbuildenv.sh"))
+    assert not os.path.exists(os.path.join(client.current_folder, "conanbuildenv.bat"))
+    assert not os.path.exists(os.path.join(client.current_folder, "conanrunenv.sh"))
+    assert not os.path.exists(os.path.join(client.current_folder, "conanrunenv.bat"))
+    buildenv = client.load("conanbuildenv.ps1")
+    assert '$env:MYPATH1="c:/path/to/ar"' in buildenv
+    build = client.load("conanbuild.ps1")
+    assert "conanbuildenv.ps1" in build
+
+    run_contents = client.load("conanrunenv.ps1")
+    assert '$env:MYVAR1="some nice content`" with quotes"' in run_contents
+
+    client.run("create .")
+    assert "MYPATH1=c:/path/to/ar" in client.out
+    assert 'MYVAR1=some nice content" with quotes' in client.out

--- a/conans/test/unittests/client/toolchain/autotools/autotools_deps_test.py
+++ b/conans/test/unittests/client/toolchain/autotools/autotools_deps_test.py
@@ -9,6 +9,7 @@ from conan.tools.gnu import AutotoolsDeps
 from conans import ConanFile
 from conans.model.build_info import CppInfo
 from conans.model.conanfile_interface import ConanFileInterface
+from conans.model.conf import ConfDefinition
 from conans.model.dependencies import ConanFileDependencies, Requirement
 from conans.model.ref import ConanFileReference
 from conans.test.utils.mocks import MockSettings
@@ -74,6 +75,7 @@ def test_foo():
              "compiler.libcxx": "libstdc++11",
              "compiler.version": "7.1",
              "cppstd": "17"})
+        consumer.conf = ConfDefinition().get_conanfile_conf(None)
         deps = AutotoolsDeps(consumer)
 
         env = deps.environment

--- a/conans/test/unittests/tools/env/test_env.py
+++ b/conans/test/unittests/tools/env/test_env.py
@@ -300,7 +300,7 @@ def test_env_win_bash():
     conanfile = ConanFileMock()
     conanfile.settings_build = MockSettings({"os": "Windows"})
     conanfile.win_bash = True
-    conanfile.conf = {"tools.microsoft.bash:subsystem": "msys2"}
+    conanfile.conf.define("tools.microsoft.bash:subsystem", "msys2")
     folder = temp_folder()
     conanfile.folders.generators = folder
     env = Environment()


### PR DESCRIPTION
Changelog: Feature: Adding new ``tools.env.virtualenv:powershell`` conf to opt-in to generate and use powershell scripts instead of .bat ones.
Docs: https://github.com/conan-io/docs/pull/2517

Close https://github.com/conan-io/conan/issues/9898
