### PR TITLE
Expose additional args when calling Git.clone()

### DIFF
--- a/conan/tools/scm/git.py
+++ b/conan/tools/scm/git.py
@@ -76,7 +76,8 @@ class Git(object):
         folder = self._run("rev-parse --show-toplevel")
         return folder.replace("\\", "/")
 
-    def clone(self, url, target="", args=[]):
+    def clone(self, url, target="", args=None):
+        args = args or []
         if os.path.exists(url):
             url = url.replace("\\", "/")  # Windows local directory
         mkdir(self.folder)

--- a/conan/tools/scm/git.py
+++ b/conan/tools/scm/git.py
@@ -76,12 +76,12 @@ class Git(object):
         folder = self._run("rev-parse --show-toplevel")
         return folder.replace("\\", "/")
 
-    def clone(self, url, target=""):
+    def clone(self, url, target="", args=[]):
         if os.path.exists(url):
             url = url.replace("\\", "/")  # Windows local directory
         mkdir(self.folder)
         self._conanfile.output.info("Cloning git repo")
-        self._run('clone "{}" {}'.format(url, target))
+        self._run('clone "{}" {} {}'.format(url, " ".join(args), target))
 
     def checkout(self, commit):
         self._conanfile.output.info("Checkout: {}".format(commit))


### PR DESCRIPTION
Changelog: Feature: Add ability to pass additional arguments to `conan.tools.scm.Git.clone()`.
Docs: https://github.com/conan-io/docs/pull/2721

As a way of addressing: https://github.com/conan-io/conan/issues/11797 

This PR exposes an `args` parameter when calling `Git.clone()`, so that we can forward additional parameters to the git command - thus enabling more advanced behaviours than cloning the default branch.

This can satisfy the issue in #11797 (by passing e.g. by passing `['--depth', '1']`). I believe the most common case when building recipes that clone from a git repository is to want to have it set to a specific commit (branch or tag). Some repositories take considerable time to clone, so the ability to tweak the `git clone` wall to make it as quick as possible seems like a good feature to have.

I'm unsure as to whether to expose a specific parameter for a shallow clone, what should it be called? `tools.Git()` had a `shallow=True/False`, but other git wrappers for Python have a specific `depth` argument, which may match more closely. And if we were to do that, why not others that also control likely toggles, like the submodule recursive (or not) clone behaviour. Exposing an args argument could be a good compromise to cover these cases.