### PR TITLE
pylint plugin: fix crash with pylint >= 2.14.0

### DIFF
--- a/conans/pylint_plugin.py
+++ b/conans/pylint_plugin.py
@@ -39,7 +39,7 @@ def transform_conanfile(node):
     }
 
     for f, t in dynamic_fields.items():
-        node.locals[f] = [t]
+        node.locals[f] = [i for i in t]
 
 
 MANAGER.register_transform(


### PR DESCRIPTION
solution by @DanielNoord
cf PyCQA/pylint#6908

Changelog: Bugfix: Fix crash in  pylint plugin with pylint >= 2.14.0.
Docs: Omit 

- [X] Refer to the issue that supports this Pull Request.
- [ ] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [X] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [X] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 

<sup>**Note:** By default this PR will skip the slower tests and will use a limited set of python versions. Check [here](https://github.com/conan-io/conan/blob/develop/.github/PR_INCREASE_TESTING.md) how to increase the testing level by writing some tags in the current PR body text.</sup>
