### PR TITLE
define [conf] for changing default toolset arch

### DIFF
--- a/conans/test/integration/toolchains/microsoft/vcvars_test.py
+++ b/conans/test/integration/toolchains/microsoft/vcvars_test.py
@@ -69,4 +69,25 @@ def test_vcvars_2015_error():
                '-s compiler.cppstd=14 -s compiler.runtime=static')
 
     vcvars = client.load("conanvcvars.bat")
+    assert 'vcvarsall.bat"  amd64' in vcvars
+    assert "-vcvars_ver" not in vcvars
+
+
+@pytest.mark.skipif(platform.system() != "Windows", reason="Requires Windows")
+def test_vcvars_platform_x86():
+    # https://github.com/conan-io/conan/issues/11144
+    client = TestClient(path_with_spaces=False)
+
+    conanfile = textwrap.dedent("""
+        from conans import ConanFile
+        class TestConan(ConanFile):
+            generators = "VCVars"
+            settings = "os", "compiler", "arch", "build_type"
+    """)
+    client.save({"conanfile.py": conanfile})
+    client.run('install . -s os=Windows -s compiler="msvc" -s compiler.version=190 '
+               '-s compiler.cppstd=14 -s compiler.runtime=static -s:b arch=x86')
+
+    vcvars = client.load("conanvcvars.bat")
+    assert 'vcvarsall.bat"  x86_amd64' in vcvars
     assert "-vcvars_ver" not in vcvars

--- a/conans/test/unittests/tools/cmake/test_cmaketoolchain.py
+++ b/conans/test/unittests/tools/cmake/test_cmaketoolchain.py
@@ -178,7 +178,16 @@ def conanfile_msvc():
 
 def test_toolset(conanfile_msvc):
     toolchain = CMakeToolchain(conanfile_msvc)
-    assert 'CMAKE_GENERATOR_TOOLSET "v143"' in toolchain.content
+    assert 'set(CMAKE_GENERATOR_TOOLSET "v143" CACHE STRING "" FORCE)' in toolchain.content
+    assert 'Visual Studio 17 2022' in toolchain.generator
+    assert 'CMAKE_CXX_STANDARD 20' in toolchain.content
+
+
+def test_toolset_x64(conanfile_msvc):
+    # https://github.com/conan-io/conan/issues/11144
+    conanfile_msvc.conf.define("tools.cmake.cmaketoolchain:toolset_arch", "x64")
+    toolchain = CMakeToolchain(conanfile_msvc)
+    assert 'set(CMAKE_GENERATOR_TOOLSET "v143,host=x64" CACHE STRING "" FORCE)' in toolchain.content
     assert 'Visual Studio 17 2022' in toolchain.generator
     assert 'CMAKE_CXX_STANDARD 20' in toolchain.content
 


### PR DESCRIPTION
Changelog: Feature: Define new ``tools.cmake.cmaketoolchain:toolset_arch`` to define VS toolset x64 or x86 architecture
Docs: https://github.com/conan-io/docs/pull/2556

Close https://github.com/conan-io/conan/issues/11144