### PR TITLE
Keep only one flavor of the same libs in `collect_libs()`

### DIFF
--- a/conan/tools/files/files.py
+++ b/conan/tools/files/files.py
@@ -515,11 +515,7 @@ def collect_libs(conanfile, folder=None):
         name, ext = os.path.splitext(f)
         if ext != ".lib" and name.startswith("lib"):
             name = name[3:]
-        if name in result:
-            conanfile.output.warn("Library '%s' was either already found in a previous "
-                                  "'conanfile.cpp_info.libdirs' folder or appears several "
-                                  "times with a different file extension" % name)
-        else:
+        if name not in result:
             result.append(name)
     result.sort()
     return result

--- a/conan/tools/files/files.py
+++ b/conan/tools/files/files.py
@@ -494,24 +494,33 @@ def collect_libs(conanfile, folder=None):
     else:
         lib_folders = [os.path.join(conanfile.package_folder, folder)
                        for folder in conanfile.cpp_info.libdirs]
-    result = []
+
+    ref_libs = {}
     for lib_folder in lib_folders:
         if not os.path.exists(lib_folder):
             conanfile.output.warn("Lib folder doesn't exist, can't collect libraries: "
                                   "{0}".format(lib_folder))
             continue
+        # In case of symlinks, only keep shortest file name in the same "group"
         files = os.listdir(lib_folder)
         for f in files:
             name, ext = os.path.splitext(f)
             if ext in (".so", ".lib", ".a", ".dylib", ".bc"):
-                if ext != ".lib" and name.startswith("lib"):
-                    name = name[3:]
-                if name in result:
-                    conanfile.output.warn("Library '%s' was either already found in a previous "
-                                          "'conanfile.cpp_info.libdirs' folder or appears several "
-                                          "times with a different file extension" % name)
-                else:
-                    result.append(name)
+                real_lib = os.path.basename(os.path.realpath(os.path.join(lib_folder, f)))
+                if real_lib not in ref_libs or len(f) < len(ref_libs[real_lib]):
+                    ref_libs[real_lib] = f
+
+    result = []
+    for f in ref_libs.values():
+        name, ext = os.path.splitext(f)
+        if ext != ".lib" and name.startswith("lib"):
+            name = name[3:]
+        if name in result:
+            conanfile.output.warn("Library '%s' was either already found in a previous "
+                                  "'conanfile.cpp_info.libdirs' folder or appears several "
+                                  "times with a different file extension" % name)
+        else:
+            result.append(name)
     result.sort()
     return result
 

--- a/conans/client/tools/files.py
+++ b/conans/client/tools/files.py
@@ -372,11 +372,7 @@ def collect_libs(conanfile, folder=None):
         name, ext = os.path.splitext(f)
         if ext != ".lib" and name.startswith("lib"):
             name = name[3:]
-        if name in result:
-            conanfile.output.warn("Library '%s' was either already found in a previous "
-                                  "'conanfile.cpp_info.libdirs' folder or appears several "
-                                  "times with a different file extension" % name)
-        else:
+        if name not in result:
             result.append(name)
     result.sort()
     return result

--- a/conans/client/tools/files.py
+++ b/conans/client/tools/files.py
@@ -351,24 +351,33 @@ def collect_libs(conanfile, folder=None):
     else:
         lib_folders = [os.path.join(conanfile.package_folder, folder)
                        for folder in conanfile.cpp_info.libdirs]
-    result = []
+
+    ref_libs = {}
     for lib_folder in lib_folders:
         if not os.path.exists(lib_folder):
             conanfile.output.warn("Lib folder doesn't exist, can't collect libraries: "
                                   "{0}".format(lib_folder))
             continue
+        # In case of symlinks, only keep shortest file name in the same "group"
         files = os.listdir(lib_folder)
         for f in files:
             name, ext = os.path.splitext(f)
             if ext in VALID_LIB_EXTENSIONS:
-                if ext != ".lib" and name.startswith("lib"):
-                    name = name[3:]
-                if name in result:
-                    conanfile.output.warn("Library '%s' was either already found in a previous "
-                                          "'conanfile.cpp_info.libdirs' folder or appears several "
-                                          "times with a different file extension" % name)
-                else:
-                    result.append(name)
+                real_lib = os.path.basename(os.path.realpath(os.path.join(lib_folder, f)))
+                if real_lib not in ref_libs or len(f) < len(ref_libs[real_lib]):
+                    ref_libs[real_lib] = f
+
+    result = []
+    for f in ref_libs.values():
+        name, ext = os.path.splitext(f)
+        if ext != ".lib" and name.startswith("lib"):
+            name = name[3:]
+        if name in result:
+            conanfile.output.warn("Library '%s' was either already found in a previous "
+                                  "'conanfile.cpp_info.libdirs' folder or appears several "
+                                  "times with a different file extension" % name)
+        else:
+            result.append(name)
     result.sort()
     return result
 

--- a/conans/test/unittests/tools/files/collect_lib_test.py
+++ b/conans/test/unittests/tools/files/collect_lib_test.py
@@ -55,6 +55,24 @@ def test_collect_libs():
     result = collect_libs(conanfile)
     assert ["mylib"] == result
 
+    # Keep only the shortest lib name per group of symlinks
+    conanfile = ConanFileMock()
+    conanfile.folders.set_base_package(temp_folder())
+    conanfile.cpp_info = CppInfo(conanfile.name, "")
+    version_mylib_path = os.path.join(conanfile.package_folder, "lib", "libmylib.1.0.0.dylib")
+    soversion_mylib_path = os.path.join(conanfile.package_folder, "lib", "libmylib.1.dylib")
+    lib_mylib_path = os.path.join(conanfile.package_folder, "lib", "libmylib.dylib")
+    lib_mylib2_path = os.path.join(conanfile.package_folder, "lib", "libmylib.2.dylib")
+    lib_mylib3_path = os.path.join(conanfile.package_folder, "custom_folder", "libmylib.3.dylib")
+    save(version_mylib_path, "")
+    os.symlink(version_mylib_path, soversion_mylib_path)
+    os.symlink(soversion_mylib_path, lib_mylib_path)
+    save(lib_mylib2_path, "")
+    save(lib_mylib3_path, "")
+    conanfile.cpp_info.libdirs = ["lib", "custom_folder"]
+    result = collect_libs(conanfile)
+    assert ["mylib", "mylib.2", "mylib.3"] == result
+
     # Warn lib folder does not exist with correct result
     conanfile = ConanFileMock()
     conanfile.folders.set_base_package(temp_folder())

--- a/conans/test/unittests/tools/files/collect_lib_test.py
+++ b/conans/test/unittests/tools/files/collect_lib_test.py
@@ -43,6 +43,18 @@ def test_collect_libs():
     result = collect_libs(conanfile, folder="custom_folder")
     assert ["customlib"] == result
 
+    # Unicity of lib names
+    conanfile = ConanFileMock()
+    conanfile.folders.set_base_package(temp_folder())
+    conanfile.cpp_info = CppInfo(conanfile.name, "")
+    custom_mylib_path = os.path.join(conanfile.package_folder, "custom_folder", "mylib.lib")
+    lib_mylib_path = os.path.join(conanfile.package_folder, "lib", "mylib.lib")
+    save(custom_mylib_path, "")
+    save(lib_mylib_path, "")
+    conanfile.cpp_info.libdirs = ["lib", "custom_folder"]
+    result = collect_libs(conanfile)
+    assert ["mylib"] == result
+
     # Warn lib folder does not exist with correct result
     conanfile = ConanFileMock()
     conanfile.folders.set_base_package(temp_folder())

--- a/conans/test/unittests/tools/files/collect_lib_test.py
+++ b/conans/test/unittests/tools/files/collect_lib_test.py
@@ -43,21 +43,6 @@ def test_collect_libs():
     result = collect_libs(conanfile, folder="custom_folder")
     assert ["customlib"] == result
 
-    # Warn same lib different folders
-    conanfile = ConanFileMock()
-    conanfile.folders.set_base_package(temp_folder())
-    conanfile.cpp_info = CppInfo(conanfile.name, "")
-    custom_mylib_path = os.path.join(conanfile.package_folder, "custom_folder", "mylib.lib")
-    lib_mylib_path = os.path.join(conanfile.package_folder, "lib", "mylib.lib")
-    save(custom_mylib_path, "")
-    save(lib_mylib_path, "")
-    conanfile.cpp_info.libdirs = ["lib", "custom_folder"]
-    result = collect_libs(conanfile)
-    assert ["mylib"] == result
-    assert "Library 'mylib' was either already found in a previous "\
-           "'conanfile.cpp_info.libdirs' folder or appears several times with a "\
-           "different file extension" in conanfile.output
-
     # Warn lib folder does not exist with correct result
     conanfile = ConanFileMock()
     conanfile.folders.set_base_package(temp_folder())

--- a/conans/test/unittests/util/tools_test.py
+++ b/conans/test/unittests/util/tools_test.py
@@ -829,6 +829,24 @@ class CollectLibTestCase(unittest.TestCase):
         result = tools.collect_libs(conanfile)
         self.assertEqual(["mylib"], result)
 
+        # Keep only the shortest lib name per group of symlinks
+        conanfile = ConanFileMock()
+        conanfile.folders.set_base_package(temp_folder())
+        conanfile.cpp_info = CppInfo(conanfile.name, "")
+        version_mylib_path = os.path.join(conanfile.package_folder, "lib", "libmylib.1.0.0.dylib")
+        soversion_mylib_path = os.path.join(conanfile.package_folder, "lib", "libmylib.1.dylib")
+        lib_mylib_path = os.path.join(conanfile.package_folder, "lib", "libmylib.dylib")
+        lib_mylib2_path = os.path.join(conanfile.package_folder, "lib", "libmylib.2.dylib")
+        lib_mylib3_path = os.path.join(conanfile.package_folder, "custom_folder", "libmylib.3.dylib")
+        save(version_mylib_path, "")
+        os.symlink(version_mylib_path, soversion_mylib_path)
+        os.symlink(soversion_mylib_path, lib_mylib_path)
+        save(lib_mylib2_path, "")
+        save(lib_mylib3_path, "")
+        conanfile.cpp_info.libdirs = ["lib", "custom_folder"]
+        result = tools.collect_libs(conanfile)
+        self.assertEqual(["mylib", "mylib.2", "mylib.3"], result)
+
         # Warn lib folder does not exist with correct result
         conanfile = ConanFileMock()
         conanfile.folders.set_base_package(temp_folder())
@@ -888,6 +906,24 @@ class CollectLibTestCase(unittest.TestCase):
         conanfile.cpp_info.libdirs = ["lib", "custom_folder"]
         result = conanfile.collect_libs()
         self.assertEqual(["mylib"], result)
+
+        # Keep only the shortest lib name per group of symlinks
+        conanfile = ConanFileMock()
+        conanfile.folders.set_base_package(temp_folder())
+        conanfile.cpp_info = CppInfo("", "")
+        version_mylib_path = os.path.join(conanfile.package_folder, "lib", "libmylib.1.0.0.dylib")
+        soversion_mylib_path = os.path.join(conanfile.package_folder, "lib", "libmylib.1.dylib")
+        lib_mylib_path = os.path.join(conanfile.package_folder, "lib", "libmylib.dylib")
+        lib_mylib2_path = os.path.join(conanfile.package_folder, "lib", "libmylib.2.dylib")
+        lib_mylib3_path = os.path.join(conanfile.package_folder, "custom_folder", "libmylib.3.dylib")
+        save(version_mylib_path, "")
+        os.symlink(version_mylib_path, soversion_mylib_path)
+        os.symlink(soversion_mylib_path, lib_mylib_path)
+        save(lib_mylib2_path, "")
+        save(lib_mylib3_path, "")
+        conanfile.cpp_info.libdirs = ["lib", "custom_folder"]
+        result = conanfile.collect_libs()
+        self.assertEqual(["mylib", "mylib.2", "mylib.3"], result)
 
         # Warn lib folder does not exist with correct result
         conanfile = ConanFileMock()

--- a/conans/test/unittests/util/tools_test.py
+++ b/conans/test/unittests/util/tools_test.py
@@ -817,21 +817,6 @@ class CollectLibTestCase(unittest.TestCase):
         result = tools.collect_libs(conanfile, folder="custom_folder")
         self.assertEqual(["customlib"], result)
 
-        # Warn same lib different folders
-        conanfile = ConanFileMock()
-        conanfile.folders.set_base_package(temp_folder())
-        conanfile.cpp_info = CppInfo(conanfile.name, "")
-        custom_mylib_path = os.path.join(conanfile.package_folder, "custom_folder", "mylib.lib")
-        lib_mylib_path = os.path.join(conanfile.package_folder, "lib", "mylib.lib")
-        save(custom_mylib_path, "")
-        save(lib_mylib_path, "")
-        conanfile.cpp_info.libdirs = ["lib", "custom_folder"]
-        result = tools.collect_libs(conanfile)
-        self.assertEqual(["mylib"], result)
-        self.assertIn("Library 'mylib' was either already found in a previous "
-                      "'conanfile.cpp_info.libdirs' folder or appears several times with a "
-                      "different file extension", conanfile.output)
-
         # Warn lib folder does not exist with correct result
         conanfile = ConanFileMock()
         conanfile.folders.set_base_package(temp_folder())
@@ -879,21 +864,6 @@ class CollectLibTestCase(unittest.TestCase):
         self.assertEqual(["lib", "custom_folder"], conanfile.cpp_info.libdirs)
         result = conanfile.collect_libs(folder="custom_folder")
         self.assertEqual(["customlib"], result)
-
-        # Warn same lib different folders
-        conanfile = ConanFileMock()
-        conanfile.folders.set_base_package(temp_folder())
-        conanfile.cpp_info = CppInfo("", "")
-        custom_mylib_path = os.path.join(conanfile.package_folder, "custom_folder", "mylib.lib")
-        lib_mylib_path = os.path.join(conanfile.package_folder, "lib", "mylib.lib")
-        save(custom_mylib_path, "")
-        save(lib_mylib_path, "")
-        conanfile.cpp_info.libdirs = ["lib", "custom_folder"]
-        result = conanfile.collect_libs()
-        self.assertEqual(["mylib"], result)
-        self.assertIn("Library 'mylib' was either already found in a previous "
-                      "'conanfile.cpp_info.libdirs' folder or appears several times with a "
-                      "different file extension", conanfile.output)
 
         # Warn lib folder does not exist with correct result
         conanfile = ConanFileMock()

--- a/conans/test/unittests/util/tools_test.py
+++ b/conans/test/unittests/util/tools_test.py
@@ -829,6 +829,21 @@ class CollectLibTestCase(unittest.TestCase):
         result = tools.collect_libs(conanfile)
         self.assertEqual(["mylib"], result)
 
+        # Warn lib folder does not exist with correct result
+        conanfile = ConanFileMock()
+        conanfile.folders.set_base_package(temp_folder())
+        conanfile.cpp_info = CppInfo(conanfile.name, "")
+        lib_mylib_path = os.path.join(conanfile.package_folder, "lib", "mylib.lib")
+        save(lib_mylib_path, "")
+        no_folder_path = os.path.join(conanfile.package_folder, "no_folder")
+        conanfile.cpp_info.libdirs = ["no_folder", "lib"]  # 'no_folder' does NOT exist
+        result = tools.collect_libs(conanfile)
+        self.assertEqual(["mylib"], result)
+        self.assertIn("WARN: Lib folder doesn't exist, can't collect libraries: %s"
+                      % no_folder_path, conanfile.output)
+
+    @pytest.mark.skipif(platform.system() == "Windows", reason="Needs symlinks support")
+    def test_collect_libs_symlinks(self):
         # Keep only the shortest lib name per group of symlinks
         conanfile = ConanFileMock()
         conanfile.folders.set_base_package(temp_folder())
@@ -846,19 +861,6 @@ class CollectLibTestCase(unittest.TestCase):
         conanfile.cpp_info.libdirs = ["lib", "custom_folder"]
         result = tools.collect_libs(conanfile)
         self.assertEqual(["mylib", "mylib.2", "mylib.3"], result)
-
-        # Warn lib folder does not exist with correct result
-        conanfile = ConanFileMock()
-        conanfile.folders.set_base_package(temp_folder())
-        conanfile.cpp_info = CppInfo(conanfile.name, "")
-        lib_mylib_path = os.path.join(conanfile.package_folder, "lib", "mylib.lib")
-        save(lib_mylib_path, "")
-        no_folder_path = os.path.join(conanfile.package_folder, "no_folder")
-        conanfile.cpp_info.libdirs = ["no_folder", "lib"]  # 'no_folder' does NOT exist
-        result = tools.collect_libs(conanfile)
-        self.assertEqual(["mylib"], result)
-        self.assertIn("WARN: Lib folder doesn't exist, can't collect libraries: %s"
-                      % no_folder_path, conanfile.output)
 
     def test_self_collect_libs(self):
         conanfile = ConanFileMock()
@@ -907,6 +909,21 @@ class CollectLibTestCase(unittest.TestCase):
         result = conanfile.collect_libs()
         self.assertEqual(["mylib"], result)
 
+        # Warn lib folder does not exist with correct result
+        conanfile = ConanFileMock()
+        conanfile.folders.set_base_package(temp_folder())
+        conanfile.cpp_info = CppInfo("", "")
+        lib_mylib_path = os.path.join(conanfile.package_folder, "lib", "mylib.lib")
+        save(lib_mylib_path, "")
+        no_folder_path = os.path.join(conanfile.package_folder, "no_folder")
+        conanfile.cpp_info.libdirs = ["no_folder", "lib"]  # 'no_folder' does NOT exist
+        result = conanfile.collect_libs()
+        self.assertEqual(["mylib"], result)
+        self.assertIn("WARN: Lib folder doesn't exist, can't collect libraries: %s"
+                      % no_folder_path, conanfile.output)
+
+    @pytest.mark.skipif(platform.system() == "Windows", reason="Needs symlinks support")
+    def test_self_collect_libs_symlinks(self):
         # Keep only the shortest lib name per group of symlinks
         conanfile = ConanFileMock()
         conanfile.folders.set_base_package(temp_folder())
@@ -924,16 +941,3 @@ class CollectLibTestCase(unittest.TestCase):
         conanfile.cpp_info.libdirs = ["lib", "custom_folder"]
         result = conanfile.collect_libs()
         self.assertEqual(["mylib", "mylib.2", "mylib.3"], result)
-
-        # Warn lib folder does not exist with correct result
-        conanfile = ConanFileMock()
-        conanfile.folders.set_base_package(temp_folder())
-        conanfile.cpp_info = CppInfo("", "")
-        lib_mylib_path = os.path.join(conanfile.package_folder, "lib", "mylib.lib")
-        save(lib_mylib_path, "")
-        no_folder_path = os.path.join(conanfile.package_folder, "no_folder")
-        conanfile.cpp_info.libdirs = ["no_folder", "lib"]  # 'no_folder' does NOT exist
-        result = conanfile.collect_libs()
-        self.assertEqual(["mylib"], result)
-        self.assertIn("WARN: Lib folder doesn't exist, can't collect libraries: %s"
-                      % no_folder_path, conanfile.output)

--- a/conans/test/unittests/util/tools_test.py
+++ b/conans/test/unittests/util/tools_test.py
@@ -817,6 +817,18 @@ class CollectLibTestCase(unittest.TestCase):
         result = tools.collect_libs(conanfile, folder="custom_folder")
         self.assertEqual(["customlib"], result)
 
+        # Unicity of lib names
+        conanfile = ConanFileMock()
+        conanfile.folders.set_base_package(temp_folder())
+        conanfile.cpp_info = CppInfo(conanfile.name, "")
+        custom_mylib_path = os.path.join(conanfile.package_folder, "custom_folder", "mylib.lib")
+        lib_mylib_path = os.path.join(conanfile.package_folder, "lib", "mylib.lib")
+        save(custom_mylib_path, "")
+        save(lib_mylib_path, "")
+        conanfile.cpp_info.libdirs = ["lib", "custom_folder"]
+        result = tools.collect_libs(conanfile)
+        self.assertEqual(["mylib"], result)
+
         # Warn lib folder does not exist with correct result
         conanfile = ConanFileMock()
         conanfile.folders.set_base_package(temp_folder())
@@ -864,6 +876,18 @@ class CollectLibTestCase(unittest.TestCase):
         self.assertEqual(["lib", "custom_folder"], conanfile.cpp_info.libdirs)
         result = conanfile.collect_libs(folder="custom_folder")
         self.assertEqual(["customlib"], result)
+
+        # Unicity of lib names
+        conanfile = ConanFileMock()
+        conanfile.folders.set_base_package(temp_folder())
+        conanfile.cpp_info = CppInfo("", "")
+        custom_mylib_path = os.path.join(conanfile.package_folder, "custom_folder", "mylib.lib")
+        lib_mylib_path = os.path.join(conanfile.package_folder, "lib", "mylib.lib")
+        save(custom_mylib_path, "")
+        save(lib_mylib_path, "")
+        conanfile.cpp_info.libdirs = ["lib", "custom_folder"]
+        result = conanfile.collect_libs()
+        self.assertEqual(["mylib"], result)
 
         # Warn lib folder does not exist with correct result
         conanfile = ConanFileMock()


### PR DESCRIPTION
closes https://github.com/conan-io/conan/issues/11282
closes https://github.com/conan-io/conan/issues/11526

Changelog: Fix: In `conans.tools.collect_libs` and `conan.tools.files.collect_libs`, avoids to list other flavors (version, soversion) of the same `dylib` on macOS, so that behavior is consistent on Linux & macOS.
Docs: https://github.com/conan-io/docs/pull/2610

- [x] Refer to the issue that supports this Pull Request.
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [x] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 

<sup>**Note:** By default this PR will skip the slower tests and will use a limited set of python versions. Check [here](https://github.com/conan-io/conan/blob/develop/.github/PR_INCREASE_TESTING.md) how to increase the testing level by writing some tags in the current PR body text.</sup>
