### PR TITLE
Replace hardcoded arch assumptions in tests

### DIFF
--- a/conans/test/functional/command/test_install_deploy.py
+++ b/conans/test/functional/command/test_install_deploy.py
@@ -34,7 +34,8 @@ def test_install_deploy():
     c.run("install . --deploy=deploy.py -of=mydeploy -g CMakeToolchain -g CMakeDeps")
     c.run("remove * -f")  # Make sure the cache is clean, no deps there
     cwd = c.current_folder.replace("\\", "/")
-    deps = c.load("mydeploy/hello-release-x86_64-data.cmake")
+    arch = c.get_default_host_profile().settings['arch']
+    deps = c.load(f"mydeploy/hello-release-{arch}-data.cmake")
     assert f'set(hello_PACKAGE_FOLDER_RELEASE "{cwd}/mydeploy/hello")' in deps
     assert 'set(hello_INCLUDE_DIRS_RELEASE "${hello_PACKAGE_FOLDER_RELEASE}/include")' in deps
     assert 'set(hello_LIB_DIRS_RELEASE "${hello_PACKAGE_FOLDER_RELEASE}/lib")' in deps
@@ -104,13 +105,15 @@ def test_builtin_deploy():
     assert "Conan built-in full deployer" in c.out
     c.run("install . --deploy=full_deploy -of=output -g CMakeDeps "
           "-s build_type=Debug -s arch=x86")
-    release = c.load("output/host/dep/0.1/Release/x86_64/include/hello.h")
-    assert "Release-x86_64" in release
+
+    host_arch = c.get_default_host_profile().settings['arch']
+    release = c.load(f"output/host/dep/0.1/Release/{host_arch}/include/hello.h")
+    assert f"Release-{host_arch}" in release
     debug = c.load("output/host/dep/0.1/Debug/x86/include/hello.h")
     assert "Debug-x86" in debug
-    cmake_release = c.load("output/dep-release-x86_64-data.cmake")
+    cmake_release = c.load(f"output/dep-release-{host_arch}-data.cmake")
     assert 'set(dep_INCLUDE_DIRS_RELEASE "${dep_PACKAGE_FOLDER_RELEASE}/include")' in cmake_release
-    assert "output/host/dep/0.1/Release/x86_64" in cmake_release
+    assert f"output/host/dep/0.1/Release/{host_arch}" in cmake_release
     cmake_debug = c.load("output/dep-debug-x86-data.cmake")
     assert 'set(dep_INCLUDE_DIRS_DEBUG "${dep_PACKAGE_FOLDER_DEBUG}/include")' in cmake_debug
     assert "output/host/dep/0.1/Debug/x86" in cmake_debug

--- a/conans/test/functional/layout/test_editable_cmake.py
+++ b/conans/test/functional/layout/test_editable_cmake.py
@@ -108,12 +108,13 @@ def editable_cmake_exe(generator):
         build_dep()
 
     def run_pkg(msg):
+        host_arch = c.get_default_host_profile().settings['arch']
         # FIXME: This only works with ``--install-folder``, layout() will break this
-        cmd_release = environment_wrap_command("conanrunenv-release-x86_64", c.current_folder,
+        cmd_release = environment_wrap_command(f"conanrunenv-release-{host_arch}", c.current_folder,
                                                "dep_app",)
         c.run_command(cmd_release)
         assert "{}: Release!".format(msg) in c.out
-        cmd_release = environment_wrap_command("conanrunenv-debug-x86_64", c.current_folder,
+        cmd_release = environment_wrap_command(f"conanrunenv-debug-{host_arch}", c.current_folder,
                                                "dep_app", )
         c.run_command(cmd_release)
         assert "{}: Debug!".format(msg) in c.out

--- a/conans/test/functional/layout/test_in_cache.py
+++ b/conans/test/functional/layout/test_in_cache.py
@@ -224,7 +224,8 @@ def test_cpp_package():
     assert "**includedirs:['foo/include']**" in out
     assert "**libdirs:['foo/libs']**" in out
     assert "**libs:['foo']**" in out
-    cmake = client.load("hello-release-x86_64-data.cmake")
+    host_arch = client.get_default_host_profile().settings['arch']
+    cmake = client.load(f"hello-release-{host_arch}-data.cmake")
 
     assert 'set(hello_INCLUDE_DIRS_RELEASE "${hello_PACKAGE_FOLDER_RELEASE}/foo/include")' in cmake
     assert 'set(hello_LIB_DIRS_RELEASE "${hello_PACKAGE_FOLDER_RELEASE}/foo/libs")' in cmake

--- a/conans/test/functional/toolchains/apple/test_xcodedeps_components.py
+++ b/conans/test/functional/toolchains/apple/test_xcodedeps_components.py
@@ -187,9 +187,11 @@ def test_xcodedeps_components():
     assert '#include "conan_network_client.xcconfig"' in chat_xcconfig
     assert '#include "conan_network_server.xcconfig"' not in chat_xcconfig
     assert '#include "conan_network_network.xcconfig"' not in chat_xcconfig
+    host_arch = client.get_default_host_profile().settings['arch']
+    arch = "arm64" if host_arch == "armv8" else host_arch
     client.run_command("xcodegen generate")
-    client.run_command("xcodebuild -project ChatApp.xcodeproj -configuration Release -arch x86_64")
-    client.run_command("xcodebuild -project ChatApp.xcodeproj -configuration Debug -arch x86_64")
+    client.run_command(f"xcodebuild -project ChatApp.xcodeproj -configuration Release -arch {arch}")
+    client.run_command(f"xcodebuild -project ChatApp.xcodeproj -configuration Debug -arch {arch}")
     client.run_command("build/Debug/chat")
     assert "core/1.0: Hello World Debug!" in client.out
     assert "tcp/1.0: Hello World Debug!" in client.out
@@ -219,8 +221,10 @@ def test_xcodedeps_test_require():
         ''')
     client.save({"conanfile.py": conanfile}, clean_first=True)
     client.run("install . -g XcodeDeps")
+    host_arch = client.get_default_host_profile().settings['arch']
+    arch = "arm64" if host_arch == "armv8" else host_arch
     assert os.path.isfile(os.path.join(client.current_folder, "conan_gtest.xcconfig"))
     assert os.path.isfile(os.path.join(client.current_folder, "conan_gtest_gtest.xcconfig"))
     assert os.path.isfile(os.path.join(client.current_folder,
-                                       "conan_gtest_gtest_release_x86_64.xcconfig"))
+                                       f"conan_gtest_gtest_release_{arch}.xcconfig"))
     assert '#include "conan_gtest.xcconfig"' in client.load("conandeps.xcconfig")

--- a/conans/test/functional/toolchains/cmake/cmakedeps/test_cmakedeps.py
+++ b/conans/test/functional/toolchains/cmake/cmakedeps/test_cmakedeps.py
@@ -230,13 +230,13 @@ def test_custom_configuration(client):
                cmake.build_context_suffix["liba"] = "_build"
                cmake.generate()
        """)
-
+    host_arch = client.get_default_host_profile().settings['arch']
     client.save({"conanfile.py": conanfile})
     client.run("install . -pr:h default -s:b build_type=RelWithDebInfo"
                " -pr:b default -s:b arch=x86 --build missing")
     curdir = client.current_folder
     data_name_context_build = "liba_build-relwithdebinfo-x86-data.cmake"
-    data_name_context_host = "liba-debug-x86_64-data.cmake"
+    data_name_context_host = f"liba-debug-{host_arch}-data.cmake"
     assert os.path.exists(os.path.join(curdir, data_name_context_build))
     assert os.path.exists(os.path.join(curdir, data_name_context_host))
 
@@ -380,7 +380,8 @@ def test_system_dep():
 
     client.run("install consumer")
     if platform.system() != "Windows":
-        data = os.path.join("consumer/build/generators/mylib-release-x86_64-data.cmake")
+        host_arch = client.get_default_host_profile().settings['arch']
+        data = os.path.join(f"consumer/build/generators/mylib-release-{host_arch}-data.cmake")
         contents = client.load(data)
         assert 'set(ZLIB_FIND_MODE "")' in contents
 

--- a/conans/test/functional/toolchains/cmake/cmakedeps/test_cmakedeps_and_linker_flags.py
+++ b/conans/test/functional/toolchains/cmake/cmakedeps/test_cmakedeps_and_linker_flags.py
@@ -51,8 +51,9 @@ def test_shared_link_flags():
     client.run("new cmake_lib -d name=hello -d version=1.0")
     client.save({"conanfile.py": conanfile})
     client.run("create .")
+    host_arch = client.get_default_host_profile().settings['arch']
     t = os.path.join("test_package", "test_output", "build", "generators",
-                     "hello-release-x86_64-data.cmake")
+                     f"hello-release-{host_arch}-data.cmake")
     target_data_cmake_content = client.load(t)
     assert 'set(hello_SHARED_LINK_FLAGS_RELEASE "-z now;-z relro")' in target_data_cmake_content
     assert 'set(hello_EXE_LINK_FLAGS_RELEASE "-z now;-z relro")' in target_data_cmake_content

--- a/conans/test/functional/toolchains/cmake/cmakedeps/test_cmakedeps_components.py
+++ b/conans/test/functional/toolchains/cmake/cmakedeps/test_cmakedeps_components.py
@@ -67,8 +67,9 @@ class PropagateSpecificComponents(unittest.TestCase):
     def test_cmakedeps_multi(self):
         t = TestClient(cache_folder=self.cache_folder)
         t.run('install --requires=middle/version@ -g CMakeDeps')
+        host_arch = t.get_default_host_profile().settings['arch']
 
-        content = t.load('middle-release-x86_64-data.cmake')
+        content = t.load(f'middle-release-{host_arch}-data.cmake')
         self.assertIn("list(APPEND middle_FIND_DEPENDENCY_NAMES top)", content)
 
         content = t.load('middle-Target-release.cmake')

--- a/conans/test/functional/toolchains/gnu/autotools/test_basic.py
+++ b/conans/test/functional/toolchains/gnu/autotools/test_basic.py
@@ -53,8 +53,9 @@ def test_autotools():
     client.run("build .")
     client.run_command("./main")
     cxx11_abi = 1 if platform.system() == "Linux" else None
-    compiler = "gcc" if platform.system() == "Linux" else "clang"
-    check_exe_run(client.out, "main", compiler, None, "Release", "x86_64", None, cxx11_abi=cxx11_abi)
+    compiler = "gcc" if platform.system() == "Linux" else "apple-clang"
+    host_arch = client.get_default_host_profile().settings['arch']
+    check_exe_run(client.out, "main", compiler, None, "Release", host_arch, None, cxx11_abi=cxx11_abi)
     assert "hello/0.1: Hello World Release!" in client.out
 
 

--- a/conans/test/functional/toolchains/meson/test_meson_and_objc.py
+++ b/conans/test/functional/toolchains/meson/test_meson_and_objc.py
@@ -46,10 +46,12 @@ executable('demo', 'main.m', link_args: ['-framework', 'Foundation'])
 @pytest.mark.skipif(sys.version_info.major == 2, reason="Meson not supported in Py2")
 @pytest.mark.skipif(platform.system() != "Darwin", reason="requires Xcode")
 def test_apple_meson_toolchain_native_compilation_objective_c():
-    profile = textwrap.dedent("""
+    t = TestClient()
+    arch = t.get_default_host_profile().settings['arch']
+    profile = textwrap.dedent(f"""
     [settings]
     os = Macos
-    arch = x86_64
+    arch = {arch}
     compiler = apple-clang
     compiler.version = 12.0
     compiler.libcxx = libc++
@@ -65,7 +67,6 @@ def test_apple_meson_toolchain_native_compilation_objective_c():
         return 0;
     }
     """)
-    t = TestClient()
     t.save({"conanfile.py": _conanfile_py,
             "meson.build": _meson_build_objc,
             "main.m": app,
@@ -81,7 +82,7 @@ def test_apple_meson_toolchain_native_compilation_objective_c():
     ('armv7', 'iOS', '10.0', 'iphoneos'),
     ('x86', 'iOS', '10.0', 'iphonesimulator'),
     ('x86_64', 'iOS', '10.0', 'iphonesimulator'),
-    ('armv8', 'Macos', '11.0', None)  # MacOS M1
+    ('armv8', 'Macos', '11.0', None)  # Apple Silicon
 ])
 @pytest.mark.tool("meson")
 @pytest.mark.skipif(sys.version_info.major == 2, reason="Meson not supported in Py2")

--- a/conans/test/functional/tools/system/package_manager_test.py
+++ b/conans/test/functional/tools/system/package_manager_test.py
@@ -50,10 +50,13 @@ def test_apt_install_substitutes():
     client.save({"conanfile.py": conanfile_py.format(installs)})
     client.run("create . --name=test --version=1.0 -c tools.system.package_manager:mode=install "
                "-c tools.system.package_manager:sudo=True", assert_error=True)
-    assert "dpkg-query: no packages found matching non-existing1:amd64" in client.out
-    assert "dpkg-query: no packages found matching non-existing2:amd64" in client.out
-    assert "dpkg-query: no packages found matching non-existing3:amd64" in client.out
-    assert "dpkg-query: no packages found matching non-existing4:amd64" in client.out
+    host_arch = client.get_default_host_profile().settings['arch']
+    arch_map = {"armv8": "arm64", "x86_64": "amd64"}
+    dpkg_arch = arch_map[host_arch]
+    assert f"dpkg-query: no packages found matching non-existing1:{dpkg_arch}" in client.out
+    assert f"dpkg-query: no packages found matching non-existing2:{dpkg_arch}" in client.out
+    assert f"dpkg-query: no packages found matching non-existing3:{dpkg_arch}" in client.out
+    assert f"dpkg-query: no packages found matching non-existing4:{dpkg_arch}" in client.out
     assert "None of the installs for the package substitutes succeeded." in client.out
 
     client.run_command("sudo apt remove nano -yy")

--- a/conans/test/integration/command/remove_test.py
+++ b/conans/test/integration/command/remove_test.py
@@ -160,12 +160,13 @@ class RemovePackageRevisionsTest(unittest.TestCase):
         ref = self.client.cache.get_latest_recipe_reference(
                RecipeReference.loads("foobar/0.1@user/testing"))
         self.client.run("list packages foobar/0.1@user/testing#{} -r default".format(ref.revision))
-        self.assertIn("arch=x86_64", self.client.out)
+        default_arch = self.client.get_default_host_profile().settings['arch']
+        self.assertIn(f"arch={default_arch}", self.client.out)
         self.assertIn("arch=x86", self.client.out)
 
         self.client.run("remove -f foobar/0.1@user/testing -p -r default")
         self.client.run("search foobar/0.1@user/testing -r default")
-        self.assertNotIn("arch=x86_64", self.client.out)
+        self.assertNotIn(f"arch={default_arch}", self.client.out)
         self.assertNotIn("arch=x86", self.client.out)
 
 

--- a/conans/test/integration/environment/test_env.py
+++ b/conans/test/integration/environment/test_env.py
@@ -704,9 +704,8 @@ def test_files_always_created():
     c.run("install consumer -g VirtualBuildEnv -g VirtualRunEnv -of=.")
     ext = "bat" if platform.system() == "Windows" else "sh"
 
-    assert os.path.isfile(os.path.join(c.current_folder, "conanbuild.{}".format(ext)))
-    assert os.path.isfile(os.path.join(c.current_folder, "conanrun.{}".format(ext)))
-    assert os.path.isfile(os.path.join(c.current_folder,
-                                       "conanbuildenv-release-x86_64.{}".format(ext)))
-    assert os.path.isfile(os.path.join(c.current_folder,
-                                       "conanbuildenv-release-x86_64.{}".format(ext)))
+    arch = c.get_default_host_profile().settings['arch']
+    assert os.path.isfile(os.path.join(c.current_folder, f"conanbuild.{ext}"))
+    assert os.path.isfile(os.path.join(c.current_folder, f"conanrun.{ext}"))
+    assert os.path.isfile(os.path.join(c.current_folder, f"conanbuildenv-release-{arch}.{ext}"))
+    assert os.path.isfile(os.path.join(c.current_folder, f"conanbuildenv-release-{arch}.{ext}"))

--- a/conans/test/integration/toolchains/apple/test_xcodedeps.py
+++ b/conans/test/integration/toolchains/apple/test_xcodedeps.py
@@ -155,7 +155,10 @@ def test_xcodedeps_aggregate_components():
     component7_entry = client.load("conan_libb_libb_comp7.xcconfig")
     assert '#include "conan_liba_liba.xcconfig"' in component7_entry
 
-    component7_vars = client.load("conan_libb_libb_comp7_release_x86_64.xcconfig")
+    arch_setting = client.get_default_host_profile().settings['arch']
+    arch = "arm64" if arch_setting == "armv8" else arch_setting
+
+    component7_vars = client.load(f"conan_libb_libb_comp7_release_{arch}.xcconfig")
 
     # all of the transitive required components and the component itself are added
     for index in range(1, 8):
@@ -163,7 +166,7 @@ def test_xcodedeps_aggregate_components():
 
     assert "mylibdir" in component7_vars
 
-    component4_vars = client.load("conan_libb_libb_comp4_release_x86_64.xcconfig")
+    component4_vars = client.load(f"conan_libb_libb_comp4_release_{arch}.xcconfig")
 
     # all of the transitive required components and the component itself are added
     for index in range(1, 5):
@@ -229,8 +232,11 @@ def test_xcodedeps_traits():
 
     client.run("install lib_b.py -g XcodeDeps")
 
-    comp1_info = client.load("conan_lib_a_cmp1_release_x86_64.xcconfig")
-    comp2_info = client.load("conan_lib_a_cmp2_release_x86_64.xcconfig")
+    arch_setting = client.get_default_host_profile().settings['arch']
+    arch = "arm64" if arch_setting == "armv8" else arch_setting
+
+    comp1_info = client.load(f"conan_lib_a_cmp1_release_{arch}.xcconfig")
+    comp2_info = client.load(f"conan_lib_a_cmp2_release_{arch}.xcconfig")
 
     assert "cmp1_include" not in comp1_info
     assert "cmp2_include" not in comp2_info
@@ -244,8 +250,8 @@ def test_xcodedeps_traits():
                 clean_first=True)
     client.run("install lib_b.py -g XcodeDeps")
 
-    comp1_info = client.load("conan_lib_a_cmp1_release_x86_64.xcconfig")
-    comp2_info = client.load("conan_lib_a_cmp2_release_x86_64.xcconfig")
+    comp1_info = client.load(f"conan_lib_a_cmp1_release_{arch}.xcconfig")
+    comp2_info = client.load(f"conan_lib_a_cmp2_release_{arch}.xcconfig")
 
     assert "cmp1_frameworkdir" not in comp1_info
     assert "cmp2_frameworkdir" not in comp2_info
@@ -262,8 +268,8 @@ def test_xcodedeps_traits():
                 clean_first=True)
     client.run("install lib_b.py -g XcodeDeps")
 
-    not_existing = ["conan_lib_a_cmp1_release_x86_64.xcconfig", "conan_lib_a_cmp1.xcconfig",
-                    "conan_lib_a_cmp2_release_x86_64.xcconfig", "conan_lib_a_cmp2.xcconfig",
+    not_existing = [f"conan_lib_a_cmp1_release_{arch}.xcconfig", "conan_lib_a_cmp1.xcconfig",
+                    f"conan_lib_a_cmp2_release_{arch}.xcconfig", "conan_lib_a_cmp2.xcconfig",
                     "conan_lib_a.xcconfig"]
 
     for file in not_existing:
@@ -281,8 +287,8 @@ def test_xcodedeps_traits():
 
     client.run("install lib_b.py -g XcodeDeps")
 
-    comp1_info = client.load("conan_lib_a_cmp1_release_x86_64.xcconfig")
-    comp2_info = client.load("conan_lib_a_cmp2_release_x86_64.xcconfig")
+    comp1_info = client.load(f"conan_lib_a_cmp1_release_{arch}.xcconfig")
+    comp2_info = client.load(f"conan_lib_a_cmp2_release_{arch}.xcconfig")
 
     assert "cmp1_define" not in comp1_info
     assert "cmp2_define" not in comp2_info
@@ -313,9 +319,12 @@ def test_xcodedeps_frameworkdirs():
     client.save({"conanfile.py": conanfile_py})
     client.run("create .")
 
+    arch_setting = client.get_default_host_profile().settings['arch']
+    arch = "arm64" if arch_setting == "armv8" else arch_setting
+
     client.run("install --requires=lib_a/1.0 -g XcodeDeps")
 
-    lib_a_xcconfig = client.load("conan_lib_a_lib_a_release_x86_64.xcconfig")
+    lib_a_xcconfig = client.load(f"conan_lib_a_lib_a_release_{arch}.xcconfig")
 
     assert "lib_a_frameworkdir" in lib_a_xcconfig
 

--- a/conans/test/integration/toolchains/cmake/cmakedeps/test_cmakedeps.py
+++ b/conans/test/integration/toolchains/cmake/cmakedeps/test_cmakedeps.py
@@ -37,7 +37,8 @@ def test_package_from_system():
     assert os.path.exists(os.path.join(client.current_folder, "dep1-config.cmake"))
     assert not os.path.exists(os.path.join(client.current_folder, "dep2-config.cmake"))
     assert not os.path.exists(os.path.join(client.current_folder, "custom_dep2-config.cmake"))
-    dep1_contents = client.load("dep1-release-x86_64-data.cmake")
+    host_arch = client.get_default_host_profile().settings['arch']
+    dep1_contents = client.load(f"dep1-release-{host_arch}-data.cmake")
     assert 'list(APPEND dep1_FIND_DEPENDENCY_NAMES custom_dep2)' in dep1_contents
     assert 'set(custom_dep2_FIND_MODE "")' in dep1_contents
 
@@ -62,7 +63,7 @@ def test_test_package():
         """)
     client.save({"conanfile.py": consumer})
     client.run("install . -s:b os=Windows -s:h os=Linux -s:h compiler=gcc -s:h compiler.version=7 "
-               "-s:h compiler.libcxx=libstdc++11 --build=missing")
+               "-s:h compiler.libcxx=libstdc++11 -s:h arch=x86_64 --build=missing")
     cmake_data = client.load("pkg-release-x86_64-data.cmake")
     assert "gtest" not in cmake_data
 
@@ -184,7 +185,8 @@ def test_cmakedeps_cppinfo_complex_strings():
     client.run("export . --name=hello --version=1.0")
     client.save({"conanfile.txt": "[requires]\nhello/1.0\n"}, clean_first=True)
     client.run("install . --build=missing -g CMakeDeps")
-    deps = client.load("hello-release-x86_64-data.cmake")
+    arch = client.get_default_host_profile().settings['arch']
+    deps = client.load(f"hello-release-{arch}-data.cmake")
     assert r"escape=partially \"escaped\"" in deps
     assert r"spaces=me you" in deps
     assert r"foobar=bazbuz" in deps


### PR DESCRIPTION
Changelog: Omit
Docs: Omit

This PR replaces instances in tests where the `x86_64` architecture is hardcoded in the test after a call to the `TestClient()` - typically because we are asserting a specific output or file existing (that includes the `x86_64` string), or because a file that contains the `x86_64` substring needs to be subsequently loaded or read.

This relies on the logic introduced in https://github.com/conan-io/conan/pull/11744 that exposes a method in the `TestClient` object to query the default architecture, which is set in `conftest.py`. 


