### PR TITLE
ux: improve error message from CMakeDeps

### DIFF
--- a/conan/tools/cmake/cmakedeps/templates/__init__.py
+++ b/conan/tools/cmake/cmakedeps/templates/__init__.py
@@ -39,7 +39,10 @@ class CMakeDepsFileTemplate(object):
             return self.conanfile.ref.name not in self.cmakedeps.build_context_build_modules
 
     def render(self):
-        context = self.context
+        try:
+            context = self.context
+        except Exception as e:
+            raise ConanException("error generating context for '{}': {}".format(self.conanfile, e))
         if context is None:
             return
         return Template(self.template, trim_blocks=True, lstrip_blocks=True,


### PR DESCRIPTION
Changelog: omit
Docs: omit


In a big (or not so big) graph, we need to know where the error comes from. I don´t know if this is the best place to catch this and add the information to the error message, but... the idea is to get a better message as shown below:


---

The error goes from:

```
ERROR: Error in generator 'CMakeDeps': U is not absolute
```

to:

```
ERROR: Error in generator 'CMakeDeps': error generating context for 'abseil/20211102.0': U is not absolute
```


