### PR TITLE
Fix hard crash when USERNAME is not set as env variable on Windows

### DIFF
--- a/conans/util/windows.py
+++ b/conans/util/windows.py
@@ -89,7 +89,7 @@ def path_shortener(path, short_paths):
         domainname = "%s\%s" % (userdomain, username) if userdomain else username
         cmd = r'cacls %s /E /G "%s":F' % (short_home, domainname)
         subprocess.check_output(cmd, stderr=subprocess.STDOUT)  # Ignoring any returned output, quiet
-    except (subprocess.CalledProcessError, EnvironmentError):
+    except (subprocess.CalledProcessError, EnvironmentError, KeyError):
         # cmd can fail if trying to set ACL in non NTFS drives, ignoring it.
         pass
 

--- a/conans/util/windows.py
+++ b/conans/util/windows.py
@@ -85,7 +85,7 @@ def path_shortener(path, short_paths):
     # to current user to avoid
     # access problems in cygwin/msys2 windows subsystems when using short_home folder
     try:
-        userdomain, username = os.getenv("USERDOMAIN"), os.environ["USERNAME"]
+        userdomain, username = os.getenv("USERDOMAIN"), os.getenv("USERNAME")
         domainname = "%s\%s" % (userdomain, username) if userdomain else username
         cmd = r'cacls %s /E /G "%s":F' % (short_home, domainname)
         subprocess.check_output(cmd, stderr=subprocess.STDOUT)  # Ignoring any returned output, quiet

--- a/conans/util/windows.py
+++ b/conans/util/windows.py
@@ -85,7 +85,7 @@ def path_shortener(path, short_paths):
     # to current user to avoid
     # access problems in cygwin/msys2 windows subsystems when using short_home folder
     try:
-        userdomain, username = os.getenv("USERDOMAIN"), os.getenv("USERNAME")
+        userdomain, username = os.getenv("USERDOMAIN"), os.environ["USERNAME"]
         domainname = "%s\%s" % (userdomain, username) if userdomain else username
         cmd = r'cacls %s /E /G "%s":F' % (short_home, domainname)
         subprocess.check_output(cmd, stderr=subprocess.STDOUT)  # Ignoring any returned output, quiet


### PR DESCRIPTION
Changelog: Bugfix: Catching `KeyError` if `USERNAME` is not set as env variable on Windows.
Docs: omit
Fixes #11222

using `os.environ` fails on __getitem__ when environmental variable
is not set. ~~Using getenv~~ catching the KeyError ensures it fails
gracefully ensuring that no hard crash occurs.

- [x] Refer to the issue that supports this Pull Request.
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 

<sup>**Note:** By default this PR will skip the slower tests and will use a limited set of python versions. Check [here](https://github.com/conan-io/conan/blob/develop/.github/PR_INCREASE_TESTING.md) how to increase the testing level by writing some tags in the current PR body text.</sup>
