### PR TITLE
[Meson] Meson appending extra machine files

### DIFF
--- a/conan/tools/meson/meson.py
+++ b/conan/tools/meson/meson.py
@@ -17,17 +17,23 @@ class Meson(object):
         cross = os.path.join(generators_folder, MesonToolchain.cross_filename)
         native = os.path.join(generators_folder, MesonToolchain.native_filename)
         deps_flags = os.path.join(generators_folder, MesonDeps.filename)  # extra machine files layer
-        has_deps_flags = os.path.exists(deps_flags)
-
+        meson_options = []
         if os.path.exists(cross):
-            cmd += ' --cross-file "{}"'.format(cross)
-            if has_deps_flags:
-                cmd += ' --cross-file "{}"'.format(deps_flags)
+            cmd_param = " --cross-file"
+            meson_options.append(cross)
         else:
-            cmd += ' --native-file "{}"'.format(native)
-            if has_deps_flags:
-                cmd += ' --native-file "{}"'.format(deps_flags)
+            cmd_param = " --native-file"
+            meson_options.append(native)
 
+        if os.path.exists(deps_flags):
+            meson_options.append(deps_flags)
+
+        user_filenames = self._conanfile.conf.get("tools.meson.mesontoolchain:user_filenames",
+                                                  default=[], check_type=list)
+        if user_filenames:
+            meson_options.extend(user_filenames)
+
+        cmd += "".join([f'{cmd_param} "{meson_option}"' for meson_option in meson_options])
         cmd += ' "{}" "{}"'.format(build_folder, source_folder)
         if self._conanfile.package_folder:
             cmd += ' -Dprefix="{}"'.format(self._conanfile.package_folder)

--- a/conan/tools/meson/meson.py
+++ b/conan/tools/meson/meson.py
@@ -17,23 +17,23 @@ class Meson(object):
         cross = os.path.join(generators_folder, MesonToolchain.cross_filename)
         native = os.path.join(generators_folder, MesonToolchain.native_filename)
         deps_flags = os.path.join(generators_folder, MesonDeps.filename)  # extra machine files layer
-        meson_options = []
+        meson_filenames = []
         if os.path.exists(cross):
             cmd_param = " --cross-file"
-            meson_options.append(cross)
+            meson_filenames.append(cross)
         else:
             cmd_param = " --native-file"
-            meson_options.append(native)
+            meson_filenames.append(native)
 
         if os.path.exists(deps_flags):
-            meson_options.append(deps_flags)
+            meson_filenames.append(deps_flags)
 
         user_filenames = self._conanfile.conf.get("tools.meson.mesontoolchain:user_filenames",
                                                   default=[], check_type=list)
         if user_filenames:
-            meson_options.extend(user_filenames)
+            meson_filenames.extend(user_filenames)
 
-        cmd += "".join([f'{cmd_param} "{meson_option}"' for meson_option in meson_options])
+        cmd += "".join([f'{cmd_param} "{meson_option}"' for meson_option in meson_filenames])
         cmd += ' "{}" "{}"'.format(build_folder, source_folder)
         if self._conanfile.package_folder:
             cmd += ' -Dprefix="{}"'.format(self._conanfile.package_folder)

--- a/conan/tools/meson/meson.py
+++ b/conan/tools/meson/meson.py
@@ -28,10 +28,10 @@ class Meson(object):
         if os.path.exists(deps_flags):
             meson_filenames.append(deps_flags)
 
-        user_filenames = self._conanfile.conf.get("tools.meson.mesontoolchain:user_filenames",
-                                                  default=[], check_type=list)
-        if user_filenames:
-            meson_filenames.extend(user_filenames)
+        machine_files = self._conanfile.conf.get("tools.meson.mesontoolchain:extra_machine_files",
+                                                 default=[], check_type=list)
+        if machine_files:
+            meson_filenames.extend(machine_files)
 
         cmd += "".join([f'{cmd_param} "{meson_option}"' for meson_option in meson_filenames])
         cmd += ' "{}" "{}"'.format(build_folder, source_folder)

--- a/conans/model/conf.py
+++ b/conans/model/conf.py
@@ -59,7 +59,7 @@ BUILT_IN_CONFS = {
     "tools.gnu:pkg_config": "Define the 'pkg_config' executable name or full path",
     "tools.env.virtualenv:powershell": "Opt-in to generate Powershell '.ps1' scripts instead of '.bat'",
     "tools.meson.mesontoolchain:backend": "Set the Meson backend. Possible values: 'ninja', 'vs', 'vs2010', 'vs2015', 'vs2017', 'vs2019', 'xcode'",
-    "tools.meson.mesontoolchain:user_filenames": "List of paths for any cross/native file references to be appended to the existing Conan ones",
+    "tools.meson.mesontoolchain:extra_machine_files": "List of paths for any additional native/cross file references to be appended to the existing Conan ones",
     "tools.files.download:download_cache": "Location for the download cache",
     "tools.build.cross_building:can_run": "Set the return value for the 'conan.tools.build.can_run()' tool",
 }

--- a/conans/model/conf.py
+++ b/conans/model/conf.py
@@ -59,6 +59,7 @@ BUILT_IN_CONFS = {
     "tools.gnu:pkg_config": "Define the 'pkg_config' executable name or full path",
     "tools.env.virtualenv:powershell": "Opt-in to generate Powershell '.ps1' scripts instead of '.bat'",
     "tools.meson.mesontoolchain:backend": "Set the Meson backend. Possible values: 'ninja', 'vs', 'vs2010', 'vs2015', 'vs2017', 'vs2019', 'xcode'",
+    "tools.meson.mesontoolchain:user_filenames": "List of paths for any cross/native file references to be appended to the existing Conan ones",
     "tools.files.download:download_cache": "Location for the download cache",
     "tools.build.cross_building:can_run": "Set the return value for the 'conan.tools.build.can_run()' tool",
 }

--- a/conans/test/functional/toolchains/meson/_base.py
+++ b/conans/test/functional/toolchains/meson/_base.py
@@ -1,5 +1,4 @@
 import platform
-import sys
 import unittest
 
 import pytest
@@ -8,7 +7,6 @@ from conans.test.utils.tools import TestClient
 
 
 @pytest.mark.tool_meson
-@pytest.mark.skipif(sys.version_info.major == 2, reason="Meson not supported in Py2")
 @pytest.mark.skipif(platform.system() not in ("Darwin", "Windows", "Linux"),
                     reason="Not tested for not mainstream boring operating systems")
 class TestMesonBase(unittest.TestCase):

--- a/conans/test/functional/toolchains/meson/test_meson.py
+++ b/conans/test/functional/toolchains/meson/test_meson.py
@@ -220,7 +220,7 @@ def test_meson_and_user_filenames_composition():
     client.run("install . -pr=profile -if build")
     client.run("build . -bf build", assert_error=True)  # fails because of the fake compiler
     # Checking the order of the appended user file (the order matters)
-    assert f'meson setup --native-file "{client.current_folder}/build/conan_meson_native.ini" ' \
-           f'--native-file "myfilename.ini"' in client.out
+    conan_meson_native = os.path.join(client.current_folder, "build", "conan_meson_native.ini")
+    assert f'meson setup --native-file "{conan_meson_native}" --native-file "myfilename.ini"' in client.out
     # Meson is trying to use the c and cpp binary paths from user file
     assert "Unknown compiler(s): [['/usr/fake/path/g++']]" in client.out

--- a/conans/test/functional/toolchains/meson/test_meson.py
+++ b/conans/test/functional/toolchains/meson/test_meson.py
@@ -186,7 +186,7 @@ def test_meson_and_user_filenames_composition():
         [settings]
         os=Windows
         arch=x86_64
-        compiler=clang
+        compiler=gcc
         compiler.version=9
         compiler.cppstd=17
         compiler.libcxx=libstdc++11
@@ -218,7 +218,9 @@ def test_meson_and_user_filenames_composition():
                  "profile": profile})
 
     client.run("install . -pr=profile -if build")
-    client.run("build . -bf build", assert_error=True)  # it has to fail because of the compiler
+    client.run("build . -bf build", assert_error=True)  # fails because of the fake compiler
+    # Checking the order of the appended user file (the order matters)
     assert f'meson setup --native-file "{client.current_folder}/build/conan_meson_native.ini" ' \
            f'--native-file "myfilename.ini"' in client.out
+    # Meson is trying to use the c and cpp binary paths from user file
     assert "Unknown compiler(s): [['/usr/fake/path/g++']]" in client.out

--- a/conans/test/functional/toolchains/meson/test_meson.py
+++ b/conans/test/functional/toolchains/meson/test_meson.py
@@ -1,5 +1,6 @@
 import os
 import platform
+import sys
 import textwrap
 
 import pytest
@@ -173,6 +174,7 @@ class MesonToolchainTest(TestMesonBase):
 
 
 @pytest.mark.tool_meson
+@pytest.mark.skipif(sys.version_info.minor < 8, reason="Latest Meson versions needs Python >= 3.8")
 def test_meson_and_additional_machine_files_composition():
     """
     Testing when users wants to append their own meson machine files and override/complement some

--- a/conans/test/functional/toolchains/meson/test_meson.py
+++ b/conans/test/functional/toolchains/meson/test_meson.py
@@ -2,9 +2,12 @@ import os
 import platform
 import textwrap
 
+import pytest
+
 from conans.model.ref import ConanFileReference
 from conans.test.assets.sources import gen_function_cpp, gen_function_h
 from conans.test.functional.toolchains.meson._base import TestMesonBase
+from conans.test.utils.tools import TestClient
 
 
 class MesonToolchainTest(TestMesonBase):
@@ -167,3 +170,55 @@ class MesonToolchainTest(TestMesonBase):
         # res/tutorial -> tutorial is being added automatically by Meson
         assert os.path.exists(os.path.join(package_folder, "res", "tutorial", "file1.txt"))
         assert os.path.exists(os.path.join(package_folder, "res", "tutorial", "file2.txt"))
+
+
+@pytest.mark.tool_meson
+def test_meson_and_user_filenames_composition():
+    """
+    Testing when users wants to append their own meson files and override/complement some
+    sections from Conan file ones.
+
+    See more information in Meson web page: https://mesonbuild.com/Machine-files.html
+
+    In this test, we're overriding only the Meson section ``[binaries]`` for instance.
+    """
+    profile = textwrap.dedent("""
+        [settings]
+        os=Windows
+        arch=x86_64
+        compiler=clang
+        compiler.version=9
+        compiler.cppstd=17
+        compiler.libcxx=libstdc++11
+        build_type=Release
+
+        [conf]
+        tools.meson.mesontoolchain:user_filenames=["myfilename.ini"]
+   """)
+    myfilename = textwrap.dedent("""
+    [binaries]
+    c = '/usr/fake/path/gcc'
+    cpp = '/usr/fake/path/g++'
+    """)
+    conanfile = textwrap.dedent("""
+    from conan import ConanFile
+    from conan.tools.meson import Meson
+    class Pkg(ConanFile):
+        settings = "os", "compiler", "build_type", "arch"
+        generators = "MesonToolchain"
+        def build(self):
+            meson = Meson(self)
+            meson.configure()
+            meson.build()
+    """)
+    client = TestClient()
+    client.save({"conanfile.py": conanfile,
+                 "build/myfilename.ini": myfilename,
+                 "meson.build": "project('tutorial', 'cpp')",  # dummy one
+                 "profile": profile})
+
+    client.run("install . -pr=profile -if build")
+    client.run("build . -bf build", assert_error=True)  # it has to fail because of the compiler
+    assert f'meson setup --native-file "{client.current_folder}/build/conan_meson_native.ini" ' \
+           f'--native-file "myfilename.ini"' in client.out
+    assert "Unknown compiler(s): [['/usr/fake/path/g++']]" in client.out

--- a/conans/test/functional/toolchains/meson/test_meson.py
+++ b/conans/test/functional/toolchains/meson/test_meson.py
@@ -217,9 +217,9 @@ def test_meson_and_additional_machine_files_composition():
                  "profile": profile})
 
     client.run("install . -pr=profile -if build")
-    client.run("build . -bf build")
+    client.run("build . -bf build", assert_error=True)
     # Checking the order of the appended user file (the order matters)
     conan_meson_native = os.path.join(client.current_folder, "build", "conan_meson_native.ini")
     assert f'meson setup --native-file "{conan_meson_native}" --native-file "myfilename.ini"' in client.out
-    # Meson warns about an unknown option
-    assert 'WARNING: Unknown options: "my_option"' in client.out
+    # Meson fails because of an unknown option
+    assert 'ERROR: Unknown options: "my_option"' in client.out

--- a/conans/test/integration/toolchains/meson/test_mesontoolchain.py
+++ b/conans/test/integration/toolchains/meson/test_mesontoolchain.py
@@ -1,13 +1,9 @@
-import sys
 import textwrap
-
-import pytest
 
 from conan.tools.meson import MesonToolchain
 from conans.test.utils.tools import TestClient
 
 
-@pytest.mark.skipif(sys.version_info.major == 2, reason="Meson not supported in Py2")
 def test_apple_meson_keep_user_custom_flags():
     default = textwrap.dedent("""
     [settings]
@@ -62,7 +58,6 @@ def test_apple_meson_keep_user_custom_flags():
     assert "cpp_link_args = ['-isysroot', '/other/sdk/path', '-arch', 'myarch', '-otherminversion=10.7', '-stdlib=libc++']" in content
 
 
-@pytest.mark.skipif(sys.version_info.major == 2, reason="Meson not supported in Py2")
 def test_extra_flags_via_conf():
     profile = textwrap.dedent("""
         [settings]
@@ -97,7 +92,6 @@ def test_extra_flags_via_conf():
     assert "cpp_link_args = ['-flag0', '-other=val', '-flag5', '-flag6']" in content
 
 
-@pytest.mark.skipif(sys.version_info.major == 2, reason="Meson not supported in Py2")
 def test_correct_quotes():
     profile = textwrap.dedent("""
        [settings]


### PR DESCRIPTION
Changelog: Feature: Add `tools.meson.mesontoolchain:extra_machine_files=["FILENAMES"]` to `Meson` build helper to append machine files to the the ones created by Conan.
Docs: https://github.com/conan-io/docs/pull/2831
Closes: https://github.com/conan-io/conan/issues/11961

