### PR TITLE
Bazeldeps: get lib file path by basename

### DIFF
--- a/conan/tools/google/bazeldeps.py
+++ b/conan/tools/google/bazeldeps.py
@@ -168,6 +168,10 @@ class BazelDeps(object):
                 full_path = os.path.join(libdir, f)
                 if not os.path.isfile(full_path):  # Make sure that directories are excluded
                     continue
+                # Users may not name their libraries in a conventional way. For example, directly
+                # use the basename of the lib file as lib name.
+                if f == lib:
+                    return full_path
                 name, ext = os.path.splitext(f)
                 if ext in (".so", ".lib", ".a", ".dylib", ".bc"):
                     if ext != ".lib" and name.startswith("lib"):

--- a/conans/test/unittests/tools/google/test_bazeldeps.py
+++ b/conans/test/unittests/tools/google/test_bazeldeps.py
@@ -50,6 +50,41 @@ def test_bazeldeps_dependency_buildfiles():
             assert 'deps = [\n    \n    ":lib1_precompiled",' in dependency_content
 
 
+def test_bazeldeps_get_lib_file_path_by_basename():
+    conanfile = ConanFile(Mock(), None)
+
+    cpp_info = CppInfo("mypkg", "dummy_root_folder1")
+    cpp_info.defines = ["DUMMY_DEFINE=\"string/value\""]
+    cpp_info.system_libs = ["system_lib1"]
+    cpp_info.libs = ["liblib1.a"]
+
+    conanfile_dep = ConanFile(Mock(), None)
+    conanfile_dep.cpp_info = cpp_info
+    conanfile_dep._conan_node = Mock()
+    conanfile_dep._conan_node.ref = ConanFileReference.loads("OriginalDepName/1.0")
+    package_folder = temp_folder()
+    save(os.path.join(package_folder, "lib", "liblib1.a"), "")
+    conanfile_dep.folders.set_base_package(package_folder)
+
+    # FIXME: This will run infinite loop if conanfile.dependencies.host.topological_sort.
+    #  Move to integration test
+    with mock.patch('conans.ConanFile.dependencies', new_callable=mock.PropertyMock) as mock_deps:
+        req = Requirement(ConanFileReference.loads("OriginalDepName/1.0"))
+        mock_deps.return_value = ConanFileDependencies({req: ConanFileInterface(conanfile_dep)})
+
+        bazeldeps = BazelDeps(conanfile)
+
+        for dependency in bazeldeps._conanfile.dependencies.host.values():
+            dependency_content = bazeldeps._get_dependency_buildfile_content(dependency)
+            assert 'cc_library(\n    name = "OriginalDepName",' in dependency_content
+            assert """defines = ["DUMMY_DEFINE=\\\\\\"string/value\\\\\\""]""" in dependency_content
+            if platform.system() == "Windows":
+                assert 'linkopts = ["/DEFAULTLIB:system_lib1"]' in dependency_content
+            else:
+                assert 'linkopts = ["-lsystem_lib1"],' in dependency_content
+            assert 'deps = [\n    \n    ":liblib1.a_precompiled",' in dependency_content
+
+
 def test_bazeldeps_dependency_transitive():
     # Create main ConanFile
     conanfile = ConanFile(Mock(), None)


### PR DESCRIPTION
Changelog: Fix: BazelDeps generator cannot find a lib when it's named with the basename of the lib file.
Docs: omit

Users may not name their libraries in a conventional way.
Sometimes directly use the basename of the lib file as lib name.
We need to be able to find the lib in this case.

Close: #11331 

- [x] Refer to the issue that supports this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.

<sup>**Note:** By default this PR will skip the slower tests and will use a limited set of python versions. Check [here](https://github.com/conan-io/conan/blob/develop/.github/PR_INCREASE_TESTING.md) how to increase the testing level by writing some tags in the current PR body text.</sup>
