### PR TITLE
[AutotoolsDeps] Allow passing filename to the linker if cpp_info spec…

### DIFF
--- a/conan/tools/gnu/gnudeps_flags.py
+++ b/conan/tools/gnu/gnudeps_flags.py
@@ -81,7 +81,8 @@ class GnuDepsFlags(object):
                     library += ".lib"
                 result.append(library)
             else:
-                result.append("-l%s" % library)
+                namespec = f":{library}" if any(x in library for x in [".a", ".so"]) else library
+                result.append("-l%s" % namespec)
         return result
 
     def _adjust_path(self, path):

--- a/conans/test/functional/toolchains/gnu/autotools/test_basic.py
+++ b/conans/test/functional/toolchains/gnu/autotools/test_basic.py
@@ -16,10 +16,17 @@ from conans.util.files import touch
 
 
 @pytest.mark.skipif(platform.system() not in ["Linux", "Darwin"], reason="Requires Autotools")
+@pytest.mark.parametrize("lib_with_extension", 
+                        [pytest.param(True, marks=pytest.mark.skipif(platform.system() == "Darwin", reason="macos linker")),
+                        False])
 @pytest.mark.tool_autotools()
-def test_autotools():
+def test_autotools(lib_with_extension):
     client = TestClient(path_with_spaces=False)
     client.run("new hello/0.1 --template=cmake_lib")
+    if lib_with_extension:
+        conanfile_hello = client.load("conanfile.py")
+        conanfile_hello = conanfile_hello.replace('["hello"]', '["libhello.a"]')
+        client.save({"conanfile.py": conanfile_hello})
     client.run("create .")
 
     main = gen_function_cpp(name="main", includes=["hello"], calls=["hello"])

--- a/conans/test/integration/toolchains/gnu/test_autotoolsdeps.py
+++ b/conans/test/integration/toolchains/gnu/test_autotoolsdeps.py
@@ -59,7 +59,7 @@ def test_link_cppinfo_libs_with_filename():
     client.run("create libhello.py -ohello:my_option=archive")
     client.run("create libhello.py -ohello:my_option=just_lib")
 
-    client.run("install conanfile.txt -g AutotoolsDeps -ohello:my_option=shared_object")
+    client.run("install conanfile.txt -g AutotoolsDeps -ohello*:my_option=shared_object")
     deps_file = client.load("conanautotoolsdeps.sh")
     assert "-l:libhello.so -l:libz.so" in deps_file
 

--- a/conans/test/integration/toolchains/gnu/test_autotoolsdeps.py
+++ b/conans/test/integration/toolchains/gnu/test_autotoolsdeps.py
@@ -55,7 +55,7 @@ def test_link_cppinfo_libs_with_filename():
 
     client = TestClient()
     client.save({"libhello.py": libhello, "conanfile.txt": conanfile_consumer})
-    client.run("create libhello.py -ohello:my_option=shared_object")
+    client.run("create libhello.py -ohello*:my_option=shared_object")
     client.run("create libhello.py -ohello:my_option=archive")
     client.run("create libhello.py -ohello:my_option=just_lib")
 

--- a/conans/test/integration/toolchains/gnu/test_autotoolsdeps.py
+++ b/conans/test/integration/toolchains/gnu/test_autotoolsdeps.py
@@ -39,10 +39,13 @@ def test_link_cppinfo_libs_with_filename():
         def package_info(self):
             if self.options.my_option == "shared_object":
                 self.cpp_info.libs = ["libhello.so"]
+                self.cpp_info.system_libs = ["libz.so"]
             elif self.options.my_option == "archive":
                 self.cpp_info.libs = ["libhello.a"]
+                self.cpp_info.system_libs = ["libz.a"]
             else:
                 self.cpp_info.libs = ["hello"]
+                self.cpp_info.system_libs = ["z"]
     """)
 
     conanfile_consumer = textwrap.dedent("""
@@ -58,15 +61,15 @@ def test_link_cppinfo_libs_with_filename():
 
     client.run("install conanfile.txt -g AutotoolsDeps -ohello:my_option=shared_object")
     deps_file = client.load("conanautotoolsdeps.sh")
-    assert "-l:libhello.so" in deps_file
+    assert "-l:libhello.so -l:libz.so" in deps_file
 
     client.run("install conanfile.txt -g AutotoolsDeps -ohello:my_option=archive")
     deps_file = client.load("conanautotoolsdeps.sh")
-    assert "-l:libhello.a" in deps_file
+    assert "-l:libhello.a -l:libz.a" in deps_file
 
     client.run("install conanfile.txt -g AutotoolsDeps -ohello:my_option=just_lib")
     deps_file = client.load("conanautotoolsdeps.sh")
-    assert "-lhello" in deps_file   
+    assert "-lhello -lz" in deps_file   
 
 
 @pytest.mark.skipif(platform.system() not in ["Linux", "Darwin"], reason="Autotools")

--- a/conans/test/integration/toolchains/gnu/test_autotoolsdeps.py
+++ b/conans/test/integration/toolchains/gnu/test_autotoolsdeps.py
@@ -56,18 +56,18 @@ def test_link_cppinfo_libs_with_filename():
     client = TestClient()
     client.save({"libhello.py": libhello, "conanfile.txt": conanfile_consumer})
     client.run("create libhello.py -ohello*:my_option=shared_object")
-    client.run("create libhello.py -ohello:my_option=archive")
-    client.run("create libhello.py -ohello:my_option=just_lib")
+    client.run("create libhello.py -ohello*:my_option=archive")
+    client.run("create libhello.py -ohello*:my_option=just_lib")
 
     client.run("install conanfile.txt -g AutotoolsDeps -ohello*:my_option=shared_object")
     deps_file = client.load("conanautotoolsdeps.sh")
     assert "-l:libhello.so -l:libz.so" in deps_file
 
-    client.run("install conanfile.txt -g AutotoolsDeps -ohello:my_option=archive")
+    client.run("install conanfile.txt -g AutotoolsDeps -ohello*:my_option=archive")
     deps_file = client.load("conanautotoolsdeps.sh")
     assert "-l:libhello.a -l:libz.a" in deps_file
 
-    client.run("install conanfile.txt -g AutotoolsDeps -ohello:my_option=just_lib")
+    client.run("install conanfile.txt -g AutotoolsDeps -ohello*:my_option=just_lib")
     deps_file = client.load("conanautotoolsdeps.sh")
     assert "-lhello -lz" in deps_file   
 


### PR DESCRIPTION
Changelog: Feature: Allow passing filename to the linker on Unix systems for libraries in `cpp_info` where a file extension (`.a`, `.so`) is specified.
Docs: TODO

Closes https://github.com/conan-io/conan/issues/11703


On Unix-like systems where the `-l` linker flags assumes a name without the `lib` prefix or a file extension, the linker will follow its own rules to locate the library in the library search directories. On Linux (and according to the documentation, systems that support ELF shared libraries), shared libraries will be searched first. 

For libraries defined in `self.cpp_info.libs` we assume the name passed is without a prefix or extension, and pass that directly as an `-l` flag. 

The current behaviour should cover most cases, especially if libraries follow the practice of _not_ including both shared and static variants of the library (which is the case in Conan Center).

However, in the issue described in https://github.com/conan-io/conan/issues/11703, one may be specifying a "system library", for which the two variants may exist (`.a` and `.so`). In case we prefer the static one, we have a few options:
1) Passing the full path at link time (no flags)
2) Pass `-Bstatic` to the linker right before the `-l` flag, and revert it back to its default (`-Bdynamic`) afterwards. 
3) Use the `-l:` notation, documented [here](https://linux.die.net/man/1/ld):
```
           Add the archive or object file specified by namespec to the
           list of files to link.  This option may be used any number of
           times.  If namespec is of the form :filename, ld will search
           the library path for a file called filename, otherwise it
           will search the library path for a file called libnamespec.a.
```

I have verified that GNU linker (bfd), gold, and mold all accept this notation.

Notably, the default linker on macOS does *not* accept this notation - it always favours shared libraries and does not allow specifying the filename with the `:` notation, nor the `-Bstatic`/`-Bdynamic` flags.
