### PR TITLE
Feature/fix bazeldeps

### DIFF
--- a/conan/tools/google/bazeldeps.py
+++ b/conan/tools/google/bazeldeps.py
@@ -165,12 +165,15 @@ class BazelDeps(object):
                 continue
             files = os.listdir(libdir)
             for f in files:
+                full_path = os.path.join(libdir, f)
+                if not os.path.isfile(full_path):  # Make sure that directories are excluded
+                    continue
                 name, ext = os.path.splitext(f)
                 if ext in (".so", ".lib", ".a", ".dylib", ".bc"):
                     if ext != ".lib" and name.startswith("lib"):
                         name = name[3:]
                 if lib == name:
-                    return os.path.join(libdir, f)
+                    return full_path
         self._conanfile.output.warning("The library {} cannot be found in the "
                                        "dependency".format(lib))
 

--- a/conans/test/integration/toolchains/google/test_bazel.py
+++ b/conans/test/integration/toolchains/google/test_bazel.py
@@ -76,4 +76,3 @@ def test_bazel_exclude_folders():
     c.run("install dep/0.1@ -g BazelDeps")
     build_file = c.load("dep/BUILD")
     assert 'static_library = "lib/libmymath.a"' in build_file
-

--- a/conans/test/integration/toolchains/google/test_bazel.py
+++ b/conans/test/integration/toolchains/google/test_bazel.py
@@ -53,3 +53,27 @@ def test_bazel_relative_paths():
     build_file = c.load("consumer/conandeps/dep/BUILD")
     assert 'hdrs = glob(["include/**"])' in build_file
     assert 'includes = ["include"]' in build_file
+
+
+def test_bazel_exclude_folders():
+    # https://github.com/conan-io/conan/issues/11081
+    dep = textwrap.dedent("""
+        import os
+        from conan import ConanFile
+        from conan.tools.files import save
+        class ExampleConanIntegration(ConanFile):
+            name = "dep"
+            version = "0.1"
+            def package(self):
+                save(self, os.path.join(self.package_folder, "lib", "mymath", "otherfile.a"), "")
+                save(self, os.path.join(self.package_folder, "lib", "libmymath.a"), "")
+            def package_info(self):
+                self.cpp_info.libs = ["mymath"]
+        """)
+    c = TestClient()
+    c.save({"dep/conanfile.py": dep})
+    c.run("create dep")
+    c.run("install dep/0.1@ -g BazelDeps")
+    build_file = c.load("dep/BUILD")
+    assert 'static_library = "lib/libmymath.a"' in build_file
+


### PR DESCRIPTION
Changelog: Bugfix: Avoid ``BazelDeps`` to find a library when a directory with the same name exists.
Docs: Omit

Close https://github.com/conan-io/conan/issues/11081
