### PR TITLE
Conan declares python 3.6 as minimum with nice failure for python2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,7 @@ def generate_long_description_file():
 
 setup(
     name='conan',
-    python_requires='>=3.7',
+    python_requires='>=3.6',
     # Versions should comply with PEP440.  For a discussion on single-sourcing
     # the version across setup.py and the project code, see
     # https://packaging.python.org/en/latest/single_source_version.html

--- a/setup.py
+++ b/setup.py
@@ -46,13 +46,13 @@ def load_version():
 
 def generate_long_description_file():
     this_directory = path.abspath(path.dirname(__file__))
-    with open(path.join(this_directory, 'README.rst'), encoding='utf-8') as f:
+    with open(path.join(this_directory, 'README.rst')) as f:
         long_description = f.read()
     return long_description
 
-
 setup(
     name='conan',
+    python_requires='>=3.7',
     # Versions should comply with PEP440.  For a discussion on single-sourcing
     # the version across setup.py and the project code, see
     # https://packaging.python.org/en/latest/single_source_version.html


### PR DESCRIPTION
Changelog: omit
Docs: omit

Instead of an error for the encoding argument, it raises: 

`ERROR: Package 'conan' requires a different Python: 2.7.18 not in '>=3.6'`