### PR TITLE
[develop2] refactoring around conan-list results

### DIFF
--- a/conans/cli/commands/list.py
+++ b/conans/cli/commands/list.py
@@ -235,15 +235,14 @@ def list_packages(conan_api, parser, subparser, *args):
         name = getattr(remote, "name", None)
         if ref.revision == "latest":
             try:
-                refs = conan_api.search.recipe_revisions(args.reference, remote)
+                ref.revision = None
+                ref = conan_api.list.latest_recipe_revision(ref, remote)
             except Exception as e:
                 results[name] = {"error": str(e)}
                 continue
-            if not refs:
+            if not ref:
                 results[name] = {"error": "There are no recipes matching '{}'".format(args.reference)}
                 continue
-            assert len(refs) == 1
-            ref = refs[0]  # To resolve the "latest"
         try:
             # TODO: This should error in the cache if the revision doesn't exist
             results[name] = {"packages": conan_api.list.packages_configurations(ref, remote=remote)}

--- a/conans/cli/commands/list.py
+++ b/conans/cli/commands/list.py
@@ -1,11 +1,11 @@
 import copy
-from typing import List
+from collections import OrderedDict
 
 from conans.cli.command import conan_command, conan_subcommand, Extender, COMMAND_GROUPS
-from conans.cli.commands import json_formatter, CommandResult
+from conans.cli.commands import json_formatter
 from conans.cli.common import get_remote_selection
 from conans.cli.output import Color, ConanOutput
-from conans.errors import ConanException, InvalidNameException, NotFoundException
+from conans.errors import ConanException, InvalidNameException
 from conans.model.package_ref import PkgReference
 from conans.model.recipe_ref import RecipeReference
 
@@ -17,85 +17,89 @@ field_color = Color.BRIGHT_YELLOW
 value_color = Color.CYAN
 
 
-def _print_common_headers(result: CommandResult):
+def print_list_recipes(results):
     out = ConanOutput()
-    if result.remote:
-        out.writeln(f"{result.remote.name}:", fg=remote_color)
-    else:
-        out.writeln("Local Cache:", remote_color)
-
-
-def print_list_recipes(results: List[CommandResult]):
-    out = ConanOutput()
-    for result in results:
-        _print_common_headers(result)
-        if result.error:
-            error = f"  ERROR: {result.error}"
-            out.writeln(error, fg=error_color)
-        elif not result.elements:
-            out.writeln("  There are no matching recipe references")
+    for remote, result in results.items():
+        name = remote if remote is not None else "Local Cache"
+        out.writeln(f"{name}:", fg=remote_color)
+        if result.get("error"):
+            out.writeln(f"  ERROR: {result.get('error')}", fg=error_color)
         else:
-            current_recipe = None
-            for ref in result.elements:
-                if ref.name != current_recipe:
-                    current_recipe = ref.name
-                    out.writeln(f"  {current_recipe}", fg=recipe_color)
+            recipes = result.get("recipes", [])
+            if not recipes:
+                # FIXME: this should be an error message, NOT FOUND
+                out.writeln("  There are no matching recipe references")
+            else:
+                current_recipe = None
+                for ref in recipes:
+                    if ref.name != current_recipe:
+                        current_recipe = ref.name
+                        out.writeln(f"  {current_recipe}", fg=recipe_color)
 
-                out.writeln(f"    {ref}", fg=reference_color)
+                    out.writeln(f"    {ref}", fg=reference_color)
 
 
 def print_list_recipe_revisions(results):
     out = ConanOutput()
-    for result in results:
-        _print_common_headers(result)
-        if result.error:
-            error = f"  ERROR: {result.error}"
-            out.writeln(error, fg=error_color)
-        elif not result.elements:
-            out.writeln(f"  There are no matching recipe references")
+    for remote, result in results.items():
+        name = remote if remote is not None else "Local Cache"
+        out.writeln(f"{name}:", fg=remote_color)
+        if result.get("error"):
+            out.writeln(f"  ERROR: {result.get('error')}", fg=error_color)
         else:
-            for ref in result.elements:
-                out.writeln(f"  {ref.repr_humantime()}", fg=recipe_color)
+            revisions = result.get("revisions", [])
+            if not revisions:
+                # FIXME: this should be an error message, NOT FOUND
+                out.writeln("  There are no matching recipe references")
+            else:
+                for ref in revisions:
+                    out.writeln(f"  {ref.repr_humantime()}", fg=recipe_color)
 
 
 def print_list_package_revisions(results):
     out = ConanOutput()
-    for result in results:
-        _print_common_headers(result)
-        if result.error:
-            error = f"  ERROR: {result.error}"
-            out.writeln(error, fg=error_color)
-        elif not result.elements:
-            out.writeln(f"  There are no matching package references")
+    for remote, result in results.items():
+        name = remote if remote is not None else "Local Cache"
+        out.writeln(f"{name}:", fg=remote_color)
+        if result.get("error"):
+            out.writeln(f"  ERROR: {result.get('error')}", fg=error_color)
         else:
-            for pref in result.elements:
-                out.writeln(f"  {pref.repr_humantime()}", fg=recipe_color)
+            revisions = result.get("revisions", [])
+            if not revisions:
+                # FIXME: this should be an error message, NOT FOUND
+                out.writeln(f"  There are no matching package references")
+            else:
+                for pref in revisions:
+                    out.writeln(f"  {pref.repr_humantime()}", fg=recipe_color)
 
 
-def print_list_package_ids(results: List[CommandResult]):
+def print_list_package_ids(results):
     out = ConanOutput()
-    for result in results:
-        _print_common_headers(result)
-        if result.error:
-            error = f"  ERROR: {result.error}"
-            out.writeln(error, fg=error_color)
-        elif not result.elements:
-            out.writeln("  There are no packages")
+    for remote, result in results.items():
+        name = remote if remote is not None else "Local Cache"
+        out.writeln(f"{name}:", fg=remote_color)
+        if result.get("error"):
+            out.writeln(f"  ERROR: {result.get('error')}", fg=error_color)
         else:
-            for pref, binary_info in result.elements.items():
-                _tmp_pref = copy.copy(pref)
-                _tmp_pref.revision = None  # Do not show the revision of the package
-                out.writeln(f"  {_tmp_pref.repr_notime()}", fg=reference_color)
-                for item, contents in binary_info.items():
-                    if not contents:
-                        continue
-                    out.writeln(f"    {item}:", fg=field_color)
-                    if not isinstance(contents, dict):
-                        for c in contents:
-                            out.writeln(f"      {c}", fg=value_color)
-                    else:
-                        for k, v in contents.items():
-                            out.writeln(f"      {k}={v}", fg=value_color)
+            packages = result.get("packages", [])
+            if not packages:
+                # It is legal not to have binaries
+                out.writeln("  There are no packages")
+            else:
+                for pref, binary_info in packages.items():
+                    _tmp_pref = copy.copy(pref)
+                    _tmp_pref.revision = None  # Do not show the revision of the package
+                    out.writeln(f"  {_tmp_pref.repr_notime()}", fg=reference_color)
+                    for item, contents in binary_info.items():
+                        if not contents:
+                            continue
+                        out.writeln(f"    {item}:", fg=field_color)
+                        if not isinstance(contents, dict):
+                            for c in contents:
+                                out.writeln(f"      {c}", fg=value_color)
+                        else:
+                            for k, v in contents.items():
+                                out.writeln(f"      {k}={v}", fg=value_color)
 
 
 def _add_remotes_and_cache_options(subparser):
@@ -103,6 +107,16 @@ def _add_remotes_and_cache_options(subparser):
     remotes_group.add_argument("-r", "--remote", default=None, action=Extender,
                                help="Remote names. Accepts wildcards")
     subparser.add_argument("-c", "--cache", action='store_true', help="Search in the local cache")
+
+
+def _selected_cache_remotes(conan_api, args):
+    # If neither remote nor cache are defined, show results only from cache
+    remotes = []
+    if args.cache or not args.remote:
+        remotes.append(None)
+    if args.remote:
+        remotes.extend(get_remote_selection(conan_api, args.remote))
+    return remotes
 
 
 @conan_subcommand(formatters={"json": json_formatter})
@@ -117,29 +131,15 @@ def list_recipes(conan_api, parser, subparser, *args):
     _add_remotes_and_cache_options(subparser)
     args = parser.parse_args(*args)
 
-    use_remotes = args.remote
-    results = []
+    remotes = _selected_cache_remotes(conan_api, args)
 
-    # If neither remote nor cache are defined, show results only from cache
-    if args.cache or not use_remotes:
-        result = CommandResult()
+    results = OrderedDict()
+    for remote in remotes:
+        name = getattr(remote, "name", None)
         try:
-            references = conan_api.search.recipes(args.query)
+            results[name] = {"recipes": conan_api.search.recipes(args.query, remote)}
         except Exception as e:
-            result.error = str(e)
-        else:
-            result.elements = references
-        results.append(result)
-
-    if use_remotes:
-        remotes = get_remote_selection(conan_api, args.remote)
-        for remote in remotes:
-            result = CommandResult(remote=remote)
-            try:
-                result.elements = conan_api.search.recipes(args.query, remote)
-            except Exception as e:
-                result.error = str(e)
-            results.append(result)
+            results[name] = {"error": str(e)}
 
     print_list_recipes(results)
     return results
@@ -158,29 +158,15 @@ def list_recipe_revisions(conan_api, parser, subparser, *args):
     if ref.revision:
         raise ConanException(f"Cannot list the revisions of a specific recipe revision")
 
-    results = []
-    # If neither remote nor cache are defined, show results only from cache
-    if args.cache or not args.remote:
-        result = CommandResult()
-        result["ref"] = ref
-        try:
-            result.elements = conan_api.list.recipe_revisions(ref)
-        except Exception as e:
-            result.error = str(e)
+    remotes = _selected_cache_remotes(conan_api, args)
 
-        results.append(result)
-    if args.remote:
-        remotes = get_remote_selection(conan_api, args.remote)
-        for remote in remotes:
-            result = CommandResult(remote=remote)
-            result["ref"] = ref
-            try:
-                result.elements = conan_api.list.recipe_revisions(ref, remote=remote)
-            except NotFoundException:
-                result.elements = []
-            except Exception as e:
-                result.error = str(e)
-            results.append(result)
+    results = OrderedDict()
+    for remote in remotes:
+        name = getattr(remote, "name", None)
+        try:
+            results[name] = {"revisions": conan_api.list.recipe_revisions(ref, remote=remote)}
+        except Exception as e:
+            results[name] = {"error": str(e)}
 
     print_list_recipe_revisions(results)
     return results
@@ -206,30 +192,15 @@ def list_package_revisions(conan_api, parser, subparser, *args):
     if pref.revision:
         raise ConanException(f"Cannot list the revisions of a specific package revision")
 
-    results = []
-    # If neither remote nor cache are defined, show results only from cache
-    if args.cache or not args.remote:
-        result = CommandResult()
+    remotes = _selected_cache_remotes(conan_api, args)
+
+    results = OrderedDict()
+    for remote in remotes:
+        name = getattr(remote, "name", None)
         try:
-            result.elements = conan_api.list.package_revisions(pref)
-        except NotFoundException:
-            result.elements = []
+            results[name] = {"revisions": conan_api.list.package_revisions(pref, remote=remote)}
         except Exception as e:
-            result.error = str(e)
-
-        results.append(result)
-
-    if args.remote:
-        remotes = get_remote_selection(conan_api, args.remote)
-        for remote in remotes:
-            result = CommandResult(remote=remote)
-            try:
-                result.elements = conan_api.list.package_revisions(pref, remote=remote)
-            except NotFoundException:
-                result.elements = []
-            except Exception as e:
-                result.error = str(e)
-            results.append(result)
+            results[name] = {"error": str(e)}
 
     print_list_package_revisions(results)
     return results
@@ -253,35 +224,18 @@ def list_packages(conan_api, parser, subparser, *args):
         raise ConanException(f"{args.reference} is not a valid recipe reference, provide a reference"
                              f" in the form name/version[@user/channel][#RECIPE_REVISION]")
 
-    results = []
-    # If neither remote nor cache are defined, show results only from cache
-    if args.cache or not args.remote:
-        result = CommandResult()
-        try:
-            # This resolves "latest" or no revision
-            refs = conan_api.search.recipe_revisions(args.reference, args.remote)
-            if len(refs) == 0:
-                raise ConanException("There are no recipes matching the expression '{}'"
-                                     "".format(args.reference))
-            if len(refs) > 1:
-                raise ConanException("The expression '{}' resolved more "
-                                     "than one recipe".format(args.reference))
-            result.elements = conan_api.list.packages_configurations(refs[0])
-        except Exception as e:
-            result.error = str(e)
-        results.append(result)
+    remotes = _selected_cache_remotes(conan_api, args)
 
-    if args.remote:
-        remotes = get_remote_selection(conan_api, args.remote)
-        for remote in remotes:
-            result = CommandResult(remote=remote)
-            try:
-                result.elements = conan_api.list.packages_configurations(ref, remote=remote)
-            except NotFoundException:
-                result.elements = []
-            except Exception as e:
-                result.error = str(e)
-            results.append(result)
+    results = OrderedDict()
+    for remote in remotes:
+        # TODO: Discuss: we cannot deduce "latest" recipe revision for each remote, it could be
+        #  different and the output would be a mess?
+        name = getattr(remote, "name", None)
+        try:
+            # TODO: This should error in the cache if the revision doesn't exist
+            results[name] = {"packages": conan_api.list.packages_configurations(ref, remote=remote)}
+        except Exception as e:
+            results[name] = {"error": str(e)}
 
     print_list_package_ids(results)
     return results

--- a/conans/cli/commands/search.py
+++ b/conans/cli/commands/search.py
@@ -1,6 +1,7 @@
+from collections import OrderedDict
+
 from conan.api.conan_api import ConanAPIV2
 from conans.cli.command import conan_command, Extender, COMMAND_GROUPS
-from conans.cli.commands import CommandResult
 from conans.cli.commands.list import print_list_recipes, json_formatter
 from conans.cli.common import get_remote_selection
 
@@ -18,14 +19,14 @@ def search(conan_api: ConanAPIV2, parser, *args):
                              "in all remotes")
     args = parser.parse_args(*args)
 
-    results = []
     remotes = get_remote_selection(conan_api, args.remote)
+
+    results = OrderedDict()
     for remote in remotes:
-        result = CommandResult(remote=remote)
+        name = getattr(remote, "name", None)
         try:
-            result.elements = conan_api.search.recipes(args.query, remote)
+            results[name] = {"recipes": conan_api.search.recipes(args.query, remote)}
         except Exception as e:
-            result.error = str(e)
-        results.append(result)
+            results[name] = {"error": str(e)}
     print_list_recipes(results)
     return results

--- a/conans/test/integration/build_requires/test_toolchain_packages.py
+++ b/conans/test/integration/build_requires/test_toolchain_packages.py
@@ -375,7 +375,7 @@ def test_compiler_gcc():
     assert "gcc/0.1 (test package): gcc-Linux-x86_64" in c.out
 
     # check the list packages
-    c.run("list packages gcc/0.1")
+    c.run("list packages gcc/0.1#latest")
     assert """settings_target:
       arch=armv7
       build_type=Release

--- a/conans/test/integration/command_v2/list_package_ids_test.py
+++ b/conans/test/integration/command_v2/list_package_ids_test.py
@@ -93,7 +93,7 @@ class TestListPackagesFromRemotes(TestListPackageIdsBase):
 
         expected_output = textwrap.dedent("""\
         Local Cache:
-          ERROR: There are no recipes matching the expression 'whatever/0.1#""")
+          There are no packages""")
 
         self.client.run(f"list packages {self._get_fake_recipe_refence('whatever/0.1')}")
         assert expected_output in self.client.out
@@ -106,9 +106,9 @@ class TestListPackagesFromRemotes(TestListPackageIdsBase):
         Local Cache:
           There are no packages
         remote1:
-          There are no packages
+          ERROR: Recipe not found: 'whatever/0.1@_/_#fca0383e6a43348f7989f11ab8f0a92d'. [Remote: remote1]
         remote2:
-          There are no packages
+          ERROR: Recipe not found: 'whatever/0.1@_/_#fca0383e6a43348f7989f11ab8f0a92d'. [Remote: remote2]
         """)
 
         rrev = self._get_fake_recipe_refence('whatever/0.1')
@@ -306,7 +306,8 @@ class TestListPackages:
                 .with_settings("os", "arch").with_shared_option(False)})
         c.run("create dep")
         c.run("create pkg -s os=Windows -s arch=x86")
-        c.run("list packages pkg/2.3.4")
+        # Revision is needed explicitly!
+        c.run("list packages pkg/2.3.4#0fc07368b81b38197adc73ee2cb89da8")
         expected = textwrap.dedent("""\
             Local Cache:
               pkg/2.3.4#0fc07368b81b38197adc73ee2cb89da8:ec080285423a5e38126f0d5d51b524cf516ff7a5

--- a/conans/test/integration/command_v2/list_package_revisions_test.py
+++ b/conans/test/integration/command_v2/list_package_revisions_test.py
@@ -101,9 +101,9 @@ class TestListPackagesFromRemotes(TestListPackageRevisionsBase):
         Local Cache:
           There are no matching package references
         remote1:
-          There are no matching package references
+          ERROR: Recipe not found: 'whatever/0.1@_/_#fca0383e6a43348f7989f11ab8f0a92d'. [Remote: remote1]
         remote2:
-          There are no matching package references
+          ERROR: Recipe not found: 'whatever/0.1@_/_#fca0383e6a43348f7989f11ab8f0a92d'. [Remote: remote2]
         """)
 
         pref = self._get_fake_package_refence('whatever/0.1')
@@ -184,7 +184,7 @@ class TestRemotes(TestListPackageRevisionsBase):
         remote1:
           {pref.repr_notime()}.*
         remote2:
-          There are no matching package references""")
+          ERROR: Recipe not found:*""")
         assert bool(re.match(expected_output, output, re.MULTILINE))
 
     def test_search_in_missing_remote(self):

--- a/conans/test/integration/command_v2/list_recipe_revisions_test.py
+++ b/conans/test/integration/command_v2/list_recipe_revisions_test.py
@@ -82,9 +82,9 @@ class TestListRecipesFromRemotes(TestListRecipeRevisionsBase):
         expected_output = ("Local Cache:\n"
                            "  There are no matching recipe references\n"
                            "remote1:\n"
-                           "  There are no matching recipe references\n"
+                           "  ERROR: Recipe not found: 'whatever/1.0@_/_'. [Remote: remote1]\n"
                            "remote2:\n"
-                           "  There are no matching recipe references\n")
+                           "  ERROR: Recipe not found: 'whatever/1.0@_/_'. [Remote: remote2]\n")
 
         self.client.run('list recipe-revisions -r="*" -c whatever/1.0')
         assert expected_output == self.client.out
@@ -151,7 +151,7 @@ class TestRemotes(TestListRecipeRevisionsBase):
 
         expected_output = (
             "remote1:\n"
-            "  There are no matching recipe references\n"
+            "  ERROR: Recipe not found: 'test_recipe/1.0.0@_/_'. [Remote: remote1]\n"
         )
 
         assert expected_output in self.client.out
@@ -163,7 +163,7 @@ class TestRemotes(TestListRecipeRevisionsBase):
             r"remote1:\n"
             r"  test_recipe/1.0.0@user/channel#.*\n"
             r"remote2:\n"
-            r"  There are no matching recipe references\n"
+            r"  ERROR: Recipe not found: 'test_recipe/1.0.0@user/channel'.*\n"
         )
 
         remote1 = "remote1"

--- a/conans/test/integration/command_v2/list_recipes_test.py
+++ b/conans/test/integration/command_v2/list_recipes_test.py
@@ -1,6 +1,6 @@
 import re
 import textwrap
-from unittest.mock import patch, Mock
+from unittest.mock import patch
 
 import pytest
 

--- a/conans/test/integration/editable/forbidden_commands_test.py
+++ b/conans/test/integration/editable/forbidden_commands_test.py
@@ -18,20 +18,20 @@ class TestOtherCommands:
         # Nothing in the cache
         t.run("list recipes *")
         assert "There are no matching recipe references" in t.out
-        t.run('list packages lib/0.1')
+        t.run('list packages lib/0.1#latest')
         assert "There are no recipes" in t.out
 
         t.run('export . ')
         assert "lib/0.1: Exported revision" in t.out
         t.run("list recipes *")
         assert "lib/0.1" in t.out
-        t.run('list packages lib/0.1')
+        t.run('list packages lib/0.1#latest')
         assert "There are no packages" in t.out  # One binary is listed
 
         t.run('export-pkg .')
         assert "lib/0.1: Calling package()" in t.out
 
-        t.run('list packages lib/0.1')
+        t.run('list packages lib/0.1#latest')
         assert "lib/0.1" in t.out  # One binary is listed
 
         t.run('upload lib/0.1 -r default')
@@ -41,7 +41,7 @@ class TestOtherCommands:
         # Nothing in the cache
         t.run("list recipes *")
         assert "There are no matching recipe references" in t.out
-        t.run('list packages lib/0.1')
+        t.run('list packages lib/0.1#latest')
         assert "There are no recipes" in t.out
 
     def test_create_editable(self):


### PR DESCRIPTION
``conan list`` command was creating an empty ``CommandResult`` object just to pass it to the print functions. This can be simplified.

- Removed ``CommandResult``
- Extracted logic of selection of remotes for ``conan list`` commands
- Changed some NotFoundError capturing for real messages, when something that must be there is not found is an error
- Raised an open issue with the latest recipe revision for ``conan list packages`` as with multiple origins it can return results from different revisions? To discuss.