### PR TITLE
Feature/cmake presets custom settings

### DIFF
--- a/conan/tools/cmake/cmake.py
+++ b/conan/tools/cmake/cmake.py
@@ -55,8 +55,8 @@ class CMake(object):
         self._conanfile = conanfile
 
         cmake_presets = load_cmake_presets(conanfile.generators_folder)
-        configure_preset = get_configure_preset(cmake_presets,
-                                                conanfile.settings.get_safe("build_type"))
+        configure_preset = get_configure_preset(cmake_presets, conanfile)
+
         self._generator = configure_preset["generator"]
         self._toolchain_file = configure_preset["toolchainFile"]
         self._cache_variables = configure_preset["cacheVariables"]

--- a/conan/tools/cmake/layout.py
+++ b/conan/tools/cmake/layout.py
@@ -48,20 +48,19 @@ def get_build_folder_vars_suffix(conanfile):
                                     default=[], check_type=list)
     ret = []
     for s in build_vars:
+        tmp = None
         if s.startswith("settings."):
             _, var = s.split("settings.", 1)
             tmp = conanfile.settings.get_safe(var)
         elif s.startswith("options."):
             _, var = s.split("options.", 1)
-            tmp = "{}_{}".format(var, conanfile.options.get_safe(var))
-
+            value = conanfile.options.get_safe(var)
+            if value:
+                tmp = "{}_{}".format(var, value)
         else:
             raise ConanException("Invalid 'tools.cmake.cmake_layout.build_folder_vars' value, it has"
                                  " to start with 'settings.' or 'options.': {}".format(s))
         if tmp:
             ret.append(tmp.lower())
-
-    if not ret:
-        return ""
 
     return "-".join(ret)

--- a/conan/tools/cmake/layout.py
+++ b/conan/tools/cmake/layout.py
@@ -19,13 +19,20 @@ def cmake_layout(conanfile, generator=None, src_folder="."):
         build_type = str(conanfile.settings.build_type)
     except ConanException:
         raise ConanException("'build_type' setting not defined, it is necessary for cmake_layout()")
+
+    suffix = get_custom_settings_suffix(conanfile)
     if multi:
         conanfile.folders.build = "build"
     else:
-        build_type = build_type.lower()
         conanfile.folders.build = "cmake-build-{}".format(build_type)
 
+    if suffix:
+        conanfile.folders.build += "-{}".format(suffix)
+
     conanfile.folders.generators = os.path.join("build", "generators")
+    if suffix:
+        conanfile.folders.generators += "-{}".format(suffix)
+
     conanfile.cpp.source.includedirs = ["include"]
 
     if multi:
@@ -34,3 +41,19 @@ def cmake_layout(conanfile, generator=None, src_folder="."):
     else:
         conanfile.cpp.build.libdirs = ["."]
         conanfile.cpp.build.bindirs = ["."]
+
+
+def get_custom_settings_suffix(conanfile):
+
+    build_settings = conanfile.conf.get("tools.cmake.cmake_layout.custom_settings",
+                                        default=[], check_type=list)
+    ret = []
+    for s in build_settings:
+        tmp = conanfile.settings.get_safe(s)
+        if tmp:
+            ret.append(tmp.lower())
+
+    if not ret:
+        return ""
+
+    return "-".join(ret)

--- a/conan/tools/cmake/layout.py
+++ b/conan/tools/cmake/layout.py
@@ -29,9 +29,8 @@ def cmake_layout(conanfile, generator=None, src_folder="."):
     if suffix:
         conanfile.folders.build += "-{}".format(suffix)
 
-    conanfile.folders.generators = os.path.join("build", "generators")
-    if suffix:
-        conanfile.folders.generators += "-{}".format(suffix)
+    conanfile.folders.generators = os.path.join("build" if not suffix else "build-{}".format(suffix),
+                                                "generators")
 
     conanfile.cpp.source.includedirs = ["include"]
 

--- a/conan/tools/cmake/layout.py
+++ b/conan/tools/cmake/layout.py
@@ -24,7 +24,7 @@ def cmake_layout(conanfile, generator=None, src_folder="."):
     if multi:
         conanfile.folders.build = "build"
     else:
-        conanfile.folders.build = "cmake-build-{}".format(build_type)
+        conanfile.folders.build = "cmake-build-{}".format(str(build_type).lower())
 
     if suffix:
         conanfile.folders.build += "-{}".format(suffix)

--- a/conan/tools/cmake/layout.py
+++ b/conan/tools/cmake/layout.py
@@ -55,7 +55,7 @@ def get_build_folder_vars_suffix(conanfile):
         elif s.startswith("options."):
             _, var = s.split("options.", 1)
             value = conanfile.options.get_safe(var)
-            if value:
+            if value is not None:
                 tmp = "{}_{}".format(var, value)
         else:
             raise ConanException("Invalid 'tools.cmake.cmake_layout.build_folder_vars' value, it has"

--- a/conan/tools/cmake/presets.py
+++ b/conan/tools/cmake/presets.py
@@ -2,7 +2,7 @@ import json
 import os
 import platform
 
-from conan.tools.cmake.layout import get_custom_settings_suffix
+from conan.tools.cmake.layout import get_build_folder_vars_suffix
 from conan.tools.cmake.utils import is_multi_configuration
 from conans.errors import ConanException
 from conans.util.files import save, load
@@ -20,7 +20,7 @@ def _add_build_preset(conanfile, multiconfig):
 
 def _build_preset_name(conanfile):
     build_type = conanfile.settings.get_safe("build_type")
-    suffix = get_custom_settings_suffix(conanfile)
+    suffix = get_build_folder_vars_suffix(conanfile)
     if suffix:
         if build_type:
             return "{}-{}".format(build_type, suffix)
@@ -31,7 +31,7 @@ def _build_preset_name(conanfile):
 
 def _configure_preset_name(conanfile, multiconfig):
     build_type = conanfile.settings.get_safe("build_type")
-    suffix = get_custom_settings_suffix(conanfile)
+    suffix = get_build_folder_vars_suffix(conanfile)
     base = "default" if multiconfig or not build_type else build_type
     if suffix:
         return "{}-{}".format(base, suffix)

--- a/conan/tools/cmake/presets.py
+++ b/conan/tools/cmake/presets.py
@@ -2,6 +2,7 @@ import json
 import os
 import platform
 
+from conan.tools.cmake.layout import get_custom_settings_suffix
 from conan.tools.cmake.utils import is_multi_configuration
 from conans.errors import ConanException
 from conans.util.files import save, load
@@ -9,27 +10,43 @@ from conans.util.files import save, load
 
 def _add_build_preset(conanfile, multiconfig):
     build_type = conanfile.settings.get_safe("build_type")
-    configure_preset_name = _configure_preset_name(build_type, multiconfig)
-    ret = {"name": build_type,
+    configure_preset_name = _configure_preset_name(conanfile, multiconfig)
+    ret = {"name": _build_preset_name(conanfile),
            "configurePreset": configure_preset_name}
     if multiconfig:
         ret["configuration"] = build_type
     return ret
 
 
-def _configure_preset_name(build_type, multiconfig):
-    return "default" if not build_type or multiconfig else build_type
+def _build_preset_name(conanfile):
+    build_type = conanfile.settings.get_safe("build_type")
+    suffix = get_custom_settings_suffix(conanfile)
+    if suffix:
+        if build_type:
+            return "{}-{}".format(build_type, suffix)
+        else:
+            return suffix
+    return build_type or "default"
+
+
+def _configure_preset_name(conanfile, multiconfig):
+    build_type = conanfile.settings.get_safe("build_type")
+    suffix = get_custom_settings_suffix(conanfile)
+    base = "default" if multiconfig or not build_type else build_type
+    if suffix:
+        return "{}-{}".format(base, suffix)
+    return base
 
 
 def _add_configure_preset(conanfile, generator, cache_variables, toolchain_file, multiconfig):
     build_type = conanfile.settings.get_safe("build_type")
-    name = _configure_preset_name(build_type, multiconfig)
-    if not multiconfig:
+    name = _configure_preset_name(conanfile, multiconfig)
+    if not multiconfig and build_type:
         cache_variables["CMAKE_BUILD_TYPE"] = build_type
     ret = {
             "name": name,
-            "displayName": "{} Config".format(name.capitalize()),
-            "description": "{} configure using '{}' generator".format(name.capitalize(), generator),
+            "displayName": "'{}' config".format(name),
+            "description": "'{}' configure using '{}' generator".format(name, generator),
             "generator": generator,
             "cacheVariables": cache_variables,
             "toolchainFile": toolchain_file,
@@ -68,21 +85,23 @@ def write_cmake_presets(conanfile, toolchain_file, generator):
 
     preset_path = os.path.join(conanfile.generators_folder, "CMakePresets.json")
     multiconfig = is_multi_configuration(generator)
-    build_type = conanfile.settings.get_safe("build_type")
 
     if os.path.exists(preset_path):
         # We append the new configuration making sure that we don't overwrite it
         data = json.loads(load(preset_path))
         if multiconfig:
             build_presets = data["buildPresets"]
-            already_exist = any([b["configuration"] for b in build_presets if b == build_type])
+            build_preset_name = _build_preset_name(conanfile)
+            already_exist = any([b["configuration"]
+                                 for b in build_presets if b == build_preset_name])
             if not already_exist:
                 data["buildPresets"].append(_add_build_preset(conanfile, multiconfig))
         else:
             configure_presets = data["configurePresets"]
+            configure_preset_name = _configure_preset_name(conanfile, multiconfig)
             already_exist = any([c["name"]
                                  for c in configure_presets
-                                 if c["name"] == _configure_preset_name(build_type, multiconfig)])
+                                 if c["name"] == configure_preset_name])
             if not already_exist:
                 conf_preset = _add_configure_preset(conanfile, generator, cache_variables,
                                                     toolchain_file, multiconfig)
@@ -100,8 +119,13 @@ def write_cmake_presets(conanfile, toolchain_file, generator):
             user_presets_path = os.path.join(conanfile.source_folder, "CMakeUserPresets.json")
             if not os.path.exists(user_presets_path):
                 data = {"version": 4, "include": [preset_path]}
-                data = json.dumps(data, indent=4)
-                save(user_presets_path, data)
+            else:
+                data = json.loads(load(user_presets_path))
+                if preset_path not in data["include"]:
+                    data["include"].append(preset_path)
+
+            data = json.dumps(data, indent=4)
+            save(user_presets_path, data)
 
 
 def load_cmake_presets(folder):
@@ -109,20 +133,21 @@ def load_cmake_presets(folder):
     return json.loads(tmp)
 
 
-def get_configure_preset(cmake_presets, build_type):
-
-    # Do we find a preset for the current build type?
+def get_configure_preset(cmake_presets, conanfile):
+    expected_name = _configure_preset_name(conanfile, multiconfig=False)
+    # Do we find a preset for the current configuration?
     for preset in cmake_presets["configurePresets"]:
-        if preset["name"] == build_type:
+        if preset["name"] == expected_name:
             return preset
 
+    expected_name = _configure_preset_name(conanfile, multiconfig=True)
     # In case of multi-config generator or None build_type
     for preset in cmake_presets["configurePresets"]:
-        if preset["name"] == "default":
+        if preset["name"] == expected_name:
             return preset
 
     # FIXME: Might be an issue if someone perform several conan install that involves different
     #        CMake generators (multi and single config). Would be impossible to determine which
     #        is the correct configurePreset because the generator IS in the configure preset.
 
-    raise ConanException("Not available configurePreset for the build_type {}".format(build_type))
+    raise ConanException("Not available configurePreset, expected name is {}".format(expected_name))

--- a/conans/model/conf.py
+++ b/conans/model/conf.py
@@ -21,6 +21,7 @@ BUILT_IN_CONFS = {
     "tools.cmake.cmaketoolchain:system_version": "Define CMAKE_SYSTEM_VERSION in CMakeToolchain",
     "tools.cmake.cmaketoolchain:system_processor": "Define CMAKE_SYSTEM_PROCESSOR in CMakeToolchain",
     "tools.env.virtualenv:auto_use": "Automatically activate virtualenv file generation",
+    "tools.cmake.cmake_layout.custom_settings": "Name of the settings that will produce a different build folder and different CMake presets names",
     "tools.files.download:retry": "Number of retries in case of failure when downloading",
     "tools.files.download:retry_wait": "Seconds to wait between download attempts",
     "tools.gnu:make_program": "Indicate path to make program",

--- a/conans/model/conf.py
+++ b/conans/model/conf.py
@@ -21,7 +21,7 @@ BUILT_IN_CONFS = {
     "tools.cmake.cmaketoolchain:system_version": "Define CMAKE_SYSTEM_VERSION in CMakeToolchain",
     "tools.cmake.cmaketoolchain:system_processor": "Define CMAKE_SYSTEM_PROCESSOR in CMakeToolchain",
     "tools.env.virtualenv:auto_use": "Automatically activate virtualenv file generation",
-    "tools.cmake.cmake_layout.custom_settings": "Name of the settings that will produce a different build folder and different CMake presets names",
+    "tools.cmake.cmake_layout.build_folder_vars": "Settings and Options that will produce a different build folder and different CMake presets names",
     "tools.files.download:retry": "Number of retries in case of failure when downloading",
     "tools.files.download:retry_wait": "Seconds to wait between download attempts",
     "tools.gnu:make_program": "Indicate path to make program",

--- a/conans/test/functional/toolchains/cmake/test_cmake_toolchain.py
+++ b/conans/test/functional/toolchains/cmake/test_cmake_toolchain.py
@@ -520,6 +520,26 @@ def test_cmake_toolchain_runtime_types_cmake_older_than_3_15():
 
 
 @pytest.mark.tool_cmake(version="3.23")
+def test_cmake_presets_missing_option():
+    client = TestClient(path_with_spaces=False)
+    client.run("new hello/0.1 --template=cmake_exe")
+    settings_layout = '-c tools.cmake.cmake_layout.build_folder_vars=' \
+                      '\'["options.missing"]\''
+    client.run("install . {}".format(settings_layout))
+    assert os.path.exists(os.path.join(client.current_folder, "build", "generators"))
+
+
+@pytest.mark.tool_cmake(version="3.23")
+def test_cmake_presets_missing_setting():
+    client = TestClient(path_with_spaces=False)
+    client.run("new hello/0.1 --template=cmake_exe")
+    settings_layout = '-c tools.cmake.cmake_layout.build_folder_vars=' \
+                      '\'["settings.missing"]\''
+    client.run("install . {}".format(settings_layout))
+    assert os.path.exists(os.path.join(client.current_folder, "build", "generators"))
+
+
+@pytest.mark.tool_cmake(version="3.23")
 def test_cmake_presets_multiple_settings_single_config():
     client = TestClient(path_with_spaces=False)
     client.run("new hello/0.1 --template=cmake_exe")

--- a/conans/test/functional/toolchains/cmake/test_cmake_toolchain.py
+++ b/conans/test/functional/toolchains/cmake/test_cmake_toolchain.py
@@ -658,19 +658,13 @@ def test_cmake_presets_multiple_settings_multi_config():
     # We can build with cmake manually
     if platform.system() == "Windows":
         client.run_command("cmake . --preset default-msvc-192-17")
+
         client.run_command("cmake --build --preset Release-msvc-192-17")
-        client.run_command("build-msvc-192-17/Release/hello")
+        client.run_command("build-msvc-192-17\\Release\\hello")
         assert "Hello World Release!" in client.out
-        assert "__cplusplus2017" in client.out
+        assert "MSVC_LANG2017" in client.out
 
-        client.run_command("cmake . --preset default-msvc-192-17")
         client.run_command("cmake --build --preset Debug-msvc-192-17")
-        client.run_command("build-msvc-192-17/Debug/hello")
+        client.run_command("build-msvc-192-17\\Debug\\hello")
         assert "Hello World Debug!" in client.out
-        assert "__cplusplus2017" in client.out
-
-        client.run_command("cmake . --preset default-msvc-193-20")
-        client.run_command("cmake --build --preset Release-193-20")
-        client.run_command("build-msvc-193-20/Debug/hello")
-        assert "Hello World Release!" in client.out
-        assert "__cplusplus2020" in client.out
+        assert "MSVC_LANG2017" in client.out

--- a/conans/test/functional/toolchains/cmake/test_cmake_toolchain.py
+++ b/conans/test/functional/toolchains/cmake/test_cmake_toolchain.py
@@ -532,7 +532,7 @@ def test_cmake_presets_multiple_settings_single_config():
     settings = "-s compiler=gcc -s compiler.libcxx=libstdc++11 " \
                "-s compiler.version=11 -s compiler.cppstd=17"
     client.run("install . {} {}".format(settings, settings_layout))
-    assert os.path.exists(os.path.join(client.current_folder, "build", "generators-gcc-11-17"))
+    assert os.path.exists(os.path.join(client.current_folder, "build-gcc-11-17", "generators"))
     assert os.path.exists(user_presets_path)
     user_presets = json.loads(load(user_presets_path))
     assert len(user_presets["include"]) == 1
@@ -546,7 +546,7 @@ def test_cmake_presets_multiple_settings_single_config():
     # If we create the "Debug" one, it has the same toolchain and preset file, that is
     # always multiconfig
     client.run("install . {} -s build_type=Debug {}".format(settings, settings_layout))
-    assert os.path.exists(os.path.join(client.current_folder, "build", "generators-gcc-11-17"))
+    assert os.path.exists(os.path.join(client.current_folder, "build-gcc-11-17", "generators"))
     assert os.path.exists(user_presets_path)
     user_presets = json.loads(load(user_presets_path))
     assert len(user_presets["include"]) == 1
@@ -565,7 +565,7 @@ def test_cmake_presets_multiple_settings_single_config():
     settings = "-s compiler=gcc -s compiler.libcxx=libstdc++11 " \
                "-s compiler.version=12 -s compiler.cppstd=20"
     client.run("install . {} {}".format(settings, settings_layout))
-    assert os.path.exists(os.path.join(client.current_folder, "build", "generators-gcc-12-20"))
+    assert os.path.exists(os.path.join(client.current_folder, "build-gcc-12-20", "generators"))
     assert os.path.exists(user_presets_path)
     user_presets = json.loads(load(user_presets_path))
     # The [0] is the gcc 11 the [1] is the gcc 12
@@ -611,7 +611,7 @@ def test_cmake_presets_multiple_settings_multi_config():
     settings = "-s compiler=msvc -s compiler.runtime=dynamic " \
                "-s compiler.version=192 -s compiler.cppstd=17"
     client.run("install . {} {}".format(settings, settings_layout))
-    assert os.path.exists(os.path.join(client.current_folder, "build", "generators-msvc-192-17"))
+    assert os.path.exists(os.path.join(client.current_folder, "build-msvc-192-17", "generators"))
     assert os.path.exists(user_presets_path)
     user_presets = json.loads(load(user_presets_path))
     assert len(user_presets["include"]) == 1
@@ -625,7 +625,7 @@ def test_cmake_presets_multiple_settings_multi_config():
     # If we create the "Debug" one, it has the same toolchain and preset file, that is
     # always multiconfig
     client.run("install . {} -s build_type=Debug {}".format(settings, settings_layout))
-    assert os.path.exists(os.path.join(client.current_folder, "build", "generators-msvc-192-17"))
+    assert os.path.exists(os.path.join(client.current_folder, "build-msvc-192-17", "generators"))
     assert os.path.exists(user_presets_path)
     user_presets = json.loads(load(user_presets_path))
     assert len(user_presets["include"]) == 1
@@ -643,7 +643,7 @@ def test_cmake_presets_multiple_settings_multi_config():
     settings = "-s compiler=msvc -s compiler.runtime=dynamic " \
                "-s compiler.version=193 -s compiler.cppstd=20"
     client.run("install . {} {}".format(settings, settings_layout))
-    assert os.path.exists(os.path.join(client.current_folder, "build", "generators-msvc-193-20"))
+    assert os.path.exists(os.path.join(client.current_folder, "build-msvc-193-20", "generators"))
     assert os.path.exists(user_presets_path)
     user_presets = json.loads(load(user_presets_path))
     # The [0] is the msvc 192 the [1] is the msvc 193
@@ -659,18 +659,18 @@ def test_cmake_presets_multiple_settings_multi_config():
     if platform.system() == "Windows":
         client.run_command("cmake . --preset default-msvc-192-17")
         client.run_command("cmake --build --preset Release-msvc-192-17")
-        client.run_command("./build-gcc-11-17/Release/hello")
+        client.run_command("build-msvc-192-17/Release/hello")
         assert "Hello World Release!" in client.out
         assert "__cplusplus2017" in client.out
 
         client.run_command("cmake . --preset default-msvc-192-17")
         client.run_command("cmake --build --preset Debug-msvc-192-17")
-        client.run_command("./build-gcc-11-17/Debug/hello")
+        client.run_command("build-msvc-192-17/Debug/hello")
         assert "Hello World Debug!" in client.out
         assert "__cplusplus2017" in client.out
 
         client.run_command("cmake . --preset default-msvc-193-20")
         client.run_command("cmake --build --preset Release-193-20")
-        client.run_command("./build-msvc-193-20/Debug/hello")
+        client.run_command("build-msvc-193-20/Debug/hello")
         assert "Hello World Release!" in client.out
         assert "__cplusplus2020" in client.out

--- a/conans/test/functional/toolchains/cmake/test_cmake_toolchain.py
+++ b/conans/test/functional/toolchains/cmake/test_cmake_toolchain.py
@@ -609,7 +609,7 @@ def test_cmake_presets_options_single_config():
                   '"options.shared"]\''
 
     default_compiler = {"Darwin": "apple-clang",
-                        "Windows": "msvc",
+                        "Windows": "visual studio",  # FIXME:  replace it with 'msvc' in develop2
                         "Linux": "gcc"}.get(platform.system())
 
     for shared in (True, False):

--- a/conans/test/functional/toolchains/cmake/test_cmake_toolchain.py
+++ b/conans/test/functional/toolchains/cmake/test_cmake_toolchain.py
@@ -523,8 +523,9 @@ def test_cmake_toolchain_runtime_types_cmake_older_than_3_15():
 def test_cmake_presets_multiple_settings_single_config():
     client = TestClient(path_with_spaces=False)
     client.run("new hello/0.1 --template=cmake_exe")
-    settings_layout = '-c tools.cmake.cmake_layout.custom_settings=' \
-                      '\'["compiler", "compiler.version", "compiler.cppstd"]\''
+    settings_layout = '-c tools.cmake.cmake_layout.build_folder_vars=' \
+                      '\'["settings.compiler", "settings.compiler.version", ' \
+                      '   "settings.compiler.cppstd"]\''
 
     user_presets_path = os.path.join(client.current_folder, "CMakeUserPresets.json")
 
@@ -532,7 +533,8 @@ def test_cmake_presets_multiple_settings_single_config():
     settings = "-s compiler=apple-clang -s compiler.libcxx=libc++ " \
                "-s compiler.version=12.0 -s compiler.cppstd=gnu17"
     client.run("install . {} {}".format(settings, settings_layout))
-    assert os.path.exists(os.path.join(client.current_folder, "build-apple-clang-12.0-gnu17", "generators"))
+    assert os.path.exists(os.path.join(client.current_folder, "build-apple-clang-12.0-gnu17",
+                                       "generators"))
     assert os.path.exists(user_presets_path)
     user_presets = json.loads(load(user_presets_path))
     assert len(user_presets["include"]) == 1
@@ -600,12 +602,51 @@ def test_cmake_presets_multiple_settings_single_config():
 
 
 @pytest.mark.tool_cmake(version="3.23")
+def test_cmake_presets_options_single_config():
+    client = TestClient(path_with_spaces=False)
+    client.run("new hello/0.1 --template=cmake_lib")
+    conf_layout = '-c tools.cmake.cmake_layout.build_folder_vars=\'["settings.compiler", ' \
+                  '"options.shared"]\''
+
+    default_compiler = {"Darwin": "apple-clang",
+                        "Windows": "msvc",
+                        "Linux": "gcc"}.get(platform.system())
+
+    for shared in (True, False):
+        client.run("install . {} -o shared={}".format(conf_layout, shared))
+        shared_str = "shared_true" if shared else "shared_false"
+        assert os.path.exists(os.path.join(client.current_folder,
+                                           "build-{}-{}".format(default_compiler, shared_str),
+                                           "generators"))
+
+    client.run("install . {}".format(conf_layout))
+    assert os.path.exists(os.path.join(client.current_folder,
+                                       "build-{}-shared_false".format(default_compiler),
+                                       "generators"))
+
+    user_presets_path = os.path.join(client.current_folder, "CMakeUserPresets.json")
+    assert os.path.exists(user_presets_path)
+
+    # We can build with cmake manually
+    if platform.system() == "Darwin":
+        for shared in (True, False):
+            shared_str = "shared_true" if shared else "shared_false"
+            client.run_command("cmake . --preset Release-apple-clang-{}".format(shared_str))
+            client.run_command("cmake --build --preset Release-apple-clang-{}".format(shared_str))
+            the_lib = "libhello.a" if not shared else "libhello.dylib"
+            path = os.path.join(client.current_folder,
+                                "cmake-build-release-apple-clang-{}".format(shared_str),
+                                the_lib)
+            assert os.path.exists(path)
+
+
+@pytest.mark.tool_cmake(version="3.23")
 @pytest.mark.skipif(platform.system() != "Windows", reason="Needs windows")
 def test_cmake_presets_multiple_settings_multi_config():
     client = TestClient(path_with_spaces=False)
     client.run("new hello/0.1 --template=cmake_exe")
-    settings_layout = '-c tools.cmake.cmake_layout.custom_settings=' \
-                      '\'["compiler.runtime", "compiler.cppstd"]\''
+    settings_layout = '-c tools.cmake.cmake_layout.build_folder_vars=' \
+                      '\'["settings.compiler.runtime", "settings.compiler.cppstd"]\''
 
     user_presets_path = os.path.join(client.current_folder, "CMakeUserPresets.json")
 
@@ -648,7 +689,7 @@ def test_cmake_presets_multiple_settings_multi_config():
     assert os.path.exists(os.path.join(client.current_folder, "build-static-17", "generators"))
     assert os.path.exists(user_presets_path)
     user_presets = json.loads(load(user_presets_path))
-    # The [0] is the msvc 192 the [1] is the msvc 193
+    # The [0] is the msvc dynamic/14 the [1] is the static/17
     assert len(user_presets["include"]) == 2
     presets = json.loads(load(user_presets["include"][1]))
     assert len(presets["configurePresets"]) == 1

--- a/conans/test/integration/build_helpers/cmake_apple_test.py
+++ b/conans/test/integration/build_helpers/cmake_apple_test.py
@@ -48,7 +48,7 @@ class CMakeAppleTest(unittest.TestCase):
                            ('watchOS', 'WatchOS.platform'),
                            ('tvOS', 'AppleTVOS.platform')
                            ])
-    def test_custom_settings(self, conan_os, expected_os):
+    def test_build_folder_vars(self, conan_os, expected_os):
         settings = MockSettings({"os": conan_os,
                                  "compiler": "apple-clang",
                                  "compiler.version": "11.0",

--- a/conans/test/unittests/model/other_settings_test.py
+++ b/conans/test/unittests/model/other_settings_test.py
@@ -58,7 +58,7 @@ cppstd=11""", client.out)
                       "'c2f0c2641722089d9b11cd646c47d239af044b5a' created",
                       client.out)
 
-    def test_custom_settings(self):
+    def test_build_folder_vars(self):
         settings = textwrap.dedent("""\
             os:
                 None:

--- a/conans/test/unittests/util/apple_test.py
+++ b/conans/test/unittests/util/apple_test.py
@@ -63,7 +63,7 @@ class AppleTest(unittest.TestCase):
         self.assertEqual(tools.apple_sdk_name(FakeSettings('iOS', 'armv8', 'iphonesimulator')),
                          'iphonesimulator')
 
-    def test_apple_sdk_name_custom_settings(self):
+    def test_apple_sdk_name_build_folder_vars(self):
         self.assertEqual(tools.apple_sdk_name(FakeSettings('Macos', 'ios_fat')), 'macosx')
         self.assertEqual(tools.apple_sdk_name(FakeSettings('iOS', 'ios_fat')), 'iphoneos')
         self.assertEqual(tools.apple_sdk_name(FakeSettings('watchOS', 'ios_fat')), 'watchos')


### PR DESCRIPTION
Changelog: Feature: Improved `cmake_layout` and `CMakePresets.json` feature so you can manage different configurations using the same `CMakeUserPresets.json` not only for multi-config (Debug/Release) but for any set of settings specified in a new conf `tools.cmake.cmake_layout:build_folder_vars` that accepts a list of settings to use. e.g `tools.cmake.cmake_layout:build_folder_vars=["settings.compiler", "options.shared"]`
Docs: https://github.com/conan-io/docs/pull/2561

Close https://github.com/conan-io/conan/issues/11189