### PR TITLE
[develop2] new pre/post_generate() and post_build_fail hooks

### DIFF
--- a/conan/api/subapi/install.py
+++ b/conan/api/subapi/install.py
@@ -50,7 +50,8 @@ class InstallAPI:
         _do_deploys(self.conan_api, deps_graph, deploy, base_folder)
 
         conanfile.generators = list(set(conanfile.generators).union(generators or []))
-        write_generators(conanfile)
+        app = ConanApp(self.conan_api.cache_folder)
+        write_generators(conanfile, app.hook_manager)
         call_system_requirements(conanfile)
 
 

--- a/conans/client/conanfile/build.py
+++ b/conans/client/conanfile/build.py
@@ -8,5 +8,9 @@ def run_build_method(conanfile, hook_manager):
         hook_manager.execute("pre_build", conanfile=conanfile)
         conanfile.output.highlight("Calling build()")
         with conanfile_exception_formatter(conanfile, "build"):
-            conanfile.build()
+            try:
+                conanfile.build()
+            except Exception:
+                hook_manager.execute("post_build_fail", conanfile=conanfile)
+                raise
         hook_manager.execute("post_build", conanfile=conanfile)

--- a/conans/client/generators/__init__.py
+++ b/conans/client/generators/__init__.py
@@ -79,7 +79,6 @@ def write_generators(conanfile, hook_manager):
     new_gen_folder = conanfile.generators_folder
     _receive_conf(conanfile)
 
-    # TODO: Should this apply to the ``generate()`` method only?
     hook_manager.execute("pre_generate", conanfile=conanfile)
 
     for generator_name in set(conanfile.generators):

--- a/conans/client/generators/__init__.py
+++ b/conans/client/generators/__init__.py
@@ -75,9 +75,12 @@ def _get_generator_class(generator_name):
                              "not complete".format(generator_name))
 
 
-def write_generators(conanfile):
+def write_generators(conanfile, hook_manager):
     new_gen_folder = conanfile.generators_folder
     _receive_conf(conanfile)
+
+    # TODO: Should this apply to the ``generate()`` method only?
+    hook_manager.execute("pre_generate", conanfile=conanfile)
 
     for generator_name in set(conanfile.generators):
         generator_class = _get_generator_class(generator_name)
@@ -116,6 +119,8 @@ def write_generators(conanfile):
 
     conanfile.output.highlight("Aggregating env generators")
     _generate_aggregated_env(conanfile)
+
+    hook_manager.execute("post_generate", conanfile=conanfile)
 
 
 def _receive_conf(conanfile):

--- a/conans/client/hook_manager.py
+++ b/conans/client/hook_manager.py
@@ -5,7 +5,8 @@ from conans.errors import ConanException
 
 valid_hook_methods = ["pre_export", "post_export",
                       "pre_source", "post_source",
-                      "pre_build", "post_build",
+                      "pre_generate", "post_generate",
+                      "pre_build", "post_build", "post_build_fail",
                       "pre_package", "post_package",
                       "pre_package_info", "post_package_info"]
 

--- a/conans/client/installer.py
+++ b/conans/client/installer.py
@@ -106,7 +106,7 @@ class _PackageBuilder(object):
                 raise ConanException("%s\nError copying sources to build folder" % msg)
 
     def _build(self, conanfile, pref):
-        write_generators(conanfile)
+        write_generators(conanfile, self._hook_manager)
 
         try:
             run_build_method(conanfile, self._hook_manager)
@@ -304,7 +304,7 @@ class BinaryInstaller:
         output = conanfile.output
         output.info("Rewriting files of editable package "
                     "'{}' at '{}'".format(conanfile.name, conanfile.generators_folder))
-        write_generators(conanfile)
+        write_generators(conanfile, self._hook_manager)
         call_system_requirements(conanfile)
 
         if node.binary == BINARY_EDITABLE_BUILD:


### PR DESCRIPTION
Close https://github.com/conan-io/conan/issues/11554 (adding a ``post_build_fail`` hook that is called when a build fail)
Close https://github.com/conan-io/conan/issues/11094 (adding ``pre_generate`` and ``post_generate`` hook, covering the generation of files, a bit more than just the ``generate()`` method call)

