### PR TITLE
CLICOLOR_FORCE support

### DIFF
--- a/conans/client/userio.py
+++ b/conans/client/userio.py
@@ -18,7 +18,15 @@ def color_enabled(stream):
     Command-line software which adds ANSI color to its output by default should check for the
     presence of a NO_COLOR environment variable that, when present (**regardless of its value**),
     prevents the addition of ANSI color.
+
+    CLICOLOR_FORCE: Force color
+
+    https://bixense.com/clicolors/
     """
+    if os.getenv("CLICOLOR_FORCE", "0") != "0":
+        # CLICOLOR_FORCE != 0, ANSI colors should be enabled no matter what.
+        return True
+
     from conan.api.output import conan_output_logger_format
     if conan_output_logger_format:
         return False

--- a/conans/client/userio.py
+++ b/conans/client/userio.py
@@ -23,13 +23,15 @@ def color_enabled(stream):
 
     https://bixense.com/clicolors/
     """
-    if os.getenv("CLICOLOR_FORCE", "0") != "0":
-        # CLICOLOR_FORCE != 0, ANSI colors should be enabled no matter what.
-        return True
 
     from conan.api.output import conan_output_logger_format
     if conan_output_logger_format:
         return False
+
+    if os.getenv("CLICOLOR_FORCE", "0") != "0":
+        # CLICOLOR_FORCE != 0, ANSI colors should be enabled no matter what.
+        return True
+
     if os.getenv("NO_COLOR") is not None:
         return False
     return is_terminal(stream)

--- a/conans/test/unittests/client/conan_output_test.py
+++ b/conans/test/unittests/client/conan_output_test.py
@@ -37,3 +37,17 @@ def test_output_forced(force):
             assert out.color is forced
             if not forced:
                 init.assert_not_called()
+
+
+def test_output_forced_but_conan_logger():
+    """ If conan is logging, no colors can be forced"""
+    env = {"CLICOLOR_FORCE": "1"}
+    with mock.patch("conan.api.output.conan_output_logger_format", return_value=True):
+        with mock.patch("colorama.init") as init:
+            with mock.patch("sys.stderr.isatty", return_value=False), \
+                 mock.patch.dict("os.environ", env, clear=True):
+                init_colorama(sys.stderr)
+                out = ConanOutput()
+
+                assert out.color is False
+                init.assert_not_called()

--- a/conans/test/unittests/client/conan_output_test.py
+++ b/conans/test/unittests/client/conan_output_test.py
@@ -3,6 +3,7 @@ import sys
 import unittest
 from unittest import mock
 
+import pytest
 from parameterized import parameterized
 
 from conan.api.output import ConanOutput
@@ -20,4 +21,19 @@ class ConanOutputTest(unittest.TestCase):
                 init_colorama(sys.stderr)
                 out = ConanOutput()
                 assert out.color is False
+                init.assert_not_called()
+
+
+@pytest.mark.parametrize("force", ["1", "0", "foo"])
+def test_output_forced(force):
+    env = {"CLICOLOR_FORCE": force}
+    forced = force != "0"
+    with mock.patch("colorama.init") as init:
+        with mock.patch("sys.stderr.isatty", return_value=False), \
+             mock.patch.dict("os.environ", env, clear=True):
+            init_colorama(sys.stderr)
+            out = ConanOutput()
+
+            assert out.color is forced
+            if not forced:
                 init.assert_not_called()


### PR DESCRIPTION
Changelog: Feature: Added support for `CLICOLOR_FORCE` env var, that will activate the colors in the output if the value is declared and different to `0`.
Docs: https://github.com/conan-io/docs/pull/XXXX


Close https://github.com/conan-io/conan/issues/11892