### PR TITLE
Fix scm commit calculation with revision_mode=scm

### DIFF
--- a/conans/client/cmd/export.py
+++ b/conans/client/cmd/export.py
@@ -98,7 +98,7 @@ def calc_revision(scoped_output, path, manifest, revision_mode):
     else:
         try:
             with chdir(path):
-                rev_detected = check_output_runner('git rev-list HEAD -n 1').strip()
+                rev_detected = check_output_runner('git rev-list HEAD -n 1 --full-history').strip()
         except Exception as exc:
             error_msg = "Cannot detect revision using '{}' mode from repository at " \
                         "'{}'".format(revision_mode, path)


### PR DESCRIPTION
[Here](https://github.com/conan-io/conan/pull/11015/files) we fixed the `Git` tool to calculate the current commit but the command that calculates the commit when exporting a recipe with `revision_mode="scm"` was still buggy.