### PR TITLE
[dev2][package_id] Part 3: Mechanism to add some `conf`s to `package_id` computation

### DIFF
--- a/conans/client/graph/compute_pid.py
+++ b/conans/client/graph/compute_pid.py
@@ -3,7 +3,6 @@ from collections import OrderedDict
 from conans.client.graph.graph import BINARY_INVALID, BINARY_ERROR
 from conans.errors import conanfile_exception_formatter, ConanInvalidConfiguration, \
     ConanErrorConfiguration, conanfile_remove_attr
-from conans.model.conf import Conf
 from conans.model.info import ConanInfo, RequirementsInfo, RequirementInfo, PythonRequiresInfo
 
 
@@ -19,7 +18,6 @@ def compute_package_id(node, new_config):
     embed_mode = new_config.get("core.package_id:default_embed_mode", default="full_mode")
     python_mode = new_config.get("core.package_id:default_python_mode", default="minor_mode")
     build_mode = new_config.get("core.package_id:default_build_mode", default=None)
-    conf_names = new_config.get("core.package_id:confs", default=[], check_type=list)
 
     python_requires = getattr(conanfile, "python_requires", None)
     if python_requires:
@@ -42,19 +40,12 @@ def compute_package_id(node, new_config):
     build_requires_info = RequirementsInfo(build_data)
     python_requires = PythonRequiresInfo(python_requires, python_mode)
 
-    # Creating Conf() object with only the configurations defined by core.package_id:confs
-    conf = Conf()
-    for conf_name in conf_names:
-        value = conanfile.conf.get(conf_name)
-        if value is not None:
-            conf.define(conf_name, value)
-
     conanfile.info = ConanInfo(settings=conanfile.settings.copy_conaninfo_settings(),
                                options=conanfile.options.copy_conaninfo_options(),
                                reqs_info=reqs_info,
                                build_requires_info=build_requires_info,
                                python_requires=python_requires,
-                               conf=conf)
+                               conf=conanfile.conf.copy_conaninfo_conf())
     conanfile.original_info = conanfile.info.clone()
 
     run_validate_package_id(conanfile)

--- a/conans/model/conf.py
+++ b/conans/model/conf.py
@@ -325,7 +325,7 @@ class Conf:
     def copy_conaninfo_conf(self):
         """
         Get a new `Conf()` object with all the configurations required by the consumer
-        to be included into the final `ConanInfo().package_id()` computation. For instance, let's
+        to be included in the final `ConanInfo().package_id()` computation. For instance, let's
         suppose that we have this Conan `profile`:
 
         ```
@@ -351,8 +351,8 @@ class Conf:
         package_id_confs = self.get("tools.info.package_id:confs", default=[], check_type=list)
         for conf_name in package_id_confs:
             value = self.get(conf_name)
-            # Pruning None values, those should not affect package ID
-            if value is not None:
+            # Pruning any empty values, those should not affect package ID
+            if value:
                 result.define(conf_name, value)
         return result
 

--- a/conans/model/conf.py
+++ b/conans/model/conf.py
@@ -344,7 +344,7 @@ class Conf:
         tools.build:cflags=["flag1"]
         ```
 
-        :return: a new `< Conf object >` with the configuration selected by `core.package_id:confs`.
+        :return: a new `< Conf object >` with the configuration selected by `tools.info.package_id:confs`.
         """
         result = Conf()
         # Reading the list of all the configurations selected by the user to use for the package_id

--- a/conans/model/conf.py
+++ b/conans/model/conf.py
@@ -8,7 +8,6 @@ from conans.model.recipe_ref import ref_matches
 BUILT_IN_CONFS = {
     "core:required_conan_version": "Raise if current version does not match the defined range.",
     "core:non_interactive": "Disable interactive user input, raises error if input necessary",
-    "core.package_id:msvc_visual_incompatible": "Allows opting-out the fallback from the new msvc compiler to the Visual Studio compiler existing binaries",
     "core:default_profile": "Defines the default host profile ('default' by default)",
     "core:default_build_profile": "Defines the default build profile (None by default)",
     "core.upload:retry": "Number of retries in case of failure when uploading to Conan server",
@@ -16,6 +15,13 @@ BUILT_IN_CONFS = {
     "core.download:parallel": "Number of concurrent threads to download packages",
     "core.download:retry": "Number of retries in case of failure when downloading from Conan server",
     "core.download:retry_wait": "Seconds to wait between download attempts from Conan server",
+    # Package ID related
+    "core.package_id:confs": "List of configurations that should be included as part of the package_id, e.g., 'tools.build:cxxflags'",
+    "core.package_id:default_unknown_mode": "",
+    "core.package_id:default_non_embed_mode": "",
+    "core.package_id:default_embed_mode": "",
+    "core.package_id:default_python_mode": "",
+    "core.package_id:default_build_mode": "",
     # General HTTP(python-requests) configuration
     "core.net.http:max_retries": "Maximum number of connection retries (requests library)",
     "core.net.http:timeout": "Number of seconds without response to timeout (requests library)",

--- a/conans/model/info.py
+++ b/conans/model/info.py
@@ -379,13 +379,14 @@ def load_binary_info(text):
 class ConanInfo:
 
     def __init__(self, settings=None, options=None, reqs_info=None, build_requires_info=None,
-                 python_requires=None):
+                 python_requires=None, conf=None):
         self.invalid = None
         self.settings = settings
         self.options = options
         self.requires = reqs_info
         self.build_requires = build_requires_info
         self.python_requires = python_requires
+        self.conf = conf
 
     def clone(self):
         """ Useful for build_id implementation and for compatibility()
@@ -397,6 +398,7 @@ class ConanInfo:
         result.requires = self.requires.copy()
         result.build_requires = self.build_requires.copy()
         result.python_requires = self.python_requires.copy()
+        result.conf = self.conf.copy()
         return result
 
     def dumps(self):
@@ -406,6 +408,8 @@ class ConanInfo:
         :return: `str` with the result of joining all the information, e.g.,
             `"[settings]\nos=Windows\n[options]\n[requires]\n"`
         """
+        # FIXME: Refactor this method to not include headers with empty content. It'll break
+        #        one or two tests...
         result = ["[settings]"]
         settings_dumps = self.settings.dumps()
         if settings_dumps:
@@ -424,7 +428,9 @@ class ConanInfo:
         if self.build_requires:
             result.append("[build_requires]")
             result.append(self.build_requires.dumps())
-        if hasattr(self, "conf"):
+        conf_dumps = self.conf.dumps()
+        if conf_dumps:
+            # result.append("[conf]")  # Let's do it when apply FIXME above
             result.append(self.conf.dumps())
         result.append("")  # Append endline so file ends with LF
         return '\n'.join(result)

--- a/conans/test/integration/package_id/package_id_and_confs_test.py
+++ b/conans/test/integration/package_id/package_id_and_confs_test.py
@@ -1,0 +1,27 @@
+import textwrap
+
+from conans.test.utils.tools import TestClient
+
+
+def test_package_id_include_confs():
+    client = TestClient()
+    client.save({"global.conf": 'core.package_id:confs=["tools.build:cxxflags", "tools.build:cflags"]'},
+                path=client.cache.cache_folder)
+    conanfile = textwrap.dedent("""
+        from conan import ConanFile
+        class Pkg(ConanFile):
+            settings = "os"
+        """)
+    profile = textwrap.dedent("""
+    include(default)
+    [conf]
+    tools.build:cxxflags=["--flag1", "--flag2"]
+    tools.build:cflags+=["--flag3", "--flag4"]
+    """)
+    client.save({"conanfile.py": conanfile, "profile": profile})
+    client.run('create . --name=pkg --version=0.1 -s os=Windows -pr profile')
+    # client.assert_listed_binary({"pkg/0.1": ("115c314122246da287f43c08de5eeab316596038",
+    #                                          "Build")})
+    # client.run('install --requires=pkg/0.1@ -s os=Windows -s compiler=msvc '
+    #            '-s compiler.version=190 -s build_type=Debug -s compiler.runtime=dynamic')
+    # client.assert_listed_binary({"pkg/0.1": ("115c314122246da287f43c08de5eeab316596038", "Cache")})

--- a/conans/test/integration/package_id/package_id_and_confs_test.py
+++ b/conans/test/integration/package_id/package_id_and_confs_test.py
@@ -39,15 +39,14 @@ def test_package_id_including_confs(package_id_confs, package_id):
     client.assert_listed_binary({"pkg/0.1": (package_id, "Build")})
 
 
-PKG_ID_4 = "5dc2f1d489aabf1f3f1cdc53ca1748560f6c9b6c"
-PKG_ID_5 = "9a11cde1f104602e41b217a5f777f441de73a9f2"
-PKG_ID_6 = "ea3b400a04f1c479b6817e49b745ca7cf10a9f67"
+PKG_ID_4 = "9a11cde1f104602e41b217a5f777f441de73a9f2"
+PKG_ID_5 = "ea3b400a04f1c479b6817e49b745ca7cf10a9f67"
 
 
 @pytest.mark.parametrize("cxx_flags, package_id", [
-    ('[]', PKG_ID_4),
-    ('["--flag1", "--flag2"]', PKG_ID_5),
-    ('["--flag3", "--flag4"]', PKG_ID_6),
+    ('[]', PKG_ID_NO_CONF),
+    ('["--flag1", "--flag2"]', PKG_ID_4),
+    ('["--flag3", "--flag4"]', PKG_ID_5),
 ])
 def test_same_package_id_configurations_but_changing_values(cxx_flags, package_id):
     client = TestClient()


### PR DESCRIPTION
Changelog: Feature: Added mechanism to include some configurations into `package_id` computation via `tools.info.package_id:confs` one.
Docs: omit
Closes: https://github.com/conan-io/conan/issues/11163