### PR TITLE
Place quote marks around append echo statement

### DIFF
--- a/conan/tools/env/environment.py
+++ b/conan/tools/env/environment.py
@@ -354,7 +354,7 @@ class EnvVars:
         deactivate_file = os.path.join(filepath, "deactivate_{}".format(filename))
         deactivate = textwrap.dedent("""\
            echo Capturing current environment in "{deactivate_file}"
-           echo echo Restoring environment >> "{deactivate_file}"
+           echo "echo Restoring environment" >> "{deactivate_file}"
            for v in {vars}
            do
                value=$(printenv $v)


### PR DESCRIPTION
Changelog: Fix: Placing quote marks around echo statement in `save_sh` function.
Docs: omit
Fixes #11122

Some bash shells seem to trip over the double echo statement.
Enclosing the statement in brackets fixes this.

- [x] Refer to the issue that supports this Pull Request.
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 

<sup>**Note:** By default this PR will skip the slower tests and will use a limited set of python versions. Check [here](https://github.com/conan-io/conan/blob/develop/.github/PR_INCREASE_TESTING.md) how to increase the testing level by writing some tags in the current PR body text.</sup>
