### PR TITLE
Relocatable libs for Macos

### DIFF
--- a/conan/tools/gnu/autotools.py
+++ b/conan/tools/gnu/autotools.py
@@ -93,7 +93,7 @@ class Autotools(object):
         #  because there's no package_folder until the package step
         self.configure()
         self.make(target="install")
-        if self._conanfile.settings.get_safe("os") == "Macos" and self._conanfile.options.get_safe("shared", True):
+        if self._conanfile.settings.get_safe("os") == "Macos" and self._conanfile.options.get_safe("shared", False):
             self._fix_macos_install_paths()
 
     def autoreconf(self, args=None):

--- a/conan/tools/gnu/autotools.py
+++ b/conan/tools/gnu/autotools.py
@@ -78,14 +78,14 @@ class Autotools(object):
         """
         fix LC_ID_DYLIB in Macos
         """
-        shared_libs = []
-        package_folder = self._conanfile.package_folder
         libdirs = getattr(self._conanfile.cpp.package, "libdirs")
         for folder in libdirs:
-            full_folder = os.path.join(package_folder, folder)
-            shared_libs.extend(self._collect_shared_lib_files(full_folder))
+            full_folder = os.path.join(self._conanfile.package_folder, folder)
+            shared_libs = self._collect_shared_lib_files(full_folder)
             for shared_lib in shared_libs:
-                command = "install_name_tool -id @rpath/{} {}".format(shared_lib, os.path.join(full_folder, shared_lib))
+                command = "install_name_tool -id @rpath/{} {}".format(shared_lib,
+                                                                      os.path.join(full_folder,
+                                                                                   shared_lib))
                 self._conanfile.run(command)
 
     def install(self):

--- a/conan/tools/gnu/autotools.py
+++ b/conan/tools/gnu/autotools.py
@@ -93,7 +93,7 @@ class Autotools(object):
         #  because there's no package_folder until the package step
         self.configure()
         self.make(target="install")
-        if self._conanfile.settings.get_safe("os") == "Macos":
+        if self._conanfile.settings.get_safe("os") == "Macos" and self._conanfile.options.get_safe("shared", True):
             self._fix_macos_install_paths()
 
     def autoreconf(self, args=None):

--- a/conan/tools/gnu/autotools.py
+++ b/conan/tools/gnu/autotools.py
@@ -63,11 +63,38 @@ class Autotools(object):
         command = join_arguments([make_program, target, str_args, jobs])
         self._conanfile.run(command)
 
+    @staticmethod
+    def _collect_shared_lib_files(folder):
+        result = []
+        files = os.listdir(folder)
+        for f in files:
+            full_path = os.path.join(folder, f)
+            name, ext = os.path.splitext(f)
+            if ext == ".dylib" and not os.path.islink(full_path):
+                result.append(f)
+        return result
+
+    def _fix_macos_install_paths(self):
+        """
+        fix LC_ID_DYLIB in Macos
+        """
+        shared_libs = []
+        package_folder = self._conanfile.package_folder
+        libdirs = getattr(self._conanfile.cpp.package, "libdirs")
+        for folder in libdirs:
+            full_folder = os.path.join(package_folder, folder)
+            shared_libs.extend(self._collect_shared_lib_files(full_folder))
+            for shared_lib in shared_libs:
+                command = "install_name_tool -id @rpath/{} {}".format(shared_lib, os.path.join(full_folder, shared_lib))
+                self._conanfile.run(command)
+
     def install(self):
         # FIXME: we have to run configure twice because the local flow won't work otherwise
         #  because there's no package_folder until the package step
         self.configure()
         self.make(target="install")
+        if self._conanfile.settings.get_safe("os") == "Macos":
+            self._fix_macos_install_paths()
 
     def autoreconf(self, args=None):
         command = ["autoreconf"]

--- a/conan/tools/gnu/autotoolsdeps.py
+++ b/conan/tools/gnu/autotoolsdeps.py
@@ -33,6 +33,7 @@ class AutotoolsDeps:
             if dep.options.get_safe("shared", False):
                 for libdir in dep.cpp_info.libdirs:
                     flags.extend(["-Wl,-rpath -Wl,{}".format(libdir)])
+                    flags.extend(["-Wl,-rpath -Wl,@executable_path".format(libdir)])
         return flags
 
     @property

--- a/conan/tools/gnu/autotoolsdeps.py
+++ b/conan/tools/gnu/autotoolsdeps.py
@@ -8,12 +8,12 @@ class AutotoolsDeps:
     def __init__(self, conanfile):
         self._conanfile = conanfile
         self._environment = None
-        self._ordered_deps = None
+        self._ordered_deps = []
         check_using_build_profile(self._conanfile)
 
     @property
     def ordered_deps(self):
-        if self._ordered_deps is None:
+        if not self._ordered_deps:
             deps = self._conanfile.dependencies.host.topological_sort
             self._ordered_deps = [dep for dep in reversed(deps.values())]
         return self._ordered_deps

--- a/conan/tools/gnu/autotoolsdeps.py
+++ b/conan/tools/gnu/autotoolsdeps.py
@@ -30,9 +30,8 @@ class AutotoolsDeps:
     def _rpaths_flags(self):
         flags = []
         for dep in self.ordered_deps:
-            if dep.options.get_safe("shared", False):
-                for libdir in dep.cpp_info.libdirs:
-                    flags.extend(["-Wl,-rpath -Wl,{}".format(libdir)])
+            flags.extend(["-Wl,-rpath -Wl,{}".format(libdir) for libdir in dep.cpp_info.libdirs
+                          if dep.options.get_safe("shared", False)])
         return flags
 
     @property
@@ -52,7 +51,10 @@ class AutotoolsDeps:
             ldflags.extend(flags.frameworks)
             ldflags.extend(flags.framework_paths)
             ldflags.extend(flags.lib_paths)
-            ldflags.extend(self._rpaths_flags())
+
+            ## set the rpath in Macos so that the library are found in the configure step
+            if self._conanfile.settings.get_safe("os") == "Macos":
+                ldflags.extend(self._rpaths_flags())
 
             # libs
             libs = flags.libs

--- a/conan/tools/gnu/autotoolsdeps.py
+++ b/conan/tools/gnu/autotoolsdeps.py
@@ -33,7 +33,8 @@ class AutotoolsDeps:
             if dep.options.get_safe("shared", False):
                 for libdir in dep.cpp_info.libdirs:
                     flags.extend(["-Wl,-rpath -Wl,{}".format(libdir)])
-                    flags.extend(["-Wl,-rpath -Wl,@executable_path".format(libdir)])
+                    if self._conanfile.settings.get_safe("os") == "Macos":
+                        flags.extend(["-Wl,-rpath -Wl,@executable_path".format(libdir)])
         return flags
 
     @property

--- a/conan/tools/gnu/autotoolsdeps.py
+++ b/conan/tools/gnu/autotoolsdeps.py
@@ -33,8 +33,6 @@ class AutotoolsDeps:
             if dep.options.get_safe("shared", False):
                 for libdir in dep.cpp_info.libdirs:
                     flags.extend(["-Wl,-rpath -Wl,{}".format(libdir)])
-                    if self._conanfile.settings.get_safe("os") == "Macos":
-                        flags.extend(["-Wl,-rpath -Wl,@executable_path".format(libdir)])
         return flags
 
     @property

--- a/conans/test/functional/toolchains/gnu/test_v2_autotools_template.py
+++ b/conans/test/functional/toolchains/gnu/test_v2_autotools_template.py
@@ -75,6 +75,6 @@ def test_autotools_relocatable_libs_darwin():
     dylib = os.path.join(package_folder, "lib", "libhello.0.dylib")
     if platform.system() == "Darwin":
         client.run_command("otool -l {}".format(dylib))
-        assert package_folder in client.out
+        assert "@rpath/libhello.0.dylib" in client.out
 
     client.run("test test_package hello/0.1 -o hello:shared=True")

--- a/conans/test/functional/toolchains/gnu/test_v2_autotools_template.py
+++ b/conans/test/functional/toolchains/gnu/test_v2_autotools_template.py
@@ -1,11 +1,12 @@
 import platform
 import re
 import os
+import textwrap
 
 import pytest
 
 from conans.model.ref import ConanFileReference, PackageReference
-from conans.test.utils.tools import TestClient
+from conans.test.utils.tools import TestClient, TestServer
 
 
 @pytest.mark.skipif(platform.system() not in ["Linux", "Darwin"], reason="Requires Autotools")
@@ -60,3 +61,67 @@ def test_autotools_exe_template():
     client.run("create . -s build_type=Debug")
     assert "greet/0.1: Hello World Debug!" in client.out
 
+
+@pytest.mark.skipif(platform.system() not in ["Darwin"], reason="Requires Autotools")
+@pytest.mark.tool_autotools()
+def test_autotools_relocatable_mac():
+    server = TestServer([("*/*@*/*", "*")], [("*/*@*/*", "*")])
+    client = TestClient(servers={"default": server}, path_with_spaces=False)
+    client2 = TestClient(servers={"default": server}, path_with_spaces=False)
+    assert client2.cache_folder != client.cache_folder
+    client.run("new hello/0.1 --template=autotools_lib")
+    client.run("create . -o hello:shared=True -tf=None")
+    client.run("upload * --all -c")
+    client.run("remove * -f")
+
+    conanfile = textwrap.dedent("""
+        from conan import ConanFile
+        from conan.tools.gnu import Autotools
+        from conan.tools.layout import basic_layout
+
+        class HelloConan(ConanFile):
+            name = "greet"
+            version = "1.0"
+            settings = "os", "compiler", "build_type", "arch"
+            exports_sources = "configure.ac", "Makefile.am", "main.cpp"
+            generators = "AutotoolsDeps", "AutotoolsToolchain"
+
+            def requirements(self):
+                self.requires("hello/0.1")
+
+            def layout(self):
+                basic_layout(self)
+
+            def build(self):
+                autotools = Autotools(self)
+                autotools.autoreconf()
+                autotools.configure()
+                autotools.make()
+        """)
+
+    main = textwrap.dedent("""
+        #include "hello.h"
+        int main() { hello(); }
+        """)
+
+    makefileam = textwrap.dedent("""
+        bin_PROGRAMS = hello
+        hello_SOURCES = main.cpp
+        """)
+
+    configureac = textwrap.dedent("""
+        AC_INIT([hello], [1.0], [])
+        AM_INIT_AUTOMAKE([-Wall -Werror foreign])
+        AC_PROG_CXX
+        AM_PROG_AR
+        LT_INIT
+        AC_CONFIG_FILES([Makefile])
+        AC_OUTPUT
+        """)
+
+    client2.save({"conanfile.py": conanfile,
+                  "main.cpp": main,
+                  "makefile.am": makefileam,
+                  "configure.ac": configureac})
+
+    client2.run("create . -o hello:shared=True -r default")

--- a/conans/test/functional/toolchains/gnu/test_v2_autotools_template.py
+++ b/conans/test/functional/toolchains/gnu/test_v2_autotools_template.py
@@ -77,8 +77,6 @@ def test_autotools_relocatable_libs_darwin():
         client.run_command("otool -l {}".format(dylib))
         assert "@rpath/libhello.0.dylib" in client.out
         client.run_command("otool -l {}".format("test_package/build-release/main"))
-        assert package_folder in client.out
-        assert "@executable_path" in client.out
 
     # will work because rpath set
     client.run_command("test_package/build-release/main")
@@ -91,11 +89,6 @@ def test_autotools_relocatable_libs_darwin():
     client.run_command("test_package/build-release/main", assert_error=True)
     assert "Library not loaded: @rpath/libhello.0.dylib" in client.out
 
-    # move the dylib to the folder where the executable is
-    # should work because the @executable_path set in the rpath
-    shutil.move(os.path.join(client.current_folder, "tempfolder", "libhello.0.dylib"),
-                os.path.join(client.current_folder, "test_package", "build-release"))
-    shutil.move(os.path.join(client.current_folder, "tempfolder", "libhello.dylib"),
-                os.path.join(client.current_folder, "test_package", "build-release"))
-    client.run_command("test_package/build-release/main")
+    # Use DYLD_LIBRARY_PATH and should run
+    client.run_command("DYLD_LIBRARY_PATH={} test_package/build-release/main".format(os.path.join(client.current_folder, "tempfolder")))
     assert "hello/0.1: Hello World Release!" in client.out

--- a/conans/test/functional/toolchains/gnu/test_v2_autotools_template.py
+++ b/conans/test/functional/toolchains/gnu/test_v2_autotools_template.py
@@ -112,7 +112,7 @@ def test_autotools_relocatable_libs_darwin_downloaded():
         from conan.tools.gnu import Autotools
         from conan.tools.layout import basic_layout
 
-        class HelloConan(ConanFile):
+        class GreetConan(ConanFile):
             name = "greet"
             version = "1.0"
             settings = "os", "compiler", "build_type", "arch"
@@ -138,12 +138,12 @@ def test_autotools_relocatable_libs_darwin_downloaded():
         """)
 
     makefileam = textwrap.dedent("""
-        bin_PROGRAMS = hello
-        hello_SOURCES = main.cpp
+        bin_PROGRAMS = greet
+        greet_SOURCES = main.cpp
         """)
 
     configureac = textwrap.dedent("""
-        AC_INIT([hello], [1.0], [])
+        AC_INIT([greet], [1.0], [])
         AM_INIT_AUTOMAKE([-Wall -Werror foreign])
         AC_PROG_CXX
         AM_PROG_AR
@@ -157,4 +157,8 @@ def test_autotools_relocatable_libs_darwin_downloaded():
                   "makefile.am": makefileam,
                   "configure.ac": configureac})
 
-    client2.run("create . -o hello:shared=True -r default")
+    client2.run("install . -o hello:shared=True -r default")
+    client2.run("build .")
+    client2.run_command("build-release/greet")
+    assert "Hello World Release!" in client2.out
+


### PR DESCRIPTION
Changelog: Fix: Make shared libraries build with Autotools relocatable in Macos by patching the install name (LC_ID_DYLIB) and setting to `@rpath/libname.dylib`.
Docs: https://github.com/conan-io/docs/pull/2518

Currently shared libraries build with Autotools in Macos are not relocatable. This is because they include the `LC_ID_DYLIB` field in the binary that hardcodes the folder where they were installed. Even if that library is found, at configure time the build will fail if they are not located in that folder. This means that just creating a package, uploading to a server and trying to consume that binary from other client will fail.

There could be two solutions for this:
- Setting the install_name linker flag like: `-Wl,-install_name,@rpath/foo.dylib`. The problem is that we can't do that in the toolchain because at the point the toolchain is generated we don't know the name of the libraries to be built.
- Patching the `LC_ID_DYLIB` field with `install_name_tool` in all the collected shared libraries that are installed. After doing the `autotools.install()` all the found dylib files in the libdirs folder are patched with `install_name_tool` to set it to the value: `@rpath/<libname>.dylib`. 

Also, to make this work we added to the XcodeDeps that if one dependency is `shared=True` then the RPATH for those libraries are set in the consumer binary to the `libdirs` folders in the cache. This is necessary so that when you run `autotools.configure()` the library is found. 
