### PR TITLE
Enable get_safe on self.info.settings and self.info.options

### DIFF
--- a/conans/client/build/cppstd_flags.py
+++ b/conans/client/build/cppstd_flags.py
@@ -50,14 +50,10 @@ def cppstd_flag_new(settings):
 
 
 def cppstd_default(settings):
-    if getattr(settings, "get_safe", None):
-        compiler = settings.get_safe("compiler")
-        compiler_version = settings.get_safe("compiler.version")
-        compiler_base = settings.get_safe("compiler.base")
-    else:
-        compiler = str(settings.compiler)
-        compiler_version = str(settings.compiler.version)
-        compiler_base = str(settings.compiler.base)
+
+    compiler = settings.get_safe("compiler")
+    compiler_version = settings.get_safe("compiler.version")
+    compiler_base = settings.get_safe("compiler.base")
     intel_cppstd_default = _intel_visual_cppstd_default if compiler_base == "Visual Studio" \
         else _intel_gcc_cppstd_default
     default = {"gcc": _gcc_cppstd_default(compiler_version),

--- a/conans/model/options.py
+++ b/conans/model/options.py
@@ -226,6 +226,11 @@ class OptionsValues(object):
     def __contains__(self, item):
         return item in self._package_values
 
+    def get_safe(self, attr):
+        if attr not in self._package_values:
+            return None
+        return getattr(self._package_values, attr)
+
     def __getitem__(self, item):
         return self._reqs_options.setdefault(item, PackageOptionValues())
 

--- a/conans/model/values.py
+++ b/conans/model/values.py
@@ -9,7 +9,8 @@ class Values(object):
         self._modified = {}  # {"compiler.version.arch": (old_value, old_reference)}
 
     def get_safe(self, attr):
-        return getattr(self, attr)
+        values = [v[1] for v in self.as_list() if v[0] == attr]
+        return values[0] if values else None
 
     def __getattr__(self, attr):
         if attr not in self._dict:

--- a/conans/model/values.py
+++ b/conans/model/values.py
@@ -8,6 +8,9 @@ class Values(object):
         self._dict = {}  # {key: Values()}
         self._modified = {}  # {"compiler.version.arch": (old_value, old_reference)}
 
+    def get_safe(self, attr):
+        return getattr(self, attr)
+
     def __getattr__(self, attr):
         if attr not in self._dict:
             return None

--- a/conans/test/integration/package_id/test_validate.py
+++ b/conans/test/integration/package_id/test_validate.py
@@ -1,4 +1,5 @@
 import json
+import re
 import textwrap
 import unittest
 
@@ -38,6 +39,59 @@ class TestValidate(unittest.TestCase):
         myjson = json.loads(client.load("myjson"))
         self.assertEqual(myjson[0]["binary"], BINARY_INVALID)
         self.assertEqual(myjson[0]["id"], 'INVALID')
+
+    def test_validate_header_only(self):
+        client = TestClient()
+        conanfile = textwrap.dedent("""
+            from conan import ConanFile
+            from conan.errors import ConanInvalidConfiguration
+            from conan.tools.build import check_min_cppstd
+            class Pkg(ConanFile):
+                settings = "os", "compiler"
+                options = {"shared": [True, False], "header_only": [True, False],}
+                default_options = {"shared": False, "header_only": True}
+
+                def package_id(self):
+                   if self.info.options.header_only:
+                       self.info.clear()
+
+                def validate(self):
+                    if self.info.options.get_safe("header_only") == "False":
+                        if self.info.settings.get_safe("os") == "Linux":
+                          raise ConanInvalidConfiguration("This package cannot exist in Linux")
+                        check_min_cppstd(self, 11)
+                        # These configurations are impossible
+                        if self.info.settings.os != "Windows" and self.info.options.shared:
+                            raise ConanInvalidConfiguration("shared is only supported under windows")
+
+                    # HOW CAN WE VALIDATE CPPSTD > 11 WHEN HEADER ONLY?
+
+            """)
+
+        client.save({"conanfile.py": conanfile})
+
+        client.run("create . pkg/0.1@ -s os=Linux -s compiler=gcc "
+                   "-s compiler.version=12 -s compiler.libcxx=libstdc++11")
+        assert re.search(r"Package '(.*)' created", str(client.out))
+
+        client.run("create . pkg/0.1@ -o header_only=False -s os=Linux -s compiler=gcc "
+                   "-s compiler.version=12 -s compiler.libcxx=libstdc++11", assert_error=True)
+
+        assert "Invalid ID: This package cannot exist in Linux" in client.out
+
+        client.run("create . pkg/0.1@ -o header_only=False -s os=Macos -s compiler=gcc "
+                   "-s compiler.version=12 -s compiler.libcxx=libstdc++11 -s compiler.cppstd=98",
+                   assert_error=True)
+
+        assert "Invalid ID: Current cppstd (98) is lower than the required C++ " \
+               "standard (11)" in client.out
+
+        client.run("create . pkg/0.1@ -o header_only=False -o shared=True "
+                   "-s os=Macos -s compiler=gcc "
+                   "-s compiler.version=12 -s compiler.libcxx=libstdc++11 -s compiler.cppstd=11",
+                   assert_error=True)
+
+        assert "Invalid ID: shared is only supported under windows" in client.out
 
     def test_validate_compatible(self):
         client = TestClient()

--- a/conans/test/integration/package_id/test_validate.py
+++ b/conans/test/integration/package_id/test_validate.py
@@ -57,8 +57,8 @@ class TestValidate(unittest.TestCase):
 
                 def validate(self):
                     if self.info.options.get_safe("header_only") == "False":
-                        if self.info.settings.get_safe("os") == "Linux":
-                          raise ConanInvalidConfiguration("This package cannot exist in Linux")
+                        if self.info.settings.get_safe("compiler.version") == "12":
+                          raise ConanInvalidConfiguration("This package cannot exist in gcc 12")
                         check_min_cppstd(self, 11)
                         # These configurations are impossible
                         if self.info.settings.os != "Windows" and self.info.options.shared:
@@ -71,16 +71,16 @@ class TestValidate(unittest.TestCase):
         client.save({"conanfile.py": conanfile})
 
         client.run("create . pkg/0.1@ -s os=Linux -s compiler=gcc "
-                   "-s compiler.version=12 -s compiler.libcxx=libstdc++11")
+                   "-s compiler.version=11 -s compiler.libcxx=libstdc++11")
         assert re.search(r"Package '(.*)' created", str(client.out))
 
         client.run("create . pkg/0.1@ -o header_only=False -s os=Linux -s compiler=gcc "
                    "-s compiler.version=12 -s compiler.libcxx=libstdc++11", assert_error=True)
 
-        assert "Invalid ID: This package cannot exist in Linux" in client.out
+        assert "Invalid ID: This package cannot exist in gcc 12" in client.out
 
         client.run("create . pkg/0.1@ -o header_only=False -s os=Macos -s compiler=gcc "
-                   "-s compiler.version=12 -s compiler.libcxx=libstdc++11 -s compiler.cppstd=98",
+                   "-s compiler.version=11 -s compiler.libcxx=libstdc++11 -s compiler.cppstd=98",
                    assert_error=True)
 
         assert "Invalid ID: Current cppstd (98) is lower than the required C++ " \
@@ -88,7 +88,7 @@ class TestValidate(unittest.TestCase):
 
         client.run("create . pkg/0.1@ -o header_only=False -o shared=True "
                    "-s os=Macos -s compiler=gcc "
-                   "-s compiler.version=12 -s compiler.libcxx=libstdc++11 -s compiler.cppstd=11",
+                   "-s compiler.version=11 -s compiler.libcxx=libstdc++11 -s compiler.cppstd=11",
                    assert_error=True)
 
         assert "Invalid ID: shared is only supported under windows" in client.out

--- a/conans/test/unittests/model/options_test.py
+++ b/conans/test/unittests/model/options_test.py
@@ -1,6 +1,7 @@
 import sys
 import unittest
 
+import pytest
 import six
 
 from conans.errors import ConanException
@@ -279,6 +280,14 @@ class OptionsValuesTest(unittest.TestCase):
         Boost:thread=True
         Boost:thread.multi=off
         """)
+
+    def test_get_safe(self):
+        option_values = OptionsValues(self.sut.as_list())
+        assert option_values.get_safe("missing") is None
+        assert option_values.get_safe("optimized") == 3
+        with pytest.raises(ConanException):
+            # This is not supported at the moment
+            option_values["Boost"].get_safe("thread")
 
     def test_from_list(self):
         option_values = OptionsValues(self.sut.as_list())

--- a/conans/test/unittests/model/settings_test.py
+++ b/conans/test/unittests/model/settings_test.py
@@ -428,6 +428,15 @@ os: [Windows, Linux]
                                                 ("compiler.version", "10"),
                                                 ("os", "Windows")])
 
+    def test_get_safe(self):
+        self.sut.os = "Windows"
+        self.sut.compiler = "Visual Studio"
+        self.sut.compiler.version = 10
+
+        assert self.sut.get_safe("missing") is None
+        assert self.sut.get_safe("os") == "Windows"
+        assert self.sut.get_safe("compiler.version") == "10"
+
     def test_basic(self):
         s = Settings({"os": ["Windows", "Linux"]})
         s.os = "Windows"

--- a/conans/test/unittests/model/settings_test.py
+++ b/conans/test/unittests/model/settings_test.py
@@ -428,15 +428,6 @@ os: [Windows, Linux]
                                                 ("compiler.version", "10"),
                                                 ("os", "Windows")])
 
-    def test_get_safe(self):
-        self.sut.os = "Windows"
-        self.sut.compiler = "Visual Studio"
-        self.sut.compiler.version = 10
-
-        assert self.sut.get_safe("missing") is None
-        assert self.sut.get_safe("os") == "Windows"
-        assert self.sut.get_safe("compiler.version") == "10"
-
     def test_basic(self):
         s = Settings({"os": ["Windows", "Linux"]})
         s.os = "Windows"


### PR DESCRIPTION
Changelog: Feature: The `self.info.settings` and `self.info.options` now allow the `get_safe("foo")` as it is available in `self.settings` and `self.options`.
Docs: omit


Close #11802 