### PR TITLE
Add new layout() test for projects sharing common code in parent folders

### DIFF
--- a/conan/tools/cmake/layout.py
+++ b/conan/tools/cmake/layout.py
@@ -3,7 +3,7 @@ import os
 from conans.errors import ConanException
 
 
-def cmake_layout(conanfile, generator=None, src_folder=".", subfolder=None):
+def cmake_layout(conanfile, generator=None, src_folder="."):
     gen = conanfile.conf.get("tools.cmake.cmaketoolchain:generator", default=generator)
     if gen:
         multi = "Visual" in gen or "Xcode" in gen or "Multi-Config" in gen
@@ -14,13 +14,14 @@ def cmake_layout(conanfile, generator=None, src_folder=".", subfolder=None):
         else:
             multi = False
 
-    conanfile.folders.source = src_folder if not subfolder else os.path.join(subfolder, src_folder)
+    subproject = conanfile.folders.subproject
+    conanfile.folders.source = src_folder if not subproject else os.path.join(subproject, src_folder)
     try:
         build_type = str(conanfile.settings.build_type)
     except ConanException:
         raise ConanException("'build_type' setting not defined, it is necessary for cmake_layout()")
 
-    build_folder = "build" if not subfolder else os.path.join(subfolder, "build")
+    build_folder = "build" if not subproject else os.path.join(subproject, "build")
     custom_conf = get_build_folder_custom_vars(conanfile)
     if custom_conf:
         build_folder = "{}/{}".format(build_folder, custom_conf)

--- a/conan/tools/cmake/layout.py
+++ b/conan/tools/cmake/layout.py
@@ -3,7 +3,7 @@ import os
 from conans.errors import ConanException
 
 
-def cmake_layout(conanfile, generator=None, src_folder="."):
+def cmake_layout(conanfile, generator=None, src_folder=".", subfolder=None):
     gen = conanfile.conf.get("tools.cmake.cmaketoolchain:generator", default=generator)
     if gen:
         multi = "Visual" in gen or "Xcode" in gen or "Multi-Config" in gen
@@ -14,13 +14,13 @@ def cmake_layout(conanfile, generator=None, src_folder="."):
         else:
             multi = False
 
-    conanfile.folders.source = src_folder
+    conanfile.folders.source = src_folder if not subfolder else os.path.join(subfolder, src_folder)
     try:
         build_type = str(conanfile.settings.build_type)
     except ConanException:
         raise ConanException("'build_type' setting not defined, it is necessary for cmake_layout()")
 
-    build_folder = "build"
+    build_folder = "build" if not subfolder else os.path.join(subfolder, "build")
     custom_conf = get_build_folder_custom_vars(conanfile)
     if custom_conf:
         build_folder = "{}/{}".format(build_folder, custom_conf)

--- a/conan/tools/layout/__init__.py
+++ b/conan/tools/layout/__init__.py
@@ -6,10 +6,12 @@ from conan.tools.google import bazel_layout
 
 
 def basic_layout(conanfile, src_folder="."):
-    conanfile.folders.build = "build"
+    subproject = conanfile.folders.subproject
+
+    conanfile.folders.source = src_folder if not subproject else os.path.join(subproject, src_folder)
+    conanfile.folders.build = "build" if not subproject else os.path.join(subproject, "build")
     if conanfile.settings.get_safe("build_type"):
         conanfile.folders.build += "-{}".format(str(conanfile.settings.build_type).lower())
     conanfile.folders.generators = os.path.join(conanfile.folders.build, "conan")
     conanfile.cpp.build.bindirs = ["."]
     conanfile.cpp.build.libdirs = ["."]
-    conanfile.folders.source = src_folder

--- a/conan/tools/microsoft/layout.py
+++ b/conan/tools/microsoft/layout.py
@@ -15,13 +15,14 @@ def vs_layout(conanfile):
         if not arch:
             raise ConanException("The 'vs_layout' doesn't "
                                  "work with the arch '{}'".format(conanfile.settings.arch))
-        base = os.path.join(arch, str(conanfile.settings.build_type))
+        bindirs = os.path.join(arch, str(conanfile.settings.build_type))
     else:
-        base = str(conanfile.settings.build_type)
+        bindirs = str(conanfile.settings.build_type)
 
-    conanfile.folders.build = "."
-    conanfile.folders.generators = "conan"
-    conanfile.folders.source = "."
-    conanfile.cpp.build.libdirs = [base]
-    conanfile.cpp.build.bindirs = [base]
+    subproject = conanfile.folders.subproject
+    conanfile.folders.build = subproject or "."
+    conanfile.folders.generators = os.path.join(subproject, "conan") if subproject else "conan"
+    conanfile.folders.source = subproject or "."
+    conanfile.cpp.build.libdirs = [bindirs]
+    conanfile.cpp.build.bindirs = [bindirs]
     conanfile.cpp.source.includedirs = ["include"]

--- a/conans/model/layout.py
+++ b/conans/model/layout.py
@@ -31,7 +31,7 @@ class Folders(object):
         # Relative location of the project root, if the conanfile is not in that project root, but
         # in a subfolder: e.g: If the conanfile is in a subfolder then self.root = ".."
         self.root = None
-        # The relative location wrt to the project root of the subproject containing the
+        # The relative location with respect to the project root of the subproject containing the
         # conanfile.py, that makes most of the output folders defined in layouts (cmake_layout, etc)
         # start from the subproject again
         self.subproject = None

--- a/conans/model/layout.py
+++ b/conans/model/layout.py
@@ -31,6 +31,10 @@ class Folders(object):
         # Relative location of the project root, if the conanfile is not in that project root, but
         # in a subfolder: e.g: If the conanfile is in a subfolder then self.root = ".."
         self.root = None
+        # The relative location wrt to the project root of the subproject containing the
+        # conanfile.py, that makes most of the output folders defined in layouts (cmake_layout, etc)
+        # start from the subproject again
+        self.subproject = None
 
     def __repr__(self):
         return str(self.__dict__)

--- a/conans/test/functional/layout/test_in_subfolder.py
+++ b/conans/test/functional/layout/test_in_subfolder.py
@@ -150,19 +150,19 @@ def test_exports_sources_common_code_layout():
                                                  custom_content=cmake_include),
             "common/myutils.cmake": 'message(STATUS "MYUTILS.CMAKE!")',
             "common/myheader.h": '#define MYDEFINE "MYDEFINEVALUE"'})
-    c.run("create pkg -s compiler.version=15")
+    c.run("create pkg")
     assert "MYUTILS.CMAKE!" in c.out
     assert "main: Release!" in c.out
     assert "MYDEFINE: MYDEFINEVALUE" in c.out
 
     # Local flow
-    c.run("install pkg -s compiler.version=15")
+    c.run("install pkg")
     c.run("build pkg")
     assert "MYUTILS.CMAKE!" in c.out
     assert "main: Release!" in c.out
     assert "MYDEFINE: MYDEFINEVALUE" in c.out
 
-    c.run("install pkg -s compiler.version=15 -s build_type=Debug")
+    c.run("install pkg -s build_type=Debug")
     c.run("build pkg")
     assert "MYUTILS.CMAKE!" in c.out
     assert "main: Debug!" in c.out

--- a/conans/test/functional/layout/test_in_subfolder.py
+++ b/conans/test/functional/layout/test_in_subfolder.py
@@ -130,7 +130,8 @@ def test_exports_sources_common_code_layout():
 
             def layout(self):
                 self.folders.root = ".."
-                cmake_layout(self, subfolder="pkg")
+                self.folders.subproject = "pkg"
+                cmake_layout(self)
 
             def export_sources(self):
                 source_folder = os.path.join(self.recipe_folder, "..")

--- a/conans/test/functional/layout/test_in_subfolder.py
+++ b/conans/test/functional/layout/test_in_subfolder.py
@@ -54,3 +54,55 @@ def test_exports_sources_own_code_in_subfolder():
     c.run("build conan")
     assert "conanfile.py (pkg/0.1): MYCMAKE-BUILD: mycmake!" in c.out
     assert c.load("build/mylib.a") == "mylib"
+
+
+def test_exports_sources_common_code():
+    """ very similar to the above, but intended for a multi-package project sharing some
+    common code
+    """
+    c = TestClient()
+    conanfile = textwrap.dedent("""
+        import os
+        from conan import ConanFile
+        from conan.tools.files import load, copy, save
+        class Pkg(ConanFile):
+            name = "pkg"
+            version = "0.1"
+
+            def layout(self):
+                self.folders.root = ".."
+                self.folders.source = "pkg"
+                self.folders.build = "build"
+
+            def export_sources(self):
+                source_folder = os.path.join(self.recipe_folder, "..")
+                copy(self, "*.txt", source_folder, self.export_sources_folder)
+                copy(self, "*.cmake", source_folder, self.export_sources_folder)
+
+            def source(self):
+                cmake = load(self, "CMakeLists.txt")
+                self.output.info("MYCMAKE-SRC: {}".format(cmake))
+
+            def build(self):
+                path = os.path.join(self.source_folder, "CMakeLists.txt")
+                cmake = load(self, path)
+                self.output.info("MYCMAKE-BUILD: {}".format(cmake))
+
+                path = os.path.join(self.export_sources_folder, "common", "myutils.cmake")
+                cmake = load(self, path)
+                self.output.info("MYUTILS-BUILD: {}".format(cmake))
+            """)
+    c.save({"pkg/conanfile.py": conanfile,
+            "pkg/CMakeLists.txt": "mycmake!",
+            "common/myutils.cmake": "myutils!"})
+    c.run("create pkg")
+    assert "pkg/0.1: MYCMAKE-SRC: mycmake!" in c.out
+    assert "pkg/0.1: MYCMAKE-BUILD: mycmake!" in c.out
+    assert "pkg/0.1: MYUTILS-BUILD: myutils!" in c.out
+
+    # Local flow
+    c.run("install pkg")
+    # SOURCE NOT CALLED! It doesnt make sense (will fail due to local exports)
+    c.run("build pkg")
+    assert "conanfile.py (pkg/0.1): MYCMAKE-BUILD: mycmake!" in c.out
+    assert "conanfile.py (pkg/0.1): MYUTILS-BUILD: myutils!" in c.out

--- a/conans/test/integration/toolchains/gnu/test_basic_layout.py
+++ b/conans/test/integration/toolchains/gnu/test_basic_layout.py
@@ -1,4 +1,5 @@
 import os
+import platform
 import textwrap
 
 from conans.test.utils.tools import TestClient
@@ -19,5 +20,6 @@ def test_basic_layout_subproject():
         """)
     c.save({"pkg/conanfile.py": conanfile})
     c.run("install pkg")
+    ext = "sh" if platform.system() != "Windows" else "bat"
     assert os.path.isfile(os.path.join(c.current_folder, "pkg", "build-release", "conan",
-                                       "conanautotoolstoolchain.bat"))
+                                       "conanautotoolstoolchain.{}".format(ext)))

--- a/conans/test/integration/toolchains/gnu/test_basic_layout.py
+++ b/conans/test/integration/toolchains/gnu/test_basic_layout.py
@@ -1,0 +1,23 @@
+import os
+import textwrap
+
+from conans.test.utils.tools import TestClient
+
+
+def test_basic_layout_subproject():
+    c = TestClient()
+    conanfile = textwrap.dedent("""
+        from conan import ConanFile
+        from conan.tools.layout import basic_layout
+        class Pkg(ConanFile):
+            settings = "os", "compiler", "build_type", "arch"
+            generators = "AutotoolsToolchain"
+            def layout(self):
+                self.folders.root = ".."
+                self.folders.subproject = "pkg"
+                basic_layout(self)
+        """)
+    c.save({"pkg/conanfile.py": conanfile})
+    c.run("install pkg")
+    assert os.path.isfile(os.path.join(c.current_folder, "pkg", "build-release", "conan",
+                                       "conanautotoolstoolchain.bat"))

--- a/conans/test/integration/toolchains/microsoft/test_vs_layout.py
+++ b/conans/test/integration/toolchains/microsoft/test_vs_layout.py
@@ -1,0 +1,22 @@
+import os
+import textwrap
+
+from conans.test.utils.tools import TestClient
+
+
+def test_vs_layout_subproject():
+    c = TestClient()
+    conanfile = textwrap.dedent("""
+        from conan import ConanFile
+        from conan.tools.microsoft import vs_layout
+        class Pkg(ConanFile):
+            settings = "os", "compiler", "build_type", "arch"
+            generators = "MSBuildToolchain"
+            def layout(self):
+                self.folders.root = ".."
+                self.folders.subproject = "pkg"
+                vs_layout(self)
+        """)
+    c.save({"pkg/conanfile.py": conanfile})
+    c.run("install pkg")
+    assert os.path.isfile(os.path.join(c.current_folder, "pkg", "conan", "conantoolchain.props"))


### PR DESCRIPTION
Changelog: Feature: Added a new ``self.folders.subproject`` for ``layout()`` to be able to define layouts that goes up to the parent or siblings folders, together with the ``self.folders.root = ".."``.
Docs: https://github.com/conan-io/docs/pull/2662
