### PR TITLE
Fix tests when running on arm64 architecture

### DIFF
--- a/conans/test/functional/toolchains/cmake/test_cmake.py
+++ b/conans/test/functional/toolchains/cmake/test_cmake.py
@@ -440,9 +440,8 @@ class AppleTest(Base):
                 "CMAKE_INSTALL_NAME_DIR": ""
                 }
 
-        host_arch = self.client.get_default_host_profile()
-
-        if host_arch == "x86_64":
+        host_profile = self.client.get_default_host_profile()
+        if host_profile.settings.get("arch") == "x86_64":
             vals.update({
                 "CMAKE_C_FLAGS": "-m64",
                 "CMAKE_CXX_FLAGS": "-m64 -stdlib=libc++",

--- a/conans/test/functional/toolchains/cmake/test_cmake.py
+++ b/conans/test/functional/toolchains/cmake/test_cmake.py
@@ -433,16 +433,26 @@ class AppleTest(Base):
         vals = {"CMAKE_CXX_STANDARD": cppstd,
                 "CMAKE_CXX_EXTENSIONS": extensions_str,
                 "CMAKE_BUILD_TYPE": build_type,
-                "CMAKE_CXX_FLAGS": "-m64 -stdlib=libc++",
                 "CMAKE_CXX_FLAGS_DEBUG": "-g",
                 "CMAKE_CXX_FLAGS_RELEASE": "-O3 -DNDEBUG",
-                "CMAKE_C_FLAGS": "-m64",
                 "CMAKE_C_FLAGS_DEBUG": "-g",
                 "CMAKE_C_FLAGS_RELEASE": "-O3 -DNDEBUG",
-                "CMAKE_SHARED_LINKER_FLAGS": "-m64",
-                "CMAKE_EXE_LINKER_FLAGS": "-m64",
                 "CMAKE_INSTALL_NAME_DIR": ""
                 }
+
+        host_arch = self.client.get_default_host_profile()
+
+        if host_arch == "x86_64":
+            vals.update({
+                "CMAKE_C_FLAGS": "-m64",
+                "CMAKE_CXX_FLAGS": "-m64 -stdlib=libc++",
+                "CMAKE_SHARED_LINKER_FLAGS": "-m64",
+                "CMAKE_EXE_LINKER_FLAGS": "-m64",
+            })
+        else:
+            vals.update({
+                "CMAKE_CXX_FLAGS": "-stdlib=libc++",
+            })
 
         def _verify_out(marker=">>"):
             if shared:

--- a/conans/test/integration/package_id/package_id_test.py
+++ b/conans/test/integration/package_id/package_id_test.py
@@ -135,11 +135,11 @@ def test_build_type_remove_windows():
                    del self.info.settings.compiler.runtime_type
         """)
     client.save({"conanfile.py": conanfile})
-    client.run('create . --name=pkg --version=0.1 -s os=Windows -s compiler=msvc '
+    client.run('create . --name=pkg --version=0.1 -s os=Windows -s compiler=msvc -s arch=x86_64 '
                '-s compiler.version=190 -s build_type=Release -s compiler.runtime=dynamic')
     package_id = "6a98270da6641cc6668b83daf547d67451910cf0"
     client.assert_listed_binary({"pkg/0.1": (package_id, "Build")})
-    client.run('install --requires=pkg/0.1@ -s os=Windows -s compiler=msvc '
+    client.run('install --requires=pkg/0.1@ -s os=Windows -s compiler=msvc -s arch=x86_64 '
                '-s compiler.version=190 -s build_type=Debug -s compiler.runtime=dynamic')
     client.assert_listed_binary({"pkg/0.1": (package_id, "Cache")})
 

--- a/conans/test/integration/toolchains/apple/test_xcodetoolchain.py
+++ b/conans/test/integration/toolchains/apple/test_xcodetoolchain.py
@@ -22,6 +22,7 @@ def _condition(configuration, architecture, sdk_version):
 @pytest.mark.skipif(platform.system() != "Darwin", reason="Only for MacOS")
 @pytest.mark.parametrize("configuration, os_version, libcxx, cppstd, arch, sdk_version, clang_cppstd", [
     ("Release", "", "", "", "x86_64", "", ""),
+    ("Debug", "", "", "", "armv8", "", ""),
     ("Release", "12.0", "libc++", "20", "x86_64", "", "c++2a"),
     ("Debug", "12.0", "libc++", "20", "x86_64", "", "c++2a"),
     ("Release", "12.0", "libc++", "20", "x86_64", "11.3", "c++2a"),
@@ -34,8 +35,10 @@ def test_toolchain_files(configuration, os_version, cppstd, libcxx, arch, sdk_ve
     cmd = cmd + " -s os.version={}".format(os_version) if os_version else cmd
     cmd = cmd + " -s compiler.cppstd={}".format(cppstd) if cppstd else cmd
     cmd = cmd + " -s os.sdk_version={}".format(sdk_version) if sdk_version else cmd
+    cmd = cmd + " -s arch={}".format(arch) if arch else cmd
     client.run(cmd)
-    filename = _get_filename(configuration, arch, sdk_version)
+    arch_name = "arm64" if arch == "armv8" else arch
+    filename = _get_filename(configuration, arch_name, sdk_version)
     condition = _condition(configuration, arch, sdk_version)
 
     toolchain_all = client.load("conantoolchain.xcconfig")

--- a/conans/test/integration/toolchains/microsoft/test_msbuildtoolchain.py
+++ b/conans/test/integration/toolchains/microsoft/test_msbuildtoolchain.py
@@ -11,6 +11,8 @@ def test_msbuildtoolchain_props_with_extra_flags():
     """
     profile = textwrap.dedent("""\
     include(default)
+    [settings]
+    arch=x86_64
     [conf]
     tools.build:cxxflags=["--flag1", "--flag2"]
     tools.build:cflags+=["--flag3", "--flag4"]

--- a/conans/test/utils/tools.py
+++ b/conans/test/utils/tools.py
@@ -653,6 +653,10 @@ class TestClient(object):
         api = ConanAPIV2(cache_folder=self.cache_folder)
         return api.profiles.get_profile([api.profiles.get_default_host()])
 
+    def get_default_build_profile(self):
+        api = ConanAPIV2(cache_folder=self.cache_folder)
+        return api.profiles.get_profile([api.profiles.get_default_build()])
+
     def recipe_exists(self, ref):
         rrev = self.cache.get_recipe_revisions_references(ref)
         return True if rrev else False


### PR DESCRIPTION
Changelog: omit
Docs: omit

`conans/test/functional/toolchains/cmake/test_cmake.py`:
- Add logic to cover the case where `-m64` is only passed when the host architecture is `x86_64` but not on others.

`conans/test/integration/toolchains/apple/test_xcodetoolchain.py`:
- Add a case to test `armv8` too - the current test however did run on macOS/Apple Silicon successfully since the architecture is explicit and the SDK supports both.

`conans/test/functional/toolchains/gnu/autotools/test_ios.py`
- Reflect that test checks for `iOS` rather than m1
- Determine name of "build" triplet based on current architecture by querying the `TestClient` object
- Add additional checks to verify that the built binary is indeed an iOS binary with 12.0 SDK as specified by the profile

`conans/test/integration/package_id/package_id_test.py`
- Explicitly pass `-s x86_64` so that the resulting package_id matches the expected one (was implicitly relying on the default value)

`conans/test/integration/toolchains/microsoft/test_msbuildtoolchain.py`
- Explicitly set the `arch` setting to `x86_64` so that the generated filename is predictable (was implicitly relying on the default value) 

`conans/test/utils/tools.py`
- `TestClient`: add method to query default _build_ profile (only one instance in the entire test suite where this is needed)
