### PR TITLE
CMakePresets compatible with schema 2

### DIFF
--- a/conan/tools/cmake/presets.py
+++ b/conan/tools/cmake/presets.py
@@ -69,7 +69,8 @@ def _add_configure_preset(conanfile, generator, cache_variables, toolchain_file,
 
 
 def _forced_schema_2(conanfile):
-    version = conanfile.conf.get("tools.cmake.cmaketoolchain.presets:max_schema_version", check_type=int)
+    version = conanfile.conf.get("tools.cmake.cmaketoolchain.presets:max_schema_version",
+                                 check_type=int, default=4)
     if version < 2:
         raise ConanException("The minimun value for 'tools.cmake.cmaketoolchain.presets:"
                              "schema_version' is 2")

--- a/conan/tools/cmake/presets.py
+++ b/conan/tools/cmake/presets.py
@@ -72,7 +72,7 @@ def _forced_schema_2(conanfile):
     version = conanfile.conf.get("tools.cmake.cmaketoolchain.presets:max_schema_version",
                                  check_type=int, default=4)
     if version < 2:
-        raise ConanException("The minimun value for 'tools.cmake.cmaketoolchain.presets:"
+        raise ConanException("The minimum value for 'tools.cmake.cmaketoolchain.presets:"
                              "schema_version' is 2")
     if version < 4:
         return True

--- a/conan/tools/cmake/presets.py
+++ b/conan/tools/cmake/presets.py
@@ -69,11 +69,21 @@ def _add_configure_preset(conanfile, generator, cache_variables, toolchain_file,
 
 
 def _forced_schema_2(conanfile):
-    return conanfile.conf.get("tools.cmake.cmaketoolchain.presets:schema2", check_type=bool)
+    version = conanfile.conf.get("tools.cmake.cmaketoolchain.presets:max_schema_version", check_type=int)
+    if version < 2:
+        raise ConanException("The minimun value for 'tools.cmake.cmaketoolchain.presets:"
+                             "schema_version' is 2")
+    if version < 4:
+        return True
+
+    return False
 
 
 def _schema_version(conanfile, default):
-    return default if not _forced_schema_2(conanfile) else 2
+    if _forced_schema_2(conanfile):
+        return 2
+
+    return default
 
 
 def _contents(conanfile, toolchain_file, cache_variables, generator):

--- a/conans/model/conf.py
+++ b/conans/model/conf.py
@@ -21,6 +21,7 @@ BUILT_IN_CONFS = {
     "tools.cmake.cmaketoolchain:system_name": "Define CMAKE_SYSTEM_NAME in CMakeToolchain",
     "tools.cmake.cmaketoolchain:system_version": "Define CMAKE_SYSTEM_VERSION in CMakeToolchain",
     "tools.cmake.cmaketoolchain:system_processor": "Define CMAKE_SYSTEM_PROCESSOR in CMakeToolchain",
+    "tools.cmake.cmaketoolchain.presets:schema2": "Generate CMakeUserPreset.json compatible with version 2 of the schema",
     "tools.env.virtualenv:auto_use": "Automatically activate virtualenv file generation",
     "tools.cmake.cmake_layout:build_folder_vars": "Settings and Options that will produce a different build folder and different CMake presets names",
     "tools.files.download:retry": "Number of retries in case of failure when downloading",

--- a/conans/model/conf.py
+++ b/conans/model/conf.py
@@ -21,7 +21,7 @@ BUILT_IN_CONFS = {
     "tools.cmake.cmaketoolchain:system_name": "Define CMAKE_SYSTEM_NAME in CMakeToolchain",
     "tools.cmake.cmaketoolchain:system_version": "Define CMAKE_SYSTEM_VERSION in CMakeToolchain",
     "tools.cmake.cmaketoolchain:system_processor": "Define CMAKE_SYSTEM_PROCESSOR in CMakeToolchain",
-    "tools.cmake.cmaketoolchain.presets:schema2": "Generate CMakeUserPreset.json compatible with version 2 of the schema",
+    "tools.cmake.cmaketoolchain.presets:max_schema_version": "Generate CMakeUserPreset.json compatible with the supplied schema version",
     "tools.env.virtualenv:auto_use": "Automatically activate virtualenv file generation",
     "tools.cmake.cmake_layout:build_folder_vars": "Settings and Options that will produce a different build folder and different CMake presets names",
     "tools.files.download:retry": "Number of retries in case of failure when downloading",

--- a/conans/test/functional/toolchains/cmake/test_cmake_toolchain.py
+++ b/conans/test/functional/toolchains/cmake/test_cmake_toolchain.py
@@ -826,10 +826,13 @@ def test_user_presets_version2():
 
     if platform.system() == "Windows":
         client.run_command("cmake . --preset 14")
+        client.run_command("cmake --build --preset 14-release")
+        client.run_command("build/14/Release/hello.exe")
     else:
         client.run_command("cmake . --preset 14-release")
-    client.run_command("cmake --build --preset 14-release")
-    client.run_command("./build/14/Release/hello")
+        client.run_command("cmake --build --preset 14-release")
+        client.run_command("./build/14/Release/hello")
+
     assert "Hello World Release!" in client.out
 
     if platform.system() != "Windows":
@@ -837,24 +840,20 @@ def test_user_presets_version2():
     else:
         assert "MSVC_LANG2014" in client.out
 
-    client.run_command("cmake . --preset 17-release")
-    client.run_command("cmake --build --preset 17-release")
-    client.run_command("./build/17/Release/hello")
+    if platform.system() == "Windows":
+        client.run_command("cmake . --preset 17")
+        client.run_command("cmake --build --preset 17-release")
+        client.run_command("build/17/Release/hello.exe")
+    else:
+        client.run_command("cmake . --preset 17-release")
+        client.run_command("cmake --build --preset 17-release")
+        client.run_command("./build/17/Release/hello")
+
     assert "Hello World Release!" in client.out
     if platform.system() != "Windows":
         assert "__cplusplus2017" in client.out
     else:
         assert "MSVC_LANG2017" in client.out
-
-    client.run_command("cmake . --preset 20-release")
-    client.run_command("cmake --build --preset 20-release")
-    client.run_command("./build/20/Release/hello")
-    assert "Hello World Release!" in client.out
-
-    if platform.system() != "Windows":
-        assert "__cplusplus2020" in client.out
-    else:
-        assert "MSVC_LANG2020" in client.out
 
 
 @pytest.mark.tool_cmake

--- a/conans/test/functional/toolchains/cmake/test_cmake_toolchain.py
+++ b/conans/test/functional/toolchains/cmake/test_cmake_toolchain.py
@@ -827,7 +827,7 @@ def test_user_presets_version2():
     if platform.system() == "Windows":
         client.run_command("cmake . --preset 14")
         client.run_command("cmake --build --preset 14-release")
-        client.run_command("build/14/Release/hello.exe")
+        client.run_command(r"build\14\Release\hello.exe")
     else:
         client.run_command("cmake . --preset 14-release")
         client.run_command("cmake --build --preset 14-release")
@@ -843,7 +843,7 @@ def test_user_presets_version2():
     if platform.system() == "Windows":
         client.run_command("cmake . --preset 17")
         client.run_command("cmake --build --preset 17-release")
-        client.run_command("build/17/Release/hello.exe")
+        client.run_command(r"build\17\Release\hello.exe")
     else:
         client.run_command("cmake . --preset 17-release")
         client.run_command("cmake --build --preset 17-release")

--- a/conans/test/integration/toolchains/cmake/test_cmaketoolchain.py
+++ b/conans/test/integration/toolchains/cmake/test_cmaketoolchain.py
@@ -514,19 +514,15 @@ def test_user_presets_version2():
                "-c tools.cmake.cmake_layout:build_folder_vars='[\"settings.compiler.cppstd\"]'"]
     client.run("install . {} -s compiler.cppstd=14".format(" ".join(configs)))
     client.run("install . {} -s compiler.cppstd=17".format(" ".join(configs)))
-    client.run("install . {} -s compiler.cppstd=20".format(" ".join(configs)))
 
     presets = json.loads(client.load("CMakeUserPresets.json"))
-    assert len(presets["configurePresets"]) == 3
+    assert len(presets["configurePresets"]) == 2
     assert presets["version"] == 2
     assert "build/14/generators/conan_toolchain.cmake" \
            in presets["configurePresets"][0]["cacheVariables"]["CMAKE_TOOLCHAIN_FILE"].replace("\\",
                                                                                                "/")
     assert "build/17/generators/conan_toolchain.cmake" \
            in presets["configurePresets"][1]["cacheVariables"]["CMAKE_TOOLCHAIN_FILE"].replace("\\",
-                                                                                               "/")
-    assert "build/20/generators/conan_toolchain.cmake" \
-           in presets["configurePresets"][2]["cacheVariables"]["CMAKE_TOOLCHAIN_FILE"].replace("\\",
                                                                                                "/")
 
 

--- a/conans/test/integration/toolchains/cmake/test_cmaketoolchain.py
+++ b/conans/test/integration/toolchains/cmake/test_cmaketoolchain.py
@@ -490,3 +490,68 @@ def test_android_c_library():
         """)
     client.save({"conanfile.py": conanfile})
     client.run("create . foo/1.0@ -s os=Android -s os.api_level=23 -c tools.android:ndk_path=/foo")
+
+
+def test_user_presets_version2():
+
+    client = TestClient()
+    conanfile = textwrap.dedent("""
+            from conan import ConanFile
+            from conan.tools.cmake import cmake_layout
+
+            class Conan(ConanFile):
+                name = "foo"
+                version = "1.0"
+                settings = "os", "arch", "compiler", "build_type"
+                generators = "CMakeToolchain"
+
+                def layout(self):
+                    cmake_layout(self)
+
+            """)
+    client.save({"conanfile.py": conanfile, "CMakeLists.txt": "foo"})
+    configs = ["-c tools.cmake.cmaketoolchain.presets:max_schema_version=2 ",
+               "-c tools.cmake.cmake_layout:build_folder_vars='[\"settings.compiler.cppstd\"]'"]
+    client.run("install . {} -s compiler.cppstd=14".format(" ".join(configs)))
+    client.run("install . {} -s compiler.cppstd=17".format(" ".join(configs)))
+    client.run("install . {} -s compiler.cppstd=20".format(" ".join(configs)))
+
+    presets = json.loads(client.load("CMakeUserPresets.json"))
+    assert len(presets["configurePresets"]) == 3
+    assert presets["version"] == 2
+    assert "build/14/generators/conan_toolchain.cmake" \
+           in presets["configurePresets"][0]["cacheVariables"]["CMAKE_TOOLCHAIN_FILE"].replace("\\",
+                                                                                               "/")
+    assert "build/17/generators/conan_toolchain.cmake" \
+           in presets["configurePresets"][1]["cacheVariables"]["CMAKE_TOOLCHAIN_FILE"].replace("\\",
+                                                                                               "/")
+    assert "build/20/generators/conan_toolchain.cmake" \
+           in presets["configurePresets"][2]["cacheVariables"]["CMAKE_TOOLCHAIN_FILE"].replace("\\",
+                                                                                               "/")
+
+
+def test_user_presets_version2_no_overwrite_user():
+
+    client = TestClient()
+    conanfile = textwrap.dedent("""
+            from conan import ConanFile
+            from conan.tools.cmake import cmake_layout
+
+            class Conan(ConanFile):
+                name = "foo"
+                version = "1.0"
+                settings = "os", "arch", "compiler", "build_type"
+                generators = "CMakeToolchain"
+
+                def layout(self):
+                    cmake_layout(self)
+
+            """)
+    client.save({"conanfile.py": conanfile, "CMakeLists.txt": "foo",
+                 "CMakeUserPresets.json": '{"from_user": 1}'})
+    configs = ["-c tools.cmake.cmaketoolchain.presets:max_schema_version=2 ",
+               "-c tools.cmake.cmake_layout:build_folder_vars='[\"settings.compiler.cppstd\"]'"]
+    client.run("install . {} -s compiler.cppstd=14".format(" ".join(configs)))
+
+    presets = json.loads(client.load("CMakeUserPresets.json"))
+    assert presets == {"from_user": 1}


### PR DESCRIPTION
Changelog: Feature: Introduced a new conf `tools.cmake.cmaketoolchain.presets:max_schema_version` to generate `CMakePresets.json` and `CMakeUserPresets.json` compatible with the specified json schema version. The minimum value supported is `>=2`.
Docs: https://github.com/conan-io/docs/pull/2666

To discuss: Is this an opt-in? or maybe an opt-out to use the "include" schema?

Close #11649
Close #11648