### PR TITLE
[feature] Add tools can_run

### DIFF
--- a/conan/tools/build/__init__.py
+++ b/conan/tools/build/__init__.py
@@ -1,2 +1,2 @@
 from conan.tools.build.cpu import build_jobs
-from conan.tools.build.cross_building import cross_building
+from conan.tools.build.cross_building import cross_building, can_run

--- a/conan/tools/build/cross_building.py
+++ b/conan/tools/build/cross_building.py
@@ -36,6 +36,6 @@ def can_run(conanfile):
     See https://github.com/conan-io/conan/issues/11035
     """
     allowed = conanfile.conf.get("tools.build.cross_building:can_run", check_type=bool)
-    if not allowed:
+    if allowed is None:
         return not cross_building(conanfile)
-    return True
+    return allowed

--- a/conan/tools/build/cross_building.py
+++ b/conan/tools/build/cross_building.py
@@ -28,3 +28,14 @@ def get_cross_building_settings(conanfile):
                 os_host, arch_host)
     else:
         return os_host, arch_host, os_host, arch_host
+
+
+def can_run(conanfile):
+    """
+    Validates if the current build platform can run a file which is not for same arch
+    See https://github.com/conan-io/conan/issues/11035
+    """
+    allowed = conanfile.conf.get("tools.build.cross_building:can_run", check_type=bool)
+    if not allowed:
+        return not cross_building(conanfile)
+    return True

--- a/conans/test/unittests/tools/build/test_can_run.py
+++ b/conans/test/unittests/tools/build/test_can_run.py
@@ -1,0 +1,66 @@
+import pytest
+
+from conans.test.utils.mocks import MockSettings, ConanFileMock
+from conan.tools.build import can_run
+
+
+class ConfigMock:
+    def __init__(self, run=None):
+        self.can_run = run
+
+    def get(self, conf_name, default=None, check_type=None):
+        return self.can_run
+
+
+@pytest.mark.parametrize("expected", [False, True])
+def test_can_run_explicit_config(expected):
+    """ When the config tools.build.cross_building:can_run is declared and evaluated (True|False),
+        can_run must return the same value.
+    """
+    config = ConfigMock(expected)
+    settings = MockSettings({"os": "Macos",
+                             "compiler": "apple-clang",
+                             "compiler.version": "11.0",
+                             "arch": "armv8"})
+    conanfile = ConanFileMock(settings)
+    conanfile.conf = config
+    assert expected == can_run(conanfile)
+
+
+@pytest.mark.parametrize("arch, expected", [("x86_64", False), ("armv8", True)])
+def test_can_run_cross_building(arch, expected):
+    """ When the config is None, and is cross-building, can_run must return False.
+    """
+    config = ConfigMock(None)
+    settings_build = MockSettings({"os": "Macos",
+                             "compiler": "apple-clang",
+                             "compiler.version": "11.0",
+                             "arch": "armv8"})
+    settings = MockSettings({"os": "Macos",
+                             "compiler": "apple-clang",
+                             "compiler.version": "11.0",
+                             "arch": arch})
+    conanfile = ConanFileMock()
+    conanfile.settings = settings
+    conanfile.settings_build = settings_build
+    conanfile.conf = config
+    assert expected == can_run(conanfile)
+
+
+def test_can_run_cross_building_with_explicit():
+    """ When the config is True or False, and is cross-building, can_run must follow the config.
+    """
+    config = ConfigMock(True)
+    settings_build = MockSettings({"os": "Macos",
+                             "compiler": "apple-clang",
+                             "compiler.version": "11.0",
+                             "arch": "armv8"})
+    settings = MockSettings({"os": "Macos",
+                             "compiler": "apple-clang",
+                             "compiler.version": "11.0",
+                             "arch": "x86_64"})
+    conanfile = ConanFileMock()
+    conanfile.settings = settings
+    conanfile.settings_build = settings_build
+    conanfile.conf = config
+    assert True == can_run(conanfile)


### PR DESCRIPTION
- Added under cross_building namespace
- TODO: Elaborate tests 

Changelog: Feature: Tools `can_run` validates if it is possible to run a and application build for a non-native architecture.
Docs: https://github.com/conan-io/docs/pull/2547
closes #11035

- [x] Refer to the issue that supports this Pull Request.
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [x] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 

<sup>**Note:** By default this PR will skip the slower tests and will use a limited set of python versions. Check [here](https://github.com/conan-io/conan/blob/develop/.github/PR_INCREASE_TESTING.md) how to increase the testing level by writing some tags in the current PR body text.</sup>
