### PR TITLE
Test that consumers of packages that use cpp_info requires on components don't propagate other components

### DIFF
--- a/conans/test/functional/toolchains/cmake/cmakedeps/test_cmakedeps_components_transitive.py
+++ b/conans/test/functional/toolchains/cmake/cmakedeps/test_cmakedeps_components_transitive.py
@@ -172,7 +172,7 @@ def test_cmakedeps_propagate_components():
         client.run("install ..")
         if platform.system() == "Windows":
             client.run_command('cmake .. -DCMAKE_TOOLCHAIN_FILE=conan_toolchain.cmake '
-                               '-G "Visual Studio 15 Win64"')
+                               '-G "Visual Studio 15"')
             client.run_command('cmake --build . --config Release')
             client.run_command(r"Release\\consumer.exe")
         else:

--- a/conans/test/functional/toolchains/cmake/cmakedeps/test_cmakedeps_components_transitive.py
+++ b/conans/test/functional/toolchains/cmake/cmakedeps/test_cmakedeps_components_transitive.py
@@ -1,3 +1,4 @@
+import platform
 import textwrap
 
 import pytest
@@ -169,8 +170,14 @@ def test_cmakedeps_propagate_components():
 
     with client.chdir("consumer/build"):
         client.run("install ..")
-        client.run_command(
-            "cmake .. -DCMAKE_TOOLCHAIN_FILE=conan_toolchain.cmake -DCMAKE_BUILD_TYPE=Release")
-        client.run_command("cmake --build .")
-        client.run_command("./consumer")
-        assert not "cmp2" in client.out
+        if platform.system() == "Windows":
+            client.run_command('cmake .. -DCMAKE_TOOLCHAIN_FILE=conan_toolchain.cmake '
+                               '-G "Visual Studio 15 Win64"')
+            client.run_command('cmake --build . --config Release')
+            client.run_command(r"Release\\consumer.exe")
+        else:
+            client.run_command(
+                "cmake .. -DCMAKE_TOOLCHAIN_FILE=conan_toolchain.cmake -DCMAKE_BUILD_TYPE=Release")
+            client.run_command("cmake --build .")
+            client.run_command("./consumer")
+        assert "cmp2" not in client.out

--- a/conans/test/functional/toolchains/cmake/cmakedeps/test_cmakedeps_components_transitive.py
+++ b/conans/test/functional/toolchains/cmake/cmakedeps/test_cmakedeps_components_transitive.py
@@ -17,50 +17,37 @@ def test_cmakedeps_propagate_components():
             name = "top"
             version = "1.0"
             settings = "os", "compiler", "build_type", "arch"
-            exports_sources = "CMakeLists.txt", "src/*", "include/*"
+            exports_sources = "CMakeLists.txt", "include/*"
             generators = "CMakeToolchain"
 
             def layout(self):
                 cmake_layout(self)
 
-            def build(self):
-                cmake = CMake(self)
-                cmake.configure()
-                cmake.build()
-
             def package(self):
                 cmake = CMake(self)
+                cmake.configure()
                 cmake.install()
 
             def package_info(self):
-                self.cpp_info.components["cmp1"].libs = ["cmp1"]
-                self.cpp_info.components["cmp2"].libs = ["cmp2"]
-        """)
-
-    cmp_cpp = textwrap.dedent("""
-        #include <iostream>
-        #include "{cmpname}.h"
-        void {cmpname}(){{ std::cout << "{cmpname}" << std::endl; }}
+                self.cpp_info.components["cmp1"].includedirs = ["include"]
+                self.cpp_info.components["cmp2"].includedirs = ["include"]
         """)
 
     cmp_include = textwrap.dedent("""
         #pragma once
-        void {cmpname}();
+        #include <iostream>
+        void {cmpname}(){{ std::cout << "{cmpname}" << std::endl; }};
         """)
 
     cmakelist = textwrap.dedent("""
         cmake_minimum_required(VERSION 3.15)
         project(top CXX)
-
-        add_library(cmp1 src/cmp1.cpp)
-        add_library(cmp2 src/cmp2.cpp)
-
-        target_include_directories(cmp1 PUBLIC include)
-        target_include_directories(cmp2 PUBLIC include)
-
+        add_library(cmp1 INTERFACE)
+        add_library(cmp2 INTERFACE)
+        target_include_directories(cmp1 INTERFACE include)
+        target_include_directories(cmp2 INTERFACE include)
         set_target_properties(cmp1 PROPERTIES PUBLIC_HEADER "include/cmp1.h")
         set_target_properties(cmp2 PROPERTIES PUBLIC_HEADER "include/cmp2.h")
-
         install(TARGETS cmp1)
         install(TARGETS cmp2)
         """)
@@ -70,8 +57,6 @@ def test_cmakedeps_propagate_components():
         'top/CMakeLists.txt': cmakelist,
         'top/include/cmp1.h': cmp_include.format(cmpname="cmp1"),
         'top/include/cmp2.h': cmp_include.format(cmpname="cmp2"),
-        'top/src/cmp1.cpp': cmp_cpp.format(cmpname="cmp1"),
-        'top/src/cmp2.cpp': cmp_cpp.format(cmpname="cmp2"),
     })
 
     client.run("create top")
@@ -87,46 +72,35 @@ def test_cmakedeps_propagate_components():
             requires = "top/1.0"
             settings = "os", "compiler", "build_type", "arch"
             generators = "CMakeDeps", "CMakeToolchain"
-            exports_sources = "CMakeLists.txt", "src/*", "include/*"
+            exports_sources = "CMakeLists.txt", "include/*"
 
             def layout(self):
                 cmake_layout(self)
 
-            def build(self):
-                cmake = CMake(self)
-                cmake.configure()
-                cmake.build()
-
             def package(self):
                 cmake = CMake(self)
+                cmake.configure()
                 cmake.install()
 
             def package_info(self):
                 self.cpp_info.requires = ["top::cmp1"]
-                self.cpp_info.libs = ["middle"]
-        """)
-
-    middle_cpp = textwrap.dedent("""
-        #include <iostream>
-        #include "cmp1.h"
-        #include "middle.h"
-
-        void middle(){ cmp1(); }
         """)
 
     middle_include = textwrap.dedent("""
         #pragma once
-        void middle();
+        #include <iostream>
+        #include "cmp1.h"
+        void middle(){ cmp1(); };
         """)
 
     cmakelist = textwrap.dedent("""
         cmake_minimum_required(VERSION 3.15)
         project(middle CXX)
         find_package(top CONFIG REQUIRED COMPONENTS cmp1)
-        add_library(middle src/middle.cpp)
-        target_include_directories(middle PUBLIC include)
+        add_library(middle INTERFACE)
+        target_include_directories(middle INTERFACE include)
+        target_link_libraries(middle INTERFACE top::cmp1)
         set_target_properties(middle PROPERTIES PUBLIC_HEADER "include/middle.h")
-        target_link_libraries(middle top::cmp1)
         install(TARGETS middle)
         """)
 
@@ -134,7 +108,6 @@ def test_cmakedeps_propagate_components():
         'middle/conanfile.py': middle,
         'middle/CMakeLists.txt': cmakelist,
         'middle/include/middle.h': middle_include,
-        'middle/src/middle.cpp': middle_cpp,
     })
 
     client.run("create middle")
@@ -168,16 +141,7 @@ def test_cmakedeps_propagate_components():
         'consumer/main.cpp': main,
     })
 
-    with client.chdir("consumer/build"):
-        client.run("install ..")
-        if platform.system() == "Windows":
-            client.run_command('cmake .. -DCMAKE_TOOLCHAIN_FILE=conan_toolchain.cmake '
-                               '-G "Visual Studio 15"')
-            client.run_command('cmake --build . --config Release')
-            client.run_command(r"Release\\consumer.exe")
-        else:
-            client.run_command(
-                "cmake .. -DCMAKE_TOOLCHAIN_FILE=conan_toolchain.cmake -DCMAKE_BUILD_TYPE=Release")
-            client.run_command("cmake --build .")
-            client.run_command("./consumer")
-        assert "cmp2" not in client.out
+    client.run("install consumer")
+
+    assert "top::cmp2" not in client.load("top-release-x86_64-data.cmake")
+    assert "top::cmp2" not in client.load("top-Target-release.cmake")

--- a/conans/test/functional/toolchains/cmake/cmakedeps/test_cmakedeps_components_transitive.py
+++ b/conans/test/functional/toolchains/cmake/cmakedeps/test_cmakedeps_components_transitive.py
@@ -112,36 +112,7 @@ def test_cmakedeps_propagate_components():
 
     client.run("create middle")
 
-    consumer = textwrap.dedent("""
-        [requires]
-        middle/1.0
-        [generators]
-        CMakeDeps
-        CMakeToolchain
-    """)
-
-    main = textwrap.dedent("""
-        // Use cmp2 that is not required by middle
-        #include "cmp2.h"
-        int main() { cmp2(); }
-        """)
-
-    cmakelist = textwrap.dedent("""
-        cmake_minimum_required(VERSION 3.15)
-        project(consumer CXX)
-        find_package(middle CONFIG REQUIRED)
-        add_executable(consumer main.cpp)
-        target_link_libraries(consumer top::cmp2)
-        install(TARGETS consumer)
-        """)
-
-    client.save({
-        'consumer/conanfile.txt': consumer,
-        'consumer/CMakeLists.txt': cmakelist,
-        'consumer/main.cpp': main,
-    })
-
-    client.run("install consumer")
+    client.run("install middle/1.0@ -g CMakeDeps")
 
     assert "top::cmp2" not in client.load("top-release-x86_64-data.cmake")
     assert "top::cmp2" not in client.load("top-Target-release.cmake")

--- a/conans/test/functional/toolchains/cmake/cmakedeps/test_cmakedeps_components_transitive.py
+++ b/conans/test/functional/toolchains/cmake/cmakedeps/test_cmakedeps_components_transitive.py
@@ -1,0 +1,176 @@
+import textwrap
+
+import pytest
+
+from conans.test.utils.tools import TestClient
+
+
+@pytest.mark.tool_cmake
+def test_cmakedeps_propagate_components():
+    client = TestClient()
+    top = textwrap.dedent("""
+        from conan import ConanFile
+        from conan.tools.cmake import CMake, cmake_layout
+
+        class TopConan(ConanFile):
+            name = "top"
+            version = "1.0"
+            settings = "os", "compiler", "build_type", "arch"
+            exports_sources = "CMakeLists.txt", "src/*", "include/*"
+            generators = "CMakeToolchain"
+
+            def layout(self):
+                cmake_layout(self)
+
+            def build(self):
+                cmake = CMake(self)
+                cmake.configure()
+                cmake.build()
+
+            def package(self):
+                cmake = CMake(self)
+                cmake.install()
+
+            def package_info(self):
+                self.cpp_info.components["cmp1"].libs = ["cmp1"]
+                self.cpp_info.components["cmp2"].libs = ["cmp2"]
+        """)
+
+    cmp_cpp = textwrap.dedent("""
+        #include <iostream>
+        #include "{cmpname}.h"
+        void {cmpname}(){{ std::cout << "{cmpname}" << std::endl; }}
+        """)
+
+    cmp_include = textwrap.dedent("""
+        #pragma once
+        void {cmpname}();
+        """)
+
+    cmakelist = textwrap.dedent("""
+        cmake_minimum_required(VERSION 3.15)
+        project(top CXX)
+
+        add_library(cmp1 src/cmp1.cpp)
+        add_library(cmp2 src/cmp2.cpp)
+
+        target_include_directories(cmp1 PUBLIC include)
+        target_include_directories(cmp2 PUBLIC include)
+
+        set_target_properties(cmp1 PROPERTIES PUBLIC_HEADER "include/cmp1.h")
+        set_target_properties(cmp2 PROPERTIES PUBLIC_HEADER "include/cmp2.h")
+
+        install(TARGETS cmp1)
+        install(TARGETS cmp2)
+        """)
+
+    client.save({
+        'top/conanfile.py': top,
+        'top/CMakeLists.txt': cmakelist,
+        'top/include/cmp1.h': cmp_include.format(cmpname="cmp1"),
+        'top/include/cmp2.h': cmp_include.format(cmpname="cmp2"),
+        'top/src/cmp1.cpp': cmp_cpp.format(cmpname="cmp1"),
+        'top/src/cmp2.cpp': cmp_cpp.format(cmpname="cmp2"),
+    })
+
+    client.run("create top")
+
+    middle = textwrap.dedent("""
+        from conan import ConanFile
+        from conan.tools.cmake import CMakeToolchain, CMake, cmake_layout
+
+
+        class MiddleConan(ConanFile):
+            name = "middle"
+            version = "1.0"
+            requires = "top/1.0"
+            settings = "os", "compiler", "build_type", "arch"
+            generators = "CMakeDeps", "CMakeToolchain"
+            exports_sources = "CMakeLists.txt", "src/*", "include/*"
+
+            def layout(self):
+                cmake_layout(self)
+
+            def build(self):
+                cmake = CMake(self)
+                cmake.configure()
+                cmake.build()
+
+            def package(self):
+                cmake = CMake(self)
+                cmake.install()
+
+            def package_info(self):
+                self.cpp_info.requires = ["top::cmp1"]
+                self.cpp_info.libs = ["middle"]
+        """)
+
+    middle_cpp = textwrap.dedent("""
+        #include <iostream>
+        #include "cmp1.h"
+        #include "middle.h"
+
+        void middle(){ cmp1(); }
+        """)
+
+    middle_include = textwrap.dedent("""
+        #pragma once
+        void middle();
+        """)
+
+    cmakelist = textwrap.dedent("""
+        cmake_minimum_required(VERSION 3.15)
+        project(middle CXX)
+        find_package(top CONFIG REQUIRED COMPONENTS cmp1)
+        add_library(middle src/middle.cpp)
+        target_include_directories(middle PUBLIC include)
+        set_target_properties(middle PROPERTIES PUBLIC_HEADER "include/middle.h")
+        target_link_libraries(middle top::cmp1)
+        install(TARGETS middle)
+        """)
+
+    client.save({
+        'middle/conanfile.py': middle,
+        'middle/CMakeLists.txt': cmakelist,
+        'middle/include/middle.h': middle_include,
+        'middle/src/middle.cpp': middle_cpp,
+    })
+
+    client.run("create middle")
+
+    consumer = textwrap.dedent("""
+        [requires]
+        middle/1.0
+        [generators]
+        CMakeDeps
+        CMakeToolchain
+    """)
+
+    main = textwrap.dedent("""
+        // Use cmp2 that is not required by middle
+        #include "cmp2.h"
+        int main() { cmp2(); }
+        """)
+
+    cmakelist = textwrap.dedent("""
+        cmake_minimum_required(VERSION 3.15)
+        project(consumer CXX)
+        find_package(middle CONFIG REQUIRED)
+        add_executable(consumer main.cpp)
+        target_link_libraries(consumer top::cmp2)
+        install(TARGETS consumer)
+        """)
+
+    client.save({
+        'consumer/conanfile.txt': consumer,
+        'consumer/CMakeLists.txt': cmakelist,
+        'consumer/main.cpp': main,
+    })
+
+    with client.chdir("consumer/build"):
+        client.run("install ..")
+        client.run_command(
+            "cmake .. -DCMAKE_TOOLCHAIN_FILE=conan_toolchain.cmake -DCMAKE_BUILD_TYPE=Release")
+        client.run_command("cmake --build .")
+        client.run_command("./consumer")
+        assert not "cmp2" in client.out

--- a/conans/test/integration/toolchains/cmake/cmakedeps/test_cmakedeps_components_transitive.py
+++ b/conans/test/integration/toolchains/cmake/cmakedeps/test_cmakedeps_components_transitive.py
@@ -1,12 +1,10 @@
 import platform
 import textwrap
 
-import pytest
 
 from conans.test.utils.tools import TestClient
 
 
-@pytest.mark.tool_cmake
 def test_cmakedeps_propagate_components():
     client = TestClient()
     top = textwrap.dedent("""


### PR DESCRIPTION
Changelog: (Feature | Fix | Bugfix): Describe here your pull request
Docs: https://github.com/conan-io/docs/pull/XXXX

top/1.0 --> two components cmp1, cmp2
middle/1.0 --> uses `self.cpp_info.requires = ["top::cmp1"]` 
consumer --> requires middle/1.0 and can use the target `top::cmp2` without failing.

Related with: https://github.com/conan-io/conan/issues/11525
