### PR TITLE
System package manager install set of equivalent packages

### DIFF
--- a/conan/tools/system/package_manager.py
+++ b/conan/tools/system/package_manager.py
@@ -61,6 +61,9 @@ class _SystemPackageManagerTool(object):
         if self._active_tool == self.__class__.tool_name:
             return method(*args, **kwargs)
 
+    def install_substitutes(self, *args, **kwargs):
+        return self.run(self._install_substitutes, *args, **kwargs)
+
     def install(self, *args, **kwargs):
         return self.run(self._install, *args, **kwargs)
 
@@ -69,6 +72,20 @@ class _SystemPackageManagerTool(object):
 
     def check(self, *args, **kwargs):
         return self.run(self._check, *args, **kwargs)
+
+    def _install_substitutes(self, *packages_substitutes, update=False, check=True, **kwargs):
+        errors = []
+        for packages in packages_substitutes:
+            try:
+                self.install(packages, update, check, **kwargs)
+                break
+            except ConanException as e:
+                errors.append(e)
+
+        if errors:
+            for error in errors:
+                self._conanfile.output.warn(str(error))
+            raise ConanException("None of the installs for the package substitutes succeeded.")
 
     def _install(self, packages, update=False, check=True, **kwargs):
         if update:

--- a/conan/tools/system/package_manager.py
+++ b/conan/tools/system/package_manager.py
@@ -77,8 +77,7 @@ class _SystemPackageManagerTool(object):
         errors = []
         for packages in packages_substitutes:
             try:
-                self.install(packages, update, check, **kwargs)
-                break
+                return self.install(packages, update, check, **kwargs)
             except ConanException as e:
                 errors.append(e)
 

--- a/conan/tools/system/package_manager.py
+++ b/conan/tools/system/package_manager.py
@@ -81,10 +81,9 @@ class _SystemPackageManagerTool(object):
             except ConanException as e:
                 errors.append(e)
 
-        if errors:
-            for error in errors:
-                self._conanfile.output.warn(str(error))
-            raise ConanException("None of the installs for the package substitutes succeeded.")
+        for error in errors:
+            self._conanfile.output.warn(str(error))
+        raise ConanException("None of the installs for the package substitutes succeeded.")
 
     def _install(self, packages, update=False, check=True, **kwargs):
         if update:

--- a/conans/test/functional/tools/system/package_manager_test.py
+++ b/conans/test/functional/tools/system/package_manager_test.py
@@ -9,7 +9,6 @@ from conans.test.utils.tools import TestClient
 
 @pytest.mark.tool_apt_get
 @pytest.mark.skipif(platform.system() != "Linux", reason="Requires apt")
-@pytest.mark.skipif(six.PY2, reason="Does not pass on Py2 with Pytest")
 def test_apt_check():
     client = TestClient()
     client.save({"conanfile.py": textwrap.dedent("""
@@ -30,7 +29,24 @@ def test_apt_check():
 
 @pytest.mark.tool_apt_get
 @pytest.mark.skipif(platform.system() != "Linux", reason="Requires apt")
-@pytest.mark.skipif(six.PY2, reason="Does not pass on Py2 with Pytest")
+def test_apt_install_substitutes():
+    client = TestClient()
+    client.save({"conanfile.py": textwrap.dedent("""
+        from conans import ConanFile
+        from conan.tools.system.package_manager import Apt
+        class MyPkg(ConanFile):
+            settings = "arch", "os"
+            def system_requirements(self):
+                apt = Apt(self)
+                apt.install_substitutes(["non-existing1", "non-existing2"],
+                                        ["non-existing3", "non-existing4"])
+        """)})
+    client.run("create . test/1.0@ -c tools.system.package_manager:mode=install", assert_error=True)
+    print(client.out)
+
+
+@pytest.mark.tool_apt_get
+@pytest.mark.skipif(platform.system() != "Linux", reason="Requires apt")
 def test_build_require():
     client = TestClient()
     client.save({"tool_require.py": textwrap.dedent("""
@@ -58,7 +74,6 @@ def test_build_require():
 
 @pytest.mark.tool_brew
 @pytest.mark.skipif(platform.system() != "Darwin", reason="Requires brew")
-@pytest.mark.skipif(six.PY2, reason="Does not pass on Py2 with Pytest")
 def test_brew_check():
     client = TestClient()
     client.save({"conanfile.py": textwrap.dedent("""

--- a/conans/test/functional/tools/system/package_manager_test.py
+++ b/conans/test/functional/tools/system/package_manager_test.py
@@ -31,7 +31,7 @@ def test_apt_check():
 @pytest.mark.skipif(platform.system() != "Linux", reason="Requires apt")
 def test_apt_install_substitutes():
     client = TestClient()
-    client.save({"conanfile.py": textwrap.dedent("""
+    conanfile_py = textwrap.dedent("""
         from conan import ConanFile
         from conan.tools.system.package_manager import Apt
         class MyPkg(ConanFile):
@@ -39,13 +39,17 @@ def test_apt_install_substitutes():
             def system_requirements(self):
                 # FIXME this is needed because the ci-functional apt-get update fails
                 try:
-                    self.run("apt-get update")
+                    self.run("sudo apt-get update")
                 except Exception:
                     pass
                 apt = Apt(self)
-                apt.install_substitutes(["non-existing1", "non-existing2"],
-                                        ["non-existing3", "non-existing4"])
-        """)})
+                {}
+        """)
+
+    client.run("remove test/1.0 -f")
+
+    installs = 'apt.install_substitutes(["non-existing1", "non-existing2"], ["non-existing3", "non-existing4"])'
+    client.save({"conanfile.py": conanfile_py.format(installs)})
     client.run("create . test/1.0@ -c tools.system.package_manager:mode=install "
                "-c tools.system.package_manager:sudo=True", assert_error=True)
     assert "dpkg-query: no packages found matching non-existing1:amd64" in client.out
@@ -54,6 +58,14 @@ def test_apt_install_substitutes():
     assert "dpkg-query: no packages found matching non-existing4:amd64" in client.out
     assert "ERROR: while executing system_requirements(): " \
            "None of the installs for the package substitutes succeeded." in client.out
+
+    client.run_command("sudo apt remove nano -yy")
+    installs = 'apt.install_substitutes(["non-existing1", "non-existing2"], ["nano"], ["non-existing3"])'
+    client.save({"conanfile.py": conanfile_py.format(installs)})
+    client.run("create . test/1.0@ -c tools.system.package_manager:mode=install "
+               "-c tools.system.package_manager:sudo=True")
+    assert "1 newly installed" in client.out
+    print(client.out)
 
 
 @pytest.mark.tool_apt_get

--- a/conans/test/functional/tools/system/package_manager_test.py
+++ b/conans/test/functional/tools/system/package_manager_test.py
@@ -38,11 +38,17 @@ def test_apt_install_substitutes():
             settings = "arch", "os"
             def system_requirements(self):
                 apt = Apt(self)
-                apt.install_substitutes(["non-existing1", "non-existing2"],
-                                        ["non-existing3", "non-existing4"])
+                apt.install_substitutes(["non-existing1", "non-e653-existing2"],
+                                        ["non-existing3", "non-e653-existing4"], update=True)
         """)})
-    client.run("create . test/1.0@ -c tools.system.package_manager:mode=install", assert_error=True)
-    print(client.out)
+    client.run("create . test/1.0@ -c tools.system.package_manager:mode=install "
+               "-c tools.system.package_manager:sudo=True", assert_error=True)
+    assert "dpkg-query: no packages found matching non-existing1:amd64" in client.out
+    assert "dpkg-query: no packages found matching non-existing2:amd64" in client.out
+    assert "dpkg-query: no packages found matching non-existing3:amd64" in client.out
+    assert "dpkg-query: no packages found matching non-existing4:amd64" in client.out
+    assert "ERROR: while executing system_requirements(): " \
+           "None of the installs for the package substitutes succeeded." in client.out
 
 
 @pytest.mark.tool_apt_get

--- a/conans/test/functional/tools/system/package_manager_test.py
+++ b/conans/test/functional/tools/system/package_manager_test.py
@@ -37,9 +37,14 @@ def test_apt_install_substitutes():
         class MyPkg(ConanFile):
             settings = "arch", "os"
             def system_requirements(self):
+                # FIXME this is needed because the ci-functional apt-get update fails
+                try:
+                    self.run("apt-get update")
+                except Exception:
+                    pass
                 apt = Apt(self)
-                apt.install_substitutes(["non-existing1", "non-e653-existing2"],
-                                        ["non-existing3", "non-e653-existing4"], update=True)
+                apt.install_substitutes(["non-existing1", "non-existing2"],
+                                        ["non-existing3", "non-existing4"])
         """)})
     client.run("create . test/1.0@ -c tools.system.package_manager:mode=install "
                "-c tools.system.package_manager:sudo=True", assert_error=True)

--- a/conans/test/functional/tools/system/package_manager_test.py
+++ b/conans/test/functional/tools/system/package_manager_test.py
@@ -12,7 +12,7 @@ from conans.test.utils.tools import TestClient
 def test_apt_check():
     client = TestClient()
     client.save({"conanfile.py": textwrap.dedent("""
-        from conans import ConanFile
+        from conan import ConanFile
         from conan.tools.system.package_manager import Apt
         class MyPkg(ConanFile):
             settings = "arch", "os"
@@ -32,7 +32,7 @@ def test_apt_check():
 def test_apt_install_substitutes():
     client = TestClient()
     client.save({"conanfile.py": textwrap.dedent("""
-        from conans import ConanFile
+        from conan import ConanFile
         from conan.tools.system.package_manager import Apt
         class MyPkg(ConanFile):
             settings = "arch", "os"
@@ -61,7 +61,7 @@ def test_apt_install_substitutes():
 def test_build_require():
     client = TestClient()
     client.save({"tool_require.py": textwrap.dedent("""
-        from conans import ConanFile
+        from conan import ConanFile
         from conan.tools.system.package_manager import Apt
         class MyPkg(ConanFile):
             settings = "arch", "os"
@@ -72,7 +72,7 @@ def test_build_require():
         """)})
     client.run("export tool_require.py tool_require/1.0@")
     client.save({"consumer.py": textwrap.dedent("""
-        from conans import ConanFile
+        from conan import ConanFile
         class consumer(ConanFile):
             settings = "arch", "os"
             tool_requires = "tool_require/1.0"
@@ -88,7 +88,7 @@ def test_build_require():
 def test_brew_check():
     client = TestClient()
     client.save({"conanfile.py": textwrap.dedent("""
-        from conans import ConanFile
+        from conan import ConanFile
         from conan.tools.system.package_manager import Brew
         class MyPkg(ConanFile):
             settings = "arch"
@@ -107,7 +107,7 @@ def test_brew_check():
 def test_brew_install_check_mode():
     client = TestClient()
     client.save({"conanfile.py": textwrap.dedent("""
-        from conans import ConanFile
+        from conan import ConanFile
         from conan.tools.system.package_manager import Brew
         class MyPkg(ConanFile):
             settings = "arch"
@@ -126,7 +126,7 @@ def test_brew_install_check_mode():
 def test_brew_install_install_mode():
     client = TestClient()
     client.save({"conanfile.py": textwrap.dedent("""
-        from conans import ConanFile
+        from conan import ConanFile
         from conan.tools.system.package_manager import Brew
         class MyPkg(ConanFile):
             settings = "arch"

--- a/conans/test/functional/tools/system/package_manager_test.py
+++ b/conans/test/functional/tools/system/package_manager_test.py
@@ -46,12 +46,11 @@ def test_apt_install_substitutes():
                 {}
         """)
 
-    client.run("remove test/1.0 -f")
-
     installs = 'apt.install_substitutes(["non-existing1", "non-existing2"], ["non-existing3", "non-existing4"])'
     client.save({"conanfile.py": conanfile_py.format(installs)})
     client.run("create . test/1.0@ -c tools.system.package_manager:mode=install "
                "-c tools.system.package_manager:sudo=True", assert_error=True)
+
     assert "dpkg-query: no packages found matching non-existing1:amd64" in client.out
     assert "dpkg-query: no packages found matching non-existing2:amd64" in client.out
     assert "dpkg-query: no packages found matching non-existing3:amd64" in client.out
@@ -65,7 +64,6 @@ def test_apt_install_substitutes():
     client.run("create . test/1.0@ -c tools.system.package_manager:mode=install "
                "-c tools.system.package_manager:sudo=True")
     assert "1 newly installed" in client.out
-    print(client.out)
 
 
 @pytest.mark.tool_apt_get


### PR DESCRIPTION
Changelog: Feature: Add `install_substitutes` to system package manager tools to be able to install sets of packages that are equivalent with different names for different distros.
Docs: https://github.com/conan-io/docs/pull/2563
