### PR TITLE
MSBuildDeps avoid recursive PATH in LocalDebuggerEnvironment

### DIFF
--- a/conan/tools/microsoft/msbuilddeps.py
+++ b/conan/tools/microsoft/msbuilddeps.py
@@ -48,7 +48,8 @@ class MSBuildDeps(object):
           </ImportGroup>
           {% if host_context %}
           <PropertyGroup>
-            <LocalDebuggerEnvironment>$(Conan{{name}}BinaryDirectories)$(LocalDebuggerEnvironment)</LocalDebuggerEnvironment>
+            <ConanDebugPath>$(Conan{{name}}BinaryDirectories);$(ConanDebugPath)</ConanDebugPath>
+            <LocalDebuggerEnvironment>PATH=$(ConanDebugPath);%PATH%</LocalDebuggerEnvironment>
             <DebuggerFlavor>WindowsLocalDebugger</DebuggerFlavor>
             {% if ca_exclude %}
             <CAExcludePath>$(Conan{{name}}IncludeDirectories);$(CAExcludePath)</CAExcludePath>

--- a/conan/tools/microsoft/msbuilddeps.py
+++ b/conan/tools/microsoft/msbuilddeps.py
@@ -48,7 +48,7 @@ class MSBuildDeps(object):
           </ImportGroup>
           {% if host_context %}
           <PropertyGroup>
-            <LocalDebuggerEnvironment>PATH=%PATH%;$(Conan{{name}}BinaryDirectories)$(LocalDebuggerEnvironment)</LocalDebuggerEnvironment>
+            <LocalDebuggerEnvironment>$(Conan{{name}}BinaryDirectories)$(LocalDebuggerEnvironment)</LocalDebuggerEnvironment>
             <DebuggerFlavor>WindowsLocalDebugger</DebuggerFlavor>
             {% if ca_exclude %}
             <CAExcludePath>$(Conan{{name}}IncludeDirectories);$(CAExcludePath)</CAExcludePath>


### PR DESCRIPTION
Changelog: BugFix: Avoid ``LocalDebuggerEnv`` overflows in ``MSBuildDeps`` due to addition of PATH env-var.
Docs: Omit

Close https://github.com/conan-io/conan/issues/11626
