### PR TITLE
Output levels + logger output + Replaced tracer

### DIFF
--- a/conan/api/conan_api.py
+++ b/conan/api/conan_api.py
@@ -57,3 +57,10 @@ class ConanAPIV2(object):
 
 
 ConanAPI = ConanAPIV2
+
+
+def set_conan_output_level(level, activate_logger=False):
+    from conans.cli import output
+    output.conan_output_level = level
+    output.conan_output_logger_format = activate_logger
+

--- a/conan/api/model.py
+++ b/conan/api/model.py
@@ -26,6 +26,9 @@ class Remote:
         return "{}: {} [Verify SSL: {}, Enabled: {}]".format(self.name, self.url, self.verify_ssl,
                                                              not self.disabled)
 
+    def __repr__(self):
+        return str(self)
+
 
 class _RecipeUploadData:
     def __init__(self, ref, prefs=None):

--- a/conan/api/subapi/__init__.py
+++ b/conan/api/subapi/__init__.py
@@ -1,7 +1,7 @@
 import functools
 import os
 
-from conans.util.tracer import log_command
+from conans.util.tracer import log_conan_api_call
 
 
 def api_method(f):
@@ -17,7 +17,7 @@ def api_method(f):
         try:
             # FIXME: Fix this hack if we want to keep the action recorder
             subapi_name = str(subapi.__class__.__name__).replace("API", "").lower()
-            log_command("{}.{}".format(subapi_name, f.__name__), kwargs)
+            log_conan_api_call("{}.{}".format(subapi_name, f.__name__), kwargs)
             return f(subapi, *args, **kwargs)
         finally:
             if old_curdir:

--- a/conan/tools/cmake/cmake.py
+++ b/conan/tools/cmake/cmake.py
@@ -98,11 +98,27 @@ class CMake(object):
 
         arg_list.extend(['-D{}="{}"'.format(k, v) for k, v in self._cache_variables.items()])
         arg_list.append('"{}"'.format(cmakelist_folder))
+        arg_list.append(self._get_log_level_arg())
 
         command = " ".join(arg_list)
         self._conanfile.output.info("CMake command: %s" % command)
         with chdir(self, build_folder):
             self._conanfile.run(command)
+
+    @staticmethod
+    def _get_log_level_arg():
+        """
+        cmake --log-level=<ERROR|WARNING|NOTICE|STATUS|VERBOSE|DEBUG|TRACE>
+        """
+        from conans.cli.output import conan_log_level, LEVEL_ERROR, LEVEL_WARNING, LEVEL_NOTICE, \
+            LEVEL_STATUS, LEVEL_DEBUG, LEVEL_TRACE, LEVEL_VERBOSE
+        cmake_level = {LEVEL_ERROR: "ERROR", LEVEL_WARNING: "WARNING", LEVEL_NOTICE: "NOTICE",
+                       LEVEL_STATUS: "STATUS", LEVEL_VERBOSE: "VERBOSE",
+                       LEVEL_DEBUG: "DEBUG", LEVEL_TRACE: "TRACE"}.get(conan_log_level, None)
+        if not cmake_level:
+            return ""
+        # TODO: Usage of -DCMAKE_VERBOSE_MAKEFILE to limit build traces?
+        return "--log-level={}".format(cmake_level)
 
     def _build(self, build_type=None, target=None, cli_args=None, build_tool_args=None):
         bf = self._conanfile.build_folder

--- a/conan/tools/cmake/cmake.py
+++ b/conan/tools/cmake/cmake.py
@@ -98,27 +98,11 @@ class CMake(object):
 
         arg_list.extend(['-D{}="{}"'.format(k, v) for k, v in self._cache_variables.items()])
         arg_list.append('"{}"'.format(cmakelist_folder))
-        arg_list.append(self._get_log_level_arg())
 
         command = " ".join(arg_list)
         self._conanfile.output.info("CMake command: %s" % command)
         with chdir(self, build_folder):
             self._conanfile.run(command)
-
-    @staticmethod
-    def _get_log_level_arg():
-        """
-        cmake --log-level=<ERROR|WARNING|NOTICE|STATUS|VERBOSE|DEBUG|TRACE>
-        """
-        from conans.cli.output import conan_log_level, LEVEL_ERROR, LEVEL_WARNING, LEVEL_NOTICE, \
-            LEVEL_STATUS, LEVEL_DEBUG, LEVEL_TRACE, LEVEL_VERBOSE
-        cmake_level = {LEVEL_ERROR: "ERROR", LEVEL_WARNING: "WARNING", LEVEL_NOTICE: "NOTICE",
-                       LEVEL_STATUS: "STATUS", LEVEL_VERBOSE: "VERBOSE",
-                       LEVEL_DEBUG: "DEBUG", LEVEL_TRACE: "TRACE"}.get(conan_log_level, None)
-        if not cmake_level:
-            return ""
-        # TODO: Usage of -DCMAKE_VERBOSE_MAKEFILE to limit build traces?
-        return "--log-level={}".format(cmake_level)
 
     def _build(self, build_type=None, target=None, cli_args=None, build_tool_args=None):
         bf = self._conanfile.build_folder

--- a/conans/cli/commands/__init__.py
+++ b/conans/cli/commands/__init__.py
@@ -35,41 +35,27 @@ def json_formatter(data):
 
 
 def add_log_level_args(subparser):
-    # FIXME: Arguments name suggestions
-    subparser.add_argument("-oe", "--errors", action='store_true',
-                           help="Display error messages")
-    subparser.add_argument("-ow", "--warnings", action='store_true',
-                           help="Display warning messages")
-    subparser.add_argument("-on", "--notice", action='store_true',
-                           help="Display important messages to attract user attention")
-    subparser.add_argument("-v", "--verbose", action='store_true',
-                           help="Display detailed information messages")
-    subparser.add_argument("-vv", action='store_true',
-                           help="Display closely related to internal implementation details "
-                                "messages")
-    subparser.add_argument("-vvv", action='store_true',
-                           help="Display fine-grained messages with very low-level implementation "
-                                "details")
-    subparser.add_argument("-q", "--quiet", action='store_true', help="Display no output")
+    subparser.add_argument("-v", "--output-level",  default="status", nargs='?',
+                           help="Level of detail of the output")
 
 
 def process_log_level_args(args):
     from conans.cli import output
-    from conans.cli.output import LEVEL_ERROR, LEVEL_WARNING, LEVEL_NOTICE, LEVEL_TRACE, \
-        LEVEL_DEBUG, LEVEL_VERBOSE, LEVEL_QUIET
+    from conans.cli.output import LEVEL_QUIET, LEVEL_ERROR, LEVEL_WARNING, LEVEL_NOTICE, \
+        LEVEL_STATUS, LEVEL_VERBOSE, LEVEL_DEBUG, LEVEL_TRACE
 
-    if args.errors:
-        output.conan_log_level = LEVEL_ERROR
-    elif args.warnings:
-        output.conan_log_level = LEVEL_WARNING
-    if args.notice:
-        output.conan_log_level = LEVEL_NOTICE
-    elif args.vvv:
-        output.conan_log_level = LEVEL_TRACE
-    elif args.vv:
-        output.conan_log_level = LEVEL_DEBUG
-    elif args.verbose:
-        output.conan_log_level = LEVEL_VERBOSE
-    elif args.quiet:
-        output.conan_log_level = LEVEL_QUIET
+    levels = {None: LEVEL_VERBOSE,  # -v
+              "verbose": LEVEL_VERBOSE,  # -vverbose
+              "v": LEVEL_DEBUG,  # -vv
+              "debug": LEVEL_DEBUG,  # -vdebug
+              "vv": LEVEL_TRACE,  # -vvv
+              "trace": LEVEL_TRACE,  # -vtrace
+              "status": LEVEL_STATUS,  # -vstatus
+              "notice": LEVEL_NOTICE,  # -vnotice
+              "warning": LEVEL_WARNING,  # -vwaring
+              "error": LEVEL_ERROR,  # -verror
+              "quiet": LEVEL_QUIET  # -vquiet
+              }
 
+    level = levels.get(args.output_level)
+    output.conan_log_level = level

--- a/conans/cli/commands/__init__.py
+++ b/conans/cli/commands/__init__.py
@@ -3,6 +3,7 @@ import os
 from json import JSONEncoder
 
 from conan.api.model import Remote
+from conans.errors import ConanException
 from conans.model.package_ref import PkgReference
 from conans.model.recipe_ref import RecipeReference
 
@@ -37,6 +38,9 @@ def json_formatter(data):
 def add_log_level_args(subparser):
     subparser.add_argument("-v", "--output-level",  default="status", nargs='?',
                            help="Level of detail of the output")
+    subparser.add_argument("--sol", "--strict-output-level", action='store_true',
+                           help="If specified, only the messages corresponding to the '-v' arg "
+                                "will be shown")
 
 
 def process_log_level_args(args):
@@ -58,4 +62,7 @@ def process_log_level_args(args):
               }
 
     level = levels.get(args.output_level)
-    output.conan_log_level = level
+    if not level:
+        raise ConanException(f"Invalid argument '-v{args.output_level}'")
+    output.conan_output_level = level
+    output.conan_strict_output_level = args.sol

--- a/conans/cli/commands/__init__.py
+++ b/conans/cli/commands/__init__.py
@@ -32,3 +32,44 @@ class ConanJSONEncoder(JSONEncoder):
 def json_formatter(data):
     myjson = json.dumps(data, indent=4, cls=ConanJSONEncoder)
     return myjson
+
+
+def add_log_level_args(subparser):
+    # FIXME: Arguments name suggestions
+    subparser.add_argument("-oe", "--errors", action='store_true',
+                           help="Display error messages")
+    subparser.add_argument("-ow", "--warnings", action='store_true',
+                           help="Display warning messages")
+    subparser.add_argument("-on", "--notice", action='store_true',
+                           help="Display important messages to attract user attention")
+    subparser.add_argument("-v", "--verbose", action='store_true',
+                           help="Display detailed information messages")
+    subparser.add_argument("-vv", action='store_true',
+                           help="Display closely related to internal implementation details "
+                                "messages")
+    subparser.add_argument("-vvv", action='store_true',
+                           help="Display fine-grained messages with very low-level implementation "
+                                "details")
+    subparser.add_argument("-q", "--quiet", action='store_true', help="Display no output")
+
+
+def process_log_level_args(args):
+    from conans.cli import output
+    from conans.cli.output import LEVEL_ERROR, LEVEL_WARNING, LEVEL_NOTICE, LEVEL_TRACE, \
+        LEVEL_DEBUG, LEVEL_VERBOSE, LEVEL_QUIET
+
+    if args.errors:
+        output.conan_log_level = LEVEL_ERROR
+    elif args.warnings:
+        output.conan_log_level = LEVEL_WARNING
+    if args.notice:
+        output.conan_log_level = LEVEL_NOTICE
+    elif args.vvv:
+        output.conan_log_level = LEVEL_TRACE
+    elif args.vv:
+        output.conan_log_level = LEVEL_DEBUG
+    elif args.verbose:
+        output.conan_log_level = LEVEL_VERBOSE
+    elif args.quiet:
+        output.conan_log_level = LEVEL_QUIET
+

--- a/conans/cli/commands/__init__.py
+++ b/conans/cli/commands/__init__.py
@@ -36,8 +36,10 @@ def json_formatter(data):
 
 
 def add_log_level_args(subparser):
-    subparser.add_argument("-v", "--output-level",  default="status", nargs='?',
-                           help="Level of detail of the output")
+    subparser.add_argument("-v", default="status", nargs='?',
+                           help="Level of detail of the output. Valid options from less verbose "
+                                "to more verbose: -vquiet, -verror, -vwarning, -vnotice, -vstatus, "
+                                "-v or -vverbose, -vv or -vdebug, -vvv or -vtrace")
     subparser.add_argument("--logger", action="store_true",
                            help="Show the output with log format, with time, type and message.")
 
@@ -47,21 +49,21 @@ def process_log_level_args(args):
     from conans.cli.output import LEVEL_QUIET, LEVEL_ERROR, LEVEL_WARNING, LEVEL_NOTICE, \
         LEVEL_STATUS, LEVEL_VERBOSE, LEVEL_DEBUG, LEVEL_TRACE
 
-    levels = {None: LEVEL_VERBOSE,  # -v
-              "verbose": LEVEL_VERBOSE,  # -vverbose
-              "v": LEVEL_DEBUG,  # -vv
-              "debug": LEVEL_DEBUG,  # -vdebug
-              "vv": LEVEL_TRACE,  # -vvv
-              "trace": LEVEL_TRACE,  # -vtrace
-              "status": LEVEL_STATUS,  # -vstatus
-              "notice": LEVEL_NOTICE,  # -vnotice
-              "warning": LEVEL_WARNING,  # -vwaring
-              "error": LEVEL_ERROR,  # -verror
-              "quiet": LEVEL_QUIET  # -vquiet
+    levels = {"quiet": LEVEL_QUIET,  # -vquiet 80
+              "error": LEVEL_ERROR,  # -verror 70
+              "warning": LEVEL_WARNING,  # -vwaring 60
+              "notice": LEVEL_NOTICE,  # -vnotice 50
+              "status": LEVEL_STATUS,  # -vstatus 40
+              "verbose": LEVEL_VERBOSE,  # -vverbose 30
+              None: LEVEL_VERBOSE,  # -v 30
+              "debug": LEVEL_DEBUG,  # -vdebug 20
+              "v": LEVEL_DEBUG,  # -vv 20
+              "trace": LEVEL_TRACE,  # -vtrace 10
+              "vv": LEVEL_TRACE,  # -vvv 10
               }
 
-    level = levels.get(args.output_level)
+    level = levels.get(args.v)
     if not level:
-        raise ConanException(f"Invalid argument '-v{args.output_level}'")
+        raise ConanException(f"Invalid argument '-v{args.v}'")
     output.conan_output_level = level
     output.conan_output_logger_format = args.logger

--- a/conans/cli/commands/__init__.py
+++ b/conans/cli/commands/__init__.py
@@ -38,9 +38,8 @@ def json_formatter(data):
 def add_log_level_args(subparser):
     subparser.add_argument("-v", "--output-level",  default="status", nargs='?',
                            help="Level of detail of the output")
-    subparser.add_argument("--sol", "--strict-output-level", action='store_true',
-                           help="If specified, only the messages corresponding to the '-v' arg "
-                                "will be shown")
+    subparser.add_argument("--logger", action="store_true",
+                           help="Show the output with log format, with time, type and message.")
 
 
 def process_log_level_args(args):
@@ -65,4 +64,4 @@ def process_log_level_args(args):
     if not level:
         raise ConanException(f"Invalid argument '-v{args.output_level}'")
     output.conan_output_level = level
-    output.conan_strict_output_level = args.sol
+    output.conan_output_logger_format = args.logger

--- a/conans/cli/commands/build.py
+++ b/conans/cli/commands/build.py
@@ -34,12 +34,12 @@ def build(conan_api, parser, *args):
     deps_graph, lockfile = graph_compute(args, conan_api, partial=args.lockfile_partial)
 
     out = ConanOutput()
-    out.highlight("\n-------- Installing packages ----------")
+    out.highlight("-------- Installing packages ----------")
     conan_api.install.install_binaries(deps_graph=deps_graph, remotes=remote, update=args.update)
 
     source_folder = folder
     output_folder = make_abs_path(args.output_folder, cwd) if args.output_folder else None
-    out.highlight("\n-------- Finalizing install (deploy, generators) ----------")
+    out.highlight("-------- Finalizing install (deploy, generators) ----------")
     conan_api.install.install_consumer(deps_graph=deps_graph, source_folder=source_folder,
                                        output_folder=output_folder)
 

--- a/conans/cli/commands/build.py
+++ b/conans/cli/commands/build.py
@@ -34,12 +34,12 @@ def build(conan_api, parser, *args):
     deps_graph, lockfile = graph_compute(args, conan_api, partial=args.lockfile_partial)
 
     out = ConanOutput()
-    out.highlight("-------- Installing packages ----------")
+    out.title("Installing packages")
     conan_api.install.install_binaries(deps_graph=deps_graph, remotes=remote, update=args.update)
 
     source_folder = folder
     output_folder = make_abs_path(args.output_folder, cwd) if args.output_folder else None
-    out.highlight("-------- Finalizing install (deploy, generators) ----------")
+    out.title("Finalizing install (deploy, generators)")
     conan_api.install.install_consumer(deps_graph=deps_graph, source_folder=source_folder,
                                        output_folder=output_folder)
 

--- a/conans/cli/commands/create.py
+++ b/conans/cli/commands/create.py
@@ -54,7 +54,7 @@ def create(conan_api, parser, *args):
         # FIXME: We need to update build_requires too, not only ``requires``
         lockfile.add(requires=[ref])
 
-    out.highlight("\n-------- Input profiles ----------")
+    out.highlight("-------- Input profiles ----------")
     out.info("Profile host:")
     out.info(profile_host.dumps())
     out.info("Profile build:")
@@ -89,7 +89,7 @@ def create(conan_api, parser, *args):
                                             update=args.update,
                                             check_update=check_updates)
     print_graph_basic(deps_graph)
-    out.highlight("\n-------- Computing necessary packages ----------")
+    out.highlight("-------- Computing necessary packages ----------")
     if args.build is None:  # Not specified, force build the tested library
         build_modes = [ref.repr_notime()]
     else:
@@ -99,7 +99,7 @@ def create(conan_api, parser, *args):
                                      lockfile=lockfile)
     print_graph_packages(deps_graph)
 
-    out.highlight("\n-------- Installing packages ----------")
+    out.highlight("-------- Installing packages ----------")
     conan_api.install.install_binaries(deps_graph=deps_graph, remotes=remotes, update=args.update)
 
     save_lockfile_out(args, deps_graph, lockfile, cwd)
@@ -126,7 +126,7 @@ def _check_tested_reference_matches(deps_graph, tested_ref, out):
 
 def test_package(conan_api, deps_graph, test_conanfile_path):
     out = ConanOutput()
-    out.highlight("\n-------- Testing the package ----------")
+    out.highlight("-------- Testing the package ----------")
     if len(deps_graph.nodes) == 1:
         raise ConanException("The conanfile at '{}' doesn't declare any requirement, "
                              "use `self.tested_reference_str` to require the "
@@ -141,12 +141,12 @@ def test_package(conan_api, deps_graph, test_conanfile_path):
                                        source_folder=conanfile_folder,
                                        output_folder=output_folder)
 
-    out.highlight("\n-------- Testing the package: Building ----------")
+    out.highlight("-------- Testing the package: Building ----------")
     app = ConanApp(conan_api.cache_folder)
     conanfile.folders.set_base_package(conanfile.folders.base_build)
     run_build_method(conanfile, app.hook_manager)
 
-    out.highlight("\n-------- Testing the package: Running test() ----------")
+    out.highlight("-------- Testing the package: Running test() ----------")
     conanfile.output.highlight("Running test()")
     with conanfile_exception_formatter(conanfile, "test"):
         with chdir(conanfile.build_folder):

--- a/conans/cli/commands/create.py
+++ b/conans/cli/commands/create.py
@@ -45,7 +45,7 @@ def create(conan_api, parser, *args):
     profile_host, profile_build = get_profiles_from_args(conan_api, args)
 
     out = ConanOutput()
-    out.highlight("-------- Exporting the recipe ----------")
+    out.highlight("Exporting the recipe")
     ref = conan_api.export.export(path=path,
                                   name=args.name, version=args.version,
                                   user=args.user, channel=args.channel,
@@ -54,7 +54,7 @@ def create(conan_api, parser, *args):
         # FIXME: We need to update build_requires too, not only ``requires``
         lockfile.add(requires=[ref])
 
-    out.highlight("-------- Input profiles ----------")
+    out.title("Input profiles")
     out.info("Profile host:")
     out.info(profile_host.dumps())
     out.info("Profile build:")
@@ -80,7 +80,7 @@ def create(conan_api, parser, *args):
                                                                 tool_requires=tool_requires,
                                                                 profile_host=profile_host)
 
-    out.highlight("-------- Computing dependency graph ----------")
+    out.highlight("Computing dependency graph")
     check_updates = args.check_updates if "check_updates" in args else False
     deps_graph = conan_api.graph.load_graph(root_node, profile_host=profile_host,
                                             profile_build=profile_build,
@@ -89,7 +89,7 @@ def create(conan_api, parser, *args):
                                             update=args.update,
                                             check_update=check_updates)
     print_graph_basic(deps_graph)
-    out.highlight("-------- Computing necessary packages ----------")
+    out.title("Computing necessary packages")
     if args.build is None:  # Not specified, force build the tested library
         build_modes = [ref.repr_notime()]
     else:
@@ -99,7 +99,7 @@ def create(conan_api, parser, *args):
                                      lockfile=lockfile)
     print_graph_packages(deps_graph)
 
-    out.highlight("-------- Installing packages ----------")
+    out.title("Installing packages")
     conan_api.install.install_binaries(deps_graph=deps_graph, remotes=remotes, update=args.update)
 
     save_lockfile_out(args, deps_graph, lockfile, cwd)
@@ -126,7 +126,7 @@ def _check_tested_reference_matches(deps_graph, tested_ref, out):
 
 def test_package(conan_api, deps_graph, test_conanfile_path):
     out = ConanOutput()
-    out.highlight("-------- Testing the package ----------")
+    out.title("Testing the package")
     if len(deps_graph.nodes) == 1:
         raise ConanException("The conanfile at '{}' doesn't declare any requirement, "
                              "use `self.tested_reference_str` to require the "
@@ -141,12 +141,12 @@ def test_package(conan_api, deps_graph, test_conanfile_path):
                                        source_folder=conanfile_folder,
                                        output_folder=output_folder)
 
-    out.highlight("-------- Testing the package: Building ----------")
+    out.title("Testing the package: Building")
     app = ConanApp(conan_api.cache_folder)
     conanfile.folders.set_base_package(conanfile.folders.base_build)
     run_build_method(conanfile, app.hook_manager)
 
-    out.highlight("-------- Testing the package: Running test() ----------")
+    out.title("Testing the package: Running test()")
     conanfile.output.highlight("Running test()")
     with conanfile_exception_formatter(conanfile, "test"):
         with chdir(conanfile.build_folder):

--- a/conans/cli/commands/create.py
+++ b/conans/cli/commands/create.py
@@ -80,7 +80,7 @@ def create(conan_api, parser, *args):
                                                                 tool_requires=tool_requires,
                                                                 profile_host=profile_host)
 
-    out.highlight("Computing dependency graph")
+    out.title("Computing dependency graph")
     check_updates = args.check_updates if "check_updates" in args else False
     deps_graph = conan_api.graph.load_graph(root_node, profile_host=profile_host,
                                             profile_build=profile_build,

--- a/conans/cli/commands/graph.py
+++ b/conans/cli/commands/graph.py
@@ -48,7 +48,7 @@ def graph_build_order(conan_api, parser, subparser, *args):
     deps_graph, lockfile = graph_compute(args, conan_api, partial=args.lockfile_partial)
 
     out = ConanOutput()
-    out.highlight("-------- Computing the build order ----------")
+    out.highlight("Computing the build order")
     install_graph = InstallGraph(deps_graph)
     install_order_serialized = install_graph.install_build_order()
     cli_build_order(install_order_serialized)

--- a/conans/cli/commands/install.py
+++ b/conans/cli/commands/install.py
@@ -85,7 +85,7 @@ def graph_compute(args, conan_api, partial=False, allow_error=False):
                                                                 tool_requires=tool_requires,
                                                                 profile_host=profile_host)
 
-    out.highlight("Computing dependency graph")
+    out.title("Computing dependency graph")
     check_updates = args.check_updates if "check_updates" in args else False
     deps_graph = conan_api.graph.load_graph(root_node, profile_host=profile_host,
                                             profile_build=profile_build,

--- a/conans/cli/commands/install.py
+++ b/conans/cli/commands/install.py
@@ -64,7 +64,7 @@ def graph_compute(args, conan_api, partial=False, allow_error=False):
     profile_host, profile_build = get_profiles_from_args(conan_api, args)
 
     out = ConanOutput()
-    out.highlight("-------- Input profiles ----------")
+    out.title("Input profiles")
     out.info("Profile host:")
     out.info(profile_host.dumps())
     out.info("Profile build:")
@@ -85,7 +85,7 @@ def graph_compute(args, conan_api, partial=False, allow_error=False):
                                                                 tool_requires=tool_requires,
                                                                 profile_host=profile_host)
 
-    out.highlight("-------- Computing dependency graph ----------")
+    out.highlight("Computing dependency graph")
     check_updates = args.check_updates if "check_updates" in args else False
     deps_graph = conan_api.graph.load_graph(root_node, profile_host=profile_host,
                                             profile_build=profile_build,
@@ -94,7 +94,7 @@ def graph_compute(args, conan_api, partial=False, allow_error=False):
                                             update=args.update,
                                             check_update=check_updates)
     print_graph_basic(deps_graph)
-    out.highlight("-------- Computing necessary packages ----------")
+    out.title("Computing necessary packages")
     if deps_graph.error:
         if allow_error:
             return deps_graph, lockfile
@@ -166,10 +166,10 @@ def install(conan_api, parser, *args):
     deps_graph, lockfile = graph_compute(args, conan_api, partial=args.lockfile_partial)
 
     out = ConanOutput()
-    out.highlight("-------- Installing packages ----------")
+    out.title("Installing packages")
     conan_api.install.install_binaries(deps_graph=deps_graph, remotes=remote, update=args.update)
 
-    out.highlight("-------- Finalizing install (deploy, generators) ----------")
+    out.title("Finalizing install (deploy, generators)")
     conan_api.install.install_consumer(deps_graph=deps_graph,
                                        generators=args.generator,
                                        output_folder=output_folder,

--- a/conans/cli/commands/install.py
+++ b/conans/cli/commands/install.py
@@ -94,7 +94,7 @@ def graph_compute(args, conan_api, partial=False, allow_error=False):
                                             update=args.update,
                                             check_update=check_updates)
     print_graph_basic(deps_graph)
-    out.highlight("\n-------- Computing necessary packages ----------")
+    out.highlight("-------- Computing necessary packages ----------")
     if deps_graph.error:
         if allow_error:
             return deps_graph, lockfile
@@ -166,10 +166,10 @@ def install(conan_api, parser, *args):
     deps_graph, lockfile = graph_compute(args, conan_api, partial=args.lockfile_partial)
 
     out = ConanOutput()
-    out.highlight("\n-------- Installing packages ----------")
+    out.highlight("-------- Installing packages ----------")
     conan_api.install.install_binaries(deps_graph=deps_graph, remotes=remote, update=args.update)
 
-    out.highlight("\n-------- Finalizing install (deploy, generators) ----------")
+    out.highlight("-------- Finalizing install (deploy, generators) ----------")
     conan_api.install.install_consumer(deps_graph=deps_graph,
                                        generators=args.generator,
                                        output_folder=output_folder,

--- a/conans/cli/commands/list.py
+++ b/conans/cli/commands/list.py
@@ -1,6 +1,5 @@
 import json
 from collections import OrderedDict
-from json import JSONEncoder
 
 from conans.cli.command import conan_command, conan_subcommand, Extender, COMMAND_GROUPS
 from conans.cli.commands import json_formatter
@@ -105,7 +104,6 @@ def _add_remotes_and_cache_options(subparser):
     remotes_group.add_argument("-r", "--remote", default=None, action=Extender,
                                help="Remote names. Accepts wildcards")
     subparser.add_argument("-c", "--cache", action='store_true', help="Search in the local cache")
-
 
 def _selected_cache_remotes(conan_api, args):
     # If neither remote nor cache are defined, show results only from cache

--- a/conans/cli/commands/test.py
+++ b/conans/cli/commands/test.py
@@ -44,7 +44,7 @@ def test(conan_api, parser, *args):
                                                          update=args.update,
                                                          lockfile=lockfile)
 
-    out.highlight("Computing dependency graph")
+    out.title("Computing dependency graph")
     check_updates = args.check_updates if "check_updates" in args else False
     deps_graph = conan_api.graph.load_graph(root_node, profile_host=profile_host,
                                             profile_build=profile_build,

--- a/conans/cli/commands/test.py
+++ b/conans/cli/commands/test.py
@@ -32,7 +32,7 @@ def test(conan_api, parser, *args):
     profile_host, profile_build = get_profiles_from_args(conan_api, args)
 
     out = ConanOutput()
-    out.highlight("-------- Input profiles ----------")
+    out.title("Input profiles")
     out.info("Profile host:")
     out.info(profile_host.dumps())
     out.info("Profile build:")
@@ -44,7 +44,7 @@ def test(conan_api, parser, *args):
                                                          update=args.update,
                                                          lockfile=lockfile)
 
-    out.highlight("-------- Computing dependency graph ----------")
+    out.highlight("Computing dependency graph")
     check_updates = args.check_updates if "check_updates" in args else False
     deps_graph = conan_api.graph.load_graph(root_node, profile_host=profile_host,
                                             profile_build=profile_build,
@@ -53,13 +53,13 @@ def test(conan_api, parser, *args):
                                             update=args.update,
                                             check_update=check_updates)
     print_graph_basic(deps_graph)
-    out.highlight("-------- Computing necessary packages ----------")
+    out.title("Computing necessary packages")
     deps_graph.report_graph_error()
     conan_api.graph.analyze_binaries(deps_graph, remotes=remotes, update=args.update,
                                      lockfile=lockfile)
     print_graph_packages(deps_graph)
 
-    out.highlight("-------- Installing packages ----------")
+    out.title("Installing packages")
     conan_api.install.install_binaries(deps_graph=deps_graph, remotes=remotes, update=args.update)
 
     save_lockfile_out(args, deps_graph, lockfile, cwd)

--- a/conans/cli/commands/test.py
+++ b/conans/cli/commands/test.py
@@ -32,7 +32,7 @@ def test(conan_api, parser, *args):
     profile_host, profile_build = get_profiles_from_args(conan_api, args)
 
     out = ConanOutput()
-    out.highlight("\n-------- Input profiles ----------")
+    out.highlight("-------- Input profiles ----------")
     out.info("Profile host:")
     out.info(profile_host.dumps())
     out.info("Profile build:")
@@ -53,13 +53,13 @@ def test(conan_api, parser, *args):
                                             update=args.update,
                                             check_update=check_updates)
     print_graph_basic(deps_graph)
-    out.highlight("\n-------- Computing necessary packages ----------")
+    out.highlight("-------- Computing necessary packages ----------")
     deps_graph.report_graph_error()
     conan_api.graph.analyze_binaries(deps_graph, remotes=remotes, update=args.update,
                                      lockfile=lockfile)
     print_graph_packages(deps_graph)
 
-    out.highlight("\n-------- Installing packages ----------")
+    out.highlight("-------- Installing packages ----------")
     conan_api.install.install_binaries(deps_graph=deps_graph, remotes=remotes, update=args.update)
 
     save_lockfile_out(args, deps_graph, lockfile, cwd)

--- a/conans/cli/formatters/graph.py
+++ b/conans/cli/formatters/graph.py
@@ -104,7 +104,7 @@ def print_graph_info(deps_graph, field_filter, package_filter):
     Used for 'graph info' command
     """
     out = ConanOutput()
-    out.highlight("-------- Basic graph information ----------")
+    out.title("Basic graph information")
     serial = deps_graph.serialize()
     for n in serial["nodes"]:
         if package_filter is not None:

--- a/conans/cli/formatters/graph.py
+++ b/conans/cli/formatters/graph.py
@@ -104,7 +104,7 @@ def print_graph_info(deps_graph, field_filter, package_filter):
     Used for 'graph info' command
     """
     out = ConanOutput()
-    out.highlight("\n-------- Basic graph information ----------")
+    out.highlight("-------- Basic graph information ----------")
     serial = deps_graph.serialize()
     for n in serial["nodes"]:
         if package_filter is not None:

--- a/conans/cli/output.py
+++ b/conans/cli/output.py
@@ -15,8 +15,16 @@ LEVEL_VERBOSE = 30  # -v  Detailed informational messages.
 LEVEL_DEBUG = 20  # -vv Closely related to internal implementation details
 LEVEL_TRACE = 10  # -vvv Fine-grained messages with very low-level implementation details
 
-# Singleton
-conan_log_level = LEVEL_STATUS
+
+# Singletons
+conan_output_level = LEVEL_STATUS
+conan_strict_output_level = False  # If True only the messages of the specified level are shown
+
+
+def log_level_allowed(level):
+    if conan_strict_output_level:
+        return level == conan_output_level
+    return conan_output_level <= level
 
 
 class Color(object):
@@ -78,7 +86,7 @@ class ConanOutput:
         self.write(data, fg, bg, newline=True)
 
     def write(self, data, fg=None, bg=None, newline=False):
-        if conan_log_level > LEVEL_NOTICE:
+        if conan_output_level > LEVEL_NOTICE:
             return
         if self._color and (fg or bg):
             data = "%s%s%s%s" % (fg or '', bg or '', data, Style.RESET_ALL)
@@ -100,7 +108,7 @@ class ConanOutput:
         self._color = tmp_color
 
     def _write_message(self, msg, fg=None, bg=None):
-        if conan_log_level == LEVEL_QUIET:
+        if conan_output_level == LEVEL_QUIET:
             return
         tmp = ""
         if self._scope:
@@ -117,35 +125,35 @@ class ConanOutput:
         self.stream.write("{}\n".format(tmp))
 
     def trace(self, msg):
-        if conan_log_level <= LEVEL_TRACE:
+        if log_level_allowed(LEVEL_TRACE):
             self._write_message(msg)
 
     def debug(self, msg):
-        if conan_log_level <= LEVEL_DEBUG:
+        if log_level_allowed(LEVEL_DEBUG):
             self._write_message(msg)
 
     def verbose(self, msg, fg=None, bg=None):
-        if conan_log_level <= LEVEL_VERBOSE:
+        if log_level_allowed(LEVEL_VERBOSE):
             self._write_message(msg, fg=fg, bg=bg)
 
     def info(self, msg, fg=None, bg=None):
-        if conan_log_level <= LEVEL_STATUS:
+        if log_level_allowed(LEVEL_STATUS):
             self._write_message(msg, fg=fg, bg=bg)
 
     def highlight(self, msg):
-        if conan_log_level <= LEVEL_NOTICE:
+        if log_level_allowed(LEVEL_NOTICE):
             self._write_message(msg, fg=Color.BRIGHT_MAGENTA)
 
     def success(self, msg):
-        if conan_log_level <= LEVEL_NOTICE:
+        if log_level_allowed(LEVEL_NOTICE):
             self._write_message(msg, fg=Color.BRIGHT_GREEN)
 
     def warning(self, msg):
-        if conan_log_level <= LEVEL_WARNING:
+        if log_level_allowed(LEVEL_WARNING):
             self._write_message("WARN: {}".format(msg), Color.YELLOW)
 
     def error(self, msg):
-        if conan_log_level <= LEVEL_ERROR:
+        if log_level_allowed(LEVEL_ERROR):
             self._write_message("ERROR: {}".format(msg), Color.RED)
 
     def flush(self):

--- a/conans/cli/output.py
+++ b/conans/cli/output.py
@@ -161,6 +161,11 @@ class ConanOutput:
     # Remove in a later refactor of all the output.info calls
     info = status
 
+    def title(self, msg):
+        if log_level_allowed(LEVEL_NOTICE):
+            self._write_message("\n-------- {} --------".format(msg), "NOTICE",
+                                fg=Color.BRIGHT_MAGENTA)
+
     def highlight(self, msg):
         if log_level_allowed(LEVEL_NOTICE):
             self._write_message(msg, "NOTICE", fg=Color.BRIGHT_MAGENTA)

--- a/conans/cli/output.py
+++ b/conans/cli/output.py
@@ -125,8 +125,11 @@ class ConanOutput:
             return
 
         if isinstance(msg, dict):
-            # For traces we can receive a dict already
-            msg = json.dumps(msg, sort_keys=True, default=json_encoder)
+            # For traces we can receive a dict already, we try to transform then into more natural
+            # text
+            msg = ", ".join([f"{k}: {v}" for k, v in msg.items()])
+            msg = "=> {}".format(msg)
+            # msg = json.dumps(msg, sort_keys=True, default=json_encoder)
 
         ret = ""
         if self._scope:

--- a/conans/client/installer.py
+++ b/conans/client/installer.py
@@ -211,7 +211,7 @@ class BinaryInstaller:
     def install(self, deps_graph):
         assert not deps_graph.error, "This graph cannot be installed: {}".format(deps_graph)
 
-        ConanOutput().info("Installing (downloading, building) binaries...")
+        ConanOutput().title("Installing (downloading, building) binaries...")
 
         # order by levels and separate the root node (ref=None) from the rest
         install_graph = InstallGraph(deps_graph)

--- a/conans/client/installer.py
+++ b/conans/client/installer.py
@@ -211,7 +211,7 @@ class BinaryInstaller:
     def install(self, deps_graph):
         assert not deps_graph.error, "This graph cannot be installed: {}".format(deps_graph)
 
-        ConanOutput().info("\nInstalling (downloading, building) binaries...")
+        ConanOutput().info("Installing (downloading, building) binaries...")
 
         # order by levels and separate the root node (ref=None) from the rest
         install_graph = InstallGraph(deps_graph)

--- a/conans/client/rest/conan_requester.py
+++ b/conans/client/rest/conan_requester.py
@@ -9,6 +9,7 @@ import requests
 from requests.adapters import HTTPAdapter
 
 from conans import __version__ as client_version
+from conans.cli.output import ConanOutput
 from conans.util.tracer import log_client_rest_api_call
 
 # Capture SSL warnings as pointed out here:

--- a/conans/client/rest/conan_requester.py
+++ b/conans/client/rest/conan_requester.py
@@ -4,12 +4,11 @@ import os
 import platform
 import time
 
-import urllib3
 import requests
+import urllib3
 from requests.adapters import HTTPAdapter
 
 from conans import __version__ as client_version
-from conans.cli.output import ConanOutput
 from conans.util.tracer import log_client_rest_api_call
 
 # Capture SSL warnings as pointed out here:

--- a/conans/client/userio.py
+++ b/conans/client/userio.py
@@ -1,6 +1,5 @@
 import getpass
 import os
-import platform
 import sys
 
 from conans.errors import ConanException
@@ -20,6 +19,9 @@ def color_enabled(stream):
     presence of a NO_COLOR environment variable that, when present (**regardless of its value**),
     prevents the addition of ANSI color.
     """
+    from conans.cli.output import conan_output_logger_format
+    if conan_output_logger_format:
+        return False
     if os.getenv("NO_COLOR") is not None:
         return False
     return is_terminal(stream)

--- a/conans/test/integration/command_v2/test_output_level.py
+++ b/conans/test/integration/command_v2/test_output_level.py
@@ -39,8 +39,28 @@ def test_output_level():
     assert "This is a warning" in t.out
     assert "This is a error" in t.out
 
+    # Print also verbose traces
+    t.run("create . --name foo --version 1.0 -vverbose")
+    assert "This is a trace" not in t.out
+    assert "This is a debug" not in t.out
+    assert "This is a verbose" in t.out
+    assert "This is a info" in t.out
+    assert "This is a highlight" in t.out
+    assert "This is a success" in t.out
+    assert "This is a warning" in t.out
+    assert "This is a error" in t.out
+
     # Print also debug traces
     t.run("create . --name foo --version 1.0 -vv")
+    assert "This is a trace" not in t.out
+    assert "This is a debug" in t.out
+    assert "This is a verbose" in t.out
+    assert "This is a info" in t.out
+    assert "This is a highlight" in t.out
+    assert "This is a success" in t.out
+    assert "This is a warning" in t.out
+    assert "This is a error" in t.out
+    t.run("create . --name foo --version 1.0 -vdebug")
     assert "This is a trace" not in t.out
     assert "This is a debug" in t.out
     assert "This is a verbose" in t.out
@@ -60,9 +80,18 @@ def test_output_level():
     assert "This is a success" in t.out
     assert "This is a warning" in t.out
     assert "This is a error" in t.out
+    t.run("create . --name foo --version 1.0 -vtrace")
+    assert "This is a trace" in t.out
+    assert "This is a debug" in t.out
+    assert "This is a verbose" in t.out
+    assert "This is a info" in t.out
+    assert "This is a highlight" in t.out
+    assert "This is a success" in t.out
+    assert "This is a warning" in t.out
+    assert "This is a error" in t.out
 
     # With warnings only warnings
-    t.run("create . --name foo --version 1.0 -ow")
+    t.run("create . --name foo --version 1.0 -vwarning")
     assert "This is a trace" not in t.out
     assert "This is a debug" not in t.out
     assert "This is a verbose" not in t.out
@@ -73,7 +102,7 @@ def test_output_level():
     assert "This is a error" in t.out
 
     # With errors only errors
-    t.run("create . --name foo --version 1.0 -oe")
+    t.run("create . --name foo --version 1.0 -verror")
     assert "This is a trace" not in t.out
     assert "This is a debug" not in t.out
     assert "This is a verbose" not in t.out

--- a/conans/test/integration/command_v2/test_output_level.py
+++ b/conans/test/integration/command_v2/test_output_level.py
@@ -1,3 +1,5 @@
+import json
+
 from conans.test.assets.genconanfile import GenConanfile
 from conans.test.utils.tools import TestClient
 
@@ -140,3 +142,21 @@ def test_output_level():
     assert "This is a success" not in t.out
     assert "This is a warning" not in t.out
     assert "This is a error" in t.out
+
+
+def test_logger_output_format():
+    t = TestClient()
+    t.save({"conanfile.py": GenConanfile()})
+
+    # By default, it prints > info
+    t.run("create . --name foo --version 1.0 --logger -vvv")
+    lines = t.out.splitlines()
+    for line in lines:
+        data = json.loads(line)
+        assert "json" in data
+        assert "level" in data["json"]
+        assert "time" in data["json"]
+        assert "data" in data["json"]
+        if data["json"]["level"] == "TRACE":
+            assert "_action" in data["json"]["data"]
+

--- a/conans/test/integration/command_v2/test_output_level.py
+++ b/conans/test/integration/command_v2/test_output_level.py
@@ -1,0 +1,85 @@
+from conans.test.assets.genconanfile import GenConanfile
+from conans.test.utils.tools import TestClient
+
+
+def test_output_level():
+
+    lines = ("self.output.trace('This is a trace')",
+             "self.output.debug('This is a debug')",
+             "self.output.verbose('This is a verbose')",
+             "self.output.info('This is a info')",
+             "self.output.highlight('This is a highlight')",
+             "self.output.success('This is a success')",
+             "self.output.warning('This is a warning')",
+             "self.output.error('This is a error')",
+             )
+
+    t = TestClient()
+    t.save({"conanfile.py": GenConanfile().with_package(*lines)})
+
+    # By default, it prints > info
+    t.run("create . --name foo --version 1.0")
+    assert "This is a trace" not in t.out
+    assert "This is a debug" not in t.out
+    assert "This is a verbose" not in t.out
+    assert "This is a info" in t.out
+    assert "This is a highlight" in t.out
+    assert "This is a success" in t.out
+    assert "This is a warning" in t.out
+    assert "This is a error" in t.out
+
+    # Print also verbose traces
+    t.run("create . --name foo --version 1.0 -v")
+    assert "This is a trace" not in t.out
+    assert "This is a debug" not in t.out
+    assert "This is a verbose" in t.out
+    assert "This is a info" in t.out
+    assert "This is a highlight" in t.out
+    assert "This is a success" in t.out
+    assert "This is a warning" in t.out
+    assert "This is a error" in t.out
+
+    # Print also debug traces
+    t.run("create . --name foo --version 1.0 -vv")
+    assert "This is a trace" not in t.out
+    assert "This is a debug" in t.out
+    assert "This is a verbose" in t.out
+    assert "This is a info" in t.out
+    assert "This is a highlight" in t.out
+    assert "This is a success" in t.out
+    assert "This is a warning" in t.out
+    assert "This is a error" in t.out
+
+    # Print also "trace" traces
+    t.run("create . --name foo --version 1.0 -vvv")
+    assert "This is a trace" in t.out
+    assert "This is a debug" in t.out
+    assert "This is a verbose" in t.out
+    assert "This is a info" in t.out
+    assert "This is a highlight" in t.out
+    assert "This is a success" in t.out
+    assert "This is a warning" in t.out
+    assert "This is a error" in t.out
+
+    # With warnings only warnings
+    t.run("create . --name foo --version 1.0 -ow")
+    assert "This is a trace" not in t.out
+    assert "This is a debug" not in t.out
+    assert "This is a verbose" not in t.out
+    assert "This is a info" not in t.out
+    assert "This is a highlight" not in t.out
+    assert "This is a success" not in t.out
+    assert "This is a warning" in t.out
+    assert "This is a error" in t.out
+
+    # With errors only errors
+    t.run("create . --name foo --version 1.0 -oe")
+    assert "This is a trace" not in t.out
+    assert "This is a debug" not in t.out
+    assert "This is a verbose" not in t.out
+    assert "This is a info" not in t.out
+    assert "This is a highlight" not in t.out
+    assert "This is a success" not in t.out
+    assert "This is a warning" not in t.out
+    assert "This is a error" in t.out
+

--- a/conans/test/integration/command_v2/test_output_level.py
+++ b/conans/test/integration/command_v2/test_output_level.py
@@ -97,7 +97,29 @@ def test_output_level():
     assert "This is a warning" in t.out
     assert "This is a error" in t.out
 
-    # With warnings only warnings
+    # With notice
+    t.run("create . --name foo --version 1.0 -vstatus")
+    assert "This is a trace" not in t.out
+    assert "This is a debug" not in t.out
+    assert "This is a verbose" not in t.out
+    assert "This is a info" in t.out
+    assert "This is a highlight" in t.out
+    assert "This is a success" in t.out
+    assert "This is a warning" in t.out
+    assert "This is a error" in t.out
+
+    # With notice
+    t.run("create . --name foo --version 1.0 -vnotice")
+    assert "This is a trace" not in t.out
+    assert "This is a debug" not in t.out
+    assert "This is a verbose" not in t.out
+    assert "This is a info" not in t.out
+    assert "This is a highlight" in t.out
+    assert "This is a success" in t.out
+    assert "This is a warning" in t.out
+    assert "This is a error" in t.out
+
+    # With warnings
     t.run("create . --name foo --version 1.0 -vwarning")
     assert "This is a trace" not in t.out
     assert "This is a debug" not in t.out
@@ -108,7 +130,7 @@ def test_output_level():
     assert "This is a warning" in t.out
     assert "This is a error" in t.out
 
-    # With errors only errors
+    # With errors
     t.run("create . --name foo --version 1.0 -verror")
     assert "This is a trace" not in t.out
     assert "This is a debug" not in t.out
@@ -118,26 +140,3 @@ def test_output_level():
     assert "This is a success" not in t.out
     assert "This is a warning" not in t.out
     assert "This is a error" in t.out
-
-    # Only verbose info
-    t.run("create . --name foo --version 1.0 -vverbose --sol")
-    assert "This is a trace" not in t.out
-    assert "This is a debug" not in t.out
-    assert "This is a verbose" in t.out
-    assert "This is a info" not in t.out
-    assert "This is a highlight" not in t.out
-    assert "This is a success" not in t.out
-    assert "This is a warning" not in t.out
-    assert "This is a error" not in t.out
-
-    # Only error info
-    t.run("create . --name foo --version 1.0 -verror --sol")
-    assert "This is a trace" not in t.out
-    assert "This is a debug" not in t.out
-    assert "This is a verbose" not in t.out
-    assert "This is a info" not in t.out
-    assert "This is a highlight" not in t.out
-    assert "This is a success" not in t.out
-    assert "This is a warning" not in t.out
-    assert "This is a error" in t.out
-

--- a/conans/test/integration/command_v2/test_output_level.py
+++ b/conans/test/integration/command_v2/test_output_level.py
@@ -2,6 +2,13 @@ from conans.test.assets.genconanfile import GenConanfile
 from conans.test.utils.tools import TestClient
 
 
+def test_invalid_output_level():
+    t = TestClient()
+    t.save({"conanfile.py": GenConanfile()})
+    t.run("create . --name foo --version 1.0 -vfooling", assert_error=True)
+    assert "Invalid argument '-vfooling'"
+
+
 def test_output_level():
 
     lines = ("self.output.trace('This is a trace')",
@@ -103,6 +110,28 @@ def test_output_level():
 
     # With errors only errors
     t.run("create . --name foo --version 1.0 -verror")
+    assert "This is a trace" not in t.out
+    assert "This is a debug" not in t.out
+    assert "This is a verbose" not in t.out
+    assert "This is a info" not in t.out
+    assert "This is a highlight" not in t.out
+    assert "This is a success" not in t.out
+    assert "This is a warning" not in t.out
+    assert "This is a error" in t.out
+
+    # Only verbose info
+    t.run("create . --name foo --version 1.0 -vverbose --sol")
+    assert "This is a trace" not in t.out
+    assert "This is a debug" not in t.out
+    assert "This is a verbose" in t.out
+    assert "This is a info" not in t.out
+    assert "This is a highlight" not in t.out
+    assert "This is a success" not in t.out
+    assert "This is a warning" not in t.out
+    assert "This is a error" not in t.out
+
+    # Only error info
+    t.run("create . --name foo --version 1.0 -verror --sol")
     assert "This is a trace" not in t.out
     assert "This is a debug" not in t.out
     assert "This is a verbose" not in t.out

--- a/conans/test/utils/tools.py
+++ b/conans/test/utils/tools.py
@@ -682,7 +682,7 @@ class TestClient(object):
         belonging to the computed package binaries
         """
         lines = self.out.splitlines()
-        line_req = lines.index("-------- Computing necessary packages ----------")
+        line_req = lines.index("-------- Computing necessary packages --------")
         line_req = lines.index("Requirements" if not build else "Build requirements", line_req)
         reqs = []
         for line in lines[line_req+1:]:

--- a/conans/util/tracer.py
+++ b/conans/util/tracer.py
@@ -18,14 +18,8 @@ from conans.util.files import md5sum, sha1sum
 
 MASKED_FIELD = "**********"
 
-
-def _append_action(action_name, props):
-    """Validate the action_name and append to logs"""
-    props["_action"] = action_name
-    ConanOutput().trace(props)
-
-
 # ############## LOG METHODS ######################
+
 
 def _file_document(name, path):
     if os.path.isdir(path):
@@ -38,81 +32,76 @@ def _file_document(name, path):
 def log_recipe_upload(ref, duration, files_uploaded, remote_name):
     files_uploaded = files_uploaded or {}
     files_uploaded = [_file_document(name, path) for name, path in files_uploaded.items()]
-    ref_norev = copy.copy(ref)
-    ref_norev.revision = None
-    _append_action("UPLOADED_RECIPE", {"_id": repr(ref_norev),
-                                       "duration": duration,
-                                       "files": files_uploaded,
-                                       "remote": remote_name})
+    data = {"_action": "UPLOADED_RECIPE", "_id": repr(ref),
+                                          "duration": duration,
+                                          "files": files_uploaded,
+                                          "remote": remote_name}
+    ConanOutput().trace(data)
 
 
 def log_package_upload(pref, duration, files_uploaded, remote):
     """files_uploaded is a dict with relative path as keys and abs path as values"""
     files_uploaded = files_uploaded or {}
     files_uploaded = [_file_document(name, path) for name, path in files_uploaded.items()]
-    tmp = copy.copy(pref)
-    tmp.revision = None
-    _append_action("UPLOADED_PACKAGE", {"_id": repr(tmp),
-                                        "duration": duration,
-                                        "files": files_uploaded,
-                                        "remote": remote.name})
+    data = {"_action": "UPLOADED_PACKAGE", "_id": repr(pref),
+                                           "duration": duration,
+                                           "files": files_uploaded,
+                                           "remote": remote.name}
+    ConanOutput().trace(data)
 
 
 def log_recipe_download(ref, duration, remote_name, files_downloaded):
     assert(isinstance(ref, RecipeReference))
     files_downloaded = files_downloaded or {}
     files_downloaded = [_file_document(name, path) for name, path in files_downloaded.items()]
-    _tmp = copy.copy(ref)
-    _tmp.revision = None
-    _append_action("DOWNLOADED_RECIPE", {"_id": repr(_tmp),
-                                         "duration": duration,
-                                         "remote": remote_name,
-                                         "files": files_downloaded})
+
+    data = {"_action": "DOWNLOADED_RECIPE", "_id": repr(ref),
+                                                    "duration": duration,
+                                                    "remote": remote_name,
+                                                    "files": files_downloaded}
+    ConanOutput().trace(data)
 
 
 def log_recipe_sources_download(ref, duration, remote_name, files_downloaded):
     assert(isinstance(ref, RecipeReference))
     files_downloaded = files_downloaded or {}
     files_downloaded = [_file_document(name, path) for name, path in files_downloaded.items()]
-    _tmp = copy.copy(ref)
-    _tmp.revision = None
-    _append_action("DOWNLOADED_RECIPE_SOURCES", {"_id": repr(_tmp),
-                                                 "duration": duration,
-                                                 "remote": remote_name,
-                                                 "files": files_downloaded})
+    data = {"_action": "DOWNLOADED_RECIPE_SOURCES", "_id": repr(ref),
+                                                    "duration": duration,
+                                                    "remote": remote_name,
+                                                    "files": files_downloaded}
+    ConanOutput().trace(data)
 
 
 def log_package_download(pref, duration, remote, files_downloaded):
     files_downloaded = files_downloaded or {}
     files_downloaded = [_file_document(name, path) for name, path in files_downloaded.items()]
-    tmp = copy.copy(pref)
-    tmp.revision = None
-    _append_action("DOWNLOADED_PACKAGE", {"_id": repr(tmp),
-                                          "duration": duration,
-                                          "remote": remote.name,
-                                          "files": files_downloaded})
+    data = {"_action": "DOWNLOADED_PACKAGE", "_id": repr(pref), "duration": duration,
+            "remote": remote.name, "files": files_downloaded}
+    ConanOutput().trace(data)
 
 
 def log_recipe_got_from_local_cache(ref):
     assert(isinstance(ref, RecipeReference))
-    ref_norev = copy.copy(ref)
-    ref_norev.revision = None
-    _append_action("GOT_RECIPE_FROM_LOCAL_CACHE", {"_id": repr(ref_norev)})
+    data = {"_action": "GOT_RECIPE_FROM_LOCAL_CACHE", "_id": repr(ref)}
+    ConanOutput().trace(data)
 
 
 def log_package_got_from_local_cache(pref):
     assert(isinstance(pref, PkgReference))
     tmp = copy.copy(pref)
     tmp.revision = None
-    _append_action("GOT_PACKAGE_FROM_LOCAL_CACHE", {"_id": repr(tmp)})
+    data = {"_action": "GOT_PACKAGE_FROM_LOCAL_CACHE", "_id": repr(tmp)}
+    ConanOutput().trace(data)
 
 
 def log_package_built(pref, duration, log_run=None):
     assert(isinstance(pref, PkgReference))
     tmp = copy.copy(pref)
     tmp.revision = None
-    _append_action("PACKAGE_BUILT_FROM_SOURCES",
-                   {"_id": repr(tmp), "duration": duration, "log": log_run})
+    data = {"_action": "PACKAGE_BUILT_FROM_SOURCES", "_id": repr(tmp), "duration": duration,
+            "log": log_run}
+    ConanOutput().trace(data)
 
 
 def log_client_rest_api_call(url, method, duration, headers):
@@ -123,33 +112,41 @@ def log_client_rest_api_call(url, method, duration, headers):
         headers["X-Client-Anonymous-Id"] = MASKED_FIELD
     if "signature=" in url:
         url = url.split("signature=")[0] + "signature=%s" % MASKED_FIELD
-    _append_action("REST_API_CALL", {"method": method, "url": url,
-                                     "duration": duration, "headers": headers})
+
+    data = {"_action": "REST_API_CALL", "method": method, "url": url, "duration": duration,
+            "headers": headers}
+    ConanOutput().trace(data)
 
 
 def log_conan_api_call(name, kwargs):
     parameters = copy.copy(kwargs)  # Ensure we don't alter any app object like args
-    _append_action("CONAN_API", {"name": name, "parameters": parameters})
+    data = {"_action": "CONAN_API", "name": name, "parameters": parameters}
+    ConanOutput().trace(data)
 
 
 def log_command(name, kwargs):
     parameters = copy.copy(kwargs)  # Ensure we don't alter any app object like args
-    _append_action("COMMAND", {"name": name, "parameters": parameters})
+    data = {"_action": "COMMAND", "name": name, "parameters": parameters}
+    ConanOutput().trace(data)
 
 
 def log_exception(exc, message):
-    _append_action("EXCEPTION", {"class": str(exc.__class__.__name__), "message": message})
+    data = {"_action": "EXCEPTION", "class": str(exc.__class__.__name__), "message": message}
+    ConanOutput().trace(data)
 
 
 def log_download(url, duration):
-    _append_action("DOWNLOAD", {"url": url, "duration": duration})
+    data = {"_action": "DOWNLOAD", "url": url, "duration": duration}
+    ConanOutput().trace(data)
 
 
 def log_uncompressed_file(src_path, duration, dest_folder):
-    _append_action("UNZIP", {"src": src_path, "dst": dest_folder, "duration": duration})
+    data = {"_action": "UNZIP", "src": src_path, "dst": dest_folder, "duration": duration}
+    ConanOutput().trace(data)
 
 
 def log_compressed_files(files, duration, tgz_path):
     files = files or {}
     files_compressed = [_file_document(name, path) for name, path in files.items()]
-    _append_action("ZIP", {"src": files_compressed, "dst": tgz_path, "duration": duration})
+    data = {"_action": "ZIP", "src": files_compressed, "dst": tgz_path, "duration": duration}
+    ConanOutput().trace(data)

--- a/conans/util/tracer.py
+++ b/conans/util/tracer.py
@@ -6,6 +6,7 @@ from os.path import isdir
 
 import fasteners
 
+from conans.cli.output import ConanOutput
 from conans.errors import ConanException
 from conans.model.package_ref import PkgReference
 from conans.model.recipe_ref import RecipeReference
@@ -14,56 +15,14 @@ from conans.util.files import md5sum, sha1sum
 
 # FIXME: Conan 2.0 the traces should have all the revisions information also.
 
-TRACER_ACTIONS = ["UPLOADED_RECIPE", "UPLOADED_PACKAGE",
-                  "DOWNLOADED_RECIPE", "DOWNLOADED_RECIPE_SOURCES", "DOWNLOADED_PACKAGE",
-                  "PACKAGE_BUILT_FROM_SOURCES",
-                  "GOT_RECIPE_FROM_LOCAL_CACHE", "GOT_PACKAGE_FROM_LOCAL_CACHE",
-                  "REST_API_CALL", "COMMAND",
-                  "EXCEPTION",
-                  "DOWNLOAD",
-                  "UNZIP", "ZIP"]
 
 MASKED_FIELD = "**********"
 
 
-def _validate_action(action_name):
-    if action_name not in TRACER_ACTIONS:
-        raise ConanException("Unknown action %s" % action_name)
-
-
-def _get_tracer_file():
-    """
-    If CONAN_TRACE_FILE is a file in an existing dir will log to it creating the file if needed
-    Otherwise won't log anything
-    """
-    trace_path = os.environ.get("CONAN_TRACE_FILE", None)
-    if trace_path is not None:
-        if not os.path.isabs(trace_path):
-            raise ConanException("Bad CONAN_TRACE_FILE value. The specified "
-                                 "path has to be an absolute path to a file.")
-        if not os.path.exists(os.path.dirname(trace_path)):
-            raise ConanException("Bad CONAN_TRACE_FILE value. The specified "
-                                 "path doesn't exist: '%s'" % os.path.dirname(trace_path))
-        if isdir(trace_path):
-            raise ConanException("CONAN_TRACE_FILE is a directory. Please, specify a file path")
-    return trace_path
-
-
-def _append_to_log(obj):
-    """Add a new line to the log file locking the file to protect concurrent access"""
-    if _get_tracer_file():
-        filepath = _get_tracer_file()
-        with fasteners.InterProcessLock(filepath + ".lock"):
-            with open(filepath, "a") as logfile:
-                logfile.write(json.dumps(obj, sort_keys=True) + "\n")
-
-
 def _append_action(action_name, props):
     """Validate the action_name and append to logs"""
-    _validate_action(action_name)
     props["_action"] = action_name
-    props["time"] = time.time()
-    _append_to_log(props)
+    ConanOutput().trace(props)
 
 
 # ############## LOG METHODS ######################
@@ -168,11 +127,13 @@ def log_client_rest_api_call(url, method, duration, headers):
                                      "duration": duration, "headers": headers})
 
 
+def log_conan_api_call(name, kwargs):
+    parameters = copy.copy(kwargs)  # Ensure we don't alter any app object like args
+    _append_action("CONAN_API", {"name": name, "parameters": parameters})
+
+
 def log_command(name, kwargs):
     parameters = copy.copy(kwargs)  # Ensure we don't alter any app object like args
-    if name == "remotes.login":
-        # FIXME: This is not doing anything because the password is not a kwarg anymore, is an arg
-        parameters["password"] = MASKED_FIELD
     _append_action("COMMAND", {"name": name, "parameters": parameters})
 
 


### PR DESCRIPTION
Changelog: Feature: Added two new arguments for all commands `-v` for controlling the verbosity of the output and `--logger` to output the contents in a json log format for log processors.

Docs: Pending (Also document: set_conan_output_level(level, activate_logger=False)

Example of output for `conan install --require zlib/1.2.11@ --logger -vvv`:

```
{"json": {"level": "TRACE", "time": "2022-06-27T07:51:43.752333+00:00", "data": {"name": "graph.load_graph", "parameters": {"profile_host": "[settings]\narch=x86_64\nbuild_type=Release\ncompiler=apple-clang\ncompiler.cppstd=gnu98\ncompiler.libcxx=libc++\ncompiler.version=13\nos=Macos\n[options]\n[tool_requires]\n[env]\n", "profile_build": "[settings]\narch=x86_64\nbuild_type=Release\ncompiler=apple-clang\ncompiler.cppstd=gnu98\ncompiler.libcxx=libc++\ncompiler.version=13\nos=Macos\n[options]\n[tool_requires]\n[env]\n", "lockfile": null, "remotes": ["conanv2: https://conanv2beta.jfrog.io/artifactory/api/conan/conan [Verify SSL: True, Enabled: True]", "conancenter: https://center.conan.io [Verify SSL: True, Enabled: True]"], "update": false, "check_update": false}, "_action": "CONAN_API"}}}
{"json": {"level": "STATUS", "time": "2022-06-27T07:51:43.754864+00:00", "data": "Not found in local cache, looking in remotes..."}}
{"json": {"level": "STATUS", "time": "2022-06-27T07:51:43.754960+00:00", "data": "Checking remote: conanv2"}}
{"json": {"level": "TRACE", "time": "2022-06-27T07:51:44.205134+00:00", "data": {"method": "GET", "url": "https://conanv2beta.jfrog.io/artifactory/api/conan/conan/v1/ping", "duration": 0.4487118721008301, "headers": {"X-Client-Anonymous-Id": "**********", "X-Client-Id": "", "User-Agent": "Conan/2.0.0-dev (Darwin 21.5.0; Python 3.9.12; x86_64)"}, "_action": "REST_API_CALL"}}}
{"json": {"level": "TRACE", "time": "2022-06-27T07:51:44.666971+00:00", "data": {"method": "GET", "url": "https://conanv2beta.jfrog.io/artifactory/api/conan/conan/v2/conans/zlib/1.2.11/_/_/latest", "duration": 0.46160888671875, "headers": {"X-Client-Anonymous-Id": "**********", "X-Client-Id": "", "User-Agent": "Conan/2.0.0-dev (Darwin 21.5.0; Python 3.9.12; x86_64)"}, "_action": "REST_API_CALL"}}}
{"json": {"level": "STATUS", "time": "2022-06-27T07:51:44.668698+00:00", "data": "Trying with 'conanv2'..."}}
{"json": {"level": "TRACE", "time": "2022-06-27T07:51:45.108887+00:00", "data": {"method": "GET", "url": "https://conanv2beta.jfrog.io/artifactory/api/conan/conan/v2/conans/zlib/1.2.11/_/_/revisions/4524fcdd41f33e8df88ece6e755a5dcc/files", "duration": 0.43569183349609375, "headers": {"X-Client-Anonymous-Id": "**********", "X-Client-Id": "", "User-Agent": "Conan/2.0.0-dev (Darwin 21.5.0; Python 3.9.12; x86_64)"}, "_action": "REST_API_CALL"}}}
{"json": {"level": "TRACE", "time": "2022-06-27T07:51:45.608625+00:00", "data": {"method": "GET", "url": "https://conanv2beta.jfrog.io/artifactory/api/conan/conan/v2/conans/zlib/1.2.11/_/_/revisions/4524fcdd41f33e8df88ece6e755a5dcc/files/conanmanifest.txt", "duration": 0.4981241226196289, "headers": {"User-Agent": "Conan/2.0.0-dev (Darwin 21.5.0; Python 3.9.12; x86_64)"}, "_action": "REST_API_CALL"}}}
{"json": {"level": "STATUS", "time": "2022-06-27T07:51:45.608747+00:00", "data": "Downloading conanmanifest.txt"}}
{"json": {"level": "TRACE", "time": "2022-06-27T07:51:45.610869+00:00", "data": {"url": "https://conanv2beta.jfrog.io/artifactory/api/conan/conan/v2/conans/zlib/1.2.11/_/_/revisions/4524fcdd41f33e8df88ece6e755a5dcc/files/conanmanifest.txt", "duration": 0.500385046005249, "_action": "DOWNLOAD"}}}
{"json": {"level": "TRACE", "time": "2022-06-27T07:51:46.043573+00:00", "data": {"method": "GET", "url": "https://conanv2beta.jfrog.io/artifactory/api/conan/conan/v2/conans/zlib/1.2.11/_/_/revisions/4524fcdd41f33e8df88ece6e755a5dcc/files/conanfile.py", "duration": 0.4324917793273926, "headers": {"User-Agent": "Conan/2.0.0-dev (Darwin 21.5.0; Python 3.9.12; x86_64)"}, "_action": "REST_API_CALL"}}}
{"json": {"level": "STATUS", "time": "2022-06-27T07:51:46.043692+00:00", "data": "Downloading conanfile.py"}}
{"json": {"level": "TRACE", "time": "2022-06-27T07:51:46.045694+00:00", "data": {"url": "https://conanv2beta.jfrog.io/artifactory/api/conan/conan/v2/conans/zlib/1.2.11/_/_/revisions/4524fcdd41f33e8df88ece6e755a5dcc/files/conanfile.py", "duration": 0.4346330165863037, "_action": "DOWNLOAD"}}}
{"json": {"level": "TRACE", "time": "2022-06-27T07:51:46.513741+00:00", "data": {"method": "GET", "url": "https://conanv2beta.jfrog.io/artifactory/api/conan/conan/v2/conans/zlib/1.2.11/_/_/revisions/4524fcdd41f33e8df88ece6e755a5dcc/files/conan_export.tgz", "duration": 0.4678950309753418, "headers": {"User-Agent": "Conan/2.0.0-dev (Darwin 21.5.0; Python 3.9.12; x86_64)"}, "_action": "REST_API_CALL"}}}
{"json": {"level": "STATUS", "time": "2022-06-27T07:51:46.513864+00:00", "data": "Downloading conan_export.tgz"}}
{"json": {"level": "TRACE", "time": "2022-06-27T07:51:46.515899+00:00", "data": {"url": "https://conanv2beta.jfrog.io/artifactory/api/conan/conan/v2/conans/zlib/1.2.11/_/_/revisions/4524fcdd41f33e8df88ece6e755a5dcc/files/conan_export.tgz", "duration": 0.47006678581237793, "_action": "DOWNLOAD"}}}
{"json": {"level": "TRACE", "time": "2022-06-27T07:51:47.034104+00:00", "data": {"method": "GET", "url": "https://conanv2beta.jfrog.io/artifactory/api/conan/conan/v2/conans/zlib/1.2.11/_/_/revisions", "duration": 0.5173289775848389, "headers": {"X-Client-Anonymous-Id": "**********", "X-Client-Id": "", "User-Agent": "Conan/2.0.0-dev (Darwin 21.5.0; Python 3.9.12; x86_64)"}, "_action": "REST_API_CALL"}}}
{"json": {"level": "TRACE", "time": "2022-06-27T07:51:47.036685+00:00", "data": {"_id": "zlib/1.2.11%1650538915.154", "duration": 2.3637590408325195, "remote": "conanv2", "files": [{"name": "conan_export.tgz", "path": "/Users/luism/.conan2/p/441d73ab51bce6ae/d/conan_export.tgz", "md5": "13718a89d7bfb85106aaa8c74a72f21d", "sha1": "4d623b1c74a19ee8f2200e0a2982e853669c2b18", "type": "folder"}, {"name": "conanmanifest.txt", "path": "/Users/luism/.conan2/p/441d73ab51bce6ae/d/conanmanifest.txt", "md5": "518050541f0404508ded3cec35025b60", "sha1": "3b2de7b57dec25825898a43221fa5016e943ee28", "type": "folder"}, {"name": "conanfile.py", "path": "/Users/luism/.conan2/p/441d73ab51bce6ae/d/conanfile.py", "md5": "1279d9efbeb348bf4c7eedcf5a8fcc32", "sha1": "56d05d8c09239ef5b6238216fa8aa0386e2baff7", "type": "folder"}], "_action": "DOWNLOADED_RECIPE"}}}
{"json": {"level": "STATUS", "time": "2022-06-27T07:51:47.036793+00:00", "data": "Decompressing conan_export.tgz"}}
{"json": {"level": "TRACE", "time": "2022-06-27T07:51:47.037834+00:00", "data": {"src": "/Users/luism/.conan2/p/441d73ab51bce6ae/d/conan_export.tgz", "dst": "/Users/luism/.conan2/p/441d73ab51bce6ae/e", "duration": 0.0010399818420410156, "_action": "UNZIP"}}}
{"json": {"level": "STATUS", "time": "2022-06-27T07:51:47.038554+00:00", "data": "Downloaded recipe revision 4524fcdd41f33e8df88ece6e755a5dcc"}}
{"json": {"level": "STATUS", "time": "2022-06-27T07:51:47.044940+00:00", "data": "Graph root"}}
{"json": {"level": "STATUS", "time": "2022-06-27T07:51:47.044990+00:00", "data": "    virtual"}}
{"json": {"level": "STATUS", "time": "2022-06-27T07:51:47.045019+00:00", "data": "Requirements"}}
{"json": {"level": "STATUS", "time": "2022-06-27T07:51:47.045050+00:00", "data": "    zlib/1.2.11#4524fcdd41f33e8df88ece6e755a5dcc - Downloaded (conanv2)"}}
{"json": {"level": "NOTICE", "time": "2022-06-27T07:51:47.045077+00:00", "data": "-------- Computing necessary packages ----------"}}
{"json": {"level": "TRACE", "time": "2022-06-27T07:51:47.045168+00:00", "data": {"name": "graph.analyze_binaries", "parameters": {"remotes": ["conanv2: https://conanv2beta.jfrog.io/artifactory/api/conan/conan [Verify SSL: True, Enabled: True]", "conancenter: https://center.conan.io [Verify SSL: True, Enabled: True]"], "update": false, "lockfile": null}, "_action": "CONAN_API"}}}
{"json": {"level": "TRACE", "time": "2022-06-27T07:51:47.448371+00:00", "data": {"method": "GET", "url": "https://conanv2beta.jfrog.io/artifactory/api/conan/conan/v1/ping", "duration": 0.3968780040740967, "headers": {"X-Client-Anonymous-Id": "**********", "X-Client-Id": "", "User-Agent": "Conan/2.0.0-dev (Darwin 21.5.0; Python 3.9.12; x86_64)"}, "_action": "REST_API_CALL"}}}
{"json": {"level": "TRACE", "time": "2022-06-27T07:51:47.886787+00:00", "data": {"method": "GET", "url": "https://conanv2beta.jfrog.io/artifactory/api/conan/conan/v2/conans/zlib/1.2.11/_/_/revisions/4524fcdd41f33e8df88ece6e755a5dcc/packages/d62dff20d86436b9c58ddc0162499d197be9de1e/latest", "duration": 0.4382143020629883, "headers": {"X-Client-Anonymous-Id": "**********", "X-Client-Id": "", "User-Agent": "Conan/2.0.0-dev (Darwin 21.5.0; Python 3.9.12; x86_64)"}, "_action": "REST_API_CALL"}}}
{"json": {"level": "STATUS", "time": "2022-06-27T07:51:47.887985+00:00", "data": "Requirements"}}
{"json": {"level": "STATUS", "time": "2022-06-27T07:51:47.888047+00:00", "data": "    zlib/1.2.11#4524fcdd41f33e8df88ece6e755a5dcc:d62dff20d86436b9c58ddc0162499d197be9de1e#3a93a98a2e86fbb87c6da2844cfda7a6 - Download (conanv2)"}}
{"json": {"level": "NOTICE", "time": "2022-06-27T07:51:47.888134+00:00", "data": "-------- Installing packages ----------"}}
{"json": {"level": "TRACE", "time": "2022-06-27T07:51:47.888224+00:00", "data": {"name": "install.install_binaries", "parameters": {"deps_graph": "virtual\nzlib/1.2.11", "remotes": ["conanv2: https://conanv2beta.jfrog.io/artifactory/api/conan/conan [Verify SSL: True, Enabled: True]", "conancenter: https://center.conan.io [Verify SSL: True, Enabled: True]"], "update": false}, "_action": "CONAN_API"}}}
{"json": {"level": "STATUS", "time": "2022-06-27T07:51:47.889757+00:00", "data": "Installing (downloading, building) binaries..."}}
{"json": {"level": "STATUS", "time": "2022-06-27T07:51:47.889859+00:00", "data": "Retrieving package d62dff20d86436b9c58ddc0162499d197be9de1e from remote 'conanv2' "}}
{"json": {"level": "TRACE", "time": "2022-06-27T07:51:48.278211+00:00", "data": {"method": "GET", "url": "https://conanv2beta.jfrog.io/artifactory/api/conan/conan/v1/ping", "duration": 0.38638806343078613, "headers": {"X-Client-Anonymous-Id": "**********", "X-Client-Id": "", "User-Agent": "Conan/2.0.0-dev (Darwin 21.5.0; Python 3.9.12; x86_64)"}, "_action": "REST_API_CALL"}}}
{"json": {"level": "TRACE", "time": "2022-06-27T07:51:48.710981+00:00", "data": {"method": "GET", "url": "https://conanv2beta.jfrog.io/artifactory/api/conan/conan/v2/conans/zlib/1.2.11/_/_/revisions/4524fcdd41f33e8df88ece6e755a5dcc/packages/d62dff20d86436b9c58ddc0162499d197be9de1e/revisions/3a93a98a2e86fbb87c6da2844cfda7a6/files", "duration": 0.4325389862060547, "headers": {"X-Client-Anonymous-Id": "**********", "X-Client-Id": "", "User-Agent": "Conan/2.0.0-dev (Darwin 21.5.0; Python 3.9.12; x86_64)"}, "_action": "REST_API_CALL"}}}
{"json": {"level": "TRACE", "time": "2022-06-27T07:51:49.147595+00:00", "data": {"method": "GET", "url": "https://conanv2beta.jfrog.io/artifactory/api/conan/conan/v2/conans/zlib/1.2.11/_/_/revisions/4524fcdd41f33e8df88ece6e755a5dcc/packages/d62dff20d86436b9c58ddc0162499d197be9de1e/revisions/3a93a98a2e86fbb87c6da2844cfda7a6/files/conanmanifest.txt", "duration": 0.43471193313598633, "headers": {"User-Agent": "Conan/2.0.0-dev (Darwin 21.5.0; Python 3.9.12; x86_64)"}, "_action": "REST_API_CALL"}}}
{"json": {"level": "STATUS", "time": "2022-06-27T07:51:49.147719+00:00", "data": "Downloading conanmanifest.txt"}}
{"json": {"level": "TRACE", "time": "2022-06-27T07:51:49.149909+00:00", "data": {"url": "https://conanv2beta.jfrog.io/artifactory/api/conan/conan/v2/conans/zlib/1.2.11/_/_/revisions/4524fcdd41f33e8df88ece6e755a5dcc/packages/d62dff20d86436b9c58ddc0162499d197be9de1e/revisions/3a93a98a2e86fbb87c6da2844cfda7a6/files/conanmanifest.txt", "duration": 0.4370460510253906, "_action": "DOWNLOAD"}}}
{"json": {"level": "TRACE", "time": "2022-06-27T07:51:49.585127+00:00", "data": {"method": "GET", "url": "https://conanv2beta.jfrog.io/artifactory/api/conan/conan/v2/conans/zlib/1.2.11/_/_/revisions/4524fcdd41f33e8df88ece6e755a5dcc/packages/d62dff20d86436b9c58ddc0162499d197be9de1e/revisions/3a93a98a2e86fbb87c6da2844cfda7a6/files/conaninfo.txt", "duration": 0.4350409507751465, "headers": {"User-Agent": "Conan/2.0.0-dev (Darwin 21.5.0; Python 3.9.12; x86_64)"}, "_action": "REST_API_CALL"}}}
{"json": {"level": "STATUS", "time": "2022-06-27T07:51:49.585252+00:00", "data": "Downloading conaninfo.txt"}}
{"json": {"level": "TRACE", "time": "2022-06-27T07:51:49.587116+00:00", "data": {"url": "https://conanv2beta.jfrog.io/artifactory/api/conan/conan/v2/conans/zlib/1.2.11/_/_/revisions/4524fcdd41f33e8df88ece6e755a5dcc/packages/d62dff20d86436b9c58ddc0162499d197be9de1e/revisions/3a93a98a2e86fbb87c6da2844cfda7a6/files/conaninfo.txt", "duration": 0.43705010414123535, "_action": "DOWNLOAD"}}}
{"json": {"level": "TRACE", "time": "2022-06-27T07:51:50.064365+00:00", "data": {"method": "GET", "url": "https://conanv2beta.jfrog.io/artifactory/api/conan/conan/v2/conans/zlib/1.2.11/_/_/revisions/4524fcdd41f33e8df88ece6e755a5dcc/packages/d62dff20d86436b9c58ddc0162499d197be9de1e/revisions/3a93a98a2e86fbb87c6da2844cfda7a6/files/conan_package.tgz", "duration": 0.4770939350128174, "headers": {"User-Agent": "Conan/2.0.0-dev (Darwin 21.5.0; Python 3.9.12; x86_64)"}, "_action": "REST_API_CALL"}}}
{"json": {"level": "STATUS", "time": "2022-06-27T07:51:50.064484+00:00", "data": "Downloading conan_package.tgz"}}
{"json": {"level": "TRACE", "time": "2022-06-27T07:51:50.265380+00:00", "data": {"url": "https://conanv2beta.jfrog.io/artifactory/api/conan/conan/v2/conans/zlib/1.2.11/_/_/revisions/4524fcdd41f33e8df88ece6e755a5dcc/packages/d62dff20d86436b9c58ddc0162499d197be9de1e/revisions/3a93a98a2e86fbb87c6da2844cfda7a6/files/conan_package.tgz", "duration": 0.6781148910522461, "_action": "DOWNLOAD"}}}
{"json": {"level": "TRACE", "time": "2022-06-27T07:51:50.266615+00:00", "data": {"_id": "zlib/1.2.11#4524fcdd41f33e8df88ece6e755a5dcc%1650538915.154:d62dff20d86436b9c58ddc0162499d197be9de1e%1655310080.729", "duration": 2.3741817474365234, "remote": "conanv2", "files": [{"name": "conaninfo.txt", "path": "/Users/luism/.conan2/p/ae937a7d87dae093/d/conaninfo.txt", "md5": "1711cf1d1b9b7a0bb3356ed9c8d3fef5", "sha1": "d62dff20d86436b9c58ddc0162499d197be9de1e", "type": "folder"}, {"name": "conan_package.tgz", "path": "/Users/luism/.conan2/p/ae937a7d87dae093/d/conan_package.tgz", "md5": "8ddd57c5987dab80915e5a5ab6430291", "sha1": "63e5bbb207d00f4e8fe2374451faa00bc7db5cf2", "type": "folder"}, {"name": "conanmanifest.txt", "path": "/Users/luism/.conan2/p/ae937a7d87dae093/d/conanmanifest.txt", "md5": "1ffd29fce8db3b59a79d7431b563abf6", "sha1": "efc3364680f2624ff8e447d4dbd53e2382ac1bf2", "type": "folder"}], "_action": "DOWNLOADED_PACKAGE"}}}
{"json": {"level": "STATUS", "time": "2022-06-27T07:51:50.266714+00:00", "data": "Decompressing conan_package.tgz"}}
{"json": {"level": "TRACE", "time": "2022-06-27T07:51:50.271267+00:00", "data": {"src": "/Users/luism/.conan2/p/ae937a7d87dae093/d/conan_package.tgz", "dst": "/Users/luism/.conan2/p/ae937a7d87dae093/p", "duration": 0.004552125930786133, "_action": "UNZIP"}}}
{"json": {"level": "NOTICE", "time": "2022-06-27T07:51:50.271979+00:00", "data": "Package installed d62dff20d86436b9c58ddc0162499d197be9de1e"}}
{"json": {"level": "STATUS", "time": "2022-06-27T07:51:50.272024+00:00", "data": "Downloaded package revision 3a93a98a2e86fbb87c6da2844cfda7a6"}}
{"json": {"level": "NOTICE", "time": "2022-06-27T07:51:50.272958+00:00", "data": "-------- Finalizing install (deploy, generators) ----------"}}
{"json": {"level": "NOTICE", "time": "2022-06-27T07:51:50.274160+00:00", "data": "Aggregating env generators"}}
```