### PR TITLE
Clear instead of header_only alternative

### DIFF
--- a/conans/model/info.py
+++ b/conans/model/info.py
@@ -575,10 +575,13 @@ class ConanInfo(object):
                            "recipe_hash": self.recipe_hash}
         return conan_info_json
 
+    # FIXME: Rename this to "clear" in 2.0
     def header_only(self):
         self.settings.clear()
         self.options.clear()
         self.requires.clear()
+
+    clear = header_only
 
     def msvc_compatible(self):
         if self.settings.compiler != "msvc":

--- a/conans/test/integration/package_id/transitive_header_only_test.py
+++ b/conans/test/integration/package_id/transitive_header_only_test.py
@@ -107,7 +107,7 @@ class TransitiveIdsTest(unittest.TestCase):
         client.run("create . libb/1.0@")
         # libC -> libB
 
-        unrelated = "self.info.header_only()"
+        unrelated = "self.info.clear()"
         client.save({"conanfile.py": GenConanfile().with_require("libb/1.0")
                                                    .with_package_id(unrelated)})
         client.run("create . libc/1.0@")

--- a/conans/test/integration/provides/test_conditional_provides.py
+++ b/conans/test/integration/provides/test_conditional_provides.py
@@ -18,7 +18,7 @@ class ConditionalProvidesTestCase(unittest.TestCase):
                     self.provides = 'libjpeg'
 
             def package_info(self):
-                self.info.header_only()
+                self.info.clear()
     """)
 
     def test_conflict_requirement(self):


### PR DESCRIPTION
Changelog: Feature: Created `self.info.clear()` as an alias of `self.info.header_only()` that will disappear in Conan 2.0.
Docs: https://github.com/conan-io/docs/pull/2612 
