### PR TITLE
Fix: interface_library should be used with shared_library on Windows

### DIFF
--- a/conan/tools/google/bazeldeps.py
+++ b/conan/tools/google/bazeldeps.py
@@ -66,6 +66,14 @@ class BazelDeps(object):
             )
             {% endfor %}
 
+            {% for libname, (lib_path, dll_path) in shared_with_interface_libs.items() %}
+            cc_import(
+                name = "{{ libname }}_precompiled",
+                interface_library = "{{ lib_path }}",
+                shared_library = "{{ dll_path }}",
+            )
+            {% endfor %}
+
             cc_library(
                 name = "{{ name }}",
                 {% if headers %}
@@ -81,9 +89,12 @@ class BazelDeps(object):
                 linkopts = [{{ linkopts }}],
                 {% endif %}
                 visibility = ["//visibility:public"],
-                {% if libs %}
+                {% if libs or shared_with_interface_libs %}
                 deps = [
                 {% for lib in libs %}
+                ":{{ lib }}_precompiled",
+                {% endfor %}
+                {% for lib in shared_with_interface_libs %}
                 ":{{ lib }}_precompiled",
                 {% endfor %}
                 {% for dep in dependencies %}
@@ -137,16 +148,26 @@ class BazelDeps(object):
         for req, dep in dependency.dependencies.items():
             dependencies.append(dep.ref.name)
 
-        libs = {}
-        for lib in cpp_info.libs:
-            real_path = self._get_lib_file_paths(cpp_info.libdirs, lib)
-            if real_path:
-                libs[lib] = _relativize_path(real_path, package_folder)
-
         shared_library = dependency.options.get_safe("shared") if dependency.options else False
+
+        libs = {}
+        shared_with_interface_libs = {}
+        for lib in cpp_info.libs:
+            lib_path, dll_path = self._get_lib_file_paths(shared_library,
+                                                          cpp_info.libdirs,
+                                                          cpp_info.bindirs,
+                                                          lib)
+            if lib_path and dll_path:
+                shared_with_interface_libs[lib] = (
+                    _relativize_path(lib_path, package_folder),
+                    _relativize_path(dll_path, package_folder))
+            elif lib_path:
+                libs[lib] = _relativize_path(lib_path, package_folder)
+
         context = {
             "name": dependency.ref.name,
             "libs": libs,
+            "shared_with_interface_libs": shared_with_interface_libs,
             "libdir": lib_dir,
             "headers": headers,
             "includes": includes,
@@ -158,12 +179,31 @@ class BazelDeps(object):
         content = Template(template).render(**context)
         return content
 
-    def _get_lib_file_paths(self, libdirs, lib):
+    def _get_dll_file_paths(self, bindirs, expected_file):
+        """Find a given dll file in bin directories. If found return the full
+        path, otherwise return None.
+        """
+        for each_bin in bindirs:
+            if not os.path.exists(each_bin):
+                self._conanfile.output.warning("The bin folder doesn't exist: {}".format(each_bin))
+                continue
+            files = os.listdir(each_bin)
+            for f in files:
+                full_path = os.path.join(each_bin, f)
+                if not os.path.isfile(full_path):
+                    continue
+                if f == expected_file:
+                    return full_path
+        return None
+
+    def _get_lib_file_paths(self, shared, libdirs, bindirs, lib):
         for libdir in libdirs:
             if not os.path.exists(libdir):
                 self._conanfile.output.warning("The library folder doesn't exist: {}".format(libdir))
                 continue
             files = os.listdir(libdir)
+            lib_basename = None
+            lib_path = None
             for f in files:
                 full_path = os.path.join(libdir, f)
                 if not os.path.isfile(full_path):  # Make sure that directories are excluded
@@ -171,15 +211,26 @@ class BazelDeps(object):
                 # Users may not name their libraries in a conventional way. For example, directly
                 # use the basename of the lib file as lib name.
                 if f == lib:
-                    return full_path
+                    lib_basename = f
+                    lib_path = full_path
+                    break
                 name, ext = os.path.splitext(f)
                 if ext in (".so", ".lib", ".a", ".dylib", ".bc"):
                     if ext != ".lib" and name.startswith("lib"):
                         name = name[3:]
                 if lib == name:
-                    return full_path
+                    lib_basename = f
+                    lib_path = full_path
+                    break
+            if lib_path is not None:
+                dll_path = None
+                name, ext = os.path.splitext(lib_basename)
+                if shared and ext == ".lib":
+                    dll_path = self._get_dll_file_paths(bindirs, name+".dll")
+                return lib_path, dll_path
         self._conanfile.output.warning("The library {} cannot be found in the "
                                        "dependency".format(lib))
+        return None, None
 
     def _create_new_local_repository(self, dependency, dependency_buildfile_name):
         if dependency.package_folder is None:


### PR DESCRIPTION
Changelog: Fix: Use `interface_library` with `shared_library` on Windows in BazelDeps.
Docs: omit
Close: #11347 

- [x] Refer to the issue that supports this Pull Request.
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.

When importing shared libraries, check if there is a corresponding DLL file in the bin directory. If the DLL file exists, we should use `cc_import` of the form:

```python
cc_import(
    name = "libname",
    interface_library = "lib/libname.lib",
    shared_library = "bin/libname.dll",
)
```

Bazel doc [here](https://bazel.build/reference/be/c-cpp#cc_import).

I also added a new `MockConanFileDeps` to avoid the infinite loop in unittest(No need to patch the `conans.ConanFile.dependecies` for all).

<sup>**Note:** By default this PR will skip the slower tests and will use a limited set of python versions. Check [here](https://github.com/conan-io/conan/blob/develop/.github/PR_INCREASE_TESTING.md) how to increase the testing level by writing some tags in the current PR body text.</sup>
