### PR TITLE
Cache variables declaration in CMakeToolchain

### DIFF
--- a/conan/tools/cmake/presets.py
+++ b/conan/tools/cmake/presets.py
@@ -82,11 +82,11 @@ def write_cmake_presets(conanfile, toolchain_file, generator, cache_variables):
     if platform.system() == "Windows" and generator == "MinGW Makefiles":
         if "CMAKE_SH" not in cache_variables:
             cache_variables["CMAKE_SH"] = "CMAKE_SH-NOTFOUND"
-        if "CMAKE_MAKE_PROGRAM" not in cache_variables:
-            cmake_make_program = conanfile.conf.get("tools.gnu:make_program", default=None)
-            if cmake_make_program:
-                cmake_make_program = cmake_make_program.replace("\\", "/")
-                cache_variables["CMAKE_MAKE_PROGRAM"] = cmake_make_program
+
+        cmake_make_program = conanfile.conf.get("tools.gnu:make_program", default=None)
+        if cmake_make_program:
+            cmake_make_program = cmake_make_program.replace("\\", "/")
+            cache_variables["CMAKE_MAKE_PROGRAM"] = cmake_make_program
 
     if "CMAKE_POLICY_DEFAULT_CMP0091" not in cache_variables:
         cache_variables["CMAKE_POLICY_DEFAULT_CMP0091"] = "NEW"

--- a/conan/tools/cmake/presets.py
+++ b/conan/tools/cmake/presets.py
@@ -42,7 +42,6 @@ def _configure_preset_name(conanfile, multiconfig):
         return str(build_type).lower()
 
 
-
 def _add_configure_preset(conanfile, generator, cache_variables, toolchain_file, multiconfig):
     build_type = conanfile.settings.get_safe("build_type")
     name = _configure_preset_name(conanfile, multiconfig)
@@ -78,15 +77,19 @@ def _contents(conanfile, toolchain_file, cache_variables, generator):
     return ret
 
 
-def write_cmake_presets(conanfile, toolchain_file, generator):
-    cache_variables = {}
+def write_cmake_presets(conanfile, toolchain_file, generator, cache_variables):
+    cache_variables = cache_variables or {}
     if platform.system() == "Windows" and generator == "MinGW Makefiles":
-        cache_variables["CMAKE_SH"] = "CMAKE_SH-NOTFOUND"
-        cmake_make_program = conanfile.conf.get("tools.gnu:make_program", default=None)
-        if cmake_make_program:
-            cmake_make_program = cmake_make_program.replace("\\", "/")
-            cache_variables["CMAKE_MAKE_PROGRAM"] = cmake_make_program
-    cache_variables["CMAKE_POLICY_DEFAULT_CMP0091"] = "NEW"
+        if "CMAKE_SH" not in cache_variables:
+            cache_variables["CMAKE_SH"] = "CMAKE_SH-NOTFOUND"
+        if "CMAKE_MAKE_PROGRAM" not in cache_variables:
+            cmake_make_program = conanfile.conf.get("tools.gnu:make_program", default=None)
+            if cmake_make_program:
+                cmake_make_program = cmake_make_program.replace("\\", "/")
+                cache_variables["CMAKE_MAKE_PROGRAM"] = cmake_make_program
+
+    if "CMAKE_POLICY_DEFAULT_CMP0091" not in cache_variables:
+        cache_variables["CMAKE_POLICY_DEFAULT_CMP0091"] = "NEW"
 
     preset_path = os.path.join(conanfile.generators_folder, "CMakePresets.json")
     multiconfig = is_multi_configuration(generator)

--- a/conan/tools/cmake/presets.py
+++ b/conan/tools/cmake/presets.py
@@ -83,7 +83,7 @@ def write_cmake_presets(conanfile, toolchain_file, generator, cache_variables):
         if "CMAKE_SH" not in cache_variables:
             cache_variables["CMAKE_SH"] = "CMAKE_SH-NOTFOUND"
 
-        cmake_make_program = conanfile.conf.get("tools.gnu:make_program", default=None)
+        cmake_make_program = conanfile.conf.get("tools.gnu:make_program", default=cache_variables.get("CMAKE_MAKE_PROGRAM"))
         if cmake_make_program:
             cmake_make_program = cmake_make_program.replace("\\", "/")
             cache_variables["CMAKE_MAKE_PROGRAM"] = cmake_make_program

--- a/conan/tools/cmake/toolchain/toolchain.py
+++ b/conan/tools/cmake/toolchain/toolchain.py
@@ -119,6 +119,8 @@ class CMakeToolchain(object):
         self._conanfile = conanfile
         self.generator = self._get_generator(generator)
         self.variables = Variables()
+        # This doesn't support multi-config, they go to the same configPreset common in multi-config
+        self.cache_variables = {}
         self.preprocessor_definitions = Variables()
 
         self.blocks = ToolchainBlocks(self._conanfile, self,
@@ -175,7 +177,14 @@ class CMakeToolchain(object):
         elif self.generator is not None and "Visual" not in self.generator:
             VCVars(self._conanfile).generate()
         toolchain = os.path.join(self._conanfile.generators_folder, toolchain_file or self.filename)
-        write_cmake_presets(self._conanfile, toolchain, self.generator)
+        cache_variables = {}
+        for name, value in self.cache_variables.items():
+            if isinstance(value, bool):
+                cache_variables[name] = "ON" if value else "OFF"
+            else:
+                cache_variables[name] = value
+
+        write_cmake_presets(self._conanfile, toolchain, self.generator, cache_variables)
 
     def _get_generator(self, recipe_generator):
         # Returns the name of the generator to be used by CMake

--- a/conans/test/unittests/tools/cmake/test_cmake_presets_definitions.py
+++ b/conans/test/unittests/tools/cmake/test_cmake_presets_definitions.py
@@ -40,7 +40,7 @@ def test_cmake_make_program(conanfile):
     conanfile.conf.define("tools.gnu:make_program", "C:\\mymake.exe")
 
     with mock.patch("platform.system", mock.MagicMock(return_value='Windows')):
-        write_cmake_presets(conanfile, "the_toolchain.cmake", "MinGW Makefiles")
+        write_cmake_presets(conanfile, "the_toolchain.cmake", "MinGW Makefiles", {})
 
     cmake = CMake(conanfile)
     cmake.configure()


### PR DESCRIPTION
Changelog: Feature: Added `CMakeToolchain(self).cache_variables` to declare `cache_variables`  in the `configurePresets` in the `CMakePresets.json` file. Conan reads them to call `cmake` with `-D` when using the `CMake(self)` build helper. These cache variables doesn't support multi-configuration generators.
Docs: https://github.com/conan-io/docs/pull/2611

Close https://github.com/conan-io/conan/issues/11476