### PR TITLE
always generate files VirtualBuildEnv VirtualRunEnv

### DIFF
--- a/conan/tools/env/virtualbuildenv.py
+++ b/conan/tools/env/virtualbuildenv.py
@@ -69,5 +69,4 @@ class VirtualBuildEnv:
 
     def generate(self, scope="build"):
         build_env = self.environment()
-        if build_env:  # Only if there is something defined
-            build_env.vars(self._conanfile, scope=scope).save_script(self._filename)
+        build_env.vars(self._conanfile, scope=scope).save_script(self._filename)

--- a/conan/tools/env/virtualrunenv.py
+++ b/conan/tools/env/virtualrunenv.py
@@ -73,5 +73,4 @@ class VirtualRunEnv:
 
     def generate(self, scope="run"):
         run_env = self.environment()
-        if run_env:
-            run_env.vars(self._conanfile, scope=scope).save_script(self._filename)
+        run_env.vars(self._conanfile, scope=scope).save_script(self._filename)

--- a/conans/test/integration/environment/test_env.py
+++ b/conans/test/integration/environment/test_env.py
@@ -663,3 +663,23 @@ def test_skip_virtualbuildenv_run():
     # client.run("create . --name consumer --version 1.0")
     client.run("create .  consumer/1.0@ -pr:h=default -pr:b=default")
     assert "FOO is BAR" not in client.out
+
+
+def test_files_always_created():
+    """ test that even if there are no env-variables, the generators always create files,
+    they will be mostly empty, but exist
+    """
+    c = TestClient()
+    c.save({"dep/conanfile.py": GenConanfile("dep", "0.1"),
+            "consumer/conanfile.txt": "[requires]\ndep/0.1"})
+    c.run("create dep")
+    c.run("install consumer -g VirtualBuildEnv -g VirtualRunEnv")
+    ext = "bat" if platform.system() == "Windows" else "sh"
+
+    assert os.path.isfile(os.path.join(c.current_folder, "conanbuild.{}".format(ext)))
+    assert os.path.isfile(os.path.join(c.current_folder, "conanrun.{}".format(ext)))
+    assert os.path.isfile(os.path.join(c.current_folder,
+                                       "conanbuildenv-release-x86_64.{}".format(ext)))
+    assert os.path.isfile(os.path.join(c.current_folder,
+                                       "conanbuildenv-release-x86_64.{}".format(ext)))
+


### PR DESCRIPTION
Changelog: Feature: ``VirtualBuildEnv`` and ``VirtualRunEnv`` always generate files, even if empty.
Docs: Omit

Close https://github.com/conan-io/conan/issues/11352