### PR TITLE
Match conan list packages to the --help

### DIFF
--- a/conan/cli/commands/list.py
+++ b/conan/cli/commands/list.py
@@ -225,12 +225,13 @@ def _list_packages_json(data):
 @conan_subcommand(formatters={"json": _list_packages_json})
 def list_packages(conan_api, parser, subparser, *args):
     """
-    List all the package IDs for a given recipe reference. If the reference doesn't
-    include the recipe revision, the command will retrieve all the package IDs for
-    the most recent revision.
+    List all the package IDs for a given recipe revision.
     """
-    subparser.add_argument("reference", help="Recipe reference or revision, e.g., libyaml/0.2.5 or "
-                                             "libyaml/0.2.5#80b7cbe095ac7f38844b6511e69e453a")
+    subparser.add_argument(
+        "reference",
+        help="Recipe reference and revision, e.g., libyaml/0.2.5#latest or "
+             "libyaml/0.2.5#80b7cbe095ac7f38844b6511e69e453a"
+        )
     _add_remotes_and_cache_options(subparser)
     args = parser.parse_args(*args)
 


### PR DESCRIPTION
Fixes #11682

In the docstrings for the `conan list packages` command, it is now stated that specifying the revision is necessary.

- [x] Refer to the issue that supports this Pull Request.
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [x] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 

<sup>**Note:** By default this PR will skip the slower tests and will use a limited set of python versions. Check [here](https://github.com/conan-io/conan/blob/develop/.github/PR_INCREASE_TESTING.md) how to increase the testing level by writing some tags in the current PR body text.</sup>
