### PR TITLE
[develop2] Upload refactors and better integrity

### DIFF
--- a/conan/api/subapi/upload.py
+++ b/conan/api/subapi/upload.py
@@ -2,7 +2,7 @@ from conan.api.model import UploadBundle
 from conan.api.subapi import api_method
 from conans.cli.conan_app import ConanApp
 from conans.client.cmd.uploader import IntegrityChecker, PackagePreparator, UploadExecutor, \
-    UploadUpstreamChecker, PkgSigning
+    UploadUpstreamChecker
 from conans.errors import ConanException
 
 
@@ -58,13 +58,11 @@ class UploadAPI:
         with the complete information. It doesn't perform the upload nor checks upstream to see
         if the recipe is still there"""
         app = ConanApp(self.conan_api.cache_folder)
-        app.load_remotes()  # Necessary to load remotes, as exports_sources might need to be
-                            # retrieved to prepare the artifacts
+        # Necessary to load remotes, as exports_sources might need to be retrieved to
+        # prepare the artifacts
+        app.load_remotes()
         preparator = PackagePreparator(app)
         preparator.prepare(upload_bundle)
-        # FIXME: POC: Signing all packages to see what breaks
-        signer = PkgSigning(app)
-        signer.sign(upload_bundle)
 
     @api_method
     def upload_bundle(self, upload_bundle, remote):

--- a/conan/cache/conan_reference_layout.py
+++ b/conan/cache/conan_reference_layout.py
@@ -65,8 +65,13 @@ class RecipeLayout(LayoutBase):
     def conandata(self):
         return os.path.join(self.export(), DATA_YML)
 
-    def recipe_manifest(self):
-        return FileTreeManifest.load(self.export())
+    def recipe_manifests(self):
+        # Used for comparison and integrity check
+        export_folder = self.export()
+        readed_manifest = FileTreeManifest.load(export_folder)
+        exports_source_folder = self.export_sources()
+        expected_manifest = FileTreeManifest.create(export_folder, exports_source_folder)
+        return readed_manifest, expected_manifest
 
     def sources_remove(self):
         src_folder = self.source()

--- a/conans/cli/commands/upload.py
+++ b/conans/cli/commands/upload.py
@@ -55,6 +55,8 @@ def upload(conan_api: ConanAPIV2, parser, *args):
 
     if not upload_bundle.any_upload:
         return
+
+    conan_api.upload.prepare(upload_bundle)
     conan_api.upload.upload_bundle(upload_bundle, remote)
 
 

--- a/conans/client/cmd/uploader.py
+++ b/conans/client/cmd/uploader.py
@@ -250,40 +250,6 @@ class PackagePreparator:
                 CONAN_MANIFEST: files[CONAN_MANIFEST]}
 
 
-class PkgSigning:
-    def __init__(self, app: ConanApp):
-        self._app = app
-
-    def sign(self, upload_data):
-        print("Signing")
-        for recipe in upload_data.recipes:
-            if recipe.upload:
-                self.sign_recipe(recipe)
-            for package in recipe.packages:
-                if package.upload:
-                    self.sign_package(package)
-
-    def sign_recipe(self, recipe):
-        ref = recipe.ref
-        print("SINGING RECIPE ", ref)
-        ref_layout = self._app.cache.ref_layout(ref)
-        download_export_folder = ref_layout.download_export()
-        signature_file = os.path.join(download_export_folder, "signature.asc")
-        content = "\n".join(recipe.files)
-        save(signature_file, content)
-        recipe.files["signature.asc"] = signature_file
-
-    def sign_package(self, package):
-        pref = package.pref
-        print("SINGING package ", pref)
-        pkg_layout = self._app.cache.pkg_layout(pref)
-        download_pkg_folder = pkg_layout.download_package()
-        signature_file = os.path.join(download_pkg_folder, "signature.asc")
-        content = "\n".join(package.files)
-        save(signature_file, content)
-        package.files["signature.asc"] = signature_file
-
-
 class UploadExecutor:
     """ does the actual file transfer to the remote. The files to be uploaded have already
     been computed and are passed in the ``upload_data`` parameter, so this executor is also

--- a/conans/test/integration/command/upload/upload_complete_test.py
+++ b/conans/test/integration/command/upload/upload_complete_test.py
@@ -153,7 +153,7 @@ class UploadTest(unittest.TestCase):
         client.run("install --requires=hello0/1.2.1@frodo/stable --build='*' -r default")
         self._set_global_conf(client, retry=3, retry_wait=0)
         client.run("upload hello* --confirm -r default")
-        self.assertEqual(str(client.out).count("ERROR: Pair file, error!"), 7)
+        self.assertEqual(str(client.out).count("ERROR: Pair file, error!"), 5)
 
     def _set_global_conf(self, client, retry=None, retry_wait=None):
         lines = []
@@ -210,7 +210,7 @@ class UploadTest(unittest.TestCase):
         client.run("install --requires=hello0/1.2.1@frodo/stable --build='*'")
         self._set_global_conf(client, retry=3, retry_wait=0)
         client.run("upload hello* --confirm -r default")
-        self.assertEqual(str(client.out).count("ERROR: Pair file, error!"), 7)
+        self.assertEqual(str(client.out).count("ERROR: Pair file, error!"), 5)
 
     def test_upload_same_package_dont_compress(self):
         client = self._get_client()

--- a/conans/test/integration/command/upload/upload_complete_test.py
+++ b/conans/test/integration/command/upload/upload_complete_test.py
@@ -153,7 +153,7 @@ class UploadTest(unittest.TestCase):
         client.run("install --requires=hello0/1.2.1@frodo/stable --build='*' -r default")
         self._set_global_conf(client, retry=3, retry_wait=0)
         client.run("upload hello* --confirm -r default")
-        self.assertEqual(str(client.out).count("ERROR: Pair file, error!"), 5)
+        self.assertEqual(str(client.out).count("ERROR: Pair file, error!"), 7)
 
     def _set_global_conf(self, client, retry=None, retry_wait=None):
         lines = []
@@ -210,7 +210,7 @@ class UploadTest(unittest.TestCase):
         client.run("install --requires=hello0/1.2.1@frodo/stable --build='*'")
         self._set_global_conf(client, retry=3, retry_wait=0)
         client.run("upload hello* --confirm -r default")
-        self.assertEqual(str(client.out).count("ERROR: Pair file, error!"), 5)
+        self.assertEqual(str(client.out).count("ERROR: Pair file, error!"), 7)
 
     def test_upload_same_package_dont_compress(self):
         client = self._get_client()

--- a/conans/test/integration/command/upload/upload_test.py
+++ b/conans/test/integration/command/upload/upload_test.py
@@ -255,9 +255,9 @@ class UploadTest(unittest.TestCase):
         save(os.path.join(package_folder, "added.txt"), "")
         os.remove(os.path.join(package_folder, "include/hello.h"))
         client.run("upload hello0/1.2.1@frodo/stable --check -r default", assert_error=True)
-        self.assertIn("WARN: Mismatched checksum 'added.txt'", client.out)
-        self.assertIn("WARN: Mismatched checksum 'include/hello.h'", client.out)
-        self.assertIn("Cannot upload corrupted package", client.out)
+        self.assertIn("ERROR:     'include/hello.h'", client.out)
+        self.assertIn("ERROR:     'added.txt'", client.out)
+        self.assertIn("ERROR: There are corrupted artifacts, check the error logs", client.out)
 
     def test_upload_modified_recipe(self):
         client = TestClient(default_server_user=True)
@@ -276,7 +276,7 @@ class UploadTest(unittest.TestCase):
         client2.run("export . --user=frodo --channel=stable")
         ref = RecipeReference.loads("hello0/1.2.1@frodo/stable")
         latest_rrev = client2.cache.get_latest_recipe_reference(ref)
-        manifest = client2.cache.ref_layout(latest_rrev).recipe_manifest()
+        manifest, _ = client2.cache.ref_layout(latest_rrev).recipe_manifests()
         manifest.time += 10
         manifest.save(client2.cache.ref_layout(latest_rrev).export())
         client2.run("upload hello0/1.2.1@frodo/stable -r default")
@@ -304,7 +304,7 @@ class UploadTest(unittest.TestCase):
         client2.run("export . --user=frodo --channel=stable")
         ref = RecipeReference.loads("hello0/1.2.1@frodo/stable")
         rrev2 = client2.cache.get_latest_recipe_reference(ref)
-        manifest = client2.cache.ref_layout(rrev2).recipe_manifest()
+        manifest, _ = client2.cache.ref_layout(rrev2).recipe_manifests()
         manifest.time += 10
         manifest.save(client2.cache.ref_layout(rrev2).export())
         client2.run("upload hello0/1.2.1@frodo/stable -r default")


### PR DESCRIPTION
- Removed dead code in upload model
- Integrity improvements:
   - Checking recipe integrity too
   - Checking all packages and recipes not failing only at the first error
   - Better output of differences, printing folder and tabs
- Calling ``conan_api.upload.prepare(upload_bundle)`` directly from ``cmd``, not indirectly within the API
- Added some docstrings