### PR TITLE
add targets to MSBuild

### DIFF
--- a/conan/tools/microsoft/msbuild.py
+++ b/conan/tools/microsoft/msbuild.py
@@ -28,7 +28,7 @@ class MSBuild(object):
             msvc_arch = conanfile.settings.get_safe("os.platform")
         self.platform = msvc_arch
 
-    def command(self, sln):
+    def command(self, sln, targets=None):
         cmd = ('msbuild "%s" /p:Configuration=%s /p:Platform=%s'
                % (sln, self.build_type, self.platform))
 
@@ -41,10 +41,15 @@ class MSBuild(object):
         if maxcpucount:
             cmd += " /m:{}".format(maxcpucount)
 
+        if targets:
+            if not isinstance(targets, list):
+                raise ConanException("targets argument should be a list")
+            cmd += " /target:{}".format(";".join(targets))
+
         return cmd
 
-    def build(self, sln):
-        cmd = self.command(sln)
+    def build(self, sln, targets=None):
+        cmd = self.command(sln, targets=targets)
         self._conanfile.run(cmd)
 
     @staticmethod

--- a/conans/test/unittests/tools/microsoft/test_msbuild.py
+++ b/conans/test/unittests/tools/microsoft/test_msbuild.py
@@ -13,6 +13,23 @@ from conans.tools import load
 from conans import ConanFile, Settings
 
 
+def test_msbuild_targets():
+    c = ConfDefinition()
+    settings = MockSettings({"build_type": "Release",
+                             "compiler": "gcc",
+                             "compiler.version": "7",
+                             "os": "Linux",
+                             "arch": "x86_64"})
+    conanfile = ConanFileMock()
+    conanfile.settings = settings
+    conanfile.conf = c.get_conanfile_conf(None)
+
+    msbuild = MSBuild(conanfile)
+    cmd = msbuild.command('project.sln', targets=["static", "shared"])
+
+    assert '/target:static;shared' in cmd
+
+
 def test_msbuild_cpu_count():
     c = ConfDefinition()
     c.loads(textwrap.dedent("""\


### PR DESCRIPTION
Changelog:  Feature: Add ``MSBuild().build(.., targets=["target1"])`` argument to new ``MSBuild``.
Docs: https://github.com/conan-io/docs/pull/2724

Close https://github.com/conan-io/conan/issues/11966
