### PR TITLE
Bugfixes 11743 and 11755

### DIFF
--- a/conan/tools/cmake/cmakedeps/templates/target_configuration.py
+++ b/conan/tools/cmake/cmakedeps/templates/target_configuration.py
@@ -168,7 +168,9 @@ class TargetConfigurationTemplate(CMakeDepsFileTemplate):
 
         ########## AGGREGATED GLOBAL TARGET WITH THE COMPONENTS #####################
         {%- for comp_variable_name, comp_target_name in components_names %}
+
         set_property(TARGET {{root_target_name}} PROPERTY INTERFACE_LINK_LIBRARIES {{ comp_target_name }} APPEND)
+
         {%- endfor %}
 
         {%- endif %}

--- a/conans/test/functional/toolchains/cmake/cmakedeps/test_cmakedeps_components.py
+++ b/conans/test/functional/toolchains/cmake/cmakedeps/test_cmakedeps_components.py
@@ -364,7 +364,7 @@ def test_cmake_add_subdirectory():
         """)
 
     cmakelists = textwrap.dedent("""
-            cmake_minimum_required(VERSION 3.16)
+            cmake_minimum_required(VERSION 3.15)
             project(hello CXX)
             find_package(Boost CONFIG)
             add_subdirectory(src)

--- a/conans/test/functional/toolchains/cmake/cmakedeps/test_cmakedeps_find_module_and_config.py
+++ b/conans/test/functional/toolchains/cmake/cmakedeps/test_cmakedeps_find_module_and_config.py
@@ -167,6 +167,10 @@ def test_transitive_modules_found(find_mode_PKGA, find_mode_PKGB, find_mode_cons
         message("MYPKGB_INCLUDE_DIRS: ${{MYPKGB_INCLUDE_DIRS}}")
         message("MYPKGB_INCLUDE_DIR: ${{MYPKGB_INCLUDE_DIR}}")
         message("MYPKGB_LIBRARIES: ${{MYPKGB_LIBRARIES}}")
+
+        get_target_property(linked_libs pkgb::pkgb INTERFACE_LINK_LIBRARIES)
+        message("MYPKGB_LINKED_LIBRARIES: '${{linked_libs}}'")
+
         message("MYPKGB_DEFINITIONS: ${{MYPKGB_DEFINITIONS}}")
         """)
 
@@ -183,7 +187,11 @@ def test_transitive_modules_found(find_mode_PKGA, find_mode_PKGB, find_mode_cons
     assert "MYPKGB_VERSION_STRING: 1.0" in client.out
     assert "MYPKGB_INCLUDE_DIRS:" in client.out
     assert "MYPKGB_INCLUDE_DIR:" in client.out
-    assert "MYPKGB_LIBRARIES: pkga::pkga" in client.out
+    # The MYPKG_LIBRARIES contains the target for the current package, but the target is linked
+    # with the dependencies also:
+    assert "MYPKGB_LIBRARIES: pkgb::pkgb" in client.out
+    assert "MYPKGB_LINKED_LIBRARIES: '$<$<CONFIG:Release>:>;$<$<CONFIG:Release>:pkga::pkga>" in client.out
+
     assert "MYPKGB_DEFINITIONS: -DDEFINE_MYPKGB" in client.out
     assert "Conan: Target declared 'pkga::pkga'"
 

--- a/conans/test/integration/toolchains/cmake/cmakedeps/test_cmakedeps.py
+++ b/conans/test/integration/toolchains/cmake/cmakedeps/test_cmakedeps.py
@@ -114,7 +114,8 @@ def test_cpp_info_component_objects():
              $<$<CONFIG:Release>:${hello_OBJECTS_RELEASE}>
              ${hello_LIBRARIES_TARGETS}""" not in content
         # But the global target is linked with the targets from the components
-        assert "target_link_libraries(hello::hello INTERFACE hello::say)" in content
+        assert "set_property(TARGET hello::hello PROPERTY " \
+               "INTERFACE_LINK_LIBRARIES hello::say APPEND)" in content
 
     with open(os.path.join(client.current_folder, "hello-release-x86_64-data.cmake")) as f:
         content = f.read()


### PR DESCRIPTION
Changelog: Bugfix: The CMakeDeps generator failed for consumers with CMake projects doing an `add_subdirectory` with two different `find_package` calls to the same package, one in the main `CMakeLists.txt` and the other in the subdirectory.
Changelog: Bugfix: The CMakeDeps generator stopped to fill the `XXX_LIBRARIES` CMake variable, especially when using components.
Docs: omit

Close https://github.com/conan-io/conan/issues/11755
Close https://github.com/conan-io/conan/issues/11743