### PR TITLE
CMakeDeps. global target: from merging cppinfo to link component targets

### DIFF
--- a/conan/tools/cmake/cmakedeps/templates/target_configuration.py
+++ b/conan/tools/cmake/cmakedeps/templates/target_configuration.py
@@ -112,7 +112,7 @@ class TargetConfigurationTemplate(CMakeDepsFileTemplate):
         {%- endfor %}
 
 
-
+        {% if not components_names %}
         ########## GLOBAL TARGET PROPERTIES {{ configuration }} ########################################
         set_property(TARGET {{root_target_name}}
                      PROPERTY INTERFACE_LINK_LIBRARIES
@@ -139,6 +139,9 @@ class TargetConfigurationTemplate(CMakeDepsFileTemplate):
                      PROPERTY INTERFACE_LINK_DIRECTORIES
                      $<$<CONFIG:{{configuration}}>:${{'{'}}{{pkg_name}}_LIB_DIRS{{config_suffix}}}> APPEND)
         {%- endif %}
+
+        {%- else %}
+
         ########## COMPONENTS TARGET PROPERTIES {{ configuration }} ########################################
 
         {%- for comp_variable_name, comp_target_name in components_names %}
@@ -167,6 +170,15 @@ class TargetConfigurationTemplate(CMakeDepsFileTemplate):
         {%- endif %}
         {%- endfor %}
 
+
+        ########## AGGREGATED GLOBAL TARGET WITH THE COMPONENTS #####################
+        {%- for comp_variable_name, comp_target_name in components_names %}
+
+        target_link_libraries({{root_target_name}} INTERFACE {{ comp_target_name }})
+
+        {%- endfor %}
+
+        {%- endif %}
 
         """)
 

--- a/conan/tools/cmake/cmakedeps/templates/target_data.py
+++ b/conan/tools/cmake/cmakedeps/templates/target_data.py
@@ -26,7 +26,7 @@ class ConfigDataTemplate(CMakeDepsFileTemplate):
     @property
     def context(self):
         global_cpp = self._get_global_cpp_cmake()
-        if global_cpp and not self.build_modules_activated:
+        if not self.build_modules_activated:
             global_cpp.build_modules_paths = ""
 
         components = self._get_required_components_cpp()

--- a/conans/test/functional/toolchains/cmake/cmakedeps/test_cmakedeps_build_modules.py
+++ b/conans/test/functional/toolchains/cmake/cmakedeps/test_cmakedeps_build_modules.py
@@ -6,8 +6,7 @@ from conans.test.utils.tools import TestClient
 
 
 @pytest.mark.tool_cmake
-@pytest.mark.parametrize("use_components", [False, True])
-def test_build_modules_alias_target(use_components):
+def test_build_modules_alias_target():
     client = TestClient()
     conanfile = textwrap.dedent("""
         import os
@@ -24,21 +23,13 @@ def test_build_modules_alias_target(use_components):
 
             def package_info(self):
                 module = os.path.join("share", "cmake", "target-alias.cmake")
-                {}
+                self.cpp_info.set_property("cmake_build_modules", [module])
         """)
-    if use_components:
-        info = """
-        self.cpp_info.components["comp"].set_property("cmake_build_modules", [module])
-        """
-    else:
-        info = """
-        self.cpp_info.set_property("cmake_build_modules", [module])
-        """
+
     target_alias = textwrap.dedent("""
         add_library(otherhello INTERFACE IMPORTED)
-        target_link_libraries(otherhello INTERFACE {target_name})
-        """).format(target_name="namespace::comp" if use_components else "hello::hello")
-    conanfile = conanfile.format(info)
+        target_link_libraries(otherhello INTERFACE hello::hello)
+        """)
     client.save({"conanfile.py": conanfile, "target-alias.cmake": target_alias})
     client.run("create .")
 
@@ -66,20 +57,13 @@ def test_build_modules_alias_target(use_components):
         """)
     client.save({"conanfile.py": consumer, "CMakeLists.txt": cmakelists})
     client.run("create .")
-    if use_components:
-        assert "otherhello link libraries: namespace::comp" in client.out
-    else:
-        assert "otherhello link libraries: hello::hello" in client.out
+    assert "otherhello link libraries: hello::hello" in client.out
 
 
 @pytest.mark.tool_cmake
-def test_build_modules_components_selection_is_not_possible():
+def test_build_modules_components_is_not_possible():
     """
-    If openssl declares different cmake_build_modules on ssl and crypto, in the consumer both
-    are included even if the cpp_info of the consumer declares:
-        def package_info(self):
-            self.cpp_info.requires = ["openssl::crypto"]
-    Because that information is defined later, not at "generate" time (building time).
+    The "cmake_build_module" property declared in the components is useless
     """
     client = TestClient()
     conanfile = textwrap.dedent("""
@@ -90,15 +74,12 @@ def test_build_modules_components_selection_is_not_possible():
             name = "openssl"
             version = "1.0"
             settings = "os", "arch", "compiler", "build_type"
-            exports_sources = ["ssl.cmake", "crypto.cmake", "root.cmake"]
+            exports_sources = ["crypto.cmake", "root.cmake"]
 
             def package(self):
                 self.copy("*.cmake", dst="share/cmake")
 
             def package_info(self):
-                ssl_module = os.path.join("share", "cmake", "ssl.cmake")
-                self.cpp_info.components["ssl"].set_property("cmake_build_modules", [ssl_module])
-
                 crypto_module = os.path.join("share", "cmake", "crypto.cmake")
                 self.cpp_info.components["crypto"].set_property("cmake_build_modules", [crypto_module])
 
@@ -106,11 +87,6 @@ def test_build_modules_components_selection_is_not_possible():
                 self.cpp_info.set_property("cmake_build_modules", [root_module])
         """)
 
-    ssl_cmake = textwrap.dedent("""
-        function(ssl_message MESSAGE_OUTPUT)
-            message("SSL MESSAGE:${ARGV${0}}")
-        endfunction()
-        """)
     crypto_cmake = textwrap.dedent("""
         function(crypto_message MESSAGE_OUTPUT)
             message("CRYPTO MESSAGE:${ARGV${0}}")
@@ -122,7 +98,6 @@ def test_build_modules_components_selection_is_not_possible():
         endfunction()
         """)
     client.save({"conanfile.py": conanfile,
-                 "ssl.cmake": ssl_cmake,
                  "crypto.cmake": crypto_cmake,
                  "root.cmake": root_cmake})
     client.run("create .")
@@ -151,17 +126,15 @@ def test_build_modules_components_selection_is_not_possible():
             project(test)
             find_package(openssl CONFIG)
             crypto_message("hello!")
-            ssl_message("hello!")
-            # The root build_module is not taken into account because there are components instead
-            # FIXME: Another alternative could be passing the global_cpp but without aggregating
-            #        the components.
-            #  root_message("hello!")
+            root_message("hello!")
             """)
     client.save({"conanfile.py": consumer, "CMakeLists.txt": cmakelists})
     # As we are requiring only "crypto" but it doesn't matter, it is not possible to include
     # only crypto build_modules
-    client.run("create .")
-    assert "SSL MESSAGE:hello!" in client.out
-    assert "CRYPTO MESSAGE:hello!" in client.out
+    client.run("create .", assert_error=True)
+    assert 'Unknown CMake command "crypto_message"' in client.out
+
+    # Comment the function call
+    client.save({"CMakeLists.txt": cmakelists.replace("crypto", "#crypto")})
     assert "ROOT MESSAGE:hello!" not in client.out
 

--- a/conans/test/functional/toolchains/cmake/cmakedeps/test_cmakedeps_build_modules.py
+++ b/conans/test/functional/toolchains/cmake/cmakedeps/test_cmakedeps_build_modules.py
@@ -152,7 +152,10 @@ def test_build_modules_components_selection_is_not_possible():
             find_package(openssl CONFIG)
             crypto_message("hello!")
             ssl_message("hello!")
-            root_message("hello!")
+            # The root build_module is not taken into account because there are components instead
+            # FIXME: Another alternative could be passing the global_cpp but without aggregating
+            #        the components.
+            #  root_message("hello!")
             """)
     client.save({"conanfile.py": consumer, "CMakeLists.txt": cmakelists})
     # As we are requiring only "crypto" but it doesn't matter, it is not possible to include
@@ -160,5 +163,5 @@ def test_build_modules_components_selection_is_not_possible():
     client.run("create .")
     assert "SSL MESSAGE:hello!" in client.out
     assert "CRYPTO MESSAGE:hello!" in client.out
-    assert "ROOT MESSAGE:hello!" in client.out
+    assert "ROOT MESSAGE:hello!" not in client.out
 

--- a/conans/test/integration/toolchains/cmake/cmakedeps/test_cmakedeps.py
+++ b/conans/test/integration/toolchains/cmake/cmakedeps/test_cmakedeps.py
@@ -107,15 +107,22 @@ def test_cpp_info_component_objects():
         assert """set_property(TARGET hello::say PROPERTY INTERFACE_LINK_LIBRARIES
              $<$<CONFIG:Release>:${hello_hello_say_OBJECTS_RELEASE}
              ${hello_hello_say_LINK_LIBS_RELEASE}> APPEND)""" in content
+        # If there are componets, there is not a global cpp so this is not generated
         assert """set_property(TARGET hello::hello
              PROPERTY INTERFACE_LINK_LIBRARIES
              $<$<CONFIG:Release>:${hello_OBJECTS_RELEASE}
-             ${hello_LIBRARIES_TARGETS_RELEASE}> APPEND)""" in content
+             ${hello_LIBRARIES_TARGETS_RELEASE}> APPEND)""" not in content
+        # But the global target is linked with the targets from the components
+        assert "target_link_libraries(hello::hello INTERFACE hello::say)" in content
 
     with open(os.path.join(client.current_folder, "hello-release-x86_64-data.cmake")) as f:
         content = f.read()
-        assert 'set(hello_OBJECTS_RELEASE "${hello_PACKAGE_FOLDER_RELEASE}/mycomponent.o")' in content
-        assert 'set(hello_hello_say_OBJECTS_RELEASE "${hello_PACKAGE_FOLDER_RELEASE}/mycomponent.o")' in content
+        # Not global variables
+        assert 'set(hello_OBJECTS_RELEASE "${hello_PACKAGE_FOLDER_RELEASE}/mycomponent.o")' \
+               not in content
+        # But component variables
+        assert 'set(hello_hello_say_OBJECTS_RELEASE "${hello_PACKAGE_FOLDER_RELEASE}/' \
+               'mycomponent.o")' in content
 
 
 def test_cpp_info_component_error_aggregate():

--- a/conans/test/unittests/tools/cmake/test_cmakedeps.py
+++ b/conans/test/unittests/tools/cmake/test_cmakedeps.py
@@ -61,8 +61,8 @@ def test_cpp_info_name_cmakedeps_components():
     conanfile.settings.arch = "x64"
 
     cpp_info = CppInfo("mypkg", "dummy_root_folder1")
-    cpp_info.set_property("cmake_target_name", "GlobakPkgName1::GlobakPkgName1")
-    cpp_info.components["mycomp"].set_property("cmake_target_name", "GlobakPkgName1::MySuperPkg1")
+    cpp_info.set_property("cmake_target_name", "GlobalPkgName1::GlobalPkgName1")
+    cpp_info.components["mycomp"].set_property("cmake_target_name", "GlobalPkgName1::MySuperPkg1")
     cpp_info.set_property("cmake_file_name", "ComplexFileName1")
 
     conanfile_dep = ConanFile(Mock(), None)
@@ -81,11 +81,13 @@ def test_cpp_info_name_cmakedeps_components():
 
         cmakedeps = CMakeDeps(conanfile)
         files = cmakedeps.content
-        assert "TARGET GlobakPkgName1::MySuperPkg1" in files["ComplexFileName1-Target-debug.cmake"]
+        assert "TARGET GlobalPkgName1::MySuperPkg1" in files["ComplexFileName1-Target-debug.cmake"]
+        # No global variables for the packages
         assert 'set(OriginalDepName_INCLUDE_DIRS_DEBUG ' \
                '"${OriginalDepName_PACKAGE_FOLDER_DEBUG}/include")' \
-               in files["ComplexFileName1-debug-x64-data.cmake"]
-        assert 'set(OriginalDepName_GlobakPkgName1_MySuperPkg1_INCLUDE_DIRS_DEBUG ' \
+               not in files["ComplexFileName1-debug-x64-data.cmake"]
+        # But components
+        assert 'set(OriginalDepName_GlobalPkgName1_MySuperPkg1_INCLUDE_DIRS_DEBUG ' \
                '"${OriginalDepName_PACKAGE_FOLDER_DEBUG}/include")' \
                in files["ComplexFileName1-debug-x64-data.cmake"]
 


### PR DESCRIPTION
Changelog: Feature: Changed `CMakeDeps` generator so the global target made for a package with components is a target linked with the targets of the components, instead of a target made from merging `cpp_info` objects from the components.

Changelog: Fix: The `cmake_build_modules` property can only be declared in the `self.cpp_info`, not in components, where will be ignored.

Docs: https://github.com/conan-io/docs/pull/2664

Closes: https://github.com/conan-io/conan/pull/11673