### PR TITLE
Fix incorrect path for CMake components with identical framework names

### DIFF
--- a/conan/tools/cmake/cmakedeps/templates/macros.py
+++ b/conan/tools/cmake/cmakedeps/templates/macros.py
@@ -29,8 +29,10 @@ class MacrosTemplate(CMakeDepsFileTemplate):
        macro(conan_find_apple_frameworks FRAMEWORKS_FOUND FRAMEWORKS FRAMEWORKS_DIRS)
            if(APPLE)
                foreach(_FRAMEWORK ${FRAMEWORKS})
+                   unset(CONAN_FRAMEWORK_${_FRAMEWORK}_FOUND CACHE)
+
                    # https://cmake.org/pipermail/cmake-developers/2017-August/030199.html
-                   find_library(CONAN_FRAMEWORK_${_FRAMEWORK}_FOUND NAMES ${_FRAMEWORK} PATHS ${FRAMEWORKS_DIRS} CMAKE_FIND_ROOT_PATH_BOTH)
+                   find_library(CONAN_FRAMEWORK_${_FRAMEWORK}_FOUND NAMES ${_FRAMEWORK} PATHS ${FRAMEWORKS_DIRS} NO_DEFAULT_PATH NO_CMAKE_FIND_ROOT_PATH)
                    if(CONAN_FRAMEWORK_${_FRAMEWORK}_FOUND)
                        list(APPEND ${FRAMEWORKS_FOUND} ${CONAN_FRAMEWORK_${_FRAMEWORK}_FOUND})
                        message(VERBOSE "Framework found! ${FRAMEWORKS_FOUND}")

--- a/conan/tools/cmake/cmakedeps/templates/macros.py
+++ b/conan/tools/cmake/cmakedeps/templates/macros.py
@@ -33,7 +33,7 @@ class MacrosTemplate(CMakeDepsFileTemplate):
 
                    # https://cmake.org/pipermail/cmake-developers/2017-August/030199.html
                    # FIXME: system Frameworks shouldn't be passed. Change CMAKE_FIND_ROOT_PATH_BOTH by NO_CMAKE_FIND_ROOT_PATH when it doesn't happen anymore
-                   find_library(CONAN_FRAMEWORK_${_FRAMEWORK}_FOUND NAMES ${_FRAMEWORK} PATHS ${FRAMEWORKS_DIRS} CMAKE_FIND_ROOT_PATH_BOTH)
+                   find_library(CONAN_FRAMEWORK_${_FRAMEWORK}_FOUND NAMES ${_FRAMEWORK} PATHS ${FRAMEWORKS_DIRS} NO_CMAKE_PATH CMAKE_FIND_ROOT_PATH_BOTH)
                    if(CONAN_FRAMEWORK_${_FRAMEWORK}_FOUND)
                     list(APPEND ${FRAMEWORKS_FOUND} ${CONAN_FRAMEWORK_${_FRAMEWORK}_FOUND})
                        message(VERBOSE "Framework found! ${FRAMEWORKS_FOUND}")

--- a/conan/tools/cmake/cmakedeps/templates/macros.py
+++ b/conan/tools/cmake/cmakedeps/templates/macros.py
@@ -32,9 +32,10 @@ class MacrosTemplate(CMakeDepsFileTemplate):
                    unset(CONAN_FRAMEWORK_${_FRAMEWORK}_FOUND CACHE)
 
                    # https://cmake.org/pipermail/cmake-developers/2017-August/030199.html
-                   find_library(CONAN_FRAMEWORK_${_FRAMEWORK}_FOUND NAMES ${_FRAMEWORK} PATHS ${FRAMEWORKS_DIRS} NO_DEFAULT_PATH NO_CMAKE_FIND_ROOT_PATH)
+                   # FIXME: system Frameworks shouldn't be passed. Change CMAKE_FIND_ROOT_PATH_BOTH by NO_CMAKE_FIND_ROOT_PATH when it doesn't happen anymore
+                   find_library(CONAN_FRAMEWORK_${_FRAMEWORK}_FOUND NAMES ${_FRAMEWORK} PATHS ${FRAMEWORKS_DIRS} CMAKE_FIND_ROOT_PATH_BOTH)
                    if(CONAN_FRAMEWORK_${_FRAMEWORK}_FOUND)
-                       list(APPEND ${FRAMEWORKS_FOUND} ${CONAN_FRAMEWORK_${_FRAMEWORK}_FOUND})
+                    list(APPEND ${FRAMEWORKS_FOUND} ${CONAN_FRAMEWORK_${_FRAMEWORK}_FOUND})
                        message(VERBOSE "Framework found! ${FRAMEWORKS_FOUND}")
                    else()
                        message(FATAL_ERROR "Framework library ${_FRAMEWORK} not found in paths: ${FRAMEWORKS_DIRS}")

--- a/conans/client/generators/cmake_find_package_common.py
+++ b/conans/client/generators/cmake_find_package_common.py
@@ -111,8 +111,10 @@ class CMakeFindPackageCommonMacros:
         macro(conan_find_apple_frameworks FRAMEWORKS_FOUND FRAMEWORKS FRAMEWORKS_DIRS)
             if(APPLE)
                 foreach(_FRAMEWORK ${FRAMEWORKS})
+                    unset(CONAN_FRAMEWORK_${_FRAMEWORK}_FOUND CACHE)
+
                     # https://cmake.org/pipermail/cmake-developers/2017-August/030199.html
-                    find_library(CONAN_FRAMEWORK_${_FRAMEWORK}_FOUND NAMES ${_FRAMEWORK} PATHS ${FRAMEWORKS_DIRS} CMAKE_FIND_ROOT_PATH_BOTH)
+                    find_library(CONAN_FRAMEWORK_${_FRAMEWORK}_FOUND NAMES ${_FRAMEWORK} PATHS ${FRAMEWORKS_DIRS} NO_DEFAULT_PATH NO_CMAKE_FIND_ROOT_PATH)
                     if(CONAN_FRAMEWORK_${_FRAMEWORK}_FOUND)
                         list(APPEND ${FRAMEWORKS_FOUND} ${CONAN_FRAMEWORK_${_FRAMEWORK}_FOUND})
                     else()

--- a/conans/client/generators/cmake_find_package_common.py
+++ b/conans/client/generators/cmake_find_package_common.py
@@ -114,7 +114,7 @@ class CMakeFindPackageCommonMacros:
                     unset(CONAN_FRAMEWORK_${_FRAMEWORK}_FOUND CACHE)
 
                     # https://cmake.org/pipermail/cmake-developers/2017-August/030199.html
-                    find_library(CONAN_FRAMEWORK_${_FRAMEWORK}_FOUND NAMES ${_FRAMEWORK} PATHS ${FRAMEWORKS_DIRS} CMAKE_FIND_ROOT_PATH_BOTH)
+                    find_library(CONAN_FRAMEWORK_${_FRAMEWORK}_FOUND NAMES ${_FRAMEWORK} PATHS ${FRAMEWORKS_DIRS} NO_CMAKE_PATH CMAKE_FIND_ROOT_PATH_BOTH)
                     if(CONAN_FRAMEWORK_${_FRAMEWORK}_FOUND)
                         list(APPEND ${FRAMEWORKS_FOUND} ${CONAN_FRAMEWORK_${_FRAMEWORK}_FOUND})
                     else()

--- a/conans/client/generators/cmake_find_package_common.py
+++ b/conans/client/generators/cmake_find_package_common.py
@@ -114,7 +114,7 @@ class CMakeFindPackageCommonMacros:
                     unset(CONAN_FRAMEWORK_${_FRAMEWORK}_FOUND CACHE)
 
                     # https://cmake.org/pipermail/cmake-developers/2017-August/030199.html
-                    find_library(CONAN_FRAMEWORK_${_FRAMEWORK}_FOUND NAMES ${_FRAMEWORK} PATHS ${FRAMEWORKS_DIRS} NO_DEFAULT_PATH NO_CMAKE_FIND_ROOT_PATH)
+                    find_library(CONAN_FRAMEWORK_${_FRAMEWORK}_FOUND NAMES ${_FRAMEWORK} PATHS ${FRAMEWORKS_DIRS} CMAKE_FIND_ROOT_PATH_BOTH)
                     if(CONAN_FRAMEWORK_${_FRAMEWORK}_FOUND)
                         list(APPEND ${FRAMEWORKS_FOUND} ${CONAN_FRAMEWORK_${_FRAMEWORK}_FOUND})
                     else()


### PR DESCRIPTION
Changelog: Bugfix: Incorrect path found for different components with the same framework names.
Docs: omit
Closes: https://github.com/conan-io/conan/issues/10140

This PR is for issue [#10140](https://github.com/conan-io/conan/issues/10140) – a detailed description of the problem (and the solution) can be found there.

Short summary: If multiple components in a recipe have `self.cpp_info.components[component].frameworks` defined as an identical value, Conan's `cmake_find_package` generator will incorrectly return the path to the **first** found component for **all** of them because the value is cached, even if each component points to a different path.

**NOTE**: This change is in line with many other Conan *macros* which properly clear a value before using it.

- [x] Refer to the issue that supports this Pull Request: [#10140](https://github.com/conan-io/conan/issues/10140)
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 