### PR TITLE
[MesonToolchain] Adding default dirs

### DIFF
--- a/conan/tools/meson/meson.py
+++ b/conan/tools/meson/meson.py
@@ -54,6 +54,8 @@ class Meson(object):
         self._conanfile.run(cmd)
 
     def test(self):
+        if self._conanfile.conf.get("tools.build:skip_test"):
+            return
         meson_build_folder = self._conanfile.build_folder
         cmd = 'meson test -v -C "{}"'.format(meson_build_folder)
         # TODO: Do we need vcvars for test?

--- a/conans/assets/templates/new_v2_meson.py
+++ b/conans/assets/templates/new_v2_meson.py
@@ -37,11 +37,6 @@ class {package_name}Conan(ConanFile):
     def package(self):
         meson = Meson(self)
         meson.install()
-        # Meson cannot install dll/so in "bin" and .a/.lib in "lib"
-        lib = os.path.join(self.package_folder, "lib")
-        bin = os.path.join(self.package_folder, "bin")
-        copy(self, "*.so", lib, bin)
-        copy(self, "*.dll", lib, bin)
 
     def package_info(self):
         self.cpp_info.libs = ["{name}"]
@@ -86,7 +81,7 @@ executable('example', 'src/example.cpp', dependencies: {name})
 
 _meson_build = """\
 project('{name} ', 'cpp')
-library('{name}', 'src/{name}.cpp', install: true, install_dir: 'lib')
+library('{name}', 'src/{name}.cpp', install: true)
 install_headers('src/{name}.h')
 """
 

--- a/conans/test/functional/toolchains/meson/_base.py
+++ b/conans/test/functional/toolchains/meson/_base.py
@@ -19,7 +19,7 @@ class TestMesonBase(unittest.TestCase):
     def _settings(self):
         settings_macosx = {"compiler": "apple-clang",
                            "compiler.libcxx": "libc++",
-                           "compiler.version": "13.0",
+                           "compiler.version": "12.0",
                            "arch": "x86_64",
                            "build_type": "Release"}
 
@@ -47,7 +47,7 @@ class TestMesonBase(unittest.TestCase):
         if platform.system() == "Darwin":
             self.assertIn("main __x86_64__ defined", self.t.out)
             self.assertIn("main __apple_build_version__", self.t.out)
-            self.assertIn("main __clang_major__13", self.t.out)
+            self.assertIn("main __clang_major__12", self.t.out)
             # TODO: check why __clang_minor__ seems to be not defined in XCode 12
             # commented while migrating to XCode12 CI
             # self.assertIn("main __clang_minor__0", self.t.out)

--- a/conans/test/functional/toolchains/meson/_base.py
+++ b/conans/test/functional/toolchains/meson/_base.py
@@ -19,7 +19,7 @@ class TestMesonBase(unittest.TestCase):
     def _settings(self):
         settings_macosx = {"compiler": "apple-clang",
                            "compiler.libcxx": "libc++",
-                           "compiler.version": "12.0",
+                           "compiler.version": "13.0",
                            "arch": "x86_64",
                            "build_type": "Release"}
 
@@ -47,7 +47,7 @@ class TestMesonBase(unittest.TestCase):
         if platform.system() == "Darwin":
             self.assertIn("main __x86_64__ defined", self.t.out)
             self.assertIn("main __apple_build_version__", self.t.out)
-            self.assertIn("main __clang_major__12", self.t.out)
+            self.assertIn("main __clang_major__13", self.t.out)
             # TODO: check why __clang_minor__ seems to be not defined in XCode 12
             # commented while migrating to XCode12 CI
             # self.assertIn("main __clang_minor__0", self.t.out)

--- a/conans/test/functional/toolchains/meson/test_install.py
+++ b/conans/test/functional/toolchains/meson/test_install.py
@@ -30,8 +30,6 @@ class MesonInstall(TestMesonBase):
 
             def generate(self):
                 tc = MesonToolchain(self)
-                # https://mesonbuild.com/Release-notes-for-0-50-0.html#libdir-defaults-to-lib-when-cross-compiling
-                tc.project_options["libdir"] = "lib"
                 tc.generate()
 
             def build(self):
@@ -42,11 +40,6 @@ class MesonInstall(TestMesonBase):
             def package(self):
                 meson = Meson(self)
                 meson.install()
-
-                # https://mesonbuild.com/FAQ.html#why-does-building-my-project-with-msvc-output-static-libraries-called-libfooa
-                if self.settings.compiler == 'Visual Studio' and not self.options.shared:
-                    shutil.move(os.path.join(self.package_folder, "lib", "libhello.a"),
-                                os.path.join(self.package_folder, "lib", "hello.lib"))
 
             def package_info(self):
                 self.cpp_info.libs = ['hello']

--- a/conans/test/functional/toolchains/meson/test_install.py
+++ b/conans/test/functional/toolchains/meson/test_install.py
@@ -41,6 +41,11 @@ class MesonInstall(TestMesonBase):
                 meson = Meson(self)
                 meson.install()
 
+                # https://mesonbuild.com/FAQ.html#why-does-building-my-project-with-msvc-output-static-libraries-called-libfooa
+                if self.settings.compiler == 'Visual Studio' and not self.options.shared:
+                    shutil.move(os.path.join(self.package_folder, "lib", "libhello.a"),
+                                os.path.join(self.package_folder, "lib", "hello.lib"))
+
             def package_info(self):
                 self.cpp_info.libs = ['hello']
         """)

--- a/conans/test/functional/toolchains/meson/test_meson.py
+++ b/conans/test/functional/toolchains/meson/test_meson.py
@@ -137,5 +137,6 @@ class MesonToolchainTest(TestMesonBase):
             ext = "dylib" if platform.system() == "Darwin" else "so"
             assert os.path.exists(os.path.join(package_folder, "bin", "demo"))
             assert os.path.exists(os.path.join(package_folder, "lib", "libhello." + ext))
+        # res/tutorial -> tutorial is being added automatically by Meson
         assert os.path.exists(os.path.join(package_folder, "res", "tutorial", "file1.txt"))
         assert os.path.exists(os.path.join(package_folder, "res", "tutorial", "file2.txt"))

--- a/conans/test/functional/toolchains/meson/test_meson.py
+++ b/conans/test/functional/toolchains/meson/test_meson.py
@@ -1,4 +1,5 @@
 import os
+import platform
 import textwrap
 
 from conan.tools.files import replace_in_file
@@ -128,7 +129,13 @@ class MesonToolchainTest(TestMesonBase):
         ref = ConanFileReference.loads("hello/1.0")
         cache_package_folder = self.t.cache.package_layout(ref).packages()
         package_folder = os.path.join(cache_package_folder, os.listdir(cache_package_folder)[0])
-        assert os.path.exists(os.path.join(package_folder, "lib", "libhello.dylib"))
-        assert os.path.exists(os.path.join(package_folder, "bin", "demo"))
+        if platform.system() == "Windows":
+            assert os.path.exists(os.path.join(package_folder, "lib", "hello.lib"))
+            assert os.path.exists(os.path.join(package_folder, "bin", "hello.dll"))
+            assert os.path.exists(os.path.join(package_folder, "bin", "demo.exe"))
+        else:
+            ext = "dylib" if platform.system() == "Darwin" else "so"
+            assert os.path.exists(os.path.join(package_folder, "bin", "demo"))
+            assert os.path.exists(os.path.join(package_folder, "lib", "libhello." + ext))
         assert os.path.exists(os.path.join(package_folder, "res", "tutorial", "file1.txt"))
         assert os.path.exists(os.path.join(package_folder, "res", "tutorial", "file2.txt"))


### PR DESCRIPTION
Changelog: Feature: Adding default directories to MesonToolchain.
Docs: https://github.com/conan-io/docs/pull/2652

Closes: https://github.com/conan-io/conan/issues/9713 
Closes: https://github.com/conan-io/conan/issues/11596

**Note**: Using the `basic_layout` seems to be enough for now.
