### PR TITLE
Update macos test profile in develop2

### DIFF
--- a/conans/test/conftest.py
+++ b/conans/test/conftest.py
@@ -209,7 +209,7 @@ default_profiles = {
         os=Macos
         arch={arch_setting}
         compiler=apple-clang
-        compiler.version=12.0
+        compiler.version=13
         compiler.libcxx=libc++
         build_type=Release
         """)

--- a/conans/test/integration/toolchains/apple/test_xcodetoolchain.py
+++ b/conans/test/integration/toolchains/apple/test_xcodetoolchain.py
@@ -23,10 +23,10 @@ def _condition(configuration, architecture, sdk_version):
 @pytest.mark.parametrize("configuration, os_version, libcxx, cppstd, arch, sdk_version, clang_cppstd", [
     ("Release", "", "", "", "x86_64", "", ""),
     ("Debug", "", "", "", "armv8", "", ""),
-    ("Release", "12.0", "libc++", "20", "x86_64", "", "c++2a"),
-    ("Debug", "12.0", "libc++", "20", "x86_64", "", "c++2a"),
-    ("Release", "12.0", "libc++", "20", "x86_64", "11.3", "c++2a"),
-    ("Release", "12.0", "libc++", "20", "x86_64", "", "c++2a"),
+    ("Release", "12.0", "libc++", "20", "x86_64", "", "c++20"),
+    ("Debug", "12.0", "libc++", "20", "x86_64", "", "c++20"),
+    ("Release", "12.0", "libc++", "20", "x86_64", "11.3", "c++20"),
+    ("Release", "12.0", "libc++", "20", "x86_64", "", "c++20"),
 ])
 def test_toolchain_files(configuration, os_version, cppstd, libcxx, arch, sdk_version, clang_cppstd):
     client = TestClient()


### PR DESCRIPTION
The compiler in the profile for testing does not match the compiler installed in the Mac CI node