### PR TITLE
Fix setting override in msbuilddeps test

### DIFF
--- a/conans/test/functional/toolchains/microsoft/test_msbuilddeps.py
+++ b/conans/test/functional/toolchains/microsoft/test_msbuilddeps.py
@@ -677,6 +677,7 @@ def test_exclude_code_analysis(pattern, exclude_a, exclude_b):
         """)
     profile = textwrap.dedent("""
         include(default)
+        [settings]
         build_type=Release
         arch=x86_64
         [conf]


### PR DESCRIPTION
Changelog: Omit
Docs: Omit

This test fails when running it on macOS/Apple Silicon, because the `arch` setting was not being correctly overridden to be `x86_64` due to the missing `[settings]` block.

