### PR TITLE
Prevent mutation of conan_data structure in apply_conandata_patches

### DIFF
--- a/conan/tools/files/patches.py
+++ b/conan/tools/files/patches.py
@@ -110,8 +110,9 @@ def apply_conandata_patches(conanfile):
     for it in entries:
         if "patch_file" in it:
             # The patch files are located in the root src
-            patch_file = os.path.join(conanfile.folders.base_source, it.pop("patch_file"))
-            patch(conanfile, patch_file=patch_file, **it)
+            patch_file = os.path.join(conanfile.folders.base_source, it.get("patch_file"))
+            patch(conanfile, patch_file=patch_file, patch_type=it.get("patch_type"), 
+                  patch_description=it.get("patch_description"))
         elif "patch_string" in it:
             patch(conanfile, **it)
         else:

--- a/conan/tools/files/patches.py
+++ b/conan/tools/files/patches.py
@@ -110,9 +110,9 @@ def apply_conandata_patches(conanfile):
     for it in entries:
         if "patch_file" in it:
             # The patch files are located in the root src
-            patch_file = os.path.join(conanfile.folders.base_source, it.get("patch_file"))
-            patch(conanfile, patch_file=patch_file, patch_type=it.get("patch_type"), 
-                  patch_description=it.get("patch_description"))
+            entry = it.copy()
+            patch_file = os.path.join(conanfile.folders.base_source, entry.pop("patch_file"))
+            patch(conanfile, patch_file=patch_file, **entry)
         elif "patch_string" in it:
             patch(conanfile, **it)
         else:

--- a/conans/test/unittests/tools/files/test_patches.py
+++ b/conans/test/unittests/tools/files/test_patches.py
@@ -202,3 +202,8 @@ def test_multiple_with_version(mock_patch_ng):
     apply_conandata_patches(conanfile)
     assert 'Apply patch (backport): Needed to build with modern clang compilers.\n' \
            == str(conanfile.output)
+    
+    # Ensure the function is not mutating the `conan_data` structure
+    assert len(conanfile.conan_data['patches']) == 2
+    assert conanfile.conan_data['patches']['1.11.0'][0]['patch_file'] == 'patches/0001-buildflatbuffers-cmake.patch'
+    assert conanfile.conan_data['patches']['1.11.0'][1]['patch_file'] == 'patches/0002-implicit-copy-constructor.patch'

--- a/conans/test/unittests/tools/files/test_patches.py
+++ b/conans/test/unittests/tools/files/test_patches.py
@@ -175,7 +175,7 @@ def test_multiple_no_version(mock_patch_ng):
 def test_multiple_with_version(mock_patch_ng):
     conanfile = ConanFileMock()
     conanfile.display_name = 'mocked/ref'
-    conanfile.conan_data = {'patches': {
+    conandata_contents = {'patches': {
         "1.11.0": [
             {'patch_file': 'patches/0001-buildflatbuffers-cmake.patch',
              'base_path': 'source_subfolder', },
@@ -189,6 +189,8 @@ def test_multiple_with_version(mock_patch_ng):
             {'patch_file': 'patches/0001-buildflatbuffers-cmake.patch',
              'base_path': 'source_subfolder', },
         ]}}
+
+    conanfile.conan_data = conandata_contents.copy()
 
     with pytest.raises(AssertionError) as excinfo:
         apply_conandata_patches(conanfile)
@@ -204,6 +206,4 @@ def test_multiple_with_version(mock_patch_ng):
            == str(conanfile.output)
     
     # Ensure the function is not mutating the `conan_data` structure
-    assert len(conanfile.conan_data['patches']) == 2
-    assert conanfile.conan_data['patches']['1.11.0'][0]['patch_file'] == 'patches/0001-buildflatbuffers-cmake.patch'
-    assert conanfile.conan_data['patches']['1.11.0'][1]['patch_file'] == 'patches/0002-implicit-copy-constructor.patch'
+    assert conanfile.conan_data == conandata_contents


### PR DESCRIPTION
Changelog: Bugfix: Prevent mutation of loaded data from conanfile.yml if accesses multiple times during the same run when calling `apply_conandata_patches()`.
Docs: Omit

Close: https://github.com/conan-io/conan/issues/11854


The case described in https://github.com/conan-io/conan/issues/11854 leads to a situation where the during a single run, the `conanfile.yml` is loaded _once_, but `apply_conandata_patches()` was being called twice (as there are two calls to `build()`, one in the host context and one in the build context). This PR fixes a bug where during `apply_conandata_patches()` the loaded structure was being mutated, removing the patches, and thus the second call to `apply_conandata_patches()` was failing. 
