### PR TITLE
Fixed tgz extraction with links and striproot

### DIFF
--- a/conan/tools/files/files.py
+++ b/conan/tools/files/files.py
@@ -375,6 +375,11 @@ def untargz(filename, destination=".", pattern=None, strip_root=False):
                     name = member.name.replace("\\", "/")
                     member.name = name.split("/", 1)[1]
                     member.path = member.name
+                    if member.linkpath.startswith(common_folder):
+                        # https://github.com/conan-io/conan/issues/11065
+                        linkpath = member.linkpath.replace("\\", "/")
+                        member.linkpath = linkpath.split("/", 1)[1]
+                        member.linkname = member.linkpath
             if pattern:
                 members = list(filter(lambda m: fnmatch(m.name, pattern),
                                       tarredgzippedFile.getmembers()))

--- a/conans/client/tools/files.py
+++ b/conans/client/tools/files.py
@@ -174,6 +174,11 @@ def untargz(filename, destination=".", pattern=None, strip_root=False):
                     name = member.name.replace("\\", "/")
                     member.name = name.split("/", 1)[1]
                     member.path = member.name
+                    if member.linkpath.startswith(common_folder):
+                        # https://github.com/conan-io/conan/issues/11065
+                        linkpath = member.linkpath.replace("\\", "/")
+                        member.linkpath = linkpath.split("/", 1)[1]
+                        member.linkname = member.linkpath
             if pattern:
                 members = list(filter(lambda m: fnmatch(m.name, pattern),
                                       tarredgzippedFile.getmembers()))

--- a/conans/test/functional/toolchains/google/test_bazel.py
+++ b/conans/test/functional/toolchains/google/test_bazel.py
@@ -52,7 +52,9 @@ def client_lib(bazelrc):
 
 
 @pytest.mark.parametrize("build_type", ["Debug", "Release", "RelWithDebInfo", "MinSizeRel"])
-@pytest.mark.tool_bazel
+@pytest.mark.skipif(platform.system() != "Linux", reason="FIXME: Darwin keeps failing randomly "
+                                                         "and win is suspect too")
+@pytest.mark.tool("bazel")
 def test_basic_exe(client_exe, build_type, base_profile):
 
     profile = base_profile.format(build_type=build_type, curdir=client_exe.current_folder)
@@ -66,7 +68,9 @@ def test_basic_exe(client_exe, build_type, base_profile):
 
 
 @pytest.mark.parametrize("build_type", ["Debug", "Release", "RelWithDebInfo", "MinSizeRel"])
-@pytest.mark.tool_bazel
+@pytest.mark.skipif(platform.system() != "Linux", reason="FIXME: Darwin keeps failing randomly "
+                                                         "and win is suspect too")
+@pytest.mark.tool("bazel")
 def test_basic_lib(client_lib, build_type, base_profile):
 
     profile = base_profile.format(build_type=build_type, curdir=client_lib.current_folder)
@@ -79,7 +83,9 @@ def test_basic_lib(client_lib, build_type, base_profile):
         assert "mylib/1.0: Hello World Debug!" in client_lib.out
 
 
-@pytest.mark.tool_bazel
+@pytest.mark.skipif(platform.system() != "Linux", reason="FIXME: Darwin keeps failing randomly "
+                                                         "and win is suspect too")
+@pytest.mark.tool("bazel")
 def test_transitive_consuming():
 
     client = TestClient(path_with_spaces=False)

--- a/conans/test/unittests/util/files/strip_root_extract_test.py
+++ b/conans/test/unittests/util/files/strip_root_extract_test.py
@@ -8,12 +8,13 @@ import six
 from mock import Mock
 
 from conans.client.tools import untargz, unzip
+from conan.tools.files import unzip as unzip_dev2
 from conans.client.tools.files import chdir, save
-from conans.test.utils.mocks import TestBufferConanOutput
+from conans.test.utils.mocks import TestBufferConanOutput, ConanFileMock
 from conans.test.utils.test_files import temp_folder
 from conans.errors import ConanException
 from conans.model.manifest import gather_files
-from conans.util.files import gzopen_without_timestamps
+from conans.util.files import gzopen_without_timestamps, rmdir
 
 
 class ZipExtractPlainTest(unittest.TestCase):
@@ -153,6 +154,14 @@ class TarExtractPlainTest(unittest.TestCase):
         assert not os.path.exists(os.path.join(tmp_folder, "subfolder", "foo.txt"))
         assert not os.path.exists(os.path.join(tmp_folder, "subfolder", "bar", "foo.txt"))
         untargz(tgz_path, destination=tmp_folder, strip_root=True)
+        assert os.path.exists(os.path.join(tmp_folder, "subfolder", "foo.txt"))
+        assert os.path.exists(os.path.join(tmp_folder, "subfolder", "bar", "foo.txt"))
+
+        # Check develop2 public unzip
+        rmdir(os.path.join(tmp_folder, "subfolder"))
+        assert not os.path.exists(os.path.join(tmp_folder, "subfolder", "foo.txt"))
+        assert not os.path.exists(os.path.join(tmp_folder, "subfolder", "bar", "foo.txt"))
+        unzip_dev2(ConanFileMock(), tgz_path, destination=tmp_folder, strip_root=True)
         assert os.path.exists(os.path.join(tmp_folder, "subfolder", "foo.txt"))
         assert os.path.exists(os.path.join(tmp_folder, "subfolder", "bar", "foo.txt"))
 


### PR DESCRIPTION
Changelog: Bugfix: Fixed unziping while using `tools.get` or `tools.unzip` with the `strip_root=True` in a `tgz` file with hardlinks inside.
Docs: omit 


Close https://github.com/conan-io/conan/issues/11065