### PR TITLE
[feature] `rm_safe` for settings and options

### DIFF
--- a/conans/model/options.py
+++ b/conans/model/options.py
@@ -80,6 +80,12 @@ class PackageOptionValues(object):
             return
         del self._dict[attr]
 
+    def rm_safe(self, name):
+        try:
+            delattr(self, name)
+        except ConanException:
+            pass
+
     def clear(self):
         self._dict.clear()
 
@@ -279,6 +285,9 @@ class OptionsValues(object):
 
     def __delattr__(self, attr):
         delattr(self._package_values, attr)
+
+    def rm_safe(self, name):
+        self._package_values.rm_safe(name)
 
     def clear_indirect(self):
         for v in self._reqs_options.values():

--- a/conans/model/options.py
+++ b/conans/model/options.py
@@ -80,12 +80,6 @@ class PackageOptionValues(object):
             return
         del self._dict[attr]
 
-    def rm_safe(self, name):
-        try:
-            delattr(self, name)
-        except ConanException:
-            pass
-
     def clear(self):
         self._dict.clear()
 
@@ -237,6 +231,12 @@ class OptionsValues(object):
             return None
         return getattr(self._package_values, attr)
 
+    def rm_safe(self, attr):
+        try:
+            delattr(self._package_values, attr)
+        except ConanException:
+            pass
+
     def __getitem__(self, item):
         return self._reqs_options.setdefault(item, PackageOptionValues())
 
@@ -285,9 +285,6 @@ class OptionsValues(object):
 
     def __delattr__(self, attr):
         delattr(self._package_values, attr)
-
-    def rm_safe(self, name):
-        self._package_values.rm_safe(name)
 
     def clear_indirect(self):
         for v in self._reqs_options.values():
@@ -433,6 +430,12 @@ class PackageOptions(object):
 
     def get_safe(self, field, default=None):
         return self._data.get(field, default)
+
+    def rm_safe(self, field):
+        try:
+            delattr(self, field)
+        except ConanException:
+            pass
 
     def validate(self):
         for child in self._data.values():
@@ -592,6 +595,9 @@ class Options(object):
             self._package_options.__delattr__(field)
         except ConanException:
             pass
+
+    def rm_safe(self, field):
+        self._package_options.rm_safe(field)
 
     @property
     def values(self):

--- a/conans/model/settings.py
+++ b/conans/model/settings.py
@@ -111,6 +111,12 @@ class SettingsItem(object):
         except Exception:
             pass
 
+    def rm_safe(self, item):
+        try:
+            delattr(self, item)
+        except:
+            pass
+
     def remove(self, values):
         if not isinstance(values, (list, tuple, set)):
             values = [values]
@@ -212,6 +218,12 @@ class Settings(object):
         if tmp is not None and tmp.value and tmp.value != "None":  # In case of subsettings is None
             return str(tmp)
         return default
+
+    def rm_safe(self, name):
+        try:
+            delattr(self, name)
+        except:
+            pass
 
     def copy(self):
         """ deepcopy, recursive

--- a/conans/model/settings.py
+++ b/conans/model/settings.py
@@ -114,7 +114,7 @@ class SettingsItem(object):
     def rm_safe(self, item):
         try:
             delattr(self, item)
-        except:
+        except ConanException:
             pass
 
     def remove(self, values):
@@ -222,7 +222,7 @@ class Settings(object):
     def rm_safe(self, name):
         try:
             delattr(self, name)
-        except:
+        except ConanException:
             pass
 
     def copy(self):

--- a/conans/model/settings.py
+++ b/conans/model/settings.py
@@ -111,12 +111,6 @@ class SettingsItem(object):
         except Exception:
             pass
 
-    def rm_safe(self, item):
-        try:
-            delattr(self, item)
-        except ConanException:
-            pass
-
     def remove(self, values):
         if not isinstance(values, (list, tuple, set)):
             values = [values]

--- a/conans/model/settings.py
+++ b/conans/model/settings.py
@@ -221,7 +221,14 @@ class Settings(object):
 
     def rm_safe(self, name):
         try:
-            delattr(self, name)
+            tmp = self
+            attr_ = name
+            if "." in name:
+                fields = name.split(".")
+                attr_ = fields.pop()
+                for prop in fields:
+                    tmp = getattr(tmp, prop)
+            delattr(tmp, attr_)
         except ConanException:
             pass
 

--- a/conans/test/integration/settings/remove_subsetting_test.py
+++ b/conans/test/integration/settings/remove_subsetting_test.py
@@ -195,7 +195,9 @@ def test_settings_and_options_rm_safe():
 
     client.run("source ..")
     assert "'settings.build_type' doesn't exist" in client.out
+    assert "'settings' possible configurations are ['compiler', 'os']" in client.out
     assert "'settings.compiler.version' doesn't exist" in client.out
+    assert "'settings.compiler' possible configurations are [" in client.out
     client.run("install ..")
     client.run("build ..")
     assert "option 'opt2' doesn't exist" in client.out

--- a/conans/test/integration/settings/remove_subsetting_test.py
+++ b/conans/test/integration/settings/remove_subsetting_test.py
@@ -171,7 +171,7 @@ def test_settings_and_options_rm_safe():
             # wrong option
             self.options.rm_safe("opt15")
 
-        def source(self):
+        def build(self):
             try:
                 self.settings.build_type
             except Exception as exc:
@@ -180,8 +180,6 @@ def test_settings_and_options_rm_safe():
                 self.settings.compiler.version
             except Exception as exc:
                 self.output.warn(str(exc))
-
-        def build(self):
             try:
                 self.options.opt2
             except Exception as exc:
@@ -193,12 +191,11 @@ def test_settings_and_options_rm_safe():
     mkdir(build_folder)
     client.current_folder = build_folder
 
-    client.run("source ..")
+    client.run("install ..")
+    client.run("build ..")
     assert "'settings.build_type' doesn't exist" in client.out
     assert "'settings' possible configurations are ['compiler', 'os']" in client.out
     assert "'settings.compiler.version' doesn't exist" in client.out
     assert "'settings.compiler' possible configurations are [" in client.out
-    client.run("install ..")
-    client.run("build ..")
     assert "option 'opt2' doesn't exist" in client.out
     assert "Possible options are ['opt1']" in client.out

--- a/conans/test/integration/settings/remove_subsetting_test.py
+++ b/conans/test/integration/settings/remove_subsetting_test.py
@@ -1,4 +1,5 @@
 import os
+import textwrap
 import unittest
 
 from conans.test.utils.tools import TestClient
@@ -144,3 +145,58 @@ class ConanLib(ConanFile):
         client.run("package .")
         self.assertIn("ERROR: PACKAGE 'settings.compiler.libcxx' doesn't exist for 'gcc'",
                       client.out)
+
+
+def test_settings_and_options_rm_safe():
+    client = TestClient()
+    conanfile = textwrap.dedent("""
+    from conan import ConanFile
+    class Pkg(ConanFile):
+        settings = "os", "build_type", "compiler"
+        options = {"opt1": [True, False], "opt2": [True, False]}
+        default_options = "opt1=True", "opt2=False"
+
+        def configure(self):
+            # setting
+            self.settings.rm_safe("build_type")
+            # sub-setting
+            self.settings.rm_safe("compiler.version")
+            # wrong settings
+            self.settings.rm_safe("fake_field")
+            self.settings.rm_safe("fake_field.version")
+
+        def config_options(self):
+            # option
+            self.options.rm_safe("opt2")
+            # wrong option
+            self.options.rm_safe("opt15")
+
+        def source(self):
+            try:
+                self.settings.build_type
+            except Exception as exc:
+                self.output.warn(str(exc))
+            try:
+                self.settings.compiler.version
+            except Exception as exc:
+                self.output.warn(str(exc))
+
+        def build(self):
+            try:
+                self.options.opt2
+            except Exception as exc:
+                self.output.warn(str(exc))
+            assert "opt2" not in self.options
+    """)
+    client.save({"conanfile.py": conanfile})
+    build_folder = os.path.join(client.current_folder, "build")
+    mkdir(build_folder)
+    client.current_folder = build_folder
+
+    client.run("source ..")
+    assert "'settings.build_type' doesn't exist" in client.out
+    assert "'settings.compiler.version' doesn't exist" in client.out
+    client.run("install ..")
+    client.run("build ..")
+    assert "option 'opt2' doesn't exist" in client.out
+    assert "Possible options are ['opt1']" in client.out


### PR DESCRIPTION
Changelog: Feature: Added method `rm_safe` to `settings` and `options`.
Docs: https://github.com/conan-io/docs/pull/2764

This feature is trying to avoid this common structure:

```python
        try:
           del self.settings.compiler.libcxx
        except Exception:
           pass
        try:
           del self.settings.compiler.cppstd
        except Exception:
           pass
```
Now, it could be:

```python
       self.settings.rm_safe("compiler.libcxx")
       self.settings.rm_safe("compiler.cppstd")
```