### PR TITLE
Fix CMake.test() target for Ninja Multi-Config

### DIFF
--- a/conan/tools/cmake/cmake.py
+++ b/conan/tools/cmake/cmake.py
@@ -153,7 +153,8 @@ class CMake(object):
             return
         if not target:
             is_multi = is_multi_configuration(self._generator)
-            target = "RUN_TESTS" if is_multi else "test"
+            is_ninja = "Ninja" in self._generator
+            target = "RUN_TESTS" if is_multi and not is_ninja else "test"
 
         self._build(build_type=build_type, target=target, cli_args=cli_args,
                     build_tool_args=build_tool_args)

--- a/conans/test/unittests/tools/cmake/test_cmake_test.py
+++ b/conans/test/unittests/tools/cmake/test_cmake_test.py
@@ -1,3 +1,4 @@
+import platform
 import pytest
 
 from conan.tools.cmake import CMake
@@ -39,4 +40,6 @@ def test_run_tests(generator, target):
     write_cmake_presets(conanfile, "toolchain", generator, {})
     cmake = CMake(conanfile)
     cmake.test()
-    assert "'--target' '%s'" % target in conanfile.command
+
+    search_pattern = "--target {}" if platform.system() == "Windows" else "'--target' '{}'"
+    assert search_pattern.format(target) in conanfile.command

--- a/conans/test/unittests/tools/cmake/test_cmake_test.py
+++ b/conans/test/unittests/tools/cmake/test_cmake_test.py
@@ -1,0 +1,42 @@
+import pytest
+
+from conan.tools.cmake import CMake
+from conan.tools.cmake.presets import write_cmake_presets
+from conans.client.conf import get_default_settings_yml
+from conans.model.conf import Conf
+from conans.model.settings import Settings
+from conans.test.utils.mocks import ConanFileMock
+from conans.test.utils.test_files import temp_folder
+
+
+@pytest.mark.parametrize("generator,target", [
+    ("NMake Makefiles", "test"),
+    ("Ninja Makefiles", "test"),
+    ("Ninja Multi-Config", "test"),
+    ("Unix Makefiles", "test"),
+    ("Visual Studio 14 2015", "RUN_TESTS"),
+    ("Xcode", "RUN_TESTS"),
+])
+def test_run_tests(generator, target):
+    """
+    Testing that the proper test target is picked for different generators, especially multi-config ones.
+    Issue related: https://github.com/conan-io/conan/issues/11405
+    """
+    settings = Settings.loads(get_default_settings_yml())
+    settings.os = "Windows"
+    settings.arch = "x86"
+    settings.build_type = "Release"
+    settings.compiler = "Visual Studio"
+    settings.compiler.runtime = "MDd"
+    settings.compiler.version = "14"
+
+    conanfile = ConanFileMock()
+    conanfile.conf = Conf()
+    conanfile.folders.generators = "."
+    conanfile.folders.set_base_generators(temp_folder())
+    conanfile.settings = settings
+
+    write_cmake_presets(conanfile, "toolchain", generator, {})
+    cmake = CMake(conanfile)
+    cmake.test()
+    assert "'--target' '%s'" % target in conanfile.command


### PR DESCRIPTION
Changelog: Bugfix: Use correct build target in `CMake.test()` for the Ninja Multi-Config generator.
Docs: omit
Fixes #11405 