### PR TITLE
[develop2] managing options conflicts with profiles priority

### DIFF
--- a/conans/client/graph/graph_builder.py
+++ b/conans/client/graph/graph_builder.py
@@ -1,10 +1,9 @@
 import copy
-import fnmatch
 from collections import deque
 
 from conans.client.conanfile.configure import run_configure_method
-from conans.client.graph.graph import DepsGraph, Node, RECIPE_EDITABLE, CONTEXT_HOST, \
-    CONTEXT_BUILD, RECIPE_CONSUMER, TransitiveRequirement, RECIPE_VIRTUAL
+from conans.client.graph.graph import DepsGraph, Node, CONTEXT_HOST, \
+    CONTEXT_BUILD, TransitiveRequirement, RECIPE_VIRTUAL
 from conans.client.graph.graph_error import GraphError
 from conans.client.graph.profile_node_definer import initialize_conanfile_profile
 from conans.client.graph.provides import check_graph_provides
@@ -79,10 +78,6 @@ class DepsGraphBuilder(object):
             else:
                 self._conflicting_version(require, node, prev_require, prev_node,
                                           prev_ref, base_previous)
-                if prev_node is not None:  # Conflicts cannot be checked if not expanded yet
-                    # and prev_node is None if it hasn't been expanded yet (half-diamonds, overrides)
-                    self._conflicting_options(require, node, prev_node, prev_require, base_previous,
-                                              profile_host, profile_build)
 
         if prev_node is None:
             # new node, must be added and expanded (node -> new_node)
@@ -132,35 +127,6 @@ class DepsGraphBuilder(object):
             conflict = _conflicting_refs(prev_ref, require.ref)
             if conflict:  # It is possible to get conflict from alias, try to resolve it
                 raise GraphError.conflict(node, require, prev_node, prev_require, base_previous)
-
-    @staticmethod
-    def _conflicting_options(require, node, prev_node, prev_require, base_previous, profile_host,
-                             profile_build):
-        # Even if the version matches, there still can be a configuration conflict
-        # Only the propagated options can conflict, because profile would have already been asigned
-        is_consumer = node.conanfile._conan_is_consumer
-
-        def _get_profile_value(option):
-            # We apply the same logic when the profile options are actually applied to the package
-            context = CONTEXT_BUILD if require.build else node.context
-            profile_options = profile_build.options if context == CONTEXT_BUILD \
-                else profile_host.options
-            option_value = None
-            for pattern, profile_pkg_options in profile_options._deps_package_options.items():
-                if ref_matches(require.ref, pattern, is_consumer=is_consumer):
-                    match_value = profile_pkg_options.get_safe(option)
-                    option_value = match_value if match_value is not None else option_value
-            return option_value
-
-        upstream_options = node.conanfile.up_options.get(require.ref, is_consumer)
-        for k, v in upstream_options.items():
-            prev_option = prev_node.conanfile.options.get_safe(k)
-            if prev_option is not None:
-                if prev_option != v:
-                    profile_value = _get_profile_value(k)
-                    if profile_value is None or profile_value != prev_option:
-                        raise GraphError.conflict_config(node, require, prev_node, prev_require,
-                                                         base_previous, k, prev_option, v)
 
     @staticmethod
     def _prepare_node(node, profile_host, profile_build, down_options):

--- a/conans/client/graph/graph_error.py
+++ b/conans/client/graph/graph_error.py
@@ -6,7 +6,6 @@ class GraphError(ConanException):
     LOOP = "graph loop"
     VERSION_CONFLICT = "version conflict"
     PROVIDE_CONFLICT = "provide conflict"
-    CONFIG_CONFLICT = "configuration conflict"
     MISSING_RECIPE = "missing recipe"
     RUNTIME = "runtime"
 
@@ -64,23 +63,6 @@ class GraphError(ConanException):
         result.prev_node = prev_node
         result.prev_require = prev_require
         result.base_previous = base_previous
-        node.error = base_previous.error = result
-        if prev_node:
-            prev_node.error = result
-        return result
-
-    @staticmethod
-    def conflict_config(node, require, prev_node, prev_require, base_previous,
-                        option, previous_value, new_value):
-        result = GraphError(GraphError.CONFIG_CONFLICT)
-        result.node = node
-        result.require = require
-        result.prev_node = prev_node
-        result.prev_require = prev_require
-        result.base_previous = base_previous
-        result.option = option
-        result.previous_value = previous_value
-        result.new_value = new_value
         node.error = base_previous.error = result
         if prev_node:
             prev_node.error = result


### PR DESCRIPTION
Investigate https://github.com/conan-io/conan/issues/11571

After some discussions, this PR is proposing:

- Removing options conflict in Conan 2.0. They are simply too problematic, complicated, fragile and confusing to users
- Recipes defining options for their dependencies propagate according to priorities. First one to define wins. Downstream recipes defining things have precedence. Profiles and command line defined options has highest precedence, they should always be respected, even if recipes says a different thing
- Recipes that will definitely not work with some of their dependencies having some invalid option values, should raise ``ConanErrorConfiguration`` in the ``validate()`` method