### PR TITLE
Compatible packages fail fixes

### DIFF
--- a/conans/client/graph/compatibility.py
+++ b/conans/client/graph/compatibility.py
@@ -132,16 +132,16 @@ class BinaryCompatibility:
         original_info = conanfile.info
         for c in compat_infos:
             conanfile.info = c
-            conanfile.settings = c.settings
-            conanfile.options = c.options
+            #conanfile.settings = c.settings
+            #conanfile.options = c.options
             run_validate_package_id(conanfile)
             pid = c.package_id()
             if pid not in result and not c.invalid:
                 result[pid] = c
         # Restore the original state
         conanfile.info = original_info
-        conanfile.settings = original_info.settings
-        conanfile.options = original_info.options
+        #conanfile.settings = original_info.settings
+        #conanfile.options = original_info.options
         return result
 
     @staticmethod

--- a/conans/client/graph/compatibility.py
+++ b/conans/client/graph/compatibility.py
@@ -132,16 +132,12 @@ class BinaryCompatibility:
         original_info = conanfile.info
         for c in compat_infos:
             conanfile.info = c
-            #conanfile.settings = c.settings
-            #conanfile.options = c.options
             run_validate_package_id(conanfile)
             pid = c.package_id()
             if pid not in result and not c.invalid:
                 result[pid] = c
         # Restore the original state
         conanfile.info = original_info
-        #conanfile.settings = original_info.settings
-        #conanfile.options = original_info.options
         return result
 
     @staticmethod

--- a/conans/client/graph/compute_pid.py
+++ b/conans/client/graph/compute_pid.py
@@ -59,7 +59,7 @@ def run_validate_package_id(conanfile):
     # IMPORTANT: This validation code must run before calling info.package_id(), to mark "invalid"
     if hasattr(conanfile, "validate"):
         with conanfile_exception_formatter(conanfile, "validate"):
-            with conanfile_remove_attr(conanfile, ['cpp_info'], "validate"):
+            with conanfile_remove_attr(conanfile, ['cpp_info', 'settings', 'options'], "validate"):
                 try:
                     conanfile.validate()
                 except ConanInvalidConfiguration as e:
@@ -70,7 +70,7 @@ def run_validate_package_id(conanfile):
     # Once we are done, call package_id() to narrow and change possible values
     if hasattr(conanfile, "package_id"):
         with conanfile_exception_formatter(conanfile, "package_id"):
-            with conanfile_remove_attr(conanfile, ['cpp_info'], "package_id"):
+            with conanfile_remove_attr(conanfile, ['cpp_info', 'settings', 'options'], "package_id"):
                 conanfile.package_id()
 
     conanfile.info.validate()

--- a/conans/client/graph/compute_pid.py
+++ b/conans/client/graph/compute_pid.py
@@ -49,8 +49,6 @@ def compute_package_id(node, new_config):
                                conf=conanfile.conf.copy_conaninfo_conf())
     conanfile.original_info = conanfile.info.clone()
 
-    conanfile.settings = conanfile.info.settings
-    conanfile.options = conanfile.info.options
     run_validate_package_id(conanfile)
 
     info = conanfile.info

--- a/conans/client/graph/compute_pid.py
+++ b/conans/client/graph/compute_pid.py
@@ -49,6 +49,8 @@ def compute_package_id(node, new_config):
                                conf=conanfile.conf.copy_conaninfo_conf())
     conanfile.original_info = conanfile.info.clone()
 
+    conanfile.settings = conanfile.info.settings
+    conanfile.options = conanfile.info.options
     run_validate_package_id(conanfile)
 
     info = conanfile.info

--- a/conans/client/graph/graph_binaries.py
+++ b/conans/client/graph/graph_binaries.py
@@ -118,8 +118,11 @@ class GraphBinariesAnalyzer(object):
                                       "compatible package '%s'" % (original_package_id, package_id))
                 # So they are available in package_info() method
                 conanfile.info = compatible_package  # Redefine current
-                conanfile.settings = compatible_package.settings
-                conanfile.options = compatible_package.options
+                conanfile.settings.update_values(compatible_package.settings.values_list)
+                # Trick to allow mutating the options (they were freeze=True)
+                # TODO: Improve this interface
+                conanfile.options = conanfile.options.copy_conaninfo_options()
+                conanfile.options.update_options(compatible_package.options)
                 break
         else:  # If no compatible is found, restore original state
             node.binary = original_binary

--- a/conans/test/functional/toolchains/microsoft/test_msbuild.py
+++ b/conans/test/functional/toolchains/microsoft/test_msbuild.py
@@ -607,21 +607,3 @@ class WinTest(unittest.TestCase):
             else:
                 self.assertNotIn("hello.dll", client.out)
             self.assertIn("KERNEL32.dll", client.out)
-
-
-def test_msvc_runtime_flag_common_usage():
-    """The msvc_runtime_flag must not break when expecting a string
-    """
-    client = TestClient()
-    conanfile = textwrap.dedent("""
-       from conan import ConanFile
-       from conan.tools.microsoft import msvc_runtime_flag
-       class App(ConanFile):
-           settings = "os", "arch", "compiler", "build_type"
-
-           def validate(self):
-               if "MT" in msvc_runtime_flag(self):
-                   pass
-        """)
-    client.save({"conanfile.py": conanfile})
-    client.run('graph info .')

--- a/conans/test/integration/conanfile/test_attributes_scope.py
+++ b/conans/test/integration/conanfile/test_attributes_scope.py
@@ -17,8 +17,38 @@ class TestAttributesScope:
                     self.cpp_info.libs = ["A"]
         """)
         t.save({'conanfile.py': conanfile})
-        t.run('create . --name=name --version=version -s os=Linux', assert_error=True)
+        t.run('create . --name=name --version=version', assert_error=True)
         assert "'self.cpp_info' access in 'package_id()' method is forbidden" in t.out
+
+    def test_settings_not_in_package_id(self):
+        # self.cpp_info is not available in 'package_id'
+        t = TestClient()
+        conanfile = textwrap.dedent("""
+               from conan import ConanFile
+
+               class Recipe(ConanFile):
+
+                   def package_id(self):
+                       self.settings
+           """)
+        t.save({'conanfile.py': conanfile})
+        t.run('create . --name=name --version=version', assert_error=True)
+        assert "'self.settings' access in 'package_id()' method is forbidden" in t.out
+
+    def test_options_not_in_package_id(self):
+        # self.cpp_info is not available in 'package_id'
+        t = TestClient()
+        conanfile = textwrap.dedent("""
+               from conan import ConanFile
+
+               class Recipe(ConanFile):
+
+                   def package_id(self):
+                       self.options
+           """)
+        t.save({'conanfile.py': conanfile})
+        t.run('create . --name=name --version=version', assert_error=True)
+        assert "'self.options' access in 'package_id()' method is forbidden" in t.out
 
     def test_info_not_in_package(self):
         # self.info is not available in 'package'
@@ -66,3 +96,35 @@ class TestAttributesScope:
         t.save({'conanfile.py': conanfile})
         t.run('create . --name=name --version=version -o shared=False', assert_error=True)
         assert "'self.options' access in 'source()' method is forbidden" in t.out
+
+    def test_validate_no_settings(self):
+        # self.setting is not available in 'validate'
+        t = TestClient()
+        conanfile = textwrap.dedent("""
+            from conan import ConanFile
+
+            class Recipe(ConanFile):
+                settings = "os",
+
+                def validate(self):
+                    self.settings.os
+           """)
+        t.save({'conanfile.py': conanfile})
+        t.run('create . --name=name --version=version -s os=Linux', assert_error=True)
+        assert "'self.settings' access in 'validate()' method is forbidden" in t.out
+
+    def test_validate_no_options(self):
+        # self.setting is not available in 'validate'
+        t = TestClient()
+        conanfile = textwrap.dedent("""
+            from conan import ConanFile
+
+            class Recipe(ConanFile):
+                options = {"shared": [True, False]}
+
+                def validate(self):
+                    self.options.shared
+           """)
+        t.save({'conanfile.py': conanfile})
+        t.run('create . --name=name --version=version', assert_error=True)
+        assert "'self.options' access in 'validate()' method is forbidden" in t.out

--- a/conans/test/integration/graph/core/test_build_requires.py
+++ b/conans/test/integration/graph/core/test_build_requires.py
@@ -725,7 +725,7 @@ class TestDuplicateBuildRequires:
     @pytest.fixture()
     def client(self):
         client = TestClient()
-        msg = "self.output.info('This is the binary for OS={}'.format(self.settings.os))"
+        msg = "self.output.info('This is the binary for OS={}'.format(self.info.settings.os))"
         msg2 = "self.output.info('This is in context={}'.format(self.context))"
         client.save({"conanfile.py": GenConanfile().with_settings("os").with_package_id(msg)
                                                                        .with_package_id(msg2)})

--- a/conans/test/integration/package_id/package_id_test.py
+++ b/conans/test/integration/package_id/package_id_test.py
@@ -117,7 +117,7 @@ def test_option_in():
     assert "fpic is an info.option!!!" in client.out
     assert "other is not an option!!!" in client.out
     assert "other is not an info.option!!!" in client.out
-    assert "ERROR: OPTIONS: option 'whatever' doesn't exist" in client.out
+    assert "OPTIONS: 'self.options' access in 'package_id()' method is forbidden" in client.out
     assert "ERROR: INFO: option 'whatever' doesn't exist" in client.out
 
 

--- a/conans/test/integration/package_id/test_cache_compatibles.py
+++ b/conans/test/integration/package_id/test_cache_compatibles.py
@@ -251,7 +251,7 @@ class TestDefaultCompat:
                 settings = "os", "arch", "compiler", "build_type"
 
                 def package_id(self):
-                    del self.options.with_fmt_alias
+                    del self.info.options.with_fmt_alias
 
                 def package_info(self):
                     self.output.warning("WITH_FMT_ALIAS={}".format(self.options.with_fmt_alias))

--- a/conans/test/integration/package_id/test_cache_compatibles.py
+++ b/conans/test/integration/package_id/test_cache_compatibles.py
@@ -251,12 +251,18 @@ class TestDefaultCompat:
                 settings = "os", "arch", "compiler", "build_type"
 
                 def package_id(self):
-                    del self.info.options.with_fmt_alias
+                    del self.options.with_fmt_alias
 
                 def package_info(self):
                     self.output.warning("WITH_FMT_ALIAS={}".format(self.options.with_fmt_alias))
             """)
         c.save({"conanfile.py": conanfile})
 
+        c.run("create .")
+        c.run("remove * -f")
+
         c.run("create . --build=missing -s compiler.cppstd=17")
+        print(c.out)
         assert "Possible options are ['shared', 'header_only']" not in c.out
+        assert "mylib/1.0: WARN: WITH_FMT_ALIAS=False" in c.out
+

--- a/conans/test/integration/package_id/test_cache_compatibles.py
+++ b/conans/test/integration/package_id/test_cache_compatibles.py
@@ -280,6 +280,6 @@ class TestDefaultCompat:
         c.run("create . --build=mylib/1.0 -s compiler.cppstd=17")
         c.run("remove '*' -f")
 
-        # this fails when looking for compatible packages
+        # this fails building after looking for compatible packages
         c.run("create . --build=missing -s compiler.cppstd=17")
         assert "Possible options are ['shared', 'header_only']" not in c.out

--- a/conans/test/integration/package_id/test_cache_compatibles.py
+++ b/conans/test/integration/package_id/test_cache_compatibles.py
@@ -265,8 +265,8 @@ class TestDefaultCompat:
         c.run("create . -s compiler.cppstd=14")
 
         c.run("create . --build=missing -s compiler.cppstd=17")
-        assert "mylib/1.0: Main binary package 'a0a14c35eeb78c552ac01bde2bc48a20823fb5ad'"\
-               " missing. Using compatible package" in c.out
+        assert "mylib/1.0: Main binary package" in c.out
+        assert " missing. Using compatible package" in c.out
         assert "Possible options are ['shared', 'header_only']" not in c.out
         assert "mylib/1.0: WARN: WITH_FMT_ALIAS=False" in c.out
 

--- a/conans/test/integration/package_id/test_cache_compatibles.py
+++ b/conans/test/integration/package_id/test_cache_compatibles.py
@@ -258,8 +258,9 @@ class TestDefaultCompat:
             """)
         c.save({"conanfile.py": conanfile})
 
-        c.run("create .")
-        c.run("remove * -f")
+        c.run("create . -s compiler.cppstd=14")
+        print(c.out)
+        #c.run("remove * -f")
 
         c.run("create . --build=missing -s compiler.cppstd=17")
         print(c.out)

--- a/conans/test/integration/package_id/test_validate.py
+++ b/conans/test/integration/package_id/test_validate.py
@@ -84,7 +84,7 @@ class TestValidate(unittest.TestCase):
                    settings = "os"
 
                    def validate(self):
-                       if self.settings.os == "Windows":
+                       if self.info.settings.os == "Windows":
                            raise ConanInvalidConfiguration("Windows not supported")
 
                    def package_id(self):


### PR DESCRIPTION
Close https://github.com/conan-io/conan/pull/11461
Close https://github.com/conan-io/conan/pull/11454

- Removes the assignment of ``settings`` and ``options`` to use the ``info.settings`` and ``info.options`` automagically inside ``validate()`` and ``package_id()`` methods
- Important: ``validate()`` and ``package_id()`` methods should operate always now with ``self.info`` fields, otherwise ``compatibility will be broken``
- Relaxed the assignment of ``settings`` and ``options`` of compatible packages to ``self.settings`` and ``self.options`` so the values are updated within ``package_info()``. Now, only an ``update`` is computed, but removed settings and options in ``package_id()`` will still have a value in ``self.settings`` and ``self.options`` in ``package_info()``.
- If some ``package_info()`` needed more accurate information of what has been removed, they should check ``self.info.settings`` instead.
