### PR TITLE
Add [layout] to `conanfile.txt`

### DIFF
--- a/conans/client/loader.py
+++ b/conans/client/loader.py
@@ -315,10 +315,13 @@ class ConanFileLoader(object):
             if not layout_method:
                 raise ConanException("Unknown predefined layout '{}' declared in "
                                      "conanfile.txt".format(parser.layout))
-            conanfile.layout = types.MethodType(layout_method, conanfile)
+
+            def layout(self):
+                layout_method(self)
+
+            conanfile.layout = types.MethodType(layout, conanfile)
 
         conanfile.generators = parser.generators
-
         try:
             options = OptionsValues.loads(parser.options)
         except Exception:

--- a/conans/client/loader.py
+++ b/conans/client/loader.py
@@ -3,10 +3,14 @@ import imp
 import inspect
 import os
 import sys
+import types
 import uuid
 
 import yaml
 
+from conan.tools.cmake import cmake_layout
+from conan.tools.google import bazel_layout
+from conan.tools.microsoft import vs_layout
 from conans.client.conf.required_version import validate_conan_version
 from conans.client.loader_txt import ConanFileTextLoader
 from conans.client.tools.files import chdir
@@ -304,6 +308,14 @@ class ConanFileLoader(object):
             if not hasattr(conanfile, "build_requires"):
                 conanfile.build_requires = []
             conanfile.build_requires.append(build_reference)
+        if parser.layout:
+            layout_method = {"cmake_layout": cmake_layout,
+                             "vs_layout": vs_layout,
+                             "bazel_layout": bazel_layout}.get(parser.layout)
+            if not layout_method:
+                raise ConanException("Unknown predefined layout '{}' declared in "
+                                     "conanfile.txt".format(parser.layout))
+            conanfile.layout = types.MethodType(layout_method, conanfile)
 
         conanfile.generators = parser.generators
 

--- a/conans/client/loader_txt.py
+++ b/conans/client/loader_txt.py
@@ -8,8 +8,18 @@ class ConanFileTextLoader(object):
     def __init__(self, input_text):
         # Prefer composition over inheritance, the __getattr__ was breaking things
         self._config_parser = ConfigParser(input_text,  ["requires", "generators", "options",
-                                                         "imports", "build_requires", "tool_requires"],
+                                                         "imports", "build_requires",
+                                                         "tool_requires", "layout"],
                                            parse_lines=True)
+
+    @property
+    def layout(self):
+        """returns the declared layout"""
+        tmp = [r.strip() for r in self._config_parser.layout.splitlines()]
+        if len(tmp) > 1:
+            raise ConanException("Only one layout can be declared in the [layout] section of "
+                                 "the conanfile.txt")
+        return tmp[0]
 
     @property
     def requirements(self):

--- a/conans/client/loader_txt.py
+++ b/conans/client/loader_txt.py
@@ -19,7 +19,7 @@ class ConanFileTextLoader(object):
         if len(tmp) > 1:
             raise ConanException("Only one layout can be declared in the [layout] section of "
                                  "the conanfile.txt")
-        return tmp[0]
+        return tmp[0] if tmp else None
 
     @property
     def requirements(self):

--- a/conans/test/conftest.py
+++ b/conans/test/conftest.py
@@ -76,6 +76,7 @@ tools_locations = {
         "3.23": {
             "path": {'Windows': 'C:/cmake/cmake-3.23.1-win64-x64/bin',
                      'Darwin': '/Users/jenkins/cmake/cmake-3.23.1/bin',
+                     # Not available in Linux
                      'Linux': None}
         }
     },
@@ -188,6 +189,12 @@ def _get_tool(name, version):
                 _cached_tools[name][version] = False
                 return False
             tool_path = tool_version.get("path", {}).get(tool_platform)
+            # To allow to skip for a platform, we can put the path to None
+            # "cmake": { "3.23": {
+            #               "path": {'Windows': 'C:/cmake/cmake-3.23.1-win64-x64/bin',
+            #                        'Darwin': '/Users/jenkins/cmake/cmake-3.23.1/bin',
+            #                        'Linux': None}}
+            #          }
             if tool_path is None:
                 _cached_tools[name][version] = False
                 return False

--- a/conans/test/conftest.py
+++ b/conans/test/conftest.py
@@ -76,7 +76,7 @@ tools_locations = {
         "3.23": {
             "path": {'Windows': 'C:/cmake/cmake-3.23.1-win64-x64/bin',
                      'Darwin': '/Users/jenkins/cmake/cmake-3.23.1/bin',
-                     'Linux': '/usr/share/cmake-3.23.1/bin'}
+                     'Linux': None}
         }
     },
     'ninja': {
@@ -188,6 +188,10 @@ def _get_tool(name, version):
                 _cached_tools[name][version] = False
                 return False
             tool_path = tool_version.get("path", {}).get(tool_platform)
+            if tool_path is None:
+                _cached_tools[name][version] = False
+                return False
+
         else:
             if version is not None:  # if the version is specified, it should be in the conf
                 _cached_tools[name][version] = True

--- a/conans/test/functional/toolchains/cmake/test_cmake_toolchain.py
+++ b/conans/test/functional/toolchains/cmake/test_cmake_toolchain.py
@@ -811,20 +811,24 @@ def test_cmake_presets_with_conanfile_txt():
     assert os.path.exists(os.path.join(c.current_folder, "CMakeUserPresets.json"))
     presets_path = os.path.join(c.current_folder, "build", "generators", "CMakePresets.json")
     assert os.path.exists(presets_path)
-    c.run_command("cmake --preset Debug")
-    c.run_command("cmake --build --preset Debug")
+
     if platform.system() != "Windows":
+        c.run_command("cmake --preset Debug")
+        c.run_command("cmake --build --preset Debug")
         c.run_command("./cmake-build-debug/foo")
     else:
-        c.run_command("./build/Debug/foo")
+        c.run_command("cmake --preset default")
+        c.run_command("cmake --build --preset Debug")
+        c.run_command("build\\Debug\\foo")
 
     assert "Hello World Debug!" in c.out
 
-    c.run_command("cmake --preset Release")
-    c.run_command("cmake --build --preset Release")
     if platform.system() != "Windows":
+        c.run_command("cmake --preset Release")
+        c.run_command("cmake --build --preset Release")
         c.run_command("./cmake-build-release/foo")
     else:
-        c.run_command("./build/Release/foo")
+        c.run_command("cmake --build --preset Release")
+        c.run_command("build\\Release\\foo")
 
     assert "Hello World Release!" in c.out

--- a/conans/test/functional/toolchains/cmake/test_cmake_toolchain.py
+++ b/conans/test/functional/toolchains/cmake/test_cmake_toolchain.py
@@ -795,9 +795,6 @@ def test_cmaketoolchain_sysroot():
 def test_cmake_presets_with_conanfile_txt():
     c = TestClient()
 
-    c.run_command("cmake --version")
-    print(c.out)
-
     # FIXME: DEVELOP 2: c.run("new cmake_exe -d name=foo -d version=1.0")
     c.run("new foo/1.0 --template cmake_exe")
     os.unlink(os.path.join(c.current_folder, "conanfile.py"))

--- a/conans/test/functional/toolchains/cmake/test_cmake_toolchain.py
+++ b/conans/test/functional/toolchains/cmake/test_cmake_toolchain.py
@@ -790,10 +790,11 @@ def test_cmaketoolchain_sysroot():
     assert "sysroot: '{}'".format(output_fake_sysroot) in client.out
 
 
-@pytest.mark.tool("cmake", "3.23")
+# FIXME: DEVELOP2: @pytest.mark.tool("cmake", "3.23")
+@pytest.mark.tool_cmake(version="3.23")
 def test_cmake_presets_with_conanfile_txt():
     c = TestClient()
-    # DEVELOP 2: c.run("new cmake_exe -d name=foo -d version=1.0")
+    # FIXME: DEVELOP 2: c.run("new cmake_exe -d name=foo -d version=1.0")
     c.run("new foo/1.0 --template cmake_exe")
     os.unlink(os.path.join(c.current_folder, "conanfile.py"))
     c.save({"conanfile.txt": textwrap.dedent("""

--- a/conans/test/functional/toolchains/cmake/test_cmake_toolchain.py
+++ b/conans/test/functional/toolchains/cmake/test_cmake_toolchain.py
@@ -794,6 +794,10 @@ def test_cmaketoolchain_sysroot():
 @pytest.mark.tool_cmake(version="3.23")
 def test_cmake_presets_with_conanfile_txt():
     c = TestClient()
+
+    c.run_command("cmake --version")
+    print(c.out)
+
     # FIXME: DEVELOP 2: c.run("new cmake_exe -d name=foo -d version=1.0")
     c.run("new foo/1.0 --template cmake_exe")
     os.unlink(os.path.join(c.current_folder, "conanfile.py"))

--- a/conans/test/unittests/client/conanfile_loader_test.py
+++ b/conans/test/unittests/client/conanfile_loader_test.py
@@ -253,6 +253,34 @@ licenses, * -> ./licenses @ root_package=Pkg, folder=True, ignore_case=False, ex
                                    "Options should be specified as 'pkg:option=value'"):
             loader.load_conanfile_txt(file_path, create_profile())
 
+    def test_layout_not_predefined(self):
+        txt = textwrap.dedent("""
+                    [layout]
+                    missing
+                """)
+        tmp_dir = temp_folder()
+        file_path = os.path.join(tmp_dir, "conanfile.txt")
+        save(file_path, txt)
+        with pytest.raises(ConanException) as exc:
+            loader = ConanFileLoader(None, Mock(), None)
+            loader.load_conanfile_txt(file_path, create_profile())
+        assert "Unknown predefined layout 'missing'" in str(exc.value)
+
+    def test_layout_multiple(self):
+        txt = textwrap.dedent("""
+                    [layout]
+                    cmake_layout
+                    vs_layout
+                """)
+        tmp_dir = temp_folder()
+        file_path = os.path.join(tmp_dir, "conanfile.txt")
+        save(file_path, txt)
+        with pytest.raises(ConanException) as exc:
+            loader = ConanFileLoader(None, Mock(), None)
+            loader.load_conanfile_txt(file_path, create_profile())
+        assert "Only one layout can be declared in the [layout] section of the conanfile.txt" \
+               in str(exc.value)
+
 
 class ImportModuleLoaderTest(unittest.TestCase):
     @staticmethod


### PR DESCRIPTION
Changelog: Feature: The ``conanfile.txt`` file now accepts a ``[layout]`` that can be filled with 3 predefined layouts: ``cmake_layout``, ``vs_layout`` and ``bazel_layout``. 
Docs: https://github.com/conan-io/docs/pull/2554
 
Closes #11286