### PR TITLE
Escape quotes for pkg_config and PkgConfigDeps generators

### DIFF
--- a/conan/tools/gnu/pkgconfigdeps/pc_files_templates.py
+++ b/conan/tools/gnu/pkgconfigdeps/pc_files_templates.py
@@ -23,17 +23,17 @@ def _get_pc_file_template():
         {%- endfor -%}
         {%- endmacro -%}
 
-        {%- macro get_cflags(includedirs, cpp_info) -%}
+        {%- macro get_cflags(includedirs, cxxflags, cflags, defines) -%}
         {%- for _ in includedirs -%}
         {{ '-I"${includedir%s}"' % loop.index + " " }}
         {%- endfor -%}
-        {%- for cxxflags in cpp_info.cxxflags -%}
-        {{ cxxflags + " " }}
+        {%- for cxxflag in cxxflags -%}
+        {{ cxxflag + " " }}
         {%- endfor -%}
-        {%- for cflags in cpp_info.cflags-%}
-        {{ cflags + " " }}
+        {%- for cflag in cflags-%}
+        {{ cflag + " " }}
         {%- endfor -%}
-        {%- for define in cpp_info.defines-%}
+        {%- for define in defines-%}
         {{  "-D%s" % define + " " }}
         {%- endfor -%}
         {%- endmacro -%}
@@ -54,7 +54,7 @@ def _get_pc_file_template():
         Description: {{ description }}
         Version: {{ version }}
         Libs: {{ get_libs(libdirs, cpp_info, gnudeps_flags) }}
-        Cflags: {{ get_cflags(includedirs, cpp_info) }}
+        Cflags: {{ get_cflags(includedirs, cxxflags, cflags, defines) }}
         {% if requires|length %}
         Requires: {{ requires|join(' ') }}
         {% endif %}
@@ -106,6 +106,9 @@ def get_pc_filename_and_content(conanfile, dep, name, requires, description, cpp
         "version": version,
         "requires": requires,
         "cpp_info": cpp_info,
+        "cxxflags": [var.replace('"', '\\"') for var in cpp_info.cxxflags],
+        "cflags": [var.replace('"', '\\"') for var in cpp_info.cflags],
+        "defines": [var.replace('"', '\\"') for var in cpp_info.defines],
         "gnudeps_flags": GnuDepsFlags(conanfile, cpp_info)
     }
     template = Template(_get_pc_file_template(), trim_blocks=True, lstrip_blocks=True,

--- a/conans/client/generators/pkg_config.py
+++ b/conans/client/generators/pkg_config.py
@@ -117,8 +117,8 @@ class PkgConfigGenerator(GeneratorComponentsMixin, Generator):
 
         lines.append("Cflags: %s" % _concat_if_not_empty(
             [include_dirs_flags,
-             cpp_info.cxxflags,
-             cpp_info.cflags,
+             [flag.replace('"', '\\"') for flag in cpp_info.cxxflags],
+             [flag.replace('"', '\\"') for flag in cpp_info.cflags],
              ["-D%s" % d.replace('"', '\\"') for d in cpp_info.defines]]))
 
         if requires_gennames:

--- a/conans/client/generators/pkg_config.py
+++ b/conans/client/generators/pkg_config.py
@@ -119,7 +119,7 @@ class PkgConfigGenerator(GeneratorComponentsMixin, Generator):
             [include_dirs_flags,
              cpp_info.cxxflags,
              cpp_info.cflags,
-             ["-D%s" % d for d in cpp_info.defines]]))
+             ["-D%s" % d.replace('"', '\\"') for d in cpp_info.defines]]))
 
         if requires_gennames:
             public_deps = " ".join(requires_gennames)

--- a/conans/test/functional/generators/pkg_config_test.py
+++ b/conans/test/functional/generators/pkg_config_test.py
@@ -334,10 +334,12 @@ def test_pkg_config_definitions_escape():
             def package_info(self):
                 self.cpp_info.defines.append("USER_CONFIG=\"user_config.h\"")
                 self.cpp_info.defines.append('OTHER="other.h"')
+                self.cpp_info.cflags.append("flag1=\"my flag1\"")
+                self.cpp_info.cxxflags.append('flag2="my flag2"')
         ''')
     client.save({"conanfile.py": conanfile})
     client.run("export . hello/1.0@")
     client.save({"conanfile.txt": "[requires]\nhello/1.0\n"}, clean_first=True)
     client.run("install . --build=missing -g pkg_config")
     client.run_command("PKG_CONFIG_PATH=$(pwd) pkg-config --cflags hello")
-    assert r'-DUSER_CONFIG=\"user_config.h\" -DOTHER=\"other.h\"' in client.out
+    assert r'flag2=\"my flag2\" flag1=\"my flag1\" -DUSER_CONFIG=\"user_config.h\" -DOTHER=\"other.h\"' in client.out

--- a/conans/test/functional/generators/pkg_config_test.py
+++ b/conans/test/functional/generators/pkg_config_test.py
@@ -324,6 +324,7 @@ def test_components_and_package_pc_creation_order():
     assert "Requires: OpenCL" in get_requires_from_content(pc_content)
 
 
+@pytest.mark.skipif(platform.system() == "Windows", reason="Requires pkg-config")
 @pytest.mark.tool_pkg_config
 def test_pkg_config_definitions_escape():
     client = TestClient(path_with_spaces=False)

--- a/conans/test/functional/toolchains/gnu/test_pkgconfigdeps.py
+++ b/conans/test/functional/toolchains/gnu/test_pkgconfigdeps.py
@@ -2,6 +2,8 @@ import glob
 import os
 import textwrap
 
+import pytest
+
 from conans.test.assets.genconanfile import GenConanfile
 from conans.test.utils.tools import TestClient
 from conans.util.files import load
@@ -598,3 +600,24 @@ def test_components_and_package_pc_creation_order():
     assert "Requires:" not in pc_content
     pc_content = client.load("pkgb.pc")
     assert "Requires: OpenCL" in get_requires_from_content(pc_content)
+
+
+@pytest.mark.tool_pkg_config
+def test_pkg_configdeps_definitions_escape():
+    client = TestClient(path_with_spaces=False)
+    conanfile = textwrap.dedent(r'''
+        from conans import ConanFile
+        class HelloLib(ConanFile):
+            def package_info(self):
+                self.cpp_info.defines.append("USER_CONFIG=\"user_config.h\"")
+                self.cpp_info.defines.append('OTHER="other.h"')
+                self.cpp_info.cflags.append("flag1=\"my flag1\"")
+                self.cpp_info.cxxflags.append('flag2="my flag2"')
+        ''')
+    client.save({"conanfile.py": conanfile})
+    client.run("export . hello/1.0@")
+    client.save({"conanfile.txt": "[requires]\nhello/1.0\n"}, clean_first=True)
+    client.run("install . --build=missing -g PkgConfigDeps")
+    client.run_command("PKG_CONFIG_PATH=$(pwd) pkg-config --cflags hello")
+    assert r'flag2=\"my flag2\" flag1=\"my flag1\" -DUSER_CONFIG=\"user_config.h\" -DOTHER=\"other.h\"' in client.out
+

--- a/conans/test/functional/toolchains/gnu/test_pkgconfigdeps.py
+++ b/conans/test/functional/toolchains/gnu/test_pkgconfigdeps.py
@@ -1,5 +1,6 @@
 import glob
 import os
+import platform
 import textwrap
 
 import pytest
@@ -602,6 +603,7 @@ def test_components_and_package_pc_creation_order():
     assert "Requires: OpenCL" in get_requires_from_content(pc_content)
 
 
+@pytest.mark.skipif(platform.system() == "Windows", reason="Needs pkg-config")
 @pytest.mark.tool_pkg_config
 def test_pkg_configdeps_definitions_escape():
     client = TestClient(path_with_spaces=False)


### PR DESCRIPTION
Changelog: Fix: Fix quote escaping for defines in pkg_config generator.
Changelog: Fix: Fix quote escaping for defines in PkgConfigDeps generator.
Docs: omit

Closes: https://github.com/conan-io/conan/issues/11013