### PR TITLE
Remove default Frameworks

### DIFF
--- a/conans/model/conan_file.py
+++ b/conans/model/conan_file.py
@@ -177,7 +177,7 @@ class ConanFile(object):
         self.cpp.package.bindirs = ["bin"]
         self.cpp.package.resdirs = ["res"]
         self.cpp.package.builddirs = [""]
-        self.cpp.package.frameworkdirs = ["Frameworks"]
+        self.cpp.package.frameworkdirs = []
 
     @property
     def context(self):

--- a/conans/test/functional/layout/test_editables_layout.py
+++ b/conans/test/functional/layout/test_editables_layout.py
@@ -86,7 +86,7 @@ def test_cpp_info_editable():
     assert "**includedirs:['package_include']**" in out
     assert "**libdirs:['lib']**" in out
     assert "**builddirs:['']**" in out
-    assert "**frameworkdirs:['Frameworks', 'package_frameworks_path']**" in out
+    assert "**frameworkdirs:['package_frameworks_path']**" in out
     assert "**libs:['lib_when_package', 'lib_when_package2']**" in out
     assert "**objects:['myobject.o']**" in out
     assert "**build_modules:['mymodules/mybuildmodule']**" in out

--- a/conans/test/integration/command/create_test.py
+++ b/conans/test/integration/command/create_test.py
@@ -540,3 +540,42 @@ class MyPkg(ConanFile):
         self.assertNotIn("requires", cpp_info_data["components"]["pkg1"])
         self.assertIn("libpkg2", cpp_info_data["components"]["pkg2"]["libs"])
         self.assertListEqual(["pkg1"], cpp_info_data["components"]["pkg2"]["requires"])
+
+
+def test_default_framework_dirs():
+
+    conanfile = textwrap.dedent("""
+    from conans import ConanFile, CMake, tools
+
+
+    class LibConan(ConanFile):
+        name = "lib"
+        version = "1.0"
+
+        def package_info(self):
+            self.output.warn("FRAMEWORKS: {}".format(self.cpp_info.frameworkdirs))""")
+    client = TestClient()
+    client.save({"conanfile.py": conanfile})
+    client.run("create .")
+    assert "FRAMEWORKS: ['Frameworks']" in client.out
+
+
+def test_default_framework_dirs_with_layout():
+
+    conanfile = textwrap.dedent("""
+    from conans import ConanFile, CMake, tools
+
+
+    class LibConan(ConanFile):
+        name = "lib"
+        version = "1.0"
+
+        def layout(self):
+            pass
+
+        def package_info(self):
+            self.output.warn("FRAMEWORKS: {}".format(self.cpp_info.frameworkdirs))""")
+    client = TestClient()
+    client.save({"conanfile.py": conanfile})
+    client.run("create .")
+    assert "FRAMEWORKS: []" in client.out


### PR DESCRIPTION
Changelog: Fix: When using the new layout() feature of Conan 2.0, change the default `cpp_info.frameworkdirs = ["Frameworks"]` to `cpp_info.frameworkdirs = []`, because it is more common to not have packaged Apple frameworks and declaring a missing folder can cause issues with the new toolchains.
Docs: https://github.com/conan-io/docs/pull/2613
