### PR TITLE
avoid empty paths in runenv

### DIFF
--- a/conan/tools/env/virtualrunenv.py
+++ b/conan/tools/env/virtualrunenv.py
@@ -11,19 +11,17 @@ def runenv_from_cpp_info(conanfile, dep, os_name):
 
     cpp_info = dep.cpp_info.aggregated_components()
 
-    def _handle_paths(paths):
-        return [p for p in paths if os.path.exists(p)]
+    def _prepend_path(envvar, paths):
+        existing = [p for p in paths if os.path.exists(p)] if paths else None
+        if existing:
+            dyn_runenv.prepend_path(envvar, existing)
 
-    if cpp_info.bindirs:  # cpp_info.exes is not defined yet
-        dyn_runenv.prepend_path("PATH", _handle_paths(cpp_info.bindirs))
+    _prepend_path("PATH", cpp_info.bindirs)
     # If it is a build_require this will be the build-os, otherwise it will be the host-os
     if os_name and not os_name.startswith("Windows"):
-        if cpp_info.libdirs:
-            libdirs = _handle_paths(cpp_info.libdirs)
-            dyn_runenv.prepend_path("LD_LIBRARY_PATH", libdirs)
-            dyn_runenv.prepend_path("DYLD_LIBRARY_PATH", libdirs)
-        if cpp_info.frameworkdirs:
-            dyn_runenv.prepend_path("DYLD_FRAMEWORK_PATH", _handle_paths(cpp_info.frameworkdirs))
+        _prepend_path("LD_LIBRARY_PATH", cpp_info.libdirs)
+        _prepend_path("DYLD_LIBRARY_PATH", cpp_info.libdirs)
+        _prepend_path("DYLD_FRAMEWORK_PATH", cpp_info.frameworkdirs)
     return dyn_runenv
 
 

--- a/conans/test/integration/environment/test_env.py
+++ b/conans/test/integration/environment/test_env.py
@@ -367,6 +367,7 @@ def test_diamond_repeated():
                 self.output.info("MYVAR2: {}!!!".format(runenv.get("MYVAR2")))
                 self.output.info("MYVAR3: {}!!!".format(runenv.get("MYVAR3")))
                 self.output.info("MYVAR4: {}!!!".format(runenv.get("MYVAR4")))
+                env.generate()
        """)
     client = TestClient()
     client.save({"pkga/conanfile.py": pkga,
@@ -385,6 +386,10 @@ def test_diamond_repeated():
     assert "MYVAR2: PkgAValue2 PkgCValue2 PkgBValue2 PkgDValue2!!!" in client.out
     assert "MYVAR3: PkgDValue3 PkgBValue3 PkgCValue3 PkgAValue3!!!" in client.out
     assert "MYVAR4: PkgDValue4!!!" in client.out
+
+    # No settings always sh
+    conanrun = client.load("conanrunenv.sh")
+    assert "PATH" not in conanrun
 
 
 def test_environment_scripts_generated_envvars():


### PR DESCRIPTION
Changelog: Fix: Avoid empty paths in run environments PATH, LD_LIBRARY_PATH, DYLD_LIBRARY_PATH env-vars.
Docs: Omit