### PR TITLE
[hotfix] CMakeToolchain.cache_variables should parse PackageOption

### DIFF
--- a/conan/tools/cmake/toolchain/toolchain.py
+++ b/conan/tools/cmake/toolchain/toolchain.py
@@ -186,6 +186,8 @@ class CMakeToolchain(object):
             elif isinstance(value, PackageOption):
                 if str(value).lower() in ["true", "false", "none"]:
                     cache_variables[name] = "ON" if bool(value) else "OFF"
+                elif str(value).isdigit():
+                    cache_variables[name] = int(value)
                 else:
                     cache_variables[name] = str(value)
             else:

--- a/conan/tools/cmake/toolchain/toolchain.py
+++ b/conan/tools/cmake/toolchain/toolchain.py
@@ -17,6 +17,7 @@ from conan.tools.intel import IntelCC
 from conan.tools.microsoft import VCVars
 from conan.tools.microsoft.visual import vs_ide_version
 from conans.errors import ConanException
+from conans.model.options import PackageOption
 from conans.util.files import save
 
 
@@ -182,6 +183,11 @@ class CMakeToolchain(object):
         for name, value in self.cache_variables.items():
             if isinstance(value, bool):
                 cache_variables[name] = "ON" if value else "OFF"
+            elif isinstance(value, PackageOption):
+                if str(value).lower() in ["true", "false", "none"]:
+                    cache_variables[name] = "ON" if bool(value) else "OFF"
+                else:
+                    cache_variables[name] = str(value)
             else:
                 cache_variables[name] = value
 

--- a/conans/test/integration/toolchains/cmake/test_cmaketoolchain.py
+++ b/conans/test/integration/toolchains/cmake/test_cmaketoolchain.py
@@ -452,8 +452,8 @@ def test_toolchain_cache_variables():
 
         class Conan(ConanFile):
             settings = "os", "arch", "compiler", "build_type"
-            options = {"enable_foobar": [True, False], "qux": ["ANY"]}
-            default_options = {"enable_foobar": True, "qux": "baz"}
+            options = {"enable_foobar": [True, False], "qux": ["ANY"], "number": [1,2]}
+            default_options = {"enable_foobar": True, "qux": "baz", "number": 1}
 
             def generate(self):
                 toolchain = CMakeToolchain(self)
@@ -462,6 +462,7 @@ def test_toolchain_cache_variables():
                 toolchain.cache_variables["var"] = "23"
                 toolchain.cache_variables["ENABLE_FOOBAR"] = self.options.enable_foobar
                 toolchain.cache_variables["QUX"] = self.options.qux
+                toolchain.cache_variables["NUMBER"] = self.options.number
                 toolchain.cache_variables["CMAKE_SH"] = "THIS VALUE HAS PRIORITY"
                 toolchain.cache_variables["CMAKE_POLICY_DEFAULT_CMP0091"] = "THIS VALUE HAS PRIORITY"
                 toolchain.cache_variables["CMAKE_MAKE_PROGRAM"] = "THIS VALUE HAS NO PRIORITY"
@@ -482,6 +483,7 @@ def test_toolchain_cache_variables():
     assert cache_variables["BUILD_TESTING"] == 'OFF'
     assert cache_variables["ENABLE_FOOBAR"] == 'ON'
     assert cache_variables["QUX"] == 'baz'
+    assert cache_variables["NUMBER"] == 1
 
 
 def test_android_c_library():

--- a/conans/test/integration/toolchains/cmake/test_cmaketoolchain.py
+++ b/conans/test/integration/toolchains/cmake/test_cmaketoolchain.py
@@ -447,17 +447,21 @@ def test_cmake_presets_singleconfig():
 def test_toolchain_cache_variables():
     client = TestClient()
     conanfile = textwrap.dedent("""
-        from conans import ConanFile
-        from conan.tools.cmake import CMakeToolchain, CMake
+        from conan import ConanFile
+        from conan.tools.cmake import CMakeToolchain
 
         class Conan(ConanFile):
             settings = "os", "arch", "compiler", "build_type"
+            options = {"enable_foobar": [True, False], "qux": ["ANY"]}
+            default_options = {"enable_foobar": True, "qux": "baz"}
 
             def generate(self):
                 toolchain = CMakeToolchain(self)
                 toolchain.cache_variables["foo"] = True
                 toolchain.cache_variables["foo2"] = False
                 toolchain.cache_variables["var"] = "23"
+                toolchain.cache_variables["ENABLE_FOOBAR"] = self.options.enable_foobar
+                toolchain.cache_variables["QUX"] = self.options.qux
                 toolchain.cache_variables["CMAKE_SH"] = "THIS VALUE HAS PRIORITY"
                 toolchain.cache_variables["CMAKE_POLICY_DEFAULT_CMP0091"] = "THIS VALUE HAS PRIORITY"
                 toolchain.cache_variables["CMAKE_MAKE_PROGRAM"] = "THIS VALUE HAS NO PRIORITY"
@@ -476,6 +480,8 @@ def test_toolchain_cache_variables():
     assert cache_variables["CMAKE_POLICY_DEFAULT_CMP0091"] == "THIS VALUE HAS PRIORITY"
     assert cache_variables["CMAKE_MAKE_PROGRAM"] == "MyMake"
     assert cache_variables["BUILD_TESTING"] == 'OFF'
+    assert cache_variables["ENABLE_FOOBAR"] == 'ON'
+    assert cache_variables["QUX"] == 'baz'
 
 
 def test_android_c_library():


### PR DESCRIPTION
Changelog: Fix: `CMakeToolchain.cache_variables` parse option value as expected.
Docs: Omit

fixes #12085


I Described in #12085 as a feature, but because I thought was related to parsing boolean.

However, when investigating toolchain class behavior, it parses boolean as expected, but it does not parse `PackageOption` objects, which causes that known error: `Object of type PackageOption is not JSON serializable`. So, we need to parse it directly.

As `PackageOption._value` is a string, because its setter always convert any value to string, we need to parse it again to discover if it's a boolean or not. I only see `true, false and none` as possible values, otherwise, we just keep as string value an that's it.


- [x] Refer to the issue that supports this Pull Request.
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 

<sup>**Note:** By default this PR will skip the slower tests and will use a limited set of python versions. Check [here](https://github.com/conan-io/conan/blob/develop/.github/PR_INCREASE_TESTING.md) how to increase the testing level by writing some tags in the current PR body text.</sup>
