### PR TITLE
Update clang 16 cppstd to gnu17

### DIFF
--- a/conans/client/build/cppstd_flags.py
+++ b/conans/client/build/cppstd_flags.py
@@ -66,6 +66,8 @@ def cppstd_default(settings):
 
 
 def _clang_cppstd_default(compiler_version):
+    if Version(compiler_version) >= "16":
+        return "gnu17"
     # Official docs are wrong, in 6.0 the default is gnu14 to follow gcc's choice
     return "gnu98" if Version(compiler_version) < "6" else "gnu14"
 

--- a/conans/test/unittests/client/build/cpp_std_flags_test.py
+++ b/conans/test/unittests/client/build/cpp_std_flags_test.py
@@ -147,6 +147,10 @@ class CompilerFlagsTest(unittest.TestCase):
         self.assertEqual(_make_cppstd_default("clang", "10"), "gnu14")
         self.assertEqual(_make_cppstd_default("clang", "11"), "gnu14")
         self.assertEqual(_make_cppstd_default("clang", "12"), "gnu14")
+        self.assertEqual(_make_cppstd_default("clang", "13"), "gnu14")
+        self.assertEqual(_make_cppstd_default("clang", "14"), "gnu14")
+        self.assertEqual(_make_cppstd_default("clang", "15"), "gnu14")
+        self.assertEqual(_make_cppstd_default("clang", "16"), "gnu17")
 
     def test_apple_clang_cppstd_flags(self):
         self.assertEqual(_make_cppstd_flag("apple-clang", "3.9", "98"), None)


### PR DESCRIPTION
Changelog: Fix: Set gnu17 as clang 16 cppstd default.
Docs: omit
Closes: https://github.com/conan-io/conan/issues/12066