### PR TITLE
Update system package manager db right before install, instead before check

### DIFF
--- a/conan/tools/system/package_manager.py
+++ b/conan/tools/system/package_manager.py
@@ -103,9 +103,6 @@ class _SystemPackageManagerTool(object):
         raise ConanException("None of the installs for the package substitutes succeeded.")
 
     def _install(self, packages, update=False, check=True, **kwargs):
-        if update:
-            self.update()
-
         if check:
             packages = self.check(packages)
 
@@ -120,6 +117,10 @@ class _SystemPackageManagerTool(object):
                                                                                      self.mode_check,
                                                                                      self.mode_install))
         elif packages:
+
+            if update:
+                self.update()
+
             packages_arch = [self.get_package_name(package) for package in packages]
             if packages_arch:
                 command = self.install_command.format(sudo=self.sudo_str,
@@ -133,7 +134,7 @@ class _SystemPackageManagerTool(object):
 
     def _update(self):
         # we just update the package manager database in case we are in 'install mode'
-        # in case we are in check mode warn about that but don't fail
+        # in case we are in check mode just ignore
         if self._mode == self.mode_install:
             command = self.update_command.format(sudo=self.sudo_str, tool=self.tool_name)
             return self._conanfile_run(command, self.accepted_update_codes)

--- a/conan/tools/system/package_manager.py
+++ b/conan/tools/system/package_manager.py
@@ -117,7 +117,6 @@ class _SystemPackageManagerTool(object):
                                                                                      self.mode_check,
                                                                                      self.mode_install))
         elif packages:
-
             if update:
                 self.update()
 

--- a/conans/test/integration/tools/system/package_manager_test.py
+++ b/conans/test/integration/tools/system/package_manager_test.py
@@ -157,7 +157,7 @@ def test_tools_update_mode_install(tool_class, result):
                 assert tool._conanfile.command == result
             else:
                 # does not run the update when mode check
-                assert tool._conanfile.command == None
+                assert tool._conanfile.command is None
 
 
 @pytest.mark.parametrize("tool_class, result", [


### PR DESCRIPTION
Changelog: Feature: Update system package manager db right before install, instead before check
Docs: omit

We can also consider if we want to manager this via a conf or we want to leave in the recipes...

Closes: https://github.com/conan-io/conan/issues/11715