### PR TITLE
Support CMAKE_SYSROOT in CMakeToolchain

### DIFF
--- a/conan/tools/cmake/toolchain/blocks.py
+++ b/conan/tools/cmake/toolchain/blocks.py
@@ -683,6 +683,9 @@ class GenericSystemBlock(Block):
         set(CMAKE_RC_COMPILER {{ compiler_rc }})
         endif()
         {% endif %}
+        {% if cmake_sysroot %}
+        set(CMAKE_SYSROOT {{ cmake_sysroot }})
+        {% endif %}
         """)
 
     def _get_toolset(self, generator):
@@ -824,6 +827,8 @@ class GenericSystemBlock(Block):
 
         system_name, system_version, system_processor = self._get_cross_build()
 
+        cmake_sysroot = self._conanfile.conf.get("tools.cmake.cmaketoolchain:cmake_sysroot")
+
         return {"compiler": compiler,
                 "compiler_rc": compiler_rc,
                 "compiler_cpp": compiler_cpp,
@@ -831,7 +836,8 @@ class GenericSystemBlock(Block):
                 "generator_platform": generator_platform,
                 "cmake_system_name": system_name,
                 "cmake_system_version": system_version,
-                "cmake_system_processor": system_processor}
+                "cmake_system_processor": system_processor,
+                "cmake_sysroot": cmake_sysroot}
 
 
 class OutputDirsBlock(Block):

--- a/conan/tools/cmake/toolchain/blocks.py
+++ b/conan/tools/cmake/toolchain/blocks.py
@@ -828,6 +828,7 @@ class GenericSystemBlock(Block):
         system_name, system_version, system_processor = self._get_cross_build()
 
         cmake_sysroot = self._conanfile.conf.get("tools.cmake.cmaketoolchain:cmake_sysroot")
+        cmake_sysroot = cmake_sysroot.replace("\\", "/") if cmake_sysroot is not None else None
 
         return {"compiler": compiler,
                 "compiler_rc": compiler_rc,
@@ -837,7 +838,7 @@ class GenericSystemBlock(Block):
                 "cmake_system_name": system_name,
                 "cmake_system_version": system_version,
                 "cmake_system_processor": system_processor,
-                "cmake_sysroot": cmake_sysroot.replace("\\", "/")}
+                "cmake_sysroot": cmake_sysroot}
 
 
 class OutputDirsBlock(Block):

--- a/conan/tools/cmake/toolchain/blocks.py
+++ b/conan/tools/cmake/toolchain/blocks.py
@@ -651,6 +651,10 @@ class TryCompileBlock(Block):
 
 class GenericSystemBlock(Block):
     template = textwrap.dedent("""
+        {% if cmake_sysroot %}
+        set(CMAKE_SYSROOT {{ cmake_sysroot }})
+        {% endif %}
+
         {% if cmake_system_name %}
         # Cross building
         set(CMAKE_SYSTEM_NAME {{ cmake_system_name }})
@@ -682,9 +686,6 @@ class GenericSystemBlock(Block):
         if(NOT DEFINED ENV{RC})
         set(CMAKE_RC_COMPILER {{ compiler_rc }})
         endif()
-        {% endif %}
-        {% if cmake_sysroot %}
-        set(CMAKE_SYSROOT {{ cmake_sysroot }})
         {% endif %}
         """)
 

--- a/conan/tools/cmake/toolchain/blocks.py
+++ b/conan/tools/cmake/toolchain/blocks.py
@@ -828,8 +828,10 @@ class GenericSystemBlock(Block):
 
         system_name, system_version, system_processor = self._get_cross_build()
 
-        cmake_sysroot = self._conanfile.conf.get("tools.cmake.cmaketoolchain:cmake_sysroot")
-        cmake_sysroot = cmake_sysroot.replace("\\", "/") if cmake_sysroot is not None else None
+        # This is handled by the tools.apple:sdk_path and CMAKE_OSX_SYSROOT in Apple 
+        if self._conanfile.settings_build.get_safe("os") != "Macos":
+            cmake_sysroot = self._conanfile.conf.get("tools.build:sysroot")
+            cmake_sysroot = cmake_sysroot.replace("\\", "/") if cmake_sysroot is not None else None
 
         return {"compiler": compiler,
                 "compiler_rc": compiler_rc,

--- a/conan/tools/cmake/toolchain/blocks.py
+++ b/conan/tools/cmake/toolchain/blocks.py
@@ -828,8 +828,9 @@ class GenericSystemBlock(Block):
 
         system_name, system_version, system_processor = self._get_cross_build()
 
-        # This is handled by the tools.apple:sdk_path and CMAKE_OSX_SYSROOT in Apple 
-        if self._conanfile.settings_build.get_safe("os") != "Macos":
+        # This is handled by the tools.apple:sdk_path and CMAKE_OSX_SYSROOT in Apple
+        cmake_sysroot = None
+        if not is_apple_os(self._conanfile.settings.get_safe("os")):
             cmake_sysroot = self._conanfile.conf.get("tools.build:sysroot")
             cmake_sysroot = cmake_sysroot.replace("\\", "/") if cmake_sysroot is not None else None
 

--- a/conan/tools/cmake/toolchain/blocks.py
+++ b/conan/tools/cmake/toolchain/blocks.py
@@ -837,7 +837,7 @@ class GenericSystemBlock(Block):
                 "cmake_system_name": system_name,
                 "cmake_system_version": system_version,
                 "cmake_system_processor": system_processor,
-                "cmake_sysroot": cmake_sysroot}
+                "cmake_sysroot": cmake_sysroot.replace("\\", "/")}
 
 
 class OutputDirsBlock(Block):

--- a/conan/tools/cmake/toolchain/blocks.py
+++ b/conan/tools/cmake/toolchain/blocks.py
@@ -829,10 +829,8 @@ class GenericSystemBlock(Block):
         system_name, system_version, system_processor = self._get_cross_build()
 
         # This is handled by the tools.apple:sdk_path and CMAKE_OSX_SYSROOT in Apple
-        cmake_sysroot = None
-        if not is_apple_os(self._conanfile.settings.get_safe("os")):
-            cmake_sysroot = self._conanfile.conf.get("tools.build:sysroot")
-            cmake_sysroot = cmake_sysroot.replace("\\", "/") if cmake_sysroot is not None else None
+        cmake_sysroot = self._conanfile.conf.get("tools.build:sysroot")
+        cmake_sysroot = cmake_sysroot.replace("\\", "/") if cmake_sysroot is not None else None
 
         return {"compiler": compiler,
                 "compiler_rc": compiler_rc,

--- a/conan/tools/gnu/autotoolsdeps.py
+++ b/conan/tools/gnu/autotoolsdeps.py
@@ -64,12 +64,6 @@ class AutotoolsDeps:
             cflags = flags.cflags
             cxxflags = flags.cxxflags
 
-            srf = flags.sysroot
-            if srf:
-                cflags.append(srf)
-                cxxflags.append(srf)
-                ldflags.append(srf)
-
             env = Environment()
             env.append("CPPFLAGS", cpp_flags)
             env.append("LIBS", libs)

--- a/conan/tools/gnu/autotoolstoolchain.py
+++ b/conan/tools/gnu/autotoolstoolchain.py
@@ -2,7 +2,7 @@ from conan.tools._check_build_profile import check_using_build_profile
 from conan.tools._compilers import architecture_flag, build_type_flags, cppstd_flag, \
     build_type_link_flags
 from conan.tools.apple.apple import apple_min_version_flag, to_apple_arch, \
-    apple_sdk_path
+    apple_sdk_path, is_apple_os
 from conan.tools.build.cross_building import cross_building, get_cross_building_settings
 from conan.tools.env import Environment
 from conan.tools.files.files import save_toolchain_args
@@ -68,7 +68,7 @@ class AutotoolsToolchain:
                 # -isysroot makes all includes for your library relative to the build directory
                 self.sysroot_flag = "-isysroot {}".format(sdk_path) if sdk_path else None
 
-        if os_build != "Macos":
+        if not is_apple_os(self._conanfile.settings.get_safe("os")):
             sysroot = self._conanfile.conf.get("tools.build:sysroot")
             sysroot = sysroot.replace("\\", "/") if sysroot is not None else None
             self.sysroot_flag = "--sysroot {}".format(sysroot) if sysroot else None

--- a/conan/tools/gnu/autotoolstoolchain.py
+++ b/conan/tools/gnu/autotoolstoolchain.py
@@ -68,10 +68,9 @@ class AutotoolsToolchain:
                 # -isysroot makes all includes for your library relative to the build directory
                 self.sysroot_flag = "-isysroot {}".format(sdk_path) if sdk_path else None
 
-        if not is_apple_os(self._conanfile.settings.get_safe("os")):
-            sysroot = self._conanfile.conf.get("tools.build:sysroot")
-            sysroot = sysroot.replace("\\", "/") if sysroot is not None else None
-            self.sysroot_flag = "--sysroot {}".format(sysroot) if sysroot else None
+        sysroot = self._conanfile.conf.get("tools.build:sysroot")
+        sysroot = sysroot.replace("\\", "/") if sysroot is not None else None
+        self.sysroot_flag = "--sysroot {}".format(sysroot) if sysroot else None
 
         check_using_build_profile(self._conanfile)
 

--- a/conan/tools/gnu/autotoolstoolchain.py
+++ b/conan/tools/gnu/autotoolstoolchain.py
@@ -48,7 +48,7 @@ class AutotoolsToolchain:
         self._build = None
         self._target = None
 
-        self.apple_arch_flag = None
+        self.apple_arch_flag = self.apple_isysroot_flag = None
         self.apple_min_version_flag = apple_min_version_flag(self._conanfile)
 
         self.sysroot_flag = None
@@ -66,7 +66,7 @@ class AutotoolsToolchain:
                 # https://man.archlinux.org/man/clang.1.en#Target_Selection_Options
                 self.apple_arch_flag = "-arch {}".format(apple_arch) if apple_arch else None
                 # -isysroot makes all includes for your library relative to the build directory
-                self.sysroot_flag = "-isysroot {}".format(sdk_path) if sdk_path else None
+                self.apple_isysroot_flag = "-isysroot {}".format(sdk_path) if sdk_path else None
 
         sysroot = self._conanfile.conf.get("tools.build:sysroot")
         sysroot = sysroot.replace("\\", "/") if sysroot is not None else None
@@ -138,7 +138,7 @@ class AutotoolsToolchain:
     def environment(self):
         env = Environment()
 
-        apple_flags = [self.apple_arch_flag, self.apple_min_version_flag]
+        apple_flags = [self.apple_isysroot_flag, self.apple_arch_flag, self.apple_min_version_flag]
         fpic = "-fPIC" if self.fpic else None
         extra_flags = self._get_extra_flags()
 

--- a/conan/tools/gnu/gnudeps_flags.py
+++ b/conan/tools/gnu/gnudeps_flags.py
@@ -21,7 +21,6 @@ class GnuDepsFlags(object):
         self.libs = self._format_libraries(cpp_info.libs)
         self.frameworks = self._format_frameworks(cpp_info.frameworks)
         self.framework_paths = self._format_frameworks(cpp_info.frameworkdirs, is_path=True)
-        self.sysroot = self._sysroot_flag(cpp_info.sysroot)
 
         # Direct flags
         self.cxxflags = cpp_info.cxxflags or []
@@ -57,13 +56,6 @@ class GnuDepsFlags(object):
             return ["-F %s" % self._adjust_path(framework_path) for framework_path in frameworks]
         else:
             return ["-framework %s" % framework for framework in frameworks]
-
-    def _sysroot_flag(self, sysroot):
-        # FIXME: Missing support for subsystems
-        if not is_msvc(self._conanfile) and sysroot:
-            sysroot = self._adjust_path(sysroot)
-            return '--sysroot=%s' % sysroot
-        return ""
 
     def _format_include_paths(self, include_paths):
         if not include_paths:

--- a/conans/model/conf.py
+++ b/conans/model/conf.py
@@ -13,6 +13,7 @@ BUILT_IN_CONFS = {
     "tools.android:ndk_path": "Argument for the CMAKE_ANDROID_NDK",
     "tools.build:skip_test": "Do not execute CMake.test() and Meson.test() when enabled",
     "tools.build:jobs": "Default compile jobs number -jX Ninja, Make, /MP VS (default: max CPUs)",
+    "tools.build:sysroot": "Pass the --sysroot=<tools.build:sysroot> flag if available. (None by default)",
     "tools.cmake.cmaketoolchain:generator": "User defined CMake generator to use instead of default",
     "tools.cmake.cmaketoolchain:find_package_prefer_config": "Argument for the CMAKE_FIND_PACKAGE_PREFER_CONFIG",
     "tools.cmake.cmaketoolchain:toolchain_file": "Use other existing file rather than conan_toolchain.cmake one",

--- a/conans/test/functional/toolchains/cmake/test_cmake_toolchain.py
+++ b/conans/test/functional/toolchains/cmake/test_cmake_toolchain.py
@@ -780,11 +780,10 @@ def test_cmaketoolchain_sysroot():
     client.run("create . app/1.0@ -c tools.build:sysroot='{}'".format(fake_sysroot))
     assert "sysroot: '{}'".format(output_fake_sysroot) in client.out
 
-    set_sysroot_in_block = 'tc.blocks["generic_system"].values["cmake_sysroot"] = "{}"'.format(fake_sysroot)
-
+    # set in a block instead of using conf
+    set_sysroot_in_block = 'tc.blocks["generic_system"].values["cmake_sysroot"] = "{}"'.format(output_fake_sysroot)
     client.save({
         "conanfile.py": conanfile.format(set_sysroot_in_block),
     })
-
     client.run("create . app/1.0@")
     assert "sysroot: '{}'".format(output_fake_sysroot) in client.out

--- a/conans/test/functional/toolchains/cmake/test_cmake_toolchain.py
+++ b/conans/test/functional/toolchains/cmake/test_cmake_toolchain.py
@@ -737,3 +737,10 @@ def test_cmake_presets_multiple_settings_multi_config():
     client.run_command("build-static-17\\Release\\hello")
     assert "Hello World Release!" in client.out
     assert "MSVC_LANG2017" in client.out
+
+
+@pytest.mark.tool_cmake
+def test_cmake_presets_multiple_settings_multi_config():
+    client = TestClient(path_with_spaces=False)
+    client.run("new hello/0.1 --template=cmake_lib")
+

--- a/conans/test/functional/toolchains/cmake/test_cmake_toolchain.py
+++ b/conans/test/functional/toolchains/cmake/test_cmake_toolchain.py
@@ -2,14 +2,13 @@ import json
 import os
 import platform
 import textwrap
-import re
 
 import pytest
 
 from conan.tools.cmake.presets import load_cmake_presets
 from conan.tools.microsoft.visual import vcvars_command
 from conans.client.tools import replace_in_file
-from conans.model.ref import ConanFileReference, PackageReference
+from conans.model.ref import ConanFileReference
 from conans.test.assets.cmake import gen_cmakelists
 from conans.test.assets.genconanfile import GenConanfile
 from conans.test.utils.tools import TestClient, TurboTestClient

--- a/conans/test/functional/toolchains/cmake/test_cmake_toolchain.py
+++ b/conans/test/functional/toolchains/cmake/test_cmake_toolchain.py
@@ -775,7 +775,7 @@ def test_cmaketoolchain_sysroot():
     })
 
     fake_sysroot = os.path.join("/usr/fakesysroot")
-    client.run("create . app/1.0@ -c tools.cmake.cmaketoolchain:cmake_sysroot='{}'".format(fake_sysroot))
+    client.run("create . app/1.0@ -c tools.build:sysroot='{}'".format(fake_sysroot))
 
     assert "sysroot: {}".format(fake_sysroot) in client.out
 

--- a/conans/test/functional/toolchains/cmake/test_cmake_toolchain.py
+++ b/conans/test/functional/toolchains/cmake/test_cmake_toolchain.py
@@ -796,7 +796,6 @@ def test_cmaketoolchain_sysroot():
 
     client.save({
         "conanfile.py": conanfile.format(set_sysroot_in_block),
-        "CMakeLists.txt": cmakelist
     })
 
     client.run("create . app/1.0@")

--- a/conans/test/functional/toolchains/cmake/test_cmake_toolchain.py
+++ b/conans/test/functional/toolchains/cmake/test_cmake_toolchain.py
@@ -776,22 +776,15 @@ def test_cmaketoolchain_sysroot():
     })
 
     fake_sysroot = client.current_folder
-    if platform.system() != "Darwin":
-        client.run("create . app/1.0@ -c tools.build:sysroot='{}'".format(fake_sysroot))
-        assert "sysroot: '{}'".format(fake_sysroot) in client.out
-        assert "osx_sysroot: ''" in client.out
-    else:
-        client.run("create . app/1.0@ -c tools.apple:sdk_path='{}'".format(fake_sysroot))
-        assert "osx_sysroot: '{}'".format(fake_sysroot) in client.out
-        assert "sysroot: ''" in client.out
+    output_fake_sysroot = fake_sysroot.replace("\\", "/") if platform.system() == "Windows" else fake_sysroot
+    client.run("create . app/1.0@ -c tools.build:sysroot='{}'".format(fake_sysroot))
+    assert "sysroot: '{}'".format(output_fake_sysroot) in client.out
 
-    if platform.system() != "Darwin":
-        set_sysroot_in_block = 'tc.blocks["generic_system"].values["cmake_sysroot"] = "{}"'.format(fake_sysroot)
+    set_sysroot_in_block = 'tc.blocks["generic_system"].values["cmake_sysroot"] = "{}"'.format(fake_sysroot)
 
-        client.save({
-            "conanfile.py": conanfile.format(set_sysroot_in_block),
-        })
+    client.save({
+        "conanfile.py": conanfile.format(set_sysroot_in_block),
+    })
 
-        client.run("create . app/1.0@")
-
-        assert "sysroot: '{}'".format(fake_sysroot) in client.out
+    client.run("create . app/1.0@")
+    assert "sysroot: '{}'".format(output_fake_sysroot) in client.out

--- a/conans/test/integration/toolchains/gnu/test_autotoolsdeps.py
+++ b/conans/test/integration/toolchains/gnu/test_autotoolsdeps.py
@@ -103,15 +103,15 @@ def test_cpp_info_aggregation():
                 self.output.warn(env["CXXFLAGS"])
 
                 # The topological order puts dep2 before dep1
-                assert env["CXXFLAGS"] == 'dep2_a_cxx_flag dep1_a_cxx_flag --sysroot=/path/to/folder/dep2'
-                assert env["CFLAGS"] == 'dep2_a_c_flag dep1_a_c_flag --sysroot=/path/to/folder/dep2'
+                assert env["CXXFLAGS"] == 'dep2_a_cxx_flag dep1_a_cxx_flag'
+                assert env["CFLAGS"] == 'dep2_a_c_flag dep1_a_c_flag'
                 assert env["LIBS"] == "-ldep2_onelib -ldep2_twolib -ldep1_onelib -ldep1_twolib "\
                                       "-ldep2_onesystemlib -ldep2_twosystemlib "\
                                       "-ldep1_onesystemlib -ldep1_twosystemlib"
 
                 assert env["LDFLAGS"].startswith('dep1_shared_link_flag dep2_exe_link_flag dep1_exe_link_flag -framework dep2_oneframework -framework dep2_twoframework ' \
                                      '-framework dep1_oneframework -framework dep1_twoframework ')
-                assert '--sysroot=/path/to/folder/dep2 OtherSuperStuff' in env["LDFLAGS"]
+                assert 'OtherSuperStuff' in env["LDFLAGS"]
     """)
 
     t.save({"conanfile.py": consumer})

--- a/conans/test/unittests/client/toolchain/autotools/autotools_toolchain_test.py
+++ b/conans/test/unittests/client/toolchain/autotools/autotools_toolchain_test.py
@@ -321,7 +321,7 @@ def test_apple_isysrootflag():
          "arch": "armv8"})
     be = AutotoolsToolchain(conanfile)
     expected = "-isysroot /path/to/sdk"
-    assert be.sysroot_flag == expected
+    assert be.apple_isysroot_flag == expected
     env = be.vars()
     assert expected in env["CXXFLAGS"]
     assert expected in env["CFLAGS"]
@@ -335,7 +335,7 @@ def test_apple_isysrootflag():
          "os.version": "14",
          "arch": "armv8"})
     be = AutotoolsToolchain(conanfile)
-    assert be.sysroot_flag is None
+    assert be.apple_isysroot_flag is None
 
 
 def test_sysrootflag():

--- a/conans/test/unittests/client/toolchain/autotools/autotools_toolchain_test.py
+++ b/conans/test/unittests/client/toolchain/autotools/autotools_toolchain_test.py
@@ -1,3 +1,4 @@
+import platform
 from os import chdir
 
 import pytest
@@ -335,6 +336,23 @@ def test_apple_isysrootflag():
          "arch": "armv8"})
     be = AutotoolsToolchain(conanfile)
     assert be.sysroot_flag is None
+
+
+def test_sysrootflag():
+    """Even when no cross building it is adjusted because it could target a Mac version"""
+    conanfile = ConanFileMock()
+    conanfile.conf.define("tools.build:sysroot", "/path/to/sysroot")
+    conanfile.settings = MockSettings(
+        {"build_type": "Debug",
+         "os": {"Darwin": "Macos"}.get(platform.system(), platform.system()),
+         "arch": "x86_64"})
+    be = AutotoolsToolchain(conanfile)
+    expected = "--sysroot /path/to/sysroot"
+    assert be.sysroot_flag == expected
+    env = be.vars()
+    assert expected in env["CXXFLAGS"]
+    assert expected in env["CFLAGS"]
+    assert expected in env["LDFLAGS"]
 
 
 def test_custom_defines():

--- a/conans/test/unittests/client/toolchain/autotools/autotools_toolchain_test.py
+++ b/conans/test/unittests/client/toolchain/autotools/autotools_toolchain_test.py
@@ -320,7 +320,7 @@ def test_apple_isysrootflag():
          "arch": "armv8"})
     be = AutotoolsToolchain(conanfile)
     expected = "-isysroot /path/to/sdk"
-    assert be.apple_isysroot_flag == expected
+    assert be.sysroot_flag == expected
     env = be.vars()
     assert expected in env["CXXFLAGS"]
     assert expected in env["CFLAGS"]
@@ -334,7 +334,7 @@ def test_apple_isysrootflag():
          "os.version": "14",
          "arch": "armv8"})
     be = AutotoolsToolchain(conanfile)
-    assert be.apple_isysroot_flag is None
+    assert be.sysroot_flag is None
 
 
 def test_custom_defines():


### PR DESCRIPTION
Changelog: Feature: Add `CMAKE_SYSROOT` support for `CMakeToolchain`.
Changelog: Feature: Add `--sysroot` support for `AutotoolsToolchain` and remove support for `cpp_info.sysroot` in `AutotoolsDeps`.
Changelog: Feature: Add `tools.build:sysroot` conf.


Docs: https://github.com/conan-io/docs/pull/2564
