### PR TITLE
Make conan_version public under conan as a Version object

### DIFF
--- a/conan/__init__.py
+++ b/conan/__init__.py
@@ -1,1 +1,6 @@
 from conans.model.conan_file import ConanFile
+from conan.tools.scm import Version
+from conans import __version__
+
+
+conan_version = Version(__version__)

--- a/conans/test/integration/tools/conan_version_test.py
+++ b/conans/test/integration/tools/conan_version_test.py
@@ -1,0 +1,26 @@
+import textwrap
+
+from conans.test.utils.tools import TestClient
+from conans import __version__
+
+
+def test_conan_version():
+
+    conanfile = textwrap.dedent("""
+        from conan import ConanFile
+        from conan import conan_version
+        from conan.tools.scm import Version
+        from conans import __version__
+
+        class pkg(ConanFile):
+
+            def generate(self):
+                assert __version__ == str(conan_version)
+                assert isinstance(conan_version, Version)
+                print(f"current version: {conan_version}")
+        """)
+
+    client = TestClient()
+    client.save({"conanfile.py": conanfile})
+    client.run("install .")
+    assert f"current version: {__version__}" in client.out


### PR DESCRIPTION
Changelog: Feature: Make the version of the Conan client available under `conan` and make it a `Version` object so it can be compared.
Docs: https://github.com/conan-io/docs/pull/2719

Closes: https://github.com/conan-io/conan/issues/11760
