### PR TITLE
validate_build over settings

### DIFF
--- a/conans/client/conan_command_output.py
+++ b/conans/client/conan_command_output.py
@@ -140,6 +140,10 @@ class CommandOutputer(object):
             item_data["build_id"] = build_id(conanfile)
             item_data["context"] = conanfile.context
 
+            item_data["invalid_build"] = node.cant_build is not False
+            if node.cant_build:
+                item_data["invalid_build_reason"] = node.cant_build
+
             python_requires = getattr(conanfile, "python_requires", None)
             if python_requires and not isinstance(python_requires, dict):  # no old python requires
                 item_data["python_requires"] = [repr(r)

--- a/conans/client/graph/graph.py
+++ b/conans/client/graph/graph.py
@@ -91,6 +91,8 @@ class Node(object):
         self.id_direct_prefs = None
         self.id_indirect_prefs = None
 
+        self.cant_build = False  # It will set to a str with a reason if the validate_build() fails
+
     @property
     def id(self):
         return self._id

--- a/conans/client/graph/graph_binaries.py
+++ b/conans/client/graph/graph_binaries.py
@@ -52,7 +52,7 @@ class GraphBinariesAnalyzer(object):
                 node.binary = BINARY_INVALID
             else:
                 node.binary = BINARY_BUILD
-                node.prev = None
+            node.prev = None
             return True
 
     def _evaluate_clean_pkg_folder_dirty(self, node, package_layout, pref):
@@ -308,7 +308,7 @@ class GraphBinariesAnalyzer(object):
                         node.binary = BINARY_INVALID
                     else:
                         node.binary = BINARY_BUILD
-                        node.prev = None
+                    node.prev = None
                 else:
                     conanfile.output.info("Package is up to date")
 

--- a/conans/client/graph/graph_binaries.py
+++ b/conans/client/graph/graph_binaries.py
@@ -414,6 +414,14 @@ class GraphBinariesAnalyzer(object):
                 except ConanInvalidConfiguration as e:
                     conanfile.info.invalid = str(e)
 
+        if hasattr(conanfile, "validate_build") and callable(conanfile.validate_build):
+            with conanfile_exception_formatter(str(conanfile), "validate_build"):
+                try:
+                    conanfile.validate_build()
+                except ConanInvalidConfiguration as e:
+                    # This 'cant_build' will be ignored if we don't have to build the node.
+                    node.cant_build = str(e)
+
         info = conanfile.info
         node.package_id = info.package_id()
 

--- a/conans/client/graph/graph_builder.py
+++ b/conans/client/graph/graph_builder.py
@@ -66,17 +66,6 @@ class DepsGraphBuilder(object):
         self._expand_node(root_node, dep_graph, Requirements(), None, None, check_updates,
                           update, remotes, profile_host, profile_build, graph_lock)
 
-        # Check if the nodes can be built or not
-        for node in dep_graph.nodes:
-            dep_conanfile = node.conanfile
-            if hasattr(dep_conanfile, "validate_build") and callable(dep_conanfile.validate_build):
-                with conanfile_exception_formatter(str(dep_conanfile), "validate_build"):
-                    try:
-                        dep_conanfile.validate_build()
-                    except ConanInvalidConfiguration as e:
-                        # This 'cant_build' will be ignored if we don't have to build the node.
-                        node.cant_build = str(e)
-
         logger.debug("GRAPH: Time to load deps %s" % (time.time() - t1))
 
         return dep_graph

--- a/conans/client/graph/graph_manager.py
+++ b/conans/client/graph/graph_manager.py
@@ -9,7 +9,7 @@ from conans.client.graph.graph import BINARY_BUILD, Node, CONTEXT_HOST, CONTEXT_
 from conans.client.graph.graph_binaries import RECIPE_CONSUMER, RECIPE_VIRTUAL, BINARY_EDITABLE, \
     BINARY_UNKNOWN
 from conans.client.graph.graph_builder import DepsGraphBuilder
-from conans.errors import ConanException, conanfile_exception_formatter
+from conans.errors import ConanException, conanfile_exception_formatter, ConanInvalidConfiguration
 from conans.model.conan_file import get_env_context_manager
 from conans.model.graph_info import GraphInfo
 from conans.model.graph_lock import GraphLock, GraphLockFile
@@ -124,6 +124,7 @@ class GraphManager(object):
         root_node = self._load_root_node(reference, create_reference, profile_host, graph_lock,
                                          root_ref, lockfile_node_id, is_build_require,
                                          require_overrides)
+
         deps_graph = self._resolve_graph(root_node, profile_host, profile_build, graph_lock,
                                          build_mode, check_updates, update, remotes, recorder,
                                          apply_build_requires=apply_build_requires)

--- a/conans/client/graph/graph_manager.py
+++ b/conans/client/graph/graph_manager.py
@@ -9,7 +9,7 @@ from conans.client.graph.graph import BINARY_BUILD, Node, CONTEXT_HOST, CONTEXT_
 from conans.client.graph.graph_binaries import RECIPE_CONSUMER, RECIPE_VIRTUAL, BINARY_EDITABLE, \
     BINARY_UNKNOWN
 from conans.client.graph.graph_builder import DepsGraphBuilder
-from conans.errors import ConanException, conanfile_exception_formatter, ConanInvalidConfiguration
+from conans.errors import ConanException, conanfile_exception_formatter
 from conans.model.conan_file import get_env_context_manager
 from conans.model.graph_info import GraphInfo
 from conans.model.graph_lock import GraphLock, GraphLockFile

--- a/conans/client/installer.py
+++ b/conans/client/installer.py
@@ -423,7 +423,13 @@ class BinaryInstaller(object):
         if invalid:
             msg = ["There are invalid packages (packages that cannot exist for this configuration):"]
             for node in invalid:
-                msg.append("{}: Invalid ID: {}".format(node.conanfile, node.conanfile.info.invalid))
+                if node.cant_build:
+                    msg.append("{}: Cannot build "
+                               "for this configuration: {}".format(node.conanfile,
+                                                                   node.cant_build))
+                else:
+                    msg.append("{}: Invalid ID: {}".format(node.conanfile,
+                                                           node.conanfile.info.invalid))
             raise ConanInvalidConfiguration("\n".join(msg))
         self._raise_missing(missing)
         processed_package_refs = {}

--- a/conans/test/integration/graph/test_validate_build.py
+++ b/conans/test/integration/graph/test_validate_build.py
@@ -1,0 +1,42 @@
+import textwrap
+
+from conans.test.utils.tools import TestClient
+
+
+def test_basic_validate_build_test():
+
+    t = TestClient()
+    conanfile = textwrap.dedent("""
+    from conan import ConanFile
+    from conans.errors import ConanInvalidConfiguration
+
+    class myConan(ConanFile):
+        name = "foo"
+        version = "1.0"
+        settings = "os", "arch", "compiler"
+
+        def validate_build(self):
+            if self.settings.compiler == "gcc":
+                raise ConanInvalidConfiguration("This doesn't build in GCC")
+
+        def package_id(self):
+            del self.info.settings.compiler
+    """)
+
+    settings_gcc = "-s compiler=gcc -s compiler.libcxx=libstdc++11 -s compiler.version=11"
+    settings_clang = "-s compiler=clang -s compiler.libcxx=libc++ -s compiler.version=8"
+
+    t.save({"conanfile.py": conanfile})
+    t.run(f"create . {settings_gcc}", assert_error=True)
+
+    assert "This doesn't build in GCC" in t.out
+
+    t.run(f"create . {settings_clang}")
+
+    # Now with GCC again, but now we have the binary, we don't need to build, so it doesn't fail
+    t.run(f"create . {settings_gcc} --build missing")
+    assert "foo/1.0: Already installed!" in t.out
+
+    # But if I force the build... it will fail
+    t.run(f"create . {settings_gcc} ", assert_error=True)
+    assert "This doesn't build in GCC" in t.out

--- a/conans/test/integration/graph/test_validate_build.py
+++ b/conans/test/integration/graph/test_validate_build.py
@@ -1,6 +1,7 @@
 import json
 import textwrap
 
+from conans.test.assets.genconanfile import GenConanfile
 from conans.test.utils.tools import TestClient
 
 
@@ -73,15 +74,7 @@ def test_with_options_validate_build_test():
     """)
     t.save({"conanfile.py": conanfile})
     t.run("export .")
-    consumer = textwrap.dedent("""
-        from conan import ConanFile
-        from conans.errors import ConanInvalidConfiguration
-
-        class myConan(ConanFile):
-            name = "consumer"
-            version = "1.0"
-            requires = "foo/1.0"
-        """)
+    consumer = GenConanfile().with_require("foo/1.0").with_name("consumer").with_version("1.0")
     t.save({"consumer.py": consumer})
     t.run("create consumer.py --build missing -o foo/*:my_option=False", assert_error=True)
     assert "foo/1.0: Cannot build for this configuration: This doesn't build " \


### PR DESCRIPTION
Changelog: Feature: Introduced a `validate_build()` method in the recipes to validate if the package can be built according to `self.settings` and `self.options` instead of `self.info.settings` and `self.info.options` that it is used to validate the `binary`.
Docs: https://github.com/conan-io/docs/pull/2667
