### PR TITLE
Available folders in post_export hook

### DIFF
--- a/conans/client/cmd/export.py
+++ b/conans/client/cmd/export.py
@@ -44,6 +44,8 @@ def cmd_export(app, conanfile_path, name, version, user, channel, graph_lock=Non
 
     # Execute post-export hook before computing the digest
     hook_manager.execute("post_export", conanfile=conanfile)
+    conanfile.folders.set_base_export(None)
+    conanfile.folders.set_base_export_sources(None)
 
     # Compute the new digest
     manifest = FileTreeManifest.create(export_folder, export_src_folder)
@@ -137,7 +139,6 @@ def export_source(conanfile, destination_source_folder):
     report_files_copied(copied, package_output)
     conanfile.folders.set_base_export_sources(destination_source_folder)
     _run_method(conanfile, "export_sources")
-    conanfile.folders.set_base_export_sources(None)
 
 
 def export_recipe(conanfile, destination_folder):
@@ -166,7 +167,6 @@ def export_recipe(conanfile, destination_folder):
 
     conanfile.folders.set_base_export(destination_folder)
     _run_method(conanfile, "export")
-    conanfile.folders.set_base_export(None)
 
 
 def _run_method(conanfile, method):

--- a/conans/test/integration/hooks/hook_test.py
+++ b/conans/test/integration/hooks/hook_test.py
@@ -11,33 +11,51 @@ import os
 
 def pre_export(conanfile):
     conanfile.output.info("Hello")
+    # TODO: To have the export_folder here needs a bit more deep refactoring
+    assert conanfile.export_folder is None
 
 def post_export(conanfile):
     conanfile.output.info("Hello")
+    assert conanfile.export_folder, "export_folder not defined"
+    assert conanfile.export_sources_folder, "export_sources_folder not defined"
 
 def pre_source(conanfile):
     conanfile.output.info("Hello")
+    assert conanfile.source_folder, "source_folder not defined"
 
 def post_source(conanfile):
     conanfile.output.info("Hello")
+    assert conanfile.source_folder, "source_folder not defined"
 
 def pre_generate(conanfile):
     conanfile.output.info("Hello")
+    assert conanfile.generators_folder, "generators_folder not defined"
 
 def post_generate(conanfile):
     conanfile.output.info("Hello")
+    assert conanfile.generators_folder, "generators_folder not defined"
 
 def pre_build(conanfile):
     conanfile.output.info("Hello")
+    assert conanfile.source_folder, "source_folder not defined"
+    assert conanfile.build_folder, "build_folder not defined"
 
 def post_build(conanfile):
     conanfile.output.info("Hello")
+    assert conanfile.source_folder, "source_folder not defined"
+    assert conanfile.build_folder, "build_folder not defined"
 
 def pre_package(conanfile):
     conanfile.output.info("Hello")
+    assert conanfile.source_folder, "source_folder not defined"
+    assert conanfile.build_folder, "build_folder not defined"
+    assert conanfile.package_folder, "package_folder not defined"
 
 def post_package(conanfile):
     conanfile.output.info("Hello")
+    assert conanfile.source_folder, "source_folder not defined"
+    assert conanfile.build_folder, "build_folder not defined"
+    assert conanfile.package_folder, "package_folder not defined"
 
 def pre_package_info(conanfile):
     conanfile.output.info("Hello")

--- a/conans/test/integration/hooks/hook_test.py
+++ b/conans/test/integration/hooks/hook_test.py
@@ -13,11 +13,13 @@ def pre_export(conanfile):
     conanfile.output.info("Hello")
     # TODO: To have the export_folder here needs a bit more deep refactoring
     assert conanfile.export_folder is None
+    assert conanfile.recipe_folder, "recipe_folder not defined"
 
 def post_export(conanfile):
     conanfile.output.info("Hello")
     assert conanfile.export_folder, "export_folder not defined"
     assert conanfile.export_sources_folder, "export_sources_folder not defined"
+    assert conanfile.recipe_folder, "recipe_folder not defined"
 
 def pre_source(conanfile):
     conanfile.output.info("Hello")

--- a/conans/test/integration/layout/export_folder_variable_test.py
+++ b/conans/test/integration/layout/export_folder_variable_test.py
@@ -57,7 +57,8 @@ class TestExportFoldersAvailability:
                 assert os.path.exists(self.export_sources_folder)
 
             def export_sources(self):
-                assert self.export_folder is None
+                # We need it available for the post_export hook so it is available
+                assert os.path.exists(self.export_folder)
 
             def export(self):
                 assert os.path.exists(self.export_folder)
@@ -97,7 +98,8 @@ class TestExportFoldersAvailability:
                 assert os.path.exists(self.export_folder)
 
             def export_sources(self):
-                assert self.export_folder is None
+                # We need it available for the post_export hook so it is available
+                assert os.path.exists(self.export_folder)
 
             def source(self):
                 assert self.export_folder is None


### PR DESCRIPTION
Changelog: Fix: The `conanfile.export_folder` and `conanfile.export_sources_folder` are now available in the `post_hook()`.
Docs: omit


