### PR TITLE
Add conan.tools.system as hidden-import to pyinstaller.py

### DIFF
--- a/pyinstaller.py
+++ b/pyinstaller.py
@@ -95,10 +95,11 @@ def pyinstall(source_folder):
               "--hidden-import=conan.tools.gnu --hidden-import=conan.tools.cmake "
               "--hidden-import=conan.tools.meson --hidden-import=conan.tools.apple "
               "--hidden-import=conan.tools.build --hidden-import=conan.tools.env "
-              "--hidden-import=conan.tools.files --hidden-import=conan.tools.gnu "
+              "--hidden-import=conan.tools.files "
               "--hidden-import=conan.tools.google --hidden-import=conan.tools.intel "
               "--hidden-import=conan.tools.layout --hidden-import=conan.tools.premake "
-              "--hidden-import=conan.tools.qbs --hidden-import=conan.tools.scm")
+              "--hidden-import=conan.tools.qbs --hidden-import=conan.tools.scm "
+              "--hidden-import=conan.tools.system")
     if platform.system() != "Windows":
         hidden += " --hidden-import=setuptools.msvc"
         win_ver = ""


### PR DESCRIPTION
Changelog: Fix: Add `conan.tools.system` as hidden-import to `pyinstaller.py`, so it is bundled with the installer.
Docs: omit

Closes: https://github.com/conan-io/conan/issues/11794

Note: extended a test in the ci job that creates the windows installer and debian package to test this works.
