### PR TITLE
Fixed cmake_paths to set the root of the packages 

### DIFF
--- a/conans/client/generators/cmake_paths.py
+++ b/conans/client/generators/cmake_paths.py
@@ -1,6 +1,5 @@
 from conans.client.generators.cmake import DepsCppCmake
 from conans.model import Generator
-import filecmp
 
 
 class CMakePathsGenerator(Generator):

--- a/conans/client/generators/cmake_paths.py
+++ b/conans/client/generators/cmake_paths.py
@@ -1,5 +1,6 @@
 from conans.client.generators.cmake import DepsCppCmake
 from conans.model import Generator
+import filecmp
 
 
 class CMakePathsGenerator(Generator):
@@ -15,10 +16,12 @@ class CMakePathsGenerator(Generator):
         # The CONAN_XXX_ROOT variables are needed because the FindXXX.cmake or XXXConfig.cmake
         # in a package could have been "patched" with the `cmake.patch_config_paths()`
         # replacing absolute paths with CONAN_XXX_ROOT variables.
+        var_names = []
         for _, dep_cpp_info in self.deps_build_info.dependencies:
             var_name = "CONAN_{}_ROOT".format(dep_cpp_info.get_name(self.name).upper())
-            lines.append('set({} {})'.format(var_name, DepsCppCmake(dep_cpp_info,
-                                                                    self.name).rootpath))
+            rootpath = DepsCppCmake(dep_cpp_info, self.name).rootpath
+            lines.append('set({} {})'.format(var_name, rootpath))
+            var_names.append("${%s}" % var_name)
 
         # We want to prioritize the FindXXX.cmake files:
         # 1. First the files found in the packages
@@ -26,10 +29,11 @@ class CMakePathsGenerator(Generator):
         # 3. The "install_folder" ones, in case there is no FindXXX.cmake, try with the install dir
         #    if the user used the "cmake_find_package" will find the auto-generated
         # 4. The CMake installation dir/Modules ones.
+        var_names = " ".join(var_names)
         deps = DepsCppCmake(self.deps_build_info, self.name)
-        lines.append("set(CMAKE_MODULE_PATH {deps.build_paths} ${{CMAKE_MODULE_PATH}} "
-                     "${{CMAKE_CURRENT_LIST_DIR}})".format(deps=deps))
-        lines.append("set(CMAKE_PREFIX_PATH {deps.build_paths} ${{CMAKE_PREFIX_PATH}} "
-                     "${{CMAKE_CURRENT_LIST_DIR}})".format(deps=deps))
+        lines.append("set(CMAKE_MODULE_PATH {deps.build_paths} {var_names} ${{CMAKE_MODULE_PATH}} "
+                     "${{CMAKE_CURRENT_LIST_DIR}})".format(deps=deps, var_names=var_names))
+        lines.append("set(CMAKE_PREFIX_PATH {deps.build_paths} {var_names} ${{CMAKE_PREFIX_PATH}} "
+                     "${{CMAKE_CURRENT_LIST_DIR}})".format(deps=deps, var_names=var_names))
 
         return "\n".join(lines)

--- a/conans/test/functional/generators/cmake_paths_test.py
+++ b/conans/test/functional/generators/cmake_paths_test.py
@@ -25,12 +25,16 @@ class CMakePathsGeneratorTest(unittest.TestCase):
         expected = 'set(CONAN_LIB2_ROOT "{pfolder2}")\r\n' \
                    'set(CONAN_LIB1_ROOT "{pfolder1}")\r\n' \
                    'set(CMAKE_MODULE_PATH "{pfolder2}/"\r\n\t\t\t"{pfolder1}/" ' \
+                   '{root_folders_variables} ' \
                    '${{CMAKE_MODULE_PATH}} ${{CMAKE_CURRENT_LIST_DIR}})\r\n' \
                    'set(CMAKE_PREFIX_PATH "{pfolder2}/"\r\n\t\t\t"{pfolder1}/" ' \
+                   '{root_folders_variables} ' \
                    '${{CMAKE_PREFIX_PATH}} ${{CMAKE_CURRENT_LIST_DIR}})'
         if platform.system() != "Windows":
             expected = expected.replace("\r", "")
-        self.assertEqual(expected.format(pfolder1=pfolder1, pfolder2=pfolder2), contents)
+        root_folders_variables = '${CONAN_LIB2_ROOT} ${CONAN_LIB1_ROOT}'
+        self.assertEqual(expected.format(pfolder1=pfolder1, pfolder2=pfolder2,
+                                         root_folders_variables=root_folders_variables), contents)
 
     def test_cmake_paths_integration(self):
         """First package with own findHello0.cmake file"""

--- a/conans/test/unittests/client/generators/cmake_paths_test.py
+++ b/conans/test/unittests/client/generators/cmake_paths_test.py
@@ -52,9 +52,9 @@ class CMakePathsGeneratorTest(unittest.TestCase):
         custom_dir = custom_dir.replace('\\', '/')
         cmake_lines = generator.content.replace('\\', '/').replace("\n\t\t\t", " ").splitlines()
         self.assertEqual('set(CONAN_MYLIB_ROOT "%s")' % path, cmake_lines[0])
-        self.assertEqual('set(CMAKE_MODULE_PATH "%s/" "%s" ${CMAKE_MODULE_PATH} '
+        self.assertEqual('set(CMAKE_MODULE_PATH "%s/" "%s" ${CONAN_MYLIB_ROOT} ${CMAKE_MODULE_PATH} '
                          '${CMAKE_CURRENT_LIST_DIR})' % (path, custom_dir), cmake_lines[1])
-        self.assertEqual('set(CMAKE_PREFIX_PATH "%s/" "%s" ${CMAKE_PREFIX_PATH} '
+        self.assertEqual('set(CMAKE_PREFIX_PATH "%s/" "%s" ${CONAN_MYLIB_ROOT} ${CMAKE_PREFIX_PATH} '
                          '${CMAKE_CURRENT_LIST_DIR})' % (path, custom_dir), cmake_lines[2])
 
     def test_cpp_info_name(self):


### PR DESCRIPTION
Changelog: Bugfix: Fixed the `cmake_paths`generator to set the root of the packages to the `CMAKE_MODULE_PATH` and `CMAKE_PREFIX_PATH`
Docs: omit

Close https://github.com/conan-io/conan/issues/11870