### PR TITLE
Fix logic when arm64 executables run on macOS Apple Silicon during tests

### DIFF
--- a/conans/test/functional/toolchains/cmake/cmakedeps/test_apple_frameworks.py
+++ b/conans/test/functional/toolchains/cmake/cmakedeps/test_apple_frameworks.py
@@ -503,7 +503,7 @@ target_link_libraries(${PROJECT_NAME} hello::libhello)
 
 @pytest.mark.tool("cmake")
 @pytest.mark.skipif(platform.system() != "Darwin", reason="Only OSX")
-def test_m1():
+def test_iphoneos_crossbuild():
     profile = textwrap.dedent("""
         include(default)
         [settings]
@@ -514,9 +514,9 @@ def test_m1():
     """).format()
 
     client = TestClient(path_with_spaces=False)
-    client.save({"m1": profile}, clean_first=True)
+    client.save({"ios-armv8": profile}, clean_first=True)
     client.run("new cmake_lib -d name=hello -d version=0.1")
-    client.run("create . --profile:build=default --profile:host=m1 -tf None")
+    client.run("create . --profile:build=default --profile:host=ios-armv8 -tf None")
 
     main = gen_function_cpp(name="main", includes=["hello"], calls=["hello"])
     # FIXME: The crossbuild for iOS etc is failing with find_package because cmake ignore the
@@ -552,12 +552,10 @@ def test_m1():
     client.save({"conanfile.py": conanfile,
                  "CMakeLists.txt": cmakelists,
                  "main.cpp": main,
-                 "m1": profile}, clean_first=True)
-    client.run("install . --profile:build=default --profile:host=m1")
-    client.run("build . --profile:build=default --profile:host=m1")
+                 "ios-armv8": profile}, clean_first=True)
+    client.run("install . --profile:build=default --profile:host=ios-armv8")
+    client.run("build . --profile:build=default --profile:host=ios-armv8")
     main_path = "./main.app/main"
-    client.run_command(main_path, assert_error=True)
-    assert "Bad CPU type in executable" in client.out
     client.run_command("lipo -info {}".format(main_path))
     assert "Non-fat file" in client.out
     assert "is architecture: arm64" in client.out

--- a/conans/test/functional/toolchains/cmake/cmakedeps/test_apple_frameworks.py
+++ b/conans/test/functional/toolchains/cmake/cmakedeps/test_apple_frameworks.py
@@ -559,3 +559,6 @@ def test_iphoneos_crossbuild():
     client.run_command("lipo -info {}".format(main_path))
     assert "Non-fat file" in client.out
     assert "is architecture: arm64" in client.out
+    client.run_command(f"vtool -show-build {main_path}")
+    assert "platform IOS" in client.out
+    assert "minos 12.0" in client.out

--- a/conans/test/functional/toolchains/cmake/test_cmake_toolchain_m1.py
+++ b/conans/test/functional/toolchains/cmake/test_cmake_toolchain_m1.py
@@ -64,8 +64,6 @@ def test_m1(op_system):
     assert "CMAKE_SYSTEM_PROCESSOR: arm64" in client.out
     main_path = "./build/Release/main.app/main" if op_system == "iOS" \
         else "./build/Release/main"
-    client.run_command(main_path, assert_error=True)
-    assert "Bad CPU type in executable" in client.out
     client.run_command("lipo -info {}".format(main_path))
     assert "Non-fat file" in client.out
     assert "is architecture: arm64" in client.out


### PR DESCRIPTION
Changelog: Omit
Docs: Omit

These tests create executables for *both* `iOS`/`armv8` and `macOS/armv8`, and try to _execute_ the program and assert that it results in a failure and that the shell prints the "Bad CPU type in executable" message.

This PR replaces the logic such that no attempts are made at "running" the executable, relying solely on on the output of `lipo` to ascertain the architecture of the produced binary. I believe this is still a sufficient check that preserves the intention of the test.


