### PR TITLE
AutotoolsToolchain: empty None values from self fields + Refactor

### DIFF
--- a/conan/tools/gnu/autotoolstoolchain.py
+++ b/conan/tools/gnu/autotoolstoolchain.py
@@ -152,14 +152,19 @@ class AutotoolsToolchain:
                             + apple_flags + extra_flags["ldflags"])
         self.defines.extend([self.ndebug, self.gcc_cxx11_abi] + extra_flags["defines"])
 
+        self.cxxflags = self._filter_list_empty_fields(self.cxxflags)
+        self.cflags = self._filter_list_empty_fields(self.cflags)
+        self.ldflags = self._filter_list_empty_fields(self.ldflags)
+        self.defines = self._filter_list_empty_fields(self.defines)
+
         if is_msvc(self._conanfile):
             env.define("CXX", "cl")
             env.define("CC", "cl")
 
-        env.append("CPPFLAGS", ["-D{}".format(d) for d in self._filter_list_empty_fields(self.defines)])
-        env.append("CXXFLAGS", self._filter_list_empty_fields(self.cxxflags))
-        env.append("CFLAGS", self._filter_list_empty_fields(self.cflags))
-        env.append("LDFLAGS", self._filter_list_empty_fields(self.ldflags))
+        env.append("CPPFLAGS", ["-D{}".format(d) for d in self.defines])
+        env.append("CXXFLAGS", self.cxxflags)
+        env.append("CFLAGS", self.cflags)
+        env.append("LDFLAGS", self.ldflags)
         env.prepend_path("PKG_CONFIG_PATH", self._conanfile.generators_folder)
 
         return env

--- a/conan/tools/gnu/autotoolstoolchain.py
+++ b/conan/tools/gnu/autotoolstoolchain.py
@@ -22,10 +22,10 @@ class AutotoolsToolchain:
         self.make_args = []
 
         # Flags
-        self.cxxflags = []
-        self.cflags = []
-        self.ldflags = []
-        self.defines = []
+        self.extra_cxxflags = []
+        self.extra_cflags = []
+        self.extra_ldflags = []
+        self.extra_defines = []
 
         # Defines
         self.gcc_cxx11_abi = self._get_cxx11_abi_define()
@@ -122,51 +122,52 @@ class AutotoolsToolchain:
     def _filter_list_empty_fields(v):
         return list(filter(bool, v))
 
-    def _get_extra_flags(self):
-        # Now, it's time to get all the flags defined by the user
-        cxxflags = self._conanfile.conf.get("tools.build:cxxflags", default=[], check_type=list)
-        cflags = self._conanfile.conf.get("tools.build:cflags", default=[], check_type=list)
-        sharedlinkflags = self._conanfile.conf.get("tools.build:sharedlinkflags", default=[], check_type=list)
-        exelinkflags = self._conanfile.conf.get("tools.build:exelinkflags", default=[], check_type=list)
-        defines = self._conanfile.conf.get("tools.build:defines", default=[], check_type=list)
-        return {
-            "cxxflags": cxxflags,
-            "cflags": cflags,
-            "defines": defines,
-            "ldflags": sharedlinkflags + exelinkflags
-        }
+    @property
+    def cxxflags(self):
+        fpic = "-fPIC" if self.fpic else None
+        ret = [self.libcxx, self.cppstd, self.arch_flag, fpic, self.msvc_runtime_flag,
+               self.sysroot_flag]
+        apple_flags = [self.apple_isysroot_flag, self.apple_arch_flag, self.apple_min_version_flag]
+        conf_flags = self._conanfile.conf.get("tools.build:cxxflags", default=[], check_type=list)
+        ret = ret + self.build_type_flags + apple_flags + conf_flags + self.extra_cxxflags
+        return self._filter_list_empty_fields(ret)
+
+    @property
+    def cflags(self):
+        fpic = "-fPIC" if self.fpic else None
+        ret = [self.arch_flag, fpic, self.msvc_runtime_flag, self.sysroot_flag]
+        apple_flags = [self.apple_isysroot_flag, self.apple_arch_flag, self.apple_min_version_flag]
+        conf_flags = self._conanfile.conf.get("tools.build:cflags", default=[], check_type=list)
+        ret = ret + self.build_type_flags + apple_flags + conf_flags + self.extra_cflags
+        return self._filter_list_empty_fields(ret)
+
+    @property
+    def ldflags(self):
+        ret = [self.arch_flag, self.sysroot_flag]
+        apple_flags = [self.apple_isysroot_flag, self.apple_arch_flag, self.apple_min_version_flag]
+        conf_flags = self._conanfile.conf.get("tools.build:sharedlinkflags", default=[],
+                                              check_type=list)
+        conf_flags.extend(self._conanfile.conf.get("tools.build:exelinkflags", default=[],
+                                                   check_type=list))
+        ret = ret + apple_flags + conf_flags + self.build_type_link_flags + self.extra_ldflags
+        return self._filter_list_empty_fields(ret)
+
+    @property
+    def defines(self):
+        conf_flags = self._conanfile.conf.get("tools.build:defines", default=[], check_type=list)
+        ret = [self.ndebug, self.gcc_cxx11_abi] + conf_flags + self.extra_defines
+        return self._filter_list_empty_fields(ret)
 
     def environment(self):
         env = Environment()
-
-        apple_flags = [self.apple_isysroot_flag, self.apple_arch_flag, self.apple_min_version_flag]
-        fpic = "-fPIC" if self.fpic else None
-        extra_flags = self._get_extra_flags()
-
-        self.cxxflags.extend([self.libcxx, self.cppstd,
-                              self.arch_flag, fpic, self.msvc_runtime_flag, self.sysroot_flag]
-                             + self.build_type_flags + apple_flags + extra_flags["cxxflags"])
-        self.cflags.extend([self.arch_flag, fpic, self.msvc_runtime_flag, self.sysroot_flag]
-                           + self.build_type_flags + apple_flags + extra_flags["cflags"])
-        self.ldflags.extend([self.arch_flag, self.sysroot_flag] + self.build_type_link_flags
-                            + apple_flags + extra_flags["ldflags"])
-        self.defines.extend([self.ndebug, self.gcc_cxx11_abi] + extra_flags["defines"])
-
-        self.cxxflags = self._filter_list_empty_fields(self.cxxflags)
-        self.cflags = self._filter_list_empty_fields(self.cflags)
-        self.ldflags = self._filter_list_empty_fields(self.ldflags)
-        self.defines = self._filter_list_empty_fields(self.defines)
-
         if is_msvc(self._conanfile):
             env.define("CXX", "cl")
             env.define("CC", "cl")
-
         env.append("CPPFLAGS", ["-D{}".format(d) for d in self.defines])
         env.append("CXXFLAGS", self.cxxflags)
         env.append("CFLAGS", self.cflags)
         env.append("LDFLAGS", self.ldflags)
         env.prepend_path("PKG_CONFIG_PATH", self._conanfile.generators_folder)
-
         return env
 
     def vars(self):

--- a/conans/test/integration/toolchains/gnu/test_autotoolstoolchain.py
+++ b/conans/test/integration/toolchains/gnu/test_autotoolstoolchain.py
@@ -42,3 +42,29 @@ def test_extra_flags_via_conf():
         assert 'export CXXFLAGS="$CXXFLAGS -O3 -s --flag1 --flag2"' in toolchain
         assert 'export CFLAGS="$CFLAGS -O3 -s --flag3 --flag4"' in toolchain
         assert 'export LDFLAGS="$LDFLAGS --flag5 --flag6"' in toolchain
+
+
+def test_not_none_values():
+
+    conanfile = textwrap.dedent("""
+        from conan import ConanFile
+        from conan.tools.gnu import AutotoolsToolchain
+
+        class Foo(ConanFile):
+            name = "foo"
+            version = "1.0"
+
+            def generate(self):
+                tc = AutotoolsToolchain(self)
+                tc.environment()
+                assert None not in tc.defines
+                assert None not in tc.cxxflags
+                assert None not in tc.cflags
+                assert None not in tc.ldflags
+
+    """)
+
+    client = TestClient()
+    client.save({"conanfile.py": conanfile})
+    client.run("install .")
+

--- a/conans/test/integration/toolchains/gnu/test_autotoolstoolchain.py
+++ b/conans/test/integration/toolchains/gnu/test_autotoolstoolchain.py
@@ -56,7 +56,6 @@ def test_not_none_values():
 
             def generate(self):
                 tc = AutotoolsToolchain(self)
-                tc.environment()
                 assert None not in tc.defines
                 assert None not in tc.cxxflags
                 assert None not in tc.cflags

--- a/conans/test/unittests/client/toolchain/autotools/autotools_toolchain_test.py
+++ b/conans/test/unittests/client/toolchain/autotools/autotools_toolchain_test.py
@@ -365,6 +365,11 @@ def test_custom_defines():
          "arch": "armv8"})
     be = AutotoolsToolchain(conanfile)
     be.extra_defines = ["MyDefine1", "MyDefine2"]
+
+    assert "MyDefine1" in be.defines
+    assert "MyDefine2" in be.defines
+    assert "NDEBUG" in be.defines
+
     env = be.vars()
     assert "-DMyDefine1" in env["CPPFLAGS"]
     assert "-DMyDefine2" in env["CPPFLAGS"]
@@ -381,6 +386,13 @@ def test_custom_cxxflags():
          "arch": "armv8"})
     be = AutotoolsToolchain(conanfile)
     be.extra_cxxflags = ["MyFlag1", "MyFlag2"]
+
+    assert "MyFlag1" in be.cxxflags
+    assert "MyFlag2" in be.cxxflags
+    assert "-mios-version-min=14" in be.cxxflags
+    assert "MyFlag" not in be.cflags
+    assert "MyFlag" not in be.ldflags
+
     env = be.vars()
     assert "MyFlag1" in env["CXXFLAGS"]
     assert "MyFlag2" in env["CXXFLAGS"]
@@ -400,6 +412,13 @@ def test_custom_cflags():
          "arch": "armv8"})
     be = AutotoolsToolchain(conanfile)
     be.extra_cflags = ["MyFlag1", "MyFlag2"]
+
+    assert "MyFlag1" in be.cflags
+    assert "MyFlag2" in be.cflags
+    assert "-mios-version-min=14" in be.cflags
+    assert "MyFlag" not in be.cxxflags
+    assert "MyFlag" not in be.ldflags
+
     env = be.vars()
     assert "MyFlag1" in env["CFLAGS"]
     assert "MyFlag2" in env["CFLAGS"]
@@ -419,6 +438,13 @@ def test_custom_ldflags():
          "arch": "armv8"})
     be = AutotoolsToolchain(conanfile)
     be.extra_ldflags = ["MyFlag1", "MyFlag2"]
+
+    assert "MyFlag1" in be.ldflags
+    assert "MyFlag2" in be.ldflags
+    assert "-mios-version-min=14" in be.ldflags
+    assert "MyFlag" not in be.cxxflags
+    assert "MyFlag" not in be.cflags
+
     env = be.vars()
     assert "MyFlag1" in env["LDFLAGS"]
     assert "MyFlag2" in env["LDFLAGS"]

--- a/conans/test/unittests/client/toolchain/autotools/autotools_toolchain_test.py
+++ b/conans/test/unittests/client/toolchain/autotools/autotools_toolchain_test.py
@@ -364,7 +364,7 @@ def test_custom_defines():
          "os.version": "14",
          "arch": "armv8"})
     be = AutotoolsToolchain(conanfile)
-    be.defines = ["MyDefine1", "MyDefine2"]
+    be.extra_defines = ["MyDefine1", "MyDefine2"]
     env = be.vars()
     assert "-DMyDefine1" in env["CPPFLAGS"]
     assert "-DMyDefine2" in env["CPPFLAGS"]
@@ -380,7 +380,7 @@ def test_custom_cxxflags():
          "os.version": "14",
          "arch": "armv8"})
     be = AutotoolsToolchain(conanfile)
-    be.cxxflags = ["MyFlag1", "MyFlag2"]
+    be.extra_cxxflags = ["MyFlag1", "MyFlag2"]
     env = be.vars()
     assert "MyFlag1" in env["CXXFLAGS"]
     assert "MyFlag2" in env["CXXFLAGS"]
@@ -399,7 +399,7 @@ def test_custom_cflags():
          "os.version": "14",
          "arch": "armv8"})
     be = AutotoolsToolchain(conanfile)
-    be.cflags = ["MyFlag1", "MyFlag2"]
+    be.extra_cflags = ["MyFlag1", "MyFlag2"]
     env = be.vars()
     assert "MyFlag1" in env["CFLAGS"]
     assert "MyFlag2" in env["CFLAGS"]
@@ -418,7 +418,7 @@ def test_custom_ldflags():
          "os.version": "14",
          "arch": "armv8"})
     be = AutotoolsToolchain(conanfile)
-    be.ldflags = ["MyFlag1", "MyFlag2"]
+    be.extra_ldflags = ["MyFlag1", "MyFlag2"]
     env = be.vars()
     assert "MyFlag1" in env["LDFLAGS"]
     assert "MyFlag2" in env["LDFLAGS"]


### PR DESCRIPTION
Changelog: Bugfix: The `AutotoolsToolchain` now clears `None` values from the attributes `.cxxflags`, `.cflags`, `.ldflags` and `.defines`.
Changelog: Feature: The `AutotoolsToolchain` attributes `.cxxflags`, `.cflags`, `.ldflags` and `.defines` can be read at any moment, now is not needed to call `.environment()` to get them calculated. In the other hand, if you want to add additional flags the following attributes have to be used: `.extra_cxxflags`, `.extra_cflags`, `.extra_ldflags` and `.extra_defines`
Docs: https://github.com/conan-io/docs/pull/2660

