### PR TITLE
Reproduce fail with compatible packages in develop2

### DIFF
--- a/conans/test/integration/package_id/test_cache_compatibles.py
+++ b/conans/test/integration/package_id/test_cache_compatibles.py
@@ -280,6 +280,6 @@ class TestDefaultCompat:
         c.run("create . --build=mylib/1.0 -s compiler.cppstd=17")
         c.run("remove '*' -f")
 
-        # this fails when looking for compatible packages
+        # this fails building after looking for compatible packages
         c.run("create . --build=missing -s compiler.cppstd=17")
         assert "Possible options are ['shared', 'header_only']" not in c.out


### PR DESCRIPTION
Changelog: (Feature | Fix | Bugfix): Describe here your pull request
Docs: https://github.com/conan-io/docs/pull/XXXX

Reproducing this: https://ci.conan.io/blue/organizations/jenkins/Examples2.0/detail/PR-23/7/pipeline/24/

It can be avoided accessing the option with get_safe, but it may be worth checking