### PR TITLE
Add core.cache:storage_path

### DIFF
--- a/conans/client/cache/cache.py
+++ b/conans/client/cache/cache.py
@@ -43,7 +43,8 @@ class ClientCache(object):
         self._new_config = None
         self.editable_packages = EditablePackages(self.cache_folder)
         # paths
-        self._store_folder = os.path.join(self.cache_folder, "p")
+        self._store_folder = self.new_config.get("core.cache:storage_path") or \
+                             os.path.join(self.cache_folder, "p")
 
         mkdir(self._store_folder)
         db_filename = os.path.join(self._store_folder, 'cache.sqlite3')

--- a/conans/model/conf.py
+++ b/conans/model/conf.py
@@ -16,6 +16,7 @@ BUILT_IN_CONFS = {
     "core.download:retry": "Number of retries in case of failure when downloading from Conan server",
     "core.download:retry_wait": "Seconds to wait between download attempts from Conan server",
     "core.download:download_cache": "Download folder used by Rest API methods",
+    "core.cache:storage_path": "Absolute path where the packages and database are stored",
     # Package ID
     "core.package_id:default_unknown_mode": "By default, 'semver_mode'",
     "core.package_id:default_non_embed_mode": "By default, 'minor_mode'",

--- a/conans/test/integration/cache/storage_path_test.py
+++ b/conans/test/integration/cache/storage_path_test.py
@@ -1,0 +1,18 @@
+import os
+
+from conans.test.utils.test_files import temp_folder
+from conans.test.utils.tools import TestClient, GenConanfile
+
+
+def test_storage_path():
+    client = TestClient()
+    client.save({"conanfile.py": GenConanfile()})
+    tmp_folder = temp_folder(path_with_spaces=True)
+    client.save({"global.conf": f"core.cache:storage_path={tmp_folder}"},
+                path=client.cache.cache_folder)
+    client.run("create . --name=mypkg --version=0.1")
+    assert f"mypkg/0.1: Folder: {tmp_folder}" in client.out
+    assert os.path.isfile(os.path.join(tmp_folder, "cache.sqlite3"))
+
+    client.run("cache path mypkg/0.1#latest")
+    assert tmp_folder in client.out


### PR DESCRIPTION
Add `core.cache:storage_path` to declare the absolute path where you want to store the Conan packages

I did not implement anything about interpreting this as a relative path, if some user wants to define a path that is relative to the conan home you can always use jinja templates inside the global.conf.

Partially addresses: https://github.com/conan-io/conan/issues/11542