### PR TITLE
fix missing binary search message

### DIFF
--- a/conans/client/installer.py
+++ b/conans/client/installer.py
@@ -368,13 +368,15 @@ class BinaryInstaller(object):
         else:
             build_str = " ".join(["--build=%s" % pref.ref.name for pref in missing_prefs])
 
+        search_ref = str(ref)
+        search_ref = search_ref + "@" if "@" not in search_ref else search_ref
         raise ConanException(textwrap.dedent('''\
             Missing prebuilt package for '%s'
             Use 'conan search %s --table=table.html -r=remote' and open the table.html file to see available packages
             Or try to build locally from sources with '%s'
 
             More Info at 'https://docs.conan.io/en/latest/faq/troubleshooting.html#error-missing-prebuilt-package'
-            ''' % (missing_pkgs, ref, build_str)))
+            ''' % (missing_pkgs, search_ref, build_str)))
 
     def _download(self, downloads, processed_package_refs):
         """ executes the download of packages (both download and update), only once for a given

--- a/conans/test/integration/command/install/install_missing_dep_test.py
+++ b/conans/test/integration/command/install/install_missing_dep_test.py
@@ -46,4 +46,5 @@ class InstallMissingDependency(unittest.TestCase):
         client.save({"conanfile.py": conanfile}, clean_first=True)
         client.run("create . pkg/1.0@", assert_error=True)
         self.assertIn("ERROR: Missing prebuilt package for 'dep1/1.0', 'dep2/1.0'", client.out)
+        assert "conan search dep1/1.0@ --table=table.html" in client.out
         self.assertIn("Or try to build locally from sources with '--build=dep1 --build=dep2'", client.out)


### PR DESCRIPTION
Changelog: Fix: Fix missing binary ``conan search dep/1.0 --table`` message when a binary is missing.
Docs: Omit

Close https://github.com/conan-io/conan/issues/12183