### PR TITLE
Add conan.errors to hidden pyinstaller imports

### DIFF
--- a/pyinstaller.py
+++ b/pyinstaller.py
@@ -90,7 +90,8 @@ def pyinstall(source_folder):
     hidden = ("--hidden-import=glob "  # core stdlib
               "--hidden-import=pathlib "
               "--hidden-import=distutils.dir_util "
-              # The conan.tools integration
+              # Modules that can be imported in ConanFile conan.tools and errors
+              "--hidden-import=conan.errors "
               "--hidden-import=conan.tools.microsoft "
               "--hidden-import=conan.tools.gnu --hidden-import=conan.tools.cmake "
               "--hidden-import=conan.tools.meson --hidden-import=conan.tools.apple "
@@ -99,7 +100,7 @@ def pyinstall(source_folder):
               "--hidden-import=conan.tools.google --hidden-import=conan.tools.intel "
               "--hidden-import=conan.tools.layout --hidden-import=conan.tools.premake "
               "--hidden-import=conan.tools.qbs --hidden-import=conan.tools.scm "
-              "--hidden-import=conan.tools.system  --hidden-import=conan.tools.system.package_manager")
+              "--hidden-import=conan.tools.system --hidden-import=conan.tools.system.package_manager")
     if platform.system() != "Windows":
         hidden += " --hidden-import=setuptools.msvc"
         win_ver = ""


### PR DESCRIPTION
Changelog: Fix: Add `conan.errors` to hidden pyinstaller imports.
Docs: omit

Should make all recipes that import from new modules locations and use Conan from debian package or win installer finally work

Closes: https://github.com/conan-io/conan/issues/11813