### PR TITLE
[WIP] Relocatable libs for Macos

### DIFF
--- a/conan/tools/gnu/autotools.py
+++ b/conan/tools/gnu/autotools.py
@@ -93,7 +93,7 @@ class Autotools(object):
         #  because there's no package_folder until the package step
         self.configure()
         self.make(target="install")
-        if self._conanfile.settings.get_safe("os") == "Macos" and self._conanfile.options.get_safe("shared", True):
+        if self._conanfile.settings.get_safe("os") == "Macos" and self._conanfile.options.get_safe("shared", False):
             self._fix_macos_install_paths()
 
     def autoreconf(self, args=None):

--- a/conan/tools/gnu/autotools.py
+++ b/conan/tools/gnu/autotools.py
@@ -78,14 +78,14 @@ class Autotools(object):
         """
         fix LC_ID_DYLIB in Macos
         """
-        shared_libs = []
-        package_folder = self._conanfile.package_folder
         libdirs = getattr(self._conanfile.cpp.package, "libdirs")
         for folder in libdirs:
-            full_folder = os.path.join(package_folder, folder)
-            shared_libs.extend(self._collect_shared_lib_files(full_folder))
+            full_folder = os.path.join(self._conanfile.package_folder, folder)
+            shared_libs = self._collect_shared_lib_files(full_folder)
             for shared_lib in shared_libs:
-                command = "install_name_tool -id @rpath/{} {}".format(shared_lib, os.path.join(full_folder, shared_lib))
+                command = "install_name_tool -id @rpath/{} {}".format(shared_lib,
+                                                                      os.path.join(full_folder,
+                                                                                   shared_lib))
                 self._conanfile.run(command)
 
     def install(self):

--- a/conan/tools/gnu/autotools.py
+++ b/conan/tools/gnu/autotools.py
@@ -93,7 +93,7 @@ class Autotools(object):
         #  because there's no package_folder until the package step
         self.configure()
         self.make(target="install")
-        if self._conanfile.settings.get_safe("os") == "Macos":
+        if self._conanfile.settings.get_safe("os") == "Macos" and self._conanfile.options.get_safe("shared", True):
             self._fix_macos_install_paths()
 
     def autoreconf(self, args=None):

--- a/conan/tools/gnu/autotools.py
+++ b/conan/tools/gnu/autotools.py
@@ -63,11 +63,38 @@ class Autotools(object):
         command = join_arguments([make_program, target, str_args, jobs])
         self._conanfile.run(command)
 
+    @staticmethod
+    def _collect_shared_lib_files(folder):
+        result = []
+        files = os.listdir(folder)
+        for f in files:
+            full_path = os.path.join(folder, f)
+            name, ext = os.path.splitext(f)
+            if ext == ".dylib" and not os.path.islink(full_path):
+                result.append(f)
+        return result
+
+    def _fix_macos_install_paths(self):
+        """
+        fix LC_ID_DYLIB in Macos
+        """
+        shared_libs = []
+        package_folder = self._conanfile.package_folder
+        libdirs = getattr(self._conanfile.cpp.package, "libdirs")
+        for folder in libdirs:
+            full_folder = os.path.join(package_folder, folder)
+            shared_libs.extend(self._collect_shared_lib_files(full_folder))
+            for shared_lib in shared_libs:
+                command = "install_name_tool -id @rpath/{} {}".format(shared_lib, os.path.join(full_folder, shared_lib))
+                self._conanfile.run(command)
+
     def install(self):
         # FIXME: we have to run configure twice because the local flow won't work otherwise
         #  because there's no package_folder until the package step
         self.configure()
         self.make(target="install")
+        if self._conanfile.settings.get_safe("os") == "Macos":
+            self._fix_macos_install_paths()
 
     def autoreconf(self, args=None):
         command = ["autoreconf"]

--- a/conan/tools/gnu/autotoolsdeps.py
+++ b/conan/tools/gnu/autotoolsdeps.py
@@ -33,6 +33,7 @@ class AutotoolsDeps:
             if dep.options.get_safe("shared", False):
                 for libdir in dep.cpp_info.libdirs:
                     flags.extend(["-Wl,-rpath -Wl,{}".format(libdir)])
+                    flags.extend(["-Wl,-rpath -Wl,@executable_path".format(libdir)])
         return flags
 
     @property

--- a/conan/tools/gnu/autotoolsdeps.py
+++ b/conan/tools/gnu/autotoolsdeps.py
@@ -8,12 +8,12 @@ class AutotoolsDeps:
     def __init__(self, conanfile):
         self._conanfile = conanfile
         self._environment = None
-        self._ordered_deps = None
+        self._ordered_deps = []
         check_using_build_profile(self._conanfile)
 
     @property
     def ordered_deps(self):
-        if self._ordered_deps is None:
+        if not self._ordered_deps:
             deps = self._conanfile.dependencies.host.topological_sort
             self._ordered_deps = [dep for dep in reversed(deps.values())]
         return self._ordered_deps

--- a/conan/tools/gnu/autotoolsdeps.py
+++ b/conan/tools/gnu/autotoolsdeps.py
@@ -30,9 +30,8 @@ class AutotoolsDeps:
     def _rpaths_flags(self):
         flags = []
         for dep in self.ordered_deps:
-            if dep.options.get_safe("shared", False):
-                for libdir in dep.cpp_info.libdirs:
-                    flags.extend(["-Wl,-rpath -Wl,{}".format(libdir)])
+            flags.extend(["-Wl,-rpath -Wl,{}".format(libdir) for libdir in dep.cpp_info.libdirs
+                          if dep.options.get_safe("shared", False)])
         return flags
 
     @property
@@ -52,7 +51,10 @@ class AutotoolsDeps:
             ldflags.extend(flags.frameworks)
             ldflags.extend(flags.framework_paths)
             ldflags.extend(flags.lib_paths)
-            ldflags.extend(self._rpaths_flags())
+
+            ## set the rpath in Macos so that the library are found in the configure step
+            if self._conanfile.settings.get_safe("os") == "Macos":
+                ldflags.extend(self._rpaths_flags())
 
             # libs
             libs = flags.libs

--- a/conan/tools/gnu/autotoolsdeps.py
+++ b/conan/tools/gnu/autotoolsdeps.py
@@ -33,7 +33,8 @@ class AutotoolsDeps:
             if dep.options.get_safe("shared", False):
                 for libdir in dep.cpp_info.libdirs:
                     flags.extend(["-Wl,-rpath -Wl,{}".format(libdir)])
-                    flags.extend(["-Wl,-rpath -Wl,@executable_path".format(libdir)])
+                    if self._conanfile.settings.get_safe("os") == "Macos":
+                        flags.extend(["-Wl,-rpath -Wl,@executable_path".format(libdir)])
         return flags
 
     @property

--- a/conan/tools/gnu/autotoolsdeps.py
+++ b/conan/tools/gnu/autotoolsdeps.py
@@ -31,8 +31,6 @@ class AutotoolsDeps:
             if dep.options.get_safe("shared", False):
                 for libdir in dep.cpp_info.libdirs:
                     flags.extend(["-Wl,-rpath -Wl,{}".format(libdir)])
-                    if self._conanfile.settings.get_safe("os") == "Macos":
-                        flags.extend(["-Wl,-rpath -Wl,@executable_path".format(libdir)])
         return flags
 
     @property

--- a/conan/tools/gnu/autotoolsdeps.py
+++ b/conan/tools/gnu/autotoolsdeps.py
@@ -33,8 +33,6 @@ class AutotoolsDeps:
             if dep.options.get_safe("shared", False):
                 for libdir in dep.cpp_info.libdirs:
                     flags.extend(["-Wl,-rpath -Wl,{}".format(libdir)])
-                    if self._conanfile.settings.get_safe("os") == "Macos":
-                        flags.extend(["-Wl,-rpath -Wl,@executable_path".format(libdir)])
         return flags
 
     @property

--- a/conans/test/functional/toolchains/gnu/test_v2_autotools_template.py
+++ b/conans/test/functional/toolchains/gnu/test_v2_autotools_template.py
@@ -75,6 +75,6 @@ def test_autotools_relocatable_libs_darwin():
     dylib = os.path.join(package_folder, "lib", "libhello.0.dylib")
     if platform.system() == "Darwin":
         client.run_command("otool -l {}".format(dylib))
-        assert package_folder in client.out
+        assert "@rpath/libhello.0.dylib" in client.out
 
     client.run("test test_package hello/0.1 -o hello:shared=True")

--- a/conans/test/functional/toolchains/gnu/test_v2_autotools_template.py
+++ b/conans/test/functional/toolchains/gnu/test_v2_autotools_template.py
@@ -77,8 +77,6 @@ def test_autotools_relocatable_libs_darwin():
         client.run_command("otool -l {}".format(dylib))
         assert "@rpath/libhello.0.dylib" in client.out
         client.run_command("otool -l {}".format("test_package/build-release/main"))
-        assert package_folder in client.out
-        assert "@executable_path" in client.out
 
     # will work because rpath set
     client.run_command("test_package/build-release/main")
@@ -91,11 +89,6 @@ def test_autotools_relocatable_libs_darwin():
     client.run_command("test_package/build-release/main", assert_error=True)
     assert "Library not loaded: @rpath/libhello.0.dylib" in client.out
 
-    # move the dylib to the folder where the executable is
-    # should work because the @executable_path set in the rpath
-    shutil.move(os.path.join(client.current_folder, "tempfolder", "libhello.0.dylib"),
-                os.path.join(client.current_folder, "test_package", "build-release"))
-    shutil.move(os.path.join(client.current_folder, "tempfolder", "libhello.dylib"),
-                os.path.join(client.current_folder, "test_package", "build-release"))
-    client.run_command("test_package/build-release/main")
+    # Use DYLD_LIBRARY_PATH and should run
+    client.run_command("DYLD_LIBRARY_PATH={} test_package/build-release/main".format(os.path.join(client.current_folder, "tempfolder")))
     assert "hello/0.1: Hello World Release!" in client.out

--- a/conans/test/functional/toolchains/gnu/test_v2_autotools_template.py
+++ b/conans/test/functional/toolchains/gnu/test_v2_autotools_template.py
@@ -92,9 +92,9 @@ def test_autotools_relocatable_libs_darwin():
     # then the execution should fail
     shutil.move(os.path.join(package_folder, "lib"), os.path.join(client.current_folder, "tempfolder"))
     # will fail because rpath does not exist
-    client.run_command("test_package/build-release/main", assert_error=True)
+    client.run_command("test_package/test-output/build-release/main", assert_error=True)
     assert "Library not loaded: @rpath/libhello.0.dylib" in client.out
 
     # Use DYLD_LIBRARY_PATH and should run
-    client.run_command("DYLD_LIBRARY_PATH={} test_package/build-release/main".format(os.path.join(client.current_folder, "tempfolder")))
+    client.run_command("DYLD_LIBRARY_PATH={} test_package/test-output/build-release/main".format(os.path.join(client.current_folder, "tempfolder")))
     assert "hello/0.1: Hello World Release!" in client.out

--- a/conans/test/functional/toolchains/gnu/test_v2_autotools_template.py
+++ b/conans/test/functional/toolchains/gnu/test_v2_autotools_template.py
@@ -92,9 +92,9 @@ def test_autotools_relocatable_libs_darwin():
     # then the execution should fail
     shutil.move(os.path.join(package_folder, "lib"), os.path.join(client.current_folder, "tempfolder"))
     # will fail because rpath does not exist
-    client.run_command("test_package/test-output/build-release/main", assert_error=True)
+    client.run_command("test_package/test_output/build-release/main", assert_error=True)
     assert "Library not loaded: @rpath/libhello.0.dylib" in client.out
 
     # Use DYLD_LIBRARY_PATH and should run
-    client.run_command("DYLD_LIBRARY_PATH={} test_package/test-output/build-release/main".format(os.path.join(client.current_folder, "tempfolder")))
+    client.run_command("DYLD_LIBRARY_PATH={} test_package/test_output/build-release/main".format(os.path.join(client.current_folder, "tempfolder")))
     assert "hello/0.1: Hello World Release!" in client.out

--- a/conans/test/functional/toolchains/gnu/test_v2_autotools_template.py
+++ b/conans/test/functional/toolchains/gnu/test_v2_autotools_template.py
@@ -71,7 +71,8 @@ def test_autotools_relocatable_libs_darwin():
     client.run("new autotools_lib -d name=hello -d version=0.1")
     client.run("create . -o hello/*:shared=True")
 
-    package_id = re.search(r"Packaging to (\S+)", str(client.out)).group(1)
+    package_id = re.search(r"Package (\S+) created", str(client.out)).group(1)
+    package_id = package_id.replace("'", "")
     ref = RecipeReference.loads("hello/0.1")
     pref = client.get_latest_package_reference(ref, package_id)
     package_folder = client.get_latest_pkg_layout(pref).package()
@@ -80,26 +81,26 @@ def test_autotools_relocatable_libs_darwin():
     if platform.system() == "Darwin":
         client.run_command("otool -l {}".format(dylib))
         assert "@rpath/libhello.0.dylib" in client.out
-        client.run_command("otool -l {}".format("test_package/build-release/main"))
+        client.run_command("otool -l {}".format("test_package/test_output/build-release/main"))
         assert package_folder in client.out
         assert "@executable_path" in client.out
 
     # will work because rpath set
-    client.run_command("test_package/build-release/main")
+    client.run_command("test_package/test_output/build-release/main")
     assert "hello/0.1: Hello World Release!" in client.out
 
     # move to another location so that the path set in the rpath does not exist
     # then the execution should fail
     shutil.move(os.path.join(package_folder, "lib"), os.path.join(client.current_folder, "tempfolder"))
     # will fail because rpath does not exist
-    client.run_command("test_package/build-release/main", assert_error=True)
+    client.run_command("test_package/test_output/build-release/main", assert_error=True)
     assert "Library not loaded: @rpath/libhello.0.dylib" in client.out
 
     # move the dylib to the folder where the executable is
     # should work because the @executable_path set in the rpath
     shutil.move(os.path.join(client.current_folder, "tempfolder", "libhello.0.dylib"),
-                os.path.join(client.current_folder, "test_package", "build-release"))
+                os.path.join(client.current_folder, "test_package", "test_output", "build-release"))
     shutil.move(os.path.join(client.current_folder, "tempfolder", "libhello.dylib"),
-                os.path.join(client.current_folder, "test_package", "build-release"))
-    client.run_command("test_package/build-release/main")
+                os.path.join(client.current_folder, "test_package", "test_output", "build-release"))
+    client.run_command("test_package/test_output/build-release/main")
     assert "hello/0.1: Hello World Release!" in client.out

--- a/conans/test/functional/toolchains/gnu/test_v2_autotools_template.py
+++ b/conans/test/functional/toolchains/gnu/test_v2_autotools_template.py
@@ -83,7 +83,6 @@ def test_autotools_relocatable_libs_darwin():
         assert "@rpath/libhello.0.dylib" in client.out
         client.run_command("otool -l {}".format("test_package/test_output/build-release/main"))
         assert package_folder in client.out
-        assert "@executable_path" in client.out
 
     # will work because rpath set
     client.run_command("test_package/test_output/build-release/main")
@@ -93,14 +92,9 @@ def test_autotools_relocatable_libs_darwin():
     # then the execution should fail
     shutil.move(os.path.join(package_folder, "lib"), os.path.join(client.current_folder, "tempfolder"))
     # will fail because rpath does not exist
-    client.run_command("test_package/test_output/build-release/main", assert_error=True)
+    client.run_command("test_package/build-release/main", assert_error=True)
     assert "Library not loaded: @rpath/libhello.0.dylib" in client.out
 
-    # move the dylib to the folder where the executable is
-    # should work because the @executable_path set in the rpath
-    shutil.move(os.path.join(client.current_folder, "tempfolder", "libhello.0.dylib"),
-                os.path.join(client.current_folder, "test_package", "test_output", "build-release"))
-    shutil.move(os.path.join(client.current_folder, "tempfolder", "libhello.dylib"),
-                os.path.join(client.current_folder, "test_package", "test_output", "build-release"))
-    client.run_command("test_package/test_output/build-release/main")
+    # Use DYLD_LIBRARY_PATH and should run
+    client.run_command("DYLD_LIBRARY_PATH={} test_package/build-release/main".format(os.path.join(client.current_folder, "tempfolder")))
     assert "hello/0.1: Hello World Release!" in client.out


### PR DESCRIPTION
Changelog: (Feature | Fix | Bugfix): Describe here your pull request
Docs: https://github.com/conan-io/docs/pull/XXXX

Will fail in Linux because missing `libtool` -> updating the `ci-functional` image

This PR tries to address several problems with shared libraries in Macos.
- In develop2 the `autotools.install()` is made over a temporal folder, so the entry `LC_ID_DYLIB` in the dylib file is set to that temporal folder. That makes the configure fail when trying to build a consumer that requires that library because it first loads the dylib file and expects that its own location is in that temporal folder that no longer exists. For fixing this, after doing the `autotools.install()` all the found dylib files in the libdirs folder are patched with `install_name_tool` to set it to the value: `@rpath/<libname>.dylib`
- Added to the XcodeDeps that if one dependency is `shared=True` then the RPATH for those libraries are set in the consumer binary to the `libdirs` folders in the cache. This is necessary so that when you run `autotools.configure()` the library is found. 