### PR TITLE
Add message to invoke cmake manually as an alternative to call the presets

### DIFF
--- a/conan/tools/cmake/presets.py
+++ b/conan/tools/cmake/presets.py
@@ -94,8 +94,9 @@ def _configure_preset(conanfile, generator, cache_variables, toolchain_file, mul
         if "CMAKE_TOOLCHAIN_FILE" not in cache_variables_info else ""
 
     conanfile.output.info(f"Preset '{name}' added to CMakePresets.json. Invoke it manually using "
-                          f"'cmake --preset {name}' or if your CMake version is not compatible with "
-                          f"the presets feature (<3.19) call cmake configure like: 'cmake <path> "
+                          f"'cmake --preset {name}'")
+    conanfile.output.info(f"If your CMake version is not compatible with "
+                          f"CMakePresets (<3.19) call cmake like: 'cmake <path> "
                           f"-G {_format_val(generator)} {add_toolchain_cache}"
                           f"{cache_variables_info}'")
     return ret

--- a/conan/tools/cmake/presets.py
+++ b/conan/tools/cmake/presets.py
@@ -84,6 +84,20 @@ def _configure_preset(conanfile, generator, cache_variables, toolchain_file, mul
         # we don't even have a conanfile with a `layout()` to determine the build folder.
         # If we install a local conanfile: "conan install ." with a layout(), it will be available.
         ret["binaryDir"] = conanfile.build_folder
+
+    def _format_val(val):
+        return f'"{val}"' if type(val) == str and " " in val else f"{val}"
+
+    # https://github.com/conan-io/conan/pull/12034#issuecomment-1253776285
+    cache_variables_info = " ".join([f"-D{var}={_format_val(value)}" for var, value in cache_variables.items()])
+    add_toolchain_cache = f"-DCMAKE_TOOLCHAIN_FILE={toolchain_file} " \
+        if "CMAKE_TOOLCHAIN_FILE" not in cache_variables_info else ""
+
+    conanfile.output.info(f"Preset '{name}' added to CMakePresets.json. Invoke it manually using "
+                          f"'cmake --preset {name}' or if your CMake version is not compatible with "
+                          f"the presets feature (<3.19) call cmake configure like: 'cmake <path> "
+                          f"-G {_format_val(generator)} {add_toolchain_cache}"
+                          f"{cache_variables_info}'")
     return ret
 
 

--- a/conans/test/integration/toolchains/cmake/test_cmaketoolchain.py
+++ b/conans/test/integration/toolchains/cmake/test_cmaketoolchain.py
@@ -508,6 +508,13 @@ def test_toolchain_cache_variables():
     assert cache_variables["QUX"] == 'baz'
     assert cache_variables["NUMBER"] == 1
 
+    def _format_val(val):
+        return f'"{val}"' if type(val) == str and " " in val else f"{val}"
+
+    for var, value in cache_variables.items():
+        assert f"-D{var}={_format_val(value)}" in client.out
+    assert "-DCMAKE_TOOLCHAIN_FILE=" in client.out
+    assert f"-G {_format_val('MinGW Makefiles')}" in client.out
 
 def test_android_c_library():
     client = TestClient()


### PR DESCRIPTION
Changelog: Feature: Add message to help users that have old CMake versions invoking CMake manually with the same information stored in the CMakePresets.
Docs: omit

Closes: https://github.com/conan-io/conan/pull/12034

Defining this:

```python
    def generate(self):
        tc = CMakeToolchain(self)
        tc.cache_variables["MYNUMBER"] = 1
        tc.cache_variables["MYMESSAGE"] = "MyValue"
        tc.cache_variables["MESSAGE_SPACES"] = "My    Value"
        tc.generate()
```

Something like:

```
conanfile.py (hello/0.1): Preset 'release' added to CMakePresets.json. Invoke it manually using 'cmake --preset release' or if your CMake version is not compatible with the presets feature (<3.19) call cmake configure like: 'cmake <path> -G "Unix Makefiles" -DCMAKE_TOOLCHAIN_FILE=/Users/carlosz/Documents/developer/conan/sandbox/toolchain_vars/build/generators/conan_toolchain.cmake -DMYNUMBER=1 -DMYMESSAGE=MyValue -DMESSAGE_SPACES="My    Value" -DCMAKE_POLICY_DEFAULT_CMP0091=NEW -DCMAKE_BUILD_TYPE=Release'
```