### PR TITLE
Prevent None folders to be processed in the package_info.

### DIFF
--- a/conans/model/build_info.py
+++ b/conans/model/build_info.py
@@ -144,7 +144,7 @@ class _CppInfo(object):
 
     def _filter_paths(self, paths):
         abs_paths = [os.path.join(self.rootpath, p)
-                     if not os.path.isabs(p) else p for p in paths]
+                     if not os.path.isabs(p) else p for p in paths if p is not None]
         if self.filter_empty:
             return [p for p in abs_paths if os.path.isdir(p)]
         else:

--- a/conans/test/integration/generators/package_info/package_info_test.py
+++ b/conans/test/integration/generators/package_info/package_info_test.py
@@ -504,3 +504,15 @@ class HelloConan(ConanFile):
         self.assertIn("conanfile.py (pkg/1.0): GTEST_INFO: GTest", client.out)
         self.assertIn("conanfile.py (pkg/1.0): GTEST_FILEINFO: GtesT", client.out)
 
+    def test_none_folders(self):
+        # https://github.com/conan-io/conan/issues/11856
+        client = TestClient()
+        conanfile = textwrap.dedent("""
+            from conan import ConanFile
+            class pkgConan(ConanFile):
+                def package_info(self):
+                    self.cpp_info.resdirs = [None]
+            """)
+        client.save({"conanfile.py": conanfile})
+        client.run("create . pkg/1.0@")
+        assert "Created package revision" in client.out


### PR DESCRIPTION
Changelog: Fix: Prevent `None` folders to be processed in the `cpp_info`.
Docs: omit

Closes: https://github.com/conan-io/conan/issues/11856