### PR TITLE
CMakeDeps: Variables for merged global target, even when only components

### DIFF
--- a/conan/tools/cmake/cmakedeps/templates/target_data.py
+++ b/conan/tools/cmake/cmakedeps/templates/target_data.py
@@ -87,7 +87,6 @@ class ConfigDataTemplate(CMakeDepsFileTemplate):
               set({{ pkg_name }}_PACKAGE_FOLDER{{ config_suffix }} "{{ package_folder }}")
               set({{ pkg_name }}_BUILD_MODULES_PATHS{{ config_suffix }} {{ global_cpp.build_modules_paths }})
 
-              {% if not has_components %}
 
               set({{ pkg_name }}_INCLUDE_DIRS{{ config_suffix }} {{ global_cpp.include_paths }})
               set({{ pkg_name }}_RES_DIRS{{ config_suffix }} {{ global_cpp.res_paths }})
@@ -104,7 +103,7 @@ class ConfigDataTemplate(CMakeDepsFileTemplate):
               set({{ pkg_name }}_FRAMEWORK_DIRS{{ config_suffix }} {{ global_cpp.framework_paths }})
               set({{ pkg_name }}_FRAMEWORKS{{ config_suffix }} {{ global_cpp.frameworks }})
               set({{ pkg_name }}_BUILD_DIRS{{ config_suffix }} {{ global_cpp.build_paths }})
-              {% else %}
+
 
               set({{ pkg_name }}_COMPONENTS{{ config_suffix }} {{ components_names }})
               {%- for comp_variable_name, comp_target_name, cpp in components_cpp %}
@@ -131,16 +130,16 @@ class ConfigDataTemplate(CMakeDepsFileTemplate):
                       $<$<STREQUAL:$<TARGET_PROPERTY:TYPE>,MODULE_LIBRARY>{{ ':${' }}{{ pkg_name }}_{{ comp_variable_name }}_SHARED_LINK_FLAGS{{ config_suffix }}}>
                       $<$<STREQUAL:$<TARGET_PROPERTY:TYPE>,EXECUTABLE>{{ ':${' }}{{ pkg_name }}_{{ comp_variable_name }}_EXE_LINK_FLAGS{{ config_suffix }}}>
               )
-              {%- endfor %}
 
-              {%- endif %}
+
+              {%- endfor %}
           """)
         return ret
 
     def _get_global_cpp_cmake(self):
+        global_cppinfo = self.conanfile.cpp_info.aggregated_components()
         pfolder_var_name = "{}_PACKAGE_FOLDER{}".format(self.pkg_name, self.config_suffix)
-        return _TargetDataContext(self.conanfile.cpp_info, pfolder_var_name,
-                                  self.conanfile.package_folder)
+        return _TargetDataContext(global_cppinfo, pfolder_var_name, self.conanfile.package_folder)
 
     def _get_required_components_cpp(self):
         """Returns a list of (component_name, DepsCppCMake)"""

--- a/conans/test/integration/toolchains/cmake/cmakedeps/test_cmakedeps.py
+++ b/conans/test/integration/toolchains/cmake/cmakedeps/test_cmakedeps.py
@@ -117,9 +117,10 @@ def test_cpp_info_component_objects():
 
     with open(os.path.join(client.current_folder, "hello-release-x86_64-data.cmake")) as f:
         content = f.read()
-        # Not global variables
+        # https://github.com/conan-io/conan/issues/11862
+        # Global variables
         assert 'set(hello_OBJECTS_RELEASE "${hello_PACKAGE_FOLDER_RELEASE}/mycomponent.o")' \
-               not in content
+               in content
         # But component variables
         assert 'set(hello_hello_say_OBJECTS_RELEASE "${hello_PACKAGE_FOLDER_RELEASE}/' \
                'mycomponent.o")' in content

--- a/conans/test/unittests/tools/cmake/test_cmakedeps.py
+++ b/conans/test/unittests/tools/cmake/test_cmakedeps.py
@@ -82,11 +82,12 @@ def test_cpp_info_name_cmakedeps_components():
         cmakedeps = CMakeDeps(conanfile)
         files = cmakedeps.content
         assert "TARGET GlobalPkgName1::MySuperPkg1" in files["ComplexFileName1-Target-debug.cmake"]
-        # No global variables for the packages
+        # Global variables for the packages
+        # https://github.com/conan-io/conan/issues/11862
         assert 'set(OriginalDepName_INCLUDE_DIRS_DEBUG ' \
                '"${OriginalDepName_PACKAGE_FOLDER_DEBUG}/include")' \
-               not in files["ComplexFileName1-debug-x64-data.cmake"]
-        # But components
+               in files["ComplexFileName1-debug-x64-data.cmake"]
+        # AND components
         assert 'set(OriginalDepName_GlobalPkgName1_MySuperPkg1_INCLUDE_DIRS_DEBUG ' \
                '"${OriginalDepName_PACKAGE_FOLDER_DEBUG}/include")' \
                in files["ComplexFileName1-debug-x64-data.cmake"]


### PR DESCRIPTION
Changelog: Fix: CMakeDeps now generates CMake variables as `XXX_INCLUDE_DIR` in the `XXXX-data.cmake` for the global cpp_info even if components are declared in the recipe. It is obtained by merging the components `cpp_info` into a global one.
Docs: omit


Closes: https://github.com/conan-io/conan/issues/11862
