### PR TITLE
Use specified output when using ConanFile.run() with bash

### DIFF
--- a/conans/client/subsystems.py
+++ b/conans/client/subsystems.py
@@ -13,7 +13,7 @@ WSL = 'wsl'  # Windows Subsystem for Linux
 SFU = 'sfu'  # Windows Services for UNIX
 
 
-def run_in_windows_bash(conanfile, command, cwd=None, env="conanbuild"):
+def run_in_windows_bash(conanfile, command, cwd=None, env="conanbuild", output=True):
     from conan.tools.env import Environment
     from conan.tools.env.environment import environment_wrap_command
     """ Will run a unix command inside a bash terminal It requires to have MSYS2, CYGWIN, or WSL"""
@@ -74,7 +74,7 @@ def run_in_windows_bash(conanfile, command, cwd=None, env="conanbuild"):
         wrapped_shell=wrapped_shell,
         inside_command=inside_command)
     conanfile.output.info('Running in windows bash: %s' % final_command)
-    return conanfile._conan_runner(final_command, output=conanfile.output, subprocess=True)
+    return conanfile._conan_runner(final_command, output=output, subprocess=True)
 
 
 def escape_windows_cmd(command):

--- a/conans/client/tools/win.py
+++ b/conans/client/tools/win.py
@@ -639,7 +639,7 @@ def unix_path(path, path_flavor=None):
 
 
 def run_in_windows_bash(conanfile, bashcmd, cwd=None, subsystem=None, msys_mingw=True, env=None,
-                        with_login=True):
+                        with_login=True, output=True):
     """ Will run a unix command inside a bash terminal
         It requires to have MSYS2, CYGWIN, or WSL
     """
@@ -717,4 +717,4 @@ def run_in_windows_bash(conanfile, bashcmd, cwd=None, subsystem=None, msys_mingw
 
         # https://github.com/conan-io/conan/issues/2839 (subprocess=True)
         with environment_append(normalized_env):
-            return conanfile._conan_runner(wincmd, output=conanfile.output, subprocess=True)
+            return conanfile._conan_runner(wincmd, output=output, subprocess=True)

--- a/conans/model/conan_file.py
+++ b/conans/model/conan_file.py
@@ -382,14 +382,14 @@ class ConanFile(object):
         # NOTE: "self.win_bash" is the new parameter "win_bash" for Conan 2.0
 
         def _run(cmd, _env):
-            # FIXME: run in windows bash is not using output
             if platform.system() == "Windows":
                 if win_bash:
                     return tools.run_in_windows_bash(self, bashcmd=cmd, cwd=cwd, subsystem=subsystem,
-                                                     msys_mingw=msys_mingw, with_login=with_login)
+                                                     msys_mingw=msys_mingw, with_login=with_login,
+                                                     output=output)
                 elif self.win_bash:  # New, Conan 2.0
                     from conans.client.subsystems import run_in_windows_bash
-                    return run_in_windows_bash(self, command=cmd, cwd=cwd, env=_env)
+                    return run_in_windows_bash(self, command=cmd, cwd=cwd, env=_env, output=output)
             from conan.tools.env.environment import environment_wrap_command
             if env:
                 wrapped_cmd = environment_wrap_command(_env, cmd, cwd=self.generators_folder)

--- a/conans/test/unittests/util/tools_test.py
+++ b/conans/test/unittests/util/tools_test.py
@@ -365,6 +365,7 @@ class HelloConan(ConanFile):
                     def __call__(self, command, output, log_filepath=None,
                                  cwd=None, subprocess=False):  # @UnusedVariable
                         self.command = command
+                        self.output = output
                 self._conan_runner = MyRun()
 
         conanfile = MockConanfile()
@@ -373,6 +374,11 @@ class HelloConan(ConanFile):
             self.assertIn("bash", conanfile._conan_runner.command)
             self.assertIn("--login -c", conanfile._conan_runner.command)
             self.assertIn("^&^& a_command.bat ^", conanfile._conan_runner.command)
+            self.assertTrue(conanfile._conan_runner.output)
+
+            output = sys.stdout
+            tools.run_in_windows_bash(conanfile, "a_command.bat", subsystem="cygwin", output=output)
+            self.assertEqual(output, conanfile._conan_runner.output)
 
         with tools.environment_append({"CONAN_BASH_PATH": "path\\to\\mybash.exe"}):
             tools.run_in_windows_bash(conanfile, "a_command.bat", subsystem="cygwin")


### PR DESCRIPTION
Fix #5670, #11076

Changelog: Feature: Use output provided by user when calling self.run() with win_bash=True
Docs: https://github.com/conan-io/docs/pull/2543

- [x] Refer to the issue that supports this Pull Request.
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [x] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 

<sup>**Note:** By default this PR will skip the slower tests and will use a limited set of python versions. Check [here](https://github.com/conan-io/conan/blob/develop/.github/PR_INCREASE_TESTING.md) how to increase the testing level by writing some tags in the current PR body text.</sup>
