### PR TITLE
Fix XcodeDeps using full package reference in case of package with components

### DIFF
--- a/conan/tools/apple/xcodedeps.py
+++ b/conan/tools/apple/xcodedeps.py
@@ -77,9 +77,8 @@ class XcodeDeps(object):
     _dep_xconfig = textwrap.dedent("""\
         // Conan XcodeDeps generated file for {{pkg_name}}::{{comp_name}}
         // Includes all configurations for each dependency
-        {% for dep in deps %}
-        // Includes for {{dep[0]}}::{{dep[1]}} dependency
-        #include "conan_{{format_name(dep[0])}}_{{format_name(dep[1])}}.xcconfig"
+        {% for include in deps_includes %}
+        #include "{{include}}"
         {% endfor %}
         #include "{{dep_xconfig_filename}}"
 
@@ -160,11 +159,18 @@ class XcodeDeps(object):
             content_multi = load(multi_path)
         else:
             content_multi = self._dep_xconfig
+
+            def _get_includes(components):
+                # if we require the root component dep::dep include conan_dep.xcconfig
+                # for components (dep::component) include conan_dep_component.xcconfig
+                return [f"conan_{_format_name(component[0])}.xcconfig" if component[0] == component[1]
+                        else f"conan_{_format_name(component[0])}_{_format_name(component[1])}.xcconfig"
+                        for component in components]
+
             content_multi = Template(content_multi).render({"pkg_name": pkg_name,
                                                             "comp_name": comp_name,
                                                             "dep_xconfig_filename": dep_xconfig_filename,
-                                                            "deps": reqs,
-                                                            "format_name": _format_name})
+                                                            "deps_includes": _get_includes(reqs)})
 
         if dep_xconfig_filename not in content_multi:
             content_multi = content_multi.replace('.xcconfig"',

--- a/conans/test/functional/toolchains/apple/test_xcodedeps_components.py
+++ b/conans/test/functional/toolchains/apple/test_xcodedeps_components.py
@@ -206,6 +206,70 @@ def test_xcodedeps_components():
 
 @pytest.mark.skipif(platform.system() != "Darwin", reason="Only for MacOS")
 @pytest.mark.tool_cmake
+def test_cpp_info_require_whole_package():
+    """
+    https://github.com/conan-io/conan/issues/12089
+
+    liba has two components liba::cmp1 liba::cmp2
+
+    libb has not components and requires liba::liba so should generate the same info as
+    if it was requiring liba::cmp1 and liba::cmp2
+
+    libc has components and one component requires liba::liba so should generate the same info as if
+    it was requiring liba::cmp1 and liba::cmp2
+    """
+    client = TestClient(path_with_spaces=False)
+
+    liba = textwrap.dedent("""
+        import os
+        from conan import ConanFile
+        class LibConan(ConanFile):
+            settings = "os", "compiler", "build_type", "arch"
+            name = "liba"
+            version = "1.0"
+            def package_info(self):
+                self.cpp_info.components["cmp1"].includedirs.append("cmp1")
+                self.cpp_info.components["cmp2"].includedirs.append("cmp2")
+        """)
+
+    libb = textwrap.dedent("""
+        import os
+        from conan import ConanFile
+        class LibConan(ConanFile):
+            settings = "os", "compiler", "build_type", "arch"
+            name = "libb"
+            version = "1.0"
+            requires = "liba/1.0"
+            def package_info(self):
+                self.cpp_info.requires = ["liba::liba"]
+        """)
+
+    libc = textwrap.dedent("""
+        import os
+        from conan import ConanFile
+        class LibConan(ConanFile):
+            settings = "os", "compiler", "build_type", "arch"
+            name = "libc"
+            version = "1.0"
+            requires = "liba/1.0"
+            def package_info(self):
+                self.cpp_info.components["cmp1"].includedirs.append("cmp1")
+                self.cpp_info.components["cmp2"].includedirs.append("cmp2")
+                self.cpp_info.components["cmp1"].requires = ["liba::liba"]
+        """)
+
+    client.save({"liba.py": liba, "libb.py": libb, "libc.py": libc})
+
+    client.run("create liba.py")
+    client.run("create libb.py")
+    client.run("create libc.py")
+    client.run("install libb/1.0@ -g XcodeDeps --install-folder=libb")
+    client.run("install libc/1.0@ -g XcodeDeps --install-folder=libc")
+    print("..........")
+
+
+@pytest.mark.skipif(platform.system() != "Darwin", reason="Only for MacOS")
+@pytest.mark.tool_cmake
 def test_xcodedeps_test_require():
     client = TestClient()
     client.run("new gtest/1.0 -m cmake_lib")

--- a/conans/test/functional/toolchains/apple/test_xcodedeps_components.py
+++ b/conans/test/functional/toolchains/apple/test_xcodedeps_components.py
@@ -264,8 +264,16 @@ def test_cpp_info_require_whole_package():
     client.run("create libb.py")
     client.run("create libc.py")
     client.run("install libb/1.0@ -g XcodeDeps --install-folder=libb")
+
+    libb_xcconfig = client.load(os.path.join("libb", "conan_libb_libb.xcconfig"))
+    assert '#include "conan_liba.xcconfig"' in libb_xcconfig
+    assert '#include "conan_liba_liba.xcconfig"' not in libb_xcconfig
+
     client.run("install libc/1.0@ -g XcodeDeps --install-folder=libc")
-    print("..........")
+
+    libc_comp1_xcconfig = client.load(os.path.join("libc", "conan_libc_cmp1.xcconfig"))
+    assert '#include "conan_liba.xcconfig"' in libc_comp1_xcconfig
+    assert '#include "conan_liba_liba.xcconfig"' not in libc_comp1_xcconfig
 
 
 @pytest.mark.skipif(platform.system() != "Darwin", reason="Only for MacOS")

--- a/conans/test/integration/toolchains/apple/test_xcodedeps.py
+++ b/conans/test/integration/toolchains/apple/test_xcodedeps.py
@@ -153,7 +153,7 @@ def test_xcodedeps_aggregate_components():
         assert f"conan_libb_libb_comp{index}.xcconfig" in lib_entry
 
     component7_entry = client.load("conan_libb_libb_comp7.xcconfig")
-    assert '#include "conan_liba_liba.xcconfig"' in component7_entry
+    assert '#include "conan_liba.xcconfig"' in component7_entry
 
     arch_setting = client.get_default_host_profile().settings['arch']
     arch = "arm64" if arch_setting == "armv8" else arch_setting


### PR DESCRIPTION
Changelog: Fix: Fix XcodeDeps using full package reference in case of package with components.
Docs: omit

Testing a fix when the syntax `self.cpp_info.requires = ["dep::dep"]` or `self.cpp_info.components["comp"].requires = ["dep::dep"]` is used for a package with components, it should include all the components

Closes: https://github.com/conan-io/conan/issues/12089