### PR TITLE
Support remotes.json in 1.X

### DIFF
--- a/conans/client/conf/config_installer.py
+++ b/conans/client/conf/config_installer.py
@@ -139,23 +139,10 @@ def _process_folder(config, folder, cache, output):
     if config.source_folder:
         folder = os.path.join(folder, config.source_folder)
 
-    all_filenames = []
-    walk_result = []
-
     for root, dirs, files in walk(folder):
         dirs[:] = [d for d in dirs if d != ".git"]
         for f in files:
-            all_filenames.append(f)
-            walk_result.append((root, f, folder))
-
-    # FIXME: remove in Conan 2.0
-    if "remotes.json" in all_filenames and "remotes.txt" in all_filenames:
-        raise ConanException(
-            "'remotes.txt' and 'remotes.json' are not supported at the same time. "
-            "Please remove one of them and try to 'config install' again")
-
-    for root, f, folder in walk_result:
-        _process_file(root, f, config, cache, output, folder)
+            _process_file(root, f, config, cache, output, folder)
 
 
 def _process_download(config, cache, output, requester):

--- a/conans/test/functional/command/config_install_test.py
+++ b/conans/test/functional/command/config_install_test.py
@@ -350,12 +350,14 @@ class Pkg(ConanFile):
             repotxt2 https://repotxt2.com True
         """)
 
-        # remotes.txt and json not allowed at the same time
+        # remotes.txt and json try to define both the remotes,
+        # could lead to unpredictable results
         save_files(folder, {"remotes.json": remotes_json,
                             "remotes.txt": remotes_txt})
 
-        self.client.run(f'config install "{folder}"', assert_error=True)
-        assert "'remotes.txt' and 'remotes.json' are not supported at the same time." in self.client.out
+        self.client.run(f'config install "{folder}"')
+        assert "Defining remotes from remotes.json" in self.client.out
+        assert "Defining remotes from remotes.txt" in self.client.out
 
         # If there's only a remotes.txt it's the one installed
         folder = temp_folder()

--- a/conans/test/functional/command/config_install_test.py
+++ b/conans/test/functional/command/config_install_test.py
@@ -333,13 +333,54 @@ class Pkg(ConanFile):
         self.client.run("remote list")
         self.assertEqual("conan.io: https://server.conan.io [Verify SSL: True]\n", self.client.out)
 
-    def test_install_remotes_json_error(self):
+    def test_install_remotes_json(self):
         folder = temp_folder()
-        save_files(folder, {"remotes.json": ""})
-        self.client.run('config install "%s"' % folder, assert_error=True)
-        self.assertIn("ERROR: Failed conan config install: "
-                      "remotes.json install is not supported yet. Use 'remotes.txt'",
-                      self.client.out)
+
+        remotes_json = textwrap.dedent("""
+            {
+                "remotes": [
+                    { "name": "repojson1", "url": "https://repojson1.net", "verify_ssl": false },
+                    { "name": "repojson2", "url": "https://repojson2.com", "verify_ssl": true }
+                ]
+            }
+        """)
+
+        remotes_txt = textwrap.dedent("""\
+            repotxt1 https://repotxt1.net False
+            repotxt2 https://repotxt2.com True
+        """)
+
+        # remotes.txt and json not allowed at the same time
+        save_files(folder, {"remotes.json": remotes_json,
+                            "remotes.txt": remotes_txt})
+
+        self.client.run(f'config install "{folder}"', assert_error=True)
+        assert "'remotes.txt' and 'remotes.json' are not supported at the same time." in self.client.out
+
+        # If there's only a remotes.txt it's the one installed
+        folder = temp_folder()
+        save_files(folder, {"remotes.txt": remotes_txt})
+
+        self.client.run(f'config install "{folder}"')
+
+        assert "Defining remotes from remotes.txt" in self.client.out
+
+        self.client.run('remote list')
+
+        assert "repotxt1: https://repotxt1.net [Verify SSL: False]" in self.client.out
+        assert "repotxt2: https://repotxt2.com [Verify SSL: True]" in self.client.out
+
+        # If there's only a remotes.json it's the one installed
+        folder = temp_folder()
+        save_files(folder, {"remotes.json": remotes_json})
+
+        self.client.run(f'config install "{folder}"')
+        assert "Defining remotes from remotes.json" in self.client.out
+
+        self.client.run('remote list')
+
+        assert "repojson1: https://repojson1.net [Verify SSL: False]" in self.client.out
+        assert "repojson2: https://repojson2.com [Verify SSL: True]" in self.client.out
 
     def test_without_profile_folder(self):
         shutil.rmtree(self.client.cache.profiles_path)


### PR DESCRIPTION
Changelog: Feature: Support remotes.json in Conan 1.X.
Docs: https://github.com/conan-io/docs/pull/2718

Closes: https://github.com/conan-io/conan/issues/11777

**Important:** we should **clearly** document for this that if you have both txt and json in the folder, repo, etc. that you are config installing from, it can have undefined behaviour as the order of the install is not deterministic. One time the txt could prevail and others the json...
