### PR TITLE
[bugfix] Fixed `compatibility` if `options` are used 

### DIFF
--- a/conans/client/graph/compatibility.py
+++ b/conans/client/graph/compatibility.py
@@ -27,6 +27,8 @@ class BinaryCompatibility:
                     compat_info.settings.update_values(settings)
                 options = elem.get("options")
                 if options:
-                    compat_info.options.update(options_values=OrderedDict(options))
+                    from conans.model.options import OptionsValues
+                    new_options = OptionsValues(options)
+                    compat_info.options.update(new_options)
                 result.append(compat_info)
         return result


### PR DESCRIPTION
Changelog: Bugfix: Fix conversion if `options` passed in `compatibility()` method.
Docs: https://github.com/conan-io/docs/pull/2727