### PR TITLE
cmake_layout single generators folder

### DIFF
--- a/conan/tools/cmake/cmake.py
+++ b/conan/tools/cmake/cmake.py
@@ -2,7 +2,7 @@ import os
 import platform
 
 from conan.tools.build import build_jobs
-from conan.tools.cmake.presets import load_cmake_presets
+from conan.tools.cmake.presets import load_cmake_presets, get_configure_preset
 from conan.tools.cmake.utils import is_multi_configuration
 from conan.tools.files import chdir, mkdir
 from conan.tools.files.files import load_toolchain_args
@@ -55,9 +55,11 @@ class CMake(object):
         self._conanfile = conanfile
 
         cmake_presets = load_cmake_presets(conanfile.generators_folder)
-        self._generator = cmake_presets["configurePresets"][0]["generator"]
-        self._toolchain_file = cmake_presets["configurePresets"][0]["toolchainFile"]
-        self._cache_variables = cmake_presets["configurePresets"][0]["cacheVariables"]
+        configure_preset = get_configure_preset(cmake_presets,
+                                                conanfile.settings.get_safe("build_type"))
+        self._generator = configure_preset["generator"]
+        self._toolchain_file = configure_preset["toolchainFile"]
+        self._cache_variables = configure_preset["cacheVariables"]
 
         self._cmake_program = "cmake"  # Path to CMake should be handled by environment
 

--- a/conan/tools/cmake/layout.py
+++ b/conan/tools/cmake/layout.py
@@ -21,11 +21,11 @@ def cmake_layout(conanfile, generator=None, src_folder="."):
         raise ConanException("'build_type' setting not defined, it is necessary for cmake_layout()")
     if multi:
         conanfile.folders.build = "build"
-        conanfile.folders.generators = "build/conan"
+        conanfile.folders.generators = "build/generators"
     else:
         build_type = build_type.lower()
         conanfile.folders.build = "cmake-build-{}".format(build_type)
-        conanfile.folders.generators = os.path.join(conanfile.folders.build, "conan")
+        conanfile.folders.generators = "build/generators"
 
     conanfile.cpp.source.includedirs = ["include"]
 

--- a/conan/tools/cmake/layout.py
+++ b/conan/tools/cmake/layout.py
@@ -1,5 +1,3 @@
-import os
-
 from conans.errors import ConanException
 
 
@@ -21,12 +19,11 @@ def cmake_layout(conanfile, generator=None, src_folder="."):
         raise ConanException("'build_type' setting not defined, it is necessary for cmake_layout()")
     if multi:
         conanfile.folders.build = "build"
-        conanfile.folders.generators = "build/generators"
     else:
         build_type = build_type.lower()
         conanfile.folders.build = "cmake-build-{}".format(build_type)
-        conanfile.folders.generators = "build/generators"
 
+    conanfile.folders.generators = "build/generators"
     conanfile.cpp.source.includedirs = ["include"]
 
     if multi:

--- a/conan/tools/cmake/presets.py
+++ b/conan/tools/cmake/presets.py
@@ -78,7 +78,7 @@ def write_cmake_presets(conanfile, toolchain_file, generator):
             if not already_exist:
                 data["buildPresets"].append(_add_build_preset(conanfile, multiconfig))
         else:
-            configure_presets = data["buildPresets"]
+            configure_presets = data["configurePresets"]
             already_exist = any([c["name"]
                                  for c in configure_presets
                                  if c["name"] == _configure_preset_name(build_type, multiconfig)])
@@ -93,14 +93,14 @@ def write_cmake_presets(conanfile, toolchain_file, generator):
     data = json.dumps(data, indent=4)
     save(preset_path, data)
 
-    # Try to save the CMakeUserPresets.json
-    # FIXME: Private base generators
-    if os.path.exists(os.path.join(conanfile.folders._base_generators, "CMakeLists.txt")):
-        user_presets_path = os.path.join(conanfile.folders._base_generators, "CMakeUserPresets.json")
-        if not os.path.exists(user_presets_path):
-            data = {"version": 4, "include": [preset_path]}
-            data = json.dumps(data, indent=4)
-            save(user_presets_path, data)
+    # Try to save the CMakeUserPresets.json if layout declared and CMakeLists.txt found
+    if conanfile.source_folder:
+        if os.path.exists(os.path.join(conanfile.source_folder, "CMakeLists.txt")):
+            user_presets_path = os.path.join(conanfile.source_folder, "CMakeUserPresets.json")
+            if not os.path.exists(user_presets_path):
+                data = {"version": 4, "include": [preset_path]}
+                data = json.dumps(data, indent=4)
+                save(user_presets_path, data)
 
 
 def load_cmake_presets(folder):

--- a/conan/tools/cmake/presets.py
+++ b/conan/tools/cmake/presets.py
@@ -10,7 +10,7 @@ from conans.util.files import save, load
 def _add_build_preset(conanfile, multiconfig):
     build_type = conanfile.settings.get_safe("build_type")
     configure_preset_name = _configure_preset_name(build_type, multiconfig)
-    ret = {"name": "Build {}".format(build_type),
+    ret = {"name": build_type,
            "configurePreset": configure_preset_name}
     if multiconfig:
         ret["configuration"] = build_type

--- a/conan/tools/cmake/presets.py
+++ b/conan/tools/cmake/presets.py
@@ -3,21 +3,27 @@ import os
 import platform
 
 from conan.tools.cmake.utils import is_multi_configuration
+from conans.errors import ConanException
 from conans.util.files import save, load
 
 
 def _add_build_preset(conanfile, multiconfig):
     build_type = conanfile.settings.get_safe("build_type")
+    configure_preset_name = _configure_preset_name(build_type, multiconfig)
     ret = {"name": "Build {}".format(build_type),
-           "configurePreset": "default"}
+           "configurePreset": configure_preset_name}
     if multiconfig:
         ret["configuration"] = build_type
     return ret
 
 
+def _configure_preset_name(build_type, multiconfig):
+    return "default" if not build_type or multiconfig else build_type
+
+
 def _add_configure_preset(conanfile, generator, cache_variables, toolchain_file, multiconfig):
     build_type = conanfile.settings.get_safe("build_type")
-    name = "default" if not build_type or multiconfig else build_type
+    name = _configure_preset_name(build_type, multiconfig)
     if not multiconfig:
         cache_variables["CMAKE_BUILD_TYPE"] = build_type
     ret = {
@@ -41,10 +47,7 @@ def _contents(conanfile, toolchain_file, cache_variables, generator):
            "cmakeMinimumRequired": {"major": 3, "minor": 15, "patch": 0},
            "configurePresets": [],
            "buildPresets": [],
-           "testPresets": [{
-              "name": "default",
-              "configurePreset": "default"
-           }]
+           "testPresets": []
           }
     multiconfig = is_multi_configuration(generator)
     ret["buildPresets"].append(_add_build_preset(conanfile, multiconfig))
@@ -65,20 +68,60 @@ def write_cmake_presets(conanfile, toolchain_file, generator):
     preset_path = os.path.join(conanfile.generators_folder, "CMakePresets.json")
     multiconfig = is_multi_configuration(generator)
     build_type = conanfile.settings.get_safe("build_type")
-    if multiconfig and os.path.exists(preset_path):
+
+    if os.path.exists(preset_path):
         # We append the new configuration making sure that we don't overwrite it
         data = json.loads(load(preset_path))
-        build_presets = data["buildPresets"]
-        already_exist = any([b["configuration"] for b in build_presets if b == build_type])
-        if not already_exist:
-            data["buildPresets"].append(_add_build_preset(conanfile, multiconfig))
+        if multiconfig:
+            build_presets = data["buildPresets"]
+            already_exist = any([b["configuration"] for b in build_presets if b == build_type])
+            if not already_exist:
+                data["buildPresets"].append(_add_build_preset(conanfile, multiconfig))
+        else:
+            configure_presets = data["buildPresets"]
+            already_exist = any([c["name"]
+                                 for c in configure_presets
+                                 if c["name"] == _configure_preset_name(build_type, multiconfig)])
+            if not already_exist:
+                conf_preset = _add_configure_preset(conanfile, generator, cache_variables,
+                                                    toolchain_file, multiconfig)
+                data["configurePresets"].append(conf_preset)
+                data["buildPresets"].append(_add_build_preset(conanfile, multiconfig))
     else:
         data = _contents(conanfile, toolchain_file, cache_variables, generator)
 
     data = json.dumps(data, indent=4)
     save(preset_path, data)
 
+    # Try to save the CMakeUserPresets.json
+    # FIXME: Private base generators
+    if os.path.exists(os.path.join(conanfile.folders._base_generators, "CMakeLists.txt")):
+        user_presets_path = os.path.join(conanfile.folders._base_generators, "CMakeUserPresets.json")
+        if not os.path.exists(user_presets_path):
+            data = {"version": 4, "include": [preset_path]}
+            data = json.dumps(data, indent=4)
+            save(user_presets_path, data)
+
 
 def load_cmake_presets(folder):
     tmp = load(os.path.join(folder, "CMakePresets.json"))
     return json.loads(tmp)
+
+
+def get_configure_preset(cmake_presets, build_type):
+
+    # Do we find a preset for the current build type?
+    for preset in cmake_presets["configurePresets"]:
+        if preset["name"] == build_type:
+            return preset
+
+    # In case of multi-config generator or None build_type
+    for preset in cmake_presets["configurePresets"]:
+        if preset["name"] == "default":
+            return preset
+
+    # FIXME: Might be an issue if someone perform several conan install that involves different
+    #        CMake generators (multi and single config). Would be impossible to determine which
+    #        is the correct configurePreset because the generator IS in the configure preset.
+
+    raise ConanException("Not available configurePreset for the build_type {}".format(build_type))

--- a/conan/tools/cmake/presets.py
+++ b/conan/tools/cmake/presets.py
@@ -94,7 +94,7 @@ def write_cmake_presets(conanfile, toolchain_file, generator):
     save(preset_path, data)
 
     # Try to save the CMakeUserPresets.json if layout declared and CMakeLists.txt found
-    if conanfile.source_folder:
+    if conanfile.source_folder and conanfile.source_folder != conanfile.generators_folder:
         if os.path.exists(os.path.join(conanfile.source_folder, "CMakeLists.txt")):
             user_presets_path = os.path.join(conanfile.source_folder, "CMakeUserPresets.json")
             if not os.path.exists(user_presets_path):

--- a/conans/test/conftest.py
+++ b/conans/test/conftest.py
@@ -72,6 +72,11 @@ tools_locations = {
             "path": {'Windows': 'C:/cmake/cmake-3.19.7-win64-x64/bin',
                      'Darwin': '/Users/jenkins/cmake/cmake-3.19.7/bin',
                      'Linux': '/usr/share/cmake-3.19.7/bin'}
+        },
+        "3.23": {
+            "path": {'Windows': 'C:/cmake/cmake-3.23.1-win64-x64/bin',
+                     'Darwin': '/Users/jenkins/cmake/cmake-3.23.1/bin',
+                     'Linux': '/usr/share/cmake-3.23.1/bin'}
         }
     },
     'ninja': {

--- a/conans/test/functional/layout/test_build_system_layout_helpers.py
+++ b/conans/test/functional/layout/test_build_system_layout_helpers.py
@@ -168,7 +168,7 @@ def test_cmake_layout_external_sources():
 
     # Local flow
     client.run("install . foo/1.0 -s os=Linux")
-    assert os.path.exists(os.path.join(client.current_folder, "cmake-build-release", "conan", "generate.txt"))
+    assert os.path.exists(os.path.join(client.current_folder, "build", "generators", "generate.txt"))
     client.run("source .")
     assert os.path.exists(os.path.join(client.current_folder, "src", "source.txt"))
     client.run("build .")

--- a/conans/test/functional/layout/test_local_commands.py
+++ b/conans/test/functional/layout/test_local_commands.py
@@ -372,8 +372,7 @@ def test_start_dir_failure():
     c = TestClient()
     c.save(pkg_cmake("dep", "0.1"))
     c.run("install .")
-    build = "build" if platform.system() == "Windows" else "cmake-build-release"
-    expected_path = os.path.join(c.current_folder, build, "conan", "conan_toolchain.cmake")
+    expected_path = os.path.join(c.current_folder, "build", "generators", "conan_toolchain.cmake")
     assert os.path.exists(expected_path)
     os.unlink(expected_path)
     with c.chdir("build"):

--- a/conans/test/functional/toolchains/cmake/cmakedeps/test_cmakedeps.py
+++ b/conans/test/functional/toolchains/cmake/cmakedeps/test_cmakedeps.py
@@ -375,6 +375,6 @@ def test_system_dep():
 
     client.run("install consumer")
     if platform.system() != "Windows":
-        data = os.path.join("consumer/cmake-build-release/conan/mylib-release-x86_64-data.cmake")
+        data = os.path.join("consumer/build/generators/mylib-release-x86_64-data.cmake")
         contents = client.load(data)
         assert 'set(ZLIB_FIND_MODE "")' in contents

--- a/conans/test/functional/toolchains/cmake/cmakedeps/test_cmakedeps_and_linker_flags.py
+++ b/conans/test/functional/toolchains/cmake/cmakedeps/test_cmakedeps_and_linker_flags.py
@@ -51,7 +51,7 @@ def test_shared_link_flags():
     client.run("new hello/1.0 -m cmake_lib")
     client.save({"conanfile.py": conanfile})
     client.run("create .")
-    t = os.path.join("test_package", "cmake-build-release", "conan", "hello-release-x86_64-data.cmake")
+    t = os.path.join("test_package", "build", "generators", "hello-release-x86_64-data.cmake")
     target_data_cmake_content = client.load(t)
     assert 'set(hello_SHARED_LINK_FLAGS_RELEASE "-z now;-z relro")' in target_data_cmake_content
     assert 'set(hello_EXE_LINK_FLAGS_RELEASE "-z now;-z relro")' in target_data_cmake_content

--- a/conans/test/functional/toolchains/cmake/test_cmake_toolchain.py
+++ b/conans/test/functional/toolchains/cmake/test_cmake_toolchain.py
@@ -111,7 +111,6 @@ def test_cmake_user_presets_load():
     assert 'CMAKE_BUILD_TYPE="Debug"' in t.out
 
 
-
 def test_cmake_toolchain_user_toolchain_from_dep():
     client = TestClient()
     conanfile = textwrap.dedent("""

--- a/conans/test/functional/toolchains/cmake/test_cmake_toolchain.py
+++ b/conans/test/functional/toolchains/cmake/test_cmake_toolchain.py
@@ -225,8 +225,7 @@ def test_install_output_directories():
     assert os.path.exists(os.path.join(p_folder, "mylibs"))
     assert not os.path.exists(os.path.join(p_folder, "lib"))
     b_folder = client.cache.package_layout(pref.ref).build(pref)
-    layout_folder = "cmake-build-release" if platform.system() != "Windows" else "build"
-    toolchain = client.load(os.path.join(b_folder, layout_folder, "conan", "conan_toolchain.cmake"))
+    toolchain = client.load(os.path.join(b_folder, "build", "generators", "conan_toolchain.cmake"))
     assert 'set(CMAKE_INSTALL_LIBDIR "mylibs")' in toolchain
 
 

--- a/conans/test/functional/toolchains/cmake/test_cmake_toolchain.py
+++ b/conans/test/functional/toolchains/cmake/test_cmake_toolchain.py
@@ -7,7 +7,6 @@ import pytest
 from conan.tools.cmake.presets import load_cmake_presets
 from conans.model.ref import ConanFileReference
 from conans.test.assets.cmake import gen_cmakelists
-from conans.test.assets.cpp_test_files import cpp_hello_conan_files
 from conans.test.assets.genconanfile import GenConanfile
 from conans.test.utils.tools import TestClient, TurboTestClient
 from conans.util.files import save

--- a/conans/test/functional/toolchains/cmake/test_cmake_toolchain.py
+++ b/conans/test/functional/toolchains/cmake/test_cmake_toolchain.py
@@ -69,7 +69,8 @@ def test_cmake_toolchain_custom_toolchain():
     assert "binaryDir" not in presets["configurePresets"][0]
 
 
-@pytest.mark.skipif(platform.system() == "Windows", reason="Single config test")
+@pytest.mark.skipif(platform.system() != "Darwin",
+                    reason="Single config test, Linux CI still without 3.23")
 @pytest.mark.tool_cmake(version="3.23")
 def test_cmake_user_presets_load():
     """

--- a/conans/test/functional/toolchains/cmake/test_cmake_toolchain_xcode_flags.py
+++ b/conans/test/functional/toolchains/cmake/test_cmake_toolchain_xcode_flags.py
@@ -38,7 +38,7 @@ def test_cmake_apple_bitcode_arc_and_visibility_flags_enabled(op_system, os_vers
     client.run("new hello/0.1 --template=cmake_lib")
     _add_message_status_flags(client)
     client.run("install . --profile:build=default --profile:host=host")
-    toolchain = client.load(os.path.join("cmake-build-release", "conan", "conan_toolchain.cmake"))
+    toolchain = client.load(os.path.join("build", "generators", "conan_toolchain.cmake"))
     # bitcode
     assert 'set(CMAKE_XCODE_ATTRIBUTE_ENABLE_BITCODE "YES")' in toolchain
     assert 'set(CMAKE_XCODE_ATTRIBUTE_BITCODE_GENERATION_MODE "bitcode")' in toolchain
@@ -121,7 +121,7 @@ def test_cmake_apple_bitcode_arc_and_visibility_flags_disabled(op_system, os_ver
     client.run("new hello/0.1 --template=cmake_lib")
     _add_message_status_flags(client)
     client.run("install . --profile:build=default --profile:host=host")
-    toolchain = client.load(os.path.join("cmake-build-release", "conan", "conan_toolchain.cmake"))
+    toolchain = client.load(os.path.join("build", "generators", "conan_toolchain.cmake"))
     # bitcode
     assert 'set(CMAKE_XCODE_ATTRIBUTE_ENABLE_BITCODE "NO")' in toolchain
     assert 'set(CMAKE_XCODE_ATTRIBUTE_BITCODE_GENERATION_MODE "bitcode")' not in toolchain
@@ -163,7 +163,7 @@ def test_cmake_apple_bitcode_arc_and_visibility_flags_are_none(op_system, os_ver
     client.run("new hello/0.1 --template=cmake_lib")
     _add_message_status_flags(client)
     client.run("install . --profile:build=default --profile:host=host")
-    toolchain = client.load(os.path.join("cmake-build-release", "conan", "conan_toolchain.cmake"))
+    toolchain = client.load(os.path.join("build", "generators", "conan_toolchain.cmake"))
     # bitcode
     assert 'set(CMAKE_XCODE_ATTRIBUTE_ENABLE_BITCODE "NO")' not in toolchain
     assert 'set(CMAKE_XCODE_ATTRIBUTE_BITCODE_GENERATION_MODE "bitcode")' not in toolchain

--- a/conans/test/integration/toolchains/cmake/test_cmaketoolchain.py
+++ b/conans/test/integration/toolchains/cmake/test_cmaketoolchain.py
@@ -434,3 +434,8 @@ def test_cmake_presets_singleconfig():
 
     assert len(presets["buildPresets"]) == 2
     assert presets["buildPresets"][1]["configurePreset"] == "Debug"
+
+    # Repeat configuration, it shouldn't add a new one
+    client.run("install mylib/1.0@ -g CMakeToolchain -s build_type=Debug --profile:h=profile")
+    presets = json.loads(client.load("CMakePresets.json"))
+    assert len(presets["configurePresets"]) == 2

--- a/conans/test/integration/toolchains/cmake/test_cmaketoolchain.py
+++ b/conans/test/integration/toolchains/cmake/test_cmaketoolchain.py
@@ -353,7 +353,7 @@ def test_cmake_presets_binary_dir_available():
     else:
         build_dir = os.path.join(client.current_folder, "build")
 
-    presets = load_cmake_presets(os.path.join(build_dir, "conan"))
+    presets = load_cmake_presets(os.path.join(client.current_folder, "build", "generators"))
     assert presets["configurePresets"][0]["binaryDir"] == build_dir
 
 
@@ -401,6 +401,9 @@ def test_cmake_presets_multiconfig():
     assert presets["buildPresets"][2]["configuration"] == "RelWithDebInfo"
     assert presets["buildPresets"][3]["configuration"] == "MinSizeRel"
 
+    assert len(presets["configurePresets"]) == 1
+    assert presets["configurePresets"][0]["name"] == "default"
+
 
 def test_cmake_presets_singleconfig():
     client = TestClient()
@@ -420,8 +423,14 @@ def test_cmake_presets_singleconfig():
     assert len(presets["configurePresets"]) == 1
     assert presets["configurePresets"][0]["name"] == "Release"
 
-    # Still only one configurePreset, but named correctly
+    assert len(presets["buildPresets"]) == 1
+    assert presets["buildPresets"][0]["configurePreset"] == "Release"
+
+    # Now two configurePreset, but named correctly
     client.run("install mylib/1.0@ -g CMakeToolchain -s build_type=Debug --profile:h=profile")
     presets = json.loads(client.load("CMakePresets.json"))
-    assert len(presets["configurePresets"]) == 1
-    assert presets["configurePresets"][0]["name"] == "Debug"
+    assert len(presets["configurePresets"]) == 2
+    assert presets["configurePresets"][1]["name"] == "Debug"
+
+    assert len(presets["buildPresets"]) == 2
+    assert presets["buildPresets"][1]["configurePreset"] == "Debug"


### PR DESCRIPTION
Changelog: Feature: The `cmake_layout` declares `folders.generators = "build/generators"` that is common for different configurations, enabling `CMakePresets.json` to support different `configurePresets` and `buildPresets` for single-config and multi-config generators.
Changelog: Feature: The `CMakeToolchain` generator will create (if missing) a `CMakeUserPresets.json` if the `CMakeLists.txt` file is found in the root folder of the project. That file will include automatically the `CMakePresets.json` file contained at `build/generators` folder to allow CMake and IDEs to locate automatically the presets generated by Conan. 
Docs: https://github.com/conan-io/docs/pull/2512

Note: This feature, is at the date, not supported yet by Visual Studio Code plugin and only by [CMake](https://cmake.org/cmake/help/latest/release/3.23.html#presets) >=3.23.
