### PR TITLE
Try ANSI encoding before Windows-1252 on Windows

### DIFF
--- a/conans/util/files.py
+++ b/conans/util/files.py
@@ -88,7 +88,10 @@ def _detect_encoding(text):
                 return encodings[bom], len(bom)
             except UnicodeDecodeError:
                 continue
-    decoders = ["utf-8", "Windows-1252"]
+    if sys.platform == "win32":
+        decoders = ["utf-8", "mbcs", "Windows-1252"]
+    else:
+        decoders = ["utf-8", "Windows-1252"]
     for decoder in decoders:
         try:
             text.decode(decoder)


### PR DESCRIPTION
Fix #11076

Changelog: Fix: outputs of subprocess using ANSI encoding are not decoded properly
Docs: no doc describes this part of Conan

- [x] Refer to the issue that supports this Pull Request.
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 

<sup>**Note:** By default this PR will skip the slower tests and will use a limited set of python versions. Check [here](https://github.com/conan-io/conan/blob/develop/.github/PR_INCREASE_TESTING.md) how to increase the testing level by writing some tags in the current PR body text.</sup>
