### PR TITLE
Add check during package download to prevent race condition

### DIFF
--- a/conans/client/installer.py
+++ b/conans/client/installer.py
@@ -26,6 +26,7 @@ from conans.model.env_info import EnvInfo
 from conans.model.graph_info import GraphInfo
 from conans.model.graph_lock import GraphLockFile
 from conans.model.info import PACKAGE_ID_UNKNOWN
+from conans.model.manifest import FileTreeManifest
 from conans.model.new_build_info import NewCppInfo, fill_old_cppinfo
 from conans.model.ref import PackageReference
 from conans.model.user_info import DepsUserInfo

--- a/conans/client/installer.py
+++ b/conans/client/installer.py
@@ -399,6 +399,10 @@ class BinaryInstaller(object):
             # We cannot embed the package_lock inside the remote.get_package()
             # because the handle_node_cache has its own lock
             with layout.package_lock(n.pref):
+                package_folder = layout.package(n.pref)
+                if os.path.exists(package_folder) and FileTreeManifest.exists_at(package_folder):
+                    self._out.info("Skipping download since it looks like that this package already exists")
+                    return
                 self._download_pkg(layout, n)
 
         parallel = self._cache.config.parallel_download

--- a/conans/client/installer.py
+++ b/conans/client/installer.py
@@ -398,10 +398,11 @@ class BinaryInstaller(object):
             layout = self._cache.package_layout(n.pref.ref, n.conanfile.short_paths)
             # We cannot embed the package_lock inside the remote.get_package()
             # because the handle_node_cache has its own lock
+            output = n.conanfile.output
             with layout.package_lock(n.pref):
                 package_folder = layout.package(n.pref)
                 if os.path.exists(package_folder) and FileTreeManifest.exists_at(package_folder):
-                    self._out.info("Skipping download since it looks like that this package already exists")
+                    output.info(f"Skipping download of package {n.pref.id} since it is already downloaded and unpacked")
                     return
                 self._download_pkg(layout, n)
 

--- a/conans/model/manifest.py
+++ b/conans/model/manifest.py
@@ -90,6 +90,10 @@ class FileTreeManifest(object):
     def load(folder):
         text = load(os.path.join(folder, CONAN_MANIFEST))
         return FileTreeManifest.loads(text)
+    
+    @staticmethod
+    def exists_at(folder):
+        return os.path.exists(os.path.join(folder, CONAN_MANIFEST))
 
     def __repr__(self):
         # Used for serialization and saving it to disk


### PR DESCRIPTION
Changelog: (Bugfix): In some cases we see race condition when 2 conan instances running at the same time and downloading same package. While locks prevent two conans from downloading and overwriting files in parallel, they currently do not prevent second conan from purging the directory prepared by the first one and re-unzipping files there.


- [ ] Refer to the issue that supports this Pull Request.
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [ ] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [ ] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 

<sup>**Note:** By default this PR will skip the slower tests and will use a limited set of python versions. Check [here](https://github.com/conan-io/conan/blob/develop/.github/PR_INCREASE_TESTING.md) how to increase the testing level by writing some tags in the current PR body text.</sup>
