### PR TITLE
Add PKG_CONFIG_PATH to AutotoolsToolchain

### DIFF
--- a/conan/tools/gnu/autotoolstoolchain.py
+++ b/conan/tools/gnu/autotoolstoolchain.py
@@ -153,7 +153,7 @@ class AutotoolsToolchain:
         env.append("CXXFLAGS", self._filter_list_empty_fields(self.cxxflags))
         env.append("CFLAGS", self._filter_list_empty_fields(self.cflags))
         env.append("LDFLAGS", self._filter_list_empty_fields(self.ldflags))
-        env.append_path("PKG_CONFIG_PATH", self._conanfile.generators_folder)
+        env.prepend_path("PKG_CONFIG_PATH", self._conanfile.generators_folder)
 
         return env
 

--- a/conan/tools/gnu/autotoolstoolchain.py
+++ b/conan/tools/gnu/autotoolstoolchain.py
@@ -153,7 +153,7 @@ class AutotoolsToolchain:
         env.append("CXXFLAGS", self._filter_list_empty_fields(self.cxxflags))
         env.append("CFLAGS", self._filter_list_empty_fields(self.cflags))
         env.append("LDFLAGS", self._filter_list_empty_fields(self.ldflags))
-        env.define("PKG_CONFIG_PATH", self._conanfile.generators_folder)
+        env.append_path("PKG_CONFIG_PATH", self._conanfile.generators_folder)
 
         return env
 

--- a/conan/tools/gnu/autotoolstoolchain.py
+++ b/conan/tools/gnu/autotoolstoolchain.py
@@ -153,6 +153,7 @@ class AutotoolsToolchain:
         env.append("CXXFLAGS", self._filter_list_empty_fields(self.cxxflags))
         env.append("CFLAGS", self._filter_list_empty_fields(self.cflags))
         env.append("LDFLAGS", self._filter_list_empty_fields(self.ldflags))
+        env.define("PKG_CONFIG_PATH", self._conanfile.generators_folder)
 
         return env
 

--- a/conans/test/functional/toolchains/gnu/autotools/test_basic.py
+++ b/conans/test/functional/toolchains/gnu/autotools/test_basic.py
@@ -2,6 +2,7 @@ import os
 import platform
 import textwrap
 import time
+import re
 
 import pytest
 
@@ -10,7 +11,6 @@ from conans.model.ref import ConanFileReference
 from conans.test.assets.autotools import gen_makefile_am, gen_configure_ac, gen_makefile
 from conans.test.assets.sources import gen_function_cpp
 from conans.test.functional.utils import check_exe_run
-from conans.test.utils.mocks import ConanFileMock
 from conans.test.utils.tools import TestClient, TurboTestClient
 from conans.util.files import touch
 
@@ -223,23 +223,25 @@ def test_install_output_directories():
 @pytest.mark.skipif(platform.system() not in ["Linux", "Darwin"], reason="Requires Autotools")
 @pytest.mark.tool_autotools()
 def test_autotools_with_pkgconfigdeps():
-    client = TurboTestClient(path_with_spaces=False)
+    client = TestClient(path_with_spaces=False)
     client.run("new hello/1.0 --template cmake_lib")
     client.run("create .")
 
     consumer_conanfile = textwrap.dedent("""
         [requires]
         hello/1.0
-
         [generators]
         AutotoolsToolchain
         PkgConfigDeps
     """)
+    client.save({"conanfile.txt": consumer_conanfile}, clean_first=True)
+    client.run("install .")
 
-    main = gen_function_cpp(name="main", includes=["hello"], calls=["hello"])
-    makefile_am = gen_makefile_am(main="main", main_srcs="main.cpp")
-    configure_ac = gen_configure_ac()
-    client.save({"conanfile.txt": consumer_conanfile,
-                 "configure.ac": configure_ac,
-                 "Makefile.am": makefile_am,
-                 "main.cpp": main}, clean_first=True)
+    client.run_command(". conanautotoolstoolchain.sh && "
+                       "pkg-config --cflags hello && "
+                       "pkg-config --libs-only-l hello && "
+                       "pkg-config --libs-only-L --libs-only-other hello")
+
+    assert re.search("I.*hello.*1.0.*include", str(client.out))
+    assert "-lhello" in client.out
+    assert re.search("L.*hello.*1.0.*package", str(client.out))

--- a/conans/test/functional/toolchains/gnu/autotools/test_basic.py
+++ b/conans/test/functional/toolchains/gnu/autotools/test_basic.py
@@ -237,7 +237,7 @@ def test_autotools_with_pkgconfigdeps():
     client.save({"conanfile.txt": consumer_conanfile}, clean_first=True)
     client.run("install .")
 
-    client.run_command(". conanautotoolstoolchain.sh && "
+    client.run_command(". ./conanautotoolstoolchain.sh && "
                        "pkg-config --cflags hello && "
                        "pkg-config --libs-only-l hello && "
                        "pkg-config --libs-only-L --libs-only-other hello")


### PR DESCRIPTION
Changelog: Feature: Append the folder where the Conan generators were installed to `PKG_CONFIG_PATH` in AutotoolsToolchain.
Docs: https://github.com/conan-io/docs/pull/2509

Closes: https://github.com/conan-io/conan/issues/10639