### PR TITLE
[dev2][package_id] Part 2: `ConanInfo.package_id()` uses `ConanInfo.dumps()` result

### DIFF
--- a/conans/model/conf.py
+++ b/conans/model/conf.py
@@ -209,11 +209,6 @@ class Conf:
         for k, v in self._values.items():
             yield k, v.value
 
-    @property
-    def sha(self):
-        # FIXME: Keeping backward compatibility
-        return self.dumps()
-
     @staticmethod
     def _get_boolean_value(value):
         if type(value) is bool:

--- a/conans/model/info.py
+++ b/conans/model/info.py
@@ -402,28 +402,6 @@ class ConanInfo(object):
         return result
 
     def dumps(self):
-        def indent(text):
-            if not text:
-                return ""
-            return '\n'.join("    " + line for line in text.splitlines())
-        result = list()
-
-        result.append("[settings]")
-        result.append(indent(self.settings.dumps()))
-        result.append("\n[requires]")
-        result.append(indent(self.requires.dumps()))
-        result.append("\n[options]")
-        result.append(indent(self.options.dumps()))
-        return '\n'.join(result) + "\n"
-
-    def clone(self):
-        q = self.copy()
-        return q
-
-    def package_id(self):
-        """ The package_id of a conans is the sha1 of its specific requirements,
-        options and settings
-        """
         result = ["[settings]"]
         settings_dumps = self.settings.dumps()
         if settings_dumps:
@@ -443,9 +421,18 @@ class ConanInfo(object):
             result.append("[build_requires]")
             result.append(self.build_requires.dumps())
         if hasattr(self, "conf"):
-            result.append(self.conf.sha)
-        result.append("")  # Append endline so file ends with LF
-        text = '\n'.join(result)
+            result.append(self.conf.dumps())
+        return '\n'.join(result)
+
+    def clone(self):
+        q = self.copy()
+        return q
+
+    def package_id(self):
+        """ The package_id of a conans is the sha1 of its specific requirements,
+        options and settings
+        """
+        text = self.dumps()
         package_id = sha1(text.encode())
         try:
             self.options.validate()

--- a/conans/model/info.py
+++ b/conans/model/info.py
@@ -402,6 +402,12 @@ class ConanInfo(object):
         return result
 
     def dumps(self):
+        """
+        Get all the information contained in settings, options, requires,
+        python_requires, build_requires and conf.
+        :return: `str` with the result of joining all the information, e.g.,
+            `"[settings]\nos=Windows\n[options]\n[requires]\n"`
+        """
         result = ["[settings]"]
         settings_dumps = self.settings.dumps()
         if settings_dumps:
@@ -422,6 +428,7 @@ class ConanInfo(object):
             result.append(self.build_requires.dumps())
         if hasattr(self, "conf"):
             result.append(self.conf.dumps())
+        result.append("")  # Append endline so file ends with LF
         return '\n'.join(result)
 
     def clone(self):
@@ -429,11 +436,14 @@ class ConanInfo(object):
         return q
 
     def package_id(self):
-        """ The package_id of a conans is the sha1 of its specific requirements,
-        options and settings
+        """
+        Get the `package_id` that is the result of applying the has function SHA-1 to the
+        `self.dumps()` return.
+        :return: `str` the `package_id`, e.g., `"040ce2bd0189e377b2d15eb7246a4274d1c63317"`
         """
         text = self.dumps()
         package_id = sha1(text.encode())
+        # FIXME: Should it be done before calling this function?
         try:
             self.options.validate()
         except ConanException as e:

--- a/conans/model/settings.py
+++ b/conans/model/settings.py
@@ -279,11 +279,6 @@ class Settings(object):
         for k in to_remove:
             del self._data[k]
 
-    @property
-    def sha(self):
-        # FIXME: Remove this function when refactored ConanInfo.package_id() method
-        return self.dumps()
-
     def dumps(self):
         """ produces a text string with lines containing a flattened version:
         compiler.arch = XX

--- a/conans/test/integration/command/create_test.py
+++ b/conans/test/integration/command/create_test.py
@@ -352,7 +352,7 @@ class MyPkg(ConanFile):
         self.assertNotIn("None", conaninfo)
         self.assertNotIn("_/", conaninfo)
         self.assertNotIn("/_", conaninfo)
-        self.assertIn("[requires]\n    hello/0.1\n", conaninfo)
+        self.assertIn("[requires]\nhello/0.1\n", conaninfo)
 
     @pytest.mark.xfail(reason="--json output has been disabled")
     def test_compoents_json_output(self):

--- a/conans/test/integration/command/remove_test.py
+++ b/conans/test/integration/command/remove_test.py
@@ -107,7 +107,7 @@ class RemovePackageRevisionsTest(unittest.TestCase):
         servers = {"default": self.test_server}
         self.client = TestClient(servers=servers, inputs=["user", "password"])
         ref = RecipeReference.loads(f"foobar/0.1@user/testing#{self.NO_SETTINGS_RREF}")
-        self.pref = PkgReference(ref, NO_SETTINGS_PACKAGE_ID, "a397cb03d51fb3b129c78d2968e2676f")
+        self.pref = PkgReference(ref, NO_SETTINGS_PACKAGE_ID, "871e6d06bd4bbea0172937df1717e075")
 
     def test_remove_local_package_id_argument(self):
         """ Remove package ID based on recipe revision. The package must be deleted, but
@@ -172,11 +172,15 @@ class RemovePackageRevisionsTest(unittest.TestCase):
 # populated packages of bar
 bar_rrev = "bar/1.1#7db54b020cc95b8bdce49cd6aa5623c0"
 bar_rrev2 = "bar/1.1#78b42a981b29d2cb00fda10b72f1e72a"
-bar_rrev2_debug = '{}:040ce2bd0189e377b2d15eb7246a4274d1c63317'.format(bar_rrev2)
-bar_rrev2_release = '{}:e53d55fd33066c49eb97a4ede6cb50cd8036fe8b'.format(bar_rrev2)
+pkg_id_debug = "040ce2bd0189e377b2d15eb7246a4274d1c63317"
+pkg_id_release = "e53d55fd33066c49eb97a4ede6cb50cd8036fe8b"
+bar_rrev2_debug = '{}:{}'.format(bar_rrev2, pkg_id_debug)
+bar_rrev2_release = '{}:{}'.format(bar_rrev2, pkg_id_release)
 
-bar_rrev2_release_prev1 = "{}#61ceea29651eaf24b902e4ccdd49cc44".format(bar_rrev2_release)
-bar_rrev2_release_prev2 = "{}#c1c8d8ef1f9f9278d7963f6e35527bc7".format(bar_rrev2_release)
+bar_prev1 = "51ef5374f2df568657c8f5198a77fa4d"
+bar_prev2 = "42ff219d456bdf6b29d165e5fb5db7ec"
+bar_rrev2_release_prev1 = "{}#{}".format(bar_rrev2_release, bar_prev1)
+bar_rrev2_release_prev2 = "{}#{}".format(bar_rrev2_release, bar_prev2)
 
 
 @pytest.fixture()
@@ -283,10 +287,10 @@ def test_new_remove_recipe_revisions_expressions(populated_client, with_remote, 
     {"remove": "bar/1.1#*:*#*", "prefs": []},
     {"remove": "bar/1.1#z*:*", "prefs": [bar_rrev2_debug, bar_rrev2_release]},
     {"remove": "bar/1.1#*:*#kk*", "prefs": [bar_rrev2_debug, bar_rrev2_release]},
-    {"remove": "bar/1.1#*:e53d55fd33066c49eb97a4ede6cb50cd8036fe8b", "prefs": [bar_rrev2_debug]},
-    {"remove": "bar/1.1#*:*cb50cd8036fe8b", "prefs": [bar_rrev2_debug]},
-    {"remove": "{}:*bd0189e377b2d15e*".format(bar_rrev2), "prefs": [bar_rrev2_release]},
-    {"remove": "*/*#*:*bd0189e377b2d15eb72*", "prefs": [bar_rrev2_release]},
+    {"remove": "bar/1.1#*:{}".format(pkg_id_release), "prefs": [bar_rrev2_debug]},
+    {"remove": "bar/1.1#*:*{}".format(pkg_id_release[-12:]), "prefs": [bar_rrev2_debug]},
+    {"remove": "{}:*{}*".format(bar_rrev2, pkg_id_debug[5:15]), "prefs": [bar_rrev2_release]},
+    {"remove": "*/*#*:*{}*".format(pkg_id_debug[5:15]), "prefs": [bar_rrev2_release]},
     {"remove": '*/*#*:* -p build_type="fake"', "prefs": [bar_rrev2_release, bar_rrev2_debug]},
     {"remove": '*/*#*:* -p build_type="Release"', "prefs": [bar_rrev2_debug]},
     {"remove": '*/*#*:* -p build_type="Debug"', "prefs": [bar_rrev2_release]},
@@ -323,9 +327,9 @@ def test_new_remove_package_expressions(populated_client, with_remote, data):
     {"remove": '{}#*kk*'.format(bar_rrev2_release), "prevs": [bar_rrev2_release_prev1,
                                                               bar_rrev2_release_prev2]},
     {"remove": '{}#*'.format(bar_rrev2_release), "prevs": []},
-    {"remove": '{}#c1c* -p "build_type=Debug"'.format(bar_rrev2_release),
+    {"remove": '{}#{}* -p "build_type=Debug"'.format(bar_rrev2_release, bar_prev2[:3]),
      "prevs": [bar_rrev2_release_prev1, bar_rrev2_release_prev2]},
-    {"remove": '{}#c1c* -p "build_type=Release"'.format(bar_rrev2_release),
+    {"remove": '{}#{}* -p "build_type=Release"'.format(bar_rrev2_release, bar_prev2[:3]),
      "prevs": [bar_rrev2_release_prev1]},
     {"remove": '{}#* -p "build_type=Release"'.format(bar_rrev2_release), "prevs": []},
     {"remove": '{}#* -p "build_type=Debug"'.format(bar_rrev2_release),

--- a/conans/test/integration/graph/test_dependencies_visit.py
+++ b/conans/test/integration/graph/test_dependencies_visit.py
@@ -2,6 +2,7 @@ import textwrap
 
 import pytest
 
+from conans.model.recipe_ref import RecipeReference
 from conans.test.assets.genconanfile import GenConanfile
 from conans.test.utils.tools import TestClient
 
@@ -32,15 +33,17 @@ def test_dependencies_visit():
     client.save({"conanfile.py": conanfile})
 
     client.run("install .")
-    assert "DefRef: openssl/0.1#705df323569bee67454c0ecb5929806f!!!" in client.out
-    assert "DefPRef: openssl/0.1#705df323569bee67454c0ecb5929806f:"\
-           "012cdbad7278c98ff196ee2aa8f1158dde7d3c61#"\
-           "2c6e0edc67e611f1acc542dd3c74dd59!!!" in client.out
+    refs = client.cache.get_latest_recipe_reference(RecipeReference.loads("openssl/0.1"))
+    pkgs = client.cache.get_package_references(refs)
+    prev1 = client.cache.get_latest_package_reference(pkgs[0])
+    assert f"DefRef: {repr(prev1.ref)}!!!" in client.out
+    assert f"DefPRef: {prev1.repr_notime()}!!!" in client.out
 
-    assert "DefRefBuild: openssl/0.2#705df323569bee67454c0ecb5929806f!!!" in client.out
-    assert "DefPRefBuild: openssl/0.2#705df323569bee67454c0ecb5929806f:" \
-           "012cdbad7278c98ff196ee2aa8f1158dde7d3c61#"\
-           "2c6e0edc67e611f1acc542dd3c74dd59!!!" in client.out
+    refs = client.cache.get_latest_recipe_reference(RecipeReference.loads("openssl/0.2"))
+    pkgs = client.cache.get_package_references(refs)
+    prev2 = client.cache.get_latest_package_reference(pkgs[0])
+    assert f"DefRefBuild: {repr(prev2.ref)}!!!" in client.out
+    assert f"DefPRefBuild: {prev2.repr_notime()}!!!" in client.out
 
     assert "conanfile.py: DIRECTBUILD True: cmake/0.1" in client.out
     assert "conanfile.py: DIRECTBUILD False: openssl/0.2" in client.out

--- a/conans/test/unittests/model/settings_test.py
+++ b/conans/test/unittests/model/settings_test.py
@@ -9,16 +9,13 @@ class SettingsLoadsTest(unittest.TestCase):
     def test_none_value(self):
         yml = "os: [None, Windows]"
         settings = Settings.loads(yml)
-        # Same sha as if settings were empty
-        self.assertEqual(settings.sha, Settings.loads("").sha)
         settings.validate()
         self.assertTrue(settings.os == None)
         self.assertEqual("", settings.dumps())
         settings.os = "None"
-        self.assertEqual(settings.sha, Settings.loads("").sha)
         settings.validate()
+        self.assertEqual(settings.dumps(), Settings.loads("").dumps())
         self.assertTrue(settings.os == "None")
-        self.assertNotIn("os=None", settings.dumps())
         settings.os = "Windows"
         self.assertTrue(settings.os == "Windows")
         self.assertEqual("os=Windows", settings.dumps())
@@ -74,20 +71,15 @@ class SettingsLoadsTest(unittest.TestCase):
         subsystem: [None, cygwin]
 """
         settings = Settings.loads(yml)
-        # Same sha as if settings were empty
-        self.assertEqual(settings.sha, Settings.loads("").sha)
         settings.validate()
-        self.assertTrue(settings.os == None)
-        self.assertEqual("", settings.dumps())
         settings.os = "None"
-        self.assertEqual(settings.sha, Settings.loads("").sha)
-        settings.validate()
         self.assertTrue(settings.os == "None")
         self.assertNotIn("os=None", settings.dumps())
         settings.os = "Windows"
         self.assertTrue(settings.os.subsystem == None)
         self.assertEqual("os=Windows", settings.dumps())
         settings.os.subsystem = "cygwin"
+        settings.validate()
         self.assertEqual("os=Windows\nos.subsystem=cygwin", settings.dumps())
 
     def test_none__sub_subsetting(self):
@@ -132,7 +124,7 @@ class SettingsTest(unittest.TestCase):
         other_settings = Settings.loads("os: [Windows, Linux]")
         settings.os = "Windows"
         other_settings.os = "Windows"
-        self.assertEqual(settings.sha, other_settings.sha)
+        self.assertEqual(settings.dumps(), other_settings.dumps())
 
     def test_any(self):
         data = {"target": ["ANY"]}


### PR DESCRIPTION
Changelog: Feature: `ConanInfo.package_id()` uses the whole `ConanInfo.dumps()` result.
Changelog: Feature: Removed all the existing `*.sha()` property methods. Now, it's used `*.dumps()` instead.
Closes: https://github.com/conan-io/conan/issues/11164