### PR TITLE
[Meson] Removing reconfigure from Meson.install()

### DIFF
--- a/conan/tools/meson/meson.py
+++ b/conan/tools/meson/meson.py
@@ -48,7 +48,6 @@ class Meson(object):
         self._conanfile.run(cmd)
 
     def install(self):
-        self.configure(reconfigure=True)  # To re-do the destination package-folder
         meson_build_folder = self._conanfile.build_folder
         cmd = 'meson install -C "{}"'.format(meson_build_folder)
         self._conanfile.run(cmd)

--- a/conan/tools/meson/meson.py
+++ b/conan/tools/meson/meson.py
@@ -20,43 +20,46 @@ class Meson(object):
         has_deps_flags = os.path.exists(deps_flags)
 
         if os.path.exists(cross):
-            cmd += ' --cross-file "{}"'.format(cross)
+            cmd += f' --cross-file "{cross}"'
             if has_deps_flags:
-                cmd += ' --cross-file "{}"'.format(deps_flags)
+                cmd += f' --cross-file "{deps_flags}"'
         else:
-            cmd += ' --native-file "{}"'.format(native)
+            cmd += f' --native-file "{native}"'
             if has_deps_flags:
-                cmd += ' --native-file "{}"'.format(deps_flags)
+                cmd += f' --native-file "{deps_flags}"'
 
-        cmd += ' "{}" "{}"'.format(build_folder, source_folder)
+        cmd += f' "{build_folder}" "{source_folder}"'
         if self._conanfile.package_folder:
-            cmd += ' -Dprefix="{}"'.format(self._conanfile.package_folder)
+            cmd += f' -Dprefix="{self._conanfile.package_folder}"'
         if reconfigure:
-            cmd += ' --reconfigure'
-        self._conanfile.output.info("Meson configure cmd: {}".format(cmd))
+            cmd += f' --reconfigure'
+        self._conanfile.output.info(f"Meson configure cmd: {cmd}")
         self._conanfile.run(cmd)
 
     def build(self, target=None):
         meson_build_folder = self._conanfile.build_folder
-        cmd = 'meson compile -C "{}"'.format(meson_build_folder)
+        cmd = f'meson compile -C "{meson_build_folder}"'
         njobs = build_jobs(self._conanfile)
         if njobs:
-            cmd += " -j{}".format(njobs)
+            cmd += f" -j{njobs}"
         if target:
-            cmd += " {}".format(target)
-        self._conanfile.output.info("Meson build cmd: {}".format(cmd))
+            cmd += f" {target}"
+        self._conanfile.output.info(f"Meson build cmd: {cmd}")
         self._conanfile.run(cmd)
 
     def install(self):
+        # To re-do the destination package-folder
+        if self._conanfile.package_folder:
+            self._conanfile.run(f"meson configure --prefix {self._conanfile.package_folder}")
         meson_build_folder = self._conanfile.build_folder
-        cmd = 'meson install -C "{}"'.format(meson_build_folder)
+        cmd = f'meson install -C "{meson_build_folder}"'
         self._conanfile.run(cmd)
 
     def test(self):
         if self._conanfile.conf.get("tools.build:skip_test"):
             return
         meson_build_folder = self._conanfile.build_folder
-        cmd = 'meson test -v -C "{}"'.format(meson_build_folder)
+        cmd = f'meson test -v -C "{meson_build_folder}"'
         # TODO: Do we need vcvars for test?
         # TODO: This should use conanrunenv, but what if meson itself is a build-require?
         self._conanfile.run(cmd)

--- a/conan/tools/meson/meson.py
+++ b/conan/tools/meson/meson.py
@@ -50,7 +50,7 @@ class Meson(object):
     def install(self):
         # To fix the destination package-folder
         if self._conanfile.package_folder:
-            cmd = f'meson configure --prefix "{self._conanfile.package_folder}"'
+            cmd = f'meson configure "{self._conanfile.build_folder}" -Dprefix="{self._conanfile.package_folder}"'
             self._conanfile.run(cmd)
             self._conanfile.output.info(f"Meson configure (prefix) cmd: {cmd}")
         meson_build_folder = self._conanfile.build_folder

--- a/conan/tools/meson/meson.py
+++ b/conan/tools/meson/meson.py
@@ -48,9 +48,11 @@ class Meson(object):
         self._conanfile.run(cmd)
 
     def install(self):
-        # To re-do the destination package-folder
+        # To fix the destination package-folder
         if self._conanfile.package_folder:
-            self._conanfile.run(f"meson configure --prefix {self._conanfile.package_folder}")
+            cmd = f'meson configure --prefix "{self._conanfile.package_folder}"'
+            self._conanfile.run(cmd)
+            self._conanfile.output.info(f"Meson configure (prefix) cmd: {cmd}")
         meson_build_folder = self._conanfile.build_folder
         cmd = f'meson install -C "{meson_build_folder}"'
         self._conanfile.run(cmd)

--- a/conans/test/conftest.py
+++ b/conans/test/conftest.py
@@ -34,6 +34,7 @@ tools_locations = {
 }
 """
 
+MacOS_M1 = all([platform.system() == "Darwin", platform.machine() == "arm64"])
 
 tools_locations = {
     "clang": {"disabled": True},
@@ -47,7 +48,9 @@ tools_locations = {
         "0.28": {
             "path": {
                 # Using chocolatey in Windows -> choco install pkgconfiglite --version 0.28
-                'Windows': "C:/ProgramData/chocolatey/lib/pkgconfiglite/tools/pkg-config-lite-0.28-1/bin"
+                'Windows': "C:/ProgramData/chocolatey/lib/pkgconfiglite/tools/pkg-config-lite-0.28-1/bin",
+                'Darwin': "/opt/homebrew/bin/pkg-config" if MacOS_M1 else "/usr/local/bin/pkg-config",
+                'Linux': "/usr/bin/pkg-config"
             }
         }},
     'autotools': {"exe": "autoconf"},
@@ -174,7 +177,7 @@ try:
 except ImportError as e:
     user_tool_locations = None
 
-if platform.machine() == "arm64":
+if MacOS_M1:
     android_ndk_path = "/opt/homebrew/share/android-ndk"
 else:
     android_ndk_path = "/usr/local/share/android-ndk"


### PR DESCRIPTION
Changelog: Feature: Removed opt-out `meson.configure(reconfigure=True)` from `Meson.install()` function. Now, it only configures the `prefix` path without reconfiguring.
Changelog: Bugfix: Added the `pkg-config` paths for MacOS and Linux in `conftest.py`.
Closes: https://github.com/conan-io/conan/issues/11910
Docs: https://github.com/conan-io/docs/pull/XXXX