### PR TITLE
MSBuildDeps traits

### DIFF
--- a/conans/test/functional/toolchains/cmake/cmakedeps/test_cmakedeps_transitivity.py
+++ b/conans/test/functional/toolchains/cmake/cmakedeps/test_cmakedeps_transitivity.py
@@ -5,20 +5,13 @@ import pytest
 
 from conan.tools.env.environment import environment_wrap_command
 from conans.test.assets.cmake import gen_cmakelists
-from conans.test.assets.pkg_cmake import pkg_cmake
 from conans.test.assets.sources import gen_function_cpp
-from conans.test.utils.tools import TestClient
 
 
 @pytest.mark.skipif(platform.system() != "Windows", reason="Requires MSBuild")
 @pytest.mark.tool("cmake")
-def test_transitive_headers_not_public():
-    c = TestClient()
-
-    c.save(pkg_cmake("liba", "0.1"))
-    c.run("create .")
-    c.save(pkg_cmake("libb", "0.1", requires=["liba/0.1"]), clean_first=True)
-    c.run("create .")
+def test_transitive_headers_not_public(transitive_libraries):
+    c = transitive_libraries
 
     conanfile = textwrap.dedent("""\
        from conan import ConanFile
@@ -57,13 +50,8 @@ def test_transitive_headers_not_public():
 
 @pytest.mark.skipif(platform.system() != "Windows", reason="Requires MSBuild")
 @pytest.mark.tool("cmake")
-def test_shared_requires_static():
-    c = TestClient()
-
-    c.save(pkg_cmake("liba", "0.1"))
-    c.run("create .")
-    c.save(pkg_cmake("libb", "0.1", requires=["liba/0.1"]), clean_first=True)
-    c.run("create . -o libb/*:shared=True")
+def test_shared_requires_static(transitive_libraries):
+    c = transitive_libraries
 
     conanfile = textwrap.dedent("""\
        from conan import ConanFile
@@ -97,13 +85,8 @@ def test_shared_requires_static():
 
 @pytest.mark.skipif(platform.system() != "Windows", reason="Requires MSBuild")
 @pytest.mark.tool("cmake")
-def test_transitive_binary_skipped():
-    c = TestClient()
-
-    c.save(pkg_cmake("liba", "0.1"))
-    c.run("create .")
-    c.save(pkg_cmake("libb", "0.1", requires=["liba/0.1"]), clean_first=True)
-    c.run("create . -o libb/*:shared=True")
+def test_transitive_binary_skipped(transitive_libraries):
+    c = transitive_libraries
     # IMPORTANT: liba binary can be removed, no longer necessary
     c.run("remove liba* -p -f")
 

--- a/conans/test/functional/toolchains/conftest.py
+++ b/conans/test/functional/toolchains/conftest.py
@@ -1,0 +1,28 @@
+import os
+import shutil
+
+import pytest
+
+from conans.test.assets.pkg_cmake import pkg_cmake
+from conans.test.utils.test_files import temp_folder
+from conans.test.utils.tools import TestClient
+
+
+@pytest.fixture(scope="session")
+def _transitive_libraries():
+    c = TestClient()
+
+    c.save(pkg_cmake("liba", "0.1"))
+    c.run("create .")
+    c.save(pkg_cmake("libb", "0.1", requires=["liba/0.1"]), clean_first=True)
+    c.run("create .")
+    c.run("create . -o libb/*:shared=True")
+    return c
+
+
+@pytest.fixture()
+def transitive_libraries(_transitive_libraries):
+    c = TestClient()
+    c.cache_folder = os.path.join(temp_folder(), ".conan2")
+    shutil.copytree(_transitive_libraries.cache_folder, c.cache_folder)
+    return c

--- a/conans/test/functional/toolchains/microsoft/test_msbuilddeps_traits.py
+++ b/conans/test/functional/toolchains/microsoft/test_msbuilddeps_traits.py
@@ -1,0 +1,39 @@
+import os
+import platform
+import textwrap
+
+import pytest
+
+from conan.tools.env.environment import environment_wrap_command
+from conans.test.assets.cmake import gen_cmakelists
+from conans.test.assets.genconanfile import GenConanfile
+from conans.test.assets.sources import gen_function_cpp
+
+
+@pytest.mark.skipif(platform.system() != "Windows", reason="Requires MSBuild")
+def test_transitive_headers_not_public(transitive_libraries):
+    c = transitive_libraries
+    c.save({"conanfile.py": GenConanfile().with_settings("build_type", "arch")
+                                          .with_generator("MSBuildDeps").with_requires("libb/0.1")},
+           clean_first=True)
+
+    c.run("install .")
+    liba_data = c.load("conan_liba_vars_release_x64.props")
+    assert "<ConanlibaIncludeDirectories></ConanlibaIncludeDirectories>" in liba_data
+    assert "<ConanlibaLibraryDirectories>$(ConanlibaRootFolder)/lib;</ConanlibaLibraryDirectories>" \
+           in liba_data
+    assert "<ConanlibaLibraries>liba.lib;</ConanlibaLibraries>" in liba_data
+
+
+@pytest.mark.skipif(platform.system() != "Windows", reason="Requires MSBuild")
+def test_shared_requires_static(transitive_libraries):
+    c = transitive_libraries
+    c.save({"conanfile.py": GenConanfile().with_settings("build_type", "arch")
+           .with_generator("MSBuildDeps").with_requires("libb/0.1")},
+           clean_first=True)
+
+    c.run("install . -o libb*:shared=True")
+    assert not os.path.exists(os.path.join(c.current_folder, "conan_liba_vars_release_x64.props"))
+    libb_data = c.load("conan_libb_vars_release_x64.props")
+    # No dependency to liba, it has been skipped as unnecessary
+    assert "<ConanlibbDependencies></ConanlibbDependencies>" in libb_data


### PR DESCRIPTION
Close https://github.com/conan-io/conan/issues/11520

As I needed some dependencies, I reused the data from the CMake tests for traits, making it a ``session`` fixture. At least in Windows that reduces test time +50%, from 30 secs in my computer to 12secs (only for the previous tests, savings will be bigger if I counted the new tests). 

Seems a good approach to save test time, but the team should be aware of this, and use it accordingly, discussing when necessary what common fixtures make sense.