### PR TITLE
Public import is_apple_os

### DIFF
--- a/conan/tools/apple/__init__.py
+++ b/conan/tools/apple/__init__.py
@@ -1,11 +1,10 @@
 # Keep everything private until we review what is really needed and refactor passing "conanfile"
 # from conan.tools.apple.apple import XCRun
 # from conan.tools.apple.apple import apple_dot_clean
-# from conan.tools.apple.apple import is_apple_os
 # from conan.tools.apple.apple import apple_sdk_name
 # from conan.tools.apple.apple import apple_deployment_target_flag
 # from conan.tools.apple.apple import to_apple_arch
-from conan.tools.apple.apple import fix_apple_shared_install_name
+from conan.tools.apple.apple import fix_apple_shared_install_name, is_apple_os
 from conan.tools.apple.xcodedeps import XcodeDeps
 from conan.tools.apple.xcodebuild import XcodeBuild
 from conan.tools.apple.xcodetoolchain import XcodeToolchain

--- a/conan/tools/apple/apple.py
+++ b/conan/tools/apple/apple.py
@@ -5,8 +5,9 @@ import os
 from conans.util.runners import check_output_runner
 
 
-def is_apple_os(os_):
+def is_apple_os(conanfile):
     """returns True if OS is Apple one (Macos, iOS, watchOS or tvOS"""
+    os_ = conanfile.settings.get_safe("os")
     return str(os_) in ['Macos', 'iOS', 'watchOS', 'tvOS']
 
 
@@ -176,7 +177,7 @@ def fix_apple_shared_install_name(conanfile):
 
     substitutions = {}
 
-    if is_apple_os(conanfile.settings.get_safe("os")) and conanfile.options.get_safe("shared", False):
+    if is_apple_os(conanfile) and conanfile.options.get_safe("shared", False):
         libdirs = getattr(conanfile.cpp.package, "libdirs")
         for libdir in libdirs:
             full_folder = os.path.join(conanfile.package_folder, libdir)

--- a/conan/tools/cmake/toolchain/blocks.py
+++ b/conan/tools/cmake/toolchain/blocks.py
@@ -402,7 +402,7 @@ class AppleSystemBlock(Block):
 
     def context(self):
         os_ = self._conanfile.settings.get_safe("os")
-        if not is_apple_os(os_):
+        if not is_apple_os(self._conanfile):
             return None
 
         arch = self._conanfile.settings.get_safe("arch")
@@ -522,7 +522,7 @@ class FindFiles(Block):
             find_package_prefer_config = "OFF"
 
         os_ = self._conanfile.settings.get_safe("os")
-        is_apple_ = is_apple_os(os_)
+        is_apple_ = is_apple_os(self._conanfile)
 
         # Read information from host context
         host_req = self._conanfile.dependencies.host.values()

--- a/conan/tools/files/files.py
+++ b/conan/tools/files/files.py
@@ -15,7 +15,6 @@ from urllib.parse import urlparse
 from urllib.request import url2pathname
 
 from conan.tools import CONAN_TOOLCHAIN_ARGS_FILE, CONAN_TOOLCHAIN_ARGS_SECTION
-from conan.tools.apple.apple import is_apple_os
 from conans.client.downloaders.download import run_downloader
 from conans.errors import ConanException
 from conans.util.files import rmdir as _internal_rmdir

--- a/conan/tools/gnu/autotoolstoolchain.py
+++ b/conan/tools/gnu/autotoolstoolchain.py
@@ -2,7 +2,7 @@ from conan.tools._check_build_profile import check_using_build_profile
 from conan.tools._compilers import architecture_flag, build_type_flags, cppstd_flag, \
     build_type_link_flags
 from conan.tools.apple.apple import apple_min_version_flag, to_apple_arch, \
-    apple_sdk_path, is_apple_os
+    apple_sdk_path
 from conan.tools.build.cross_building import cross_building, get_cross_building_settings
 from conan.tools.env import Environment
 from conan.tools.files.files import save_toolchain_args

--- a/conan/tools/gnu/gnudeps_flags.py
+++ b/conan/tools/gnu/gnudeps_flags.py
@@ -46,7 +46,7 @@ class GnuDepsFlags(object):
         or an empty array, if Apple Frameworks aren't supported by the given compiler
         """
         os_ = self._conanfile.settings.get_safe("os")
-        if not frameworks or not is_apple_os(os_):
+        if not frameworks or not is_apple_os(self._conanfile):
             return []
         compiler = self._conanfile.settings.get_safe("compiler")
         if str(compiler) not in self._GCC_LIKE:

--- a/conan/tools/meson/toolchain.py
+++ b/conan/tools/meson/toolchain.py
@@ -87,7 +87,7 @@ class MesonToolchain(object):
     def __init__(self, conanfile, backend=None):
         self._conanfile = conanfile
         self._os = self._conanfile.settings.get_safe("os")
-        self._is_apple_system = is_apple_os(self._os)
+        self._is_apple_system = is_apple_os(self._conanfile)
 
         # Values are kept as Python built-ins so users can modify them more easily, and they are
         # only converted to Meson file syntax for rendering
@@ -147,7 +147,7 @@ class MesonToolchain(object):
                 os_target = settings_target.get_safe("os")
                 arch_target = settings_target.get_safe("arch")
                 self.cross_build["target"] = to_meson_machine(os_target, arch_target)
-            if is_apple_os(os_host):  # default cross-compiler in Apple is common
+            if is_apple_os(self._conanfile):  # default cross-compiler in Apple is common
                 default_comp = "clang"
                 default_comp_cpp = "clang++"
         else:

--- a/conans/test/unittests/tools/gnu/gnudepsflags_test.py
+++ b/conans/test/unittests/tools/gnu/gnudepsflags_test.py
@@ -26,7 +26,7 @@ def test_framework_flags_only_for_apple_os(os_):
     gnudepsflags = GnuDepsFlags(conanfile, cpp_info)
     expected_framework = []
     expected_framework_path = []
-    if is_apple_os(os_):
+    if is_apple_os(conanfile):
         expected_framework = ["-framework Foundation"]
         expected_framework_path = ["-F Framework"]
     assert gnudepsflags.frameworks == expected_framework


### PR DESCRIPTION
Changelog: Fix: The tool `is_apple_os` can be imported from `conan.tools.apple` and receives an instance of `Conanfile`.
Docs: https://github.com/conan-io/docs/pull/2703


Close https://github.com/conan-io/conan/issues/11894