### PR TITLE
accept pyyaml 6.0

### DIFF
--- a/conans/requirements.txt
+++ b/conans/requirements.txt
@@ -1,7 +1,7 @@
 requests>=2.25, <3.0.0
 urllib3>=1.26.6, <1.27
 colorama>=0.3.3, <0.5.0
-PyYAML>=3.11, <6.0
+PyYAML>=3.11, <=6.0
 patch-ng>=1.17.4, <1.18
 fasteners>=0.14.1
 six>=1.10.0,<=1.16.0


### PR DESCRIPTION
Changelog: Feature: Allow pyyaml 6.0 dependency.
Docs: Omit

Close https://github.com/conan-io/conan/issues/10759
