### PR TITLE
[develop2]fix aggregation of test trait in diamonds

### DIFF
--- a/conans/model/requires.py
+++ b/conans/model/requires.py
@@ -223,6 +223,8 @@ class Requirement:
         self.run = self.run or other.run
         self.visible |= other.visible
         self.force |= other.force
+        if not other.test:
+            self.test = False  # it it was previously a test, but also required by non-test
         # TODO: self.package_id_mode => Choose more restrictive?
 
     def transform_downstream(self, pkg_type, require, dep_pkg_type):


### PR DESCRIPTION
If there are diamonds in host context mixing test and non test requirements, the ``test=False`` should prevail, so filters like ``dependencies.host`` find it.
