### PR TITLE
Fix autotools install on Windows

### DIFF
--- a/conan/tools/gnu/autotools.py
+++ b/conan/tools/gnu/autotools.py
@@ -6,6 +6,7 @@ from conans.client.subsystems import subsystem_path, deduce_subsystem
 from conans.client.build import join_arguments
 from conans.tools import args_to_string
 from conan.tools.files import chdir
+from conan.tools.microsoft import unix_path
 from conans.util.runners import check_output_runner
 
 
@@ -55,7 +56,7 @@ class Autotools(object):
         self._conanfile.run(command)
 
     def install(self, args=None):
-        args = args if args is not None else ["DESTDIR={}".format(self._conanfile.package_folder)]
+        args = args if args is not None else ["DESTDIR={}".format(unix_path(self._conanfile, self._conanfile.package_folder))]
         self.make(target="install", args=args)
 
     def autoreconf(self, args=None):

--- a/conans/test/functional/toolchains/gnu/autotools/test_win_bash.py
+++ b/conans/test/functional/toolchains/gnu/autotools/test_win_bash.py
@@ -47,9 +47,6 @@ def test_autotools_bash_complete():
                 autotools = Autotools(self)
                 autotools.configure()
                 autotools.make()
-
-            def package(self):
-                autotools = Autotools(self)
                 autotools.install()
         """)
 

--- a/conans/test/functional/toolchains/gnu/autotools/test_win_bash.py
+++ b/conans/test/functional/toolchains/gnu/autotools/test_win_bash.py
@@ -47,6 +47,10 @@ def test_autotools_bash_complete():
                 autotools = Autotools(self)
                 autotools.configure()
                 autotools.make()
+
+            def package(self):
+                autotools = Autotools(self)
+                autotools.install()
         """)
 
     client.save({"conanfile.py": conanfile,


### PR DESCRIPTION
Changelog: Bugfix: Fix Autotools install on Windows. The default argument passed is `DESTDIR=unix_path(self, self.package_folder)`.
Docs: https://github.com/conan-io/docs/pull/2801
Closes https://github.com/conan-io/conan/issues/12153

- [x] Refer to the issue that supports this Pull Request.
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [ ] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 

<sup>**Note:** By default this PR will skip the slower tests and will use a limited set of python versions. Check [here](https://github.com/conan-io/conan/blob/develop/.github/PR_INCREASE_TESTING.md) how to increase the testing level by writing some tags in the current PR body text.</sup>
