### PR TITLE
Fix binaryDir CMakePresets.json

### DIFF
--- a/conan/tools/cmake/presets.py
+++ b/conan/tools/cmake/presets.py
@@ -26,6 +26,9 @@ def _contents(conanfile, toolchain_file, cache_variables, generator):
            }]
           }
     if conanfile.build_folder:
+        # If we are installing a ref: "conan install <ref>", we don't have build_folder, because
+        # we don't even have a conanfile with a `layout()` to determine the build folder.
+        # If we install a local conanfile: "conan install ." with a layout(), it will be available.
         ret["configurePresets"][0]["binaryDir"] = conanfile.build_folder
     return ret
 

--- a/conan/tools/cmake/presets.py
+++ b/conan/tools/cmake/presets.py
@@ -6,26 +6,28 @@ from conans.util.files import save, load
 
 
 def _contents(conanfile, toolchain_file, cache_variables, generator):
-    return {"version": 3,
-            "cmakeMinimumRequired": {"major": 3, "minor": 15, "patch": 0},
-            "configurePresets": [{
+    ret = {"version": 3,
+           "cmakeMinimumRequired": {"major": 3, "minor": 15, "patch": 0},
+           "configurePresets": [{
                 "name": "default",
                 "displayName": "Default Config",
                 "description": "Default configure using '{}' generator".format(generator),
                 "generator": generator,
                 "cacheVariables": cache_variables,
                 "toolchainFile": toolchain_file,
-                "binaryDir": conanfile.build_folder
-            }],
-            "buildPresets": [{
+           }],
+           "buildPresets": [{
               "name": "default",
               "configurePreset": "default"
-            }],
-            "testPresets": [{
+           }],
+           "testPresets": [{
               "name": "default",
               "configurePreset": "default"
-            }]
-            }
+           }]
+          }
+    if conanfile.build_folder:
+        ret["configurePresets"][0]["binaryDir"] = conanfile.build_folder
+    return ret
 
 
 def write_cmake_presets(conanfile, toolchain_file, generator):

--- a/conans/test/functional/toolchains/cmake/test_cmake_toolchain.py
+++ b/conans/test/functional/toolchains/cmake/test_cmake_toolchain.py
@@ -66,6 +66,7 @@ def test_cmake_toolchain_custom_toolchain():
     assert not os.path.exists(os.path.join(client.current_folder, "conan_toolchain.cmake"))
     presets = load_cmake_presets(client.current_folder)
     assert "mytoolchain.cmake" in presets["configurePresets"][0]["toolchainFile"]
+    assert "binaryDir" not in presets["configurePresets"][0]
 
 
 def test_cmake_toolchain_user_toolchain_from_dep():

--- a/conans/test/integration/toolchains/cmake/test_cmaketoolchain.py
+++ b/conans/test/integration/toolchains/cmake/test_cmaketoolchain.py
@@ -4,6 +4,7 @@ import textwrap
 
 import pytest
 
+from conan.tools.cmake.presets import load_cmake_presets
 from conans.test.assets.genconanfile import GenConanfile
 from conans.test.utils.tools import TestClient
 
@@ -328,3 +329,28 @@ def test_extra_flags_via_conf():
     assert 'string(APPEND CONAN_SHARED_LINKER_FLAGS " --flag5 --flag6")' in toolchain
     assert 'string(APPEND CONAN_EXE_LINKER_FLAGS " --flag7 --flag8")' in toolchain
     assert 'add_compile_definitions( D1 D2)' in toolchain
+
+
+def test_cmake_presets_binary_dir_available():
+    client = TestClient(path_with_spaces=False)
+    conanfile = textwrap.dedent("""
+    from conan import ConanFile
+    from conan.tools.cmake import cmake_layout
+    class HelloConan(ConanFile):
+        generators = "CMakeToolchain"
+        settings = "os", "compiler", "build_type", "arch"
+
+        def layout(self):
+            cmake_layout(self)
+
+    """)
+
+    client.save({"conanfile.py": conanfile})
+    client.run("install .")
+    if platform.system() != "Windows":
+        build_dir = os.path.join(client.current_folder, "cmake-build-release")
+    else:
+        build_dir = os.path.join(client.current_folder, "build")
+
+    presets = load_cmake_presets(os.path.join(build_dir, "conan"))
+    assert presets["configurePresets"][0]["binaryDir"] == build_dir


### PR DESCRIPTION
Changelog: Bugfix: The `binaryDir` field at `CMakePresets.json` is not set if the `conanfile.build_folder` is not available, avoiding a `null` value breaking the specification.
Docs: omit

Close https://github.com/conan-io/conan/issues/11084