### PR TITLE
Adding libcxx support to MesonToolchain

### DIFF
--- a/conan/tools/_compilers.py
+++ b/conan/tools/_compilers.py
@@ -79,7 +79,7 @@ def libcxx_flags(conanfile):
                "libstdc++": "-library=stdcpp"
                }.get(libcxx)
     elif compiler == "qcc":
-        return "-Y _{}".format(libcxx)
+        lib = "-Y _{}".format(libcxx)
 
     if compiler in ['clang', 'apple-clang', 'gcc']:
         if libcxx == "libstdc++":

--- a/conan/tools/_compilers.py
+++ b/conan/tools/_compilers.py
@@ -57,6 +57,39 @@ def architecture_flag(settings):
     return ""
 
 
+def libcxx_flags(conanfile):
+    libcxx = conanfile.settings.get_safe("compiler.libcxx")
+    if not libcxx:
+        return None, None
+    compiler = conanfile.settings.get_safe("compiler")
+    lib = stdlib11 = None
+    if compiler == "apple-clang":
+        # In apple-clang 2 only values atm are "libc++" and "libstdc++"
+        lib = "-stdlib={}".format(libcxx)
+    elif compiler == "clang" or compiler == "intel-cc":
+        if libcxx == "libc++":
+            lib = "-stdlib=libc++"
+        elif libcxx == "libstdc++" or libcxx == "libstdc++11":
+            lib = "-stdlib=libstdc++"
+        # FIXME, something to do with the other values? Android c++_shared?
+    elif compiler == "sun-cc":
+        lib = {"libCstd": "-library=Cstd",
+               "libstdcxx": "-library=stdcxx4",
+               "libstlport": "-library=stlport4",
+               "libstdc++": "-library=stdcpp"
+               }.get(libcxx)
+    elif compiler == "qcc":
+        return "-Y _{}".format(libcxx)
+
+    if compiler in ['clang', 'apple-clang', 'gcc']:
+        if libcxx == "libstdc++":
+            stdlib11 = "_GLIBCXX_USE_CXX11_ABI=0"
+        elif libcxx == "libstdc++11" and conanfile.conf.get("tools.gnu:define_libcxx11_abi",
+                                                            check_type=bool):
+            stdlib11 = "_GLIBCXX_USE_CXX11_ABI=1"
+    return lib, stdlib11
+
+
 def build_type_link_flags(settings):
     """
     returns link flags specific to the build type (Debug, Release, etc.)

--- a/conan/tools/cmake/toolchain/blocks.py
+++ b/conan/tools/cmake/toolchain/blocks.py
@@ -165,8 +165,6 @@ class GLibCXXBlock(Block):
 
     def context(self):
         libcxx, stdlib11 = libcxx_flags(self._conanfile)
-        if libcxx is None and stdlib11 is None:
-            return None
         return {"set_libcxx": libcxx, "glibcxx": stdlib11}
 
 

--- a/conan/tools/cmake/toolchain/blocks.py
+++ b/conan/tools/cmake/toolchain/blocks.py
@@ -5,7 +5,7 @@ from collections import OrderedDict
 
 from jinja2 import Template
 
-from conan.tools._compilers import architecture_flag
+from conan.tools._compilers import architecture_flag, libcxx_flags
 from conan.tools.apple.apple import is_apple_os, to_apple_arch
 from conan.tools.build import build_jobs
 from conan.tools.build.cross_building import cross_building
@@ -159,41 +159,15 @@ class GLibCXXBlock(Block):
         string(APPEND CONAN_CXX_FLAGS " {{ set_libcxx }}")
         {% endif %}
         {% if glibcxx %}
-        add_compile_definitions(_GLIBCXX_USE_CXX11_ABI={{ glibcxx }})
+        add_compile_definitions({{ glibcxx }})
         {% endif %}
         """)
 
     def context(self):
-        libcxx = self._conanfile.settings.get_safe("compiler.libcxx")
-        if not libcxx:
+        libcxx, stdlib11 = libcxx_flags(self._conanfile)
+        if libcxx is None and stdlib11 is None:
             return None
-        compiler = self._conanfile.settings.get_safe("compiler")
-        lib = glib = None
-        if compiler == "apple-clang":
-            # In apple-clang 2 only values atm are "libc++" and "libstdc++"
-            lib = "-stdlib={}".format(libcxx)
-        elif compiler == "clang" or compiler == "intel-cc":
-            if libcxx == "libc++":
-                lib = "-stdlib=libc++"
-            elif libcxx == "libstdc++" or libcxx == "libstdc++11":
-                lib = "-stdlib=libstdc++"
-            # FIXME, something to do with the other values? Android c++_shared?
-        elif compiler == "sun-cc":
-            lib = {"libCstd": "Cstd",
-                   "libstdcxx": "stdcxx4",
-                   "libstlport": "stlport4",
-                   "libstdc++": "stdcpp"
-                   }.get(libcxx)
-            if lib:
-                lib = "-library={}".format(lib)
-
-        if compiler in ['clang', 'apple-clang', 'gcc']:
-            if libcxx == "libstdc++":
-                glib = "0"
-            elif libcxx == "libstdc++11" and self._conanfile.conf.get("tools.gnu:define_libcxx11_abi",
-                                                                      check_type=bool):
-                glib = "1"
-        return {"set_libcxx": lib, "glibcxx": glib}
+        return {"set_libcxx": libcxx, "glibcxx": stdlib11}
 
 
 class SkipRPath(Block):

--- a/conan/tools/meson/toolchain.py
+++ b/conan/tools/meson/toolchain.py
@@ -318,7 +318,7 @@ class MesonToolchain(object):
         if self.libcxx:
             self.cpp_args.append(self.libcxx)
         if self.gcc_cxx11_abi:
-            self.cpp_args.append(self.gcc_cxx11_abi)
+            self.cpp_args.append("-D{}".format(self.gcc_cxx11_abi))
 
         return {
             # https://mesonbuild.com/Machine-files.html#properties

--- a/conan/tools/meson/toolchain.py
+++ b/conan/tools/meson/toolchain.py
@@ -4,6 +4,7 @@ import textwrap
 from jinja2 import Template
 
 from conan.tools._check_build_profile import check_using_build_profile
+from conan.tools._compilers import libcxx_flags
 from conan.tools.apple.apple import to_apple_arch, is_apple_os, apple_min_version_flag
 from conan.tools.build.cross_building import cross_building, get_cross_building_settings
 from conan.tools.env import VirtualBuildEnv
@@ -131,6 +132,7 @@ class MesonToolchain(object):
 
         self.preprocessor_definitions = {}
         self.pkg_config_path = self._conanfile.generators_folder
+        self.libcxx, self.gcc_cxx11_abi = libcxx_flags(self._conanfile)
 
         check_using_build_profile(self._conanfile)
 
@@ -312,6 +314,11 @@ class MesonToolchain(object):
         # These link_args have already the LDFLAGS env value so let's add only the new possible ones
         self.objc_link_args.extend(apple_flags + extra_flags["ldflags"])
         self.objcpp_link_args.extend(apple_flags + extra_flags["ldflags"])
+
+        if self.libcxx:
+            self.cpp_args.append(self.libcxx)
+        if self.gcc_cxx11_abi:
+            self.cpp_args.append(self.gcc_cxx11_abi)
 
         return {
             # https://mesonbuild.com/Machine-files.html#properties

--- a/conans/test/functional/toolchains/meson/test_meson_and_gnu_deps_flags.py
+++ b/conans/test/functional/toolchains/meson/test_meson_and_gnu_deps_flags.py
@@ -142,5 +142,7 @@ class TestMesonToolchainAndGnuFlags(TestMesonBase):
                "".format(folder=client.current_folder.replace("\\", "/")) in meson_log
         # Flags/Defines from deps and consumer are appearing in meson-log.txt as part
         # of the command-line
-        assert '%s -DVAR="VALUE" -DVAR2="VALUE2" %s' % (flags, deps_flags) in meson_log
+        assert flags in meson_log
+        assert '-DVAR="VALUE" -DVAR2="VALUE2"' in meson_log
+        assert deps_flags in meson_log
         assert '-DDEF3=simple_string -DDEF1=one_string -DDEF2=other_string' in meson_log

--- a/conans/test/unittests/client/toolchain/autotools/autotools_toolchain_test.py
+++ b/conans/test/unittests/client/toolchain/autotools/autotools_toolchain_test.py
@@ -152,7 +152,7 @@ def test_ndebug():
     ("clang", 'libstdc++11', '-stdlib=libstdc++'),
     ("clang", 'libc++', '-stdlib=libc++'),
     ("apple-clang", 'libstdc++', '-stdlib=libstdc++'),
-    ("apple-clang", 'libstdc++11', '-stdlib=libstdc++'),
+    # ("apple-clang", 'libstdc++11', '-stdlib=libstdc++'), # this is invalid input
     ("apple-clang", 'libc++', '-stdlib=libc++'),
     ("sun-cc", 'libCstd', '-library=Cstd'),
     ("sun-cc", 'libstdcxx', '-library=stdcxx4'),

--- a/conans/test/unittests/tools/cmake/test_cmaketoolchain.py
+++ b/conans/test/unittests/tools/cmake/test_cmaketoolchain.py
@@ -402,7 +402,7 @@ def test_libcxx_abi_flag():
     # by default, no flag is output anymore, it is assumed the compiler default
     assert 'GLIBCXX_USE_CXX11_ABI' not in content
     # recipe workaround for older distros
-    toolchain.blocks["libcxx"].values["glibcxx"] = "1"
+    toolchain.blocks["libcxx"].values["glibcxx"] = "_GLIBCXX_USE_CXX11_ABI=1"
     content = toolchain.content
     assert '_GLIBCXX_USE_CXX11_ABI=1' in content
 


### PR DESCRIPTION
Changelog: Bugfix: Implement correct ``libcxx`` support in ``MesonToolchain``.
Docs: Omit

Close https://github.com/conan-io/conan/issues/12009
