### PR TITLE
Capture error loading custom command

### DIFF
--- a/conan/cli/cli.py
+++ b/conan/cli/cli.py
@@ -32,12 +32,14 @@ class Cli:
         self._conan_api = conan_api
         self._groups = defaultdict(list)
         self._commands = {}
+
+    def _add_commands(self):
         conan_commands_path = os.path.join(os.path.dirname(os.path.abspath(__file__)), "commands")
         for module in pkgutil.iter_modules([conan_commands_path]):
             module_name = module[1]
             self._add_command("conan.cli.commands.{}".format(module_name), module_name)
 
-        custom_commands_path = ClientCache(conan_api.cache_folder).custom_commands_path
+        custom_commands_path = ClientCache(self._conan_api.cache_folder).custom_commands_path
         if not os.path.isdir(custom_commands_path):
             return
 
@@ -45,7 +47,11 @@ class Cli:
         for module in pkgutil.iter_modules([custom_commands_path]):
             module_name = module[1]
             if module_name.startswith("cmd_"):
-                self._add_command(module_name, module_name.replace("cmd_", ""))
+                try:
+                    self._add_command(module_name, module_name.replace("cmd_", ""))
+                except Exception as e:
+                    raise ConanException("Error loading custom command "
+                                         "'{}.py': {}".format(module_name, e))
         # layers
         for folder in os.listdir(custom_commands_path):
             layer_folder = os.path.join(custom_commands_path, folder)
@@ -135,6 +141,7 @@ class Cli:
         """
         output = ConanOutput()
         try:
+            self._add_commands()
             try:
                 command_argument = args[0][0]
             except IndexError:  # No parameters

--- a/conan/cli/cli.py
+++ b/conan/cli/cli.py
@@ -50,8 +50,8 @@ class Cli:
                 try:
                     self._add_command(module_name, module_name.replace("cmd_", ""))
                 except Exception as e:
-                    raise ConanException("Error loading custom command "
-                                         "'{}.py': {}".format(module_name, e))
+                    ConanOutput().error("Error loading custom command "
+                                        "'{}.py': {}".format(module_name, e))
         # layers
         for folder in os.listdir(custom_commands_path):
             layer_folder = os.path.join(custom_commands_path, folder)

--- a/conans/test/integration/command_v2/custom_commands_test.py
+++ b/conans/test/integration/command_v2/custom_commands_test.py
@@ -16,7 +16,7 @@ class TestCustomCommands:
                                          'commands', 'cmd_mycommand.py')
         client.save({f"{command_file_path}": mycommand})
         # Call to any other command, it will fail loading the custom command
-        client.run("search '*'", assert_error=True)
+        client.run("list recipes '*'")
         assert "ERROR: Error loading custom command 'cmd_mycommand.py': " \
                "No module named 'this_doesnt_exist'" in client.out
 

--- a/conans/test/integration/command_v2/custom_commands_test.py
+++ b/conans/test/integration/command_v2/custom_commands_test.py
@@ -5,6 +5,21 @@ from conans.test.utils.tools import TestClient
 
 
 class TestCustomCommands:
+
+    def test_import_error_custom_command(self):
+        mycommand = textwrap.dedent("""
+            import this_doesnt_exist
+            """)
+
+        client = TestClient()
+        command_file_path = os.path.join(client.cache_folder, 'extensions',
+                                         'commands', 'cmd_mycommand.py')
+        client.save({f"{command_file_path}": mycommand})
+        # Call to any other command, it will fail loading the custom command
+        client.run("search '*'", assert_error=True)
+        assert "ERROR: Error loading custom command 'cmd_mycommand.py': " \
+               "No module named 'this_doesnt_exist'" in client.out
+
     def test_simple_custom_command(self):
         mycommand = textwrap.dedent("""
             import json


### PR DESCRIPTION
Changelog: Fix: If Conan fails to load a custom command now it fails with a useful error message.
Docs: omit

Closes https://github.com/conan-io/conan/issues/11702