### PR TITLE
Fix non subscriptable error in develop 2 with pathlib

### DIFF
--- a/conans/util/windows.py
+++ b/conans/util/windows.py
@@ -5,6 +5,7 @@ def conan_expand_user(path):
     """ wrapper to the original expanduser function, to workaround python returning
     verbatim %USERPROFILE% when some other app (git for windows) sets HOME envvar
     """
+    path = str(path)
     if path[:1] != '~':
         return path
     # In win these variables should exist and point to user directory, which


### PR DESCRIPTION
This wont run on the PR (we only run unittests on Linux on PR's) ci but I checked locally that solves the issue. The function conan_expand_user in Windows was taking a path that was not subscriptable, let's force it to a str.