### PR TITLE
Add alwayslink attribute to bazel static library import

### DIFF
--- a/conan/tools/google/bazeldeps.py
+++ b/conan/tools/google/bazeldeps.py
@@ -63,7 +63,6 @@ class BazelDeps(object):
             cc_import(
                 name = "{{ libname }}_precompiled",
                 {{ library_type }} = "{{ filepath }}",
-                alwayslink = True,
             )
             {% endfor %}
 
@@ -92,6 +91,7 @@ class BazelDeps(object):
                 visibility = ["//visibility:public"],
                 {% if libs or shared_with_interface_libs %}
                 deps = [
+                    # do not sort
                 {% for lib in libs %}
                 ":{{ lib }}_precompiled",
                 {% endfor %}

--- a/conan/tools/google/bazeldeps.py
+++ b/conan/tools/google/bazeldeps.py
@@ -62,7 +62,8 @@ class BazelDeps(object):
             {% for libname, filepath in libs.items() %}
             cc_import(
                 name = "{{ libname }}_precompiled",
-                {{ library_type }} = "{{ filepath }}"
+                {{ library_type }} = "{{ filepath }}",
+                alwayslink = True,
             )
             {% endfor %}
 

--- a/conans/test/unittests/tools/google/test_bazeldeps.py
+++ b/conans/test/unittests/tools/google/test_bazeldeps.py
@@ -220,7 +220,7 @@ cc_library(
     includes=["include"],
     visibility=["//visibility:public"],
     deps = [
-        #donotsort
+        # do not sort
         ":lib1_precompiled",
     ],
 )

--- a/conans/test/unittests/tools/google/test_bazeldeps.py
+++ b/conans/test/unittests/tools/google/test_bazeldeps.py
@@ -58,7 +58,7 @@ def test_bazeldeps_dependency_buildfiles():
                 assert 'linkopts = ["/DEFAULTLIB:system_lib1"]' in dependency_content
             else:
                 assert 'linkopts = ["-lsystem_lib1"],' in dependency_content
-            assert 'deps = [\n    \n    ":lib1_precompiled",' in dependency_content
+            assert """deps = [\n        # do not sort\n    \n    ":lib1_precompiled",""" in dependency_content
 
 
 def test_bazeldeps_get_lib_file_path_by_basename():
@@ -93,7 +93,7 @@ def test_bazeldeps_get_lib_file_path_by_basename():
                 assert 'linkopts = ["/DEFAULTLIB:system_lib1"]' in dependency_content
             else:
                 assert 'linkopts = ["-lsystem_lib1"],' in dependency_content
-            assert 'deps = [\n    \n    ":liblib1.a_precompiled",' in dependency_content
+            assert 'deps = [\n        # do not sort\n    \n    ":liblib1.a_precompiled",' in dependency_content
 
 
 def test_bazeldeps_dependency_transitive():
@@ -148,7 +148,7 @@ def test_bazeldeps_dependency_transitive():
 
         # Ensure that transitive dependency is referenced by the 'deps' attribute of the direct
         # dependency
-        assert re.search(r'deps =\s*\[\s*":lib1_precompiled",\s*"@TransitiveDepName"',
+        assert re.search(r'deps =\s*\[\s*# do not sort\s*":lib1_precompiled",\s*"@TransitiveDepName"',
                          dependency_content)
 
 
@@ -220,6 +220,7 @@ cc_library(
     includes=["include"],
     visibility=["//visibility:public"],
     deps = [
+        #donotsort
         ":lib1_precompiled",
     ],
 )


### PR DESCRIPTION
Fixes #11559 , if this solution is taken.

There is no test currently for the static library only version
Test exists only for the case when shared_with_interface_libs contains
elements.

Changelog: omit
Docs: omit
- [x] Refer to the issue that supports this Pull Request.
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 

<sup>**Note:** By default this PR will skip the slower tests and will use a limited set of python versions. Check [here](https://github.com/conan-io/conan/blob/develop/.github/PR_INCREASE_TESTING.md) how to increase the testing level by writing some tags in the current PR body text.</sup>


Before adding something to the doc, we should discuss in #11559 if this is a viable solution
