### PR TITLE
validate_build with compatible packages not raising the ConanInvalidConfiguration error

### DIFF
--- a/conans/client/graph/graph_binaries.py
+++ b/conans/client/graph/graph_binaries.py
@@ -236,11 +236,10 @@ class GraphBinariesAnalyzer(object):
                             break
                     if node.binary == BINARY_MISSING and node.package_id == PACKAGE_ID_INVALID:
                         node.binary = BINARY_INVALID
-                if node.binary == BINARY_MISSING and build_mode.allowed(node.conanfile):
-                    if node.cant_build:
-                        node.binary = BINARY_INVALID
-                    else:
-                        node.binary = BINARY_BUILD
+                if node.cant_build:
+                    node.binary = BINARY_INVALID
+                elif node.binary == BINARY_MISSING and build_mode.allowed(node.conanfile):
+                    node.binary = BINARY_BUILD
 
             if locked:
                 # package_id was not locked, this means a base lockfile that is being completed

--- a/conans/test/integration/tools/cppstd_minimum_version_test.py
+++ b/conans/test/integration/tools/cppstd_minimum_version_test.py
@@ -49,29 +49,3 @@ class CppStdMinimumVersionTests(unittest.TestCase):
         self.client.run("create . user/channel -pr myprofile", assert_error=True)
         self.assertIn("Invalid configuration: Current cppstd (%s) is lower than the required C++ "
                       "standard (17)." % cppstd, self.client.out)
-
-
-def test_header_only_check_min_cppstd():
-
-    conanfile = dedent("""
-        import os
-        from conan import ConanFile
-        from conan.tools.build import check_min_cppstd, valid_min_cppstd
-
-        class Fake(ConanFile):
-            name = "fake"
-            version = "0.1"
-            settings = "compiler"
-            def package_id(self):
-                self.info.clear()
-            def validate(self):
-                if self.info.settings.compiler.cppstd:
-                    check_min_cppstd(self, "11")
-            def compatibility(self):
-                check_min_cppstd(self, "11")
-        """)
-    client = TestClient()
-    client.save({"conanfile.py": conanfile})
-    client.run("create . -s compiler.cppstd=11")
-    client.run("install fake/0.1@ -s compiler.cppstd=14")
-    print(client.out)

--- a/conans/test/integration/tools/cppstd_minimum_version_test.py
+++ b/conans/test/integration/tools/cppstd_minimum_version_test.py
@@ -49,3 +49,29 @@ class CppStdMinimumVersionTests(unittest.TestCase):
         self.client.run("create . user/channel -pr myprofile", assert_error=True)
         self.assertIn("Invalid configuration: Current cppstd (%s) is lower than the required C++ "
                       "standard (17)." % cppstd, self.client.out)
+
+
+def test_header_only_check_min_cppstd():
+
+    conanfile = dedent("""
+        import os
+        from conan import ConanFile
+        from conan.tools.build import check_min_cppstd, valid_min_cppstd
+
+        class Fake(ConanFile):
+            name = "fake"
+            version = "0.1"
+            settings = "compiler"
+            def package_id(self):
+                self.info.clear()
+            def validate(self):
+                if self.info.settings.compiler.cppstd:
+                    check_min_cppstd(self, "11")
+            def compatibility(self):
+                check_min_cppstd(self, "11")
+        """)
+    client = TestClient()
+    client.save({"conanfile.py": conanfile})
+    client.run("create . -s compiler.cppstd=11")
+    client.run("install fake/0.1@ -s compiler.cppstd=14")
+    print(client.out)


### PR DESCRIPTION
Changelog: Fix: Fix `validate_build` with compatible packages not raising the ConanInvalidConfiguration error.
Docs: https://github.com/conan-io/docs/pull/XXXX

In the process of testing something similar to this: https://github.com/conan-io/conan/pull/12031 on 1.X branch I noticed that when `validate_build` is used and there are some compatible packages it will fail with something like:

```
ERROR: Missing binary: fake/0.1:affba8ce0c5d515063c1e2327ab3378ecf5f1eda

fake/0.1: WARN: Can't find a 'fake/0.1' package for the specified settings, options and dependencies:
- Settings: compiler=apple-clang, compiler.libcxx=libc++, compiler.version=13
- Options: 
- Dependencies: 
- Requirements: 
- Package ID: affba8ce0c5d515063c1e2327ab3378ecf5f1eda

ERROR: Missing prebuilt package for 'fake/0.1'
Use 'conan search fake/0.1 --table=table.html -r=remote' and open the table.html file to see available packages
Or try to build locally from sources with '--build=fake'

More Info at 'https://docs.conan.io/en/latest/faq/troubleshooting.html#error-missing-prebuilt-package'
```

and not the expected error raised in the `validate_build()`

Related to: https://github.com/conan-io/conan/issues/11786
