### PR TITLE
Fix full_deploy Failure on Skipped Packages

### DIFF
--- a/conan/api/subapi/install.py
+++ b/conan/api/subapi/install.py
@@ -108,6 +108,8 @@ def full_deploy(conanfile, output_folder):
 
     conanfile.output.info(f"Conan built-in full deployer to {output_folder}")
     for dep in conanfile.dependencies.values():
+        if dep.package_folder is None:
+            continue
         folder_name = os.path.join(dep.context, dep.ref.name, str(dep.ref.version))
         build_type = dep.info.settings.get_safe("build_type")
         arch = dep.info.settings.get_safe("arch")


### PR DESCRIPTION
Changelog: Bugfix: Resolve full_deploy exception when attempting to copy "Skip'd" requirements.
Docs: Omit

fixes #12218 

- [X] Refer to the issue that supports this Pull Request.
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [X] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 
