### PR TITLE
Feature/components default new cppinfo

### DIFF
--- a/conan/tools/gnu/autotoolstoolchain.py
+++ b/conan/tools/gnu/autotoolstoolchain.py
@@ -203,7 +203,7 @@ class AutotoolsToolchain:
                                        _get_argument("includedir", "includedirs"),
                                        _get_argument("oldincludedir", "includedirs"),
                                        _get_argument("datarootdir", "resdirs")])
-        return configure_install_flags
+        return [el for el in configure_install_flags if el]
 
     def _default_autoreconf_flags(self):
         return ["--force", "--install"]

--- a/conans/client/installer.py
+++ b/conans/client/installer.py
@@ -675,7 +675,7 @@ class BinaryInstaller(object):
                         conanfile.cpp_info = CppInfo(conanfile.name, package_folder,
                                                      default_values=CppInfoDefaultValues())
                         if not is_editable:
-                            conanfile.cpp.package.set_relative_base_folder(conanfile.package_folder)
+                            # conanfile.cpp.package.set_relative_base_folder(conanfile.package_folder)
                             # Copy the infos.package into the old cppinfo
                             fill_old_cppinfo(conanfile.cpp.package, conanfile.cpp_info)
                         else:
@@ -683,25 +683,21 @@ class BinaryInstaller(object):
 
                     conanfile.package_info()
 
-                    if hasattr(conanfile, "layout"):
-                        if is_editable:
-                            # Adjust the folders of the layout to consolidate the rootfolder of the
-                            # cppinfos inside
-                            # convert directory entries to be relative to the declared folders.build
-                            conanfile.cpp.build.set_relative_base_folder(conanfile.build_folder)
+                    if hasattr(conanfile, "layout") and is_editable:
+                        # Adjust the folders of the layout to consolidate the rootfolder of the
+                        # cppinfos inside
+                        # convert directory entries to be relative to the declared folders.build
+                        conanfile.cpp.build.set_relative_base_folder(conanfile.build_folder)
 
-                            # convert directory entries to be relative to the declared folders.source
-                            conanfile.cpp.source.set_relative_base_folder(conanfile.source_folder)
+                        # convert directory entries to be relative to the declared folders.source
+                        conanfile.cpp.source.set_relative_base_folder(conanfile.source_folder)
 
-                            full_editable_cppinfo = NewCppInfo()
-                            full_editable_cppinfo.merge(conanfile.cpp.source)
-                            full_editable_cppinfo.merge(conanfile.cpp.build)
-                            # Paste the editable cpp_info but prioritizing it, only if a
-                            # variable is not declared at build/source, the package will keep the value
-                            fill_old_cppinfo(full_editable_cppinfo, conanfile.cpp_info)
-                        else:
-                            fill_old_cppinfo(conanfile.cpp.package, conanfile.cpp_info)
-
+                        full_editable_cppinfo = NewCppInfo()
+                        full_editable_cppinfo.merge(conanfile.cpp.source)
+                        full_editable_cppinfo.merge(conanfile.cpp.build)
+                        # Paste the editable cpp_info but prioritizing it, only if a
+                        # variable is not declared at build/source, the package will keep the value
+                        fill_old_cppinfo(full_editable_cppinfo, conanfile.cpp_info)
 
                     if conanfile._conan_dep_cpp_info is None:
                         try:

--- a/conans/client/installer.py
+++ b/conans/client/installer.py
@@ -683,21 +683,25 @@ class BinaryInstaller(object):
 
                     conanfile.package_info()
 
-                    if hasattr(conanfile, "layout") and is_editable:
-                        # Adjust the folders of the layout to consolidate the rootfolder of the
-                        # cppinfos inside
-                        # convert directory entries to be relative to the declared folders.build
-                        conanfile.cpp.build.set_relative_base_folder(conanfile.build_folder)
+                    if hasattr(conanfile, "layout"):
+                        if is_editable:
+                            # Adjust the folders of the layout to consolidate the rootfolder of the
+                            # cppinfos inside
+                            # convert directory entries to be relative to the declared folders.build
+                            conanfile.cpp.build.set_relative_base_folder(conanfile.build_folder)
 
-                        # convert directory entries to be relative to the declared folders.source
-                        conanfile.cpp.source.set_relative_base_folder(conanfile.source_folder)
+                            # convert directory entries to be relative to the declared folders.source
+                            conanfile.cpp.source.set_relative_base_folder(conanfile.source_folder)
 
-                        full_editable_cppinfo = NewCppInfo()
-                        full_editable_cppinfo.merge(conanfile.cpp.source)
-                        full_editable_cppinfo.merge(conanfile.cpp.build)
-                        # Paste the editable cpp_info but prioritizing it, only if a
-                        # variable is not declared at build/source, the package will keep the value
-                        fill_old_cppinfo(full_editable_cppinfo, conanfile.cpp_info)
+                            full_editable_cppinfo = NewCppInfo()
+                            full_editable_cppinfo.merge(conanfile.cpp.source)
+                            full_editable_cppinfo.merge(conanfile.cpp.build)
+                            # Paste the editable cpp_info but prioritizing it, only if a
+                            # variable is not declared at build/source, the package will keep the value
+                            fill_old_cppinfo(full_editable_cppinfo, conanfile.cpp_info)
+                        else:
+                            fill_old_cppinfo(conanfile.cpp.package, conanfile.cpp_info)
+
 
                     if conanfile._conan_dep_cpp_info is None:
                         try:

--- a/conans/client/installer.py
+++ b/conans/client/installer.py
@@ -675,7 +675,6 @@ class BinaryInstaller(object):
                         conanfile.cpp_info = CppInfo(conanfile.name, package_folder,
                                                      default_values=CppInfoDefaultValues())
                         if not is_editable:
-                            # conanfile.cpp.package.set_relative_base_folder(conanfile.package_folder)
                             # Copy the infos.package into the old cppinfo
                             fill_old_cppinfo(conanfile.cpp.package, conanfile.cpp_info)
                         else:

--- a/conans/model/conan_file.py
+++ b/conans/model/conan_file.py
@@ -175,7 +175,7 @@ class ConanFile(object):
         self.cpp.package.includedirs = ["include"]
         self.cpp.package.libdirs = ["lib"]
         self.cpp.package.bindirs = ["bin"]
-        self.cpp.package.resdirs = ["res"]
+        self.cpp.package.resdirs = []
         self.cpp.package.builddirs = [""]
         self.cpp.package.frameworkdirs = []
 

--- a/conans/model/layout.py
+++ b/conans/model/layout.py
@@ -8,7 +8,7 @@ class Infos(object):
     def __init__(self):
         self.source = NewCppInfo()
         self.build = NewCppInfo()
-        self.package = NewCppInfo()
+        self.package = NewCppInfo(with_defaults=True)
 
 
 class Folders(object):

--- a/conans/model/new_build_info.py
+++ b/conans/model/new_build_info.py
@@ -276,6 +276,6 @@ def fill_old_cppinfo(origin, old_cpp):
         if origin._generator_properties is not None:
             old_cpp._generator_properties = copy.copy(origin._generator_properties)
 
-    # We change the defaults for the components of the old cpp info that we are managing in
-    # self.cpp_info
+    # We change the defaults so the new components the user is going to declare in package_info
+    # have also defaults, not only the declared in the `self.cpp.package`
     old_cpp._default_values = CppInfoDefaultValues(includedir="include", libdir="lib")

--- a/conans/model/new_build_info.py
+++ b/conans/model/new_build_info.py
@@ -43,6 +43,7 @@ class _NewComponent(object):
         if with_defaults:
             self.includedirs = ["include"]
             self.libdirs = ["lib"]
+            self.bindirs = ["bin"]
 
     @property
     def required_component_names(self):
@@ -278,4 +279,4 @@ def fill_old_cppinfo(origin, old_cpp):
 
     # We change the defaults so the new components the user is going to declare in package_info
     # have also defaults, not only the declared in the `self.cpp.package`
-    old_cpp._default_values = CppInfoDefaultValues(includedir="include", libdir="lib")
+    old_cpp._default_values = CppInfoDefaultValues(includedir="include", libdir="lib", bindir="bin")

--- a/conans/model/new_build_info.py
+++ b/conans/model/new_build_info.py
@@ -2,7 +2,7 @@ import copy
 import os
 from collections import OrderedDict
 
-from conans.model.build_info import DefaultOrderedDict
+from conans.model.build_info import DefaultOrderedDict, CppInfoDefaultValues
 
 _DIRS_VAR_NAMES = ["includedirs", "srcdirs", "libdirs", "resdirs", "bindirs", "builddirs",
                    "frameworkdirs", "objects"]
@@ -13,7 +13,7 @@ _ALL_NAMES = _DIRS_VAR_NAMES + _FIELD_VAR_NAMES
 
 class _NewComponent(object):
 
-    def __init__(self):
+    def __init__(self, with_defaults=False):
         # ###### PROPERTIES
         self._generator_properties = None
 
@@ -39,6 +39,10 @@ class _NewComponent(object):
 
         self.sysroot = None
         self.requires = None
+
+        if with_defaults:
+            self.includedirs = ["include"]
+            self.libdirs = ["lib"]
 
     @property
     def required_component_names(self):
@@ -70,10 +74,10 @@ class _NewComponent(object):
 
 class NewCppInfo(object):
 
-    def __init__(self):
-        self.components = DefaultOrderedDict(lambda: _NewComponent())
+    def __init__(self, with_defaults=False):
+        self.components = DefaultOrderedDict(lambda: _NewComponent(with_defaults))
         # Main package is a component with None key
-        self.components[None] = _NewComponent()
+        self.components[None] = _NewComponent(with_defaults)
         self._aggregated = None  # A _NewComponent object with all the components aggregated
 
     def __getattr__(self, attr):
@@ -271,3 +275,7 @@ def fill_old_cppinfo(origin, old_cpp):
                 setattr(old_cpp, varname, copy.copy(value))
         if origin._generator_properties is not None:
             old_cpp._generator_properties = copy.copy(origin._generator_properties)
+
+    # We change the defaults for the components of the old cpp info that we are managing in
+    # self.cpp_info
+    old_cpp._default_values = CppInfoDefaultValues(includedir="include", libdir="lib")

--- a/conans/test/functional/layout/test_editables_layout.py
+++ b/conans/test/functional/layout/test_editables_layout.py
@@ -213,8 +213,8 @@ def test_cpp_info_components_editable():
     client2.run("create . lib/1.0@")
     out = str(client2.out).replace(r"\\", "/").replace(package_folder, "")
     assert "**FOO includedirs:['package_include_foo']**" in out
-    assert "**FOO libdirs:[]**" in out  # The components don't have default dirs
-    assert "**FOO builddirs:[]**" in out  # The components don't have default dirs
+    assert "**FOO libdirs:['lib']**" in out  # The components does have default dirs
+    assert "**FOO builddirs:[]**" in out  # The components don't have default dirs for builddirs
     assert "**FOO libs:['lib_when_package_foo', 'lib_when_package2_foo']**" in out
     assert "**FOO objects:['myobject.o']**" in out
     assert "**FOO build_modules:['mymodules/mybuildmodule']**" in out
@@ -222,7 +222,7 @@ def test_cpp_info_components_editable():
     assert "**FOO cflags:['my_c_flag_foo']**" in out
 
     assert "**VAR includedirs:['package_include_var']**" in out
-    assert "**VAR libdirs:[]**" in out  # The components don't have default dirs
+    assert "**VAR libdirs:['lib']**" in out  # The components does have default dirs
     assert "**VAR builddirs:[]**" in out  # The components don't have default dirs
     assert "**VAR libs:['lib_when_package_var', 'lib_when_package2_var']**" in out
     assert "**VAR cxxflags:['my_cxx_flag2_var']**" in out

--- a/conans/test/functional/layout/test_layout_autopackage.py
+++ b/conans/test/functional/layout/test_layout_autopackage.py
@@ -295,6 +295,7 @@ def test_auto_package_default_folders_with_components():
     conan_file += """
     def layout(self):
         for el in [self.cpp.source, self.cpp.build]:
+            # The defaults for cpp.build and cpp.source are empty
             assert el.components["foo"].includedirs is None
             assert el.components["foo"].libdirs is None
             assert el.components["foo"].bindirs is None
@@ -302,8 +303,9 @@ def test_auto_package_default_folders_with_components():
             assert el.components["foo"].srcdirs is None
             assert el.components["foo"].resdirs is None
 
-        assert self.cpp.package.components["foo"].includedirs is None
-        assert self.cpp.package.components["foo"].libdirs is None
+        # The defaults for cpp.package are filled includedirs and libdirs
+        assert self.cpp.package.components["foo"].includedirs is not None
+        assert self.cpp.package.components["foo"].libdirs is not None
         assert self.cpp.package.components["foo"].bindirs is None
         assert self.cpp.package.components["foo"].frameworkdirs is None
         assert self.cpp.package.components["foo"].srcdirs is None

--- a/conans/test/functional/layout/test_layout_autopackage.py
+++ b/conans/test/functional/layout/test_layout_autopackage.py
@@ -303,10 +303,10 @@ def test_auto_package_default_folders_with_components():
             assert el.components["foo"].srcdirs is None
             assert el.components["foo"].resdirs is None
 
-        # The defaults for cpp.package are filled includedirs and libdirs
+        # The defaults for cpp.package are filled includedirs and libdirs and bindirs
         assert self.cpp.package.components["foo"].includedirs is not None
         assert self.cpp.package.components["foo"].libdirs is not None
-        assert self.cpp.package.components["foo"].bindirs is None
+        assert self.cpp.package.components["foo"].bindirs is not None
         assert self.cpp.package.components["foo"].frameworkdirs is None
         assert self.cpp.package.components["foo"].srcdirs is None
         assert self.cpp.package.components["foo"].resdirs is None

--- a/conans/test/functional/toolchains/gnu/autotools/test_ios.py
+++ b/conans/test/functional/toolchains/gnu/autotools/test_ios.py
@@ -53,6 +53,9 @@ def test_ios():
             exports_sources = "configure.ac", "Makefile.am", "main.cpp"
             generators = "AutotoolsToolchain", "AutotoolsDeps"
 
+            def layout(self):
+                self.cpp.package.resdirs = ["res"]
+
             def build(self):
                 autotools = Autotools(self)
                 autotools.autoreconf()

--- a/conans/test/integration/command/create_test.py
+++ b/conans/test/integration/command/create_test.py
@@ -625,6 +625,7 @@ def test_defaults_in_components_without_layout(with_layout):
                     cppinfo = dict(self.deps_cpp_info.dependencies)["lib"]
 
                 components = cppinfo.components
+                self.output.warn("BINDIRS: {}".format(cppinfo.bindirs))
                 self.output.warn("LIBDIRS: {}".format(cppinfo.libdirs))
                 self.output.warn("INCLUDEDIRS: {}".format(cppinfo.includedirs))
                 self.output.warn("FOO LIBDIRS: {}".format(components["foo"].libdirs))
@@ -641,12 +642,14 @@ def test_defaults_in_components_without_layout(with_layout):
     if with_layout:
         # The paths are absolute and the components have defaults
         # ".+" Check that there is a path, not only "lib"
+        assert re.search("BINDIRS: \['.+bin'\]", str(client.out))
         assert re.search("LIBDIRS: \['.+lib'\]", str(client.out))
         assert re.search("INCLUDEDIRS: \['.+include'\]", str(client.out))
         assert bool(re.search("FOO LIBDIRS: \['.+lib'\]", str(client.out))) is with_layout
         assert bool(re.search("FOO INCLUDEDIRS: \['.+include'\]", str(client.out))) is with_layout
     else:
         # The paths are not absolute and the components have defaults
+        assert "BINDIRS: ['bin']" in client.out
         assert "LIBDIRS: ['lib']" in client.out
         assert "INCLUDEDIRS: ['include']" in client.out
         assert "FOO LIBDIRS: ['lib']" in client.out

--- a/conans/test/integration/command/create_test.py
+++ b/conans/test/integration/command/create_test.py
@@ -628,8 +628,10 @@ def test_defaults_in_components_without_layout(with_layout):
                 self.output.warn("BINDIRS: {}".format(cppinfo.bindirs))
                 self.output.warn("LIBDIRS: {}".format(cppinfo.libdirs))
                 self.output.warn("INCLUDEDIRS: {}".format(cppinfo.includedirs))
+                self.output.warn("RESDIRS: {}".format(cppinfo.resdirs))
                 self.output.warn("FOO LIBDIRS: {}".format(components["foo"].libdirs))
                 self.output.warn("FOO INCLUDEDIRS: {}".format(components["foo"].includedirs))
+                self.output.warn("FOO RESDIRS: {}".format(components["foo"].resdirs))
 
         """)
 
@@ -645,8 +647,10 @@ def test_defaults_in_components_without_layout(with_layout):
         assert re.search("BINDIRS: \['.+bin'\]", str(client.out))
         assert re.search("LIBDIRS: \['.+lib'\]", str(client.out))
         assert re.search("INCLUDEDIRS: \['.+include'\]", str(client.out))
-        assert bool(re.search("FOO LIBDIRS: \['.+lib'\]", str(client.out))) is with_layout
-        assert bool(re.search("FOO INCLUDEDIRS: \['.+include'\]", str(client.out))) is with_layout
+        assert "WARN: RES DIRS: []"
+        assert bool(re.search("WARN: FOO LIBDIRS: \['.+lib'\]", str(client.out))) is with_layout
+        assert bool(re.search("WARN: FOO INCLUDEDIRS: \['.+include'\]", str(client.out))) is with_layout
+        assert "WARN: FOO RESDIRS: []" in client.out
     else:
         # The paths are not absolute and the components have defaults
         assert "BINDIRS: ['bin']" in client.out
@@ -654,3 +658,4 @@ def test_defaults_in_components_without_layout(with_layout):
         assert "INCLUDEDIRS: ['include']" in client.out
         assert "FOO LIBDIRS: ['lib']" in client.out
         assert "FOO INCLUDEDIRS: ['include']" in client.out
+        assert "FOO RESDIRS: ['res']" in client.out


### PR DESCRIPTION
Changelog:  Fix: When using the `layout()` (as opt-in of some Conan 2.0 features) the default `includedirs` of the declared components is now `["include"]` the default of the `libdirs` is `["lib"]` and the default for the `bindirs` is `["bin"]`. Previously, the components always had empty fields. Also the default of `cpp_info.resdirs` is now empty.
Docs: https://github.com/conan-io/docs/pull/2613

