### PR TITLE
Allow ["ANY"] in a list 

### DIFF
--- a/conans/model/options.py
+++ b/conans/model/options.py
@@ -331,7 +331,8 @@ class PackageOption(object):
     def __init__(self, possible_values, name):
         self._name = name
         self._value = None
-        if possible_values == "ANY":
+        if possible_values == "ANY" or (isinstance(possible_values, list) and
+                                        "ANY" in possible_values):
             self._possible_values = "ANY"
         else:
             self._possible_values = sorted(str(v) for v in possible_values)

--- a/conans/test/unittests/model/options_test.py
+++ b/conans/test/unittests/model/options_test.py
@@ -376,3 +376,21 @@ class OptionsValuesTest(unittest.TestCase):
     def test_package_with_spaces(self):
         self.assertEqual(OptionsValues([('pck2:opt', 50), ]).dumps(),
                          OptionsValues([('pck2 :opt', 50), ]).dumps())
+
+
+def test_validate_any_as_list():
+    package_options = PackageOptions.loads("""{
+    path: ["ANY", "kk"]}""")
+    values = PackageOptionValues()
+    values.add_option("path", "FOO")
+    package_options.values = values
+    sut = Options(package_options)
+    assert sut.path == "FOO"
+
+    package_options = PackageOptions.loads("""{
+        path: "ANY"}""")
+    values = PackageOptionValues()
+    values.add_option("path", "WHATEVER")
+    package_options.values = values
+    sut = Options(package_options)
+    assert sut.path == "WHATEVER"


### PR DESCRIPTION
Changelog: Feature: Allow options having ["ANY"] as a list like Conan 2.X.
Docs: https://github.com/conan-io/docs/pull/2615
