### PR TITLE
Refactored CMakeDep using always targets instead of lists

### DIFF
--- a/conan/tools/cmake/cmakedeps/templates/macros.py
+++ b/conan/tools/cmake/cmakedeps/templates/macros.py
@@ -41,7 +41,7 @@ class MacrosTemplate(CMakeDepsFileTemplate):
            endif()
        endmacro()
 
-       function(conan_package_library_targets libraries package_libdir deps out_libraries_target config package_name)
+       function(conan_package_library_targets libraries package_libdir deps_target out_libraries_target config package_name)
            set(_out_libraries "")
            set(_out_libraries_target "")
            set(_CONAN_ACTUAL_TARGETS "")
@@ -73,10 +73,9 @@ class MacrosTemplate(CMakeDepsFileTemplate):
                unset(CONAN_FOUND_LIBRARY CACHE)
            endforeach()
 
-           # Add all dependencies to all targets
-           string(REPLACE " " ";" deps_list "${deps}")
+           # Add the dependencies target for all the imported libraries
            foreach(_CONAN_ACTUAL_TARGET ${_CONAN_ACTUAL_TARGETS})
-               set_property(TARGET ${_CONAN_ACTUAL_TARGET} PROPERTY INTERFACE_LINK_LIBRARIES $<$<CONFIG:${config}>:${deps_list}> APPEND)
+               set_property(TARGET ${_CONAN_ACTUAL_TARGET} PROPERTY INTERFACE_LINK_LIBRARIES ${deps_target} APPEND)
            endforeach()
 
            # ONLY FOR DEBUGGING PURPOSES

--- a/conan/tools/cmake/cmakedeps/templates/target_configuration.py
+++ b/conan/tools/cmake/cmakedeps/templates/target_configuration.py
@@ -96,7 +96,7 @@ class TargetConfigurationTemplate(CMakeDepsFileTemplate):
             set_property(TARGET {{root_target_name}}
                          PROPERTY INTERFACE_LINK_LIBRARIES
                          $<$<CONFIG:{{configuration}}>:{{ '${'+pkg_name+'_OBJECTS'+config_suffix+'}' }}>
-                         ${{'{'}}{{pkg_name}}_LIBRARIES_TARGETS}x
+                         ${{'{'}}{{pkg_name}}_LIBRARIES_TARGETS}
                          APPEND)
 
             if("{{ '${' }}{{ pkg_name }}_LIBS{{ config_suffix }}}" STREQUAL "")

--- a/conan/tools/cmake/cmakedeps/templates/target_configuration.py
+++ b/conan/tools/cmake/cmakedeps/templates/target_configuration.py
@@ -40,6 +40,8 @@ class TargetConfigurationTemplate(CMakeDepsFileTemplate):
     @property
     def template(self):
         return textwrap.dedent("""\
+        # Avoid multiple calls to find_package to append duplicated properties to the targets
+        include_guard()
 
         {%- macro tvalue(pkg_name, comp_name, var, config_suffix) -%}
             {{'${'+pkg_name+'_'+comp_name+'_'+var+config_suffix+'}'}}
@@ -93,8 +95,8 @@ class TargetConfigurationTemplate(CMakeDepsFileTemplate):
         ########## GLOBAL TARGET PROPERTIES {{ configuration }} ########################################
             set_property(TARGET {{root_target_name}}
                          PROPERTY INTERFACE_LINK_LIBRARIES
-                         ${{'{'}}{{pkg_name}}_LIBRARIES_TARGETS}
                          $<$<CONFIG:{{configuration}}>:{{ '${'+pkg_name+'_OBJECTS'+config_suffix+'}' }}>
+                         ${{'{'}}{{pkg_name}}_LIBRARIES_TARGETS}x
                          APPEND)
 
             if("{{ '${' }}{{ pkg_name }}_LIBS{{ config_suffix }}}" STREQUAL "")
@@ -167,8 +169,8 @@ class TargetConfigurationTemplate(CMakeDepsFileTemplate):
                 ########## TARGET PROPERTIES #####################################
                 set_property(TARGET {{comp_target_name}}
                              PROPERTY INTERFACE_LINK_LIBRARIES
-                             ${{'{'}}{{pkg_name}}_{{comp_variable_name}}_LIBRARIES_TARGETS}
                              $<$<CONFIG:{{configuration}}>:{{ '${'+pkg_name+'_'+comp_variable_name+'_OBJECTS'+config_suffix+'}' }}>
+                             ${{'{'}}{{pkg_name}}_{{comp_variable_name}}_LIBRARIES_TARGETS}
                              APPEND)
 
                 if("{{ '${' }}{{ pkg_name }}_{{comp_variable_name}}_LIBS{{ config_suffix }}}" STREQUAL "")

--- a/conan/tools/cmake/cmakedeps/templates/target_configuration.py
+++ b/conan/tools/cmake/cmakedeps/templates/target_configuration.py
@@ -60,15 +60,26 @@ class TargetConfigurationTemplate(CMakeDepsFileTemplate):
         set({{ pkg_name }}_FRAMEWORKS_FOUND{{ config_suffix }} "") # Will be filled later
         conan_find_apple_frameworks({{ pkg_name }}_FRAMEWORKS_FOUND{{ config_suffix }} "{{ '${' }}{{ pkg_name }}_FRAMEWORKS{{ config_suffix }}}" "{{ '${' }}{{ pkg_name }}_FRAMEWORK_DIRS{{ config_suffix }}}")
 
-        # Gather all the libraries that should be linked to the targets (do not touch existing variables)
-        # FIXME: Why is needed to pass all the dependencies to link with the micro-targets?
-        set(_{{ pkg_name }}_DEPENDENCIES{{ config_suffix }} "{{ deps_targets_names }}")
-
         set({{ pkg_name }}_LIBRARIES_TARGETS{{ config_suffix }} "") # Will be filled later
-        set({{ pkg_name }}_LIBRARIES{{ config_suffix }} "") # Will be filled later
+
+
+        ######## Create an interface target to contain all the dependencies (frameworks, system and conan deps)
+        if(NOT TARGET {{ pkg_name+'_DEPS_TARGET'}})
+            add_library({{ pkg_name+'_DEPS_TARGET'}} INTERFACE)
+        endif()
+
+        set_property(TARGET {{ pkg_name + '_DEPS_TARGET'}}
+                     PROPERTY INTERFACE_LINK_LIBRARIES
+                     $<$<CONFIG:{{configuration}}>:{{ '${'+pkg_name+'_FRAMEWORKS_FOUND'+config_suffix+'}' }}>
+                     $<$<CONFIG:{{configuration}}>:{{ '${'+pkg_name+'_SYSTEM_LIBS'+config_suffix+'}' }}>
+                     $<$<CONFIG:{{configuration}}>:{{ deps_targets_names }}>
+                     APPEND)
+
+        ####### Find the libraries declared in cpp_info.libs, create an IMPORTED target for each one and link the
+        ####### {{pkg_name}}_DEPS_TARGET to all of them
         conan_package_library_targets("{{ '${' }}{{ pkg_name }}_LIBS{{ config_suffix }}}"    # libraries
                                       "{{ '${' }}{{ pkg_name }}_LIB_DIRS{{ config_suffix }}}" # package_libdir
-                                      "{{ '${' }}_{{ pkg_name }}_DEPENDENCIES{{ config_suffix }}}" # deps
+                                      {{ pkg_name + '_DEPS_TARGET'}}
                                       {{ pkg_name }}_LIBRARIES_TARGETS  # out_libraries_targets
                                       "{{ config }}" # DEBUG, RELEASE ...
                                       "{{ pkg_name }}")    # package_name
@@ -78,102 +89,131 @@ class TargetConfigurationTemplate(CMakeDepsFileTemplate):
         set(CMAKE_PREFIX_PATH {{ '${' }}{{ pkg_name }}_BUILD_DIRS{{ config_suffix }}} {{ '${' }}CMAKE_PREFIX_PATH})
 
         {% if not components_names %}
+
         ########## GLOBAL TARGET PROPERTIES {{ configuration }} ########################################
-        set_property(TARGET {{root_target_name}}
-                     PROPERTY INTERFACE_LINK_LIBRARIES
-                     $<$<CONFIG:{{configuration}}>:${{'{'}}{{pkg_name}}_OBJECTS{{config_suffix}}}>
-                     ${{'{'}}{{pkg_name}}_LIBRARIES_TARGETS}
-                     $<$<CONFIG:{{configuration}}>:${{'{'}}_{{pkg_name}}_DEPENDENCIES{{config_suffix}}}>
-                     $<$<CONFIG:{{configuration}}>:${{'{'}}{{pkg_name}}_FRAMEWORKS_FOUND{{config_suffix}}}>
-                     $<$<CONFIG:{{configuration}}>:${{'{'}}{{pkg_name}}_SYSTEM_LIBS{{config_suffix}}}>
-                     APPEND)
+            set_property(TARGET {{root_target_name}}
+                         PROPERTY INTERFACE_LINK_LIBRARIES
+                         ${{'{'}}{{pkg_name}}_LIBRARIES_TARGETS}
+                         $<$<CONFIG:{{configuration}}>:{{ '${'+pkg_name+'_OBJECTS'+config_suffix+'}' }}>
+                         APPEND)
 
-        set_property(TARGET {{root_target_name}}
-                     PROPERTY INTERFACE_LINK_OPTIONS
-                     $<$<CONFIG:{{configuration}}>:${{'{'}}{{pkg_name}}_LINKER_FLAGS{{config_suffix}}}> APPEND)
-        set_property(TARGET {{root_target_name}}
-                     PROPERTY INTERFACE_INCLUDE_DIRECTORIES
-                     $<$<CONFIG:{{configuration}}>:${{'{'}}{{pkg_name}}_INCLUDE_DIRS{{config_suffix}}}> APPEND)
-        set_property(TARGET {{root_target_name}}
-                     PROPERTY INTERFACE_COMPILE_DEFINITIONS
-                     $<$<CONFIG:{{configuration}}>:${{'{'}}{{pkg_name}}_COMPILE_DEFINITIONS{{config_suffix}}}> APPEND)
-        set_property(TARGET {{root_target_name}}
-                     PROPERTY INTERFACE_COMPILE_OPTIONS
-                     $<$<CONFIG:{{configuration}}>:${{'{'}}{{pkg_name}}_COMPILE_OPTIONS{{config_suffix}}}> APPEND)
+            if("{{ '${' }}{{ pkg_name }}_LIBS{{ config_suffix }}}" STREQUAL "")
+                # If the package is not declaring any "cpp_info.libs" the package deps, system libs,
+                # frameworks etc are not linked to the imported targets and we need to do it to the
+                # global target
+                set_property(TARGET {{root_target_name}}
+                             PROPERTY INTERFACE_LINK_LIBRARIES
+                             {{pkg_name}}_DEPS_TARGET
+                             APPEND)
+            endif()
 
-        {%- if set_interface_link_directories %}
+            set_property(TARGET {{root_target_name}}
+                         PROPERTY INTERFACE_LINK_OPTIONS
+                         $<$<CONFIG:{{configuration}}>:${{'{'}}{{pkg_name}}_LINKER_FLAGS{{config_suffix}}}> APPEND)
+            set_property(TARGET {{root_target_name}}
+                         PROPERTY INTERFACE_INCLUDE_DIRECTORIES
+                         $<$<CONFIG:{{configuration}}>:${{'{'}}{{pkg_name}}_INCLUDE_DIRS{{config_suffix}}}> APPEND)
+            set_property(TARGET {{root_target_name}}
+                         PROPERTY INTERFACE_COMPILE_DEFINITIONS
+                         $<$<CONFIG:{{configuration}}>:${{'{'}}{{pkg_name}}_COMPILE_DEFINITIONS{{config_suffix}}}> APPEND)
+            set_property(TARGET {{root_target_name}}
+                         PROPERTY INTERFACE_COMPILE_OPTIONS
+                         $<$<CONFIG:{{configuration}}>:${{'{'}}{{pkg_name}}_COMPILE_OPTIONS{{config_suffix}}}> APPEND)
 
-        # This is only used for '#pragma comment(lib, "foo")' (automatic link)
-        set_property(TARGET {{root_target_name}}
-                     PROPERTY INTERFACE_LINK_DIRECTORIES
-                     $<$<CONFIG:{{configuration}}>:${{'{'}}{{pkg_name}}_LIB_DIRS{{config_suffix}}}> APPEND)
-        {%- endif %}
+            {%- if set_interface_link_directories %}
 
-        # For the modules (FindXXX)
-        list(APPEND {{ pkg_name }}_LIBRARIES{{ config_suffix }} {{root_target_name}})
+            # This is only used for '#pragma comment(lib, "foo")' (automatic link)
+            set_property(TARGET {{root_target_name}}
+                         PROPERTY INTERFACE_LINK_DIRECTORIES
+                         $<$<CONFIG:{{configuration}}>:${{'{'}}{{pkg_name}}_LIB_DIRS{{config_suffix}}}> APPEND)
+            {%- endif %}
+
 
         {%- else %}
 
         ########## COMPONENTS TARGET PROPERTIES {{ configuration }} ########################################
 
-        {%- for comp_variable_name, comp_target_name in components_names %}
+            {%- for comp_variable_name, comp_target_name in components_names %}
 
-        ########## COMPONENT {{ comp_target_name }} FIND LIBRARIES & FRAMEWORKS / DYNAMIC VARS #############
 
-        set({{ pkg_name }}_{{ comp_variable_name }}_FRAMEWORKS_FOUND{{ config_suffix }} "")
-        conan_find_apple_frameworks({{ pkg_name }}_{{ comp_variable_name }}_FRAMEWORKS_FOUND{{ config_suffix }} "{{ '${'+pkg_name+'_'+comp_variable_name+'_FRAMEWORKS'+config_suffix+'}' }}" "{{ '${'+pkg_name+'_'+comp_variable_name+'_FRAMEWORK_DIRS'+config_suffix+'}' }}")
+            ########## COMPONENT {{ comp_target_name }} #############
 
-        set({{ pkg_name }}_{{ comp_variable_name }}_LIBRARIES_TARGETS "")
+                set({{ pkg_name }}_{{ comp_variable_name }}_FRAMEWORKS_FOUND{{ config_suffix }} "")
+                conan_find_apple_frameworks({{ pkg_name }}_{{ comp_variable_name }}_FRAMEWORKS_FOUND{{ config_suffix }} "{{ '${'+pkg_name+'_'+comp_variable_name+'_FRAMEWORKS'+config_suffix+'}' }}" "{{ '${'+pkg_name+'_'+comp_variable_name+'_FRAMEWORK_DIRS'+config_suffix+'}' }}")
 
-        conan_package_library_targets("{{ '${'+pkg_name+'_'+comp_variable_name+'_LIBS'+config_suffix+'}' }}"
-                                      "{{ '${'+pkg_name+'_'+comp_variable_name+'_LIB_DIRS'+config_suffix+'}' }}"
-                                      "{{ '${'+pkg_name+'_'+comp_variable_name+'_DEPENDENCIES'+config_suffix+'}' }}"
-                                      {{ pkg_name }}_{{ comp_variable_name }}_LIBRARIES_TARGETS
-                                      "{{ config }}" # DEBUG, RELEASE...
-                                      "{{ pkg_name }}_{{ comp_variable_name }}")
+                set({{ pkg_name }}_{{ comp_variable_name }}_LIBRARIES_TARGETS "")
 
-        ########## COMPONENT {{ comp_target_name }} TARGET PROPERTIES #####################################
-        set_property(TARGET {{comp_target_name}}
-                     PROPERTY INTERFACE_LINK_LIBRARIES
-                     $<$<CONFIG:{{configuration}}>:${{'{'}}{{pkg_name}}_{{comp_variable_name}}_OBJECTS{{config_suffix}}}>
-                     ${{'{'}}{{pkg_name}}_{{comp_variable_name}}_LIBRARIES_TARGETS}
-                     $<$<CONFIG:{{configuration}}>:${{'{'}}{{pkg_name}}_{{comp_variable_name}}_DEPENDENCIES{{config_suffix}}}>
-                     $<$<CONFIG:{{configuration}}>:${{'{'}}{{pkg_name}}_{{comp_variable_name}}_FRAMEWORKS_FOUND{{config_suffix}}}>
-                     $<$<CONFIG:{{configuration}}>:${{'{'}}{{pkg_name}}_{{comp_variable_name}}_SYSTEM_LIBS{{config_suffix}}}>
-                     APPEND)
+                ######## Create an interface target to contain all the dependencies (frameworks, system and conan deps)
+                if(NOT TARGET {{ pkg_name + '_' + comp_variable_name + '_DEPS_TARGET'}})
+                    add_library({{ pkg_name + '_' + comp_variable_name + '_DEPS_TARGET'}} INTERFACE)
+                endif()
 
-        set_property(TARGET {{ comp_target_name }} PROPERTY INTERFACE_LINK_OPTIONS
-                     $<$<CONFIG:{{ configuration }}>:{{tvalue(pkg_name, comp_variable_name, 'LINKER_FLAGS', config_suffix)}}> APPEND)
-        set_property(TARGET {{ comp_target_name }} PROPERTY INTERFACE_INCLUDE_DIRECTORIES
-                     $<$<CONFIG:{{ configuration }}>:{{tvalue(pkg_name, comp_variable_name, 'INCLUDE_DIRS', config_suffix)}}> APPEND)
-        set_property(TARGET {{ comp_target_name }} PROPERTY INTERFACE_COMPILE_DEFINITIONS
-                     $<$<CONFIG:{{ configuration }}>:{{tvalue(pkg_name, comp_variable_name, 'COMPILE_DEFINITIONS', config_suffix)}}> APPEND)
-        set_property(TARGET {{ comp_target_name }} PROPERTY INTERFACE_COMPILE_OPTIONS
-                     $<$<CONFIG:{{ configuration }}>:
-                     {{tvalue(pkg_name, comp_variable_name, 'COMPILE_OPTIONS_C', config_suffix)}}
-                     {{tvalue(pkg_name, comp_variable_name, 'COMPILE_OPTIONS_CXX', config_suffix)}}> APPEND)
-        set({{ pkg_name }}_{{ comp_variable_name }}_TARGET_PROPERTIES TRUE)
+                set_property(TARGET {{ pkg_name + '_' + comp_variable_name + '_DEPS_TARGET'}}
+                             PROPERTY INTERFACE_LINK_LIBRARIES
+                             $<$<CONFIG:{{configuration}}>:{{ '${'+pkg_name+'_'+comp_variable_name+'_FRAMEWORKS_FOUND'+config_suffix+'}' }}>
+                             $<$<CONFIG:{{configuration}}>:{{ '${'+pkg_name+'_'+comp_variable_name+'_SYSTEM_LIBS'+config_suffix+'}' }}>
+                             $<$<CONFIG:{{configuration}}>:{{ '${'+pkg_name+'_'+comp_variable_name+'_DEPENDENCIES'+config_suffix+'}' }}>
+                             APPEND)
 
-        # For the modules (FindXXX)
-        list(APPEND {{ pkg_name }}_LIBRARIES{{ config_suffix }} {{comp_target_name}})
+                ####### Find the libraries declared in cpp_info.component["xxx"].libs,
+                ####### create an IMPORTED target for each one and link the '{{pkg_name}}_{{comp_variable_name}}_DEPS_TARGET' to all of them
+                conan_package_library_targets("{{ '${'+pkg_name+'_'+comp_variable_name+'_LIBS'+config_suffix+'}' }}"
+                                              "{{ '${'+pkg_name+'_'+comp_variable_name+'_LIB_DIRS'+config_suffix+'}' }}"
+                                              {{ pkg_name + '_' + comp_variable_name + '_DEPS_TARGET'}}
+                                              {{ pkg_name }}_{{ comp_variable_name }}_LIBRARIES_TARGETS
+                                              "{{ config }}" # DEBUG, RELEASE...
+                                              "{{ pkg_name }}_{{ comp_variable_name }}")
 
-        {%- if set_interface_link_directories %}
-        # This is only used for '#pragma comment(lib, "foo")' (automatic link)
-        set_property(TARGET {{ comp_target_name }} PROPERTY INTERFACE_LINK_DIRECTORIES
-                     $<$<CONFIG:{{ configuration }}>:{{tvalue(pkg_name, comp_variable_name, 'LIB_DIRS', config_suffix)}}> APPEND)
+                ########## TARGET PROPERTIES #####################################
+                set_property(TARGET {{comp_target_name}}
+                             PROPERTY INTERFACE_LINK_LIBRARIES
+                             ${{'{'}}{{pkg_name}}_{{comp_variable_name}}_LIBRARIES_TARGETS}
+                             $<$<CONFIG:{{configuration}}>:{{ '${'+pkg_name+'_'+comp_variable_name+'_OBJECTS'+config_suffix+'}' }}>
+                             APPEND)
+
+                if("{{ '${' }}{{ pkg_name }}_{{comp_variable_name}}_LIBS{{ config_suffix }}}" STREQUAL "")
+                    # If the component is not declaring any "cpp_info.components['foo'].libs" the system, frameworks etc are not
+                    # linked to the imported targets and we need to do it to the global target
+                    set_property(TARGET {{comp_target_name}}
+                                 PROPERTY INTERFACE_LINK_LIBRARIES
+                                 {{pkg_name}}_{{comp_variable_name}}_DEPS_TARGET
+                                 APPEND)
+                endif()
+
+                set_property(TARGET {{ comp_target_name }} PROPERTY INTERFACE_LINK_OPTIONS
+                             $<$<CONFIG:{{ configuration }}>:{{tvalue(pkg_name, comp_variable_name, 'LINKER_FLAGS', config_suffix)}}> APPEND)
+                set_property(TARGET {{ comp_target_name }} PROPERTY INTERFACE_INCLUDE_DIRECTORIES
+                             $<$<CONFIG:{{ configuration }}>:{{tvalue(pkg_name, comp_variable_name, 'INCLUDE_DIRS', config_suffix)}}> APPEND)
+                set_property(TARGET {{ comp_target_name }} PROPERTY INTERFACE_COMPILE_DEFINITIONS
+                             $<$<CONFIG:{{ configuration }}>:{{tvalue(pkg_name, comp_variable_name, 'COMPILE_DEFINITIONS', config_suffix)}}> APPEND)
+                set_property(TARGET {{ comp_target_name }} PROPERTY INTERFACE_COMPILE_OPTIONS
+                             $<$<CONFIG:{{ configuration }}>:
+                             {{tvalue(pkg_name, comp_variable_name, 'COMPILE_OPTIONS_C', config_suffix)}}
+                             {{tvalue(pkg_name, comp_variable_name, 'COMPILE_OPTIONS_CXX', config_suffix)}}> APPEND)
+                set({{ pkg_name }}_{{ comp_variable_name }}_TARGET_PROPERTIES TRUE)
+
+                {%- if set_interface_link_directories %}
+                # This is only used for '#pragma comment(lib, "foo")' (automatic link)
+                set_property(TARGET {{ comp_target_name }} PROPERTY INTERFACE_LINK_DIRECTORIES
+                             $<$<CONFIG:{{ configuration }}>:{{tvalue(pkg_name, comp_variable_name, 'LIB_DIRS', config_suffix)}}> APPEND)
+
+                {%- endif %}
+            {%endfor %}
+
+
+            ########## AGGREGATED GLOBAL TARGET WITH THE COMPONENTS #####################
+            {%- for comp_variable_name, comp_target_name in components_names %}
+
+            set_property(TARGET {{root_target_name}} PROPERTY INTERFACE_LINK_LIBRARIES {{ comp_target_name }} APPEND)
+
+            {%- endfor %}
+
 
         {%- endif %}
-        {%- endfor %}
 
 
-        ########## AGGREGATED GLOBAL TARGET WITH THE COMPONENTS #####################
-        {%- for comp_variable_name, comp_target_name in components_names %}
-
-        set_property(TARGET {{root_target_name}} PROPERTY INTERFACE_LINK_LIBRARIES {{ comp_target_name }} APPEND)
-
-        {%- endfor %}
-
-        {%- endif %}
+        ########## For the modules (FindXXX)
+        set({{ pkg_name }}_LIBRARIES{{ config_suffix }} {{root_target_name}})
 
         """)
 

--- a/conan/tools/cmake/cmakedeps/templates/target_data.py
+++ b/conan/tools/cmake/cmakedeps/templates/target_data.py
@@ -108,7 +108,9 @@ class ConfigDataTemplate(CMakeDepsFileTemplate):
 
               set({{ pkg_name }}_COMPONENTS{{ config_suffix }} {{ components_names }})
               {%- for comp_variable_name, comp_target_name, cpp in components_cpp %}
-              ########### COMPONENT {{ comp_target_name }} VARIABLES #############################################
+
+              ########### COMPONENT {{ comp_target_name }} VARIABLES ############################################
+
               set({{ pkg_name }}_{{ comp_variable_name }}_INCLUDE_DIRS{{ config_suffix }} {{ cpp.include_paths }})
               set({{ pkg_name }}_{{ comp_variable_name }}_LIB_DIRS{{ config_suffix }} {{ cpp.lib_paths }})
               set({{ pkg_name }}_{{ comp_variable_name }}_RES_DIRS{{ config_suffix }} {{ cpp.res_paths }})

--- a/conans/test/functional/toolchains/cmake/cmakedeps/test_cmakedeps.py
+++ b/conans/test/functional/toolchains/cmake/cmakedeps/test_cmakedeps.py
@@ -161,7 +161,7 @@ def test_system_libs():
             assert "System libs debug: %s" % library_name in client.out
             assert "Libraries to Link debug: lib1" in client.out
 
-        assert f"Target libs: CONAN_LIB::Test_lib1;$<$<CONFIG:{build_type}>:>" in client.out
+        assert f"Target libs: $<$<CONFIG:{build_type}>:>;CONAN_LIB::Test_lib1" in client.out
         assert "Micro-target libs: Test_DEPS_TARGET" in client.out
         micro_target_deps = f"Micro-target deps: $<$<CONFIG:{build_type}>:>;$<$<CONFIG:{build_type}>:{library_name}>;" \
                             f"$<$<CONFIG:{build_type}>:>"

--- a/conans/test/functional/toolchains/cmake/cmakedeps/test_cmakedeps.py
+++ b/conans/test/functional/toolchains/cmake/cmakedeps/test_cmakedeps.py
@@ -141,6 +141,10 @@ def test_system_libs():
         message("Libraries to Link debug: ${Test_LIBS_DEBUG}")
         get_target_property(tmp Test::Test INTERFACE_LINK_LIBRARIES)
         message("Target libs: ${tmp}")
+        get_target_property(tmp CONAN_LIB::Test_lib1 INTERFACE_LINK_LIBRARIES)
+        message("Micro-target libs: ${tmp}")
+        get_target_property(tmp Test_DEPS_TARGET INTERFACE_LINK_LIBRARIES)
+        message("Micro-target deps: ${tmp}")
         """)
 
     for build_type in ["Release", "Debug"]:
@@ -157,10 +161,136 @@ def test_system_libs():
             assert "System libs debug: %s" % library_name in client.out
             assert "Libraries to Link debug: lib1" in client.out
 
-        # FIXME: This assert is ugly, empty configs comes from empty _OBJECTS, FRAMEWORKS etc
-        target_libs = f"$<$<CONFIG:{build_type}>:>;CONAN_LIB::Test_lib1;$<$<CONFIG:{build_type}>" \
-                      f":>;$<$<CONFIG:{build_type}>:>;$<$<CONFIG:{build_type}>:{library_name}>"
-        assert target_libs in client.out
+        assert f"Target libs: CONAN_LIB::Test_lib1;$<$<CONFIG:{build_type}>:>" in client.out
+        assert "Micro-target libs: Test_DEPS_TARGET" in client.out
+        micro_target_deps = f"Micro-target deps: $<$<CONFIG:{build_type}>:>;$<$<CONFIG:{build_type}>:{library_name}>;" \
+                            f"$<$<CONFIG:{build_type}>:>"
+        assert micro_target_deps in client.out
+
+
+@pytest.mark.tool_cmake
+def test_system_libs_no_libs():
+    """If the recipe doesn't declare cpp_info.libs then the target with the system deps, frameworks
+       and transitive deps has to be linked to the global target"""
+    conanfile = textwrap.dedent("""
+        from conans import ConanFile
+        from conans.tools import save
+        import os
+
+        class Test(ConanFile):
+            name = "Test"
+            version = "0.1"
+            settings = "build_type"
+
+            def package_info(self):
+                if self.settings.build_type == "Debug":
+                    self.cpp_info.system_libs.append("sys1d")
+                else:
+                    self.cpp_info.system_libs.append("sys1")
+        """)
+    client = TestClient()
+    client.save({"conanfile.py": conanfile})
+    client.run("create . -s build_type=Release")
+    client.run("create . -s build_type=Debug")
+
+    conanfile = textwrap.dedent("""
+        [requires]
+        Test/0.1
+
+        [generators]
+        CMakeDeps
+        """)
+    cmakelists = textwrap.dedent("""
+        cmake_minimum_required(VERSION 3.15)
+        project(consumer NONE)
+        set(CMAKE_PREFIX_PATH ${CMAKE_BINARY_DIR})
+        set(CMAKE_MODULE_PATH ${CMAKE_BINARY_DIR})
+        find_package(Test)
+        message("System libs Release: ${Test_SYSTEM_LIBS_RELEASE}")
+        message("Libraries to Link release: ${Test_LIBS_RELEASE}")
+        message("System libs Debug: ${Test_SYSTEM_LIBS_DEBUG}")
+        message("Libraries to Link debug: ${Test_LIBS_DEBUG}")
+        get_target_property(tmp Test::Test INTERFACE_LINK_LIBRARIES)
+        message("Target libs: ${tmp}")
+        get_target_property(tmp Test_DEPS_TARGET INTERFACE_LINK_LIBRARIES)
+        message("DEPS TARGET: ${tmp}")
+
+        """)
+
+    for build_type in ["Release", "Debug"]:
+        client.save({"conanfile.txt": conanfile, "CMakeLists.txt": cmakelists}, clean_first=True)
+        client.run("install conanfile.txt -s build_type=%s" % build_type)
+        client.run_command('cmake . -DCMAKE_BUILD_TYPE={0}'.format(build_type))
+
+        library_name = "sys1d" if build_type == "Debug" else "sys1"
+
+        assert f"System libs {build_type}: {library_name}" in client.out
+        assert f"Target libs: $<$<CONFIG:{build_type}>:>;Test_DEPS_TARGET" in client.out
+        assert f"DEPS TARGET: $<$<CONFIG:{build_type}>:>;" \
+               f"$<$<CONFIG:{build_type}>:{library_name}>" in client.out
+
+
+@pytest.mark.tool_cmake
+def test_system_libs_components_no_libs():
+    """If the recipe doesn't declare cpp_info.libs then the target with the system deps, frameworks
+       and transitive deps has to be linked to the component target"""
+    conanfile = textwrap.dedent("""
+        from conans import ConanFile
+        from conans.tools import save
+        import os
+
+        class Test(ConanFile):
+            name = "Test"
+            version = "0.1"
+            settings = "build_type"
+
+            def package_info(self):
+                if self.settings.build_type == "Debug":
+                    self.cpp_info.components["foo"].system_libs.append("sys1d")
+                else:
+                    self.cpp_info.components["foo"].system_libs.append("sys1")
+        """)
+    client = TestClient()
+    client.save({"conanfile.py": conanfile})
+    client.run("create . -s build_type=Release")
+    client.run("create . -s build_type=Debug")
+
+    conanfile = textwrap.dedent("""
+        [requires]
+        Test/0.1
+
+        [generators]
+        CMakeDeps
+        """)
+    cmakelists = textwrap.dedent("""
+        cmake_minimum_required(VERSION 3.15)
+        project(consumer NONE)
+        set(CMAKE_PREFIX_PATH ${CMAKE_BINARY_DIR})
+        set(CMAKE_MODULE_PATH ${CMAKE_BINARY_DIR})
+        find_package(Test)
+        message("System libs Release: ${Test_Test_foo_SYSTEM_LIBS_RELEASE}")
+        message("Libraries to Link release: ${Test_Test_foo_LIBS_RELEASE}")
+        message("System libs Debug: ${Test_Test_foo_SYSTEM_LIBS_DEBUG}")
+        message("Libraries to Link debug: ${Test_Test_foo_LIBS_DEBUG}")
+
+        get_target_property(tmp Test::foo INTERFACE_LINK_LIBRARIES)
+        message("Target libs: ${tmp}")
+        get_target_property(tmp Test_Test_foo_DEPS_TARGET INTERFACE_LINK_LIBRARIES)
+        message("DEPS TARGET: ${tmp}")
+
+        """)
+
+    for build_type in ["Release", "Debug"]:
+        client.save({"conanfile.txt": conanfile, "CMakeLists.txt": cmakelists}, clean_first=True)
+        client.run("install conanfile.txt -s build_type=%s" % build_type)
+        client.run_command('cmake . -DCMAKE_BUILD_TYPE={0}'.format(build_type))
+
+        library_name = "sys1d" if build_type == "Debug" else "sys1"
+
+        assert f"System libs {build_type}: {library_name}" in client.out
+        assert f"Target libs: $<$<CONFIG:{build_type}>:>;Test_Test_foo_DEPS_TARGET" in client.out
+        assert f"DEPS TARGET: $<$<CONFIG:{build_type}>:>;" \
+               f"$<$<CONFIG:{build_type}>:{library_name}>" in client.out
 
 
 @pytest.mark.tool_cmake

--- a/conans/test/functional/toolchains/cmake/cmakedeps/test_cmakedeps_components.py
+++ b/conans/test/functional/toolchains/cmake/cmakedeps/test_cmakedeps_components.py
@@ -375,6 +375,21 @@ def test_cmake_add_subdirectory():
             find_package(Boost REQUIRED COMPONENTS exception headers)
 
             message("AGGREGATED LIBS: ${Boost_LIBRARIES}")
+            get_target_property(tmp boost::boost INTERFACE_LINK_LIBRARIES)
+            message("AGGREGATED LINKED: ${tmp}")
+
+            get_target_property(tmp boost::B INTERFACE_LINK_LIBRARIES)
+            message("BOOST_B LINKED: ${tmp}")
+
+            get_target_property(tmp boost::A INTERFACE_LINK_LIBRARIES)
+            message("BOOST_A LINKED: ${tmp}")
+
+            get_target_property(tmp boost_boost_B_DEPS_TARGET INTERFACE_LINK_LIBRARIES)
+            message("BOOST_B_DEPS LINKED: ${tmp}")
+
+            get_target_property(tmp boost_boost_A_DEPS_TARGET INTERFACE_LINK_LIBRARIES)
+            message("BOOST_A_DEPS LINKED: ${tmp}")
+
     """)
 
     t.save({"conanfile.py": conanfile,
@@ -382,4 +397,10 @@ def test_cmake_add_subdirectory():
     t.run("install .")
     # only doing the configure failed before #11743 fix
     t.run("build .")
-    assert "AGGREGATED LIBS: boost::B;boost::A" in t.out
+    # The boost::boost target has linked the two components
+    assert "AGGREGATED LIBS: boost::boost" in t.out
+    assert "AGGREGATED LINKED: boost::B;boost::A" in t.out
+    assert "BOOST_B LINKED: $<$<CONFIG:Release>:>;boost_boost_B_DEPS_TARGET" in t.out
+    assert "BOOST_A LINKED: $<$<CONFIG:Release>:>;boost_boost_A_DEPS_TARGET" in t.out
+    assert "BOOST_B_DEPS LINKED: $<$<CONFIG:Release>:>;$<$<CONFIG:Release>:B_1;B_2>" in t.out
+    assert "BOOST_A_DEPS LINKED: $<$<CONFIG:Release>:>;$<$<CONFIG:Release>:A_1;A_2>;" in t.out

--- a/conans/test/functional/toolchains/cmake/cmakedeps/test_cmakedeps_components.py
+++ b/conans/test/functional/toolchains/cmake/cmakedeps/test_cmakedeps_components.py
@@ -198,15 +198,16 @@ def test_components_system_libs():
         find_package(requirement)
         get_target_property(tmp_libs requirement::component INTERFACE_LINK_LIBRARIES)
         get_target_property(tmp_options requirement::component INTERFACE_LINK_OPTIONS)
+        get_target_property(tmp_deps requirement_requirement_component_DEPS_TARGET INTERFACE_LINK_LIBRARIES)
         message("component libs: ${tmp_libs}")
         message("component options: ${tmp_options}")
+        message("component deps: ${tmp_deps}")
     """)
 
     t.save({"conanfile.py": conanfile, "CMakeLists.txt": cmakelists})
     t.run("create . --build missing -s build_type=Release")
-    # FIXME: This assert is ugly, empty configs comes from empty _OBJECTS, FRAMEWORKS etc
-    assert 'component libs: $<$<CONFIG:Release>:>;$<$<CONFIG:Release>:>;$<$<CONFIG:Release>:>' \
-           ';$<$<CONFIG:Release>:system_lib_component>' in t.out
+    assert 'component libs: $<$<CONFIG:Release>:>;requirement_requirement_component_DEPS_TARGET' in t.out
+    assert 'component deps: $<$<CONFIG:Release>:>;$<$<CONFIG:Release>:system_lib_component>;' in t.out
     assert ('component options: '
             '$<$<CONFIG:Release>:'
             '$<$<STREQUAL:$<TARGET_PROPERTY:TYPE>,SHARED_LIBRARY>:>;'

--- a/conans/test/functional/toolchains/cmake/cmakedeps/test_cmakedeps_find_module_and_config.py
+++ b/conans/test/functional/toolchains/cmake/cmakedeps/test_cmakedeps_find_module_and_config.py
@@ -171,6 +171,9 @@ def test_transitive_modules_found(find_mode_PKGA, find_mode_PKGB, find_mode_cons
         get_target_property(linked_libs pkgb::pkgb INTERFACE_LINK_LIBRARIES)
         message("MYPKGB_LINKED_LIBRARIES: '${{linked_libs}}'")
 
+        get_target_property(linked_deps pkgb_DEPS_TARGET INTERFACE_LINK_LIBRARIES)
+        message("MYPKGB_DEPS_LIBRARIES: '${{linked_deps}}'")
+
         message("MYPKGB_DEFINITIONS: ${{MYPKGB_DEFINITIONS}}")
         """)
 
@@ -190,10 +193,13 @@ def test_transitive_modules_found(find_mode_PKGA, find_mode_PKGB, find_mode_cons
     # The MYPKG_LIBRARIES contains the target for the current package, but the target is linked
     # with the dependencies also:
     assert "MYPKGB_LIBRARIES: pkgb::pkgb" in client.out
-    assert "MYPKGB_LINKED_LIBRARIES: '$<$<CONFIG:Release>:>;$<$<CONFIG:Release>:pkga::pkga>" in client.out
+    assert "MYPKGB_LINKED_LIBRARIES: '$<$<CONFIG:Release>:>;pkgb_DEPS_TARGET'" in client.out
+    assert "MYPKGB_DEPS_LIBRARIES: '$<$<CONFIG:Release>:>;$<$<CONFIG:Release>:>;" \
+           "$<$<CONFIG:Release>:pkga::pkga>'" in client.out
 
     assert "MYPKGB_DEFINITIONS: -DDEFINE_MYPKGB" in client.out
     assert "Conan: Target declared 'pkga::pkga'"
 
     if find_mode_PKGA == "module":
         assert 'Found unicorns: 1.0 (found version "1.0")' in client.out
+

--- a/conans/test/integration/toolchains/cmake/cmakedeps/test_cmakedeps.py
+++ b/conans/test/integration/toolchains/cmake/cmakedeps/test_cmakedeps.py
@@ -105,17 +105,15 @@ def test_cpp_info_component_objects():
     with open(os.path.join(client.current_folder, "hello-Target-release.cmake")) as f:
         content = f.read()
         assert """set_property(TARGET hello::say
-             PROPERTY INTERFACE_LINK_LIBRARIES
-             $<$<CONFIG:Release>:${hello_hello_say_OBJECTS_RELEASE}>
-             ${hello_hello_say_LIBRARIES_TARGETS}""" in content
+                     PROPERTY INTERFACE_LINK_LIBRARIES
+                     $<$<CONFIG:Release>:${hello_hello_say_OBJECTS_RELEASE}>
+                     ${hello_hello_say_LIBRARIES_TARGETS}
+                     APPEND)""" in content
         # If there are componets, there is not a global cpp so this is not generated
-        assert """set_property(TARGET hello::hello
-             PROPERTY INTERFACE_LINK_LIBRARIES
-             $<$<CONFIG:Release>:${hello_OBJECTS_RELEASE}>
-             ${hello_LIBRARIES_TARGETS}""" not in content
+        assert "hello_OBJECTS_RELEASE" not in content
         # But the global target is linked with the targets from the components
-        assert "set_property(TARGET hello::hello PROPERTY " \
-               "INTERFACE_LINK_LIBRARIES hello::say APPEND)" in content
+        assert "set_property(TARGET hello::hello PROPERTY INTERFACE_LINK_LIBRARIES " \
+               "hello::say APPEND)" in content
 
     with open(os.path.join(client.current_folder, "hello-release-x86_64-data.cmake")) as f:
         content = f.read()


### PR DESCRIPTION
Changelog: Bugfix: Refactored CMakeDep using always targets instead of lists.
Docs:  omit

The bug appeared when components require system libraries, and those were not linked to the `IMPORTED` but to the component target. CMake was not able to order the system libraries correctly causing linker errors. So it has been fixed using always targets instead of lists, the dependencies of a package/component (such as the system libraries, apple frameworks, and transitive dependencies) are linked to an `INTERFACE` target that later is linked to the `IMPORTED` targets when `cpp_info.libs` are declared, otherwise to the global or component target. 

Close https://github.com/conan-io/conan/issues/11773