### PR TITLE
Simplify XcodeDeps generator

### DIFF
--- a/conan/tools/apple/xcodedeps.py
+++ b/conan/tools/apple/xcodedeps.py
@@ -129,8 +129,6 @@ class XcodeDeps(object):
         fields = {
             'pkg_name': pkg_name,
             'comp_name': comp_name,
-            'bin_dirs': " ".join('"{}"'.format(p) for p in cpp_info.bindirs),
-            'res_dirs': " ".join('"{}"'.format(p) for p in cpp_info.resdirs),
             'include_dirs': " ".join('"{}"'.format(p) for p in cpp_info.includedirs),
             'lib_dirs': " ".join('"{}"'.format(p) for p in cpp_info.libdirs),
             'libs': " ".join("-l{}".format(lib) for lib in cpp_info.libs),

--- a/conan/tools/apple/xcodedeps.py
+++ b/conan/tools/apple/xcodedeps.py
@@ -81,15 +81,15 @@ class XcodeDeps(object):
         {% endfor %}
         #include "{{dep_xconfig_filename}}"
 
-        HEADER_SEARCH_PATHS = $(HEADER_SEARCH_PATHS_{{pkg_name}}_{{comp_name}})
-        GCC_PREPROCESSOR_DEFINITIONS = $(GCC_PREPROCESSOR_DEFINITIONS_{{pkg_name}}_{{comp_name}})
-        OTHER_CFLAGS = $(OTHER_CFLAGS_{{pkg_name}}_{{comp_name}})
-        OTHER_CPLUSPLUSFLAGS = $(OTHER_CPLUSPLUSFLAGS_{{pkg_name}}_{{comp_name}})
-        FRAMEWORK_SEARCH_PATHS = $(FRAMEWORK_SEARCH_PATHS_{{pkg_name}}_{{comp_name}})
+        HEADER_SEARCH_PATHS = $(inherited) $(HEADER_SEARCH_PATHS_{{pkg_name}}_{{comp_name}})
+        GCC_PREPROCESSOR_DEFINITIONS = $(inherited) $(GCC_PREPROCESSOR_DEFINITIONS_{{pkg_name}}_{{comp_name}})
+        OTHER_CFLAGS = $(inherited) $(OTHER_CFLAGS_{{pkg_name}}_{{comp_name}})
+        OTHER_CPLUSPLUSFLAGS = $(inherited) $(OTHER_CPLUSPLUSFLAGS_{{pkg_name}}_{{comp_name}})
+        FRAMEWORK_SEARCH_PATHS = $(inherited) $(FRAMEWORK_SEARCH_PATHS_{{pkg_name}}_{{comp_name}})
 
         // Link options for {{pkg_name}}_{{comp_name}}
-        LIBRARY_SEARCH_PATHS = $(LIBRARY_SEARCH_PATHS_{{pkg_name}}_{{comp_name}})
-        OTHER_LDFLAGS = $(OTHER_LDFLAGS_{{pkg_name}}_{{comp_name}})
+        LIBRARY_SEARCH_PATHS = $(inherited) $(LIBRARY_SEARCH_PATHS_{{pkg_name}}_{{comp_name}})
+        OTHER_LDFLAGS = $(inherited) $(OTHER_LDFLAGS_{{pkg_name}}_{{comp_name}})
          """)
 
     _all_xconfig = textwrap.dedent("""\

--- a/conans/test/functional/toolchains/apple/test_xcodedeps_build_configs.py
+++ b/conans/test/functional/toolchains/apple/test_xcodedeps_build_configs.py
@@ -114,7 +114,7 @@ def test_xcodedeps_dashes_names_and_arch():
                  "project.yml": xcode_project}, clean_first=True)
     client.run("install . -s arch=armv8 --build=missing -g XcodeDeps")
     assert os.path.exists(os.path.join(client.current_folder,
-                                       "conan_hello_dashes_hello_dashes_vars_release_arm64.xcconfig"))
+                                       "conan_hello_dashes_hello_dashes_release_arm64.xcconfig"))
     client.run_command("xcodegen generate")
     client.run_command("xcodebuild -project app.xcodeproj -arch arm64")
     assert "BUILD SUCCEEDED" in client.out

--- a/conans/test/functional/toolchains/apple/test_xcodedeps_components.py
+++ b/conans/test/functional/toolchains/apple/test_xcodedeps_components.py
@@ -225,5 +225,4 @@ def test_xcodedeps_test_require():
     assert os.path.isfile(os.path.join(client.current_folder, "conan_gtest.xcconfig"))
     assert os.path.isfile(os.path.join(client.current_folder, "conan_gtest_gtest.xcconfig"))
     assert os.path.isfile(os.path.join(client.current_folder, "conan_gtest_gtest_release_x86_64.xcconfig"))
-    assert os.path.isfile(os.path.join(client.current_folder, "conan_gtest_gtest_vars_release_x86_64.xcconfig"))
     assert '#include "conan_gtest.xcconfig"' in client.load("conandeps.xcconfig")

--- a/conans/test/integration/toolchains/apple/test_xcodedeps.py
+++ b/conans/test/integration/toolchains/apple/test_xcodedeps.py
@@ -17,30 +17,14 @@ _expected_dep_xconfig = [
     "OTHER_LDFLAGS = $(inherited) $(OTHER_LDFLAGS_{name}_{name})",
 ]
 
-_expected_vars_xconfig = [
-    "CONAN_{name}_{name}_BINARY_DIRECTORIES[config={configuration}][arch={architecture}][sdk={sdk}{sdk_version}] =",
-    "CONAN_{name}_{name}_C_COMPILER_FLAGS[config={configuration}][arch={architecture}][sdk={sdk}{sdk_version}] =",
-    "CONAN_{name}_{name}_CXX_COMPILER_FLAGS[config={configuration}][arch={architecture}][sdk={sdk}{sdk_version}] =",
-    "CONAN_{name}_{name}_LINKER_FLAGS[config={configuration}][arch={architecture}][sdk={sdk}{sdk_version}] =",
-    "CONAN_{name}_{name}_PREPROCESSOR_DEFINITIONS[config={configuration}][arch={architecture}][sdk={sdk}{sdk_version}] =",
-    "CONAN_{name}_{name}_INCLUDE_DIRECTORIES[config={configuration}][arch={architecture}][sdk={sdk}{sdk_version}] =",
-    "CONAN_{name}_{name}_RESOURCE_DIRECTORIES[config={configuration}][arch={architecture}][sdk={sdk}{sdk_version}] =",
-    "CONAN_{name}_{name}_LIBRARY_DIRECTORIES[config={configuration}][arch={architecture}][sdk={sdk}{sdk_version}] =",
-    "CONAN_{name}_{name}_LIBRARIES[config={configuration}][arch={architecture}][sdk={sdk}{sdk_version}] = -l{name}",
-    "CONAN_{name}_{name}_SYSTEM_LIBS[config={configuration}][arch={architecture}][sdk={sdk}{sdk_version}] =",
-    "CONAN_{name}_{name}_FRAMEWORKS_DIRECTORIES[config={configuration}][arch={architecture}][sdk={sdk}{sdk_version}] =",
-    "CONAN_{name}_{name}_FRAMEWORKS[config={configuration}][arch={architecture}][sdk={sdk}{sdk_version}] = -framework framework_{name}"
-]
-
 _expected_conf_xconfig = [
-    "#include \"{vars_name}\"",
-    "HEADER_SEARCH_PATHS_{name}_{name} = $(CONAN_{name}_{name}_INCLUDE_DIRECTORIES",
-    "GCC_PREPROCESSOR_DEFINITIONS_{name}_{name} = $(CONAN_{name}_{name}_PREPROCESSOR_DEFINITIONS",
-    "OTHER_CFLAGS_{name}_{name} = $(CONAN_{name}_{name}_C_COMPILER_FLAGS",
-    "OTHER_CPLUSPLUSFLAGS_{name}_{name} = $(CONAN_{name}_{name}_CXX_COMPILER_FLAGS",
-    "FRAMEWORK_SEARCH_PATHS_{name}_{name} = $(CONAN_{name}_{name}_FRAMEWORKS_DIRECTORIES",
-    "LIBRARY_SEARCH_PATHS_{name}_{name} = $(CONAN_{name}_{name}_LIBRARY_DIRECTORIES",
-    "OTHER_LDFLAGS_{name}_{name} = $(CONAN_{name}_{name}_LINKER_FLAGS) $(CONAN_{name}_{name}_LIBRARIES) $(CONAN_{name}_{name}_SYSTEM_LIBS) $(CONAN_{name}_{name}_FRAMEWORKS"
+    "HEADER_SEARCH_PATHS_{name}_{name}[config={configuration}][arch={architecture}][sdk={sdk}{sdk_version}] = ",
+    "GCC_PREPROCESSOR_DEFINITIONS_{name}_{name}[config={configuration}][arch={architecture}][sdk={sdk}{sdk_version}] = ",
+    "OTHER_CFLAGS_{name}_{name}[config={configuration}][arch={architecture}][sdk={sdk}{sdk_version}] = ",
+    "OTHER_CPLUSPLUSFLAGS_{name}_{name}[config={configuration}][arch={architecture}][sdk={sdk}{sdk_version}] = ",
+    "FRAMEWORK_SEARCH_PATHS_{name}_{name}[config={configuration}][arch={architecture}][sdk={sdk}{sdk_version}] = ",
+    "LIBRARY_SEARCH_PATHS_{name}_{name}[config={configuration}][arch={architecture}][sdk={sdk}{sdk_version}] = ",
+    "OTHER_LDFLAGS_{name}_{name}[config={configuration}][arch={architecture}][sdk={sdk}{sdk_version}] = "
 ]
 
 
@@ -50,8 +34,6 @@ def expected_files(current_folder, configuration, architecture, sdk, sdk_version
     deps = ["hello", "goodbye"]
     files.extend(
         [os.path.join(current_folder, "conan_{dep}_{dep}{name}.xcconfig".format(dep=dep, name=name)) for dep in deps])
-    files.extend(
-        [os.path.join(current_folder, "conan_{dep}_{dep}_vars{name}.xcconfig".format(dep=dep, name=name)) for dep in deps])
     files.append(os.path.join(current_folder, "conandeps.xcconfig"))
     return files
 
@@ -67,17 +49,10 @@ def check_contents(client, deps, configuration, architecture, sdk, sdk_version):
             line = var.format(name=dep_name)
             assert line in dep_xconfig
 
-        vars_name = "conan_{}_{}_vars{}.xcconfig".format(dep_name, dep_name,
-                                                      _get_filename(configuration, architecture, sdk, sdk_version))
-        conan_vars = client.load(vars_name)
-        for var in _expected_vars_xconfig:
-            line = var.format(name=dep_name, configuration=configuration, architecture=architecture,
-                              sdk=sdk, sdk_version=sdk_version)
-            assert line in conan_vars
-
         conan_conf = client.load(conf_name)
         for var in _expected_conf_xconfig:
-            assert var.format(vars_name=vars_name, name=dep_name) in conan_conf
+            assert var.format(name=dep_name, configuration=configuration, architecture=architecture,
+                              sdk=sdk, sdk_version=sdk_version) in conan_conf
 
 
 @pytest.mark.skipif(platform.system() != "Darwin", reason="Only for MacOS")


### PR DESCRIPTION
Changelog: Feature: Simplify XcodeDeps generator.
Docs: https://github.com/conan-io/docs/pull/2619

This PR removes a file containing variables that was included from other file, the contents of these two files can be merged. It is also removing *_BINARY_DIRECTORIES* and *_RESOURCE_DIRECTORIES* because those were not used in the xcconfig files and it's not clear to which Xcode variable can be added, if there's one.

This is a preliminar step to another upcoming PR that will try to adress the problem that libraries with components that have lots of dependencies between components make xcode crash because of adding too many duplicated include paths and so on...