### PR TITLE
Bugfix/fix toolchain path slash

### DIFF
--- a/conan/tools/cmake/toolchain/toolchain.py
+++ b/conan/tools/cmake/toolchain/toolchain.py
@@ -176,7 +176,8 @@ class CMakeToolchain(object):
         # Generators like Ninja or NMake requires an active vcvars
         elif self.generator is not None and "Visual" not in self.generator:
             VCVars(self._conanfile).generate()
-        toolchain = os.path.join(self._conanfile.generators_folder, toolchain_file or self.filename)
+        toolchain = os.path.abspath(os.path.join(self._conanfile.generators_folder,
+                                                 toolchain_file or self.filename))
         cache_variables = {}
         for name, value in self.cache_variables.items():
             if isinstance(value, bool):

--- a/conans/test/integration/toolchains/cmake/test_cmaketoolchain.py
+++ b/conans/test/integration/toolchains/cmake/test_cmaketoolchain.py
@@ -490,3 +490,25 @@ def test_android_c_library():
         """)
     client.save({"conanfile.py": conanfile})
     client.run("create . foo/1.0@ -s os=Android -s os.api_level=23 -c tools.android:ndk_path=/foo")
+
+
+@pytest.mark.skipif(platform.system() != "Windows", reason="Only Windows")
+def test_toolchain_path_correct():
+    client = TestClient()
+    conanfile = textwrap.dedent("""
+            from conan import ConanFile
+            from conan.tools.cmake import cmake_layout
+
+            class Conan(ConanFile):
+                settings = "os", "arch", "compiler", "build_type"
+                generators = "CMakeToolchain"
+
+                def layout(self):
+                    cmake_layout(self)
+            """)
+    client.save({"conanfile.py": conanfile})
+    client.run("install . ")
+    contents = json.loads(client.load("build/generators/CMakePresets.json"))
+    toolchain_file = contents["configurePresets"][0]["toolchainFile"]
+    assert "/" not in toolchain_file
+

--- a/conans/test/integration/toolchains/cmake/test_cmaketoolchain.py
+++ b/conans/test/integration/toolchains/cmake/test_cmaketoolchain.py
@@ -493,7 +493,7 @@ def test_android_c_library():
 
 
 @pytest.mark.skipif(platform.system() != "Windows", reason="Only Windows")
-def test_toolchain_path_correct():
+def test_presets_paths_correct():
     client = TestClient()
     conanfile = textwrap.dedent("""
             from conan import ConanFile
@@ -511,4 +511,7 @@ def test_toolchain_path_correct():
     contents = json.loads(client.load("build/generators/CMakePresets.json"))
     toolchain_file = contents["configurePresets"][0]["toolchainFile"]
     assert "/" not in toolchain_file
+
+    binary_dir = contents["configurePresets"][0]["binaryDir"]
+    assert "/" not in binary_dir
 


### PR DESCRIPTION
Changelog: Bugfix: The `CMakePresets.json` file contained invalid paths (mixing `/` and `\`) for Windows that caused issues when using `Visual Studio`. 
Docs: omit

Close https://github.com/conan-io/conan/issues/11647