### PR TITLE
Test check_min_cppstd and validate_build

### DIFF
--- a/conans/test/integration/tools/cppstd_minimum_version_test.py
+++ b/conans/test/integration/tools/cppstd_minimum_version_test.py
@@ -49,3 +49,28 @@ class CppStdMinimumVersionTests(unittest.TestCase):
         self.client.run("create . --user=user --channel=channel -pr myprofile", assert_error=True)
         self.assertIn("Invalid: Current cppstd (%s) is lower than the required C++ standard (17)."
                       % cppstd, self.client.out)
+
+
+def test_header_only_check_min_cppstd():
+
+    conanfile = dedent("""
+        import os
+        from conan import ConanFile
+        from conan.tools.build import check_min_cppstd, valid_min_cppstd
+
+        class Fake(ConanFile):
+            name = "fake"
+            version = "0.1"
+            settings = "compiler"
+            def package_id(self):
+                self.info.clear()
+            def validate(self):
+                check_min_cppstd(self, "11")
+            def compatibility(self):
+                check_min_cppstd(self, "11")
+        """)
+    client = TestClient()
+    client.save({"conanfile.py": conanfile})
+    client.run("create .")
+    client.run("install fake/0.1@ -s compiler.cppstd=14")
+    print(client.out)

--- a/conans/test/integration/tools/cppstd_minimum_version_test.py
+++ b/conans/test/integration/tools/cppstd_minimum_version_test.py
@@ -71,6 +71,6 @@ def test_header_only_check_min_cppstd():
         """)
     client = TestClient()
     client.save({"conanfile.py": conanfile})
-    client.run("create .")
-    client.run("install fake/0.1@ -s compiler.cppstd=14")
+    client.run("create . -s compiler.cppstd=11")
+    client.run("install --require=fake/0.1@ -s compiler.cppstd=14")
     print(client.out)

--- a/conans/test/integration/tools/cppstd_minimum_version_test.py
+++ b/conans/test/integration/tools/cppstd_minimum_version_test.py
@@ -59,7 +59,7 @@ def test_header_only_check_min_cppstd():
     conanfile = dedent("""
         import os
         from conan import ConanFile
-        from conan.tools.build import check_min_cppstd, valid_min_cppstd
+        from conan.tools.build import check_min_cppstd
 
         class Fake(ConanFile):
             name = "fake"
@@ -85,7 +85,7 @@ def test_validate_build_check_min_cppstd():
     conanfile = dedent("""
         import os
         from conan import ConanFile
-        from conan.tools.build import check_min_cppstd, valid_min_cppstd
+        from conan.tools.build import check_min_cppstd
 
         class Fake(ConanFile):
             name = "fake"

--- a/conans/test/integration/tools/cppstd_minimum_version_test.py
+++ b/conans/test/integration/tools/cppstd_minimum_version_test.py
@@ -65,7 +65,8 @@ def test_header_only_check_min_cppstd():
             def package_id(self):
                 self.info.clear()
             def validate(self):
-                check_min_cppstd(self, "11")
+                if self.info.settings.compiler.cppstd:
+                    check_min_cppstd(self, "11")
             def compatibility(self):
                 check_min_cppstd(self, "11")
         """)


### PR DESCRIPTION
Add test for two cases:
- header only packages that don't have self.info but can check the min cppstd in the validate() method without failing
- packages that need a certain cppstd to build but can be consumed without setting the cppstd because they could have a pure C interface for example 

Related to: https://github.com/conan-io/conan/issues/11786

