### PR TITLE
Update just in mode install and don't fail if mode check for tools.system.package_manager

### DIFF
--- a/conan/tools/system/package_manager.py
+++ b/conan/tools/system/package_manager.py
@@ -137,10 +137,6 @@ class _SystemPackageManagerTool(object):
         if self._mode == self.mode_install:
             command = self.update_command.format(sudo=self.sudo_str, tool=self.tool_name)
             return self._conanfile_run(command, self.accepted_update_codes)
-        else:
-            self._conanfile.output.info(f"Did not update '{str(self.__class__.__name__)}'. "
-                                        f"To run the update operation set the 'tools.system.package_manager:mode' "
-                                        f"configuration to 'install'")
 
     def _check(self, packages):
         missing = [pkg for pkg in packages if self.check_package(self.get_package_name(pkg)) != 0]

--- a/conan/tools/system/package_manager.py
+++ b/conan/tools/system/package_manager.py
@@ -132,16 +132,15 @@ class _SystemPackageManagerTool(object):
                                         "installed".format(" ".join(packages)))
 
     def _update(self):
-        if self._mode == self.mode_check:
-            raise ConanException("Can't update because tools.system.package_manager:mode is '{0}'."
-                                 "Please update packages manually or set "
-                                 "'tools.system.package_manager:mode' "
-                                 "to '{1}' in the [conf] section of the profile, "
-                                 "or in the command line using "
-                                 "'-c tools.system.package_manager:mode={1}'".format(self.mode_check,
-                                                                                     self.mode_install))
-        command = self.update_command.format(sudo=self.sudo_str, tool=self.tool_name)
-        return self._conanfile_run(command, self.accepted_update_codes)
+        # we just update the package manager database in case we are in 'install mode'
+        # in case we are in check mode warn about that but don't fail
+        if self._mode == self.mode_install:
+            command = self.update_command.format(sudo=self.sudo_str, tool=self.tool_name)
+            return self._conanfile_run(command, self.accepted_update_codes)
+        else:
+            self._conanfile.output.info(f"Did not update '{str(self.__class__.__name__)}'. "
+                                        f"To run the update operation set the 'tools.system.package_manager:mode' "
+                                        f"configuration to 'install'")
 
     def _check(self, packages):
         missing = [pkg for pkg in packages if self.check_package(self.get_package_name(pkg)) != 0]

--- a/conans/test/integration/tools/system/package_manager_test.py
+++ b/conans/test/integration/tools/system/package_manager_test.py
@@ -11,7 +11,6 @@ from conans import Settings
 from conans.errors import ConanException
 from conans.model.conf import Conf
 from conans.test.utils.mocks import ConanFileMock
-from conans.test.utils.tools import redirect_output
 
 
 @pytest.mark.parametrize("platform, tool", [

--- a/conans/test/integration/tools/system/package_manager_test.py
+++ b/conans/test/integration/tools/system/package_manager_test.py
@@ -11,6 +11,7 @@ from conans import Settings
 from conans.errors import ConanException
 from conans.model.conf import Conf
 from conans.test.utils.mocks import ConanFileMock
+from conans.test.utils.tools import redirect_output
 
 
 @pytest.mark.parametrize("platform, tool", [
@@ -130,27 +131,8 @@ def test_tools_install_mode_check(tool_class):
                                          "'-c tools.system.package_manager:mode=install'"
 
 
-@pytest.mark.parametrize("tool_class",
-                         [Apt, Yum, Dnf, Brew, Pkg, PkgUtil, Chocolatey, PacMan, Zypper])
-def test_tools_update_mode_check(tool_class):
-    conanfile = ConanFileMock()
-    conanfile.conf = Conf()
-    conanfile.settings = Settings()
-    conanfile.conf["tools.system.package_manager:tool"] = tool_class.tool_name
-    conanfile.conf["tools.system.package_manager:mode"] = "check"
-    with mock.patch('conans.ConanFile.context', new_callable=PropertyMock) as context_mock:
-        context_mock.return_value = "host"
-        tool = tool_class(conanfile)
-        with pytest.raises(ConanException) as exc_info:
-            tool.update()
-        assert exc_info.value.args[0] == "Can't update because tools.system.package_manager:mode is " \
-                                         "'check'.Please update packages manually or set " \
-                                         "'tools.system.package_manager:mode' to 'install' in the [conf] " \
-                                         "section of the profile, or in the command line using " \
-                                         "'-c tools.system.package_manager:mode=install'"
-
-
-@pytest.mark.parametrize("tool_class, result", [
+@pytest.mark.parametrize("tool_class, result",
+[
     (Apt, "apt-get update"),
     (Yum, "yum check-update -y"),
     (Dnf, "dnf check-update -y"),
@@ -166,12 +148,18 @@ def test_tools_update_mode_install(tool_class, result):
     conanfile.conf = Conf()
     conanfile.settings = Settings()
     conanfile.conf["tools.system.package_manager:tool"] = tool_class.tool_name
-    conanfile.conf["tools.system.package_manager:mode"] = "install"
-    with mock.patch('conans.ConanFile.context', new_callable=PropertyMock) as context_mock:
-        context_mock.return_value = "host"
-        tool = tool_class(conanfile)
-        tool.update()
-    assert tool._conanfile.command == result
+    for mode in ["check", "install"]:
+        conanfile.conf["tools.system.package_manager:mode"] = mode
+        with mock.patch('conans.ConanFile.context', new_callable=PropertyMock) as context_mock:
+            context_mock.return_value = "host"
+            tool = tool_class(conanfile)
+            tool.update()
+            if mode == "check":
+                assert f"Did not update '{str(tool_class.__name__)}'. To run the update operation " \
+                       "set the 'tools.system.package_manager:mode' configuration " \
+                       "to 'install'" in tool._conanfile.output
+            else:
+                assert tool._conanfile.command == result
 
 
 @pytest.mark.parametrize("tool_class, result", [

--- a/conans/test/integration/tools/system/package_manager_test.py
+++ b/conans/test/integration/tools/system/package_manager_test.py
@@ -154,12 +154,11 @@ def test_tools_update_mode_install(tool_class, result):
             context_mock.return_value = "host"
             tool = tool_class(conanfile)
             tool.update()
-            if mode == "check":
-                assert f"Did not update '{str(tool_class.__name__)}'. To run the update operation " \
-                       "set the 'tools.system.package_manager:mode' configuration " \
-                       "to 'install'" in tool._conanfile.output
-            else:
+            if mode == "install":
                 assert tool._conanfile.command == result
+            else:
+                # does not run the update when mode check
+                assert tool._conanfile.command == None
 
 
 @pytest.mark.parametrize("tool_class, result", [


### PR DESCRIPTION
Changelog: Feature: Do the package manager update just in mode `install` and ignore if mode is `check`.
Docs: https://github.com/conan-io/docs/pull/2663

Just checking if this may make more sense than raising an exception if `mode=check` and `update=True` because unless you use `mode=install` you will never check if the packages are installed.

Closes: https://github.com/conan-io/conan/issues/11706