### PR TITLE
Deny 'settings.build_type' in 'tools.cmake.cmake_layout:build_folder'

### DIFF
--- a/conan/tools/cmake/layout.py
+++ b/conan/tools/cmake/layout.py
@@ -51,6 +51,11 @@ def get_build_folder_custom_vars(conanfile):
         tmp = None
         if s.startswith("settings."):
             _, var = s.split("settings.", 1)
+            if var == "build_type":
+                raise ConanException("Error, don't include 'settings.build_type' in the "
+                                     "'tools.cmake.cmake_layout:build_folder_vars' conf. It is "
+                                     "managed by default because 'CMakeToolchain' and 'CMakeDeps' "
+                                     "are multi-config generators.`")
             tmp = conanfile.settings.get_safe(var)
         elif s.startswith("options."):
             _, var = s.split("options.", 1)

--- a/conans/test/functional/toolchains/cmake/test_cmake_toolchain.py
+++ b/conans/test/functional/toolchains/cmake/test_cmake_toolchain.py
@@ -907,3 +907,14 @@ def test_cmake_presets_with_conanfile_txt():
         c.run_command("build\\Release\\foo")
 
     assert "Hello World Release!" in c.out
+
+
+def test_cmake_presets_forbidden_build_type():
+    client = TestClient(path_with_spaces=False)
+    client.run("new hello/0.1 --template cmake_exe")
+    # client.run("new cmake_exe -d name=hello -d version=0.1")
+    settings_layout = '-c tools.cmake.cmake_layout:build_folder_vars=' \
+                      '\'["options.missing", "settings.build_type"]\''
+    client.run("install . {}".format(settings_layout), assert_error=True)
+    assert "Error, don't include 'settings.build_type' in the " \
+           "'tools.cmake.cmake_layout:build_folder_vars' conf" in client.out


### PR DESCRIPTION
Changelog: Fix: The `CMakeToolchain` will fail if `settings.build_type` is specified in the `'tools.cmake.cmake_layout:build_folder'` conf because the build_type is automatically managed by the CMakeToolchain and CMakeDeps generators by default.
Docs: https://github.com/conan-io/docs/pull/2614

