### PR TITLE
remove legacy opt-in layout

### DIFF
--- a/conans/client/installer.py
+++ b/conans/client/installer.py
@@ -368,7 +368,7 @@ class BinaryInstaller:
                 # TODO: Check this package_folder usage for editable when not defined
                 conanfile.cpp.package.set_relative_base_folder(package_folder)
 
-                if hasattr(conanfile, "layout") and is_editable:
+                if is_editable:
                     # Adjust the folders of the layout to consolidate the rootfolder of the
                     # cppinfos inside
 


### PR DESCRIPTION
In Conan 2.0, the behavior should always be the same, with and without layout() method.
