### PR TITLE
Add logic to cover arm64 architecture in compiler defines

### DIFF
--- a/conan/internal/api/new/cmake_lib.py
+++ b/conan/internal/api/new/cmake_lib.py
@@ -86,7 +86,7 @@ void {{name.replace("-", "_").replace("+", "_").replace(".", "_")}}(){
     std::cout << "  {{name}}/{{version}}: _M_IX86 defined\n";
     #endif
 
-    #idef _M_ARM64
+    #ifdef _M_ARM64
     std::cout << "  {{name}}/{{version}}: _M_ARM64 defined\n";
     #endif
 

--- a/conan/internal/api/new/cmake_lib.py
+++ b/conan/internal/api/new/cmake_lib.py
@@ -86,12 +86,20 @@ void {{name.replace("-", "_").replace("+", "_").replace(".", "_")}}(){
     std::cout << "  {{name}}/{{version}}: _M_IX86 defined\n";
     #endif
 
+    #idef _M_ARM64
+    std::cout << "  {{name}}/{{version}}: _M_ARM64 defined\n";
+    #endif
+
     #if __i386__
     std::cout << "  {{name}}/{{version}}: __i386__ defined\n";
     #endif
 
     #if __x86_64__
     std::cout << "  {{name}}/{{version}}: __x86_64__ defined\n";
+    #endif
+
+    #if __aarch64__
+    std::cout << "  {{name}}/{{version}}: __aarch64__ defined\n";
     #endif
 
     // Libstdc++

--- a/conans/test/assets/sources.py
+++ b/conans/test/assets/sources.py
@@ -27,12 +27,20 @@ int {{name}}(){
     std::cout << "  {{ msg or name }} _M_IX86 defined\n";
     #endif
 
+    #ifdef _M_ARM64
+    std::cout << "  {{ msg or name }}: _M_ARM64 defined\n";
+    #endif
+
     #if __i386__
     std::cout << "  {{ msg or name }} __i386__ defined\n";
     #endif
 
     #if __x86_64__
     std::cout << "  {{ msg or name }} __x86_64__ defined\n";
+    #endif
+
+    #if __aarch64__
+    std::cout << "  {{ msg or name }} __aarch64__ defined\n";
     #endif
 
     // Libstdc++

--- a/conans/test/functional/toolchains/meson/_base.py
+++ b/conans/test/functional/toolchains/meson/_base.py
@@ -16,18 +16,23 @@ class TestMesonBase(unittest.TestCase):
         self.t = TestClient()
 
     def _check_binary(self):
-        # FIXME: This is hardcoded for CI
+        # FIXME: Some values are hardcoded to match the CI setup
+        host_arch =  self.t.get_default_host_profile().settings['arch']
+        arch_macro = {
+            "gcc": {"armv8": "__aarch64__", "x86_64": "__x86_64__"},
+            "msvc": {"armv8": "_M_ARM64", "x86_64": "_M_X64"}
+        }
         if platform.system() == "Darwin":
-            self.assertIn("main __x86_64__ defined", self.t.out)
+            self.assertIn(f"main {arch_macro['gcc'][host_arch]} defined", self.t.out)
             self.assertIn("main __apple_build_version__", self.t.out)
             self.assertIn("main __clang_major__13", self.t.out)
             # TODO: check why __clang_minor__ seems to be not defined in XCode 12
             # commented while migrating to XCode12 CI
             # self.assertIn("main __clang_minor__0", self.t.out)
         elif platform.system() == "Windows":
-            self.assertIn("main _M_X64 defined", self.t.out)
+            self.assertIn(f"main {arch_macro['msvc'][host_arch]} defined", self.t.out)
             self.assertIn("main _MSC_VER19", self.t.out)
             self.assertIn("main _MSVC_LANG2014", self.t.out)
         elif platform.system() == "Linux":
-            self.assertIn("main __x86_64__ defined", self.t.out)
+            self.assertIn(f"main {arch_macro['gcc'][host_arch]} defined", self.t.out)
             self.assertIn("main __GNUC__9", self.t.out)

--- a/conans/test/functional/utils.py
+++ b/conans/test/functional/utils.py
@@ -86,6 +86,8 @@ def check_exe_run(output, names, compiler, version, build_type, arch, cppstd, de
                 assert "{} _M_IX86 defined".format(name) in output
             elif arch == "x86_64":
                 assert "{} _M_X64 defined".format(name) in output
+            elif arch == "armv8":
+                assert "{} _M_ARM64 defined".format(name) in output
             else:
                 assert arch is None, "checked don't know how to validate this architecture"
 


### PR DESCRIPTION
Changelog: Omit
Docs: Omit

* Add logic to print a message in compiled code when building for aarch64/ARM64 architecture  when testing - this covers most common case for macOS, Linux and Windows.
* Improve logic in tests to assert for the specific architecture based on the default host profile and the compiler being used (different compilers use different macros).
* Add macros/messages for aarch64/ARM64 architecture to the `cmake_lib` template

(Note that this needs https://github.com/conan-io/conan/pull/11744 merged first)