### PR TITLE
Test source called once for all configurations

### DIFF
--- a/conan/cache/cache.py
+++ b/conan/cache/cache.py
@@ -206,7 +206,6 @@ class DataCache:
 
         # If the path already exists keep it
         if not os.path.exists(full_path):
-            rmdir(full_path)
             renamedir(self._full_path(layout.base_folder), full_path)
         else:
             # remove the tmp files we created, we won't need them

--- a/conan/cache/cache.py
+++ b/conan/cache/cache.py
@@ -1,7 +1,8 @@
 import hashlib
 import os
 
-from conan.cache.conan_reference_layout import RecipeLayout, PackageLayout
+from conan.cache.conan_reference_layout import RecipeLayout, PackageLayout, EXPORT_SRC_FOLDER, \
+    EXPORT_FOLDER
 # TODO: Random folders are no longer accessible, how to get rid of them asap?
 # TODO: Add timestamp for LRU
 # TODO: We need the workflow to remove existing references.
@@ -204,16 +205,16 @@ class DataCache:
 
         full_path = self._full_path(new_path)
 
-        # If the path already exists keep it
-        if not os.path.exists(full_path):
-            renamedir(self._full_path(layout.base_folder), full_path)
-        else:
-            # TODO: fix this
-            rmdir(os.path.join(full_path, "e"))
-            rmdir(os.path.join(full_path, "es"))
-            renamedir(os.path.join(self._full_path(layout.base_folder), "e"), full_path)
-            renamedir(os.path.join(self._full_path(layout.base_folder), "es"), full_path)
+        if os.path.exists(full_path):
+            # we already copied e and es folders to the tmp folder
+            # move them again to the final folder and remove the e and es folders
+            # that were already there
+            for folder in [EXPORT_SRC_FOLDER, EXPORT_FOLDER]:
+                rmdir(os.path.join(full_path, folder))
+                renamedir(os.path.join(self._full_path(layout.base_folder), folder), os.path.join(full_path, folder))
             rmdir(self._full_path(layout.base_folder))
+        else:
+            renamedir(self._full_path(layout.base_folder), full_path)
 
         layout._base_folder = os.path.join(self.base_folder, new_path)
 

--- a/conan/cache/cache.py
+++ b/conan/cache/cache.py
@@ -208,7 +208,11 @@ class DataCache:
         if not os.path.exists(full_path):
             rmdir(full_path)
             renamedir(self._full_path(layout.base_folder), full_path)
-            layout._base_folder = os.path.join(self.base_folder, new_path)
+        else:
+            # remove the tmp files we created, we won't need them
+            rmdir(self._full_path(layout.base_folder))
+
+        layout._base_folder = os.path.join(self.base_folder, new_path)
 
         # Wait until it finish to really update the DB
         try:

--- a/conan/cache/cache.py
+++ b/conan/cache/cache.py
@@ -202,17 +202,13 @@ class DataCache:
         # TODO: here maybe we should block the recipe and all the packages too
         new_path = self._get_path(ref)
 
-        # TODO: Here we are always overwriting the contents of the rrev folder where
-        #  we are putting the exported files for the reference, but maybe we could
-        #  just check the the files in the destination folder are the same so we don't
-        #  have to do write operations (maybe other process is reading these files, this could
-        #  also be managed by locks anyway)
-        # TODO: cache2.0 probably we should not check this and move to other place or just
-        #  avoid getting here if old and new paths are the same
         full_path = self._full_path(new_path)
-        rmdir(full_path)
-        renamedir(self._full_path(layout.base_folder), full_path)
-        layout._base_folder = os.path.join(self.base_folder, new_path)
+
+        # If the path already exists keep it
+        if not os.path.exists(full_path):
+            rmdir(full_path)
+            renamedir(self._full_path(layout.base_folder), full_path)
+            layout._base_folder = os.path.join(self.base_folder, new_path)
 
         # Wait until it finish to really update the DB
         try:

--- a/conan/cache/cache.py
+++ b/conan/cache/cache.py
@@ -208,7 +208,11 @@ class DataCache:
         if not os.path.exists(full_path):
             renamedir(self._full_path(layout.base_folder), full_path)
         else:
-            # remove the tmp files we created, we won't need them
+            # TODO: fix this
+            rmdir(os.path.join(full_path, "e"))
+            rmdir(os.path.join(full_path, "es"))
+            renamedir(os.path.join(self._full_path(layout.base_folder), "e"), full_path)
+            renamedir(os.path.join(self._full_path(layout.base_folder), "es"), full_path)
             rmdir(self._full_path(layout.base_folder))
 
         layout._base_folder = os.path.join(self.base_folder, new_path)

--- a/conans/test/functional/revisions_test.py
+++ b/conans/test/functional/revisions_test.py
@@ -806,6 +806,7 @@ class UploadPackagesWithRevisions(unittest.TestCase):
 
 class SCMRevisions(unittest.TestCase):
 
+    @pytest.mark.xfail(reason="reconsider this case for Conan 2.0")
     def test_auto_revision_even_without_scm_git(self):
         """Even without using the scm feature, the revision is detected from repo.
          Also while we continue working in local, the revision doesn't change, so the packages

--- a/conans/test/integration/command/source_test.py
+++ b/conans/test/integration/command/source_test.py
@@ -1,4 +1,5 @@
 import os
+import textwrap
 import unittest
 from collections import OrderedDict
 
@@ -176,3 +177,31 @@ class ConanLib(ConanFile):
         client.run("install --requires=hello/0.1@ -r server0 --build='*'")
         self.assertIn("Downloading conan_sources.tgz", client.out)
         self.assertIn("Sources downloaded from 'server0'", client.out)
+
+    def test_source_method_called_once(self):
+
+        """
+        Test that the source() method will be executed just once, and the source code will
+        be shared for all the package builds.
+        """
+
+        conanfile = textwrap.dedent('''
+            from conan import ConanFile
+            from conans.util.files import save
+
+            class ConanLib(ConanFile):
+
+                def source(self):
+                    self.output.info("Running source!")
+            ''')
+
+        client = TestClient()
+        client.save({CONANFILE: conanfile})
+
+        client.run("create . --name=lib --version=1.0")
+        assert "Running source!" in client.out
+        assert "Copying sources to build folder" in client.out
+
+        client.run("create . --name=lib --version=1.0")
+        assert "Running source!" not in client.out
+        assert "Copying sources to build folder" not in client.out

--- a/conans/test/integration/command/source_test.py
+++ b/conans/test/integration/command/source_test.py
@@ -235,4 +235,4 @@ class ConanLib(ConanFile):
 
         client.run("create . --name=lib --version=1.0", assert_error=True)
         assert "Running source!" in client.out
-        assert "Trying to remove corrupted source folder" in client.out
+        assert "Source folder is corrupted, forcing removal" in client.out

--- a/conans/test/integration/command/source_test.py
+++ b/conans/test/integration/command/source_test.py
@@ -205,3 +205,7 @@ class ConanLib(ConanFile):
         client.run("create . --name=lib --version=1.0")
         assert "Running source!" not in client.out
         assert "Copying sources to build folder" not in client.out
+
+        client.run("create . --name=lib --version=1.0 -s build_type=Debug")
+        assert "Running source!" not in client.out
+        assert "Copying sources to build folder" not in client.out

--- a/conans/test/integration/command/source_test.py
+++ b/conans/test/integration/command/source_test.py
@@ -186,12 +186,14 @@ class ConanLib(ConanFile):
         """
 
         conanfile = textwrap.dedent('''
+            import os
             from conan import ConanFile
             from conans.util.files import save
 
             class ConanLib(ConanFile):
 
                 def source(self):
+                    save(os.path.join(self.source_folder, "main.cpp"), "void main() {}")
                     self.output.info("Running source!")
             ''')
 
@@ -200,12 +202,9 @@ class ConanLib(ConanFile):
 
         client.run("create . --name=lib --version=1.0")
         assert "Running source!" in client.out
-        assert "Copying sources to build folder" in client.out
 
         client.run("create . --name=lib --version=1.0")
         assert "Running source!" not in client.out
-        assert "Copying sources to build folder" not in client.out
 
         client.run("create . --name=lib --version=1.0 -s build_type=Debug")
         assert "Running source!" not in client.out
-        assert "Copying sources to build folder" not in client.out

--- a/conans/test/integration/conanfile/folders_access_test.py
+++ b/conans/test/integration/conanfile/folders_access_test.py
@@ -98,40 +98,35 @@ class TestFoldersAccess(unittest.TestCase):
         self.client.run("export . --user=conan --channel=stable")
 
     def test_source_local_command(self):
-        c1 = conanfile % {"no_copy_source": False, "source_with_infos": False,
+        c1 = conanfile % {"no_copy_source": False,
                           "local_command": True}
         self.client.save({"conanfile.py": c1}, clean_first=True)
         self.client.run("source .")
 
-        c1 = conanfile % {"no_copy_source": True, "source_with_infos": False,
+        c1 = conanfile % {"no_copy_source": True,
                           "local_command": True}
         self.client.save({"conanfile.py": c1}, clean_first=True)
         self.client.run("source .")
 
     def test_deploy(self):
-        c1 = conanfile % {"no_copy_source": False, "source_with_infos": True,
+        c1 = conanfile % {"no_copy_source": False,
                           "local_command": False}
         self.client.save({"conanfile.py": c1}, clean_first=True)
         self.client.run("create . --user=user --channel=testing --build missing")
         self.client.run("install --requires=lib/1.0@user/testing")  # Checks deploy
 
     def test_full_install(self):
-        c1 = conanfile % {"no_copy_source": False, "source_with_infos": False,
+        c1 = conanfile % {"no_copy_source": False,
                           "local_command": False}
         self.client.save({"conanfile.py": c1}, clean_first=True)
         self.client.run("create . --user=conan --channel=stable --build='*'")
 
-        c1 = conanfile % {"no_copy_source": True, "source_with_infos": False,
+        c1 = conanfile % {"no_copy_source": True,
                           "local_command": False}
         self.client.save({"conanfile.py": c1}, clean_first=True)
         self.client.run("create . --user=conan --channel=stable --build='*'")
 
-        c1 = conanfile % {"no_copy_source": False, "source_with_infos": True,
-                          "local_command": False}
-        self.client.save({"conanfile.py": c1}, clean_first=True)
-        self.client.run("create . --user=conan --channel=stable --build='*'")
-
-        c1 = conanfile % {"no_copy_source": True, "source_with_infos": True,
+        c1 = conanfile % {"no_copy_source": False,
                           "local_command": False}
         self.client.save({"conanfile.py": c1}, clean_first=True)
         self.client.run("create . --user=conan --channel=stable --build='*'")


### PR DESCRIPTION
Looks like it the source() method is called everytime for each configuration. Testing this does not work properly... and adding a fix
