### PR TITLE
WIP: [autotools / gnu tools] use "-l:" for static libraries

### DIFF
--- a/conan/tools/gnu/gnudeps_flags.py
+++ b/conan/tools/gnu/gnudeps_flags.py
@@ -80,6 +80,11 @@ class GnuDepsFlags(object):
                 if not library.endswith(".lib"):
                     library += ".lib"
                 result.append(library)
+            elif library.startswith("lib") and library.endswith(".a"):
+                # link by filename
+                # TODO: at this point, we should only use -l:
+                # if we are sure that we use ld as linker
+                result.append("-l:%s" % library)
             else:
                 result.append("-l%s" % library)
         return result

--- a/conans/client/build/compiler_flags.py
+++ b/conans/client/build/compiler_flags.py
@@ -250,6 +250,11 @@ def format_libraries(libraries, settings):
             if not library.endswith(".lib"):
                 library += ".lib"
             result.append(library)
+        elif library.startswith("lib") and library.endswith(".a"):
+            # link by filename
+            # TODO: at this point, we should only use -l:
+            # if we are sure that we use ld as linker
+            result.append("-l:%s" % library)
         else:
             result.append("-l%s" % library)
     return result

--- a/conans/test/unittests/client/build/compiler_flags_test.py
+++ b/conans/test/unittests/client/build/compiler_flags_test.py
@@ -244,3 +244,5 @@ class CompilerFlagsTest(unittest.TestCase):
         self.assertEqual(['lib1.lib', 'lib2.lib'],
                          format_libraries(['lib1', 'lib2'],
                                           MockSettings({"compiler": "Visual Studio"})))
+        self.assertEqual(['-l:liba.a', '-l:libb.a'],
+                         format_libraries(['liba.a', 'libb.a'], MockSettings({})))


### PR DESCRIPTION
attempt to solve issue #11703 - tested with gcc and ld on Ubuntu and a Yocto variant

This PR is WIP:

* TODO: detect that the linker 'ld' is the one in use

Changelog: (Feature | Fix | Bugfix): Describe here your pull request
Docs: https://github.com/conan-io/docs/pull/XXXX

- [x] Refer to the issue that supports this Pull Request.
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [ ] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 

<sup>**Note:** By default this PR will skip the slower tests and will use a limited set of python versions. Check [here](https://github.com/conan-io/conan/blob/develop/.github/PR_INCREASE_TESTING.md) how to increase the testing level by writing some tags in the current PR body text.</sup>
