### PR TITLE
fixing clang 13.0 compatibility

### DIFF
--- a/conans/__init__.py
+++ b/conans/__init__.py
@@ -20,4 +20,4 @@ OAUTH_TOKEN = "oauth_token"
 SERVER_CAPABILITIES = [COMPLEX_SEARCH_CAPABILITY, REVISIONS]  # Server is always with revisions
 DEFAULT_REVISION_V1 = "0"
 
-__version__ = '1.48.0'
+__version__ = '1.48.1'

--- a/conans/client/migrations_settings.py
+++ b/conans/client/migrations_settings.py
@@ -3556,3 +3556,4 @@ cppstd: [None, 98, gnu98, 11, gnu11, 14, gnu14, 17, gnu17, 20, gnu20, 23, gnu23]
 """
 
 settings_1_48_0 = settings_1_47_0
+settings_1_48_1 = settings_1_48_0

--- a/conans/model/info.py
+++ b/conans/model/info.py
@@ -603,7 +603,7 @@ class ConanInfo(object):
         # https://github.com/conan-io/conan/pull/10797
         # apple-clang compiler version 13 will be compatible with 13.0
         if not self.settings.compiler or \
-           (self.settings.compiler != "apple-clang" and self.settings.compiler.version != "13"):
+           (self.settings.compiler != "apple-clang" or self.settings.compiler.version != "13"):
             return
 
         compatible = self.clone()


### PR DESCRIPTION
Changelog: Bugfix: Fixed broken ``apple-clang`` 13.0 compatibility.
Docs: Omit

Close https://github.com/conan-io/conan/issues/11227
Close https://github.com/conan-io/conan/issues/11104