### PR TITLE
Opt-in compatible compilers per local cache rather than per recipe

### DIFF
--- a/conans/client/conf/__init__.py
+++ b/conans/client/conf/__init__.py
@@ -159,6 +159,16 @@ _t_default_settings_yml = Template(textwrap.dedent("""
                     threads: [None]
                     exceptions: [None]
 
+    # opt-in for stating which versions of compilers are compatible with other versions
+    # do not specify this as part of your recipe settings
+    #compiler_compatibility:
+    #    apple-clang:
+    #        "13.0": ["12.0", "11.0", "10.0"]
+    #    gcc:
+    #        "9": ["6", "4.8"]
+    #    Visual Studio:
+    #        "16": ["15", "14"]
+
     build_type: [None, Debug, Release, RelWithDebInfo, MinSizeRel]
 
 

--- a/conans/client/graph/graph_manager.py
+++ b/conans/client/graph/graph_manager.py
@@ -334,7 +334,7 @@ class GraphManager(object):
         :param graph: This is the full dependency graph with all nodes from all recursions
         """
         default_context = CONTEXT_BUILD if profile_build else CONTEXT_HOST
-        self._binary_analyzer.evaluate_graph(graph, build_mode, update, remotes, nodes_subset, root)
+        self._binary_analyzer.evaluate_graph(graph, build_mode, update, remotes, nodes_subset, root, profile_host)
         if not apply_build_requires:
             return
 

--- a/conans/test/integration/package_id/compatible_compiler_test.py
+++ b/conans/test/integration/package_id/compatible_compiler_test.py
@@ -1,0 +1,89 @@
+import textwrap
+
+
+from conans.test.utils.tools import TestClient
+from conans.util.files import load, save
+
+
+FOO_CONANFILE = textwrap.dedent("""
+    from conans import ConanFile
+    class FooConan(ConanFile):
+        settings = ("compiler")
+    """)
+
+
+BAR_CONANFILE = textwrap.dedent("""
+    from conans import ConanFile
+    class BarConan(ConanFile):
+        settings = ("compiler")
+        requires = ("foo/1.0")
+    """)
+
+
+# arbitrarily select a compiler; the important thing is that there
+# are two different versions used in order to make different package_ids
+PROFILE_OLD = textwrap.dedent("""
+    [settings]
+    compiler=msvc
+    compiler.version=170
+    compiler.cppstd=17
+    compiler.runtime=dynamic
+    """)
+
+
+PROFILE_NEW = textwrap.dedent("""
+    [settings]
+    compiler=msvc
+    compiler.version=180
+    compiler.cppstd=17
+    compiler.runtime=dynamic
+    """)
+
+
+SPECIFIED_COMPILER_COMPATIBILITY = textwrap.dedent("""
+    compiler_compatibility:
+        msvc:
+            "180": ["170"]
+    """)
+
+
+class TestCompilerCompatible:
+    def test_incompatible_dependency(self):
+        """
+        Build two packages against two profiles with a different compiler version.
+        """
+        client = TestClient()
+        client.save({
+            "foo_conanfile.py": FOO_CONANFILE,
+            "bar_conanfile.py": BAR_CONANFILE,
+            "profile_old": PROFILE_OLD,
+            "profile_new": PROFILE_NEW,
+        })
+        client.run('create foo_conanfile.py foo/1.0@ -pr profile_old')
+        # expected failure
+        client.run('install bar_conanfile.py bar/2.0@ -pr profile_new', assert_error=True)
+
+    def test_compiler_compatible_dependency(self):
+        """
+        Build two packages against two profiles with a different compiler version.
+        Specify compiler compatibility in the settings.yml
+        """
+        client = TestClient()
+
+        # Generate the customised settings.yml for compatible compilers for all packages
+        client.run("config init")
+        default_settings = load(client.cache.settings_path)
+        default_settings += SPECIFIED_COMPILER_COMPATIBILITY
+        save(client.cache.settings_path, default_settings)
+
+        client.save({
+            "foo_conanfile.py": FOO_CONANFILE,
+            "bar_conanfile.py": BAR_CONANFILE,
+            "profile_old": PROFILE_OLD,
+            "profile_new": PROFILE_NEW,
+        })
+        client.run('create foo_conanfile.py foo/1.0@ -pr profile_old')
+        # expected success
+        client.run('install bar_conanfile.py bar/2.0@ -pr profile_new', assert_error=False)
+        # ensure it is via a compatible package
+        assert "Using compatible package" in client.out


### PR DESCRIPTION
Changelog: (Feature): Fixes issue #11722. Adding the ability to specify compatible compilers per local cache for all dependent packages, to avoid the need to modify their recipes. Use case is to ease the testing/migration of product builds to new compiler versions that produces ABI compatible code with existing packages in Artifactory.

cc @FnGyula

- [x] Refer to the issue that supports this Pull Request.
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 

<sup>**Note:** By default this PR will skip the slower tests and will use a limited set of python versions. Check [here](https://github.com/conan-io/conan/blob/develop/.github/PR_INCREASE_TESTING.md) how to increase the testing level by writing some tags in the current PR body text.</sup>
