### PR TITLE
Limit usage of list2cmdline in check_output_runner to Windows

### DIFF
--- a/conan/tools/build/__init__.py
+++ b/conan/tools/build/__init__.py
@@ -1,10 +1,10 @@
-import subprocess
 import sys
+from shlex import quote
 
-from conan.tools.build.cpu import build_jobs
-from conan.tools.build.cross_building import cross_building, can_run
 from conan.tools.build.cppstd import check_min_cppstd, valid_min_cppstd, default_cppstd, \
     supported_cppstd
+from conan.tools.build.cpu import build_jobs
+from conan.tools.build.cross_building import cross_building, can_run
 
 
 def use_win_mingw(conanfile):
@@ -19,11 +19,30 @@ def use_win_mingw(conanfile):
     return False
 
 
-def args_to_string(args):
+def cmd_args_to_string(args):
     if not args:
         return ""
-    # FIXME: This is ugly, hardcoding condition how to parse args
     if sys.platform == 'win32':
-        return subprocess.list2cmdline(args)
+        return _windows_cmd_args_to_string(args)
     else:
-        return " ".join("'" + arg.replace("'", r"'\''") + "'" for arg in args)
+        return _unix_cmd_args_to_string(args)
+
+
+def _unix_cmd_args_to_string(args):
+    """Return a shell-escaped string from *split_command*."""
+    return ' '.join(quote(arg) for arg in args)
+
+
+def _windows_cmd_args_to_string(args):
+    # FIXME: This is not managing all the parsing from list2cmdline, but covering simplified cases
+    ret = []
+    for arg in args:
+        # escaped quotes have to be double escaped
+        arg = arg.replace(r'\"', r'\\"')
+        # quotes have to be escaped
+        arg = arg.replace(r'"', r'\"')
+        # if argument have spaces, quote it
+        if ' ' or '\t' in arg:
+            ret.append('"{}"'.format(arg))
+    return " ".join(ret)
+

--- a/conan/tools/build/__init__.py
+++ b/conan/tools/build/__init__.py
@@ -42,7 +42,9 @@ def _windows_cmd_args_to_string(args):
         # quotes have to be escaped
         arg = arg.replace(r'"', r'\"')
         # if argument have spaces, quote it
-        if ' ' or '\t' in arg:
+        if ' ' in arg or '\t' in arg:
             ret.append('"{}"'.format(arg))
+        else:
+            ret.append(arg)
     return " ".join(ret)
 

--- a/conan/tools/build/__init__.py
+++ b/conan/tools/build/__init__.py
@@ -37,10 +37,14 @@ def _windows_cmd_args_to_string(args):
     # FIXME: This is not managing all the parsing from list2cmdline, but covering simplified cases
     ret = []
     for arg in args:
-        # escaped quotes have to be double escaped
-        arg = arg.replace(r'\"', r'\\"')
+        # escaped quotes have to escape the \ and then the ". Replace with <QUOTE> so next
+        # replace doesn't interfere
+        arg = arg.replace(r'\"', r'\\\<QUOTE>')
         # quotes have to be escaped
         arg = arg.replace(r'"', r'\"')
+
+        # restore the quotes
+        arg = arg.replace("<QUOTE>", '"')
         # if argument have spaces, quote it
         if ' ' in arg or '\t' in arg:
             ret.append('"{}"'.format(arg))

--- a/conan/tools/cmake/cmake.py
+++ b/conan/tools/cmake/cmake.py
@@ -1,6 +1,6 @@
 import os
 
-from conan.tools.build import build_jobs, args_to_string
+from conan.tools.build import build_jobs, cmd_args_to_string
 from conan.tools.cmake.presets import load_cmake_presets, get_configure_preset
 from conan.tools.cmake.utils import is_multi_configuration
 from conan.tools.files import chdir, mkdir
@@ -128,7 +128,7 @@ class CMake(object):
         if cmd_line_args:
             args += ['--'] + cmd_line_args
 
-        arg_list = ['"{}"'.format(bf), build_config, args_to_string(args)]
+        arg_list = ['"{}"'.format(bf), build_config, cmd_args_to_string(args)]
         arg_list = " ".join(filter(None, arg_list))
         command = "%s --build %s" % (self._cmake_program, arg_list)
         self._conanfile.output.info("CMake command: %s" % command)

--- a/conan/tools/gnu/autotools.py
+++ b/conan/tools/gnu/autotools.py
@@ -1,6 +1,6 @@
 import os
 
-from conan.tools.build import build_jobs, args_to_string
+from conan.tools.build import build_jobs, cmd_args_to_string
 from conan.tools.files.files import load_toolchain_args
 from conans.client.subsystems import subsystem_path, deduce_subsystem
 from conan.tools.files import chdir
@@ -49,7 +49,7 @@ class Autotools(object):
         configure_args = []
         configure_args.extend(args or [])
 
-        self._configure_args = "{} {}".format(self._configure_args, args_to_string(configure_args))
+        self._configure_args = "{} {}".format(self._configure_args, cmd_args_to_string(configure_args))
 
         configure_cmd = "{}/configure".format(script_folder)
         subsystem = deduce_subsystem(self._conanfile, scope="build")
@@ -99,7 +99,7 @@ class Autotools(object):
                      ``autoreconf`` call.
         """
         args = args or []
-        command = join_arguments(["autoreconf", self._autoreconf_args, args_to_string(args)])
+        command = join_arguments(["autoreconf", self._autoreconf_args, cmd_args_to_string(args)])
         with chdir(self, self._conanfile.source_folder):
             self._conanfile.run(command)
 

--- a/conan/tools/gnu/autotoolstoolchain.py
+++ b/conan/tools/gnu/autotoolstoolchain.py
@@ -1,6 +1,6 @@
 from conan.tools.apple.apple import apple_min_version_flag, to_apple_arch
 from conan.tools.apple.apple import get_apple_sdk_fullname
-from conan.tools.build import args_to_string
+from conan.tools.build import cmd_args_to_string
 from conan.tools.build.cross_building import cross_building
 from conan.tools.build.flags import architecture_flag, build_type_flags, cppstd_flag, libcxx_flag, \
     build_type_link_flags
@@ -207,13 +207,13 @@ class AutotoolsToolchain:
     def generate_args(self):
         configure_args = []
         configure_args.extend(self.configure_args)
-        user_args_str = args_to_string(self.configure_args)
+        user_args_str = cmd_args_to_string(self.configure_args)
         for flag, var in (("host", self._host), ("build", self._build), ("target", self._target)):
             if var and flag not in user_args_str:
                 configure_args.append('--{}={}'.format(flag, var))
 
-        args = {"configure_args": args_to_string(configure_args),
-                "make_args":  args_to_string(self.make_args),
-                "autoreconf_args": args_to_string(self.autoreconf_args)}
+        args = {"configure_args": cmd_args_to_string(configure_args),
+                "make_args":  cmd_args_to_string(self.make_args),
+                "autoreconf_args": cmd_args_to_string(self.autoreconf_args)}
 
         save_toolchain_args(args, namespace=self._namespace)

--- a/conan/tools/gnu/pkgconfig.py
+++ b/conan/tools/gnu/pkgconfig.py
@@ -1,3 +1,4 @@
+from conan.tools.build import cmd_args_to_string
 from conan.tools.env import Environment
 from conans.errors import ConanException
 from conans.util.runners import check_output_runner
@@ -21,7 +22,7 @@ class PkgConfig:
 
     def _parse_output(self, option):
         executable = self._conanfile.conf.get("tools.gnu:pkg_config", default="pkg-config")
-        command = [executable, '--' + option, self._library, '--print-errors']
+        command = cmd_args_to_string([executable, '--' + option, self._library, '--print-errors'])
         env = Environment()
         if self._pkg_config_path:
             env.prepend_path("PKG_CONFIG_PATH", self._pkg_config_path)

--- a/conans/client/conf/detect_vs.py
+++ b/conans/client/conf/detect_vs.py
@@ -1,5 +1,6 @@
 import json
 import os
+import subprocess
 from shutil import which
 
 from conans.cli.output import ConanOutput
@@ -149,7 +150,8 @@ def vswhere(all_=False, prerelease=False, products=None, requires=None, version=
 
     try:
         from conans.util.runners import check_output_runner
-        output = check_output_runner(arguments).strip()
+        cmd = subprocess.list2cmdline(arguments)
+        output = check_output_runner(cmd).strip()
         # Ignore the "description" field, that even decoded contains non valid charsets for json
         # (ignored ones)
         output = "\n".join([line for line in output.splitlines()

--- a/conans/client/conf/detect_vs.py
+++ b/conans/client/conf/detect_vs.py
@@ -1,8 +1,8 @@
 import json
 import os
-import subprocess
 from shutil import which
 
+from conan.tools.build import cmd_args_to_string
 from conans.cli.output import ConanOutput
 from conans.errors import ConanException
 from conans.model.version import Version
@@ -150,7 +150,7 @@ def vswhere(all_=False, prerelease=False, products=None, requires=None, version=
 
     try:
         from conans.util.runners import check_output_runner
-        cmd = subprocess.list2cmdline(arguments)
+        cmd = cmd_args_to_string(arguments)
         output = check_output_runner(cmd).strip()
         # Ignore the "description" field, that even decoded contains non valid charsets for json
         # (ignored ones)

--- a/conans/client/subsystems.py
+++ b/conans/client/subsystems.py
@@ -22,8 +22,8 @@ Potential scenarios:
 import os
 import platform
 import re
-import subprocess
 
+from conan.tools.build import cmd_args_to_string
 from conans.errors import ConanException
 
 WINDOWS = "windows"
@@ -88,7 +88,7 @@ def _escape_windows_cmd(command):
 
         Useful to escape commands to be executed in a windows bash (msys2, cygwin etc)
     """
-    quoted_arg = subprocess.list2cmdline([command])
+    quoted_arg = cmd_args_to_string([command])
     return "".join(["^%s" % arg if arg in r'()%!^"<>&|' else arg for arg in quoted_arg])
 
 

--- a/conans/test/functional/command/profile_test.py
+++ b/conans/test/functional/command/profile_test.py
@@ -102,7 +102,7 @@ class DetectCompilersTest(unittest.TestCase):
         Test if gcc in Mac OS X is using apple-clang as frontend
         """
         # See: https://github.com/conan-io/conan/issues/2231
-        output = check_output_runner(["gcc", "--version"], stderr=subprocess.STDOUT)
+        output = check_output_runner("gcc --version", stderr=subprocess.STDOUT)
 
         if "clang" not in output:
             # Not test scenario gcc should display clang in output

--- a/conans/test/functional/toolchains/gnu/autotools/test_ios.py
+++ b/conans/test/functional/toolchains/gnu/autotools/test_ios.py
@@ -74,9 +74,9 @@ def test_ios():
     configure_args = conanbuild["configure_args"]
     make_args = conanbuild["make_args"]
     autoreconf_args = conanbuild["autoreconf_args"]
-    assert configure_args == "'--prefix=/' '--bindir=${prefix}/bin' '--sbindir=${prefix}/bin' " \
+    assert configure_args == "--prefix=/ '--bindir=${prefix}/bin' '--sbindir=${prefix}/bin' " \
                              "'--libdir=${prefix}/lib' '--includedir=${prefix}/include' " \
                              "'--oldincludedir=${prefix}/include' '--datarootdir=${prefix}/res' " \
-                             "'--host=aarch64-apple-ios' '--build=x86_64-apple-darwin'"
+                             "--host=aarch64-apple-ios --build=x86_64-apple-darwin"
     assert make_args == ""
-    assert autoreconf_args == "'--force' '--install'"
+    assert autoreconf_args == "--force --install"

--- a/conans/test/functional/util/test_cmd_args_to_string.py
+++ b/conans/test/functional/util/test_cmd_args_to_string.py
@@ -1,0 +1,68 @@
+import os
+import platform
+import textwrap
+
+import pytest
+
+from conan.tools.build import cmd_args_to_string
+from conans.test.utils.tools import TestClient
+from conans.util.files import chdir
+from conans.util.runners import check_output_runner
+
+
+@pytest.fixture(scope="module")
+def application_folder():
+    t = TestClient()
+    main = textwrap.dedent("""
+    #include<stdio.h>
+    int main(int argc, char *argv[]){
+        int i;
+        for(i=1;i<argc;i++){
+            printf("%s\\n",argv[i]);
+        }
+        return 0;
+    }
+    """
+    )
+
+    cmake = textwrap.dedent("""
+    cmake_minimum_required(VERSION 3.15)
+    project(arg_printer C)
+
+    add_executable(arg_printer main.c)
+    """)
+
+    t.save({"CMakeLists.txt": cmake, "main.c": main})
+    t.run_command("cmake . -DCMAKE_BUILD_TYPE=Release")
+    if platform.system() == "Windows":
+        t.run_command("cmake --build . --config Release")
+    else:
+        t.run_command("cmake --build .")
+
+    if platform.system() == "Windows":
+        return os.path.join(t.current_folder, "Release")
+    else:
+        return t.current_folder
+
+
+@pytest.mark.tool("cmake")
+@pytest.mark.skipif(platform.system() == "Windows", reason="Unix console parsing")
+@pytest.mark.parametrize("_input, output", [
+         (['.', 'foo'], '. foo'),
+         (['.', 'foo with sp'], ". 'foo with sp'"),
+         (['.', 'foo "with" sp'], ". 'foo \"with\" sp'"),
+         (['.', '\'foo with sp\''], '. \'\'"\'"\'foo with sp\'"\'"\'\''),
+         (['"."', 'foo'], '\'"."\' foo'),
+         (['".', 'foo'], '\'".\' foo'),
+])
+def test_unix_cases(application_folder, _input, output):
+    _input = ["arg_printer"] + _input
+    output = "arg_printer {}".format(output)
+    assert cmd_args_to_string(_input) == output
+
+    # Check calling the exe that the arguments are the same we tried to input
+    with chdir(application_folder):
+        cmd_parsed_output = check_output_runner("./{}".format(output))
+        interpreted_args = cmd_parsed_output.splitlines()
+        real_args = _input[1:]
+        assert real_args == interpreted_args

--- a/conans/test/unittests/tools/cmake/test_cmake_test.py
+++ b/conans/test/unittests/tools/cmake/test_cmake_test.py
@@ -42,5 +42,5 @@ def test_run_tests(generator, target):
     cmake = CMake(conanfile)
     cmake.test()
 
-    search_pattern = "--target {}" if platform.system() == "Windows" else "'--target' '{}'"
+    search_pattern = "--target {}"
     assert search_pattern.format(target) in conanfile.command

--- a/conans/test/unittests/tools/env/test_env.py
+++ b/conans/test/unittests/tools/env/test_env.py
@@ -7,8 +7,8 @@ import pytest
 
 from conan.tools.env import Environment
 from conan.tools.env.environment import ProfileEnvironment
-from conans.model.recipe_ref import RecipeReference
 from conans.client.subsystems import WINDOWS
+from conans.model.recipe_ref import RecipeReference
 from conans.test.utils.mocks import ConanFileMock, MockSettings
 from conans.test.utils.test_files import temp_folder
 from conans.util.env import environment_update

--- a/conans/test/unittests/util/tools_test.py
+++ b/conans/test/unittests/util/tools_test.py
@@ -138,7 +138,7 @@ class ToolsTest(unittest.TestCase):
         original_temp = temp_folder()
         patched_temp = os.path.join(original_temp, "dir with spaces")
         payload = "hello world"
-        output = check_output_runner(["echo", payload], stderr=subprocess.STDOUT)
+        output = check_output_runner("echo {}".format(payload), stderr=subprocess.STDOUT)
         self.assertIn(payload, str(output))
 
 

--- a/conans/test/utils/apple.py
+++ b/conans/test/utils/apple.py
@@ -1,3 +1,5 @@
+from conan.tools.build import cmd_args_to_string
+
 
 class XCRun(object):
 
@@ -11,8 +13,8 @@ class XCRun(object):
     def _invoke(self, args):
         def cmd_output(cmd):
             from conans.util.runners import check_output_runner
-            cmd = " ".join(cmd)
-            return check_output_runner(cmd).strip()
+            cmd_str = cmd_args_to_string(cmd)
+            return check_output_runner(cmd_str).strip()
 
         command = ['xcrun']
         if self.sdk:

--- a/conans/test/utils/apple.py
+++ b/conans/test/utils/apple.py
@@ -11,6 +11,7 @@ class XCRun(object):
     def _invoke(self, args):
         def cmd_output(cmd):
             from conans.util.runners import check_output_runner
+            cmd = " ".join(cmd)
             return check_output_runner(cmd).strip()
 
         command = ['xcrun']

--- a/conans/util/runners.py
+++ b/conans/util/runners.py
@@ -81,12 +81,12 @@ def detect_runner(command):
 
 def check_output_runner(cmd, stderr=None):
     # Used to run several utilities, like Pacman detect, AIX version, uname, SCM
+    assert isinstance(cmd, str)
     d = tempfile.mkdtemp()
     tmp_file = os.path.join(d, "output")
     try:
         # We don't want stderr to print warnings that will mess the pristine outputs
         stderr = stderr or subprocess.PIPE
-        cmd = cmd if isinstance(cmd, str) else subprocess.list2cmdline(cmd)
         command = '{} > "{}"'.format(cmd, tmp_file)
         process = subprocess.Popen(command, shell=True, stderr=stderr)
         stdout, stderr = process.communicate()


### PR DESCRIPTION
I have not removed the `list2cmdline` (well, the command is removed but not the escaping with other new function) following the strategy of "I prefer to see it fail and fix later" because the need is now clear and tested and the usage is more limited and verified. In my opinion, it makes sense to keep a function to prepare any call to the command line, because it is indeed very necessary to quote special characters or the system calls will fail.

- More controlled usage
- Replaced `list2cmdline` with a basic tool that should cover 99% of weird command line parsing
- Introduced a test with a real executable reading the parameters. When issues appear, we can add a new assert to the test easily.


Changelog: omit
Docs: omit
