### PR TITLE
Add conan.conanrc file to setup the conan user home

### DIFF
--- a/conans/paths/__init__.py
+++ b/conans/paths/__init__.py
@@ -14,7 +14,7 @@ DEFAULT_CONAN_HOME = ".conan2"
 def get_conan_user_home():
     def _read_user_home_from_rc():
         try:
-            conanrc_path = os.path.join(os.getcwd(), "conan.conanrc")
+            conanrc_path = os.path.join(os.getcwd(), ".conanrc")
             values = {k: str(v) for k, v in
                       (line.split('=') for line in open(conanrc_path).read().splitlines() if
                        not line.startswith("#"))}

--- a/conans/paths/__init__.py
+++ b/conans/paths/__init__.py
@@ -25,9 +25,12 @@ def get_conan_user_home():
     def _user_home_from_conanrc_file():
         try:
             conanrc_path = _find_conanrc_file()
-            values = {k: str(v) for k, v in
-                      (line.split('=') for line in open(conanrc_path).read().splitlines() if
-                       not line.startswith("#"))}
+
+            with open(conanrc_path) as conanrc_file:
+                values = {k: str(v) for k, v in
+                          (line.split('=') for line in conanrc_file.read().splitlines() if
+                           not line.startswith("#"))}
+
             conan_home = values["conan_home"]
             # check if it's a local folder
             if conan_home[:2] in ("./", ".\\") or conan_home.startswith(".."):

--- a/conans/paths/__init__.py
+++ b/conans/paths/__init__.py
@@ -25,7 +25,7 @@ def get_conan_user_home():
         except KeyError:
             pass
 
-    if conanrc_home and conanrc_home[:2] in ("./", ".\\") or conanrc_home.startswith(".."):  # local
+    if conanrc_home and (conanrc_home[:2] in ("./", ".\\") or conanrc_home.startswith("..")):  # local
         conanrc_home = os.path.abspath(os.path.join(os.getcwd(), conanrc_home))
 
     user_home = conanrc_home or os.getenv("CONAN_HOME")

--- a/conans/paths/__init__.py
+++ b/conans/paths/__init__.py
@@ -25,7 +25,7 @@ def get_conan_user_home():
         except KeyError:
             pass
 
-    if conanrc_home[:2] in ("./", ".\\") or conanrc_home.startswith(".."):  # local
+    if conanrc_home and conanrc_home[:2] in ("./", ".\\") or conanrc_home.startswith(".."):  # local
         conanrc_home = os.path.abspath(os.path.join(os.getcwd(), conanrc_home))
 
     user_home = conanrc_home or os.getenv("CONAN_HOME")

--- a/conans/paths/__init__.py
+++ b/conans/paths/__init__.py
@@ -1,7 +1,8 @@
 # coding=utf-8
-
+from configparser import ConfigParser
 import os
 import platform
+
 
 if platform.system() == "Windows":
     from conans.util.windows import conan_expand_user
@@ -12,7 +13,22 @@ DEFAULT_CONAN_HOME = ".conan2"
 
 
 def get_conan_user_home():
-    user_home = os.getenv("CONAN_HOME")
+    conanrc_home = None
+
+    conanrc_config = ConfigParser()
+    conanrc_file = conanrc_config.read(os.path.join(os.getcwd(), "conan.conanrc"))
+
+    if conanrc_file:
+        try:
+            init_section = conanrc_config["init"]
+            conanrc_home = init_section["conan_home"]
+        except KeyError:
+            pass
+
+    if conanrc_home[:2] in ("./", ".\\") or conanrc_home.startswith(".."):  # local
+        conanrc_home = os.path.abspath(os.path.join(os.getcwd(), conanrc_home))
+
+    user_home = conanrc_home or os.getenv("CONAN_HOME")
     if user_home is None:
         # the default, in the user home
         user_home = os.path.join(conan_expand_user("~"), DEFAULT_CONAN_HOME)

--- a/conans/paths/__init__.py
+++ b/conans/paths/__init__.py
@@ -20,7 +20,7 @@ def get_conan_user_home():
                        not line.startswith("#"))}
             conan_home = values["conan_home"]
             # check if it's a local folder
-            if conan_home and (conan_home[:2] in ("./", ".\\") or conan_home.startswith("..")):
+            if conan_home[:2] in ("./", ".\\") or conan_home.startswith(".."):
                 conan_home = os.path.abspath(os.path.join(os.getcwd(), conan_home))
             return conan_home
         except (IOError, KeyError):

--- a/conans/test/unittests/paths/user_home_test.py
+++ b/conans/test/unittests/paths/user_home_test.py
@@ -1,6 +1,7 @@
 import os
+import platform
 
-from conans.paths import get_conan_user_home
+from conans.paths import get_conan_user_home, DEFAULT_CONAN_HOME
 from conans.test.utils.test_files import temp_folder
 from conans.util.files import chdir
 
@@ -9,7 +10,7 @@ def test_conanrc_abs_path_get_conan_user_home():
     _temp_folder = temp_folder(path_with_spaces=True)
     with chdir(_temp_folder):
         with open(os.path.join(_temp_folder, "conan.conanrc"), 'w+') as file:
-            file.write(f'[init]\nconan_home={_temp_folder}\n')
+            file.write(f'conan_home={_temp_folder}\n')
         conan_home = get_conan_user_home()
         assert _temp_folder == conan_home
 
@@ -19,7 +20,7 @@ def test_conanrc_local_path_get_conan_user_home():
     subfolder = "subfolder inside temp"
     with chdir(_temp_folder):
         with open(os.path.join(_temp_folder, "conan.conanrc"), 'w+') as file:
-            file.write(f'[init]\nconan_home=.{os.sep}{subfolder}\n')
+            file.write(f'conan_home=.{os.sep}{subfolder}\n')
         conan_home = get_conan_user_home()
         assert str(os.path.join(_temp_folder, subfolder)) == conan_home
 
@@ -30,6 +31,30 @@ def test_conanrc_local_outside_folder_path_get_conan_user_home():
     os.mkdir(folder1)
     with chdir(folder1):
         with open(os.path.join(folder1, "conan.conanrc"), 'w+') as file:
-            file.write(f'[init]\nconan_home=..{os.sep}folder2\n')
+            file.write(f'conan_home=..{os.sep}folder2\n')
         conan_home = get_conan_user_home()
         assert str(os.path.join(_temp_folder, "folder2")) == conan_home
+
+
+def test_conanrc_comments():
+    _temp_folder = temp_folder(path_with_spaces=True)
+    with chdir(_temp_folder):
+        with open(os.path.join(_temp_folder, "conan.conanrc"), 'w+') as file:
+            file.write(f'#commenting something\nconan_home={_temp_folder}\n')
+        conan_home = get_conan_user_home()
+        assert _temp_folder == conan_home
+
+
+def test_conanrc_wrong_format():
+    _temp_folder = temp_folder(path_with_spaces=True)
+    with chdir(_temp_folder):
+        with open(os.path.join(_temp_folder, "conan.conanrc"), 'w+') as file:
+            file.write(f'ronan_jome={_temp_folder}\n')
+        conan_home = get_conan_user_home()
+
+        if platform.system() == "Windows":
+            from conans.util.windows import conan_expand_user
+        else:
+            conan_expand_user = os.path.expanduser
+        assert os.path.join(conan_expand_user("~"), DEFAULT_CONAN_HOME) == conan_home
+        assert _temp_folder not in conan_home

--- a/conans/test/unittests/paths/user_home_test.py
+++ b/conans/test/unittests/paths/user_home_test.py
@@ -1,0 +1,35 @@
+import os
+
+from conans.paths import get_conan_user_home
+from conans.test.utils.test_files import temp_folder
+from conans.util.files import chdir
+
+
+def test_conanrc_abs_path_get_conan_user_home():
+    _temp_folder = temp_folder(path_with_spaces=True)
+    with chdir(_temp_folder):
+        with open(os.path.join(_temp_folder, "conan.conanrc"), 'w+') as file:
+            file.write(f'[init]\nconan_home={_temp_folder}\n')
+        conan_home = get_conan_user_home()
+        assert _temp_folder == conan_home
+
+
+def test_conanrc_local_path_get_conan_user_home():
+    _temp_folder = temp_folder(path_with_spaces=True)
+    subfolder = "subfolder inside temp"
+    with chdir(_temp_folder):
+        with open(os.path.join(_temp_folder, "conan.conanrc"), 'w+') as file:
+            file.write(f'[init]\nconan_home=.{os.sep}{subfolder}\n')
+        conan_home = get_conan_user_home()
+        assert str(os.path.join(_temp_folder, subfolder)) == conan_home
+
+
+def test_conanrc_local_outside_folder_path_get_conan_user_home():
+    _temp_folder = temp_folder(path_with_spaces=True)
+    folder1 = os.path.join(_temp_folder, "folder1")
+    os.mkdir(folder1)
+    with chdir(folder1):
+        with open(os.path.join(folder1, "conan.conanrc"), 'w+') as file:
+            file.write(f'[init]\nconan_home=..{os.sep}folder2\n')
+        conan_home = get_conan_user_home()
+        assert str(os.path.join(_temp_folder, "folder2")) == conan_home

--- a/conans/test/unittests/paths/user_home_test.py
+++ b/conans/test/unittests/paths/user_home_test.py
@@ -9,7 +9,7 @@ from conans.util.files import chdir
 def test_conanrc_abs_path_get_conan_user_home():
     _temp_folder = temp_folder(path_with_spaces=True)
     with chdir(_temp_folder):
-        with open(os.path.join(_temp_folder, "conan.conanrc"), 'w+') as file:
+        with open(os.path.join(_temp_folder, ".conanrc"), 'w+') as file:
             file.write(f'conan_home={_temp_folder}\n')
         conan_home = get_conan_user_home()
         assert _temp_folder == conan_home
@@ -19,7 +19,7 @@ def test_conanrc_local_path_get_conan_user_home():
     _temp_folder = temp_folder(path_with_spaces=True)
     subfolder = "subfolder inside temp"
     with chdir(_temp_folder):
-        with open(os.path.join(_temp_folder, "conan.conanrc"), 'w+') as file:
+        with open(os.path.join(_temp_folder, ".conanrc"), 'w+') as file:
             file.write(f'conan_home=.{os.sep}{subfolder}\n')
         conan_home = get_conan_user_home()
         assert str(os.path.join(_temp_folder, subfolder)) == conan_home
@@ -30,7 +30,7 @@ def test_conanrc_local_outside_folder_path_get_conan_user_home():
     folder1 = os.path.join(_temp_folder, "folder1")
     os.mkdir(folder1)
     with chdir(folder1):
-        with open(os.path.join(folder1, "conan.conanrc"), 'w+') as file:
+        with open(os.path.join(folder1, ".conanrc"), 'w+') as file:
             file.write(f'conan_home=..{os.sep}folder2\n')
         conan_home = get_conan_user_home()
         assert str(os.path.join(_temp_folder, "folder2")) == conan_home
@@ -39,7 +39,7 @@ def test_conanrc_local_outside_folder_path_get_conan_user_home():
 def test_conanrc_comments():
     _temp_folder = temp_folder(path_with_spaces=True)
     with chdir(_temp_folder):
-        with open(os.path.join(_temp_folder, "conan.conanrc"), 'w+') as file:
+        with open(os.path.join(_temp_folder, ".conanrc"), 'w+') as file:
             file.write(f'#commenting something\nconan_home={_temp_folder}\n')
         conan_home = get_conan_user_home()
         assert _temp_folder == conan_home
@@ -48,7 +48,7 @@ def test_conanrc_comments():
 def test_conanrc_wrong_format():
     _temp_folder = temp_folder(path_with_spaces=True)
     with chdir(_temp_folder):
-        with open(os.path.join(_temp_folder, "conan.conanrc"), 'w+') as file:
+        with open(os.path.join(_temp_folder, ".conanrc"), 'w+') as file:
             file.write(f'ronan_jome={_temp_folder}\n')
         conan_home = get_conan_user_home()
 

--- a/conans/test/unittests/paths/user_home_test.py
+++ b/conans/test/unittests/paths/user_home_test.py
@@ -1,16 +1,24 @@
 import os
 import platform
+from pathlib import Path
 
 from conans.paths import get_conan_user_home, DEFAULT_CONAN_HOME
 from conans.test.utils.test_files import temp_folder
 from conans.util.files import chdir
 
+if platform.system() == "Windows":
+    from conans.util.windows import conan_expand_user
+else:
+    conan_expand_user = os.path.expanduser
+
 
 def test_conanrc_abs_path_get_conan_user_home():
     _temp_folder = temp_folder(path_with_spaces=True)
-    with chdir(_temp_folder):
-        with open(os.path.join(_temp_folder, ".conanrc"), 'w+') as file:
-            file.write(f'conan_home={_temp_folder}\n')
+    folder_conan_runs = os.path.join(_temp_folder, "folder_where_conan_runs")
+    os.mkdir(folder_conan_runs)
+    with open(os.path.join(_temp_folder, ".conanrc"), 'w+') as file:
+        file.write(f'conan_home={_temp_folder}\n')
+    with chdir(folder_conan_runs):
         conan_home = get_conan_user_home()
         assert _temp_folder == conan_home
 
@@ -25,6 +33,17 @@ def test_conanrc_local_path_get_conan_user_home():
         assert str(os.path.join(_temp_folder, subfolder)) == conan_home
 
 
+def test_conanrc_local_path_run_conan_subfolder_get_conan_user_home():
+    _temp_folder = temp_folder(path_with_spaces=True)
+    folder_conan_runs = os.path.join(_temp_folder, "folder_where_conan_runs")
+    os.mkdir(folder_conan_runs)
+    with open(os.path.join(_temp_folder, ".conanrc"), 'w+') as file:
+        file.write(f'conan_home=.{os.sep}\n')
+    with chdir(folder_conan_runs):
+        conan_home = get_conan_user_home()
+        assert str(os.path.join(_temp_folder)) == conan_home
+
+
 def test_conanrc_local_outside_folder_path_get_conan_user_home():
     _temp_folder = temp_folder(path_with_spaces=True)
     folder1 = os.path.join(_temp_folder, "folder1")
@@ -33,7 +52,8 @@ def test_conanrc_local_outside_folder_path_get_conan_user_home():
         with open(os.path.join(folder1, ".conanrc"), 'w+') as file:
             file.write(f'conan_home=..{os.sep}folder2\n')
         conan_home = get_conan_user_home()
-        assert str(os.path.join(_temp_folder, "folder2")) == conan_home
+        this_path = Path(_temp_folder) / "folder1" / f"..{os.sep}folder2"
+        assert str(this_path) == str(conan_home)
 
 
 def test_conanrc_comments():
@@ -52,9 +72,12 @@ def test_conanrc_wrong_format():
             file.write(f'ronan_jome={_temp_folder}\n')
         conan_home = get_conan_user_home()
 
-        if platform.system() == "Windows":
-            from conans.util.windows import conan_expand_user
-        else:
-            conan_expand_user = os.path.expanduser
         assert os.path.join(conan_expand_user("~"), DEFAULT_CONAN_HOME) == conan_home
         assert _temp_folder not in conan_home
+
+
+def test_conanrc_not_existing():
+    _temp_folder = temp_folder(path_with_spaces=True)
+    with chdir(_temp_folder):
+        conan_home = get_conan_user_home()
+    assert os.path.join(conan_expand_user("~"), DEFAULT_CONAN_HOME) == conan_home


### PR DESCRIPTION
Closes: https://github.com/conan-io/conan/issues/11542

You can create a _.conanrc_ file in the folder where you are running conan (or any parent folder), it can have this content:

Set the conan home to an absolute folder
```
# accepts comments
conan_home=/absolute/folder
```

Set the conan home to a relative folder inside the current folder
```
# accepts comments
conan_home=./relative folder/inside current folder
```

Set the conan home to a relative folder outside the current folder
```
# accepts comments
conan_home=../relative folder/outside current folder
```

Set the conan home to a path containing the `~` that will be expanded to the system's user home
```
# accepts comments
conan_home=~/use the user home to expand it
```
The _.conanrc_ file is searched for in all parent folders so, if for example, in this structure:

````
.
.conanrc
├── project1
└── project2
````

And you are running from folder `project1` the parent folders are traversed recursively until a _.conanrc_ is found in case it exists.

