### PR TITLE
CMakePresets.json multi build configurations

### DIFF
--- a/conan/tools/cmake/presets.py
+++ b/conan/tools/cmake/presets.py
@@ -2,10 +2,20 @@ import json
 import os
 import platform
 
+from conan.tools.cmake.utils import is_multi_configuration
 from conans.util.files import save, load
 
 
+def _add_build_preset(build_type, multiconfig=False):
+    ret = {"name": "Build {}".format(build_type),
+           "configurePreset": "default"}
+    if multiconfig:
+        ret["configuration"] = build_type
+    return ret
+
+
 def _contents(conanfile, toolchain_file, cache_variables, generator):
+    build_type = conanfile.settings.get_safe("build_type") or "default"
     ret = {"version": 3,
            "cmakeMinimumRequired": {"major": 3, "minor": 15, "patch": 0},
            "configurePresets": [{
@@ -16,15 +26,14 @@ def _contents(conanfile, toolchain_file, cache_variables, generator):
                 "cacheVariables": cache_variables,
                 "toolchainFile": toolchain_file,
            }],
-           "buildPresets": [{
-              "name": "default",
-              "configurePreset": "default"
-           }],
+           "buildPresets": [],
            "testPresets": [{
               "name": "default",
               "configurePreset": "default"
            }]
           }
+    multiconfig = is_multi_configuration(generator)
+    ret["buildPresets"].append(_add_build_preset(build_type, multiconfig))
     if conanfile.build_folder:
         # If we are installing a ref: "conan install <ref>", we don't have build_folder, because
         # we don't even have a conanfile with a `layout()` to determine the build folder.
@@ -42,9 +51,21 @@ def write_cmake_presets(conanfile, toolchain_file, generator):
             cmake_make_program = cmake_make_program.replace("\\", "/")
             cache_variables["CMAKE_MAKE_PROGRAM"] = cmake_make_program
 
-    tmp = _contents(conanfile, toolchain_file, cache_variables, generator)
-    tmp = json.dumps(tmp, indent=4)
-    save(os.path.join(conanfile.generators_folder, "CMakePresets.json"), tmp)
+    preset_path = os.path.join(conanfile.generators_folder, "CMakePresets.json")
+    multiconfig = is_multi_configuration(generator)
+    if multiconfig and os.path.exists(preset_path):
+        # We append the new configuration making sure that we don't overwrite it
+        build_type = conanfile.settings.get_safe("build_type")
+        data = json.loads(load(preset_path))
+        build_presets = data["buildPresets"]
+        already_exist = any([b["configuration"] for b in build_presets if b == build_type])
+        if not already_exist:
+            data["buildPresets"].append(_add_build_preset(build_type, multiconfig))
+    else:
+        data = _contents(conanfile, toolchain_file, cache_variables, generator)
+
+    data = json.dumps(data, indent=4)
+    save(preset_path, data)
 
 
 def load_cmake_presets(folder):

--- a/conan/tools/cmake/toolchain/toolchain.py
+++ b/conan/tools/cmake/toolchain/toolchain.py
@@ -175,7 +175,7 @@ class CMakeToolchain(object):
         elif self.generator is not None and "Visual" not in self.generator:
             VCVars(self._conanfile).generate()
         toolchain = os.path.join(self._conanfile.generators_folder, toolchain_file or self.filename)
-        write_cmake_presets(self._conanfile,toolchain , self.generator)
+        write_cmake_presets(self._conanfile, toolchain, self.generator)
 
     def _get_generator(self, recipe_generator):
         # Returns the name of the generator to be used by CMake


### PR DESCRIPTION
Changelog: Feature: The `CMakePresets.json` (file generated when specified the `CMakeToolchain` generator) is appended with a new `buildPresets` after a `conan install` with a different `build_type` when using a multiconfiguration generator like `Visual Studio`.
Docs: https://github.com/conan-io/docs/pull/2512

Close https://github.com/conan-io/conan/issues/11085

PENDING TO TRY IT WITH VISUAL STUDIO CODE ON WINDOWS.