### PR TITLE
Part1: Move CMAKE_BUILD_TYPE from toolchain to CMakePresets.json

### DIFF
--- a/conan/tools/cmake/toolchain/blocks.py
+++ b/conan/tools/cmake/toolchain/blocks.py
@@ -681,9 +681,6 @@ class GenericSystemBlock(Block):
         set(CMAKE_RC_COMPILER {{ compiler_rc }})
         endif()
         {% endif %}
-        {% if build_type %}
-        set(CMAKE_BUILD_TYPE "{{ build_type }}" CACHE STRING "Choose the type of build." FORCE)
-        {% endif %}
         """)
 
     def _get_toolset(self, generator):
@@ -815,15 +812,11 @@ class GenericSystemBlock(Block):
         return system_name, system_version, system_processor
 
     def context(self):
-        # build_type (Release, Debug, etc) is only defined for single-config generators
         generator = self._toolchain.generator
         generator_platform = self._get_generator_platform(generator)
         toolset = self._get_toolset(generator)
 
         compiler, compiler_cpp, compiler_rc = self._get_compiler(generator)
-
-        build_type = self._conanfile.settings.get_safe("build_type")
-        build_type = build_type if not is_multi_configuration(generator) else None
 
         system_name, system_version, system_processor = self._get_cross_build()
 
@@ -832,7 +825,6 @@ class GenericSystemBlock(Block):
                 "compiler_cpp": compiler_cpp,
                 "toolset": toolset,
                 "generator_platform": generator_platform,
-                "build_type": build_type,
                 "cmake_system_name": system_name,
                 "cmake_system_version": system_version,
                 "cmake_system_processor": system_processor}

--- a/conans/test/functional/configuration/profile_test.py
+++ b/conans/test/functional/configuration/profile_test.py
@@ -1,3 +1,4 @@
+import json
 import os
 import platform
 import textwrap
@@ -738,8 +739,8 @@ def test_consumer_specific_settings():
         assert "I'm dep and my build type is Release" in client.out
         # Verify the cmake toolchain takes Debug
         assert "I'm dep and my shared is False" in client.out
-        contents = client.load("conan_toolchain.cmake")
-        assert 'set(CMAKE_BUILD_TYPE "Debug"' in contents
+        presets = json.loads(client.load("CMakePresets.json"))
+        assert presets["configurePresets"][0]["cacheVariables"]['CMAKE_BUILD_TYPE'] == "Debug"
 
 
 def test_create_and_priority_of_consumer_specific_setting():

--- a/conans/test/functional/toolchains/cmake/cmakedeps/test_cmakedeps.py
+++ b/conans/test/functional/toolchains/cmake/cmakedeps/test_cmakedeps.py
@@ -81,8 +81,8 @@ def test_transitive_multi(client):
             assert "MYVARliba: Release" in client.out
             assert "MYVARlibb: Release" in client.out
         else:
-            # The TOOLCHAIN IS MESSING WITH THE BUILD TYPE and then ignores the -D so I remove it
-            replace_in_file(os.path.join(client.current_folder, "conan_toolchain.cmake"),
+            # The CMakePresets IS MESSING WITH THE BUILD TYPE and then ignores the -D so I remove it
+            replace_in_file(os.path.join(client.current_folder, "CMakePresets.json"),
                             "CMAKE_BUILD_TYPE", "DONT_MESS_WITH_BUILD_TYPE")
             for bt in ("Debug", "Release"):
                 client.run_command('cmake .. -DCMAKE_BUILD_TYPE={} '

--- a/conans/test/functional/toolchains/cmake/cmakedeps/test_cmakedeps_custom_configs.py
+++ b/conans/test/functional/toolchains/cmake/cmakedeps/test_cmakedeps_custom_configs.py
@@ -227,7 +227,7 @@ def test_changing_build_type():
     # in MSVC multi-config -s pkg:build_type=Debug is not really necesary, toolchain do nothing
     # TODO: Challenge how to define consumer build_type for conanfile.txt
     client.run("install . -s pkg:build_type=Debug -s build_type=Release")
-    client.run_command("cmake . -DCMAKE_TOOLCHAIN_FILE=conan_toolchain.cmake")
+    client.run_command("cmake . -DCMAKE_TOOLCHAIN_FILE=conan_toolchain.cmake -DCMAKE_BUILD_TYPE=Debug")
     client.run_command("cmake --build . --config Debug")
     cmd = os.path.join(".", "Debug", "app") if platform.system() == "Windows" else "./app"
     client.run_command(cmd)

--- a/conans/test/functional/toolchains/cmake/test_cmake_and_no_soname_flag.py
+++ b/conans/test/functional/toolchains/cmake/test_cmake_and_no_soname_flag.py
@@ -134,4 +134,4 @@ def test_no_soname_flag():
                 clean_first=True)
     client.run('install . ')
     client.run_command('cmake -G "Unix Makefiles" -DCMAKE_TOOLCHAIN_FILE="./conan_toolchain.cmake" .'
-                       ' && cmake --build . && ./example')
+                       ' -DCMAKE_BUILD_TYPE=Release && cmake --build . && ./example')

--- a/conans/test/functional/toolchains/cmake/test_ninja.py
+++ b/conans/test/functional/toolchains/cmake/test_ninja.py
@@ -180,8 +180,8 @@ def test_locally_build_gcc(build_type, shared, client):
 def test_locally_build_macos(build_type, shared, client):
     client.run('install . -s os=Macos -s arch=x86_64 -s build_type={} -o hello:shared={}'
                .format(build_type, shared))
-    client.run_command('cmake . -G"Ninja" -DCMAKE_TOOLCHAIN_FILE={}'
-                       .format(CMakeToolchain.filename))
+    client.run_command('cmake . -G"Ninja" -DCMAKE_TOOLCHAIN_FILE={} -DCMAKE_BUILD_TYPE={}'
+                       .format(CMakeToolchain.filename, build_type))
 
     client.run_command('ninja')
     if shared:

--- a/conans/test/functional/toolchains/cmake/test_ninja.py
+++ b/conans/test/functional/toolchains/cmake/test_ninja.py
@@ -62,8 +62,8 @@ def test_locally_build_linux(build_type, shared, client):
     settings = "-s os=Linux -s arch=x86_64 -s build_type={} -o hello:shared={}".format(build_type,
                                                                                        shared)
     client.run("install . {}".format(settings))
-    client.run_command('cmake . -G "Ninja" -DCMAKE_TOOLCHAIN_FILE={}'
-                       .format(CMakeToolchain.filename))
+    client.run_command('cmake . -G "Ninja" -DCMAKE_TOOLCHAIN_FILE={} -DCMAKE_BUILD_TYPE={}'
+                       .format(CMakeToolchain.filename, build_type))
 
     client.run_command('ninja')
     if shared:

--- a/conans/test/unittests/tools/cmake/test_cmaketoolchain.py
+++ b/conans/test/unittests/tools/cmake/test_cmaketoolchain.py
@@ -20,12 +20,12 @@ def conanfile():
     c = ConanFile(Mock(), None)
     c.settings = "os", "compiler", "build_type", "arch"
     c.initialize(Settings({"os": ["Windows"],
-                           "compiler": {"gcc": {"libcxx": ["libstdc++"]}},
+                           "compiler": {"clang": {"libcxx": ["libstdc++"]}},
                            "build_type": ["Release"],
                            "arch": ["x86"]}), EnvValues())
     c.settings.build_type = "Release"
     c.settings.arch = "x86"
-    c.settings.compiler = "gcc"
+    c.settings.compiler = "clang"
     c.settings.compiler.libcxx = "libstdc++"
     c.settings.os = "Windows"
     c.conf = Conf()
@@ -38,29 +38,29 @@ def conanfile():
 def test_cmake_toolchain(conanfile):
     toolchain = CMakeToolchain(conanfile)
     content = toolchain.content
-    assert 'set(CMAKE_BUILD_TYPE "Release"' in content
+    assert 'set(CMAKE_C_COMPILER clang)' in content
 
 
 def test_remove(conanfile):
     toolchain = CMakeToolchain(conanfile)
     toolchain.blocks.remove("generic_system")
     content = toolchain.content
-    assert 'CMAKE_BUILD_TYPE' not in content
+    assert 'CMAKE_C_COMPILER' not in content
 
 
 def test_template_remove(conanfile):
     toolchain = CMakeToolchain(conanfile)
     toolchain.blocks["generic_system"].template = ""
     content = toolchain.content
-    assert 'CMAKE_BUILD_TYPE' not in content
+    assert 'CMAKE_C_COMPILER' not in content
 
 
 def test_template_change(conanfile):
     toolchain = CMakeToolchain(conanfile)
     tmp = toolchain.blocks["generic_system"].template
-    toolchain.blocks["generic_system"].template = tmp.replace("CMAKE_BUILD_TYPE", "OTHER_THING")
+    toolchain.blocks["generic_system"].template = tmp.replace("CMAKE_C_COMPILER", "OTHER_THING")
     content = toolchain.content
-    assert 'set(OTHER_THING "Release"' in content
+    assert 'set(OTHER_THING clang)' in content
 
 
 def test_context_change(conanfile):
@@ -69,25 +69,25 @@ def test_context_change(conanfile):
 
     def context(self):
         assert self
-        return {"build_type": "SuperRelease"}
+        return {"compiler": None}
     tmp.context = types.MethodType(context, tmp)
     content = toolchain.content
-    assert 'set(CMAKE_BUILD_TYPE "SuperRelease"' in content
+    assert 'CMAKE_C_COMPILER' not in content
 
 
 def test_context_update(conanfile):
     toolchain = CMakeToolchain(conanfile)
-    build_type = toolchain.blocks["generic_system"].values["build_type"]
-    toolchain.blocks["generic_system"].values["build_type"] = "Super" + build_type
+    compiler = toolchain.blocks["generic_system"].values["compiler"]
+    toolchain.blocks["generic_system"].values["compiler"] = "Super" + compiler
     content = toolchain.content
-    assert 'set(CMAKE_BUILD_TYPE "SuperRelease"' in content
+    assert 'set(CMAKE_C_COMPILER Superclang)' in content
 
 
 def test_context_replace(conanfile):
     toolchain = CMakeToolchain(conanfile)
-    toolchain.blocks["generic_system"].values = {"build_type": "SuperRelease"}
+    toolchain.blocks["generic_system"].values = {"compiler": "SuperClang"}
     content = toolchain.content
-    assert 'set(CMAKE_BUILD_TYPE "SuperRelease"' in content
+    assert 'set(CMAKE_C_COMPILER SuperClang)' in content
 
 
 def test_replace_block(conanfile):
@@ -102,7 +102,7 @@ def test_replace_block(conanfile):
     toolchain.blocks["generic_system"] = MyBlock
     content = toolchain.content
     assert 'HelloWorld' in content
-    assert 'CMAKE_BUILD_TYPE' not in content
+    assert 'CMAKE_C_COMPILER' not in content
 
 
 def test_add_new_block(conanfile):
@@ -117,7 +117,7 @@ def test_add_new_block(conanfile):
     toolchain.blocks["mynewblock"] = MyBlock
     content = toolchain.content
     assert 'Hello World!!!' in content
-    assert 'CMAKE_BUILD_TYPE' in content
+    assert 'CMAKE_C_COMPILER' in content
 
 
 def test_user_toolchain(conanfile):


### PR DESCRIPTION
Changelog: Feature: The `CMAKE_BUILD_TYPE` is not adjusted in the `conan_toolchain.cmake` anymore, the configuration is moved to the `CMakePresets.json` preparing Conan to support multiple "single-config" configurations in one `CMakePresets.json` file
Docs: https://github.com/conan-io/docs/pull/2512
