### PR TITLE
[bug] get_cpus is not supporting cgroup2 #11635

### DIFF
--- a/conan/tools/build/cpu.py
+++ b/conan/tools/build/cpu.py
@@ -1,5 +1,6 @@
 import math
 import multiprocessing
+import os
 
 from conans.util.files import load
 
@@ -15,8 +16,18 @@ def _cpu_count():
     try:
         try:
             # This is necessary to deduce docker cpu_count
-            cfs_quota_us = int(load("/sys/fs/cgroup/cpu/cpu.cfs_quota_us"))
-            cfs_period_us = int(load("/sys/fs/cgroup/cpu/cpu.cfs_period_us"))
+            # cgroup2
+            if os.path.exists("/sys/fs/cgroup/cgroup.controllers"):
+                cpu_max = load("/sys/fs/cgroup/cpu.max").split()
+                if cpu_max[0] == "max":
+                    return 1
+                elif len(cpu_max) == 1:
+                    cfs_quota_us, cfs_period_us = int(cpu_max[0]), 1
+                else:
+                    cfs_quota_us, cfs_period_us = map(int, cpu_max)
+            else:  # cgroup1
+                cfs_quota_us = int(load("/sys/fs/cgroup/cpu/cpu.cfs_quota_us"))
+                cfs_period_us = int(load("/sys/fs/cgroup/cpu/cpu.cfs_period_us"))
             if cfs_quota_us > 0 and cfs_period_us > 0:
                 return int(math.ceil(cfs_quota_us / cfs_period_us))
         except (EnvironmentError, TypeError):

--- a/conan/tools/build/cpu.py
+++ b/conan/tools/build/cpu.py
@@ -16,15 +16,15 @@ def _cpu_count():
     try:
         try:
             # This is necessary to deduce docker cpu_count
+            cfs_quota_us = cfs_period_us = 0
             # cgroup2
             if os.path.exists("/sys/fs/cgroup/cgroup.controllers"):
                 cpu_max = load("/sys/fs/cgroup/cpu.max").split()
-                if cpu_max[0] == "max":
-                    return 1
-                elif len(cpu_max) == 1:
-                    cfs_quota_us, cfs_period_us = int(cpu_max[0]), 1
-                else:
-                    cfs_quota_us, cfs_period_us = map(int, cpu_max)
+                if cpu_max[0] != "max":
+                    if len(cpu_max) == 1:
+                        cfs_quota_us, cfs_period_us = int(cpu_max[0]), 100_000
+                    else:
+                        cfs_quota_us, cfs_period_us = map(int, cpu_max)
             else:  # cgroup1
                 cfs_quota_us = int(load("/sys/fs/cgroup/cpu/cpu.cfs_quota_us"))
                 cfs_period_us = int(load("/sys/fs/cgroup/cpu/cpu.cfs_period_us"))


### PR DESCRIPTION
Changelog: Fix: Get the cpu count for cgroup2 from `/sys/fs/cgroup/cpu.max`.
Docs: https://github.com/conan-io/docs/pull/2658

Fixes #11635

Gets the cpu count for cgroup2 from `/sys/fs/cgroup/cpu.max` file. From [docs](https://www.kernel.org/doc/html/latest/admin-guide/cgroup-v2.html), `/sys/fs/cgroup/cpu.max` file has the following format: `$MAX $PERIOD`.
In case `$MAX` is "max", return 1.
If there is no `$PERIOD`, use only `$MAX` as the return value.
When both values are integers, use them as before.

- [x] Refer to the issue that supports this Pull Request.
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [x] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 

<sup>**Note:** By default this PR will skip the slower tests and will use a limited set of python versions. Check [here](https://github.com/conan-io/conan/blob/develop/.github/PR_INCREASE_TESTING.md) how to increase the testing level by writing some tags in the current PR body text.</sup>
