### PR TITLE
Bugfix/issue 11261 transitive module dependency wrong name

### DIFF
--- a/conan/tools/cmake/cmakedeps/templates/__init__.py
+++ b/conan/tools/cmake/cmakedeps/templates/__init__.py
@@ -7,11 +7,11 @@ from conans.errors import ConanException
 
 class CMakeDepsFileTemplate(object):
 
-    def __init__(self, cmakedeps, require, conanfile, find_module_mode=False):
+    def __init__(self, cmakedeps, require, conanfile, generating_module=False):
         self.cmakedeps = cmakedeps
         self.require = require
         self.conanfile = conanfile
-        self.find_module_mode = find_module_mode
+        self.generating_module = generating_module
 
     @property
     def pkg_name(self):
@@ -23,7 +23,7 @@ class CMakeDepsFileTemplate(object):
 
     @property
     def file_name(self):
-        return get_cmake_package_name(self.conanfile, module_mode=self.find_module_mode) + self.suffix
+        return get_cmake_package_name(self.conanfile, module_mode=self.generating_module) + self.suffix
 
     @property
     def suffix(self):
@@ -81,7 +81,7 @@ class CMakeDepsFileTemplate(object):
                                                         name=req.ref.name, suffix=suffix)
 
     def get_root_target_name(self, req, suffix=""):
-        if self.find_module_mode:
+        if self.generating_module:
             ret = req.cpp_info.get_property("cmake_module_target_name")
             if ret:
                 return ret
@@ -95,7 +95,7 @@ class CMakeDepsFileTemplate(object):
                 return self.get_root_target_name(req)
             raise ConanException("Component '{name}::{cname}' not found in '{name}' "
                                  "package requirement".format(name=req.ref.name, cname=comp_name))
-        if self.find_module_mode:
+        if self.generating_module:
             ret = req.cpp_info.components[comp_name].get_property("cmake_module_target_name")
             if ret:
                 return ret

--- a/conan/tools/cmake/cmakedeps/templates/__init__.py
+++ b/conan/tools/cmake/cmakedeps/templates/__init__.py
@@ -1,7 +1,7 @@
 import jinja2
 from jinja2 import Template
 
-from conan.tools.cmake.utils import get_file_name
+from conan.tools.cmake.utils import get_cmake_package_name
 from conans.errors import ConanException
 
 
@@ -23,7 +23,7 @@ class CMakeDepsFileTemplate(object):
 
     @property
     def file_name(self):
-        return get_file_name(self.conanfile, forced_module_mode=self.find_module_mode) + self.suffix
+        return get_cmake_package_name(self.conanfile, module_mode=self.find_module_mode) + self.suffix
 
     @property
     def suffix(self):

--- a/conan/tools/cmake/cmakedeps/templates/config.py
+++ b/conan/tools/cmake/cmakedeps/templates/config.py
@@ -14,7 +14,7 @@ class ConfigTemplate(CMakeDepsFileTemplate):
 
     @property
     def filename(self):
-        if self.find_module_mode:
+        if self.generating_module:
             return "Find{}.cmake".format(self.file_name)
         else:
             if self.file_name == self.file_name.lower():
@@ -24,9 +24,9 @@ class ConfigTemplate(CMakeDepsFileTemplate):
 
     @property
     def context(self):
-        targets_include = "" if not self.find_module_mode else "module-"
+        targets_include = "" if not self.generating_module else "module-"
         targets_include += "{}Targets.cmake".format(self.file_name)
-        return {"is_module": self.find_module_mode,
+        return {"is_module": self.generating_module,
                 "version": self.conanfile.ref.version,
                 "file_name": self.file_name,
                 "pkg_name": self.pkg_name,

--- a/conan/tools/cmake/cmakedeps/templates/config.py
+++ b/conan/tools/cmake/cmakedeps/templates/config.py
@@ -45,17 +45,6 @@ class ConfigTemplate(CMakeDepsFileTemplate):
             message(FATAL_ERROR "The 'CMakeDeps' generator only works with CMake >= 3.15")
         endif()
 
-        {% if is_module %}
-        include(FindPackageHandleStandardArgs)
-        set({{ file_name }}_FOUND 1)
-        set({{ file_name }}_VERSION "{{ version }}")
-
-        find_package_handle_standard_args({{ file_name }}
-                                          REQUIRED_VARS {{ file_name }}_VERSION
-                                          VERSION_VAR {{ file_name }}_VERSION)
-        mark_as_advanced({{ file_name }}_FOUND {{ file_name }}_VERSION)
-        {% endif %}
-
         include(${CMAKE_CURRENT_LIST_DIR}/cmakedeps_macros.cmake)
         include(${CMAKE_CURRENT_LIST_DIR}/{{ targets_include_file }})
         include(CMakeFindDependencyMacro)
@@ -91,5 +80,16 @@ class ConfigTemplate(CMakeDepsFileTemplate):
                 endif()
             endforeach()
         endif()
+        {% endif %}
+
+        {% if is_module %}
+        include(FindPackageHandleStandardArgs)
+        set({{ file_name }}_FOUND 1)
+        set({{ file_name }}_VERSION "{{ version }}")
+
+        find_package_handle_standard_args({{ file_name }}
+                                          REQUIRED_VARS {{ file_name }}_VERSION
+                                          VERSION_VAR {{ file_name }}_VERSION)
+        mark_as_advanced({{ file_name }}_FOUND {{ file_name }}_VERSION)
         {% endif %}
         """)

--- a/conan/tools/cmake/cmakedeps/templates/target_configuration.py
+++ b/conan/tools/cmake/cmakedeps/templates/target_configuration.py
@@ -13,7 +13,7 @@ class TargetConfigurationTemplate(CMakeDepsFileTemplate):
 
     @property
     def filename(self):
-        name = "" if not self.find_module_mode else "module-"
+        name = "" if not self.generating_module else "module-"
         name += "{}-Target-{}.cmake".format(self.file_name, self.cmakedeps.configuration.lower())
         return name
 

--- a/conan/tools/cmake/cmakedeps/templates/target_data.py
+++ b/conan/tools/cmake/cmakedeps/templates/target_data.py
@@ -25,6 +25,10 @@ class ConfigDataTemplate(CMakeDepsFileTemplate):
 
     @property
     def context(self):
+
+        if self.filename == "module-Fontconfig-release-armv8-data.cmake":
+            foo = "trece"
+
         global_cpp = self._get_global_cpp_cmake()
         if not self.build_modules_activated:
             global_cpp.build_modules_paths = ""
@@ -172,7 +176,8 @@ class ConfigDataTemplate(CMakeDepsFileTemplate):
                     req = direct_host[dep_name]
                     ret.append(get_file_name(req))
         elif direct_host:
-            ret = [get_file_name(r) for r in direct_host.values()]
+            ret = [get_file_name(r, self.find_module_mode) for r in direct_host.values()]
+            #ret = [get_file_name(r) for r in direct_host.values()]
 
         return ret
 
@@ -182,7 +187,8 @@ class ConfigDataTemplate(CMakeDepsFileTemplate):
             return ret
         deps = self.conanfile.dependencies.filter({"build": False, "visible": True, "direct": True})
         for dep in deps.values():
-            dep_file_name = get_file_name(dep)
+            dep_file_name = get_file_name(dep, self.find_module_mode)
+            #dep_file_name = get_file_name(dep)
             find_mode = get_find_mode(dep)
             default_value = "NO_MODULE" if not self.find_module_mode else "MODULE"
             values = {

--- a/conan/tools/cmake/cmakedeps/templates/target_data.py
+++ b/conan/tools/cmake/cmakedeps/templates/target_data.py
@@ -16,7 +16,7 @@ class ConfigDataTemplate(CMakeDepsFileTemplate):
 
     @property
     def filename(self):
-        data_fname = "" if not self.find_module_mode else "module-"
+        data_fname = "" if not self.generating_module else "module-"
         data_fname += "{}-{}".format(self.file_name, self.configuration.lower())
         if self.arch:
             data_fname += "-{}".format(self.arch)
@@ -172,7 +172,7 @@ class ConfigDataTemplate(CMakeDepsFileTemplate):
                     req = direct_host[dep_name]
                     ret.append(get_cmake_package_name(req))
         elif direct_host:
-            ret = [get_cmake_package_name(r, self.find_module_mode) for r in direct_host.values()]
+            ret = [get_cmake_package_name(r, self.generating_module) for r in direct_host.values()]
 
         return ret
 
@@ -182,9 +182,9 @@ class ConfigDataTemplate(CMakeDepsFileTemplate):
             return ret
         deps = self.conanfile.dependencies.filter({"build": False, "visible": True, "direct": True})
         for dep in deps.values():
-            dep_file_name = get_cmake_package_name(dep, self.find_module_mode)
+            dep_file_name = get_cmake_package_name(dep, self.generating_module)
             find_mode = get_find_mode(dep)
-            default_value = "NO_MODULE" if not self.find_module_mode else "MODULE"
+            default_value = "NO_MODULE" if not self.generating_module else "MODULE"
             values = {
                 FIND_MODE_NONE: "",
                 FIND_MODE_CONFIG: "NO_MODULE",

--- a/conan/tools/cmake/cmakedeps/templates/target_data.py
+++ b/conan/tools/cmake/cmakedeps/templates/target_data.py
@@ -4,7 +4,7 @@ import textwrap
 from conan.tools.cmake.cmakedeps import FIND_MODE_NONE, FIND_MODE_CONFIG, FIND_MODE_MODULE, \
     FIND_MODE_BOTH
 from conan.tools.cmake.cmakedeps.templates import CMakeDepsFileTemplate
-from conan.tools.cmake.utils import get_file_name, get_find_mode
+from conan.tools.cmake.utils import get_cmake_package_name, get_find_mode
 """
 
 foo-release-x86_64-data.cmake
@@ -170,9 +170,9 @@ class ConfigDataTemplate(CMakeDepsFileTemplate):
             for dep_name, _ in self.conanfile.cpp_info.required_components:
                 if dep_name and dep_name not in ret:  # External dep
                     req = direct_host[dep_name]
-                    ret.append(get_file_name(req))
+                    ret.append(get_cmake_package_name(req))
         elif direct_host:
-            ret = [get_file_name(r, self.find_module_mode) for r in direct_host.values()]
+            ret = [get_cmake_package_name(r, self.find_module_mode) for r in direct_host.values()]
 
         return ret
 
@@ -182,7 +182,7 @@ class ConfigDataTemplate(CMakeDepsFileTemplate):
             return ret
         deps = self.conanfile.dependencies.filter({"build": False, "visible": True, "direct": True})
         for dep in deps.values():
-            dep_file_name = get_file_name(dep, self.find_module_mode)
+            dep_file_name = get_cmake_package_name(dep, self.find_module_mode)
             find_mode = get_find_mode(dep)
             default_value = "NO_MODULE" if not self.find_module_mode else "MODULE"
             values = {

--- a/conan/tools/cmake/cmakedeps/templates/target_data.py
+++ b/conan/tools/cmake/cmakedeps/templates/target_data.py
@@ -25,10 +25,6 @@ class ConfigDataTemplate(CMakeDepsFileTemplate):
 
     @property
     def context(self):
-
-        if self.filename == "module-Fontconfig-release-armv8-data.cmake":
-            foo = "trece"
-
         global_cpp = self._get_global_cpp_cmake()
         if not self.build_modules_activated:
             global_cpp.build_modules_paths = ""
@@ -177,7 +173,6 @@ class ConfigDataTemplate(CMakeDepsFileTemplate):
                     ret.append(get_file_name(req))
         elif direct_host:
             ret = [get_file_name(r, self.find_module_mode) for r in direct_host.values()]
-            #ret = [get_file_name(r) for r in direct_host.values()]
 
         return ret
 
@@ -188,7 +183,6 @@ class ConfigDataTemplate(CMakeDepsFileTemplate):
         deps = self.conanfile.dependencies.filter({"build": False, "visible": True, "direct": True})
         for dep in deps.values():
             dep_file_name = get_file_name(dep, self.find_module_mode)
-            #dep_file_name = get_file_name(dep)
             find_mode = get_find_mode(dep)
             default_value = "NO_MODULE" if not self.find_module_mode else "MODULE"
             values = {

--- a/conan/tools/cmake/cmakedeps/templates/targets.py
+++ b/conan/tools/cmake/cmakedeps/templates/targets.py
@@ -13,16 +13,16 @@ class TargetsTemplate(CMakeDepsFileTemplate):
 
     @property
     def filename(self):
-        name = "" if not self.find_module_mode else "module-"
+        name = "" if not self.generating_module else "module-"
         name += self.file_name + "Targets.cmake"
         return name
 
     @property
     def context(self):
-        data_pattern = "${_DIR}/" if not self.find_module_mode else "${_DIR}/module-"
+        data_pattern = "${_DIR}/" if not self.generating_module else "${_DIR}/module-"
         data_pattern += "{}-*-data.cmake".format(self.file_name)
 
-        target_pattern = "" if not self.find_module_mode else "module-"
+        target_pattern = "" if not self.generating_module else "module-"
         target_pattern += "{}-Target-*.cmake".format(self.file_name)
 
         cmake_target_aliases = self.conanfile.cpp_info.\

--- a/conan/tools/cmake/utils.py
+++ b/conan/tools/cmake/utils.py
@@ -1,4 +1,4 @@
-from conan.tools.cmake.cmakedeps import FIND_MODE_MODULE
+from conan.tools.cmake.cmakedeps import FIND_MODE_MODULE, FIND_MODE_BOTH
 
 
 def is_multi_configuration(generator):
@@ -11,7 +11,8 @@ def get_file_name(conanfile, forced_module_mode=None):
     """Get the name of the file for the find_package(XXX)"""
     # This is used by the CMakeToolchain to adjust the XXX_DIR variables and the CMakeDeps. Both
     # to know the file name that will have the XXX-config.cmake files.
-    if forced_module_mode or get_find_mode(conanfile) == FIND_MODE_MODULE:
+    # TODO: update this comment
+    if forced_module_mode and get_find_mode(conanfile) in [FIND_MODE_MODULE, FIND_MODE_BOTH]:
         ret = conanfile.cpp_info.get_property("cmake_module_file_name")
         if ret:
             return ret

--- a/conan/tools/cmake/utils.py
+++ b/conan/tools/cmake/utils.py
@@ -7,12 +7,13 @@ def is_multi_configuration(generator):
     return "Visual" in generator or "Xcode" in generator or "Multi-Config" in generator
 
 
-def get_file_name(conanfile, forced_module_mode=None):
+def get_cmake_package_name(conanfile, module_mode=None):
     """Get the name of the file for the find_package(XXX)"""
-    # This is used by the CMakeToolchain to adjust the XXX_DIR variables and the CMakeDeps. Both
-    # to know the file name that will have the XXX-config.cmake files.
-    # TODO: update this comment
-    if forced_module_mode and get_find_mode(conanfile) in [FIND_MODE_MODULE, FIND_MODE_BOTH]:
+    # This is used by CMakeToolchain/CMakeDeps to determine:
+    # - The filename to generate (XXX-config.cmake or FindXXX.cmake)
+    # - The name of the defined XXX_DIR variables
+    # - The name of transitive dependencies for calls to find_dependency
+    if module_mode and get_find_mode(conanfile) in [FIND_MODE_MODULE, FIND_MODE_BOTH]:
         ret = conanfile.cpp_info.get_property("cmake_module_file_name")
         if ret:
             return ret

--- a/conans/client/generators/markdown.py
+++ b/conans/client/generators/markdown.py
@@ -8,7 +8,7 @@ from jinja2 import Environment
 from conan.tools.cmake.cmakedeps.cmakedeps import CMakeDeps
 from conan.tools.cmake.cmakedeps.templates import (
     CMakeDepsFileTemplate,
-    get_file_name as cmake_get_file_name)
+    get_cmake_package_name as cmake_get_file_name)
 from conan.tools.gnu.pkgconfigdeps.pc_info_loader import (
     _get_component_name as pkgconfig_get_component_name,
     _get_name_with_namespace as pkgconfig_get_name_with_namespace,

--- a/conans/client/generators/markdown.py
+++ b/conans/client/generators/markdown.py
@@ -426,7 +426,7 @@ class MarkdownGenerator(Generator):
             cmake_deps_template = CMakeDepsFileTemplate(cmake_deps,
                                                         requirement,
                                                         self.conanfile,
-                                                        find_module_mode=False)
+                                                        generating_module=False)
 
             cmake_component_alias = {
                 component_name: cmake_deps_template.get_component_alias(requirement, component_name)

--- a/conans/test/functional/toolchains/cmake/cmakedeps/test_cmakedeps_find_module_and_config.py
+++ b/conans/test/functional/toolchains/cmake/cmakedeps/test_cmakedeps_find_module_and_config.py
@@ -65,52 +65,52 @@ def client():
     return t
 
 
-# @pytest.mark.tool_cmake
-# def test_reuse_with_modules_and_config(client):
-#     cpp = gen_function_cpp(name="main")
+@pytest.mark.tool_cmake
+def test_reuse_with_modules_and_config(client):
+    cpp = gen_function_cpp(name="main")
 
-#     cmake_exe_config = """
-#     add_executable(myapp main.cpp)
-#     find_package(MyDep) # This one will find the config
-#     target_link_libraries(myapp MyDepTarget::MyCrispinTarget)
-#     """
+    cmake_exe_config = """
+    add_executable(myapp main.cpp)
+    find_package(MyDep) # This one will find the config
+    target_link_libraries(myapp MyDepTarget::MyCrispinTarget)
+    """
 
-#     cmake_exe_module = """
-#     add_executable(myapp2 main.cpp)
-#     find_package(mi_dependencia) # This one will find the module
-#     target_link_libraries(myapp2 mi_dependencia_namespace::mi_crispin_target)
-#     """
+    cmake_exe_module = """
+    add_executable(myapp2 main.cpp)
+    find_package(mi_dependencia) # This one will find the module
+    target_link_libraries(myapp2 mi_dependencia_namespace::mi_crispin_target)
+    """
 
-#     cmake = """
-#     set(CMAKE_CXX_COMPILER_WORKS 1)
-#     set(CMAKE_CXX_ABI_COMPILED 1)
-#     set(CMAKE_C_COMPILER_WORKS 1)
-#     set(CMAKE_C_ABI_COMPILED 1)
+    cmake = """
+    set(CMAKE_CXX_COMPILER_WORKS 1)
+    set(CMAKE_CXX_ABI_COMPILED 1)
+    set(CMAKE_C_COMPILER_WORKS 1)
+    set(CMAKE_C_ABI_COMPILED 1)
 
-#     cmake_minimum_required(VERSION 3.15)
-#     project(project CXX)
-#     {}
-#     """
+    cmake_minimum_required(VERSION 3.15)
+    project(project CXX)
+    {}
+    """
 
-#     # test config
-#     conanfile = GenConanfile().with_name("myapp")\
-#         .with_cmake_build().with_exports_sources("*.cpp", "*.txt").with_require("mydep/1.0")
-#     client.save({"conanfile.py": conanfile,
-#                  "main.cpp": cpp,
-#                  "CMakeLists.txt": cmake.format(cmake_exe_config)})
+    # test config
+    conanfile = GenConanfile().with_name("myapp")\
+        .with_cmake_build().with_exports_sources("*.cpp", "*.txt").with_require("mydep/1.0")
+    client.save({"conanfile.py": conanfile,
+                 "main.cpp": cpp,
+                 "CMakeLists.txt": cmake.format(cmake_exe_config)})
 
-#     client.run("install . -if=install")
-#     client.run("build . -if=install")
+    client.run("install . -if=install")
+    client.run("build . -if=install")
 
-#     # test modules
-#     conanfile = GenConanfile().with_name("myapp")\
-#         .with_cmake_build().with_exports_sources("*.cpp", "*.txt").with_require("mydep/1.0")
-#     client.save({"conanfile.py": conanfile,
-#                  "main.cpp": cpp,
-#                  "CMakeLists.txt": cmake.format(cmake_exe_module)}, clean_first=True)
+    # test modules
+    conanfile = GenConanfile().with_name("myapp")\
+        .with_cmake_build().with_exports_sources("*.cpp", "*.txt").with_require("mydep/1.0")
+    client.save({"conanfile.py": conanfile,
+                 "main.cpp": cpp,
+                 "CMakeLists.txt": cmake.format(cmake_exe_module)}, clean_first=True)
 
-#     client.run("install . -if=install")
-#     client.run("build . -if=install")
+    client.run("install . -if=install")
+    client.run("build . -if=install")
 
 
 find_modes = [

--- a/conans/test/functional/toolchains/cmake/cmakedeps/test_cmakedeps_find_module_and_config.py
+++ b/conans/test/functional/toolchains/cmake/cmakedeps/test_cmakedeps_find_module_and_config.py
@@ -65,52 +65,52 @@ def client():
     return t
 
 
-@pytest.mark.tool_cmake
-def test_reuse_with_modules_and_config(client):
-    cpp = gen_function_cpp(name="main")
+# @pytest.mark.tool_cmake
+# def test_reuse_with_modules_and_config(client):
+#     cpp = gen_function_cpp(name="main")
 
-    cmake_exe_config = """
-    add_executable(myapp main.cpp)
-    find_package(MyDep) # This one will find the config
-    target_link_libraries(myapp MyDepTarget::MyCrispinTarget)
-    """
+#     cmake_exe_config = """
+#     add_executable(myapp main.cpp)
+#     find_package(MyDep) # This one will find the config
+#     target_link_libraries(myapp MyDepTarget::MyCrispinTarget)
+#     """
 
-    cmake_exe_module = """
-    add_executable(myapp2 main.cpp)
-    find_package(mi_dependencia) # This one will find the module
-    target_link_libraries(myapp2 mi_dependencia_namespace::mi_crispin_target)
-    """
+#     cmake_exe_module = """
+#     add_executable(myapp2 main.cpp)
+#     find_package(mi_dependencia) # This one will find the module
+#     target_link_libraries(myapp2 mi_dependencia_namespace::mi_crispin_target)
+#     """
 
-    cmake = """
-    set(CMAKE_CXX_COMPILER_WORKS 1)
-    set(CMAKE_CXX_ABI_COMPILED 1)
-    set(CMAKE_C_COMPILER_WORKS 1)
-    set(CMAKE_C_ABI_COMPILED 1)
+#     cmake = """
+#     set(CMAKE_CXX_COMPILER_WORKS 1)
+#     set(CMAKE_CXX_ABI_COMPILED 1)
+#     set(CMAKE_C_COMPILER_WORKS 1)
+#     set(CMAKE_C_ABI_COMPILED 1)
 
-    cmake_minimum_required(VERSION 3.15)
-    project(project CXX)
-    {}
-    """
+#     cmake_minimum_required(VERSION 3.15)
+#     project(project CXX)
+#     {}
+#     """
 
-    # test config
-    conanfile = GenConanfile().with_name("myapp")\
-        .with_cmake_build().with_exports_sources("*.cpp", "*.txt").with_require("mydep/1.0")
-    client.save({"conanfile.py": conanfile,
-                 "main.cpp": cpp,
-                 "CMakeLists.txt": cmake.format(cmake_exe_config)})
+#     # test config
+#     conanfile = GenConanfile().with_name("myapp")\
+#         .with_cmake_build().with_exports_sources("*.cpp", "*.txt").with_require("mydep/1.0")
+#     client.save({"conanfile.py": conanfile,
+#                  "main.cpp": cpp,
+#                  "CMakeLists.txt": cmake.format(cmake_exe_config)})
 
-    client.run("install . -if=install")
-    client.run("build . -if=install")
+#     client.run("install . -if=install")
+#     client.run("build . -if=install")
 
-    # test modules
-    conanfile = GenConanfile().with_name("myapp")\
-        .with_cmake_build().with_exports_sources("*.cpp", "*.txt").with_require("mydep/1.0")
-    client.save({"conanfile.py": conanfile,
-                 "main.cpp": cpp,
-                 "CMakeLists.txt": cmake.format(cmake_exe_module)}, clean_first=True)
+#     # test modules
+#     conanfile = GenConanfile().with_name("myapp")\
+#         .with_cmake_build().with_exports_sources("*.cpp", "*.txt").with_require("mydep/1.0")
+#     client.save({"conanfile.py": conanfile,
+#                  "main.cpp": cpp,
+#                  "CMakeLists.txt": cmake.format(cmake_exe_module)}, clean_first=True)
 
-    client.run("install . -if=install")
-    client.run("build . -if=install")
+#     client.run("install . -if=install")
+#     client.run("build . -if=install")
 
 
 find_modes = [
@@ -168,13 +168,11 @@ def test_transitive_modules_found(find_mode_PKGA, find_mode_PKGB, find_mode_cons
         message("MYPKGB_INCLUDE_DIR: ${{MYPKGB_INCLUDE_DIR}}")
         message("MYPKGB_LIBRARIES: ${{MYPKGB_LIBRARIES}}")
         message("MYPKGB_DEFINITIONS: ${{MYPKGB_DEFINITIONS}}")
-        message("mypkga_FOUND: ${{mypkga_FOUND}}")
-        message("MYPKGA_FOUND: ${{MYPKGA_FOUND}}")
         """)
 
     client.save({"pkgb.py": conan_pkg.format(requires='requires="pkga/1.0"', filename='MYPKGB', module_filename='MYPKGB',
                                              mode=find_mode_PKGB),
-                 "pkga.py": conan_pkg.format(requires='', filename='MYPKGA', module_filename='mypkga', mode=find_mode_PKGA),
+                 "pkga.py": conan_pkg.format(requires='', filename='MYPKGA', module_filename='unicorns', mode=find_mode_PKGA),
                  "consumer.py": consumer,
                  "CMakeLists.txt": cmakelist.format(find_mode=find_mode_consumer)})
     client.run("create pkga.py pkga/1.0@")
@@ -188,5 +186,6 @@ def test_transitive_modules_found(find_mode_PKGA, find_mode_PKGB, find_mode_cons
     assert "MYPKGB_LIBRARIES: pkga::pkga" in client.out
     assert "MYPKGB_DEFINITIONS: -DDEFINE_MYPKGB" in client.out
     assert "Conan: Target declared 'pkga::pkga'"
+
     if find_mode_PKGA == "module":
-        assert 'Found mypkga: 1.0 (found version "1.0")' in client.out
+        assert 'Found unicorns: 1.0 (found version "1.0")' in client.out

--- a/conans/test/functional/toolchains/cmake/cmakedeps/test_cmakedeps_find_module_and_config.py
+++ b/conans/test/functional/toolchains/cmake/cmakedeps/test_cmakedeps_find_module_and_config.py
@@ -115,10 +115,11 @@ def test_reuse_with_modules_and_config(client):
 
 find_modes = [
     ("both", "both", ""),
+    ("both", "both", "MODULE"),
     ("config", "config", ""),
     ("module", "module", ""),
-    ("both", None, ""),
-    ("both", None, "MODULE")
+    (None, "both", ""),
+    (None, "both", "MODULE")
 ]
 
 
@@ -139,6 +140,7 @@ def test_transitive_modules_found(find_mode_PKGA, find_mode_PKGB, find_mode_cons
                 if "{mode}" != "None":
                     self.cpp_info.set_property("cmake_find_mode", "{mode}")
                 self.cpp_info.set_property("cmake_file_name", "{filename}")
+                self.cpp_info.set_property("cmake_module_file_name", "{module_filename}")
                 self.cpp_info.defines.append("DEFINE_{filename}")
             """)
 
@@ -166,11 +168,13 @@ def test_transitive_modules_found(find_mode_PKGA, find_mode_PKGB, find_mode_cons
         message("MYPKGB_INCLUDE_DIR: ${{MYPKGB_INCLUDE_DIR}}")
         message("MYPKGB_LIBRARIES: ${{MYPKGB_LIBRARIES}}")
         message("MYPKGB_DEFINITIONS: ${{MYPKGB_DEFINITIONS}}")
+        message("mypkga_FOUND: ${{mypkga_FOUND}}")
+        message("MYPKGA_FOUND: ${{MYPKGA_FOUND}}")
         """)
 
-    client.save({"pkgb.py": conan_pkg.format(requires='requires="pkga/1.0"', filename='MYPKGB',
-                                             mode=find_mode_PKGA),
-                 "pkga.py": conan_pkg.format(requires='', filename='MYPKGA', mode=find_mode_PKGB),
+    client.save({"pkgb.py": conan_pkg.format(requires='requires="pkga/1.0"', filename='MYPKGB', module_filename='MYPKGB',
+                                             mode=find_mode_PKGB),
+                 "pkga.py": conan_pkg.format(requires='', filename='MYPKGA', module_filename='mypkga', mode=find_mode_PKGA),
                  "consumer.py": consumer,
                  "CMakeLists.txt": cmakelist.format(find_mode=find_mode_consumer)})
     client.run("create pkga.py pkga/1.0@")
@@ -185,4 +189,4 @@ def test_transitive_modules_found(find_mode_PKGA, find_mode_PKGB, find_mode_cons
     assert "MYPKGB_DEFINITIONS: -DDEFINE_MYPKGB" in client.out
     assert "Conan: Target declared 'pkga::pkga'"
     if find_mode_PKGA == "module":
-        assert 'Found MYPKGA: 1.0 (found version "1.0")' in client.out
+        assert 'Found mypkga: 1.0 (found version "1.0")' in client.out


### PR DESCRIPTION
Changelog: Bugfix: Fix case where CMakeDeps generator may use the wrong dependency name for transitive dependencies.
Docs: Omit

This PR fixes issue #11261, where the generated _module_ files in the CMakeDeps generator _may_ use the wrong dependency name for transitive dependencies.  The issue was only happening when the following 3 conditions were true:
* we are generating a Find module
* we have a transitive dependency where `cmake_find_mode` is explicitly `both`
* the same transitive dependency defines a module name that is different from the config name (by setting the `cmake_module_file_name` property)

This PR fixes the issue and adds a test case that exercises exactly those 3 conditions. This should also fix a related issue where CMake may issue a _warning_ on case insensitive filesystems where the name of the `xxx_FOUND` variable does not match the name of the package passed to `find_package()`. 


Additionally:

* `get_file_name` has been renamed to `get_cmake_package_name` to try and reflect better how it's used - comments have been added to clarify that the function is not only used to determine the file name, but also the names of transitive dependencies and the defined variables. In CMake, for the same package all of the above need to be "the same" for the same package.

* In the CMakeDeps template, move the logic of the code that does `set({{ file_name }}_FOUND 1)` to the bottom of the file, _after_ all transitive dependencies have been found. Due to https://github.com/conan-io/conan/issues/11261 (which is still an outstanding issue), if the call to `find_dependency` is not successful, the top-level call to `find_package` may appear successful and then cause CMake failures further down the line. This would cause an early termination that should help troubleshooting.

* Add the `find_mode` flag when calling `get_cmake_package_name` in `conan/tools/cmake/cmakedeps/templates/target_data.py` - this is mostly what fixes the bug in this PR, and what was causing the erroneous behaviour of using the `config` name when we were generating a ` module`

* Add a test that covers the behaviour that we are trying to fix. This also sets the module name of the transitive dependency to something that is not a variation of lower/upper case, such that we can reproduce the same behaviour across filesystems (we were getting different results in case in/sensitive filesystems)

* Fix small issue with the test where the variable names were swapped (but were still testing the right thing)


