### PR TITLE
CMakeDeps: no more modification of `CMAKE_MODULE_PATH`/`CMAKE_PREFIX_PATH`

### DIFF
--- a/conan/tools/cmake/cmakedeps/templates/target_configuration.py
+++ b/conan/tools/cmake/cmakedeps/templates/target_configuration.py
@@ -86,10 +86,6 @@ class TargetConfigurationTemplate(CMakeDepsFileTemplate):
                                       "{{ config_suffix }}"
                                       "{{ pkg_name }}")    # package_name
 
-        # FIXME: What is the result of this for multi-config? All configs adding themselves to path?
-        set(CMAKE_MODULE_PATH {{ '${' }}{{ pkg_name }}_BUILD_DIRS{{ config_suffix }}} {{ '${' }}CMAKE_MODULE_PATH})
-        set(CMAKE_PREFIX_PATH {{ '${' }}{{ pkg_name }}_BUILD_DIRS{{ config_suffix }}} {{ '${' }}CMAKE_PREFIX_PATH})
-
         {% if not components_names %}
 
         ########## GLOBAL TARGET PROPERTIES {{ configuration }} ########################################

--- a/conans/test/functional/toolchains/cmake/test_cmaketoolchain_paths.py
+++ b/conans/test/functional/toolchains/cmake/test_cmaketoolchain_paths.py
@@ -450,13 +450,14 @@ def test_cmaketoolchain_path_find_program(settings, find_root_path_modes):
     consumer = textwrap.dedent("""
         cmake_minimum_required(VERSION 3.15)
         project(MyHello)
+        find_package(hello_host REQUIRED)
         find_program(HELLOPROG hello)
         if(HELLOPROG)
             message("Found hello prog: ${HELLOPROG}")
         endif()
     """)
     client.save({"conanfile.py": conanfile, "CMakeLists.txt": consumer}, clean_first=True)
-    client.run("install . pkg/0.1@ -g CMakeToolchain -pr:b default {}".format(settings))
+    client.run(f"install . pkg/0.1@ -g CMakeToolchain -g CMakeDeps -pr:b default {settings}")
     with client.chdir("build"):
         client.run_command(_cmake_command_toolchain(find_root_path_modes))
     assert "Found hello prog" in client.out


### PR DESCRIPTION
Changelog: (Fix): Remove `CMAKE_MODULE_PATH`/`CMAKE_PREFIX_PATH` modification in files generated by `CMakeDeps`
Docs: https://github.com/conan-io/docs/pull/XXXX

closes https://github.com/conan-io/conan/issues/12237

Basically these modifications of `CMAKE_MODULE_PATH`/`CMAKE_PREFIX_PATH` in `CMakeDeps` can defeat the logic of `CMakeToolchain` implemented in https://github.com/conan-io/conan/pull/10186.
For example: https://github.com/conan-io/conan-center-index/pull/13269#issuecomment-1264691043

It means that if:
- a recipeA provides both a lib & an executable `foo`
- user depends on recipeA both in `requires` & `tool_requires`
- user relies on `CMakeToolchain` & `CMakeDeps`, and has `find_package(recipeA)` before `find_program(FOO NAMES foo)`

then, `find_program()` will find executable `foo` from recipeA "requires" package instead of recipeA "tool_requires" package.

So this PR removes this side effect.

Anyway it's not the responsibility of a config file to modify these variables (canonical files generated by a `install(EXPORT ...)` command don't do that).

- [ ] Refer to the issue that supports this Pull Request.
- [ ] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [ ] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [ ] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 

<sup>**Note:** By default this PR will skip the slower tests and will use a limited set of python versions. Check [here](https://github.com/conan-io/conan/blob/develop/.github/PR_INCREASE_TESTING.md) how to increase the testing level by writing some tags in the current PR body text.</sup>
