### PR TITLE
Default to source_folder in conan.tools.files.patch if exports_sources is not defined and using local flow

### DIFF
--- a/conan/tools/files/patches.py
+++ b/conan/tools/files/patches.py
@@ -49,7 +49,7 @@ def patch(conanfile, base_path=None, patch_file=None, patch_string=None, strip=0
     if patch_file:
         # trick *1: patch_file path could be absolute (e.g. conanfile.build_folder), in that case
         # the join does nothing and works.
-        patch_path = os.path.join(conanfile.export_sources_folder, patch_file)
+        patch_path = os.path.join(conanfile.export_sources_folder or conanfile.source_folder, patch_file)
         patchset = patch_ng.fromfile(patch_path)
     else:
         patchset = patch_ng.fromstring(patch_string.encode())


### PR DESCRIPTION
Changelog: Fix: Default to source_folder in conan.tools.files.patch if exports_sources is not defined
Docs: TODO

Closes: https://github.com/conan-io/conan/issues/11781
