### PR TITLE
Add DCMAKE_BUILD_TYPE to markdown generator instructions

### DIFF
--- a/conans/client/generators/markdown.py
+++ b/conans/client/generators/markdown.py
@@ -149,7 +149,7 @@ buildsystem_cmake_tpl = textwrap.dedent("""
     ```shell
     # for Linux/macOS
     $ conan install . --install-folder cmake-build-release --build=missing
-    $ cmake . -DCMAKE_TOOLCHAIN_FILE=cmake-build-release/conan_toolchain.cmake
+    $ cmake . -DCMAKE_TOOLCHAIN_FILE=cmake-build-release/conan_toolchain.cmake -DCMAKE_BUILD_TYPE=Release
     $ cmake --build .
 
     # for Windows and Visual Studio 2017


### PR DESCRIPTION
Changelog: Fix: Add `-DCMAKE_BUILD_TYPE` to markdown generator instructions for CMake single config.
Docs: omit

After the changes introduced in 1.48 that the toolchain no longer contains the build type these instructions were not correct.

Should we port this to 1.48.1?

