### PR TITLE
Better upload output

### DIFF
--- a/conan/api/subapi/download.py
+++ b/conan/api/subapi/download.py
@@ -23,7 +23,7 @@ class DownloadAPI:
             output.info(f"Skip {ref.repr_notime()} download, already in cache")
             return False
 
-        output.info(f"Downloading {ref.repr_notime()}")
+        output.info(f"Downloading recipe '{ref.repr_notime()}'")
         app.remote_manager.get_recipe(ref, remote)
 
         layout = app.cache.ref_layout(ref)
@@ -31,7 +31,7 @@ class DownloadAPI:
         conanfile = app.loader.load_basic(conan_file_path, display=ref)
 
         # Download the sources too, don't be lazy
-        output.info(f"Downloading {str(ref)} sources")
+        output.info(f"Downloading '{str(ref)}' sources")
         retrieve_exports_sources(app.remote_manager, layout, conanfile, ref, [remote])
         return True
 
@@ -51,6 +51,6 @@ class DownloadAPI:
         layout = app.cache.ref_layout(pref.ref)
         conan_file_path = layout.conanfile()
         conanfile = app.loader.load_basic(conan_file_path, display=pref.ref)
-        output.info(f"Downloading {pref.repr_notime()}")
+        output.info(f"Downloading package '{pref.repr_notime()}'")
         app.remote_manager.get_package(conanfile, pref, remote)
         return True

--- a/conans/client/cmd/uploader.py
+++ b/conans/client/cmd/uploader.py
@@ -101,10 +101,10 @@ class UploadUpstreamChecker:
             recipe.force = False
         else:
             if force:
-                self._output.info("{} already in server, forcing upload".format(ref.repr_notime()))
+                self._output.info("Recipe '{}' already in server, forcing upload".format(ref.repr_notime()))
                 recipe.force = True
             else:
-                self._output.info("{} already in server, skipping upload".format(ref.repr_notime()))
+                self._output.info("Recipe '{}' already in server, skipping upload".format(ref.repr_notime()))
                 recipe.upload = False
                 recipe.force = False
 
@@ -123,10 +123,10 @@ class UploadUpstreamChecker:
             package.force = False
         else:
             if force:
-                self._output.info("{} already in server, forcing upload".format(pref.repr_notime()))
+                self._output.info("Package '{}' already in server, forcing upload".format(pref.repr_notime()))
                 package.force = True
             else:
-                self._output.info("{} already in server, skipping upload".format(pref.repr_notime()))
+                self._output.info("Package '{}' already in server, skipping upload".format(pref.repr_notime()))
                 package.upload = False
                 package.force = False
 
@@ -286,7 +286,7 @@ class UploadExecutor:
         return files, deleted
 
     def upload_recipe(self, recipe, remote):
-        self._output.info(f"Uploading {recipe.ref}")
+        self._output.info(f"Uploading recipe '{recipe.ref.repr_notime()}'")
         t1 = time.time()
         ref = recipe.ref
         cache_files = recipe.files
@@ -301,7 +301,7 @@ class UploadExecutor:
         return ref
 
     def upload_package(self, package, remote):
-        self._output.info(f"Uploading {package.pref.repr_reduced()}")
+        self._output.info(f"Uploading package '{package.pref.repr_notime()}'")
         pref = package.pref
         cache_files = package.files
         assert (pref.revision is not None), "Cannot upload a package without PREV"

--- a/conans/client/rest/rest_client_v2.py
+++ b/conans/client/rest/rest_client_v2.py
@@ -120,14 +120,14 @@ class RestV2Methods(RestCommonMethods):
         # Direct upload the recipe
         urls = {fn: self.router.recipe_file(ref, fn)
                 for fn in files_to_upload}
-        self._upload_files(files_to_upload, urls, display_name=str(ref))
+        self._upload_files(files_to_upload, urls)
 
     def _upload_package(self, pref, files_to_upload):
         urls = {fn: self.router.package_file(pref, fn)
                 for fn in files_to_upload}
-        self._upload_files(files_to_upload, urls, display_name=pref.repr_reduced())
+        self._upload_files(files_to_upload, urls)
 
-    def _upload_files(self, files, urls, display_name=None):
+    def _upload_files(self, files, urls):
         t1 = time.time()
         failed = []
         uploader = FileUploader(self.requester, self.verify_ssl, self._config)
@@ -136,15 +136,14 @@ class RestV2Methods(RestCommonMethods):
         output = ConanOutput()
         for filename in sorted(files):
             if output and not output.is_terminal:
-                msg = "Uploading: %s" % filename if not display_name else (
-                    "Uploading %s -> %s" % (filename, display_name))
+                msg ="-> %s" % filename
                 output.info(msg)
             resource_url = urls[filename]
             try:
                 headers = {}
                 uploader.upload(resource_url, files[filename], auth=self.auth,
                                 dedup=self._checksum_deploy,
-                                headers=headers, display_name=display_name)
+                                headers=headers)
             except (AuthenticationException, ForbiddenException):
                 raise
             except Exception as exc:

--- a/conans/test/integration/command/download/download_test.py
+++ b/conans/test/integration/command/download/download_test.py
@@ -207,11 +207,11 @@ class Pkg(ConanFile):
         client.run("remove * -f")
 
         client.run("download pkg/1.0#latest:{} -r default".format(NO_SETTINGS_PACKAGE_ID))
-        self.assertIn("Downloading pkg/1.0#4d670581ccb765839f2239cc8dff8fbd:%s" %
+        self.assertIn("Downloading package 'pkg/1.0#4d670581ccb765839f2239cc8dff8fbd:%s" %
                       NO_SETTINGS_PACKAGE_ID, client.out)
 
         # All
         client.run("remove * -f")
         client.run("download pkg/1.0#*:* -r default")
-        self.assertIn("Downloading pkg/1.0#4d670581ccb765839f2239cc8dff8fbd:%s" %
+        self.assertIn("Downloading package 'pkg/1.0#4d670581ccb765839f2239cc8dff8fbd:%s" %
                       NO_SETTINGS_PACKAGE_ID, client.out)

--- a/conans/test/integration/command/install/install_test.py
+++ b/conans/test/integration/command/install/install_test.py
@@ -261,7 +261,7 @@ def test_install_without_ref(client):
     assert "lib/1.0: Package '{}' created".format(NO_SETTINGS_PACKAGE_ID) in client.out
 
     client.run('upload lib/1.0 -c -r default')
-    assert "Uploading lib/1.0" in client.out
+    assert "Uploading recipe 'lib/1.0" in client.out
 
     client.run('remove "*" -f')
 

--- a/conans/test/integration/command/source_test.py
+++ b/conans/test/integration/command/source_test.py
@@ -166,7 +166,7 @@ class ConanLib(ConanFile):
         client.run("remove * -f")
         client.run("install --requires=hello/0.1@ -r server1")
         client.run("upload hello/0.1 -r server1")
-        assert f"hello/0.1#{rrev} already in server, skipping upload" in client.out
+        assert f"'hello/0.1#{rrev}' already in server, skipping upload" in client.out
         self.assertNotIn("Downloading conan_sources.tgz", client.out)
         self.assertNotIn("Sources downloaded from 'server0'", client.out)
 

--- a/conans/test/integration/command/upload/upload_complete_test.py
+++ b/conans/test/integration/command/upload/upload_complete_test.py
@@ -62,10 +62,10 @@ def test_upload_with_pattern():
 
     client.run("upload hello* --confirm -r default")
     for num in range(3):
-        assert "Uploading hello%s/1.2.1@frodo/stable" % num in client.out
+        assert "Uploading recipe 'hello%s/1.2.1@frodo/stable" % num in client.out
 
     client.run("upload hello0* --confirm -r default")
-    assert f"hello0/1.2.1@frodo/stable#761f54e34d59deb172d6078add7050a7 "\
+    assert f"'hello0/1.2.1@frodo/stable#761f54e34d59deb172d6078add7050a7' "\
            "already in server, skipping upload" in client.out
     assert "hello1" not in client.out
     assert "hello2" not in client.out
@@ -78,13 +78,13 @@ def test_check_upload_confirm_question():
     client.run("export . --user=frodo --channel=stable")
     client.run("upload hello* -r default")
 
-    assert "Uploading hello1/1.2.1@frodo/stable" in client.out
+    assert "Uploading recipe 'hello1/1.2.1@frodo/stable" in client.out
 
     client.save({"conanfile.py": GenConanfile("hello2", "1.2.1")})
     client.run("export . --user=frodo --channel=stable")
     client.run("upload hello* -r default")
 
-    assert "Uploading hello2/1.2.1@frodo/stable" not in client.out
+    assert "Uploading recipe 'hello2/1.2.1@frodo/stable" not in client.out
 
 
 class UploadTest(unittest.TestCase):

--- a/conans/test/integration/editable/forbidden_commands_test.py
+++ b/conans/test/integration/editable/forbidden_commands_test.py
@@ -35,7 +35,7 @@ class TestOtherCommands:
         assert "lib/0.1" in t.out  # One binary is listed
 
         t.run('upload lib/0.1 -r default')
-        assert "Uploading lib/0.1" in t.out
+        assert "Uploading recipe 'lib/0.1" in t.out
 
         t.run("remove * -f")
         # Nothing in the cache

--- a/conans/test/integration/remote/multi_remote_test.py
+++ b/conans/test/integration/remote/multi_remote_test.py
@@ -74,7 +74,7 @@ class MultiRemotesTest(unittest.TestCase):
         # Update hello0 with client_a and reupload
         self._create(client_a, "hello0", "0.0", modifier="\n")
         client_a.run("upload hello0/0.0@lasote/stable -r local --only-recipe")
-        self.assertIn("Uploading hello0/0.0@lasote/stable", client_a.out)
+        self.assertIn("Uploading recipe 'hello0/0.0@lasote/stable", client_a.out)
 
         # Execute info method in client_b, should advise that there is an update
         client_b.run("graph info --requires=hello0/0.0@lasote/stable --check-updates")


### PR DESCRIPTION
Closes https://github.com/conan-io/conan/issues/11371

Example of output:

```
Uploading recipe 'hello0/1.2.1@user/testing#5dc538bd43d0fd8e2a2089bf64762146'
-> conan_sources.tgz
-> conanfile.py
-> conanmanifest.txt
Uploading package 'hello0/1.2.1@user/testing#5dc538bd43d0fd8e2a2089bf64762146:da39a3ee5e6b4b0d3255bfef95601890afd80709#eb264163f8b058326d487ad8aae85a32'
-> conan_package.tgz
-> conaninfo.txt
-> conanmanifest.txt
```