### PR TITLE
[develop2] Internal info.validate() for complete definitions

### DIFF
--- a/conan/api/subapi/install.py
+++ b/conan/api/subapi/install.py
@@ -38,7 +38,7 @@ class InstallAPI:
         root_node = deps_graph.root
         conanfile = root_node.conanfile
 
-        if conanfile.info.invalid:
+        if conanfile.info is not None and conanfile.info.invalid:
             binary, reason = conanfile.info.invalid
             msg = "{}: Invalid ID: {}: {}".format(conanfile, binary, reason)
             raise ConanInvalidConfiguration(msg)

--- a/conans/client/graph/compute_pid.py
+++ b/conans/client/graph/compute_pid.py
@@ -2,7 +2,7 @@ from collections import OrderedDict
 
 from conans.client.graph.graph import BINARY_INVALID, BINARY_ERROR
 from conans.errors import conanfile_exception_formatter, ConanInvalidConfiguration, \
-    ConanErrorConfiguration, conanfile_remove_attr
+    ConanErrorConfiguration, conanfile_remove_attr, ConanException
 from conans.model.info import ConanInfo, RequirementsInfo, RequirementInfo
 
 
@@ -70,3 +70,5 @@ def run_validate_package_id(conanfile):
         with conanfile_exception_formatter(conanfile, "package_id"):
             with conanfile_remove_attr(conanfile, ['cpp_info'], "package_id"):
                 conanfile.package_id()
+
+    conanfile.info.validate()

--- a/conans/client/graph/graph_binaries.py
+++ b/conans/client/graph/graph_binaries.py
@@ -289,9 +289,12 @@ class GraphBinariesAnalyzer(object):
     def evaluate_graph(self, deps_graph, build_mode, lockfile):
         build_mode = BuildMode(build_mode)
         for node in deps_graph.ordered_iterate():
-            self._evaluate_package_id(node)
             if node.recipe in (RECIPE_CONSUMER, RECIPE_VIRTUAL):
+                if node.path is not None and node.path.endswith(".py"):
+                    # For .py we keep evaluating the package_id, validate(), etc
+                    self._evaluate_package_id(node)
                 continue
+            self._evaluate_package_id(node)
             if lockfile:
                 locked_prev = lockfile.resolve_prev(node)
                 if locked_prev:

--- a/conans/model/conan_file.py
+++ b/conans/model/conan_file.py
@@ -59,6 +59,7 @@ class ConanFile:
         self.runenv_info = Environment()
         # At the moment only for build_requires, others will be ignored
         self.conf_info = Conf()
+        self.info = None
         self._conan_buildenv = None  # The profile buildenv, will be assigned initialize()
         self._conan_node = None  # access to container Node object, to access info, context, deps...
 

--- a/conans/model/info.py
+++ b/conans/model/info.py
@@ -443,11 +443,6 @@ class ConanInfo(object):
         """
         text = self.dumps()
         package_id = sha1(text.encode())
-        # FIXME: Should it be done before calling this function?
-        try:
-            self.options.validate()
-        except ConanException as e:
-            self.invalid = BINARY_INVALID, str(e)
         return package_id
 
     def serialize_min(self):
@@ -465,3 +460,15 @@ class ConanInfo(object):
         self.settings.clear()
         self.options.clear()
         self.requires.clear()
+
+    def validate(self):
+        # If the options are not fully defined, this is also an invalid case
+        try:
+            self.options.validate()
+        except ConanException as e:
+            self.invalid = BINARY_INVALID, str(e)
+
+        try:
+            self.settings.validate()
+        except ConanException as e:
+            self.invalid = BINARY_INVALID, str(e)

--- a/conans/test/functional/settings/conan_settings_preprocessor_test.py
+++ b/conans/test/functional/settings/conan_settings_preprocessor_test.py
@@ -42,10 +42,11 @@ class HelloConan(ConanFile):
         default_settings = default_settings.replace("runtime:", "# runtime:")
         default_settings = default_settings.replace("runtime_type:", "# runtime_type:")
         save(self.client.cache.settings_path, default_settings)
-        save(self.client.cache.default_profile_path, "")
+        save(self.client.cache.default_profile_path,
+             "[settings]\nos=Windows\ncompiler=msvc\ncompiler.version=191")
         # Ensure the runtime setting is not there anymore
-        self.client.run('install --requires=hello0/0.1@lasote/channel --build missing -s '
-                        'compiler="msvc" -s compiler.runtime="dynamic"', assert_error=True)
+        self.client.run('install --requires=hello0/0.1@lasote/channel --build missing '
+                        '-s compiler.runtime="dynamic"', assert_error=True)
         self.assertIn("'settings.compiler.runtime' doesn't exist for 'msvc'",
                       self.client.out)
 

--- a/conans/test/integration/configuration/conf/test_conf_profile.py
+++ b/conans/test/integration/configuration/conf/test_conf_profile.py
@@ -197,7 +197,7 @@ def test_conf_package_patterns():
     client.save({"dep/conanfile.py": str(conanfile) + generate,
                  "pkg/conanfile.py": str(conanfile.with_requirement("dep/0.1", visible=False)) + generate,
                  "consumer/conanfile.py": str(conanfile.with_requires("pkg/0.1")
-                .with_settings("os", "build_type", "arch")) + generate})
+                .with_settings("os", "build_type")) + generate})
 
     client.run("export dep --name=dep --version=0.1")
     client.run("export pkg --name=pkg --version=0.1")


### PR DESCRIPTION
- ``self.options.validate()`` was in a weird place, moved to its own method
- Added ``self.settings.validate()``
- Fixed computation of ``package_id()`` only for ``.py`` consumer recipes, not virtuals, not ``conanfile.txt``