### PR TITLE
package_manager: fix opensuse detection

### DIFF
--- a/conan/tools/system/package_manager.py
+++ b/conan/tools/system/package_manager.py
@@ -43,6 +43,9 @@ class _SystemPackageManagerTool(object):
         for tool, distros in manager_mapping.items():
             if os_name in distros:
                 return tool
+            for d in distros:
+                if d in ["opensuse", "sles"] and os_name in d:
+                    return true
 
     def get_package_name(self, package):
         # TODO: should we only add the arch if cross-building?

--- a/conan/tools/system/package_manager.py
+++ b/conan/tools/system/package_manager.py
@@ -37,15 +37,12 @@ class _SystemPackageManagerTool(object):
                            "brew": ["Darwin"],
                            "pacman": ["arch", "manjaro", "msys2"],
                            "choco": ["Windows"],
-                           "zypper": ["opensuse", "sles"],
+                           "zypper": ["opensuse", "sles", "opensuse-tumbleweed"],
                            "pkg": ["freebsd"],
                            "pkgutil": ["Solaris"]}
         for tool, distros in manager_mapping.items():
             if os_name in distros:
                 return tool
-            for d in distros:
-                if d in ["opensuse", "sles"] and os_name in d:
-                    return true
 
     def get_package_name(self, package):
         # TODO: should we only add the arch if cross-building?

--- a/conan/tools/system/package_manager.py
+++ b/conan/tools/system/package_manager.py
@@ -37,12 +37,13 @@ class _SystemPackageManagerTool(object):
                            "brew": ["Darwin"],
                            "pacman": ["arch", "manjaro", "msys2"],
                            "choco": ["Windows"],
-                           "zypper": ["opensuse", "sles", "opensuse-tumbleweed"],
+                           "zypper": ["opensuse", "sles"],
                            "pkg": ["freebsd"],
                            "pkgutil": ["Solaris"]}
         for tool, distros in manager_mapping.items():
-            if os_name in distros:
-                return tool
+            for d in distros:
+                if d in os_name:
+                    return tool
 
     def get_package_name(self, package):
         # TODO: should we only add the arch if cross-building?

--- a/conan/tools/system/package_manager.py
+++ b/conan/tools/system/package_manager.py
@@ -40,6 +40,13 @@ class _SystemPackageManagerTool(object):
                            "zypper": ["opensuse", "sles"],
                            "pkg": ["freebsd"],
                            "pkgutil": ["Solaris"]}
+        # first check exact match of name
+        for tool, distros in manager_mapping.items():
+            if os_name in distros:
+                return tool
+        # in case we did not detect any exact match, check
+        # if the name is contained inside the returned distro name
+        # like for opensuse, that can have opensuse-version names
         for tool, distros in manager_mapping.items():
             for d in distros:
                 if d in os_name:

--- a/conans/test/integration/tools/system/package_manager_test.py
+++ b/conans/test/integration/tools/system/package_manager_test.py
@@ -55,6 +55,7 @@ def test_msys2():
     ("opensuse-tumbleweed", "zypper"),
     ("freebsd", "pkg"),
 ])
+@pytest.mark.skipif(platform.system() != "Linux", reason="Only linux")
 def test_package_manager_distro(distro, tool):
     with mock.patch("platform.system", return_value="Linux"):
         with mock.patch("distro.id", return_value=distro):

--- a/conans/test/integration/tools/system/package_manager_test.py
+++ b/conans/test/integration/tools/system/package_manager_test.py
@@ -58,7 +58,7 @@ def test_msys2():
     ("opensuse-next_version", "zypper"),
     ("freebsd", "pkg"),
 ])
-#@pytest.mark.skipif(platform.system() != "Linux", reason="Only linux")
+@pytest.mark.skipif(platform.system() != "Linux", reason="Only linux")
 def test_package_manager_distro(distro, tool):
     with mock.patch("platform.system", return_value="Linux"):
         with mock.patch("distro.id", return_value=distro):

--- a/conans/test/integration/tools/system/package_manager_test.py
+++ b/conans/test/integration/tools/system/package_manager_test.py
@@ -52,10 +52,13 @@ def test_msys2():
     ("arch", "pacman"),
     ("opensuse", "zypper"),
     ("sles", "zypper"),
+    ("opensuse", "zypper"),
     ("opensuse-tumbleweed", "zypper"),
+    ("opensuse-leap", "zypper"),
+    ("opensuse-next_version", "zypper"),
     ("freebsd", "pkg"),
 ])
-@pytest.mark.skipif(platform.system() != "Linux", reason="Only linux")
+#@pytest.mark.skipif(platform.system() != "Linux", reason="Only linux")
 def test_package_manager_distro(distro, tool):
     with mock.patch("platform.system", return_value="Linux"):
         with mock.patch("distro.id", return_value=distro):

--- a/conans/test/integration/tools/system/package_manager_test.py
+++ b/conans/test/integration/tools/system/package_manager_test.py
@@ -51,9 +51,10 @@ def test_msys2():
     ("fedora", "dnf"),
     ("arch", "pacman"),
     ("opensuse", "zypper"),
+    ("sles", "zypper"),
+    ("opensuse-tumbleweed", "zypper"),
     ("freebsd", "pkg"),
 ])
-@pytest.mark.skipif(platform.system() != "Linux", reason="Only linux")
 def test_package_manager_distro(distro, tool):
     with mock.patch("platform.system", return_value="Linux"):
         with mock.patch("distro.id", return_value=distro):


### PR DESCRIPTION
Changelog: Fix: Improve opensuse detection in `tool.system.package_manager`.
Docs: omit

For example, on opensuse tumbleweed, the distro name is `opensuse-tumbleweed`
this re-implements what was done in https://github.com/conan-io/conan/blob/f9215513368e576a82f071ab5d7b4cf990d156ca/conans/client/tools/oss.py#L230

- [ ] Refer to the issue that supports this Pull Request.
- [ ] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [ ] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [ ] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 

<sup>**Note:** By default this PR will skip the slower tests and will use a limited set of python versions. Check [here](https://github.com/conan-io/conan/blob/develop/.github/PR_INCREASE_TESTING.md) how to increase the testing level by writing some tags in the current PR body text.</sup>
