### PR TITLE
Allow customization of the authorization process

### DIFF
--- a/conans/server/conf/__init__.py
+++ b/conans/server/conf/__init__.py
@@ -53,6 +53,7 @@ class ConanServerConfigParser(ConfigParser):
                            "public_port": get_env("CONAN_SERVER_PUBLIC_PORT", None, environment),
                            "host_name": get_env("CONAN_HOST_NAME", None, environment),
                            "custom_authenticator": get_env("CONAN_CUSTOM_AUTHENTICATOR", None, environment),
+                           "custom_authorizer": get_env("CONAN_CUSTOM_AUTHORIZER", None, environment),
                            # "user:pass,user2:pass2"
                            "users": get_env("CONAN_SERVER_USERS", None, environment)}
 
@@ -165,6 +166,13 @@ class ConanServerConfigParser(ConfigParser):
     def custom_authenticator(self):
         try:
             return self._get_conf_server_string("custom_authenticator")
+        except ConanException:
+            return None
+
+    @property
+    def custom_authorizer(self):
+        try:
+            return self._get_conf_server_string("custom_authorizer")
         except ConanException:
             return None
 

--- a/conans/server/conf/default_server_conf.py
+++ b/conans/server/conf/default_server_conf.py
@@ -27,6 +27,12 @@ updown_secret: {updown_secret}
 #
 # custom_authenticator: my_authenticator
 
+# Check docs.conan.io to implement a different authorizer plugin for conan_server
+# if custom_authorizer is not specified, the [read_permissions] and [write_permissions]
+# sections will be used to grant/reject access.
+#
+# custom_authorizer: my_authorizer
+
 # name/version@user/channel: user1, user2, user3
 #
 # The rules are applied in order. 

--- a/conans/server/launcher.py
+++ b/conans/server/launcher.py
@@ -9,7 +9,7 @@ from conans.server.conf import get_server_store
 from conans.server.crypto.jwt.jwt_credentials_manager import JWTCredentialsManager
 from conans.server.crypto.jwt.jwt_updown_manager import JWTUpDownAuthManager
 from conans.server.migrate import migrate_and_get_server_config
-from conans.server.plugin_loader import load_authentication_plugin
+from conans.server.plugin_loader import load_authentication_plugin, load_authorization_plugin
 from conans.server.rest.server import ConanServer
 
 from conans.server.service.authorize import BasicAuthorizer, BasicAuthenticator
@@ -29,14 +29,19 @@ class ServerLauncher(object):
         server_config = migrate_and_get_server_config(
             user_folder, self.force_migration, server_dir is not None
         )
-        custom_auth = server_config.custom_authenticator
-        if custom_auth:
-            authenticator = load_authentication_plugin(server_folder, custom_auth)
+        custom_authn = server_config.custom_authenticator
+        if custom_authn:
+            authenticator = load_authentication_plugin(server_folder, custom_authn)
         else:
             authenticator = BasicAuthenticator(dict(server_config.users))
 
-        authorizer = BasicAuthorizer(server_config.read_permissions,
-                                     server_config.write_permissions)
+        custom_authz = server_config.custom_authorizer
+        if custom_authz:
+            authorizer = load_authorization_plugin(server_folder, custom_authz)
+        else:
+            authorizer = BasicAuthorizer(server_config.read_permissions,
+                                         server_config.write_permissions)
+
         credentials_manager = JWTCredentialsManager(server_config.jwt_secret,
                                                     server_config.jwt_expire_time)
 

--- a/conans/server/plugin_loader.py
+++ b/conans/server/plugin_loader.py
@@ -1,18 +1,26 @@
 import os
 
 
-def load_authentication_plugin(server_folder, plugin_name):
+def load_plugin(server_folder, plugin_type, plugin_name):
     try:
         from pluginbase import PluginBase
-        plugin_base = PluginBase(package="plugins/authenticator")
-        plugins_dir = os.path.join(server_folder, "plugins", "authenticator")
+        plugin_base = PluginBase(package="plugins/%s" % plugin_type)
+        plugins_dir = os.path.join(server_folder, "plugins", plugin_type)
         plugin_source = plugin_base.make_plugin_source(
                         searchpath=[plugins_dir])
-        auth = plugin_source.load_plugin(plugin_name).get_class()
+        plugin = plugin_source.load_plugin(plugin_name).get_class()
         # it is necessary to keep a reference to the plugin, otherwise it is removed
         # and some imports fail
-        auth.plugin_source = plugin_source
-        return auth
+        plugin.plugin_source = plugin_source
+        return plugin
     except Exception:
-        print("Error loading authenticator plugin '%s'" % plugin_name)
+        print("Error loading %s plugin '%s'" % (plugin_type, plugin_name))
         raise
+
+
+def load_authentication_plugin(server_folder, plugin_name):
+    return load_plugin(server_folder, "authenticator", plugin_name)
+
+
+def load_authorization_plugin(server_folder, plugin_name):
+    return load_plugin(server_folder, "authorizer", plugin_name)

--- a/conans/server/service/authorize.py
+++ b/conans/server/service/authorize.py
@@ -44,6 +44,14 @@ class Authorizer(object):
         raise NotImplemented()
 
     @abstractmethod
+    def check_delete_conan(self, username, ref):
+        """
+        username: User requesting a recipe's deletion
+        ref: ConanFileReference
+        """
+        raise NotImplemented()
+
+    @abstractmethod
     def check_read_package(self, username, pref):
         """
         username: User that request to read the package
@@ -55,6 +63,14 @@ class Authorizer(object):
     def check_write_package(self, username, pref):
         """
         username: User that request to write the package
+        pref: PackageReference
+        """
+        raise NotImplemented()
+
+    @abstractmethod
+    def check_delete_package(self, username, pref):
+        """
+        username: User requesting a package's deletion
         pref: PackageReference
         """
         raise NotImplemented()


### PR DESCRIPTION
Changelog: Feature: Allow the authorization process in conan_server to be customized, just like authentication.
Docs: https://github.com/conan-io/docs/pull/2684

Closes: #5758

- [x] Refer to the issue that supports this Pull Request.
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [x] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 

<sup>**Note:** By default this PR will skip the slower tests and will use a limited set of python versions. Check [here](https://github.com/conan-io/conan/blob/develop/.github/PR_INCREASE_TESTING.md) how to increase the testing level by writing some tags in the current PR body text.</sup>
