### PR TITLE
WIP: Fix rpath for executables in `fix_apple_shared_install_name` tool

### DIFF
--- a/conans/client/conf/__init__.py
+++ b/conans/client/conf/__init__.py
@@ -124,7 +124,7 @@ _t_default_settings_yml = Template(textwrap.dedent("""
             runtime: [None, MD, MT, MTd, MDd, static, dynamic]
             runtime_type: [None, Debug, Release]
         apple-clang: &apple_clang
-            version: ["5.0", "5.1", "6.0", "6.1", "7.0", "7.3", "8.0", "8.1", "9.0", "9.1", "10.0", "11.0", "12.0", "13", "13.0", "13.1"]
+            version: ["5.0", "5.1", "6.0", "6.1", "7.0", "7.3", "8.0", "8.1", "9.0", "9.1", "10.0", "11.0", "12.0", "13", "13.0", "13.1", "14"]
             libcxx: [libstdc++, libc++]
             cppstd: [None, 98, gnu98, 11, gnu11, 14, gnu14, 17, gnu17, 20, gnu20]
         intel:

--- a/conans/client/conf/__init__.py
+++ b/conans/client/conf/__init__.py
@@ -124,7 +124,7 @@ _t_default_settings_yml = Template(textwrap.dedent("""
             runtime: [None, MD, MT, MTd, MDd, static, dynamic]
             runtime_type: [None, Debug, Release]
         apple-clang: &apple_clang
-            version: ["5.0", "5.1", "6.0", "6.1", "7.0", "7.3", "8.0", "8.1", "9.0", "9.1", "10.0", "11.0", "12.0", "13", "13.0", "13.1", "14"]
+            version: ["5.0", "5.1", "6.0", "6.1", "7.0", "7.3", "8.0", "8.1", "9.0", "9.1", "10.0", "11.0", "12.0", "13", "13.0", "13.1"]
             libcxx: [libstdc++, libc++]
             cppstd: [None, 98, gnu98, 11, gnu11, 14, gnu14, 17, gnu17, 20, gnu20]
         intel:


### PR DESCRIPTION
Changelog: Feature: The tool `fix_apple_shared_install_name` now also patches the `<package_id>/bin` executables found to point to the libraries at `../lib/xxx.dylib`.
Docs: https://github.com/conan-io/docs/pull/XXXX

Close https://github.com/conan-io/conan/issues/12107