### PR TITLE
relax XML substitutions in MSBuildDeps

### DIFF
--- a/conan/tools/microsoft/msbuilddeps.py
+++ b/conan/tools/microsoft/msbuilddeps.py
@@ -11,7 +11,6 @@ from conans.errors import ConanException
 from conans.util.files import load, save
 
 VALID_LIB_EXTENSIONS = (".so", ".lib", ".a", ".dylib", ".bc")
-EXCLUDED_SYMBOLS_PATTERN = re.compile(r"[\.+\-]")
 
 
 class MSBuildDeps(object):
@@ -133,7 +132,7 @@ class MSBuildDeps(object):
 
     @staticmethod
     def _get_valid_xml_format(name):
-        return EXCLUDED_SYMBOLS_PATTERN.sub("_", name)
+        return re.compile(r"[.+]").sub("_", name)
 
     def _vars_props_file(self, dep, name, cpp_info, deps, build):
         """


### PR DESCRIPTION
Changelog: Fix: Avoid changing MSBuildDeps filenames with ``-`` while trying to avoid wrong XML formats.
Docs: Omit

Close https://github.com/conan-io/conan/issues/12098