### PR TITLE
implement cmake_layout(build_folder)

### DIFF
--- a/conan/tools/cmake/layout.py
+++ b/conan/tools/cmake/layout.py
@@ -3,7 +3,7 @@ import os
 from conans.errors import ConanException
 
 
-def cmake_layout(conanfile, generator=None, src_folder="."):
+def cmake_layout(conanfile, generator=None, src_folder=".", build_folder="build"):
     gen = conanfile.conf.get("tools.cmake.cmaketoolchain:generator", default=generator)
     if gen:
         multi = "Visual" in gen or "Xcode" in gen or "Multi-Config" in gen
@@ -21,7 +21,7 @@ def cmake_layout(conanfile, generator=None, src_folder="."):
     except ConanException:
         raise ConanException("'build_type' setting not defined, it is necessary for cmake_layout()")
 
-    build_folder = "build" if not subproject else os.path.join(subproject, "build")
+    build_folder = build_folder if not subproject else os.path.join(subproject, build_folder)
     custom_conf = get_build_folder_custom_vars(conanfile)
     if custom_conf:
         build_folder = os.path.join(build_folder, custom_conf)

--- a/conans/test/functional/layout/test_build_system_layout_helpers.py
+++ b/conans/test/functional/layout/test_build_system_layout_helpers.py
@@ -276,3 +276,22 @@ def test_basic_layout_no_external_sources(with_build_type):
     assert contents == "exported_contents"
     client.run("export-pkg . foo/1.0@ --force")
     assert "Packaged 1 '.txt' file: build.txt" in client.out
+
+
+def test_cmake_layout_custom_build_folder():
+    # https://github.com/conan-io/conan/issues/11838
+    conanfile = textwrap.dedent("""
+        from conan import ConanFile
+        from conan.tools.cmake import cmake_layout
+        class Pkg(ConanFile):
+            settings = "os", "build_type"
+            generators = "CMakeToolchain"
+            def layout(self):
+                cmake_layout(self, src_folder="src", build_folder="mybuild")
+        """)
+
+    client = TestClient()
+    client.save({"conanfile.py": conanfile})
+    client.run("install .")
+    assert os.path.exists(os.path.join(client.current_folder,
+                                       "mybuild/generators/conan_toolchain.cmake"))


### PR DESCRIPTION
Changelog: Feature: Implement ``cmake_layout(..., build_folder="build)`` build folder argument.
Docs: https://github.com/conan-io/docs/pull/2715

Close https://github.com/conan-io/conan/issues/11838
