### PR TITLE
xcodedeps: Fix dependency resolution if transitive dependencies have …

### DIFF
--- a/conan/tools/apple/xcodedeps.py
+++ b/conan/tools/apple/xcodedeps.py
@@ -230,6 +230,7 @@ class XcodeDeps(object):
 
                 sorted_components = dep.cpp_info.get_sorted_components().items()
                 for comp_name, comp_cpp_info in sorted_components:
+                    comp_name = _format_name(comp_name)
 
                     # returns: ("list of cpp infos from required components in same package",
                     #           "list of names from required components from other packages")
@@ -266,8 +267,17 @@ class XcodeDeps(object):
                     include_components_names.append((dep_name, comp_name))
                     result.update(component_content)
             else:
-                public_deps = [(_format_name(d.ref.name),) * 2 for r, d in
-                               dep.dependencies.direct_host.items() if r.visible]
+                public_deps = []
+                for r, d in dep.dependencies.direct_host.items():
+                    if not r.visible:
+                        continue
+                    if d.cpp_info.has_components:
+                        sorted_components = d.cpp_info.get_sorted_components().items()
+                        for comp_name, comp_cpp_info in sorted_components:
+                            public_deps.append((_format_name(d.ref.name), _format_name(comp_name)))
+                    else:
+                        public_deps.append((_format_name(d.ref.name),) * 2)
+
                 required_components = dep.cpp_info.required_components if dep.cpp_info.required_components else public_deps
                 root_content = self.get_content_for_component(dep_name, dep_name, [dep.cpp_info],
                                                               required_components)


### PR DESCRIPTION
Changelog: Bugfix: Fix XcodeDeps component handling in transitive dependencies
Docs: omit

…components

When a dependency of a dependency would have components, only the default
name `conan_dep_dep.xconfig` would be included. However, this file was never
generated, as they are in the form `conan_dep_component.xconfig`.

Fix this by adding all components instead.

Also allow the components to have dashes and use _format_name() to
avoid issues when parsing the xcconfig file.


- [ ] Refer to the issue that supports this Pull Request.
- [ ] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 

<sup>**Note:** By default this PR will skip the slower tests and will use a limited set of python versions. Check [here](https://github.com/conan-io/conan/blob/develop/.github/PR_INCREASE_TESTING.md) how to increase the testing level by writing some tags in the current PR body text.</sup>
