### PR TITLE
Update info for the markdown generator

### DIFF
--- a/conans/client/generators/markdown.py
+++ b/conans/client/generators/markdown.py
@@ -308,7 +308,6 @@ buildsystem_autotools_tpl = textwrap.dedent("""
     # set the environment variables for Autotools
     $ source conanautotoolstoolchain.sh
 
-    # You will have to set the PKG_CONFIG_PATH to where Conan created the {{ pkgconfig_variables.pkg_name }}.pc file
     $ export CPPFLAGS="$CPPFLAGS $(pkg-config --cflags {{ requirement.ref.name }})"
     $ export LIBS="$LIBS $(pkg-config --libs-only-l {{ requirement.ref.name }})"
     $ export LDFLAGS="$LDFLAGS $(pkg-config --libs-only-L --libs-only-other {{ requirement.ref.name }})"


### PR DESCRIPTION
Changelog: Feature: Do not recommend to set `PKG_CONFIG_PATH` in markdown generator any more as it is already set by the AutotoolsToolchain.
Docs: omit

After https://github.com/conan-io/conan/pull/11063 the PKG_CONFIG_PATH is already set by the AutotoolsToolchain.