### PR TITLE
Solving conf_info from BR inherited by consumers' test_package

### DIFF
--- a/conans/client/cmd/build.py
+++ b/conans/client/cmd/build.py
@@ -12,7 +12,7 @@ from conans.util.log import logger
 def cmd_build(app, conanfile_path, base_path, source_folder, build_folder, package_folder,
               install_folder, test=False, should_configure=True, should_build=True,
               should_install=True, should_test=True, layout_source_folder=None,
-              layout_build_folder=None):
+              layout_build_folder=None, conf=None):
     """ Call to build() method saved on the conanfile.py
     param conanfile_path: path to a conanfile.py
     """
@@ -29,6 +29,7 @@ def cmd_build(app, conanfile_path, base_path, source_folder, build_folder, packa
                              "requirements and generators from '%s' file"
                              % (CONANFILE, CONANFILE, CONANFILE_TXT))
 
+    conan_file.conf = conf
     if test:
         try:
             conan_file.requires.add_ref(test)

--- a/conans/client/cmd/build.py
+++ b/conans/client/cmd/build.py
@@ -29,7 +29,8 @@ def cmd_build(app, conanfile_path, base_path, source_folder, build_folder, packa
                              "requirements and generators from '%s' file"
                              % (CONANFILE, CONANFILE, CONANFILE_TXT))
 
-    conan_file.conf = conf
+    if conf:
+        conan_file.conf.compose_conf(conf)
     if test:
         try:
             conan_file.requires.add_ref(test)

--- a/conans/client/cmd/test.py
+++ b/conans/client/cmd/test.py
@@ -32,7 +32,7 @@ def install_build_and_test(app, conanfile_abs_path, reference, graph_info,
     if build_modes is None:
         build_modes = ["never"]
     try:
-        install_folder = deps_install(app=app,
+        install_folder, conanfile = deps_install(app=app,
                                       create_reference=reference,
                                       ref_or_path=conanfile_abs_path,
                                       install_folder=test_build_folder,
@@ -53,7 +53,7 @@ def install_build_and_test(app, conanfile_abs_path, reference, graph_info,
         cmd_build(app, conanfile_abs_path, test_build_folder,
                   source_folder=base_folder, build_folder=test_build_folder,
                   package_folder=os.path.join(test_build_folder, "package"),
-                  install_folder=install_folder, test=reference)
+                  install_folder=install_folder, test=reference, conf=conanfile.conf)
     finally:
         if delete_after_build:
             # Required for windows where deleting the cwd is not possible.

--- a/conans/client/manager.py
+++ b/conans/client/manager.py
@@ -146,4 +146,4 @@ def deps_install(app, ref_or_path, install_folder, base_folder, graph_info, remo
             if hasattr(deploy_conanfile, "deploy") and callable(deploy_conanfile.deploy):
                 run_deploy(deploy_conanfile, install_folder)
 
-    return install_folder
+    return install_folder, conanfile

--- a/conans/test/integration/toolchains/env/test_virtualenv_winbash.py
+++ b/conans/test/integration/toolchains/env/test_virtualenv_winbash.py
@@ -169,6 +169,7 @@ def test_nowinbash_virtual_cygwin(client):
     assert 'export RUNTIME_VAR="/cygdrive/c/path/to/exe"' in run_contents
 
 
+@pytest.mark.skipif(platform.system() != "Windows", reason="Requires Windows")
 def test_conf_inherited_in_test_package():
     client = TestClient()
     conanfile = textwrap.dedent("""

--- a/conans/test/integration/toolchains/env/test_virtualenv_winbash.py
+++ b/conans/test/integration/toolchains/env/test_virtualenv_winbash.py
@@ -191,13 +191,6 @@ def test_conf_inherited_in_test_package():
                 class Recipe(ConanFile):
                     name="consumer"
                     version="1.0"
-                    win_bash = True
-
-                    def build_requirements(self):
-                        self.tool_requires("msys2/1.0")
-
-                    def build(self):
-                        self.run("pwd")
         """)
     test_package = textwrap.dedent("""
                     from conan import ConanFile
@@ -213,12 +206,13 @@ def test_conf_inherited_in_test_package():
 
                         def build(self):
                             self.output.warn(self.conf["tools.microsoft.bash:subsystem"])
-                            self.run("foo")
+                            self.run("pwd")
 
                         def test(self):
                             pass
             """)
     client.save({"conanfile.py": conanfile, "test_package/conanfile.py": test_package})
     # THIS SHOULD WORK
-    client.run("create .", assert_error=True)
-    assert "are needed to run commands in a Windows subsystem" in client.out
+    client.run("create .")
+    assert "are needed to run commands in a Windows subsystem" not in client.out
+    assert "/usr/bin" in client.out

--- a/conans/test/integration/toolchains/env/test_virtualenv_winbash.py
+++ b/conans/test/integration/toolchains/env/test_virtualenv_winbash.py
@@ -180,6 +180,7 @@ def test_conf_inherited_in_test_package():
 
                 def package_info(self):
                     self.conf_info["tools.microsoft.bash:subsystem"] = "msys2"
+                    self.conf_info["tools.microsoft.bash:path"] = "C:/msys64/usr/bin/bash.exe"
     """)
     client.save({"conanfile.py": conanfile})
     client.run("create .")
@@ -211,12 +212,13 @@ def test_conf_inherited_in_test_package():
                             self.tool_requires("msys2/1.0")
 
                         def build(self):
-                            self.run("pwd")
+                            self.output.warn(self.conf["tools.microsoft.bash:subsystem"])
+                            self.run("foo")
 
                         def test(self):
                             pass
             """)
     client.save({"conanfile.py": conanfile, "test_package/conanfile.py": test_package})
-    client.run("create .")
-
-
+    # THIS SHOULD WORK
+    client.run("create .", assert_error=True)
+    assert "are needed to run commands in a Windows subsystem" in client.out

--- a/conans/test/integration/toolchains/env/test_virtualenv_winbash.py
+++ b/conans/test/integration/toolchains/env/test_virtualenv_winbash.py
@@ -183,8 +183,8 @@ def test_conf_inherited_in_test_package():
                 version="1.0"
 
                 def package_info(self):
-                    self.conf_info["tools.microsoft.bash:subsystem"] = "msys2"
-                    self.conf_info["tools.microsoft.bash:path"] = "{}"
+                    self.conf_info.define("tools.microsoft.bash:subsystem", "msys2")
+                    self.conf_info.define("tools.microsoft.bash:path", "{}")
     """.format(bash_path))
     client.save({"conanfile.py": conanfile})
     client.run("create .")
@@ -209,7 +209,7 @@ def test_conf_inherited_in_test_package():
                             self.tool_requires("msys2/1.0")
 
                         def build(self):
-                            self.output.warn(self.conf["tools.microsoft.bash:subsystem"])
+                            self.output.warning(self.conf.get("tools.microsoft.bash:subsystem"))
                             self.run("aclocal --version")
 
                         def test(self):

--- a/conans/test/integration/toolchains/env/test_virtualenv_winbash.py
+++ b/conans/test/integration/toolchains/env/test_virtualenv_winbash.py
@@ -213,7 +213,6 @@ def test_conf_inherited_in_test_package():
                             pass
             """)
     client.save({"conanfile.py": conanfile, "test_package/conanfile.py": test_package})
-    # THIS SHOULD WORK
     client.run("create .")
     assert "are needed to run commands in a Windows subsystem" not in client.out
-    assert "/usr/bin" in client.out
+    assert "/c/test_conan/" in client.out

--- a/conans/test/integration/toolchains/env/test_virtualenv_winbash.py
+++ b/conans/test/integration/toolchains/env/test_virtualenv_winbash.py
@@ -5,6 +5,7 @@ import textwrap
 import pytest
 
 from conans.test.assets.genconanfile import GenConanfile
+from conans.test.conftest import tools_locations
 from conans.test.utils.tools import TestClient
 from conans.tools import save
 
@@ -172,6 +173,7 @@ def test_nowinbash_virtual_cygwin(client):
 @pytest.mark.skipif(platform.system() != "Windows", reason="Requires Windows")
 def test_conf_inherited_in_test_package():
     client = TestClient()
+    bash_path = tools_locations["msys2"]["system"]["path"]["Windows"] + "/bash.exe"
     conanfile = textwrap.dedent("""
             from conan import ConanFile
 
@@ -181,8 +183,8 @@ def test_conf_inherited_in_test_package():
 
                 def package_info(self):
                     self.conf_info["tools.microsoft.bash:subsystem"] = "msys2"
-                    self.conf_info["tools.microsoft.bash:path"] = "C:/msys64/usr/bin/bash.exe"
-    """)
+                    self.conf_info["tools.microsoft.bash:path"] = "{}"
+    """.format(bash_path))
     client.save({"conanfile.py": conanfile})
     client.run("create .")
 
@@ -207,7 +209,7 @@ def test_conf_inherited_in_test_package():
 
                         def build(self):
                             self.output.warn(self.conf["tools.microsoft.bash:subsystem"])
-                            self.run("pwd")
+                            self.run("aclocal --version")
 
                         def test(self):
                             pass
@@ -215,4 +217,4 @@ def test_conf_inherited_in_test_package():
     client.save({"conanfile.py": conanfile, "test_package/conanfile.py": test_package})
     client.run("create .")
     assert "are needed to run commands in a Windows subsystem" not in client.out
-    assert "/c/test_conan/" in client.out
+    assert "aclocal (GNU automake)" in client.out

--- a/conans/test/integration/toolchains/env/test_virtualenv_winbash.py
+++ b/conans/test/integration/toolchains/env/test_virtualenv_winbash.py
@@ -171,6 +171,7 @@ def test_nowinbash_virtual_cygwin(client):
 
 
 @pytest.mark.skipif(platform.system() != "Windows", reason="Requires Windows")
+@pytest.mark.tool_msys2
 def test_conf_inherited_in_test_package():
     client = TestClient()
     bash_path = tools_locations["msys2"]["system"]["path"]["Windows"] + "/bash.exe"
@@ -215,6 +216,6 @@ def test_conf_inherited_in_test_package():
                             pass
             """)
     client.save({"conanfile.py": conanfile, "test_package/conanfile.py": test_package})
-    client.run("create .")
+    client.run("create . -s:b os=Windows -s:h os=Windows")
     assert "are needed to run commands in a Windows subsystem" not in client.out
     assert "aclocal (GNU automake)" in client.out


### PR DESCRIPTION
Changelog: Fix: Fixed a bug when getting the values from the `self.conf` in the conanfile of a `test_package` with build_requirements declaring the `self.conf_info`.
Docs: omit

The issue is in conan 1.x , the test_package conanfile cannot read (loses) the `conf` inherited from the build requires.
It works for 2.x BUT this is a conan-center-index recipes migration issue so we should provide the fix.

Closes https://github.com/conan-io/conan/issues/11975

