### PR TITLE
[bugfix] Bad legacy cpp_info if layout is used

### DIFF
--- a/conans/client/installer.py
+++ b/conans/client/installer.py
@@ -680,6 +680,12 @@ class BinaryInstaller(object):
                         # Old cpp info without defaults (the defaults are in the new one)
                         conanfile.cpp_info = CppInfo(conanfile.name, package_folder,
                                                      default_values=CppInfoDefaultValues())
+                        # Note: Remember that this is not needed for Conan 2.x
+                        # Let's avoid losing this information already processed before.
+                        conanfile.cpp_info.version = conanfile.version
+                        conanfile.cpp_info.description = conanfile.description
+                        conanfile.cpp_info.public_deps = public_deps
+
                         if not is_editable:
                             # Copy the infos.package into the old cppinfo
                             fill_old_cppinfo(conanfile.cpp.package, conanfile.cpp_info)

--- a/conans/client/installer.py
+++ b/conans/client/installer.py
@@ -681,7 +681,7 @@ class BinaryInstaller(object):
                         conanfile.cpp_info = CppInfo(conanfile.name, package_folder,
                                                      default_values=CppInfoDefaultValues())
                         # Note: Remember that this is not needed for Conan 2.x
-                        # Let's avoid losing this information already processed before.
+                        # Let's avoid losing this information.
                         conanfile.cpp_info.version = conanfile.version
                         conanfile.cpp_info.description = conanfile.description
                         conanfile.cpp_info.public_deps = public_deps

--- a/conans/test/integration/generators/json_test.py
+++ b/conans/test/integration/generators/json_test.py
@@ -13,7 +13,7 @@ class JsonTest(unittest.TestCase):
 
 class HelloConan(ConanFile):
     exports_sources = "*.h"
-    description = "foo"
+    description = "my desc"
     def layout(self):
         pass
     def package(self):
@@ -30,7 +30,7 @@ class HelloConan(ConanFile):
         conan_json = client.load("conanbuildinfo.json")
         data = json.loads(conan_json)
         self.assertEqual(data["dependencies"][0]["version"], "0.1")
-        self.assertIsNone(data["dependencies"][0]["description"])
+        self.assertEqual(data["dependencies"][0]["description"], "my desc")
         self.assertEqual(data["deps_env_info"]["MY_ENV_VAR"], "foo")
         self.assertEqual(data["deps_user_info"]["Hello"]["my_var"], "my_value")
 

--- a/conans/test/integration/layout/test_legacy_cpp_info_and_layout.py
+++ b/conans/test/integration/layout/test_legacy_cpp_info_and_layout.py
@@ -1,0 +1,36 @@
+import textwrap
+
+import pytest
+
+from conans.test.utils.tools import TestClient
+
+
+# TODO: This test does not make sense for Conan v2. Please, remove/skip it in that case.
+@pytest.mark.parametrize("declare_layout", [True, False])
+def test_legacy_deps_cpp_info_deps_version_using_or_not_layout(declare_layout):
+    conanfile = textwrap.dedent("""
+    from conan import ConanFile
+
+    class HelloConan(ConanFile):
+        name = "hello"
+        version = "1.0"
+        {}
+        def package_info(self):
+            self.cpp_info.libs = ["hello"]
+    """.format("def layout(self):pass" if declare_layout else ""))
+    test_conanfile = textwrap.dedent("""
+    from conan import ConanFile
+
+    class HelloTestConan(ConanFile):
+        settings = "os", "compiler", "build_type", "arch"
+
+        def build(self):
+            self.output.info(self.deps_cpp_info["hello"].version)
+
+        def test(self):
+            pass
+    """)
+    client = TestClient()
+    client.save({"conanfile.py": conanfile, "test_package/conanfile.py": test_conanfile})
+    client.run("create .")
+    assert "hello/1.0 (test package): 1.0" in client.out


### PR DESCRIPTION
Changelog: Bugfix: Legacy `cpp_info` for consumers was losing information in case of depending on a package with a layout.
Docs: omit

Closes: 
- https://github.com/conan-io/conan/issues/11784
- https://github.com/conan-io/conan/issues/11789
