### PR TITLE
Fixed two bugs with CMakePresets

### DIFF
--- a/conan/tools/cmake/presets.py
+++ b/conan/tools/cmake/presets.py
@@ -123,21 +123,13 @@ def write_cmake_presets(conanfile, toolchain_file, generator):
                 data = {"version": 4, "include": [preset_path]}
             else:
                 data = json.loads(load(user_presets_path))
-                data = _clean_deleted_presets(data)
+                # Clear the folders that have been deleted
+                data["include"] = [i for i in data["include"] if os.path.exists(i)]
                 if preset_path not in data["include"]:
                     data["include"].append(preset_path)
 
             data = json.dumps(data, indent=4)
             save(user_presets_path, data)
-
-
-def _clean_deleted_presets(data):
-    includes = []
-    for include in data["include"]:
-        if os.path.exists(include):
-            includes.append(include)
-    data["include"] = includes
-    return data
 
 
 def load_cmake_presets(folder):

--- a/conan/tools/cmake/presets.py
+++ b/conan/tools/cmake/presets.py
@@ -95,18 +95,15 @@ def write_cmake_presets(conanfile, toolchain_file, generator):
         # We append the new configuration making sure that we don't overwrite it
         data = json.loads(load(preset_path))
         if multiconfig:
-            build_presets = data["buildPresets"]
-            build_preset_name = _build_preset_name(conanfile)
-            already_exist = any([b["configuration"]
-                                 for b in build_presets if b == build_preset_name])
+            new_build_preset_name = _build_preset_name(conanfile)
+            already_exist = any([b["name"] for b in data["buildPresets"]
+                                 if b["name"] == new_build_preset_name])
             if not already_exist:
                 data["buildPresets"].append(_add_build_preset(conanfile, multiconfig))
         else:
-            configure_presets = data["configurePresets"]
-            configure_preset_name = _configure_preset_name(conanfile, multiconfig)
-            already_exist = any([c["name"]
-                                 for c in configure_presets
-                                 if c["name"] == configure_preset_name])
+            new_configure_preset_name = _configure_preset_name(conanfile, multiconfig)
+            already_exist = any([c["name"] for c in data["configurePresets"]
+                                 if c["name"] == new_configure_preset_name])
             if not already_exist:
                 conf_preset = _add_configure_preset(conanfile, generator, cache_variables,
                                                     toolchain_file, multiconfig)
@@ -126,11 +123,21 @@ def write_cmake_presets(conanfile, toolchain_file, generator):
                 data = {"version": 4, "include": [preset_path]}
             else:
                 data = json.loads(load(user_presets_path))
+                data = _clean_deleted_presets(data)
                 if preset_path not in data["include"]:
                     data["include"].append(preset_path)
 
             data = json.dumps(data, indent=4)
             save(user_presets_path, data)
+
+
+def _clean_deleted_presets(data):
+    includes = []
+    for include in data["include"]:
+        if os.path.exists(include):
+            includes.append(include)
+    data["include"] = includes
+    return data
 
 
 def load_cmake_presets(folder):


### PR DESCRIPTION
Changelog: Bugfix: The `CMakePresets.json` file, when performing several `conan install` commands, ended-up with several entries of duplicated "buildPresets" if used with a `multi-configuration` cmake generator.
Changelog: Fix:  The "include" paths list in a `CMakeUserPresets.json`, when performing a new `conan install`, are now checked, and in case some of them is a missing path (deleted directory), it is cleaned from the list. 
Docs: omit

Closes https://github.com/conan-io/conan/issues/11413
Closes https://github.com/conan-io/conan/issues/11409