### PR TITLE
Allow conan new templates to contain Readme.md and LICENSE.txt files

### DIFF
--- a/conans/client/conf/config_installer.py
+++ b/conans/client/conf/config_installer.py
@@ -113,7 +113,7 @@ def _process_file(directory, filename, config, cache, output, folder):
         raise ConanException("remotes.json install is not supported yet. Use 'remotes.txt'")
     else:
         # This is ugly, should be removed in Conan 2.0
-        if filename in ("README.md", "LICENSE.txt"):
+        if filename in ("README.md", "LICENSE.txt") and not directory.startswith("templates"):
             output.info("Skip %s" % filename)
         else:
             relpath = os.path.relpath(directory, folder)


### PR DESCRIPTION
This is just a small fix. I didn't find an issue for this and I don't think an issue is needed. I'm not sure if changes to the documentation are needed. On one hand the docs are clear that Readme.md and LICENSE.txt are skipped, on the other hand for templates these kinds of files are sometimes essential.

Changelog: Fix: Allow templates for `conan new` to contain _Readme.md_ and _LICENSE.txt files_.
Docs: omit

- [x] Refer to the issue that supports this Pull Request.
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [x] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 

<sup>**Note:** By default this PR will skip the slower tests and will use a limited set of python versions. Check [here](https://github.com/conan-io/conan/blob/develop/.github/PR_INCREASE_TESTING.md) how to increase the testing level by writing some tags in the current PR body text.</sup>
