### PR TITLE
Expose default profile in test client and set current architecture in conftest

### DIFF
--- a/conans/test/conftest.py
+++ b/conans/test/conftest.py
@@ -163,6 +163,8 @@ tools_locations = {
 
 
 # TODO: Make this match the default tools (compilers) above automatically
+arch = platform.machine()
+arch_setting = "armv8" if arch in ["arm64", "aarch64"] else arch
 default_profiles = {
     "Windows": textwrap.dedent("""\
         [settings]
@@ -173,19 +175,19 @@ default_profiles = {
         compiler.runtime=dynamic
         build_type=Release
         """),
-    "Linux": textwrap.dedent("""\
+    "Linux": textwrap.dedent(f"""\
         [settings]
         os=Linux
-        arch=x86_64
+        arch={arch_setting}
         compiler=gcc
         compiler.version=8
         compiler.libcxx=libstdc++11
         build_type=Release
         """),
-    "Darwin": textwrap.dedent("""\
+    "Darwin": textwrap.dedent(f"""\
         [settings]
         os=Macos
-        arch=x86_64
+        arch={arch_setting}
         compiler=apple-clang
         compiler.version=12.0
         compiler.libcxx=libc++

--- a/conans/test/utils/tools.py
+++ b/conans/test/utils/tools.py
@@ -649,6 +649,10 @@ class TestClient(object):
         ref_layout = self.cache.ref_layout(latest_rrev)
         return ref_layout
 
+    def get_default_host_profile(self):
+        api = ConanAPIV2(cache_folder=self.cache_folder)
+        return api.profiles.get_profile([api.profiles.get_default_host()])
+
     def recipe_exists(self, ref):
         rrev = self.cache.get_recipe_revisions_references(ref)
         return True if rrev else False


### PR DESCRIPTION
Changelog: omit
Docs: omit

* Add method that exposes the default host profile in the Test Client, for convenience.
* When writing the default profiles used for tests in `conftest.py`, set the architecture base on the current native architecture (as per the Python interpreter).

This is to enable tests that make calls to a `TestClient` object and make assumptions about the output (e.g. filenames that encode the architecture setting, or assert output in compiled code or tool logs).

