### PR TITLE
Update cmake_layout to use path to generate the  generator folder path

### DIFF
--- a/conan/tools/cmake/layout.py
+++ b/conan/tools/cmake/layout.py
@@ -1,3 +1,5 @@
+import os
+
 from conans.errors import ConanException
 
 
@@ -23,7 +25,7 @@ def cmake_layout(conanfile, generator=None, src_folder="."):
         build_type = build_type.lower()
         conanfile.folders.build = "cmake-build-{}".format(build_type)
 
-    conanfile.folders.generators = "build/generators"
+    conanfile.folders.generators = os.path.join("build", "generators")
     conanfile.cpp.source.includedirs = ["include"]
 
     if multi:


### PR DESCRIPTION
Changelog: Bugfix: Update cmake_layout generators folder to honor os path format.
Docs: omit
closes #11251

- [X] Refer to the issue that supports this Pull Request.
- [X] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [X] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [X] I've followed the PEP8 style guides for Python code.
- [X] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 

<sup>**Note:** By default this PR will skip the slower tests and will use a limited set of python versions. Check [here](https://github.com/conan-io/conan/blob/develop/.github/PR_INCREASE_TESTING.md) how to increase the testing level by writing some tags in the current PR body text.</sup>
