### PR TITLE
Bugfix: Follow SONAME to generate BazelDeps correctly

### DIFF
--- a/conans/requirements.txt
+++ b/conans/requirements.txt
@@ -14,3 +14,4 @@ MarkupSafe<=2.0.1;python_version<='2.7'
 Jinja2>=3.0, <4.0.0;python_version>='3'
 python-dateutil>=2.7.0, <3
 configparser>=3.5;python_version<='2.7'
+pyelftools>=0.28, <1


### PR DESCRIPTION
Changelog: (Feature | Fix | Bugfix):

- Bugfix: `BazelDeps` generates incorrect `cc_import` when the shared library is versioned by `SONAME`.
        **Description:** If A and B are both shared libraries, and A links to B, the linker assigns the `NEEDED` tag of A according to the `SONAME` tag of B. The file name of B was chosen if and only if the `SONAME` tag of B does not exist. Because of this rule, the `BazelDeps` should generate `cc_import` directive of shared libraries from their `SONAME` tags instead of thier file names. Without that, we meet library loading errors in runtime because the Bazel don't know how to put the file (perhaps a symlink) named by its `SONAME` tag into the cache directory.</sup>

<!--Docs: https://github.com/conan-io/docs/pull/XXXX-->

- [x] Refer to the issue that supports this Pull Request.
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [x] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 

<sup>**Note:** By default this PR will skip the slower tests and will use a limited set of python versions. Check [here](https://github.com/conan-io/conan/blob/develop/.github/PR_INCREASE_TESTING.md) how to increase the testing level by writing some tags in the current PR body text.</sup>
