### PR TITLE
Add relative path support to Git SCM tool

### DIFF
--- a/conan/tools/scm/git.py
+++ b/conan/tools/scm/git.py
@@ -22,7 +22,7 @@ class Git(object):
             # --full-history is needed to not avoid wrong commits:
             # https://github.com/conan-io/conan/issues/10971
             # https://git-scm.com/docs/git-rev-list#Documentation/git-rev-list.txt-Defaultmode
-            commit = self._run('rev-list HEAD -n 1 --full-history -- "{}"'.format(self.folder))
+            commit = self._run('rev-list HEAD -n 1 --full-history -- "."')
             return commit
         except Exception as e:
             raise ConanException("Unable to get git commit in '%s': %s" % (self.folder, str(e)))

--- a/conans/test/unittests/tools/scm/test_git_get_commit.py
+++ b/conans/test/unittests/tools/scm/test_git_get_commit.py
@@ -1,6 +1,7 @@
 import os
 
 from conan.tools.scm import Git
+from conans.tools import chdir
 from conans.test.utils.mocks import MockConanfile
 from conans.test.utils.tools import TestClient
 
@@ -97,3 +98,67 @@ def test_multi_folder_repo():
     c.run_command("git rev-parse HEAD")
     commit_real = str(c.out).splitlines()[0]
     assert new_commit_root == commit_real
+
+def test_relative_folder_repo():
+    c = TestClient()
+    conanfile = MockConanfile({})
+    c.save({"lib_a/conanfile.py": ""})
+    c.run_command("git init .")
+    c.run_command('git config user.name myname')
+    c.run_command('git config user.email myname@mycompany.com')
+    c.run_command("git add .")
+    c.run_command('git commit -m "lib_a commit"')
+    c.save({"lib_b/conanfile.py": ""})
+    c.run_command("git add .")
+    c.run_command('git commit -m "lib_b commit"')
+    c.save({"lib_c/conanfile.py": ""})
+    c.run_command("git add .")
+    c.run_command('git commit -m "lib_c commit"')
+    c.save({"root_change": ""})
+    c.run_command("git add .")
+    c.run_command('git commit -m "root change"')
+
+    # Relative paths for folders, from the current_folder
+    with chdir(c.current_folder):
+        git = Git(conanfile, folder="lib_a")
+        commit_libA = git.get_commit()
+
+        git = Git(conanfile, folder="lib_b")
+        commit_libB = git.get_commit()
+
+        git = Git(conanfile, folder="./lib_c")
+        commit_libC = git.get_commit()
+
+        # this is folder default, but be explicit
+        git = Git(conanfile, folder=".")
+        commit_root = git.get_commit()
+
+    # All different
+    assert len({commit_libA, commit_libB, commit_libC, commit_root}) == 4
+
+    # Compare to Full paths
+    git = Git(conanfile, folder=os.path.join(c.current_folder, "lib_a"))
+    full_commit_libA = git.get_commit()
+
+    git = Git(conanfile, folder=os.path.join(c.current_folder, "lib_b"))
+    full_commit_libB = git.get_commit()
+
+    git = Git(conanfile, folder=os.path.join(c.current_folder, "lib_c"))
+    full_commit_libC = git.get_commit()
+
+    git = Git(conanfile, folder=c.current_folder)
+    full_commit_root = git.get_commit()
+
+    assert full_commit_libA == commit_libA
+    assert full_commit_libB == commit_libB
+    assert full_commit_libC == commit_libC
+    assert full_commit_root == commit_root
+
+    # Sanity checks
+    c.run_command("git rev-parse HEAD")
+    commit_real_root = str(c.out).splitlines()[0]
+    assert commit_real_root == commit_root
+
+    c.run_command("git rev-list -n 1 --full-history HEAD -- lib_a")
+    commit_real_libA = str(c.out).splitlines()[0]
+    assert commit_real_libA == commit_libA


### PR DESCRIPTION
Changelog: Feature: Add relative path support to Git SCM tool.
Docs: omit

Closes: #11408

When trying to setup Conan packaging with the target source in a submodule relative to the recipe, I was receiving
empty commit ids. Upon further investigation, it seems that the current assumption is that the folder path to Git()
will be absolute. A minor adjustment allows relative paths to be used as well: since the git command always `chdir`s to the
target git folder, we can perform the `rev-parse` relative to the current directory and receive the expected behavior.

- Test cases have been added.
- Documentation does not seem to warrant updates since this behavior is implied by the currently document default value for `folder`

<!--
- [x] Explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
-->
<sup>**Note:** By default this PR will skip the slower tests and will use a limited set of python versions. Check [here](https://github.com/conan-io/conan/blob/develop/.github/PR_INCREASE_TESTING.md) how to increase the testing level by writing some tags in the current PR body text.</sup>
