### PR TITLE
Only generate or modify CMakeUserPresets.json if none existed, or existing was previously generated by conan

### DIFF
--- a/conan/tools/cmake/presets.py
+++ b/conan/tools/cmake/presets.py
@@ -124,11 +124,11 @@ def write_cmake_presets(conanfile, toolchain_file, generator):
             else:
                 data = json.loads(load(user_presets_path))
                 if "conan" in data.get("vendor", {}):
-                # Clear the folders that have been deleted
-                data.setdefault("include", list())
-                data["include"] = [i for i in data["include"] if os.path.exists(i)]
-                if preset_path not in data["include"]:
-                    data["include"].append(preset_path)
+                    # Clear the folders that have been deleted
+                    data.setdefault("include", list())
+                    data["include"] = [i for i in data["include"] if os.path.exists(i)]
+                    if preset_path not in data["include"]:
+                        data["include"].append(preset_path)
 
             data = json.dumps(data, indent=4)
             save(user_presets_path, data)

--- a/conan/tools/cmake/presets.py
+++ b/conan/tools/cmake/presets.py
@@ -120,9 +120,10 @@ def write_cmake_presets(conanfile, toolchain_file, generator):
         if os.path.exists(os.path.join(conanfile.source_folder, "CMakeLists.txt")):
             user_presets_path = os.path.join(conanfile.source_folder, "CMakeUserPresets.json")
             if not os.path.exists(user_presets_path):
-                data = {"version": 4, "include": [preset_path]}
+                data = {"version": 4, "include": [preset_path], "vendor": {"conan": dict()}}
             else:
                 data = json.loads(load(user_presets_path))
+                if "conan" in data.get("vendor", {}):
                 # Clear the folders that have been deleted
                 data.setdefault("include", list())
                 data["include"] = [i for i in data["include"] if os.path.exists(i)]

--- a/conan/tools/cmake/presets.py
+++ b/conan/tools/cmake/presets.py
@@ -125,8 +125,7 @@ def write_cmake_presets(conanfile, toolchain_file, generator):
                 data = json.loads(load(user_presets_path))
                 if "conan" in data.get("vendor", {}):
                     # Clear the folders that have been deleted
-                    data.setdefault("include", list())
-                    data["include"] = [i for i in data["include"] if os.path.exists(i)]
+                    data["include"] = [i for i in data.get("include", []) if os.path.exists(i)]
                     if preset_path not in data["include"]:
                         data["include"].append(preset_path)
 

--- a/conan/tools/cmake/presets.py
+++ b/conan/tools/cmake/presets.py
@@ -124,6 +124,7 @@ def write_cmake_presets(conanfile, toolchain_file, generator):
             else:
                 data = json.loads(load(user_presets_path))
                 # Clear the folders that have been deleted
+                data.setdefault("include", list())
                 data["include"] = [i for i in data["include"] if os.path.exists(i)]
                 if preset_path not in data["include"]:
                     data["include"].append(preset_path)

--- a/conans/test/functional/toolchains/cmake/test_cmake_toolchain.py
+++ b/conans/test/functional/toolchains/cmake/test_cmake_toolchain.py
@@ -133,10 +133,10 @@ def test_cmake_user_presets_load(existing_user_presets):
         assert "include" in user_presets_data.keys()
 
     if existing_user_presets == None:
-    t.run_command("cmake . --preset release")
-    assert 'CMAKE_BUILD_TYPE="Release"' in t.out
-    t.run_command("cmake . --preset debug")
-    assert 'CMAKE_BUILD_TYPE="Debug"' in t.out
+        t.run_command("cmake . --preset release")
+        assert 'CMAKE_BUILD_TYPE="Release"' in t.out
+        t.run_command("cmake . --preset debug")
+        assert 'CMAKE_BUILD_TYPE="Debug"' in t.out
 
 
 def test_cmake_toolchain_user_toolchain_from_dep():


### PR DESCRIPTION
Changelog: Bugfix: Fix logic in the generation of `CMakeUserPresets.json` - Conan will only generate the file if it did not previously exist, and will modify an existing one if the file was previously generated by conan. Existing `CMakeUserPresets.json` will be left untouched otherwise.

Docs: https://github.com/conan-io/docs/pull/2591


# Description
Before this PR: if `CMakeUserPresets.json` file existed next to `CMakeLists.txt`, but was empty or did not contain the `include` section (or was empty) - the generator would fail.

In this PR: conan will only generate `CMakeUserPresets.json` if the file did not previously exist, or if it existed and was previously generated by conan, which we now identify with an empty `conan` member in the `vendor` field (which is reserved by CMake for third-party tooling).


## Tests
Modified existing test to cover 3 cases:
* `CMakeUserPresets.json` did *not* exist, and is generated with the correct information after generation (this was already what was being tested)
* `CMakeUserPresets.json` exists but does not have the `conan` member in the `vendor` field
* `CMakeUserPresets.json` exists and it was previously generated by conan (in this case the test also verifies that the correct information is updated).
