### PR TITLE
reviewing lockfiles for 2.0

### DIFF
--- a/conans/cli/commands/build.py
+++ b/conans/cli/commands/build.py
@@ -4,11 +4,10 @@ from conans.cli.command import conan_command, COMMAND_GROUPS
 from conans.cli.commands import make_abs_path
 from conans.cli.commands.install import graph_compute, _get_conanfile_path
 from conans.cli.common import _add_common_install_arguments, _help_build_policies, \
-    get_multiple_remotes, add_lockfile_args, add_reference_args
+    get_multiple_remotes, add_lockfile_args, add_reference_args, save_lockfile_out
 from conans.cli.conan_app import ConanApp
 from conans.cli.output import ConanOutput
 from conans.client.conanfile.build import run_build_method
-from conans.model.graph_lock import Lockfile
 
 
 @conan_command(group=COMMAND_GROUPS['creator'])
@@ -50,12 +49,4 @@ def build(conan_api, parser, *args):
     conanfile.folders.set_base_package(conanfile.folders.base_build)
     run_build_method(conanfile, app.hook_manager, conanfile_path=path)
 
-    if args.lockfile_out:
-        # TODO: Repeated pattern
-        if lockfile is None:
-            lockfile = Lockfile(deps_graph, args.lockfile_packages)
-        else:
-            lockfile.update_lock(deps_graph, args.lockfile_packages)
-        lockfile_out = make_abs_path(args.lockfile_out, cwd)
-        out.info(f"Saving lockfile: {lockfile_out}")
-        lockfile.save(lockfile_out)
+    save_lockfile_out(args, deps_graph, lockfile, cwd)

--- a/conans/cli/commands/build.py
+++ b/conans/cli/commands/build.py
@@ -31,7 +31,7 @@ def build(conan_api, parser, *args):
     folder = os.path.dirname(path)
     remote = get_multiple_remotes(conan_api, args.remote)
 
-    deps_graph, lockfile = graph_compute(args, conan_api, strict=not args.lockfile_no_strict)
+    deps_graph, lockfile = graph_compute(args, conan_api, partial=args.lockfile_partial)
 
     out = ConanOutput()
     out.highlight("\n-------- Installing packages ----------")

--- a/conans/cli/commands/create.py
+++ b/conans/cli/commands/create.py
@@ -33,7 +33,8 @@ def create(conan_api, parser, *args):
 
     cwd = os.getcwd()
     path = _get_conanfile_path(args.path, cwd, py=True)
-    lockfile = get_lockfile(lockfile_path=args.lockfile, cwd=cwd, strict=not args.lockfile_no_strict)
+    lockfile = get_lockfile(lockfile_path=args.lockfile, cwd=cwd, conanfile_path=path,
+                            partial=args.lockfile_partial)
     remotes = get_multiple_remotes(conan_api, args.remote)
     profile_host, profile_build = get_profiles_from_args(conan_api, args)
 

--- a/conans/cli/commands/export.py
+++ b/conans/cli/commands/export.py
@@ -19,14 +19,15 @@ def export(conan_api, parser, *args):
     common_args_export(parser)
     parser.add_argument("-l", "--lockfile", action=OnceArgument,
                         help="Path to a lockfile.")
-    parser.add_argument("--lockfile-no-strict", action="store_true",
-                        help="Raise an error if some dependency is not found in lockfile")
+    parser.add_argument("--lockfile-partial", action="store_true",
+                        help="Do not raise an error if some dependency is not found in lockfile")
 
     args = parser.parse_args(*args)
 
     cwd = os.getcwd()
-    lockfile = get_lockfile(lockfile_path=args.lockfile, cwd=cwd, strict=not args.lockfile_no_strict)
-    path = _get_conanfile_path(args.path, cwd, py=None) if args.path else None
+    path = _get_conanfile_path(args.path, cwd, py=True)
+    lockfile = get_lockfile(lockfile_path=args.lockfile, cwd=cwd, conanfile_path=path,
+                            partial=args.lockfile_partial)
     ref = conan_api.export.export(path=path,
                                   name=args.name, version=args.version,
                                   user=args.user, channel=args.channel,

--- a/conans/cli/commands/export_pkg.py
+++ b/conans/cli/commands/export_pkg.py
@@ -1,6 +1,6 @@
 import os
 
-from conans.cli.command import conan_command, COMMAND_GROUPS, OnceArgument
+from conans.cli.command import conan_command, COMMAND_GROUPS
 from conans.cli.commands import make_abs_path
 from conans.cli.commands.install import _get_conanfile_path
 from conans.cli.common import get_lockfile, add_profiles_args, get_profiles_from_args, \
@@ -19,8 +19,7 @@ def export_pkg(conan_api, parser, *args, **kwargs):
     args = parser.parse_args(*args)
 
     cwd = os.getcwd()
-    lockfile_path = make_abs_path(args.lockfile, cwd)
-    lockfile = get_lockfile(lockfile=lockfile_path, strict=args.lockfile_strict)
+    lockfile = get_lockfile(lockfile_path=args.lockfile, cwd=cwd, strict=not args.lockfile_no_strict)
     path = _get_conanfile_path(args.path, cwd, py=None) if args.path else None
     profile_host, profile_build = get_profiles_from_args(conan_api, args)
 
@@ -47,5 +46,6 @@ def export_pkg(conan_api, parser, *args, **kwargs):
     conan_api.export.export_pkg(deps_graph, path)
 
     if args.lockfile_out:
+
         lockfile_out = make_abs_path(args.lockfile_out, cwd)
         lockfile.save(lockfile_out)

--- a/conans/cli/commands/export_pkg.py
+++ b/conans/cli/commands/export_pkg.py
@@ -1,14 +1,13 @@
 import os
 
 from conans.cli.command import conan_command, COMMAND_GROUPS
-from conans.cli.commands import make_abs_path
 from conans.cli.commands.install import _get_conanfile_path
 from conans.cli.common import get_lockfile, add_profiles_args, get_profiles_from_args, \
-    add_lockfile_args, add_reference_args, scope_options
+    add_lockfile_args, add_reference_args, scope_options, save_lockfile_out
 
 
 @conan_command(group=COMMAND_GROUPS['creator'])
-def export_pkg(conan_api, parser, *args, **kwargs):
+def export_pkg(conan_api, parser, *args):
     """
     Export recipe to the Conan package cache
     """
@@ -45,7 +44,4 @@ def export_pkg(conan_api, parser, *args, **kwargs):
 
     conan_api.export.export_pkg(deps_graph, path)
 
-    if args.lockfile_out:
-
-        lockfile_out = make_abs_path(args.lockfile_out, cwd)
-        lockfile.save(lockfile_out)
+    save_lockfile_out(args, deps_graph, lockfile, cwd)

--- a/conans/cli/commands/export_pkg.py
+++ b/conans/cli/commands/export_pkg.py
@@ -18,8 +18,10 @@ def export_pkg(conan_api, parser, *args):
     args = parser.parse_args(*args)
 
     cwd = os.getcwd()
-    lockfile = get_lockfile(lockfile_path=args.lockfile, cwd=cwd, strict=not args.lockfile_no_strict)
-    path = _get_conanfile_path(args.path, cwd, py=None) if args.path else None
+    path = _get_conanfile_path(args.path, cwd, py=True)
+    lockfile = get_lockfile(lockfile_path=args.lockfile, cwd=cwd, conanfile_path=path,
+                            partial=args.lockfile_partial)
+
     profile_host, profile_build = get_profiles_from_args(conan_api, args)
 
     ref = conan_api.export.export(path=path,

--- a/conans/cli/commands/graph.py
+++ b/conans/cli/commands/graph.py
@@ -44,7 +44,7 @@ def graph_build_order(conan_api, parser, subparser, *args):
         raise ConanException("Can't use --name, --version, --user or --channel arguments with "
                              "--requires")
 
-    deps_graph, lockfile = graph_compute(args, conan_api, strict=args.lockfile_strict)
+    deps_graph, lockfile = graph_compute(args, conan_api, strict=not args.lockfile_no_strict)
 
     out = ConanOutput()
     out.highlight("-------- Computing the build order ----------")
@@ -96,7 +96,7 @@ def graph_info(conan_api, parser, subparser, *args):
     if args.format is not None and (args.filter or args.package_filter):
         raise ConanException("Formatted outputs cannot be filtered")
 
-    deps_graph, lockfile = graph_compute(args, conan_api, strict=args.lockfile_strict,
+    deps_graph, lockfile = graph_compute(args, conan_api, strict=not args.lockfile_no_strict,
                                          allow_error=True)
     if not args.format:
         print_graph_info(deps_graph, args.filter, args.package_filter)

--- a/conans/cli/commands/graph.py
+++ b/conans/cli/commands/graph.py
@@ -46,7 +46,7 @@ def graph_build_order(conan_api, parser, subparser, *args):
         raise ConanException("Can't use --name, --version, --user or --channel arguments with "
                              "--requires")
 
-    deps_graph, lockfile = graph_compute(args, conan_api, strict=not args.lockfile_no_strict)
+    deps_graph, lockfile = graph_compute(args, conan_api, partial=args.lockfile_partial)
 
     out = ConanOutput()
     out.highlight("-------- Computing the build order ----------")
@@ -98,7 +98,7 @@ def graph_info(conan_api, parser, subparser, *args):
     if args.format is not None and (args.filter or args.package_filter):
         raise ConanException("Formatted outputs cannot be filtered")
 
-    deps_graph, lockfile = graph_compute(args, conan_api, strict=not args.lockfile_no_strict,
+    deps_graph, lockfile = graph_compute(args, conan_api, partial=args.lockfile_partial,
                                          allow_error=True)
     if not args.format:
         print_graph_info(deps_graph, args.filter, args.package_filter)

--- a/conans/cli/commands/graph.py
+++ b/conans/cli/commands/graph.py
@@ -5,11 +5,13 @@ from conans.cli.command import conan_command, COMMAND_GROUPS, conan_subcommand, 
     Extender
 from conans.cli.commands import make_abs_path
 from conans.cli.commands.install import graph_compute, common_graph_args
+from conans.cli.common import save_lockfile_out
 from conans.cli.formatters.graph import format_graph_html, format_graph_json, format_graph_dot, \
     print_graph_info
 from conans.cli.output import ConanOutput
 from conans.client.graph.install_graph import InstallGraph
 from conans.errors import ConanException
+from conans.model.graph_lock import Lockfile
 
 
 @conan_command(group=COMMAND_GROUPS['consumer'])
@@ -101,10 +103,7 @@ def graph_info(conan_api, parser, subparser, *args):
     if not args.format:
         print_graph_info(deps_graph, args.filter, args.package_filter)
 
-    if args.lockfile_out:
-        lockfile_out = make_abs_path(args.lockfile_out, os.getcwd())
-        ConanOutput().info(f"Saving lockfile: {lockfile_out}")
-        lockfile.save(lockfile_out)
+    save_lockfile_out(args, deps_graph, lockfile, os.getcwd())
 
     return deps_graph, os.path.join(conan_api.cache_folder, "templates")
 

--- a/conans/cli/commands/install.py
+++ b/conans/cli/commands/install.py
@@ -47,7 +47,6 @@ def _get_conanfile_path(path, cwd, py):
 
 def graph_compute(args, conan_api, strict=False, allow_error=False):
     cwd = os.getcwd()
-    lockfile_path = make_abs_path(args.lockfile, cwd)
     path = _get_conanfile_path(args.path, cwd, py=None) if args.path else None
 
     requires = [RecipeReference.loads(r) for r in args.requires] \
@@ -60,7 +59,7 @@ def graph_compute(args, conan_api, strict=False, allow_error=False):
 
     # Basic collaborators, remotes, lockfile, profiles
     remotes = get_multiple_remotes(conan_api, args.remote)
-    lockfile = get_lockfile(lockfile=lockfile_path, strict=strict)
+    lockfile = get_lockfile(lockfile_path=args.lockfile, cwd=cwd, strict=strict)
     profile_host, profile_build = get_profiles_from_args(conan_api, args)
 
     out = ConanOutput()
@@ -163,7 +162,7 @@ def install(conan_api, parser, *args):
 
     remote = get_multiple_remotes(conan_api, args.remote)
 
-    deps_graph, lockfile = graph_compute(args, conan_api, strict=args.lockfile_strict)
+    deps_graph, lockfile = graph_compute(args, conan_api, strict=not args.lockfile_no_strict)
 
     out = ConanOutput()
     out.highlight("\n-------- Installing packages ----------")

--- a/conans/cli/commands/install.py
+++ b/conans/cli/commands/install.py
@@ -45,7 +45,7 @@ def _get_conanfile_path(path, cwd, py):
     return path
 
 
-def graph_compute(args, conan_api, strict=False, allow_error=False):
+def graph_compute(args, conan_api, partial=False, allow_error=False):
     cwd = os.getcwd()
     path = _get_conanfile_path(args.path, cwd, py=None) if args.path else None
 
@@ -59,7 +59,8 @@ def graph_compute(args, conan_api, strict=False, allow_error=False):
 
     # Basic collaborators, remotes, lockfile, profiles
     remotes = get_multiple_remotes(conan_api, args.remote)
-    lockfile = get_lockfile(lockfile_path=args.lockfile, cwd=cwd, strict=strict)
+    lockfile = get_lockfile(lockfile_path=args.lockfile, cwd=cwd, conanfile_path=path,
+                            partial=partial)
     profile_host, profile_build = get_profiles_from_args(conan_api, args)
 
     out = ConanOutput()
@@ -162,7 +163,7 @@ def install(conan_api, parser, *args):
 
     remote = get_multiple_remotes(conan_api, args.remote)
 
-    deps_graph, lockfile = graph_compute(args, conan_api, strict=not args.lockfile_no_strict)
+    deps_graph, lockfile = graph_compute(args, conan_api, partial=args.lockfile_partial)
 
     out = ConanOutput()
     out.highlight("\n-------- Installing packages ----------")
@@ -175,4 +176,5 @@ def install(conan_api, parser, *args):
                                        source_folder=source_folder,
                                        deploy=args.deploy
                                        )
+
     save_lockfile_out(args, deps_graph, lockfile, cwd)

--- a/conans/cli/commands/install.py
+++ b/conans/cli/commands/install.py
@@ -4,7 +4,7 @@ from conans.cli.command import conan_command, Extender, COMMAND_GROUPS
 from conans.cli.commands import make_abs_path
 from conans.cli.common import _add_common_install_arguments, _help_build_policies, \
     get_profiles_from_args, get_lockfile, get_multiple_remotes, add_lockfile_args, \
-    add_reference_args, scope_options
+    add_reference_args, scope_options, save_lockfile_out
 from conans.cli.formatters.graph import print_graph_basic, print_graph_packages
 from conans.cli.output import ConanOutput
 from conans.errors import ConanException
@@ -175,8 +175,4 @@ def install(conan_api, parser, *args):
                                        source_folder=source_folder,
                                        deploy=args.deploy
                                        )
-
-    if args.lockfile_out:
-        lockfile_out = make_abs_path(args.lockfile_out, cwd)
-        out.info(f"Saving lockfile: {lockfile_out}")
-        lockfile.save(lockfile_out)
+    save_lockfile_out(args, deps_graph, lockfile, cwd)

--- a/conans/cli/commands/lock.py
+++ b/conans/cli/commands/lock.py
@@ -4,7 +4,7 @@ from conans.cli.commands import make_abs_path
 from conans.cli.commands.install import common_graph_args, graph_compute
 from conans.cli.output import ConanOutput
 from conans.errors import ConanException
-from conans.model.graph_lock import Lockfile
+from conans.model.graph_lock import Lockfile, LOCKFILE
 from conans.model.recipe_ref import RecipeReference
 
 
@@ -96,6 +96,6 @@ def lock_add(conan_api, parser, subparser, *args):
 
     lockfile.add(requires=requires, build_requires=build_requires, python_requires=python_requires)
 
-    lockfile_out = make_abs_path(args.lockfile_out)
+    lockfile_out = make_abs_path(args.lockfile_out or LOCKFILE)
     lockfile.save(lockfile_out)
     ConanOutput().info("Generated lockfile: %s" % lockfile_out)

--- a/conans/cli/commands/lock.py
+++ b/conans/cli/commands/lock.py
@@ -1,7 +1,10 @@
+import os
+
 from conans.cli.command import conan_command, COMMAND_GROUPS, OnceArgument, \
     conan_subcommand
 from conans.cli.commands import make_abs_path
 from conans.cli.commands.install import common_graph_args, graph_compute
+from conans.cli.common import save_lockfile_out
 from conans.cli.output import ConanOutput
 from conans.errors import ConanException
 from conans.model.graph_lock import Lockfile, LOCKFILE
@@ -21,8 +24,6 @@ def lock_create(conan_api, parser, subparser, *args):
     Create a lockfile from a conanfile or a reference
     """
     common_graph_args(subparser)
-    subparser.add_argument("--clean", action="store_true", help="remove unused")
-
     args = parser.parse_args(*args)
 
     # parameter validation
@@ -32,14 +33,8 @@ def lock_create(conan_api, parser, subparser, *args):
 
     deps_graph, lockfile = graph_compute(args, conan_api, strict=False)
 
-    if lockfile is None or args.clean:
-        lockfile = Lockfile(deps_graph, args.lockfile_packages)
-    else:
-        lockfile.update_lock(deps_graph, args.lockfile_packages)
-
-    lockfile_out = make_abs_path(args.lockfile_out or "conan.lock")
-    lockfile.save(lockfile_out)
-    ConanOutput().info("Generated lockfile: %s" % lockfile_out)
+    args.lockfile_out = args.lockfile_out or "conan.lock"
+    save_lockfile_out(args, deps_graph, lockfile, os.getcwd())
 
 
 @conan_subcommand()

--- a/conans/cli/commands/test.py
+++ b/conans/cli/commands/test.py
@@ -1,11 +1,10 @@
 import os
 
 from conans.cli.command import conan_command, COMMAND_GROUPS, OnceArgument
-from conans.cli.commands import make_abs_path
 from conans.cli.commands.create import test_package
 from conans.cli.commands.install import _get_conanfile_path
 from conans.cli.common import get_lockfile, get_profiles_from_args, _add_common_install_arguments, \
-    get_multiple_remotes, add_lockfile_args
+    get_multiple_remotes, add_lockfile_args, save_lockfile_out
 from conans.cli.formatters.graph import print_graph_basic, print_graph_packages
 from conans.cli.output import ConanOutput
 from conans.model.recipe_ref import RecipeReference
@@ -62,9 +61,6 @@ def test(conan_api, parser, *args):
     out.highlight("\n-------- Installing packages ----------")
     conan_api.install.install_binaries(deps_graph=deps_graph, remotes=remotes, update=args.update)
 
-    if args.lockfile_out:
-        lockfile_out = make_abs_path(args.lockfile_out, cwd)
-        out.info(f"Saving lockfile: {lockfile_out}")
-        lockfile.save(lockfile_out)
+    save_lockfile_out(args, deps_graph, lockfile, cwd)
 
     test_package(conan_api, deps_graph, path)

--- a/conans/cli/commands/test.py
+++ b/conans/cli/commands/test.py
@@ -26,7 +26,8 @@ def test(conan_api, parser, *args):
     cwd = os.getcwd()
     ref = RecipeReference.loads(args.reference)
     path = _get_conanfile_path(args.path, cwd, py=True)
-    lockfile = get_lockfile(lockfile_path=args.lockfile, cwd=cwd, strict=not args.lockfile_no_strict)
+    lockfile = get_lockfile(lockfile_path=args.lockfile, cwd=cwd, conanfile_path=path,
+                            partial=args.lockfile_partial)
     remotes = get_multiple_remotes(conan_api, args.remote)
     profile_host, profile_build = get_profiles_from_args(conan_api, args)
 

--- a/conans/cli/commands/test.py
+++ b/conans/cli/commands/test.py
@@ -6,13 +6,9 @@ from conans.cli.commands.create import test_package
 from conans.cli.commands.install import _get_conanfile_path
 from conans.cli.common import get_lockfile, get_profiles_from_args, _add_common_install_arguments, \
     get_multiple_remotes, add_lockfile_args
-from conans.cli.conan_app import ConanApp
 from conans.cli.formatters.graph import print_graph_basic, print_graph_packages
 from conans.cli.output import ConanOutput
-from conans.client.conanfile.build import run_build_method
-from conans.errors import conanfile_exception_formatter
 from conans.model.recipe_ref import RecipeReference
-from conans.util.files import chdir
 
 
 @conan_command(group=COMMAND_GROUPS['creator'])
@@ -31,8 +27,7 @@ def test(conan_api, parser, *args):
     cwd = os.getcwd()
     ref = RecipeReference.loads(args.reference)
     path = _get_conanfile_path(args.path, cwd, py=True)
-    lockfile_path = make_abs_path(args.lockfile, cwd)
-    lockfile = get_lockfile(lockfile=lockfile_path, strict=args.lockfile_strict)
+    lockfile = get_lockfile(lockfile_path=args.lockfile, cwd=cwd, strict=not args.lockfile_no_strict)
     remotes = get_multiple_remotes(conan_api, args.remote)
     profile_host, profile_build = get_profiles_from_args(conan_api, args)
 

--- a/conans/cli/common.py
+++ b/conans/cli/common.py
@@ -108,6 +108,7 @@ def add_lockfile_args(parser):
                         help="Filename of the updated lockfile")
     parser.add_argument("--lockfile-packages", action="store_true",
                         help="Lock package-id and package-revision information")
+    parser.add_argument("--lockfile-clean", action="store_true", help="remove unused")
 
 
 def get_profiles_from_args(conan_api, args):
@@ -151,6 +152,18 @@ def get_lockfile(lockfile_path, cwd, strict=False):
     graph_lock.strict = strict
     ConanOutput().info("Using lockfile: '{}'".format(lockfile_path))
     return graph_lock
+
+
+def save_lockfile_out(args, graph, lockfile, cwd):
+    if not args.lockfile_out:
+        return
+    if lockfile is None or args.lockfile_clean:
+        lockfile = Lockfile(graph, args.lockfile_packages)
+    else:
+        lockfile.update_lock(graph, args.lockfile_packages)
+    lockfile_out = make_abs_path(args.lockfile_out, cwd)
+    lockfile.save(lockfile_out)
+    ConanOutput().info(f"Generated lockfile: {lockfile_out}")
 
 
 def get_multiple_remotes(conan_api, remote_names=None):

--- a/conans/client/cmd/export.py
+++ b/conans/client/cmd/export.py
@@ -80,9 +80,6 @@ def cmd_export(app, conanfile_path, name, version, user, channel, graph_lock=Non
             set_dirty(source_folder)
 
     scoped_output.info("Exported revision: %s" % revision)
-    if graph_lock is not None:
-        graph_lock.update_lock_export_ref(ref)
-
     return ref
 
 

--- a/conans/model/graph_lock.py
+++ b/conans/model/graph_lock.py
@@ -56,6 +56,7 @@ class _LockRequires:
             self._requires.setdefault(ref, {}).update(package_ids)
         else:
             self._requires.setdefault(ref, None)  # To keep previous packgae_id: prev if exists
+        self.sort()
 
     def insert(self, ref):
         self._requires[ref] = None
@@ -85,7 +86,7 @@ class Lockfile(object):
         self._python_requires = _LockRequires()
         self._build_requires = _LockRequires()
         self.alias = {}  # TODO: Alias locking needs to be tested more
-        self.strict = False
+        self.partial = False
 
         if deps_graph is None:
             return
@@ -206,7 +207,7 @@ class Lockfile(object):
                     require.ref = m
                     break
             else:
-                if self.strict:
+                if not self.partial:
                     raise ConanException(f"Requirement '{ref}' not in lockfile")
         else:
             alias = require.alias
@@ -219,10 +220,10 @@ class Lockfile(object):
                         require.ref = r
                         break
                 else:
-                    if self.strict:
+                    if not self.partial:
                         raise ConanException(f"Requirement '{ref}' not in lockfile")
             else:
-                if ref not in locked_refs and self.strict:
+                if ref not in locked_refs and not self.partial:
                     raise ConanException(f"Requirement '{repr(ref)}' not in lockfile")
 
     def resolve_locked_pyrequires(self, require):

--- a/conans/test/integration/command/create_test.py
+++ b/conans/test/integration/command/create_test.py
@@ -386,8 +386,5 @@ def test_lockfile_input_not_specified():
     client = TestClient()
     client.save({"conanfile.py": GenConanfile().with_name("foo").with_version("1.0")})
     client.run("lock create . --lockfile-out locks/conan.lock")
-    client.run("create . --lockfile-out locks/conan.lock", assert_error=True)
-    assert "Specify --lockfile with a valid file if you use --lockfile-out or use " \
-           "'conan lock create' to create a new lockfile" in client.out
-    client.run("create . --lockfile locks/conan.lock --lockfile-out locks/conan.lock")
+    client.run("create . --lockfile-out locks/conan.lock")
     assert "Saving lockfile:" in client.out

--- a/conans/test/integration/command/create_test.py
+++ b/conans/test/integration/command/create_test.py
@@ -387,4 +387,4 @@ def test_lockfile_input_not_specified():
     client.save({"conanfile.py": GenConanfile().with_name("foo").with_version("1.0")})
     client.run("lock create . --lockfile-out locks/conan.lock")
     client.run("create . --lockfile-out locks/conan.lock")
-    assert "Saving lockfile:" in client.out
+    assert "Generated lockfile:" in client.out

--- a/conans/test/integration/lockfile/test_ci.py
+++ b/conans/test/integration/lockfile/test_ci.py
@@ -184,7 +184,7 @@ def test_single_config_centralized_change_dep(client_setup):
 
     # Test that pkgb/0.2 works
     c.run("create pkgb --name=pkgb --version=0.2 -s os=Windows "
-          "--lockfile=app1.lock --lockfile-out=app1_b_changed.lock")
+          "--lockfile=app1.lock --lockfile-out=app1_b_changed.lock --lockfile-no-strict")
     assert "pkgb/0.2: DEP FILE pkgj: HelloJ" in c.out
     # Build new package alternative J, it won't be included, already locked in this create
     c.run("create pkgj --name=pkgj --version=0.2 -s os=Windows")

--- a/conans/test/integration/lockfile/test_ci.py
+++ b/conans/test/integration/lockfile/test_ci.py
@@ -116,7 +116,7 @@ def test_single_config_centralized(client_setup):
 
     # All good! We can get rid of the now unused pkgb/0.1 version in the lockfile
     c.run("lock create --requires=app1/0.1@ --lockfile=app1_b_integrated.lock "
-          "--lockfile-out=app1_clean.lock -s os=Windows --clean")
+          "--lockfile-out=app1_clean.lock -s os=Windows --lockfile-clean")
     app1_clean = c.load("app1_clean.lock")
     assert "pkgb/0.2" in app1_clean
     assert "pkgb/0.1" not in app1_clean
@@ -158,7 +158,7 @@ def test_single_config_centralized_out_range(client_setup):
 
     # All good! We can get rid of the now unused pkgb/1.0 version in the lockfile
     c.run("lock create --requires=app1/0.1@ --lockfile=app1_b_integrated.lock "
-          "--lockfile-out=app1_clean.lock -s os=Windows --clean")
+          "--lockfile-out=app1_clean.lock -s os=Windows --lockfile-clean")
     app1_clean = c.load("app1_clean.lock")
     assert "pkgb/0.1" in app1_clean
     assert "pkgb/1.0" not in app1_clean
@@ -203,7 +203,7 @@ def test_single_config_centralized_change_dep(client_setup):
 
     # All good! We can get rid of the now unused pkgb/1.0 version in the lockfile
     c.run("lock create --requires=app1/0.1@ --lockfile=app1_b_integrated.lock "
-          "--lockfile-out=app1_clean.lock -s os=Windows --clean")
+          "--lockfile-out=app1_clean.lock -s os=Windows --lockfile-clean")
     app1_clean = c.load("app1_clean.lock")
     assert "pkgj/0.1" in app1_clean
     assert "pkgb/0.2" in app1_clean
@@ -265,7 +265,7 @@ def test_multi_config_centralized(client_setup):
 
     # All good! We can get rid of the now unused pkgb/0.1 version in the lockfile
     c.run("lock create --requires=app1/0.1@ --lockfile=app1_win.lock "
-          "--lockfile-out=app1_win.lock -s os=Windows --clean")
+          "--lockfile-out=app1_win.lock -s os=Windows --lockfile-clean")
     app1_clean = c.load("app1_win.lock")
     assert "pkgawin/0.1" in app1_clean
     assert "pkgb/0.2" in app1_clean
@@ -273,7 +273,7 @@ def test_multi_config_centralized(client_setup):
     assert "pkgawin/0.2" not in app1_clean
     assert "pkganix/0.2" not in app1_clean
     c.run("lock create --requires=app1/0.1@ --lockfile=app1_nix.lock "
-          "--lockfile-out=app1_nix.lock -s os=Linux --clean")
+          "--lockfile-out=app1_nix.lock -s os=Linux --lockfile-clean")
     app1_clean = c.load("app1_nix.lock")
     assert "pkganix/0.1" in app1_clean
     assert "pkgb/0.2" in app1_clean

--- a/conans/test/integration/lockfile/test_ci.py
+++ b/conans/test/integration/lockfile/test_ci.py
@@ -184,7 +184,7 @@ def test_single_config_centralized_change_dep(client_setup):
 
     # Test that pkgb/0.2 works
     c.run("create pkgb --name=pkgb --version=0.2 -s os=Windows "
-          "--lockfile=app1.lock --lockfile-out=app1_b_changed.lock --lockfile-no-strict")
+          "--lockfile=app1.lock --lockfile-out=app1_b_changed.lock --lockfile-partial")
     assert "pkgb/0.2: DEP FILE pkgj: HelloJ" in c.out
     # Build new package alternative J, it won't be included, already locked in this create
     c.run("create pkgj --name=pkgj --version=0.2 -s os=Windows")

--- a/conans/test/integration/lockfile/test_ci_revisions.py
+++ b/conans/test/integration/lockfile/test_ci_revisions.py
@@ -192,7 +192,7 @@ def test_single_config_centralized_change_dep(client_setup):
             "pkgb/myfile.txt": "ByeB World!!"})
 
     # Test that pkgb/0.1 new revision works
-    c.run("create pkgb --name=pkgb --version=0.1 -s os=Windows "
+    c.run("create pkgb --name=pkgb --version=0.1 -s os=Windows --lockfile-no-strict "
           "--lockfile=app1.lock --lockfile-out=app1_b_changed.lock")
     assert "pkgb/0.1: DEP FILE pkgj: HelloJ" in c.out
     # Build new package alternative J, it won't be included, already locked in this create

--- a/conans/test/integration/lockfile/test_ci_revisions.py
+++ b/conans/test/integration/lockfile/test_ci_revisions.py
@@ -192,7 +192,7 @@ def test_single_config_centralized_change_dep(client_setup):
             "pkgb/myfile.txt": "ByeB World!!"})
 
     # Test that pkgb/0.1 new revision works
-    c.run("create pkgb --name=pkgb --version=0.1 -s os=Windows --lockfile-no-strict "
+    c.run("create pkgb --name=pkgb --version=0.1 -s os=Windows --lockfile-partial "
           "--lockfile=app1.lock --lockfile-out=app1_b_changed.lock")
     assert "pkgb/0.1: DEP FILE pkgj: HelloJ" in c.out
     # Build new package alternative J, it won't be included, already locked in this create

--- a/conans/test/integration/lockfile/test_ci_revisions.py
+++ b/conans/test/integration/lockfile/test_ci_revisions.py
@@ -116,7 +116,7 @@ def test_single_config_centralized(client_setup):
 
     # All good! We can get rid of the now unused pkgb/0.1 version in the lockfile
     c.run("lock create --requires=app1/0.1@ --lockfile=app1_b_integrated.lock "
-          "--lockfile-out=app1_clean.lock -s os=Windows --clean")
+          "--lockfile-out=app1_clean.lock -s os=Windows --lockfile-clean")
     app1_clean = c.load("app1_clean.lock")
     assert "pkgb/0.1#d03e920d532beeeb198cd886095bcca1" not in app1_clean
     assert "pkgb/0.1#bb12977c3353d7633b34d55a926fe58c" in app1_clean
@@ -167,7 +167,7 @@ def test_single_config_centralized_out_range(client_setup):
 
     # All good! We can get rid of the now unused pkgb/1.0 version in the lockfile
     c.run("lock create --requires=app1/0.1@ --lockfile=app1_b_integrated.lock "
-          "--lockfile-out=app1_clean.lock -s os=Windows --clean")
+          "--lockfile-out=app1_clean.lock -s os=Windows --lockfile-clean")
     app1_clean = c.load("app1_clean.lock")
     assert "pkgb/0.1#d03e920d532beeeb198cd886095bcca1" in app1_clean
     assert "pkgb/0.1#504bc7152c72b49c99a6f16733fb2ff6" not in app1_clean
@@ -212,7 +212,7 @@ def test_single_config_centralized_change_dep(client_setup):
 
     # All good! We can get rid of the now unused pkgb/1.0 version in the lockfile
     c.run("lock create --requires=app1/0.1@ --lockfile=app1_b_integrated.lock "
-          "--lockfile-out=app1_clean.lock -s os=Windows --clean")
+          "--lockfile-out=app1_clean.lock -s os=Windows --lockfile-clean")
     app1_clean = c.load("app1_clean.lock")
     assert "pkgj/0.1" in app1_clean
     assert "pkgb/0.1" in app1_clean
@@ -276,9 +276,9 @@ def test_multi_config_centralized(client_setup):
 
     # All good! We can get rid of the now unused pkgb/0.1 version in the lockfile
     c.run("lock create --requires=app1/0.1@ --lockfile=app1_win.lock "
-          "--lockfile-out=app1_win.lock -s os=Windows --clean")
+          "--lockfile-out=app1_win.lock -s os=Windows --lockfile-clean")
     c.run("lock create --requires=app1/0.1@ --lockfile=app1_nix.lock "
-          "--lockfile-out=app1_nix.lock -s os=Linux --clean")
+          "--lockfile-out=app1_nix.lock -s os=Linux --lockfile-clean")
 
     # Finally, merge the 2 clean lockfiles, for keeping just 1 for next iteration
     c.run("lock merge --lockfile=app1_win.lock --lockfile=app1_nix.lock "

--- a/conans/test/integration/lockfile/test_lock_packages.py
+++ b/conans/test/integration/lockfile/test_lock_packages.py
@@ -1,3 +1,5 @@
+import os
+
 import pytest
 
 from conans.test.assets.genconanfile import GenConanfile
@@ -19,7 +21,7 @@ def test_lock_packages(requires):
         client.run("create pkg --name=pkg --version=0.1")
     prev = client.created_package_revision("pkg/0.1")
 
-    client.run("lock create consumer/conanfile.txt  --lockfile-out=conan.lock --lockfile-packages")
+    client.run("lock create consumer/conanfile.txt --lockfile-packages")
     assert "pkg/0.1#" in client.out
     lock = client.load("conan.lock")
     assert NO_SETTINGS_PACKAGE_ID in lock
@@ -29,10 +31,11 @@ def test_lock_packages(requires):
     prev2 = client.created_package_revision("pkg/0.1")
     assert prev2 != prev
 
-    client.run("install consumer/conanfile.txt --lockfile=conan.lock")
+    client.run("install consumer/conanfile.txt")
     assert prev in client.out
     assert prev2 not in client.out
 
+    os.remove(os.path.join(client.current_folder, "conan.lock"))
     client.run("install consumer/conanfile.txt")
     assert prev2 in client.out
     assert prev not in client.out

--- a/conans/test/integration/lockfile/test_lock_packages.py
+++ b/conans/test/integration/lockfile/test_lock_packages.py
@@ -23,7 +23,7 @@ def test_lock_packages(requires):
 
     client.run("lock create consumer/conanfile.txt --lockfile-packages")
     assert "pkg/0.1#" in client.out
-    lock = client.load("conan.lock")
+    lock = client.load("consumer/conan.lock")
     assert NO_SETTINGS_PACKAGE_ID in lock
 
     with environment_update({"MYVAR": "MYVALUE2"}):
@@ -35,7 +35,7 @@ def test_lock_packages(requires):
     assert prev in client.out
     assert prev2 not in client.out
 
-    os.remove(os.path.join(client.current_folder, "conan.lock"))
+    os.remove(os.path.join(client.current_folder, "consumer/conan.lock"))
     client.run("install consumer/conanfile.txt")
     assert prev2 in client.out
     assert prev not in client.out

--- a/conans/test/integration/lockfile/test_lock_pyrequires.py
+++ b/conans/test/integration/lockfile/test_lock_pyrequires.py
@@ -1,3 +1,4 @@
+import os
 import textwrap
 
 from conans.test.assets.genconanfile import GenConanfile
@@ -23,14 +24,15 @@ def test_transitive_py_requires():
 
     client.run("export dep --name=dep --version=0.1 --user=user --channel=channel")
     client.run("export pkg --name=pkg --version=0.1 --user=user --channel=channel")
-    client.run("lock create consumer/conanfile.py --lockfile-out=conan.lock")
+    client.run("lock create consumer/conanfile.py")
 
     client.run("export dep --name=dep --version=0.2 --user=user --channel=channel")
 
-    client.run("install consumer/conanfile.py --lockfile=conan.lock")
+    client.run("install consumer/conanfile.py")
     assert "dep/0.1@user/channel" in client.out
     assert "dep/0.2" not in client.out
 
+    os.remove(os.path.join(client.current_folder, "conan.lock"))
     client.run("install consumer/conanfile.py")
     assert "dep/0.2@user/channel" in client.out
     assert "dep/0.1" not in client.out
@@ -64,14 +66,14 @@ def test_transitive_matching_ranges():
     client.run("export tool2 --name=tool --version=0.2")
     client.run("create pkga --name=pkga --version=0.1")
     client.run("create pkgb --name=pkgb --version=0.1")
-    client.run("lock create app/conanfile.py --lockfile-out=conan.lock")
+    client.run("lock create app/conanfile.py --lockfile-out=app.lock")
 
     client.run("export dep --name=dep --version=0.2")
     client.run("export tool2 --name=tool --version=0.3")
     client.run("create pkga --name=pkga --version=0.2")
     client.run("create pkgb --name=pkgb --version=0.2")
 
-    client.run("install app/conanfile.py --lockfile=conan.lock")
+    client.run("install app/conanfile.py --lockfile=app.lock")
     assert "pkga/0.1: tool: tool/0.1!!" in client.out
     assert "pkga/0.1: dep: dep/0.1!!" in client.out
     assert "pkgb/0.1: tool: tool/0.2!!" in client.out

--- a/conans/test/integration/lockfile/test_lock_pyrequires.py
+++ b/conans/test/integration/lockfile/test_lock_pyrequires.py
@@ -32,7 +32,7 @@ def test_transitive_py_requires():
     assert "dep/0.1@user/channel" in client.out
     assert "dep/0.2" not in client.out
 
-    os.remove(os.path.join(client.current_folder, "conan.lock"))
+    os.remove(os.path.join(client.current_folder, "consumer/conan.lock"))
     client.run("install consumer/conanfile.py")
     assert "dep/0.2@user/channel" in client.out
     assert "dep/0.1" not in client.out

--- a/conans/test/integration/lockfile/test_lock_pyrequires_revisions.py
+++ b/conans/test/integration/lockfile/test_lock_pyrequires_revisions.py
@@ -1,3 +1,4 @@
+import os
 import textwrap
 
 from conans.test.assets.genconanfile import GenConanfile
@@ -31,14 +32,15 @@ def test_transitive_py_requires_revisions():
 
     client.run("export dep --name=dep --version=0.1 --user=user --channel=channel")
     client.run("export pkg --name=pkg --version=0.1 --user=user --channel=channel")
-    client.run("lock create consumer/conanfile.py --lockfile-out=conan.lock")
+    client.run("lock create consumer/conanfile.py")
 
     client.save({"dep/conanfile.py": python_req.format("123")})
     client.run("export dep --name=dep --version=0.1 --user=user --channel=channel")
 
-    client.run("install consumer/conanfile.py --lockfile=conan.lock")
+    client.run("install consumer/conanfile.py")
     assert "conanfile.py: VAR=42!!!" in client.out
 
+    os.remove(os.path.join(client.current_folder, "conan.lock"))
     client.run("install consumer/conanfile.py")
     assert "conanfile.py: VAR=123!!!" in client.out
 
@@ -78,13 +80,13 @@ def test_transitive_matching_revisions():
     client.run("export toolb --name=toolb --version=0.1")
     client.run("create pkga --name=pkga --version=0.1")
     client.run("create pkgb --name=pkgb --version=0.1")
-    client.run("lock create app/conanfile.py --lockfile-out=conan.lock")
+    client.run("lock create app/conanfile.py --lockfile-out=app.lock")
 
     client.save({"dep/conanfile.py": dep.format(123)})
     client.run("export dep --name=dep --version=0.1")
     client.run("export dep --name=dep --version=0.2")
 
-    client.run("install app/conanfile.py --lockfile=conan.lock")
+    client.run("install app/conanfile.py --lockfile=app.lock")
     assert "pkga/0.1: VAR=42!!!" in client.out
     assert "pkgb/0.1: VAR=42!!!" in client.out
     assert "VAR=123" not in client.out

--- a/conans/test/integration/lockfile/test_lock_pyrequires_revisions.py
+++ b/conans/test/integration/lockfile/test_lock_pyrequires_revisions.py
@@ -40,7 +40,7 @@ def test_transitive_py_requires_revisions():
     client.run("install consumer/conanfile.py")
     assert "conanfile.py: VAR=42!!!" in client.out
 
-    os.remove(os.path.join(client.current_folder, "conan.lock"))
+    os.remove(os.path.join(client.current_folder, "consumer/conan.lock"))
     client.run("install consumer/conanfile.py")
     assert "conanfile.py: VAR=123!!!" in client.out
 

--- a/conans/test/integration/lockfile/test_lock_requires.py
+++ b/conans/test/integration/lockfile/test_lock_requires.py
@@ -1,3 +1,4 @@
+import os
 import textwrap
 
 import pytest
@@ -15,14 +16,16 @@ def test_conanfile_txt_deps_ranges(requires):
     client.save({"pkg/conanfile.py": GenConanfile(),
                  "consumer/conanfile.txt": f"[{requires}]\npkg/[>0.0]@user/testing"})
     client.run("create pkg --name=pkg --version=0.1 --user=user --channel=testing")
-    client.run("lock create consumer/conanfile.txt  --lockfile-out=conan.lock")
+    client.run("lock create consumer/conanfile.txt")
     assert "pkg/0.1@user/testing#" in client.out
 
     client.run("create pkg --name=pkg --version=0.2 --user=user --channel=testing")
 
-    client.run("install consumer/conanfile.txt --lockfile=conan.lock")
+    client.run("install consumer/conanfile.txt")
     assert "pkg/0.1@user/testing#" in client.out
     assert "pkg/0.2" not in client.out
+
+    os.remove(os.path.join(client.current_folder, "conan.lock"))
     client.run("install consumer/conanfile.txt")
     assert "pkg/0.2@user/testing#" in client.out
     assert "pkg/0.1" not in client.out
@@ -40,15 +43,17 @@ def test_conanfile_txt_deps_ranges_transitive(requires):
     client.run("create dep --name=dep --version=0.1 --user=user --channel=testing")
     client.run("create pkg --name=pkg --version=0.1 --user=user --channel=testing")
 
-    client.run("lock create consumer/conanfile.txt  --lockfile-out=conan.lock")
+    client.run("lock create consumer/conanfile.txt")
     assert "dep/0.1@user/testing#" in client.out
     assert "pkg/0.1@user/testing#" in client.out
 
     client.run("create dep --name=dep --version=0.2 --user=user --channel=testing")
 
-    client.run("install consumer/conanfile.txt --lockfile=conan.lock")
+    client.run("install consumer/conanfile.txt")
     assert "dep/0.1@user/testing#" in client.out
     assert "dep/0.2" not in client.out
+
+    os.remove(os.path.join(client.current_folder, "conan.lock"))
     client.run("install consumer/conanfile.txt", assert_error=True)
     assert "dep/0.2@user/testing#" in client.out
     assert "dep/0.1" not in client.out
@@ -63,7 +68,7 @@ def test_conanfile_txt_strict(requires):
     client.save({"pkg/conanfile.py": GenConanfile(),
                  "consumer/conanfile.txt": f"[{requires}]\npkg/[>0.0]@user/testing"})
     client.run("create pkg --name=pkg --version=0.1 --user=user --channel=testing")
-    client.run("lock create consumer/conanfile.txt  --lockfile-out=conan.lock")
+    client.run("lock create consumer/conanfile.txt")
     assert "pkg/0.1@user/testing#" in client.out
 
     client.run("create pkg --name=pkg --version=0.2 --user=user --channel=testing")
@@ -72,23 +77,21 @@ def test_conanfile_txt_strict(requires):
     # Not strict mode works
     client.save({"consumer/conanfile.txt": f"[{requires}]\npkg/[>1.0]@user/testing"})
 
-    client.run("install consumer/conanfile.txt --lockfile=conan.lock --lockfile-strict",
-               assert_error=True)
+    client.run("install consumer/conanfile.txt", assert_error=True)
     assert "Requirement 'pkg/[>1.0]@user/testing' not in lockfile" in client.out
 
-    client.run("install consumer/conanfile.txt --lockfile=conan.lock")
+    client.run("install consumer/conanfile.txt --lockfile-no-strict")
     assert "pkg/1.2@user/testing" in client.out
     assert "pkg/1.2" not in client.load("conan.lock")
 
     # test it is possible to capture new changes too, when not strict, mutating the lockfile
-    client.run("install consumer/conanfile.txt --lockfile=conan.lock --lockfile-out=conan.lock")
+    client.run("install consumer/conanfile.txt --lockfile-no-strict --lockfile-out=conan.lock")
     assert "pkg/1.2@user/testing" in client.out
     lock = client.load("conan.lock")
     assert "pkg/1.2" in lock
     assert "pkg/0.1" in lock  # both versions are locked now
     # clean legacy versions
-    client.run("lock create consumer/conanfile.txt "
-               "--lockfile=conan.lock --lockfile-out=conan.lock --clean")
+    client.run("lock create consumer/conanfile.txt --lockfile-out=conan.lock --clean")
     lock = client.load("conan.lock")
     assert "pkg/1.2" in lock
     assert "pkg/0.1" not in lock
@@ -121,12 +124,12 @@ def test_conditional_os(requires):
     client.run("create pkg --name=pkg --version=0.1 -s os=Windows")
     client.run("create pkg --name=pkg --version=0.1 -s os=Linux")
 
-    client.run("lock create consumer/conanfile.txt  --lockfile-out=conan.lock -s os=Windows"
+    client.run("lock create consumer/conanfile.txt  --lockfile-out=consumer.lock -s os=Windows"
                " -s:b os=Windows")
     assert "win/0.1#" in client.out
     assert "pkg/0.1#" in client.out
-    client.run("lock create consumer/conanfile.txt  --lockfile=conan.lock "
-               "--lockfile-out=conan.lock -s os=Linux -s:b os=Linux")
+    client.run("lock create consumer/conanfile.txt  --lockfile=consumer.lock "
+               "--lockfile-out=consumer.lock -s os=Linux -s:b os=Linux")
     assert "nix/0.1#" in client.out
     assert "pkg/0.1#" in client.out
 
@@ -136,7 +139,7 @@ def test_conditional_os(requires):
     client.run("create pkg --name=pkg --version=0.1 -s os=Windows")
     client.run("create pkg --name=pkg --version=0.1 -s os=Linux")
 
-    client.run("install consumer --lockfile=conan.lock -s os=Windows -s:b os=Windows")
+    client.run("install consumer --lockfile=consumer.lock -s os=Windows -s:b os=Windows")
     assert "win/0.1#" in client.out
     assert "win/0.2" not in client.out
     client.run("install consumer -s os=Windows -s:b os=Windows")
@@ -144,7 +147,7 @@ def test_conditional_os(requires):
     assert "win/0.1" not in client.out
     assert "nix/0.1" not in client.out
 
-    client.run("install consumer --lockfile=conan.lock -s os=Linux -s:b os=Linux")
+    client.run("install consumer --lockfile=consumer.lock -s os=Linux -s:b os=Linux")
     assert "nix/0.1#" in client.out
     assert "nix/0.2" not in client.out
     client.run("install consumer -s os=Linux -s:b os=Linux")
@@ -315,14 +318,14 @@ def test_partial_lockfile():
     c.run("create pkgb --lockfile=b.lock")
     assert "pkga/0.1" in c.out
     assert "pkga/0.2" not in c.out
-    c.run("install pkgc --lockfile=b.lock")
+    c.run("install pkgc --lockfile=b.lock --lockfile-no-strict")
     assert "pkga/0.1" in c.out
     assert "pkga/0.2" not in c.out
-    c.run("create pkgc  --lockfile=b.lock")
+    c.run("create pkgc  --lockfile=b.lock --lockfile-no-strict")
     assert "pkga/0.1" in c.out
     assert "pkga/0.2" not in c.out
-    c.run("create app --lockfile=b.lock")
+    c.run("create app --lockfile=b.lock --lockfile-no-strict")
     assert "pkga/0.1" in c.out
     assert "pkga/0.2" not in c.out
-    c.run("create app --lockfile=b.lock --lockfile-strict", assert_error=True)
+    c.run("create app --lockfile=b.lock", assert_error=True)
     assert "ERROR: Requirement 'pkgc/[*]' not in lockfile" in c.out

--- a/conans/test/integration/lockfile/test_lock_requires.py
+++ b/conans/test/integration/lockfile/test_lock_requires.py
@@ -25,7 +25,7 @@ def test_conanfile_txt_deps_ranges(requires):
     assert "pkg/0.1@user/testing#" in client.out
     assert "pkg/0.2" not in client.out
 
-    os.remove(os.path.join(client.current_folder, "conan.lock"))
+    os.remove(os.path.join(client.current_folder, "consumer/conan.lock"))
     client.run("install consumer/conanfile.txt")
     assert "pkg/0.2@user/testing#" in client.out
     assert "pkg/0.1" not in client.out
@@ -65,7 +65,7 @@ def test_conanfile_txt_deps_ranges_transitive(requires):
     assert "dep/0.1@user/testing#" in client.out
     assert "dep/0.2" not in client.out
 
-    os.remove(os.path.join(client.current_folder, "conan.lock"))
+    os.remove(os.path.join(client.current_folder, "consumer/conan.lock"))
     client.run("install consumer/conanfile.txt", assert_error=True)
     assert "dep/0.2@user/testing#" in client.out
     assert "dep/0.1" not in client.out
@@ -92,12 +92,12 @@ def test_conanfile_txt_strict(requires):
     client.run("install consumer/conanfile.txt", assert_error=True)
     assert "Requirement 'pkg/[>1.0]@user/testing' not in lockfile" in client.out
 
-    client.run("install consumer/conanfile.txt --lockfile-no-strict")
+    client.run("install consumer/conanfile.txt --lockfile-partial")
     assert "pkg/1.2@user/testing" in client.out
-    assert "pkg/1.2" not in client.load("conan.lock")
+    assert "pkg/1.2" not in client.load("consumer/conan.lock")
 
     # test it is possible to capture new changes too, when not strict, mutating the lockfile
-    client.run("install consumer/conanfile.txt --lockfile-no-strict --lockfile-out=conan.lock")
+    client.run("install consumer/conanfile.txt --lockfile-partial --lockfile-out=conan.lock")
     assert "pkg/1.2@user/testing" in client.out
     lock = client.load("conan.lock")
     assert "pkg/1.2" in lock
@@ -330,13 +330,13 @@ def test_partial_lockfile():
     c.run("create pkgb --lockfile=b.lock")
     assert "pkga/0.1" in c.out
     assert "pkga/0.2" not in c.out
-    c.run("install pkgc --lockfile=b.lock --lockfile-no-strict")
+    c.run("install pkgc --lockfile=b.lock --lockfile-partial")
     assert "pkga/0.1" in c.out
     assert "pkga/0.2" not in c.out
-    c.run("create pkgc  --lockfile=b.lock --lockfile-no-strict")
+    c.run("create pkgc  --lockfile=b.lock --lockfile-partial")
     assert "pkga/0.1" in c.out
     assert "pkga/0.2" not in c.out
-    c.run("create app --lockfile=b.lock --lockfile-no-strict")
+    c.run("create app --lockfile=b.lock --lockfile-partial")
     assert "pkga/0.1" in c.out
     assert "pkga/0.2" not in c.out
     c.run("create app --lockfile=b.lock", assert_error=True)

--- a/conans/test/integration/lockfile/test_lock_requires_revisions.py
+++ b/conans/test/integration/lockfile/test_lock_requires_revisions.py
@@ -17,14 +17,14 @@ def test_conanfile_txt_deps_revisions(requires):
                  "consumer/conanfile.txt": f"[{requires}]\npkg/0.1@user/testing"})
     client.run("create pkg --name=pkg --version=0.1 --user=user --channel=testing")
     assert "REV1!!!" in client.out
-    client.run("lock create consumer/conanfile.txt  --lockfile-out=conan.lock")
+    client.run("lock create consumer/conanfile.txt  --lockfile-out=consumer.lock")
     assert "pkg/0.1@user/testing#" in client.out
 
     client.save({"pkg/conanfile.py": GenConanfile().with_package_id("self.output.info('REV2!!!!')")})
     client.run("create pkg --name=pkg --version=0.1 --user=user --channel=testing")
     assert "REV2!!!" in client.out
 
-    client.run("install consumer/conanfile.txt --lockfile=conan.lock")
+    client.run("install consumer/conanfile.txt --lockfile=consumer.lock")
     assert "REV1!!!" in client.out
     assert "REV2!!!" not in client.out
     client.run("install consumer/conanfile.txt")
@@ -46,7 +46,7 @@ def test_conanfile_txt_deps_revisions_transitive(requires, req_version):
     assert "REV1!!!" in client.out
     client.run("create pkg --name=pkg --version=0.1 --user=user --channel=testing")
 
-    client.run("lock create consumer/conanfile.txt  --lockfile-out=conan.lock")
+    client.run("lock create consumer/conanfile.txt  --lockfile-out=consumer.lock")
     assert "dep/0.1@user/testing#" in client.out
     assert "pkg/0.1@user/testing#" in client.out
 
@@ -54,7 +54,7 @@ def test_conanfile_txt_deps_revisions_transitive(requires, req_version):
     client.run("create dep --name=dep --version=0.1 --user=user --channel=testing")
     assert "REV2!!!" in client.out
 
-    client.run("install consumer/conanfile.txt --lockfile=conan.lock")
+    client.run("install consumer/conanfile.txt --lockfile=consumer.lock")
     assert "REV1!!!" in client.out
     assert "REV2!!!" not in client.out
     client.run("list recipe-revisions dep/0.1@user/testing")
@@ -72,7 +72,7 @@ def test_conanfile_txt_strict_revisions(requires):
     client.save({"pkg/conanfile.py": GenConanfile().with_package_id("self.output.info('REV1!!!!')"),
                  "consumer/conanfile.txt": f"[{requires}]\npkg/0.1@user/testing"})
     client.run("create pkg --name=pkg --version=0.1 --user=user --channel=testing")
-    client.run("lock create consumer/conanfile.txt  --lockfile-out=conan.lock")
+    client.run("lock create consumer/conanfile.txt")
     assert "pkg/0.1@user/testing#" in client.out
 
     client.save({"pkg/conanfile.py": GenConanfile().with_package_id("self.output.info('REV2!!!!')")})
@@ -82,8 +82,7 @@ def test_conanfile_txt_strict_revisions(requires):
     # Not strict mode works
     client.save({"consumer/conanfile.txt": f"[{requires}]\npkg/0.1@user/testing#{rrev}"})
 
-    client.run("install consumer/conanfile.txt --lockfile=conan.lock --lockfile-strict",
-               assert_error=True)
+    client.run("install consumer/conanfile.txt", assert_error=True)
     assert f"Requirement 'pkg/0.1@user/testing#{rrev}' not in lockfile" in client.out
 
 
@@ -115,12 +114,12 @@ def test_conditional_os(requires):
     client.run("create pkg --name=pkg --version=0.1 -s os=Windows")
     client.run("create pkg --name=pkg --version=0.1 -s os=Linux")
 
-    client.run("lock create consumer/conanfile.txt  --lockfile-out=conan.lock -s os=Windows"
+    client.run("lock create consumer/conanfile.txt  --lockfile-out=consumer.lock -s os=Windows"
                " -s:b os=Windows")
     assert "win/0.1#" in client.out
     assert "pkg/0.1#" in client.out
-    client.run("lock create consumer/conanfile.txt  --lockfile=conan.lock "
-               "--lockfile-out=conan.lock -s os=Linux -s:b os=Linux")
+    client.run("lock create consumer/conanfile.txt  --lockfile=consumer.lock "
+               "--lockfile-out=consumer.lock -s os=Linux -s:b os=Linux")
     assert "nix/0.1#" in client.out
     assert "pkg/0.1#" in client.out
 
@@ -131,7 +130,7 @@ def test_conditional_os(requires):
     client.run("create pkg --name=pkg --version=0.1 -s os=Windows")
     client.run("create pkg --name=pkg --version=0.1 -s os=Linux")
 
-    client.run("install consumer --lockfile=conan.lock -s os=Windows -s:b os=Windows")
+    client.run("install consumer --lockfile=consumer.lock -s os=Windows -s:b os=Windows")
     assert "REV1!!!" in client.out
     assert "REV2!!!" not in client.out
     assert "nix" not in client.out
@@ -140,7 +139,7 @@ def test_conditional_os(requires):
     assert "REV1!!!" not in client.out
     assert "nix" not in client.out
 
-    client.run("install consumer --lockfile=conan.lock -s os=Linux -s:b os=Linux")
+    client.run("install consumer --lockfile=consumer.lock -s os=Linux -s:b os=Linux")
     assert "REV1!!!" in client.out
     assert "REV2!!!" not in client.out
     assert "win" not in client.out

--- a/conans/test/integration/lockfile/test_options.py
+++ b/conans/test/integration/lockfile/test_options.py
@@ -31,9 +31,9 @@ def test_options():
                  "variant/conanfile.py": variant})
     client.run("export ffmepg --name=ffmpeg --version=1.0")
     client.run("export variant --name=nano --version=1.0")
-    client.run("lock create --requires=nano/1.0@ --build=* --lockfile-out=conan.lock")
+    client.run("lock create --requires=nano/1.0@ --build=*")
     client.run("graph build-order --requires=nano/1.0@ "
-               "--lockfile=conan.lock --lockfile-out=conan.lock --build=missing "
+               "--lockfile-out=conan.lock --build=missing "
                "--format=json", redirect_stdout="build_order.json")
 
     json_file = client.load("build_order.json")
@@ -42,6 +42,6 @@ def test_options():
     ref = ffmpeg["ref"]
     options = " ".join(f"-o {option}" for option in ffmpeg["packages"][0]["options"])
 
-    cmd = "install --requires={} --build={} {} --lockfile=conan.lock".format(ref, ref, options)
+    cmd = "install --requires={} --build={} {}".format(ref, ref, options)
     client.run(cmd)
     assert "ffmpeg/1.0: Variation nano!!" in client.out

--- a/conans/test/integration/lockfile/test_user_overrides.py
+++ b/conans/test/integration/lockfile/test_user_overrides.py
@@ -20,8 +20,8 @@ def test_user_overrides():
     assert "math/1.2" in c.out
     assert "math/1.0" not in c.out
 
-    c.run("lock add --requires=math/1.0 --requires=unrelated/2.0 --lockfile-out=conan.lock")
-    c.run("graph info game --lockfile=conan.lock --lockfile-out=new.lock")
+    c.run("lock add --requires=math/1.0 --requires=unrelated/2.0")
+    c.run("graph info game --lockfile-out=new.lock --lockfile-no-strict")
     assert "math/1.0" in c.out
     assert "math/1.2" not in c.out
     # The resulting lockfile contains the full revision now
@@ -29,8 +29,8 @@ def test_user_overrides():
     assert "math/1.0#8e1a7a5ce869d8c54ae3d33468fd657" in new_lock
 
     # Repeat for 1.1
-    c.run("lock add --requires=math/1.1 --requires=unrelated/2.0 --lockfile-out=conan.lock")
-    c.run("graph info game --lockfile=conan.lock --lockfile-out=new.lock")
+    c.run("lock add --requires=math/1.1 --requires=unrelated/2.0")
+    c.run("graph info game --lockfile-no-strict --lockfile-out=new.lock")
     assert "math/1.1" in c.out
     assert "math/1.0" not in c.out
     # The resulting lockfile contains the full revision now
@@ -53,8 +53,8 @@ def test_user_build_overrides():
     assert "cmake/1.2" in c.out
     assert "cmake/1.0" not in c.out
 
-    c.run("lock add --build-requires=cmake/1.0 --lockfile-out=conan.lock")
-    c.run("graph info engine --lockfile=conan.lock --lockfile-out=new.lock")
+    c.run("lock add --build-requires=cmake/1.0")
+    c.run("graph info engine --lockfile-out=new.lock --lockfile-no-strict")
     assert "cmake/1.0" in c.out
     assert "cmake/1.2" not in c.out
     # The resulting lockfile contains the full revision now
@@ -63,7 +63,7 @@ def test_user_build_overrides():
 
     # Repeat for 1.1
     c.run("lock add --build-requires=cmake/1.1 --lockfile-out=conan.lock")
-    c.run("graph info engine --lockfile=conan.lock --lockfile-out=new.lock")
+    c.run("graph info engine --lockfile-out=new.lock --lockfile-no-strict")
     assert "cmake/1.1" in c.out
     assert "cmake/1.0" not in c.out
     # The resulting lockfile contains the full revision now

--- a/conans/test/integration/lockfile/test_user_overrides.py
+++ b/conans/test/integration/lockfile/test_user_overrides.py
@@ -21,7 +21,7 @@ def test_user_overrides():
     assert "math/1.0" not in c.out
 
     c.run("lock add --requires=math/1.0 --requires=unrelated/2.0")
-    c.run("graph info game --lockfile-out=new.lock --lockfile-no-strict")
+    c.run("graph info game --lockfile=conan.lock --lockfile-out=new.lock --lockfile-partial")
     assert "math/1.0" in c.out
     assert "math/1.2" not in c.out
     # The resulting lockfile contains the full revision now
@@ -30,7 +30,7 @@ def test_user_overrides():
 
     # Repeat for 1.1
     c.run("lock add --requires=math/1.1 --requires=unrelated/2.0")
-    c.run("graph info game --lockfile-no-strict --lockfile-out=new.lock")
+    c.run("graph info game --lockfile=conan.lock --lockfile-partial --lockfile-out=new.lock")
     assert "math/1.1" in c.out
     assert "math/1.0" not in c.out
     # The resulting lockfile contains the full revision now
@@ -54,7 +54,7 @@ def test_user_build_overrides():
     assert "cmake/1.0" not in c.out
 
     c.run("lock add --build-requires=cmake/1.0")
-    c.run("graph info engine --lockfile-out=new.lock --lockfile-no-strict")
+    c.run("graph info engine --lockfile=conan.lock --lockfile-out=new.lock --lockfile-partial")
     assert "cmake/1.0" in c.out
     assert "cmake/1.2" not in c.out
     # The resulting lockfile contains the full revision now
@@ -63,7 +63,7 @@ def test_user_build_overrides():
 
     # Repeat for 1.1
     c.run("lock add --build-requires=cmake/1.1 --lockfile-out=conan.lock")
-    c.run("graph info engine --lockfile-out=new.lock --lockfile-no-strict")
+    c.run("graph info engine --lockfile=conan.lock --lockfile-out=new.lock --lockfile-partial")
     assert "cmake/1.1" in c.out
     assert "cmake/1.0" not in c.out
     # The resulting lockfile contains the full revision now


### PR DESCRIPTION
Review from Tribe proposal https://github.com/conan-io/tribe/pull/34:

- Defined a default "conan.lock" filename
- Whenever the default "conan.lock" file is found in the current folder, it will be used as ``--lockfile=conan.lock``, automatically by commands that implement this argument
- ``conan lock create`` will also default to output "conan.lock", even without ``--lockfile-out`` argument
- Commands that implement a ``--lockfile-out`` will allow to save a lockfile as a result, even if a lockfile was not provided as input
- The logic for strict vs non-strict has changed its default. Now by default, commands are "strict", and the arg ``--lockfile-no-strict`` (arg name not great, we can try to think a better one) will allow non-locked ``requires`` to not fail
- The ``--clean`` argument that was existing only for ``conan lock create`` has been renamed to ``--lockfile-clean``, because it now can be used by the other commands that save a ``--lockfile-out``.


Second round of review:
- The ``conan.lock`` is assumed by default besides the ``conanfile``, not in the ``cwd``
- Renamed ``--lockfile-no-strict`` => ``--lockfile-partial``, it seems a bit more aligned with the actual behavior
