### PR TITLE
[CMake] Adding CMAKE_PROGRAM env variable

### DIFF
--- a/conan/tools/cmake/cmake.py
+++ b/conan/tools/cmake/cmake.py
@@ -1,11 +1,10 @@
 import os
-import platform
 
 from conan.tools.build import build_jobs
 from conan.tools.cmake.presets import load_cmake_presets, get_configure_preset
 from conan.tools.cmake.utils import is_multi_configuration
+from conan.tools.env import VirtualBuildEnv
 from conan.tools.files import chdir, mkdir
-from conan.tools.files.files import load_toolchain_args
 from conan.tools.microsoft.msbuild import msbuild_verbosity_cmd_line_arg
 from conans.client.tools.oss import args_to_string
 from conans.errors import ConanException
@@ -61,7 +60,8 @@ class CMake(object):
         self._toolchain_file = configure_preset["toolchainFile"]
         self._cache_variables = configure_preset["cacheVariables"]
 
-        self._cmake_program = "cmake"  # Path to CMake should be handled by environment
+        build_env = VirtualBuildEnv(self._conanfile).vars()
+        self._cmake_program = build_env.get("CMAKE_PROGRAM", default="cmake")
 
     def configure(self, variables=None, build_script_folder=None):
         cmakelist_folder = self._conanfile.source_folder

--- a/conans/test/functional/toolchains/cmake/test_cmake.py
+++ b/conans/test/functional/toolchains/cmake/test_cmake.py
@@ -45,7 +45,9 @@ def test_simple_cmake_mingw():
 def test_cmake_and_cmake_program_env_var():
     client = TestClient()
     client.run("new hello/1.0 -m cmake_lib")
-    cmake_path = client.run_command("which cmake")
+    client.run_command("which cmake")
+    cmake_path = str(client.out).splitlines()[0]
+
     client.save({"cmake_program": """
         include(default)
 

--- a/conans/test/functional/toolchains/cmake/test_cmake.py
+++ b/conans/test/functional/toolchains/cmake/test_cmake.py
@@ -41,6 +41,21 @@ def test_simple_cmake_mingw():
 
 
 @pytest.mark.tool_cmake
+@pytest.mark.skipif(platform.system() == "Windows", reason="Needs UNIX")
+def test_cmake_and_cmake_program_env_var():
+    client = TestClient()
+    client.run("new hello/1.0 -m cmake_lib")
+    cmake_path = client.run_command("which cmake")
+    client.save({"cmake_program": """
+        include(default)
+
+        [buildenv]
+        CMAKE_PROGRAM={}
+        """.format(cmake_path)})
+    client.run("create . --profile=cmake_program")
+
+
+@pytest.mark.tool_cmake
 class Base(unittest.TestCase):
 
     conanfile = textwrap.dedent(r"""


### PR DESCRIPTION
Changelog: Feature: Reading `CMAKE_PROGRAM` variable from build environment in `conan.tools.cmake.CMake`.
Docs: https://github.com/conan-io/docs/pull/XXXX
Closes: https://github.com/conan-io/conan/issues/11177