### PR TITLE
[develop2] adding `options_description` test and improve ``conan inspect``

### DIFF
--- a/conans/cli/commands/inspect.py
+++ b/conans/cli/commands/inspect.py
@@ -3,7 +3,6 @@ import inspect as python_inspect
 
 from conans.cli.command import conan_command, COMMAND_GROUPS, conan_subcommand
 from conans.cli.output import ConanOutput
-from conans.errors import ConanException
 
 
 def _inspect_json_formatter(data):
@@ -34,6 +33,13 @@ def inspect_path(conan_api, parser, subparser, *args, **kwargs):
            or python_inspect.isfunction(value) or isinstance(value, property):
             continue
         ret[name] = value
-        out.writeln("{}: {}".format(name, value))
+        if value is None:
+            continue
+        if isinstance(value, dict):
+            out.writeln(f"{name}:")
+            for k, v in value.items():
+                out.writeln(f"    {k}: {v}")
+        else:
+            out.writeln("{}: {}".format(name, value))
 
     return ret

--- a/conans/test/integration/command_v2/test_inspect.py
+++ b/conans/test/integration/command_v2/test_inspect.py
@@ -1,4 +1,5 @@
 import json
+import textwrap
 
 from conans.test.assets.genconanfile import GenConanfile
 from conans.test.utils.tools import TestClient
@@ -9,29 +10,29 @@ def test_basic_inspect():
     t.save({"foo/conanfile.py": GenConanfile().with_name("foo").with_shared_option()})
     t.run("inspect path foo/conanfile.py")
     lines = t.out.splitlines()
-    assert lines == ['author: None',
-                     'build_policy: None',
-                     'channel: None',
-                     "default_options: {'shared': False}",
-                     'deprecated: None',
-                     'description: None',
-                     'exports: None',
-                     'exports_sources: None',
+    assert lines == ["default_options:",
+                     "    shared: False",
                      'generators: []',
-                     'homepage: None',
-                     'license: None',
                      'name: foo',
-                     "options: {'shared': [True, False]}",
-                     'package_type: None',
-                     'provides: None',
+                     "options:",
+                     "    shared: [True, False]",
                      'revision_mode: hash',
-                     'settings: None',
-                     'tested_reference_str: None',
-                     'topics: None',
-                     'url: None',
-                     'user: None',
-                     'version: None',
-                     'win_bash: None']
+                     ]
+
+
+def test_options_description():
+    t = TestClient()
+    conanfile = textwrap.dedent("""\
+        from conan import ConanFile
+        class Pkg(ConanFile):
+            options = {"shared": [True, False, None], "fpic": [True, False, None]}
+            options_description = {"shared": "Some long explanation about shared option",
+                                   "fpic": "Yet another long explanation of fpic"}
+            """)
+    t.save({"foo/conanfile.py": conanfile})
+    t.run("inspect path foo/conanfile.py")
+    assert "shared: Some long explanation about shared option" in t.out
+    assert "fpic: Yet another long explanation of fpic" in t.out
 
 
 def test_missing_conanfile():
@@ -46,4 +47,3 @@ def test_json():
     t.run("inspect path foo/conanfile.py --format json")
     assert json.loads(t.stdout)["name"] == "foo"
     assert json.loads(t.stdout)["options"] == {"shared": [True, False]}
-


### PR DESCRIPTION
Close https://github.com/conan-io/conan/issues/11108

A couple of improvements. The readability of the output of ``conan inspect`` was poor, I have suggested:
- Hide ``None`` values
- List ``dicts`` as nested ``key: value`` pairs

So ``conan inspect`` shows:
```
generators: []
options:
    shared: [True, False, None]
    fpic: [True, False, None]
options_description:
    shared: Some long explanation about shared option
    fpic: Yet another long explanation of fpic
revision_mode: hash
```
instead of
```
author: None
build_policy: None
channel: None
default_options: None
deprecated: None
description: None
exports: None
exports_sources: None
generators: []
homepage: None
license: None
name: None
options: {'shared': [True, False, None], 'fpic': [True, False, None]}
options_description: {'shared': 'Some long explanation about shared option', 'fpic': 'Yet another long explanation of fpic'}
package_type: None
provides: None
revision_mode: hash
settings: None
tested_reference_str: None
topics: None
url: None
user: None
version: None
win_bash: None
```


