### PR TITLE
fix tools.scm.Version construction from non-str

### DIFF
--- a/conans/model/version.py
+++ b/conans/model/version.py
@@ -9,7 +9,7 @@ class Version(str):
     version_pattern = re.compile('[.-]')
 
     def __new__(cls, content):
-        return str.__new__(cls, content.strip())
+        return str.__new__(cls, str(content).strip())
 
     @property
     def as_list(self):

--- a/conans/test/unittests/tools/scm/test_version.py
+++ b/conans/test/unittests/tools/scm/test_version.py
@@ -1,0 +1,23 @@
+import textwrap
+
+from conans.test.utils.tools import TestClient
+
+
+def test_version():
+    c = TestClient()
+    conanfile = textwrap.dedent("""
+        from conan import ConanFile
+        from conan.tools.scm import Version
+
+        class Pkg(ConanFile):
+            name = "pkg"
+            version = "0.1"
+            settings = "compiler"
+            def configure(self):
+                v = Version(self.settings.compiler.version)
+                assert v > "10"
+        """)
+    c.save({"conanfile.py": conanfile})
+    settings = "-s compiler=gcc -s compiler.libcxx=libstdc++11"
+    c.run("create . {} -s compiler.version=11".format(settings))
+    c.run("create . {} -s compiler.version=9".format(settings), assert_error=True)


### PR DESCRIPTION
Changelog: Fix: Allow ``Version(self.settings.compiler.version)`` to work for ``new`` tools.scm.Version``.
Docs: Omit

Close https://github.com/conan-io/conan/issues/11105
