### PR TITLE
Use "android-xx" format for ANDROID_PLATFORM

### DIFF
--- a/conan/tools/cmake/toolchain/blocks.py
+++ b/conan/tools/cmake/toolchain/blocks.py
@@ -313,7 +313,7 @@ class AndroidSystemBlock(Block):
         android_ndk_path = android_ndk_path.replace("\\", "/")
 
         ctxt_toolchain = {
-            'android_platform': self._conanfile.settings.os.api_level,
+            'android_platform': 'android-' + str(self._conanfile.settings.os.api_level),
             'android_abi': android_abi,
             'android_stl': libcxx_str,
             'android_ndk_path': android_ndk_path,

--- a/conans/test/integration/toolchains/cmake/test_cmaketoolchain.py
+++ b/conans/test/integration/toolchains/cmake/test_cmaketoolchain.py
@@ -9,7 +9,7 @@ from mock import mock
 from conan.tools.cmake.presets import load_cmake_presets
 from conans.test.assets.genconanfile import GenConanfile
 from conans.test.utils.tools import TestClient
-from conans.util.files import rmdir, load
+from conans.util.files import rmdir
 
 
 def test_cross_build():
@@ -496,7 +496,7 @@ def test_android_c_library():
     # Checking the Android variables created
     # Issue: https://github.com/conan-io/conan/issues/11798
     client.run("install . " + settings)
-    conan_toolchain = load(os.path.join(client.current_folder, "conan_toolchain.cmake"))
+    conan_toolchain = client.load(os.path.join(client.current_folder, "conan_toolchain.cmake"))
     assert "set(ANDROID_PLATFORM android-23)" in conan_toolchain
     assert "set(ANDROID_ABI x86_64)" in conan_toolchain
     assert "include(/foo/build/cmake/android.toolchain.cmake)" in conan_toolchain

--- a/conans/test/integration/toolchains/cmake/test_cmaketoolchain.py
+++ b/conans/test/integration/toolchains/cmake/test_cmaketoolchain.py
@@ -7,10 +7,9 @@ import pytest
 from mock import mock
 
 from conan.tools.cmake.presets import load_cmake_presets
-from conan.tools.files import load
 from conans.test.assets.genconanfile import GenConanfile
 from conans.test.utils.tools import TestClient
-from conans.util.files import rmdir
+from conans.util.files import rmdir, load
 
 
 def test_cross_build():
@@ -497,7 +496,7 @@ def test_android_c_library():
     # Checking the Android variables created
     # Issue: https://github.com/conan-io/conan/issues/11798
     client.run("install . " + settings)
-    conan_toolchain = load(None, os.path.join(client.current_folder, "conan_toolchain.cmake"))
+    conan_toolchain = load(os.path.join(client.current_folder, "conan_toolchain.cmake"))
     assert "set(ANDROID_PLATFORM android-23)" in conan_toolchain
     assert "set(ANDROID_ABI x86_64)" in conan_toolchain
     assert "include(/foo/build/cmake/android.toolchain.cmake)" in conan_toolchain


### PR DESCRIPTION
Changelog: Bugfix: Use "android-<level>" format for the ANDROID_PLATFORM argument to be compatible with old NDK versions.
Docs: omit

Closes: https://github.com/conan-io/conan/issues/11798

- [x] Refer to the issue that supports this Pull Request.
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 

<sup>**Note:** By default this PR will skip the slower tests and will use a limited set of python versions. Check [here](https://github.com/conan-io/conan/blob/develop/.github/PR_INCREASE_TESTING.md) how to increase the testing level by writing some tags in the current PR body text.</sup>

Fixes #11798 
