### PR TITLE
[bugfix] Environment shell script path is now formatted based on the subsystem

### DIFF
--- a/conans/client/subsystems.py
+++ b/conans/client/subsystems.py
@@ -72,6 +72,7 @@ def _windows_bash_wrapper(conanfile, command, env, envfiles_folder):
     # Wrapping the inside_command enable to prioritize our environment, otherwise /usr/bin go
     # first and there could be commands that we want to skip
     wrapped_user_cmd = environment_wrap_command(env, envfiles_folder, command,
+                                                subsystem=subsystem,
                                                 accepted_extensions=("sh", ))
     wrapped_user_cmd = _escape_windows_cmd(wrapped_user_cmd)
 


### PR DESCRIPTION
The shell script for the environments should be formatted based on the subsystem now.

Fixes #11980

Changelog: (Bugfix): Environment shell script path is now formatted based on the subsystem
Docs: https://github.com/conan-io/docs/pull/XXXX

- [X] Refer to the issue that supports this Pull Request.
- [ ] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [X] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [X] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 

<sup>**Note:** By default this PR will skip the slower tests and will use a limited set of python versions. Check [here](https://github.com/conan-io/conan/blob/develop/.github/PR_INCREASE_TESTING.md) how to increase the testing level by writing some tags in the current PR body text.</sup>
