### PR TITLE
Add error if missing CMAKE_BUILD_TYPE when invoking CMake

### DIFF
--- a/conan/tools/cmake/cmakedeps/templates/config.py
+++ b/conan/tools/cmake/cmakedeps/templates/config.py
@@ -45,6 +45,13 @@ class ConfigTemplate(CMakeDepsFileTemplate):
             message(FATAL_ERROR "The 'CMakeDeps' generator only works with CMake >= 3.15")
         endif()
 
+        # Check that the -DCMAKE_BUILD_TYPE argument is always present
+        get_property(isMultiConfig GLOBAL PROPERTY GENERATOR_IS_MULTI_CONFIG)
+        if(NOT isMultiConfig AND NOT CMAKE_BUILD_TYPE)
+            message(FATAL_ERROR "Please, set the CMAKE_BUILD_TYPE variable when calling to CMake "
+                                "adding the '-DCMAKE_BUILD_TYPE=<build_type>' argument.")
+        endif()
+
         {% if is_module %}
         include(FindPackageHandleStandardArgs)
         set({{ file_name }}_FOUND 1)

--- a/conan/tools/cmake/cmakedeps/templates/config.py
+++ b/conan/tools/cmake/cmakedeps/templates/config.py
@@ -45,13 +45,6 @@ class ConfigTemplate(CMakeDepsFileTemplate):
             message(FATAL_ERROR "The 'CMakeDeps' generator only works with CMake >= 3.15")
         endif()
 
-        # Check that the -DCMAKE_BUILD_TYPE argument is always present
-        get_property(isMultiConfig GLOBAL PROPERTY GENERATOR_IS_MULTI_CONFIG)
-        if(NOT isMultiConfig AND NOT CMAKE_BUILD_TYPE)
-            message(FATAL_ERROR "Please, set the CMAKE_BUILD_TYPE variable when calling to CMake "
-                                "adding the '-DCMAKE_BUILD_TYPE=<build_type>' argument.")
-        endif()
-
         {% if is_module %}
         include(FindPackageHandleStandardArgs)
         set({{ file_name }}_FOUND 1)
@@ -66,6 +59,8 @@ class ConfigTemplate(CMakeDepsFileTemplate):
         include(${CMAKE_CURRENT_LIST_DIR}/cmakedeps_macros.cmake)
         include(${CMAKE_CURRENT_LIST_DIR}/{{ targets_include_file }})
         include(CMakeFindDependencyMacro)
+
+        check_build_type_defined()
 
         foreach(_DEPENDENCY {{ '${' + pkg_name + '_FIND_DEPENDENCY_NAMES' + '}' }} )
             # Check that we have not already called a find_package with the transitive dependency

--- a/conan/tools/cmake/cmakedeps/templates/macros.py
+++ b/conan/tools/cmake/cmakedeps/templates/macros.py
@@ -88,4 +88,14 @@ class MacrosTemplate(CMakeDepsFileTemplate):
            set(${out_libraries} ${_out_libraries} PARENT_SCOPE)
            set(${out_libraries_target} ${_out_libraries_target} PARENT_SCOPE)
        endfunction()
+
+       macro(check_build_type_defined)
+           # Check that the -DCMAKE_BUILD_TYPE argument is always present
+           get_property(isMultiConfig GLOBAL PROPERTY GENERATOR_IS_MULTI_CONFIG)
+           if(NOT isMultiConfig AND NOT CMAKE_BUILD_TYPE)
+               message(FATAL_ERROR "Please, set the CMAKE_BUILD_TYPE variable when calling to CMake "
+                                   "adding the '-DCMAKE_BUILD_TYPE=<build_type>' argument.")
+           endif()
+       endmacro()
+
         """)

--- a/conans/test/functional/toolchains/cmake/cmakedeps/test_build_context_transitive_build.py
+++ b/conans/test/functional/toolchains/cmake/cmakedeps/test_build_context_transitive_build.py
@@ -72,7 +72,7 @@ def test_zlib_not_included(client):
                 clean_first=True)
     client.run("install . -pr:h=default -pr:b=default")
     # The compilation works, so it finds the doxygen without transitive failures
-    client.run_command("cmake . -DCMAKE_TOOLCHAIN_FILE=conan_toolchain.cmake")
+    client.run_command("cmake . -DCMAKE_TOOLCHAIN_FILE=conan_toolchain.cmake -DCMAKE_BUILD_TYPE=Release")
 
     # Assert there is no zlib target
     assert "Target declared 'zlib::zlib'" not in client.out

--- a/conans/test/functional/toolchains/cmake/cmakedeps/test_cmakedeps.py
+++ b/conans/test/functional/toolchains/cmake/cmakedeps/test_cmakedeps.py
@@ -427,7 +427,13 @@ def test_error_missing_build_type():
     }, clean_first=True)
 
     client.run("install .")
-    client.run_command("cmake . -DCMAKE_TOOLCHAIN_FILE=conan_toolchain.cmake -G Xcode")
+
+    generator = {
+        "Windows": '-G "Visual Studio 15 Win64"',
+        "Darwin": '-G "Xcode"',
+        "Linux": '-G "Ninja Multi-Config"'
+    }.get(platform.system())
+
+    client.run_command("cmake . -DCMAKE_TOOLCHAIN_FILE=conan_toolchain.cmake {}".format(generator))
     client.run_command("cmake --build . --config Release")
-    client.run_command("./Release/app")
-    assert "Hello World Release!" in client.out
+    assert "BUILD SUCCEEDED" in client.out

--- a/conans/test/functional/toolchains/cmake/cmakedeps/test_cmakedeps.py
+++ b/conans/test/functional/toolchains/cmake/cmakedeps/test_cmakedeps.py
@@ -437,5 +437,5 @@ def test_error_missing_build_type():
 
     client.run_command("cmake . -DCMAKE_TOOLCHAIN_FILE=conan_toolchain.cmake {}".format(generator))
     client.run_command("cmake --build . --config Release")
-
-    assert ("BUILD SUCCEEDED" in client.out or "Build succeeded" in client.out)
+    client.run_command("./Release/app")
+    assert "Hello World Release!" in client.out

--- a/conans/test/functional/toolchains/cmake/cmakedeps/test_cmakedeps.py
+++ b/conans/test/functional/toolchains/cmake/cmakedeps/test_cmakedeps.py
@@ -436,9 +436,6 @@ def test_error_missing_build_type():
     }.get(platform.system())
 
     client.run_command("cmake . -DCMAKE_TOOLCHAIN_FILE=conan_toolchain.cmake {}".format(generator))
-    if platform.system() in ["Windows", "Darwin"]:
-        client.run_command("cmake --build . --config Release")
-    else:
-        client.run_command("cmake --build .")
+    client.run_command("cmake --build . --config Release")
 
-    assert "BUILD SUCCEEDED" in client.out
+    assert ("BUILD SUCCEEDED" in client.out or "Build succeeded" in client.out)

--- a/conans/test/functional/toolchains/cmake/cmakedeps/test_cmakedeps.py
+++ b/conans/test/functional/toolchains/cmake/cmakedeps/test_cmakedeps.py
@@ -410,15 +410,16 @@ def test_error_missing_build_type():
         target_sources(app PRIVATE main.cpp)
     """)
 
-    client.save({
-        "conanfile.txt": conanfile,
-        "main.cpp": main,
-        "CMakeLists.txt": cmakelists
-    }, clean_first=True)
+    if platform.system() != "Windows":
+        client.save({
+            "conanfile.txt": conanfile,
+            "main.cpp": main,
+            "CMakeLists.txt": cmakelists
+        }, clean_first=True)
 
-    client.run("install .")
-    client.run_command("cmake . -DCMAKE_TOOLCHAIN_FILE=conan_toolchain.cmake", assert_error=True)
-    assert "Please, set the CMAKE_BUILD_TYPE variable when calling to CMake" in client.out
+        client.run("install .")
+        client.run_command("cmake . -DCMAKE_TOOLCHAIN_FILE=conan_toolchain.cmake -G 'Unix Makefiles'", assert_error=True)
+        assert "Please, set the CMAKE_BUILD_TYPE variable when calling to CMake" in client.out
 
     client.save({
         "conanfile.txt": conanfile,
@@ -435,5 +436,9 @@ def test_error_missing_build_type():
     }.get(platform.system())
 
     client.run_command("cmake . -DCMAKE_TOOLCHAIN_FILE=conan_toolchain.cmake {}".format(generator))
-    client.run_command("cmake --build . --config Release")
+    if platform.system() in ["Windows", "Darwin"]:
+        client.run_command("cmake --build . --config Release")
+    else:
+        client.run_command("cmake --build .")
+
     assert "BUILD SUCCEEDED" in client.out

--- a/conans/test/functional/toolchains/cmake/cmakedeps/test_cmakedeps.py
+++ b/conans/test/functional/toolchains/cmake/cmakedeps/test_cmakedeps.py
@@ -437,5 +437,6 @@ def test_error_missing_build_type():
 
     client.run_command("cmake . -DCMAKE_TOOLCHAIN_FILE=conan_toolchain.cmake {}".format(generator))
     client.run_command("cmake --build . --config Release")
-    client.run_command("./Release/app")
+    run_app = r".\Release\app.exe" if platform.system() == "Windows" else "./Release/app"
+    client.run_command(run_app)
     assert "Hello World Release!" in client.out

--- a/conans/test/functional/toolchains/cmake/cmakedeps/test_cmakedeps.py
+++ b/conans/test/functional/toolchains/cmake/cmakedeps/test_cmakedeps.py
@@ -380,7 +380,7 @@ def test_system_dep():
         assert 'set(ZLIB_FIND_MODE "")' in contents
 
 
-@pytest.mark.tool_cmake
+@pytest.mark.tool_cmake(version="3.19")
 def test_error_missing_build_type():
     # https://github.com/conan-io/conan/issues/11168
     client = TestClient()
@@ -430,7 +430,7 @@ def test_error_missing_build_type():
     client.run("install .")
 
     generator = {
-        "Windows": '-G "Visual Studio 15 Win64"',
+        "Windows": '-G "Visual Studio 15 2017"',
         "Darwin": '-G "Xcode"',
         "Linux": '-G "Ninja Multi-Config"'
     }.get(platform.system())

--- a/conans/test/functional/toolchains/cmake/test_cmake_toolchain.py
+++ b/conans/test/functional/toolchains/cmake/test_cmake_toolchain.py
@@ -240,8 +240,9 @@ def test_cmaketoolchain_no_warnings():
 
     client.run("create dep")
     client.run("install .")
-    client.run_command("cmake . -DCMAKE_TOOLCHAIN_FILE=./conan_toolchain.cmake -DCMAKE_BUILD_TYPE=Release"
-                       "-Werror=dev --warn-uninitialized")
+    build_type = "-DCMAKE_BUILD_TYPE=Release" if platform.system() != "Windows" else ""
+    client.run_command("cmake . -DCMAKE_TOOLCHAIN_FILE=./conan_toolchain.cmake {}"
+                       "-Werror=dev --warn-uninitialized".format(build_type))
     assert "Using Conan toolchain" in client.out
     # The real test is that there are no errors, it returns successfully
 

--- a/conans/test/functional/toolchains/cmake/test_cmake_toolchain.py
+++ b/conans/test/functional/toolchains/cmake/test_cmake_toolchain.py
@@ -240,7 +240,7 @@ def test_cmaketoolchain_no_warnings():
 
     client.run("create dep")
     client.run("install .")
-    client.run_command("cmake . -DCMAKE_TOOLCHAIN_FILE=./conan_toolchain.cmake "
+    client.run_command("cmake . -DCMAKE_TOOLCHAIN_FILE=./conan_toolchain.cmake -DCMAKE_BUILD_TYPE=Release"
                        "-Werror=dev --warn-uninitialized")
     assert "Using Conan toolchain" in client.out
     # The real test is that there are no errors, it returns successfully

--- a/conans/test/functional/toolchains/cmake/test_cmaketoolchain_paths.py
+++ b/conans/test/functional/toolchains/cmake/test_cmaketoolchain_paths.py
@@ -29,7 +29,8 @@ find_root_path_modes_cross_build = _FindRootPathModes(
 
 
 def _cmake_command_toolchain(find_root_path_modes):
-    cmake_command = "cmake .. -DCMAKE_TOOLCHAIN_FILE=../conan_toolchain.cmake -DCMAKE_BUILD_TYPE=Release"
+    build_type = "-DCMAKE_BUILD_TYPE=Release" if platform.system() != "Windows" else ""
+    cmake_command = "cmake .. -DCMAKE_TOOLCHAIN_FILE=../conan_toolchain.cmake {}".format(build_type)
     if find_root_path_modes.package:
         cmake_command += " -DCMAKE_FIND_ROOT_PATH_MODE_PACKAGE={}".format(find_root_path_modes.package)
     if find_root_path_modes.library:

--- a/conans/test/functional/toolchains/cmake/test_cmaketoolchain_paths.py
+++ b/conans/test/functional/toolchains/cmake/test_cmaketoolchain_paths.py
@@ -29,7 +29,7 @@ find_root_path_modes_cross_build = _FindRootPathModes(
 
 
 def _cmake_command_toolchain(find_root_path_modes):
-    cmake_command = "cmake .. -DCMAKE_TOOLCHAIN_FILE=../conan_toolchain.cmake"
+    cmake_command = "cmake .. -DCMAKE_TOOLCHAIN_FILE=../conan_toolchain.cmake -DCMAKE_BUILD_TYPE=Release"
     if find_root_path_modes.package:
         cmake_command += " -DCMAKE_FIND_ROOT_PATH_MODE_PACKAGE={}".format(find_root_path_modes.package)
     if find_root_path_modes.library:


### PR DESCRIPTION
Changelog: Feature: Raise an error when running CMake if CMAKE_BUILD_TYPE is not defined and the generator is not multi-config.
Docs: https://github.com/conan-io/docs/pull/2557

I initially thought about making this a warning, but I think that throwing an error makes more sense, as having no build type will not work for unexpected reasons...

Closes: https://github.com/conan-io/conan/issues/11168