### PR TITLE
[dev2][package_id] Part 1: Unified `Settings.sha` and `Settings.dumps()` methods

### DIFF
--- a/conans/model/info.py
+++ b/conans/model/info.py
@@ -424,8 +424,11 @@ class ConanInfo(object):
         """ The package_id of a conans is the sha1 of its specific requirements,
         options and settings
         """
-        result = [self.settings.sha,
-                  "[options]"]
+        result = ["[settings]"]
+        settings_dumps = self.settings.dumps()
+        if settings_dumps:
+            result.append(settings_dumps)
+        result.append("[options]")
         options_dumps = self.options.dumps()
         if options_dumps:
             result.append(options_dumps)

--- a/conans/model/settings.py
+++ b/conans/model/settings.py
@@ -281,8 +281,15 @@ class Settings(object):
 
     @property
     def sha(self):
-        # FIXME: This should fail if trying to hash a not defined value (None not in range)
-        result = ["[settings]"]
+        # FIXME: Remove this function when refactored ConanInfo.package_id() method
+        return self.dumps()
+
+    def dumps(self):
+        """ produces a text string with lines containing a flattened version:
+        compiler.arch = XX
+        compiler.arch.speed = YY
+        """
+        result = []
         for (name, value) in self.values_list:
             # It is important to discard None values, so migrations in settings can be done
             # without breaking all existing packages SHAs, by adding a first "None" option
@@ -291,10 +298,3 @@ class Settings(object):
                 result.append("%s=%s" % (name, value))
         return '\n'.join(result)
 
-    def dumps(self):
-        """ produces a text string with lines containine a flattened version:
-        compiler.arch = XX
-        compiler.arch.speed = YY
-        """
-        return "\n".join(["%s=%s" % (field, value)
-                          for (field, value) in self.values_list])

--- a/conans/test/unittests/model/settings_test.py
+++ b/conans/test/unittests/model/settings_test.py
@@ -18,7 +18,7 @@ class SettingsLoadsTest(unittest.TestCase):
         self.assertEqual(settings.sha, Settings.loads("").sha)
         settings.validate()
         self.assertTrue(settings.os == "None")
-        self.assertEqual("os=None", settings.dumps())
+        self.assertNotIn("os=None", settings.dumps())
         settings.os = "Windows"
         self.assertTrue(settings.os == "Windows")
         self.assertEqual("os=Windows", settings.dumps())
@@ -31,7 +31,7 @@ class SettingsLoadsTest(unittest.TestCase):
         settings.os = "None"
         settings.validate()
         self.assertTrue(settings.os == "None")
-        self.assertEqual("os=None", settings.dumps())
+        self.assertNotIn("os=None", settings.dumps())
         settings.os = "Windows"
         self.assertTrue(settings.os == "Windows")
         self.assertEqual("os=Windows", settings.dumps())
@@ -43,7 +43,7 @@ class SettingsLoadsTest(unittest.TestCase):
         settings.os = "None"
         settings.validate()
         self.assertTrue(settings.os == "None")
-        self.assertEqual("os=None", settings.dumps())
+        self.assertNotIn("os=None", settings.dumps())
         settings.os = "Windows"
         self.assertTrue(settings.os == "Windows")
         self.assertEqual("os=Windows", settings.dumps())
@@ -83,7 +83,7 @@ class SettingsLoadsTest(unittest.TestCase):
         self.assertEqual(settings.sha, Settings.loads("").sha)
         settings.validate()
         self.assertTrue(settings.os == "None")
-        self.assertEqual("os=None", settings.dumps())
+        self.assertNotIn("os=None", settings.dumps())
         settings.os = "Windows"
         self.assertTrue(settings.os.subsystem == None)
         self.assertEqual("os=Windows", settings.dumps())


### PR DESCRIPTION
Changelog: Feature: `Settings.sha` is returning the same as `Settings.dumps()` method.
Closes: https://github.com/conan-io/conan/issues/11162