### PR TITLE
Fix require_overrides for virtual packages

### DIFF
--- a/conans/client/graph/graph_manager.py
+++ b/conans/client/graph/graph_manager.py
@@ -151,7 +151,8 @@ class GraphManager(object):
         profile_host.dev_reference = create_reference  # Make sure the created one has develop=True
 
         if isinstance(reference, list):  # Install workspace with multiple root nodes
-            conanfile = self._loader.load_virtual(reference, profile_host, scope_options=False)
+            conanfile = self._loader.load_virtual(reference, profile_host, scope_options=False,
+                                                  require_overrides=require_overrides)
             # Locking in workspaces not implemented yet
             return Node(ref=None, context=CONTEXT_HOST, conanfile=conanfile, recipe=RECIPE_VIRTUAL)
 


### PR DESCRIPTION
Changelog: Bugfix: Workspaces with multiple root nodes did not respect require_overrides, but now they are passed correctly


- [ ] Refer to the issue that supports this Pull Request.
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 

When testing my custom workspace functionality, I noticed that the `require_overrides` were not passed along, which seems like a mistake, since it's passed with all other types of root packages. So this fixes that.
