### PR TITLE
Explore new syntax alternative to self.cpp_info.requires for components

### DIFF
--- a/conans/client/conanfile/configure.py
+++ b/conans/client/conanfile/configure.py
@@ -38,6 +38,16 @@ def run_configure_method(conanfile, down_options, profile_options, ref):
             with conanfile_exception_formatter(conanfile, "requirements"):
                 conanfile.requirements()
 
+        set_cpp_info_requires = False
+        for require in conanfile.requires.values():
+            if require.components:
+                set_cpp_info_requires = True
+                break
+
+        if set_cpp_info_requires:
+            print(require.components)
+            print(conanfile.cpp.package)
+
         # TODO: Maybe this could be integrated in one single requirements() method
         if hasattr(conanfile, "build_requirements"):
             with conanfile_exception_formatter(conanfile, "build_requirements"):

--- a/conans/model/requires.py
+++ b/conans/model/requires.py
@@ -11,7 +11,7 @@ class Requirement:
     """
     def __init__(self, ref, *, headers=None, libs=None, build=False, run=None, visible=None,
                  transitive_headers=None, transitive_libs=None, test=None, package_id_mode=None,
-                 force=None, override=None, direct=None, options=None):
+                 force=None, override=None, direct=None, options=None, components=None):
         # * prevents the usage of more positional parameters, always ref + **kwargs
         # By default this is a generic library requirement
         self.ref = ref
@@ -27,6 +27,7 @@ class Requirement:
         self._force = force
         self._override = override
         self._direct = direct
+        self.components = components
         self.options = options
 
     @staticmethod

--- a/conans/test/integration/test_components.py
+++ b/conans/test/integration/test_components.py
@@ -94,10 +94,20 @@ def test_components_cycle_complex():
 
 def test_requires_components_new_syntax():
     """
-    lib_a: has four components cmp1, cmp2, cmp3, cmp4
-    lib_b --> uses libA cmp1 so cpp_info.requires = ["lib_a::cmp1"]
-    lib_c --> uses libA cmp2 so cpp_info.requires = ["lib_a::cmp2"]
-    consumer --> libB, libC
+    Check that the generated files for the current syntax of cpp_info.requires
+    are exactly the same as the syntax with requires(.., components=...)
+
+    def requirements(self):
+        self.requires("lib_a/1.0", components=["cmp1"])
+        self.requires("lib_b/1.0")
+
+    is equivalent to:
+
+    def requirements(self):
+        self.requires("lib_a/1.0")
+        self.requires("lib_b/1.0")
+    def package_info(self):
+        self.cpp_info.requires = ["lib_a::cmp1", "lib_b::lib_b"]
     """
     client = TestClient()
     lib_a = textwrap.dedent("""
@@ -118,14 +128,6 @@ def test_requires_components_new_syntax():
     client.run("create lib_a")
 
     client.run("create lib_b")
-
-    """
-    Check that the generated lib_c files use lib_a::cmp1 and lib_b but not lib_a::cmp2
-    The results must be equivalent to the declaration of
-        def package_info(self):
-            self.cpp_info.requires = ["lib_a::cmp1", "lib_b::lib_b"]
-    in lib_c
-    """
 
     lib_c = textwrap.dedent("""
         from conan import ConanFile

--- a/conans/test/integration/test_components.py
+++ b/conans/test/integration/test_components.py
@@ -144,37 +144,39 @@ def test_requires_components_new_syntax():
 
     old_syntax = """
     def requirements(self):
-        self.requires("lib_a/1.0", components=["cmp1"])
+        self.requires("lib_a/1.0")
         self.requires("lib_b/1.0")
     def package_info(self):
         self.cpp_info.requires = ["lib_a::cmp1", "lib_b::lib_b"]
     """
 
-    client.save({'lib_c/conanfile.py': lib_c.format(rest_of_file=new_syntax)},
-                clean_first=True)
+    for generator in ["CMakeDeps", "XcodeDeps", "PkgConfigDeps", "MSBuildDeps"]:
 
-    client.run("create lib_c")
+        client.save({'lib_c/conanfile.py': lib_c.format(rest_of_file=new_syntax)},
+                    clean_first=True)
 
-    client.run("install --requires=lib_c/1.0 -g CMakeDeps -of=output")
+        client.run("create lib_c")
 
-    generated_files = {}
-    for _, _, files in os.walk(os.path.join(client.current_folder, "output")):
-        for f in files:
-            file_content = client.load(os.path.join(client.current_folder, "output", f))
-            # remove info about cache folders
-            file_content = re.sub(fr'(?s)(\.conan2{os.path.sep}p)(.*?)(p)', "", file_content)
-            generated_files[f] = file_content
+        client.run(f"install --requires=lib_c/1.0 -g {generator} -of=output")
 
-    client.save({'lib_c/conanfile.py': lib_c.format(rest_of_file=old_syntax)},
-                clean_first=True)
+        generated_files = {}
+        for _, _, files in os.walk(os.path.join(client.current_folder, "output")):
+            for f in files:
+                file_content = client.load(os.path.join(client.current_folder, "output", f))
+                # remove info about cache folders
+                file_content = re.sub(fr'(?s)(\.conan2{os.path.sep}p)(.*?)(p)', "", file_content)
+                generated_files[f] = file_content
 
-    client.run("create lib_c")
+        client.save({'lib_c/conanfile.py': lib_c.format(rest_of_file=old_syntax)},
+                    clean_first=True)
 
-    client.run("install --requires=lib_c/1.0 -g CMakeDeps -of=output")
+        client.run("create lib_c")
 
-    # the generated files with the old syntax should be exactly the same as the new one
-    for _, _, files in os.walk(os.path.join(client.current_folder, "output")):
-        for f in files:
-            old_syntax_file = client.load(os.path.join(client.current_folder, "output", f))
-            old_syntax_file = re.sub(fr'(?s)(\.conan2{os.path.sep}p)(.*?)(p)', "", old_syntax_file)
-            assert generated_files[f] == old_syntax_file
+        client.run(f"install --requires=lib_c/1.0 -g {generator} -of=output")
+
+        # the generated files with the old syntax should be exactly the same as the new one
+        for _, _, files in os.walk(os.path.join(client.current_folder, "output")):
+            for f in files:
+                old_syntax_file = client.load(os.path.join(client.current_folder, "output", f))
+                old_syntax_file = re.sub(fr'(?s)(\.conan2{os.path.sep}p)(.*?)(p)', "", old_syntax_file)
+                assert generated_files[f] == old_syntax_file

--- a/conans/test/integration/test_components.py
+++ b/conans/test/integration/test_components.py
@@ -160,11 +160,12 @@ def test_requires_components_new_syntax():
         client.run(f"install --requires=lib_c/1.0 -g {generator} -of=output")
 
         generated_files = {}
+        # remove all info about cache folders that could be different
+        genexp_pick_folder = fr'(?s)(\.conan2{os.path.sep}p)(.*?)(p)'
         for _, _, files in os.walk(os.path.join(client.current_folder, "output")):
             for f in files:
-                file_content = client.load(os.path.join(client.current_folder, "output", f))
-                # remove info about cache folders
-                file_content = re.sub(fr'(?s)(\.conan2{os.path.sep}p)(.*?)(p)', "", file_content)
+                file_content = re.sub(genexp_pick_folder, "",
+                                      client.load(os.path.join(client.current_folder, "output", f)))
                 generated_files[f] = file_content
 
         client.save({'lib_c/conanfile.py': lib_c.format(rest_of_file=old_syntax)},
@@ -177,6 +178,6 @@ def test_requires_components_new_syntax():
         # the generated files with the old syntax should be exactly the same as the new one
         for _, _, files in os.walk(os.path.join(client.current_folder, "output")):
             for f in files:
-                old_syntax_file = client.load(os.path.join(client.current_folder, "output", f))
-                old_syntax_file = re.sub(fr'(?s)(\.conan2{os.path.sep}p)(.*?)(p)', "", old_syntax_file)
+                old_syntax_file = re.sub(genexp_pick_folder, "",
+                                         client.load(os.path.join(client.current_folder, "output", f)))
                 assert generated_files[f] == old_syntax_file


### PR DESCRIPTION
Just exploring if we can simplify the syntax regarding the components that are passed to dependencies about components.
Motivated by: https://github.com/conan-io/conan/issues/11525#issuecomment-1180634142

This PR proposes this syntax:

```python
    def requirements(self):
        self.requires("lib_a/1.0", components=["cmp1"])
        self.requires("lib_b/1.0")
```

as an equivalent to:

```python
    def requirements(self):
        self.requires("lib_a/1.0")
        self.requires("lib_b/1.0")
    def package_info(self):
        self.cpp_info.requires = ["lib_a::cmp1", "lib_b::lib_b"]
```
