### PR TITLE
Add export_conandata_patches utility

### DIFF
--- a/conan/tools/files/__init__.py
+++ b/conan/tools/files/__init__.py
@@ -1,7 +1,7 @@
 from conan.tools.files.files import load, save, mkdir, rmdir, rm, ftp_download, download, get, \
     rename, chdir, unzip, replace_in_file, collect_libs, check_md5, check_sha1, check_sha256
 
-from conan.tools.files.patches import patch, apply_conandata_patches
+from conan.tools.files.patches import patch, apply_conandata_patches, export_conandata_patches
 from conan.tools.files.cpp_package import CppPackage
 from conan.tools.files.packager import AutoPackager
 from conan.tools.files.symlinks import symlinks

--- a/conan/tools/files/patches.py
+++ b/conan/tools/files/patches.py
@@ -118,3 +118,27 @@ def apply_conandata_patches(conanfile):
         else:
             raise ConanException("The 'conandata.yml' file needs a 'patch_file' or 'patch_string'"
                                  " entry for every patch to be applied")
+
+
+def export_conandata_patches(conanfile):
+    """
+    Exports patches stored in 'conanfile.conan_data' (read from 'conandata.yml' file). It will export
+    all the patches under 'patches' entry that matches the given 'conanfile.version'. If versions are
+    not defined in 'conandata.yml' it will export all the patches directly under 'patches' keyword.
+    """
+
+    patches = conanfile.conan_data.get('patches')
+
+    if isinstance(patches, dict):
+        assert conanfile.version, "Can only be exported if conanfile.version is already defined"
+        entries = patches.get(conanfile.version, [])
+    elif isinstance(patches, Iterable):
+        entries = patches
+    else:
+        return
+    for it in entries:
+        if "patch_file" in it:
+            # The patch files are located in the root src
+            entry = it.copy()
+            patch_file = os.path.join(conanfile.folders.base_source, entry.pop("patch_file"))
+            conanfile.copy(patch_file)

--- a/conan/tools/files/patches.py
+++ b/conan/tools/files/patches.py
@@ -99,7 +99,8 @@ def apply_conandata_patches(conanfile):
 
     patches = conanfile.conan_data.get('patches')
     if patches is None:
-        raise ConanException("No patches defined in conandata")
+        conanfile.output.info("apply_conandata_patches(): No patches defined in conandata")
+        return
 
     if isinstance(patches, dict):
         assert conanfile.version, "Can only be applied if conanfile.version is already defined"
@@ -132,7 +133,8 @@ def export_conandata_patches(conanfile):
 
     patches = conanfile.conan_data.get('patches')
     if patches is None:
-        raise ConanException("No patches defined in conandata")
+        conanfile.output.info("export_conandata_patches(): No patches defined in conandata")
+        return
 
     if isinstance(patches, dict):
         assert conanfile.version, "Can only be exported if conanfile.version is already defined"

--- a/conan/tools/files/patches.py
+++ b/conan/tools/files/patches.py
@@ -98,7 +98,7 @@ def apply_conandata_patches(conanfile):
         raise ConanException("conandata.yml not defined")
 
     patches = conanfile.conan_data.get('patches')
-    if not patches:
+    if patches is None:
         raise ConanException("No patches defined in conandata")
 
     if isinstance(patches, dict):
@@ -131,7 +131,7 @@ def export_conandata_patches(conanfile):
         raise ConanException("conandata.yml not defined")
 
     patches = conanfile.conan_data.get('patches')
-    if not patches:
+    if patches is None:
         raise ConanException("No patches defined in conandata")
 
     if isinstance(patches, dict):

--- a/conan/tools/files/patches.py
+++ b/conan/tools/files/patches.py
@@ -1,7 +1,7 @@
 import logging
 import os
 
-import patch_ng
+import patch_ng, copy
 
 from conans.errors import ConanException
 
@@ -141,4 +141,4 @@ def export_conandata_patches(conanfile):
             # The patch files are located in the root src
             entry = it.copy()
             patch_file = os.path.join(conanfile.folders.base_source, entry.pop("patch_file"))
-            conanfile.copy(patch_file)
+            copy(conanfile, patch_file, conanfile.recipe_folder, conanfile.export_sources_folder)

--- a/conans/test/functional/layout/test_exports_sources.py
+++ b/conans/test/functional/layout/test_exports_sources.py
@@ -5,7 +5,7 @@ from conans.test.utils.tools import TestClient
 
 def test_exports_sources_patch():
     """
-    tests that using ``self.base_source_folder`` we can access both from the source() and build()
+    tests that using ``self.export_sources_folder`` we can access both from the source() and build()
     methods the folder where the exported sources (patches, new build files) are. And maintain
     a local flow without exports copies
     """

--- a/conans/test/functional/test_third_party_patch_flow.py
+++ b/conans/test/functional/test_third_party_patch_flow.py
@@ -43,6 +43,10 @@ def test_third_party_patch_flow():
     client.save({"conanfile.py": conanfile,
                  "conandata.yml": ""})
     client.run("install .")
+    client.run("source .", assert_error=True)
+    assert "No patches defined in conandata" in client.out
+
+    client.save({"conandata.yml": "patches: {}"})
     client.run("source .")
     client.run("build .", assert_error=True)
     assert "MISTAKE1 BUILD!" in client.out

--- a/conans/test/functional/test_third_party_patch_flow.py
+++ b/conans/test/functional/test_third_party_patch_flow.py
@@ -43,8 +43,8 @@ def test_third_party_patch_flow():
     client.save({"conanfile.py": conanfile,
                  "conandata.yml": ""})
     client.run("install .")
-    client.run("source .", assert_error=True)
-    assert "No patches defined in conandata" in client.out
+    client.run("source .")
+    assert "apply_conandata_patches(): No patches defined in conandata" in client.out
 
     client.save({"conandata.yml": "patches: {}"})
     client.run("source .")

--- a/conans/test/functional/tools/test_files.py
+++ b/conans/test/functional/tools/test_files.py
@@ -374,11 +374,12 @@ def test_export_conandata_patches(mock_patch_ng):
     # Empty conandata
     client.save({"conandata.yml": ""})
     client.run("create .", assert_error=True)
-    assert "No patches defined in conandata"
+    assert "export_conandata_patches(): No patches defined in conandata" in client.out
+    assert "ERROR: mypkg/1.0: Error in source() method, line 18" in client.out
     # wrong patches
     client.save({"conandata.yml": "patches: 123"})
     client.run("create .", assert_error=True)
-    assert "conandata.yml 'patches' should be a list or a dict"
+    assert "conandata.yml 'patches' should be a list or a dict"  in client.out
 
     # No patch found
     client.save({"conandata.yml": conandata_yml})

--- a/conans/test/functional/tools/test_files.py
+++ b/conans/test/functional/tools/test_files.py
@@ -389,3 +389,12 @@ def test_export_conandata_patches(mock_patch_ng):
     client.save({"patches/mypatch.patch": "mypatch!!!"})
     client.run("create .")
     assert "mypkg/1.0: mypatch!!!" in client.out
+
+    conandata_yml = textwrap.dedent("""
+        patches:
+            "1.0":
+                - patch_file: "patches/mypatch.patch"
+    """)
+    client.save({"conandata.yml": conandata_yml})
+    client.run("create .")
+    assert "mypkg/1.0: mypatch!!!" in client.out

--- a/conans/test/functional/tools/test_files.py
+++ b/conans/test/functional/tools/test_files.py
@@ -340,3 +340,28 @@ def test_relate_base_path_all_versions(mock_patch_ng):
 
     assert mock_patch_ng.apply_args[0].endswith(os.path.join('source_subfolder', "relative_dir"))
     assert mock_patch_ng.apply_args[1:] == (0, False)
+
+def test_export_conandata_patches(mock_patch_ng):
+    conanfile = textwrap.dedent("""
+        from conans import ConanFile
+        from conan.tools.files import export_conandata_patches, get
+
+        class Pkg(ConanFile):
+            name = "mypkg"
+            version = "1.0"
+
+            def layout(self):
+                self.folders.source = "source_subfolder"
+
+            def export_sources(self):
+                export_conandata_patches(self)
+        """)
+    conandata_yml = textwrap.dedent("""
+        patches:
+          - patch_file: "patches/0001-buildflatbuffers-cmake.patch"
+            base_path: "relative_dir"
+    """)
+
+    client = TestClient()
+    client.save({"conanfile.py": conanfile})
+    client.run("create .")

--- a/conans/test/functional/tools/test_files.py
+++ b/conans/test/functional/tools/test_files.py
@@ -341,10 +341,12 @@ def test_relate_base_path_all_versions(mock_patch_ng):
     assert mock_patch_ng.apply_args[0].endswith(os.path.join('source_subfolder', "relative_dir"))
     assert mock_patch_ng.apply_args[1:] == (0, False)
 
+
 def test_export_conandata_patches(mock_patch_ng):
     conanfile = textwrap.dedent("""
-        from conans import ConanFile
-        from conan.tools.files import export_conandata_patches, get
+        import os
+        from conan import ConanFile
+        from conan.tools.files import export_conandata_patches, load
 
         class Pkg(ConanFile):
             name = "mypkg"
@@ -355,13 +357,34 @@ def test_export_conandata_patches(mock_patch_ng):
 
             def export_sources(self):
                 export_conandata_patches(self)
+
+            def source(self):
+                self.output.info(load(self, os.path.join(self.export_sources_folder,
+                                                         "patches/mypatch.patch")))
         """)
     conandata_yml = textwrap.dedent("""
         patches:
-          - patch_file: "patches/0001-buildflatbuffers-cmake.patch"
-            base_path: "relative_dir"
+          - patch_file: "patches/mypatch.patch"
     """)
 
     client = TestClient()
     client.save({"conanfile.py": conanfile})
+    client.run("create .", assert_error=True)
+    assert "conandata.yml not defined" in client.out
+    # Empty conandata
+    client.save({"conandata.yml": ""})
+    client.run("create .", assert_error=True)
+    assert "No patches defined in conandata"
+    # wrong patches
+    client.save({"conandata.yml": "patches: 123"})
+    client.run("create .", assert_error=True)
+    assert "conandata.yml 'patches' should be a list or a dict"
+
+    # No patch found
+    client.save({"conandata.yml": conandata_yml})
+    client.run("create .", assert_error=True)
+    assert "No such file or directory" in client.out
+
+    client.save({"patches/mypatch.patch": "mypatch!!!"})
     client.run("create .")
+    assert "mypkg/1.0: mypatch!!!" in client.out


### PR DESCRIPTION
Changelog: Feature: Add `export_conandata_patches` tool.
Docs: https://github.com/conan-io/docs/pull/2720

Closes: https://github.com/conan-io/conan/issues/11770
Closes: https://github.com/conan-io/conan/issues/11923

This issue has no test because I didn't managed to make it work but you can see this as a quick proposal before going further in the implementation.

- [ ] Refer to the issue that supports this Pull Request.
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 

<sup>**Note:** By default this PR will skip the slower tests and will use a limited set of python versions. Check [here](https://github.com/conan-io/conan/blob/develop/.github/PR_INCREASE_TESTING.md) how to increase the testing level by writing some tags in the current PR body text.</sup>
