### PR TITLE
Port markdown readme fix to 1.48

### DIFF
--- a/conans/client/generators/markdown.py
+++ b/conans/client/generators/markdown.py
@@ -149,7 +149,7 @@ buildsystem_cmake_tpl = textwrap.dedent("""
     ```shell
     # for Linux/macOS
     $ conan install . --install-folder cmake-build-release --build=missing
-    $ cmake . -DCMAKE_TOOLCHAIN_FILE=cmake-build-release/conan_toolchain.cmake
+    $ cmake . -DCMAKE_TOOLCHAIN_FILE=cmake-build-release/conan_toolchain.cmake -DCMAKE_BUILD_TYPE=Release
     $ cmake --build .
 
     # for Windows and Visual Studio 2017


### PR DESCRIPTION
Changelog: Fix: Add `-DCMAKE_BUILD_TYPE` to markdown generator instructions for CMake single config.
Docs: omit

Port: https://github.com/conan-io/conan/pull/11220 to 1.48