### PR TITLE
propose check_min_vs()

### DIFF
--- a/conan/tools/microsoft/__init__.py
+++ b/conan/tools/microsoft/__init__.py
@@ -1,6 +1,7 @@
-from conan.tools.microsoft.toolchain import MSBuildToolchain
+from conan.tools.microsoft.layout import vs_layout
 from conan.tools.microsoft.msbuild import MSBuild
 from conan.tools.microsoft.msbuilddeps import MSBuildDeps
-from conan.tools.microsoft.visual import msvc_runtime_flag, VCVars, is_msvc, is_msvc_static_runtime
-from conan.tools.microsoft.layout import vs_layout
 from conan.tools.microsoft.subsystems import unix_path
+from conan.tools.microsoft.toolchain import MSBuildToolchain
+from conan.tools.microsoft.visual import msvc_runtime_flag, VCVars, is_msvc, \
+    is_msvc_static_runtime, check_min_vs

--- a/conan/tools/microsoft/visual.py
+++ b/conan/tools/microsoft/visual.py
@@ -2,9 +2,37 @@ import os
 import textwrap
 
 from conans.client.tools import vs_installation_path
-from conans.errors import ConanException
+from conans.client.tools.version import Version
+from conans.errors import ConanException, ConanInvalidConfiguration
 
 CONAN_VCVARS_FILE = "conanvcvars.bat"
+
+
+def check_min_vs(conanfile, version):
+    """ this is a helper method to allow the migration of 1.X->2.0 and VisualStudio->msvc settings
+    withoug breaking recipes
+    The legacy "Visual Studio" with different toolset is not managed, not worth the complexity
+    """
+    compiler = conanfile.settings.get_safe("compiler")
+    compiler_version = None
+    if compiler == "Visual Studio":
+        compiler_version = conanfile.settings.get_safe("compiler.version")
+        compiler_version = {"17": "193",
+                            "16": "192",
+                            "15": "191",
+                            "14": "190",
+                            "12": "180",
+                            "11": "170"}.get(compiler_version)
+    elif compiler == "msvc":
+        compiler_version = conanfile.settings.get_safe("compiler.version")
+        compiler_update = conanfile.settings.get_safe("compiler.update")
+        if compiler_version and compiler_update is not None:
+            compiler_version += ".{}".format(compiler_update)
+
+    if compiler_version and Version(compiler_version) < version:
+        msg = "This package doesn't work with VS compiler version '{}'" \
+              ", it requires at least '{}'".format(compiler_version, version)
+        raise ConanInvalidConfiguration(msg)
 
 
 def msvc_version_to_vs_ide_version(version):

--- a/conans/test/unittests/tools/microsoft/test_check_min_vs.py
+++ b/conans/test/unittests/tools/microsoft/test_check_min_vs.py
@@ -1,0 +1,39 @@
+import pytest
+
+from conan.tools.microsoft import check_min_vs
+from conans.errors import ConanInvalidConfiguration
+from conans.test.utils.mocks import MockConanfile, MockSettings
+
+
+class TestCheckMinVS:
+
+    @staticmethod
+    def _create_conanfile(compiler, version, update=None):
+        settings = MockSettings({"compiler": compiler,
+                                 "compiler.version": version,
+                                 "compiler.update": update})
+        conanfile = MockConanfile(settings)
+        return conanfile
+
+    @pytest.mark.parametrize("compiler,version,update,minimum", [
+        ("Visual Studio", "15", None, "191"),
+        ("Visual Studio", "16", None, "192"),
+        ("msvc", "193", None, "193"),
+        ("msvc", "193", None, "192"),
+        ("msvc", "193", "2", "193.1"),
+    ])
+    def test_valid(self, compiler, version, update, minimum):
+        conanfile = self._create_conanfile(compiler, version, update)
+        check_min_vs(conanfile, minimum)
+
+    @pytest.mark.parametrize("compiler,version,update,minimum", [
+        ("Visual Studio", "15", None, "192"),
+        ("Visual Studio", "16", None, "193.1"),
+        ("msvc", "192", None, "193"),
+        ("msvc", "193", None, "193.1"),
+        ("msvc", "193", "1", "193.2"),
+    ])
+    def test_invalid(self, compiler, version, update, minimum):
+        conanfile = self._create_conanfile(compiler, version, update)
+        with pytest.raises(ConanInvalidConfiguration):
+            check_min_vs(conanfile, minimum)


### PR DESCRIPTION
Changelog: Feature: Implement a ``check_min_vs()`` checker that will work for both ``Visual Studio`` and ``msvc`` to allow migration from 1.X to 2.0
Docs: https://github.com/conan-io/docs/pull/2555

Close https://github.com/conan-io/conan/issues/11158
