### PR TITLE
[dev2][conf] Improvements

### DIFF
--- a/conan/tools/files/files.py
+++ b/conan/tools/files/files.py
@@ -228,7 +228,7 @@ def download(conanfile, url, filename, verify=True, retry=None, retry_wait=None,
         else retry_wait if retry_wait is not None else 5
 
     checksum = sha256 or sha1 or md5
-    download_cache = config["tools.files.download:download_cache"] if checksum else None
+    download_cache = config.get("tools.files.download:download_cache") if checksum else None
 
     def _download_file(file_url):
         # The download cache is only used if a checksum is provided, otherwise, a normal download

--- a/conans/cli/commands/config.py
+++ b/conans/cli/commands/config.py
@@ -1,5 +1,8 @@
+import json
+
 from conans.cli.command import conan_command, COMMAND_GROUPS, conan_subcommand
-from conans.cli.output import ConanOutput
+from conans.cli.output import ConanOutput, Color
+from conans.model.conf import BUILT_IN_CONFS
 from conans.util.config_parser import get_bool_from_text
 
 
@@ -46,3 +49,17 @@ def config_home(conan_api, parser, subparser, *args):
     home = conan_api.config.home()
     ConanOutput().info(f"Current Conan home: {home}")
     return home
+
+
+@conan_subcommand(formatters={"json": lambda x: json.dumps(x, indent=4)})
+def config_list(conan_api, parser, subparser, *args):
+    """
+    Prints all the Conan available configurations: core and tools.
+    """
+    out = ConanOutput()
+    confs = BUILT_IN_CONFS
+    out.writeln(f"Supported Conan global.conf and [conf] properties:",
+                fg=Color.BRIGHT_CYAN)
+    for k, v in confs.items():
+        out.writeln(f"{k}: {v}")
+    return confs

--- a/conans/cli/commands/config.py
+++ b/conans/cli/commands/config.py
@@ -1,6 +1,5 @@
-import json
-
 from conans.cli.command import conan_command, COMMAND_GROUPS, conan_subcommand
+from conans.cli.commands import json_formatter
 from conans.cli.output import ConanOutput, Color
 from conans.model.conf import BUILT_IN_CONFS
 from conans.util.config_parser import get_bool_from_text
@@ -51,7 +50,7 @@ def config_home(conan_api, parser, subparser, *args):
     return home
 
 
-@conan_subcommand(formatters={"json": lambda x: json.dumps(x, indent=4)})
+@conan_subcommand(formatters={"json": json_formatter})
 def config_list(conan_api, parser, subparser, *args):
     """
     Prints all the Conan available configurations: core and tools.

--- a/conans/client/profile_loader.py
+++ b/conans/client/profile_loader.py
@@ -7,7 +7,7 @@ from jinja2 import Environment, FileSystemLoader
 from conan.tools.env.environment import ProfileEnvironment
 from conans.client.loader import load_python_file
 from conans.errors import ConanException
-from conans.model.conf import ConfDefinition
+from conans.model.conf import ConfDefinition, CORE_CONF_PATTERN
 from conans.model.options import Options
 from conans.model.profile import Profile
 from conans.model.recipe_ref import RecipeReference
@@ -118,6 +118,9 @@ class ProfileLoader:
         """ Return a Profile object, as the result of merging a potentially existing Profile
         file and the args command-line arguments
         """
+        if conf and any(CORE_CONF_PATTERN.match(c) for c in conf):
+            raise ConanException("[conf] 'core.*' configurations are not allowed in profiles.")
+
         result = Profile()
         for p in profiles:
             tmp = self.load_profile(p, cwd)

--- a/conans/model/conf.py
+++ b/conans/model/conf.py
@@ -38,6 +38,7 @@ BUILT_IN_CONFS = {
     "tools.build:skip_test": "Do not execute CMake.test() and Meson.test() when enabled",
     "tools.build:jobs": "Default compile jobs number -jX Ninja, Make, /MP VS (default: max CPUs)",
     "tools.build:sysroot": "Pass the --sysroot=<tools.build:sysroot> flag if available. (None by default)",
+    "tools.build.cross_building:can_run": "",
     "tools.cmake.cmaketoolchain:generator": "User defined CMake generator to use instead of default",
     "tools.cmake.cmaketoolchain:find_package_prefer_config": "Argument for the CMAKE_FIND_PACKAGE_PREFER_CONFIG",
     "tools.cmake.cmaketoolchain:toolchain_file": "Use other existing file rather than conan_toolchain.cmake one",

--- a/conans/model/conf.py
+++ b/conans/model/conf.py
@@ -14,6 +14,12 @@ BUILT_IN_CONFS = {
     "core.download:parallel": "Number of concurrent threads to download packages",
     "core.download:retry": "Number of retries in case of failure when downloading from Conan server",
     "core.download:retry_wait": "Seconds to wait between download attempts from Conan server",
+    # Package ID
+    "core.package_id:default_unknown_mode": "By default, 'semver_mode'",
+    "core.package_id:default_non_embed_mode": "By default, 'minor_mode'",
+    "core.package_id:default_embed_mode": "By default, 'full_mode'",
+    "core.package_id:default_python_mode": "By default, 'minor_mode'",
+    "core.package_id:default_build_mode": "",
     # General HTTP(python-requests) configuration
     "core.net.http:max_retries": "Maximum number of connection retries (requests library)",
     "core.net.http:timeout": "Number of seconds without response to timeout (requests library)",
@@ -68,6 +74,8 @@ BUILT_IN_CONFS = {
     "tools.build:defines": "List of extra definition flags used by different toolchains like CMakeToolchain and AutotoolsToolchain",
     "tools.build:sharedlinkflags": "List of extra flags used by CMakeToolchain for CMAKE_SHARED_LINKER_FLAGS_INIT variable",
     "tools.build:exelinkflags": "List of extra flags used by CMakeToolchain for CMAKE_EXE_LINKER_FLAGS_INIT variable",
+    # Package ID composition
+    "tools.info.package_id:confs": "List of existing configuration to be part of the package ID",
 }
 
 

--- a/conans/model/conf.py
+++ b/conans/model/conf.py
@@ -53,6 +53,7 @@ BUILT_IN_CONFS = {
     "tools.files.download:retry_wait": "Seconds to wait between download attempts",
     "tools.gnu:make_program": "Indicate path to make program",
     "tools.gnu:define_libcxx11_abi": "Force definition of GLIBCXX_USE_CXX11_ABI=1 for libstdc++11",
+    "tools.gnu:pkg_config": "Path to pkg-config executable used by PkgConfig build helper",
     "tools.google.bazel:configs": "Define Bazel config file",
     "tools.google.bazel:bazelrc_path": "Defines Bazel rc-path",
     "tools.meson.mesontoolchain:backend": "Any Meson backend: ninja, vs, vs2010, vs2012, vs2013, vs2015, vs2017, vs2019, xcode",

--- a/conans/model/conf.py
+++ b/conans/model/conf.py
@@ -15,6 +15,7 @@ BUILT_IN_CONFS = {
     "core.download:parallel": "Number of concurrent threads to download packages",
     "core.download:retry": "Number of retries in case of failure when downloading from Conan server",
     "core.download:retry_wait": "Seconds to wait between download attempts from Conan server",
+    "core.download:download_cache": "",
     # Package ID
     "core.package_id:default_unknown_mode": "By default, 'semver_mode'",
     "core.package_id:default_non_embed_mode": "By default, 'minor_mode'",
@@ -32,6 +33,7 @@ BUILT_IN_CONFS = {
     # Gzip compression
     "core.gzip:compresslevel": "The Gzip compresion level for Conan artifacts (default=9)",
     # Tools
+    "tools.files.download:download_cache": "",
     "tools.android:ndk_path": "Argument for the CMAKE_ANDROID_NDK",
     "tools.build:skip_test": "Do not execute CMake.test() and Meson.test() when enabled",
     "tools.build:jobs": "Default compile jobs number -jX Ninja, Make, /MP VS (default: max CPUs)",

--- a/conans/model/conf.py
+++ b/conans/model/conf.py
@@ -15,7 +15,7 @@ BUILT_IN_CONFS = {
     "core.download:parallel": "Number of concurrent threads to download packages",
     "core.download:retry": "Number of retries in case of failure when downloading from Conan server",
     "core.download:retry_wait": "Seconds to wait between download attempts from Conan server",
-    "core.download:download_cache": "",
+    "core.download:download_cache": "Download folder used by Rest API methods",
     # Package ID
     "core.package_id:default_unknown_mode": "By default, 'semver_mode'",
     "core.package_id:default_non_embed_mode": "By default, 'minor_mode'",
@@ -33,12 +33,13 @@ BUILT_IN_CONFS = {
     # Gzip compression
     "core.gzip:compresslevel": "The Gzip compresion level for Conan artifacts (default=9)",
     # Tools
-    "tools.files.download:download_cache": "",
+    "tools.files.download:download_cache": "Download folder to be used by 'download' tool and only if a checksum is provided",
     "tools.android:ndk_path": "Argument for the CMAKE_ANDROID_NDK",
     "tools.build:skip_test": "Do not execute CMake.test() and Meson.test() when enabled",
     "tools.build:jobs": "Default compile jobs number -jX Ninja, Make, /MP VS (default: max CPUs)",
     "tools.build:sysroot": "Pass the --sysroot=<tools.build:sysroot> flag if available. (None by default)",
-    "tools.build.cross_building:can_run": "",
+    "tools.build.cross_building:can_run": "Bool value that indicates whether is possible to run a non-native "
+                                          "app on the same architecture. It's used by 'can_run' tool",
     "tools.cmake.cmaketoolchain:generator": "User defined CMake generator to use instead of default",
     "tools.cmake.cmaketoolchain:find_package_prefer_config": "Argument for the CMAKE_FIND_PACKAGE_PREFER_CONFIG",
     "tools.cmake.cmaketoolchain:toolchain_file": "Use other existing file rather than conan_toolchain.cmake one",
@@ -46,7 +47,7 @@ BUILT_IN_CONFS = {
     "tools.cmake.cmaketoolchain:system_name": "Define CMAKE_SYSTEM_NAME in CMakeToolchain",
     "tools.cmake.cmaketoolchain:system_version": "Define CMAKE_SYSTEM_VERSION in CMakeToolchain",
     "tools.cmake.cmaketoolchain:system_processor": "Define CMAKE_SYSTEM_PROCESSOR in CMakeToolchain",
-    "tools.cmake.cmaketoolchain:toolset_arch": "",
+    "tools.cmake.cmaketoolchain:toolset_arch": "Toolset architecture to be used as part of CMAKE_GENERATOR_TOOLSET in CMakeToolchain",
     "tools.cmake.cmake_layout:build_folder_vars": "Settings and Options that will produce a different build folder and different CMake presets names",
     "tools.files.download:retry": "Number of retries in case of failure when downloading",
     "tools.files.download:retry_wait": "Seconds to wait between download attempts",
@@ -54,6 +55,7 @@ BUILT_IN_CONFS = {
     "tools.gnu:define_libcxx11_abi": "Force definition of GLIBCXX_USE_CXX11_ABI=1 for libstdc++11",
     "tools.google.bazel:configs": "Define Bazel config file",
     "tools.google.bazel:bazelrc_path": "Defines Bazel rc-path",
+    "tools.meson.mesontoolchain:backend": "Any Meson backend: ninja, vs, vs2010, vs2012, vs2013, vs2015, vs2017, vs2019, xcode",
     "tools.microsoft.msbuild:verbosity": "Verbosity level for MSBuild: 'Quiet', 'Minimal', 'Normal', 'Detailed', 'Diagnostic'",
     "tools.microsoft.msbuild:vs_version": "Defines the IDE version when using the new msvc compiler",
     "tools.microsoft.msbuild:max_cpu_count": "Argument for the /m when running msvc to build parallel projects",
@@ -73,7 +75,7 @@ BUILT_IN_CONFS = {
     "tools.apple:enable_bitcode": "(boolean) Enable/Disable Bitcode Apple Clang flags",
     "tools.apple:enable_arc": "(boolean) Enable/Disable ARC Apple Clang flags",
     "tools.apple:enable_visibility": "(boolean) Enable/Disable Visibility Apple Clang flags",
-    "tools.env.virtualenv:powershell": "",
+    "tools.env.virtualenv:powershell": "If it is set to True it will generate powershell launchers if os=Windows",
     # Flags configuration
     "tools.build:cxxflags": "List of extra CXX flags used by different toolchains like CMakeToolchain, AutotoolsToolchain and MesonToolchain",
     "tools.build:cflags": "List of extra C flags used by different toolchains like CMakeToolchain, AutotoolsToolchain and MesonToolchain",

--- a/conans/test/integration/command/config_test.py
+++ b/conans/test/integration/command/config_test.py
@@ -1,5 +1,7 @@
+import json
 import os
 
+from conans.model.conf import BUILT_IN_CONFS
 from conans.test.assets.genconanfile import GenConanfile
 from conans.test.utils.test_files import temp_folder
 from conans.test.utils.tools import TestClient
@@ -45,3 +47,15 @@ def test_config_home_custom_install():
         client.save({"conanfile.py": GenConanfile()})
         client.run("install .")
         assert "Installing (downloading, building) binaries" in client.out
+
+
+def test_config_list():
+    """
+    'conan config list' shows all the built-in Conan configurations
+    """
+    client = TestClient()
+    client.run("config list")
+    for k, v in BUILT_IN_CONFS.items():
+        assert f"{k}: {v}" in client.out
+    client.run("config list --format=json")
+    assert json.dumps(BUILT_IN_CONFS, indent=4) == client.stdout

--- a/conans/test/integration/configuration/test_profile_jinja.py
+++ b/conans/test/integration/configuration/test_profile_jinja.py
@@ -57,14 +57,14 @@ def test_profile_template_profile_dir():
     client = TestClient()
     tpl1 = textwrap.dedent("""
         [conf]
-        tools.toolchain:mydir = {{ os.path.join(profile_dir, "toolchain.cmake") }}
+        user.toolchain:mydir = {{ os.path.join(profile_dir, "toolchain.cmake") }}
         """)
     conanfile = textwrap.dedent("""
         from conan import ConanFile
         from conan.tools.files import load
         class Pkg(ConanFile):
             def generate(self):
-                content = load(self, self.conf.get("tools.toolchain:mydir"))
+                content = load(self, self.conf.get("user.toolchain:mydir"))
                 self.output.info("CONTENT: {}".format(content))
         """)
     client.save({"conanfile.py": conanfile,

--- a/conans/test/integration/package_id/package_id_and_confs_test.py
+++ b/conans/test/integration/package_id/package_id_and_confs_test.py
@@ -12,7 +12,7 @@ PKG_ID_3 = "45b796ec237c7e2399944e79bee49b56fd022067"
 
 @pytest.mark.parametrize("package_id_confs, package_id", [
     ('[]', PKG_ID_NO_CONF),
-    ('["tools.fake:no_existing_conf"]', PKG_ID_NO_CONF),
+    ('["user.fake:no_existing_conf"]', PKG_ID_NO_CONF),
     ('["tools.build:cxxflags", "tools.build:cflags"]', PKG_ID_1),
     ('["tools.build:defines"]', PKG_ID_2),
     ('["tools.build:cxxflags", "tools.build:sharedlinkflags"]', PKG_ID_3),

--- a/conans/test/unittests/cli/common_test.py
+++ b/conans/test/unittests/cli/common_test.py
@@ -15,12 +15,7 @@ from conans.test.utils.test_files import temp_folder
 def conan_api():
     tmp_folder = temp_folder()
     cache = ClientCache(tmp_folder)
-    save(None, cache.default_profile_path, textwrap.dedent("""\
-        [settings]
-        [options]
-        [tool_requires]
-        [conf]
-    """))
+    save(None, cache.default_profile_path, "")
     return ConanAPIV2(tmp_folder)
 
 

--- a/conans/test/unittests/cli/common_test.py
+++ b/conans/test/unittests/cli/common_test.py
@@ -1,0 +1,51 @@
+import textwrap
+from unittest.mock import MagicMock
+
+import pytest
+
+from conan.api.conan_api import ConanAPIV2
+from conan.tools.files import save
+from conans.cli.common import get_profiles_from_args
+from conans.client.cache.cache import ClientCache
+from conans.errors import ConanException
+from conans.test.utils.test_files import temp_folder
+
+
+@pytest.fixture()
+def conan_api():
+    tmp_folder = temp_folder()
+    cache = ClientCache(tmp_folder)
+    save(None, cache.default_profile_path, textwrap.dedent("""\
+        [settings]
+        [options]
+        [tool_requires]
+        [conf]
+    """))
+    return ConanAPIV2(tmp_folder)
+
+
+@pytest.fixture()
+def argparse_args():
+    return MagicMock(
+        profile_build=None,
+        profile_host=None,
+        settings_build=None,
+        settings_host=None,
+        options_build=None,
+        options_host=None,
+        conf_build=None,
+        conf_host=None
+    )
+
+
+@pytest.mark.parametrize("conf_name", [
+    "core.doesnotexist:never",
+    "core:doesnotexist"
+])
+def test_core_confs_not_allowed_via_cli(conan_api, argparse_args, conf_name):
+    argparse_args.conf_build = [conf_name]
+    argparse_args.conf_host = [conf_name]
+
+    with pytest.raises(ConanException) as exc:
+        get_profiles_from_args(conan_api, argparse_args)
+    assert "[conf] 'core.*' configurations are not allowed in profiles" in str(exc.value)


### PR DESCRIPTION
Changelog: Bugfix: Fixed the wrong behavior about writing `-c core.xxx=value` via CLI.
Changelog: Feature: Raising an exception if the internal configuration is used and it does not exist in the configuration list. It only affects `tools*` and `core*` ones.
Changelog: Feature: Brought `conan config list` command back.
Docs: https://github.com/conan-io/docs/pull/XXXX
Closes: https://github.com/conan-io/conan/issues/11346
