### PR TITLE
Assume only config files are generated in CMakeDeps generator when none is specified

### DIFF
--- a/conan/tools/cmake/utils.py
+++ b/conan/tools/cmake/utils.py
@@ -22,9 +22,9 @@ def get_file_name(conanfile, forced_module_mode=None):
 def get_find_mode(conanfile):
     """
     :param conanfile: conanfile of the requirement
-    :return: "none" or "config" or "module" or "both" or None when not set
+    :return: "none" or "config" or "module" or "both" or "config" when not set
     """
     tmp = conanfile.cpp_info.get_property("cmake_find_mode")
     if tmp is None:
-        return None
+        return "config"
     return tmp.lower()

--- a/conans/test/functional/toolchains/cmake/cmakedeps/test_cmakedeps_find_module_and_config.py
+++ b/conans/test/functional/toolchains/cmake/cmakedeps/test_cmakedeps_find_module_and_config.py
@@ -113,8 +113,17 @@ def test_reuse_with_modules_and_config(client):
     client.run("build . -if=install")
 
 
-@pytest.mark.parametrize("find_mode", ["both", "config", "module"])
-def test_transitive_modules_found(find_mode):
+find_modes = [
+    ("both", "both", ""),
+    ("config", "config", ""),
+    ("module", "module", ""),
+    ("both", None, ""),
+    ("both", None, "MODULE")
+]
+
+
+@pytest.mark.parametrize("find_mode_PKGA, find_mode_PKGB, find_mode_consumer", find_modes)
+def test_transitive_modules_found(find_mode_PKGA, find_mode_PKGB, find_mode_consumer):
     """
     related to https://github.com/conan-io/conan/issues/10224
     modules files variables were set with the pkg_name_FOUND or pkg_name_VERSION
@@ -127,7 +136,8 @@ def test_transitive_modules_found(find_mode):
         class Pkg(ConanFile):
             {requires}
             def package_info(self):
-                self.cpp_info.set_property("cmake_find_mode", "{mode}")
+                if "{mode}" != "None":
+                    self.cpp_info.set_property("cmake_find_mode", "{mode}")
                 self.cpp_info.set_property("cmake_file_name", "{filename}")
                 self.cpp_info.defines.append("DEFINE_{filename}")
             """)
@@ -149,19 +159,20 @@ def test_transitive_modules_found(find_mode):
     cmakelist = textwrap.dedent("""
         cmake_minimum_required(VERSION 3.1)
         project(test_package CXX)
-        find_package(MYPKGB REQUIRED)
-        message("MYPKGB_VERSION: ${MYPKGB_VERSION}")
-        message("MYPKGB_VERSION_STRING: ${MYPKGB_VERSION_STRING}")
-        message("MYPKGB_INCLUDE_DIRS: ${MYPKGB_INCLUDE_DIRS}")
-        message("MYPKGB_INCLUDE_DIR: ${MYPKGB_INCLUDE_DIR}")
-        message("MYPKGB_LIBRARIES: ${MYPKGB_LIBRARIES}")
-        message("MYPKGB_DEFINITIONS: ${MYPKGB_DEFINITIONS}")
+        find_package(MYPKGB REQUIRED {find_mode})
+        message("MYPKGB_VERSION: ${{MYPKGB_VERSION}}")
+        message("MYPKGB_VERSION_STRING: ${{MYPKGB_VERSION_STRING}}")
+        message("MYPKGB_INCLUDE_DIRS: ${{MYPKGB_INCLUDE_DIRS}}")
+        message("MYPKGB_INCLUDE_DIR: ${{MYPKGB_INCLUDE_DIR}}")
+        message("MYPKGB_LIBRARIES: ${{MYPKGB_LIBRARIES}}")
+        message("MYPKGB_DEFINITIONS: ${{MYPKGB_DEFINITIONS}}")
         """)
 
-    client.save({"pkgb.py": conan_pkg.format(requires='requires="pkga/1.0"', filename='MYPKGB', mode=find_mode),
-                 "pkga.py": conan_pkg.format(requires='', filename='MYPKGA', mode=find_mode),
+    client.save({"pkgb.py": conan_pkg.format(requires='requires="pkga/1.0"', filename='MYPKGB',
+                                             mode=find_mode_PKGA),
+                 "pkga.py": conan_pkg.format(requires='', filename='MYPKGA', mode=find_mode_PKGB),
                  "consumer.py": consumer,
-                 "CMakeLists.txt": cmakelist})
+                 "CMakeLists.txt": cmakelist.format(find_mode=find_mode_consumer)})
     client.run("create pkga.py pkga/1.0@")
     client.run("create pkgb.py pkgb/1.0@")
     client.run("create consumer.py consumer/1.0@")
@@ -173,7 +184,5 @@ def test_transitive_modules_found(find_mode):
     assert "MYPKGB_LIBRARIES: pkga::pkga" in client.out
     assert "MYPKGB_DEFINITIONS: -DDEFINE_MYPKGB" in client.out
     assert "Conan: Target declared 'pkga::pkga'"
-    if find_mode == "module":
+    if find_mode_PKGA == "module":
         assert 'Found MYPKGA: 1.0 (found version "1.0")' in client.out
-
-


### PR DESCRIPTION
Changelog: Bugfix: Fix case where CMakeDeps assumes a module dependency when transitive dependencies do not define `cmake_find_mode` and fallback to a config one.

Docs: omit

Fixes https://github.com/conan-io/conan/issues/11201

The `CMakeDeps` generator explicitly specifies the search mode (config or module) for _transitive_ dependencies. It does so by inspecting the value of the `cmake_find_mode` property defined in `package_info()` in the individual packages, as well as whether or not it is generating a config or a module file. When a dependency specifies that both should be generated, the `CMakeDeps` generator will try to align modules to "depend" on modules, and configs to depend on configs.

The issue was that when a transitive dependency does _not_ define a `cmake_find_mode` explicitly, it should be assumed to be `config`, and thus, the transitive `find_dependency` calls should explicitly say `CONFIG` as that's the only one available to be searched for. The generator was working correctly in this case (generating the config when `cmake_find_mode` was not specified), but when encoding the dependency find mode in consumers, it was defaulting to `MODULE` instead of `CONFIG`. This was only causing issues when the direct dependency was consumed as a module instead of a config (as seen [here](https://github.com/conan-io/conan-center-index/pull/10698))

A test has been modified to cover the case when a consumer depends on package B which depends on package A, and package B is consumed from a module when package A only generates a config.