### PR TITLE
MSBuildDeps: map armv8 to ARM64 platform (#11504)

### DIFF
--- a/conan/tools/microsoft/msbuild.py
+++ b/conan/tools/microsoft/msbuild.py
@@ -10,7 +10,7 @@ def msbuild_verbosity_cmd_line_arg(conanfile):
 
 
 def msbuild_arch(arch):
-    return {'x86': 'Win32',
+    return {'x86': 'x86',
             'x86_64': 'x64',
             'armv7': 'ARM',
             'armv8': 'ARM64'}.get(str(arch))

--- a/conan/tools/microsoft/msbuild.py
+++ b/conan/tools/microsoft/msbuild.py
@@ -10,7 +10,7 @@ def msbuild_verbosity_cmd_line_arg(conanfile):
 
 
 def msbuild_arch(arch):
-    return {'x86': 'x86',
+    return {'x86': 'Win32',
             'x86_64': 'x64',
             'armv7': 'ARM',
             'armv8': 'ARM64'}.get(str(arch))

--- a/conan/tools/microsoft/msbuilddeps.py
+++ b/conan/tools/microsoft/msbuilddeps.py
@@ -6,6 +6,7 @@ from xml.dom import minidom
 from jinja2 import Template
 
 from conan.tools._check_build_profile import check_using_build_profile
+from conan.tools.microsoft.msbuild import msbuild_arch
 from conans.errors import ConanException
 from conans.util.files import load, save
 
@@ -105,8 +106,7 @@ class MSBuildDeps(object):
     def __init__(self, conanfile):
         self._conanfile = conanfile
         self.configuration = conanfile.settings.build_type
-        self.platform = {'x86': 'Win32',
-                         'x86_64': 'x64'}.get(str(conanfile.settings.arch))
+        self.platform = msbuild_arch(conanfile.settings.arch)
         # ca_exclude section
         # TODO: Accept single strings, not lists
         self.exclude_code_analysis = self._conanfile.conf.get("tools.microsoft.msbuilddeps:exclude_code_analysis",

--- a/conan/tools/microsoft/msbuilddeps.py
+++ b/conan/tools/microsoft/msbuilddeps.py
@@ -6,7 +6,6 @@ from xml.dom import minidom
 from jinja2 import Template
 
 from conan.tools._check_build_profile import check_using_build_profile
-from conan.tools.microsoft.msbuild import msbuild_arch
 from conans.errors import ConanException
 from conans.util.files import load, save
 
@@ -106,7 +105,12 @@ class MSBuildDeps(object):
     def __init__(self, conanfile):
         self._conanfile = conanfile
         self.configuration = conanfile.settings.build_type
-        self.platform = msbuild_arch(conanfile.settings.arch)
+        # TODO: This platform is not exactly the same as ``msbuild_arch``, because it differs
+        # in x86=>Win32
+        self.platform = {'x86': 'Win32',
+                         'x86_64': 'x64',
+                         'armv7': 'ARM',
+                         'armv8': 'ARM64'}.get(str(conanfile.settings.arch))
         # ca_exclude section
         # TODO: Accept single strings, not lists
         self.exclude_code_analysis = self._conanfile.conf.get("tools.microsoft.msbuilddeps:exclude_code_analysis",

--- a/conan/tools/microsoft/toolchain.py
+++ b/conan/tools/microsoft/toolchain.py
@@ -55,9 +55,12 @@ class MSBuildToolchain(object):
 
     def _name_condition(self, settings):
         props = [("Configuration", self.configuration),
-                 # FIXME: This probably requires mapping ARM architectures
+                 # TODO: refactor, put in common with MSBuildDeps. Beware this is != msbuild_arch
+                 #  because of Win32
                  ("Platform", {'x86': 'Win32',
-                               'x86_64': 'x64'}.get(settings.get_safe("arch")))]
+                               'x86_64': 'x64',
+                               'armv7': 'ARM',
+                               'armv8': 'ARM64'}.get(settings.get_safe("arch")))]
 
         name = "".join("_%s" % v for _, v in props if v is not None)
         condition = " And ".join("'$(%s)' == '%s'" % (k, v) for k, v in props if v is not None)

--- a/conans/test/integration/toolchains/microsoft/test_msbuilddeps.py
+++ b/conans/test/integration/toolchains/microsoft/test_msbuilddeps.py
@@ -1,23 +1,20 @@
 import os
-import textwrap
 
 import pytest
 
 from conans.test.utils.tools import TestClient
 
 
-@pytest.mark.parametrize("arch,exp_platform", [
-    ("x86", "Win32"),
-    ("x86_64", "x64"),
-    ("armv7", "ARM"),
-    ("armv8", "ARM64"),
-])
+@pytest.mark.parametrize(
+    "arch,exp_platform",
+    [
+        ("x86", "Win32"),
+        ("x86_64", "x64"),
+        ("armv7", "ARM"),
+        ("armv8", "ARM64"),
+    ],
+)
 def test_msbuilddeps_maps_architecture_to_platform(arch, exp_platform):
-    """
-    Simple test checking that conantoolchain_release_x64.props is adding all the expected
-    flags and preprocessor definitions
-    """
-
     client = TestClient(path_with_spaces=False)
     client.run("new hello/0.1 --template=msbuild_lib")
     client.run(f"install . -g MSBuildDeps -s arch={arch} -pr:b=default -if=install")

--- a/conans/test/integration/toolchains/microsoft/test_msbuilddeps.py
+++ b/conans/test/integration/toolchains/microsoft/test_msbuilddeps.py
@@ -1,0 +1,26 @@
+import os
+import textwrap
+
+import pytest
+
+from conans.test.utils.tools import TestClient
+
+
+@pytest.mark.parametrize("arch,exp_platform", [
+    ("x86", "Win32"),
+    ("x86_64", "x64"),
+    ("armv7", "ARM"),
+    ("armv8", "ARM64"),
+])
+def test_msbuilddeps_maps_architecture_to_platform(arch, exp_platform):
+    """
+    Simple test checking that conantoolchain_release_x64.props is adding all the expected
+    flags and preprocessor definitions
+    """
+
+    client = TestClient(path_with_spaces=False)
+    client.run("new hello/0.1 --template=msbuild_lib")
+    client.run(f"install . -g MSBuildDeps -s arch={arch} -pr:b=default -if=install")
+    toolchain = client.load(os.path.join("conan", "conantoolchain.props"))
+    expected_import = f"""<Import Condition="'$(Configuration)' == 'Release' And '$(Platform)' == '{exp_platform}'" Project="conantoolchain_release_{exp_platform.lower()}.props"/>"""
+    assert expected_import in toolchain


### PR DESCRIPTION
Changelog: Feature: map `armv8` arch to `ARM64` MSBuild platform in MSBuildDeps generator.

Docs: Omit

- [x] Refer to the issue that supports this Pull Request.
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 

<sup>**Note:** By default this PR will skip the slower tests and will use a limited set of python versions. Check [here](https://github.com/conan-io/conan/blob/develop/.github/PR_INCREASE_TESTING.md) how to increase the testing level by writing some tags in the current PR body text.</sup>
