### PR TITLE
allow traits in self.requires() for 2.0 compatibility

### DIFF
--- a/conans/model/requires.py
+++ b/conans/model/requires.py
@@ -180,7 +180,7 @@ class Requirements(OrderedDict):
             new_reqs[name] = req
         return new_reqs
 
-    def __call__(self, reference, private=False, override=False):
+    def __call__(self, reference, private=False, override=False, **kwargs):
         self.add(reference, private, override)
 
     def __repr__(self):

--- a/conans/test/integration/conan_v2/test_requires_traits.py
+++ b/conans/test/integration/conan_v2/test_requires_traits.py
@@ -1,0 +1,24 @@
+import textwrap
+
+from conans.test.assets.genconanfile import GenConanfile
+from conans.test.utils.tools import TestClient
+
+
+def test_requires_traits():
+    """ traits can be passed to self.requires(), but:
+    - They have absolutely no effect
+    - They are not checked to be correct or match expected 2.0 traits
+    """
+    c = TestClient()
+    conanfile = textwrap.dedent("""
+        from conan import ConanFile
+        class Pkg(ConanFile):
+            def requirements(self):
+                self.requires("dep/1.0", transitive_headers=True)
+        """)
+    c.save({"dep/conanfile.py": GenConanfile("dep", "1.0"),
+            "consumer/conanfile.py": conanfile})
+    c.run("create dep")
+    # This should not crash
+    c.run("install consumer")
+    assert "dep/1.0" in c.out


### PR DESCRIPTION
Changelog: Feature: Allow traits in `self.requires()` for 2.0 compatibility.
Docs: https://github.com/conan-io/docs/pull/2714

Close https://github.com/conan-io/conan/issues/11927
