### PR TITLE
Macro `conan_package_library_targets` reverted to single config

### DIFF
--- a/conan/tools/cmake/cmakedeps/templates/macros.py
+++ b/conan/tools/cmake/cmakedeps/templates/macros.py
@@ -80,6 +80,12 @@ class MacrosTemplate(CMakeDepsFileTemplate):
 
            # ONLY FOR DEBUGGING PURPOSES
            foreach(_CONAN_ACTUAL_TARGET ${_CONAN_ACTUAL_TARGETS})
+              get_target_property(imported_location ${_CONAN_ACTUAL_TARGET} IMPORTED_LOCATION_DEBUG)
+              message(VERBOSE "Target Properties: ${_CONAN_ACTUAL_TARGET} IMPORTED_LOCATION_DEBUG ='${imported_location}'")
+
+              get_target_property(imported_location ${_CONAN_ACTUAL_TARGET} IMPORTED_LOCATION_RELEASE)
+              message(VERBOSE "Target Properties: ${_CONAN_ACTUAL_TARGET} IMPORTED_LOCATION_RELEASE ='${imported_location}'")
+
               get_target_property(linked_libs ${_CONAN_ACTUAL_TARGET} INTERFACE_LINK_LIBRARIES)
               message(VERBOSE "Target Properties: ${_CONAN_ACTUAL_TARGET} INTERFACE_LINK_LIBRARIES ='${linked_libs}'")
            endforeach()

--- a/conan/tools/cmake/cmakedeps/templates/macros.py
+++ b/conan/tools/cmake/cmakedeps/templates/macros.py
@@ -48,7 +48,7 @@ class MacrosTemplate(CMakeDepsFileTemplate):
                find_library(CONAN_FOUND_LIBRARY NAMES ${_LIBRARY_NAME} PATHS ${package_libdir}
                             NO_DEFAULT_PATH NO_CMAKE_FIND_ROOT_PATH)
                if(CONAN_FOUND_LIBRARY)
-                   message("Conan: Library ${_LIBRARY_NAME} found ${CONAN_FOUND_LIBRARY}")
+                   message(VERBOSE "Conan: Library ${_LIBRARY_NAME} found ${CONAN_FOUND_LIBRARY}")
 
                    # Create a micro-target for each lib/a found
                    # Allow only some characters for the target name
@@ -70,7 +70,6 @@ class MacrosTemplate(CMakeDepsFileTemplate):
 
            # Add the dependencies target for all the imported libraries
            foreach(_T ${_out_libraries_target})
-                message("LINK A ${_T}")
                set_property(TARGET ${_T} PROPERTY INTERFACE_LINK_LIBRARIES ${deps_target} APPEND)
            endforeach()
 

--- a/conan/tools/cmake/cmakedeps/templates/macros.py
+++ b/conan/tools/cmake/cmakedeps/templates/macros.py
@@ -41,19 +41,19 @@ class MacrosTemplate(CMakeDepsFileTemplate):
            endif()
        endmacro()
 
-       function(conan_package_library_targets libraries package_libdir deps_target out_libraries_target package_name)
+       function(conan_package_library_targets libraries package_libdir deps_target out_libraries_target config_suffix package_name)
            set(_out_libraries_target "")
 
            foreach(_LIBRARY_NAME ${libraries})
                find_library(CONAN_FOUND_LIBRARY NAMES ${_LIBRARY_NAME} PATHS ${package_libdir}
                             NO_DEFAULT_PATH NO_CMAKE_FIND_ROOT_PATH)
                if(CONAN_FOUND_LIBRARY)
-                   message(VERBOSE "Conan: Library ${_LIBRARY_NAME} found ${CONAN_FOUND_LIBRARY}")
+                   message("Conan: Library ${_LIBRARY_NAME} found ${CONAN_FOUND_LIBRARY}")
 
                    # Create a micro-target for each lib/a found
                    # Allow only some characters for the target name
                    string(REGEX REPLACE "[^A-Za-z0-9.+_-]" "_" _LIBRARY_NAME ${_LIBRARY_NAME})
-                   set(_LIB_NAME CONAN_LIB::${package_name}_${_LIBRARY_NAME})
+                   set(_LIB_NAME CONAN_LIB::${package_name}_${_LIBRARY_NAME}${config_suffix})
                    if(NOT TARGET ${_LIB_NAME})
                        # Create a micro-target for each lib/a found
                        add_library(${_LIB_NAME} UNKNOWN IMPORTED)
@@ -70,6 +70,7 @@ class MacrosTemplate(CMakeDepsFileTemplate):
 
            # Add the dependencies target for all the imported libraries
            foreach(_T ${_out_libraries_target})
+                message("LINK A ${_T}")
                set_property(TARGET ${_T} PROPERTY INTERFACE_LINK_LIBRARIES ${deps_target} APPEND)
            endforeach()
 

--- a/conan/tools/cmake/cmakedeps/templates/macros.py
+++ b/conan/tools/cmake/cmakedeps/templates/macros.py
@@ -41,10 +41,8 @@ class MacrosTemplate(CMakeDepsFileTemplate):
            endif()
        endmacro()
 
-       function(conan_package_library_targets libraries package_libdir deps_target out_libraries_target config package_name)
-           set(_out_libraries "")
+       function(conan_package_library_targets libraries package_libdir deps_target out_libraries_target package_name)
            set(_out_libraries_target "")
-           set(_CONAN_ACTUAL_TARGETS "")
 
            foreach(_LIBRARY_NAME ${libraries})
                find_library(CONAN_FOUND_LIBRARY NAMES ${_LIBRARY_NAME} PATHS ${package_libdir}
@@ -60,11 +58,8 @@ class MacrosTemplate(CMakeDepsFileTemplate):
                        # Create a micro-target for each lib/a found
                        add_library(${_LIB_NAME} UNKNOWN IMPORTED)
                    endif()
-                   # Enable configuration only when it is available to avoid missing configs
-                   set_property(TARGET ${_LIB_NAME} APPEND PROPERTY IMPORTED_CONFIGURATIONS ${config})
                    # Link library file
-                   set_target_properties(${_LIB_NAME} PROPERTIES IMPORTED_LOCATION_${config} ${CONAN_FOUND_LIBRARY})
-                   list(APPEND _CONAN_ACTUAL_TARGETS ${_LIB_NAME})
+                   set_target_properties(${_LIB_NAME} PROPERTIES IMPORTED_LOCATION ${CONAN_FOUND_LIBRARY})
                    list(APPEND _out_libraries_target ${_LIB_NAME})
                    message(VERBOSE "Conan: Found: ${CONAN_FOUND_LIBRARY}")
                else()
@@ -74,20 +69,8 @@ class MacrosTemplate(CMakeDepsFileTemplate):
            endforeach()
 
            # Add the dependencies target for all the imported libraries
-           foreach(_CONAN_ACTUAL_TARGET ${_CONAN_ACTUAL_TARGETS})
-               set_property(TARGET ${_CONAN_ACTUAL_TARGET} PROPERTY INTERFACE_LINK_LIBRARIES ${deps_target} APPEND)
-           endforeach()
-
-           # ONLY FOR DEBUGGING PURPOSES
-           foreach(_CONAN_ACTUAL_TARGET ${_CONAN_ACTUAL_TARGETS})
-              get_target_property(imported_location ${_CONAN_ACTUAL_TARGET} IMPORTED_LOCATION_DEBUG)
-              message(VERBOSE "Target Properties: ${_CONAN_ACTUAL_TARGET} IMPORTED_LOCATION_DEBUG ='${imported_location}'")
-
-              get_target_property(imported_location ${_CONAN_ACTUAL_TARGET} IMPORTED_LOCATION_RELEASE)
-              message(VERBOSE "Target Properties: ${_CONAN_ACTUAL_TARGET} IMPORTED_LOCATION_RELEASE ='${imported_location}'")
-
-              get_target_property(linked_libs ${_CONAN_ACTUAL_TARGET} INTERFACE_LINK_LIBRARIES)
-              message(VERBOSE "Target Properties: ${_CONAN_ACTUAL_TARGET} INTERFACE_LINK_LIBRARIES ='${linked_libs}'")
+           foreach(_T ${_out_libraries_target})
+               set_property(TARGET ${_T} PROPERTY INTERFACE_LINK_LIBRARIES ${deps_target} APPEND)
            endforeach()
 
            set(${out_libraries_target} ${_out_libraries_target} PARENT_SCOPE)

--- a/conan/tools/cmake/cmakedeps/templates/target_configuration.py
+++ b/conan/tools/cmake/cmakedeps/templates/target_configuration.py
@@ -62,7 +62,7 @@ class TargetConfigurationTemplate(CMakeDepsFileTemplate):
         set({{ pkg_name }}_FRAMEWORKS_FOUND{{ config_suffix }} "") # Will be filled later
         conan_find_apple_frameworks({{ pkg_name }}_FRAMEWORKS_FOUND{{ config_suffix }} "{{ '${' }}{{ pkg_name }}_FRAMEWORKS{{ config_suffix }}}" "{{ '${' }}{{ pkg_name }}_FRAMEWORK_DIRS{{ config_suffix }}}")
 
-        set({{ pkg_name }}_LIBRARIES_TARGETS{{ config_suffix }} "") # Will be filled later
+        set({{ pkg_name }}_LIBRARIES_TARGETS "") # Will be filled later
 
 
         ######## Create an interface target to contain all the dependencies (frameworks, system and conan deps)

--- a/conan/tools/cmake/cmakedeps/templates/target_configuration.py
+++ b/conan/tools/cmake/cmakedeps/templates/target_configuration.py
@@ -83,6 +83,7 @@ class TargetConfigurationTemplate(CMakeDepsFileTemplate):
                                       "{{ '${' }}{{ pkg_name }}_LIB_DIRS{{ config_suffix }}}" # package_libdir
                                       {{ pkg_name + '_DEPS_TARGET'}}
                                       {{ pkg_name }}_LIBRARIES_TARGETS  # out_libraries_targets
+                                      "{{ config_suffix }}"
                                       "{{ pkg_name }}")    # package_name
 
         # FIXME: What is the result of this for multi-config? All configs adding themselves to path?
@@ -162,6 +163,7 @@ class TargetConfigurationTemplate(CMakeDepsFileTemplate):
                                               "{{ '${'+pkg_name+'_'+comp_variable_name+'_LIB_DIRS'+config_suffix+'}' }}"
                                               {{ pkg_name + '_' + comp_variable_name + '_DEPS_TARGET'}}
                                               {{ pkg_name }}_{{ comp_variable_name }}_LIBRARIES_TARGETS
+                                              "{{ config_suffix }}"
                                               "{{ pkg_name }}_{{ comp_variable_name }}")
 
                 ########## TARGET PROPERTIES #####################################

--- a/conan/tools/cmake/cmakedeps/templates/target_configuration.py
+++ b/conan/tools/cmake/cmakedeps/templates/target_configuration.py
@@ -83,7 +83,6 @@ class TargetConfigurationTemplate(CMakeDepsFileTemplate):
                                       "{{ '${' }}{{ pkg_name }}_LIB_DIRS{{ config_suffix }}}" # package_libdir
                                       {{ pkg_name + '_DEPS_TARGET'}}
                                       {{ pkg_name }}_LIBRARIES_TARGETS  # out_libraries_targets
-                                      "{{ config }}" # DEBUG, RELEASE ...
                                       "{{ pkg_name }}")    # package_name
 
         # FIXME: What is the result of this for multi-config? All configs adding themselves to path?
@@ -96,7 +95,7 @@ class TargetConfigurationTemplate(CMakeDepsFileTemplate):
             set_property(TARGET {{root_target_name}}
                          PROPERTY INTERFACE_LINK_LIBRARIES
                          $<$<CONFIG:{{configuration}}>:{{ '${'+pkg_name+'_OBJECTS'+config_suffix+'}' }}>
-                         ${{'{'}}{{pkg_name}}_LIBRARIES_TARGETS}
+                         $<$<CONFIG:{{configuration}}>:${{'{'}}{{pkg_name}}_LIBRARIES_TARGETS}>
                          APPEND)
 
             if("{{ '${' }}{{ pkg_name }}_LIBS{{ config_suffix }}}" STREQUAL "")
@@ -163,14 +162,13 @@ class TargetConfigurationTemplate(CMakeDepsFileTemplate):
                                               "{{ '${'+pkg_name+'_'+comp_variable_name+'_LIB_DIRS'+config_suffix+'}' }}"
                                               {{ pkg_name + '_' + comp_variable_name + '_DEPS_TARGET'}}
                                               {{ pkg_name }}_{{ comp_variable_name }}_LIBRARIES_TARGETS
-                                              "{{ config }}" # DEBUG, RELEASE...
                                               "{{ pkg_name }}_{{ comp_variable_name }}")
 
                 ########## TARGET PROPERTIES #####################################
                 set_property(TARGET {{comp_target_name}}
                              PROPERTY INTERFACE_LINK_LIBRARIES
                              $<$<CONFIG:{{configuration}}>:{{ '${'+pkg_name+'_'+comp_variable_name+'_OBJECTS'+config_suffix+'}' }}>
-                             ${{'{'}}{{pkg_name}}_{{comp_variable_name}}_LIBRARIES_TARGETS}
+                             $<$<CONFIG:{{configuration}}>:${{'{'}}{{pkg_name}}_{{comp_variable_name}}_LIBRARIES_TARGETS}>
                              APPEND)
 
                 if("{{ '${' }}{{ pkg_name }}_{{comp_variable_name}}_LIBS{{ config_suffix }}}" STREQUAL "")

--- a/conans/test/functional/toolchains/cmake/cmakedeps/test_cmakedeps.py
+++ b/conans/test/functional/toolchains/cmake/cmakedeps/test_cmakedeps.py
@@ -161,7 +161,7 @@ def test_system_libs():
             assert "System libs debug: %s" % library_name in client.out
             assert "Libraries to Link debug: lib1" in client.out
 
-        assert f"Target libs: $<$<CONFIG:{build_type}>:>;CONAN_LIB::Test_lib1" in client.out
+        assert f"Target libs: $<$<CONFIG:{build_type}>:>;$<$<CONFIG:{build_type}>:CONAN_LIB::Test_lib1>" in client.out
         assert "Micro-target libs: Test_DEPS_TARGET" in client.out
         micro_target_deps = f"Micro-target deps: $<$<CONFIG:{build_type}>:>;$<$<CONFIG:{build_type}>:{library_name}>;" \
                             f"$<$<CONFIG:{build_type}>:>"
@@ -225,7 +225,7 @@ def test_system_libs_no_libs():
         library_name = "sys1d" if build_type == "Debug" else "sys1"
 
         assert f"System libs {build_type}: {library_name}" in client.out
-        assert f"Target libs: $<$<CONFIG:{build_type}>:>;Test_DEPS_TARGET" in client.out
+        assert f"Target libs: $<$<CONFIG:{build_type}>:>;$<$<CONFIG:{build_type}>:>;Test_DEPS_TARGET" in client.out
         assert f"DEPS TARGET: $<$<CONFIG:{build_type}>:>;" \
                f"$<$<CONFIG:{build_type}>:{library_name}>" in client.out
 
@@ -288,7 +288,7 @@ def test_system_libs_components_no_libs():
         library_name = "sys1d" if build_type == "Debug" else "sys1"
 
         assert f"System libs {build_type}: {library_name}" in client.out
-        assert f"Target libs: $<$<CONFIG:{build_type}>:>;Test_Test_foo_DEPS_TARGET" in client.out
+        assert f"Target libs: $<$<CONFIG:{build_type}>:>;$<$<CONFIG:{build_type}>:>;Test_Test_foo_DEPS_TARGET" in client.out
         assert f"DEPS TARGET: $<$<CONFIG:{build_type}>:>;" \
                f"$<$<CONFIG:{build_type}>:{library_name}>" in client.out
 

--- a/conans/test/functional/toolchains/cmake/cmakedeps/test_cmakedeps.py
+++ b/conans/test/functional/toolchains/cmake/cmakedeps/test_cmakedeps.py
@@ -141,14 +141,15 @@ def test_system_libs():
         message("Libraries to Link debug: ${Test_LIBS_DEBUG}")
         get_target_property(tmp Test::Test INTERFACE_LINK_LIBRARIES)
         message("Target libs: ${tmp}")
-        get_target_property(tmp CONAN_LIB::Test_lib1 INTERFACE_LINK_LIBRARIES)
+        get_target_property(tmp CONAN_LIB::Test_lib1_%s INTERFACE_LINK_LIBRARIES)
         message("Micro-target libs: ${tmp}")
         get_target_property(tmp Test_DEPS_TARGET INTERFACE_LINK_LIBRARIES)
         message("Micro-target deps: ${tmp}")
         """)
 
     for build_type in ["Release", "Debug"]:
-        client.save({"conanfile.txt": conanfile, "CMakeLists.txt": cmakelists}, clean_first=True)
+        client.save({"conanfile.txt": conanfile,
+                     "CMakeLists.txt": cmakelists % build_type.upper()}, clean_first=True)
         client.run("install conanfile.txt -s build_type=%s" % build_type)
         client.run_command('cmake . -DCMAKE_BUILD_TYPE={0}'.format(build_type))
 
@@ -161,7 +162,7 @@ def test_system_libs():
             assert "System libs debug: %s" % library_name in client.out
             assert "Libraries to Link debug: lib1" in client.out
 
-        assert f"Target libs: $<$<CONFIG:{build_type}>:>;$<$<CONFIG:{build_type}>:CONAN_LIB::Test_lib1>" in client.out
+        assert f"Target libs: $<$<CONFIG:{build_type}>:>;$<$<CONFIG:{build_type}>:CONAN_LIB::Test_lib1_{build_type.upper()}>" in client.out
         assert "Micro-target libs: Test_DEPS_TARGET" in client.out
         micro_target_deps = f"Micro-target deps: $<$<CONFIG:{build_type}>:>;$<$<CONFIG:{build_type}>:{library_name}>;" \
                             f"$<$<CONFIG:{build_type}>:>"

--- a/conans/test/functional/toolchains/cmake/cmakedeps/test_cmakedeps_and_linker_flags.py
+++ b/conans/test/functional/toolchains/cmake/cmakedeps/test_cmakedeps_and_linker_flags.py
@@ -76,13 +76,13 @@ def test_not_mixed_configurations():
             cmake_minimum_required(VERSION 3.15)
             project(foo CXX)
 
-            add_library(foo src/foo.cpp)
+            add_library(foo "src/foo.cpp")
             target_include_directories(foo PUBLIC include)
             set_target_properties(foo PROPERTIES PUBLIC_HEADER "include/foo.h")
 
             # Different name for Release or Debug
-            set_target_properties(foo PROPERTIES OUTPUT_NAME "$<$<CONFIG:Debug>:foo_d>$<$<CONFIG:Release>:foo>")
-
+            set_target_properties(foo PROPERTIES OUTPUT_NAME_DEBUG foo_d)
+            set_target_properties(foo PROPERTIES OUTPUT_NAME_RELEASE foo)
             install(TARGETS foo)
     """)
 
@@ -140,6 +140,8 @@ def test_not_mixed_configurations():
 
     client.run("install . -s build_type=Debug")
     client.run("install . -s build_type=Release")
+    # With the bug, this build only fail on windows
     client.run("build .")
-    # Check that foo_d is not being linked
+
+    # But we inspect the output for Macos/Linux to check the the library is not linked
     assert "foo_d" not in client.out

--- a/conans/test/functional/toolchains/cmake/cmakedeps/test_cmakedeps_and_linker_flags.py
+++ b/conans/test/functional/toolchains/cmake/cmakedeps/test_cmakedeps_and_linker_flags.py
@@ -144,4 +144,4 @@ def test_not_mixed_configurations():
     client.run("build .")
 
     # But we inspect the output for Macos/Linux to check the the library is not linked
-    assert "foo_d" not in client.out
+    assert "libfoo_d.a" not in client.out

--- a/conans/test/functional/toolchains/cmake/cmakedeps/test_cmakedeps_and_linker_flags.py
+++ b/conans/test/functional/toolchains/cmake/cmakedeps/test_cmakedeps_and_linker_flags.py
@@ -4,6 +4,7 @@ import textwrap
 
 import pytest
 
+from conans.test.assets.sources import gen_function_cpp, gen_function_h
 from conans.test.utils.tools import TestClient
 
 
@@ -56,3 +57,89 @@ def test_shared_link_flags():
     assert 'set(hello_SHARED_LINK_FLAGS_RELEASE "-z now;-z relro")' in target_data_cmake_content
     assert 'set(hello_EXE_LINK_FLAGS_RELEASE "-z now;-z relro")' in target_data_cmake_content
     assert "hello/1.0: Hello World Release!" in client.out
+
+
+def test_not_mixed_configurations():
+    # https://github.com/conan-io/conan/issues/11852
+
+    client = TestClient()
+    client.run("new foo/1.0 -m cmake_lib")
+
+    conanfile = client.load("conanfile.py")
+    conanfile.replace("package_info(self)", "invalid(self)")
+    conanfile += """
+    def package_info(self):
+        self.cpp_info.libs = ["foo" if self.settings.build_type == "Release" else "foo_d"]
+    """
+
+    cmake = textwrap.dedent("""
+            cmake_minimum_required(VERSION 3.15)
+            project(foo CXX)
+
+            add_library(foo src/foo.cpp)
+            target_include_directories(foo PUBLIC include)
+            set_target_properties(foo PROPERTIES PUBLIC_HEADER "include/foo.h")
+
+            # Different name for Release or Debug
+            set_target_properties(foo PROPERTIES OUTPUT_NAME "$<$<CONFIG:Debug>:foo_d>$<$<CONFIG:Release>:foo>")
+
+            install(TARGETS foo)
+    """)
+
+    client.save({"CMakeLists.txt": cmake, "conanfile.py": conanfile})
+    client.run("create .")
+    client.run("create . -s build_type=Debug")
+    if platform.system() != "Windows":
+        assert "libfoo_d.a" in client.out  # Just to make sure we built the foo_d
+
+    # Now create a consumer of foo with CMakeDeps locally
+    conanfile = textwrap.dedent("""
+        from conan import ConanFile
+        from conan.tools.cmake import CMakeToolchain, CMake, cmake_layout
+
+        class ConsumerConan(ConanFile):
+            name = "consumer"
+            version = "1.0"
+            settings = "os", "compiler", "build_type", "arch"
+            requires = "foo/1.0"
+            generators = "CMakeDeps"
+
+            def layout(self):
+                cmake_layout(self)
+
+            def generate(self):
+                tc = CMakeToolchain(self)
+                tc.cache_variables["CMAKE_VERBOSE_MAKEFILE:BOOL"] = "ON"
+                tc.generate()
+
+            def build(self):
+                cmake = CMake(self)
+                cmake.configure()
+                cmake.build()
+
+            """)
+    cmake = textwrap.dedent("""
+            cmake_minimum_required(VERSION 3.15)
+            project(consumer CXX)
+
+            find_package(foo)
+
+            add_executable(consumer src/consumer.cpp)
+            target_include_directories(consumer PUBLIC include)
+            target_link_libraries(consumer foo::foo)
+
+            get_target_property(linked_libs foo::foo INTERFACE_LINK_LIBRARIES)
+            message("Target Properties: foo::foo INTERFACE_LINK_LIBRARIES ='${linked_libs}'")
+
+            set_target_properties(consumer PROPERTIES PUBLIC_HEADER "include/consumer.h")""")
+    consumer_cpp = gen_function_cpp(name="main", includes=["foo"], calls=["foo"])
+    consumer_h = gen_function_h(name="consumer")
+
+    client.save({"conanfile.py": conanfile, "CMakeLists.txt": cmake,
+                 "src/consumer.cpp": consumer_cpp, "src/consumer.h": consumer_h})
+
+    client.run("install . -s build_type=Debug")
+    client.run("install . -s build_type=Release")
+    client.run("build .")
+    # Check that foo_d is not being linked
+    assert "foo_d" not in client.out

--- a/conans/test/functional/toolchains/cmake/cmakedeps/test_cmakedeps_and_linker_flags.py
+++ b/conans/test/functional/toolchains/cmake/cmakedeps/test_cmakedeps_and_linker_flags.py
@@ -129,7 +129,7 @@ def test_not_mixed_configurations():
             target_link_libraries(consumer foo::foo)
 
             get_target_property(linked_libs foo::foo INTERFACE_LINK_LIBRARIES)
-            message("Target Properties: foo::foo INTERFACE_LINK_LIBRARIES ='${linked_libs}'")
+            message("===> foo::foo INTERFACE_LINK_LIBRARIES='${linked_libs}'")
 
             set_target_properties(consumer PROPERTIES PUBLIC_HEADER "include/consumer.h")""")
     consumer_cpp = gen_function_cpp(name="main", includes=["foo"], calls=["foo"])

--- a/conans/test/functional/toolchains/cmake/cmakedeps/test_cmakedeps_and_linker_flags.py
+++ b/conans/test/functional/toolchains/cmake/cmakedeps/test_cmakedeps_and_linker_flags.py
@@ -143,5 +143,6 @@ def test_not_mixed_configurations():
     # With the bug, this build only fail on windows
     client.run("build .")
 
-    # But we inspect the output for Macos/Linux to check the the library is not linked
-    assert "libfoo_d.a" not in client.out
+    # But we inspect the output for Macos/Linux to check that the library is not linked
+    if platform.system() != "Windows":
+        assert "libfoo_d.a" not in client.out

--- a/conans/test/functional/toolchains/cmake/cmakedeps/test_cmakedeps_and_linker_flags.py
+++ b/conans/test/functional/toolchains/cmake/cmakedeps/test_cmakedeps_and_linker_flags.py
@@ -128,9 +128,6 @@ def test_not_mixed_configurations():
             target_include_directories(consumer PUBLIC include)
             target_link_libraries(consumer foo::foo)
 
-            get_target_property(linked_libs foo::foo INTERFACE_LINK_LIBRARIES)
-            message("===> foo::foo INTERFACE_LINK_LIBRARIES='${linked_libs}'")
-
             set_target_properties(consumer PROPERTIES PUBLIC_HEADER "include/consumer.h")""")
     consumer_cpp = gen_function_cpp(name="main", includes=["foo"], calls=["foo"])
     consumer_h = gen_function_h(name="consumer")
@@ -146,3 +143,4 @@ def test_not_mixed_configurations():
     # But we inspect the output for Macos/Linux to check that the library is not linked
     if platform.system() != "Windows":
         assert "libfoo_d.a" not in client.out
+        assert "libfoo.a" in client.out

--- a/conans/test/functional/toolchains/cmake/cmakedeps/test_cmakedeps_components.py
+++ b/conans/test/functional/toolchains/cmake/cmakedeps/test_cmakedeps_components.py
@@ -206,7 +206,7 @@ def test_components_system_libs():
 
     t.save({"conanfile.py": conanfile, "CMakeLists.txt": cmakelists})
     t.run("create . --build missing -s build_type=Release")
-    assert 'component libs: $<$<CONFIG:Release>:>;requirement_requirement_component_DEPS_TARGET' in t.out
+    assert 'component libs: $<$<CONFIG:Release>:>;$<$<CONFIG:Release>:>;requirement_requirement_component_DEPS_TARGET' in t.out
     assert 'component deps: $<$<CONFIG:Release>:>;$<$<CONFIG:Release>:system_lib_component>;' in t.out
     assert ('component options: '
             '$<$<CONFIG:Release>:'
@@ -400,7 +400,7 @@ def test_cmake_add_subdirectory():
     # The boost::boost target has linked the two components
     assert "AGGREGATED LIBS: boost::boost" in t.out
     assert "AGGREGATED LINKED: boost::B;boost::A" in t.out
-    assert "BOOST_B LINKED: $<$<CONFIG:Release>:>;boost_boost_B_DEPS_TARGET" in t.out
-    assert "BOOST_A LINKED: $<$<CONFIG:Release>:>;boost_boost_A_DEPS_TARGET" in t.out
+    assert "BOOST_B LINKED: $<$<CONFIG:Release>:>;$<$<CONFIG:Release>:>;boost_boost_B_DEPS_TARGET" in t.out
+    assert "BOOST_A LINKED: $<$<CONFIG:Release>:>;$<$<CONFIG:Release>:>;boost_boost_A_DEPS_TARGET" in t.out
     assert "BOOST_B_DEPS LINKED: $<$<CONFIG:Release>:>;$<$<CONFIG:Release>:B_1;B_2>" in t.out
     assert "BOOST_A_DEPS LINKED: $<$<CONFIG:Release>:>;$<$<CONFIG:Release>:A_1;A_2>;" in t.out

--- a/conans/test/functional/toolchains/cmake/cmakedeps/test_cmakedeps_find_module_and_config.py
+++ b/conans/test/functional/toolchains/cmake/cmakedeps/test_cmakedeps_find_module_and_config.py
@@ -193,7 +193,7 @@ def test_transitive_modules_found(find_mode_PKGA, find_mode_PKGB, find_mode_cons
     # The MYPKG_LIBRARIES contains the target for the current package, but the target is linked
     # with the dependencies also:
     assert "MYPKGB_LIBRARIES: pkgb::pkgb" in client.out
-    assert "MYPKGB_LINKED_LIBRARIES: '$<$<CONFIG:Release>:>;pkgb_DEPS_TARGET'" in client.out
+    assert "MYPKGB_LINKED_LIBRARIES: '$<$<CONFIG:Release>:>;$<$<CONFIG:Release>:>;pkgb_DEPS_TARGET'" in client.out
     assert "MYPKGB_DEPS_LIBRARIES: '$<$<CONFIG:Release>:>;$<$<CONFIG:Release>:>;" \
            "$<$<CONFIG:Release>:pkga::pkga>'" in client.out
 

--- a/conans/test/functional/toolchains/cmake/test_cmake.py
+++ b/conans/test/functional/toolchains/cmake/test_cmake.py
@@ -9,7 +9,6 @@ from parameterized.parameterized import parameterized
 
 from conans.model.ref import ConanFileReference, PackageReference
 from conans.test.assets.cmake import gen_cmakelists
-from conans.test.assets.genconanfile import GenConanfile
 from conans.test.assets.sources import gen_function_cpp, gen_function_h
 from conans.test.functional.utils import check_vs_runtime, check_exe_run
 from conans.test.utils.tools import TestClient
@@ -657,89 +656,3 @@ class TestCMakeFindPackagePreferConfig:
         client.run("install . --profile=profile_false")
         client.run("build .")
         assert "using FindComandante.cmake" in client.out
-
-
-def test_not_mixed_configurations():
-    # https://github.com/conan-io/conan/issues/11852
-
-    client = TestClient()
-    client.run("new foo/1.0 -m cmake_lib")
-
-    conanfile = client.load("conanfile.py")
-    conanfile.replace("package_info(self)", "invalid(self)")
-    conanfile += """
-    def package_info(self):
-        self.cpp_info.libs = ["foo" if self.settings.build_type == "Release" else "foo_d"]
-    """
-
-    cmake = textwrap.dedent("""
-            cmake_minimum_required(VERSION 3.15)
-            project(foo CXX)
-
-            add_library(foo src/foo.cpp)
-            target_include_directories(foo PUBLIC include)
-            set_target_properties(foo PROPERTIES PUBLIC_HEADER "include/foo.h")
-
-            # Different name for Release or Debug
-            set_target_properties(foo PROPERTIES OUTPUT_NAME "$<$<CONFIG:Debug>:foo_d>$<$<CONFIG:Release>:foo>")
-
-            install(TARGETS foo)
-    """)
-
-    client.save({"CMakeLists.txt": cmake, "conanfile.py": conanfile})
-    client.run("create .")
-    client.run("create . -s build_type=Debug")
-    if platform.system() != "Windows":
-        assert "libfoo_d.a" in client.out  # Just to make sure we built the foo_d
-
-    # Now create a consumer of foo with CMakeDeps locally
-    conanfile = textwrap.dedent("""
-        from conan import ConanFile
-        from conan.tools.cmake import CMakeToolchain, CMake, cmake_layout
-
-        class ConsumerConan(ConanFile):
-            name = "consumer"
-            version = "1.0"
-            settings = "os", "compiler", "build_type", "arch"
-            requires = "foo/1.0"
-            generators = "CMakeDeps"
-
-            def layout(self):
-                cmake_layout(self)
-
-            def generate(self):
-                tc = CMakeToolchain(self)
-                tc.cache_variables["CMAKE_VERBOSE_MAKEFILE:BOOL"] = "ON"
-                tc.generate()
-
-            def build(self):
-                cmake = CMake(self)
-                cmake.configure()
-                cmake.build()
-
-            """)
-    cmake = textwrap.dedent("""
-            cmake_minimum_required(VERSION 3.15)
-            project(consumer CXX)
-
-            find_package(foo)
-
-            add_executable(consumer src/consumer.cpp)
-            target_include_directories(consumer PUBLIC include)
-            target_link_libraries(consumer foo::foo)
-
-            get_target_property(linked_libs foo::foo INTERFACE_LINK_LIBRARIES)
-            message("Target Properties: foo::foo INTERFACE_LINK_LIBRARIES ='${linked_libs}'")
-
-            set_target_properties(consumer PROPERTIES PUBLIC_HEADER "include/consumer.h")""")
-    consumer_cpp = gen_function_cpp(name="main", includes=["foo"], calls=["foo"])
-    consumer_h = gen_function_h(name="consumer")
-
-    client.save({"conanfile.py": conanfile, "CMakeLists.txt": cmake,
-                 "src/consumer.cpp": consumer_cpp, "src/consumer.h": consumer_h})
-
-    client.run("install . -s build_type=Debug")
-    client.run("install . -s build_type=Release")
-    client.run("build .")
-    # Check that foo_d is not being linked
-    assert "foo_d" not in client.out

--- a/conans/test/functional/toolchains/cmake/test_cmake.py
+++ b/conans/test/functional/toolchains/cmake/test_cmake.py
@@ -9,6 +9,7 @@ from parameterized.parameterized import parameterized
 
 from conans.model.ref import ConanFileReference, PackageReference
 from conans.test.assets.cmake import gen_cmakelists
+from conans.test.assets.genconanfile import GenConanfile
 from conans.test.assets.sources import gen_function_cpp, gen_function_h
 from conans.test.functional.utils import check_vs_runtime, check_exe_run
 from conans.test.utils.tools import TestClient
@@ -656,3 +657,89 @@ class TestCMakeFindPackagePreferConfig:
         client.run("install . --profile=profile_false")
         client.run("build .")
         assert "using FindComandante.cmake" in client.out
+
+
+def test_not_mixed_configurations():
+    # https://github.com/conan-io/conan/issues/11852
+
+    client = TestClient()
+    client.run("new foo/1.0 -m cmake_lib")
+
+    conanfile = client.load("conanfile.py")
+    conanfile.replace("package_info(self)", "invalid(self)")
+    conanfile += """
+    def package_info(self):
+        self.cpp_info.libs = ["foo" if self.settings.build_type == "Release" else "foo_d"]
+    """
+
+    cmake = textwrap.dedent("""
+            cmake_minimum_required(VERSION 3.15)
+            project(foo CXX)
+
+            add_library(foo src/foo.cpp)
+            target_include_directories(foo PUBLIC include)
+            set_target_properties(foo PROPERTIES PUBLIC_HEADER "include/foo.h")
+
+            # Different name for Release or Debug
+            set_target_properties(foo PROPERTIES OUTPUT_NAME "$<$<CONFIG:Debug>:foo_d>$<$<CONFIG:Release>:foo>")
+
+            install(TARGETS foo)
+    """)
+
+    client.save({"CMakeLists.txt": cmake, "conanfile.py": conanfile})
+    client.run("create .")
+    client.run("create . -s build_type=Debug")
+    if platform.system() != "Windows":
+        assert "libfoo_d.a" in client.out  # Just to make sure we built the foo_d
+
+    # Now create a consumer of foo with CMakeDeps locally
+    conanfile = textwrap.dedent("""
+        from conan import ConanFile
+        from conan.tools.cmake import CMakeToolchain, CMake, cmake_layout
+
+        class ConsumerConan(ConanFile):
+            name = "consumer"
+            version = "1.0"
+            settings = "os", "compiler", "build_type", "arch"
+            requires = "foo/1.0"
+            generators = "CMakeDeps"
+
+            def layout(self):
+                cmake_layout(self)
+
+            def generate(self):
+                tc = CMakeToolchain(self)
+                tc.cache_variables["CMAKE_VERBOSE_MAKEFILE:BOOL"] = "ON"
+                tc.generate()
+
+            def build(self):
+                cmake = CMake(self)
+                cmake.configure()
+                cmake.build()
+
+            """)
+    cmake = textwrap.dedent("""
+            cmake_minimum_required(VERSION 3.15)
+            project(consumer CXX)
+
+            find_package(foo)
+
+            add_executable(consumer src/consumer.cpp)
+            target_include_directories(consumer PUBLIC include)
+            target_link_libraries(consumer foo::foo)
+
+            get_target_property(linked_libs foo::foo INTERFACE_LINK_LIBRARIES)
+            message("Target Properties: foo::foo INTERFACE_LINK_LIBRARIES ='${linked_libs}'")
+
+            set_target_properties(consumer PROPERTIES PUBLIC_HEADER "include/consumer.h")""")
+    consumer_cpp = gen_function_cpp(name="main", includes=["foo"], calls=["foo"])
+    consumer_h = gen_function_h(name="consumer")
+
+    client.save({"conanfile.py": conanfile, "CMakeLists.txt": cmake,
+                 "src/consumer.cpp": consumer_cpp, "src/consumer.h": consumer_h})
+
+    client.run("install . -s build_type=Debug")
+    client.run("install . -s build_type=Release")
+    client.run("build .")
+    # Check that foo_d is not being linked
+    assert "foo_d" not in client.out

--- a/conans/test/integration/toolchains/cmake/cmakedeps/test_cmakedeps.py
+++ b/conans/test/integration/toolchains/cmake/cmakedeps/test_cmakedeps.py
@@ -107,7 +107,7 @@ def test_cpp_info_component_objects():
         assert """set_property(TARGET hello::say
                      PROPERTY INTERFACE_LINK_LIBRARIES
                      $<$<CONFIG:Release>:${hello_hello_say_OBJECTS_RELEASE}>
-                     ${hello_hello_say_LIBRARIES_TARGETS}
+                     $<$<CONFIG:Release>:${hello_hello_say_LIBRARIES_TARGETS}>
                      APPEND)""" in content
         # If there are componets, there is not a global cpp so this is not generated
         assert "hello_OBJECTS_RELEASE" not in content


### PR DESCRIPTION
Changelog: Bugfix: The CMakeDeps generator was not managing correctly the IMPORTED LOCATION of the libraries for different `build_type`.
Docs: omit

Close https://github.com/conan-io/conan/issues/11852

After investigating (thanks @jcar87) looks like the `IMPORTED_LOCATION_<build_type>` doesn't make the targets of the library files multi-config, CMake only uses it as a priority based on other things like the config mappings. More (cryptic) info can be found here: https://gitlab.kitware.com/cmake/cmake/-/issues/16280
So I decided to revert that part of the macro keeping the improvements introduced in the last release, that **so far** have worked ok.


