### PR TITLE
add conan.tools.scm as hidden-import to pyinstaller

### DIFF
--- a/pyinstaller.py
+++ b/pyinstaller.py
@@ -98,7 +98,7 @@ def pyinstall(source_folder):
               "--hidden-import=conan.tools.files --hidden-import=conan.tools.gnu "
               "--hidden-import=conan.tools.google --hidden-import=conan.tools.intel "
               "--hidden-import=conan.tools.layout --hidden-import=conan.tools.premake "
-              "--hidden-import=conan.tools.qbs")
+              "--hidden-import=conan.tools.qbs --hidden-import=conan.tools.scm")
     if platform.system() != "Windows":
         hidden += " --hidden-import=setuptools.msvc"
         win_ver = ""


### PR DESCRIPTION
Changelog: Fix: Add `conan.tools.scm` as hidden-import to _pyinstaller.py_, so it is bundled with the installer.
Docs: Omit

Close #11676 