### PR TITLE
Ensure that msys2 bin dir is on PATH for bash

### DIFF
--- a/conans/client/subsystems.py
+++ b/conans/client/subsystems.py
@@ -61,6 +61,7 @@ def _windows_bash_wrapper(conanfile, command, env, envfiles_folder):
         _msystem = {"x86": "MINGW32"}.get(conanfile.settings.get_safe("arch"), "MINGW64")
         msys2_mode_env.define("MSYSTEM", _msystem)
         msys2_mode_env.define("MSYS2_PATH_TYPE", "inherit")
+        msys2_mode_env.prepend_path("PATH", os.path.dirname(shell_path))
         path = os.path.join(conanfile.generators_folder, "msys2_mode.bat")
         msys2_mode_env.vars(conanfile, "build").save_bat(path)
         env.append(path)


### PR DESCRIPTION
This should prepend the root directory of msys bin dir, on which the bash.exe
is located, as well as tools such as `printenv`.

Fixes #11986

Changelog: (Bugfix): Ensure that msys2 bin dir is on PATH for bash
Docs: https://github.com/conan-io/docs/pull/XXXX

- [X] Refer to the issue that supports this Pull Request.
- [ ] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [X] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [X] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 

<sup>**Note:** By default this PR will skip the slower tests and will use a limited set of python versions. Check [here](https://github.com/conan-io/conan/blob/develop/.github/PR_INCREASE_TESTING.md) how to increase the testing level by writing some tags in the current PR body text.</sup>
